### PR TITLE
render: optimize topk when limit=1 and input is monotonic (append-only)

### DIFF
--- a/src/dataflow/src/render/top_k.rs
+++ b/src/dataflow/src/render/top_k.rs
@@ -9,7 +9,11 @@
 
 use differential_dataflow::hashable::Hashable;
 use differential_dataflow::lattice::Lattice;
+use differential_dataflow::operators::arrange::ArrangeBySelf;
+use differential_dataflow::operators::reduce::ReduceCore;
 use differential_dataflow::operators::Consolidate;
+use differential_dataflow::trace::implementations::ord::OrdValSpine;
+use differential_dataflow::AsCollection;
 use differential_dataflow::Collection;
 use timely::dataflow::Scope;
 
@@ -36,8 +40,25 @@ where
             let arity = input.arity();
             let (ok_input, err_input) = self.collection(input).unwrap();
 
-            // For monotonic inputs, we are able to retract inputs not produced as outputs.
-            if *monotonic {
+            if *monotonic && *offset == 0 && *limit == Some(1) {
+                // If the input to a TopK is monotonic (aka append-only aka no retractions) then we
+                // don't have to worry about keeping every row we've seen around forever. Instead,
+                // the reduce can incrementally compute a new answer by looking at just the old TopK
+                // for a key and the incremental data.
+                //
+                // This optimization generalizes to any TopK over a monotonic source, but we special
+                // case only TopK with offset=0 and limit=1 (aka Top1) for now. This is because (1)
+                // Top1 can merge in each incremental row in constant space and time while the
+                // generalized solution needs something like a priority queue and (2) we expect Top1
+                // will be a common pattern used to turn a Kafka source's "upsert" semantics into
+                // differential's semantics. (2) is especially interesting because Kafka is
+                // monotonic with an ENVELOPE of NONE, which is the default for ENVELOPE in
+                // Materialize and commonly used by users.
+                let result = self.render_top1_monotonic(ok_input, group_key, order_key);
+                self.collections
+                    .insert(relation_expr.clone(), (result, err_input));
+            } else if *monotonic {
+                // For monotonic inputs, we are able to retract inputs not produced as outputs.
                 use differential_dataflow::operators::iterate::Variable;
                 let delay = std::time::Duration::from_nanos(10_000_000_000);
                 let retractions = Variable::new(&mut ok_input.scope(), delay.as_millis() as u64);
@@ -203,6 +224,118 @@ where
 
                 negated_output.negate().concat(&input).consolidate()
             }
+        }
+    }
+
+    fn render_top1_monotonic(
+        &self,
+        collection: Collection<G, Row, Diff>,
+        group_key: &[usize],
+        order_key: &[expr::ColumnOrder],
+    ) -> Collection<G, Row, Diff> {
+        // We can place our rows directly into the diff field, and only keep the relevant one
+        // corresponding to evaluating our aggregate, instead of having to do a hierarchical
+        // reduction.
+        use timely::dataflow::operators::Map;
+
+        let group_clone = group_key.to_vec();
+        let collection = collection.map({
+            move |row| {
+                let datums = row.unpack();
+                let iterator = group_clone.iter().map(|i| datums[*i]);
+                let total_size = repr::datums_size(iterator.clone());
+                let mut group_key = Row::with_capacity(total_size);
+                group_key.extend(iterator);
+                (group_key, row)
+            }
+        });
+
+        // We arrange the inputs ourself to force it into a leaner structure because we know we
+        // won't care about values.
+        //
+        // TODO: Could we use explode here? We'd lose the diff>0 assert and we'd have to impl Mul
+        // for the monoid, unclear if it's worth it.
+        let order_clone = order_key.to_vec();
+        let partial: Collection<G, Row, monoids::Top1Monoid> = collection
+            .consolidate()
+            .inner
+            .map(move |((group_key, row), time, diff)| {
+                assert!(diff > 0);
+                // NB: Top1 can throw out the diff since we've asserted that it's > 0. A more
+                // general TopK monoid would have to account for diff.
+                (
+                    group_key,
+                    time,
+                    monoids::Top1Monoid {
+                        row,
+                        order_key: order_clone.clone(),
+                    },
+                )
+            })
+            .as_collection();
+        let result = partial
+            .arrange_by_self()
+            .reduce_abelian::<_, OrdValSpine<_, _, _, _>>("Top1Monotonic", {
+                move |_key, input, output| {
+                    let accum = &input[0].1;
+                    output.push((accum.row.clone(), 1));
+                }
+            });
+        result.as_collection(|_k, v| v.clone())
+    }
+}
+
+/// Monoids for in-place compaction of monotonic streams.
+pub mod monoids {
+    use std::cmp::Ordering;
+
+    use differential_dataflow::difference::Semigroup;
+    use serde::{Deserialize, Serialize};
+
+    use expr::ColumnOrder;
+    use repr::Row;
+
+    /// A monoid containing a row and an ordering.
+    #[derive(Eq, PartialEq, Debug, Clone, Serialize, Deserialize, Hash)]
+    pub struct Top1Monoid {
+        pub row: Row,
+        pub order_key: Vec<ColumnOrder>,
+    }
+
+    impl Ord for Top1Monoid {
+        fn cmp(&self, other: &Self) -> Ordering {
+            debug_assert_eq!(self.order_key, other.order_key);
+
+            // It might be nice to cache this row decoding like the non-monotonic codepath, but we'd
+            // have to store the decoded Datums in the same struct as the Row, which gets tricky.
+            let left: Vec<_> = self.row.iter().collect();
+            let right: Vec<_> = other.row.iter().collect();
+            expr::compare_columns(&self.order_key, &left, &right, || left.cmp(&right))
+        }
+    }
+    impl PartialOrd for Top1Monoid {
+        fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+            Some(self.cmp(other))
+        }
+    }
+
+    impl Semigroup for Top1Monoid {
+        fn plus_equals(&mut self, rhs: &Self) {
+            // It's unclear what the semantics are of a TopK without an ordering, but match the
+            // non-monotonic impl's behavior of not doing any decoding work.
+            if self.order_key.is_empty() {
+                return;
+            }
+
+            let cmp = (self as &Top1Monoid).cmp(rhs);
+            // NB: Reminder that TopK returns the _minimum_ K items.
+            if cmp == Ordering::Greater {
+                self.clone_from(&rhs);
+            }
+        }
+
+        fn is_zero(&self) -> bool {
+            false
         }
     }
 }

--- a/test/sqllogictest/topk_monotonic.slt
+++ b/test/sqllogictest/topk_monotonic.slt
@@ -1,0 +1,108 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+mode cockroach
+
+# Use a constant source for the data instead of a table because this optmization
+# only applies to monotonic (append-only) sources and a TABLE is not.
+statement ok
+CREATE VIEW cities AS SELECT name, state, pop FROM (VALUES
+    ('Nullsville', 'CA', NULL),
+    ('Los_Angeles', 'CA', 3979576),
+    ('Phoenix', 'AZ', 1680992),
+    ('Houston', 'TX', 2320268),
+    ('San_Diego', 'CA', 1423851),
+    ('San_Francisco', 'CA', 881549),
+    ('New_York', 'NY', 8336817),
+    ('Dallas', 'TX', 1343573),
+    ('San_Antonio', 'TX', 1547253),
+    ('San_Jose', 'CA', 1021795),
+    ('Chicago', 'IL', 2695598),
+    ('Austin', 'TX', 978908),
+    ('Nulltown', 'Nostate', NULL)
+) t(name, state, pop)
+
+mode standard
+
+# Verify that the VALUES isn't just constant folded all the way to an answer.
+query T multiline
+EXPLAIN PLAN FOR SELECT state, name FROM
+    (SELECT DISTINCT state FROM cities) grp,
+    LATERAL (SELECT name, pop FROM cities WHERE state = grp.state ORDER BY pop DESC LIMIT 1)
+----
+%0 =
+| Constant ("Austin", "TX", 978908) ("Dallas", "TX", 1343573) ("Nullsville", "CA", null) ("Chicago", "IL", 2695598) ("Houston", "TX", 2320268) ("Phoenix", "AZ", 1680992) ("New_York", "NY", 8336817) ("San_Jose", "CA", 1021795) ("Nulltown", "Nostate", null) ("San_Diego", "CA", 1423851) ("Los_Angeles", "CA", 3979576) ("San_Antonio", "TX", 1547253) ("San_Francisco", "CA", 881549)
+| TopK group=(#1) order=(#2 desc) limit=1 offset=0
+| Project (#1, #0)
+
+EOF
+
+mode cockroach
+
+query TT rowsort
+SELECT state, name FROM
+    (SELECT DISTINCT state FROM cities) grp,
+    LATERAL (SELECT name FROM cities WHERE state = grp.state ORDER BY pop DESC LIMIT 1)
+----
+AZ  Phoenix
+CA  Los_Angeles
+IL  Chicago
+NY  New_York
+Nostate Nulltown
+TX  Houston
+
+# Also check ASC to stress NULL handling in the monoid.
+query TT rowsort
+SELECT state, name FROM
+    (SELECT DISTINCT state FROM cities) grp,
+    LATERAL (SELECT name FROM cities WHERE state = grp.state ORDER BY pop LIMIT 1)
+----
+AZ  Phoenix
+CA  Nullsville
+IL  Chicago
+NY  New_York
+Nostate  Nulltown
+TX  Austin
+
+# TABLEs are currently monotonic because they don't yet support UPDATE or DELETE. Use the postgres
+# passthrough behavior to test the behavior of this optimization in case that changes.
+
+mode cockroach
+
+statement ok
+CREATE TABLE cities_t (
+    name text NOT NULL,
+    state text NOT NULL,
+    pop int NOT NULL
+)
+
+statement ok
+INSERT INTO cities_t VALUES
+    ('Los_Angeles', 'CA', 3979576),
+    ('San_Francisco', 'CA', 881549)
+
+statement ok
+CREATE MATERIALIZED VIEW topk AS SELECT state, name FROM
+    (SELECT DISTINCT state FROM cities_t) grp,
+    LATERAL (SELECT name FROM cities_t WHERE state = grp.state ORDER BY pop DESC LIMIT 1);
+
+mode cockroach
+
+query TT rowsort
+SELECT * FROM topk;
+----
+CA  Los_Angeles
+
+statement ok
+DELETE FROM cities_t WHERE name = 'Los_Angeles';
+
+query TT rowsort
+SELECT * FROM topk;
+----
+CA  San_Francisco

--- a/test/testdrive/top-1-monotonic.td
+++ b/test/testdrive/top-1-monotonic.td
@@ -1,0 +1,253 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Tests in support of https://github.com/MaterializeInc/materialize/pull/6471
+# "optimize topk when limit=1 and input is monotonic (append-only)"
+#
+
+#
+# Make sure that the general pattern of all queries in this file will use TopK and not some other future operator or optimization
+#
+
+# Remove both newlines, references to internal table identifiers, and "materialize.public" strings, all with a single regexp
+$ set-regex match=(\s\(u\d+\)|\n|materialize\.public\.) replacement=
+> EXPLAIN SELECT (SELECT 'a' LIMIT 1);
+"%0 = Let l0 =| Constant ()| TopK group=() order=() limit=1 offset=0%1 =| Get %0 (l0)| Map \"a\"%2 =| Get %0 (l0)| Negate%3 =| Constant ()%4 =| Union %2 %3| Map null%5 =| Union %1 %4"
+
+$ set schema={"type": "record", "name": "schema", "fields": [ {"name": "f1", "type": ["int", "null"]} , {"name": "f2", "type": ["int", "null"]}] }
+
+$ kafka-create-topic topic=top1
+
+$ kafka-ingest format=avro topic=top1 schema=${schema} publish=true timestamp=1
+
+> CREATE MATERIALIZED SOURCE t1
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-top1-${testdrive.seed}'
+  WITH (timestamp_frequency_ms = 100)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE NONE
+
+#
+# Over constants
+#
+
+> SELECT (SELECT 'a' LIMIT 1);
+a
+
+> SELECT (SELECT 'a' ORDER BY 1 LIMIT 1);
+a
+
+> SELECT (SELECT 'a' GROUP BY 1 LIMIT 1);
+a
+
+> SELECT (SELECT 'a' ORDER BY 'a' LIMIT 1);
+a
+
+> SELECT (SELECT 'a' GROUP BY 'a' LIMIT 1);
+a
+
+#
+# And now some actual materialized views
+#
+
+> CREATE MATERIALIZED VIEW limit_only AS SELECT (SELECT f1 FROM t1 LIMIT 1);
+
+> CREATE MATERIALIZED VIEW group_by_limit AS SELECT (SELECT f1 FROM t1 GROUP BY f1 LIMIT 1);
+
+> CREATE MATERIALIZED VIEW order_by_limit AS SELECT (SELECT f1 FROM t1 ORDER BY f1 LIMIT 1);
+
+> CREATE MATERIALIZED VIEW order_by_desc_limit AS SELECT (SELECT f1 FROM t1 ORDER BY f1 DESC LIMIT 1);
+
+> CREATE MATERIALIZED VIEW group_by_in_top_1 AS SELECT (select f2 FROM t1 AS inner WHERE inner.f1 = outer.f1 GROUP BY f2 LIMIT 1) FROM t1 AS outer;
+
+> CREATE MATERIALIZED VIEW group_by_order_by_in_top_1 AS SELECT (select f2 FROM t1 AS inner WHERE inner.f1 = outer.f1 ORDER BY f2 DESC LIMIT 1) FROM t1 AS outer;
+
+#
+# Over an empty source
+#
+
+> SELECT * from limit_only AS OF NOW();
+<null>
+
+> SELECT * from group_by_limit;
+<null>
+
+> SELECT * FROM order_by_limit;
+<null>
+
+> SELECT * from order_by_desc_limit;
+<null>
+
+> SELECT * FROM group_by_in_top_1;
+
+> SELECT * FROM group_by_order_by_in_top_1;
+
+#
+# Over a source with a single record
+#
+
+$ kafka-ingest format=avro topic=top1 schema=${schema} publish=true timestamp=1
+{"f1": {"int": 123}, "f2": {"int": -123} }
+
+> SELECT * from limit_only AS OF NOW();
+123
+
+> SELECT * from group_by_limit;
+123
+
+> SELECT * FROM order_by_limit;
+123
+
+> SELECT * from order_by_desc_limit;
+123
+
+> SELECT * FROM group_by_in_top_1;
+-123
+
+> SELECT * FROM group_by_order_by_in_top_1;
+-123
+
+#
+# A second record arrives, causes the ORDER BY DESC view to change output
+#
+
+$ kafka-ingest format=avro topic=top1 schema=${schema} publish=true timestamp=2
+{"f1": {"int": 234}, "f2": {"int" : -234} }
+
+> SELECT * from limit_only AS OF NOW();
+123
+
+> SELECT * from group_by_limit;
+123
+
+> SELECT * FROM order_by_limit;
+123
+
+> SELECT * from order_by_desc_limit;
+234
+
+> SELECT * FROM group_by_in_top_1;
+-123
+-234
+
+> SELECT * FROM group_by_order_by_in_top_1;
+-123
+-234
+
+#
+# The third record causes all other views to change outputs
+#
+
+$ kafka-ingest format=avro topic=top1 schema=${schema} publish=true timestamp=3
+{"f1": {"int": 0}, "f2": {"int": 0} }
+
+> SELECT * from limit_only;
+0
+
+> SELECT * from group_by_limit;
+0
+
+> SELECT * FROM order_by_limit;
+0
+
+> SELECT * from order_by_desc_limit;
+234
+
+> SELECT * FROM group_by_in_top_1;
+0
+-123
+-234
+
+> SELECT * FROM group_by_order_by_in_top_1;
+0
+-123
+-234
+
+#
+# Insert some more rows, mostly for the benefit of the "in_top_1" views
+#
+
+$ kafka-ingest format=avro topic=top1 schema=${schema} publish=true timestamp=4
+{"f1": {"int": 0}, "f2": {"int": 0}}
+{"f1": {"int": 234}, "f2": {"int": 0}}
+{"f1": {"int": 123}, "f2": {"int": -234} }
+
+> SELECT * from limit_only AS OF NOW();
+0
+
+> SELECT * from group_by_limit;
+0
+
+> SELECT * FROM order_by_limit;
+0
+
+> SELECT * from order_by_desc_limit;
+234
+
+> SELECT * FROM group_by_in_top_1;
+0
+0
+0
+0
+-234
+-234
+
+> SELECT * FROM group_by_order_by_in_top_1;
+-123
+-123
+0
+0
+0
+0
+
+#
+# And finally, insert some NULL values
+#
+
+$ kafka-ingest format=avro topic=top1 schema=${schema} publish=true timestamp=5
+{"f1": null, "f2": null}
+{"f1": {"int":0}, "f2": null}
+{"f1": null, "f2": {"int": 0}}
+{"f1": null, "f2": {"int": -234}}
+
+> SELECT * from limit_only AS OF NOW();
+<null>
+
+> SELECT * from group_by_limit;
+<null>
+
+> SELECT * FROM order_by_limit;
+<null>
+
+> SELECT * from order_by_desc_limit;
+234
+
+> SELECT * FROM group_by_in_top_1;
+-234
+-234
+0
+0
+<null>
+<null>
+<null>
+<null>
+<null>
+<null>
+
+> SELECT * FROM group_by_order_by_in_top_1;
+-123
+-123
+0
+0
+0
+0
+0
+<null>
+<null>
+<null>


### PR DESCRIPTION
If the input to a TopK is monotonic (aka append-only aka no retractions)
then we don't have to worry about keeping every row we've seen around
forever. Instead, the reduce can incrementally compute a new answer by
looking at just the old TopK for a key and the incremental data. We do
an identical optimization for MIN and MAX of monotonic sources.

This optimization generalizes to any TopK over a monotonic source, but
we special case only TopK with offset=0 and limit=1 (aka Top1) for now.
This is because (1) Top1 can merge in each incremental row in constant
space and time while the generalized solution needs something like a
priority queue and (2) we expect Top1 will be a common pattern used to
turn a Kafka source's "upsert" semantics into differential's semantics.
(2) is especially interesting because Kafka is monotonic with an
ENVELOPE of NONE, which is the default for ENVELOPE in Materialize and
commonly used by users.

Closes #5996