### PR TITLE
Extend union fusion transformation

### DIFF
--- a/src/transform/src/fusion/union.rs
+++ b/src/transform/src/fusion/union.rs
@@ -33,21 +33,44 @@ impl crate::Transform for Union {
 
 impl Union {
     /// Fuses multiple `Union` operators into one.
+    /// Nested negated unions are merged into the parent one by pushing
+    /// the Negate to all their branches.
     pub fn action(&self, relation: &mut MirRelationExpr) {
         let relation_type = relation.typ();
         if let MirRelationExpr::Union { base, inputs } = relation {
-            let can_fuse = iter::once(&**base)
-                .chain(&*inputs)
-                .any(|input| matches!(input, MirRelationExpr::Union { .. }));
+            let can_fuse = iter::once(&**base).chain(&*inputs).any(|input| -> bool {
+                match input {
+                    MirRelationExpr::Union { .. } => true,
+                    MirRelationExpr::Negate { input: inner_input } => {
+                        if let MirRelationExpr::Union { .. } = **inner_input {
+                            true
+                        } else {
+                            false
+                        }
+                    }
+                    _ => false,
+                }
+            });
             if can_fuse {
                 let mut new_inputs: Vec<MirRelationExpr> = vec![];
                 for input in iter::once(&mut **base).chain(inputs) {
-                    match input.take_dangerous() {
+                    let outer_input = input.take_dangerous();
+                    match outer_input {
                         MirRelationExpr::Union { base, inputs } => {
                             new_inputs.push(*base);
                             new_inputs.extend(inputs);
                         }
-                        input => new_inputs.push(input),
+                        MirRelationExpr::Negate {
+                            input: ref inner_input,
+                        } => {
+                            if let MirRelationExpr::Union { base, inputs } = &**inner_input {
+                                new_inputs.push(base.to_owned().negate());
+                                new_inputs.extend(inputs.into_iter().map(|x| x.clone().negate()));
+                            } else {
+                                new_inputs.push(outer_input);
+                            }
+                        }
+                        _ => new_inputs.push(outer_input),
                     }
                 }
                 *relation = MirRelationExpr::union_many(new_inputs, relation_type);

--- a/src/transform/src/fusion/union.rs
+++ b/src/transform/src/fusion/union.rs
@@ -8,6 +8,9 @@
 // by the Apache License, Version 2.0.
 
 //! Fuses multiple `Union` operators into one.
+//!
+//! Nested negated unions are merged into the parent one by pushing
+//! the Negate to all their branches.
 
 use std::iter;
 

--- a/test/sqllogictest/transform/union.slt
+++ b/test/sqllogictest/transform/union.slt
@@ -1,0 +1,88 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+mode cockroach
+
+statement ok
+CREATE TABLE t1 (key integer PRIMARY KEY, nokey integer)
+
+statement ok
+INSERT INTO t1 VALUES (1, 1), (2, 3), (4, 5);
+
+statement ok
+CREATE TABLE t2 (key integer PRIMARY KEY, nokey integer)
+
+statement ok
+INSERT INTO t2 VALUES (2, 3), (5, 5);
+
+# Test that nested unions are fused into a single Union operator
+query T multiline
+EXPLAIN (SELECT * FROM t1 UNION ALL SELECT * FROM t1) UNION ALL (SELECT * FROM t2 UNION ALL SELECT * FROM t2);
+----
+%0 =
+| Get materialize.public.t1 (u1)
+
+%1 =
+| Get materialize.public.t1 (u1)
+
+%2 =
+| Get materialize.public.t2 (u3)
+
+%3 =
+| Get materialize.public.t2 (u3)
+
+%4 =
+| Union %0 %1 %2 %3
+
+EOF
+
+query II
+(SELECT * FROM t1 UNION ALL SELECT * FROM t1) UNION ALL (SELECT * FROM t2 UNION ALL SELECT * FROM t2);
+----
+1  1
+1  1
+2  3
+2  3
+2  3
+2  3
+4  5
+4  5
+5  5
+5  5
+
+# Test that nested negated unions are merged into the parent Union operator by pushing the Negate into their branches
+query T multiline
+EXPLAIN (SELECT * FROM t1 UNION ALL SELECT * FROM t1) EXCEPT ALL (SELECT * FROM t2 UNION ALL SELECT * FROM t2);
+----
+%0 =
+| Get materialize.public.t1 (u1)
+
+%1 =
+| Get materialize.public.t1 (u1)
+
+%2 =
+| Get materialize.public.t2 (u3)
+| Negate
+
+%3 =
+| Get materialize.public.t2 (u3)
+| Negate
+
+%4 =
+| Union %0 %1 %2 %3
+| Threshold
+EOF
+
+query II
+(SELECT * FROM t1 UNION ALL SELECT * FROM t1) EXCEPT ALL (SELECT * FROM t2 UNION ALL SELECT * FROM t2);
+----
+1  1
+1  1
+4  5
+4  5


### PR DESCRIPTION
When a union branch contains a negated union, push the negate to each
branch of the nested union and merge them into the parent union.

This addresses this [comment](https://github.com/MaterializeInc/materialize/pull/6446#discussion_r612921115).