### PR TITLE
tb: Guard against null values returned from AvroCoverter

### DIFF
--- a/misc/tb/src/ChangeWriter.java
+++ b/misc/tb/src/ChangeWriter.java
@@ -94,7 +94,9 @@ public class ChangeWriter implements Consumer<RecordChangeEvent<SourceRecord>> {
         }
 
         Object datum = avroConverter.fromConnectData(record.valueSchema(), record.value());
-        dfw.append(datum);
+        if (datum != null) {
+            dfw.append(datum);
+        }
     }
 
     /**


### PR DESCRIPTION
This is an attempt to resolve #6479, but without a reproducer it is
unknown if this will fix it.