### PR TITLE
Fix syntax of pubnub example view

### DIFF
--- a/doc/user/content/sql/create-source/json-pubnub.md
+++ b/doc/user/content/sql/create-source/json-pubnub.md
@@ -44,6 +44,6 @@ SELECT
     (text::jsonb)->>'order_quantity' AS order_quantity,
     (text::jsonb)->>'symbol' AS symbol,
     (text::jsonb)->>'trade_type' AS trade_type,
-    to_timestamp((text::jsonb)->'timestamp')::bigint) AS timestamp
+    to_timestamp(((text::jsonb)->'timestamp')::bigint) AS timestamp
 FROM market_orders_raw;
 ```


### PR DESCRIPTION
This was missing an opening paren, causing psql to complain about a syntax error when following the stocks example.