### PR TITLE
Key/Value Formats

### DIFF
--- a/src/coord/src/catalog/migrate.rs
+++ b/src/coord/src/catalog/migrate.rs
@@ -13,10 +13,10 @@ use ore::collections::CollectionExt;
 use sql::ast::display::AstDisplay;
 use sql::ast::visit_mut::{self, VisitMut};
 use sql::ast::{
-    AvroSchema, CreateIndexStatement, CreateSinkStatement, CreateSourceStatement,
-    CreateTableStatement, CreateTypeStatement, CreateViewStatement, DataType, Format, Function,
-    Ident, Raw, RawName, Statement, TableFactor, UnresolvedObjectName, Value, WithOption,
-    WithOptionValue,
+    AvroSchema, CreateIndexStatement, CreateSinkStatement, CreateSourceFormat,
+    CreateSourceStatement, CreateTableStatement, CreateTypeStatement, CreateViewStatement,
+    DataType, Format, Function, Ident, Raw, RawName, Statement, TableFactor, UnresolvedObjectName,
+    Value, WithOption, WithOptionValue,
 };
 use sql::plan::resolve_names_stmt;
 
@@ -292,7 +292,7 @@ pub const CONTENT_MIGRATIONS: &[fn(&mut Catalog) -> Result<(), anyhow::Error>] =
             match stmt {
                 Statement::CreateSource(CreateSourceStatement {
                     format:
-                        Some(Format::Avro(AvroSchema::Schema {
+                        CreateSourceFormat::Bare(Format::Avro(AvroSchema::Schema {
                             ref mut with_options,
                             ..
                         })),

--- a/src/coord/src/timestamp.rs
+++ b/src/coord/src/timestamp.rs
@@ -484,11 +484,12 @@ impl Timestamper {
                                 }
                             }
                             Consistency::BringYourOwn(consistency_topic) => {
-                                info!("Timestamping Source {} with BYO Consistency. Consistency Source: {}.", source_id, consistency_topic);
+                                info!("Timestamping Source {} with BYO Consistency. Consistency Source: {}.",
+                                      source_id, consistency_topic);
                                 let consumer = self.create_byo_connector(
                                     source_id,
                                     sc,
-                                    enc,
+                                    enc.value(),
                                     env,
                                     consistency_topic,
                                 );

--- a/src/dataflow/src/decode/key_value.rs
+++ b/src/dataflow/src/decode/key_value.rs
@@ -1,0 +1,58 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use super::DecoderState;
+
+pub(crate) struct KeyValueDecoder {
+    key_decoder: Box<dyn DecoderState>,
+    value_decoder: Box<dyn DecoderState>,
+}
+
+impl KeyValueDecoder {
+    pub fn new(
+        key_decoder: Box<dyn DecoderState>,
+        value_decoder: Box<dyn DecoderState>,
+    ) -> KeyValueDecoder {
+        KeyValueDecoder {
+            key_decoder,
+            value_decoder,
+        }
+    }
+}
+
+impl DecoderState for KeyValueDecoder {
+    fn decode_key(&mut self, bytes: &[u8]) -> Result<Option<repr::Row>, String> {
+        self.key_decoder.decode_upsert_value(bytes, None, None)
+    }
+
+    fn decode_upsert_value(
+        &mut self,
+        bytes: &[u8],
+        aux_num: Option<i64>,
+        upstream_time_millis: Option<i64>,
+    ) -> Result<Option<repr::Row>, String> {
+        self.value_decoder
+            .decode_upsert_value(bytes, aux_num, upstream_time_millis)
+    }
+
+    fn get_value(
+        &mut self,
+        bytes: &[u8],
+        aux_num: Option<i64>,
+        upstream_time_millis: Option<i64>,
+    ) -> Option<Result<repr::Row, dataflow_types::DataflowError>> {
+        self.value_decoder
+            .get_value(bytes, aux_num, upstream_time_millis)
+    }
+
+    fn log_error_count(&mut self) {
+        self.key_decoder.log_error_count();
+        self.value_decoder.log_error_count()
+    }
+}

--- a/src/dataflow/src/decode/mod.rs
+++ b/src/dataflow/src/decode/mod.rs
@@ -595,7 +595,7 @@ where
     C: ParallelizationContract<Timestamp, SourceOutput<Vec<u8>, Vec<u8>>>,
 {
     let stream = stream.unary(contract, &op_name, move |_, _| {
-        let mut trackstate = if upsert_debezium {
+        let mut upsert_state = if upsert_debezium {
             Some((
                 HashMap::new(),
                 metrics::DEBEZIUM_UPSERT_COUNT.with_label_values(&[
@@ -622,7 +622,7 @@ where
                             decoder_state.get_value(payload, *aux_num, *upstream_time_millis);
 
                         if let Some(val) = val {
-                            let val = if let Some((keys, metrics)) = trackstate.as_mut() {
+                            let val = if let Some((keys, metrics)) = upsert_state.as_mut() {
                                 match decoder_state.decode_key(key) {
                                     Ok(Some(decoded_key)) => {
                                         rewrite_for_upsert(val, keys, decoded_key, metrics)

--- a/src/dataflow/src/render/upsert.rs
+++ b/src/dataflow/src/render/upsert.rs
@@ -36,8 +36,7 @@ use crate::source::{SourceData, SourceOutput};
 pub fn decode_stream<G>(
     stream: &Stream<G, SourceOutput<Vec<u8>, Vec<u8>>>,
     as_of_frontier: Antichain<Timestamp>,
-    mut key_decoder_state: Box<dyn DecoderState>,
-    mut value_decoder_state: Box<dyn DecoderState>,
+    mut decoder_state: impl DecoderState + 'static,
     operators: &mut Option<LinearOperator>,
     source_arity: usize,
 ) -> (
@@ -201,20 +200,18 @@ where
                         let mut session = output.session(cap);
                         removed_times.push(time.clone());
                         for (key, data) in map.drain() {
-                            // decode key and value
+                            // decode key and value, and apply predicates/projections to they combined key/value
+                            //
                             // TODO(mcsherry): we could record key decoding errors as the value
                             // which would allow us to recover from key decoding errors by a
                             // later retraction of the key (it will never decode correctly, but
                             // we could produce and then remove the error from the output).
-                            //
-                            // TODO(bwm): migrate upsert to use the same framework for key-value
-                            // decoding as other code, as we build out a design for that.
-                            match key_decoder_state.decode_upsert_value(&key, None, None) {
+                            match decoder_state.decode_key(&key) {
                                 Ok(Some(decoded_key)) => {
                                     let decoded_value = if data.value.is_empty() {
                                         Ok(None)
                                     } else {
-                                        value_decoder_state
+                                        decoder_state
                                             // Start with an attempt to decode the value.
                                             .decode_upsert_value(
                                                 &data.value,
@@ -282,8 +279,7 @@ where
                 for time in removed_times {
                     to_send.remove(&time);
                 }
-                key_decoder_state.log_error_count();
-                value_decoder_state.log_error_count();
+                decoder_state.log_error_count();
             }
         },
     );

--- a/src/dataflow/src/source/file.rs
+++ b/src/dataflow/src/source/file.rs
@@ -21,6 +21,7 @@ use timely::scheduling::SyncActivator;
 
 use dataflow_types::{
     AvroOcfEncoding, Compression, DataEncoding, ExternalSourceConnector, MzOffset,
+    SourceDataEncoding,
 };
 use expr::{PartitionId, SourceInstanceId};
 use mz_avro::types::Value;
@@ -63,9 +64,10 @@ impl SourceReader<Value> for FileSourceReader<Value> {
         _: usize,
         consumer_activator: SyncActivator,
         connector: ExternalSourceConnector,
-        encoding: DataEncoding,
+        encoding: SourceDataEncoding,
         _: Option<Logger>,
     ) -> Result<(FileSourceReader<Value>, Option<PartitionId>), anyhow::Error> {
+        let encoding = encoding.single("File source")?;
         let receiver = match connector {
             ExternalSourceConnector::AvroOcf(oc) => {
                 let reader_schema = match &encoding {
@@ -140,7 +142,7 @@ impl SourceReader<Vec<u8>> for FileSourceReader<Vec<u8>> {
         worker_id: usize,
         consumer_activator: SyncActivator,
         connector: ExternalSourceConnector,
-        _: DataEncoding,
+        _: SourceDataEncoding,
         _: Option<Logger>,
     ) -> Result<(FileSourceReader<Vec<u8>>, Option<PartitionId>), anyhow::Error> {
         let receiver = match connector {

--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -21,7 +21,9 @@ use rdkafka::topic_partition_list::Offset;
 use rdkafka::{ClientConfig, ClientContext, Message, Statistics, TopicPartitionList};
 use timely::scheduling::activate::SyncActivator;
 
-use dataflow_types::{DataEncoding, ExternalSourceConnector, KafkaOffset, KafkaSourceConnector};
+use dataflow_types::{
+    ExternalSourceConnector, KafkaOffset, KafkaSourceConnector, SourceDataEncoding,
+};
 use expr::{PartitionId, SourceInstanceId};
 use kafka_util::KafkaAddrs;
 use log::{error, info, log_enabled, warn};
@@ -226,7 +228,7 @@ impl SourceReader<Vec<u8>> for KafkaSourceReader {
         worker_id: usize,
         consumer_activator: SyncActivator,
         connector: ExternalSourceConnector,
-        _: DataEncoding,
+        _: SourceDataEncoding,
         logger: Option<Logger>,
     ) -> Result<(KafkaSourceReader, Option<PartitionId>), anyhow::Error> {
         match connector {

--- a/src/dataflow/src/source/kinesis.rs
+++ b/src/dataflow/src/source/kinesis.rs
@@ -21,7 +21,9 @@ use rusoto_core::RusotoError;
 use rusoto_kinesis::{GetRecordsError, GetRecordsInput, GetRecordsOutput, Kinesis, KinesisClient};
 use timely::scheduling::SyncActivator;
 
-use dataflow_types::{DataEncoding, ExternalSourceConnector, KinesisSourceConnector, MzOffset};
+use dataflow_types::{
+    ExternalSourceConnector, KinesisSourceConnector, MzOffset, SourceDataEncoding,
+};
 use expr::{PartitionId, SourceInstanceId};
 
 use crate::logging::materialized::Logger;
@@ -101,7 +103,7 @@ impl SourceReader<Vec<u8>> for KinesisSourceReader {
         _worker_id: usize,
         _consumer_activator: SyncActivator,
         connector: ExternalSourceConnector,
-        _encoding: DataEncoding,
+        _encoding: SourceDataEncoding,
         _: Option<Logger>,
     ) -> Result<(Self, Option<PartitionId>), anyhow::Error> {
         let kc = match connector {

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -27,7 +27,9 @@ use timely::dataflow::{
 
 use anyhow::anyhow;
 use async_trait::async_trait;
-use dataflow_types::{Consistency, DataEncoding, ExternalSourceConnector, MzOffset, SourceError};
+use dataflow_types::{
+    Consistency, ExternalSourceConnector, MzOffset, SourceDataEncoding, SourceError,
+};
 use expr::{PartitionId, SourceInstanceId};
 use lazy_static::lazy_static;
 use log::{debug, error, trace};
@@ -104,7 +106,7 @@ pub struct SourceConfig<'a, G> {
     /// Whether this worker has been chosen to actually receive data.
     pub active: bool,
     /// Data encoding
-    pub encoding: DataEncoding,
+    pub encoding: SourceDataEncoding,
     /// Channel to send source caching information to cacher thread
     pub caching_tx: Option<mpsc::UnboundedSender<CacheMessage>>,
     /// Timely worker logger for source events
@@ -287,7 +289,7 @@ pub(crate) trait SourceReader<Out> {
         worker_id: usize,
         consumer_activator: SyncActivator,
         connector: ExternalSourceConnector,
-        encoding: DataEncoding,
+        encoding: SourceDataEncoding,
         logger: Option<Logger>,
     ) -> Result<(Self, Option<PartitionId>), anyhow::Error>
     where

--- a/src/dataflow/src/source/s3.rs
+++ b/src/dataflow/src/source/s3.rs
@@ -32,7 +32,9 @@ use tokio::sync::mpsc as tokio_mpsc;
 use tokio::time::{self, Duration};
 
 use aws_util::aws;
-use dataflow_types::{Compression, DataEncoding, ExternalSourceConnector, MzOffset, S3KeySource};
+use dataflow_types::{
+    Compression, ExternalSourceConnector, MzOffset, S3KeySource, SourceDataEncoding,
+};
 use expr::{PartitionId, SourceInstanceId};
 
 use crate::logging::materialized::Logger;
@@ -631,7 +633,7 @@ impl SourceReader<Vec<u8>> for S3SourceReader {
         worker_id: usize,
         consumer_activator: SyncActivator,
         connector: ExternalSourceConnector,
-        _encoding: DataEncoding,
+        _encoding: SourceDataEncoding,
         _: Option<Logger>,
     ) -> Result<(S3SourceReader, Option<PartitionId>), anyhow::Error> {
         let s3_conn = match connector {

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -125,6 +125,59 @@ impl AstDisplay for CsrSeed {
 impl_display!(CsrSeed);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum CreateSourceFormat<T: AstInfo> {
+    None,
+    /// `CREATE SOURCE .. FORMAT`
+    Bare(Format<T>),
+    /// `CREATE SOURCE .. KEY FORMAT .. VALUE FORMAT`
+    ///
+    /// Also the destination for the legacy `ENVELOPE UPSERT FORMAT ...`
+    KeyValue {
+        key: Format<T>,
+        value: Format<T>,
+    },
+}
+
+impl<T: AstInfo + PartialEq> CreateSourceFormat<T> {
+    /// True if this is a Bare format that can contain no configuration
+    pub fn is_simple(&self) -> bool {
+        match self {
+            CreateSourceFormat::Bare(f) => f.is_simple(),
+            CreateSourceFormat::KeyValue { .. } => false,
+            CreateSourceFormat::None => false,
+        }
+    }
+
+    /// The value portion of a `KeyValue` format, or the only format in `Bare`
+    pub fn value(self) -> Option<Format<T>> {
+        match self {
+            CreateSourceFormat::None => None,
+            CreateSourceFormat::Bare(f) => Some(f),
+            CreateSourceFormat::KeyValue { value, .. } => Some(value),
+        }
+    }
+}
+
+impl<T: AstInfo> AstDisplay for CreateSourceFormat<T> {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        match self {
+            CreateSourceFormat::None => {}
+            CreateSourceFormat::Bare(format) => {
+                f.write_str(" FORMAT ");
+                f.write_node(format)
+            }
+            CreateSourceFormat::KeyValue { key, value } => {
+                f.write_str(" KEY FORMAT ");
+                f.write_node(key);
+                f.write_str(" VALUE FORMAT ");
+                f.write_node(value);
+            }
+        }
+    }
+}
+impl_display_t!(CreateSourceFormat);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Format<T: AstInfo> {
     Bytes,
     Avro(AvroSchema<T>),
@@ -142,21 +195,28 @@ pub enum Format<T: AstInfo> {
     Text,
 }
 
+impl<T: AstInfo> Format<T> {
+    /// True if the format cannot carry any configuration
+    pub fn is_simple(&self) -> bool {
+        matches!(self, Format::Bytes | Format::Text)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum Envelope<T: AstInfo> {
+pub enum Envelope {
     None,
     Debezium(DbzMode),
-    Upsert(Option<Format<T>>),
+    Upsert,
     CdcV2,
 }
 
-impl<T: AstInfo> Default for Envelope<T> {
+impl Default for Envelope {
     fn default() -> Self {
         Self::None
     }
 }
 
-impl<T: AstInfo> AstDisplay for Envelope<T> {
+impl AstDisplay for Envelope {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
             Self::None => {
@@ -167,12 +227,8 @@ impl<T: AstInfo> AstDisplay for Envelope<T> {
                 f.write_str("DEBEZIUM");
                 f.write_node(mode);
             }
-            Self::Upsert(format) => {
+            Self::Upsert => {
                 f.write_str("UPSERT");
-                if let Some(format) = format {
-                    f.write_str(" FORMAT ");
-                    f.write_node(format);
-                }
             }
             Self::CdcV2 => {
                 f.write_str("MATERIALIZE");
@@ -180,7 +236,7 @@ impl<T: AstInfo> AstDisplay for Envelope<T> {
         }
     }
 }
-impl_display_t!(Envelope);
+impl_display!(Envelope);
 
 impl<T: AstInfo> AstDisplay for Format<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -149,7 +149,7 @@ impl<T: AstInfo + PartialEq> CreateSourceFormat<T> {
     }
 
     /// The value portion of a `KeyValue` format, or the only format in `Bare`
-    pub fn value(self) -> Option<Format<T>> {
+    pub fn value(&self) -> Option<&Format<T>> {
         match self {
             CreateSourceFormat::None => None,
             CreateSourceFormat::Bare(f) => Some(f),

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -22,8 +22,8 @@ use std::fmt;
 
 use crate::ast::display::{self, AstDisplay, AstFormatter};
 use crate::ast::{
-    AstInfo, ColumnDef, Connector, DataType, Envelope, Expr, Format, Ident, MultiConnector, Query,
-    TableConstraint, UnresolvedObjectName, Value,
+    AstInfo, ColumnDef, Connector, CreateSourceFormat, DataType, Envelope, Expr, Format, Ident,
+    MultiConnector, Query, TableConstraint, UnresolvedObjectName, Value,
 };
 
 /// A top-level statement (SELECT, INSERT, CREATE, etc.)
@@ -356,8 +356,8 @@ pub struct CreateSourceStatement<T: AstInfo> {
     pub col_names: Vec<Ident>,
     pub connector: Connector<T>,
     pub with_options: Vec<SqlOption<T>>,
-    pub format: Option<Format<T>>,
-    pub envelope: Envelope<T>,
+    pub format: CreateSourceFormat<T>,
+    pub envelope: Envelope,
     pub if_not_exists: bool,
     pub materialized: bool,
 }
@@ -386,10 +386,7 @@ impl<T: AstInfo> AstDisplay for CreateSourceStatement<T> {
             f.write_node(&display::comma_separated(&self.with_options));
             f.write_str(")");
         }
-        if let Some(format) = &self.format {
-            f.write_str(" FORMAT ");
-            f.write_node(format);
-        }
+        f.write_node(&self.format);
         match self.envelope {
             Envelope::None => (),
             _ => {
@@ -429,7 +426,7 @@ pub struct CreateSinkStatement<T: AstInfo> {
     pub connector: Connector<T>,
     pub with_options: Vec<SqlOption<T>>,
     pub format: Option<Format<T>>,
-    pub envelope: Option<Envelope<T>>,
+    pub envelope: Option<Envelope>,
     pub with_snapshot: bool,
     pub as_of: Option<Expr<T>>,
     pub if_not_exists: bool,

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -24,7 +24,7 @@ use std::error::Error;
 use std::fmt;
 
 use itertools::Itertools;
-use log::debug;
+use log::{debug, warn};
 
 use ore::collections::CollectionExt;
 use repr::adt::datetime::DateTimeField;
@@ -1599,7 +1599,7 @@ impl<'a> Parser<'a> {
         Ok(schema)
     }
 
-    fn parse_envelope(&mut self) -> Result<Envelope<Raw>, ParserError> {
+    fn parse_envelope(&mut self) -> Result<Envelope, ParserError> {
         let envelope = if self.parse_keyword(NONE) {
             Envelope::None
         } else if self.parse_keyword(DEBEZIUM) {
@@ -1610,12 +1610,7 @@ impl<'a> Parser<'a> {
             };
             Envelope::Debezium(debezium_mode)
         } else if self.parse_keyword(UPSERT) {
-            let format = if self.parse_keyword(FORMAT) {
-                Some(self.parse_format()?)
-            } else {
-                None
-            };
-            Envelope::Upsert(format)
+            Envelope::Upsert
         } else if self.parse_keyword(MATERIALIZE) {
             Envelope::CdcV2
         } else {
@@ -1648,13 +1643,64 @@ impl<'a> Parser<'a> {
         self.expect_keyword(FROM)?;
         let connector = self.parse_connector()?;
         let with_options = self.parse_opt_with_sql_options()?;
-        let format = if self.parse_keyword(FORMAT) {
-            Some(self.parse_format()?)
+        // legacy upsert format syntax allows setting the key format after the keyword UPSERT, so we
+        // may mutate this variable in the next block
+        let mut format = if matches!(connector, Connector::Kafka { .. }) {
+            // pure.rs asserts that KeyValue formats only make sense for Kafka
+            match self.parse_one_of_keywords(&[KEY, FORMAT]) {
+                Some(KEY) => {
+                    self.expect_keyword(FORMAT)?;
+                    let key = self.parse_format()?;
+                    self.expect_keywords(&[VALUE, FORMAT])?;
+                    let value = self.parse_format()?;
+                    CreateSourceFormat::KeyValue { key, value }
+                }
+                Some(FORMAT) => CreateSourceFormat::Bare(self.parse_format()?),
+                Some(_) => unreachable!("parse_one_of_keywords returns None for this"),
+                None => CreateSourceFormat::None,
+            }
+        } else if self.parse_keyword(FORMAT) {
+            CreateSourceFormat::Bare(self.parse_format()?)
         } else {
-            None
+            CreateSourceFormat::None
         };
         let envelope = if self.parse_keyword(ENVELOPE) {
-            self.parse_envelope()?
+            let envelope = self.parse_envelope()?;
+            if matches!(envelope, Envelope::Upsert) {
+                // TODO: remove support for explicit UPSERT FORMAT after a period of deprecation
+                if self.parse_keyword(FORMAT) {
+                    warn!("UPSERT FORMAT has been deprecated, use the new KEY FORMAT syntax");
+                    if let CreateSourceFormat::Bare(value) = format {
+                        let key = self.parse_format()?;
+                        format = CreateSourceFormat::KeyValue { key, value };
+                    } else {
+                        self.error(
+                            self.index,
+                            "Key/Value format specified multiple times".into(),
+                        );
+                    }
+                } else if format.is_simple() {
+                    // the existing semantics of Upsert is that specifying a simple bare format
+                    // duplicates the format into the key.
+                    //
+                    // TODO(bwm): We should either make this the semantics everywhere, or deprecate
+                    // this.
+                    let value = format.value();
+                    if let Some(value) = value {
+                        format = CreateSourceFormat::KeyValue {
+                            key: value.clone(),
+                            value,
+                        }
+                    } else {
+                        return parser_err!(
+                            self,
+                            self.peek_pos(),
+                            "Upsert requires a value format"
+                        );
+                    };
+                }
+            }
+            envelope
         } else {
             Default::default()
         };
@@ -1705,7 +1751,8 @@ impl<'a> Parser<'a> {
             None
         };
         let envelope = if self.parse_keyword(ENVELOPE) {
-            Some(self.parse_envelope()?)
+            let envelope = self.parse_envelope()?;
+            Some(envelope)
         } else {
             None
         };
@@ -1792,7 +1839,13 @@ impl<'a> Parser<'a> {
                 let broker = self.parse_literal_string()?;
                 self.expect_keyword(TOPIC)?;
                 let topic = self.parse_literal_string()?;
-                let key = if self.parse_keyword(KEY) {
+                // one token of lookahead:
+                // * `KEY (` means we're parsing a list of columns for the key
+                // * `KEY FORMAT` means there is no key, we'll parse a KeyValueFormat later
+                let is_key_format = (matches!(self.peek_keyword(), Some(KEY))
+                    && matches!(self.peek_nth_token(1), Some(Token::Keyword(FORMAT))));
+                let key = if !is_key_format && self.peek_keyword() == Some(KEY) {
+                    let _ = self.expect_keyword(KEY);
                     Some(self.parse_parenthesized_column_list(Mandatory)?)
                 } else {
                     None

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -330,7 +330,7 @@ CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING SCHEMA 'baz'
 ----
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING SCHEMA 'baz'
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Some(Avro(Schema { schema: Inline("baz"), with_options: [] })), envelope: None, if_not_exists: false, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Bare(Avro(Schema { schema: Inline("baz"), with_options: [] })), envelope: None, if_not_exists: false, materialized: false })
 
 parse-statement
 CREATE SOURCE foo
@@ -339,7 +339,7 @@ FORMAT BYTES
 ----
 CREATE SOURCE foo FROM KAFKA BROKER 'bar' TOPIC 'baz' WITH (consistency = 'lug', ssl_certificate_file = '/Path/to/file') FORMAT BYTES
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: Kafka { broker: "bar", topic: "baz", key: None }, with_options: [Value { name: Ident("consistency"), value: String("lug") }, Value { name: Ident("ssl_certificate_file"), value: String("/Path/to/file") }], format: Some(Bytes), envelope: None, if_not_exists: false, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: Kafka { broker: "bar", topic: "baz", key: None }, with_options: [Value { name: Ident("consistency"), value: String("lug") }, Value { name: Ident("ssl_certificate_file"), value: String("/Path/to/file") }], format: Bare(Bytes), envelope: None, if_not_exists: false, materialized: false })
 
 parse-statement
 CREATE MATERIALIZED SOURCE foo FROM FILE 'bar' FORMAT PROTOBUF MESSAGE
@@ -347,49 +347,49 @@ CREATE MATERIALIZED SOURCE foo FROM FILE 'bar' FORMAT PROTOBUF MESSAGE
 ----
 CREATE MATERIALIZED SOURCE foo FROM FILE 'bar' FORMAT PROTOBUF MESSAGE 'somemessage' USING SCHEMA FILE 'path'
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Some(Protobuf { message_name: "somemessage", schema: File("path") }), envelope: None, if_not_exists: false, materialized: true })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Bare(Protobuf { message_name: "somemessage", schema: File("path") }), envelope: None, if_not_exists: false, materialized: true })
 
 parse-statement
 CREATE SOURCE IF NOT EXISTS foo FROM FILE 'bar' WITH (tail = true) FORMAT REGEX '(asdf)|(jkl)'
 ----
 CREATE SOURCE IF NOT EXISTS foo FROM FILE 'bar' WITH (tail = true) FORMAT REGEX '(asdf)|(jkl)'
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [Value { name: Ident("tail"), value: Boolean(true) }], format: Some(Regex("(asdf)|(jkl)")), envelope: None, if_not_exists: true, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [Value { name: Ident("tail"), value: Boolean(true) }], format: Bare(Regex("(asdf)|(jkl)")), envelope: None, if_not_exists: true, materialized: false })
 
 parse-statement
 CREATE SOURCE IF NOT EXISTS foo (one, two) FROM FILE 'bar' WITH (tail = true) FORMAT REGEX '(asdf)|(jkl)'
 ----
 CREATE SOURCE IF NOT EXISTS foo (one, two) FROM FILE 'bar' WITH (tail = true) FORMAT REGEX '(asdf)|(jkl)'
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [Ident("one"), Ident("two")], connector: File { path: "bar", compression: None }, with_options: [Value { name: Ident("tail"), value: Boolean(true) }], format: Some(Regex("(asdf)|(jkl)")), envelope: None, if_not_exists: true, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [Ident("one"), Ident("two")], connector: File { path: "bar", compression: None }, with_options: [Value { name: Ident("tail"), value: Boolean(true) }], format: Bare(Regex("(asdf)|(jkl)")), envelope: None, if_not_exists: true, materialized: false })
 
 parse-statement
 CREATE SOURCE foo FROM FILE 'bar' WITH (tail = false) FORMAT CSV WITH HEADER
 ----
 CREATE SOURCE foo FROM FILE 'bar' WITH (tail = false) FORMAT CSV WITH HEADER
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [Value { name: Ident("tail"), value: Boolean(false) }], format: Some(Csv { header_row: true, n_cols: None, delimiter: ',' }), envelope: None, if_not_exists: false, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [Value { name: Ident("tail"), value: Boolean(false) }], format: Bare(Csv { header_row: true, n_cols: None, delimiter: ',' }), envelope: None, if_not_exists: false, materialized: false })
 
 parse-statement
 CREATE SOURCE foo FROM FILE 'bar' WITH (tail = false) FORMAT CSV WITH 3 COLUMNS
 ----
 CREATE SOURCE foo FROM FILE 'bar' WITH (tail = false) FORMAT CSV WITH 3 COLUMNS
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [Value { name: Ident("tail"), value: Boolean(false) }], format: Some(Csv { header_row: false, n_cols: Some(3), delimiter: ',' }), envelope: None, if_not_exists: false, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [Value { name: Ident("tail"), value: Boolean(false) }], format: Bare(Csv { header_row: false, n_cols: Some(3), delimiter: ',' }), envelope: None, if_not_exists: false, materialized: false })
 
 parse-statement
 CREATE SOURCE foo (one, two) FROM FILE 'bar' FORMAT CSV WITH HEADER
 ----
 CREATE SOURCE foo (one, two) FROM FILE 'bar' FORMAT CSV WITH HEADER
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [Ident("one"), Ident("two")], connector: File { path: "bar", compression: None }, with_options: [], format: Some(Csv { header_row: true, n_cols: None, delimiter: ',' }), envelope: None, if_not_exists: false, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [Ident("one"), Ident("two")], connector: File { path: "bar", compression: None }, with_options: [], format: Bare(Csv { header_row: true, n_cols: None, delimiter: ',' }), envelope: None, if_not_exists: false, materialized: false })
 
 parse-statement
 CREATE SOURCE foo FROM FILE 'bar' WITH (tail = true) FORMAT CSV WITH 3 COLUMNS DELIMITED BY '|'
 ----
 CREATE SOURCE foo FROM FILE 'bar' WITH (tail = true) FORMAT CSV WITH 3 COLUMNS DELIMITED BY '|'
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [Value { name: Ident("tail"), value: Boolean(true) }], format: Some(Csv { header_row: false, n_cols: Some(3), delimiter: '|' }), envelope: None, if_not_exists: false, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [Value { name: Ident("tail"), value: Boolean(true) }], format: Bare(Csv { header_row: false, n_cols: Some(3), delimiter: '|' }), envelope: None, if_not_exists: false, materialized: false })
 
 parse-statement
 CREATE MATERIALIZED OR VIEW foo as SELECT * from bar
@@ -410,91 +410,91 @@ CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'h
 ----
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' ENVELOPE DEBEZIUM
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [] })), envelope: Debezium(Plain), if_not_exists: false, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Bare(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [] })), envelope: Debezium(Plain), if_not_exists: false, materialized: false })
 
 parse-statement
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' SEED VALUE SCHEMA 'blah'
 ----
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' SEED VALUE SCHEMA 'blah'
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: Some(CsrSeed { key_schema: None, value_schema: "blah" }), with_options: [] })), envelope: None, if_not_exists: false, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Bare(Avro(CsrUrl { url: "http://localhost:8081", seed: Some(CsrSeed { key_schema: None, value_schema: "blah" }), with_options: [] })), envelope: None, if_not_exists: false, materialized: false })
 
 parse-statement
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' SEED KEY SCHEMA 'a' VALUE SCHEMA 'b'
 ----
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' SEED KEY SCHEMA 'a' VALUE SCHEMA 'b'
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: Some(CsrSeed { key_schema: Some("a"), value_schema: "b" }), with_options: [] })), envelope: None, if_not_exists: false, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Bare(Avro(CsrUrl { url: "http://localhost:8081", seed: Some(CsrSeed { key_schema: Some("a"), value_schema: "b" }), with_options: [] })), envelope: None, if_not_exists: false, materialized: false })
 
 parse-statement
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (a = 'b') ENVELOPE DEBEZIUM
 ----
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (a = 'b') ENVELOPE DEBEZIUM
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [Value { name: Ident("a"), value: String("b") }] })), envelope: Debezium(Plain), if_not_exists: false, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Bare(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [Value { name: Ident("a"), value: String("b") }] })), envelope: Debezium(Plain), if_not_exists: false, materialized: false })
 
 parse-statement
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081'
 ----
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081'
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [] })), envelope: None, if_not_exists: false, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Bare(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [] })), envelope: None, if_not_exists: false, materialized: false })
 
 parse-statement
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' ENVELOPE UPSERT
 ----
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' ENVELOPE UPSERT
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connector: Kafka { broker: "zubat", topic: "hoothoot", key: None }, with_options: [], format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [] })), envelope: Upsert(None), if_not_exists: false, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connector: Kafka { broker: "zubat", topic: "hoothoot", key: None }, with_options: [], format: Bare(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [] })), envelope: Upsert, if_not_exists: false, materialized: false })
 
 parse-statement
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USING SCHEMA 'string' ENVELOPE UPSERT FORMAT AVRO USING SCHEMA 'long'
 ----
-CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USING SCHEMA 'string' ENVELOPE UPSERT FORMAT AVRO USING SCHEMA 'long'
+CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT AVRO USING SCHEMA 'long' VALUE FORMAT AVRO USING SCHEMA 'string' ENVELOPE UPSERT
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connector: Kafka { broker: "zubat", topic: "hoothoot", key: None }, with_options: [], format: Some(Avro(Schema { schema: Inline("string"), with_options: [] })), envelope: Upsert(Some(Avro(Schema { schema: Inline("long"), with_options: [] }))), if_not_exists: false, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connector: Kafka { broker: "zubat", topic: "hoothoot", key: None }, with_options: [], format: KeyValue { key: Avro(Schema { schema: Inline("long"), with_options: [] }), value: Avro(Schema { schema: Inline("string"), with_options: [] }) }, envelope: Upsert, if_not_exists: false, materialized: false })
 
 parse-statement
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USING SCHEMA 'string' WITH (confluent_wire_format = false) ENVELOPE NONE
 ----
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USING SCHEMA 'string' WITH (confluent_wire_format = false)
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connector: Kafka { broker: "zubat", topic: "hoothoot", key: None }, with_options: [], format: Some(Avro(Schema { schema: Inline("string"), with_options: [WithOption { key: Ident("confluent_wire_format"), value: Some(Value(Boolean(false))) }] })), envelope: None, if_not_exists: false, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connector: Kafka { broker: "zubat", topic: "hoothoot", key: None }, with_options: [], format: Bare(Avro(Schema { schema: Inline("string"), with_options: [WithOption { key: Ident("confluent_wire_format"), value: Some(Value(Boolean(false))) }] })), envelope: None, if_not_exists: false, materialized: false })
 
 parse-statement
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT FORMAT TEXT
 ----
-CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT FORMAT TEXT
+CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connector: Kafka { broker: "zubat", topic: "hoothoot", key: None }, with_options: [], format: Some(Avro(Schema { schema: File("path"), with_options: [] })), envelope: Upsert(Some(Text)), if_not_exists: false, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connector: Kafka { broker: "zubat", topic: "hoothoot", key: None }, with_options: [], format: KeyValue { key: Text, value: Avro(Schema { schema: File("path"), with_options: [] }) }, envelope: Upsert, if_not_exists: false, materialized: false })
 
 parse-statement
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset=2) FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT FORMAT TEXT
 ----
-CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset = 2) FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT FORMAT TEXT
+CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset = 2) KEY FORMAT TEXT VALUE FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka { broker: "broker", topic: "topic", key: None }, with_options: [Value { name: Ident("start_offset"), value: Number("2") }], format: Some(Avro(Schema { schema: File("path"), with_options: [] })), envelope: Upsert(Some(Text)), if_not_exists: false, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka { broker: "broker", topic: "topic", key: None }, with_options: [Value { name: Ident("start_offset"), value: Number("2") }], format: KeyValue { key: Text, value: Avro(Schema { schema: File("path"), with_options: [] }) }, envelope: Upsert, if_not_exists: false, materialized: false })
 
 parse-statement
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset=[]) FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT FORMAT TEXT
 ----
-CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset = []) FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT FORMAT TEXT
+CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset = []) KEY FORMAT TEXT VALUE FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka { broker: "broker", topic: "topic", key: None }, with_options: [Value { name: Ident("start_offset"), value: Array([]) }], format: Some(Avro(Schema { schema: File("path"), with_options: [] })), envelope: Upsert(Some(Text)), if_not_exists: false, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka { broker: "broker", topic: "topic", key: None }, with_options: [Value { name: Ident("start_offset"), value: Array([]) }], format: KeyValue { key: Text, value: Avro(Schema { schema: File("path"), with_options: [] }) }, envelope: Upsert, if_not_exists: false, materialized: false })
 
 parse-statement
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset=[2]) FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT FORMAT TEXT
 ----
-CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset = [2]) FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT FORMAT TEXT
+CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset = [2]) KEY FORMAT TEXT VALUE FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka { broker: "broker", topic: "topic", key: None }, with_options: [Value { name: Ident("start_offset"), value: Array([Number("2")]) }], format: Some(Avro(Schema { schema: File("path"), with_options: [] })), envelope: Upsert(Some(Text)), if_not_exists: false, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka { broker: "broker", topic: "topic", key: None }, with_options: [Value { name: Ident("start_offset"), value: Array([Number("2")]) }], format: KeyValue { key: Text, value: Avro(Schema { schema: File("path"), with_options: [] }) }, envelope: Upsert, if_not_exists: false, materialized: false })
 
 parse-statement
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset=[2, 40000000]) FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT FORMAT TEXT
 ----
-CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset = [2, 40000000]) FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT FORMAT TEXT
+CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset = [2, 40000000]) KEY FORMAT TEXT VALUE FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka { broker: "broker", topic: "topic", key: None }, with_options: [Value { name: Ident("start_offset"), value: Array([Number("2"), Number("40000000")]) }], format: Some(Avro(Schema { schema: File("path"), with_options: [] })), envelope: Upsert(Some(Text)), if_not_exists: false, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka { broker: "broker", topic: "topic", key: None }, with_options: [Value { name: Ident("start_offset"), value: Array([Number("2"), Number("40000000")]) }], format: KeyValue { key: Text, value: Avro(Schema { schema: File("path"), with_options: [] }) }, envelope: Upsert, if_not_exists: false, materialized: false })
 
 parse-statement
 CREATE SOURCE psychic FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' TABLE generation1.psychic (pokedex_id int NOT NULL, evolution int);
@@ -515,7 +515,7 @@ CREATE SOURCE IF NOT EXISTS foo FROM FILE 'bar' FORMAT BYTES
 ----
 CREATE SOURCE IF NOT EXISTS foo FROM FILE 'bar' FORMAT BYTES
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Some(Bytes), envelope: None, if_not_exists: true, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Bare(Bytes), envelope: None, if_not_exists: true, materialized: false })
 
 parse-statement
 CREATE SOURCE IF EXISTS foo FROM FILE 'bar' USING SCHEMA ''
@@ -597,9 +597,9 @@ CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), fro
 parse-statement
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY FORMAT BYTES
 ----
-error: Expected a list of columns in parentheses, found FORMAT
+error: Expected end of statement, found KEY
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY FORMAT BYTES
-                                                                   ^
+                                                               ^
 
 parse-statement
 CREATE SINK foo FROM bar INTO AVRO OCF 'baz'

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -394,9 +394,170 @@ pub fn plan_create_source(
         materialized,
         format,
     } = &stmt;
+    let get_encoding_inner = |format: &Format<Raw>| {
+        // Avro/CSR can return a `SourceDataEncoding::KeyValue`
+        Ok(SourceDataEncoding::Single(match format {
+            Format::Bytes => DataEncoding::Bytes,
+            Format::Avro(schema) => {
+                let Schema {
+                    key_schema,
+                    value_schema,
+                    schema_registry_config,
+                    confluent_wire_format,
+                } = match schema {
+                    // TODO(jldlaughlin): we need a way to pass in primary key information
+                    // when building a source from a string or file.
+                    AvroSchema::Schema {
+                        schema: sql_parser::ast::Schema::Inline(schema),
+                        with_options,
+                    } => {
+                        with_options! {
+                            struct ConfluentMagic {
+                                confluent_wire_format: bool,
+                            }
+                        }
 
-    // TODO(bwm): use the normalized with_options in all the helper methods
-    let with_options_orig = with_options;
+                        Schema {
+                            key_schema: None,
+                            value_schema: schema.clone(),
+                            schema_registry_config: None,
+                            confluent_wire_format: ConfluentMagic::try_from(with_options.clone())?
+                                .confluent_wire_format
+                                .unwrap_or(true),
+                        }
+                    }
+                    AvroSchema::Schema {
+                        schema: sql_parser::ast::Schema::File(_),
+                        ..
+                    } => {
+                        unreachable!("File schema should already have been inlined")
+                    }
+                    AvroSchema::CsrUrl {
+                        url,
+                        seed,
+                        with_options: ccsr_options,
+                    } => {
+                        let url: Url = url.parse()?;
+                        let kafka_options =
+                            kafka_util::extract_config(&mut normalize::options(with_options))?;
+                        let ccsr_config = kafka_util::generate_ccsr_client_config(
+                            url,
+                            &kafka_options,
+                            normalize::options(&ccsr_options),
+                        )?;
+
+                        if let Some(seed) = seed {
+                            Schema {
+                                key_schema: seed.key_schema.clone(),
+                                value_schema: seed.value_schema.clone(),
+                                schema_registry_config: Some(ccsr_config),
+                                confluent_wire_format: true,
+                            }
+                        } else {
+                            unreachable!("CSR seed resolution should already have been called")
+                        }
+                    }
+                };
+
+                if let Some(key_schema) = key_schema {
+                    return Ok(SourceDataEncoding::KeyValue {
+                        key: DataEncoding::Avro(AvroEncoding {
+                            schema: key_schema,
+                            schema_registry_config: schema_registry_config.clone(),
+                            confluent_wire_format,
+                        }),
+                        value: DataEncoding::Avro(AvroEncoding {
+                            schema: value_schema,
+                            schema_registry_config,
+                            confluent_wire_format,
+                        }),
+                    });
+                } else {
+                    DataEncoding::Avro(AvroEncoding {
+                        schema: value_schema,
+                        schema_registry_config,
+                        confluent_wire_format,
+                    })
+                }
+            }
+            Format::Protobuf {
+                message_name,
+                schema,
+            } => {
+                let descriptors = match schema {
+                    sql_parser::ast::Schema::Inline(bytes) => strconv::parse_bytes(&bytes)?,
+                    sql_parser::ast::Schema::File(_) => {
+                        unreachable!("File schema should already have been inlined")
+                    }
+                };
+
+                DataEncoding::Protobuf(ProtobufEncoding {
+                    descriptors,
+                    message_name: message_name.to_owned(),
+                })
+            }
+            Format::Regex(regex) => {
+                let regex = Regex::new(&regex)?;
+                DataEncoding::Regex(RegexEncoding { regex })
+            }
+            Format::Csv {
+                header_row,
+                n_cols,
+                delimiter,
+            } => {
+                let n_cols = if col_names.is_empty() {
+                    match n_cols {
+                        Some(n) => *n,
+                        None => bail!(
+                            "Cannot determine number of columns in CSV source; specify using \
+                             CREATE SOURCE...FORMAT CSV WITH X COLUMNS"
+                        ),
+                    }
+                } else {
+                    col_names.len()
+                };
+                DataEncoding::Csv(CsvEncoding {
+                    header_row: *header_row,
+                    n_cols,
+                    delimiter: match *delimiter as u32 {
+                        0..=127 => *delimiter as u8,
+                        _ => bail!("CSV delimiter must be an ASCII character"),
+                    },
+                })
+            }
+            Format::Json => unsupported!("JSON sources"),
+            Format::Text => DataEncoding::Text,
+        }))
+    };
+    let get_encoding = |format: &CreateSourceFormat<Raw>| {
+        let encoding = match format {
+            CreateSourceFormat::None => bail!("Source format must be specified"),
+            CreateSourceFormat::Bare(format) => get_encoding_inner(format)?,
+            CreateSourceFormat::KeyValue { key, value } => {
+                let key = match get_encoding_inner(key)? {
+                    SourceDataEncoding::Single(key) => key,
+                    SourceDataEncoding::KeyValue { key, .. } => key,
+                };
+                let value = match get_encoding_inner(value)? {
+                    SourceDataEncoding::Single(value) => value,
+                    SourceDataEncoding::KeyValue { value, .. } => value,
+                };
+                SourceDataEncoding::KeyValue { key, value }
+            }
+        };
+
+        let requires_keyvalue = matches!(
+            envelope,
+            Envelope::Debezium(DbzMode::Upsert) | Envelope::Upsert
+        );
+        let is_keyvalue = matches!(encoding, SourceDataEncoding::KeyValue { .. });
+        if requires_keyvalue && !is_keyvalue {
+            bail!("ENVELOPE [DEBEZIUM] UPSERT requires that KEY FORMAT be specified");
+        };
+
+        Ok(encoding)
+    };
+
     let mut with_options = normalize::options(with_options);
 
     let mut consistency = Consistency::RealTime;
@@ -476,7 +637,7 @@ pub fn plan_create_source(
                 enable_caching,
                 cached_files: None,
             });
-            let encoding = get_encoding(format, &envelope, with_options_orig, col_names)?;
+            let encoding = get_encoding(format)?;
 
             if consistency != Consistency::RealTime
                 && *envelope != sql_parser::ast::Envelope::Debezium(sql_parser::ast::DbzMode::Plain)
@@ -509,7 +670,7 @@ pub fn plan_create_source(
                 stream_name,
                 aws_info,
             });
-            let encoding = get_encoding(format, &envelope, with_options_orig, col_names)?;
+            let encoding = get_encoding(format)?;
             (connector, encoding)
         }
         Connector::File { path, compression } => {
@@ -535,7 +696,7 @@ pub fn plan_create_source(
                 },
                 tail,
             });
-            let encoding = get_encoding(format, &envelope, with_options_orig, col_names)?;
+            let encoding = get_encoding(format)?;
             (connector, encoding)
         }
         Connector::S3 {
@@ -577,7 +738,7 @@ pub fn plan_create_source(
                     Compression::None => dataflow_types::Compression::None,
                 },
             });
-            let encoding = get_encoding(format, &envelope, with_options_orig, col_names)?;
+            let encoding = get_encoding(format)?;
             (connector, encoding)
         }
         Connector::Postgres {
@@ -941,182 +1102,6 @@ pub fn plan_create_sources(
     }
 
     Ok(Plan::CreateSources { sources })
-}
-
-fn get_encoding(
-    format: &CreateSourceFormat<Raw>,
-    envelope: &Envelope,
-    with_options: &Vec<SqlOption<Raw>>,
-    col_names: &Vec<Ident>,
-) -> Result<SourceDataEncoding, anyhow::Error> {
-    // TODO(bwm): move single -> keyvalue rewriting to purify?
-    let encoding = match format {
-        CreateSourceFormat::None => bail!("Source format must be specified"),
-        CreateSourceFormat::Bare(format) => get_encoding_inner(format, with_options, col_names)?,
-        CreateSourceFormat::KeyValue { key, value } => {
-            let key = match get_encoding_inner(key, with_options, col_names)? {
-                SourceDataEncoding::Single(key) => key,
-                SourceDataEncoding::KeyValue { key, .. } => key,
-            };
-            let value = match get_encoding_inner(value, with_options, col_names)? {
-                SourceDataEncoding::Single(value) => value,
-                SourceDataEncoding::KeyValue { value, .. } => value,
-            };
-            SourceDataEncoding::KeyValue { key, value }
-        }
-    };
-
-    let requires_keyvalue = matches!(
-        envelope,
-        Envelope::Debezium(DbzMode::Upsert) | Envelope::Upsert
-    );
-    let is_keyvalue = matches!(encoding, SourceDataEncoding::KeyValue { .. });
-    if requires_keyvalue && !is_keyvalue {
-        bail!("ENVELOPE [DEBEZIUM] UPSERT requires that KEY FORMAT be specified");
-    };
-
-    Ok(encoding)
-}
-
-fn get_encoding_inner(
-    format: &Format<Raw>,
-    with_options: &Vec<SqlOption<Raw>>,
-    col_names: &Vec<Ident>,
-) -> Result<SourceDataEncoding, anyhow::Error> {
-    // Avro/CSR can return a `SourceDataEncoding::KeyValue`
-    Ok(SourceDataEncoding::Single(match format {
-        Format::Bytes => DataEncoding::Bytes,
-        Format::Avro(schema) => {
-            let Schema {
-                key_schema,
-                value_schema,
-                schema_registry_config,
-                confluent_wire_format,
-            } = match schema {
-                // TODO(jldlaughlin): we need a way to pass in primary key information
-                // when building a source from a string or file.
-                AvroSchema::Schema {
-                    schema: sql_parser::ast::Schema::Inline(schema),
-                    with_options,
-                } => {
-                    with_options! {
-                        struct ConfluentMagic {
-                            confluent_wire_format: bool,
-                        }
-                    }
-
-                    Schema {
-                        key_schema: None,
-                        value_schema: schema.clone(),
-                        schema_registry_config: None,
-                        confluent_wire_format: ConfluentMagic::try_from(with_options.clone())?
-                            .confluent_wire_format
-                            .unwrap_or(true),
-                    }
-                }
-                AvroSchema::Schema {
-                    schema: sql_parser::ast::Schema::File(_),
-                    ..
-                } => {
-                    unreachable!("File schema should already have been inlined")
-                }
-                AvroSchema::CsrUrl {
-                    url,
-                    seed,
-                    with_options: ccsr_options,
-                } => {
-                    let url: Url = url.parse()?;
-                    let kafka_options =
-                        kafka_util::extract_config(&mut normalize::options(with_options))?;
-                    let ccsr_config = kafka_util::generate_ccsr_client_config(
-                        url,
-                        &kafka_options,
-                        normalize::options(ccsr_options),
-                    )?;
-
-                    if let Some(seed) = seed {
-                        Schema {
-                            key_schema: seed.key_schema.clone(),
-                            value_schema: seed.value_schema.clone(),
-                            schema_registry_config: Some(ccsr_config),
-                            confluent_wire_format: true,
-                        }
-                    } else {
-                        unreachable!("CSR seed resolution should already have been called")
-                    }
-                }
-            };
-
-            // TODO(bwm): move this into purify_format
-            if let Some(key_schema) = key_schema {
-                return Ok(SourceDataEncoding::KeyValue {
-                    key: DataEncoding::Avro(AvroEncoding {
-                        schema: key_schema,
-                        schema_registry_config: schema_registry_config.clone(),
-                        confluent_wire_format,
-                    }),
-                    value: DataEncoding::Avro(AvroEncoding {
-                        schema: value_schema,
-                        schema_registry_config,
-                        confluent_wire_format,
-                    }),
-                });
-            } else {
-                DataEncoding::Avro(AvroEncoding {
-                    schema: value_schema,
-                    schema_registry_config,
-                    confluent_wire_format,
-                })
-            }
-        }
-        Format::Protobuf {
-            message_name,
-            schema,
-        } => {
-            let descriptors = match schema {
-                sql_parser::ast::Schema::Inline(bytes) => strconv::parse_bytes(&bytes)?,
-                sql_parser::ast::Schema::File(_) => {
-                    unreachable!("File schema should already have been inlined")
-                }
-            };
-
-            DataEncoding::Protobuf(ProtobufEncoding {
-                descriptors,
-                message_name: message_name.to_owned(),
-            })
-        }
-        Format::Regex(regex) => {
-            let regex = Regex::new(regex)?;
-            DataEncoding::Regex(RegexEncoding { regex })
-        }
-        Format::Csv {
-            header_row,
-            n_cols,
-            delimiter,
-        } => {
-            let n_cols = if col_names.is_empty() {
-                match n_cols {
-                    Some(n) => *n,
-                    None => bail!(
-                        "Cannot determine number of columns in CSV source; specify using \
-                             CREATE SOURCE...FORMAT CSV WITH X COLUMNS"
-                    ),
-                }
-            } else {
-                col_names.len()
-            };
-            DataEncoding::Csv(CsvEncoding {
-                header_row: *header_row,
-                n_cols,
-                delimiter: match *delimiter as u32 {
-                    0..=127 => *delimiter as u8,
-                    _ => bail!("CSV delimiter must be an ASCII character"),
-                },
-            })
-        }
-        Format::Json => unsupported!("JSON sources"),
-        Format::Text => DataEncoding::Text,
-    }))
 }
 
 pub fn describe_create_view(

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -389,10 +389,10 @@ pub fn plan_create_source(
         col_names,
         connector,
         with_options,
-        format,
         envelope,
         if_not_exists,
         materialized,
+        format,
     } = &stmt;
 
     // TODO(bwm): use the normalized with_options in all the helper methods
@@ -949,7 +949,7 @@ fn get_encoding(
     with_options: &Vec<SqlOption<Raw>>,
     col_names: &Vec<Ident>,
 ) -> Result<SourceDataEncoding, anyhow::Error> {
-    // TODO(bwm): move single -> keyvalue rewriting to purify
+    // TODO(bwm): move single -> keyvalue rewriting to purify?
     let encoding = match format {
         CreateSourceFormat::None => bail!("Source format must be specified"),
         CreateSourceFormat::Bare(format) => get_encoding_inner(format, with_options, col_names)?,

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -960,9 +960,11 @@ pub fn plan_create_source(
         sql_parser::ast::Envelope::Upsert => match connector {
             Connector::Kafka { .. } => match format {
                 CreateSourceFormat::KeyValue { .. } => SourceEnvelope::Upsert,
-                // this is validated to become keyvalue in purify, where we can talk to CSR
                 CreateSourceFormat::Bare(Format::Avro(AvroSchema::CsrUrl { .. })) => {
-                    SourceEnvelope::Upsert
+                    bail!(
+                        "[internal-error] CSR create source statements should be \
+                           canonicalized to key/value format in purify"
+                    );
                 }
                 _ => unsupported!(format!("upsert requires a key/value format: {:?}", format)),
             },

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -13,7 +13,7 @@
 
 use std::collections::{BTreeMap, HashSet};
 
-use anyhow::{anyhow, bail, Context};
+use anyhow::{anyhow, bail, ensure, Context};
 use aws_arn::ARN;
 use tokio::fs::File;
 use tokio::io::AsyncBufReadExt;
@@ -24,9 +24,9 @@ use uuid::Uuid;
 use repr::strconv;
 use sql_parser::ast::display::AstDisplay;
 use sql_parser::ast::{
-    AvroSchema, ColumnDef, ColumnOption, Connector, CreateSourceStatement, CreateSourcesStatement,
-    CsrSeed, DbzMode, Envelope, Format, Ident, MultiConnector, Raw, Statement,
-    UnresolvedObjectName,
+    AvroSchema, ColumnDef, ColumnOption, Connector, CreateSourceFormat, CreateSourceStatement,
+    CreateSourcesStatement, CsrSeed, DbzMode, Envelope, Format, Ident, MultiConnector, Raw,
+    Statement, UnresolvedObjectName,
 };
 use sql_parser::parser::parse_columns;
 
@@ -134,25 +134,6 @@ pub async fn purify(mut stmt: Statement<Raw>) -> Result<Statement<Raw>, anyhow::
             &config_options,
         )
         .await?;
-        if let sql_parser::ast::Envelope::Upsert(_) = envelope {
-            // TODO(bwm): this will be removed with the upcoming upsert rationalization
-            //
-            // The `format` argument is mutated in the call to purify_format, so it must be the
-            // original format from the outer envelope. The envelope is just matched against, and
-            // can be cloned safely.
-            let envelope_dupe = envelope.clone();
-            if let sql_parser::ast::Envelope::Upsert(format) = envelope {
-                purify_format(
-                    format,
-                    connector,
-                    &envelope_dupe,
-                    col_names,
-                    None,
-                    &config_options,
-                )
-                .await?;
-            }
-        }
     }
     if let Statement::CreateSources(CreateSourcesStatement {
         connector,
@@ -186,7 +167,7 @@ pub async fn purify(mut stmt: Statement<Raw>) -> Result<Statement<Raw>, anyhow::
                             table: table.name.to_owned(),
                             columns: table.columns.clone(),
                         },
-                        format: None,
+                        format: CreateSourceFormat::None,
                         with_options: vec![],
                         envelope: Envelope::None,
                         if_not_exists: false,
@@ -265,15 +246,52 @@ async fn purify_postgres_table(
 }
 
 async fn purify_format(
-    format: &mut Option<Format<Raw>>,
+    format: &mut CreateSourceFormat<Raw>,
     connector: &mut Connector<Raw>,
-    envelope: &Envelope<Raw>,
+    envelope: &Envelope,
     col_names: &mut Vec<Ident>,
     file: Option<File>,
     connector_options: &BTreeMap<String, String>,
 ) -> Result<(), anyhow::Error> {
     match format {
-        Some(Format::Avro(schema)) => match schema {
+        CreateSourceFormat::None => {}
+        CreateSourceFormat::Bare(format) => {
+            purify_format_single(
+                format,
+                connector,
+                envelope,
+                col_names,
+                file,
+                connector_options,
+            )
+            .await?
+        }
+
+        CreateSourceFormat::KeyValue { key, value: val } => {
+            ensure!(
+                file.is_none(),
+                anyhow!("[internal-error] File sources cannot be key-value sources")
+            );
+
+            purify_format_single(key, connector, envelope, col_names, None, connector_options)
+                .await?;
+            purify_format_single(val, connector, envelope, col_names, None, connector_options)
+                .await?;
+        }
+    }
+    Ok(())
+}
+
+async fn purify_format_single(
+    format: &mut Format<Raw>,
+    connector: &mut Connector<Raw>,
+    envelope: &Envelope,
+    col_names: &mut Vec<Ident>,
+    file: Option<File>,
+    connector_options: &BTreeMap<String, String>,
+) -> Result<(), anyhow::Error> {
+    match format {
+        Format::Avro(schema) => match schema {
             AvroSchema::CsrUrl {
                 url,
                 seed,
@@ -315,32 +333,15 @@ async fn purify_format(
                 schema: sql_parser::ast::Schema::File(path),
                 with_options,
             } => {
-                if matches!(envelope, Envelope::Debezium(DbzMode::Upsert)) {
-                    // TODO(bwm): Support key schemas everywhere, something like
-                    // https://github.com/MaterializeInc/materialize/pull/6286
-                    bail!(
-                        "ENVELOPE DEBEZIUM UPSERT can only be used with schemas from \
-                           the confluent schema registry, and requires a key schema"
-                    );
-                }
-                let value_schema = tokio::fs::read_to_string(path).await?;
+                let file_schema = tokio::fs::read_to_string(path).await?;
                 *schema = AvroSchema::Schema {
-                    schema: sql_parser::ast::Schema::Inline(value_schema),
+                    schema: sql_parser::ast::Schema::Inline(file_schema),
                     with_options: with_options.clone(),
                 };
             }
-            _ => {
-                if matches!(envelope, Envelope::Debezium(DbzMode::Upsert)) {
-                    // TODO(bwm): Support key schemas everywhere, something like
-                    // https://github.com/MaterializeInc/materialize/pull/6286
-                    bail!(
-                        "ENVELOPE DEBEZIUM UPSERT can only be used with schemas from \
-                           the confluent schema registry, and requires a key schema"
-                    );
-                }
-            }
+            _ => {}
         },
-        Some(Format::Protobuf { schema, .. }) => {
+        Format::Protobuf { schema, .. } => {
             if let sql_parser::ast::Schema::File(path) = schema {
                 let descriptors = tokio::fs::read(path).await?;
                 let mut buf = String::new();
@@ -348,11 +349,11 @@ async fn purify_format(
                 *schema = sql_parser::ast::Schema::Inline(buf);
             }
         }
-        Some(Format::Csv {
+        Format::Csv {
             header_row,
             delimiter,
             ..
-        }) => {
+        } => {
             if *header_row && col_names.is_empty() {
                 if let Some(file) = file {
                     let file = tokio::io::BufReader::new(file);
@@ -370,7 +371,7 @@ async fn purify_format(
                 }
             }
         }
-        _ => (),
+        Format::Bytes | Format::Regex(_) | Format::Json | Format::Text => (),
     }
     Ok(())
 }

--- a/test/testdrive/upsert-kafka-debezium.td
+++ b/test/testdrive/upsert-kafka-debezium.td
@@ -58,7 +58,7 @@ $ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschem
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE DEBEZIUM UPSERT
-ENVELOPE DEBEZIUM UPSERT can only be used with schemas from the confluent schema registry, and requires a key schema
+ENVELOPE [DEBEZIUM] UPSERT requires that KEY FORMAT be specified
 
 > CREATE MATERIALIZED SOURCE doin_upsert
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-dbzupsert-${testdrive.seed}'

--- a/test/testdrive/upsert-kafka-new.td
+++ b/test/testdrive/upsert-kafka-new.td
@@ -7,9 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# This testdrive file uses the deprecated syntax, but is otherwise identical to upsert-kafka-new.td
-#
-# This file can be deleted when/if we finish the deprecation and perform the removal of the old syntax.
+# This testdrive file is exactly the same as upsert-kafka.td, but using the new syntax.
 
 $ set keyschema={
     "type": "record",
@@ -42,8 +40,7 @@ $ kafka-ingest format=avro topic=avroavro key-format=avro key-schema=${keyschema
 {"key": "mammalmore"} {"f1":"moose", "f2": 2}
 
 > CREATE MATERIALIZED SOURCE avroavro
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
-  'testdrive-avroavro-${testdrive.seed}'
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avroavro-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE UPSERT
 
@@ -64,17 +61,18 @@ mammal1: {"f1": "moose", "f2": 1}
 
 > CREATE MATERIALIZED SOURCE bytesavro
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-textavro-${testdrive.seed}'
-  FORMAT AVRO USING SCHEMA  '${schema}'
-  ENVELOPE UPSERT FORMAT BYTES
+  KEY FORMAT BYTES
+  VALUE FORMAT AVRO USING SCHEMA  '${schema}'
+  ENVELOPE UPSERT
 
 $ file-append path=data-schema.json
 \${schema}
 
 > CREATE MATERIALIZED SOURCE textavro
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
-  'testdrive-textavro-${testdrive.seed}'
-  FORMAT AVRO USING SCHEMA FILE '${testdrive.temp-dir}/data-schema.json'
-  ENVELOPE UPSERT FORMAT TEXT
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-textavro-${testdrive.seed}'
+  KEY FORMAT TEXT
+  VALUE FORMAT AVRO USING SCHEMA FILE '${testdrive.temp-dir}/data-schema.json'
+  ENVELOPE UPSERT
 
 > select * from bytesavro
 key0          f1       f2
@@ -107,24 +105,24 @@ mammal1:moose
 bìrd1:
 
 > CREATE MATERIALIZED SOURCE texttext
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
-  'testdrive-textbytes-${testdrive.seed}'
-    FORMAT TEXT ENVELOPE UPSERT
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-textbytes-${testdrive.seed}'
+  FORMAT TEXT ENVELOPE UPSERT
 
 > CREATE MATERIALIZED SOURCE textbytes
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
-  'testdrive-textbytes-${testdrive.seed}'
-  FORMAT BYTES ENVELOPE UPSERT FORMAT TEXT
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-textbytes-${testdrive.seed}'
+  KEY FORMAT TEXT
+  VALUE FORMAT BYTES
+  ENVELOPE UPSERT
 
 > CREATE MATERIALIZED SOURCE bytesbytes
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
-  'testdrive-textbytes-${testdrive.seed}'
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-textbytes-${testdrive.seed}'
   FORMAT BYTES ENVELOPE UPSERT
 
 > CREATE MATERIALIZED SOURCE bytestext
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
-  'testdrive-textbytes-${testdrive.seed}'
-  FORMAT TEXT ENVELOPE UPSERT FORMAT BYTES
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-textbytes-${testdrive.seed}'
+  KEY FORMAT BYTES
+  VALUE FORMAT TEXT
+  ENVELOPE UPSERT
 
 > select * from texttext
 key0          text  mz_offset
@@ -172,16 +170,16 @@ mammalmore       herd             10
 $ kafka-create-topic topic=textproto
 
 > CREATE MATERIALIZED SOURCE textproto
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
-  'testdrive-textproto-${testdrive.seed}'
-  FORMAT PROTOBUF MESSAGE '.Struct' USING SCHEMA FILE '${testdrive.protobuf-descriptors-file}'
-  ENVELOPE UPSERT FORMAT TEXT
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-textproto-${testdrive.seed}'
+  KEY FORMAT TEXT
+  VALUE FORMAT PROTOBUF MESSAGE '.Struct' USING SCHEMA FILE '${testdrive.protobuf-descriptors-file}'
+  ENVELOPE UPSERT
 
 > CREATE MATERIALIZED SOURCE bytesproto
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
-  'testdrive-textproto-${testdrive.seed}'
-  FORMAT PROTOBUF MESSAGE '.Struct' USING SCHEMA FILE '${testdrive.protobuf-descriptors-file}'
-  ENVELOPE UPSERT FORMAT BYTES
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-textproto-${testdrive.seed}'
+  KEY FORMAT BYTES
+  VALUE FORMAT PROTOBUF MESSAGE '.Struct' USING SCHEMA FILE '${testdrive.protobuf-descriptors-file}'
+  ENVELOPE UPSERT
 
 $ kafka-ingest format=protobuf message=struct topic=textproto key-format=bytes key-terminator=: publish=true
 fish:{"int": 1, "bad_int": 1, "bin": "ONE", "st": "my-string"}
@@ -234,9 +232,10 @@ mammalmore:moose
 mammal1:
 
 > CREATE MATERIALIZED SOURCE nullkey
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
-  'testdrive-nullkey-${testdrive.seed}'
-  FORMAT TEXT ENVELOPE UPSERT FORMAT TEXT
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-nullkey-${testdrive.seed}'
+  KEY FORMAT TEXT
+  VALUE FORMAT TEXT
+  ENVELOPE UPSERT
 
 > select * from nullkey
 key0          text  mz_offset
@@ -267,10 +266,10 @@ $ kafka-ingest format=avro topic=realtimeavroavro key-format=avro key-schema=${k
 {"f3": {"string": "earth"}, "f1":{"string": "dao"}}
 
 > CREATE SOURCE realtimeavroavro (f3, f4, f1, f2)
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
-  'testdrive-realtimeavroavro-${testdrive.seed}'
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-  ENVELOPE UPSERT FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-realtimeavroavro-${testdrive.seed}'
+  KEY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  VALUE FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE UPSERT
 
 > CREATE MATERIALIZED VIEW realtimeavroavro_view as SELECT * from realtimeavroavro;
 
@@ -286,8 +285,9 @@ water     <null>  crocodile      7
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
   'testdrive-realtimeavroavro-${testdrive.seed}'
   WITH (start_offset=1)
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-  ENVELOPE UPSERT FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  KEY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  VALUE FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE UPSERT
 
 > SELECT * FROM realtimeavroavro_ff
 f3        f1        f1           f2
@@ -345,10 +345,10 @@ $ kafka-ingest format=avro topic=realtimefilteravro key-format=avro key-schema=$
 {"k1": {"string": "boucherie"}, "k2": {"long": 5}} {"f1": {"string": "apple"}, "f2": {"long": 3}}
 
 > CREATE SOURCE realtimefilteravro
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
-  'testdrive-realtimefilteravro-${testdrive.seed}'
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-  ENVELOPE UPSERT FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-realtimefilteravro-${testdrive.seed}'
+  KEY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  VALUE FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE UPSERT
 
 # filter on key only
 > CREATE MATERIALIZED VIEW filterforkey AS


### PR DESCRIPTION
Interesting parts of this change:

* Two new types: CreateSourceFormat/SourceDataEncoding, which wrap the
  encoding definition with something that can specify Key/Value or just
  Value encoding. Currently only kafka supports this.
  * The Upsert syntax (UPSERT FORMAT ...) is still supported, but it
    emits a warning and gets normalized to KEY FORMAT / VALUE FORMAT internally
* KeyValueDecoder, which takes a pair of boxed DecoderStates to handle
  key/value decoding.
* All of the upsert key/value rewriting is now internal to the upsert
  code, it no longer affects anything externally.
* We can now handle arbitrary encodings for keys/values with a unified
  framework, everything should just work when we add new encodings in
  the future.
* The legacy upsert key format embedding is still supported with a
  WARN-level log, but the new syntax is also supported (see the new
  kafka-upsert-new TD test file.)