### PR TITLE
Deduplicate identical ports on docker inspect output

### DIFF
--- a/misc/python/materialize/mzcompose.py
+++ b/misc/python/materialize/mzcompose.py
@@ -356,7 +356,8 @@ class Composition:
             if md["Config"]["Labels"]["com.docker.compose.service"] == service:
                 for (name, port_entry) in md["NetworkSettings"]["Ports"].items():
                     for p in port_entry or []:
-                        ports.append(p["HostPort"])
+                        if p["HostPort"] not in ports:
+                            ports.append(p["HostPort"])
         return ports
 
     def get_container_id(self, service: str, running: bool = False) -> str:


### PR DESCRIPTION
After a recent upgrade of Docker, I got the following error when trying
to start an mzcompose workflow:

    Failed! Could not unambiguously determine port for mysql found: 3306,3306

Looking at the output of `docker inspect`, we now see this:

    "Ports": {
      "3306/tcp": [
        {
          "HostIp": "0.0.0.0",
          "HostPort": "3306"
        },
        {
          "HostIp": "::",
          "HostPort": "3306"
        }
      ],
      "33060/tcp": null
    },

It appears that Docker is listing ipv4 and ipv6 addresses as their own
entries. For the purposes of find_host_ports, which uses `localhost`,
let's treat these identically.