### PR TITLE
End-to-end test for Debezium

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -227,6 +227,14 @@ steps:
           composition: dbt-materialize
           run: ci
 
+  - id: debezium-avro
+    label: "Debezium Avro test"
+    depends_on: build
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: debezium-avro
+          run: debezium-avro
+
   - id: pg-cdc
     label: "Postgres CDC test"
     depends_on: build

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -40,6 +40,7 @@ mod kafka;
 mod kinesis;
 mod postgres;
 mod s3;
+mod shell;
 mod sleep;
 mod sql;
 
@@ -464,6 +465,7 @@ pub fn build(cmds: Vec<PosCommand>, state: &State) -> Result<Vec<PosAction>, Err
                         vars.extend(builtin.args);
                         continue;
                     }
+                    "shell-execute" => Box::new(shell::build_execute(builtin).map_err(wrap_err)?),
                     _ => {
                         return Err(InputError {
                             msg: format!("unknown built-in command {}", builtin.name),

--- a/src/testdrive/src/action/shell.rs
+++ b/src/testdrive/src/action/shell.rs
@@ -1,0 +1,58 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use async_trait::async_trait;
+
+use crate::action::{Action, State};
+use crate::parser::BuiltinCommand;
+
+use tokio::process::Command;
+
+pub struct ExecuteAction {
+    command: String,
+}
+
+pub fn build_execute(cmd: BuiltinCommand) -> Result<ExecuteAction, String> {
+    Ok(ExecuteAction {
+        command: cmd.input.join("\n"),
+    })
+}
+
+#[async_trait]
+impl Action for ExecuteAction {
+    async fn undo(&self, _: &mut State) -> Result<(), String> {
+        Ok(())
+    }
+
+    async fn redo(&self, _: &mut State) -> Result<(), String> {
+        println!("$ shell-execute\n{}", self.command);
+
+        let status = Command::new("bash")
+            .arg("-c")
+            .arg(&self.command)
+            .spawn()
+            .map_err(|e| e.to_string())?
+            .wait()
+            .await
+            .map_err(|e| e.to_string())?;
+
+        // Make sure the output of the shell command is separated from the output of the
+        // subsequent testdrive command
+        println!("");
+
+        if status.success() {
+            Ok(())
+        } else {
+            Err(format!(
+                "shell command returned non-zero exit code: {}",
+                status.code().unwrap()
+            ))
+        }
+    }
+}

--- a/test/debezium-avro/README.md
+++ b/test/debezium-avro/README.md
@@ -1,0 +1,6 @@
+This is an end-to-end test that spawns a Postgres -> Debezium -> Kafka -> Materialize pipeline
+and then performs various operations on it, including DDL and schema migrations
+
+To run:
+
+./mzcompose down -v ; ./mzcompose run debezium-avro

--- a/test/debezium-avro/debezium.td
+++ b/test/debezium-avro/debezium.td
@@ -1,0 +1,79 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Configure the Postgres side
+#
+# we could use postgres:postgres as our Debezium user, however our
+# documentation suggests the creation of a dedicated user, so
+# we do the same in the test.
+#
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+CREATE USER debezium WITH SUPERUSER PASSWORD 'debezium';
+GRANT ALL PRIVILEGES ON DATABASE "postgres" to debezium;
+GRANT ALL PRIVILEGES ON SCHEMA "public" to debezium;
+
+#
+# Create a table and insert some data
+#
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+CREATE TABLE t1 (f1 INTEGER);
+INSERT INTO t1 VALUES (123);
+
+#
+# Configure the Debezium side
+#
+
+$ shell-execute
+curl -H 'Content-Type: application/json' debezium:8083/connectors --data '{
+  "name": "psql-connector",
+  "config": {
+    "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
+    "database.hostname": "postgres",
+    "database.port": "5432",
+    "database.user": "debezium",
+    "database.password": "debezium",
+    "database.dbname" : "postgres",
+    "database.server.name": "postgres",
+    "plugin.name": "pgoutput",
+    "slot.name" : "tester",
+    "database.history.kafka.bootstrap.servers": "kafka:9092",
+    "database.history.kafka.topic": "schema-changes.history"
+  }
+}'
+
+#
+# Configure the Materialize side
+#
+
+> CREATE MATERIALIZED SOURCE t1
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'postgres.public.t1'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE DEBEZIUM;
+
+> SELECT * FROM t1;
+123
+
+#
+# Perform DDL on a table being replicated
+#
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE t1 ADD COLUMN f2 INTEGER;
+INSERT INTO t1 VALUES (234, 345);
+
+#
+# The new column is not visible on the Materialize side
+#
+
+> SELECT * FROM t1
+123
+234

--- a/test/debezium-avro/mzcompose
+++ b/test/debezium-avro/mzcompose
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Copyright Materialize, Inc. All rights reserved.
 #
 # Use of this software is governed by the Business Source License
@@ -6,20 +8,7 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
+#
+# mzcompose — runs Docker Compose with Materialize customizations.
 
-FROM ubuntu:bionic-20200403
-
-RUN apt-get update && apt-get -qy install \
-    ca-certificates \
-    curl \
-    wait-for-it
-
-COPY kdestroy kinit testdrive /usr/local/bin/
-
-WORKDIR /workdir
-
-RUN mkdir -p /share/tmp && chmod 777 /share/tmp
-RUN mkdir -p /share/mzdata && chmod 777 /share/mzdata
-
-VOLUME /share/tmp
-VOLUME /share/mzdata
+exec "$(dirname "$0")/../../bin/mzcompose" "$@"

--- a/test/debezium-avro/mzcompose.yml
+++ b/test/debezium-avro/mzcompose.yml
@@ -1,0 +1,132 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+version: '3.7'
+
+mzworkflows:
+  debezium-avro:
+    steps:
+      - step: workflow
+        workflow: start-deps
+
+      - step: run
+        service: testdrive-svc
+        command: debezium.td
+
+  start-deps:
+    steps:
+      - step: start-services
+        services: [postgres, kafka, schema-registry, materialized, debezium]
+      - step: wait-for-tcp
+        host: kafka
+        port: 9092
+        timeout_secs: 120
+      - step: wait-for-tcp
+        host: schema-registry
+        port: 8081
+      - step: wait-for-tcp
+        host: debezium
+        port: 8083
+      - step: wait-for-mz
+      - step: wait-for-postgres
+        dbname: postgres
+
+services:
+  testdrive-svc:
+    mzbuild: testdrive
+    entrypoint:
+      - bash
+      - -c
+      - >-
+        testdrive
+        --kafka-addr=kafka:9092
+        --schema-registry-url=http://schema-registry:8081
+        --materialized-url=postgres://materialize@materialized:6875
+        --validate-catalog=/share/mzdata/catalog
+        $$*
+      - bash
+    environment:
+    - TMPDIR=/share/tmp
+    - MZ_LOG
+    - AWS_ACCESS_KEY_ID
+    - AWS_SECRET_ACCESS_KEY
+    - AWS_SESSION_TOKEN
+    - AWS_SECURITY_TOKEN
+    volumes:
+    - .:/workdir
+    - mzdata:/share/mzdata
+    - tmp:/share/tmp
+    propagate-uid-gid: true
+    init: true
+    depends_on: [kafka, zookeeper, schema-registry, materialized, debezium]
+  materialized:
+    mzbuild: materialized
+    command: >-
+      --data-directory=/share/mzdata
+      -w1 --experimental
+      --cache-max-pending-records 1
+      --timestamp-frequency 100ms
+      --disable-telemetry
+      --retain-prometheus-metrics 1s
+    ports:
+      - 6875
+    environment:
+    - MZ_DEV=1
+    - MZ_LOG
+    - AWS_ACCESS_KEY_ID
+    - AWS_SECRET_ACCESS_KEY
+    - AWS_SESSION_TOKEN
+    - AWS_SECURITY_TOKEN
+    - ALL_PROXY
+    volumes:
+    - mzdata:/share/mzdata
+    - tmp:/share/tmp
+  zookeeper:
+    image: confluentinc/cp-zookeeper:5.5.3
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+  kafka:
+    image: confluentinc/cp-kafka:5.5.3
+    environment:
+    - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+    - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092
+    - KAFKA_AUTO_CREATE_TOPICS_ENABLE=true
+    - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+  schema-registry:
+    image: confluentinc/cp-schema-registry:5.5.3
+    environment:
+    - SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=PLAINTEXT://kafka:9092
+    - SCHEMA_REGISTRY_HOST_NAME=localhost
+    depends_on: [kafka, zookeeper]
+  postgres:
+    image: postgres:11.4
+    ports:
+      - 5432
+    command: postgres -c wal_level=logical -c max_wal_senders=20 -c max_replication_slots=20
+  debezium:
+    image: debezium/connect:1.5
+    hostname: debezium
+    ports:
+      - 8083
+    environment:
+      BOOTSTRAP_SERVERS: kafka:9092
+      CONFIG_STORAGE_TOPIC: connect_configs
+      OFFSET_STORAGE_TOPIC: connect_offsets
+      STATUS_STORAGE_TOPIC: connect_statuses
+      # We don't support JSON, so ensure that connect uses AVRO to encode messages and CSR to
+      # record the schema
+      KEY_CONVERTER: io.confluent.connect.avro.AvroConverter
+      VALUE_CONVERTER: io.confluent.connect.avro.AvroConverter
+      CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL: http://schema-registry:8081
+      CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL: http://schema-registry:8081
+    depends_on: [kafka, schema-registry]
+
+volumes:
+  mzdata:
+  tmp:

--- a/test/testdrive/testdrive.td
+++ b/test/testdrive/testdrive.td
@@ -85,3 +85,8 @@ INSERT INTO postgres_execute VALUES (123);
 
 > SELECT * FROM postgres_execute;
 123
+
+# Execute shell commands, in particular curl
+
+$ shell-execute
+curl --version


### PR DESCRIPTION
This PR is about the infrastructure changes needed to get an end-to-end Debezium test running. I am going to add more test content inside the .td file if the infrastructure part is approved.

I had to make the following changes:
- add ```$ shell-execute``` command to testdrive, so that I can communicate with Debezium via curl without spawning a separate container just to run curl (and I will need multiple invocations of curl for a comprehensive test)
- add the ```curl``` package to the testdrive container