### PR TITLE
Remove AS OF NOW() from some tests

### DIFF
--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -352,13 +352,13 @@ incorrect column specification: 3 columns were specified, upstream has 2: pk, f2
 # Basic sanity check that the timestamps are reasonable
 #
 
-> SELECT COUNT(*) > 0 FROM pk_table AS OF NOW();
+> SELECT COUNT(*) > 0 FROM pk_table;
 true
 
-> SELECT COUNT(*) > 0 FROM nonpk_table AS OF NOW();
+> SELECT COUNT(*) > 0 FROM nonpk_table;
 true
 
-> SELECT COUNT(*) > 0 FROM join_view AS OF NOW();
+> SELECT COUNT(*) > 0 FROM join_view;
 true
 
 #
@@ -450,13 +450,13 @@ UPDATE utf8_table SET f1 = f1 || f1 , f2 = f2 || f2;
 # Check that the timestamps continue to be reasonable in the face of incoming updates
 #
 
-> SELECT COUNT(*) > 0 FROM pk_table AS OF NOW();
+> SELECT COUNT(*) > 0 FROM pk_table;
 true
 
-> SELECT COUNT(*) > 0 FROM nonpk_table AS OF NOW();
+> SELECT COUNT(*) > 0 FROM nonpk_table;
 true
 
-> SELECT COUNT(*) > 0 FROM join_view AS OF NOW();
+> SELECT COUNT(*) > 0 FROM join_view;
 true
 
 #


### PR DESCRIPTION
Several tests have `AS OF NOW()` which forces a timestamp selection, rather than allow MZ to pick one. This has the occasional defect that it errors for a table that may be valid in the future of `now()` rather than right now (e.g. various timestamps get rounded up, and then compacted just behind what they were rounded to).

It seems like this is not the intended behavior to test, though one could certainly imagine that we might want to present the property that all of a certain class of sources and views are always valid at `now()`.

There are many other tests that use `AS OF NOW()` and we could sweep for those. I'm inclined to land this to unblock CI but tagging @philip-stoev so that we don't forget (I'm happy to help out, but want to make sure I don't delete places where this is intended).