### PR TITLE
Include Kafka topic in human-readable source name

### DIFF
--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -638,6 +638,25 @@ impl ExternalSourceConnector {
         }
     }
 
+    /// Optionally returns the name of the upstream resource this source corresponds to.
+    /// (Currently only implemented for Kafka and Kinesis, to match old-style behavior
+    ///  TODO: decide whether we want file paths and other upstream names to show up in metrics too.
+    pub fn upstream_name(&self) -> Option<&str> {
+        match self {
+            ExternalSourceConnector::Kafka(KafkaSourceConnector { topic, .. }) => {
+                Some(topic.as_str())
+            }
+            ExternalSourceConnector::Kinesis(KinesisSourceConnector { stream_name, .. }) => {
+                Some(stream_name.as_str())
+            }
+            ExternalSourceConnector::File(_) => None,
+            ExternalSourceConnector::AvroOcf(_) => None,
+            ExternalSourceConnector::S3(_) => None,
+            ExternalSourceConnector::Postgres(_) => None,
+            ExternalSourceConnector::PubNub(_) => None,
+        }
+    }
+
     /// Returns whether or not source caching is enabled for this connector
     pub fn caching_enabled(&self) -> bool {
         match self {

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -136,6 +136,7 @@ where
 
                 let source_config = SourceConfig {
                     name: format!("{}-{}", connector.name(), uid),
+                    upstream_name: connector.upstream_name().map(ToOwned::to_owned),
                     id: uid,
                     scope,
                     // Distribute read responsibility among workers.

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -81,6 +81,9 @@ static YIELD_INTERVAL_MS: u128 = 10;
 pub struct SourceConfig<'a, G> {
     /// The name to attach to the underlying timely operator.
     pub name: String,
+    /// The name of the upstream resource this source corresponds to
+    /// (For example, a Kafka topic)
+    pub upstream_name: Option<String>,
     /// The ID of this instantiation of this source.
     pub id: SourceInstanceId,
     /// The timely scope in which to build the source.
@@ -521,7 +524,7 @@ pub struct ConsistencyInfo {
 impl ConsistencyInfo {
     fn new(
         active: bool,
-        source_name: String,
+        metrics_name: String,
         source_id: SourceInstanceId,
         worker_id: usize,
         worker_count: usize,
@@ -536,7 +539,7 @@ impl ConsistencyInfo {
             partition_metadata: HashMap::new(),
             source_type: consistency,
             source_metrics: SourceMetrics::new(
-                &source_name,
+                &metrics_name,
                 source_id,
                 &worker_id.to_string(),
                 logger,
@@ -1241,6 +1244,7 @@ where
 {
     let SourceConfig {
         name,
+        upstream_name,
         id,
         scope,
         timestamp_histories,
@@ -1261,7 +1265,7 @@ where
         // Create control plane information (Consistency-related information)
         let mut consistency_info = ConsistencyInfo::new(
             active,
-            name.clone(),
+            upstream_name.unwrap_or_else(|| name.clone()),
             id,
             worker_id,
             worker_count,

--- a/test/testdrive/kafka-stats.td
+++ b/test/testdrive/kafka-stats.td
@@ -89,7 +89,7 @@ partition_id  rx_msgs  rx_bytes  tx_msgs  tx_bytes  lo_offset  hi_offset  ls_off
 0  4  28  0  0  0  4  4  4 0
 
 # Verify that we can join against mz_source_info
-> SELECT mz_kafka_consumer_partitions.rx_msgs FROM mz_kafka_consumer_partitions INNER JOIN mz_source_info USING (source_id, dataflow_id, partition_id) WHERE mz_source_info.source_name like 'kafka-%%';
+> SELECT mz_kafka_consumer_partitions.rx_msgs FROM mz_kafka_consumer_partitions INNER JOIN mz_source_info USING (source_id, dataflow_id, partition_id) WHERE mz_source_info.source_name like 'testdrive-data-%%';
 rx_msgs
 -------
 4


### PR DESCRIPTION
This should cause the topic name to show up in Grafana again (where it was until a recent refactor), and also show up in the Timely operator name (where it wasn't before). This seems fine, but let me know if you envision any issues.

Also, @quodlibetor , what's the best way to test that this is working for Grafana?