### PR TITLE
Literal lifting transform improvements

### DIFF
--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -1349,6 +1349,35 @@ impl AggregateExpr {
     pub fn typ(&self, relation_type: &RelationType) -> ColumnType {
         self.func.output_type(self.expr.typ(relation_type))
     }
+
+    /// Returns whether the expression has a constant result.
+    pub fn is_constant(&self) -> bool {
+        match self.func {
+            AggregateFunc::MaxInt32
+            | AggregateFunc::MaxInt64
+            | AggregateFunc::MaxFloat32
+            | AggregateFunc::MaxFloat64
+            | AggregateFunc::MaxDecimal
+            | AggregateFunc::MaxBool
+            | AggregateFunc::MaxString
+            | AggregateFunc::MaxDate
+            | AggregateFunc::MaxTimestamp
+            | AggregateFunc::MaxTimestampTz
+            | AggregateFunc::MinInt32
+            | AggregateFunc::MinInt64
+            | AggregateFunc::MinFloat32
+            | AggregateFunc::MinFloat64
+            | AggregateFunc::MinDecimal
+            | AggregateFunc::MinBool
+            | AggregateFunc::MinString
+            | AggregateFunc::MinDate
+            | AggregateFunc::MinTimestamp
+            | AggregateFunc::MinTimestampTz
+            | AggregateFunc::Any
+            | AggregateFunc::All => self.expr.is_literal(),
+            _ => false,
+        }
+    }
 }
 
 impl fmt::Display for AggregateExpr {

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -238,6 +238,7 @@ impl Default for Optimizer {
                     Box::new(crate::fusion::filter::Filter),
                     Box::new(crate::demand::Demand),
                     Box::new(crate::map_lifting::LiteralLifting),
+                    Box::new(crate::fusion::map::Map),
                 ],
             }),
             Box::new(crate::reduction_pushdown::ReductionPushdown),

--- a/src/transform/src/map_lifting.rs
+++ b/src/transform/src/map_lifting.rs
@@ -95,7 +95,6 @@ impl LiteralLifting {
                     let remaining_common_literals = the_same.iter().filter(|e| **e).count();
                     if remaining_common_literals > 0 {
                         let final_arity = the_same.len() - remaining_common_literals;
-                        let data = row.unpack();
                         let mut projected_literals = Vec::new();
                         let mut projection = Vec::new();
                         let mut new_column_types = Vec::new();

--- a/src/transform/src/map_lifting.rs
+++ b/src/transform/src/map_lifting.rs
@@ -503,12 +503,12 @@ impl LiteralLifting {
                     let mut projected_literals = Vec::new();
 
                     let mut new_group_key = Vec::new();
-                    for (old_pos, key) in group_key.drain(..).enumerate() {
+                    for key in group_key.drain(..) {
                         if key.is_literal() {
                             projection.push(first_projected_literal + projected_literals.len());
                             projected_literals.push(key);
                         } else {
-                            projection.push(old_pos - projected_literals.len());
+                            projection.push(new_group_key.len());
                             new_group_key.push(key);
                         }
                     }
@@ -516,12 +516,12 @@ impl LiteralLifting {
                     *group_key = new_group_key;
 
                     let mut new_aggregates = Vec::new();
-                    for (old_pos, aggr) in aggregates.drain(..).enumerate() {
+                    for aggr in aggregates.drain(..) {
                         if aggr.is_constant() {
                             projection.push(first_projected_literal + projected_literals.len());
                             projected_literals.push(eval_constant_aggr(&aggr));
                         } else {
-                            projection.push(group_key.len() + old_pos - projected_literals.len());
+                            projection.push(group_key.len() + new_aggregates.len());
                             new_aggregates.push(aggr);
                         }
                     }

--- a/src/transform/src/map_lifting.rs
+++ b/src/transform/src/map_lifting.rs
@@ -205,9 +205,9 @@ impl LiteralLifting {
                     // Discard literals that are not projected
                     let input_arity = input.arity();
                     let mut used_literals = vec![false; literals.len()];
-                    for i in 0..outputs.len() {
-                        if outputs[i] >= input_arity {
-                            used_literals[outputs[i] - input_arity] = true;
+                    for output in outputs.iter() {
+                        if *output >= input_arity {
+                            used_literals[*output - input_arity] = true;
                         }
                     }
                     if used_literals.iter().filter(|x| !*x).count() > 0 {

--- a/src/transform/src/map_lifting.rs
+++ b/src/transform/src/map_lifting.rs
@@ -501,16 +501,14 @@ impl LiteralLifting {
                     let first_projected_literal: usize = non_literal_keys + aggregates.len();
                     let mut projection = Vec::new();
                     let mut projected_literals = Vec::new();
-                    let mut new_key_pos: usize = 0;
                     let mut new_group_key = Vec::new();
-                    for key in group_key.iter() {
+                    for (old_pos, key) in group_key.iter().enumerate() {
                         if key.is_literal() {
                             projection.push(first_projected_literal + projected_literals.len());
                             projected_literals.push(key.clone());
                         } else {
+                            projection.push(old_pos - projected_literals.len());
                             new_group_key.push(key.clone());
-                            projection.push(new_key_pos);
-                            new_key_pos += 1;
                         }
                     }
                     // The new group key without literals

--- a/src/transform/src/map_lifting.rs
+++ b/src/transform/src/map_lifting.rs
@@ -124,7 +124,7 @@ impl LiteralLifting {
                         typ.keys.dedup();
 
                         let remove_extracted_literals = |row: &mut Row| {
-                            let mut new_row = Row::with_capacity(final_arity);
+                            let mut new_row = Row::default();
                             let data = row.unpack();
                             for i in 0..the_same.len() {
                                 if !the_same[i] {

--- a/src/transform/src/map_lifting.rs
+++ b/src/transform/src/map_lifting.rs
@@ -239,18 +239,7 @@ impl LiteralLifting {
                     // Ideally this doesn't happen much, as projects
                     // get lifted too.
                     if !literals.is_empty() {
-                        let mut scalars = literals;
-                        // Merge nested Map operators.
-                        while let MirRelationExpr::Map {
-                            input: inner_input,
-                            scalars: inner_scalars,
-                        } = &mut **input
-                        {
-                            inner_scalars.extend(scalars.clone());
-                            scalars = inner_scalars.clone();
-                            **input = inner_input.take_dangerous();
-                        }
-                        **input = input.take_dangerous().map(scalars);
+                        **input = input.take_dangerous().map(literals);
                     }
                 }
                 // Policy: Do not lift literals around projects.

--- a/src/transform/src/map_lifting.rs
+++ b/src/transform/src/map_lifting.rs
@@ -59,10 +59,9 @@ impl LiteralLifting {
     /// expressions as it goes.
     ///
     /// In several cases, we only manage to extract literals from the final
-    /// columns. This could be improved using permutations to move all of
-    /// the literals to the final columns, and then rely on projection
-    /// hoisting to allow the these literals to move up the AST.
-    // TODO(frank): Fix this.
+    /// columns. But in those cases where it is possible, permutations are
+    /// used to move all of the literals to the final columns, and then rely
+    /// on projection hoisting to allow the these literals to move up the AST.
     pub fn action(
         &self,
         relation: &mut MirRelationExpr,

--- a/src/transform/src/map_lifting.rs
+++ b/src/transform/src/map_lifting.rs
@@ -281,7 +281,6 @@ impl LiteralLifting {
                         let mut new_scalars = Vec::new();
                         let mut projected_literals = Vec::new();
                         let mut projection = (0..input_arity).collect::<Vec<usize>>();
-                        let mut column_map = projection.clone();
                         for scalar in scalars.iter_mut() {
                             if scalar.is_literal() {
                                 projection.push(first_literal_id + projected_literals.len());
@@ -291,7 +290,7 @@ impl LiteralLifting {
                                 // Propagate literals through expressions and remap columns.
                                 cloned_scalar.visit_mut(&mut |e| {
                                     if let MirScalarExpr::Column(old_id) = e {
-                                        let new_id = column_map[*old_id];
+                                        let new_id = projection[*old_id];
                                         if new_id >= first_literal_id {
                                             *e = projected_literals[new_id - first_literal_id]
                                                 .clone();
@@ -303,7 +302,6 @@ impl LiteralLifting {
                                 projection.push(input_arity + new_scalars.len());
                                 new_scalars.push(cloned_scalar);
                             }
-                            column_map.push(*projection.last().unwrap());
                         }
                         new_scalars.extend(projected_literals);
                         *relation = input.take_dangerous().map(new_scalars).project(projection);

--- a/src/transform/src/map_lifting.rs
+++ b/src/transform/src/map_lifting.rs
@@ -98,17 +98,15 @@ impl LiteralLifting {
                         let mut projected_literals = Vec::new();
                         let mut projection = Vec::new();
                         let mut new_column_types = Vec::new();
-                        let mut new_constant_pos = vec![0; the_same.len()];
-                        for i in 0..the_same.len() {
-                            if the_same[i] {
+                        for (i, sameness) in the_same.iter().enumerate() {
+                            if *sameness {
                                 projection.push(final_arity + projected_literals.len());
                                 projected_literals.push(MirScalarExpr::literal_ok(
                                     data[i],
                                     typ.column_types[i].scalar_type.clone(),
                                 ));
                             } else {
-                                new_constant_pos[i] = new_column_types.len();
-                                projection.push(i - projected_literals.len());
+                                projection.push(new_column_types.len());
                                 new_column_types.push(typ.column_types[i].clone());
                             }
                         }
@@ -119,7 +117,7 @@ impl LiteralLifting {
                             *key = key
                                 .iter()
                                 .filter(|x| !the_same[**x])
-                                .map(|x| new_constant_pos[*x])
+                                .map(|x| projection[*x])
                                 .collect::<Vec<usize>>();
                         }
                         typ.keys.sort();

--- a/src/transform/src/map_lifting.rs
+++ b/src/transform/src/map_lifting.rs
@@ -519,6 +519,11 @@ impl LiteralLifting {
                     // The new group key without literals
                     *group_key = new_group_key;
 
+                    // Add the aggregates to the final projection
+                    for i in 0..aggregates.len() {
+                        projection.push(non_literal_keys + i);
+                    }
+
                     *relation = relation
                         .take_dangerous()
                         .map(projected_literals)

--- a/src/transform/src/map_lifting.rs
+++ b/src/transform/src/map_lifting.rs
@@ -159,6 +159,8 @@ impl LiteralLifting {
                         {
                             literals.pop();
                         }
+                    } else {
+                        literals.clear();
                     }
                     // If the literals need to be re-interleaved,
                     // we don't have much choice but to install a

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -618,6 +618,7 @@ mod tests {
         // TODO(justin): is there a way to just extract these from the Optimizer list of
         // transforms?
         match name {
+            "LiteralLifting" => Ok(Box::new(transform::map_lifting::LiteralLifting)),
             "PredicatePushdown" => Ok(Box::new(transform::predicate_pushdown::PredicatePushdown)),
             _ => Err(anyhow!(
                 "no transform named {} (you might have to add it to get_transform)",

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -618,9 +618,15 @@ mod tests {
         // TODO(justin): is there a way to just extract these from the Optimizer list of
         // transforms?
         match name {
+            "ColumnKnowledge" => Ok(Box::new(transform::column_knowledge::ColumnKnowledge)),
+            "Demand" => Ok(Box::new(transform::demand::Demand)),
             "LiteralLifting" => Ok(Box::new(transform::map_lifting::LiteralLifting)),
             "PredicatePushdown" => Ok(Box::new(transform::predicate_pushdown::PredicatePushdown)),
+            "ProjectionExtraction" => Ok(Box::new(
+                transform::projection_extraction::ProjectionExtraction,
+            )),
             "ProjectionLifting" => Ok(Box::new(transform::projection_lifting::ProjectionLifting)),
+            "ReductionPushdown" => Ok(Box::new(transform::reduction_pushdown::ReductionPushdown)),
             _ => Err(anyhow!(
                 "no transform named {} (you might have to add it to get_transform)",
                 name

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -620,6 +620,7 @@ mod tests {
         match name {
             "LiteralLifting" => Ok(Box::new(transform::map_lifting::LiteralLifting)),
             "PredicatePushdown" => Ok(Box::new(transform::predicate_pushdown::PredicatePushdown)),
+            "ProjectionLifting" => Ok(Box::new(transform::projection_lifting::ProjectionLifting)),
             _ => Err(anyhow!(
                 "no transform named {} (you might have to add it to get_transform)",
                 name

--- a/src/transform/tests/testdata/keys
+++ b/src/transform/tests/testdata/keys
@@ -75,7 +75,7 @@ Applied Fixpoint { transforms: [NonNullable, FoldConstants, PredicatePushdown, J
 | | keys = ((#0), (#1))
 
 ====
-No change: FoldConstants, Fixpoint { transforms: [ProjectionLifting, JoinImplementation, ColumnKnowledge, FoldConstants, Filter, Demand, LiteralLifting], limit: 100 }, ReductionPushdown, Map, ProjectionLifting, JoinImplementation, Project, FoldConstants
+No change: FoldConstants, Fixpoint { transforms: [ProjectionLifting, JoinImplementation, ColumnKnowledge, FoldConstants, Filter, Demand, LiteralLifting, Map], limit: 100 }, ReductionPushdown, Map, ProjectionLifting, JoinImplementation, Project, FoldConstants
 ====
 Final:
 %0 =

--- a/src/transform/tests/testdata/lifting
+++ b/src/transform/tests/testdata/lifting
@@ -12,6 +12,7 @@ cat
 ----
 ok
 
+# Discard literals that are not projected.
 build apply=LiteralLifting
 (project
   (map (get x) [1 2 3 4])
@@ -21,3 +22,68 @@ build apply=LiteralLifting
 | Get x (u0)
 | Map 2, 4
 | Project (#3, #2)
+
+
+# Merge nested Map operators within a Project
+build apply=LiteralLifting
+(project
+  (map (map (get x) [1]) [2])
+  [#2 #3])
+----
+%0 =
+| Get x (u0)
+| Map 1, 2
+| Project (#2, #3)
+
+# Map: Permute columns to put literals at the end
+build apply=LiteralLifting
+(project
+  (map (map (get x) [1 #0 2]) [3 #2 4])
+  [#3 #6])
+----
+%0 =
+| Get x (u0)
+| Map #0, 1
+| Project (#0, #1, #3, #2)
+| Map #2, 2, 3
+| Project (#0..#3, #5, #6, #4)
+| Project (#3, #6)
+
+
+build apply=(LiteralLifting,ProjectionLifting,LiteralLifting)
+(project
+  (map (map (get x) [1 #0 2]) [3 #2 4])
+  [#3 #6])
+----
+%0 =
+| Get x (u0)
+| Map #0
+| Map 1, 1
+| Project (#0..#2, #4, #3)
+| Project (#2, #4)
+
+opt
+(project
+  (map (map (get x) [1 #0 2]) [3 #2 4])
+  [#3 #6])
+----
+%0 =
+| Get x (u0)
+| Map 1
+| Project (#0, #2)
+
+# Extract common values in all rows in Constant operator
+build
+(constant [[1 2 3] [1 4 3]] [int32 int64 int32])
+----
+%0 =
+| Constant (1, 2, 3) (1, 4, 3)
+
+build apply=LiteralLifting
+(constant [[1 2 3] [1 4 3]] [int32 int64 int32])
+----
+%0 =
+| Constant (2) (4)
+| Map 1
+| Project (#1, #0)
+| Map 3

--- a/src/transform/tests/testdata/lifting
+++ b/src/transform/tests/testdata/lifting
@@ -28,6 +28,35 @@ build apply=LiteralLifting
 | Map 2, 4
 | Project (#3, #2)
 
+build
+(project
+  (map (get x) [1 2 3])
+  [#3 #3])
+----
+%0 =
+| Get x (u0)
+| Map 1, 2, 3
+| Project (#3, #3)
+
+build apply=LiteralLifting
+(project
+  (map (get x) [1 2 3])
+  [#3 #3])
+----
+%0 =
+| Get x (u0)
+| Map 2
+| Project (#2, #2)
+
+build apply=LiteralLifting
+(project
+  (map (get x) [1 2 3])
+  [#3 #4 #3])
+----
+%0 =
+| Get x (u0)
+| Map 2, 3
+| Project (#2, #3, #2)
 
 # Merge nested Map operators within a Project
 build apply=LiteralLifting

--- a/src/transform/tests/testdata/lifting
+++ b/src/transform/tests/testdata/lifting
@@ -108,13 +108,13 @@ opt
 
 # Extract common values in all rows in Constant operator
 build
-(constant [[1 2 3] [1 4 3]] [int32 int64 int32])
+(constant [[1 2 3] [1 4 3]] [int64 int64 int64])
 ----
 %0 =
 | Constant (1, 2, 3) (1, 4, 3)
 
 build apply=LiteralLifting
-(constant [[1 2 3] [1 4 3]] [int32 int64 int32])
+(constant [[1 2 3] [1 4 3]] [int64 int64 int64])
 ----
 %0 =
 | Constant (2) (4)
@@ -124,8 +124,8 @@ build apply=LiteralLifting
 
 build apply=LiteralLifting
 (union
-  [(constant [[1 2 3] [2 4 3]] [int32 int64 int32])
-   (constant [[3 2 3] [4 4 3]] [int32 int64 int32])])
+  [(constant [[1 2 3] [2 4 3]] [int64 int64 int64])
+   (constant [[3 2 3] [4 4 3]] [int64 int64 int64])])
 ----
 ----
 %0 =
@@ -142,8 +142,8 @@ build apply=LiteralLifting
 
 build apply=LiteralLifting
 (union
-  [(constant [[1 2 3] [1 4 3]] [int32 int64 int32])
-   (constant [[1 2 3] [1 4 3]] [int32 int64 int32])])
+  [(constant [[1 2 3] [1 4 3]] [int64 int64 int64])
+   (constant [[1 2 3] [1 4 3]] [int64 int64 int64])])
 ----
 ----
 %0 =
@@ -164,8 +164,8 @@ build apply=LiteralLifting
 
 build apply=(LiteralLifting,ProjectionLifting,LiteralLifting)
 (union
-  [(constant [[1 2 3] [1 4 3]] [int32 int64 int32])
-   (constant [[1 2 3] [1 4 3]] [int32 int64 int32])])
+  [(constant [[1 2 3] [1 4 3]] [int64 int64 int64])
+   (constant [[1 2 3] [1 4 3]] [int64 int64 int64])])
 ----
 ----
 %0 =
@@ -183,8 +183,8 @@ build apply=(LiteralLifting,ProjectionLifting,LiteralLifting)
 
 build apply=LiteralLifting
 (union
-  [(constant [[1 2 3] [1 4 3]] [int32 int64 int32])
-   (constant [[2 2 3] [2 4 3]] [int32 int64 int32])])
+  [(constant [[1 2 3] [1 4 3]] [int64 int64 int64])
+   (constant [[2 2 3] [2 4 3]] [int64 int64 int64])])
 ----
 ----
 %0 =

--- a/src/transform/tests/testdata/lifting
+++ b/src/transform/tests/testdata/lifting
@@ -122,6 +122,24 @@ build apply=LiteralLifting
 | Project (#1, #0)
 | Map 3
 
+build apply=LiteralLifting
+(union
+  [(constant [[1 2 3] [2 4 3]] [int32 int64 int32])
+   (constant [[3 2 3] [4 4 3]] [int32 int64 int32])])
+----
+----
+%0 =
+| Constant (1, 2) (2, 4)
+
+%1 =
+| Constant (3, 2) (4, 4)
+
+%2 =
+| Union %0 %1
+| Map 3
+----
+----
+
 # Union: literals in the suffix in all branches are lifted...
 build apply=LiteralLifting
 (union

--- a/src/transform/tests/testdata/lifting
+++ b/src/transform/tests/testdata/lifting
@@ -1,0 +1,23 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+cat
+(defsource x [int32 int64])
+----
+ok
+
+build apply=LiteralLifting
+(project
+  (map (get x) [1 2 3 4])
+  [#5 #3])
+----
+%0 =
+| Get x (u0)
+| Map 2, 4
+| Project (#3, #2)

--- a/src/transform/tests/testdata/lifting
+++ b/src/transform/tests/testdata/lifting
@@ -140,6 +140,132 @@ build apply=LiteralLifting
 ----
 ----
 
+build apply=LiteralLifting
+(union
+  [(constant [[1 2 3] [1 4 3]] [int32 int64 int32])
+   (constant [[1 2 3] [1 4 3]] [int32 int64 int32])])
+----
+----
+%0 =
+| Constant (2) (4)
+| Map 1
+| Project (#1, #0)
+
+%1 =
+| Constant (2) (4)
+| Map 1
+| Project (#1, #0)
+
+%2 =
+| Union %0 %1
+| Map 3
+----
+----
+
+build apply=(LiteralLifting,ProjectionLifting,LiteralLifting)
+(union
+  [(constant [[1 2 3] [1 4 3]] [int32 int64 int32])
+   (constant [[1 2 3] [1 4 3]] [int32 int64 int32])])
+----
+----
+%0 =
+| Constant (2) (4)
+
+%1 =
+| Constant (2) (4)
+
+%2 =
+| Union %0 %1
+| Map 1, 3
+| Project (#1, #0, #2)
+----
+----
+
+build apply=LiteralLifting
+(union
+  [(constant [[1 2 3] [1 4 3]] [int32 int64 int32])
+   (constant [[2 2 3] [2 4 3]] [int32 int64 int32])])
+----
+----
+%0 =
+| Constant (2) (4)
+| Map 1
+| Project (#1, #0)
+
+%1 =
+| Constant (2) (4)
+| Map 2
+| Project (#1, #0)
+
+%2 =
+| Union %0 %1
+| Map 3
+----
+----
+
+build apply=(LiteralLifting,ProjectionLifting,LiteralLifting)
+(union
+  [(constant [[1 2 3] [1 4 3]] [int64 int64 int64])
+   (constant [[2 2 3] [2 4 3]] [int64 int64 int64])])
+----
+----
+%0 =
+| Constant (2) (4)
+| Map 1
+
+%1 =
+| Constant (2) (4)
+| Map 2
+
+%2 =
+| Union %0 %1
+| Map 3
+| Project (#1, #0, #2)
+----
+----
+
+build apply=(LiteralLifting)
+(union
+  [(constant [[1 2 3] [2 2 3]] [int64 int64 int64])
+   (constant [[4 3 3] [4 5 3]] [int64 int64 int64])])
+----
+----
+%0 =
+| Constant (1) (2)
+| Map 2
+
+%1 =
+| Constant (3) (5)
+| Map 4
+| Project (#1, #0)
+
+%2 =
+| Union %0 %1
+| Map 3
+----
+----
+
+build apply=(LiteralLifting,ProjectionLifting,LiteralLifting)
+(union
+  [(constant [[1 2 3] [2 2 3]] [int64 int64 int64])
+   (constant [[4 3 3] [4 5 3]] [int64 int64 int64])])
+----
+----
+%0 =
+| Constant (1) (2)
+| Map 2
+
+%1 =
+| Constant (3) (5)
+| Map 4
+| Project (#1, #0)
+
+%2 =
+| Union %0 %1
+| Map 3
+----
+----
+
 # Union: literals in the suffix in all branches are lifted...
 build apply=LiteralLifting
 (union

--- a/src/transform/tests/testdata/lifting
+++ b/src/transform/tests/testdata/lifting
@@ -12,6 +12,11 @@ cat
 ----
 ok
 
+cat
+(defsource y [int64 int64])
+----
+ok
+
 # Discard literals that are not projected.
 build apply=LiteralLifting
 (project
@@ -87,3 +92,104 @@ build apply=LiteralLifting
 | Map 1
 | Project (#1, #0)
 | Map 3
+
+# Union: literals in the suffix in all branches are lifted...
+build apply=LiteralLifting
+(union
+  [(project
+     (map (get x) [2 1])
+     [#0 #3 #2])
+   (project
+     (map (get x) [1 2])
+     [#0 #2 #3])])
+----
+----
+%0 =
+| Get x (u0)
+| Map 2, 1
+| Project (#0, #3, #2)
+
+%1 =
+| Get x (u0)
+| Map 1, 2
+| Project (#0, #2, #3)
+
+%2 =
+| Union %0 %1
+----
+----
+
+# .. but other common literals are not lifted by LiteralLifting...
+build apply=LiteralLifting
+(union
+  [(project
+     (map (get x) [1])
+     [#2 #0])
+   (project
+     (map (get x) [1])
+     [#2 #0])])
+----
+----
+%0 =
+| Get x (u0)
+| Map 1
+| Project (#2, #0)
+
+%1 =
+| Get x (u0)
+| Map 1
+| Project (#2, #0)
+
+%2 =
+| Union %0 %1
+----
+----
+
+# ... however, they eventually get lifted as a result of the following transformations
+build apply=(ProjectionLifting,LiteralLifting)
+(union
+  [(project
+     (map (get x) [1])
+     [#2 #0])
+   (project
+     (map (get x) [1])
+     [#2 #0])])
+----
+----
+%0 =
+| Get x (u0)
+
+%1 =
+| Get x (u0)
+
+%2 =
+| Union %0 %1
+| Map 1
+| Project (#2, #0)
+----
+----
+
+opt
+(union
+  [(project
+     (map (get y) [1])
+     [#2 #0])
+   (project
+     (map (get y) [1])
+     [#2 #1])])
+----
+----
+%0 =
+| Get y (u1)
+| Map 1
+| Project (#2, #0)
+
+%1 =
+| Get y (u1)
+| Map 1
+| Project (#2, #1)
+
+%2 =
+| Union %0 %1
+----
+----

--- a/src/transform/tests/testdata/steps
+++ b/src/transform/tests/testdata/steps
@@ -30,7 +30,7 @@ steps
 | Union %0 %1
 
 ====
-No change: Join, InlineLet, FoldConstants, Filter, Map, ProjectionExtraction, Project, Join, FoldConstants, Filter, Map, FoldConstants, Fixpoint { transforms: [NonNullable, FoldConstants, PredicatePushdown, Join, Filter, Project, Map, Union, ReduceElision, InlineLet, UpdateLet, ProjectionExtraction, ProjectionLifting, LiteralLifting, NonNullRequirements, ColumnKnowledge, ReductionPushdown, RedundantJoin, TopKElision, Demand, UnionBranchCancellation], limit: 100 }, FoldConstants, Fixpoint { transforms: [ProjectionLifting, JoinImplementation, ColumnKnowledge, FoldConstants, Filter, Demand, LiteralLifting], limit: 100 }, ReductionPushdown, Map, ProjectionLifting, JoinImplementation, Project, FoldConstants
+No change: Join, InlineLet, FoldConstants, Filter, Map, ProjectionExtraction, Project, Join, FoldConstants, Filter, Map, FoldConstants, Fixpoint { transforms: [NonNullable, FoldConstants, PredicatePushdown, Join, Filter, Project, Map, Union, ReduceElision, InlineLet, UpdateLet, ProjectionExtraction, ProjectionLifting, LiteralLifting, NonNullRequirements, ColumnKnowledge, ReductionPushdown, RedundantJoin, TopKElision, Demand, UnionBranchCancellation], limit: 100 }, FoldConstants, Fixpoint { transforms: [ProjectionLifting, JoinImplementation, ColumnKnowledge, FoldConstants, Filter, Demand, LiteralLifting, Map], limit: 100 }, ReductionPushdown, Map, ProjectionLifting, JoinImplementation, Project, FoldConstants
 ====
 Final:
 %0 =

--- a/test/sqllogictest/column_knowledge.slt
+++ b/test/sqllogictest/column_knowledge.slt
@@ -263,8 +263,8 @@ EXPLAIN SELECT (SELECT t1.f1 FROM t1 WHERE t1.f1 = t2.f1) FROM t2 WHERE t2.f1 = 
 | Join %8 %9
 | | implementation = Differential %8 %9.()
 | | demand = ()
-| Map 123, null
-| Project (#0, #4)
+| Map null
+| Project (#0, #3)
 
 %11 =
 | Union %5 %10

--- a/test/sqllogictest/transform/lifting.slt
+++ b/test/sqllogictest/transform/lifting.slt
@@ -296,3 +296,247 @@ explain select * from (select 1 as a from t), generate_series(a+1, 4);
 | Project (#3, #2)
 
 EOF
+
+# Make sure that grouping/distinct is handled correctly in the face of derived tables
+# We want the proper interleaving between Map and Distinct to be preserved
+
+# With literals only
+
+query T multiline
+explain select 123 from (select 234 from t);
+----
+%0 =
+| Get materialize.public.t (u1)
+| Map 123
+| Project (#2)
+
+EOF
+
+query T multiline
+explain select 123 from (select distinct 234 from t);
+----
+%0 =
+| Get materialize.public.t (u1)
+| Distinct group=()
+| Map 123
+
+EOF
+
+query T multiline
+explain select distinct 123 from (select 234 from t);
+----
+%0 =
+| Get materialize.public.t (u1)
+| Distinct group=()
+| Map 123
+
+EOF
+
+query T multiline
+explain select distinct 123 from (select distinct 234 from t);
+----
+%0 =
+| Get materialize.public.t (u1)
+| Distinct group=()
+| Map 123
+
+EOF
+
+# With a single literal
+
+query T multiline
+explain select * from (select distinct 123 from t);
+----
+%0 =
+| Get materialize.public.t (u1)
+| Distinct group=()
+| Map 123
+
+EOF
+
+query T multiline
+explain select distinct * from (select 123 from t);
+----
+%0 =
+| Get materialize.public.t (u1)
+| Distinct group=()
+| Map 123
+
+EOF
+
+# With a literal in the outer query and a column in the derived table
+
+query T multiline
+explain select 123 from (select a from t);
+----
+%0 =
+| Get materialize.public.t (u1)
+| Map 123
+| Project (#2)
+
+EOF
+
+query T multiline
+explain select 123 from (select distinct a from t);
+----
+%0 =
+| Get materialize.public.t (u1)
+| Distinct group=(#0)
+| Map 123
+| Project (#1)
+
+EOF
+
+query T multiline
+explain select distinct 123 from (select a from t);
+----
+%0 =
+| Get materialize.public.t (u1)
+| Distinct group=()
+| Map 123
+
+EOF
+
+query T multiline
+explain select distinct 123 from (select distinct a from t);
+----
+%0 =
+| Get materialize.public.t (u1)
+| Distinct group=(#0)
+| Distinct group=()
+| Map 123
+
+EOF
+
+# With a literal and a column in the derived table
+
+query T multiline
+explain select distinct a1.a, a1.literal from (select a, 123 as literal from t) as a1;
+----
+%0 =
+| Get materialize.public.t (u1)
+| Distinct group=(#0)
+| Map 123
+
+EOF
+
+query T multiline
+explain select a1.a, a1.literal from (select distinct a, 123 as literal from t) as a1;
+----
+%0 =
+| Get materialize.public.t (u1)
+| Distinct group=(#0)
+| Map 123
+
+EOF
+
+query T multiline
+explain select a1.a, a1.literal from (select distinct a, 123 as literal from t) as a1;
+----
+%0 =
+| Get materialize.public.t (u1)
+| Distinct group=(#0)
+| Map 123
+
+EOF
+
+query T multiline
+explain select distinct a1.a, a1.literal from (select distinct a, 123 as literal from t) as a1;
+----
+%0 =
+| Get materialize.public.t (u1)
+| Distinct group=(#0)
+| Map 123
+
+EOF
+
+# With a literal and a column in the outer query
+
+query T multiline
+explain select distinct a1.a, 123 from (select a from t) as a1;
+----
+%0 =
+| Get materialize.public.t (u1)
+| Distinct group=(#0)
+| Map 123
+
+EOF
+
+query T multiline
+explain select distinct a1.a, 123 from (select distinct a from t) as a1;
+----
+%0 =
+| Get materialize.public.t (u1)
+| Distinct group=(#0)
+| Map 123
+
+EOF
+
+# With expressions
+query T multiline
+explain select distinct a1.a+2 from (select distinct a+1 as a, 123 as literal from t) as a1;
+----
+%0 =
+| Get materialize.public.t (u1)
+| Distinct group=((#0 + 1))
+| Distinct group=((#0 + 2))
+
+EOF
+
+query T multiline
+explain select distinct a1.a, 123 from (select distinct a+1 as a, 234 as literal from t) as a1;
+----
+%0 =
+| Get materialize.public.t (u1)
+| Distinct group=((#0 + 1))
+| Map 123
+
+EOF
+
+query T multiline
+explain select distinct a1.a+2, a1.literal from (select distinct a+1 as a, 123 as literal from t) as a1;
+----
+%0 =
+| Get materialize.public.t (u1)
+| Distinct group=((#0 + 1))
+| Distinct group=((#0 + 2))
+| Map 123
+
+EOF
+
+
+query T multiline
+explain select distinct a1.a, a1.literal + 1 from (select distinct a, 123 as literal from t) as a1;
+----
+%0 =
+| Get materialize.public.t (u1)
+| Distinct group=(#0)
+| Map 124
+
+EOF
+
+# Check that literals do not interfere with table elimination
+
+statement ok
+create table t_pk (
+  a int primary key,
+  b int
+)
+
+query T multiline
+explain select a1.*, 123 from t_pk as a1, t_pk as a2 WHERE a1.a = a2.a;
+----
+%0 =
+| Get materialize.public.t_pk (u3)
+| Map 123
+
+EOF
+
+query T multiline
+explain select distinct a1.*, 123 from t_pk as a1, t_pk as a2 WHERE a1.a = a2.a;
+----
+%0 =
+| Get materialize.public.t_pk (u3)
+| Map 123
+
+EOF

--- a/test/sqllogictest/transform/lifting.slt
+++ b/test/sqllogictest/transform/lifting.slt
@@ -82,3 +82,29 @@ union all
 | Union %0 %1 %2
 
 EOF
+
+# Group key literal lifting
+query T multiline
+explain
+select a, b from t where a = 1 group by a, b
+----
+%0 =
+| Get materialize.public.t (u1)
+| Filter (#0 = 1)
+| Distinct group=(#1)
+| Map 1
+| Project (#1, #0)
+
+EOF
+
+query T multiline
+explain
+select a, b from t where b = 1 group by a, b
+----
+%0 =
+| Get materialize.public.t (u1)
+| Filter (#1 = 1)
+| Distinct group=(#0)
+| Map 1
+
+EOF

--- a/test/sqllogictest/transform/lifting.slt
+++ b/test/sqllogictest/transform/lifting.slt
@@ -540,3 +540,44 @@ explain select distinct a1.*, 123 from t_pk as a1, t_pk as a2 WHERE a1.a = a2.a;
 | Map 123
 
 EOF
+
+# Reduce
+query T multiline
+explain
+select a, b, max(2), count(*) from t where b = 1 group by a, b;
+----
+%0 =
+| Get materialize.public.t (u1)
+| Filter (#1 = 1)
+| Reduce group=(#0)
+| | agg dummy(dummy)
+| Map 1, 2
+| Project (#0, #2, #3, #0)
+
+EOF
+
+query T multiline
+explain
+select a, b, count(*), max(2) from t where b = 1 group by a, b;
+----
+%0 =
+| Get materialize.public.t (u1)
+| Filter (#1 = 1)
+| Reduce group=(#0)
+| | agg dummy(dummy)
+| Map 1, 2
+| Project (#0, #2, #0, #3)
+
+EOF
+
+query T multiline
+explain
+select a, b, min(2), max(3) from t where b = 1 group by a, b;
+----
+%0 =
+| Get materialize.public.t (u1)
+| Filter (#1 = 1)
+| Distinct group=(#0)
+| Map 1, 2, 3
+
+EOF

--- a/test/sqllogictest/transform/lifting.slt
+++ b/test/sqllogictest/transform/lifting.slt
@@ -108,3 +108,90 @@ select a, b from t where b = 1 group by a, b
 | Map 1
 
 EOF
+
+
+# Permute literals in Map operator so they can be lifted
+query T multiline
+explain
+select * from (select 1, a+1 from t), t;
+----
+%0 =
+| Get materialize.public.t (u1)
+| Map (#0 + 1)
+| ArrangeBy ()
+
+%1 =
+| Get materialize.public.t (u1)
+
+%2 =
+| Join %0 %1
+| | implementation = Differential %1 %0.()
+| | demand = (#2..#4)
+| Map 1
+| Project (#5, #2..#4)
+
+EOF
+
+query T multiline
+explain
+select * from (select b+1, 2, 1, a+1 from t), t;
+----
+%0 =
+| Get materialize.public.t (u1)
+| Map (#1 + 1), (#0 + 1)
+| ArrangeBy ()
+
+%1 =
+| Get materialize.public.t (u1)
+
+%2 =
+| Join %0 %1
+| | implementation = Differential %1 %0.()
+| | demand = (#2..#5)
+| Map 2, 1
+| Project (#2, #6, #7, #3..#5)
+
+EOF
+
+query T multiline
+explain
+select * from (select 3, b+1, 2, a+2, 1, a+1 from t), t;
+----
+%0 =
+| Get materialize.public.t (u1)
+| Map (#1 + 1), (#0 + 2), (#0 + 1)
+| ArrangeBy ()
+
+%1 =
+| Get materialize.public.t (u1)
+
+%2 =
+| Join %0 %1
+| | implementation = Differential %1 %0.()
+| | demand = (#2..#6)
+| Map 3, 2, 1
+| Project (#7, #2, #8, #3, #9, #4..#6)
+
+EOF
+
+query T multiline
+explain
+select a+1 from (select 1 as a, b from t);
+----
+%0 =
+| Get materialize.public.t (u1)
+| Map 2
+| Project (#2)
+
+EOF
+
+query T multiline
+explain
+select z+1 from (select 2 as y, a, 1 as z, b from t);
+----
+%0 =
+| Get materialize.public.t (u1)
+| Map 2
+| Project (#2)
+
+EOF

--- a/test/sqllogictest/transform/lifting.slt
+++ b/test/sqllogictest/transform/lifting.slt
@@ -195,3 +195,91 @@ select z+1 from (select 2 as y, a, 1 as z, b from t);
 | Project (#2)
 
 EOF
+
+# Extract common values in all rows in Constant operator
+query T multiline
+explain
+select c1, c1 + a from (select 1 as c1, x as c2, 3 as c3 from generate_series(1, 3) as x union all select 1, x, 3 from generate_series(5, 8) as x), t;
+----
+%0 =
+| Constant (1) (2) (3) (5) (6) (7) (8)
+
+%1 =
+| Get materialize.public.t (u1)
+
+%2 =
+| Join %0 %1
+| | implementation = Differential %1 %0.()
+| | demand = (#1)
+| Map (1 + #1), 1
+| Project (#4, #3)
+
+EOF
+
+query T multiline
+explain
+select * from (select 1 as f1, 2 as f2), generate_series(f1, f2);
+----
+%0 =
+| Constant (1, 2, 1) (1, 2, 2)
+
+EOF
+
+# ... check keys are updated properly
+query T multiline
+explain typed plan for
+select c.* from (select f1, f2 from (select f2, f1 from (select 1 as f1), generate_series(2, 4) as f2) group by f2, f1) as c, t;
+----
+%0 =
+| Constant (2) (3) (4)
+| | types = (integer)
+| | keys = ((#0))
+
+%1 =
+| Get materialize.public.t (u1)
+| | types = (integer?, integer?)
+| | keys = ()
+
+%2 =
+| Join %0 %1
+| | implementation = Differential %1 %0.()
+| | demand = (#0)
+| | types = (integer, integer?, integer?)
+| | keys = ()
+| Map 1
+| | types = (integer, integer?, integer?, integer)
+| | keys = ()
+| Project (#3, #0)
+| | types = (integer, integer)
+| | keys = ()
+
+EOF
+
+query T multiline
+explain typed plan for
+select c.* from (select f2, f1, f3 from (select f3, f2, f1 from generate_series(2, 4) as f2, generate_series(3, 5) as f3, (select 1 as f1)) group by f2, f3, f1) as c, t;
+----
+%0 =
+| Constant (2, 3) (2, 4) (2, 5) (3, 3) (3, 4) (3, 5) (4, 3) (4, 4) (4, 5)
+| | types = (integer, integer)
+| | keys = ((#0, #1))
+
+%1 =
+| Get materialize.public.t (u1)
+| | types = (integer?, integer?)
+| | keys = ()
+
+%2 =
+| Join %0 %1
+| | implementation = Differential %1 %0.()
+| | demand = (#0, #1)
+| | types = (integer, integer, integer?, integer?)
+| | keys = ()
+| Map 1
+| | types = (integer, integer, integer?, integer?, integer)
+| | keys = ()
+| Project (#0, #4, #1)
+| | types = (integer, integer, integer)
+| | keys = ()
+
+EOF

--- a/test/sqllogictest/transform/lifting.slt
+++ b/test/sqllogictest/transform/lifting.slt
@@ -296,4 +296,3 @@ explain select * from (select 1 as a from t), generate_series(a+1, 4);
 | Project (#3, #2)
 
 EOF
-

--- a/test/sqllogictest/transform/lifting.slt
+++ b/test/sqllogictest/transform/lifting.slt
@@ -283,3 +283,17 @@ select c.* from (select f2, f1, f3 from (select f3, f2, f1 from generate_series(
 | | keys = ()
 
 EOF
+
+# Permute the literals around the columns added by FlatMap
+query T multiline
+explain select * from (select 1 as a from t), generate_series(a+1, 4);
+----
+%0 =
+| Get materialize.public.t (u1)
+| FlatMap generate_series(2, 4)
+| | demand = (#2)
+| Map 1
+| Project (#3, #2)
+
+EOF
+

--- a/test/sqllogictest/transform/lifting.slt
+++ b/test/sqllogictest/transform/lifting.slt
@@ -550,9 +550,9 @@ select a, b, max(2), count(*) from t where b = 1 group by a, b;
 | Get materialize.public.t (u1)
 | Filter (#1 = 1)
 | Reduce group=(#0)
-| | agg dummy(dummy)
+| | agg count(true)
 | Map 1, 2
-| Project (#0, #2, #3, #0)
+| Project (#0, #2, #3, #1)
 
 EOF
 
@@ -564,9 +564,9 @@ select a, b, count(*), max(2) from t where b = 1 group by a, b;
 | Get materialize.public.t (u1)
 | Filter (#1 = 1)
 | Reduce group=(#0)
-| | agg dummy(dummy)
+| | agg count(true)
 | Map 1, 2
-| Project (#0, #2, #0, #3)
+| Project (#0, #2, #1, #3)
 
 EOF
 


### PR DESCRIPTION
Lift literals that are not final columns for most operators, but Union.

Union's case needs special handling. It needs to check whether all branches have a Project on top of a Map projecting the same literal in the same order. The following snippet shows the case not covered by this PR.

```
opt
(union
  [(project
     (map (get y) [1])
     [#2 #0])
   (project
     (map (get y) [1])
     [#2 #1])])
----
----
%0 =
| Get y (u1)
| Map 1
| Project (#2, #0)

%1 =
| Get y (u1)
| Map 1
| Project (#2, #1)

%2 =
| Union %0 %1

```

My impression is that this kind of rewrites would be much simpler in an earlier stage of the pipeline for semantic rewrites, using a representation that is closer to the semantics of the query, rather than to the execution plan for it. The Query Graph Model is a representation that is well-suited semantic rewrites such as this one, removing unused columns, pushing predicates down, flattening joins and so on.

Fixes #6441.