### PR TITLE
dbt-materialize: remove superfluous transactions

### DIFF
--- a/misc/dbt-materialize/dbt/include/materialize/macros/relations.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/relations.sql
@@ -15,35 +15,35 @@
 -- limitations under the License.
 
 {% macro materialize_get_columns(relation) -%}
-  {% call statement('get_columns', fetch_result=True, auto_begin=True) %}
+  {% call statement('get_columns', fetch_result=True, auto_begin=False) %}
     show columns from {{ relation }}
   {% endcall %}
   {{ return(load_result('get_columns').table) }}
 {% endmacro %}
 
 {% macro materialize_get_full_views(schema) -%}
-  {% call statement('get_full_views', fetch_result=True, auto_begin=True) %}
+  {% call statement('get_full_views', fetch_result=True, auto_begin=False) %}
     show full views from {{ schema }}
   {% endcall %}
   {{ return(load_result('get_full_views').table) }}
 {% endmacro %}
 
 {% macro materialize_get_sources(schema) -%}
-  {% call statement('get_sources', fetch_result=True, auto_begin=True) %}
+  {% call statement('get_sources', fetch_result=True, auto_begin=False) %}
     show sources from {{ schema }}
   {% endcall %}
   {{ return(load_result('get_sources').table) }}
 {% endmacro %}
 
 {% macro materialize_show_view(relation) -%}
-  {% call statement('show_view', fetch_result=True, auto_begin=True) %}
+  {% call statement('show_view', fetch_result=True, auto_begin=False) %}
     show create view {{ relation }}
   {% endcall %}
   {{ return(load_result('show_view').table) }}
 {% endmacro %}
 
 {% macro materialize_get_schemas() -%}
-  {% call statement('get_schemas', fetch_result=True, auto_begin=True) %}
+  {% call statement('get_schemas', fetch_result=True, auto_begin=False) %}
     show extended schemas
   {% endcall %}
   {{ return(load_result('get_schemas').table) }}


### PR DESCRIPTION
The dbt-materialize adapter starts unnecessary transactions when
reading data (indicated by the auto_begin flag). This didn't matter
before, because transactions were a no-op in Materialize. With
mjibson's PR to implement read transactions (#[5849](https://github.com/MaterializeInc/materialize/pull/5849)), it does matter.
This PR removes those transactions.