### PR TITLE
dbt-materialize: bump to v0.18.1.post2

### DIFF
--- a/misc/dbt-materialize/setup.py
+++ b/misc/dbt-materialize/setup.py
@@ -26,7 +26,7 @@ package_name = "dbt-materialize"
 # This adapter's version, and its required dbt-postgres version, tracks the
 # target dbt version.
 target_package_version = "0.18.1"
-package_version_suffix = ".post1"
+package_version_suffix = ".post2"
 package_version = "{}{}".format(target_package_version, package_version_suffix)
 description = """The Materialize adapter plugin for dbt (data build tool)"""
 


### PR DESCRIPTION
Bumps the adapter version after landing #[6525](https://github.com/MaterializeInc/materialize/pull/6525), which removed
superfluous transactions from various read-only commands.

Pushed [to PyPI](https://pypi.org/project/dbt-materialize/0.18.1.post2/#description)!