### PR TITLE
Files required to bundle all Confluent services in a single combined container

### DIFF
--- a/test/atp/combined-confluent-container/Dockerfile
+++ b/test/atp/combined-confluent-container/Dockerfile
@@ -1,0 +1,133 @@
+#
+# Copyright 2019 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG DOCKER_UPSTREAM_REGISTRY
+ARG DOCKER_UPSTREAM_TAG=5.5.3
+
+FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-new:${DOCKER_UPSTREAM_TAG}
+
+ARG PROJECT_VERSION
+ARG ARTIFACT_ID
+
+LABEL maintainer="partner-support@confluent.io"
+LABEL io.confluent.docker=true
+ARG GIT_COMMIT
+LABEL io.confluent.docker.git.id=$GIT_COMMIT
+ARG BUILD_NUMBER=-1
+LABEL io.confluent.docker.build.number=$BUILD_NUMBER
+LABEL io.confluent.docker.git.repo="confluentinc/kafka-images"
+
+ARG CONFLUENT_VERSION=5.5.3
+ARG CONFLUENT_PACKAGES_REPO=https://packages.confluent.io/deb/5.5
+ARG CONFLUENT_PLATFORM_LABEL
+ARG CONFLUENT_DEB_VERSION
+ARG ALLOW_UNSIGNED=true
+ARG SCALA_VERSION=2.12
+
+EXPOSE 2181 2888 3888
+
+ENV COMPONENT=zookeeper
+
+RUN echo "===> Installing ${COMPONENT}..." \
+    && apt-get update \
+    && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
+    && if [ "x$ALLOW_UNSIGNED" = "xtrue" ]; then echo "APT::Get::AllowUnauthenticated \"true\";" > /etc/apt/apt.conf.d/allow_unauthenticated; else curl -s -L ${CONFLUENT_PACKAGES_REPO}/archive.key -o /tmp/archive.key && apt-key add /tmp/archive.key; fi \
+    && echo "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO} stable main" >> /etc/apt/sources.list \
+    && cat /etc/apt/sources.list \
+    && apt-get install -y apt-transport-https \
+    && apt-get update \
+    && apt-get install -y confluent-kafka-${SCALA_VERSION}=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+    && echo "===> clean up ..." \
+    && rm -rf /tmp/* \
+    && echo "===> Setting up ${COMPONENT} dirs" \
+    && mkdir -p /etc/kafka /var/log/kafka /var/log/confluent /var/lib/kafka /var/lib/zookeeper /var/lib/${COMPONENT}/data /var/lib/${COMPONENT}/log /etc/${COMPONENT}/secrets \
+    && chmod -R ag+w /etc/kafka /var/lib/${COMPONENT}/data /var/lib/${COMPONENT}/log /etc/${COMPONENT}/secrets \
+    && chown -R root:root /var/log/kafka /var/log/confluent /var/lib/kafka /var/lib/zookeeper
+
+VOLUME ["/var/lib/${COMPONENT}/data", "/var/lib/${COMPONENT}/log", "/etc/${COMPONENT}/secrets"]
+
+ARG DOCKER_UPSTREAM_REGISTRY
+ARG DOCKER_UPSTREAM_TAG=latest
+
+ARG PROJECT_VERSION
+ARG ARTIFACT_ID
+
+LABEL maintainer="partner-support@confluent.io"
+LABEL io.confluent.docker=true
+ARG GIT_COMMIT
+LABEL io.confluent.docker.git.id=$GIT_COMMIT
+ARG BUILD_NUMBER=-1
+LABEL io.confluent.docker.build.number=$BUILD_NUMBER
+LABEL io.confluent.docker.git.repo="confluentinc/kafka-images"
+
+# allow arg override of required env params
+ARG KAFKA_ZOOKEEPER_CONNECT
+ENV KAFKA_ZOOKEEPER_CONNECT=${KAFKA_ZOOKEEPER_CONNECT}
+ARG KAFKA_ADVERTISED_LISTENERS
+ENV KAFKA_ADVERTISED_LISTENERS=${KAFKA_ADVERTISED_LISTENERS}
+
+ENV COMPONENT=kafka
+
+# primary
+EXPOSE 9092
+
+RUN echo "===> Installing ${COMPONENT}..." \
+    && echo "===> clean up ..." \
+    && rm -rf /tmp/* \
+    && echo "===> Setting up ${COMPONENT} dirs..." \
+    && mkdir -p /etc/kafka /var/log/kafka /var/log/confluent /var/lib/kafka /var/lib/zookeeper /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets\
+    && chmod -R ag+w /etc/${COMPONENT} /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets \
+    && chown -R root:root /var/log/kafka /var/log/confluent /var/lib/kafka /var/lib/zookeeper
+
+VOLUME ["/var/lib/${COMPONENT}/data", "/etc/${COMPONENT}/secrets"]
+
+ARG DOCKER_UPSTREAM_REGISTRY
+ARG DOCKER_UPSTREAM_TAG=latest
+
+ARG PROJECT_VERSION
+ARG ARTIFACT_ID
+
+LABEL maintainer="partner-support@confluent.io"
+LABEL io.confluent.docker=true
+ARG GIT_COMMIT
+LABEL io.confluent.docker.git.id=$GIT_COMMIT
+ARG BUILD_NUMBER=-1
+LABEL io.confluent.docker.build.number=$BUILD_NUMBER
+LABEL io.confluent.docker.git.repo="confluentinc/schema-registry-images"
+
+ENV COMPONENT=schema-registry
+
+# Default listener
+EXPOSE 8081
+
+ARG CONFLUENT_PACKAGES_REPO=https://packages.confluent.io/deb/5.5
+
+RUN echo "===> Installing ${COMPONENT}..." \
+    && apt-get install -y confluent-${COMPONENT}=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+    confluent-control-center=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+    confluent-security=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+    && echo "===> clean up ..." \
+    && rm -rf /tmp/* \
+    && echo "===> Setting up ${COMPONENT} dirs" \
+    && mkdir -p /etc/${COMPONENT}/secrets \
+    && chmod -R ag+w /etc/${COMPONENT} /etc/${COMPONENT}/secrets
+
+VOLUME ["/etc/${COMPONENT}/secrets"]
+
+COPY zookeeper/include/etc/confluent/docker /etc/confluent/docker/zookeeper/
+COPY kafka/include/etc/confluent/docker /etc/confluent/docker/kafka/
+COPY schema-registry/include/etc/confluent/docker /etc/confluent/docker/schema-registry
+
+CMD /bin/bash -c 'COMPONENT=zookeeper /etc/confluent/docker/zookeeper/run; COMPONENT=kafka /etc/confluent/docker/kafka/run ; COMPONENT=schema-registry ; /etc/confluent/docker/schema-registry/run '

--- a/test/atp/combined-confluent-container/kafka/include/etc/confluent/docker/configure
+++ b/test/atp/combined-confluent-container/kafka/include/etc/confluent/docker/configure
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# shellcheck disable=SC1091
+. /etc/confluent/docker/bash-config
+
+dub ensure KAFKA_ZOOKEEPER_CONNECT
+dub ensure KAFKA_ADVERTISED_LISTENERS
+
+# By default, LISTENERS is derived from ADVERTISED_LISTENERS by replacing
+# hosts with 0.0.0.0. This is good default as it ensures that the broker
+# process listens on all ports.
+if [[ -z "${KAFKA_LISTENERS-}" ]]
+then
+  export KAFKA_LISTENERS
+  KAFKA_LISTENERS=$(cub listeners "$KAFKA_ADVERTISED_LISTENERS")
+fi
+
+dub path /etc/kafka/ writable
+
+if [[ -z "${KAFKA_LOG_DIRS-}" ]]
+then
+  export KAFKA_LOG_DIRS
+  KAFKA_LOG_DIRS="/var/lib/kafka/data"
+fi
+
+# advertised.host, advertised.port, host and port are deprecated. Exit if these properties are set.
+if [[ -n "${KAFKA_ADVERTISED_PORT-}" ]]
+then
+  echo "advertised.port is deprecated. Please use KAFKA_ADVERTISED_LISTENERS instead."
+  exit 1
+fi
+
+if [[ -n "${KAFKA_ADVERTISED_HOST-}" ]]
+then
+  echo "advertised.host is deprecated. Please use KAFKA_ADVERTISED_LISTENERS instead."
+  exit 1
+fi
+
+if [[ -n "${KAFKA_HOST-}" ]]
+then
+  echo "host is deprecated. Please use KAFKA_ADVERTISED_LISTENERS instead."
+  exit 1
+fi
+
+if [[ -n "${KAFKA_PORT-}" ]]
+then
+  echo "port is deprecated. Please use KAFKA_ADVERTISED_LISTENERS instead."
+  exit 1
+fi
+
+# Set if ADVERTISED_LISTENERS has SSL:// or SASL_SSL:// endpoints.
+if [[ $KAFKA_ADVERTISED_LISTENERS == *"SSL://"* ]]
+then
+  echo "SSL is enabled."
+
+  dub ensure KAFKA_SSL_KEYSTORE_FILENAME
+  export KAFKA_SSL_KEYSTORE_LOCATION="/etc/kafka/secrets/$KAFKA_SSL_KEYSTORE_FILENAME"
+  dub path "$KAFKA_SSL_KEYSTORE_LOCATION" exists
+
+  dub ensure KAFKA_SSL_KEY_CREDENTIALS
+  KAFKA_SSL_KEY_CREDENTIALS_LOCATION="/etc/kafka/secrets/$KAFKA_SSL_KEY_CREDENTIALS"
+  dub path "$KAFKA_SSL_KEY_CREDENTIALS_LOCATION" exists
+  export KAFKA_SSL_KEY_PASSWORD
+  KAFKA_SSL_KEY_PASSWORD=$(cat "$KAFKA_SSL_KEY_CREDENTIALS_LOCATION")
+
+  dub ensure KAFKA_SSL_KEYSTORE_CREDENTIALS
+  KAFKA_SSL_KEYSTORE_CREDENTIALS_LOCATION="/etc/kafka/secrets/$KAFKA_SSL_KEYSTORE_CREDENTIALS"
+  dub path "$KAFKA_SSL_KEYSTORE_CREDENTIALS_LOCATION" exists
+  export KAFKA_SSL_KEYSTORE_PASSWORD
+  KAFKA_SSL_KEYSTORE_PASSWORD=$(cat "$KAFKA_SSL_KEYSTORE_CREDENTIALS_LOCATION")
+
+  if [[ -n "${KAFKA_SSL_CLIENT_AUTH-}" ]] && { [[ $KAFKA_SSL_CLIENT_AUTH == *"required"* ]] || [[ $KAFKA_SSL_CLIENT_AUTH == *"requested"* ]]; }
+  then
+      dub ensure KAFKA_SSL_TRUSTSTORE_FILENAME
+      export KAFKA_SSL_TRUSTSTORE_LOCATION="/etc/kafka/secrets/$KAFKA_SSL_TRUSTSTORE_FILENAME"
+      dub path "$KAFKA_SSL_TRUSTSTORE_LOCATION" exists
+
+      dub ensure KAFKA_SSL_TRUSTSTORE_CREDENTIALS
+      KAFKA_SSL_TRUSTSTORE_CREDENTIALS_LOCATION="/etc/kafka/secrets/$KAFKA_SSL_TRUSTSTORE_CREDENTIALS"
+      dub path "$KAFKA_SSL_TRUSTSTORE_CREDENTIALS_LOCATION" exists
+      export KAFKA_SSL_TRUSTSTORE_PASSWORD
+      KAFKA_SSL_TRUSTSTORE_PASSWORD=$(cat "$KAFKA_SSL_TRUSTSTORE_CREDENTIALS_LOCATION")
+  fi
+
+fi
+
+# Set if KAFKA_ADVERTISED_LISTENERS has SASL_PLAINTEXT:// or SASL_SSL:// endpoints.
+if [[ $KAFKA_ADVERTISED_LISTENERS =~ .*SASL_.*://.* ]]
+then
+  echo "SASL" is enabled.
+
+  dub ensure KAFKA_OPTS
+
+  if [[ ! $KAFKA_OPTS == *"java.security.auth.login.config"*  ]]
+  then
+    echo "KAFKA_OPTS should contain 'java.security.auth.login.config' property."
+  fi
+fi
+
+if [[ -n "${KAFKA_JMX_OPTS-}" ]]
+then
+  if [[ ! $KAFKA_JMX_OPTS == *"com.sun.management.jmxremote.rmi.port"*  ]]
+  then
+    echo "KAFKA_OPTS should contain 'com.sun.management.jmxremote.rmi.port' property. It is required for accessing the JMX metrics externally."
+  fi
+fi
+
+dub template "/etc/confluent/docker/${COMPONENT}/${COMPONENT}.properties.template" "/etc/${COMPONENT}/${COMPONENT}.properties"
+dub template "/etc/confluent/docker/${COMPONENT}/log4j.properties.template" "/etc/${COMPONENT}/log4j.properties"
+dub template "/etc/confluent/docker/${COMPONENT}/tools-log4j.properties.template" "/etc/${COMPONENT}/tools-log4j.properties"

--- a/test/atp/combined-confluent-container/kafka/include/etc/confluent/docker/ensure
+++ b/test/atp/combined-confluent-container/kafka/include/etc/confluent/docker/ensure
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Copyright 2020 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# shellcheck disable=SC1091
+. /etc/confluent/docker/bash-config
+
+export KAFKA_DATA_DIRS=${KAFKA_DATA_DIRS:-"/var/lib/kafka/data"}
+echo "===> Check if $KAFKA_DATA_DIRS is writable ..."
+dub path "$KAFKA_DATA_DIRS" writable
+
+if [[ -n "${KAFKA_ZOOKEEPER_SSL_CLIENT_ENABLE-}" ]] && [[ $KAFKA_ZOOKEEPER_SSL_CLIENT_ENABLE == "true" ]]
+then
+    echo "===> Skipping Zookeeper health check for SSL connections..."
+else
+    echo "===> Check if Zookeeper is healthy ..."
+    cub zk-ready "$KAFKA_ZOOKEEPER_CONNECT" "${KAFKA_CUB_ZK_TIMEOUT:-40}"
+fi

--- a/test/atp/combined-confluent-container/kafka/include/etc/confluent/docker/kafka.properties.template
+++ b/test/atp/combined-confluent-container/kafka/include/etc/confluent/docker/kafka.properties.template
@@ -1,0 +1,33 @@
+{% set excluded_props = ['KAFKA_VERSION',
+                         'KAFKA_HEAP_OPTS'
+                         'KAFKA_LOG4J_OPTS',
+                         'KAFKA_OPTS',
+                         'KAFKA_JMX_OPTS',
+                         'KAFKA_JVM_PERFORMANCE_OPTS',
+                         'KAFKA_GC_LOG_OPTS',
+                         'KAFKA_LOG4J_ROOT_LOGLEVEL',
+                         'KAFKA_LOG4J_LOGGERS',
+                         'KAFKA_TOOLS_LOG4J_LOGLEVEL',
+                         'KAFKA_ZOOKEEPER_CLIENT_CNXN_SOCKET']
+-%}
+
+{# properties that don't fit the standard format #}
+{% set other_props = {
+  'KAFKA_ZOOKEEPER_CLIENT_CNXN_SOCKET' : 'zookeeper.clientCnxnSocket'
+ } -%}
+
+{% set kafka_props = env_to_props('KAFKA_', '', exclude=excluded_props) -%}
+{% for name, value in kafka_props.items() -%}
+{{name}}={{value}}
+{% endfor -%}
+
+{% for k, property in other_props.items() -%}
+{% if env.get(k) != None -%}
+{{property}}={{env[k]}}
+{% endif -%}
+{% endfor -%}
+
+{% set confluent_support_props = env_to_props('CONFLUENT_SUPPORT_', 'confluent.support.') -%}
+{% for name, value in confluent_support_props.items() -%}
+{{name}}={{value}}
+{% endfor -%}

--- a/test/atp/combined-confluent-container/kafka/include/etc/confluent/docker/launch
+++ b/test/atp/combined-confluent-container/kafka/include/etc/confluent/docker/launch
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Override this section from the script to include the com.sun.management.jmxremote.rmi.port property.
+if [ -z "$KAFKA_JMX_OPTS" ]; then
+  export KAFKA_JMX_OPTS="-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.authenticate=false  -Dcom.sun.management.jmxremote.ssl=false "
+fi
+
+# The JMX client needs to be able to connect to java.rmi.server.hostname.
+# The default for bridged n/w is the bridged IP so you will only be able to connect from another docker container.
+# For host n/w, this is the IP that the hostname on the host resolves to.
+
+# If you have more that one n/w configured, hostname -i gives you all the IPs,
+# the default is to pick the first IP (or network).
+export KAFKA_JMX_HOSTNAME=${KAFKA_JMX_HOSTNAME:-$(hostname -i | cut -d" " -f1)}
+
+if [ "$KAFKA_JMX_PORT" ]; then
+  # This ensures that the "if" section for JMX_PORT in kafka launch script does not trigger.
+  export JMX_PORT=$KAFKA_JMX_PORT
+  export KAFKA_JMX_OPTS="$KAFKA_JMX_OPTS -Djava.rmi.server.hostname=$KAFKA_JMX_HOSTNAME -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.rmi.port=$JMX_PORT -Dcom.sun.management.jmxremote.port=$JMX_PORT"
+fi
+
+echo "===> Launching ${COMPONENT} ... "
+exec "${COMPONENT}"-server-start /etc/"${COMPONENT}"/"${COMPONENT}".properties

--- a/test/atp/combined-confluent-container/kafka/include/etc/confluent/docker/log4j.properties.template
+++ b/test/atp/combined-confluent-container/kafka/include/etc/confluent/docker/log4j.properties.template
@@ -1,0 +1,26 @@
+
+log4j.rootLogger={{ env["KAFKA_LOG4J_ROOT_LOGLEVEL"] | default('INFO') }}, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n
+
+{% set loggers = {
+  'kafka': 'INFO',
+  'kafka.network.RequestChannel$': 'WARN',
+  'kafka.producer.async.DefaultEventHandler': 'DEBUG',
+  'kafka.request.logger': 'WARN',
+  'kafka.controller': 'TRACE',
+  'kafka.log.LogCleaner': 'INFO',
+  'state.change.logger': 'TRACE',
+  'kafka.authorizer.logger': 'WARN'
+  } -%}
+
+
+{% if env['KAFKA_LOG4J_LOGGERS'] %}
+{% set loggers = parse_log4j_loggers(env['KAFKA_LOG4J_LOGGERS'], loggers) %}
+{% endif %}
+
+{% for logger,loglevel in loggers.items() %}
+log4j.logger.{{logger}}={{loglevel}}
+{% endfor %}

--- a/test/atp/combined-confluent-container/kafka/include/etc/confluent/docker/run
+++ b/test/atp/combined-confluent-container/kafka/include/etc/confluent/docker/run
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# shellcheck disable=SC1091
+. /etc/confluent/docker/bash-config
+
+# Set environment values if they exist as arguments
+if [ $# -ne 0 ]; then
+  echo "===> Overriding env params with args ..."
+  for var in "$@"
+  do
+    export var
+  done
+fi
+
+echo "===> User"
+id
+
+echo "===> Configuring ..."
+/etc/confluent/docker/"${COMPONENT}"/configure
+
+echo "===> Running preflight checks ... "
+/etc/confluent/docker/"${COMPONENT}"/ensure
+
+echo "===> Launching ... "
+exec /etc/confluent/docker/"${COMPONENT}"/launch &

--- a/test/atp/combined-confluent-container/kafka/include/etc/confluent/docker/tools-log4j.properties.template
+++ b/test/atp/combined-confluent-container/kafka/include/etc/confluent/docker/tools-log4j.properties.template
@@ -1,0 +1,7 @@
+
+log4j.rootLogger={{ env["KAFKA_TOOLS_LOG4J_LOGLEVEL"] | default('WARN') }}, stderr
+
+log4j.appender.stderr=org.apache.log4j.ConsoleAppender
+log4j.appender.stderr.layout=org.apache.log4j.PatternLayout
+log4j.appender.stderr.layout.ConversionPattern=[%d] %p %m (%c)%n
+log4j.appender.stderr.Target=System.err

--- a/test/atp/combined-confluent-container/schema-registry/include/etc/confluent/docker/admin.properties.template
+++ b/test/atp/combined-confluent-container/schema-registry/include/etc/confluent/docker/admin.properties.template
@@ -1,0 +1,4 @@
+{% set security_props = env_to_props('SCHEMA_REGISTRY_KAFKASTORE_', '') -%}
+{% for name, value in security_props.items() -%}
+{{name}}={{value}}
+{% endfor -%}

--- a/test/atp/combined-confluent-container/schema-registry/include/etc/confluent/docker/apply-mesos-overrides
+++ b/test/atp/combined-confluent-container/schema-registry/include/etc/confluent/docker/apply-mesos-overrides
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Mesos DC/OS docker deployments will have HOST and PORT0
+# set for the proxying of the service.
+#
+# Use those values provide things we know we'll need.
+
+if [ -n "${HOST:-}" ] && [ -z "${SCHEMA_REGISTRY_HOST_NAME:-}" ]
+then
+  export SCHEMA_REGISTRY_HOST_NAME=$HOST
+else
+  true # we don't want the setup to fail if not on Mesos
+fi

--- a/test/atp/combined-confluent-container/schema-registry/include/etc/confluent/docker/configure
+++ b/test/atp/combined-confluent-container/schema-registry/include/etc/confluent/docker/configure
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# Copyright 2016 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# shellcheck disable=SC1091
+. /etc/confluent/docker/bash-config
+
+dub ensure-atleast-one SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS
+dub ensure SCHEMA_REGISTRY_HOST_NAME
+dub path /etc/"${COMPONENT}"/ writable
+
+if [[ -n "${SCHEMA_REGISTRY_PORT-}" ]]
+then
+  echo "PORT is deprecated. Please use SCHEMA_REGISTRY_LISTENERS instead."
+  exit 1
+fi
+
+if [[ -n "${SCHEMA_REGISTRY_JMX_OPTS-}" ]]
+then
+  if [[ ! $SCHEMA_REGISTRY_JMX_OPTS == *"com.sun.management.jmxremote.rmi.port"*  ]]
+  then
+    echo "SCHEMA_REGISTRY_OPTS should contain 'com.sun.management.jmxremote.rmi.port' property. It is required for accessing the JMX metrics externally."
+  fi
+fi
+
+dub template "/etc/confluent/docker/${COMPONENT}/${COMPONENT}.properties.template" "/etc/${COMPONENT}/${COMPONENT}.properties"
+dub template "/etc/confluent/docker/${COMPONENT}/log4j.properties.template" "/etc/${COMPONENT}/log4j.properties"
+dub template "/etc/confluent/docker/${COMPONENT}/admin.properties.template" "/etc/${COMPONENT}/admin.properties"

--- a/test/atp/combined-confluent-container/schema-registry/include/etc/confluent/docker/ensure
+++ b/test/atp/combined-confluent-container/schema-registry/include/etc/confluent/docker/ensure
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# shellcheck disable=SC1091
+. /etc/confluent/docker/bash-config
+
+if [[ -n "${SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL-}" ]]
+then
+    echo "===> Check if Zookeeper is healthy ..."
+    cub zk-ready "$SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL" "${SCHEMA_REGISTRY_CUB_ZK_TIMEOUT:-40}"
+fi
+
+echo "===> Check if Kafka is healthy ..."
+
+if [[ -n "${SCHEMA_REGISTRY_KAFKASTORE_SECURITY_PROTOCOL-}" ]] && [[ $SCHEMA_REGISTRY_KAFKASTORE_SECURITY_PROTOCOL != "PLAINTEXT" ]]
+then
+    cub kafka-ready \
+        "${SCHEMA_REGISTRY_CUB_KAFKA_MIN_BROKERS:-1}" \
+        "${SCHEMA_REGISTRY_CUB_KAFKA_TIMEOUT:-40}" \
+        -b "${SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS}" \
+        --config /etc/"${COMPONENT}"/admin.properties
+else
+    if [[ -n "${SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL-}" ]]
+    then
+        cub kafka-ready \
+            "${SCHEMA_REGISTRY_CUB_KAFKA_MIN_BROKERS:-1}" \
+            "${SCHEMA_REGISTRY_CUB_KAFKA_TIMEOUT:-40}" \
+            -z "$SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL"
+    elif [[ -n "${SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS-}" ]]
+    then
+        cub kafka-ready \
+            "${SCHEMA_REGISTRY_CUB_KAFKA_MIN_BROKERS:-1}" \
+            "${SCHEMA_REGISTRY_CUB_KAFKA_TIMEOUT:-40}" \
+            -b "${SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS}"
+    fi
+fi

--- a/test/atp/combined-confluent-container/schema-registry/include/etc/confluent/docker/launch
+++ b/test/atp/combined-confluent-container/schema-registry/include/etc/confluent/docker/launch
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# JMX settings
+if [ -z "$SCHEMA_REGISTRY_JMX_OPTS" ]; then
+  SCHEMA_REGISTRY_JMX_OPTS="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false "
+fi
+
+# The JMX client needs to be able to connect to java.rmi.server.hostname.
+# The default for bridged n/w is the bridged IP so you will only be able to connect from another docker container.
+# For host n/w, this is the IP that the hostname on the host resolves to.
+
+# If you have more that one n/w configured, hostname -i gives you all the IPs,
+# the default is to pick the first IP (or network).
+export SCHEMA_REGISTRY_JMX_HOSTNAME=${SCHEMA_REGISTRY_JMX_HOSTNAME:-$(hostname -i | cut -d" " -f1)}
+
+# JMX port to use
+if [  "$SCHEMA_REGISTRY_JMX_PORT" ]; then
+  export JMX_PORT=$SCHEMA_REGISTRY_JMX_PORT
+export SCHEMA_REGISTRY_JMX_OPTS="$SCHEMA_REGISTRY_JMX_OPTS -Djava.rmi.server.hostname=$SCHEMA_REGISTRY_JMX_HOSTNAME -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.rmi.port=$JMX_PORT -Dcom.sun.management.jmxremote.port=$JMX_PORT"
+fi
+
+echo "===> Launching ${COMPONENT} ... "
+exec "${COMPONENT}"-start /etc/"${COMPONENT}"/"${COMPONENT}".properties

--- a/test/atp/combined-confluent-container/schema-registry/include/etc/confluent/docker/log4j.properties.template
+++ b/test/atp/combined-confluent-container/schema-registry/include/etc/confluent/docker/log4j.properties.template
@@ -1,0 +1,13 @@
+
+log4j.rootLogger={{ env["SCHEMA_REGISTRY_LOG4J_ROOT_LOGLEVEL"] | default('INFO') }}, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n
+
+{% if env['SCHEMA_REGISTRY_LOG4J_LOGGERS'] %}
+{% set loggers = parse_log4j_loggers(env['SCHEMA_REGISTRY_LOG4J_LOGGERS']) %}
+{% for logger,loglevel in loggers.items() %}
+log4j.logger.{{logger}}={{loglevel}}, stdout
+{% endfor %}
+{% endif %}

--- a/test/atp/combined-confluent-container/schema-registry/include/etc/confluent/docker/run
+++ b/test/atp/combined-confluent-container/schema-registry/include/etc/confluent/docker/run
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# shellcheck disable=SC1090
+# shellcheck disable=SC1091
+. /etc/confluent/docker/bash-config
+
+. /etc/confluent/docker/mesos-setup.sh
+. /etc/confluent/docker/"${COMPONENT}"/apply-mesos-overrides
+
+echo "===> User"
+id
+
+echo "===> Configuring ..."
+/etc/confluent/docker/"${COMPONENT}"/configure
+
+echo "===> Running preflight checks ... "
+/etc/confluent/docker/"${COMPONENT}"/ensure
+
+echo "===> Launching ... "
+exec /etc/confluent/docker/"${COMPONENT}"/launch

--- a/test/atp/combined-confluent-container/schema-registry/include/etc/confluent/docker/schema-registry.properties.template
+++ b/test/atp/combined-confluent-container/schema-registry/include/etc/confluent/docker/schema-registry.properties.template
@@ -1,0 +1,4 @@
+{% set sr_props = env_to_props('SCHEMA_REGISTRY_', '') -%}
+{% for name, value in sr_props.items() -%}
+{{name}}={{value}}
+{% endfor -%}

--- a/test/atp/combined-confluent-container/zookeeper/include/etc/confluent/docker/configure
+++ b/test/atp/combined-confluent-container/zookeeper/include/etc/confluent/docker/configure
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# shellcheck disable=SC1091
+. /etc/confluent/docker/bash-config
+
+dub ensure ZOOKEEPER_CLIENT_PORT
+
+dub path /etc/kafka/ writable
+
+# myid is required for clusters
+if [[ -n "${ZOOKEEPER_SERVERS-}" ]]
+then
+  dub ensure ZOOKEEPER_SERVER_ID
+  export ZOOKEEPER_INIT_LIMIT=${ZOOKEEPER_INIT_LIMIT:-"10"}
+  export ZOOKEEPER_SYNC_LIMIT=${ZOOKEEPER_SYNC_LIMIT:-"5"}
+fi
+
+if [[ -n "${ZOOKEEPER_SERVER_ID-}" ]]
+then
+  dub template "/etc/confluent/docker/myid.template" "/var/lib/${COMPONENT}/data/myid"
+fi
+
+if [[ -n "${KAFKA_JMX_OPTS-}" ]]
+then
+  if [[ ! $KAFKA_JMX_OPTS == *"com.sun.management.jmxremote.rmi.port"*  ]]
+  then
+    echo "KAFKA_JMX_OPTS should contain 'com.sun.management.jmxremote.rmi.port' property. It is required for accessing the JMX metrics externally."
+  fi
+fi
+
+dub template "/etc/confluent/docker/${COMPONENT}/${COMPONENT}.properties.template" "/etc/kafka/${COMPONENT}.properties"
+dub template "/etc/confluent/docker/${COMPONENT}/log4j.properties.template" "/etc/kafka/log4j.properties"
+dub template "/etc/confluent/docker/${COMPONENT}/tools-log4j.properties.template" "/etc/kafka/tools-log4j.properties"

--- a/test/atp/combined-confluent-container/zookeeper/include/etc/confluent/docker/ensure
+++ b/test/atp/combined-confluent-container/zookeeper/include/etc/confluent/docker/ensure
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Copyright 2016 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# shellcheck disable=SC1091
+. /etc/confluent/docker/bash-config
+
+echo "===> Check if /var/lib/zookeeper/data is writable ..."
+dub path /var/lib/zookeeper/data writable
+
+echo "===> Check if /var/lib/zookeeper/log is writable ..."
+dub path /var/lib/zookeeper/log writable

--- a/test/atp/combined-confluent-container/zookeeper/include/etc/confluent/docker/launch
+++ b/test/atp/combined-confluent-container/zookeeper/include/etc/confluent/docker/launch
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Override this section from the script to include the com.sun.management.jmxremote.rmi.port property.
+if [ -z "$KAFKA_JMX_OPTS" ]; then
+  export KAFKA_JMX_OPTS="-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.authenticate=false  -Dcom.sun.management.jmxremote.ssl=false "
+fi
+
+# The JMX client needs to be able to connect to java.rmi.server.hostname.
+# The default for bridged n/w is the bridged IP so you will only be able to connect from another docker container.
+# For host n/w, this is the IP that the hostname on the host resolves to.
+
+# If you have more that one n/w configured, hostname -i gives you all the IPs,
+# the default is to pick the first IP (or network).
+export KAFKA_JMX_HOSTNAME=${KAFKA_JMX_HOSTNAME:-$(hostname -i | cut -d" " -f1)}
+
+if [ "$KAFKA_JMX_PORT" ]; then
+  # This ensures that the "if" section for JMX_PORT in kafka launch script does not trigger.
+  export JMX_PORT=$KAFKA_JMX_PORT
+  export KAFKA_JMX_OPTS="$KAFKA_JMX_OPTS -Djava.rmi.server.hostname=$KAFKA_JMX_HOSTNAME -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.rmi.port=$JMX_PORT -Dcom.sun.management.jmxremote.port=$JMX_PORT"
+fi
+
+
+if [[ -n "${ZOOKEEPER_SERVER_ID-}" ]]
+then
+  echo "===> Printing /var/lib/${COMPONENT}/data/myid "
+  cat /var/lib/"${COMPONENT}"/data/myid
+fi
+
+echo "===> Launching ${COMPONENT} ... "
+exec "${COMPONENT}"-server-start /etc/kafka/"${COMPONENT}".properties

--- a/test/atp/combined-confluent-container/zookeeper/include/etc/confluent/docker/log4j.properties.template
+++ b/test/atp/combined-confluent-container/zookeeper/include/etc/confluent/docker/log4j.properties.template
@@ -1,0 +1,13 @@
+
+log4j.rootLogger={{ env["ZOOKEEPER_LOG4J_ROOT_LOGLEVEL"] | default('INFO') }}, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n
+
+{% if env['ZOOKEEPER_LOG4J_LOGGERS'] %}
+{% set loggers = parse_log4j_loggers(env['ZOOKEEPER_LOG4J_LOGGERS']) %}
+{% for logger,loglevel in loggers.items() %}
+log4j.logger.{{logger}}={{loglevel}}, stdout
+{% endfor %}
+{% endif %}

--- a/test/atp/combined-confluent-container/zookeeper/include/etc/confluent/docker/myid.template
+++ b/test/atp/combined-confluent-container/zookeeper/include/etc/confluent/docker/myid.template
@@ -1,0 +1,1 @@
+{{env["ZOOKEEPER_SERVER_ID"]}}

--- a/test/atp/combined-confluent-container/zookeeper/include/etc/confluent/docker/run
+++ b/test/atp/combined-confluent-container/zookeeper/include/etc/confluent/docker/run
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# shellcheck disable=SC1091
+. /etc/confluent/docker/bash-config
+
+echo "===> User"
+id
+
+echo "===> Configuring ..."
+/etc/confluent/docker/"${COMPONENT}"/configure
+
+echo "===> Running preflight checks ... "
+/etc/confluent/docker/"${COMPONENT}"/ensure
+
+echo "===> Launching ... "
+exec /etc/confluent/docker/"${COMPONENT}"/launch &

--- a/test/atp/combined-confluent-container/zookeeper/include/etc/confluent/docker/tools-log4j.properties.template
+++ b/test/atp/combined-confluent-container/zookeeper/include/etc/confluent/docker/tools-log4j.properties.template
@@ -1,0 +1,7 @@
+
+log4j.rootLogger={{ env["ZOOKEEPER_TOOLS_LOG4J_LOGLEVEL"] | default('WARN') }}, stderr
+
+log4j.appender.stderr=org.apache.log4j.ConsoleAppender
+log4j.appender.stderr.layout=org.apache.log4j.PatternLayout
+log4j.appender.stderr.layout.ConversionPattern=[%d] %p %m (%c)%n
+log4j.appender.stderr.Target=System.err

--- a/test/atp/combined-confluent-container/zookeeper/include/etc/confluent/docker/zookeeper.properties.template
+++ b/test/atp/combined-confluent-container/zookeeper/include/etc/confluent/docker/zookeeper.properties.template
@@ -1,0 +1,100 @@
+
+dataDir=/var/lib/zookeeper/data
+dataLogDir=/var/lib/zookeeper/log
+
+{# optional properties #}
+{% set other_props = {
+  'ZOOKEEPER_CLIENT_PORT' : 'clientPort',
+  'ZOOKEEPER_TICK_TIME': 'tickTime',
+  'ZOOKEEPER_GLOBAL_OUTSTANDING_LIMIT' : 'globalOutstandingLimit',
+  'ZOOKEEPER_PRE_ALLOC_SIZE': 'preAllocSize',
+  'ZOOKEEPER_SNAP_COUNT': 'snapCount',
+  'ZOOKEEPER_TRACE_FILE': 'traceFile',
+  'ZOOKEEPER_MAX_CLIENT_CNXNS' : 'maxClientCnxns',
+  'ZOOKEEPER_CLIENT_PORT_ADDRESS' : 'clientPortAddress',
+  'ZOOKEEPER_MIN_SESSION_TIMEOUT' : 'minSessionTimeout',
+  'ZOOKEEPER_MAX_SESSION_TIMEOUT' : 'maxSessionTimeout',
+  'ZOOKEEPER_FSYNC_WARNING_THRESHOLDMS' : 'fsync.warningthresholdms',
+  'ZOOKEEPER_AUTOPURGE_SNAP_RETAIN_COUNT' : 'autopurge.snapRetainCount',
+  'ZOOKEEPER_AUTOPURGE_PURGE_INTERVAL': 'autopurge.purgeInterval',
+  'ZOOKEEPER_SYNC_ENABLED': 'syncEnabled',
+  'ZOOKEEPER_ELECTION_ALG' : 'electionAlg',
+  'ZOOKEEPER_INIT_LIMIT': 'initLimit',
+  'ZOOKEEPER_LEADER_SERVES': 'leaderServes',
+  'ZOOKEEPER_SYNC_LIMIT' : 'syncLimit',
+  'ZOOKEEPER_CNX_TIMEOUT': 'cnxTimeout',
+  'ZOOKEEPER_FORCE_SYNC': 'forceSync',
+  'ZOOKEEPER_JUTE_MAX_BUFFER': 'jute.maxbuffer',
+  'ZOOKEEPER_SKIP_ACL': 'skipACL',
+  'ZOOKEEPER_QUORUM_LISTEN_ON_ALL_IPS': 'quorumListenOnAllIPs',
+  'ZOOKEEPER_CLIENT_CNXN_SOCKET' : 'clientCnxnSocket',
+  'ZOOKEEPER_SECURE_CLIENT_PORT' : 'secureClientPort',
+  'ZOOKEEPER_SERVER_CNXN_SOCKET' : 'serverCnxnSocket',
+  'ZOOKEEPER_X509_AUTHENTICATION_PROVIDER_SUPER_USER' : 'X509AuthenticationProvider.superUser',
+  'ZOOKEEPER_SSL_AUTH_PROVIDER' : 'ssl.authProvider',
+  'ZOOKEEPER_SSL_CLIENT_AUTH' : 'ssl.clientAuth',
+  'ZOOKEEPER_SSL_KEYSTORE_LOCATION' : 'ssl.keyStore.location',
+  'ZOOKEEPER_SSL_KEYSTORE_PASSWORD' : 'ssl.keyStore.password',
+  'ZOOKEEPER_SSL_KEYSTORE_TYPE' : 'ssl.keyStore.type',
+  'ZOOKEEPER_SSL_TRUSTSTORE_LOCATION' : 'ssl.trustStore.location',
+  'ZOOKEEPER_SSL_TRUSTSTORE_PASSWORD' : 'ssl.trustStore.password',
+  'ZOOKEEPER_SSL_TRUSTSTORE_TYPE' : 'ssl.trustStore.type',
+  'ZOOKEEPER_SSL_ENABLED_PROTOCOLS' : 'ssl.enabledProtocols',
+  'ZOOKEEPER_SSL_CONTEXT_SUPPLIER_CLASS' : 'ssl.context.supplier.class',
+  'ZOOKEEPER_SSL_CIPHER_SUITES' : 'ssl.ciphersuites',
+  'ZOOKEEPER_SSL_HOSTNAME_VERIFICATION' : 'ssl.hostnameVerification',
+  'ZOOKEEPER_SSL_CRL' : 'ssl.crl',
+  'ZOOKEEPER_SSL_OCPS' : 'ssl.ocsp',
+  'ZOOKEEPER_SSL_HANDSHAKE_DETECTION_TIMEOUT_MILLIS' : 'ssl.handshakeDetectionTimeoutMillis',
+  'ZOOKEEPER_SSL_QUORUM' : 'sslQuorum',
+  'ZOOKEEPER_SSL_QUORUM_CLIENT_AUTH' : 'ssl.quorum.clientAuth',
+  'ZOOKEEPER_SSL_QUORUM_KEYSTORE_LOCATION' : 'ssl.quorum.keyStore.location',
+  'ZOOKEEPER_SSL_QUORUM_KEYSTORE_PASSWORD' : 'ssl.quorum.keyStore.password',
+  'ZOOKEEPER_SSL_QUORUM_KEYSTORE_TYPE' : 'ssl.quorum.keyStore.type',
+  'ZOOKEEPER_SSL_QUORUM_TRUSTSTORE_LOCATION' : 'ssl.quorum.trustStore.location',
+  'ZOOKEEPER_SSL_QUORUM_TRUSTSTORE_PASSWORD' : 'ssl.quorum.trustStore.password',
+  'ZOOKEEPER_SSL_QUORUM_TRUSTSTORE_TYPE' : 'ssl.quorum.trustStore.type',
+  'ZOOKEEPER_SSL_QUORUM_ENABLED_PROTOCOLS' : 'ssl.quorum.enabledProtocols',
+  'ZOOKEEPER_SSL_QUORUM_CIPHER_SUITES' : 'ssl.quorum.ciphersuites',
+  'ZOOKEEPER_SSL_QUORUM_CONTEXT_SUPPLIER_CLASS' : 'ssl.quorum.context.supplier.class',
+  'ZOOKEEPER_SSL_QUORUM_HOSTNAME_VERIFICATION' : 'ssl.quorum.hostnameVerification',
+  'ZOOKEEPER_SSL_QUORUM_CRL' : 'ssl.quorum.crl',
+  'ZOOKEEPER_SSL_QUORUM_OCPS' : 'ssl.quorum.ocsp',
+  'ZOOKEEPER_SSL_QUORUM_HANDSHAKE_DETECTION_TIMEOUT_MILLIS' : 'ssl.quorum.handshakeDetectionTimeoutMillis',
+  'ZOOKEEPER_SERVER_CNXN_FACTORY' : 'serverCnxnFactory',
+  'ZOOKEEPER_AUTH_PROVIDER_X509' : 'authProvider.x509',
+  'ZOOKEEPER_AUTH_PROVIDER_SASL' : 'authProvider.sasl',
+  'ZOOKEEPER_CLIENT_PORT_UNIFICATION' : 'client.portUnification',
+  'ZOOKEEPER_ADMIN_ENABLE_SERVER' : 'admin.enableServer',
+  'ZOOKEEPER_ADMIN_SERVER_ADDRESS' : 'admin.serverAddress',
+  'ZOOKEEPER_ADMIN_SERVER_PORT' : 'admin.serverPort',
+  'ZOOKEEPER_ADMIN_IDLE_TIMEOUT' : 'admin.idleTimeout',
+  'ZOOKEEPER_ADMIN_COMMAND_URL' : 'admin.commandURL'
+ } -%}
+
+{% for k, property in other_props.items() -%}
+{% if env.get(k) != None -%}
+{{property}}={{env[k]}}
+{% endif -%}
+{% endfor -%}
+
+{% if env['ZOOKEEPER_SERVERS'] %}
+{% set servers = env['ZOOKEEPER_SERVERS'].split(';') %}
+{% for server in servers %}
+server.{{ loop.index }}={{server}}
+{% endfor %}
+{% endif %}
+
+{% if env['ZOOKEEPER_GROUPS'] %}
+{% set groups = env['ZOOKEEPER_GROUPS'].split(';') %}
+{% for group in groups %}
+group.{{ loop.index }}={{group}}
+{% endfor %}
+{% endif %}
+
+{% if env['ZOOKEEPER_WEIGHTS'] %}
+{% set weights = env['ZOOKEEPER_WEIGHTS'].split(';') %}
+{% for weight in weights %}
+weight.{{ loop.index }}={{weight}}
+{% endfor %}
+{% endif %}

--- a/test/atp/driver/docker-compose.yml
+++ b/test/atp/driver/docker-compose.yml
@@ -8,13 +8,17 @@
 # by the Apache License, Version 2.0.
 
 services:
-  kafka:
+  cp-combined:
     environment:
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      ZOOKEEPER_CLIENT_PORT: 2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://cp-combined:9092
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: '1'
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-    image: confluentinc/cp-kafka:5.5.3
+      KAFKA_ZOOKEEPER_CONNECT: localhost:2181
+      SCHEMA_REGISTRY_HOST_NAME: localhost
+      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: PLAINTEXT://localhost:9092
+    image: cp-combined
+    hostname: cp-combined
   materialized:
     command:
       --data-directory=/share/mzdata
@@ -36,39 +40,25 @@ services:
     volumes:
       - mzdata:/share/mzdata:rw
       - tmp:/share/tmp:rw
-  schema-registry:
-    depends_on:
-      kafka:
-        condition: service_started
-      zookeeper:
-        condition: service_started
-    environment:
-      SCHEMA_REGISTRY_HOST_NAME: localhost
-      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: PLAINTEXT://kafka:9092
-    image: cp-schema-registry
   atp-testdrive:
     depends_on:
-      kafka:
+      cp-combined:
         condition: service_started
       materialized:
         condition: service_started
-      schema-registry:
-        condition: service_started
-      zookeeper:
-        condition: service_started
     entrypoint:
-      - bash
+      - /bin/bash
       - -O
       - extglob
       - -c
       # We skip tests that deal with services that are not available, such as S3 and Kinesis
       - >-
-        wait-for-it --timeout=30 kafka:9092 &&
-        wait-for-it --timeout=30 schema-registry:8081 &&
+        wait-for-it --timeout=30 cp-combined:9092 &&
+        wait-for-it --timeout=30 cp-combined:8081 &&
         wait-for-it --timeout=30 materialized:6875 &&
         while testdrive
-        --kafka-addr=kafka:9092
-        --schema-registry-url=http://schema-registry:8081
+        --kafka-addr=cp-combined:9092
+        --schema-registry-url=http://cp-combined:8081
         --materialized-url=postgres://materialize@materialized:6875
         --validate-catalog=/share/mzdata/catalog
         --default-timeout 300
@@ -84,14 +74,9 @@ services:
       TMPDIR: /share/tmp
     image: atp-testdrive
     init: true
-    user: 1000:1000
     volumes:
       - mzdata:/share/mzdata:rw
       - tmp:/share/tmp:rw
-  zookeeper:
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-    image: cp-zookeeper
 version: '3.7'
 volumes:
   mzdata: {}


### PR DESCRIPTION
The linter is going crazy over this PR , no idea how to silence it.

Basically what I did is as follows:
- test/atp/combined-confluent-container/Dockerfile has been created that is a combination of the Dockerfiles from the upstream confluent repositories, modified to allow all services to coexist together; some lines from the Dockerfile may not be strictly necessary, but I decided to not take the time to examine every single thing in it for applicability.
- test/atp/driver/docker-compose.yml has been switched to use the combined Confluent container
- all the confluent services have been pinned to the 5.5.3 version

Also:
- various scripts and files from the upstream repositories have been brought in
- some of the scripts were modified to allow coexistence, and the last line of the "run" scripts for some of the services has been modified to make the respective service start in the background.

@benesch I have not touched any of your deployment scripting.