### PR TITLE
sql: mark tail descriptors as nullable when PROGRESS is set

### DIFF
--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -575,9 +575,9 @@ lazy_static! {
         name: "mz_view_keys",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-            .with_column("global_id", ScalarType::String.nullable(false))
-            .with_column("column", ScalarType::Int64.nullable(false))
-            .with_column("key_group", ScalarType::Int64.nullable(false)),
+            .with_named_column("global_id", ScalarType::String.nullable(false))
+            .with_named_column("column", ScalarType::Int64.nullable(false))
+            .with_named_column("key_group", ScalarType::Int64.nullable(false)),
         id: GlobalId::System(4001),
         index_id: GlobalId::System(4002),
     };
@@ -585,11 +585,11 @@ lazy_static! {
         name: "mz_view_foreign_keys",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-            .with_column("child_id", ScalarType::String.nullable(false))
-            .with_column("child_column", ScalarType::Int64.nullable(false))
-            .with_column("parent_id", ScalarType::String.nullable(false))
-            .with_column("parent_column", ScalarType::Int64.nullable(false))
-            .with_column("key_group", ScalarType::Int64.nullable(false))
+            .with_named_column("child_id", ScalarType::String.nullable(false))
+            .with_named_column("child_column", ScalarType::Int64.nullable(false))
+            .with_named_column("parent_id", ScalarType::String.nullable(false))
+            .with_named_column("parent_column", ScalarType::Int64.nullable(false))
+            .with_named_column("key_group", ScalarType::Int64.nullable(false))
             .with_key(vec![0, 1, 4]), // TODO: explain why this is a key.
         id: GlobalId::System(4003),
         index_id: GlobalId::System(4004),
@@ -598,8 +598,8 @@ lazy_static! {
         name: "mz_kafka_sinks",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-            .with_column("sink_id", ScalarType::String.nullable(false))
-            .with_column("topic", ScalarType::String.nullable(false))
+            .with_named_column("sink_id", ScalarType::String.nullable(false))
+            .with_named_column("topic", ScalarType::String.nullable(false))
             .with_key(vec![0]),
         id: GlobalId::System(4005),
         index_id: GlobalId::System(4006),
@@ -608,8 +608,8 @@ lazy_static! {
         name: "mz_avro_ocf_sinks",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-            .with_column("sink_id", ScalarType::String.nullable(false))
-            .with_column("path", ScalarType::Bytes.nullable(false))
+            .with_named_column("sink_id", ScalarType::String.nullable(false))
+            .with_named_column("path", ScalarType::Bytes.nullable(false))
             .with_key(vec![0]),
         id: GlobalId::System(4007),
         index_id: GlobalId::System(4008),
@@ -618,9 +618,9 @@ lazy_static! {
         name: "mz_databases",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-            .with_column("id", ScalarType::Int64.nullable(false))
-            .with_column("oid", ScalarType::Oid.nullable(false))
-            .with_column("name", ScalarType::String.nullable(false)),
+            .with_named_column("id", ScalarType::Int64.nullable(false))
+            .with_named_column("oid", ScalarType::Oid.nullable(false))
+            .with_named_column("name", ScalarType::String.nullable(false)),
         id: GlobalId::System(4009),
         index_id: GlobalId::System(4010),
     };
@@ -628,10 +628,10 @@ lazy_static! {
         name: "mz_schemas",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-            .with_column("id", ScalarType::Int64.nullable(false))
-            .with_column("oid", ScalarType::Oid.nullable(false))
-            .with_column("database_id", ScalarType::Int64.nullable(true))
-            .with_column("name", ScalarType::String.nullable(false)),
+            .with_named_column("id", ScalarType::Int64.nullable(false))
+            .with_named_column("oid", ScalarType::Oid.nullable(false))
+            .with_named_column("database_id", ScalarType::Int64.nullable(true))
+            .with_named_column("name", ScalarType::String.nullable(false)),
         id: GlobalId::System(4011),
         index_id: GlobalId::System(4012),
     };
@@ -639,11 +639,11 @@ lazy_static! {
         name: "mz_columns",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-            .with_column("id", ScalarType::String.nullable(false))
-            .with_column("name", ScalarType::String.nullable(false))
-            .with_column("position", ScalarType::Int64.nullable(false))
-            .with_column("nullable", ScalarType::Bool.nullable(false))
-            .with_column("type", ScalarType::String.nullable(false)),
+            .with_named_column("id", ScalarType::String.nullable(false))
+            .with_named_column("name", ScalarType::String.nullable(false))
+            .with_named_column("position", ScalarType::Int64.nullable(false))
+            .with_named_column("nullable", ScalarType::Bool.nullable(false))
+            .with_named_column("type", ScalarType::String.nullable(false)),
         id: GlobalId::System(4013),
         index_id: GlobalId::System(4014),
     };
@@ -651,11 +651,11 @@ lazy_static! {
         name: "mz_indexes",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-            .with_column("id", ScalarType::String.nullable(false))
-            .with_column("oid", ScalarType::Oid.nullable(false))
-            .with_column("name", ScalarType::String.nullable(false))
-            .with_column("on_id", ScalarType::String.nullable(false))
-            .with_column("volatility", ScalarType::String.nullable(false)),
+            .with_named_column("id", ScalarType::String.nullable(false))
+            .with_named_column("oid", ScalarType::Oid.nullable(false))
+            .with_named_column("name", ScalarType::String.nullable(false))
+            .with_named_column("on_id", ScalarType::String.nullable(false))
+            .with_named_column("volatility", ScalarType::String.nullable(false)),
         id: GlobalId::System(4015),
         index_id: GlobalId::System(4016),
     };
@@ -663,11 +663,11 @@ lazy_static! {
         name: "mz_index_columns",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-            .with_column("index_id", ScalarType::String.nullable(false))
-            .with_column("index_position", ScalarType::Int64.nullable(false))
-            .with_column("on_position", ScalarType::Int64.nullable(true))
-            .with_column("on_expression", ScalarType::String.nullable(true))
-            .with_column("nullable", ScalarType::Bool.nullable(false)),
+            .with_named_column("index_id", ScalarType::String.nullable(false))
+            .with_named_column("index_position", ScalarType::Int64.nullable(false))
+            .with_named_column("on_position", ScalarType::Int64.nullable(true))
+            .with_named_column("on_expression", ScalarType::String.nullable(true))
+            .with_named_column("nullable", ScalarType::Bool.nullable(false)),
         id: GlobalId::System(4017),
         index_id: GlobalId::System(4018),
     };
@@ -675,10 +675,10 @@ lazy_static! {
         name: "mz_tables",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-            .with_column("id", ScalarType::String.nullable(false))
-            .with_column("oid", ScalarType::Oid.nullable(false))
-            .with_column("schema_id", ScalarType::Int64.nullable(false))
-            .with_column("name", ScalarType::String.nullable(false)),
+            .with_named_column("id", ScalarType::String.nullable(false))
+            .with_named_column("oid", ScalarType::Oid.nullable(false))
+            .with_named_column("schema_id", ScalarType::Int64.nullable(false))
+            .with_named_column("name", ScalarType::String.nullable(false)),
         id: GlobalId::System(4019),
         index_id: GlobalId::System(4020),
     };
@@ -686,11 +686,11 @@ lazy_static! {
         name: "mz_sources",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-            .with_column("id", ScalarType::String.nullable(false))
-            .with_column("oid", ScalarType::Oid.nullable(false))
-            .with_column("schema_id", ScalarType::Int64.nullable(false))
-            .with_column("name", ScalarType::String.nullable(false))
-            .with_column("volatility", ScalarType::String.nullable(false)),
+            .with_named_column("id", ScalarType::String.nullable(false))
+            .with_named_column("oid", ScalarType::Oid.nullable(false))
+            .with_named_column("schema_id", ScalarType::Int64.nullable(false))
+            .with_named_column("name", ScalarType::String.nullable(false))
+            .with_named_column("volatility", ScalarType::String.nullable(false)),
         id: GlobalId::System(4021),
         index_id: GlobalId::System(4022),
     };
@@ -698,11 +698,11 @@ lazy_static! {
         name: "mz_sinks",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-            .with_column("id", ScalarType::String.nullable(false))
-            .with_column("oid", ScalarType::Oid.nullable(false))
-            .with_column("schema_id", ScalarType::Int64.nullable(false))
-            .with_column("name", ScalarType::String.nullable(false))
-            .with_column("volatility", ScalarType::String.nullable(false)),
+            .with_named_column("id", ScalarType::String.nullable(false))
+            .with_named_column("oid", ScalarType::Oid.nullable(false))
+            .with_named_column("schema_id", ScalarType::Int64.nullable(false))
+            .with_named_column("name", ScalarType::String.nullable(false))
+            .with_named_column("volatility", ScalarType::String.nullable(false)),
         id: GlobalId::System(4023),
         index_id: GlobalId::System(4024),
     };
@@ -710,11 +710,11 @@ lazy_static! {
         name: "mz_views",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-            .with_column("id", ScalarType::String.nullable(false))
-            .with_column("oid", ScalarType::Oid.nullable(false))
-            .with_column("schema_id", ScalarType::Int64.nullable(false))
-            .with_column("name", ScalarType::String.nullable(false))
-            .with_column("volatility", ScalarType::String.nullable(false)),
+            .with_named_column("id", ScalarType::String.nullable(false))
+            .with_named_column("oid", ScalarType::Oid.nullable(false))
+            .with_named_column("schema_id", ScalarType::Int64.nullable(false))
+            .with_named_column("name", ScalarType::String.nullable(false))
+            .with_named_column("volatility", ScalarType::String.nullable(false)),
         id: GlobalId::System(4025),
         index_id: GlobalId::System(4026),
     };
@@ -722,10 +722,10 @@ lazy_static! {
         name: "mz_types",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-            .with_column("id", ScalarType::String.nullable(false))
-            .with_column("oid", ScalarType::Oid.nullable(false))
-            .with_column("schema_id", ScalarType::Int64.nullable(false))
-            .with_column("name", ScalarType::String.nullable(false)),
+            .with_named_column("id", ScalarType::String.nullable(false))
+            .with_named_column("oid", ScalarType::Oid.nullable(false))
+            .with_named_column("schema_id", ScalarType::Int64.nullable(false))
+            .with_named_column("name", ScalarType::String.nullable(false)),
         id: GlobalId::System(4027),
         index_id: GlobalId::System(4028),
     };
@@ -733,8 +733,8 @@ lazy_static! {
         name: "mz_array_types",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-            .with_column("type_id", ScalarType::String.nullable(false))
-            .with_column("element_id", ScalarType::String.nullable(false)),
+            .with_named_column("type_id", ScalarType::String.nullable(false))
+            .with_named_column("element_id", ScalarType::String.nullable(false)),
             id: GlobalId::System(4029),
             index_id: GlobalId::System(4030),
     };
@@ -742,7 +742,7 @@ lazy_static! {
         name: "mz_base_types",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-            .with_column("type_id", ScalarType::String.nullable(false)),
+            .with_named_column("type_id", ScalarType::String.nullable(false)),
             id: GlobalId::System(4031),
             index_id: GlobalId::System(4032),
     };
@@ -750,8 +750,8 @@ lazy_static! {
         name: "mz_list_types",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-            .with_column("type_id", ScalarType::String.nullable(false))
-            .with_column("element_id", ScalarType::String.nullable(false)),
+            .with_named_column("type_id", ScalarType::String.nullable(false))
+            .with_named_column("element_id", ScalarType::String.nullable(false)),
             id: GlobalId::System(4033),
             index_id: GlobalId::System(4034),
     };
@@ -759,9 +759,9 @@ lazy_static! {
         name: "mz_map_types",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-            .with_column("type_id", ScalarType::String.nullable(false))
-            .with_column("key_id", ScalarType::String.nullable(false))
-            .with_column("value_id", ScalarType::String.nullable(false)),
+            .with_named_column("type_id", ScalarType::String.nullable(false))
+            .with_named_column("key_id", ScalarType::String.nullable(false))
+            .with_named_column("value_id", ScalarType::String.nullable(false)),
             id: GlobalId::System(4035),
             index_id: GlobalId::System(4036),
     };
@@ -769,9 +769,9 @@ lazy_static! {
         name: "mz_roles",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-            .with_column("id", ScalarType::Int64.nullable(false))
-            .with_column("oid", ScalarType::Oid.nullable(false))
-            .with_column("name", ScalarType::String.nullable(false)),
+            .with_named_column("id", ScalarType::Int64.nullable(false))
+            .with_named_column("oid", ScalarType::Oid.nullable(false))
+            .with_named_column("name", ScalarType::String.nullable(false)),
         id: GlobalId::System(4037),
         index_id: GlobalId::System(4038),
     };
@@ -779,7 +779,7 @@ lazy_static! {
         name: "mz_pseudo_types",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-            .with_column("type_id", ScalarType::String.nullable(false)),
+            .with_named_column("type_id", ScalarType::String.nullable(false)),
         id: GlobalId::System(4039),
         index_id: GlobalId::System(4040),
     };
@@ -787,12 +787,12 @@ lazy_static! {
         name: "mz_functions",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-            .with_column("id", ScalarType::String.nullable(false))
-            .with_column("oid", ScalarType::Oid.nullable(false))
-            .with_column("schema_id", ScalarType::Int64.nullable(false))
-            .with_column("name", ScalarType::String.nullable(false))
-            .with_column("arg_ids", ScalarType::Array(Box::new(ScalarType::String)).nullable(false))
-            .with_column("variadic_id", ScalarType::String.nullable(true)),
+            .with_named_column("id", ScalarType::String.nullable(false))
+            .with_named_column("oid", ScalarType::Oid.nullable(false))
+            .with_named_column("schema_id", ScalarType::Int64.nullable(false))
+            .with_named_column("name", ScalarType::String.nullable(false))
+            .with_named_column("arg_ids", ScalarType::Array(Box::new(ScalarType::String)).nullable(false))
+            .with_named_column("variadic_id", ScalarType::String.nullable(true)),
         id: GlobalId::System(4041),
         index_id: GlobalId::System(4042),
     };
@@ -800,10 +800,10 @@ lazy_static! {
         name: "mz_metrics",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-                .with_column("metric", ScalarType::String.nullable(false))
-                .with_column("time", ScalarType::Timestamp.nullable(false))
-                .with_column("labels", ScalarType::Jsonb.nullable(false))
-                .with_column("value", ScalarType::Float64.nullable(false))
+                .with_named_column("metric", ScalarType::String.nullable(false))
+                .with_named_column("time", ScalarType::Timestamp.nullable(false))
+                .with_named_column("labels", ScalarType::Jsonb.nullable(false))
+                .with_named_column("value", ScalarType::Float64.nullable(false))
                 .with_key(vec![0, 1, 2]),
         id: GlobalId::System(4043),
         index_id: GlobalId::System(4044),
@@ -812,9 +812,9 @@ lazy_static! {
         name: "mz_metrics_meta",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-                .with_column("metric", ScalarType::String.nullable(false))
-                .with_column("type", ScalarType::String.nullable(false))
-                .with_column("help", ScalarType::String.nullable(false))
+                .with_named_column("metric", ScalarType::String.nullable(false))
+                .with_named_column("type", ScalarType::String.nullable(false))
+                .with_named_column("help", ScalarType::String.nullable(false))
                 .with_key(vec![0]),
         id: GlobalId::System(4045),
         index_id: GlobalId::System(4046),
@@ -823,11 +823,11 @@ lazy_static! {
         name: "mz_metric_histograms",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-                .with_column("metric", ScalarType::String.nullable(false))
-                .with_column("time", ScalarType::Timestamp.nullable(false))
-                .with_column("labels", ScalarType::Jsonb.nullable(false))
-                .with_column("bound", ScalarType::Float64.nullable(false))
-                .with_column("count", ScalarType::Int64.nullable(false))
+                .with_named_column("metric", ScalarType::String.nullable(false))
+                .with_named_column("time", ScalarType::Timestamp.nullable(false))
+                .with_named_column("labels", ScalarType::Jsonb.nullable(false))
+                .with_named_column("bound", ScalarType::Float64.nullable(false))
+                .with_named_column("count", ScalarType::Int64.nullable(false))
                 .with_key(vec![0, 1, 2]),
         id: GlobalId::System(4047),
         index_id: GlobalId::System(4048),

--- a/src/dataflow-types/src/logging.rs
+++ b/src/dataflow-types/src/logging.rs
@@ -78,37 +78,37 @@ impl LogVariant {
     pub fn desc(&self) -> RelationDesc {
         match self {
             LogVariant::Timely(TimelyLog::Operates) => RelationDesc::empty()
-                .with_column("id", ScalarType::Int64.nullable(false))
-                .with_column("worker", ScalarType::Int64.nullable(false))
-                .with_column("name", ScalarType::String.nullable(false))
+                .with_named_column("id", ScalarType::Int64.nullable(false))
+                .with_named_column("worker", ScalarType::Int64.nullable(false))
+                .with_named_column("name", ScalarType::String.nullable(false))
                 .with_key(vec![0, 1]),
 
             LogVariant::Timely(TimelyLog::Channels) => RelationDesc::empty()
-                .with_column("id", ScalarType::Int64.nullable(false))
-                .with_column("worker", ScalarType::Int64.nullable(false))
-                .with_column("source_node", ScalarType::Int64.nullable(false))
-                .with_column("source_port", ScalarType::Int64.nullable(false))
-                .with_column("target_node", ScalarType::Int64.nullable(false))
-                .with_column("target_port", ScalarType::Int64.nullable(false))
+                .with_named_column("id", ScalarType::Int64.nullable(false))
+                .with_named_column("worker", ScalarType::Int64.nullable(false))
+                .with_named_column("source_node", ScalarType::Int64.nullable(false))
+                .with_named_column("source_port", ScalarType::Int64.nullable(false))
+                .with_named_column("target_node", ScalarType::Int64.nullable(false))
+                .with_named_column("target_port", ScalarType::Int64.nullable(false))
                 .with_key(vec![0, 1]),
 
             LogVariant::Timely(TimelyLog::Elapsed) => RelationDesc::empty()
-                .with_column("id", ScalarType::Int64.nullable(false))
-                .with_column("worker", ScalarType::Int64.nullable(false))
-                .with_column("elapsed_ns", ScalarType::Int64.nullable(false))
+                .with_named_column("id", ScalarType::Int64.nullable(false))
+                .with_named_column("worker", ScalarType::Int64.nullable(false))
+                .with_named_column("elapsed_ns", ScalarType::Int64.nullable(false))
                 .with_key(vec![0, 1]),
 
             LogVariant::Timely(TimelyLog::Histogram) => RelationDesc::empty()
-                .with_column("id", ScalarType::Int64.nullable(false))
-                .with_column("worker", ScalarType::Int64.nullable(false))
-                .with_column("duration_ns", ScalarType::Int64.nullable(false))
-                .with_column("count", ScalarType::Int64.nullable(false))
+                .with_named_column("id", ScalarType::Int64.nullable(false))
+                .with_named_column("worker", ScalarType::Int64.nullable(false))
+                .with_named_column("duration_ns", ScalarType::Int64.nullable(false))
+                .with_named_column("count", ScalarType::Int64.nullable(false))
                 .with_key(vec![0, 1]),
 
             LogVariant::Timely(TimelyLog::Addresses) => RelationDesc::empty()
-                .with_column("id", ScalarType::Int64.nullable(false))
-                .with_column("worker", ScalarType::Int64.nullable(false))
-                .with_column(
+                .with_named_column("id", ScalarType::Int64.nullable(false))
+                .with_named_column("worker", ScalarType::Int64.nullable(false))
+                .with_named_column(
                     "address",
                     ScalarType::List {
                         element_type: Box::new(ScalarType::Int64),
@@ -119,103 +119,103 @@ impl LogVariant {
                 .with_key(vec![0, 1]),
 
             LogVariant::Timely(TimelyLog::Parks) => RelationDesc::empty()
-                .with_column("worker", ScalarType::Int64.nullable(false))
-                .with_column("slept_for", ScalarType::Int64.nullable(false))
-                .with_column("requested", ScalarType::Int64.nullable(false))
-                .with_column("count", ScalarType::Int64.nullable(false))
+                .with_named_column("worker", ScalarType::Int64.nullable(false))
+                .with_named_column("slept_for", ScalarType::Int64.nullable(false))
+                .with_named_column("requested", ScalarType::Int64.nullable(false))
+                .with_named_column("count", ScalarType::Int64.nullable(false))
                 .with_key(vec![0, 1, 2]),
 
             LogVariant::Timely(TimelyLog::Messages) => RelationDesc::empty()
-                .with_column("channel", ScalarType::Int64.nullable(false))
-                .with_column("source_worker", ScalarType::Int64.nullable(false))
-                .with_column("target_worker", ScalarType::Int64.nullable(false))
-                .with_column("sent", ScalarType::Int64.nullable(false))
-                .with_column("received", ScalarType::Int64.nullable(false))
+                .with_named_column("channel", ScalarType::Int64.nullable(false))
+                .with_named_column("source_worker", ScalarType::Int64.nullable(false))
+                .with_named_column("target_worker", ScalarType::Int64.nullable(false))
+                .with_named_column("sent", ScalarType::Int64.nullable(false))
+                .with_named_column("received", ScalarType::Int64.nullable(false))
                 .with_key(vec![0, 1, 2]),
 
             LogVariant::Differential(DifferentialLog::Arrangement) => RelationDesc::empty()
-                .with_column("operator", ScalarType::Int64.nullable(false))
-                .with_column("worker", ScalarType::Int64.nullable(false))
-                .with_column("records", ScalarType::Int64.nullable(false))
-                .with_column("batches", ScalarType::Int64.nullable(false))
+                .with_named_column("operator", ScalarType::Int64.nullable(false))
+                .with_named_column("worker", ScalarType::Int64.nullable(false))
+                .with_named_column("records", ScalarType::Int64.nullable(false))
+                .with_named_column("batches", ScalarType::Int64.nullable(false))
                 .with_key(vec![0, 1]),
 
             LogVariant::Differential(DifferentialLog::Sharing) => RelationDesc::empty()
-                .with_column("operator", ScalarType::Int64.nullable(false))
-                .with_column("worker", ScalarType::Int64.nullable(false))
-                .with_column("count", ScalarType::Int64.nullable(false))
+                .with_named_column("operator", ScalarType::Int64.nullable(false))
+                .with_named_column("worker", ScalarType::Int64.nullable(false))
+                .with_named_column("count", ScalarType::Int64.nullable(false))
                 .with_key(vec![0, 1]),
 
             LogVariant::Materialized(MaterializedLog::DataflowCurrent) => RelationDesc::empty()
-                .with_column("name", ScalarType::String.nullable(false))
-                .with_column("worker", ScalarType::Int64.nullable(false))
+                .with_named_column("name", ScalarType::String.nullable(false))
+                .with_named_column("worker", ScalarType::Int64.nullable(false))
                 .with_key(vec![0, 1]),
 
             LogVariant::Materialized(MaterializedLog::SourceInfo) => RelationDesc::empty()
-                .with_column("source_name", ScalarType::String.nullable(false))
-                .with_column("source_id", ScalarType::String.nullable(false))
-                .with_column("dataflow_id", ScalarType::Int64.nullable(false))
-                .with_column("partition_id", ScalarType::String.nullable(false))
-                .with_column("offset", ScalarType::Int64.nullable(false))
-                .with_column("timestamp", ScalarType::Int64.nullable(false))
+                .with_named_column("source_name", ScalarType::String.nullable(false))
+                .with_named_column("source_id", ScalarType::String.nullable(false))
+                .with_named_column("dataflow_id", ScalarType::Int64.nullable(false))
+                .with_named_column("partition_id", ScalarType::String.nullable(false))
+                .with_named_column("offset", ScalarType::Int64.nullable(false))
+                .with_named_column("timestamp", ScalarType::Int64.nullable(false))
                 .with_key(vec![0, 1, 2, 3]),
 
             LogVariant::Materialized(MaterializedLog::DataflowDependency) => RelationDesc::empty()
-                .with_column("dataflow", ScalarType::String.nullable(false))
-                .with_column("source", ScalarType::String.nullable(false))
-                .with_column("worker", ScalarType::Int64.nullable(false)),
+                .with_named_column("dataflow", ScalarType::String.nullable(false))
+                .with_named_column("source", ScalarType::String.nullable(false))
+                .with_named_column("worker", ScalarType::Int64.nullable(false)),
 
             LogVariant::Materialized(MaterializedLog::FrontierCurrent) => RelationDesc::empty()
-                .with_column("global_id", ScalarType::String.nullable(false))
-                .with_column("worker", ScalarType::Int64.nullable(false))
-                .with_column("time", ScalarType::Int64.nullable(false)),
+                .with_named_column("global_id", ScalarType::String.nullable(false))
+                .with_named_column("worker", ScalarType::Int64.nullable(false))
+                .with_named_column("time", ScalarType::Int64.nullable(false)),
 
             LogVariant::Materialized(MaterializedLog::KafkaBrokerRtt) => RelationDesc::empty()
-                .with_column("consumer_name", ScalarType::String.nullable(false))
-                .with_column("source_id", ScalarType::String.nullable(false))
-                .with_column("dataflow_id", ScalarType::Int64.nullable(false))
-                .with_column("broker_name", ScalarType::String.nullable(false))
-                .with_column("min", ScalarType::Int64.nullable(false))
-                .with_column("max", ScalarType::Int64.nullable(false))
-                .with_column("avg", ScalarType::Int64.nullable(false))
-                .with_column("sum", ScalarType::Int64.nullable(false))
-                .with_column("cnt", ScalarType::Int64.nullable(false))
-                .with_column("stddev", ScalarType::Int64.nullable(false))
-                .with_column("p50", ScalarType::Int64.nullable(false))
-                .with_column("p75", ScalarType::Int64.nullable(false))
-                .with_column("p90", ScalarType::Int64.nullable(false))
-                .with_column("p95", ScalarType::Int64.nullable(false))
-                .with_column("p99", ScalarType::Int64.nullable(false))
-                .with_column("p99_99", ScalarType::Int64.nullable(false))
+                .with_named_column("consumer_name", ScalarType::String.nullable(false))
+                .with_named_column("source_id", ScalarType::String.nullable(false))
+                .with_named_column("dataflow_id", ScalarType::Int64.nullable(false))
+                .with_named_column("broker_name", ScalarType::String.nullable(false))
+                .with_named_column("min", ScalarType::Int64.nullable(false))
+                .with_named_column("max", ScalarType::Int64.nullable(false))
+                .with_named_column("avg", ScalarType::Int64.nullable(false))
+                .with_named_column("sum", ScalarType::Int64.nullable(false))
+                .with_named_column("cnt", ScalarType::Int64.nullable(false))
+                .with_named_column("stddev", ScalarType::Int64.nullable(false))
+                .with_named_column("p50", ScalarType::Int64.nullable(false))
+                .with_named_column("p75", ScalarType::Int64.nullable(false))
+                .with_named_column("p90", ScalarType::Int64.nullable(false))
+                .with_named_column("p95", ScalarType::Int64.nullable(false))
+                .with_named_column("p99", ScalarType::Int64.nullable(false))
+                .with_named_column("p99_99", ScalarType::Int64.nullable(false))
                 .with_key(vec![0, 1, 2]),
 
             LogVariant::Materialized(MaterializedLog::KafkaConsumerInfo) => RelationDesc::empty()
-                .with_column("consumer_name", ScalarType::String.nullable(false))
-                .with_column("source_id", ScalarType::String.nullable(false))
-                .with_column("dataflow_id", ScalarType::Int64.nullable(false))
-                .with_column("partition_id", ScalarType::String.nullable(false))
-                .with_column("rx_msgs", ScalarType::Int64.nullable(false))
-                .with_column("rx_bytes", ScalarType::Int64.nullable(false))
-                .with_column("tx_msgs", ScalarType::Int64.nullable(false))
-                .with_column("tx_bytes", ScalarType::Int64.nullable(false))
-                .with_column("lo_offset", ScalarType::Int64.nullable(false))
-                .with_column("hi_offset", ScalarType::Int64.nullable(false))
-                .with_column("ls_offset", ScalarType::Int64.nullable(false))
-                .with_column("app_offset", ScalarType::Int64.nullable(false))
-                .with_column("consumer_lag", ScalarType::Int64.nullable(false))
+                .with_named_column("consumer_name", ScalarType::String.nullable(false))
+                .with_named_column("source_id", ScalarType::String.nullable(false))
+                .with_named_column("dataflow_id", ScalarType::Int64.nullable(false))
+                .with_named_column("partition_id", ScalarType::String.nullable(false))
+                .with_named_column("rx_msgs", ScalarType::Int64.nullable(false))
+                .with_named_column("rx_bytes", ScalarType::Int64.nullable(false))
+                .with_named_column("tx_msgs", ScalarType::Int64.nullable(false))
+                .with_named_column("tx_bytes", ScalarType::Int64.nullable(false))
+                .with_named_column("lo_offset", ScalarType::Int64.nullable(false))
+                .with_named_column("hi_offset", ScalarType::Int64.nullable(false))
+                .with_named_column("ls_offset", ScalarType::Int64.nullable(false))
+                .with_named_column("app_offset", ScalarType::Int64.nullable(false))
+                .with_named_column("consumer_lag", ScalarType::Int64.nullable(false))
                 .with_key(vec![0, 1, 2]),
 
             LogVariant::Materialized(MaterializedLog::PeekCurrent) => RelationDesc::empty()
-                .with_column("uuid", ScalarType::String.nullable(false))
-                .with_column("worker", ScalarType::Int64.nullable(false))
-                .with_column("id", ScalarType::String.nullable(false))
-                .with_column("time", ScalarType::Int64.nullable(false))
+                .with_named_column("uuid", ScalarType::String.nullable(false))
+                .with_named_column("worker", ScalarType::Int64.nullable(false))
+                .with_named_column("id", ScalarType::String.nullable(false))
+                .with_named_column("time", ScalarType::Int64.nullable(false))
                 .with_key(vec![0, 1]),
 
             LogVariant::Materialized(MaterializedLog::PeekDuration) => RelationDesc::empty()
-                .with_column("worker", ScalarType::Int64.nullable(false))
-                .with_column("duration_ns", ScalarType::Int64.nullable(false))
-                .with_column("count", ScalarType::Int64.nullable(false))
+                .with_named_column("worker", ScalarType::Int64.nullable(false))
+                .with_named_column("duration_ns", ScalarType::Int64.nullable(false))
+                .with_named_column("count", ScalarType::Int64.nullable(false))
                 .with_key(vec![0, 1]),
         }
     }

--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -147,7 +147,7 @@ mod tests {
             ),
         ];
         for (typ, datum, expected) in valid_pairings {
-            let desc = RelationDesc::empty().with_column("column1", typ.nullable(false));
+            let desc = RelationDesc::empty().with_named_column("column1", typ.nullable(false));
             let encoder = Encoder::new(None, desc, false);
             let avro_value = encode_datums_as_avro(std::iter::once(datum), encoder.value_columns());
             assert_eq!(

--- a/src/interchange/src/avro/envelope_cdc_v2.rs
+++ b/src/interchange/src/avro/envelope_cdc_v2.rs
@@ -266,8 +266,8 @@ mod tests {
     #[test]
     fn test_roundtrip() {
         let desc = RelationDesc::empty()
-            .with_column("id", ScalarType::Int64.nullable(false))
-            .with_column("price", ScalarType::Float64.nullable(true));
+            .with_named_column("id", ScalarType::Int64.nullable(false))
+            .with_named_column("price", ScalarType::Float64.nullable(true));
 
         let encoder = Encoder::new(desc.clone());
         let row_schema = build_row_schema_json(&crate::avro::column_names_and_types(desc), "data");

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -253,14 +253,22 @@ impl RelationDesc {
         self
     }
 
-    /// Appends a named column with the specified column type.
-    pub fn with_column<N>(mut self, name: N, column_type: ColumnType) -> Self
+    /// Appends an optionally named column with the specified column type.
+    pub fn with_column<N>(mut self, name: Option<N>, column_type: ColumnType) -> Self
     where
         N: Into<ColumnName>,
     {
         self.typ.column_types.push(column_type);
-        self.names.push(Some(name.into()));
+        self.names.push(name.map(|n| n.into()));
         self
+    }
+
+    /// Appends a named column with the specified column type.
+    pub fn with_named_column<N>(self, name: N, column_type: ColumnType) -> Self
+    where
+        N: Into<ColumnName>,
+    {
+        self.with_column(Some(name), column_type)
     }
 
     /// Adds a new key for the relation.

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -176,8 +176,8 @@ impl From<&ColumnName> for ColumnName {
 /// use repr::{ColumnType, RelationDesc, ScalarType};
 ///
 /// let desc = RelationDesc::empty()
-///     .with_column("id", ScalarType::Int64.nullable(false))
-///     .with_column("price", ScalarType::Float64.nullable(true));
+///     .with_named_column("id", ScalarType::Int64.nullable(false))
+///     .with_named_column("price", ScalarType::Float64.nullable(true));
 /// ```
 ///
 /// In more complicated cases, like when constructing a `RelationDesc` in

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1019,7 +1019,7 @@ pub fn plan_create_source(
         (DataEncoding::Avro { .. }, _) | (_, SourceEnvelope::Debezium(_, _)) => (),
         _ => {
             for (name, ty) in external_connector.metadata_columns() {
-                bare_desc = bare_desc.with_column(name, ty);
+                bare_desc = bare_desc.with_named_column(name, ty);
             }
         }
     }

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -255,17 +255,23 @@ pub fn describe_tail(
 ) -> Result<StatementDesc, anyhow::Error> {
     let sql_object = scx.resolve_item(name)?;
     let options = TailOptions::try_from(options)?;
+    let progress = options.progress.unwrap_or(false);
     const MAX_U64_DIGITS: u8 = 20;
     let mut desc = RelationDesc::empty().with_named_column(
         "timestamp",
         ScalarType::Decimal(MAX_U64_DIGITS, 0).nullable(false),
     );
-    if options.progress.unwrap_or(false) {
+    if progress {
         desc = desc.with_named_column("progressed", ScalarType::Bool.nullable(false));
     }
-    let desc = desc
-        .with_named_column("diff", ScalarType::Int64.nullable(true))
-        .concat(sql_object.desc()?.clone());
+    desc = desc.with_named_column("diff", ScalarType::Int64.nullable(true));
+    for (name, ty) in sql_object.desc()?.iter() {
+        let mut ty = ty.clone();
+        if progress {
+            ty.nullable = true;
+        }
+        desc = desc.with_column(name.clone(), ty);
+    }
     Ok(StatementDesc::new(Some(desc)))
 }
 

--- a/src/sql/src/plan/statement/scl.rs
+++ b/src/sql/src/plan/statement/scl.rs
@@ -60,11 +60,12 @@ pub fn describe_show_variable(
 ) -> Result<StatementDesc, anyhow::Error> {
     let desc = if variable.as_str() == unicase::Ascii::new("ALL") {
         RelationDesc::empty()
-            .with_column("name", ScalarType::String.nullable(false))
-            .with_column("setting", ScalarType::String.nullable(false))
-            .with_column("description", ScalarType::String.nullable(false))
+            .with_named_column("name", ScalarType::String.nullable(false))
+            .with_named_column("setting", ScalarType::String.nullable(false))
+            .with_named_column("description", ScalarType::String.nullable(false))
     } else {
-        RelationDesc::empty().with_column(variable.as_str(), ScalarType::String.nullable(false))
+        RelationDesc::empty()
+            .with_named_column(variable.as_str(), ScalarType::String.nullable(false))
     };
     Ok(StatementDesc::new(Some(desc)))
 }

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -40,8 +40,8 @@ pub fn describe_show_create_view(
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(Some(
         RelationDesc::empty()
-            .with_column("View", ScalarType::String.nullable(false))
-            .with_column("Create View", ScalarType::String.nullable(false)),
+            .with_named_column("View", ScalarType::String.nullable(false))
+            .with_named_column("Create View", ScalarType::String.nullable(false)),
     )))
 }
 
@@ -94,8 +94,8 @@ pub fn describe_show_create_table(
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(Some(
         RelationDesc::empty()
-            .with_column("Table", ScalarType::String.nullable(false))
-            .with_column("Create Table", ScalarType::String.nullable(false)),
+            .with_named_column("Table", ScalarType::String.nullable(false))
+            .with_named_column("Create Table", ScalarType::String.nullable(false)),
     )))
 }
 
@@ -120,8 +120,8 @@ pub fn describe_show_create_source(
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(Some(
         RelationDesc::empty()
-            .with_column("Source", ScalarType::String.nullable(false))
-            .with_column("Create Source", ScalarType::String.nullable(false)),
+            .with_named_column("Source", ScalarType::String.nullable(false))
+            .with_named_column("Create Source", ScalarType::String.nullable(false)),
     )))
 }
 
@@ -146,8 +146,8 @@ pub fn describe_show_create_sink(
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(Some(
         RelationDesc::empty()
-            .with_column("Sink", ScalarType::String.nullable(false))
-            .with_column("Create Sink", ScalarType::String.nullable(false)),
+            .with_named_column("Sink", ScalarType::String.nullable(false))
+            .with_named_column("Create Sink", ScalarType::String.nullable(false)),
     )))
 }
 
@@ -172,8 +172,8 @@ pub fn describe_show_create_index(
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(Some(
         RelationDesc::empty()
-            .with_column("Index", ScalarType::String.nullable(false))
-            .with_column("Create Index", ScalarType::String.nullable(false)),
+            .with_named_column("Index", ScalarType::String.nullable(false))
+            .with_named_column("Create Index", ScalarType::String.nullable(false)),
     )))
 }
 


### PR DESCRIPTION
Fix #6522.

@mjibson feel free to ditch this in favor of your work. I was fighting with the `RelationDesc` API a lot here.