### PR TITLE
docs: add --name param to docker run instructions

### DIFF
--- a/doc/user/content/install.md
+++ b/doc/user/content/install.md
@@ -26,7 +26,7 @@ We provide the `materialize/materialized` image in Docker Hub. If you already ha
 way. For example:
 
 ```shell
-docker run -p 6875:6875 materialize/materialized:{{< version >}} --workers 1
+docker run -p 6875:6875 materialize/materialized:{{< version >}}  --name materialized --workers 1
 ```
 
 [docker-start]: https://www.docker.com/get-started


### PR DESCRIPTION
If you don't specify a [--name](https://docs.docker.com/engine/reference/run/#name---name) for your Docker container, Docker
will bring it up with a random string for a name. It seems better
to bring it up as `materialized` instead.