### PR TITLE
sql: integrate postgres source namespace into table string

### DIFF
--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -766,8 +766,9 @@ pub struct FileSourceConnector {
 pub struct PostgresSourceConnector {
     pub conn: String,
     pub publication: String,
-    pub namespace: String,
-    pub table: String,
+    // The table's UnresolvedObjectName.to_ast_string(), for use in literal SQL
+    // strings.
+    pub ast_table: String,
     pub cast_exprs: Vec<MirScalarExpr>,
     pub slot_name: String,
 }

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -154,7 +154,6 @@ Minute
 Minutes
 Month
 Months
-Namespace
 Natural
 Next
 No

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1757,10 +1757,8 @@ impl<'a> Parser<'a> {
                 } else {
                     None
                 };
-                self.expect_keyword(NAMESPACE)?;
-                let namespace = self.parse_literal_string()?;
                 self.expect_keyword(TABLE)?;
-                let table = self.parse_literal_string()?;
+                let table = self.parse_object_name()?;
 
                 let (columns, constraints) = self.parse_columns(Optional)?;
 
@@ -1776,7 +1774,6 @@ impl<'a> Parser<'a> {
                     conn,
                     publication,
                     slot,
-                    namespace,
                     table,
                     columns,
                 })
@@ -1873,8 +1870,6 @@ impl<'a> Parser<'a> {
                 } else {
                     None
                 };
-                self.expect_keyword(NAMESPACE)?;
-                let namespace = self.parse_literal_string()?;
                 self.expect_keyword(TABLES)?;
                 self.expect_token(&Token::LParen)?;
                 let tables = self.parse_postgres_tables()?;
@@ -1883,7 +1878,6 @@ impl<'a> Parser<'a> {
                     conn,
                     publication,
                     slot,
-                    namespace,
                     tables,
                 })
             }
@@ -2121,7 +2115,7 @@ impl<'a> Parser<'a> {
     fn parse_postgres_tables(&mut self) -> Result<Vec<PgTable<Raw>>, ParserError> {
         let mut tables = vec![];
         loop {
-            let name = self.parse_literal_string()?;
+            let name = self.parse_object_name()?;
             self.expect_keyword(AS)?;
             let alias = RawName::Name(self.parse_object_name()?);
             let (columns, constraints) = self.parse_columns(Optional)?;

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -497,11 +497,11 @@ CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka { broker: "broker", topic: "topic", key: None }, with_options: [Value { name: Ident("start_offset"), value: Array([Number("2"), Number("40000000")]) }], format: Some(Avro(Schema { schema: File("path"), with_options: [] })), envelope: Upsert(Some(Text)), if_not_exists: false, materialized: false })
 
 parse-statement
-CREATE SOURCE psychic FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' NAMESPACE 'generation1' TABLE 'psychic' (pokedex_id int NOT NULL, evolution int);
+CREATE SOURCE psychic FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' TABLE generation1.psychic (pokedex_id int NOT NULL, evolution int);
 ----
-CREATE SOURCE psychic FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' NAMESPACE 'generation1' TABLE 'psychic' (pokedex_id int4 NOT NULL, evolution int4)
+CREATE SOURCE psychic FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' TABLE generation1.psychic (pokedex_id int4 NOT NULL, evolution int4)
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("psychic")]), col_names: [], connector: Postgres { conn: "host=kanto user=ash password=teamrocket dbname=pokemon", publication: "red", slot: None, namespace: "generation1", table: "psychic", columns: [ColumnDef { name: Ident("pokedex_id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("evolution"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }] }, with_options: [], format: None, envelope: None, if_not_exists: false, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("psychic")]), col_names: [], connector: Postgres { conn: "host=kanto user=ash password=teamrocket dbname=pokemon", publication: "red", slot: None, table: UnresolvedObjectName([Ident("generation1"), Ident("psychic")]), columns: [ColumnDef { name: Ident("pokedex_id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("evolution"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }] }, with_options: [], format: None, envelope: None, if_not_exists: false, materialized: false })
 
 parse-statement
 CREATE SOURCE psychic FROM PUBNUB SUBSCRIBE KEY 'subscribe_key' CHANNEL 'channel';
@@ -525,46 +525,46 @@ CREATE SOURCE IF EXISTS foo FROM FILE 'bar' USING SCHEMA ''
                  ^
 
 parse-statement
-CREATE SOURCES FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' NAMESPACE 'generation1' TABLES ();
+CREATE SOURCES FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' TABLES ();
 ----
-error: Expected literal string, found right parenthesis
-CREATE SOURCES FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' NAMESPACE 'generation1' TABLES ();
-                                                                                                                                             ^
+error: Expected identifier, found right parenthesis
+CREATE SOURCES FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' TABLES ();
+                                                                                                                     ^
 
 parse-statement
-CREATE SOURCES FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' NAMESPACE 'generation1' TABLES (SELECT 1);
+CREATE SOURCES FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' TABLES (SELECT 1);
 ----
-error: Expected literal string, found SELECT
-CREATE SOURCES FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' NAMESPACE 'generation1' TABLES (SELECT 1);
-                                                                                                                                             ^
+error: Expected AS, found number '1'
+CREATE SOURCES FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' TABLES (SELECT 1);
+                                                                                                                            ^
 
 parse-statement
-CREATE SOURCES FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' NAMESPACE 'generation1' TABLES ("public.psychic" (pokedex_id int NOT NULL, evolution int))
+CREATE SOURCES FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' TABLES ('public.psychic' (pokedex_id int NOT NULL, evolution int))
 ----
-error: Expected literal string, found identifier 'public.psychic'
-CREATE SOURCES FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' NAMESPACE 'generation1' TABLES ("public.psychic" (pokedex_id int NOT NULL, evolution int))
-                                                                                                                                             ^
+error: Expected identifier, found string literal 'public.psychic'
+CREATE SOURCES FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' TABLES ('public.psychic' (pokedex_id int NOT NULL, evolution int))
+                                                                                                                     ^
 
 parse-statement
-CREATE SOURCES FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' NAMESPACE 'generation1' TABLES ('psychic' as "public.psychic" (pokedex_id int NOT NULL, evolution int))
+CREATE SOURCES FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' TABLES (generation1.psychic as "public.psychic" (pokedex_id int NOT NULL, evolution int))
 ----
-CREATE SOURCES FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' NAMESPACE 'generation1' TABLES ('psychic' AS "public.psychic" (pokedex_id int4 NOT NULL, evolution int4))
+CREATE SOURCES FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' TABLES (generation1.psychic AS "public.psychic" (pokedex_id int4 NOT NULL, evolution int4))
 =>
-CreateSources(CreateSourcesStatement { connector: Postgres { conn: "host=kanto user=ash password=teamrocket dbname=pokemon", publication: "red", slot: None, namespace: "generation1", tables: [PgTable { name: "psychic", alias: Name(UnresolvedObjectName([Ident("public.psychic")])), columns: [ColumnDef { name: Ident("pokedex_id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("evolution"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }] }] }, materialized: false, stmts: [] })
+CreateSources(CreateSourcesStatement { connector: Postgres { conn: "host=kanto user=ash password=teamrocket dbname=pokemon", publication: "red", slot: None, tables: [PgTable { name: UnresolvedObjectName([Ident("generation1"), Ident("psychic")]), alias: Name(UnresolvedObjectName([Ident("public.psychic")])), columns: [ColumnDef { name: Ident("pokedex_id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("evolution"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }] }] }, materialized: false, stmts: [] })
 
 parse-statement
-CREATE SOURCES FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' NAMESPACE 'generation1' TABLES ('random.psychic' as "public.psychic" (pokedex_id int NOT NULL, evolution int), 'another_table' as "another_one")
+CREATE SOURCES FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' TABLES (generation1.random.psychic as "public.psychic" (pokedex_id int NOT NULL, evolution int), another_table as "another_one")
 ----
-CREATE SOURCES FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' NAMESPACE 'generation1' TABLES ('random.psychic' AS "public.psychic" (pokedex_id int4 NOT NULL, evolution int4), 'another_table' AS another_one)
+CREATE SOURCES FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' TABLES (generation1.random.psychic AS "public.psychic" (pokedex_id int4 NOT NULL, evolution int4), another_table AS another_one)
 =>
-CreateSources(CreateSourcesStatement { connector: Postgres { conn: "host=kanto user=ash password=teamrocket dbname=pokemon", publication: "red", slot: None, namespace: "generation1", tables: [PgTable { name: "random.psychic", alias: Name(UnresolvedObjectName([Ident("public.psychic")])), columns: [ColumnDef { name: Ident("pokedex_id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("evolution"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }] }, PgTable { name: "another_table", alias: Name(UnresolvedObjectName([Ident("another_one")])), columns: [] }] }, materialized: false, stmts: [] })
+CreateSources(CreateSourcesStatement { connector: Postgres { conn: "host=kanto user=ash password=teamrocket dbname=pokemon", publication: "red", slot: None, tables: [PgTable { name: UnresolvedObjectName([Ident("generation1"), Ident("random"), Ident("psychic")]), alias: Name(UnresolvedObjectName([Ident("public.psychic")])), columns: [ColumnDef { name: Ident("pokedex_id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("evolution"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }] }, PgTable { name: UnresolvedObjectName([Ident("another_table")]), alias: Name(UnresolvedObjectName([Ident("another_one")])), columns: [] }] }, materialized: false, stmts: [] })
 
 parse-statement
-CREATE MATERIALIZED SOURCES FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' NAMESPACE 'generation1' TABLES ('random.psychic' as "public.psychic" (pokedex_id int NOT NULL, evolution int), 'another_table' as "another_one")
+CREATE MATERIALIZED SOURCES FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' TABLES (generation1.random.psychic as "public.psychic" (pokedex_id int NOT NULL, evolution int), another_table as "another_one")
 ----
-CREATE MATERIALIZED SOURCES FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' NAMESPACE 'generation1' TABLES ('random.psychic' AS "public.psychic" (pokedex_id int4 NOT NULL, evolution int4), 'another_table' AS another_one)
+CREATE MATERIALIZED SOURCES FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' TABLES (generation1.random.psychic AS "public.psychic" (pokedex_id int4 NOT NULL, evolution int4), another_table AS another_one)
 =>
-CreateSources(CreateSourcesStatement { connector: Postgres { conn: "host=kanto user=ash password=teamrocket dbname=pokemon", publication: "red", slot: None, namespace: "generation1", tables: [PgTable { name: "random.psychic", alias: Name(UnresolvedObjectName([Ident("public.psychic")])), columns: [ColumnDef { name: Ident("pokedex_id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("evolution"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }] }, PgTable { name: "another_table", alias: Name(UnresolvedObjectName([Ident("another_one")])), columns: [] }] }, materialized: true, stmts: [] })
+CreateSources(CreateSourcesStatement { connector: Postgres { conn: "host=kanto user=ash password=teamrocket dbname=pokemon", publication: "red", slot: None, tables: [PgTable { name: UnresolvedObjectName([Ident("generation1"), Ident("random"), Ident("psychic")]), alias: Name(UnresolvedObjectName([Ident("public.psychic")])), columns: [ColumnDef { name: Ident("pokedex_id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("evolution"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }] }, PgTable { name: UnresolvedObjectName([Ident("another_table")]), alias: Name(UnresolvedObjectName([Ident("another_one")])), columns: [] }] }, materialized: true, stmts: [] })
 
 parse-statement
 CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT BYTES

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -712,7 +712,6 @@ pub fn plan_create_source(
         Connector::Postgres {
             conn,
             publication,
-            namespace,
             table,
             columns,
             slot,
@@ -788,8 +787,7 @@ pub fn plan_create_source(
             let connector = ExternalSourceConnector::Postgres(PostgresSourceConnector {
                 conn: conn.clone(),
                 publication: publication.clone(),
-                namespace: namespace.clone(),
-                table: table.clone(),
+                ast_table: table.to_ast_string(),
                 cast_exprs,
                 slot_name: slot_name.clone(),
             });

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -75,30 +75,26 @@ INSERT INTO no_replica_identity VALUES (1), (2);
   FROM POSTGRES
     HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
     PUBLICATION 'mz_source'
-    NAMESPACE 'public'
-    TABLE 'numbers';
+    TABLE numbers;
 
 > CREATE SOURCE "empty_schema2"
   FROM POSTGRES
     HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
     PUBLICATION 'mz_source'
-    NAMESPACE 'public'
-    TABLE 'numbers' ();
+    TABLE numbers ();
 # TODO: This should be an error
 
 > CREATE SOURCE "correct_schema_explicit_null"
   FROM POSTGRES
     HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
     PUBLICATION 'mz_source'
-    NAMESPACE 'public'
-    TABLE 'numbers' (number int PRIMARY KEY, is_prime bool NULL, name text NULL)
+    TABLE numbers (number int PRIMARY KEY, is_prime bool NULL, name text NULL)
 
 > CREATE MATERIALIZED SOURCE "correct_schema"
   FROM POSTGRES
     HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
     PUBLICATION 'mz_source'
-    NAMESPACE 'public'
-    TABLE 'numbers' (number int PRIMARY KEY NOT NULL, is_prime bool, name text)
+    TABLE numbers (number int PRIMARY KEY NOT NULL, is_prime bool, name text)
 
 ## CREATE SOURCE with incorrect information should fail purification.
 
@@ -106,40 +102,35 @@ INSERT INTO no_replica_identity VALUES (1), (2);
   FROM POSTGRES
     HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
     PUBLICATION 'mz_source'
-    NAMESPACE 'public'
-    TABLE 'numbers' (number int NOT NULL)
+    TABLE numbers (number int NOT NULL)
 incorrect column specification: 1 columns were specified, upstream has 3: number, is_prime, name
 
 ! CREATE MATERIALIZED SOURCE "numbers"
   FROM POSTGRES
     HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
     PUBLICATION 'mz_source'
-    NAMESPACE 'public'
-    TABLE 'numbers' (number int NOT NULL, is_prime bool null, name text, extra numeric NULL)
+    TABLE numbers (number int NOT NULL, is_prime bool null, name text, extra numeric NULL)
 incorrect column specification: 4 columns were specified, upstream has 3: number, is_prime, name
 
 ! CREATE MATERIALIZED SOURCE "numbers"
   FROM POSTGRES
     HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
     PUBLICATION 'mz_source'
-    NAMESPACE 'public'
-    TABLE 'numbers' (number int NOT NULL, is_prime int, name text)
+    TABLE numbers (number int NOT NULL, is_prime int, name text)
 incorrect column specification: specified column modifiers do not match upstream source, specified: number int4 NOT NULL, upstream: number int4 PRIMARY KEY NOT NULL
 
 ! CREATE MATERIALIZED SOURCE "numbers"
   FROM POSTGRES
     HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
     PUBLICATION 'mz_source'
-    NAMESPACE 'public'
-    TABLE 'numbers' (number int NULL, is_prime bool null, name text)
+    TABLE numbers (number int NULL, is_prime bool null, name text)
 incorrect column specification: specified column modifiers do not match upstream source, specified: number int4 NULL, upstream: number int4 PRIMARY KEY NOT NULL
 
 ! CREATE MATERIALIZED SOURCE "numbers"
   FROM POSTGRES
     HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
     PUBLICATION 'mz_source'
-    NAMESPACE 'public'
-    TABLE 'numbers' (number int PRIMARY KEY, is_prime bool, name text NOT NULL)
+    TABLE numbers (number int PRIMARY KEY, is_prime bool, name text NOT NULL)
 incorrect column specification: specified column modifiers do not match upstream source, specified: name text NOT NULL, upstream: name text NULL
 
 ## CREATE SOURCES with correct information should pass purification and fail afterwards.
@@ -148,16 +139,14 @@ incorrect column specification: specified column modifiers do not match upstream
   FROM POSTGRES
     HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
     PUBLICATION 'mz_source'
-    NAMESPACE 'public'
-    TABLES ('numbers' AS "numbers")
+    TABLES (numbers AS "numbers")
 CREATE SOURCES not yet supported
 
 ! CREATE SOURCES
   FROM POSTGRES
     HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
     PUBLICATION 'mz_source'
-    NAMESPACE 'public'
-    TABLES ('numbers' AS "numbers", 'numbers' AS "second_numbers" (number int PRIMARY KEY, is_prime bool NULL, name text NULL))
+    TABLES (numbers AS "numbers", numbers AS "second_numbers" (number int PRIMARY KEY, is_prime bool NULL, name text NULL))
 CREATE SOURCES not yet supported
 
 ## CREATE SOURCES with incorrect information should fail purification.
@@ -166,16 +155,14 @@ CREATE SOURCES not yet supported
   FROM POSTGRES
     HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
     PUBLICATION 'mz_source'
-    NAMESPACE 'public'
-    TABLES ('numbers' AS "numbers" (number int NULL))
+    TABLES (numbers AS "numbers" (number int NULL))
 incorrect column specification: 1 columns were specified, upstream has 3: number, is_prime, name
 
 ! CREATE SOURCES
   FROM POSTGRES
     HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
     PUBLICATION 'mz_source'
-    NAMESPACE 'public'
-    TABLES ('numbers' AS "numbers" (number int NULL, is_prime bool NULL, name text))
+    TABLES (numbers AS "numbers" (number int NULL, is_prime bool NULL, name text))
 incorrect column specification: specified column modifiers do not match upstream source, specified: number int4 NULL, upstream: number int4 PRIMARY KEY NOT NULL
 
 #
@@ -184,72 +171,72 @@ incorrect column specification: specified column modifiers do not match upstream
 
 ! CREATE SOURCE "no_such_host"
   FROM POSTGRES HOST 'host=no_such_postgres.mtrlz.com port=5432 user=postgres password=postgres dbname=postgres'
-  PUBLICATION 'mz_source' NAMESPACE 'public' TABLE 'pk_table' (pk INTEGER NOT NULL, f2 TEXT);
+  PUBLICATION 'mz_source' TABLE pk_table (pk INTEGER NOT NULL, f2 TEXT);
 error connecting to server: failed to lookup address information: Name or service not known
 
 ! CREATE SOURCE "no_such_port"
   FROM POSTGRES HOST 'host=postgres port=65534 user=postgres password=postgres dbname=postgres'
-  PUBLICATION 'mz_source' NAMESPACE 'public' TABLE 'pk_table' (pk INTEGER NOT NULL, f2 TEXT);
+  PUBLICATION 'mz_source' TABLE pk_table (pk INTEGER NOT NULL, f2 TEXT);
 error connecting to server: Connection refused (os error 111)
 
 ! CREATE SOURCE "no_such_user"
   FROM POSTGRES HOST 'host=postgres port=5432 user=no_such_user password=postgres dbname=postgres'
-  PUBLICATION 'mz_source' NAMESPACE 'public' TABLE 'pk_table' (pk INTEGER NOT NULL, f2 TEXT);
+  PUBLICATION 'mz_source' TABLE pk_table (pk INTEGER NOT NULL, f2 TEXT);
 db error: FATAL: role "no_such_user" does not exist
 
 > CREATE SOURCE "no_such_password"
   FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=no_such_password dbname=postgres'
-  PUBLICATION 'mz_source' NAMESPACE 'public' TABLE 'pk_table' (pk INTEGER PRIMARY KEY NOT NULL, f2 TEXT);
+  PUBLICATION 'mz_source' TABLE pk_table (pk INTEGER PRIMARY KEY NOT NULL, f2 TEXT);
 # TODO: This should produce an error
 
-> CREATE SOURCE "no_replication"
+! CREATE SOURCE "no_replication"
   FROM POSTGRES HOST 'host=postgres port=5432 user=no_replication password=no_replication dbname=postgres'
-  PUBLICATION 'mz_source' NAMESPACE 'public' TABLE 'pk_table' (pk INTEGER PRIMARY KEY, f2 TEXT);
-# TODO: This should produce an error
+  PUBLICATION 'mz_source' TABLE pk_table (pk INTEGER PRIMARY KEY, f2 TEXT);
+db error: ERROR: relation "pk_table" does not exist
 
 ! CREATE SOURCE "no_such_dbname"
   FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=no_such_dbname'
-  PUBLICATION 'mz_source' NAMESPACE 'public' TABLE 'pk_table' (pk INTEGER PRIMARY KEY, f2 TEXT);
+  PUBLICATION 'mz_source' TABLE pk_table (pk INTEGER PRIMARY KEY, f2 TEXT);
 db error: FATAL: database "no_such_dbname" does not exist
 
 > CREATE SOURCE "no_such_publication"
   FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-  PUBLICATION 'no_such_publication' NAMESPACE 'public' TABLE 'pk_table' (pk INTEGER PRIMARY KEY NOT NULL, f2 TEXT);
+  PUBLICATION 'no_such_publication' TABLE pk_table (pk INTEGER PRIMARY KEY NOT NULL, f2 TEXT);
 # TODO: This should produce an error
 
 ! CREATE SOURCE "no_such_namespace"
   FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-  PUBLICATION 'mz_source' NAMESPACE 'no_such_namespace' TABLE 'pk_table' (pk INTEGER PRIMARY KEY NOT NULL, f2 TEXT);
-table not found in the upstream catalog
+  PUBLICATION 'mz_source' TABLE no_such_namespace.pk_table (pk INTEGER PRIMARY KEY NOT NULL, f2 TEXT);
+schema "no_such_namespace" does not exist
 
 ! CREATE SOURCE "no_such_table"
   FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-  PUBLICATION 'mz_source' NAMESPACE 'public' TABLE 'no_such_table' (pk INTEGER PRIMARY KEY, f2 TEXT);
-table not found in the upstream catalog
+  PUBLICATION 'mz_source' TABLE no_such_table (pk INTEGER PRIMARY KEY, f2 TEXT);
+relation "no_such_table" does not exist
 
 ! CREATE SOURCE "no_such_column"
   FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-  PUBLICATION 'mz_source' NAMESPACE 'public' TABLE 'pk_table' (no_such_column INTEGER, f2 TEXT);
+  PUBLICATION 'mz_source' TABLE pk_table (no_such_column INTEGER, f2 TEXT);
 column does not match upstream source, specified: no_such_column int4, upstream: pk int4 PRIMARY KEY NOT NULL
 
 ! CREATE SOURCE "column_type_mismatch"
   FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-  PUBLICATION 'mz_source' NAMESPACE 'public' TABLE 'pk_table' (f1 TIMESTAMP, f2 TEXT);
+  PUBLICATION 'mz_source' TABLE pk_table (f1 TIMESTAMP, f2 TEXT);
 column does not match upstream source, specified: f1 timestamp, upstream: pk int4 PRIMARY KEY NOT NULL
 
 ! CREATE SOURCE "missing_column"
   FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-  PUBLICATION 'mz_source' NAMESPACE 'public' TABLE 'pk_table' (pk INTEGER NOT NULL);
+  PUBLICATION 'mz_source' TABLE pk_table (pk INTEGER NOT NULL);
 incorrect column specification: 1 columns were specified, upstream has 2: pk, f2
 
 ! CREATE SOURCE "extra_column"
   FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-  PUBLICATION 'mz_source' NAMESPACE 'public' TABLE 'pk_table' (pk INTEGER NOT NULL, f2 TEXT, f3 INTEGER);
+  PUBLICATION 'mz_source' TABLE pk_table (pk INTEGER NOT NULL, f2 TEXT, f3 INTEGER);
 incorrect column specification: 3 columns were specified, upstream has 2: pk, f2
 
 > CREATE MATERIALIZED SOURCE "no_replica_identity"
   FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-  PUBLICATION 'mz_source' NAMESPACE 'public' TABLE 'no_replica_identity' (f1 INTEGER);
+  PUBLICATION 'mz_source' TABLE no_replica_identity (f1 INTEGER);
 # TODO: This should produce an error
 
 #
@@ -266,39 +253,39 @@ incorrect column specification: 3 columns were specified, upstream has 2: pk, f2
 
 > CREATE MATERIALIZED SOURCE "pk_table"
   FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-  PUBLICATION 'mz_source' NAMESPACE 'public' TABLE 'pk_table' (pk INTEGER PRIMARY KEY, f2 TEXT);
+  PUBLICATION 'mz_source' TABLE pk_table (pk INTEGER PRIMARY KEY, f2 TEXT);
 
 > CREATE MATERIALIZED SOURCE "nonpk_table"
   FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-  PUBLICATION 'mz_source' NAMESPACE 'public' TABLE 'nonpk_table' (f1 INTEGER, f2 INTEGER);
+  PUBLICATION 'mz_source' TABLE nonpk_table (f1 INTEGER, f2 INTEGER);
 
 > CREATE MATERIALIZED SOURCE "types_table"
   FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-  PUBLICATION 'mz_source' NAMESPACE 'public' TABLE 'types_table' (date_col DATE, time_col TIME, timestamp_col TIMESTAMP, uuid_col UUID, double_col DOUBLE PRECISION);
+  PUBLICATION 'mz_source' TABLE types_table (date_col DATE, time_col TIME, timestamp_col TIMESTAMP, uuid_col UUID, double_col DOUBLE PRECISION);
 
 > CREATE MATERIALIZED SOURCE "large_text"
   FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-  PUBLICATION 'mz_source' NAMESPACE 'public' TABLE 'large_text' (f1 TEXT);
+  PUBLICATION 'mz_source' TABLE large_text (f1 TEXT);
 
 > CREATE MATERIALIZED SOURCE "trailing_space_pk"
   FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-  PUBLICATION 'mz_source' NAMESPACE 'public' TABLE 'trailing_space_pk' (f1 TEXT PRIMARY KEY);
+  PUBLICATION 'mz_source' TABLE trailing_space_pk (f1 TEXT PRIMARY KEY);
 
 > CREATE MATERIALIZED SOURCE "trailing_space_nopk"
   FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-  PUBLICATION 'mz_source' NAMESPACE 'public' TABLE 'trailing_space_nopk' (f1 TEXT);
+  PUBLICATION 'mz_source' TABLE trailing_space_nopk (f1 TEXT);
 
 > CREATE MATERIALIZED SOURCE "multipart_pk"
   FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-  PUBLICATION 'mz_source' NAMESPACE 'public' TABLE 'multipart_pk' (f1 INTEGER PRIMARY KEY, f2 TEXT PRIMARY KEY NOT NULL, f3 TEXT);
+  PUBLICATION 'mz_source' TABLE multipart_pk (f1 INTEGER PRIMARY KEY, f2 TEXT PRIMARY KEY NOT NULL, f3 TEXT);
 
 > CREATE MATERIALIZED SOURCE "nulls_table"
   FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-  PUBLICATION 'mz_source' NAMESPACE 'public' TABLE 'nulls_table' (f1 TEXT, f2 INTEGER);
+  PUBLICATION 'mz_source' TABLE nulls_table (f1 TEXT, f2 INTEGER);
 
 > CREATE MATERIALIZED SOURCE "utf8_table"
   FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-  PUBLICATION 'mz_source' NAMESPACE 'public' TABLE 'utf8_table' (f1 TEXT PRIMARY KEY, f2 TEXT);
+  PUBLICATION 'mz_source' TABLE utf8_table (f1 TEXT PRIMARY KEY, f2 TEXT);
 
 #
 # Perform sanity checks of the initial snapshot

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -69,6 +69,19 @@ ALTER TABLE utf8_table REPLICA IDENTITY FULL;
 CREATE TABLE no_replica_identity (f1 INTEGER);
 INSERT INTO no_replica_identity VALUES (1), (2);
 
+CREATE TABLE "таблица" ("колона" TEXT);
+ALTER TABLE "таблица" REPLICA IDENTITY FULL;
+INSERT INTO "таблица" VALUES ('стойност');
+
+CREATE TABLE conflict_table (f1 INTEGER);
+ALTER TABLE conflict_table REPLICA IDENTITY FULL;
+INSERT INTO conflict_table VALUES (123);
+
+CREATE SCHEMA conflict_schema;
+CREATE TABLE conflict_schema.conflict_table (f1 TEXT);
+ALTER TABLE conflict_schema.conflict_table REPLICA IDENTITY FULL;
+INSERT INTO conflict_schema.conflict_table VALUES ('234');
+
 ## CREATE SOURCE with correct information should pass purification and fail afterwards.
 
 > CREATE SOURCE "schema_omitted"
@@ -247,6 +260,11 @@ incorrect column specification: 3 columns were specified, upstream has 2: pk, f2
 1
 2
 
+! CREATE MATERIALIZED SOURCE "conflict_table"
+  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
+  PUBLICATION 'mz_source' TABLE conflict_table (f1 TEXT)
+incorrect column specification: specified column does not match upstream source
+
 #
 # Establish direct replication
 #
@@ -287,6 +305,14 @@ incorrect column specification: 3 columns were specified, upstream has 2: pk, f2
   FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
   PUBLICATION 'mz_source' TABLE utf8_table (f1 TEXT PRIMARY KEY, f2 TEXT);
 
+> CREATE MATERIALIZED SOURCE "таблица"
+  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
+  PUBLICATION 'mz_source' TABLE "таблица" ("колона" TEXT);
+
+> CREATE MATERIALIZED SOURCE "conflict_table"
+  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
+  PUBLICATION 'mz_source' TABLE conflict_schema.conflict_table
+
 #
 # Perform sanity checks of the initial snapshot
 #
@@ -322,6 +348,12 @@ incorrect column specification: 3 columns were specified, upstream has 2: pk, f2
 
 > SELECT * FROM utf8_table;
 "това е текст" "това \'е\' \"текст\""
+
+> SELECT * FROM "таблица";
+стойност
+
+> SELECT * FROM conflict_table;
+234
 
 #
 # Confirm that the new sources can be used to build upon
@@ -386,6 +418,7 @@ UPDATE nulls_table SET f2 = NULL WHERE f2 = 2;
 INSERT INTO utf8_table VALUES ('това е текст 2', 'това ''е'' "текст" 2');
 UPDATE utf8_table SET f1 = f1 || f1 , f2 = f2 || f2;
 
+INSERT INTO "таблица" SELECT * FROM "таблица";
 #
 # Check the updated data on the Materialize side
 #
@@ -429,6 +462,10 @@ UPDATE utf8_table SET f1 = f1 || f1 , f2 = f2 || f2;
 "това е текст 2това е текст 2" "това \'е\' \"текст\" 2това \'е\' \"текст\" 2"
 "това е тексттова е текст" "това \'е\' \"текст\"това \'е\' \"текст\""
 
+> SELECT * FROM "таблица";
+стойност
+стойност
+
 > SELECT * FROM join_view;
 "2" "two_two" "2" "2"
 "2" "two_two" "2" "2"
@@ -459,6 +496,8 @@ DELETE FROM trailing_space_nopk;
 DELETE FROM multipart_pk;
 DELETE FROM nulls_table;
 DELETE FROM utf8_table;
+DELETE FROM "таблица";
+DELETE FROM conflict_schema.conflict_table;
 
 #
 # Check that all data sources empty out on the Materialize side
@@ -489,6 +528,12 @@ true
 true
 
 > SELECT COUNT(*) = 0 FROM join_view;
+true
+
+> SELECT COUNT(*) = 0 FROM "таблица";
+true
+
+> SELECT COUNT(*) = 0 FROM conflict_table;
 true
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres


### PR DESCRIPTION
Previously we used a NAMESPACE string to specify the namespace/schema
of a postgres replication source. For most sources this was a
redundant "public" specifier that no one cared about. It was needed to
be able to determine the OID of the table. We can instead parse the
table as an object name, and then convert it to an ast-safe string
that can include a namespace if needed by a user.

This greatly simplifies the syntax and should feel more native to
users of materialize, who might otherwise be surprisied that in this
one specific place, you used to have to quote your table name.