### PR TITLE
issue 6305 FETCH 0 does not return immediately

### DIFF
--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -831,15 +831,22 @@ where
                 ExecuteCount::Count(usize::cast_from(count))
             }
         };
-        let cursor_name = name.to_string();
-        self.execute(
-            cursor_name,
-            count,
-            fetch_message,
-            fetch_portal_name,
-            timeout,
-        )
-        .await
+        match count {
+            ExecuteCount::Count(0) => {
+                Ok(State::Ready)
+            },
+            _ => {
+                let cursor_name = name.to_string();
+                self.execute(
+                    cursor_name,
+                    count,
+                    fetch_message,
+                    fetch_portal_name,
+                    timeout,
+                )
+                .await
+            }
+        }
     }
 
     async fn flush(&mut self) -> Result<State, io::Error> {


### PR DESCRIPTION
This is a very simplistic fix, trap the edge case and return
immediately. I don't see how to test this in an automated fashion, it
was only tested manually.