### PR TITLE
introduce temporal filters as rfc

### DIFF
--- a/doc/developer/design/20210426_temporal_filters.md
+++ b/doc/developer/design/20210426_temporal_filters.md
@@ -1,6 +1,13 @@
 # Temporal Filters
 
-Materialize is able to introduce and remove records as a function of timestamps presented as data in the records.
+## Summary
+
+<!--
+// Brief, high-level overview. A few sentences long.
+// Be sure to capture the customer impact - framing this as a release note may be useful.
+-->
+
+Materialize will be able to introduce and remove records as a function of timestamps presented as data in the records.
 This is performed using idiomatic SQL, with some restrictions, but it can be hard to understand at first.
 
 Consider the following SQL query:
@@ -17,7 +24,30 @@ In particular, in a maintained query any row will not be present at timestamps b
 Materialize does not re-evaluate the predicate every millisecond for every row.
 Understanding what Materialize does do may help you understand the behavior of and restrictions on temporal filters.
 
-## Manipulating timestamped updates
+## Goals
+
+<!--
+// Enumerate the concrete goals that are in scope for the project.
+-->
+
+Allow users to allow users to express constraints between their data and Materialize's logical time, and thereby enable more efficient implementation.
+
+## Non-goals
+
+<!--
+// Enumerate potential goals that are explicitly out of scope for the project
+// ie. what could we do or what do we want to do in the future - but are not doing now
+-->
+
+Allow users to manipulate timestamps or watermarks directly.
+Enable temporal patterns other than those enabled by idiomatic SQL use of `WHERE` clauses.
+
+## Description
+
+<!--
+// Describe the approach in detail. If there is no clear frontrunner, feel free to list all approaches in alternatives.
+// If applicable, be sure to call out any new testing/validation that will be required
+-->
 
 Materialize records *updates* to collections of data.
 Each updates has the form `(data, time, diff)`, and indicates that the occurence count of `data` changes at "logical timestamp" `time` by `diff`.
@@ -45,13 +75,13 @@ Any conjunction of these inequalities is valid, including just bounding `mz_logi
 
 The inequality cannot be "not equal" (`!=` or `<>`) as this results in a "hole" rather than an upper and lower bound.
 
-## Correctness
+### Correctness
 
 Using a temporal filter does not ensure that a record will be present at `valid_from`.
 The update that introduces a record has its own logical timestamp, and a temporal filter can only advance that time.
 To ensure precise validity consider using a CDC format that allows you to specify update timestamps explicitly.
 
-## Performance
+### Performance
 
 Materialize will re-evaluate downstream views at each timestamp presented to them.
 These timestamps are denominated in milliseconds, but are often much more coarse-grained because of a source's timestamping policy.
@@ -68,3 +98,30 @@ Temporal filters allow you to introduce updates arbitrarily far in the future.
 Materialize is optimized to maintain collections and queries "now", and it is not optimized as a data store for far-future updates.
 Until the timestamps in your temporal bounds come to pass, each record will impose an ongoing cost in memory and compute to Materialize.
 If you find you need to use far-future times and the performance is less acceptable than with near-term times, please get in touch.
+
+## Alternatives
+
+<!--
+// Similar to the Description section. List of alternative approaches considered, pros/cons or why they were not chosen
+-->
+
+One alternative is to require users to manually supply retractions and such themselves, using a format like MzCDC.
+This approach provides direct control to the user, and minimizes the surprise to the user who presumably is doing this only once they understand the implications.
+At the same time, this is a substantial barrier to correct use.
+Additionally, there can be moments half-way through a dataflow where a temporal filter constraint could make sense, which could not be effected at the boundary.
+
+Another alternative would be to adopt syntax from existing streaming systems for describing several enumerated flavors of windows (e.g. SLIDING, TUMBLING, HOPPING, SESSION).
+These would be a substantial syntactic departure from "vanilla SQL", but would reach those users whose queries are currently in this form.
+These windows are generally restrictive, in ways that temporal filters need not be (e.g. they preclude general validity intervals)
+
+## Open questions
+
+<!--
+// Anything currently unanswered that needs specific focus. This section may be expanded during the doc meeting as
+// other unknowns are pointed out.
+// These questions may be technical, product, or anything in-between.
+-->
+
+The implementation of temporal filters as an operator has been easy, but there is potential fall-out when downstream operators must manage far-future updates.
+To date this has not been problematic, and it has somewhat simple solutions (e.g. put a priority queue right after the temporal filter), but we should watch for this.
+Additionally, some approaches to fault tolerance presume that the state of a query will only include updates at times that have been accepted in the input; temporal filters violates this principle.

--- a/doc/developer/design/20210426_temporal_filters.md
+++ b/doc/developer/design/20210426_temporal_filters.md
@@ -30,7 +30,7 @@ Understanding what Materialize does do may help you understand the behavior of a
 // Enumerate the concrete goals that are in scope for the project.
 -->
 
-Allow users to allow users to express constraints between their data and Materialize's logical time, and thereby enable more efficient implementation.
+To allow users to express constraints between their data and Materialize's logical time, and thereby enable more efficient implementation.
 
 ## Non-goals
 


### PR DESCRIPTION
This PR moves the existing developer documentation about temporal filters into a design RFC so that we can agree to stabilize it.