### PR TITLE
End-to-end Postgres -> Debezium -> Kafka/Avro - Mz test

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -227,6 +227,14 @@ steps:
           composition: dbt-materialize
           run: ci
 
+  - id: debezium-avro
+    label: "Debezium Avro test"
+    depends_on: build
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: debezium-avro
+          run: debezium-avro
+
   - id: pg-cdc
     label: "Postgres CDC test"
     depends_on: build

--- a/test/debezium-avro/02-add-primary-key.td.gh6570
+++ b/test/debezium-avro/02-add-primary-key.td.gh6570
@@ -1,0 +1,34 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Test adding a primary key over an existing column
+#
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+CREATE TABLE alter_add_primary_key (f1 INTEGER);
+INSERT INTO alter_add_primary_key VALUES (123), (234);
+
+> CREATE MATERIALIZED SOURCE alter_add_primary_key
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'postgres.public.alter_add_primary_key'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE DEBEZIUM;
+
+> SELECT * FROM alter_add_primary_key;
+123
+234
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE alter_add_primary_key ADD PRIMARY KEY (f1);
+INSERT INTO alter_add_primary_key VALUES (345);
+DELETE FROM alter_add_primary_key WHERE f1 = 123;
+
+> SELECT * FROM alter_add_primary_key;
+234
+345

--- a/test/debezium-avro/02-drop-primary-key.td.gh6521
+++ b/test/debezium-avro/02-drop-primary-key.td.gh6521
@@ -1,0 +1,35 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Test that dropping the primary key is handled correctly
+#
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+CREATE TABLE alter_drop_primary_key (f1 INTEGER PRIMARY KEY);
+INSERT INTO alter_drop_primary_key VALUES (123);
+
+> CREATE MATERIALIZED SOURCE alter_drop_primary_key
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'postgres.public.alter_drop_primary_key'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE DEBEZIUM;
+
+> SELECT * FROM alter_drop_primary_key;
+123
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+CREATE SEQUENCE pk_sequence;
+ALTER TABLE alter_drop_primary_key DROP CONSTRAINT alter_drop_primary_key_pkey;
+INSERT INTO alter_drop_primary_key VALUES (123);
+
+> SELECT COUNT(*) = 2 FROM alter_drop_primary_key;
+true
+
+> SELECT DISTINCT f1 FROM alter_drop_primary_key;
+123

--- a/test/debezium-avro/03-drop-not-null-column.td
+++ b/test/debezium-avro/03-drop-not-null-column.td
@@ -1,0 +1,34 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Check that DROP COLUMN on a NOT NULL column is handled. No NULLs should
+# appear in the stream at a column that was NOT NULLable
+#
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+CREATE TABLE alter_drop_column_not_null (f1 INTEGER, col_not_null INTEGER NOT NULL);
+INSERT INTO alter_drop_column_not_null VALUES (123, 234);
+
+> CREATE MATERIALIZED SOURCE alter_drop_column_not_null
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'postgres.public.alter_drop_column_not_null'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE DEBEZIUM;
+
+> SELECT * FROM alter_drop_column_not_null;
+123 234
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE alter_drop_column_not_null DROP COLUMN col_not_null;
+INSERT INTO alter_drop_column_not_null VALUES (345);
+
+# An error is thrown instead of returning nulls in a NOT NULL column
+
+! SELECT * FROM alter_drop_column_not_null;
+Reader field `col_not_null` not found in writer, and has no default

--- a/test/debezium-avro/04-drop-column-nullable.td
+++ b/test/debezium-avro/04-drop-column-nullable.td
@@ -1,0 +1,34 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Test DROP COLUMN on nullable columns
+#
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+CREATE TABLE alter_drop_column (f1 INTEGER, col_null_no_default INTEGER, col_null_default INTEGER DEFAULT 999);
+INSERT INTO alter_drop_column VALUES (123, 234, 345);
+
+> CREATE MATERIALIZED SOURCE alter_drop_column
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'postgres.public.alter_drop_column'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE DEBEZIUM;
+
+> SELECT * FROM alter_drop_column;
+123 234 345
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE alter_drop_column DROP COLUMN col_null_default;
+INSERT INTO alter_drop_column VALUES (123);
+
+# The DEFAULT 999 clause is ignored, NULLs are returned for col_null_default
+
+> SELECT * FROM alter_drop_column;
+123 234 345
+123 <null> <null>

--- a/test/debezium-avro/05-add-column-primary-key.td.gh6570
+++ b/test/debezium-avro/05-add-column-primary-key.td.gh6570
@@ -1,0 +1,36 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Test that adding a primary key as a completely new column does not mess things up
+# Currently rejected by the schema registry on the Debezium side. Replication stops
+#
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+CREATE TABLE alter_add_column_primary_key (f1 INTEGER);
+INSERT INTO alter_add_column_primary_key VALUES (123);
+
+> CREATE MATERIALIZED SOURCE alter_add_column_primary_key
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'postgres.public.alter_add_column_primary_key'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE DEBEZIUM;
+
+> SELECT * FROM alter_add_column_primary_key;
+123
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+CREATE SEQUENCE pk_sequence;
+ALTER TABLE alter_add_column_primary_key ADD COLUMN pk_column INTEGER PRIMARY KEY DEFAULT nextval('pk_sequence');
+INSERT INTO alter_add_column_primary_key VALUES (123,2);
+
+UPDATE alter_add_column_primary_key SET f1 = f1 * 10 WHERE pk_column = 1;
+UPDATE alter_add_column_primary_key SET f1 = f1 * 100 WHERE pk_column = 2;
+
+> SELECT * FROM alter_add_column_primary_key;
+123

--- a/test/debezium-avro/06-add-column-with-update.td
+++ b/test/debezium-avro/06-add-column-with-update.td
@@ -1,0 +1,41 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Test that adding a column does not mess things up.
+# We expect that updates where the data is only different in this column will
+# be handled correctly.
+#
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+CREATE TABLE alter_add_column (f1 INTEGER);
+ALTER TABLE alter_add_column REPLICA IDENTITY FULL;
+INSERT INTO alter_add_column VALUES (123);
+
+> CREATE MATERIALIZED SOURCE alter_add_column
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'postgres.public.alter_add_column'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE DEBEZIUM;
+
+> SELECT * FROM alter_add_column;
+123
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE alter_add_column ADD COLUMN new_column INTEGER DEFAULT 1;
+INSERT INTO alter_add_column VALUES (123,2);
+
+UPDATE alter_add_column SET f1 = f1 * 10 WHERE new_column = 1;
+UPDATE alter_add_column SET f1 = f1 * 100 WHERE new_column = 2;
+
+# Even though we do not have new_column in our source, we expect that the
+# updates above have landed on the appropriate distinct rows
+
+> SELECT * FROM alter_add_column;
+1230
+12300

--- a/test/debezium-avro/07-add-column-with-delete.td
+++ b/test/debezium-avro/07-add-column-with-delete.td
@@ -1,0 +1,51 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Test that adding a column does not mess things up.
+# We expect that deletes where the data is only different in this column will
+# be handled correctly.
+#
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+CREATE TABLE alter_add_column_with_delete (f1 INTEGER);
+ALTER TABLE alter_add_column_with_delete REPLICA IDENTITY FULL;
+INSERT INTO alter_add_column_with_delete VALUES (123),(123),(123),(123);
+
+> CREATE MATERIALIZED SOURCE alter_add_column_with_delete
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'postgres.public.alter_add_column_with_delete'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE DEBEZIUM;
+
+> SELECT * FROM alter_add_column_with_delete;
+123
+123
+123
+123
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE alter_add_column_with_delete ADD COLUMN new_column INTEGER DEFAULT 1;
+INSERT INTO alter_add_column_with_delete VALUES (123,2);
+INSERT INTO alter_add_column_with_delete VALUES (123,2);
+DELETE FROM alter_add_column_with_delete WHERE new_column = 2;
+
+# Even though we do not have new_column in our source, we expect that the
+# updates above have landed on the appropriate distinct rows
+
+> SELECT * FROM alter_add_column_with_delete;
+123
+123
+123
+123
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+DELETE FROM alter_add_column_with_delete WHERE new_column = 1;
+
+> SELECT COUNT(*) = 0 FROM alter_add_column_with_delete;
+true

--- a/test/debezium-avro/08-primary-key-extend.td.gh6570
+++ b/test/debezium-avro/08-primary-key-extend.td.gh6570
@@ -1,0 +1,37 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Extend the number of columns that participate in a primary key
+# Currently, this throws an error on the Debezium side and replication stops
+#
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+CREATE TABLE alter_extend_primary_key (f1 INTEGER, f2 INTEGER, PRIMARY KEY (f1));
+ALTER TABLE alter_extend_primary_key REPLICA IDENTITY FULL;
+INSERT INTO alter_extend_primary_key VALUES (123, 234), (345, 456);
+
+> CREATE MATERIALIZED SOURCE alter_extend_primary_key
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'postgres.public.alter_extend_primary_key'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE DEBEZIUM;
+
+> SELECT * FROM alter_extend_primary_key;
+123 234
+345 456
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE alter_extend_primary_key DROP CONSTRAINT alter_extend_primary_key_pkey, ADD PRIMARY KEY (f1, f2);
+INSERT INTO alter_extend_primary_key VALUES (123, 567);
+DELETE FROM alter_extend_primary_key WHERE f1 = 345;
+
+# The updates after the ALTER TABLE are not replicated as replication has stopped
+> SELECT * FROM alter_extend_primary_key;
+123 234
+345 456

--- a/test/debezium-avro/08-primary-key-shrink.td.gh6570
+++ b/test/debezium-avro/08-primary-key-shrink.td.gh6570
@@ -1,0 +1,36 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Shrink the number of columns that participate in a primary key
+# Currently, this throws an error on the Debezium side and replication stops
+#
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+CREATE TABLE alter_shrink_primary_key (f1 INTEGER DEFAULT 1, f2 INTEGER DEFAULT 2, PRIMARY KEY (f1, f2));
+ALTER TABLE alter_shrink_primary_key REPLICA IDENTITY FULL;
+INSERT INTO alter_shrink_primary_key VALUES (123,234),(345,456);
+
+> CREATE MATERIALIZED SOURCE alter_shrink_primary_key
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'postgres.public.alter_shrink_primary_key'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE DEBEZIUM;
+
+> SELECT * FROM alter_shrink_primary_key;
+123 234
+345 456
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE alter_shrink_primary_key DROP COLUMN f2, ADD PRIMARY KEY (f1);
+INSERT INTO alter_shrink_primary_key VALUES (567);
+DELETE FROM alter_shrink_primary_key WHERE f1 = 123;
+
+> SELECT * FROM alter_shrink_primary_key;
+345
+567

--- a/test/debezium-avro/09-add-nullability.td.gh6522
+++ b/test/debezium-avro/09-add-nullability.td.gh6522
@@ -1,0 +1,36 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Change the definition of a column to be NOT NULL
+#
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+CREATE TABLE alter_allow_nullability (f1 INTEGER NOT NULL);
+ALTER TABLE alter_allow_nullability REPLICA IDENTITY FULL;
+INSERT INTO alter_allow_nullability VALUES (123),(234);
+
+> CREATE MATERIALIZED SOURCE alter_allow_nullability
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'postgres.public.alter_allow_nullability'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE DEBEZIUM;
+
+> SELECT * FROM alter_allow_nullability;
+123
+234
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE alter_allow_nullability ALTER COLUMN f1 DROP NOT NULL;
+INSERT INTO alter_allow_nullability VALUES (NULL);
+UPDATE alter_allow_nullability SET f1 = NULL WHERE f1 = 123;
+DELETE FROM alter_allow_nullability WHERE f1 = 234;
+
+> SELECT * FROM alter_allow_nullability;
+<null>
+<null>

--- a/test/debezium-avro/10-remove-nullability.td.gh6570
+++ b/test/debezium-avro/10-remove-nullability.td.gh6570
@@ -1,0 +1,36 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Change the definition of a column to be NOT NULL
+#
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+CREATE TABLE alter_remove_nullability (f1 INTEGER);
+ALTER TABLE alter_remove_nullability REPLICA IDENTITY FULL;
+INSERT INTO alter_remove_nullability VALUES (123),(234);
+
+> CREATE MATERIALIZED SOURCE alter_remove_nullability
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'postgres.public.alter_remove_nullability'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE DEBEZIUM;
+
+> SELECT * FROM alter_remove_nullability;
+123
+234
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE alter_remove_nullability ALTER COLUMN f1 SET NOT NULL;
+INSERT INTO alter_remove_nullability VALUES (345);
+UPDATE alter_remove_nullability SET f1 = 456 WHERE f1 = 123;
+DELETE FROM alter_remove_nullability WHERE f1 = 234;
+
+> SELECT * FROM alter_remove_nullability;
+345
+456

--- a/test/debezium-avro/11-change-date-timestamp.td
+++ b/test/debezium-avro/11-change-date-timestamp.td
@@ -1,0 +1,35 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Change a column from DATE to TIMESTAMP is not allowed
+#
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+CREATE TABLE alter_change_date_timestamp (f1 DATE);
+ALTER TABLE alter_change_date_timestamp REPLICA IDENTITY FULL;
+INSERT INTO alter_change_date_timestamp VALUES ('2011-11-11'),('2012-12-12');
+
+> CREATE MATERIALIZED SOURCE alter_change_date_timestamp
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'postgres.public.alter_change_date_timestamp'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE DEBEZIUM;
+
+> SELECT * FROM alter_change_date_timestamp;
+2011-11-11
+2012-12-12
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE alter_change_date_timestamp ALTER COLUMN f1 TYPE TIMESTAMP;
+INSERT INTO alter_change_date_timestamp VALUES ('2011-11-11 11:11:11');
+UPDATE alter_change_date_timestamp SET f1 = '2012-12-12 12:12:12' WHERE f1 = '2012-12-12';
+DELETE FROM alter_change_date_timestamp WHERE f1 = '2011-11-11';
+
+! SELECT * FROM alter_change_date_timestamp;
+Failed to match TimestampMicro against any variant in the reader

--- a/test/debezium-avro/12-change-decimal.td.gh6536
+++ b/test/debezium-avro/12-change-decimal.td.gh6536
@@ -1,0 +1,38 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Change the definition of a DECIMAL column
+#
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+CREATE TABLE alter_change_decimal (f1 DECIMAL(5,3));
+ALTER TABLE alter_change_decimal REPLICA IDENTITY FULL;
+INSERT INTO alter_change_decimal VALUES (0),(NULL),(12.345);
+
+> CREATE MATERIALIZED SOURCE alter_change_decimal
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'postgres.public.alter_change_decimal'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE DEBEZIUM;
+
+> SELECT * FROM alter_change_decimal;
+<null>
+0.000
+12.345
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE alter_change_decimal ALTER COLUMN f1 TYPE DECIMAL(6,4);
+INSERT INTO alter_change_decimal VALUES (23.456);
+UPDATE alter_change_decimal SET f1 = 34.567 WHERE f1 = 0;
+
+> SELECT * FROM alter_change_decimal;
+12.345
+234.560
+345.670
+<null>

--- a/test/debezium-avro/20-types-temporal.td.gh6535
+++ b/test/debezium-avro/20-types-temporal.td.gh6535
@@ -1,0 +1,31 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Make sure that temporal types are properly replicated, including sub-second precision
+#
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+CREATE TABLE temporal_types (date_col DATE, time_col TIME, timestamp_col TIMESTAMP);
+ALTER TABLE temporal_types REPLICA IDENTITY FULL;
+INSERT INTO temporal_types VALUES ('2011-11-11', '11:11:11.123456', '2011-11-11 11:11:11.123456');
+
+> CREATE MATERIALIZED SOURCE temporal_types
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'postgres.public.temporal_types'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE DEBEZIUM;
+
+> SELECT * FROM temporal_types;
+2011-11-11 11:11:11.123456 "2011-11-11 11:11:11.123456"
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+UPDATE temporal_types SET date_col = '2012-12-12', time_col = '12:12:12.234567', timestamp_col = '2012-12-12 12:12:12.234567';
+
+> SELECT * FROM temporal_types;
+2012-12-12 12:12:12.234567 "2012-12-12 12:12:12.234567"

--- a/test/debezium-avro/21-types-boolean.td
+++ b/test/debezium-avro/21-types-boolean.td
@@ -1,0 +1,34 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Make sure that the boolean type is replicated correctly
+#
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+CREATE TABLE boolean_type (pk_col BOOLEAN PRIMARY KEY, nopk_col BOOLEAN);
+ALTER TABLE boolean_type REPLICA IDENTITY FULL;
+INSERT INTO boolean_type VALUES (TRUE, TRUE);
+INSERT INTO boolean_type VALUES (FALSE, FALSE);
+
+> CREATE MATERIALIZED SOURCE boolean_type
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'postgres.public.boolean_type'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE DEBEZIUM;
+
+> SELECT * FROM boolean_type;
+true true
+false false
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+UPDATE boolean_type SET nopk_col = NULL WHERE pk_col = TRUE;
+DELETE FROM boolean_type WHERE pk_col = FALSE;
+
+> SELECT * FROM boolean_type;
+true <null>

--- a/test/debezium-avro/22-types-double.td
+++ b/test/debezium-avro/22-types-double.td
@@ -1,0 +1,39 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Make sure that the double type is replicated correctly
+#
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+CREATE TABLE double_type (f1 DOUBLE PRECISION);
+ALTER TABLE double_type REPLICA IDENTITY FULL;
+INSERT INTO double_type VALUES (NULL), ('Infinity'),('-Infinity'), ('NaN');
+
+> CREATE MATERIALIZED SOURCE double_type
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'postgres.public.double_type'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE DEBEZIUM;
+
+> SELECT * FROM double_type;
+<null>
+inf
+-inf
+NaN
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+UPDATE double_type SET f1 = 123 WHERE f1 = 'Infinity';
+UPDATE double_type SET f1 = -123 WHERE f1 = '-Infinity';
+UPDATE double_type SET f1 = NULL WHERE f1 = 'NaN';
+
+> SELECT * FROM double_type;
+<null>
+<null>
+123
+-123

--- a/test/debezium-avro/23-types-decimal.td
+++ b/test/debezium-avro/23-types-decimal.td
@@ -1,0 +1,41 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Make sure that the decimal type is replicated correctly
+#
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+CREATE TABLE decimal_type (f1 DECIMAL(5,3));
+ALTER TABLE decimal_type REPLICA IDENTITY FULL;
+INSERT INTO decimal_type VALUES (NULL), (NULL), (12.345), ('NaN');
+
+> CREATE MATERIALIZED SOURCE decimal_type
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'postgres.public.decimal_type'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE DEBEZIUM;
+
+# NaN arrives as NULL
+
+> SELECT * FROM decimal_type;
+12.345
+<null>
+<null>
+<null>
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+UPDATE decimal_type SET f1 = NULL WHERE f1 = 'NaN';
+UPDATE decimal_type SET f1 = 0.123 WHERE f1 = 12.345;
+UPDATE decimal_type SET f1 = 'NaN' WHERE f1 IS NULL;
+
+> SELECT * FROM decimal_type;
+<null>
+<null>
+<null>
+0.123

--- a/test/debezium-avro/24-types-enum.td
+++ b/test/debezium-avro/24-types-enum.td
@@ -1,0 +1,26 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Make sure that the ENUM type is replicated correctly
+#
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+CREATE TYPE enum1 AS ENUM ('val1', 'val2');
+CREATE TABLE enum_type ( f1 enum1);
+INSERT INTO enum_type VALUES ('val1'), ('val2');
+
+> CREATE MATERIALIZED SOURCE enum_type
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'postgres.public.enum_type'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE DEBEZIUM;
+
+> SELECT pg_typeof(f1), f1 FROM enum_type;
+text val1
+text val2

--- a/test/debezium-avro/24-types-money.bug
+++ b/test/debezium-avro/24-types-money.bug
@@ -1,0 +1,25 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Make sure that the MONEY type is replicated correctly
+#
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+CREATE TABLE money_type (f1 MONEY);
+ALTER TABLE money_type REPLICA IDENTITY FULL;
+INSERT INTO money_type VALUES (NULL), (12.34);
+
+> CREATE MATERIALIZED SOURCE money_type
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'postgres.public.money_type'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE DEBEZIUM;
+
+! SELECT * FROM money_type;
+decimals with precision greater than 38 are not supported

--- a/test/debezium-avro/25-types-array.td
+++ b/test/debezium-avro/25-types-array.td
@@ -1,0 +1,22 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# ARRAY columns are not supported
+#
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+CREATE TABLE array_type (f1 integer[3][3]);
+INSERT INTO array_type VALUES ('{{1,2,3},{4,5,6},{7,8,9}}');
+
+! CREATE MATERIALIZED SOURCE array_type
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'postgres.public.array_type'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE DEBEZIUM;
+Unsupported type in schema

--- a/test/debezium-avro/26-types-bytea.td
+++ b/test/debezium-avro/26-types-bytea.td
@@ -1,0 +1,41 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Make sure that the BYTEA type is replicated correctly
+#
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+CREATE TABLE bytea_type (f1 BYTEA);
+ALTER TABLE bytea_type REPLICA IDENTITY FULL;
+INSERT INTO bytea_type VALUES (NULL), (''), (E'\\x00'), (E'\\xABCDEF1234');
+
+> CREATE MATERIALIZED SOURCE bytea_type
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'postgres.public.bytea_type'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE DEBEZIUM;
+
+# There is \\x124 below instead of \x1234 but apparently this is outside of Mz
+# as Mz returns the correct length and the correct output in the psql client
+> SELECT f1, length(f1), f1 = E'\\xABCDEF1234' FROM bytea_type;
+"" 0 false
+<null> <null> <null>
+"\\x00" 1 false
+"\\xab\\xcd\\xef\\x124" 5 true
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+UPDATE bytea_type SET f1 = E'\\xFFFF' WHERE f1 IS NULL;
+UPDATE bytea_type SET f1 = NULL WHERE f1 = E'\\xABCDEF1234';
+UPDATE bytea_type SET f1 = E'\\x0000' WHERE f1 = E'\\x00';
+
+> SELECT f1, length(f1) FROM bytea_type;
+"" "0"
+<null> <null>
+"\\x00\\x00" 2
+"\\xff\\xff" 2

--- a/test/debezium-avro/27-types-hstore.td
+++ b/test/debezium-avro/27-types-hstore.td
@@ -1,0 +1,27 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Make sure that the HSTORE type is replicated correctly
+#
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+CREATE EXTENSION IF NOT EXISTS hstore;
+CREATE TABLE hstore_type (f1 hstore);
+ALTER TABLE hstore_type REPLICA IDENTITY FULL;
+INSERT INTO hstore_type VALUES (NULL), ('a=>1'::hstore);
+
+> CREATE MATERIALIZED SOURCE hstore_type
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'postgres.public.hstore_type'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE DEBEZIUM;
+
+> SELECT f1, f1 ->> 'a', pg_typeof(f1) FROM hstore_type;
+<null> <null> jsonb
+"{\"a\":\"1\"}" 1 jsonb

--- a/test/debezium-avro/33-toasted-values.td
+++ b/test/debezium-avro/33-toasted-values.td
@@ -1,0 +1,41 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Make sure that TOAST-ed values are handled correctly.
+#
+# TOAST-ed values are values larger than around 8Kb
+# see https://debezium.io/documentation/reference/connectors/postgresql.html#postgresql-toasted-values
+# and https://www.postgresql.org/docs/current/storage-toast.html
+#
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+CREATE TABLE toasted_full (f1 text);
+ALTER TABLE toasted_full REPLICA IDENTITY FULL;
+INSERT INTO toasted_full VALUES (NULL), (REPEAT('a', 32 * 1024) || 'b');
+
+> CREATE MATERIALIZED SOURCE toasted_full
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'postgres.public.toasted_full'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE DEBEZIUM;
+
+> SELECT length(f1) = (32 * 1024) + 1, substr(f1, 1, 2), substr(f1, 32 * 1024, 2) FROM toasted_full;
+<null> <null> <null>
+true aa ab
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+UPDATE toasted_full SET f1 = (REPEAT('c', 32 * 1024) || 'd') WHERE f1 IS NULL;
+UPDATE toasted_full SET f1 = (REPEAT('e', 32 * 1024) || 'f') WHERE f1 = REPEAT('a', 32 * 1024) || 'b';
+
+> SELECT length(f1) = (32 * 1024) + 1, substr(f1, 1, 2), substr(f1, 32 * 1024, 2) FROM toasted_full;
+true cc cd
+true ee ef
+
+# The documentation says that we do not support REPLICA IDENTITY DEFAULT, which is the more interesting
+# case, so we are not testing that here.

--- a/test/debezium-avro/34-replica-identity-default.td
+++ b/test/debezium-avro/34-replica-identity-default.td
@@ -1,0 +1,38 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# A cursory check for REPLICA IDENTITY DEFAULT. It is not a supported
+# configuration but we should not panic.
+#
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+CREATE TABLE replica_identity_default (f1 INTEGER, f2 INTEGER, f3 INTEGER, PRIMARY KEY (f1));
+ALTER TABLE replica_identity_default REPLICA IDENTITY DEFAULT;
+INSERT INTO replica_identity_default VALUES (1,1,1), (2,2,2), (3,3,3), (4,4,4);
+
+> CREATE MATERIALIZED SOURCE replica_identity_default
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'postgres.public.replica_identity_default'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE DEBEZIUM;
+
+> SELECT * FROM replica_identity_default
+1 1 1
+2 2 2
+3 3 3
+4 4 4
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+UPDATE replica_identity_default SET f2 = 5 WHERE f1 = 1;
+UPDATE replica_identity_default SET f3 = 5 WHERE f1 = 2;
+DELETE FROM replica_identity_default WHERE f1 = 3;
+UPDATE replica_identity_default SET f1 = 5 WHERE f1 = 4;
+
+! SELECT * FROM replica_identity_default;
+Invalid data in source, saw retractions

--- a/test/debezium-avro/40-truncate-table.td.DBZ-3469
+++ b/test/debezium-avro/40-truncate-table.td.DBZ-3469
@@ -1,0 +1,37 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Check that TRUNCATE table is properly replicated. Debezium is supposed
+# to issue a dedicated TRUNCATE message on the topic, however instead
+# it suffers an internal JAva exception and replication stops
+#
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+CREATE TABLE truncate_table (f1 INTEGER PRIMARY KEY);
+INSERT INTO truncate_table VALUES (1),(2),(3);
+
+> CREATE MATERIALIZED SOURCE truncate_table
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'postgres.public.truncate_table'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE DEBEZIUM;
+
+> SELECT * FROM truncate_table;
+1
+2
+3
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+TRUNCATE TABLE truncate_table;
+INSERT INTO truncate_table VALUES (2),(3),(4);
+
+> SELECT * FROM truncate_table;
+2
+3
+4

--- a/test/debezium-avro/50-large-transaction.td.bug6555
+++ b/test/debezium-avro/50-large-transaction.td.bug6555
@@ -1,0 +1,52 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# Test that large transactions are properly replicated
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+DROP TABLE IF EXISTS ten;
+CREATE TABLE ten (f1 INTEGER);
+INSERT INTO ten VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10);
+CREATE TABLE large_distinct_rows (f1 INTEGER, PRIMARY KEY (f1));
+ALTER TABLE large_distinct_rows REPLICA IDENTITY FULL;
+CREATE TABLE large_same_rows (f1 INTEGER);
+ALTER TABLE large_same_rows REPLICA IDENTITY FULL;
+CREATE SEQUENCE large_transaction_sequence;
+BEGIN;
+INSERT INTO large_distinct_rows SELECT nextval('large_transaction_sequence') FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4, ten AS a5, ten AS a6;
+INSERT INTO large_same_rows SELECT 1 FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4, ten AS a5, ten AS a6;
+COMMIT;
+
+> CREATE MATERIALIZED SOURCE large_distinct_rows
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'postgres.public.large_distinct_rows'
+  WITH (consistency = 'postgres.transaction')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE DEBEZIUM;
+
+> CREATE MATERIALIZED SOURCE large_same_rows
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'postgres.public.large_same_rows'
+  WITH (consistency = 'postgres.transaction')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE DEBEZIUM;
+
+> SELECT COUNT(*), COUNT(DISTINCT f1), MIN(f1), MAX(f1) FROM large_distinct_rows
+1000000 1000000 1 1000000
+
+> SELECT COUNT(*), COUNT(DISTINCT f1), MIN(f1), MAX(f1) FROM large_same_rows;
+1000000 1 1 1
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+UPDATE large_distinct_rows SET f1 = f1 + 1000000;
+UPDATE large_same_rows SET f1 = 2;
+
+> SELECT COUNT(*), COUNT(DISTINCT f1), MIN(f1), MAX(f1) FROM large_distinct_rows
+1000000 1000000 1000001 2000000
+
+> SELECT COUNT(*), COUNT(DISTINCT f1), MIN(f1), MAX(f1) FROM large_same_rows
+1000000 1 2 2

--- a/test/debezium-avro/60-update-pk-values.td.bug6555
+++ b/test/debezium-avro/60-update-pk-values.td.bug6555
@@ -1,0 +1,37 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Make sure that moving a record from one PK to another works
+#
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+DROP TABLE IF EXISTS ten;
+CREATE TABLE ten (f1 INTEGER);
+INSERT INTO ten VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10);
+CREATE SEQUENCE update_pk_values_sequence;
+CREATE TABLE update_pk_values (f1 INTEGER, PRIMARY KEY (f1));
+ALTER TABLE update_pk_values REPLICA IDENTITY FULL;
+BEGIN;
+INSERT INTO update_pk_values VALUES (1);
+COMMIT;
+
+> CREATE MATERIALIZED SOURCE update_pk_values
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'postgres.public.update_pk_values'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE DEBEZIUM;
+
+> SELECT COUNT(*), COUNT(DISTINCT f1), MIN(f1), MAX(f1) FROM update_pk_values;
+1 1 1 1
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+UPDATE update_pk_values SET f1 = f1 + 1;
+
+> SELECT COUNT(*), COUNT(DISTINCT f1), MIN(f1), MAX(f1) FROM update_pk_values;
+1 1 2 2

--- a/test/debezium-avro/90-decimal-handling-mode.td
+++ b/test/debezium-avro/90-decimal-handling-mode.td
@@ -1,0 +1,125 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Start with decimal.handling.mode PRECISE
+#
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+CREATE TABLE decimal_handling_mode_precise (f1 DECIMAL(10,3) PRIMARY KEY);
+INSERT INTO decimal_handling_mode_precise VALUES (1234567.890);
+
+> CREATE MATERIALIZED SOURCE decimal_handling_mode_precise
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'postgres.public.decimal_handling_mode_precise'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE DEBEZIUM;
+
+> SELECT f1, pg_typeof(f1) FROM decimal_handling_mode_precise
+1234567.890 numeric(10,3)
+
+#
+# Set decimal.handling.mode to DOUBLE
+#
+
+$ http-request method=PUT url=http://debezium:8083/connectors/psql-connector/config content-type=application/json
+{
+  "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
+  "database.hostname": "postgres",
+  "database.port": "5432",
+  "database.user": "debezium",
+  "database.password": "debezium",
+  "database.dbname" : "postgres",
+  "database.server.name": "postgres",
+  "plugin.name": "pgoutput",
+  "slot.name" : "tester",
+  "database.history.kafka.bootstrap.servers": "kafka:9092",
+  "database.history.kafka.topic": "schema-changes.history",
+  "truncate.handling.mode": "include",
+  "provide.transaction.metadata": "true",
+  "decimal.handling.mode": "double"
+}
+
+# PUT requests do not take effect immediately, we need to sleep
+
+> SELECT mz_internal.mz_sleep(10)
+<null>
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+CREATE TABLE decimal_handling_mode_double (f1 DECIMAL(10,3) PRIMARY KEY);
+INSERT INTO decimal_handling_mode_double VALUES (2234567.890);
+
+> CREATE MATERIALIZED SOURCE decimal_handling_mode_double
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'postgres.public.decimal_handling_mode_double'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE DEBEZIUM;
+
+> SELECT f1, pg_typeof(f1) FROM decimal_handling_mode_double;
+2234567.89 "double precision"
+
+#
+# Set decimal.handling.mode to STRING
+#
+
+$ http-request method=PUT url=http://debezium:8083/connectors/psql-connector/config content-type=application/json
+{
+  "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
+  "database.hostname": "postgres",
+  "database.port": "5432",
+  "database.user": "debezium",
+  "database.password": "debezium",
+  "database.dbname" : "postgres",
+  "database.server.name": "postgres",
+  "plugin.name": "pgoutput",
+  "slot.name" : "tester",
+  "database.history.kafka.bootstrap.servers": "kafka:9092",
+  "database.history.kafka.topic": "schema-changes.history",
+  "truncate.handling.mode": "include",
+  "provide.transaction.metadata": "true",
+  "decimal.handling.mode": "string"
+}
+
+> SELECT mz_internal.mz_sleep(10)
+<null>
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+CREATE TABLE decimal_handling_mode_string (f1 DECIMAL(10,3) PRIMARY KEY);
+INSERT INTO decimal_handling_mode_string VALUES (3234567.890);
+
+> CREATE MATERIALIZED SOURCE decimal_handling_mode_string
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'postgres.public.decimal_handling_mode_string'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE DEBEZIUM;
+
+> SELECT f1, pg_typeof(f1) FROM decimal_handling_mode_string;
+3234567.890 text
+
+#
+# Restore default
+#
+
+$ http-request method=PUT url=http://debezium:8083/connectors/psql-connector/config content-type=application/json
+{
+  "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
+  "database.hostname": "postgres",
+  "database.port": "5432",
+  "database.user": "debezium",
+  "database.password": "debezium",
+  "database.dbname" : "postgres",
+  "database.server.name": "postgres",
+  "plugin.name": "pgoutput",
+  "slot.name" : "tester",
+  "database.history.kafka.bootstrap.servers": "kafka:9092",
+  "database.history.kafka.topic": "schema-changes.history",
+  "truncate.handling.mode": "include",
+  "provide.transaction.metadata": "true",
+  "decimal.handling.mode": "precise"
+}
+
+> SELECT mz_internal.mz_sleep(10)
+<null>

--- a/test/debezium-avro/91-hstore-handling-mode.td
+++ b/test/debezium-avro/91-hstore-handling-mode.td
@@ -1,0 +1,73 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Test hstore.handling.mode = MAP
+# Not currently supported
+#
+
+$ http-request method=PUT url=http://debezium:8083/connectors/psql-connector/config content-type=application/json
+{
+  "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
+  "database.hostname": "postgres",
+  "database.port": "5432",
+  "database.user": "debezium",
+  "database.password": "debezium",
+  "database.dbname" : "postgres",
+  "database.server.name": "postgres",
+  "plugin.name": "pgoutput",
+  "slot.name" : "tester",
+  "database.history.kafka.bootstrap.servers": "kafka:9092",
+  "database.history.kafka.topic": "schema-changes.history",
+  "truncate.handling.mode": "include",
+  "provide.transaction.metadata": "true",
+  "hstore.handling.mode": "map"
+}
+
+# PUT requests do not take effect immediately, we need to sleep
+
+> SELECT mz_internal.mz_sleep(10)
+<null>
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+CREATE EXTENSION IF NOT EXISTS hstore;
+CREATE TABLE hstore_map (f1 hstore);
+ALTER TABLE hstore_map REPLICA IDENTITY FULL;
+INSERT INTO hstore_map VALUES (NULL), ('a=>1'::hstore);
+
+! CREATE MATERIALIZED SOURCE hstore_map
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'postgres.public.hstore_map'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE DEBEZIUM;
+Unsupported type in schema
+
+#
+# Restore default
+#
+
+$ http-request method=PUT url=http://debezium:8083/connectors/psql-connector/config content-type=application/json
+{
+  "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
+  "database.hostname": "postgres",
+  "database.port": "5432",
+  "database.user": "debezium",
+  "database.password": "debezium",
+  "database.dbname" : "postgres",
+  "database.server.name": "postgres",
+  "plugin.name": "pgoutput",
+  "slot.name" : "tester",
+  "database.history.kafka.bootstrap.servers": "kafka:9092",
+  "database.history.kafka.topic": "schema-changes.history",
+  "truncate.handling.mode": "include",
+  "provide.transaction.metadata": "true",
+  "hstore.handling.mode": "json"
+}
+
+> SELECT mz_internal.mz_sleep(10)
+<null>

--- a/test/debezium-avro/README.md
+++ b/test/debezium-avro/README.md
@@ -1,0 +1,9 @@
+This is an end-to-end test that spawns a Postgres -> Debezium -> Kafka -> Materialize pipeline
+and then performs various operations on it, including DDL and schema migrations
+
+To run:
+
+./mzcompose down -v ; ./mzcompose run debezium-avro
+
+The tests are numbered so that 01-initialize.td runs before all others and 9*.td run
+after all others, since they modify the Debezium configuration on the fly.

--- a/test/debezium-avro/debezium-postgres.td.initialize
+++ b/test/debezium-avro/debezium-postgres.td.initialize
@@ -1,0 +1,60 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Note that this file is *not* reentrant. Neither Postgres nor
+# Debezium allow error-free dropping of objects (users or connectors)
+# that may or may not exist using the same set of commands for all
+# cases.
+#
+# Furthermore, doing a couple of REST calls against the same Debezium
+# connector is an easy way to bork it, so please always do
+#
+# ./mzcompose -down v
+#
+# before running this test framework again.
+#
+
+#
+# Configure the Postgres side
+#
+# we could use postgres:postgres as our Debezium user, however our
+# documentation suggests the creation of a dedicated user, so
+# we do the same in the test.
+#
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+CREATE USER debezium WITH SUPERUSER PASSWORD 'debezium';
+GRANT ALL PRIVILEGES ON DATABASE "postgres" TO debezium;
+GRANT ALL PRIVILEGES ON SCHEMA "public" TO debezium;
+
+#
+# Configure the Debezium side
+#
+
+$ http-request method=POST url=http://debezium:8083/connectors content-type=application/json
+{
+  "name": "psql-connector",
+  "config": {
+    "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
+    "database.hostname": "postgres",
+    "database.port": "5432",
+    "database.user": "debezium",
+    "database.password": "debezium",
+    "database.dbname" : "postgres",
+    "database.server.name": "postgres",
+    "plugin.name": "pgoutput",
+    "slot.name" : "tester",
+    "database.history.kafka.bootstrap.servers": "kafka:9092",
+    "database.history.kafka.topic": "schema-changes.history",
+    "truncate.handling.mode": "include",
+    "provide.transaction.metadata": "true",
+    "decimal.handling.mode": "precise"
+  }
+}

--- a/test/debezium-avro/mzcompose
+++ b/test/debezium-avro/mzcompose
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# mzcompose — runs Docker Compose with Materialize customizations.
+
+exec "$(dirname "$0")/../../bin/mzcompose" "$@"

--- a/test/debezium-avro/mzcompose.yml
+++ b/test/debezium-avro/mzcompose.yml
@@ -1,0 +1,139 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+version: '3.7'
+
+mzworkflows:
+  debezium-avro:
+    steps:
+      - step: workflow
+        workflow: start-deps
+
+      - step: run
+        service: testdrive-svc
+        command: debezium-postgres.td.initialize
+
+      - step: run
+        service: testdrive-svc
+        command: ${TD_TEST:-*.td}
+
+  start-deps:
+    steps:
+      - step: start-services
+        services: [postgres, kafka, schema-registry, materialized, debezium]
+      - step: wait-for-tcp
+        host: kafka
+        port: 9092
+        timeout_secs: 120
+      - step: wait-for-tcp
+        host: schema-registry
+        port: 8081
+      - step: wait-for-tcp
+        host: debezium
+        port: 8083
+      - step: wait-for-mz
+      - step: wait-for-postgres
+        dbname: postgres
+
+services:
+  testdrive-svc:
+    mzbuild: testdrive
+    entrypoint:
+      - bash
+      - -c
+      - >-
+        testdrive
+        --kafka-addr=kafka:9092
+        --schema-registry-url=http://schema-registry:8081
+        --materialized-url=postgres://materialize@materialized:6875
+        --validate-catalog=/share/mzdata/catalog
+        --no-reset
+        --default-timeout 60
+        $$*
+      - bash
+    environment:
+    - TMPDIR=/share/tmp
+    - MZ_LOG
+    - AWS_ACCESS_KEY_ID
+    - AWS_SECRET_ACCESS_KEY
+    - AWS_SESSION_TOKEN
+    - AWS_SECURITY_TOKEN
+    volumes:
+    - .:/workdir
+    - mzdata:/share/mzdata
+    - tmp:/share/tmp
+    propagate-uid-gid: true
+    init: true
+    depends_on: [kafka, zookeeper, schema-registry, materialized, debezium]
+  materialized:
+    mzbuild: materialized
+    command: >-
+      --data-directory=/share/mzdata
+      --workers 1
+      --experimental
+      --cache-max-pending-records 1
+      --timestamp-frequency 100ms
+      --disable-telemetry
+      --retain-prometheus-metrics 1s
+    ports:
+      - 6875
+    environment:
+    - MZ_DEV=1
+    - MZ_LOG
+    - AWS_ACCESS_KEY_ID
+    - AWS_SECRET_ACCESS_KEY
+    - AWS_SESSION_TOKEN
+    - AWS_SECURITY_TOKEN
+    - ALL_PROXY
+    volumes:
+    - mzdata:/share/mzdata
+    - tmp:/share/tmp
+  zookeeper:
+    image: confluentinc/cp-zookeeper:5.5.3
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+  kafka:
+    image: confluentinc/cp-kafka:5.5.3
+    environment:
+    - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+    - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092
+    - KAFKA_AUTO_CREATE_TOPICS_ENABLE=true
+    - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+  schema-registry:
+    image: confluentinc/cp-schema-registry:5.5.3
+    environment:
+    - SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=PLAINTEXT://kafka:9092
+    - SCHEMA_REGISTRY_HOST_NAME=localhost
+    depends_on: [kafka, zookeeper]
+  postgres:
+    image: postgres:11.4
+    ports:
+      - 5432
+    command: postgres -c wal_level=logical -c max_wal_senders=20 -c max_replication_slots=20
+  debezium:
+    image: debezium/connect:1.5
+    hostname: debezium
+    ports:
+      - 8083
+    environment:
+      BOOTSTRAP_SERVERS: kafka:9092
+      CONFIG_STORAGE_TOPIC: connect_configs
+      OFFSET_STORAGE_TOPIC: connect_offsets
+      STATUS_STORAGE_TOPIC: connect_statuses
+      # We don't support JSON, so ensure that connect uses AVRO to encode messages and CSR to
+      # record the schema
+      KEY_CONVERTER: io.confluent.connect.avro.AvroConverter
+      VALUE_CONVERTER: io.confluent.connect.avro.AvroConverter
+      CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL: http://schema-registry:8081
+      CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL: http://schema-registry:8081
+    depends_on: [kafka, schema-registry]
+
+volumes:
+  mzdata:
+  tmp:


### PR DESCRIPTION
A mzcompose-based test that sets up a complete Debezium pipeline
and uses testdrive to run queries through it.

Tests that are currently failing have also been pushed with an
extension that specifies the ticket number. Those tests will be
ignored by the mzcompose testdrive workflow

An attempt was made to test the following things:
- various Postgres data types
- various Postgres DDLs
- some Debezium options that pertain to the format the data it shipped to Mz
- the consistency topic

The outcome was generally as follows:
- if the schema registry sends a rejection to Debezium , replication will stop and Mz will not be notified
- if the schema registry accepts a schema change, Mz may also accept it and inconsistency can occur in certain cases.

Any feedback and suggestions for future testing would be much appreciated!