### PR TITLE
(docs) Add convert_from to SQL Functions 

### DIFF
--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -208,7 +208,7 @@
     description: Number of code points in `s`
 
   - signature: 'convert_from(b: bytea, src_encoding: text) -> text'
-    description: Convert data `b` from original encoding specified by `src_encoding` into text with current database encoding. 
+    description: Convert data `b` from original encoding specified by `src_encoding` into text with current database encoding.
 
   - signature: 'decode(s: text, format: text) -> bytea'
     description: Decode `s` using the specified textual representation.

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -207,6 +207,9 @@
   - signature: 'char_length(s: str) -> int'
     description: Number of code points in `s`
 
+  - signature: 'convert_from(b: bytea, src_encoding: text) -> text'
+    description: Convert data `b` from original encoding specified by `src_encoding` into text with current database encoding. 
+
   - signature: 'decode(s: text, format: text) -> bytea'
     description: Decode `s` using the specified textual representation.
     url: encode

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -208,7 +208,7 @@
     description: Number of code points in `s`
 
   - signature: 'convert_from(b: bytea, src_encoding: text) -> text'
-    description: Convert data `b` from original encoding specified by `src_encoding` into text with current database encoding.
+    description: Convert data `b` from original encoding specified by `src_encoding` into `text`.
 
   - signature: 'decode(s: text, format: text) -> bytea'
     description: Decode `s` using the specified textual representation.


### PR DESCRIPTION
Adds convert_from function to list of SQL functions, convert_from is discussed elsewhere on JSON Source pages like this: https://materialize.com/docs/sql/create-source/json-kafka/#extracting-json-data-from-bytes

![image](https://user-images.githubusercontent.com/11527560/116124495-5cf61800-a692-11eb-8646-fa092b931469.png)
