### PR TITLE
sql: implement CREATE SOURCES FROM POSTGRES

### DIFF
--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1075,12 +1075,15 @@ pub fn plan_create_sources(
 ) -> Result<Plan, anyhow::Error> {
     scx.require_experimental_mode("Postgres Sources")?;
     let CreateSourcesStatement { stmts, .. } = stmt;
-    let mut planned = vec![];
+    let mut sources = vec![];
     for stmt in stmts {
-        planned.push(plan_create_source(scx, stmt)?);
+        match plan_create_source(scx, stmt)? {
+            Plan::CreateSource(plan) => sources.push(plan),
+            _ => unreachable!("non-create source plan"),
+        }
     }
 
-    unsupported!("CREATE SOURCES");
+    Ok(Plan::CreateSources { sources })
 }
 
 pub fn describe_create_view(

--- a/test/pg-cdc/mzcompose.yml
+++ b/test/pg-cdc/mzcompose.yml
@@ -32,7 +32,7 @@ services:
     mzbuild: materialized
     command: --experimental --disable-telemetry
     ports:
-      - 6875
+      - 6875:6875
     environment:
     - MZ_DEV=1
     - MZ_LOG
@@ -40,5 +40,5 @@ services:
   postgres:
     image: postgres:11.4
     ports:
-      - 5432
+      - 5432:5432
     command: postgres -c wal_level=logical -c max_wal_senders=20 -c max_replication_slots=20

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -146,22 +146,6 @@ incorrect column specification: specified column modifiers do not match upstream
     TABLE numbers (number int PRIMARY KEY, is_prime bool, name text NOT NULL)
 incorrect column specification: specified column modifiers do not match upstream source, specified: name text NOT NULL, upstream: name text NULL
 
-## CREATE SOURCES with correct information should pass purification and fail afterwards.
-
-! CREATE SOURCES
-  FROM POSTGRES
-    HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-    PUBLICATION 'mz_source'
-    TABLES (numbers AS "numbers")
-CREATE SOURCES not yet supported
-
-! CREATE SOURCES
-  FROM POSTGRES
-    HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-    PUBLICATION 'mz_source'
-    TABLES (numbers AS "numbers", numbers AS "second_numbers" (number int PRIMARY KEY, is_prime bool NULL, name text NULL))
-CREATE SOURCES not yet supported
-
 ## CREATE SOURCES with incorrect information should fail purification.
 
 ! CREATE SOURCES
@@ -177,6 +161,21 @@ incorrect column specification: 1 columns were specified, upstream has 3: number
     PUBLICATION 'mz_source'
     TABLES (numbers AS "numbers" (number int NULL, is_prime bool NULL, name text))
 incorrect column specification: specified column modifiers do not match upstream source, specified: number int4 NULL, upstream: number int4 PRIMARY KEY NOT NULL
+
+! CREATE SOURCES
+  FROM POSTGRES
+    HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
+    PUBLICATION 'mz_source'
+    TABLES ()
+Expected identifier, found right parenthesis
+
+## CREATE SOURCES
+
+> CREATE MATERIALIZED SOURCES
+  FROM POSTGRES
+    HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
+    PUBLICATION 'mz_source'
+    TABLES (numbers AS "numbers_from_sources", numbers AS "second_numbers_from_sources" (number int PRIMARY KEY, is_prime bool, name text))
 
 #
 # Error checking
@@ -354,6 +353,21 @@ incorrect column specification: specified column does not match upstream source
 
 > SELECT * FROM conflict_table;
 234
+
+> SELECT * FROM numbers_from_sources;
+5 true five
+
+> SELECT * FROM second_numbers_from_sources;
+5 true five
+
+#
+# Confirm that we can independently DROP individual sources created via CREATE SOURCES
+#
+
+> DROP SOURCE numbers_from_sources;
+
+> SELECT COUNT(*) = 1 FROM second_numbers_from_sources;
+true
 
 #
 # Confirm that the new sources can be used to build upon


### PR DESCRIPTION
Fully implements `CREATE SOURCES FROM POSTGRES`. Each of the created
sources will, in turn, create its own replication slot. Sharing
an underlying replication slot is left for future work.