### PR TITLE
Optimization: Filter(unique_key = literal) results in a one-row input

### DIFF
--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -248,8 +248,10 @@ impl MirRelationExpr {
                         }
                     }
                     if rows.len() == 0 || (rows.len() == 1 && rows[0].1 == 1) {
-                        typ.clone().with_key(Vec::new())
+                        RelationType::new(typ.column_types.clone()).with_key(vec![])
                     } else {
+                        // TODO: Have the keys of the constant be the columns
+                        // containing unique values
                         typ.clone()
                     }
                 } else {
@@ -343,7 +345,34 @@ impl MirRelationExpr {
                 let typ = RelationType::new(input_typ.column_types);
                 typ
             }
-            MirRelationExpr::Filter { input, .. } => input.typ(),
+            MirRelationExpr::Filter { input, predicates } => {
+                // A filter inherits the keys of its input unless the filters
+                // have reduced the input to a single row, in which case the
+                // keys of the input are `()`.
+                let mut input_typ = input.typ();
+                let cols_equal_to_literal = predicates
+                    .iter()
+                    .filter_map(|p| {
+                        if let MirScalarExpr::CallBinary {
+                            func: crate::BinaryFunc::Eq,
+                            expr1,
+                            expr2,
+                        } = p
+                        {
+                            if let MirScalarExpr::Column(c) = &**expr1 {
+                                if expr2.is_literal_ok() {
+                                    return Some(c);
+                                }
+                            }
+                        }
+                        None
+                    })
+                    .collect::<Vec<_>>();
+                for key_set in &mut input_typ.keys {
+                    key_set.retain(|k| !cols_equal_to_literal.contains(&k));
+                }
+                input_typ
+            }
             MirRelationExpr::Join {
                 inputs,
                 equivalences,
@@ -468,7 +497,7 @@ impl MirRelationExpr {
                 // If there are A, B, each with a unique `key` such that
                 // we are looking at
                 //
-                //     A + (B - A.proj(key)).map(stuff)
+                //     A.proj(set_containg_key) + (B - A.proj(key)).map(stuff)
                 //
                 // Then we can report `key` as a unique key.
                 //
@@ -478,11 +507,20 @@ impl MirRelationExpr {
                 // subset of B, as otherwise there are negative records
                 // and who knows what is true (not expected, but again
                 // who knows what the query plan might look like).
+
+                let (base_projection, base_with_project_stripped) =
+                    if let MirRelationExpr::Project { input, outputs } = &**base {
+                        (outputs.clone(), &**input)
+                    } else {
+                        // A input without a project is equivalent to an input
+                        // with the project being all columns in the input in order.
+                        ((0..base_cols.len()).collect::<Vec<_>>(), &**base)
+                    };
                 let mut keys = Vec::new();
                 if let MirRelationExpr::Get {
                     id: first_id,
                     typ: _,
-                } = &**base
+                } = base_with_project_stripped
                 {
                     if inputs.len() == 1 {
                         if let MirRelationExpr::Map { input, .. } = &inputs[0] {
@@ -501,6 +539,8 @@ impl MirRelationExpr {
                                                             |key| {
                                                                 key.iter().all(|c| {
                                                                     outputs.get(*c) == Some(c)
+                                                                        && base_projection.get(*c)
+                                                                            == Some(c)
                                                                 })
                                                             },
                                                         ),
@@ -515,11 +555,7 @@ impl MirRelationExpr {
                     }
                 }
 
-                let mut result = RelationType::new(base_cols);
-                for key in keys {
-                    result = result.with_key(key);
-                }
-                result
+                RelationType::new(base_cols).with_keys(keys)
                 // Important: do not inherit keys of either input, as not unique.
             }
             MirRelationExpr::ArrangeBy { input, .. } => input.typ(),

--- a/test/sqllogictest/column_knowledge.slt
+++ b/test/sqllogictest/column_knowledge.slt
@@ -77,26 +77,16 @@ EXPLAIN SELECT * FROM t1 LEFT JOIN t2 ON (t1.f1 = t2.f1) WHERE t1.f1 = 123;
 | | demand = (#0..#3)
 
 %4 =
-| Get %0 (l0)
-| ArrangeBy ()
-
-%5 =
 | Get %3 (l1)
-| Distinct group=(123)
-
-%6 =
-| Join %4 %5
-| | implementation = Differential %5 %4.()
-| | demand = (#0, #1)
 | Negate
 | Project (#0, #1)
 
-%7 =
-| Union %6 %0
+%5 =
+| Union %4 %0
 | Map null, null
 
-%8 =
-| Union %7 %3
+%6 =
+| Union %5 %3
 
 EOF
 
@@ -122,26 +112,31 @@ EXPLAIN SELECT * FROM t1 LEFT JOIN t2 USING (f1) WHERE t1.f1 = 123;
 
 %4 =
 | Get %3 (l1)
-| Distinct group=(123, #1)
 | Negate
+| Map 123
+| Project (#4, #1)
 
 %5 =
 | Get %0 (l0)
-| Distinct group=(123, #1)
+| Map 123
+| Project (#2, #1)
 
 %6 =
 | Union %4 %5
-| ArrangeBy (#1)
 
 %7 =
-| Join %6 %0 (= #1 #3)
-| | implementation = Differential %0 %6.(#1)
+| Get %0 (l0)
+| ArrangeBy (#1)
+
+%8 =
+| Join %6 %7 (= #1 #3)
+| | implementation = Differential %6 %7.(#1)
 | | demand = (#0, #1)
 | Map null, null
 | Project (#0, #1, #4, #5)
 
-%8 =
-| Union %3 %7
+%9 =
+| Union %3 %8
 | Project (#0, #1, #3)
 
 EOF
@@ -224,64 +219,59 @@ EXPLAIN SELECT (SELECT t1.f1 FROM t1 WHERE t1.f1 = t2.f1) FROM t2 WHERE t2.f1 = 
 | Get materialize.public.t2 (u3)
 | Filter (#0 = 123)
 
-%1 = Let l1 =
+%1 =
 | Get %0 (l0)
-| Distinct group=(123)
-
-%2 =
-| Get %1 (l1)
 | ArrangeBy ()
 
-%3 =
+%2 =
 | Get materialize.public.t1 (u1)
 | Filter (#0 = 123)
 
-%4 = Let l2 =
-| Join %2 %3
-| | implementation = Differential %3 %2.()
-| | demand = (#1)
+%3 = Let l1 =
+| Join %1 %2
+| | implementation = Differential %2 %1.()
+| | demand = (#2)
 
-%5 =
-| Get %4 (l2)
-| Project (#0, #1)
-
-%6 =
-| Get %4 (l2)
-| Reduce group=(123)
-| | agg count(true)
-| Filter (#1 > 1)
-| Map (err: more than one record produced in subquery)
-| Project (#0, #2)
-
-%7 = Let l3 =
-| Union %5 %6
-
-%8 =
+%4 =
 | Get %0 (l0)
 | ArrangeBy ()
 
-%9 =
-| Get %7 (l3)
-| Distinct group=(123)
-| Negate
+%5 =
+| Get %3 (l1)
+| Map 123
+| Project (#4, #2)
 
-%10 =
-| Union %9 %1
+%6 =
+| Get %3 (l1)
+| Negate
+| Map 123
+| Project (#4)
+
+%7 =
+| Get %0 (l0)
+| Map 123
+| Project (#2)
+
+%8 =
+| Union %6 %7
+
+%9 =
+| Get %0 (l0)
 | ArrangeBy ()
 
-%11 =
-| Join %10 %1
-| | implementation = Differential %1 %10.()
+%10 =
+| Join %8 %9
+| | implementation = Differential %8 %9.()
 | | demand = ()
-| Map null
-| Project (#0, #2)
+| Map 123, null
+| Project (#0, #4)
+
+%11 =
+| Union %5 %10
 
 %12 =
-| Union %7 %11
-
-%13 =
-| Join %8 %12
-| | implementation = Differential %12 %8.()
+| Join %4 %11
+| | implementation = Differential %11 %4.()
 | | demand = (#3)
 | Project (#3)
 
@@ -338,26 +328,18 @@ EOF
 query T multiline
 EXPLAIN SELECT * FROM t1 WHERE t1.f1 = 123 AND EXISTS (SELECT * FROM t2 WHERE t2.f1 = t1.f1);
 ----
-%0 = Let l0 =
+%0 =
 | Get materialize.public.t1 (u1)
 | Filter (#0 = 123)
+| ArrangeBy ()
 
 %1 =
-| Get %0 (l0)
-| ArrangeBy ()
-
-%2 =
-| Get %0 (l0)
-| Distinct group=(123)
-| ArrangeBy ()
-
-%3 =
 | Get materialize.public.t2 (u3)
 | Filter (#0 = 123)
 
-%4 =
-| Join %1 %2 %3
-| | implementation = Differential %3 %1.() %2.()
+%2 =
+| Join %0 %1
+| | implementation = Differential %1 %0.()
 | | demand = (#0, #1)
 | Project (#0, #1)
 
@@ -366,44 +348,23 @@ EOF
 query T multiline
 EXPLAIN SELECT * FROM t1 WHERE t1.f1 = 123 AND EXISTS (SELECT * FROM t2 WHERE t2.f1 = t1.f1) AND EXISTS (SELECT * FROM t3 WHERE t3.f1 = t1.f1);
 ----
-%0 = Let l0 =
+%0 =
 | Get materialize.public.t1 (u1)
 | Filter (#0 = 123)
+| ArrangeBy ()
 
 %1 =
-| Get %0 (l0)
+| Get materialize.public.t2 (u3)
+| Filter (#0 = 123)
 | ArrangeBy ()
 
 %2 =
-| Get %0 (l0)
-| Distinct group=(123)
-| ArrangeBy ()
-
-%3 =
-| Get materialize.public.t2 (u3)
-| Filter (#0 = 123)
-
-%4 = Let l1 =
-| Join %1 %2 %3
-| | implementation = Differential %3 %1.() %2.()
-| | demand = (#0, #1)
-
-%5 =
-| Get %4 (l1)
-| ArrangeBy ()
-
-%6 =
-| Get %4 (l1)
-| Distinct group=(123)
-| ArrangeBy ()
-
-%7 =
 | Get materialize.public.t3 (u5)
 | Filter (#0 = 123)
 
-%8 =
-| Join %5 %6 %7
-| | implementation = Differential %7 %5.() %6.()
+%3 =
+| Join %0 %1 %2
+| | implementation = Differential %2 %0.() %1.()
 | | demand = (#0, #1)
 | Project (#0, #1)
 
@@ -541,26 +502,31 @@ EXPLAIN SELECT * FROM t4 AS a1 LEFT JOIN t4 AS a2 USING (f1, f2) WHERE a1.f1 = 1
 
 %4 =
 | Get %3 (l1)
-| Distinct group=(123, 234)
 | Negate
+| Map 123, 234
+| Project (#4, #5)
 
 %5 =
 | Get %0 (l0)
-| Distinct group=(123, 234)
+| Map 123, 234
+| Project (#2, #3)
 
 %6 =
 | Union %4 %5
-| ArrangeBy ()
 
 %7 =
-| Join %6 %0
-| | implementation = Differential %0 %6.()
+| Get %0 (l0)
+| ArrangeBy ()
+
+%8 =
+| Join %6 %7
+| | implementation = Differential %6 %7.()
 | | demand = (#0, #1)
 | Map null, null
 | Project (#0, #1, #4, #5)
 
-%8 =
-| Union %3 %7
+%9 =
+| Union %3 %8
 | Project (#0, #1)
 
 EOF
@@ -591,26 +557,31 @@ EXPLAIN SELECT * FROM t4 AS a1 LEFT JOIN t4 AS a2 USING (f1, f2) WHERE a1.f1 = 1
 
 %4 =
 | Get %3 (l1)
-| Distinct group=(123, 234)
 | Negate
+| Map 123, 234
+| Project (#4, #5)
 
 %5 =
 | Get %0 (l0)
-| Distinct group=(123, 234)
+| Map 123, 234
+| Project (#2, #3)
 
 %6 =
 | Union %4 %5
-| ArrangeBy ()
 
 %7 =
-| Join %6 %0
-| | implementation = Differential %0 %6.()
+| Get %0 (l0)
+| ArrangeBy ()
+
+%8 =
+| Join %6 %7
+| | implementation = Differential %6 %7.()
 | | demand = (#0, #1)
 | Map null, null
 | Project (#0, #1, #4, #5)
 
-%8 =
-| Union %3 %7
+%9 =
+| Union %3 %8
 | Project (#0, #1)
 
 EOF
@@ -641,26 +612,31 @@ EXPLAIN SELECT * FROM t1 LEFT JOIN t2 USING (f1) WHERE t1.f1 = 123 AND t2.f1 = 2
 
 %4 =
 | Get %3 (l1)
-| Distinct group=(123, #1)
 | Negate
+| Map 123
+| Project (#4, #1)
 
 %5 =
 | Get %0 (l0)
-| Distinct group=(123, #1)
+| Map 123
+| Project (#2, #1)
 
 %6 =
 | Union %4 %5
-| ArrangeBy (#1)
 
 %7 =
-| Join %6 %0 (= #1 #3)
-| | implementation = Differential %0 %6.(#1)
+| Get %0 (l0)
+| ArrangeBy (#1)
+
+%8 =
+| Join %6 %7 (= #1 #3)
+| | implementation = Differential %6 %7.(#1)
 | | demand = (#0, #1)
 | Map null, null
 | Project (#0, #1, #4, #5)
 
-%8 =
-| Union %3 %7
+%9 =
+| Union %3 %8
 | Project (#0, #1, #3)
 
 EOF

--- a/test/sqllogictest/transform/topk.slt
+++ b/test/sqllogictest/transform/topk.slt
@@ -78,3 +78,18 @@ EXPLAIN PLAN FOR SELECT * FROM test1 UNION ALL SELECT * FROM test1 UNION ALL SEL
 | Union %0 %1 %2
 
 EOF
+
+# Test that `limit 0` results in an empty constant with () as the keys
+
+statement ok
+CREATE TABLE with_primary_key(a int primary key, b int)
+
+query T multiline
+explain typed plan for select * from (select * from with_primary_key limit 0);
+----
+%0 =
+| Constant
+| | types = (integer, integer)
+| | keys = (())
+
+EOF


### PR DESCRIPTION
It turns out that `ColumnKnowledge` and `ReduceElision` work against each other.

If your plan looks like this:
```
%0 = Let l0 =
| Get source
| Filter (unique_key = literal)
...
%n
| Get l0
| Reduce group_by=(unique_key) agg=(something)​
```

Then `ReduceElision` will eliminate the Reduce and replace it with a `Map + Project`. However, if `ColumnKnowledge` runs first, what `ReduceElision` will see is:

```
%0 = Let l0 =
| Get source
| Filter (unique_key = literal)
...
%n
| Get l0
| Reduce group_by=(literal) agg=(something)​
```

On main, we determine the key of `l0` to be `(unique_key)`, so `ReduceElision` will not eliminate the `Reduce`. 

But actually, the key of `l0` should be `()` since the filter will make it so that the `l0` has either zero or one rows. This PR makes that change so that `ReduceElision` works even if `ColumnKnowledge` runs first.

Also:
* Zero- and single-row constants now have `()` as their only set of keys. As discussed on Slack, it seems like a bug that zero-row constants can have `keys = ((#0), ())`.
* Expand key detection support in union from the pattern `A + (B - A.proj(key)).map(stuff)` to also include the pattern `A.proj(set containing key) + (B - A.proj(key)).map(stuff)`. As I mentioned in meetings last Wednesday, this is needed in order for #5396 to eventually merge. The `A + (B - A.proj(key)).map(stuff)` pattern exists so that an aggregation will return `null` in the event the input has no columns, so `A` is meant to be a reduce. Certain partial reduction pushdowns result in the need to put an extra project around `A`. Specifically, a reduce turns a int32 column into an int64 column and turns an int64 column into a decimal column. A partially pushed down `Sum(int32_column)` reduction results in a decimal column instead of an int64 column, so the extra project around the outer reduce exists to turn the column back into an int64. 