### PR TITLE
testdrive: Increase timeouts for FETCH calls

### DIFF
--- a/test/testdrive/fetch-select-during-ingest.td
+++ b/test/testdrive/fetch-select-during-ingest.td
@@ -33,7 +33,7 @@ $ kafka-ingest format=avro topic=tail-fetch-during-ingest schema=${int} timestam
 
 > DECLARE c CURSOR FOR SELECT * FROM fetch_during_ingest;
 
-> FETCH 1 c WITH (timeout='2s');
+> FETCH 1 c WITH (timeout='60s');
 123
 
 $ kafka-ingest format=avro topic=tail-fetch-during-ingest schema=${int} timestamp=2
@@ -58,6 +58,6 @@ $ kafka-ingest format=avro topic=tail-fetch-during-ingest schema=${int} timestam
 
 > DECLARE c CURSOR FOR SELECT * FROM fetch_during_ingest;
 
-> FETCH 2 c WITH (timeout='2s');
+> FETCH 2 c WITH (timeout='60s');
 123
 234

--- a/test/testdrive/fetch-tail-during-ingest.td
+++ b/test/testdrive/fetch-tail-during-ingest.td
@@ -30,12 +30,12 @@ $ kafka-create-topic topic=tail-fetch-during-ingest
 $ kafka-ingest format=avro topic=tail-fetch-during-ingest schema=${int} timestamp=1
 {"f1": 123}
 
-> FETCH 1 c WITH (timeout='2s');
+> FETCH 1 c WITH (timeout='60s');
 <TIMESTAMP> 1 123
 
 $ kafka-ingest format=avro topic=tail-fetch-during-ingest schema=${int} timestamp=2
 {"f1": 234}
 
 # The row just inserted is ours to fetch
-> FETCH 1 c WITH (timeout='2s');
+> FETCH 1 c WITH (timeout='60s');
 <TIMESTAMP> 1 234

--- a/test/testdrive/fetch-tail-timestamp-zero.td
+++ b/test/testdrive/fetch-tail-timestamp-zero.td
@@ -27,10 +27,10 @@
 
 > DECLARE c2 CURSOR FOR TAIL v2 WITH (PROGRESS = TRUE);
 
-> FETCH 2 FROM c1 WITH (timeout = '3s')
+> FETCH 2 FROM c1 WITH (timeout = '60s')
 0 false 1 123
 
-> FETCH 2 FROM c2 WITH (timeout = '3s')
+> FETCH 2 FROM c2 WITH (timeout = '60s')
 0 false 1 123
 
 > COMMIT;

--- a/test/testdrive/fetch-tail-without-snapshot.td
+++ b/test/testdrive/fetch-tail-without-snapshot.td
@@ -40,5 +40,5 @@ $ kafka-ingest format=avro topic=tail-without-snapshot schema=${int} timestamp=1
 $ kafka-ingest format=avro topic=tail-without-snapshot schema=${int} timestamp=1
 {"f1": 567}
 
-> FETCH 1 FROM c WITH (timeout = '2s')
+> FETCH 1 FROM c WITH (timeout = '60s')
 <TIMESTAMP> 1 567


### PR DESCRIPTION
Due to the semantics of the FETCH call, it is excluded from
testdrive's retry logic. Therefore, it is on the test writer
to provide a timeout value that is high enough so that the tests
do not fail even if run in a constrained environment.

This commit makes all the timeout value for FETCH to be 60s
with the exception of those FETCH-es that are not expected
to return any rows, so that the full minute is not waited on those.