### PR TITLE
WIP: try out new subquery count testing

### DIFF
--- a/test/sqllogictest/column_knowledge.slt
+++ b/test/sqllogictest/column_knowledge.slt
@@ -249,8 +249,8 @@ EXPLAIN SELECT (SELECT t1.f1 FROM t1 WHERE t1.f1 = t2.f1) FROM t2 WHERE t2.f1 = 
 | Get %4 (l2)
 | Reduce group=(123)
 | | agg count(true)
-| Filter (#1 > 1)
-| Map (err: more than one record produced in subquery)
+| Filter if (#1 > 1) then {(err: more than one record produced in subquery)} else {false}
+| Map null
 | Project (#0, #2)
 
 %7 = Let l3 =
@@ -299,8 +299,8 @@ EXPLAIN SELECT (SELECT t1.f1 FROM t1) = t2.f1 FROM t2 WHERE t2.f1 = 123;
 | Get materialize.public.t1 (u1)
 | Reduce group=()
 | | agg count(true)
-| Filter (#0 > 1)
-| Map (err: more than one record produced in subquery)
+| Filter if (#0 > 1) then {(err: more than one record produced in subquery)} else {false}
+| Map null
 | Project (#1)
 
 %2 = Let l0 =
@@ -439,22 +439,10 @@ EXPLAIN SELECT * FROM t1 WHERE 123 = (SELECT t2.f1 FROM t2);
 %1 =
 | Get materialize.public.t2 (u3)
 | Filter (#0 = 123)
-| Project (#0)
 
 %2 =
-| Get materialize.public.t2 (u3)
-| Reduce group=()
-| | agg count(true)
-| Filter (err: more than one record produced in subquery), (#0 > 1)
-| Map (err: more than one record produced in subquery)
-| Project (#1)
-
-%3 =
-| Union %1 %2
-
-%4 =
-| Join %0 %3
-| | implementation = Differential %3 %0.()
+| Join %0 %1
+| | implementation = Differential %1 %0.()
 | | demand = (#0, #1)
 | Project (#0, #1)
 
@@ -471,22 +459,10 @@ EXPLAIN SELECT * FROM t1 WHERE t1.f1 = 123 AND t1.f1 = (SELECT t2.f1 FROM t2);
 %1 =
 | Get materialize.public.t2 (u3)
 | Filter (#0 = 123)
-| Project (#0)
 
 %2 =
-| Get materialize.public.t2 (u3)
-| Reduce group=()
-| | agg count(true)
-| Filter (err: more than one record produced in subquery), (#0 > 1)
-| Map (err: more than one record produced in subquery)
-| Project (#1)
-
-%3 =
-| Union %1 %2
-
-%4 =
-| Join %0 %3
-| | implementation = Differential %3 %0.()
+| Join %0 %1
+| | implementation = Differential %1 %0.()
 | | demand = (#0, #1)
 | Project (#0, #1)
 

--- a/test/sqllogictest/dates-times.slt
+++ b/test/sqllogictest/dates-times.slt
@@ -455,10 +455,10 @@ VALUES
 query T rowsort
 SELECT * FROM timestampwithtzish
 ----
-1999-12-31 06:00:00
-1999-12-31 07:11:01
-1999-12-31 13:46:01
-2000-01-01 08:00:00
+1999-12-31 01:00:00
+1999-12-31 02:11:01
+1999-12-31 08:46:01
+2000-01-01 03:00:00
 
 statement ok
 CREATE TABLE timestamptzish (

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -550,32 +550,17 @@ mode standard
 query T multiline
 EXPLAIN SELECT name, id FROM v4362 WHERE name = (SELECT name FROM v4362 WHERE id = 1)
 ----
-%0 = Let l0 =
-| Get materialize.public.t4362 (u10)
-| Filter (#1 = 1)
-
-%1 =
+%0 =
 | Get materialize.public.t4362 (u10)
 | ArrangeBy (#0)
 
+%1 =
+| Get materialize.public.t4362 (u10)
+| Filter (#1 = 1)
+
 %2 =
-| Get %0 (l0)
-| Project (#0)
-
-%3 =
-| Get %0 (l0)
-| Reduce group=()
-| | agg count(true)
-| Filter (#0 > 1)
-| Map (err: more than one record produced in subquery)
-| Project (#1)
-
-%4 =
-| Union %2 %3
-
-%5 =
-| Join %1 %4 (= #0 #2)
-| | implementation = Differential %4 %1.(#0)
+| Join %0 %1 (= #0 #2)
+| | implementation = Differential %1 %0.(#0)
 | | demand = (#0, #1)
 | Project (#0, #1)
 


### PR DESCRIPTION
This PR tries out a new way to write the test for subquery counts greater than one, that uses a `MirScalarExpr::If` to "ensure" that the error should not leak out for subqueries whose counts are not greater than one. The code previously used a `Filter` against the count, followed by a `Map` that introduces the error. This is technically incorrect, in that the filter is allowed to move, and it could move to the other side of the `Map` expression.

This "fix" also makes it a bit harder for the error to leak out because we do not write it to a column of the results; instead it is the result of the filter. The error being part of the output seems like it should not have been the root of the problem, so I'm not ecstatic about this fixing it (it seems like the evidence of problems gets removed).

There is also a shift in one of the output results that seems totally unrelated (changing some dates and times) that need to be investigated!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6589)
<!-- Reviewable:end -->
