### PR TITLE
Support equality operator for lists

### DIFF
--- a/src/pgrepr/src/oid.rs
+++ b/src/pgrepr/src/oid.rs
@@ -64,3 +64,4 @@ pub const FUNC_MZ_SESSION_ID_OID: u32 = 16_435;
 pub const FUNC_MZ_UPTIME_OID: u32 = 16_436;
 pub const FUNC_MZ_WORKERS_OID: u32 = 16_437;
 pub const TYPE_RDN_OID: u32 = 16_438;
+pub const FUNC_LIST_EQ_OID: u32 = 16_439;

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -2546,6 +2546,7 @@ lazy_static! {
                 params!(Bytes, Bytes) => BinaryFunc::Eq, 1955;
                 params!(String, String) => BinaryFunc::Eq, 98;
                 params!(Jsonb, Jsonb) => BinaryFunc::Eq, 3240;
+                params!(ListAny, ListAny) => BinaryFunc::Eq, oid::FUNC_LIST_EQ_OID;
             },
             "<>" => Scalar {
                 params!(DecimalAny, DecimalAny) => {

--- a/test/sqllogictest/list.slt
+++ b/test/sqllogictest/list.slt
@@ -1886,6 +1886,63 @@ SELECT LIST[1] || '{2}'::text
 query error no overload for f32 list || f64 list: arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
 SELECT '{1}'::float4 list || '{2}'::float8 list
 
+# 🔬🔬 equality (=)
+
+# 🔬🔬🔬 list = list
+
+query T
+SELECT LIST[1, 2] = LIST[1, 2]
+----
+true
+
+query T
+SELECT LIST[1, 2] = LIST[1, 3]
+----
+false
+
+query T
+SELECT LIST[[1], [2]] = LIST[[1], [2]]
+----
+true
+
+query T
+SELECT LIST[[1], [2]] = LIST[[1], [3]]
+----
+false
+
+# Equality properly casts text to appropriate list type
+query T
+SELECT LIST[1] = '{1}'
+----
+true
+
+query T
+SELECT LIST[1] = '{2}'
+----
+false
+
+# 🔬🔬🔬 errors
+
+query error no overload for integer list = text list: arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+SELECT LIST[1] = LIST['a']
+
+query error no overload for text list = integer list: arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+SELECT LIST[NULL] = LIST[1]
+
+query error no overload for text list list = integer list: arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+SELECT LIST[[NULL]] = LIST[1]
+
+query error no overload for integer list list list = integer list: arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+SELECT LIST[[[1]]] = LIST[2]
+
+# Literal text cannot be implicitly cast to list
+query error no overload for integer list = text: arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+SELECT LIST[1] = '{2}'::text
+
+# Two lists containing implicitly castable element types are not implicitly castable to one another
+query error no overload for real list = double precision list: arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+SELECT '{1}'::float4 list = '{2}'::float8 list
+
 # 🔬 CREATE TYPE .. AS LIST
 
 query error element_type must be of class type, but received pg_catalog.pg_enum which is of class view


### PR DESCRIPTION
Fixes #6403.

Adds an equality comparison operator on lists and tests to [sqllogictest/list.slt](https://github.com/MaterializeInc/materialize/blob/main/test/sqllogictest/list.slt)

```
materialize=> SELECT List[1,2,3]=List[1,2,3];
 ?column? 
----------
 t
(1 row)
```

Created a `FUNC_LIST_EQ_OID` [here](https://github.com/laurenarnett/materialize/blob/8fb6e24ef7385bc688c8cb8eedf9140f8338fa9a/src/pgrepr/src/oid.rs#L67) but it should probably be grouped with the other `FUNC_LIST_X_OID`s [here](https://github.com/laurenarnett/materialize/blob/8fb6e24ef7385bc688c8cb8eedf9140f8338fa9a/src/pgrepr/src/oid.rs#L21-L26).

Run tests:
```
cargo run --bin sqllogictest -- test/sqllogictest/list.slt -vv
```