### PR TITLE
WIP: source/postgres: present the raw replication stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -813,7 +813,6 @@ dependencies = [
  "ore",
  "pdqselect",
  "postgres-protocol",
- "postgres-util",
  "prometheus",
  "prometheus-static-metric",
  "pubnub-hyper",

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -305,6 +305,8 @@ impl Coordinator {
                         self.indexes
                             .insert(entry.id(), Frontiers::new(self.num_workers(), Some(1_000)));
                     } else {
+                        // TODO(petrosagg): group all indexes that use the same sources in a single
+                        // DataflowDesc
                         let df = self.dataflow_builder().build_index_dataflow(entry.id());
                         self.ship_dataflow(df).await?;
                     }

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -306,7 +306,7 @@ pub enum DataEncoding {
     Protobuf(ProtobufEncoding),
     Csv(CsvEncoding),
     Regex(RegexEncoding),
-    Postgres(RelationDesc),
+    Postgres,
     Bytes,
     Text,
 }
@@ -427,7 +427,16 @@ impl DataEncoding {
             DataEncoding::Text => {
                 key_desc.with_named_column("text", ScalarType::String.nullable(false))
             }
-            DataEncoding::Postgres(desc) => desc.clone(),
+            DataEncoding::Postgres => key_desc
+                .with_named_column("oid", ScalarType::Int32.nullable(false))
+                .with_named_column(
+                    "row",
+                    ScalarType::List {
+                        element_type: Box::new(ScalarType::String),
+                        custom_oid: None,
+                    }
+                    .nullable(false),
+                ),
         })
     }
 
@@ -440,7 +449,7 @@ impl DataEncoding {
             DataEncoding::Regex { .. } => "Regex",
             DataEncoding::Csv(_) => "Csv",
             DataEncoding::Text => "Text",
-            DataEncoding::Postgres(_) => "Postgres",
+            DataEncoding::Postgres => "Postgres",
         }
     }
 }
@@ -766,10 +775,6 @@ pub struct FileSourceConnector {
 pub struct PostgresSourceConnector {
     pub conn: String,
     pub publication: String,
-    // The table's UnresolvedObjectName.to_ast_string(), for use in literal SQL
-    // strings.
-    pub ast_table: String,
-    pub cast_exprs: Vec<MirScalarExpr>,
     pub slot_name: String,
 }
 

--- a/src/dataflow/Cargo.toml
+++ b/src/dataflow/Cargo.toml
@@ -32,7 +32,6 @@ mz-avro = { path = "../avro", features = ["snappy"] }
 ore = { path = "../ore" }
 pdqselect = "0.1.0"
 postgres-protocol = { git = "https://github.com/MaterializeInc/rust-postgres" }
-postgres-util = { path = "../postgres-util" }
 prometheus = { git = "https://github.com/MaterializeInc/rust-prometheus.git", default-features = false }
 prometheus-static-metric = { git = "https://github.com/MaterializeInc/rust-prometheus.git" }
 pubnub-hyper = { git = "https://github.com/MaterializeInc/pubnub-rust", default-features = false }
@@ -49,7 +48,7 @@ serde = { version = "1.0.125", features = ["derive"] }
 serde_json = "1.0.64"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 tokio = { version = "1.5.0", features = ["fs", "rt", "sync"] }
-tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["with-uuid-0_8", "with-chrono-0_4"] }
+tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
 tokio-util = { version = "0.6.6", features = ["codec"] }
 url = { version = "2.2.1", features = ["serde"] }
 uuid = { version = "0.8.2", features = ["serde", "v4"] }

--- a/src/dataflow/src/decode/mod.rs
+++ b/src/dataflow/src/decode/mod.rs
@@ -561,7 +561,7 @@ where
             ),
             None,
         ),
-        (DataEncoding::Postgres(_), _) => {
+        (DataEncoding::Postgres, _) => {
             unreachable!("Internal error: postgres sources are never decoded");
         }
     }

--- a/src/dataflow/src/source/postgres.rs
+++ b/src/dataflow/src/source/postgres.rs
@@ -13,7 +13,6 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{anyhow, bail};
 use async_trait::async_trait;
-use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 use futures::StreamExt;
 use itertools::Itertools;
 use lazy_static::lazy_static;
@@ -21,18 +20,15 @@ use lazy_static::lazy_static;
 use postgres_protocol::message::backend::{
     LogicalReplicationMessage, ReplicationMessage, Tuple, TupleData,
 };
-use tokio_postgres::binary_copy::BinaryCopyOutStream;
 use tokio_postgres::config::{Config, ReplicationMode};
 use tokio_postgres::error::{DbError, Severity, SqlState};
 use tokio_postgres::replication::LogicalReplicationStream;
-use tokio_postgres::types::{PgLsn, Type as PgType};
+use tokio_postgres::types::PgLsn;
 use tokio_postgres::{Client, NoTls, SimpleQueryMessage};
-use uuid::Uuid;
 
 use crate::source::{SimpleSource, SourceError, Timestamper};
 use dataflow_types::PostgresSourceConnector;
-use postgres_util::TableInfo;
-use repr::{Datum, Row, RowArena};
+use repr::{Datum, Row};
 
 lazy_static! {
     /// Postgres epoch is 2000-01-01T00:00:00Z
@@ -93,11 +89,7 @@ impl PostgresSourceReader {
     ///
     /// After the initial snapshot has been produced it returns the name of the created slot and
     /// the LSN at which we should start the replication stream at.
-    async fn produce_snapshot(
-        &mut self,
-        table_info: &TableInfo,
-        timestamper: &Timestamper,
-    ) -> Result<(), anyhow::Error> {
+    async fn produce_snapshot(&mut self, timestamper: &Timestamper) -> Result<(), anyhow::Error> {
         let client = self.connect_replication().await?;
 
         // We're initialising this source so any previously existing slot must be removed and
@@ -108,6 +100,33 @@ impl PostgresSourceReader {
                 &self.connector.slot_name
             ))
             .await;
+
+        // Get all the relevant tables for this publication
+        let publication_tables = client
+            .simple_query(&format!(
+                "SELECT
+                    c.oid, p.schemaname, p.tablename
+                FROM
+                    pg_catalog.pg_class AS c
+                    JOIN pg_namespace AS n ON c.relnamespace = n.oid
+                    JOIN pg_publication_tables AS p ON
+                            c.relname = p.tablename AND n.nspname = p.schemaname
+                WHERE
+                    p.pubname = '{}'",
+                self.connector.publication
+            ))
+            .await?
+            .into_iter()
+            .flat_map(|msg| match msg {
+                SimpleQueryMessage::Row(row) => Some((
+                    row.get("oid").unwrap().parse::<i32>().unwrap(),
+                    row.get("schemaname").unwrap().to_owned(),
+                    row.get("tablename").unwrap().to_owned(),
+                )),
+                SimpleQueryMessage::CommandComplete(_) => None,
+                _ => todo!("unexpected message"),
+            })
+            .collect_vec();
 
         // Start a transaction and immediatelly create a replication slot with the USE SNAPSHOT
         // directive. This makes the starting point of the slot and the snapshot of the transaction
@@ -138,47 +157,25 @@ impl PostgresSourceReader {
             .parse()
             .or_else(|_| Err(anyhow!("invalid lsn")))?;
 
-        let copy_query = format!(
-            r#"COPY {} TO STDOUT WITH (FORMAT binary);"#,
-            self.connector.ast_table,
-        );
-
-        let stream = client.copy_out_simple(&copy_query).await?;
-
-        let scalar_types = table_info
-            .schema
-            .iter()
-            .map(|c| c.scalar_type.clone())
-            .collect_vec();
-
-        let rows = BinaryCopyOutStream::new(stream, &scalar_types);
-        tokio::pin!(rows);
-
         let snapshot_tx = timestamper.start_tx().await;
-        while let Some(row) = rows.next().await.transpose()? {
-            let mut mz_row = Row::default();
-            for (i, ty) in table_info.schema.iter().enumerate() {
-                let datum: Datum = match ty.scalar_type {
-                    PgType::BOOL => row.get::<Option<bool>>(i).into(),
-                    PgType::INT4 => row.get::<Option<i32>>(i).into(),
-                    PgType::INT8 => row.get::<Option<i64>>(i).into(),
-                    PgType::FLOAT4 => row.get::<Option<f32>>(i).into(),
-                    PgType::FLOAT8 => row.get::<Option<f64>>(i).into(),
-                    PgType::DATE => row.get::<Option<NaiveDate>>(i).into(),
-                    PgType::TIME => row.get::<Option<NaiveTime>>(i).into(),
-                    PgType::TIMESTAMP => row.get::<Option<NaiveDateTime>>(i).into(),
-                    PgType::TEXT => row.get::<Option<&str>>(i).into(),
-                    PgType::UUID => row.get::<Option<Uuid>>(i).into(),
-                    ref other => bail!("Unsupported data type {:?}", other),
-                };
 
-                if !ty.nullable && datum.is_null() {
-                    bail!("Got null value in non nullable column");
+        for (rel_id, schema, table) in publication_tables {
+            let data = client
+                .simple_query(&format!("SELECT * FROM {:?}.{:?}", schema, table))
+                .await?;
+
+            for msg in data {
+                if let SimpleQueryMessage::Row(row) = msg {
+                    let mut mz_row = Row::default();
+                    let rel_id: Datum = rel_id.into();
+                    mz_row.push(rel_id);
+                    mz_row.push_list((0..row.len()).map(|n| {
+                        let a: Datum = row.get(n).into();
+                        a
+                    }));
+                    snapshot_tx.insert(mz_row).await?;
                 }
-                mz_row.push(datum);
             }
-
-            snapshot_tx.insert(mz_row).await?;
         }
 
         client.simple_query("COMMIT;").await?;
@@ -188,32 +185,28 @@ impl PostgresSourceReader {
     /// Converts a Tuple received in the replication stream into a Row instance. The logical
     /// replication protocol doesn't use the binary encoding for column values so contrary to the
     /// initial snapshot here we need to parse the textual form of each column.
-    fn row_from_tuple(&mut self, tuple: &Tuple) -> Result<Row, anyhow::Error> {
+    fn row_from_tuple(&mut self, rel_id: u32, tuple: &Tuple) -> Result<Row, anyhow::Error> {
         let mut row = Row::default();
-        let arena = RowArena::new();
 
-        for (val, cast_expr) in tuple
-            .tuple_data()
-            .iter()
-            .zip(self.connector.cast_exprs.iter())
-        {
-            let datum = match val {
-                TupleData::Null => Datum::Null,
-                TupleData::UnchangedToast => bail!("Unsupported TOAST value"),
-                TupleData::Text(b) => {
-                    let txt_datum: Datum = std::str::from_utf8(&b)?.into();
-                    cast_expr.eval(&[txt_datum], &arena)?
-                }
-            };
-            row.push(datum);
-        }
+        let rel_id: Datum = (rel_id as i32).into();
+        row.push(rel_id);
+        row.push_list_with(|packer| {
+            for val in tuple.tuple_data() {
+                let datum = match val {
+                    TupleData::Null => Datum::Null,
+                    TupleData::UnchangedToast => bail!("Unsupported TOAST value"),
+                    TupleData::Text(b) => std::str::from_utf8(&b)?.into(),
+                };
+                packer.push(datum);
+            }
+            Ok(())
+        })?;
 
         Ok(row)
     }
 
     async fn produce_replication(
         &mut self,
-        table_info: &TableInfo,
         timestamper: &Timestamper,
     ) -> Result<(), ReplicationError> {
         use ReplicationError::*;
@@ -247,30 +240,29 @@ impl PostgresSourceReader {
                                 )));
                             }
                         }
-                        // The replication stream might include data from other tables in the
-                        // publication, so we ignore them
-                        Insert(event) if event.rel_id() != table_info.rel_id => continue,
-                        Update(event) if event.rel_id() != table_info.rel_id => continue,
-                        Delete(event) if event.rel_id() != table_info.rel_id => continue,
                         Insert(insert) => {
-                            let row = try_fatal!(self.row_from_tuple(insert.tuple()));
+                            let rel_id = insert.rel_id();
+                            let row = try_fatal!(self.row_from_tuple(rel_id, insert.tuple()));
                             inserts.push(row);
                         }
                         Update(update) => {
+                            let rel_id = update.rel_id();
                             let old_tuple = try_fatal!(update
                                 .old_tuple()
                                 .ok_or_else(|| anyhow!("full row missisng from update")));
-                            let old_row = try_fatal!(self.row_from_tuple(old_tuple));
+                            let old_row = try_fatal!(self.row_from_tuple(rel_id, old_tuple));
                             deletes.push(old_row);
 
-                            let new_row = try_fatal!(self.row_from_tuple(update.new_tuple()));
+                            let new_row =
+                                try_fatal!(self.row_from_tuple(rel_id, update.new_tuple()));
                             inserts.push(new_row);
                         }
                         Delete(delete) => {
+                            let rel_id = delete.rel_id();
                             let old_tuple = try_fatal!(delete
                                 .old_tuple()
                                 .ok_or_else(|| anyhow!("full row missisng from delete")));
-                            let row = try_fatal!(self.row_from_tuple(old_tuple));
+                            let row = try_fatal!(self.row_from_tuple(rel_id, old_tuple));
                             deletes.push(row);
                         }
                         Commit(commit) => {
@@ -355,17 +347,13 @@ impl PostgresSourceReader {
 impl SimpleSource for PostgresSourceReader {
     /// The top-level control of the state machine and retry logic
     async fn start(mut self, timestamper: &Timestamper) -> Result<(), SourceError> {
-        let table_info = postgres_util::table_info(&self.connector.conn, &self.connector.ast_table)
-            .await
-            .map_err(|e| SourceError::FileIO(e.to_string()))?;
-
         // The initial snapshot has no easy way of retrying it in case of connection failures
-        self.produce_snapshot(&table_info, timestamper)
+        self.produce_snapshot(timestamper)
             .await
             .map_err(|e| SourceError::FileIO(e.to_string()))?;
 
         loop {
-            match self.produce_replication(&table_info, timestamper).await {
+            match self.produce_replication(timestamper).await {
                 Ok(_) => log::info!("replication interrupted with no error"),
                 Err(ReplicationError::Recoverable(e)) => {
                     log::info!("replication interrupted: {}", e)

--- a/src/postgres-util/src/lib.rs
+++ b/src/postgres-util/src/lib.rs
@@ -47,67 +47,88 @@ impl_display!(PgColumn);
 pub struct TableInfo {
     /// The OID of the table
     pub rel_id: u32,
+    /// The namespace the table belongs to
+    pub namespace: String,
+    /// The name of the table
+    pub name: String,
     /// The schema of each column, in order
     pub schema: Vec<PgColumn>,
 }
 
-/// Fetches column information from an upstream Postgres source, given
-/// a connection string and a target table.
+/// Fetches table schema information from an upstream Postgres source for all tables that are part
+/// of a publication, given a connection string and the publication name.
 ///
 /// # Errors
 ///
 /// - Invalid connection string, user information, or user permissions.
 /// - Upstream table does not exist or contains invalid values.
-pub async fn table_info(conn: &str, ast_table: &String) -> Result<TableInfo, anyhow::Error> {
+pub async fn publication_info(conn: &str, publication: &str) -> Result<Vec<TableInfo>, anyhow::Error> {
     let (client, connection) = tokio_postgres::connect(&conn, NoTls).await?;
     tokio::spawn(connection);
 
-    let rel_id: u32 = client
-        // The "::regclass::oid" thing converts its LHS to an OID, so this gets
-        // us the OID of a specified table (which can optionally include a schema
-        // namespace). The "::text" is to appease the rust postgres driver since we are
-        // passing a string, not a regclass.
-        .query("SELECT $1::text::regclass::oid", &[ast_table])
-        .await?
-        .get(0)
-        .ok_or_else(|| anyhow!("table not found in the upstream catalog"))?
-        .get(0);
-
-    let schema = client
+    let tables = client
         .query(
             "SELECT
-                    a.attname,
-                    a.atttypid,
-                    a.attnotnull,
-                    b.oid IS NOT NULL
-                FROM pg_catalog.pg_attribute a
-                LEFT JOIN pg_catalog.pg_constraint b
-                    ON a.attrelid = b.conrelid
-                    AND b.contype = 'p'
-                    AND a.attnum = ANY (b.conkey)
-                WHERE a.attnum > 0::pg_catalog.int2
-                    AND NOT a.attisdropped
-                    AND a.attrelid = $1
-                ORDER BY a.attnum",
-            &[&rel_id],
+                c.oid, p.schemaname, p.tablename
+            FROM
+                pg_catalog.pg_class AS c
+                JOIN pg_namespace AS n ON c.relnamespace = n.oid
+                JOIN pg_publication_tables AS p ON
+                        c.relname = p.tablename AND n.nspname = p.schemaname
+            WHERE
+                p.pubname = $1",
+            &[&publication]
         )
-        .await?
-        .into_iter()
-        .map(|row| {
-            let name: String = row.get(0);
-            let oid = row.get(1);
-            let scalar_type =
-                PgType::from_oid(oid).ok_or_else(|| anyhow!("unknown type OID: {}", oid))?;
-            let nullable = !row.get::<_, bool>(2);
-            let primary_key = row.get(3);
-            Ok(PgColumn {
-                name,
-                scalar_type,
-                nullable,
-                primary_key,
-            })
-        })
-        .collect::<Result<Vec<_>, anyhow::Error>>()?;
+        .await?;
 
-    Ok(TableInfo { rel_id, schema })
+    let mut table_infos = vec![];
+    for row in tables {
+        let rel_id = row.get("oid");
+
+        let schema = client
+            .query(
+                "SELECT
+                        a.attname,
+                        a.atttypid,
+                        a.attnotnull,
+                        b.oid IS NOT NULL
+                    FROM pg_catalog.pg_attribute a
+                    LEFT JOIN pg_catalog.pg_constraint b
+                        ON a.attrelid = b.conrelid
+                        AND b.contype = 'p'
+                        AND a.attnum = ANY (b.conkey)
+                    WHERE a.attnum > 0::pg_catalog.int2
+                        AND NOT a.attisdropped
+                        AND a.attrelid = $1
+                    ORDER BY a.attnum",
+                &[&rel_id],
+            )
+            .await?
+            .into_iter()
+            .map(|row| {
+                let name: String = row.get(0);
+                let oid = row.get(1);
+                let scalar_type =
+                    PgType::from_oid(oid).ok_or_else(|| anyhow!("unknown type OID: {}", oid))?;
+                let nullable = !row.get::<_, bool>(2);
+                let primary_key = row.get(3);
+                Ok(PgColumn {
+                    name,
+                    scalar_type,
+                    nullable,
+                    primary_key,
+                })
+            })
+            .collect::<Result<Vec<_>, anyhow::Error>>()?;
+
+        table_infos.push(TableInfo {
+            rel_id,
+            namespace: row.get("schemaname"),
+            name: row.get("tablename"),
+            schema,
+        });
+    }
+
+
+    Ok(table_infos)
 }

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -444,6 +444,8 @@ impl_display_t!(MultiConnector);
 pub struct PgTable<T: AstInfo> {
     /// The name of the table to sync
     pub name: UnresolvedObjectName,
+    /// The OID of the table to sync
+    pub oid: u32,
     /// The name for the table in Materialize
     pub alias: T::ObjectName,
     /// The expected column schema of the synced table

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -276,7 +276,7 @@ impl AstDisplay for DbzMode {
 impl_display!(DbzMode);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum Connector<T: AstInfo> {
+pub enum Connector {
     File {
         path: String,
         compression: Compression,
@@ -307,10 +307,6 @@ pub enum Connector<T: AstInfo> {
         publication: String,
         /// The replication slot name that will be created upstream
         slot: Option<String>,
-        /// The name of the table to sync
-        table: UnresolvedObjectName,
-        /// The expected column schema of the synced table
-        columns: Vec<ColumnDef<T>>,
     },
     PubNub {
         /// PubNub's subscribe key
@@ -320,7 +316,7 @@ pub enum Connector<T: AstInfo> {
     },
 }
 
-impl<T: AstInfo> AstDisplay for Connector<T> {
+impl AstDisplay for Connector {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
             Connector::File { path, compression } => {
@@ -376,8 +372,6 @@ impl<T: AstInfo> AstDisplay for Connector<T> {
             Connector::Postgres {
                 conn,
                 publication,
-                table,
-                columns,
                 slot,
             } => {
                 f.write_str("POSTGRES HOST '");
@@ -388,11 +382,7 @@ impl<T: AstInfo> AstDisplay for Connector<T> {
                     f.write_str("' SLOT '");
                     f.write_str(&display::escape_single_quote_string(slot));
                 }
-                f.write_str("' TABLE ");
-                f.write_node(table);
-                f.write_str(" (");
-                f.write_node(&display::comma_separated(columns));
-                f.write_str(")");
+                f.write_str("'");
             }
             Connector::PubNub {
                 subscribe_key,
@@ -407,7 +397,7 @@ impl<T: AstInfo> AstDisplay for Connector<T> {
         }
     }
 }
-impl_display_t!(Connector);
+impl_display!(Connector);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum MultiConnector<T: AstInfo> {

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -354,7 +354,7 @@ impl_display!(CreateSchemaStatement);
 pub struct CreateSourceStatement<T: AstInfo> {
     pub name: UnresolvedObjectName,
     pub col_names: Vec<Ident>,
-    pub connector: Connector<T>,
+    pub connector: Connector,
     pub with_options: Vec<SqlOption<T>>,
     pub format: Option<Format<T>>,
     pub envelope: Envelope<T>,
@@ -426,7 +426,7 @@ impl_display_t!(CreateSourcesStatement);
 pub struct CreateSinkStatement<T: AstInfo> {
     pub name: UnresolvedObjectName,
     pub from: UnresolvedObjectName,
-    pub connector: Connector<T>,
+    pub connector: Connector,
     pub with_options: Vec<SqlOption<T>>,
     pub format: Option<Format<T>>,
     pub envelope: Option<Envelope<T>>,

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -404,9 +404,9 @@ impl_display_t!(CreateSourceStatement);
 /// `CREATE SOURCES`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CreateSourcesStatement<T: AstInfo> {
-    pub connector: MultiConnector<T>,
     pub materialized: bool,
-    pub stmts: Vec<CreateSourceStatement<T>>,
+    pub source_stmt: CreateSourceStatement<T>,
+    pub view_stmts: Vec<CreateViewStatement<T>>,
 }
 
 impl<T: AstInfo> AstDisplay for CreateSourcesStatement<T> {
@@ -416,7 +416,7 @@ impl<T: AstInfo> AstDisplay for CreateSourcesStatement<T> {
             f.write_str("MATERIALIZED ");
         }
         f.write_str("SOURCES FROM ");
-        f.write_node(&self.connector);
+        // f.write_node(&self.connector);
     }
 }
 impl_display_t!(CreateSourcesStatement);

--- a/src/sql-parser/src/ast/display.rs
+++ b/src/sql-parser/src/ast/display.rs
@@ -165,6 +165,13 @@ impl AstDisplay for u64 {
     }
 }
 
+// u32 used directly to represent, e.g., postgres oids
+impl AstDisplay for u32 {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        f.write_str(self);
+    }
+}
+
 pub struct EscapeSingleQuoteString<'a>(&'a str);
 
 impl<'a> AstDisplay for EscapeSingleQuoteString<'a> {

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1734,7 +1734,7 @@ impl<'a> Parser<'a> {
         }))
     }
 
-    fn parse_connector(&mut self) -> Result<Connector<Raw>, ParserError> {
+    fn parse_connector(&mut self) -> Result<Connector, ParserError> {
         match self.expect_one_of_keywords(&[FILE, KAFKA, KINESIS, AVRO, S3, POSTGRES, PUBNUB])? {
             PUBNUB => {
                 self.expect_keywords(&[SUBSCRIBE, KEY])?;
@@ -1757,25 +1757,11 @@ impl<'a> Parser<'a> {
                 } else {
                     None
                 };
-                self.expect_keyword(TABLE)?;
-                let table = self.parse_object_name()?;
-
-                let (columns, constraints) = self.parse_columns(Optional)?;
-
-                if !constraints.is_empty() {
-                    return parser_err!(
-                        self,
-                        self.peek_prev_pos(),
-                        "Cannot specify constraints in Postgres table definition"
-                    );
-                }
 
                 Ok(Connector::Postgres {
                     conn,
                     publication,
                     slot,
-                    table,
-                    columns,
                 })
             }
             FILE => {

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -499,9 +499,9 @@ CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")
 parse-statement
 CREATE SOURCE psychic FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' TABLE generation1.psychic (pokedex_id int NOT NULL, evolution int);
 ----
-CREATE SOURCE psychic FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' TABLE generation1.psychic (pokedex_id int4 NOT NULL, evolution int4)
-=>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("psychic")]), col_names: [], connector: Postgres { conn: "host=kanto user=ash password=teamrocket dbname=pokemon", publication: "red", slot: None, table: UnresolvedObjectName([Ident("generation1"), Ident("psychic")]), columns: [ColumnDef { name: Ident("pokedex_id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("evolution"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }] }, with_options: [], format: None, envelope: None, if_not_exists: false, materialized: false })
+error: Expected end of statement, found TABLE
+CREATE SOURCE psychic FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' TABLE generation1.psychic (pokedex_id int NOT NULL, evolution int);
+                                                                                                                    ^
 
 parse-statement
 CREATE SOURCE psychic FROM PUBNUB SUBSCRIBE KEY 'subscribe_key' CHANNEL 'channel';
@@ -527,44 +527,44 @@ CREATE SOURCE IF EXISTS foo FROM FILE 'bar' USING SCHEMA ''
 parse-statement
 CREATE SOURCES FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' TABLES ();
 ----
-error: Expected identifier, found right parenthesis
+error: Expected FROM, found POSTGRES
 CREATE SOURCES FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' TABLES ();
-                                                                                                                     ^
+                    ^
 
 parse-statement
 CREATE SOURCES FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' TABLES (SELECT 1);
 ----
-error: Expected AS, found number '1'
+error: Expected FROM, found POSTGRES
 CREATE SOURCES FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' TABLES (SELECT 1);
-                                                                                                                            ^
+                    ^
 
 parse-statement
 CREATE SOURCES FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' TABLES ('public.psychic' (pokedex_id int NOT NULL, evolution int))
 ----
-error: Expected identifier, found string literal 'public.psychic'
+error: Expected FROM, found POSTGRES
 CREATE SOURCES FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' TABLES ('public.psychic' (pokedex_id int NOT NULL, evolution int))
-                                                                                                                     ^
+                    ^
 
 parse-statement
 CREATE SOURCES FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' TABLES (generation1.psychic as "public.psychic" (pokedex_id int NOT NULL, evolution int))
 ----
-CREATE SOURCES FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' TABLES (generation1.psychic AS "public.psychic" (pokedex_id int4 NOT NULL, evolution int4))
-=>
-CreateSources(CreateSourcesStatement { connector: Postgres { conn: "host=kanto user=ash password=teamrocket dbname=pokemon", publication: "red", slot: None, tables: [PgTable { name: UnresolvedObjectName([Ident("generation1"), Ident("psychic")]), alias: Name(UnresolvedObjectName([Ident("public.psychic")])), columns: [ColumnDef { name: Ident("pokedex_id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("evolution"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }] }] }, materialized: false, stmts: [] })
+error: Expected FROM, found POSTGRES
+CREATE SOURCES FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' TABLES (generation1.psychic as "public.psychic" (pokedex_id int NOT NULL, evolution int))
+                    ^
 
 parse-statement
 CREATE SOURCES FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' TABLES (generation1.random.psychic as "public.psychic" (pokedex_id int NOT NULL, evolution int), another_table as "another_one")
 ----
-CREATE SOURCES FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' TABLES (generation1.random.psychic AS "public.psychic" (pokedex_id int4 NOT NULL, evolution int4), another_table AS another_one)
-=>
-CreateSources(CreateSourcesStatement { connector: Postgres { conn: "host=kanto user=ash password=teamrocket dbname=pokemon", publication: "red", slot: None, tables: [PgTable { name: UnresolvedObjectName([Ident("generation1"), Ident("random"), Ident("psychic")]), alias: Name(UnresolvedObjectName([Ident("public.psychic")])), columns: [ColumnDef { name: Ident("pokedex_id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("evolution"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }] }, PgTable { name: UnresolvedObjectName([Ident("another_table")]), alias: Name(UnresolvedObjectName([Ident("another_one")])), columns: [] }] }, materialized: false, stmts: [] })
+error: Expected FROM, found POSTGRES
+CREATE SOURCES FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' TABLES (generation1.random.psychic as "public.psychic" (pokedex_id int NOT NULL, evolution int), another_table as "another_one")
+                    ^
 
 parse-statement
 CREATE MATERIALIZED SOURCES FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' TABLES (generation1.random.psychic as "public.psychic" (pokedex_id int NOT NULL, evolution int), another_table as "another_one")
 ----
-CREATE MATERIALIZED SOURCES FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' TABLES (generation1.random.psychic AS "public.psychic" (pokedex_id int4 NOT NULL, evolution int4), another_table AS another_one)
-=>
-CreateSources(CreateSourcesStatement { connector: Postgres { conn: "host=kanto user=ash password=teamrocket dbname=pokemon", publication: "red", slot: None, tables: [PgTable { name: UnresolvedObjectName([Ident("generation1"), Ident("random"), Ident("psychic")]), alias: Name(UnresolvedObjectName([Ident("public.psychic")])), columns: [ColumnDef { name: Ident("pokedex_id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("evolution"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }] }, PgTable { name: UnresolvedObjectName([Ident("another_table")]), alias: Name(UnresolvedObjectName([Ident("another_one")])), columns: [] }] }, materialized: true, stmts: [] })
+error: Expected FROM, found POSTGRES
+CREATE MATERIALIZED SOURCES FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' TABLES (generation1.random.psychic as "public.psychic" (pokedex_id int NOT NULL, evolution int), another_table as "another_one")
+                                 ^
 
 parse-statement
 CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT BYTES

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -24,7 +24,7 @@ use repr::ColumnName;
 use sql_parser::ast::display::AstDisplay;
 use sql_parser::ast::visit_mut::{self, VisitMut};
 use sql_parser::ast::{
-    AstInfo, Connector, CreateIndexStatement, CreateSinkStatement, CreateSourceStatement,
+    AstInfo, CreateIndexStatement, CreateSinkStatement, CreateSourceStatement,
     CreateTableStatement, CreateTypeStatement, CreateViewStatement, Function, FunctionArgs, Ident,
     IfExistsBehavior, Query, Raw, SqlOption, Statement, TableFactor, UnresolvedObjectName, Value,
 };
@@ -256,7 +256,7 @@ pub fn create_statement(
         Statement::CreateSource(CreateSourceStatement {
             name,
             col_names: _,
-            connector,
+            connector: _,
             with_options: _,
             format: _,
             envelope: _,
@@ -266,12 +266,6 @@ pub fn create_statement(
             *name = allocate_name(name)?;
             *if_not_exists = false;
             *materialized = false;
-            if let Connector::Postgres { columns, .. } = connector {
-                let mut normalizer = QueryNormalizer::new(scx);
-                for c in columns {
-                    normalizer.visit_column_def_mut(c);
-                }
-            }
         }
 
         Statement::CreateTable(CreateTableStatement {

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -78,7 +78,8 @@ pub enum Plan {
     },
     CreateSource(CreateSourcePlan),
     CreateSources {
-        sources: Vec<CreateSourcePlan>,
+        source: CreateSourcePlan,
+        views: Vec<Plan>,
     },
     CreateSink {
         name: FullName,

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -66,13 +66,11 @@ use crate::names::{DatabaseSpecifier, FullName, SchemaName};
 use crate::normalize;
 use crate::plan::error::PlanError;
 use crate::plan::expr::{ColumnRef, HirScalarExpr, JoinKind};
-use crate::plan::query::{resolve_names_data_type, ExprContext, QueryLifetime};
-use crate::plan::scope::Scope;
+use crate::plan::query::{resolve_names_data_type, QueryLifetime};
 use crate::plan::statement::{StatementContext, StatementDesc};
-use crate::plan::typeconv::{plan_hypothetical_cast, CastContext};
 use crate::plan::{
     self, plan_utils, query, CreateSourcePlan, HirRelationExpr, Index, IndexOption,
-    IndexOptionName, Params, Plan, QueryContext, Sink, Source, Table, Type, TypeInner, View,
+    IndexOptionName, Params, Plan, Sink, Source, Table, Type, TypeInner, View,
 };
 use crate::pure::Schema;
 
@@ -712,8 +710,6 @@ pub fn plan_create_source(
         Connector::Postgres {
             conn,
             publication,
-            table,
-            columns,
             slot,
         } => {
             scx.require_experimental_mode("Postgres Sources")?;
@@ -722,77 +718,13 @@ pub fn plan_create_source(
                 .as_ref()
                 .ok_or_else(|| anyhow!("Postgres sources must provide a slot name"))?;
 
-            let qcx = QueryContext::root(scx, QueryLifetime::Static);
-            let cast_desc = RelationDesc::empty();
-            let ecx = ExprContext {
-                qcx: &qcx,
-                name: "postgres column cast",
-                scope: &Scope::empty(None),
-                relation_type: &cast_desc.typ(),
-                allow_aggregates: false,
-                allow_subqueries: true,
-            };
-
-            // Build the expected relation description
-            let col_names: Vec<_> = columns
-                .iter()
-                .map(|c| Some(normalize::column_name(c.name.clone())))
-                .collect();
-
-            let mut col_types = vec![];
-            let mut key_cols = vec![];
-            let mut cast_exprs = vec![];
-            for (i, c) in columns.iter().enumerate() {
-                if let Some(collation) = &c.collation {
-                    unsupported!(format!(
-                        "CREATE SOURCE FROM POSTGRES with column collation: {}",
-                        collation
-                    ));
-                }
-
-                let (aug_data_type, _ids) = resolve_names_data_type(scx, c.data_type.clone())?;
-                let scalar_ty = plan::scalar_type_from_sql(scx, &aug_data_type)?;
-
-                let mut nullable = true;
-                for option in &c.options {
-                    match &option.option {
-                        ColumnOption::Null => (),
-                        ColumnOption::NotNull => nullable = false,
-                        ColumnOption::Unique { is_primary: true } => key_cols.push(i),
-                        other => unsupported!(format!(
-                            "CREATE SOURCE FROM POSTGRES with column constraint: {}",
-                            other
-                        )),
-                    }
-                }
-
-                let cast_expr = plan_hypothetical_cast(
-                    &ecx,
-                    CastContext::Explicit,
-                    &ScalarType::String,
-                    &scalar_ty,
-                )
-                .unwrap();
-
-                col_types.push(scalar_ty.nullable(nullable));
-                cast_exprs.push(cast_expr);
-            }
-
-            let typ = if key_cols.is_empty() {
-                RelationType::new(col_types)
-            } else {
-                RelationType::new(col_types).with_key(key_cols)
-            };
-            let desc = RelationDesc::new(typ, col_names);
             let connector = ExternalSourceConnector::Postgres(PostgresSourceConnector {
                 conn: conn.clone(),
                 publication: publication.clone(),
-                ast_table: table.to_ast_string(),
-                cast_exprs,
                 slot_name: slot_name.clone(),
             });
 
-            (connector, DataEncoding::Postgres(desc))
+            (connector, DataEncoding::Postgres)
         }
         Connector::PubNub {
             subscribe_key,

--- a/src/walkabout/src/ir.rs
+++ b/src/walkabout/src/ir.rs
@@ -306,7 +306,7 @@ fn analyze_type(ty: &syn::Type) -> Result<Type> {
                         // comes from another crate whose source code is not easily
                         // accessible here. We probably want our own local definition of
                         // this type, but for now, just hardcode it as a primitive.
-                        "bool" | "usize" | "u64" | "char" | "String" | "PathBuf"
+                        "bool" | "usize" | "u32" | "u64" | "char" | "String" | "PathBuf"
                         | "DateTimeField" => match segment.arguments {
                             syn::PathArguments::None => Ok(Type::Primitive),
                             _ => bail!(


### PR DESCRIPTION
Previously the postgres source was both reading the replication stream
and decoding the rows of a particular table to present them to the
system. This makes replicating multiple tables efficiently tricky.

This change makes the source present the raw replication stream to the
system for futher processing. The output schema is (oid, row_data) where
oid is the relation id and row_data is a LIST of the column data encoded
as text. Casting the text data in the appropriate type is the
responsibility of downstream consumers.