### PR TITLE
coord,testdrive: drop Postgres replication slots on DROP SOURCE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4660,6 +4660,7 @@ dependencies = [
  "ore",
  "parse_duration",
  "pgrepr",
+ "postgres-util",
  "postgres_array",
  "predicates",
  "protobuf",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,6 +551,7 @@ dependencies = [
  "ore",
  "pgrepr",
  "postgres-types",
+ "postgres-util",
  "prometheus",
  "rand 0.8.3",
  "rdkafka",
@@ -3087,6 +3088,7 @@ name = "postgres-util"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "log",
  "sql-parser",
  "tokio",
  "tokio-postgres",

--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -29,6 +29,7 @@ mz-avro = { path = "../avro", features = ["snappy"] }
 ore = { path = "../ore" }
 pgrepr = { path = "../pgrepr" }
 postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres" }
+postgres-util = { path = "../postgres-util" }
 prometheus = { git = "https://github.com/MaterializeInc/rust-prometheus.git", default-features = false }
 rand = "0.8.3"
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "libz-static"] }

--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -422,6 +422,14 @@ impl CatalogItem {
             }
         }
     }
+
+    /// todo
+    pub fn external_state_op(&self) -> Option<dataflow_types::ExternalStateOp> {
+        match self {
+            CatalogItem::Source(source) => source.connector.external_state_op(),
+            _ => None,
+        }
+    }
 }
 
 impl CatalogEntry {

--- a/src/postgres-util/Cargo.toml
+++ b/src/postgres-util/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.40"
+log = "0.4.13"
 sql-parser = { path = "../sql-parser" }
 tokio = { version = "1.5.0", features = ["fs"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -28,6 +28,7 @@ ore = { path = "../ore" }
 parse_duration = "2.1.1"
 pgrepr = { path = "../pgrepr" }
 postgres_array = { git = "https://github.com/MaterializeInc/rust-postgres-array" }
+postgres-util = { path = "../postgres-util" }
 protobuf = { version = "2.17.0", features = ["with-serde"] }
 rand = "0.8.3"
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "libz-static"] }

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -426,6 +426,9 @@ pub fn build(cmds: Vec<PosCommand>, state: &State) -> Result<Vec<PosAction>, Err
                     "postgres-execute" => {
                         Box::new(postgres::build_execute(builtin).map_err(wrap_err)?)
                     }
+                    "postgres-verify-slot" => {
+                        Box::new(postgres::build_verify_slot(builtin).map_err(wrap_err)?)
+                    }
                     "random-sleep" => {
                         Box::new(sleep::build_random_sleep(builtin).map_err(wrap_err)?)
                     }

--- a/src/testdrive/src/action/postgres.rs
+++ b/src/testdrive/src/action/postgres.rs
@@ -7,52 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use async_trait::async_trait;
-use tokio_postgres::NoTls;
+mod execute;
+mod verify_slot;
 
-use crate::action::{Action, State};
-use crate::parser::BuiltinCommand;
-
-pub struct ExecuteAction {
-    connection: String,
-    queries: Vec<String>,
-}
-
-pub fn build_execute(mut cmd: BuiltinCommand) -> Result<ExecuteAction, String> {
-    let connection = cmd.args.string("connection")?;
-    cmd.args.done()?;
-    Ok(ExecuteAction {
-        connection,
-        queries: cmd.input,
-    })
-}
-
-#[async_trait]
-impl Action for ExecuteAction {
-    async fn undo(&self, _: &mut State) -> Result<(), String> {
-        Ok(())
-    }
-
-    async fn redo(&self, _: &mut State) -> Result<(), String> {
-        let (client, conn) = tokio_postgres::connect(&self.connection, NoTls)
-            .await
-            .map_err(|e| format!("connecting to postgres: {}", e))?;
-        println!(
-            "Executing queries against PostgreSQL server at {}...",
-            self.connection
-        );
-        let conn_handle = tokio::spawn(conn);
-        for query in &self.queries {
-            println!(">> {}", query);
-            client
-                .batch_execute(query)
-                .await
-                .map_err(|e| format!("executing postgres query: {}", e))?;
-        }
-        drop(client);
-        conn_handle
-            .await
-            .unwrap()
-            .map_err(|e| format!("postgres connection error: {}", e))
-    }
-}
+pub use execute::build_execute;
+pub use verify_slot::build_verify_slot;

--- a/src/testdrive/src/action/postgres/execute.rs
+++ b/src/testdrive/src/action/postgres/execute.rs
@@ -1,0 +1,58 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use async_trait::async_trait;
+use tokio_postgres::NoTls;
+
+use crate::action::{Action, State};
+use crate::parser::BuiltinCommand;
+
+pub struct ExecuteAction {
+    connection: String,
+    queries: Vec<String>,
+}
+
+pub fn build_execute(mut cmd: BuiltinCommand) -> Result<ExecuteAction, String> {
+    let connection = cmd.args.string("connection")?;
+    cmd.args.done()?;
+    Ok(ExecuteAction {
+        connection,
+        queries: cmd.input,
+    })
+}
+
+#[async_trait]
+impl Action for ExecuteAction {
+    async fn undo(&self, _: &mut State) -> Result<(), String> {
+        Ok(())
+    }
+
+    async fn redo(&self, _: &mut State) -> Result<(), String> {
+        let (client, conn) = tokio_postgres::connect(&self.connection, NoTls)
+            .await
+            .map_err(|e| format!("connecting to postgres: {}", e))?;
+        println!(
+            "Executing queries against PostgreSQL server at {}...",
+            self.connection
+        );
+        let conn_handle = tokio::spawn(conn);
+        for query in &self.queries {
+            println!(">> {}", query);
+            client
+                .batch_execute(query)
+                .await
+                .map_err(|e| format!("executing postgres query: {}", e))?;
+        }
+        drop(client);
+        conn_handle
+            .await
+            .unwrap()
+            .map_err(|e| format!("postgres connection error: {}", e))
+    }
+}

--- a/src/testdrive/src/action/postgres/verify_slot.rs
+++ b/src/testdrive/src/action/postgres/verify_slot.rs
@@ -1,0 +1,75 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use async_trait::async_trait;
+use tokio_postgres::NoTls;
+
+use postgres_util;
+
+use crate::action::{Action, State};
+use crate::parser::BuiltinCommand;
+
+pub struct VerifySlotAction {
+    connection: String,
+    slot: String,
+    exists: bool,
+}
+
+pub fn build_verify_slot(mut cmd: BuiltinCommand) -> Result<VerifySlotAction, String> {
+    let connection = cmd.args.string("connection")?;
+    let slot = cmd.args.string("slot")?;
+    let exists: bool = cmd.args.parse("exists")?;
+    cmd.args.done()?;
+    Ok(VerifySlotAction {
+        connection,
+        slot,
+        exists,
+    })
+}
+
+#[async_trait]
+impl Action for VerifySlotAction {
+    async fn undo(&self, _: &mut State) -> Result<(), String> {
+        Ok(())
+    }
+
+    async fn redo(&self, _: &mut State) -> Result<(), String> {
+        let (client, conn) = tokio_postgres::connect(&self.connection, NoTls)
+            .await
+            .map_err(|e| format!("connecting to postgres: {}", e))?;
+        println!(
+            "Executing queries against PostgreSQL server at {}...",
+            self.connection
+        );
+        let conn_handle = tokio::spawn(conn);
+
+        println!(">> checking for postgres replication slot {}", &self.slot);
+        let (active, _) = postgres_util::query_pg_replication_slots(&client, &self.slot)
+            .await
+            .map_err(|e| format!("querying postgres for replication slot: {}", e))?;
+
+        if self.exists && !active {
+            return Err(format!(
+                "expected slot {} to be active, is inactive",
+                &self.slot
+            ));
+        } else if !self.exists && active {
+            return Err(format!(
+                "expected slot {} to be inactive, is active",
+                &self.slot
+            ));
+        }
+
+        drop(client);
+        conn_handle
+            .await
+            .unwrap()
+            .map_err(|e| format!("postgres connection error: {}", e))
+    }
+}

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -498,6 +498,24 @@ true
 true
 
 #
+# Test that slots created for replication sources are deleted on DROP
+#
+$ postgres-verify-slot connection=postgres://postgres:postgres@postgres slot=test_slot exists=false
+
+> CREATE MATERIALIZED SOURCE "test_slot_source"
+  FROM POSTGRES
+    HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
+    PUBLICATION 'mz_source'
+    SLOT 'test_slot'
+    TABLE numbers;
+
+$ postgres-verify-slot connection=postgres://postgres:postgres@postgres slot=test_slot exists=true
+
+> DROP SOURCE test_slot_source
+
+$ postgres-verify-slot connection=postgres://postgres:postgres@postgres slot=test_slot exists=false
+
+#
 # Remove all data on the Postgres side
 #
 


### PR DESCRIPTION
This PR is separated into two commits. The first drops upstream Postgres [replication slots](https://www.postgresql.org/docs/9.4/warm-standby.html#STREAMING-REPLICATION-SLOTS) when a user `DROP`s a Postgres source. The second adds a new `postgres-verify-slot` testdrive action to test that we are correctly dropping the upstream slots.