### PR TITLE
testdrive: Remove attempts to access external hosts

### DIFF
--- a/test/testdrive/mzcompose.yml
+++ b/test/testdrive/mzcompose.yml
@@ -127,6 +127,7 @@ services:
     - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092
     - KAFKA_AUTO_CREATE_TOPICS_ENABLE=false
     - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+    - KAFKA_CONFLUENT_SUPPORT_METRICS_ENABLE=false
   schema-registry:
     image: confluentinc/cp-schema-registry:5.5.3
     environment:

--- a/test/testdrive/schema-registry-network-errors.td
+++ b/test/testdrive/schema-registry-network-errors.td
@@ -43,22 +43,21 @@ URL scheme is not allowed
 fetching latest schema for subject 'foo-value' from registry: subject not found
 
 #
-# HTTP connection to an HTTPS port
+# HTTP connection to a non-HTTP port port
 #
 
 ! CREATE MATERIALIZED SOURCE foo
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'foo'
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://www.materialize.com:443'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://${testdrive.kafka-addr}'
   ENVELOPE NONE
-fetching latest schema for subject 'foo-value' from registry: server error 400: unable to decode error details
-
+Connection reset by peer
 
 #
-# HTTPS connection to an HTTP port
+# HTTPS connection to a non-HTTPS port
 #
 
 ! CREATE MATERIALIZED SOURCE foo
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'foo'
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'https://www.materialize.com'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'https://${testdrive.kafka-addr}'
   ENVELOPE NONE
-fetching latest schema for subject 'foo-value' from registry: server error 301: unable to decode error details
+Connection reset by peer


### PR DESCRIPTION
Modify schema-registry-network-errors.td to not attempt to
access external hosts. This makes the test work in containerized
environments without Internet access.

---

@benesch I attempted to put the entire thing under a docker ```internal: true``` network, but in this case port forwarding breaks since the host is also considered to be external entity as well. So we get a ```Failed! Unable to unambiguously determine port for materialized, found ports:``` error and furthermore connecting to a mz instance running inside a mz container using a psql client located on the host becomes impossible, and this is important for debugging purposes.

So I just fixed the test instead and grepped for other tests that could be in violation.