### PR TITLE
Standalone program to parse Debezium Transaction messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5145,6 +5145,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "validate-debezium-topics"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "ccsr",
+ "futures",
+ "log",
+ "mz-avro",
+ "ore",
+ "rdkafka",
+ "structopt",
+ "tokio",
+ "url",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "demo/billing",
     "demo/debezium/loadgen",
+    "demo/debezium/validate-topics",
     "fuzz",
     "play/mbta",
     "src/avro",

--- a/demo/debezium/README.md
+++ b/demo/debezium/README.md
@@ -340,3 +340,23 @@ FROM KAFKA BROKER 'kafka:9092' TOPIC 'debezium.inventory.customers'
 FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://schema-registry:8081'
 ENVELOPE DEBEZIUM;
 ```
+
+You can even import the transaction topic if you want to take a look at it!
+
+```sql
+CREATE MATERIALIZED SOURCE IF NOT EXISTS dbz_transactions
+FROM KAFKA BROKER 'kafka:9092' TOPIC 'dbserver1.transaction'
+FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://schema-registry:8081';
+```
+
+This will give something like the following:
+
+```sql
+materialize=> select * from dbz_transactions order by id limit 4;
+ status |               id                | event_count |                                               data_collections
+--------+---------------------------------+-------------+--------------------------------------------------------------------------------------------------------------
+ BEGIN  | file=mysql-bin.000003,pos=10668 |             |
+ END    | file=mysql-bin.000003,pos=10668 |           5 | {"(inventory.products_on_hand,1)","(inventory.addresses,1)","(inventory.orders,2)","(inventory.products,1)"}
+ BEGIN  | file=mysql-bin.000003,pos=11483 |             |
+ END    | file=mysql-bin.000003,pos=11483 |           2 | {"(inventory.products_on_hand,1)","(inventory.customers,1)"}
+```

--- a/demo/debezium/README.md
+++ b/demo/debezium/README.md
@@ -264,6 +264,71 @@ kafkacat -C -b localhost:9092 -s avro -r localhost:8081 -t debezium.inventory.cu
 % Reached end of topic debezium.inventory.customers [0] at offset 4: exiting
 ```
 
+### Getting the List of Transaction IDs
+
+Use the transaction topic to generate the list of transactions, in commit order:
+
+```sh
+[chris-work:~/materialize/materialize:(main[|]*)] kafkacat -C -b localhost:9092 -r localhost:8081 -s avro -t dbserver1.transaction -e -f "Partition: %p\tOffset: %o\t: %k\n"
+Partition: 0    Offset: 0       : {"id": "file=mysql-bin.000003,pos=2201"}
+Partition: 0    Offset: 1       : {"id": "file=mysql-bin.000003,pos=2201"}
+Partition: 0    Offset: 2       : {"id": "file=mysql-bin.000003,pos=3491"}
+Partition: 0    Offset: 3       : {"id": "file=mysql-bin.000003,pos=3491"}
+Partition: 0    Offset: 4       : {"id": "file=mysql-bin.000003,pos=4397"}
+Partition: 0    Offset: 5       : {"id": "file=mysql-bin.000003,pos=4397"}
+Partition: 0    Offset: 6       : {"id": "file=mysql-bin.000003,pos=5506"}
+Partition: 0    Offset: 7       : {"id": "file=mysql-bin.000003,pos=5506"}
+Partition: 0    Offset: 8       : {"id": "file=mysql-bin.000003,pos=6250"}
+Partition: 0    Offset: 9       : {"id": "file=mysql-bin.000003,pos=6250"}
+Partition: 0    Offset: 10      : {"id": "file=mysql-bin.000003,pos=6710"}
+Partition: 0    Offset: 11      : {"id": "file=mysql-bin.000003,pos=6710"}
+Partition: 0    Offset: 12      : {"id": "file=mysql-bin.000003,pos=7397"}
+Partition: 0    Offset: 13      : {"id": "file=mysql-bin.000003,pos=7397"}
+Partition: 0    Offset: 14      : {"id": "file=mysql-bin.000003,pos=7819"}
+Partition: 0    Offset: 15      : {"id": "file=mysql-bin.000003,pos=7819"}
+Partition: 0    Offset: 16      : {"id": "file=mysql-bin.000003,pos=9048"}
+Partition: 0    Offset: 17      : {"id": "file=mysql-bin.000003,pos=9048"}
+Partition: 0    Offset: 18      : {"id": "file=mysql-bin.000003,pos=10238"}
+Partition: 0    Offset: 19      : {"id": "file=mysql-bin.000003,pos=10238"}
+Partition: 0    Offset: 20      : {"id": "file=mysql-bin.000003,pos=10944"}
+Partition: 0    Offset: 21      : {"id": "file=mysql-bin.000003,pos=10944"}
+Partition: 0    Offset: 22      : {"id": "file=mysql-bin.000003,pos=11591"}
+Partition: 0    Offset: 23      : {"id": "file=mysql-bin.000003,pos=11591"}
+Partition: 0    Offset: 24      : {"id": "file=mysql-bin.000003,pos=12248"}
+Partition: 0    Offset: 25      : {"id": "file=mysql-bin.000003,pos=12248"}
+Partition: 0    Offset: 26      : {"id": "file=mysql-bin.000003,pos=13065"}
+Partition: 0    Offset: 27      : {"id": "file=mysql-bin.000003,pos=13065"}
+Partition: 0    Offset: 28      : {"id": "file=mysql-bin.000003,pos=13941"}
+Partition: 0    Offset: 29      : {"id": "file=mysql-bin.000003,pos=13941"}
+Partition: 0    Offset: 30      : {"id": "file=mysql-bin.000003,pos=14480"}
+Partition: 0    Offset: 31      : {"id": "file=mysql-bin.000003,pos=14480"}
+```
+
+You can then list another topic, and you'll see 5 types of messages:
+
+- Initial snapshot of data, (.before is null, .after is non null) -- no transaction ID,
+- Creates,(.before is null, .after is non null) -- transaction ID is supplied
+- Updates (.before and .after are both non null) -- transaction ID is supplied
+- Deletes (.before is non null, .after is null) -- transaction ID is supplied
+- Tombstone messages, entire value is empty -- no transaction ID because no value
+
+You might see something like:
+
+```sh
+{"id": 1003}{"before": null, "after": {"Value": {"id": 1003, "first_name": "Edward", "last_name": "Walker", "email": "ed@walker.com"}}, "source": {"version": "1.5.0.Final", "connector": "mysql", "name": "dbserver1", "ts_ms": 1619121065623, "snapshot": {"string": "true"}, "db": "inventory", "sequence": null, "table": {"string": "customers"}, "server_id": 0, "gtid": null, "file": "mysql-bin.000003", "pos": 154, "row": 0, "thread": null, "query": null}, "op": "r", "ts_ms": {"long": 1619121065623}, "transaction": null}
+{"id": 1003}{"before": {"Value": {"id": 1003, "first_name": "Edward", "last_name": "Walker", "email": "ed@walker.com"}}, "after": null, "source": {"version": "1.5.0.Final", "connector": "mysql", "name": "dbserver1", "ts_ms": 1619121079000, "snapshot": {"string": "false"}, "db": "inventory", "sequence": null, "table": {"string": "customers"}, "server_id": 223344, "gtid": null, "file": "mysql-bin.000003", "pos": 7542, "row": 0, "thread": null, "query": null}, "op": "d", "ts_ms": {"long": 1619121080079}, "transaction": {"ConnectDefault": {"id": "file=mysql-bin.000003,pos=7397", "total_order": 1, "data_collection_order": 1}}}
+{"id": 1003}
+% Reached end of topic dbserver1.inventory.customers [0] at offset 28: exiting
+```
+
+The first message is the initial load, the second is an delete and the third is a tombstone for
+both records.
+
+#### Messages in Transaction ID Order
+
+For messages with transaction IDs, they are presented in order of the transaction ID presented in
+the transaction topic.
+
 ## Importing Tables in Materialized
 
 If you want to import the tables by hand, you can use the following SQL

--- a/demo/debezium/mzcompose.yml
+++ b/demo/debezium/mzcompose.yml
@@ -199,5 +199,9 @@ mzworkflows:
     steps:
     - step: workflow
       workflow: bring-up-mysql-kafka
+    # Without this sleep, our mysql generator will grab locks that prevent the initial replication
+    # from debezium
+    - step: sleep
+      duration: 15
     - step: run
       service: debezium-mysql-gen

--- a/demo/debezium/mzcompose.yml
+++ b/demo/debezium/mzcompose.yml
@@ -106,6 +106,8 @@ services:
     depends_on: [kafka, schema-registry]
   debezium-mysql-gen:
     mzbuild: debezium-mysql-gen
+  validate-debezium-topics:
+    mzbuild: validate-debezium-topics
   simple-mysql-connector:
     build: simple-mysql-connector
     depends_on: [connect]
@@ -205,3 +207,8 @@ mzworkflows:
       duration: 15
     - step: run
       service: debezium-mysql-gen
+
+  validate-topics:
+    steps:
+    - step: run
+      service: validate-debezium-topics

--- a/demo/debezium/validate-topics/Cargo.toml
+++ b/demo/debezium/validate-topics/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "validate-debezium-topics"
+description = "Utilty to validate Kafka topics written by debezium"
+version = "0.0.0"
+edition = "2018"
+publish = false
+
+[dependencies]
+anyhow = "1.0.40"
+ccsr = { path = "../../../src/ccsr" }
+futures = "0.3.14"
+log = "0.4.13"
+mz-avro = { path = "../../../src/avro" }
+ore = { path = "../../../src/ore" }
+rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "libz-static"] }
+structopt = "0.3.21"
+tokio = "1.5.0"
+url = "2.2.1"

--- a/demo/debezium/validate-topics/ci/.gitignore
+++ b/demo/debezium/validate-topics/ci/.gitignore
@@ -1,0 +1,1 @@
+/validate-debezium-topics

--- a/demo/debezium/validate-topics/ci/Dockerfile
+++ b/demo/debezium/validate-topics/ci/Dockerfile
@@ -1,0 +1,14 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+FROM ubuntu:bionic-20200403
+
+COPY validate-debezium-topics /usr/local/bin
+
+ENTRYPOINT ["validate-debezium-topics"]

--- a/demo/debezium/validate-topics/ci/mzbuild.yml
+++ b/demo/debezium/validate-topics/ci/mzbuild.yml
@@ -1,0 +1,14 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+name: validate-debezium-topics
+publish: false
+pre-image:
+  type: cargo-build
+  bin: validate-debezium-topics

--- a/demo/debezium/validate-topics/src/bin/validate-debezium-topics.rs
+++ b/demo/debezium/validate-topics/src/bin/validate-debezium-topics.rs
@@ -1,0 +1,197 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Validate transaction invariants for Kafka topics written by Debezium
+//! when replicating MySQL
+
+use anyhow::Error;
+use futures::stream::StreamExt;
+use log::{debug, error, info};
+use mz_avro::types::Value;
+use mz_avro::{from_avro_datum, Schema};
+use rdkafka::config::ClientConfig;
+use rdkafka::consumer::stream_consumer::StreamConsumer;
+use rdkafka::consumer::Consumer;
+use rdkafka::Message;
+use std::time::Duration;
+use structopt::StructOpt;
+use url::Url;
+
+#[derive(Clone, Debug, StructOpt)]
+pub struct Args {
+    #[structopt(long, default_value = "kafka:9092", value_name = "KAFKA_BROKER")]
+    pub kafka_brokers: String,
+    #[structopt(
+        long,
+        default_value = "http://schema-registry:8081",
+        value_name = "SCHEMA_REGISTRY"
+    )]
+    pub schema_registry: Url,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    ore::panic::set_abort_on_panic();
+    ore::test::init_logging();
+
+    let args: Args = ore::cli::parse_args();
+
+    info!("validating debezium topics!");
+
+    // Read the entire transaction topic and return an ordered list of transaction IDs
+    let transaction_ids = get_transaction_ids(args).await?;
+
+    info!("Transactions: {:#?}", transaction_ids);
+
+    // Read the list of database tables, spawning a reader per topic/partition, passing a cloned
+    // vec! of transaction IDs and have each reader validate that transactions appear in that order
+
+    Ok(())
+}
+
+async fn get_transaction_ids(args: Args) -> Result<Vec<String>, Error> {
+    let transaction_topic = "dbserver1.transaction";
+
+    let ccsr = ccsr::ClientConfig::new(args.schema_registry.clone())
+        .build()
+        .expect("can create schema registry object");
+    let key_schema: Schema = ccsr
+        .get_schema_by_subject("dbserver1.transaction-key")
+        .await
+        .expect("can fetch key schema for transactions topic")
+        .raw
+        .parse()
+        .expect("can parse key schema");
+    let value_schema: Schema = ccsr
+        .get_schema_by_subject("dbserver1.transaction-value")
+        .await
+        .expect("can fetch key schema for transactions topic")
+        .raw
+        .parse()
+        .expect("can parse value schema");
+    debug!(
+        "key schema: {:#?}, value schema: {:#?}",
+        key_schema, value_schema
+    );
+
+    let consumer: StreamConsumer = ClientConfig::new()
+        .set("group.id", "validate.topics")
+        .set("bootstrap.servers", args.kafka_brokers)
+        .set("enable.auto.commit", "false")
+        .set("auto.offset.reset", "earliest")
+        .create()
+        .expect("can create transaction topic consumer");
+
+    let (_, num_transactions) = consumer
+        .fetch_watermarks(transaction_topic, 0, Duration::from_secs(5))
+        .unwrap();
+
+    info!(
+        "reading {} transactions from transactions topic",
+        num_transactions
+    );
+
+    consumer
+        .subscribe(&[transaction_topic])
+        .expect("can subscribe to transaction topic");
+
+    let mut transactions: Vec<String> = vec![];
+    for _ in 0..num_transactions {
+        let msg = consumer
+            .stream()
+            .next()
+            .await
+            .expect("can read message from topic");
+
+        match msg {
+            Ok(m) => {
+                debug!(
+                    "partition: {}, offset: {}, key: {:#?}, payload: {:#?}",
+                    m.partition(),
+                    m.offset(),
+                    m.key_view::<str>(),
+                    m.payload_view::<str>()
+                );
+
+                let mut is_end = false;
+                match m.payload_view::<[u8]>() {
+                    Some(value) => match value {
+                        Ok(contents) => {
+                            let res = from_avro_datum(&value_schema, &mut &contents[5..]).unwrap();
+                            debug!("v: {:?}", res);
+
+                            match res {
+                                Value::Record(fields) => {
+                                    for (k, v) in fields {
+                                        match k.as_str() {
+                                            "status" => match v {
+                                                Value::String(s) => match s.as_str() {
+                                                    "BEGIN" => (),
+                                                    "END" => is_end = true,
+                                                    other => {
+                                                        error!("Unexpected record type: {}", other)
+                                                    }
+                                                },
+                                                other => {
+                                                    error!("Unexpected status type: {:?}", other)
+                                                }
+                                            },
+                                            _ => (),
+                                        }
+                                    }
+                                }
+                                _ => error!("expected Record type"),
+                            }
+                        }
+                        Err(_) => error!("failed to read value!"),
+                    },
+                    None => (),
+                }
+
+                match m.key_view::<[u8]>() {
+                    Some(key) => match key {
+                        Ok(contents) => {
+                            let res = from_avro_datum(&key_schema, &mut &contents[5..]).unwrap();
+                            debug!("k: {:?}", res);
+
+                            match res {
+                                Value::Record(fields) => {
+                                    for (k, v) in fields {
+                                        match k.as_str() {
+                                            "id" => match v {
+                                                Value::String(s) => {
+                                                    if is_end {
+                                                        transactions.push(s)
+                                                    }
+                                                }
+                                                other => error!(
+                                                    "unexpected Value type for ID: {:?}",
+                                                    other
+                                                ),
+                                            },
+                                            _ => (),
+                                        }
+                                    }
+                                }
+                                _ => error!("expected Record type!"),
+                            }
+                        }
+                        Err(_) => error!("failed to read key!"),
+                    },
+                    None => (),
+                }
+
+                // let key_reader = Reader::new(m.key_view());
+            }
+            Err(_) => (),
+        }
+    }
+
+    return Ok(transactions);
+}

--- a/demo/debezium/validate-topics/src/bin/validate-debezium-topics.rs
+++ b/demo/debezium/validate-topics/src/bin/validate-debezium-topics.rs
@@ -10,15 +10,16 @@
 //! Validate transaction invariants for Kafka topics written by Debezium
 //! when replicating MySQL
 
-use anyhow::Error;
+use anyhow::{anyhow, Error};
 use futures::stream::StreamExt;
-use log::{debug, error, info};
+use log::{debug, info};
 use mz_avro::types::Value;
 use mz_avro::{from_avro_datum, Schema};
 use rdkafka::config::ClientConfig;
 use rdkafka::consumer::stream_consumer::StreamConsumer;
 use rdkafka::consumer::Consumer;
 use rdkafka::Message;
+use std::collections::HashMap;
 use std::time::Duration;
 use structopt::StructOpt;
 use url::Url;
@@ -55,7 +56,25 @@ async fn main() -> Result<(), Error> {
     Ok(())
 }
 
-async fn get_transaction_ids(args: Args) -> Result<Vec<String>, Error> {
+#[derive(Debug)]
+struct DebeziumTransactionInfo {
+    event_count: i64,
+    collections: HashMap<String, i64>,
+}
+
+#[derive(Debug)]
+enum DebeziumTransactionStatus {
+    BEGIN,
+    END { txinfo: DebeziumTransactionInfo },
+}
+
+#[derive(Debug)]
+struct DebeziumTransaction {
+    id: String,
+    status: DebeziumTransactionStatus,
+}
+
+async fn get_transaction_ids(args: Args) -> Result<Vec<DebeziumTransaction>, Error> {
     let transaction_topic = "dbserver1.transaction";
 
     let ccsr = ccsr::ClientConfig::new(args.schema_registry.clone())
@@ -88,6 +107,7 @@ async fn get_transaction_ids(args: Args) -> Result<Vec<String>, Error> {
         .create()
         .expect("can create transaction topic consumer");
 
+    // TODO: Correctly handle this unwrap because Kafka likes to fail this API every once and a while
     let (_, num_transactions) = consumer
         .fetch_watermarks(transaction_topic, 0, Duration::from_secs(5))
         .unwrap();
@@ -101,7 +121,7 @@ async fn get_transaction_ids(args: Args) -> Result<Vec<String>, Error> {
         .subscribe(&[transaction_topic])
         .expect("can subscribe to transaction topic");
 
-    let mut transactions: Vec<String> = vec![];
+    let mut transactions = vec![];
     for _ in 0..num_transactions {
         let msg = consumer
             .stream()
@@ -119,79 +139,159 @@ async fn get_transaction_ids(args: Args) -> Result<Vec<String>, Error> {
                     m.payload_view::<str>()
                 );
 
-                let mut is_end = false;
-                match m.payload_view::<[u8]>() {
-                    Some(value) => match value {
-                        Ok(contents) => {
-                            let res = from_avro_datum(&value_schema, &mut &contents[5..]).unwrap();
-                            debug!("v: {:?}", res);
-
-                            match res {
-                                Value::Record(fields) => {
-                                    for (k, v) in fields {
-                                        match k.as_str() {
-                                            "status" => match v {
-                                                Value::String(s) => match s.as_str() {
-                                                    "BEGIN" => (),
-                                                    "END" => is_end = true,
-                                                    other => {
-                                                        error!("Unexpected record type: {}", other)
-                                                    }
-                                                },
-                                                other => {
-                                                    error!("Unexpected status type: {:?}", other)
-                                                }
-                                            },
-                                            _ => (),
-                                        }
-                                    }
-                                }
-                                _ => error!("expected Record type"),
-                            }
-                        }
-                        Err(_) => error!("failed to read value!"),
-                    },
-                    None => (),
-                }
-
-                match m.key_view::<[u8]>() {
-                    Some(key) => match key {
-                        Ok(contents) => {
-                            let res = from_avro_datum(&key_schema, &mut &contents[5..]).unwrap();
-                            debug!("k: {:?}", res);
-
-                            match res {
-                                Value::Record(fields) => {
-                                    for (k, v) in fields {
-                                        match k.as_str() {
-                                            "id" => match v {
-                                                Value::String(s) => {
-                                                    if is_end {
-                                                        transactions.push(s)
-                                                    }
-                                                }
-                                                other => error!(
-                                                    "unexpected Value type for ID: {:?}",
-                                                    other
-                                                ),
-                                            },
-                                            _ => (),
-                                        }
-                                    }
-                                }
-                                _ => error!("expected Record type!"),
-                            }
-                        }
-                        Err(_) => error!("failed to read key!"),
-                    },
-                    None => (),
-                }
-
-                // let key_reader = Reader::new(m.key_view());
+                transactions.push(parse_transaction(&value_schema, m)?);
             }
             Err(_) => (),
         }
     }
 
     return Ok(transactions);
+}
+
+fn parse_transaction(
+    reader_schema: &Schema,
+    msg: rdkafka::message::BorrowedMessage,
+) -> Result<DebeziumTransaction, anyhow::Error> {
+    match msg.payload_view::<[u8]>() {
+        Some(value) => match value {
+            Ok(contents) => {
+                let res = from_avro_datum(reader_schema, &mut &contents[5..]).unwrap();
+                match res {
+                    Value::Record(items) => {
+                        let mut fields: HashMap<_, _> = items.into_iter().collect();
+
+                        match parse_status(&fields)?.as_str() {
+                            "END" => Ok(DebeziumTransaction {
+                                id: parse_transaction_id(&fields)?,
+                                status: DebeziumTransactionStatus::END {
+                                    txinfo: DebeziumTransactionInfo {
+                                        event_count: parse_event_count(&fields)?,
+                                        collections: parse_collections(&mut fields)?,
+                                    },
+                                },
+                            }),
+                            "BEGIN" => Ok(DebeziumTransaction {
+                                id: parse_transaction_id(&fields)?,
+                                status: DebeziumTransactionStatus::BEGIN,
+                            }),
+                            other => Err(anyhow!("Unexpected value for status: {}", other)),
+                        }
+                    }
+                    _ => Err(anyhow!("expected Record type")),
+                }
+            }
+            Err(_) => Err(anyhow!("failed to read value!")),
+        },
+        None => Err(anyhow!("Got None when trying to parse transaction!")),
+    }
+}
+
+fn parse_status(fields: &HashMap<String, Value>) -> Result<String, anyhow::Error> {
+    match fields.get("status") {
+        Some(status) => match status {
+            Value::String(s) => Ok(s.to_string()),
+            _ => Err(anyhow!(
+                "Expected status to be a String but got: {:?}",
+                status
+            )),
+        },
+        None => Err(anyhow!("Expected to find a status field")),
+    }
+}
+
+fn parse_transaction_id(fields: &HashMap<String, Value>) -> Result<String, anyhow::Error> {
+    match fields.get("id") {
+        Some(transaction) => match transaction {
+            Value::String(t) => Ok(t.to_string()),
+            _ => Err(anyhow!(
+                "Expected transaction to be a String but got: {:?}",
+                transaction
+            )),
+        },
+        None => Err(anyhow!("Expected to find a id field!")),
+    }
+}
+
+fn parse_event_count(fields: &HashMap<String, Value>) -> Result<i64, anyhow::Error> {
+    match fields.get("event_count") {
+        Some(inner) => match inner {
+            Value::Union { inner: value, .. } => {
+                if let Value::Long(c) = **value {
+                    Ok(c)
+                } else {
+                    Err(anyhow!("Expect Long type for event, got {:?}", **value))
+                }
+            }
+            other => Err(anyhow!(
+                "Expected union type for event_count, got {:?}",
+                other
+            )),
+        },
+        None => Err(anyhow!("Expected event count for END transaction message!")),
+    }
+}
+
+fn parse_collections(
+    fields: &mut HashMap<String, Value>,
+) -> Result<HashMap<String, i64>, anyhow::Error> {
+    match fields.remove("data_collections") {
+        Some(inner) => match inner {
+            Value::Union { inner: value, .. } => {
+                if let Value::Array(items) = *value {
+                    let mut collections = HashMap::new();
+                    for i in items {
+                        let (collection, count) = parse_data_collection(i)?;
+                        collections.insert(collection, count);
+                    }
+                    Ok(collections)
+                } else {
+                    Err(anyhow!("Expect Array type for event, got {:?}", *value))
+                }
+            }
+            other => Err(anyhow!(
+                "Expected union type for data_collections, got {:?}",
+                other
+            )),
+        },
+        None => Err(anyhow!(
+            "Expected data_collections for END transaction message!"
+        )),
+    }
+}
+
+fn parse_data_collection(collection: Value) -> Result<(String, i64), anyhow::Error> {
+    match collection {
+        Value::Record(items) => {
+            let fields: HashMap<_, _> = items.into_iter().collect();
+
+            let collection_name = match fields.get("data_collection") {
+                Some(value) => match value {
+                    Value::String(s) => Ok(s.to_string()),
+                    _ => Err(anyhow!(
+                        "Expected string type for data collection name, got {:?}",
+                        value
+                    )),
+                },
+                None => Err(anyhow!(
+                    "Expected data_collection field from data collection"
+                )),
+            }?;
+
+            let count = match fields.get("event_count") {
+                Some(value) => match value {
+                    Value::Long(c) => Ok(*c),
+                    _ => Err(anyhow!("Expected long for count, got {:?}", value)),
+                },
+                None => Err(anyhow!(
+                    "Expected data_collection field from data collection"
+                )),
+            }?;
+
+            Ok((collection_name, count))
+        }
+        _ => Err(anyhow!(
+            "Expected Record for data collection, got {:?}",
+            collection
+        )),
+    }
 }


### PR DESCRIPTION
This adds a new binary to the `demo/debezium` work that will read transaction messages from the debezium transaction topic and convert them into structured objects.

The validation work is still TBD. I'm putting this PR up because I felt like it got lost in the weeds of codifying how to parse Debezium messages / our Avro parsing. I've also found a few opportunities for improvement in materialized debezium parsing and will open a PR for that as well.

Long term, I think the program is useful to keep around because it can provide a reference for how to write a Debezium consumer that can be simpler than the materialized version.