### PR TITLE
Return the number of days when subtracting a date from a date

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -54,6 +54,10 @@ Wrap your release notes at the 80 character mark.
 - Add a new metric, `mz_log_message_total` that counts the number of log
   messages emitted per severity.
 
+- Return the number of days between two dates (an integer) when subtracting one
+  date from the other. Previously, the interval between the two dates would be
+  returned. The new behavior matches the behavior in PostgreSQL.
+
 {{% version-header v0.7.2 %}}
 
 - Introduce the concept of [volatility](/overview/volatility) to describe

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -1076,7 +1076,7 @@ fn sub_timestamptz<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 fn sub_date<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
-    Datum::from(a.unwrap_date() - b.unwrap_date())
+    Datum::from((a.unwrap_date() - b.unwrap_date()).num_days() as i32)
 }
 
 fn sub_time<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
@@ -2570,9 +2570,13 @@ impl BinaryFunc {
             ToCharTimestamp | ToCharTimestampTz | ConvertFrom | Right | Trim | TrimLeading
             | TrimTrailing => ScalarType::String.nullable(in_nullable),
 
-            AddInt32 | SubInt32 | MulInt32 | DivInt32 | ModInt32 | EncodedBytesCharLength => {
-                ScalarType::Int32.nullable(in_nullable || is_div_mod)
-            }
+            AddInt32
+            | SubInt32
+            | MulInt32
+            | DivInt32
+            | ModInt32
+            | EncodedBytesCharLength
+            | SubDate => ScalarType::Int32.nullable(in_nullable || is_div_mod),
 
             AddInt64 | SubInt64 | MulInt64 | DivInt64 | ModInt64 => {
                 ScalarType::Int64.nullable(in_nullable || is_div_mod)
@@ -2586,7 +2590,7 @@ impl BinaryFunc {
                 ScalarType::Float64.nullable(in_nullable || is_div_mod)
             }
 
-            AddInterval | SubInterval | SubTimestamp | SubTimestampTz | SubDate | MulInterval
+            AddInterval | SubInterval | SubTimestamp | SubTimestampTz | MulInterval
             | DivInterval => ScalarType::Interval.nullable(in_nullable),
 
             AddNumeric | DivNumeric => ScalarType::Numeric { scale: None }.nullable(in_nullable),

--- a/test/sqllogictest/dates-times.slt
+++ b/test/sqllogictest/dates-times.slt
@@ -195,7 +195,7 @@ SELECT DATE '2000-01-01' + TIME '01:02:03'
 query T
 SELECT DATE '2019-02-03' - DATE '2019-01-01';
 ----
-33 days
+33
 
 # Time arithmetic with intervals.
 

--- a/test/sqllogictest/jsonb.slt
+++ b/test/sqllogictest/jsonb.slt
@@ -1208,7 +1208,7 @@ SELECT jsonb_build_object('a',2,'b',4)
 query T
 SELECT jsonb_build_object(true,'val',1,0,1.3,2,date '2019-02-03' - date '2019-01-01',4)
 ----
-{"1":0,"1.3":2,"33 days":4,"true":"val"}
+{"1":0,"1.3":2,"33":4,"true":"val"}
 
 query T
 SELECT jsonb_build_object('a',1,'b',1.2::float,'c',true,'d',null,'e','{"x":3,"y":[1,2,3]}'::JSONB)


### PR DESCRIPTION
In Postgres, when subtracting a date from a date, the number of days (an integer)
is returned, whereas Materialize would currently return an interval.

This fixes #6187