### PR TITLE
change the default for kafka source enable_auto_commit to false

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -58,6 +58,9 @@ Wrap your release notes at the 80 character mark.
   date from the other. Previously, the interval between the two dates would be
   returned. The new behavior matches the behavior in PostgreSQL.
 
+- **Breaking change.** Change the default for the `enable_auto_commit` option
+  on [Kafka sources](/sql/create-source/avro-kafka) to `false`.
+
 {{% version-header v0.7.2 %}}
 
 - Introduce the concept of [volatility](/overview/volatility) to describe

--- a/doc/user/layouts/partials/create-source/connector/kafka/with-options.html
+++ b/doc/user/layouts/partials/create-source/connector/kafka/with-options.html
@@ -6,7 +6,7 @@
 `statistics_interval_ms` | `int` | `librdkafka` statistics emit interval in `ms`. Accepts values [0, 86400000]. The granularity is 1000ms. A value of 0 disables statistics. Statistics can be queried using the `mz_kafka_consumer_partitions` system table.`start_offset`| `int` | Read partitions from the specified offset. You cannot update the offsets once a source has been created; you will need to recreate the source. Values must be zero or positive integers. See [Kafka source details](#partition-offsets) for important warnings for this feature.
 `timestamp_frequency_ms`| `int` | Default: `1000`. Sets the timestamping frequency in `ms`. Reflects how frequently the source advances its timestamp. This measure reflects how stale data in views will be. Lower values result in more-up-to-date views but may reduce throughput.
 `topic_metadata_refresh_interval_ms` | `int` | Default: `30000`. Sets the frequency in `ms` at which the system checks for new partitions. Accepts values [0,3600000].
-`enable_auto_commit` | `boolean`| Default: `true`. Controls whether or not Materialize commits read offsets back into Kafka. This is purely for consumer progress monitoring and does not cause Materialize to resume reading from where it left off across restarts.
+`enable_auto_commit` | `boolean`| Default: `false`. Controls whether or not Materialize commits read offsets back into Kafka. This is purely for consumer progress monitoring and does not cause Materialize to resume reading from where it left off across restarts.
 
 #### SSL `WITH` options
 

--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -602,11 +602,13 @@ fn create_kafka_config(
     // Broker configuration.
     kafka_config.set("bootstrap.servers", &addrs.to_string());
 
-    // Automatically commit read offsets back to Kafka for monitoring purposes,
-    // but on restart begin ingest at 0
-    kafka_config
-        .set("enable.auto.commit", "true")
-        .set("auto.offset.reset", "earliest");
+    // Default to disabling Kafka auto commit. This can be explicitly enabled
+    // by the user if they want to use it for progress tracking.
+    kafka_config.set("enable.auto.commit", "false");
+
+    // Always begin ingest at 0 when restarted, even if Kafka contains committed
+    // consumer read offsets
+    kafka_config.set("auto.offset.reset", "earliest");
 
     // How often to refresh metadata from the Kafka broker. This can have a
     // minor impact on startup latency and latency after adding a new partition,


### PR DESCRIPTION
    change the default for kafka source enable_auto_commit to false
    
    This parameter controls consumer offset commit back into Kafka. The main
    use is server-side monitoring of materialize's read progress.
    
    Materialize today creates potentially many consumers, so this can create
    high load depending on the Kafka cluster configuration. Many users don't
    actually need this, and in the future we'd ideally default to not using
    consumer groups at all.
    
    Therefore, switching the default to false to make this functionality opt
    in.

closes #6602