### PR TITLE
include the Kafka topic name when calling fetch_metadata in purification

### DIFF
--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -57,14 +57,14 @@ pub async fn purify(mut stmt: Statement<Raw>) -> Result<Statement<Raw>, anyhow::
 
         let mut file = None;
         match connector {
-            Connector::Kafka { broker, .. } => {
+            Connector::Kafka { broker, topic, .. } => {
                 if !broker.contains(':') {
                     *broker += ":9092";
                 }
 
                 // Verify that the provided security options are valid and then test them.
                 config_options = kafka_util::extract_config(&mut with_options_map)?;
-                kafka_util::test_config(&broker, &config_options).await?;
+                kafka_util::test_config(&broker, &topic, &config_options).await?;
             }
             Connector::AvroOcf { path, .. } => {
                 let path = path.clone();


### PR DESCRIPTION
    During purification of Kafka CREATE SOURCE we make a fetch_metadata call
    to validate basic connectivity/auth, allowing us to fast-fail to the
    user with a nice error message. This change scopes that fetch_metadata
    call to the specific topic we're creating a source from in an effort to
    play nicer with whatever Kafka ACLs may be configured.
    
    Note that this is not appropriate for eg. sinks where the topic may not
    have been created. Calling fetch_metadata with a specific nonexistent
    topic name may _create_ that topic in certain Kafka cluster
    configurations.