### PR TITLE
coord,sql: auto-generate an available name for default indexes

### DIFF
--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -135,6 +135,19 @@ pub trait Catalog: fmt::Debug + ExprHumanizer {
     /// from elsewhere.
     fn try_get_lossy_scalar_type_by_id(&self, id: &GlobalId) -> Option<ScalarType>;
 
+    /// Finds a name like `name` that is not already in use.
+    ///
+    /// If `name` itself is available, it is returned unchanged.
+    fn find_available_name(&self, mut name: FullName) -> FullName {
+        let mut i = 0;
+        let orig_item_name = name.item.clone();
+        while self.item_exists(&name) {
+            i += 1;
+            name.item = format!("{}{}", orig_item_name, i);
+        }
+        name
+    }
+
     /// Returns the configuration of the catalog.
     fn config(&self) -> &CatalogConfig;
 }

--- a/test/testdrive/rename.td
+++ b/test/testdrive/rename.td
@@ -752,3 +752,13 @@ renamed_j
 name
 ------
 renamed_j
+
+# Test that after renaming a materialized object it is possible to create
+# another object with the original name. This used to fail because the index
+# on the original object is not renamed. See #5096.
+> CREATE TABLE t_orig ()
+> ALTER TABLE t_orig RENAME TO t_dontcare
+> CREATE TABLE t_orig ()
+> CREATE MATERIALIZED VIEW v_orig AS SELECT 1
+> ALTER VIEW v_orig RENAME TO v_dontcare
+> CREATE MATERIALIZED VIEW v_orig AS SELECT 1


### PR DESCRIPTION
Previously, when creating the default index for a materialized source,
view, or table, Materialize would insist upon using the name
"OBJECT_primary_idx". If this name was not available, the entire
operation was aborted.

This was at odds with the behavior of "CREATE INDEX", which will search
until it finds an available name. If "OBJECT_primary_idx" is not
available, Materialize will try "OBJECT_primary_idx1",
"OBJECT_primary_idx2", and so on.

This commit teaches "CREATE MATERIALIZED {SOURCE,VIEW}" and "CREATE
TABLE" to do the same. In particular, this makes the following sequence
of statements succeed where it used to fail:

    CREATE TABLE t_orig ()
    ALTER TABLE t_orig RENAME TO t_dontcare
    CREATE TABLE t_orig ()

Fix #5096, though not exactly as proposed in the issue. (The fix
described there suggested renaming indexes when the object they're built
on is renamed, but that would be at odds with PostgreSQL and is also
just hard.)