### PR TITLE
mz_metadata metric should not depend on http interactions to exist

### DIFF
--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -606,6 +606,9 @@ swap: {swap_total}KB total, {swap_used}KB used",
             experimental_mode: args.experimental,
             safe_mode: args.safe,
             telemetry_url,
+            introspection_frequency: args
+                .introspection_frequency
+                .unwrap_or_else(|| Duration::from_secs(1)),
         },
         runtime.clone(),
     ))?;

--- a/src/materialized/src/server_metrics.rs
+++ b/src/materialized/src/server_metrics.rs
@@ -76,13 +76,17 @@ lazy_static! {
 /// Call [`prometheus::gather`], ensuring that all our metrics are up to date
 pub fn load_prom_metrics(start_time: Instant) -> Vec<prometheus::proto::MetricFamily> {
     let before_gather = Instant::now();
-    let uptime = before_gather - start_time;
-    let (secs, milli_part) = (uptime.as_secs() as f64, uptime.subsec_millis() as f64);
-    SERVER_METADATA.set(secs + milli_part / 1_000.0);
+    update_uptime(start_time);
     let result = prometheus::gather();
 
     REQUEST_METRICS_GATHER.set(Instant::now().duration_since(before_gather).as_micros() as i64);
     result
+}
+
+pub fn update_uptime(start_time: Instant) {
+    let uptime = start_time.elapsed();
+    let (secs, milli_part) = (uptime.as_secs() as f64, uptime.subsec_millis() as f64);
+    SERVER_METADATA.set(secs + milli_part / 1_000.0);
 }
 
 pub fn filter_metrics<'a>(

--- a/src/materialized/tests/util.rs
+++ b/src/materialized/tests/util.rs
@@ -138,6 +138,7 @@ pub fn start_server(config: Config) -> Result<Server, Box<dyn Error>> {
             experimental_mode: config.experimental_mode,
             safe_mode: config.safe_mode,
             telemetry_url: None,
+            introspection_frequency: Duration::from_secs(1),
         },
         runtime.clone(),
     ))?;

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -529,6 +529,7 @@ impl Runner {
             experimental_mode: true,
             safe_mode: false,
             telemetry_url: None,
+            introspection_frequency: Duration::from_secs(1),
         };
         let server = materialized::serve(mz_config, config.runtime.clone()).await?;
         let client = connect(&server).await;

--- a/test/testdrive/prometheus.td
+++ b/test/testdrive/prometheus.td
@@ -12,6 +12,10 @@
 
 # Some prometheus metrics should always exist
 
+> SELECT value > 0 AND labels ? 'os' FROM mz_metrics WHERE metric = 'mz_server_metadata_seconds'
+  ORDER BY time DESC LIMIT 1
+true
+
 > SELECT value FROM mz_metrics WHERE metric = 'mz_worker_pending_peeks_queue_size'
   ORDER BY time DESC LIMIT 1
 0


### PR DESCRIPTION
**Contains commits from #6603**, only the last commit should be reviewed here.

Spawn a Tokio task to update it at introspection frequency. This also updates it whenever the Prometheus endpoint is called, to guard against the loop possibly being disabled or set to a very large value.