### PR TITLE
sql: support equality operator for arrays

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -61,6 +61,9 @@ Wrap your release notes at the 80 character mark.
 - **Breaking change.** Change the default for the `enable_auto_commit` option
   on [Kafka sources](/sql/create-source/avro-kafka) to `false`.
 
+- Support the [equality operator](/sql/functions/#boolean) on
+  [array data](/sql/types/array).
+
 {{% version-header v0.7.2 %}}
 
 - Introduce the concept of [volatility](/overview/volatility) to describe

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -2547,6 +2547,7 @@ lazy_static! {
                 params!(String, String) => BinaryFunc::Eq, 98;
                 params!(Jsonb, Jsonb) => BinaryFunc::Eq, 3240;
                 params!(ListAny, ListAny) => BinaryFunc::Eq, oid::FUNC_LIST_EQ_OID;
+                params!(ArrayAny, ArrayAny) => BinaryFunc::Eq, 1070;
             },
             "<>" => Scalar {
                 params!(DecimalAny, DecimalAny) => {

--- a/test/sqllogictest/arrays.slt
+++ b/test/sqllogictest/arrays.slt
@@ -211,3 +211,30 @@ query T
 SELECT ARRAY['a', 'b', 'c'][3.5]
 ----
 NULL
+
+# Array equality
+
+query B
+SELECT ARRAY[1,2,3] = ARRAY[1,2,3]
+----
+true
+
+query B
+SELECT ARRAY[1,2,4] = ARRAY[1,2,3]
+----
+false
+
+query B
+SELECT ARRAY[1,2,4] = NULL
+----
+NULL
+
+# This behavior is surprising (one might expect that the result would be
+# NULL), but it's how Postgres behaves.
+query B
+SELECT ARRAY[1,2,NULL] = ARRAY[1,2,3]
+----
+false
+
+query error no overload for integer\[\] = text\[\]: arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+SELECT ARRAY[1,2,3] = ARRAY['1','2','3']


### PR DESCRIPTION
This was mostly exploring the code base and copy/pasting... 🙈 
* The `oid` comes from [pg_operator.dat](https://github.com/postgres/postgres/blob/master/src/include/catalog/pg_operator.dat#L1228-L1232).
* The additions to `arrays.slt` come from the cockroach slt array suite (which is noted in an existing comment in the file).

Did we want to add support for the other equality operators as well?
