### PR TITLE
Explain: Add ability to easily print typed explanations when debugging.

### DIFF
--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -1164,6 +1164,13 @@ impl MirRelationExpr {
         ViewExplanation::new(self, &DummyHumanizer).to_string()
     }
 
+    /// Pretty-print this MirRelationExpr to a string with type information.
+    pub fn pretty_typed(&self) -> String {
+        let mut explanation = ViewExplanation::new(self, &DummyHumanizer);
+        explanation.explain_types();
+        explanation.to_string()
+    }
+
     /// Take ownership of `self`, leaving an empty `MirRelationExpr::Constant` with the correct type.
     pub fn take_safely(&mut self) -> MirRelationExpr {
         let typ = self.typ();


### PR DESCRIPTION
We have an internal function for pretty-printing a `MirRelationExpr` when debugging transforms. I am adding an internal function for pretty-printing a `MirRelationExpr` with type information because some transforms make decisions based on the presence of keys, and it would be nice to know what keys the transform is seeing. 