### PR TITLE
coord: use a single PlanContext for the duration of a transaction

### DIFF
--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -326,7 +326,7 @@ impl Params {
 }
 
 /// Controls planning of a SQL query.
-#[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
+#[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, Copy)]
 pub struct PlanContext {
     pub wall_time: DateTime<Utc>,
 }

--- a/test/testdrive/transactions-stable.td
+++ b/test/testdrive/transactions-stable.td
@@ -1,0 +1,35 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Verify that transaction-stable functions, like "now", don't change during a transaction.
+
+> CREATE TABLE now_inc (a TIMESTAMP)
+
+> INSERT INTO now_inc VALUES (now())
+
+# Sleep 2ms to ensure now() has increased, due to its ms resolution.
+> SELECT mz_internal.mz_sleep(0.002)
+<null>
+
+# These execute in a single txn, so should be the same, and should
+# produce 3 identical rows.
+> BEGIN
+> INSERT INTO now_inc VALUES (now()), (now())
+> INSERT INTO now_inc VALUES (now())
+> COMMIT
+
+> SELECT mz_internal.mz_sleep(0.002)
+<null>
+
+> INSERT INTO now_inc VALUES (now())
+
+> SELECT count(*) FROM now_inc GROUP BY a ORDER BY a
+1
+3
+1


### PR DESCRIPTION
This makes "now()" stable across transactions.

Fixes #5903