### PR TITLE
avro+kafka: decimal data generation

### DIFF
--- a/src/avro/src/schema.rs
+++ b/src/avro/src/schema.rs
@@ -1980,7 +1980,8 @@ fn parsing_canonical_form(schema: &serde_json::Value) -> String {
         serde_json::Value::Object(map) => pcf_map(map),
         serde_json::Value::String(s) => pcf_string(s),
         serde_json::Value::Array(v) => pcf_array(v),
-        _ => unreachable!(),
+        serde_json::Value::Number(n) => n.to_string(),
+        _ => unreachable!("{:?} cannot yet be printed in canonical form", schema),
     }
 }
 
@@ -2067,6 +2068,12 @@ fn field_ordering_position(field: &str) -> Option<usize> {
         "items" => 5,
         "values" => 6,
         "size" => 7,
+        // Supports decimals
+        "logicalType" => 8,
+        // Supports decimals
+        "precision" => 9,
+        // Supports decimals
+        "scale" => 10,
         _ => return None,
     };
 


### PR DESCRIPTION
@cirego helped create the scaffolding for benchmark for aggregations over decimal data (#6643), and in trying to bring it over the finish line ran into...
- `kgen` lacking decimal data generation
- An issue propagating decimal data declarations from an Avro schema into the schema registry, and ultimately into Materialize. I don't know if this implies that no one is sending us decimal data over Avro, or if I am really "holding it wrong."

The proposed commits resolve both of the points above.

Regarding the second point above re: decimals in Avro schemas, here's a snippet of the value schema I'm using, which is congruent with [this example from our Avro tests](https://github.com/MaterializeInc/materialize/blob/a202a01c954a16dd4bc9e81bc7d59f188d057765/src/avro/tests/io.rs#L705-L713):

```
{
  "name": "aggregationtest",
  "type": "record",
  "namespace": "com.acme.avro",
  "fields": [
    {
      "name": "Key1Unused",
      "type": "long"
    },
    {
      "name": "Key2Unused",
      "type": "long"
    },
    {
      "name": "OuterRecord",
      "type": {
        "name": "OuterRecord",
        "type": "record",
        "fields": [
          {
            "name": "Record1",
            "type": {
              "name": "Record1",
              "type": "record",
              "fields": [
                {
                  "name": "InnerRecord1",
                  "type": {
                    "name": "InnerRecord1",
                    "type": "record",
                    "fields": [
                      {
                        "name": "DecPoint",
                        "type": {
                          "type": "bytes",
                          "scale": 2,
                          "precision": 15,
                          "logicalType": "decimal"
                        }
                      }
                    ]
                  }
                },
...
```

This PR might be better suited to get folded into #6643, but wanted to get @umanwizard's eyes on the change before continuing to work off of these commits.