### PR TITLE
sql: support equality operators for arrays

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -61,7 +61,7 @@ Wrap your release notes at the 80 character mark.
 - **Breaking change.** Change the default for the `enable_auto_commit` option
   on [Kafka sources](/sql/create-source/avro-kafka) to `false`.
 
-- Support the [equality operator](/sql/functions/#boolean) on
+- Support [equality operators](/sql/functions/#boolean) on
   [array data](/sql/types/array).
 
 {{% version-header v0.7.2 %}}

--- a/src/repr/src/adt/array.rs
+++ b/src/repr/src/adt/array.rs
@@ -17,6 +17,7 @@ use std::mem;
 use serde::{Deserialize, Serialize};
 
 use crate::row::DatumList;
+use std::cmp::Ordering;
 
 /// The maximum number of dimensions permitted in an array.
 pub const MAX_ARRAY_DIMENSIONS: u8 = 6;
@@ -24,10 +25,10 @@ pub const MAX_ARRAY_DIMENSIONS: u8 = 6;
 /// A variable-length multi-dimensional array.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Array<'a> {
-    /// The dimensions of the array.
-    pub(crate) dims: ArrayDimensions<'a>,
     /// The elements in the array.
     pub(crate) elements: DatumList<'a>,
+    /// The dimensions of the array.
+    pub(crate) dims: ArrayDimensions<'a>,
 }
 
 impl<'a> Array<'a> {
@@ -43,7 +44,7 @@ impl<'a> Array<'a> {
 }
 
 /// The dimensions of an [`Array`].
-#[derive(Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Clone, Copy, Eq, PartialEq, Hash)]
 pub struct ArrayDimensions<'a> {
     pub(crate) data: &'a [u8],
 }
@@ -63,6 +64,18 @@ impl ArrayDimensions<'_> {
     /// Reports whether the number of dimensions in the array is zero.
     pub fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+}
+
+impl Ord for ArrayDimensions<'_> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.ndims().cmp(&other.ndims())
+    }
+}
+
+impl PartialOrd for ArrayDimensions<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }
 

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -2454,6 +2454,7 @@ lazy_static! {
                 params!(Bytes, Bytes) => BinaryFunc::Lt, 1957;
                 params!(String, String) => BinaryFunc::Lt, 664;
                 params!(Jsonb, Jsonb) => BinaryFunc::Lt, 3242;
+                params!(ArrayAny, ArrayAny) => BinaryFunc::Lt, 1072;
             },
             "<=" => Scalar {
                 params!(DecimalAny, DecimalAny) => {
@@ -2477,6 +2478,7 @@ lazy_static! {
                 params!(Bytes, Bytes) => BinaryFunc::Lte, 1958;
                 params!(String, String) => BinaryFunc::Lte, 665;
                 params!(Jsonb, Jsonb) => BinaryFunc::Lte, 3244;
+                params!(ArrayAny, ArrayAny) => BinaryFunc::Lte, 1074;
             },
             ">" => Scalar {
                 params!(DecimalAny, DecimalAny) => {
@@ -2500,6 +2502,7 @@ lazy_static! {
                 params!(Bytes, Bytes) => BinaryFunc::Gt, 1959;
                 params!(String, String) => BinaryFunc::Gt, 666;
                 params!(Jsonb, Jsonb) => BinaryFunc::Gt, 3243;
+                params!(ArrayAny, ArrayAny) => BinaryFunc::Gt, 1073;
             },
             ">=" => Scalar {
                 params!(DecimalAny, DecimalAny) => {
@@ -2523,6 +2526,7 @@ lazy_static! {
                 params!(Bytes, Bytes) => BinaryFunc::Gte, 1960;
                 params!(String, String) => BinaryFunc::Gte, 667;
                 params!(Jsonb, Jsonb) => BinaryFunc::Gte, 3245;
+                params!(ArrayAny, ArrayAny) => BinaryFunc::Gte, 1075;
             },
             "=" => Scalar {
                 params!(DecimalAny, DecimalAny) => {
@@ -2571,6 +2575,7 @@ lazy_static! {
                 params!(Bytes, Bytes) => BinaryFunc::NotEq, 1956;
                 params!(String, String) => BinaryFunc::NotEq, 531;
                 params!(Jsonb, Jsonb) => BinaryFunc::NotEq, 3241;
+                params!(ArrayAny, ArrayAny) => BinaryFunc::NotEq, 1071;
             }
         }
     };

--- a/test/sqllogictest/arrays.slt
+++ b/test/sqllogictest/arrays.slt
@@ -225,6 +225,16 @@ SELECT ARRAY[1,2,4] = ARRAY[1,2,3]
 false
 
 query B
+SELECT ARRAY[1,2,3] != ARRAY[1,2,3]
+----
+false
+
+query B
+SELECT ARRAY[1,2,4] != ARRAY[1,2,3]
+----
+true
+
+query B
 SELECT ARRAY[1,2,4] = NULL
 ----
 NULL
@@ -236,5 +246,72 @@ SELECT ARRAY[1,2,NULL] = ARRAY[1,2,3]
 ----
 false
 
+query BB
+SELECT ARRAY[1] < ARRAY[1], ARRAY[1] <= ARRAY[1]
+----
+false true
+
+query BB
+SELECT ARRAY[1] < ARRAY[2], ARRAY[1] <= ARRAY[2]
+----
+true true
+
+query BB
+SELECT ARRAY[1] < ARRAY[[1]], ARRAY[1] <= ARRAY[[1]]
+----
+true true
+
+query BB
+SELECT ARRAY[2] < ARRAY[1, 2], ARRAY[2] <= ARRAY[1, 2]
+----
+false false
+
+# todo(uce): uncomment after #5982
+#query BB
+#SELECT ARRAY[1] < ARRAY[NULL]::int[], ARRAY[1] <= ARRAY[NULL]::int[]
+#----
+#true true
+
+query BB
+SELECT ARRAY[1] > ARRAY[1], ARRAY[1] >= ARRAY[1]
+----
+false true
+
+query BB
+SELECT ARRAY[1] > ARRAY[2], ARRAY[1] >= ARRAY[2]
+----
+false false
+
+query BB
+SELECT ARRAY[1] > ARRAY[[1]], ARRAY[1] >= ARRAY[[1]]
+----
+false false
+
+query BB
+SELECT ARRAY[2] > ARRAY[1, 2], ARRAY[2] >= ARRAY[1, 2]
+----
+true true
+
+# todo(uce): uncomment after #5982
+#query BB
+#SELECT ARRAY[1] > ARRAY[NULL]::int[], ARRAY[1] >= ARRAY[NULL]::int[]
+#----
+#false false
+
 query error no overload for integer\[\] = text\[\]: arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
 SELECT ARRAY[1,2,3] = ARRAY['1','2','3']
+
+query error no overload for integer\[\] <> text\[\]: arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+SELECT ARRAY[1,2,3] != ARRAY['1','2','3']
+
+query error no overload for integer\[\] < text\[\]: arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+SELECT ARRAY[1,2,3] < ARRAY['1','2','3']
+
+query error no overload for integer\[\] <= text\[\]: arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+SELECT ARRAY[1,2,3] <= ARRAY['1','2','3']
+
+query error no overload for integer\[\] > text\[\]: arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+SELECT ARRAY[1,2,3] > ARRAY['1','2','3']
+
+query error no overload for integer\[\] >= text\[\]: arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+SELECT ARRAY[1,2,3] >= ARRAY['1','2','3']


### PR DESCRIPTION
Fixes #6402. The `=` operator was added in #6648.

PS: I hope that this change [still counts as a single RU](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#commit-strategy). The actual change to support the comparisons was rather small and the tests don't work without the fix. I'm happy to split it out though, just let me know.