### PR TITLE
New syntax for postgres sources

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -244,13 +244,13 @@ steps:
           composition: debezium-avro
           run: debezium-avro
 
-  # - id: pg-cdc
-  #   label: "Postgres CDC test"
-  #   depends_on: build
-  #   plugins:
-  #     - ./ci/plugins/mzcompose:
-  #         composition: pg-cdc
-  #         run: pg-cdc
+  - id: pg-cdc
+    label: "Postgres CDC test"
+    depends_on: build
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: pg-cdc
+          run: pg-cdc
 
   - id: persistent-tables
     label: "Test for --persistent-tables"

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -860,8 +860,10 @@ impl Coordinator {
                         }
 
                         let internal_cmd_tx = self.internal_cmd_tx.clone();
+                        let catalog = self.catalog.for_session(&session);
+                        let purify_fut = sql::pure::purify(&catalog, stmt);
                         tokio::spawn(async move {
-                            let result = sql::pure::purify(stmt).await.map_err(|e| e.into());
+                            let result = purify_fut.await.map_err(|e| e.into());
                             internal_cmd_tx
                                 .send(Message::StatementReady(StatementReady {
                                     session,

--- a/src/sql/src/lib.rs
+++ b/src/sql/src/lib.rs
@@ -57,9 +57,9 @@
 //! CREATE SOURCE ... FORMAT AVRO USING SCHEMA '{"name": "foo", "fields": [...]}'
 //! ```
 //!
-//! Importantly, purification runs without access to the catalog. That means it
-//! can run in its own Tokio task so that it does not block any other SQL
-//! commands on the server.
+//! Importantly, purification cannot hold its reference to the catalog across an
+//! await point. That means it can run in its own Tokio task so that it does not
+//! block any other SQL commands on the server.
 //!
 //! [`Plan`]: crate::plan::Plan
 

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1119,7 +1119,7 @@ pub fn plan_create_views(
                 views: planned_views,
             }))
         }
-        CreateViewsDefinition::Source { .. } => bail!("cannot plan unpurified statement"),
+        CreateViewsDefinition::Source { .. } => bail!("cannot create view from source"),
     }
 }
 

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -11,7 +11,8 @@
 //!
 //! See the [crate-level documentation](crate) for details.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
+use std::future::Future;
 
 use anyhow::{anyhow, bail, ensure, Context};
 use aws_arn::ARN;
@@ -21,11 +22,15 @@ use tokio::task;
 use tokio::time::Duration;
 use uuid::Uuid;
 
+use dataflow_types::{ExternalSourceConnector, PostgresSourceConnector, SourceConnector};
 use repr::strconv;
 use sql_parser::ast::{
-    AvroSchema, Connector, CreateSourceFormat, CreateSourceStatement, CsrSeed, DbzMode, Envelope,
-    Format, Ident, Raw, Statement,
+    display::AstDisplay, AvroSchema, Connector, CreateSourceFormat, CreateSourceStatement,
+    CreateViewStatement, CreateViewsDefinition, CreateViewsSourceTarget, CreateViewsStatement,
+    CsrSeed, DbzMode, Envelope, Expr, Format, Ident, Query, Raw, RawName, Select, SelectItem,
+    SetExpr, Statement, TableFactor, TableWithJoins, UnresolvedObjectName, Value,
 };
+use sql_parser::parser::parse_columns;
 
 use crate::catalog::Catalog;
 use crate::kafka_util;
@@ -41,9 +46,29 @@ use crate::normalize;
 /// [`Catalog`](crate::catalog::Catalog), as that would require locking access
 /// to the catalog for an unbounded amount of time.
 pub fn purify(
-    _catalog: &dyn Catalog,
+    catalog: &dyn Catalog,
     mut stmt: Statement<Raw>,
 ) -> impl Future<Output = Result<Statement<Raw>, anyhow::Error>> {
+    // If we're dealing with a CREATE VIEWS statement we need to query the catalog for the
+    // corresponding source connector and store it before we enter the async section.
+    let source_connector = if let Statement::CreateViews(CreateViewsStatement {
+        views_definition: CreateViewsDefinition::Source { name, .. },
+        ..
+    }) = &stmt
+    {
+        normalize::unresolved_object_name(name.clone())
+            .map_err(anyhow::Error::new)
+            .and_then(|name| {
+                catalog
+                    .resolve_item(&name)
+                    .and_then(|item| item.source_connector())
+                    .map(|s| s.clone())
+                    .map_err(anyhow::Error::new)
+            })
+    } else {
+        Err(anyhow!("SQL statement does not refer to a source"))
+    };
+
     async {
         if let Statement::CreateSource(CreateSourceStatement {
             col_names,
@@ -138,6 +163,136 @@ pub fn purify(
                 &config_options,
             )
             .await?;
+        }
+        if let Statement::CreateViews(CreateViewsStatement {
+            if_exists,
+            temporary,
+            materialized,
+            views_definition,
+        }) = &mut stmt
+        {
+            if let CreateViewsDefinition::Source {
+                name: source_name,
+                targets,
+            } = views_definition
+            {
+                match source_connector? {
+                    SourceConnector::External {
+                        connector:
+                            ExternalSourceConnector::Postgres(PostgresSourceConnector {
+                                conn,
+                                publication,
+                                ..
+                            }),
+                        ..
+                    } => {
+                        let publication_info: HashMap<_, _> =
+                            postgres_util::publication_info(&conn, &publication)
+                                .await?
+                                .into_iter()
+                                .map(|info| (info.name.clone(), info))
+                                .collect();
+
+                        let mut view_stmts = Vec::with_capacity(publication_info.len());
+
+                        let targets = targets.clone().unwrap_or_else(|| {
+                            publication_info
+                                .keys()
+                                .map(|name| CreateViewsSourceTarget {
+                                    name: Ident::new(name),
+                                    alias: None,
+                                })
+                                .collect()
+                        });
+
+                        for target in targets {
+                            let table_info = match publication_info.get(target.name.as_str()) {
+                                Some(info) => info,
+                                None => bail!(
+                                    "table {:?} does not exist in upstream database",
+                                    target.name.as_str()
+                                ),
+                            };
+
+                            let view_name =
+                                target.alias.clone().unwrap_or_else(|| target.name.clone());
+
+                            let col_schema = table_info
+                                .schema
+                                .iter()
+                                .map(|c| c.to_ast_string())
+                                .collect::<Vec<String>>()
+                                .join(", ");
+                            let (columns, _constraints) =
+                                parse_columns(&format!("({})", col_schema))?;
+
+                            let mut projection = vec![];
+                            for (i, column) in columns.iter().enumerate() {
+                                projection.push(SelectItem::Expr {
+                                    expr: Expr::Cast {
+                                        expr: Box::new(Expr::SubscriptIndex {
+                                            expr: Box::new(Expr::Identifier(vec![Ident::new(
+                                                "row_data",
+                                            )])),
+                                            subscript: Box::new(Expr::Value(Value::Number(
+                                                // LIST is one based
+                                                (i + 1).to_string(),
+                                            ))),
+                                        }),
+                                        data_type: column.data_type.clone(),
+                                    },
+                                    alias: Some(column.name.clone()),
+                                });
+                            }
+
+                            let query = Query {
+                                ctes: vec![],
+                                body: SetExpr::Select(Box::new(Select {
+                                    distinct: None,
+                                    projection,
+                                    from: vec![TableWithJoins {
+                                        relation: TableFactor::Table {
+                                            name: RawName::Name(UnresolvedObjectName::unqualified(
+                                                &source_name.to_string(),
+                                            )),
+                                            alias: None,
+                                        },
+                                        joins: vec![],
+                                    }],
+                                    selection: Some(Expr::Op {
+                                        op: "=".to_string(),
+                                        expr1: Box::new(Expr::Identifier(vec![Ident::new("oid")])),
+                                        expr2: Some(Box::new(Expr::Value(Value::Number(
+                                            table_info.rel_id.to_string(),
+                                        )))),
+                                    }),
+                                    group_by: vec![],
+                                    having: None,
+                                    options: vec![],
+                                })),
+                                order_by: vec![],
+                                limit: None,
+                                offset: None,
+                            };
+
+                            view_stmts.push(CreateViewStatement {
+                                name: UnresolvedObjectName::unqualified(view_name.as_str()),
+                                columns: columns.iter().map(|c| c.name.clone()).collect(),
+                                with_options: vec![],
+                                query: query,
+                                if_exists: *if_exists,
+                                temporary: *temporary,
+                                materialized: *materialized,
+                            });
+                        }
+                        *views_definition = CreateViewsDefinition::Literal(view_stmts);
+                    }
+                    SourceConnector::External { connector, .. } => {
+                        bail!("cannot generate views from {} sources", connector.name())
+                    }
+                    SourceConnector::Local => bail!("cannot generate views from local sources"),
+                }
+            }
         }
         Ok(stmt)
     }

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -19,6 +19,7 @@ CREATE SCHEMA public;
 CREATE TABLE numbers (number int PRIMARY KEY, is_prime bool, name text);
 ALTER TABLE numbers REPLICA IDENTITY FULL;
 
+DROP SCHEMA IF EXISTS other_schema CASCADE;
 CREATE SCHEMA other_schema;
 CREATE TABLE other_schema.numbers (number int PRIMARY KEY, is_prime bool NOT NULL, name text NOT NULL);
 
@@ -77,147 +78,57 @@ CREATE TABLE conflict_table (f1 INTEGER);
 ALTER TABLE conflict_table REPLICA IDENTITY FULL;
 INSERT INTO conflict_table VALUES (123);
 
+DROP SCHEMA IF EXISTS conflict_schema CASCADE;
 CREATE SCHEMA conflict_schema;
 CREATE TABLE conflict_schema.conflict_table (f1 TEXT);
 ALTER TABLE conflict_schema.conflict_table REPLICA IDENTITY FULL;
 INSERT INTO conflict_schema.conflict_table VALUES ('234');
 
-## CREATE SOURCE with correct information should pass purification and fail afterwards.
-
-> CREATE SOURCE "schema_omitted"
-  FROM POSTGRES
-    HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-    PUBLICATION 'mz_source'
-    TABLE numbers;
-
-> CREATE SOURCE "empty_schema2"
-  FROM POSTGRES
-    HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-    PUBLICATION 'mz_source'
-    TABLE numbers ();
-# TODO: This should be an error
-
-> CREATE SOURCE "correct_schema_explicit_null"
-  FROM POSTGRES
-    HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-    PUBLICATION 'mz_source'
-    TABLE numbers (number int PRIMARY KEY, is_prime bool NULL, name text NULL)
-
-> CREATE MATERIALIZED SOURCE "correct_schema"
-  FROM POSTGRES
-    HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-    PUBLICATION 'mz_source'
-    TABLE numbers (number int PRIMARY KEY NOT NULL, is_prime bool, name text)
-
-## CREATE SOURCE with incorrect information should fail purification.
-
-! CREATE MATERIALIZED SOURCE "numbers"
-  FROM POSTGRES
-    HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-    PUBLICATION 'mz_source'
-    TABLE numbers (number int NOT NULL)
-incorrect column specification: 1 columns were specified, upstream has 3: number, is_prime, name
-
-! CREATE MATERIALIZED SOURCE "numbers"
-  FROM POSTGRES
-    HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-    PUBLICATION 'mz_source'
-    TABLE numbers (number int NOT NULL, is_prime bool null, name text, extra numeric NULL)
-incorrect column specification: 4 columns were specified, upstream has 3: number, is_prime, name
-
-! CREATE MATERIALIZED SOURCE "numbers"
-  FROM POSTGRES
-    HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-    PUBLICATION 'mz_source'
-    TABLE numbers (number int NOT NULL, is_prime int, name text)
-incorrect column specification: specified column modifiers do not match upstream source, specified: number int4 NOT NULL, upstream: number int4 PRIMARY KEY NOT NULL
-
-! CREATE MATERIALIZED SOURCE "numbers"
-  FROM POSTGRES
-    HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-    PUBLICATION 'mz_source'
-    TABLE numbers (number int NULL, is_prime bool null, name text)
-incorrect column specification: specified column modifiers do not match upstream source, specified: number int4 NULL, upstream: number int4 PRIMARY KEY NOT NULL
-
-! CREATE MATERIALIZED SOURCE "numbers"
-  FROM POSTGRES
-    HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-    PUBLICATION 'mz_source'
-    TABLE numbers (number int PRIMARY KEY, is_prime bool, name text NOT NULL)
-incorrect column specification: specified column modifiers do not match upstream source, specified: name text NOT NULL, upstream: name text NULL
-
 #
 # Error checking
 #
 
-! CREATE SOURCE "no_such_host"
+! CREATE MATERIALIZED SOURCE "no_such_host"
   FROM POSTGRES HOST 'host=no_such_postgres.mtrlz.com port=5432 user=postgres password=postgres dbname=postgres'
-  PUBLICATION 'mz_source' TABLE pk_table (pk INTEGER NOT NULL, f2 TEXT);
+  PUBLICATION 'mz_source';
 error connecting to server: failed to lookup address information: Name or service not known
 
-! CREATE SOURCE "no_such_port"
+! CREATE MATERIALIZED SOURCE "no_such_port"
   FROM POSTGRES HOST 'host=postgres port=65534 user=postgres password=postgres dbname=postgres'
-  PUBLICATION 'mz_source' TABLE pk_table (pk INTEGER NOT NULL, f2 TEXT);
+  PUBLICATION 'mz_source';
 error connecting to server: Connection refused (os error 111)
 
-! CREATE SOURCE "no_such_user"
+! CREATE MATERIALIZED SOURCE "no_such_user"
   FROM POSTGRES HOST 'host=postgres port=5432 user=no_such_user password=postgres dbname=postgres'
-  PUBLICATION 'mz_source' TABLE pk_table (pk INTEGER NOT NULL, f2 TEXT);
+  PUBLICATION 'mz_source';
 db error: FATAL: role "no_such_user" does not exist
 
-> CREATE SOURCE "no_such_password"
+> CREATE MATERIALIZED SOURCE "no_such_password"
   FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=no_such_password dbname=postgres'
-  PUBLICATION 'mz_source' TABLE pk_table (pk INTEGER PRIMARY KEY NOT NULL, f2 TEXT);
+  PUBLICATION 'mz_source';
 # TODO: This should produce an error
 
-! CREATE SOURCE "no_replication"
+> CREATE MATERIALIZED SOURCE "no_replication"
   FROM POSTGRES HOST 'host=postgres port=5432 user=no_replication password=no_replication dbname=postgres'
-  PUBLICATION 'mz_source' TABLE pk_table (pk INTEGER PRIMARY KEY, f2 TEXT);
-db error: ERROR: relation "pk_table" does not exist
+  PUBLICATION 'mz_source';
+# TODO: This should produce an error
 
-! CREATE SOURCE "no_such_dbname"
+! CREATE MATERIALIZED SOURCE "no_such_dbname"
   FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=no_such_dbname'
-  PUBLICATION 'mz_source' TABLE pk_table (pk INTEGER PRIMARY KEY, f2 TEXT);
+  PUBLICATION 'mz_source';
 db error: FATAL: database "no_such_dbname" does not exist
 
-> CREATE SOURCE "no_such_publication"
+> CREATE MATERIALIZED SOURCE "no_such_publication"
   FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-  PUBLICATION 'no_such_publication' TABLE pk_table (pk INTEGER PRIMARY KEY NOT NULL, f2 TEXT);
+  PUBLICATION 'no_such_publication';
 # TODO: This should produce an error
 
-! CREATE SOURCE "no_such_namespace"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-  PUBLICATION 'mz_source' TABLE no_such_namespace.pk_table (pk INTEGER PRIMARY KEY NOT NULL, f2 TEXT);
-schema "no_such_namespace" does not exist
 
-! CREATE SOURCE "no_such_table"
+> CREATE MATERIALIZED SOURCE "mz_source"
   FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-  PUBLICATION 'mz_source' TABLE no_such_table (pk INTEGER PRIMARY KEY, f2 TEXT);
-relation "no_such_table" does not exist
+  PUBLICATION 'mz_source';
 
-! CREATE SOURCE "no_such_column"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-  PUBLICATION 'mz_source' TABLE pk_table (no_such_column INTEGER, f2 TEXT);
-column does not match upstream source, specified: no_such_column int4, upstream: pk int4 PRIMARY KEY NOT NULL
-
-! CREATE SOURCE "column_type_mismatch"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-  PUBLICATION 'mz_source' TABLE pk_table (f1 TIMESTAMP, f2 TEXT);
-column does not match upstream source, specified: f1 timestamp, upstream: pk int4 PRIMARY KEY NOT NULL
-
-! CREATE SOURCE "missing_column"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-  PUBLICATION 'mz_source' TABLE pk_table (pk INTEGER NOT NULL);
-incorrect column specification: 1 columns were specified, upstream has 2: pk, f2
-
-! CREATE SOURCE "extra_column"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-  PUBLICATION 'mz_source' TABLE pk_table (pk INTEGER NOT NULL, f2 TEXT, f3 INTEGER);
-incorrect column specification: 3 columns were specified, upstream has 2: pk, f2
-
-> CREATE MATERIALIZED SOURCE "no_replica_identity"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-  PUBLICATION 'mz_source' TABLE no_replica_identity (f1 INTEGER);
+> CREATE VIEWS FROM SOURCE "mz_source" ("no_replica_identity")
 # TODO: This should produce an error
 
 #
@@ -228,58 +139,33 @@ incorrect column specification: 3 columns were specified, upstream has 2: pk, f2
 1
 2
 
-! CREATE MATERIALIZED SOURCE "conflict_table"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-  PUBLICATION 'mz_source' TABLE conflict_table (f1 TEXT)
-incorrect column specification: specified column does not match upstream source
-
 #
 # Establish direct replication
 #
 
-> CREATE MATERIALIZED SOURCE "pk_table"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-  PUBLICATION 'mz_source' TABLE pk_table (pk INTEGER PRIMARY KEY, f2 TEXT);
+> CREATE VIEWS FROM SOURCE "mz_source" ("pk_table");
 
-> CREATE MATERIALIZED SOURCE "nonpk_table"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-  PUBLICATION 'mz_source' TABLE nonpk_table (f1 INTEGER, f2 INTEGER);
+> CREATE VIEWS FROM SOURCE "mz_source" ("nonpk_table");
 
-> CREATE MATERIALIZED SOURCE "types_table"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-  PUBLICATION 'mz_source' TABLE types_table (date_col DATE, time_col TIME, timestamp_col TIMESTAMP, uuid_col UUID, double_col DOUBLE PRECISION);
+> CREATE VIEWS FROM SOURCE "mz_source" ("types_table");
 
-> CREATE MATERIALIZED SOURCE "large_text"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-  PUBLICATION 'mz_source' TABLE large_text (f1 TEXT);
+> CREATE VIEWS FROM SOURCE "mz_source" ("large_text");
 
-> CREATE MATERIALIZED SOURCE "trailing_space_pk"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-  PUBLICATION 'mz_source' TABLE trailing_space_pk (f1 TEXT PRIMARY KEY);
+> CREATE VIEWS FROM SOURCE "mz_source" ("trailing_space_pk");
 
-> CREATE MATERIALIZED SOURCE "trailing_space_nopk"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-  PUBLICATION 'mz_source' TABLE trailing_space_nopk (f1 TEXT);
+> CREATE VIEWS FROM SOURCE "mz_source" ("trailing_space_nopk");
 
-> CREATE MATERIALIZED SOURCE "multipart_pk"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-  PUBLICATION 'mz_source' TABLE multipart_pk (f1 INTEGER PRIMARY KEY, f2 TEXT PRIMARY KEY NOT NULL, f3 TEXT);
+> CREATE VIEWS FROM SOURCE "mz_source" ("multipart_pk");
 
-> CREATE MATERIALIZED SOURCE "nulls_table"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-  PUBLICATION 'mz_source' TABLE nulls_table (f1 TEXT, f2 INTEGER);
+> CREATE VIEWS FROM SOURCE "mz_source" ("nulls_table");
 
-> CREATE MATERIALIZED SOURCE "utf8_table"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-  PUBLICATION 'mz_source' TABLE utf8_table (f1 TEXT PRIMARY KEY, f2 TEXT);
+> CREATE VIEWS FROM SOURCE "mz_source" ("utf8_table");
 
-> CREATE MATERIALIZED SOURCE "таблица"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-  PUBLICATION 'mz_source' TABLE "таблица" ("колона" TEXT);
+> CREATE VIEWS FROM SOURCE "mz_source" ("таблица");
 
-> CREATE MATERIALIZED SOURCE "conflict_table"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
-  PUBLICATION 'mz_source' TABLE conflict_schema.conflict_table
+# TODO(petrosagg): support this syntax
+! CREATE VIEWS FROM SOURCE "mz_source" (conflict_schema.conflict_table AS conflict_table);
+Expected right parenthesis, found dot
 
 #
 # Perform sanity checks of the initial snapshot
@@ -320,8 +206,9 @@ incorrect column specification: specified column does not match upstream source
 > SELECT * FROM "таблица";
 стойност
 
-> SELECT * FROM conflict_table;
-234
+# TODO(petrosagg): contigent to fixing fully qualified targets
+# > SELECT * FROM conflict_table;
+# 234
 
 #
 # Confirm that the new sources can be used to build upon
@@ -501,8 +388,8 @@ true
 > SELECT COUNT(*) = 0 FROM "таблица";
 true
 
-> SELECT COUNT(*) = 0 FROM conflict_table;
-true
+# > SELECT COUNT(*) = 0 FROM conflict_table;
+# true
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 DROP PUBLICATION mz_source;


### PR DESCRIPTION
This PR provides syntax-sugar for auto-generating views on top of the pg replication stream sources based on information received from the upstream database.

The generated views filter based on a particular OID and then cast the text encoded values present in `row_data` into the appropriate data types. The generated view looks like this:

```sql
CREATE VIEW "foo" AS (SELECT
    row_data[1]::int AS my_int_column
FROM "source_name"
WHERE oid = 1337
```