### PR TITLE
Validate debezium topics in chbench

### DIFF
--- a/demo/chbench/mzcompose.yml
+++ b/demo/chbench/mzcompose.yml
@@ -271,6 +271,8 @@ services:
     command: ${CORRECTNESS_CMD:---mz-sources --checks c3321 --config-file /etc/test-correctness/checks-noconsistency.toml}
     volumes:
       - ./test-correctness-config:/etc/test-correctness
+  validate-debezium-topics:
+    mzbuild: validate-debezium-topics
 
 
 volumes:
@@ -771,3 +773,10 @@ mzworkflows:
         -l /var/log/chbench.log
         --config-file-path=/etc/chbenchmark/mz-default-postgres.cfg
         --mz-url=postgresql://materialize@${MZ_HOST:-materialized}:${MZ_PORT:-6875}/materialize?sslmode=disable
+
+  validate-topics:
+    steps:
+    - step: run
+      service: validate-debezium-topics
+      command: >-
+        --database-name=debezium

--- a/src/coord/src/timestamp.rs
+++ b/src/coord/src/timestamp.rs
@@ -485,8 +485,9 @@ fn parse_debezium(
             (_, _) => (),
         }
     }
-    // TODO (#6670): figure out if we can assert that event_count is non-zero
-    // Can a transaction message have zero colections?
+    if event_count < 0 {
+        bail!("Expected non-negative event count, got '{}'", event_count);
+    }
     if collections.iter().map(|(_, c)| c).sum::<i64>() != event_count {
         bail!(
             "Event count '{:?}' does not match parsed collections: {:?}",


### PR DESCRIPTION
Apparently "event_count" can be zero when using Postgres, so update
the related comment in timestamp.rs.

Make the debezium transaction topic name configurable.

Fixes #6670