### PR TITLE
Improve error handling in benchmarks

### DIFF
--- a/misc/perf-dash/create_views/create_views
+++ b/misc/perf-dash/create_views/create_views
@@ -11,5 +11,5 @@
 set -euo pipefail
 
 for view_file in *.sql; do
-    psql -h perf-dash-metrics -p 8675 -U materialize -f "${view_file}" materialize
+    psql -v ON_ERROR_STOP=1 -h perf-dash-metrics -p 8675 -U materialize -f "${view_file}" materialize
 done

--- a/test/bench/avro-upsert/create_views/create_views
+++ b/test/bench/avro-upsert/create_views/create_views
@@ -12,4 +12,4 @@ set -euo pipefail
 
 view_file="/data/${1:-upsert_views.sql}"
 
-psql -h materialized -p 6875 -U materialize -f "${view_file}" materialize
+psql -v ON_ERROR_STOP=1 -h materialized -p 6875 -U materialize -f "${view_file}" materialize

--- a/test/bench/kafka-sink-avro-debezium/create_sink/create_sink
+++ b/test/bench/kafka-sink-avro-debezium/create_sink/create_sink
@@ -12,4 +12,4 @@ set -euo pipefail
 
 sink_file="/data/${1:-no-consistency-no-exactly-once-sink.sql}"
 
-psql -h materialized -p 6875 -U materialize -f "${sink_file}" materialize
+psql -v ON_ERROR_STOP=1 -h materialized -p 6875 -U materialize -f "${sink_file}" materialize

--- a/test/bench/util/kafka-avro-generator/generate_records
+++ b/test/bench/util/kafka-avro-generator/generate_records
@@ -13,10 +13,11 @@ import argparse
 import multiprocessing
 import pathlib
 import subprocess
+import sys
 
 DISTRIBUTIONS = "/usr/share/generator/distributions"
 
-def run(args: argparse.Namespace) -> None:
+def run(args: argparse.Namespace) -> int:
     """Run the generator, inserting args.num_records number of messages."""
 
     records_per_process = int(args.num_records / args.parallelism)
@@ -66,11 +67,19 @@ def run(args: argparse.Namespace) -> None:
         f"Spawning {args.parallelism} generator processes, writing {records_per_process} messages each"
     )
     procs = [subprocess.Popen(kafka_gen) for _ in range(0, args.parallelism)]
+
+    exit_code = 0
     for (i, p) in enumerate(procs):
         p.wait()
         print(
             f"{i}/{args.parallelism} processes finished: pid={p.pid} returncode={p.returncode}"
         )
+
+        # If a process exited with an error, exit with the return code of the first such process
+        if p.returncode != 0 and exit_code == 0:
+            exit_code = p.returncode
+
+    return exit_code
 
 
 if __name__ == "__main__":
@@ -128,4 +137,4 @@ if __name__ == "__main__":
         print("ERROR: Number of records must divide evenly by number of processes")
         sys.exit(1)
 
-    run(args)
+    sys.exit(run(args))


### PR DESCRIPTION
If we fail to create views, or if any kgen process exits with
error, then we know the benchmark won't be valid. Ensure that
we exit with error to make sure that the benchmark fails at the
right point instead of timing out or presenting another inscrutable
error.