### PR TITLE
debezium-avro: apply a 300-second global timeout

### DIFF
--- a/test/debezium-avro/03-drop-not-null-column.td
+++ b/test/debezium-avro/03-drop-not-null-column.td
@@ -16,9 +16,6 @@ $ postgres-execute connection=postgres://postgres:postgres@postgres
 CREATE TABLE alter_drop_column_not_null (f1 INTEGER, col_not_null INTEGER NOT NULL);
 INSERT INTO alter_drop_column_not_null VALUES (123, 234);
 
-# Debezium can take a while to make the topic
-$ set-sql-timeout duration=300s
-
 > CREATE MATERIALIZED SOURCE alter_drop_column_not_null
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'postgres.public.alter_drop_column_not_null'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'

--- a/test/debezium-avro/mzcompose.yml
+++ b/test/debezium-avro/mzcompose.yml
@@ -54,7 +54,7 @@ services:
         --materialized-url=postgres://materialize@materialized:6875
         --validate-catalog=/share/mzdata/catalog
         --no-reset
-        --default-timeout 60
+        --default-timeout 300
         $$*
       - bash
     environment:


### PR DESCRIPTION
Debezium is known to be very slow when creating topics, so use a
global 300-second timeout across the board.