### PR TITLE
avro: provide a more informative message on schema resolution errors

### DIFF
--- a/src/interchange/src/avro/schema.rs
+++ b/src/interchange/src/avro/schema.rs
@@ -12,7 +12,7 @@ use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::str::FromStr;
 
-use anyhow::{anyhow, bail, Context};
+use anyhow::{anyhow, bail, Error};
 
 use byteorder::{BigEndian, ByteOrder};
 use mz_avro::error::Error as AvroError;
@@ -383,7 +383,7 @@ impl ConfluentAvroResolver {
                 cache
                     .get(schema_id, &self.reader_schema)
                     .await
-                    .with_context(|| format!("Failed to fetch schema with ID {}", schema_id))?
+                    .map_err(Error::msg)?
             }
 
             // If we haven't been asked to use a schema registry, we have no way

--- a/test/testdrive/avro-resolution-no-publish-writer.td
+++ b/test/testdrive/avro-resolution-no-publish-writer.td
@@ -30,4 +30,4 @@ $ kafka-ingest format=avro topic=resolution-no-publish-writer schema=${int-schem
 {"f1": 123}
 
 ! SELECT * FROM resolution_no_publish_writer;
-Failed to fetch schema
+Attempted to resolve writer schema node named .some_record against reader schema node named .schema_int

--- a/test/testdrive/avro-resolution-types-array.td
+++ b/test/testdrive/avro-resolution-types-array.td
@@ -28,4 +28,4 @@ $ kafka-ingest format=avro topic=resolution-arrays schema=${array-double} publis
 {"f1": [ 234.345 ] }
 
 ! SELECT f1[0] FROM resolution_arrays
-Failed to fetch schema
+Schemas don't match: Double, Int

--- a/test/testdrive/avro-resolution-types-map.td
+++ b/test/testdrive/avro-resolution-types-map.td
@@ -28,4 +28,4 @@ $ kafka-ingest format=avro topic=resolution-maps schema=${map-double} publish=tr
 {"f1": { "key1": 234.345 } }
 
 ! SELECT f1 -> 'key1' FROM resolution_maps
-Failed to fetch schema
+Schemas don't match: Double, Int

--- a/test/testdrive/avro-resolution-types-records.td
+++ b/test/testdrive/avro-resolution-types-records.td
@@ -29,4 +29,4 @@ $ kafka-ingest format=avro topic=resolution-records-int2double schema=${double-c
 {"f1": { "f1": 123.234 }}
 
 ! SELECT * FROM resolution_records_int2double
-Failed to fetch schema
+Schemas don't match: Double, Int

--- a/test/testdrive/avro-resolution-types.td
+++ b/test/testdrive/avro-resolution-types.td
@@ -29,4 +29,4 @@ $ kafka-ingest format=avro topic=resolution-int2double schema=${double-col} publ
 {"f1": 234.456}
 
 ! SELECT * FROM resolution_int2double
-Failed to fetch schema
+Schema resolution error: Schemas don't match: Double, Int


### PR DESCRIPTION
Previously, the error was "Failed to fetch schema with ID X" but with this
patch the underlying error is reported directly without leaking the schema ID