### PR TITLE
Always inline subexpressions invoking mz_logical_timestamp

### DIFF
--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -10,7 +10,7 @@ use std::collections::{HashMap, HashSet};
 
 use serde::{Deserialize, Serialize};
 
-use crate::{MirRelationExpr, MirScalarExpr, NullaryFunc};
+use crate::{MirRelationExpr, MirScalarExpr};
 use repr::{Datum, Row};
 
 /// A compound operator that can be applied row-by-row.
@@ -855,6 +855,7 @@ impl MapFilterProject {
                         true
                     } else {
                         reference_count[i] == 1
+                            || self.expressions[i - input_arity].contains_temporal()
                     }
                 }
             })
@@ -1009,7 +1010,6 @@ pub fn memoize_expr(
                 MirScalarExpr::Column(_) | MirScalarExpr::Literal(_, _) => {
                     // Literals do not need to be memoized.
                 }
-                MirScalarExpr::CallNullary(_func @ NullaryFunc::MzLogicalTimestamp) => {}
                 _ => {
                     if let Some(position) = memoized_parts.iter().position(|e2| e2 == e) {
                         // Any complex expression that already exists as a prior column can

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -10,7 +10,7 @@ use std::collections::{HashMap, HashSet};
 
 use serde::{Deserialize, Serialize};
 
-use crate::{MirRelationExpr, MirScalarExpr};
+use crate::{MirRelationExpr, MirScalarExpr, NullaryFunc};
 use repr::{Datum, Row};
 
 /// A compound operator that can be applied row-by-row.
@@ -1009,6 +1009,7 @@ pub fn memoize_expr(
                 MirScalarExpr::Column(_) | MirScalarExpr::Literal(_, _) => {
                     // Literals do not need to be memoized.
                 }
+                MirScalarExpr::CallNullary(_func @ NullaryFunc::MzLogicalTimestamp) => {}
                 _ => {
                     if let Some(position) = memoized_parts.iter().position(|e2| e2 == e) {
                         // Any complex expression that already exists as a prior column can

--- a/test/sqllogictest/temporal.slt
+++ b/test/sqllogictest/temporal.slt
@@ -54,3 +54,26 @@ query II rowsort
 select * from valid AS OF 18446744073709551615;
 ----
 5  18446744073709551616
+
+#
+# Regression test for #6635
+#
+statement ok
+CREATE TABLE events (
+    content text,
+    insert_ts numeric,
+    delete_ts numeric
+);
+
+statement ok
+CREATE MATERIALIZED VIEW valid_events AS
+SELECT content, count(*)
+FROM events
+WHERE mz_logical_timestamp() >= insert_ts
+  AND mz_logical_timestamp()  < delete_ts
+GROUP BY content;
+
+
+query TI rowsort
+select * from valid_events;
+----


### PR DESCRIPTION
Fix for #6635.