### PR TITLE
Publish the validate-debezium-topics Docker image

### DIFF
--- a/demo/debezium/validate-topics/ci/mzbuild.yml
+++ b/demo/debezium/validate-topics/ci/mzbuild.yml
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 name: validate-debezium-topics
-publish: false
 pre-image:
   - type: cargo-build
     bin: validate-debezium-topics


### PR DESCRIPTION
Our nightly load tests do not have a rust compilation toolchain, so
adding this image to our load test compositions caused them to fail.

Additionally not having this as a pre-built Docker image causes all
users of the chbench demo to be forced to to compile and therefore have
a rust toolchain.

I created and configured the repo at: https://hub.docker.com/repository/docker/materialize/validate-debezium-topics