### PR TITLE
test: fix flakey FETCH test

### DIFF
--- a/test/testdrive/fetch-tail-as-of.td
+++ b/test/testdrive/fetch-tail-as-of.td
@@ -26,6 +26,13 @@ out of range integral type conversion attempted
 
 > COMMIT
 
+# Since FETCH isn't idempotent and can't be correctly retried by testdrive
+# (although testdrive will try), wait until SELECT fails with this error
+# (which will happen after t has been compacted) and then we should be
+# able to see the same failure with FETCH.
+! SELECT * FROM t1 AS OF 0
+Timestamp (0) is not valid for all inputs
+
 > BEGIN
 
 > DECLARE c CURSOR FOR TAIL t1 AS OF 0;


### PR DESCRIPTION
FETCH isn't idempotent, so if it expects an error we have to be sure
it'll produce it on the first try.