### PR TITLE
coord: manage Postgres source external state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,6 +867,7 @@ dependencies = [
  "interchange",
  "kafka-util",
  "log",
+ "postgres-util",
  "regex",
  "repr",
  "rusoto_core",

--- a/src/coord/src/catalog/error.rs
+++ b/src/coord/src/catalog/error.rs
@@ -32,6 +32,7 @@ pub(crate) enum ErrorKind {
     SchemaAlreadyExists(String),
     RoleAlreadyExists(String),
     ItemAlreadyExists(String),
+    ExternalStateAlreadyExists(String),
     ReservedSchemaName(String),
     ReservedRoleName(String),
     ReadOnlySystemSchema(String),
@@ -107,6 +108,7 @@ impl std::error::Error for Error {
             | ErrorKind::SchemaAlreadyExists(_)
             | ErrorKind::RoleAlreadyExists(_)
             | ErrorKind::ItemAlreadyExists(_)
+            | ErrorKind::ExternalStateAlreadyExists(_)
             | ErrorKind::ReservedSchemaName(_)
             | ErrorKind::ReservedRoleName(_)
             | ErrorKind::ReadOnlySystemSchema(_)
@@ -143,6 +145,13 @@ impl fmt::Display for Error {
             }
             ErrorKind::ItemAlreadyExists(name) => {
                 write!(f, "catalog item '{}' already exists", name)
+            }
+            ErrorKind::ExternalStateAlreadyExists(gid) => {
+                write!(
+                    f,
+                    "external state for catalog item '{}' already exists",
+                    gid
+                )
             }
             ErrorKind::ReservedSchemaName(name) => {
                 write!(f, "unacceptable schema name '{}'", name)

--- a/src/dataflow-types/Cargo.toml
+++ b/src/dataflow-types/Cargo.toml
@@ -14,6 +14,7 @@ globset = { version = "0.4.0", features = ["serde1"] }
 interchange = { path = "../interchange" }
 kafka-util = { path = "../kafka-util" }
 log = "0.4.13"
+postgres-util = { path = "../postgres-util" }
 regex = "1.4.6"
 repr = { path = "../repr" }
 rusoto_core = { git = "https://github.com/rusoto/rusoto.git" }

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -752,7 +752,7 @@ impl ExternalSourceConnector {
         match self {
             ExternalSourceConnector::Postgres(p) => Some(ExternalState::PostgresReplicationSlot {
                 conn: p.conn.clone(),
-                slot_prefix: p.slot_name.clone(),
+                slot_name: p.slot_name.clone(),
             }),
             _ => None,
         }
@@ -1032,7 +1032,7 @@ impl LinearOperator {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum ExternalState {
-    PostgresReplicationSlot { conn: String, slot_prefix: String },
+    PostgresReplicationSlot { conn: String, slot_name: String },
 }
 
 impl ExternalState {
@@ -1046,7 +1046,9 @@ impl ExternalState {
 
     pub async fn destroy(&self) -> Result<(), anyhow::Error> {
         match self {
-            ExternalState::PostgresReplicationSlot { .. } => (),
+            ExternalState::PostgresReplicationSlot { conn, slot_name } => {
+                postgres_util::drop_replication_slots(conn, &[slot_name]).await?
+            }
         }
         Ok(())
     }

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -312,6 +312,8 @@ pub enum CatalogError {
     UnknownRole(String),
     /// Unknown item.
     UnknownItem(String),
+    /// Unknown external state.
+    UnknownExternalState(String),
     /// Unknown function.
     UnknownFunction(String),
     /// Unknown source.
@@ -334,6 +336,7 @@ impl fmt::Display for CatalogError {
             Self::UnknownSchema(name) => write!(f, "unknown schema '{}'", name),
             Self::UnknownRole(name) => write!(f, "unknown role '{}'", name),
             Self::UnknownItem(name) => write!(f, "unknown catalog item '{}'", name),
+            Self::UnknownExternalState(name) => write!(f, "unknown external state '{}'", name),
             Self::InvalidDependency { name, typ } => write!(
                 f,
                 "catalog item '{}' is {} {} and so cannot be depended upon",

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -426,6 +426,9 @@ pub fn build(cmds: Vec<PosCommand>, state: &State) -> Result<Vec<PosAction>, Err
                     "postgres-execute" => {
                         Box::new(postgres::build_execute(builtin).map_err(wrap_err)?)
                     }
+                    "postgres-verify-slot" => {
+                        Box::new(postgres::build_verify_slot(builtin).map_err(wrap_err)?)
+                    }
                     "random-sleep" => {
                         Box::new(sleep::build_random_sleep(builtin).map_err(wrap_err)?)
                     }

--- a/src/testdrive/src/action/postgres.rs
+++ b/src/testdrive/src/action/postgres.rs
@@ -7,52 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use async_trait::async_trait;
-use tokio_postgres::NoTls;
+mod execute;
+mod verify_slot;
 
-use crate::action::{Action, State};
-use crate::parser::BuiltinCommand;
-
-pub struct ExecuteAction {
-    connection: String,
-    queries: Vec<String>,
-}
-
-pub fn build_execute(mut cmd: BuiltinCommand) -> Result<ExecuteAction, String> {
-    let connection = cmd.args.string("connection")?;
-    cmd.args.done()?;
-    Ok(ExecuteAction {
-        connection,
-        queries: cmd.input,
-    })
-}
-
-#[async_trait]
-impl Action for ExecuteAction {
-    async fn undo(&self, _: &mut State) -> Result<(), String> {
-        Ok(())
-    }
-
-    async fn redo(&self, _: &mut State) -> Result<(), String> {
-        let (client, conn) = tokio_postgres::connect(&self.connection, NoTls)
-            .await
-            .map_err(|e| format!("connecting to postgres: {}", e))?;
-        println!(
-            "Executing queries against PostgreSQL server at {}...",
-            self.connection
-        );
-        let conn_handle = tokio::spawn(conn);
-        for query in &self.queries {
-            println!(">> {}", query);
-            client
-                .batch_execute(query)
-                .await
-                .map_err(|e| format!("executing postgres query: {}", e))?;
-        }
-        drop(client);
-        conn_handle
-            .await
-            .unwrap()
-            .map_err(|e| format!("postgres connection error: {}", e))
-    }
-}
+pub use execute::build_execute;
+pub use verify_slot::build_verify_slot;

--- a/src/testdrive/src/action/postgres/execute.rs
+++ b/src/testdrive/src/action/postgres/execute.rs
@@ -1,0 +1,58 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use async_trait::async_trait;
+use tokio_postgres::NoTls;
+
+use crate::action::{Action, State};
+use crate::parser::BuiltinCommand;
+
+pub struct ExecuteAction {
+    connection: String,
+    queries: Vec<String>,
+}
+
+pub fn build_execute(mut cmd: BuiltinCommand) -> Result<ExecuteAction, String> {
+    let connection = cmd.args.string("connection")?;
+    cmd.args.done()?;
+    Ok(ExecuteAction {
+        connection,
+        queries: cmd.input,
+    })
+}
+
+#[async_trait]
+impl Action for ExecuteAction {
+    async fn undo(&self, _: &mut State) -> Result<(), String> {
+        Ok(())
+    }
+
+    async fn redo(&self, _: &mut State) -> Result<(), String> {
+        let (client, conn) = tokio_postgres::connect(&self.connection, NoTls)
+            .await
+            .map_err(|e| format!("connecting to postgres: {}", e))?;
+        println!(
+            "Executing queries against PostgreSQL server at {}...",
+            self.connection
+        );
+        let conn_handle = tokio::spawn(conn);
+        for query in &self.queries {
+            println!(">> {}", query);
+            client
+                .batch_execute(query)
+                .await
+                .map_err(|e| format!("executing postgres query: {}", e))?;
+        }
+        drop(client);
+        conn_handle
+            .await
+            .unwrap()
+            .map_err(|e| format!("postgres connection error: {}", e))
+    }
+}

--- a/src/testdrive/src/action/postgres/verify_slot.rs
+++ b/src/testdrive/src/action/postgres/verify_slot.rs
@@ -1,0 +1,99 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use async_trait::async_trait;
+use std::time::Duration;
+use tokio_postgres::NoTls;
+
+use ore::retry::Retry;
+
+use crate::action::{Action, State};
+use crate::parser::BuiltinCommand;
+
+pub struct VerifySlotAction {
+    connection: String,
+    slot: String,
+    active: bool,
+}
+
+pub fn build_verify_slot(mut cmd: BuiltinCommand) -> Result<VerifySlotAction, String> {
+    let connection = cmd.args.string("connection")?;
+    let slot = cmd.args.string("slot")?;
+    let active: bool = cmd.args.parse("active")?;
+    cmd.args.done()?;
+    Ok(VerifySlotAction {
+        connection,
+        slot,
+        active,
+    })
+}
+
+#[async_trait]
+impl Action for VerifySlotAction {
+    async fn undo(&self, _: &mut State) -> Result<(), String> {
+        Ok(())
+    }
+
+    async fn redo(&self, _: &mut State) -> Result<(), String> {
+        let (client, conn) = tokio_postgres::connect(&self.connection, NoTls)
+            .await
+            .map_err(|e| format!("connecting to postgres: {}", e))?;
+        println!(
+            "Executing queries against PostgreSQL server at {}...",
+            self.connection
+        );
+        let conn_handle = tokio::spawn(conn);
+
+        Retry::default()
+            .initial_backoff(Duration::from_millis(50))
+            .max_duration(Duration::from_secs(3))
+            .retry(|_| async {
+                println!(">> checking for postgres replication slot {}", &self.slot);
+                let rows = client
+                    .query(
+                        "SELECT active_pid FROM pg_replication_slots WHERE slot_name = $1::TEXT",
+                        &[&self.slot],
+                    )
+                    .await
+                    .map_err(|e| format!("querying postgres for replication slot: {}", e))?;
+
+                if self.active {
+                    if rows.len() != 1 {
+                        return Err(format!(
+                            "expected entry for slot {} in pg_replication slots, found {}",
+                            &self.slot,
+                            rows.len()
+                        ));
+                    }
+                    let active_pid: Option<i32> = rows[0].get(0);
+                    if active_pid.is_none() {
+                        return Err(format!(
+                            "expected slot {} to be active, is inactive",
+                            &self.slot
+                        ));
+                    }
+                } else {
+                    if rows.len() != 0 {
+                        return Err(format!(
+                            "expected slot {} to be inactive, is active",
+                            &self.slot
+                        ));
+                    }
+                }
+                Ok(())
+            })
+            .await?;
+
+        drop(client);
+        conn_handle
+            .await
+            .unwrap()
+            .map_err(|e| format!("postgres connection error: {}", e))
+    }
+}

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -339,6 +339,23 @@ true
 true
 
 #
+# Test that slots created for replication sources are deleted on DROP
+#
+$ postgres-verify-slot connection=postgres://postgres:postgres@postgres slot=test_slot active=false
+
+> CREATE MATERIALIZED SOURCE "test_slot_source"
+  FROM POSTGRES
+    HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
+    PUBLICATION 'mz_source'
+    SLOT 'test_slot';
+
+$ postgres-verify-slot connection=postgres://postgres:postgres@postgres slot=test_slot active=true
+
+> DROP SOURCE test_slot_source
+
+$ postgres-verify-slot connection=postgres://postgres:postgres@postgres slot=test_slot active=false
+
+#
 # Remove all data on the Postgres side
 #
 


### PR DESCRIPTION
This PR does a few things:
- Introduces the scaffolding for the new `ExternalState` enum that was settled upon in our [recent design review and discussion](https://github.com/MaterializeInc/materialize/pull/6655).
- Correctly drops an upstream Postgres replication slot when a Postgres source is dropped using the new `ExternalState` enum.
- Adds a new `postgres-verify-slot` action to testdrive with tests to confirm that we are correctly dropping the upstream replication slots.

This implementation works as long as we enforce that users can only create materialized Postgres sources, but will need to be tweaked when we allow unmaterialized Postgres sources. This future work is captured in [this refactoring issue](https://github.com/MaterializeInc/materialize/issues/6723).