### PR TITLE
debezium-avro: mz_sleep() after configuring Debezium

### DIFF
--- a/test/debezium-avro/debezium-postgres.td.initialize
+++ b/test/debezium-avro/debezium-postgres.td.initialize
@@ -58,3 +58,9 @@ $ http-request method=POST url=http://debezium:8083/connectors content-type=appl
     "decimal.handling.mode": "precise"
   }
 }
+
+# Sleep for 10 seconds, as Debezium may fail to replicate any
+# postgresql statements that come immediately afterwards
+
+> SELECT mz_internal.mz_sleep(10)
+<null>


### PR DESCRIPTION
Due to a race condition in Debezium, tables that are created
immediately after configuring Debezium are not detected and replicated.

They are not made part of the initial snapshot and their presence
is not detected afterwards. No schema registry entries are created
which in turn causes Mz to error out.

-------------------------------

This issue could not be reproduced locally, no matter how much I fiddled with the execution speed of the containers.

So instead I diff-ed the debezium log from a failed and a successful run.

Turns out that during a failed run, the first postgresql table that is created immediately after configuring debezium is not reflected in the log at all. It is not part of the initial snapshot that Debezium takes and it is also not part of any subsequent replication activities. The only explanation for this would be a race condition in the Debezium code between the initial snapshot and subsequent replication that allows the table to fall through the cracks altogether.

