### PR TITLE
Support TLS connections for Postgres sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3098,6 +3098,8 @@ name = "postgres-util"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "openssl",
+ "postgres-openssl",
  "sql-parser",
  "tokio",
  "tokio-postgres",

--- a/src/dataflow/src/source/postgres.rs
+++ b/src/dataflow/src/source/postgres.rs
@@ -23,7 +23,7 @@ use tokio_postgres::config::{Config, ReplicationMode};
 use tokio_postgres::error::{DbError, Severity, SqlState};
 use tokio_postgres::replication::LogicalReplicationStream;
 use tokio_postgres::types::PgLsn;
-use tokio_postgres::{Client, NoTls, SimpleQueryMessage};
+use tokio_postgres::{Client, SimpleQueryMessage};
 
 use crate::source::{SimpleSource, SourceError, Timestamper};
 use dataflow_types::PostgresSourceConnector;
@@ -75,10 +75,10 @@ impl PostgresSourceReader {
     /// Starts a replication connection to the upstream database
     async fn connect_replication(&self) -> Result<Client, anyhow::Error> {
         let mut config: Config = self.connector.conn.parse()?;
-
+        let tls = postgres_util::make_tls(&config)?;
         let (client, conn) = config
             .replication_mode(ReplicationMode::Logical)
-            .connect(NoTls)
+            .connect(tls)
             .await?;
         tokio::spawn(conn);
         Ok(client)

--- a/src/postgres-util/Cargo.toml
+++ b/src/postgres-util/Cargo.toml
@@ -7,6 +7,8 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.40"
+openssl = { version = "0.10.34", features = ["vendored"] }
+postgres-openssl = { git = "https://github.com/MaterializeInc/rust-postgres" }
 sql-parser = { path = "../sql-parser" }
 tokio = { version = "1.5.0", features = ["fs"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }

--- a/test/pg-cdc/mzcompose.yml
+++ b/test/pg-cdc/mzcompose.yml
@@ -19,11 +19,19 @@ mzworkflows:
         dbname: postgres
       - step: run
         service: testdrive-svc
+        command: ${TD_TEST:-*.td}
 
 services:
   testdrive-svc:
     mzbuild: testdrive
-    entrypoint: testdrive --materialized-url=postgres://materialize@materialized:6875 pg-cdc.td
+    entrypoint:
+      - bash
+      - -c
+      - >-
+        testdrive
+        --materialized-url=postgres://materialize@materialized:6875
+        $$*
+      - bash
     volumes:
       - .:/workdir
     depends_on: [materialized, postgres]
@@ -32,13 +40,21 @@ services:
     mzbuild: materialized
     command: --experimental --disable-telemetry
     ports:
-      - 6875:6875
+      - 6875
     environment:
     - MZ_DEV=1
     - MZ_LOG
 
   postgres:
-    image: postgres:11.4
+    mzbuild: postgres
     ports:
-      - 5432:5432
-    command: postgres -c wal_level=logical -c max_wal_senders=20 -c max_replication_slots=20
+      - 5432
+    volumes:
+      - ./pg_hba.conf:/share/conf/pg_hba.conf
+    command: >
+      postgres
+        -c wal_level=logical
+        -c max_wal_senders=20
+        -c max_replication_slots=20
+        -c ssl=on
+        -c hba_file=/share/conf/pg_hba.conf

--- a/test/pg-cdc/pg-cdc-ssl.td
+++ b/test/pg-cdc/pg-cdc-ssl.td
@@ -1,0 +1,165 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# We test interesting combinations of server and client SSL configs
+# (part of the CREATE SOURCE statement).
+#
+# The important bit is that each user is named after the record type
+# in `pg_hba.conf`. The record type indicates what kind of connection
+# is allowed, e.g. `host` allows SSL and plaintext whereas `hostssl`
+# only allows SSL.
+#
+# Check out https://www.postgresql.org/docs/13/auth-pg-hba-conf.html
+# for more details.
+
+# Bootstrap users and data
+$ postgres-execute connection=postgres://postgres:postgres@postgres:5432
+DROP SCHEMA IF EXISTS public CASCADE;
+CREATE SCHEMA public;
+
+DROP USER IF EXISTS host;
+CREATE USER host LOGIN SUPERUSER;
+
+DROP USER IF EXISTS hostssl;
+CREATE USER hostssl LOGIN SUPERUSER;
+
+DROP USER IF EXISTS hostnossl;
+CREATE USER hostnossl LOGIN SUPERUSER;
+
+DROP TABLE IF EXISTS numbers;
+CREATE TABLE numbers (number int PRIMARY KEY, is_prime bool, name text);
+ALTER TABLE numbers REPLICA IDENTITY FULL;
+
+DROP PUBLICATION IF EXISTS mz_source;
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+INSERT INTO numbers VALUES (1, true, 'one');
+
+$ set-regex match=(\d{1,3}\.){3}\d{1,3} replacement=(HOST)
+
+# server: host, client: disable => OK
+> CREATE MATERIALIZED SOURCE "mz_source"
+  FROM POSTGRES HOST 'host=postgres port=5432 user=host sslmode=disable dbname=postgres'
+  PUBLICATION 'mz_source';
+> CREATE VIEWS FROM SOURCE "mz_source" ("numbers")
+> SELECT * FROM "numbers";
+1 true one
+$ postgres-execute connection=postgres://postgres:postgres@postgres:5432
+INSERT INTO numbers VALUES (2, true, 'two');
+> SELECT * FROM "numbers";
+1 true one
+2 true two
+> DROP VIEW "numbers";
+> DROP SOURCE "mz_source";
+$ postgres-execute connection=postgres://postgres:postgres@postgres:5432
+DELETE FROM numbers WHERE number = 2;
+
+# server: host, client: prefer => OK
+> CREATE MATERIALIZED SOURCE "mz_source"
+  FROM POSTGRES HOST 'host=postgres port=5432 user=host sslmode=prefer dbname=postgres'
+  PUBLICATION 'mz_source';
+> CREATE VIEWS FROM SOURCE "mz_source" ("numbers")
+> SELECT * FROM "numbers";
+1 true one
+$ postgres-execute connection=postgres://postgres:postgres@postgres:5432
+INSERT INTO numbers VALUES (2, true, 'two');
+> SELECT * FROM "numbers";
+1 true one
+2 true two
+> DROP VIEW "numbers";
+> DROP SOURCE "mz_source";
+$ postgres-execute connection=postgres://postgres:postgres@postgres:5432
+DELETE FROM numbers WHERE number = 2;
+
+# server: host, client: require => OK
+> CREATE MATERIALIZED SOURCE "mz_source"
+  FROM POSTGRES HOST 'host=postgres port=5432 user=host sslmode=require dbname=postgres'
+  PUBLICATION 'mz_source';
+> CREATE VIEWS FROM SOURCE "mz_source" ("numbers")
+> SELECT * FROM "numbers";
+1 true one
+$ postgres-execute connection=postgres://postgres:postgres@postgres:5432
+INSERT INTO numbers VALUES (2, true, 'two');
+> SELECT * FROM "numbers";
+1 true one
+2 true two
+> DROP VIEW "numbers";
+> DROP SOURCE "mz_source";
+$ postgres-execute connection=postgres://postgres:postgres@postgres:5432
+DELETE FROM numbers WHERE number = 2;
+
+# server: hostssl, client: disable => ERROR
+! CREATE MATERIALIZED SOURCE "mz_source"
+  FROM POSTGRES HOST 'host=postgres port=5432 user=hostssl sslmode=disable dbname=postgres'
+  PUBLICATION 'mz_source';
+db error: FATAL: no pg_hba.conf entry for host "(HOST)", user "hostssl", database "postgres", SSL off
+
+# server: hostssl, client: prefer => OK
+> CREATE MATERIALIZED SOURCE "mz_source"
+  FROM POSTGRES HOST 'host=postgres port=5432 user=hostssl sslmode=prefer dbname=postgres'
+  PUBLICATION 'mz_source';
+> CREATE VIEWS FROM SOURCE "mz_source" ("numbers")
+> SELECT * FROM "numbers";
+1 true one
+$ postgres-execute connection=postgres://postgres:postgres@postgres:5432
+INSERT INTO numbers VALUES (2, true, 'two');
+> SELECT * FROM "numbers";
+1 true one
+2 true two
+> DROP VIEW "numbers";
+> DROP SOURCE "mz_source";
+$ postgres-execute connection=postgres://postgres:postgres@postgres:5432
+DELETE FROM numbers WHERE number = 2;
+
+# server: hostssl, client: require => OK
+> CREATE MATERIALIZED SOURCE "mz_source"
+  FROM POSTGRES HOST 'host=postgres port=5432 user=hostssl sslmode=require dbname=postgres'
+  PUBLICATION 'mz_source';
+> CREATE VIEWS FROM SOURCE "mz_source" ("numbers")
+> SELECT * FROM "numbers";
+1 true one
+$ postgres-execute connection=postgres://postgres:postgres@postgres:5432
+INSERT INTO numbers VALUES (2, true, 'two');
+> SELECT * FROM "numbers";
+1 true one
+2 true two
+> DROP VIEW "numbers";
+> DROP SOURCE "mz_source";
+$ postgres-execute connection=postgres://postgres:postgres@postgres:5432
+DELETE FROM numbers WHERE number = 2;
+
+# server: hostnossl, client: disable => OK
+> CREATE MATERIALIZED SOURCE "mz_source"
+  FROM POSTGRES HOST 'host=postgres port=5432 user=hostnossl sslmode=disable dbname=postgres'
+  PUBLICATION 'mz_source';
+> CREATE VIEWS FROM SOURCE "mz_source" ("numbers")
+> SELECT * FROM "numbers";
+1 true one
+$ postgres-execute connection=postgres://postgres:postgres@postgres:5432
+INSERT INTO numbers VALUES (2, true, 'two');
+> SELECT * FROM "numbers";
+1 true one
+2 true two
+> DROP VIEW "numbers";
+> DROP SOURCE "mz_source";
+$ postgres-execute connection=postgres://postgres:postgres@postgres:5432
+DELETE FROM numbers WHERE number = 2;
+
+# server: hostnossl, client: prefer => OK
+# todo(uce): rust-postgres does not fall back to no SSL
+! CREATE MATERIALIZED SOURCE "mz_source"
+  FROM POSTGRES HOST 'host=postgres port=5432 user=hostnossl sslmode=prefer dbname=postgres'
+  PUBLICATION 'mz_source';
+db error: FATAL: no pg_hba.conf entry for host "(HOST)", user "hostnossl", database "postgres", SSL on
+
+# server: hostnossl, client: require => ERROR
+! CREATE MATERIALIZED SOURCE "mz_source"
+  FROM POSTGRES HOST 'host=postgres port=5432 user=hostnossl sslmode=require dbname=postgres'
+  PUBLICATION 'mz_source';
+db error: FATAL: no pg_hba.conf entry for host "(HOST)", user "hostnossl", database "postgres", SSL on

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -7,6 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+# IMPORTANT: The Postgres server has a custom pg_hba.conf that only
+# accepts connections from specific users. You will have to update
+# pg_hba.conf if you modify the existing user names or add new ones.
+
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 DROP USER IF EXISTS no_replication;
 CREATE USER no_replication WITH PASSWORD 'no_replication';
@@ -125,7 +129,7 @@ db error: FATAL: database "no_such_dbname" does not exist
 
 
 > CREATE MATERIALIZED SOURCE "mz_source"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
+  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
   PUBLICATION 'mz_source';
 
 > CREATE VIEWS FROM SOURCE "mz_source" ("no_replica_identity")

--- a/test/pg-cdc/pg_hba.conf
+++ b/test/pg-cdc/pg_hba.conf
@@ -1,0 +1,17 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# https://www.postgresql.org/docs/13/auth-pg-hba-conf.html
+# type      db    user             addr  auth-method [auth-options]
+host        all   postgres         all   trust
+host        all   no_such_user     all   trust
+host        all   no_replication   all   trust
+host        all   host             all   trust
+hostssl     all   hostssl          all   trust
+hostnossl   all   hostnossl        all   trust

--- a/test/pg-cdc/postgres/Dockerfile
+++ b/test/pg-cdc/postgres/Dockerfile
@@ -1,0 +1,14 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+MZFROM test-certs as certs
+
+FROM postgres:11.4
+COPY --chown=postgres --from=certs /secrets/* /share/secrets/
+COPY setup-postgres.sh /docker-entrypoint-initdb.d/setup-postgres.sh

--- a/test/pg-cdc/postgres/mzbuild.yml
+++ b/test/pg-cdc/postgres/mzbuild.yml
@@ -1,0 +1,10 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+name: postgres

--- a/test/pg-cdc/postgres/setup-postgres.sh
+++ b/test/pg-cdc/postgres/setup-postgres.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+set -e
+
+cat >> "$PGDATA/postgresql.conf" <<-EOCONF
+ssl_cert_file = '/share/secrets/postgres.crt'
+ssl_key_file = '/share/secrets/postgres.key'
+EOCONF

--- a/test/test-certs/create-certs.sh
+++ b/test/test-certs/create-certs.sh
@@ -28,7 +28,7 @@ openssl req \
 	-passin pass:$SSL_SECRET \
 	-passout pass:$SSL_SECRET
 
-for i in kafka kafka1 kafka2 schema-registry materialized producer
+for i in kafka kafka1 kafka2 schema-registry materialized producer postgres
 do
 	# Create key & csr
 	openssl req -nodes \
@@ -97,3 +97,5 @@ echo $SSL_SECRET > secrets/cert_creds
 
 # Ensure files are readable for any user
 chmod -R a+r secrets/
+# Keys are only user-accessible
+chmod -R og-rwx secrets/*.key

--- a/test/test-certs/openssl.cnf
+++ b/test/test-certs/openssl.cnf
@@ -33,3 +33,9 @@ authorityKeyIdentifier=keyid,issuer
 basicConstraints=CA:FALSE
 keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
 subjectAltName = DNS:schema-registry
+
+[ postgres ]
+authorityKeyIdentifier=keyid,issuer
+basicConstraints=CA:FALSE
+keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+subjectAltName = DNS:schema-registry


### PR DESCRIPTION
Opening this as a draft while I work on the `rust-postgres` client changes that block the remaining changes. @petrosagg Do the tests and the places where we create the TLS connector look sane?

## TODO
- [x] Use existing test certs infra (just saw this after opening the PR)
- [ ] Add remaining sslmodes to `rust-postgres`
