### PR TITLE
testdrive: Add --shuffle-tests option

### DIFF
--- a/test/antithesis/driver/docker-compose.yml
+++ b/test/antithesis/driver/docker-compose.yml
@@ -67,6 +67,8 @@ services:
         --materialized-url=postgres://materialize@materialized:6875
         --validate-catalog=/share/mzdata/catalog
         --default-timeout 300
+        --shuffle-tests
+        --seed ${ANTITHESIS_RANDOM_SEED:-1}
         !(*s3|kinesis*).td ;
         do :; done ; exit 1
       - bash


### PR DESCRIPTION
--shuffle-tests respects --seed to provide a
deterministic shuffle. Antithesis will be providing the seed
via an environment variable.