### PR TITLE
Introduce half_join operator for delta joins

### DIFF
--- a/src/dataflow/src/render/join/delta_join.rs
+++ b/src/dataflow/src/render/join/delta_join.rs
@@ -18,14 +18,12 @@
 //! not create any new stateful operators.
 
 #![allow(clippy::op_ref)]
-use differential_dataflow::lattice::Lattice;
-use dogsdogsdogs::altneu::AltNeu;
 use std::collections::HashSet;
 use timely::dataflow::Scope;
 
 use dataflow_types::DataflowError;
 use expr::{JoinInputMapper, MapFilterProject, MirRelationExpr, MirScalarExpr};
-use repr::{Datum, Row, RowArena, Timestamp};
+use repr::{Row, RowArena};
 
 use super::super::context::{ArrangementFlavor, Context};
 use crate::operator::CollectionExt;
@@ -38,6 +36,7 @@ use crate::render::join::{JoinBuildState, JoinClosure};
 /// in arrangements for other join inputs. These lookups require specific
 /// instructions about which expressions to use as keys. Along the way,
 /// various closures are applied to filter and project as early as possible.
+#[derive(Debug)]
 pub struct DeltaJoinPlan {
     /// The set of path plans.
     ///
@@ -47,6 +46,7 @@ pub struct DeltaJoinPlan {
 }
 
 /// A delta query path is implemented by a sequences of stages,
+#[derive(Debug)]
 pub struct DeltaPathPlan {
     /// The relation whose updates seed the dataflow path.
     source_relation: usize,
@@ -63,6 +63,7 @@ pub struct DeltaPathPlan {
 }
 
 /// A delta query stage performs a stream lookup into an arrangement.
+#[derive(Debug)]
 pub struct DeltaStagePlan {
     /// The relation index into which we will look up.
     lookup_relation: usize,
@@ -181,25 +182,20 @@ impl DeltaJoinPlan {
     }
 }
 
-impl<G> Context<G, MirRelationExpr, Row, Timestamp>
+impl<G> Context<G, MirRelationExpr, Row, repr::Timestamp>
 where
-    G: Scope<Timestamp = Timestamp>,
+    G: Scope<Timestamp = repr::Timestamp>,
 {
     /// Renders `MirRelationExpr:Join` using dogs^3 delta query dataflows.
     ///
     /// The join is followed by the application of `map_filter_project`, whose
     /// implementation will be pushed in to the join pipeline if at all possible.
-    pub fn render_delta_join<F>(
+    pub fn render_delta_join(
         &mut self,
         relation_expr: &MirRelationExpr,
         map_filter_project: MapFilterProject,
         scope: &mut G,
-        worker_index: usize,
-        subtract: F,
-    ) -> (Collection<G, Row>, Collection<G, DataflowError>)
-    where
-        F: Fn(&G::Timestamp) -> G::Timestamp + Clone + 'static,
-    {
+    ) -> (Collection<G, Row>, Collection<G, DataflowError>) {
         if let MirRelationExpr::Join {
             inputs,
             equivalences,
@@ -216,10 +212,6 @@ where
                 map_filter_project,
             );
 
-            for input in inputs.iter() {
-                self.ensure_rendered(input, scope, worker_index);
-            }
-
             // Collects error streams for the ambient scope.
             let mut scope_errs = Vec::new();
 
@@ -230,293 +222,246 @@ where
             // We'll need a new scope, to hold `AltNeu` wrappers, and we'll want
             // to import all traces as alt and neu variants (unless we do a more
             // careful analysis).
-            let results =
-                scope
-                    .clone()
-                    .scoped::<AltNeu<G::Timestamp>, _, _>("delta query", |inner| {
-                        // Our plan is to iterate through each input relation, and attempt
-                        // to find a plan that maximally uses existing keys (better: uses
-                        // existing arrangements, to which we have access).
-                        let mut join_results = Vec::new();
+            let results = scope.clone().region_named("delta query", |inner| {
+                // Our plan is to iterate through each input relation, and attempt
+                // to find a plan that maximally uses existing keys (better: uses
+                // existing arrangements, to which we have access).
+                let mut join_results = Vec::new();
 
-                        // First let's prepare the input arrangements we will need.
-                        // This reduces redundant imports, and simplifies the dataflow structure.
-                        // As the arrangements are all shared, it should not dramatically improve
-                        // the efficiency, but the dataflow simplification is worth doing.
+                // First let's prepare the input arrangements we will need.
+                // This reduces redundant imports, and simplifies the dataflow structure.
+                // As the arrangements are all shared, it should not dramatically improve
+                // the efficiency, but the dataflow simplification is worth doing.
+                //
+                // The arrangements are keyed by input and arrangement key, and by whether
+                // the arrangement is "alt" or "neu", which corresponds to whether the use
+                // of the arrangement is by a relation before or after it in the order, resp.
+                // Because the alt and neu variants have different types, we will maintain
+                // them in different collections.
+                let mut arrangements = std::collections::BTreeMap::new();
+                for relation in 0..inputs.len() {
+                    let order = &orders[relation];
+                    for (other, lookup_key) in order.iter() {
+                        arrangements
+                            .entry((other, &lookup_key[..]))
+                            .or_insert_with(|| {
+                                match self
+                                    .arrangement(&inputs[*other], &lookup_key[..])
+                                    .unwrap_or_else(|| {
+                                        panic!(
+                                            "Arrangement alarmingly absent!: {}, {:?}",
+                                            inputs[*other].pretty(),
+                                            &lookup_key[..]
+                                        )
+                                    }) {
+                                    ArrangementFlavor::Local(oks, errs) => {
+                                        if local_err_dedup
+                                            .insert((&inputs[*other], &lookup_key[..]))
+                                        {
+                                            scope_errs.push(errs.as_collection(|k, _v| k.clone()));
+                                        }
+                                        Ok(oks.enter(inner))
+                                    }
+                                    ArrangementFlavor::Trace(_gid, oks, errs) => {
+                                        if trace_err_dedup
+                                            .insert((&inputs[*other], &lookup_key[..]))
+                                        {
+                                            scope_errs.push(errs.as_collection(|k, _v| k.clone()));
+                                        }
+                                        Err(oks.enter(inner))
+                                    }
+                                }
+                            });
+                    }
+                }
+
+                // Collects error streams for the inner scope. Concats before leaving.
+                let mut inner_errs = Vec::with_capacity(inputs.len());
+                for path_plan in join_plan.path_plans.into_iter() {
+                    // Deconstruct the stages of the path plan.
+                    let DeltaPathPlan {
+                        source_relation,
+                        initial_closure,
+                        stage_plans,
+                        final_closure,
+                    } = path_plan;
+
+                    // This collection determines changes that result from updates inbound
+                    // from `inputs[relation]` and reflects all strictly prior updates and
+                    // concurrent updates from relations prior to `relation`.
+                    let name = format!("delta path {}", source_relation);
+                    let path_results = inner.clone().region_named(&name, |region| {
+                        // The plan is to move through each relation, starting from `relation` and in the order
+                        // indicated in `orders[relation]`. At each moment, we will have the columns from the
+                        // subset of relations encountered so far, and we will have applied as much as we can
+                        // of the filters in `equivalences` and the logic in `map_filter_project`, based on the
+                        // available columns.
                         //
-                        // The arrangements are keyed by input and arrangement key, and by whether
-                        // the arrangement is "alt" or "neu", which corresponds to whether the use
-                        // of the arrangement is by a relation before or after it in the order, resp.
-                        // Because the alt and neu variants have different types, we will maintain
-                        // them in different collections.
-                        let mut arrangements_alt = std::collections::HashMap::new();
-                        let mut arrangements_neu = std::collections::HashMap::new();
-                        for relation in 0..inputs.len() {
-                            let order = &orders[relation];
-                            for (other, lookup_key) in order.iter() {
-                                let subtract = subtract.clone();
-                                // Alt case
-                                if other > &relation {
-                                    arrangements_alt
-                                        .entry((&inputs[*other], &lookup_key[..]))
-                                        .or_insert_with(|| {
-                                            match self
-                                                .arrangement(&inputs[*other], &lookup_key[..])
-                                                .unwrap_or_else(|| {
-                                                    panic!(
-                                                        "Arrangement alarmingly absent!: {}, {:?}",
-                                                        inputs[*other].pretty(),
-                                                        &lookup_key[..]
-                                                    )
-                                                }) {
-                                                ArrangementFlavor::Local(oks, errs) => {
-                                                    if local_err_dedup
-                                                        .insert((&inputs[*other], &lookup_key[..]))
-                                                    {
-                                                        scope_errs.push(
-                                                            errs.as_collection(|k, _v| k.clone()),
-                                                        );
-                                                    }
-                                                    Ok(oks.enter_at(
-                                                        inner,
-                                                        |_, _, t| AltNeu::alt(t.clone()),
-                                                        move |t| subtract(&t.time),
-                                                    ))
-                                                }
-                                                ArrangementFlavor::Trace(_gid, oks, errs) => {
-                                                    if trace_err_dedup
-                                                        .insert((&inputs[*other], &lookup_key[..]))
-                                                    {
-                                                        scope_errs.push(
-                                                            errs.as_collection(|k, _v| k.clone()),
-                                                        );
-                                                    }
-                                                    Err(oks.enter_at(
-                                                        inner,
-                                                        |_, _, t| AltNeu::alt(t.clone()),
-                                                        move |t| subtract(&t.time),
-                                                    ))
-                                                }
-                                            }
-                                        });
-                                } else {
-                                    arrangements_neu
-                                        .entry((&inputs[*other], &lookup_key[..]))
-                                        .or_insert_with(|| {
-                                            match self
-                                                .arrangement(&inputs[*other], &lookup_key[..])
-                                                .unwrap_or_else(|| {
-                                                    panic!(
-                                                        "Arrangement alarmingly absent!: {}, {:?}",
-                                                        inputs[*other].pretty(),
-                                                        &lookup_key[..]
-                                                    )
-                                                }) {
-                                                ArrangementFlavor::Local(oks, errs) => {
-                                                    if local_err_dedup
-                                                        .insert((&inputs[*other], &lookup_key[..]))
-                                                    {
-                                                        scope_errs.push(
-                                                            errs.as_collection(|k, _v| k.clone()),
-                                                        );
-                                                    }
-                                                    Ok(oks.enter_at(
-                                                        inner,
-                                                        |_, _, t| AltNeu::neu(t.clone()),
-                                                        move |t| subtract(&t.time),
-                                                    ))
-                                                }
-                                                ArrangementFlavor::Trace(_gid, oks, errs) => {
-                                                    if trace_err_dedup
-                                                        .insert((&inputs[*other], &lookup_key[..]))
-                                                    {
-                                                        scope_errs.push(
-                                                            errs.as_collection(|k, _v| k.clone()),
-                                                        );
-                                                    }
-                                                    Err(oks.enter_at(
-                                                        inner,
-                                                        |_, _, t| AltNeu::neu(t.clone()),
-                                                        move |t| subtract(&t.time),
-                                                    ))
-                                                }
-                                            }
-                                        });
+                        // As we go, we will track the physical locations of each intended output column, as well
+                        // as the locations of intermediate results from partial application of `map_filter_project`.
+                        //
+                        // Just before we apply the `lookup` function to perform a join, we will first use our
+                        // available information to determine the filtering and logic that we can apply, and
+                        // introduce that in to the `lookup` logic to cause it to happen in that operator.
+
+                        // Collects error streams for the region scope. Concats before leaving.
+                        let mut region_errs = Vec::with_capacity(inputs.len());
+
+                        use differential_dataflow::AsCollection;
+                        use timely::dataflow::operators::Map;
+
+                        // Ensure this input is rendered, and extract its update stream.
+                        let mut update_stream = if let Some((_key, val)) = arrangements
+                            .iter()
+                            .find(|(key, _val)| key.0 == &source_relation)
+                        {
+                            match val {
+                                Ok(local) => {
+                                    local.as_collection(|_k, v| v.clone()).enter_region(region)
+                                }
+                                Err(trace) => {
+                                    trace.as_collection(|_k, v| v.clone()).enter_region(region)
                                 }
                             }
+                        } else {
+                            self.collection(&inputs[source_relation])
+                                .expect("Failed to render update stream")
+                                .0
+                                .enter(inner)
+                                .enter_region(region)
+                        };
+
+                        // Apply what `closure` we are able to, and record any errors.
+                        if let Some(initial_closure) = initial_closure {
+                            let (stream, errs) = update_stream.flat_map_fallible({
+                                let mut datums = DatumVec::new();
+                                move |row| {
+                                    let temp_storage = RowArena::new();
+                                    let mut datums_local = datums.borrow_with(&row);
+                                    // TODO(mcsherry): re-use `row` allocation.
+                                    initial_closure
+                                        .apply(&mut datums_local, &temp_storage)
+                                        .transpose()
+                                }
+                            });
+                            update_stream = stream;
+                            region_errs.push(errs.map(DataflowError::from));
                         }
 
-                        // Collects error streams for the inner scope. Concats before leaving.
-                        let mut inner_errs = Vec::with_capacity(inputs.len());
-                        for path_plan in join_plan.path_plans.into_iter() {
-                            // Deconstruct the stages of the path plan.
-                            let DeltaPathPlan {
-                                source_relation,
-                                initial_closure,
-                                stage_plans,
-                                final_closure,
-                            } = path_plan;
+                        // Promote `time` to a datum element.
+                        let mut update_stream = update_stream
+                            .inner
+                            .map(|(v, t, d)| ((v, t.clone()), t, d))
+                            .as_collection();
 
-                            // This collection determines changes that result from updates inbound
-                            // from `inputs[relation]` and reflects all strictly prior updates and
-                            // concurrent updates from relations prior to `relation`.
-                            let name = format!("delta path {}", source_relation);
-                            let path_results = inner.clone().region_named(&name, |region| {
-                                // The plan is to move through each relation, starting from `relation` and in the order
-                                // indicated in `orders[relation]`. At each moment, we will have the columns from the
-                                // subset of relations encountered so far, and we will have applied as much as we can
-                                // of the filters in `equivalences` and the logic in `map_filter_project`, based on the
-                                // available columns.
-                                //
-                                // As we go, we will track the physical locations of each intended output column, as well
-                                // as the locations of intermediate results from partial application of `map_filter_project`.
-                                //
-                                // Just before we apply the `lookup` function to perform a join, we will first use our
-                                // available information to determine the filtering and logic that we can apply, and
-                                // introduce that in to the `lookup` logic to cause it to happen in that operator.
+                        // Repeatedly update `update_stream` to reflect joins with more and more
+                        // other relations, in the specified order.
+                        for stage_plan in stage_plans.into_iter() {
+                            let DeltaStagePlan {
+                                lookup_relation,
+                                stream_key,
+                                lookup_key,
+                                closure,
+                            } = stage_plan;
 
-                                // Collects error streams for the region scope. Concats before leaving.
-                                let mut region_errs = Vec::with_capacity(inputs.len());
-
-                                // Ensure this input is rendered, and extract its update stream.
-                                let mut update_stream = if let Some((_key, val)) = arrangements_alt
-                                    .iter()
-                                    .find(|(key, _val)| key.0 == &inputs[source_relation])
-                                {
-                                    match val {
-                                        Ok(local) => local
-                                            .as_collection(|_k, v| v.clone())
-                                            .enter_region(region),
-                                        Err(trace) => trace
-                                            .as_collection(|_k, v| v.clone())
-                                            .enter_region(region),
-                                    }
-                                } else {
-                                    self.collection(&inputs[source_relation])
-                                        .expect("Failed to render update stream")
-                                        .0
-                                        .enter(inner)
-                                        .enter_region(region)
-                                };
-
-                                // Apply what `closure` we are able to, and record any errors.
-                                if let Some(initial_closure) = initial_closure {
-                                    let (stream, errs) = update_stream.flat_map_fallible({
-                                        let mut datums = DatumVec::new();
-                                        move |row| {
-                                            let temp_storage = RowArena::new();
-                                            let mut datums_local = datums.borrow_with(&row);
-                                            // TODO(mcsherry): re-use `row` allocation.
-                                            initial_closure
-                                                .apply(&mut datums_local, &temp_storage)
-                                                .transpose()
-                                        }
-                                    });
-                                    update_stream = stream;
-                                    region_errs.push(errs.map(DataflowError::from));
-                                }
-
-                                // Repeatedly update `update_stream` to reflect joins with more and more
-                                // other relations, in the specified order.
-                                for stage_plan in stage_plans.into_iter() {
-                                    let DeltaStagePlan {
-                                        lookup_relation,
-                                        stream_key,
-                                        lookup_key,
-                                        closure,
-                                    } = stage_plan;
-
-                                    // We require different logic based on the flavor of arrangement.
-                                    // We may need to cache each of these if we want to re-use the same wrapped
-                                    // arrangement, rather than re-wrap each time we use a thing.
-                                    let (oks, errs) = if lookup_relation > source_relation {
-                                        match arrangements_alt
-                                            .get(&(&inputs[lookup_relation], &lookup_key[..]))
-                                            .unwrap()
-                                        {
-                                            Ok(local) => build_lookup(
-                                                update_stream,
-                                                local.enter_region(region),
-                                                stream_key,
-                                                closure,
-                                            ),
-                                            Err(trace) => build_lookup(
-                                                update_stream,
-                                                trace.enter_region(region),
-                                                stream_key,
-                                                closure,
-                                            ),
-                                        }
+                            // We require different logic based on the flavor of arrangement.
+                            // We may need to cache each of these if we want to re-use the same wrapped
+                            // arrangement, rather than re-wrap each time we use a thing.
+                            let (oks, errs) = match arrangements
+                                .get(&(&lookup_relation, &lookup_key[..]))
+                                .unwrap()
+                            {
+                                Ok(local) => {
+                                    if lookup_relation > source_relation {
+                                        build_halfjoin(
+                                            update_stream,
+                                            local.enter_region(region),
+                                            stream_key,
+                                            |t1, t2| t1.lt(t2),
+                                            closure,
+                                        )
                                     } else {
-                                        match arrangements_neu
-                                            .get(&(&inputs[lookup_relation], &lookup_key[..]))
-                                            .unwrap()
-                                        {
-                                            Ok(local) => build_lookup(
-                                                update_stream,
-                                                local.enter_region(region),
-                                                stream_key,
-                                                closure,
-                                            ),
-                                            Err(trace) => build_lookup(
-                                                update_stream,
-                                                trace.enter_region(region),
-                                                stream_key,
-                                                closure,
-                                            ),
-                                        }
-                                    };
-                                    update_stream = oks;
-                                    region_errs.push(errs);
+                                        build_halfjoin(
+                                            update_stream,
+                                            local.enter_region(region),
+                                            stream_key,
+                                            |t1, t2| t1.le(t2),
+                                            closure,
+                                        )
+                                    }
                                 }
-
-                                // We have completed the join building, but may have work remaining.
-                                // For example, we may have expressions not pushed down (e.g. literals)
-                                // and projections that could not be applied (e.g. column repetition).
-                                if let Some(final_closure) = final_closure {
-                                    let (updates, errors) = update_stream.flat_map_fallible({
-                                        // Reuseable allocation for unpacking.
-                                        let mut datums = DatumVec::new();
-                                        move |row| {
-                                            let temp_storage = RowArena::new();
-                                            let mut datums_local = datums.borrow_with(&row);
-                                            // TODO(mcsherry): re-use `row` allocation.
-                                            final_closure
-                                                .apply(&mut datums_local, &temp_storage)
-                                                .map_err(DataflowError::from)
-                                                .transpose()
-                                        }
-                                    });
-
-                                    update_stream = updates;
-                                    region_errs.push(errors);
+                                Err(trace) => {
+                                    if lookup_relation > source_relation {
+                                        build_halfjoin(
+                                            update_stream,
+                                            trace.enter_region(region),
+                                            stream_key,
+                                            |t1, t2| t1.lt(t2),
+                                            closure,
+                                        )
+                                    } else {
+                                        build_halfjoin(
+                                            update_stream,
+                                            trace.enter_region(region),
+                                            stream_key,
+                                            |t1, t2| t1.le(t2),
+                                            closure,
+                                        )
+                                    }
                                 }
+                            };
+                            update_stream = oks;
+                            region_errs.push(errs);
+                        }
 
-                                inner_errs.push(
-                                    differential_dataflow::collection::concatenate(
-                                        region,
-                                        region_errs,
-                                    )
-                                    .leave(),
-                                );
-                                update_stream.leave()
+                        // Delay updates as appropriate.
+                        let mut update_stream = update_stream
+                            .inner
+                            .map(|((row, time), _, diff)| (row, time, diff))
+                            .as_collection();
+
+                        // We have completed the join building, but may have work remaining.
+                        // For example, we may have expressions not pushed down (e.g. literals)
+                        // and projections that could not be applied (e.g. column repetition).
+                        if let Some(final_closure) = final_closure {
+                            let (updates, errors) = update_stream.flat_map_fallible({
+                                // Reuseable allocation for unpacking.
+                                let mut datums = DatumVec::new();
+                                move |row| {
+                                    let temp_storage = RowArena::new();
+                                    let mut datums_local = datums.borrow_with(&row);
+                                    // TODO(mcsherry): re-use `row` allocation.
+                                    final_closure
+                                        .apply(&mut datums_local, &temp_storage)
+                                        .map_err(DataflowError::from)
+                                        .transpose()
+                                }
                             });
 
-                            join_results.push(path_results);
+                            update_stream = updates;
+                            region_errs.push(errors);
                         }
 
-                        scope_errs.push(
-                            differential_dataflow::collection::concatenate(inner, inner_errs)
+                        inner_errs.push(
+                            differential_dataflow::collection::concatenate(region, region_errs)
                                 .leave(),
                         );
-
-                        // Concatenate the results of each delta query as the accumulated results.
-                        (
-                            differential_dataflow::collection::concatenate(inner, join_results)
-                                .leave(),
-                            differential_dataflow::collection::concatenate(scope, scope_errs),
-                        )
+                        update_stream.leave()
                     });
+
+                    join_results.push(path_results);
+                }
+
+                scope_errs.push(
+                    differential_dataflow::collection::concatenate(inner, inner_errs).leave(),
+                );
+
+                // Concatenate the results of each delta query as the accumulated results.
+                (
+                    differential_dataflow::collection::concatenate(inner, join_results).leave(),
+                    differential_dataflow::collection::concatenate(scope, scope_errs),
+                )
+            });
             results
         } else {
             panic!("render_delta_join invoked on non-delta join implementation");
@@ -530,27 +475,33 @@ use differential_dataflow::trace::Cursor;
 use differential_dataflow::trace::TraceReader;
 use differential_dataflow::Collection;
 
-/// Constructs a `lookup_map` from supplied arguments.
+/// Constructs a `half_join` from supplied arguments.
 ///
 /// This method exists to factor common logic from four code paths that are generic over the type of trace.
-fn build_lookup<G, Tr>(
-    updates: Collection<G, Row>,
+/// The `comparison` function should either be `le` or `lt` depending on which relation comes first in the
+/// total order on relations (in order to break ties consistently).
+fn build_halfjoin<G, Tr, CF>(
+    updates: Collection<G, (Row, G::Timestamp)>,
     trace: Arranged<G, Tr>,
     prev_key: Vec<MirScalarExpr>,
+    comparison: CF,
     closure: JoinClosure,
-) -> (Collection<G, Row>, Collection<G, DataflowError>)
+) -> (
+    Collection<G, (Row, G::Timestamp)>,
+    Collection<G, DataflowError>,
+)
 where
-    G: Scope,
-    G::Timestamp: Lattice,
+    G: Scope<Timestamp = repr::Timestamp>,
     Tr: TraceReader<Time = G::Timestamp, Key = Row, Val = Row, R = isize> + Clone + 'static,
     Tr::Batch: BatchReader<Tr::Key, Tr::Val, Tr::Time, Tr::R>,
     Tr::Cursor: Cursor<Tr::Key, Tr::Val, Tr::Time, Tr::R>,
+    CF: Fn(&G::Timestamp, &G::Timestamp) -> bool + 'static,
 {
     let (updates, errs) = updates.map_fallible({
         // Reuseable allocation for unpacking.
         let mut datums = DatumVec::new();
         let mut row_packer = Row::default();
-        move |row| {
+        move |(row, time)| {
             let temp_storage = RowArena::new();
             let datums_local = datums.borrow_with(&row);
             row_packer.clear();
@@ -562,7 +513,7 @@ where
             let row_key = row_packer.finish_and_reuse();
             // Explicit drop to release borrow on `row` so that it can be returned.
             drop(datums_local);
-            Ok((row, row_key))
+            Ok((row_key, row, time))
         }
     });
 
@@ -570,35 +521,27 @@ where
     use timely::dataflow::operators::OkErr;
 
     let mut datums = DatumVec::new();
-    let (oks, errs2) = dogsdogsdogs::operators::lookup_map(
+    let (oks, errs2) = dogsdogsdogs::operators::half_join(
         &updates,
         trace,
-        move |(_row, row_key), key| {
-            // Prefix key selector must populate `key` with key from prefix `row`.
-            key.clone_from(&row_key);
-        },
-        // TODO(mcsherry): consider `RefOrMut` in `lookup` interface to allow re-use.
-        move |(stream_row, _stream_row_key), diff1, lookup_row, diff2| {
+        |time| time.saturating_sub(1),
+        comparison,
+        // TODO(mcsherry): consider `RefOrMut` in `half_join` interface to allow re-use.
+        move |_key, stream_row, lookup_row| {
             let temp_storage = RowArena::new();
             let mut datums_local = datums.borrow();
             datums_local.extend(stream_row.iter());
             datums_local.extend(lookup_row.iter());
-            (
-                closure.apply(&mut datums_local, &temp_storage),
-                diff1 * diff2,
-            )
+            closure.apply(&mut datums_local, &temp_storage)
         },
-        // Three default values, for decoding keys into.
-        Row::pack::<_, Datum>(None),
-        Row::pack::<_, Datum>(None),
-        Row::pack::<_, Datum>(None),
     )
     .inner
     .ok_err(|(x, t, d)| {
         // TODO(mcsherry): consider `ok_err()` for `Collection`.
         match x {
-            Ok(x) => Ok((x, t, d)),
-            Err(x) => Err((DataflowError::from(x), t, d)),
+            (Ok(x), time) => Ok((x.map(|x| (x, time)), t, d)),
+            // TODO(mcsherry): what time should we use here?
+            (Err(x), _time) => Err((DataflowError::from(x), t, d)),
         }
     });
 

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -469,9 +469,7 @@ where
                         self.render_join(input, mfp, scope)
                     }
                     expr::JoinImplementation::DeltaQuery(_orders) => {
-                        self.render_delta_join(input, mfp, scope, worker_index, |t| {
-                            t.saturating_sub(1)
-                        })
+                        self.render_delta_join(input, mfp, scope)
                     }
                     expr::JoinImplementation::Unimplemented => {
                         panic!("Attempt to render unimplemented join");
@@ -652,13 +650,7 @@ where
                             self.collections.insert(relation_expr.clone(), collection);
                         }
                         expr::JoinImplementation::DeltaQuery(_orders) => {
-                            let collection = self.render_delta_join(
-                                relation_expr,
-                                mfp,
-                                scope,
-                                worker_index,
-                                |t| t.saturating_sub(1),
-                            );
+                            let collection = self.render_delta_join(relation_expr, mfp, scope);
                             self.collections.insert(relation_expr.clone(), collection);
                         }
                         expr::JoinImplementation::Unimplemented => {

--- a/test/testdrive/gh6744.td
+++ b/test/testdrive/gh6744.td
@@ -1,0 +1,49 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Test for the issue uncovered in a previous version of this PR
+# issue: https://github.com/MaterializeInc/materialize/pull/6291#issuecomment-816457944
+# fix: https://github.com/MaterializeInc/materialize/pull/6291/commits/71bcd461446796e178584133a4dd232b4cef8382
+#
+
+> CREATE TABLE customer (
+    c_custkey     integer
+  );
+
+> CREATE TABLE orders (
+    o_orderkey       integer,
+    o_custkey        integer NOT NULL
+  );
+
+> CREATE INDEX pk_orders_orderkey ON orders (o_orderkey);
+> CREATE INDEX fk_orders_custkey ON orders (o_custkey ASC);
+
+> CREATE TABLE lineitem (
+    l_orderkey       integer NOT NULL
+  );
+
+> INSERT INTO "customer" VALUES (1),(14),(15);
+> INSERT INTO lineitem VALUES ( 176);
+
+> CREATE MATERIALIZED VIEW v1 AS
+  SELECT * FROM lineitem JOIN orders ON ( l_orderkey = o_orderkey ) JOIN customer ON ( o_custkey = c_custkey );
+
+> INSERT INTO orders VALUES ( 176, 14);
+
+> CREATE VIEW v1_nonmaterialized AS
+  SELECT * FROM lineitem JOIN orders ON ( l_orderkey = o_orderkey ) JOIN customer ON ( o_custkey = c_custkey );
+
+# 1 row expected; prior to the fix 2 rows were returned
+
+> SELECT * FROM v1;
+176 176 14 14
+
+> SELECT * FROM v1_nonmaterialized;
+176 176 14 14


### PR DESCRIPTION
This PR changes the implementation of delta joins to switch from `lookup_map` to `half_join`. These two functions are meant to be effectively identical on totally ordered times, and their behavior varies on partially ordered times. The `half_join` implementation is believed to be the "correct" one. At the same time, the change also removes the need to have e.g. `AltNeu` wrappers for times, which simplifies the traces we need to import.

There is a potential negative impact in that we keep a second copy of each timestamp through the pipeline, which increases the volume of data moved around. This is important for correct behavior, especially if we modify timestamps of records along the dataflow paths (we need to ensure that we match up certain record exactly once, and it is based on timestamps; if we mess around with them, we could screw that up unless we hold something constant through the pipeline).