### PR TITLE
coord: prevent views from multiple timelines

### DIFF
--- a/doc/developer/design/20210408_timelines.md
+++ b/doc/developer/design/20210408_timelines.md
@@ -1,0 +1,101 @@
+# Timelines
+
+## Summary
+
+Some kinds of sources in Materialized have different meanings for the timestamps they attach to data.
+If a user asks Materialized to join sources with different meanings of what a timestamp is, Materialized should tell the user that the timestamps can't be used together.
+Tracking timelines (the meaning of a timestamp) provides a way for Materialized to produce errors when attempting to use data with different meanings of timestamps.
+
+## Goals
+
+1. Prevent users from doing things that are silently meaningless.
+Joining timestamps with different meaning produces results that don't mean anything correct, and we should inform users of that with an error.
+2. Prevent user queries blocking forever.
+In addition to the above point, a query of that kind could potentially block forever.
+This is a bad experience for users and we should prevent it from happening.
+3. Unblock work on linearizability.
+We would like to be linearizable in the future, and our current best understanding of how to do that is to have one timestamp per timeline that always increases when serving reads.
+
+## Non-Goals
+
+The API described here is easily misusable, because it is opt-in.
+It is not a goal to make this misusable because the correct pieces are not yet in place.
+We would like to be able to perform transactional catalog changes along with shipping new dataflows where we could detect timeline misuse, but there's some complicated work to be done there.
+We can instead ship a solution that works in a much simpler way, with the potential for misuse (or rather, lack of use).
+
+## Description
+
+From dataflow's perspective, a timestamp is an arbitrary number, and dataflow will do whatever it is instructed when asked to join indexes at a specific timestamp number.
+Most sources use something around wall-clock now when generating that number, so asking about the state of various indexes at time X will incur at most a very short (< 1 second) wait for the data to be ready.
+
+A problem occurs when there is a source that generates timestamp numbers that may not be related to wall-clock now.
+The two in our system are Debezium consistency topics and CDCv2.
+Debezium consistency topics start their "timestamp" number at 1 and increment it for each transaction.
+If these sources are joined with wall-clock now sources, the dataflow layer will happily wait for the timestamps to be equal.
+For the Debezium sources, this would require waiting until there were as many transactions as milliseconds since the Unix epoch, which essentially will never happen.
+We should prevent this poor UX from happening to users.
+
+In addition to an infinite delay, there are cases where, even if the numbers were the same, they are meaningless when related to each other.
+For example, two separate Debezium consistency topics.
+Although they both start counting at 1 and thus have relatively close numbers, there's no meaning in the transaction counter, and joining data on that will not produce results that are meaningful.
+We should inform users when they attempt to join data from differing timelines that they have not asked us a useful question.
+
+The third concern is linearizability.
+We would like to provide that property when users issue SELECT queries.
+If we can distinguish the meaning of timestamps across data, we can provide linearizability across sources correctly.
+(This will be described with more detail in a later doc.)
+
+A solution to this problem is to inform the system what the timestamp number means for all data, and allow the system to reject queries that request data from multiple meanings.
+We introduce a thing called a timeline which is the meaning of the timestamp number.
+At the points in the system at which it is possible to join different sources together, we will return an error to the user if there is more than one timeline present.
+There are two places where this can occur: `CREATE VIEW` and `SELECT`.
+These have been taught to check that their expression depends at most one timeline.
+Other operations that can create dataflow indexes (TAIL, CREATE SOURCE, CREATE SINK, CREATE INDEX) operate on existing views, and are thus unable to create dataflows from multiple timelines.
+
+This is implemented by adding a `Timeline` enum, and requiring sources and tables to provide their `Timeline` to the Coordinator.
+When a VIEW or SELECT is planned, its MirRelationExpr is crawled to discover all timelines.
+
+Variants of `Timeline`:
+
+- `EpochMilliseconds` for anything producing timestamps near wall-clock now.
+- `Counter(struct)` for Debezium consistency topics, with a struct to track broker/topic to tell apart different sources.
+- `External(String)` for CDCv2 sources with the source's name attached, making a CDCv2 source only joinable with itself.
+- `User(String)` for user-defined timelines by a name chosen by the user.
+
+All sources can specify `WITH (timeline='some_name')` to choose the `User` variant.
+This will group any set of sources together if users need to join CDCv2 and realtime sources, or multiple CDCv2 sources.
+
+By default, a CDCv2 source is joinable only with itself.
+We do not allow them to join with even other CDCv2 sources because of side effects in linearizability and time domains, which might like to advance to the most recent time.
+CDCv2 sources have a special `WITH (epoch_ms_timeline=true)` syntax to put that source into the EpochMilliseconds timeline.
+Since we don't verify that the timestamps are indeed milliseconds from the epoch in this case, features that use this timeline (linearizability or transaction time domains, for example) will need to protect against data problems (for example, a CDCv2 source that is in the wrong units or has timezone errors, or is otherwise ahead or behind by many minutes).
+
+## Alternatives
+
+One alternative is to change the timestamp type to contain this enum.
+If that's possible we could then error if there is more than one variant present, or we could maybe select from multiple timelines, each at their own value, and join data that way.
+Changing the timestamp type is probably a large, difficult change.
+We could also do another thing where the timestamp type is a (system time, event time) tuple, allowing each source to generate timestamps however it wants (event time), but using the system time when joining sources.
+
+A second is to reclock all incoming data to EpochMilliseconds which would make all sources joinable to another based on when the system ingested them.
+This would require us to keep a mapping back to the original timestamp for some data, since that might be meaningful to a user in the case of CDCv2.
+This is also a very large change with lots of user-facing impact.
+
+A third implementation is to teach either the dataflow builder or dataflow shipper to be able to error.
+In the implementation above, we hand picked VIEW and SELECT to check that their dataflows are ok.
+If we change something in the future and provide another way to create a potentially multi-timeline index, we might forget to check.
+The above API is easily misusable, whereas teaching the dataflow bulider/shipper would be a global API that can't be misused.
+Attempts were made to do this, but dataflow building and shipping interacts closely with the catalog, which doesn't support interactive (to the Coordinator, not the user) transactions.
+Thus we didn't have a correct way to produce an error and rollback catalog changes.
+We would like interactive catalog transactions in the future, so this may get done.
+The attempts here illustrated that it was more difficult than expected, and so the work was tabled for a simpler solution to the timeline problem.
+
+## Open questions
+
+How safe is it to specify that a CDCv2 source is EpochMilliseconds?
+What if a user does that, but their CDCv2 source is using seconds or microseconds instead of the expected milliseconds?
+Or their timestamps are ahead or behind by minutes or hours?
+This would cause the same problems that this proposal is trying to solve.
+The simple solution there is to remove the view and fix the data.
+A deeper difficulty occurs when we attempt linearizability, which would like these numbers to always go forward, and we don't want to block the entire system because some CDCv2 source had a very high timestamp that forces all other reads to wait forever.
+This can maybe be solved by waiting to persist the linearizability tracker until a query has returned, but that could still have problems if that source wasn't joined to an actual EpochMilliseconds source.

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -46,6 +46,13 @@ Use relative links (/path/to/doc), not absolute links
 Wrap your release notes at the 80 character mark.
 {{< /comment >}}
 
+{{% version-header v0.8.1 %}}
+
+- Add [timelines](/sql/timelines) to all sources to prevent
+  joining data whose time is not comparable. This only affects new
+  [CDC](/connect/materialize-cdc) and Debezium consistency topic sources
+  by default.
+
 {{% version-header v0.8.0 %}}
 
 - Add the [`COPY FROM`](/sql/copy-from) statement, which allows populating a

--- a/doc/user/content/sql/timelines.md
+++ b/doc/user/content/sql/timelines.md
@@ -1,0 +1,59 @@
+---
+title: "Timelines"
+description: "Timelines describe sources' meaning of time."
+menu:
+  main:
+    parent: sql
+---
+
+All data in Materialize has a timestamp.
+Most sources, and all tables, created by Materialize use the system time (milliseconds since the Unix epoch) when the data were ingested as their timestamp.
+[CDC sources][cdc-sources] require users to specify the timestamps of their data, but the timestamps might not match the timestamp format of the system time.
+For example, they could use seconds instead of milliseconds, or just be a counter that starts at 1 and increments.
+
+We use the term **timeline** to describe the meaning of this timestamp number.
+All sources are assigned to a timeline.
+Materialize prevents joining sources from different timelines because it cannot guarantee that a meaningful result will ever be returned.
+Users can specify custom timelines if they need to join sources that are by default on different timelines.
+
+## Default Timeline
+
+- [CDC sources][cdc-sources] default to their own individual timeline, and cannot be joined with any other source (even other CDC sources).
+- All other sources (and all tables) use the system timeline.
+
+## User Timelines
+
+When creating a source, users can specify a `timeline` as a `WITH` option.
+This can be used to allow multiple CDC sources, or a CDC source and system time sources, to be joinable.
+
+For example, to create two CDC sources that are joinable:
+
+```sql
+CREATE MATERIALIZED SOURCE source_1
+  FROM KAFKA BROKER 'broker' TOPIC 'topic-1'
+    WITH (timeline='user')
+  FORMAT AVRO USING SCHEMA 'schema-1'
+  ENVELOPE MATERIALIZE;
+
+CREATE MATERIALIZED SOURCE source_2
+  FROM KAFKA BROKER 'broker' TOPIC 'topic-2'
+    WITH (timeline='user')
+  FORMAT AVRO USING SCHEMA 'schema-2'
+  ENVELOPE MATERIALIZE;
+```
+
+## CDC Sources
+
+[CDC sources][cdc-sources] supports a `epoch_ms_timeline` `WITH` option that moves it to the system timeline, making the CDC source joinable to tables and other system timeline sources.
+Users **must** ensure that the `time` field's units are milliseconds since the Unix epoch.
+Joining this source to other system time sources will result in query delays until the timestamps being received are close to wall-clock `now()`.
+
+```sql
+CREATE MATERIALIZED SOURCE source_3
+  FROM KAFKA BROKER 'broker' TOPIC 'topic-3'
+    WITH (epoch_ms_timeline=true)
+  FORMAT AVRO USING SCHEMA 'schema'
+  ENVELOPE MATERIALIZE
+```
+
+[cdc-sources]: /connect/materialize-cdc

--- a/src/coord/src/cache.rs
+++ b/src/coord/src/cache.rs
@@ -354,7 +354,7 @@ pub fn augment_connector(
                 Ok(Some(source_connector))
             }
         }
-        SourceConnector::Local => Ok(None),
+        SourceConnector::Local(_) => Ok(None),
     }
 }
 

--- a/src/coord/src/catalog/metrics.rs
+++ b/src/coord/src/catalog/metrics.rs
@@ -65,7 +65,7 @@ pub(super) fn item_created(id: GlobalId, item: &CatalogItem) {
                 ExternalSourceConnector::PubNub(_) => SOURCE_COUNT_PUBNUB.inc(),
                 ExternalSourceConnector::S3(_) => SOURCE_COUNT_S3.inc(),
             },
-            SourceConnector::Local => {} // nothing interesting to users here
+            SourceConnector::Local(_) => {} // nothing interesting to users here
         },
         CatalogItem::Sink(Sink { connector, .. }) => match connector {
             SinkConnectorState::Pending(_) => {}
@@ -96,7 +96,7 @@ pub(super) fn item_dropped(id: GlobalId, item: &CatalogItem) {
                 ExternalSourceConnector::PubNub(_) => SOURCE_COUNT_PUBNUB.dec(),
                 ExternalSourceConnector::S3(_) => SOURCE_COUNT_S3.dec(),
             },
-            SourceConnector::Local => {} // nothing interesting to users here
+            SourceConnector::Local(_) => {} // nothing interesting to users here
         },
         CatalogItem::Sink(Sink { connector, .. }) => match connector {
             SinkConnectorState::Pending(_) => {}

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -70,7 +70,7 @@ use dataflow_types::{
     DataflowDesc, ExternalSourceConnector, IndexDesc, PeekResponse, PostgresSourceConnector,
     SinkConnector, SourceConnector, TailSinkConnector, TimestampSourceUpdate, Update,
 };
-use dataflow_types::{SinkAsOf, SinkEnvelope};
+use dataflow_types::{SinkAsOf, SinkEnvelope, Timeline};
 use expr::{
     ExprHumanizer, GlobalId, Id, MirRelationExpr, MirScalarExpr, NullaryFunc,
     OptimizedMirRelationExpr,
@@ -1860,6 +1860,8 @@ impl Coordinator {
             depends_on,
         } = plan;
 
+        self.validate_timeline(view.expr.global_uses())?;
+
         let mut ops = vec![];
 
         if let Some(id) = replace {
@@ -2365,6 +2367,7 @@ impl Coordinator {
                 // a new transient dataflow that will be dropped after the
                 // peek completes.
                 let typ = source.typ();
+                self.validate_timeline(inner.global_uses())?;
                 map_filter_project = expr::MapFilterProject::new(typ.arity());
                 let key: Vec<_> = (0..typ.arity()).map(MirScalarExpr::Column).collect();
                 let view_id = self.allocate_transient_id()?;
@@ -2726,6 +2729,7 @@ impl Coordinator {
                 explanation.to_string()
             }
             ExplainStage::OptimizedPlan => {
+                self.validate_timeline(decorrelated_plan.global_uses())?;
                 let optimized_plan =
                     self.prep_relation_expr(decorrelated_plan, ExprPrepStyle::Explain)?;
                 let mut dataflow = DataflowDesc::new(format!("explanation"));
@@ -3213,6 +3217,67 @@ impl Coordinator {
         }
         self.transient_id_counter += 1;
         Ok(GlobalId::Transient(id))
+    }
+
+    /// Return an error if the ids are from incompatible timelines. This should
+    /// be used to prevent users from doing things that are either meaningless
+    /// (joining data from timelines that have similar numbers with different
+    /// meanings like two separate debezium topics) or will never complete (joining
+    /// byo and realtime data).
+    fn validate_timeline(&self, mut ids: Vec<GlobalId>) -> Result<(), CoordError> {
+        let mut timelines = HashMap::new();
+
+        // Recurse through IDs to find all sources and tables, adding new ones to
+        // the set until we reach the bottom. Static views will end up with an empty
+        // timelines.
+        while let Some(id) = ids.pop() {
+            // Protect against possible infinite recursion. Not sure if it's possible, but
+            // a cheap prevention for the future.
+            if timelines.contains_key(&id) {
+                continue;
+            }
+            let entry = self.catalog.get_by_id(&id);
+            match entry.item() {
+                CatalogItem::Source(source) => {
+                    timelines.insert(id, source.connector.timeline());
+                }
+                CatalogItem::Index(index) => {
+                    ids.push(index.on);
+                }
+                CatalogItem::View(view) => {
+                    ids.extend(view.optimized_expr.global_uses());
+                }
+                CatalogItem::Table(table) => {
+                    timelines.insert(id, table.timeline());
+                }
+                _ => {}
+            }
+        }
+
+        let timelines: HashSet<Timeline> = timelines
+            .into_iter()
+            .map(|(_, timeline)| timeline)
+            .collect();
+
+        // If there's more than one timeline, we will not produce meaningful
+        // data to a user. Take, for example, some realtime source and a debezium
+        // consistency topic source. The realtime source uses something close to now
+        // for its timestamps. The debezium source starts at 1 and increments per
+        // transaction. We don't want to choose some timestamp that is valid for both
+        // of these because the debezium source will never get to the same value as the
+        // realtime source's "milliseconds since Unix epoch" value. And even if it did,
+        // it's not meaningful to join just because those two numbers happen to be the
+        // same now.
+        //
+        // Another example: assume two separate debezium consistency topics. Both
+        // start counting at 1 and thus have similarish numbers that probably overlap
+        // a lot. However it's still not meaningful to join those two at a specific
+        // transaction counter number because those counters are unrelated to the
+        // other.
+        if timelines.len() > 1 {
+            coord_bail!("Dataflow cannot use multiple timelines");
+        }
+        Ok(())
     }
 }
 

--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -74,7 +74,7 @@ impl<'a> DataflowBuilder<'a> {
                     dataflow.add_source_import(
                         entry.name().to_string(),
                         *id,
-                        SourceConnector::Local,
+                        SourceConnector::Local(table.timeline()),
                         table.desc.clone(),
                         *id,
                     );

--- a/src/coord/src/timestamp.rs
+++ b/src/coord/src/timestamp.rs
@@ -537,14 +537,14 @@ impl Timestamper {
                                 }
                             }
                             Consistency::BringYourOwn(consistency_topic) => {
-                                info!("Timestamping Source {} with BYO Consistency. Consistency Source: {}.",
+                                info!("Timestamping Source {} with BYO Consistency. Consistency Source: {:?}.",
                                       source_id, consistency_topic);
                                 let consumer = self.create_byo_connector(
                                     source_id,
                                     sc,
                                     enc.value(),
                                     env,
-                                    consistency_topic,
+                                    consistency_topic.topic,
                                 );
                                 if let Some(consumer) = consumer {
                                     self.byo_sources.insert(source_id, consumer);

--- a/src/coord/src/timestamp.rs
+++ b/src/coord/src/timestamp.rs
@@ -513,6 +513,7 @@ impl Timestamper {
                         envelope,
                         consistency,
                         ts_frequency: _,
+                        timeline: _,
                     } = sc
                     {
                         (connector, encoding, envelope, consistency)

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -622,6 +622,33 @@ pub enum Compression {
     None,
 }
 
+/// The meaning of the timestamp number produced by data sources. This type
+/// is not concerned with the source of the timestamp (like if the data came
+/// from a Debezium consistency topic or a CDCv2 stream), instead only what the
+/// timestamp number means.
+///
+/// Some variants here have attached data used to differentiate incomparable
+/// instantiations. These attached data types should be expanded in the future
+/// if we need to tell apart more kinds of sources.
+#[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Serialize, Deserialize, Hash)]
+pub enum Timeline {
+    /// EpochMilliseconds means the timestamp is the number of milliseconds since
+    /// the Unix epoch.
+    EpochMilliseconds,
+    /// Counter means the timestamp starts at 1 and is incremented for each
+    /// transaction. It holds the BYO source so different instantiations can be
+    /// differentiated.
+    Counter(BringYourOwn),
+    /// External means the timestamp comes from an external data source and we
+    /// don't know what the number means. The attached String is the source's name,
+    /// which will result in different sources being incomparable.
+    External(String),
+    /// User means the user has manually specified a timeline. The attached
+    /// String is specified by the user, allowing them to decide sources that are
+    /// joinable.
+    User(String),
+}
+
 /// A struct to hold more specific information about where a BYO source
 /// came from so we can differentiate between topics of the same name across
 /// different brokers.
@@ -639,8 +666,9 @@ pub enum SourceConnector {
         envelope: SourceEnvelope,
         consistency: Consistency,
         ts_frequency: Duration,
+        timeline: Timeline,
     },
-    Local,
+    Local(Timeline),
 }
 
 impl SourceConnector {
@@ -682,7 +710,14 @@ impl SourceConnector {
     pub fn caching_enabled(&self) -> bool {
         match self {
             SourceConnector::External { connector, .. } => connector.caching_enabled(),
-            SourceConnector::Local => false,
+            SourceConnector::Local(_) => false,
+        }
+    }
+
+    pub fn timeline(&self) -> Timeline {
+        match self {
+            SourceConnector::External { timeline, .. } => timeline.clone(),
+            SourceConnector::Local(timeline) => timeline.clone(),
         }
     }
 }

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -622,6 +622,15 @@ pub enum Compression {
     None,
 }
 
+/// A struct to hold more specific information about where a BYO source
+/// came from so we can differentiate between topics of the same name across
+/// different brokers.
+#[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Serialize, Deserialize, Hash)]
+pub struct BringYourOwn {
+    pub broker: String,
+    pub topic: String,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum SourceConnector {
     External {
@@ -776,7 +785,7 @@ impl ExternalSourceConnector {
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum Consistency {
-    BringYourOwn(String),
+    BringYourOwn(BringYourOwn),
     RealTime,
 }
 

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -86,7 +86,7 @@ where
         match src.connector.clone() {
             // Create a new local input (exposed as TABLEs to users). Data is inserted
             // via SequencedCommand::Insert commands.
-            SourceConnector::Local => {
+            SourceConnector::Local(_) => {
                 let ((handle, capability), stream) = scope.new_unordered_input();
                 render_state
                     .local_inputs
@@ -110,6 +110,7 @@ where
                 envelope,
                 consistency,
                 ts_frequency,
+                timeline: _,
             } => {
                 // TODO(benesch): this match arm is hard to follow. Refactor.
 

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -27,8 +27,8 @@ use regex::Regex;
 use reqwest::Url;
 
 use dataflow_types::{
-    AvroEncoding, AvroOcfEncoding, AvroOcfSinkConnectorBuilder, Consistency, CsvEncoding,
-    DataEncoding, DebeziumMode, ExternalSourceConnector, FileSourceConnector,
+    AvroEncoding, AvroOcfEncoding, AvroOcfSinkConnectorBuilder, BringYourOwn, Consistency,
+    CsvEncoding, DataEncoding, DebeziumMode, ExternalSourceConnector, FileSourceConnector,
     KafkaSinkConnectorBuilder, KafkaSourceConnector, KinesisSourceConnector,
     PostgresSourceConnector, ProtobufEncoding, PubNubSourceConnector, RegexEncoding,
     S3SourceConnector, SinkConnectorBuilder, SinkEnvelope, SourceConnector, SourceDataEncoding,
@@ -403,7 +403,10 @@ pub fn plan_create_source(
 
             consistency = match with_options.remove("consistency_topic") {
                 None => Consistency::RealTime,
-                Some(Value::String(topic)) => Consistency::BringYourOwn(topic),
+                Some(Value::String(topic)) => Consistency::BringYourOwn(BringYourOwn {
+                    broker: broker.clone(),
+                    topic,
+                }),
                 Some(_) => bail!("consistency_topic must be a string"),
             };
 
@@ -613,7 +616,10 @@ pub fn plan_create_source(
             };
             consistency = match with_options.remove("consistency_topic") {
                 None => Consistency::RealTime,
-                Some(Value::String(topic)) => Consistency::BringYourOwn(topic),
+                Some(Value::String(topic)) => Consistency::BringYourOwn(BringYourOwn {
+                    broker: path.clone(),
+                    topic,
+                }),
                 Some(_) => bail!("consistency_topic must be a string"),
             };
 

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -336,7 +336,7 @@ pub fn purify(
                     SourceConnector::External { connector, .. } => {
                         bail!("cannot generate views from {} sources", connector.name())
                     }
-                    SourceConnector::Local => bail!("cannot generate views from local sources"),
+                    SourceConnector::Local(_) => bail!("cannot generate views from local sources"),
                 }
             }
         }

--- a/test/testdrive/kafka-exactly-once-sink.td
+++ b/test/testdrive/kafka-exactly-once-sink.td
@@ -58,12 +58,6 @@ $ kafka-create-topic topic=input
 
 > CREATE MATERIALIZED VIEW input_values_mview AS VALUES (1), (2), (3);
 
-> CREATE VIEW input_kafka_no_byo_join_view AS SELECT * FROM input_kafka_byo, input_kafka_no_byo;
-
-> CREATE MATERIALIZED VIEW input_kafka_no_byo_join_mview AS SELECT * FROM input_kafka_no_byo, input_kafka_byo;
-
-> CREATE MATERIALIZED VIEW input_kafka_no_byo_scalar_subquery AS SELECT (SELECT a FROM input_kafka_no_byo LIMIT 1) FROM input_kafka_byo;
-
 > CREATE MATERIALIZED VIEW input_kafka_no_byo_derived_table AS SELECT * FROM ( SELECT * FROM input_kafka_no_byo ) AS a1;
 
 $ file-append path=static.csv
@@ -129,21 +123,6 @@ all inputs of an exactly-once Kafka sink must be sources, materialize.public.inp
   WITH (exactly_once=true, consistency_topic='output-view-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 all inputs of an exactly-once Kafka sink must be sources, materialize.public.input_values_mview is not
-
-> CREATE SINK output9 FROM input_kafka_no_byo_join_view
-  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
-  WITH (exactly_once=true, consistency_topic='output-view-consistency-${testdrive.seed}')
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-
-> CREATE SINK output10 FROM input_kafka_no_byo_join_mview
-  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
-  WITH (exactly_once=true, consistency_topic='output-view-consistency-${testdrive.seed}')
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-
-> CREATE SINK output11 FROM input_kafka_no_byo_scalar_subquery
-  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
-  WITH (exactly_once=true, consistency_topic='output-view-consistency-${testdrive.seed}')
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 > CREATE SINK output12 FROM input_kafka_no_byo_derived_table
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'

--- a/test/testdrive/timelines.td
+++ b/test/testdrive/timelines.td
@@ -1,0 +1,247 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test various joins and how they interact with timeline checks.
+
+$ set schema={
+    "type": "record",
+    "name": "envelope",
+    "fields": [
+      {
+        "name": "before",
+        "type": [
+          {
+            "name": "row",
+            "type": "record",
+            "fields": [
+              {"name": "a", "type": "long"},
+              {"name": "b", "type": "long"}
+            ]
+          },
+          "null"
+        ]
+      },
+      { "name": "after", "type": ["row", "null"] }
+    ]
+  }
+
+$ kafka-create-topic topic=input-consistency
+$ kafka-create-topic topic=input-system
+
+> CREATE MATERIALIZED SOURCE source_byo
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-${testdrive.seed}'
+    WITH (consistency_topic = 'testdrive-input-consistency-${testdrive.seed}')
+  FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
+
+> CREATE MATERIALIZED SOURCE source_byo_user
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-${testdrive.seed}'
+    WITH (consistency_topic = 'testdrive-input-consistency-${testdrive.seed}', timeline = 'user')
+  FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
+
+> CREATE MATERIALIZED SOURCE source_byo_user2
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-${testdrive.seed}'
+    WITH (consistency_topic = 'testdrive-input-consistency-${testdrive.seed}', timeline = 'user2')
+  FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
+
+> CREATE MATERIALIZED SOURCE source_system
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-system-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
+
+> CREATE MATERIALIZED SOURCE source_system_user
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-system-${testdrive.seed}'
+    WITH (timeline = 'user')
+  FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
+
+$ set schema=[
+  {
+    "type": "array",
+    "items": {
+      "type": "record",
+      "name": "update",
+      "namespace": "com.materialize.cdc",
+      "fields": [
+        {
+          "name": "data",
+          "type": {
+            "type": "record",
+            "name": "data",
+            "fields": [
+              {
+                "name": "id",
+                "type": "long"
+              },
+              {
+                "name": "price",
+                "type": [
+                  "null",
+                  "int"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "time",
+          "type": "long"
+        },
+        {
+          "name": "diff",
+          "type": "long"
+        }
+      ]
+    }
+  },
+  {
+    "type": "record",
+    "name": "progress",
+    "namespace": "com.materialize.cdc",
+    "fields": [
+      {
+        "name": "lower",
+        "type": {
+          "type": "array",
+          "items": "long"
+        }
+      },
+      {
+        "name": "upper",
+        "type": {
+          "type": "array",
+          "items": "long"
+        }
+      },
+      {
+        "name": "counts",
+        "type": {
+          "type": "array",
+          "items": {
+            "type": "record",
+            "name": "counts",
+            "fields": [
+              {
+                "name": "time",
+                "type": "long"
+              },
+              {
+                "name": "count",
+                "type": "long"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+  ]
+
+$ kafka-create-topic topic=input-cdcv2
+
+$ kafka-ingest format=avro topic=input-cdcv2 schema=${schema} timestamp=1
+{"array":[{"data":{"id":5,"price":{"int":10}},"time":5,"diff":1}]}
+{"array":[{"data":{"id":5,"price":{"int":12}},"time":4,"diff":1}]}
+{"array":[{"data":{"id":5,"price":{"int":12}},"time":5,"diff":-1}]}
+
+> CREATE MATERIALIZED SOURCE source_cdcv2
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-cdcv2-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${schema}'
+  ENVELOPE MATERIALIZE
+
+! CREATE MATERIALIZED SOURCE source_cdcv2_system
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-cdcv2-${testdrive.seed}'
+    WITH (epoch_ms_timeline=false)
+  FORMAT AVRO USING SCHEMA '${schema}'
+  ENVELOPE MATERIALIZE
+unsupported epoch_ms_timeline value
+
+# Can't specify epoch_ms_timeline and timeline.
+! CREATE MATERIALIZED SOURCE source_cdcv2_system
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-cdcv2-${testdrive.seed}'
+    WITH (epoch_ms_timeline=false, timeline='user')
+  FORMAT AVRO USING SCHEMA '${schema}'
+  ENVELOPE MATERIALIZE
+unexpected parameters for CREATE SOURCE: epoch_ms_timeline
+
+> CREATE MATERIALIZED SOURCE source_cdcv2_system
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-cdcv2-${testdrive.seed}'
+    WITH (epoch_ms_timeline=true)
+  FORMAT AVRO USING SCHEMA '${schema}'
+  ENVELOPE MATERIALIZE
+
+> CREATE MATERIALIZED SOURCE source_cdcv2_user
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-cdcv2-${testdrive.seed}'
+    WITH (timeline='user')
+  FORMAT AVRO USING SCHEMA '${schema}'
+  ENVELOPE MATERIALIZE
+
+> CREATE TABLE input_table (a bigint);
+
+> CREATE VIEW input_values_view AS VALUES (1), (2), (3);
+
+> CREATE MATERIALIZED VIEW input_values_mview AS VALUES (1), (2), (3);
+
+! CREATE VIEW must_fail AS SELECT * FROM source_byo, source_system;
+Dataflow cannot use multiple timelines
+
+! CREATE MATERIALIZED VIEW must_fail AS SELECT * FROM source_system, source_byo;
+Dataflow cannot use multiple timelines
+
+! CREATE MATERIALIZED VIEW must_fail AS SELECT * FROM source_system, source_byo;
+Dataflow cannot use multiple timelines
+
+! CREATE MATERIALIZED VIEW must_fail AS SELECT * FROM source_system, source_cdcv2;
+Dataflow cannot use multiple timelines
+
+! CREATE MATERIALIZED VIEW must_fail AS SELECT * FROM source_byo, source_cdcv2;
+Dataflow cannot use multiple timelines
+
+! CREATE MATERIALIZED VIEW must_fail AS SELECT (SELECT a FROM source_system LIMIT 1) FROM source_byo;
+Dataflow cannot use multiple timelines
+
+# Verify that user timelines don't allow things to be joinable with their non-user versions.
+! CREATE MATERIALIZED VIEW must_fail AS SELECT * FROM source_system, source_system_user;
+Dataflow cannot use multiple timelines
+! CREATE MATERIALIZED VIEW must_fail AS SELECT * FROM source_byo, source_byo_user;
+Dataflow cannot use multiple timelines
+
+# Can join static view with anything.
+> CREATE VIEW values_table_view AS SELECT * FROM input_values_view, input_table;
+> CREATE VIEW values_values_view AS SELECT * FROM input_values_view, input_values_mview LIMIT 0;
+> CREATE VIEW values_system_view AS SELECT * FROM input_values_view, source_system;
+> CREATE VIEW values_system_user_view AS SELECT * FROM input_values_view, source_system_user;
+> CREATE VIEW values_cdcv2_view AS SELECT * FROM input_values_view, source_cdcv2;
+> CREATE VIEW values_byo_view AS SELECT * FROM input_values_view, source_byo;
+> CREATE VIEW values_byo_user_view AS SELECT * FROM input_values_view, source_byo_user;
+> CREATE VIEW values_mz_catalog_view AS SELECT * FROM input_values_view, mz_catalog_names, mz_views, mz_source_info;
+
+# System sources, tables, and logs should be joinable with eachother.
+> CREATE VIEW various_system AS SELECT * FROM mz_catalog_names, mz_views, mz_source_info;
+
+# System things should be joinable only with system sources.
+! CREATE VIEW must_fail AS SELECT * FROM mz_catalog_names, mz_views, mz_source_info, source_byo;
+Dataflow cannot use multiple timelines
+! CREATE VIEW must_fail AS SELECT * FROM mz_catalog_names, mz_views, mz_source_info, source_cdcv2;
+Dataflow cannot use multiple timelines
+> CREATE VIEW various_system_no_byo AS SELECT * FROM mz_catalog_names, mz_views, mz_source_info, source_system;
+> CREATE VIEW various_system_table AS SELECT * FROM mz_catalog_names, mz_views, mz_source_info, input_table;
+
+# EXPLAIN should complain too.
+! EXPLAIN SELECT * FROM source_system, source_byo;
+Dataflow cannot use multiple timelines
+
+# Can join user-specified timelines.
+> CREATE MATERIALIZED VIEW source_system_byo_user AS SELECT * FROM source_system_user, source_byo_user, source_cdcv2_user;
+
+# Unless they are from different user timelines.
+! CREATE MATERIALIZED VIEW must_fail AS SELECT * FROM source_byo_user, source_byo_user2;
+Dataflow cannot use multiple timelines
+
+# CDCv2 can only be joined with system time stuff if specified
+> CREATE MATERIALIZED VIEW source_cdcv2_table_system AS SELECT * FROM source_cdcv2_system, input_table;
+! CREATE MATERIALIZED VIEW must_fail AS SELECT * FROM source_cdcv2, input_table;
+Dataflow cannot use multiple timelines


### PR DESCRIPTION
Teach the system about Timelines, which is the meaning of the timestamp
number. Prevent users from joining data from multiple timelines because
it's meaningless and/or will block forever.
    
The implementation here avoids teaching ship_dataflow or DataflowBuilder
about timelines because those require transactional catalog changes which
we don't yet have, and are not straightforward to implement. Instead
we opt-in the places that can create arbitrary SQL expressions (SELECT,
CREATE VIEW) to check for timeline violations.
    
These changes introduce the coordinator to the notion of timelines and block queries
would span multiple timelines.