### PR TITLE
pgwire: correctly clear txn state during errors

### DIFF
--- a/src/coord/src/session.rs
+++ b/src/coord/src/session.rs
@@ -123,6 +123,7 @@ impl Session {
     /// > a named portal object lasts till the end of the current transaction
     /// and
     /// > An unnamed portal is destroyed at the end of the transaction
+    #[must_use]
     pub fn clear_transaction(&mut self) -> (Vec<GlobalId>, TransactionStatus) {
         self.portals.clear();
         self.pcx = None;


### PR DESCRIPTION
Previously the call to clear_transaction ignored the sinks that needed
to be dropped. Prevent this by adding a must_use directive so we don't
make this mistake again in the future. Now the error route correctly
goes through the coordinator which can process any needed side effects
when ending a transaction.