### PR TITLE
Allow Row arrangements backed by columns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1670,7 +1670,7 @@ checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 [[package]]
 name = "differential-dataflow"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#93da9134f7b440beef329216e434ea974619ac38"
+source = "git+https://github.com/frankmcsherry/differential-dataflow.git?branch=columnation#713e643cdf9777ad79881e08b7c1a81920525688"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -1747,7 +1747,7 @@ checksum = "923dea538cea0aa3025e8685b20d6ee21ef99c4f77e954a30febbaac5ec73a97"
 [[package]]
 name = "dogsdogsdogs"
 version = "0.1.0"
-source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#93da9134f7b440beef329216e434ea974619ac38"
+source = "git+https://github.com/frankmcsherry/differential-dataflow.git?branch=columnation#713e643cdf9777ad79881e08b7c1a81920525688"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -4311,6 +4311,7 @@ dependencies = [
  "bytes",
  "chrono",
  "chrono-tz",
+ "columnation",
  "criterion",
  "dec",
  "differential-dataflow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3527,6 +3527,7 @@ dependencies = [
  "async-trait",
  "bytesize",
  "chrono",
+ "columnation",
  "differential-dataflow",
  "futures",
  "mz-build-info",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1670,7 +1670,7 @@ checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 [[package]]
 name = "differential-dataflow"
 version = "0.12.0"
-source = "git+https://github.com/frankmcsherry/differential-dataflow.git?branch=columnation#713e643cdf9777ad79881e08b7c1a81920525688"
+source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#93da9134f7b440beef329216e434ea974619ac38"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -1747,7 +1747,7 @@ checksum = "923dea538cea0aa3025e8685b20d6ee21ef99c4f77e954a30febbaac5ec73a97"
 [[package]]
 name = "dogsdogsdogs"
 version = "0.1.0"
-source = "git+https://github.com/frankmcsherry/differential-dataflow.git?branch=columnation#713e643cdf9777ad79881e08b7c1a81920525688"
+source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#93da9134f7b440beef329216e434ea974619ac38"
 dependencies = [
  "abomonation",
  "abomonation_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,3 @@ tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
 tungstenite = { git = "https://github.com/snapview/tungstenite-rs.git" }
 serde-value = { git = "https://github.com/MaterializeInc/serde-value.git" }
 vte = { git = "https://github.com/alacritty/vte" }
-
-[patch."https://github.com/TimelyDataflow/differential-dataflow.git"]
-differential-dataflow = { git = "https://github.com/frankmcsherry/differential-dataflow.git", branch = "columnation" }
-dogsdogsdogs = { git = "https://github.com/frankmcsherry/differential-dataflow.git", branch = "columnation" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,3 +115,7 @@ tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
 tungstenite = { git = "https://github.com/snapview/tungstenite-rs.git" }
 serde-value = { git = "https://github.com/MaterializeInc/serde-value.git" }
 vte = { git = "https://github.com/alacritty/vte" }
+
+[patch."https://github.com/TimelyDataflow/differential-dataflow.git"]
+differential-dataflow = { git = "https://github.com/frankmcsherry/differential-dataflow.git", branch = "columnation" }
+dogsdogsdogs = { git = "https://github.com/frankmcsherry/differential-dataflow.git", branch = "columnation" }

--- a/src/compute-client/Cargo.toml
+++ b/src/compute-client/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = "1.0.66"
 async-stream = "0.3.3"
 async-trait = "0.1.59"
 bytesize = "1.1.0"
+columnation = { git = "https://github.com/frankmcsherry/columnation" }
 chrono = { version = "0.4.23", default-features = false, features = ["std"] }
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 futures = "0.3.25"

--- a/src/compute-client/src/plan/reduce.rs
+++ b/src/compute-client/src/plan/reduce.rs
@@ -97,6 +97,10 @@ pub enum ReductionType {
     Basic,
 }
 
+impl columnation::Columnation for ReductionType {
+    type InnerRegion = columnation::CloneRegion<ReductionType>;
+}
+
 impl RustType<ProtoReductionType> for ReductionType {
     fn into_proto(&self) -> ProtoReductionType {
         use proto_reduction_type::Kind;

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -23,6 +23,7 @@ use differential_dataflow::Collection;
 use differential_dataflow::Data;
 use mz_compute_client::plan::AvailableCollections;
 use timely::communication::message::RefOrMut;
+use timely::container::columnation;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::{Scope, ScopeParent};
 use timely::progress::timestamp::Refines;
@@ -64,7 +65,7 @@ pub(crate) type ErrArrangementImport<S, T> = Arranged<
 /// former must refine the latter. The former is the timestamp used by the scope in question,
 /// and the latter is the timestamp of imported traces. The two may be different in the case
 /// of regions or iteration.
-pub struct Context<S: Scope, V: Data, T = mz_repr::Timestamp>
+pub struct Context<S: Scope, V: Data + columnation::Columnation, T = mz_repr::Timestamp>
 where
     T: Timestamp + Lattice,
     S::Timestamp: Lattice + Refines<T>,
@@ -85,7 +86,7 @@ where
     pub bindings: BTreeMap<Id, CollectionBundle<S, V, T>>,
 }
 
-impl<S: Scope, V: Data> Context<S, V>
+impl<S: Scope, V: Data + columnation::Columnation> Context<S, V>
 where
     S::Timestamp: Lattice + Refines<mz_repr::Timestamp>,
 {
@@ -109,7 +110,7 @@ where
     }
 }
 
-impl<S: Scope, V: Data, T> Context<S, V, T>
+impl<S: Scope, V: Data + columnation::Columnation, T> Context<S, V, T>
 where
     T: Timestamp + Lattice,
     S::Timestamp: Lattice + Refines<T>,
@@ -156,7 +157,7 @@ where
 
 /// Describes flavor of arrangement: local or imported trace.
 #[derive(Clone)]
-pub enum ArrangementFlavor<S: Scope, V: Data, T = mz_repr::Timestamp>
+pub enum ArrangementFlavor<S: Scope, V: Data + columnation::Columnation, T = mz_repr::Timestamp>
 where
     T: Timestamp + Lattice,
     S::Timestamp: Lattice + Refines<T>,
@@ -268,7 +269,7 @@ where
 /// This type maintains the invariant that it does contain at least one valid
 /// source of data, either a collection or at least one arrangement.
 #[derive(Clone)]
-pub struct CollectionBundle<S: Scope, V: Data, T = mz_repr::Timestamp>
+pub struct CollectionBundle<S: Scope, V: Data + columnation::Columnation, T = mz_repr::Timestamp>
 where
     T: Timestamp + Lattice,
     S::Timestamp: Lattice + Refines<T>,
@@ -277,7 +278,7 @@ where
     pub arranged: BTreeMap<Vec<MirScalarExpr>, ArrangementFlavor<S, V, T>>,
 }
 
-impl<S: Scope, V: Data, T: Lattice> CollectionBundle<S, V, T>
+impl<S: Scope, V: Data + columnation::Columnation, T: Lattice> CollectionBundle<S, V, T>
 where
     T: Timestamp + Lattice,
     S::Timestamp: Lattice + Refines<T>,

--- a/src/compute/src/typedefs.rs
+++ b/src/compute/src/typedefs.rs
@@ -12,13 +12,13 @@
 #![allow(missing_docs)]
 
 use differential_dataflow::operators::arrange::TraceAgent;
-use differential_dataflow::trace::implementations::ord::{OrdKeySpine, OrdValSpine};
+use differential_dataflow::trace::implementations::ord::{ColKeySpine, ColValSpine, OrdKeySpine};
 
 use mz_repr::{Diff, Row, Timestamp};
 use mz_storage_client::types::errors::DataflowError;
 
-pub type RowSpine<K, V, T, R, O = usize> = OrdValSpine<K, V, T, R, O>;
-pub type RowKeySpine<K, T, R, O = usize> = OrdKeySpine<K, T, R, O>;
+pub type RowSpine<K, V, T, R, O = usize> = ColValSpine<K, V, T, R, O>;
+pub type RowKeySpine<K, T, R, O = usize> = ColKeySpine<K, T, R, O>;
 pub type ErrSpine<K, T, R, O = usize> = OrdKeySpine<K, T, R, O>;
 pub type TraceRowHandle<K, V, T, R> = TraceAgent<RowSpine<K, V, T, R>>;
 pub type TraceErrHandle<K, T, R> = TraceAgent<ErrSpine<K, T, R>>;

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -18,6 +18,7 @@ harness = false
 anyhow = "1.0.66"
 bitflags = "1.3.2"
 bytes = "1.3.0"
+columnation = { git = "https://github.com/frankmcsherry/columnation" }
 chrono = { version = "0.4.23", default-features = false, features = ["serde", "std"] }
 chrono-tz = { version = "0.8.1", features = ["serde", "case-insensitive"] }
 dec = "0.4.8"

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -166,6 +166,70 @@ impl Ord for Row {
     }
 }
 
+#[allow(missing_debug_implementations)]
+mod columnation {
+
+    use super::Row;
+    use columnation::{Columnation, Region, StableRegion};
+
+    /// Region allocation for `Row` data.
+    ///
+    /// Content bytes are stored in stable contiguous memory locations,
+    /// and then a `Row` referencing them is falsified.
+    #[derive(Default)]
+    pub struct RowStack {
+        region: StableRegion<u8>,
+    }
+
+    impl Columnation for Row {
+        type InnerRegion = RowStack;
+    }
+
+    impl Region for RowStack {
+        type Item = Row;
+        #[inline]
+        fn clear(&mut self) {
+            self.region.clear();
+        }
+        #[inline(always)]
+        unsafe fn copy(&mut self, item: &Row) -> Row {
+            if item.data.spilled() {
+                let bytes = self.region.copy_slice(&item.data[..]);
+                Row {
+                    data: smallvec::SmallVec::from_raw_parts(
+                        bytes.as_mut_ptr(),
+                        item.data.len(),
+                        item.data.capacity(),
+                    ),
+                }
+            } else {
+                item.clone()
+            }
+        }
+
+        fn reserve_items<'a, I>(&mut self, items: I)
+        where
+            Self: 'a,
+            I: Iterator<Item = &'a Self::Item> + Clone,
+        {
+            self.region.reserve(
+                items
+                    .filter(|row| row.data.spilled())
+                    .map(|row| row.data.len())
+                    .sum(),
+            );
+        }
+
+        fn reserve_regions<'a, I>(&mut self, regions: I)
+        where
+            Self: 'a,
+            I: Iterator<Item = &'a Self> + Clone,
+        {
+            self.region.reserve(regions.map(|r| r.region.len()).sum());
+        }
+    }
+}
+
 /// Packs datums into a [`Row`].
 ///
 /// Creating a `RowPacker` via [`Row::packer`] starts a packing operation on the

--- a/src/repr/src/timestamp.rs
+++ b/src/repr/src/timestamp.rs
@@ -343,3 +343,7 @@ impl TryFrom<Numeric> for Timestamp {
         })
     }
 }
+
+impl columnation::Columnation for Timestamp {
+    type InnerRegion = columnation::CloneRegion<Timestamp>;
+}


### PR DESCRIPTION
This PR explores the use of columnar storage to back `Row` allocations, to both reduce the number of allocations, and better lay out memory in the case of paging. The PR exists mostly allow folks to check out the implementation (@danhhz especially) and the branch may be used to evaluate some paging applications.

The main changes are introducing a columnation implementation for `Row` and putting `dataflow::arrangement::manager` in charge of determining the types of arrangements we use, rather than have everyone announce `OrdValSpine` on their own.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6763)
<!-- Reviewable:end -->
