### PR TITLE
kafka: use natural (primary) relation key for sinks if available

### DIFF
--- a/src/coord/src/sink_connector.rs
+++ b/src/coord/src/sink_connector.rs
@@ -454,6 +454,7 @@ async fn build_kafka(
         value_schema_id,
         topic,
         addrs: builder.broker_addrs,
+        relation_key_indices: builder.relation_key_indices,
         key_desc_and_indices: builder.key_desc_and_indices,
         value_desc: builder.value_desc,
         consistency,

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -910,6 +910,7 @@ pub struct KafkaSinkConnector {
     pub addrs: KafkaAddrs,
     pub topic: String,
     pub key_desc_and_indices: Option<(RelationDesc, Vec<usize>)>,
+    pub relation_key_indices: Option<Vec<usize>>,
     pub value_desc: RelationDesc,
     pub key_schema_id: Option<i32>,
     pub value_schema_id: i32,
@@ -942,6 +943,14 @@ impl SinkConnector {
                 .key_desc_and_indices
                 .as_ref()
                 .map(|(_desc, indices)| indices.as_slice()),
+            SinkConnector::Tail(_) => None,
+            SinkConnector::AvroOcf(_) => None,
+        }
+    }
+
+    pub fn get_relation_key_indices(&self) -> Option<&[usize]> {
+        match self {
+            SinkConnector::Kafka(k) => k.relation_key_indices.as_deref(),
             SinkConnector::Tail(_) => None,
             SinkConnector::AvroOcf(_) => None,
         }
@@ -984,6 +993,9 @@ pub struct KafkaSinkConnectorBuilder {
     pub schema_registry_url: Url,
     pub key_schema: Option<String>,
     pub value_schema: String,
+    /// A natural key of the sinked relation (view or source).
+    pub relation_key_indices: Option<Vec<usize>>,
+    /// The user-specified key for the sink.
     pub key_desc_and_indices: Option<(RelationDesc, Vec<usize>)>,
     pub value_desc: RelationDesc,
     pub topic_prefix: String,

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1141,6 +1141,7 @@ fn kafka_sink_builder(
     with_options: &mut BTreeMap<String, Value>,
     broker: String,
     topic_prefix: String,
+    relation_key_indices: Option<Vec<usize>>,
     key_desc_and_indices: Option<(RelationDesc, Vec<usize>)>,
     value_desc: RelationDesc,
     topic_suffix_nonce: String,
@@ -1259,6 +1260,7 @@ fn kafka_sink_builder(
         config_options,
         ccsr_config,
         key_schema,
+        relation_key_indices,
         key_desc_and_indices,
         value_desc,
         exactly_once,
@@ -1378,6 +1380,9 @@ pub fn plan_create_sink(
         Connector::PubNub { .. } => None,
     };
 
+    // pick the first valid natural relation key, if any
+    let relation_key_indices = desc.typ().keys.get(0).cloned();
+
     let key_desc_and_indices = key_indices.map(|key_indices| {
         let cols = desc.clone().into_iter().collect::<Vec<_>>();
         let (names, types): (Vec<_>, Vec<_>) =
@@ -1414,6 +1419,7 @@ pub fn plan_create_sink(
             &mut with_options,
             broker,
             topic,
+            relation_key_indices,
             key_desc_and_indices,
             value_desc,
             suffix_nonce,

--- a/test/kafka-exactly-once/after-restart.td
+++ b/test/kafka-exactly-once/after-restart.td
@@ -89,14 +89,20 @@ a  b
 4  1
 5  2
 
-$ kafka-verify format=avro sink=materialize.public.output
+$ kafka-verify format=avro sink=materialize.public.output sort-messages=true
 {"before": null, "after": {"row": {"a": 1, "b": 1}}, "transaction": {"id": "1"}}
 {"before": null, "after": {"row": {"a": 1, "b": 2}}, "transaction": {"id": "1"}}
 {"before": null, "after": {"row": {"a": 2, "b": 1}}, "transaction": {"id": "1"}}
 {"before": null, "after": {"row": {"a": 3, "b": 1}}, "transaction": {"id": "1"}}
+
+$ kafka-verify format=avro sink=materialize.public.output sort-messages=true
 {"before": null, "after": {"row": {"a": 11, "b": 11}}, "transaction": {"id": "2"}}
 {"before": null, "after": {"row": {"a": 22, "b": 11}}, "transaction": {"id": "2"}}
+
+$ kafka-verify format=avro sink=materialize.public.output sort-messages=true
 {"before": null, "after": {"row": {"a": 3, "b": 4}}, "transaction": {"id": "3"}}
 {"before": null, "after": {"row": {"a": 5, "b": 6}}, "transaction": {"id": "3"}}
+
+$ kafka-verify format=avro sink=materialize.public.output sort-messages=true
 {"before": null, "after": {"row": {"a": 4, "b": 1}}, "transaction": {"id": "4"}}
 {"before": null, "after": {"row": {"a": 5, "b": 2}}, "transaction": {"id": "4"}}

--- a/test/kafka-exactly-once/before-restart.td
+++ b/test/kafka-exactly-once/before-restart.td
@@ -105,13 +105,17 @@ $ kafka-ingest format=avro topic=input schema=${schema} timestamp=4
 {"before": null, "after": {"row": {"a": 3, "b": 4}}}
 {"before": null, "after": {"row": {"a": 5, "b": 6}}}
 
-$ kafka-verify format=avro sink=materialize.public.output
+$ kafka-verify format=avro sink=materialize.public.output sort-messages=true
 {"before": null, "after": {"row": {"a": 1, "b": 1}}, "transaction": {"id": "1"}}
 {"before": null, "after": {"row": {"a": 1, "b": 2}}, "transaction": {"id": "1"}}
 {"before": null, "after": {"row": {"a": 2, "b": 1}}, "transaction": {"id": "1"}}
 {"before": null, "after": {"row": {"a": 3, "b": 1}}, "transaction": {"id": "1"}}
+
+$ kafka-verify format=avro sink=materialize.public.output sort-messages=true
 {"before": null, "after": {"row": {"a": 11, "b": 11}}, "transaction": {"id": "2"}}
 {"before": null, "after": {"row": {"a": 22, "b": 11}}, "transaction": {"id": "2"}}
+
+$ kafka-verify format=avro sink=materialize.public.output sort-messages=true
 {"before": null, "after": {"row": {"a": 3, "b": 4}}, "transaction": {"id": "3"}}
 {"before": null, "after": {"row": {"a": 5, "b": 6}}, "transaction": {"id": "3"}}
 

--- a/test/testdrive/consolidation.td
+++ b/test/testdrive/consolidation.td
@@ -114,10 +114,21 @@ $ kafka-ingest format=avro topic=tx schema=${tx-schema}
 # Test that by default updates that occurred at the same time are consolidated,
 # but updates that occurred at distinct times are not.
 
+# we know that transactions (timestamps) are emitted in order, but the order
+# of emitted records with the same timestamp is not deterministic. We therefore
+# verify each transaction separately and sort within each transaction to get
+# deterministic results.
+
 $ kafka-verify format=avro sink=materialize.public.nums_sink
 {"before": null, "after": {"row": {"num": 3}}}
-{"before": {"row": {"num": 3}}, "after": {"row": {"num": 4}}}
-{"before": {"row": {"num": 4}}, "after": {"row": {"num": 5}}}
+
+$ kafka-verify format=avro sink=materialize.public.nums_sink sort-messages=true
+{"before": null, "after": {"row": {"num": 4}}}
+{"before": {"row": {"num": 3}}, "after": null}
+
+$ kafka-verify format=avro sink=materialize.public.nums_sink sort-messages=true
+{"before": null, "after": {"row": {"num": 5}}}
+{"before": {"row": {"num": 4}}, "after": null}
 
 # TODO(benesch): re-enable when we support `CREATE SINK ... AS OF`.
 # # Test that a Debezium sink created `AS OF 3` (the latest completed timestamp)

--- a/test/testdrive/kafka-avro-debezium-sinks.td
+++ b/test/testdrive/kafka-avro-debezium-sinks.td
@@ -17,13 +17,15 @@
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'data-sink'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
-$ kafka-verify format=avro sink=materialize.public.data_sink
+$ kafka-verify format=avro sink=materialize.public.data_sink sort-messages=true
 {"before": null, "after": {"row": {"a": 1, "b": 1}}}
 {"before": null, "after": {"row": {"a": 1, "b": 2}}}
 {"before": null, "after": {"row": {"a": 2, "b": 1}}}
 {"before": null, "after": {"row": {"a": 3, "b": 1}}}
 
-# More complex sinks, with multiple keys and/or a consistency topic
+# More complex sinks, with multiple keys and/or a consistency topic. We test
+# all the possible combinations of user-specified sink key and
+# natural (primary) relation key.
 
 $ set schema={
     "type": "record",
@@ -85,19 +87,41 @@ $ set trxschema={
 $ kafka-create-topic topic=consistency
 $ kafka-create-topic topic=input
 
+# first create all the sinks, then ingest data, to ensure that
+# input is processed in consistency batches and not all at once
+
 > CREATE MATERIALIZED SOURCE input
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-${testdrive.seed}'
     WITH (consistency_topic = 'testdrive-consistency-${testdrive.seed}')
   FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
 
-> CREATE SINK input_sink FROM input
-  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'input-sink' KEY (a)
-  WITH (consistency_topic = 'input-sink-consistency') FORMAT AVRO
+> CREATE SINK non_keyed_sink FROM input
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'non-keyed-sink'
+  WITH (consistency_topic = 'non-keyed-sink-consistency') FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
-> CREATE SINK input_sink_multiple_keys FROM input
-  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'input-sink-multi-key' KEY (b, a)
-  WITH (consistency_topic = 'input-sink-multi-key-consistency') FORMAT AVRO
+> CREATE VIEW max_view AS SELECT a, MAX(b) as b FROM input GROUP BY a
+
+# the sinked relation has the natural primary key (a)
+
+> CREATE SINK non_keyed_sink_of_keyed_relation FROM input
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'non-keyed-sink-of-keyed-relation'
+  WITH (consistency_topic = 'non-keyed-sink-of-keyed-relation-consistency') FORMAT AVRO
+  USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+
+> CREATE SINK keyed_sink FROM input
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'keyed-sink' KEY (a)
+  WITH (consistency_topic = 'keyed-sink-consistency') FORMAT AVRO
+  USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+
+> CREATE SINK keyed_sink_of_keyed_relation FROM input
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'keyed-sink-of-keyed-relation' KEY (b)
+  WITH (consistency_topic = 'keyed-sink-of-keyed-relation-consistency') FORMAT AVRO
+  USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+
+> CREATE SINK multi_keyed_sink FROM input
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'multi-keyed-sink' KEY (b, a)
+  WITH (consistency_topic = 'multi-keyed-sink-consistency') FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 $ kafka-ingest format=avro topic=input schema=${schema} timestamp=1
@@ -130,18 +154,18 @@ a  b
 # transaction appear together as one "bundle" in the output. But there is no
 # guarantee on the order within a transaction.
 
-$ kafka-verify format=avro sink=materialize.public.input_sink sort-messages=true
-{"a": 1} {"before": null, "after": {"row": {"a": 1, "b": 1}}, "transaction": {"id": "1"}}
-{"a": 2} {"before": null, "after": {"row": {"a": 2, "b": 2}}, "transaction": {"id": "1"}}
+$ kafka-verify format=avro sink=materialize.public.non_keyed_sink sort-messages=true
+{"before": null, "after": {"row": {"a": 1, "b": 1}}, "transaction": {"id": "1"}}
+{"before": null, "after": {"row": {"a": 2, "b": 2}}, "transaction": {"id": "1"}}
 
-$ kafka-verify format=avro sink=materialize.public.input_sink sort-messages=true
-{"a": 3} {"before": null, "after": {"row": {"a": 3, "b": 1}}, "transaction": {"id": "2"}}
-{"a": 4} {"before": null, "after": {"row": {"a": 4, "b": 2}}, "transaction": {"id": "2"}}
+$ kafka-verify format=avro sink=materialize.public.non_keyed_sink sort-messages=true
+{"before": null, "after": {"row": {"a": 3, "b": 1}}, "transaction": {"id": "2"}}
+{"before": null, "after": {"row": {"a": 4, "b": 2}}, "transaction": {"id": "2"}}
 
-$ kafka-verify format=avro sink=materialize.public.input_sink sort-messages=true
-{"a": 1} {"before": null, "after": {"row": {"a": 1, "b": 7}}, "transaction": {"id": "3"}}
+$ kafka-verify format=avro sink=materialize.public.non_keyed_sink sort-messages=true
+{"before": null, "after": {"row": {"a": 1, "b": 7}}, "transaction": {"id": "3"}}
 
-$ kafka-verify format=avro sink=materialize.public.input_sink consistency=debezium
+$ kafka-verify format=avro sink=materialize.public.non_keyed_sink consistency=debezium
 {"id": "1", "status": "BEGIN", "event_count": null}
 {"id": "1", "status": "END", "event_count": {"long": 2}}
 {"id": "2", "status": "BEGIN", "event_count": null}
@@ -151,13 +175,84 @@ $ kafka-verify format=avro sink=materialize.public.input_sink consistency=debezi
 
 # Again, compare split by transaction. See comment just above.
 
-$ kafka-verify format=avro sink=materialize.public.input_sink_multiple_keys sort-messages=true
+$ kafka-verify format=avro sink=materialize.public.non_keyed_sink_of_keyed_relation sort-messages=true
+{"before": null, "after": {"row": {"a": 1, "b": 1}}, "transaction": {"id": "1"}}
+{"before": null, "after": {"row": {"a": 2, "b": 2}}, "transaction": {"id": "1"}}
+
+$ kafka-verify format=avro sink=materialize.public.non_keyed_sink_of_keyed_relation sort-messages=true
+{"before": null, "after": {"row": {"a": 3, "b": 1}}, "transaction": {"id": "2"}}
+{"before": null, "after": {"row": {"a": 4, "b": 2}}, "transaction": {"id": "2"}}
+
+$ kafka-verify format=avro sink=materialize.public.non_keyed_sink_of_keyed_relation sort-messages=true
+{"before": null, "after": {"row": {"a": 1, "b": 7}}, "transaction": {"id": "3"}}
+
+$ kafka-verify format=avro sink=materialize.public.non_keyed_sink_of_keyed_relation consistency=debezium
+{"id": "1", "status": "BEGIN", "event_count": null}
+{"id": "1", "status": "END", "event_count": {"long": 2}}
+{"id": "2", "status": "BEGIN", "event_count": null}
+{"id": "2", "status": "END", "event_count": {"long": 2}}
+{"id": "3", "status": "BEGIN", "event_count": null}
+{"id": "3", "status": "END", "event_count": {"long": 1}}
+
+# Again, compare split by transaction. See comment just above.
+
+$ kafka-verify format=avro sink=materialize.public.keyed_sink sort-messages=true
+{"a": 1} {"before": null, "after": {"row": {"a": 1, "b": 1}}, "transaction": {"id": "1"}}
+{"a": 2} {"before": null, "after": {"row": {"a": 2, "b": 2}}, "transaction": {"id": "1"}}
+
+$ kafka-verify format=avro sink=materialize.public.keyed_sink sort-messages=true
+{"a": 3} {"before": null, "after": {"row": {"a": 3, "b": 1}}, "transaction": {"id": "2"}}
+{"a": 4} {"before": null, "after": {"row": {"a": 4, "b": 2}}, "transaction": {"id": "2"}}
+
+$ kafka-verify format=avro sink=materialize.public.keyed_sink sort-messages=true
+{"a": 1} {"before": null, "after": {"row": {"a": 1, "b": 7}}, "transaction": {"id": "3"}}
+
+$ kafka-verify format=avro sink=materialize.public.keyed_sink consistency=debezium
+{"id": "1", "status": "BEGIN", "event_count": null}
+{"id": "1", "status": "END", "event_count": {"long": 2}}
+{"id": "2", "status": "BEGIN", "event_count": null}
+{"id": "2", "status": "END", "event_count": {"long": 2}}
+{"id": "3", "status": "BEGIN", "event_count": null}
+{"id": "3", "status": "END", "event_count": {"long": 1}}
+
+# Again, compare split by transaction. See comment just above.
+
+$ kafka-verify format=avro sink=materialize.public.keyed_sink_of_keyed_relation sort-messages=true
+{"b": 1} {"before": null, "after": {"row": {"a": 1, "b": 1}}, "transaction": {"id": "1"}}
+{"b": 2} {"before": null, "after": {"row": {"a": 2, "b": 2}}, "transaction": {"id": "1"}}
+
+$ kafka-verify format=avro sink=materialize.public.keyed_sink_of_keyed_relation sort-messages=true
+{"b": 1} {"before": null, "after": {"row": {"a": 3, "b": 1}}, "transaction": {"id": "2"}}
+{"b": 2} {"before": null, "after": {"row": {"a": 4, "b": 2}}, "transaction": {"id": "2"}}
+
+$ kafka-verify format=avro sink=materialize.public.keyed_sink_of_keyed_relation sort-messages=true
+{"b": 7} {"before": null, "after": {"row": {"a": 1, "b": 7}}, "transaction": {"id": "3"}}
+
+$ kafka-verify format=avro sink=materialize.public.keyed_sink_of_keyed_relation consistency=debezium
+{"id": "1", "status": "BEGIN", "event_count": null}
+{"id": "1", "status": "END", "event_count": {"long": 2}}
+{"id": "2", "status": "BEGIN", "event_count": null}
+{"id": "2", "status": "END", "event_count": {"long": 2}}
+{"id": "3", "status": "BEGIN", "event_count": null}
+{"id": "3", "status": "END", "event_count": {"long": 1}}
+
+# Again, compare split by transaction. See comment just above.
+
+$ kafka-verify format=avro sink=materialize.public.multi_keyed_sink sort-messages=true
 {"b": 1, "a": 1} {"before": null, "after": {"row": {"a": 1, "b": 1}}, "transaction": {"id": "1"}}
 {"b": 2, "a": 2} {"before": null, "after": {"row": {"a": 2, "b": 2}}, "transaction": {"id": "1"}}
 
-$ kafka-verify format=avro sink=materialize.public.input_sink_multiple_keys sort-messages=true
+$ kafka-verify format=avro sink=materialize.public.multi_keyed_sink sort-messages=true
 {"b": 1, "a": 3} {"before": null, "after": {"row": {"a": 3, "b": 1}}, "transaction": {"id": "2"}}
 {"b": 2, "a": 4} {"before": null, "after": {"row": {"a": 4, "b": 2}}, "transaction": {"id": "2"}}
 
-$ kafka-verify format=avro sink=materialize.public.input_sink_multiple_keys sort-messages=true
+$ kafka-verify format=avro sink=materialize.public.multi_keyed_sink sort-messages=true
 {"b": 7, "a": 1} {"before": null, "after": {"row": {"a": 1, "b": 7}}, "transaction": {"id": "3"}}
+
+$ kafka-verify format=avro sink=materialize.public.multi_keyed_sink consistency=debezium
+{"id": "1", "status": "BEGIN", "event_count": null}
+{"id": "1", "status": "END", "event_count": {"long": 2}}
+{"id": "2", "status": "BEGIN", "event_count": null}
+{"id": "2", "status": "END", "event_count": {"long": 2}}
+{"id": "3", "status": "BEGIN", "event_count": null}
+{"id": "3", "status": "END", "event_count": {"long": 1}}

--- a/test/testdrive/kafka-avro-sinks.td
+++ b/test/testdrive/kafka-avro-sinks.td
@@ -44,9 +44,9 @@ $ kafka-verify format=avro sink=materialize.public.clashing_cols_sink
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'datetime-data-sink'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
-$ kafka-verify format=avro sink=materialize.public.datetime_data_sink
-{"before": null, "after": {"row": {"date": 10988, "ts": 949399810111000, "ts_tz": 949392610111000}}}
+$ kafka-verify format=avro sink=materialize.public.datetime_data_sink sort-messages=true
 {"before": null, "after": {"row": {"date": 10957, "ts": 946721410111000, "ts_tz": 946714210111000}}}
+{"before": null, "after": {"row": {"date": 10988, "ts": 949399810111000, "ts_tz": 949392610111000}}}
 
 > CREATE VIEW time_data (time) AS VALUES (TIME '01:02:03'), (TIME '01:02:04')
 
@@ -54,7 +54,7 @@ $ kafka-verify format=avro sink=materialize.public.datetime_data_sink
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'time-data-sink'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
-$ kafka-verify format=avro sink=materialize.public.time_data_sink
+$ kafka-verify format=avro sink=materialize.public.time_data_sink sort-messages=true
 {"before": null, "after": {"row": {"time": 3723000000}}}
 {"before": null, "after": {"row": {"time": 3724000000}}}
 

--- a/test/testdrive/sinks.td
+++ b/test/testdrive/sinks.td
@@ -97,25 +97,25 @@ snk3   user  unknown
 snk4   user  unknown
 snk5   user  unknown
 
-$ kafka-verify format=avro sink=materialize.public.snk1
-{"before": null, "after": {"row":{"a": "jack", "b": "jill", "mz_line_no": 1}}}
+$ kafka-verify format=avro sink=materialize.public.snk1 sort-messages=true
 {"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "mz_line_no": 2}}}
-
-$ kafka-verify format=avro sink=materialize.public.snk2
 {"before": null, "after": {"row":{"a": "jack", "b": "jill", "mz_line_no": 1}}}
+
+$ kafka-verify format=avro sink=materialize.public.snk2 sort-messages=true
 {"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "mz_line_no": 2}}}
+{"before": null, "after": {"row":{"a": "jack", "b": "jill", "mz_line_no": 1}}}
 
-$ kafka-verify format=avro sink=materialize.public.snk3
-{"before": null, "after": {"row":{"c": "jackjill"}}}
+$ kafka-verify format=avro sink=materialize.public.snk3 sort-messages=true
 {"before": null, "after": {"row":{"c": "goofusgallant"}}}
+{"before": null, "after": {"row":{"c": "jackjill"}}}
 
-$ kafka-verify format=avro sink=materialize.public.snk4
-{"before": null, "after": {"row":{"c": "jackjill"}}}
+$ kafka-verify format=avro sink=materialize.public.snk4 sort-messages=true
 {"before": null, "after": {"row":{"c": "goofusgallant"}}}
+{"before": null, "after": {"row":{"c": "jackjill"}}}
 
-$ kafka-verify format=avro sink=materialize.public.snk5
-{"before": null, "after": {"row":{"c": "jackjill"}}}
+$ kafka-verify format=avro sink=materialize.public.snk5 sort-messages=true
 {"before": null, "after": {"row":{"c": "goofusgallant"}}}
+{"before": null, "after": {"row":{"c": "jackjill"}}}
 
 # Test the case where we have non +/- 1 multiplicities
 
@@ -157,10 +157,10 @@ extra,row
 $ kafka-verify format=avro sink=materialize.public.snk7
 {"before": null, "after": {"row":{"a": "extra", "b": "row", "mz_line_no": 3}}}
 
-$ kafka-verify format=avro sink=materialize.public.snk8
-{"before": null, "after": {"row":{"a": "jack", "b": "jill", "mz_line_no": 1}}}
-{"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "mz_line_no": 2}}}
+$ kafka-verify format=avro sink=materialize.public.snk8 sort-messages=true
 {"before": null, "after": {"row":{"a": "extra", "b": "row", "mz_line_no": 3}}}
+{"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "mz_line_no": 2}}}
+{"before": null, "after": {"row":{"a": "jack", "b": "jill", "mz_line_no": 1}}}
 
 # Test that we are correctly handling WITH/WITHOUT SNAPSHOT on views with
 # empty upper frontier
@@ -178,7 +178,7 @@ $ kafka-verify format=avro sink=materialize.public.sink9
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   WITH SNAPSHOT
 
-$ kafka-verify format=avro sink=materialize.public.sink10
+$ kafka-verify format=avro sink=materialize.public.sink10 sort-messages=true
 {"before": null, "after": {"row":{"column1": 1}}}
 {"before": null, "after": {"row":{"column1": 2}}}
 {"before": null, "after": {"row":{"column1": 3}}}


### PR DESCRIPTION
This changes how `before` and `after` updates for DEBEZIUM sinks are
merged together. We now do the following:

1. if there is a user-specified key, merge updates by that (as before),
   otherwise
2. if there is a natural (primary) relation key, merge updates by that,
   otherwise
3. consolidate using whole row, and don't merge updates.

For cases 2. and 3. we don't write the key out to Kafka but only use it
to consolidate/merge updates and distribute the sink work across
workers.

Using a key for all cases has the effect of more evenly utilizing all
available workers, increasing throughput.

We need to adapt some tests because the order of writing unrelated
changes to Kafka is not deterministic anymore. These tests were working
before because both the sources and the sinks where non-parallel, which
is not necessarily the case for real-world use cases. Now the tests
behave more like those real-world use cases. Otherwise, user-visible
behaviour should not change, other than the aforementioned improved
throughput out of the box.

This also adds test for all the possible combinations of relation key
and user-specified key for DEBEZIUM sinks. Only DEBEZIUM sinks are
effected because 1) UPSERT sinks always have a user-specified key, and
2) this only affects Kafka sinks for now.


This closes #6776.