### PR TITLE
coord,testdrive: drop replication slots when dropping Postgres source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -552,6 +552,7 @@ dependencies = [
  "ore",
  "pgrepr",
  "postgres-types",
+ "postgres-util",
  "prometheus",
  "rand 0.8.3",
  "rdkafka",

--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -29,6 +29,7 @@ mz-avro = { path = "../avro", features = ["snappy"] }
 ore = { path = "../ore" }
 pgrepr = { path = "../pgrepr" }
 postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres" }
+postgres-util = { path = "../postgres-util" }
 prometheus = { git = "https://github.com/MaterializeInc/rust-prometheus.git", default-features = false }
 rand = "0.8.3"
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "libz-static"] }

--- a/src/postgres-util/src/lib.rs
+++ b/src/postgres-util/src/lib.rs
@@ -15,7 +15,7 @@ use anyhow::anyhow;
 use openssl::ssl::{SslConnector, SslMethod, SslVerifyMode};
 use postgres_openssl::MakeTlsConnector;
 use tokio_postgres::types::Type as PgType;
-use tokio_postgres::Config;
+use tokio_postgres::{Client, Config};
 
 use sql_parser::ast::display::{AstDisplay, AstFormatter};
 use sql_parser::impl_display;
@@ -194,4 +194,37 @@ pub async fn publication_info(
     }
 
     Ok(table_infos)
+}
+
+pub async fn drop_replication_slots(conn: &str, slots: &[String]) -> Result<(), anyhow::Error> {
+    let config = conn.parse()?;
+    let tls = make_tls(&config)?;
+    let (client, connection) = tokio_postgres::connect(&conn, tls).await?;
+    tokio::spawn(connection);
+
+    for slot in slots {
+        let active_pid = query_pg_replication_slots(&client, slot).await?;
+        if let Some(pid) = active_pid {
+            client
+                .query("SELECT pg_terminate_backend($1)", &[&pid])
+                .await?;
+        }
+        client
+            .query("SELECT pg_drop_replication_slot($1)", &[&slot])
+            .await?;
+    }
+    Ok(())
+}
+
+pub async fn query_pg_replication_slots(
+    client: &Client,
+    slot: &str,
+) -> Result<Option<i32>, anyhow::Error> {
+    let row = client
+        .query_one(
+            "SELECT active_pid FROM pg_replication_slots WHERE slot_name = $1::TEXT",
+            &[&slot],
+        )
+        .await?;
+    Ok(row.get(0))
 }

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -426,6 +426,9 @@ pub fn build(cmds: Vec<PosCommand>, state: &State) -> Result<Vec<PosAction>, Err
                     "postgres-execute" => {
                         Box::new(postgres::build_execute(builtin).map_err(wrap_err)?)
                     }
+                    "postgres-verify-slot" => {
+                        Box::new(postgres::build_verify_slot(builtin).map_err(wrap_err)?)
+                    }
                     "random-sleep" => {
                         Box::new(sleep::build_random_sleep(builtin).map_err(wrap_err)?)
                     }

--- a/src/testdrive/src/action/postgres.rs
+++ b/src/testdrive/src/action/postgres.rs
@@ -7,52 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use async_trait::async_trait;
-use tokio_postgres::NoTls;
+mod execute;
+mod verify_slot;
 
-use crate::action::{Action, State};
-use crate::parser::BuiltinCommand;
-
-pub struct ExecuteAction {
-    connection: String,
-    queries: Vec<String>,
-}
-
-pub fn build_execute(mut cmd: BuiltinCommand) -> Result<ExecuteAction, String> {
-    let connection = cmd.args.string("connection")?;
-    cmd.args.done()?;
-    Ok(ExecuteAction {
-        connection,
-        queries: cmd.input,
-    })
-}
-
-#[async_trait]
-impl Action for ExecuteAction {
-    async fn undo(&self, _: &mut State) -> Result<(), String> {
-        Ok(())
-    }
-
-    async fn redo(&self, _: &mut State) -> Result<(), String> {
-        let (client, conn) = tokio_postgres::connect(&self.connection, NoTls)
-            .await
-            .map_err(|e| format!("connecting to postgres: {}", e))?;
-        println!(
-            "Executing queries against PostgreSQL server at {}...",
-            self.connection
-        );
-        let conn_handle = tokio::spawn(conn);
-        for query in &self.queries {
-            println!(">> {}", query);
-            client
-                .batch_execute(query)
-                .await
-                .map_err(|e| format!("executing postgres query: {}", e))?;
-        }
-        drop(client);
-        conn_handle
-            .await
-            .unwrap()
-            .map_err(|e| format!("postgres connection error: {}", e))
-    }
-}
+pub use execute::build_execute;
+pub use verify_slot::build_verify_slot;

--- a/src/testdrive/src/action/postgres/execute.rs
+++ b/src/testdrive/src/action/postgres/execute.rs
@@ -1,0 +1,58 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use async_trait::async_trait;
+use tokio_postgres::NoTls;
+
+use crate::action::{Action, State};
+use crate::parser::BuiltinCommand;
+
+pub struct ExecuteAction {
+    connection: String,
+    queries: Vec<String>,
+}
+
+pub fn build_execute(mut cmd: BuiltinCommand) -> Result<ExecuteAction, String> {
+    let connection = cmd.args.string("connection")?;
+    cmd.args.done()?;
+    Ok(ExecuteAction {
+        connection,
+        queries: cmd.input,
+    })
+}
+
+#[async_trait]
+impl Action for ExecuteAction {
+    async fn undo(&self, _: &mut State) -> Result<(), String> {
+        Ok(())
+    }
+
+    async fn redo(&self, _: &mut State) -> Result<(), String> {
+        let (client, conn) = tokio_postgres::connect(&self.connection, NoTls)
+            .await
+            .map_err(|e| format!("connecting to postgres: {}", e))?;
+        println!(
+            "Executing queries against PostgreSQL server at {}...",
+            self.connection
+        );
+        let conn_handle = tokio::spawn(conn);
+        for query in &self.queries {
+            println!(">> {}", query);
+            client
+                .batch_execute(query)
+                .await
+                .map_err(|e| format!("executing postgres query: {}", e))?;
+        }
+        drop(client);
+        conn_handle
+            .await
+            .unwrap()
+            .map_err(|e| format!("postgres connection error: {}", e))
+    }
+}

--- a/src/testdrive/src/action/postgres/verify_slot.rs
+++ b/src/testdrive/src/action/postgres/verify_slot.rs
@@ -1,0 +1,99 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use async_trait::async_trait;
+use std::time::Duration;
+use tokio_postgres::NoTls;
+
+use ore::retry::Retry;
+
+use crate::action::{Action, State};
+use crate::parser::BuiltinCommand;
+
+pub struct VerifySlotAction {
+    connection: String,
+    slot: String,
+    active: bool,
+}
+
+pub fn build_verify_slot(mut cmd: BuiltinCommand) -> Result<VerifySlotAction, String> {
+    let connection = cmd.args.string("connection")?;
+    let slot = cmd.args.string("slot")?;
+    let active: bool = cmd.args.parse("active")?;
+    cmd.args.done()?;
+    Ok(VerifySlotAction {
+        connection,
+        slot,
+        active,
+    })
+}
+
+#[async_trait]
+impl Action for VerifySlotAction {
+    async fn undo(&self, _: &mut State) -> Result<(), String> {
+        Ok(())
+    }
+
+    async fn redo(&self, _: &mut State) -> Result<(), String> {
+        let (client, conn) = tokio_postgres::connect(&self.connection, NoTls)
+            .await
+            .map_err(|e| format!("connecting to postgres: {}", e))?;
+        println!(
+            "Executing queries against PostgreSQL server at {}...",
+            self.connection
+        );
+        let conn_handle = tokio::spawn(conn);
+
+        Retry::default()
+            .initial_backoff(Duration::from_millis(50))
+            .max_duration(Duration::from_secs(3))
+            .retry(|_| async {
+                println!(">> checking for postgres replication slot {}", &self.slot);
+                let rows = client
+                    .query(
+                        "SELECT active_pid FROM pg_replication_slots WHERE slot_name = $1::TEXT",
+                        &[&self.slot],
+                    )
+                    .await
+                    .map_err(|e| format!("querying postgres for replication slot: {}", e))?;
+
+                if self.active {
+                    if rows.len() != 1 {
+                        return Err(format!(
+                            "expected entry for slot {} in pg_replication slots, found {}",
+                            &self.slot,
+                            rows.len()
+                        ));
+                    }
+                    let active_pid: Option<i32> = rows[0].get(0);
+                    if active_pid.is_none() {
+                        return Err(format!(
+                            "expected slot {} to be active, is inactive",
+                            &self.slot
+                        ));
+                    }
+                } else {
+                    if rows.len() != 0 {
+                        return Err(format!(
+                            "expected slot {} to be inactive, is active",
+                            &self.slot
+                        ));
+                    }
+                }
+                Ok(())
+            })
+            .await?;
+
+        drop(client);
+        conn_handle
+            .await
+            .unwrap()
+            .map_err(|e| format!("postgres connection error: {}", e))
+    }
+}

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -346,6 +346,23 @@ true
 true
 
 #
+# Test that slots created for replication sources are deleted on DROP
+#
+$ postgres-verify-slot connection=postgres://postgres:postgres@postgres slot=test_slot active=false
+
+> CREATE MATERIALIZED SOURCE "test_slot_source"
+  FROM POSTGRES
+    HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
+    PUBLICATION 'mz_source'
+    SLOT 'test_slot';
+
+$ postgres-verify-slot connection=postgres://postgres:postgres@postgres slot=test_slot active=true
+
+> DROP SOURCE test_slot_source
+
+$ postgres-verify-slot connection=postgres://postgres:postgres@postgres slot=test_slot active=false
+
+#
 # Remove all data on the Postgres side
 #
 


### PR DESCRIPTION
This is a simplified version of #6714 until we figure out how we'd want to persist per-source external state data on disk.

To address the following comment from #6714:
> Oh, shoot. I suspect calling pg_terminate_backend will be problematic in a lot of real world deployments. That requires a superuser account, and you probably don't want to give Materialize that kind of access to your Postgres instance.

This is true, but there's also [a loophole](https://www.postgresql.org/docs/13/functions-admin.html#FUNCTIONS-ADMIN-SIGNAL):
> [Calling pg_terminate_backend] is also allowed if the calling role is a member of the role whose backend is being terminated...

Because we will be terminating the backend process using the same role that created it (the `user` parameter of the Postgres `CREATE SOURCE` statement), the role doesn't need to be a superuser. To illustrate, I spun up Materialize using this branch, created a non-superuser, used that to create a Postgres source, and then used that same user to kill the backend process.

In Postgres:
```
jessicalaughlin=# create role test_replication;
jessicalaughlin=# alter role test_replication replication;
jessicalaughlin=# alter role test_replication with login;
jessicalaughlin=# grant usage on schema public to test_replication;
jessicalaughlin=# grant select on test to test_replication;
jessicalaughlin=# \du
                                       List of roles
    Role name     |                         Attributes                         | Member of
------------------+------------------------------------------------------------+-----------
 jessicalaughlin  | Superuser, Create role, Create DB, Replication, Bypass RLS | {}
 postgres         | Superuser, Replication                                     | {}
 test_replication | Replication                                                | {}

jessicalaughlin=# select grantee, table_schema, table_name, privilege_type from information_schema.role_table_grants where grantee = 'test_replication';
     grantee      | table_schema | table_name | privilege_type
------------------+--------------+------------+----------------
 test_replication | public       | test       | SELECT
```

In Materialize:
```
materialize=> CREATE MATERIALIZED SOURCE "test"
FROM POSTGRES HOST 'host=localhost user=test_replication password=postgres dbname=jessicalaughlin'
PUBLICATION 'mz_source'
SLOT 'test2';
```

Back in Postgres:
```
jessicalaughlin=# select * from pg_replication_slots;
 slot_name |  plugin  | slot_type | datoid |    database     | temporary | active | active_pid | xmin | catalog_xmin | restart_lsn | confirmed_flush_lsn | wal_status | safe_wal_size
-----------+----------+-----------+--------+-----------------+-----------+--------+------------+------+--------------+-------------+---------------------+------------+---------------
 test2     | pgoutput | logical   |  16384 | jessicalaughlin | f         | t      |      92687 |      |         2517 | 0/35F5348   | 0/35F5348           | reserved   |
(1 row)

jessicalaughlin=# set role test_replication;
jessicalaughlin=> select pg_terminate_backend(92687);
 pg_terminate_backend
----------------------
 t
(1 row)
jessicalaughlin=> select pg_drop_replication_slot('test2');
 pg_drop_replication_slot
--------------------------

(1 row)

jessicalaughlin=> select * from pg_replication_slots;
 slot_name | plugin | slot_type | datoid | database | temporary | active | active_pid | xmin | catalog_xmin | restart_lsn | confirmed_flush_lsn | wal_status | safe_wal_size
-----------+--------+-----------+--------+----------+-----------+--------+------------+------+--------------+-------------+---------------------+------------+---------------
(0 rows)
```

(This also works when running `DROP SOURCE test` against Materialize with this PR, but just to illustrate my point.)