### PR TITLE
postgres: add `WITH` tls options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3034,7 +3034,7 @@ dependencies = [
 [[package]]
 name = "postgres"
 version = "0.19.1"
-source = "git+https://github.com/MaterializeInc/rust-postgres#fea178cfc3114d0c20622cb4372d78b22282aa72"
+source = "git+https://github.com/uce/rust-postgres?branch=6716-ssl_modes#f791e6dd3552d6ee44dbf90dbac22f997f35a520"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -3047,7 +3047,7 @@ dependencies = [
 [[package]]
 name = "postgres-openssl"
 version = "0.5.0"
-source = "git+https://github.com/MaterializeInc/rust-postgres#fea178cfc3114d0c20622cb4372d78b22282aa72"
+source = "git+https://github.com/uce/rust-postgres?branch=6716-ssl_modes#f791e6dd3552d6ee44dbf90dbac22f997f35a520"
 dependencies = [
  "futures",
  "openssl",
@@ -3059,7 +3059,7 @@ dependencies = [
 [[package]]
 name = "postgres-protocol"
 version = "0.6.1"
-source = "git+https://github.com/MaterializeInc/rust-postgres#fea178cfc3114d0c20622cb4372d78b22282aa72"
+source = "git+https://github.com/uce/rust-postgres?branch=6716-ssl_modes#f791e6dd3552d6ee44dbf90dbac22f997f35a520"
 dependencies = [
  "base64",
  "byteorder",
@@ -3076,7 +3076,7 @@ dependencies = [
 [[package]]
 name = "postgres-types"
 version = "0.2.1"
-source = "git+https://github.com/MaterializeInc/rust-postgres#fea178cfc3114d0c20622cb4372d78b22282aa72"
+source = "git+https://github.com/uce/rust-postgres?branch=6716-ssl_modes#f791e6dd3552d6ee44dbf90dbac22f997f35a520"
 dependencies = [
  "bytes",
  "chrono",
@@ -3102,7 +3102,7 @@ dependencies = [
 [[package]]
 name = "postgres_array"
 version = "0.11.0"
-source = "git+https://github.com/MaterializeInc/rust-postgres-array#cbf48cd674ded4b6e7648fab253807c055c8ec10"
+source = "git+https://github.com/uce/rust-postgres-array?branch=6716-ssl_modes#b1afcfcd8483ff8214259a61d6ea0fd8f8220acf"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -4890,7 +4890,7 @@ dependencies = [
 [[package]]
 name = "tokio-postgres"
 version = "0.7.1"
-source = "git+https://github.com/MaterializeInc/rust-postgres#fea178cfc3114d0c20622cb4372d78b22282aa72"
+source = "git+https://github.com/uce/rust-postgres?branch=6716-ssl_modes#f791e6dd3552d6ee44dbf90dbac22f997f35a520"
 dependencies = [
  "async-trait",
  "byteorder",

--- a/demo/billing/Cargo.toml
+++ b/demo/billing/Cargo.toml
@@ -17,14 +17,14 @@ hex = "0.4.3"
 log = "0.4.13"
 ore = { path = "../../src/ore" }
 parse_duration = "2.1.1"
-postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres" }
+postgres-types = { git = "https://github.com/uce/rust-postgres", branch = "6716-ssl_modes" }
 protobuf = "2.17.0"
 rand = "0.8.3"
 rand_distr = "0.4.0"
 structopt = "0.3.21"
 test-util = { path = "../../test/test-util" }
 tokio = "1.6.0"
-tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
+tokio-postgres = { git = "https://github.com/uce/rust-postgres", branch = "6716-ssl_modes" }
 uuid = { version = "0.8.2", features = ["v4"] }
 
 [build-dependencies]

--- a/deny.toml
+++ b/deny.toml
@@ -74,13 +74,12 @@ unknown-git = "deny"
 unknown-registry = "deny"
 allow-git = [
     "https://github.com/MaterializeInc/pubnub-rust.git",
-    # Until https://github.com/sfackler/rust-postgres/pull/752 is merged and released
-    "https://github.com/MaterializeInc/rust-postgres.git",
-    "https://github.com/MaterializeInc/rust-postgres-array.git",
     "https://github.com/MaterializeInc/rust-prometheus.git",
     "https://github.com/MaterializeInc/serde-protobuf.git",
     "https://github.com/TimelyDataflow/timely-dataflow",
     "https://github.com/TimelyDataflow/differential-dataflow.git",
     "https://github.com/fede1024/rust-rdkafka.git",
-    "https://github.com/rusoto/rusoto.git"
+    "https://github.com/rusoto/rusoto.git",
+    "https://github.com/uce/rust-postgres.git",
+    "https://github.com/uce/rust-postgres-array.git",
 ]

--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -28,7 +28,7 @@ log = "0.4.13"
 mz-avro = { path = "../avro", features = ["snappy"] }
 ore = { path = "../ore" }
 pgrepr = { path = "../pgrepr" }
-postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres" }
+postgres-types = { git = "https://github.com/uce/rust-postgres", branch = "6716-ssl_modes" }
 prometheus = { git = "https://github.com/MaterializeInc/rust-prometheus.git", default-features = false }
 rand = "0.8.3"
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "libz-static"] }
@@ -44,7 +44,7 @@ storage = { path = "../storage" }
 symbiosis = { path = "../symbiosis" }
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 tokio = "1.6.0"
-tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
+tokio-postgres = { git = "https://github.com/uce/rust-postgres", branch = "6716-ssl_modes" }
 tokio-stream = "0.1.6"
 transform = { path = "../transform" }
 unicase = "2.6.0"

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -846,6 +846,7 @@ pub struct PostgresSourceConnector {
     pub conn: String,
     pub publication: String,
     pub slot_name: String,
+    pub config_options: BTreeMap<String, String>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/src/dataflow/Cargo.toml
+++ b/src/dataflow/Cargo.toml
@@ -31,7 +31,7 @@ log = "0.4.13"
 mz-avro = { path = "../avro", features = ["snappy"] }
 ore = { path = "../ore" }
 pdqselect = "0.1.0"
-postgres-protocol = { git = "https://github.com/MaterializeInc/rust-postgres" }
+postgres-protocol = { git = "https://github.com/uce/rust-postgres", branch = "6716-ssl_modes" }
 postgres-util = { path = "../postgres-util" }
 prometheus = { git = "https://github.com/MaterializeInc/rust-prometheus.git", default-features = false }
 prometheus-static-metric = { git = "https://github.com/MaterializeInc/rust-prometheus.git" }
@@ -49,7 +49,7 @@ serde = { version = "1.0.125", features = ["derive"] }
 serde_json = "1.0.64"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 tokio = { version = "1.6.0", features = ["fs", "rt", "sync"] }
-tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
+tokio-postgres = { git = "https://github.com/uce/rust-postgres", branch = "6716-ssl_modes" }
 tokio-util = { version = "0.6.6", features = ["codec"] }
 url = { version = "2.2.2", features = ["serde"] }
 uuid = { version = "0.8.2", features = ["serde", "v4"] }

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -105,16 +105,16 @@ itertools = "0.9.0"
 kafka-util = { path = "../kafka-util" }
 pgrepr = { path = "../pgrepr" }
 pgtest = { path = "../pgtest" }
-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["with-chrono-0_4"] }
-postgres-openssl = { git = "https://github.com/MaterializeInc/rust-postgres" }
-postgres-protocol = { git = "https://github.com/MaterializeInc/rust-postgres" }
-postgres_array = { git = "https://github.com/MaterializeInc/rust-postgres-array" }
+postgres = { git = "https://github.com/uce/rust-postgres", branch = "6716-ssl_modes", features = ["with-chrono-0_4"] }
+postgres-openssl = { git = "https://github.com/uce/rust-postgres", branch = "6716-ssl_modes" }
+postgres-protocol = { git = "https://github.com/uce/rust-postgres", branch = "6716-ssl_modes" }
+postgres_array = { git = "https://github.com/uce/rust-postgres-array", branch = "6716-ssl_modes" }
 predicates = "1.0.8"
 rand = "0.8.3"
 repr = { path = "../repr" }
 reqwest = { version = "0.11.3", features = ["blocking"] }
 serde_json = "1.0.64"
-tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["with-chrono-0_4"] }
+tokio-postgres = { git = "https://github.com/uce/rust-postgres", branch = "6716-ssl_modes", features = ["with-chrono-0_4"] }
 
 [build-dependencies]
 anyhow = "1.0.40"

--- a/src/peeker/Cargo.toml
+++ b/src/peeker/Cargo.toml
@@ -14,7 +14,7 @@ log = "0.4.13"
 mz-process-collector = { path = "../mz-process-collector" }
 ore = { path = "../ore" }
 parse_duration = "2.1.1"
-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
+postgres = { git = "https://github.com/uce/rust-postgres", branch = "6716-ssl_modes" }
 prometheus = { git = "https://github.com/MaterializeInc/rust-prometheus.git", default-features = false }
 regex = "1.4.6"
 serde = { version = "1.0.125", features = ["derive"] }

--- a/src/pgrepr/Cargo.toml
+++ b/src/pgrepr/Cargo.toml
@@ -12,6 +12,6 @@ chrono = { version = "0.4.0", default-features = false, features = ["std"] }
 dec = "0.3.3"
 lazy_static = "1.4.0"
 ore = { path = "../ore" }
-postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["with-chrono-0_4", "with-uuid-0_8"] }
+postgres-types = { git = "https://github.com/uce/rust-postgres", branch = "6716-ssl_modes", features = ["with-chrono-0_4", "with-uuid-0_8"] }
 repr = { path = "../repr" }
 uuid = "0.8.2"

--- a/src/pgtest/Cargo.toml
+++ b/src/pgtest/Cargo.toml
@@ -11,8 +11,8 @@ bytes = "1.0.1"
 datadriven = "0.5.0"
 fallible-iterator = "0.2.0"
 ore = { path = "../ore" }
-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
-postgres-protocol = { git = "https://github.com/MaterializeInc/rust-postgres" }
+postgres = { git = "https://github.com/uce/rust-postgres", branch = "6716-ssl_modes" }
+postgres-protocol = { git = "https://github.com/uce/rust-postgres", branch = "6716-ssl_modes" }
 serde = { version = "1.0.125", features = ["derive"] }
 serde_json = "1.0.64"
 structopt = "0.3.21"

--- a/src/pgwire/Cargo.toml
+++ b/src/pgwire/Cargo.toml
@@ -22,7 +22,7 @@ openssl = { version = "0.10.34", features = ["vendored"] }
 ordered-float = { version = "2.2.0", features = ["serde"] }
 ore = { path = "../ore" }
 pgrepr = { path = "../pgrepr" }
-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
+postgres = { git = "https://github.com/uce/rust-postgres", branch = "6716-ssl_modes" }
 prometheus = { git = "https://github.com/MaterializeInc/rust-prometheus.git", default-features = false }
 repr = { path = "../repr" }
 sql = { path = "../sql" }

--- a/src/postgres-util/Cargo.toml
+++ b/src/postgres-util/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.40"
 openssl = { version = "0.10.34", features = ["vendored"] }
-postgres-openssl = { git = "https://github.com/MaterializeInc/rust-postgres" }
+postgres-openssl = { git = "https://github.com/uce/rust-postgres", branch = "6716-ssl_modes" }
 sql-parser = { path = "../sql-parser" }
 tokio = { version = "1.6.0", features = ["fs"] }
-tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
+tokio-postgres = { git = "https://github.com/uce/rust-postgres", branch = "6716-ssl_modes" }

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -25,8 +25,8 @@ mz-avro = { path = "../avro", features = ["snappy"] }
 ore = { path = "../ore" }
 parse_duration = "2.1.1"
 pgrepr = { path = "../pgrepr" }
-postgres-protocol = { git = "https://github.com/MaterializeInc/rust-postgres" }
-postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["with-chrono-0_4", "with-uuid-0_8"] }
+postgres-protocol = { git = "https://github.com/uce/rust-postgres", branch = "6716-ssl_modes" }
+postgres-types = { git = "https://github.com/uce/rust-postgres", branch = "6716-ssl_modes", features = ["with-chrono-0_4", "with-uuid-0_8"] }
 postgres-util = { path = "../postgres-util" }
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "gssapi-vendored", "libz-static"] }
 regex = "1.4.6"
@@ -37,7 +37,7 @@ serde = { version = "1.0.125", features = ["derive"] }
 serde_json = "1.0.64"
 sql-parser = { path = "../sql-parser" }
 tokio = { version = "1.6.0", features = ["fs"] }
-tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
+tokio-postgres = { git = "https://github.com/uce/rust-postgres", branch = "6716-ssl_modes" }
 unicase = "2.6.0"
 url = "2.2.2"
 uuid = { version = "0.8.2", features = ["serde", "v4"] }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -744,10 +744,12 @@ pub fn plan_create_source(
                 .as_ref()
                 .ok_or_else(|| anyhow!("Postgres sources must provide a slot name"))?;
 
+            let config_options = postgres_util::extract_config(&mut with_options)?;
             let connector = ExternalSourceConnector::Postgres(PostgresSourceConnector {
                 conn: conn.clone(),
                 publication: publication.clone(),
                 slot_name: slot_name.clone(),
+                config_options,
             });
 
             let encoding = SourceDataEncoding::Single(DataEncoding::Postgres);

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -147,10 +147,13 @@ pub fn purify(
                         )
                     });
 
+                    let config_options = postgres_util::extract_config(&mut with_options_map)?;
+
                     // verify that we can connect upstream
                     // TODO(petrosagg): store this info along with the source for better error
                     // detection
-                    let _ = postgres_util::publication_info(&conn, &publication).await?;
+                    let _ = postgres_util::publication_info(&conn, &publication, &config_options)
+                        .await?;
                 }
                 Connector::PubNub { .. } => (),
             }
@@ -177,11 +180,14 @@ pub fn purify(
                             ExternalSourceConnector::Postgres(PostgresSourceConnector {
                                 conn,
                                 publication,
-                                ..
+                                slot_name: _,
+                                config_options,
                             }),
                         ..
                     } => {
-                        let pub_info = postgres_util::publication_info(&conn, &publication).await?;
+                        let pub_info =
+                            postgres_util::publication_info(&conn, &publication, &config_options)
+                                .await?;
 
                         // If the user didn't specify targets we'll generate views for all of them
                         let targets = targets.clone().unwrap_or_else(|| {

--- a/src/sqllogictest/Cargo.toml
+++ b/src/sqllogictest/Cargo.toml
@@ -16,7 +16,7 @@ materialized = { path = "../materialized" }
 md-5 = "0.9.0"
 ore = { path = "../ore" }
 pgrepr = { path = "../pgrepr" }
-postgres-protocol = { git = "https://github.com/MaterializeInc/rust-postgres" }
+postgres-protocol = { git = "https://github.com/uce/rust-postgres", branch = "6716-ssl_modes" }
 regex = "1.4.6"
 repr = { path = "../repr" }
 serde_json = "1.0.64"
@@ -25,6 +25,6 @@ structopt = "0.3.21"
 tempfile = "3.2.0"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 tokio = "1.6.0"
-tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["with-chrono-0_4", "with-uuid-0_8", "with-serde_json-1"] }
+tokio-postgres = { git = "https://github.com/uce/rust-postgres", branch = "6716-ssl_modes", features = ["with-chrono-0_4", "with-uuid-0_8", "with-serde_json-1"] }
 uuid = "0.8.2"
 walkdir = "2.3.2"

--- a/src/symbiosis/Cargo.toml
+++ b/src/symbiosis/Cargo.toml
@@ -17,6 +17,6 @@ repr = { path = "../repr" }
 serde_json = "1.0.64"
 sql = { path = "../sql" }
 tokio = "1.6.0"
-tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["with-chrono-0_4", "with-serde_json-1"] }
+tokio-postgres = { git = "https://github.com/uce/rust-postgres", branch = "6716-ssl_modes", features = ["with-chrono-0_4", "with-serde_json-1"] }
 uuid = "0.8.2"
 whoami = "1.1.2"

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -27,7 +27,7 @@ mz-avro = { path = "../avro", features = ["snappy"] }
 ore = { path = "../ore" }
 parse_duration = "2.1.1"
 pgrepr = { path = "../pgrepr" }
-postgres_array = { git = "https://github.com/MaterializeInc/rust-postgres-array" }
+postgres_array = { git = "https://github.com/uce/rust-postgres-array", branch = "6716-ssl_modes" }
 protobuf = { version = "2.17.0", features = ["with-serde"] }
 rand = "0.8.3"
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "libz-static"] }
@@ -48,7 +48,7 @@ structopt = "0.3.21"
 tempfile = "3.2.0"
 termcolor = "1.1.2"
 tokio = "1.6.0"
-tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["with-chrono-0_4", "with-serde_json-1"] }
+tokio-postgres = { git = "https://github.com/uce/rust-postgres", branch = "6716-ssl_modes", features = ["with-chrono-0_4", "with-serde_json-1"] }
 tokio-stream = "0.1.6"
 url = "2.2.2"
 uuid = "0.8.2"

--- a/test/correctness/Cargo.toml
+++ b/test/correctness/Cargo.toml
@@ -20,12 +20,12 @@ mz-process-collector = { path = "../../src/mz-process-collector" }
 ore = { path = "../../src/ore" }
 parse_duration = "2.1.1"
 pgrepr = { path = "../../src/pgrepr" }
-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
-postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres" }
+postgres = { git = "https://github.com/uce/rust-postgres", branch = "6716-ssl_modes" }
+postgres-types = { git = "https://github.com/uce/rust-postgres", branch = "6716-ssl_modes" }
 prometheus = { git = "https://github.com/MaterializeInc/rust-prometheus.git", default-features = false }
 regex = "1.4.6"
 serde = { version = "1.0.125", features = ["derive"] }
 structopt = "0.3.21"
 tokio = "1.6.0"
-tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
+tokio-postgres = { git = "https://github.com/uce/rust-postgres", branch = "6716-ssl_modes" }
 toml = "0.5.8"

--- a/test/metabase/smoketest/Cargo.toml
+++ b/test/metabase/smoketest/Cargo.toml
@@ -12,4 +12,4 @@ log = "0.4.13"
 metabase = { path = "../../../src/metabase" }
 ore = { path = "../../../src/ore" }
 tokio = "1.6.0"
-tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
+tokio-postgres = { git = "https://github.com/uce/rust-postgres", branch = "6716-ssl_modes" }

--- a/test/performance/perf-kinesis/Cargo.toml
+++ b/test/performance/perf-kinesis/Cargo.toml
@@ -22,4 +22,4 @@ rusoto_kinesis = { git = "https://github.com/rusoto/rusoto.git" }
 structopt = "0.3.21"
 test-util = { path = "../../test-util" }
 tokio = "1.6.0"
-tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
+tokio-postgres = { git = "https://github.com/uce/rust-postgres", branch = "6716-ssl_modes" }

--- a/test/performance/perf-upsert/Cargo.toml
+++ b/test/performance/perf-upsert/Cargo.toml
@@ -14,10 +14,10 @@ futures = "0.3.14"
 futures-channel = "0.3.15"
 hex = "0.4.3"
 log = "0.4.13"
-postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres" }
+postgres-types = { git = "https://github.com/uce/rust-postgres", branch = "6716-ssl_modes" }
 rand = "0.8.3"
 rand_distr = "0.4.0"
 structopt = "0.3.21"
 test-util = { path = "../../test-util" }
 tokio = "1.6.0"
-tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
+tokio-postgres = { git = "https://github.com/uce/rust-postgres", branch = "6716-ssl_modes" }

--- a/test/pg-cdc/mzcompose.yml
+++ b/test/pg-cdc/mzcompose.yml
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-version: '3.7'
+version: "3.7"
 
 mzworkflows:
   pg-cdc:
@@ -22,6 +22,10 @@ mzworkflows:
         command: ${TD_TEST:-*.td}
 
 services:
+  test-certs:
+    mzbuild: test-certs
+    volumes:
+      - secrets:/secrets
   testdrive-svc:
     mzbuild: testdrive
     entrypoint:
@@ -41,9 +45,12 @@ services:
     command: --experimental --disable-telemetry
     ports:
       - 6875
+    volumes:
+      - secrets:/share/secrets
     environment:
-    - MZ_DEV=1
-    - MZ_LOG
+      - MZ_DEV=1
+      - MZ_LOG
+    depends_on: [test-certs]
 
   postgres:
     mzbuild: postgres
@@ -58,3 +65,5 @@ services:
         -c max_replication_slots=20
         -c ssl=on
         -c hba_file=/share/conf/pg_hba.conf
+volumes:
+  secrets:

--- a/test/pg-cdc/pg-cdc-ssl.td
+++ b/test/pg-cdc/pg-cdc-ssl.td
@@ -32,6 +32,9 @@ CREATE USER hostssl LOGIN SUPERUSER;
 DROP USER IF EXISTS hostnossl;
 CREATE USER hostnossl LOGIN SUPERUSER;
 
+DROP USER IF EXISTS cert_user;
+CREATE USER cert_user LOGIN SUPERUSER;
+
 DROP TABLE IF EXISTS numbers;
 CREATE TABLE numbers (number int PRIMARY KEY, is_prime bool, name text);
 ALTER TABLE numbers REPLICA IDENTITY FULL;
@@ -163,3 +166,139 @@ db error: FATAL: no pg_hba.conf entry for host "(HOST)", user "hostnossl", datab
   FROM POSTGRES HOST 'host=postgres port=5432 user=hostnossl sslmode=require dbname=postgres'
   PUBLICATION 'mz_source';
 db error: FATAL: no pg_hba.conf entry for host "(HOST)", user "hostnossl", database "postgres", SSL on
+
+# server: cert_user, client: require => OK
+> CREATE MATERIALIZED SOURCE "mz_source"
+  FROM POSTGRES HOST 'host=postgres port=5432 user=cert_user sslmode=require dbname=postgres'
+  PUBLICATION 'mz_source'
+  WITH (
+    sslcert = '/share/secrets/cert_user.crt',
+    sslkey = '/share/secrets/cert_user.key',
+    sslrootcert = '/share/secrets/ca.crt'
+  );
+> CREATE VIEWS FROM SOURCE "mz_source" ("numbers")
+> SELECT * FROM "numbers";
+1 true one
+$ postgres-execute connection=postgres://postgres:postgres@postgres:5432
+INSERT INTO numbers VALUES (2, true, 'two');
+> SELECT * FROM "numbers";
+1 true one
+2 true two
+> DROP VIEW "numbers";
+> DROP SOURCE "mz_source";
+$ postgres-execute connection=postgres://postgres:postgres@postgres:5432
+DELETE FROM numbers WHERE number = 2;
+
+# server: cert_user, client: verify-ca => ERROR
+! CREATE MATERIALIZED SOURCE "mz_source"
+  FROM POSTGRES HOST 'host=postgres port=5432 user=cert_user sslmode=verify-ca dbname=postgres'
+  PUBLICATION 'mz_source'
+  WITH (
+    sslrootcert = '/share/secrets/ca.crt'
+  );
+db error: FATAL: connection requires a valid client certificate
+
+# server: cert_user, client: verify-ca (wrong cert) => ERROR
+! CREATE MATERIALIZED SOURCE "mz_source"
+  FROM POSTGRES HOST 'host=postgres port=5432 user=cert_user sslmode=verify-ca dbname=postgres'
+  PUBLICATION 'mz_source'
+  WITH (
+    sslcert = '/share/secrets/postgres.crt',
+    sslkey = '/share/secrets/postgres.key',
+    sslrootcert = '/share/secrets/ca.crt'
+  );
+db error: FATAL: certificate authentication failed for user "cert_user"
+
+# server: cert_user, client: verify-ca => OK
+> CREATE MATERIALIZED SOURCE "mz_source"
+  FROM POSTGRES HOST 'host=postgres port=5432 user=cert_user sslmode=verify-ca dbname=postgres'
+  PUBLICATION 'mz_source'
+  WITH (
+    sslcert = '/share/secrets/cert_user.crt',
+    sslkey = '/share/secrets/cert_user.key',
+    sslrootcert = '/share/secrets/ca.crt'
+  );
+> CREATE VIEWS FROM SOURCE "mz_source" ("numbers")
+> SELECT * FROM "numbers";
+1 true one
+$ postgres-execute connection=postgres://postgres:postgres@postgres:5432
+INSERT INTO numbers VALUES (2, true, 'two');
+> SELECT * FROM "numbers";
+1 true one
+2 true two
+> DROP VIEW "numbers";
+> DROP SOURCE "mz_source";
+$ postgres-execute connection=postgres://postgres:postgres@postgres:5432
+DELETE FROM numbers WHERE number = 2;
+
+# server: cert_user, client: verify-full => OK
+> CREATE MATERIALIZED SOURCE "mz_source"
+  FROM POSTGRES HOST 'host=postgres port=5432 user=cert_user sslmode=verify-ca dbname=postgres'
+  PUBLICATION 'mz_source'
+  WITH (
+    sslcert = '/share/secrets/cert_user.crt',
+    sslkey = '/share/secrets/cert_user.key',
+    sslrootcert = '/share/secrets/ca.crt'
+  );
+> CREATE VIEWS FROM SOURCE "mz_source" ("numbers")
+> SELECT * FROM "numbers";
+1 true one
+$ postgres-execute connection=postgres://postgres:postgres@postgres:5432
+INSERT INTO numbers VALUES (2, true, 'two');
+> SELECT * FROM "numbers";
+1 true one
+2 true two
+> DROP VIEW "numbers";
+> DROP SOURCE "mz_source";
+$ postgres-execute connection=postgres://postgres:postgres@postgres:5432
+DELETE FROM numbers WHERE number = 2;
+
+# missing sslcert
+! CREATE MATERIALIZED SOURCE "mz_source"
+  FROM POSTGRES HOST 'host=postgres port=5432 user=cert_user sslmode=verify-ca dbname=postgres'
+  PUBLICATION 'mz_source'
+  WITH (
+    sslcert = '/share/secrets/missing',
+    sslkey = '/share/secrets/cert_user.key',
+    sslrootcert = '/share/secrets/ca.crt'
+  );
+sslcert `/share/secrets/missing` does not exist
+
+# missing sslkey
+! CREATE MATERIALIZED SOURCE "mz_source"
+  FROM POSTGRES HOST 'host=postgres port=5432 user=cert_user sslmode=verify-ca dbname=postgres'
+  PUBLICATION 'mz_source'
+  WITH (
+    sslcert = '/share/secrets/cert_user.crt',
+    sslkey = '/share/secrets/missing',
+    sslrootcert = '/share/secrets/ca.crt'
+  );
+sslkey `/share/secrets/missing` does not exist
+
+# missing sslrootcert
+! CREATE MATERIALIZED SOURCE "mz_source"
+  FROM POSTGRES HOST 'host=postgres port=5432 user=cert_user sslmode=verify-ca dbname=postgres'
+  PUBLICATION 'mz_source'
+  WITH (
+    sslcert = '/share/secrets/cert_user.crt',
+    sslkey = '/share/secrets/cert_user.key',
+    sslrootcert = '/share/secrets/missing'
+  );
+sslrootcert `/share/secrets/missing` does not exist
+
+# require both sslcert and sslkey
+! CREATE MATERIALIZED SOURCE "mz_source"
+  FROM POSTGRES HOST 'host=postgres port=5432 user=cert_user sslmode=verify-ca dbname=postgres'
+  PUBLICATION 'mz_source'
+  WITH (
+    sslcert = '/share/secrets/cert_user.crt'
+  );
+must provide both sslcert and sslkey, but only provided one
+
+! CREATE MATERIALIZED SOURCE "mz_source"
+  FROM POSTGRES HOST 'host=postgres port=5432 user=cert_user sslmode=verify-ca dbname=postgres'
+  PUBLICATION 'mz_source'
+  WITH (
+    sslkey = '/share/secrets/cert_user.key'
+  );
+must provide both sslcert and sslkey, but only provided one

--- a/test/pg-cdc/pg_hba.conf
+++ b/test/pg-cdc/pg_hba.conf
@@ -15,3 +15,4 @@ host        all   no_replication   all   trust
 host        all   host             all   trust
 hostssl     all   hostssl          all   trust
 hostnossl   all   hostnossl        all   trust
+hostssl     all   cert_user        all   cert

--- a/test/pg-cdc/postgres/setup-postgres.sh
+++ b/test/pg-cdc/postgres/setup-postgres.sh
@@ -14,4 +14,5 @@ set -e
 cat >> "$PGDATA/postgresql.conf" <<-EOCONF
 ssl_cert_file = '/share/secrets/postgres.crt'
 ssl_key_file = '/share/secrets/postgres.key'
+ssl_ca_file = '/share/secrets/ca.crt'
 EOCONF

--- a/test/smith/Cargo.toml
+++ b/test/smith/Cargo.toml
@@ -11,12 +11,12 @@ env_logger = "0.8.3"
 futures = "0.3.14"
 futures-channel = "0.3.15"
 log = "0.4.13"
-postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres" }
+postgres-types = { git = "https://github.com/uce/rust-postgres", branch = "6716-ssl_modes" }
 reqwest = { version = "0.11.3", features = ["json"] }
 serde = { version = "1.0.125", features = ["derive"] }
 serde_json = "1.0.64"
 structopt = "0.3.21"
 test-util = { path = "../test-util" }
 tokio = "1.6.0"
-tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
+tokio-postgres = { git = "https://github.com/uce/rust-postgres", branch = "6716-ssl_modes" }
 url = "2.2.2"

--- a/test/test-certs/create-certs.sh
+++ b/test/test-certs/create-certs.sh
@@ -28,7 +28,7 @@ openssl req \
 	-passin pass:$SSL_SECRET \
 	-passout pass:$SSL_SECRET
 
-for i in kafka kafka1 kafka2 schema-registry materialized producer postgres
+for i in kafka kafka1 kafka2 schema-registry materialized producer postgres cert_user
 do
 	# Create key & csr
 	openssl req -nodes \

--- a/test/test-certs/openssl.cnf
+++ b/test/test-certs/openssl.cnf
@@ -39,3 +39,9 @@ authorityKeyIdentifier=keyid,issuer
 basicConstraints=CA:FALSE
 keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
 subjectAltName = DNS:schema-registry
+
+[ cert_user ]
+authorityKeyIdentifier=keyid,issuer
+basicConstraints=CA:FALSE
+keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+subjectAltName = DNS:schema-registry

--- a/test/test-util/Cargo.toml
+++ b/test/test-util/Cargo.toml
@@ -14,4 +14,4 @@ ore = { path = "../../src/ore" }
 rand = "0.8.3"
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "libz-static"] }
 tokio = "1.6.0"
-tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
+tokio-postgres = { git = "https://github.com/uce/rust-postgres", branch = "6716-ssl_modes" }


### PR DESCRIPTION
This PR depends on changes to `rust-postgres` that are currently PR'd to the [upstream project](https://github.com/sfackler/rust-postgres/pull/774). 3fcde15 pulls in the changes based on top of the [HEAD of our fork](https://github.com/MaterializeInc/rust-postgres/pull/1).

The logic to configure the `SslConnector` is part of `rust-postgres/postgres-openssl` (see linked PR). I found it hard to justify why we would want to have the additional sslmodes upstream without an easy way to make use of them upstream. If there are concerns about the changes upstream, we should be able to easily pull them into our repo.

Users can now specify TLS configuration as in:

```sql
CREATE MATERIALIZED SOURCE "mz_source"
FROM POSTGRES HOST 'host=postgres port=5432 user=cert_user sslmode=verify-ca dbname=postgres'
PUBLICATION 'mz_source'
WITH (
  sslcert = '/share/secrets/cert_user.crt',
  sslkey = '/share/secrets/cert_user.key',
  sslrootcert = '/share/secrets/ca.crt'
);
```

The key names are based on the [official Postgres keys](https://www.postgresql.org/docs/current/libpq-ssl.html).
