### PR TITLE
dataflow: add new source initialization error

### DIFF
--- a/src/dataflow-types/src/errors.rs
+++ b/src/dataflow-types/src/errors.rs
@@ -27,14 +27,41 @@ impl Display for DecodeError {
 }
 
 #[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
-pub enum SourceError {
-    FileIO(String),
+pub struct SourceError {
+    pub source_name: String,
+    pub error: SourceErrorDetails,
+}
+
+impl SourceError {
+    pub fn new(source_name: String, error: SourceErrorDetails) -> SourceError {
+        SourceError { source_name, error }
+    }
 }
 
 impl Display for SourceError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: ", self.source_name)?;
+        self.error.fmt(f)
+    }
+}
+
+#[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
+pub enum SourceErrorDetails {
+    Initialization(String),
+    FileIO(String),
+}
+
+impl Display for SourceErrorDetails {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            SourceError::FileIO(e) => write!(f, "File IO: {}", e),
+            SourceErrorDetails::Initialization(e) => {
+                write!(
+                    f,
+                    "failed during initialization, must be dropped and recreated: {}",
+                    e
+                )
+            }
+            SourceErrorDetails::FileIO(e) => write!(f, "file IO: {}", e),
         }
     }
 }

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -128,12 +128,14 @@ impl DataflowDesc {
 
     pub fn add_source_import(
         &mut self,
+        name: String,
         id: GlobalId,
         connector: SourceConnector,
         bare_desc: RelationDesc,
         orig_id: GlobalId,
     ) {
         let source_description = SourceDesc {
+            name,
             connector,
             operators: None,
             bare_desc,
@@ -554,6 +556,7 @@ pub struct RegexEncoding {
 /// of the collection.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SourceDesc {
+    pub name: String,
     pub connector: SourceConnector,
     /// Optionally, filtering and projection that may optimistically be applied
     /// to the output of the source.

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -141,6 +141,7 @@ where
 
                 let source_config = SourceConfig {
                     name: format!("{}-{}", connector.name(), uid),
+                    sql_name: src.name.clone(),
                     upstream_name: connector.upstream_name().map(ToOwned::to_owned),
                     id: uid,
                     scope,
@@ -158,7 +159,7 @@ where
 
                 let (collection, capability) =
                     if let ExternalSourceConnector::PubNub(pubnub_connector) = connector {
-                        let source = PubNubSourceReader::new(pubnub_connector);
+                        let source = PubNubSourceReader::new(src.name.clone(), pubnub_connector);
                         let ((ok_stream, err_stream), capability) =
                             source::create_source_simple(source_config, source);
 
@@ -171,7 +172,7 @@ where
 
                         (ok_stream.as_collection(), capability)
                     } else if let ExternalSourceConnector::Postgres(pg_connector) = connector {
-                        let source = PostgresSourceReader::new(pg_connector);
+                        let source = PostgresSourceReader::new(src.name.clone(), pg_connector);
 
                         let ((ok_stream, err_stream), capability) =
                             source::create_source_simple(source_config, source);

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -392,4 +392,6 @@ DROP PUBLICATION mz_source;
 INSERT INTO pk_table VALUES (99999);
 
 ! SELECT COUNT(*) = 0 FROM pk_table;
-Source error: File IO: db error: ERROR: publication "mz_source" does not exist
+# todo: we're purifying Postgres view names incorrectly, fix that and this error!
+# should be "materialize.public.pk_table"
+Source error: materialize.public.mz_source: file IO: db error: ERROR: publication "mz_source" does not exist

--- a/test/testdrive/csv-sources.td
+++ b/test/testdrive/csv-sources.td
@@ -104,7 +104,7 @@ $ file-delete path=deleting.csv
 > CREATE INDEX i ON deleting_csv(city,state,zip)
 
 ! SELECT * FROM deleting_csv
-Source error: File IO:
+Source error: materialize.public.deleting_csv: file IO: file source: unable to open file at path
 
 ! CREATE SOURCE should_fail FROM FILE '/'
 / is a directory.


### PR DESCRIPTION
This PR does some of the work for https://github.com/MaterializeInc/materialize/issues/6599.

As @philip-stoev suggested, it adds more useful error messages, including the name of the source, when a source fails. It does not implement the buffer solution that @petrosagg suggested, which will come in a separate PR.