### PR TITLE
Unify Kafka source/sink parameter naming of consistency parameter

### DIFF
--- a/demo/billing/src/mz.rs
+++ b/demo/billing/src/mz.rs
@@ -60,7 +60,7 @@ pub async fn create_kafka_sink(
 ) -> Result<String> {
     let query = format!(
             "CREATE SINK {sink} FROM billing_monthly_statement INTO KAFKA BROKER '{kafka_url}' TOPIC '{topic}' \
-             WITH (consistency = true) FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '{schema_registry}'",
+             WITH (consistency_topic = '{topic}-consistency') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '{schema_registry}'",
              sink = sink_name,
              kafka_url = kafka_url,
              topic = sink_topic_name,

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -54,6 +54,11 @@ Wrap your release notes at the 80 character mark.
 - **Breaking change.** Sort `NULL`s last, to match the default sort order in
   PostgreSQL.
 
+- **Breaking change.** Rename `consistency` parameter to `consistency_topic`
+  for both Kafka sources and sinks. Additionally, change `consistency_topic` on
+  sinks to be a string that specifies a topic name instead of a boolean. This
+  harmonizes the parameter behavior between sources and sinks.
+
 {{% version-header v0.7.3 %}}
 
 - Add the [`pow`](/sql/functions/#numbers-func) function as an alias for the

--- a/doc/user/content/sql/create-sink.md
+++ b/doc/user/content/sql/create-sink.md
@@ -54,9 +54,9 @@ Field                | Value type | Description
 ---------------------|------------|------------
 `partition_count`    | `int`      | Set the sink Kafka topic's partition count. This defaults to -1 (use the broker default).
 `replication_factor` | `int`      | Set the sink Kafka topic's replication factor. This defaults to -1 (use the broker default).
-`consistency`        | `boolean`  | Makes the sink emit additional [consistency metadata](#consistency-metadata). Only valid for Kafka sinks. This defaults to false.
-`security_protocol` | `text` | Use [`ssl`](#ssl-with-options) or, for [Kerberos](#kerberos-with-options), `sasl_plaintext`, `sasl-scram-sha-256`, or `sasl-sha-512` to connect to the Kafka cluster.
-`acks` | `text`| Sets the number of Kafka replicas that must acknowledge Materialize writes. Accepts values [-1,1000]. `-1` (the default) specifies all replicas.
+`consistency_topic`  | `text`     | Makes the sink emit additional [consistency metadata](#consistency-metadata). Only valid for Kafka sinks. This defaults to empty, meaning no consistency information is emitted by default.
+`security_protocol`  | `text`     | Use [`ssl`](#ssl-with-options) or, for [Kerberos](#kerberos-with-options), `sasl_plaintext`, `sasl-scram-sha-256`, or `sasl-sha-512` to connect to the Kafka cluster.
+`acks`               | `text`     | Sets the number of Kafka replicas that must acknowledge Materialize writes. Accepts values [-1,1000]. `-1` (the default) specifies all replicas.
 
 #### SSL `WITH` options
 
@@ -193,7 +193,7 @@ Each message sent to Kafka has a `transaction` field, along with a `transaction_
 
 In addition to the inline information, Materialize creates a new "consistency topic" that stores counts of how many changes were generated per `transaction_id`. This consistency topic is named using the format below.
 ```nofmt
-{topic_prefix}-{sink_global_id}-{materialize-startup-time}-{nonce}-consistency
+{consistency_topic_prefix}-{sink_global_id}-{materialize-startup-time}-{nonce}
 ```
 
 Each message in the consistency topic has the schema below.

--- a/doc/user/content/sql/system-catalog.md
+++ b/doc/user/content/sql/system-catalog.md
@@ -168,10 +168,11 @@ Field           | Type       | Meaning
 
 The `mz_kafka_sinks` table contains a row for each Kafka sink in the system.
 
-Field     | Type     | Meaning
-----------|----------|--------
-`sink_id` | [`text`] | The ID of the sink.
-`topic`   | [`text`] | The name of the Kafka topic into which the sink is writing.
+Field                | Type     | Meaning
+---------------------|----------|--------
+`sink_id`            | [`text`] | The ID of the sink.
+`topic`              | [`text`] | The name of the Kafka topic into which the sink is writing.
+`consistency_topic`  | [`text`] | The name of the Kafka topic into which the sink is writing consistency information. This is `NULL` when the sink does not write consistency information.
 
 ### `mz_map_types`
 

--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -606,6 +606,7 @@ lazy_static! {
         desc: RelationDesc::empty()
             .with_named_column("sink_id", ScalarType::String.nullable(false))
             .with_named_column("topic", ScalarType::String.nullable(false))
+            .with_named_column("consistency_topic", ScalarType::String.nullable(true))
             .with_key(vec![0]),
         id: GlobalId::System(4005),
         index_id: GlobalId::System(4006),

--- a/src/coord/src/catalog/builtin_table_updates.rs
+++ b/src/coord/src/catalog/builtin_table_updates.rs
@@ -212,12 +212,20 @@ impl Catalog {
         } = sink
         {
             match connector {
-                SinkConnector::Kafka(KafkaSinkConnector { topic, .. }) => {
+                SinkConnector::Kafka(KafkaSinkConnector {
+                    topic, consistency, ..
+                }) => {
+                    let consistency_topic = if let Some(consistency) = consistency {
+                        Datum::String(consistency.topic.as_str())
+                    } else {
+                        Datum::Null
+                    };
                     updates.push(BuiltinTableUpdate {
                         id: MZ_KAFKA_SINKS.id,
                         row: Row::pack_slice(&[
                             Datum::String(&id.to_string()),
                             Datum::String(topic.as_str()),
+                            consistency_topic,
                         ]),
                         diff,
                     });

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -976,6 +976,7 @@ pub struct KafkaSinkConnectorBuilder {
     pub key_desc_and_indices: Option<(RelationDesc, Vec<usize>)>,
     pub value_desc: RelationDesc,
     pub topic_prefix: String,
+    pub consistency_topic_prefix: Option<String>,
     pub topic_suffix_nonce: String,
     pub partition_count: i32,
     pub replication_factor: i32,

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -563,10 +563,10 @@ pub fn plan_create_source(
         Connector::Kafka { broker, topic, .. } => {
             let config_options = kafka_util::extract_config(&mut with_options)?;
 
-            consistency = match with_options.remove("consistency") {
+            consistency = match with_options.remove("consistency_topic") {
                 None => Consistency::RealTime,
                 Some(Value::String(topic)) => Consistency::BringYourOwn(topic),
-                Some(_) => bail!("consistency must be a string"),
+                Some(_) => bail!("consistency_topic must be a string"),
             };
 
             let group_id_prefix = match with_options.remove("group_id_prefix") {
@@ -671,7 +671,7 @@ pub fn plan_create_source(
                 Some(Value::Boolean(b)) => b,
                 Some(_) => bail!("tail must be a boolean"),
             };
-            consistency = match with_options.remove("consistency") {
+            consistency = match with_options.remove("consistency_topic") {
                 None => Consistency::RealTime,
                 Some(_) => bail!("BYO consistency not supported for file sources"),
             };
@@ -773,10 +773,10 @@ pub fn plan_create_source(
                 Some(Value::Boolean(b)) => b,
                 Some(_) => bail!("tail must be a boolean"),
             };
-            consistency = match with_options.remove("consistency") {
+            consistency = match with_options.remove("consistency_topic") {
                 None => Consistency::RealTime,
                 Some(Value::String(topic)) => Consistency::BringYourOwn(topic),
-                Some(_) => bail!("consistency must be a string"),
+                Some(_) => bail!("consistency_topic must be a string"),
             };
 
             if consistency != Consistency::RealTime {

--- a/test/debezium-avro/50-large-transaction.td.bug6555
+++ b/test/debezium-avro/50-large-transaction.td.bug6555
@@ -25,13 +25,13 @@ COMMIT;
 
 > CREATE MATERIALIZED SOURCE large_distinct_rows
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'postgres.public.large_distinct_rows'
-  WITH (consistency = 'postgres.transaction')
+  WITH (consistency_topic = 'postgres.transaction')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE DEBEZIUM;
 
 > CREATE MATERIALIZED SOURCE large_same_rows
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'postgres.public.large_same_rows'
-  WITH (consistency = 'postgres.transaction')
+  WITH (consistency_topic = 'postgres.transaction')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE DEBEZIUM;
 

--- a/test/kafka-exactly-once/before-restart.td
+++ b/test/kafka-exactly-once/before-restart.td
@@ -70,7 +70,7 @@ $ kafka-create-topic topic=input
 
 > CREATE MATERIALIZED SOURCE input_byo
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-${testdrive.seed}'
-    WITH (consistency = 'testdrive-input-consistency-${testdrive.seed}')
+    WITH (consistency_topic = 'testdrive-input-consistency-${testdrive.seed}')
   FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
 
 > CREATE SINK output FROM input_byo

--- a/test/kafka-exactly-once/before-restart.td
+++ b/test/kafka-exactly-once/before-restart.td
@@ -75,7 +75,7 @@ $ kafka-create-topic topic=input
 
 > CREATE SINK output FROM input_byo
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-sink-${testdrive.seed}'
-  WITH (exactly_once=true, consistency=true)
+  WITH (exactly_once=true, consistency_topic='output-sink-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 $ kafka-ingest format=avro topic=input-consistency timestamp=1 schema=${trxschemakey}

--- a/test/testdrive/consolidation.td
+++ b/test/testdrive/consolidation.td
@@ -78,7 +78,7 @@ $ kafka-create-topic topic=tx
 
 > CREATE MATERIALIZED SOURCE nums
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-nums-${testdrive.seed}'
-  WITH (consistency = 'testdrive-tx-${testdrive.seed}')
+  WITH (consistency_topic = 'testdrive-tx-${testdrive.seed}')
   FORMAT AVRO USING SCHEMA '${nums-schema}'
   ENVELOPE DEBEZIUM
 

--- a/test/testdrive/kafka-avro-debezium-sinks.td
+++ b/test/testdrive/kafka-avro-debezium-sinks.td
@@ -87,7 +87,7 @@ $ kafka-create-topic topic=input
 
 > CREATE MATERIALIZED SOURCE input
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-${testdrive.seed}'
-    WITH (consistency = 'testdrive-consistency-${testdrive.seed}')
+    WITH (consistency_topic = 'testdrive-consistency-${testdrive.seed}')
   FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
 
 > CREATE SINK input_sink FROM input

--- a/test/testdrive/kafka-avro-debezium-sinks.td
+++ b/test/testdrive/kafka-avro-debezium-sinks.td
@@ -92,12 +92,12 @@ $ kafka-create-topic topic=input
 
 > CREATE SINK input_sink FROM input
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'input-sink' KEY (a)
-  WITH (consistency = true) FORMAT AVRO
+  WITH (consistency_topic = 'input-sink-consistency') FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 > CREATE SINK input_sink_multiple_keys FROM input
-  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'input-sink' KEY (b, a)
-  WITH (consistency = true) FORMAT AVRO
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'input-sink-multi-key' KEY (b, a)
+  WITH (consistency_topic = 'input-sink-multi-key-consistency') FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 $ kafka-ingest format=avro topic=input schema=${schema} timestamp=1

--- a/test/testdrive/kafka-avro-upsert-sinks.td
+++ b/test/testdrive/kafka-avro-upsert-sinks.td
@@ -128,14 +128,14 @@ $ kafka-create-topic topic=input
 
 > CREATE SINK input_sink FROM input_keyed
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'input-sink' KEY (a)
-  WITH (consistency = true) FORMAT AVRO
+  WITH (consistency_topic = 'input-sink-consistency') FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' ENVELOPE UPSERT
 
 # requesting to key by (a, b) is fine when (a) is a unique key
 
 > CREATE SINK input_sink_multiple_keys FROM input_keyed
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'input-sink' KEY (b, a)
-  WITH (consistency = true) FORMAT AVRO
+  WITH (consistency_topic = 'input-sink-consistency') FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' ENVELOPE UPSERT
 
 $ kafka-ingest format=avro topic=input schema=${schema} timestamp=1
@@ -263,13 +263,13 @@ $ kafka-verify format=avro sink=materialize.public.input_with_deletions_sink sor
 
 ! CREATE SINK invalid_key FROM input
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'input-sink' KEY (a)
-  WITH (consistency = true) FORMAT AVRO
+  WITH (consistency_topic = true) FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' ENVELOPE UPSERT
 Invalid upsert key: (a), there are no valid keys
 
 ! CREATE SINK another_invalid_key FROM input_keyed
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'input-sink' KEY (b)
-  WITH (consistency = true) FORMAT AVRO
+  WITH (consistency_topic = true) FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' ENVELOPE UPSERT
 Invalid upsert key: (b), valid keys are: (a)
 
@@ -277,13 +277,13 @@ Invalid upsert key: (b), valid keys are: (a)
 
 ! CREATE SINK invalid_sub_key FROM input_keyed_ab
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'input-sink' KEY (a)
-  WITH (consistency = true) FORMAT AVRO
+  WITH (consistency_topic = true) FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' ENVELOPE UPSERT
 Invalid upsert key: (a), valid keys are: (a, b)
 
 ! CREATE SINK another_invalid_sub_key FROM input_keyed_ab
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'input-sink' KEY (b)
-  WITH (consistency = true) FORMAT AVRO
+  WITH (consistency_topic = true) FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' ENVELOPE UPSERT
 Invalid upsert key: (b), valid keys are: (a, b)
 

--- a/test/testdrive/kafka-avro-upsert-sinks.td
+++ b/test/testdrive/kafka-avro-upsert-sinks.td
@@ -121,7 +121,7 @@ $ kafka-create-topic topic=input
 
 > CREATE MATERIALIZED SOURCE input
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-${testdrive.seed}'
-    WITH (consistency = 'testdrive-consistency-${testdrive.seed}')
+    WITH (consistency_topic = 'testdrive-consistency-${testdrive.seed}')
   FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
 
 > CREATE VIEW input_keyed AS SELECT a, max(b) as b FROM input GROUP BY a

--- a/test/testdrive/kafka-exactly-once-sink.td
+++ b/test/testdrive/kafka-exactly-once-sink.td
@@ -35,7 +35,7 @@ $ kafka-create-topic topic=input
 
 > CREATE MATERIALIZED SOURCE input_kafka_byo
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-${testdrive.seed}'
-    WITH (consistency = 'testdrive-input-consistency-${testdrive.seed}')
+    WITH (consistency_topic = 'testdrive-input-consistency-${testdrive.seed}')
   FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
 
 > CREATE MATERIALIZED SOURCE input_kafka_no_byo

--- a/test/testdrive/kafka-exactly-once-sink.td
+++ b/test/testdrive/kafka-exactly-once-sink.td
@@ -78,87 +78,87 @@ New York,NY,10004
 
 > CREATE SINK output1 FROM input_kafka_byo
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
-  WITH (exactly_once=true, consistency=true)
+  WITH (exactly_once=true, consistency_topic='output-view-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 ! CREATE SINK output2 FROM input_kafka_no_byo
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
-  WITH (exactly_once=true, consistency=true)
+  WITH (exactly_once=true, consistency_topic='output-view-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 all input sources of an exactly-once Kafka sink must be replayable, materialize.public.input_kafka_no_byo is not
 
 ! CREATE SINK output3 FROM input_table
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
-  WITH (exactly_once=true, consistency=true)
+  WITH (exactly_once=true, consistency_topic='output-view-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 all inputs of an exactly-once Kafka sink must be sources, materialize.public.input_table is not
 
 > CREATE SINK output4 FROM input_kafka_byo_mview
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
-  WITH (exactly_once=true, consistency=true)
+  WITH (exactly_once=true, consistency_topic='output-view-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 > CREATE SINK output4_view FROM input_kafka_byo_mview_view
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
-  WITH (exactly_once=true, consistency=true)
+  WITH (exactly_once=true, consistency_topic='output-view-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 ! CREATE SINK output5 FROM input_kafka_no_byo_mview
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
-  WITH (exactly_once=true, consistency=true)
+  WITH (exactly_once=true, consistency_topic='output-view-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 all input sources of an exactly-once Kafka sink must be replayable, materialize.public.input_kafka_no_byo is not
 
 ! CREATE SINK output5_view FROM input_kafka_no_byo_mview_view
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
-  WITH (exactly_once=true, consistency=true)
+  WITH (exactly_once=true, consistency_topic='output-view-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 all input sources of an exactly-once Kafka sink must be replayable, materialize.public.input_kafka_no_byo is not
 
 ! CREATE SINK output6 FROM input_table_mview
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
-  WITH (exactly_once=true, consistency=true)
+  WITH (exactly_once=true, consistency_topic='output-view-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 all inputs of an exactly-once Kafka sink must be sources, materialize.public.input_table is not
 
 ! CREATE SINK output7 FROM input_values_view
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
-  WITH (exactly_once=true, consistency=true)
+  WITH (exactly_once=true, consistency_topic='output-view-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 all inputs of an exactly-once Kafka sink must be sources, materialize.public.input_values_view is not
 
 ! CREATE SINK output8 FROM input_values_mview
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
-  WITH (exactly_once=true, consistency=true)
+  WITH (exactly_once=true, consistency_topic='output-view-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 all inputs of an exactly-once Kafka sink must be sources, materialize.public.input_values_mview is not
 
 ! CREATE SINK output9 FROM input_kafka_no_byo_join_view
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
-  WITH (exactly_once=true, consistency=true)
+  WITH (exactly_once=true, consistency_topic='output-view-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 all input sources of an exactly-once Kafka sink must be replayable, materialize.public.input_kafka_no_byo is not
 
 ! CREATE SINK output9 FROM input_kafka_no_byo_join_mview
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
-  WITH (exactly_once=true, consistency=true)
+  WITH (exactly_once=true, consistency_topic='output-view-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 all input sources of an exactly-once Kafka sink must be replayable, materialize.public.input_kafka_no_byo is not
 
 ! CREATE SINK output9 FROM input_kafka_no_byo_scalar_subquery
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
-  WITH (exactly_once=true, consistency=true)
+  WITH (exactly_once=true, consistency_topic='output-view-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 all input sources of an exactly-once Kafka sink must be replayable, materialize.public.input_kafka_no_byo is not
 
 ! CREATE SINK output9 FROM input_kafka_no_byo_derived_table
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
-  WITH (exactly_once=true, consistency=true)
+  WITH (exactly_once=true, consistency_topic='output-view-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 all input sources of an exactly-once Kafka sink must be replayable, materialize.public.input_kafka_no_byo is not
 
 ! CREATE SINK output9 FROM input_csv
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
-  WITH (exactly_once=true, consistency=true)
+  WITH (exactly_once=true, consistency_topic='output-view-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 all input sources of an exactly-once Kafka sink must be replayable, materialize.public.input_csv is not

--- a/test/testdrive/kafka-sink-errors.td
+++ b/test/testdrive/kafka-sink-errors.td
@@ -68,9 +68,9 @@ replication factor for sink topics must be a positive integer or -1 for broker d
 ! CREATE SINK invalid_consistency FROM v1
   INTO KAFKA BROKER '${testdrive.kafka-addr}'
   TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
-  WITH (consistency = -2)
+  WITH (consistency_topic = -2)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-consistency must be a boolean
+consistency_topic must be a string
 
 ! CREATE SINK invalid_acks FROM v1
   INTO KAFKA BROKER '${testdrive.kafka-addr}'

--- a/test/testdrive/timestamps-debezium-kafka.td
+++ b/test/testdrive/timestamps-debezium-kafka.td
@@ -79,12 +79,12 @@ $ kafka-ingest format=avro topic=bar schema=${schema} timestamp=1
 
 > CREATE MATERIALIZED SOURCE data_foo
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-foo-${testdrive.seed}'
-    WITH (consistency = 'testdrive-consistency-${testdrive.seed}')
+    WITH (consistency_topic = 'testdrive-consistency-${testdrive.seed}')
   FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
 
 > CREATE MATERIALIZED SOURCE data_bar
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-bar-${testdrive.seed}'
-    WITH (consistency = 'testdrive-consistency-${testdrive.seed}')
+    WITH (consistency_topic = 'testdrive-consistency-${testdrive.seed}')
   FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
 
 


### PR DESCRIPTION
The commit messages have the details. Some things to note:

 - I changed `mz_kafka_sinks` to include the consistency topic
 - I added release notes but I'm not sure we want them because the features have been a bit under the radar for now

This closes #6213