### PR TITLE
dataflow: buffer initial Postgres snapshot for retries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -832,6 +832,7 @@ dependencies = [
  "rusoto_sqs",
  "serde",
  "serde_json",
+ "tempfile",
  "timely",
  "tokio",
  "tokio-postgres",

--- a/src/dataflow/Cargo.toml
+++ b/src/dataflow/Cargo.toml
@@ -48,6 +48,7 @@ rusoto_s3 = { git = "https://github.com/rusoto/rusoto.git" }
 rusoto_sqs = { git = "https://github.com/rusoto/rusoto.git" }
 serde = { version = "1.0.126", features = ["derive"] }
 serde_json = "1.0.64"
+tempfile = "3.2.0"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 tokio = { version = "1.6.0", features = ["fs", "rt", "sync"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", branch = "mz-0.7.2" }

--- a/src/dataflow/src/source/postgres.rs
+++ b/src/dataflow/src/source/postgres.rs
@@ -9,6 +9,7 @@
 
 use std::convert::TryInto;
 use std::error::Error;
+use std::io::{BufReader, Read, Seek, SeekFrom};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use anyhow::{anyhow, bail};
@@ -19,12 +20,14 @@ use lazy_static::lazy_static;
 use postgres_protocol::message::backend::{
     LogicalReplicationMessage, ReplicationMessage, Tuple, TupleData,
 };
+use tokio::io::{AsyncWrite, AsyncWriteExt};
+use tokio::runtime::Handle;
 use tokio_postgres::error::{DbError, Severity, SqlState};
 use tokio_postgres::replication::LogicalReplicationStream;
 use tokio_postgres::types::PgLsn;
 use tokio_postgres::SimpleQueryMessage;
 
-use crate::source::{SimpleSource, SourceError, Timestamper};
+use crate::source::{SimpleSource, SourceError, SourceTransaction, Timestamper};
 use dataflow_types::{PostgresSourceConnector, SourceErrorDetails};
 use repr::{Datum, Row};
 
@@ -127,8 +130,13 @@ impl PostgresSourceReader {
     ///
     /// After the initial snapshot has been produced it returns the name of the created slot and
     /// the LSN at which we should start the replication stream at.
-    async fn produce_snapshot(&mut self, timestamper: &Timestamper) -> Result<(), anyhow::Error> {
-        let client = postgres_util::connect_replication(&self.connector.conn).await?;
+    async fn produce_snapshot<W: AsyncWrite + Unpin>(
+        &mut self,
+        snapshot_tx: &mut SourceTransaction<'_>,
+        buffer: &mut W,
+    ) -> Result<(), ReplicationError> {
+        let client =
+            try_recoverable!(postgres_util::connect_replication(&self.connector.conn).await);
 
         // We're initialising this source so any previously existing slot must be removed and
         // re-created. Once we have data persistence we will be able to reuse slots across restarts
@@ -140,9 +148,10 @@ impl PostgresSourceReader {
             .await;
 
         // Get all the relevant tables for this publication
-        let publication_tables =
+        let publication_tables = try_recoverable!(
             postgres_util::publication_info(&self.connector.conn, &self.connector.publication)
-                .await?;
+                .await
+        );
 
         // Start a transaction and immediatelly create a replication slot with the USE SNAPSHOT
         // directive. This makes the starting point of the slot and the snapshot of the transaction
@@ -164,16 +173,19 @@ impl PostgresSourceReader {
                 SimpleQueryMessage::Row(row) => Some(row),
                 _ => None,
             })
-            .ok_or_else(|| anyhow!("empty result after creating replication slot"))?;
+            .ok_or_else(|| {
+                ReplicationError::Recoverable(anyhow!(
+                    "empty result after creating replication slot"
+                ))
+            })?;
 
         // Store the lsn at which we will need to start the replication stream from
-        self.lsn = slot_row
+        let consistent_point = try_recoverable!(slot_row
             .get("consistent_point")
-            .ok_or_else(|| anyhow!("missing expected column: `consistent_point`"))?
+            .ok_or_else(|| anyhow!("missing expected column: `consistent_point`")));
+        self.lsn = try_fatal!(consistent_point
             .parse()
-            .or_else(|_| Err(anyhow!("invalid lsn")))?;
-
-        let snapshot_tx = timestamper.start_tx().await;
+            .or_else(|_| Err(anyhow!("invalid lsn"))));
 
         for info in publication_tables {
             // TODO(petrosagg): use a COPY statement here for more efficient network transfer
@@ -183,7 +195,6 @@ impl PostgresSourceReader {
                     info.namespace, info.name
                 ))
                 .await?;
-
             for msg in data {
                 if let SimpleQueryMessage::Row(row) = msg {
                     let mut mz_row = Row::default();
@@ -193,13 +204,32 @@ impl PostgresSourceReader {
                         let a: Datum = row.get(n).into();
                         a
                     }));
-                    snapshot_tx.insert(mz_row).await?;
+                    try_recoverable!(snapshot_tx.insert(mz_row.clone()).await);
+                    try_fatal!(buffer.write(&try_fatal!(bincode::serialize(&mz_row))).await);
                 }
             }
         }
-
         client.simple_query("COMMIT;").await?;
         Ok(())
+    }
+
+    /// Reverts a failed snapshot by deleting any processed rows from the dataflow.
+    async fn revert_snapshot<R: Read + Seek>(
+        &self,
+        snapshot_tx: &mut SourceTransaction<'_>,
+        mut reader: R,
+    ) -> Result<(), anyhow::Error> {
+        tokio::task::block_in_place(|| -> Result<(), anyhow::Error> {
+            let len = reader.seek(SeekFrom::Current(0))?;
+            reader.seek(SeekFrom::Start(0))?;
+            let mut reader = reader.take(len);
+            let handle = Handle::current();
+            while reader.limit() > 0 {
+                let row = bincode::deserialize_from(&mut reader)?;
+                handle.block_on(snapshot_tx.delete(row))?;
+            }
+            Ok(())
+        })
     }
 
     /// Converts a Tuple received in the replication stream into a Row instance. The logical
@@ -346,13 +376,55 @@ impl PostgresSourceReader {
 impl SimpleSource for PostgresSourceReader {
     /// The top-level control of the state machine and retry logic
     async fn start(mut self, timestamper: &Timestamper) -> Result<(), SourceError> {
-        // The initial snapshot has no easy way of retrying it in case of connection failures
-        self.produce_snapshot(timestamper)
-            .await
-            .map_err(|e| SourceError {
-                source_name: self.source_name.clone(),
-                error: SourceErrorDetails::Initialization(e.to_string()),
-            })?;
+        // Buffer rows from snapshot to retract and retry, if initial snapshot fails.
+        // Postgres sources cannot proceed without a successful snapshot.
+        {
+            let mut snapshot_tx = timestamper.start_tx().await;
+            loop {
+                let file =
+                    tokio::fs::File::from_std(tempfile::tempfile().map_err(|e| SourceError {
+                        source_name: self.source_name.clone(),
+                        error: SourceErrorDetails::FileIO(e.to_string()),
+                    })?);
+                let mut writer = tokio::io::BufWriter::new(file);
+                match self.produce_snapshot(&mut snapshot_tx, &mut writer).await {
+                    Ok(_) => {
+                        log::info!(
+                            "replication snapshot for source {} succeeded",
+                            &self.source_name
+                        );
+                        break;
+                    }
+                    Err(ReplicationError::Recoverable(e)) => {
+                        writer.flush().await.map_err(|e| SourceError {
+                            source_name: self.source_name.clone(),
+                            error: SourceErrorDetails::Initialization(e.to_string()),
+                        })?;
+                        log::warn!(
+                            "replication snapshot for source {} failed, retrying: {}",
+                            &self.source_name,
+                            e
+                        );
+                        let reader = BufReader::new(writer.into_inner().into_std().await);
+                        self.revert_snapshot(&mut snapshot_tx, reader)
+                            .await
+                            .map_err(|e| SourceError {
+                                source_name: self.source_name.clone(),
+                                error: SourceErrorDetails::FileIO(e.to_string()),
+                            })?;
+                    }
+                    Err(ReplicationError::Fatal(e)) => {
+                        return Err(SourceError {
+                            source_name: self.source_name,
+                            error: SourceErrorDetails::Initialization(e.to_string()),
+                        })
+                    }
+                }
+
+                // TODO(petrosagg): implement exponential back-off
+                tokio::time::sleep(Duration::from_secs(3)).await;
+            }
+        }
 
         loop {
             match self.produce_replication(timestamper).await {


### PR DESCRIPTION
In response to #6599, this change makes the initial snapshot for
Postgres sources a bit more robust. This change buffers snapshot
rows in a temporary file. If the snapshot fails, we retract the
stashed rows from the created dataflow, and try again. Snapshotting
can fail 3 times before it will fail the source.

To test out this change, I manually ran a (slight variation) of @philip-stoev's
test from [`philip-stoev:gh6599-test`](https://github.com/philip-stoev/materialize/commit/09864de05f544a197432ff7e9ef8cc3baed6d7fb). The
variation is that instead of checking the count of the `t1` source directly, I created
a view from the source and checked the row count of that:
```
# in 01-before-restart.td
> CREATE VIEWS FROM SOURCE "t1" ("t1" as "t1_view")

....
# in 02-after-restart.td
> SELECT COUNT(*) = 2000000 FROM t1_view;
true
```

This PR updates the Postgres source in a way so that this test now succeeds.
I didn't include the test in this PR because I wasn't sure that we'd want to add
another test repo for this, but I'm happy to do that! @philip-stoev you're probably
the best person to advise here.