### PR TITLE
Add nightly Redpanda job to CI

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -35,3 +35,10 @@
     - ./ci/plugins/mzcompose:
         composition: kafka-multi-broker
         run: kafka-multi-broker
+
+  - id: testdrive-redpanda
+    label: ":racing_car: testdrive :panda_face:"
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: testdrive
+          run: testdrive-redpanda

--- a/misc/python/materialize/mzcompose.py
+++ b/misc/python/materialize/mzcompose.py
@@ -1250,7 +1250,7 @@ class RunStep(WorkflowStep):
         self,
         *,
         service: str,
-        command: Optional[str] = None,
+        command: Optional[Union[str, list]] = None,
         daemon: bool = False,
         entrypoint: Optional[str] = None,
         service_ports: bool = True,
@@ -1261,8 +1261,10 @@ class RunStep(WorkflowStep):
         if entrypoint:
             cmd.append(f"--entrypoint={entrypoint}")
         cmd.append(service)
-        if command is not None:
+        if isinstance(command, str):
             cmd.extend(shlex.split(command))
+        elif isinstance(command, list):
+            cmd.extend(command)
         self._service_ports = service_ports
         self._command = cmd
 

--- a/test/testdrive/mzcompose.yml
+++ b/test/testdrive/mzcompose.yml
@@ -24,6 +24,36 @@ mzworkflows:
         service: testdrive-svc
         command: --aws-endpoint=http://localstack:4566 ${TD_TEST:-*.td esoteric/*.td}
 
+  # Runs the tests that interact with Kafka against Redpanda.
+  #
+  # Specify the `TD_TEST` environment variable to select a specific test to run.
+  # Otherwise, this workflow runs against the test files in this directory that
+  # use a Kafka action but do *not* use `kafka-add-partition`, as Redpanda does
+  # not yet support dynamically adding partitions to a topic.
+  testdrive-redpanda:
+    steps:
+      - step: start-services
+        services: [redpanda, schema-registry, materialized]
+      - step: wait-for-tcp
+        host: redpanda
+        port: 9092
+        timeout_secs: 120
+      - step: wait-for-tcp
+        host: schema-registry
+        port: 8081
+      - step: wait-for-mz
+      - step: run
+        service: testdrive-svc
+        entrypoint: /bin/bash
+        command:
+        - -c
+        - >-
+          testdrive
+          --kafka-addr=redpanda:9092
+          --schema-registry-url=http://schema-registry:8081
+          --materialized-url=postgres://materialize@materialized:6875
+          ${TD_TEST:-$(grep -lF '$ kafka' $(grep -LF '$ kafka-add-partitions' *.td))}
+
   # Run tests, requires AWS credentials to be present. See guide-testing for
   # details.
   ci:
@@ -134,6 +164,20 @@ services:
     - SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=PLAINTEXT://kafka:9092
     - SCHEMA_REGISTRY_HOST_NAME=localhost
     depends_on: [kafka, zookeeper]
+  redpanda:
+    image: vectorized/redpanda:v21.5.3
+    # Most of these options are simply required when using Redpanda in Docker.
+    # See: https://vectorized.io/docs/quick-start-docker/#Single-command-for-a-1-node-cluster
+    # The `enable_transactions` and `enable_idempotence` feature flags enable
+    # features Materialize requires that are present by default in Apache Kafka
+    # but not in Redpanda.
+    command: >-
+      redpanda start
+      --overprovisioned --smp=1 --memory=1G --reserve-memory=0M
+      --node-id=0 --check=false
+      --set "redpanda.enable_transactions=true"
+      --set "redpanda.enable_idempotence=true"
+      --advertise-kafka-addr redpanda:9092
   localstack:
     image: localstack/localstack:0.12.5
     environment:


### PR DESCRIPTION
Add a nightly CI job that will run all Kafka-related tests aginst
Redpanda, except for those that involve dynamically adding partitions to
Kafka topics, as that is not yet supported by Redpanda.

Why a nightly job, and not a per-PR job? Running these tests on every PR
will slow down CI and potentially block PRs that hit bugs in Redpanda.
That's a tradeoff worth making when we're ready to publicly commit to
Redpanda support, but I don't think we're quite ready yet. We're now
well positioned to make that commitment in the future, though.

Note that @cirego, @senior7515, and the rest of the Redpanda team did
the heavy lifting to make Materialize and Redpanda work together. See
the many comments on #6078 for the details on that work.

Closes #6078.
Closes #6800.