### PR TITLE
antithesis: reduce the default timeout to 60 seconds

### DIFF
--- a/test/antithesis/driver/docker-compose.yml
+++ b/test/antithesis/driver/docker-compose.yml
@@ -66,7 +66,7 @@ services:
         --schema-registry-url=http://cp-combined:8081
         --materialized-url=postgres://materialize@materialized:6875
         --validate-catalog=/share/mzdata/catalog
-        --default-timeout 300
+        --default-timeout 60
         --shuffle-tests
         --seed ${ANTITHESIS_RANDOM_SEED:-1}
         !(*s3|kinesis*).td ;


### PR DESCRIPTION
300 was a very conservative value that causes the test to stall for
that long every time there is a failure.