### PR TITLE
postgres: use cert config in make_tls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3035,7 +3035,7 @@ dependencies = [
 [[package]]
 name = "postgres"
 version = "0.19.1"
-source = "git+https://github.com/MaterializeInc/rust-postgres#fea178cfc3114d0c20622cb4372d78b22282aa72"
+source = "git+https://github.com/MaterializeInc/rust-postgres#0f57dede5f8633f079a658ddbafe059b27b719ba"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -3048,7 +3048,7 @@ dependencies = [
 [[package]]
 name = "postgres-openssl"
 version = "0.5.0"
-source = "git+https://github.com/MaterializeInc/rust-postgres#fea178cfc3114d0c20622cb4372d78b22282aa72"
+source = "git+https://github.com/MaterializeInc/rust-postgres#0f57dede5f8633f079a658ddbafe059b27b719ba"
 dependencies = [
  "futures",
  "openssl",
@@ -3060,7 +3060,7 @@ dependencies = [
 [[package]]
 name = "postgres-protocol"
 version = "0.6.1"
-source = "git+https://github.com/MaterializeInc/rust-postgres#fea178cfc3114d0c20622cb4372d78b22282aa72"
+source = "git+https://github.com/MaterializeInc/rust-postgres#0f57dede5f8633f079a658ddbafe059b27b719ba"
 dependencies = [
  "base64",
  "byteorder",
@@ -3077,7 +3077,7 @@ dependencies = [
 [[package]]
 name = "postgres-types"
 version = "0.2.1"
-source = "git+https://github.com/MaterializeInc/rust-postgres#fea178cfc3114d0c20622cb4372d78b22282aa72"
+source = "git+https://github.com/MaterializeInc/rust-postgres#0f57dede5f8633f079a658ddbafe059b27b719ba"
 dependencies = [
  "bytes",
  "chrono",
@@ -4891,7 +4891,7 @@ dependencies = [
 [[package]]
 name = "tokio-postgres"
 version = "0.7.1"
-source = "git+https://github.com/MaterializeInc/rust-postgres#fea178cfc3114d0c20622cb4372d78b22282aa72"
+source = "git+https://github.com/MaterializeInc/rust-postgres#0f57dede5f8633f079a658ddbafe059b27b719ba"
 dependencies = [
  "async-trait",
  "byteorder",

--- a/test/pg-cdc/mzcompose.yml
+++ b/test/pg-cdc/mzcompose.yml
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-version: '3.7'
+version: "3.7"
 
 mzworkflows:
   pg-cdc:
@@ -22,6 +22,10 @@ mzworkflows:
         command: ${TD_TEST:-*.td}
 
 services:
+  test-certs:
+    mzbuild: test-certs
+    volumes:
+      - secrets:/secrets
   testdrive-svc:
     mzbuild: testdrive
     entrypoint:
@@ -41,9 +45,12 @@ services:
     command: --experimental --disable-telemetry
     ports:
       - 6875
+    volumes:
+      - secrets:/share/secrets
     environment:
-    - MZ_DEV=1
-    - MZ_LOG
+      - MZ_DEV=1
+      - MZ_LOG
+    depends_on: [test-certs]
 
   postgres:
     mzbuild: postgres
@@ -58,3 +65,5 @@ services:
         -c max_replication_slots=20
         -c ssl=on
         -c hba_file=/share/conf/pg_hba.conf
+volumes:
+  secrets:

--- a/test/pg-cdc/pg-cdc-ssl.td
+++ b/test/pg-cdc/pg-cdc-ssl.td
@@ -32,6 +32,9 @@ CREATE USER hostssl LOGIN SUPERUSER;
 DROP USER IF EXISTS hostnossl;
 CREATE USER hostnossl LOGIN SUPERUSER;
 
+DROP USER IF EXISTS certuser;
+CREATE USER certuser LOGIN SUPERUSER;
+
 DROP TABLE IF EXISTS numbers;
 CREATE TABLE numbers (number int PRIMARY KEY, is_prime bool, name text);
 ALTER TABLE numbers REPLICA IDENTITY FULL;
@@ -134,6 +137,52 @@ INSERT INTO numbers VALUES (2, true, 'two');
 $ postgres-execute connection=postgres://postgres:postgres@postgres:5432
 DELETE FROM numbers WHERE number = 2;
 
+# server: hostssl, client: verify-ca => ERROR
+! CREATE MATERIALIZED SOURCE "mz_source"
+  FROM POSTGRES HOST 'host=postgres port=5432 user=hostssl dbname=postgres sslmode=verify-ca'
+  PUBLICATION 'mz_source';
+self signed certificate in certificate chain
+
+# server: hostssl, client: verify-ca => OK
+> CREATE MATERIALIZED SOURCE "mz_source"
+  FROM POSTGRES HOST 'host=postgres port=5432 user=hostssl dbname=postgres sslmode=verify-ca sslrootcert=/share/secrets/ca.crt'
+  PUBLICATION 'mz_source';
+> CREATE VIEWS FROM SOURCE "mz_source" ("numbers")
+> SELECT * FROM "numbers";
+1 true one
+$ postgres-execute connection=postgres://postgres:postgres@postgres:5432
+INSERT INTO numbers VALUES (2, true, 'two');
+> SELECT * FROM "numbers";
+1 true one
+2 true two
+> DROP VIEW "numbers";
+> DROP SOURCE "mz_source";
+$ postgres-execute connection=postgres://postgres:postgres@postgres:5432
+DELETE FROM numbers WHERE number = 2;
+
+# server: hostssl, client: verify-full => ERROR
+! CREATE MATERIALIZED SOURCE "mz_source"
+  FROM POSTGRES HOST 'host=postgres port=5432 user=hostssl dbname=postgres sslmode=verify-full'
+  PUBLICATION 'mz_source';
+self signed certificate in certificate chain
+
+# server: hostssl, client: verify-full => OK
+> CREATE MATERIALIZED SOURCE "mz_source"
+  FROM POSTGRES HOST 'host=postgres port=5432 user=hostssl dbname=postgres sslmode=verify-full sslrootcert=/share/secrets/ca.crt'
+  PUBLICATION 'mz_source';
+> CREATE VIEWS FROM SOURCE "mz_source" ("numbers")
+> SELECT * FROM "numbers";
+1 true one
+$ postgres-execute connection=postgres://postgres:postgres@postgres:5432
+INSERT INTO numbers VALUES (2, true, 'two');
+> SELECT * FROM "numbers";
+1 true one
+2 true two
+> DROP VIEW "numbers";
+> DROP SOURCE "mz_source";
+$ postgres-execute connection=postgres://postgres:postgres@postgres:5432
+DELETE FROM numbers WHERE number = 2;
+
 # server: hostnossl, client: disable => OK
 > CREATE MATERIALIZED SOURCE "mz_source"
   FROM POSTGRES HOST 'host=postgres port=5432 user=hostnossl sslmode=disable dbname=postgres'
@@ -163,3 +212,107 @@ db error: FATAL: no pg_hba.conf entry for host "(HOST)", user "hostnossl", datab
   FROM POSTGRES HOST 'host=postgres port=5432 user=hostnossl sslmode=require dbname=postgres'
   PUBLICATION 'mz_source';
 db error: FATAL: no pg_hba.conf entry for host "(HOST)", user "hostnossl", database "postgres", SSL on
+
+# server: hostnossl, client: verify-ca => ERROR
+! CREATE MATERIALIZED SOURCE "mz_source"
+  FROM POSTGRES HOST 'host=postgres port=5432 user=hostnossl sslmode=verify-ca dbname=postgres'
+  PUBLICATION 'mz_source';
+self signed certificate in certificate chain
+
+# server: hostnossl, client: verify-full => ERROR
+! CREATE MATERIALIZED SOURCE "mz_source"
+  FROM POSTGRES HOST 'host=postgres port=5432 user=hostnossl sslmode=verify-full dbname=postgres'
+  PUBLICATION 'mz_source';
+self signed certificate in certificate chain
+
+# server: certuser, client: require => OK
+> CREATE MATERIALIZED SOURCE "mz_source"
+  FROM POSTGRES HOST 'host=postgres port=5432 user=certuser sslmode=require sslcert=/share/secrets/certuser.crt sslkey=/share/secrets/certuser.key sslrootcert=/share/secrets/ca.crt dbname=postgres'
+  PUBLICATION 'mz_source'
+> CREATE VIEWS FROM SOURCE "mz_source" ("numbers")
+> SELECT * FROM "numbers";
+1 true one
+$ postgres-execute connection=postgres://postgres:postgres@postgres:5432
+INSERT INTO numbers VALUES (2, true, 'two');
+> SELECT * FROM "numbers";
+1 true one
+2 true two
+> DROP VIEW "numbers";
+> DROP SOURCE "mz_source";
+$ postgres-execute connection=postgres://postgres:postgres@postgres:5432
+DELETE FROM numbers WHERE number = 2;
+
+# server: certuser, client: verify-ca => ERROR
+! CREATE MATERIALIZED SOURCE "mz_source"
+  FROM POSTGRES HOST 'host=postgres port=5432 user=certuser dbname=postgres sslmode=verify-ca sslrootcert=/share/secrets/ca.crt'
+  PUBLICATION 'mz_source'
+db error: FATAL: connection requires a valid client certificate
+
+# server: certuser, client: verify-ca (wrong cert) => ERROR
+! CREATE MATERIALIZED SOURCE "mz_source"
+  FROM POSTGRES HOST 'host=postgres port=5432 user=certuser dbname=postgres sslmode=verify-ca sslcert=/share/secrets/postgres.crt sslkey=/share/secrets/postgres.key sslrootcert=/share/secrets/ca.crt'
+  PUBLICATION 'mz_source'
+db error: FATAL: certificate authentication failed for user "certuser"
+
+# server: certuser, client: verify-ca => OK
+> CREATE MATERIALIZED SOURCE "mz_source"
+  FROM POSTGRES HOST 'host=postgres port=5432 user=certuser sslmode=verify-ca sslcert=/share/secrets/certuser.crt sslkey=/share/secrets/certuser.key sslrootcert=/share/secrets/ca.crt dbname=postgres'
+  PUBLICATION 'mz_source'
+> CREATE VIEWS FROM SOURCE "mz_source" ("numbers")
+> SELECT * FROM "numbers";
+1 true one
+$ postgres-execute connection=postgres://postgres:postgres@postgres:5432
+INSERT INTO numbers VALUES (2, true, 'two');
+> SELECT * FROM "numbers";
+1 true one
+2 true two
+> DROP VIEW "numbers";
+> DROP SOURCE "mz_source";
+$ postgres-execute connection=postgres://postgres:postgres@postgres:5432
+DELETE FROM numbers WHERE number = 2;
+
+# server: certuser, client: verify-full => OK
+> CREATE MATERIALIZED SOURCE "mz_source"
+  FROM POSTGRES HOST 'host=postgres port=5432 user=certuser sslmode=verify-ca sslcert=/share/secrets/certuser.crt sslkey=/share/secrets/certuser.key sslrootcert=/share/secrets/ca.crt dbname=postgres'
+  PUBLICATION 'mz_source'
+> CREATE VIEWS FROM SOURCE "mz_source" ("numbers")
+> SELECT * FROM "numbers";
+1 true one
+$ postgres-execute connection=postgres://postgres:postgres@postgres:5432
+INSERT INTO numbers VALUES (2, true, 'two');
+> SELECT * FROM "numbers";
+1 true one
+2 true two
+> DROP VIEW "numbers";
+> DROP SOURCE "mz_source";
+$ postgres-execute connection=postgres://postgres:postgres@postgres:5432
+DELETE FROM numbers WHERE number = 2;
+
+# missing sslcert
+! CREATE MATERIALIZED SOURCE "mz_source"
+  FROM POSTGRES HOST 'host=postgres port=5432 user=certuser sslmode=verify-ca sslcert=/share/secrets/missing sslkey=/share/secrets/certuser.key sslrootcert=/share/secrets/ca.crt dbname=postgres'
+  PUBLICATION 'mz_source'
+invalid connection string: invalid value for option `sslcert`
+
+# missing sslkey
+! CREATE MATERIALIZED SOURCE "mz_source"
+  FROM POSTGRES HOST 'host=postgres port=5432 user=certuser sslmode=verify-ca sslcert=/share/secrets/certuser.crt sslkey=/share/secrets/missing sslrootcert=/share/secrets/ca.crt dbname=postgres'
+  PUBLICATION 'mz_source'
+invalid connection string: invalid value for option `sslkey`
+
+# missing sslrootcert
+! CREATE MATERIALIZED SOURCE "mz_source"
+  FROM POSTGRES HOST 'host=postgres port=5432 user=certuser sslmode=verify-ca sslcert=/share/secrets/certuser.crt sslkey=/share/secrets/certuser.key sslrootcert=/share/secrets/missing dbname=postgres'
+  PUBLICATION 'mz_source'
+invalid connection string: invalid value for option `sslrootcert`
+
+# require both sslcert and sslkey
+! CREATE MATERIALIZED SOURCE "mz_source"
+  FROM POSTGRES HOST 'host=postgres port=5432 user=certuser sslmode=verify-ca sslcert=/share/secrets/certuser.crt dbname=postgres'
+  PUBLICATION 'mz_source'
+must provide both sslcert and sslkey, but only provided sslcert
+
+! CREATE MATERIALIZED SOURCE "mz_source"
+  FROM POSTGRES HOST 'host=postgres port=5432 user=certuser sslmode=verify-ca sslkey=/share/secrets/certuser.key dbname=postgres'
+  PUBLICATION 'mz_source'
+must provide both sslcert and sslkey, but only provided sslkey

--- a/test/pg-cdc/pg_hba.conf
+++ b/test/pg-cdc/pg_hba.conf
@@ -15,3 +15,4 @@ host        all   no_replication   all   trust
 host        all   host             all   trust
 hostssl     all   hostssl          all   trust
 hostnossl   all   hostnossl        all   trust
+hostssl     all   certuser         all   cert

--- a/test/pg-cdc/postgres/setup-postgres.sh
+++ b/test/pg-cdc/postgres/setup-postgres.sh
@@ -14,4 +14,5 @@ set -e
 cat >> "$PGDATA/postgresql.conf" <<-EOCONF
 ssl_cert_file = '/share/secrets/postgres.crt'
 ssl_key_file = '/share/secrets/postgres.key'
+ssl_ca_file = '/share/secrets/ca.crt'
 EOCONF

--- a/test/test-certs/create-certs.sh
+++ b/test/test-certs/create-certs.sh
@@ -28,7 +28,7 @@ openssl req \
 	-passin pass:$SSL_SECRET \
 	-passout pass:$SSL_SECRET
 
-for i in kafka kafka1 kafka2 schema-registry materialized producer postgres
+for i in kafka kafka1 kafka2 schema-registry materialized producer postgres certuser
 do
 	# Create key & csr
 	openssl req -nodes \

--- a/test/test-certs/openssl.cnf
+++ b/test/test-certs/openssl.cnf
@@ -39,3 +39,9 @@ authorityKeyIdentifier=keyid,issuer
 basicConstraints=CA:FALSE
 keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
 subjectAltName = DNS:schema-registry
+
+[ certuser ]
+authorityKeyIdentifier=keyid,issuer
+basicConstraints=CA:FALSE
+keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+subjectAltName = DNS:schema-registry


### PR DESCRIPTION
This is based on changes in https://github.com/MaterializeInc/rust-postgres/pull/2.

---

Returns a `MakeTlsConnector` that matches the semantics of the Postgres client for SSL connections.

In contrast to the earlier PR, we now specify the ssl config in the connection string, similar to the Postgres client:

```sql
CREATE MATERIALIZED SOURCE "mz_source"
FROM POSTGRES
HOST 'host=postgres user=mz dbname=mz sslmode=verify-full sslcert=/share/secrets/mz.crt sslkey=/share/secrets/mz.key sslrootcert=/share/secrets/ca.crt'
PUBLICATION 'mz_source'
```

Check out https://www.postgresql.org/docs/current/libpq-ssl.html for more details on the expected behavior.