### PR TITLE
deny.toml: remove Zlib as an allowed license

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -65,7 +65,6 @@ allow = [
     "ICU",
     "ISC",
     "MIT",
-    "Zlib",
 ]
 private = { ignore = true }
 


### PR DESCRIPTION
Since we no longer have any Zlib-using crates in the graph, `cargo deny`
is warning us about that, so remove it. We can add it back if it becomes
necessary in the future.