### PR TITLE
Rename `decode_stream` to `upsert`

### DIFF
--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -320,7 +320,7 @@ where
                                             errors.pass_through("decode-errors").as_collection();
                                         (stream, Some(errors))
                                     }
-                                    SourceEnvelope::Upsert => super::upsert::decode_stream(
+                                    SourceEnvelope::Upsert => super::upsert::upsert(
                                         &results,
                                         self.as_of_frontier.clone(),
                                         &mut linear_operators,

--- a/src/dataflow/src/render/upsert.rs
+++ b/src/dataflow/src/render/upsert.rs
@@ -33,7 +33,7 @@ use crate::source::SourceData;
 /// the rendering pipeline in that their input is a stream
 /// with two components instead of one, and the second component
 /// can be null or empty.
-pub fn decode_stream<G>(
+pub fn upsert<G>(
     stream: &Stream<G, DecodeResult>,
     as_of_frontier: Antichain<Timestamp>,
     operators: &mut Option<LinearOperator>,


### PR DESCRIPTION
This function doesn't do decoding anymore; it just applies the upsert transform. Rename it accordingly.