### PR TITLE
Error out upsert sources on key decoding errors

### DIFF
--- a/src/dataflow/src/render/upsert.rs
+++ b/src/dataflow/src/render/upsert.rs
@@ -243,7 +243,9 @@ where
                                 }
                                 None => {}
                                 Some(Err(err)) => {
-                                    error!("key decoding error: {}", err);
+                                    // This can never be retracted! But at least it's better to put the source in a
+                                    // permanently errored state than to keep on trucking with wrong results.
+                                    session.give((Err(err), cap.time().clone(), 1));
                                 }
                             }
                         }

--- a/test/testdrive/upsert-key-decode-error.td
+++ b/test/testdrive/upsert-key-decode-error.td
@@ -1,3 +1,12 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
 $ set keyschema-1-int-key={
     "type": "record",
     "name": "Key",

--- a/test/testdrive/upsert-key-decode-error.td
+++ b/test/testdrive/upsert-key-decode-error.td
@@ -1,0 +1,40 @@
+$ set keyschema-1-int-key={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "key", "type": "int"}
+    ]
+  }
+
+$ set keyschema-1-long-key={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "key", "type": "long"}
+    ]
+  }
+
+$ set schema={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"nokey", "type":"string"}
+        ]
+    }
+
+$ kafka-create-topic topic=int2long
+
+$ kafka-ingest format=avro topic=int2long key-format=avro key-schema=${keyschema-1-int-key} schema=${schema} publish=true
+{"key": 1234} {"nokey": "nokey1"}
+
+> CREATE MATERIALIZED SOURCE int2long
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
+  'testdrive-int2long-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE UPSERT
+
+$ kafka-ingest format=avro topic=int2long key-format=avro key-schema=${keyschema-1-long-key} schema=${schema} publish=true
+{"key": 999999999999} {"nokey": "nokey1"}
+
+! SELECT * FROM int2long
+Schemas don't match: Long, Int


### PR DESCRIPTION
Summary of a discussion between me and @frankmcsherry :

This is a strict improvement on the current state of affairs. Ideally, in the future, we would make it possible to retract these errors, by making them include the bytes corresponding to the key, and allowing the user to retract them by issuing `(<bad key>, None)` .

Fixes #6388