### PR TITLE
Implement recursive ColumnType union for records

### DIFF
--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -34,12 +34,24 @@ pub struct ColumnType {
 impl ColumnType {
     pub fn union(&self, other: &Self) -> Result<Self, anyhow::Error> {
         match (self.scalar_type.clone(), other.scalar_type.clone()) {
-            (scalar_type, other_scalar_type) if scalar_type == other_scalar_type => Ok(ColumnType {
-                scalar_type: scalar_type,
-                nullable: self.nullable || other.nullable,
-            }),
-            (ScalarType::Record { fields, custom_oid, custom_name },
-             ScalarType::Record { fields: other_fields, custom_oid: other_custom_oid, custom_name: other_custom_name }) => {
+            (scalar_type, other_scalar_type) if scalar_type == other_scalar_type => {
+                Ok(ColumnType {
+                    scalar_type: scalar_type,
+                    nullable: self.nullable || other.nullable,
+                })
+            }
+            (
+                ScalarType::Record {
+                    fields,
+                    custom_oid,
+                    custom_name,
+                },
+                ScalarType::Record {
+                    fields: other_fields,
+                    custom_oid: other_custom_oid,
+                    custom_name: other_custom_name,
+                },
+            ) => {
                 if custom_oid != other_custom_oid || custom_name != other_custom_name {
                     bail!(
                         "Can't union types: {:?} and {:?}",
@@ -60,14 +72,22 @@ impl ColumnType {
                         let union_column_type = field.1.union(&other_field.1)?;
                         union_fields.push((field.0.clone(), union_column_type));
                     };
-                };
+                }
 
                 Ok(ColumnType {
-                    scalar_type: ScalarType::Record { fields: union_fields, custom_oid, custom_name },
+                    scalar_type: ScalarType::Record {
+                        fields: union_fields,
+                        custom_oid,
+                        custom_name,
+                    },
                     nullable: self.nullable || other.nullable,
                 })
-            },
-            _ => bail!("Can't union types: {:?} and {:?}", self.scalar_type, other.scalar_type)
+            }
+            _ => bail!(
+                "Can't union types: {:?} and {:?}",
+                self.scalar_type,
+                other.scalar_type
+            ),
         }
     }
 

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -33,17 +33,42 @@ pub struct ColumnType {
 
 impl ColumnType {
     pub fn union(&self, other: &Self) -> Result<Self, anyhow::Error> {
-        if self.scalar_type != other.scalar_type {
-            bail!(
-                "Can't union types: {:?} and {:?}",
-                self.scalar_type,
-                other.scalar_type
-            );
+        match (self.scalar_type.clone(), other.scalar_type.clone()) {
+            (scalar_type, other_scalar_type) if scalar_type == other_scalar_type => Ok(ColumnType {
+                scalar_type: scalar_type,
+                nullable: self.nullable || other.nullable,
+            }),
+            (ScalarType::Record { fields, custom_oid, custom_name },
+             ScalarType::Record { fields: other_fields, custom_oid: other_custom_oid, custom_name: other_custom_name }) => {
+                if custom_oid != other_custom_oid || custom_name != other_custom_name {
+                    bail!(
+                        "Can't union types: {:?} and {:?}",
+                        self.scalar_type,
+                        other.scalar_type
+                    );
+                };
+
+                let mut union_fields: Vec<(ColumnName, ColumnType)> = vec![];
+                for (field, other_field) in fields.iter().zip(other_fields.iter()) {
+                    if field.0 != other_field.0 {
+                        bail!(
+                            "Can't union types: {:?} and {:?}",
+                            self.scalar_type,
+                            other.scalar_type
+                        );
+                    } else {
+                        let union_column_type = field.1.union(&other_field.1)?;
+                        union_fields.push((field.0.clone(), union_column_type));
+                    };
+                };
+
+                Ok(ColumnType {
+                    scalar_type: ScalarType::Record { fields: union_fields, custom_oid, custom_name },
+                    nullable: self.nullable || other.nullable,
+                })
+            },
+            _ => bail!("Can't union types: {:?} and {:?}", self.scalar_type, other.scalar_type)
         }
-        Ok(ColumnType {
-            scalar_type: self.scalar_type.clone(),
-            nullable: self.nullable || other.nullable,
-        })
     }
 
     /// Consumes this `ColumnType` and returns a new `ColumnType` with its

--- a/test/sqllogictest/recursive_type_unioning.slt
+++ b/test/sqllogictest/recursive_type_unioning.slt
@@ -1,3 +1,12 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
 statement ok
 CREATE TABLE t1 (a int not null, b int not null)
 

--- a/test/sqllogictest/recursive_type_unioning.slt
+++ b/test/sqllogictest/recursive_type_unioning.slt
@@ -1,0 +1,30 @@
+statement ok
+CREATE TABLE t1 (a int not null, b int not null)
+
+statement ok
+CREATE TABLE t2 (a int, b int)
+
+statement ok
+INSERT INTO t1 values (1, 2)
+
+statement ok
+INSERT INTO t2 values (null, null)
+
+query T multiline
+EXPLAIN SELECT row(a,b) as record from t1 union select row(a,b) as record from t2
+----
+%0 =
+| Get materialize.public.t1 (u1)
+| Map record_create(#0, #1)
+| Project (#2)
+
+%1 =
+| Get materialize.public.t2 (u3)
+| Map record_create(#0, #1)
+| Project (#2)
+
+%2 =
+| Union %0 %1
+| Distinct group=(#0)
+
+EOF


### PR DESCRIPTION
This PR solves https://github.com/MaterializeInc/materialize/issues/6750. It unions ColumnTypes which the ScalarType is a Record recursively: union each ColumnType inside record fields if they have the same ColumName.