### PR TITLE
fix wrong avro typename; "uuid" -> "UUID"; fixes #6163

### DIFF
--- a/src/avro/src/schema.rs
+++ b/src/avro/src/schema.rs
@@ -1202,7 +1202,7 @@ impl SchemaParser {
             }
         }
         if let Some(name) = complex.get("logicalType") {
-            if name == "uuid" {
+            if name == "UUID" {
                 return SchemaPiece::Uuid;
             }
         }


### PR DESCRIPTION
in avro parse_complex function uuid logical type expected as "uuid", but from producer camed as "UUID" and in this case uuid type becomes String

fixes #6163