### PR TITLE
Resolve differing schemas regardless of fingerprints

### DIFF
--- a/src/interchange/src/avro/schema.rs
+++ b/src/interchange/src/avro/schema.rs
@@ -474,16 +474,11 @@ impl SchemaCache {
                 // However, we can't just cache it directly, since resolving schemas takes significant CPU work,
                 // which  we don't want to repeat for every record. So, parse and resolve it, and cache the
                 // result (whether schema or error).
-                let rf = &self.reader_fingerprint.bytes;
                 let result = Schema::from_str(&response.raw).and_then(|schema| {
-                    if &schema.fingerprint::<Sha256>().bytes == rf {
-                        Ok(schema)
-                    } else {
-                        // the writer schema differs from the reader schema,
-                        // so we need to perform schema resolution.
-                        let resolved = resolve_schemas(&schema, reader_schema)?;
-                        Ok(resolved)
-                    }
+                    // Schema fingerprints don't actually capture whether two schemas are meaningfully
+                    // different, because they strip out logical types. Thus, resolve in all cases.
+                    let resolved = resolve_schemas(&schema, reader_schema)?;
+                    Ok(resolved)
                 });
                 v.insert(result)
             }


### PR DESCRIPTION
We have been using Avro's notion of Parsing Canonical Form to check whether schemas are "the same" before bothering to do schema resolution on them. However, this is conceptually broken - PCF strips out various things that are actually relevant to the interpretation of a schema in Materialize; for example, logical type information.

We should perhaps come up with our own notion of canonical form that is actually useful; until we do so, it's best to just ignore it. This will degrade performance in cases where people make irrelevant changes to schemas (i.e., adding a doc comment), but that's better than silently giving wrong results.

This mitigates, but does not fully resolve, #6536 . After this change, the test proposed in that issue reports an error, rather than silently giving wrong results. As a follow-up, we should loosen the restrictions on decimal schema resolution so that we can correctly interpret things in this case.