### PR TITLE
Delta join start-up performance improvement

### DIFF
--- a/src/dataflow/src/render/join/delta_join.rs
+++ b/src/dataflow/src/render/join/delta_join.rs
@@ -334,6 +334,9 @@ where
                                 }
                             }
                         } else {
+                            // If this branch is reached, it means that the optimizer, specifically the
+                            // transform `JoinImplementation`, has made a mistake and the plan may be
+                            // suboptimal, but it is still possible to render the plan.
                             let mut update_stream = self
                                 .collection(&inputs[source_relation])
                                 .expect("Failed to render update stream")

--- a/test/testdrive/render-delta-join.td
+++ b/test/testdrive/render-delta-join.td
@@ -8,32 +8,35 @@
 # by the Apache License, Version 2.0.
 
 # Remove both newlines, references to internal table identifiers, and "materialize.public" strings, all with a single regexp
-
 $ set-regex match=(\s\(u\d+\)|\n|materialize\.public\.) replacement=
 
-> create table t1(f1 int, f2 int);
-> create index i1 on t1(f1);
-> create table t2(f1 int, f2 int);
-> create index i2 on t2(f1);
-> insert into t1 values (1, 2);
-> insert into t2 select s, s from generate_series(0, 2000) as s;
+> CREATE TABLE t1(f1 INT, f2 INT);
+> CREATE INDEX i1 ON t1(f1);
+> CREATE TABLE t2(f1 INT, f2 INT);
+> CREATE INDEX i2 ON t2(f1);
+> INSERT INTO t1 VALUES (1, 2);
+> INSERT INTO t2 SELECT s, s FROM generate_series(0, 2000) AS s;
 
 > select count(*) as count from t2;
 count
 ----
 2001
 
-> create materialized view delta_join as select * from t1, t2 where t1.f1 = t2.f1;
+> CREATE MATERIALIZED VIEW delta_join AS SELECT * FROM t1, t2 WHERE t1.f1 = t2.f1;
 
-> explain view delta_join;
+> EXPLAIN VIEW delta_join;
 "%0 =| Get t1| ArrangeBy (#0)%1 =| Get t2| ArrangeBy (#0)%2 =| Join %0 %1 (= #0 #2)| | implementation = DeltaQuery| |   delta %0 %1.(#0)| |   delta %1 %0.(#0)| | demand = (#0, #1, #3)| Filter !(isnull(#0))| Project (#0, #1, #0, #3)"
 
-> select count(*) as count from delta_join;
+> SELECT count(*) AS count FROM delta_join;
 count
 ----
 1
 
-# check that no dataflow channel reports more than a single message
+# The purpose of this test is to check that only the first delta path sees updates
+# at start-up time. According to the plan above, only t1's path will see them, so
+# the delta path for t2 won't see the 2000 rows in t2. 100 is used as an arbitrary
+# threshold since the actual number of messages sent depends on the number of
+# workers.
 > SELECT
     sum(sent) as sent
   FROM
@@ -51,42 +54,19 @@ count
                    FROM mz_catalog.mz_dataflow_names
                    WHERE name LIKE '%.delta_join%')))
   GROUP BY id, source_node, target_node, source_port, target_port
-  HAVING sum(sent) > 0
+  HAVING sum(sent) > 100
   ORDER BY sent;
 sent
 ----
-1
-1
-1
-1
-1
-1
-1
-1
-1
-1
-1
-1
-1
-1
-1
-1
-1
-1
-1
-1
-1
-1
-1
-1
 
-> insert into t2 select s, s from generate_series(2001, 4000) as s;
-> select count(*) as count from t2;
+
+> INSERT INTO t2 SELECT s, s FROM generate_series(2001, 4000) AS s;
+> SELECT count(*) AS count FROM t2;
 count
 ----
 4001
 
-# the update stream in delta path 1 now projects the new 2000 t2 records
+# The update stream in delta path 1 now projects the new 2000 t2 records
 # inserted after the view was created
 > SELECT
     sum(sent) as sent
@@ -105,34 +85,10 @@ count
                    FROM mz_catalog.mz_dataflow_names
                    WHERE name LIKE '%.delta_join%')))
   GROUP BY id, source_node, target_node, source_port, target_port
-  HAVING sum(sent) > 0
+  HAVING sum(sent) > 100
   ORDER BY sent;
 sent
 ----
-1
-1
-1
-1
-1
-1
-1
-1
-1
-1
-1
-1
-1
-1
-1
-1
-1
-1
-2
-2
-2
-2
-2
-2
 2000
 2000
 2000

--- a/test/testdrive/render-delta-join.td
+++ b/test/testdrive/render-delta-join.td
@@ -1,0 +1,134 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Remove both newlines, references to internal table identifiers, and "materialize.public" strings, all with a single regexp
+
+$ set-regex match=(\s\(u\d+\)|\n|materialize\.public\.) replacement=
+
+> create table t1(f1 int, f2 int);
+> create index i1 on t1(f1);
+> create table t2(f1 int, f2 int);
+> create index i2 on t2(f1);
+> insert into t1 values (1, 2);
+> insert into t2 select s, s from generate_series(0, 2000) as s;
+
+> select count(*) as count from t2;
+count
+----
+2001
+
+> create materialized view delta_join as select * from t1, t2 where t1.f1 = t2.f1;
+
+> explain view delta_join;
+"%0 =| Get t1| ArrangeBy (#0)%1 =| Get t2| ArrangeBy (#0)%2 =| Join %0 %1 (= #0 #2)| | implementation = DeltaQuery| |   delta %0 %1.(#0)| |   delta %1 %0.(#0)| | demand = (#0, #1, #3)| Filter !(isnull(#0))| Project (#0, #1, #0, #3)"
+
+> select count(*) as count from delta_join;
+count
+----
+1
+
+# check that no dataflow channel reports more than a single message
+> SELECT
+    sum(sent) as sent
+  FROM
+    mz_catalog.mz_dataflow_channels AS channels
+    LEFT JOIN mz_catalog.mz_message_counts AS counts
+        ON channels.id = counts.channel AND channels.worker = counts.source_worker
+  WHERE id IN
+        (SELECT id
+         FROM mz_catalog.mz_dataflow_operator_addresses
+         WHERE address[1] =
+             (SELECT DISTINCT address[1]
+              FROM mz_catalog.mz_dataflow_operator_addresses
+              WHERE id =
+                  (SELECT DISTINCT id
+                   FROM mz_catalog.mz_dataflow_names
+                   WHERE name LIKE '%.delta_join%')))
+  GROUP BY id, source_node, target_node, source_port, target_port
+  HAVING sum(sent) > 0
+  ORDER BY sent;
+sent
+----
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+
+> insert into t2 select s, s from generate_series(2001, 4000) as s;
+> select count(*) as count from t2;
+count
+----
+4001
+
+> SELECT
+    sum(sent) as sent
+  FROM
+    mz_catalog.mz_dataflow_channels AS channels
+    LEFT JOIN mz_catalog.mz_message_counts AS counts
+        ON channels.id = counts.channel AND channels.worker = counts.source_worker
+  WHERE id IN
+        (SELECT id
+         FROM mz_catalog.mz_dataflow_operator_addresses
+         WHERE address[1] =
+             (SELECT DISTINCT address[1]
+              FROM mz_catalog.mz_dataflow_operator_addresses
+              WHERE id =
+                  (SELECT DISTINCT id
+                   FROM mz_catalog.mz_dataflow_names
+                   WHERE name LIKE '%.delta_join%')))
+  GROUP BY id, source_node, target_node, source_port, target_port
+  HAVING sum(sent) > 0
+  ORDER BY sent;
+sent
+----
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+2
+2
+2
+2
+2
+2000
+2000
+2000

--- a/test/testdrive/render-delta-join.td
+++ b/test/testdrive/render-delta-join.td
@@ -77,6 +77,8 @@ sent
 1
 1
 1
+1
+1
 
 > insert into t2 select s, s from generate_series(2001, 4000) as s;
 > select count(*) as count from t2;
@@ -84,6 +86,8 @@ count
 ----
 4001
 
+# the update stream in delta path 1 now projects the new 2000 t2 records
+# inserted after the view was created
 > SELECT
     sum(sent) as sent
   FROM
@@ -122,6 +126,8 @@ sent
 1
 1
 1
+1
+2
 2
 2
 2

--- a/test/testdrive/render-delta-join.td
+++ b/test/testdrive/render-delta-join.td
@@ -77,7 +77,6 @@ sent
 1
 1
 1
-1
 
 > insert into t2 select s, s from generate_series(2001, 4000) as s;
 > select count(*) as count from t2;
@@ -106,7 +105,6 @@ count
   ORDER BY sent;
 sent
 ----
-1
 1
 1
 1


### PR DESCRIPTION
Discard updates at the beginning of the update stream at start-up time on all delta paths but the first one, since they will be discarded anyway due to the tie-breaking logic. This avoids injecting loads of useless data through the dataflow at start-up, leading to significant performance improvements.

Fixes #6789.