### PR TITLE
kafka,testdrive: increase various timeouts to more reasonable values

### DIFF
--- a/src/kafka-util/src/admin.rs
+++ b/src/kafka-util/src/admin.rs
@@ -68,7 +68,7 @@ where
                 // Asking about the topic will create it automatically...
                 // with the wrong number of partitions. Yes, this is
                 // unbelievably horrible.
-                .fetch_metadata(None, Some(Duration::from_secs(1)))?;
+                .fetch_metadata(None, Some(Duration::from_secs(10)))?;
             let topic = metadata
                 .topics()
                 .iter()

--- a/src/testdrive/src/action/kafka/add_partitions.rs
+++ b/src/testdrive/src/action/kafka/add_partitions.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::cmp;
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -87,7 +88,10 @@ impl Action for AddPartitionsAction {
                 let metadata = state
                     .kafka_producer
                     .client()
-                    .fetch_metadata(Some(&topic_name), Some(Duration::from_secs(1)))
+                    .fetch_metadata(
+                        Some(&topic_name),
+                        Some(cmp::max(state.default_timeout, Duration::from_secs(1))),
+                    )
                     .map_err(|e| e.to_string())?;
                 if metadata.topics().len() != 1 {
                     return Err("metadata fetch returned no topics".to_string());


### PR DESCRIPTION
* kafka_util:create_topic used a 1-second timeout when fetching topic
metadata. This is too low, so hard-code a 10-second timeout instead.

* increase various testdrive timeouts to be at least equal to
  --default-timeout

----

The 1-second timeout was too low for the Antithesis environment. Since there is no API to pass a larger timeout value all the way to kafka_util::create_topic, I opted to hard-code 10 seconds instead.