### PR TITLE
coord: correctly instantiate since frontier and assert progress on ad…

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -973,7 +973,7 @@ impl Coordinator {
                         // an AntichainToken. Advance it. Changes to the AntichainToken's frontier
                         // will propagate to the Frontiers' since, and changes to that will propate to
                         // self.since_updates.
-                        self.since_handles.get_mut(name).unwrap().advance(
+                        self.since_handles.get_mut(name).unwrap().maybe_advance(
                             index_state.upper.frontier().iter().map(|time| {
                                 compaction_window_ms
                                     * (time.saturating_sub(compaction_window_ms)
@@ -988,7 +988,7 @@ impl Coordinator {
             if !changes.is_empty() {
                 if let Some(compaction_window_ms) = source_state.compaction_window_ms {
                     if !source_state.upper.frontier().is_empty() {
-                        self.since_handles.get_mut(name).unwrap().advance(
+                        self.since_handles.get_mut(name).unwrap().maybe_advance(
                             source_state.upper.frontier().iter().map(|time| {
                                 compaction_window_ms
                                     * (time.saturating_sub(compaction_window_ms)


### PR DESCRIPTION
…vance

This pull request comes from a comment by Frank in #6532 about properly instantiating the since frontier so that its never instantiated as empty. That way, an empty frontier can unambiguously mean "I am become death, destroyer of worlds" (there is no time I do not know of)

this pull request is still a bit of a WIP because I couldn't figure out how to actually assert for progress without adding some allocations. will think about this a bit more