### PR TITLE
persist: begin initial skeleton of persistence core subsystem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2874,6 +2874,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "persist"
+version = "0.0.0"
+dependencies = [
+ "timely",
+]
+
+[[package]]
 name = "pest"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "src/mz-process-collector",
     "src/ore",
     "src/peeker",
+    "src/persist",
     "src/pgrepr",
     "src/pgtest",
     "src/pgwire",

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "persist"
+description = "Abstraction for Materialize dataplane persistence."
+version = "0.0.0"
+edition = "2018"
+publish = false
+
+# NB: This is meant to be a strong, independant abstraction boundary, please
+# don't leak in deps on other Materialize packages.
+[dependencies]
+timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }

--- a/src/persist/README.md
+++ b/src/persist/README.md
@@ -1,0 +1,53 @@
+# Materialize Dataplane Persistence
+
+This is an in-progress implementation for a general persistence abstraction for
+Materialize.
+
+### Overview
+
+A persistence user would start by constructing a `PersistManager` which is a
+thin `Send+Sync+Clone` handle around a `Persister` impl which does the heavy
+lifting (see details below). `PersistManager` is a registry for multiple streams
+(each corresponding to a table, source, or operator) in a single process. This
+allows us to funnel everything a process is persisting through a single place
+for batching and rate limiting.
+
+Given a unique `Id`, `PersistManager` will hand back a `Token`. This
+can be handed in (consumed) to create a timely operator that persists and passes
+through its input.
+
+### V1 and V2
+
+`Persister` corresponds to [`PersisterV1` in the prototype][persister v1] and
+basically just supports synchronously writing data out, grabbing a snapshot of
+everything written so far, and unblocking compaction of everything less than a
+given timestamp. It could implemented on top of a SQLite table with something
+like the following schema:
+
+[persister v1]: https://github.com/danhhz/differential-dataflow/blob/02673114b05933341893ab603327237a9583e432/persist/src/persister.rs#L30-L39
+
+```sql
+CREATE TABLE persisted (persisted_id INT, key BYTES, val BYTES, ts BYTES, diff BYTES);
+CREATE INDEX ON persisted (persisted_id, ts, key);
+```
+
+A second phase of the project will extend `Persister` to look more like
+[`PersisterV2`][persister v2], which notably adds support for accessing the
+persisted data as an arrangement. This would be useful in source persistence
+because it could performantly answer "have we assigned this data a timestamp
+before?" (for timestamp persistence) and "what was the previous value for this
+key?" (for de-upserting). The arrangement is also a key piece of Lorenzo's
+thesis on operator persistence. (Still missing is an analog of Lorenzo's
+FutureLog, which could be added to `PersisterV2` but we haven't gotten there
+yet.)
+
+[persister v2]: https://github.com/danhhz/differential-dataflow/blob/02673114b05933341893ab603327237a9583e432/persist/src/persister.rs#L41-L44
+
+In the prototype, `PersisterV2` has one implementation, which is itself in terms
+of the `Buffer` and `Blob` traits. Internally, any data is immediately handed to
+the Buffer, which could be durable for source persistence (a WAL on EBS or maybe
+redPanda) or not durable for operator persistence. As timestamps are closed,
+data from the buffer is moved into a persistent trace built on top of `Blob`
+which is a KV abstraction over S3 and files. For operator persistence, we'll
+have to add a FutureLog holding pen which immediately slurps everything from the
+Buffer (or they're tee'd?) and indexes it in the necessary way.

--- a/src/persist/src/error.rs
+++ b/src/persist/src/error.rs
@@ -1,0 +1,47 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Persistence related errors.
+
+use std::{error, fmt, io, sync};
+
+/// A persistence related error.
+#[derive(Debug)]
+pub enum Error {
+    /// A persistence related error resulting from an io failure.
+    IO(io::Error),
+    /// An unstructured persistence related error.
+    String(String),
+}
+
+impl error::Error for Error {}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(e: io::Error) -> Self {
+        Error::IO(e)
+    }
+}
+
+impl From<String> for Error {
+    fn from(e: String) -> Self {
+        Error::String(e)
+    }
+}
+
+impl<T> From<sync::PoisonError<T>> for Error {
+    fn from(e: sync::PoisonError<T>) -> Self {
+        Error::String(format!("poison: {}", e))
+    }
+}

--- a/src/persist/src/lib.rs
+++ b/src/persist/src/lib.rs
@@ -1,0 +1,104 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Persistence for Materialize dataflows.
+
+#![warn(missing_docs)]
+
+pub mod error;
+pub mod mem;
+pub mod operators;
+pub mod persister;
+pub mod storage;
+
+use std::sync::{Arc, Mutex};
+
+use crate::error::Error;
+use crate::persister::Persister;
+
+// TODO
+// - Finish implementing StoragePersister.
+// - Should we hard-code the Key, Val, Time, Diff types everywhere or introduce
+//   them as type parameters? Materialize will only be using one combination of
+//   them (two with `()` vals?) but the generality might make things easier to
+//   read. Of course, it also might make things harder to read.
+// - Is PersistManager getting us anything over a type alias? At the moment, the
+//   only thing it does is wrap mutex poison errors in this crate's error type.
+// - It's intended that Persister will multiplex and batch multiple streams, but
+//   the APIs probably aren't quite right for this yet.
+// - Support progress messages.
+// - This method of getting the metadata handle ends up being pretty clunky in
+//   practice. Maybe instead the user should pass in a mutable reference to a
+//   `Meta` they've constructed like `probe_with`?
+// - The async story. I haven't grokked how async plays with timely yet, so
+//   dunno if/where that fits in yet.
+// - Error handling. Right now, there are a bunch of `expect`s and this likely
+//   needs to hook into the error streams that Materialize hands around.
+// - Blobs (think S3) should likely be cached in some sort of LRU. Unclear where
+//   this lives. I originally was thinking inside the S3Blob impl, but maybe we
+//   want it to be after decode? Dunno.
+// - What's our story with poisoned mutexes?
+// - Backward compatibility of persisted data, particularly the encoded keys and
+//   values.
+// - Restarting with a different number of workers.
+// - Meta TODO: These were my immediate thoughts but there's stuff I'm
+//   forgetting. Flesh this list out.
+
+/// A unique id for a persisted stream.
+#[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash)]
+pub struct Id(pub u64);
+
+/// A thread-safe, clone-able wrapper for [Persister].
+pub struct PersistManager<P> {
+    persister: Arc<Mutex<P>>,
+}
+
+// The derived Send, Sync, and Clone don't work because of the type parameter.
+unsafe impl<P> Send for PersistManager<P> {}
+unsafe impl<P> Sync for PersistManager<P> {}
+impl<P> Clone for PersistManager<P> {
+    fn clone(&self) -> Self {
+        PersistManager {
+            persister: self.persister.clone(),
+        }
+    }
+}
+
+impl<P: Persister> PersistManager<P> {
+    /// Returns a [PersistManager] wrapper for the given [Persister].
+    pub fn new(persister: P) -> Self {
+        PersistManager {
+            persister: Arc::new(Mutex::new(persister)),
+        }
+    }
+
+    /// A wrapper for [Persister::create_or_load].
+    pub fn create_or_load(&mut self, id: Id) -> Result<Token<P::Write, P::Meta>, Error> {
+        self.persister.lock()?.create_or_load(id)
+    }
+
+    /// A wrapper for [Persister::destroy].
+    pub fn destroy(&mut self, id: Id) -> Result<(), Error> {
+        self.persister.lock()?.destroy(id)
+    }
+}
+
+/// An exclusivity token needed to construct persistence [operators].
+///
+/// Intentionally not Clone since it's an exclusivity token.
+pub struct Token<W, M> {
+    write: W,
+    meta: M,
+}
+
+impl<W, M> Token<W, M> {
+    fn into_inner(self) -> (W, M) {
+        (self.write, self.meta)
+    }
+}

--- a/src/persist/src/mem.rs
+++ b/src/persist/src/mem.rs
@@ -1,0 +1,179 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! In-memory implementations for testing and benchmarking.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex};
+
+use crate::error::Error;
+use crate::persister::{Meta, Persister, Snapshot, Write};
+use crate::storage::{Blob, Buffer};
+use crate::{Id, Token};
+
+/// An in-memory implementation of [Buffer].
+pub struct MemBuffer {
+    dataz: Vec<Vec<u8>>,
+}
+
+impl MemBuffer {
+    /// Constructs a new, empty MemBuffer.
+    pub fn new() -> Self {
+        MemBuffer { dataz: Vec::new() }
+    }
+}
+
+impl Buffer for MemBuffer {
+    fn write_sync(&mut self, buf: Vec<u8>) -> Result<(), Error> {
+        self.dataz.push(buf);
+        Ok(())
+    }
+
+    fn snapshot<F>(&self, mut logic: F) -> Result<(), Error>
+    where
+        F: FnMut(&[u8]) -> Result<(), Error>,
+    {
+        self.dataz.iter().map(|x| logic(&x[..])).collect()
+    }
+}
+
+/// An in-memory implementation of [Blob].
+pub struct MemBlob {
+    dataz: HashMap<String, Vec<u8>>,
+}
+
+impl MemBlob {
+    /// Constructs a new, empty MemBlob.
+    pub fn new() -> Self {
+        MemBlob {
+            dataz: HashMap::new(),
+        }
+    }
+}
+
+impl Blob for MemBlob {
+    fn get(&self, key: &str) -> Result<Option<&Vec<u8>>, Error> {
+        Ok(self.dataz.get(key))
+    }
+
+    fn set(&mut self, key: &str, value: Vec<u8>, allow_overwrite: bool) -> Result<(), Error> {
+        if allow_overwrite {
+            self.dataz.insert(key.to_owned(), value);
+        } else if self.dataz.contains_key(key) {
+            return Err(format!("not allowed to overwrite: {}", key).into());
+        } else {
+            self.dataz.insert(key.to_owned(), value);
+        };
+        Ok(())
+    }
+}
+
+/// An in-memory implementation of [Persister].
+pub struct MemPersister {
+    registered: HashSet<Id>,
+    dataz: HashMap<Id, MemStream>,
+}
+
+impl MemPersister {
+    /// Constructs a new, empty MemPersister.
+    pub fn new() -> Self {
+        MemPersister {
+            registered: HashSet::new(),
+            dataz: HashMap::new(),
+        }
+    }
+
+    /// Consumes this MemPersister, returning the underlying data.
+    #[cfg(test)]
+    pub fn into_inner(self) -> HashMap<Id, MemStream> {
+        self.dataz
+    }
+
+    /// Constructs a MemPersister from a previous MemPersister's data but with
+    /// the create_or_load registrations reset.
+    #[cfg(test)]
+    pub fn from_inner(inner: HashMap<Id, MemStream>) -> Self {
+        MemPersister {
+            registered: HashSet::new(),
+            dataz: inner,
+        }
+    }
+}
+
+impl Persister for MemPersister {
+    type Write = MemStream;
+    type Meta = MemStream;
+
+    fn create_or_load(&mut self, id: Id) -> Result<Token<Self::Write, Self::Meta>, Error> {
+        if self.registered.contains(&id) {
+            return Err(format!("internal error: {:?} already registered", id).into());
+        }
+        self.registered.insert(id);
+        let p = self.dataz.entry(id).or_insert_with(MemStream::new);
+        let t = Token {
+            write: p.clone(),
+            meta: p.clone(),
+        };
+        Ok(t)
+    }
+
+    fn destroy(&mut self, id: Id) -> Result<(), Error> {
+        if self.dataz.remove(&id).is_none() {
+            return Err(format!("internal error: {:?} not registered", id).into());
+        }
+        Ok(())
+    }
+}
+
+/// An in-memory implementation of [Write] and [Meta].
+#[derive(Clone, Debug)]
+pub struct MemStream {
+    dataz: Arc<Mutex<Vec<((String, String), u64, isize)>>>,
+}
+
+impl MemStream {
+    fn new() -> Self {
+        MemStream {
+            dataz: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+}
+
+impl Write for MemStream {
+    fn write_sync(&mut self, updates: &[((String, String), u64, isize)]) -> Result<(), Error> {
+        self.dataz.lock()?.extend_from_slice(&updates);
+        Ok(())
+    }
+}
+
+impl Meta for MemStream {
+    type Snapshot = MemSnapshot;
+
+    fn snapshot(&self) -> Result<Self::Snapshot, Error> {
+        let dataz = self.dataz.lock()?.clone();
+        Ok(MemSnapshot { dataz })
+    }
+
+    fn allow_compaction(&mut self, _ts: u64) -> Result<(), Error> {
+        // No-op for now.
+        Ok(())
+    }
+}
+
+/// An in-memory implementation of [Snapshot].
+pub struct MemSnapshot {
+    dataz: Vec<((String, String), u64, isize)>,
+}
+
+impl Snapshot for MemSnapshot {
+    fn read<E: Extend<((String, String), u64, isize)>>(&mut self, buf: &mut E) -> bool {
+        buf.extend(self.dataz.drain(..));
+        false
+    }
+}

--- a/src/persist/src/operators/input.rs
+++ b/src/persist/src/operators/input.rs
@@ -1,0 +1,165 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! A Timely Dataflow operator that synchronously persists stream input.
+
+use timely::dataflow::channels::pushers::buffer::AutoflushSession;
+use timely::dataflow::channels::pushers::{Counter, Tee};
+use timely::dataflow::operators::unordered_input::UnorderedHandle;
+use timely::dataflow::operators::{ActivateCapability, Concat, ToStream, UnorderedInput};
+use timely::dataflow::{Scope, Stream};
+use timely::scheduling::ActivateOnDrop;
+
+use crate::persister::{Meta, Snapshot, Write};
+use crate::Token;
+
+/// A persistent equivalent of [UnorderedInput].
+pub trait PersistentUnorderedInput<G: Scope<Timestamp = u64>> {
+    /// A persistent equivalent of [UnorderedInput::new_unordered_input].
+    fn new_persistent_unordered_input<W: Write + 'static, M: Meta>(
+        &mut self,
+        token: Token<W, M>,
+    ) -> (
+        (PersistentUnorderedHandle, ActivateCapability<G::Timestamp>),
+        Stream<G, (String, u64, isize)>,
+    );
+}
+
+impl<G> PersistentUnorderedInput<G> for G
+where
+    G: Scope<Timestamp = u64>,
+{
+    fn new_persistent_unordered_input<W: Write + 'static, M: Meta>(
+        &mut self,
+        token: Token<W, M>,
+    ) -> (
+        (PersistentUnorderedHandle, ActivateCapability<G::Timestamp>),
+        Stream<G, (String, u64, isize)>,
+    ) {
+        let ((handle, cap), stream) = self.new_unordered_input();
+        let (write, meta) = token.into_inner();
+
+        // Replay the previously persisted data, if any.
+        //
+        // TODO: Do this with a timely operator that reads the snapshot.
+        let previously_persisted = {
+            let mut snap = meta.snapshot().expect("TODO");
+            let mut buf = Vec::new();
+            while snap.read(&mut buf) {}
+            buf.into_iter()
+                .map(|((key, _), ts, diff)| (key, ts, diff))
+                .to_stream(self)
+        };
+
+        let handle = PersistentUnorderedHandle {
+            write: Box::new(write),
+            handle,
+        };
+        ((handle, cap), previously_persisted.concat(&stream))
+    }
+}
+
+/// A persistent equivalent of [UnorderedHandle].
+pub struct PersistentUnorderedHandle {
+    write: Box<dyn Write>,
+    handle: UnorderedHandle<u64, (String, u64, isize)>,
+}
+
+impl PersistentUnorderedHandle {
+    /// A persistent equivalent of [UnorderedHandle::session].
+    pub fn session<'b>(
+        &'b mut self,
+        cap: ActivateCapability<u64>,
+    ) -> PersistentUnorderedSession<'b> {
+        PersistentUnorderedSession {
+            write: &mut self.write,
+            session: self.handle.session(cap),
+        }
+    }
+}
+
+/// A persistent equivalent of [UnorderedHandle::session]'s return type.
+pub struct PersistentUnorderedSession<'b> {
+    write: &'b mut Box<dyn Write>,
+    session: ActivateOnDrop<
+        AutoflushSession<
+            'b,
+            u64,
+            (String, u64, isize),
+            Counter<u64, (String, u64, isize), Tee<u64, (String, u64, isize)>>,
+        >,
+    >,
+}
+
+impl<'b> PersistentUnorderedSession<'b> {
+    /// Transmits a single record after synchronously persisting it.
+    pub fn give(&mut self, data: (String, u64, isize)) {
+        self.write
+            .write_sync(&[((data.0.clone(), String::new()), data.1, data.2)])
+            .expect("TODO");
+        self.session.give(data);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use timely::dataflow::operators::capture::Extract;
+    use timely::dataflow::operators::Capture;
+
+    use crate::error::Error;
+    use crate::mem::MemPersister;
+    use crate::persister::Persister;
+    use crate::Id;
+
+    use super::*;
+
+    #[test]
+    fn new_persistent_unordered_input() -> Result<(), Error> {
+        let mut p = MemPersister::new();
+
+        let dataz = timely::execute_directly(move |worker| {
+            let (mut handle, cap) = worker.dataflow(|scope| {
+                let persister = p.create_or_load(Id(1)).unwrap();
+                let (input, _stream) = scope.new_persistent_unordered_input(persister);
+                input
+            });
+            let mut session = handle.session(cap);
+            for i in 1..=5 {
+                session.give((i.to_string(), i, 1));
+            }
+            p.into_inner()
+        });
+
+        let mut p = MemPersister::from_inner(dataz);
+        let recv = timely::execute_directly(move |worker| {
+            let ((mut handle, cap), recv) = worker.dataflow(|scope| {
+                let persister = p.create_or_load(Id(1)).unwrap();
+                let (input, stream) = scope.new_persistent_unordered_input(persister);
+                let recv = stream.capture();
+                (input, recv)
+            });
+            let mut session = handle.session(cap);
+            for i in 6..=9 {
+                session.give((i.to_string(), i, 1));
+            }
+            recv
+        });
+
+        let mut actual = recv
+            .extract()
+            .into_iter()
+            .flat_map(|(_, xs)| xs.into_iter().map(|x| x.0))
+            .collect::<Vec<_>>();
+        actual.sort();
+        let expected = (1usize..=9usize).map(|x| x.to_string()).collect::<Vec<_>>();
+        assert_eq!(actual, expected);
+
+        Ok(())
+    }
+}

--- a/src/persist/src/operators/mod.rs
+++ b/src/persist/src/operators/mod.rs
@@ -1,0 +1,13 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Timely and Differential Dataflow operators for persisting and replaying
+//! data.
+
+pub mod input;

--- a/src/persist/src/persister.rs
+++ b/src/persist/src/persister.rs
@@ -1,0 +1,64 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! An abstraction for multiplexed streams of persisted data.
+
+use crate::error::Error;
+use crate::{Id, Token};
+
+/// An abstraction for a writer of (Key, Value, Time, Diff) updates.
+pub trait Write {
+    /// Synchronously writes (Key, Value, Time, Diff) updates.
+    fn write_sync(&mut self, updates: &[((String, String), u64, isize)]) -> Result<(), Error>;
+}
+
+/// An isolated, consistent read of previously written (Key, Value, Time, Diff)
+/// updates.
+pub trait Snapshot {
+    /// A partial read of the data in the snapshot.
+    ///
+    /// Returns true if read needs to be called again for more data.
+    fn read<E: Extend<((String, String), u64, isize)>>(&mut self, buf: &mut E) -> bool;
+}
+
+/// A handle for a persisted stream.
+pub trait Meta: Clone {
+    /// The type of snapshots returned by [Meta::snapshot].
+    type Snapshot: Snapshot;
+
+    /// Returns a consistent snapshot of all previously persisted stream data.
+    fn snapshot(&self) -> Result<Self::Snapshot, Error>;
+
+    /// Unblocks compaction for updates before a time.
+    fn allow_compaction(&mut self, ts: u64) -> Result<(), Error>;
+}
+
+/// An implementation of a persister for multiplexed streams of (Key, Value,
+/// Time, Diff) updates.
+pub trait Persister: Sized {
+    /// The persister's associated [Write] implementation.
+    type Write: Write;
+
+    /// The persister's associated [Meta] implementation.
+    type Meta: Meta;
+
+    /// Returns a token used to construct a persisted stream operator.
+    ///
+    /// If data was written by a previous Persister for this id, it's loaded and
+    /// replayed into the stream once constructed.
+    ///
+    /// Within a process, this can only be called once per id, even if that id
+    /// has since been destroyed. An `Err` is returned for calls after the
+    /// first. TODO: Is this restriction necessary/helpful?
+    fn create_or_load(&mut self, id: Id) -> Result<Token<Self::Write, Self::Meta>, Error>;
+
+    ///
+    /// TODO: Should this live on Meta?
+    fn destroy(&mut self, id: Id) -> Result<(), Error>;
+}

--- a/src/persist/src/storage/mod.rs
+++ b/src/persist/src/storage/mod.rs
@@ -1,0 +1,34 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Abstractions over files, cloud storage, etc used in persistence.
+
+use crate::error::Error;
+
+/// An abstraction over a `bytes key->bytes value` store.
+pub trait Blob {
+    /// Returns a reference to the value corresponding to the key.
+    fn get(&self, key: &str) -> Result<Option<&Vec<u8>>, Error>;
+
+    /// Inserts a key-value pair into the map.
+    fn set(&mut self, key: &str, value: Vec<u8>, allow_overwrite: bool) -> Result<(), Error>;
+}
+
+/// An abstraction over an append-only bytes log.
+pub trait Buffer {
+    /// Synchronously appends an entry.
+    fn write_sync(&mut self, buf: Vec<u8>) -> Result<(), Error>;
+
+    /// Returns a consistent snapshot of all previously written entries.
+    fn snapshot<F>(&self, logic: F) -> Result<(), Error>
+    where
+        F: FnMut(&[u8]) -> Result<(), Error>;
+}
+
+// TODO: Implement [Persister] in terms of a [Buffer] and [Blob].


### PR DESCRIPTION
Merging early to faciliate collaboration.

A persistence user would start by constructing a `PersistManager` which
is a thin `Send+Sync+Clone` handle around a `Persister` impl which does
the heavy lifting (see details below). `PersistManager` is a registry
for multiple `Persisted`s (each corresponding to a table, source, or
operator) in a single process. This allows us to funnel everything a
process is persisting through a single place for batching and rate
limiting.

Given a unique identifier, `PersistManager` will hand back a `Persisted`
token. This can be handed in (consumed) to create a timely operator that
persists and passes through its input.