### PR TITLE
testdrive: apply the set-regexp setting to kafka-verify

### DIFF
--- a/src/testdrive/src/format/avro.rs
+++ b/src/testdrive/src/format/avro.rs
@@ -21,6 +21,8 @@ use std::collections::HashMap;
 use std::convert::{TryFrom, TryInto};
 use std::num::TryFromIntError;
 
+use regex::Regex;
+
 use serde_json::Value as JsonValue;
 
 // Re-export components from the various other Avro libraries, so that other
@@ -229,6 +231,8 @@ pub fn validate_sink<I>(
     value_schema: &Schema,
     expected: I,
     actual: &[(Option<Value>, Option<Value>)],
+    regex: &Option<Regex>,
+    regex_replacement: &String,
 ) -> Result<(), String>
 where
     I: IntoIterator,
@@ -264,10 +268,18 @@ where
         let i = index.next().expect("known to exist");
         match (expected.next(), actual.next()) {
             (Some(e), Some(a)) => {
-                if e != a {
+                let e_str = format!("{:#?}", e);
+                let a_str = match &regex {
+                    Some(regex) => regex
+                        .replace_all(&format!("{:#?}", a).to_string(), regex_replacement.as_str())
+                        .to_string(),
+                    _ => format!("{:#?}", a),
+                };
+
+                if e_str != a_str {
                     return Err(format!(
-                        "record {} did not match\nexpected:\n{:#?}\n\nactual:\n{:#?}",
-                        i, e, a
+                        "record {} did not match\nexpected:\n{}\n\nactual:\n{}",
+                        i, e_str, a_str
                     ));
                 }
             }

--- a/test/testdrive/testdrive.td
+++ b/test/testdrive/testdrive.td
@@ -128,3 +128,15 @@ $ kafka-ingest format=avro topic=kafka-ingest-repeat schema=${kafka-ingest-repea
 $ kafka-verify format=avro sink=materialize.public.kafka_ingest_repeat_sink sort-messages=true
 {"before":null,"after":{"row":{"f1":"fish"}}}
 {"before":null,"after":{"row":{"f1":"fish"}}}
+
+# kafka-verify with regexp (the set-regexp from above is used
+
+> CREATE VIEW kafka_verify_regexp (a) AS VALUES ('u123'), ('u234');
+
+> CREATE SINK kafka_verify_regexp_sink FROM kafka_verify_regexp
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'kafka-verify-regexp-sink'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+
+$ kafka-verify format=avro sink=materialize.public.kafka_verify_regexp_sink sort-messages=true
+{"before": null, "after": {"row": {"a": "UID"}}}
+{"before": null, "after": {"row": {"a": "UID"}}}


### PR DESCRIPTION
Regular expressions will be appied over the data consumed by
kafka-verify. This way topics that contain variable data such
as timestamps can be tested.

In order for the regular expression to be applied, the actual
and expected json values are being compared via their serialized
string representation.