### PR TITLE
[dataflow] TopK tidy and bugfix

### DIFF
--- a/src/dataflow/src/render/top_k.rs
+++ b/src/dataflow/src/render/top_k.rs
@@ -58,7 +58,7 @@ where
                     // monotonic with an ENVELOPE of NONE, which is the default for ENVELOPE in
                     // Materialize and commonly used by users.
                     render_top1_monotonic(ok_input, group_key, order_key)
-                } else if *monotonic {
+                } else if *monotonic && *offset == 0 {
                     // For monotonic inputs, we are able to retract inputs not produced as outputs.
                     use differential_dataflow::operators::iterate::Variable;
                     let delay = std::time::Duration::from_nanos(10_000_000_000);

--- a/src/dataflow/src/render/top_k.rs
+++ b/src/dataflow/src/render/top_k.rs
@@ -59,7 +59,14 @@ where
                     // Materialize and commonly used by users.
                     render_top1_monotonic(ok_input, group_key, order_key)
                 } else if *monotonic && *offset == 0 {
-                    // For monotonic inputs, we are able to retract inputs not produced as outputs.
+                    // For monotonic inputs, we are able to retract inputs that can no longer be produced
+                    // as outputs. Any inputs beyond `offset + limit` will never again be produced as
+                    // outputs, and can be removed. The simplest form of this is when `offset == 0` and
+                    // these removeable records are those in the input not produced in the output.
+                    // TODO: consider broadening this optimization to `offset > 0` by first filtering
+                    // down to `offset = 0` and `limit = offset + limit`, followed by a finishing act
+                    // of `offset` and `limit`, discarding only the records not produced in the intermediate
+                    // stage.
                     use differential_dataflow::operators::iterate::Variable;
                     let delay = std::time::Duration::from_nanos(10_000_000_000);
                     let retractions =

--- a/src/dataflow/src/render/top_k.rs
+++ b/src/dataflow/src/render/top_k.rs
@@ -41,7 +41,7 @@ where
             let (ok_input, err_input) = self.collection(input).unwrap();
 
             // We create a new region to compartmentalize the topk logic.
-            let ok_result = ok_input.scope().clone().region_named("TopK", |inner| {
+            let ok_result = ok_input.scope().region_named("TopK", |inner| {
                 let ok_input = ok_input.enter(inner);
                 let ok_result = if *monotonic && *offset == 0 && *limit == Some(1) {
                     // If the input to a TopK is monotonic (aka append-only aka no retractions) then we


### PR DESCRIPTION
This PR adds a `region` around the dataflow fragment rendered for `TopK`, and also corrects an apparent error when a monotonic input has an `offset > 0` (we would retract records that precede the offset, mistaking them for records after `limit`). The first commit just adds a region, but is a bit noisy as some of the helper methods had opinions on the exact type of scope they would apply to.

@philip-stoev : I wonder if we should try and get more coverage on monotonic/append-only inputs? 