### PR TITLE
postgres-util: fix drop_replication_slots

### DIFF
--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -112,6 +112,11 @@ db error: FATAL: database "no_such_dbname" does not exist
   PUBLICATION 'no_such_publication';
 # TODO: This should produce an error
 
+# Invalid sources that are shipped should still be able to be dropped
+# Related issue: https://github.com/MaterializeInc/materialize/issues/6823
+> DROP SOURCE "no_such_password"
+
+> DROP SOURCE "no_such_publication"
 
 > CREATE MATERIALIZED SOURCE "mz_source"
   FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'


### PR DESCRIPTION
Fixes https://github.com/MaterializeInc/materialize/issues/6822, https://github.com/MaterializeInc/materialize/issues/6823.

Materialize currently ships some types of invalid Postgres sources.
When these invalid sources are shipped, they are stashed into the Catalog
with a slot name that doesn't actually exist upstream. Then, when we
try to drop the invalid source, drop_replication_slots throws an error.
This change bypasses that error. A better, future fix would be to prevent
invalid Postgres sources from being shipped at all.