### PR TITLE
Print a newline after threshold.

### DIFF
--- a/src/expr/src/explain.rs
+++ b/src/expr/src/explain.rs
@@ -323,8 +323,8 @@ impl<'a> ViewExplanation<'a> {
                 writeln!(f, " offset={}", offset)?
             }
             Negate { .. } => writeln!(f, "| Negate")?,
-            Threshold { .. } => write!(f, "| Threshold")?,
-            DeclareKeys { input: _, keys } => write!(
+            Threshold { .. } => writeln!(f, "| Threshold")?,
+            DeclareKeys { input: _, keys } => writeln!(
                 f,
                 "| Declare primary keys {}",
                 separated(

--- a/test/sqllogictest/transform/union.slt
+++ b/test/sqllogictest/transform/union.slt
@@ -77,6 +77,7 @@ EXPLAIN (SELECT * FROM t1 UNION ALL SELECT * FROM t1) EXCEPT ALL (SELECT * FROM 
 %4 =
 | Union %0 %1 %2 %3
 | Threshold
+
 EOF
 
 query II

--- a/test/sqllogictest/transform/union_cancel.slt
+++ b/test/sqllogictest/transform/union_cancel.slt
@@ -85,6 +85,7 @@ EXPLAIN SELECT * FROM t1 UNION ALL SELECT * FROM t1 EXCEPT ALL SELECT * FROM t1
 %0 =
 | Get materialize.public.t1 (u1)
 | Threshold
+
 EOF
 
 query II
@@ -115,6 +116,7 @@ EXPLAIN SELECT * FROM t1 UNION ALL SELECT * FROM t2 EXCEPT ALL SELECT * FROM t1
 %0 =
 | Get materialize.public.t2 (u3)
 | Threshold
+
 EOF
 
 query II
@@ -129,6 +131,7 @@ EXPLAIN SELECT * FROM t2 UNION ALL SELECT * FROM t1 EXCEPT ALL SELECT * FROM t1
 %0 =
 | Get materialize.public.t2 (u3)
 | Threshold
+
 EOF
 
 query II
@@ -150,6 +153,7 @@ EXPLAIN SELECT * FROM t2 EXCEPT ALL SELECT * FROM t1 UNION ALL SELECT * FROM t1
 %2 =
 | Union %0 %1
 | Threshold
+
 %3 =
 | Get materialize.public.t1 (u1)
 


### PR DESCRIPTION
It turns out that a newline has not been properly printed after a threshold operator, resulting in plans that look like 
```
 %4 =                             +
 | Union %2 %3                    +
 | Threshold| Negate              +
 | Negate                         +
```