### PR TITLE
pg-cdc: A test for the Postgres CDC resumption logic

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -265,6 +265,15 @@ steps:
           composition: pg-cdc
           run: pg-cdc
 
+  - id: pg-cdc-resumption
+    label: "Postgres CDC test (Resumption logic)"
+    depends_on: build
+    inputs: [test/pg-cdc-resumption]
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: pg-cdc-resumption
+          run: pg-cdc-resumption
+
   - id: persistent-tables
     label: "Test for --persistent-tables"
     depends_on: build

--- a/misc/python/materialize/mzcompose.py
+++ b/misc/python/materialize/mzcompose.py
@@ -1220,7 +1220,11 @@ class WorkflowWorkflowStep(WorkflowStep):
     def run(self, workflow: Workflow) -> None:
         try:
             # Run the specified workflow with the context of the parent workflow
-            workflow.composition.get_workflow(workflow.env, self._workflow).run()
+            child_workflow = workflow.composition.get_workflow(
+                workflow.env, self._workflow
+            )
+            print(f"Running workflow {child_workflow.name} ...")
+            child_workflow.run()
         except KeyError:
             raise errors.UnknownItem(
                 f"workflow in {workflow.composition.name}",

--- a/test/pg-cdc-resumption/README.md
+++ b/test/pg-cdc-resumption/README.md
@@ -1,0 +1,18 @@
+This test suite checks the resumption logic for Postgres sources
+by performing inserts and deletes on the Postgres side, injecting
+some form of failure and then making sure that the Materialize
+side has been able to resume replicating and fully catches up
+after the interruption has been cleared.
+
+The two different phases of Postgres replication are checked:
+- interruptions during the initial snapshot
+- interruptions during the actual replication
+
+The following failures are injected:
+- disconnecting Postgres from Materialize via toxiproxy
+- restart of the Postgres server
+- restart of the Materialize instance
+
+To run:
+
+./mzcompose down -v ; ./mzcompose run pg-cdc-resumption

--- a/test/pg-cdc-resumption/configure-materalize.td
+++ b/test/pg-cdc-resumption/configure-materalize.td
@@ -1,0 +1,15 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> CREATE MATERIALIZED SOURCE mz_source
+  FROM POSTGRES
+  HOST 'host=toxiproxy port=5432 user=postgres password=postgres dbname=postgres'
+  PUBLICATION 'mz_source'
+
+> CREATE MATERIALIZED VIEWS FROM SOURCE mz_source;

--- a/test/pg-cdc-resumption/configure-postgres.td
+++ b/test/pg-cdc-resumption/configure-postgres.td
@@ -1,0 +1,15 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+CREATE USER debezium WITH SUPERUSER PASSWORD 'debezium';
+GRANT ALL PRIVILEGES ON DATABASE "postgres" TO debezium;
+GRANT ALL PRIVILEGES ON SCHEMA "public" TO debezium;
+
+CREATE PUBLICATION mz_source FOR ALL TABLES;

--- a/test/pg-cdc-resumption/configure-toxiproxy.td
+++ b/test/pg-cdc-resumption/configure-toxiproxy.td
@@ -1,0 +1,15 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ http-request method=POST url=http://toxiproxy:8474/proxies content-type=application/json
+{
+  "name": "postgres",
+  "listen": "0.0.0.0:5432",
+  "upstream": "postgres:5432"
+}

--- a/test/pg-cdc-resumption/delete-rows-t1.td
+++ b/test/pg-cdc-resumption/delete-rows-t1.td
@@ -1,0 +1,11 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+DELETE FROM t1 WHERE f1 % 2 = 0;

--- a/test/pg-cdc-resumption/delete-rows-t2.td
+++ b/test/pg-cdc-resumption/delete-rows-t2.td
@@ -1,0 +1,11 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+DELETE FROM t2 WHERE f1 % 2 = 1;

--- a/test/pg-cdc-resumption/mzcompose
+++ b/test/pg-cdc-resumption/mzcompose
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# mzcompose — runs Docker Compose with Materialize customizations.
+
+exec "$(dirname "$0")/../../bin/mzcompose" "$@"

--- a/test/pg-cdc-resumption/mzcompose.yml
+++ b/test/pg-cdc-resumption/mzcompose.yml
@@ -1,0 +1,209 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+version: '3.7'
+
+mzworkflows:
+  pg-cdc-resumption:
+    steps:
+      - step: start-services
+        services: [materialized, postgres, toxiproxy]
+
+      - step: wait-for-mz
+
+      - step: wait-for-postgres
+        dbname: postgres
+
+      - step: wait-for-tcp
+        host: toxiproxy
+        port: 8474
+
+        # We run configure-postgres.td only once for all workflows as
+        # it contains CREATE USER that is not indempotent
+      - step: run
+        service: testdrive-svc
+        command: configure-postgres.td
+
+      - step: workflow
+        workflow: disconnect-pg-during-snapshot
+
+      - step: workflow
+        workflow: restart-pg-during-snapshot
+
+      - step: workflow
+        workflow: restart-mz-during-snapshot
+
+      - step: workflow
+        workflow: disconnect-pg-during-replication
+
+      - step: workflow
+        workflow: restart-pg-during-replication
+
+      - step: workflow
+        workflow: restart-mz-during-replication
+
+  disconnect-pg-during-snapshot:
+    steps:
+      - step: run
+        service: testdrive-svc
+        command:
+           - --no-reset
+           - configure-toxiproxy.td
+           - populate-tables.td
+           - configure-materalize.td
+           - toxiproxy-close-connection.td
+           - toxiproxy-restore-connection.td
+           - delete-rows-t1.td
+           - delete-rows-t2.td
+           - verify-data.td
+           - toxiproxy-remove.td
+
+  restart-pg-during-snapshot:
+    steps:
+      - step: run
+        service: testdrive-svc
+        command: --no-reset configure-toxiproxy.td populate-tables.td configure-materalize.td
+
+      - step: kill-services
+        services: [postgres]
+
+      - step: start-services
+        services: [postgres]
+
+      - step: wait-for-postgres
+        dbname: postgres
+
+      - step: run
+        service: testdrive-svc
+        command: --no-reset delete-rows-t1.td delete-rows-t2.td verify-data.td toxiproxy-remove.td
+
+
+  restart-mz-during-snapshot:
+    steps:
+      - step: run
+        service: testdrive-svc
+        command: --no-reset configure-toxiproxy.td populate-tables.td configure-materalize.td
+
+      - step: kill-services
+        services: [materialized]
+
+      - step: start-services
+        services: [materialized]
+
+      - step: wait-for-mz
+
+      - step: run
+        service: testdrive-svc
+        command: --no-reset delete-rows-t1.td delete-rows-t2.td verify-data.td toxiproxy-remove.td
+
+
+  disconnect-pg-during-replication:
+    steps:
+      - step: run
+        service: testdrive-svc
+        command:
+          - --no-reset
+          - configure-toxiproxy.td
+          - populate-tables.td
+          - configure-materalize.td
+          - wait-for-snapshot.td
+          - delete-rows-t1.td
+          - delete-rows-t2.td
+          - toxiproxy-close-connection.td
+          - toxiproxy-restore-connection.td
+          - verify-data.td
+          - toxiproxy-remove.td
+
+
+  restart-pg-during-replication:
+    steps:
+      - step: run
+        service: testdrive-svc
+        command:
+          - --no-reset
+          - configure-toxiproxy.td
+          - populate-tables.td
+          - configure-materalize.td
+          - wait-for-snapshot.td
+          - delete-rows-t1.td
+
+      - step: kill-services
+        services: [postgres]
+
+      - step: start-services
+        services: [postgres]
+
+      - step: wait-for-postgres
+        dbname: postgres
+
+      - step: run
+        service: testdrive-svc
+        command: --no-reset delete-rows-t2.td verify-data.td toxiproxy-remove.td
+
+
+  restart-mz-during-replication:
+    steps:
+      - step: run
+        service: testdrive-svc
+        command:
+          - --no-reset
+          - configure-toxiproxy.td
+          - populate-tables.td
+          - configure-materalize.td
+          - wait-for-snapshot.td
+          - delete-rows-t1.td
+
+      - step: kill-services
+        services: [materialized]
+
+      - step: start-services
+        services: [materialized]
+
+      - step: wait-for-mz
+
+      - step: run
+        service: testdrive-svc
+        command: --no-reset delete-rows-t2.td verify-data.td toxiproxy-remove.td
+
+
+services:
+  testdrive-svc:
+    mzbuild: testdrive
+    entrypoint:
+      - bash
+      - -c
+      - >-
+        testdrive
+        --materialized-url=postgres://materialize@materialized:6875
+        $$*
+      - bash
+    volumes:
+      - .:/workdir
+    depends_on: [materialized, postgres, toxiproxy]
+
+  materialized:
+    mzbuild: materialized
+    command: --experimental --disable-telemetry
+    ports:
+      - 6875
+    environment:
+    - MZ_DEV=1
+    - MZ_LOG
+
+  postgres:
+    image: postgres:11.4
+    ports:
+      - 5432
+    command: postgres -c wal_level=logical -c max_wal_senders=20 -c max_replication_slots=20
+
+  toxiproxy:
+    image: shopify/toxiproxy:2.1.4
+    ports:
+      - 5432
+      - 8474

--- a/test/pg-cdc-resumption/populate-tables.td
+++ b/test/pg-cdc-resumption/populate-tables.td
@@ -1,0 +1,30 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+DROP TABLE IF EXISTS ten;
+CREATE TABLE ten (f1 INTEGER);
+ALTER TABLE ten REPLICA IDENTITY FULL;
+INSERT INTO ten VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10);
+
+DROP TABLE IF EXISTS t0;
+CREATE TABLE t0 (f1 INTEGER, f2 TEXT);
+ALTER TABLE t0 REPLICA IDENTITY FULL;
+
+DROP TABLE IF EXISTS t1;
+CREATE TABLE t1 (f1 INTEGER, f2 TEXT);
+ALTER TABLE t1 REPLICA IDENTITY FULL;
+
+INSERT INTO t1 SELECT a1.f1 + a6.f1 , E'abc\nxyz' FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4, ten AS a5, ten AS a6;
+
+DROP TABLE IF EXISTS t2;
+CREATE TABLE t2 (f1 INTEGER, f2 TEXT);
+ALTER TABLE t2 REPLICA IDENTITY FULL;
+
+INSERT INTO t2 SELECT a1.f1 + a6.f1 , E'abc\nxyz' FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4, ten AS a5, ten AS a6;

--- a/test/pg-cdc-resumption/toxiproxy-close-connection.td
+++ b/test/pg-cdc-resumption/toxiproxy-close-connection.td
@@ -1,0 +1,21 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+
+# This REST call will cause toxiproxy to close the connection after processing 64K bytes
+
+$ http-request method=POST url=http://toxiproxy:8474/proxies/postgres/toxics content-type=application/json
+{
+  "name": "postgres",
+  "type": "limit_data",
+  "attributes": { "bytes": 65535 }
+}
+
+> SELECT mz_internal.mz_sleep(5);
+<null>

--- a/test/pg-cdc-resumption/toxiproxy-remove.td
+++ b/test/pg-cdc-resumption/toxiproxy-remove.td
@@ -1,0 +1,10 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ http-request method=DELETE url=http://toxiproxy:8474/proxies/postgres content-type=application/json

--- a/test/pg-cdc-resumption/toxiproxy-restore-connection.td
+++ b/test/pg-cdc-resumption/toxiproxy-restore-connection.td
@@ -1,0 +1,10 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ http-request method=DELETE url=http://toxiproxy:8474/proxies/postgres/toxics/postgres content-type=application/json

--- a/test/pg-cdc-resumption/toxiproxy-timeout.td
+++ b/test/pg-cdc-resumption/toxiproxy-timeout.td
@@ -1,0 +1,15 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ http-request method=POST url=http://toxiproxy:8474/proxies/postgres/toxics content-type=application/json
+{
+  "name": "postgres",
+  "type": "timeout",
+  "attributes": { "delay": "100" }
+}

--- a/test/pg-cdc-resumption/verify-data.td
+++ b/test/pg-cdc-resumption/verify-data.td
@@ -1,0 +1,13 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> SELECT COUNT(*) = 500000 FROM t1;
+true
+> SELECT COUNT(*) = 500000 FROM t2;
+true

--- a/test/pg-cdc-resumption/wait-for-snapshot.td
+++ b/test/pg-cdc-resumption/wait-for-snapshot.td
@@ -1,0 +1,17 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Make sure that the initial snapshot is complete and that the initial data has
+# arrived at Materialize. This ensures that any further disruptions will happen
+# during the replication and not during the initial snapshot
+#
+
+> SELECT COUNT(*) = 0 FROM t0;
+true


### PR DESCRIPTION
Test the pgc-cdc resumption logic both during snapshot and during
actual replication. Restart Postgres, Materialize and introduce
network disruption between the two and make sure that replication
resumes properly after the interruption has been cleared.

---

@petrosagg , @JLDLaughlin this is FYI -- once all the PRs currently in flight are merged to main I hope this entire suite of tests will pass and I will be able to merge it.

As usual, I am open for any and all suggestions about testing stuff in the area.