### PR TITLE
pg-cdc: mark more errors as recoverable 

### DIFF
--- a/src/dataflow/src/source/postgres.rs
+++ b/src/dataflow/src/source/postgres.rs
@@ -58,6 +58,9 @@ impl ErrorExt for tokio_postgres::Error {
                         db_err.code() == &SqlState::CONNECTION_EXCEPTION
                             || db_err.code() == &SqlState::CONNECTION_DOES_NOT_EXIST
                             || db_err.code() == &SqlState::CONNECTION_FAILURE
+                            || db_err.code() == &SqlState::CANNOT_CONNECT_NOW
+                            || db_err.code() == &SqlState::ADMIN_SHUTDOWN
+                            || db_err.code() == &SqlState::CRASH_SHUTDOWN
                             || !matches!(
                                 db_err.parsed_severity(),
                                 Some(Error) | Some(Fatal) | Some(Panic)


### PR DESCRIPTION
`CANNOT_CONNECT_NOW` can happen when the database is just starting up and is not ready yet to accept queries.

`ADMIN_SHUTDOWN` and `CRASH_SHUTDOWN` can happen when the database is in the process of shutting down and will eventually restart.

It also pulls the recoverable logic in its own extension trait that makes it reusable and also compatible with the `?` operator