### PR TITLE
SHOW COLUMNS preserves original column order

### DIFF
--- a/test/testdrive/tables.td
+++ b/test/testdrive/tables.td
@@ -351,3 +351,11 @@ INSERT has more expressions than target columns
 2
 > SELECT count(DISTINCT *) FROM nocols
 1
+
+# Test that show columns preserves the column order
+> CREATE TABLE column_order (b int, a int);
+> SHOW COLUMNS FROM column_order
+name nullable type
+-----------------------
+b    true     integer
+a    true     integer


### PR DESCRIPTION
SHOW COLUMNS now preserves the original column ordering as specified
during table creation. Previously, the output was sorted. This change
maintains compatibility with Postgres.

Signed-off-by: Moritz Hoffmann <mh@materialize.com>