### PR TITLE
Move `bracketed` and `separated` from `expr::explain` to `ore::str`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,6 +861,7 @@ dependencies = [
  "interchange",
  "kafka-util",
  "log",
+ "ore",
  "regex",
  "repr",
  "rusoto_core",

--- a/src/dataflow-types/Cargo.toml
+++ b/src/dataflow-types/Cargo.toml
@@ -14,6 +14,7 @@ globset = { version = "0.4.0", features = ["serde1"] }
 interchange = { path = "../interchange" }
 kafka-util = { path = "../kafka-util" }
 log = "0.4.13"
+ore = { path = "../ore" }
 regex = "1.4.6"
 repr = { path = "../repr" }
 rusoto_core = { git = "https://github.com/rusoto/rusoto.git" }

--- a/src/dataflow-types/src/explain.rs
+++ b/src/dataflow-types/src/explain.rs
@@ -32,8 +32,9 @@ use std::fmt;
 
 use crate::{DataflowDesc, LinearOperator};
 
-use expr::explain::*;
+use expr::explain::{Indices, ViewExplanation};
 use expr::{ExprHumanizer, GlobalId, MirRelationExpr, RowSetFinishing};
+use ore::str::{bracketed, separated};
 
 /// An `Explanation` facilitates pretty-printing of the parts of a
 /// [`DataflowDesc`] that are relevant to dataflow rendering.

--- a/src/expr/src/explain.rs
+++ b/src/expr/src/explain.rs
@@ -28,7 +28,7 @@ use std::collections::HashMap;
 use std::fmt;
 use std::iter;
 
-use ore::str::StrExt;
+use ore::str::{bracketed, separated, StrExt};
 use repr::RelationType;
 
 use crate::{ExprHumanizer, Id, JoinImplementation, LocalId, MirRelationExpr};
@@ -432,69 +432,6 @@ impl<'a> ViewExplanation<'a> {
     /// the explanation.
     fn expr_chain(&self, expr: &MirRelationExpr) -> usize {
         self.expr_chains[&(expr as *const MirRelationExpr)]
-    }
-}
-
-/// Creates a type whose [`fmt::Display`] implementation outputs each item in
-/// `iter` separated by `separator`.
-pub fn separated<'a, I>(separator: &'a str, iter: I) -> impl fmt::Display + 'a
-where
-    I: IntoIterator,
-    I::IntoIter: Clone + 'a,
-    I::Item: fmt::Display + 'a,
-{
-    struct Separated<'a, I> {
-        separator: &'a str,
-        iter: I,
-    }
-
-    impl<'a, I> fmt::Display for Separated<'a, I>
-    where
-        I: Iterator + Clone,
-        I::Item: fmt::Display,
-    {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            for (i, item) in self.iter.clone().enumerate() {
-                if i != 0 {
-                    write!(f, "{}", self.separator)?;
-                }
-                write!(f, "{}", item)?;
-            }
-            Ok(())
-        }
-    }
-
-    Separated {
-        separator,
-        iter: iter.into_iter(),
-    }
-}
-
-/// Creates a type whose [`fmt::Display`] implementation outputs item preceded
-/// by `open` and followed by `close`.
-pub fn bracketed<'a, D>(open: &'a str, close: &'a str, contents: D) -> impl fmt::Display + 'a
-where
-    D: fmt::Display + 'a,
-{
-    struct Bracketed<'a, D> {
-        open: &'a str,
-        close: &'a str,
-        contents: D,
-    }
-
-    impl<'a, D> fmt::Display for Bracketed<'a, D>
-    where
-        D: fmt::Display,
-    {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            write!(f, "{}{}{}", self.open, self.contents, self.close)
-        }
-    }
-
-    Bracketed {
-        open,
-        close,
-        contents,
     }
 }
 

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -22,7 +22,6 @@ use repr::strconv::{ParseError, ParseHexError};
 use repr::{ColumnType, Datum, RelationType, Row, RowArena, ScalarType};
 
 use self::func::{BinaryFunc, NullaryFunc, UnaryFunc, VariadicFunc};
-use crate::explain;
 use crate::scalar::func::parse_timezone;
 
 pub mod func;

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -14,6 +14,7 @@ use std::mem;
 use serde::{Deserialize, Serialize};
 
 use ore::collections::CollectionExt;
+use ore::str::separated;
 use repr::adt::array::InvalidArrayError;
 use repr::adt::datetime::DateTimeUnits;
 use repr::adt::regex::Regex;
@@ -869,7 +870,7 @@ impl fmt::Display for MirScalarExpr {
                 }
             }
             CallVariadic { func, exprs } => {
-                write!(f, "{}({})", func, explain::separated(", ", exprs.clone()))?;
+                write!(f, "{}({})", func, separated(", ", exprs.clone()))?;
             }
             If { cond, then, els } => {
                 write!(f, "if {} then {{{}}} else {{{}}}", cond, then, els)?;

--- a/src/ore/src/str.rs
+++ b/src/ore/src/str.rs
@@ -71,3 +71,66 @@ impl<'a> Deref for QuotedStr<'a> {
         &self.0
     }
 }
+
+/// Creates a type whose [`fmt::Display`] implementation outputs item preceded
+/// by `open` and followed by `close`.
+pub fn bracketed<'a, D>(open: &'a str, close: &'a str, contents: D) -> impl fmt::Display + 'a
+where
+    D: fmt::Display + 'a,
+{
+    struct Bracketed<'a, D> {
+        open: &'a str,
+        close: &'a str,
+        contents: D,
+    }
+
+    impl<'a, D> fmt::Display for Bracketed<'a, D>
+    where
+        D: fmt::Display,
+    {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "{}{}{}", self.open, self.contents, self.close)
+        }
+    }
+
+    Bracketed {
+        open,
+        close,
+        contents,
+    }
+}
+
+/// Creates a type whose [`fmt::Display`] implementation outputs each item in
+/// `iter` separated by `separator`.
+pub fn separated<'a, I>(separator: &'a str, iter: I) -> impl fmt::Display + 'a
+where
+    I: IntoIterator,
+    I::IntoIter: Clone + 'a,
+    I::Item: fmt::Display + 'a,
+{
+    struct Separated<'a, I> {
+        separator: &'a str,
+        iter: I,
+    }
+
+    impl<'a, I> fmt::Display for Separated<'a, I>
+    where
+        I: Iterator + Clone,
+        I::Item: fmt::Display,
+    {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            for (i, item) in self.iter.clone().enumerate() {
+                if i != 0 {
+                    write!(f, "{}", self.separator)?;
+                }
+                write!(f, "{}", item)?;
+            }
+            Ok(())
+        }
+    }
+
+    Separated {
+        separator,
+        iter: iter.into_iter(),
+    }
+}

--- a/src/sql/src/plan/explain.rs
+++ b/src/sql/src/plan/explain.rs
@@ -21,8 +21,9 @@
 use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 
-use expr::explain::{bracketed, separated, Indices};
+use expr::explain::Indices;
 use expr::{ExprHumanizer, Id, IdGen, RowSetFinishing};
+use ore::str::{bracketed, separated};
 use repr::{RelationType, ScalarType};
 
 use crate::plan::expr::{AggregateExpr, HirRelationExpr, HirScalarExpr};


### PR DESCRIPTION
Part of #6889 already approved by @benesch.

The functions `separated` and `bracketed` are generally useful for printing stuff, so they can go in `ore`.