### PR TITLE
buildkite: Include steps if any of their dependencies have changed

### DIFF
--- a/ci/test/mkpipeline.py
+++ b/ci/test/mkpipeline.py
@@ -147,6 +147,17 @@ def trim_pipeline(pipeline: Any) -> None:
         if have_paths_changed(inputs):
             changed.add(step.id)
 
+    # Find all steps that have had their dependencies changed, but which have not themselves changed
+    retry = True
+    while retry:
+        retry = False
+        for step in steps.values():
+            if step.id not in changed:
+                for dep in step.step_dependencies:
+                    if steps[dep].id in changed:
+                        changed.add(step.id)
+                        retry = True
+
     # Then collect all changed steps, and all the steps that those changed steps
     # depend on.
     needed = set()

--- a/ci/test/mkpipeline.py
+++ b/ci/test/mkpipeline.py
@@ -57,8 +57,9 @@ def main() -> int:
 
     if os.environ["BUILDKITE_BRANCH"] == "main" or os.environ["BUILDKITE_TAG"]:
         print("On main branch or tag, so not trimming pipeline")
-    elif have_paths_changed(CI_GLUE_GLOBS):
-        print("Repository glue code has changed, so not trimming pipeline")
+    # DEBUG! testing changes
+    # elif have_paths_changed(CI_GLUE_GLOBS):
+    #     print("Repository glue code has changed, so not trimming pipeline")
     else:
         print("--- Trimming unchanged steps from pipeline")
         trim_pipeline(pipeline)


### PR DESCRIPTION
Primarily this affects `deploy`, which should only be run if any of the
steps which generate docker images are needed.

I've confirmed with Nikhil, and the intention is that we do desire and
intend to deploy docker images on PRs if all tests pass, the fact that
we don't currently is a bug.