### PR TITLE
dataflow: fold all single partition sources under one id

### DIFF
--- a/src/dataflow-types/src/logging.rs
+++ b/src/dataflow-types/src/logging.rs
@@ -155,7 +155,7 @@ impl LogVariant {
                 .with_named_column("source_name", ScalarType::String.nullable(false))
                 .with_named_column("source_id", ScalarType::String.nullable(false))
                 .with_named_column("dataflow_id", ScalarType::Int64.nullable(false))
-                .with_named_column("partition_id", ScalarType::String.nullable(false))
+                .with_named_column("partition_id", ScalarType::String.nullable(true))
                 .with_named_column("offset", ScalarType::Int64.nullable(false))
                 .with_named_column("timestamp", ScalarType::Int64.nullable(false))
                 .with_key(vec![0, 1, 2, 3]),

--- a/src/dataflow/src/logging/materialized.rs
+++ b/src/dataflow/src/logging/materialized.rs
@@ -111,7 +111,7 @@ pub enum MaterializedEvent {
         /// Source identifier
         source_id: SourceInstanceId,
         /// Partition identifier
-        partition_id: String,
+        partition_id: Option<String>,
         /// Difference between the previous offset and current highest offset we've seen
         offset: i64,
         /// Difference between the previous timestamp and current highest timestamp we've seen
@@ -439,7 +439,7 @@ pub fn construct<A: Allocate>(
                     Datum::String(&name),
                     Datum::String(&id.source_id.to_string()),
                     Datum::Int64(id.dataflow_id as i64),
-                    Datum::String(&pid),
+                    Datum::from(pid.as_deref()),
                     Datum::Int64(offset),
                     Datum::Int64(timestamp),
                 ])

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -702,27 +702,27 @@ where
                             Some(rt_default)
                         }
                         (ExternalSourceConnector::AvroOcf(_), Consistency::BringYourOwn(_)) => {
-                            byo_default.add_partition(PartitionId::File);
+                            byo_default.add_partition(PartitionId::None);
                             Some(byo_default)
                         }
                         (ExternalSourceConnector::AvroOcf(_), Consistency::RealTime) => {
-                            rt_default.add_partition(PartitionId::File);
+                            rt_default.add_partition(PartitionId::None);
                             Some(rt_default)
                         }
                         (ExternalSourceConnector::File(_), Consistency::BringYourOwn(_)) => {
-                            byo_default.add_partition(PartitionId::File);
+                            byo_default.add_partition(PartitionId::None);
                             Some(byo_default)
                         }
                         (ExternalSourceConnector::File(_), Consistency::RealTime) => {
-                            rt_default.add_partition(PartitionId::File);
+                            rt_default.add_partition(PartitionId::None);
                             Some(rt_default)
                         }
                         (ExternalSourceConnector::Kinesis(_), Consistency::RealTime) => {
-                            rt_default.add_partition(PartitionId::Kinesis);
+                            rt_default.add_partition(PartitionId::None);
                             Some(rt_default)
                         }
                         (ExternalSourceConnector::S3(_), Consistency::RealTime) => {
-                            rt_default.add_partition(PartitionId::S3);
+                            rt_default.add_partition(PartitionId::None);
                             Some(rt_default)
                         }
                         (ExternalSourceConnector::Kinesis(_), Consistency::BringYourOwn(_)) => {

--- a/src/dataflow/src/source/file.rs
+++ b/src/dataflow/src/source/file.rs
@@ -156,7 +156,7 @@ impl SourceReader for FileSourceReader {
                 receiver_stream: receiver,
                 current_file_offset: FileOffset { offset: 0 },
             },
-            Some(PartitionId::File),
+            Some(PartitionId::None),
         ))
     }
 
@@ -165,7 +165,7 @@ impl SourceReader for FileSourceReader {
             Ok(Ok(record)) => {
                 self.current_file_offset.offset += 1;
                 let message = SourceMessage {
-                    partition: PartitionId::File,
+                    partition: PartitionId::None,
                     offset: self.current_file_offset.into(),
                     upstream_time_millis: None,
                     key: None,

--- a/src/dataflow/src/source/kinesis.rs
+++ b/src/dataflow/src/source/kinesis.rs
@@ -124,7 +124,7 @@ impl SourceReader for KinesisSourceReader {
                     stream_name,
                     processed_message_count: 0,
                 },
-                Some(PartitionId::Kinesis),
+                Some(PartitionId::None),
             )),
             Err(e) => Err(anyhow!("{}", e)),
         }
@@ -198,7 +198,7 @@ impl SourceReader for KinesisSourceReader {
                         let data = record.data.as_ref().to_vec();
                         self.processed_message_count += 1;
                         let source_message = SourceMessage {
-                            partition: PartitionId::Kinesis,
+                            partition: PartitionId::None,
                             offset: MzOffset {
                                 //TODO: should MzOffset be modified to be a string?
                                 offset: self.processed_message_count,

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -607,9 +607,7 @@ impl ConsistencyInfo {
     /// Returns true if this worker is responsible for handling this partition
     fn responsible_for(&self, pid: &PartitionId) -> bool {
         match pid {
-            PartitionId::File | PartitionId::S3 | PartitionId::Kinesis | PartitionId::None => {
-                self.active
-            }
+            PartitionId::None => self.active,
             PartitionId::Kafka(p) => {
                 // We want to distribute partitions across workers evenly, such that
                 // - different partitions for the same source are uniformly distributed across workers
@@ -639,7 +637,7 @@ impl ConsistencyInfo {
     /// ingest from `pid`.
     fn add_partition(&mut self, pid: &PartitionId) {
         if self.partition_metadata.contains_key(pid) {
-            error!("Incorrectly attempting to add a partition twice for source: {} partion: {}. Ignoring",
+            error!("Incorrectly attempting to add a partition twice for source: {} partition: {}. Ignoring",
                    self.source_id,
                    pid
             );
@@ -889,7 +887,7 @@ impl Drop for SourceMetrics {
                 logger.log(MaterializedEvent::SourceInfo {
                     source_name: self.source_name.clone(),
                     source_id: self.source_id,
-                    partition_id: partition.to_string(),
+                    partition_id: partition.into(),
                     offset: -metric.last_offset,
                     timestamp: -metric.last_timestamp,
                 });
@@ -926,7 +924,7 @@ impl PartitionMetrics {
         logger.log(MaterializedEvent::SourceInfo {
             source_name: source_name.to_string(),
             source_id,
-            partition_id: partition_id.to_string(),
+            partition_id: partition_id.into(),
             offset: offset - self.last_offset,
             timestamp: timestamp - self.last_timestamp,
         });

--- a/src/dataflow/src/source/s3.rs
+++ b/src/dataflow/src/source/s3.rs
@@ -708,7 +708,7 @@ impl SourceReader for S3SourceReader {
                 receiver_stream: receiver,
                 offset: S3Offset(0),
             },
-            Some(PartitionId::S3),
+            Some(PartitionId::None),
         ))
     }
 
@@ -717,7 +717,7 @@ impl SourceReader for S3SourceReader {
             Ok(Ok(InternalMessage { record })) => {
                 self.offset += 1;
                 Ok(NextMessage::Ready(SourceMessage {
-                    partition: PartitionId::S3,
+                    partition: PartitionId::None,
                     offset: self.offset.into(),
                     upstream_time_millis: None,
                     key: None,

--- a/src/expr/src/id.rs
+++ b/src/expr/src/id.rs
@@ -130,15 +130,10 @@ impl fmt::Display for SourceInstanceId {
 
 /// Unique identifier for each part of a whole source.
 ///     Kafka -> partition
-///     Kinesis -> currently treated as single partition, should be shard.
-///     File -> only one
-///     S3 -> https://github.com/MaterializeInc/materialize/issues/5715
+///     None -> sources that have no notion of partitioning (e.g file sources)
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub enum PartitionId {
     Kafka(i32),
-    Kinesis,
-    File,
-    S3,
     None,
 }
 
@@ -146,10 +141,16 @@ impl fmt::Display for PartitionId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             PartitionId::Kafka(id) => write!(f, "{}", id.to_string()),
-            PartitionId::S3 => write!(f, "s3"),
-            PartitionId::Kinesis => write!(f, "kinesis"),
-            PartitionId::File => write!(f, "0"),
             PartitionId::None => write!(f, "none"),
+        }
+    }
+}
+
+impl From<&PartitionId> for Option<String> {
+    fn from(pid: &PartitionId) -> Option<String> {
+        match pid {
+            PartitionId::None => None,
+            _ => Some(pid.to_string()),
         }
     }
 }

--- a/test/pg-cdc/mz-source-tables.td
+++ b/test/pg-cdc/mz-source-tables.td
@@ -27,5 +27,5 @@ CREATE PUBLICATION mz_source FOR ALL TABLES;
 > SELECt id LIKE 'u%', oid > 0, schema_id > 1, volatility = 'unknown' FROM mz_sources WHERE name = 'mz_source';
 true true true true
 
-> SELECT partition_id = 'none', "offset" = timestamp, timestamp > 0, source_id like 'u%', dataflow_id > 0 FROM mz_source_info WHERE source_name LIKE '%postgres%';
+> SELECT partition_id IS NULL, "offset" = timestamp, timestamp > 0, source_id like 'u%', dataflow_id > 0 FROM mz_source_info WHERE source_name LIKE '%postgres%';
 true true true true true


### PR DESCRIPTION
Changes the `partition_id` column to be nullable to accurately describe sources for which a partition doesn't make sense. Additionally, a single `PartitionId` variant (`None`) is used for all sources that fall into this category and the previous variants are removed.