### PR TITLE
ci: Push docker images with their git sha's as well as their fingerprints

### DIFF
--- a/ci/test/build.py
+++ b/ci/test/build.py
@@ -33,11 +33,11 @@ def main() -> None:
     # images that we build to Docker Hub, where they will be accessible to
     # other build agents.
     print("--- Acquiring mzbuild images")
+    commit_tag = f'unstable-{git.rev_parse("HEAD")}'
     deps = repo.resolve_dependencies(image for image in repo if image.publish)
     deps.acquire()
-    for d in deps:
-        if not d.pushed():
-            d.push()
+    deps.push()
+    deps.push_tagged(commit_tag)
 
     print("--- Staging Debian package")
     if os.environ["BUILDKITE_BRANCH"] == "main":


### PR DESCRIPTION
The specific impetus of this is that our load test infra depends on git
commits, not arbitrary images, but in general referring to a git commit
is easier for humans than finding and referring to a fingerprint.