### PR TITLE
ci: always trigger a build

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -18,6 +18,8 @@ steps:
   - id: build
     label: ":docker: build"
     command: bin/ci-builder run stable bin/pyactivate --dev -m ci.test.build
+    inputs:
+      - "*"
     timeout_in_minutes: 30
     agents:
       queue: builder


### PR DESCRIPTION
Relying on downstream jobs to depend on the build step doesn't always do the right thing and can lead to broken code to be merged in main like in MaterializeInc/materialize#6910.

Since pretty much every single substep relies on the build step, this PR makes the build step trigger with any file change.