### PR TITLE
expr: go through Deref for OptimizedMirRelationExpr -> MirRelationExpr

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -1740,8 +1740,7 @@ impl Catalog {
             Plan::CreateSource(CreateSourcePlan { source, .. }) => {
                 let mut optimizer = Optimizer::default();
                 let optimized_expr = optimizer.optimize(source.expr, self.indexes())?;
-                let transformed_desc =
-                    RelationDesc::new(optimized_expr.as_ref().typ(), source.column_names);
+                let transformed_desc = RelationDesc::new(optimized_expr.typ(), source.column_names);
                 CatalogItem::Source(Source {
                     create_sql: source.create_sql,
                     plan_cx: pcx,
@@ -1756,7 +1755,7 @@ impl Catalog {
             }) => {
                 let mut optimizer = Optimizer::default();
                 let optimized_expr = optimizer.optimize(view.expr, self.indexes())?;
-                let desc = RelationDesc::new(optimized_expr.as_ref().typ(), view.column_names);
+                let desc = RelationDesc::new(optimized_expr.typ(), view.column_names);
                 CatalogItem::View(View {
                     create_sql: view.create_sql,
                     plan_cx: pcx,

--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -159,11 +159,11 @@ impl<'a> DataflowBuilder<'a> {
         dataflow: &mut DataflowDesc,
     ) {
         // TODO: We only need to import Get arguments for which we cannot find arrangements.
-        for get_id in view.as_ref().global_uses() {
+        for get_id in view.global_uses() {
             self.import_into_dataflow(&get_id, dataflow);
         }
         // Collect sources, views, and indexes used.
-        view.as_ref().visit(&mut |e| {
+        view.visit(&mut |e| {
             if let MirRelationExpr::ArrangeBy { input, keys } = e {
                 if let MirRelationExpr::Get {
                     id: Id::Global(on_id),
@@ -186,7 +186,7 @@ impl<'a> DataflowBuilder<'a> {
                 }
             }
         });
-        dataflow.add_view_to_build(*view_id, view.clone(), view.as_ref().typ());
+        dataflow.add_view_to_build(*view_id, view.clone(), view.typ());
     }
 
     /// Builds a dataflow description for the index with the specified ID.

--- a/src/dataflow-types/src/explain.rs
+++ b/src/dataflow-types/src/explain.rs
@@ -91,7 +91,7 @@ impl<'a> Explanation<'a> {
             .map(|build_desc| {
                 (
                     build_desc.id,
-                    ViewExplanation::new(build_desc.relation_expr.as_ref(), expr_humanizer),
+                    ViewExplanation::new(&build_desc.relation_expr, expr_humanizer),
                 )
             })
             .collect::<Vec<_>>();

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -151,7 +151,7 @@ impl DataflowDesc {
         expr: OptimizedMirRelationExpr,
         typ: RelationType,
     ) {
-        for get_id in expr.as_ref().global_uses() {
+        for get_id in expr.global_uses() {
             self.add_dependency(id, get_id);
         }
         self.objects_to_build.push(BuildDesc {
@@ -293,7 +293,7 @@ impl DataflowDesc {
         }
         for desc in self.objects_to_build.iter() {
             if &desc.id == id {
-                return desc.relation_expr.as_ref().arity();
+                return desc.relation_expr.arity();
             }
         }
         panic!("GlobalId {} not found in DataflowDesc", id);

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -284,14 +284,14 @@ where
     }
 
     fn build_object(&mut self, scope: &mut Child<'g, G, G::Timestamp>, object: &BuildDesc) {
-        self.ensure_rendered(object.relation_expr.as_ref(), scope, scope.index());
+        self.ensure_rendered(&object.relation_expr, scope, scope.index());
         if let Some(typ) = &object.typ {
             self.clone_from_to(
-                &object.relation_expr.as_ref(),
+                &object.relation_expr,
                 &MirRelationExpr::global_get(object.id, typ.clone()),
             );
         } else {
-            self.render_arrangeby(&object.relation_expr.as_ref(), Some(&object.id.to_string()));
+            self.render_arrangeby(&object.relation_expr, Some(&object.id.to_string()));
             // Under the premise that this is always an arrange_by aroung a global get,
             // this will leave behind the arrangements bound to the global get, so that
             // we will not tidy them up in the next pass.

--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -12,6 +12,7 @@
 #![deny(missing_debug_implementations)]
 
 use std::fmt;
+use std::ops::Deref;
 
 use serde::{Deserialize, Serialize};
 
@@ -56,20 +57,24 @@ impl OptimizedMirRelationExpr {
         OptimizedMirRelationExpr(expr)
     }
 
+    /// Get mutable access to the inner [MirRelationExpr]
+    ///
+    /// Callers of this method need to ensure that the underlying expression stays optimized after
+    /// any mutations are applied
+    pub fn as_inner_mut(&mut self) -> &mut MirRelationExpr {
+        &mut self.0
+    }
+
     pub fn into_inner(self) -> MirRelationExpr {
         self.0
     }
 }
 
-impl AsRef<MirRelationExpr> for OptimizedMirRelationExpr {
-    fn as_ref(&self) -> &MirRelationExpr {
-        &self.0
-    }
-}
+impl Deref for OptimizedMirRelationExpr {
+    type Target = MirRelationExpr;
 
-impl AsMut<MirRelationExpr> for OptimizedMirRelationExpr {
-    fn as_mut(&mut self) -> &mut MirRelationExpr {
-        &mut self.0
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -76,7 +76,6 @@ fn inline_views(dataflow: &mut DataflowDesc) {
             for other in (index + 1)..dataflow.objects_to_build.len() {
                 if dataflow.objects_to_build[other]
                     .relation_expr
-                    .as_ref()
                     .global_uses()
                     .contains(&global_id)
                 {
@@ -98,20 +97,24 @@ fn inline_views(dataflow: &mut DataflowDesc) {
                 let new_local = LocalId::new(id_gen.allocate_id());
                 // Use the same `id_gen` to assign new identifiers to `index`.
                 update_let.action(
-                    dataflow.objects_to_build[index].relation_expr.as_mut(),
+                    dataflow.objects_to_build[index]
+                        .relation_expr
+                        .as_inner_mut(),
                     &mut HashMap::new(),
                     &mut id_gen,
                 );
                 // Assign new identifiers to the other relation.
                 update_let.action(
-                    dataflow.objects_to_build[other].relation_expr.as_mut(),
+                    dataflow.objects_to_build[other]
+                        .relation_expr
+                        .as_inner_mut(),
                     &mut HashMap::new(),
                     &mut id_gen,
                 );
                 // Install the `new_local` name wherever `global_id` was used.
                 dataflow.objects_to_build[other]
                     .relation_expr
-                    .as_mut()
+                    .as_inner_mut()
                     .visit_mut(&mut |expr| {
                         if let MirRelationExpr::Get { id, .. } = expr {
                             if id == &Id::Global(global_id) {
@@ -125,13 +128,15 @@ fn inline_views(dataflow: &mut DataflowDesc) {
                 // whose body is `other`.
                 let body = dataflow.objects_to_build[other]
                     .relation_expr
-                    .as_mut()
+                    .as_inner_mut()
                     .take_dangerous();
                 let value = dataflow.objects_to_build[index]
                     .relation_expr
-                    .as_mut()
+                    .as_inner_mut()
                     .take_dangerous();
-                *dataflow.objects_to_build[other].relation_expr.as_mut() = MirRelationExpr::Let {
+                *dataflow.objects_to_build[other]
+                    .relation_expr
+                    .as_inner_mut() = MirRelationExpr::Let {
                     id: new_local,
                     value: Box::new(value),
                     body: Box::new(body),
@@ -164,7 +169,7 @@ fn inline_views(dataflow: &mut DataflowDesc) {
         // `InlineLet` which probably wants a reworking in any case.
         // Re-run all optimizations on the composite views.
         optimizer
-            .transform(object.relation_expr.as_mut(), &indexes)
+            .transform(object.relation_expr.as_inner_mut(), &indexes)
             .unwrap();
     }
 }
@@ -196,7 +201,7 @@ fn optimize_dataflow_demand(dataflow: &mut DataflowDesc) {
         let transform = crate::demand::Demand;
         if let Some(columns) = demand.get(&Id::Global(build_desc.id)).clone() {
             transform.action(
-                build_desc.relation_expr.as_mut(),
+                build_desc.relation_expr.as_inner_mut(),
                 columns.clone(),
                 &mut demand,
             );
@@ -232,14 +237,14 @@ fn optimize_dataflow_filters(dataflow: &mut DataflowDesc) {
         let transform = crate::predicate_pushdown::PredicatePushdown;
         if let Some(list) = predicates.get(&Id::Global(build_desc.id)).clone() {
             if !list.is_empty() {
-                *build_desc.relation_expr.as_mut() = build_desc
+                *build_desc.relation_expr.as_inner_mut() = build_desc
                     .relation_expr
-                    .as_mut()
+                    .as_inner_mut()
                     .take_dangerous()
                     .filter(list.iter().cloned());
             }
         }
-        transform.dataflow_transform(build_desc.relation_expr.as_mut(), &mut predicates);
+        transform.dataflow_transform(build_desc.relation_expr.as_inner_mut(), &mut predicates);
     }
 
     // Push predicate information into the SourceDesc.
@@ -356,7 +361,7 @@ pub mod monotonic {
 
         // Propagate predicate information from outputs to inputs.
         for build_desc in dataflow.objects_to_build.iter_mut() {
-            is_monotonic(build_desc.relation_expr.as_mut(), &monotonic);
+            is_monotonic(build_desc.relation_expr.as_inner_mut(), &monotonic);
         }
     }
 }


### PR DESCRIPTION
Since `OptimizedMirRelationExpr` is just a wrapper type it's natural to deref to its inner type which makes accessing the inner methods a lot more ergonomic due to autoderef.