### PR TITLE
exactly-once-sinks

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -1302,6 +1302,24 @@ impl Catalog {
         Ok(())
     }
 
+    /// Compact timestamp bindings for a source
+    ///
+    /// In practice this ends up being "remove all bindings less than a given timestamp"
+    /// because all offsets are then assigned to the next available binding.
+    pub fn compact_timestamp_bindings(
+        &mut self,
+        source_id: GlobalId,
+        frontier: Timestamp,
+    ) -> Result<(), Error> {
+        let mut storage = self.storage();
+        let tx = storage.transaction()?;
+
+        tx.compact_timestamp_bindings(source_id, frontier)?;
+        tx.commit()?;
+
+        Ok(())
+    }
+
     pub fn transact(&mut self, ops: Vec<Op>) -> Result<Vec<BuiltinTableUpdate>, Error> {
         trace!("transact: {:?}", ops);
 

--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -16,13 +16,14 @@ use std::time::{Duration, Instant};
 
 use anyhow::bail;
 use chrono::{DateTime, TimeZone, Utc};
-use dataflow_types::{ExternalSourceConnector, SinkEnvelope};
-use expr::Id;
+use dataflow_types::{ExternalSourceConnector, MzOffset, SinkEnvelope};
+use expr::{Id, PartitionId};
 use itertools::Itertools;
 use lazy_static::lazy_static;
 use log::{info, trace};
 use ore::collections::CollectionExt;
 use regex::Regex;
+use repr::Timestamp;
 use serde::{Deserialize, Serialize};
 
 use build_info::DUMMY_BUILD_INFO;
@@ -1248,6 +1249,57 @@ impl Catalog {
             }
         }
         Ok(temporary_ids)
+    }
+
+    /// Insert timestamp bindings into SQLite, and ignores duplicate timestamp bindings.
+    ///
+    /// Each individual binding is listed as (source_id, partition_id, timestamp, offset)
+    /// and it indicates that all data from (source, partition) for offsets < `offset`, can
+    /// be assigned `timestamp` iff `offset` is the minimal such offset (this is a way to encode
+    /// a [start, end) offset interval without having to duplicate adjacent starts and ends in
+    /// storage).
+    /// TODO: we intentionally ignore duplicates because BYO sources can send multiple
+    /// copies of the same timestamp.
+    pub fn insert_timestamp_bindings(
+        &mut self,
+        timestamps: impl IntoIterator<Item = (GlobalId, String, Timestamp, i64)>,
+    ) -> Result<(), Error> {
+        let mut storage = self.storage();
+        let tx = storage.transaction()?;
+
+        for (sid, pid, ts, offset) in timestamps.into_iter() {
+            tx.insert_timestamp_binding(&sid, &pid, ts, offset)?;
+        }
+        tx.commit()?;
+
+        Ok(())
+    }
+
+    /// Read all available timestamp bindings for a source
+    ///
+    /// Returns its output sorted by (partition, timestamp)
+    pub fn load_timestamp_bindings(
+        &mut self,
+        source_id: GlobalId,
+    ) -> Result<Vec<(PartitionId, Timestamp, MzOffset)>, Error> {
+        let mut storage = self.storage();
+        let tx = storage.transaction()?;
+
+        let ret = tx.load_timestamp_bindings(source_id)?;
+        tx.commit()?;
+
+        Ok(ret)
+    }
+
+    /// Delete all timestamp bindings for a source
+    pub fn delete_timestamp_bindings(&mut self, source_id: GlobalId) -> Result<(), Error> {
+        let mut storage = self.storage();
+        let tx = storage.transaction()?;
+
+        tx.delete_timestamp_bindings(source_id)?;
+        tx.commit()?;
+
+        Ok(())
     }
 
     pub fn transact(&mut self, ops: Vec<Op>) -> Result<Vec<BuiltinTableUpdate>, Error> {

--- a/src/coord/src/catalog/storage.rs
+++ b/src/coord/src/catalog/storage.rs
@@ -547,6 +547,21 @@ impl Transaction<'_> {
         }
     }
 
+    pub fn compact_timestamp_bindings(
+        &self,
+        source_id: GlobalId,
+        frontier: Timestamp,
+    ) -> Result<(), Error> {
+        match self
+            .inner
+            .prepare_cached("DELETE FROM timestamps WHERE sid = ? AND timestamp < ?")?
+            .execute(params![SqlVal(&source_id), frontier])
+        {
+            Ok(_) => Ok(()),
+            Err(err) => Err(err.into()),
+        }
+    }
+
     pub fn remove_database(&self, name: &str) -> Result<(), Error> {
         let n = self
             .inner

--- a/src/coord/src/catalog/storage.rs
+++ b/src/coord/src/catalog/storage.rs
@@ -14,8 +14,10 @@ use rusqlite::types::{FromSql, FromSqlError, ToSql, ToSqlOutput, Value, ValueRef
 use rusqlite::OptionalExtension;
 use serde::{Deserialize, Serialize};
 
-use expr::GlobalId;
+use dataflow_types::MzOffset;
+use expr::{GlobalId, PartitionId};
 use ore::cast::CastFrom;
+use repr::Timestamp;
 use sql::catalog::CatalogError as SqlCatalogError;
 use sql::names::{DatabaseSpecifier, FullName};
 use uuid::Uuid;
@@ -105,6 +107,21 @@ const MIGRATIONS: &[&str] = &[
     // Introduced in v0.7.0.
     "INSERT INTO schemas (database_id, name) VALUES
         (NULL, 'mz_internal');",
+    // Adjusts timestamp table to support replayable source timestamp bindings.
+    //
+    // Introduced for v0.7.4
+    //
+    // ATTENTION: this migration blows away data and must not be used as a model
+    // for future migrations! It is only acceptable now because we have not yet
+    // made any consistency promises to users.
+    "DROP TABLE timestamps;
+     CREATE TABLE timestamps (
+        sid blob NOT NULL,
+        pid blob NOT NULL,
+        timestamp integer NOT NULL,
+        offset blob NOT NULL,
+        PRIMARY KEY (sid, pid, timestamp, offset)
+    );",
     // Add new migrations here.
     //
     // Migrations should be preceded with a comment of the following form:
@@ -417,6 +434,25 @@ impl Transaction<'_> {
         }
     }
 
+    pub fn load_timestamp_bindings(
+        &self,
+        source_id: GlobalId,
+    ) -> Result<Vec<(PartitionId, Timestamp, MzOffset)>, Error> {
+        self.inner
+            .prepare_cached(
+                "SELECT pid, timestamp, offset from timestamps where sid = ? order by pid, timestamp")?
+            .query_and_then(params![SqlVal(&source_id)], |row| -> Result<_, Error> {
+                let partition: PartitionId = row.get::<_, String>(0)?.parse().expect("parsing partition id from string cannot fail");
+                let timestamp: Timestamp = row.get(1)?;
+                let offset = MzOffset {
+                    offset: row.get(2)?,
+                };
+
+                Ok((partition, timestamp, offset))
+            })?
+            .collect()
+    }
+
     pub fn insert_database(&mut self, database_name: &str) -> Result<i64, Error> {
         match self
             .inner
@@ -477,6 +513,36 @@ impl Transaction<'_> {
             Err(err) if is_constraint_violation(&err) => Err(Error::new(
                 ErrorKind::ItemAlreadyExists(item_name.to_owned()),
             )),
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    pub fn insert_timestamp_binding(
+        &self,
+        source_id: &GlobalId,
+        partition_id: &str,
+        timestamp: Timestamp,
+        offset: i64,
+    ) -> Result<(), Error> {
+        match self
+            .inner
+            .prepare_cached(
+                "INSERT OR IGNORE INTO timestamps (sid, pid, timestamp, offset) VALUES (?, ?, ?, ?)",
+            )?
+            .execute(params![SqlVal(source_id), partition_id, timestamp, offset])
+        {
+            Ok(_) => Ok(()),
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    pub fn delete_timestamp_bindings(&self, source_id: GlobalId) -> Result<(), Error> {
+        match self
+            .inner
+            .prepare_cached("DELETE FROM timestamps WHERE sid = ?")?
+            .execute(params![SqlVal(&source_id)])
+        {
+            Ok(_) => Ok(()),
             Err(err) => Err(err.into()),
         }
     }

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -3262,6 +3262,7 @@ pub async fn serve(
     let worker_guards = dataflow::serve(dataflow::Config {
         command_receivers: worker_rxs,
         timely_worker,
+        experimental_mode,
     })
     .map_err(|s| CoordError::Unstructured(anyhow!("{}", s)))?;
 

--- a/src/coord/src/coord/arrangement_state.rs
+++ b/src/coord/src/coord/arrangement_state.rs
@@ -111,7 +111,7 @@ pub struct Frontiers<T: Timestamp> {
     /// The compaction frontier.
     /// All peeks in advance of this frontier will be correct,
     /// but peeks not in advance of this frontier may not be.
-    since: Rc<RefCell<MutableAntichain<T>>>,
+    pub since: Rc<RefCell<MutableAntichain<T>>>,
     /// The function to run on since changes.
     /// Passes the new since frontier.
     since_action: Rc<RefCell<dyn FnMut(Antichain<T>)>>,
@@ -169,6 +169,42 @@ impl<T: Timestamp + Copy> Frontiers<T> {
     /// Sets the latency behind the collection frontier at which compaction occurs.
     pub fn set_compaction_window_ms(&mut self, window_ms: Option<T>) {
         self.compaction_window_ms = window_ms;
+    }
+}
+
+/// Track sink state for which timestamps the sink has written out.
+pub struct SinkWrites<T: Timestamp> {
+    /// The write frontier for the sink, ie all subsequent writes will be at
+    /// timestamps that are at or in advance of this frontier.
+    pub frontier: MutableAntichain<T>,
+    /// Set of handles to sources that the sink transitively depends on. We hold
+    /// back all of these sources' since frontiers to trail the sink's write frontier
+    /// and allow the since frontier to advance as the sink's write frontier advances.
+    pub source_handles: Vec<AntichainToken<T>>,
+}
+
+impl<T: Timestamp> SinkWrites<T> {
+    pub fn new(source_handles: Vec<AntichainToken<T>>) -> Self {
+        let mut frontier = MutableAntichain::new();
+        frontier.update_iter(Some((T::minimum(), 1)));
+
+        SinkWrites {
+            frontier,
+            source_handles,
+        }
+    }
+
+    /// Allow all sources that the sink transitively depends on to advance their compaction/since
+    /// frontiers up to the sink's write frontier, if they so choose.
+    ///
+    /// This function needs to be called periodically, otherwise sink's source dependencies will
+    /// never compact their timestamp bindings in memory or in the catalog. However, this doesn't
+    /// have to happen in lockstep with write frontier updates.
+    pub fn advance_source_handles(&mut self) {
+        let frontier: Vec<_> = self.frontier.frontier().to_owned().elements().to_vec();
+        for handle in self.source_handles.iter_mut() {
+            handle.maybe_advance(frontier.iter().cloned());
+        }
     }
 }
 

--- a/src/coord/src/coord/arrangement_state.rs
+++ b/src/coord/src/coord/arrangement_state.rs
@@ -104,6 +104,10 @@ pub struct Frontiers<T: Timestamp> {
     /// The most recent frontier for new data.
     /// All further changes will be in advance of this bound.
     pub upper: MutableAntichain<T>,
+    /// The most recent frontier for durable data.
+    /// All data at times in advance of this frontier have not yet been
+    /// durably persisted and may not be replayable across restarts.
+    pub durability: MutableAntichain<T>,
     /// The compaction frontier.
     /// All peeks in advance of this frontier will be correct,
     /// but peeks not in advance of this frontier may not be.
@@ -135,8 +139,10 @@ impl<T: Timestamp + Copy> Frontiers<T> {
         // Upper must always start at minimum ("0"), even if we initialize since to
         // something in advance of it.
         upper.update_iter(Some((T::minimum(), workers as i64)));
+        let durability = upper.clone();
         let frontier = Self {
             upper,
+            durability,
             since: Rc::new(RefCell::new(MutableAntichain::new())),
             compaction_window_ms,
             since_action: Rc::new(RefCell::new(since_action)),

--- a/src/coord/src/sink_connector.rs
+++ b/src/coord/src/sink_connector.rs
@@ -459,6 +459,7 @@ async fn build_kafka(
         value_desc: builder.value_desc,
         consistency,
         exactly_once: builder.exactly_once,
+        transitive_source_dependencies: builder.transitive_source_dependencies,
         fuel: builder.fuel,
         config_options: builder.config_options,
     }))

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -657,6 +657,19 @@ impl SourceConnector {
         }
     }
 
+    /// Returns true iff this connector uses BYO consistency
+    pub fn is_byo(&self) -> bool {
+        if let SourceConnector::External { consistency, .. } = self {
+            if let Consistency::BringYourOwn(_) = consistency {
+                true
+            } else {
+                false
+            }
+        } else {
+            false
+        }
+    }
+
     pub fn caching_enabled(&self) -> bool {
         match self {
             SourceConnector::External { connector, .. } => connector.caching_enabled(),

--- a/src/dataflow/src/lib.rs
+++ b/src/dataflow/src/lib.rs
@@ -23,5 +23,6 @@ pub mod logging;
 pub mod source;
 
 pub use server::{
-    serve, CacheMessage, Config, SequencedCommand, WorkerFeedback, WorkerFeedbackWithMeta,
+    serve, CacheMessage, Config, SequencedCommand, TimestampBindingFeedback, WorkerFeedback,
+    WorkerFeedbackWithMeta,
 };

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -101,6 +101,7 @@
 //! if/when the errors are retracted.
 
 use std::any::Any;
+use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::iter;
 use std::rc::Rc;
@@ -111,6 +112,7 @@ use timely::communication::Allocate;
 use timely::dataflow::operators::to_stream::ToStream;
 use timely::dataflow::scopes::Child;
 use timely::dataflow::Scope;
+use timely::progress::Antichain;
 use timely::worker::Worker as TimelyWorker;
 use tokio::sync::mpsc;
 
@@ -154,6 +156,9 @@ pub struct RenderState {
     pub dataflow_tokens: HashMap<GlobalId, Box<dyn Any>>,
     /// Sender to give data to be cached.
     pub caching_tx: Option<mpsc::UnboundedSender<CacheMessage>>,
+    /// Frontier of sink writes (all subsequent writes will be at times at or
+    /// equal to this frontier)
+    pub sink_write_frontiers: HashMap<GlobalId, Rc<RefCell<Antichain<Timestamp>>>>,
 }
 
 /// A container for "tokens" that are relevant to an in-construction dataflow.
@@ -231,7 +236,15 @@ pub fn build_dataflow<A: Allocate>(
             // Export declared sinks.
             for (sink_id, sink) in &dataflow.sink_exports {
                 let imports = dataflow.get_imports(&sink.from);
-                context.export_sink(render_state, &mut tokens, imports, *sink_id, sink);
+                context.export_sink(
+                    render_state,
+                    &mut tokens,
+                    imports,
+                    *sink_id,
+                    sink,
+                    region.index(),
+                    region.peers(),
+                );
             }
         });
     })

--- a/src/dataflow/src/render/sinks.rs
+++ b/src/dataflow/src/render/sinks.rs
@@ -19,6 +19,7 @@ use differential_dataflow::{AsCollection, Hashable};
 use timely::dataflow::operators::Map;
 use timely::dataflow::scopes::Child;
 use timely::dataflow::Scope;
+use timely::progress::Antichain;
 
 use dataflow_types::*;
 use expr::{GlobalId, MirRelationExpr};
@@ -56,6 +57,7 @@ where
                 needed_source_tokens.push(source_token.clone());
             }
         }
+
         let (collection, _err_collection) = self
             .collection(&MirRelationExpr::global_get(
                 sink.from,
@@ -205,6 +207,20 @@ where
 
         match sink.connector.clone() {
             SinkConnector::Kafka(c) => {
+                // Extract handles to the relevant source timestamp histories the sink
+                // needs to hear from before it can write data out to Kafka.
+                let mut source_ts_histories = Vec::new();
+
+                for id in &c.transitive_source_dependencies {
+                    if let Some(history) = render_state.ts_histories.get(id) {
+                        let mut history_bindings = history.clone();
+                        // We don't want these to block compaction
+                        // ever.
+                        history_bindings.set_compaction_frontier(Antichain::new().borrow());
+                        source_ts_histories.push(history_bindings);
+                    }
+                }
+
                 let token = sink::kafka(
                     collection,
                     sink_id,
@@ -212,6 +228,7 @@ where
                     sink.key_desc.clone(),
                     sink.value_desc.clone(),
                     sink.as_of.clone(),
+                    source_ts_histories,
                 );
                 needed_sink_tokens.push(token);
             }

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -33,7 +33,7 @@ use uuid::Uuid;
 
 use dataflow_types::logging::LoggingConfig;
 use dataflow_types::{
-    Consistency, DataflowDesc, DataflowError, ExternalSourceConnector, PeekResponse,
+    Consistency, DataflowDesc, DataflowError, ExternalSourceConnector, MzOffset, PeekResponse,
     SourceConnector, TimestampSourceUpdate, Update,
 };
 use expr::{GlobalId, PartitionId, RowSetFinishing};
@@ -49,6 +49,10 @@ use crate::source::cache::WorkerCacheData;
 use crate::source::timestamp::TimestampBindingRc;
 
 mod metrics;
+
+/// How frequently each dataflow worker sends timestamp binding updates
+/// back to the coordinator.
+static TS_BINDING_FEEDBACK_INTERVAL_MS: u128 = 1_000;
 
 /// Explicit instructions for timely dataflow workers.
 #[derive(Clone, Debug)]
@@ -108,6 +112,8 @@ pub enum SequencedCommand {
         id: GlobalId,
         /// The connector for the timestamped source.
         connector: SourceConnector,
+        /// Previously stored timestamp bindings.
+        bindings: Vec<(PartitionId, Timestamp, MzOffset)>,
     },
     /// Advance worker timestamp
     AdvanceSourceTimestamp {
@@ -158,11 +164,23 @@ pub enum CacheMessage {
     DropSource(GlobalId),
 }
 
+/// Data about timestamp bindings that dataflow workers send to the coordinator
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TimestampBindingFeedback {
+    /// Durability frontier changes
+    pub changes: Vec<(GlobalId, ChangeBatch<Timestamp>)>,
+    /// Timestamp bindings for all of those frontier changes
+    pub bindings: Vec<(GlobalId, PartitionId, Timestamp, MzOffset)>,
+}
+
 /// Responses the worker can provide back to the coordinator.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum WorkerFeedback {
     /// A list of identifiers of traces, with prior and new upper frontiers.
     FrontierUppers(Vec<(GlobalId, ChangeBatch<Timestamp>)>),
+    /// Timestamp bindings and prior and new frontiers for those bindings for all
+    /// sources
+    TimestampBindings(TimestampBindingFeedback),
 }
 
 /// Configures a dataflow server.
@@ -217,6 +235,8 @@ pub fn serve(config: Config) -> Result<WorkerGuards<()>, String> {
                 pending_peeks: Vec::new(),
                 feedback_tx: None,
                 reported_frontiers: HashMap::new(),
+                reported_bindings_frontiers: HashMap::new(),
+                last_bindings_feedback: Instant::now(),
                 metrics: Metrics::for_worker_id(worker_idx),
             }
             .run()
@@ -246,6 +266,10 @@ where
     feedback_tx: Option<mpsc::UnboundedSender<WorkerFeedbackWithMeta>>,
     /// Tracks the frontier information that has been sent over `feedback_tx`.
     reported_frontiers: HashMap<GlobalId, Antichain<Timestamp>>,
+    /// Tracks the timestamp binding durability information that has been sent over `feedback_tx`.
+    reported_bindings_frontiers: HashMap<GlobalId, Antichain<Timestamp>>,
+    /// Tracks the last time we sent binding durability info over `feedback_tx`.
+    last_bindings_feedback: Instant,
     /// Metrics bundle.
     metrics: Metrics,
 }
@@ -415,6 +439,7 @@ where
             // Report frontier information back the coordinator.
             self.report_frontiers();
             self.update_rt_timestamps();
+            self.report_timestamp_bindings();
 
             // Handle any received commands.
             let cmds: Vec<_> = self.command_rx.try_iter().collect();
@@ -470,6 +495,15 @@ where
                 }
             }
 
+            // Log index frontier changes
+            if let Some(logger) = self.materialized_logger.as_mut() {
+                for (id, changes) in &mut progress {
+                    for (time, diff) in changes.iter() {
+                        logger.log(MaterializedEvent::Frontier(*id, *time, *diff));
+                    }
+                }
+            }
+
             for (id, history) in self.render_state.ts_histories.iter() {
                 // Read the upper frontier and compare to what we've reported.
                 history.read_upper(&mut new_frontier);
@@ -486,13 +520,6 @@ where
                     prev_frontier.clone_from(&new_frontier);
                 }
             }
-            if let Some(logger) = self.materialized_logger.as_mut() {
-                for (id, changes) in &mut progress {
-                    for (time, diff) in changes.iter() {
-                        logger.log(MaterializedEvent::Frontier(*id, *time, *diff));
-                    }
-                }
-            }
             if !progress.is_empty() {
                 feedback_tx
                     .send(WorkerFeedbackWithMeta {
@@ -502,6 +529,74 @@ where
                     .expect("feedback receriver should not drop first");
             }
         }
+    }
+
+    /// Send information about new timestamp bindings created by dataflow workers back to
+    /// the coordinator.
+    fn report_timestamp_bindings(&mut self) {
+        // Do nothing if dataflow workers can't send feedback or if not enough time has elapsed since
+        // the last time we reported timestamp bindings.
+        if self.feedback_tx.is_none()
+            || self.last_bindings_feedback.elapsed().as_millis() < TS_BINDING_FEEDBACK_INTERVAL_MS
+        {
+            return;
+        }
+
+        let mut changes = Vec::new();
+        let mut bindings = Vec::new();
+        let mut new_frontier = Antichain::new();
+
+        // Need to go through all sources that are generating timestamp bindings, and extract their upper frontiers.
+        // If that frontier is different than the durability frontier we've previously reported then we also need to
+        // get the new bindings we've produced and send them to the coordinator.
+        for (id, history) in self.render_state.ts_histories.iter() {
+            // Read the upper frontier and compare to what we've reported.
+            history.read_upper(&mut new_frontier);
+            let prev_frontier = self
+                .reported_bindings_frontiers
+                .get_mut(&id)
+                .expect("Frontier missing!");
+            assert!(<_ as PartialOrder>::less_equal(
+                prev_frontier,
+                &new_frontier
+            ));
+            if prev_frontier != &new_frontier {
+                let mut change_batch = ChangeBatch::new();
+                for time in prev_frontier.elements().iter() {
+                    change_batch.update(time.clone(), -1);
+                }
+                for time in new_frontier.elements().iter() {
+                    change_batch.update(time.clone(), 1);
+                }
+                change_batch.compact();
+                if !change_batch.is_empty() {
+                    changes.push((*id, change_batch));
+                }
+                // Add all timestamp bindings we know about between the old and new frontier.
+                bindings.extend(
+                    history
+                        .get_bindings_in_range(prev_frontier.borrow(), new_frontier.borrow())
+                        .into_iter()
+                        .map(|(pid, ts, offset)| (*id, pid, ts, offset)),
+                );
+                prev_frontier.clone_from(&new_frontier);
+            }
+        }
+
+        if !changes.is_empty() || !bindings.is_empty() {
+            self.feedback_tx
+                .as_mut()
+                .expect("known to exist")
+                .send(WorkerFeedbackWithMeta {
+                    worker_id: self.timely_worker.index(),
+                    message: WorkerFeedback::TimestampBindings(TimestampBindingFeedback {
+                        changes,
+                        bindings,
+                    }),
+                })
+                .expect("feedback receiver should not drop first");
+        }
+        self.last_bindings_feedback = Instant::now();
     }
 
     /// Instruct all real-time sources managed by the worker to close their current
@@ -681,7 +776,11 @@ where
                 self.render_state.traces.del_all_traces();
                 self.shutdown_logging();
             }
-            SequencedCommand::AddSourceTimestamping { id, connector } => {
+            SequencedCommand::AddSourceTimestamping {
+                id,
+                connector,
+                bindings,
+            } => {
                 let source_timestamp_data = if let SourceConnector::External {
                     connector,
                     consistency,
@@ -754,10 +853,19 @@ where
                     None
                 };
 
+                // Add any timestamp bindings that we were already aware of on restart.
                 if let Some(data) = source_timestamp_data {
+                    for (pid, timestamp, offset) in bindings {
+                        data.add_partition(pid.clone());
+                        data.add_binding(pid, timestamp, offset, false);
+                    }
                     let prev = self.render_state.ts_histories.insert(id, data);
                     assert!(prev.is_none());
                     self.reported_frontiers.insert(id, Antichain::from_elem(0));
+                    self.reported_bindings_frontiers
+                        .insert(id, Antichain::from_elem(0));
+                } else {
+                    assert!(bindings.is_empty());
                 }
             }
             SequencedCommand::AdvanceSourceTimestamp { id, update } => {
@@ -765,8 +873,16 @@ where
                     match update {
                         TimestampSourceUpdate::BringYourOwn(pid, timestamp, offset) => {
                             // TODO: change the interface between the dataflow server and the
-                            // timestamper.
-                            history.add_binding(pid, timestamp, offset + 1, false);
+                            // timestamper. Specifically, we probably want to inform the timestamper
+                            // of the timestamps we already know about so that it doesn't send us
+                            // duplicate copies again.
+
+                            let mut upper = Antichain::new();
+                            history.read_upper(&mut upper);
+
+                            if upper.less_equal(&timestamp) {
+                                history.add_binding(pid, timestamp, offset + 1, false);
+                            }
                         }
                         TimestampSourceUpdate::RealTime(new_partition) => {
                             history.add_partition(new_partition);
@@ -800,6 +916,7 @@ where
                 }
 
                 self.reported_frontiers.remove(&id);
+                self.reported_bindings_frontiers.remove(&id);
             }
         }
     }

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -106,6 +106,12 @@ pub enum SequencedCommand {
     /// accumulations must be correct. The workers gain the liberty of compacting
     /// the corresponding maintained traces up through that frontier.
     AllowCompaction(Vec<(GlobalId, Antichain<Timestamp>)>),
+    /// Update durability information for sources.
+    ///
+    /// Each entry names a source and provides a frontier before which the source can
+    /// be exactly replayed across restarts (i.e. we can assign the same timestamps to
+    /// all the same data)
+    DurabilityFrontierUpdates(Vec<(GlobalId, Antichain<Timestamp>)>),
     /// Add a new source to be aware of for timestamping.
     AddSourceTimestamping {
         /// The ID of the timestamped source
@@ -598,7 +604,6 @@ where
         }
         self.last_bindings_feedback = Instant::now();
     }
-
     /// Instruct all real-time sources managed by the worker to close their current
     /// timestamp and move to the next wall clock time.
     ///
@@ -758,6 +763,13 @@ where
                         .allow_compaction(id, frontier.borrow());
                     if let Some(ts_history) = self.render_state.ts_histories.get_mut(&id) {
                         ts_history.set_compaction_frontier(frontier.borrow());
+                    }
+                }
+            }
+            SequencedCommand::DurabilityFrontierUpdates(list) => {
+                for (id, frontier) in list {
+                    if let Some(ts_history) = self.render_state.ts_histories.get_mut(&id) {
+                        ts_history.set_durability_frontier(frontier.borrow());
                     }
                 }
             }

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -235,6 +235,7 @@ pub fn serve(config: Config) -> Result<WorkerGuards<()>, String> {
                     ts_histories: HashMap::default(),
                     dataflow_tokens: HashMap::new(),
                     caching_tx: None,
+                    sink_write_frontiers: HashMap::new(),
                 },
                 materialized_logger: None,
                 command_rx,
@@ -494,7 +495,7 @@ where
                 let prev_frontier = self
                     .reported_frontiers
                     .get_mut(&id)
-                    .expect("Frontier missing!");
+                    .expect("Index frontier missing!");
                 if prev_frontier != &new_frontier {
                     add_progress(*id, &new_frontier, &prev_frontier, &mut progress);
                     prev_frontier.clone_from(&new_frontier);
@@ -516,13 +517,28 @@ where
                 let prev_frontier = self
                     .reported_frontiers
                     .get_mut(&id)
-                    .expect("Frontier missing!");
+                    .expect("Source frontier missing!");
                 assert!(<_ as PartialOrder>::less_equal(
                     prev_frontier,
                     &new_frontier
                 ));
                 if prev_frontier != &new_frontier {
                     add_progress(*id, &new_frontier, &prev_frontier, &mut progress);
+                    prev_frontier.clone_from(&new_frontier);
+                }
+            }
+            for (id, frontier) in self.render_state.sink_write_frontiers.iter() {
+                new_frontier.clone_from(&frontier.borrow());
+                let prev_frontier = self
+                    .reported_frontiers
+                    .get_mut(&id)
+                    .expect("Sink frontier missing!");
+                assert!(<_ as PartialOrder>::less_equal(
+                    prev_frontier,
+                    &new_frontier
+                ));
+                if prev_frontier != &new_frontier {
+                    add_progress(*id, &prev_frontier, &new_frontier, &mut progress);
                     prev_frontier.clone_from(&new_frontier);
                 }
             }
@@ -619,6 +635,10 @@ where
         match cmd {
             SequencedCommand::CreateDataflows(dataflows) => {
                 for dataflow in dataflows.into_iter() {
+                    for (sink_id, _) in dataflow.sink_exports.iter() {
+                        self.reported_frontiers
+                            .insert(*sink_id, Antichain::from_elem(0));
+                    }
                     for (idx_id, idx, _) in dataflow.index_exports.iter() {
                         self.reported_frontiers
                             .insert(*idx_id, Antichain::from_elem(0));
@@ -645,6 +665,8 @@ where
             }
             SequencedCommand::DropSinks(ids) => {
                 for id in ids {
+                    self.reported_frontiers.remove(&id);
+                    self.render_state.sink_write_frontiers.remove(&id);
                     self.render_state.dataflow_tokens.remove(&id);
                 }
             }

--- a/src/dataflow/src/server/metrics.rs
+++ b/src/dataflow/src/server/metrics.rs
@@ -103,6 +103,8 @@ struct CommandsProcessedMetrics {
     insert: IntCounter,
     allow_compaction_int: i32,
     allow_compaction: IntCounter,
+    durability_frontier_updates_int: i32,
+    durability_frontier_updates: IntCounter,
     append_log_int: i32,
     append_log: IntCounter,
     add_source_timestamping_int: i32,
@@ -147,6 +149,9 @@ impl CommandsProcessedMetrics {
             allow_compaction_int: 0,
             allow_compaction: COMMANDS_PROCESSED_RAW
                 .with_label_values(&[worker, "allow_compaction"]),
+            durability_frontier_updates_int: 0,
+            durability_frontier_updates: COMMANDS_PROCESSED_RAW
+                .with_label_values(&[worker, "durability_frontier_updates"]),
             append_log_int: 0,
             append_log: COMMANDS_PROCESSED_RAW.with_label_values(&[worker, "append_log"]),
             add_source_timestamping_int: 0,
@@ -182,6 +187,9 @@ impl CommandsProcessedMetrics {
             SequencedCommand::CancelPeek { .. } => self.cancel_peek_int += 1,
             SequencedCommand::Insert { .. } => self.insert_int += 1,
             SequencedCommand::AllowCompaction(..) => self.allow_compaction_int += 1,
+            SequencedCommand::DurabilityFrontierUpdates(..) => {
+                self.durability_frontier_updates_int += 1
+            }
             SequencedCommand::AddSourceTimestamping { .. } => self.add_source_timestamping_int += 1,
             SequencedCommand::AdvanceSourceTimestamp { .. } => {
                 self.advance_source_timestamp_int += 1
@@ -233,6 +241,11 @@ impl CommandsProcessedMetrics {
             self.allow_compaction
                 .inc_by(self.allow_compaction_int as i64);
             self.allow_compaction_int = 0;
+        }
+        if self.durability_frontier_updates_int > 0 {
+            self.durability_frontier_updates
+                .inc_by(self.durability_frontier_updates_int as i64);
+            self.durability_frontier_updates_int = 0;
         }
         if self.add_source_timestamping_int > 0 {
             self.add_source_timestamping

--- a/src/expr/src/id.rs
+++ b/src/expr/src/id.rs
@@ -155,6 +155,20 @@ impl From<&PartitionId> for Option<String> {
     }
 }
 
+impl FromStr for PartitionId {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "none" => Ok(PartitionId::None),
+            s => {
+                let val: i32 = s.parse()?;
+                Ok(PartitionId::Kafka(val))
+            }
+        }
+    }
+}
+
 impl PartitionId {
     pub fn kafka_id(&self) -> Option<i32> {
         match self {

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1137,6 +1137,7 @@ pub fn plan_create_views(
 
 #[allow(clippy::too_many_arguments)]
 fn kafka_sink_builder(
+    scx: &StatementContext,
     format: Option<Format<Raw>>,
     with_options: &mut BTreeMap<String, Value>,
     broker: String,
@@ -1181,13 +1182,15 @@ fn kafka_sink_builder(
 
     let transitive_source_dependencies: Vec<_> = if exactly_once {
         for item in root_dependencies.iter() {
-            if item.item_type() == CatalogItemType::Source
-                && !item.source_connector()?.yields_stable_input()
-            {
-                bail!(
+            if item.item_type() == CatalogItemType::Source {
+                if !item.source_connector()?.yields_stable_input() {
+                    bail!(
                     "all input sources of an exactly-once Kafka sink must be replayable, {} is not",
                     item.name()
                 );
+                } else if !item.source_connector()?.is_byo() {
+                    scx.require_experimental_mode("Exactly-once sinks")?;
+                }
             } else if item.item_type() != CatalogItemType::Source {
                 bail!(
                     "all inputs of an exactly-once Kafka sink must be sources, {} is not",
@@ -1420,6 +1423,7 @@ pub fn plan_create_sink(
     let connector_builder = match connector {
         Connector::File { .. } => unsupported!("file sinks"),
         Connector::Kafka { broker, topic, .. } => kafka_sink_builder(
+            scx,
             format,
             &mut with_options,
             broker,

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1179,7 +1179,7 @@ fn kafka_sink_builder(
         bail!("exactly-once requires a consistency topic");
     }
 
-    if exactly_once {
+    let transitive_source_dependencies: Vec<_> = if exactly_once {
         for item in root_dependencies.iter() {
             if item.item_type() == CatalogItemType::Source
                 && !item.source_connector()?.yields_stable_input()
@@ -1195,7 +1195,11 @@ fn kafka_sink_builder(
                 );
             };
         }
-    }
+
+        root_dependencies.iter().map(|i| i.id()).collect()
+    } else {
+        Vec::new()
+    };
 
     let encoder = Encoder::new(
         key_desc_and_indices
@@ -1264,6 +1268,7 @@ fn kafka_sink_builder(
         key_desc_and_indices,
         value_desc,
         exactly_once,
+        transitive_source_dependencies,
     }))
 }
 

--- a/test/kafka-exactly-once/after-restart.td
+++ b/test/kafka-exactly-once/after-restart.td
@@ -106,3 +106,17 @@ $ kafka-verify format=avro sink=materialize.public.output sort-messages=true
 $ kafka-verify format=avro sink=materialize.public.output sort-messages=true
 {"before": null, "after": {"row": {"a": 4, "b": 1}}, "transaction": {"id": "4"}}
 {"before": null, "after": {"row": {"a": 5, "b": 2}}, "transaction": {"id": "4"}}
+
+> SELECT * FROM reingest_rt_sink
+a  b
+------
+1   1
+2   1
+3   1
+1   2
+11  11
+22  11
+3   4
+5   6
+4  1
+5  2

--- a/test/kafka-exactly-once/before-restart.td
+++ b/test/kafka-exactly-once/before-restart.td
@@ -68,6 +68,15 @@ $ kafka-create-topic topic=input-consistency
 
 $ kafka-create-topic topic=input
 
+> CREATE MATERIALIZED SOURCE input_rt
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
+
+> CREATE SINK output2 FROM input_rt
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-rt-sink-${testdrive.seed}'
+  WITH (exactly_once=true, consistency_topic='output-sink-consistency-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+
 > CREATE MATERIALIZED SOURCE input_byo
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-${testdrive.seed}'
     WITH (consistency_topic = 'testdrive-input-consistency-${testdrive.seed}')
@@ -120,6 +129,62 @@ $ kafka-verify format=avro sink=materialize.public.output sort-messages=true
 {"before": null, "after": {"row": {"a": 5, "b": 6}}, "transaction": {"id": "3"}}
 
 > SELECT * FROM input_byo
+a  b
+------
+1   1
+2   1
+3   1
+1   2
+11  11
+22  11
+3   4
+5   6
+
+$ set sink-schema={
+    "type": "record",
+    "name": "envelope",
+    "fields": [
+      {
+        "name": "before",
+        "type": [
+          "null",
+          {
+            "name": "row",
+            "type": "record",
+            "fields": [
+              {"name": "a", "type": "long"},
+              {"name": "b", "type": "long"}
+            ]
+          }
+        ]
+      },
+      { "name": "after", "type": ["null", "row"] },
+      {
+        "name": "transaction",
+        "type": {
+          "type": "record",
+          "name": "transaction",
+          "fields": [
+            {
+              "name": "id",
+              "type": "string"
+            }
+          ]
+        }
+      }
+    ]
+  }
+
+# Reingest the sink based on rt sources to confirm correct output.
+# TODO: it's brittle to hardcode the global id in the desired topic name like this
+# TODO: this needs to have deduplication='none' because the deduplication code expects
+# certain fields that the sink does not emit
+> CREATE MATERIALIZED SOURCE reingest_rt_sink
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-rt-sink-${testdrive.seed}-u3'
+  WITH (deduplication='none')
+  FORMAT AVRO USING SCHEMA '${sink-schema}' ENVELOPE DEBEZIUM
+
+> SELECT * FROM reingest_rt_sink
 a  b
 ------
 1   1

--- a/test/kafka-exactly-once/mzcompose.yml
+++ b/test/kafka-exactly-once/mzcompose.yml
@@ -77,6 +77,7 @@ services:
       -w1
       --disable-telemetry
       --logical-compaction-window=off
+      --experimental
     environment:
       - MZ_DEV=1
       - MZ_LOG=${MZ_LOG:-dataflow::sink::kafka=debug,dataflow::source::kafka=debug,coord::timestamp=debug,dataflow::source=debug,info}

--- a/test/testdrive/kafka-exactly-once-sink.td
+++ b/test/testdrive/kafka-exactly-once-sink.td
@@ -81,11 +81,10 @@ New York,NY,10004
   WITH (exactly_once=true, consistency_topic='output-view-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
-! CREATE SINK output2 FROM input_kafka_no_byo
+> CREATE SINK output2 FROM input_kafka_no_byo
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
   WITH (exactly_once=true, consistency_topic='output-view-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-all input sources of an exactly-once Kafka sink must be replayable, materialize.public.input_kafka_no_byo is not
 
 ! CREATE SINK output3 FROM input_table
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
@@ -103,17 +102,15 @@ all inputs of an exactly-once Kafka sink must be sources, materialize.public.inp
   WITH (exactly_once=true, consistency_topic='output-view-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
-! CREATE SINK output5 FROM input_kafka_no_byo_mview
+> CREATE SINK output5 FROM input_kafka_no_byo_mview
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
   WITH (exactly_once=true, consistency_topic='output-view-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-all input sources of an exactly-once Kafka sink must be replayable, materialize.public.input_kafka_no_byo is not
 
-! CREATE SINK output5_view FROM input_kafka_no_byo_mview_view
+> CREATE SINK output5_view FROM input_kafka_no_byo_mview_view
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
   WITH (exactly_once=true, consistency_topic='output-view-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-all input sources of an exactly-once Kafka sink must be replayable, materialize.public.input_kafka_no_byo is not
 
 ! CREATE SINK output6 FROM input_table_mview
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
@@ -133,32 +130,27 @@ all inputs of an exactly-once Kafka sink must be sources, materialize.public.inp
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 all inputs of an exactly-once Kafka sink must be sources, materialize.public.input_values_mview is not
 
-! CREATE SINK output9 FROM input_kafka_no_byo_join_view
+> CREATE SINK output9 FROM input_kafka_no_byo_join_view
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
   WITH (exactly_once=true, consistency_topic='output-view-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-all input sources of an exactly-once Kafka sink must be replayable, materialize.public.input_kafka_no_byo is not
 
-! CREATE SINK output9 FROM input_kafka_no_byo_join_mview
+> CREATE SINK output10 FROM input_kafka_no_byo_join_mview
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
   WITH (exactly_once=true, consistency_topic='output-view-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-all input sources of an exactly-once Kafka sink must be replayable, materialize.public.input_kafka_no_byo is not
 
-! CREATE SINK output9 FROM input_kafka_no_byo_scalar_subquery
+> CREATE SINK output11 FROM input_kafka_no_byo_scalar_subquery
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
   WITH (exactly_once=true, consistency_topic='output-view-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-all input sources of an exactly-once Kafka sink must be replayable, materialize.public.input_kafka_no_byo is not
 
-! CREATE SINK output9 FROM input_kafka_no_byo_derived_table
+> CREATE SINK output12 FROM input_kafka_no_byo_derived_table
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
   WITH (exactly_once=true, consistency_topic='output-view-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-all input sources of an exactly-once Kafka sink must be replayable, materialize.public.input_kafka_no_byo is not
 
-! CREATE SINK output9 FROM input_csv
+> CREATE SINK output13 FROM input_csv
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
   WITH (exactly_once=true, consistency_topic='output-view-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-all input sources of an exactly-once Kafka sink must be replayable, materialize.public.input_csv is not


### PR DESCRIPTION
this is RFAL. I've broken this up into 3 logical commits 

1. Teach coordinator to write down timestamp bindings that the dataflow workers send it and rehydrate on restart
2. Teach the coordinator to publish a "durability frontier" and teach sinks to wait for timestamps to become durable before writing data out
3. Teach sinks to emit a "what have I written" frontier and then teach coordinator to hold back in-memory and on disk of compaction for a sources ts bindings until all dependent sinks have done their writing + a smoke test

todos for me:

* change the durability frontier to be a MutableAntichain
* more documentation everywhere
* figure out why slt tests are timing out _only in slt_. I have been banging my head against that for a bit without any good leads. good leads very appreciated :D 