### PR TITLE
Build Mz with the nightly compiler in the Nightly build

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -7,6 +7,14 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+- id: build-nightly-compiler
+  label: ":docker: build with the Nightly compiler"
+  command: bin/ci-builder run nightly bin/pyactivate --dev -m ci.test.build
+  timeout_in_minutes: 30
+  agents:
+    queue: builder
+
+
 - id: sqlsmith
   label: SQLsmith fuzzing
   timeout_in_minutes: 240


### PR DESCRIPTION
Build the entire thing with the Nightly compiler. Previously only the ```repr``` crate was being built that way via the ```miri``` build step.

I am unable to run exactly the same setup in the branch, as Buildkite would not run the step even if I put it in the normal build pipeline, let alone the Nightly pipeline. So the only way to see what will happen is to merge this and wait for an actual Nightly run to occur.

My guess is that one of the several errors I saw locally will show up, but I am not sure which one. My bet is on:

```
error: custom inner attributes are unstable
 --> /home/pstoev/philip-stoev-code_coverage/target/x86_64-unknown-linux-gnu/release/build/billing-demo-7e82d8372796bdc1/out/protobuf/billing.rs:9:4
  |
9 | #![rustfmt::skip]
  |    ^^^^^^^^^^^^^
  |
  = note: `#[deny(soft_unstable)]` on by default
  = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
  = note: for more information, see issue #64266 <https://github.com/rust-lang/rust/issues/64266>
```

This is the first step in gettting a full-blown coverage build and test into Buildkite.