### PR TITLE
Merge nested joins behind filters

### DIFF
--- a/src/transform/src/fusion/join.rs
+++ b/src/transform/src/fusion/join.rs
@@ -50,133 +50,152 @@ impl Join {
         if let MirRelationExpr::Join {
             inputs,
             equivalences,
-            demand,
-            implementation,
+            ..
         } = relation
         {
-            let mut new_inputs = Vec::new();
-            let mut new_equivalences = Vec::new();
-            let mut new_columns = 0;
-            let mut new_filters = Vec::new();
+            let mut join_builder = JoinBuilder::new(equivalences);
 
             // We scan through each input, digesting any joins that we find and updating their equivalence classes.
             // We retain any existing equivalence classes, as they are already with respect to the cross product.
             for input in inputs.drain(..) {
-                if let MirRelationExpr::Join {
-                    mut inputs,
-                    mut equivalences,
-                    ..
-                } = input
-                {
-                    // Update and push all of the variables.
-                    for mut equivalence in equivalences.drain(..) {
-                        for expr in equivalence.iter_mut() {
-                            expr.visit_mut(&mut |e| {
-                                if let MirScalarExpr::Column(c) = e {
-                                    *c += new_columns;
-                                }
-                            });
-                        }
-                        new_equivalences.push(equivalence);
-                    }
-                    // Add all of the inputs.
-                    for input in inputs.drain(..) {
-                        new_columns += input.arity();
-                        new_inputs.push(input);
-                    }
-                } else if let MirRelationExpr::Filter {
-                    input,
-                    mut predicates,
-                } = input
-                {
-                    if let MirRelationExpr::Join {
-                        mut inputs,
-                        mut equivalences,
+                match input {
+                    MirRelationExpr::Join {
+                        inputs,
+                        equivalences,
                         ..
-                    } = *input
-                    {
-                        // Update and push all of the variables.
-                        for mut equivalence in equivalences.drain(..) {
-                            for expr in equivalence.iter_mut() {
-                                expr.visit_mut(&mut |e| {
-                                    if let MirScalarExpr::Column(c) = e {
-                                        *c += new_columns;
-                                    }
-                                });
-                            }
-                            new_equivalences.push(equivalence);
-                        }
-
-                        // Update and push all the filters
-                        for mut expr in predicates.drain(..) {
-                            expr.visit_mut(&mut |e| {
-                                if let MirScalarExpr::Column(c) = e {
-                                    *c += new_columns;
-                                }
-                            });
-                            new_filters.push(expr);
-                        }
-
-                        // Add all of the inputs.
-                        for input in inputs.drain(..) {
-                            new_columns += input.arity();
-                            new_inputs.push(input);
-                        }
-                    } else {
-                        let input = input.filter(predicates);
-                        new_columns += input.arity();
-                        new_inputs.push(input);
+                    } => {
+                        // Merge the inputs into the new join being built.
+                        join_builder.add_inputs(inputs, equivalences, None);
                     }
-                } else {
-                    // Retain the input.
-                    new_columns += input.arity();
-                    new_inputs.push(input);
+                    MirRelationExpr::Filter { input, predicates } => {
+                        if let MirRelationExpr::Join {
+                            inputs,
+                            equivalences,
+                            ..
+                        } = *input
+                        {
+                            // Merge the inputs and the predicates into the new join being built.
+                            join_builder.add_inputs(inputs, equivalences, Some(predicates));
+                        } else {
+                            // Retain the input.
+                            let input = input.filter(predicates);
+                            join_builder.add_input(input);
+                        }
+                    }
+                    _ => {
+                        // Retain the input.
+                        join_builder.add_input(input);
+                    }
                 }
             }
 
-            // Filter join identities out of the inputs.
-            // The join identity is a single 0-ary row constant expression.
-            new_inputs.retain(|input| {
-                if let MirRelationExpr::Constant {
-                    rows: Ok(rows),
-                    typ,
-                } = &input
-                {
-                    !(rows.len() == 1 && typ.column_types.len() == 0 && rows[0].1 == 1)
-                } else {
-                    true
-                }
-            });
+            *relation = join_builder.build();
+        }
+    }
+}
 
-            new_equivalences.extend(equivalences.drain(..));
-            expr::canonicalize::canonicalize_equivalences(&mut new_equivalences);
+/// Helper builder for fusing the inputs of nested joins into a single Join expression.
+struct JoinBuilder {
+    inputs: Vec<MirRelationExpr>,
+    equivalences: Vec<Vec<MirScalarExpr>>,
+    num_columns: usize,
+    /// Predicates that will be evaluated on top of the join, if any.
+    predicates: Vec<MirScalarExpr>,
+}
 
-            *inputs = new_inputs;
-            *equivalences = new_equivalences;
-            *demand = None;
-            *implementation = expr::JoinImplementation::Unimplemented;
+impl JoinBuilder {
+    fn new(equivalences: &mut Vec<Vec<MirScalarExpr>>) -> Self {
+        Self {
+            inputs: Vec::new(),
+            equivalences: equivalences.drain(..).collect(),
+            num_columns: 0,
+            predicates: Vec::new(),
+        }
+    }
 
-            // If `inputs` is now empty or a singleton (without constraints),
-            // we can remove the join.
-            match inputs.len() {
-                0 => {
-                    // The identity for join is the collection containing a single 0-ary row.
-                    *relation = MirRelationExpr::constant(vec![vec![]], RelationType::empty());
-                }
-                1 => {
-                    // if there are constraints, they probably should have
-                    // been pushed down by predicate pushdown, but .. let's
-                    // not re-write that code here.
-                    if equivalences.is_empty() {
-                        *relation = inputs.pop().unwrap();
+    fn add_input(&mut self, input: MirRelationExpr) {
+        self.num_columns += input.arity();
+        self.inputs.push(input);
+    }
+
+    fn add_inputs<I>(
+        &mut self,
+        inputs: I,
+        mut equivalences: Vec<Vec<MirScalarExpr>>,
+        predicates: Option<Vec<MirScalarExpr>>,
+    ) where
+        I: IntoIterator<Item = MirRelationExpr>,
+    {
+        // Update and push all of the variables.
+        for mut equivalence in equivalences.drain(..) {
+            for expr in equivalence.iter_mut() {
+                expr.visit_mut(&mut |e| {
+                    if let MirScalarExpr::Column(c) = e {
+                        *c += self.num_columns;
                     }
-                }
-                _ => {}
+                });
             }
+            self.equivalences.push(equivalence);
+        }
 
-            if !new_filters.is_empty() {
-                *relation = relation.take_dangerous().filter(new_filters);
+        if let Some(mut predicates) = predicates {
+            for mut expr in predicates.drain(..) {
+                expr.visit_mut(&mut |e| {
+                    if let MirScalarExpr::Column(c) = e {
+                        *c += self.num_columns;
+                    }
+                });
+                self.predicates.push(expr);
             }
         }
+
+        // Add all of the inputs.
+        for input in inputs {
+            self.add_input(input);
+        }
+    }
+
+    fn build(mut self) -> MirRelationExpr {
+        // Filter join identities out of the inputs.
+        // The join identity is a single 0-ary row constant expression.
+        self.inputs.retain(|input| {
+            if let MirRelationExpr::Constant {
+                rows: Ok(rows),
+                typ,
+            } = &input
+            {
+                !(rows.len() == 1 && typ.column_types.len() == 0 && rows[0].1 == 1)
+            } else {
+                true
+            }
+        });
+
+        expr::canonicalize::canonicalize_equivalences(&mut self.equivalences);
+
+        // If `inputs` is now empty or a singleton (without constraints),
+        // we can remove the join.
+        let mut join = match self.inputs.len() {
+            0 => {
+                // The identity for join is the collection containing a single 0-ary row.
+                MirRelationExpr::constant(vec![vec![]], RelationType::empty())
+            }
+            1 if self.equivalences.is_empty() => {
+                // if there are constraints, they probably should have
+                // been pushed down by predicate pushdown, but .. let's
+                // not re-write that code here.
+                self.inputs.pop().unwrap()
+            }
+            _ => MirRelationExpr::Join {
+                inputs: self.inputs,
+                equivalences: self.equivalences,
+                demand: None,
+                implementation: expr::JoinImplementation::Unimplemented,
+            },
+        };
+
+        if !self.predicates.is_empty() {
+            join = join.filter(self.predicates);
+        }
+        join
     }
 }

--- a/src/transform/src/fusion/join.rs
+++ b/src/transform/src/fusion/join.rs
@@ -65,7 +65,7 @@ impl Join {
                         ..
                     } => {
                         // Merge the inputs into the new join being built.
-                        join_builder.add_inputs(inputs, equivalences, None);
+                        join_builder.add_subjoin(inputs, equivalences, None);
                     }
                     MirRelationExpr::Filter { input, predicates } => {
                         if let MirRelationExpr::Join {
@@ -75,7 +75,7 @@ impl Join {
                         } = *input
                         {
                             // Merge the inputs and the predicates into the new join being built.
-                            join_builder.add_inputs(inputs, equivalences, Some(predicates));
+                            join_builder.add_subjoin(inputs, equivalences, Some(predicates));
                         } else {
                             // Retain the input.
                             let input = input.filter(predicates);
@@ -118,7 +118,7 @@ impl JoinBuilder {
         self.inputs.push(input);
     }
 
-    fn add_inputs<I>(
+    fn add_subjoin<I>(
         &mut self,
         inputs: I,
         mut equivalences: Vec<Vec<MirScalarExpr>>,

--- a/src/transform/src/fusion/join.rs
+++ b/src/transform/src/fusion/join.rs
@@ -28,6 +28,7 @@ use repr::RelationType;
 /// Fuses multiple `Join` operators into one `Join` operator.
 ///
 /// Removes unit collections from joins, and joins with fewer than two inputs.
+/// Filters on top of nested joins are lifted so the nested joins can be fused.
 #[derive(Debug)]
 pub struct Join;
 

--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -600,7 +600,7 @@ impl PredicatePushdown {
                     } else {
                         // Case 3: There are no literals in the equivalence
                         // class. Push a predicate for every pair of expressions
-                        // in the equivalence that etiher belong to a single
+                        // in the equivalence that either belong to a single
                         // input or can be localized to a given input through
                         // the rest of equivalences.
                         let mut to_remove = Vec::new();
@@ -686,7 +686,7 @@ impl PredicatePushdown {
                                     // The equivalence is either a single input one or fully localizable
                                     // to a single input through other equivalences, so it can be removed
                                     // completely without introducing any new cross join.
-                                    to_remove.extend(localized.iter().filter_map(|(pos, _)| *pos));
+                                    to_remove.extend(0..equivalences[equivalence_pos].len());
                                 } else {
                                     // Leave an expression from this input in the equivalence to avoid
                                     // cross joins

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -620,6 +620,7 @@ mod tests {
         match name {
             "ColumnKnowledge" => Ok(Box::new(transform::column_knowledge::ColumnKnowledge)),
             "Demand" => Ok(Box::new(transform::demand::Demand)),
+            "JoinFusion" => Ok(Box::new(transform::fusion::join::Join)),
             "LiteralLifting" => Ok(Box::new(transform::map_lifting::LiteralLifting)),
             "PredicatePushdown" => Ok(Box::new(transform::predicate_pushdown::PredicatePushdown)),
             "ProjectionExtraction" => Ok(Box::new(

--- a/src/transform/tests/testdata/join-fusion
+++ b/src/transform/tests/testdata/join-fusion
@@ -1,0 +1,72 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+cat
+(defsource x [int64 int64])
+----
+ok
+
+cat
+(defsource y [int64 int64])
+----
+ok
+
+build
+(join
+  [(get x)
+   (filter
+     (join [(get x) (get y)] [[#0 #2]])
+     [#1])]
+   [[#0 #2]])
+----
+----
+%0 =
+| Get x (u0)
+
+%1 =
+| Get x (u0)
+
+%2 =
+| Get y (u1)
+
+%3 =
+| Join %1 %2 (= #0 #2)
+| | implementation = Unimplemented
+| Filter #1
+
+%4 =
+| Join %0 %3 (= #0 #2)
+| | implementation = Unimplemented
+----
+----
+
+build apply=JoinFusion
+(join
+  [(get x)
+   (filter
+     (join [(get x) (get y)] [[#0 #2]])
+     [#1])]
+   [[#0 #2]])
+----
+----
+%0 =
+| Get x (u0)
+
+%1 =
+| Get x (u0)
+
+%2 =
+| Get y (u1)
+
+%3 =
+| Join %0 %1 %2 (= #0 #2 #4)
+| | implementation = Unimplemented
+| Filter #3
+----
+----

--- a/src/transform/tests/testdata/join-fusion
+++ b/src/transform/tests/testdata/join-fusion
@@ -70,3 +70,90 @@ build apply=JoinFusion
 | Filter #3
 ----
 ----
+
+build apply=JoinFusion
+(join
+  [(get x)
+   (filter
+     (get y)
+     [#1])]
+   [[#0 #2]])
+----
+----
+%0 =
+| Get x (u0)
+
+%1 =
+| Get y (u1)
+| Filter #1
+
+%2 =
+| Join %0 %1 (= #0 #2)
+| | implementation = Unimplemented
+----
+----
+
+# Check that filters around non-join operators are handled properly
+build apply=JoinFusion
+(join
+  [(get x)
+   (filter
+     (join [(get x) (get y)] [[#0 #2]])
+     [#1])
+   (filter
+     (get y)
+     [#1])]
+   [[#0 #2 #6]])
+----
+----
+%0 =
+| Get x (u0)
+
+%1 =
+| Get x (u0)
+
+%2 =
+| Get y (u1)
+
+%3 =
+| Get y (u1)
+| Filter #1
+
+%4 =
+| Join %0 %1 %2 %3 (= #0 #2 #4 #6)
+| | implementation = Unimplemented
+| Filter #3
+----
+----
+
+build apply=(JoinFusion,PredicatePushdown)
+(join
+  [(get x)
+   (filter
+     (join [(get x) (get y)] [[#0 #2]])
+     [#1])
+   (filter
+     (get y)
+     [#1])]
+   [[#0 #2 #6]])
+----
+----
+%0 =
+| Get x (u0)
+
+%1 =
+| Get x (u0)
+| Filter #1
+
+%2 =
+| Get y (u1)
+
+%3 =
+| Get y (u1)
+| Filter #1
+
+%4 =
+| Join %0 %1 %2 %3 (= #0 #2 #4 #6)
+| | implementation = Unimplemented
+----
+----

--- a/src/transform/tests/testdata/join-implementation
+++ b/src/transform/tests/testdata/join-implementation
@@ -39,14 +39,14 @@ opt
 ----
 %0 =
 | Get x (u0)
-| Filter ((isnull(#0) && isnull(#1)) || (#0 = #1)), ((isnull(#0) && isnull(#2)) || (#0 = #2))
+| Filter ((isnull(#0) && isnull(#1)) || (#0 = #1)), ((isnull(#0) && isnull(#2)) || (#0 = #2)), ((isnull(#1) && isnull(#2)) || (#1 = #2))
 
 opt
 (join [(get x)] [[#0 #2 #1 #2]])
 ----
 %0 =
 | Get x (u0)
-| Filter ((isnull(#0) && isnull(#1)) || (#0 = #1)), ((isnull(#0) && isnull(#2)) || (#0 = #2))
+| Filter ((isnull(#0) && isnull(#1)) || (#0 = #1)), ((isnull(#0) && isnull(#2)) || (#0 = #2)), ((isnull(#1) && isnull(#2)) || (#1 = #2))
 
 opt
 (join [(get x)] [[#0 #1 5]])

--- a/test/sqllogictest/transform/join_fusion.slt
+++ b/test/sqllogictest/transform/join_fusion.slt
@@ -201,6 +201,7 @@ EXPLAIN SELECT l_partkey AS col24843 , l_orderkey AS col24844 , l_partkey AS col
 ----
 %0 =
 | Get materialize.public.lineitem (u15)
+| Filter (#4 = (#4 % 500dec))
 | ArrangeBy ()
 
 %1 =
@@ -230,21 +231,21 @@ EXPLAIN SELECT *
 ----
 %0 =
 | Get materialize.public.lineitem (u15)
-| Filter !(isnull(datetots(#7)))
+| Filter !(isnull(datetots(#7))), (datetots(#7) = (#5 + 6 days))
 | ArrangeBy ()
 
 %1 =
 | Get materialize.public.orders (u11)
 | Filter (#1 = 229)
-| ArrangeBy (#2, #3, (#3 + 6 days))
+| ArrangeBy (#2, #3)
 
 %2 =
 | Get materialize.public.customer (u7)
 | Filter !(isnull(#0)), (#0 = 229)
 
 %3 =
-| Join %0 %1 %2 (= #4 #10) (= #5 #11) (= datetots(#7) (#11 + 6 days))
-| | implementation = Differential %2 %0.() %1.(#2, #3, (#3 + 6 days))
+| Join %0 %1 %2 (= #4 #10) (= #5 #11)
+| | implementation = Differential %2 %0.() %1.(#2, #3)
 | | demand = (#0..#9, #12..#14)
 | Project (#0..#9, #4, #5, #12..#14)
 

--- a/test/sqllogictest/transform/join_fusion.slt
+++ b/test/sqllogictest/transform/join_fusion.slt
@@ -1,0 +1,59 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+mode cockroach
+
+statement ok
+CREATE TABLE t1 (f1 integer, f2 integer)
+
+statement ok
+INSERT INTO t1 VALUES (1, 1), (2, 3), (4, 5);
+
+statement ok
+CREATE TABLE t2 (f1 integer, f2 integer)
+
+statement ok
+INSERT INTO t2 VALUES (2, 3), (5, 5);
+
+statement ok
+CREATE TABLE t3 (f1 integer, f2 integer)
+
+statement ok
+INSERT INTO t3 VALUES (2, 3), (5, 5);
+
+query T multiline
+EXPLAIN SELECT * FROM t1 INNER JOIN t2 ON t2.f2 = t1.f2 INNER JOIN t3 ON t1.f1 = t3.f1 WHERE t1.f1 <= t2.f1 AND t3.f1 > 0;
+----
+%0 =
+| Get materialize.public.t1 (u1)
+| Filter !(isnull(#0)), !(isnull(#1)), (#0 > 0)
+| ArrangeBy (#0)
+
+%1 =
+| Get materialize.public.t2 (u3)
+| Filter !(isnull(#1))
+| ArrangeBy (#1)
+
+%2 =
+| Get materialize.public.t3 (u5)
+| Filter !(isnull(#0)), (#0 > 0)
+
+%3 =
+| Join %0 %1 %2 (= #0 #4) (= #1 #3)
+| | implementation = Differential %2 %0.(#0) %1.(#1)
+| | demand = (#0..#2, #5)
+| Filter (#0 <= #2)
+| Project (#0..#2, #1, #0, #5)
+
+EOF
+
+query IIIIII
+SELECT * FROM t1 INNER JOIN t2 ON t2.f2 = t1.f2 INNER JOIN t3 ON t1.f1 = t3.f1 WHERE t1.f1 <= t2.f1 AND t3.f1 > 0;
+----
+2  3  2  3  2  3

--- a/test/sqllogictest/transform/join_fusion.slt
+++ b/test/sqllogictest/transform/join_fusion.slt
@@ -57,3 +57,219 @@ query IIIIII
 SELECT * FROM t1 INNER JOIN t2 ON t2.f2 = t1.f2 INNER JOIN t3 ON t1.f1 = t3.f1 WHERE t1.f1 <= t2.f1 AND t3.f1 > 0;
 ----
 2  3  2  3  2  3
+
+#
+# Additional queries that came out of the randomized testing of #6936
+#
+
+#
+# Randomized queries against a TPC-like schema
+#
+
+statement ok
+CREATE TABLE customer (c_custkey integer, c_nationkey integer NOT NULL, c_acctbal decimal(15, 2) NOT NULL);
+
+statement ok
+CREATE INDEX pk_customer_custkey ON customer (c_custkey);
+
+statement ok
+CREATE INDEX fk_customer_nationkey ON customer (c_nationkey ASC);
+
+statement ok
+CREATE TABLE orders (o_orderkey integer, o_custkey integer NOT NULL, o_totalprice decimal(15, 2) NOT NULL, o_orderdate DATE NOT NULL);
+
+statement ok
+CREATE INDEX pk_orders_orderkey ON orders (o_orderkey);
+
+statement ok
+CREATE INDEX fk_orders_custkey ON orders (o_custkey ASC);
+
+statement ok
+CREATE TABLE lineitem (l_orderkey integer NOT NULL, l_partkey integer NOT NULL, l_suppkey integer NOT NULL, l_linenumber integer NOT NULL, l_extendedprice decimal(15, 2) NOT NULL, l_shipdate date NOT NULL, l_commitdate date NOT NULL, l_receiptdate date NOT NULL);
+
+statement ok
+CREATE INDEX pk_lineitem_orderkey_linenumber ON lineitem (l_orderkey, l_linenumber);
+
+statement ok
+CREATE INDEX fk_lineitem_orderkey ON lineitem (l_orderkey ASC);
+
+statement ok
+CREATE INDEX fk_lineitem_partkey ON lineitem (l_partkey ASC);
+
+statement ok
+CREATE INDEX fk_lineitem_suppkey ON lineitem (l_suppkey ASC);
+
+statement ok
+CREATE INDEX fk_lineitem_partsuppkey ON lineitem (l_partkey ASC, l_suppkey ASC);
+
+query T multiline
+EXPLAIN SELECT * FROM lineitem
+  JOIN orders ON ( l_orderkey = o_orderkey )
+  JOIN customer ON ( c_acctbal >= o_totalprice )
+  WHERE l_shipDATE <> o_orderdate
+  AND o_orderdate = l_shipDATE - INTERVAL ' 9 MONTHS ';
+----
+%0 =
+| Get materialize.public.lineitem (u15)
+| ArrangeBy ()
+
+%1 =
+| Get materialize.public.orders (u11)
+| Filter !(isnull(#0)), !(isnull(datetots(#3)))
+| ArrangeBy (#0, datetots(#3))
+
+%2 =
+| Get materialize.public.customer (u7)
+
+%3 =
+| Join %0 %1 %2 (= #0 #8) (= datetots(#11) (#5 - 9 months))
+| | implementation = Differential %2 %0.() %1.(#0, datetots(#3))
+| | demand = (#0..#7, #9..#14)
+| Filter (#5 != #11), (#14 >= #10)
+| Project (#0..#7, #0, #9..#14)
+
+EOF
+
+query T multiline
+EXPLAIN SELECT  MIN( o_orderkey  )
+  FROM lineitem  JOIN orders  ON ( l_extendedprice  = o_totalprice  )
+  WHERE l_commitDATE  = '1997-01-25'
+  AND o_orderkey  BETWEEN  38  AND  195
+  AND o_orderdate  = l_commitDATE  + ' 7 MONTHS '
+  AND o_orderkey  = (  SELECT l_orderkey  FROM lineitem  WHERE l_orderkey  =  38  )
+----
+%0 = Let l0 =
+| Get materialize.public.lineitem (u15)
+| Filter (#0 = 38)
+
+%1 =
+| Get materialize.public.lineitem (u15)
+| Filter (#6 = 1997-01-25)
+| ArrangeBy (#4)
+
+%2 =
+| Get materialize.public.orders (u11)
+| ArrangeBy (#0)
+
+%3 =
+| Get %0 (l0)
+| Project (#0)
+
+%4 =
+| Get %0 (l0)
+| Reduce group=()
+| | agg count(true)
+| Filter (err: more than one record produced in subquery), (#0 > 1)
+| Map (err: more than one record produced in subquery)
+| Project (#1)
+
+%5 =
+| Union %3 %4
+
+%6 = Let l1 =
+| Join %1 %2 %5 (= #4 #10) (= #8 #12)
+| | implementation = Differential %5 %2.(#0) %1.(#4)
+| | demand = (#8, #11)
+| Filter !(isnull(datetots(#11))), (1997-08-25 00:00:00 = datetots(#11)), (#8 <= 195), (#8 >= 38)
+| Reduce group=()
+| | agg min(#8)
+
+%7 =
+| Get %6 (l1)
+| Negate
+| Project ()
+
+%8 =
+| Constant ()
+
+%9 =
+| Union %7 %8
+| Map null
+
+%10 =
+| Union %6 %9
+
+EOF
+
+query T multiline
+EXPLAIN SELECT l_partkey AS col24843 , l_orderkey AS col24844 , l_partkey AS col24845
+  FROM lineitem JOIN orders ON ( l_commitDATE = o_orderdate )
+  JOIN customer ON ( o_custkey = c_custkey )
+  WHERE l_extendedprice = o_totalprice
+  AND c_custkey = 134
+  AND l_extendedprice = MOD (o_totalprice , 5 ) ;
+----
+%0 =
+| Get materialize.public.lineitem (u15)
+| ArrangeBy ()
+
+%1 =
+| Get materialize.public.orders (u11)
+| Filter (#1 = 134), (#2 = (#2 % 500dec))
+| ArrangeBy (#2, #3)
+
+%2 =
+| Get materialize.public.customer (u7)
+| Filter !(isnull(#0)), (#0 = 134)
+
+%3 =
+| Join %0 %1 %2 (= #4 #10) (= #6 #11)
+| | implementation = Differential %2 %0.() %1.(#2, #3)
+| | demand = (#0, #1)
+| Project (#1, #0, #1)
+
+EOF
+
+query T multiline
+EXPLAIN SELECT *
+  FROM lineitem JOIN orders ON ( l_extendedprice = o_totalprice )
+  JOIN customer ON ( o_custkey = c_custkey )
+  WHERE o_custkey = 229
+  AND l_receiptDATE = o_orderdate + INTERVAL ' 6 DAYS '
+  AND l_shipDATE = o_orderdate;
+----
+%0 =
+| Get materialize.public.lineitem (u15)
+| Filter !(isnull(datetots(#7)))
+| ArrangeBy ()
+
+%1 =
+| Get materialize.public.orders (u11)
+| Filter (#1 = 229)
+| ArrangeBy (#2, #3, (#3 + 6 days))
+
+%2 =
+| Get materialize.public.customer (u7)
+| Filter !(isnull(#0)), (#0 = 229)
+
+%3 =
+| Join %0 %1 %2 (= #4 #10) (= #5 #11) (= datetots(#7) (#11 + 6 days))
+| | implementation = Differential %2 %0.() %1.(#2, #3, (#3 + 6 days))
+| | demand = (#0..#9, #12..#14)
+| Project (#0..#9, #4, #5, #12..#14)
+
+EOF
+
+#
+# Randomized queries against the "simple" schema
+#
+
+query T multiline
+EXPLAIN SELECT * FROM t1 AS a1, t1 AS a2
+WHERE a2.f1 + a1.f2 = (SELECT 1)
+AND a2.f1 IS NULL;
+----
+%0 =
+| Get materialize.public.t1 (u1)
+| ArrangeBy ()
+
+%1 =
+| Get materialize.public.t1 (u1)
+| Filter isnull(#0)
+
+%2 =
+| Join %0 %1 (= 1 (#2 + #1))
+| | implementation = Differential %1 %0.()
+| | demand = (#0..#3)
+
+EOF

--- a/test/sqllogictest/transform/predicate_pushdown.slt
+++ b/test/sqllogictest/transform/predicate_pushdown.slt
@@ -129,3 +129,33 @@ SELECT a FROM (SELECT DISTINCT a FROM x UNION ALL SELECT a FROM y) WHERE a = 3
 | Union %0 %1
 
 EOF
+
+statement ok
+CREATE TABLE t1 (f1 integer, f2 integer)
+
+statement ok
+CREATE TABLE t2 (f1 integer, f2 integer)
+
+# redundant equivalence is pushed down to all join branches and removed
+query T multiline
+EXPLAIN
+SELECT * FROM t1, t2 WHERE t1.f1 = t2.f1 AND t1.f2 = t2.f2 AND t1.f1 + t2.f2 = t2.f1 + t1.f2;
+----
+%0 =
+| Get materialize.public.t1 (u5)
+| ArrangeBy (#0, #1)
+
+%1 =
+| Get materialize.public.t2 (u7)
+| ArrangeBy (#0, #1)
+
+%2 =
+| Join %0 %1 (= #0 #2) (= #1 #3)
+| | implementation = DeltaQuery
+| |   delta %0 %1.(#0, #1)
+| |   delta %1 %0.(#0, #1)
+| | demand = (#0, #1)
+| Filter !(isnull(#0)), !(isnull(#1))
+| Project (#0, #1, #0, #1)
+
+EOF


### PR DESCRIPTION
Fuse nested joins with a filter operator on top, by moving the filters on top of the new join.

Fixes #6933.