### PR TITLE
Mark temporal filters as stabilized (non-experimental)

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -76,6 +76,8 @@ Wrap your release notes at the 80 character mark.
 
 - Support [equality operators](/sql/functions/#boolean) on
   [array data](/sql/types/array).
+  
+- Stabilized temporal filters (no longer require `--experimental`)
 
 {{% version-header v0.7.2 %}}
 

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -76,7 +76,7 @@ Wrap your release notes at the 80 character mark.
 
 - Support [equality operators](/sql/functions/#boolean) on
   [array data](/sql/types/array).
-  
+
 - Stabilized temporal filters (no longer require `--experimental`)
 
 {{% version-header v0.7.2 %}}


### PR DESCRIPTION
Tiny change (asked by community user), but I don't think we've announced graduated features in the past, so I'm not entirely sure if this is best practice