### PR TITLE
mzcompose: add code coverage feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,5 @@ __pycache__
 .mypy_cache
 venv
 node_modules
+coverage
 **/*.swp

--- a/bin/xcompile
+++ b/bin/xcompile
@@ -67,6 +67,8 @@ do_cargo() {
         # Otherwise, build inside the CI builder image, unless we're already
         # inside of it.
         command+=("$root"/bin/ci-builder run stable env "RUSTFLAGS=${XCOMPILE_RUSTFLAGS:-}")
+    else
+        export RUSTFLAGS=${XCOMPILE_RUSTFLAGS:-}
     fi
 
     subcommand="$1"

--- a/ci/nightly/coverage.py
+++ b/ci/nightly/coverage.py
@@ -1,0 +1,68 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""Generator for the test CI pipeline.
+
+This script takes pipeline.template.yml as input, possibly trims out jobs
+whose inputs have not changed relative to the code on main, and uploads the
+resulting pipeline to the Buildkite job that triggers this script.
+
+On main and tags, all jobs are always run.
+
+For details about how steps are trimmed, see the comment at the top of
+pipeline.template.yml and the docstring on `trim_pipeline` below.
+"""
+
+from pathlib import Path
+import yaml
+import sys
+
+import materialize.cli.mzcompose
+
+
+def main() -> int:
+    with open(Path(__file__).parent.parent / "test" / "pipeline.template.yml") as f:
+        pipeline = yaml.safe_load(f)
+
+    tests = []
+
+    for step in pipeline["steps"]:
+        for plugin in step.get("plugins", []):
+            for plugin_name, plugin_config in plugin.items():
+                if plugin_name == "./ci/plugins/mzcompose":
+                    tests.append((plugin_config["composition"], plugin_config["run"]))
+
+    for (composition, workflow) in tests:
+        print(f"==> Running workflow {workflow} in {composition}")
+        materialize.cli.mzcompose.main(
+            [
+                "run",
+                workflow,
+                "--mz-coverage",
+                "--mz-find",
+                composition,
+            ]
+        )
+        materialize.cli.mzcompose.main(
+            [
+                "down",
+                "-v",
+                "--mz-coverage",
+                "--mz-find",
+                composition,
+            ]
+        )
+
+    # TODO: gather and combine coverage information.
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -7,6 +7,11 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+- id: coverage
+  label: Code coverage
+  timeout_in_minutes: 240
+  command: bin/ci-builder run nightly bin/pyactivate --dev -m ci.nightly.coverage
+
 - id: sqlsmith
   label: SQLsmith fuzzing
   timeout_in_minutes: 240

--- a/ci/test/cargo-test/mzcompose.yml
+++ b/ci/test/cargo-test/mzcompose.yml
@@ -32,7 +32,7 @@ services:
   zookeeper:
     image: confluentinc/cp-zookeeper:5.5.4
     environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
+    - ZOOKEEPER_CLIENT_PORT=2181
   kafka:
     image: confluentinc/cp-kafka:5.5.4
     environment:

--- a/demo/billing/mzcompose.yml
+++ b/demo/billing/mzcompose.yml
@@ -28,19 +28,19 @@ services:
   zookeeper:
     image: confluentinc/cp-zookeeper:5.5.4
     environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
+    - ZOOKEEPER_CLIENT_PORT=2181
   kafka:
     image: confluentinc/cp-enterprise-kafka:5.5.4
     ports:
       - *kafka
     depends_on: [zookeeper]
     environment:
-      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
-      KAFKA_BROKER_ID: 1
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_JMX_PORT: 9991
-      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
+    - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+    - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092
+    - KAFKA_BROKER_ID=1
+    - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+    - KAFKA_JMX_PORT=9991
+    - KAFKA_AUTO_CREATE_TOPICS_ENABLE=false
   schema-registry:
     image: confluentinc/cp-schema-registry:5.5.4
     ports:

--- a/demo/chbench/mzcompose.yml
+++ b/demo/chbench/mzcompose.yml
@@ -97,7 +97,7 @@ services:
   zookeeper:
     image: confluentinc/cp-zookeeper:5.5.4
     environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
+    - ZOOKEEPER_CLIENT_PORT=2181
     volumes:
       - ${MZ_CHBENCH_SNAPSHOT_ZK_DATA:-zk-data}:/var/lib/zookeeper
   kafka:
@@ -107,33 +107,33 @@ services:
       - *kafka-external
     depends_on: [zookeeper]
     environment:
-      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,EXTERNAL://0.0.0.0:9093
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,EXTERNAL://${KAFKA_HOST:-kafka}:9093
-      KAFKA_METRIC_REPORTERS: "io.confluent.metrics.reporter.ConfluentMetricsReporter"
-      KAFKA_BROKER_ID: 1
-      KAFKA_LOG_RETENTION_HOURS: -1
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      #KAFKA_LOG_CLEANUP_POLICY: "compact"
-      CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS: "kafka:9092"
-      CONFLUENT_METRICS_REPORTER_TOPIC_REPLICAS: 1
-      # To avoid race condition with control-center
-      CONFLUENT_METRICS_REPORTER_TOPIC_CREATE: "false"
-      KAFKA_JMX_PORT: 9991
+    - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+    - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
+    - KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:9092,EXTERNAL://0.0.0.0:9093
+    - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092,EXTERNAL://${KAFKA_HOST:-kafka}:9093
+    - KAFKA_METRIC_REPORTERS="io.confluent.metrics.reporter.ConfluentMetricsReporter"
+    - KAFKA_BROKER_ID=1
+    - KAFKA_LOG_RETENTION_HOURS=-1
+    - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+    - #KAFKA_LOG_CLEANUP_POLICY="compact"
+    - CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS=kafka:9092
+    - CONFLUENT_METRICS_REPORTER_TOPIC_REPLICAS=1
+    - #=o avoid race condition with control-center
+    - CONFLUENT_METRICS_REPORTER_TOPIC_CREATE="false"
+    - KAFKA_JMX_PORT=9991
     volumes:
       - ${MZ_CHBENCH_SNAPSHOT_KAFKA_DATA:-kafka-data}:/var/lib/kafka/data
   connect:
     image: debezium/connect:1.4
     environment:
-      BOOTSTRAP_SERVERS: kafka:9092
-      GROUP_ID: 1
-      CONFIG_STORAGE_TOPIC: connect_configs
-      OFFSET_STORAGE_TOPIC: connect_offsets
-      KEY_CONVERTER: io.confluent.connect.avro.AvroConverter
-      VALUE_CONVERTER: io.confluent.connect.avro.AvroConverter
-      CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL: http://schema-registry:8081
-      CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL: http://schema-registry:8081
+    - BOOTSTRAP_SERVERS=kafka:9092
+    - GROUP_ID=1
+    - CONFIG_STORAGE_TOPIC=connect_configs
+    - OFFSET_STORAGE_TOPIC=connect_offsets
+    - KEY_CONVERTER=io.confluent.connect.avro.AvroConverter
+    - VALUE_CONVERTER=io.confluent.connect.avro.AvroConverter
+    - CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL=http://schema-registry:8081
+    - CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL=http://schema-registry:8081
     depends_on: [kafka, schema-registry]
   schema-registry:
     image: confluentinc/cp-schema-registry:5.5.4
@@ -157,20 +157,20 @@ services:
     ports:
       - *control-center
     environment:
-      CONTROL_CENTER_BOOTSTRAP_SERVERS: "kafka:9092"
-      CONTROL_CENTER_ZOOKEEPER_CONNECT: "zookeeper:2181"
-      CONTROL_CENTER_REPLICATION_FACTOR: 1
-      CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_REPLICATION: 1
-      CONTROL_CENTER_INTERNAL_TOPICS_REPLICATION: 1
-      CONTROL_CENTER_COMMAND_TOPIC_REPLICATION: 1
-      CONTROL_CENTER_METRICS_TOPIC_REPLICATION: 1
-      CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_PARTITIONS: 1
-      CONTROL_CENTER_INTERNAL_TOPICS_PARTITIONS: 1
-      CONTROL_CENTER_METRICS_TOPIC_PARTITIONS: 1
-      CONTROL_CENTER_STREAMS_NUM_STREAM_THREADS: 1
-      CONTROL_CENTER_CONNECT_CLUSTER: "http://connect:8083"
-      CONTROL_CENTER_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
-      CONTROL_CENTER_DEPRECATED_VIEWS_ENABLE: "true"
+    - CONTROL_CENTER_BOOTSTRAP_SERVERS=kafka:9092
+    - CONTROL_CENTER_ZOOKEEPER_CONNECT=zookeeper:2181
+    - CONTROL_CENTER_REPLICATION_FACTOR=1
+    - CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_REPLICATION=1
+    - CONTROL_CENTER_INTERNAL_TOPICS_REPLICATION=1
+    - CONTROL_CENTER_COMMAND_TOPIC_REPLICATION=1
+    - CONTROL_CENTER_METRICS_TOPIC_REPLICATION=1
+    - CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_PARTITIONS=1
+    - CONTROL_CENTER_INTERNAL_TOPICS_PARTITIONS=1
+    - CONTROL_CENTER_METRICS_TOPIC_PARTITIONS=1
+    - CONTROL_CENTER_STREAMS_NUM_STREAM_THREADS=1
+    - CONTROL_CENTER_CONNECT_CLUSTER=http://connect:8083
+    - CONTROL_CENTER_SCHEMA_REGISTRY_URL=http://schema-registry:8081
+    - CONTROL_CENTER_DEPRECATED_VIEWS_ENABLE=true
   chbench:
     init: true
     mzbuild: chbenchmark
@@ -212,7 +212,7 @@ services:
     mzbuild: dashboard
     propagate-uid-gid: true
     environment:
-      - 'MATERIALIZED_URL=materialized:6875'
+    - MATERIALIZED_URL=materialized:6875
     ports:
       - *grafana
       - *prometheus
@@ -245,10 +245,10 @@ services:
       - ${MZ_SQL_EXPORTER_PORT:-9399}
   peeker:
     environment:
-      KAFKA_HOST: ${KAFKA_HOST:-kafka}
-      KAFKA_EXTERNAL_PORT: ${KAFKA_EXTERNAL_PORT:-9092}
-      SR_HOST: ${SR_HOST:-schema-registry}
-      OLAP_THREADS: ${OLAP_THREADS:-1}
+    - KAFKA_HOST=${KAFKA_HOST:-kafka}
+    - KAFKA_EXTERNAL_PORT=${KAFKA_EXTERNAL_PORT:-9092}
+    - SR_HOST=${SR_HOST:-schema-registry}
+    - OLAP_THREADS=${OLAP_THREADS:-1}
     # NOTE: we really don't want to include depends_on, it causes dependencies to be restarted
     mzbuild: peeker
     init: true

--- a/demo/debezium/mzcompose.yml
+++ b/demo/debezium/mzcompose.yml
@@ -62,7 +62,7 @@ services:
   zookeeper:
     image: confluentinc/cp-zookeeper:5.5.4
     environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
+    - ZOOKEEPER_CLIENT_PORT=2181
     volumes:
       - zookeeper:/var/lib/zookeeper
   kafka:
@@ -72,20 +72,18 @@ services:
       - *kafka-external
     depends_on: [zookeeper]
     environment:
-      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,EXTERNAL://0.0.0.0:9093
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,EXTERNAL://${KAFKA_HOST:-kafka}:9093
-      KAFKA_METRIC_REPORTERS: "io.confluent.metrics.reporter.ConfluentMetricsReporter"
-      KAFKA_BROKER_ID: 1
-      KAFKA_LOG_RETENTION_HOURS: -1
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      #KAFKA_LOG_CLEANUP_POLICY: "compact"
-      CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS: "kafka:9092"
-      CONFLUENT_METRICS_REPORTER_TOPIC_REPLICAS: 1
-      # To avoid race condition with control-center
-      CONFLUENT_METRICS_REPORTER_TOPIC_CREATE: "false"
-      KAFKA_JMX_PORT: 9991
+    - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+    - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
+    - KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:9092,EXTERNAL://0.0.0.0:9093
+    - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092,EXTERNAL://${KAFKA_HOST:-kafka}:9093
+    - KAFKA_METRIC_REPORTERS="io.confluent.metrics.reporter.ConfluentMetricsReporter"
+    - KAFKA_BROKER_ID=1
+    - KAFKA_LOG_RETENTION_HOURS=-1
+    - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+    - CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS=kafka:9092
+    - CONFLUENT_METRICS_REPORTER_TOPIC_REPLICAS=1
+    - CONFLUENT_METRICS_REPORTER_TOPIC_CREATE=false
+    - KAFKA_JMX_PORT=9991
     volumes:
       - kafka:/var/lib/kafka/data
   connect:
@@ -93,16 +91,16 @@ services:
     ports:
       - *connect
     environment:
-      BOOTSTRAP_SERVERS: kafka:9092
-      CONFIG_STORAGE_TOPIC: connect_configs
-      OFFSET_STORAGE_TOPIC: connect_offsets
-      STATUS_STORAGE_TOPIC: connect_statuses
+      - BOOTSTRAP_SERVERS=kafka:9092
+      - CONFIG_STORAGE_TOPIC=connect_configs
+      - OFFSET_STORAGE_TOPIC=connect_offsets
+      - STATUS_STORAGE_TOPIC=connect_statuses
       # We don't support JSON, so ensure that connect uses AVRO to encode messages and CSR to
       # record the schema
-      KEY_CONVERTER: io.confluent.connect.avro.AvroConverter
-      VALUE_CONVERTER: io.confluent.connect.avro.AvroConverter
-      CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL: http://schema-registry:8081
-      CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL: http://schema-registry:8081
+      - KEY_CONVERTER=io.confluent.connect.avro.AvroConverter
+      - VALUE_CONVERTER=io.confluent.connect.avro.AvroConverter
+      - CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL=http://schema-registry:8081
+      - CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL=http://schema-registry:8081
     depends_on: [kafka, schema-registry]
   debezium-mysql-gen:
     mzbuild: debezium-mysql-gen
@@ -127,20 +125,20 @@ services:
     ports:
       - *control-center
     environment:
-      CONTROL_CENTER_BOOTSTRAP_SERVERS: "kafka:9092"
-      CONTROL_CENTER_ZOOKEEPER_CONNECT: "zookeeper:2181"
-      CONTROL_CENTER_REPLICATION_FACTOR: 1
-      CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_REPLICATION: 1
-      CONTROL_CENTER_INTERNAL_TOPICS_REPLICATION: 1
-      CONTROL_CENTER_COMMAND_TOPIC_REPLICATION: 1
-      CONTROL_CENTER_METRICS_TOPIC_REPLICATION: 1
-      CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_PARTITIONS: 1
-      CONTROL_CENTER_INTERNAL_TOPICS_PARTITIONS: 1
-      CONTROL_CENTER_METRICS_TOPIC_PARTITIONS: 1
-      CONTROL_CENTER_STREAMS_NUM_STREAM_THREADS: 1
-      CONTROL_CENTER_CONNECT_CLUSTER: "http://connect:8083"
-      CONTROL_CENTER_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
-      CONTROL_CENTER_DEPRECATED_VIEWS_ENABLE: "true"
+      - CONTROL_CENTER_BOOTSTRAP_SERVERS=kafka:9092
+      - CONTROL_CENTER_ZOOKEEPER_CONNECT=zookeeper:2181
+      - CONTROL_CENTER_REPLICATION_FACTOR=1
+      - CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_REPLICATION=1
+      - CONTROL_CENTER_INTERNAL_TOPICS_REPLICATION=1
+      - CONTROL_CENTER_COMMAND_TOPIC_REPLICATION=1
+      - CONTROL_CENTER_METRICS_TOPIC_REPLICATION=1
+      - CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_PARTITIONS=1
+      - CONTROL_CENTER_INTERNAL_TOPICS_PARTITIONS=1
+      - CONTROL_CENTER_METRICS_TOPIC_PARTITIONS=1
+      - CONTROL_CENTER_STREAMS_NUM_STREAM_THREADS=1
+      - CONTROL_CENTER_CONNECT_CLUSTER=http://connect:8083
+      - CONTROL_CENTER_SCHEMA_REGISTRY_URL=http://schema-registry:8081
+      - CONTROL_CENTER_DEPRECATED_VIEWS_ENABLE=true
 
 
 volumes:

--- a/demo/simple/mzcompose.yml
+++ b/demo/simple/mzcompose.yml
@@ -36,27 +36,27 @@ services:
   zookeeper:
     image: confluentinc/cp-zookeeper:5.5.4
     environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
+    - ZOOKEEPER_CLIENT_PORT=2181
   kafka:
     image: confluentinc/cp-enterprise-kafka:5.5.4
     depends_on: [zookeeper]
     environment:
-      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
-      KAFKA_BROKER_ID: 1
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_JMX_PORT: 9991
+    - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+    - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092
+    - KAFKA_BROKER_ID=1
+    - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+    - KAFKA_JMX_PORT=9991
   connect:
     image: debezium/connect:1.4
     environment:
-      BOOTSTRAP_SERVERS: kafka:9092
-      GROUP_ID: 1
-      CONFIG_STORAGE_TOPIC: connect_configs
-      OFFSET_STORAGE_TOPIC: connect_offsets
-      KEY_CONVERTER: io.confluent.connect.avro.AvroConverter
-      VALUE_CONVERTER: io.confluent.connect.avro.AvroConverter
-      CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL: http://schema-registry:8081
-      CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL: http://schema-registry:8081
+    - BOOTSTRAP_SERVERS=kafka:9092
+    - GROUP_ID=1
+    - CONFIG_STORAGE_TOPIC=connect_configs
+    - OFFSET_STORAGE_TOPIC=connect_offsets
+    - KEY_CONVERTER=io.confluent.connect.avro.AvroConverter
+    - VALUE_CONVERTER=io.confluent.connect.avro.AvroConverter
+    - CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL=http://schema-registry:8081
+    - CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL=http://schema-registry:8081
     depends_on: [kafka]
   schema-registry:
     image: confluentinc/cp-schema-registry:5.5.4

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -87,12 +87,15 @@ class RepositoryDetails:
     Attributes:
         root: The path to the root of the repository.
         release_mode: Whether the repository is being built in release mode.
+        coverage: Whether the repository has code coverage instrumentation
+            enabled.
         cargo_workspace: The `cargo.Workspace` associated with the repository.
     """
 
-    def __init__(self, root: Path, release_mode: bool):
+    def __init__(self, root: Path, release_mode: bool, coverage: bool):
         self.root = root
         self.release_mode = release_mode
+        self.coverage = coverage
         self.cargo_workspace = cargo.Workspace(root)
 
     def xcargo(self) -> str:
@@ -210,8 +213,15 @@ class CargoPreImage(PreImage):
         }
 
     def extra(self) -> str:
-        # Cargo images depend on the release mode.
-        return str(self.rd.release_mode)
+        # Cargo images depend on the release mode and whether coverage is
+        # enabled.
+        flags: List[str] = []
+        if self.rd.release_mode:
+            flags += "release"
+        if self.rd.coverage:
+            flags += "coverage"
+        flags.sort()
+        return ",".join(flags)
 
 
 class CargoBuild(CargoPreImage):
@@ -223,6 +233,13 @@ class CargoBuild(CargoPreImage):
         self.strip = config.pop("strip", True)
         self.extract = config.pop("extract", {})
         self.rustflags = config.pop("rustflags", "")
+        if rd.coverage:
+            self.rustflags += " -Zinstrument-coverage"
+            # Nix generates some unresolved symbols that -Zinstrument-coverage
+            # somehow causes the linker to complain about, so just disable
+            # warnings about unresolved symbols and hope it all works out.
+            # See: https://github.com/nix-rust/nix/issues/1116
+            self.rustflags += " -Clink-arg=-Wl,--warn-unresolved-symbols"
         if self.bin is None:
             raise ValueError("mzbuild config is missing pre-build target")
 
@@ -689,14 +706,16 @@ class Repository:
 
     Args:
         root: The path to the root of the repository.
+        release_mode: Whether to build the repository in release mode.
+        coverage: Whether to enable code coverage instrumentation.
 
     Attributes:
         images: A mapping from image name to `Image` for all contained images.
         compose_dirs: The set of directories containing an `mzcompose.yml` file.
     """
 
-    def __init__(self, root: Path, release_mode: bool = True):
-        self.rd = RepositoryDetails(root, release_mode)
+    def __init__(self, root: Path, release_mode: bool = True, coverage: bool = False):
+        self.rd = RepositoryDetails(root, release_mode, coverage)
         self.images: Dict[str, Image] = {}
         self.compositions: Dict[str, Path] = {}
         for (path, dirs, files) in os.walk(self.root, topdown=True):

--- a/misc/python/materialize/mzcompose.py
+++ b/misc/python/materialize/mzcompose.py
@@ -97,6 +97,13 @@ def lint_composition(path: Path, composition: Any, errors: List[LintError]) -> N
         elif "mzbuild" not in service and "image" in service:
             lint_image_name(path, service["image"], errors)
 
+        if isinstance(service.get("environment"), dict):
+            errors.append(
+                LintError(
+                    path, f"environment for service {name} uses dict instead of list"
+                )
+            )
+
 
 def lint_image_name(path: Path, spec: str, errors: List[LintError]) -> None:
     match = re.search(r"((?P<repo>[^/]+)/)?(?P<image>[^:]+)(:(?P<tag>.*))?", spec)

--- a/play/mbta/mzcompose.yml
+++ b/play/mbta/mzcompose.yml
@@ -25,18 +25,18 @@ services:
   zookeeper:
     image: confluentinc/cp-zookeeper:5.5.4
     environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
+    - ZOOKEEPER_CLIENT_PORT=2181
   kafka:
     image: confluentinc/cp-enterprise-kafka:5.5.4
     ports:
       - *kafka
     depends_on: [zookeeper]
     environment:
-      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:${KAFKA_PORT:-9092}
-      KAFKA_BROKER_ID: 1
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_JMX_PORT: 9991
+    - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+    - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:${KAFKA_PORT:-9092}
+    - KAFKA_BROKER_ID=1
+    - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+    - KAFKA_JMX_PORT=9991
   mbta-demo:
     mzbuild: mbta-demo
     volumes:

--- a/test/bench/aggregations/mzcompose.yml
+++ b/test/bench/aggregations/mzcompose.yml
@@ -68,7 +68,7 @@ services:
   zookeeper:
     image: confluentinc/cp-zookeeper:5.5.4
     environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
+      - ZOOKEEPER_CLIENT_PORT=2181
   kafka:
     image: confluentinc/cp-enterprise-kafka:5.5.4
     ports:
@@ -76,21 +76,19 @@ services:
       - *kafka-external
     depends_on: [zookeeper]
     environment:
-      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,EXTERNAL://0.0.0.0:9093
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,EXTERNAL://${KAFKA_HOST:-kafka}:9093
-      KAFKA_METRIC_REPORTERS: "io.confluent.metrics.reporter.ConfluentMetricsReporter"
-      KAFKA_BROKER_ID: 1
-      KAFKA_LOG_RETENTION_HOURS: -1
-      KAFKA_NUM_PARTITIONS: 30
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      #KAFKA_LOG_CLEANUP_POLICY: "compact"
-      CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS: "kafka:9092"
-      CONFLUENT_METRICS_REPORTER_TOPIC_REPLICAS: 1
-      # To avoid race condition with control-center
-      CONFLUENT_METRICS_REPORTER_TOPIC_CREATE: "false"
-      KAFKA_JMX_PORT: 9991
+      - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
+      - KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:9092,EXTERNAL://0.0.0.0:9093
+      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092,EXTERNAL://${KAFKA_HOST:-kafka}:9093
+      - KAFKA_METRIC_REPORTERS="io.confluent.metrics.reporter.ConfluentMetricsReporter"
+      - KAFKA_BROKER_ID=1
+      - KAFKA_LOG_RETENTION_HOURS=-1
+      - KAFKA_NUM_PARTITIONS=30
+      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+      - CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS=kafka:9092
+      - CONFLUENT_METRICS_REPORTER_TOPIC_REPLICAS=1
+      - CONFLUENT_METRICS_REPORTER_TOPIC_CREATE="false"
+      - KAFKA_JMX_PORT=9991
   schema-registry:
     image: confluentinc/cp-schema-registry:5.5.4
     ports:
@@ -105,9 +103,9 @@ services:
   metric-verifier:
     mzbuild: metric-verifier
     environment:
-      MZ_WORKERS: ${MZ_WORKERS:-0}
-      MZBENCH_GIT_REF: ${MZBENCH_GIT_REF:-None}
-      MZBENCH_ID: ${MZBENCH_ID:-0}
+      - MZ_WORKERS=${MZ_WORKERS:-0}
+      - MZBENCH_GIT_REF=${MZBENCH_GIT_REF:-None}
+      - MZBENCH_ID=${MZBENCH_ID:-0}
   # All monitoring
   dashboard:
     mzbuild: dashboard

--- a/test/bench/avro-insert/mzcompose.yml
+++ b/test/bench/avro-insert/mzcompose.yml
@@ -68,7 +68,7 @@ services:
   zookeeper:
     image: confluentinc/cp-zookeeper:5.5.4
     environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
+      - ZOOKEEPER_CLIENT_PORT=2181
   kafka:
     image: confluentinc/cp-enterprise-kafka:5.5.4
     ports:
@@ -76,21 +76,19 @@ services:
       - *kafka-external
     depends_on: [zookeeper]
     environment:
-      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,EXTERNAL://0.0.0.0:9093
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,EXTERNAL://${KAFKA_HOST:-kafka}:9093
-      KAFKA_METRIC_REPORTERS: "io.confluent.metrics.reporter.ConfluentMetricsReporter"
-      KAFKA_BROKER_ID: 1
-      KAFKA_LOG_RETENTION_HOURS: -1
-      KAFKA_NUM_PARTITIONS: 30
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      #KAFKA_LOG_CLEANUP_POLICY: "compact"
-      CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS: "kafka:9092"
-      CONFLUENT_METRICS_REPORTER_TOPIC_REPLICAS: 1
-      # To avoid race condition with control-center
-      CONFLUENT_METRICS_REPORTER_TOPIC_CREATE: "false"
-      KAFKA_JMX_PORT: 9991
+      - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
+      - KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:9092,EXTERNAL://0.0.0.0:9093
+      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092,EXTERNAL://${KAFKA_HOST:-kafka}:9093
+      - KAFKA_METRIC_REPORTERS="io.confluent.metrics.reporter.ConfluentMetricsReporter"
+      - KAFKA_BROKER_ID=1
+      - KAFKA_LOG_RETENTION_HOURS=-1
+      - KAFKA_NUM_PARTITIONS=30
+      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+      - CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS=kafka:9092
+      - CONFLUENT_METRICS_REPORTER_TOPIC_REPLICAS=1
+      - CONFLUENT_METRICS_REPORTER_TOPIC_CREATE="false"
+      - KAFKA_JMX_PORT=9991
   schema-registry:
     image: confluentinc/cp-schema-registry:5.5.4
     ports:
@@ -105,9 +103,9 @@ services:
   metric-verifier:
     mzbuild: metric-verifier
     environment:
-      MZ_WORKERS: ${MZ_WORKERS:-0}
-      MZBENCH_GIT_REF: ${MZBENCH_GIT_REF:-None}
-      MZBENCH_ID: ${MZBENCH_ID:-0}
+      - MZ_WORKERS=${MZ_WORKERS:-0}
+      - MZBENCH_GIT_REF=${MZBENCH_GIT_REF:-None}
+      - MZBENCH_ID=${MZBENCH_ID:-0}
   # All monitoring
   dashboard:
     mzbuild: dashboard

--- a/test/bench/avro-upsert/mzcompose.yml
+++ b/test/bench/avro-upsert/mzcompose.yml
@@ -68,7 +68,7 @@ services:
   zookeeper:
     image: confluentinc/cp-zookeeper:5.5.4
     environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
+      - ZOOKEEPER_CLIENT_PORT=2181
   kafka:
     image: confluentinc/cp-enterprise-kafka:5.5.4
     ports:
@@ -76,21 +76,19 @@ services:
       - *kafka-external
     depends_on: [zookeeper]
     environment:
-      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,EXTERNAL://0.0.0.0:9093
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,EXTERNAL://${KAFKA_HOST:-kafka}:9093
-      KAFKA_METRIC_REPORTERS: "io.confluent.metrics.reporter.ConfluentMetricsReporter"
-      KAFKA_BROKER_ID: 1
-      KAFKA_LOG_RETENTION_HOURS: -1
-      KAFKA_NUM_PARTITIONS: 30
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      #KAFKA_LOG_CLEANUP_POLICY: "compact"
-      CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS: "kafka:9092"
-      CONFLUENT_METRICS_REPORTER_TOPIC_REPLICAS: 1
-      # To avoid race condition with control-center
-      CONFLUENT_METRICS_REPORTER_TOPIC_CREATE: "false"
-      KAFKA_JMX_PORT: 9991
+      - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
+      - KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:9092,EXTERNAL://0.0.0.0:9093
+      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092,EXTERNAL://${KAFKA_HOST:-kafka}:9093
+      - KAFKA_METRIC_REPORTERS="io.confluent.metrics.reporter.ConfluentMetricsReporter"
+      - KAFKA_BROKER_ID=1
+      - KAFKA_LOG_RETENTION_HOURS=-1
+      - KAFKA_NUM_PARTITIONS=30
+      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+      - CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS=kafka:9092
+      - CONFLUENT_METRICS_REPORTER_TOPIC_REPLICAS=1
+      - CONFLUENT_METRICS_REPORTER_TOPIC_CREATE=false
+      - KAFKA_JMX_PORT=9991
   schema-registry:
     image: confluentinc/cp-schema-registry:5.5.4
     ports:
@@ -105,9 +103,9 @@ services:
   metric-verifier:
     mzbuild: metric-verifier
     environment:
-      MZ_WORKERS: ${MZ_WORKERS:-0}
-      MZBENCH_GIT_REF: ${MZBENCH_GIT_REF:-None}
-      MZBENCH_ID: ${MZBENCH_ID:-0}
+      - MZ_WORKERS=${MZ_WORKERS:-0}
+      - MZBENCH_GIT_REF=${MZBENCH_GIT_REF:-None}
+      - MZBENCH_ID=${MZBENCH_ID:-0}
   # All monitoring
   dashboard:
     mzbuild: dashboard

--- a/test/bench/kafka-sink-avro-debezium/mzcompose.yml
+++ b/test/bench/kafka-sink-avro-debezium/mzcompose.yml
@@ -62,7 +62,7 @@ services:
   zookeeper:
     image: confluentinc/cp-zookeeper:5.5.4
     environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
+      - ZOOKEEPER_CLIENT_PORT=2181
   kafka:
     image: confluentinc/cp-enterprise-kafka:5.5.4
     ports:
@@ -70,21 +70,19 @@ services:
       - *kafka-external
     depends_on: [zookeeper]
     environment:
-      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,EXTERNAL://0.0.0.0:9093
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,EXTERNAL://${KAFKA_HOST:-kafka}:9093
-      KAFKA_METRIC_REPORTERS: "io.confluent.metrics.reporter.ConfluentMetricsReporter"
-      KAFKA_BROKER_ID: 1
-      KAFKA_LOG_RETENTION_HOURS: -1
-      KAFKA_NUM_PARTITIONS: 1
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      #KAFKA_LOG_CLEANUP_POLICY: "compact"
-      CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS: "kafka:9092"
-      CONFLUENT_METRICS_REPORTER_TOPIC_REPLICAS: 1
-      # To avoid race condition with control-center
-      CONFLUENT_METRICS_REPORTER_TOPIC_CREATE: "false"
-      KAFKA_JMX_PORT: 9991
+      - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
+      - KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:9092,EXTERNAL://0.0.0.0:9093
+      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092,EXTERNAL://${KAFKA_HOST:-kafka}:9093
+      - KAFKA_METRIC_REPORTERS="io.confluent.metrics.reporter.ConfluentMetricsReporter"
+      - KAFKA_BROKER_ID=1
+      - KAFKA_LOG_RETENTION_HOURS=-1
+      - KAFKA_NUM_PARTITIONS=1
+      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+      - CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS=kafka:9092
+      - CONFLUENT_METRICS_REPORTER_TOPIC_REPLICAS=1
+      - CONFLUENT_METRICS_REPORTER_TOPIC_CREATE="false"
+      - KAFKA_JMX_PORT=9991
   schema-registry:
     image: confluentinc/cp-schema-registry:5.5.4
     ports:
@@ -99,9 +97,9 @@ services:
   metric-verifier:
     mzbuild: metric-verifier
     environment:
-      MZ_WORKERS: ${MZ_WORKERS:-0}
-      MZBENCH_GIT_REF: ${MZBENCH_GIT_REF:-None}
-      MZBENCH_ID: ${MZBENCH_ID:-0}
+    - MZ_WORKERS=${MZ_WORKERS:-0}
+    - MZBENCH_GIT_REF=${MZBENCH_GIT_REF:-None}
+    - MZBENCH_ID=${MZBENCH_ID:-0}
   # All monitoring
   dashboard:
     mzbuild: dashboard

--- a/test/catalog-compat/mzcompose.yml
+++ b/test/catalog-compat/mzcompose.yml
@@ -15,7 +15,7 @@ services:
   zookeeper:
     image: confluentinc/cp-zookeeper:5.5.4
     environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
+    - ZOOKEEPER_CLIENT_PORT=2181
   kafka:
     image: confluentinc/cp-kafka:5.5.4
     environment:

--- a/test/chaos/mzcompose.yml
+++ b/test/chaos/mzcompose.yml
@@ -40,7 +40,7 @@ services:
   zookeeper:
     image: confluentinc/cp-zookeeper:5.5.4
     environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
+      - ZOOKEEPER_CLIENT_PORT=2181
     cap_add:
       - NET_ADMIN
 
@@ -50,11 +50,11 @@ services:
       - *kafka
     depends_on: [zookeeper]
     environment:
-      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
-      KAFKA_BROKER_ID: 1
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_JMX_PORT: 9991
+      - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092
+      - KAFKA_BROKER_ID=1
+      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+      - KAFKA_JMX_PORT=9991
     cap_add:
       - NET_ADMIN
 
@@ -75,14 +75,14 @@ services:
     ports:
       - *connect
     environment:
-      BOOTSTRAP_SERVERS: kafka:9092
-      GROUP_ID: 1
-      CONFIG_STORAGE_TOPIC: connect_configs
-      OFFSET_STORAGE_TOPIC: connect_offsets
-      KEY_CONVERTER: io.confluent.connect.avro.AvroConverter
-      VALUE_CONVERTER: io.confluent.connect.avro.AvroConverter
-      CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL: http://schema-registry:8081
-      CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL: http://schema-registry:8081
+      - BOOTSTRAP_SERVERS=kafka:9092
+      - GROUP_ID=1
+      - CONFIG_STORAGE_TOPIC=connect_configs
+      - OFFSET_STORAGE_TOPIC=connect_offsets
+      - KEY_CONVERTER=io.confluent.connect.avro.AvroConverter
+      - VALUE_CONVERTER=io.confluent.connect.avro.AvroConverter
+      - CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL=http://schema-registry:8081
+      - CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL=http://schema-registry:8081
     depends_on: [kafka, schema-registry]
     cap_add:
       - NET_ADMIN

--- a/test/debezium-avro/mzcompose.yml
+++ b/test/debezium-avro/mzcompose.yml
@@ -97,7 +97,7 @@ services:
   zookeeper:
     image: confluentinc/cp-zookeeper:5.5.4
     environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
+      - ZOOKEEPER_CLIENT_PORT=2181
   kafka:
     image: confluentinc/cp-kafka:5.5.4
     environment:
@@ -122,16 +122,16 @@ services:
     ports:
       - 8083
     environment:
-      BOOTSTRAP_SERVERS: kafka:9092
-      CONFIG_STORAGE_TOPIC: connect_configs
-      OFFSET_STORAGE_TOPIC: connect_offsets
-      STATUS_STORAGE_TOPIC: connect_statuses
-      # We don't support JSON, so ensure that connect uses AVRO to encode messages and CSR to
-      # record the schema
-      KEY_CONVERTER: io.confluent.connect.avro.AvroConverter
-      VALUE_CONVERTER: io.confluent.connect.avro.AvroConverter
-      CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL: http://schema-registry:8081
-      CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL: http://schema-registry:8081
+    - BOOTSTRAP_SERVERS=kafka:9092
+    - CONFIG_STORAGE_TOPIC=connect_configs
+    - OFFSET_STORAGE_TOPIC=connect_offsets
+    - STATUS_STORAGE_TOPIC=connect_statuses
+    # We don't support JSON, so ensure that connect uses AVRO to encode messages and CSR to
+    # record the schema
+    - KEY_CONVERTER=io.confluent.connect.avro.AvroConverter
+    - VALUE_CONVERTER=io.confluent.connect.avro.AvroConverter
+    - CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL=http://schema-registry:8081
+    - CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL=http://schema-registry:8081
     depends_on: [kafka, schema-registry]
 
 volumes:

--- a/test/kafka-exactly-once/mzcompose.yml
+++ b/test/kafka-exactly-once/mzcompose.yml
@@ -88,7 +88,7 @@ services:
   zookeeper:
     image: confluentinc/cp-zookeeper:$KAFKA_VERSION
     environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
+      - ZOOKEEPER_CLIENT_PORT=2181
 
   kafka:
     image: confluentinc/cp-kafka:$KAFKA_VERSION

--- a/test/kafka-krb5/mzcompose.yml
+++ b/test/kafka-krb5/mzcompose.yml
@@ -27,15 +27,10 @@ services:
       - ./kdc/krb5.conf:/etc/krb5.conf
       - ./sasl.jaas.config:/etc/zookeeper/sasl.jaas.config
     environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
+      - ZOOKEEPER_CLIENT_PORT=2181
       # Despite the environment variable name, these are JVM options that are
       # passed through to Zookeeper.
-      KAFKA_OPTS: >-
-        -Dzookeeper.authProvider.1=org.apache.zookeeper.server.auth.SASLAuthenticationProvider
-        -Dzookeeper.sessionRequireClientSASLAuth=true
-        -Djava.security.auth.login.config=/etc/zookeeper/sasl.jaas.config
-        -Djava.security.krb5.conf=/etc/krb5.conf
-        -Dsun.security.krb5.debug=true
+      - KAFKA_OPTS=-Dzookeeper.authProvider.1=org.apache.zookeeper.server.auth.SASLAuthenticationProvider -Dzookeeper.sessionRequireClientSASLAuth=true -Djava.security.auth.login.config=/etc/zookeeper/sasl.jaas.config -Djava.security.krb5.conf=/etc/krb5.conf -Dsun.security.krb5.debug=true
 
   kafka:
     image: confluentinc/cp-kafka:5.5.4
@@ -47,31 +42,24 @@ services:
       - ./kdc/krb5.conf:/etc/krb5.conf
       - ./sasl.jaas.config:/etc/kafka/sasl.jaas.config
     environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_ADVERTISED_LISTENERS: SASL_PLAINTEXT://kafka:9092
-      KAFKA_INTER_BROKER_LISTENER_NAME: SASL_PLAINTEXT
-      KAFKA_SASL_KERBEROS_SERVICE_NAME: kafka
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_OPTS: >-
-        -Dzookeeper.sasl.client.canonicalize.hostname=false
-        -Djava.security.auth.login.config=/etc/kafka/sasl.jaas.config
-        -Djava.security.krb5.conf=/etc/krb5.conf
+      - KAFKA_BROKER_ID=1
+      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+      - KAFKA_ADVERTISED_LISTENERS=SASL_PLAINTEXT://kafka:9092
+      - KAFKA_INTER_BROKER_LISTENER_NAME=SASL_PLAINTEXT
+      - KAFKA_SASL_KERBEROS_SERVICE_NAME=kafka
+      - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+      - KAFKA_OPTS=-Dzookeeper.sasl.client.canonicalize.hostname=false -Djava.security.auth.login.config=/etc/kafka/sasl.jaas.config -Djava.security.krb5.conf=/etc/krb5.conf
 
   schema-registry:
     image: confluentinc/cp-schema-registry:5.5.4
     environment:
-      SCHEMA_REGISTRY_HOST_NAME: schema-registry
-      SCHEMA_REGISTRY_LISTENERS: "http://0.0.0.0:8081"
-      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: SASL_PLAINTEXT://kafka:9092
-      SCHEMA_REGISTRY_KAFKASTORE_SASL_KERBEROS_SERVICE_NAME: kafka
-      SCHEMA_REGISTRY_KAFKASTORE_SECURITY_PROTOCOL: SASL_PLAINTEXT
-      KAFKA_OPTS: >-
-        -Djava.security.auth.login.config=/etc/kafka/sasl.jaas.config
-        -Djava.security.krb5.conf=/etc/krb5.conf
-      SCHEMA_REGISTRY_OPTS: >-
-        -Djava.security.auth.login.config=/etc/kafka/sasl.jaas.config
-        -Djava.security.krb5.conf=/etc/krb5.conf
+      - SCHEMA_REGISTRY_HOST_NAME=schema-registry
+      - SCHEMA_REGISTRY_LISTENERS=http://0.0.0.0:8081
+      - SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=SASL_PLAINTEXT://kafka:9092
+      - SCHEMA_REGISTRY_KAFKASTORE_SASL_KERBEROS_SERVICE_NAME=kafka
+      - SCHEMA_REGISTRY_KAFKASTORE_SECURITY_PROTOCOL=SASL_PLAINTEXT
+      - KAFKA_OPTS=-Djava.security.auth.login.config=/etc/kafka/sasl.jaas.config -Djava.security.krb5.conf=/etc/krb5.conf
+      - SCHEMA_REGISTRY_OPTS=-Djava.security.auth.login.config=/etc/kafka/sasl.jaas.config -Djava.security.krb5.conf=/etc/krb5.conf
     volumes:
       - secrets:/var/lib/secret
       - ./kdc/krb5.conf:/etc/krb5.conf

--- a/test/kafka-matrix/mzcompose.yml
+++ b/test/kafka-matrix/mzcompose.yml
@@ -129,7 +129,7 @@ services:
   zookeeper:
     image: confluentinc/cp-zookeeper:$KAFKA_VERSION
     environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
+    - ZOOKEEPER_CLIENT_PORT=2181
   kafka:
     image: confluentinc/cp-kafka:$KAFKA_VERSION
     environment:

--- a/test/kafka-multi-broker/mzcompose.yml
+++ b/test/kafka-multi-broker/mzcompose.yml
@@ -79,8 +79,8 @@ services:
   zookeeper:
     image: confluentinc/cp-zookeeper:5.5.4
     environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOO_TICK_TIME: 500
+      - ZOOKEEPER_CLIENT_PORT=2181
+      - ZOO_TICK_TIME=500
 
   schema-registry:
     image: confluentinc/cp-schema-registry:5.5.4
@@ -93,11 +93,11 @@ services:
     image: confluentinc/cp-kafka:5.5.4
     hostname: kafka1
     environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_ADVERTISED_HOST_NAME: kafka1
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka1:9092
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 2
+      - KAFKA_BROKER_ID=1
+      - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+      - KAFKA_ADVERTISED_HOST_NAME=kafka1
+      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka1:9092
+      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=2
     depends_on: [zookeeper]
     ports: [9092]
 
@@ -105,11 +105,11 @@ services:
     image: confluentinc/cp-kafka:5.5.4
     hostname: kafka2
     environment:
-      KAFKA_BROKER_ID: 2
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_ADVERTISED_HOST_NAME: kafka2
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka2:9092
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 2
+      - KAFKA_BROKER_ID=2
+      - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+      - KAFKA_ADVERTISED_HOST_NAME=kafka2
+      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka2:9092
+      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=2
     depends_on: [zookeeper]
     ports: [9092]
 
@@ -117,10 +117,10 @@ services:
     image: confluentinc/cp-kafka:5.5.4
     hostname: kafka3
     environment:
-      KAFKA_BROKER_ID: 3
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_ADVERTISED_HOST_NAME: kafka3
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka3:9092
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 2
+      - KAFKA_BROKER_ID=3
+      - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+      - KAFKA_ADVERTISED_HOST_NAME=kafka3
+      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka3:9092
+      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=2
     depends_on: [zookeeper]
     ports: [9092]

--- a/test/kafka-sasl-plain/mzcompose.yml
+++ b/test/kafka-sasl-plain/mzcompose.yml
@@ -56,33 +56,29 @@ services:
   zookeeper:
     image: confluentinc/cp-zookeeper:5.5.4
     environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
+      - ZOOKEEPER_CLIENT_PORT=2181
       # Despite the environment variable name, these are JVM options that are
       # passed through to Zookeeper.
-      KAFKA_OPTS: >-
-        -Dzookeeper.authProvider.1=org.apache.zookeeper.server.auth.SASLAuthenticationProvider
-        -Dzookeeper.sessionRequireClientSASLAuth=true
-        -Djava.security.auth.login.config=/etc/zookeeper/sasl.jaas.config
+      - KAFKA_OPTS=-Dzookeeper.authProvider.1=org.apache.zookeeper.server.auth.SASLAuthenticationProvider -Dzookeeper.sessionRequireClientSASLAuth=true -Djava.security.auth.login.config=/etc/zookeeper/sasl.jaas.config
     volumes:
       - ./sasl.jaas.config:/etc/zookeeper/sasl.jaas.config
   kafka:
     image: confluentinc/cp-kafka:5.5.4
     environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_ADVERTISED_LISTENERS: SASL_SSL://kafka:9092
-      KAFKA_SASL_ENABLED_MECHANISMS: PLAIN
-      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: PLAIN
-      KAFKA_SSL_KEYSTORE_FILENAME: kafka.keystore.jks
-      KAFKA_SSL_KEYSTORE_CREDENTIALS: cert_creds
-      KAFKA_SSL_KEY_CREDENTIALS: cert_creds
-      KAFKA_SSL_TRUSTSTORE_FILENAME: kafka.truststore.jks
-      KAFKA_SSL_TRUSTSTORE_CREDENTIALS: cert_creds
-      KAFKA_SSL_CLIENT_AUTH: required
-      KAFKA_SECURITY_INTER_BROKER_PROTOCOL: SASL_SSL
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_OPTS: >-
-        -Djava.security.auth.login.config=/etc/kafka/sasl.jaas.config
+      - KAFKA_BROKER_ID=1
+      - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+      - KAFKA_ADVERTISED_LISTENERS=SASL_SSL://kafka:9092
+      - KAFKA_SASL_ENABLED_MECHANISMS=PLAIN
+      - KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL=PLAIN
+      - KAFKA_SSL_KEYSTORE_FILENAME=kafka.keystore.jks
+      - KAFKA_SSL_KEYSTORE_CREDENTIALS=cert_creds
+      - KAFKA_SSL_KEY_CREDENTIALS=cert_creds
+      - KAFKA_SSL_TRUSTSTORE_FILENAME=kafka.truststore.jks
+      - KAFKA_SSL_TRUSTSTORE_CREDENTIALS=cert_creds
+      - KAFKA_SSL_CLIENT_AUTH=required
+      - KAFKA_SECURITY_INTER_BROKER_PROTOCOL=SASL_SSL
+      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+      - KAFKA_OPTS=-Djava.security.auth.login.config=/etc/kafka/sasl.jaas.config
     volumes:
       - secrets:/etc/kafka/secrets
       - ./sasl.jaas.config:/etc/kafka/sasl.jaas.config
@@ -90,30 +86,28 @@ services:
   schema-registry:
     image: confluentinc/cp-schema-registry:5.5.4
     environment:
-      SCHEMA_REGISTRY_HOST_NAME: schema-registry
-      SCHEMA_REGISTRY_LISTENERS: "https://0.0.0.0:8081"
-      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: SASL_SSL://kafka:9092
-      SCHEMA_REGISTRY_KAFKASTORE_SASL_MECHANISM: PLAIN
-      SCHEMA_REGISTRY_KAFKASTORE_SECURITY_PROTOCOL: SASL_SSL
-      SCHEMA_REGISTRY_KAFKASTORE_SSL_KEY_PASSWORD: mzmzmz
-      SCHEMA_REGISTRY_KAFKASTORE_SSL_KEYSTORE_LOCATION: /etc/schema-registry/secrets/schema-registry.keystore.jks
-      SCHEMA_REGISTRY_KAFKASTORE_SSL_KEYSTORE_PASSWORD: mzmzmz
-      SCHEMA_REGISTRY_KAFKASTORE_SSL_TRUSTSTORE_LOCATION: /etc/schema-registry/secrets/schema-registry.truststore.jks
-      SCHEMA_REGISTRY_KAFKASTORE_SSL_TRUSTSTORE_PASSWORD: mzmzmz
-      SCHEMA_REGISTRY_SSL_KEY_PASSWORD: mzmzmz
-      SCHEMA_REGISTRY_SSL_KEYSTORE_LOCATION: /etc/schema-registry/secrets/schema-registry.keystore.jks
-      SCHEMA_REGISTRY_SSL_KEYSTORE_PASSWORD: mzmzmz
-      SCHEMA_REGISTRY_KAFKASTORE_SSL_KEY_PASSWORD: mzmzmz
-      SCHEMA_REGISTRY_KAFKASTORE_SSL_KEYSTORE_LOCATION: /etc/schema-registry/secrets/schema-registry.keystore.jks
-      SCHEMA_REGISTRY_KAFKASTORE_SSL_KEYSTORE_PASSWORD: mzmzmz
-      SCHEMA_REGISTRY_INTER_INSTANCE_PROTOCOL: https
-      SCHEMA_REGISTRY_AUTHENTICATION_METHOD: BASIC
-      SCHEMA_REGISTRY_AUTHENTICATION_ROLES: user
-      SCHEMA_REGISTRY_AUTHENTICATION_REALM: SchemaRegistry
-      KAFKA_OPTS: >-
-        -Djava.security.auth.login.config=/etc/schema-registry/sasl.jaas.config
-      SCHEMA_REGISTRY_OPTS: >-
-        -Djava.security.auth.login.config=/etc/schema-registry/sasl.jaas.config
+    - SCHEMA_REGISTRY_HOST_NAME=schema-registry
+    - SCHEMA_REGISTRY_LISTENERS="https://0.0.0.0:8081"
+    - SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=SASL_SSL://kafka:9092
+    - SCHEMA_REGISTRY_KAFKASTORE_SASL_MECHANISM=PLAIN
+    - SCHEMA_REGISTRY_KAFKASTORE_SECURITY_PROTOCOL=SASL_SSL
+    - SCHEMA_REGISTRY_KAFKASTORE_SSL_KEY_PASSWORD=mzmzmz
+    - SCHEMA_REGISTRY_KAFKASTORE_SSL_KEYSTORE_LOCATION=/etc/schema-registry/secrets/schema-registry.keystore.jks
+    - SCHEMA_REGISTRY_KAFKASTORE_SSL_KEYSTORE_PASSWORD=mzmzmz
+    - SCHEMA_REGISTRY_KAFKASTORE_SSL_TRUSTSTORE_LOCATION=/etc/schema-registry/secrets/schema-registry.truststore.jks
+    - SCHEMA_REGISTRY_KAFKASTORE_SSL_TRUSTSTORE_PASSWORD=mzmzmz
+    - SCHEMA_REGISTRY_SSL_KEY_PASSWORD=mzmzmz
+    - SCHEMA_REGISTRY_SSL_KEYSTORE_LOCATION=/etc/schema-registry/secrets/schema-registry.keystore.jks
+    - SCHEMA_REGISTRY_SSL_KEYSTORE_PASSWORD=mzmzmz
+    - SCHEMA_REGISTRY_KAFKASTORE_SSL_KEY_PASSWORD=mzmzmz
+    - SCHEMA_REGISTRY_KAFKASTORE_SSL_KEYSTORE_LOCATION=/etc/schema-registry/secrets/schema-registry.keystore.jks
+    - SCHEMA_REGISTRY_KAFKASTORE_SSL_KEYSTORE_PASSWORD=mzmzmz
+    - SCHEMA_REGISTRY_INTER_INSTANCE_PROTOCOL=https
+    - SCHEMA_REGISTRY_AUTHENTICATION_METHOD=BASIC
+    - SCHEMA_REGISTRY_AUTHENTICATION_ROLES=user
+    - SCHEMA_REGISTRY_AUTHENTICATION_REALM=SchemaRegistry
+    - KAFKA_OPTS=-Djava.security.auth.login.config=/etc/schema-registry/sasl.jaas.config
+    - SCHEMA_REGISTRY_OPTS=-Djava.security.auth.login.config=/etc/schema-registry/sasl.jaas.config
     volumes:
       - secrets:/etc/schema-registry/secrets
       - ./sasl.jaas.config:/etc/schema-registry/sasl.jaas.config

--- a/test/kafka-ssl/mzcompose.yml
+++ b/test/kafka-ssl/mzcompose.yml
@@ -52,44 +52,44 @@ services:
   zookeeper:
     image: confluentinc/cp-zookeeper:5.5.4
     environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
+    - ZOOKEEPER_CLIENT_PORT=2181
   kafka:
     image: confluentinc/cp-kafka:5.5.4
     environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_ADVERTISED_LISTENERS: SSL://kafka:9092
-      KAFKA_SSL_KEYSTORE_FILENAME: kafka.keystore.jks
-      KAFKA_SSL_KEYSTORE_CREDENTIALS: cert_creds
-      KAFKA_SSL_KEY_CREDENTIALS: cert_creds
-      KAFKA_SSL_TRUSTSTORE_FILENAME: kafka.truststore.jks
-      KAFKA_SSL_TRUSTSTORE_CREDENTIALS: cert_creds
-      KAFKA_SSL_CLIENT_AUTH: required
-      KAFKA_SECURITY_INTER_BROKER_PROTOCOL: SSL
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+    - KAFKA_BROKER_ID=1
+    - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+    - KAFKA_ADVERTISED_LISTENERS=SSL://kafka:9092
+    - KAFKA_SSL_KEYSTORE_FILENAME=kafka.keystore.jks
+    - KAFKA_SSL_KEYSTORE_CREDENTIALS=cert_creds
+    - KAFKA_SSL_KEY_CREDENTIALS=cert_creds
+    - KAFKA_SSL_TRUSTSTORE_FILENAME=kafka.truststore.jks
+    - KAFKA_SSL_TRUSTSTORE_CREDENTIALS=cert_creds
+    - KAFKA_SSL_CLIENT_AUTH=required
+    - KAFKA_SECURITY_INTER_BROKER_PROTOCOL=SSL
+    - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
     volumes:
       - secrets:/etc/kafka/secrets
     depends_on: [zookeeper, test-certs]
   schema-registry:
     image: confluentinc/cp-schema-registry:5.5.4
     environment:
-      SCHEMA_REGISTRY_HOST_NAME: schema-registry
-      SCHEMA_REGISTRY_LISTENERS: "https://0.0.0.0:8081"
-      SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: zookeeper:2181
-      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: SSL://kafka:9092
-      SCHEMA_REGISTRY_KAFKASTORE_SECURITY_PROTOCOL: SSL
-      SCHEMA_REGISTRY_KAFKASTORE_SSL_KEYSTORE_LOCATION: /etc/schema-registry/secrets/schema-registry.keystore.jks
-      SCHEMA_REGISTRY_SSL_KEYSTORE_LOCATION: /etc/schema-registry/secrets/schema-registry.keystore.jks
-      SCHEMA_REGISTRY_KAFKASTORE_SSL_KEYSTORE_PASSWORD: mzmzmz
-      SCHEMA_REGISTRY_SSL_KEYSTORE_PASSWORD: mzmzmz
-      SCHEMA_REGISTRY_KAFKASTORE_SSL_KEY_PASSWORD: mzmzmz
-      SCHEMA_REGISTRY_SSL_KEY_PASSWORD: mzmzmz
-      SCHEMA_REGISTRY_KAFKASTORE_SSL_TRUSTSTORE_LOCATION: /etc/schema-registry/secrets/schema-registry.truststore.jks
-      SCHEMA_REGISTRY_SSL_TRUSTSTORE_LOCATION: /etc/schema-registry/secrets/schema-registry.truststore.jks
-      SCHEMA_REGISTRY_KAFKASTORE_SSL_TRUSTSTORE_PASSWORD: mzmzmz
-      SCHEMA_REGISTRY_SSL_TRUSTSTORE_PASSWORD: mzmzmz
-      SCHEMA_REGISTRY_SCHEMA_REGISTRY_INTER_INSTANCE_PROTOCOL: https
-      SCHEMA_REGISTRY_SSL_CLIENT_AUTH: "true"
+    - SCHEMA_REGISTRY_HOST_NAME=schema-registry
+    - SCHEMA_REGISTRY_LISTENERS="https://0.0.0.0:8081"
+    - SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL=zookeeper:2181
+    - SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=SSL://kafka:9092
+    - SCHEMA_REGISTRY_KAFKASTORE_SECURITY_PROTOCOL=SSL
+    - SCHEMA_REGISTRY_KAFKASTORE_SSL_KEYSTORE_LOCATION=/etc/schema-registry/secrets/schema-registry.keystore.jks
+    - SCHEMA_REGISTRY_SSL_KEYSTORE_LOCATION=/etc/schema-registry/secrets/schema-registry.keystore.jks
+    - SCHEMA_REGISTRY_KAFKASTORE_SSL_KEYSTORE_PASSWORD=mzmzmz
+    - SCHEMA_REGISTRY_SSL_KEYSTORE_PASSWORD=mzmzmz
+    - SCHEMA_REGISTRY_KAFKASTORE_SSL_KEY_PASSWORD=mzmzmz
+    - SCHEMA_REGISTRY_SSL_KEY_PASSWORD=mzmzmz
+    - SCHEMA_REGISTRY_KAFKASTORE_SSL_TRUSTSTORE_LOCATION=/etc/schema-registry/secrets/schema-registry.truststore.jks
+    - SCHEMA_REGISTRY_SSL_TRUSTSTORE_LOCATION=/etc/schema-registry/secrets/schema-registry.truststore.jks
+    - SCHEMA_REGISTRY_KAFKASTORE_SSL_TRUSTSTORE_PASSWORD=mzmzmz
+    - SCHEMA_REGISTRY_SSL_TRUSTSTORE_PASSWORD=mzmzmz
+    - SCHEMA_REGISTRY_SCHEMA_REGISTRY_INTER_INSTANCE_PROTOCOL=https
+    - SCHEMA_REGISTRY_SSL_CLIENT_AUTH="true"
     volumes:
       - secrets:/etc/schema-registry/secrets
     depends_on: [kafka, zookeeper, test-certs]

--- a/test/performance/perf-upsert/mzcompose.yml
+++ b/test/performance/perf-upsert/mzcompose.yml
@@ -25,19 +25,19 @@ services:
   zookeeper:
     image: confluentinc/cp-zookeeper:5.5.4
     environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
+    - ZOOKEEPER_CLIENT_PORT=2181
   kafka:
     image: confluentinc/cp-enterprise-kafka:5.5.4
     ports:
       - *kafka
     depends_on: [zookeeper]
     environment:
-      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
-      KAFKA_BROKER_ID: 1
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_JMX_PORT: 9991
-      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
+    - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+    - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092
+    - KAFKA_BROKER_ID=1
+    - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+    - KAFKA_JMX_PORT=9991
+    - KAFKA_AUTO_CREATE_TOPICS_ENABLE=false
   perf-upsert:
     mzbuild: perf-upsert
     environment:

--- a/test/testdrive/mzcompose.yml
+++ b/test/testdrive/mzcompose.yml
@@ -149,7 +149,7 @@ services:
   zookeeper:
     image: confluentinc/cp-zookeeper:5.5.4
     environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
+    - ZOOKEEPER_CLIENT_PORT=2181
   kafka:
     image: confluentinc/cp-kafka:5.5.4
     environment:


### PR DESCRIPTION
@philip-stoev I have to run, but hopefully this is enough to get you started!

----

Add a --mz-coverage flag to mzcompose that will generate a code
coverage report for any contained Rust binaries. The flag works by
building a modified copy of the Rust binaries with the "-Z
instrument-coverage" flag, then wiring up the right environment
variables and volumes to emit the coverage report to the host machine
after running a workflow.
