### PR TITLE
Add a load test of materialized in experimental mode

### DIFF
--- a/demo/chbench/mzcompose.yml
+++ b/demo/chbench/mzcompose.yml
@@ -55,6 +55,26 @@ services:
       # get more verbose logs.
       - MZ_LOG=pgwire=debug,info
       - MZ_DEV=1
+  materialized-experimental:
+    mzbuild: materialized
+    ports:
+     - *materialized
+    command:
+      - --workers=${MZ_WORKERS:-1}
+      # We want this to eventually count up to the size of the largest batch in
+      # an arrangement. This number represents a tradeoff between proactive
+      # merging (which takes time) and low latency.
+      #
+      # 1000 was chosen by fair dice roll.
+      - --differential-idle-merge-effort=1000
+      - --timely-progress-mode=${MZ_TIMELY_PROGRESS_MODE:-demand}
+      - --disable-telemetry
+      - --experimental
+    environment:
+      # You can, for example, add `pgwire=trace` or change `info` to `debug` to
+      # get more verbose logs.
+      - MZ_LOG=pgwire=debug,info
+      - MZ_DEV=1
   mysql:
     mzbuild: chbench-mysql
     ports:
@@ -540,6 +560,44 @@ mzworkflows:
     steps:
     - step: workflow
       workflow: bring-up-source-data-mysql
+    - step: start-services
+      services: [prometheus_sql_exporter_mysql_tpcch, prometheus_sql_exporter_mz]
+    - step: workflow
+      workflow: heavy-load-mysql
+    - step: run
+      service: peeker
+      daemon: true
+      command: --queries ${PEEKER_QUERIES:-loadtest}
+    - step: ensure-stays-up
+      container: peeker
+      seconds: 10
+
+  # Run the cloud load test, but with materialized in experimental mode
+  cloud-load-test-experimental:
+    env:
+      PEEKER_PORT: "16875:16875"
+      MYSQL_EXPORTER_PORT: "9399:9399"
+      MZ_SQL_EXPORTER_PORT: "9400:9399"
+    steps:
+    - step: start-services
+      services: [materialized-experimental]
+    - step: wait-for-tcp
+      host: materialized
+      port: 6875
+    - step: workflow
+      workflow: bring-up-mysql-kafka
+    - step: wait-for-tcp
+      host: materialized
+      port: 6875
+    - step: wait-for-tcp
+      host: mysql
+      port: 3306
+    - step: run
+      service: chbench
+      command: >-
+        gen
+        --warehouses=${NUM_WAREHOUSES:-1}
+        --config-file-path=/etc/chbenchmark/mz-default-mysql.cfg
     - step: start-services
       services: [prometheus_sql_exporter_mysql_tpcch, prometheus_sql_exporter_mz]
     - step: workflow


### PR DESCRIPTION
This is separate from the regular materialized service specifically
because we want to check the perf difference of having source
timestamping turned on.

The intention is to revert this change after we are convinced that we
don't need to check the perf differences between experimental and
regular mode anymore.