### PR TITLE
Fix cloud-load-test-experimental hostname

### DIFF
--- a/demo/chbench/mzcompose.yml
+++ b/demo/chbench/mzcompose.yml
@@ -57,6 +57,7 @@ services:
       - MZ_DEV=1
   materialized-experimental:
     mzbuild: materialized
+    hostname: materialized
     ports:
      - *materialized
     command:


### PR DESCRIPTION
It conflicts with the plain cload-load-test workflow, but that is
required without mzcompose workflow parameterization.