### PR TITLE
ci: use mzcompose to setup the slt-fast tests

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -137,16 +137,15 @@ steps:
           composition: kafka-sasl-plain
           run: testdrive
 
-  - id: short-sqllogictest
-    label: ":bulb: Short SQL logic tests"
+  - id: sqllogictest-fast
+    label: ":bulb: Fast SQL logic tests"
     depends_on: build
-    command: ci/test/slt-fast.sh
     timeout_in_minutes: 10
     inputs: [test/sqllogictest]
     plugins:
       - ./ci/plugins/mzcompose:
           composition: sqllogictest
-          run: sqllogictest
+          run: sqllogictest-fast
 
   - id: streaming-demo
     label: ":shower: protobuf kafka streaming-demo"

--- a/ci/test/slt-fast.sh
+++ b/ci/test/slt-fast.sh
@@ -13,14 +13,6 @@
 
 set -euo pipefail
 
-. misc/shlib/shlib.bash
-
-if [[ ! "${BUILDKITE-}" ]]; then
-    sqllogictest() {
-        cargo run --release --bin sqllogictest -- "$@"
-    }
-fi
-
 export RUST_BACKTRACE=full
 
 tests=(
@@ -163,9 +155,5 @@ tests=(
     test/sqllogictest/postgres/subselect.slt
     test/sqllogictest/postgres/pgcrypto/*.slt
 )
-
-if [[ "${BUILDKITE-}" ]]; then
-    await_postgres -h postgres -p 5432
-fi
 
 sqllogictest -v "${tests[@]}"

--- a/test/sqllogictest/mzcompose.yml
+++ b/test/sqllogictest/mzcompose.yml
@@ -8,19 +8,35 @@
 # by the Apache License, Version 2.0.
 
 version: '3.7'
+
+mzworkflows:
+  sqllogictest-fast:
+    steps:
+      - step: start-services
+        services: [postgres]
+      - step: wait-for-postgres
+        dbname: postgres
+      - step: run
+        service: sqllogictest-svc
+
 services:
-  sqllogictest:
+  sqllogictest-svc:
     mzbuild: sqllogictest
     volumes:
     - ../../:/workdir
     propagate-uid-gid: true
     environment:
+    - RUST_BACKTRACE=full
     - PGUSER=postgres
     - PGHOST=postgres
-    - SQLLOGICTEST_FAST
-    - BUILDKITE
+    - PGPASSWORD=postgres
     depends_on: [postgres]
+    entrypoint:
+    - ci/test/slt-fast.sh
   postgres:
     image: postgres:11.4
+    ports:
+      - 5432
     environment:
-    - POSTGRESDB=sqllogictest
+    - POSTGRESDB=postgres
+    - POSTGRES_PASSWORD=postgres


### PR DESCRIPTION
Move the test setup from the slt-fast.sh script into sqllogictest/mzcompose.yml

This allows the SLT tests to be run inside coverage builds