### PR TITLE
Dataflow LIR

### DIFF
--- a/bin/check
+++ b/bin/check
@@ -47,6 +47,10 @@ disabled_lints=(
     # Unstable sort is not strictly better than sort, notably on partially
     # sorted inputs.
     clippy::stable-sort-primitive
+
+    # This lint has false positives where the pattern cannot be avoided without cloning
+    # the key used in the map.
+    clippy::map_entry
 )
 
 extra_lints=(

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -3450,7 +3450,6 @@ fn auto_generate_primary_idx(
     depends_on: Vec<GlobalId>,
 ) -> catalog::Index {
     let default_key = on_desc.typ().default_key();
-
     catalog::Index {
         create_sql: index_sql(index_name, on_name, &on_desc, &default_key),
         plan_cx: PlanContext::default(),

--- a/src/dataflow/src/decode/mod.rs
+++ b/src/dataflow/src/decode/mod.rs
@@ -758,7 +758,7 @@ where
                     };
 
                     // Check whether we have a partial message from last time.
-                    // If so, we need to pre-pend it to the bytes we got from _this_ message.
+                    // If so, we need to prepend it to the bytes we got from _this_ message.
                     let value = if value_buf.is_empty() {
                         value
                     } else {

--- a/src/dataflow/src/render/arrange_by.rs
+++ b/src/dataflow/src/render/arrange_by.rs
@@ -20,7 +20,7 @@ use repr::{Row, RowArena};
 use crate::operator::CollectionExt;
 use crate::render::context::{ArrangementFlavor, Context};
 
-impl<G, T> Context<G, MirRelationExpr, Row, T>
+impl<G, T> Context<G, Row, T>
 where
     G: Scope,
     G::Timestamp: Lattice + Refines<T>,

--- a/src/dataflow/src/render/context.rs
+++ b/src/dataflow/src/render/context.rs
@@ -10,7 +10,7 @@
 //! Management of dataflow-local state, like arrangements, while building a
 //! dataflow.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::{Arranged, TraceAgent};
@@ -28,7 +28,8 @@ use timely::progress::timestamp::Refines;
 use timely::progress::{Antichain, Timestamp};
 
 use dataflow_types::{DataflowDesc, DataflowError};
-use expr::{GlobalId, MirScalarExpr};
+use expr::{GlobalId, Id, MapFilterProject, MirScalarExpr};
+use repr::{Row, RowArena};
 
 /// A trace handle for key-only data.
 pub type TraceKeyHandle<K, T, R> = TraceAgent<OrdKeySpine<K, T, R>>;
@@ -64,9 +65,8 @@ pub type ErrArrangementImport<S, T> = Arranged<
 /// former must refine the latter. The former is the timestamp used by the scope in question,
 /// and the latter is the timestamp of imported traces. The two may be different in the case
 /// of regions or iteration.
-pub struct Context<S: Scope, P, V: Data, T>
+pub struct Context<S: Scope, V: Data, T>
 where
-    P: Eq + std::hash::Hash + Clone,
     T: Timestamp + Lattice,
     S::Timestamp: Lattice + Refines<T>,
 {
@@ -79,28 +79,12 @@ where
     /// imported traces, both because it improves performance, and because
     /// potentially incorrect results are visible in sinks.
     pub as_of_frontier: Antichain<repr::Timestamp>,
-    /// Dataflow local collections.
-    pub collections: HashMap<P, (Collection<S, V, Diff>, Collection<S, DataflowError, Diff>)>,
-    /// Dataflow local arrangements.
-    pub local: HashMap<P, BTreeMap<Vec<MirScalarExpr>, (Arrangement<S, V>, ErrArrangement<S>)>>,
-    /// Imported arrangements.
-    #[allow(clippy::type_complexity)] // TODO(fms): fix or ignore lint globally.
-    pub trace: HashMap<
-        P,
-        BTreeMap<
-            Vec<MirScalarExpr>,
-            (
-                GlobalId,
-                ArrangementImport<S, V, T>,
-                ErrArrangementImport<S, T>,
-            ),
-        >,
-    >,
+    /// Bindings of identifiers to collections.
+    pub bindings: BTreeMap<Id, CollectionRepresentation<S, V, T>>,
 }
 
-impl<S: Scope, P, V: Data, T> Context<S, P, V, T>
+impl<S: Scope, V: Data, T> Context<S, V, T>
 where
-    P: Eq + std::hash::Hash + Clone,
     T: Timestamp + Lattice,
     S::Timestamp: Lattice + Refines<T>,
 {
@@ -115,290 +99,52 @@ where
             debug_name: dataflow.debug_name.clone(),
             dataflow_id,
             as_of_frontier,
-            collections: HashMap::new(),
-            local: HashMap::new(),
-            trace: HashMap::new(),
+            bindings: BTreeMap::new(),
         }
     }
 
-    /// Indicates if a collection is available.
-    pub fn has_collection(&self, relation_expr: &P) -> bool {
-        self.collections.get(relation_expr).is_some()
-            || self.local.get(relation_expr).is_some()
-            || self.trace.get(relation_expr).is_some()
+    /// Insert a collection reperesentation by an identifier.
+    ///
+    /// This is expected to be used to install external collections (sources, indexes, other views),
+    /// as well as for `Let` bindings of local collections.
+    pub fn insert_id(
+        &mut self,
+        id: Id,
+        collection: CollectionRepresentation<S, V, T>,
+    ) -> Option<CollectionRepresentation<S, V, T>> {
+        self.bindings.insert(id, collection)
     }
-
-    /// Assembles a collection if available.
+    /// Remove a collection representation by an identifier.
     ///
-    /// This method consults all available data assets to create the appropriate
-    /// collection. This can be either a collection itself, or if absent we may
-    /// also be able to find a stashed arrangement for the same relation_expr, which we
-    /// flatten down to a collection.
-    ///
-    /// If insufficient data assets exist to create the collection the method
-    /// will return `None`.
-    pub fn collection(
-        &self,
-        relation_expr: &P,
-    ) -> Option<(Collection<S, V, Diff>, Collection<S, DataflowError, Diff>)> {
-        if let Some(collection) = self.collections.get(relation_expr) {
-            Some(collection.clone())
-        } else if let Some(local) = self.local.get(relation_expr) {
-            let (oks, errs) = local.values().next().expect("Empty arrangement");
-            Some((
-                oks.as_collection(|_k, v| v.clone()),
-                errs.as_collection(|k, _v| k.clone()),
-            ))
-        } else if let Some(trace) = self.trace.get(relation_expr) {
-            let (_id, oks, errs) = trace.values().next().expect("Empty arrangement");
-            Some((
-                oks.as_collection(|_k, v| v.clone()),
-                errs.as_collection(|k, _v| k.clone()),
-            ))
+    /// The primary use of this method is uninstalling `Let` bindings.
+    pub fn remove_id(&mut self, id: Id) -> Option<CollectionRepresentation<S, V, T>> {
+        self.bindings.remove(&id)
+    }
+    /// Melds a collection to whatever exists.
+    pub fn update_id(&mut self, id: Id, collection: CollectionRepresentation<S, V, T>) {
+        if !self.bindings.contains_key(&id) {
+            self.bindings.insert(id, collection);
         } else {
-            None
-        }
-    }
-
-    /// Applies logic to elements of a collection and returns the results.
-    ///
-    /// This method allows savvy users to avoid the potential allocation
-    /// required by `self.collection(expr)` when converting data from an
-    /// arrangement; if less data are required, the `logic` argument is able
-    /// to use a reference and produce the minimal amount of data instead.
-    ///
-    /// The method also takes a `key_selector` argument which allows the
-    /// caller to indicate that certain scalar expressions may have literal
-    /// values (at least, for all yielded results). This can enable the
-    /// use of keys in arrangements, and in particular drive the choice of
-    /// which arrangement to use toward one whose keys must be literals.
-    pub fn flat_map_ref<I, L, K>(
-        &self,
-        relation_expr: &P,
-        mut key_selector: K,
-        mut logic: L,
-    ) -> Option<(
-        Collection<S, I::Item, Diff>,
-        Collection<S, DataflowError, Diff>,
-    )>
-    where
-        I: IntoIterator,
-        I::Item: Data,
-        L: FnMut(RefOrMut<V>) -> I + 'static,
-        K: FnMut(&[MirScalarExpr]) -> Option<V>,
-    {
-        if let Some((oks, err)) = self.collections.get(relation_expr) {
-            Some((
-                oks.flat_map(move |mut v| logic(RefOrMut::Mut(&mut v))),
-                err.clone(),
-            ))
-        } else if let Some(local) = self.local.get(relation_expr) {
-            // Determine a key that is constrained to a literal value.
-            let mut constrained_keys = local
-                .keys()
-                .filter_map(|key| key_selector(key).map(|row| (key.clone(), row)))
-                .collect::<Vec<_>>();
-            // Sort keys by length as a proxy for selectivity.
-            // TODO(#4580): improve this heuristic when possible.
-            constrained_keys.sort_by_key(|(key, _row)| key.len());
-            // If we found such a key, use a more advanced implementation.
-            if let Some((key, row)) = constrained_keys.pop() {
-                let (oks, errs) = &local[&key];
-                let result = Self::flat_map_ref_inner(oks, row, logic);
-                Some((result, errs.as_collection(|k, _v| k.clone())))
-            } else {
-                let (oks, errs) = local.values().next().expect("Empty arrangement");
-                Some((
-                    oks.flat_map_ref(move |_k, v| logic(RefOrMut::Ref(&v))),
-                    errs.as_collection(|k, _v| k.clone()),
-                ))
+            let binding = self
+                .bindings
+                .get_mut(&id)
+                .expect("Binding verified to exist");
+            if collection.collection.is_some() {
+                binding.collection = collection.collection;
             }
-        } else if let Some(trace) = self.trace.get(relation_expr) {
-            // Determine a key that is constrained to a literal value.
-            let mut constrained_keys = trace
-                .keys()
-                .filter_map(|key| key_selector(key).map(|row| (key.clone(), row)))
-                .collect::<Vec<_>>();
-            // Sort keys by length as a proxy for selectivity.
-            // TODO(#4580): improve this heuristic when possible.
-            constrained_keys.sort_by_key(|(key, _row)| key.len());
-            // If we found such a key, use a more advanced implementation.
-            if let Some((key, row)) = constrained_keys.pop() {
-                let (_id, oks, errs) = &trace[&key];
-                let result = Self::flat_map_ref_inner(oks, row, logic);
-                Some((result, errs.as_collection(|k, _v| k.clone())))
-            } else {
-                let (_id, oks, errs) = trace.values().next().expect("Empty arrangement");
-                Some((
-                    oks.flat_map_ref(move |_k, v| logic(RefOrMut::Ref(&v))),
-                    errs.as_collection(|k, _v| k.clone()),
-                ))
+            for (key, flavor) in collection.arranged.into_iter() {
+                binding.arranged.insert(key, flavor);
             }
-        } else {
-            None
         }
     }
-
-    /// Factored out common logic for using literal keys in general traces.
-    ///
-    /// This logic is sufficiently interesting that we want to write it only
-    /// once, and thereby avoid any skew in the two uses of the logic.
-    fn flat_map_ref_inner<Tr, I, L>(
-        trace: &Arranged<S, Tr>,
-        row: V,
-        mut logic: L,
-    ) -> Collection<S, I::Item, Diff>
-    where
-        Tr: TraceReader<Key = V, Val = V, Time = S::Timestamp, R = repr::Diff> + Clone + 'static,
-        Tr::Batch: BatchReader<V, Tr::Val, S::Timestamp, repr::Diff> + 'static,
-        Tr::Cursor: Cursor<V, Tr::Val, S::Timestamp, repr::Diff> + 'static,
-        I: IntoIterator,
-        I::Item: Data,
-        L: FnMut(RefOrMut<V>) -> I + 'static,
-    {
-        use differential_dataflow::AsCollection;
-        use timely::dataflow::operators::Operator;
-        trace
-            .stream
-            .unary(Pipeline, "AsCollection", move |_, _| {
-                move |input, output| {
-                    input.for_each(|time, data| {
-                        let mut session = output.session(&time);
-                        for wrapper in data.iter() {
-                            let batch = &wrapper;
-                            let mut cursor = batch.cursor();
-                            cursor.seek_key(batch, &row);
-                            if cursor.get_key(batch) == Some(&row) {
-                                while let Some(val) = cursor.get_val(batch) {
-                                    for datum in logic(RefOrMut::Ref(val)) {
-                                        cursor.map_times(batch, |time, diff| {
-                                            session.give((
-                                                datum.clone(),
-                                                time.clone(),
-                                                diff.clone(),
-                                            ));
-                                        });
-                                    }
-                                    cursor.step_val(batch);
-                                }
-                            }
-                        }
-                    });
-                }
-            })
-            .as_collection()
-    }
-
-    /// Convenience method for accessing `arrangement` when all keys are plain columns
-    pub fn arrangement_columns(
-        &self,
-        relation_expr: &P,
-        columns: &[usize],
-    ) -> Option<ArrangementFlavor<S, V, T>> {
-        let mut keys = Vec::new();
-        for column in columns {
-            keys.push(MirScalarExpr::Column(*column));
-        }
-        self.arrangement(relation_expr, &keys)
-    }
-
-    /// Produces an arrangement if available.
-    ///
-    /// A context store multiple types of arrangements, and prioritizes
-    /// dataflow-local arrangements in its return values.
-    pub fn arrangement(
-        &self,
-        relation_expr: &P,
-        keys: &[MirScalarExpr],
-    ) -> Option<ArrangementFlavor<S, V, T>> {
-        if let Some(local) = self.get_local(relation_expr, keys) {
-            let (oks, errs) = local.clone();
-            Some(ArrangementFlavor::Local(oks, errs))
-        } else if let Some((gid, oks, errs)) = self.get_trace(relation_expr, keys) {
-            Some(ArrangementFlavor::Trace(*gid, oks.clone(), errs.clone()))
-        } else {
-            None
-        }
-    }
-
-    /// Retrieves a local arrangement from a relation_expr and keys.
-    pub fn get_local(
-        &self,
-        relation_expr: &P,
-        keys: &[MirScalarExpr],
-    ) -> Option<&(Arrangement<S, V>, ErrArrangement<S>)> {
-        self.local.get(relation_expr).and_then(|x| x.get(keys))
-    }
-
-    /// Convenience method for `set_local` when all keys are plain columns
-    pub fn set_local_columns(
-        &mut self,
-        relation_expr: &P,
-        columns: &[usize],
-        arranged: (Arrangement<S, V>, ErrArrangement<S>),
-    ) {
-        let mut keys = Vec::new();
-        for column in columns {
-            keys.push(MirScalarExpr::Column(*column));
-        }
-        self.set_local(relation_expr, &keys, arranged);
-    }
-
-    /// Binds a relation_expr and keys to a local arrangement.
-    pub fn set_local(
-        &mut self,
-        relation_expr: &P,
-        keys: &[MirScalarExpr],
-        arranged: (Arrangement<S, V>, ErrArrangement<S>),
-    ) {
-        self.local
-            .entry(relation_expr.clone())
-            .or_insert_with(BTreeMap::new)
-            .insert(keys.to_vec(), arranged);
-    }
-
-    /// Retrieves an imported arrangement from a relation_expr and keys.
-    pub fn get_trace(
-        &self,
-        relation_expr: &P,
-        keys: &[MirScalarExpr],
-    ) -> Option<&(
-        GlobalId,
-        ArrangementImport<S, V, T>,
-        ErrArrangementImport<S, T>,
-    )> {
-        self.trace.get(relation_expr).and_then(|x| x.get(keys))
-    }
-
-    /// Binds a relation_expr and keys to an imported arrangement.
-    pub fn set_trace(
-        &mut self,
-        gid: GlobalId,
-        relation_expr: &P,
-        keys: &[MirScalarExpr],
-        arranged: (ArrangementImport<S, V, T>, ErrArrangementImport<S, T>),
-    ) {
-        self.trace
-            .entry(relation_expr.clone())
-            .or_insert_with(BTreeMap::new)
-            .insert(keys.to_vec(), (gid, arranged.0, arranged.1));
-    }
-
-    /// Clones from one key to another, as needed in let binding.
-    pub fn clone_from_to(&mut self, key1: &P, key2: &P) {
-        if let Some(collection) = self.collections.get(key1).cloned() {
-            self.collections.insert(key2.clone(), collection);
-        }
-        if let Some(handles) = self.local.get(key1).cloned() {
-            self.local.insert(key2.clone(), handles);
-        }
-        if let Some(handles) = self.trace.get(key1).cloned() {
-            self.trace.insert(key2.clone(), handles);
-        }
+    /// Look up a collection representation by an identifier.
+    pub fn lookup_id(&self, id: Id) -> Option<CollectionRepresentation<S, V, T>> {
+        self.bindings.get(&id).cloned()
     }
 }
 
 /// Describes flavor of arrangement: local or imported trace.
+#[derive(Clone)]
 pub enum ArrangementFlavor<S: Scope, V: Data, T: Lattice>
 where
     T: Timestamp + Lattice,
@@ -412,4 +158,310 @@ where
         ArrangementImport<S, V, T>,
         ErrArrangementImport<S, T>,
     ),
+}
+
+/// A bundle of the various ways a collection can be represented.
+///
+/// This type maintains the invariant that it does contain at least one valid
+/// source of data, either a collection or at least one arrangement.
+#[derive(Clone)]
+pub struct CollectionRepresentation<S: Scope, V: Data, T: Lattice>
+where
+    T: Timestamp + Lattice,
+    S::Timestamp: Lattice + Refines<T>,
+{
+    pub collection: Option<(Collection<S, V, Diff>, Collection<S, DataflowError, Diff>)>,
+    pub arranged: BTreeMap<Vec<MirScalarExpr>, ArrangementFlavor<S, V, T>>,
+}
+
+impl<S: Scope, V: Data, T: Lattice> CollectionRepresentation<S, V, T>
+where
+    T: Timestamp + Lattice,
+    S::Timestamp: Lattice + Refines<T>,
+{
+    /// Construct a new collection representation from update streams.
+    pub fn from_collections(
+        oks: Collection<S, V, Diff>,
+        errs: Collection<S, DataflowError, Diff>,
+    ) -> Self {
+        Self {
+            collection: Some((oks, errs)),
+            arranged: BTreeMap::default(),
+        }
+    }
+
+    /// Inserts arrangements by the expressions on which they are keyed.
+    pub fn from_expressions(
+        exprs: Vec<MirScalarExpr>,
+        arrangements: ArrangementFlavor<S, V, T>,
+    ) -> Self {
+        let mut arranged = BTreeMap::new();
+        arranged.insert(exprs, arrangements);
+        Self {
+            collection: None,
+            arranged,
+        }
+    }
+
+    /// Inserts arrangements by the columns on which they are keyed.
+    pub fn from_columns<I: IntoIterator<Item = usize>>(
+        columns: I,
+        arrangements: ArrangementFlavor<S, V, T>,
+    ) -> Self {
+        let mut keys = Vec::new();
+        for column in columns {
+            keys.push(MirScalarExpr::Column(column));
+        }
+        Self::from_expressions(keys, arrangements)
+    }
+
+    /// Presents `self` as a stream of updates.
+    ///
+    /// This method presents the contents as they are, without further computation.
+    /// If you have logic that could be applied to each record, consider using the
+    /// `as_collection_mfp` methods which allows this and can reduce the work done.
+    pub fn as_collection(&self) -> (Collection<S, V, Diff>, Collection<S, DataflowError, Diff>) {
+        if let Some(collection) = &self.collection {
+            collection.clone()
+        } else {
+            let arranged = self
+                .arranged
+                .values()
+                .next()
+                .expect("Invariant violated: CollectionRepresentation contains no collection.");
+            match arranged {
+                ArrangementFlavor::Local(oks, errs) => (
+                    oks.as_collection(|_k, v| v.clone()),
+                    errs.as_collection(|k, _v| k.clone()),
+                ),
+                ArrangementFlavor::Trace(_, oks, errs) => (
+                    oks.as_collection(|_k, v| v.clone()),
+                    errs.as_collection(|k, _v| k.clone()),
+                ),
+            }
+        }
+    }
+
+    /// Applies logic to elements of a collection and returns the results.
+    ///
+    /// If `key_val` is set, this is a promise that `logic` will produce no results on
+    /// records for which the key does not evaluate to the value. This is used when we
+    /// have an arrangement by that key to leap directly to exactly those records.
+    /// It is important that `logic` still guard against data that does not satisfy
+    /// this constraint, as this method does not statically know that it will have
+    /// that arrangement.
+    pub fn flat_map<I, L>(
+        &self,
+        key_val: Option<(Vec<MirScalarExpr>, V)>,
+        mut logic: L,
+    ) -> (
+        timely::dataflow::Stream<S, I::Item>,
+        Collection<S, DataflowError, Diff>,
+    )
+    where
+        I: IntoIterator,
+        I::Item: Data,
+        L: for<'a, 'b> FnMut(RefOrMut<'b, V>, &'a S::Timestamp, &'a Diff) -> I + 'static,
+    {
+        // If `key_val` is set, and we have the arrangement by that key, we should
+        // use that arrangement.
+        if let Some((key, val)) = key_val {
+            if let Some(flavor) = self.arrangement(&key) {
+                match flavor {
+                    ArrangementFlavor::Local(oks, errs) => {
+                        let oks = Self::flat_map_core(&oks, Some(val), logic);
+                        let errs = errs.as_collection(|k, _v| k.clone());
+                        return (oks, errs);
+                    }
+                    ArrangementFlavor::Trace(_, oks, errs) => {
+                        let oks = Self::flat_map_core(&oks, Some(val), logic);
+                        let errs = errs.as_collection(|k, _v| k.clone());
+                        return (oks, errs);
+                    }
+                }
+            }
+        }
+
+        // No key, or no matching arrangement (that would be weird).
+        // We should now prefer to use an arrangement if available (avoids allocation),
+        // and resort to using a collection if not available (copies all rows).
+        if let Some(flavor) = self.arranged.values().next() {
+            match flavor {
+                ArrangementFlavor::Local(oks, errs) => {
+                    let oks = Self::flat_map_core(&oks, None, logic);
+                    let errs = errs.as_collection(|k, _v| k.clone());
+                    (oks, errs)
+                }
+                ArrangementFlavor::Trace(_, oks, errs) => {
+                    let oks = Self::flat_map_core(&oks, None, logic);
+                    let errs = errs.as_collection(|k, _v| k.clone());
+                    (oks, errs)
+                }
+            }
+        } else {
+            use timely::dataflow::operators::Map;
+            let (oks, errs) = self.as_collection();
+            (
+                oks.inner
+                    .flat_map(move |(mut v, t, d)| logic(RefOrMut::Mut(&mut v), &t, &d)),
+                errs,
+            )
+        }
+    }
+
+    /// Factored out common logic for using literal keys in general traces.
+    ///
+    /// This logic is sufficiently interesting that we want to write it only
+    /// once, and thereby avoid any skew in the two uses of the logic.
+    fn flat_map_core<Tr, I, L>(
+        trace: &Arranged<S, Tr>,
+        key: Option<V>,
+        mut logic: L,
+    ) -> timely::dataflow::Stream<S, I::Item>
+    where
+        Tr: TraceReader<Key = V, Val = V, Time = S::Timestamp, R = repr::Diff> + Clone + 'static,
+        Tr::Batch: BatchReader<V, Tr::Val, S::Timestamp, repr::Diff> + 'static,
+        Tr::Cursor: Cursor<V, Tr::Val, S::Timestamp, repr::Diff> + 'static,
+        I: IntoIterator,
+        I::Item: Data,
+        L: for<'a, 'b> FnMut(RefOrMut<'b, V>, &'a S::Timestamp, &'a repr::Diff) -> I + 'static,
+    {
+        let mode = if key.is_some() { "index" } else { "scan" };
+        let name = format!("ArrangementFlatMap({})", mode);
+        use timely::dataflow::operators::Operator;
+        trace.stream.unary(Pipeline, &name, move |_, _| {
+            move |input, output| {
+                input.for_each(|time, data| {
+                    let mut session = output.session(&time);
+                    for wrapper in data.iter() {
+                        let batch = &wrapper;
+                        let mut cursor = batch.cursor();
+                        if let Some(key) = &key {
+                            cursor.seek_key(batch, key);
+                        }
+                        if key.is_none() || cursor.get_key(batch) == key.as_ref() {
+                            while let Some(val) = cursor.get_val(batch) {
+                                cursor.map_times(batch, |time, diff| {
+                                    for datum in logic(RefOrMut::Ref(val), time, diff) {
+                                        session.give(datum);
+                                    }
+                                });
+                                cursor.step_val(batch);
+                            }
+                        }
+                    }
+                });
+            }
+        })
+    }
+
+    /// Look up an arrangemement by the expressions that form the key.
+    ///
+    /// The result may be `None` if no such arrangement exists, or it may be one of many
+    /// "arrangement flavors" that represent the types of arranged data we might have.
+    pub fn arrangement(&self, key: &[MirScalarExpr]) -> Option<ArrangementFlavor<S, V, T>> {
+        self.arranged.get(key).map(|x| x.clone())
+    }
+
+    /// Reports the keys for any arrangement which evaluate to a literal under `key_selector`.
+    pub fn constrained_keys<K>(&self, mut key_selector: K) -> Vec<(Vec<MirScalarExpr>, V)>
+    where
+        K: FnMut(&[MirScalarExpr]) -> Option<V>,
+    {
+        self.arranged
+            .keys()
+            .filter_map(|key| key_selector(key).map(|val| (key.clone(), val)))
+            .collect::<Vec<_>>()
+    }
+}
+
+impl<S: Scope, T: Lattice> CollectionRepresentation<S, repr::Row, T>
+where
+    T: Timestamp + Lattice,
+    S::Timestamp: Lattice + Refines<T>,
+{
+    /// Ensures that arrangement in `keys` are present, creating them if they do not exist.
+    pub fn ensure_arrangements<K: IntoIterator<Item = Vec<MirScalarExpr>>>(
+        mut self,
+        keys: K,
+    ) -> Self {
+        for key in keys {
+            if !self.arranged.contains_key(&key) {
+                // TODO: Consider allowing more expressive names.
+                let name = format!("ArrangeBy[{:?}]", key);
+                let key2 = key.clone();
+                if self.collection.is_none() {
+                    // Cache collection to avoid reforming it each time.
+                    // TODO(mcsherry): In theory this could be faster run out of another arrangement,
+                    // as the `map_fallible` that follows could be run against an arrangement itself.
+                    self.collection = Some(self.as_collection());
+                }
+                let (oks, errs) = self.as_collection();
+                use crate::operator::CollectionExt;
+                let (oks_keyed, errs_keyed) = oks.map_fallible(move |row| {
+                    let datums = row.unpack();
+                    let temp_storage = RowArena::new();
+                    let key_row =
+                        Row::try_pack(key2.iter().map(|k| k.eval(&datums, &temp_storage)))?;
+                    Ok::<(Row, Row), DataflowError>((key_row, row))
+                });
+
+                use differential_dataflow::operators::arrange::Arrange;
+                let oks = oks_keyed.arrange_named::<OrdValSpine<Row, Row, _, _>>(&name);
+                let errs = errs
+                    .concat(&errs_keyed)
+                    .arrange_named::<OrdKeySpine<_, _, _>>(&format!("{}-errors", name));
+                self.arranged
+                    .insert(key, ArrangementFlavor::Local(oks, errs));
+            }
+        }
+        self
+    }
+}
+
+impl<S> CollectionRepresentation<S, repr::Row, repr::Timestamp>
+where
+    S: Scope<Timestamp = repr::Timestamp>,
+{
+    /// Presents `self` as a stream of updates, having been subjected to `mfp`.
+    ///
+    /// This operator is able to apply the logic of `mfp` early, which can substantially
+    /// reduce the amount of data produced when `mfp` is non-trivial.
+    pub fn as_collection_core(
+        &self,
+        mut mfp: MapFilterProject,
+    ) -> (
+        Collection<S, repr::Row, Diff>,
+        Collection<S, DataflowError, Diff>,
+    ) {
+        if mfp.is_identity() {
+            self.as_collection()
+        } else {
+            mfp.optimize();
+            let mfp2 = mfp.clone();
+            let mfp_plan = mfp.into_plan().unwrap();
+            // TODO(): Improve key selection heuristic.
+            let key_val = self
+                .constrained_keys(move |exprs| mfp2.literal_constraints(exprs))
+                .pop();
+            let (stream, errors) = self.flat_map(key_val, {
+                let mut datums = crate::render::datum_vec::DatumVec::new();
+                move |data, time, diff| {
+                    let temp_storage = repr::RowArena::new();
+                    let mut datums_local = datums.borrow_with(&data);
+                    mfp_plan
+                        .evaluate(&mut datums_local, &temp_storage, time.clone(), diff.clone())
+                        .map(|x| x.map_err(|(e, t, d)| (e.into(), t, d)))
+                }
+            });
+
+            use timely::dataflow::operators::ok_err::OkErr;
+            let (oks, errs) = stream.ok_err(|x| x);
+
+            use differential_dataflow::AsCollection;
+            let oks = oks.as_collection();
+            let errs = errs.as_collection();
+            (oks, errors.concat(&errs))
+        }
+    }
 }

--- a/src/dataflow/src/render/context.rs
+++ b/src/dataflow/src/render/context.rs
@@ -103,7 +103,7 @@ where
         }
     }
 
-    /// Insert a collection reperesentation by an identifier.
+    /// Insert a collection bundle by an identifier.
     ///
     /// This is expected to be used to install external collections (sources, indexes, other views),
     /// as well as for `Let` bindings of local collections.
@@ -285,7 +285,8 @@ where
             }
         }
 
-        // No key, or no matching arrangement (that would be weird).
+        // No key, or a key but no matching arrangement (the latter would likely imply
+        // an error in the contract between key-production and available arrangements).
         // We should now prefer to use an arrangement if available (avoids allocation),
         // and resort to using a collection if not available (copies all rows).
         if let Some(flavor) = self.arranged.values().next() {

--- a/src/dataflow/src/render/flat_map.rs
+++ b/src/dataflow/src/render/flat_map.rs
@@ -30,8 +30,6 @@ where
         exprs: Vec<MirScalarExpr>,
         mfp: MapFilterProject,
     ) -> CollectionRepresentation<G, Row, G::Timestamp> {
-        let func = func.clone();
-        let exprs = exprs.clone();
         let mfp_plan = mfp.into_plan().expect("MapFilterProject planning failed");
         let (ok_collection, err_collection) = input.as_collection();
         let (oks, errs) = ok_collection.inner.flat_map_fallible({

--- a/src/dataflow/src/render/flat_map.rs
+++ b/src/dataflow/src/render/flat_map.rs
@@ -7,139 +7,73 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use differential_dataflow::Collection;
 use timely::dataflow::Scope;
 
 use dataflow_types::*;
-use expr::MirRelationExpr;
-use repr::{Datum, Row, RowArena};
+use expr::{MapFilterProject, MirScalarExpr, TableFunc};
+use repr::{Row, RowArena};
 
 use crate::operator::StreamExt;
+use crate::render::context::CollectionRepresentation;
 use crate::render::context::Context;
 use crate::render::datum_vec::DatumVec;
 
-impl<G> Context<G, MirRelationExpr, Row, repr::Timestamp>
+impl<G> Context<G, Row, repr::Timestamp>
 where
     G: Scope<Timestamp = repr::Timestamp>,
 {
     /// Renders `relation_expr` followed by `map_filter_project` if provided.
     pub fn render_flat_map(
         &mut self,
-        relation_expr: &MirRelationExpr,
-        map_filter_project: Option<expr::MfpPlan>,
-    ) -> (Collection<G, Row>, Collection<G, DataflowError>) {
-        if let MirRelationExpr::FlatMap {
-            input,
-            func,
-            exprs,
-            demand,
-        } = relation_expr
-        {
-            let func = func.clone();
-            let exprs = exprs.clone();
-
-            // Determine for each output column if it should be replaced by a
-            // small default value. This information comes from the "demand"
-            // analysis, and is meant to allow us to avoid reproducing the
-            // input in each output, if at all possible.
-            let types = relation_expr.typ();
-            let arity = types.column_types.len();
-            let replace = (0..arity)
-                .map(|col| !demand.as_ref().map(|d| d.contains(&col)).unwrap_or(true))
-                .collect::<Vec<_>>();
-
-            let (ok_collection, err_collection) = self.collection(input).unwrap();
-            let (oks, errs) = ok_collection.inner.flat_map_fallible({
-                let mut datums = DatumVec::new();
-                let mut row_packer = repr::Row::default();
-                move |(input_row, time, diff)| {
-                    let temp_storage = RowArena::new();
-                    // Unpack datums and capture its length (to rewind MFP eval).
-                    let mut datums_local = datums.borrow_with(&input_row);
-                    let datums_len = datums_local.len();
-                    let exprs = exprs
-                        .iter()
-                        .map(|e| e.eval(&datums_local, &temp_storage))
-                        .collect::<Result<Vec<_>, _>>();
-                    let exprs = match exprs {
-                        Ok(exprs) => exprs,
-                        Err(e) => return vec![(Err((e.into(), time, diff)))],
-                    };
-                    let output_rows = func.eval(exprs, &temp_storage);
-                    // Blank out entries in `datum` here, for simplicity later on.
-                    for index in 0..datums_len {
-                        if replace[index] {
-                            datums_local[index] = Datum::Dummy;
-                        }
-                    }
-                    // Declare borrows outside the closure so that appropriately lifetimed
-                    // borrows are moved in and used by `mfp.evaluate`.
-                    let map_filter_project = &map_filter_project;
-                    let row_packer = &mut row_packer;
-                    let temp_storage = &temp_storage;
-                    let replace = &replace;
-                    if let Some(mfp) = map_filter_project {
-                        output_rows
-                            .iter()
-                            .flat_map(move |(output_row, r)| {
-                                // Remove any additional columns added in prior evaluation.
-                                datums_local.truncate(datums_len);
-                                // Extend datums with additional columns, replace some with dummy values.
-                                datums_local.extend(output_row.iter());
-                                for index in datums_len..datums_local.len() {
-                                    if replace[index] {
-                                        datums_local[index] = Datum::Dummy;
-                                    }
-                                }
-                                mfp.evaluate(&mut datums_local, temp_storage, time, diff * *r)
-                                    .map(|x| x.map_err(|(e, t, r)| (DataflowError::from(e), t, r)))
-                            })
+        input: CollectionRepresentation<G, Row, G::Timestamp>,
+        func: TableFunc,
+        exprs: Vec<MirScalarExpr>,
+        mfp: MapFilterProject,
+    ) -> CollectionRepresentation<G, Row, G::Timestamp> {
+        let func = func.clone();
+        let exprs = exprs.clone();
+        let mfp_plan = mfp.into_plan().expect("MapFilterProject planning failed");
+        let (ok_collection, err_collection) = input.as_collection();
+        let (oks, errs) = ok_collection.inner.flat_map_fallible({
+            let mut datums = DatumVec::new();
+            move |(input_row, time, diff)| {
+                let temp_storage = RowArena::new();
+                // Unpack datums and capture its length (to rewind MFP eval).
+                let mut datums_local = datums.borrow_with(&input_row);
+                let datums_len = datums_local.len();
+                let exprs = exprs
+                    .iter()
+                    .map(|e| e.eval(&datums_local, &temp_storage))
+                    .collect::<Result<Vec<_>, _>>();
+                let exprs = match exprs {
+                    Ok(exprs) => exprs,
+                    Err(e) => return vec![(Err((e.into(), time, diff)))],
+                };
+                let output_rows = func.eval(exprs, &temp_storage);
+                // Declare borrows outside the closure so that appropriately lifetimed
+                // borrows are moved in and used by `mfp.evaluate`.
+                let temp_storage = &temp_storage;
+                let mfp_plan = &mfp_plan;
+                output_rows
+                    .iter()
+                    .flat_map(move |(output_row, r)| {
+                        // Remove any additional columns added in prior evaluation.
+                        datums_local.truncate(datums_len);
+                        // Extend datums with additional columns, replace some with dummy values.
+                        datums_local.extend(output_row.iter());
+                        mfp_plan
+                            .evaluate(&mut datums_local, temp_storage, time, diff * *r)
+                            .map(|x| x.map_err(|(e, t, r)| (DataflowError::from(e), t, r)))
                             .collect::<Vec<_>>()
-                    } else {
-                        output_rows
-                            .iter()
-                            .map(move |(output_row, r)| {
-                                Ok((
-                                    {
-                                        row_packer.extend(
-                                            datums_local
-                                                .iter()
-                                                .cloned()
-                                                .chain(output_row.iter())
-                                                .zip(replace.iter())
-                                                .map(
-                                                    |(datum, replace)| {
-                                                        if *replace {
-                                                            Datum::Dummy
-                                                        } else {
-                                                            datum
-                                                        }
-                                                    },
-                                                ),
-                                        );
-                                        row_packer.finish_and_reuse()
-                                    },
-                                    time,
-                                    diff * *r,
-                                ))
-                            })
-                            .collect::<Vec<_>>()
-                    }
-                    // The collection avoids the lifetime issues of the `datums` borrow,
-                    // which allows us to avoid multiple unpackings of `input_row`. We
-                    // could avoid this allocation with a custom iterator that understands
-                    // the borrowing, but it probably isn't the leading order issue here.
-                }
-            });
+                    })
+                    .collect::<Vec<_>>()
+            }
+        });
 
-            use differential_dataflow::AsCollection;
-            let ok_collection = oks.as_collection();
-            let new_err_collection = errs.as_collection();
-
-            let err_collection = err_collection.concat(&new_err_collection);
-            (ok_collection, err_collection)
-        } else {
-            panic!("Non-FlatMap expression provided to `render_flat_map`");
-        }
+        use differential_dataflow::AsCollection;
+        let ok_collection = oks.as_collection();
+        let new_err_collection = errs.as_collection();
+        let err_collection = err_collection.concat(&new_err_collection);
+        CollectionRepresentation::from_collections(ok_collection, err_collection)
     }
 }

--- a/src/dataflow/src/render/flat_map.rs
+++ b/src/dataflow/src/render/flat_map.rs
@@ -14,7 +14,7 @@ use expr::{MapFilterProject, MirScalarExpr, TableFunc};
 use repr::{Row, RowArena};
 
 use crate::operator::StreamExt;
-use crate::render::context::CollectionRepresentation;
+use crate::render::context::CollectionBundle;
 use crate::render::context::Context;
 use crate::render::datum_vec::DatumVec;
 
@@ -25,11 +25,11 @@ where
     /// Renders `relation_expr` followed by `map_filter_project` if provided.
     pub fn render_flat_map(
         &mut self,
-        input: CollectionRepresentation<G, Row, G::Timestamp>,
+        input: CollectionBundle<G, Row, G::Timestamp>,
         func: TableFunc,
         exprs: Vec<MirScalarExpr>,
         mfp: MapFilterProject,
-    ) -> CollectionRepresentation<G, Row, G::Timestamp> {
+    ) -> CollectionBundle<G, Row, G::Timestamp> {
         let mfp_plan = mfp.into_plan().expect("MapFilterProject planning failed");
         let (ok_collection, err_collection) = input.as_collection();
         let (oks, errs) = ok_collection.inner.flat_map_fallible({
@@ -72,6 +72,6 @@ where
         let ok_collection = oks.as_collection();
         let new_err_collection = errs.as_collection();
         let err_collection = err_collection.concat(&new_err_collection);
-        CollectionRepresentation::from_collections(ok_collection, err_collection)
+        CollectionBundle::from_collections(ok_collection, err_collection)
     }
 }

--- a/src/dataflow/src/render/join/delta_join.rs
+++ b/src/dataflow/src/render/join/delta_join.rs
@@ -28,7 +28,7 @@ use timely::progress::Antichain;
 
 use super::super::context::{ArrangementFlavor, Context};
 use crate::operator::CollectionExt;
-use crate::render::context::CollectionRepresentation;
+use crate::render::context::CollectionBundle;
 use crate::render::datum_vec::DatumVec;
 use crate::render::join::{JoinBuildState, JoinClosure};
 
@@ -194,10 +194,10 @@ where
     /// implementation will be pushed in to the join pipeline if at all possible.
     pub fn render_delta_join(
         &mut self,
-        inputs: Vec<CollectionRepresentation<G, Row, G::Timestamp>>,
+        inputs: Vec<CollectionBundle<G, Row, G::Timestamp>>,
         join_plan: DeltaJoinPlan,
         scope: &mut G,
-    ) -> CollectionRepresentation<G, Row, G::Timestamp> {
+    ) -> CollectionBundle<G, Row, G::Timestamp> {
         // Collects error streams for the ambient scope.
         let mut scope_errs = Vec::new();
 
@@ -466,7 +466,7 @@ where
                 differential_dataflow::collection::concatenate(scope, scope_errs),
             )
         });
-        CollectionRepresentation::from_collections(oks, errs)
+        CollectionBundle::from_collections(oks, errs)
     }
 }
 

--- a/src/dataflow/src/render/join/delta_join.rs
+++ b/src/dataflow/src/render/join/delta_join.rs
@@ -22,12 +22,13 @@ use std::collections::HashSet;
 use timely::dataflow::Scope;
 
 use dataflow_types::DataflowError;
-use expr::{JoinInputMapper, MapFilterProject, MirRelationExpr, MirScalarExpr};
+use expr::{JoinInputMapper, MapFilterProject, MirScalarExpr};
 use repr::{Row, RowArena};
 use timely::progress::Antichain;
 
 use super::super::context::{ArrangementFlavor, Context};
 use crate::operator::CollectionExt;
+use crate::render::context::CollectionRepresentation;
 use crate::render::datum_vec::DatumVec;
 use crate::render::join::{JoinBuildState, JoinClosure};
 
@@ -183,7 +184,7 @@ impl DeltaJoinPlan {
     }
 }
 
-impl<G> Context<G, MirRelationExpr, Row, repr::Timestamp>
+impl<G> Context<G, Row, repr::Timestamp>
 where
     G: Scope<Timestamp = repr::Timestamp>,
 {
@@ -193,208 +194,184 @@ where
     /// implementation will be pushed in to the join pipeline if at all possible.
     pub fn render_delta_join(
         &mut self,
-        relation_expr: &MirRelationExpr,
-        map_filter_project: MapFilterProject,
+        inputs: Vec<CollectionRepresentation<G, Row, G::Timestamp>>,
+        join_plan: DeltaJoinPlan,
         scope: &mut G,
-    ) -> (Collection<G, Row>, Collection<G, DataflowError>) {
-        if let MirRelationExpr::Join {
-            inputs,
-            equivalences,
-            demand: _,
-            implementation: expr::JoinImplementation::DeltaQuery(orders),
-        } = relation_expr
-        {
-            // Step one is to plan the execution of the delta query.
-            let input_mapper = JoinInputMapper::new(inputs);
-            let join_plan = DeltaJoinPlan::create_from(
-                equivalences,
-                &orders[..],
-                input_mapper,
-                map_filter_project,
-            );
+    ) -> CollectionRepresentation<G, Row, G::Timestamp> {
+        // Collects error streams for the ambient scope.
+        let mut scope_errs = Vec::new();
 
-            // Collects error streams for the ambient scope.
-            let mut scope_errs = Vec::new();
+        // Deduplicate the error streams of multiply used arrangements.
+        let mut err_dedup = HashSet::new();
 
-            // Deduplicate the error streams of multiply used arrangements.
-            let mut local_err_dedup = HashSet::new();
-            let mut trace_err_dedup = HashSet::new();
+        // We create a new region to contain the dataflow paths for the delta join.
+        let (oks, errs) = scope.clone().region_named("delta query", |inner| {
+            // Our plan is to iterate through each input relation, and attempt
+            // to find a plan that maximally uses existing keys (better: uses
+            // existing arrangements, to which we have access).
+            let mut join_results = Vec::new();
 
-            // We create a new region to contain the dataflow paths for the delta join.
-            let results = scope.clone().region_named("delta query", |inner| {
-                // Our plan is to iterate through each input relation, and attempt
-                // to find a plan that maximally uses existing keys (better: uses
-                // existing arrangements, to which we have access).
-                let mut join_results = Vec::new();
-
-                // First let's prepare the input arrangements we will need.
-                // This reduces redundant imports, and simplifies the dataflow structure.
-                // As the arrangements are all shared, it should not dramatically improve
-                // the efficiency, but the dataflow simplification is worth doing.
-                let mut arrangements = std::collections::BTreeMap::new();
-                for relation in 0..inputs.len() {
-                    let order = &orders[relation];
-                    for (other, lookup_key) in order.iter() {
-                        arrangements
-                            .entry((other, &lookup_key[..]))
-                            .or_insert_with(|| {
-                                match self
-                                    .arrangement(&inputs[*other], &lookup_key[..])
-                                    .unwrap_or_else(|| {
-                                        panic!(
-                                            "Arrangement alarmingly absent!: {}, {:?}",
-                                            inputs[*other].pretty(),
-                                            &lookup_key[..]
-                                        )
-                                    }) {
-                                    ArrangementFlavor::Local(oks, errs) => {
-                                        if local_err_dedup
-                                            .insert((&inputs[*other], &lookup_key[..]))
-                                        {
-                                            scope_errs.push(errs.as_collection(|k, _v| k.clone()));
-                                        }
-                                        Ok(oks.enter(inner))
+            // First let's prepare the input arrangements we will need.
+            // This reduces redundant imports, and simplifies the dataflow structure.
+            // As the arrangements are all shared, it should not dramatically improve
+            // the efficiency, but the dataflow simplification is worth doing.
+            let mut arrangements = std::collections::BTreeMap::new();
+            for path_plan in join_plan.path_plans.iter() {
+                for stage_plan in path_plan.stage_plans.iter() {
+                    let lookup_idx = stage_plan.lookup_relation;
+                    let lookup_key = stage_plan.lookup_key.clone();
+                    arrangements
+                        .entry((lookup_idx, lookup_key.clone()))
+                        .or_insert_with(|| {
+                            match inputs[lookup_idx]
+                                .arrangement(&lookup_key)
+                                .unwrap_or_else(|| {
+                                    panic!(
+                                        "Arrangement alarmingly absent!: {}, {:?}",
+                                        lookup_idx, lookup_key,
+                                    )
+                                }) {
+                                ArrangementFlavor::Local(oks, errs) => {
+                                    if err_dedup.insert((lookup_idx, lookup_key)) {
+                                        scope_errs.push(errs.as_collection(|k, _v| k.clone()));
                                     }
-                                    ArrangementFlavor::Trace(_gid, oks, errs) => {
-                                        if trace_err_dedup
-                                            .insert((&inputs[*other], &lookup_key[..]))
-                                        {
-                                            scope_errs.push(errs.as_collection(|k, _v| k.clone()));
-                                        }
-                                        Err(oks.enter(inner))
+                                    Ok(oks.enter(inner))
+                                }
+                                ArrangementFlavor::Trace(_gid, oks, errs) => {
+                                    if err_dedup.insert((lookup_idx, lookup_key)) {
+                                        scope_errs.push(errs.as_collection(|k, _v| k.clone()));
                                     }
+                                    Err(oks.enter(inner))
+                                }
+                            }
+                        });
+                }
+            }
+
+            // Collects error streams for the inner scope. Concats before leaving.
+            let mut inner_errs = Vec::with_capacity(inputs.len());
+            for path_plan in join_plan.path_plans.into_iter() {
+                // Deconstruct the stages of the path plan.
+                let DeltaPathPlan {
+                    source_relation,
+                    initial_closure,
+                    stage_plans,
+                    final_closure,
+                } = path_plan;
+
+                // This collection determines changes that result from updates inbound
+                // from `inputs[relation]` and reflects all strictly prior updates and
+                // concurrent updates from relations prior to `relation`.
+                let name = format!("delta path {}", source_relation);
+                let path_results = inner.clone().region_named(&name, |region| {
+                    // The plan is to move through each relation, starting from `relation` and in the order
+                    // indicated in `orders[relation]`. At each moment, we will have the columns from the
+                    // subset of relations encountered so far, and we will have applied as much as we can
+                    // of the filters in `equivalences` and the logic in `map_filter_project`, based on the
+                    // available columns.
+                    //
+                    // As we go, we will track the physical locations of each intended output column, as well
+                    // as the locations of intermediate results from partial application of `map_filter_project`.
+                    //
+                    // Just before we apply the `lookup` function to perform a join, we will first use our
+                    // available information to determine the filtering and logic that we can apply, and
+                    // introduce that in to the `lookup` logic to cause it to happen in that operator.
+
+                    // Collects error streams for the region scope. Concats before leaving.
+                    let mut region_errs = Vec::with_capacity(inputs.len());
+
+                    use differential_dataflow::AsCollection;
+                    use timely::dataflow::operators::Map;
+
+                    // Ensure this input is rendered, and extract its update stream.
+                    let update_stream = if let Some((_key, val)) = arrangements
+                        .iter()
+                        .find(|(key, _val)| key.0 == source_relation)
+                    {
+                        let as_of = self.as_of_frontier.clone();
+                        match val {
+                            Ok(local) => {
+                                let arranged = local.enter(region);
+                                let (update_stream, err_stream) = build_update_stream(
+                                    arranged,
+                                    as_of,
+                                    source_relation,
+                                    initial_closure,
+                                );
+                                region_errs.push(err_stream);
+                                update_stream
+                            }
+                            Err(trace) => {
+                                let arranged = trace.enter(region);
+                                let (update_stream, err_stream) = build_update_stream(
+                                    arranged,
+                                    as_of,
+                                    source_relation,
+                                    initial_closure,
+                                );
+                                region_errs.push(err_stream);
+                                update_stream
+                            }
+                        }
+                    } else {
+                        // If this branch is reached, it means that the optimizer, specifically the
+                        // transform `JoinImplementation`, has made a mistake and the plan may be
+                        // suboptimal, but it is still possible to render the plan.
+                        let mut update_stream = inputs[source_relation]
+                            .as_collection()
+                            .0
+                            .enter(inner)
+                            .enter_region(region);
+
+                        // Apply what `closure` we are able to, and record any errors.
+                        if let Some(initial_closure) = initial_closure {
+                            let (stream, errs) = update_stream.flat_map_fallible({
+                                let mut datums = DatumVec::new();
+                                move |row| {
+                                    let temp_storage = RowArena::new();
+                                    let mut datums_local = datums.borrow_with(&row);
+                                    // TODO(mcsherry): re-use `row` allocation.
+                                    initial_closure
+                                        .apply(&mut datums_local, &temp_storage)
+                                        .transpose()
                                 }
                             });
-                    }
-                }
+                            update_stream = stream;
+                            region_errs.push(errs.map(DataflowError::from));
+                        }
 
-                // Collects error streams for the inner scope. Concats before leaving.
-                let mut inner_errs = Vec::with_capacity(inputs.len());
-                for path_plan in join_plan.path_plans.into_iter() {
-                    // Deconstruct the stages of the path plan.
-                    let DeltaPathPlan {
-                        source_relation,
-                        initial_closure,
-                        stage_plans,
-                        final_closure,
-                    } = path_plan;
+                        update_stream
+                    };
 
-                    // This collection determines changes that result from updates inbound
-                    // from `inputs[relation]` and reflects all strictly prior updates and
-                    // concurrent updates from relations prior to `relation`.
-                    let name = format!("delta path {}", source_relation);
-                    let path_results = inner.clone().region_named(&name, |region| {
-                        // The plan is to move through each relation, starting from `relation` and in the order
-                        // indicated in `orders[relation]`. At each moment, we will have the columns from the
-                        // subset of relations encountered so far, and we will have applied as much as we can
-                        // of the filters in `equivalences` and the logic in `map_filter_project`, based on the
-                        // available columns.
+                    // Promote `time` to a datum element.
+                    //
+                    // The `half_join` operator manipulates as "data" a pair `(data, time)`,
+                    // while tracking the initial time `init_time` separately and without
+                    // modification. The initial value for both times is the initial time.
+                    let mut update_stream = update_stream
+                        .inner
+                        .map(|(v, t, d)| ((v, t.clone()), t, d))
+                        .as_collection();
+
+                    // Repeatedly update `update_stream` to reflect joins with more and more
+                    // other relations, in the specified order.
+                    for stage_plan in stage_plans.into_iter() {
+                        let DeltaStagePlan {
+                            lookup_relation,
+                            stream_key,
+                            lookup_key,
+                            closure,
+                        } = stage_plan;
+
+                        // We require different logic based on the relative order of the two inputs.
+                        // If the `source` relation precedes the `lookup` relation, we present all
+                        // updates with less or equal `time`, and otherwise we present only updates
+                        // with strictly less `time`.
                         //
-                        // As we go, we will track the physical locations of each intended output column, as well
-                        // as the locations of intermediate results from partial application of `map_filter_project`.
-                        //
-                        // Just before we apply the `lookup` function to perform a join, we will first use our
-                        // available information to determine the filtering and logic that we can apply, and
-                        // introduce that in to the `lookup` logic to cause it to happen in that operator.
-
-                        // Collects error streams for the region scope. Concats before leaving.
-                        let mut region_errs = Vec::with_capacity(inputs.len());
-
-                        use differential_dataflow::AsCollection;
-                        use timely::dataflow::operators::Map;
-
-                        // Ensure this input is rendered, and extract its update stream.
-                        let update_stream = if let Some((_key, val)) = arrangements
-                            .iter()
-                            .find(|(key, _val)| key.0 == &source_relation)
-                        {
-                            let as_of = self.as_of_frontier.clone();
-                            match val {
-                                Ok(local) => {
-                                    let arranged = local.enter(region);
-                                    let (update_stream, err_stream) = build_update_stream(
-                                        arranged,
-                                        as_of,
-                                        source_relation,
-                                        initial_closure,
-                                    );
-                                    region_errs.push(err_stream);
-                                    update_stream
-                                }
-                                Err(trace) => {
-                                    let arranged = trace.enter(region);
-                                    let (update_stream, err_stream) = build_update_stream(
-                                        arranged,
-                                        as_of,
-                                        source_relation,
-                                        initial_closure,
-                                    );
-                                    region_errs.push(err_stream);
-                                    update_stream
-                                }
-                            }
-                        } else {
-                            // If this branch is reached, it means that the optimizer, specifically the
-                            // transform `JoinImplementation`, has made a mistake and the plan may be
-                            // suboptimal, but it is still possible to render the plan.
-                            let mut update_stream = self
-                                .collection(&inputs[source_relation])
-                                .expect("Failed to render update stream")
-                                .0
-                                .enter(inner)
-                                .enter_region(region);
-
-                            // Apply what `closure` we are able to, and record any errors.
-                            if let Some(initial_closure) = initial_closure {
-                                let (stream, errs) = update_stream.flat_map_fallible({
-                                    let mut datums = DatumVec::new();
-                                    move |row| {
-                                        let temp_storage = RowArena::new();
-                                        let mut datums_local = datums.borrow_with(&row);
-                                        // TODO(mcsherry): re-use `row` allocation.
-                                        initial_closure
-                                            .apply(&mut datums_local, &temp_storage)
-                                            .transpose()
-                                    }
-                                });
-                                update_stream = stream;
-                                region_errs.push(errs.map(DataflowError::from));
-                            }
-
-                            update_stream
-                        };
-
-                        // Promote `time` to a datum element.
-                        //
-                        // The `half_join` operator manipulates as "data" a pair `(data, time)`,
-                        // while tracking the initial time `init_time` separately and without
-                        // modification. The initial value for both times is the initial time.
-                        let mut update_stream = update_stream
-                            .inner
-                            .map(|(v, t, d)| ((v, t.clone()), t, d))
-                            .as_collection();
-
-                        // Repeatedly update `update_stream` to reflect joins with more and more
-                        // other relations, in the specified order.
-                        for stage_plan in stage_plans.into_iter() {
-                            let DeltaStagePlan {
-                                lookup_relation,
-                                stream_key,
-                                lookup_key,
-                                closure,
-                            } = stage_plan;
-
-                            // We require different logic based on the relative order of the two inputs.
-                            // If the `source` relation precedes the `lookup` relation, we present all
-                            // updates with less or equal `time`, and otherwise we present only updates
-                            // with strictly less `time`.
-                            //
-                            // We need to write the logic twice, as there are two types of arrangement
-                            // we might have: either dataflow-local or an imported trace.
-                            let (oks, errs) = match arrangements
-                                .get(&(&lookup_relation, &lookup_key[..]))
-                                .unwrap()
-                            {
+                        // We need to write the logic twice, as there are two types of arrangement
+                        // we might have: either dataflow-local or an imported trace.
+                        let (oks, errs) =
+                            match arrangements.get(&(lookup_relation, lookup_key)).unwrap() {
                                 Ok(local) => {
                                     if source_relation < lookup_relation {
                                         build_halfjoin(
@@ -434,67 +411,62 @@ where
                                     }
                                 }
                             };
-                            update_stream = oks;
-                            region_errs.push(errs);
-                        }
+                        update_stream = oks;
+                        region_errs.push(errs);
+                    }
 
-                        // Delay updates as appropriate.
-                        //
-                        // The `half_join` operator maintains a time that we now discard (the `_`),
-                        // and replace with the `time` that is maintained with the data. The former
-                        // exists to pin a consistent total order on updates throughout the process,
-                        // while allowing `time` to vary upwards as a result of actions on time.
-                        let mut update_stream = update_stream
-                            .inner
-                            .map(|((row, time), _, diff)| (row, time, diff))
-                            .as_collection();
+                    // Delay updates as appropriate.
+                    //
+                    // The `half_join` operator maintains a time that we now discard (the `_`),
+                    // and replace with the `time` that is maintained with the data. The former
+                    // exists to pin a consistent total order on updates throughout the process,
+                    // while allowing `time` to vary upwards as a result of actions on time.
+                    let mut update_stream = update_stream
+                        .inner
+                        .map(|((row, time), _, diff)| (row, time, diff))
+                        .as_collection();
 
-                        // We have completed the join building, but may have work remaining.
-                        // For example, we may have expressions not pushed down (e.g. literals)
-                        // and projections that could not be applied (e.g. column repetition).
-                        if let Some(final_closure) = final_closure {
-                            let (updates, errors) = update_stream.flat_map_fallible({
-                                // Reuseable allocation for unpacking.
-                                let mut datums = DatumVec::new();
-                                move |row| {
-                                    let temp_storage = RowArena::new();
-                                    let mut datums_local = datums.borrow_with(&row);
-                                    // TODO(mcsherry): re-use `row` allocation.
-                                    final_closure
-                                        .apply(&mut datums_local, &temp_storage)
-                                        .map_err(DataflowError::from)
-                                        .transpose()
-                                }
-                            });
+                    // We have completed the join building, but may have work remaining.
+                    // For example, we may have expressions not pushed down (e.g. literals)
+                    // and projections that could not be applied (e.g. column repetition).
+                    if let Some(final_closure) = final_closure {
+                        let (updates, errors) = update_stream.flat_map_fallible({
+                            // Reuseable allocation for unpacking.
+                            let mut datums = DatumVec::new();
+                            move |row| {
+                                let temp_storage = RowArena::new();
+                                let mut datums_local = datums.borrow_with(&row);
+                                // TODO(mcsherry): re-use `row` allocation.
+                                final_closure
+                                    .apply(&mut datums_local, &temp_storage)
+                                    .map_err(DataflowError::from)
+                                    .transpose()
+                            }
+                        });
 
-                            update_stream = updates;
-                            region_errs.push(errors);
-                        }
+                        update_stream = updates;
+                        region_errs.push(errors);
+                    }
 
-                        inner_errs.push(
-                            differential_dataflow::collection::concatenate(region, region_errs)
-                                .leave(),
-                        );
-                        update_stream.leave()
-                    });
+                    inner_errs.push(
+                        differential_dataflow::collection::concatenate(region, region_errs).leave(),
+                    );
+                    update_stream.leave()
+                });
 
-                    join_results.push(path_results);
-                }
+                join_results.push(path_results);
+            }
 
-                scope_errs.push(
-                    differential_dataflow::collection::concatenate(inner, inner_errs).leave(),
-                );
+            scope_errs
+                .push(differential_dataflow::collection::concatenate(inner, inner_errs).leave());
 
-                // Concatenate the results of each delta query as the accumulated results.
-                (
-                    differential_dataflow::collection::concatenate(inner, join_results).leave(),
-                    differential_dataflow::collection::concatenate(scope, scope_errs),
-                )
-            });
-            results
-        } else {
-            panic!("render_delta_join invoked on non-delta join implementation");
-        }
+            // Concatenate the results of each delta query as the accumulated results.
+            (
+                differential_dataflow::collection::concatenate(inner, join_results).leave(),
+                differential_dataflow::collection::concatenate(scope, scope_errs),
+            )
+        });
+        CollectionRepresentation::from_collections(oks, errs)
     }
 }
 

--- a/src/dataflow/src/render/join/linear_join.rs
+++ b/src/dataflow/src/render/join/linear_join.rs
@@ -20,10 +20,11 @@ use timely::dataflow::Scope;
 use timely::progress::{timestamp::Refines, Timestamp};
 
 use dataflow_types::*;
-use expr::{MapFilterProject, MirRelationExpr, MirScalarExpr};
-use repr::{Datum, Row, RowArena};
+use expr::{MapFilterProject, MirScalarExpr};
+use repr::{Row, RowArena};
 
 use crate::operator::CollectionExt;
+use crate::render::context::CollectionRepresentation;
 use crate::render::context::{Arrangement, ArrangementFlavor, ArrangementImport, Context, Diff};
 use crate::render::datum_vec::DatumVec;
 use crate::render::join::{JoinBuildState, JoinClosure};
@@ -164,7 +165,7 @@ where
     Trace(ArrangementImport<G, Row, T>),
 }
 
-impl<G, T> Context<G, MirRelationExpr, Row, T>
+impl<G, T> Context<G, Row, T>
 where
     G: Scope,
     G::Timestamp: Lattice + Refines<T>,
@@ -172,130 +173,43 @@ where
 {
     pub fn render_join(
         &mut self,
-        relation_expr: &MirRelationExpr,
-        map_filter_project: MapFilterProject,
-        // TODO(frank): use this argument to create a region surrounding the join.
+        inputs: Vec<CollectionRepresentation<G, Row, T>>,
+        linear_plan: LinearJoinPlan,
         scope: &mut G,
-    ) -> (Collection<G, Row>, Collection<G, DataflowError>) {
-        if let MirRelationExpr::Join {
-            inputs,
-            equivalences,
-            demand,
-            implementation: expr::JoinImplementation::Differential((start, _start_arr), order),
-        } = relation_expr
-        {
-            let input_mapper = expr::JoinInputMapper::new(inputs);
-            let output_arity = input_mapper.total_columns();
+    ) -> CollectionRepresentation<G, Row, T> {
+        // Collect all error streams, and concatenate them at the end.
+        let mut errors = Vec::new();
 
-            // Determine dummy columns for un-demanded outputs, and a projection.
-            let (dummies, demand_projection) = if let Some(demand) = demand {
-                let mut dummies = Vec::new();
-                let mut demand_projection = Vec::new();
-                for (column, typ) in relation_expr.typ().column_types.into_iter().enumerate() {
-                    if demand.contains(&column) {
-                        demand_projection.push(column);
-                    } else {
-                        demand_projection.push(output_arity + dummies.len());
-                        dummies.push(MirScalarExpr::literal_ok(Datum::Dummy, typ.scalar_type));
-                    }
-                }
-                (dummies, demand_projection)
-            } else {
-                (Vec::new(), (0..output_arity).collect::<Vec<_>>())
-            };
-
-            let (map, filter, project) = map_filter_project.as_map_filter_project();
-
-            let map_filter_project = MapFilterProject::new(output_arity)
-                .map(dummies)
-                .project(demand_projection)
-                .map(map)
-                .filter(filter)
-                .project(project);
-
-            // Create a join plan based on the linear join.
-            let linear_plan = LinearJoinPlan::create_from(
-                *start,
-                equivalences,
-                order,
-                input_mapper,
-                map_filter_project,
-            );
-
-            // Collect all error streams, and concatenate them at the end.
-            let mut errors = Vec::new();
-
-            // Determine which form our maintained spine of updates will initially take.
-            // First, just check out the availability of an appropriate arrangement.
-            // This will be `None` in the degenerate single-input join case, which ensures
-            // that we do not panic if we never go around the `stage_plans` loop.
-            let arrangement = linear_plan.stage_plans.get(0).and_then(|stage| {
-                self.arrangement(&inputs[linear_plan.source_relation], &stage.stream_key)
-            });
-            // We can use an arrangement if it exists and an initial closure does not.
-            let mut joined = match (arrangement, linear_plan.initial_closure) {
-                (Some(ArrangementFlavor::Local(oks, errs)), None) => {
-                    errors.push(errs.as_collection(|k, _v| k.clone()));
-                    JoinedFlavor::Local(oks)
-                }
-                (Some(ArrangementFlavor::Trace(_gid, oks, errs)), None) => {
-                    errors.push(errs.as_collection(|k, _v| k.clone()));
-                    JoinedFlavor::Trace(oks)
-                }
-                (_, initial_closure) => {
-                    // TODO: extract closure from the first stage in the join plan, should it exist.
-                    // TODO: apply that closure in `flat_map_ref` rather than calling `.collection`.
-                    let (mut joined, errs) = self.collection(&inputs[*start]).unwrap();
-                    errors.push(errs);
-                    // In the current code this should always be `None`, but we have this here should
-                    // we change that and want to know what we should be doing.
-                    if let Some(closure) = initial_closure {
-                        // If there is no starting arrangement, then we can run filters
-                        // directly on the starting collection.
-                        // If there is only one input, we are done joining, so run filters
-                        let (j, errs) = joined.flat_map_fallible({
-                            // Reuseable allocation for unpacking.
-                            let mut datums = DatumVec::new();
-                            move |row| {
-                                let temp_storage = RowArena::new();
-                                let mut datums_local = datums.borrow_with(&row);
-                                // TODO(mcsherry): re-use `row` allocation.
-                                closure
-                                    .apply(&mut datums_local, &temp_storage)
-                                    .map_err(DataflowError::from)
-                                    .transpose()
-                            }
-                        });
-                        joined = j;
-                        errors.push(errs);
-                    }
-
-                    JoinedFlavor::Collection(joined)
-                }
-            };
-
-            // Progress through stages, updating partial results and errors.
-            for stage_plan in linear_plan.stage_plans.into_iter() {
-                // Different variants of `joined` implement this differently,
-                // and the logic is centralized there.
-                let stream = self.differential_join(
-                    joined,
-                    stage_plan.stream_key,
-                    &inputs[stage_plan.lookup_relation],
-                    stage_plan.lookup_key,
-                    stage_plan.closure,
-                    &mut errors,
-                );
-                // Update joined results and capture any errors.
-                joined = JoinedFlavor::Collection(stream);
+        // Determine which form our maintained spine of updates will initially take.
+        // First, just check out the availability of an appropriate arrangement.
+        // This will be `None` in the degenerate single-input join case, which ensures
+        // that we do not panic if we never go around the `stage_plans` loop.
+        let arrangement = linear_plan
+            .stage_plans
+            .get(0)
+            .and_then(|stage| inputs[linear_plan.source_relation].arrangement(&stage.stream_key));
+        // We can use an arrangement if it exists and an initial closure does not.
+        let mut joined = match (arrangement, linear_plan.initial_closure) {
+            (Some(ArrangementFlavor::Local(oks, errs)), None) => {
+                errors.push(errs.as_collection(|k, _v| k.clone()));
+                JoinedFlavor::Local(oks)
             }
-
-            // We have completed the join building, but may have work remaining.
-            // For example, we may have expressions not pushed down (e.g. literals)
-            // and projections that could not be applied (e.g. column repetition).
-            if let JoinedFlavor::Collection(mut joined) = joined {
-                if let Some(closure) = linear_plan.final_closure {
-                    let (updates, errs) = joined.flat_map_fallible({
+            (Some(ArrangementFlavor::Trace(_gid, oks, errs)), None) => {
+                errors.push(errs.as_collection(|k, _v| k.clone()));
+                JoinedFlavor::Trace(oks)
+            }
+            (_, initial_closure) => {
+                // TODO: extract closure from the first stage in the join plan, should it exist.
+                // TODO: apply that closure in `flat_map_ref` rather than calling `.collection`.
+                let (mut joined, errs) = inputs[linear_plan.source_relation].as_collection();
+                errors.push(errs);
+                // In the current code this should always be `None`, but we have this here should
+                // we change that and want to know what we should be doing.
+                if let Some(closure) = initial_closure {
+                    // If there is no starting arrangement, then we can run filters
+                    // directly on the starting collection.
+                    // If there is only one input, we are done joining, so run filters
+                    let (j, errs) = joined.flat_map_fallible({
                         // Reuseable allocation for unpacking.
                         let mut datums = DatumVec::new();
                         move |row| {
@@ -308,21 +222,60 @@ where
                                 .transpose()
                         }
                     });
-
-                    joined = updates;
+                    joined = j;
                     errors.push(errs);
                 }
 
-                // Return joined results and all produced errors collected together.
-                (
-                    joined,
-                    differential_dataflow::collection::concatenate(scope, errors),
-                )
-            } else {
-                panic!("Unexpectedly arranged join output");
+                JoinedFlavor::Collection(joined)
             }
+        };
+
+        // Progress through stages, updating partial results and errors.
+        for stage_plan in linear_plan.stage_plans.into_iter() {
+            // Different variants of `joined` implement this differently,
+            // and the logic is centralized there.
+            let stream = self.differential_join(
+                joined,
+                stage_plan.stream_key,
+                inputs[stage_plan.lookup_relation].clone(),
+                stage_plan.lookup_key,
+                stage_plan.closure,
+                &mut errors,
+            );
+            // Update joined results and capture any errors.
+            joined = JoinedFlavor::Collection(stream);
+        }
+
+        // We have completed the join building, but may have work remaining.
+        // For example, we may have expressions not pushed down (e.g. literals)
+        // and projections that could not be applied (e.g. column repetition).
+        if let JoinedFlavor::Collection(mut joined) = joined {
+            if let Some(closure) = linear_plan.final_closure {
+                let (updates, errs) = joined.flat_map_fallible({
+                    // Reuseable allocation for unpacking.
+                    let mut datums = DatumVec::new();
+                    move |row| {
+                        let temp_storage = RowArena::new();
+                        let mut datums_local = datums.borrow_with(&row);
+                        // TODO(mcsherry): re-use `row` allocation.
+                        closure
+                            .apply(&mut datums_local, &temp_storage)
+                            .map_err(DataflowError::from)
+                            .transpose()
+                    }
+                });
+
+                joined = updates;
+                errors.push(errs);
+            }
+
+            // Return joined results and all produced errors collected together.
+            CollectionRepresentation::from_collections(
+                joined,
+                differential_dataflow::collection::concatenate(scope, errors),
+            )
         } else {
-            panic!("render_join called on invalid expression.")
+            panic!("Unexpectedly arranged join output");
         }
     }
 
@@ -333,7 +286,7 @@ where
         &mut self,
         mut joined: JoinedFlavor<G, T>,
         stream_key: Vec<MirScalarExpr>,
-        lookup_relation: &MirRelationExpr,
+        lookup_relation: CollectionRepresentation<G, Row, T>,
         lookup_key: Vec<MirScalarExpr>,
         closure: JoinClosure,
         errors: &mut Vec<Collection<G, DataflowError>>,
@@ -364,68 +317,48 @@ where
             joined = JoinedFlavor::Local(arranged);
         }
 
-        // Pre-test for the arrangement existence, so that we can populate it if the
-        // collection is present but the arrangement is not.
-        if self.arrangement(lookup_relation, &lookup_key[..]).is_none() {
-            // The join may be faulty, and announce keys for an arrangement we have
-            // not formed. This *shouldn't* happen, but we prefer to do something
-            // sane rather than panic.
-            // TODO: If this ever trips, the `collection` call is a wasteful way to
-            // determine if we have rendered the collection.
-            if self.collection(lookup_relation).is_some() {
-                let arrange_by = MirRelationExpr::ArrangeBy {
-                    input: Box::new(lookup_relation.clone()),
-                    keys: vec![lookup_key.to_vec()],
-                };
-                self.render_arrangeby(&arrange_by, Some("MissingArrangement"));
-            } else {
-                panic!("Arrangement alarmingly absent!");
-            }
-        }
+        // Ensure that the correct arrangement exists.
+        let lookup_relation = lookup_relation.ensure_arrangements(Some(lookup_key.clone()));
 
         // Demultiplex the four different cross products of arrangement types we might have.
         match joined {
             JoinedFlavor::Collection(_) => {
                 unreachable!("JoinedFlavor::Collection variant avoided at top of method");
             }
-            JoinedFlavor::Local(local) => {
-                match self.arrangement(lookup_relation, &lookup_key[..]) {
-                    Some(ArrangementFlavor::Local(oks, errs1)) => {
-                        let (oks, errs2) = self.differential_join_inner(local, oks, closure);
-                        errors.push(errs1.as_collection(|k, _v| k.clone()));
-                        errors.push(errs2);
-                        oks
-                    }
-                    Some(ArrangementFlavor::Trace(_gid, oks, errs1)) => {
-                        let (oks, errs2) = self.differential_join_inner(local, oks, closure);
-                        errors.push(errs1.as_collection(|k, _v| k.clone()));
-                        errors.push(errs2);
-                        oks
-                    }
-                    None => {
-                        unreachable!("Arrangement absent despite explicit construction");
-                    }
+            JoinedFlavor::Local(local) => match lookup_relation.arrangement(&lookup_key[..]) {
+                Some(ArrangementFlavor::Local(oks, errs1)) => {
+                    let (oks, errs2) = self.differential_join_inner(local, oks, closure);
+                    errors.push(errs1.as_collection(|k, _v| k.clone()));
+                    errors.push(errs2);
+                    oks
                 }
-            }
-            JoinedFlavor::Trace(trace) => {
-                match self.arrangement(lookup_relation, &lookup_key[..]) {
-                    Some(ArrangementFlavor::Local(oks, errs1)) => {
-                        let (oks, errs2) = self.differential_join_inner(trace, oks, closure);
-                        errors.push(errs1.as_collection(|k, _v| k.clone()));
-                        errors.push(errs2);
-                        oks
-                    }
-                    Some(ArrangementFlavor::Trace(_gid, oks, errs1)) => {
-                        let (oks, errs2) = self.differential_join_inner(trace, oks, closure);
-                        errors.push(errs1.as_collection(|k, _v| k.clone()));
-                        errors.push(errs2);
-                        oks
-                    }
-                    None => {
-                        unreachable!("Arrangement absent despite explicit construction");
-                    }
+                Some(ArrangementFlavor::Trace(_gid, oks, errs1)) => {
+                    let (oks, errs2) = self.differential_join_inner(local, oks, closure);
+                    errors.push(errs1.as_collection(|k, _v| k.clone()));
+                    errors.push(errs2);
+                    oks
                 }
-            }
+                None => {
+                    unreachable!("Arrangement absent despite explicit construction");
+                }
+            },
+            JoinedFlavor::Trace(trace) => match lookup_relation.arrangement(&lookup_key[..]) {
+                Some(ArrangementFlavor::Local(oks, errs1)) => {
+                    let (oks, errs2) = self.differential_join_inner(trace, oks, closure);
+                    errors.push(errs1.as_collection(|k, _v| k.clone()));
+                    errors.push(errs2);
+                    oks
+                }
+                Some(ArrangementFlavor::Trace(_gid, oks, errs1)) => {
+                    let (oks, errs2) = self.differential_join_inner(trace, oks, closure);
+                    errors.push(errs1.as_collection(|k, _v| k.clone()));
+                    errors.push(errs2);
+                    oks
+                }
+                None => {
+                    unreachable!("Arrangement absent despite explicit construction");
+                }
+            },
         }
     }
 

--- a/src/dataflow/src/render/join/linear_join.rs
+++ b/src/dataflow/src/render/join/linear_join.rs
@@ -30,6 +30,7 @@ use crate::render::datum_vec::DatumVec;
 use crate::render::join::{JoinBuildState, JoinClosure};
 
 // TODO(mcsherry): Identical to `DeltaPathPlan`; consider unifying.
+#[derive(Debug)]
 pub struct LinearJoinPlan {
     /// The source relation from which we start the join.
     source_relation: usize,
@@ -46,6 +47,7 @@ pub struct LinearJoinPlan {
 }
 
 // TODO(mcsherry): Identical to `DeltaStagePlan`; consider unifying.
+#[derive(Debug)]
 pub struct LinearStagePlan {
     /// The relation index into which we will look up.
     lookup_relation: usize,

--- a/src/dataflow/src/render/join/linear_join.rs
+++ b/src/dataflow/src/render/join/linear_join.rs
@@ -24,7 +24,7 @@ use expr::{MapFilterProject, MirScalarExpr};
 use repr::{Row, RowArena};
 
 use crate::operator::CollectionExt;
-use crate::render::context::CollectionRepresentation;
+use crate::render::context::CollectionBundle;
 use crate::render::context::{Arrangement, ArrangementFlavor, ArrangementImport, Context, Diff};
 use crate::render::datum_vec::DatumVec;
 use crate::render::join::{JoinBuildState, JoinClosure};
@@ -175,10 +175,10 @@ where
 {
     pub fn render_join(
         &mut self,
-        inputs: Vec<CollectionRepresentation<G, Row, T>>,
+        inputs: Vec<CollectionBundle<G, Row, T>>,
         linear_plan: LinearJoinPlan,
         scope: &mut G,
-    ) -> CollectionRepresentation<G, Row, T> {
+    ) -> CollectionBundle<G, Row, T> {
         // Collect all error streams, and concatenate them at the end.
         let mut errors = Vec::new();
 
@@ -272,7 +272,7 @@ where
             }
 
             // Return joined results and all produced errors collected together.
-            CollectionRepresentation::from_collections(
+            CollectionBundle::from_collections(
                 joined,
                 differential_dataflow::collection::concatenate(scope, errors),
             )
@@ -288,7 +288,7 @@ where
         &mut self,
         mut joined: JoinedFlavor<G, T>,
         stream_key: Vec<MirScalarExpr>,
-        lookup_relation: CollectionRepresentation<G, Row, T>,
+        lookup_relation: CollectionBundle<G, Row, T>,
         lookup_key: Vec<MirScalarExpr>,
         closure: JoinClosure,
         errors: &mut Vec<Collection<G, DataflowError>>,

--- a/src/dataflow/src/render/join/mod.rs
+++ b/src/dataflow/src/render/join/mod.rs
@@ -39,6 +39,7 @@ pub use delta_join::DeltaJoinPlan;
 pub use linear_join::LinearJoinPlan;
 
 /// A complete enumeration of possible join plans to render.
+#[derive(Debug)]
 pub enum JoinPlan {
     Linear(LinearJoinPlan),
     Delta(DeltaJoinPlan),

--- a/src/dataflow/src/render/join/mod.rs
+++ b/src/dataflow/src/render/join/mod.rs
@@ -35,6 +35,15 @@ use std::collections::HashMap;
 use expr::{MapFilterProject, MirScalarExpr};
 use repr::{Datum, Row, RowArena};
 
+pub use delta_join::DeltaJoinPlan;
+pub use linear_join::LinearJoinPlan;
+
+/// A complete enumeration of possible join plans to render.
+pub enum JoinPlan {
+    Linear(LinearJoinPlan),
+    Delta(DeltaJoinPlan),
+}
+
 /// A manual closure implementation of filtering and logic application.
 ///
 /// This manual implementation exists to express lifetime constraints clearly,

--- a/src/dataflow/src/render/map_filter_project.rs
+++ b/src/dataflow/src/render/map_filter_project.rs
@@ -32,7 +32,7 @@ use crate::operator::StreamExt;
 use crate::render::context::Context;
 use crate::render::datum_vec::DatumVec;
 
-impl<G, T> Context<G, MirRelationExpr, Row, T>
+impl<G, T> Context<G, Row, T>
 where
     G: Scope<Timestamp = repr::Timestamp>,
     G::Timestamp: Lattice + Refines<T>,

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -607,7 +607,7 @@ pub mod plan {
         /// This is commonly either an external reference to an existing source or
         /// maintained arrangement, or an internal reference to a `Let` identifier.
         Get {
-            /// A global or local identifier nameing the collection.
+            /// A global or local identifier naming the collection.
             id: Id,
             /// Any linear operator work to apply as part of producing the data.
             ///

--- a/src/dataflow/src/render/reduce.rs
+++ b/src/dataflow/src/render/reduce.rs
@@ -86,7 +86,7 @@ use repr::{Datum, DatumList, Row, RowArena};
 
 use super::context::Context;
 use crate::render::context::Arrangement;
-use crate::render::context::CollectionRepresentation;
+use crate::render::context::CollectionBundle;
 use crate::render::datum_vec::DatumVec;
 use crate::render::ArrangementFlavor;
 
@@ -573,10 +573,10 @@ where
     /// minimize worst-case incremental update times and memory footprint.
     pub fn render_reduce(
         &mut self,
-        input: CollectionRepresentation<G, Row, T>,
+        input: CollectionBundle<G, Row, T>,
         key_val_plan: KeyValPlan,
         reduce_plan: ReducePlan,
-    ) -> CollectionRepresentation<G, Row, T> {
+    ) -> CollectionBundle<G, Row, T> {
         let KeyValPlan {
             key_plan,
             val_plan,
@@ -638,7 +638,7 @@ where
 
         // First, let's plan out what we are going to do with this reduce
         let arrangement = reduce_plan.render(ok_input);
-        CollectionRepresentation::from_columns(
+        CollectionBundle::from_columns(
             0..key_arity,
             ArrangementFlavor::Local(arrangement, err_input.arrange()),
         )

--- a/src/dataflow/src/render/reduce.rs
+++ b/src/dataflow/src/render/reduce.rs
@@ -509,6 +509,7 @@ impl ReducePlan {
 }
 
 /// Plan for extracting keys and values in preparation for a reduction.
+#[derive(Debug)]
 pub struct KeyValPlan {
     /// Extracts the columns used as the key.
     key_plan: expr::SafeMfpPlan,

--- a/src/dataflow/src/render/sinks.rs
+++ b/src/dataflow/src/render/sinks.rs
@@ -22,7 +22,7 @@ use timely::dataflow::Scope;
 use timely::progress::Antichain;
 
 use dataflow_types::*;
-use expr::{GlobalId, MirRelationExpr};
+use expr::GlobalId;
 use interchange::envelopes::{combine_at_timestamp, dbz_format, upsert_format};
 use ore::cast::CastFrom;
 use repr::adt::decimal::Significand;
@@ -32,7 +32,7 @@ use crate::render::context::Context;
 use crate::render::{RelevantTokens, RenderState};
 use crate::sink;
 
-impl<'g, G> Context<Child<'g, G, G::Timestamp>, MirRelationExpr, Row, Timestamp>
+impl<'g, G> Context<Child<'g, G, G::Timestamp>, Row, Timestamp>
 where
     G: Scope<Timestamp = Timestamp>,
 {
@@ -61,11 +61,9 @@ where
         }
 
         let (collection, _err_collection) = self
-            .collection(&MirRelationExpr::global_get(
-                sink.from,
-                sink.from_desc.typ().clone(),
-            ))
-            .expect("Sink source collection not loaded");
+            .lookup_id(expr::Id::Global(sink.from))
+            .expect("Sink source collection not loaded")
+            .as_collection();
 
         // Some connectors support keys - extract them.
         let keyed = match sink.connector.clone() {

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -493,10 +493,7 @@ where
                 // Introduce the stream by name, as an unarranged collection.
                 self.insert_id(
                     Id::Global(src_id),
-                    crate::render::CollectionBundle::from_collections(
-                        collection,
-                        err_collection,
-                    ),
+                    crate::render::CollectionBundle::from_collections(collection, err_collection),
                 );
 
                 let token = Rc::new(capability);

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -23,7 +23,7 @@ use timely::dataflow::scopes::Child;
 use timely::dataflow::Scope;
 
 use dataflow_types::*;
-use expr::{GlobalId, Id, MirRelationExpr, SourceInstanceId};
+use expr::{GlobalId, Id, SourceInstanceId};
 use ore::cast::CastFrom;
 use repr::RelationDesc;
 use repr::ScalarType;
@@ -46,7 +46,7 @@ use crate::source::{
     PubNubSourceReader, S3SourceReader,
 };
 
-impl<'g, G> Context<Child<'g, G, G::Timestamp>, MirRelationExpr, Row, Timestamp>
+impl<'g, G> Context<Child<'g, G, G::Timestamp>, Row, Timestamp>
 where
     G: Scope<Timestamp = Timestamp>,
 {
@@ -98,9 +98,12 @@ where
                     })
                     .as_collection();
                 let err_collection = Collection::empty(scope);
-                self.collections.insert(
-                    MirRelationExpr::global_get(src_id, src.bare_desc.typ().clone()),
-                    (ok_collection, err_collection),
+                self.insert_id(
+                    Id::Global(src_id),
+                    crate::render::CollectionRepresentation::from_collections(
+                        ok_collection,
+                        err_collection,
+                    ),
                 );
             }
 
@@ -487,13 +490,14 @@ where
                     }
                 }
 
-                let get = MirRelationExpr::Get {
-                    id: Id::Global(src_id),
-                    typ: src.bare_desc.typ().clone(),
-                };
-
                 // Introduce the stream by name, as an unarranged collection.
-                self.collections.insert(get, (collection, err_collection));
+                self.insert_id(
+                    Id::Global(src_id),
+                    crate::render::CollectionRepresentation::from_collections(
+                        collection,
+                        err_collection,
+                    ),
+                );
 
                 let token = Rc::new(capability);
                 tokens.source_tokens.insert(src_id, token.clone());

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -100,7 +100,7 @@ where
                 let err_collection = Collection::empty(scope);
                 self.insert_id(
                     Id::Global(src_id),
-                    crate::render::CollectionRepresentation::from_collections(
+                    crate::render::CollectionBundle::from_collections(
                         ok_collection,
                         err_collection,
                     ),
@@ -493,7 +493,7 @@ where
                 // Introduce the stream by name, as an unarranged collection.
                 self.insert_id(
                     Id::Global(src_id),
-                    crate::render::CollectionRepresentation::from_collections(
+                    crate::render::CollectionBundle::from_collections(
                         collection,
                         err_collection,
                     ),

--- a/src/dataflow/src/render/threshold.rs
+++ b/src/dataflow/src/render/threshold.rs
@@ -52,10 +52,7 @@ where
                         }
                     },
                 );
-                CollectionBundle::from_columns(
-                    0..arity,
-                    ArrangementFlavor::Local(oks, errs),
-                )
+                CollectionBundle::from_columns(0..arity, ArrangementFlavor::Local(oks, errs))
             }
             ArrangementFlavor::Trace(_, oks, errs) => {
                 let oks = oks.reduce_abelian::<_, OrdValSpine<_, _, _, _>>(
@@ -70,10 +67,7 @@ where
                 );
                 use differential_dataflow::operators::arrange::ArrangeBySelf;
                 let errs = errs.as_collection(|k, _| k.clone()).arrange_by_self();
-                CollectionBundle::from_columns(
-                    0..arity,
-                    ArrangementFlavor::Local(oks, errs),
-                )
+                CollectionBundle::from_columns(0..arity, ArrangementFlavor::Local(oks, errs))
             }
         }
     }

--- a/src/dataflow/src/render/threshold.rs
+++ b/src/dataflow/src/render/threshold.rs
@@ -15,7 +15,7 @@ use timely::progress::{timestamp::Refines, Timestamp};
 
 use repr::Row;
 
-use crate::render::context::CollectionRepresentation;
+use crate::render::context::CollectionBundle;
 use crate::render::context::{ArrangementFlavor, Context};
 
 impl<G, T> Context<G, Row, T>
@@ -26,9 +26,9 @@ where
 {
     pub fn render_threshold(
         &mut self,
-        mut input: CollectionRepresentation<G, Row, T>,
+        mut input: CollectionBundle<G, Row, T>,
         arity: usize,
-    ) -> CollectionRepresentation<G, Row, T> {
+    ) -> CollectionBundle<G, Row, T> {
         // Arrange the input by all columns in order.
         // Different trace variants require different implementations because their
         // types are different, but the logic is identical.
@@ -52,7 +52,7 @@ where
                         }
                     },
                 );
-                CollectionRepresentation::from_columns(
+                CollectionBundle::from_columns(
                     0..arity,
                     ArrangementFlavor::Local(oks, errs),
                 )
@@ -70,7 +70,7 @@ where
                 );
                 use differential_dataflow::operators::arrange::ArrangeBySelf;
                 let errs = errs.as_collection(|k, _| k.clone()).arrange_by_self();
-                CollectionRepresentation::from_columns(
+                CollectionBundle::from_columns(
                     0..arity,
                     ArrangementFlavor::Local(oks, errs),
                 )

--- a/src/dataflow/src/render/threshold.rs
+++ b/src/dataflow/src/render/threshold.rs
@@ -8,85 +8,73 @@
 // by the Apache License, Version 2.0.
 
 use differential_dataflow::lattice::Lattice;
-use differential_dataflow::operators::arrange::arrangement::Arrange;
-use differential_dataflow::operators::arrange::arrangement::ArrangeByKey;
+use differential_dataflow::operators::reduce::ReduceCore;
 use differential_dataflow::trace::implementations::ord::OrdValSpine;
 use timely::dataflow::Scope;
 use timely::progress::{timestamp::Refines, Timestamp};
 
-use expr::MirRelationExpr;
 use repr::Row;
 
+use crate::render::context::CollectionRepresentation;
 use crate::render::context::{ArrangementFlavor, Context};
 
-impl<G, T> Context<G, MirRelationExpr, Row, T>
+impl<G, T> Context<G, Row, T>
 where
     G: Scope,
     G::Timestamp: Lattice + Refines<T>,
     T: Timestamp + Lattice,
 {
-    pub fn render_threshold(&mut self, relation_expr: &MirRelationExpr) {
-        if let MirRelationExpr::Threshold { input } = relation_expr {
-            // TODO: re-use and publish arrangement here.
-            let arity = input.arity();
-            let keys = (0..arity).collect::<Vec<_>>();
-
-            // TODO: easier idioms for detecting, re-using, and stashing.
-            if self.arrangement_columns(&input, &keys[..]).is_none() {
-                // self.ensure_rendered(input, scope, worker_index);
-                let (ok_built, err_built) = self.collection(input).unwrap();
-                let keys2 = keys.clone();
-                let ok_keyed = ok_built
-                    .map({
-                        move |row| {
-                            let datums = row.unpack();
-                            let iterator = keys2.iter().map(|i| datums[*i]);
-                            let total_size = repr::datums_size(iterator.clone());
-                            let mut key_row = Row::with_capacity(total_size);
-                            key_row.extend(iterator);
-                            (key_row, row)
+    pub fn render_threshold(
+        &mut self,
+        mut input: CollectionRepresentation<G, Row, T>,
+        arity: usize,
+    ) -> CollectionRepresentation<G, Row, T> {
+        // Arrange the input by all columns in order.
+        // Different trace variants require different implementations because their
+        // types are different, but the logic is identical.
+        let mut all_columns = Vec::new();
+        for column in 0..arity {
+            all_columns.push(expr::MirScalarExpr::Column(column));
+        }
+        input = input.ensure_arrangements(Some(all_columns.clone()));
+        match input
+            .arrangement(&all_columns)
+            .expect("Arrangement ensured to exist")
+        {
+            ArrangementFlavor::Local(oks, errs) => {
+                let oks = oks.reduce_abelian::<_, OrdValSpine<_, _, _, _>>(
+                    "Threshold",
+                    move |_k, s, t| {
+                        for (record, count) in s.iter() {
+                            if *count > 0 {
+                                t.push(((*record).clone(), *count));
+                            }
                         }
-                    })
-                    .arrange_by_key();
-                self.set_local_columns(&input, &keys[..], (ok_keyed, err_built.arrange()));
+                    },
+                );
+                CollectionRepresentation::from_columns(
+                    0..arity,
+                    ArrangementFlavor::Local(oks, errs),
+                )
             }
-
-            use differential_dataflow::operators::reduce::ReduceCore;
-
-            let (ok_arranged, err_arranged) = match self.arrangement_columns(&input, &keys[..]) {
-                Some(ArrangementFlavor::Local(oks, errs)) => (
-                    oks.reduce_abelian::<_, OrdValSpine<_, _, _, _>>(
-                        "Threshold",
-                        move |_k, s, t| {
-                            for (record, count) in s.iter() {
-                                if *count > 0 {
-                                    t.push(((*record).clone(), *count));
-                                }
+            ArrangementFlavor::Trace(_, oks, errs) => {
+                let oks = oks.reduce_abelian::<_, OrdValSpine<_, _, _, _>>(
+                    "Threshold",
+                    move |_k, s, t| {
+                        for (record, count) in s.iter() {
+                            if *count > 0 {
+                                t.push(((*record).clone(), *count));
                             }
-                        },
-                    ),
-                    errs,
-                ),
-                Some(ArrangementFlavor::Trace(_gid, oks, errs)) => (
-                    oks.reduce_abelian::<_, OrdValSpine<_, _, _, _>>(
-                        "Threshold",
-                        move |_k, s, t| {
-                            for (record, count) in s.iter() {
-                                if *count > 0 {
-                                    t.push(((*record).clone(), *count));
-                                }
-                            }
-                        },
-                    ),
-                    errs.as_collection(|k, _v| k.clone()).arrange(),
-                ),
-                None => {
-                    panic!("Arrangement alarmingly absent!");
-                }
-            };
-
-            let index = (0..keys.len()).collect::<Vec<_>>();
-            self.set_local_columns(relation_expr, &index[..], (ok_arranged, err_arranged));
+                        }
+                    },
+                );
+                use differential_dataflow::operators::arrange::ArrangeBySelf;
+                let errs = errs.as_collection(|k, _| k.clone()).arrange_by_self();
+                CollectionRepresentation::from_columns(
+                    0..arity,
+                    ArrangementFlavor::Local(oks, errs),
+                )
+            }
         }
     }
 }

--- a/src/dataflow/src/render/top_k.rs
+++ b/src/dataflow/src/render/top_k.rs
@@ -20,7 +20,7 @@ use timely::dataflow::Scope;
 use expr::ColumnOrder;
 use repr::{Diff, Row};
 
-use crate::render::context::CollectionRepresentation;
+use crate::render::context::CollectionBundle;
 use crate::render::context::Context;
 
 // The implementation requires integer timestamps to be able to delay feedback for monotonic inputs.
@@ -30,14 +30,14 @@ where
 {
     pub fn render_topk(
         &mut self,
-        input: CollectionRepresentation<G, Row, G::Timestamp>,
+        input: CollectionBundle<G, Row, G::Timestamp>,
         group_key: Vec<usize>,
         order_key: Vec<ColumnOrder>,
         limit: Option<usize>,
         offset: usize,
         monotonic: bool,
         arity: usize,
-    ) -> CollectionRepresentation<G, Row, G::Timestamp> {
+    ) -> CollectionBundle<G, Row, G::Timestamp> {
         let (ok_input, err_input) = input.as_collection();
 
         // We create a new region to compartmentalize the topk logic.
@@ -95,7 +95,7 @@ where
             ok_result.leave_region()
         });
 
-        return CollectionRepresentation::from_collections(ok_result, err_input);
+        return CollectionBundle::from_collections(ok_result, err_input);
 
         /// Constructs a TopK dataflow subgraph.
         fn build_topk<G>(

--- a/src/dataflow/src/render/top_k.rs
+++ b/src/dataflow/src/render/top_k.rs
@@ -17,285 +17,294 @@ use differential_dataflow::AsCollection;
 use differential_dataflow::Collection;
 use timely::dataflow::Scope;
 
-use expr::MirRelationExpr;
+use expr::ColumnOrder;
 use repr::{Diff, Row};
 
+use crate::render::context::CollectionRepresentation;
 use crate::render::context::Context;
 
 // The implementation requires integer timestamps to be able to delay feedback for monotonic inputs.
-impl<G> Context<G, MirRelationExpr, Row, repr::Timestamp>
+impl<G> Context<G, Row, repr::Timestamp>
 where
     G: Scope<Timestamp = repr::Timestamp>,
 {
-    pub fn render_topk(&mut self, relation_expr: &MirRelationExpr) {
-        if let MirRelationExpr::TopK {
-            input,
-            group_key,
-            order_key,
-            limit,
-            offset,
-            monotonic,
-        } = relation_expr
-        {
-            let arity = input.arity();
-            let (ok_input, err_input) = self.collection(input).unwrap();
+    pub fn render_topk(
+        &mut self,
+        input: CollectionRepresentation<G, Row, G::Timestamp>,
+        group_key: Vec<usize>,
+        order_key: Vec<ColumnOrder>,
+        limit: Option<usize>,
+        offset: usize,
+        monotonic: bool,
+        arity: usize,
+    ) -> CollectionRepresentation<G, Row, G::Timestamp> {
+        let (ok_input, err_input) = input.as_collection();
 
-            // We create a new region to compartmentalize the topk logic.
-            let ok_result = ok_input.scope().region_named("TopK", |inner| {
-                let ok_input = ok_input.enter(inner);
-                let ok_result = if *monotonic && *offset == 0 && *limit == Some(1) {
-                    // If the input to a TopK is monotonic (aka append-only aka no retractions) then we
-                    // don't have to worry about keeping every row we've seen around forever. Instead,
-                    // the reduce can incrementally compute a new answer by looking at just the old TopK
-                    // for a key and the incremental data.
-                    //
-                    // This optimization generalizes to any TopK over a monotonic source, but we special
-                    // case only TopK with offset=0 and limit=1 (aka Top1) for now. This is because (1)
-                    // Top1 can merge in each incremental row in constant space and time while the
-                    // generalized solution needs something like a priority queue and (2) we expect Top1
-                    // will be a common pattern used to turn a Kafka source's "upsert" semantics into
-                    // differential's semantics. (2) is especially interesting because Kafka is
-                    // monotonic with an ENVELOPE of NONE, which is the default for ENVELOPE in
-                    // Materialize and commonly used by users.
-                    render_top1_monotonic(ok_input, group_key, order_key)
-                } else if *monotonic && *offset == 0 {
-                    // For monotonic inputs, we are able to retract inputs that can no longer be produced
-                    // as outputs. Any inputs beyond `offset + limit` will never again be produced as
-                    // outputs, and can be removed. The simplest form of this is when `offset == 0` and
-                    // these removeable records are those in the input not produced in the output.
-                    // TODO: consider broadening this optimization to `offset > 0` by first filtering
-                    // down to `offset = 0` and `limit = offset + limit`, followed by a finishing act
-                    // of `offset` and `limit`, discarding only the records not produced in the intermediate
-                    // stage.
-                    use differential_dataflow::operators::iterate::Variable;
-                    let delay = std::time::Duration::from_nanos(10_000_000_000);
-                    let retractions =
-                        Variable::new(&mut ok_input.scope(), delay.as_millis() as u64);
-                    let thinned = ok_input.concat(&retractions.negate());
-                    let result = build_topk(thinned, group_key, order_key, *offset, *limit, arity);
-                    retractions.set(&ok_input.concat(&result.negate()));
-                    result
-                } else {
-                    build_topk(ok_input, group_key, order_key, *offset, *limit, arity)
-                };
-                // Extract the results from the region.
-                ok_result.leave_region()
-            });
-
-            self.collections
-                .insert(relation_expr.clone(), (ok_result, err_input));
-
-            /// Constructs a TopK dataflow subgraph.
-            fn build_topk<G>(
-                collection: Collection<G, Row, Diff>,
-                group_key: &[usize],
-                order_key: &[expr::ColumnOrder],
-                offset: usize,
-                limit: Option<usize>,
-                arity: usize,
-            ) -> Collection<G, Row, Diff>
-            where
-                G: Scope,
-                G::Timestamp: Lattice,
-            {
-                let group_clone = group_key.to_vec();
-                let mut collection = collection.map({
-                    move |row| {
-                        let row_hash = row.hashed();
-                        let datums = row.unpack();
-                        let iterator = group_clone.iter().map(|i| datums[*i]);
-                        let total_size = repr::datums_size(iterator.clone());
-                        let mut group_row = Row::with_capacity(total_size);
-                        group_row.extend(iterator);
-                        ((group_row, row_hash), row)
-                    }
-                });
-                // This sequence of numbers defines the shifts that happen to the 64 bit hash
-                // of the record, and has the properties that 1. there are not too many of them,
-                // and 2. each has a modest difference to the next.
+        // We create a new region to compartmentalize the topk logic.
+        let ok_result = ok_input.scope().region_named("TopK", |inner| {
+            let ok_input = ok_input.enter(inner);
+            let ok_result = if monotonic && offset == 0 && limit == Some(1) {
+                // If the input to a TopK is monotonic (aka append-only aka no retractions) then we
+                // don't have to worry about keeping every row we've seen around forever. Instead,
+                // the reduce can incrementally compute a new answer by looking at just the old TopK
+                // for a key and the incremental data.
                 //
-                // These two properties mean that there should be no reductions on groups that
-                // are substantially larger than `offset + limit` (the largest factor should be
-                // bounded by two raised to the difference between subsequent numbers);
-                if let Some(limit) = limit {
-                    for log_modulus in
-                        [60, 56, 52, 48, 44, 40, 36, 32, 28, 24, 20, 16, 12, 8, 4u64].iter()
-                    {
-                        // here we do not apply `offset`, but instead restrict ourself with a limit
-                        // that includes the offset. We cannot apply `offset` until we perform the
-                        // final, complete reduction.
-                        collection = build_topk_stage(
-                            collection,
-                            order_key,
-                            1u64 << log_modulus,
-                            0,
-                            Some(offset + limit),
-                            arity,
-                        );
+                // This optimization generalizes to any TopK over a monotonic source, but we special
+                // case only TopK with offset=0 and limit=1 (aka Top1) for now. This is because (1)
+                // Top1 can merge in each incremental row in constant space and time while the
+                // generalized solution needs something like a priority queue and (2) we expect Top1
+                // will be a common pattern used to turn a Kafka source's "upsert" semantics into
+                // differential's semantics. (2) is especially interesting because Kafka is
+                // monotonic with an ENVELOPE of NONE, which is the default for ENVELOPE in
+                // Materialize and commonly used by users.
+                render_top1_monotonic(ok_input, &group_key[..], &order_key[..])
+            } else if monotonic && offset == 0 {
+                // For monotonic inputs, we are able to retract inputs that can no longer be produced
+                // as outputs. Any inputs beyond `offset + limit` will never again be produced as
+                // outputs, and can be removed. The simplest form of this is when `offset == 0` and
+                // these removeable records are those in the input not produced in the output.
+                // TODO: consider broadening this optimization to `offset > 0` by first filtering
+                // down to `offset = 0` and `limit = offset + limit`, followed by a finishing act
+                // of `offset` and `limit`, discarding only the records not produced in the intermediate
+                // stage.
+                use differential_dataflow::operators::iterate::Variable;
+                let delay = std::time::Duration::from_nanos(10_000_000_000);
+                let retractions = Variable::new(&mut ok_input.scope(), delay.as_millis() as u64);
+                let thinned = ok_input.concat(&retractions.negate());
+                let result = build_topk(
+                    thinned,
+                    &group_key[..],
+                    &order_key[..],
+                    offset,
+                    limit,
+                    arity,
+                );
+                retractions.set(&ok_input.concat(&result.negate()));
+                result
+            } else {
+                build_topk(
+                    ok_input,
+                    &group_key[..],
+                    &order_key[..],
+                    offset,
+                    limit,
+                    arity,
+                )
+            };
+            // Extract the results from the region.
+            ok_result.leave_region()
+        });
+
+        return CollectionRepresentation::from_collections(ok_result, err_input);
+
+        /// Constructs a TopK dataflow subgraph.
+        fn build_topk<G>(
+            collection: Collection<G, Row, Diff>,
+            group_key: &[usize],
+            order_key: &[expr::ColumnOrder],
+            offset: usize,
+            limit: Option<usize>,
+            arity: usize,
+        ) -> Collection<G, Row, Diff>
+        where
+            G: Scope,
+            G::Timestamp: Lattice,
+        {
+            let group_clone = group_key.to_vec();
+            let mut collection = collection.map({
+                move |row| {
+                    let row_hash = row.hashed();
+                    let datums = row.unpack();
+                    let iterator = group_clone.iter().map(|i| datums[*i]);
+                    let total_size = repr::datums_size(iterator.clone());
+                    let mut group_row = Row::with_capacity(total_size);
+                    group_row.extend(iterator);
+                    ((group_row, row_hash), row)
+                }
+            });
+            // This sequence of numbers defines the shifts that happen to the 64 bit hash
+            // of the record, and has the properties that 1. there are not too many of them,
+            // and 2. each has a modest difference to the next.
+            //
+            // These two properties mean that there should be no reductions on groups that
+            // are substantially larger than `offset + limit` (the largest factor should be
+            // bounded by two raised to the difference between subsequent numbers);
+            if let Some(limit) = limit {
+                for log_modulus in
+                    [60, 56, 52, 48, 44, 40, 36, 32, 28, 24, 20, 16, 12, 8, 4u64].iter()
+                {
+                    // here we do not apply `offset`, but instead restrict ourself with a limit
+                    // that includes the offset. We cannot apply `offset` until we perform the
+                    // final, complete reduction.
+                    collection = build_topk_stage(
+                        collection,
+                        order_key,
+                        1u64 << log_modulus,
+                        0,
+                        Some(offset + limit),
+                        arity,
+                    );
+                }
+            }
+
+            // We do a final step, both to make sure that we complete the reduction, and to correctly
+            // apply `offset` to the final group, as we have not yet been applying it to the partially
+            // formed groups.
+            build_topk_stage(collection, order_key, 1u64, offset, limit, arity)
+                .map(|((_key, _hash), row)| row)
+        }
+
+        // To provide a robust incremental orderby-limit experience, we want to avoid grouping
+        // *all* records (or even large groups) and then applying the ordering and limit. Instead,
+        // a more robust approach forms groups of bounded size (here, 16) and applies the offset
+        // and limit to each, and then increases the sizes of the groups.
+
+        // Builds a "stage", which uses a finer grouping than is required to reduce the volume of
+        // updates, and to reduce the amount of work on the critical path for updates. The cost is
+        // a larger number of arrangements when this optimization does nothing beneficial.
+        fn build_topk_stage<G>(
+            collection: Collection<G, ((Row, u64), Row), Diff>,
+            order_key: &[expr::ColumnOrder],
+            modulus: u64,
+            offset: usize,
+            limit: Option<usize>,
+            arity: usize,
+        ) -> Collection<G, ((Row, u64), Row), Diff>
+        where
+            G: Scope,
+            G::Timestamp: Lattice,
+        {
+            use differential_dataflow::operators::Reduce;
+            let order_clone = order_key.to_vec();
+
+            let input = collection.map(move |((key, hash), row)| ((key, hash % modulus), row));
+            // We only want to arrange parts of the input that are not part of the actal output
+            // such that `input.concat(&negated_output.negate())` yields the correct TopK
+            let negated_output = input.reduce_named("TopK", {
+                move |_key, source, target: &mut Vec<(Row, isize)>| {
+                    // Determine if we must actually shrink the result set.
+                    let must_shrink = offset > 0
+                        || limit
+                            .map(|l| source.iter().map(|(_, d)| *d).sum::<isize>() as usize > l)
+                            .unwrap_or(false);
+                    if must_shrink {
+                        // First go ahead and emit all records
+                        for (row, diff) in source.iter() {
+                            target.push(((*row).clone(), diff.clone()));
+                        }
+                        // local copies that may count down to zero.
+                        let mut offset = offset;
+                        let mut limit = limit;
+
+                        // The order in which we should produce rows.
+                        let mut indexes = (0..source.len()).collect::<Vec<_>>();
+                        if !order_clone.is_empty() {
+                            // We decode the datums once, into a common buffer for efficiency.
+                            // Each row should contain `arity` columns; we should check that.
+                            let mut buffer = Vec::with_capacity(arity * source.len());
+                            for (index, row) in source.iter().enumerate() {
+                                buffer.extend(row.0.iter());
+                                assert_eq!(buffer.len(), arity * (index + 1));
+                            }
+                            let width = buffer.len() / source.len();
+
+                            //todo: use arrangements or otherwise make the sort more performant?
+                            indexes.sort_by(|left, right| {
+                                let left = &buffer[left * width..][..width];
+                                let right = &buffer[right * width..][..width];
+                                expr::compare_columns(&order_clone, left, right, || left.cmp(right))
+                            });
+                        }
+
+                        // We now need to lay out the data in order of `buffer`, but respecting
+                        // the `offset` and `limit` constraints.
+                        for index in indexes.into_iter() {
+                            let (row, mut diff) = source[index];
+                            if diff > 0 {
+                                // If we are still skipping early records ...
+                                if offset > 0 {
+                                    let to_skip = std::cmp::min(offset, diff as usize);
+                                    offset -= to_skip;
+                                    diff -= to_skip as isize;
+                                }
+                                // We should produce at most `limit` records.
+                                if let Some(limit) = &mut limit {
+                                    diff = std::cmp::min(diff, *limit as isize);
+                                    *limit -= diff as usize;
+                                }
+                                // Output the indicated number of rows.
+                                if diff > 0 {
+                                    // Emit retractions for the elements actually part of
+                                    // the set of TopK elements.
+                                    target.push((row.clone(), -diff));
+                                }
+                            }
+                        }
                     }
                 }
+            });
 
-                // We do a final step, both to make sure that we complete the reduction, and to correctly
-                // apply `offset` to the final group, as we have not yet been applying it to the partially
-                // formed groups.
-                build_topk_stage(collection, order_key, 1u64, offset, limit, arity)
-                    .map(|((_key, _hash), row)| row)
-            }
+            negated_output.negate().concat(&input).consolidate()
+        }
 
-            // To provide a robust incremental orderby-limit experience, we want to avoid grouping
-            // *all* records (or even large groups) and then applying the ordering and limit. Instead,
-            // a more robust approach forms groups of bounded size (here, 16) and applies the offset
-            // and limit to each, and then increases the sizes of the groups.
+        fn render_top1_monotonic<G>(
+            collection: Collection<G, Row, Diff>,
+            group_key: &[usize],
+            order_key: &[expr::ColumnOrder],
+        ) -> Collection<G, Row, Diff>
+        where
+            G: Scope,
+            G::Timestamp: Lattice,
+        {
+            // We can place our rows directly into the diff field, and only keep the relevant one
+            // corresponding to evaluating our aggregate, instead of having to do a hierarchical
+            // reduction.
+            use timely::dataflow::operators::Map;
 
-            // Builds a "stage", which uses a finer grouping than is required to reduce the volume of
-            // updates, and to reduce the amount of work on the critical path for updates. The cost is
-            // a larger number of arrangements when this optimization does nothing beneficial.
-            fn build_topk_stage<G>(
-                collection: Collection<G, ((Row, u64), Row), Diff>,
-                order_key: &[expr::ColumnOrder],
-                modulus: u64,
-                offset: usize,
-                limit: Option<usize>,
-                arity: usize,
-            ) -> Collection<G, ((Row, u64), Row), Diff>
-            where
-                G: Scope,
-                G::Timestamp: Lattice,
-            {
-                use differential_dataflow::operators::Reduce;
-                let order_clone = order_key.to_vec();
+            let group_clone = group_key.to_vec();
+            let collection = collection.map({
+                move |row| {
+                    let datums = row.unpack();
+                    let iterator = group_clone.iter().map(|i| datums[*i]);
+                    let total_size = repr::datums_size(iterator.clone());
+                    let mut group_key = Row::with_capacity(total_size);
+                    group_key.extend(iterator);
+                    (group_key, row)
+                }
+            });
 
-                let input = collection.map(move |((key, hash), row)| ((key, hash % modulus), row));
-                // We only want to arrange parts of the input that are not part of the actal output
-                // such that `input.concat(&negated_output.negate())` yields the correct TopK
-                let negated_output = input.reduce_named("TopK", {
-                    move |_key, source, target: &mut Vec<(Row, isize)>| {
-                        // Determine if we must actually shrink the result set.
-                        let must_shrink = offset > 0
-                            || limit
-                                .map(|l| source.iter().map(|(_, d)| *d).sum::<isize>() as usize > l)
-                                .unwrap_or(false);
-                        if must_shrink {
-                            // First go ahead and emit all records
-                            for (row, diff) in source.iter() {
-                                target.push(((*row).clone(), diff.clone()));
-                            }
-                            // local copies that may count down to zero.
-                            let mut offset = offset;
-                            let mut limit = limit;
-
-                            // The order in which we should produce rows.
-                            let mut indexes = (0..source.len()).collect::<Vec<_>>();
-                            if !order_clone.is_empty() {
-                                // We decode the datums once, into a common buffer for efficiency.
-                                // Each row should contain `arity` columns; we should check that.
-                                let mut buffer = Vec::with_capacity(arity * source.len());
-                                for (index, row) in source.iter().enumerate() {
-                                    buffer.extend(row.0.iter());
-                                    assert_eq!(buffer.len(), arity * (index + 1));
-                                }
-                                let width = buffer.len() / source.len();
-
-                                //todo: use arrangements or otherwise make the sort more performant?
-                                indexes.sort_by(|left, right| {
-                                    let left = &buffer[left * width..][..width];
-                                    let right = &buffer[right * width..][..width];
-                                    expr::compare_columns(&order_clone, left, right, || {
-                                        left.cmp(right)
-                                    })
-                                });
-                            }
-
-                            // We now need to lay out the data in order of `buffer`, but respecting
-                            // the `offset` and `limit` constraints.
-                            for index in indexes.into_iter() {
-                                let (row, mut diff) = source[index];
-                                if diff > 0 {
-                                    // If we are still skipping early records ...
-                                    if offset > 0 {
-                                        let to_skip = std::cmp::min(offset, diff as usize);
-                                        offset -= to_skip;
-                                        diff -= to_skip as isize;
-                                    }
-                                    // We should produce at most `limit` records.
-                                    if let Some(limit) = &mut limit {
-                                        diff = std::cmp::min(diff, *limit as isize);
-                                        *limit -= diff as usize;
-                                    }
-                                    // Output the indicated number of rows.
-                                    if diff > 0 {
-                                        // Emit retractions for the elements actually part of
-                                        // the set of TopK elements.
-                                        target.push((row.clone(), -diff));
-                                    }
-                                }
-                            }
-                        }
+            // We arrange the inputs ourself to force it into a leaner structure because we know we
+            // won't care about values.
+            //
+            // TODO: Could we use explode here? We'd lose the diff>0 assert and we'd have to impl Mul
+            // for the monoid, unclear if it's worth it.
+            let order_clone = order_key.to_vec();
+            let partial: Collection<G, Row, monoids::Top1Monoid> = collection
+                .consolidate()
+                .inner
+                .map(move |((group_key, row), time, diff)| {
+                    assert!(diff > 0);
+                    // NB: Top1 can throw out the diff since we've asserted that it's > 0. A more
+                    // general TopK monoid would have to account for diff.
+                    (
+                        group_key,
+                        time,
+                        monoids::Top1Monoid {
+                            row,
+                            order_key: order_clone.clone(),
+                        },
+                    )
+                })
+                .as_collection();
+            let result = partial
+                .arrange_by_self()
+                .reduce_abelian::<_, OrdValSpine<_, _, _, _>>("Top1Monotonic", {
+                    move |_key, input, output| {
+                        let accum = &input[0].1;
+                        output.push((accum.row.clone(), 1));
                     }
                 });
-
-                negated_output.negate().concat(&input).consolidate()
-            }
-
-            fn render_top1_monotonic<G>(
-                collection: Collection<G, Row, Diff>,
-                group_key: &[usize],
-                order_key: &[expr::ColumnOrder],
-            ) -> Collection<G, Row, Diff>
-            where
-                G: Scope,
-                G::Timestamp: Lattice,
-            {
-                // We can place our rows directly into the diff field, and only keep the relevant one
-                // corresponding to evaluating our aggregate, instead of having to do a hierarchical
-                // reduction.
-                use timely::dataflow::operators::Map;
-
-                let group_clone = group_key.to_vec();
-                let collection = collection.map({
-                    move |row| {
-                        let datums = row.unpack();
-                        let iterator = group_clone.iter().map(|i| datums[*i]);
-                        let total_size = repr::datums_size(iterator.clone());
-                        let mut group_key = Row::with_capacity(total_size);
-                        group_key.extend(iterator);
-                        (group_key, row)
-                    }
-                });
-
-                // We arrange the inputs ourself to force it into a leaner structure because we know we
-                // won't care about values.
-                //
-                // TODO: Could we use explode here? We'd lose the diff>0 assert and we'd have to impl Mul
-                // for the monoid, unclear if it's worth it.
-                let order_clone = order_key.to_vec();
-                let partial: Collection<G, Row, monoids::Top1Monoid> = collection
-                    .consolidate()
-                    .inner
-                    .map(move |((group_key, row), time, diff)| {
-                        assert!(diff > 0);
-                        // NB: Top1 can throw out the diff since we've asserted that it's > 0. A more
-                        // general TopK monoid would have to account for diff.
-                        (
-                            group_key,
-                            time,
-                            monoids::Top1Monoid {
-                                row,
-                                order_key: order_clone.clone(),
-                            },
-                        )
-                    })
-                    .as_collection();
-                let result = partial
-                    .arrange_by_self()
-                    .reduce_abelian::<_, OrdValSpine<_, _, _, _>>("Top1Monotonic", {
-                        move |_key, input, output| {
-                            let accum = &input[0].1;
-                            output.push((accum.row.clone(), 1));
-                        }
-                    });
-                result.as_collection(|_k, v| v.clone())
-            }
+            result.as_collection(|_k, v| v.clone())
         }
     }
 }

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -37,7 +37,7 @@ pub struct MapFilterProject {
     /// Expressions that must evaluate to `Datum::True` for the output
     /// row to be produced.
     ///
-    /// Each entry is pre-pended with a column identifier indicating
+    /// Each entry is prepended with a column identifier indicating
     /// the column *before* which the predicate should first be applied.
     /// Most commonly this would be one plus the largest column identifier
     /// in the predicate's support, but it could be larger to implement


### PR DESCRIPTION
This PR introduces a low-level intermediate representation for rendering dataflows. The `Plan` type is closely coupled to the actual dataflow rendering, and should stay so as the rendering techniques evolve. Rendering is now fairly substantially different (documentation still needs to be updated): rather than a collection of bindings of `MirRelationExpr`s to various collection representations, the `Context` tracks only bound identifiers, and simply renders and hands off collections to the LIR node above them (which may install it for sharing, as a `Let`, but otherwise consumes them and moves on).

This approach was fairly disruptive, not to the core of rendering, but a lot of contact points nonetheless. There are currently errors, though things do seem to run without crashing. There are also some potential performance regressions as various moments of sideways communication no longer happen (e.g. an arrangement formed in on branch of an expression would be shared with operators in another branch; we now rely on `Let` to communicate this explicitly).

The PR is up for inspection, and to terrify anyone who wants that. I need to chase down some of the bugs, but it would be interesting to get a take on the rough structure, which is seen mainly in the `Context::render_plan` method.

cc: @ruchirK , @wangandi , @asenac 