### PR TITLE
docs: update required permissions for sqs notifications

### DIFF
--- a/doc/user/layouts/partials/create-source/connector/s3/with-options.html
+++ b/doc/user/layouts/partials/create-source/connector/s3/with-options.html
@@ -21,7 +21,7 @@ of key names to download, you must grant the Materialize IAM User or Role the `L
 |-----------------------|------------------------------------------------------------------------------------------|
 | All                   | [`GetObject` permission][getobject] for the objects to be downloaded              |
 | **BUCKET SCAN**       | [`ListObject` permission][listobject] for the buckets to be scanned, **unless** the `MATCHING` pattern can only match a single object. In such cases, Materialize will perform only the necessary `GetObject` API call. |
-| **SQS NOTIFICATIONS** | `GetMessage`, `GetQueueUrl` [SQS Permissions][sqs-perms] for the queue Materialize will listen to |
+| **SQS NOTIFICATIONS** | `ChangeMessageVisibility`, `DeleteMessage`, `GetQueueUrl`, `ReceiveMessage` [SQS Permissions][sqs-perms] for the queue Materialize will listen to |
 
 The root AWS documentation for S3 permissions is [available here][s3-permissions].
 


### PR DESCRIPTION
SQS notifications will not work with the set of permissions in the current docs (`GetMessage` doesn't actually exist for sqs). I have updated the docs to what i believe is the minimal set of necessary permissions.