### PR TITLE
testdrive: apply --no-reset to AWS resources as well

### DIFF
--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -76,8 +76,8 @@ pub struct Config {
     /// If present, testdrive will periodically verify that the on-disk catalog
     /// matches its expectations.
     pub materialized_catalog_path: Option<PathBuf>,
-    /// Whether to reset materialized's state at the start of each script.
-    pub reset_materialized: bool,
+    /// Whether to reset Materialized and AWS's state at the start of each script.
+    pub reset: bool,
     /// Emit Buildkite-specific markup.
     pub ci_output: bool,
     /// The default timeout to use for any operation that is retried.

--- a/src/testdrive/src/lib.rs
+++ b/src/testdrive/src/lib.rs
@@ -87,7 +87,7 @@ async fn run_line_reader(config: &Config, line_reader: &mut LineReader<'_>) -> R
         println!("Run {} ...", execution_count);
         cmds_exec = cmds.clone();
         let (mut state, state_cleanup) = action::create_state(config).await?;
-        if config.reset_materialized {
+        if config.reset {
             state.reset_materialized().await?;
         }
         let actions = action::build(cmds_exec, &state)?;
@@ -99,16 +99,23 @@ async fn run_line_reader(config: &Config, line_reader: &mut LineReader<'_>) -> R
             let redo = a.action.redo(&mut state);
             redo.await.map_err(|e| InputError { msg: e, pos: a.pos })?;
         }
+
         let mut errors = Vec::new();
-        if let Err(e) = state.reset_s3().await {
-            errors.push(e);
+
+        if config.reset {
+            if let Err(e) = state.reset_s3().await {
+                errors.push(e);
+            }
+
+            if let Err(e) = state.reset_sqs().await {
+                errors.push(e);
+            }
+
+            if let Err(e) = state.reset_kinesis().await {
+                errors.push(e);
+            }
         }
-        if let Err(e) = state.reset_sqs().await {
-            errors.push(e);
-        }
-        if let Err(e) = state.reset_kinesis().await {
-            errors.push(e);
-        }
+
         drop(state);
         if let Err(e) = state_cleanup.await {
             errors.push(e);

--- a/src/testdrive/src/main.rs
+++ b/src/testdrive/src/main.rs
@@ -163,7 +163,7 @@ async fn main() {
         aws_credentials,
         materialized_pgconfig: args.materialized_url,
         materialized_catalog_path: args.validate_catalog,
-        reset_materialized: !args.no_reset,
+        reset: !args.no_reset,
         ci_output: args.ci_output,
         default_timeout,
         seed: args.seed,


### PR DESCRIPTION
Do not clean up AWS resources if the --no-reset option is specified.
This allows the creation of S3 tests with multiple testdrive stages.