### PR TITLE
coord: teach timedomains to also filter by timeline

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -28,7 +28,7 @@ use serde::{Deserialize, Serialize};
 
 use build_info::DUMMY_BUILD_INFO;
 use dataflow_types::{SinkConnector, SinkConnectorBuilder, SourceConnector, Timeline};
-use expr::{ExprHumanizer, GlobalId, MirRelationExpr, MirScalarExpr, OptimizedMirRelationExpr};
+use expr::{ExprHumanizer, GlobalId, MirScalarExpr, OptimizedMirRelationExpr};
 use repr::{ColumnType, RelationDesc, ScalarType};
 use sql::ast::display::AstDisplay;
 use sql::ast::{Expr, Raw};
@@ -2022,18 +2022,13 @@ impl Catalog {
         self.by_id.values()
     }
 
-    /// Returns the items in a "time domain" for an expression.
-    ///
-    /// A "time domain" is a set of relations (tables, views, sources) that need to
-    /// share time guarantees. Currently we assume time domains to mean "everything
-    /// in a schema". For example, a read transaction on table A in some schema may
-    /// also need to query table B in the same schema, so A and B (and all other
-    /// tables and views in the schema) are in the same time domain.
-    pub fn timedomain_for(&self, source: &MirRelationExpr, conn_id: u32) -> Vec<GlobalId> {
+    /// Returns all tables, views, and sources in the same schemas as a set of
+    /// input ids.
+    pub fn schema_adjacent_relations(&self, sources: &[GlobalId], conn_id: u32) -> Vec<GlobalId> {
         // Find all relations referenced by the expression. Find their parent schemas
         // and add all tables, views, and sources in those schemas to a set.
         let mut ids = HashSet::new();
-        for id in source.global_uses() {
+        for id in sources {
             let entry = self.get_by_id(&id);
             let name = entry.name();
             if let Some(schema) = self.get_schema(&name.database, &name.schema, conn_id) {

--- a/test/testdrive/timelines.td
+++ b/test/testdrive/timelines.td
@@ -245,3 +245,21 @@ Dataflow cannot use multiple timelines
 > CREATE MATERIALIZED VIEW source_cdcv2_table_system AS SELECT * FROM source_cdcv2_system, input_table;
 ! CREATE MATERIALIZED VIEW must_fail AS SELECT * FROM source_cdcv2, input_table;
 Dataflow cannot use multiple timelines
+
+# Verify that timedomains don't cross timelines. In the case that
+# source_byo is grouped in the same timedomain as epoch ms sources,
+# the SELECT will hang forever. We expect the error here since we have
+# not written any rows so its upper is still 0, which determine_timestamp
+# complains about.
+> BEGIN;
+! SELECT * FROM source_byo;
+At least one input has no complete timestamps yet
+> ROLLBACK;
+
+# Verify that if the transaction starts on some timeline (epoch ms here),
+# things outside that are not there due to timedomain reasons.
+> BEGIN;
+> SELECT * FROM input_table;
+! SELECT * FROM source_byo;
+transactions can only reference nearby relations
+> ROLLBACK;


### PR DESCRIPTION
With the addition of timelines, we can improve the time domain feature
of transactions. Previously (even before timelines were added), if you
had a CDC/Debezium consistency topic source in the same schema as an
epoch source, selecting from a source that had timestamps less than epoch
milliseconds inside a transaction would block forever because we helpfully
bumped up the chosen timestamp to be valid for all sources in the schema.

Prevent this by filtering timedomain ids to be in the same timeline as the
original query so users can have multiple timelines in the same schema.