### PR TITLE
sql: require apd function impl args to be explicitly cast

### DIFF
--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -372,6 +372,16 @@ impl ParamList {
 
         for (i, typ) in typs.iter().enumerate() {
             let param = &self[i];
+
+            // Require explicitly cast APD values to prevent confusion
+            // w/ current decimal impls
+            // todo(apd): remove this when merging with decimal
+            if param == &ParamType::Plain(ScalarType::APD { scale: None })
+                && !matches!(typ, Some(ScalarType::APD { .. }))
+            {
+                return false;
+            }
+
             if let Some(typ) = typ {
                 // Ensures either `typ` can at least be implicitly cast to a
                 // type `param` accepts. Implicit in this check is that unknown


### PR DESCRIPTION
While we're developing the new decimal type (apd) alongside the
current decimal implementation, ensure that only values explicitly
cast as apd (i.e. have a known type of apd) are accepted for
apd functions; i.e. do not coerce e.g. ints to apd in function
selection.