### PR TITLE
Do not propagate error literals through join inputs

### DIFF
--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -1400,7 +1400,7 @@ impl AggregateExpr {
             | AggregateFunc::MinTimestampTz
             | AggregateFunc::Any
             | AggregateFunc::All => self.expr.is_literal(),
-            _ => false,
+            _ => self.expr.is_literal_err(),
         }
     }
 }

--- a/src/transform/src/column_knowledge.rs
+++ b/src/transform/src/column_knowledge.rs
@@ -165,7 +165,13 @@ impl ColumnKnowledge {
                 // Aggregate column knowledge from each input into one `Vec`.
                 let mut knowledges = Vec::new();
                 for input in inputs.iter_mut() {
-                    for knowledge in ColumnKnowledge::harvest(input, knowledge)? {
+                    for mut knowledge in ColumnKnowledge::harvest(input, knowledge)? {
+                        // Do not propagate error literals beyond join inputs, since that may result
+                        // in them being propagated to other inputs of the join and evaluated when
+                        // they should not.
+                        if let Some((Err(_), _)) = knowledge.value {
+                            knowledge.value = None;
+                        }
                         knowledges.push(knowledge);
                     }
                 }

--- a/src/transform/src/map_lifting.rs
+++ b/src/transform/src/map_lifting.rs
@@ -494,10 +494,11 @@ impl LiteralLifting {
 
                 let eval_constant_aggr = |aggr: &expr::AggregateExpr| {
                     let temp = repr::RowArena::new();
-                    let eval = aggr
-                        .func
-                        .eval(Some(aggr.expr.eval(&[], &temp).unwrap()), &temp);
-                    MirScalarExpr::literal_ok(
+                    let mut eval = aggr.expr.eval(&[], &temp);
+                    if let Ok(param) = eval {
+                        eval = Ok(aggr.func.eval(Some(param), &temp));
+                    }
+                    MirScalarExpr::literal(
                         eval,
                         // This type information should be available in the `a.expr` literal,
                         // but extracting it with pattern matching seems awkward.

--- a/test/sqllogictest/transform/lifting.slt
+++ b/test/sqllogictest/transform/lifting.slt
@@ -584,6 +584,33 @@ EOF
 
 # regression tests for #6943
 query T multiline
+explain select min(1/x) from (select a as y, 0 as x from t);
+----
+%0 = Let l0 =
+| Get materialize.public.t (u1)
+| Distinct group=()
+
+%1 =
+| Get %0 (l0)
+| Map (err: division by zero)
+
+%2 =
+| Get %0 (l0)
+| Negate
+
+%3 =
+| Constant ()
+
+%4 =
+| Union %2 %3
+| Map null
+
+%5 =
+| Union %1 %4
+
+EOF
+
+query T multiline
 explain select min(a) from t_pk where a between 38 and 195 and a = (select a from t where a = 1308);
 ----
 %0 =

--- a/test/sqllogictest/transform/lifting.slt
+++ b/test/sqllogictest/transform/lifting.slt
@@ -731,3 +731,35 @@ insert into t values (1308);
 
 statement error more than one record produced in subquery
 select min(a) from t_pk where a between 38 and 195 and a = (select a from t where a = 1308);
+
+# check that literal errors are not lifted beyond Joins, but also that that doesn't lead to
+# a stack overflow due to LiteralLifting and JoinImplementation fighting against each other
+statement ok
+create table t1 (f1 double precision, f2 double precision not null);
+
+query T multiline
+explain select * from t1 as a1 join t1 as a2 on (a2.f2 = (select 6 from t1)) where a2.f2 = 9;
+----
+%0 =
+| Get materialize.public.t1 (u5)
+| ArrangeBy ()
+
+%1 =
+| Get materialize.public.t1 (u5)
+| Filter (#1 = 9)
+
+%2 =
+| Get materialize.public.t1 (u5)
+| Reduce group=()
+| | agg count(true)
+| Filter (err: more than one record produced in subquery), (#0 > 1)
+| Map (err: more than one record produced in subquery)
+| ArrangeBy ()
+
+%3 =
+| Join %0 %1 %2
+| | implementation = Differential %1 %2.() %0.()
+| | demand = (#0..#3)
+| Project (#0..#3)
+
+EOF

--- a/test/sqllogictest/transform/lifting.slt
+++ b/test/sqllogictest/transform/lifting.slt
@@ -611,6 +611,33 @@ explain select min(1/x) from (select a as y, 0 as x from t);
 EOF
 
 query T multiline
+explain select sum(1/x) from (select a as y, 0 as x from t);
+----
+%0 = Let l0 =
+| Get materialize.public.t (u1)
+| Distinct group=()
+
+%1 =
+| Get %0 (l0)
+| Map (err: division by zero)
+
+%2 =
+| Get %0 (l0)
+| Negate
+
+%3 =
+| Constant ()
+
+%4 =
+| Union %2 %3
+| Map null
+
+%5 =
+| Union %1 %4
+
+EOF
+
+query T multiline
 explain select min(a) from t_pk where a between 38 and 195 and a = (select a from t where a = 1308);
 ----
 %0 =

--- a/test/sqllogictest/transform/lifting.slt
+++ b/test/sqllogictest/transform/lifting.slt
@@ -581,3 +581,126 @@ select a, b, min(2), max(3) from t where b = 1 group by a, b;
 | Map 1, 2, 3
 
 EOF
+
+# regression tests for #6943
+query T multiline
+explain select min(a) from t_pk where a between 38 and 195 and a = (select a from t where a = 1308);
+----
+%0 =
+| Get materialize.public.t_pk (u3)
+| ArrangeBy (#0)
+
+%1 =
+| Get materialize.public.t (u1)
+| Filter (#0 = 1308)
+| Reduce group=()
+| | agg count(true)
+| Filter (err: more than one record produced in subquery), (#0 > 1)
+| Map (err: more than one record produced in subquery)
+
+%2 = Let l0 =
+| Join %0 %1 (= #0 #3)
+| | implementation = Differential %1 %0.(#0)
+| | demand = (#0)
+| Filter (#0 <= 195), (#0 >= 38)
+| Reduce group=()
+| | agg min(#0)
+
+%3 =
+| Get %2 (l0)
+| Negate
+| Project ()
+
+%4 =
+| Constant ()
+
+%5 =
+| Union %3 %4
+| Map null
+
+%6 =
+| Union %2 %5
+
+EOF
+
+query T multiline
+explain select min(a) from t where a between 38 and 195 and a = (select a from t where a = 1308);
+----
+%0 = Let l0 =
+| Get materialize.public.t (u1)
+| Filter (#0 = 1308)
+
+%1 =
+| Get materialize.public.t (u1)
+| Filter !(isnull(#0)), (#0 <= 195), (#0 >= 38)
+| ArrangeBy (#0)
+
+%2 =
+| Get %0 (l0)
+| Project (#0)
+
+%3 =
+| Get %0 (l0)
+| Reduce group=()
+| | agg count(true)
+| Filter (err: more than one record produced in subquery), (#0 > 1)
+| Map (err: more than one record produced in subquery)
+| Project (#1)
+
+%4 =
+| Union %2 %3
+
+%5 = Let l1 =
+| Join %1 %4 (= #0 #2)
+| | implementation = Differential %4 %1.(#0)
+| | demand = (#0)
+| Reduce group=()
+| | agg min(#0)
+
+%6 =
+| Get %5 (l1)
+| Negate
+| Project ()
+
+%7 =
+| Constant ()
+
+%8 =
+| Union %6 %7
+| Map null
+
+%9 =
+| Union %5 %8
+
+EOF
+
+statement ok
+insert into t_pk values (40);
+
+# check no error is returned, but a NULL result
+query I
+select min(a) from t_pk where a between 38 and 195 and a = (select a from t where a = 1308);
+----
+NULL
+
+statement ok
+insert into t values (1308);
+
+query I
+select min(a) from t_pk where a between 38 and 195 and a = (select a from t where a = 1308);
+----
+NULL
+
+statement ok
+insert into t_pk values (1308);
+
+query I
+select min(a) from t_pk where a between 38 and 195 and a = (select a from t where a = 1308);
+----
+NULL
+
+statement ok
+insert into t values (1308);
+
+statement error more than one record produced in subquery
+select min(a) from t_pk where a between 38 and 195 and a = (select a from t where a = 1308);


### PR DESCRIPTION
That may result in them being evaluated before they should, resulting in queries with impossible conditions returning errors, rather than empty results.

Fixes #6943 