### PR TITLE
persist: start documenting and debug_asserting some invariants

### DIFF
--- a/src/persist/src/error.rs
+++ b/src/persist/src/error.rs
@@ -28,6 +28,18 @@ impl fmt::Display for Error {
     }
 }
 
+// Hack so we can debug_assert_eq against Result<(), Error>.
+impl PartialEq for Error {
+    fn eq(&self, other: &Self) -> bool {
+        if let Error::String(s) = self {
+            if let Error::String(o) = other {
+                return s == o;
+            }
+        }
+        return false;
+    }
+}
+
 impl From<io::Error> for Error {
     fn from(e: io::Error) -> Self {
         Error::IO(e)
@@ -37,6 +49,12 @@ impl From<io::Error> for Error {
 impl From<String> for Error {
     fn from(e: String) -> Self {
         Error::String(e)
+    }
+}
+
+impl<'a> From<&'a str> for Error {
+    fn from(e: &'a str) -> Self {
+        Error::String(e.into())
     }
 }
 

--- a/src/persist/src/indexed/cache.rs
+++ b/src/persist/src/indexed/cache.rs
@@ -15,7 +15,7 @@ use std::sync::{Arc, Mutex};
 use abomonation::abomonated::Abomonated;
 
 use crate::error::Error;
-use crate::indexed::{BlobFutureBatch, BlobMeta, BlobTraceBatch};
+use crate::indexed::encoding::{BlobFutureBatch, BlobMeta, BlobTraceBatch};
 use crate::storage::Blob;
 
 /// A disk-backed cache for objects in [Blob] storage.
@@ -75,16 +75,17 @@ impl<L: Blob> BlobCache<L> {
             .blob
             .lock()?
             .get(key)?
-            .ok_or_else(|| Error::from(format!("no blob for key: {}", key)))?
-            .clone();
-        let val: Abomonated<BlobFutureBatch, Vec<u8>> = unsafe { Abomonated::new(bytes) }
+            .ok_or_else(|| Error::from(format!("no blob for key: {}", key)))?;
+        let batch: Abomonated<BlobFutureBatch, Vec<u8>> = unsafe { Abomonated::new(bytes) }
             .ok_or_else(|| Error::from(format!("invalid batch at key: {}", key)))?;
 
         // NB: Batch blobs are write-once, so we're not worried about the race
         // of two get calls for the same key.
         let mut cache = self.future.lock()?;
         // TODO: Well this is ugly.
-        cache.insert(key.to_owned(), Arc::new((*val).clone()));
+        let batch = (*batch).clone();
+        debug_assert_eq!(batch.validate(), Ok(()), "{:?}", &batch);
+        cache.insert(key.to_owned(), Arc::new(batch));
         Ok(cache.get(key).unwrap().clone())
     }
 
@@ -93,6 +94,7 @@ impl<L: Blob> BlobCache<L> {
         if key == Self::META_KEY {
             return Err(format!("cannot write trace batch to meta key: {}", Self::META_KEY).into());
         }
+        debug_assert_eq!(batch.validate(), Ok(()), "{:?}", &batch);
 
         let mut val = Vec::new();
         unsafe { abomonation::encode(&batch, &mut val) }.expect("write to Vec is infallible");
@@ -116,16 +118,17 @@ impl<L: Blob> BlobCache<L> {
             .blob
             .lock()?
             .get(key)?
-            .ok_or_else(|| Error::from(format!("no blob for key: {}", key)))?
-            .clone();
-        let val: Abomonated<BlobTraceBatch, Vec<u8>> = unsafe { Abomonated::new(bytes) }
+            .ok_or_else(|| Error::from(format!("no blob for key: {}", key)))?;
+        let batch: Abomonated<BlobTraceBatch, Vec<u8>> = unsafe { Abomonated::new(bytes) }
             .ok_or_else(|| Error::from(format!("invalid batch at key: {}", key)))?;
 
         // NB: Batch blobs are write-once, so we're not worried about the race
         // of two get calls for the same key.
         let mut cache = self.trace.lock()?;
         // TODO: Well this is ugly.
-        cache.insert(key.to_owned(), Arc::new((*val).clone()));
+        let batch = (*batch).clone();
+        debug_assert_eq!(batch.validate(), Ok(()), "{:?}", &batch);
+        cache.insert(key.to_owned(), Arc::new(batch));
         Ok(cache.get(key).unwrap().clone())
     }
 
@@ -134,6 +137,7 @@ impl<L: Blob> BlobCache<L> {
         if key == Self::META_KEY {
             return Err(format!("cannot write trace batch to meta key: {}", Self::META_KEY).into());
         }
+        debug_assert_eq!(batch.validate(), Ok(()), "{:?}", &batch);
 
         let mut val = Vec::new();
         unsafe { abomonation::encode(&batch, &mut val) }.expect("write to Vec is infallible");
@@ -148,16 +152,17 @@ impl<L: Blob> BlobCache<L> {
         let bytes = match blob.get(Self::META_KEY)? {
             Some(bytes) => bytes,
             None => return Ok(None),
-        }
-        .to_owned();
-        let val: Abomonated<BlobMeta, Vec<u8>> = unsafe { Abomonated::new(bytes) }
+        };
+        let meta: Abomonated<BlobMeta, Vec<u8>> = unsafe { Abomonated::new(bytes) }
             .ok_or_else(|| Error::from(format!("invalid meta at key: {}", Self::META_KEY)))?;
-        let m = (*val).clone();
-        Ok(Some(m))
+        let meta = (*meta).clone();
+        debug_assert_eq!(meta.validate(), Ok(()), "{:?}", &meta);
+        Ok(Some(meta))
     }
 
     /// Overwrites metadata about what batches are in [Blob] storage.
     pub fn set_meta(&self, meta: BlobMeta) -> Result<(), Error> {
+        debug_assert_eq!(meta.validate(), Ok(()), "{:?}", &meta);
         let mut val = Vec::new();
         unsafe { abomonation::encode(&meta, &mut val) }.expect("write to Vec is infallible");
         self.blob.lock()?.set(Self::META_KEY, val, true)

--- a/src/persist/src/indexed/encoding.rs
+++ b/src/persist/src/indexed/encoding.rs
@@ -1,0 +1,648 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Data structures stored in Blobs and Buffers in serialized form.
+
+use std::cmp::Ordering;
+use std::time::SystemTime;
+
+use abomonation_derive::Abomonation;
+use differential_dataflow::trace::Description;
+use timely::progress::Antichain;
+use timely::PartialOrder;
+
+use crate::error::Error;
+use crate::storage::SeqNo;
+
+/// The structure serialized and stored as an entry in a
+/// [crate::storage::Buffer].
+///
+/// Invariants:
+/// - The updates field is non-empty.
+#[derive(Debug, Abomonation)]
+pub struct BufferEntry {
+    /// Id of the stream this batch belongs to.
+    pub id: u64,
+    /// The updates themselves.
+    pub updates: Vec<((String, String), u64, isize)>,
+}
+
+/// The structure serialized and stored as a value in [crate::storage::Blob]
+/// storage for metadata keys.
+///
+/// TODO: Invariants
+#[derive(Clone, Debug, Abomonation)]
+pub struct BlobMeta {
+    /// The most recently assigned key name.
+    pub last_file_id: u128,
+    /// BlobFutures indexed by stream id.
+    ///
+    /// A stream id should be in here at most once. This would be more naturally
+    /// be modeled as a map from Id to BlobFutureMeta, but that doesn't work
+    /// with Abomonation.
+    pub futures: Vec<(u64, BlobFutureMeta)>,
+    /// BlobFutures indexed by stream id.
+    ///
+    /// A stream id should be in here at most once. This would be more naturally
+    /// be modeled as a map from Id to BlobTraceMeta, but that doesn't work with
+    /// Abomonation.
+    pub traces: Vec<(u64, BlobTraceMeta)>,
+}
+
+/// The metadata necessary to reconstruct a BlobFuture.
+///
+/// Invariants:
+/// - The batch SeqNo ranges are sorted, non-overlapping, and contiguous.
+#[derive(Clone, Debug, Abomonation)]
+pub struct BlobFutureMeta {
+    /// A lower bound of data contained by this BlobFuture. Data before this may
+    /// be present in the batches, but has been logically moved into the trace
+    /// and should be ignored.
+    pub ts_lower: Antichain<u64>,
+    /// The batches that make up the BlobFuture, represented by their
+    /// description and the key to retrieve the batch's data from the blob
+    /// store. Note that Descriptions are half-open intervals `[lower, upper)`.
+    pub batches: Vec<(Description<SeqNo>, String)>,
+}
+
+/// The metadata necessary to reconstruct a BlobTrace.
+///
+/// Invariants:
+/// - The batch Descriptions are sorted, non-overlapping, and contiguous.
+#[derive(Clone, Debug, Abomonation)]
+pub struct BlobTraceMeta {
+    /// The batches that make up the BlobTrace, represented by their description
+    /// and the key to retrieve the batch's data from the blob store. Note that
+    /// Descriptions are half-open intervals `[lower, upper)`.
+    pub batches: Vec<(Description<u64>, String)>,
+}
+
+/// The structure serialized and stored as a value in [crate::storage::Blob]
+/// storage for data keys corresponding to future data.
+///
+/// Invariants:
+/// - The seqno of each update is >= to desc.lower() and < desc.upper().
+/// - The values in updates are sorted by (time, key, value).
+/// - The values in updates are "consolidated", i.e. (time, key, value) is
+///   unique.
+/// - All entries have a non-zero diff.
+/// - The updates field is non-empty.
+#[derive(Clone, Debug, Abomonation)]
+pub struct BlobFutureBatch {
+    /// Id of the stream this batch belongs to.
+    pub id: u64,
+    /// Which updates are included in this batch.
+    pub desc: Description<SeqNo>,
+    /// The updates themselves.
+    pub updates: Vec<(SeqNo, (String, String), u64, isize)>,
+}
+
+/// The structure serialized and stored as a value in [crate::storage::Blob]
+/// storage for data keys corresponding to trace data.
+///
+/// Invariants:
+/// - The timestamp of each update is >= to desc.lower() and < desc.upper().
+/// - The values in updates are sorted by (key, value, time).
+/// - The values in updates are "consolidated", i.e. (key, value, time) is
+///   unique.
+/// - All entries have a non-zero diff.
+/// - (Intentionally no invariant around update non-emptiness because we might
+///   need empty batches to make the timestamps line up.)
+///
+/// TODO: This probably wants to be a different level of abstraction, so we can
+/// put multiple small batches in a single blob but also break a very large
+/// batch over multiple blobs. We also may want to break the latter into chunks
+/// for checksum and encryption?
+#[derive(Clone, Debug, Abomonation)]
+pub struct BlobTraceBatch {
+    /// Id of the trace this batch belongs to.
+    pub id: u64,
+    /// Which updates are included in this batch.
+    pub desc: Description<u64>,
+    /// The updates themselves.
+    pub updates: Vec<((String, String), u64, isize)>,
+}
+
+impl BufferEntry {
+    /// Asserts Self's documented invariants, returning an error if any are
+    /// violated.
+    pub fn validate(&self) -> Result<(), Error> {
+        // TODO: It's unclear if this invariant is useful/harmful. Feel free to
+        // remove it if it ends up not making sense.
+        if self.updates.is_empty() {
+            return Err("updates is empty".into());
+        }
+        Ok(())
+    }
+}
+
+impl Default for BlobMeta {
+    fn default() -> Self {
+        BlobMeta {
+            last_file_id: Self::now_millis(),
+            futures: Vec::new(),
+            traces: Vec::new(),
+        }
+    }
+}
+
+impl BlobMeta {
+    /// Asserts Self's documented invariants, returning an error if any are
+    /// violated.
+    pub fn validate(&self) -> Result<(), Error> {
+        for (_, f) in self.futures.iter() {
+            f.validate()?;
+        }
+        for (_, t) in self.traces.iter() {
+            t.validate()?;
+        }
+        // TODO: Assert that each stream id in futures is also present in traces
+        // and vice-versa. Also validate that that ts_lower of each future lines
+        // up wth the ts_upper of the corresponding trace.
+        Ok(())
+    }
+
+    /// Returns the current SystemTime in millis since epoch.
+    pub fn now_millis() -> u128 {
+        SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis()
+    }
+}
+
+impl BlobFutureMeta {
+    /// Asserts Self's documented invariants, returning an error if any are
+    /// violated.
+    pub fn validate(&self) -> Result<(), Error> {
+        let mut prev: Option<&Description<SeqNo>> = None;
+        for (desc, _) in self.batches.iter() {
+            if let Some(prev) = prev {
+                if prev.upper() != desc.lower() {
+                    return Err(format!(
+                        "invalid batch sequence: {:?} followed by {:?}",
+                        prev, desc
+                    )
+                    .into());
+                }
+            }
+            prev = Some(desc)
+        }
+        Ok(())
+    }
+}
+
+impl BlobTraceMeta {
+    /// Asserts Self's documented invariants, returning an error if any are
+    /// violated.
+    pub fn validate(&self) -> Result<(), Error> {
+        let mut prev: Option<&Description<u64>> = None;
+        for (desc, _) in self.batches.iter() {
+            if let Some(prev) = prev {
+                if prev.upper() != desc.lower() {
+                    return Err(format!(
+                        "invalid batch sequence: {:?} followed by {:?}",
+                        prev, desc,
+                    )
+                    .into());
+                }
+            }
+            prev = Some(desc)
+        }
+        Ok(())
+    }
+}
+
+impl BlobFutureBatch {
+    /// Asserts Self's documented invariants, returning an error if any are
+    /// violated.
+    pub fn validate(&self) -> Result<(), Error> {
+        // TODO: It's unclear if the equal case (an empty desc) is
+        // useful/harmful. Feel free to make this a less_than if empty descs end
+        // up making sense.
+        if PartialOrder::less_equal(self.desc.upper(), &self.desc.lower()) {
+            return Err(format!("invalid desc: {:?}", &self.desc).into());
+        }
+        // TODO: It's unclear if this invariant is useful/harmful. Feel free to
+        // remove it if it ends up not making sense.
+        if self.updates.is_empty() {
+            return Err("updates is empty".into());
+        }
+
+        let mut prev: Option<(&u64, &String, &String)> = None;
+        for update in self.updates.iter() {
+            let (seqno, (key, val), ts, diff) = update;
+            // Check seqno against desc.
+            if !self.desc.lower().less_equal(seqno) {
+                return Err(format!(
+                    "seqno {:?} is less than the batch lower: {:?}",
+                    seqno, self.desc
+                )
+                .into());
+            }
+            if self.desc.upper().less_equal(seqno) {
+                return Err(format!(
+                    "seqno {:?} is greater than or equal to the batch upper: {:?}",
+                    seqno, self.desc
+                )
+                .into());
+            }
+
+            // Check ordering.
+            let this = (ts, key, val);
+            if let Some(prev) = prev {
+                match prev.cmp(&this) {
+                    Ordering::Less => {} // Correct.
+                    Ordering::Equal => return Err(format!("unconsolidated: {:?}", this).into()),
+                    Ordering::Greater => {
+                        return Err(format!("unsorted: {:?} was before {:?}", prev, this).into())
+                    }
+                }
+            }
+            prev = Some(this);
+
+            // Check data invariants.
+            if *diff == 0 {
+                return Err(format!("update with 0 diff: {:?}", update).into());
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl BlobTraceBatch {
+    /// Asserts the documented invariants, returning an error if any are
+    /// violated.
+    pub fn validate(&self) -> Result<(), Error> {
+        // TODO: It's unclear if the equal case (an empty desc) is
+        // useful/harmful. Feel free to make this a less_than if empty descs end
+        // up making sense.
+        if PartialOrder::less_equal(self.desc.upper(), &self.desc.lower()) {
+            return Err(format!("invalid desc: {:?}", &self.desc).into());
+        }
+
+        let mut prev: Option<(&String, &String, &u64)> = None;
+        for update in self.updates.iter() {
+            let ((key, val), ts, diff) = update;
+            // Check ts against desc.
+            if !self.desc.lower().less_equal(ts) {
+                return Err(format!(
+                    "timestamp {} is less than the batch lower: {:?}",
+                    ts, self.desc
+                )
+                .into());
+            }
+            if self.desc.upper().less_equal(ts) {
+                return Err(format!(
+                    "timestamp {} is greater than or equal to the batch upper: {:?}",
+                    ts, self.desc
+                )
+                .into());
+            }
+
+            // Check ordering.
+            let this = (key, val, ts);
+            if let Some(prev) = prev {
+                match prev.cmp(&this) {
+                    Ordering::Less => {} // Correct.
+                    Ordering::Equal => return Err(format!("unconsolidated: {:?}", this).into()),
+                    Ordering::Greater => {
+                        return Err(format!("unsorted: {:?} was before {:?}", prev, this).into())
+                    }
+                }
+            }
+            prev = Some(this);
+
+            // Check data invariants.
+            if *diff == 0 {
+                return Err(format!("update with 0 diff: {:?}", update).into());
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::error::Error;
+
+    use super::*;
+
+    fn update_with_ts(seqno: u64, ts: u64) -> (SeqNo, (String, String), u64, isize) {
+        (SeqNo(seqno), ("".into(), "".into()), ts, 1)
+    }
+
+    fn update_with_key(ts: u64, key: &'static str) -> ((String, String), u64, isize) {
+        ((key.into(), "".into()), ts, 1)
+    }
+
+    fn u64_desc(lower: u64, upper: u64) -> Description<u64> {
+        Description::new(
+            Antichain::from_elem(lower),
+            Antichain::from_elem(upper),
+            Antichain::from_elem(0),
+        )
+    }
+
+    fn seqno_desc(lower: u64, upper: u64) -> Description<SeqNo> {
+        Description::new(
+            Antichain::from_elem(SeqNo(lower)),
+            Antichain::from_elem(SeqNo(upper)),
+            Antichain::from_elem(SeqNo(0)),
+        )
+    }
+
+    #[test]
+    fn buffer_entry_validate() {
+        // Normal case
+        let b = BufferEntry {
+            id: 0,
+            updates: vec![update_with_key(0, "0")],
+        };
+        assert_eq!(b.validate(), Ok(()));
+
+        // Empty
+        let b = BufferEntry {
+            id: 0,
+            updates: vec![],
+        };
+        assert_eq!(b.validate(), Err("updates is empty".into()));
+    }
+
+    #[test]
+    fn future_batch_validate() {
+        // Normal case
+        let b = BlobFutureBatch {
+            id: 0,
+            desc: seqno_desc(0, 2),
+            updates: vec![update_with_ts(0, 0), update_with_ts(1, 1)],
+        };
+        assert_eq!(b.validate(), Ok(()));
+
+        // Empty
+        let b = BlobFutureBatch {
+            id: 0,
+            desc: seqno_desc(0, 2),
+            updates: vec![],
+        };
+        assert_eq!(b.validate(), Err("updates is empty".into()));
+
+        // Invalid desc
+        let b = BlobFutureBatch {
+            id: 0,
+            desc: seqno_desc(2, 0),
+            updates: vec![],
+        };
+        assert_eq!(
+            b.validate(),
+            Err(Error::from(
+                "invalid desc: Description { lower: Antichain { elements: [SeqNo(2)] }, upper: Antichain { elements: [SeqNo(0)] }, since: Antichain { elements: [SeqNo(0)] } }"
+            ))
+        );
+
+        // Empty desc
+        let b = BlobFutureBatch {
+            id: 0,
+            desc: seqno_desc(0, 0),
+            updates: vec![],
+        };
+        assert_eq!(
+            b.validate(),
+            Err(Error::from(
+                "invalid desc: Description { lower: Antichain { elements: [SeqNo(0)] }, upper: Antichain { elements: [SeqNo(0)] }, since: Antichain { elements: [SeqNo(0)] } }"
+            ))
+        );
+
+        // Not sorted by time
+        let b = BlobFutureBatch {
+            id: 0,
+            desc: seqno_desc(0, 2),
+            updates: vec![update_with_ts(0, 1), update_with_ts(1, 0)],
+        };
+        assert_eq!(
+            b.validate(),
+            Err(Error::from(
+                "unsorted: (1, \"\", \"\") was before (0, \"\", \"\")"
+            ))
+        );
+
+        // Not consolidated
+        let b = BlobFutureBatch {
+            id: 0,
+            desc: seqno_desc(0, 2),
+            updates: vec![update_with_ts(0, 0), update_with_ts(1, 0)],
+        };
+        assert_eq!(
+            b.validate(),
+            Err(Error::from("unconsolidated: (0, \"\", \"\")"))
+        );
+
+        // Update "before" desc
+        let b = BlobFutureBatch {
+            id: 0,
+            desc: seqno_desc(1, 2),
+            updates: vec![update_with_ts(0, 0)],
+        };
+        assert_eq!(
+            b.validate(),
+            Err(Error::from(
+                "seqno SeqNo(0) is less than the batch lower: Description { lower: Antichain { elements: [SeqNo(1)] }, upper: Antichain { elements: [SeqNo(2)] }, since: Antichain { elements: [SeqNo(0)] } }"
+            ))
+        );
+
+        // Update "after" desc
+        let b = BlobFutureBatch {
+            id: 0,
+            desc: seqno_desc(0, 2),
+            updates: vec![update_with_ts(2, 2)],
+        };
+        assert_eq!(
+            b.validate(),
+            Err(Error::from(
+                "seqno SeqNo(2) is greater than or equal to the batch upper: Description { lower: Antichain { elements: [SeqNo(0)] }, upper: Antichain { elements: [SeqNo(2)] }, since: Antichain { elements: [SeqNo(0)] } }"
+            ))
+        );
+
+        // Invalid update
+        let b = BlobFutureBatch {
+            id: 0,
+            desc: seqno_desc(0, 1),
+            updates: vec![(SeqNo(0), ("0".into(), "0".into()), 0, 0)],
+        };
+        assert_eq!(
+            b.validate(),
+            Err(Error::from(
+                "update with 0 diff: (SeqNo(0), (\"0\", \"0\"), 0, 0)"
+            ))
+        );
+    }
+
+    #[test]
+    fn trace_batch_validate() {
+        // Normal case
+        let b = BlobTraceBatch {
+            id: 0,
+            desc: u64_desc(0, 2),
+            updates: vec![update_with_key(0, "0"), update_with_key(1, "1")],
+        };
+        assert_eq!(b.validate(), Ok(()));
+
+        // Empty
+        let b = BlobTraceBatch {
+            id: 0,
+            desc: u64_desc(0, 2),
+            updates: vec![],
+        };
+        assert_eq!(b.validate(), Ok(()));
+
+        // Invalid desc
+        let b = BlobTraceBatch {
+            id: 0,
+            desc: u64_desc(2, 0),
+            updates: vec![],
+        };
+        assert_eq!(
+            b.validate(),
+            Err(Error::from(
+                "invalid desc: Description { lower: Antichain { elements: [2] }, upper: Antichain { elements: [0] }, since: Antichain { elements: [0] } }"
+            ))
+        );
+
+        // Empty desc
+        let b = BlobTraceBatch {
+            id: 0,
+            desc: u64_desc(0, 0),
+            updates: vec![],
+        };
+        assert_eq!(
+            b.validate(),
+            Err(Error::from(
+                "invalid desc: Description { lower: Antichain { elements: [0] }, upper: Antichain { elements: [0] }, since: Antichain { elements: [0] } }"
+            ))
+        );
+
+        // Not sorted by key
+        let b = BlobTraceBatch {
+            id: 0,
+            desc: u64_desc(0, 2),
+            updates: vec![update_with_key(0, "1"), update_with_key(1, "0")],
+        };
+        assert_eq!(
+            b.validate(),
+            Err(Error::from(
+                "unsorted: (\"1\", \"\", 0) was before (\"0\", \"\", 1)"
+            ))
+        );
+
+        // Not consolidated
+        let b = BlobTraceBatch {
+            id: 0,
+            desc: u64_desc(0, 2),
+            updates: vec![update_with_key(0, "0"), update_with_key(0, "0")],
+        };
+        assert_eq!(
+            b.validate(),
+            Err(Error::from("unconsolidated: (\"0\", \"\", 0)"))
+        );
+
+        // Update "before" desc
+        let b = BlobTraceBatch {
+            id: 0,
+            desc: u64_desc(1, 2),
+            updates: vec![update_with_key(0, "0")],
+        };
+        assert_eq!(b.validate(), Err(Error::from("timestamp 0 is less than the batch lower: Description { lower: Antichain { elements: [1] }, upper: Antichain { elements: [2] }, since: Antichain { elements: [0] } }")));
+
+        // Update "after" desc
+        let b = BlobTraceBatch {
+            id: 0,
+            desc: u64_desc(1, 2),
+            updates: vec![update_with_key(2, "0")],
+        };
+        assert_eq!(b.validate(), Err(Error::from("timestamp 2 is greater than or equal to the batch upper: Description { lower: Antichain { elements: [1] }, upper: Antichain { elements: [2] }, since: Antichain { elements: [0] } }")));
+
+        // Invalid update
+        let b = BlobTraceBatch {
+            id: 0,
+            desc: u64_desc(0, 1),
+            updates: vec![(("0".into(), "0".into()), 0, 0)],
+        };
+        assert_eq!(
+            b.validate(),
+            Err(Error::from("update with 0 diff: ((\"0\", \"0\"), 0, 0)"))
+        );
+    }
+
+    #[test]
+    fn trace_meta_validate() {
+        // Empty
+        let b = BlobTraceMeta { batches: vec![] };
+        assert_eq!(b.validate(), Ok(()));
+
+        // Normal case
+        let b = BlobTraceMeta {
+            batches: vec![(u64_desc(0, 1), "".into()), (u64_desc(1, 2), "".into())],
+        };
+        assert_eq!(b.validate(), Ok(()));
+
+        // Gap
+        let b = BlobTraceMeta {
+            batches: vec![(u64_desc(0, 1), "".into()), (u64_desc(2, 3), "".into())],
+        };
+        assert_eq!(b.validate(), Err(Error::from("invalid batch sequence: Description { lower: Antichain { elements: [0] }, upper: Antichain { elements: [1] }, since: Antichain { elements: [0] } } followed by Description { lower: Antichain { elements: [2] }, upper: Antichain { elements: [3] }, since: Antichain { elements: [0] } }")));
+
+        // Overlapping
+        let b = BlobTraceMeta {
+            batches: vec![(u64_desc(0, 2), "".into()), (u64_desc(1, 3), "".into())],
+        };
+        assert_eq!(b.validate(), Err(Error::from("invalid batch sequence: Description { lower: Antichain { elements: [0] }, upper: Antichain { elements: [2] }, since: Antichain { elements: [0] } } followed by Description { lower: Antichain { elements: [1] }, upper: Antichain { elements: [3] }, since: Antichain { elements: [0] } }")));
+    }
+
+    #[test]
+    fn future_meta_validate() {
+        // Empty
+        let b = BlobFutureMeta {
+            ts_lower: Antichain::from_elem(0),
+            batches: vec![],
+        };
+        assert_eq!(b.validate(), Ok(()));
+
+        // Normal case
+        let b = BlobFutureMeta {
+            ts_lower: Antichain::from_elem(0),
+            batches: vec![(seqno_desc(0, 1), "".into()), (seqno_desc(1, 2), "".into())],
+        };
+        assert_eq!(b.validate(), Ok(()));
+
+        // Gap
+        let b = BlobFutureMeta {
+            ts_lower: Antichain::from_elem(0),
+            batches: vec![(seqno_desc(0, 1), "".into()), (seqno_desc(2, 3), "".into())],
+        };
+        assert_eq!(
+            b.validate(),
+            Err(Error::from(
+                "invalid batch sequence: Description { lower: Antichain { elements: [SeqNo(0)] }, upper: Antichain { elements: [SeqNo(1)] }, since: Antichain { elements: [SeqNo(0)] } } followed by Description { lower: Antichain { elements: [SeqNo(2)] }, upper: Antichain { elements: [SeqNo(3)] }, since: Antichain { elements: [SeqNo(0)] } }"
+            ))
+        );
+
+        // Overlapping
+        let b = BlobFutureMeta {
+            ts_lower: Antichain::from_elem(0),
+            batches: vec![(seqno_desc(0, 2), "".into()), (seqno_desc(1, 3), "".into())],
+        };
+        assert_eq!(
+            b.validate(),
+            Err(Error::from(
+                "invalid batch sequence: Description { lower: Antichain { elements: [SeqNo(0)] }, upper: Antichain { elements: [SeqNo(2)] }, since: Antichain { elements: [SeqNo(0)] } } followed by Description { lower: Antichain { elements: [SeqNo(1)] }, upper: Antichain { elements: [SeqNo(3)] }, since: Antichain { elements: [SeqNo(0)] } }"
+            ))
+        );
+    }
+}

--- a/src/persist/src/indexed/future.rs
+++ b/src/persist/src/indexed/future.rs
@@ -17,7 +17,8 @@ use timely::progress::{Antichain, Timestamp};
 
 use crate::error::Error;
 use crate::indexed::cache::BlobCache;
-use crate::indexed::{BlobFutureBatch, BlobFutureMeta};
+use crate::indexed::encoding::BlobFutureMeta;
+use crate::indexed::BlobFutureBatch;
 use crate::persister::Snapshot;
 use crate::storage::{Blob, SeqNo};
 

--- a/src/persist/src/indexed/trace.rs
+++ b/src/persist/src/indexed/trace.rs
@@ -20,7 +20,8 @@ use timely::progress::{Antichain, Timestamp};
 
 use crate::error::Error;
 use crate::indexed::cache::BlobCache;
-use crate::indexed::{BlobTraceBatch, BlobTraceMeta};
+use crate::indexed::encoding::BlobTraceMeta;
+use crate::indexed::BlobTraceBatch;
 use crate::persister::Snapshot;
 use crate::storage::Blob;
 

--- a/src/persist/src/storage.rs
+++ b/src/persist/src/storage.rs
@@ -60,9 +60,13 @@ pub trait Buffer {
 ///
 /// - Invariant: Implementations are responsible for ensuring that they are
 ///   exclusive writers to this location.
+///
+/// TODO: Document restrictions on what keys are legal.
+///
+/// TODO: Add the ability to close a blob so a new writer can use the location.
 pub trait Blob {
     /// Returns a reference to the value corresponding to the key.
-    fn get(&self, key: &str) -> Result<Option<&Vec<u8>>, Error>;
+    fn get(&self, key: &str) -> Result<Option<Vec<u8>>, Error>;
 
     /// Inserts a key-value pair into the map.
     fn set(&mut self, key: &str, value: Vec<u8>, allow_overwrite: bool) -> Result<(), Error>;
@@ -101,5 +105,106 @@ impl<U: Buffer, L: Blob> Persister for StoragePersister<U, L> {
 
     fn destroy(&mut self, _id: Id) -> Result<(), Error> {
         unimplemented!()
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use std::ops::RangeInclusive;
+
+    use crate::error::Error;
+    use crate::storage::Blob;
+    use crate::storage::Buffer;
+    use crate::storage::SeqNo;
+
+    fn slurp<U: Buffer>(buf: &U) -> Result<Vec<Vec<u8>>, Error> {
+        let mut entries = Vec::new();
+        buf.snapshot(|_, x| {
+            entries.push(x.to_vec());
+            Ok(())
+        })?;
+        Ok(entries)
+    }
+
+    pub fn buffer_impl_test<U: Buffer, F: FnMut(usize) -> Result<U, Error>>(
+        mut new_fn: F,
+    ) -> Result<(), Error> {
+        let entries = vec![
+            "entry0".as_bytes().to_vec(),
+            "entry1".as_bytes().to_vec(),
+            "entry2".as_bytes().to_vec(),
+        ];
+        let sub_entries =
+            |r: RangeInclusive<usize>| -> Vec<Vec<u8>> { entries[r].iter().cloned().collect() };
+
+        let mut buf0 = new_fn(0)?;
+
+        // We can create a second buffer writing to a different place.
+        let _ = new_fn(1)?;
+
+        // But the buffer impl prevents us from opening the same place for
+        // writing twice.
+        assert!(new_fn(0).is_err());
+
+        // Empty writer is empty.
+        assert!(slurp(&buf0)?.is_empty());
+
+        // First write is assigned SeqNo(0).
+        assert_eq!(buf0.write_sync(entries[0].clone())?, SeqNo(0));
+        assert_eq!(slurp(&buf0)?, sub_entries(0..=0));
+
+        // Second write is assigned SeqNo(1). Now contains 2 entries.
+        assert_eq!(buf0.write_sync(entries[1].clone())?, SeqNo(1));
+        assert_eq!(slurp(&buf0)?, sub_entries(0..=1));
+
+        // Truncate removes the first entry.
+        buf0.truncate(SeqNo(1))?;
+        assert_eq!(slurp(&buf0)?, sub_entries(1..=1));
+
+        // We are not allowed to truncate to places outside the current range.
+        assert!(buf0.truncate(SeqNo(0)).is_err());
+        assert!(buf0.truncate(SeqNo(3)).is_err());
+
+        // Write works after a truncate has happened.
+        assert_eq!(buf0.write_sync(entries[2].clone())?, SeqNo(2));
+        assert_eq!(slurp(&buf0)?, sub_entries(1..=2));
+
+        // Truncate everything.
+        buf0.truncate(SeqNo(3))?;
+        assert!(slurp(&buf0)?.is_empty());
+
+        Ok(())
+    }
+
+    pub fn blob_impl_test<L: Blob, F: FnMut(usize) -> Result<L, Error>>(
+        mut new_fn: F,
+    ) -> Result<(), Error> {
+        let values = vec!["v0".as_bytes().to_vec(), "v1".as_bytes().to_vec()];
+        // let sub_entries =
+        //     |r: RangeInclusive<usize>| -> Vec<Vec<u8>> { entries[r].iter().cloned().collect() };
+
+        let mut blob0 = new_fn(0)?;
+
+        // We can create a second blob writing to a different place.
+        let _ = new_fn(1)?;
+
+        // But the blob impl prevents us from opening the same place for
+        // writing twice.
+        assert!(new_fn(0).is_err());
+
+        // Empty key is empty.
+        assert_eq!(blob0.get("k0")?, None);
+
+        // Set a key and get it back.
+        blob0.set("k0", values[0].clone(), false)?;
+        assert_eq!(blob0.get("k0")?, Some(values[0].clone()));
+
+        // Can only overwrite a key without allow_overwrite.
+        assert!(blob0.set("k0", values[1].clone(), false).is_err());
+        assert_eq!(blob0.get("k0")?, Some(values[0].clone()));
+        blob0.set("k0", values[1].clone(), true)?;
+        assert_eq!(blob0.get("k0")?, Some(values[1].clone()));
+
+        Ok(())
     }
 }


### PR DESCRIPTION
Some of these are just sanity checks and some are going to be necessary
to provide indexing on top of the persisted batches. Get this started
early to get in the habit of thinking about what our invariants are.