### PR TITLE
Change apt bucket name

### DIFF
--- a/ci/deploy/linux.py
+++ b/ci/deploy/linux.py
@@ -62,7 +62,7 @@ def publish_deb(package: str, version: str) -> None:
     bt.repo("apt").package(package).publish_uploads(version)
 
     s3 = boto3.client("s3")
-    bucket = "materialize-apt-repository"
+    bucket = "apt.materialize.com"
     object_key = f"pool/generic/m/ma/materialized-{version}.deb"
     # Download the staged package (deb-s3 needs to get various metadata from it)
     s3.download_file(bucket, object_key, f"materialized-{version}.deb")

--- a/ci/test/build.py
+++ b/ci/test/build.py
@@ -124,7 +124,7 @@ def stage_deb(repo: mzbuild.Repository, package: str, version: str) -> None:
     s3 = boto3.client("s3")
     s3.put_object(
         Body=open(deb_path, "rb"),
-        Bucket="materialize-apt-repository",
+        Bucket="apt.materialize.com",
         Key=f"pool/generic/m/ma/materialized-{version}.deb",
     )
 

--- a/doc/user/content/install.md
+++ b/doc/user/content/install.md
@@ -56,9 +56,9 @@ Run the following commands as root.
 
 ```shell
 # Add the signing key for the Materialize apt repository
-apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 79DEC5E1B7AE7694
+apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 379CE192D401AB61
 # Add and update the repository
-sh -c 'echo "deb http://apt.materialize.com/ generic main" > /etc/apt/sources.list.d/materialize.list'
+sh -c 'echo "deb http://packages.materialize.io/apt/ /" > /etc/apt/sources.list.d/materialize.list'
 apt update
 # Install materialized
 apt install materialized

--- a/doc/user/content/install.md
+++ b/doc/user/content/install.md
@@ -56,9 +56,9 @@ Run the following commands as root.
 
 ```shell
 # Add the signing key for the Materialize apt repository
-apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 379CE192D401AB61
+apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 79DEC5E1B7AE7694
 # Add and update the repository
-sh -c 'echo "deb http://packages.materialize.io/apt/ /" > /etc/apt/sources.list.d/materialize.list'
+sh -c 'echo "deb http://apt.materialize.com/ generic main" > /etc/apt/sources.list.d/materialize.list'
 apt update
 # Install materialized
 apt install materialized


### PR DESCRIPTION
S3 doesn't allow you to cname arbitrary domains to arbitrary buckets -- the bucket must be named the same as the domain.

https://github.com/MaterializeInc/infra/pull/922 is also needed.