### PR TITLE
Fix wrong results issue due to wrong nullability semantics of COUNT aggregate function

### DIFF
--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -601,7 +601,10 @@ impl AggregateFunc {
         scalar_type.nullable(nullable)
     }
 
-    /// Whether the result of the aggregate can be non-null with null inputs
+    /// Returns true if the non-null constraint on the aggregation can be
+    /// converted into a non-null constraint on its parameter expression, ie.
+    /// whether the result of the aggregation is null if all the input values
+    /// are null.
     pub fn propagates_nonnull_constraint(&self) -> bool {
         match self {
             AggregateFunc::MaxApd

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -600,6 +600,15 @@ impl AggregateFunc {
         };
         scalar_type.nullable(nullable)
     }
+
+    /// Whether the result of the aggregate can be non-null with null inputs
+    pub fn propagates_nonnull_constraint(&self) -> bool {
+        match self {
+            // Count is never null
+            AggregateFunc::Count => false,
+            _ => true,
+        }
+    }
 }
 
 fn jsonb_each<'a>(a: Datum<'a>, temp_storage: &'a RowArena, stringify: bool) -> Vec<(Row, Diff)> {

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -604,9 +604,37 @@ impl AggregateFunc {
     /// Whether the result of the aggregate can be non-null with null inputs
     pub fn propagates_nonnull_constraint(&self) -> bool {
         match self {
+            AggregateFunc::MaxApd
+            | AggregateFunc::MaxInt32
+            | AggregateFunc::MaxInt64
+            | AggregateFunc::MaxFloat32
+            | AggregateFunc::MaxFloat64
+            | AggregateFunc::MaxDecimal
+            | AggregateFunc::MaxBool
+            | AggregateFunc::MaxString
+            | AggregateFunc::MaxDate
+            | AggregateFunc::MaxTimestamp
+            | AggregateFunc::MaxTimestampTz
+            | AggregateFunc::MinApd
+            | AggregateFunc::MinInt32
+            | AggregateFunc::MinInt64
+            | AggregateFunc::MinFloat32
+            | AggregateFunc::MinFloat64
+            | AggregateFunc::MinDecimal
+            | AggregateFunc::MinBool
+            | AggregateFunc::MinString
+            | AggregateFunc::MinDate
+            | AggregateFunc::MinTimestamp
+            | AggregateFunc::MinTimestampTz
+            | AggregateFunc::SumInt32
+            | AggregateFunc::SumInt64
+            | AggregateFunc::SumFloat32
+            | AggregateFunc::SumFloat64
+            | AggregateFunc::SumDecimal
+            | AggregateFunc::SumAPD => true,
             // Count is never null
             AggregateFunc::Count => false,
-            _ => true,
+            _ => false,
         }
     }
 }

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -1445,15 +1445,6 @@ impl AggregateExpr {
             _ => self.expr.is_literal_err(),
         }
     }
-
-    /// Adds any columns that *must* be non-Null for `self` to be non-Null.
-    pub fn non_null_requirements(&self, columns: &mut HashSet<usize>) {
-        match self.func {
-            // Count is never null
-            AggregateFunc::Count => {}
-            _ => self.expr.non_null_requirements(columns),
-        }
-    }
 }
 
 impl fmt::Display for AggregateExpr {

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -1445,6 +1445,15 @@ impl AggregateExpr {
             _ => self.expr.is_literal_err(),
         }
     }
+
+    /// Adds any columns that *must* be non-Null for `self` to be non-Null.
+    pub fn non_null_requirements(&self, columns: &mut HashSet<usize>) {
+        match self.func {
+            // Count is never null
+            AggregateFunc::Count => {}
+            _ => self.expr.non_null_requirements(columns),
+        }
+    }
 }
 
 impl fmt::Display for AggregateExpr {

--- a/src/transform/src/column_knowledge.rs
+++ b/src/transform/src/column_knowledge.rs
@@ -248,8 +248,12 @@ impl ColumnKnowledge {
                             // These methods propagate constant values exactly.
                             knowledge
                         }
+                        AggregateFunc::Count => DatumKnowledge {
+                            value: None,
+                            nullable: false,
+                        },
                         _ => {
-                            // All aggregates are non-null if their inputs are non-null.
+                            // The remaining aggregates are non-null if their inputs are non-null.
                             DatumKnowledge {
                                 value: None,
                                 nullable: knowledge.nullable,

--- a/src/transform/src/nonnull_requirements.rs
+++ b/src/transform/src/nonnull_requirements.rs
@@ -200,9 +200,17 @@ impl NonNullRequirements {
                     // A "non-empty" requirement, I guess?
                     if column < group_key.len() {
                         group_key[column].non_null_requirements(&mut new_columns);
-                    }
-                    if column == group_key.len() && aggregates.len() == 1 {
-                        aggregates[0].expr.non_null_requirements(&mut new_columns);
+                    } else {
+                        let agg_pos = column - group_key.len();
+                        match aggregates[agg_pos].func {
+                            // Count is non-null even for all null inputs
+                            expr::AggregateFunc::Count => {}
+                            _ => {
+                                aggregates[agg_pos]
+                                    .expr
+                                    .non_null_requirements(&mut new_columns);
+                            }
+                        }
                     }
                 }
                 self.action(input, new_columns, gets);

--- a/src/transform/src/nonnull_requirements.rs
+++ b/src/transform/src/nonnull_requirements.rs
@@ -230,9 +230,10 @@ impl NonNullRequirements {
                             } else {
                                 req_intersection = Some(nonnull_columns.clone());
                             }
-                        } else if !aggr_nonnull_req.iter().any(|(cols, flag)| {
-                            *flag && nonnull_columns.intersection(cols).count() > 0
-                        }) {
+                        } else if !aggr_nonnull_req
+                            .iter()
+                            .any(|(cols, flag)| *flag && cols.is_subset(&nonnull_columns))
+                        {
                             // An aggregate function that is either a COUNT or any other
                             // aggregate not required to be non-null, that doesn't intersect
                             // with the requirements of any non-null aggregate.

--- a/src/transform/src/nonnull_requirements.rs
+++ b/src/transform/src/nonnull_requirements.rs
@@ -212,8 +212,10 @@ impl NonNullRequirements {
                             let should_push_down = aggr.func.propagates_nonnull_constraint()
                                 && aggr_columns.contains(&(group_key.len() + pos));
                             let mut ignores_nulls_on_columns = HashSet::new();
-                            aggr.expr
-                                .non_null_requirements(&mut ignores_nulls_on_columns);
+                            if let repr::Datum::Null = aggr.func.identity_datum() {
+                                aggr.expr
+                                    .non_null_requirements(&mut ignores_nulls_on_columns);
+                            }
                             (should_push_down, ignores_nulls_on_columns)
                         })
                         .collect::<Vec<_>>();

--- a/test/sqllogictest/transform/aggregation_nullability.slt
+++ b/test/sqllogictest/transform/aggregation_nullability.slt
@@ -907,3 +907,86 @@ WHERE t1.f2 = derived.agg2;
 | Project (#2)
 
 EOF
+
+statement ok
+DROP TABLE t1;
+
+statement ok
+CREATE TABLE t1 (f1 INTEGER NOT NULL);
+
+statement ok
+INSERT INTO t1 VALUES (1);
+
+statement ok
+DROP TABLE t2;
+
+statement ok
+CREATE TABLE t2 (f1 INTEGER NOT NULL);
+
+statement ok
+INSERT INTO t2 VALUES (1);
+
+statement ok
+INSERT INTO t2 VALUES (2);
+
+# outer-to-inner join conversion not allowed
+query T multiline
+EXPLAIN SELECT SUM(t1.f1 + t2.f1), SUM(t2.f1 + 0)
+FROM t2
+LEFT JOIN t1
+ON t1.f1 < t2.f1
+HAVING SUM(t1.f1 + t2.f1) > 0;
+----
+%0 =
+| Get materialize.public.t2 (u19)
+| ArrangeBy ()
+
+%1 =
+| Get materialize.public.t1 (u17)
+
+%2 = Let l0 =
+| Join %0 %1
+| | implementation = Differential %1 %0.()
+| | demand = (#0, #1)
+| Filter (#1 < #0)
+
+%3 =
+| Get %2 (l0)
+| Distinct group=(#0)
+| Negate
+
+%4 =
+| Get materialize.public.t2 (u19)
+| Distinct group=(#0)
+
+%5 =
+| Union %3 %4
+
+%6 =
+| Get materialize.public.t2 (u19)
+| ArrangeBy (#0)
+
+%7 =
+| Join %5 %6 (= #0 #1)
+| | implementation = Differential %5 %6.(#0)
+| | demand = (#0)
+| Map null
+| Project (#0, #2)
+
+%8 =
+| Union %2 %7
+| Reduce group=()
+| | agg sum((#1 + #0))
+| | agg sum((#0 + 0))
+| Filter (#0 > 0)
+
+EOF
+
+query II
+SELECT SUM(t1.f1 + t2.f1), SUM(t2.f1 + 0)
+FROM t2
+LEFT JOIN t1
+ON t1.f1 < t2.f1
+HAVING SUM(t1.f1 + t2.f1) > 0;
+----
+3  3

--- a/test/sqllogictest/transform/aggregation_nullability.slt
+++ b/test/sqllogictest/transform/aggregation_nullability.slt
@@ -73,7 +73,8 @@ EOF
 query II
 select t1.f1, count(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having count(t2.f1) >= 0;
 ----
-1 0
+1  0
+
 
 # ... but a filter on any other aggregation should convert a left join into an inner join if its parameter comes from the non-preserving side
 query T multiline
@@ -500,6 +501,125 @@ EXPLAIN select t1.f1, sum(t1.f1), max(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.
 
 EOF
 
+# outer join to inner join conversion not allowed
+query T multiline
+EXPLAIN select t1.f1, count(t2.f2) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1;
+----
+%0 =
+| Get materialize.public.t1 (u1)
+| Filter !(isnull(#0))
+| ArrangeBy (#0)
+
+%1 =
+| Get materialize.public.t2 (u3)
+| Filter !(isnull(#0))
+
+%2 = Let l0 =
+| Join %0 %1 (= #0 #2)
+| | implementation = Differential %1 %0.(#0)
+| | demand = (#0, #3)
+
+%3 =
+| Get materialize.public.t1 (u1)
+
+%4 =
+| Get %2 (l0)
+| Distinct group=(#0)
+| ArrangeBy (#0)
+
+%5 =
+| Join %3 %4 (= #0 #2)
+| | implementation = Differential %3 %4.(#0)
+| | demand = (#0)
+| Negate
+| Project (#0, #1)
+
+%6 =
+| Get materialize.public.t1 (u1)
+
+%7 =
+| Union %5 %6
+| Map null, null
+
+%8 =
+| Union %7 %2
+| Reduce group=(#0)
+| | agg count(#3)
+
+EOF
+
+# outer join to inner join conversion not allowed
+query T multiline
+EXPLAIN select t1.f1, count(t2.f2), max(t2.f2) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1;
+----
+%0 =
+| Get materialize.public.t1 (u1)
+| Filter !(isnull(#0))
+| ArrangeBy (#0)
+
+%1 =
+| Get materialize.public.t2 (u3)
+| Filter !(isnull(#0))
+
+%2 = Let l0 =
+| Join %0 %1 (= #0 #2)
+| | implementation = Differential %1 %0.(#0)
+| | demand = (#0, #3)
+
+%3 =
+| Get materialize.public.t1 (u1)
+
+%4 =
+| Get %2 (l0)
+| Distinct group=(#0)
+| ArrangeBy (#0)
+
+%5 =
+| Join %3 %4 (= #0 #2)
+| | implementation = Differential %3 %4.(#0)
+| | demand = (#0)
+| Negate
+| Project (#0, #1)
+
+%6 =
+| Get materialize.public.t1 (u1)
+
+%7 =
+| Union %5 %6
+| Map null, null
+
+%8 =
+| Union %7 %2
+| Reduce group=(#0)
+| | agg count(#3)
+| | agg max(#3)
+
+EOF
+
+# outer join to inner join conversion allowed
+query T multiline
+EXPLAIN select t1.f1, count(t2.f2), max(t2.f2) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having max(t2.f2) > 0;
+----
+%0 =
+| Get materialize.public.t1 (u1)
+| Filter !(isnull(#0))
+| ArrangeBy (#0)
+
+%1 =
+| Get materialize.public.t2 (u3)
+| Filter !(isnull(#0))
+
+%2 =
+| Join %0 %1 (= #0 #2)
+| | implementation = Differential %1 %0.(#0)
+| | demand = (#0, #3)
+| Reduce group=(#0)
+| | agg count(#3)
+| | agg max(#3)
+| Filter (#2 > 0)
+
+EOF
+
 # check that a filter on a non-count aggregation doesn't change the COUNT value
 statement ok
 drop table t1
@@ -683,6 +803,7 @@ query III
 SELECT * FROM (SELECT 123, COUNT(right_table.f1) AS aggregate FROM t1 AS left_table LEFT JOIN t1 AS right_table ON FALSE GROUP BY 1) AS subquery, t1 AS outer_table WHERE outer_table.f1 = subquery.aggregate;
 ----
 123  0  0
+
 
 # non-null requeriment on a non-count aggregation coming from a join predicate
 statement ok

--- a/test/sqllogictest/transform/aggregation_nullability.slt
+++ b/test/sqllogictest/transform/aggregation_nullability.slt
@@ -1,0 +1,270 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+mode cockroach
+
+statement ok
+CREATE TABLE t1(f1 int, f2 int)
+
+statement ok
+CREATE TABLE t2(f1 int, f2 int)
+
+statement ok
+INSERT INTO t1 VALUES (1, 2)
+
+# regression test for #7049: a filter on COUNT aggregation must not trigger the outer to inner join conversion
+query T multiline
+EXPLAIN select t1.f1, count(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having count(t2.f1) >= 0;
+----
+%0 =
+| Get materialize.public.t1 (u1)
+| Filter !(isnull(#0))
+| ArrangeBy (#0)
+
+%1 =
+| Get materialize.public.t2 (u3)
+| Filter !(isnull(#0))
+
+%2 = Let l0 =
+| Join %0 %1 (= #0 #2)
+| | implementation = Differential %1 %0.(#0)
+| | demand = (#0)
+
+%3 =
+| Get materialize.public.t1 (u1)
+
+%4 =
+| Get %2 (l0)
+| Distinct group=(#0)
+| ArrangeBy (#0)
+
+%5 =
+| Join %3 %4 (= #0 #2)
+| | implementation = Differential %3 %4.(#0)
+| | demand = (#0)
+| Negate
+| Project (#0, #1)
+
+%6 =
+| Get materialize.public.t1 (u1)
+
+%7 =
+| Union %5 %6
+| Map null, null
+
+%8 =
+| Get %2 (l0)
+| Project (#0, #1, #0, #3)
+
+%9 =
+| Union %7 %8
+| Reduce group=(#0)
+| | agg count(#2)
+| Filter (#1 >= 0)
+
+EOF
+
+query II
+select t1.f1, count(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having count(t2.f1) >= 0;
+----
+1 0
+
+# ... but a filter on any other aggregation should convert a left join into an inner join if its parameter comes from the non-preserving side
+query T multiline
+EXPLAIN select t1.f1, sum(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having sum(t2.f1) >= 0;
+----
+%0 =
+| Get materialize.public.t1 (u1)
+| Filter !(isnull(#0))
+| ArrangeBy (#0)
+
+%1 =
+| Get materialize.public.t2 (u3)
+| Filter !(isnull(#0))
+
+%2 =
+| Join %0 %1 (= #0 #2)
+| | implementation = Differential %1 %0.(#0)
+| | demand = (#0)
+| Reduce group=(#0)
+| | agg sum(#0)
+| Filter (#1 >= 0)
+
+EOF
+
+query II
+select t1.f1, sum(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having sum(t2.f1) >= 0;
+----
+
+# multiple aggregations
+query T multiline
+EXPLAIN select t1.f1, count(t2.f1), sum(t2.f1), max(t2.f1), min(t2.f1), count(t1.f2), sum(t1.f2), min(t1.f2), max(t1.f2) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1;
+----
+%0 =
+| Get materialize.public.t1 (u1)
+| Filter !(isnull(#0))
+| ArrangeBy (#0)
+
+%1 =
+| Get materialize.public.t2 (u3)
+| Filter !(isnull(#0))
+
+%2 = Let l0 =
+| Join %0 %1 (= #0 #2)
+| | implementation = Differential %1 %0.(#0)
+| | demand = (#0, #1)
+
+%3 =
+| Get materialize.public.t1 (u1)
+
+%4 =
+| Get %2 (l0)
+| Distinct group=(#0)
+| ArrangeBy (#0)
+
+%5 =
+| Join %3 %4 (= #0 #2)
+| | implementation = Differential %3 %4.(#0)
+| | demand = (#0, #1)
+| Negate
+| Project (#0, #1)
+
+%6 =
+| Get materialize.public.t1 (u1)
+
+%7 =
+| Union %5 %6
+| Map null, null
+
+%8 =
+| Get %2 (l0)
+| Project (#0, #1, #0, #3)
+
+%9 =
+| Union %7 %8
+| Reduce group=(#0)
+| | agg count(#2)
+| | agg sum(#2)
+| | agg max(#2)
+| | agg min(#2)
+| | agg count(#1)
+| | agg sum(#1)
+| | agg min(#1)
+| | agg max(#1)
+
+EOF
+
+query T multiline
+EXPLAIN select t1.f1, count(t2.f1), sum(t2.f1), max(t2.f1), min(t2.f1), count(t1.f2), sum(t1.f2), min(t1.f2), max(t1.f2) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having sum(t1.f2) >= 0;
+----
+%0 =
+| Get materialize.public.t1 (u1)
+| Filter !(isnull(#0))
+| ArrangeBy (#0)
+
+%1 =
+| Get materialize.public.t2 (u3)
+| Filter !(isnull(#0))
+
+%2 = Let l0 =
+| Join %0 %1 (= #0 #2)
+| | implementation = Differential %1 %0.(#0)
+| | demand = (#0, #1)
+
+%3 =
+| Get materialize.public.t1 (u1)
+
+%4 =
+| Get %2 (l0)
+| Distinct group=(#0)
+| ArrangeBy (#0)
+
+%5 =
+| Join %3 %4 (= #0 #2)
+| | implementation = Differential %3 %4.(#0)
+| | demand = (#0, #1)
+| Negate
+| Project (#0, #1)
+
+%6 =
+| Get materialize.public.t1 (u1)
+
+%7 =
+| Union %5 %6
+| Map null, null
+
+%8 =
+| Get %2 (l0)
+| Project (#0, #1, #0, #3)
+
+%9 =
+| Union %7 %8
+| Reduce group=(#0)
+| | agg count(#2)
+| | agg sum(#2)
+| | agg max(#2)
+| | agg min(#2)
+| | agg count(#1)
+| | agg sum(#1)
+| | agg min(#1)
+| | agg max(#1)
+| Filter (#6 >= 0)
+
+EOF
+
+query T multiline
+EXPLAIN select t1.f1, count(t2.f1), sum(t2.f1), max(t2.f1), min(t2.f1), count(t1.f2), sum(t1.f2), min(t1.f2), max(t1.f2) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having sum(t2.f1) >= 0;
+----
+%0 =
+| Get materialize.public.t1 (u1)
+| Filter !(isnull(#0))
+| ArrangeBy (#0)
+
+%1 =
+| Get materialize.public.t2 (u3)
+| Filter !(isnull(#0))
+
+%2 =
+| Join %0 %1 (= #0 #2)
+| | implementation = Differential %1 %0.(#0)
+| | demand = (#0, #1)
+| Reduce group=(#0)
+| | agg count(#0)
+| | agg sum(#0)
+| | agg max(#0)
+| | agg min(#0)
+| | agg count(#1)
+| | agg sum(#1)
+| | agg min(#1)
+| | agg max(#1)
+| Filter (#2 >= 0)
+
+EOF
+
+# count is never null, predicate removed
+query T multiline
+EXPLAIN select t1.f1, count(t1.f2) from t1 group by t1.f1 having count(t1.f2) is not null;
+----
+%0 =
+| Get materialize.public.t1 (u1)
+| Reduce group=(#0)
+| | agg count(#1)
+
+EOF
+
+query T multiline
+EXPLAIN select t1.f1, sum(t1.f2) from t1 group by t1.f1 having sum(t1.f2) is not null;
+----
+%0 =
+| Get materialize.public.t1 (u1)
+| Reduce group=(#0)
+| | agg sum(#1)
+| Filter !(isnull(#1))
+
+EOF

--- a/test/sqllogictest/transform/aggregation_nullability.slt
+++ b/test/sqllogictest/transform/aggregation_nullability.slt
@@ -268,3 +268,40 @@ EXPLAIN select t1.f1, sum(t1.f2) from t1 group by t1.f1 having sum(t1.f2) is not
 | Filter !(isnull(#1))
 
 EOF
+
+# regression test for #7047
+statement ok
+drop table t1
+
+statement ok
+create table t1(f1 integer)
+
+statement ok
+insert into t1 values (0), (1)
+
+query T multiline
+EXPLAIN SELECT * FROM (SELECT 123, COUNT(right_table.f1) AS aggregate FROM t1 AS left_table LEFT JOIN t1 AS right_table ON FALSE GROUP BY 1) AS subquery, t1 AS outer_table WHERE outer_table.f1 = subquery.aggregate;
+----
+%0 =
+| Get materialize.public.t1 (u5)
+| Reduce group=()
+| | agg count(null)
+| ArrangeBy (#0)
+
+%1 =
+| Get materialize.public.t1 (u5)
+| Filter !(isnull(i32toi64(#0)))
+
+%2 =
+| Join %0 %1 (= #0 i32toi64(#1))
+| | implementation = Differential %1 %0.(#0)
+| | demand = (#0, #1)
+| Map 123
+| Project (#2, #0, #1)
+
+EOF
+
+query III
+SELECT * FROM (SELECT 123, COUNT(right_table.f1) AS aggregate FROM t1 AS left_table LEFT JOIN t1 AS right_table ON FALSE GROUP BY 1) AS subquery, t1 AS outer_table WHERE outer_table.f1 = subquery.aggregate;
+----
+123  0  0

--- a/test/sqllogictest/transform/aggregation_nullability.slt
+++ b/test/sqllogictest/transform/aggregation_nullability.slt
@@ -620,6 +620,30 @@ EXPLAIN select t1.f1, count(t2.f2), max(t2.f2) from t1 LEFT JOIN t2 ON t1.f1 = t
 
 EOF
 
+# outer join to inner join conversion allowed
+query T multiline
+EXPLAIN select t1.f1, max(t1.f1 + t2.f2), sum(t1.f2 + t2.f2) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having max(t1.f1 + t2.f2) > 0;
+----
+%0 =
+| Get materialize.public.t1 (u1)
+| Filter !(isnull(#0))
+| ArrangeBy (#0)
+
+%1 =
+| Get materialize.public.t2 (u3)
+| Filter !(isnull(#0))
+
+%2 =
+| Join %0 %1 (= #0 #2)
+| | implementation = Differential %1 %0.(#0)
+| | demand = (#0, #1, #3)
+| Reduce group=(#0)
+| | agg max((#0 + #3))
+| | agg sum((#1 + #3))
+| Filter (#1 > 0)
+
+EOF
+
 # check that a filter on a non-count aggregation doesn't change the COUNT value
 statement ok
 drop table t1

--- a/test/sqllogictest/transform/aggregation_nullability.slt
+++ b/test/sqllogictest/transform/aggregation_nullability.slt
@@ -298,6 +298,208 @@ EXPLAIN select t1.f1, sum(t1.f2) from t1 group by t1.f1 having sum(t1.f2) is not
 
 EOF
 
+# outer-to-inner-join conversion allowed
+query T multiline
+EXPLAIN select t1.f1, sum(t2.f1), max(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having max(t2.f1) >= 0;
+----
+%0 =
+| Get materialize.public.t1 (u1)
+| Filter !(isnull(#0))
+| ArrangeBy (#0)
+
+%1 =
+| Get materialize.public.t2 (u3)
+| Filter !(isnull(#0))
+
+%2 =
+| Join %0 %1 (= #0 #2)
+| | implementation = Differential %1 %0.(#0)
+| | demand = (#0)
+| Reduce group=(#0)
+| | agg sum(#0)
+| | agg max(#0)
+| Filter (#2 >= 0)
+
+EOF
+
+# outer-to-inner-join conversion allowed
+query T multiline
+EXPLAIN select t1.f1, sum(t2.f1), max(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having max(t2.f1) >= 0 and sum(t2.f1) >= 0;
+----
+%0 =
+| Get materialize.public.t1 (u1)
+| Filter !(isnull(#0))
+| ArrangeBy (#0)
+
+%1 =
+| Get materialize.public.t2 (u3)
+| Filter !(isnull(#0))
+
+%2 =
+| Join %0 %1 (= #0 #2)
+| | implementation = Differential %1 %0.(#0)
+| | demand = (#0)
+| Reduce group=(#0)
+| | agg sum(#0)
+| | agg max(#0)
+| Filter (#1 >= 0), (#2 >= 0)
+
+EOF
+
+# outer-to-inner-join conversion allowed, but we fail to detect this case
+query T multiline
+EXPLAIN select t1.f1, sum(t2.f2), max(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having max(t2.f1) >= 0;
+----
+%0 =
+| Get materialize.public.t1 (u1)
+| Filter !(isnull(#0))
+| ArrangeBy (#0)
+
+%1 =
+| Get materialize.public.t2 (u3)
+| Filter !(isnull(#0))
+
+%2 = Let l0 =
+| Join %0 %1 (= #0 #2)
+| | implementation = Differential %1 %0.(#0)
+| | demand = (#0, #3)
+
+%3 =
+| Get materialize.public.t1 (u1)
+
+%4 =
+| Get %2 (l0)
+| Distinct group=(#0)
+| ArrangeBy (#0)
+
+%5 =
+| Join %3 %4 (= #0 #2)
+| | implementation = Differential %3 %4.(#0)
+| | demand = (#0)
+| Negate
+| Project (#0, #1)
+
+%6 =
+| Get materialize.public.t1 (u1)
+
+%7 =
+| Union %5 %6
+| Map null, null
+
+%8 =
+| Get %2 (l0)
+| Project (#0, #1, #0, #3)
+
+%9 =
+| Union %7 %8
+| Reduce group=(#0)
+| | agg sum(#3)
+| | agg max(#2)
+| Filter (#2 >= 0)
+
+EOF
+
+# outer-to-inner-join conversion allowed
+query T multiline
+EXPLAIN select t1.f1, sum(t2.f1 + t2.f2), max(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having max(t2.f1) >= 0;
+----
+%0 =
+| Get materialize.public.t1 (u1)
+| Filter !(isnull(#0))
+| ArrangeBy (#0)
+
+%1 =
+| Get materialize.public.t2 (u3)
+| Filter !(isnull(#0))
+
+%2 =
+| Join %0 %1 (= #0 #2)
+| | implementation = Differential %1 %0.(#0)
+| | demand = (#0, #3)
+| Reduce group=(#0)
+| | agg sum((#0 + #3))
+| | agg max(#0)
+| Filter (#2 >= 0)
+
+EOF
+
+# outer-to-inner-join conversion allowed
+query T multiline
+EXPLAIN select t1.f1, sum(t1.f1 + t2.f1), max(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having max(t2.f1) >= 0;
+----
+%0 =
+| Get materialize.public.t1 (u1)
+| Filter !(isnull(#0))
+| ArrangeBy (#0)
+
+%1 =
+| Get materialize.public.t2 (u3)
+| Filter !(isnull(#0))
+
+%2 =
+| Join %0 %1 (= #0 #2)
+| | implementation = Differential %1 %0.(#0)
+| | demand = (#0)
+| Reduce group=(#0)
+| | agg sum((#0 + #0))
+| | agg max(#0)
+| Filter (#2 >= 0)
+
+EOF
+
+# outer-to-inner-join conversion not allowed since that would alter the result of sum(t1.f1)
+query T multiline
+EXPLAIN select t1.f1, sum(t1.f1), max(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having max(t2.f1) >= 0;
+----
+%0 =
+| Get materialize.public.t1 (u1)
+| Filter !(isnull(#0))
+| ArrangeBy (#0)
+
+%1 =
+| Get materialize.public.t2 (u3)
+| Filter !(isnull(#0))
+
+%2 = Let l0 =
+| Join %0 %1 (= #0 #2)
+| | implementation = Differential %1 %0.(#0)
+| | demand = (#0)
+
+%3 =
+| Get materialize.public.t1 (u1)
+
+%4 =
+| Get %2 (l0)
+| Distinct group=(#0)
+| ArrangeBy (#0)
+
+%5 =
+| Join %3 %4 (= #0 #2)
+| | implementation = Differential %3 %4.(#0)
+| | demand = (#0)
+| Negate
+| Project (#0, #1)
+
+%6 =
+| Get materialize.public.t1 (u1)
+
+%7 =
+| Union %5 %6
+| Map null, null
+
+%8 =
+| Get %2 (l0)
+| Project (#0, #1, #0, #3)
+
+%9 =
+| Union %7 %8
+| Reduce group=(#0)
+| | agg sum(#0)
+| | agg max(#2)
+| Filter (#2 >= 0)
+
+EOF
+
 # check that a filter on a non-count aggregation doesn't change the COUNT value
 statement ok
 drop table t1

--- a/test/sqllogictest/transform/aggregation_nullability.slt
+++ b/test/sqllogictest/transform/aggregation_nullability.slt
@@ -230,15 +230,44 @@ EXPLAIN select t1.f1, count(t2.f1), sum(t2.f1), max(t2.f1), min(t2.f1), count(t1
 | Get materialize.public.t2 (u3)
 | Filter !(isnull(#0))
 
-%2 =
+%2 = Let l0 =
 | Join %0 %1 (= #0 #2)
 | | implementation = Differential %1 %0.(#0)
 | | demand = (#0, #1)
+
+%3 =
+| Get materialize.public.t1 (u1)
+
+%4 =
+| Get %2 (l0)
+| Distinct group=(#0)
+| ArrangeBy (#0)
+
+%5 =
+| Join %3 %4 (= #0 #2)
+| | implementation = Differential %3 %4.(#0)
+| | demand = (#0, #1)
+| Negate
+| Project (#0, #1)
+
+%6 =
+| Get materialize.public.t1 (u1)
+
+%7 =
+| Union %5 %6
+| Map null, null
+
+%8 =
+| Get %2 (l0)
+| Project (#0, #1, #0, #3)
+
+%9 =
+| Union %7 %8
 | Reduce group=(#0)
-| | agg count(#0)
-| | agg sum(#0)
-| | agg max(#0)
-| | agg min(#0)
+| | agg count(#2)
+| | agg sum(#2)
+| | agg max(#2)
+| | agg min(#2)
 | | agg count(#1)
 | | agg sum(#1)
 | | agg min(#1)
@@ -269,6 +298,153 @@ EXPLAIN select t1.f1, sum(t1.f2) from t1 group by t1.f1 having sum(t1.f2) is not
 
 EOF
 
+# check that a filter on a non-count aggregation doesn't change the COUNT value
+statement ok
+drop table t1
+
+statement ok
+drop table t2
+
+statement ok
+create table t1(f1 integer, f2 integer)
+
+statement ok
+create table t2(f1 integer, f2 integer)
+
+statement ok
+insert into t1 values (1, 0), (1, 1), (1, 1)
+
+statement ok
+insert into t2 values (0, 2)
+
+query III
+select t1.f1, count(t1.f2), max(t2.f2) from t1 left join t2 on t1.f2 = t2.f1 group by t1.f1
+----
+1  3  2
+
+query III
+select t1.f1, count(t1.f2), max(t2.f2) from t1 left join t2 on t1.f2 = t2.f1 group by t1.f1 having max(t2.f2) > 0
+----
+1  3  2
+
+query T multiline
+explain select t1.f1, count(t1.f2), max(t2.f2) from t1 left join t2 on t1.f2 = t2.f1 group by t1.f1
+----
+%0 =
+| Get materialize.public.t1 (u5)
+| Filter !(isnull(#1))
+| ArrangeBy (#1)
+
+%1 =
+| Get materialize.public.t2 (u7)
+| Filter !(isnull(#0))
+
+%2 = Let l0 =
+| Join %0 %1 (= #1 #2)
+| | implementation = Differential %1 %0.(#1)
+| | demand = (#0, #1, #3)
+
+%3 =
+| Get materialize.public.t1 (u5)
+
+%4 =
+| Get %2 (l0)
+| Distinct group=(#1)
+| ArrangeBy (#0)
+
+%5 =
+| Join %3 %4 (= #1 #2)
+| | implementation = Differential %3 %4.(#0)
+| | demand = (#0, #1)
+| Negate
+| Project (#0, #1)
+
+%6 =
+| Get materialize.public.t1 (u5)
+
+%7 =
+| Union %5 %6
+| Map null, null
+
+%8 =
+| Union %7 %2
+| Reduce group=(#0)
+| | agg count(#1)
+| | agg max(#3)
+
+EOF
+
+query T multiline
+explain select t1.f1, count(t1.f2), max(t2.f2) from t1 left join t2 on t1.f2 = t2.f1 group by t1.f1 having max(t2.f2) > 0
+----
+%0 =
+| Get materialize.public.t1 (u5)
+| Filter !(isnull(#1))
+| ArrangeBy (#1)
+
+%1 =
+| Get materialize.public.t2 (u7)
+| Filter !(isnull(#0))
+
+%2 = Let l0 =
+| Join %0 %1 (= #1 #2)
+| | implementation = Differential %1 %0.(#1)
+| | demand = (#0, #1, #3)
+
+%3 =
+| Get materialize.public.t1 (u5)
+
+%4 =
+| Get %2 (l0)
+| Distinct group=(#1)
+| ArrangeBy (#0)
+
+%5 =
+| Join %3 %4 (= #1 #2)
+| | implementation = Differential %3 %4.(#0)
+| | demand = (#0, #1)
+| Negate
+| Project (#0, #1)
+
+%6 =
+| Get materialize.public.t1 (u5)
+
+%7 =
+| Union %5 %6
+| Map null, null
+
+%8 =
+| Union %7 %2
+| Reduce group=(#0)
+| | agg count(#1)
+| | agg max(#3)
+| Filter (#2 > 0)
+
+EOF
+
+# if the count is removed, the outer join can be safely converted into an inner join
+query T multiline
+explain select t1.f1, max(t2.f2) from t1 left join t2 on t1.f2 = t2.f1 group by t1.f1 having max(t2.f2) > 0
+----
+%0 =
+| Get materialize.public.t1 (u5)
+| Filter !(isnull(#1))
+| ArrangeBy (#1)
+
+%1 =
+| Get materialize.public.t2 (u7)
+| Filter !(isnull(#0))
+
+%2 =
+| Join %0 %1 (= #1 #2)
+| | implementation = Differential %1 %0.(#1)
+| | demand = (#0, #3)
+| Reduce group=(#0)
+| | agg max(#3)
+| Filter (#1 > 0)
+
+EOF
+
 # regression test for #7047
 statement ok
 drop table t1
@@ -283,13 +459,13 @@ query T multiline
 EXPLAIN SELECT * FROM (SELECT 123, COUNT(right_table.f1) AS aggregate FROM t1 AS left_table LEFT JOIN t1 AS right_table ON FALSE GROUP BY 1) AS subquery, t1 AS outer_table WHERE outer_table.f1 = subquery.aggregate;
 ----
 %0 =
-| Get materialize.public.t1 (u5)
+| Get materialize.public.t1 (u9)
 | Reduce group=()
 | | agg count(null)
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.t1 (u5)
+| Get materialize.public.t1 (u9)
 | Filter !(isnull(i32toi64(#0)))
 
 %2 =
@@ -305,3 +481,106 @@ query III
 SELECT * FROM (SELECT 123, COUNT(right_table.f1) AS aggregate FROM t1 AS left_table LEFT JOIN t1 AS right_table ON FALSE GROUP BY 1) AS subquery, t1 AS outer_table WHERE outer_table.f1 = subquery.aggregate;
 ----
 123  0  0
+
+# non-null requeriment on a non-count aggregation coming from a join predicate
+statement ok
+drop table t1
+
+statement ok
+drop table t2
+
+statement ok
+create table t1(f1 integer, f2 integer not null)
+
+statement ok
+insert into t1 values (null, 0)
+
+statement ok
+create table t2(f1 integer, f2 integer)
+
+statement ok
+insert into t2 values (null, 0)
+
+
+statement ok
+create table t3(f1 integer, f2 integer)
+
+statement ok
+insert into t3 values (null, 0), (null, 0), (1, 1), (6, 6)
+
+query I
+SELECT derived.agg1 FROM t1
+JOIN (
+    SELECT COUNT(*) AS agg1 , MAX(t2.f2) AS agg2
+    FROM t2
+    RIGHT JOIN t3 ON t3.f2 = 6
+) AS derived ON TRUE
+WHERE t1.f2 = derived.agg2;
+----
+4
+
+# the count aggregation prevents the outer-to-inner join conversion
+query T multiline
+EXPLAIN SELECT derived.agg1 FROM t1
+JOIN (
+    SELECT COUNT(*) AS agg1 , MAX(t2.f2) AS agg2
+    FROM t2
+    RIGHT JOIN t3 ON t3.f2 = 6
+) AS derived ON TRUE
+WHERE t1.f2 = derived.agg2;
+----
+%0 =
+| Get materialize.public.t2 (u13)
+| ArrangeBy ()
+
+%1 =
+| Get materialize.public.t3 (u15)
+| Filter (#1 = 6)
+
+%2 = Let l0 =
+| Join %0 %1
+| | implementation = Differential %1 %0.()
+| | demand = (#1, #2)
+
+%3 =
+| Get materialize.public.t1 (u11)
+
+%4 =
+| Get %2 (l0)
+| Distinct group=(#2)
+| Negate
+| Map 6
+
+%5 =
+| Get materialize.public.t3 (u15)
+| Distinct group=(#0, #1)
+
+%6 =
+| Union %4 %5
+
+%7 =
+| Get materialize.public.t3 (u15)
+| ArrangeBy (#0, #1)
+
+%8 =
+| Join %6 %7 (= #0 #2) (= #1 #3)
+| | implementation = Differential %6 %7.(#0, #1)
+| | demand = ()
+| Map null, null
+| Project (#4, #5, #0, #1)
+
+%9 =
+| Union %2 %8
+| Reduce group=()
+| | agg count(true)
+| | agg max(#1)
+| Filter !(isnull(#1))
+| ArrangeBy (#1)
+
+%10 =
+| Join %3 %9 (= #1 #3)
+| | implementation = Differential %3 %9.(#1)
+| | demand = (#2)
+| Project (#2)
+
+EOF

--- a/test/sqllogictest/transform/aggregation_nullability.slt
+++ b/test/sqllogictest/transform/aggregation_nullability.slt
@@ -782,20 +782,19 @@ EXPLAIN SELECT * FROM (SELECT 123, COUNT(right_table.f1) AS aggregate FROM t1 AS
 ----
 %0 =
 | Get materialize.public.t1 (u9)
-| Reduce group=()
-| | agg count(null)
-| ArrangeBy (#0)
+| Distinct group=()
+| ArrangeBy ()
 
 %1 =
 | Get materialize.public.t1 (u9)
-| Filter !(isnull(i32toi64(#0)))
+| Filter !(isnull(i32toi64(#0))), (0 = i32toi64(#0))
 
 %2 =
-| Join %0 %1 (= #0 i32toi64(#1))
-| | implementation = Differential %1 %0.(#0)
-| | demand = (#0, #1)
-| Map 123
-| Project (#2, #0, #1)
+| Join %0 %1
+| | implementation = Differential %1 %0.()
+| | demand = (#0)
+| Map 123, 0
+| Project (#1, #2, #0)
 
 EOF
 


### PR DESCRIPTION
This patch fixes an issue whereby any null rejecting filter on the result of a COUNT aggregation, resulted in the requirement for its parameter expression to be non-null.

Fixes #7049, #7047