### PR TITLE
dataflow/sink: fix kafka sinks to reschedule sinks with pending updates

### DIFF
--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -618,6 +618,14 @@ where
             return true;
         }
 
+        if !pending_rows.is_empty() {
+            // We have some more rows that we need to wait for frontiers to advance before we
+            // can write them out. Let's make sure to reschedule with a small delay to give the
+            // system time to advance.
+            s.activator.activate_after(Duration::from_millis(100));
+            return true;
+        }
+
         if in_flight > 0 {
             // We still have messages that need to be flushed out to Kafka
             // Let's make sure to keep the sink operator around until

--- a/test/kafka-exactly-once/mzcompose.yml
+++ b/test/kafka-exactly-once/mzcompose.yml
@@ -77,6 +77,7 @@ services:
       -w1
       --disable-telemetry
       --logical-compaction-window=off
+      --experimental
     environment:
       - MZ_DEV=1
       - MZ_LOG=${MZ_LOG:-dataflow::sink::kafka=debug,dataflow::source::kafka=debug,coord::timestamp=debug,dataflow::source=debug,info}


### PR DESCRIPTION
(also moves the EOS test back to experimental so that it can exercise the new durability code)

Previously, we were seeing inconsistent behavior with BYO EOS (and potentially also rt eos) where if updates got sent to the sink and enqueued because the timestamps were not durably persistent, they would never get written out because the sink never got rescheduled even if the timestamps were persisted afterwards

touches #7003 