### PR TITLE
pgwire: correctly send EmptyQueryResponse

### DIFF
--- a/src/pgtest/src/lib.rs
+++ b/src/pgtest/src/lib.rs
@@ -254,6 +254,7 @@ impl PgTest {
                     ),
                     Message::ParameterStatus(_) => continue,
                     Message::NoData => ("NoData", "".to_string()),
+                    Message::EmptyQueryResponse => ("EmptyQueryResponse", "".to_string()),
                     _ => ("UNKNOWN", format!("'{}'", ch)),
                 };
                 if self.verbose {

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -451,6 +451,11 @@ where
                 self.commit_transaction().await;
             }
         }
+
+        if num_stmts == 0 {
+            self.conn.send(BackendMessage::EmptyQueryResponse).await?;
+        }
+
         self.ready().await
     }
 

--- a/test/pgtest/empty.pt
+++ b/test/pgtest/empty.pt
@@ -1,0 +1,43 @@
+# Test EmptyQueryResponse.
+
+send
+Query {"query": ";"}
+----
+
+until
+ReadyForQuery
+----
+EmptyQueryResponse
+ReadyForQuery {"status":"I"}
+
+send
+Query {"query": ";;"}
+----
+
+until
+ReadyForQuery
+----
+EmptyQueryResponse
+ReadyForQuery {"status":"I"}
+
+send
+Query {"query": ""}
+----
+
+until
+ReadyForQuery
+----
+EmptyQueryResponse
+ReadyForQuery {"status":"I"}
+
+send
+Query {"query": "; ; select 1; ;"}
+----
+
+until
+ReadyForQuery
+----
+RowDescription {"fields":[{"name":"?column?"}]}
+DataRow {"fields":["1"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}


### PR DESCRIPTION
This adheres more closely to the spec. It also allows Go libpq's Ping
method to work instead of panicing libpq.

See: https://github.com/postgres/postgres/blob/d3c878499c9d639ff06e0664d06b8c731e30c2fc/src/backend/tcop/postgres.c#L1288