### PR TITLE
deny.toml: prune num-bigint exception

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -43,9 +43,6 @@ skip = [
     { name = "semver-parser", version = "0.7.0"},
     { name = "rustc_version", version = "0.3.0"},
 
-    # Waiting on parse_duration.
-    { name = "num-bigint", version = "0.2.6" },
-
     # Waiting on https://github.com/hyperium/headers/pull/83.
     { name = "time", version = "0.1.44" },
 ]

--- a/src/transform/tests/testdata/join-fusion
+++ b/src/transform/tests/testdata/join-fusion
@@ -1,4 +1,4 @@
-# Copyright Materialize, Inc. All rights reserved.
+# Copyright Materialize, Inc. and contributors. All rights reserved.
 #
 # Use of this software is governed by the Business Source License
 # included in the LICENSE file.

--- a/test/sqllogictest/transform/join_fusion.slt
+++ b/test/sqllogictest/transform/join_fusion.slt
@@ -1,7 +1,7 @@
-# Copyright Materialize, Inc. All rights reserved.
+# Copyright Materialize, Inc. and contributors. All rights reserved.
 #
 # Use of this software is governed by the Business Source License
-# included in the LICENSE file at the root of this repository.
+# included in the LICENSE file.
 #
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed


### PR DESCRIPTION
We no longer use the parse_duration crate, so we no longer have a
duplicate version of num-bigint in the tree.