### PR TITLE
dbt-materialize: allow authenticated connections

### DIFF
--- a/misc/dbt-materialize/Dockerfile
+++ b/misc/dbt-materialize/Dockerfile
@@ -13,4 +13,4 @@ COPY . dbt-materialize/
 
 RUN pip install -r dbt-materialize/requirements.txt
 
-CMD [ "pytest", "dbt-materialize/test/materialize.dbtspec" ]
+CMD [ "pytest", "dbt-materialize/test/" ]

--- a/misc/dbt-materialize/dbt/adapters/materialize/connections.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/connections.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import psycopg2
+
 from dbt.adapters.postgres import PostgresConnectionManager
 from dbt.adapters.postgres import PostgresCredentials
 
@@ -21,10 +23,15 @@ import dbt.exceptions
 from dataclasses import dataclass
 from dbt import flags
 from dbt.logger import GLOBAL_LOGGER as logger
+from typing import Optional
 
 
 @dataclass
 class MaterializeCredentials(PostgresCredentials):
+    sslcert: Optional[str] = None
+    sslkey: Optional[str] = None
+    sslrootcert: Optional[str] = None
+
     @property
     def type(self):
         return "materialize"
@@ -35,7 +42,65 @@ class MaterializeConnectionManager(PostgresConnectionManager):
 
     @classmethod
     def open(cls, connection):
-        connection = super().open(connection)
+        if connection.state == "open":
+            logger.debug("Connection is already open, skipping open.")
+            return connection
+
+        credentials = cls.get_credentials(connection.credentials)
+        kwargs = {}
+        # we don't want to pass 0 along to connect() as postgres will try to
+        # call an invalid setsockopt() call (contrary to the docs).
+        if credentials.keepalives_idle:
+            kwargs["keepalives_idle"] = credentials.keepalives_idle
+
+        # psycopg2 doesn't support search_path officially,
+        # see https://github.com/psycopg/psycopg2/issues/465
+        search_path = credentials.search_path
+        if search_path is not None and search_path != "":
+            # see https://postgresql.org/docs/9.5/libpq-connect.html
+            kwargs["options"] = "-c search_path={}".format(
+                search_path.replace(" ", "\\ ")
+            )
+
+        if credentials.sslmode:
+            kwargs["sslmode"] = credentials.sslmode
+
+        if credentials.sslcert is not None:
+            kwargs["sslcert"] = credentials.sslcert
+
+        if credentials.sslkey is not None:
+            kwargs["sslkey"] = credentials.sslkey
+
+        if credentials.sslrootcert is not None:
+            kwargs["sslrootcert"] = credentials.sslrootcert
+
+        try:
+            handle = psycopg2.connect(
+                dbname=credentials.database,
+                user=credentials.user,
+                host=credentials.host,
+                password=credentials.password,
+                port=credentials.port,
+                connect_timeout=10,
+                **kwargs,
+            )
+
+            if credentials.role:
+                handle.cursor().execute("set role {}".format(credentials.role))
+
+            connection.handle = handle
+            connection.state = "open"
+        except psycopg2.Error as e:
+            logger.debug(
+                "Got an error when attempting to open a postgres "
+                "connection: '{}'".format(e)
+            )
+
+            connection.handle = None
+            connection.state = "fail"
+
+            raise dbt.exceptions.FailedToConnectException(str(e))
+
         # Prevents psycopg connection from automatically opening transactions
         # More info: https://www.psycopg.org/docs/usage.html#transactions-control
         connection.handle.autocommit = True

--- a/misc/dbt-materialize/dbt/include/materialize/sample_profiles.yml
+++ b/misc/dbt-materialize/dbt/include/materialize/sample_profiles.yml
@@ -19,22 +19,26 @@ default:
 
     dev:
       type: materialize
-      threads: [1 or more]
-      host: [host - default is localhost]
-      port: [port - default is 6875]
+      threads: 1
+      host: localhost
+      port: 6875
       user: materialize
-      pass: [dev_password - any value]
-      dbname: [dbname - default is materialize]
-      schema: [dev_schema - default is public]
+      pass: password
+      dbname: materialize
+      schema: public
 
-    prod:
+    authenticated:
       type: materialize
-      threads: [1 or more]
-      host: [host - default is localhost]
-      port: [port - default is 6875]
+      threads: 1
+      host: instance.materialize.cloud
+      port: 6875
       user: materialize
-      pass: [prod_password - any value]
-      dbname: [dbname - default is materialize]
-      schema: [prod_schema - default is public]
+      pass: password
+      dbname: materialize
+      schema: analytics
+      sslmode: verify-ca
+      sslcert: materialize.crt
+      sslkey: materialize.key
+      sslrootcert: ca.crt
 
   target: dev

--- a/misc/dbt-materialize/mzcompose.yml
+++ b/misc/dbt-materialize/mzcompose.yml
@@ -7,9 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-x-port-mappings:
-  - &materialized ${MZ_PORT:-6875:6875}
-
 version: '3.7'
 services:
   materialized:
@@ -18,19 +15,46 @@ services:
     environment:
       - MZ_DEV=1
     ports:
-      - *materialized
+      - 6875
+  tls-materialized:
+    mzbuild: materialized
+    command:
+      - --disable-telemetry
+      - --tls-mode=verify-ca
+      - --tls-cert=/share/secrets/materialized.crt
+      - --tls-key=/share/secrets/materialized.key
+      - --tls-ca=/share/secrets/ca.crt
+      - --listen-addr=0.0.0.0:6876
+    volumes:
+      - secrets:/share/secrets
+    environment:
+      - MZ_DEV=1
+    ports:
+      - 6876
+    depends_on: [test-certs]
   dbt-test:
     mzbuild: dbt-materialize
+    volumes:
+      - secrets:/share/secrets
+    depends_on: [test-certs]
+  test-certs:
+    mzbuild: test-certs
+    volumes:
+      - secrets:/secrets
 
 mzworkflows:
   ci:
-    env:
-      MZ_PORT: 6875
     steps:
       - step: start-services
-        services: [materialized]
+        services: [materialized, tls-materialized]
       - step: wait-for-tcp
         host: materialized
         port: 6875
+      - step: wait-for-tcp
+        host: tls-materialized
+        port: 6876
       - step: run
         service: dbt-test
+
+volumes:
+  secrets:

--- a/misc/dbt-materialize/setup.py
+++ b/misc/dbt-materialize/setup.py
@@ -26,7 +26,7 @@ package_name = "dbt-materialize"
 # This adapter's version, and its required dbt-postgres version, tracks the
 # target dbt version.
 target_package_version = "0.18.1"
-package_version_suffix = ".post2"
+package_version_suffix = ".post3"
 package_version = "{}{}".format(target_package_version, package_version_suffix)
 description = """The Materialize adapter plugin for dbt (data build tool)"""
 

--- a/misc/dbt-materialize/test/tls-materialize.dbtspec
+++ b/misc/dbt-materialize/test/tls-materialize.dbtspec
@@ -1,0 +1,75 @@
+# Copyright 2020 Josh Wills. All rights reserved.
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License in the LICENSE file at the
+# root of this repository, or online at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+target:
+  type: materialize
+  host: tls-materialized
+  user: materialize
+  pass: password
+  database: materialize
+  schema: "dbt_test_{{ var('_dbt_random_suffix') }}"
+  port: 6876
+  threads: 1
+  sslmode: verify-ca
+  sslcert: /share/secrets/materialized.crt
+  sslkey: /share/secrets/materialized.key
+  sslrootcert: /share/secrets/ca.crt
+sequences:
+  test_dbt_empty: empty
+  # Custom base test that removes the last incremental portion.
+  test_dbt_base:
+    project: base
+    sequence:
+      - type: dbt
+        cmd: seed
+      - type: run_results
+        length: fact.seed.length
+      - type: dbt
+        cmd: run
+      - type: run_results
+        length: fact.run.length
+      - type: relation_types
+        expect: fact.expected_types_table
+      - type: relation_rows
+        name: base
+        length: fact.base.rowcount
+      - type: relations_equal
+        relations: fact.persisted_relations
+      - type: dbt
+        cmd: docs generate
+      - type: catalog
+        exists: True
+        nodes:
+          length: fact.catalog.nodes.length
+        sources:
+          length: fact.catalog.sources.length
+      # now swap
+      - type: dbt
+        cmd: run -m swappable
+        vars:
+          materialized_var: view
+      - type: run_results
+        length: 1
+      - type: relation_types
+        expect: fact.expected_types_view
+  test_dbt_data_test: data_test
+  test_dbt_schema_test: schema_test
+  test_dbt_ephemeral: ephemeral
+  test_dbt_ephemeral_data_tests: data_test_ephemeral_models
+  # dbt-materialize does not support incremental models or snapshots
+  # test_dbt_incremental: incremental
+  # test_dbt_snapshot_strategy_timestamp: snapshot_strategy_timestamp
+  # test_dbt_snapshot_strategy_check_cols: snapshot_strategy_check_cols


### PR DESCRIPTION
Updates the `dbt-materialize` adapter to allow providing `sslcert`,
`sslkey`, and `sslrootcert` parameters. This will allow users to use
the `dbt-materialize` adapter to connect to Materialize Cloud.