### PR TITLE
Extend NonNullRequirements transform for join equivalences

### DIFF
--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -150,53 +150,49 @@ WHERE l1.la IN (
 ----
 %0 = Let l0 =
 | Get materialize.public.l (u1)
+| Filter !(isnull(#0))
+
+%1 = Let l1 =
+| Get %0 (l0)
 | Project (#0)
 
-%1 =
-| Get %0 (l0)
+%2 =
+| Get materialize.public.l (u1)
+| Project (#0)
 | Distinct group=(#0)
 | ArrangeBy ()
 
-%2 = Let l1 =
-| Join %1 %0
-| | implementation = Differential %0 %1.()
-
-%3 =
-| Get materialize.public.l (u1)
+%3 = Let l2 =
+| Join %2 %1
+| | implementation = Differential %1 %2.()
 
 %4 =
-| Get %2 (l1)
+| Get %3 (l2)
 | Filter (#0 = (#1 + 1))
 
 %5 =
-| Get %2 (l1)
-| Filter !(isnull(#1))
+| Get %3 (l2)
 | Project (#1)
 | Distinct group=(#0)
 | ArrangeBy (#0)
 
 %6 =
-| Get materialize.public.l (u1)
-| Filter !(isnull(#0))
+| Join %5 %1 (= #0 (#1 + 1))
+| | implementation = Differential %1 %5.(#0)
 | Project (#0)
+| Distinct group=(#0)
+| ArrangeBy (#0)
 
 %7 =
-| Join %5 %6 (= #0 (#1 + 1))
-| | implementation = Differential %6 %5.(#0)
+| Join %4 %6 (= #1 #2)
+| | implementation = Differential %4 %6.(#0)
 | Project (#0)
 | Distinct group=(#0)
 | ArrangeBy (#0)
 
 %8 =
-| Join %4 %7 (= #1 #2)
-| | implementation = Differential %4 %7.(#0)
-| Project (#0)
-| Distinct group=(#0)
-| ArrangeBy (#0)
-
-%9 =
-| Join %3 %8 (= #0 #2)
-| | implementation = Differential %3 %8.(#0)
+| Join %0 %7 (= #0 #2)
+| | implementation = Differential %0 %7.(#0)
 | Project (#0, #1)
 
 EOF
@@ -311,32 +307,32 @@ query T multiline
 EXPLAIN PLAN FOR
 SELECT * FROM l LEFT JOIN r ON l.la = r.ra
 ----
-%0 =
+%0 = Let l0 =
 | Get materialize.public.l (u1)
 | Filter !(isnull(#0))
-| ArrangeBy (#0)
 
 %1 =
+| Get %0 (l0)
+| ArrangeBy (#0)
+
+%2 =
 | Get materialize.public.r (u3)
 | Filter !(isnull(#0))
 
-%2 = Let l0 =
-| Join %0 %1 (= #0 #2)
-| | implementation = Differential %1 %0.(#0)
+%3 = Let l1 =
+| Join %1 %2 (= #0 #2)
+| | implementation = Differential %2 %1.(#0)
 | Project (#0, #1, #3)
 
-%3 =
-| Get materialize.public.l (u1)
-
 %4 =
-| Get %2 (l0)
+| Get %3 (l1)
 | Project (#0)
 | Distinct group=(#0)
 | ArrangeBy (#0)
 
 %5 =
-| Join %3 %4 (= #0 #2)
-| | implementation = Differential %3 %4.(#0)
+| Join %0 %4 (= #0 #2)
+| | implementation = Differential %0 %4.(#0)
 | Project (#0, #1)
 | Negate
 
@@ -348,7 +344,7 @@ SELECT * FROM l LEFT JOIN r ON l.la = r.ra
 | Map null, null
 
 %8 =
-| Get %2 (l0)
+| Get %3 (l1)
 | Project (#0, #1, #0, #2)
 
 %9 =
@@ -360,49 +356,46 @@ query T multiline
 EXPLAIN PLAN FOR
 SELECT * FROM l RIGHT JOIN r ON l.la = r.ra
 ----
-%0 =
+%0 = Let l0 =
+| Get materialize.public.r (u3)
+| Filter !(isnull(#0))
+
+%1 =
 | Get materialize.public.l (u1)
 | Filter !(isnull(#0))
 | ArrangeBy (#0)
 
-%1 =
-| Get materialize.public.r (u3)
-| Filter !(isnull(#0))
-
-%2 = Let l0 =
-| Join %0 %1 (= #0 #2)
-| | implementation = Differential %1 %0.(#0)
+%2 = Let l1 =
+| Join %1 %0 (= #0 #2)
+| | implementation = Differential %0 %1.(#0)
 | Project (#0, #1, #3)
 
 %3 =
-| Get materialize.public.r (u3)
-
-%4 =
-| Get %2 (l0)
+| Get %2 (l1)
 | Project (#0)
 | Distinct group=(#0)
 | ArrangeBy (#0)
 
-%5 =
-| Join %3 %4 (= #0 #2)
-| | implementation = Differential %3 %4.(#0)
+%4 =
+| Join %0 %3 (= #0 #2)
+| | implementation = Differential %0 %3.(#0)
 | Project (#0, #1)
 | Negate
 
-%6 =
+%5 =
 | Get materialize.public.r (u3)
 
-%7 =
-| Union %5 %6
+%6 =
+| Union %4 %5
 | Map null, null
 | Project (#2, #3, #0, #1)
 
-%8 =
-| Get %2 (l0)
+%7 =
+| Get %2 (l1)
 | Project (#0, #1, #0, #2)
 
-%9 =
-| Union %7 %8
+%8 =
+| Union %6 %7
 
 EOF
 
@@ -410,32 +403,32 @@ query T multiline
 EXPLAIN PLAN FOR
 SELECT * FROM l FULL JOIN r ON l.la = r.ra
 ----
-%0 =
+%0 = Let l0 =
 | Get materialize.public.l (u1)
 | Filter !(isnull(#0))
-| ArrangeBy (#0)
 
-%1 =
+%1 = Let l1 =
 | Get materialize.public.r (u3)
 | Filter !(isnull(#0))
 
-%2 = Let l0 =
-| Join %0 %1 (= #0 #2)
-| | implementation = Differential %1 %0.(#0)
+%2 =
+| Get %0 (l0)
+| ArrangeBy (#0)
+
+%3 = Let l2 =
+| Join %2 %1 (= #0 #2)
+| | implementation = Differential %1 %2.(#0)
 | Project (#0, #1, #3)
 
-%3 = Let l1 =
-| Get %2 (l0)
+%4 = Let l3 =
+| Get %3 (l2)
 | Project (#0)
 | Distinct group=(#0)
 | ArrangeBy (#0)
 
-%4 =
-| Get materialize.public.r (u3)
-
 %5 =
-| Join %4 %3 (= #0 #2)
-| | implementation = Differential %4 %3.(#0)
+| Join %1 %4 (= #0 #2)
+| | implementation = Differential %1 %4.(#0)
 | Project (#0, #1)
 | Negate
 
@@ -448,27 +441,24 @@ SELECT * FROM l FULL JOIN r ON l.la = r.ra
 | Project (#2, #3, #0, #1)
 
 %8 =
-| Get materialize.public.l (u1)
-
-%9 =
-| Join %8 %3 (= #0 #2)
-| | implementation = Differential %8 %3.(#0)
+| Join %0 %4 (= #0 #2)
+| | implementation = Differential %0 %4.(#0)
 | Project (#0, #1)
 | Negate
 
-%10 =
+%9 =
 | Get materialize.public.l (u1)
 
-%11 =
-| Union %9 %10
+%10 =
+| Union %8 %9
 | Map null, null
 
-%12 =
-| Get %2 (l0)
+%11 =
+| Get %3 (l2)
 | Project (#0, #1, #0, #2)
 
-%13 =
-| Union %7 %11 %12
+%12 =
+| Union %7 %10 %11
 
 EOF
 
@@ -556,7 +546,7 @@ EXPLAIN SELECT name, id FROM v4362 WHERE name = (SELECT name FROM v4362 WHERE id
 | Project ()
 | Reduce group=()
 | | agg count(true)
-| Filter (#0 > 1)
+| Filter (err: more than one record produced in subquery), (#0 > 1)
 | Project ()
 | Map (err: more than one record produced in subquery)
 

--- a/test/sqllogictest/transform/aggregation_nullability.slt
+++ b/test/sqllogictest/transform/aggregation_nullability.slt
@@ -22,47 +22,50 @@ INSERT INTO t1 VALUES (1, 2)
 query T multiline
 EXPLAIN select t1.f1, count(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having count(t2.f1) >= 0;
 ----
-%0 =
+%0 = Let l0 =
 | Get materialize.public.t1 (u1)
 | Filter !(isnull(#0))
 | Project (#0)
-| ArrangeBy (#0)
 
 %1 =
+| Get %0 (l0)
+| ArrangeBy (#0)
+
+%2 =
 | Get materialize.public.t2 (u3)
 | Filter !(isnull(#0))
 | Project (#0)
 
-%2 = Let l0 =
-| Join %0 %1 (= #0 #1)
-| | implementation = Differential %1 %0.(#0)
-| Project (#0)
-
 %3 = Let l1 =
-| Get materialize.public.t1 (u1)
+| Join %1 %2 (= #0 #1)
+| | implementation = Differential %2 %1.(#0)
 | Project (#0)
 
 %4 =
-| Get %2 (l0)
+| Get %3 (l1)
 | Distinct group=(#0)
 | ArrangeBy (#0)
 
 %5 =
-| Join %3 %4 (= #0 #1)
-| | implementation = Differential %3 %4.(#0)
+| Join %0 %4 (= #0 #1)
+| | implementation = Differential %0 %4.(#0)
 | Project (#0)
 | Negate
 
 %6 =
-| Union %5 %3
-| Map null
+| Get materialize.public.t1 (u1)
+| Project (#0)
 
 %7 =
-| Get %2 (l0)
-| Project (#0, #0)
+| Union %5 %6
+| Map null
 
 %8 =
-| Union %6 %7
+| Get %3 (l1)
+| Project (#0, #0)
+
+%9 =
+| Union %7 %8
 | Reduce group=(#0)
 | | agg count(#1)
 | Filter (#1 >= 0)
@@ -108,33 +111,33 @@ select t1.f1, sum(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 ha
 query T multiline
 EXPLAIN select t1.f1, count(t2.f1), sum(t2.f1), max(t2.f1), min(t2.f1), count(t1.f2), sum(t1.f2), min(t1.f2), max(t1.f2) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1;
 ----
-%0 =
+%0 = Let l0 =
 | Get materialize.public.t1 (u1)
 | Filter !(isnull(#0))
-| ArrangeBy (#0)
 
 %1 =
+| Get %0 (l0)
+| ArrangeBy (#0)
+
+%2 =
 | Get materialize.public.t2 (u3)
 | Filter !(isnull(#0))
 | Project (#0)
 
-%2 = Let l0 =
-| Join %0 %1 (= #0 #2)
-| | implementation = Differential %1 %0.(#0)
+%3 = Let l1 =
+| Join %1 %2 (= #0 #2)
+| | implementation = Differential %2 %1.(#0)
 | Project (#0, #1)
 
-%3 =
-| Get materialize.public.t1 (u1)
-
 %4 =
-| Get %2 (l0)
+| Get %3 (l1)
 | Project (#0)
 | Distinct group=(#0)
 | ArrangeBy (#0)
 
 %5 =
-| Join %3 %4 (= #0 #2)
-| | implementation = Differential %3 %4.(#0)
+| Join %0 %4 (= #0 #2)
+| | implementation = Differential %0 %4.(#0)
 | Project (#0, #1)
 | Negate
 
@@ -146,7 +149,7 @@ EXPLAIN select t1.f1, count(t2.f1), sum(t2.f1), max(t2.f1), min(t2.f1), count(t1
 | Map null
 
 %8 =
-| Get %2 (l0)
+| Get %3 (l1)
 | Project (#0, #1, #0)
 
 %9 =
@@ -166,33 +169,33 @@ EOF
 query T multiline
 EXPLAIN select t1.f1, count(t2.f1), sum(t2.f1), max(t2.f1), min(t2.f1), count(t1.f2), sum(t1.f2), min(t1.f2), max(t1.f2) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having sum(t1.f2) >= 0;
 ----
-%0 =
+%0 = Let l0 =
 | Get materialize.public.t1 (u1)
 | Filter !(isnull(#0))
-| ArrangeBy (#0)
 
 %1 =
+| Get %0 (l0)
+| ArrangeBy (#0)
+
+%2 =
 | Get materialize.public.t2 (u3)
 | Filter !(isnull(#0))
 | Project (#0)
 
-%2 = Let l0 =
-| Join %0 %1 (= #0 #2)
-| | implementation = Differential %1 %0.(#0)
+%3 = Let l1 =
+| Join %1 %2 (= #0 #2)
+| | implementation = Differential %2 %1.(#0)
 | Project (#0, #1)
 
-%3 =
-| Get materialize.public.t1 (u1)
-
 %4 =
-| Get %2 (l0)
+| Get %3 (l1)
 | Project (#0)
 | Distinct group=(#0)
 | ArrangeBy (#0)
 
 %5 =
-| Join %3 %4 (= #0 #2)
-| | implementation = Differential %3 %4.(#0)
+| Join %0 %4 (= #0 #2)
+| | implementation = Differential %0 %4.(#0)
 | Project (#0, #1)
 | Negate
 
@@ -204,7 +207,7 @@ EXPLAIN select t1.f1, count(t2.f1), sum(t2.f1), max(t2.f1), min(t2.f1), count(t1
 | Map null
 
 %8 =
-| Get %2 (l0)
+| Get %3 (l1)
 | Project (#0, #1, #0)
 
 %9 =
@@ -225,33 +228,33 @@ EOF
 query T multiline
 EXPLAIN select t1.f1, count(t2.f1), sum(t2.f1), max(t2.f1), min(t2.f1), count(t1.f2), sum(t1.f2), min(t1.f2), max(t1.f2) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having sum(t2.f1) >= 0;
 ----
-%0 =
+%0 = Let l0 =
 | Get materialize.public.t1 (u1)
 | Filter !(isnull(#0))
-| ArrangeBy (#0)
 
 %1 =
+| Get %0 (l0)
+| ArrangeBy (#0)
+
+%2 =
 | Get materialize.public.t2 (u3)
 | Filter !(isnull(#0))
 | Project (#0)
 
-%2 = Let l0 =
-| Join %0 %1 (= #0 #2)
-| | implementation = Differential %1 %0.(#0)
+%3 = Let l1 =
+| Join %1 %2 (= #0 #2)
+| | implementation = Differential %2 %1.(#0)
 | Project (#0, #1)
 
-%3 =
-| Get materialize.public.t1 (u1)
-
 %4 =
-| Get %2 (l0)
+| Get %3 (l1)
 | Project (#0)
 | Distinct group=(#0)
 | ArrangeBy (#0)
 
 %5 =
-| Join %3 %4 (= #0 #2)
-| | implementation = Differential %3 %4.(#0)
+| Join %0 %4 (= #0 #2)
+| | implementation = Differential %0 %4.(#0)
 | Project (#0, #1)
 | Negate
 
@@ -263,7 +266,7 @@ EXPLAIN select t1.f1, count(t2.f1), sum(t2.f1), max(t2.f1), min(t2.f1), count(t1
 | Map null
 
 %8 =
-| Get %2 (l0)
+| Get %3 (l1)
 | Project (#0, #1, #0)
 
 %9 =
@@ -359,47 +362,50 @@ EOF
 query T multiline
 EXPLAIN select t1.f1, sum(t2.f2), max(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having max(t2.f1) >= 0;
 ----
-%0 =
+%0 = Let l0 =
 | Get materialize.public.t1 (u1)
 | Filter !(isnull(#0))
 | Project (#0)
-| ArrangeBy (#0)
 
 %1 =
+| Get %0 (l0)
+| ArrangeBy (#0)
+
+%2 =
 | Get materialize.public.t2 (u3)
 | Filter !(isnull(#0))
 
-%2 = Let l0 =
-| Join %0 %1 (= #0 #1)
-| | implementation = Differential %1 %0.(#0)
+%3 = Let l1 =
+| Join %1 %2 (= #0 #1)
+| | implementation = Differential %2 %1.(#0)
 | Project (#0, #2)
 
-%3 = Let l1 =
-| Get materialize.public.t1 (u1)
-| Project (#0)
-
 %4 =
-| Get %2 (l0)
+| Get %3 (l1)
 | Project (#0)
 | Distinct group=(#0)
 | ArrangeBy (#0)
 
 %5 =
-| Join %3 %4 (= #0 #1)
-| | implementation = Differential %3 %4.(#0)
+| Join %0 %4 (= #0 #1)
+| | implementation = Differential %0 %4.(#0)
 | Project (#0)
 | Negate
 
 %6 =
-| Union %5 %3
-| Map null, null
+| Get materialize.public.t1 (u1)
+| Project (#0)
 
 %7 =
-| Get %2 (l0)
-| Project (#0, #0, #1)
+| Union %5 %6
+| Map null, null
 
 %8 =
-| Union %6 %7
+| Get %3 (l1)
+| Project (#0, #0, #1)
+
+%9 =
+| Union %7 %8
 | Reduce group=(#0)
 | | agg sum(#2)
 | | agg max(#1)
@@ -462,47 +468,50 @@ EOF
 query T multiline
 EXPLAIN select t1.f1, sum(t1.f1), max(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having max(t2.f1) >= 0;
 ----
-%0 =
+%0 = Let l0 =
 | Get materialize.public.t1 (u1)
 | Filter !(isnull(#0))
 | Project (#0)
-| ArrangeBy (#0)
 
 %1 =
+| Get %0 (l0)
+| ArrangeBy (#0)
+
+%2 =
 | Get materialize.public.t2 (u3)
 | Filter !(isnull(#0))
 | Project (#0)
 
-%2 = Let l0 =
-| Join %0 %1 (= #0 #1)
-| | implementation = Differential %1 %0.(#0)
-| Project (#0)
-
 %3 = Let l1 =
-| Get materialize.public.t1 (u1)
+| Join %1 %2 (= #0 #1)
+| | implementation = Differential %2 %1.(#0)
 | Project (#0)
 
 %4 =
-| Get %2 (l0)
+| Get %3 (l1)
 | Distinct group=(#0)
 | ArrangeBy (#0)
 
 %5 =
-| Join %3 %4 (= #0 #1)
-| | implementation = Differential %3 %4.(#0)
+| Join %0 %4 (= #0 #1)
+| | implementation = Differential %0 %4.(#0)
 | Project (#0)
 | Negate
 
 %6 =
-| Union %5 %3
-| Map null
+| Get materialize.public.t1 (u1)
+| Project (#0)
 
 %7 =
-| Get %2 (l0)
-| Project (#0, #0)
+| Union %5 %6
+| Map null
 
 %8 =
-| Union %6 %7
+| Get %3 (l1)
+| Project (#0, #0)
+
+%9 =
+| Union %7 %8
 | Reduce group=(#0)
 | | agg sum(#0)
 | | agg max(#1)
@@ -514,43 +523,46 @@ EOF
 query T multiline
 EXPLAIN select t1.f1, count(t2.f2) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1;
 ----
-%0 =
+%0 = Let l0 =
 | Get materialize.public.t1 (u1)
 | Filter !(isnull(#0))
 | Project (#0)
-| ArrangeBy (#0)
 
 %1 =
+| Get %0 (l0)
+| ArrangeBy (#0)
+
+%2 =
 | Get materialize.public.t2 (u3)
 | Filter !(isnull(#0))
 
-%2 = Let l0 =
-| Join %0 %1 (= #0 #1)
-| | implementation = Differential %1 %0.(#0)
+%3 = Let l1 =
+| Join %1 %2 (= #0 #1)
+| | implementation = Differential %2 %1.(#0)
 | Project (#0, #2)
 
-%3 = Let l1 =
-| Get materialize.public.t1 (u1)
-| Project (#0)
-
 %4 =
-| Get %2 (l0)
+| Get %3 (l1)
 | Project (#0)
 | Distinct group=(#0)
 | ArrangeBy (#0)
 
 %5 =
-| Join %3 %4 (= #0 #1)
-| | implementation = Differential %3 %4.(#0)
+| Join %0 %4 (= #0 #1)
+| | implementation = Differential %0 %4.(#0)
 | Project (#0)
 | Negate
 
 %6 =
-| Union %5 %3
-| Map null
+| Get materialize.public.t1 (u1)
+| Project (#0)
 
 %7 =
-| Union %6 %2
+| Union %5 %6
+| Map null
+
+%8 =
+| Union %7 %3
 | Reduce group=(#0)
 | | agg count(#1)
 
@@ -560,43 +572,46 @@ EOF
 query T multiline
 EXPLAIN select t1.f1, count(t2.f2), max(t2.f2) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1;
 ----
-%0 =
+%0 = Let l0 =
 | Get materialize.public.t1 (u1)
 | Filter !(isnull(#0))
 | Project (#0)
-| ArrangeBy (#0)
 
 %1 =
+| Get %0 (l0)
+| ArrangeBy (#0)
+
+%2 =
 | Get materialize.public.t2 (u3)
 | Filter !(isnull(#0))
 
-%2 = Let l0 =
-| Join %0 %1 (= #0 #1)
-| | implementation = Differential %1 %0.(#0)
+%3 = Let l1 =
+| Join %1 %2 (= #0 #1)
+| | implementation = Differential %2 %1.(#0)
 | Project (#0, #2)
 
-%3 = Let l1 =
-| Get materialize.public.t1 (u1)
-| Project (#0)
-
 %4 =
-| Get %2 (l0)
+| Get %3 (l1)
 | Project (#0)
 | Distinct group=(#0)
 | ArrangeBy (#0)
 
 %5 =
-| Join %3 %4 (= #0 #1)
-| | implementation = Differential %3 %4.(#0)
+| Join %0 %4 (= #0 #1)
+| | implementation = Differential %0 %4.(#0)
 | Project (#0)
 | Negate
 
 %6 =
-| Union %5 %3
-| Map null
+| Get materialize.public.t1 (u1)
+| Project (#0)
 
 %7 =
-| Union %6 %2
+| Union %5 %6
+| Map null
+
+%8 =
+| Union %7 %3
 | Reduce group=(#0)
 | | agg count(#1)
 | | agg max(#1)
@@ -615,14 +630,14 @@ EXPLAIN select t1.f1, count(t2.f2), max(t2.f2) from t1 LEFT JOIN t2 ON t1.f1 = t
 
 %1 =
 | Get materialize.public.t2 (u3)
-| Filter !(isnull(#0))
+| Filter !(isnull(#0)), !(isnull(#1))
 
 %2 =
 | Join %0 %1 (= #0 #1)
 | | implementation = Differential %1 %0.(#0)
 | Project (#0, #2)
 | Reduce group=(#0)
-| | agg count(#1)
+| | agg count(true)
 | | agg max(#1)
 | Filter (#2 > 0)
 
@@ -639,7 +654,7 @@ EXPLAIN select t1.f1, max(t1.f1 + t2.f2), sum(t1.f2 + t2.f2) from t1 LEFT JOIN t
 
 %1 =
 | Get materialize.public.t2 (u3)
-| Filter !(isnull(#0))
+| Filter !(isnull(#0)), !(isnull(#1))
 
 %2 =
 | Join %0 %1 (= #0 #2)
@@ -684,32 +699,32 @@ select t1.f1, count(t1.f2), max(t2.f2) from t1 left join t2 on t1.f2 = t2.f1 gro
 query T multiline
 explain select t1.f1, count(t1.f2), max(t2.f2) from t1 left join t2 on t1.f2 = t2.f1 group by t1.f1
 ----
-%0 =
+%0 = Let l0 =
 | Get materialize.public.t1 (u5)
 | Filter !(isnull(#1))
-| ArrangeBy (#1)
 
 %1 =
+| Get %0 (l0)
+| ArrangeBy (#1)
+
+%2 =
 | Get materialize.public.t2 (u7)
 | Filter !(isnull(#0))
 
-%2 = Let l0 =
-| Join %0 %1 (= #1 #2)
-| | implementation = Differential %1 %0.(#1)
+%3 = Let l1 =
+| Join %1 %2 (= #1 #2)
+| | implementation = Differential %2 %1.(#1)
 | Project (#0, #1, #3)
 
-%3 =
-| Get materialize.public.t1 (u5)
-
 %4 =
-| Get %2 (l0)
+| Get %3 (l1)
 | Project (#1)
 | Distinct group=(#0)
 | ArrangeBy (#0)
 
 %5 =
-| Join %3 %4 (= #1 #2)
-| | implementation = Differential %3 %4.(#0)
+| Join %0 %4 (= #1 #2)
+| | implementation = Differential %0 %4.(#0)
 | Project (#0, #1)
 | Negate
 
@@ -721,7 +736,7 @@ explain select t1.f1, count(t1.f2), max(t2.f2) from t1 left join t2 on t1.f2 = t
 | Map null
 
 %8 =
-| Union %7 %2
+| Union %7 %3
 | Reduce group=(#0)
 | | agg count(#1)
 | | agg max(#2)
@@ -731,32 +746,32 @@ EOF
 query T multiline
 explain select t1.f1, count(t1.f2), max(t2.f2) from t1 left join t2 on t1.f2 = t2.f1 group by t1.f1 having max(t2.f2) > 0
 ----
-%0 =
+%0 = Let l0 =
 | Get materialize.public.t1 (u5)
 | Filter !(isnull(#1))
-| ArrangeBy (#1)
 
 %1 =
+| Get %0 (l0)
+| ArrangeBy (#1)
+
+%2 =
 | Get materialize.public.t2 (u7)
 | Filter !(isnull(#0))
 
-%2 = Let l0 =
-| Join %0 %1 (= #1 #2)
-| | implementation = Differential %1 %0.(#1)
+%3 = Let l1 =
+| Join %1 %2 (= #1 #2)
+| | implementation = Differential %2 %1.(#1)
 | Project (#0, #1, #3)
 
-%3 =
-| Get materialize.public.t1 (u5)
-
 %4 =
-| Get %2 (l0)
+| Get %3 (l1)
 | Project (#1)
 | Distinct group=(#0)
 | ArrangeBy (#0)
 
 %5 =
-| Join %3 %4 (= #1 #2)
-| | implementation = Differential %3 %4.(#0)
+| Join %0 %4 (= #1 #2)
+| | implementation = Differential %0 %4.(#0)
 | Project (#0, #1)
 | Negate
 
@@ -768,7 +783,7 @@ explain select t1.f1, count(t1.f2), max(t2.f2) from t1 left join t2 on t1.f2 = t
 | Map null
 
 %8 =
-| Union %7 %2
+| Union %7 %3
 | Reduce group=(#0)
 | | agg count(#1)
 | | agg max(#2)
@@ -787,7 +802,7 @@ explain select t1.f1, max(t2.f2) from t1 left join t2 on t1.f2 = t2.f1 group by 
 
 %1 =
 | Get materialize.public.t2 (u7)
-| Filter !(isnull(#0))
+| Filter !(isnull(#0)), !(isnull(#1))
 
 %2 =
 | Join %0 %1 (= #1 #2)

--- a/test/sqllogictest/transform/is_null_propagation.slt
+++ b/test/sqllogictest/transform/is_null_propagation.slt
@@ -34,6 +34,7 @@ EXPLAIN SELECT FROM t1, t2 WHERE t1.f2 + t2.f1 = t1.f1 AND t2.f1 IS NOT NULL
 
 %1 =
 | Get materialize.public.t2 (u3)
+| Filter !(isnull(#0))
 | Project (#0)
 
 %2 =

--- a/test/sqllogictest/transform/join_fusion.slt
+++ b/test/sqllogictest/transform/join_fusion.slt
@@ -37,7 +37,7 @@ EXPLAIN SELECT * FROM t1 INNER JOIN t2 ON t2.f2 = t1.f2 INNER JOIN t3 ON t1.f1 =
 
 %1 =
 | Get materialize.public.t2 (u3)
-| Filter !(isnull(#1))
+| Filter !(isnull(#0)), !(isnull(#1))
 | ArrangeBy (#1)
 
 %2 =

--- a/test/sqllogictest/transform/join_index.slt
+++ b/test/sqllogictest/transform/join_index.slt
@@ -306,10 +306,12 @@ explain plan for select foo.b, bar.b from foo, bar, (select 1 as a) const where 
 ----
 %0 =
 | Get materialize.public.foo (u1)
+| Filter !(isnull(#0))
 | ArrangeBy ()
 
 %1 =
 | Get materialize.public.bar (u3)
+| Filter !(isnull(#0))
 
 %2 =
 | Join %0 %1 (= 1 (#0 / #2))
@@ -335,10 +337,12 @@ and bar.b - foo.b = foo.a / bar.a
 ----
 %0 =
 | Get materialize.public.foo (u1)
+| Filter !(isnull(#0)), !(isnull(#1))
 | ArrangeBy ()
 
 %1 =
 | Get materialize.public.bar (u3)
+| Filter !(isnull(#0)), !(isnull(#1))
 
 %2 =
 | Join %0 %1 (= -1 (#3 - #1) (#0 / #2))

--- a/test/sqllogictest/transform/join_nonnull_requirements.slt
+++ b/test/sqllogictest/transform/join_nonnull_requirements.slt
@@ -1,0 +1,135 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+mode cockroach
+
+statement ok
+CREATE TABLE t1 (
+    f1 int NOT NULL,
+    f2 int
+)
+
+# non-null requirement on f2 derived from the join equality
+query T multiline
+EXPLAIN SELECT * FROM t1 AS a1, t1 AS a2 WHERE a1.f1 = a2.f2;
+----
+%0 =
+| Get materialize.public.t1 (u1)
+| ArrangeBy (#0)
+
+%1 =
+| Get materialize.public.t1 (u1)
+| Filter !(isnull(#1))
+
+%2 =
+| Join %0 %1 (= #0 #3)
+| | implementation = Differential %1 %0.(#0)
+| Project (#0..#2, #0)
+
+EOF
+
+# non-null requirement on f2 derived from the join equality
+query T multiline
+EXPLAIN SELECT * FROM t1 AS a1, t1 AS a2 WHERE a1.f1 = a2.f2 + 1;
+----
+%0 =
+| Get materialize.public.t1 (u1)
+| ArrangeBy (#0)
+
+%1 =
+| Get materialize.public.t1 (u1)
+| Filter !(isnull(#1))
+
+%2 =
+| Join %0 %1 (= #0 (#3 + 1))
+| | implementation = Differential %1 %0.(#0)
+
+EOF
+
+# non-null requirement on f2 derived from the join equality contradicts filter
+query T multiline
+EXPLAIN SELECT * FROM t1 AS a1, t1 AS a2 WHERE a1.f1 = a2.f2 AND a2.f2 IS NULL;
+----
+%0 =
+| Constant
+
+EOF
+
+# non-null requirement on f2 derived from the equality with a non-null literal
+query T multiline
+EXPLAIN SELECT * FROM t1 AS a1, t1 AS a2 WHERE a1.f2 = a2.f2 AND a1.f2 = 2;
+----
+%0 = Let l0 =
+| Get materialize.public.t1 (u1)
+| Filter (#1 = 2)
+
+%1 =
+| Get %0 (l0)
+| ArrangeBy ()
+
+%2 =
+| Join %1 %0
+| | implementation = Differential %0 %1.()
+
+EOF
+
+# we fail to infer here that a1.f2 SQL= a2.f2 can never be true, since a2.f2 is required to be NULL
+query T multiline
+EXPLAIN SELECT * FROM t1 AS a1, t1 AS a2 WHERE (a1.f2 = a2.f2 or (a1.f2 IS NULL AND a2.f2 IS NULL)) AND a2.f2 IS NULL;
+----
+%0 =
+| Get materialize.public.t1 (u1)
+| ArrangeBy ()
+
+%1 =
+| Get materialize.public.t1 (u1)
+| Filter isnull(#1)
+
+%2 =
+| Join %0 %1
+| | implementation = Differential %1 %0.()
+| Filter (isnull(#1) || (#1 = #3))
+
+EOF
+
+# no requirement on f2, since NULLs are treated as equal by the join
+query T multiline
+EXPLAIN SELECT * FROM t1 AS a1, t1 AS a2 WHERE a1.f2 = a2.f2 or (a1.f2 IS NULL AND a2.f2 IS NULL);
+----
+%0 =
+| Get materialize.public.t1 (u1)
+| ArrangeBy (#1)
+
+%1 =
+| Get materialize.public.t1 (u1)
+
+%2 =
+| Join %0 %1 (= #1 #3)
+| | implementation = Differential %1 %0.(#1)
+| Project (#0..#2, #1)
+
+EOF
+
+query T multiline
+EXPLAIN SELECT * FROM (SELECT * FROM t1 WHERE f1 + f2 IS NULL) blah JOIN t1 t2 ON blah.f1 = t2.f1;
+----
+%0 =
+| Get materialize.public.t1 (u1)
+| Filter isnull(#1)
+| ArrangeBy (#0)
+
+%1 =
+| Get materialize.public.t1 (u1)
+
+%2 =
+| Join %0 %1 (= #0 #2)
+| | implementation = Differential %1 %0.(#0)
+| Project (#0, #1, #0, #3)
+
+EOF

--- a/test/sqllogictest/transform/lifting.slt
+++ b/test/sqllogictest/transform/lifting.slt
@@ -684,7 +684,7 @@ explain select min(a) from t_pk where a between 38 and 195 and a = (select a fro
 | Project ()
 | Reduce group=()
 | | agg count(true)
-| Filter (#0 > 1)
+| Filter (err: more than one record produced in subquery), (#0 > 1)
 | Project ()
 | Map (err: more than one record produced in subquery)
 
@@ -738,7 +738,7 @@ explain select min(a) from t where a between 38 and 195 and a = (select a from t
 | Project ()
 | Reduce group=()
 | | agg count(true)
-| Filter (#0 > 1)
+| Filter (err: more than one record produced in subquery), (#0 > 1)
 | Project ()
 | Map (err: more than one record produced in subquery)
 

--- a/test/sqllogictest/transform/union.slt
+++ b/test/sqllogictest/transform/union.slt
@@ -160,33 +160,33 @@ SELECT * FROM t2 EXCEPT ALL (SELECT * FROM t1 INTERSECT ALL SELECT f1, null::int
 query T multiline
 EXPLAIN SELECT a1.* FROM t3 AS a1 LEFT JOIN t2 AS a2 ON (a1.f1 = a2.nokey);
 ----
-%0 =
+%0 = Let l0 =
 | Get materialize.public.t3 (u5)
 | Filter !(isnull(#0))
-| ArrangeBy (#0)
 
 %1 =
+| Get %0 (l0)
+| ArrangeBy (#0)
+
+%2 =
 | Get materialize.public.t2 (u3)
 | Filter !(isnull(#1))
 | Project (#1)
 
-%2 = Let l0 =
-| Join %0 %1 (= #0 #2)
-| | implementation = Differential %1 %0.(#0)
+%3 = Let l1 =
+| Join %1 %2 (= #0 #2)
+| | implementation = Differential %2 %1.(#0)
 | Project (#0, #1)
 
-%3 =
-| Get materialize.public.t3 (u5)
-
 %4 =
-| Get %2 (l0)
+| Get %3 (l1)
 | Project (#0)
 | Distinct group=(#0)
 | ArrangeBy (#0)
 
 %5 =
-| Join %3 %4 (= #0 #2)
-| | implementation = Differential %3 %4.(#0)
+| Join %0 %4 (= #0 #2)
+| | implementation = Differential %0 %4.(#0)
 | Project (#0, #1)
 | Negate
 
@@ -194,7 +194,7 @@ EXPLAIN SELECT a1.* FROM t3 AS a1 LEFT JOIN t2 AS a2 ON (a1.f1 = a2.nokey);
 | Get materialize.public.t3 (u5)
 
 %7 =
-| Union %5 %6 %2
+| Union %5 %6 %3
 
 EOF
 

--- a/test/sqllogictest/transform/union_cancel.slt
+++ b/test/sqllogictest/transform/union_cancel.slt
@@ -206,25 +206,22 @@ SELECT a1.* FROM t3 AS a1 LEFT JOIN t3_with_key AS a2 ON (a1.f1 = a2.key);
 | Filter !(isnull(#0))
 
 %1 =
-| Get materialize.public.t3 (u5)
-
-%2 =
 | Get %0 (l0)
 | Project (#0)
 | Distinct group=(#0)
 | ArrangeBy (#0)
 
-%3 =
-| Join %1 %2 (= #0 #2)
-| | implementation = Differential %1 %2.(#0)
+%2 =
+| Join %0 %1 (= #0 #2)
+| | implementation = Differential %0 %1.(#0)
 | Project (#0, #1)
 | Negate
 
-%4 =
+%3 =
 | Get materialize.public.t3 (u5)
 
-%5 =
-| Union %3 %4 %0
+%4 =
+| Union %2 %3 %0
 
 EOF
 


### PR DESCRIPTION
Extract non-null requirements from join equivalences.

Detect impossible conditions in NonNullRequirements transform when there
is an IS NULL predicate on a column that is required to be non-null.

This PR addresses the last regression introduced by #6936. After the changes in 6936, in some cases predicates become join equivalences sooner and, due to this missing logic in NonNullRequirements, we were not inferring non-null requirements  from those predicates anymore.