### PR TITLE
Allow manually specifying a (non-enforced) primary key on sources

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -79,6 +79,9 @@ Wrap your release notes at the 80 character mark.
 - Add the [`current_role`](/sql/functions/#system-information-func) system
   information function.
 
+- Support manually declaring a [`(non-enforced) primary key`](/sql/create-source/avro-kafka/#key-constraint-details)
+  on sources.
+
 {{% version-header v0.8.0 %}}
 
 - Add the [`COPY FROM`](/sql/copy-from) statement, which allows populating a

--- a/doc/user/content/sql/create-source/avro-file.md
+++ b/doc/user/content/sql/create-source/avro-file.md
@@ -17,7 +17,11 @@ Files] (OCFs).
 
 {{< diagram "create-source-avro-file.svg" >}}
 
-{{% create-source/syntax-details connector="avro-ocf" formats="none" envelopes="append-only debezium" %}}
+### key_constraint
+
+{{< diagram "key-constraint.svg" >}}
+
+{{% create-source/syntax-details connector="avro-ocf" formats="none" envelopes="append-only debezium" keyConstraint=true %}}
 
 ## Examples
 

--- a/doc/user/content/sql/create-source/avro-kafka.md
+++ b/doc/user/content/sql/create-source/avro-kafka.md
@@ -23,7 +23,11 @@ topic.
 
 {{< diagram "format-spec-avro-kafka.svg" >}}
 
-{{% create-source/syntax-details connector="kafka" formats="avro-ccsr" envelopes="debezium upsert append-only" %}}
+### key_constraint
+
+{{< diagram "key-constraint.svg" >}}
+
+{{% create-source/syntax-details connector="kafka" formats="avro-ccsr" envelopes="debezium upsert append-only" keyConstraint=true %}}
 
 ## Examples
 

--- a/doc/user/content/sql/create-source/csv-file.md
+++ b/doc/user/content/sql/create-source/csv-file.md
@@ -17,7 +17,11 @@ This document details how to connect Materialize to local CSV files.
 
 {{< diagram "create-source-csv-file.svg" >}}
 
-{{% create-source/syntax-details connector="file" formats="csv" envelopes="append-only" %}}
+### key_constraint
+
+{{< diagram "key-constraint.svg" >}}
+
+{{% create-source/syntax-details connector="file" formats="csv" envelopes="append-only" keyConstraint=true %}}
 
 ## Example
 

--- a/doc/user/content/sql/create-source/csv-kafka.md
+++ b/doc/user/content/sql/create-source/csv-kafka.md
@@ -14,7 +14,11 @@ This document details how to connect Materialize to a CSV-formatted Kafka topic.
 
 {{< diagram "create-source-csv-kafka.svg" >}}
 
-{{% create-source/syntax-details connector="kafka" formats="csv" envelopes="append-only" %}}
+### key_constraint
+
+{{< diagram "key-constraint.svg" >}}
+
+{{% create-source/syntax-details connector="kafka" formats="csv" envelopes="append-only" keyConstraint=true %}}
 
 ## Example
 

--- a/doc/user/content/sql/create-source/csv-kinesis.md
+++ b/doc/user/content/sql/create-source/csv-kinesis.md
@@ -23,7 +23,11 @@ streams.
 
 {{< diagram "create-source-csv-kinesis.svg" >}}
 
-{{% create-source/syntax-details connector="kinesis" formats="csv" envelopes="append-only" %}}
+### key_constraint
+
+{{< diagram "key-constraint.svg" >}}
+
+{{% create-source/syntax-details connector="kinesis" formats="csv" envelopes="append-only" keyConstraint=true %}}
 
 ## Example
 

--- a/doc/user/content/sql/create-source/csv-s3.md
+++ b/doc/user/content/sql/create-source/csv-s3.md
@@ -15,7 +15,11 @@ contain multiple records serialized as CSV, separated by newlines.
 
 {{< diagram "create-source-s3-csv.svg" >}}
 
-{{% create-source/syntax-details connector="s3" formats="csv" envelopes="append-only" %}}
+### key_constraint
+
+{{< diagram "key-constraint.svg" >}}
+
+{{% create-source/syntax-details connector="s3" formats="csv" envelopes="append-only" keyConstraint=true %}}
 
 ## Example
 

--- a/doc/user/content/sql/create-source/json-file.md
+++ b/doc/user/content/sql/create-source/json-file.md
@@ -16,7 +16,7 @@ This document details how to connect Materialize to a JSON-formatted local text 
 
 {{< diagram "create-source-json.svg" >}}
 
-{{% create-source/syntax-details connector="file" formats="json-bytes" envelopes="append-only" %}}
+{{% create-source/syntax-details connector="file" formats="json-bytes" envelopes="append-only" keyConstraint=false %}}
 
 ## Examples
 

--- a/doc/user/content/sql/create-source/json-kafka.md
+++ b/doc/user/content/sql/create-source/json-kafka.md
@@ -16,7 +16,7 @@ topics.
 
 {{< diagram "create-source-json-kafka.svg" >}}
 
-{{% create-source/syntax-details connector="kafka" formats="json-bytes" envelopes="append-only" %}}
+{{% create-source/syntax-details connector="kafka" formats="json-bytes" envelopes="append-only" keyConstraint=false %}}
 
 ## Examples
 

--- a/doc/user/content/sql/create-source/json-kinesis.md
+++ b/doc/user/content/sql/create-source/json-kinesis.md
@@ -23,7 +23,7 @@ streams.
 
 {{< diagram "create-source-json-kinesis.svg" >}}
 
-{{% create-source/syntax-details connector="kinesis" formats="json-bytes" envelopes="append-only" %}}
+{{% create-source/syntax-details connector="kinesis" formats="json-bytes" envelopes="append-only" keyConstraint=false %}}
 
 ## Examples
 

--- a/doc/user/content/sql/create-source/json-pubnub.md
+++ b/doc/user/content/sql/create-source/json-pubnub.md
@@ -17,7 +17,7 @@ This document details how to connect Materialize to a JSON–formatted
 
 {{< diagram "create-source-pubnub-text.svg" >}}
 
-{{% create-source/syntax-details connector="pubnub" formats="text" envelopes="append-only" %}}
+{{% create-source/syntax-details connector="pubnub" formats="text" envelopes="append-only" keyConstraint=false %}}
 
 ## Examples
 

--- a/doc/user/content/sql/create-source/json-s3.md
+++ b/doc/user/content/sql/create-source/json-s3.md
@@ -15,7 +15,7 @@ contain multiple records serialized as JSON, separated by newlines.
 
 {{< diagram "create-source-s3-json.svg" >}}
 
-{{% create-source/syntax-details connector="s3" formats="text bytes" envelopes="append-only" %}}
+{{% create-source/syntax-details connector="s3" formats="text bytes" envelopes="append-only" keyConstraint=false %}}
 
 ## Example
 

--- a/doc/user/content/sql/create-source/protobuf-kafka.md
+++ b/doc/user/content/sql/create-source/protobuf-kafka.md
@@ -19,7 +19,11 @@ topics.
 
 {{< diagram "create-source-protobuf-kafka.svg" >}}
 
-{{% create-source/syntax-details connector="kafka" formats="protobuf" envelopes="append-only" %}}
+### key_constraint
+
+{{< diagram "key-constraint.svg" >}}
+
+{{% create-source/syntax-details connector="kafka" formats="protobuf" envelopes="append-only" keyConstraint=true %}}
 
 ## Examples
 

--- a/doc/user/content/sql/create-source/protobuf-kinesis.md
+++ b/doc/user/content/sql/create-source/protobuf-kinesis.md
@@ -20,7 +20,11 @@ stream.
 
 {{< diagram "create-source-protobuf-kinesis.svg" >}}
 
-{{% create-source/syntax-details connector="kinesis" formats="protobuf" envelopes="append-only" %}}
+### key_constraint
+
+{{< diagram "key-constraint.svg" >}}
+
+{{% create-source/syntax-details connector="kinesis" formats="protobuf" envelopes="append-only" keyConstraint=true %}}
 
 ## Examples
 

--- a/doc/user/content/sql/create-source/text-file.md
+++ b/doc/user/content/sql/create-source/text-file.md
@@ -32,7 +32,11 @@ the **TEXT** formatting option.
 
 {{< diagram "create-source-text.svg" >}}
 
-{{% create-source/syntax-details connector="file" formats="regex text bytes" envelopes="append-only" %}}
+### key_constraint
+
+{{< diagram "key-constraint.svg" >}}
+
+{{% create-source/syntax-details connector="file" formats="regex text bytes" envelopes="append-only" keyConstraint=true %}}
 
 ## Examples
 

--- a/doc/user/content/sql/create-source/text-kafka.md
+++ b/doc/user/content/sql/create-source/text-kafka.md
@@ -15,7 +15,7 @@ Kafka topic.
 
 {{< diagram "create-source-text-kafka.svg" >}}
 
-{{% create-source/syntax-details connector="kafka" formats="text bytes" envelopes="upsert append-only" %}}
+{{% create-source/syntax-details connector="kafka" formats="text bytes" envelopes="upsert append-only" keyConstraint=false %}}
 
 ## Examples
 

--- a/doc/user/content/sql/create-source/text-kinesis.md
+++ b/doc/user/content/sql/create-source/text-kinesis.md
@@ -20,7 +20,7 @@ Kinesis stream.
 
 {{< diagram "create-source-text-kinesis.svg" >}}
 
-{{% create-source/syntax-details connector="kinesis" formats="text bytes" envelopes="append-only" %}}
+{{% create-source/syntax-details connector="kinesis" formats="text bytes" envelopes="append-only" keyConstraint=false %}}
 
 ## Examples
 

--- a/doc/user/content/sql/create-source/text-pubnub.md
+++ b/doc/user/content/sql/create-source/text-pubnub.md
@@ -17,7 +17,7 @@ This document details how to connect Materialize to a text–formatted
 
 {{< diagram "create-source-pubnub-text.svg" >}}
 
-{{% create-source/syntax-details connector="pubnub" formats="text" envelopes="append-only" %}}
+{{% create-source/syntax-details connector="pubnub" formats="text" envelopes="append-only" keyConstraint=false %}}
 
 ## Examples
 

--- a/doc/user/content/sql/create-source/text-s3.md
+++ b/doc/user/content/sql/create-source/text-s3.md
@@ -15,7 +15,11 @@ contain multiple byte- or text-encoded records, separated by newlines.
 
 {{< diagram "create-source-s3-text.svg" >}}
 
-{{% create-source/syntax-details connector="s3" formats="regex text bytes" envelopes="append-only" %}}
+### key_constraint
+
+{{< diagram "key-constraint.svg" >}}
+
+{{% create-source/syntax-details connector="s3" formats="regex text bytes" envelopes="append-only" keyConstraint=true %}}
 
 ## Examples
 

--- a/doc/user/layouts/partials/create-source/key-constraint/details.html
+++ b/doc/user/layouts/partials/create-source/key-constraint/details.html
@@ -1,0 +1,14 @@
+### Key constraint details
+
+Primary keys are automatically inferred for [`Kafka sources`](/sql/create-source/avro-kafka)
+using [`Upsert`](/sql/create-source/avro-kafka/#upsert-envelope-details) or
+[`Debezium`](/sql/create-source/avro-kafka/#debezium-envelope-details) envelopes and
+[`Postgres sources`](/sql/create-source/postgres).
+
+For other source configurations, the [`key_constraint`](#key_constraint) syntax
+allows to *manually* declare a set of columns as a primary key. This enables
+optimizations and constructs that rely on a key to be present when it cannot be
+inferred.
+
+<strong>WARNING!</strong> Materialize will *not enforce* the constraint and
+will produce wrong results if it is not correct.

--- a/doc/user/layouts/partials/create-source/key-constraint/syntax.html
+++ b/doc/user/layouts/partials/create-source/key-constraint/syntax.html
@@ -1,0 +1,1 @@
+**PRIMARY KEY (** _col_list_ **) NOT ENFORCED** | Declare a set of columns as a primary key. For more information, see [`Key constraint details`](#key-constraint-details).

--- a/doc/user/layouts/partials/sql-grammar/create-source-avro-file.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-source-avro-file.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="587" height="451">
+<svg xmlns="http://www.w3.org/2000/svg" width="589" height="615">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="74" height="32" rx="10"/>
@@ -33,127 +33,138 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="431" y="53">IF NOT EXISTS</text>
-   <rect x="25" y="145" width="80" height="32"/>
-   <rect x="23" y="143" width="80" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="33" y="163">src_name</text>
-   <rect x="145" y="145" width="24" height="32" rx="10"/>
-   <rect x="143"
-         y="143"
+   <rect x="256" y="101" width="80" height="32"/>
+   <rect x="254" y="99" width="80" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="264" y="119">src_name</text>
+   <rect x="45" y="211" width="24" height="32" rx="10"/>
+   <rect x="43"
+         y="209"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="153" y="163">(</text>
-   <rect x="209" y="145" width="80" height="32"/>
-   <rect x="207" y="143" width="80" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="217" y="163">col_name</text>
-   <rect x="209" y="101" width="24" height="32" rx="10"/>
-   <rect x="207"
-         y="99"
+   <text class="terminal" x="53" y="229">(</text>
+   <rect x="109" y="211" width="80" height="32"/>
+   <rect x="107" y="209" width="80" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="117" y="229">col_name</text>
+   <rect x="109" y="167" width="24" height="32" rx="10"/>
+   <rect x="107"
+         y="165"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="217" y="119">,</text>
-   <rect x="329" y="145" width="24" height="32" rx="10"/>
-   <rect x="327"
-         y="143"
+   <text class="terminal" x="117" y="185">,</text>
+   <rect x="249" y="243" width="24" height="32" rx="10"/>
+   <rect x="247"
+         y="241"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="337" y="163">)</text>
-   <rect x="393" y="145" width="60" height="32" rx="10"/>
-   <rect x="391"
-         y="143"
+   <text class="terminal" x="257" y="261">,</text>
+   <rect x="293" y="243" width="110" height="32"/>
+   <rect x="291" y="241" width="110" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="301" y="261">key_constraint</text>
+   <rect x="443" y="211" width="24" height="32" rx="10"/>
+   <rect x="441"
+         y="209"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="451" y="229">)</text>
+   <rect x="507" y="211" width="60" height="32" rx="10"/>
+   <rect x="505"
+         y="209"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="401" y="163">FROM</text>
-   <rect x="473" y="145" width="92" height="32" rx="10"/>
-   <rect x="471"
-         y="143"
+   <text class="terminal" x="515" y="229">FROM</text>
+   <rect x="216" y="325" width="92" height="32" rx="10"/>
+   <rect x="214"
+         y="323"
          width="92"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="481" y="163">AVRO OCF</text>
-   <rect x="64" y="271" width="48" height="32"/>
-   <rect x="62" y="269" width="48" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="72" y="289">path</text>
-   <rect x="152" y="271" width="56" height="32" rx="10"/>
-   <rect x="150"
-         y="269"
+   <text class="terminal" x="224" y="343">AVRO OCF</text>
+   <rect x="328" y="325" width="48" height="32"/>
+   <rect x="326" y="323" width="48" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="336" y="343">path</text>
+   <rect x="119" y="435" width="56" height="32" rx="10"/>
+   <rect x="117"
+         y="433"
          width="56"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="160" y="289">WITH</text>
-   <rect x="228" y="271" width="24" height="32" rx="10"/>
-   <rect x="226"
-         y="269"
+   <text class="terminal" x="127" y="453">WITH</text>
+   <rect x="195" y="435" width="24" height="32" rx="10"/>
+   <rect x="193"
+         y="433"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="236" y="289">(</text>
-   <rect x="292" y="271" width="46" height="32"/>
-   <rect x="290" y="269" width="46" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="300" y="289">field</text>
-   <rect x="358" y="271" width="26" height="32" rx="10"/>
-   <rect x="356"
-         y="269"
+   <text class="terminal" x="203" y="453">(</text>
+   <rect x="259" y="435" width="46" height="32"/>
+   <rect x="257" y="433" width="46" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="267" y="453">field</text>
+   <rect x="325" y="435" width="26" height="32" rx="10"/>
+   <rect x="323"
+         y="433"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="366" y="289">=</text>
-   <rect x="404" y="271" width="38" height="32"/>
-   <rect x="402" y="269" width="38" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="412" y="289">val</text>
-   <rect x="292" y="227" width="24" height="32" rx="10"/>
-   <rect x="290"
-         y="225"
+   <text class="terminal" x="333" y="453">=</text>
+   <rect x="371" y="435" width="38" height="32"/>
+   <rect x="369" y="433" width="38" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="379" y="453">val</text>
+   <rect x="259" y="391" width="24" height="32" rx="10"/>
+   <rect x="257"
+         y="389"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="300" y="245">,</text>
-   <rect x="482" y="271" width="24" height="32" rx="10"/>
-   <rect x="480"
-         y="269"
+   <text class="terminal" x="267" y="409">,</text>
+   <rect x="449" y="435" width="24" height="32" rx="10"/>
+   <rect x="447"
+         y="433"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="490" y="289">)</text>
-   <rect x="295" y="373" width="92" height="32" rx="10"/>
-   <rect x="293"
-         y="371"
+   <text class="terminal" x="457" y="453">)</text>
+   <rect x="297" y="537" width="92" height="32" rx="10"/>
+   <rect x="295"
+         y="535"
          width="92"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="303" y="391">ENVELOPE</text>
-   <rect x="427" y="373" width="60" height="32" rx="10"/>
-   <rect x="425"
-         y="371"
+   <text class="terminal" x="305" y="555">ENVELOPE</text>
+   <rect x="429" y="537" width="60" height="32" rx="10"/>
+   <rect x="427"
+         y="535"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="435" y="391">NONE</text>
-   <rect x="427" y="417" width="92" height="32" rx="10"/>
-   <rect x="425"
-         y="415"
+   <text class="terminal" x="437" y="555">NONE</text>
+   <rect x="429" y="581" width="92" height="32" rx="10"/>
+   <rect x="427"
+         y="579"
          width="92"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="435" y="435">DEBEZIUM</text>
+   <text class="terminal" x="437" y="599">DEBEZIUM</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m74 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m78 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-580 142 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m80 0 h10 m20 0 h10 m24 0 h10 m20 0 h10 m80 0 h10 m-120 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m100 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-100 0 h10 m24 0 h10 m0 0 h56 m20 44 h10 m24 0 h10 m-248 0 h20 m228 0 h20 m-268 0 q10 0 10 10 m248 0 q0 -10 10 -10 m-258 10 v14 m248 0 v-14 m-248 14 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m0 0 h218 m20 -34 h10 m60 0 h10 m0 0 h10 m92 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-545 126 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m48 0 h10 m20 0 h10 m56 0 h10 m0 0 h10 m24 0 h10 m20 0 h10 m46 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m38 0 h10 m-190 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m170 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-170 0 h10 m24 0 h10 m0 0 h126 m20 44 h10 m24 0 h10 m-394 0 h20 m374 0 h20 m-414 0 q10 0 10 10 m394 0 q0 -10 10 -10 m-404 10 v14 m394 0 v-14 m-394 14 q0 10 10 10 m374 0 q10 0 10 -10 m-384 10 h10 m0 0 h364 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-295 70 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h254 m-284 0 h20 m264 0 h20 m-304 0 q10 0 10 10 m284 0 q0 -10 10 -10 m-294 10 v12 m284 0 v-12 m-284 12 q0 10 10 10 m264 0 q10 0 10 -10 m-274 10 h10 m92 0 h10 m20 0 h10 m60 0 h10 m0 0 h32 m-132 0 h20 m112 0 h20 m-152 0 q10 0 10 10 m132 0 q0 -10 10 -10 m-142 10 v24 m132 0 v-24 m-132 24 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m92 0 h10 m43 -76 h-3"/>
-   <polygon points="577 355 585 351 585 359"/>
-   <polygon points="577 355 569 351 569 359"/>
+         d="m17 17 h2 m0 0 h10 m74 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m78 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-349 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m80 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-355 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m24 0 h10 m20 0 h10 m80 0 h10 m-120 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m100 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-100 0 h10 m24 0 h10 m0 0 h56 m40 44 h10 m0 0 h164 m-194 0 h20 m174 0 h20 m-214 0 q10 0 10 10 m194 0 q0 -10 10 -10 m-204 10 v12 m194 0 v-12 m-194 12 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m24 0 h10 m0 0 h10 m110 0 h10 m20 -32 h10 m24 0 h10 m-462 0 h20 m442 0 h20 m-482 0 q10 0 10 10 m462 0 q0 -10 10 -10 m-472 10 v46 m462 0 v-46 m-462 46 q0 10 10 10 m442 0 q10 0 10 -10 m-452 10 h10 m0 0 h432 m20 -66 h10 m60 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-395 114 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m92 0 h10 m0 0 h10 m48 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-321 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m56 0 h10 m0 0 h10 m24 0 h10 m20 0 h10 m46 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m38 0 h10 m-190 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m170 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-170 0 h10 m24 0 h10 m0 0 h126 m20 44 h10 m24 0 h10 m-394 0 h20 m374 0 h20 m-414 0 q10 0 10 10 m394 0 q0 -10 10 -10 m-404 10 v14 m394 0 v-14 m-394 14 q0 10 10 10 m374 0 q10 0 10 -10 m-384 10 h10 m0 0 h364 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-260 70 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h254 m-284 0 h20 m264 0 h20 m-304 0 q10 0 10 10 m284 0 q0 -10 10 -10 m-294 10 v12 m284 0 v-12 m-284 12 q0 10 10 10 m264 0 q10 0 10 -10 m-274 10 h10 m92 0 h10 m20 0 h10 m60 0 h10 m0 0 h32 m-132 0 h20 m112 0 h20 m-152 0 q10 0 10 10 m132 0 q0 -10 10 -10 m-142 10 v24 m132 0 v-24 m-132 24 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m92 0 h10 m43 -76 h-3"/>
+   <polygon points="579 519 587 515 587 523"/>
+   <polygon points="579 519 571 515 571 523"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/create-source-avro-kafka.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-source-avro-kafka.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="583" height="691">
+<svg xmlns="http://www.w3.org/2000/svg" width="589" height="789">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="74" height="32" rx="10"/>
@@ -33,176 +33,187 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="431" y="53">IF NOT EXISTS</text>
-   <rect x="79" y="145" width="80" height="32"/>
-   <rect x="77" y="143" width="80" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="87" y="163">src_name</text>
-   <rect x="199" y="145" width="24" height="32" rx="10"/>
-   <rect x="197"
-         y="143"
+   <rect x="256" y="101" width="80" height="32"/>
+   <rect x="254" y="99" width="80" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="264" y="119">src_name</text>
+   <rect x="45" y="211" width="24" height="32" rx="10"/>
+   <rect x="43"
+         y="209"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="207" y="163">(</text>
-   <rect x="263" y="145" width="80" height="32"/>
-   <rect x="261" y="143" width="80" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="271" y="163">col_name</text>
-   <rect x="263" y="101" width="24" height="32" rx="10"/>
-   <rect x="261"
-         y="99"
+   <text class="terminal" x="53" y="229">(</text>
+   <rect x="109" y="211" width="80" height="32"/>
+   <rect x="107" y="209" width="80" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="117" y="229">col_name</text>
+   <rect x="109" y="167" width="24" height="32" rx="10"/>
+   <rect x="107"
+         y="165"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="271" y="119">,</text>
-   <rect x="383" y="145" width="24" height="32" rx="10"/>
-   <rect x="381"
-         y="143"
+   <text class="terminal" x="117" y="185">,</text>
+   <rect x="249" y="243" width="24" height="32" rx="10"/>
+   <rect x="247"
+         y="241"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="391" y="163">)</text>
-   <rect x="447" y="145" width="60" height="32" rx="10"/>
-   <rect x="445"
-         y="143"
+   <text class="terminal" x="257" y="261">,</text>
+   <rect x="293" y="243" width="110" height="32"/>
+   <rect x="291" y="241" width="110" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="301" y="261">key_constraint</text>
+   <rect x="443" y="211" width="24" height="32" rx="10"/>
+   <rect x="441"
+         y="209"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="451" y="229">)</text>
+   <rect x="507" y="211" width="60" height="32" rx="10"/>
+   <rect x="505"
+         y="209"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="455" y="163">FROM</text>
-   <rect x="121" y="227" width="126" height="32" rx="10"/>
-   <rect x="119"
-         y="225"
+   <text class="terminal" x="515" y="229">FROM</text>
+   <rect x="124" y="325" width="126" height="32" rx="10"/>
+   <rect x="122"
+         y="323"
          width="126"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="129" y="245">KAFKA BROKER</text>
-   <rect x="267" y="227" width="46" height="32"/>
-   <rect x="265" y="225" width="46" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="275" y="245">host</text>
-   <rect x="333" y="227" width="62" height="32" rx="10"/>
-   <rect x="331"
-         y="225"
+   <text class="terminal" x="132" y="343">KAFKA BROKER</text>
+   <rect x="270" y="325" width="46" height="32"/>
+   <rect x="268" y="323" width="46" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="278" y="343">host</text>
+   <rect x="336" y="325" width="62" height="32" rx="10"/>
+   <rect x="334"
+         y="323"
          width="62"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="341" y="245">TOPIC</text>
-   <rect x="415" y="227" width="50" height="32"/>
-   <rect x="413" y="225" width="50" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="423" y="245">topic</text>
-   <rect x="67" y="337" width="56" height="32" rx="10"/>
-   <rect x="65"
-         y="335"
+   <text class="terminal" x="344" y="343">TOPIC</text>
+   <rect x="418" y="325" width="50" height="32"/>
+   <rect x="416" y="323" width="50" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="426" y="343">topic</text>
+   <rect x="70" y="435" width="56" height="32" rx="10"/>
+   <rect x="68"
+         y="433"
          width="56"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="75" y="355">WITH</text>
-   <rect x="143" y="337" width="24" height="32" rx="10"/>
-   <rect x="141"
-         y="335"
+   <text class="terminal" x="78" y="453">WITH</text>
+   <rect x="146" y="435" width="24" height="32" rx="10"/>
+   <rect x="144"
+         y="433"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="151" y="355">(</text>
-   <rect x="207" y="337" width="46" height="32"/>
-   <rect x="205" y="335" width="46" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="215" y="355">field</text>
-   <rect x="273" y="337" width="26" height="32" rx="10"/>
-   <rect x="271"
-         y="335"
+   <text class="terminal" x="154" y="453">(</text>
+   <rect x="210" y="435" width="46" height="32"/>
+   <rect x="208" y="433" width="46" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="218" y="453">field</text>
+   <rect x="276" y="435" width="26" height="32" rx="10"/>
+   <rect x="274"
+         y="433"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="281" y="355">=</text>
-   <rect x="319" y="337" width="38" height="32"/>
-   <rect x="317" y="335" width="38" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="327" y="355">val</text>
-   <rect x="207" y="293" width="24" height="32" rx="10"/>
-   <rect x="205"
-         y="291"
+   <text class="terminal" x="284" y="453">=</text>
+   <rect x="322" y="435" width="38" height="32"/>
+   <rect x="320" y="433" width="38" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="330" y="453">val</text>
+   <rect x="210" y="391" width="24" height="32" rx="10"/>
+   <rect x="208"
+         y="389"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="215" y="311">,</text>
-   <rect x="397" y="337" width="24" height="32" rx="10"/>
-   <rect x="395"
-         y="335"
+   <text class="terminal" x="218" y="409">,</text>
+   <rect x="400" y="435" width="24" height="32" rx="10"/>
+   <rect x="398"
+         y="433"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="405" y="355">)</text>
-   <rect x="461" y="337" width="78" height="32" rx="10"/>
-   <rect x="459"
-         y="335"
+   <text class="terminal" x="408" y="453">)</text>
+   <rect x="464" y="435" width="78" height="32" rx="10"/>
+   <rect x="462"
+         y="433"
          width="78"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="469" y="355">FORMAT</text>
-   <rect x="245" y="419" width="96" height="32"/>
-   <rect x="243" y="417" width="96" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="253" y="437">format_spec</text>
-   <rect x="55" y="505" width="92" height="32" rx="10"/>
-   <rect x="53"
-         y="503"
+   <text class="terminal" x="472" y="453">FORMAT</text>
+   <rect x="248" y="517" width="96" height="32"/>
+   <rect x="246" y="515" width="96" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="256" y="535">format_spec</text>
+   <rect x="61" y="603" width="92" height="32" rx="10"/>
+   <rect x="59"
+         y="601"
          width="92"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="63" y="523">ENVELOPE</text>
-   <rect x="187" y="505" width="60" height="32" rx="10"/>
-   <rect x="185"
-         y="503"
+   <text class="terminal" x="69" y="621">ENVELOPE</text>
+   <rect x="193" y="603" width="60" height="32" rx="10"/>
+   <rect x="191"
+         y="601"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="195" y="523">NONE</text>
-   <rect x="187" y="549" width="92" height="32" rx="10"/>
-   <rect x="185"
-         y="547"
+   <text class="terminal" x="201" y="621">NONE</text>
+   <rect x="193" y="647" width="92" height="32" rx="10"/>
+   <rect x="191"
+         y="645"
          width="92"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="195" y="567">DEBEZIUM</text>
-   <rect x="319" y="581" width="74" height="32" rx="10"/>
-   <rect x="317"
-         y="579"
+   <text class="terminal" x="201" y="665">DEBEZIUM</text>
+   <rect x="325" y="679" width="74" height="32" rx="10"/>
+   <rect x="323"
+         y="677"
          width="74"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="327" y="599">UPSERT</text>
-   <rect x="187" y="625" width="74" height="32" rx="10"/>
-   <rect x="185"
-         y="623"
+   <text class="terminal" x="333" y="697">UPSERT</text>
+   <rect x="193" y="723" width="74" height="32" rx="10"/>
+   <rect x="191"
+         y="721"
          width="74"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="195" y="643">UPSERT</text>
-   <rect x="301" y="657" width="78" height="32" rx="10"/>
-   <rect x="299"
-         y="655"
+   <text class="terminal" x="201" y="741">UPSERT</text>
+   <rect x="307" y="755" width="78" height="32" rx="10"/>
+   <rect x="305"
+         y="753"
          width="78"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="309" y="675">FORMAT</text>
-   <rect x="399" y="657" width="96" height="32"/>
-   <rect x="397" y="655" width="96" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="407" y="675">format_spec</text>
+   <text class="terminal" x="315" y="773">FORMAT</text>
+   <rect x="405" y="755" width="96" height="32"/>
+   <rect x="403" y="753" width="96" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="413" y="773">format_spec</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m74 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m78 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-526 142 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m80 0 h10 m20 0 h10 m24 0 h10 m20 0 h10 m80 0 h10 m-120 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m100 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-100 0 h10 m24 0 h10 m0 0 h56 m20 44 h10 m24 0 h10 m-248 0 h20 m228 0 h20 m-268 0 q10 0 10 10 m248 0 q0 -10 10 -10 m-258 10 v14 m248 0 v-14 m-248 14 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m0 0 h218 m20 -34 h10 m60 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-430 82 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m126 0 h10 m0 0 h10 m46 0 h10 m0 0 h10 m62 0 h10 m0 0 h10 m50 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-462 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m56 0 h10 m0 0 h10 m24 0 h10 m20 0 h10 m46 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m38 0 h10 m-190 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m170 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-170 0 h10 m24 0 h10 m0 0 h126 m20 44 h10 m24 0 h10 m-394 0 h20 m374 0 h20 m-414 0 q10 0 10 10 m394 0 q0 -10 10 -10 m-404 10 v14 m394 0 v-14 m-394 14 q0 10 10 10 m374 0 q10 0 10 -10 m-384 10 h10 m0 0 h364 m20 -34 h10 m78 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-338 82 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m96 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-350 54 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h490 m-520 0 h20 m500 0 h20 m-540 0 q10 0 10 10 m520 0 q0 -10 10 -10 m-530 10 v12 m520 0 v-12 m-520 12 q0 10 10 10 m500 0 q10 0 10 -10 m-510 10 h10 m92 0 h10 m20 0 h10 m60 0 h10 m0 0 h268 m-368 0 h20 m348 0 h20 m-388 0 q10 0 10 10 m368 0 q0 -10 10 -10 m-378 10 v24 m368 0 v-24 m-368 24 q0 10 10 10 m348 0 q10 0 10 -10 m-358 10 h10 m92 0 h10 m20 0 h10 m0 0 h84 m-114 0 h20 m94 0 h20 m-134 0 q10 0 10 10 m114 0 q0 -10 10 -10 m-124 10 v12 m114 0 v-12 m-114 12 q0 10 10 10 m94 0 q10 0 10 -10 m-104 10 h10 m74 0 h10 m20 -32 h102 m-358 -10 v20 m368 0 v-20 m-368 20 v56 m368 0 v-56 m-368 56 q0 10 10 10 m348 0 q10 0 10 -10 m-358 10 h10 m74 0 h10 m20 0 h10 m0 0 h204 m-234 0 h20 m214 0 h20 m-254 0 q10 0 10 10 m234 0 q0 -10 10 -10 m-244 10 v12 m234 0 v-12 m-234 12 q0 10 10 10 m214 0 q10 0 10 -10 m-224 10 h10 m78 0 h10 m0 0 h10 m96 0 h10 m63 -184 h-3"/>
-   <polygon points="573 487 581 483 581 491"/>
-   <polygon points="573 487 565 483 565 491"/>
+         d="m17 17 h2 m0 0 h10 m74 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m78 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-349 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m80 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-355 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m24 0 h10 m20 0 h10 m80 0 h10 m-120 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m100 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-100 0 h10 m24 0 h10 m0 0 h56 m40 44 h10 m0 0 h164 m-194 0 h20 m174 0 h20 m-214 0 q10 0 10 10 m194 0 q0 -10 10 -10 m-204 10 v12 m194 0 v-12 m-194 12 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m24 0 h10 m0 0 h10 m110 0 h10 m20 -32 h10 m24 0 h10 m-462 0 h20 m442 0 h20 m-482 0 q10 0 10 10 m462 0 q0 -10 10 -10 m-472 10 v46 m462 0 v-46 m-462 46 q0 10 10 10 m442 0 q10 0 10 -10 m-452 10 h10 m0 0 h432 m20 -66 h10 m60 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-487 114 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m126 0 h10 m0 0 h10 m46 0 h10 m0 0 h10 m62 0 h10 m0 0 h10 m50 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-462 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m56 0 h10 m0 0 h10 m24 0 h10 m20 0 h10 m46 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m38 0 h10 m-190 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m170 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-170 0 h10 m24 0 h10 m0 0 h126 m20 44 h10 m24 0 h10 m-394 0 h20 m374 0 h20 m-414 0 q10 0 10 10 m394 0 q0 -10 10 -10 m-404 10 v14 m394 0 v-14 m-394 14 q0 10 10 10 m374 0 q10 0 10 -10 m-384 10 h10 m0 0 h364 m20 -34 h10 m78 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-338 82 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m96 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-347 54 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h490 m-520 0 h20 m500 0 h20 m-540 0 q10 0 10 10 m520 0 q0 -10 10 -10 m-530 10 v12 m520 0 v-12 m-520 12 q0 10 10 10 m500 0 q10 0 10 -10 m-510 10 h10 m92 0 h10 m20 0 h10 m60 0 h10 m0 0 h268 m-368 0 h20 m348 0 h20 m-388 0 q10 0 10 10 m368 0 q0 -10 10 -10 m-378 10 v24 m368 0 v-24 m-368 24 q0 10 10 10 m348 0 q10 0 10 -10 m-358 10 h10 m92 0 h10 m20 0 h10 m0 0 h84 m-114 0 h20 m94 0 h20 m-134 0 q10 0 10 10 m114 0 q0 -10 10 -10 m-124 10 v12 m114 0 v-12 m-114 12 q0 10 10 10 m94 0 q10 0 10 -10 m-104 10 h10 m74 0 h10 m20 -32 h102 m-358 -10 v20 m368 0 v-20 m-368 20 v56 m368 0 v-56 m-368 56 q0 10 10 10 m348 0 q10 0 10 -10 m-358 10 h10 m74 0 h10 m20 0 h10 m0 0 h204 m-234 0 h20 m214 0 h20 m-254 0 q10 0 10 10 m234 0 q0 -10 10 -10 m-244 10 v12 m234 0 v-12 m-234 12 q0 10 10 10 m214 0 q10 0 10 -10 m-224 10 h10 m78 0 h10 m0 0 h10 m96 0 h10 m63 -184 h-3"/>
+   <polygon points="579 585 587 581 587 589"/>
+   <polygon points="579 585 571 581 571 589"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/create-source-csv-file.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-source-csv-file.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="583" height="573">
+<svg xmlns="http://www.w3.org/2000/svg" width="589" height="671">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="74" height="32" rx="10"/>
@@ -33,173 +33,184 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="431" y="53">IF NOT EXISTS</text>
-   <rect x="45" y="145" width="80" height="32"/>
-   <rect x="43" y="143" width="80" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="53" y="163">src_name</text>
-   <rect x="165" y="145" width="24" height="32" rx="10"/>
-   <rect x="163"
-         y="143"
+   <rect x="256" y="101" width="80" height="32"/>
+   <rect x="254" y="99" width="80" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="264" y="119">src_name</text>
+   <rect x="45" y="211" width="24" height="32" rx="10"/>
+   <rect x="43"
+         y="209"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="173" y="163">(</text>
-   <rect x="229" y="145" width="80" height="32"/>
-   <rect x="227" y="143" width="80" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="237" y="163">col_name</text>
-   <rect x="229" y="101" width="24" height="32" rx="10"/>
-   <rect x="227"
-         y="99"
+   <text class="terminal" x="53" y="229">(</text>
+   <rect x="109" y="211" width="80" height="32"/>
+   <rect x="107" y="209" width="80" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="117" y="229">col_name</text>
+   <rect x="109" y="167" width="24" height="32" rx="10"/>
+   <rect x="107"
+         y="165"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="237" y="119">,</text>
-   <rect x="349" y="145" width="24" height="32" rx="10"/>
-   <rect x="347"
-         y="143"
+   <text class="terminal" x="117" y="185">,</text>
+   <rect x="249" y="243" width="24" height="32" rx="10"/>
+   <rect x="247"
+         y="241"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="357" y="163">)</text>
-   <rect x="413" y="145" width="60" height="32" rx="10"/>
-   <rect x="411"
-         y="143"
+   <text class="terminal" x="257" y="261">,</text>
+   <rect x="293" y="243" width="110" height="32"/>
+   <rect x="291" y="241" width="110" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="301" y="261">key_constraint</text>
+   <rect x="443" y="211" width="24" height="32" rx="10"/>
+   <rect x="441"
+         y="209"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="451" y="229">)</text>
+   <rect x="507" y="211" width="60" height="32" rx="10"/>
+   <rect x="505"
+         y="209"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="421" y="163">FROM</text>
-   <rect x="493" y="145" width="48" height="32" rx="10"/>
-   <rect x="491"
-         y="143"
+   <text class="terminal" x="515" y="229">FROM</text>
+   <rect x="87" y="325" width="48" height="32" rx="10"/>
+   <rect x="85"
+         y="323"
          width="48"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="501" y="163">FILE</text>
-   <rect x="118" y="227" width="48" height="32"/>
-   <rect x="116" y="225" width="48" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="126" y="245">path</text>
-   <rect x="206" y="259" width="122" height="32" rx="10"/>
-   <rect x="204"
-         y="257"
+   <text class="terminal" x="95" y="343">FILE</text>
+   <rect x="155" y="325" width="48" height="32"/>
+   <rect x="153" y="323" width="48" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="163" y="343">path</text>
+   <rect x="243" y="357" width="122" height="32" rx="10"/>
+   <rect x="241"
+         y="355"
          width="122"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="214" y="277">COMPRESSION</text>
-   <rect x="368" y="259" width="60" height="32" rx="10"/>
-   <rect x="366"
-         y="257"
+   <text class="terminal" x="251" y="375">COMPRESSION</text>
+   <rect x="405" y="357" width="60" height="32" rx="10"/>
+   <rect x="403"
+         y="355"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="376" y="277">NONE</text>
-   <rect x="368" y="303" width="52" height="32" rx="10"/>
-   <rect x="366"
-         y="301"
+   <text class="terminal" x="413" y="375">NONE</text>
+   <rect x="405" y="401" width="52" height="32" rx="10"/>
+   <rect x="403"
+         y="399"
          width="52"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="376" y="321">GZIP</text>
-   <rect x="67" y="413" width="56" height="32" rx="10"/>
-   <rect x="65"
-         y="411"
+   <text class="terminal" x="413" y="419">GZIP</text>
+   <rect x="70" y="511" width="56" height="32" rx="10"/>
+   <rect x="68"
+         y="509"
          width="56"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="75" y="431">WITH</text>
-   <rect x="143" y="413" width="24" height="32" rx="10"/>
-   <rect x="141"
-         y="411"
+   <text class="terminal" x="78" y="529">WITH</text>
+   <rect x="146" y="511" width="24" height="32" rx="10"/>
+   <rect x="144"
+         y="509"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="151" y="431">(</text>
-   <rect x="207" y="413" width="46" height="32"/>
-   <rect x="205" y="411" width="46" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="215" y="431">field</text>
-   <rect x="273" y="413" width="26" height="32" rx="10"/>
-   <rect x="271"
-         y="411"
+   <text class="terminal" x="154" y="529">(</text>
+   <rect x="210" y="511" width="46" height="32"/>
+   <rect x="208" y="509" width="46" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="218" y="529">field</text>
+   <rect x="276" y="511" width="26" height="32" rx="10"/>
+   <rect x="274"
+         y="509"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="281" y="431">=</text>
-   <rect x="319" y="413" width="38" height="32"/>
-   <rect x="317" y="411" width="38" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="327" y="431">val</text>
-   <rect x="207" y="369" width="24" height="32" rx="10"/>
-   <rect x="205"
-         y="367"
+   <text class="terminal" x="284" y="529">=</text>
+   <rect x="322" y="511" width="38" height="32"/>
+   <rect x="320" y="509" width="38" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="330" y="529">val</text>
+   <rect x="210" y="467" width="24" height="32" rx="10"/>
+   <rect x="208"
+         y="465"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="215" y="387">,</text>
-   <rect x="397" y="413" width="24" height="32" rx="10"/>
-   <rect x="395"
-         y="411"
+   <text class="terminal" x="218" y="485">,</text>
+   <rect x="400" y="511" width="24" height="32" rx="10"/>
+   <rect x="398"
+         y="509"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="405" y="431">)</text>
-   <rect x="461" y="413" width="78" height="32" rx="10"/>
-   <rect x="459"
-         y="411"
+   <text class="terminal" x="408" y="529">)</text>
+   <rect x="464" y="511" width="78" height="32" rx="10"/>
+   <rect x="462"
+         y="509"
          width="78"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="469" y="431">FORMAT</text>
-   <rect x="27" y="495" width="88" height="32" rx="10"/>
-   <rect x="25"
-         y="493"
+   <text class="terminal" x="472" y="529">FORMAT</text>
+   <rect x="33" y="593" width="88" height="32" rx="10"/>
+   <rect x="31"
+         y="591"
          width="88"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="35" y="513">CSV WITH</text>
-   <rect x="155" y="495" width="76" height="32" rx="10"/>
-   <rect x="153"
-         y="493"
+   <text class="terminal" x="41" y="611">CSV WITH</text>
+   <rect x="161" y="593" width="76" height="32" rx="10"/>
+   <rect x="159"
+         y="591"
          width="76"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="163" y="513">HEADER</text>
-   <rect x="155" y="539" width="28" height="32"/>
-   <rect x="153" y="537" width="28" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="163" y="557">n</text>
-   <rect x="203" y="539" width="90" height="32" rx="10"/>
-   <rect x="201"
-         y="537"
+   <text class="terminal" x="169" y="611">HEADER</text>
+   <rect x="161" y="637" width="28" height="32"/>
+   <rect x="159" y="635" width="28" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="169" y="655">n</text>
+   <rect x="209" y="637" width="90" height="32" rx="10"/>
+   <rect x="207"
+         y="635"
          width="90"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="211" y="557">COLUMNS</text>
-   <rect x="353" y="527" width="116" height="32" rx="10"/>
-   <rect x="351"
-         y="525"
+   <text class="terminal" x="217" y="655">COLUMNS</text>
+   <rect x="359" y="625" width="116" height="32" rx="10"/>
+   <rect x="357"
+         y="623"
          width="116"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="361" y="545">DELIMITED BY</text>
-   <rect x="489" y="527" width="46" height="32"/>
-   <rect x="487" y="525" width="46" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="497" y="545">char</text>
+   <text class="terminal" x="367" y="643">DELIMITED BY</text>
+   <rect x="495" y="625" width="46" height="32"/>
+   <rect x="493" y="623" width="46" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="503" y="643">char</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m74 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m78 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-560 142 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m80 0 h10 m20 0 h10 m24 0 h10 m20 0 h10 m80 0 h10 m-120 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m100 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-100 0 h10 m24 0 h10 m0 0 h56 m20 44 h10 m24 0 h10 m-248 0 h20 m228 0 h20 m-268 0 q10 0 10 10 m248 0 q0 -10 10 -10 m-258 10 v14 m248 0 v-14 m-248 14 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m0 0 h218 m20 -34 h10 m60 0 h10 m0 0 h10 m48 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-467 82 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m48 0 h10 m20 0 h10 m0 0 h252 m-282 0 h20 m262 0 h20 m-302 0 q10 0 10 10 m282 0 q0 -10 10 -10 m-292 10 v12 m282 0 v-12 m-282 12 q0 10 10 10 m262 0 q10 0 10 -10 m-272 10 h10 m122 0 h10 m20 0 h10 m60 0 h10 m-100 0 h20 m80 0 h20 m-120 0 q10 0 10 10 m100 0 q0 -10 10 -10 m-110 10 v24 m100 0 v-24 m-100 24 q0 10 10 10 m80 0 q10 0 10 -10 m-90 10 h10 m52 0 h10 m0 0 h8 m42 -76 l2 0 m2 0 l2 0 m2 0 l2 0 m-465 186 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m56 0 h10 m0 0 h10 m24 0 h10 m20 0 h10 m46 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m38 0 h10 m-190 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m170 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-170 0 h10 m24 0 h10 m0 0 h126 m20 44 h10 m24 0 h10 m-394 0 h20 m374 0 h20 m-414 0 q10 0 10 10 m394 0 q0 -10 10 -10 m-404 10 v14 m394 0 v-14 m-394 14 q0 10 10 10 m374 0 q10 0 10 -10 m-384 10 h10 m0 0 h364 m20 -34 h10 m78 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-556 82 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m88 0 h10 m20 0 h10 m76 0 h10 m0 0 h62 m-178 0 h20 m158 0 h20 m-198 0 q10 0 10 10 m178 0 q0 -10 10 -10 m-188 10 v24 m178 0 v-24 m-178 24 q0 10 10 10 m158 0 q10 0 10 -10 m-168 10 h10 m28 0 h10 m0 0 h10 m90 0 h10 m40 -44 h10 m0 0 h192 m-222 0 h20 m202 0 h20 m-242 0 q10 0 10 10 m222 0 q0 -10 10 -10 m-232 10 v12 m222 0 v-12 m-222 12 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m116 0 h10 m0 0 h10 m46 0 h10 m23 -32 h-3"/>
-   <polygon points="573 509 581 505 581 513"/>
-   <polygon points="573 509 565 505 565 513"/>
+         d="m17 17 h2 m0 0 h10 m74 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m78 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-349 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m80 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-355 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m24 0 h10 m20 0 h10 m80 0 h10 m-120 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m100 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-100 0 h10 m24 0 h10 m0 0 h56 m40 44 h10 m0 0 h164 m-194 0 h20 m174 0 h20 m-214 0 q10 0 10 10 m194 0 q0 -10 10 -10 m-204 10 v12 m194 0 v-12 m-194 12 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m24 0 h10 m0 0 h10 m110 0 h10 m20 -32 h10 m24 0 h10 m-462 0 h20 m442 0 h20 m-482 0 q10 0 10 10 m462 0 q0 -10 10 -10 m-472 10 v46 m462 0 v-46 m-462 46 q0 10 10 10 m442 0 q10 0 10 -10 m-452 10 h10 m0 0 h432 m20 -66 h10 m60 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-524 114 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m48 0 h10 m0 0 h10 m48 0 h10 m20 0 h10 m0 0 h252 m-282 0 h20 m262 0 h20 m-302 0 q10 0 10 10 m282 0 q0 -10 10 -10 m-292 10 v12 m282 0 v-12 m-282 12 q0 10 10 10 m262 0 q10 0 10 -10 m-272 10 h10 m122 0 h10 m20 0 h10 m60 0 h10 m-100 0 h20 m80 0 h20 m-120 0 q10 0 10 10 m100 0 q0 -10 10 -10 m-110 10 v24 m100 0 v-24 m-100 24 q0 10 10 10 m80 0 q10 0 10 -10 m-90 10 h10 m52 0 h10 m0 0 h8 m42 -76 l2 0 m2 0 l2 0 m2 0 l2 0 m-499 186 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m56 0 h10 m0 0 h10 m24 0 h10 m20 0 h10 m46 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m38 0 h10 m-190 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m170 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-170 0 h10 m24 0 h10 m0 0 h126 m20 44 h10 m24 0 h10 m-394 0 h20 m374 0 h20 m-414 0 q10 0 10 10 m394 0 q0 -10 10 -10 m-404 10 v14 m394 0 v-14 m-394 14 q0 10 10 10 m374 0 q10 0 10 -10 m-384 10 h10 m0 0 h364 m20 -34 h10 m78 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-553 82 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m88 0 h10 m20 0 h10 m76 0 h10 m0 0 h62 m-178 0 h20 m158 0 h20 m-198 0 q10 0 10 10 m178 0 q0 -10 10 -10 m-188 10 v24 m178 0 v-24 m-178 24 q0 10 10 10 m158 0 q10 0 10 -10 m-168 10 h10 m28 0 h10 m0 0 h10 m90 0 h10 m40 -44 h10 m0 0 h192 m-222 0 h20 m202 0 h20 m-242 0 q10 0 10 10 m222 0 q0 -10 10 -10 m-232 10 v12 m222 0 v-12 m-222 12 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m116 0 h10 m0 0 h10 m46 0 h10 m23 -32 h-3"/>
+   <polygon points="579 607 587 603 587 611"/>
+   <polygon points="579 607 571 603 571 611"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/create-source-csv-kafka.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-source-csv-kafka.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="583" height="529">
+<svg xmlns="http://www.w3.org/2000/svg" width="589" height="627">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="74" height="32" rx="10"/>
@@ -33,160 +33,171 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="431" y="53">IF NOT EXISTS</text>
-   <rect x="79" y="145" width="80" height="32"/>
-   <rect x="77" y="143" width="80" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="87" y="163">src_name</text>
-   <rect x="199" y="145" width="24" height="32" rx="10"/>
-   <rect x="197"
-         y="143"
+   <rect x="256" y="101" width="80" height="32"/>
+   <rect x="254" y="99" width="80" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="264" y="119">src_name</text>
+   <rect x="45" y="211" width="24" height="32" rx="10"/>
+   <rect x="43"
+         y="209"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="207" y="163">(</text>
-   <rect x="263" y="145" width="80" height="32"/>
-   <rect x="261" y="143" width="80" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="271" y="163">col_name</text>
-   <rect x="263" y="101" width="24" height="32" rx="10"/>
-   <rect x="261"
-         y="99"
+   <text class="terminal" x="53" y="229">(</text>
+   <rect x="109" y="211" width="80" height="32"/>
+   <rect x="107" y="209" width="80" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="117" y="229">col_name</text>
+   <rect x="109" y="167" width="24" height="32" rx="10"/>
+   <rect x="107"
+         y="165"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="271" y="119">,</text>
-   <rect x="383" y="145" width="24" height="32" rx="10"/>
-   <rect x="381"
-         y="143"
+   <text class="terminal" x="117" y="185">,</text>
+   <rect x="249" y="243" width="24" height="32" rx="10"/>
+   <rect x="247"
+         y="241"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="391" y="163">)</text>
-   <rect x="447" y="145" width="60" height="32" rx="10"/>
-   <rect x="445"
-         y="143"
+   <text class="terminal" x="257" y="261">,</text>
+   <rect x="293" y="243" width="110" height="32"/>
+   <rect x="291" y="241" width="110" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="301" y="261">key_constraint</text>
+   <rect x="443" y="211" width="24" height="32" rx="10"/>
+   <rect x="441"
+         y="209"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="451" y="229">)</text>
+   <rect x="507" y="211" width="60" height="32" rx="10"/>
+   <rect x="505"
+         y="209"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="455" y="163">FROM</text>
-   <rect x="101" y="227" width="126" height="32" rx="10"/>
-   <rect x="99"
-         y="225"
+   <text class="terminal" x="515" y="229">FROM</text>
+   <rect x="104" y="325" width="126" height="32" rx="10"/>
+   <rect x="102"
+         y="323"
          width="126"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="109" y="245">KAFKA BROKER</text>
-   <rect x="247" y="227" width="46" height="32"/>
-   <rect x="245" y="225" width="46" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="255" y="245">host</text>
-   <rect x="313" y="227" width="62" height="32" rx="10"/>
-   <rect x="311"
-         y="225"
+   <text class="terminal" x="112" y="343">KAFKA BROKER</text>
+   <rect x="250" y="325" width="46" height="32"/>
+   <rect x="248" y="323" width="46" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="258" y="343">host</text>
+   <rect x="316" y="325" width="62" height="32" rx="10"/>
+   <rect x="314"
+         y="323"
          width="62"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="321" y="245">TOPIC</text>
-   <rect x="415" y="259" width="50" height="32"/>
-   <rect x="413" y="257" width="50" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="423" y="277">topic</text>
-   <rect x="67" y="369" width="56" height="32" rx="10"/>
-   <rect x="65"
-         y="367"
+   <text class="terminal" x="324" y="343">TOPIC</text>
+   <rect x="418" y="357" width="50" height="32"/>
+   <rect x="416" y="355" width="50" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="426" y="375">topic</text>
+   <rect x="70" y="467" width="56" height="32" rx="10"/>
+   <rect x="68"
+         y="465"
          width="56"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="75" y="387">WITH</text>
-   <rect x="143" y="369" width="24" height="32" rx="10"/>
-   <rect x="141"
-         y="367"
+   <text class="terminal" x="78" y="485">WITH</text>
+   <rect x="146" y="467" width="24" height="32" rx="10"/>
+   <rect x="144"
+         y="465"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="151" y="387">(</text>
-   <rect x="207" y="369" width="46" height="32"/>
-   <rect x="205" y="367" width="46" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="215" y="387">field</text>
-   <rect x="273" y="369" width="26" height="32" rx="10"/>
-   <rect x="271"
-         y="367"
+   <text class="terminal" x="154" y="485">(</text>
+   <rect x="210" y="467" width="46" height="32"/>
+   <rect x="208" y="465" width="46" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="218" y="485">field</text>
+   <rect x="276" y="467" width="26" height="32" rx="10"/>
+   <rect x="274"
+         y="465"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="281" y="387">=</text>
-   <rect x="319" y="369" width="38" height="32"/>
-   <rect x="317" y="367" width="38" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="327" y="387">val</text>
-   <rect x="207" y="325" width="24" height="32" rx="10"/>
-   <rect x="205"
-         y="323"
+   <text class="terminal" x="284" y="485">=</text>
+   <rect x="322" y="467" width="38" height="32"/>
+   <rect x="320" y="465" width="38" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="330" y="485">val</text>
+   <rect x="210" y="423" width="24" height="32" rx="10"/>
+   <rect x="208"
+         y="421"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="215" y="343">,</text>
-   <rect x="397" y="369" width="24" height="32" rx="10"/>
-   <rect x="395"
-         y="367"
+   <text class="terminal" x="218" y="441">,</text>
+   <rect x="400" y="467" width="24" height="32" rx="10"/>
+   <rect x="398"
+         y="465"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="405" y="387">)</text>
-   <rect x="461" y="369" width="78" height="32" rx="10"/>
-   <rect x="459"
-         y="367"
+   <text class="terminal" x="408" y="485">)</text>
+   <rect x="464" y="467" width="78" height="32" rx="10"/>
+   <rect x="462"
+         y="465"
          width="78"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="469" y="387">FORMAT</text>
-   <rect x="27" y="451" width="88" height="32" rx="10"/>
-   <rect x="25"
-         y="449"
+   <text class="terminal" x="472" y="485">FORMAT</text>
+   <rect x="33" y="549" width="88" height="32" rx="10"/>
+   <rect x="31"
+         y="547"
          width="88"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="35" y="469">CSV WITH</text>
-   <rect x="155" y="451" width="76" height="32" rx="10"/>
-   <rect x="153"
-         y="449"
+   <text class="terminal" x="41" y="567">CSV WITH</text>
+   <rect x="161" y="549" width="76" height="32" rx="10"/>
+   <rect x="159"
+         y="547"
          width="76"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="163" y="469">HEADER</text>
-   <rect x="155" y="495" width="28" height="32"/>
-   <rect x="153" y="493" width="28" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="163" y="513">n</text>
-   <rect x="203" y="495" width="90" height="32" rx="10"/>
-   <rect x="201"
-         y="493"
+   <text class="terminal" x="169" y="567">HEADER</text>
+   <rect x="161" y="593" width="28" height="32"/>
+   <rect x="159" y="591" width="28" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="169" y="611">n</text>
+   <rect x="209" y="593" width="90" height="32" rx="10"/>
+   <rect x="207"
+         y="591"
          width="90"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="211" y="513">COLUMNS</text>
-   <rect x="353" y="483" width="116" height="32" rx="10"/>
-   <rect x="351"
-         y="481"
+   <text class="terminal" x="217" y="611">COLUMNS</text>
+   <rect x="359" y="581" width="116" height="32" rx="10"/>
+   <rect x="357"
+         y="579"
          width="116"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="361" y="501">DELIMITED BY</text>
-   <rect x="489" y="483" width="46" height="32"/>
-   <rect x="487" y="481" width="46" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="497" y="501">char</text>
+   <text class="terminal" x="367" y="599">DELIMITED BY</text>
+   <rect x="495" y="581" width="46" height="32"/>
+   <rect x="493" y="579" width="46" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="503" y="599">char</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m74 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m78 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-526 142 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m80 0 h10 m20 0 h10 m24 0 h10 m20 0 h10 m80 0 h10 m-120 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m100 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-100 0 h10 m24 0 h10 m0 0 h56 m20 44 h10 m24 0 h10 m-248 0 h20 m228 0 h20 m-268 0 q10 0 10 10 m248 0 q0 -10 10 -10 m-258 10 v14 m248 0 v-14 m-248 14 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m0 0 h218 m20 -34 h10 m60 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-450 82 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m126 0 h10 m0 0 h10 m46 0 h10 m0 0 h10 m62 0 h10 m20 0 h10 m0 0 h60 m-90 0 h20 m70 0 h20 m-110 0 q10 0 10 10 m90 0 q0 -10 10 -10 m-100 10 v12 m90 0 v-12 m-90 12 q0 10 10 10 m70 0 q10 0 10 -10 m-80 10 h10 m50 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-482 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m56 0 h10 m0 0 h10 m24 0 h10 m20 0 h10 m46 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m38 0 h10 m-190 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m170 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-170 0 h10 m24 0 h10 m0 0 h126 m20 44 h10 m24 0 h10 m-394 0 h20 m374 0 h20 m-414 0 q10 0 10 10 m394 0 q0 -10 10 -10 m-404 10 v14 m394 0 v-14 m-394 14 q0 10 10 10 m374 0 q10 0 10 -10 m-384 10 h10 m0 0 h364 m20 -34 h10 m78 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-556 82 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m88 0 h10 m20 0 h10 m76 0 h10 m0 0 h62 m-178 0 h20 m158 0 h20 m-198 0 q10 0 10 10 m178 0 q0 -10 10 -10 m-188 10 v24 m178 0 v-24 m-178 24 q0 10 10 10 m158 0 q10 0 10 -10 m-168 10 h10 m28 0 h10 m0 0 h10 m90 0 h10 m40 -44 h10 m0 0 h192 m-222 0 h20 m202 0 h20 m-242 0 q10 0 10 10 m222 0 q0 -10 10 -10 m-232 10 v12 m222 0 v-12 m-222 12 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m116 0 h10 m0 0 h10 m46 0 h10 m23 -32 h-3"/>
-   <polygon points="573 465 581 461 581 469"/>
-   <polygon points="573 465 565 461 565 469"/>
+         d="m17 17 h2 m0 0 h10 m74 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m78 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-349 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m80 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-355 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m24 0 h10 m20 0 h10 m80 0 h10 m-120 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m100 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-100 0 h10 m24 0 h10 m0 0 h56 m40 44 h10 m0 0 h164 m-194 0 h20 m174 0 h20 m-214 0 q10 0 10 10 m194 0 q0 -10 10 -10 m-204 10 v12 m194 0 v-12 m-194 12 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m24 0 h10 m0 0 h10 m110 0 h10 m20 -32 h10 m24 0 h10 m-462 0 h20 m442 0 h20 m-482 0 q10 0 10 10 m462 0 q0 -10 10 -10 m-472 10 v46 m462 0 v-46 m-462 46 q0 10 10 10 m442 0 q10 0 10 -10 m-452 10 h10 m0 0 h432 m20 -66 h10 m60 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-507 114 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m126 0 h10 m0 0 h10 m46 0 h10 m0 0 h10 m62 0 h10 m20 0 h10 m0 0 h60 m-90 0 h20 m70 0 h20 m-110 0 q10 0 10 10 m90 0 q0 -10 10 -10 m-100 10 v12 m90 0 v-12 m-90 12 q0 10 10 10 m70 0 q10 0 10 -10 m-80 10 h10 m50 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-482 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m56 0 h10 m0 0 h10 m24 0 h10 m20 0 h10 m46 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m38 0 h10 m-190 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m170 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-170 0 h10 m24 0 h10 m0 0 h126 m20 44 h10 m24 0 h10 m-394 0 h20 m374 0 h20 m-414 0 q10 0 10 10 m394 0 q0 -10 10 -10 m-404 10 v14 m394 0 v-14 m-394 14 q0 10 10 10 m374 0 q10 0 10 -10 m-384 10 h10 m0 0 h364 m20 -34 h10 m78 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-553 82 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m88 0 h10 m20 0 h10 m76 0 h10 m0 0 h62 m-178 0 h20 m158 0 h20 m-198 0 q10 0 10 10 m178 0 q0 -10 10 -10 m-188 10 v24 m178 0 v-24 m-178 24 q0 10 10 10 m158 0 q10 0 10 -10 m-168 10 h10 m28 0 h10 m0 0 h10 m90 0 h10 m40 -44 h10 m0 0 h192 m-222 0 h20 m202 0 h20 m-242 0 q10 0 10 10 m222 0 q0 -10 10 -10 m-232 10 v12 m222 0 v-12 m-222 12 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m116 0 h10 m0 0 h10 m46 0 h10 m23 -32 h-3"/>
+   <polygon points="579 563 587 559 587 567"/>
+   <polygon points="579 563 571 559 571 567"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/create-source-csv-kinesis.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-source-csv-kinesis.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="601" height="431">
+<svg xmlns="http://www.w3.org/2000/svg" width="589" height="595">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="74" height="32" rx="10"/>
@@ -33,149 +33,160 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="431" y="53">IF NOT EXISTS</text>
-   <rect x="25" y="145" width="80" height="32"/>
-   <rect x="23" y="143" width="80" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="33" y="163">src_name</text>
-   <rect x="145" y="145" width="24" height="32" rx="10"/>
-   <rect x="143"
-         y="143"
+   <rect x="256" y="101" width="80" height="32"/>
+   <rect x="254" y="99" width="80" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="264" y="119">src_name</text>
+   <rect x="45" y="211" width="24" height="32" rx="10"/>
+   <rect x="43"
+         y="209"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="153" y="163">(</text>
-   <rect x="209" y="145" width="80" height="32"/>
-   <rect x="207" y="143" width="80" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="217" y="163">col_name</text>
-   <rect x="209" y="101" width="24" height="32" rx="10"/>
-   <rect x="207"
-         y="99"
+   <text class="terminal" x="53" y="229">(</text>
+   <rect x="109" y="211" width="80" height="32"/>
+   <rect x="107" y="209" width="80" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="117" y="229">col_name</text>
+   <rect x="109" y="167" width="24" height="32" rx="10"/>
+   <rect x="107"
+         y="165"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="217" y="119">,</text>
-   <rect x="329" y="145" width="24" height="32" rx="10"/>
-   <rect x="327"
-         y="143"
+   <text class="terminal" x="117" y="185">,</text>
+   <rect x="249" y="243" width="24" height="32" rx="10"/>
+   <rect x="247"
+         y="241"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="337" y="163">)</text>
-   <rect x="393" y="145" width="60" height="32" rx="10"/>
-   <rect x="391"
-         y="143"
+   <text class="terminal" x="257" y="261">,</text>
+   <rect x="293" y="243" width="110" height="32"/>
+   <rect x="291" y="241" width="110" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="301" y="261">key_constraint</text>
+   <rect x="443" y="211" width="24" height="32" rx="10"/>
+   <rect x="441"
+         y="209"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="451" y="229">)</text>
+   <rect x="507" y="211" width="60" height="32" rx="10"/>
+   <rect x="505"
+         y="209"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="401" y="163">FROM</text>
-   <rect x="473" y="145" width="106" height="32" rx="10"/>
-   <rect x="471"
-         y="143"
+   <text class="terminal" x="515" y="229">FROM</text>
+   <rect x="213" y="325" width="106" height="32" rx="10"/>
+   <rect x="211"
+         y="323"
          width="106"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="481" y="163">KINESIS ARN</text>
-   <rect x="26" y="271" width="40" height="32"/>
-   <rect x="24" y="269" width="40" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="34" y="289">arn</text>
-   <rect x="106" y="271" width="56" height="32" rx="10"/>
-   <rect x="104"
-         y="269"
+   <text class="terminal" x="221" y="343">KINESIS ARN</text>
+   <rect x="339" y="325" width="40" height="32"/>
+   <rect x="337" y="323" width="40" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="347" y="343">arn</text>
+   <rect x="70" y="435" width="56" height="32" rx="10"/>
+   <rect x="68"
+         y="433"
          width="56"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="114" y="289">WITH</text>
-   <rect x="182" y="271" width="24" height="32" rx="10"/>
-   <rect x="180"
-         y="269"
+   <text class="terminal" x="78" y="453">WITH</text>
+   <rect x="146" y="435" width="24" height="32" rx="10"/>
+   <rect x="144"
+         y="433"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="190" y="289">(</text>
-   <rect x="246" y="271" width="46" height="32"/>
-   <rect x="244" y="269" width="46" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="254" y="289">field</text>
-   <rect x="312" y="271" width="26" height="32" rx="10"/>
-   <rect x="310"
-         y="269"
+   <text class="terminal" x="154" y="453">(</text>
+   <rect x="210" y="435" width="46" height="32"/>
+   <rect x="208" y="433" width="46" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="218" y="453">field</text>
+   <rect x="276" y="435" width="26" height="32" rx="10"/>
+   <rect x="274"
+         y="433"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="320" y="289">=</text>
-   <rect x="358" y="271" width="38" height="32"/>
-   <rect x="356" y="269" width="38" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="366" y="289">val</text>
-   <rect x="246" y="227" width="24" height="32" rx="10"/>
-   <rect x="244"
-         y="225"
+   <text class="terminal" x="284" y="453">=</text>
+   <rect x="322" y="435" width="38" height="32"/>
+   <rect x="320" y="433" width="38" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="330" y="453">val</text>
+   <rect x="210" y="391" width="24" height="32" rx="10"/>
+   <rect x="208"
+         y="389"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="254" y="245">,</text>
-   <rect x="436" y="271" width="24" height="32" rx="10"/>
-   <rect x="434"
-         y="269"
+   <text class="terminal" x="218" y="409">,</text>
+   <rect x="400" y="435" width="24" height="32" rx="10"/>
+   <rect x="398"
+         y="433"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="444" y="289">)</text>
-   <rect x="500" y="271" width="78" height="32" rx="10"/>
-   <rect x="498"
-         y="269"
+   <text class="terminal" x="408" y="453">)</text>
+   <rect x="464" y="435" width="78" height="32" rx="10"/>
+   <rect x="462"
+         y="433"
          width="78"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="508" y="289">FORMAT</text>
-   <rect x="45" y="353" width="88" height="32" rx="10"/>
-   <rect x="43"
-         y="351"
+   <text class="terminal" x="472" y="453">FORMAT</text>
+   <rect x="33" y="517" width="88" height="32" rx="10"/>
+   <rect x="31"
+         y="515"
          width="88"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="53" y="371">CSV WITH</text>
-   <rect x="173" y="353" width="76" height="32" rx="10"/>
-   <rect x="171"
-         y="351"
+   <text class="terminal" x="41" y="535">CSV WITH</text>
+   <rect x="161" y="517" width="76" height="32" rx="10"/>
+   <rect x="159"
+         y="515"
          width="76"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="181" y="371">HEADER</text>
-   <rect x="173" y="397" width="28" height="32"/>
-   <rect x="171" y="395" width="28" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="181" y="415">n</text>
-   <rect x="221" y="397" width="90" height="32" rx="10"/>
-   <rect x="219"
-         y="395"
+   <text class="terminal" x="169" y="535">HEADER</text>
+   <rect x="161" y="561" width="28" height="32"/>
+   <rect x="159" y="559" width="28" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="169" y="579">n</text>
+   <rect x="209" y="561" width="90" height="32" rx="10"/>
+   <rect x="207"
+         y="559"
          width="90"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="229" y="415">COLUMNS</text>
-   <rect x="371" y="385" width="116" height="32" rx="10"/>
-   <rect x="369"
-         y="383"
+   <text class="terminal" x="217" y="579">COLUMNS</text>
+   <rect x="359" y="549" width="116" height="32" rx="10"/>
+   <rect x="357"
+         y="547"
          width="116"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="379" y="403">DELIMITED BY</text>
-   <rect x="507" y="385" width="46" height="32"/>
-   <rect x="505" y="383" width="46" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="515" y="403">char</text>
+   <text class="terminal" x="367" y="567">DELIMITED BY</text>
+   <rect x="495" y="549" width="46" height="32"/>
+   <rect x="493" y="547" width="46" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="503" y="567">char</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m74 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m78 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-580 142 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m80 0 h10 m20 0 h10 m24 0 h10 m20 0 h10 m80 0 h10 m-120 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m100 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-100 0 h10 m24 0 h10 m0 0 h56 m20 44 h10 m24 0 h10 m-248 0 h20 m228 0 h20 m-268 0 q10 0 10 10 m248 0 q0 -10 10 -10 m-258 10 v14 m248 0 v-14 m-248 14 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m0 0 h218 m20 -34 h10 m60 0 h10 m0 0 h10 m106 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-597 126 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m40 0 h10 m20 0 h10 m56 0 h10 m0 0 h10 m24 0 h10 m20 0 h10 m46 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m38 0 h10 m-190 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m170 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-170 0 h10 m24 0 h10 m0 0 h126 m20 44 h10 m24 0 h10 m-394 0 h20 m374 0 h20 m-414 0 q10 0 10 10 m394 0 q0 -10 10 -10 m-404 10 v14 m394 0 v-14 m-394 14 q0 10 10 10 m374 0 q10 0 10 -10 m-384 10 h10 m0 0 h364 m20 -34 h10 m78 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-577 82 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m88 0 h10 m20 0 h10 m76 0 h10 m0 0 h62 m-178 0 h20 m158 0 h20 m-198 0 q10 0 10 10 m178 0 q0 -10 10 -10 m-188 10 v24 m178 0 v-24 m-178 24 q0 10 10 10 m158 0 q10 0 10 -10 m-168 10 h10 m28 0 h10 m0 0 h10 m90 0 h10 m40 -44 h10 m0 0 h192 m-222 0 h20 m202 0 h20 m-242 0 q10 0 10 10 m222 0 q0 -10 10 -10 m-232 10 v12 m222 0 v-12 m-222 12 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m116 0 h10 m0 0 h10 m46 0 h10 m23 -32 h-3"/>
-   <polygon points="591 367 599 363 599 371"/>
-   <polygon points="591 367 583 363 583 371"/>
+         d="m17 17 h2 m0 0 h10 m74 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m78 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-349 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m80 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-355 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m24 0 h10 m20 0 h10 m80 0 h10 m-120 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m100 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-100 0 h10 m24 0 h10 m0 0 h56 m40 44 h10 m0 0 h164 m-194 0 h20 m174 0 h20 m-214 0 q10 0 10 10 m194 0 q0 -10 10 -10 m-204 10 v12 m194 0 v-12 m-194 12 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m24 0 h10 m0 0 h10 m110 0 h10 m20 -32 h10 m24 0 h10 m-462 0 h20 m442 0 h20 m-482 0 q10 0 10 10 m462 0 q0 -10 10 -10 m-472 10 v46 m462 0 v-46 m-462 46 q0 10 10 10 m442 0 q10 0 10 -10 m-452 10 h10 m0 0 h432 m20 -66 h10 m60 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-398 114 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m106 0 h10 m0 0 h10 m40 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-373 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m56 0 h10 m0 0 h10 m24 0 h10 m20 0 h10 m46 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m38 0 h10 m-190 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m170 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-170 0 h10 m24 0 h10 m0 0 h126 m20 44 h10 m24 0 h10 m-394 0 h20 m374 0 h20 m-414 0 q10 0 10 10 m394 0 q0 -10 10 -10 m-404 10 v14 m394 0 v-14 m-394 14 q0 10 10 10 m374 0 q10 0 10 -10 m-384 10 h10 m0 0 h364 m20 -34 h10 m78 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-553 82 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m88 0 h10 m20 0 h10 m76 0 h10 m0 0 h62 m-178 0 h20 m158 0 h20 m-198 0 q10 0 10 10 m178 0 q0 -10 10 -10 m-188 10 v24 m178 0 v-24 m-178 24 q0 10 10 10 m158 0 q10 0 10 -10 m-168 10 h10 m28 0 h10 m0 0 h10 m90 0 h10 m40 -44 h10 m0 0 h192 m-222 0 h20 m202 0 h20 m-242 0 q10 0 10 10 m222 0 q0 -10 10 -10 m-232 10 v12 m222 0 v-12 m-222 12 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m116 0 h10 m0 0 h10 m46 0 h10 m23 -32 h-3"/>
+   <polygon points="579 531 587 527 587 535"/>
+   <polygon points="579 531 571 527 571 535"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/create-source-protobuf-kafka.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-source-protobuf-kafka.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="583" height="595">
+<svg xmlns="http://www.w3.org/2000/svg" width="589" height="693">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="74" height="32" rx="10"/>
@@ -33,155 +33,166 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="431" y="53">IF NOT EXISTS</text>
-   <rect x="79" y="145" width="80" height="32"/>
-   <rect x="77" y="143" width="80" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="87" y="163">src_name</text>
-   <rect x="199" y="145" width="24" height="32" rx="10"/>
-   <rect x="197"
-         y="143"
+   <rect x="256" y="101" width="80" height="32"/>
+   <rect x="254" y="99" width="80" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="264" y="119">src_name</text>
+   <rect x="45" y="211" width="24" height="32" rx="10"/>
+   <rect x="43"
+         y="209"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="207" y="163">(</text>
-   <rect x="263" y="145" width="80" height="32"/>
-   <rect x="261" y="143" width="80" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="271" y="163">col_name</text>
-   <rect x="263" y="101" width="24" height="32" rx="10"/>
-   <rect x="261"
-         y="99"
+   <text class="terminal" x="53" y="229">(</text>
+   <rect x="109" y="211" width="80" height="32"/>
+   <rect x="107" y="209" width="80" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="117" y="229">col_name</text>
+   <rect x="109" y="167" width="24" height="32" rx="10"/>
+   <rect x="107"
+         y="165"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="271" y="119">,</text>
-   <rect x="383" y="145" width="24" height="32" rx="10"/>
-   <rect x="381"
-         y="143"
+   <text class="terminal" x="117" y="185">,</text>
+   <rect x="249" y="243" width="24" height="32" rx="10"/>
+   <rect x="247"
+         y="241"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="391" y="163">)</text>
-   <rect x="447" y="145" width="60" height="32" rx="10"/>
-   <rect x="445"
-         y="143"
+   <text class="terminal" x="257" y="261">,</text>
+   <rect x="293" y="243" width="110" height="32"/>
+   <rect x="291" y="241" width="110" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="301" y="261">key_constraint</text>
+   <rect x="443" y="211" width="24" height="32" rx="10"/>
+   <rect x="441"
+         y="209"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="451" y="229">)</text>
+   <rect x="507" y="211" width="60" height="32" rx="10"/>
+   <rect x="505"
+         y="209"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="455" y="163">FROM</text>
-   <rect x="101" y="227" width="126" height="32" rx="10"/>
-   <rect x="99"
-         y="225"
+   <text class="terminal" x="515" y="229">FROM</text>
+   <rect x="104" y="325" width="126" height="32" rx="10"/>
+   <rect x="102"
+         y="323"
          width="126"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="109" y="245">KAFKA BROKER</text>
-   <rect x="247" y="227" width="46" height="32"/>
-   <rect x="245" y="225" width="46" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="255" y="245">host</text>
-   <rect x="313" y="227" width="62" height="32" rx="10"/>
-   <rect x="311"
-         y="225"
+   <text class="terminal" x="112" y="343">KAFKA BROKER</text>
+   <rect x="250" y="325" width="46" height="32"/>
+   <rect x="248" y="323" width="46" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="258" y="343">host</text>
+   <rect x="316" y="325" width="62" height="32" rx="10"/>
+   <rect x="314"
+         y="323"
          width="62"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="321" y="245">TOPIC</text>
-   <rect x="415" y="259" width="50" height="32"/>
-   <rect x="413" y="257" width="50" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="423" y="277">topic</text>
-   <rect x="67" y="369" width="56" height="32" rx="10"/>
-   <rect x="65"
-         y="367"
+   <text class="terminal" x="324" y="343">TOPIC</text>
+   <rect x="418" y="357" width="50" height="32"/>
+   <rect x="416" y="355" width="50" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="426" y="375">topic</text>
+   <rect x="70" y="467" width="56" height="32" rx="10"/>
+   <rect x="68"
+         y="465"
          width="56"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="75" y="387">WITH</text>
-   <rect x="143" y="369" width="24" height="32" rx="10"/>
-   <rect x="141"
-         y="367"
+   <text class="terminal" x="78" y="485">WITH</text>
+   <rect x="146" y="467" width="24" height="32" rx="10"/>
+   <rect x="144"
+         y="465"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="151" y="387">(</text>
-   <rect x="207" y="369" width="46" height="32"/>
-   <rect x="205" y="367" width="46" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="215" y="387">field</text>
-   <rect x="273" y="369" width="26" height="32" rx="10"/>
-   <rect x="271"
-         y="367"
+   <text class="terminal" x="154" y="485">(</text>
+   <rect x="210" y="467" width="46" height="32"/>
+   <rect x="208" y="465" width="46" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="218" y="485">field</text>
+   <rect x="276" y="467" width="26" height="32" rx="10"/>
+   <rect x="274"
+         y="465"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="281" y="387">=</text>
-   <rect x="319" y="369" width="38" height="32"/>
-   <rect x="317" y="367" width="38" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="327" y="387">val</text>
-   <rect x="207" y="325" width="24" height="32" rx="10"/>
-   <rect x="205"
-         y="323"
+   <text class="terminal" x="284" y="485">=</text>
+   <rect x="322" y="467" width="38" height="32"/>
+   <rect x="320" y="465" width="38" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="330" y="485">val</text>
+   <rect x="210" y="423" width="24" height="32" rx="10"/>
+   <rect x="208"
+         y="421"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="215" y="343">,</text>
-   <rect x="397" y="369" width="24" height="32" rx="10"/>
-   <rect x="395"
-         y="367"
+   <text class="terminal" x="218" y="441">,</text>
+   <rect x="400" y="467" width="24" height="32" rx="10"/>
+   <rect x="398"
+         y="465"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="405" y="387">)</text>
-   <rect x="461" y="369" width="78" height="32" rx="10"/>
-   <rect x="459"
-         y="367"
+   <text class="terminal" x="408" y="485">)</text>
+   <rect x="464" y="467" width="78" height="32" rx="10"/>
+   <rect x="462"
+         y="465"
          width="78"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="469" y="387">FORMAT</text>
-   <rect x="68" y="451" width="168" height="32" rx="10"/>
-   <rect x="66"
-         y="449"
+   <text class="terminal" x="472" y="485">FORMAT</text>
+   <rect x="71" y="549" width="168" height="32" rx="10"/>
+   <rect x="69"
+         y="547"
          width="168"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="76" y="469">PROTOBUF MESSAGE</text>
-   <rect x="256" y="451" width="116" height="32"/>
-   <rect x="254" y="449" width="116" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="264" y="469">message_name</text>
-   <rect x="392" y="451" width="126" height="32" rx="10"/>
-   <rect x="390"
-         y="449"
+   <text class="terminal" x="79" y="567">PROTOBUF MESSAGE</text>
+   <rect x="259" y="549" width="116" height="32"/>
+   <rect x="257" y="547" width="116" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="267" y="567">message_name</text>
+   <rect x="395" y="549" width="126" height="32" rx="10"/>
+   <rect x="393"
+         y="547"
          width="126"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="400" y="469">USING SCHEMA</text>
-   <rect x="339" y="517" width="48" height="32" rx="10"/>
-   <rect x="337"
-         y="515"
+   <text class="terminal" x="403" y="567">USING SCHEMA</text>
+   <rect x="345" y="615" width="48" height="32" rx="10"/>
+   <rect x="343"
+         y="613"
          width="48"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="347" y="535">FILE</text>
-   <rect x="407" y="517" width="128" height="32"/>
-   <rect x="405" y="515" width="128" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="415" y="535">schema_file_path</text>
-   <rect x="339" y="561" width="108" height="32"/>
-   <rect x="337" y="559" width="108" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="347" y="579">inline_schema</text>
+   <text class="terminal" x="353" y="633">FILE</text>
+   <rect x="413" y="615" width="128" height="32"/>
+   <rect x="411" y="613" width="128" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="421" y="633">schema_file_path</text>
+   <rect x="345" y="659" width="108" height="32"/>
+   <rect x="343" y="657" width="108" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="353" y="677">inline_schema</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m74 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m78 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-526 142 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m80 0 h10 m20 0 h10 m24 0 h10 m20 0 h10 m80 0 h10 m-120 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m100 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-100 0 h10 m24 0 h10 m0 0 h56 m20 44 h10 m24 0 h10 m-248 0 h20 m228 0 h20 m-268 0 q10 0 10 10 m248 0 q0 -10 10 -10 m-258 10 v14 m248 0 v-14 m-248 14 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m0 0 h218 m20 -34 h10 m60 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-450 82 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m126 0 h10 m0 0 h10 m46 0 h10 m0 0 h10 m62 0 h10 m20 0 h10 m0 0 h60 m-90 0 h20 m70 0 h20 m-110 0 q10 0 10 10 m90 0 q0 -10 10 -10 m-100 10 v12 m90 0 v-12 m-90 12 q0 10 10 10 m70 0 q10 0 10 -10 m-80 10 h10 m50 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-482 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m56 0 h10 m0 0 h10 m24 0 h10 m20 0 h10 m46 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m38 0 h10 m-190 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m170 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-170 0 h10 m24 0 h10 m0 0 h126 m20 44 h10 m24 0 h10 m-394 0 h20 m374 0 h20 m-414 0 q10 0 10 10 m394 0 q0 -10 10 -10 m-404 10 v14 m394 0 v-14 m-394 14 q0 10 10 10 m374 0 q10 0 10 -10 m-384 10 h10 m0 0 h364 m20 -34 h10 m78 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-515 82 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m168 0 h10 m0 0 h10 m116 0 h10 m0 0 h10 m126 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-243 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m48 0 h10 m0 0 h10 m128 0 h10 m-236 0 h20 m216 0 h20 m-256 0 q10 0 10 10 m236 0 q0 -10 10 -10 m-246 10 v24 m236 0 v-24 m-236 24 q0 10 10 10 m216 0 q10 0 10 -10 m-226 10 h10 m108 0 h10 m0 0 h88 m23 -44 h-3"/>
-   <polygon points="573 531 581 527 581 535"/>
-   <polygon points="573 531 565 527 565 535"/>
+         d="m17 17 h2 m0 0 h10 m74 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m78 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-349 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m80 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-355 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m24 0 h10 m20 0 h10 m80 0 h10 m-120 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m100 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-100 0 h10 m24 0 h10 m0 0 h56 m40 44 h10 m0 0 h164 m-194 0 h20 m174 0 h20 m-214 0 q10 0 10 10 m194 0 q0 -10 10 -10 m-204 10 v12 m194 0 v-12 m-194 12 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m24 0 h10 m0 0 h10 m110 0 h10 m20 -32 h10 m24 0 h10 m-462 0 h20 m442 0 h20 m-482 0 q10 0 10 10 m462 0 q0 -10 10 -10 m-472 10 v46 m462 0 v-46 m-462 46 q0 10 10 10 m442 0 q10 0 10 -10 m-452 10 h10 m0 0 h432 m20 -66 h10 m60 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-507 114 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m126 0 h10 m0 0 h10 m46 0 h10 m0 0 h10 m62 0 h10 m20 0 h10 m0 0 h60 m-90 0 h20 m70 0 h20 m-110 0 q10 0 10 10 m90 0 q0 -10 10 -10 m-100 10 v12 m90 0 v-12 m-90 12 q0 10 10 10 m70 0 q10 0 10 -10 m-80 10 h10 m50 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-482 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m56 0 h10 m0 0 h10 m24 0 h10 m20 0 h10 m46 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m38 0 h10 m-190 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m170 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-170 0 h10 m24 0 h10 m0 0 h126 m20 44 h10 m24 0 h10 m-394 0 h20 m374 0 h20 m-414 0 q10 0 10 10 m394 0 q0 -10 10 -10 m-404 10 v14 m394 0 v-14 m-394 14 q0 10 10 10 m374 0 q10 0 10 -10 m-384 10 h10 m0 0 h364 m20 -34 h10 m78 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-515 82 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m168 0 h10 m0 0 h10 m116 0 h10 m0 0 h10 m126 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-240 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m48 0 h10 m0 0 h10 m128 0 h10 m-236 0 h20 m216 0 h20 m-256 0 q10 0 10 10 m236 0 q0 -10 10 -10 m-246 10 v24 m236 0 v-24 m-236 24 q0 10 10 10 m216 0 q10 0 10 -10 m-226 10 h10 m108 0 h10 m0 0 h88 m23 -44 h-3"/>
+   <polygon points="579 629 587 625 587 633"/>
+   <polygon points="579 629 571 625 571 633"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/create-source-protobuf-kinesis.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-source-protobuf-kinesis.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="601" height="497">
+<svg xmlns="http://www.w3.org/2000/svg" width="589" height="661">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="74" height="32" rx="10"/>
@@ -33,144 +33,155 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="431" y="53">IF NOT EXISTS</text>
-   <rect x="25" y="145" width="80" height="32"/>
-   <rect x="23" y="143" width="80" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="33" y="163">src_name</text>
-   <rect x="145" y="145" width="24" height="32" rx="10"/>
-   <rect x="143"
-         y="143"
+   <rect x="256" y="101" width="80" height="32"/>
+   <rect x="254" y="99" width="80" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="264" y="119">src_name</text>
+   <rect x="45" y="211" width="24" height="32" rx="10"/>
+   <rect x="43"
+         y="209"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="153" y="163">(</text>
-   <rect x="209" y="145" width="80" height="32"/>
-   <rect x="207" y="143" width="80" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="217" y="163">col_name</text>
-   <rect x="209" y="101" width="24" height="32" rx="10"/>
-   <rect x="207"
-         y="99"
+   <text class="terminal" x="53" y="229">(</text>
+   <rect x="109" y="211" width="80" height="32"/>
+   <rect x="107" y="209" width="80" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="117" y="229">col_name</text>
+   <rect x="109" y="167" width="24" height="32" rx="10"/>
+   <rect x="107"
+         y="165"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="217" y="119">,</text>
-   <rect x="329" y="145" width="24" height="32" rx="10"/>
-   <rect x="327"
-         y="143"
+   <text class="terminal" x="117" y="185">,</text>
+   <rect x="249" y="243" width="24" height="32" rx="10"/>
+   <rect x="247"
+         y="241"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="337" y="163">)</text>
-   <rect x="393" y="145" width="60" height="32" rx="10"/>
-   <rect x="391"
-         y="143"
+   <text class="terminal" x="257" y="261">,</text>
+   <rect x="293" y="243" width="110" height="32"/>
+   <rect x="291" y="241" width="110" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="301" y="261">key_constraint</text>
+   <rect x="443" y="211" width="24" height="32" rx="10"/>
+   <rect x="441"
+         y="209"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="451" y="229">)</text>
+   <rect x="507" y="211" width="60" height="32" rx="10"/>
+   <rect x="505"
+         y="209"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="401" y="163">FROM</text>
-   <rect x="473" y="145" width="106" height="32" rx="10"/>
-   <rect x="471"
-         y="143"
+   <text class="terminal" x="515" y="229">FROM</text>
+   <rect x="213" y="325" width="106" height="32" rx="10"/>
+   <rect x="211"
+         y="323"
          width="106"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="481" y="163">KINESIS ARN</text>
-   <rect x="26" y="271" width="40" height="32"/>
-   <rect x="24" y="269" width="40" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="34" y="289">arn</text>
-   <rect x="106" y="271" width="56" height="32" rx="10"/>
-   <rect x="104"
-         y="269"
+   <text class="terminal" x="221" y="343">KINESIS ARN</text>
+   <rect x="339" y="325" width="40" height="32"/>
+   <rect x="337" y="323" width="40" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="347" y="343">arn</text>
+   <rect x="70" y="435" width="56" height="32" rx="10"/>
+   <rect x="68"
+         y="433"
          width="56"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="114" y="289">WITH</text>
-   <rect x="182" y="271" width="24" height="32" rx="10"/>
-   <rect x="180"
-         y="269"
+   <text class="terminal" x="78" y="453">WITH</text>
+   <rect x="146" y="435" width="24" height="32" rx="10"/>
+   <rect x="144"
+         y="433"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="190" y="289">(</text>
-   <rect x="246" y="271" width="46" height="32"/>
-   <rect x="244" y="269" width="46" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="254" y="289">field</text>
-   <rect x="312" y="271" width="26" height="32" rx="10"/>
-   <rect x="310"
-         y="269"
+   <text class="terminal" x="154" y="453">(</text>
+   <rect x="210" y="435" width="46" height="32"/>
+   <rect x="208" y="433" width="46" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="218" y="453">field</text>
+   <rect x="276" y="435" width="26" height="32" rx="10"/>
+   <rect x="274"
+         y="433"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="320" y="289">=</text>
-   <rect x="358" y="271" width="38" height="32"/>
-   <rect x="356" y="269" width="38" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="366" y="289">val</text>
-   <rect x="246" y="227" width="24" height="32" rx="10"/>
-   <rect x="244"
-         y="225"
+   <text class="terminal" x="284" y="453">=</text>
+   <rect x="322" y="435" width="38" height="32"/>
+   <rect x="320" y="433" width="38" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="330" y="453">val</text>
+   <rect x="210" y="391" width="24" height="32" rx="10"/>
+   <rect x="208"
+         y="389"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="254" y="245">,</text>
-   <rect x="436" y="271" width="24" height="32" rx="10"/>
-   <rect x="434"
-         y="269"
+   <text class="terminal" x="218" y="409">,</text>
+   <rect x="400" y="435" width="24" height="32" rx="10"/>
+   <rect x="398"
+         y="433"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="444" y="289">)</text>
-   <rect x="500" y="271" width="78" height="32" rx="10"/>
-   <rect x="498"
-         y="269"
+   <text class="terminal" x="408" y="453">)</text>
+   <rect x="464" y="435" width="78" height="32" rx="10"/>
+   <rect x="462"
+         y="433"
          width="78"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="508" y="289">FORMAT</text>
-   <rect x="77" y="353" width="168" height="32" rx="10"/>
-   <rect x="75"
-         y="351"
+   <text class="terminal" x="472" y="453">FORMAT</text>
+   <rect x="71" y="517" width="168" height="32" rx="10"/>
+   <rect x="69"
+         y="515"
          width="168"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="85" y="371">PROTOBUF MESSAGE</text>
-   <rect x="265" y="353" width="116" height="32"/>
-   <rect x="263" y="351" width="116" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="273" y="371">message_name</text>
-   <rect x="401" y="353" width="126" height="32" rx="10"/>
-   <rect x="399"
-         y="351"
+   <text class="terminal" x="79" y="535">PROTOBUF MESSAGE</text>
+   <rect x="259" y="517" width="116" height="32"/>
+   <rect x="257" y="515" width="116" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="267" y="535">message_name</text>
+   <rect x="395" y="517" width="126" height="32" rx="10"/>
+   <rect x="393"
+         y="515"
          width="126"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="409" y="371">USING SCHEMA</text>
-   <rect x="357" y="419" width="48" height="32" rx="10"/>
-   <rect x="355"
-         y="417"
+   <text class="terminal" x="403" y="535">USING SCHEMA</text>
+   <rect x="345" y="583" width="48" height="32" rx="10"/>
+   <rect x="343"
+         y="581"
          width="48"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="365" y="437">FILE</text>
-   <rect x="425" y="419" width="128" height="32"/>
-   <rect x="423" y="417" width="128" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="433" y="437">schema_file_path</text>
-   <rect x="357" y="463" width="108" height="32"/>
-   <rect x="355" y="461" width="108" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="365" y="481">inline_schema</text>
+   <text class="terminal" x="353" y="601">FILE</text>
+   <rect x="413" y="583" width="128" height="32"/>
+   <rect x="411" y="581" width="128" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="421" y="601">schema_file_path</text>
+   <rect x="345" y="627" width="108" height="32"/>
+   <rect x="343" y="625" width="108" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="353" y="645">inline_schema</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m74 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m78 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-580 142 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m80 0 h10 m20 0 h10 m24 0 h10 m20 0 h10 m80 0 h10 m-120 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m100 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-100 0 h10 m24 0 h10 m0 0 h56 m20 44 h10 m24 0 h10 m-248 0 h20 m228 0 h20 m-268 0 q10 0 10 10 m248 0 q0 -10 10 -10 m-258 10 v14 m248 0 v-14 m-248 14 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m0 0 h218 m20 -34 h10 m60 0 h10 m0 0 h10 m106 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-597 126 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m40 0 h10 m20 0 h10 m56 0 h10 m0 0 h10 m24 0 h10 m20 0 h10 m46 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m38 0 h10 m-190 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m170 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-170 0 h10 m24 0 h10 m0 0 h126 m20 44 h10 m24 0 h10 m-394 0 h20 m374 0 h20 m-414 0 q10 0 10 10 m394 0 q0 -10 10 -10 m-404 10 v14 m394 0 v-14 m-394 14 q0 10 10 10 m374 0 q10 0 10 -10 m-384 10 h10 m0 0 h364 m20 -34 h10 m78 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-545 82 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m168 0 h10 m0 0 h10 m116 0 h10 m0 0 h10 m126 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-234 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m48 0 h10 m0 0 h10 m128 0 h10 m-236 0 h20 m216 0 h20 m-256 0 q10 0 10 10 m236 0 q0 -10 10 -10 m-246 10 v24 m236 0 v-24 m-236 24 q0 10 10 10 m216 0 q10 0 10 -10 m-226 10 h10 m108 0 h10 m0 0 h88 m23 -44 h-3"/>
-   <polygon points="591 433 599 429 599 437"/>
-   <polygon points="591 433 583 429 583 437"/>
+         d="m17 17 h2 m0 0 h10 m74 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m78 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-349 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m80 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-355 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m24 0 h10 m20 0 h10 m80 0 h10 m-120 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m100 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-100 0 h10 m24 0 h10 m0 0 h56 m40 44 h10 m0 0 h164 m-194 0 h20 m174 0 h20 m-214 0 q10 0 10 10 m194 0 q0 -10 10 -10 m-204 10 v12 m194 0 v-12 m-194 12 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m24 0 h10 m0 0 h10 m110 0 h10 m20 -32 h10 m24 0 h10 m-462 0 h20 m442 0 h20 m-482 0 q10 0 10 10 m462 0 q0 -10 10 -10 m-472 10 v46 m462 0 v-46 m-462 46 q0 10 10 10 m442 0 q10 0 10 -10 m-452 10 h10 m0 0 h432 m20 -66 h10 m60 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-398 114 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m106 0 h10 m0 0 h10 m40 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-373 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m56 0 h10 m0 0 h10 m24 0 h10 m20 0 h10 m46 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m38 0 h10 m-190 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m170 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-170 0 h10 m24 0 h10 m0 0 h126 m20 44 h10 m24 0 h10 m-394 0 h20 m374 0 h20 m-414 0 q10 0 10 10 m394 0 q0 -10 10 -10 m-404 10 v14 m394 0 v-14 m-394 14 q0 10 10 10 m374 0 q10 0 10 -10 m-384 10 h10 m0 0 h364 m20 -34 h10 m78 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-515 82 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m168 0 h10 m0 0 h10 m116 0 h10 m0 0 h10 m126 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-240 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m48 0 h10 m0 0 h10 m128 0 h10 m-236 0 h20 m216 0 h20 m-256 0 q10 0 10 10 m236 0 q0 -10 10 -10 m-246 10 v24 m236 0 v-24 m-236 24 q0 10 10 10 m216 0 q10 0 10 -10 m-226 10 h10 m108 0 h10 m0 0 h88 m23 -44 h-3"/>
+   <polygon points="579 597 587 593 587 601"/>
+   <polygon points="579 597 571 593 571 601"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/create-source-s3-csv.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-source-s3-csv.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="583" height="753">
+<svg xmlns="http://www.w3.org/2000/svg" width="589" height="851">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="74" height="32" rx="10"/>
@@ -33,208 +33,219 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="431" y="53">IF NOT EXISTS</text>
-   <rect x="51" y="145" width="80" height="32"/>
-   <rect x="49" y="143" width="80" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="59" y="163">src_name</text>
-   <rect x="171" y="145" width="24" height="32" rx="10"/>
-   <rect x="169"
-         y="143"
+   <rect x="256" y="101" width="80" height="32"/>
+   <rect x="254" y="99" width="80" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="264" y="119">src_name</text>
+   <rect x="45" y="211" width="24" height="32" rx="10"/>
+   <rect x="43"
+         y="209"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="179" y="163">(</text>
-   <rect x="235" y="145" width="80" height="32"/>
-   <rect x="233" y="143" width="80" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="243" y="163">col_name</text>
-   <rect x="235" y="101" width="24" height="32" rx="10"/>
-   <rect x="233"
-         y="99"
+   <text class="terminal" x="53" y="229">(</text>
+   <rect x="109" y="211" width="80" height="32"/>
+   <rect x="107" y="209" width="80" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="117" y="229">col_name</text>
+   <rect x="109" y="167" width="24" height="32" rx="10"/>
+   <rect x="107"
+         y="165"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="243" y="119">,</text>
-   <rect x="355" y="145" width="24" height="32" rx="10"/>
-   <rect x="353"
-         y="143"
+   <text class="terminal" x="117" y="185">,</text>
+   <rect x="229" y="211" width="24" height="32" rx="10"/>
+   <rect x="227"
+         y="209"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="363" y="163">)</text>
-   <rect x="419" y="145" width="60" height="32" rx="10"/>
-   <rect x="417"
-         y="143"
+   <text class="terminal" x="237" y="229">)</text>
+   <rect x="293" y="243" width="24" height="32" rx="10"/>
+   <rect x="291"
+         y="241"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="301" y="261">,</text>
+   <rect x="337" y="243" width="110" height="32"/>
+   <rect x="335" y="241" width="110" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="345" y="261">key_constraint</text>
+   <rect x="507" y="211" width="60" height="32" rx="10"/>
+   <rect x="505"
+         y="209"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="427" y="163">FROM</text>
-   <rect x="499" y="145" width="36" height="32" rx="10"/>
-   <rect x="497"
-         y="143"
+   <text class="terminal" x="515" y="229">FROM</text>
+   <rect x="28" y="325" width="36" height="32" rx="10"/>
+   <rect x="26"
+         y="323"
          width="36"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="507" y="163">S3</text>
-   <rect x="53" y="227" width="158" height="32" rx="10"/>
-   <rect x="51"
-         y="225"
+   <text class="terminal" x="36" y="343">S3</text>
+   <rect x="84" y="325" width="158" height="32" rx="10"/>
+   <rect x="82"
+         y="323"
          width="158"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="61" y="245">DISCOVER OBJECTS</text>
-   <rect x="251" y="259" width="94" height="32" rx="10"/>
-   <rect x="249"
-         y="257"
+   <text class="terminal" x="92" y="343">DISCOVER OBJECTS</text>
+   <rect x="282" y="357" width="94" height="32" rx="10"/>
+   <rect x="280"
+         y="355"
          width="94"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="259" y="277">MATCHING</text>
-   <rect x="365" y="259" width="64" height="32"/>
-   <rect x="363" y="257" width="64" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="373" y="277">pattern</text>
-   <rect x="469" y="227" width="64" height="32" rx="10"/>
-   <rect x="467"
-         y="225"
+   <text class="terminal" x="290" y="375">MATCHING</text>
+   <rect x="396" y="357" width="64" height="32"/>
+   <rect x="394" y="355" width="64" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="404" y="375">pattern</text>
+   <rect x="500" y="325" width="64" height="32" rx="10"/>
+   <rect x="498"
+         y="323"
          width="64"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="477" y="245">USING</text>
-   <rect x="153" y="369" width="118" height="32" rx="10"/>
-   <rect x="151"
-         y="367"
+   <text class="terminal" x="508" y="343">USING</text>
+   <rect x="156" y="467" width="118" height="32" rx="10"/>
+   <rect x="154"
+         y="465"
          width="118"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="161" y="387">BUCKET SCAN</text>
-   <rect x="291" y="369" width="102" height="32"/>
-   <rect x="289" y="367" width="102" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="299" y="387">bucket_name</text>
-   <rect x="153" y="413" width="160" height="32" rx="10"/>
-   <rect x="151"
-         y="411"
+   <text class="terminal" x="164" y="485">BUCKET SCAN</text>
+   <rect x="294" y="467" width="102" height="32"/>
+   <rect x="292" y="465" width="102" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="302" y="485">bucket_name</text>
+   <rect x="156" y="511" width="160" height="32" rx="10"/>
+   <rect x="154"
+         y="509"
          width="160"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="161" y="431">SQS NOTIFICATIONS</text>
-   <rect x="333" y="413" width="100" height="32"/>
-   <rect x="331" y="411" width="100" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="341" y="431">queue_name</text>
-   <rect x="133" y="325" width="24" height="32" rx="10"/>
-   <rect x="131"
-         y="323"
+   <text class="terminal" x="164" y="529">SQS NOTIFICATIONS</text>
+   <rect x="336" y="511" width="100" height="32"/>
+   <rect x="334" y="509" width="100" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="344" y="529">queue_name</text>
+   <rect x="136" y="423" width="24" height="32" rx="10"/>
+   <rect x="134"
+         y="421"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="141" y="343">,</text>
-   <rect x="67" y="511" width="122" height="32" rx="10"/>
-   <rect x="65"
-         y="509"
+   <text class="terminal" x="144" y="441">,</text>
+   <rect x="70" y="609" width="122" height="32" rx="10"/>
+   <rect x="68"
+         y="607"
          width="122"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="75" y="529">COMPRESSION</text>
-   <rect x="229" y="511" width="60" height="32" rx="10"/>
-   <rect x="227"
-         y="509"
+   <text class="terminal" x="78" y="627">COMPRESSION</text>
+   <rect x="232" y="609" width="60" height="32" rx="10"/>
+   <rect x="230"
+         y="607"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="237" y="529">NONE</text>
-   <rect x="229" y="555" width="52" height="32" rx="10"/>
-   <rect x="227"
-         y="553"
+   <text class="terminal" x="240" y="627">NONE</text>
+   <rect x="232" y="653" width="52" height="32" rx="10"/>
+   <rect x="230"
+         y="651"
          width="52"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="237" y="573">GZIP</text>
-   <rect x="349" y="479" width="56" height="32" rx="10"/>
-   <rect x="347"
-         y="477"
+   <text class="terminal" x="240" y="671">GZIP</text>
+   <rect x="352" y="577" width="56" height="32" rx="10"/>
+   <rect x="350"
+         y="575"
          width="56"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="357" y="497">WITH</text>
-   <rect x="425" y="479" width="24" height="32" rx="10"/>
-   <rect x="423"
-         y="477"
+   <text class="terminal" x="360" y="595">WITH</text>
+   <rect x="428" y="577" width="24" height="32" rx="10"/>
+   <rect x="426"
+         y="575"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="433" y="497">(</text>
-   <rect x="469" y="479" width="70" height="32" rx="10"/>
-   <rect x="467"
-         y="477"
+   <text class="terminal" x="436" y="595">(</text>
+   <rect x="472" y="577" width="70" height="32" rx="10"/>
+   <rect x="470"
+         y="575"
          width="70"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="477" y="497">region =</text>
-   <rect x="32" y="621" width="58" height="32"/>
-   <rect x="30" y="619" width="58" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="40" y="639">region</text>
-   <rect x="130" y="653" width="118" height="32"/>
-   <rect x="128" y="651" width="118" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="138" y="671">aws_credentials</text>
-   <rect x="288" y="621" width="24" height="32" rx="10"/>
-   <rect x="286"
-         y="619"
+   <text class="terminal" x="480" y="595">region =</text>
+   <rect x="35" y="719" width="58" height="32"/>
+   <rect x="33" y="717" width="58" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="43" y="737">region</text>
+   <rect x="133" y="751" width="118" height="32"/>
+   <rect x="131" y="749" width="118" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="141" y="769">aws_credentials</text>
+   <rect x="291" y="719" width="24" height="32" rx="10"/>
+   <rect x="289"
+         y="717"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="296" y="639">)</text>
-   <rect x="332" y="621" width="78" height="32" rx="10"/>
-   <rect x="330"
-         y="619"
+   <text class="terminal" x="299" y="737">)</text>
+   <rect x="335" y="719" width="78" height="32" rx="10"/>
+   <rect x="333"
+         y="717"
          width="78"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="340" y="639">FORMAT</text>
-   <rect x="430" y="621" width="48" height="32" rx="10"/>
-   <rect x="428"
-         y="619"
+   <text class="terminal" x="343" y="737">FORMAT</text>
+   <rect x="433" y="719" width="48" height="32" rx="10"/>
+   <rect x="431"
+         y="717"
          width="48"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="438" y="639">CSV</text>
-   <rect x="498" y="621" width="56" height="32" rx="10"/>
-   <rect x="496"
-         y="619"
+   <text class="terminal" x="441" y="737">CSV</text>
+   <rect x="501" y="719" width="56" height="32" rx="10"/>
+   <rect x="499"
+         y="717"
          width="56"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="506" y="639">WITH</text>
-   <rect x="337" y="719" width="108" height="32"/>
-   <rect x="335" y="717" width="108" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="345" y="737">column_count</text>
-   <rect x="465" y="719" width="90" height="32" rx="10"/>
-   <rect x="463"
-         y="717"
+   <text class="terminal" x="509" y="737">WITH</text>
+   <rect x="343" y="817" width="108" height="32"/>
+   <rect x="341" y="815" width="108" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="351" y="835">column_count</text>
+   <rect x="471" y="817" width="90" height="32" rx="10"/>
+   <rect x="469"
+         y="815"
          width="90"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="473" y="737">COLUMNS</text>
+   <text class="terminal" x="479" y="835">COLUMNS</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m74 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m78 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-554 142 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m80 0 h10 m20 0 h10 m24 0 h10 m20 0 h10 m80 0 h10 m-120 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m100 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-100 0 h10 m24 0 h10 m0 0 h56 m20 44 h10 m24 0 h10 m-248 0 h20 m228 0 h20 m-268 0 q10 0 10 10 m248 0 q0 -10 10 -10 m-258 10 v14 m248 0 v-14 m-248 14 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m0 0 h218 m20 -34 h10 m60 0 h10 m0 0 h10 m36 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-526 82 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m158 0 h10 m20 0 h10 m0 0 h188 m-218 0 h20 m198 0 h20 m-238 0 q10 0 10 10 m218 0 q0 -10 10 -10 m-228 10 v12 m218 0 v-12 m-218 12 q0 10 10 10 m198 0 q10 0 10 -10 m-208 10 h10 m94 0 h10 m0 0 h10 m64 0 h10 m20 -32 h10 m64 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-464 142 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m118 0 h10 m0 0 h10 m102 0 h10 m0 0 h40 m-320 0 h20 m300 0 h20 m-340 0 q10 0 10 10 m320 0 q0 -10 10 -10 m-330 10 v24 m320 0 v-24 m-320 24 q0 10 10 10 m300 0 q10 0 10 -10 m-310 10 h10 m160 0 h10 m0 0 h10 m100 0 h10 m-340 -44 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m340 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-340 0 h10 m24 0 h10 m0 0 h296 m22 44 l2 0 m2 0 l2 0 m2 0 l2 0 m-470 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h252 m-282 0 h20 m262 0 h20 m-302 0 q10 0 10 10 m282 0 q0 -10 10 -10 m-292 10 v12 m282 0 v-12 m-282 12 q0 10 10 10 m262 0 q10 0 10 -10 m-272 10 h10 m122 0 h10 m20 0 h10 m60 0 h10 m-100 0 h20 m80 0 h20 m-120 0 q10 0 10 10 m100 0 q0 -10 10 -10 m-110 10 v24 m100 0 v-24 m-100 24 q0 10 10 10 m80 0 q10 0 10 -10 m-90 10 h10 m52 0 h10 m0 0 h8 m40 -76 h10 m56 0 h10 m0 0 h10 m24 0 h10 m0 0 h10 m70 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-551 142 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m58 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m20 -32 h10 m24 0 h10 m0 0 h10 m78 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m56 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-261 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m108 0 h10 m0 0 h10 m90 0 h10 m3 0 h-3"/>
-   <polygon points="573 733 581 729 581 737"/>
-   <polygon points="573 733 565 729 565 737"/>
+         d="m17 17 h2 m0 0 h10 m74 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m78 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-349 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m80 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-355 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m24 0 h10 m20 0 h10 m80 0 h10 m-120 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m100 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-100 0 h10 m24 0 h10 m0 0 h56 m20 44 h10 m24 0 h10 m20 0 h10 m0 0 h164 m-194 0 h20 m174 0 h20 m-214 0 q10 0 10 10 m194 0 q0 -10 10 -10 m-204 10 v12 m194 0 v-12 m-194 12 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m24 0 h10 m0 0 h10 m110 0 h10 m-442 -32 h20 m442 0 h20 m-482 0 q10 0 10 10 m462 0 q0 -10 10 -10 m-472 10 v46 m462 0 v-46 m-462 46 q0 10 10 10 m442 0 q10 0 10 -10 m-452 10 h10 m0 0 h432 m20 -66 h10 m60 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-583 114 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m36 0 h10 m0 0 h10 m158 0 h10 m20 0 h10 m0 0 h188 m-218 0 h20 m198 0 h20 m-238 0 q10 0 10 10 m218 0 q0 -10 10 -10 m-228 10 v12 m218 0 v-12 m-218 12 q0 10 10 10 m198 0 q10 0 10 -10 m-208 10 h10 m94 0 h10 m0 0 h10 m64 0 h10 m20 -32 h10 m64 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-492 142 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m118 0 h10 m0 0 h10 m102 0 h10 m0 0 h40 m-320 0 h20 m300 0 h20 m-340 0 q10 0 10 10 m320 0 q0 -10 10 -10 m-330 10 v24 m320 0 v-24 m-320 24 q0 10 10 10 m300 0 q10 0 10 -10 m-310 10 h10 m160 0 h10 m0 0 h10 m100 0 h10 m-340 -44 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m340 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-340 0 h10 m24 0 h10 m0 0 h296 m22 44 l2 0 m2 0 l2 0 m2 0 l2 0 m-470 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h252 m-282 0 h20 m262 0 h20 m-302 0 q10 0 10 10 m282 0 q0 -10 10 -10 m-292 10 v12 m282 0 v-12 m-282 12 q0 10 10 10 m262 0 q10 0 10 -10 m-272 10 h10 m122 0 h10 m20 0 h10 m60 0 h10 m-100 0 h20 m80 0 h20 m-120 0 q10 0 10 10 m100 0 q0 -10 10 -10 m-110 10 v24 m100 0 v-24 m-100 24 q0 10 10 10 m80 0 q10 0 10 -10 m-90 10 h10 m52 0 h10 m0 0 h8 m40 -76 h10 m56 0 h10 m0 0 h10 m24 0 h10 m0 0 h10 m70 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-551 142 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m58 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m20 -32 h10 m24 0 h10 m0 0 h10 m78 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m56 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-258 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m108 0 h10 m0 0 h10 m90 0 h10 m3 0 h-3"/>
+   <polygon points="579 831 587 827 587 835"/>
+   <polygon points="579 831 571 827 571 835"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/create-source-s3-text.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-source-s3-text.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="583" height="781">
+<svg xmlns="http://www.w3.org/2000/svg" width="589" height="939">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="74" height="32" rx="10"/>
@@ -33,181 +33,219 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="431" y="53">IF NOT EXISTS</text>
-   <rect x="96" y="101" width="80" height="32"/>
-   <rect x="94" y="99" width="80" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="104" y="119">src_name</text>
-   <rect x="196" y="101" width="60" height="32" rx="10"/>
-   <rect x="194"
-         y="99"
+   <rect x="256" y="101" width="80" height="32"/>
+   <rect x="254" y="99" width="80" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="264" y="119">src_name</text>
+   <rect x="45" y="211" width="24" height="32" rx="10"/>
+   <rect x="43"
+         y="209"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="229">(</text>
+   <rect x="109" y="211" width="80" height="32"/>
+   <rect x="107" y="209" width="80" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="117" y="229">col_name</text>
+   <rect x="109" y="167" width="24" height="32" rx="10"/>
+   <rect x="107"
+         y="165"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="117" y="185">,</text>
+   <rect x="249" y="243" width="24" height="32" rx="10"/>
+   <rect x="247"
+         y="241"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="257" y="261">,</text>
+   <rect x="293" y="243" width="110" height="32"/>
+   <rect x="291" y="241" width="110" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="301" y="261">key_constraint</text>
+   <rect x="443" y="211" width="24" height="32" rx="10"/>
+   <rect x="441"
+         y="209"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="451" y="229">)</text>
+   <rect x="507" y="211" width="60" height="32" rx="10"/>
+   <rect x="505"
+         y="209"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="204" y="119">FROM</text>
-   <rect x="276" y="101" width="36" height="32" rx="10"/>
-   <rect x="274"
-         y="99"
+   <text class="terminal" x="515" y="229">FROM</text>
+   <rect x="28" y="325" width="36" height="32" rx="10"/>
+   <rect x="26"
+         y="323"
          width="36"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="284" y="119">S3</text>
-   <rect x="332" y="101" width="158" height="32" rx="10"/>
-   <rect x="330"
-         y="99"
+   <text class="terminal" x="36" y="343">S3</text>
+   <rect x="84" y="325" width="158" height="32" rx="10"/>
+   <rect x="82"
+         y="323"
          width="158"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="340" y="119">DISCOVER OBJECTS</text>
-   <rect x="162" y="199" width="94" height="32" rx="10"/>
-   <rect x="160"
-         y="197"
+   <text class="terminal" x="92" y="343">DISCOVER OBJECTS</text>
+   <rect x="282" y="357" width="94" height="32" rx="10"/>
+   <rect x="280"
+         y="355"
          width="94"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="170" y="217">MATCHING</text>
-   <rect x="276" y="199" width="64" height="32"/>
-   <rect x="274" y="197" width="64" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="284" y="217">pattern</text>
-   <rect x="380" y="167" width="64" height="32" rx="10"/>
-   <rect x="378"
-         y="165"
+   <text class="terminal" x="290" y="375">MATCHING</text>
+   <rect x="396" y="357" width="64" height="32"/>
+   <rect x="394" y="355" width="64" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="404" y="375">pattern</text>
+   <rect x="500" y="325" width="64" height="32" rx="10"/>
+   <rect x="498"
+         y="323"
          width="64"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="388" y="185">USING</text>
-   <rect x="153" y="309" width="118" height="32" rx="10"/>
-   <rect x="151"
-         y="307"
+   <text class="terminal" x="508" y="343">USING</text>
+   <rect x="156" y="467" width="118" height="32" rx="10"/>
+   <rect x="154"
+         y="465"
          width="118"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="161" y="327">BUCKET SCAN</text>
-   <rect x="291" y="309" width="102" height="32"/>
-   <rect x="289" y="307" width="102" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="299" y="327">bucket_name</text>
-   <rect x="153" y="353" width="160" height="32" rx="10"/>
-   <rect x="151"
-         y="351"
+   <text class="terminal" x="164" y="485">BUCKET SCAN</text>
+   <rect x="294" y="467" width="102" height="32"/>
+   <rect x="292" y="465" width="102" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="302" y="485">bucket_name</text>
+   <rect x="156" y="511" width="160" height="32" rx="10"/>
+   <rect x="154"
+         y="509"
          width="160"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="161" y="371">SQS NOTIFICATIONS</text>
-   <rect x="333" y="353" width="100" height="32"/>
-   <rect x="331" y="351" width="100" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="341" y="371">queue_name</text>
-   <rect x="133" y="265" width="24" height="32" rx="10"/>
-   <rect x="131"
-         y="263"
+   <text class="terminal" x="164" y="529">SQS NOTIFICATIONS</text>
+   <rect x="336" y="511" width="100" height="32"/>
+   <rect x="334" y="509" width="100" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="344" y="529">queue_name</text>
+   <rect x="136" y="423" width="24" height="32" rx="10"/>
+   <rect x="134"
+         y="421"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="141" y="283">,</text>
-   <rect x="67" y="451" width="122" height="32" rx="10"/>
-   <rect x="65"
-         y="449"
+   <text class="terminal" x="144" y="441">,</text>
+   <rect x="70" y="609" width="122" height="32" rx="10"/>
+   <rect x="68"
+         y="607"
          width="122"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="75" y="469">COMPRESSION</text>
-   <rect x="229" y="451" width="60" height="32" rx="10"/>
-   <rect x="227"
-         y="449"
+   <text class="terminal" x="78" y="627">COMPRESSION</text>
+   <rect x="232" y="609" width="60" height="32" rx="10"/>
+   <rect x="230"
+         y="607"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="237" y="469">NONE</text>
-   <rect x="229" y="495" width="52" height="32" rx="10"/>
-   <rect x="227"
-         y="493"
+   <text class="terminal" x="240" y="627">NONE</text>
+   <rect x="232" y="653" width="52" height="32" rx="10"/>
+   <rect x="230"
+         y="651"
          width="52"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="237" y="513">GZIP</text>
-   <rect x="349" y="419" width="56" height="32" rx="10"/>
-   <rect x="347"
-         y="417"
+   <text class="terminal" x="240" y="671">GZIP</text>
+   <rect x="352" y="577" width="56" height="32" rx="10"/>
+   <rect x="350"
+         y="575"
          width="56"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="357" y="437">WITH</text>
-   <rect x="425" y="419" width="24" height="32" rx="10"/>
-   <rect x="423"
-         y="417"
+   <text class="terminal" x="360" y="595">WITH</text>
+   <rect x="428" y="577" width="24" height="32" rx="10"/>
+   <rect x="426"
+         y="575"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="433" y="437">(</text>
-   <rect x="469" y="419" width="70" height="32" rx="10"/>
-   <rect x="467"
-         y="417"
+   <text class="terminal" x="436" y="595">(</text>
+   <rect x="472" y="577" width="70" height="32" rx="10"/>
+   <rect x="470"
+         y="575"
          width="70"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="477" y="437">region =</text>
-   <rect x="104" y="561" width="58" height="32"/>
-   <rect x="102" y="559" width="58" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="112" y="579">region</text>
-   <rect x="202" y="593" width="118" height="32"/>
-   <rect x="200" y="591" width="118" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="210" y="611">aws_credentials</text>
-   <rect x="360" y="561" width="24" height="32" rx="10"/>
-   <rect x="358"
-         y="559"
+   <text class="terminal" x="480" y="595">region =</text>
+   <rect x="107" y="719" width="58" height="32"/>
+   <rect x="105" y="717" width="58" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="115" y="737">region</text>
+   <rect x="205" y="751" width="118" height="32"/>
+   <rect x="203" y="749" width="118" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="213" y="769">aws_credentials</text>
+   <rect x="363" y="719" width="24" height="32" rx="10"/>
+   <rect x="361"
+         y="717"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="368" y="579">)</text>
-   <rect x="404" y="561" width="78" height="32" rx="10"/>
-   <rect x="402"
-         y="559"
+   <text class="terminal" x="371" y="737">)</text>
+   <rect x="407" y="719" width="78" height="32" rx="10"/>
+   <rect x="405"
+         y="717"
          width="78"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="412" y="579">FORMAT</text>
-   <rect x="395" y="659" width="66" height="32" rx="10"/>
-   <rect x="393"
-         y="657"
+   <text class="terminal" x="415" y="737">FORMAT</text>
+   <rect x="401" y="817" width="66" height="32" rx="10"/>
+   <rect x="399"
+         y="815"
          width="66"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="403" y="677">REGEX</text>
-   <rect x="481" y="659" width="54" height="32"/>
-   <rect x="479" y="657" width="54" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="489" y="677">regex</text>
-   <rect x="395" y="703" width="54" height="32" rx="10"/>
-   <rect x="393"
-         y="701"
+   <text class="terminal" x="409" y="835">REGEX</text>
+   <rect x="487" y="817" width="54" height="32"/>
+   <rect x="485" y="815" width="54" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="495" y="835">regex</text>
+   <rect x="401" y="861" width="54" height="32" rx="10"/>
+   <rect x="399"
+         y="859"
          width="54"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="403" y="721">TEXT</text>
-   <rect x="395" y="747" width="64" height="32" rx="10"/>
-   <rect x="393"
-         y="745"
+   <text class="terminal" x="409" y="879">TEXT</text>
+   <rect x="401" y="905" width="64" height="32" rx="10"/>
+   <rect x="399"
+         y="903"
          width="64"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="403" y="765">BYTES</text>
+   <text class="terminal" x="409" y="923">BYTES</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m74 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m78 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-509 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m80 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m36 0 h10 m0 0 h10 m158 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-392 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h188 m-218 0 h20 m198 0 h20 m-238 0 q10 0 10 10 m218 0 q0 -10 10 -10 m-228 10 v12 m218 0 v-12 m-218 12 q0 10 10 10 m198 0 q10 0 10 -10 m-208 10 h10 m94 0 h10 m0 0 h10 m64 0 h10 m20 -32 h10 m64 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-375 142 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m118 0 h10 m0 0 h10 m102 0 h10 m0 0 h40 m-320 0 h20 m300 0 h20 m-340 0 q10 0 10 10 m320 0 q0 -10 10 -10 m-330 10 v24 m320 0 v-24 m-320 24 q0 10 10 10 m300 0 q10 0 10 -10 m-310 10 h10 m160 0 h10 m0 0 h10 m100 0 h10 m-340 -44 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m340 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-340 0 h10 m24 0 h10 m0 0 h296 m22 44 l2 0 m2 0 l2 0 m2 0 l2 0 m-470 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h252 m-282 0 h20 m262 0 h20 m-302 0 q10 0 10 10 m282 0 q0 -10 10 -10 m-292 10 v12 m282 0 v-12 m-282 12 q0 10 10 10 m262 0 q10 0 10 -10 m-272 10 h10 m122 0 h10 m20 0 h10 m60 0 h10 m-100 0 h20 m80 0 h20 m-120 0 q10 0 10 10 m100 0 q0 -10 10 -10 m-110 10 v24 m100 0 v-24 m-100 24 q0 10 10 10 m80 0 q10 0 10 -10 m-90 10 h10 m52 0 h10 m0 0 h8 m40 -76 h10 m56 0 h10 m0 0 h10 m24 0 h10 m0 0 h10 m70 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-479 142 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m58 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m20 -32 h10 m24 0 h10 m0 0 h10 m78 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-151 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m66 0 h10 m0 0 h10 m54 0 h10 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m54 0 h10 m0 0 h86 m-170 -10 v20 m180 0 v-20 m-180 20 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m64 0 h10 m0 0 h76 m23 -88 h-3"/>
-   <polygon points="573 673 581 669 581 677"/>
-   <polygon points="573 673 565 669 565 677"/>
+         d="m17 17 h2 m0 0 h10 m74 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m78 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-349 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m80 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-355 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m24 0 h10 m20 0 h10 m80 0 h10 m-120 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m100 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-100 0 h10 m24 0 h10 m0 0 h56 m40 44 h10 m0 0 h164 m-194 0 h20 m174 0 h20 m-214 0 q10 0 10 10 m194 0 q0 -10 10 -10 m-204 10 v12 m194 0 v-12 m-194 12 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m24 0 h10 m0 0 h10 m110 0 h10 m20 -32 h10 m24 0 h10 m-462 0 h20 m442 0 h20 m-482 0 q10 0 10 10 m462 0 q0 -10 10 -10 m-472 10 v46 m462 0 v-46 m-462 46 q0 10 10 10 m442 0 q10 0 10 -10 m-452 10 h10 m0 0 h432 m20 -66 h10 m60 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-583 114 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m36 0 h10 m0 0 h10 m158 0 h10 m20 0 h10 m0 0 h188 m-218 0 h20 m198 0 h20 m-238 0 q10 0 10 10 m218 0 q0 -10 10 -10 m-228 10 v12 m218 0 v-12 m-218 12 q0 10 10 10 m198 0 q10 0 10 -10 m-208 10 h10 m94 0 h10 m0 0 h10 m64 0 h10 m20 -32 h10 m64 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-492 142 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m118 0 h10 m0 0 h10 m102 0 h10 m0 0 h40 m-320 0 h20 m300 0 h20 m-340 0 q10 0 10 10 m320 0 q0 -10 10 -10 m-330 10 v24 m320 0 v-24 m-320 24 q0 10 10 10 m300 0 q10 0 10 -10 m-310 10 h10 m160 0 h10 m0 0 h10 m100 0 h10 m-340 -44 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m340 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-340 0 h10 m24 0 h10 m0 0 h296 m22 44 l2 0 m2 0 l2 0 m2 0 l2 0 m-470 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h252 m-282 0 h20 m262 0 h20 m-302 0 q10 0 10 10 m282 0 q0 -10 10 -10 m-292 10 v12 m282 0 v-12 m-282 12 q0 10 10 10 m262 0 q10 0 10 -10 m-272 10 h10 m122 0 h10 m20 0 h10 m60 0 h10 m-100 0 h20 m80 0 h20 m-120 0 q10 0 10 10 m100 0 q0 -10 10 -10 m-110 10 v24 m100 0 v-24 m-100 24 q0 10 10 10 m80 0 q10 0 10 -10 m-90 10 h10 m52 0 h10 m0 0 h8 m40 -76 h10 m56 0 h10 m0 0 h10 m24 0 h10 m0 0 h10 m70 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-479 142 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m58 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m20 -32 h10 m24 0 h10 m0 0 h10 m78 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-148 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m66 0 h10 m0 0 h10 m54 0 h10 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m54 0 h10 m0 0 h86 m-170 -10 v20 m180 0 v-20 m-180 20 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m64 0 h10 m0 0 h76 m23 -88 h-3"/>
+   <polygon points="579 831 587 827 587 835"/>
+   <polygon points="579 831 571 827 571 835"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/create-source-text.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-source-text.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="583" height="617">
+<svg xmlns="http://www.w3.org/2000/svg" width="589" height="715">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="74" height="32" rx="10"/>
@@ -33,162 +33,173 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="431" y="53">IF NOT EXISTS</text>
-   <rect x="45" y="145" width="80" height="32"/>
-   <rect x="43" y="143" width="80" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="53" y="163">src_name</text>
-   <rect x="165" y="145" width="24" height="32" rx="10"/>
-   <rect x="163"
-         y="143"
+   <rect x="256" y="101" width="80" height="32"/>
+   <rect x="254" y="99" width="80" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="264" y="119">src_name</text>
+   <rect x="45" y="211" width="24" height="32" rx="10"/>
+   <rect x="43"
+         y="209"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="173" y="163">(</text>
-   <rect x="229" y="145" width="80" height="32"/>
-   <rect x="227" y="143" width="80" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="237" y="163">col_name</text>
-   <rect x="229" y="101" width="24" height="32" rx="10"/>
-   <rect x="227"
-         y="99"
+   <text class="terminal" x="53" y="229">(</text>
+   <rect x="109" y="211" width="80" height="32"/>
+   <rect x="107" y="209" width="80" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="117" y="229">col_name</text>
+   <rect x="109" y="167" width="24" height="32" rx="10"/>
+   <rect x="107"
+         y="165"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="237" y="119">,</text>
-   <rect x="349" y="145" width="24" height="32" rx="10"/>
-   <rect x="347"
-         y="143"
+   <text class="terminal" x="117" y="185">,</text>
+   <rect x="249" y="243" width="24" height="32" rx="10"/>
+   <rect x="247"
+         y="241"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="357" y="163">)</text>
-   <rect x="413" y="145" width="60" height="32" rx="10"/>
-   <rect x="411"
-         y="143"
+   <text class="terminal" x="257" y="261">,</text>
+   <rect x="293" y="243" width="110" height="32"/>
+   <rect x="291" y="241" width="110" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="301" y="261">key_constraint</text>
+   <rect x="443" y="211" width="24" height="32" rx="10"/>
+   <rect x="441"
+         y="209"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="451" y="229">)</text>
+   <rect x="507" y="211" width="60" height="32" rx="10"/>
+   <rect x="505"
+         y="209"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="421" y="163">FROM</text>
-   <rect x="493" y="145" width="48" height="32" rx="10"/>
-   <rect x="491"
-         y="143"
+   <text class="terminal" x="515" y="229">FROM</text>
+   <rect x="87" y="325" width="48" height="32" rx="10"/>
+   <rect x="85"
+         y="323"
          width="48"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="501" y="163">FILE</text>
-   <rect x="118" y="227" width="48" height="32"/>
-   <rect x="116" y="225" width="48" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="126" y="245">path</text>
-   <rect x="206" y="259" width="122" height="32" rx="10"/>
-   <rect x="204"
-         y="257"
+   <text class="terminal" x="95" y="343">FILE</text>
+   <rect x="155" y="325" width="48" height="32"/>
+   <rect x="153" y="323" width="48" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="163" y="343">path</text>
+   <rect x="243" y="357" width="122" height="32" rx="10"/>
+   <rect x="241"
+         y="355"
          width="122"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="214" y="277">COMPRESSION</text>
-   <rect x="368" y="259" width="60" height="32" rx="10"/>
-   <rect x="366"
-         y="257"
+   <text class="terminal" x="251" y="375">COMPRESSION</text>
+   <rect x="405" y="357" width="60" height="32" rx="10"/>
+   <rect x="403"
+         y="355"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="376" y="277">NONE</text>
-   <rect x="368" y="303" width="52" height="32" rx="10"/>
-   <rect x="366"
-         y="301"
+   <text class="terminal" x="413" y="375">NONE</text>
+   <rect x="405" y="401" width="52" height="32" rx="10"/>
+   <rect x="403"
+         y="399"
          width="52"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="376" y="321">GZIP</text>
-   <rect x="67" y="413" width="56" height="32" rx="10"/>
-   <rect x="65"
-         y="411"
+   <text class="terminal" x="413" y="419">GZIP</text>
+   <rect x="70" y="511" width="56" height="32" rx="10"/>
+   <rect x="68"
+         y="509"
          width="56"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="75" y="431">WITH</text>
-   <rect x="143" y="413" width="24" height="32" rx="10"/>
-   <rect x="141"
-         y="411"
+   <text class="terminal" x="78" y="529">WITH</text>
+   <rect x="146" y="511" width="24" height="32" rx="10"/>
+   <rect x="144"
+         y="509"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="151" y="431">(</text>
-   <rect x="207" y="413" width="46" height="32"/>
-   <rect x="205" y="411" width="46" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="215" y="431">field</text>
-   <rect x="273" y="413" width="26" height="32" rx="10"/>
-   <rect x="271"
-         y="411"
+   <text class="terminal" x="154" y="529">(</text>
+   <rect x="210" y="511" width="46" height="32"/>
+   <rect x="208" y="509" width="46" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="218" y="529">field</text>
+   <rect x="276" y="511" width="26" height="32" rx="10"/>
+   <rect x="274"
+         y="509"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="281" y="431">=</text>
-   <rect x="319" y="413" width="38" height="32"/>
-   <rect x="317" y="411" width="38" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="327" y="431">val</text>
-   <rect x="207" y="369" width="24" height="32" rx="10"/>
-   <rect x="205"
-         y="367"
+   <text class="terminal" x="284" y="529">=</text>
+   <rect x="322" y="511" width="38" height="32"/>
+   <rect x="320" y="509" width="38" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="330" y="529">val</text>
+   <rect x="210" y="467" width="24" height="32" rx="10"/>
+   <rect x="208"
+         y="465"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="215" y="387">,</text>
-   <rect x="397" y="413" width="24" height="32" rx="10"/>
-   <rect x="395"
-         y="411"
+   <text class="terminal" x="218" y="485">,</text>
+   <rect x="400" y="511" width="24" height="32" rx="10"/>
+   <rect x="398"
+         y="509"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="405" y="431">)</text>
-   <rect x="461" y="413" width="78" height="32" rx="10"/>
-   <rect x="459"
-         y="411"
+   <text class="terminal" x="408" y="529">)</text>
+   <rect x="464" y="511" width="78" height="32" rx="10"/>
+   <rect x="462"
+         y="509"
          width="78"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="469" y="431">FORMAT</text>
-   <rect x="395" y="495" width="66" height="32" rx="10"/>
-   <rect x="393"
-         y="493"
+   <text class="terminal" x="472" y="529">FORMAT</text>
+   <rect x="401" y="593" width="66" height="32" rx="10"/>
+   <rect x="399"
+         y="591"
          width="66"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="403" y="513">REGEX</text>
-   <rect x="481" y="495" width="54" height="32"/>
-   <rect x="479" y="493" width="54" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="489" y="513">regex</text>
-   <rect x="395" y="539" width="54" height="32" rx="10"/>
-   <rect x="393"
-         y="537"
+   <text class="terminal" x="409" y="611">REGEX</text>
+   <rect x="487" y="593" width="54" height="32"/>
+   <rect x="485" y="591" width="54" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="495" y="611">regex</text>
+   <rect x="401" y="637" width="54" height="32" rx="10"/>
+   <rect x="399"
+         y="635"
          width="54"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="403" y="557">TEXT</text>
-   <rect x="395" y="583" width="64" height="32" rx="10"/>
-   <rect x="393"
-         y="581"
+   <text class="terminal" x="409" y="655">TEXT</text>
+   <rect x="401" y="681" width="64" height="32" rx="10"/>
+   <rect x="399"
+         y="679"
          width="64"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="403" y="601">BYTES</text>
+   <text class="terminal" x="409" y="699">BYTES</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m74 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m78 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-560 142 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m80 0 h10 m20 0 h10 m24 0 h10 m20 0 h10 m80 0 h10 m-120 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m100 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-100 0 h10 m24 0 h10 m0 0 h56 m20 44 h10 m24 0 h10 m-248 0 h20 m228 0 h20 m-268 0 q10 0 10 10 m248 0 q0 -10 10 -10 m-258 10 v14 m248 0 v-14 m-248 14 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m0 0 h218 m20 -34 h10 m60 0 h10 m0 0 h10 m48 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-467 82 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m48 0 h10 m20 0 h10 m0 0 h252 m-282 0 h20 m262 0 h20 m-302 0 q10 0 10 10 m282 0 q0 -10 10 -10 m-292 10 v12 m282 0 v-12 m-282 12 q0 10 10 10 m262 0 q10 0 10 -10 m-272 10 h10 m122 0 h10 m20 0 h10 m60 0 h10 m-100 0 h20 m80 0 h20 m-120 0 q10 0 10 10 m100 0 q0 -10 10 -10 m-110 10 v24 m100 0 v-24 m-100 24 q0 10 10 10 m80 0 q10 0 10 -10 m-90 10 h10 m52 0 h10 m0 0 h8 m42 -76 l2 0 m2 0 l2 0 m2 0 l2 0 m-465 186 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m56 0 h10 m0 0 h10 m24 0 h10 m20 0 h10 m46 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m38 0 h10 m-190 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m170 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-170 0 h10 m24 0 h10 m0 0 h126 m20 44 h10 m24 0 h10 m-394 0 h20 m374 0 h20 m-414 0 q10 0 10 10 m394 0 q0 -10 10 -10 m-404 10 v14 m394 0 v-14 m-394 14 q0 10 10 10 m374 0 q10 0 10 -10 m-384 10 h10 m0 0 h364 m20 -34 h10 m78 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-208 82 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m66 0 h10 m0 0 h10 m54 0 h10 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m54 0 h10 m0 0 h86 m-170 -10 v20 m180 0 v-20 m-180 20 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m64 0 h10 m0 0 h76 m23 -88 h-3"/>
-   <polygon points="573 509 581 505 581 513"/>
-   <polygon points="573 509 565 505 565 513"/>
+         d="m17 17 h2 m0 0 h10 m74 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m78 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-349 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m80 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-355 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m24 0 h10 m20 0 h10 m80 0 h10 m-120 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m100 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-100 0 h10 m24 0 h10 m0 0 h56 m40 44 h10 m0 0 h164 m-194 0 h20 m174 0 h20 m-214 0 q10 0 10 10 m194 0 q0 -10 10 -10 m-204 10 v12 m194 0 v-12 m-194 12 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m24 0 h10 m0 0 h10 m110 0 h10 m20 -32 h10 m24 0 h10 m-462 0 h20 m442 0 h20 m-482 0 q10 0 10 10 m462 0 q0 -10 10 -10 m-472 10 v46 m462 0 v-46 m-462 46 q0 10 10 10 m442 0 q10 0 10 -10 m-452 10 h10 m0 0 h432 m20 -66 h10 m60 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-524 114 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m48 0 h10 m0 0 h10 m48 0 h10 m20 0 h10 m0 0 h252 m-282 0 h20 m262 0 h20 m-302 0 q10 0 10 10 m282 0 q0 -10 10 -10 m-292 10 v12 m282 0 v-12 m-282 12 q0 10 10 10 m262 0 q10 0 10 -10 m-272 10 h10 m122 0 h10 m20 0 h10 m60 0 h10 m-100 0 h20 m80 0 h20 m-120 0 q10 0 10 10 m100 0 q0 -10 10 -10 m-110 10 v24 m100 0 v-24 m-100 24 q0 10 10 10 m80 0 q10 0 10 -10 m-90 10 h10 m52 0 h10 m0 0 h8 m42 -76 l2 0 m2 0 l2 0 m2 0 l2 0 m-499 186 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m56 0 h10 m0 0 h10 m24 0 h10 m20 0 h10 m46 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m38 0 h10 m-190 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m170 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-170 0 h10 m24 0 h10 m0 0 h126 m20 44 h10 m24 0 h10 m-394 0 h20 m374 0 h20 m-414 0 q10 0 10 10 m394 0 q0 -10 10 -10 m-404 10 v14 m394 0 v-14 m-394 14 q0 10 10 10 m374 0 q10 0 10 -10 m-384 10 h10 m0 0 h364 m20 -34 h10 m78 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-205 82 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m66 0 h10 m0 0 h10 m54 0 h10 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m54 0 h10 m0 0 h86 m-170 -10 v20 m180 0 v-20 m-180 20 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m64 0 h10 m0 0 h76 m23 -88 h-3"/>
+   <polygon points="579 607 587 603 587 611"/>
+   <polygon points="579 607 571 603 571 611"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/key-constraint.svg
+++ b/doc/user/layouts/partials/sql-grammar/key-constraint.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="549" height="81">
+   <polygon points="9 61 1 57 1 65"/>
+   <polygon points="17 61 9 57 9 65"/>
+   <rect x="31" y="47" width="112" height="32" rx="10"/>
+   <rect x="29"
+         y="45"
+         width="112"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="65">PRIMARY KEY</text>
+   <rect x="163" y="47" width="24" height="32" rx="10"/>
+   <rect x="161"
+         y="45"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="171" y="65">(</text>
+   <rect x="227" y="47" width="80" height="32"/>
+   <rect x="225" y="45" width="80" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="235" y="65">col_name</text>
+   <rect x="227" y="3" width="24" height="32" rx="10"/>
+   <rect x="225"
+         y="1"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="235" y="21">,</text>
+   <rect x="347" y="47" width="24" height="32" rx="10"/>
+   <rect x="345"
+         y="45"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="355" y="65">)</text>
+   <rect x="391" y="47" width="130" height="32" rx="10"/>
+   <rect x="389"
+         y="45"
+         width="130"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="399" y="65">NOT ENFORCED</text>
+   <path class="line"
+         d="m17 61 h2 m0 0 h10 m112 0 h10 m0 0 h10 m24 0 h10 m20 0 h10 m80 0 h10 m-120 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m100 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-100 0 h10 m24 0 h10 m0 0 h56 m20 44 h10 m24 0 h10 m0 0 h10 m130 0 h10 m3 0 h-3"/>
+   <polygon points="539 61 547 57 547 65"/>
+   <polygon points="539 61 531 57 531 65"/>
+</svg>

--- a/doc/user/layouts/shortcodes/create-source/syntax-details.html
+++ b/doc/user/layouts/shortcodes/create-source/syntax-details.html
@@ -1,6 +1,7 @@
 {{ $connector := .Get "connector" }}
 {{ $formats := split ( .Get "formats" ) " " }}
 {{ $envelopes := split ( .Get "envelopes" ) " " }}
+{{ $keyConstraint := .Get "keyConstraint" }}
 
 Field | Use
 ------|-----
@@ -11,6 +12,7 @@ _col&lowbar;name_ | Override default column name with the provided [identifier](
 **WITH (** _option&lowbar;list_ **)** | Options affecting source creation. For more detail, see [`WITH` options](#with-options).
 {{ range $formats }}{{ partial (printf "create-source/format/%s/syntax" .) . }}{{ end -}}
 {{ range $envelopes }}{{ partial (printf "create-source/envelope/%s/syntax" .) . }}{{ end -}}
+{{ if $keyConstraint }}{{ partial "create-source/key-constraint/syntax" . }}{{ end -}}
 
 ### `WITH` options
 
@@ -52,3 +54,5 @@ footprint](/sql/create-index/#memory-footprint).
 {{ range $formats }}{{ partial (printf "create-source/format/%s/details" .) . }}{{ end -}}
 
 {{ range $envelopes }}{{ partial (printf "create-source/envelope/%s/details" .) . }}{{ end -}}
+
+{{ if $keyConstraint }}{{ partial "create-source/key-constraint/details" . }}{{ end -}}

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -48,12 +48,12 @@ create_sink ::=
    ('AS OF' timestamp_expression)?
 create_source_avro_file ::=
   'CREATE' 'MATERIALIZED'? 'SOURCE' ('IF NOT EXISTS')? src_name
-  ('(' (col_name) ( ( ',' col_name ) )* ')')?
+  ('(' (col_name) ( ( ',' col_name ) )* ( ',' key_constraint )? ')')?
   'FROM' 'AVRO OCF' path ('WITH' '(' ( field '=' val ) ( ( ',' field '=' val ) )* ')')?
   ('ENVELOPE' ('NONE'|'DEBEZIUM'))?
 create_source_avro_kafka ::=
   'CREATE' 'MATERIALIZED'? 'SOURCE' ('IF NOT EXISTS')? src_name
-  ('(' (col_name) ( ( ',' col_name ) )* ')')?
+  ('(' (col_name) ( ( ',' col_name ) )* ( ',' key_constraint )? ')')?
   'FROM' 'KAFKA BROKER' host 'TOPIC' topic
   ('WITH' '(' ( field '=' val ) ( ( ',' field '=' val ) )* ')')?
   'FORMAT' format_spec
@@ -66,7 +66,7 @@ create_source ::=
   ('ENVELOPE' ('NONE'|'DEBEZIUM'))?
 create_source_csv_file ::=
   'CREATE' 'MATERIALIZED'? 'SOURCE' ('IF NOT EXISTS')? src_name
-  ('(' (col_name) ( ( ',' col_name ) )* ')')?
+  ('(' (col_name) ( ( ',' col_name ) )* ( ',' key_constraint )? ')')?
   'FROM' 'FILE' path ('COMPRESSION' ('NONE' | 'GZIP'))? ('WITH' '(' ( field '=' val ) ( ( ',' field '=' val ) )* ')')?
   'FORMAT' 'CSV WITH' ( 'HEADER' | n 'COLUMNS')
   ('DELIMITED BY' char)?
@@ -77,14 +77,14 @@ create_source_json ::=
   'FORMAT' 'BYTES'
 create_source_csv_kafka ::=
   'CREATE' 'MATERIALIZED'? 'SOURCE' ('IF NOT EXISTS')? src_name
-  ('(' (col_name) ( ( ',' col_name ) )* ')')?
+  ('(' (col_name) ( ( ',' col_name ) )* ( ',' key_constraint )? ')')?
   'FROM' 'KAFKA BROKER' host 'TOPIC' topic?
   ('WITH' '(' ( field '=' val ) ( ( ',' field '=' val ) )* ')')?
   'FORMAT' 'CSV WITH' ( 'HEADER' | n 'COLUMNS')
   ('DELIMITED BY' char)?
 create_source_csv_kinesis ::=
   'CREATE' 'MATERIALIZED'? 'SOURCE' ('IF NOT EXISTS')? src_name
-  ('(' (col_name) ( ( ',' col_name ) )* ')')?
+  ('(' (col_name) ( ( ',' col_name ) )* ( ',' key_constraint )? ')')?
   'FROM' 'KINESIS ARN' arn ('WITH' '(' ( field '=' val ) ( ( ',' field '=' val ) )* ')')?
   'FORMAT' 'CSV WITH' ( 'HEADER' | n 'COLUMNS')
   ('DELIMITED BY' char)?
@@ -106,14 +106,14 @@ create_source_postgres ::=
   'PUBLICATION' 'publication_name'
 create_source_protobuf_kafka ::=
   'CREATE' 'MATERIALIZED'? 'SOURCE' ('IF NOT EXISTS')? src_name
-  ('(' (col_name) ( ( ',' col_name ) )* ')')?
+  ('(' (col_name) ( ( ',' col_name ) )* ( ',' key_constraint )? ')')?
   'FROM' 'KAFKA BROKER' host 'TOPIC' topic?
   ('WITH' '(' ( field '=' val ) ( ( ',' field '=' val ) )* ')')?
   'FORMAT' 'PROTOBUF MESSAGE' message_name
   'USING SCHEMA' ('FILE' schema_file_path | inline_schema)
 create_source_protobuf_kinesis ::=
   'CREATE' 'MATERIALIZED'? 'SOURCE' ('IF NOT EXISTS')? src_name
-  ('(' (col_name) ( ( ',' col_name ) )* ')')?
+  ('(' (col_name) ( ( ',' col_name ) )* ( ',' key_constraint )? ')')?
   'FROM' 'KINESIS ARN' arn ('WITH' '(' ( field '=' val ) ( ( ',' field '=' val ) )* ')')?
   'FORMAT' 'PROTOBUF MESSAGE' message_name
   'USING SCHEMA' ('FILE' schema_file_path | inline_schema)
@@ -125,6 +125,7 @@ create_source_pubnub_text ::=
   ('ENVELOPE' 'NONE')?
 create_source_s3_text ::=
   'CREATE' 'MATERIALIZED'? 'SOURCE' ('IF NOT EXISTS')? src_name
+  ('(' (col_name) ( ( ',' col_name ) )* ( ',' key_constraint )? ')')?
   'FROM' 'S3' 'DISCOVER OBJECTS'
   ('MATCHING' pattern)?
   'USING' (
@@ -165,7 +166,7 @@ create_source_s3_json ::=
   'FORMAT' ('TEXT' | 'BYTES')
 create_source_s3_csv ::=
   'CREATE' 'MATERIALIZED'? 'SOURCE' ('IF NOT EXISTS')?
-  src_name ( '(' col_name (',' col_name)* ')' )?
+  src_name ( '(' col_name (',' col_name)* ')' ( ',' key_constraint )? )?
   'FROM' 'S3' 'DISCOVER OBJECTS'
   ('MATCHING' pattern)?
   'USING' (
@@ -184,7 +185,7 @@ create_source_s3_csv ::=
   'FORMAT' 'CSV' 'WITH' column_count 'COLUMNS'
 create_source_text ::=
   'CREATE' 'MATERIALIZED'? 'SOURCE' ('IF NOT EXISTS')? src_name
-  ('(' (col_name) ( ( ',' col_name ) )* ')')?
+  ('(' (col_name) ( ( ',' col_name ) )* ( ',' key_constraint )? ')')?
   'FROM' 'FILE' path ('COMPRESSION' ('NONE' | 'GZIP'))? ('WITH' '(' ( field '=' val ) ( ( ',' field '=' val ) )* ')')?
   'FORMAT' (
     'REGEX' regex |
@@ -283,6 +284,7 @@ format_spec ::=
   'CSV WITH' n 'COLUMNS' ('DELIMITED BY' char)? |
   'TEXT' |
   'BYTES'
+key_constraint ::= ('PRIMARY KEY' '(' (col_name) ( ( ',' col_name ) )* ')' 'NOT ENFORCED')
 func_at_time_zone ::=
     'SELECT' ( 'TIMESTAMP' | 'TIMESTAMPTZ' ) ('timestamp' | 'timestamptz') 'AT TIME ZONE' 'zone::type'
 func_cast ::=

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -395,8 +395,8 @@ impl SourceDataEncoding {
 }
 
 impl DataEncoding {
-    /// Computes the [`RelationDesc`] for the relation specified by the this
-    /// data encoding and envelope.s
+    /// Computes the [`RelationDesc`] for the relation specified by this
+    /// data encoding and envelope.
     fn desc(
         &self,
         envelope: &SourceEnvelope,

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -577,6 +577,28 @@ impl<T: AstInfo> AstDisplay for TableConstraint<T> {
 }
 impl_display_t!(TableConstraint);
 
+/// A key constraint, specified in a `CREATE SOURCE`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum KeyConstraint {
+    // PRIMARY KEY (<columns>) NOT ENFORCED
+    PrimaryKeyNotEnforced { columns: Vec<Ident> },
+}
+
+impl AstDisplay for KeyConstraint {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        match self {
+            KeyConstraint::PrimaryKeyNotEnforced { columns } => {
+                f.write_str("PRIMARY KEY ");
+                f.write_str("(");
+                f.write_node(&display::comma_separated(columns));
+                f.write_str(") ");
+                f.write_str("NOT ENFORCED");
+            }
+        }
+    }
+}
+impl_display!(KeyConstraint);
+
 /// SQL column definition
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ColumnDef<T: AstInfo> {

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -23,7 +23,7 @@ use std::fmt;
 use crate::ast::display::{self, AstDisplay, AstFormatter};
 use crate::ast::{
     AstInfo, ColumnDef, Connector, CreateSourceFormat, DataType, Envelope, Expr, Format, Ident,
-    Query, TableConstraint, UnresolvedObjectName, Value,
+    KeyConstraint, Query, TableConstraint, UnresolvedObjectName, Value,
 };
 
 /// A top-level statement (SELECT, INSERT, CREATE, etc.)
@@ -360,6 +360,7 @@ pub struct CreateSourceStatement<T: AstInfo> {
     pub envelope: Envelope,
     pub if_not_exists: bool,
     pub materialized: bool,
+    pub key_constraint: Option<KeyConstraint>,
 }
 
 impl<T: AstInfo> AstDisplay for CreateSourceStatement<T> {
@@ -377,7 +378,15 @@ impl<T: AstInfo> AstDisplay for CreateSourceStatement<T> {
         if !self.col_names.is_empty() {
             f.write_str("(");
             f.write_node(&display::comma_separated(&self.col_names));
+            if self.key_constraint.is_some() {
+                f.write_str(", ");
+                f.write_node(self.key_constraint.as_ref().unwrap());
+            }
             f.write_str(") ");
+        } else if self.key_constraint.is_some() {
+            f.write_str("(");
+            f.write_node(self.key_constraint.as_ref().unwrap());
+            f.write_str(") ")
         }
         f.write_str("FROM ");
         f.write_node(&self.connector);

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -87,6 +87,7 @@ Double
 Drop
 Else
 End
+Enforced
 Envelope
 Except
 Exists

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -372,7 +372,7 @@ CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING SCHEMA 'baz'
 ----
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING SCHEMA 'baz'
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Bare(Avro(Schema { schema: Inline("baz"), with_options: [] })), envelope: None, if_not_exists: false, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Bare(Avro(Schema { schema: Inline("baz"), with_options: [] })), envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE foo
@@ -381,7 +381,7 @@ FORMAT BYTES
 ----
 CREATE SOURCE foo FROM KAFKA BROKER 'bar' TOPIC 'baz' WITH (consistency = 'lug', ssl_certificate_file = '/Path/to/file') FORMAT BYTES
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: Kafka { broker: "bar", topic: "baz", key: None }, with_options: [Value { name: Ident("consistency"), value: String("lug") }, Value { name: Ident("ssl_certificate_file"), value: String("/Path/to/file") }], format: Bare(Bytes), envelope: None, if_not_exists: false, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: Kafka { broker: "bar", topic: "baz", key: None }, with_options: [Value { name: Ident("consistency"), value: String("lug") }, Value { name: Ident("ssl_certificate_file"), value: String("/Path/to/file") }], format: Bare(Bytes), envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE MATERIALIZED SOURCE foo FROM FILE 'bar' FORMAT PROTOBUF MESSAGE
@@ -389,49 +389,49 @@ CREATE MATERIALIZED SOURCE foo FROM FILE 'bar' FORMAT PROTOBUF MESSAGE
 ----
 CREATE MATERIALIZED SOURCE foo FROM FILE 'bar' FORMAT PROTOBUF MESSAGE 'somemessage' USING SCHEMA FILE 'path'
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Bare(Protobuf { message_name: "somemessage", schema: File("path") }), envelope: None, if_not_exists: false, materialized: true })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Bare(Protobuf { message_name: "somemessage", schema: File("path") }), envelope: None, if_not_exists: false, materialized: true, key_constraint: None })
 
 parse-statement
 CREATE SOURCE IF NOT EXISTS foo FROM FILE 'bar' WITH (tail = true) FORMAT REGEX '(asdf)|(jkl)'
 ----
 CREATE SOURCE IF NOT EXISTS foo FROM FILE 'bar' WITH (tail = true) FORMAT REGEX '(asdf)|(jkl)'
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [Value { name: Ident("tail"), value: Boolean(true) }], format: Bare(Regex("(asdf)|(jkl)")), envelope: None, if_not_exists: true, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [Value { name: Ident("tail"), value: Boolean(true) }], format: Bare(Regex("(asdf)|(jkl)")), envelope: None, if_not_exists: true, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE IF NOT EXISTS foo (one, two) FROM FILE 'bar' WITH (tail = true) FORMAT REGEX '(asdf)|(jkl)'
 ----
 CREATE SOURCE IF NOT EXISTS foo (one, two) FROM FILE 'bar' WITH (tail = true) FORMAT REGEX '(asdf)|(jkl)'
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [Ident("one"), Ident("two")], connector: File { path: "bar", compression: None }, with_options: [Value { name: Ident("tail"), value: Boolean(true) }], format: Bare(Regex("(asdf)|(jkl)")), envelope: None, if_not_exists: true, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [Ident("one"), Ident("two")], connector: File { path: "bar", compression: None }, with_options: [Value { name: Ident("tail"), value: Boolean(true) }], format: Bare(Regex("(asdf)|(jkl)")), envelope: None, if_not_exists: true, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE foo FROM FILE 'bar' WITH (tail = false) FORMAT CSV WITH HEADER
 ----
 CREATE SOURCE foo FROM FILE 'bar' WITH (tail = false) FORMAT CSV WITH HEADER
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [Value { name: Ident("tail"), value: Boolean(false) }], format: Bare(Csv { header_row: true, n_cols: None, delimiter: ',' }), envelope: None, if_not_exists: false, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [Value { name: Ident("tail"), value: Boolean(false) }], format: Bare(Csv { header_row: true, n_cols: None, delimiter: ',' }), envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE foo FROM FILE 'bar' WITH (tail = false) FORMAT CSV WITH 3 COLUMNS
 ----
 CREATE SOURCE foo FROM FILE 'bar' WITH (tail = false) FORMAT CSV WITH 3 COLUMNS
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [Value { name: Ident("tail"), value: Boolean(false) }], format: Bare(Csv { header_row: false, n_cols: Some(3), delimiter: ',' }), envelope: None, if_not_exists: false, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [Value { name: Ident("tail"), value: Boolean(false) }], format: Bare(Csv { header_row: false, n_cols: Some(3), delimiter: ',' }), envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE foo (one, two) FROM FILE 'bar' FORMAT CSV WITH HEADER
 ----
 CREATE SOURCE foo (one, two) FROM FILE 'bar' FORMAT CSV WITH HEADER
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [Ident("one"), Ident("two")], connector: File { path: "bar", compression: None }, with_options: [], format: Bare(Csv { header_row: true, n_cols: None, delimiter: ',' }), envelope: None, if_not_exists: false, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [Ident("one"), Ident("two")], connector: File { path: "bar", compression: None }, with_options: [], format: Bare(Csv { header_row: true, n_cols: None, delimiter: ',' }), envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE foo FROM FILE 'bar' WITH (tail = true) FORMAT CSV WITH 3 COLUMNS DELIMITED BY '|'
 ----
 CREATE SOURCE foo FROM FILE 'bar' WITH (tail = true) FORMAT CSV WITH 3 COLUMNS DELIMITED BY '|'
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [Value { name: Ident("tail"), value: Boolean(true) }], format: Bare(Csv { header_row: false, n_cols: Some(3), delimiter: '|' }), envelope: None, if_not_exists: false, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [Value { name: Ident("tail"), value: Boolean(true) }], format: Bare(Csv { header_row: false, n_cols: Some(3), delimiter: '|' }), envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE MATERIALIZED OR VIEW foo as SELECT * from bar
@@ -445,119 +445,168 @@ CREATE SOURCE foo FROM AVRO OCF '/tmp/bar'
 ----
 CREATE SOURCE foo FROM AVRO OCF '/tmp/bar'
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: AvroOcf { path: "/tmp/bar" }, with_options: [], format: None, envelope: None, if_not_exists: false, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: AvroOcf { path: "/tmp/bar" }, with_options: [], format: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' ENVELOPE DEBEZIUM
 ----
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' ENVELOPE DEBEZIUM
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Bare(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [] })), envelope: Debezium(Plain), if_not_exists: false, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Bare(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [] })), envelope: Debezium(Plain), if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' SEED VALUE SCHEMA 'blah'
 ----
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' SEED VALUE SCHEMA 'blah'
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Bare(Avro(CsrUrl { url: "http://localhost:8081", seed: Some(CsrSeed { key_schema: None, value_schema: "blah" }), with_options: [] })), envelope: None, if_not_exists: false, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Bare(Avro(CsrUrl { url: "http://localhost:8081", seed: Some(CsrSeed { key_schema: None, value_schema: "blah" }), with_options: [] })), envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' SEED KEY SCHEMA 'a' VALUE SCHEMA 'b'
 ----
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' SEED KEY SCHEMA 'a' VALUE SCHEMA 'b'
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Bare(Avro(CsrUrl { url: "http://localhost:8081", seed: Some(CsrSeed { key_schema: Some("a"), value_schema: "b" }), with_options: [] })), envelope: None, if_not_exists: false, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Bare(Avro(CsrUrl { url: "http://localhost:8081", seed: Some(CsrSeed { key_schema: Some("a"), value_schema: "b" }), with_options: [] })), envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (a = 'b') ENVELOPE DEBEZIUM
 ----
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (a = 'b') ENVELOPE DEBEZIUM
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Bare(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [Value { name: Ident("a"), value: String("b") }] })), envelope: Debezium(Plain), if_not_exists: false, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Bare(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [Value { name: Ident("a"), value: String("b") }] })), envelope: Debezium(Plain), if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081'
 ----
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081'
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Bare(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [] })), envelope: None, if_not_exists: false, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Bare(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [] })), envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' ENVELOPE UPSERT
 ----
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' ENVELOPE UPSERT
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connector: Kafka { broker: "zubat", topic: "hoothoot", key: None }, with_options: [], format: Bare(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [] })), envelope: Upsert, if_not_exists: false, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connector: Kafka { broker: "zubat", topic: "hoothoot", key: None }, with_options: [], format: Bare(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [] })), envelope: Upsert, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USING SCHEMA 'string' ENVELOPE UPSERT FORMAT AVRO USING SCHEMA 'long'
 ----
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT AVRO USING SCHEMA 'long' VALUE FORMAT AVRO USING SCHEMA 'string' ENVELOPE UPSERT
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connector: Kafka { broker: "zubat", topic: "hoothoot", key: None }, with_options: [], format: KeyValue { key: Avro(Schema { schema: Inline("long"), with_options: [] }), value: Avro(Schema { schema: Inline("string"), with_options: [] }) }, envelope: Upsert, if_not_exists: false, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connector: Kafka { broker: "zubat", topic: "hoothoot", key: None }, with_options: [], format: KeyValue { key: Avro(Schema { schema: Inline("long"), with_options: [] }), value: Avro(Schema { schema: Inline("string"), with_options: [] }) }, envelope: Upsert, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USING SCHEMA 'string' WITH (confluent_wire_format = false) ENVELOPE NONE
 ----
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USING SCHEMA 'string' WITH (confluent_wire_format = false)
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connector: Kafka { broker: "zubat", topic: "hoothoot", key: None }, with_options: [], format: Bare(Avro(Schema { schema: Inline("string"), with_options: [WithOption { key: Ident("confluent_wire_format"), value: Some(Value(Boolean(false))) }] })), envelope: None, if_not_exists: false, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connector: Kafka { broker: "zubat", topic: "hoothoot", key: None }, with_options: [], format: Bare(Avro(Schema { schema: Inline("string"), with_options: [WithOption { key: Ident("confluent_wire_format"), value: Some(Value(Boolean(false))) }] })), envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT FORMAT TEXT
 ----
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connector: Kafka { broker: "zubat", topic: "hoothoot", key: None }, with_options: [], format: KeyValue { key: Text, value: Avro(Schema { schema: File("path"), with_options: [] }) }, envelope: Upsert, if_not_exists: false, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connector: Kafka { broker: "zubat", topic: "hoothoot", key: None }, with_options: [], format: KeyValue { key: Text, value: Avro(Schema { schema: File("path"), with_options: [] }) }, envelope: Upsert, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset=2) FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT FORMAT TEXT
 ----
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset = 2) KEY FORMAT TEXT VALUE FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka { broker: "broker", topic: "topic", key: None }, with_options: [Value { name: Ident("start_offset"), value: Number("2") }], format: KeyValue { key: Text, value: Avro(Schema { schema: File("path"), with_options: [] }) }, envelope: Upsert, if_not_exists: false, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka { broker: "broker", topic: "topic", key: None }, with_options: [Value { name: Ident("start_offset"), value: Number("2") }], format: KeyValue { key: Text, value: Avro(Schema { schema: File("path"), with_options: [] }) }, envelope: Upsert, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset=[]) FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT FORMAT TEXT
 ----
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset = []) KEY FORMAT TEXT VALUE FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka { broker: "broker", topic: "topic", key: None }, with_options: [Value { name: Ident("start_offset"), value: Array([]) }], format: KeyValue { key: Text, value: Avro(Schema { schema: File("path"), with_options: [] }) }, envelope: Upsert, if_not_exists: false, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka { broker: "broker", topic: "topic", key: None }, with_options: [Value { name: Ident("start_offset"), value: Array([]) }], format: KeyValue { key: Text, value: Avro(Schema { schema: File("path"), with_options: [] }) }, envelope: Upsert, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset=[2]) FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT FORMAT TEXT
 ----
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset = [2]) KEY FORMAT TEXT VALUE FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka { broker: "broker", topic: "topic", key: None }, with_options: [Value { name: Ident("start_offset"), value: Array([Number("2")]) }], format: KeyValue { key: Text, value: Avro(Schema { schema: File("path"), with_options: [] }) }, envelope: Upsert, if_not_exists: false, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka { broker: "broker", topic: "topic", key: None }, with_options: [Value { name: Ident("start_offset"), value: Array([Number("2")]) }], format: KeyValue { key: Text, value: Avro(Schema { schema: File("path"), with_options: [] }) }, envelope: Upsert, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset=[2, 40000000]) FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT FORMAT TEXT
 ----
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset = [2, 40000000]) KEY FORMAT TEXT VALUE FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka { broker: "broker", topic: "topic", key: None }, with_options: [Value { name: Ident("start_offset"), value: Array([Number("2"), Number("40000000")]) }], format: KeyValue { key: Text, value: Avro(Schema { schema: File("path"), with_options: [] }) }, envelope: Upsert, if_not_exists: false, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka { broker: "broker", topic: "topic", key: None }, with_options: [Value { name: Ident("start_offset"), value: Array([Number("2"), Number("40000000")]) }], format: KeyValue { key: Text, value: Avro(Schema { schema: File("path"), with_options: [] }) }, envelope: Upsert, if_not_exists: false, materialized: false, key_constraint: None })
+
+parse-statement
+CREATE SOURCE source (a, b, PRIMARY KEY (a) NOT ENFORCED) FROM KAFKA BROKER 'broker' TOPIC 'topic'
+----
+CREATE SOURCE source (a, b, PRIMARY KEY (a) NOT ENFORCED) FROM KAFKA BROKER 'broker' TOPIC 'topic'
+=>
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [Ident("a"), Ident("b")], connector: Kafka { broker: "broker", topic: "topic", key: None }, with_options: [], format: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: Some(PrimaryKeyNotEnforced { columns: [Ident("a")] }) })
+
+parse-statement
+CREATE SOURCE source (a, PRIMARY KEY (a) NOT ENFORCED, b) FROM KAFKA BROKER 'broker' TOPIC 'topic'
+----
+CREATE SOURCE source (a, b, PRIMARY KEY (a) NOT ENFORCED) FROM KAFKA BROKER 'broker' TOPIC 'topic'
+=>
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [Ident("a"), Ident("b")], connector: Kafka { broker: "broker", topic: "topic", key: None }, with_options: [], format: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: Some(PrimaryKeyNotEnforced { columns: [Ident("a")] }) })
+
+parse-statement
+CREATE SOURCE source (PRIMARY KEY (a) NOT ENFORCED) FROM KAFKA BROKER 'broker' TOPIC 'topic'
+----
+CREATE SOURCE source (PRIMARY KEY (a) NOT ENFORCED) FROM KAFKA BROKER 'broker' TOPIC 'topic'
+=>
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka { broker: "broker", topic: "topic", key: None }, with_options: [], format: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: Some(PrimaryKeyNotEnforced { columns: [Ident("a")] }) })
+
+parse-statement
+CREATE SOURCE source (PRIMARY, PRIMARY KEY (a) NOT ENFORCED) FROM KAFKA BROKER 'broker' TOPIC 'topic'
+----
+CREATE SOURCE source (primary, PRIMARY KEY (a) NOT ENFORCED) FROM KAFKA BROKER 'broker' TOPIC 'topic'
+=>
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [Ident("primary")], connector: Kafka { broker: "broker", topic: "topic", key: None }, with_options: [], format: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: Some(PrimaryKeyNotEnforced { columns: [Ident("a")] }) })
+
+parse-statement
+CREATE SOURCE source PRIMARY KEY (a) NOT ENFORCED FROM KAFKA BROKER 'broker' TOPIC 'topic'
+----
+error: Expected FROM, found PRIMARY
+CREATE SOURCE source PRIMARY KEY (a) NOT ENFORCED FROM KAFKA BROKER 'broker' TOPIC 'topic'
+                     ^
+
+parse-statement
+CREATE SOURCE source (PRIMARY KEY () NOT ENFORCED) FROM KAFKA BROKER 'broker' TOPIC 'topic'
+----
+error: Expected identifier, found right parenthesis
+CREATE SOURCE source (PRIMARY KEY () NOT ENFORCED) FROM KAFKA BROKER 'broker' TOPIC 'topic'
+                                   ^
+
+parse-statement
+CREATE SOURCE source (a, b, PRIMARY KEY (a) NOT ENFORCED, PRIMARY KEY (b) NOT ENFORCED) FROM KAFKA BROKER 'broker' TOPIC 'topic'
+----
+error: Multiple key constraints not allowed
+CREATE SOURCE source (a, b, PRIMARY KEY (a) NOT ENFORCED, PRIMARY KEY (b) NOT ENFORCED) FROM KAFKA BROKER 'broker' TOPIC 'topic'
+                                                          ^
 
 parse-statement
 CREATE SOURCE psychic FROM POSTGRES CONNECTION 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red';
 ----
 CREATE SOURCE psychic FROM POSTGRES CONNECTION 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red'
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("psychic")]), col_names: [], connector: Postgres { conn: "host=kanto user=ash password=teamrocket dbname=pokemon", publication: "red", slot: None }, with_options: [], format: None, envelope: None, if_not_exists: false, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("psychic")]), col_names: [], connector: Postgres { conn: "host=kanto user=ash password=teamrocket dbname=pokemon", publication: "red", slot: None }, with_options: [], format: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE psychic FROM PUBNUB SUBSCRIBE KEY 'subscribe_key' CHANNEL 'channel';
 ----
 CREATE SOURCE psychic FROM PUBNUB SUBSCRIBE KEY 'subscribe_key' CHANNEL 'channel'
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("psychic")]), col_names: [], connector: PubNub { subscribe_key: "subscribe_key", channel: "channel" }, with_options: [], format: None, envelope: None, if_not_exists: false, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("psychic")]), col_names: [], connector: PubNub { subscribe_key: "subscribe_key", channel: "channel" }, with_options: [], format: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE IF NOT EXISTS foo FROM FILE 'bar' FORMAT BYTES
 ----
 CREATE SOURCE IF NOT EXISTS foo FROM FILE 'bar' FORMAT BYTES
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Bare(Bytes), envelope: None, if_not_exists: true, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Bare(Bytes), envelope: None, if_not_exists: true, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE IF EXISTS foo FROM FILE 'bar' USING SCHEMA ''

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -263,6 +263,7 @@ pub fn create_statement(
             envelope: _,
             if_not_exists,
             materialized,
+            key_constraint: _,
         }) => {
             *name = allocate_name(name)?;
             *if_not_exists = false;

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -389,6 +389,7 @@ pub fn plan_create_source(
         if_not_exists,
         materialized,
         format,
+        key_constraint: _,
     } = &stmt;
 
     let with_options_original = with_options;

--- a/test/testdrive/csv-sources.td
+++ b/test/testdrive/csv-sources.td
@@ -135,3 +135,21 @@ Dollars,Category
 
 ! SELECT * FROM bad_text_csv
 Decode error: Text: CSV error at record number 2: invalid UTF-8
+
+# Declare a key constraint (PRIMARY KEY NOT ENFORCED)
+
+$ kafka-create-topic topic=static-csv-pkne-sink
+
+> CREATE MATERIALIZED SOURCE static_csv_pkne (PRIMARY KEY (zip) NOT ENFORCED)
+  FROM FILE '${testdrive.temp-dir}/static.csv'
+  FORMAT CSV WITH HEADER
+
+> CREATE SINK static_csv_pkne_sink FROM static_csv_pkne
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'static-csv-pkne-sink'
+  KEY (zip)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' ENVELOPE UPSERT
+
+$ kafka-verify format=avro sink=materialize.public.static_csv_pkne_sink sort-messages=true
+{"zip": "10004"} {"city": "New York", "state": "NY", "zip": "10004", "mz_line_no": 2}
+{"zip": "14618"} {"city": "Rochester", "state": "NY", "zip": "14618", "mz_line_no": 1}
+{"zip": "92679"} {"city": "bad,\nplace\"", "state": "CA", "zip": "92679", "mz_line_no": 3}

--- a/test/testdrive/kafka-upsert-sources.td
+++ b/test/testdrive/kafka-upsert-sources.td
@@ -487,3 +487,127 @@ melon  2
 k1        k2
 -----------
 librairie 10
+
+# Declare a key constraint (PRIMARY KEY NOT ENFORCED)
+
+$ set schema={
+    "type": "record",
+    "name": "row",
+    "fields": [
+      {"name": "a", "type": "long"},
+      {"name": "b", "type": "long"}
+    ]
+  }
+
+$ kafka-create-topic topic=input-pkne-flat
+
+$ kafka-ingest format=avro topic=input-pkne-flat schema=${schema}
+{"a": 1, "b": 11}
+{"a": 2, "b": 22}
+{"a": 3, "b": 33}
+
+> CREATE MATERIALIZED SOURCE input_pkne_flat_a (PRIMARY KEY (a) NOT ENFORCED)
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-pkne-flat-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE NONE
+
+> CREATE MATERIALIZED SOURCE input_pkne_flat_b (PRIMARY KEY (b) NOT ENFORCED)
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-pkne-flat-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE NONE
+
+> CREATE MATERIALIZED SOURCE input_pkne_flat_ab (PRIMARY KEY (a, b) NOT ENFORCED)
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-pkne-flat-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE NONE
+
+> CREATE SINK input_pkne_flat_a_sink FROM input_pkne_flat_a
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'input-pkne-flat-a-sink'
+  KEY (a)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' ENVELOPE UPSERT
+
+> CREATE SINK input_pkne_flat_b_sink FROM input_pkne_flat_b
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'input-pkne-flat-b-sink'
+  KEY (b)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' ENVELOPE UPSERT
+
+> CREATE SINK input_pkne_flat_ab_sink FROM input_pkne_flat_ab
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'input-pkne-flat-ab-sink'
+  KEY (a, b)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' ENVELOPE UPSERT
+
+$ kafka-verify format=avro sink=materialize.public.input_pkne_flat_a_sink sort-messages=true
+{"a": 1} {"a": 1, "b": 11}
+{"a": 2} {"a": 2, "b": 22}
+{"a": 3} {"a": 3, "b": 33}
+
+$ kafka-verify format=avro sink=materialize.public.input_pkne_flat_b_sink sort-messages=true
+{"b": 11} {"a": 1, "b": 11}
+{"b": 22} {"a": 2, "b": 22}
+{"b": 33} {"a": 3, "b": 33}
+
+$ kafka-verify format=avro sink=materialize.public.input_pkne_flat_ab_sink sort-messages=true
+{"a": 1, "b": 11} {"a": 1, "b": 11}
+{"a": 2, "b": 22} {"a": 2, "b": 22}
+{"a": 3, "b": 33} {"a": 3, "b": 33}
+
+$ set keyschema={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "key1", "type": "string"},
+        {"name": "key2", "type": "long"}
+    ]
+  }
+
+$ kafka-create-topic topic=input-pkne-key
+
+$ kafka-ingest topic=input-pkne-key key-format=avro key-schema=${keyschema} format=avro schema=${schema}
+{"key1": "a", "key2": 1} {"a": 1, "b": 11}
+{"key1": "b", "key2": 2} {"a": 2, "b": 22}
+{"key1": "c", "key2": 3} {"a": 3, "b": 33}
+
+> CREATE MATERIALIZED SOURCE input_pkne_key (PRIMARY KEY (key1) NOT ENFORCED)
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-pkne-key-${testdrive.seed}'
+  WITH (ignore_source_keys=true)
+  FORMAT AVRO USING SCHEMA '${schema}'
+  ENVELOPE UPSERT FORMAT AVRO USING SCHEMA '${keyschema}'
+
+> CREATE SINK input_pkne_key_sink FROM input_pkne_key
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'input-pkne-key-sink'
+  KEY (key1)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' ENVELOPE UPSERT
+
+$ kafka-verify format=avro sink=materialize.public.input_pkne_key_sink sort-messages=true
+{"key1": "a"} {"key1": "a", "key2": 1, "a": 1, "b": 11}
+{"key1": "b"} {"key1": "b", "key2": 2, "a": 2, "b": 22}
+{"key1": "c"} {"key1": "c", "key2": 3, "a": 3, "b": 33}
+
+! CREATE MATERIALIZED SOURCE avroavro (PRIMARY KEY (f1) NOT ENFORCED)
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avroavro-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE UPSERT
+Key constraint (f1) conflicts with existing key (key)
+
+! CREATE MATERIALIZED SOURCE avroavro (PRIMARY KEY (unknown) NOT ENFORCED)
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avroavro-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE UPSERT
+No such column in source key constraint: unknown
+
+! CREATE MATERIALIZED SOURCE avroavro (PRIMARY KEY (f1, f1) NOT ENFORCED)
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avroavro-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE NONE
+Repeated column name in source key constraint: f1
+
+$ set ambiguous-schema={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"f1", "type":"string"},
+            {"name":"f2", "type":"long"},
+            {"name":"f1", "type":"long"}
+        ]
+    }
+
+! CREATE MATERIALIZED SOURCE input_pkne (f1, f2, f1, PRIMARY KEY (f1) NOT ENFORCED)
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avroavro-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${ambiguous-schema}' ENVELOPE NONE
+Ambiguous column in source key constraint: f1

--- a/test/testdrive/primary-key-optimizations.td
+++ b/test/testdrive/primary-key-optimizations.td
@@ -103,16 +103,19 @@ $ kafka-ingest format=avro topic=t1 key-format=avro key-schema=${keyschema-2keys
 > EXPLAIN SELECT DISTINCT key1, key2 FROM v2;
 "%0 =| Get v2| Project (#0, #1)"
 
-# Make sure that having a DISTINCT or a GROUP BY confers PK semantics on upstream views
+# Make sure that having a DISTINCT or GROUP BY confers PK semantics on upstream views
 
-> CREATE VIEW distinct_view AS SELECT DISTINCT nokey FROM t1;
+> CREATE MATERIALIZED VIEW distinct_view AS SELECT DISTINCT nokey FROM t1;
+
+> EXPLAIN SELECT DISTINCT nokey FROM distinct_view
+"%0 =| Get distinct_view"
 
 > CREATE MATERIALIZED VIEW group_by_view AS SELECT nokey || 'a' AS f1 , nokey || 'b' AS f2 FROM t1 GROUP BY nokey || 'a', nokey || 'b';
 
 > EXPLAIN SELECT DISTINCT f1, f2 FROM group_by_view;
 "%0 =| Get group_by_view"
 
-# Redundant table is eliminated from an inner join using PK infomration
+# Redundant table is eliminated from an inner join using PK information
 
 > EXPLAIN SELECT a1.* FROM t1 AS a1, t1 AS a2 WHERE a1.key1 = a2.key1 AND a1.key2 = a2.key2;
 "%0 =| Get t1"
@@ -122,3 +125,109 @@ $ kafka-ingest format=avro topic=t1 key-format=avro key-schema=${keyschema-2keys
 
 > EXPLAIN SELECT a1.* FROM v2 AS a1, v2 AS a2 WHERE a1.key1 = a2.key1 AND a1.key2 = a2.key2;
 "%0 =| Get v2"
+
+# Declare a key constraint (PRIMARY KEY NOT ENFORCED); otherwise identical tests as above.
+
+$ set schema={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"key1","type":"string"},
+            {"name":"key2","type":"string"},
+            {"name":"nokey", "type":"string"}
+        ]
+    }
+
+$ kafka-create-topic topic=t1-pkne
+
+$ kafka-ingest format=avro topic=t1-pkne schema=${schema} publish=true
+
+> CREATE MATERIALIZED SOURCE t1_pkne (PRIMARY KEY (key1, key2) NOT ENFORCED)
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
+  'testdrive-t1-pkne-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE NONE;
+
+# Optimization is possible - no distinct is mentioned in the plan
+
+> EXPLAIN SELECT DISTINCT key1, key2 FROM t1_pkne;
+"%0 =| Get t1_pkne| Project (#0, #1)"
+
+> EXPLAIN SELECT DISTINCT key2, key1 FROM t1_pkne;
+"%0 =| Get t1_pkne| Project (#1, #0)"
+
+> EXPLAIN SELECT DISTINCT key2, key1, key2 FROM t1_pkne;
+"%0 =| Get t1_pkne| Project (#1, #0, #1)"
+
+> EXPLAIN SELECT key2, key1 FROM t1_pkne GROUP BY key1, key2;
+"%0 =| Get t1_pkne| Project (#1, #0)"
+
+> EXPLAIN SELECT key2, key1 FROM t1_pkne GROUP BY key1, key2, key2 || 'a';
+"%0 =| Get t1_pkne| Project (#1, #0)"
+
+> EXPLAIN SELECT DISTINCT key1, key2, nokey FROM t1_pkne;
+"%0 =| Get t1_pkne"
+
+> EXPLAIN SELECT key1, key2, nokey FROM t1_pkne GROUP BY key1, key2, nokey;
+"%0 =| Get t1_pkne"
+
+> EXPLAIN SELECT key1, key2 FROM t1_pkne GROUP BY key1, key2 HAVING key1 = 'a';
+"%0 =| Get t1_pkne| Filter (#0 = \"a\")| Map \"a\"| Project (#3, #1)"
+
+# Optimization not possible - explicit distinct is present in plan
+
+> EXPLAIN SELECT DISTINCT key1 FROM t1_pkne;
+"%0 =| Get t1_pkne| Distinct group=(#0)"
+
+> EXPLAIN SELECT DISTINCT key2 FROM t1_pkne;
+"%0 =| Get t1_pkne| Distinct group=(#1)"
+
+> EXPLAIN SELECT DISTINCT key1, upper(key2) FROM t1_pkne;
+"%0 =| Get t1_pkne| Distinct group=(#0, upper(#1))"
+
+> EXPLAIN SELECT DISTINCT key1, key2 || 'a' FROM t1_pkne;
+"%0 =| Get t1_pkne| Distinct group=(#0, (#1 || \"a\"))"
+
+> EXPLAIN SELECT key1 FROM t1_pkne GROUP BY key1;
+"%0 =| Get t1_pkne| Distinct group=(#0)"
+
+> EXPLAIN SELECT key2 FROM t1_pkne GROUP BY key2;
+"%0 =| Get t1_pkne| Distinct group=(#1)"
+
+> EXPLAIN SELECT COUNT(DISTINCT key1) FROM t1_pkne;
+"%0 = Let l0 =| Get t1_pkne| Reduce group=()| | agg count(distinct #0)%1 =| Get %0 (l0)| Negate| Project ()%2 =| Constant ()%3 =| Union %1 %2| Map 0%4 =| Union %0 %3"
+
+# Make sure that primary key information is inherited from the source
+
+> CREATE VIEW v1_pkne AS SELECT * FROM t1_pkne;
+
+> EXPLAIN SELECT DISTINCT key1, key2 FROM v1_pkne;
+"%0 =| Get t1_pkne| Project (#0, #1)"
+
+> CREATE MATERIALIZED VIEW v2_pkne AS SELECT * FROM t1_pkne;
+
+> EXPLAIN SELECT DISTINCT key1, key2 FROM v2_pkne;
+"%0 =| Get v2_pkne| Project (#0, #1)"
+
+# Make sure that having a DISTINCT or GROUP BY confers PK semantics on upstream views
+
+> CREATE MATERIALIZED VIEW distinct_view_pkne AS SELECT DISTINCT nokey FROM t1_pkne;
+
+> EXPLAIN SELECT DISTINCT nokey FROM distinct_view_pkne
+"%0 =| Get distinct_view_pkne"
+
+> CREATE MATERIALIZED VIEW group_by_view_pkne AS SELECT nokey || 'a' AS f1 , nokey || 'b' AS f2 FROM t1_pkne GROUP BY nokey || 'a', nokey || 'b';
+
+> EXPLAIN SELECT DISTINCT f1, f2 FROM group_by_view_pkne;
+"%0 =| Get group_by_view_pkne"
+
+# Redundant table is eliminated from an inner join using PK information
+
+> EXPLAIN SELECT a1.* FROM t1_pkne AS a1, t1_pkne AS a2 WHERE a1.key1 = a2.key1 AND a1.key2 = a2.key2;
+"%0 =| Get t1_pkne"
+
+> EXPLAIN SELECT a1.* FROM v1_pkne AS a1, v1_pkne AS a2 WHERE a1.key1 = a2.key1 AND a1.key2 = a2.key2;
+"%0 =| Get t1_pkne"
+
+> EXPLAIN SELECT a1.* FROM v2_pkne AS a1, v2_pkne AS a2 WHERE a1.key1 = a2.key1 AND a1.key2 = a2.key2;
+"%0 =| Get v2_pkne"


### PR DESCRIPTION
* **General**
  *  The overall diff is quite large, because of tests and documentation, but the actual changes are small, so I hope that this is reviewable. I would suggest to ignore the docs commit on the first pass. I'm also happy to break it up into multiple PRs if that's better.
* **Docs**
  * I was unsure how prominently we want to document this. I included updates to the railroad diagrams, but happy to revert if we want to keep this under the radar.
  * I omitted pages that only document formats resulting in single columns (e.g. I updated the Text/bytes + file page, because it supports the regex format which can generate multiple columns, but not the Text + PubNub, because it only supports text format).
* **Follow-ups**
  * We could follow-up with support for field expressions in order to allow keys from nested data, e.g. 
    ```sql
    PRIMARY KEY ((f0).f1.f2, f1) NOT ENFORCED
    ```
    where the first key field is nested under `f0.f1`. What do you think?

@aljoscha I picked you for review, because you opened the issue, but feel free to pull in others.