### PR TITLE
pg-cdc-resumption: increase the default timeout across the test

### DIFF
--- a/test/pg-cdc-resumption/mzcompose.yml
+++ b/test/pg-cdc-resumption/mzcompose.yml
@@ -181,6 +181,8 @@ services:
       - >-
         testdrive
         --materialized-url=postgres://materialize@materialized:6875
+        --max-errors=1
+        --default-timeout=60
         $$*
       - bash
     volumes:


### PR DESCRIPTION
In order to prevent sporadic test failures. The testdrive default
of 10 seconds is not sufficient to guarantee that the large datasets
involved have been replicated in time in the face of network
disruptions.

@petrosagg , @JLDLaughlin JFYI.