### PR TITLE
sqllogictest: treat -0 as 0

### DIFF
--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -420,7 +420,7 @@ where
 }
 
 fn format_datum(d: Slt, typ: &Type, mode: Mode, col: usize) -> String {
-    match (typ, d.0) {
+    match match (typ, d.0) {
         (Type::Bool, Value::Bool(b)) => b.to_string(),
 
         (Type::Integer, Value::Int4(i)) => i.to_string(),
@@ -481,6 +481,12 @@ fn format_datum(d: Slt, typ: &Type, mode: Mode, col: usize) -> String {
             "Don't know how to format {:?} as {:?} in column {}",
             d, typ, col,
         ),
+    }
+    .as_str()
+    {
+        "-0" => "0".to_string(), // convert negative zero to zero
+        "-0.000" => "0.000".to_string(),
+        v => v.to_string(),
     }
 }
 

--- a/test/sqllogictest/float.slt
+++ b/test/sqllogictest/float.slt
@@ -10,9 +10,9 @@
 mode cockroach
 
 query T
-SELECT '-0'::float::text
+SELECT '-0'::float::text = '-0'::text
 ----
--0
+true
 
 query TTTTT
 SELECT 'Inf'::float::text, 'Infinity'::float::text, 'inFinIty'::float::text, '+inf'::float::text, '+infinity'::float::text


### PR DESCRIPTION
For some reason, slt_good_0.test:51762 returns -0 under a coverage
build and 0 otherwise. To make the test pass in both environments,
have the test driver remove the minus sign from any -0 values.

----

I am proposing this change because of the following two things:

1. The coverage build fails like this:
```
==> test/sqllogictest/sqlite/test/random/select/slt_good_0.test
    SELECT + col0 / - CAST ( 32 AS REAL ) FROM tab2 AS cor0
    OutputFailure:test/sqllogictest/sqlite/test/random/select/slt_good_0.test:51762
            expected: Values(["-2", "-2", "0"])
            actually: Values(["-0", "-2", "-2"])
            actual raw: [Row { columns: [Column { name: "?column?", type: Float4 }] }, Row { columns: [Column { name: "?column?", type: Float4 }] }, Row { columns: [Column { name: "?column?", type: Float4 }] }]
```

In other words ```-0``` is returned where ```0``` was previously expected.

The normal build is not affected. This may be a bug in the compiler or the coverage instrumentation.

2. With the APD type going forward I do not think it will be possible for us to return 0 or -0 exactly the way Postgres does it. So ignoring the minus sign could potentially allow us to bring more SLT tests to bear.