### PR TITLE
sqllogictest: correct printing floats as integers

### DIFF
--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -426,8 +426,8 @@ fn format_datum(d: Slt, typ: &Type, mode: Mode, col: usize) -> String {
         (Type::Integer, Value::Int4(i)) => i.to_string(),
         (Type::Integer, Value::Int8(i)) => i.to_string(),
         (Type::Integer, Value::Numeric(d)) => format!("{:.0}", d),
-        (Type::Integer, Value::Float4(f)) => format!("{:.0}", f.trunc()),
-        (Type::Integer, Value::Float8(f)) => format!("{:.0}", f.trunc()),
+        (Type::Integer, Value::Float4(f)) => format!("{}", f as i64),
+        (Type::Integer, Value::Float8(f)) => format!("{}", f as i64),
         // This is so wrong, but sqlite needs it.
         (Type::Integer, Value::Text(_)) => "0".to_string(),
         (Type::Integer, Value::Bool(b)) => i8::from(b).to_string(),

--- a/test/sqllogictest/arithmetic.slt
+++ b/test/sqllogictest/arithmetic.slt
@@ -259,7 +259,7 @@ SELECT 1 + CAST ('5' AS double precision)
 ----
 6
 
-query II
+query TT
 SELECT CAST ('+Inf' AS double precision), CAST ('inf' AS double precision)
 ----
 inf inf


### PR DESCRIPTION
In SQLite's SLT, floats are printed as integers by casting the float to
an integer then printing the integer. Our SLT runner was printing floats
rounding the float then printing the float with zero digits after the
decimal point. This is almost the same thing, except that "0" is printed
as "-0" since rust-lang/rust#78618. Future proof the code (and make it
work the same way in the nightly coverage build) by following the SQLite
approach.

Supersedes #7096.