### PR TITLE
sql,coord: make SystemTime::now a pluggable function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2667,6 +2667,7 @@ version = "0.0.0"
 dependencies = [
  "async-trait",
  "bytes",
+ "chrono",
  "crossbeam-utils",
  "either",
  "futures",

--- a/src/coord/src/catalog/config.rs
+++ b/src/coord/src/catalog/config.rs
@@ -33,4 +33,6 @@ pub struct Config<'a> {
     pub num_workers: usize,
     /// Timestamp frequency to use for CREATE SOURCE
     pub timestamp_frequency: Duration,
+    /// Function to generate wall clock now; can be mocked.
+    pub now: ore::now::NowFn,
 }

--- a/src/coord/src/command.rs
+++ b/src/coord/src/command.rs
@@ -57,6 +57,12 @@ pub enum Command {
         tx: oneshot::Sender<Response<ExecuteResponse>>,
     },
 
+    StartTransaction {
+        implicit: Option<usize>,
+        session: Session,
+        tx: oneshot::Sender<Response<()>>,
+    },
+
     Commit {
         action: EndTransactionAction,
         session: Session,

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -3325,6 +3325,7 @@ pub async fn serve(
         command_receivers: worker_rxs,
         timely_worker,
         experimental_mode,
+        now: system_time,
     })
     .map_err(|s| CoordError::Unstructured(anyhow!("{}", s)))?;
 

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -43,7 +43,7 @@ use std::path::Path;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::thread;
-use std::time::{Duration, SystemTime};
+use std::time::Duration;
 
 use self::prometheus::{Scraper, ScraperMessage};
 use anyhow::{anyhow, Context};
@@ -226,6 +226,7 @@ pub struct Coordinator {
     /// A map from connection ID to metadata about that connection for all
     /// active connections.
     active_conns: HashMap<u32, ConnMeta>,
+    now: ore::now::NowFn,
 
     /// Holds pending compaction messages to be sent to the dataflow workers. When
     /// `since_handles` are advanced or `txn_reads` are dropped, this can advance.
@@ -294,12 +295,7 @@ impl Coordinator {
         // This is a hack. In a perfect world we would represent time as having a "real" dimension
         // and a "coordinator" dimension so that clients always observed linearizability from
         // things the coordinator did without being related to the real dimension.
-        let ts = SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .expect("failed to get millis since epoch")
-            .as_millis()
-            .try_into()
-            .expect("current time did not fit into u64");
+        let ts = (self.now)();
 
         if ts < self.read_lower_bound {
             self.read_lower_bound
@@ -1091,7 +1087,7 @@ impl Coordinator {
         }
 
         match sql::plan::plan(
-            &pcx,
+            Some(&pcx),
             &self.catalog.for_session(session),
             stmt.clone(),
             params,
@@ -3297,6 +3293,7 @@ pub async fn serve(
         build_info,
         num_workers: workers,
         timestamp_frequency,
+        now: ore::now::system_time,
     })?;
     let cluster_id = catalog.config().cluster_id;
     let session_id = catalog.config().session_id;
@@ -3362,6 +3359,7 @@ pub async fn serve(
     let thread = thread::Builder::new()
         .name("coordinator".to_string())
         .spawn(move || {
+            let now = catalog.config().now;
             let mut coord = Coordinator {
                 worker_guards,
                 worker_txs,
@@ -3389,6 +3387,7 @@ pub async fn serve(
                 since_handles: HashMap::new(),
                 since_updates: Rc::new(RefCell::new(HashMap::new())),
                 sink_writes: HashMap::new(),
+                now,
             };
             coord.broadcast(SequencedCommand::EnableFeedback(feedback_tx));
             if let Some(config) = &logging {
@@ -3534,7 +3533,7 @@ pub fn describe(
     catalog: &dyn sql::catalog::Catalog,
     stmt: Statement<Raw>,
     param_types: &[Option<pgrepr::Type>],
-    session: &Session,
+    session: &mut Session,
 ) -> Result<StatementDesc, CoordError> {
     match stmt {
         // FETCH's description depends on the current session, which describe_statement
@@ -3545,7 +3544,12 @@ pub fn describe(
                 None => Err(CoordError::UnknownCursor(name.to_string())),
             }
         }
-        _ => Ok(sql::plan::describe(catalog, stmt, param_types)?),
+        _ => Ok(sql::plan::describe(
+            &session.pcx(),
+            catalog,
+            stmt,
+            param_types,
+        )?),
     }
 }
 

--- a/src/coord/src/session.rs
+++ b/src/coord/src/session.rs
@@ -81,7 +81,9 @@ impl Session {
     /// This is cleared at the end of a transaction.
     pub fn pcx(&mut self) -> PlanContext {
         if self.pcx == None {
-            self.pcx = Some(PlanContext::default());
+            self.pcx = Some(PlanContext::new(ore::now::to_datetime(
+                ore::now::system_time(),
+            )));
         }
         self.pcx.unwrap()
     }

--- a/src/coord/tests/parameters.rs
+++ b/src/coord/tests/parameters.rs
@@ -14,6 +14,7 @@ use tempfile::NamedTempFile;
 use coord::catalog::Catalog;
 use ore::collections::CollectionExt;
 use pgrepr::Type;
+use sql::plan::PlanContext;
 
 #[test]
 fn test_parameter_type_inference() -> Result<(), Box<dyn Error>> {
@@ -91,12 +92,12 @@ fn test_parameter_type_inference() -> Result<(), Box<dyn Error>> {
     ];
 
     let catalog_file = NamedTempFile::new()?;
-    let catalog = Catalog::open_debug(catalog_file.path())?;
+    let catalog = Catalog::open_debug(catalog_file.path(), ore::now::now_zero)?;
     let catalog = catalog.for_system_session();
     for (sql, types) in test_cases {
         println!("> {}", sql);
         let stmt = sql::parse::parse(sql)?.into_element();
-        let desc = sql::plan::describe(&catalog, stmt, &[])?;
+        let desc = sql::plan::describe(&PlanContext::zero(), &catalog, stmt, &[])?;
         assert_eq!(desc.param_types, types);
     }
     Ok(())

--- a/src/coord/tests/sql.rs
+++ b/src/coord/tests/sql.rs
@@ -44,7 +44,7 @@ fn datadriven() {
 
     walk("tests/testdata", |f| {
         let catalog_file = NamedTempFile::new().unwrap();
-        let mut catalog = Catalog::open_debug(catalog_file.path()).unwrap();
+        let mut catalog = Catalog::open_debug(catalog_file.path(), ore::now::now_zero).unwrap();
         let mut id: u32 = 1;
         f.run(|test_case| -> String {
             match test_case.directive.as_str() {
@@ -77,9 +77,9 @@ fn datadriven() {
                     let catalog = catalog.for_session(&sess);
 
                     let parsed = parse_statements(&test_case.input).unwrap();
-                    let pcx = PlanContext::default();
+                    let pcx = &PlanContext::zero();
                     let scx = StatementContext::new(
-                        Some(&pcx),
+                        Some(pcx),
                         &catalog,
                         Rc::new(RefCell::new(BTreeMap::new())),
                     );

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -119,6 +119,7 @@ use dataflow_types::*;
 use expr::{GlobalId, Id};
 use ore::collections::CollectionExt as _;
 use ore::iter::IteratorExt;
+use ore::now::NowFn;
 use repr::{Row, Timestamp};
 
 use crate::arrangement::manager::{TraceBundle, TraceManager};
@@ -178,6 +179,7 @@ pub fn build_dataflow<A: Allocate>(
     timely_worker: &mut TimelyWorker<A>,
     render_state: &mut RenderState,
     dataflow: DataflowDesc,
+    now: NowFn,
 ) {
     let worker_logging = timely_worker.log_register().get("timely");
     let name = format!("Dataflow: {}", &dataflow.debug_name);
@@ -211,6 +213,7 @@ pub fn build_dataflow<A: Allocate>(
                     src_id,
                     src,
                     orig_id,
+                    now,
                 );
             }
 

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -24,6 +24,7 @@ use timely::dataflow::Scope;
 use dataflow_types::*;
 use expr::{GlobalId, Id, SourceInstanceId};
 use ore::cast::CastFrom;
+use ore::now::NowFn;
 use repr::RelationDesc;
 use repr::ScalarType;
 use repr::{Datum, Row, Timestamp};
@@ -62,6 +63,7 @@ where
         // have its own transient ID) and a relational transformation (which has the original source
         // ID).
         orig_id: GlobalId,
+        now: NowFn,
     ) {
         // Extract the linear operators, as we will need to manipulate them.
         // extracting them reduces the change we might accidentally communicate
@@ -171,6 +173,7 @@ where
                     logger: materialized_logging,
                     encoding: encoding.clone(),
                     caching_tx,
+                    now,
                 };
 
                 let (collection, capability) =

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 publish = false
 
 [features]
-default = ["network", "cli", "test"]
+default = ["network", "cli", "test", "chrono"]
 network = ["tokio", "tokio-openssl", "async-trait", "futures", "smallvec", "bytes", "openssl"]
 cli = ["structopt"]
 test = ["tracing-subscriber"]
@@ -21,6 +21,7 @@ test = ["tracing-subscriber"]
 [dependencies]
 async-trait = { version = "0.1.50", optional = true }
 bytes = { version = "1.0.1", optional = true }
+chrono = { version = "0.4.0", default-features = false, features = ["std"], optional = true }
 either = "1.5.1"
 futures = { version = "0.3.14", optional = true }
 # This isn't directly imported by anything, but it's required at link time. The

--- a/src/ore/src/lib.rs
+++ b/src/ore/src/lib.rs
@@ -40,6 +40,7 @@ pub mod iter;
 pub mod lex;
 #[cfg(feature = "network")]
 pub mod netio;
+pub mod now;
 pub mod option;
 pub mod panic;
 pub mod result;

--- a/src/ore/src/now.rs
+++ b/src/ore/src/now.rs
@@ -1,0 +1,44 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Now utilities.
+
+use std::convert::TryInto;
+use std::time::SystemTime;
+
+#[cfg(feature = "chrono")]
+use chrono::{DateTime, TimeZone, Utc};
+
+/// A type representing the number of milliseconds since the Unix epoch.
+pub type EpochMillis = u64;
+
+/// A function that returns system or mocked time.
+pub type NowFn = fn() -> EpochMillis;
+
+/// Returns the current system time.
+pub fn system_time() -> EpochMillis {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .expect("failed to get millis since epoch")
+        .as_millis()
+        .try_into()
+        .expect("current time did not fit into u64")
+}
+
+/// Converts epoch milliseconds to a DateTime.
+#[cfg(feature = "chrono")]
+pub fn to_datetime(millis: EpochMillis) -> DateTime<Utc> {
+    let dur = std::time::Duration::from_millis(millis);
+    Utc.timestamp(dur.as_secs() as i64, dur.subsec_nanos())
+}
+
+/// Returns zero.
+pub const fn now_zero() -> EpochMillis {
+    0
+}

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -272,7 +272,7 @@ impl From<&CoordTransactionStatus> for TransactionStatus {
             CoordTransactionStatus::Started(_) => TransactionStatus::InTransaction,
             CoordTransactionStatus::InTransaction(_) => TransactionStatus::InTransaction,
             CoordTransactionStatus::InTransactionImplicit(_) => TransactionStatus::InTransaction,
-            CoordTransactionStatus::Failed => TransactionStatus::Failed,
+            CoordTransactionStatus::Failed(_) => TransactionStatus::Failed,
         }
     }
 }

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -434,10 +434,17 @@ pub struct PlanContext {
     pub wall_time: DateTime<Utc>,
 }
 
-impl Default for PlanContext {
-    fn default() -> PlanContext {
+impl PlanContext {
+    pub fn new(wall_time: DateTime<Utc>) -> Self {
+        Self { wall_time }
+    }
+
+    /// Return a PlanContext with zero values. This should only be used when
+    /// planning is required but unused (like in `plan_create_table()`) or in
+    /// tests.
+    pub fn zero() -> Self {
         PlanContext {
-            wall_time: Utc::now(),
+            wall_time: ore::now::to_datetime(ore::now::now_zero()),
         }
     }
 }

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -85,6 +85,7 @@ impl StatementDesc {
 ///
 /// See the documentation of [`StatementDesc`] for details.
 pub fn describe(
+    pcx: &PlanContext,
     catalog: &dyn Catalog,
     stmt: Statement<Raw>,
     param_types_in: &[Option<pgrepr::Type>],
@@ -96,10 +97,9 @@ pub fn describe(
         }
     }
 
-    let pcx = PlanContext::default();
     let scx = StatementContext {
+        pcx: Some(pcx),
         catalog,
-        pcx: Some(&pcx),
         param_types: Rc::new(RefCell::new(param_types)),
     };
 
@@ -169,7 +169,7 @@ pub fn describe(
 /// of the catalog changes after planning, the validity of the plan is not
 /// guaranteed.
 pub fn plan(
-    pcx: &PlanContext,
+    pcx: Option<&PlanContext>,
     catalog: &dyn Catalog,
     stmt: Statement<Raw>,
     params: &Params,
@@ -182,7 +182,7 @@ pub fn plan(
         .collect();
 
     let scx = &StatementContext {
-        pcx: Some(pcx),
+        pcx,
         catalog,
         param_types: Rc::new(RefCell::new(param_types)),
     };

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -69,8 +69,9 @@ pub fn purify(
     } else {
         Err(anyhow!("SQL statement does not refer to a source"))
     };
+    let now = catalog.now();
 
-    async {
+    async move {
         if let Statement::CreateSource(CreateSourceStatement {
             col_names,
             connector,
@@ -100,6 +101,7 @@ pub fn purify(
                         consumer.clone(),
                         &topic,
                         &with_options_map,
+                        now,
                     )
                     .await?
                     {

--- a/src/testdrive/src/action/sql.rs
+++ b/src/testdrive/src/action/sql.rs
@@ -166,7 +166,9 @@ impl Action for SqlAction {
                 | Statement::CreateView { .. }
                 | Statement::DropDatabase { .. }
                 | Statement::DropObjects { .. } => {
-                    let disk_state = Catalog::open_debug(path).map_err(|e| e.to_string())?.dump();
+                    let disk_state = Catalog::open_debug(path, ore::now::now_zero)
+                        .map_err(|e| e.to_string())?
+                        .dump();
                     let mem_state = reqwest::get(&format!(
                         "http://{}/internal/catalog",
                         state.materialized_addr,


### PR DESCRIPTION
Centralize all calls to SystemTime::now into a single configurable function. This has both improved our correctness (by not generating probably-incorrect default PlanContexts anytime we needed one) and our ability to deterministically test with a mocked function.