### PR TITLE
Part of #6889 to merge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2104,6 +2104,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "lowertest"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "datadriven",
+ "lazy_static",
+ "lowertest-derive",
+ "ore",
+ "proc-macro2",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "lowertest-derive"
+version = "0.0.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "lru"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4437,9 +4460,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.72"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
+checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ members = [
     "src/http-util",
     "src/interchange",
     "src/kafka-util",
+    "src/lowertest",
+    "src/lowertest-derive",
     "src/materialized",
     "src/metabase",
     "src/mz-process-collector",

--- a/src/lowertest-derive/Cargo.toml
+++ b/src/lowertest-derive/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "lowertest-derive"
+description = "Macros to support unit testing of lower parts of the stack"
+version = "0.0.0"
+edition = "2018"
+publish = false
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = "1.0.9"
+syn = {version="1.0.73", features=["extra-traits", "printing"]}
+proc-macro2 = "1.0.27"

--- a/src/lowertest-derive/src/lib.rs
+++ b/src/lowertest-derive/src/lib.rs
@@ -8,6 +8,8 @@
 // by the Apache License, Version 2.0.
 
 //! Macros needed by the `lowertest` crate.
+//!
+//! TODO: eliminate macros in favor of using `walkabout`?
 
 use proc_macro::{TokenStream, TokenTree};
 use proc_macro2::Span;

--- a/src/lowertest-derive/src/lib.rs
+++ b/src/lowertest-derive/src/lib.rs
@@ -1,0 +1,221 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Macros needed by the `lowertest` crate.
+
+use proc_macro::{TokenStream, TokenTree};
+use proc_macro2::Span;
+use quote::{quote, ToTokens};
+use syn::{parse, Data, DeriveInput, Fields};
+
+/// Macro generating an implementation for the trait MzEnumReflect
+#[proc_macro_derive(MzEnumReflect)]
+pub fn mzenumreflect_derive(input: TokenStream) -> TokenStream {
+    // The intended trait implementation is
+    // ```
+    // impl MzEnumReflect for #name {
+    //    fn mz_enum_reflect() ->
+    //    std::collections::HashMap<
+    //        &'static str,
+    //        (Vec<&'static str>, Vec<&'static str>)
+    //    >
+    //    {
+    //       use std::collections::HashMap;
+    //       let mut result = HashMap::new();
+    //       // repeat line below for all variants
+    //       result.add(variant_name, (<field_names>, <field_types>))
+    //       result
+    //    }
+    // }
+    // ```
+    let ast: DeriveInput = parse(input).unwrap();
+
+    let method_impl = if let Data::Enum(enumdata) = &ast.data {
+        let variants = enumdata
+            .variants
+            .iter()
+            .map(|v| {
+                let variant_name = v.ident.to_string();
+                let (names, types) = get_field_names_types(&v.fields);
+                quote! {
+                    result.insert(#variant_name, (vec![#(#names),*], vec![#(#types),*]));
+                }
+            })
+            .collect::<Vec<_>>();
+        quote! {
+          use std::collections::HashMap;
+          let mut result = HashMap::new();
+          #(#variants)*
+          result
+        }
+    } else {
+        unreachable!("Not an enum")
+    };
+
+    let name = &ast.ident;
+    let gen = quote! {
+      impl MzEnumReflect for #name {
+        fn mz_enum_reflect() ->
+            std::collections::HashMap<
+                &'static str,
+                (Vec<&'static str>, Vec<&'static str>)
+            >
+        {
+           #method_impl
+        }
+      }
+    };
+    gen.into()
+}
+
+/// Macro generating an implementation for the trait MzStructReflect
+#[proc_macro_derive(MzStructReflect)]
+pub fn mzstructreflect_derive(input: TokenStream) -> TokenStream {
+    // The intended trait implementation is
+    // ```
+    // impl MzStructReflect for #name {
+    //    fn mz_struct_reflect() -> (Vec<&'static str>, Vec<&'static str>)
+    //    {
+    //       (<field_names>, <field_types>))
+    //    }
+    // }
+    // ```
+    let ast: DeriveInput = parse(input).unwrap();
+    let method_impl = if let Data::Struct(structdata) = &ast.data {
+        let (names, types) = get_field_names_types(&structdata.fields);
+        quote! {
+            (vec![#(#names),*], vec![#(#types),*])
+        }
+    } else {
+        unreachable!("Not a struct")
+    };
+
+    let name = &ast.ident;
+    let gen = quote! {
+      impl MzStructReflect for #name {
+        fn mz_struct_reflect() -> (Vec<&'static str>, Vec<&'static str>)
+        {
+           #method_impl
+        }
+      }
+    };
+    gen.into()
+}
+
+/// Generates a function that generates `ReflectedTypeInfo`
+///
+/// Accepts three comma-separated arguments:
+/// * first is the name of the function to generate
+/// * second is a list of enums that can be looked up in the
+/// `ReflectedTypeInfo`
+/// * third is a list of enums that can be looked up in the
+/// `ReflectedTypeInfo`
+/// The latter two arguments are optional
+#[proc_macro]
+pub fn gen_reflect_info_func(input: TokenStream) -> TokenStream {
+    let mut input_iter = input.into_iter();
+    let func_name = if let Some(TokenTree::Ident(ident)) = input_iter.next() {
+        syn::Ident::new(&ident.to_string(), Span::call_site())
+    } else {
+        unreachable!("No function name specified")
+    };
+    // skip comma
+    input_iter.next();
+    let enum_dict = input_iter.next();
+    // skip comma
+    input_iter.next();
+    let struct_dict = input_iter.next();
+    let add_enums = if let Some(TokenTree::Group(group)) = enum_dict {
+        group
+            .stream()
+            .into_iter()
+            .filter_map(|tt| {
+                if let TokenTree::Ident(ident) = tt {
+                    let type_name = ident.to_string();
+                    let typ = syn::Ident::new(&type_name, Span::call_site());
+                    Some(quote! { enum_dict.insert(#type_name, #typ::mz_enum_reflect()) })
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>()
+    } else {
+        vec![]
+    };
+    let add_structs = if let Some(TokenTree::Group(group)) = struct_dict {
+        group
+            .stream()
+            .into_iter()
+            .filter_map(|tt| {
+                if let TokenTree::Ident(ident) = tt {
+                    let type_name = ident.to_string();
+                    let typ = syn::Ident::new(&type_name, Span::call_site());
+                    Some(quote! { struct_dict.insert(#type_name, #typ::mz_struct_reflect()) })
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>()
+    } else {
+        vec![]
+    };
+    let gen = quote! {
+        fn #func_name () -> ReflectedTypeInfo {
+            let mut enum_dict = std::collections::HashMap::new();
+            let mut struct_dict = std::collections::HashMap::new();
+            #(#add_enums);* ;
+            #(#add_structs);* ;
+            ReflectedTypeInfo {
+                enum_dict,
+                struct_dict
+            }
+        }
+    };
+    gen.into()
+}
+
+/* #region Helper methods */
+
+/// Gets the names and the types of the fields of an enum variant or struct.
+fn get_field_names_types(f: &syn::Fields) -> (Vec<String>, Vec<String>) {
+    match f {
+        Fields::Named(named_fields) => {
+            let (names, types): (Vec<_>, Vec<_>) = named_fields
+                .named
+                .iter()
+                .map(|n| {
+                    (
+                        n.ident.as_ref().unwrap().to_string(),
+                        get_type_as_string(&n.ty),
+                    )
+                })
+                .unzip();
+            (names, types)
+        }
+        Fields::Unnamed(unnamed_fields) => {
+            let types = unnamed_fields
+                .unnamed
+                .iter()
+                .map(|u| get_type_as_string(&u.ty))
+                .collect::<Vec<_>>();
+            (Vec::new(), types)
+        }
+        Fields::Unit => (Vec::new(), Vec::new()),
+    }
+}
+
+/// Gets the type name from the [`syn::Type`] object
+fn get_type_as_string(t: &syn::Type) -> String {
+    // convert type back into a token stream and then into a string
+    let mut token_stream = proc_macro2::TokenStream::new();
+    t.to_tokens(&mut token_stream);
+    token_stream.to_string()
+}
+
+/* #endregion */

--- a/src/lowertest/Cargo.toml
+++ b/src/lowertest/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "lowertest"
+description = "Utilities for testing lower layers of the Materialize stack"
+version = "0.0.0"
+edition = "2018"
+publish = false
+
+[dependencies]
+lowertest-derive = {path = "../lowertest-derive"}
+ore = {path = "../ore"}
+proc-macro2 = "1.0.27"
+serde = { version = "1.0.126", features = ["derive"] }
+serde_json = "1.0.64"
+
+[dev-dependencies]
+anyhow = "1.0.40"
+datadriven = "0.5.0"
+lazy_static = "1.4.0"

--- a/src/lowertest/README.md
+++ b/src/lowertest/README.md
@@ -147,6 +147,10 @@ If an object being created is registered as an enum or struct in
 * If the spec is an punct, `first_arg` will be the punct, and `rest_of_stream`
   will be `<any_puncts_in_between> <first_not_punct_token>`.
 
+Since a one-arg enum or struct can be specified as `(<the_arg>)` or
+`<the_arg>`, passing in the specification in the manner described above saves
+you from having to implement both syntaxes in `override_syntax`.
+
 ### Supported types
 
 * Enums

--- a/src/lowertest/README.md
+++ b/src/lowertest/README.md
@@ -1,0 +1,160 @@
+# Utility for testing lower layers of the Materialize stack
+
+## Purpose
+
+If you want to run tests on something like `MirRelationExpr`, specifying it in
+Rust is not only onerous but makes the tests hard to read.
+
+This crate supports converting a specification written in a readable syntax (see
+[#syntax]) into a Rust object that way you can directly test the lower layers of
+the stack.
+
+## Syntax
+
+Write:
+* an enum as `(variant_in_snake_case field1 field2 .. fieldn)`
+* a struct as `(field1 field2 .. fieldn)`
+* a `Vec` as `[elem1 elem2 .. elemn]`
+* a tuple as `{elem1 elem2 .. elemn}`
+* `None` or `null` as `null`
+* `true` (resp. `false`) as `true` (resp. `false`)
+* a string as `"something with quotations"`.
+* a numeric value like 1.1 or -1 as is.
+
+You can put commas between fields and elements; they will essentially be treated
+as whitespace.
+
+A enum (resp. struct) specs with only one argument can alternatively be written
+as `variant_in_snake_case` (resp. `field1`).
+
+The syntax can be overridden and extended by creating an object that implements
+the trait `TestDeserializationContext`; see [#extending-the-syntax] for more
+details.
+
+## Creating an object
+
+Look in the [tests](./tests) folder of this crate for an example.
+
+The main object creation method is
+```
+pub fn deserialize<D, I, C>(
+    stream_iter: &mut I,
+    type_name: &'static str,
+    rti: &ReflectedTypeInfo,
+    ctx: &mut C,
+) -> Result<D, String>
+where
+    C: TestDeserializeContext,
+    D: DeserializeOwned,
+    I: Iterator<Item = proc_macro2::TokenTree>
+```
+
+Let's break down what you need to do before you can call `deserialize` and what you
+should supply to `deserialize`.
+
+### 0. Required trait derivations
+
+The methods in this crate translate the test syntax into a JSON formatted string
+that can be correctly deserialized by [serde_json]. Because of this, the object
+you are trying to create must implement `serde::Deserialize`. It is
+recommended that the object also implement `serde::Serialize`.
+
+In order to translate the text syntax into a correctly-deserializable JSON
+string, we need information about enums and structs being created that are not
+specified in the test syntax.
+Thus, you need to derive the trait `MzEnumReflect` (resp. `MzStructReflect`) for
+each enum (resp. struct) that you will need to construct your object.
+
+Default values are supported as long as the default fields are last. Put
+`#[serde(default)]` over any fields you want to be default and make sure those
+fields have default values.
+
+[serde_json]: https://docs.serde.rs/serde_json/
+
+### 1. Parsing the test syntax
+
+Parse the string `s` containing your specification by calling
+`let mut stream_iter = s.to_string().parse::<proc_macro2::TokenStream>()?.into_iter()`.
+
+You now have an iterator over [`TokenTree`][proc_macro2] that you can pass
+into `deserialize`.
+
+You can specify the creation of multiple objects in the same string and
+deserialize them in order by making repeat calls to `deserialize`, passing in
+the same mutable iterator reference each time.
+
+### 2. Supplying the name of the object's type
+
+You have to pass in a string containing the name of your type.
+
+Rust does not have type objects that you can manipulate. Thus, information about
+enums and structs are keyed by string.
+
+### 3. Feeding in type information
+
+Enum/struct information must be passed into the converter via
+the struct `ReflectedTypeInfo`. For your convenience, there is a macro to
+generate a function will produce the right `ReflectedTypeInfo` for the object
+you are trying to create.
+```
+get_reflect_info_func!(func_name, [EnumType1, .., EnumTypeN], [StructType1, ..,StructTypeN])
+```
+Calling `func_name()` will produce the desired `ReflectedTypeInfo`.
+
+For instructions on how to manually populate `ReflectedTypeInfo`, see the struct
+documentation.
+
+### 4. Feeding in syntax extensions
+
+If you don't need to extend or override the syntax, give a
+`&mut GenericTestDeserializationContext::default()`.
+
+Otherwise, see [#extending-the-syntax].
+
+## Extending the syntax
+
+Create an object that implements the trait `TestDeserializationContext`.
+
+The trait has one method `override_syntax`.
+* Its first argument is `&mut self` this way the `TestDeserializationContext`
+  can store state across multiple objects being created.
+* The return value should always be `Ok(None)` except in the specific cases when
+  you are overriding or extending the syntax, in which case the return value
+  will be either `Ok(Some(JSON_string))` or `Err(err_string)`.
+* The second and third arguments of the method is the first element in the
+  stream and a pointer to the rest of the stream respectively. The contract of
+  `override_syntax` is that you promise not to iterate through the stream more
+  than is necessary to construct your object. If you return `Ok(None)`, you
+  should have left the stream untouched.
+* The fourth argument is the type of the object whose specification is currently
+  being translated. Note that the name of the type is only guaranteed to be
+  accurate if it is a [supported type](supported-types). Thus, if an enum
+  variant (resp. struct) you are trying to create has a field that is not a
+  supported type, you should use `override_syntax` to specify how to create the
+  enum variant (resp. struct).
+
+Refer to the [proc_macro2] docs for information how to parse the stream.
+
+[proc_macro2]: https://docs.rs/proc-macro2/1.0.27/proc_macro2/enum.TokenTree.html
+
+If an object being created is registered as an enum or struct in
+`ReflectedTypeInfo`, what is passed to `override_syntax` changes:
+* If the spec is a parentheses group (<arg1> .. <argn>), `first_arg` will be
+  `<arg1>` and `rest_of_stream` will be `<arg2> .. <argn>`. This saves you the
+  effort of unpacking the parentheses group.
+* If the spec is an ident or literal, `first_arg` will be the ident or literal,
+  and `rest_of_stream` will be empty.
+* If the spec is an punct, `first_arg` will be the punct, and `rest_of_stream`
+  will be `<any_puncts_in_between> <first_not_punct_token>`.
+
+### Supported types
+
+* Enums
+* Structs
+* Primitive types
+* Strings
+* Tuples
+* `Box<>`
+* `Option<>`
+* `Vec<>`
+* Combinations of the above.

--- a/src/lowertest/src/lib.rs
+++ b/src/lowertest/src/lib.rs
@@ -9,7 +9,7 @@
 
 //! Utilities for testing lower layers of the Materialize stack.
 //!
-//! See [README.md]
+//! See [README.md].
 
 use std::collections::HashMap;
 
@@ -144,11 +144,17 @@ where
         &type_name
     };
     if let Some(first_arg) = stream_iter.next() {
+        // If the type refers to an enum or struct defined by us, go to a
+        // special branch that allows reuse of code paths for the
+        // `(<arg1>..<argn>)` syntax as well as the `<only_arg>` syntax.
+        // Note that `parse_as_enum_or_struct` also calls
+        // `ctx.override_syntax`.
         if let Some(result) =
             parse_as_enum_or_struct(first_arg.clone(), stream_iter, &type_name, rti, ctx)?
         {
             return Ok(Some(result));
         }
+        // Resolving types that are not enums or structs defined by us.
         if let Some(result) =
             ctx.override_syntax(first_arg.clone(), stream_iter, &type_name, rti)?
         {

--- a/src/lowertest/src/lib.rs
+++ b/src/lowertest/src/lib.rs
@@ -1,0 +1,577 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Utilities for testing lower layers of the Materialize stack.
+//!
+//! See [README.md]
+
+use std::collections::HashMap;
+
+use proc_macro2::{Delimiter, TokenTree};
+use serde::de::DeserializeOwned;
+
+use ore::str::separated;
+
+pub use lowertest_derive::{gen_reflect_info_func, MzEnumReflect, MzStructReflect};
+
+/// A trait for listing the variants of an enum and the fields of each variant.
+///
+/// The information listed about the fields help build a JSON string that can
+/// be correctly deserialized into the enum.
+pub trait MzEnumReflect {
+    /// Returns a mapping of the variants of an enum to its fields.
+    ///
+    /// The first vector comprises the names of the variant's fields. It is
+    /// empty if the variant has no fields or if the variant's fields are
+    /// unnamed.
+    ///
+    /// The second vector comprises the types of the variant's fields. It is
+    /// empty if the variant has no fields.
+    fn mz_enum_reflect() -> HashMap<&'static str, (Vec<&'static str>, Vec<&'static str>)>;
+}
+
+/// A trait for listing the fields of a struct.
+///
+/// The information listed about the fields help build a JSON string that can
+/// be correctly deserialized into the struct.
+pub trait MzStructReflect {
+    /// Returns the fields of a struct.
+    ///
+    /// The first vector comprises the names of the struct's fields. It is
+    /// empty if the struct has no fields or if the struct's fields are
+    /// unnamed.
+    ///
+    /// The second vector comprises the types of the struct's fields. It is
+    /// empty if the struct has no fields.
+    fn mz_struct_reflect() -> (Vec<&'static str>, Vec<&'static str>);
+}
+
+/// If the `stream_iter` is not empty, deserialize the next `TokenTree` into a `D`.
+///
+/// See [`to_json`] for the object spec syntax.
+///
+/// `type_name` should be `D` in string form.
+///
+/// `stream_iter` will advance by one `TokenTree` no matter the result.
+pub fn deserialize_optional<D, I, C>(
+    stream_iter: &mut I,
+    type_name: &'static str,
+    rti: &ReflectedTypeInfo,
+    ctx: &mut C,
+) -> Result<Option<D>, String>
+where
+    C: TestDeserializeContext,
+    D: DeserializeOwned,
+    I: Iterator<Item = TokenTree>,
+{
+    match to_json(stream_iter, type_name, rti, ctx)? {
+        Some(j) => Ok(Some(serde_json::from_str::<D>(&j).map_err(|e| {
+            format!("String while serializing: {}\nOriginal JSON: {}", e, j)
+        })?)),
+        None => Ok(None),
+    }
+}
+
+/// Deserialize the next `TokenTree` into a `D` object.
+///
+/// See [`to_json`] for the object spec syntax.
+///
+/// `type_name` should be `D` in string form.
+///
+/// `stream_iter` will advance by one `TokenTree` no matter the result.
+pub fn deserialize<D, I, C>(
+    stream_iter: &mut I,
+    type_name: &'static str,
+    rti: &ReflectedTypeInfo,
+    ctx: &mut C,
+) -> Result<D, String>
+where
+    C: TestDeserializeContext,
+    D: DeserializeOwned,
+    I: Iterator<Item = TokenTree>,
+{
+    deserialize_optional(stream_iter, type_name, rti, ctx)?
+        .ok_or_else(|| format!("Empty spec for type {}", type_name))
+}
+
+/// Converts the next `TokenTree` in the stream into deserializable JSON.
+///
+/// Returns `None` if end of stream has been reached.
+///
+/// The JSON string should be deserializable into an object of type
+/// `type_name`.
+///
+/// Default object syntax:
+/// * An enum is represented as `(enum_variant_snake_case <arg1> <arg2> ..)`,
+///   unless it is a unit enum, in which case it can also be represented as
+///   `enum_variant_snake_case`. Enums can have optional arguments, which should
+///   all come at the end.
+/// * A struct is represented as `(<arg1> <arg2> ..)`
+/// * A vec or tuple is represented as `[<elem1> <elem2> ..]`
+/// * None/null is represented as `null`
+/// * true (resp. false) is represented as `true` (resp. `false`)
+/// * Strings are represented as `"something with quotations"`.
+/// * A numeric value like -1 or 1.1 is represented as is.
+/// * You can delimit arguments and elements using whitespace and/or commas.
+///
+/// `ctx` will extend and/or override the default syntax.
+pub fn to_json<I, C>(
+    stream_iter: &mut I,
+    type_name: &str,
+    rti: &ReflectedTypeInfo,
+    ctx: &mut C,
+) -> Result<Option<String>, String>
+where
+    C: TestDeserializeContext,
+    I: Iterator<Item = TokenTree>,
+{
+    // Normalize the type name by stripping whitespace.
+    let type_name = type_name.replace(" ", "");
+    // Eliminate outer `Option<>` and `Box<>` from type names because they are
+    // inconsequential when it comes to creating a correctly deserializable JSON
+    // string.
+    let type_name = if type_name.starts_with("Option<") && type_name.ends_with('>') {
+        &type_name[7..(type_name.len() - 1)]
+    } else if type_name.starts_with("Box<") && type_name.ends_with('>') {
+        &type_name[4..(type_name.len() - 1)]
+    } else {
+        &type_name
+    };
+    if let Some(first_arg) = stream_iter.next() {
+        if let Some(result) =
+            parse_as_enum_or_struct(first_arg.clone(), stream_iter, &type_name, rti, ctx)?
+        {
+            return Ok(Some(result));
+        }
+        if let Some(result) =
+            ctx.override_syntax(first_arg.clone(), stream_iter, &type_name, rti)?
+        {
+            return Ok(Some(result));
+        }
+        match first_arg {
+            TokenTree::Group(group) => {
+                let mut inner_iter = group.stream().into_iter();
+                match group.delimiter() {
+                    Delimiter::Bracket => {
+                        if type_name.starts_with("Vec<") && type_name.ends_with('>') {
+                            // This is a Vec<type_name>.
+                            Ok(Some(format!(
+                                "[{}]",
+                                separated(
+                                    ",",
+                                    parse_as_vec(
+                                        &mut inner_iter,
+                                        &type_name[4..(type_name.len() - 1)],
+                                        rti,
+                                        ctx
+                                    )?
+                                    .iter()
+                                )
+                            )))
+                        } else if type_name.starts_with('(') && type_name.ends_with(')') {
+                            Ok(Some(format!(
+                                "[{}]",
+                                separated(
+                                    ",",
+                                    parse_as_tuple(
+                                        &mut inner_iter,
+                                        &type_name[1..(type_name.len() - 1)],
+                                        rti,
+                                        ctx
+                                    )?
+                                    .iter()
+                                )
+                            )))
+                        } else {
+                            Err(format!(
+                                "Object specified with brackets {:?} has unsupported type {}",
+                                inner_iter, type_name
+                            ))
+                        }
+                    }
+                    delim => Err(format!(
+                        "Object spec {:?} (type {}) has unsupported delimiter {:?}",
+                        inner_iter.collect::<Vec<_>>(),
+                        type_name,
+                        delim
+                    )),
+                }
+            }
+            TokenTree::Punct(punct) => {
+                match punct.as_char() {
+                    // Pretend the comma does not exist and process the
+                    // next `TokenTree`
+                    ',' => to_json(stream_iter, type_name, rti, ctx),
+                    // Process the next `TokenTree` and prepend the
+                    // punctuation. This enables support for negative
+                    // numbers.
+                    other => match to_json(stream_iter, type_name, rti, ctx)? {
+                        Some(result) => Ok(Some(format!("{}{}", other, result))),
+                        None => Ok(Some(other.to_string())),
+                    },
+                }
+            }
+            TokenTree::Ident(ident) => Ok(Some(ident.to_string())),
+            TokenTree::Literal(literal) => Ok(Some(literal.to_string())),
+        }
+    } else {
+        Ok(None)
+    }
+}
+
+/// Info that must be combined with a spec to form deserializable JSON.
+///
+/// To add information about an enum, call
+/// `enum_dict.insert("EnumType", EnumType::mz_enum_reflect())`
+/// To add information about a struct, call
+/// `struct_dict.insert("StructType", StructType::mz_struct_reflect())`
+#[derive(Debug)]
+pub struct ReflectedTypeInfo {
+    pub enum_dict:
+        HashMap<&'static str, HashMap<&'static str, (Vec<&'static str>, Vec<&'static str>)>>,
+    pub struct_dict: HashMap<&'static str, (Vec<&'static str>, Vec<&'static str>)>,
+}
+
+/// A trait for extending and/or overriding the default test case syntax.
+///
+/// Note when creating an implementation of this trait that the
+/// `[proc_macro2::TokenStream]` considers:
+/// * null/true/false to be `Ident`s
+/// * strings and positive numeric values (like 1 or 1.1) to be `Literal`s.
+/// * negative numeric values to be a `Punct('-')` followed by a `Literal`.
+pub trait TestDeserializeContext {
+    /// Override the way that `first_arg` is resolved.
+    ///
+    /// `first_arg` is the first `TokenTree` of the `TokenStream`.
+    /// `rest_of_stream` contains a reference to the rest of the stream.
+    ///
+    /// Returns Ok(Some(value)) if `first_arg` has been resolved.
+    /// Returns Ok(None) if `first_arg` should be resolved using the default
+    /// syntax. If returning Ok(None), the function implementation
+    /// promises not to advance `rest_of_stream`.
+    fn override_syntax<I>(
+        &mut self,
+        first_arg: TokenTree,
+        rest_of_stream: &mut I,
+        type_name: &str,
+        rti: &ReflectedTypeInfo,
+    ) -> Result<Option<String>, String>
+    where
+        I: Iterator<Item = TokenTree>;
+}
+
+/// Default `TestDeserializeContext`.
+///
+/// Does not override or extend any of the default syntax.
+#[derive(Default)]
+pub struct GenericTestDeserializeContext;
+
+impl TestDeserializeContext for GenericTestDeserializeContext {
+    fn override_syntax<I>(
+        &mut self,
+        _first_arg: TokenTree,
+        _rest_of_stream: &mut I,
+        _type_name: &str,
+        _rti: &ReflectedTypeInfo,
+    ) -> Result<Option<String>, String>
+    where
+        I: Iterator<Item = TokenTree>,
+    {
+        Ok(None)
+    }
+}
+
+/* #region helper functions */
+
+/// Converts all `TokenTree`s into JSON deserializable to `type_name`.
+fn parse_as_vec<I, C>(
+    stream_iter: &mut I,
+    type_name: &str,
+    rti: &ReflectedTypeInfo,
+    ctx: &mut C,
+) -> Result<Vec<String>, String>
+where
+    C: TestDeserializeContext,
+    I: Iterator<Item = TokenTree>,
+{
+    let mut result = Vec::new();
+    while let Some(element) = to_json(stream_iter, type_name, rti, ctx)? {
+        result.push(element);
+    }
+    Ok(result)
+}
+
+/// Converts all `TokenTree`s into JSON.
+///
+/// `type_name` is assumed to have been stripped of whitespace.
+fn parse_as_tuple<I, C>(
+    stream_iter: &mut I,
+    type_name: &str,
+    rti: &ReflectedTypeInfo,
+    ctx: &mut C,
+) -> Result<Vec<String>, String>
+where
+    C: TestDeserializeContext,
+    I: Iterator<Item = TokenTree>,
+{
+    let mut next_elem_begin = 0;
+    let mut result = Vec::new();
+    loop {
+        // The elements of the tuple can be a plain type, a nested tuple, or a
+        // Box/Vec/Option with the argument being nested tuple.
+        // `type1, (type2, type3), Vec<(type4, type5)>`
+        // Thus, the type of the next element is whatever comes before the
+        // next comma. Unless... a '(' comes from before the next comma, which
+        // means it is a nested tuple, and the type of the next element is
+        // whatever comes before the comma after the last ')'.
+        let mut next_elem_end = type_name[next_elem_begin..]
+            .find(',')
+            .unwrap_or_else(|| type_name.len());
+        if let Some(l_paren_pos) = type_name[next_elem_begin..].find('(') {
+            if l_paren_pos < next_elem_end {
+                if let Some(r_paren_pos) = type_name[next_elem_begin..].rfind(')') {
+                    next_elem_end = next_elem_begin
+                        + r_paren_pos
+                        + type_name[(next_elem_begin + r_paren_pos)..]
+                            .find(',')
+                            .unwrap_or_else(|| type_name.len());
+                }
+            }
+        };
+        match to_json(
+            stream_iter,
+            &type_name[next_elem_begin..next_elem_end],
+            rti,
+            ctx,
+        )? {
+            Some(elem) => result.push(elem),
+            // we have reached the end of the tuple. Assume that any remaining
+            // elements of the tuple are optional.
+            None => break,
+        }
+        if next_elem_end < type_name.len() {
+            //skip over the comma
+            next_elem_begin = next_elem_end + 1;
+        } else {
+            // assume that that we have reached the end of the tuple.
+            break;
+        }
+    }
+    Ok(result)
+}
+
+/// Converts stream into JSON if `type_name` refers to an enum or struct
+///
+/// Returns `Ok(Some(string))` if `type_name` refers to an enum or struct, and
+/// there are no stream conversion errors.
+/// Returns `Ok(None)` if `type_name` does not refer to an enum or struct.
+fn parse_as_enum_or_struct<I, C>(
+    first_arg: TokenTree,
+    rest_of_stream: &mut I,
+    type_name: &str,
+    rti: &ReflectedTypeInfo,
+    ctx: &mut C,
+) -> Result<Option<String>, String>
+where
+    C: TestDeserializeContext,
+    I: Iterator<Item = TokenTree>,
+{
+    if rti.enum_dict.contains_key(type_name) || rti.struct_dict.contains_key(type_name) {
+        // An enum or a struct can be specified as `(arg1 .. argn)` or
+        // `only_arg`. The goal here is to feed the enum/struct specification
+        // into a common inner method that takes
+        // `(first_token_of_spec, rest_of_tokens_comprising_spec)`
+        match first_arg {
+            TokenTree::Group(group) => {
+                let mut inner_iter = group.stream().into_iter();
+                match group.delimiter() {
+                    Delimiter::Parenthesis => match inner_iter.next() {
+                        // the spec is the inner `TokenStream`
+                        Some(first_arg) => parse_as_enum_or_struct_inner(
+                            first_arg,
+                            &mut inner_iter,
+                            type_name,
+                            rti,
+                            ctx,
+                        ),
+                        None => Ok(None),
+                    },
+                    _ => Ok(None),
+                }
+            }
+            TokenTree::Punct(punct) => {
+                // The spec is all consecutive puncts + the first non-punct
+                // symbol. This allows for specifying structs with the first
+                // argument being something like -1.1.
+                let mut consecutive_punct = Vec::new();
+                while let Some(token) = rest_of_stream.next() {
+                    consecutive_punct.push(token);
+                    match &consecutive_punct[consecutive_punct.len() - 1] {
+                        TokenTree::Punct(_) => {}
+                        _ => {
+                            break;
+                        }
+                    }
+                }
+                parse_as_enum_or_struct_inner(
+                    TokenTree::Punct(punct),
+                    &mut consecutive_punct.into_iter(),
+                    type_name,
+                    rti,
+                    ctx,
+                )
+            }
+            other => {
+                // The entire enum/struct is specified by the Ident/Literal,
+                // so feed in (the_ident_literal, nothing)
+                parse_as_enum_or_struct_inner(other, &mut std::iter::empty(), type_name, rti, ctx)
+            }
+        }
+    } else {
+        Ok(None)
+    }
+}
+
+fn parse_as_enum_or_struct_inner<I, C>(
+    first_arg: TokenTree,
+    rest_of_stream: &mut I,
+    type_name: &str,
+    rti: &ReflectedTypeInfo,
+    ctx: &mut C,
+) -> Result<Option<String>, String>
+where
+    C: TestDeserializeContext,
+    I: Iterator<Item = TokenTree>,
+{
+    if let Some(result) = ctx.override_syntax(first_arg.clone(), rest_of_stream, type_name, rti)? {
+        Ok(Some(result))
+    } else if let Some((f_names, f_types)) = rti.struct_dict.get(type_name).map(|r| r.clone()) {
+        Ok(Some(to_json_fields(
+            &mut (&mut std::iter::once(first_arg)).chain(rest_of_stream),
+            f_names,
+            f_types,
+            rti,
+            ctx,
+        )?))
+    } else if let TokenTree::Ident(ident) = first_arg {
+        Ok(Some(to_json_generic_enum(
+            ident.to_string(),
+            rest_of_stream,
+            type_name,
+            rti,
+            ctx,
+        )?))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Converts the spec of an enum into deserializable JSON
+fn to_json_generic_enum<I, C>(
+    variant_snake_case: String,
+    rest_of_stream: &mut I,
+    type_name: &str,
+    rti: &ReflectedTypeInfo,
+    ctx: &mut C,
+) -> Result<String, String>
+where
+    C: TestDeserializeContext,
+    I: Iterator<Item = TokenTree>,
+{
+    // Convert the variant from snake_case to CamelCase
+    let variant_camel_case = variant_snake_case
+        .split('_')
+        .map(|s| {
+            let mut chars = s.chars();
+            let result = chars
+                .next()
+                .map(|c| c.to_uppercase().chain(chars).collect::<String>())
+                .unwrap_or_else(|| String::new());
+            result
+        })
+        .collect::<Vec<_>>()
+        .concat();
+    let (f_names, f_types) = rti
+        .enum_dict
+        .get(type_name)
+        .unwrap()
+        .get(&variant_camel_case[..])
+        .map(|v| v.clone())
+        .ok_or_else(|| {
+            format!(
+                "{}::{} is not a supported enum ",
+                type_name, variant_camel_case
+            )
+        })?;
+    // If we reach end of stream before getting a value for each field,
+    // we assume that the fields we don't have values for are optional.
+    if f_types.is_empty() {
+        // The JSON for a unit enum is just `"variant"`.
+        Ok(format!("\"{}\"", variant_camel_case))
+    } else {
+        let fields = to_json_fields(rest_of_stream, f_names, f_types, rti, ctx)?;
+        Ok(format!("{{\"{}\":{}}}", variant_camel_case, fields))
+    }
+}
+
+/// Converts the spec for fields of an enum/struct into deserializable JSON.
+///
+/// `f_names` contains the names of the fields. If the fields are unnamed,
+/// `f_names` is empty.
+/// `f_types` contains the types of the fields.
+fn to_json_fields<I, C>(
+    stream_iter: &mut I,
+    f_names: Vec<&'static str>,
+    f_types: Vec<&'static str>,
+    rti: &ReflectedTypeInfo,
+    ctx: &mut C,
+) -> Result<String, String>
+where
+    C: TestDeserializeContext,
+    I: Iterator<Item = TokenTree>,
+{
+    let mut f_values = Vec::new();
+    for t in f_types.iter() {
+        match to_json(stream_iter, t, rti, ctx)? {
+            Some(value) => f_values.push(value),
+            None => {
+                break;
+            }
+        }
+    }
+    if !f_names.is_empty() {
+        // The JSON for named fields is
+        // `{"arg1":<val1>, ..}}`.
+        Ok(format!(
+            "{{{}}}",
+            separated(
+                ",",
+                f_names
+                    .iter()
+                    .zip(f_values.into_iter())
+                    .map(|(n, v)| format!("\"{}\":{}", n, v))
+            )
+        ))
+    } else {
+        // The JSON for unnamed fields is
+        // `[<val1>, ..]}`, unless it has only one field,
+        // in which case the JSON is `<val1>`
+        if f_types.len() == 1 {
+            Ok(format!(
+                "{}",
+                f_values.pop().ok_or_else(|| {
+                    "Cannot use default value for enum with unnamed single field".to_string()
+                })?
+            ))
+        } else {
+            Ok(format!("[{}]", separated(",", f_values.into_iter())))
+        }
+    }
+}
+/* #endregion */

--- a/src/lowertest/tests/test_runner.rs
+++ b/src/lowertest/tests/test_runner.rs
@@ -1,0 +1,169 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+#[cfg(test)]
+mod tests {
+    use lowertest::*;
+
+    use std::collections::HashMap;
+
+    use lazy_static::lazy_static;
+    use proc_macro2::{TokenStream, TokenTree};
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Deserialize, Serialize, MzStructReflect)]
+    struct TestStruct1(Box<f64>);
+
+    #[derive(Debug, Deserialize, Serialize, MzStructReflect)]
+    struct TestStruct2(Vec<(usize, Vec<(String, usize)>, usize)>, String);
+
+    #[derive(Debug, Deserialize, Serialize, MzStructReflect)]
+    struct TestStruct3 {
+        fizz: Vec<Option<bool>>,
+        bizz: Vec<Vec<(TestStruct1, bool)>>,
+    }
+
+    #[derive(Debug, Deserialize, Serialize, MzEnumReflect)]
+    enum TestEnum {
+        SingleNamedField {
+            foo: Vec<usize>,
+        },
+        MultiNamedFields {
+            #[serde(default)]
+            bar: Option<String>,
+            #[serde(default)]
+            baz: bool,
+        },
+        SingleUnnamedField(TestStruct1),
+        MultiUnnamedFields(TestStruct2, TestStruct3, Box<TestEnum>),
+        Unit,
+    }
+
+    gen_reflect_info_func!(
+        produce_rti,
+        [TestEnum],
+        [TestStruct1, TestStruct2, TestStruct3]
+    );
+
+    lazy_static! {
+        static ref RTI: ReflectedTypeInfo = produce_rti();
+    }
+
+    #[derive(Default)]
+    struct TestOverrideDeserializeContext;
+
+    impl TestDeserializeContext for TestOverrideDeserializeContext {
+        /// This increments all numbers of type "usize" by one.
+        /// If a positive f64 has been specified with +<the number>,
+        /// ignore the +.
+        /// Define an alternate syntax for `TestStruct2`:
+        /// * (<usize1> "string") creates
+        ///   `TestStruct2([(<usize1>, [("string", <usize1>)], <usize1>)], "string")`
+        /// * "string" creates `TestStruct2([], "string")`
+        /// * "<usize1>" creates
+        ///   `TestStruct2([(<usize1>, [("", <usize1>)], <usize1>)], "")
+        fn override_syntax<I>(
+            &mut self,
+            first_arg: TokenTree,
+            rest_of_stream: &mut I,
+            type_name: &str,
+            rti: &ReflectedTypeInfo,
+        ) -> Result<Option<String>, String>
+        where
+            I: Iterator<Item = TokenTree>,
+        {
+            if type_name == "TestStruct2" {
+                if let TokenTree::Literal(literal) = first_arg.clone() {
+                    let litval = literal.to_string();
+                    if litval.starts_with('"') {
+                        return Ok(Some(format!("[[], {}]", litval)));
+                    } else {
+                        let usize_lit = litval.parse::<usize>().map_err(|_| {
+                            format!("{} cannot be parsed as a usize or a string", litval)
+                        })?;
+                        let mut stream_peek = rest_of_stream.peekable();
+                        let str_lit = if stream_peek.peek().is_some() {
+                            match stream_peek.next() {
+                                Some(TokenTree::Literal(literal)) => literal.to_string(),
+                                unexpected => {
+                                    return Err(format!(
+                                        "unexpected second argument for TestStruct2 {:?}",
+                                        unexpected
+                                    ))
+                                }
+                            }
+                        } else {
+                            "".to_string()
+                        };
+                        return Ok(Some(
+                            serde_json::to_string(&TestStruct2(
+                                vec![(usize_lit, vec![(str_lit.clone(), usize_lit)], usize_lit)],
+                                str_lit,
+                            ))
+                            .unwrap(),
+                        ));
+                    }
+                }
+            } else if type_name == "f64" {
+                if let TokenTree::Punct(punct) = first_arg.clone() {
+                    if punct.as_char() == '+' {
+                        return to_json(rest_of_stream, type_name, rti, self);
+                    }
+                }
+            } else if type_name == "usize" {
+                if let TokenTree::Literal(literal) = first_arg {
+                    let litval = literal
+                        .to_string()
+                        .parse::<usize>()
+                        .map_err(|e| e.to_string())?;
+                    return Ok(Some(format!("{}", litval + 1)));
+                }
+            }
+            Ok(None)
+        }
+    }
+
+    fn build(s: &str, args: &HashMap<String, Vec<String>>) -> Result<String, String> {
+        let stream = s
+            .to_string()
+            .parse::<TokenStream>()
+            .map_err(|e| e.to_string())?;
+        let result: Option<TestEnum> = if args.get("override").is_some() {
+            deserialize_optional(
+                &mut stream.into_iter(),
+                "TestEnum",
+                &RTI,
+                &mut TestOverrideDeserializeContext::default(),
+            )
+        } else {
+            deserialize_optional(
+                &mut stream.into_iter(),
+                "TestEnum",
+                &RTI,
+                &mut GenericTestDeserializeContext::default(),
+            )
+        }?;
+        Ok(format!("{:?}", result))
+    }
+
+    #[test]
+    fn run() {
+        datadriven::walk("tests/testdata", |f| {
+            f.run(move |s| -> String {
+                match s.directive.as_str() {
+                    "build" => match build(&s.input, &s.args) {
+                        Ok(msg) => format!("{}\n", msg.trim_end().to_string()),
+                        Err(err) => format!("error: {}\n", err),
+                    },
+                    _ => panic!("unknown directive: {}", s.directive),
+                }
+            })
+        });
+    }
+}

--- a/src/lowertest/tests/testdata/build
+++ b/src/lowertest/tests/testdata/build
@@ -1,0 +1,68 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Tests that this module supports the default syntax as specified in the
+# readme.
+
+build
+----
+None
+
+build
+(multi_unnamed_fields
+    (
+        [
+            [3 [["world" 5] ["this" 2]] 4]
+            [2 [] 0]
+        ]
+        "hello"
+    )
+    ([true false null] [[[100 true] [200 false]][]])
+    (single_named_field [0 10 42]))
+----
+Some(MultiUnnamedFields(TestStruct2([(3, [("world", 5), ("this", 2)], 4), (2, [], 0)], "hello"), TestStruct3 { fizz: [Some(true), Some(false), None], bizz: [[(TestStruct1(100.0), true), (TestStruct1(200.0), false)], []] }, SingleNamedField { foo: [0, 10, 42] }))
+
+build
+(multi_named_fields null false)
+----
+Some(MultiNamedFields { bar: None, baz: false })
+
+# test that unit enum variants and structs with a single field can be
+# constructed with and without parenthesis around them
+build
+unit
+----
+Some(Unit)
+
+build
+(single_unnamed_field -1.1)
+----
+Some(SingleUnnamedField(TestStruct1(-1.1)))
+
+build
+(unit)
+----
+Some(Unit)
+
+build
+(single_unnamed_field (-1.1))
+----
+Some(SingleUnnamedField(TestStruct1(-1.1)))
+
+# default argument tests
+
+build
+multi_named_fields
+----
+Some(MultiNamedFields { bar: None, baz: false })
+
+build
+(multi_named_fields "realm")
+----
+Some(MultiNamedFields { bar: Some("realm"), baz: false })

--- a/src/lowertest/tests/testdata/build-override
+++ b/src/lowertest/tests/testdata/build-override
@@ -1,0 +1,85 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Everything that we haven't overridden should build the same.
+
+build override=true
+----
+None
+
+build override=true
+unit
+----
+Some(Unit)
+
+build override=true
+(single_unnamed_field -1.1)
+----
+Some(SingleUnnamedField(TestStruct1(-1.1)))
+
+build override=true
+(unit)
+----
+Some(Unit)
+
+build
+(single_unnamed_field (-1.1))
+----
+Some(SingleUnnamedField(TestStruct1(-1.1)))
+
+build
+(multi_named_fields null false)
+----
+Some(MultiNamedFields { bar: None, baz: false })
+
+build override=true
+multi_named_fields
+----
+Some(MultiNamedFields { bar: None, baz: false })
+
+build override=true
+(multi_named_fields "realm")
+----
+Some(MultiNamedFields { bar: Some("realm"), baz: false })
+
+# Override tests.
+
+# Note that this is also a test that we are correctly
+# transmitting type information during the creation of each subfield.
+
+build override=true
+(multi_unnamed_fields
+    (
+        [
+            [3 [["world" 5] ["this" 2]] 4]
+            [2 [] 0]
+        ]
+        "hello"
+    )
+    ([true false null] [[[100 true] [200 false]][]])
+    (single_named_field [0 10 42]))
+----
+Some(MultiUnnamedFields(TestStruct2([(4, [("world", 6), ("this", 3)], 5), (3, [], 1)], "hello"), TestStruct3 { fizz: [Some(true), Some(false), None], bizz: [[(TestStruct1(100.0), true), (TestStruct1(200.0), false)], []] }, SingleNamedField { foo: [1, 11, 43] }))
+
+build override=true
+(single_unnamed_field +1.1)
+----
+Some(SingleUnnamedField(TestStruct1(1.1)))
+
+# Test our alternate syntax for passing in enum/struct information
+# for overriding
+build override=true
+(multi_unnamed_fields
+    (2 "goodbye")
+    ([true false null] [[[100 true] [200 false]][]])
+    (multi_unnamed_fields 3 ([] [[[-1 true]]])
+         (multi_unnamed_fields "again" ([false false false] []) unit)
+        ))
+----
+Some(MultiUnnamedFields(TestStruct2([(2, [("\"goodbye\"", 2)], 2)], "\"goodbye\""), TestStruct3 { fizz: [Some(true), Some(false), None], bizz: [[(TestStruct1(100.0), true), (TestStruct1(200.0), false)], []] }, MultiUnnamedFields(TestStruct2([(3, [("", 3)], 3)], ""), TestStruct3 { fizz: [], bizz: [[(TestStruct1(-1.0), true)]] }, MultiUnnamedFields(TestStruct2([], "again"), TestStruct3 { fizz: [Some(false), Some(false), Some(false)], bizz: [] }, Unit))))


### PR DESCRIPTION
The first commit here is the first commit in #6889, which contains the general framework for creating arbitrary IRs.
Two new crates src/lowertest and src/lowertest-derive are being created.

The second commit here addresses comments in #6889 from @asenac and @benesch . Kept the macros since @benesch believes them to be a negligible cost at compile time, but added a comment that `walkabout` is an option.