### PR TITLE
persist:  remove the Persister trait and move its methods to a struct over Buffer and Blob impls

### DIFF
--- a/src/persist/README.md
+++ b/src/persist/README.md
@@ -5,14 +5,12 @@ Materialize.
 
 ### Overview
 
-A persistence user would start by constructing a `PersistManager` which is a
-thin `Send+Sync+Clone` handle around a `Persister` impl which does the heavy
-lifting (see details below). `PersistManager` is a registry for multiple streams
-(each corresponding to a table, source, or operator) in a single process. This
-allows us to funnel everything a process is persisting through a single place
-for batching and rate limiting.
+A persistence user would start by constructing a `Persister` which is a registry
+for multiple streams (each corresponding to a table, source, or operator) in a
+single process. This allows us to funnel everything a process is persisting through
+a single place for batching and rate limiting.
 
-Given a unique `Id`, `PersistManager` will hand back a `Token`. This
+Given a unique `Id`, `Persister` will hand back a `Token`. This
 can be handed in (consumed) to create a timely operator that persists and passes
 through its input.
 

--- a/src/persist/src/indexed/mod.rs
+++ b/src/persist/src/indexed/mod.rs
@@ -391,7 +391,10 @@ mod tests {
             (("2".into(), "".into()), 2, 1),
         ];
 
-        let mut i = Indexed::new(MemBuffer::new(), MemBlob::new())?;
+        let mut i = Indexed::new(
+            MemBuffer::new("single_stream")?,
+            MemBlob::new("single_stream")?,
+        )?;
         let id = Id(0);
         i.register(id);
 

--- a/src/persist/src/lib.rs
+++ b/src/persist/src/lib.rs
@@ -19,11 +19,6 @@ pub mod operators;
 pub mod persister;
 pub mod storage;
 
-use std::sync::{Arc, Mutex};
-
-use crate::error::Error;
-use crate::persister::Persister;
-
 // TODO
 // - The concurrency story. I imagine this working something like the following:
 //   - Writes from all streams are funnelled to a single thread which
@@ -45,8 +40,6 @@ use crate::persister::Persister;
 //   them as type parameters? Materialize will only be using one combination of
 //   them (two with `()` vals?) but the generality might make things easier to
 //   read. Of course, it also might make things harder to read.
-// - Is PersistManager getting us anything over a type alias? At the moment, the
-//   only thing it does is wrap mutex poison errors in this crate's error type.
 // - This method of getting the metadata handle ends up being pretty clunky in
 //   practice. Maybe instead the user should pass in a mutable reference to a
 //   `Meta` they've constructed like `probe_with`?
@@ -77,41 +70,6 @@ use crate::persister::Persister;
 /// A unique id for a persisted stream.
 #[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub struct Id(pub u64);
-
-/// A thread-safe, clone-able wrapper for [Persister].
-pub struct PersistManager<P> {
-    persister: Arc<Mutex<P>>,
-}
-
-// The derived Send, Sync, and Clone don't work because of the type parameter.
-unsafe impl<P> Send for PersistManager<P> {}
-unsafe impl<P> Sync for PersistManager<P> {}
-impl<P> Clone for PersistManager<P> {
-    fn clone(&self) -> Self {
-        PersistManager {
-            persister: self.persister.clone(),
-        }
-    }
-}
-
-impl<P: Persister> PersistManager<P> {
-    /// Returns a [PersistManager] wrapper for the given [Persister].
-    pub fn new(persister: P) -> Self {
-        PersistManager {
-            persister: Arc::new(Mutex::new(persister)),
-        }
-    }
-
-    /// A wrapper for [Persister::create_or_load].
-    pub fn create_or_load(&mut self, id: Id) -> Result<Token<P::Write, P::Meta>, Error> {
-        self.persister.lock()?.create_or_load(id)
-    }
-
-    /// A wrapper for [Persister::destroy].
-    pub fn destroy(&mut self, id: Id) -> Result<(), Error> {
-        self.persister.lock()?.destroy(id)
-    }
-}
 
 /// An exclusivity token needed to construct persistence [operators].
 ///

--- a/src/persist/src/mem.rs
+++ b/src/persist/src/mem.rs
@@ -9,33 +9,56 @@
 
 //! In-memory implementations for testing and benchmarking.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::ops::Range;
 use std::sync::{Arc, Mutex};
 
 use crate::error::Error;
-use crate::persister::{Meta, Persister, Snapshot, Write};
-use crate::storage::{Blob, Buffer, SeqNo};
-use crate::{Id, Token};
+use crate::persister::{Meta, Snapshot, Write};
+use crate::storage::{Blob, Buffer, Persister, SeqNo};
 
-/// An in-memory implementation of [Buffer].
-pub struct MemBuffer {
+struct MemBufferCore {
     seqno: Range<SeqNo>,
     dataz: Vec<Vec<u8>>,
+    lock: Option<String>,
 }
 
-impl MemBuffer {
-    /// Constructs a new, empty MemBuffer.
-    pub fn new() -> Self {
-        MemBuffer {
+impl MemBufferCore {
+    fn new() -> Self {
+        MemBufferCore {
             seqno: SeqNo(0)..SeqNo(0),
             dataz: Vec::new(),
+            lock: None,
         }
     }
-}
 
-impl Buffer for MemBuffer {
+    fn open(&mut self, lock_info: &str) -> Result<(), Error> {
+        if let Some(lock) = &self.lock {
+            return Err(format!("buffer is already open: {}", lock).into());
+        }
+
+        self.lock = Some(lock_info.to_string());
+
+        Ok(())
+    }
+
+    fn close(&mut self) -> Result<(), Error> {
+        self.ensure_open()?;
+
+        self.lock = None;
+        Ok(())
+    }
+
+    fn ensure_open(&self) -> Result<(), Error> {
+        if self.lock.is_none() {
+            return Err("buffer unexpectedly closed".into());
+        }
+
+        Ok(())
+    }
+
     fn write_sync(&mut self, buf: Vec<u8>) -> Result<SeqNo, Error> {
+        self.ensure_open()?;
         let write_seqno = self.seqno.end;
         self.seqno = self.seqno.start..SeqNo(self.seqno.end.0 + 1);
         self.dataz.push(buf);
@@ -50,6 +73,7 @@ impl Buffer for MemBuffer {
     where
         F: FnMut(SeqNo, &[u8]) -> Result<(), Error>,
     {
+        self.ensure_open()?;
         self.dataz
             .iter()
             .enumerate()
@@ -59,6 +83,7 @@ impl Buffer for MemBuffer {
     }
 
     fn truncate(&mut self, upper: SeqNo) -> Result<(), Error> {
+        self.ensure_open()?;
         // TODO: Test the edge cases here.
         if upper <= self.seqno.start || upper > self.seqno.end {
             return Err(format!(
@@ -78,26 +103,101 @@ impl Buffer for MemBuffer {
     }
 }
 
-/// An in-memory implementation of [Blob].
-pub struct MemBlob {
-    dataz: HashMap<String, Vec<u8>>,
+/// An in-memory implementation of [Buffer].
+pub struct MemBuffer {
+    core: Arc<Mutex<MemBufferCore>>,
 }
 
-impl MemBlob {
-    /// Constructs a new, empty MemBlob.
-    pub fn new() -> Self {
-        MemBlob {
-            dataz: HashMap::new(),
-        }
+impl MemBuffer {
+    /// Constructs a new, empty MemBuffer.
+    pub fn new(lock_info: &str) -> Result<Self, Error> {
+        let mut core = MemBufferCore::new();
+        core.open(lock_info)?;
+        Ok(Self {
+            core: Arc::new(Mutex::new(core)),
+        })
+    }
+
+    /// Open a pre-existing MemBuffer.
+    fn open(core: Arc<Mutex<MemBufferCore>>, lock_info: &str) -> Result<Self, Error> {
+        core.lock()?.open(lock_info)?;
+        Ok(Self { core })
+    }
+
+    /// Close a pre-existing MemBuffer
+    fn close(&mut self) -> Result<(), Error> {
+        self.core.lock()?.close()
     }
 }
 
-impl Blob for MemBlob {
+impl Drop for MemBuffer {
+    fn drop(&mut self) {
+        self.close().expect("closing MemBuffer cannot fail");
+    }
+}
+
+impl Buffer for MemBuffer {
+    fn write_sync(&mut self, buf: Vec<u8>) -> Result<SeqNo, Error> {
+        self.core.lock()?.write_sync(buf)
+    }
+
+    fn snapshot<F>(&self, logic: F) -> Result<Range<SeqNo>, Error>
+    where
+        F: FnMut(SeqNo, &[u8]) -> Result<(), Error>,
+    {
+        self.core.lock()?.snapshot(logic)
+    }
+
+    fn truncate(&mut self, upper: SeqNo) -> Result<(), Error> {
+        self.core.lock()?.truncate(upper)
+    }
+}
+
+struct MemBlobCore {
+    dataz: HashMap<String, Vec<u8>>,
+    lock: Option<String>,
+}
+
+impl MemBlobCore {
+    fn new() -> Self {
+        MemBlobCore {
+            dataz: HashMap::new(),
+            lock: None,
+        }
+    }
+
+    fn open(&mut self, lock_info: &str) -> Result<(), Error> {
+        if let Some(lock) = &self.lock {
+            return Err(format!("blob is already open: {}", lock).into());
+        }
+
+        self.lock = Some(lock_info.to_string());
+
+        Ok(())
+    }
+
+    fn close(&mut self) -> Result<(), Error> {
+        self.ensure_open()?;
+
+        self.lock = None;
+        Ok(())
+    }
+
+    fn ensure_open(&self) -> Result<(), Error> {
+        if self.lock.is_none() {
+            return Err("blob unexpectedly closed".into());
+        }
+
+        Ok(())
+    }
+
     fn get(&self, key: &str) -> Result<Option<Vec<u8>>, Error> {
+        self.ensure_open()?;
         Ok(self.dataz.get(key).cloned())
     }
 
     fn set(&mut self, key: &str, value: Vec<u8>, allow_overwrite: bool) -> Result<(), Error> {
+        self.ensure_open()?;
         if allow_overwrite {
             self.dataz.insert(key.to_owned(), value);
         } else if self.dataz.contains_key(key) {
@@ -109,60 +209,83 @@ impl Blob for MemBlob {
     }
 }
 
-/// An in-memory implementation of [Persister].
-pub struct MemPersister {
-    registered: HashSet<Id>,
-    dataz: HashMap<Id, MemStream>,
+/// An in-memory implementation of [Blob].
+pub struct MemBlob {
+    core: Arc<Mutex<MemBlobCore>>,
 }
 
-impl MemPersister {
-    /// Constructs a new, empty MemPersister.
+impl MemBlob {
+    /// Constructs a new, empty MemBlob.
+    pub fn new(lock_info: &str) -> Result<Self, Error> {
+        let mut core = MemBlobCore::new();
+        core.open(lock_info)?;
+        Ok(MemBlob {
+            core: Arc::new(Mutex::new(core)),
+        })
+    }
+
+    /// Open a pre-existing MemBlob.
+    fn open(core: Arc<Mutex<MemBlobCore>>, lock_info: &str) -> Result<Self, Error> {
+        core.lock()?.open(lock_info)?;
+        Ok(Self { core })
+    }
+
+    /// Close a pre-existing MemBlob
+    fn close(&mut self) -> Result<(), Error> {
+        self.core.lock()?.close()
+    }
+}
+
+impl Drop for MemBlob {
+    fn drop(&mut self) {
+        self.close().expect("closing MemBlob cannot fail");
+    }
+}
+
+impl Blob for MemBlob {
+    fn get(&self, key: &str) -> Result<Option<Vec<u8>>, Error> {
+        self.core.lock()?.get(key)
+    }
+
+    fn set(&mut self, key: &str, value: Vec<u8>, allow_overwrite: bool) -> Result<(), Error> {
+        self.core.lock()?.set(key, value, allow_overwrite)
+    }
+}
+
+/// An in-memory representation of a set of [Buffer]s and [Blob]s that can be reused
+/// across dataflows
+pub struct MemRegistry {
+    by_path: HashMap<usize, (Arc<Mutex<MemBufferCore>>, Arc<Mutex<MemBlobCore>>)>,
+}
+
+impl MemRegistry {
+    /// Constructs a new, empty MemRegistry
     pub fn new() -> Self {
-        MemPersister {
-            registered: HashSet::new(),
-            dataz: HashMap::new(),
+        MemRegistry {
+            by_path: HashMap::new(),
         }
     }
 
-    /// Consumes this MemPersister, returning the underlying data.
-    #[cfg(test)]
-    pub fn into_inner(self) -> HashMap<Id, MemStream> {
-        self.dataz
-    }
+    /// Opens the in-memory [Persister] associated with `path` or creates one if
+    /// none exists.
+    pub fn open(
+        &mut self,
+        path: usize,
+        lock_info: &str,
+    ) -> Result<Persister<MemBuffer, MemBlob>, Error> {
+        let (buffer, blob) = if let Some((buffer, blob)) = self.by_path.get(&path) {
+            (buffer.clone(), blob.clone())
+        } else {
+            let buffer = Arc::new(Mutex::new(MemBufferCore::new()));
+            let blob = Arc::new(Mutex::new(MemBlobCore::new()));
 
-    /// Constructs a MemPersister from a previous MemPersister's data but with
-    /// the create_or_load registrations reset.
-    #[cfg(test)]
-    pub fn from_inner(inner: HashMap<Id, MemStream>) -> Self {
-        MemPersister {
-            registered: HashSet::new(),
-            dataz: inner,
-        }
-    }
-}
-
-impl Persister for MemPersister {
-    type Write = MemStream;
-    type Meta = MemStream;
-
-    fn create_or_load(&mut self, id: Id) -> Result<Token<Self::Write, Self::Meta>, Error> {
-        if self.registered.contains(&id) {
-            return Err(format!("internal error: {:?} already registered", id).into());
-        }
-        self.registered.insert(id);
-        let p = self.dataz.entry(id).or_insert_with(MemStream::new);
-        let t = Token {
-            write: p.clone(),
-            meta: p.clone(),
+            self.by_path.insert(path, (buffer.clone(), blob.clone()));
+            (buffer, blob)
         };
-        Ok(t)
-    }
 
-    fn destroy(&mut self, id: Id) -> Result<(), Error> {
-        if self.dataz.remove(&id).is_none() {
-            return Err(format!("internal error: {:?} not registered", id).into());
-        }
-        Ok(())
+        let buffer = MemBuffer::open(buffer, lock_info)?;
+        let blob = MemBlob::open(blob, lock_info)?;
+        Persister::new(buffer, blob)
     }
 }
 
@@ -243,7 +366,7 @@ mod tests {
                 return Err(Error::from(format!("LOCKED: memory buffer {}", idx)));
             }
             registered.insert(idx);
-            Ok(MemBuffer::new())
+            MemBuffer::new("buffer_impl_test")
         })
     }
 
@@ -255,7 +378,7 @@ mod tests {
                 return Err(Error::from(format!("LOCKED: memory buffer {}", idx)));
             }
             registered.insert(idx);
-            Ok(MemBlob::new())
+            MemBlob::new("blob_impl_test")
         })
     }
 }

--- a/src/persist/src/persister.rs
+++ b/src/persist/src/persister.rs
@@ -10,7 +10,6 @@
 //! An abstraction for multiplexed streams of persisted data.
 
 use crate::error::Error;
-use crate::{Id, Token};
 
 /// An abstraction for a writer of (Key, Value, Time, Diff) updates.
 pub trait Write {
@@ -49,28 +48,4 @@ pub trait Meta: Clone {
 
     /// Unblocks compaction for updates before a time.
     fn allow_compaction(&mut self, ts: u64) -> Result<(), Error>;
-}
-
-/// An implementation of a persister for multiplexed streams of (Key, Value,
-/// Time, Diff) updates.
-pub trait Persister: Sized {
-    /// The persister's associated [Write] implementation.
-    type Write: Write;
-
-    /// The persister's associated [Meta] implementation.
-    type Meta: Meta;
-
-    /// Returns a token used to construct a persisted stream operator.
-    ///
-    /// If data was written by a previous Persister for this id, it's loaded and
-    /// replayed into the stream once constructed.
-    ///
-    /// Within a process, this can only be called once per id, even if that id
-    /// has since been destroyed. An `Err` is returned for calls after the
-    /// first. TODO: Is this restriction necessary/helpful?
-    fn create_or_load(&mut self, id: Id) -> Result<Token<Self::Write, Self::Meta>, Error>;
-
-    ///
-    /// TODO: Should this live on Meta?
-    fn destroy(&mut self, id: Id) -> Result<(), Error>;
 }

--- a/src/persist/src/storage.rs
+++ b/src/persist/src/storage.rs
@@ -18,7 +18,6 @@ use abomonation_derive::Abomonation;
 use crate::error::Error;
 use crate::indexed::handle::{StreamMetaHandle, StreamWriteHandle};
 use crate::indexed::Indexed;
-use crate::persister::Persister;
 use crate::{Id, Token};
 
 /// A "sequence number", uniquely associated with an entry in a Buffer.
@@ -72,28 +71,34 @@ pub trait Blob {
     fn set(&mut self, key: &str, value: Vec<u8>, allow_overwrite: bool) -> Result<(), Error>;
 }
 
-/// An implementation of [Persister] in terms of a [Buffer] and [Blob].
-pub struct StoragePersister<U: Buffer, L: Blob> {
+/// An implementation of a persister for multiplexed streams of (Key, Value,
+/// Time, Diff) updates.
+pub struct Persister<U: Buffer, L: Blob> {
     registered: HashSet<Id>,
     indexed: Arc<Mutex<Indexed<U, L>>>,
 }
 
-impl<U: Buffer, L: Blob> StoragePersister<U, L> {
-    /// Returns a [StoragePersister] initialized with previous data, if any.
+impl<U: Buffer, L: Blob> Persister<U, L> {
+    /// Returns a [Persister] initialized with previous data, if any.
     pub fn new(buf: U, blob: L) -> Result<Self, Error> {
-        Ok(StoragePersister {
+        Ok(Persister {
             registered: HashSet::new(),
             indexed: Arc::new(Mutex::new(Indexed::new(buf, blob)?)),
         })
     }
-}
 
-impl<U: Buffer, L: Blob> Persister for StoragePersister<U, L> {
-    type Write = StreamWriteHandle<U, L>;
-
-    type Meta = StreamMetaHandle<U, L>;
-
-    fn create_or_load(&mut self, id: Id) -> Result<Token<Self::Write, Self::Meta>, Error> {
+    /// Returns a token used to construct a persisted stream operator.
+    ///
+    /// If data was written by a previous [Persister] for this id, it's loaded and
+    /// replayed into the stream once constructed.
+    ///
+    /// Within a process, this can only be called once per id, even if that id
+    /// has since been destroyed. An `Err` is returned for calls after the
+    /// first. TODO: Is this restriction necessary/helpful?
+    pub fn create_or_load(
+        &mut self,
+        id: Id,
+    ) -> Result<Token<StreamWriteHandle<U, L>, StreamMetaHandle<U, L>>, Error> {
         if self.registered.contains(&id) {
             return Err(format!("internal error: {:?} already registered", id).into());
         }
@@ -107,7 +112,10 @@ impl<U: Buffer, L: Blob> Persister for StoragePersister<U, L> {
         Ok(Token { write, meta })
     }
 
-    fn destroy(&mut self, _id: Id) -> Result<(), Error> {
+    /// Remove the persisted stream.
+    ///
+    /// TODO: Should this live on Meta?
+    pub fn destroy(&mut self, _id: Id) -> Result<(), Error> {
         unimplemented!()
     }
 }

--- a/src/persist/src/storage.rs
+++ b/src/persist/src/storage.rs
@@ -98,6 +98,10 @@ impl<U: Buffer, L: Blob> Persister for StoragePersister<U, L> {
             return Err(format!("internal error: {:?} already registered", id).into());
         }
         self.registered.insert(id);
+        {
+            let mut guard = self.indexed.lock()?;
+            guard.register(id);
+        }
         let write = StreamWriteHandle::new(id, self.indexed.clone());
         let meta = StreamMetaHandle::new(id, self.indexed.clone());
         Ok(Token { write, meta })


### PR DESCRIPTION
first commit is #7103 

this pr is still extremely janky, getting it out now mostly because I'm at a nice stopping point for the day and find it easier to self review on github :D 