### PR TITLE
dbt-materialize: add mz_create_source and drop_source macros

### DIFF
--- a/misc/dbt-materialize/README.md
+++ b/misc/dbt-materialize/README.md
@@ -39,6 +39,17 @@ table | YES | Creates a [materialized view](https://materialize.com/docs/sql/cre
 ephemeral | YES | Executes queries using CTEs.
 incremental | NO | Use the `materializedview` materialization instead! dbt's incremental models are valuable because they only spend your time and money transforming your new data as it arrives. Luckily, this is exactly what Materialize's materialized views were built to do! Better yet, our materialized views will always return up-to-date results without manual or configured refreshes. For more information, check out [our documentation](https://materialize.com/docs/).
 
+### Additional macros
+
+dbt only supports a limited set of [materialization types](https://docs.getdbt.com/docs/building-a-dbt-project/building-models/materializations). To create other types of objects in Materialize
+via dbt, use the following Materialize-specific macros:
+
+Macro | Details
+------|----------
+mz_generate_name(identifier) | Generates a fully-qualified name (including the database and schema) given an object name.
+mz_create_source(sql) | Given some [`CREATE SOURCE`](https://materialize.com/docs/sql/create-source/) sql statement, creates the source in the Materialize instance.
+mz_drop_source(name, if_exists, cascade) | [Drops the named source](https://materialize.com/docs/sql/drop-source/) in Materialize.
+
 ### Seeds
 
 [`dbt seed`](https://docs.getdbt.com/reference/commands/seed/) will create a static materialized

--- a/misc/dbt-materialize/dbt/include/materialize/macros/mz_create_source.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/mz_create_source.sql
@@ -1,0 +1,24 @@
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License in the LICENSE file at the
+-- root of this repository, or online at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+{% macro mz_create_source(sql) -%}
+  -- todo@jldlaughlin
+  -- figure out docs and hooks!
+
+  {% call statement('main', auto_begin=False) -%}
+    {{ materialize__create_arbitrary_object(sql) }}
+  {%- endcall %}
+
+{% endmacro %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/mz_drop_source.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/mz_drop_source.sql
@@ -1,0 +1,34 @@
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License in the LICENSE file at the
+-- root of this repository, or online at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+{% macro mz_drop_source(name, if_exists=True, cascade=False) -%}
+
+  {% set dropstmt %}
+    DROP SOURCE
+    {% if if_exists %}
+        IF EXISTS
+    {% endif %}
+    {{ name }}
+    {% if cascade %}
+        CASCADE
+    {% endif %}
+  {% endset %}
+
+  {% do run_query(dropstmt) %}
+
+  -- todo@jldlaughlin
+  -- {% do persist_docs(target_relation, model) %}
+
+{% endmacro %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/mz_generate_name.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/mz_generate_name.sql
@@ -1,0 +1,18 @@
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License in the LICENSE file at the
+-- root of this repository, or online at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+{% macro mz_generate_name(identifier) -%}
+  {{ return("{}.{}.{}".format(database, schema, identifier)) }}
+{% endmacro %}

--- a/misc/dbt-materialize/setup.py
+++ b/misc/dbt-materialize/setup.py
@@ -26,7 +26,7 @@ package_name = "dbt-materialize"
 # This adapter's version, and its required dbt-postgres version, tracks the
 # target dbt version.
 target_package_version = "0.18.1"
-package_version_suffix = ".post3"
+package_version_suffix = ".post4"
 package_version = "{}{}".format(target_package_version, package_version_suffix)
 description = """The Materialize adapter plugin for dbt (data build tool)"""
 

--- a/play/materialize-cloud-dbt/README.md
+++ b/play/materialize-cloud-dbt/README.md
@@ -1,0 +1,3 @@
+### materialize-cloud-dbt
+
+A sample project that let's you connect to [Materialize Cloud](https://materialize.com/docs/cloud/what-is-materialize-cloud/)!

--- a/play/materialize-cloud-dbt/dbt_project.yml
+++ b/play/materialize-cloud-dbt/dbt_project.yml
@@ -1,0 +1,22 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License in the LICENSE file at the
+# root of this repository, or online at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'materialize-cloud-dbt'
+version: '1.0.0'
+config-version: 2
+
+profile: 'test-cloud'
+
+source-paths: ["models"]

--- a/play/materialize-cloud-dbt/models/example/market_orders.sql
+++ b/play/materialize-cloud-dbt/models/example/market_orders.sql
@@ -13,21 +13,20 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-{% macro mz_drop_source(name, if_exists=True, cascade=False) -%}
-  -- todo@jldlaughlin
-  -- figure out docs and hooks!
+{% set source_name %}
+    {{ mz_generate_name('market_orders_raw') }}
+{% endset %}
 
-  {% set dropstmt %}
-    DROP SOURCE
-    {% if if_exists %}
-        IF EXISTS
-    {% endif %}
-    {{ name }}
-    {% if cascade %}
-        CASCADE
-    {% endif %}
-  {% endset %}
+{% set stmt %}
+    CREATE MATERIALIZED SOURCE {{ source_name }} FROM PUBNUB
+    SUBSCRIBE KEY 'sub-c-4377ab04-f100-11e3-bffd-02ee2ddab7fe'
+    CHANNEL 'pubnub-market-orders';
+{% endset %}
 
-  {% do run_query(dropstmt) %}
+{{ mz_drop_source(source_name, if_exists=True, cascade=True) }}
+{{ mz_create_source(stmt) }}
 
-{% endmacro %}
+{{ config(materialized='materializedview') }}
+
+select *
+from {{ source_name }}

--- a/play/materialize-cloud-dbt/models/example/schema.yml
+++ b/play/materialize-cloud-dbt/models/example/schema.yml
@@ -1,0 +1,20 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License in the LICENSE file at the
+# root of this repository, or online at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: 2
+
+models:
+    - name: market_orders
+      description: "Latest market orders from a Pubnub stream"


### PR DESCRIPTION
Fixes https://github.com/MaterializeInc/materialize/issues/6249.

Adds three new Materialize-specific macros:
1. `mz_create_source`: Given a full `CREATE SOURCE` statement, creates the source in Materialize.
2. `mz_drop_source`: Given a source name and boolean values for `if_exists` and `cascade`, drops a source in Materialize.
3. `mz_generate_name`: Generates a fully-qualified name from an identifier.

Together, these macros will enable users to create and drop sources in Materialize via dbt. Some additional details...

#### Why didn't we create a new [materialization](https://docs.getdbt.com/docs/building-a-dbt-project/building-models/materializations) type for source objects?

Adding a new materialization type would be the best option, but unfortunately dbt only supports a [limited set of materialization types](https://github.com/fishtown-analytics/dbt/blob/9d414f6ec30bfedbb448e8954a506f63d550dbad/core/dbt/contracts/relation.py#L16). I will open an issue upstream to see if there's any interest in expanding that list, but we need to create entirely separate macros until it's (potentially) expanded.

#### What is the impact of using a macro instead of a materialization?

Materializations are included at the top of model files or in a project's `schema.yml` to indicate how a query should be persisted in the underlying database. Macros, on the other hand, will need to be called from a model file. The user will have to understand that the macro will create the source, not the model.

Concretely, this difference also means that sources will not show up in dbt docs. This is a bummer! And something we should investigate fixing either via adding a new materialization type upstream or by some other means.

#### Why is this macro so generic?

There are lots of ways to [`CREATE SOURCE`](https://materialize.com/docs/sql/create-source/)s in Materialize! With even more configuration options! At least for now, I don't think it's worth taking on the maintenance burden of creating and maintaining a macro per source type. However, that's something we could add in the future.
