### PR TITLE
ci: account for new scratch AWS access

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -92,6 +92,7 @@ case "$cmd" in
             --env AWS_ACCESS_KEY_ID
             --env AWS_DEFAULT_REGION
             --env AWS_SECRET_ACCESS_KEY
+            --env AWS_SESSION_TOKEN
             --env BUILDKITE
             --env BUILDKITE_AGENT_ACCESS_TOKEN
             --env BUILDKITE_BRANCH

--- a/ci/README.md
+++ b/ci/README.md
@@ -46,66 +46,9 @@ That way agents in the builder stack have a warm Cargo and Docker cache, and
 will typically build much faster because they don't need to recompile all
 dependencies.
 
-## Buildkite configuration
-
-Configuration of the CI stack lives in three places: the CloudFormation
-template, which contains the bulk of the knobs; the "buildkite-managedsecrets"
-S3 bucket, which contains SSH keys and Docker credentials; and the
-"buildkite-config" S3 bucket, which contains a bootstrapping script to tweak the
-agent configuration.
-
-If the CloudFormation template gets lost, the important configuration knobs are
-listed below, along with their rationale.
-
-Parameter name                     | Value
----------------------------------- | -----
-**InstanceType**                   | `c5.2xlarge`
-**ManagedPolicyARN**               | `arn:aws:iam::000000000000:policy/buildkite-agent`<br><br>An IAM policy that permits access to the bootstrap script in the buildkite-config S3 bucket. This is documented in detail in the official CI stack documentation.
-**KeyName**                        | The name of an EC2 SSH key that will permit you to log into the build agents, should you need to diagnose a problem.
-**BootstrapScriptUrl**             | `s3://buildkite-config-<SECRETNAME>/bootstrap.sh`
-**EnableDockerUserNamespaceRemap** | `false`<br><br>User namespace remapping breaks permissions on bind mounts, as it interacts poorly with [autouseradd]. It's possible that user namespace remapping could be used in place of autouseradd, but that requires some investigation, and it's not like we need the additional security of user namespace remapping, as we're not currently running untrusted PRs in CI.
-
-The current bootstrap script looks like this:
-
-```bash
-#!/usr/bin/env bash
-
-# Create cache directories that are owned by the buildkite-agent user,
-# otherwise the Docker daemon will create them as root, making them
-# unavailable from within the container.
-for dir in /var/lib/buildkite-agent/{.cache/sccache,.cargo}
-do
-    sudo mkdir -p "$dir"
-    sudo chown -R buildkite-agent: "$dir"
-done
-
-# Don't clean gitignored files. This allows reuse of the Rust build
-# cache, which is stored in the ignored "target" directory.
-cat <<EOF >> /etc/buildkite-agent/buildkite-agent.cfg
-git-clean-flags=-ffdq
-EOF
-```
-
-**Warning:** this bootstrap script is likely to diverge from the source of truth
-in the S3 bucket. If you update the bootstrap script, download the current
-version from S3, update it, and reupload it. Don't use the version here as your
-base.
-
-The secrets in the buildkite-managedsecrets bucket are, for obvious reasons, not
-reproduced here. If you need to recreate the SSH key:
-
-  1. Create a new SSH key with `ssh-keygen`.
-  2. Log in as the [materializer GitHub user] and add the new SSH key. This
-     grants read/write access to all private Materialize GitHub repositories.
-     The credentials for the materializer account are in the company 1Password.
-  3. Log into mtrlz.dev and add the SSH key to the buildkite user's
-     authorized_keys file.
-
-If you need the Docker hub password, it's in the company 1Password.
-
 ## Build caching
 
-We once used [sccache], a distributed build cache from Mozilla, to share built
+We once used sccache, a distributed build cache from Mozilla, to share built
 artifacts between agents. Unfortunately, for reasons Nikhil never fully tracked
 down, setting `RUSTC_WRAPPER=sccache` was causing Cargo to always build from
 scratch, a process that was taking 7m+ at the time sccache was removed. Even
@@ -256,15 +199,6 @@ $ sudo apt install gdb
 $ ps ax | grep <FAULTY-PROCESS-NAME>
 $ gdb -p <FAULTY-PROCESS-PID>
 ```
-
-## Performance testing
-
-We have a dedicated Linux machine in the office that Nikhil intends to use for
-reproducable performance testing. (Cloud VMs tend to be very noisy.) To get SSH
-access, ask Nikhil to add your account. We don't currently pay WeWork for a
-static IP, so we maintain a reverse SSH tunnel to mtrlz.dev:2222 via autossh.
-That means you can connect, credentials permitting, with something like `ssh
-USER@mtrlz.dev -p 2222`.
 
 [Buildkite]: https://buildkite.com
 [Docker Compose]: https://docs.docker.com/compose/

--- a/ci/plugins/scratch-aws-access/README.md
+++ b/ci/plugins/scratch-aws-access/README.md
@@ -1,0 +1,21 @@
+# Scratch AWS access Buildkite Plugin
+
+A [Buildkite plugin] that assumes a role with nearly unrestricted access to a
+scratch AWS account. The following environment variables are set:
+
+* `AWS_ACCESS_KEY_ID`
+* `AWS_SECRET_ACCESS_KEY`
+* `AWS_SESSION_TOKEN`
+
+The credentials are valid for one hour.
+
+## Example
+
+```yml
+steps:
+  - id: aws-requiring-step
+    plugins:
+      - ./ci/plugins/scratch-aws-access
+```
+
+[Buildkite plugin]: https://buildkite.com/docs/agent/v3/plugins

--- a/ci/plugins/scratch-aws-access/hooks/pre-command
+++ b/ci/plugins/scratch-aws-access/hooks/pre-command
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+set -euo pipefail
+
+echo "~~~ Assuming scratch AWS role"
+
+creds=$(aws sts assume-role --role-arn "$AWS_SCRATCH_ROLE_ARN" --role-session-name ci)
+
+AWS_ACCESS_KEY_ID=$(jq -r '.Credentials.AccessKeyId' <<< "$creds")
+AWS_SECRET_ACCESS_KEY=$(jq -r '.Credentials.SecretAccessKey' <<< "$creds")
+AWS_SESSION_TOKEN=$(jq -r '.Credentials.SessionToken' <<< "$creds")
+
+export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+
+echo "Role ARN: $AWS_SCRATCH_ROLE_ARN"
+echo "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID"
+echo "AWS_SECRET_ACCESS_KEY=(${#AWS_SECRET_ACCESS_KEY} chars)"
+echo "AWS_SESSION_TOKEN=(${#AWS_SESSION_TOKEN} chars)"

--- a/ci/plugins/scratch-aws-access/plugin.yml
+++ b/ci/plugins/scratch-aws-access/plugin.yml
@@ -7,12 +7,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# Cleans up CI resources that occasionally leak.
-
-steps:
-  - command: bin/ci-builder run stable bin/pyactivate --dev -m ci.cleanup.aws
-    timeout_in_minutes: 10
-    env:
-      AWS_DEFAULT_REGION: us-east-2
-    plugins:
-       - ./ci/plugins/scratch-aws-access
+name: mzcompose
+description: Runs an mzcompose file
+author: "Materialize, Inc."
+requirements: []
+configuration:
+  additionalProperties: false

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -83,9 +83,11 @@ steps:
     timeout_in_minutes: 30
     inputs: [test/testdrive]
     plugins:
+      - ./ci/plugins/scratch-aws-access
       - ./ci/plugins/mzcompose:
           composition: testdrive
           run: ci
+
 
   - id: testdrive-proxy
     label: ":squid: testdrive proxy"
@@ -93,6 +95,7 @@ steps:
     timeout_in_minutes: 30
     inputs: [test/testdrive]
     plugins:
+      - ./ci/plugins/scratch-aws-access
       - ./ci/plugins/mzcompose:
           composition: testdrive
           run: ci-proxy
@@ -103,6 +106,7 @@ steps:
     timeout_in_minutes: 30
     inputs: [test/testdrive/proxy]
     plugins:
+      - ./ci/plugins/scratch-aws-access
       - ./ci/plugins/mzcompose:
           composition: testdrive
           run: ci-proxy
@@ -161,6 +165,7 @@ steps:
     depends_on: build
     timeout_in_minutes: 30
     plugins:
+      - ./ci/plugins/scratch-aws-access
       - ./ci/plugins/mzcompose:
           composition: perf-kinesis
           run: ci

--- a/test/performance/perf-kinesis/mzcompose.yml
+++ b/test/performance/perf-kinesis/mzcompose.yml
@@ -24,6 +24,10 @@ services:
     command: --stream-prefix testdrive-perf-kinesis
     environment:
       - RUST_LOG=perf-kinesis=debug,info
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_SESSION_TOKEN
+      - AWS_SECURITY_TOKEN
     depends_on: [materialized]
 
   materialized:


### PR DESCRIPTION
In the new Buildkite setup, CI is granted nearly unrestricted access to
a separate AWS account upon request.