### PR TITLE
persist: replace all "as" conversions with ore::cast::CastFrom

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2833,6 +2833,7 @@ dependencies = [
  "abomonation_derive",
  "criterion",
  "differential-dataflow",
+ "ore",
  "tempfile",
  "timely",
 ]

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -15,6 +15,7 @@ harness = false
 abomonation = "0.7"
 abomonation_derive = "0.5"
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
+ore = { path = "../ore", default-features = false }
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 tempfile = "3.2.0"
 

--- a/src/persist/src/lib.rs
+++ b/src/persist/src/lib.rs
@@ -10,6 +10,11 @@
 //! Persistence for Materialize dataflows.
 
 #![warn(missing_docs)]
+#![warn(
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss
+)]
 
 pub mod error;
 pub mod file;

--- a/src/persist/src/mem.rs
+++ b/src/persist/src/mem.rs
@@ -13,6 +13,8 @@ use std::collections::{HashMap, HashSet};
 use std::ops::Range;
 use std::sync::{Arc, Mutex};
 
+use ore::cast::CastFrom;
+
 use crate::error::Error;
 use crate::persister::{Meta, Persister, Snapshot, Write};
 use crate::storage::{Blob, Buffer, SeqNo};
@@ -40,7 +42,7 @@ impl Buffer for MemBuffer {
         self.seqno = self.seqno.start..SeqNo(self.seqno.end.0 + 1);
         self.dataz.push(buf);
         debug_assert_eq!(
-            (self.seqno.end.0 - self.seqno.start.0) as usize,
+            usize::cast_from(self.seqno.end.0 - self.seqno.start.0),
             self.dataz.len()
         );
         Ok(write_seqno)
@@ -53,7 +55,7 @@ impl Buffer for MemBuffer {
         self.dataz
             .iter()
             .enumerate()
-            .map(|(idx, x)| logic(SeqNo(self.seqno.start.0 + idx as u64), &x[..]))
+            .map(|(idx, x)| logic(SeqNo(self.seqno.start.0 + u64::cast_from(idx)), &x[..]))
             .collect::<Result<(), Error>>()?;
         Ok(self.seqno.clone())
     }
@@ -69,9 +71,9 @@ impl Buffer for MemBuffer {
         }
         let removed = upper.0 - self.seqno.start.0;
         self.seqno = upper..self.seqno.end;
-        self.dataz.drain(0..removed as usize);
+        self.dataz.drain(0..usize::cast_from(removed));
         debug_assert_eq!(
-            (self.seqno.end.0 - self.seqno.start.0) as usize,
+            usize::cast_from(self.seqno.end.0 - self.seqno.start.0),
             self.dataz.len()
         );
         Ok(())


### PR DESCRIPTION
CastFrom documents that Materialize is committed to building only on 64
bit platforms and so the casts it allows are lossless.