### PR TITLE
fix urls broken by mtrlz.dev dns change

### DIFF
--- a/doc/developer/README.md
+++ b/doc/developer/README.md
@@ -5,7 +5,7 @@ describes our engineering process and philosophy.
 
 For a more general introduction to Materialize, see the [user
 documentation](https://materialize.com/docs). For API documentation, see
-[mtrlz.dev](https://mtrlz.dev).
+[dev.materialize.com](https://dev.materialize.com).
 
 ## New contributors
 

--- a/doc/developer/mzbuild.md
+++ b/doc/developer/mzbuild.md
@@ -513,7 +513,7 @@ mzworkflows:
   of a series of steps that are executed in sequence and a set of environment
   variables that are set during the execution of the workflow. The available
   steps and their options are only documented by way of the developer docs.
-  See <https://mtrlz.dev/api/python/materialize/mzcompose.html>.
+  See <https://dev.materialize.com/api/python/materialize/mzcompose.html>.
 
   Also see the [chbench demo mzcompose](../../demo/chbench/mzcompose.yml) for
   a detailed example.

--- a/doc/user/content/install.md
+++ b/doc/user/content/install.md
@@ -14,7 +14,7 @@ weight: 2
 You can access Materialize through the `materialized` binary, which you can
 install on macOS and Linux, or [build](#build-from-source) on most OSes (e.g. FreeBSD). These
 instructions install the latest release of Materialize, **{{< version >}}**. The latest (unstable)
-developer builds are available at https://mtrlz.dev/. For prior releases,
+developer builds are available at https://dev.materialize.com/. For prior releases,
 see the [Versions page](/versions).
 
 **Have any questions?** [Contact us](https://materialize.com/contact/)


### PR DESCRIPTION
katacoda broke because of the dns change, so i went ahead and fixed these broken urls as well. note that there's a couple broken mtrlz.dev urls that i haven't fixed (`doc/developer/guide-testing.md` and `doc/developer/guide.md`) because i think they might have been broken to begin with