### PR TITLE
expr: fix nullability deduction of record fields

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -4122,7 +4122,11 @@ impl UnaryFunc {
             JsonbPretty => ScalarType::String.nullable(in_nullable),
 
             RecordGet(i) => match input_type.scalar_type {
-                ScalarType::Record { mut fields, .. } => fields.swap_remove(*i).1,
+                ScalarType::Record { mut fields, .. } => {
+                    let (_name, mut ty) = fields.swap_remove(*i);
+                    ty.nullable = ty.nullable || input_type.nullable;
+                    ty
+                }
                 _ => unreachable!("RecordGet specified nonexistent field"),
             },
 

--- a/test/testdrive/avro-nonnull-record.td
+++ b/test/testdrive/avro-nonnull-record.td
@@ -1,0 +1,41 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Regression test for #7170, in which non-nullable fields of nullable records
+# were not correctly handled.
+
+$ set writer-schema={
+    "name": "row",
+    "type": "record",
+    "fields": [
+      {
+        "name": "a",
+        "type": {
+          "name": "b",
+          "fields": [
+            {"name": "b", "type": "int"},
+            {"name": "c", "type": "int"}
+          ],
+          "type": "record"
+        }
+      }
+    ]
+  }
+
+$ avro-ocf-write path=data.ocf schema=${writer-schema}
+{"a": {"b": 1, "c": 1}}
+{"a": {"b": 2, "c": 1}}
+
+> CREATE MATERIALIZED SOURCE basic
+  FROM AVRO OCF '${testdrive.temp-dir}/data.ocf'
+
+> SELECT (b1.a).b, (b2.a).b FROM basic b1 LEFT JOIN basic b2 ON (b1.a).b = (b2.a).c
+1 1
+1 2
+2 <null>


### PR DESCRIPTION
The type of a record field access expression like

    (record).field

depends on both the nullability of the field in the record type and the
nullability of the record itself. The expression is nullable if *either*
`record` or the field in the record is nullable. Previously we were only
considering the nullability of the field itself.

This requires adding an "optimization" to RelationExpr::typ to notice
when a RelationExpr::Filter is filtering out nulls on a column and mark
that column as non-nullable.

Fix #7170.