### PR TITLE
repr: fix memory unsafety in RowArena again

### DIFF
--- a/test/sqllogictest/github-7168.slt
+++ b/test/sqllogictest/github-7168.slt
@@ -1,0 +1,68 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Regression test for https://github.com/MaterializeInc/materialize/issues/7168.
+#
+# The shape of this table would reliably trigger memory unsafety. The datums
+# were exactly the right length to corrupt the stack given the bug. It's
+# unlikely that these specific datums will do much to prevent memory unsafety in
+# the future, but keeping this test doesn't hurt.
+
+statement ok
+CREATE TABLE t (
+  killmail text,
+  ship text,
+  cost text,
+  solarsystem text,
+  hi text,
+  med text,
+  low text,
+  rig text,
+  sub text,
+  items text
+)
+
+statement ok
+INSERT INTO t VALUES (
+  93457529,
+  596,
+  9911,
+  30001389,
+  '[3634, 3651]',
+  '[21857]',
+  'null',
+  'null',
+  'null',
+  '[596, 21857, 3634, 3651]'
+)
+
+query IIIITTTTTT
+SELECT
+  killmail::int4,
+  ship::int4,
+  cost::int8,
+  solarsystem::int4,
+  hi::jsonb,
+  med::jsonb,
+  low::jsonb,
+  rig::jsonb,
+  sub::jsonb,
+  items::jsonb
+FROM t
+----
+93457529
+596
+9911
+30001389
+[3634,3651]
+[21857]
+null
+null
+null
+[596,21857,3634,3651]


### PR DESCRIPTION
When we switched Row to use a SmallVec as its backing store (#3248), we
accidentally made RowArena unsound. It is NOT valid for the RowArena to
hand out references to a SmallVec, as the SmallVec might be using inline
storage, and the address of that inline storage will change if the
vector containing the SmallVec reallocates.

Fix the unsafety by forcing the SmallVec to spill to the heap, and
storing *that* vector in the RowArena.

In practice, the memory safety was only observed when packing wide rows
that contained small lists, but still scary to think how long this has
been present.

Fix #7168.
Fix #7169.