### PR TITLE
sql: rename `HOST` to `CONNECTION` for pg sources

### DIFF
--- a/doc/developer/design/20210412_postgres_sources.md
+++ b/doc/developer/design/20210412_postgres_sources.md
@@ -124,7 +124,7 @@ Here is a complete example of what the user will type into materialize:
 
 ```sql
 CREATE SOURCE "repl_stream"
-       FROM POSTGRES HOST 'host=postgres user=postgres dbname=postgres'
+       FROM POSTGRES CONNECTION 'host=postgres user=postgres dbname=postgres'
        PUBLICATION 'mz_source';
 
 CREATE VIEWS FROM SOURCE "repl_stream" ("table_a", "table_b");

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -48,6 +48,10 @@ Wrap your release notes at the 80 character mark.
 
 {{% version-header v0.8.1 %}}
 
+- **Breaking change.** `HOST` keyword when creating
+  [postgres sources](/sql/create-source/postgres/#syntax) has been renamed to
+  `CONNECTION`.
+
 - Add [timelines](/sql/timelines) to all sources to prevent
   joining data whose time is not comparable. This only affects new
   [CDC](/connect/materialize-cdc) and Debezium consistency topic sources

--- a/doc/user/content/sql/create-source/postgres.md
+++ b/doc/user/content/sql/create-source/postgres.md
@@ -23,7 +23,7 @@ Field | Use
 **MATERIALIZED** | Materializes the source's data, which retains all data in memory and makes sources directly selectable. **Currently required for all Postgres sources.** For more information, see [Materialized source details](#materialized-source-details).
 _src_name_  | The name for the source.
 **IF NOT EXISTS**  | Do nothing (except issuing a notice) if a source with the same name already exists. _Default._
-**HOST** _connection_info_ | Postgres host. See the Postgres documentation on [supported correction parameters](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS) for details.
+**CONNECTION** _connection_info_ | Postgres connection parameters. See the Postgres documentation on [supported correction parameters](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS) for details.
 **PUBLICATION** _publication_name_ | Postgres [publication](https://www.postgresql.org/docs/current/logical-replication-publication.html) (the replication data set containing the tables to be streamed to Materialize).
 
 ## Details
@@ -136,7 +136,7 @@ Once you have set up Postgres, you can create the source in Materialize.
 
 ```sql
 CREATE MATERIALIZED SOURCE "mz_source" FROM POSTGRES
-HOST 'host=postgres port=5432 user=host sslmode=require dbname=postgres'
+CONNECTION 'host=postgres port=5432 user=host sslmode=require dbname=postgres'
 PUBLICATION 'mz_source';
 ```
 

--- a/doc/user/layouts/partials/sql-grammar/create-source-postgres.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-source-postgres.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="583" height="201">
+<svg xmlns="http://www.w3.org/2000/svg" width="591" height="201">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="74" height="32" rx="10"/>
@@ -33,86 +33,86 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="431" y="53">IF NOT EXISTS</text>
-   <rect x="49" y="101" width="26" height="32" rx="10"/>
-   <rect x="47"
+   <rect x="25" y="101" width="26" height="32" rx="10"/>
+   <rect x="23"
          y="99"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="57" y="119">"</text>
-   <rect x="95" y="101" width="80" height="32"/>
-   <rect x="93" y="99" width="80" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="103" y="119">src_name</text>
-   <rect x="195" y="101" width="26" height="32" rx="10"/>
-   <rect x="193"
+   <text class="terminal" x="33" y="119">"</text>
+   <rect x="71" y="101" width="80" height="32"/>
+   <rect x="69" y="99" width="80" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="79" y="119">src_name</text>
+   <rect x="171" y="101" width="26" height="32" rx="10"/>
+   <rect x="169"
          y="99"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="203" y="119">"</text>
-   <rect x="241" y="101" width="60" height="32" rx="10"/>
-   <rect x="239"
+   <text class="terminal" x="179" y="119">"</text>
+   <rect x="217" y="101" width="60" height="32" rx="10"/>
+   <rect x="215"
          y="99"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="249" y="119">FROM</text>
-   <rect x="321" y="101" width="94" height="32" rx="10"/>
-   <rect x="319"
+   <text class="terminal" x="225" y="119">FROM</text>
+   <rect x="297" y="101" width="94" height="32" rx="10"/>
+   <rect x="295"
          y="99"
          width="94"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="329" y="119">POSTGRES</text>
-   <rect x="435" y="101" width="58" height="32" rx="10"/>
-   <rect x="433"
+   <text class="terminal" x="305" y="119">POSTGRES</text>
+   <rect x="411" y="101" width="114" height="32" rx="10"/>
+   <rect x="409"
          y="99"
-         width="58"
+         width="114"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="443" y="119">HOST</text>
-   <rect x="513" y="101" width="24" height="32" rx="10"/>
-   <rect x="511"
+   <text class="terminal" x="419" y="119">CONNECTION</text>
+   <rect x="545" y="101" width="24" height="32" rx="10"/>
+   <rect x="543"
          y="99"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="521" y="119">(</text>
-   <rect x="109" y="167" width="118" height="32"/>
-   <rect x="107" y="165" width="118" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="117" y="185">connection_info</text>
-   <rect x="247" y="167" width="24" height="32" rx="10"/>
-   <rect x="245"
+   <text class="terminal" x="553" y="119">(</text>
+   <rect x="117" y="167" width="118" height="32"/>
+   <rect x="115" y="165" width="118" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="125" y="185">connection_info</text>
+   <rect x="255" y="167" width="24" height="32" rx="10"/>
+   <rect x="253"
          y="165"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="255" y="185">)</text>
-   <rect x="291" y="167" width="112" height="32" rx="10"/>
-   <rect x="289"
+   <text class="terminal" x="263" y="185">)</text>
+   <rect x="299" y="167" width="112" height="32" rx="10"/>
+   <rect x="297"
          y="165"
          width="112"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="299" y="185">PUBLICATION</text>
-   <rect x="423" y="167" width="132" height="32" rx="10"/>
-   <rect x="421"
+   <text class="terminal" x="307" y="185">PUBLICATION</text>
+   <rect x="431" y="167" width="132" height="32" rx="10"/>
+   <rect x="429"
          y="165"
          width="132"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="431" y="185">publication_name</text>
+   <text class="terminal" x="439" y="185">publication_name</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m74 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m78 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-556 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m26 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m94 0 h10 m0 0 h10 m58 0 h10 m0 0 h10 m24 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-472 66 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m118 0 h10 m0 0 h10 m24 0 h10 m0 0 h10 m112 0 h10 m0 0 h10 m132 0 h10 m3 0 h-3"/>
-   <polygon points="573 181 581 177 581 185"/>
-   <polygon points="573 181 565 177 565 185"/>
+         d="m17 17 h2 m0 0 h10 m74 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m78 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-580 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m26 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m94 0 h10 m0 0 h10 m114 0 h10 m0 0 h10 m24 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-496 66 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m118 0 h10 m0 0 h10 m24 0 h10 m0 0 h10 m112 0 h10 m0 0 h10 m132 0 h10 m3 0 h-3"/>
+   <polygon points="581 181 589 177 589 185"/>
+   <polygon points="581 181 573 177 573 185"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -102,7 +102,7 @@ create_source_json_kafka ::=
 create_source_postgres ::=
   'CREATE' 'MATERIALIZED'? 'SOURCE' ('IF NOT EXISTS')? '"'src_name'"'
   'FROM' 'POSTGRES'
-  'HOST' '('connection_info')'
+  'CONNECTION' '('connection_info')'
   'PUBLICATION' 'publication_name'
 create_source_protobuf_kafka ::=
   'CREATE' 'MATERIALIZED'? 'SOURCE' ('IF NOT EXISTS')? src_name

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -430,7 +430,7 @@ impl AstDisplay for Connector {
                 publication,
                 slot,
             } => {
-                f.write_str("POSTGRES HOST '");
+                f.write_str("POSTGRES CONNECTION '");
                 f.write_str(&display::escape_single_quote_string(conn));
                 f.write_str("' PUBLICATION '");
                 f.write_str(&display::escape_single_quote_string(publication));

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -59,6 +59,7 @@ Commit
 Committed
 Compression
 Confluent
+Connection
 Constraint
 Copy
 Create
@@ -113,7 +114,6 @@ Having
 Header
 Headers
 Hold
-Host
 Hour
 Hours
 If

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1727,7 +1727,7 @@ impl<'a> Parser<'a> {
                 })
             }
             POSTGRES => {
-                self.expect_keyword(HOST)?;
+                self.expect_keyword(CONNECTION)?;
                 let conn = self.parse_literal_string()?;
                 self.expect_keyword(PUBLICATION)?;
                 let publication = self.parse_literal_string()?;

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -539,9 +539,9 @@ CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka { broker: "broker", topic: "topic", key: None }, with_options: [Value { name: Ident("start_offset"), value: Array([Number("2"), Number("40000000")]) }], format: KeyValue { key: Text, value: Avro(Schema { schema: File("path"), with_options: [] }) }, envelope: Upsert, if_not_exists: false, materialized: false })
 
 parse-statement
-CREATE SOURCE psychic FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red';
+CREATE SOURCE psychic FROM POSTGRES CONNECTION 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red';
 ----
-CREATE SOURCE psychic FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red'
+CREATE SOURCE psychic FROM POSTGRES CONNECTION 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red'
 =>
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("psychic")]), col_names: [], connector: Postgres { conn: "host=kanto user=ash password=teamrocket dbname=pokemon", publication: "red", slot: None }, with_options: [], format: None, envelope: None, if_not_exists: false, materialized: false })
 

--- a/test/pg-cdc-resumption/configure-materalize.td
+++ b/test/pg-cdc-resumption/configure-materalize.td
@@ -9,7 +9,7 @@
 
 > CREATE MATERIALIZED SOURCE mz_source
   FROM POSTGRES
-  HOST 'host=toxiproxy port=5432 user=postgres password=postgres dbname=postgres'
+  CONNECTION 'host=toxiproxy port=5432 user=postgres password=postgres dbname=postgres'
   PUBLICATION 'mz_source'
 
 > CREATE MATERIALIZED VIEWS FROM SOURCE mz_source;

--- a/test/pg-cdc/create-table-after-source.td
+++ b/test/pg-cdc/create-table-after-source.td
@@ -19,7 +19,7 @@ CREATE SCHEMA public;
 CREATE PUBLICATION mz_source FOR ALL TABLES;
 
 > CREATE MATERIALIZED SOURCE mz_source
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
   PUBLICATION 'mz_source';
 
 > SELECT COUNT(*) = 0 FROM mz_source;

--- a/test/pg-cdc/create-views-from-source-in-schema.td
+++ b/test/pg-cdc/create-views-from-source-in-schema.td
@@ -33,7 +33,7 @@ CREATE PUBLICATION mz_source FOR ALL TABLES;
 > CREATE SCHEMA schema1
 
 > CREATE MATERIALIZED SOURCE mz_source
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
   PUBLICATION 'mz_source';
 
 # Wait for snapshot to be complete

--- a/test/pg-cdc/create-views-from-source-with-schema.td
+++ b/test/pg-cdc/create-views-from-source-with-schema.td
@@ -29,7 +29,7 @@ CREATE PUBLICATION mz_source FOR ALL TABLES;
 > CREATE SCHEMA schema1
 
 > CREATE MATERIALIZED SOURCE schema1.mz_source
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
   PUBLICATION 'mz_source';
 
 > CREATE VIEWS FROM SOURCE schema1.mz_source;

--- a/test/pg-cdc/data-utf8.td
+++ b/test/pg-cdc/data-utf8.td
@@ -27,7 +27,7 @@ INSERT INTO t1 VALUES ('това е текст'), ('това ''е'' "текст"
 CREATE PUBLICATION mz_source FOR ALL TABLES;
 
 > CREATE MATERIALIZED SOURCE mz_source
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
   PUBLICATION 'mz_source';
 
 > SELECT COUNT(*) > 0 FROM mz_source;

--- a/test/pg-cdc/mz-source-tables.td
+++ b/test/pg-cdc/mz-source-tables.td
@@ -20,7 +20,7 @@ CREATE SCHEMA public;
 CREATE PUBLICATION mz_source FOR ALL TABLES;
 
 > CREATE MATERIALIZED SOURCE mz_source
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
   PUBLICATION 'mz_source';
 
 

--- a/test/pg-cdc/pg-cdc-ssl.td
+++ b/test/pg-cdc/pg-cdc-ssl.td
@@ -48,7 +48,7 @@ $ set-regex match=(\d{1,3}\.){3}\d{1,3} replacement=(HOST)
 
 # server: host, client: disable => OK
 > CREATE MATERIALIZED SOURCE "mz_source"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=host sslmode=disable dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=host sslmode=disable dbname=postgres'
   PUBLICATION 'mz_source';
 > CREATE VIEWS FROM SOURCE "mz_source" ("numbers")
 > SELECT * FROM "numbers";
@@ -65,7 +65,7 @@ DELETE FROM numbers WHERE number = 2;
 
 # server: host, client: prefer => OK
 > CREATE MATERIALIZED SOURCE "mz_source"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=host sslmode=prefer dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=host sslmode=prefer dbname=postgres'
   PUBLICATION 'mz_source';
 > CREATE VIEWS FROM SOURCE "mz_source" ("numbers")
 > SELECT * FROM "numbers";
@@ -82,7 +82,7 @@ DELETE FROM numbers WHERE number = 2;
 
 # server: host, client: require => OK
 > CREATE MATERIALIZED SOURCE "mz_source"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=host sslmode=require dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=host sslmode=require dbname=postgres'
   PUBLICATION 'mz_source';
 > CREATE VIEWS FROM SOURCE "mz_source" ("numbers")
 > SELECT * FROM "numbers";
@@ -99,13 +99,13 @@ DELETE FROM numbers WHERE number = 2;
 
 # server: hostssl, client: disable => ERROR
 ! CREATE MATERIALIZED SOURCE "mz_source"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=hostssl sslmode=disable dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=hostssl sslmode=disable dbname=postgres'
   PUBLICATION 'mz_source';
 db error: FATAL: no pg_hba.conf entry for host "(HOST)", user "hostssl", database "postgres", SSL off
 
 # server: hostssl, client: prefer => OK
 > CREATE MATERIALIZED SOURCE "mz_source"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=hostssl sslmode=prefer dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=hostssl sslmode=prefer dbname=postgres'
   PUBLICATION 'mz_source';
 > CREATE VIEWS FROM SOURCE "mz_source" ("numbers")
 > SELECT * FROM "numbers";
@@ -122,7 +122,7 @@ DELETE FROM numbers WHERE number = 2;
 
 # server: hostssl, client: require => OK
 > CREATE MATERIALIZED SOURCE "mz_source"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=hostssl sslmode=require dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=hostssl sslmode=require dbname=postgres'
   PUBLICATION 'mz_source';
 > CREATE VIEWS FROM SOURCE "mz_source" ("numbers")
 > SELECT * FROM "numbers";
@@ -139,13 +139,13 @@ DELETE FROM numbers WHERE number = 2;
 
 # server: hostssl, client: verify-ca => ERROR
 ! CREATE MATERIALIZED SOURCE "mz_source"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=hostssl dbname=postgres sslmode=verify-ca'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=hostssl dbname=postgres sslmode=verify-ca'
   PUBLICATION 'mz_source';
 self signed certificate in certificate chain
 
 # server: hostssl, client: verify-ca => OK
 > CREATE MATERIALIZED SOURCE "mz_source"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=hostssl dbname=postgres sslmode=verify-ca sslrootcert=/share/secrets/ca.crt'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=hostssl dbname=postgres sslmode=verify-ca sslrootcert=/share/secrets/ca.crt'
   PUBLICATION 'mz_source';
 > CREATE VIEWS FROM SOURCE "mz_source" ("numbers")
 > SELECT * FROM "numbers";
@@ -162,13 +162,13 @@ DELETE FROM numbers WHERE number = 2;
 
 # server: hostssl, client: verify-full => ERROR
 ! CREATE MATERIALIZED SOURCE "mz_source"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=hostssl dbname=postgres sslmode=verify-full'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=hostssl dbname=postgres sslmode=verify-full'
   PUBLICATION 'mz_source';
 self signed certificate in certificate chain
 
 # server: hostssl, client: verify-full => OK
 > CREATE MATERIALIZED SOURCE "mz_source"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=hostssl dbname=postgres sslmode=verify-full sslrootcert=/share/secrets/ca.crt'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=hostssl dbname=postgres sslmode=verify-full sslrootcert=/share/secrets/ca.crt'
   PUBLICATION 'mz_source';
 > CREATE VIEWS FROM SOURCE "mz_source" ("numbers")
 > SELECT * FROM "numbers";
@@ -185,7 +185,7 @@ DELETE FROM numbers WHERE number = 2;
 
 # server: hostnossl, client: disable => OK
 > CREATE MATERIALIZED SOURCE "mz_source"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=hostnossl sslmode=disable dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=hostnossl sslmode=disable dbname=postgres'
   PUBLICATION 'mz_source';
 > CREATE VIEWS FROM SOURCE "mz_source" ("numbers")
 > SELECT * FROM "numbers";
@@ -203,31 +203,31 @@ DELETE FROM numbers WHERE number = 2;
 # server: hostnossl, client: prefer => OK
 # todo(uce): rust-postgres does not fall back to no SSL
 ! CREATE MATERIALIZED SOURCE "mz_source"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=hostnossl sslmode=prefer dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=hostnossl sslmode=prefer dbname=postgres'
   PUBLICATION 'mz_source';
 db error: FATAL: no pg_hba.conf entry for host "(HOST)", user "hostnossl", database "postgres", SSL on
 
 # server: hostnossl, client: require => ERROR
 ! CREATE MATERIALIZED SOURCE "mz_source"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=hostnossl sslmode=require dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=hostnossl sslmode=require dbname=postgres'
   PUBLICATION 'mz_source';
 db error: FATAL: no pg_hba.conf entry for host "(HOST)", user "hostnossl", database "postgres", SSL on
 
 # server: hostnossl, client: verify-ca => ERROR
 ! CREATE MATERIALIZED SOURCE "mz_source"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=hostnossl sslmode=verify-ca dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=hostnossl sslmode=verify-ca dbname=postgres'
   PUBLICATION 'mz_source';
 self signed certificate in certificate chain
 
 # server: hostnossl, client: verify-full => ERROR
 ! CREATE MATERIALIZED SOURCE "mz_source"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=hostnossl sslmode=verify-full dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=hostnossl sslmode=verify-full dbname=postgres'
   PUBLICATION 'mz_source';
 self signed certificate in certificate chain
 
 # server: certuser, client: require => OK
 > CREATE MATERIALIZED SOURCE "mz_source"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=certuser sslmode=require sslcert=/share/secrets/certuser.crt sslkey=/share/secrets/certuser.key sslrootcert=/share/secrets/ca.crt dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=certuser sslmode=require sslcert=/share/secrets/certuser.crt sslkey=/share/secrets/certuser.key sslrootcert=/share/secrets/ca.crt dbname=postgres'
   PUBLICATION 'mz_source'
 > CREATE VIEWS FROM SOURCE "mz_source" ("numbers")
 > SELECT * FROM "numbers";
@@ -244,19 +244,19 @@ DELETE FROM numbers WHERE number = 2;
 
 # server: certuser, client: verify-ca => ERROR
 ! CREATE MATERIALIZED SOURCE "mz_source"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=certuser dbname=postgres sslmode=verify-ca sslrootcert=/share/secrets/ca.crt'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=certuser dbname=postgres sslmode=verify-ca sslrootcert=/share/secrets/ca.crt'
   PUBLICATION 'mz_source'
 db error: FATAL: connection requires a valid client certificate
 
 # server: certuser, client: verify-ca (wrong cert) => ERROR
 ! CREATE MATERIALIZED SOURCE "mz_source"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=certuser dbname=postgres sslmode=verify-ca sslcert=/share/secrets/postgres.crt sslkey=/share/secrets/postgres.key sslrootcert=/share/secrets/ca.crt'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=certuser dbname=postgres sslmode=verify-ca sslcert=/share/secrets/postgres.crt sslkey=/share/secrets/postgres.key sslrootcert=/share/secrets/ca.crt'
   PUBLICATION 'mz_source'
 db error: FATAL: certificate authentication failed for user "certuser"
 
 # server: certuser, client: verify-ca => OK
 > CREATE MATERIALIZED SOURCE "mz_source"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=certuser sslmode=verify-ca sslcert=/share/secrets/certuser.crt sslkey=/share/secrets/certuser.key sslrootcert=/share/secrets/ca.crt dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=certuser sslmode=verify-ca sslcert=/share/secrets/certuser.crt sslkey=/share/secrets/certuser.key sslrootcert=/share/secrets/ca.crt dbname=postgres'
   PUBLICATION 'mz_source'
 > CREATE VIEWS FROM SOURCE "mz_source" ("numbers")
 > SELECT * FROM "numbers";
@@ -273,7 +273,7 @@ DELETE FROM numbers WHERE number = 2;
 
 # server: certuser, client: verify-full => OK
 > CREATE MATERIALIZED SOURCE "mz_source"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=certuser sslmode=verify-ca sslcert=/share/secrets/certuser.crt sslkey=/share/secrets/certuser.key sslrootcert=/share/secrets/ca.crt dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=certuser sslmode=verify-ca sslcert=/share/secrets/certuser.crt sslkey=/share/secrets/certuser.key sslrootcert=/share/secrets/ca.crt dbname=postgres'
   PUBLICATION 'mz_source'
 > CREATE VIEWS FROM SOURCE "mz_source" ("numbers")
 > SELECT * FROM "numbers";
@@ -290,29 +290,29 @@ DELETE FROM numbers WHERE number = 2;
 
 # missing sslcert
 ! CREATE MATERIALIZED SOURCE "mz_source"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=certuser sslmode=verify-ca sslcert=/share/secrets/missing sslkey=/share/secrets/certuser.key sslrootcert=/share/secrets/ca.crt dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=certuser sslmode=verify-ca sslcert=/share/secrets/missing sslkey=/share/secrets/certuser.key sslrootcert=/share/secrets/ca.crt dbname=postgres'
   PUBLICATION 'mz_source'
 invalid connection string: invalid value for option `sslcert`
 
 # missing sslkey
 ! CREATE MATERIALIZED SOURCE "mz_source"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=certuser sslmode=verify-ca sslcert=/share/secrets/certuser.crt sslkey=/share/secrets/missing sslrootcert=/share/secrets/ca.crt dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=certuser sslmode=verify-ca sslcert=/share/secrets/certuser.crt sslkey=/share/secrets/missing sslrootcert=/share/secrets/ca.crt dbname=postgres'
   PUBLICATION 'mz_source'
 invalid connection string: invalid value for option `sslkey`
 
 # missing sslrootcert
 ! CREATE MATERIALIZED SOURCE "mz_source"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=certuser sslmode=verify-ca sslcert=/share/secrets/certuser.crt sslkey=/share/secrets/certuser.key sslrootcert=/share/secrets/missing dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=certuser sslmode=verify-ca sslcert=/share/secrets/certuser.crt sslkey=/share/secrets/certuser.key sslrootcert=/share/secrets/missing dbname=postgres'
   PUBLICATION 'mz_source'
 invalid connection string: invalid value for option `sslrootcert`
 
 # require both sslcert and sslkey
 ! CREATE MATERIALIZED SOURCE "mz_source"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=certuser sslmode=verify-ca sslcert=/share/secrets/certuser.crt dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=certuser sslmode=verify-ca sslcert=/share/secrets/certuser.crt dbname=postgres'
   PUBLICATION 'mz_source'
 must provide both sslcert and sslkey, but only provided sslcert
 
 ! CREATE MATERIALIZED SOURCE "mz_source"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=certuser sslmode=verify-ca sslkey=/share/secrets/certuser.key dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=certuser sslmode=verify-ca sslkey=/share/secrets/certuser.key dbname=postgres'
   PUBLICATION 'mz_source'
 must provide both sslcert and sslkey, but only provided sslkey

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -83,39 +83,39 @@ CREATE TABLE "space table" ("space column" INTEGER);
 #
 
 ! CREATE MATERIALIZED SOURCE "no_such_host"
-  FROM POSTGRES HOST 'host=no_such_postgres.mtrlz.com port=5432 user=postgres password=postgres dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=no_such_postgres.mtrlz.com port=5432 user=postgres password=postgres dbname=postgres'
   PUBLICATION 'mz_source';
 error connecting to server: failed to lookup address information: Name or service not known
 
 ! CREATE MATERIALIZED SOURCE "no_such_port"
-  FROM POSTGRES HOST 'host=postgres port=65534 user=postgres password=postgres dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=65534 user=postgres password=postgres dbname=postgres'
   PUBLICATION 'mz_source';
 error connecting to server: Connection refused (os error 111)
 
 ! CREATE MATERIALIZED SOURCE "no_such_user"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=no_such_user password=postgres dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=no_such_user password=postgres dbname=postgres'
   PUBLICATION 'mz_source';
 db error: FATAL: role "no_such_user" does not exist
 
 ! CREATE MATERIALIZED SOURCE "no_such_password"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=no_such_password dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=no_such_password dbname=postgres'
   PUBLICATION 'mz_source';
 db error: FATAL: password authentication failed for user "postgres"
 
 ! CREATE MATERIALIZED SOURCE "no_such_dbname"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=no_such_dbname'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres dbname=no_such_dbname'
   PUBLICATION 'mz_source';
 db error: FATAL: database "no_such_dbname" does not exist
 
 > CREATE MATERIALIZED SOURCE "no_such_publication"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
   PUBLICATION 'no_such_publication';
 # TODO: This should produce an error
 
 > DROP SOURCE "no_such_publication"
 
 > CREATE MATERIALIZED SOURCE "mz_source"
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
   PUBLICATION 'mz_source';
 
 > CREATE VIEWS FROM SOURCE "mz_source" ("no_replica_identity")
@@ -337,7 +337,7 @@ $ postgres-verify-slot connection=postgres://postgres:postgres@postgres slot=tes
 
 > CREATE MATERIALIZED SOURCE "test_slot_source"
   FROM POSTGRES
-    HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
+    CONNECTION 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
     PUBLICATION 'mz_source'
     SLOT 'test_slot';
 

--- a/test/pg-cdc/publication-for-table.td
+++ b/test/pg-cdc/publication-for-table.td
@@ -29,7 +29,7 @@ INSERT INTO t2 VALUES (5);
 CREATE PUBLICATION mz_source FOR TABLE t1;
 
 > CREATE MATERIALIZED SOURCE mz_source
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
   PUBLICATION 'mz_source';
 
 > CREATE VIEWS FROM SOURCE mz_source (t1);

--- a/test/pg-cdc/publication-with-publish-option.td
+++ b/test/pg-cdc/publication-with-publish-option.td
@@ -27,15 +27,15 @@ CREATE PUBLICATION mz_source_update FOR TABLE t1 WITH ( publish = 'update') ;
 CREATE PUBLICATION mz_source_delete FOR TABLE t1 WITH ( publish = 'delete') ;
 
 > CREATE MATERIALIZED SOURCE mz_source_insert
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
   PUBLICATION 'mz_source_insert';
 
 > CREATE MATERIALIZED SOURCE mz_source_update
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
   PUBLICATION 'mz_source_update';
 
 > CREATE MATERIALIZED SOURCE mz_source_delete
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
   PUBLICATION 'mz_source_delete';
 
 # Make sure that the above sources are fully instantiated so that the DML statements below

--- a/test/pg-cdc/replica-identity-default-nothing.td
+++ b/test/pg-cdc/replica-identity-default-nothing.td
@@ -36,7 +36,7 @@ ALTER TABLE identity_nothing REPLICA IDENTITY NOTHING;
 CREATE PUBLICATION mz_source FOR ALL TABLES;
 
 > CREATE MATERIALIZED SOURCE mz_source
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
   PUBLICATION 'mz_source';
 
 # Make sure that the above sources are fully instantiated so that the DML statements below

--- a/test/pg-cdc/truncate-table.td
+++ b/test/pg-cdc/truncate-table.td
@@ -25,7 +25,7 @@ INSERT INTO t1 VALUES (1);
 CREATE PUBLICATION mz_source FOR ALL TABLES;
 
 > CREATE MATERIALIZED SOURCE mz_source
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
   PUBLICATION 'mz_source';
 
 > CREATE VIEWS FROM SOURCE mz_source;

--- a/test/pg-cdc/two-publications-one-table.td
+++ b/test/pg-cdc/two-publications-one-table.td
@@ -31,13 +31,13 @@ CREATE PUBLICATION mz_source2 FOR ALL TABLES;
 > CREATE SCHEMA schema1
 
 > CREATE MATERIALIZED SOURCE mz_source1
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
   PUBLICATION 'mz_source1';
 
 > CREATE VIEWS FROM SOURCE mz_source1 (t1 AS t1_1);
 
 > CREATE MATERIALIZED SOURCE mz_source2
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
   PUBLICATION 'mz_source2';
 
 > CREATE VIEWS FROM SOURCE mz_source2 (t1 AS t1_2);

--- a/test/pg-cdc/two-source-schemas.td
+++ b/test/pg-cdc/two-source-schemas.td
@@ -33,7 +33,7 @@ INSERT INTO schema2.t1 VALUES (2);
 CREATE PUBLICATION mz_source FOR ALL TABLES;
 
 > CREATE MATERIALIZED SOURCE mz_source
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
   PUBLICATION 'mz_source';
 
 > SELECT COUNT(*) > 0 FROM mz_source;

--- a/test/pg-cdc/two-sources-one-publication.td
+++ b/test/pg-cdc/two-sources-one-publication.td
@@ -33,13 +33,13 @@ CREATE PUBLICATION mz_source FOR ALL TABLES;
 > CREATE SCHEMA schema1
 
 > CREATE MATERIALIZED SOURCE mz_source1
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
   PUBLICATION 'mz_source';
 
 > CREATE VIEWS FROM SOURCE mz_source1 (t1 AS t1_1, t2 AS t2_1);
 
 > CREATE MATERIALIZED SOURCE mz_source2
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
   PUBLICATION 'mz_source';
 
 > CREATE VIEWS FROM SOURCE mz_source2 (t1 AS t1_2, t2 AS t2_2);

--- a/test/pg-cdc/types-boolean.td
+++ b/test/pg-cdc/types-boolean.td
@@ -28,7 +28,7 @@ INSERT INTO t1 VALUES ('true'),('false');
 CREATE PUBLICATION mz_source FOR ALL TABLES;
 
 > CREATE MATERIALIZED SOURCE mz_source
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
   PUBLICATION 'mz_source';
 
 > SELECT COUNT(*) > 0 FROM mz_source;

--- a/test/pg-cdc/types-bytea.td
+++ b/test/pg-cdc/types-bytea.td
@@ -29,7 +29,7 @@ INSERT INTO t1 VALUES (NULL), (''), (E'\\x00'), (E'\\xABCDEF1234');
 CREATE PUBLICATION mz_source FOR ALL TABLES;
 
 > CREATE MATERIALIZED SOURCE mz_source
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
   PUBLICATION 'mz_source';
 
 > SELECT COUNT(*) > 0 FROM mz_source;

--- a/test/pg-cdc/types-character.td
+++ b/test/pg-cdc/types-character.td
@@ -27,7 +27,7 @@ INSERT INTO t1 VALUES ('abc', 'abc', 'abc');
 CREATE PUBLICATION mz_source FOR ALL TABLES;
 
 > CREATE MATERIALIZED SOURCE mz_source
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
   PUBLICATION 'mz_source';
 
 > SELECT COUNT(*) > 0 FROM mz_source;

--- a/test/pg-cdc/types-decimal.td
+++ b/test/pg-cdc/types-decimal.td
@@ -28,7 +28,7 @@ INSERT INTO t1 VALUES ('-99999999999999999999', '-0.99999999999999999999', '-999
 CREATE PUBLICATION mz_source FOR ALL TABLES;
 
 > CREATE MATERIALIZED SOURCE mz_source
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
   PUBLICATION 'mz_source';
 
 > SELECT COUNT(*) > 0 FROM mz_source;

--- a/test/pg-cdc/types-double.td
+++ b/test/pg-cdc/types-double.td
@@ -32,7 +32,7 @@ INSERT INTO t1 VALUES ('-1111111111111111111111111111111', '-1111111111111111111
 CREATE PUBLICATION mz_source FOR ALL TABLES;
 
 > CREATE MATERIALIZED SOURCE mz_source
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
   PUBLICATION 'mz_source';
 
 > SELECT COUNT(*) > 0 FROM mz_source;

--- a/test/pg-cdc/types-enum.td.gh6818
+++ b/test/pg-cdc/types-enum.td.gh6818
@@ -27,7 +27,7 @@ INSERT INTO enum_type VALUES ('val1'), ('val2');
 CREATE PUBLICATION mz_source FOR ALL TABLES;
 
 > CREATE MATERIALIZED SOURCE mz_source
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
   PUBLICATION 'mz_source';
 
 > SELECT COUNT(*) > 0 FROM mz_source;

--- a/test/pg-cdc/types-hstore.td.gh6818
+++ b/test/pg-cdc/types-hstore.td.gh6818
@@ -28,7 +28,7 @@ INSERT INTO t1 VALUES (NULL), ('a=>1'::hstore);
 CREATE PUBLICATION mz_source FOR ALL TABLES;
 
 > CREATE MATERIALIZED SOURCE mz_source
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
   PUBLICATION 'mz_source';
 
 > SELECT COUNT(*) > 0 FROM mz_source;

--- a/test/pg-cdc/types-integer.td
+++ b/test/pg-cdc/types-integer.td
@@ -28,7 +28,7 @@ INSERT INTO t1 VALUES (32767, 2147483647, 9223372036854775807);
 CREATE PUBLICATION mz_source FOR ALL TABLES;
 
 > CREATE MATERIALIZED SOURCE mz_source
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
   PUBLICATION 'mz_source';
 
 > SELECT COUNT(*) > 0 FROM mz_source;

--- a/test/pg-cdc/types-interval.td
+++ b/test/pg-cdc/types-interval.td
@@ -27,7 +27,7 @@ INSERT INTO t1 VALUES (interval '1 year 2 month 3 day 4 hour 5 minute 6.789123 s
 CREATE PUBLICATION mz_source FOR ALL TABLES;
 
 > CREATE MATERIALIZED SOURCE mz_source
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
   PUBLICATION 'mz_source';
 
 > SELECT COUNT(*) > 0 FROM mz_source;

--- a/test/pg-cdc/types-json.td
+++ b/test/pg-cdc/types-json.td
@@ -28,7 +28,7 @@ INSERT INTO t1 VALUES ('{"bar": "baz", "balance": 7.77, "active": false}'::json)
 CREATE PUBLICATION mz_source FOR ALL TABLES;
 
 > CREATE MATERIALIZED SOURCE mz_source
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
   PUBLICATION 'mz_source';
 
 > SELECT COUNT(*) > 0 FROM mz_source;

--- a/test/pg-cdc/types-money.td.gh6819
+++ b/test/pg-cdc/types-money.td.gh6819
@@ -28,7 +28,7 @@ INSERT INTO t1 VALUES (-92233720368547758.08), (+92233720368547758.07);
 CREATE PUBLICATION mz_source FOR ALL TABLES;
 
 > CREATE MATERIALIZED SOURCE mz_source
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
   PUBLICATION 'mz_source';
 
 > SELECT COUNT(*) > 0 FROM mz_source;

--- a/test/pg-cdc/types-numeric-arbitrary-precision.td.gh6821
+++ b/test/pg-cdc/types-numeric-arbitrary-precision.td.gh6821
@@ -27,7 +27,7 @@ INSERT INTO t1 VALUES (NULL), ('0.000000000000000000000000000001'), ('-111111111
 CREATE PUBLICATION mz_source FOR ALL TABLES;
 
 > CREATE MATERIALIZED SOURCE mz_source
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
   PUBLICATION 'mz_source';
 
 > SELECT COUNT(*) > 0 FROM mz_source;

--- a/test/pg-cdc/types-serial.td
+++ b/test/pg-cdc/types-serial.td
@@ -27,7 +27,7 @@ INSERT INTO t1 VALUES (32767, 2147483647, 9223372036854775807);
 CREATE PUBLICATION mz_source FOR ALL TABLES;
 
 > CREATE MATERIALIZED SOURCE mz_source
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
   PUBLICATION 'mz_source';
 
 > SELECT COUNT(*) > 0 FROM mz_source;

--- a/test/pg-cdc/types-temporal-with-tz.td
+++ b/test/pg-cdc/types-temporal-with-tz.td
@@ -32,7 +32,7 @@ ALTER TABLE timestamp_table REPLICA IDENTITY FULL;
 CREATE PUBLICATION mz_source FOR ALL TABLES;
 
 > CREATE MATERIALIZED SOURCE mz_source
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
   PUBLICATION 'mz_source';
 
 > SELECT COUNT(*) > 0 FROM mz_source;

--- a/test/pg-cdc/types-temporal.td
+++ b/test/pg-cdc/types-temporal.td
@@ -27,7 +27,7 @@ INSERT INTO t1 VALUES ('2011-11-11', '11:11:11.123456', '2011-11-11 11:11:11.123
 CREATE PUBLICATION mz_source FOR ALL TABLES;
 
 > CREATE MATERIALIZED SOURCE mz_source
-  FROM POSTGRES HOST 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
   PUBLICATION 'mz_source';
 
 > SELECT COUNT(*) > 0 FROM mz_source;


### PR DESCRIPTION
This is a shortcoming of the initial implementation that is better fixed while the feature is experimental. The paramater contains a lot more information than just the host and also `CONNECTION` aligns our syntax further with postgres' `CREATE SUBSCRIPTION` syntax.