### PR TITLE
sql: transform power to its fully-qualified form

### DIFF
--- a/src/sql/src/plan/transform_ast.rs
+++ b/src/sql/src/plan/transform_ast.rs
@@ -224,7 +224,7 @@ impl<'a> FuncRewriter<'a> {
                     let (lhs, rhs) = (args[0].clone(), args[1].clone());
                     match name.item.as_str() {
                         "mod" => lhs.modulo(rhs),
-                        "pow" => Expr::call(vec!["power"], vec![lhs, rhs]),
+                        "pow" => Expr::call(vec!["pg_catalog", "power"], vec![lhs, rhs]),
                         _ => return None,
                     }
                 } else {

--- a/test/testdrive/github-7191.td
+++ b/test/testdrive/github-7191.td
@@ -1,0 +1,15 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# The presence of this query in a view tests that the transformation of
+# "pow" -> "power" is correctly planned on reboot when testdrive is run with
+# --validate-catalog. This protects against regression of #7191.
+> CREATE VIEW v AS SELECT pow(2, 4)
+> SELECT * FROM v
+16


### PR DESCRIPTION
This ensures the transform query can be planned in contexts with an
empty search path, like when the server boots.

Fix #7191.