### PR TITLE
expr: correct nullability of casts from json

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -4071,14 +4071,14 @@ impl UnaryFunc {
             // converts null to jsonnull
             CastJsonbOrNullToJsonb => ScalarType::Jsonb.nullable(false),
 
-            // can return null for other jsonb types
+            // These return null when their input is SQL null.
             CastJsonbToString => ScalarType::String.nullable(true),
-            CastJsonbToInt32 => ScalarType::Int32.nullable(false),
-            CastJsonbToInt64 => ScalarType::Int64.nullable(false),
-            CastJsonbToFloat32 => ScalarType::Float32.nullable(false),
-            CastJsonbToFloat64 => ScalarType::Float64.nullable(false),
+            CastJsonbToInt32 => ScalarType::Int32.nullable(true),
+            CastJsonbToInt64 => ScalarType::Int64.nullable(true),
+            CastJsonbToFloat32 => ScalarType::Float32.nullable(true),
+            CastJsonbToFloat64 => ScalarType::Float64.nullable(true),
             CastJsonbToDecimal(scale) => {
-                ScalarType::Decimal(MAX_DECIMAL_PRECISION, *scale).nullable(false)
+                ScalarType::Decimal(MAX_DECIMAL_PRECISION, *scale).nullable(true)
             }
             CastJsonbToBool => ScalarType::Bool.nullable(true),
 

--- a/test/sqllogictest/jsonb.slt
+++ b/test/sqllogictest/jsonb.slt
@@ -1950,3 +1950,16 @@ query T
 SELECT jsonb_object_agg(a, a) FILTER (WHERE a IS NOT NULL) FROM t1
 ----
 {"1":1,"2":2,"3":3}
+
+# Null casts. Protects against #7183.
+query TTTTTTT
+SELECT
+    NULL::jsonb::text,
+    NULL::jsonb::int4,
+    NULL::jsonb::int8,
+    NULL::jsonb::float4,
+    NULL::jsonb::float8,
+    NULL::jsonb::decimal,
+    NULL::jsonb::bool
+----
+NULL NULL NULL NULL NULL NULL NULL


### PR DESCRIPTION
All of these casts are nullable because they can produce null when given
SQL null as input.

Fix #7183.