### PR TITLE
sql-parser: fix parsing of dollar-quoted strings

### DIFF
--- a/src/sql-parser/src/lexer.rs
+++ b/src/sql-parser/src/lexer.rs
@@ -284,6 +284,7 @@ fn lex_to_adjacent_string(buf: &mut LexBuf) -> bool {
 fn lex_dollar_string(buf: &mut LexBuf) -> Result<Token, ParserError> {
     let pos = buf.pos() - 1;
     let tag = format!("${}$", buf.take_while(|ch| ch != '$'));
+    let _ = buf.next();
     if let Some(s) = buf.take_to_delimiter(&tag) {
         Ok(Token::String(s.into()))
     } else {

--- a/src/sql-parser/tests/testdata/lexer
+++ b/src/sql-parser/tests/testdata/lexer
@@ -103,7 +103,7 @@ e'\x1fg'
 parse-statement roundtrip
 SELECT $$Postgre's SQL$$, $eOf$Postgre's SQL$eOf$, end
 ----
-SELECT '$Postgre''s SQL', '$Postgre''s SQL', end
+SELECT 'Postgre''s SQL', 'Postgre''s SQL', end
 
 parse-statement roundtrip
 SELECT $$POST
@@ -118,6 +118,11 @@ SELECT $EOF$PostgreSQL$$eof$$
 error: unterminated dollar-quoted string
 SELECT $EOF$PostgreSQL$$eof$$
        ^
+
+parse-statement roundtrip
+SELECT $$$$
+----
+SELECT ''
 
 # Numeric literals
 parse-scalar


### PR DESCRIPTION
The lexer was not correctly skipping over the second `$` character in
the opening tag. This bug has been present since the lexer was rewritten
with support for this style of string literal, and was reflected in the
test cases already... just no one had noticed until now (h/t @ruchirK).

Fix #7198.