### PR TITLE
Fix and update Docs Search

### DIFF
--- a/doc/user/README.md
+++ b/doc/user/README.md
@@ -199,6 +199,27 @@ programming language). For expressivity, we chose `nofmt`.
   would like to volunteer their web development expertise to make this more
   sane, I would be really happy to help them out.
 
+## Search
+
+Search is powered by Algolia. A [custom JSON index template]( doc/user/layouts/_default/index.search.json) renders metadata (documented below) for each page. The metadata is pushed into Algolia using a post-deploy action. The front-end uses a lightly customized out-of-the-box Algolia search widget (instantsearch.js) to query the index.
+
+**How are deleted pages removed from index?** If we only ever updated search results, deleted pages or pages with changed URLs would cause issues. To work around that, upon every deploy: 1. We delete all results from the index, 2. We push the updated set of results to the index.
+
+### Search Specification
+
+The following metadata attributes are pushed to the JSON index for every page and sub-page.
+
+| Field | Type | Limits | Description
+| ----- | ---- | ------ | ----------- |
+| `objectId` | string | unique | Unique identifier required by search index, for docs we just use absolute URL.  |
+| `category` | string | "docs" OR "blog" | This field can eventually be used to give us universal search across docs, blog, etc... but is set to "docs" for everything in hugo.  |
+| `parentTitle` | string | not required | When the result is a subsection of a page, this is set to parent page title. |
+| `title` | string | required | The title to be displayed in results, carries the most weight for text matching. |
+| `description` | string | up to 241 chars | The description to be displayed and ...snippetted... in results, also used for text matching. In the event that a result doesn't have a description explicity set in hugo frontmatter, the first 240 chars of plain text are used.|
+| `url` | string | required | Absolute URL the user should be taken to upon clicking the result. Can include anchor tags for deeplinks. |
+| `breadcrumbs` | string | | Currently just a visual
+| `level` | integer | required | Level indicates the level of depth from the docs home of a result, closer to homepage acts as tie-breaker for results with equal text matching scores. |
+
 ## Miscellany, trivia, & footguns
 
 - Headers are automatically hyperlinked using [AnchorJS].

--- a/doc/user/assets/js/search.js
+++ b/doc/user/assets/js/search.js
@@ -1,0 +1,40 @@
+/* global instantsearch algoliasearch */
+
+const ENV = document.head.querySelector("[name=environment][content]").content,
+search = instantsearch({
+  indexName: ENV + '_materialize',
+  searchClient: algoliasearch('RD8N8OKT1S', '3964a300b5b3516d542717f6cf704bd4'),
+  //Prevent empty search on load
+  searchFunction: function(helper) {
+    if (helper.state.query === '') {
+      document.getElementById('search-hits').innerHTML = '';
+      return;
+    }
+    helper.search();
+  },
+});
+
+search.addWidgets([
+  instantsearch.widgets.searchBox({
+    container: '#search-input',
+    placeholder: 'Search the docs'
+  }),
+  instantsearch.widgets.hits({
+    container: '#search-hits',
+    templates: {
+      item: `
+        <a href="{{permalink}}">
+          <div class="hit-title">
+            <span class="parentTitle">{{parentTitle}}</span>{{#helpers.highlight}}{ "attribute": "title" }{{/helpers.highlight}}
+          </div>
+          <div class="hit-description">
+            {{#helpers.snippet}}{ "attribute": "description" }{{/helpers.snippet}}
+          </div>
+          <span class="eyebrow">{{breadcrumbs}}</span>
+        </a>
+      `,
+    },
+  }),
+]);
+
+search.start();

--- a/doc/user/assets/js/search.js
+++ b/doc/user/assets/js/search.js
@@ -23,7 +23,7 @@ search.addWidgets([
     container: '#search-hits',
     templates: {
       item: `
-        <a href="{{permalink}}">
+        <a href="{{url}}">
           <div class="hit-title">
             <span class="parentTitle">{{parentTitle}}</span>{{#helpers.highlight}}{ "attribute": "title" }{{/helpers.highlight}}
           </div>

--- a/doc/user/assets/js/search.js
+++ b/doc/user/assets/js/search.js
@@ -1,5 +1,3 @@
-/* global instantsearch algoliasearch */
-
 // Copyright Materialize, Inc. and contributors. All rights reserved.
 //
 // Use of this software is governed by the Business Source License
@@ -8,6 +6,8 @@
 // As of the Change Date specified in that file, in accordance with
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
+
+/* global instantsearch algoliasearch */
 
 const ENV = document.head.querySelector("[name=environment][content]").content,
 search = instantsearch({

--- a/doc/user/assets/js/search.js
+++ b/doc/user/assets/js/search.js
@@ -1,5 +1,14 @@
 /* global instantsearch algoliasearch */
 
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
 const ENV = document.head.querySelector("[name=environment][content]").content,
 search = instantsearch({
   indexName: ENV + '_materialize',

--- a/doc/user/assets/sass/_layout.scss
+++ b/doc/user/assets/sass/_layout.scss
@@ -123,7 +123,6 @@ header {
     }
 
     a {
-
         padding-left: 0.5rem;
         margin-left: 2px;
 
@@ -151,6 +150,10 @@ header {
     .parentTitle {
         font-weight: normal;
         margin-right: 12px;
+
+        &:empty {
+            display: none;
+        }
 
         &:after {
             content: "›";

--- a/doc/user/assets/sass/_layout.scss
+++ b/doc/user/assets/sass/_layout.scss
@@ -108,29 +108,56 @@ header {
   padding: 0 40px;
 }
 
-.algolia-autocomplete {
-  width: 100%;
-
-  .ds-cursor .algolia-docsearch-suggestion--content {
-    background: rgba($purple, 0.03) !important;
-  }
-
-  .algolia-docsearch-suggestion--highlight {
-    background: rgba($purple, 0.03) !important;
-    color: $purple !important;
-    box-shadow: inset 0 -2px 0 0 $purple-40 !important;
-  }
+#search-input {
+  margin-bottom: 12px;
 }
 
-#search-input {
-  border-radius: 5px;
-  border: 1px solid $grey;
-  box-sizing: border-box;
-  font-family: "RM Neue";
-  font-size: 15px;
-  margin-bottom: 12px;
-  padding: 3px 5px;
-  width: 100%;
+#search-hits {
+    box-shadow: 5px 5px 10px rgba(0,0,0,0.2);
+    position: absolute;
+    width: 500px;
+    z-index: 10;
+
+    .ais-Hits-item {
+        padding: 1rem 1rem 1rem 0.5rem;
+    }
+
+    a {
+
+        padding-left: 0.5rem;
+        margin-left: 2px;
+
+        &:hover {
+            opacity: 1;
+            border-left: 2px solid $purple;
+            margin-left: 0;
+        }
+    }
+
+    .eyebrow {
+        color: $grey-dark;
+    }
+
+    .hit-title {
+        font-size: 16px;
+        font-weight: bold;
+    }
+
+    .hit-description {
+        color: $off-black;
+        padding: 0.25rem 0;
+    }
+
+    .parentTitle {
+        font-weight: normal;
+        margin-right: 12px;
+
+        &:after {
+            content: "›";
+            position: relative;
+            left: 5px;
+        }
+    }
 }
 
 .sidebar-wrapper {

--- a/doc/user/config.toml
+++ b/doc/user/config.toml
@@ -77,3 +77,12 @@ weight = 120
 [markup.goldmark.renderer]
 # allow <a name="link-target">, the old syntax no longer works
 unsafe = true
+
+[outputFormats.search]
+baseName = "search"
+isPlainText = true
+mediaType = "application/json"
+notAlternative = true
+
+[outputs]
+home = [ "HTML", "search"]

--- a/doc/user/content/stylesheet.md
+++ b/doc/user/content/stylesheet.md
@@ -1,5 +1,6 @@
 ---
 title: "Stylesheet"
+hidden: true
 ---
 
 The following page works as a quick visual demo of how we render common HTML elements using our stylesheet.

--- a/doc/user/layouts/_default/baseof.html
+++ b/doc/user/layouts/_default/baseof.html
@@ -50,6 +50,8 @@ by the Apache License, Version 2.0.  */}}
 
         $(".content ol:has(p)").addClass("has-p");
     </script>
+    {{ $script := resources.Get "js/search.js" }}
+    <script src="{{ $script.RelPermalink }}"></script>
 </body>
 
 </html>

--- a/doc/user/layouts/_default/index.search.json
+++ b/doc/user/layouts/_default/index.search.json
@@ -1,0 +1,73 @@
+{{- $.Scratch.Add "index" slice -}}
+
+{{- /* Index every page */ -}}
+{{- range $page := .Site.Pages -}}
+	
+	{{- $section := .Site.GetPage .Section -}}
+	
+	{{- /* Exclude homepage, drafts, hidden pages, descendants of drafts, descendants of hidden pages */ -}}
+	{{- if and (not ($page.IsHome)) (not (.Params.draft)) (not (.Params.hidden))  (not ($section.Params.draft)) (not ($section.Params.hidden)) -}}
+		
+		{{- /* If no description is provided, use the first x chars of summary */ -}}
+		{{- $description := (cond (gt (len $page.Description) 0) $page.Description (print (substr $page.Summary 0 240) "…")) -}}
+
+		{{- /* Build breadcrumb context string */ -}}
+		{{- $.Scratch.Set "breadcrumbs" "" }}
+    {{- $.Scratch.Set "level" 0 }}
+		{{- if $page.Parent -}}
+			{{- $.Scratch.Set "breadcrumbs" $page.Parent.LinkTitle -}}
+      {{- $.Scratch.Set "level" 1 }}
+			{{- if $page.Parent.Parent -}}
+				{{- $.Scratch.Set "breadcrumbs" (print $page.Parent.Parent.LinkTitle " / " ($.Scratch.Get "breadcrumbs")) -}}
+        {{- $.Scratch.Set "level" 2 }}
+				{{- if $page.Parent.Parent.Parent -}}
+					{{- $.Scratch.Set "breadcrumbs" (print $page.Parent.Parent.Parent.LinkTitle " / " ($.Scratch.Get "breadcrumbs")) -}}
+          {{- $.Scratch.Set "level" 3 }}
+				{{- end -}}
+			{{- end -}}
+		{{- end -}}
+
+    {{- $.Scratch.Set "breadcrumbs" (replace ($.Scratch.Get "breadcrumbs") "Docs Home" "Docs") -}}
+
+		{{- $.Scratch.Set "currPage" (dict) -}}
+    {{- $.Scratch.SetInMap "currPage" "objectID"    $page.Permalink -}}
+    {{- $.Scratch.SetInMap "currPage" "parentTitle" "" -}}
+		{{- $.Scratch.SetInMap "currPage" "title"       $page.Title -}}
+		{{- $.Scratch.SetInMap "currPage" "description" $description -}}
+		{{- $.Scratch.SetInMap "currPage" "tags"        (plainify $page.Section) -}}
+		{{- $.Scratch.SetInMap "currPage" "breadcrumbs" ($.Scratch.Get "breadcrumbs") -}}
+		{{- $.Scratch.SetInMap "currPage" "url"         $page.Permalink -}}
+		{{- $.Scratch.SetInMap "currPage" "level"       ($.Scratch.Get "level") -}}
+		{{- $.Scratch.SetInMap "currPage" "category"    "docs" -}}
+		
+		{{- $.Scratch.Add "index" ($.Scratch.Get "currPage") -}}
+		
+		{{- /* Split a single page up into blocks of deeplinkable anchors (e.g. <h2 id="...">) and content */ -}}
+		{{- /* Skip first sections using `after 2` - first anchorlink is typically a subheading or toc */ -}}
+		{{- range $subsection := after 2 (split (replaceRE "<[^>]+ id=\"[^\"]+\"[^>]*>" "ALGOLIA-SPLIT" $page.Content) "ALGOLIA-SPLIT" ) -}}
+			
+			{{- $sectionLines := split . "\n" -}}
+			{{- $subTitle := (plainify (htmlUnescape (index $sectionLines 0))) -}}
+			{{- $subContent := (plainify (htmlUnescape ((delimit (after 1 $sectionLines) "")))) -}}
+			
+			{{- /* Only index subsections that actually have content */ -}}
+			{{- if and (gt (len $subContent) 0) (gt (len $subTitle) 0) -}}
+
+				{{- $.Scratch.Set "currPage" (dict) -}}
+        {{- $.Scratch.SetInMap "currPage" "objectID"    (print $page.Permalink "#" (anchorize $subTitle)) -}}
+				{{- $.Scratch.SetInMap "currPage" "parentTitle" $page.Title -}}
+        {{- $.Scratch.SetInMap "currPage" "title"       $subTitle -}}
+				{{- $.Scratch.SetInMap "currPage" "description" (print $subContent) -}}
+		    {{- $.Scratch.SetInMap "currPage" "breadcrumbs" ($.Scratch.Get "breadcrumbs") -}}
+				{{- $.Scratch.SetInMap "currPage" "permalink"   (print $page.Permalink "#" (anchorize $subTitle)) -}}
+				{{- $.Scratch.SetInMap "currPage" "level"       (add ($.Scratch.Get "level") 1) -}}
+				{{- $.Scratch.SetInMap "currPage" "category"    "docs" -}}
+				
+				{{- $.Scratch.Add "index" ($.Scratch.Get "currPage") -}}
+			
+			{{- end -}}
+		{{- end -}}
+	{{- end -}}
+{{- end -}}
+
+{{ $.Scratch.Get "index" | jsonify }}

--- a/doc/user/layouts/_default/index.search.json
+++ b/doc/user/layouts/_default/index.search.json
@@ -60,7 +60,7 @@
 				{{- $.Scratch.SetInMap "currPage" "description" (print $subContent) -}}
 		    {{- $.Scratch.SetInMap "currPage" "breadcrumbs" ($.Scratch.Get "breadcrumbs") -}}
 				{{- $.Scratch.SetInMap "currPage" "url"         (print $page.Permalink "#" (anchorize $subTitle)) -}}
-				{{- $.Scratch.SetInMap "currPage" "level"       (add ($.Scratch.Get "level") 1) -}}
+				{{- $.Scratch.SetInMap "currPage" "level"       (add ($.Scratch.Get "level") 3) -}}
 				{{- $.Scratch.SetInMap "currPage" "category"    "docs" -}}
 				
 				{{- $.Scratch.Add "index" ($.Scratch.Get "currPage") -}}

--- a/doc/user/layouts/_default/index.search.json
+++ b/doc/user/layouts/_default/index.search.json
@@ -59,7 +59,7 @@
         {{- $.Scratch.SetInMap "currPage" "title"       $subTitle -}}
 				{{- $.Scratch.SetInMap "currPage" "description" (print $subContent) -}}
 		    {{- $.Scratch.SetInMap "currPage" "breadcrumbs" ($.Scratch.Get "breadcrumbs") -}}
-				{{- $.Scratch.SetInMap "currPage" "permalink"   (print $page.Permalink "#" (anchorize $subTitle)) -}}
+				{{- $.Scratch.SetInMap "currPage" "url"         (print $page.Permalink "#" (anchorize $subTitle)) -}}
 				{{- $.Scratch.SetInMap "currPage" "level"       (add ($.Scratch.Get "level") 1) -}}
 				{{- $.Scratch.SetInMap "currPage" "category"    "docs" -}}
 				

--- a/doc/user/layouts/_default/index.search.json
+++ b/doc/user/layouts/_default/index.search.json
@@ -2,12 +2,12 @@
 
 {{- /* Index every page */ -}}
 {{- range $page := .Site.Pages -}}
-	
+
 	{{- $section := .Site.GetPage .Section -}}
-	
+
 	{{- /* Exclude homepage, drafts, hidden pages, descendants of drafts, descendants of hidden pages */ -}}
 	{{- if and (not ($page.IsHome)) (not (.Params.draft)) (not (.Params.hidden))  (not ($section.Params.draft)) (not ($section.Params.hidden)) -}}
-		
+
 		{{- /* If no description is provided, use the first x chars of summary */ -}}
 		{{- $description := (cond (gt (len $page.Description) 0) $page.Description (print (substr $page.Summary 0 240) "…")) -}}
 
@@ -39,17 +39,17 @@
 		{{- $.Scratch.SetInMap "currPage" "url"         $page.Permalink -}}
 		{{- $.Scratch.SetInMap "currPage" "level"       ($.Scratch.Get "level") -}}
 		{{- $.Scratch.SetInMap "currPage" "category"    "docs" -}}
-		
+
 		{{- $.Scratch.Add "index" ($.Scratch.Get "currPage") -}}
-		
+
 		{{- /* Split a single page up into blocks of deeplinkable anchors (e.g. <h2 id="...">) and content */ -}}
 		{{- /* Skip first sections using `after 2` - first anchorlink is typically a subheading or toc */ -}}
 		{{- range $subsection := after 2 (split (replaceRE "<[^>]+ id=\"[^\"]+\"[^>]*>" "ALGOLIA-SPLIT" $page.Content) "ALGOLIA-SPLIT" ) -}}
-			
+
 			{{- $sectionLines := split . "\n" -}}
 			{{- $subTitle := (plainify (htmlUnescape (index $sectionLines 0))) -}}
 			{{- $subContent := (plainify (htmlUnescape ((delimit (after 1 $sectionLines) "")))) -}}
-			
+
 			{{- /* Only index subsections that actually have content */ -}}
 			{{- if and (gt (len $subContent) 0) (gt (len $subTitle) 0) -}}
 
@@ -62,9 +62,9 @@
 				{{- $.Scratch.SetInMap "currPage" "url"         (print $page.Permalink "#" (anchorize $subTitle)) -}}
 				{{- $.Scratch.SetInMap "currPage" "level"       (add ($.Scratch.Get "level") 3) -}}
 				{{- $.Scratch.SetInMap "currPage" "category"    "docs" -}}
-				
+
 				{{- $.Scratch.Add "index" ($.Scratch.Get "currPage") -}}
-			
+
 			{{- end -}}
 		{{- end -}}
 	{{- end -}}

--- a/doc/user/layouts/partials/head.html
+++ b/doc/user/layouts/partials/head.html
@@ -1,24 +1,17 @@
 <meta name="viewport" content="width=1024">
+<meta name="environment" content="{{ hugo.Environment }}">
 
 {{/*  Include all JavaScript files here  */}}
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/anchor-js/anchor.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/simple-scrollspy@2.0.3/dist/simple-scrollspy.min.js"></script>
 
+{{/* Algolia InstantSearchv4 */}}
+<script src="https://cdn.jsdelivr.net/npm/algoliasearch@4/dist/algoliasearch-lite.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/instantsearch.js@4"></script>
+
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/instantsearch.css@7.4.5/themes/satellite-min.css" integrity="sha256-TehzF/2QvNKhGQrrNpoOb2Ck4iGZ1J/DI4pkd2oUsBc=" crossorigin="anonymous">
+
 {{/*  Sass processing here  */}}
 {{ $style := resources.Get "sass/main.scss" | toCSS | fingerprint }}
 <link rel="stylesheet" href="{{ $style.RelPermalink }}">
-
-{{/* Algolia DocSearch */}}
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
-<script src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
-<script defer>
-addEventListener("DOMContentLoaded", () => {
-  docsearch({
-    apiKey: "4a00e9b5208d93ae2445d7ea064ddbac",
-    indexName: "materialize",
-    inputSelector: '#search-input',
-    debug: true,
-  });
-});
-</script>

--- a/doc/user/layouts/partials/head.html
+++ b/doc/user/layouts/partials/head.html
@@ -1,3 +1,7 @@
+{{ if .Params.hidden }}
+<meta name="robots" content="noindex" /> 
+{{ end }}
+
 <meta name="viewport" content="width=1024">
 <meta name="environment" content="{{ hugo.Environment }}">
 

--- a/doc/user/layouts/partials/head.html
+++ b/doc/user/layouts/partials/head.html
@@ -1,5 +1,5 @@
 {{ if .Params.hidden }}
-<meta name="robots" content="noindex" /> 
+<meta name="robots" content="noindex" />
 {{ end }}
 
 <meta name="viewport" content="width=1024">

--- a/doc/user/layouts/partials/sidebar.html
+++ b/doc/user/layouts/partials/sidebar.html
@@ -1,8 +1,8 @@
 <div class="sidebar-wrapper">
   {{ $currentPage := . }}
   <nav role="navigation" class="sidebar">
-    <input id="search-input" placeholder="Search">
-
+    <div id="search-input"></div>
+    <div id="search-hits"></div>
     <ul>
       {{ range .Site.Menus.main.ByWeight }}
       <li class="level-1 {{if .HasChildren }}has-children{{end}}">


### PR DESCRIPTION
Docs search previously used Algolia's free https://docsearch.algolia.com/ product. While this was zero-effort to implement, I think it is worthwhile to switch to a full Algolia account for a few reasons:

1. Free products tend to get neglected, give users zero recourse for support and help.
2. When we push results to Algolia, we update our indexes faster and we have more control over the results.
3. This gives us the option to use the same search in the Blog and elsewhere in the future.

With that in mind, I added two pieces:

## 1. Search Index

I've added a new JSON-formatted hugo index template in `/layouts/_default/index.search.json` that has some pretty rough-looking hugo code, but works fine and accomplishes two things:

1. JSON object with necessary metadata for every page.
2. JSON object with necessary metadata for every deeplink-able subsection of every page

The second one is a bit complicated because I _DONT_ want to index a heading that is immediately followed by another heading.

I've also added a specification for the metadata fields in the docs readme to make it clear what fields are required and how they are used.

The end result is that a single JSON file should render out to https://materialize.com/docs/search.json with an object for every page and subpage. This JSON file will need to be pushed (via post-deploy action) to Algolia.

## 2. Search UI

The search UI uses Algolia's InstantSearch.js v4. I had to style the results _(I'm not a CSS wizard so I chose a style that felt readable and matched our color scheme.)_  