### PR TITLE
[optimization] nullability in types reflects predicates

### DIFF
--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -400,7 +400,15 @@ impl MirRelationExpr {
                 for key_set in &mut input_typ.keys {
                     key_set.retain(|k| !cols_equal_to_literal.contains(&k));
                 }
+                // Augment non-nullability of columns, by observing either
+                // 1. Predicates that explicitly test for null values, and
+                // 2. Columns that if null would make a predicate be null.
+                let mut nonnull_required_columns = HashSet::new();
                 for predicate in predicates {
+                    // Add any columns that being null would force the predicate to be null.
+                    // Should that happen, the row would be discarded.
+                    predicate.non_null_requirements(&mut nonnull_required_columns);
+                    // Test for explicit checks that a column is non-null.
                     if let MirScalarExpr::CallUnary {
                         func: UnaryFunc::Not,
                         expr,
@@ -416,6 +424,11 @@ impl MirRelationExpr {
                             }
                         }
                     }
+                }
+                // Set as nonnull any columns where null values would cause
+                // any predicate to evaluate to null.
+                for column in nonnull_required_columns.into_iter() {
+                    input_typ.column_types[column].nullable = false;
                 }
                 input_typ
             }

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -1559,7 +1559,7 @@ ORDER BY substr(c_state, 1, 1)
 | Filter ((((((("1" = substr(#11, 1, 1)) || ("2" = substr(#11, 1, 1))) || ("3" = substr(#11, 1, 1))) || ("4" = substr(#11, 1, 1))) || ("5" = substr(#11, 1, 1))) || ("6" = substr(#11, 1, 1))) || ("7" = substr(#11, 1, 1))), (#16 > 0dec)
 | Reduce group=()
 | | agg sum(#16)
-| | agg count(#16)
+| | agg count(true)
 | Map (((#0 * 10000000dec) / i64todec(if (#1 = 0) then {null} else {#1})) / 10dec)
 | ArrangeBy ()
 


### PR DESCRIPTION
Each `Filter` predicate will be null if certain of its input columns are null. In those cases, the record will be dropped, meaning that after the `Filter` those columns can be sure to be non-null. The `RelationExpr::typ` method is improved to do this reasoning for `Filter` stages.