### PR TITLE
Revert "doc/user: emergency update for doc search"

### DIFF
--- a/doc/user/layouts/partials/head.html
+++ b/doc/user/layouts/partials/head.html
@@ -15,8 +15,7 @@
 <script defer>
 addEventListener("DOMContentLoaded", () => {
   docsearch({
-    appId: "UR3ZY8WA0J",
-    apiKey: "7368fcb6df9de12eca2de79a04ac92f6",
+    apiKey: "4a00e9b5208d93ae2445d7ea064ddbac",
     indexName: "materialize",
     inputSelector: '#search-input',
     debug: true,


### PR DESCRIPTION
This reverts commit 41dec9542781fbbd990cf6acd05745acceb282b9.
Algolia's hosted index is back online.