### PR TITLE
sql/apd: avoid -0 when rescaling values

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -1798,6 +1798,7 @@ fn rescale_apd<'a>(a: Datum<'a>, scale: u8) -> Result<Datum<'a>, EvalError> {
     if apd::rescale(&mut d.0, scale).is_err() {
         return Err(EvalError::NumericFieldOverflow);
     };
+    apd::munge_apd(&mut d.0).unwrap();
     Ok(Datum::APD(d))
 }
 

--- a/test/sqllogictest/apd.slt
+++ b/test/sqllogictest/apd.slt
@@ -68,6 +68,11 @@ SELECT ('1.2e-20'::apd)::text
 0.000000000000000000012
 
 query T
+SELECT '-0.0000001'::apd(10,2)::text
+----
+0
+
+query T
 SELECT ('    1.2'::apd)::text
 ----
 1.2


### PR DESCRIPTION
This is currently the only function that should be munged but wasn't (at least afaict).

Fixes #7215