### PR TITLE
sinks,kafka: continuously update write frontier instead of only after commits 

### DIFF
--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -552,7 +552,7 @@ where
                         &new_frontier
                     ));
                     if prev_frontier != &new_frontier {
-                        add_progress(*id, &prev_frontier, &new_frontier, &mut progress);
+                        add_progress(*id, &new_frontier, &prev_frontier, &mut progress);
                         prev_frontier.clone_from(&new_frontier);
                     }
                 }


### PR DESCRIPTION
This ensures that we can compact source timestamp bindings even when no data is flowing to sinks.

I'm not yet 100% convinced updating the write frontier like this is correct, though I'm pretty sure. Please see my inline comment about this and poke holes into my thinking. 