### PR TITLE
coord: add only indexed views/sources to timedomains

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -2158,7 +2158,9 @@ impl Coordinator {
         source_timeline: &Option<Timeline>,
         conn_id: u32,
     ) -> Result<Vec<GlobalId>, CoordError> {
-        let mut timedomain_ids = self.catalog.schema_adjacent_relations(&source_ids, conn_id);
+        let mut timedomain_ids = self
+            .catalog
+            .schema_adjacent_indexed_relations(&source_ids, conn_id);
 
         // Filter out ids from different timelines. The timeline code only verifies
         // that the SELECT doesn't cross timelines. The schema-adjacent code looks

--- a/test/sqllogictest/transactions.slt
+++ b/test/sqllogictest/transactions.slt
@@ -360,4 +360,4 @@ simple conn=t1
 SELECT * FROM v1;
 COMMIT;
 ----
-db error: ERROR: transactions can only reference nearby relations; "materialize.public.v1" referenced here, but only the following are available: "materialize.public.t", "materialize.public.t5727", "materialize.public.v"
+db error: ERROR: transactions can only reference nearby relations; "materialize.public.v1" referenced here, but only the following are available: "materialize.public.t", "materialize.public.t5727", "materialize.public.v", "materialize.public.v_primary_idx"

--- a/test/testdrive/transactions-timedomain-nonmaterialized.td
+++ b/test/testdrive/transactions-timedomain-nonmaterialized.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# Test behavior of timedomains with non-materialized sources. Currently they prevent transactions
+# Test behavior of timedomains with non-materialized sources.
 
 $ file-append path=static.csv
 1
@@ -22,21 +22,82 @@ $ file-append path=static.csv
   FROM FILE '${testdrive.temp-dir}/static.csv'
   FORMAT CSV WITH 1 COLUMNS
 
+> CREATE VIEW v_unindexed AS SELECT count(*) FROM unindexed
+
 # A SELECT from the materialized source should succeed outside a transaction.
 > SELECT c FROM indexed ORDER BY c
 1
 2
 4
 
-! SELECT c FROM unindexed ORDER BY c
+! SELECT * FROM unindexed
+Unable to automatically determine a timestamp for your query; this can happen if your query depends on non-materialized sources.
+
+! SELECT * FROM v_unindexed
 Unable to automatically determine a timestamp for your query; this can happen if your query depends on non-materialized sources.
 
 > BEGIN
 
-# A SELECT from the materialized source will fail in a transaction
-# because the non-materialized source is in the same time domain.
-# TODO(mjibson): Fix this. #6651.
-! SELECT c FROM indexed ORDER BY c
-Unable to automatically determine a timestamp for your query; this can happen if your query depends on non-materialized sources.
+# A SELECT from the materialized source in a transaction should succeed
+# even though a non-materialized source is in the same time domain.
+> SELECT c FROM indexed ORDER BY c
+1
+2
+4
+
+! SELECT c FROM unindexed ORDER BY c
+transactions can only reference nearby relations
 
 > ROLLBACK
+
+# The unindexed view should be the same.
+> BEGIN
+
+> SELECT c FROM indexed ORDER BY c
+1
+2
+4
+
+! SELECT * FROM v_unindexed
+transactions can only reference nearby relations
+
+> ROLLBACK
+
+# Ensure that other optionally indexed things (views) are correctly
+# included in the timedomain.
+> CREATE VIEW v AS SELECT COUNT(*) FROM indexed
+
+# Wait until there are results.
+> SELECT * FROM v
+3
+
+> BEGIN
+
+> SELECT c FROM indexed ORDER BY c
+1
+2
+4
+
+> SELECT * FROM v
+3
+
+> COMMIT
+
+# Make v indexed to ensure it works too.
+> CREATE DEFAULT INDEX ON v;
+
+# Wait until there are results.
+> SELECT * FROM v
+3
+
+> BEGIN
+
+> SELECT c FROM indexed ORDER BY c
+1
+2
+4
+
+> SELECT * FROM v
+3
+
+> COMMIT


### PR DESCRIPTION
This prevents unmaterialized sources joining timedomains when not
requested, which made transactions unusable in that case.

Fixes #6651
Fixes #7193
Fixes #7167