### PR TITLE
dbt-materialize: index macros

### DIFF
--- a/misc/dbt-materialize/README.md
+++ b/misc/dbt-materialize/README.md
@@ -44,11 +44,42 @@ incremental | NO | Use the `materializedview` materialization instead! dbt's inc
 dbt only supports a limited set of [materialization types](https://docs.getdbt.com/docs/building-a-dbt-project/building-models/materializations). To create other types of objects in Materialize
 via dbt, use the following Materialize-specific macros:
 
-Macro | Details
+Macro | Purpose
 ------|----------
 mz_generate_name(identifier) | Generates a fully-qualified name (including the database and schema) given an object name.
 mz_create_source(sql) | Given some [`CREATE SOURCE`](https://materialize.com/docs/sql/create-source/) sql statement, creates the source in the Materialize instance.
 mz_drop_source(name, if_exists, cascade) | [Drops the named source](https://materialize.com/docs/sql/drop-source/) in Materialize.
+mz_create_index(obj_name, default, idx_name, col_refs, with_options) | [Creates an index](https://materialize.com/docs/sql/create-index/) in Materialize.
+mz_drop_index(name, default, if_exists, cascade) | [Drops an index](https://materialize.com/docs/sql/drop-index/) in Materialize.
+
+### Additional macro details
+
+#### mz_drop_source(name, if_exists, cascade)
+
+Argument | Type | Detail
+---------|------|--------
+name     | string | Name of the source to drop
+if_exists | boolean | Does not return an error if the named source does not exist
+cascade | boolean | Drops the source and its dependent objects
+
+#### mz_create_index(obj_name, name, default, col_refs, with_options)
+
+Argument | Type | Detail
+---------|------|--------
+obj_name | string | Name of the source or view to create an index on
+name | optional string | If not a `default` index, the name of the index to create
+default | boolean | `True` will create a default index on the named source or view
+col_refs | optional list of strings | The columns to use as the key into the index
+with_options | optional list of strings | The name of index parameters to set as val
+
+#### mz_drop_index(name, default, if_exists, cascade)
+
+Argument | Type | Detail
+---------|------|--------
+name | string | Name of the index to drop
+default | boolean | `True` will drop the default index
+if_exists | boolean | Does not return an error if the named index does not exist
+cascade | boolean | Drops the index and its dependent objects
 
 ### Seeds
 

--- a/misc/dbt-materialize/dbt/include/materialize/macros/mz_create_index.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/mz_create_index.sql
@@ -1,0 +1,48 @@
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License in the LICENSE file at the
+-- root of this repository, or online at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+{% macro mz_create_index(obj_name, idx_name=None, default=False, col_refs=None, with_options=None) -%}
+  {# todo@jldlaughlin: figure out docs and hooks! #}
+  {% set createstmt %}
+    CREATE
+    {% if default %}
+      DEFAULT INDEX
+    {% else %}
+      INDEX
+        {% if idx_name %}
+            {{ idx_name }}
+        {% endif %}
+    {% endif %}
+    ON {{ obj_name }}
+    {% if col_refs %}
+      (
+        {% for col in col_refs %}
+          {{ col }}{{ ", " if not loop.last else "" }}
+        {% endfor %}
+      )
+    {% endif %}
+    {% if with_options %}
+      WITH
+      (
+        {% for option in with_options %}
+          {{ option }}{{ ", " if not loop.last else "" }}
+        {% endfor %}
+      )
+    {% endif %}
+  {% endset %}
+
+  {% do run_query(createstmt) %}
+
+{% endmacro %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/mz_drop_index.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/mz_drop_index.sql
@@ -1,0 +1,35 @@
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License in the LICENSE file at the
+-- root of this repository, or online at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+{% macro mz_drop_index(name, default=False, if_exists=True, cascade=False) -%}
+  {# todo@jldlaughlin: figure out docs and hooks! #}
+  {% set dropstmt %}
+    DROP INDEX
+    {% if if_exists %}
+        IF EXISTS
+    {% endif %}
+    {% if default %}
+        {{ "{}_default_idx".format(name.rstrip()) }}
+    {% else %}
+        {{ name }}
+    {% endif %}
+    {% if cascade %}
+        CASCADE
+    {% endif %}
+  {% endset %}
+
+  {% do run_query(dropstmt) %}
+
+{% endmacro %}

--- a/play/materialize-cloud-dbt/dbt_project.yml
+++ b/play/materialize-cloud-dbt/dbt_project.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 'materialize-cloud-dbt'
+name: 'materialize_cloud_dbt'
 version: '1.0.0'
 config-version: 2
 


### PR DESCRIPTION
Fixes https://github.com/MaterializeInc/materialize/issues/6788.

Adds new `mz_create_index` and `mz_drop_index` macros, which mirror the
[`CREATE INDEX`](https://materialize.com/docs/sql/create-index/) and [`DROP INDEX`](https://materialize.com/docs/sql/drop-index/) statements in Materialize. Example usage
of these macros can be found in the `play/materialize-cloud-dbt` project.