### PR TITLE
sql/apd: properly rescale values on insert

### DIFF
--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -864,9 +864,13 @@ impl<'a> ScalarType {
     }
 }
 
-// TODO(benesch): the implementations of PartialEq and Hash for ScalarType can
-// be removed when decimal precision is either fixed or removed.
-
+/// NOTE: `ScalarType` equality is complicated by variants that store values.
+/// While we might want to handle stored values in one manner most of the time,
+/// that same approach might be insufficient in some cases.
+///
+/// When assessing unexpected behavior with type planning, it's worthwhile to
+/// see if the default equality is overridden in some other part of the code,
+/// e.g. when deciding how to handle potential casts between types.
 impl PartialEq for ScalarType {
     fn eq(&self, other: &Self) -> bool {
         use ScalarType::*;

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1153,9 +1153,8 @@ fn coerce_args_to_types(
             .expect("function selection verifies that polymorphic types successfully resolved")
     };
 
-    let do_convert = |arg, ty: &ScalarType| {
-        let arg = typeconv::plan_coerce(ecx, arg, ty)?;
-        typeconv::plan_cast(spec, ecx, CastContext::Implicit, arg, ty)
+    let do_convert = |arg: CoercibleScalarExpr, ty: &ScalarType| {
+        arg.cast_to(&spec.to_string(), ecx, CastContext::Implicit, ty)
     };
 
     let mut exprs = Vec::new();

--- a/test/testdrive/apd.td
+++ b/test/testdrive/apd.td
@@ -1,0 +1,25 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> CREATE TABLE apd_insertions (a APD(39,2));
+
+> CREATE TABLE apd_deletions (a APD(39,2));
+
+> CREATE VIEW apd_values AS
+  SELECT a FROM apd_insertions
+    EXCEPT (SELECT a FROM apd_deletions);
+
+> INSERT INTO apd_insertions VALUES ('0.0001');
+> INSERT INTO apd_insertions VALUES ('0.009');
+
+> SELECT a::text, a = '0'::apd AS eq_zero FROM apd_values;
+a    eq_zero
+------------
+0    true
+0.01 false


### PR DESCRIPTION
The fixed issue was caused by a failure to rescale APD values on insert (though they did get properly rescaled when read from the tables out to `psql`). The underlying cause of _that_ was that `cast_relation` thought all APD columns were equal irrespective of scale due to its reliance of `ScalarType::eq`, and didn't perform the casts we expected.

Rather than move the pseudo-equal logic from `get_cast` to a helper function, I instead have `cast_relation` call `plan_cast` on every column and throw away the unnecessary casts.

Fixes #7226

Also...
Fixes #7220 