### PR TITLE
dbt-materialize: sink macros

### DIFF
--- a/misc/dbt-materialize/README.md
+++ b/misc/dbt-materialize/README.md
@@ -47,10 +47,12 @@ via dbt, use the following Materialize-specific macros:
 Macro | Purpose
 ------|----------
 mz_generate_name(identifier) | Generates a fully-qualified name (including the database and schema) given an object name.
-mz_create_source(sql) | Given some [`CREATE SOURCE`](https://materialize.com/docs/sql/create-source/) sql statement, creates the source in the Materialize instance.
+mz_create_source(sql) | Given a [`CREATE SOURCE`](https://materialize.com/docs/sql/create-source/) SQL statement, creates the source in the Materialize instance.
 mz_drop_source(name, if_exists, cascade) | [Drops the named source](https://materialize.com/docs/sql/drop-source/) in Materialize.
 mz_create_index(obj_name, default, idx_name, col_refs, with_options) | [Creates an index](https://materialize.com/docs/sql/create-index/) in Materialize.
 mz_drop_index(name, default, if_exists, cascade) | [Drops an index](https://materialize.com/docs/sql/drop-index/) in Materialize.
+mz_create_sink(name) | Given a [`CREATE SINK`](https://materialize.com/docs/sql/create-sink/) SQL statement, creates a sink in the Materialize instance.
+mz_drop_sink(name, if_exists) | [Drops a sink](https://materialize.com/docs/sql/drop-sink/) in Materialize.
 
 ### Additional macro details
 

--- a/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
@@ -28,6 +28,10 @@
   );
 {%- endmacro %}
 
+{% macro materialize__create_arbitrary_object(sql) -%}
+    {{ sql }}
+{%- endmacro %}
+
 {% macro materialize__create_schema(relation) -%}
   {% if relation.database -%}
     {{ adapter.verify_database(relation.database) }}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/mz_create_sink.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/mz_create_sink.sql
@@ -13,37 +13,11 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-{% macro mz_create_index(obj_name, name=None, default=False, col_refs=None, with_options=None) -%}
+{% macro mz_create_sink(sql) -%}
   {# todo@jldlaughlin: figure out docs and hooks! #}
 
-  {% set createstmt %}
-    CREATE
-    {% if default %}
-      DEFAULT INDEX
-    {% else %}
-      INDEX
-        {% if name %}
-            {{ name }}
-        {% endif %}
-    {% endif %}
-    ON {{ obj_name }}
-    {% if col_refs %}
-      (
-        {% for col in col_refs %}
-          {{ col }}{{ ", " if not loop.last else "" }}
-        {% endfor %}
-      )
-    {% endif %}
-    {% if with_options %}
-      WITH
-      (
-        {% for option in with_options %}
-          {{ option }}{{ ", " if not loop.last else "" }}
-        {% endfor %}
-      )
-    {% endif %}
-  {% endset %}
-
-  {% do run_query(createstmt) %}
+  {% call statement('main', auto_begin=False) -%}
+    {{ materialize__create_arbitrary_object(sql) }}
+  {%- endcall %}
 
 {% endmacro %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/mz_create_source.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/mz_create_source.sql
@@ -14,8 +14,7 @@
 -- limitations under the License.
 
 {% macro mz_create_source(sql) -%}
-  -- todo@jldlaughlin
-  -- figure out docs and hooks!
+  {# todo@jldlaughlin: figure out docs and hooks! #}
 
   {% call statement('main', auto_begin=False) -%}
     {{ materialize__create_arbitrary_object(sql) }}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/mz_drop_index.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/mz_drop_index.sql
@@ -15,6 +15,7 @@
 
 {% macro mz_drop_index(name, default=False, if_exists=True, cascade=False) -%}
   {# todo@jldlaughlin: figure out docs and hooks! #}
+
   {% set dropstmt %}
     DROP INDEX
     {% if if_exists %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/mz_drop_sink.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/mz_drop_sink.sql
@@ -13,37 +13,16 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-{% macro mz_create_index(obj_name, name=None, default=False, col_refs=None, with_options=None) -%}
+{% macro mz_drop_sink(name, if_exists=True) -%}
   {# todo@jldlaughlin: figure out docs and hooks! #}
 
-  {% set createstmt %}
-    CREATE
-    {% if default %}
-      DEFAULT INDEX
-    {% else %}
-      INDEX
-        {% if name %}
-            {{ name }}
-        {% endif %}
+  {% set dropstmt %}
+    DROP SINK
+    {% if if_exists %}
+        IF EXISTS
     {% endif %}
-    ON {{ obj_name }}
-    {% if col_refs %}
-      (
-        {% for col in col_refs %}
-          {{ col }}{{ ", " if not loop.last else "" }}
-        {% endfor %}
-      )
-    {% endif %}
-    {% if with_options %}
-      WITH
-      (
-        {% for option in with_options %}
-          {{ option }}{{ ", " if not loop.last else "" }}
-        {% endfor %}
-      )
-    {% endif %}
+    {{ name }}
   {% endset %}
 
-  {% do run_query(createstmt) %}
-
+  {% do run_query(dropstmt) %}
 {% endmacro %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/mz_drop_source.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/mz_drop_source.sql
@@ -14,8 +14,7 @@
 -- limitations under the License.
 
 {% macro mz_drop_source(name, if_exists=True, cascade=False) -%}
-  -- todo@jldlaughlin
-  -- figure out docs and hooks!
+  {# todo@jldlaughlin: figure out docs and hooks! #}
 
   {% set dropstmt %}
     DROP SOURCE

--- a/play/materialize-cloud-dbt/models/example/market_orders.sql
+++ b/play/materialize-cloud-dbt/models/example/market_orders.sql
@@ -17,7 +17,7 @@
     {{ mz_generate_name('market_orders_raw') }}
 {% endset %}
 
-{% set stmt %}
+{% set source_stmt %}
     CREATE MATERIALIZED SOURCE {{ source_name }} FROM PUBNUB
     SUBSCRIBE KEY 'sub-c-4377ab04-f100-11e3-bffd-02ee2ddab7fe'
     CHANNEL 'pubnub-market-orders';
@@ -25,7 +25,7 @@
 
 --- DROP SOURCE, CREATE SOURCE
 {{ mz_drop_source(source_name, cascade=True) }}
-{{ mz_create_source(stmt) }}
+{{ mz_create_source(source_stmt) }}
 
 --- CREATE INDEX ON UNMATERIALIZED SOURCE, DROP THEM
 {{ mz_drop_index(source_name, default=True, cascade=True) }}
@@ -33,10 +33,24 @@
 {{ mz_drop_index("non_default_idx", cascade=True) }}
 {{ mz_create_index(source_name, idx_name="non_default_idx", col_refs=["text"], with_options=["logical_compaction_window = '500ms'"])}}
 
--- CREATE THE MATERIALIZED VIEW FROM THE UNMATERIALIZED SOURCE
+--- CREATE MATERIALIZED VIEW
 {{ config(materialized='materializedview') }}
 
 SELECT
     val->>'symbol' AS symbol,
     (val->'bid_price')::float AS bid_price
 FROM (SELECT text::jsonb AS val FROM {{ source_name }})
+
+--- CREATE SINK
+-- {% set sink_name %}
+--     {{ mz_generate_name('market_orders_sink') }}
+-- {% endset %}
+
+-- {% set sink_stmt %}
+--     CREATE SINK {{ sink_name }}
+--     FROM "market_orders"
+--     INTO AVRO OCF '/tester.ocf;'
+-- {% endset %}
+
+-- {{ mz_drop_sink(sink_name) }}
+-- {{ mz_create_sink(sink_stmt) }}


### PR DESCRIPTION
Fixes https://github.com/MaterializeInc/materialize/issues/6621.

Adds new `mz_create_sink` and `mz_drop_sink` macros, which allow users
to create and drop sinks via dbt. Adds relevant docs and an example
in the `play/materialize-cloud-dbt project`.

~Note: the first commit belongs to [another PR](https://github.com/MaterializeInc/materialize/pull/7238), please ignore!~