### PR TITLE
Expr/Repr testing: Enable specifying RelationType in unit testing.

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -30,7 +30,7 @@ use serde::{Deserialize, Serialize};
 use build_info::DUMMY_BUILD_INFO;
 use dataflow_types::{SinkConnector, SinkConnectorBuilder, SourceConnector, Timeline};
 use expr::{ExprHumanizer, GlobalId, MirScalarExpr, OptimizedMirRelationExpr};
-use repr::{ColumnType, RelationDesc, ScalarType};
+use repr::{RelationDesc, ScalarType};
 use sql::ast::display::AstDisplay;
 use sql::ast::{Expr, Raw};
 use sql::catalog::{
@@ -2186,14 +2186,6 @@ impl ExprHumanizer for ConnCatalog<'_> {
                 }
             }
         }
-    }
-
-    fn humanize_column_type(&self, typ: &ColumnType) -> String {
-        format!(
-            "{}{}",
-            self.humanize_scalar_type(&typ.scalar_type),
-            if typ.nullable { "?" } else { "" }
-        )
     }
 }
 

--- a/src/expr-test-util/src/lib.rs
+++ b/src/expr-test-util/src/lib.rs
@@ -32,7 +32,7 @@ gen_reflect_info_func!(
         MirRelationExpr,
         JoinImplementation
     ],
-    [ColumnType]
+    [ColumnType, RelationType]
 );
 
 lazy_static! {
@@ -123,25 +123,8 @@ impl<'a> TestCatalog {
                         }?;
 
                         let mut ctx = GenericTestDeserializeContext::default();
-                        let scalar_types: Vec<ScalarType> =
-                            deserialize(&mut inner_iter, "Vec<ScalarType>", &RTI, &mut ctx)?;
-
-                        let mut typ = RelationType::new(
-                            scalar_types
-                                .into_iter()
-                                .map(|t| t.nullable(true))
-                                .collect::<Vec<_>>(),
-                        );
-
-                        let keys: Option<Vec<Vec<usize>>> = deserialize_optional(
-                            &mut inner_iter,
-                            "Vec<Vec<usize>>",
-                            &RTI,
-                            &mut ctx,
-                        )?;
-                        if let Some(keys) = keys {
-                            typ = typ.with_keys(keys)
-                        }
+                        let typ: RelationType =
+                            deserialize(&mut inner_iter, "RelationType", &RTI, &mut ctx)?;
 
                         self.insert(&name, typ);
                         Ok(())
@@ -161,10 +144,6 @@ impl ExprHumanizer for TestCatalog {
 
     fn humanize_scalar_type(&self, ty: &ScalarType) -> String {
         DummyHumanizer.humanize_scalar_type(ty)
-    }
-
-    fn humanize_column_type(&self, ty: &ColumnType) -> String {
-        DummyHumanizer.humanize_column_type(ty)
     }
 }
 

--- a/src/expr-test-util/tests/testdata/cat
+++ b/src/expr-test-util/tests/testdata/cat
@@ -1,0 +1,75 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# test being able to add sources of different types to the catalog
+
+cat
+(defsource x ([((list bool null) false) ((array string)) (float32)] [[0] [1]]))
+----
+ok
+
+build format=types
+(get x)
+----
+%0 =
+| Get x (u0)
+| | types = (List { element_type: Bool, custom_oid: None }, Array(String)?, Float32?)
+| | keys = ((#0), (#1))
+
+cat
+(defsource y ([int32 (interval false) (float32 true) ((bytes) false)] [[0 1] [2]]))
+----
+ok
+
+build format=types
+(get y)
+----
+%0 =
+| Get y (u1)
+| | types = (Int32?, Interval, Float32?, Bytes)
+| | keys = ((#0, #1), (#2))
+
+cat
+(defsource source ([] [[]]))
+----
+ok
+
+build format=types
+(get source)
+----
+%0 =
+| Get source (u2)
+| | types = ()
+| | keys = (())
+
+cat
+(defsource word [time])
+----
+ok
+
+build format=types
+(get word)
+----
+%0 =
+| Get word (u3)
+| | types = (Time?)
+| | keys = ()
+
+cat
+(defsource some_thing ([timestamp date] [[1]]))
+----
+ok
+
+build format=types
+(get some_thing)
+----
+%0 =
+| Get some_thing (u4)
+| | types = (Timestamp?, Date?)
+| | keys = ((#1))

--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -88,7 +88,13 @@ pub trait ExprHumanizer: fmt::Debug {
     fn humanize_scalar_type(&self, ty: &ScalarType) -> String;
 
     /// Returns a human-readable name for the specified scalar type.
-    fn humanize_column_type(&self, ty: &ColumnType) -> String;
+    fn humanize_column_type(&self, typ: &ColumnType) -> String {
+        format!(
+            "{}{}",
+            self.humanize_scalar_type(&typ.scalar_type),
+            if typ.nullable { "?" } else { "" }
+        )
+    }
 }
 
 /// A bare-minimum implementation of [`ExprHumanizer`].
@@ -107,11 +113,6 @@ impl ExprHumanizer for DummyHumanizer {
     }
 
     fn humanize_scalar_type(&self, ty: &ScalarType) -> String {
-        // The debug implementation is better than nothing.
-        format!("{:?}", ty)
-    }
-
-    fn humanize_column_type(&self, ty: &ColumnType) -> String {
         // The debug implementation is better than nothing.
         format!("{:?}", ty)
     }

--- a/src/lowertest/README.md
+++ b/src/lowertest/README.md
@@ -24,13 +24,13 @@ Write:
 You can put commas between fields and elements; they will essentially be treated
 as whitespace.
 
-As an convenience, a unit enum (resp. a struct with only one argument) can
+As a convenience, a unit enum (resp. a struct with only one argument) can
 alternatively be written as `variant_in_snake_case` (resp. `field1`).
 
-The convenience cannot be used if you have a struct whose only argument is an
+The convenience cannot be used if you have a struct whose only argument is a
 non-unit enum (resp. a struct with multiple arguments). In this case, you
 should use two sets of parentheses, e.g.
-`((variant_in_snake_case field1 .. fieldn))` (resp. `((field1 .. fieldn))`). to
+`((variant_in_snake_case field1 .. fieldn))` (resp. `((field1 .. fieldn))`) to
 make it clear that the multiple arguments belong to the inner enum/struct and
 not the outer struct.
 

--- a/src/lowertest/README.md
+++ b/src/lowertest/README.md
@@ -24,8 +24,15 @@ Write:
 You can put commas between fields and elements; they will essentially be treated
 as whitespace.
 
-A enum (resp. struct) specs with only one argument can alternatively be written
-as `variant_in_snake_case` (resp. `field1`).
+As an convenience, a unit enum (resp. a struct with only one argument) can
+alternatively be written as `variant_in_snake_case` (resp. `field1`).
+
+The convenience cannot be used if you have a struct whose only argument is an
+non-unit enum (resp. a struct with multiple arguments). In this case, you
+should use two sets of parentheses, e.g.
+`((variant_in_snake_case field1 .. fieldn))` (resp. `((field1 .. fieldn))`). to
+make it clear that the multiple arguments belong to the inner enum/struct and
+not the outer struct.
 
 The syntax can be overridden and extended by creating an object that implements
 the trait `TestDeserializationContext`; see [#extending-the-syntax] for more

--- a/src/lowertest/tests/testdata/build
+++ b/src/lowertest/tests/testdata/build
@@ -7,8 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# Tests that this module supports the default syntax as specified in the
-# readme.
+# This module supports the default syntax as specified in the readme.
 
 build
 ----
@@ -26,36 +25,14 @@ build
     ([true false null] [[[100 true] [200 false]][]])
     (single_named_field [0 10 42]))
 ----
-Some(MultiUnnamedFields(TestStruct2([(3, [("world", 5), ("this", 2)], 4), (2, [], 0)], "hello"), TestStruct3 { fizz: [Some(true), Some(false), None], bizz: [[(TestStruct1(100.0), true), (TestStruct1(200.0), false)], []] }, SingleNamedField { foo: [0, 10, 42] }))
+Some(MultiUnnamedFields(MultiUnnamedArg([(3, [("world", 5), ("this", 2)], 4), (2, [], 0)], "hello"), MultiNamedArg { fizz: [Some(true), Some(false), None], bizz: [[(SingleUnnamedArg(100.0), true), (SingleUnnamedArg(200.0), false)], []] }, SingleNamedField { foo: [0, 10, 42] }))
 
 build
 (multi_named_fields null false)
 ----
 Some(MultiNamedFields { bar: None, baz: false })
 
-# test that unit enum variants and structs with a single field can be
-# constructed with and without parenthesis around them
-build
-unit
-----
-Some(Unit)
-
-build
-(single_unnamed_field -1.1)
-----
-Some(SingleUnnamedField(TestStruct1(-1.1)))
-
-build
-(unit)
-----
-Some(Unit)
-
-build
-(single_unnamed_field (-1.1))
-----
-Some(SingleUnnamedField(TestStruct1(-1.1)))
-
-# default argument tests
+# Default arguments work
 
 build
 multi_named_fields
@@ -66,3 +43,80 @@ build
 (multi_named_fields "realm")
 ----
 Some(MultiNamedFields { bar: Some("realm"), baz: false })
+
+# Unit enum variants and structs with a single field can be
+# constructed with and without parenthesis around them
+
+build
+unit
+----
+Some(Unit)
+
+build
+(unit)
+----
+Some(Unit)
+
+#single field starts with a Punct
+
+build
+(single_unnamed_field -1.1)
+----
+Some(SingleUnnamedField(SingleUnnamedArg(-1.1)))
+
+build
+(single_unnamed_field (-1.1))
+----
+Some(SingleUnnamedField(SingleUnnamedArg(-1.1)))
+
+build
+(single_unnamed_field 2.2)
+----
+Some(SingleUnnamedField(SingleUnnamedArg(2.2)))
+
+build
+(single_unnamed_field (2.2))
+----
+Some(SingleUnnamedField(SingleUnnamedArg(2.2)))
+
+#single field is an Ident
+
+build
+(multi_unnamed_fields_2 false unit)
+----
+Some(MultiUnnamedFields2(OptionalArg(false, (0.0, 0)), FirstArgEnum { test_enum: Unit, second_arg: "" }, ""))
+
+build
+(multi_unnamed_fields_2 (false) (unit))
+----
+Some(MultiUnnamedFields2(OptionalArg(false, (0.0, 0)), FirstArgEnum { test_enum: Unit, second_arg: "" }, ""))
+
+#single field is a Vec
+
+build
+(multi_unnamed_fields ([], "bar") [false null true] (single_named_field [0 10 11]))
+----
+Some(MultiUnnamedFields(MultiUnnamedArg([], "bar"), MultiNamedArg { fizz: [Some(false), None, Some(true)], bizz: [] }, SingleNamedField { foo: [0, 10, 11] }))
+
+build
+(multi_unnamed_fields ([], "bar") ([false null true]) (single_named_field [0 10 11]))
+----
+Some(MultiUnnamedFields(MultiUnnamedArg([], "bar"), MultiNamedArg { fizz: [Some(false), None, Some(true)], bizz: [] }, SingleNamedField { foo: [0, 10, 11] }))
+
+# Arguments are assumed to be part of an outer struct/enum
+# unless enclosed in parentheses.
+
+build
+(multi_unnamed_fields_2 true unit "baz")
+----
+Some(MultiUnnamedFields2(OptionalArg(true, (0.0, 0)), FirstArgEnum { test_enum: Unit, second_arg: "" }, "baz"))
+
+build
+(multi_unnamed_fields_2 true (unit) "baz")
+----
+Some(MultiUnnamedFields2(OptionalArg(true, (0.0, 0)), FirstArgEnum { test_enum: Unit, second_arg: "" }, "baz"))
+
+build
+(multi_unnamed_fields_2 true (unit "baz"))
+----
+Some(MultiUnnamedFields2(OptionalArg(true, (0.0, 0)), FirstArgEnum { test_enum: Unit, second_arg: "baz" }, ""))

--- a/src/lowertest/tests/testdata/build-override
+++ b/src/lowertest/tests/testdata/build-override
@@ -14,26 +14,6 @@ build override=true
 None
 
 build override=true
-unit
-----
-Some(Unit)
-
-build override=true
-(single_unnamed_field -1.1)
-----
-Some(SingleUnnamedField(TestStruct1(-1.1)))
-
-build override=true
-(unit)
-----
-Some(Unit)
-
-build
-(single_unnamed_field (-1.1))
-----
-Some(SingleUnnamedField(TestStruct1(-1.1)))
-
-build
 (multi_named_fields null false)
 ----
 Some(MultiNamedFields { bar: None, baz: false })
@@ -47,6 +27,61 @@ build override=true
 (multi_named_fields "realm")
 ----
 Some(MultiNamedFields { bar: Some("realm"), baz: false })
+
+build override=true
+unit
+----
+Some(Unit)
+
+build override=true
+(unit)
+----
+Some(Unit)
+
+build override=true
+(single_unnamed_field -1.1)
+----
+Some(SingleUnnamedField(SingleUnnamedArg(-1.1)))
+
+build override=true
+(single_unnamed_field (-1.1))
+----
+Some(SingleUnnamedField(SingleUnnamedArg(-1.1)))
+
+build override=true
+(single_unnamed_field 2.2)
+----
+Some(SingleUnnamedField(SingleUnnamedArg(2.2)))
+
+build override=true
+(single_unnamed_field (2.2))
+----
+Some(SingleUnnamedField(SingleUnnamedArg(2.2)))
+
+build override=true
+(multi_unnamed_fields_2 false unit)
+----
+Some(MultiUnnamedFields2(OptionalArg(false, (0.0, 0)), FirstArgEnum { test_enum: Unit, second_arg: "" }, ""))
+
+build override=true
+(multi_unnamed_fields_2 (false) (unit))
+----
+Some(MultiUnnamedFields2(OptionalArg(false, (0.0, 0)), FirstArgEnum { test_enum: Unit, second_arg: "" }, ""))
+
+build override=true
+(multi_unnamed_fields_2 true unit "baz")
+----
+Some(MultiUnnamedFields2(OptionalArg(true, (0.0, 0)), FirstArgEnum { test_enum: Unit, second_arg: "" }, "baz"))
+
+build override=true
+(multi_unnamed_fields_2 true (unit) "baz")
+----
+Some(MultiUnnamedFields2(OptionalArg(true, (0.0, 0)), FirstArgEnum { test_enum: Unit, second_arg: "" }, "baz"))
+
+build override=true
+(multi_unnamed_fields_2 true (unit "baz"))
+----
+Some(MultiUnnamedFields2(OptionalArg(true, (0.0, 0)), FirstArgEnum { test_enum: Unit, second_arg: "baz" }, ""))
 
 # Override tests.
 
@@ -65,12 +100,12 @@ build override=true
     ([true false null] [[[100 true] [200 false]][]])
     (single_named_field [0 10 42]))
 ----
-Some(MultiUnnamedFields(TestStruct2([(4, [("world", 6), ("this", 3)], 5), (3, [], 1)], "hello"), TestStruct3 { fizz: [Some(true), Some(false), None], bizz: [[(TestStruct1(100.0), true), (TestStruct1(200.0), false)], []] }, SingleNamedField { foo: [1, 11, 43] }))
+Some(MultiUnnamedFields(MultiUnnamedArg([(4, [("world", 6), ("this", 3)], 5), (3, [], 1)], "hello"), MultiNamedArg { fizz: [Some(true), Some(false), None], bizz: [[(SingleUnnamedArg(100.0), true), (SingleUnnamedArg(200.0), false)], []] }, SingleNamedField { foo: [1, 11, 43] }))
 
 build override=true
 (single_unnamed_field +1.1)
 ----
-Some(SingleUnnamedField(TestStruct1(1.1)))
+Some(SingleUnnamedField(SingleUnnamedArg(1.1)))
 
 # Test our alternate syntax for passing in enum/struct information
 # for overriding
@@ -82,4 +117,4 @@ build override=true
          (multi_unnamed_fields "again" ([false false false] []) unit)
         ))
 ----
-Some(MultiUnnamedFields(TestStruct2([(2, [("\"goodbye\"", 2)], 2)], "\"goodbye\""), TestStruct3 { fizz: [Some(true), Some(false), None], bizz: [[(TestStruct1(100.0), true), (TestStruct1(200.0), false)], []] }, MultiUnnamedFields(TestStruct2([(3, [("", 3)], 3)], ""), TestStruct3 { fizz: [], bizz: [[(TestStruct1(-1.0), true)]] }, MultiUnnamedFields(TestStruct2([], "again"), TestStruct3 { fizz: [Some(false), Some(false), Some(false)], bizz: [] }, Unit))))
+Some(MultiUnnamedFields(MultiUnnamedArg([(2, [("\"goodbye\"", 2)], 2)], "\"goodbye\""), MultiNamedArg { fizz: [Some(true), Some(false), None], bizz: [[(SingleUnnamedArg(100.0), true), (SingleUnnamedArg(200.0), false)], []] }, MultiUnnamedFields(MultiUnnamedArg([(3, [("", 3)], 3)], ""), MultiNamedArg { fizz: [], bizz: [[(SingleUnnamedArg(-1.0), true)]] }, MultiUnnamedFields(MultiUnnamedArg([], "again"), MultiNamedArg { fizz: [Some(false), Some(false), Some(false)], bizz: [] }, Unit))))

--- a/src/repr-test-util/tests/testdata/scalartype
+++ b/src/repr-test-util/tests/testdata/scalartype
@@ -48,12 +48,12 @@ List { element_type: Jsonb, custom_oid: Some(100) }
 
 build-scalar-type
 (record
-    [["col1name" (true date)]
-     ["col2name" (false (list (map bytes 98) null))]
-     ["col3name" (false (list interval 34234))]]
+    [["col1name" (date true)]
+     ["col2name" ((list (map bytes 98) null) false)]
+     ["col3name" ((list interval 34234) false) ]]
      0 "recordname")
 ----
-Record { fields: [(ColumnName("col1name"), ColumnType { nullable: true, scalar_type: Date }), (ColumnName("col2name"), ColumnType { nullable: false, scalar_type: List { element_type: Map { value_type: Bytes, custom_oid: Some(98) }, custom_oid: None } }), (ColumnName("col3name"), ColumnType { nullable: false, scalar_type: List { element_type: Interval, custom_oid: Some(34234) } })], custom_oid: Some(0), custom_name: Some("recordname") }
+Record { fields: [(ColumnName("col1name"), ColumnType { scalar_type: Date, nullable: true }), (ColumnName("col2name"), ColumnType { scalar_type: List { element_type: Map { value_type: Bytes, custom_oid: Some(98) }, custom_oid: None }, nullable: false }), (ColumnName("col3name"), ColumnType { scalar_type: List { element_type: Interval, custom_oid: Some(34234) }, nullable: false })], custom_oid: Some(0), custom_name: Some("recordname") }
 
 build-scalar-type
 nonexistent

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -36,8 +36,11 @@ pub struct ColumnType {
     pub nullable: bool,
 }
 
-/// The default value for a bool. This method exists solely for the purpose of
-/// making ColumnType nullable by default in unit tests.
+/// This method exists solely for the purpose of making ColumnType nullable by
+/// default in unit tests. The default value of a bool is false, and the only
+/// way to make an object take on any other value by default is to pass it a
+/// function that returns the desired default value. See
+/// https://github.com/serde-rs/serde/issues/1030
 #[inline(always)]
 fn return_true() -> bool {
     true

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -29,10 +29,18 @@ use crate::ScalarType;
     Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash, MzStructReflect,
 )]
 pub struct ColumnType {
-    /// Whether this datum can be null.
-    pub nullable: bool,
     /// The underlying scalar type (e.g., Int32 or String) of this column.
     pub scalar_type: ScalarType,
+    /// Whether this datum can be null.
+    #[serde(default = "return_true")]
+    pub nullable: bool,
+}
+
+/// The default value for a bool. This method exists solely for the purpose of
+/// making ColumnType nullable by default in unit tests.
+#[inline(always)]
+fn return_true() -> bool {
+    true
 }
 
 impl ColumnType {
@@ -104,7 +112,7 @@ impl ColumnType {
 }
 
 /// The type of a relation.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzStructReflect)]
 pub struct RelationType {
     /// The type for each column, in order.
     pub column_types: Vec<ColumnType>,
@@ -117,6 +125,7 @@ pub struct RelationType {
     ///
     /// A collection can contain multiple sets of keys, although it is common to
     /// have either zero or one sets of key indices.
+    #[serde(default)]
     pub keys: Vec<Vec<usize>>,
 }
 

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -23,7 +23,7 @@ use lazy_static::lazy_static;
 use build_info::{BuildInfo, DUMMY_BUILD_INFO};
 use expr::{DummyHumanizer, ExprHumanizer, GlobalId, MirScalarExpr};
 use ore::now::{now_zero, EpochMillis, NowFn};
-use repr::{ColumnType, RelationDesc, ScalarType};
+use repr::{RelationDesc, ScalarType};
 use sql_parser::ast::{Expr, Raw};
 use uuid::Uuid;
 
@@ -460,9 +460,5 @@ impl ExprHumanizer for DummyCatalog {
 
     fn humanize_scalar_type(&self, ty: &ScalarType) -> String {
         DummyHumanizer.humanize_scalar_type(ty)
-    }
-
-    fn humanize_column_type(&self, ty: &ColumnType) -> String {
-        DummyHumanizer.humanize_column_type(ty)
     }
 }

--- a/src/transform/tests/testdata/keys
+++ b/src/transform/tests/testdata/keys
@@ -11,7 +11,7 @@
 # and report on key information in plans
 
 cat
-(defsource x [int32 int64 int32] [[0] [1]])
+(defsource x ([int32 int64 int32] [[0] [1]]))
 ----
 ok
 
@@ -20,10 +20,10 @@ build format=types
 ----
 %0 =
 | Get x (u0)
-| | types = (ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 })
+| | types = (Int32?, Int64?, Int32?)
 | | keys = ((#0), (#1))
 | Map 4145
-| | types = (ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: false, scalar_type: Int64 })
+| | types = (Int32?, Int64?, Int32?, Int64)
 | | keys = ((#0), (#1))
 
 # Run tests where a transform occuring depends on the input keys.
@@ -36,10 +36,10 @@ opt format=types
 ----
 %0 =
 | Get x (u0)
-| | types = (ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 })
+| | types = (Int32?, Int64?, Int32?)
 | | keys = ((#0), (#1))
 | Project (#0..#2, #0..#2)
-| | types = (ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 })
+| | types = (Int32?, Int64?, Int32?, Int32?, Int64?, Int32?)
 | | keys = ((#0), (#1))
 
 steps format=types
@@ -48,18 +48,18 @@ steps format=types
 ----
 %0 =
 | Get x (u0)
-| | types = (ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 })
+| | types = (Int32?, Int64?, Int32?)
 | | keys = ((#0), (#1))
 
 %1 =
 | Get x (u0)
-| | types = (ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 })
+| | types = (Int32?, Int64?, Int32?)
 | | keys = ((#0), (#1))
 
 %2 =
 | Join %0 %1 (= #0 #3) (= #2 #5)
 | | implementation = Unimplemented
-| | types = (ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 })
+| | types = (Int32?, Int64?, Int32?, Int32?, Int64?, Int32?)
 | | keys = ((#0), (#1))
 
 ====
@@ -68,10 +68,10 @@ No change: TopKElision, NonNullRequirements
 Applied Fixpoint { transforms: [FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting, Map, Filter, Project, Join, InlineLet, Union, UnionBranchCancellation, UpdateLet, RedundantJoin, FoldConstants] }], limit: 100 }:
 %0 =
 | Get x (u0)
-| | types = (ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 })
+| | types = (Int32?, Int64?, Int32?)
 | | keys = ((#0), (#1))
 | Project (#0..#2, #0..#2)
-| | types = (ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 })
+| | types = (Int32?, Int64?, Int32?, Int32?, Int64?, Int32?)
 | | keys = ((#0), (#1))
 
 ====
@@ -80,10 +80,10 @@ No change: Fixpoint { transforms: [PredicatePushdown, NonNullable, ColumnKnowled
 Final:
 %0 =
 | Get x (u0)
-| | types = (ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 })
+| | types = (Int32?, Int64?, Int32?)
 | | keys = ((#0), (#1))
 | Project (#0..#2, #0..#2)
-| | types = (ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 })
+| | types = (Int32?, Int64?, Int32?, Int32?, Int64?, Int32?)
 | | keys = ((#0), (#1))
 
 ====
@@ -96,25 +96,25 @@ opt format=types
 ----
 %0 =
 | Get x (u0)
-| | types = (ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 })
+| | types = (Int32?, Int64?, Int32?)
 | | keys = ((#0), (#1))
 | ArrangeBy (#2)
-| | types = (ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 })
+| | types = (Int32?, Int64?, Int32?)
 | | keys = ((#0), (#1))
 
 %1 =
 | Get x (u0)
-| | types = (ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 })
+| | types = (Int32?, Int64?, Int32?)
 | | keys = ((#0), (#1))
 
 %2 =
 | Join %0 %1 (= #2 #5)
 | | implementation = Differential %1 %0.(#2)
 | | demand = (#0..#4)
-| | types = (ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 })
+| | types = (Int32?, Int64?, Int32?, Int32?, Int64?, Int32?)
 | | keys = ()
 | Project (#0..#4, #2)
-| | types = (ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 })
+| | types = (Int32?, Int64?, Int32?, Int32?, Int64?, Int32?)
 | | keys = ()
 ----
 ----


### PR DESCRIPTION
Allow creating an arbitrary RelationType in unit tests, with columns defaulting to nullable.

Fix error in arbitrary struct creation where the first and only argument to a struct would not be passed in if it were a `Vec` (which is delimited by brackets). 

Have the default implementation of `ExprHumanizer::humanize_column_type` be the same as the implementation in the Catalog, which is appending a "?" to the result of `ExprHumanizer::humanize_scalar_type` if the column is nullable and doing nothing if the column is not nullable. This makes the printed version of the column type much more compact in unit testing. (and saves the few lines of effort required to implement `humanize_column_type` in various test implementations of the `ExprHumanizer` trait.