### PR TITLE
persist: name streams externally as a string, make u64 id internal

### DIFF
--- a/src/persist/src/indexed/handle.rs
+++ b/src/persist/src/indexed/handle.rs
@@ -14,10 +14,10 @@ use std::sync::Arc;
 use std::sync::Mutex;
 
 use crate::error::Error;
+use crate::indexed::encoding::Id;
 use crate::indexed::{Indexed, IndexedSnapshot};
 use crate::persister::{Meta, Write};
 use crate::storage::{Blob, Buffer};
-use crate::Id;
 
 /// An implementation of [Write] in terms of an [Indexed].
 pub struct StreamWriteHandle<U: Buffer, L: Blob> {

--- a/src/persist/src/operators/input.rs
+++ b/src/persist/src/operators/input.rs
@@ -114,7 +114,6 @@ mod tests {
 
     use crate::error::Error;
     use crate::mem::MemRegistry;
-    use crate::Id;
 
     use super::*;
 
@@ -125,7 +124,7 @@ mod tests {
 
         timely::execute_directly(move |worker| {
             let (mut handle, cap) = worker.dataflow(|scope| {
-                let persister = p.create_or_load(Id(1)).unwrap();
+                let persister = p.create_or_load("1").unwrap();
                 let (input, _stream) = scope.new_persistent_unordered_input(persister);
                 input
             });
@@ -141,7 +140,7 @@ mod tests {
         let mut p = registry.open(1, "new_persistent_unordered_input_2")?;
         let recv = timely::execute_directly(move |worker| {
             let ((mut handle, cap), recv) = worker.dataflow(|scope| {
-                let persister = p.create_or_load(Id(1)).unwrap();
+                let persister = p.create_or_load("1").unwrap();
                 let (input, stream) = scope.new_persistent_unordered_input(persister);
                 // Send the data to be captured by a channel so that we can replay
                 // its contents outside of the dataflow and verify they are correct


### PR DESCRIPTION
It was going to be (doable but) annoying to map GroupId, which is an
enum of 3 u64s into our single u64 stream id. Additionally, sources
might end up with more than one stream (e.g. one for the regular row
output, one for the raw bytes coming in if we want to be defensive
against bugs in decoding, and one for timestamp assignments),
complicating this further. Now we can simply use something like:

    user-table-[schema]-[database]-[table]
    sys-table-[schema]-[database]-[table]
    user-stream-[schema]-[database]-[source]-output
    user-stream-[schema]-[database]-[source]-input
    user-stream-[schema]-[database]-[source]-ts

There is a bonus benefit that (future) debugging tools will be able to
print the name instead of a u64, which will be much easier if someone
wants to inspect what's been stored.

This keeps the internal u64 id in the batches we store to keep them
lean. The mapping happens once at stream registration, so there isn't a
performance concern for the translation.

Also, now that Id is an internal implementation detail, allow it to
derive Abomonation and remove all the various casts.