### PR TITLE
*: bump to latest confluent platform and debezium in all demos and tests

### DIFF
--- a/ci/test/cargo-test/mzcompose.yml
+++ b/ci/test/cargo-test/mzcompose.yml
@@ -30,18 +30,18 @@ services:
     propagate-uid-gid: true
     depends_on: [kafka, zookeeper, schema-registry]
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.5.4
+    image: confluentinc/cp-zookeeper:6.2.0
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
   kafka:
-    image: confluentinc/cp-kafka:5.5.4
+    image: confluentinc/cp-kafka:6.2.0
     environment:
     - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
     - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092
     - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
     depends_on: [zookeeper]
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.5.4
+    image: confluentinc/cp-schema-registry:6.2.0
     environment:
     - SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=PLAINTEXT://kafka:9092
     - SCHEMA_REGISTRY_HOST_NAME=localhost

--- a/demo/billing/mzcompose.yml
+++ b/demo/billing/mzcompose.yml
@@ -26,11 +26,11 @@ services:
       - MZ_LOG=dataflow=error,info
       - MZ_DEV=1
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.5.4
+    image: confluentinc/cp-zookeeper:6.2.0
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
   kafka:
-    image: confluentinc/cp-enterprise-kafka:5.5.4
+    image: confluentinc/cp-enterprise-kafka:6.2.0
     ports:
       - *kafka
     depends_on: [zookeeper]
@@ -42,7 +42,7 @@ services:
       KAFKA_JMX_PORT: 9991
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.5.4
+    image: confluentinc/cp-schema-registry:6.2.0
     ports:
      - *schema-registry
     environment:

--- a/demo/chbench/connector-mysql/Dockerfile
+++ b/demo/chbench/connector-mysql/Dockerfile
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-FROM confluentinc/cp-enterprise-kafka:5.3.0
+FROM confluentinc/cp-enterprise-kafka:6.2.0
 
 # https://github.com/confluentinc/cp-docker-images/issues/764
 RUN sed -i s,https://s3-us-west-2.amazonaws.com/staging-confluent-packages-5.3.0/deb/5.3,https://packages.confluent.io/deb/5.3, /etc/apt/sources.list

--- a/demo/chbench/connector-postgres/Dockerfile
+++ b/demo/chbench/connector-postgres/Dockerfile
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-FROM confluentinc/cp-enterprise-kafka:5.3.0
+FROM confluentinc/cp-enterprise-kafka:6.2.0
 
 # https://github.com/confluentinc/cp-docker-images/issues/764
 RUN sed -i s,https://s3-us-west-2.amazonaws.com/staging-confluent-packages-5.3.0/deb/5.3,https://packages.confluent.io/deb/5.3, /etc/apt/sources.list

--- a/demo/chbench/mzcompose.yml
+++ b/demo/chbench/mzcompose.yml
@@ -92,13 +92,13 @@ services:
       - type: tmpfs
         target: /var/lib/mysql
   mysqlcli:
-    image: debezium/example-mysql:1.4
+    image: debezium/example-mysql:1.5
     command: ["mysql", "--host=mysql", "--port=3306", "--user=root", "--password=rootpw", "--database=tpcch"]
     init: true
     depends_on:
       - mysql
   postgres:
-    image: debezium/example-postgres:1.4
+    image: debezium/example-postgres:1.5
     ports:
      - *postgres
     environment:
@@ -110,19 +110,19 @@ services:
         target: /var/lib/postgres-files
         read_only: true
   postgrescli:
-    image: debezium/example-postgres:1.4
+    image: debezium/example-postgres:1.5
     command: ["psql", "--host=postgres",  "--user=postgres"]
     init: true
     depends_on:
       - postgres
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.5.4
+    image: confluentinc/cp-zookeeper:6.2.0
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
     volumes:
       - ${MZ_CHBENCH_SNAPSHOT_ZK_DATA:-zk-data}:/var/lib/zookeeper
   kafka:
-    image: confluentinc/cp-enterprise-kafka:5.5.4
+    image: confluentinc/cp-enterprise-kafka:6.2.0
     ports:
       - *kafka-internal
       - *kafka-external
@@ -145,7 +145,7 @@ services:
     volumes:
       - ${MZ_CHBENCH_SNAPSHOT_KAFKA_DATA:-kafka-data}:/var/lib/kafka/data
   connect:
-    image: debezium/connect:1.4
+    image: debezium/connect:1.5
     environment:
       BOOTSTRAP_SERVERS: kafka:9092
       GROUP_ID: 1
@@ -157,7 +157,7 @@ services:
       CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL: http://schema-registry:8081
     depends_on: [kafka, schema-registry]
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.5.4
+    image: confluentinc/cp-schema-registry:6.2.0
     ports:
       - *schema-registry
     environment:
@@ -173,7 +173,7 @@ services:
     build: connector-postgres
     depends_on: [schema-registry, control-center]
   control-center:
-    image: confluentinc/cp-enterprise-control-center:5.5.4
+    image: confluentinc/cp-enterprise-control-center:6.2.0
     depends_on: [zookeeper, kafka, connect]
     ports:
       - *control-center

--- a/demo/simple/connector/Dockerfile
+++ b/demo/simple/connector/Dockerfile
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-FROM confluentinc/cp-enterprise-kafka:5.3.0
+FROM confluentinc/cp-enterprise-kafka:6.2.0
 
 # https://github.com/confluentinc/cp-docker-images/issues/764
 RUN sed -i s,https://s3-us-west-2.amazonaws.com/staging-confluent-packages-5.3.0/deb/5.3,https://packages.confluent.io/deb/5.3, /etc/apt/sources.list

--- a/demo/simple/mzcompose.yml
+++ b/demo/simple/mzcompose.yml
@@ -20,7 +20,7 @@ services:
     ports:
       - *materialized
   mysql:
-    image: debezium/example-mysql:1.4
+    image: debezium/example-mysql:1.5
     ports:
      - 3306:3306
     environment:
@@ -28,17 +28,17 @@ services:
      - MYSQL_USER=mysqluser
      - MYSQL_PASSWORD=mysqlpw
   mysqlcli:
-    image: debezium/example-mysql:1.4
+    image: debezium/example-mysql:1.5
     command: ["mysql", "--host=mysql", "--port=3306", "--user=root", "--password=debezium"]
     init: true
     depends_on:
       - mysql
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.5.4
+    image: confluentinc/cp-zookeeper:6.2.0
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
   kafka:
-    image: confluentinc/cp-enterprise-kafka:5.5.4
+    image: confluentinc/cp-enterprise-kafka:6.2.0
     depends_on: [zookeeper]
     environment:
       KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
@@ -47,7 +47,7 @@ services:
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_JMX_PORT: 9991
   connect:
-    image: debezium/connect:1.4
+    image: debezium/connect:1.5
     environment:
       BOOTSTRAP_SERVERS: kafka:9092
       GROUP_ID: 1
@@ -59,7 +59,7 @@ services:
       CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL: http://schema-registry:8081
     depends_on: [kafka]
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.5.4
+    image: confluentinc/cp-schema-registry:6.2.0
     environment:
      - SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL=zookeeper:2181
      - SCHEMA_REGISTRY_HOST_NAME=schema-registry

--- a/misc/python/materialize/mzcompose.py
+++ b/misc/python/materialize/mzcompose.py
@@ -75,8 +75,8 @@ _BASHLIKE_ENV_VAR_PATTERN = re.compile(
 )
 
 
-LINT_CONFLUENT_PLATFORM_VERSION = "5.5.4"
-LINT_DEBEZIUM_VERSIONS = ["1.4", "1.5"]
+LINT_CONFLUENT_PLATFORM_VERSION = "6.2.0"
+LINT_DEBEZIUM_VERSION = "1.5"
 
 
 class LintError:
@@ -123,12 +123,12 @@ def lint_image_name(path: Path, spec: str, errors: List[LintError]) -> None:
             )
 
     if repo == "debezium":
-        if "$" not in tag and tag not in LINT_DEBEZIUM_VERSIONS:
+        if "$" not in tag and tag != LINT_DEBEZIUM_VERSION:
             errors.append(
                 LintError(
                     path,
                     f"image {spec} depends on wrong version of Debezium "
-                    f"(want {LINT_DEBEZIUM_VERSIONS})",
+                    f"(want {LINT_DEBEZIUM_VERSION})",
                 )
             )
 

--- a/play/mbta/mzcompose.yml
+++ b/play/mbta/mzcompose.yml
@@ -23,11 +23,11 @@ services:
     volumes:
       - .:/workdir
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.5.4
+    image: confluentinc/cp-zookeeper:6.2.0
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
   kafka:
-    image: confluentinc/cp-enterprise-kafka:5.5.4
+    image: confluentinc/cp-enterprise-kafka:6.2.0
     ports:
       - *kafka
     depends_on: [zookeeper]

--- a/test/antithesis/cp-combined/Dockerfile
+++ b/test/antithesis/cp-combined/Dockerfile
@@ -9,7 +9,7 @@
 
 FROM ubuntu:bionic-20200403
 
-ENV CONFLUENT_VERSION=5.5.4-1
+ENV CONFLUENT_VERSION=6.2.0-1
 
 RUN apt-get update \
     && apt-get install -y ca-certificates wait-for-it \

--- a/test/bench/aggregations/mzcompose.yml
+++ b/test/bench/aggregations/mzcompose.yml
@@ -66,11 +66,11 @@ services:
       - MZ_LOG=pgwire=debug,info
       - MZ_DEV=1
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.5.4
+    image: confluentinc/cp-zookeeper:6.2.0
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
   kafka:
-    image: confluentinc/cp-enterprise-kafka:5.5.4
+    image: confluentinc/cp-enterprise-kafka:6.2.0
     ports:
       - *kafka-internal
       - *kafka-external
@@ -92,7 +92,7 @@ services:
       CONFLUENT_METRICS_REPORTER_TOPIC_CREATE: "false"
       KAFKA_JMX_PORT: 9991
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.5.4
+    image: confluentinc/cp-schema-registry:6.2.0
     ports:
       - *schema-registry
     environment:

--- a/test/bench/avro-insert/mzcompose.yml
+++ b/test/bench/avro-insert/mzcompose.yml
@@ -66,11 +66,11 @@ services:
       - MZ_LOG=pgwire=debug,info
       - MZ_DEV=1
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.5.4
+    image: confluentinc/cp-zookeeper:6.2.0
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
   kafka:
-    image: confluentinc/cp-enterprise-kafka:5.5.4
+    image: confluentinc/cp-enterprise-kafka:6.2.0
     ports:
       - *kafka-internal
       - *kafka-external
@@ -92,7 +92,7 @@ services:
       CONFLUENT_METRICS_REPORTER_TOPIC_CREATE: "false"
       KAFKA_JMX_PORT: 9991
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.5.4
+    image: confluentinc/cp-schema-registry:6.2.0
     ports:
       - *schema-registry
     environment:

--- a/test/bench/avro-upsert/mzcompose.yml
+++ b/test/bench/avro-upsert/mzcompose.yml
@@ -66,11 +66,11 @@ services:
       - MZ_LOG=pgwire=debug,info
       - MZ_DEV=1
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.5.4
+    image: confluentinc/cp-zookeeper:6.2.0
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
   kafka:
-    image: confluentinc/cp-enterprise-kafka:5.5.4
+    image: confluentinc/cp-enterprise-kafka:6.2.0
     ports:
       - *kafka-internal
       - *kafka-external
@@ -92,7 +92,7 @@ services:
       CONFLUENT_METRICS_REPORTER_TOPIC_CREATE: "false"
       KAFKA_JMX_PORT: 9991
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.5.4
+    image: confluentinc/cp-schema-registry:6.2.0
     ports:
       - *schema-registry
     environment:

--- a/test/bench/kafka-sink-avro-debezium/mzcompose.yml
+++ b/test/bench/kafka-sink-avro-debezium/mzcompose.yml
@@ -60,11 +60,11 @@ services:
       - MZ_LOG=dataflow::sink::kafka=debug,librdkafka=warn,rdkafka=warn,sql_parser=warn,hyper=warn,info
       - MZ_DEV=1
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.5.4
+    image: confluentinc/cp-zookeeper:6.2.0
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
   kafka:
-    image: confluentinc/cp-enterprise-kafka:5.5.4
+    image: confluentinc/cp-enterprise-kafka:6.2.0
     ports:
       - *kafka-internal
       - *kafka-external
@@ -86,7 +86,7 @@ services:
       CONFLUENT_METRICS_REPORTER_TOPIC_CREATE: "false"
       KAFKA_JMX_PORT: 9991
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.5.4
+    image: confluentinc/cp-schema-registry:6.2.0
     ports:
       - *schema-registry
     environment:

--- a/test/catalog-compat/mzcompose.yml
+++ b/test/catalog-compat/mzcompose.yml
@@ -13,11 +13,11 @@ services:
     mzbuild: catcompatck
     depends_on: [zookeeper, kafka]
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.5.4
+    image: confluentinc/cp-zookeeper:6.2.0
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
   kafka:
-    image: confluentinc/cp-kafka:5.5.4
+    image: confluentinc/cp-kafka:6.2.0
     environment:
     - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
     - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092

--- a/test/chaos/connector-mysql/Dockerfile
+++ b/test/chaos/connector-mysql/Dockerfile
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-FROM confluentinc/cp-enterprise-kafka:5.3.0
+FROM confluentinc/cp-enterprise-kafka:6.2.0
 
 # https://github.com/confluentinc/cp-docker-images/issues/764
 RUN sed -i s,https://s3-us-west-2.amazonaws.com/staging-confluent-packages-5.3.0/deb/5.3,https://packages.confluent.io/deb/5.3, /etc/apt/sources.list

--- a/test/chaos/mzcompose.yml
+++ b/test/chaos/mzcompose.yml
@@ -38,14 +38,14 @@ services:
       - MZ_DEV=1
 
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.5.4
+    image: confluentinc/cp-zookeeper:6.2.0
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
     cap_add:
       - NET_ADMIN
 
   kafka:
-    image: confluentinc/cp-enterprise-kafka:5.5.4
+    image: confluentinc/cp-enterprise-kafka:6.2.0
     ports:
       - *kafka
     depends_on: [zookeeper]
@@ -59,7 +59,7 @@ services:
       - NET_ADMIN
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.5.4
+    image: confluentinc/cp-schema-registry:6.2.0
     ports:
       - *schema-registry
     environment:
@@ -88,7 +88,7 @@ services:
       - NET_ADMIN
 
   connector:
-    image: confluentinc/cp-enterprise-kafka:5.5.4
+    image: confluentinc/cp-enterprise-kafka:6.2.0
     volumes:
       - ./connector/docker-entrypoint.sh:/usr/local/bin/docker-entrypoint.sh
     entrypoint:
@@ -97,7 +97,7 @@ services:
       - NET_ADMIN
 
   mysql:
-    image: debezium/example-mysql:1.4
+    image: debezium/example-mysql:1.5
     ports:
       - *mysql
     environment:
@@ -116,7 +116,7 @@ services:
     build: connector-mysql
     depends_on: [schema-registry, control-center]
   control-center:
-    image: confluentinc/cp-enterprise-control-center:5.5.4
+    image: confluentinc/cp-enterprise-control-center:6.2.0
     depends_on: [zookeeper, kafka, connect]
     ports:
       - *control-center

--- a/test/debezium-avro/mzcompose.yml
+++ b/test/debezium-avro/mzcompose.yml
@@ -95,18 +95,18 @@ services:
     - mzdata:/share/mzdata
     - tmp:/share/tmp
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.5.4
+    image: confluentinc/cp-zookeeper:6.2.0
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
   kafka:
-    image: confluentinc/cp-kafka:5.5.4
+    image: confluentinc/cp-kafka:6.2.0
     environment:
     - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
     - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092
     - KAFKA_AUTO_CREATE_TOPICS_ENABLE=true
     - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.5.4
+    image: confluentinc/cp-schema-registry:6.2.0
     environment:
     - SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=PLAINTEXT://kafka:9092
     - SCHEMA_REGISTRY_HOST_NAME=localhost

--- a/test/kafka-krb5/mzcompose.yml
+++ b/test/kafka-krb5/mzcompose.yml
@@ -19,7 +19,7 @@ services:
       - ./kdc/krb5.conf:/etc/krb5.conf
 
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.5.4
+    image: confluentinc/cp-zookeeper:6.2.0
     depends_on:
       - kdc
     volumes:
@@ -38,7 +38,7 @@ services:
         -Dsun.security.krb5.debug=true
 
   kafka:
-    image: confluentinc/cp-kafka:5.5.4
+    image: confluentinc/cp-kafka:6.2.0
     depends_on:
       - kdc
       - zookeeper
@@ -59,7 +59,7 @@ services:
         -Djava.security.krb5.conf=/etc/krb5.conf
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.5.4
+    image: confluentinc/cp-schema-registry:6.2.0
     environment:
       SCHEMA_REGISTRY_HOST_NAME: schema-registry
       SCHEMA_REGISTRY_LISTENERS: "http://0.0.0.0:8081"

--- a/test/kafka-multi-broker/mzcompose.yml
+++ b/test/kafka-multi-broker/mzcompose.yml
@@ -77,20 +77,20 @@ services:
       - MZ_DEV=1
 
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.5.4
+    image: confluentinc/cp-zookeeper:6.2.0
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOO_TICK_TIME: 500
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.5.4
+    image: confluentinc/cp-schema-registry:6.2.0
     environment:
     - SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=PLAINTEXT://kafka2:9092
     - SCHEMA_REGISTRY_HOST_NAME=localhost
     depends_on: [kafka2, zookeeper]
 
   kafka1:
-    image: confluentinc/cp-kafka:5.5.4
+    image: confluentinc/cp-kafka:6.2.0
     hostname: kafka1
     environment:
       KAFKA_BROKER_ID: 1
@@ -102,7 +102,7 @@ services:
     ports: [9092]
 
   kafka2:
-    image: confluentinc/cp-kafka:5.5.4
+    image: confluentinc/cp-kafka:6.2.0
     hostname: kafka2
     environment:
       KAFKA_BROKER_ID: 2
@@ -114,7 +114,7 @@ services:
     ports: [9092]
 
   kafka3:
-    image: confluentinc/cp-kafka:5.5.4
+    image: confluentinc/cp-kafka:6.2.0
     hostname: kafka3
     environment:
       KAFKA_BROKER_ID: 3

--- a/test/kafka-sasl-plain/mzcompose.yml
+++ b/test/kafka-sasl-plain/mzcompose.yml
@@ -54,7 +54,7 @@ services:
       - secrets:/share/secrets
     depends_on: [test-certs]
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.5.4
+    image: confluentinc/cp-zookeeper:6.2.0
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       # Despite the environment variable name, these are JVM options that are
@@ -66,7 +66,7 @@ services:
     volumes:
       - ./sasl.jaas.config:/etc/zookeeper/sasl.jaas.config
   kafka:
-    image: confluentinc/cp-kafka:5.5.4
+    image: confluentinc/cp-kafka:6.2.0
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
@@ -88,7 +88,7 @@ services:
       - ./sasl.jaas.config:/etc/kafka/sasl.jaas.config
     depends_on: [zookeeper, test-certs]
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.5.4
+    image: confluentinc/cp-schema-registry:6.2.0
     environment:
       SCHEMA_REGISTRY_HOST_NAME: schema-registry
       SCHEMA_REGISTRY_LISTENERS: "https://0.0.0.0:8081"

--- a/test/kafka-ssl/mzcompose.yml
+++ b/test/kafka-ssl/mzcompose.yml
@@ -50,11 +50,11 @@ services:
     environment:
       - MZ_DEV=1
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.5.4
+    image: confluentinc/cp-zookeeper:6.2.0
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
   kafka:
-    image: confluentinc/cp-kafka:5.5.4
+    image: confluentinc/cp-kafka:6.2.0
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
@@ -71,7 +71,7 @@ services:
       - secrets:/etc/kafka/secrets
     depends_on: [zookeeper, test-certs]
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.5.4
+    image: confluentinc/cp-schema-registry:6.2.0
     environment:
       SCHEMA_REGISTRY_HOST_NAME: schema-registry
       SCHEMA_REGISTRY_LISTENERS: "https://0.0.0.0:8081"

--- a/test/performance/perf-upsert/mzcompose.yml
+++ b/test/performance/perf-upsert/mzcompose.yml
@@ -23,11 +23,11 @@ services:
       - MZ_LOG=dataflow=error,info
       - MZ_DEV=1
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.5.4
+    image: confluentinc/cp-zookeeper:6.2.0
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
   kafka:
-    image: confluentinc/cp-enterprise-kafka:5.5.4
+    image: confluentinc/cp-enterprise-kafka:6.2.0
     ports:
       - *kafka
     depends_on: [zookeeper]

--- a/test/tb/mzcompose.yml
+++ b/test/tb/mzcompose.yml
@@ -18,7 +18,7 @@ services:
     environment:
       - MZ_DEV=1
   mysql:
-    image: debezium/example-mysql:1.4
+    image: debezium/example-mysql:1.5
     ports: [3306]
     environment:
       - MYSQL_ROOT_PASSWORD=rootpw

--- a/test/testdrive/mzcompose.yml
+++ b/test/testdrive/mzcompose.yml
@@ -147,11 +147,11 @@ services:
     - mzdata:/share/mzdata
     - tmp:/share/tmp
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.5.4
+    image: confluentinc/cp-zookeeper:6.2.0
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
   kafka:
-    image: confluentinc/cp-kafka:5.5.4
+    image: confluentinc/cp-kafka:6.2.0
     environment:
     - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
     - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092
@@ -159,7 +159,7 @@ services:
     - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
     - KAFKA_CONFLUENT_SUPPORT_METRICS_ENABLE=false
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.5.4
+    image: confluentinc/cp-schema-registry:6.2.0
     environment:
     - SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=PLAINTEXT://kafka:9092
     - SCHEMA_REGISTRY_HOST_NAME=localhost


### PR DESCRIPTION
The latest Confluent Platform images avoid a segfault when run via
Docker on M1 macs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/7253)
<!-- Reviewable:end -->
