### PR TITLE
expr: Fix nullability of UnaryFunc::output_type

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -3963,21 +3963,27 @@ impl UnaryFunc {
 
     pub fn output_type(&self, input_type: ColumnType) -> ColumnType {
         use UnaryFunc::*;
-        let in_nullable = input_type.nullable;
+        let nullable = if self.introduces_nulls() {
+            true
+        } else if self.propagates_nulls() {
+            input_type.nullable
+        } else {
+            false
+        };
         match self {
-            IsNull => ScalarType::Bool.nullable(false),
+            IsNull => ScalarType::Bool.nullable(nullable),
 
             Ascii | CharLength | BitLengthBytes | BitLengthString | ByteLengthBytes
-            | ByteLengthString => ScalarType::Int32.nullable(in_nullable),
+            | ByteLengthString => ScalarType::Int32.nullable(nullable),
 
             IsRegexpMatch(_) | CastInt32ToBool | CastInt64ToBool | CastStringToBool => {
-                ScalarType::Bool.nullable(in_nullable)
+                ScalarType::Bool.nullable(nullable)
             }
 
-            CastStringToBytes => ScalarType::Bytes.nullable(in_nullable),
-            CastStringToInterval | CastTimeToInterval => ScalarType::Interval.nullable(in_nullable),
-            CastStringToUuid => ScalarType::Uuid.nullable(in_nullable),
-            CastStringToJsonb => ScalarType::Jsonb.nullable(in_nullable),
+            CastStringToBytes => ScalarType::Bytes.nullable(nullable),
+            CastStringToInterval | CastTimeToInterval => ScalarType::Interval.nullable(nullable),
+            CastStringToUuid => ScalarType::Uuid.nullable(nullable),
+            CastStringToJsonb => ScalarType::Jsonb.nullable(nullable),
 
             CastBoolToString
             | CastBoolToStringNonstandard
@@ -4002,24 +4008,24 @@ impl UnaryFunc {
             | TrimLeadingWhitespace
             | TrimTrailingWhitespace
             | Upper
-            | Lower => ScalarType::String.nullable(in_nullable),
+            | Lower => ScalarType::String.nullable(nullable),
 
             CastStringToFloat32
             | CastFloat64ToFloat32
             | CastInt32ToFloat32
             | CastInt64ToFloat32
             | CastSignificandToFloat32
-            | CastAPDToFloat32 => ScalarType::Float32.nullable(in_nullable),
+            | CastAPDToFloat32 => ScalarType::Float32.nullable(nullable),
 
             CastStringToFloat64
             | CastInt32ToFloat64
             | CastInt64ToFloat64
             | CastFloat32ToFloat64
             | CastSignificandToFloat64
-            | CastAPDToFloat64 => ScalarType::Float64.nullable(in_nullable),
+            | CastAPDToFloat64 => ScalarType::Float64.nullable(nullable),
 
             CastStringToDecimal(s) | CastFloat32ToDecimal(s) | CastFloat64ToDecimal(s) => {
-                ScalarType::Decimal(MAX_DECIMAL_PRECISION, *s).nullable(in_nullable)
+                ScalarType::Decimal(MAX_DECIMAL_PRECISION, *s).nullable(nullable)
             }
 
             CastBoolToInt32
@@ -4028,91 +4034,90 @@ impl UnaryFunc {
             | CastDecimalToInt32(_)
             | CastFloat32ToInt32
             | CastFloat64ToInt32
-            | CastAPDToInt32 => ScalarType::Int32.nullable(in_nullable),
+            | CastAPDToInt32 => ScalarType::Int32.nullable(nullable),
 
             CastStringToInt64
             | CastInt32ToInt64
             | CastDecimalToInt64(_)
             | CastFloat32ToInt64
             | CastFloat64ToInt64
-            | CastAPDToInt64 => ScalarType::Int64.nullable(in_nullable),
+            | CastAPDToInt64 => ScalarType::Int64.nullable(nullable),
 
-            CastInt32ToDecimal => ScalarType::Decimal(0, 0).nullable(in_nullable),
-            CastInt64ToDecimal => ScalarType::Decimal(0, 0).nullable(in_nullable),
+            CastInt32ToDecimal => ScalarType::Decimal(0, 0).nullable(nullable),
+            CastInt64ToDecimal => ScalarType::Decimal(0, 0).nullable(nullable),
             CastStringToAPD(scale)
             | CastInt32ToAPD(scale)
             | CastInt64ToAPD(scale)
             | CastFloat32ToAPD(scale)
             | CastFloat64ToAPD(scale)
-            | CastJsonbToAPD(scale) => ScalarType::APD { scale: *scale }.nullable(in_nullable),
+            | CastJsonbToAPD(scale) => ScalarType::APD { scale: *scale }.nullable(nullable),
 
-            CastInt32ToOid => ScalarType::Oid.nullable(in_nullable),
-            CastOidToInt32 => ScalarType::Oid.nullable(in_nullable),
+            CastInt32ToOid => ScalarType::Oid.nullable(nullable),
+            CastOidToInt32 => ScalarType::Oid.nullable(nullable),
 
             CastStringToDate | CastTimestampToDate | CastTimestampTzToDate => {
-                ScalarType::Date.nullable(in_nullable)
+                ScalarType::Date.nullable(nullable)
             }
 
             CastStringToTime | CastIntervalToTime | TimezoneTime { .. } => {
-                ScalarType::Time.nullable(in_nullable)
+                ScalarType::Time.nullable(nullable)
             }
 
             CastStringToTimestamp
             | CastDateToTimestamp
             | CastTimestampTzToTimestamp
-            | TimezoneTimestampTz(_) => ScalarType::Timestamp.nullable(in_nullable),
+            | TimezoneTimestampTz(_) => ScalarType::Timestamp.nullable(nullable),
 
             CastStringToTimestampTz
             | CastDateToTimestampTz
             | CastTimestampToTimestampTz
-            | TimezoneTimestamp(_) => ScalarType::TimestampTz.nullable(in_nullable),
+            | TimezoneTimestamp(_) => ScalarType::TimestampTz.nullable(nullable),
 
             // converts null to jsonnull
-            CastJsonbOrNullToJsonb => ScalarType::Jsonb.nullable(false),
+            CastJsonbOrNullToJsonb => ScalarType::Jsonb.nullable(nullable),
 
-            // These return null when their input is SQL null.
-            CastJsonbToString => ScalarType::String.nullable(true),
-            CastJsonbToInt32 => ScalarType::Int32.nullable(true),
-            CastJsonbToInt64 => ScalarType::Int64.nullable(true),
-            CastJsonbToFloat32 => ScalarType::Float32.nullable(true),
-            CastJsonbToFloat64 => ScalarType::Float64.nullable(true),
+            CastJsonbToString => ScalarType::String.nullable(nullable),
+            CastJsonbToInt32 => ScalarType::Int32.nullable(nullable),
+            CastJsonbToInt64 => ScalarType::Int64.nullable(nullable),
+            CastJsonbToFloat32 => ScalarType::Float32.nullable(nullable),
+            CastJsonbToFloat64 => ScalarType::Float64.nullable(nullable),
             CastJsonbToDecimal(scale) => {
-                ScalarType::Decimal(MAX_DECIMAL_PRECISION, *scale).nullable(true)
+                ScalarType::Decimal(MAX_DECIMAL_PRECISION, *scale).nullable(nullable)
             }
-            CastJsonbToBool => ScalarType::Bool.nullable(true),
+            CastJsonbToBool => ScalarType::Bool.nullable(nullable),
 
             CastList1ToList2 { return_ty, .. }
             | CastStringToArray { return_ty, .. }
             | CastStringToList { return_ty, .. }
             | CastStringToMap { return_ty, .. }
-            | CastInPlace { return_ty } => (return_ty.clone()).nullable(in_nullable),
+            | CastInPlace { return_ty } => (return_ty.clone()).nullable(nullable),
 
-            CeilFloat32 | FloorFloat32 | RoundFloat32 => ScalarType::Float32.nullable(in_nullable),
-            CeilFloat64 | FloorFloat64 | RoundFloat64 => ScalarType::Float64.nullable(in_nullable),
+            CeilFloat32 | FloorFloat32 | RoundFloat32 => ScalarType::Float32.nullable(nullable),
+            CeilFloat64 | FloorFloat64 | RoundFloat64 => ScalarType::Float64.nullable(nullable),
             CeilDecimal(scale) | FloorDecimal(scale) | RoundDecimal(scale) | SqrtDec(scale) => {
                 match input_type.scalar_type {
                     ScalarType::Decimal(_, s) => assert_eq!(*scale, s),
                     _ => unreachable!(),
                 }
-                input_type.scalar_type.nullable(in_nullable)
+                input_type
             }
 
             Not | NegInt32 | NegInt64 | NegFloat32 | NegFloat64 | NegDecimal | NegInterval
             | AbsInt32 | AbsInt64 | AbsFloat32 | AbsFloat64 | AbsDecimal => input_type,
 
             DatePartInterval(_) | DatePartTimestamp(_) | DatePartTimestampTz(_) => {
-                ScalarType::Float64.nullable(in_nullable)
+                ScalarType::Float64.nullable(nullable)
             }
 
-            DateTruncTimestamp(_) => ScalarType::Timestamp.nullable(in_nullable),
-            DateTruncTimestampTz(_) => ScalarType::TimestampTz.nullable(in_nullable),
+            DateTruncTimestamp(_) => ScalarType::Timestamp.nullable(nullable),
+            DateTruncTimestampTz(_) => ScalarType::TimestampTz.nullable(nullable),
 
-            ToTimestamp => ScalarType::TimestampTz.nullable(true),
+            ToTimestamp => ScalarType::TimestampTz.nullable(nullable),
 
-            JsonbArrayLength => ScalarType::Int64.nullable(true),
-            JsonbTypeof => ScalarType::String.nullable(in_nullable),
-            JsonbStripNulls => ScalarType::Jsonb.nullable(in_nullable),
-            JsonbPretty => ScalarType::String.nullable(in_nullable),
+            JsonbArrayLength => ScalarType::Int64.nullable(nullable),
+            JsonbTypeof => ScalarType::String.nullable(nullable),
+            JsonbStripNulls => ScalarType::Jsonb.nullable(nullable),
+            JsonbPretty => ScalarType::String.nullable(nullable),
 
             RecordGet(i) => match input_type.scalar_type {
                 ScalarType::Record { mut fields, .. } => {
@@ -4123,50 +4128,156 @@ impl UnaryFunc {
                 _ => unreachable!("RecordGet specified nonexistent field"),
             },
 
-            ListLength => ScalarType::Int64.nullable(in_nullable),
+            ListLength => ScalarType::Int64.nullable(nullable),
 
-            RegexpMatch(_) => ScalarType::Array(Box::new(ScalarType::String)).nullable(true),
+            RegexpMatch(_) => ScalarType::Array(Box::new(ScalarType::String)).nullable(nullable),
 
-            SqrtFloat64 | CbrtFloat64 => ScalarType::Float64.nullable(in_nullable),
-            Cos | Cosh | Sin | Sinh | Tan | Tanh | Cot => ScalarType::Float64.nullable(in_nullable),
-            Log10 | Ln | Exp => ScalarType::Float64.nullable(in_nullable),
+            SqrtFloat64 | CbrtFloat64 => ScalarType::Float64.nullable(nullable),
+            Cos | Cosh | Sin | Sinh | Tan | Tanh | Cot => ScalarType::Float64.nullable(nullable),
+            Log10 | Ln | Exp => ScalarType::Float64.nullable(nullable),
             Log10Decimal(_) | LnDecimal(_) | ExpDecimal(_) => input_type,
-            Sleep => ScalarType::TimestampTz.nullable(true),
-            RescaleAPD(scale) => ScalarType::APD {
+            Sleep => ScalarType::TimestampTz.nullable(nullable),
+            RescaleAPD(scale) => (ScalarType::APD {
                 scale: Some(*scale),
-            }
-            .nullable(in_nullable),
-            PgColumnSize => ScalarType::Int32.nullable(in_nullable),
-            MzRowSize => ScalarType::Int32.nullable(in_nullable),
+            })
+            .nullable(nullable),
+            PgColumnSize => ScalarType::Int32.nullable(nullable),
+            MzRowSize => ScalarType::Int32.nullable(nullable),
 
             AbsAPD | CeilAPD | ExpAPD | FloorAPD | LnAPD | Log10APD | NegAPD | RoundAPD
-            | SqrtAPD => ScalarType::APD { scale: None }.nullable(in_nullable),
+            | SqrtAPD => ScalarType::APD { scale: None }.nullable(nullable),
         }
     }
 
     /// Whether the function output is NULL if any of its inputs are NULL.
     pub fn propagates_nulls(&self) -> bool {
-        !matches!(self, UnaryFunc::IsNull | UnaryFunc::CastJsonbOrNullToJsonb)
+        !matches!(
+            self,
+            UnaryFunc::IsNull
+            // converts null to jsonnull
+            | UnaryFunc::CastJsonbOrNullToJsonb
+        )
     }
 
     /// Whether the function might return NULL even if none of its inputs are
     /// NULL.
     pub fn introduces_nulls(&self) -> bool {
-        matches!(
-            self,
-            UnaryFunc::CastJsonbToString
-                | UnaryFunc::CastJsonbToInt32
-                | UnaryFunc::CastJsonbToInt64
-                | UnaryFunc::CastJsonbToFloat32
-                | UnaryFunc::CastJsonbToFloat64
-                | UnaryFunc::CastJsonbToDecimal(_)
-                | UnaryFunc::CastJsonbToBool
-                | UnaryFunc::JsonbArrayLength
-                | UnaryFunc::RegexpMatch(_)
-                | UnaryFunc::RecordGet(_)
-                | UnaryFunc::Sleep
-                | UnaryFunc::ToTimestamp
-        )
+        use UnaryFunc::*;
+        match self {
+            // These return null when their input is SQL null.
+            CastJsonbToString
+            | CastJsonbToInt32
+            | CastJsonbToInt64
+            | CastJsonbToFloat32
+            | CastJsonbToFloat64
+            | CastJsonbToDecimal(_)
+            | CastJsonbToBool => true,
+            // Return null if the inner field is null
+            RecordGet(_) => true,
+            // Always returns null
+            Sleep => true,
+            // Returns null if the regex did not match
+            RegexpMatch(_) => true,
+            // Returns null on non-array input
+            JsonbArrayLength => true,
+            // Returns null on infinite input
+            ToTimestamp => true,
+            IsNull => false,
+            Ascii | CharLength | BitLengthBytes | BitLengthString | ByteLengthBytes
+            | ByteLengthString => false,
+            IsRegexpMatch(_)
+            | CastInt32ToBool
+            | CastInt64ToBool
+            | CastStringToBool
+            | CastJsonbOrNullToJsonb => false,
+            CastStringToBytes | CastStringToInterval | CastTimeToInterval | CastStringToJsonb => {
+                false
+            }
+            CastBoolToString
+            | CastBoolToStringNonstandard
+            | CastInt32ToString
+            | CastInt64ToString
+            | CastFloat32ToString
+            | CastFloat64ToString
+            | CastDecimalToString(_)
+            | CastAPDToString
+            | CastDateToString
+            | CastTimeToString
+            | CastTimestampToString
+            | CastTimestampTzToString
+            | CastIntervalToString
+            | CastBytesToString
+            | CastUuidToString
+            | CastRecordToString { .. }
+            | CastArrayToString { .. }
+            | CastListToString { .. }
+            | CastMapToString { .. }
+            | TrimWhitespace
+            | TrimLeadingWhitespace
+            | TrimTrailingWhitespace
+            | Upper
+            | Lower => false,
+            CastStringToFloat32
+            | CastFloat64ToFloat32
+            | CastInt32ToFloat32
+            | CastInt64ToFloat32
+            | CastSignificandToFloat32
+            | CastAPDToFloat32 => false,
+            CastStringToFloat64
+            | CastInt32ToFloat64
+            | CastInt64ToFloat64
+            | CastFloat32ToFloat64
+            | CastSignificandToFloat64
+            | CastAPDToFloat64 => false,
+            CastStringToDecimal(_) | CastFloat32ToDecimal(_) | CastFloat64ToDecimal(_) => false,
+            CastBoolToInt32
+            | CastStringToInt32
+            | CastInt64ToInt32
+            | CastDecimalToInt32(_)
+            | CastFloat32ToInt32
+            | CastFloat64ToInt32
+            | CastAPDToInt32 => false,
+            CastStringToInt64
+            | CastInt32ToInt64
+            | CastDecimalToInt64(_)
+            | CastFloat32ToInt64
+            | CastFloat64ToInt64
+            | CastAPDToInt64 => false,
+            CastInt32ToDecimal | CastInt64ToDecimal => false,
+            CastStringToAPD(_) | CastInt32ToAPD(_) | CastInt64ToAPD(_) | CastFloat32ToAPD(_)
+            | CastFloat64ToAPD(_) | CastJsonbToAPD(_) => false,
+            CastInt32ToOid | CastOidToInt32 => false,
+            CastStringToDate | CastTimestampToDate | CastTimestampTzToDate => false,
+            CastStringToTime | CastIntervalToTime | TimezoneTime { .. } => false,
+            CastStringToTimestamp
+            | CastDateToTimestamp
+            | CastTimestampTzToTimestamp
+            | TimezoneTimestampTz(_) => false,
+            CastStringToTimestampTz
+            | CastDateToTimestampTz
+            | CastTimestampToTimestampTz
+            | TimezoneTimestamp(_) => false,
+            CastStringToUuid => false,
+            CastList1ToList2 { .. }
+            | CastStringToArray { .. }
+            | CastStringToList { .. }
+            | CastStringToMap { .. }
+            | CastInPlace { .. } => false,
+            JsonbTypeof | JsonbStripNulls | JsonbPretty | ListLength => false,
+            DatePartInterval(_) | DatePartTimestamp(_) | DatePartTimestampTz(_) => false,
+            DateTruncTimestamp(_) | DateTruncTimestampTz(_) => false,
+            Not | NegInt32 | NegInt64 | NegFloat32 | NegFloat64 | NegDecimal | NegInterval
+            | AbsInt32 | AbsInt64 | AbsFloat32 | AbsFloat64 | AbsDecimal => false,
+            CeilFloat32 | FloorFloat32 | RoundFloat32 => false,
+            CeilFloat64 | FloorFloat64 | RoundFloat64 => false,
+            CeilDecimal(_) | FloorDecimal(_) | RoundDecimal(_) | SqrtDec(_) => false,
+            Log10 | Ln | Exp | Cos | Cosh | Sin | Sinh | Tan | Tanh | Cot | SqrtFloat64
+            | CbrtFloat64 => false,
+            Log10Decimal(_) | LnDecimal(_) | ExpDecimal(_) => false,
+            PgColumnSize | MzRowSize => false,
+            AbsAPD | CeilAPD | ExpAPD | FloorAPD | LnAPD | Log10APD | NegAPD | RoundAPD
+            | SqrtAPD | RescaleAPD(_) => false,
+        }
     }
 
     /// True iff for x != y, we are assured f(x) != f(y).
@@ -5533,8 +5644,8 @@ mod test {
         NaiveDate::from_ymd(year, month, 1).and_hms(9, 9, 9)
     }
 
-    // Tests that `UnaryFunc::introduces_nulls` answers consistent with
-    // `UnaryFunc::output_type` and `UnaryFunc::propagates_nulls`.
+    // Tests that `UnaryFunc::output_type` are consistent with
+    // `UnaryFunc::introduces_nulls` and `UnaryFunc::propagates_nulls`.
     // Currently, only unit variants of UnaryFunc are tested because those are
     // the easiest to construct in bulk.
     #[test]


### PR DESCRIPTION
Fixing #7221 requires having a sense of whether a unary func propagates or introduces nulls.

`UnaryFunc` already has a `propagates_nulls` method, and as I was adding an `introduces_nulls` method, I realized that the result of `output_types` is wrong for a bunch of `UnaryFunc`s:
1) A bunch of casts return `ScalarType::something.nullable(false)`, which is wrong and results in an internal error if you try to cast a column containing null.
```
materialize=> create table t1(str_col string);
materialize=> insert into t1 values (null);
materialize=> select str_col::map[text=>double] from t1;
ERROR:  internal error: column 0 is not of expected type ColumnType { scalar_type: Map { value_type: Float64, custom_oid: None }, nullable: false }: Null
```
2) A bunch of casts/functions return `ScalarType::something.nullable(true)` unnecessarily when nullability should be `in_nullable`. I think this because we used to return nulls in the event of a parse failure or invalid input, but we now return EvalError instead, and the nullability of the output type has not been updated. I determined whether the nullability of an output_type should be changed from `true` to `in_nullable` by just checking the func's implementation in `func.rs`, so this class of casts/functions could especially use a look-see.

I've added a test that checks all UnaryFunc variants with no arguments for whether the nullability of `output_types` and `propagates_nulls` line up.