### PR TITLE
sql/apd: munge values after every rescale

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -1798,7 +1798,6 @@ fn rescale_apd<'a>(a: Datum<'a>, scale: u8) -> Result<Datum<'a>, EvalError> {
     if apd::rescale(&mut d.0, scale).is_err() {
         return Err(EvalError::NumericFieldOverflow);
     };
-    apd::munge_apd(&mut d.0).unwrap();
     Ok(Datum::APD(d))
 }
 

--- a/src/repr/src/adt/apd.rs
+++ b/src/repr/src/adt/apd.rs
@@ -166,6 +166,7 @@ pub fn rescale(n: &mut Apd, scale: u8) -> Result<(), anyhow::Error> {
             APD_DATUM_MAX_PRECISION
         )
     }
+    munge_apd(n)?;
 
     Ok(())
 }


### PR DESCRIPTION
#7239 prevented many calls to the rescale function, which #7231 was unknowingly dependent upon. This change simply moves the call to `munge_apd` to affect _all_ rescaled values, which was the change intended with #7231.