### PR TITLE
Dataflow desc cleanup

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -2361,7 +2361,6 @@ impl Coordinator {
                 dataflow.set_as_of(Antichain::from_elem(timestamp));
                 self.dataflow_builder()
                     .import_view_into_dataflow(&view_id, &source, &mut dataflow);
-                dataflow.add_index_to_build(index_id, view_id, typ.clone(), key.clone());
                 dataflow.export_index(index_id, view_id, typ, key);
                 self.ship_dataflow(dataflow).await;
             }

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -2362,7 +2362,7 @@ impl Coordinator {
                 self.dataflow_builder()
                     .import_view_into_dataflow(&view_id, &source, &mut dataflow);
                 dataflow.add_index_to_build(index_id, view_id, typ.clone(), key.clone());
-                dataflow.add_index_export(index_id, view_id, typ, key);
+                dataflow.export_index(index_id, view_id, typ, key);
                 self.ship_dataflow(dataflow).await;
             }
 

--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -186,7 +186,7 @@ impl<'a> DataflowBuilder<'a> {
                 }
             }
         });
-        dataflow.add_view_to_build(*view_id, view.clone(), view.typ());
+        dataflow.add_view_to_build(*view_id, view.clone());
     }
 
     /// Builds a dataflow description for the index with the specified ID.

--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -186,7 +186,7 @@ impl<'a> DataflowBuilder<'a> {
                 }
             }
         });
-        dataflow.add_view_to_build(*view_id, view.clone());
+        dataflow.insert_view(*view_id, view.clone());
     }
 
     /// Builds a dataflow description for the index with the specified ID.
@@ -202,7 +202,6 @@ impl<'a> DataflowBuilder<'a> {
         let on_id = index.on;
         let keys = index.keys.clone();
         self.import_into_dataflow(&on_id, &mut dataflow);
-        dataflow.add_index_to_build(id, on_id.clone(), on_type.clone(), keys.clone());
         dataflow.export_index(id, on_id, on_type, keys);
         dataflow
     }


### PR DESCRIPTION
Some changes in `DataflowDesc` as first steps towards cleaning it up. The main change is the removal of the distinction between views and indexes as objects to build. The distinction was apparently only used by the inlining logic, that was scared to inline an index because it didn't know what that would mean. It seems to be a non-issue (an index is just a `MirRelationExpr` fragment) but we'll want to see if tests agree with that.

Also some method renaming to more clearly reflect function. Many instances of `add_noun_verb` were replaced with `verb_noun`.