### PR TITLE
doc: propose beta features

### DIFF
--- a/doc/user/assets/sass/_content.scss
+++ b/doc/user/assets/sass/_content.scss
@@ -218,7 +218,7 @@ a {
     padding: 16px;
   }
 
-  .experimental {
+  .beta {
     background-color: $purple-1;
     border: 1px dashed $purple-60;
     margin: 16px 0;

--- a/doc/user/content/sql/create-source/_index.md
+++ b/doc/user/content/sql/create-source/_index.md
@@ -29,7 +29,7 @@ documentation for the type of data you are trying to load into Materialize:
 Source type     | Avro                         | Text/bytes                             | Protobuf                                 | CSV                            | JSON
 ----------------|------------------------------|----------------------------------------|------------------------------------------|--------------------------------|---------------------------------
 Kafka           | [Avro + Kafka](./avro-kafka) | [Text/bytes + Kafka](./text-kafka)     | [Protobuf + Kafka](./protobuf-kafka)     | [CSV + Kafka](./csv-kafka)     | [JSON + Kafka](./json-kafka)
-Kinesis (Alpha) | -                            | [Text/bytes + Kinesis](./text-kinesis) | [Protobuf + Kinesis](./protobuf-kinesis) | [CSV + Kinesis](./csv-kinesis) | [JSON + Kinesis](./json-kinesis)
+Kinesis         | -                            | [Text/bytes + Kinesis](./text-kinesis) | [Protobuf + Kinesis](./protobuf-kinesis) | [CSV + Kinesis](./csv-kinesis) | [JSON + Kinesis](./json-kinesis)
 S3              | -                            | [Text/bytes + S3](./text-s3)           | -                                        | [CSV + S3](./csv-s3)           | [JSON + S3](./json-s3)
 PubNub          | -                            | [Text + PubNub](./text-pubnub)         | -                                        | -                              | [JSON + PubNub](./json-pubnub)
 Local files     | [Avro + file](./avro-file)   | [Text/bytes + file](./text-file)       | -                                        | [CSV + files](./csv-file)      | [JSON + file](./json-file)
@@ -37,8 +37,6 @@ Local files     | [Avro + file](./avro-file)   | [Text/bytes + file](./text-file
 
 
 Don't see what you're looking for? [Let us know on GitHub](https://github.com/MaterializeInc/materialize/issues/new?labels=C-feature&template=feature.md).
-
-{{< kinesis-alpha >}}
 
 ## Related pages
 

--- a/doc/user/content/sql/create-source/csv-kinesis.md
+++ b/doc/user/content/sql/create-source/csv-kinesis.md
@@ -9,11 +9,11 @@ aliases:
     - /sql/create-source/csv-source
 ---
 
+{{< beta />}}
+
 {{% create-source/intro %}}
 This document details how to connect Materialize to CSV-formatted Kinesis
 streams.
-
-{{< kinesis-alpha >}}
 
 {{< volatility-warning >}}Kinesis{{< /volatility-warning >}}
 

--- a/doc/user/content/sql/create-source/json-kinesis.md
+++ b/doc/user/content/sql/create-source/json-kinesis.md
@@ -9,11 +9,11 @@ aliases:
     - /sql/create-source/kinesis-source
 ---
 
+{{< beta />}}
+
 {{% create-source/intro %}}
 This document details how to connect Materialize to JSON-formatted Kinesis
 streams.
-
-{{< kinesis-alpha >}}
 
 {{< volatility-warning >}}Kinesis{{< /volatility-warning >}}
 

--- a/doc/user/content/sql/create-source/postgres.md
+++ b/doc/user/content/sql/create-source/postgres.md
@@ -8,6 +8,8 @@ aliases:
   - /sql/create-source/postgresql
 ---
 
+{{< beta />}}
+
 {{< version-added v0.8.0 />}}
 
 {{% create-source/intro %}}

--- a/doc/user/content/sql/create-source/protobuf-kinesis.md
+++ b/doc/user/content/sql/create-source/protobuf-kinesis.md
@@ -6,11 +6,12 @@ menu:
     parent: 'create-source'
 ---
 
+{{< beta />}}
+
 {{% create-source/intro %}}
 This document details how to connect Materialize to Protobuf-formatted Kinesis
 stream.
 
-{{< kinesis-alpha >}}
 
 {{< volatility-warning >}}Kinesis{{< /volatility-warning >}}
 

--- a/doc/user/content/sql/create-source/text-kinesis.md
+++ b/doc/user/content/sql/create-source/text-kinesis.md
@@ -6,11 +6,11 @@ menu:
     parent: 'create-source'
 ---
 
+{{< beta />}}
+
 {{% create-source/intro %}}
 This document details how to connect Materialize to a text- or byte–formatted
 Kinesis stream.
-
-{{< kinesis-alpha >}}
 
 {{< volatility-warning >}}Kinesis{{< /volatility-warning >}}
 

--- a/doc/user/content/versions.md
+++ b/doc/user/content/versions.md
@@ -125,7 +125,8 @@ the [release notes](/release-notes).
 There are several aspects of the product that are not considered part of
 Materialize's stable interface:
 
-  * Features that requires [experimental mode](/cli/#experimental-mode)
+  * Features that require [experimental mode](/cli/#experimental-mode)
+  * Features that are in beta (labeled as such in their documentation)
   * The [Grafana monitoring dashboard](/ops/monitoring)
   * Any HTTP interfaces, including:
     * Memory profiling tools

--- a/doc/user/layouts/partials/breadcrumbs.html
+++ b/doc/user/layouts/partials/breadcrumbs.html
@@ -2,7 +2,7 @@
 {{ define "breadcrumb" }}
   {{ with .Parent }}
     {{ template "breadcrumb" . }}
-    {{ if not .IsHome }}&nbsp;/&nbsp;&nbsp;{{end}}<a href="{{ .Permalink }}">{{ if .IsHome }}Home{{ else }}{{.Title}}{{ end }}</a>
+    {{ if not .IsHome }}&nbsp;/&nbsp;&nbsp;{{end}}<a href="{{ .RelPermalink }}">{{ if .IsHome }}Home{{ else }}{{.Title}}{{ end }}</a>
   {{ end }}
 {{ end }}
 {{ if not .IsHome }}

--- a/doc/user/layouts/shortcodes/beta.html
+++ b/doc/user/layouts/shortcodes/beta.html
@@ -1,0 +1,7 @@
+<div class="beta">
+    <strong>BETA!</strong>
+    {{ with .Inner}}{{.|$.Page.RenderString}}{{else}}This feature{{ end }}
+    is in beta. It may have performance or stability issues and is not subject
+    to our <a href="{{ "/versions/#backwards-compatibility" | relURL }}">backwards compatibility</a>
+    guarantee.
+</div>

--- a/doc/user/layouts/shortcodes/experimental.html
+++ b/doc/user/layouts/shortcodes/experimental.html
@@ -1,4 +1,4 @@
-<div class="experimental">
+<div class="warning">
   <strong>EXPERIMENTAL!</strong>
   {{ with .Inner}}{{.|$.Page.RenderString}}{{else}}This feature{{ end }}
   is under construction and requires

--- a/doc/user/layouts/shortcodes/kinesis-alpha.html
+++ b/doc/user/layouts/shortcodes/kinesis-alpha.html
@@ -1,6 +1,0 @@
-<div class="warning">
- <strong>WARNING!</strong> Kinesis support is undergoing active
- development, and is in <strong>Alpha</strong> status. If you run into any issues with it, please let us know with a
- <a href="https://github.com/MaterializeInc/materialize/issues/new?labels=C-bug&template=bug.md">GitHub
- issue</a>.
-</div>


### PR DESCRIPTION
The idea is that features that are ready for user testing but might
still have poor performance or stability get marked as "beta" in the
docs. This is purely about setting user expectations appropriately;
there is no opt-in required to use these features.

To start, PostgreSQL and Kinesis sources are marked as beta. This
overrides the old designation of Kinesis as "alpha".