### PR TITLE
persist: benchmark reads (snapshots) from Indexed

### DIFF
--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -9,6 +9,10 @@ publish = false
 name = "writer"
 harness = false
 
+[[bench]]
+name = "snapshot"
+harness = false
+
 # NB: This is meant to be a strong, independent abstraction boundary, please
 # don't leak in deps on other Materialize packages.
 [dependencies]

--- a/src/persist/benches/snapshot.rs
+++ b/src/persist/benches/snapshot.rs
@@ -1,0 +1,103 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Benchmarks for reading from different parts of an [Indexed]
+
+use criterion::{black_box, criterion_group, criterion_main, Bencher, Criterion};
+
+use persist::error::Error;
+use persist::file::{FileBlob, FileBuffer};
+use persist::indexed::encoding::Id;
+use persist::indexed::Indexed;
+use persist::mem::{MemBlob, MemBuffer};
+use persist::persister::Snapshot;
+use persist::storage::{Blob, Buffer};
+
+fn read_full_snapshot<U: Buffer, L: Blob>(
+    index: &Indexed<U, L>,
+    id: Id,
+    expected_len: usize,
+) -> Vec<((String, String), u64, isize)> {
+    let mut buf = Vec::with_capacity(expected_len);
+    let mut snapshot = index.snapshot(id).expect("reading snapshot cannot fail");
+
+    while snapshot.read(&mut buf) {}
+
+    assert_eq!(buf.len(), expected_len);
+    buf
+}
+
+fn bench_snapshot<U: Buffer, L: Blob>(
+    index: &Indexed<U, L>,
+    id: Id,
+    expected_len: usize,
+    b: &mut Bencher,
+) {
+    b.iter(move || black_box(read_full_snapshot(index, id, expected_len)))
+}
+
+fn bench_indexed_snapshots<U, L, F>(c: &mut Criterion, name: &str, mut new_fn: F)
+where
+    U: Buffer,
+    L: Blob,
+    F: FnMut(usize) -> Result<Indexed<U, L>, Error>,
+{
+    let data_len = 100_000;
+    let data: Vec<_> = (0..data_len)
+        .map(|i| ((format!("key{}", i), format!("val{}", i)), i as u64, 1))
+        .collect();
+
+    let mut i = new_fn(1).expect("creating index cannot fail");
+    let id = i.register("0");
+
+    // Write the data out to the index's buffer.
+    i.write_sync(id, &data)
+        .expect("writing to index cannot fail");
+    c.bench_function(&format!("{}_buffer_snapshot", name), |b| {
+        bench_snapshot(&i, id, data_len, b)
+    });
+
+    // After a step, it's all moved into the future part of the index.
+    i.step().expect("processing records in index cannot fail");
+    c.bench_function(&format!("{}_future_snapshot", name), |b| {
+        bench_snapshot(&i, id, data_len, b)
+    });
+    // Seal the updates to move them all to the trace
+    i.seal(id, 100_001).expect("sealing update times");
+    c.bench_function(&format!("{}_trace_snapshot", name), |b| {
+        bench_snapshot(&i, id, data_len, b)
+    });
+}
+
+pub fn bench_mem_snapshots(c: &mut Criterion) {
+    bench_indexed_snapshots(c, "mem", |path| {
+        let name = format!("snapshot_bench_{}", path);
+        Indexed::new(MemBuffer::new(&name)?, MemBlob::new(&name)?)
+    });
+}
+
+pub fn bench_file_snapshots(c: &mut Criterion) {
+    let temp_dir = tempfile::tempdir().expect("failed to create temp directory");
+    bench_indexed_snapshots(c, "file", move |path| {
+        let buffer_dir = temp_dir
+            .path()
+            .join(format!("snapshot_bench_buffer_{}", path));
+        let blob_dir = temp_dir
+            .path()
+            .join(format!("snapshot_bench_blob_{}", path));
+        let lock_info = b"snapshot_bench";
+        Indexed::new(
+            FileBuffer::new(buffer_dir, lock_info)?,
+            FileBlob::new(blob_dir, lock_info)?,
+        )
+    });
+}
+
+criterion_group!(benches, bench_mem_snapshots, bench_file_snapshots);
+criterion_main!(benches);


### PR DESCRIPTION
the first commit is just #7242 

Results from this benchmark:

High level: reading from files vs in memory seems broadly comparable with files being ~20% slower? Perhaps this just means that this benchmark is stressing the file caching capabilities of the file system more than anything else

Actual output:

```
mem_buffer_snapshot     time:   [25.648 ms 25.860 ms 26.082 ms]
                        change: [-0.3499% +0.6124% +1.5401%] (p = 0.23 > 0.05)
                        No change in performance detected.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

mem_future_snapshot     time:   [25.212 ms 25.551 ms 25.910 ms]
                        change: [+6.9837% +8.5211% +9.9528%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild

mem_trace_snapshot      time:   [26.731 ms 27.045 ms 27.357 ms]
                        change: [+8.9733% +10.996% +12.952%] (p = 0.00 < 0.05)
                        Performance has regressed.

file_buffer_snapshot    time:   [32.709 ms 33.093 ms 33.483 ms]
                        change: [+5.5729% +7.0326% +8.5845%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

file_future_snapshot    time:   [30.278 ms 30.692 ms 31.112 ms]
                        change: [+6.5000% +8.1366% +9.7230%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

file_trace_snapshot     time:   [29.035 ms 29.322 ms 29.627 ms]
                        change: [+2.0798% +3.7799% +5.4456%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 11 outliers among 100 measurements (11.00%)
  10 (10.00%) high mild
  1 (1.00%) high severe

```