### PR TITLE
Refactor sink rendering code, move closely coupled code together in one place

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1308,25 +1308,23 @@ impl Coordinator {
             as_of,
         );
 
-        if let SinkConnector::Kafka(kafka_sink) = connector {
-            // For exactly-once Kafka sinks, we need to block compaction of each timestamp binding
-            // until all sinks that depend on a given source have finished writing out that timestamp.
-            // To achieve that, each sink will hold a AntichainToken for all of the sources it depends
-            // on, and will advance all of its source dependencies' compaction frontiers as it completes
-            // writes.
-            if kafka_sink.exactly_once {
-                let mut tokens = Vec::new();
+        // For some sinks, we need to block compaction of each timestamp binding
+        // until all sinks that depend on a given source have finished writing out that timestamp.
+        // To achieve that, each sink will hold a AntichainToken for all of the sources it depends
+        // on, and will advance all of its source dependencies' compaction frontiers as it completes
+        // writes.
+        if connector.requires_source_compaction_holdback() {
+            let mut tokens = Vec::new();
 
-                // Collect AntichainTokens from all of the sources that have them.
-                for id in &kafka_sink.transitive_source_dependencies {
-                    if let Some(token) = self.since_handles.get(&id) {
-                        tokens.push(token.clone());
-                    }
+            // Collect AntichainTokens from all of the sources that have them.
+            for id in connector.transitive_source_dependencies() {
+                if let Some(token) = self.since_handles.get(&id) {
+                    tokens.push(token.clone());
                 }
-
-                let sink_writes = SinkWrites::new(tokens);
-                self.sink_writes.insert(id, sink_writes);
             }
+
+            let sink_writes = SinkWrites::new(tokens);
+            self.sink_writes.insert(id, sink_writes);
         }
         Ok(self.ship_dataflow(df).await)
     }

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1304,7 +1304,7 @@ impl Coordinator {
             id,
             sink.from,
             connector.clone(),
-            sink.envelope,
+            Some(sink.envelope),
             as_of,
         );
 
@@ -2526,7 +2526,7 @@ impl Coordinator {
                 object_columns,
                 value_desc: desc,
             }),
-            SinkEnvelope::Tail { emit_progress },
+            None,
             SinkAsOf {
                 frontier,
                 strict: !with_snapshot,

--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -174,7 +174,7 @@ impl<'a> DataflowBuilder<'a> {
         id: GlobalId,
         from: GlobalId,
         connector: SinkConnector,
-        envelope: SinkEnvelope,
+        envelope: Option<SinkEnvelope>,
         as_of: SinkAsOf,
     ) -> DataflowDesc {
         let mut dataflow = DataflowDesc::new(name);

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -184,7 +184,7 @@ impl DataflowDescription<OptimizedMirRelationExpr> {
         from_id: GlobalId,
         from_desc: RelationDesc,
         connector: SinkConnector,
-        envelope: SinkEnvelope,
+        envelope: Option<SinkEnvelope>,
         as_of: SinkAsOf,
     ) {
         let key_desc = connector.get_key_desc().cloned();
@@ -629,7 +629,7 @@ pub struct SinkDesc {
     pub value_desc: RelationDesc,
     pub key_desc: Option<RelationDesc>,
     pub connector: SinkConnector,
-    pub envelope: SinkEnvelope,
+    pub envelope: Option<SinkEnvelope>,
     pub as_of: SinkAsOf,
 }
 
@@ -637,7 +637,6 @@ pub struct SinkDesc {
 pub enum SinkEnvelope {
     Debezium,
     Upsert,
-    Tail { emit_progress: bool },
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -187,15 +187,11 @@ impl DataflowDescription<OptimizedMirRelationExpr> {
         envelope: Option<SinkEnvelope>,
         as_of: SinkAsOf,
     ) {
-        let key_desc = connector.get_key_desc().cloned();
-        let value_desc = connector.get_value_desc().clone();
         self.sink_exports.push((
             id,
             SinkDesc {
                 from: from_id,
                 from_desc,
-                key_desc,
-                value_desc,
                 connector,
                 envelope,
                 as_of,
@@ -626,8 +622,6 @@ pub struct SourceDesc {
 pub struct SinkDesc {
     pub from: GlobalId,
     pub from_desc: RelationDesc,
-    pub value_desc: RelationDesc,
-    pub key_desc: Option<RelationDesc>,
     pub connector: SinkConnector,
     pub envelope: Option<SinkEnvelope>,
     pub as_of: SinkAsOf,
@@ -1056,49 +1050,6 @@ impl SinkConnector {
             SinkConnector::AvroOcf(_) => "avro-ocf",
             SinkConnector::Kafka(_) => "kafka",
             SinkConnector::Tail(_) => "tail",
-        }
-    }
-
-    pub fn uses_keys(&self) -> bool {
-        match self {
-            SinkConnector::Kafka(_) => true,
-            SinkConnector::Tail(_) => false,
-            SinkConnector::AvroOcf(_) => false,
-        }
-    }
-
-    pub fn get_key_desc(&self) -> Option<&RelationDesc> {
-        match self {
-            SinkConnector::Kafka(k) => k.key_desc_and_indices.as_ref().map(|(desc, _indices)| desc),
-            SinkConnector::Tail(_) => None,
-            SinkConnector::AvroOcf(_) => None,
-        }
-    }
-
-    pub fn get_key_indices(&self) -> Option<&[usize]> {
-        match self {
-            SinkConnector::Kafka(k) => k
-                .key_desc_and_indices
-                .as_ref()
-                .map(|(_desc, indices)| indices.as_slice()),
-            SinkConnector::Tail(_) => None,
-            SinkConnector::AvroOcf(_) => None,
-        }
-    }
-
-    pub fn get_relation_key_indices(&self) -> Option<&[usize]> {
-        match self {
-            SinkConnector::Kafka(k) => k.relation_key_indices.as_deref(),
-            SinkConnector::Tail(_) => None,
-            SinkConnector::AvroOcf(_) => None,
-        }
-    }
-
-    pub fn get_value_desc(&self) -> &RelationDesc {
-        match self {
-            SinkConnector::Kafka(k) => &k.value_desc,
-            SinkConnector::Tail(t) => &t.value_desc,
-            SinkConnector::AvroOcf(a) => &a.value_desc,
         }
     }
 }

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -1059,6 +1059,14 @@ impl SinkConnector {
         }
     }
 
+    pub fn uses_keys(&self) -> bool {
+        match self {
+            SinkConnector::Kafka(_) => true,
+            SinkConnector::Tail(_) => false,
+            SinkConnector::AvroOcf(_) => false,
+        }
+    }
+
     pub fn get_key_desc(&self) -> Option<&RelationDesc> {
         match self {
             SinkConnector::Kafka(k) => k.key_desc_and_indices.as_ref().map(|(desc, _indices)| desc),

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -238,15 +238,7 @@ pub fn build_dataflow<A: Allocate>(
             // Export declared sinks.
             for (sink_id, sink) in &dataflow.sink_exports {
                 let imports = dataflow.get_imports(&sink.from);
-                context.export_sink(
-                    render_state,
-                    &mut tokens,
-                    imports,
-                    *sink_id,
-                    sink,
-                    region.index(),
-                    region.peers(),
-                );
+                context.export_sink(render_state, &mut tokens, imports, *sink_id, sink);
             }
         });
     })

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -132,7 +132,7 @@ mod context;
 mod flat_map;
 mod join;
 mod reduce;
-mod sinks;
+pub mod sinks;
 mod sources;
 mod threshold;
 mod top_k;

--- a/src/dataflow/src/render/sinks.rs
+++ b/src/dataflow/src/render/sinks.rs
@@ -15,21 +15,17 @@ use std::collections::HashSet;
 use std::rc::Rc;
 
 use differential_dataflow::operators::arrange::arrangement::ArrangeByKey;
-use differential_dataflow::{AsCollection, Collection, Hashable};
-use timely::dataflow::operators::Map;
+use differential_dataflow::{Collection, Hashable};
 use timely::dataflow::scopes::Child;
 use timely::dataflow::Scope;
-use timely::progress::Antichain;
 
 use dataflow_types::*;
 use expr::GlobalId;
 use interchange::envelopes::{combine_at_timestamp, dbz_format, upsert_format};
-use ore::cast::CastFrom;
 use repr::{Datum, Diff, Row, Timestamp};
 
 use crate::render::context::Context;
 use crate::render::{RelevantTokens, RenderState};
-use crate::sink;
 
 impl<'g, G> Context<Child<'g, G, G::Timestamp>, Row, Timestamp>
 where
@@ -193,7 +189,7 @@ where
     collection
 }
 
-trait SinkRender<G>
+pub trait SinkRender<G>
 where
     G: Scope<Timestamp = Timestamp>,
 {
@@ -216,129 +212,5 @@ where
         SinkConnector::Kafka(connector) => Box::new(connector.clone()),
         SinkConnector::AvroOcf(connector) => Box::new(connector.clone()),
         SinkConnector::Tail(connector) => Box::new(connector.clone()),
-    }
-}
-
-impl<G> SinkRender<G> for KafkaSinkConnector
-where
-    G: Scope<Timestamp = Timestamp>,
-{
-    fn render_continuous_sink(
-        &self,
-        render_state: &mut RenderState,
-        sink: &SinkDesc,
-        sink_id: GlobalId,
-        sinked_collection: Collection<Child<G, G::Timestamp>, (Option<Row>, Option<Row>), Diff>,
-    ) -> Option<Box<dyn Any>>
-    where
-        G: Scope<Timestamp = Timestamp>,
-    {
-        // consistent/exactly-once Kafka sinks need the timestamp in the row
-        let sinked_collection = if self.consistency.is_some() {
-            sinked_collection
-                .inner
-                .map(|((k, v), t, diff)| {
-                    let v = v.map(|mut v| {
-                        let t = t.to_string();
-                        v.push_list_with(|rp| {
-                            rp.push(Datum::String(&t));
-                        });
-                        v
-                    });
-                    ((k, v), t, diff)
-                })
-                .as_collection()
-        } else {
-            sinked_collection
-        };
-
-        // Extract handles to the relevant source timestamp histories the sink
-        // needs to hear from before it can write data out to Kafka.
-        let mut source_ts_histories = Vec::new();
-
-        for id in &self.transitive_source_dependencies {
-            if let Some(history) = render_state.ts_histories.get(id) {
-                let mut history_bindings = history.clone();
-                // We don't want these to block compaction
-                // ever.
-                history_bindings.set_compaction_frontier(Antichain::new().borrow());
-                source_ts_histories.push(history_bindings);
-            }
-        }
-
-        // TODO: this is a brittle way to indicate the worker that will write to the sink
-        // because it relies on us continuing to hash on the sink_id, with the same hash
-        // function, and for the Exchange pact to continue to distribute by modulo number
-        // of workers.
-        let peers = sinked_collection.inner.scope().peers();
-        let worker_index = sinked_collection.inner.scope().index();
-        let active_write_worker = (usize::cast_from(sink_id.hashed()) % peers) == worker_index;
-        let shared_frontier = Rc::new(RefCell::new(Antichain::from_elem(0)));
-
-        let token = sink::kafka(
-            sinked_collection,
-            sink_id,
-            self.clone(),
-            sink.key_desc.clone(),
-            sink.value_desc.clone(),
-            sink.as_of.clone(),
-            source_ts_histories,
-            shared_frontier.clone(),
-        );
-
-        if active_write_worker {
-            render_state
-                .sink_write_frontiers
-                .insert(sink_id, shared_frontier);
-        }
-
-        Some(token)
-    }
-}
-
-impl<G> SinkRender<G> for AvroOcfSinkConnector
-where
-    G: Scope<Timestamp = Timestamp>,
-{
-    fn render_continuous_sink(
-        &self,
-        _render_state: &mut RenderState,
-        sink: &SinkDesc,
-        sink_id: GlobalId,
-        sinked_collection: Collection<Child<G, G::Timestamp>, (Option<Row>, Option<Row>), Diff>,
-    ) -> Option<Box<dyn Any>>
-    where
-        G: Scope<Timestamp = Timestamp>,
-    {
-        sink::avro_ocf(
-            sinked_collection,
-            sink_id,
-            self.clone(),
-            sink.value_desc.clone(),
-        );
-
-        // no sink token
-        None
-    }
-}
-
-impl<G> SinkRender<G> for TailSinkConnector
-where
-    G: Scope<Timestamp = Timestamp>,
-{
-    fn render_continuous_sink(
-        &self,
-        _render_state: &mut RenderState,
-        sink: &SinkDesc,
-        sink_id: GlobalId,
-        sinked_collection: Collection<Child<G, G::Timestamp>, (Option<Row>, Option<Row>), Diff>,
-    ) -> Option<Box<dyn Any>>
-    where
-        G: Scope<Timestamp = Timestamp>,
-    {
-        sink::tail(sinked_collection, sink_id, self.clone(), sink.as_of.clone());
-
-        // no sink token
-        None
     }
 }

--- a/src/dataflow/src/render/sinks.rs
+++ b/src/dataflow/src/render/sinks.rs
@@ -45,8 +45,6 @@ where
         import_ids: HashSet<GlobalId>,
         sink_id: GlobalId,
         sink: &SinkDesc,
-        _worker_index: usize,
-        _peers: usize,
     ) {
         // put together tokens that belong to the export
         let mut needed_source_tokens = Vec::new();

--- a/src/dataflow/src/sink/avro_ocf.rs
+++ b/src/dataflow/src/sink/avro_ocf.rs
@@ -31,10 +31,30 @@ impl<G> SinkRender<G> for AvroOcfSinkConnector
 where
     G: Scope<Timestamp = Timestamp>,
 {
+    fn uses_keys(&self) -> bool {
+        false
+    }
+
+    fn get_key_desc(&self) -> Option<&RelationDesc> {
+        None
+    }
+
+    fn get_key_indices(&self) -> Option<&[usize]> {
+        None
+    }
+
+    fn get_relation_key_indices(&self) -> Option<&[usize]> {
+        None
+    }
+
+    fn get_value_desc(&self) -> &RelationDesc {
+        &self.value_desc
+    }
+
     fn render_continuous_sink(
         &self,
         _render_state: &mut RenderState,
-        sink: &SinkDesc,
+        _sink: &SinkDesc,
         sink_id: GlobalId,
         sinked_collection: Collection<Child<G, G::Timestamp>, (Option<Row>, Option<Row>), Diff>,
     ) -> Option<Box<dyn Any>>
@@ -45,7 +65,7 @@ where
             sinked_collection,
             sink_id,
             self.clone(),
-            sink.value_desc.clone(),
+            self.value_desc.clone(),
         );
 
         // no sink token

--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -16,7 +16,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use differential_dataflow::{Collection, Hashable};
+use differential_dataflow::{AsCollection, Collection, Hashable};
 use itertools::Itertools;
 use lazy_static::lazy_static;
 use log::{debug, error, info};
@@ -34,19 +34,100 @@ use timely::dataflow::channels::pact::Exchange;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use timely::dataflow::operators::generic::{FrontieredInputHandle, InputHandle, OutputHandle};
-use timely::dataflow::operators::Capability;
+use timely::dataflow::operators::{Capability, Map};
+use timely::dataflow::scopes::Child;
 use timely::dataflow::{Scope, Stream};
+use timely::progress::frontier::AntichainRef;
 use timely::progress::Antichain;
 use timely::scheduling::Activator;
 
-use dataflow_types::{KafkaSinkConnector, KafkaSinkConsistencyConnector, SinkAsOf};
+use dataflow_types::{KafkaSinkConnector, KafkaSinkConsistencyConnector, SinkAsOf, SinkDesc};
 use expr::GlobalId;
 use interchange::avro::{self, AvroEncoder, AvroSchemaGenerator};
 use interchange::encode::Encode;
-use repr::{Diff, RelationDesc, Row, Timestamp};
-use timely::progress::frontier::AntichainRef;
+use ore::cast::CastFrom;
+use repr::{Datum, Diff, RelationDesc, Row, Timestamp};
 
+use crate::render::sinks::SinkRender;
+use crate::render::RenderState;
 use crate::source::timestamp::TimestampBindingRc;
+
+impl<G> SinkRender<G> for KafkaSinkConnector
+where
+    G: Scope<Timestamp = Timestamp>,
+{
+    fn render_continuous_sink(
+        &self,
+        render_state: &mut RenderState,
+        sink: &SinkDesc,
+        sink_id: GlobalId,
+        sinked_collection: Collection<Child<G, G::Timestamp>, (Option<Row>, Option<Row>), Diff>,
+    ) -> Option<Box<dyn Any>>
+    where
+        G: Scope<Timestamp = Timestamp>,
+    {
+        // consistent/exactly-once Kafka sinks need the timestamp in the row
+        let sinked_collection = if self.consistency.is_some() {
+            sinked_collection
+                .inner
+                .map(|((k, v), t, diff)| {
+                    let v = v.map(|mut v| {
+                        let t = t.to_string();
+                        v.push_list_with(|rp| {
+                            rp.push(Datum::String(&t));
+                        });
+                        v
+                    });
+                    ((k, v), t, diff)
+                })
+                .as_collection()
+        } else {
+            sinked_collection
+        };
+
+        // Extract handles to the relevant source timestamp histories the sink
+        // needs to hear from before it can write data out to Kafka.
+        let mut source_ts_histories = Vec::new();
+
+        for id in &self.transitive_source_dependencies {
+            if let Some(history) = render_state.ts_histories.get(id) {
+                let mut history_bindings = history.clone();
+                // We don't want these to block compaction
+                // ever.
+                history_bindings.set_compaction_frontier(Antichain::new().borrow());
+                source_ts_histories.push(history_bindings);
+            }
+        }
+
+        // TODO: this is a brittle way to indicate the worker that will write to the sink
+        // because it relies on us continuing to hash on the sink_id, with the same hash
+        // function, and for the Exchange pact to continue to distribute by modulo number
+        // of workers.
+        let peers = sinked_collection.inner.scope().peers();
+        let worker_index = sinked_collection.inner.scope().index();
+        let active_write_worker = (usize::cast_from(sink_id.hashed()) % peers) == worker_index;
+        let shared_frontier = Rc::new(RefCell::new(Antichain::from_elem(0)));
+
+        let token = kafka(
+            sinked_collection,
+            sink_id,
+            self.clone(),
+            sink.key_desc.clone(),
+            sink.value_desc.clone(),
+            sink.as_of.clone(),
+            source_ts_histories,
+            shared_frontier.clone(),
+        );
+
+        if active_write_worker {
+            render_state
+                .sink_write_frontiers
+                .insert(sink_id, shared_frontier);
+        }
+
+        Some(token)
+    }
+}
 
 /// Per-Kafka sink metrics.
 #[derive(Clone)]
@@ -444,7 +525,7 @@ struct EncodedRow {
 }
 
 // TODO@jldlaughlin: What guarantees does this sink support? #1728
-pub fn kafka<G>(
+fn kafka<G>(
     collection: Collection<G, (Option<Row>, Option<Row>)>,
     id: GlobalId,
     connector: KafkaSinkConnector,

--- a/src/dataflow/src/sink/mod.rs
+++ b/src/dataflow/src/sink/mod.rs
@@ -10,7 +10,3 @@
 mod avro_ocf;
 mod kafka;
 mod tail;
-
-pub use avro_ocf::avro_ocf;
-pub use kafka::kafka;
-pub use tail::tail;

--- a/src/dataflow/src/sink/tail.rs
+++ b/src/dataflow/src/sink/tail.rs
@@ -28,7 +28,7 @@ use dataflow_types::{SinkAsOf, SinkDesc, TailSinkConnector};
 use expr::GlobalId;
 use ore::cast::CastFrom;
 use repr::adt::numeric::{self, Numeric};
-use repr::{Datum, Diff, Row, Timestamp};
+use repr::{Datum, Diff, RelationDesc, Row, Timestamp};
 
 use crate::render::sinks::SinkRender;
 use crate::render::RenderState;
@@ -37,6 +37,26 @@ impl<G> SinkRender<G> for TailSinkConnector
 where
     G: Scope<Timestamp = Timestamp>,
 {
+    fn uses_keys(&self) -> bool {
+        false
+    }
+
+    fn get_key_desc(&self) -> Option<&RelationDesc> {
+        None
+    }
+
+    fn get_key_indices(&self) -> Option<&[usize]> {
+        None
+    }
+
+    fn get_relation_key_indices(&self) -> Option<&[usize]> {
+        None
+    }
+
+    fn get_value_desc(&self) -> &RelationDesc {
+        &self.value_desc
+    }
+
     fn render_continuous_sink(
         &self,
         _render_state: &mut RenderState,

--- a/src/dataflow/src/sink/tail.rs
+++ b/src/dataflow/src/sink/tail.rs
@@ -123,6 +123,11 @@ fn tail<G>(
                             if should_emit {
                                 packer.push(Datum::from(numeric::Numeric::from(*time)));
                                 if connector.emit_progress {
+                                    // When sinking with PROGRESS, the output
+                                    // includes an additional column that
+                                    // indicates whether a timestamp is
+                                    // complete. For regular "data" upates this
+                                    // is always `false`.
                                     packer.push(Datum::False);
                                 }
 

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1514,9 +1514,6 @@ pub fn plan_create_sink(
     let value_desc = match envelope {
         SinkEnvelope::Debezium => envelopes::dbz_desc(desc.clone()),
         SinkEnvelope::Upsert => desc.clone(),
-        SinkEnvelope::Tail { .. } => {
-            unreachable!("SinkEnvelope::Tail is only used when creating tails, not sinks")
-        }
     };
 
     if as_of.is_some() {


### PR DESCRIPTION
The main goal was to move any code that depends on a specific sink out of the main sink rendering method and closer to the specific sink code.

To do this, I'm introducing a `SinkRender` trait that consists of methods that allow a sink to announce what it needs to the generic rendering code, along with a `render` method that will create the sink-dependent dataflow operators.

This is mostly moving code around and extracting methods.

Two bigger changes are:
 - I removed the `TAIL` envelope because it's not a real envelope in the sense of the other envelopes
 - I simplified the `TAIL` code, removed an unnecessary `consolidate()`, added another unit test for `TAIL`

The fact that the `TAIL` code could be simplified this way was obscured before by the splitting up of the `TAIL` code into a pseudo envelope and the "real" sink code.

All the changes are heavily documented in the commits.

This is by no means the desired end state but I think it's a step in the right direction. Eventually, I think it should be possible for sink implementors to implement a trait, without having to fiddle with writing actual dataflow code.