### PR TITLE
Add `Threshold`/`Distinct` variants maintaining retractions

### DIFF
--- a/src/dataflow/src/render/context.rs
+++ b/src/dataflow/src/render/context.rs
@@ -385,7 +385,7 @@ where
         })
     }
 
-    /// Look up an arrangemement by the expressions that form the key.
+    /// Look up an arrangement by the expressions that form the key.
     ///
     /// The result may be `None` if no such arrangement exists, or it may be one of many
     /// "arrangement flavors" that represent the types of arranged data we might have.

--- a/src/dataflow/src/render/reduce.rs
+++ b/src/dataflow/src/render/reduce.rs
@@ -124,8 +124,8 @@ pub enum ReducePlan {
     /// Plan for not computing any aggregations, just determining the set of
     /// distinct keys.
     Distinct,
-    /// Plan for not computing any aggregations, just determining the set of
-    /// distinct keys.
+    /// Plan for not computing any aggregations, just determining the set of distinct keys. A
+    /// specialization of [ReducePlan::Distinct] maintaining rows not in the output.
     #[allow(dead_code)]
     DistinctNegated,
     /// Plan for computing only accumulable aggregations.
@@ -228,7 +228,7 @@ pub struct BucketedPlan {
 /// additional reduce operator whenever we have multiple reduce aggregates
 /// to combine and present results in the appropriate order. If we
 /// were only asked to compute a single aggregation, we can skip
-/// that step and return the arragement provided by computing the aggregation
+/// that step and return the arrangement provided by computing the aggregation
 /// directly.
 #[derive(Clone, Debug)]
 pub enum BasicPlan {
@@ -415,7 +415,7 @@ impl ReducePlan {
 
                     // Distribute buckets in powers of 16, so that we can strike
                     // a balance between how many inputs each layer gets from
-                    // the preceeding layer, while also limiting the number of
+                    // the preceding layer, while also limiting the number of
                     // layers.
                     while current < limit {
                         buckets.push(current as u64);
@@ -721,7 +721,7 @@ where
 ///
 /// This computes the same thing as a join on the group key followed by shuffling
 /// the values into the correct order. This implementation assumes that all input
-/// arrangements present values in a way thats respects the desired output order,
+/// arrangements present values in a way that respects the desired output order,
 /// so we can do a linear merge to form the output.
 fn build_collation<G>(
     arrangements: Vec<(ReductionType, Arrangement<G, Row>)>,

--- a/src/dataflow/src/render/reduce.rs
+++ b/src/dataflow/src/render/reduce.rs
@@ -516,7 +516,7 @@ impl ReducePlan {
                 build_collation(to_collate, expr.aggregate_types, &mut collection.scope()).into()
             }
         };
-        arrangement_or_bundle.to_bundle(key_arity, err_input)
+        arrangement_or_bundle.into_bundle(key_arity, err_input)
     }
 }
 
@@ -542,7 +542,7 @@ where
     ///
     /// * `key_arity` - The number of columns in the key. Only used for arrangement variants.
     /// * `err_input` - A collection containing the error stream.
-    fn to_bundle<T>(
+    fn into_bundle<T>(
         self,
         key_arity: usize,
         err_input: Collection<G, DataflowError>,

--- a/src/dataflow/src/render/threshold.rs
+++ b/src/dataflow/src/render/threshold.rs
@@ -20,6 +20,136 @@ use repr::{Diff, Row};
 use crate::render::context::CollectionBundle;
 use crate::render::context::{ArrangementFlavor, Context};
 
+/// A plan describing how to compute a threshold operation.
+#[derive(Debug)]
+pub enum ThresholdPlan {
+    /// Basic threshold maintains all positive inputs.
+    Basic(BasicThresholdPlan),
+    /// Retractions threshold maintains all negative inputs.
+    Retractions(RetractionsThresholdPlan),
+}
+
+/// A plan to maintain all inputs with positive counts.
+#[derive(Debug)]
+pub struct BasicThresholdPlan {
+    /// The number of columns in the input and output.
+    arity: usize,
+}
+
+/// A plan to maintain all inputs with negative counts, which are subtracted from the output
+/// in order to maintain an equivalent collection compared to [BasicThresholdPlan].
+#[derive(Debug)]
+pub struct RetractionsThresholdPlan {
+    /// The number of columns in the input and output.
+    arity: usize,
+}
+
+impl ThresholdPlan {
+    /// Construct the plan from the number of columns (`arity`). `maintain_retractions` allows to
+    /// switch between an implementation that maintains rows with negative counts (`true`), or
+    /// rows with positive counts (`false`).
+    pub fn create_from(arity: usize, maintain_retractions: bool) -> Self {
+        if maintain_retractions {
+            ThresholdPlan::Retractions(RetractionsThresholdPlan { arity })
+        } else {
+            ThresholdPlan::Basic(BasicThresholdPlan { arity })
+        }
+    }
+}
+
+/// Shared function to compute an arrangement of values matching `logic`.
+fn threshold_arrangement<G, T, R, L>(
+    arrangement: &R,
+    name: &str,
+    logic: L,
+) -> Arranged<G, TraceAgent<OrdValSpine<Row, Row, G::Timestamp, Diff>>>
+where
+    G: Scope,
+    G::Timestamp: Lattice + Refines<T>,
+    T: Timestamp + Lattice,
+    R: ReduceCore<G, Row, Row, Diff>,
+    L: Fn(&isize) -> bool + 'static,
+{
+    arrangement.reduce_abelian(name, move |_k, s, t| {
+        for (record, count) in s.iter() {
+            if logic(count) {
+                t.push(((*record).clone(), *count));
+            }
+        }
+    })
+}
+
+pub fn build_threshold_basic<G, T>(
+    input: CollectionBundle<G, Row, T>,
+    arity: usize,
+) -> CollectionBundle<G, Row, T>
+where
+    G: Scope,
+    G::Timestamp: Lattice + Refines<T>,
+    T: Timestamp + Lattice,
+{
+    // Arrange the input by all columns in order.
+    // Different trace variants require different implementations because their
+    // types are different, but the logic is identical.
+    let mut all_columns = Vec::new();
+    for column in 0..arity {
+        all_columns.push(expr::MirScalarExpr::Column(column));
+    }
+    let input = input.ensure_arrangements(Some(all_columns.clone()));
+    match input
+        .arrangement(&all_columns)
+        .expect("Arrangement ensured to exist")
+    {
+        ArrangementFlavor::Local(oks, errs) => {
+            let oks = threshold_arrangement(&oks, "Threshold local", |count| *count > 0);
+            CollectionBundle::from_columns(0..arity, ArrangementFlavor::Local(oks, errs))
+        }
+        ArrangementFlavor::Trace(_, oks, errs) => {
+            let oks = threshold_arrangement(&oks, "Threshold trace", |count| *count > 0);
+            use differential_dataflow::operators::arrange::ArrangeBySelf;
+            let errs = errs.as_collection(|k, _| k.clone()).arrange_by_self();
+            CollectionBundle::from_columns(0..arity, ArrangementFlavor::Local(oks, errs))
+        }
+    }
+}
+
+pub fn build_threshold_retractions<G, T>(
+    input: CollectionBundle<G, Row, T>,
+    arity: usize,
+) -> CollectionBundle<G, Row, T>
+where
+    G: Scope,
+    G::Timestamp: Lattice + Refines<T>,
+    T: Timestamp + Lattice,
+{
+    // Arrange the input by all columns in order.
+    // Different trace variants require different implementations because their
+    // types are different, but the logic is identical.
+    let mut all_columns = Vec::new();
+    for column in 0..arity {
+        all_columns.push(expr::MirScalarExpr::Column(column));
+    }
+    let input = input.ensure_arrangements(Some(all_columns.clone()));
+    let arrangement = input
+        .arrangement(&all_columns)
+        .expect("Arrangement ensured to exist");
+    let negatives = match &arrangement {
+        ArrangementFlavor::Local(oks, _) => {
+            threshold_arrangement(oks, "Threshold retractions local", |count| *count < 0)
+        }
+        ArrangementFlavor::Trace(_, oks, _) => {
+            threshold_arrangement(oks, "Threshold retractions trace", |count| *count < 0)
+        }
+    };
+    let (oks, errs) = arrangement.as_collection();
+    let oks = negatives
+        .as_collection(|k, _| k.clone())
+        .negate()
+        .concat(&oks)
+        .consolidate();
+    CollectionBundle::from_collections(oks, errs)
+}
+
 impl<G, T> Context<G, Row, T>
 where
     G: Scope,
@@ -27,49 +157,17 @@ where
     T: Timestamp + Lattice,
 {
     pub fn render_threshold(
-        &mut self,
-        mut input: CollectionBundle<G, Row, T>,
-        arity: usize,
+        &self,
+        input: CollectionBundle<G, Row, T>,
+        threshold_plan: ThresholdPlan,
     ) -> CollectionBundle<G, Row, T> {
-        fn threshold_arrangement<G, T, R>(
-            arrangement: &R,
-        ) -> Arranged<G, TraceAgent<OrdValSpine<Row, Row, G::Timestamp, Diff>>>
-        where
-            G: Scope,
-            G::Timestamp: Lattice + Refines<T>,
-            T: Timestamp + Lattice,
-            R: ReduceCore<G, Row, Row, Diff>,
-        {
-            arrangement.reduce_abelian("Threshold", move |_k, s, t| {
-                for (record, count) in s.iter() {
-                    if *count < 0 {
-                        t.push(((*record).clone(), *count));
-                    }
-                }
-            })
+        match threshold_plan {
+            ThresholdPlan::Basic(BasicThresholdPlan { arity }) => {
+                build_threshold_basic(input, arity)
+            }
+            ThresholdPlan::Retractions(RetractionsThresholdPlan { arity }) => {
+                build_threshold_retractions(input, arity)
+            }
         }
-
-        // Arrange the input by all columns in order.
-        // Different trace variants require different implementations because their
-        // types are different, but the logic is identical.
-        let mut all_columns = Vec::new();
-        for column in 0..arity {
-            all_columns.push(expr::MirScalarExpr::Column(column));
-        }
-        input = input.ensure_arrangements(Some(all_columns.clone()));
-        let arrangement = input
-            .arrangement(&all_columns)
-            .expect("Arrangement ensured to exist");
-        let negatives = match &arrangement {
-            ArrangementFlavor::Local(oks, _) => threshold_arrangement(oks),
-            ArrangementFlavor::Trace(_, oks, _) => threshold_arrangement(oks),
-        };
-        let (oks, errs) = arrangement.as_collection();
-        let oks = negatives
-            .as_collection(|k, _| k.clone())
-            .negate()
-            .concat(&oks)
-            .consolidate();
-        CollectionBundle::from_collections(oks, errs)
     }
 }

--- a/src/dataflow/src/render/threshold.rs
+++ b/src/dataflow/src/render/threshold.rs
@@ -8,13 +8,14 @@
 // by the Apache License, Version 2.0.
 
 use differential_dataflow::lattice::Lattice;
+use differential_dataflow::operators::arrange::{Arranged, TraceAgent};
 use differential_dataflow::operators::reduce::ReduceCore;
 use differential_dataflow::operators::Consolidate;
 use differential_dataflow::trace::implementations::ord::OrdValSpine;
 use timely::dataflow::Scope;
 use timely::progress::{timestamp::Refines, Timestamp};
 
-use repr::Row;
+use repr::{Diff, Row};
 
 use crate::render::context::CollectionBundle;
 use crate::render::context::{ArrangementFlavor, Context};
@@ -30,6 +31,24 @@ where
         mut input: CollectionBundle<G, Row, T>,
         arity: usize,
     ) -> CollectionBundle<G, Row, T> {
+        fn threshold_arrangement<G, T, R>(
+            arrangement: &R,
+        ) -> Arranged<G, TraceAgent<OrdValSpine<Row, Row, G::Timestamp, Diff>>>
+        where
+            G: Scope,
+            G::Timestamp: Lattice + Refines<T>,
+            T: Timestamp + Lattice,
+            R: ReduceCore<G, Row, Row, Diff>,
+        {
+            arrangement.reduce_abelian("Threshold", move |_k, s, t| {
+                for (record, count) in s.iter() {
+                    if *count < 0 {
+                        t.push(((*record).clone(), *count));
+                    }
+                }
+            })
+        }
+
         // Arrange the input by all columns in order.
         // Different trace variants require different implementations because their
         // types are different, but the logic is identical.
@@ -38,33 +57,14 @@ where
             all_columns.push(expr::MirScalarExpr::Column(column));
         }
         input = input.ensure_arrangements(Some(all_columns.clone()));
-        let (oks, negatives, errs) = match input
+        let arrangement = input
             .arrangement(&all_columns)
-            .expect("Arrangement ensured to exist")
-        {
-            ArrangementFlavor::Local(oks, errs) => (
-                oks.as_collection(|k, _| k.clone()),
-                oks.reduce_abelian::<_, OrdValSpine<_, _, _, _>>("Threshold", move |_k, s, t| {
-                    for (record, count) in s.iter() {
-                        if *count < 0 {
-                            t.push(((*record).clone(), *count));
-                        }
-                    }
-                }),
-                errs.as_collection(|k, _| k.clone()),
-            ),
-            ArrangementFlavor::Trace(_, oks, errs) => (
-                oks.as_collection(|k, _| k.clone()),
-                oks.reduce_abelian::<_, OrdValSpine<_, _, _, _>>("Threshold", move |_k, s, t| {
-                    for (record, count) in s.iter() {
-                        if *count < 0 {
-                            t.push(((*record).clone(), *count));
-                        }
-                    }
-                }),
-                errs.as_collection(|k, _| k.clone()),
-            ),
+            .expect("Arrangement ensured to exist");
+        let negatives = match &arrangement {
+            ArrangementFlavor::Local(oks, _) => threshold_arrangement(oks),
+            ArrangementFlavor::Trace(_, oks, _) => threshold_arrangement(oks),
         };
+        let (oks, errs) = arrangement.as_collection();
         let oks = negatives
             .as_collection(|k, _| k.clone())
             .negate()


### PR DESCRIPTION
Fixes #7249.

Reduction operators could provide an optimization by not maintaining their output but rather a smaller set of data needed to compute their correct outputs.

Pull-up the `CollectionBundle` type during rendering a reduction dataflow. This would permit reductions to return collections instead of arrangements if they do not maintain their outputs.
