### PR TITLE
Deduplicate results in skew query

### DIFF
--- a/doc/user/content/ops/diagnosing-using-sql.md
+++ b/doc/user/content/ops/diagnosing-using-sql.md
@@ -178,7 +178,8 @@ from
 where
     mse.id = aebi.id and
     mse.elapsed_ns > 2 * aebi.avg_ns and
-    mse.id = dod.id
+    mse.id = dod.id and
+    mse.worker = dod.worker
 order by ratio desc;
 ```
 


### PR DESCRIPTION
The diagnostic skew query joins various results with `mz_dataflow_operator_dataflows` which has rows for each worker. This results in duplication of each row as many times as there are workers, e.g.
```
 id  |    name     | worker | elapsed_ns |     avg_ns      |     ratio      
-----+-------------+--------+------------+-----------------+----------------
 739 | MapFallible |      0 |   78451495 | 19614376.000000 | 3.999693600000
 739 | MapFallible |      0 |   78451495 | 19614376.000000 | 3.999693600000
 739 | MapFallible |      0 |   78451495 | 19614376.000000 | 3.999693600000
 739 | MapFallible |      0 |   78451495 | 19614376.000000 | 3.999693600000
 777 | MapFallible |      0 |    5136990 |  1284438.750000 | 3.999404400000
 777 | MapFallible |      0 |    5136990 |  1284438.750000 | 3.999404400000
 777 | MapFallible |      0 |    5136990 |  1284438.750000 | 3.999404400000
 777 | MapFallible |      0 |    5136990 |  1284438.750000 | 3.999404400000
```
We add a constraint that also picks out only the relevant worker, which reduces the results to their distinct rows.