### PR TITLE
Force shuffling of source streams

### DIFF
--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -415,6 +415,10 @@ where
                     _ => collection,
                 };
 
+                // Force a shuffling of data in case sources are not uniformly distributed.
+                use differential_dataflow::operators::Consolidate;
+                collection = collection.consolidate();
+
                 // Implement source filtering and projection.
                 // At the moment this is strictly optional, but we perform it anyhow
                 // to demonstrate the intended use.


### PR DESCRIPTION
This PR adds a `consolidate` operation before sources are presented to the rest of `dataflow`, as insurance against source streams that may not be distributed across workers.

Fixes #7295