### PR TITLE
materialized: use the new telemetry server URL directly

### DIFF
--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -414,7 +414,7 @@ fn run(args: Args) -> Result<(), anyhow::Error> {
         Some(materialized::TelemetryConfig {
             domain: args
                 .telemetry_domain
-                .unwrap_or_else(|| "telemetry.materialize.com".into()),
+                .unwrap_or_else(|| "cloud.materialize.com".into()),
             interval: args
                 .telemetry_interval
                 .unwrap_or_else(|| Duration::from_secs(3600)),

--- a/src/materialized/src/telemetry.rs
+++ b/src/materialized/src/telemetry.rs
@@ -112,7 +112,7 @@ async fn report_one(config: &Config) -> Result<semver::Version, anyhow::Error> {
                 .await?;
             let response = http_util::reqwest_client()?
                 .post(format!(
-                    "https://{}/api/v1/version/{}",
+                    "https://{}/api/telemetry/{}",
                     config.domain, config.cluster_id
                 ))
                 .timeout(Duration::from_secs(10))


### PR DESCRIPTION
The telemetry server is now integrated into the cloud backend and lives
at:

    cloud.materialize.com/api/telemetry

Update materialized accordingly. We'll keep forwarding the old URL
(telemetry.materialize.com/api/v1/version) for a while, but at least
this way we can eventually turn off the forwarder, once we no longer
care about ancient versions of Materialize.