### PR TITLE
sql/apd: numerous small fixes

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -3176,8 +3176,13 @@ impl BinaryFunc {
             ListLengthMax { .. } | ArrayLength | ArrayLower | ArrayUpper => {
                 ScalarType::Int64.nullable(true)
             }
-            ListListConcat | ListElementConcat => input1_type.scalar_type.nullable(true),
-            ElementListConcat => input2_type.scalar_type.nullable(true),
+
+            ListListConcat | ListElementConcat => {
+                input1_type.scalar_type.unscale_any_apd().nullable(true)
+            }
+
+            ElementListConcat => input2_type.scalar_type.unscale_any_apd().nullable(true),
+
             DigestString | DigestBytes => ScalarType::Bytes.nullable(true),
             Position => ScalarType::Int32.nullable(in_nullable),
             Encode => ScalarType::String.nullable(in_nullable),
@@ -4085,11 +4090,13 @@ impl UnaryFunc {
             }
             CastJsonbToBool => ScalarType::Bool.nullable(nullable),
 
-            CastList1ToList2 { return_ty, .. }
-            | CastStringToArray { return_ty, .. }
-            | CastStringToList { return_ty, .. }
+            CastStringToArray { return_ty, .. }
             | CastStringToMap { return_ty, .. }
             | CastInPlace { return_ty } => (return_ty.clone()).nullable(nullable),
+
+            CastList1ToList2 { return_ty, .. } | CastStringToList { return_ty, .. } => {
+                return_ty.unscale_any_apd().nullable(false)
+            }
 
             CeilFloat32 | FloorFloat32 | RoundFloat32 => ScalarType::Float32.nullable(nullable),
             CeilFloat64 | FloorFloat64 | RoundFloat64 => ScalarType::Float64.nullable(nullable),

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -808,6 +808,30 @@ impl<'a> ScalarType {
         dims
     }
 
+    /// Returns `self` with any values equal to `ScalarType::APD` with their
+    /// `scale` set to `None`.
+    pub fn unscale_any_apd(&self) -> ScalarType {
+        use ScalarType::*;
+        match self {
+            APD { scale: Some(..) } => APD { scale: None },
+            List {
+                element_type,
+                custom_oid: None,
+            } => List {
+                element_type: Box::new(element_type.unscale_any_apd()),
+                custom_oid: None,
+            },
+            Map {
+                value_type,
+                custom_oid: None,
+            } => Map {
+                value_type: Box::new(value_type.unscale_any_apd()),
+                custom_oid: None,
+            },
+            _ => self.clone(),
+        }
+    }
+
     /// Returns the [`ScalarType`] of elements in a [`ScalarType::Array`].
     ///
     /// # Panics

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -160,7 +160,7 @@ lazy_static! {
                 let (_, s) = to_type.unwrap_decimal_parts();
                 Some(move |e: HirScalarExpr| e.call_unary(CastFloat32ToDecimal(s)))
             }),
-            (Float32, APD) => Implicit: CastTemplate::new(|_ecx, _ccx, _from_type, to_type| {
+            (Float32, APD) => Assignment: CastTemplate::new(|_ecx, _ccx, _from_type, to_type| {
                 let s = to_type.unwrap_apd_scale();
                 Some(move |e: HirScalarExpr| e.call_unary(CastFloat32ToAPD(s)))
             }),
@@ -174,7 +174,7 @@ lazy_static! {
                 let (_, s) = to_type.unwrap_decimal_parts();
                 Some(move |e: HirScalarExpr| e.call_unary(CastFloat64ToDecimal(s)))
             }),
-            (Float64, APD) => Implicit: CastTemplate::new(|_ecx, _ccx, _from_type, to_type| {
+            (Float64, APD) => Assignment: CastTemplate::new(|_ecx, _ccx, _from_type, to_type| {
                 let s = to_type.unwrap_apd_scale();
                 Some(move |e: HirScalarExpr| e.call_unary(CastFloat64ToAPD(s)))
             }),

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -510,13 +510,14 @@ fn guess_compatible_cast_type(types: &[ScalarType]) -> Option<&ScalarType> {
         ScalarType::Int32 => 0,
         ScalarType::Int64 => 1,
         ScalarType::Decimal(_, _) => 2,
-        ScalarType::Float32 => 3,
-        ScalarType::Float64 => 4,
+        ScalarType::APD { scale: None } => 3,
+        ScalarType::Float32 => 4,
+        ScalarType::Float64 => 5,
         // [`TypeCategory::DateTime`]
-        ScalarType::Date => 5,
-        ScalarType::Timestamp => 6,
-        ScalarType::TimestampTz => 7,
-        _ => 8,
+        ScalarType::Date => 6,
+        ScalarType::Timestamp => 7,
+        ScalarType::TimestampTz => 8,
+        _ => 9,
     })
 }
 

--- a/test/sqllogictest/list.slt
+++ b/test/sqllogictest/list.slt
@@ -1709,6 +1709,12 @@ SELECT ('{1.2}'::numeric(38,5) list || '{2.3}'::numeric(38,0) list)::text;
 ----
 {1.20000,2.00000}
 
+# Note that APD values are also implicitly castable to one another, but do not rescale values
+query T
+SELECT ('{1.2}'::apd(39,5) list || '{2.3}'::apd(39,0) list)::text;
+----
+{1.2,2}
+
 # ...including on multiple dimensions
 query T
 SELECT ('{{1.2}}'::numeric(38,5) list list || '{{2.3}}'::numeric(38,0) list list)::text;


### PR DESCRIPTION
These are some small lingering issues with APD's semantics/general bugs. Most of these are not on active code paths, but are thoroughly tested once we replace the current decimal implementation with APD (#7312), so does not include a robust set of tests.