### PR TITLE
[dataflow] Mandate operator names, remove redundancy

### DIFF
--- a/src/dataflow/src/render/context.rs
+++ b/src/dataflow/src/render/context.rs
@@ -414,7 +414,7 @@ where
                 }
                 let (oks, errs) = self.as_collection();
                 use crate::operator::CollectionExt;
-                let (oks_keyed, errs_keyed) = oks.map_fallible(move |row| {
+                let (oks_keyed, errs_keyed) = oks.map_fallible("FormArrangementKey", move |row| {
                     let datums = row.unpack();
                     let temp_storage = RowArena::new();
                     let key_row =

--- a/src/dataflow/src/render/flat_map.rs
+++ b/src/dataflow/src/render/flat_map.rs
@@ -32,7 +32,7 @@ where
     ) -> CollectionBundle<G, Row, G::Timestamp> {
         let mfp_plan = mfp.into_plan().expect("MapFilterProject planning failed");
         let (ok_collection, err_collection) = input.as_collection();
-        let (oks, errs) = ok_collection.inner.flat_map_fallible({
+        let (oks, errs) = ok_collection.inner.flat_map_fallible("FlatMapStage", {
             let mut datums = DatumVec::new();
             move |(input_row, time, diff)| {
                 let temp_storage = RowArena::new();

--- a/src/dataflow/src/render/join/linear_join.rs
+++ b/src/dataflow/src/render/join/linear_join.rs
@@ -217,7 +217,7 @@ where
                     // If there is no starting arrangement, then we can run filters
                     // directly on the starting collection.
                     // If there is only one input, we are done joining, so run filters
-                    let (j, errs) = joined.flat_map_fallible({
+                    let (j, errs) = joined.flat_map_fallible("LinearJoinInitialization", {
                         // Reuseable allocation for unpacking.
                         let mut datums = DatumVec::new();
                         move |row| {
@@ -259,7 +259,7 @@ where
         // and projections that could not be applied (e.g. column repetition).
         if let JoinedFlavor::Collection(mut joined) = joined {
             if let Some(closure) = linear_plan.final_closure {
-                let (updates, errs) = joined.flat_map_fallible({
+                let (updates, errs) = joined.flat_map_fallible("LinearJoinFinalization", {
                     // Reuseable allocation for unpacking.
                     let mut datums = DatumVec::new();
                     move |row| {
@@ -301,7 +301,7 @@ where
     ) -> Collection<G, Row> {
         // If we have only a streamed collection, we must first form an arrangement.
         if let JoinedFlavor::Collection(stream) = joined {
-            let (keyed, errs) = stream.map_fallible({
+            let (keyed, errs) = stream.map_fallible("LinearJoinKeyPreparation", {
                 // Reuseable allocation for unpacking.
                 let mut datums = DatumVec::new();
                 move |row| {

--- a/src/dataflow/src/render/upsert.rs
+++ b/src/dataflow/src/render/upsert.rs
@@ -272,7 +272,7 @@ where
 
     // If we have temporal predicates do the thing they have to do.
     if let Some(plan) = temporal_plan {
-        let (oks2, errs2) = oks.flat_map_fallible({
+        let (oks2, errs2) = oks.flat_map_fallible("UpsertTemporalOperators", {
             let mut datums = crate::render::datum_vec::DatumVec::new();
             move |(row, time, diff)| {
                 let arena = repr::RowArena::new();

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -1246,7 +1246,10 @@ where
         }
     });
 
-    (stream.map_fallible(|r| r), Some(capability))
+    (
+        stream.map_fallible("SimpleSourceErrorDemux", |r| r),
+        Some(capability),
+    )
 }
 
 /// Creates a source dataflow operator. The type of ExternalSourceConnector determines the
@@ -1488,7 +1491,7 @@ where
         }
     });
 
-    let (ok_stream, err_stream) = stream.map_fallible(move |r| {
+    let (ok_stream, err_stream) = stream.map_fallible("SourceErrorDemux", move |r| {
         r.map_err(|e| SourceError::new(sql_name.clone(), SourceErrorDetails::FileIO(e)))
     });
 


### PR DESCRIPTION
Our linear operator wrappers just announced themselves as e.g. `FlatMapFallible` which isn't very helpful for diagnostic reports. This PR requires a name argument, and updates all call sites to use a descriptive name. These are all currently unique, and further call sites should strive to maintain this property.