### PR TITLE
test/perf: propagate env vars to kinesis materialize container

### DIFF
--- a/test/debezium-avro/mzcompose.yml
+++ b/test/debezium-avro/mzcompose.yml
@@ -63,7 +63,6 @@ services:
     - AWS_ACCESS_KEY_ID
     - AWS_SECRET_ACCESS_KEY
     - AWS_SESSION_TOKEN
-    - AWS_SECURITY_TOKEN
     volumes:
     - .:/workdir
     - mzdata:/share/mzdata
@@ -89,7 +88,6 @@ services:
     - AWS_ACCESS_KEY_ID
     - AWS_SECRET_ACCESS_KEY
     - AWS_SESSION_TOKEN
-    - AWS_SECURITY_TOKEN
     - ALL_PROXY
     volumes:
     - mzdata:/share/mzdata

--- a/test/performance/perf-kinesis/mzcompose.yml
+++ b/test/performance/perf-kinesis/mzcompose.yml
@@ -27,7 +27,6 @@ services:
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY
       - AWS_SESSION_TOKEN
-      - AWS_SECURITY_TOKEN
     depends_on: [materialized]
 
   materialized:
@@ -37,6 +36,9 @@ services:
     command: -w ${MZ_WORKERS:-4} --disable-telemetry
     environment:
       - MZ_DEV=1
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_SESSION_TOKEN
   dashboard:
     mzbuild: dashboard
     environment:

--- a/test/testdrive/mzcompose.yml
+++ b/test/testdrive/mzcompose.yml
@@ -116,7 +116,6 @@ services:
     - AWS_ACCESS_KEY_ID
     - AWS_SECRET_ACCESS_KEY
     - AWS_SESSION_TOKEN
-    - AWS_SECURITY_TOKEN
     volumes:
     - .:/workdir
     - mzdata:/share/mzdata
@@ -141,7 +140,6 @@ services:
     - AWS_ACCESS_KEY_ID
     - AWS_SECRET_ACCESS_KEY
     - AWS_SESSION_TOKEN
-    - AWS_SECURITY_TOKEN
     - ALL_PROXY
     volumes:
     - mzdata:/share/mzdata


### PR DESCRIPTION
Without propagating these flags, it's challenging to run this
workflow locally.