### PR TITLE
persist: use <K,V> generics instead of hardcoding String everywhere

### DIFF
--- a/src/persist/benches/snapshot.rs
+++ b/src/persist/benches/snapshot.rs
@@ -20,7 +20,7 @@ use persist::persister::Snapshot;
 use persist::storage::{Blob, Buffer};
 
 fn read_full_snapshot<U: Buffer, L: Blob>(
-    index: &Indexed<U, L>,
+    index: &Indexed<String, String, U, L>,
     id: Id,
     expected_len: usize,
 ) -> Vec<((String, String), u64, isize)> {
@@ -34,7 +34,7 @@ fn read_full_snapshot<U: Buffer, L: Blob>(
 }
 
 fn bench_snapshot<U: Buffer, L: Blob>(
-    index: &Indexed<U, L>,
+    index: &Indexed<String, String, U, L>,
     id: Id,
     expected_len: usize,
     b: &mut Bencher,
@@ -46,7 +46,7 @@ fn bench_indexed_snapshots<U, L, F>(c: &mut Criterion, name: &str, mut new_fn: F
 where
     U: Buffer,
     L: Blob,
-    F: FnMut(usize) -> Result<Indexed<U, L>, Error>,
+    F: FnMut(usize) -> Result<Indexed<String, String, U, L>, Error>,
 {
     let data_len = 100_000;
     let data: Vec<_> = (0..data_len)

--- a/src/persist/src/indexed/future.rs
+++ b/src/persist/src/indexed/future.rs
@@ -95,9 +95,6 @@ impl<K: Data, V: Data> BlobFuture<K, V> {
         // TODO: Assert that nothing in the batch is before self.ts_lower. That
         // would indicate a logic error by the user of this BlobFuture.
 
-        // TODO: Sort the updates in the batch by `(time, key, value)` (or
-        // ensure that they're sorted, if it turns out this work should have
-        // happened somewhere else).
         let desc = batch.desc.clone();
         blob.set_future_batch(key.clone(), batch)?;
         self.batches.push((desc, key));

--- a/src/persist/src/indexed/runtime.rs
+++ b/src/persist/src/indexed/runtime.rs
@@ -286,7 +286,7 @@ mod tests {
     use std::sync::mpsc;
 
     use crate::mem::{MemBlob, MemBuffer, MemRegistry};
-    use crate::persister::Snapshot;
+    use crate::persister::SnapshotExt;
 
     use super::*;
 
@@ -309,7 +309,7 @@ mod tests {
         let id = runtime.register("0")?;
         block_on(|res| runtime.write(id, &data, res))?;
         block_on(|res| runtime.seal(id, 3, res))?;
-        let mut snap = block_on(|res| runtime.snapshot(id, res))?;
+        let snap = block_on(|res| runtime.snapshot(id, res))?;
         assert_eq!(snap.read_to_end(), data);
 
         // Commands sent after stop return an error, but calling stop again is
@@ -336,7 +336,7 @@ mod tests {
         let mut client2 = client1.clone();
         drop(client1);
         block_on(|res| client2.write(id, &data, res))?;
-        let mut snap = block_on(|res| client2.snapshot(id, res))?;
+        let snap = block_on(|res| client2.snapshot(id, res))?;
         assert_eq!(snap.read_to_end(), data);
         client2.stop()?;
 
@@ -371,7 +371,7 @@ mod tests {
         {
             let mut persister = registry.open("path", "restart-1")?;
             let (_, meta) = persister.create_or_load("0")?.into_inner();
-            let mut snap = meta.snapshot()?;
+            let snap = meta.snapshot()?;
             let mut actual = snap.read_to_end();
             actual.sort();
             assert_eq!(actual, data);

--- a/src/persist/src/indexed/trace.rs
+++ b/src/persist/src/indexed/trace.rs
@@ -12,6 +12,7 @@
 //!
 //! This is directly a persistent analog of [differential_dataflow::trace::Trace].
 
+use std::marker::PhantomData;
 use std::sync::Arc;
 
 use differential_dataflow::lattice::Lattice;
@@ -24,6 +25,7 @@ use crate::indexed::encoding::BlobTraceMeta;
 use crate::indexed::BlobTraceBatch;
 use crate::persister::Snapshot;
 use crate::storage::Blob;
+use crate::Data;
 
 /// A persistent, compacting data structure containing `(Key, Value, Time,
 /// Diff)` entries indexed by `(key, value, time)`.
@@ -35,14 +37,15 @@ use crate::storage::Blob;
 ///   the ability to read at old times is lost).
 /// - TODO: Explain since and logical compactions.
 /// - TODO: Space usage.
-pub struct BlobTrace {
+pub struct BlobTrace<K, V> {
     since: Antichain<u64>,
     // NB: The Descriptions here are sorted and contiguous half-open intervals
     // `[lower, upper)`.
     batches: Vec<(Description<u64>, String)>,
+    _phantom: PhantomData<(K, V)>,
 }
 
-impl Default for BlobTrace {
+impl<K: Data, V: Data> Default for BlobTrace<K, V> {
     fn default() -> Self {
         BlobTrace::new(BlobTraceMeta {
             batches: Vec::new(),
@@ -50,7 +53,7 @@ impl Default for BlobTrace {
     }
 }
 
-impl BlobTrace {
+impl<K: Data, V: Data> BlobTrace<K, V> {
     /// Returns a BlobTrace re-instantiated with the previously serialized
     /// state.
     pub fn new(meta: BlobTraceMeta) -> Self {
@@ -61,6 +64,7 @@ impl BlobTrace {
         BlobTrace {
             since: since,
             batches: meta.batches,
+            _phantom: PhantomData,
         }
     }
 
@@ -90,8 +94,8 @@ impl BlobTrace {
     pub fn append<L: Blob>(
         &mut self,
         key: String,
-        batch: BlobTraceBatch,
-        blob: &mut BlobCache<L>,
+        batch: BlobTraceBatch<K, V>,
+        blob: &mut BlobCache<K, V, L>,
     ) -> Result<(), Error> {
         if &self.ts_upper() != batch.desc.lower() {
             return Err(Error::from(format!(
@@ -110,7 +114,10 @@ impl BlobTrace {
     }
 
     /// Returns a consistent read of all the updates contained in this trace.
-    pub fn snapshot<L: Blob>(&self, blob: &BlobCache<L>) -> Result<TraceSnapshot, Error> {
+    pub fn snapshot<L: Blob>(
+        &self,
+        blob: &BlobCache<K, V, L>,
+    ) -> Result<TraceSnapshot<K, V>, Error> {
         let ts_upper = self.ts_upper();
         let mut updates = Vec::with_capacity(self.batches.len());
         for (_, key) in self.batches.iter() {
@@ -122,14 +129,14 @@ impl BlobTrace {
 
 /// A consistent snapshot of the data currently in a persistent [BlobTrace].
 #[derive(Debug)]
-pub struct TraceSnapshot {
+pub struct TraceSnapshot<K, V> {
     /// An open upper bound on the times of contained updates.
     pub ts_upper: Antichain<u64>,
-    updates: Vec<Arc<BlobTraceBatch>>,
+    updates: Vec<Arc<BlobTraceBatch<K, V>>>,
 }
 
-impl Snapshot for TraceSnapshot {
-    fn read<E: Extend<((String, String), u64, isize)>>(&mut self, buf: &mut E) -> bool {
+impl<K: Clone, V: Clone> Snapshot<K, V> for TraceSnapshot<K, V> {
+    fn read<E: Extend<((K, V), u64, isize)>>(&mut self, buf: &mut E) -> bool {
         if let Some(batch) = self.updates.pop() {
             buf.extend(batch.updates.iter().cloned());
             return true;

--- a/src/persist/src/indexed/trace.rs
+++ b/src/persist/src/indexed/trace.rs
@@ -104,9 +104,6 @@ impl<K: Data, V: Data> BlobTrace<K, V> {
                 batch.desc
             )));
         }
-        // TODO: Sort the updates in the batch by `(key, value, time)` (or
-        // ensure that they're sorted, if it turns out this work should have
-        // happened somewhere else).
         let desc = batch.desc.clone();
         blob.set_trace_batch(key.clone(), batch)?;
         self.batches.push((desc, key));

--- a/src/persist/src/lib.rs
+++ b/src/persist/src/lib.rs
@@ -16,6 +16,10 @@
     clippy::cast_sign_loss
 )]
 
+use std::fmt;
+
+use abomonation::Abomonation;
+
 pub mod error;
 pub mod file;
 pub mod indexed;
@@ -25,16 +29,11 @@ pub mod persister;
 pub mod storage;
 
 // TODO
-// - Should we hard-code the Key, Val, Time, Diff types everywhere or introduce
-//   them as type parameters? Materialize will only be using one combination of
-//   them (two with `()` vals?) but the generality might make things easier to
-//   read. Of course, it also might make things harder to read.
 // - This method of getting the metadata handle ends up being pretty clunky in
 //   practice. Maybe instead the user should pass in a mutable reference to a
 //   `Meta` they've constructed like `probe_with`?
 // - Error handling. Right now, there are a bunch of `expect`s and this likely
 //   needs to hook into the error streams that Materialize hands around.
-// - What's our story with poisoned mutexes?
 // - Backward compatibility of persisted data, particularly the encoded keys and
 //   values.
 // - Restarting with a different number of workers.
@@ -55,6 +54,12 @@ pub mod storage;
 // Testing edge cases:
 // - Failure while draining from buffer into future.
 // - Equality edge cases around all the various timestamp/frontier checks.
+
+/// A type usable as a persisted key or value.
+///
+/// TODO: Replace Abomonation with something like an Encode+Decode trait.
+pub trait Data: Clone + Abomonation + fmt::Debug + Ord {}
+impl<T: Clone + Abomonation + fmt::Debug + Ord> Data for T {}
 
 /// An exclusivity token needed to construct persistence [operators].
 ///

--- a/src/persist/src/mem.rs
+++ b/src/persist/src/mem.rs
@@ -17,6 +17,7 @@ use ore::cast::CastFrom;
 
 use crate::error::Error;
 use crate::storage::{Blob, Buffer, Persister, SeqNo};
+use crate::Data;
 
 struct MemBufferCore {
     seqno: Range<SeqNo>,
@@ -289,7 +290,11 @@ impl MemRegistry {
 
     /// Opens the in-memory [Persister] associated with `path` or creates one if
     /// none exists.
-    pub fn open(&mut self, path: &str, lock_info: &str) -> Result<Persister, Error> {
+    pub fn open<K, V>(&mut self, path: &str, lock_info: &str) -> Result<Persister<K, V>, Error>
+    where
+        K: Data + Send + Sync + 'static,
+        V: Data + Send + Sync + 'static,
+    {
         let buffer = self.buffer(path, lock_info)?;
         let blob = self.blob(path, lock_info)?;
         Persister::new(buffer, blob)

--- a/src/persist/src/persister.rs
+++ b/src/persist/src/persister.rs
@@ -16,12 +16,19 @@ pub trait Snapshot<K, V> {
     ///
     /// Returns true if read needs to be called again for more data.
     fn read<E: Extend<((K, V), u64, isize)>>(&mut self, buf: &mut E) -> bool;
+}
 
+/// Extension methods on `Snapshot<K, V>` for use in tests.
+#[cfg(test)]
+pub trait SnapshotExt<K: Ord, V: Ord>: Snapshot<K, V> + Sized {
     /// A full read of the data in the snapshot.
-    #[cfg(test)]
-    fn read_to_end(&mut self) -> Vec<((K, V), u64, isize)> {
+    fn read_to_end(mut self) -> Vec<((K, V), u64, isize)> {
         let mut buf = Vec::new();
         while self.read(&mut buf) {}
+        buf.sort();
         buf
     }
 }
+
+#[cfg(test)]
+impl<K: Ord, V: Ord, S: Snapshot<K, V> + Sized> SnapshotExt<K, V> for S {}

--- a/src/persist/src/persister.rs
+++ b/src/persist/src/persister.rs
@@ -11,18 +11,17 @@
 
 /// An isolated, consistent read of previously written (Key, Value, Time, Diff)
 /// updates.
-pub trait Snapshot {
+pub trait Snapshot<K, V> {
     /// A partial read of the data in the snapshot.
     ///
     /// Returns true if read needs to be called again for more data.
-    fn read<E: Extend<((String, String), u64, isize)>>(&mut self, buf: &mut E) -> bool;
+    fn read<E: Extend<((K, V), u64, isize)>>(&mut self, buf: &mut E) -> bool;
 
     /// A full read of the data in the snapshot.
     #[cfg(test)]
-    fn read_to_end(&mut self) -> Vec<((String, String), u64, isize)> {
+    fn read_to_end(&mut self) -> Vec<((K, V), u64, isize)> {
         let mut buf = Vec::new();
         while self.read(&mut buf) {}
-        buf.sort();
         buf
     }
 }


### PR DESCRIPTION
String was used initially to make it easier to iterate without
constantly having to reason about generics, but it seems like things
have started to settle down.s