### PR TITLE
Extend predicate canonicalization to remove redundant IS NOT NULL predicates

### DIFF
--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -136,6 +136,10 @@ mod tests {
         match name {
             "ColumnKnowledge" => Ok(Box::new(transform::column_knowledge::ColumnKnowledge)),
             "Demand" => Ok(Box::new(transform::demand::Demand)),
+            "FilterFusion" => Ok(Box::new(transform::fusion::filter::Filter)),
+            "FoldConstants" => Ok(Box::new(transform::reduction::FoldConstants {
+                limit: None,
+            })),
             "JoinFusion" => Ok(Box::new(transform::fusion::join::Join)),
             "LiteralLifting" => Ok(Box::new(transform::map_lifting::LiteralLifting)),
             "NonNullRequirements" => Ok(Box::new(

--- a/src/transform/tests/testdata/filter
+++ b/src/transform/tests/testdata/filter
@@ -1,0 +1,65 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+cat
+(defsource x [int64 int64])
+----
+ok
+
+# Redundant IS NOT NULL predicate
+
+build apply=FilterFusion
+(filter (get x) [(call_unary not (call_unary is_null #0)) (call_binary eq #0 1)])
+----
+%0 =
+| Get x (u0)
+| Filter (#0 = 1)
+
+build apply=FilterFusion
+(filter (get x) [(call_unary not (call_unary is_null #1)) (call_binary eq #0 #1)])
+----
+%0 =
+| Get x (u0)
+| Filter (#0 = #1)
+
+build apply=FilterFusion
+(filter (filter (get x) [(call_unary not (call_unary is_null #0))]) [(call_binary eq #0 1)])
+----
+%0 =
+| Get x (u0)
+| Filter (#0 = 1)
+
+# Impossible condition detection
+
+build apply=FilterFusion
+(filter (filter (get x) [(call_unary is_null #0)]) [(call_binary eq #0 1)])
+----
+%0 =
+| Get x (u0)
+| Filter false, (#0 = 1)
+
+build apply=(FilterFusion,FoldConstants)
+(filter (filter (get x) [(call_unary is_null #0)]) [(call_binary eq #0 1)])
+----
+%0 =
+| Constant
+
+build apply=FilterFusion
+(filter (filter (get x) [(call_unary is_null #1)]) [(call_binary eq #0 #1)])
+----
+%0 =
+| Get x (u0)
+| Filter false, (#0 = #1)
+
+build apply=FilterFusion
+(filter (filter (get x) [(call_unary is_null #0)]) [(call_unary not (call_unary is_null #0))])
+----
+%0 =
+| Get x (u0)
+| Filter false, !(isnull(#0))

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -169,7 +169,7 @@ WHERE l1.la IN (
 
 %4 =
 | Get %2 (l0)
-| Filter !(isnull(#0)), (#0 = (#1 + 1))
+| Filter (#0 = (#1 + 1))
 
 %5 =
 | Get %2 (l0)

--- a/test/sqllogictest/transform/aggregation_nullability.slt
+++ b/test/sqllogictest/transform/aggregation_nullability.slt
@@ -811,7 +811,7 @@ EXPLAIN SELECT * FROM (SELECT 123, COUNT(right_table.f1) AS aggregate FROM t1 AS
 
 %1 =
 | Get materialize.public.t1 (u9)
-| Filter !(isnull(#0)), (0 = i32toi64(#0))
+| Filter (0 = i32toi64(#0))
 
 %2 =
 | Join %0 %1

--- a/test/sqllogictest/transform/is_null_propagation.slt
+++ b/test/sqllogictest/transform/is_null_propagation.slt
@@ -1,0 +1,111 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+mode cockroach
+
+statement ok
+CREATE TABLE t1 (f1 DOUBLE PRECISION, f2 DOUBLE PRECISION NOT NULL);
+
+statement ok
+CREATE TABLE t2 (f1 DOUBLE PRECISION, f2 DOUBLE PRECISION NOT NULL);
+
+query T multiline
+EXPLAIN SELECT FROM ( SELECT FROM t2 a1 RIGHT JOIN t2 ON a1.f1 IS NULL WHERE TRUE AND a1.f1 = a1.f2 )
+----
+%0 =
+| Constant
+
+EOF
+
+# TODO missing !isnull(#0) in %1
+query T multiline
+EXPLAIN SELECT FROM t1, t2 WHERE t1.f2 + t2.f1 = t1.f1 AND t2.f1 IS NOT NULL
+----
+%0 =
+| Get materialize.public.t1 (u1)
+| Filter !(isnull(#0))
+| ArrangeBy ()
+
+%1 =
+| Get materialize.public.t2 (u3)
+
+%2 =
+| Join %0 %1 (= #0 (#1 + #2))
+| | implementation = Differential %1 %0.()
+| | demand = ()
+| Project ()
+
+EOF
+
+query T multiline
+EXPLAIN SELECT FROM t1 WHERE f2 IN ( SELECT agg1 FROM ( SELECT COUNT ( TRUE ) agg1 FROM t2 a1 JOIN ( SELECT a2.f2 FROM t1 LEFT JOIN t1 a2 ON TRUE ) a2 ON TRUE WHERE  a2.f2 IS NOT NULL AND a2.f2 > a1.f2 ) )
+----
+%0 = Let l0 =
+| Get materialize.public.t1 (u1)
+| Distinct group=(#1)
+
+%1 =
+| Get materialize.public.t2 (u3)
+| ArrangeBy ()
+
+%2 =
+| Get %0 (l0)
+| ArrangeBy ()
+
+%3 =
+| Get materialize.public.t1 (u1)
+| ArrangeBy ()
+
+%4 =
+| Get materialize.public.t1 (u1)
+
+%5 = Let l1 =
+| Join %1 %2 %3 %4
+| | implementation = Differential %4 %1.() %2.() %3.()
+| | demand = (#1, #2, #6)
+| Filter (#6 > #1)
+| Reduce group=(#2)
+| | agg count(true)
+
+%6 =
+| Get materialize.public.t1 (u1)
+
+%7 =
+| Get %5 (l1)
+| Filter (#0 = i64tof64(#1))
+
+%8 =
+| Get %5 (l1)
+| Filter (#0 = 0)
+| Negate
+| Map 0
+| Project (#2)
+
+%9 =
+| Get %0 (l0)
+| Filter (#0 = 0)
+| Map 0
+| Project (#1)
+
+%10 =
+| Union %8 %9
+| Map 0
+
+%11 =
+| Union %7 %10
+| Distinct group=(#0)
+| ArrangeBy (#0)
+
+%12 =
+| Join %6 %11 (= #1 #2)
+| | implementation = Differential %6 %11.(#0)
+| | demand = ()
+| Project ()
+
+EOF

--- a/test/sqllogictest/transform/join_fusion.slt
+++ b/test/sqllogictest/transform/join_fusion.slt
@@ -261,16 +261,6 @@ WHERE a2.f1 + a1.f2 = (SELECT 1)
 AND a2.f1 IS NULL;
 ----
 %0 =
-| Get materialize.public.t1 (u1)
-| ArrangeBy ()
-
-%1 =
-| Get materialize.public.t1 (u1)
-| Filter isnull(#0)
-
-%2 =
-| Join %0 %1 (= 1 (#2 + #1))
-| | implementation = Differential %1 %0.()
-| | demand = (#0..#3)
+| Constant
 
 EOF

--- a/test/sqllogictest/transform/join_fusion.slt
+++ b/test/sqllogictest/transform/join_fusion.slt
@@ -32,7 +32,7 @@ EXPLAIN SELECT * FROM t1 INNER JOIN t2 ON t2.f2 = t1.f2 INNER JOIN t3 ON t1.f1 =
 ----
 %0 =
 | Get materialize.public.t1 (u1)
-| Filter !(isnull(#0)), !(isnull(#1)), (#0 > 0)
+| Filter !(isnull(#1)), (#0 > 0)
 | ArrangeBy (#0)
 
 %1 =
@@ -42,7 +42,7 @@ EXPLAIN SELECT * FROM t1 INNER JOIN t2 ON t2.f2 = t1.f2 INNER JOIN t3 ON t1.f1 =
 
 %2 =
 | Get materialize.public.t3 (u5)
-| Filter !(isnull(#0)), (#0 > 0)
+| Filter (#0 > 0)
 
 %3 =
 | Join %0 %1 %2 (= #0 #4) (= #1 #3)
@@ -211,7 +211,7 @@ EXPLAIN SELECT l_partkey AS col24843 , l_orderkey AS col24844 , l_partkey AS col
 
 %2 =
 | Get materialize.public.customer (u7)
-| Filter !(isnull(#0)), (#0 = 134)
+| Filter (#0 = 134)
 
 %3 =
 | Join %0 %1 %2 (= #4 #10) (= #6 #11)
@@ -241,7 +241,7 @@ EXPLAIN SELECT *
 
 %2 =
 | Get materialize.public.customer (u7)
-| Filter !(isnull(#0)), (#0 = 229)
+| Filter (#0 = 229)
 
 %3 =
 | Join %0 %1 %2 (= #4 #10) (= #5 #11)

--- a/test/sqllogictest/transform/join_index.slt
+++ b/test/sqllogictest/transform/join_index.slt
@@ -31,12 +31,12 @@ EXPLAIN PLAN FOR select * from foo inner join bar on foo.a = bar.a where foo.a =
 ----
 %0 =
 | Get materialize.public.foo (u1)
-| Filter !(isnull(#0)), (#0 = 1)
+| Filter (#0 = 1)
 | ArrangeBy ()
 
 %1 =
 | Get materialize.public.bar (u3)
-| Filter !(isnull(#0)), (#0 = 1)
+| Filter (#0 = 1)
 
 %2 =
 | Join %0 %1
@@ -59,12 +59,12 @@ EXPLAIN PLAN FOR select * from foo inner join bar on foo.a = abs(bar.a) where mo
 ----
 %0 =
 | Get materialize.public.foo (u1)
-| Filter !(isnull(#0)), (1 = (#0 % 2))
+| Filter (1 = (#0 % 2))
 | ArrangeBy (#0)
 
 %1 =
 | Get materialize.public.bar (u3)
-| Filter !(isnull(#0)), (1 = (abs(#0) % 2))
+| Filter (1 = (abs(#0) % 2))
 
 %2 =
 | Join %0 %1 (= #0 abs(#2))
@@ -92,12 +92,12 @@ EXPLAIN PLAN FOR select * from (select * from foo where a = 1) filtered_foo, bar
 ----
 %0 =
 | Get materialize.public.foo (u1)
-| Filter !(isnull(#0)), (#0 = 1)
+| Filter (#0 = 1)
 | ArrangeBy ()
 
 %1 =
 | Get materialize.public.bar (u3)
-| Filter !(isnull(#0)), (#0 = 1)
+| Filter (#0 = 1)
 
 %2 =
 | Join %0 %1

--- a/test/sqllogictest/transform/lifting.slt
+++ b/test/sqllogictest/transform/lifting.slt
@@ -694,7 +694,7 @@ explain select min(a) from t where a between 38 and 195 and a = (select a from t
 
 %1 =
 | Get materialize.public.t (u1)
-| Filter !(isnull(#0)), (#0 <= 195), (#0 >= 38)
+| Filter (#0 <= 195), (#0 >= 38)
 | ArrangeBy (#0)
 
 %2 =

--- a/test/sqllogictest/transform/predicate_pushdown.slt
+++ b/test/sqllogictest/transform/predicate_pushdown.slt
@@ -155,7 +155,7 @@ SELECT * FROM t1, t2 WHERE t1.f1 = t2.f1 AND t1.f2 = t2.f2 AND t1.f1 + t2.f2 = t
 | |   delta %0 %1.(#0, #1)
 | |   delta %1 %0.(#0, #1)
 | | demand = (#0, #1)
-| Filter !(isnull(#0)), !(isnull(#1)), ((#0 + #1) = (#0 + #1))
+| Filter ((#0 + #1) = (#0 + #1))
 | Project (#0, #1, #0, #1)
 
 EOF

--- a/test/sqllogictest/transform/predicate_reduction.slt
+++ b/test/sqllogictest/transform/predicate_reduction.slt
@@ -56,7 +56,7 @@ EXPLAIN SELECT * FROM t1 WHERE f1 is not null and (f1 is null or f1 = 1)
 ----
 %0 =
 | Get materialize.public.t1 (u1)
-| Filter !(isnull(#0)), (#0 = 1)
+| Filter (#0 = 1)
 
 EOF
 


### PR DESCRIPTION
Extracted from #7087.

Remove redundant IS NOT NULL predicates, probably added by some transformations, but that are already implicitly evaluated by other predicates in the same Filter operator, ie. the null values from the same subexpression are already rejected by another existing predicate.

I could add explicit unit tests after #7322 is merged.