### PR TITLE
Expose LIR planning to the coordinator

### DIFF
--- a/src/dataflow-types/src/explain.rs
+++ b/src/dataflow-types/src/explain.rs
@@ -91,7 +91,7 @@ impl<'a> Explanation<'a> {
             .map(|build_desc| {
                 (
                     build_desc.id,
-                    ViewExplanation::new(&build_desc.relation_expr, expr_humanizer),
+                    ViewExplanation::new(&build_desc.view, expr_humanizer),
                 )
             })
             .collect::<Vec<_>>();

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -70,7 +70,7 @@ pub type DataflowDesc = DataflowDescription<OptimizedMirRelationExpr>;
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct BuildDesc<View> {
     pub id: GlobalId,
-    pub relation_expr: View,
+    pub view: View,
 }
 
 /// A description of a dataflow to construct and results to surface.
@@ -153,10 +153,7 @@ impl DataflowDescription<OptimizedMirRelationExpr> {
         for get_id in view.global_uses() {
             self.record_depends_on(id, get_id);
         }
-        self.objects_to_build.push(BuildDesc {
-            id,
-            relation_expr: view,
-        });
+        self.objects_to_build.push(BuildDesc { id, view });
     }
 
     /// Exports as `id` an index on `on_id`.
@@ -264,7 +261,7 @@ impl DataflowDescription<OptimizedMirRelationExpr> {
         }
         for desc in self.objects_to_build.iter() {
             if &desc.id == id {
-                return desc.relation_expr.arity();
+                return desc.view.arity();
             }
         }
         panic!("GlobalId {} not found in DataflowDesc", id);

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -63,17 +63,19 @@ pub struct Update {
     pub diff: isize,
 }
 
-/// A description of view or index to be added to the local context
-/// for a dataflow
+/// A commonly used name for dataflows contain MIR expressions.
+pub type DataflowDesc = DataflowDescription<OptimizedMirRelationExpr>;
+
+/// An association of a global identifier to an expression.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct BuildDesc {
+pub struct BuildDesc<View> {
     pub id: GlobalId,
-    pub relation_expr: OptimizedMirRelationExpr,
+    pub relation_expr: View,
 }
 
 /// A description of a dataflow to construct and results to surface.
 #[derive(Clone, Debug, Default)]
-pub struct DataflowDesc {
+pub struct DataflowDescription<View> {
     /// Sources made available to the dataflow.
     pub source_imports: BTreeMap<GlobalId, (SourceDesc, GlobalId)>,
     /// Indexes made available to the dataflow.
@@ -81,7 +83,7 @@ pub struct DataflowDesc {
     /// Views and indexes to be built and stored in the local context.
     /// Objects must be built in the specific order, as there may be
     /// dependencies of later objects on prior identifiers.
-    pub objects_to_build: Vec<BuildDesc>,
+    pub objects_to_build: Vec<BuildDesc<View>>,
     /// Indexes to be made available to be shared with other dataflows
     /// (id of new index, description of index, relationtype of base source/view)
     pub index_exports: Vec<(GlobalId, IndexDesc, RelationType)>,
@@ -100,12 +102,18 @@ pub struct DataflowDesc {
     pub debug_name: String,
 }
 
-impl DataflowDesc {
+impl DataflowDescription<OptimizedMirRelationExpr> {
     /// Creates a new dataflow description with a human-readable name.
     pub fn new(name: String) -> Self {
-        DataflowDesc {
+        Self {
+            source_imports: Default::default(),
+            index_imports: Default::default(),
+            objects_to_build: Vec::new(),
+            index_exports: Default::default(),
+            sink_exports: Default::default(),
+            dependent_objects: Default::default(),
+            as_of: Default::default(),
             debug_name: name,
-            ..Default::default()
         }
     }
 
@@ -141,13 +149,13 @@ impl DataflowDesc {
     }
 
     /// Binds to `id` the relation expression `expr`.
-    pub fn insert_view(&mut self, id: GlobalId, expr: OptimizedMirRelationExpr) {
-        for get_id in expr.global_uses() {
+    pub fn insert_view(&mut self, id: GlobalId, view: OptimizedMirRelationExpr) {
+        for get_id in view.global_uses() {
             self.record_depends_on(id, get_id);
         }
         self.objects_to_build.push(BuildDesc {
             id,
-            relation_expr: expr,
+            relation_expr: view,
         });
     }
 
@@ -242,6 +250,28 @@ impl DataflowDesc {
         self.as_of = Some(as_of);
     }
 
+    /// The number of columns associated with an identifier in the dataflow.
+    pub fn arity_of(&self, id: &GlobalId) -> usize {
+        for (source_id, (desc, _orig_id)) in self.source_imports.iter() {
+            if source_id == id {
+                return desc.bare_desc.arity();
+            }
+        }
+        for (_index_id, (desc, typ)) in self.index_imports.iter() {
+            if &desc.on_id == id {
+                return typ.arity();
+            }
+        }
+        for desc in self.objects_to_build.iter() {
+            if &desc.id == id {
+                return desc.relation_expr.arity();
+            }
+        }
+        panic!("GlobalId {} not found in DataflowDesc", id);
+    }
+}
+
+impl<View> DataflowDescription<View> {
     /// Collects all indexes required to construct all exports.
     pub fn get_all_imports(&self) -> HashSet<GlobalId> {
         let mut result = HashSet::new();
@@ -270,26 +300,6 @@ impl DataflowDesc {
         }
         result.retain(|id| self.dependent_objects.get(id).is_none());
         result
-    }
-
-    /// The number of columns associated with an identifier in the dataflow.
-    pub fn arity_of(&self, id: &GlobalId) -> usize {
-        for (source_id, (desc, _orig_id)) in self.source_imports.iter() {
-            if source_id == id {
-                return desc.bare_desc.arity();
-            }
-        }
-        for (_index_id, (desc, typ)) in self.index_imports.iter() {
-            if &desc.on_id == id {
-                return typ.arity();
-            }
-        }
-        for desc in self.objects_to_build.iter() {
-            if &desc.id == id {
-                return desc.relation_expr.arity();
-            }
-        }
-        panic!("GlobalId {} not found in DataflowDesc", id);
     }
 }
 

--- a/src/dataflow/src/lib.rs
+++ b/src/dataflow/src/lib.rs
@@ -22,6 +22,7 @@ mod sink;
 pub mod logging;
 pub mod source;
 
+pub use render::plan::Plan;
 pub use server::{
     serve, Config, SequencedCommand, TimestampBindingFeedback, WorkerFeedback,
     WorkerFeedbackWithMeta,

--- a/src/dataflow/src/render/context.rs
+++ b/src/dataflow/src/render/context.rs
@@ -27,7 +27,7 @@ use timely::dataflow::{Scope, ScopeParent};
 use timely::progress::timestamp::Refines;
 use timely::progress::{Antichain, Timestamp};
 
-use dataflow_types::{DataflowDesc, DataflowError};
+use dataflow_types::{DataflowDescription, DataflowError};
 use expr::{GlobalId, Id, MapFilterProject, MirScalarExpr};
 use repr::{Row, RowArena};
 
@@ -89,7 +89,7 @@ where
     S::Timestamp: Lattice + Refines<T>,
 {
     /// Creates a new empty Context.
-    pub fn for_dataflow(dataflow: &DataflowDesc, dataflow_id: usize) -> Self {
+    pub fn for_dataflow<Plan>(dataflow: &DataflowDescription<Plan>, dataflow_id: usize) -> Self {
         let as_of_frontier = dataflow
             .as_of
             .clone()

--- a/src/dataflow/src/render/join/delta_join.rs
+++ b/src/dataflow/src/render/join/delta_join.rs
@@ -38,7 +38,7 @@ use crate::render::join::{JoinBuildState, JoinClosure};
 /// in arrangements for other join inputs. These lookups require specific
 /// instructions about which expressions to use as keys. Along the way,
 /// various closures are applied to filter and project as early as possible.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct DeltaJoinPlan {
     /// The set of path plans.
     ///
@@ -48,7 +48,7 @@ pub struct DeltaJoinPlan {
 }
 
 /// A delta query path is implemented by a sequences of stages,
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct DeltaPathPlan {
     /// The relation whose updates seed the dataflow path.
     source_relation: usize,
@@ -65,7 +65,7 @@ pub struct DeltaPathPlan {
 }
 
 /// A delta query stage performs a stream lookup into an arrangement.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct DeltaStagePlan {
     /// The relation index into which we will look up.
     lookup_relation: usize,

--- a/src/dataflow/src/render/join/linear_join.rs
+++ b/src/dataflow/src/render/join/linear_join.rs
@@ -30,7 +30,7 @@ use crate::render::datum_vec::DatumVec;
 use crate::render::join::{JoinBuildState, JoinClosure};
 
 // TODO(mcsherry): Identical to `DeltaPathPlan`; consider unifying.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct LinearJoinPlan {
     /// The source relation from which we start the join.
     source_relation: usize,
@@ -47,7 +47,7 @@ pub struct LinearJoinPlan {
 }
 
 // TODO(mcsherry): Identical to `DeltaStagePlan`; consider unifying.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct LinearStagePlan {
     /// The relation index into which we will look up.
     lookup_relation: usize,

--- a/src/dataflow/src/render/join/mod.rs
+++ b/src/dataflow/src/render/join/mod.rs
@@ -39,7 +39,7 @@ pub use delta_join::DeltaJoinPlan;
 pub use linear_join::LinearJoinPlan;
 
 /// A complete enumeration of possible join plans to render.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum JoinPlan {
     Linear(LinearJoinPlan),
     Delta(DeltaJoinPlan),
@@ -51,7 +51,7 @@ pub enum JoinPlan {
 /// as there is a relationship between the borrowed lifetime of the closed-over
 /// state and the arguments it takes when invoked. It was not clear how to do
 /// this with a Rust closure (glorious battle was waged, but ultimately lost).
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 struct JoinClosure {
     ready_equivalences: Vec<Vec<MirScalarExpr>>,
     before: expr::SafeMfpPlan,

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -309,7 +309,7 @@ where
         object: BuildDesc<plan::Plan>,
     ) {
         // First, transform the relation expression into a render plan.
-        let bundle = self.render_plan(object.relation_expr, scope, scope.index());
+        let bundle = self.render_plan(object.view, scope, scope.index());
         self.insert_id(Id::Global(object.id), bundle);
     }
 
@@ -971,7 +971,7 @@ pub mod plan {
                 .into_iter()
                 .map(|build| dataflow_types::BuildDesc {
                     id: build.id,
-                    relation_expr: Self::from_mir(&build.relation_expr)
+                    view: Self::from_mir(&build.view)
                         .expect("Dataflow finalization failed to produce plan"),
                 })
                 .collect::<Vec<_>>();

--- a/src/dataflow/src/render/reduce.rs
+++ b/src/dataflow/src/render/reduce.rs
@@ -584,7 +584,7 @@ where
 }
 
 /// Plan for extracting keys and values in preparation for a reduction.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct KeyValPlan {
     /// Extracts the columns used as the key.
     key_plan: expr::SafeMfpPlan,

--- a/src/dataflow/src/render/threshold.rs
+++ b/src/dataflow/src/render/threshold.rs
@@ -36,7 +36,7 @@ use crate::render::context::CollectionBundle;
 use crate::render::context::{ArrangementFlavor, Context};
 
 /// A plan describing how to compute a threshold operation.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum ThresholdPlan {
     /// Basic threshold maintains all positive inputs.
     Basic(BasicThresholdPlan),
@@ -45,7 +45,7 @@ pub enum ThresholdPlan {
 }
 
 /// A plan to maintain all inputs with positive counts.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct BasicThresholdPlan {
     /// The number of columns in the input and output.
     arity: usize,
@@ -53,7 +53,7 @@ pub struct BasicThresholdPlan {
 
 /// A plan to maintain all inputs with negative counts, which are subtracted from the output
 /// in order to maintain an equivalent collection compared to [BasicThresholdPlan].
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct RetractionsThresholdPlan {
     /// The number of columns in the input and output.
     arity: usize,

--- a/src/dataflow/src/render/top_k.rs
+++ b/src/dataflow/src/render/top_k.rs
@@ -33,7 +33,7 @@ use crate::render::context::CollectionBundle;
 use crate::render::context::Context;
 
 /// A plan encapsulating different variants to compute a TopK operation.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum TopKPlan {
     /// A plan for Top1 for monotonic inputs.
     MonotonicTop1(MonotonicTop1Plan),
@@ -109,7 +109,7 @@ impl TopKPlan {
 /// differential's semantics. (2) is especially interesting because Kafka is
 /// monotonic with an ENVELOPE of NONE, which is the default for ENVELOPE in
 /// Materialize and commonly used by users.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct MonotonicTop1Plan {
     /// The columns that form the key for each group.
     group_key: Vec<usize>,
@@ -118,7 +118,7 @@ pub struct MonotonicTop1Plan {
 }
 
 /// A plan for monotonic TopKs with an offset of 0 and an arbitrary limit.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct MonotonicTopKPlan {
     /// The columns that form the key for each group.
     group_key: Vec<usize>,
@@ -132,7 +132,7 @@ pub struct MonotonicTopKPlan {
 }
 
 /// A plan for generic TopKs that don't fit any more specific category.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct BasicTopKPlan {
     /// The columns that form the key for each group.
     group_key: Vec<usize>,

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -32,8 +32,8 @@ use tokio::sync::mpsc;
 
 use dataflow_types::logging::LoggingConfig;
 use dataflow_types::{
-    Consistency, DataflowDesc, DataflowError, ExternalSourceConnector, MzOffset, PeekResponse,
-    SourceConnector, TimestampSourceUpdate, Update,
+    Consistency, DataflowDescription, DataflowError, ExternalSourceConnector, MzOffset,
+    PeekResponse, SourceConnector, TimestampSourceUpdate, Update,
 };
 use expr::{GlobalId, PartitionId, RowSetFinishing};
 use ore::now::NowFn;
@@ -43,7 +43,7 @@ use crate::arrangement::manager::{TraceBundle, TraceManager};
 use crate::logging;
 use crate::logging::materialized::MaterializedEvent;
 use crate::operator::CollectionExt;
-use crate::render::{self, RenderState};
+use crate::render::{self, plan::Plan as RenderPlan, RenderState};
 use crate::server::metrics::Metrics;
 use crate::source::timestamp::TimestampBindingRc;
 
@@ -57,7 +57,7 @@ static TS_BINDING_FEEDBACK_INTERVAL_MS: u128 = 1_000;
 #[derive(Clone, Debug)]
 pub enum SequencedCommand {
     /// Create a sequence of dataflows.
-    CreateDataflows(Vec<DataflowDesc>),
+    CreateDataflows(Vec<DataflowDescription<RenderPlan>>),
     /// Drop the sources bound to these names.
     DropSources(Vec<GlobalId>),
     /// Drop the sinks bound to these names.


### PR DESCRIPTION
This PR teaches the coordinator to invoke LIR planning, which it does before transmitting a dataflow description to workers. This transformation is done ahead of the workers so that they do less deciding themselves, and also so that the coordinator is informed about how to invoke this planning itself so that it can report actual dataflow plans to interested users.

There is follow-up work of having the plans provide more information about themselves, which requires thinking harder about the indexes that have been made available (and probably discarding ones that are deemed useless, in the process). The render plans have no opinion on how they should be displayed, and interested persons may want to copy/paste the `Display` implementation for `MirRelationExpression`, or whatever we use at the moment.