### PR TITLE
expr: support jsonb_typeof for integers

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -2684,6 +2684,7 @@ fn jsonb_typeof<'a>(a: Datum<'a>) -> Datum<'a> {
         Datum::List(_) => Datum::String("array"),
         Datum::String(_) => Datum::String("string"),
         Datum::Float64(_) => Datum::String("number"),
+        Datum::Int64(_) => Datum::String("number"),
         Datum::True | Datum::False => Datum::String("boolean"),
         Datum::JsonNull => Datum::String("null"),
         Datum::Null => Datum::Null,

--- a/test/sqllogictest/jsonb.slt
+++ b/test/sqllogictest/jsonb.slt
@@ -944,6 +944,11 @@ statement ok
 DROP TABLE json_family
 
 query T
+SELECT jsonb_typeof('-123'::JSON)
+----
+number
+
+query T
 SELECT jsonb_typeof('-123.4'::JSON)
 ----
 number


### PR DESCRIPTION
JSONB numbers can sometimes be represented internally as Int64 since #6126, but this case was missing in the pattern match inside`jsonb_typeof`.

Fix #7345.