### PR TITLE
s3 sources: Handle empty objects for gzip sources

### DIFF
--- a/src/dataflow/src/source/s3.rs
+++ b/src/dataflow/src/source/s3.rs
@@ -628,7 +628,9 @@ async fn download_object(
 
         match reader.read_to_end(&mut buf).await {
             Ok(_) => {
-                let activate = !buf.is_empty();
+                if buf.is_empty() {
+                    return (DownloadStatus::Ok, None);
+                }
 
                 let bytes_read = buf.len() as u64;
 
@@ -683,9 +685,7 @@ async fn download_object(
                         download_status = DownloadStatus::SendFailed;
                     }
                 }
-                if activate {
-                    activator.activate().expect("s3 reader activation failed");
-                }
+                activator.activate().expect("s3 reader activation failed");
                 (
                     download_status,
                     Some(DownloadMetricUpdate {

--- a/test/testdrive/esoteric/s3-gzip.td
+++ b/test/testdrive/esoteric/s3-gzip.td
@@ -45,6 +45,9 @@ b3 6
 
 $ s3-create-bucket bucket=gzip-compression
 
+# ensure that we can handle empty objects
+$ s3-put-object bucket=gzip-compression key=short/
+
 $ s3-put-object bucket=gzip-compression key=short/compressed compression=gzip
 a1
 a2


### PR DESCRIPTION
S3 allows empty objects, and if you use their UI to create folders[1] it will automatically create empty objects for you.

This is fine for uncompressed objects where we will simply iterate over nothing, but the gzip decompressor we use will throw an error if you try to decompress nothing.

So, since there is no reason to do anything in that loop we skip everything in the decode loop
if the object is empty.

Resolves #7350 

1: https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-folders.html