### PR TITLE
persist: remove SeqNo from Future batches

### DIFF
--- a/src/persist/src/storage.rs
+++ b/src/persist/src/storage.rs
@@ -41,6 +41,9 @@ pub trait Buffer {
 
     /// Returns a consistent snapshot of all written but not yet truncated
     /// entries.
+    ///
+    /// - Invariant: all returned entries must have a sequence number within
+    ///   the declared [lower, upper) range of sequence numbers.
     fn snapshot<F>(&self, logic: F) -> Result<Range<SeqNo>, Error>
     where
         F: FnMut(SeqNo, &[u8]) -> Result<(), Error>;


### PR DESCRIPTION
Still need to figure out a way to test the new sanity checks in `drain_buf` but this will be a good simplicity win for consolidating / compacting