### PR TITLE
[sql] enlarge left argument to avoid overflow

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -5183,7 +5183,7 @@ fn position<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
 
 fn left<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let string: &'a str = a.unwrap_str();
-    let n = b.unwrap_int32();
+    let n = i64::from(b.unwrap_int32());
 
     let mut byte_indices = string.char_indices().map(|(i, _)| i);
 


### PR DESCRIPTION
The `left` function was crashing on a test case, owing to overflow when negating. Argument enlarged to a `i64` before doing that avoids the problem.