### PR TITLE
Lowering: Fix multiplicity error 

### DIFF
--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -1328,7 +1328,9 @@ impl MirRelationExpr {
     /// Return:
     /// * every row in keys_and_values
     /// * every row in `self` that does not have a matching row in the first columns of `keys_and_values`, using `default` to fill in the remaining columns
-    /// (If `default` is a row of nulls, this is LEFT OUTER JOIN)
+    /// (This is LEFT OUTER JOIN if:
+    /// 1) `default` is a row of null
+    /// 2) matching rows in `keys_and_values` and `self` have the same multiplicity.)
     pub fn lookup(
         self,
         id_gen: &mut IdGen,

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -623,7 +623,7 @@ impl HirScalarExpr {
             // When the subquery would return 0 rows for some row in the outer query, `subquery.applied_to(get_inner)` will not have any corresponding row.
             // Use `lookup` if you need to add default values for cases when the subquery returns 0 rows.
             Exists(expr) => {
-                let apply_requires_distinct_outer = false;
+                let apply_requires_distinct_outer = true;
                 *inner = branch(
                     id_gen,
                     inner.take_dangerous(),

--- a/test/sqllogictest/subquery.slt
+++ b/test/sqllogictest/subquery.slt
@@ -665,3 +665,11 @@ FROM (SELECT 1 col1)
 
 query error aggregate functions that refer exclusively to outer columns not yet supported
 SELECT (SELECT count(likes.likee)) FROM likes
+
+# Regression test for #7121, where the multiplicity of the outer query was not
+# preserved when an EXISTS subquery only involves constants/mpf/flatmaps.
+query I
+SELECT x FROM xs WHERE EXISTS (SELECT y FROM (SELECT 1 as y) WHERE x = y)
+----
+1
+1


### PR DESCRIPTION
Closes #7121

`exists(bar).applied_to(foo)`, when `bar` is "simple", was being converted to: 
```
bar.applied_to(foo).distinct_by(foo_cols).map(true) 
union
(foo join 
   (distinct(foo) - (bar.applied_to(foo)).distinct_by(foo_cols))
).map(false)
```
This caused the loss of all but one copy of each row for where `exists(bar)`.

The correct conversion should be
```
(foo join 
  bar.applied_to(foo).distinct_by(foo_cols)
).map(true) 
union
(foo join 
   (distinct(foo) - (bar.applied_to(foo)).distinct_by(foo_cols))
).map(false)
```