### PR TITLE
[dataflow] Consolidate the results of key_val mapping

### DIFF
--- a/src/dataflow/src/render/reduce.rs
+++ b/src/dataflow/src/render/reduce.rs
@@ -705,11 +705,14 @@ where
         });
 
         // Demux out the potential errors from key and value selector evaluation.
+        use differential_dataflow::operators::consolidate::ConsolidateStream;
         use timely::dataflow::operators::ok_err::OkErr;
         let (ok, err) = key_val_input.ok_err(|x| x);
 
         let ok_input = ok.as_collection();
         err_input = err.as_collection().concat(&err_input);
+
+        let ok_input = ok_input.consolidate_stream();
 
         // Render the reduce plan
         reduce_plan.render(ok_input, err_input, key_arity)


### PR DESCRIPTION
The first step in `Reduce` planning is to extract the key and value from the input record. This is a moment where there could be a dramatic reduction in the number of distinct records, and is specifically the case for `COUNT(*)` queries. This PR adds a `consolidate_stream` operator, a low cost consolidation operator, right after the key and value extraction.

This results in a 3x performance improvement for counting for me, from
```sql
materialize=> select count(*) from fits_items;
  count   
----------
 62559351
(1 row)
Time: 12289.791 ms (00:12.290)
```
to
```sql
materialize=> select count(*) from fits_items;
  count   
----------
 62559351
(1 row)

Time: 3962.189 ms (00:03.962)
materialize=> 
```

There is more to do, in that the consolidation could be moved just upwards to avoid moving all the records through the `ok_err` operator, though the types do not currently permit this. More generally, we would like to fuse the `explode` action as early as possible, because at that moment we can perform all of the data reduction (at the moment, we shuffle unconsolidated data into and out of various operators).