### PR TITLE
persist: add initial simple invariant-based random tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2737,6 +2737,7 @@ dependencies = [
  "differential-dataflow",
  "log",
  "ore",
+ "rand",
  "tempfile",
  "timely",
 ]

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -26,4 +26,5 @@ timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-fe
 
 [dev-dependencies]
 criterion = "0.3.4"
+rand = { version = "0.8.4", features = [ "small_rng" ] }
 tempfile = "3.2.0"

--- a/src/persist/src/lib.rs
+++ b/src/persist/src/lib.rs
@@ -24,6 +24,8 @@ pub mod error;
 pub mod file;
 pub mod indexed;
 pub mod mem;
+#[cfg(test)]
+pub mod nemesis;
 pub mod operators;
 pub mod storage;
 

--- a/src/persist/src/nemesis/direct.rs
+++ b/src/persist/src/nemesis/direct.rs
@@ -1,0 +1,132 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::sync::mpsc;
+
+use crate::error::Error;
+use crate::indexed::runtime::{self, RuntimeClient, StreamReadHandle, StreamWriteHandle};
+use crate::indexed::{IndexedSnapshot, Snapshot};
+use crate::mem::{MemBlob, MemBuffer};
+use crate::nemesis::{
+    Input, ReadSnapshotReq, ReadSnapshotRes, Req, Res, Runtime, SealReq, SnapshotId, Step,
+    TakeSnapshotReq, WriteReq, WriteRes,
+};
+
+pub struct Direct {
+    persister: RuntimeClient<String, ()>,
+    streams: HashMap<String, (StreamWriteHandle<String, ()>, StreamReadHandle<String, ()>)>,
+    snapshots: HashMap<SnapshotId, IndexedSnapshot<String, ()>>,
+}
+
+impl Runtime for Direct {
+    fn run(&mut self, i: Input) -> Step {
+        let res = match i.req {
+            Req::Write(req) => Res::Write(req.clone(), self.write(req)),
+            Req::Seal(req) => Res::Seal(req.clone(), self.seal(req)),
+            Req::TakeSnapshot(req) => Res::TakeSnapshot(req.clone(), self.take_snapshot(req)),
+            Req::ReadSnapshot(req) => Res::ReadSnapshot(req.clone(), self.read_snapshot(req)),
+        };
+        Step {
+            req_id: i.req_id,
+            res,
+        }
+    }
+
+    fn finish(self) {}
+}
+
+impl Direct {
+    pub fn new(lock_info: &str) -> Result<Self, Error> {
+        let buffer = MemBuffer::new(lock_info)?;
+        let blob = MemBlob::new(lock_info)?;
+        let persister = runtime::start(buffer, blob)?;
+        Ok(Direct {
+            persister,
+            streams: HashMap::new(),
+            snapshots: HashMap::new(),
+        })
+    }
+
+    fn stream(
+        &mut self,
+        name: &str,
+    ) -> &mut (StreamWriteHandle<String, ()>, StreamReadHandle<String, ()>) {
+        let (streams, persister) = (&mut self.streams, &mut self.persister);
+        streams.entry(name.to_string()).or_insert_with(|| {
+            persister
+                .create_or_load(name)
+                .expect("we only ever register once")
+                .into_inner()
+        })
+    }
+
+    fn write(&mut self, req: WriteReq) -> Result<WriteRes, Error> {
+        let (write, _) = self.stream(&req.stream);
+        let (tx, rx) = mpsc::channel();
+        write.write(&[req.update], tx.into());
+        let seqno = rx.recv().map_err(|_| Error::RuntimeShutdown)??.0;
+        Ok(WriteRes { seqno })
+    }
+
+    fn seal(&mut self, req: SealReq) -> Result<(), Error> {
+        let (write, _) = self.stream(&req.stream);
+        let (tx, rx) = mpsc::channel();
+        write.seal(req.ts, tx.into());
+        rx.recv().map_err(|_| Error::RuntimeShutdown)?
+    }
+
+    fn take_snapshot(&mut self, req: TakeSnapshotReq) -> Result<(), Error> {
+        let (_, meta) = self.stream(&req.stream);
+        let snap = meta.snapshot()?;
+        match self.snapshots.entry(req.snap) {
+            Entry::Occupied(x) => {
+                return Err(format!(
+                    "internal nemesis error: duplicate snapshot id {:?}",
+                    x.key()
+                )
+                .into())
+            }
+            Entry::Vacant(x) => {
+                x.insert(snap);
+            }
+        }
+        Ok(())
+    }
+
+    fn read_snapshot(&mut self, req: ReadSnapshotReq) -> Result<ReadSnapshotRes, Error> {
+        let mut snap = match self.snapshots.remove(&req.snap) {
+            Some(snap) => snap,
+            None => return Err(format!("unknown snap: {:?}", req.snap).into()),
+        };
+        let mut contents = Vec::new();
+        while snap.read(&mut contents) {}
+        Ok(ReadSnapshotRes {
+            seqno: snap.seqno().0,
+            contents,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::nemesis;
+
+    use super::*;
+
+    // TODO: Un-ignore this once the bugs it's catching are fixed.
+    #[test]
+    #[ignore]
+    fn direct_mem() {
+        nemesis::run(100, || {
+            Direct::new("direct_mem").expect("new empty persist runtime is infallible")
+        })
+    }
+}

--- a/src/persist/src/nemesis/generator.rs
+++ b/src/persist/src/nemesis/generator.rs
@@ -1,0 +1,95 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use rand::prelude::SmallRng;
+use rand::{Rng, SeedableRng};
+
+use crate::nemesis::{
+    Input, ReadSnapshotReq, Req, ReqId, SealReq, SnapshotId, TakeSnapshotReq, WriteReq,
+};
+
+pub struct Generator {
+    seed: u64,
+    req_id: u64,
+    snap_id: u64,
+}
+
+// TODO: Make Generator configurable, so individual tests can be written to
+// stress interesting combinations of random traffic.
+impl Generator {
+    pub fn from_seed(seed: u64) -> Self {
+        Generator {
+            seed,
+            req_id: 0,
+            snap_id: 0,
+        }
+    }
+
+    pub fn gen(&mut self) -> Input {
+        let req_id = ReqId(self.req_id);
+        self.req_id += 1;
+        let mut rng = SmallRng::seed_from_u64(self.seed + req_id.0);
+        let req = loop {
+            break match rng.gen_range(0..=3) {
+                0 => {
+                    let stream = rng.gen_range(0..5).to_string();
+                    let key = rng.gen_range('a'..'e').to_string();
+                    // TODO: dd/timely allow for a lot of generality here, but
+                    // mz sources mostly just introduce data in order. Once the
+                    // Generator is made more configurable, we should probably
+                    // break this into two buckets, each modeled separately.
+                    // First is one that picks a time within +N of the current
+                    // capability of the input. Second is one that picks a time
+                    // less than the current input (which should receive an
+                    // error when run).
+                    let ts = rng.gen_range(0..100);
+                    // TODO: Tables and sources generally will be using -1 and
+                    // 1. 0, -2, and 2 might find some more interesting edge
+                    // cases. Is it worth expanding this to something with a
+                    // wider range (and possibly a non-uniform distribution)
+                    // once we start thinking of operator persistence? Perhaps
+                    // overflows, what else might be relevant here then?
+                    let diff = rng.gen_range(-2..=2);
+                    Req::Write(WriteReq {
+                        stream,
+                        update: ((key, ()), ts, diff),
+                    })
+                }
+                1 => {
+                    let stream = rng.gen_range(0..5).to_string();
+                    let ts = rng.gen_range(0..100);
+                    Req::Seal(SealReq { stream, ts })
+                }
+                2 => {
+                    let stream = rng.gen_range(0..5).to_string();
+                    let snap = SnapshotId(self.snap_id);
+                    self.snap_id += 1;
+                    Req::TakeSnapshot(TakeSnapshotReq { stream, snap })
+                }
+                3 => {
+                    if self.snap_id == 0 {
+                        continue;
+                    }
+                    let snap = SnapshotId(rng.gen_range(0..self.snap_id));
+                    Req::ReadSnapshot(ReadSnapshotReq { snap })
+                }
+                _ => unreachable!(),
+            };
+        };
+        Input { req_id, req }
+    }
+}
+
+impl Iterator for Generator {
+    type Item = Input;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        Some(self.gen())
+    }
+}

--- a/src/persist/src/nemesis/mod.rs
+++ b/src/persist/src/nemesis/mod.rs
@@ -1,0 +1,213 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Invariant-based random tests for the persist crate.
+//!
+//! This module generates random traffic against the external API of the persist
+//! crate. It records the requests sent and responses received and afterward
+//! checks this history against the API invariants.
+//!
+//! API traffic is modeled as a series of [Input]s. These are created by a
+//! [Generator], which is totally deterministic given a seed. The [Input]s are
+//! handed to an implementation of [Runtime] which executes the embedded [Req]
+//! and saves the [Res] wrapped up with metadata about the execution into a
+//! [Step]. These steps collectively form a history, which is handed to
+//! [Validator] to check for API invariant violations (representing a bug in the
+//! persist crate).
+//!
+//! The initial Runtime implementation is [Direct].
+//!
+//! Several of these components can be configured. Particularly interesting
+//! combinations of these are committed as unit tests. By default, these unit
+//! tests all select and use a random seed for traffic generation. This runs the
+//! test randomly once and is of limited usefulness.
+//!
+//! ```shell
+//! cargo test -p persist -- nemesis
+//! ```
+//!
+//! The seed is printed when the test is run and override-able, so if a test
+//! does fail (persist violated one of its invariants aka a bug), the previous
+//! traffic can be exactly replayed. For a deterministic runtime (the "direct_*"
+//! variants) this results in exactly the same execution sequence and can be
+//! used to verify the bug fix.
+//!
+//! ```shell
+//! NEMESIS_SEED=16385522461931935384 cargo test -p persist -- failing_test_name
+//! ```
+//!
+//! If the runtime is not deterministic, the seed can still be fixed to increase
+//! the likelihood of ticking the same bug again. The cargo-stress crate, which
+//! runs a unit test (or set of tests) in a tight loop until failure, is useful
+//! for this.
+//!
+//! ```shell
+//! NEMESIS_SEED=16385522461931935384 cargo stress -p persist -- failing_test_name
+//! ```
+//!
+//! Finally, the cargo-stress crate is also useful without fixing the seed to
+//! search for new invariant violations. This repeatedly runs all nemesis tests,
+//! each with new random traffic to maximize the chances of finding an
+//! interesting history.
+//!
+//! ```shell
+//! cargo stress -p persist -- nemesis
+//! ```
+
+// TODO
+// - Variant with FileBuffer and FileBlob
+// - Variant with S3Blob
+// - Variant with mz-like traffic distribution (write-heavy/snapshot-light)
+// - Impl of Runtime with Timely workers running in threads
+// - Impl of Runtime with Timely workers running in processes
+// - Restarting workers
+// - Advancing the compaction frontier
+// - Configurable Generator
+// - Storage (buffer/blob) downtime via a shim implementation
+// - Storage (buffer/blob) with variable latency/slow requests
+// - Vary key size
+// - Non-uniform (zipfian) distribution of keys (any other distributions?)
+// - Deleting streams
+
+use std::env;
+
+use rand::rngs::OsRng;
+use rand::RngCore;
+
+use crate::error::Error;
+use crate::nemesis::generator::Generator;
+use crate::nemesis::validator::Validator;
+
+mod direct;
+mod generator;
+mod validator;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReqId(u64);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct SnapshotId(u64);
+
+/// A single logical operator to run against the persist API.
+///
+/// This attempts to give the ability to tickle edge cases while maintaining as
+/// much determinism as possible. For example, an actual persist user would
+/// receive a snapshot as an in-memory object and immediately read it. To stress
+/// race conditions between snapshots and various write/compaction/etc operators
+/// as well as eventually the edge cases around the still TODO disk-backed LRU
+/// cache for the persisted data, snapshots are modeled here as two requests.
+/// One takes a snapshot and registers it with a known id in a nemesis-specific
+/// snapshot registry. The second removes this snapshot from the registry, reads
+/// the contents, and returns them. This allows us to insert whatever other
+/// `Input`s we like in between them.
+#[derive(Clone, Debug)]
+pub struct Input {
+    req_id: ReqId,
+    req: Req,
+}
+
+#[derive(Debug)]
+pub struct Step {
+    req_id: ReqId,
+    res: Res,
+}
+
+#[derive(Clone, Debug)]
+pub enum Req {
+    Write(WriteReq),
+    Seal(SealReq),
+    TakeSnapshot(TakeSnapshotReq),
+    ReadSnapshot(ReadSnapshotReq),
+}
+
+#[derive(Debug)]
+pub enum Res {
+    Write(WriteReq, Result<WriteRes, Error>),
+    Seal(SealReq, Result<(), Error>),
+    TakeSnapshot(TakeSnapshotReq, Result<(), Error>),
+    ReadSnapshot(ReadSnapshotReq, Result<ReadSnapshotRes, Error>),
+}
+
+#[derive(Clone, Debug)]
+pub struct WriteReq {
+    stream: String,
+    update: ((String, ()), u64, isize),
+}
+
+#[derive(Clone, Debug)]
+pub struct WriteRes {
+    seqno: u64,
+}
+
+#[derive(Clone, Debug)]
+pub struct SealReq {
+    stream: String,
+    ts: u64,
+}
+
+#[derive(Clone, Debug)]
+pub struct TakeSnapshotReq {
+    stream: String,
+    snap: SnapshotId,
+}
+
+#[derive(Clone, Debug)]
+pub struct ReadSnapshotReq {
+    snap: SnapshotId,
+}
+
+#[derive(Clone, Debug)]
+pub struct ReadSnapshotRes {
+    seqno: u64,
+    contents: Vec<((String, ()), u64, isize)>,
+}
+
+pub trait Runtime {
+    fn run(&mut self, i: Input) -> Step;
+    fn finish(self);
+}
+
+pub struct Runner<R: Runtime> {
+    generator: Generator,
+    steps: Vec<Step>,
+    runtime: R,
+}
+
+impl<R: Runtime> Runner<R> {
+    pub fn new(seed: u64, runtime: R) -> Self {
+        Runner {
+            generator: Generator::from_seed(seed),
+            steps: Vec::new(),
+            runtime,
+        }
+    }
+
+    pub fn run(mut self, steps: usize) -> Vec<Step> {
+        for input in self.generator.take(steps) {
+            self.steps.push(self.runtime.run(input));
+        }
+        self.runtime.finish();
+        self.steps
+    }
+}
+
+pub fn run<R: Runtime, F: FnOnce() -> R>(steps: usize, new_runtime: F) {
+    let seed =
+        env::var("MZ_NEMESIS_SEED").map_or_else(|_| OsRng.next_u64(), |s| s.parse().unwrap());
+    eprintln!("MZ_NEMESIS_SEED={}", seed);
+    let runtime = new_runtime();
+    let runner = Runner::new(seed, runtime);
+    let history = runner.run(steps);
+    if let Err(errors) = Validator::validate(history) {
+        for err in errors.iter() {
+            eprintln!("invariant violation: {}", err)
+        }
+        assert!(errors.is_empty());
+    }
+}

--- a/src/persist/src/nemesis/validator.rs
+++ b/src/persist/src/nemesis/validator.rs
@@ -1,0 +1,150 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::{BTreeMap, HashMap};
+use std::fmt;
+
+use crate::error::Error;
+use crate::nemesis::{
+    ReadSnapshotReq, ReadSnapshotRes, ReqId, Res, SealReq, SnapshotId, Step, TakeSnapshotReq,
+    WriteReq, WriteRes,
+};
+use crate::storage::SeqNo;
+
+pub struct Validator {
+    sealed: HashMap<String, u64>,
+    writes_by_seqno: BTreeMap<(String, SeqNo), ((String, ()), u64, isize)>,
+    available_snapshots: HashMap<SnapshotId, String>,
+    errors: Vec<String>,
+}
+
+// TODO: Unit tests for Validator. This is already fairly complicatd and it's
+// only going to get more complicated as we add more checks for API invariants.
+impl Validator {
+    pub fn validate<I: IntoIterator<Item = Step>>(history: I) -> Result<(), Vec<String>> {
+        let mut v = Validator::new();
+        // TODO: We'll need a sort here once we start validating concurrent
+        // timelines. Also likely a before and after time for each
+        // request/response.
+        for step in history.into_iter() {
+            v.step(step);
+        }
+        v.finish()
+    }
+
+    fn new() -> Self {
+        Validator {
+            sealed: HashMap::new(),
+            writes_by_seqno: BTreeMap::new(),
+            available_snapshots: HashMap::new(),
+            errors: Vec::new(),
+        }
+    }
+
+    fn finish(self) -> Result<(), Vec<String>> {
+        if self.errors.is_empty() {
+            Ok(())
+        } else {
+            Err(self.errors)
+        }
+    }
+
+    fn step(&mut self, s: Step) {
+        // TODO: Figure out how to get the log crate working.
+        eprintln!("step: {:?}", &s);
+        match s.res {
+            Res::Write(req, res) => self.step_write(s.req_id, req, res),
+            Res::Seal(req, res) => self.step_seal(s.req_id, req, res),
+            Res::TakeSnapshot(req, res) => self.step_take_snapshot(s.req_id, req, res),
+            Res::ReadSnapshot(req, res) => self.step_read_snapshot(s.req_id, req, res),
+        }
+    }
+
+    fn check_success<T: fmt::Debug>(
+        &mut self,
+        req_id: ReqId,
+        res: &Result<T, Error>,
+        should_succeed: bool,
+    ) {
+        match (should_succeed, res) {
+            (true, Ok(_)) | (false, Err(_)) => {}
+            (true, Err(err)) => self.errors.push(format!(
+                "expected success but got error {:?}: {}",
+                req_id, err
+            )),
+            (false, Ok(res)) => self.errors.push(format!(
+                "expected error but got success {:?}: {:?}",
+                req_id, res
+            )),
+        }
+    }
+
+    fn step_write(&mut self, req_id: ReqId, req: WriteReq, res: Result<WriteRes, Error>) {
+        let should_succeed =
+            req.update.1 >= self.sealed.get(&req.stream).copied().unwrap_or_default();
+        self.check_success(req_id, &res, should_succeed);
+        if let Ok(res) = res {
+            self.writes_by_seqno
+                .insert((req.stream, SeqNo(res.seqno)), req.update);
+        }
+    }
+
+    fn step_seal(&mut self, req_id: ReqId, req: SealReq, res: Result<(), Error>) {
+        let should_succeed = req.ts > self.sealed.get(&req.stream).copied().unwrap_or_default();
+        self.check_success(req_id, &res, should_succeed);
+        if let Ok(_) = res {
+            self.sealed.insert(req.stream, req.ts);
+        }
+    }
+
+    fn step_take_snapshot(&mut self, req_id: ReqId, req: TakeSnapshotReq, res: Result<(), Error>) {
+        // At the moment, there are no nemeses that would prevent a snapshot
+        // from working, so we shouldn't see any errors.
+        let should_succeed = true;
+        self.check_success(req_id, &res, should_succeed);
+        if let Ok(_) = res {
+            self.available_snapshots.insert(req.snap, req.stream);
+        }
+    }
+
+    fn step_read_snapshot(
+        &mut self,
+        req_id: ReqId,
+        req: ReadSnapshotReq,
+        res: Result<ReadSnapshotRes, Error>,
+    ) {
+        match self.available_snapshots.remove(&req.snap) {
+            None => {
+                self.check_success(req_id, &res, false);
+            }
+            Some(stream) => {
+                self.check_success(req_id, &res, true);
+                if let Ok(res) = res {
+                    let mut actual = res.contents;
+                    actual.sort();
+                    let mut expected: Vec<((String, ()), u64, isize)> = self
+                        .writes_by_seqno
+                        .range((stream.clone(), SeqNo(0))..(stream, SeqNo(res.seqno)))
+                        .map(|(_, v)| v)
+                        .cloned()
+                        .collect();
+                    expected.sort();
+                    // TODO: We need to consolidate and account for since here once
+                    // that's supported in persist.
+                    if actual != expected {
+                        self.errors.push(format!(
+                            "incorrect snapshot {:?} expected {:?} got: {:?}",
+                            req_id, expected, actual
+                        ));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/persist/src/operators/input.rs
+++ b/src/persist/src/operators/input.rs
@@ -24,6 +24,7 @@ use timely::Data;
 use crate::error::Error;
 use crate::indexed::runtime::{CmdResponse, StreamReadHandle, StreamWriteHandle};
 use crate::indexed::Snapshot;
+use crate::storage::SeqNo;
 use crate::Token;
 
 /// A persistent equivalent of [UnorderedInput].
@@ -119,7 +120,7 @@ pub struct PersistentUnorderedSession<'b, K: timely::Data> {
 
 impl<'b, K: timely::Data> PersistentUnorderedSession<'b, K> {
     /// Transmits a single record after synchronously persisting it.
-    pub fn give(&mut self, data: (K, u64, isize), res: CmdResponse<()>) {
+    pub fn give(&mut self, data: (K, u64, isize), res: CmdResponse<SeqNo>) {
         let (tx, rx) = mpsc::channel();
         self.write
             .write(&[((data.0.clone(), ()), data.1, data.2)], tx.into());
@@ -168,7 +169,7 @@ mod tests {
             for _ in 1..=5 {
                 rx.recv()
                     .expect("runtime has not stopped")
-                    .expect("write was successful")
+                    .expect("write was successful");
             }
         });
 
@@ -193,7 +194,7 @@ mod tests {
             for _ in 6..=9 {
                 rx.recv()
                     .expect("runtime has not stopped")
-                    .expect("write was successful")
+                    .expect("write was successful");
             }
             recv
         });


### PR DESCRIPTION
This module generates random traffic against the external API of the
persist crate. It records the requests sent and responses received and
afterward checks this history against the API invariants.

API traffic is modeled as a series of [Input]s. These are created by a
[Generator], which is totally deterministic given a seed. The [Input]s
are handed to an implementation of [Runtime] which executes the embedded
[Req] and saves the [Res] wrapped up with metadata about the execution
into a [Step]. These steps collectively form a history, which is handed
to [Validator] to check for API invariant violations (representing a bug
in the persist crate).

The initial Runtime implementation is [Direct].

Several of these components can be configured. Particularly interesting
combinations of these are committed as unit tests. By default, these
unit tests all select and use a random seed for traffic generation. This
runs the test randomly once and is of limited usefulness.

    cargo test -p persist -- nemesis

The seed is printed when the test is run and override-able, so if a test
does fail (persist violated one of its invariants aka a bug), the
previous traffic can be exactly replayed. For a deterministic runtime
(the "direct_*" variants) this results in exactly the same execution
sequence and can be used to verify the bug fix.

    NEMESIS_SEED=16385522461931935384 cargo test -p persist -- failing_test_name

If the runtime is not deterministic, the seed can still be fixed to
increase the likelihood of ticking the same bug again. The cargo-stress
crate, which runs a unit test (or set of tests) in a tight loop until
failure, is useful for this.

    NEMESIS_SEED=16385522461931935384 cargo stress -p persist -- failing_test_name

Finally, the cargo-stress crate is also useful without fixing the seed
to search for new invariant violations. This repeatedly runs all nemesis
tests, each with new random traffic to maximize the chances of finding
an interesting history.

    cargo stress -p persist -- nemesis