### PR TITLE
update tokio to 1.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4484,9 +4484,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.6.1"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a38d31d7831c6ed7aad00aa4c12d9375fd225a6dd77da1d25b707346319a975"
+checksum = "98c8b05dc14c75ea83d63dd391100353789f5f24b8b3866542a5e85c8be8e985"
 dependencies = [
  "autocfg",
  "bytes",


### PR DESCRIPTION
fixes https://buildkite.com/materialize/security/builds/453#c684d090-eb8d-418c-ab21-783b7e75762b