### PR TITLE
materialized: account for changed semantics of JoinHandle::abort

### DIFF
--- a/src/materialized/tests/sql.rs
+++ b/src/materialized/tests/sql.rs
@@ -655,6 +655,10 @@ fn test_tail_shutdown() -> Result<(), Box<dyn Error>> {
         // Un-gracefully abort the connection.
         conn_task.abort();
 
+        // Need to await `conn_task` to actually deliver the `abort`. We don't
+        // care about the result though (it's probably `JoinError::Cancelled`).
+        let _ = conn_task.await;
+
         Ok::<_, Box<dyn Error>>(())
     })?;
 


### PR DESCRIPTION
tokio-rs/tokio#3934 changed the semantics of JoinHandle::abort such that
you have to await the underlying task to actually deliver the abort. Do
so, to fix a stall in `test_tail_shutdown` caused by the connection not
actually getting aborted.