### PR TITLE
kafka-matrix: stabilize and update test

### DIFF
--- a/test/kafka-matrix/mzcompose.yml
+++ b/test/kafka-matrix/mzcompose.yml
@@ -16,7 +16,10 @@ mzworkflows:
         workflow: kafka-latest
 
       - step: workflow
-        workflow: kafka-6_1_0
+        workflow: kafka-6_2_0
+
+      - step: workflow
+        workflow: kafka-6_1_2
 
       - step: workflow
         workflow: kafka-6_0_2
@@ -34,12 +37,20 @@ mzworkflows:
       - step: workflow
         workflow: test-kafka
 
-  kafka-6_1_0:
+  kafka-6_2_0:
     env:
-      KAFKA_VERSION: 6.1.0
+      KAFKA_VERSION: 6.2.0
     steps:
       - step: workflow
         workflow: test-kafka
+
+  kafka-6_1_2:
+    env:
+      KAFKA_VERSION: 6.1.2
+    steps:
+      - step: workflow
+        workflow: test-kafka
+
 
   kafka-6_0_2:
     env:
@@ -76,14 +87,26 @@ mzworkflows:
   start-deps:
     steps:
       - step: start-services
-        services: [kafka, schema-registry, materialized]
+        services: [zookeeper]
+      - step: wait-for-tcp
+        host: zookeeper
+        port: 2181
+
+      - step: start-services
+        services: [kafka]
       - step: wait-for-tcp
         host: kafka
         port: 9092
         timeout_secs: 120
+
+      - step: start-services
+        services: [schema-registry]
       - step: wait-for-tcp
         host: schema-registry
         port: 8081
+
+      - step: start-services
+        services: [materialized]
       - step: wait-for-mz
 
 services:


### PR DESCRIPTION
- start each participating service sequentially to avoid
  a race condition where Materialize starts up before Kafka
  is fully up.

- update the configuration so that 6.1.2 and 6.2.0 are tested.