### PR TITLE
persist: return errors reading snapshot as a stream

### DIFF
--- a/src/persist/src/error.rs
+++ b/src/persist/src/error.rs
@@ -27,7 +27,11 @@ impl error::Error for Error {}
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(self, f)
+        match self {
+            Error::IO(e) => fmt::Display::fmt(e, f),
+            Error::String(e) => f.write_str(e),
+            Error::RuntimeShutdown => f.write_str("runtime shutdown"),
+        }
     }
 }
 

--- a/src/persist/src/lib.rs
+++ b/src/persist/src/lib.rs
@@ -28,6 +28,7 @@ pub mod mem;
 pub mod nemesis;
 pub mod operators;
 pub mod storage;
+pub mod unreliable;
 
 // TODO
 // - This method of getting the metadata handle ends up being pretty clunky in

--- a/src/persist/src/mem.rs
+++ b/src/persist/src/mem.rs
@@ -18,6 +18,7 @@ use ore::cast::CastFrom;
 use crate::error::Error;
 use crate::indexed::runtime::{self, RuntimeClient};
 use crate::storage::{Blob, Buffer, SeqNo};
+use crate::unreliable::{UnreliableBlob, UnreliableBuffer, UnreliableHandle};
 use crate::Data;
 
 struct MemBufferCore {
@@ -297,6 +298,24 @@ impl MemRegistry {
         let buffer = self.buffer(path, lock_info)?;
         let blob = self.blob(path, lock_info)?;
         runtime::start(buffer, blob)
+    }
+
+    /// Open a [RuntimeClient] with unreliable storage associated with `path`.
+    pub fn open_unreliable<K, V>(
+        &mut self,
+        path: &str,
+        lock_info: &str,
+    ) -> Result<(RuntimeClient<K, V>, UnreliableHandle), Error>
+    where
+        K: Data + Send + Sync + 'static,
+        V: Data + Send + Sync + 'static,
+    {
+        let buffer = self.buffer(path, lock_info)?;
+        let (buffer, unreliable) = UnreliableBuffer::new(buffer);
+        let blob = self.blob(path, lock_info)?;
+        let blob = UnreliableBlob::from_handle(blob, unreliable.clone());
+        let client = runtime::start(buffer, blob)?;
+        Ok((client, unreliable))
     }
 }
 

--- a/src/persist/src/unreliable.rs
+++ b/src/persist/src/unreliable.rs
@@ -1,0 +1,204 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Test utilities for injecting latency and errors.
+
+use std::ops::Range;
+use std::sync::{Arc, Mutex};
+
+use crate::error::Error;
+use crate::storage::{Blob, Buffer, SeqNo};
+
+struct UnreliableCore {
+    unavailable: bool,
+    // TODO: Delays, what else?
+}
+
+impl Default for UnreliableCore {
+    fn default() -> Self {
+        UnreliableCore { unavailable: false }
+    }
+}
+
+/// A handle for controlling the behavior of an unreliable delegate.
+#[derive(Clone)]
+pub struct UnreliableHandle {
+    core: Arc<Mutex<UnreliableCore>>,
+}
+
+impl UnreliableHandle {
+    fn check_unavailable(&self, details: &str) -> Result<(), Error> {
+        let unavailable = self
+            .core
+            .lock()
+            .expect("never panics while holding lock")
+            .unavailable;
+        if unavailable {
+            Err(format!("unavailable: {}", details).into())
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Cause all later operators to return an "unavailable" error.
+    pub fn make_unavailable(&mut self) -> &mut UnreliableHandle {
+        self.core
+            .lock()
+            .expect("never panics while holding lock")
+            .unavailable = true;
+        self
+    }
+
+    /// Cause all later operators to succeed.
+    pub fn make_available(&mut self) -> &mut UnreliableHandle {
+        self.core
+            .lock()
+            .expect("never panics while holding lock")
+            .unavailable = false;
+        self
+    }
+}
+
+/// An unreliable delegate to [Buffer].
+pub struct UnreliableBuffer<U> {
+    handle: UnreliableHandle,
+    buf: U,
+}
+
+impl<U: Buffer> UnreliableBuffer<U> {
+    /// Returns a new [UnreliableBuffer] and a handle for controlling it.
+    pub fn new(buf: U) -> (Self, UnreliableHandle) {
+        let h = UnreliableHandle {
+            core: Arc::new(Mutex::new(Default::default())),
+        };
+        let buf = Self::from_handle(buf, h.clone());
+        (buf, h)
+    }
+
+    /// Returns a new [UnreliableBuffer] sharing the given handle.
+    pub fn from_handle(buf: U, handle: UnreliableHandle) -> Self {
+        UnreliableBuffer { handle, buf }
+    }
+}
+
+impl<U: Buffer> Buffer for UnreliableBuffer<U> {
+    fn write_sync(&mut self, buf: Vec<u8>) -> Result<SeqNo, Error> {
+        self.handle.check_unavailable("buffer write")?;
+        self.buf.write_sync(buf)
+    }
+
+    fn snapshot<F>(&self, logic: F) -> Result<Range<SeqNo>, Error>
+    where
+        F: FnMut(SeqNo, &[u8]) -> Result<(), Error>,
+    {
+        self.handle.check_unavailable("buffer snapshot")?;
+        self.buf.snapshot(logic)
+    }
+
+    fn truncate(&mut self, upper: SeqNo) -> Result<(), Error> {
+        self.handle.check_unavailable("buffer truncate")?;
+        self.buf.truncate(upper)
+    }
+
+    fn close(&mut self) -> Result<(), Error> {
+        self.handle.check_unavailable("buffer close")?;
+        self.buf.close()
+    }
+}
+
+/// An unreliable delegate to [Blob].
+pub struct UnreliableBlob<L> {
+    handle: UnreliableHandle,
+    blob: L,
+}
+
+impl<L: Blob> UnreliableBlob<L> {
+    /// Returns a new [UnreliableBlob] and a handle for controlling it.
+    pub fn new(blob: L) -> (Self, UnreliableHandle) {
+        let h = UnreliableHandle {
+            core: Arc::new(Mutex::new(Default::default())),
+        };
+        let blob = Self::from_handle(blob, h.clone());
+        (blob, h)
+    }
+
+    /// Returns a new [UnreliableBuffer] sharing the given handle.
+    pub fn from_handle(blob: L, handle: UnreliableHandle) -> Self {
+        UnreliableBlob { handle, blob }
+    }
+}
+
+impl<L: Blob> Blob for UnreliableBlob<L> {
+    fn get(&self, key: &str) -> Result<Option<Vec<u8>>, Error> {
+        self.handle.check_unavailable("blob get")?;
+        self.blob.get(key)
+    }
+
+    fn set(&mut self, key: &str, value: Vec<u8>, allow_overwrite: bool) -> Result<(), Error> {
+        self.handle.check_unavailable("blob set")?;
+        self.blob.set(key, value, allow_overwrite)
+    }
+
+    fn close(&mut self) -> Result<(), Error> {
+        self.handle.check_unavailable("blob close")?;
+        self.blob.close()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::mem::{MemBlob, MemBuffer};
+
+    use super::*;
+
+    #[test]
+    fn buffer() -> Result<(), Error> {
+        let (mut buffer, mut handle) = UnreliableBuffer::new(MemBuffer::new("unreliable")?);
+
+        // Initially starts reliable.
+        assert!(buffer.write_sync(vec![]).is_ok());
+        assert!(buffer.snapshot(|_, _| { Ok(()) }).is_ok());
+        assert!(buffer.truncate(SeqNo(1)).is_ok());
+
+        // Setting it to unavailable causes all operations to fail.
+        handle.make_unavailable();
+        assert!(buffer.write_sync(vec![]).is_err());
+        assert!(buffer.snapshot(|_, _| { Ok(()) }).is_err());
+        assert!(buffer.truncate(SeqNo(1)).is_err());
+
+        // Can be set back to working.
+        handle.make_available();
+        assert!(buffer.write_sync(vec![]).is_ok());
+        assert!(buffer.snapshot(|_, _| { Ok(()) }).is_ok());
+        assert!(buffer.truncate(SeqNo(2)).is_ok());
+
+        Ok(())
+    }
+
+    #[test]
+    fn blob() -> Result<(), Error> {
+        let (mut blob, mut handle) = UnreliableBlob::new(MemBlob::new("unreliable")?);
+
+        // Initially starts reliable.
+        assert!(blob.set("a", b"1".to_vec(), true).is_ok());
+        assert!(blob.get("a").is_ok());
+
+        // Setting it to unavailable causes all operations to fail.
+        handle.make_unavailable();
+        assert!(blob.set("a", b"2".to_vec(), true).is_err());
+        assert!(blob.get("a").is_err());
+
+        // Can be set back to working.
+        handle.make_available();
+        assert!(blob.set("a", b"3".to_vec(), true).is_ok());
+        assert!(blob.get("a").is_ok());
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Still TODO is to figure out the hard part of making these retractable
for situations where we can recover, but this does the initial plumbing
so we can hook things up correctly in #7283.