### PR TITLE
testdrive: allow --temp-dir to be specified on the command line

### DIFF
--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -85,11 +85,14 @@ pub struct Config {
     pub default_timeout: Duration,
     /// A random number to distinguish each run of a testdrive script.
     pub seed: Option<u32>,
+    /// Force the use of a specific temporary directory
+    pub temp_dir: Option<String>,
 }
 
 pub struct State {
     seed: u32,
-    temp_dir: tempfile::TempDir,
+    temp_path: PathBuf,
+    _tempfile_handle: Option<tempfile::TempDir>,
     materialized_catalog_path: Option<PathBuf>,
     materialized_addr: String,
     materialized_user: String,
@@ -334,7 +337,7 @@ pub fn build(cmds: Vec<PosCommand>, state: &State) -> Result<Vec<PosAction>, Err
     vars.insert("testdrive.seed".into(), state.seed.to_string());
     vars.insert(
         "testdrive.temp-dir".into(),
-        state.temp_dir.path().display().to_string(),
+        state.temp_path.display().to_string(),
     );
     {
         let protobuf_descriptors = crate::format::protobuf::gen::FILE_DESCRIPTOR_SET_DATA;
@@ -344,7 +347,7 @@ pub fn build(cmds: Vec<PosCommand>, state: &State) -> Result<Vec<PosAction>, Err
             out
         });
         vars.insert("testdrive.protobuf-descriptors-file".into(), {
-            let path = state.temp_dir.path().join("protobuf-descriptors");
+            let path = state.temp_path.join("protobuf-descriptors");
             fs::write(&path, &protobuf_descriptors).err_ctx("writing protobuf descriptors file")?;
             path.display().to_string()
         });
@@ -546,7 +549,19 @@ pub async fn create_state(
 ) -> Result<(State, impl Future<Output = Result<(), Error>>), Error> {
     let seed = config.seed.unwrap_or_else(|| rand::thread_rng().gen());
 
-    let temp_dir = tempfile::tempdir().err_ctx("creating temporary directory")?;
+    let (_tempfile_handle, temp_path) = match &config.temp_dir {
+        Some(temp_dir) => {
+            fs::create_dir_all(temp_dir).err_ctx("creating temporary directory")?;
+            (None, PathBuf::from(&temp_dir))
+        }
+        _ => {
+            // Stash the tempfile object so that it does not go out of scope and delete
+            // the tempdir prematurely
+            let tempfile_handle = tempfile::tempdir().err_ctx("creating temporary directory")?;
+            let temp_path = tempfile_handle.path().to_path_buf();
+            (Some(tempfile_handle), temp_path)
+        }
+    };
 
     let materialized_catalog_path = if let Some(path) = &config.materialized_catalog_path {
         match fs::metadata(&path) {
@@ -684,7 +699,8 @@ pub async fn create_state(
 
     let state = State {
         seed,
-        temp_dir,
+        temp_path,
+        _tempfile_handle,
         materialized_catalog_path,
         materialized_addr,
         materialized_user,

--- a/src/testdrive/src/action/avro_ocf.rs
+++ b/src/testdrive/src/action/avro_ocf.rs
@@ -55,7 +55,7 @@ impl SyncAction for WriteAction {
     }
 
     fn redo(&self, state: &mut State) -> Result<(), String> {
-        let path = state.temp_dir.path().join(&self.path);
+        let path = state.temp_path.join(&self.path);
         println!("Writing to {}", path.display());
         let mut file = File::create(path).map_err(|e| e.to_string())?;
         let schema =
@@ -90,7 +90,7 @@ impl SyncAction for AppendAction {
     }
 
     fn redo(&self, state: &mut State) -> Result<(), String> {
-        let path = state.temp_dir.path().join(&self.path);
+        let path = state.temp_path.join(&self.path);
         println!("Appending to {}", path.display());
         let file = OpenOptions::new()
             .read(true)

--- a/src/testdrive/src/action/file.rs
+++ b/src/testdrive/src/action/file.rs
@@ -84,7 +84,7 @@ impl Action for AppendAction {
     }
 
     async fn redo(&self, state: &mut State) -> Result<(), String> {
-        let path = state.temp_dir.path().join(&self.path);
+        let path = state.temp_path.join(&self.path);
         println!("Appending to file {}", path.display());
         let file = OpenOptions::new()
             .create(true)
@@ -124,7 +124,7 @@ impl Action for DeleteAction {
     }
 
     async fn redo(&self, state: &mut State) -> Result<(), String> {
-        let path = state.temp_dir.path().join(&self.path);
+        let path = state.temp_path.join(&self.path);
         println!("Deleting file {}", path.display());
         tokio::fs::remove_file(&path)
             .await

--- a/src/testdrive/src/main.rs
+++ b/src/testdrive/src/main.rs
@@ -92,6 +92,10 @@ struct Args {
     #[structopt(long)]
     shuffle_tests: bool,
 
+    /// Force the use of the specfied temporary directory rather than creating one with a random name
+    #[structopt(long)]
+    temp_dir: Option<String>,
+
     // === Positional arguments. ===
     /// Paths to testdrive scripts to run.
     files: Vec<String>,
@@ -167,6 +171,7 @@ async fn main() {
         ci_output: args.ci_output,
         default_timeout,
         seed: args.seed,
+        temp_dir: args.temp_dir,
     };
 
     let mut errors = Vec::new();


### PR DESCRIPTION
If --temp-dir is not specified, a directory is created as before
using the tempfile crate. A PathBuf is passed downstream in both
cases.

We stash the tempfile::TempDir object, if used, so that it does
not go out of scope immediately and delete the temporary directory
that was just created.
