### PR TITLE
prof: Enable jemalloc stats and add download option

### DIFF
--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -93,7 +93,7 @@ uuid = "0.8.2"
 #
 # See: https://github.com/jemalloc/jemalloc/issues/956#issuecomment-316224733
 prof = { path = "../prof", features = ["jemalloc"] }
-jemallocator = { version = "0.3.0", features = ["profiling", "unprefixed_malloc_on_supported_platforms", "background_threads"] }
+jemallocator = { version = "0.3.0", features = ["profiling", "stats", "unprefixed_malloc_on_supported_platforms", "background_threads"] }
 
 [dev-dependencies]
 assert_cmd = "1.0.7"

--- a/src/materialized/src/http/prof.rs
+++ b/src/materialized/src/http/prof.rs
@@ -262,6 +262,17 @@ mod enabled {
                     .body(Body::from(s))
                     .unwrap())
             }
+            "dump_stats" => {
+                let mut borrow = prof_ctl.lock().await;
+                let s = borrow.dump_stats()?;
+                Ok(Response::builder()
+                    .header(
+                        header::CONTENT_DISPOSITION,
+                        "attachment; filename=\"jestats.txt\"",
+                    )
+                    .body(Body::from(s))
+                    .unwrap())
+            }
             "dump_symbolicated_file" => {
                 let mut borrow = prof_ctl.lock().await;
                 let f = borrow.dump()?;

--- a/src/materialized/src/http/prof.rs
+++ b/src/materialized/src/http/prof.rs
@@ -266,10 +266,7 @@ mod enabled {
                 let mut borrow = prof_ctl.lock().await;
                 let s = borrow.dump_stats()?;
                 Ok(Response::builder()
-                    .header(
-                        header::CONTENT_DISPOSITION,
-                        "attachment; filename=\"jestats.txt\"",
-                    )
+                    .header(header::CONTENT_TYPE, "text/plain")
                     .body(Body::from(s))
                     .unwrap())
             }

--- a/src/materialized/src/http/templates/prof.html
+++ b/src/materialized/src/http/templates/prof.html
@@ -19,11 +19,13 @@
       <button name="action" value="dump_file">Download heap profile</button>
       <button name="action" value="dump_symbolicated_file">Download symbolicated heap profile</button>
       <button name="action" value="mem_fg">Visualize heap profile (flamegraph)</button>
+      <button name="action" value="dump_stats">Download stats</button>
     </form>
   {% when None %}
       <p>Jemalloc profiling enabled but inactive.</p>
       <form method="post">
         <button type="submit" name="action" value="activate">Activate</button>
+        <button name="action" value="dump_stats">Download stats</button>
       </form>
   {% endmatch %}
 {% when crate::http::prof::MemProfilingStatus::Disabled %}

--- a/src/prof/src/jemalloc.rs
+++ b/src/prof/src/jemalloc.rs
@@ -183,6 +183,13 @@ impl JemallocProfCtl {
         Ok(f.into_file())
     }
 
+    pub fn dump_stats(&mut self) -> anyhow::Result<String> {
+        // Try to avoid allocations within `stats_print`
+        let mut buf = Vec::with_capacity(1 << 20);
+        jemalloc_ctl::stats_print::stats_print(&mut buf, Default::default())?;
+        Ok(String::from_utf8(buf)?)
+    }
+
     pub fn stats(&self) -> anyhow::Result<JemallocStats> {
         epoch::advance()?;
         Ok(JemallocStats {


### PR DESCRIPTION
jemalloc exposes detailed allocation and arena stats. Make the stats
available through the web interface.

Signed-off-by: Moritz Hoffmann <mh@materialize.com>