### PR TITLE
persist: fix non-sequential future batches bug

### DIFF
--- a/src/persist/src/indexed/encoding.rs
+++ b/src/persist/src/indexed/encoding.rs
@@ -46,15 +46,20 @@ pub struct BufferEntry<K, V> {
 /// - All strings in id_mapping are unique.
 /// - All ids in id_mapping are unique.
 /// - The same set of ids are present in id_mapping, futures, and traces.
-/// - For each id, the ts_lower in the future is >= the ts_upper in the
-///   corresponding trace. (They're usually equal, but at the moment, we don't
-///   do the swap atomically, so there is a moment in t
+/// - For each id, the ts_lower in the future is == the ts_upper in the
+///   corresponding trace.
 #[derive(Clone, Debug, Abomonation)]
 pub struct BlobMeta {
     /// The most recently assigned key name.
     pub last_file_id: u64,
     /// The next internal stream id to assign.
     pub next_stream_id: Id,
+    /// The position of buffer the last time data was step'd into futures.
+    ///
+    /// Invariant: For each BlobFutureMeta in `futures`, this is >= the last
+    /// batch's upper. If they are not equal, there is logically an empty batch
+    /// between [last batch's upper, futures_seqno_upper).
+    pub futures_seqno_upper: SeqNo,
     /// Internal stream id indexed by external stream name.
     ///
     /// Invariant: Each stream name and stream id are in here at most once.
@@ -164,6 +169,7 @@ impl Default for BlobMeta {
         BlobMeta {
             last_file_id: 0,
             next_stream_id: Id(0),
+            futures_seqno_upper: SeqNo(0),
             id_mapping: Vec::new(),
             futures: Vec::new(),
             traces: Vec::new(),
@@ -215,10 +221,14 @@ impl BlobMeta {
             let trace = traces.get(id).ok_or_else(|| {
                 Error::from(format!("id_mapping id {:?} not present in traces", id))
             })?;
-            let trace_ts_upper = trace.batches.last().map_or_else(
-                || Antichain::from_elem(Timestamp::minimum()),
-                |(d, _)| d.upper().clone(),
-            );
+            let future_seqno_upper = future.seqno_upper();
+            if !future_seqno_upper.less_equal(&self.futures_seqno_upper) {
+                return Err(Error::from(format!(
+                    "id {:?} future seqno_upper {:?} is not less than the blob's future_seqno_upper {:?}",
+                    id, future_seqno_upper, self.futures_seqno_upper,
+                )));
+            }
+            let trace_ts_upper = trace.ts_upper();
             if trace_ts_upper != future.ts_lower {
                 return Err(Error::from(format!(
                     "id {:?} trace ts_upper {:?} does not match future ts_lower {:?}",
@@ -246,6 +256,10 @@ impl BlobFutureMeta {
         let mut prev: Option<&Description<SeqNo>> = None;
         for (desc, _) in self.batches.iter() {
             if let Some(prev) = prev {
+                // TODO: It's definitely useful in Trace for us to enforce that
+                // these line up, but is it useful in Future? Maybe not. It's
+                // also harder since SeqNos are multiplexed for all streams, but
+                // traces are sealed per-stream.
                 if prev.upper() != desc.lower() {
                     return Err(format!(
                         "invalid batch sequence: {:?} followed by {:?}",
@@ -257,6 +271,14 @@ impl BlobFutureMeta {
             prev = Some(desc)
         }
         Ok(())
+    }
+
+    /// Returns an open upper bound on the seqnos contained in this future.
+    pub fn seqno_upper(&self) -> Antichain<SeqNo> {
+        self.batches.last().map_or_else(
+            || Antichain::from_elem(SeqNo(0)),
+            |(d, _)| d.upper().clone(),
+        )
     }
 }
 
@@ -697,21 +719,21 @@ mod tests {
 
         // Normal case
         let b = BlobMeta {
-            last_file_id: 1,
             next_stream_id: Id(2),
             id_mapping: vec![("0".into(), Id(0)), ("1".into(), Id(1))],
             futures: vec![(Id(0), Default::default()), (Id(1), Default::default())],
             traces: vec![(Id(0), Default::default()), (Id(1), Default::default())],
+            ..Default::default()
         };
         assert_eq!(b.validate(), Ok(()));
 
         // Duplicate external stream id
         let b = BlobMeta {
-            last_file_id: 1,
             next_stream_id: Id(2),
             id_mapping: vec![("1".into(), Id(0)), ("1".into(), Id(1))],
             futures: vec![(Id(0), Default::default()), (Id(1), Default::default())],
             traces: vec![(Id(0), Default::default()), (Id(1), Default::default())],
+            ..Default::default()
         };
         assert_eq!(
             b.validate(),
@@ -720,11 +742,11 @@ mod tests {
 
         // Duplicate internal stream id
         let b = BlobMeta {
-            last_file_id: 1,
             next_stream_id: Id(2),
             id_mapping: vec![("0".into(), Id(1)), ("1".into(), Id(1))],
             futures: vec![(Id(0), Default::default()), (Id(1), Default::default())],
             traces: vec![(Id(0), Default::default()), (Id(1), Default::default())],
+            ..Default::default()
         };
         assert_eq!(
             b.validate(),
@@ -733,11 +755,11 @@ mod tests {
 
         // Invalid next_stream_id
         let b = BlobMeta {
-            last_file_id: 1,
             next_stream_id: Id(1),
             id_mapping: vec![("0".into(), Id(0)), ("1".into(), Id(1))],
             futures: vec![(Id(0), Default::default()), (Id(1), Default::default())],
             traces: vec![(Id(0), Default::default()), (Id(1), Default::default())],
+            ..Default::default()
         };
         assert_eq!(
             b.validate(),
@@ -748,11 +770,11 @@ mod tests {
 
         // Missing future
         let b = BlobMeta {
-            last_file_id: 1,
             next_stream_id: Id(1),
             id_mapping: vec![("0".into(), Id(0))],
             futures: vec![],
             traces: vec![(Id(0), Default::default())],
+            ..Default::default()
         };
         assert_eq!(
             b.validate(),
@@ -761,11 +783,11 @@ mod tests {
 
         // Missing trace
         let b = BlobMeta {
-            last_file_id: 1,
             next_stream_id: Id(1),
             id_mapping: vec![("0".into(), Id(0))],
             futures: vec![(Id(0), Default::default())],
             traces: vec![],
+            ..Default::default()
         };
         assert_eq!(
             b.validate(),
@@ -774,11 +796,11 @@ mod tests {
 
         // Extra future
         let b = BlobMeta {
-            last_file_id: 1,
             next_stream_id: Id(1),
             id_mapping: vec![],
             futures: vec![(Id(0), Default::default())],
             traces: vec![],
+            ..Default::default()
         };
         assert_eq!(
             b.validate(),
@@ -787,11 +809,11 @@ mod tests {
 
         // Extra trace
         let b = BlobMeta {
-            last_file_id: 1,
             next_stream_id: Id(1),
             id_mapping: vec![],
             futures: vec![],
             traces: vec![(Id(0), Default::default())],
+            ..Default::default()
         };
         assert_eq!(
             b.validate(),
@@ -800,7 +822,6 @@ mod tests {
 
         // Future ts_lower doesn't match trace ts_upper
         let b = BlobMeta {
-            last_file_id: 1,
             next_stream_id: Id(1),
             id_mapping: vec![("0".into(), Id(0))],
             futures: vec![(
@@ -816,11 +837,34 @@ mod tests {
                     batches: vec![(u64_desc(0, 1), "".into())],
                 },
             )],
+            ..Default::default()
         };
         assert_eq!(
             b.validate(),
             Err(Error::from(
                 "id Id(0) trace ts_upper Antichain { elements: [1] } does not match future ts_lower Antichain { elements: [2] }"
+            ))
+        );
+
+        // future_seqno_upper less than one of the future seqno uppers
+        let b = BlobMeta {
+            next_stream_id: Id(1),
+            id_mapping: vec![("0".into(), Id(0))],
+            futures_seqno_upper: SeqNo(2),
+            futures: vec![(
+                Id(0),
+                BlobFutureMeta {
+                    batches: vec![(seqno_desc(0, 3), "".into())],
+                    ..Default::default()
+                },
+            )],
+            traces: vec![(Id(0), Default::default())],
+            ..Default::default()
+        };
+        assert_eq!(
+            b.validate(),
+            Err(Error::from(
+                "id Id(0) future seqno_upper Antichain { elements: [SeqNo(3)] } is not less than the blob's future_seqno_upper SeqNo(2)"
             ))
         );
     }

--- a/src/persist/src/nemesis/direct.rs
+++ b/src/persist/src/nemesis/direct.rs
@@ -121,9 +121,7 @@ mod tests {
 
     use super::*;
 
-    // TODO: Un-ignore this once the bugs it's catching are fixed.
     #[test]
-    #[ignore]
     fn direct_mem() {
         nemesis::run(100, || {
             Direct::new("direct_mem").expect("new empty persist runtime is infallible")

--- a/src/persist/src/nemesis/validator.rs
+++ b/src/persist/src/nemesis/validator.rs
@@ -127,16 +127,17 @@ impl Validator {
                 self.check_success(req_id, &res, true);
                 if let Ok(res) = res {
                     let mut actual = res.contents;
-                    actual.sort();
                     let mut expected: Vec<((String, ()), u64, isize)> = self
                         .writes_by_seqno
                         .range((stream.clone(), SeqNo(0))..(stream, SeqNo(res.seqno)))
                         .map(|(_, v)| v)
                         .cloned()
                         .collect();
-                    expected.sort();
-                    // TODO: We need to consolidate and account for since here once
-                    // that's supported in persist.
+                    // TODO: This is also used by the implementation. Write a
+                    // slower but more obvious impl of consolidation here and
+                    // use it for validation.
+                    differential_dataflow::consolidation::consolidate_updates(&mut actual);
+                    differential_dataflow::consolidation::consolidate_updates(&mut expected);
                     if actual != expected {
                         self.errors.push(format!(
                             "incorrect snapshot {:?} expected {:?} got: {:?}",


### PR DESCRIPTION
This is one of the invariants we maintain (for now anyway, neither
ruchirk nor I are particularly convinced at the moment that this
invariant is buying us much). On the other hand, this commit fixes it in
a straightforward and lightweight way, so may as well keep it for now.

The bug comes in two flavors, both fixed in this commit.

First is some stream is registered, written to, and step'd, moving seqno
0..X into future. Then a second stream is registered, written to, and
step'd. When it goes to move X..Y into the future, the second stream is
missing a batch for 0..X. (Newly registered streams are missing 0 to the
seqno that buffer was at when they are registered.)

The second flavor is similar. If we then write to the first stream again
and step, it is then missing X..Y. (A stream not written to between two
step calls doesn't get a batch.)

This also has the nice side effect of updating META once per drain_buf
instead of once per stream written to in the drained records.

Found by nemesis.

This plus ruchirk's recent consolidation PR fix all the outstanding bugs
caught by nemesis, so un-ignore the test.