### PR TITLE
persist: implement compaction v1

### DIFF
--- a/src/persist/src/indexed/encoding.rs
+++ b/src/persist/src/indexed/encoding.rs
@@ -103,14 +103,15 @@ pub struct BlobFutureMeta {
 /// - The since frontier is either 0 or < the trace's upper (the largest upper
 ///   amongst all of the batches).
 /// - Every batch's since frontier is <= the overall trace's since frontier.
+/// - The compaction level of batches is weakly decreasing when iterating from oldest
+///   to most recent time intervals.
+/// - TODO: key uniqueness invariants?
 #[derive(Clone, Debug, Abomonation)]
 pub struct BlobTraceMeta {
     /// The stream this trace belongs to.
     pub id: Id,
-    /// The batches that make up the BlobTrace, represented by their description
-    /// and the key to retrieve the batch's data from the blob store. Note that
-    /// Descriptions are half-open intervals `[lower, upper)`.
-    pub batches: Vec<(Description<u64>, String)>,
+    /// Metadata about he batches that make up the BlobTrace.
+    pub batches: Vec<BlobTraceBatchMeta>,
     /// Compaction frontier for the batches contained in this trace.
     /// There may still be batches containing updates at times < since, but the
     /// the trace only contains correct answers for times at or in advance of this
@@ -119,6 +120,22 @@ pub struct BlobTraceMeta {
     pub since: Antichain<u64>,
     /// The next id used to assign a Blob key for this trace.
     pub next_blob_id: u64,
+}
+
+/// The metadata necessary to reconstruct a [BlobTraceBatch].
+///
+/// Invariants:
+/// - The Description's time interval is non-empty.
+/// - TODO: key invariants?
+#[derive(Clone, Debug, Abomonation)]
+pub struct BlobTraceBatchMeta {
+    /// The key to retrieve the batch's data from the blob store.
+    pub key: String,
+    /// The half-open time interval `[lower, upper)` this batch contains data
+    /// for.
+    pub desc: Description<u64>,
+    /// The compaction level of each batch.
+    pub level: u64,
 }
 
 /// The structure serialized and stored as a value in [crate::storage::Blob]
@@ -333,7 +350,7 @@ impl BlobTraceMeta {
     pub fn ts_upper(&self) -> Antichain<u64> {
         self.batches.last().map_or_else(
             || Antichain::from_elem(Timestamp::minimum()),
-            |(d, _)| d.upper().clone(),
+            |meta| meta.desc.upper().clone(),
         )
     }
 
@@ -351,26 +368,52 @@ impl BlobTraceMeta {
             .into());
         }
 
-        let mut prev: Option<&Description<u64>> = None;
-        for (desc, _) in self.batches.iter() {
-            if !PartialOrder::less_equal(desc.since(), &self.since) {
+        let mut prev: Option<&BlobTraceBatchMeta> = None;
+        for meta in self.batches.iter() {
+            if !PartialOrder::less_equal(meta.desc.since(), &self.since) {
                 return Err(format!(
                     "invalid batch since: {:?} in advance of trace since {:?}",
-                    desc, self.since
+                    meta.desc, self.since
                 )
                 .into());
             }
+
+            meta.validate()?;
+
             if let Some(prev) = prev {
-                if prev.upper() != desc.lower() {
+                if prev.desc.upper() != meta.desc.lower() {
                     return Err(format!(
                         "invalid batch sequence: {:?} followed by {:?}",
-                        prev, desc,
+                        prev.desc, meta.desc,
+                    )
+                    .into());
+                }
+
+                if prev.level < meta.level {
+                    return Err(format!(
+                        "invalid batch sequence: compaction level {} followed by {}",
+                        prev.level, meta.level
                     )
                     .into());
                 }
             }
-            prev = Some(desc)
+            prev = Some(&meta)
         }
+        Ok(())
+    }
+}
+
+impl BlobTraceBatchMeta {
+    /// Asserts Self's documented invariants, returning an error if any are
+    /// violated.
+    pub fn validate(&self) -> Result<(), Error> {
+        // TODO: It's unclear if the equal case (an empty desc) is
+        // useful/harmful. Feel free to make this a less_than if empty descs end
+        // up making sense.
+        if PartialOrder::less_equal(self.desc.upper(), &self.desc.lower()) {
+            return Err(format!("invalid desc: {:?}", &self.desc).into());
+        }
+
         Ok(())
     }
 }
@@ -506,6 +549,22 @@ mod tests {
             Antichain::from_elem(upper),
             Antichain::from_elem(0),
         )
+    }
+
+    fn batch_meta(lower: u64, upper: u64) -> BlobTraceBatchMeta {
+        BlobTraceBatchMeta {
+            key: "".to_string(),
+            desc: u64_desc(lower, upper),
+            level: 1,
+        }
+    }
+
+    fn batch_meta_full(lower: u64, upper: u64, since: u64, level: u64) -> BlobTraceBatchMeta {
+        BlobTraceBatchMeta {
+            key: "".to_string(),
+            desc: u64_desc_since(lower, upper, since),
+            level,
+        }
     }
 
     fn u64_desc_since(lower: u64, upper: u64, since: u64) -> Description<u64> {
@@ -723,6 +782,29 @@ mod tests {
     }
 
     #[test]
+    fn trace_batch_meta_validate() {
+        // Normal case
+        let b = batch_meta(0, 1);
+        assert_eq!(b.validate(), Ok(()));
+
+        // Empty interval
+        let b = batch_meta(0, 0);
+        assert_eq!(b.validate(),
+            Err(Error::from(
+                "invalid desc: Description { lower: Antichain { elements: [0] }, upper: Antichain { elements: [0] }, since: Antichain { elements: [0] } }"
+            )),
+        );
+
+        // Invalid interval
+        let b = batch_meta(2, 0);
+        assert_eq!(b.validate(),
+            Err(Error::from(
+                "invalid desc: Description { lower: Antichain { elements: [2] }, upper: Antichain { elements: [0] }, since: Antichain { elements: [0] } }"
+            )),
+        );
+    }
+
+    #[test]
     fn trace_meta_validate() {
         // Empty
         let b = BlobTraceMeta {
@@ -736,7 +818,7 @@ mod tests {
         // Normal case
         let b = BlobTraceMeta {
             id: Id(0),
-            batches: vec![(u64_desc(0, 1), "".into()), (u64_desc(1, 2), "".into())],
+            batches: vec![batch_meta(0, 1), batch_meta(1, 2)],
             since: Antichain::from_elem(0),
             next_blob_id: 0,
         };
@@ -745,7 +827,7 @@ mod tests {
         // Gap
         let b = BlobTraceMeta {
             id: Id(0),
-            batches: vec![(u64_desc(0, 1), "".into()), (u64_desc(2, 3), "".into())],
+            batches: vec![batch_meta(0, 1), batch_meta(2, 3)],
             since: Antichain::from_elem(0),
             next_blob_id: 0,
         };
@@ -754,7 +836,7 @@ mod tests {
         // Overlapping
         let b = BlobTraceMeta {
             id: Id(0),
-            batches: vec![(u64_desc(0, 2), "".into()), (u64_desc(1, 3), "".into())],
+            batches: vec![batch_meta(0, 2), batch_meta(1, 3)],
             since: Antichain::from_elem(0),
             next_blob_id: 0,
         };
@@ -763,7 +845,7 @@ mod tests {
         // Normal case: trace since before nonzero trace upper
         let b = BlobTraceMeta {
             id: Id(0),
-            batches: vec![(u64_desc(0, 1), "".into()), (u64_desc(1, 2), "".into())],
+            batches: vec![batch_meta(0, 1), batch_meta(1, 2)],
             since: Antichain::from_elem(1),
             next_blob_id: 0,
         };
@@ -772,7 +854,7 @@ mod tests {
         // Trace since at nonzero trace upper
         let b = BlobTraceMeta {
             id: Id(0),
-            batches: vec![(u64_desc(0, 2), "".into()), (u64_desc(2, 3), "".into())],
+            batches: vec![batch_meta(0, 2), batch_meta(2, 3)],
             since: Antichain::from_elem(3),
             next_blob_id: 0,
         };
@@ -781,7 +863,7 @@ mod tests {
         // Trace since in advance of nonzero trace upper
         let b = BlobTraceMeta {
             id: Id(0),
-            batches: vec![(u64_desc(0, 2), "".into()), (u64_desc(2, 3), "".into())],
+            batches: vec![batch_meta(0, 2), batch_meta(2, 3)],
             since: Antichain::from_elem(4),
             next_blob_id: 0,
         };
@@ -790,10 +872,7 @@ mod tests {
         // Normal case: batch since at or before trace since
         let b = BlobTraceMeta {
             id: Id(0),
-            batches: vec![
-                (u64_desc(0, 1), "".into()),
-                (u64_desc_since(1, 2, 1), "".into()),
-            ],
+            batches: vec![batch_meta(0, 1), batch_meta_full(1, 2, 1, 1)],
             since: Antichain::from_elem(1),
             next_blob_id: 0,
         };
@@ -802,14 +881,38 @@ mod tests {
         // Batch since in advance of trace since
         let b = BlobTraceMeta {
             id: Id(0),
-            batches: vec![
-                (u64_desc(0, 1), "".into()),
-                (u64_desc_since(1, 2, 2), "".into()),
-            ],
+            batches: vec![batch_meta(0, 1), batch_meta_full(1, 2, 2, 1)],
             since: Antichain::from_elem(1),
             next_blob_id: 0,
         };
         assert_eq!(b.validate(), Err(Error::from("invalid batch since: Description { lower: Antichain { elements: [1] }, upper: Antichain { elements: [2] }, since: Antichain { elements: [2] } } in advance of trace since Antichain { elements: [1] }")));
+
+        // Normal case: decreasing or constant compaction levels
+        let b = BlobTraceMeta {
+            id: Id(0),
+            batches: vec![
+                batch_meta_full(0, 1, 0, 2),
+                batch_meta_full(1, 2, 0, 2),
+                batch_meta_full(2, 3, 0, 1),
+            ],
+            since: Antichain::from_elem(0),
+            next_blob_id: 0,
+        };
+        assert_eq!(b.validate(), Ok(()));
+
+        // Increasing compaction level.
+        let b = BlobTraceMeta {
+            id: Id(0),
+            batches: vec![batch_meta_full(0, 1, 0, 1), batch_meta_full(1, 2, 0, 2)],
+            since: Antichain::from_elem(0),
+            next_blob_id: 0,
+        };
+        assert_eq!(
+            b.validate(),
+            Err(Error::from(
+                "invalid batch sequence: compaction level 1 followed by 2"
+            ))
+        );
     }
 
     #[test]
@@ -1002,7 +1105,7 @@ mod tests {
             }],
             traces: vec![BlobTraceMeta {
                 id: Id(0),
-                batches: vec![(u64_desc(0, 1), "".into())],
+                batches: vec![batch_meta(0, 1)],
                 since: Antichain::from_elem(0),
                 next_blob_id: 0,
             }],

--- a/src/persist/src/indexed/mod.rs
+++ b/src/persist/src/indexed/mod.rs
@@ -350,6 +350,30 @@ impl<K: Data, V: Data, U: Buffer, L: Blob> Indexed<K, V, U, L> {
         // to compact trace.
     }
 
+    /// Permit compaction of updates at times < since to since.
+    ///
+    /// The compaction frontier can only monotonically increase and it is an error
+    /// to call this function with a since argument that is less than or equal to
+    /// the current compaction frontier. It is also an error to advance the
+    /// compaction frontier beyond the current sealed frontier.
+    /// TODO: it's unclear whether this function needs to be so restrictive about
+    /// calls with a frontier <= current_compaction_frontier. We chose to mirror
+    /// the `seal` API here but if that doesn't make sense, remove the restrictions.
+    pub fn allow_compaction(&mut self, id: Id, since: u64) -> Result<(), Error> {
+        let trace = self
+            .traces
+            .get_mut(&id)
+            .ok_or_else(|| Error::from(format!("never registered: {:?}", id)))?;
+        let since = Antichain::from_elem(since);
+
+        trace.allow_compaction(since)?;
+        // Atomically update the meta with both the trace and future changes.
+        //
+        // TODO: Instead of fully overwriting META each time, this should be
+        // more like a compactable log.
+        self.blob.set_meta(self.serialize_meta())
+    }
+
     /// Appends the given `batch` to the future for `id`, writing the data into
     /// blob storage.
     ///
@@ -561,6 +585,9 @@ mod tests {
         assert_eq!(buf.read_to_end(), vec![]);
         assert_eq!(future.read_to_end(), vec![]);
         assert_eq!(trace.read_to_end(), updates);
+
+        // Can advance compaction frontier to a time that has already been sealed
+        i.allow_compaction(id, 2)?;
 
         Ok(())
     }

--- a/src/persist/src/indexed/mod.rs
+++ b/src/persist/src/indexed/mod.rs
@@ -356,6 +356,7 @@ impl<K: Data, V: Data, U: Buffer, L: Blob> Indexed<K, V, U, L> {
     /// to call this function with a since argument that is less than or equal to
     /// the current compaction frontier. It is also an error to advance the
     /// compaction frontier beyond the current sealed frontier.
+    ///
     /// TODO: it's unclear whether this function needs to be so restrictive about
     /// calls with a frontier <= current_compaction_frontier. We chose to mirror
     /// the `seal` API here but if that doesn't make sense, remove the restrictions.

--- a/src/persist/src/indexed/trace.rs
+++ b/src/persist/src/indexed/trace.rs
@@ -21,7 +21,7 @@ use timely::PartialOrder;
 
 use crate::error::Error;
 use crate::indexed::cache::BlobCache;
-use crate::indexed::encoding::BlobTraceMeta;
+use crate::indexed::encoding::{BlobTraceBatchMeta, BlobTraceMeta};
 use crate::indexed::{BlobTraceBatch, Id, Snapshot};
 use crate::storage::Blob;
 use crate::Data;
@@ -29,12 +29,46 @@ use crate::Data;
 /// A persistent, compacting data structure containing `(Key, Value, Time,
 /// Diff)` entries indexed by `(key, value, time)`.
 ///
+/// We maintain an append-only list of immutable batches that describe updates
+/// corresponding to sorted, contiguous, non-overlapping ranges of times. The
+/// `since` frontier defines a time before which we can compact the history of
+/// updates (and correspondingly no longer answer queries about).
+///
+/// We can compact the updates prior to the since frontier physically, by combining
+/// batches representing consecutive intervals into one large batch representing the
+/// union of those intervals, and logically, by forwarding updates at times before
+/// the since frontier to the since frontier.
+///
+/// We also want to achieve a balance between the compactness of the representation
+/// with the computational effort required to maintain the representation. Specifically,
+/// if we have N batches of data already compacted, we don't want every additional
+/// batch to perform O(N) work (i.e. merge with N batches worth of data) in order
+/// to get compacted. Instead, we would like to keep a geometrically decreasing
+/// (when viewed from oldest to most recent) sequence of batches and perform O(N)
+/// work every N calls to append.
+/// Thankfully, we can achieve all of this with a few simple rules:
+///  - Batches are able to be compacted once the since frontier is in advance of all
+///    of the data in the batch.
+///  - All batches are assigned a nonzero compaction level. When a new batch is appended
+///    to the trace it is assigned a compaction level of 0.
+///  - We periodically merge consecutive batches at the same level L representing
+///    time intervals [lo, mid) and [mid, hi) into a single batch representing
+///    all of the updates in [lo, hi) with level L + 1. Once two batches are merged
+///    they are removed from the trace and replaced with the merged batch.
+///  - Perform merges for the oldest batches possible first.
+///
+/// NB: this approach assumes that all batches are roughly uniformly sized when they
+/// are first appended.
+///
 /// Invariants:
 /// - All entries are before some time frontier.
-/// - This acts as an append-only log. Data is added in advancing batches and
-///   logically immutable after that (modulo compactions, which preserve it, but
-///   the ability to read at old times is lost).
-/// - TODO: Explain since and logical compactions.
+/// - Batches are sorted by time and represent a sorted, consecutive, non-overlapping
+///   list of time intervals.
+/// - Individual batches are immutable, and their set of updates, the time interval
+///   they describe and their compaction level all remain constant as long as the batch
+///   remains in the trace.
+/// - The compaction levels across the list of batches in a trace are weakly decreasing
+///   (non-increasing) when iterating from oldest to most recent time intervals.
 /// - TODO: Space usage.
 pub struct BlobTrace<K, V> {
     id: Id,
@@ -45,7 +79,7 @@ pub struct BlobTrace<K, V> {
     since: Antichain<u64>,
     // NB: The Descriptions here are sorted and contiguous half-open intervals
     // `[lower, upper)`.
-    batches: Vec<(Description<u64>, String)>,
+    batches: Vec<BlobTraceBatchMeta>,
     _phantom: PhantomData<(K, V)>,
 }
 
@@ -73,8 +107,8 @@ impl<K: Data, V: Data> BlobTrace<K, V> {
     pub fn meta(&self) -> BlobTraceMeta {
         BlobTraceMeta {
             id: self.id,
-            batches: self.batches.clone(),
             since: self.since.clone(),
+            batches: self.batches.clone(),
             next_blob_id: self.next_blob_id,
         }
     }
@@ -82,7 +116,7 @@ impl<K: Data, V: Data> BlobTrace<K, V> {
     /// An upper bound on the times of contained updates.
     pub fn ts_upper(&self) -> Antichain<u64> {
         match self.batches.last() {
-            Some((desc, _)) => desc.upper().clone(),
+            Some(meta) => meta.desc.upper().clone(),
             None => Antichain::from_elem(Timestamp::minimum()),
         }
     }
@@ -110,7 +144,13 @@ impl<K: Data, V: Data> BlobTrace<K, V> {
         let desc = batch.desc.clone();
         let key = self.new_blob_key();
         blob.set_trace_batch(key.clone(), batch)?;
-        self.batches.push((desc, key));
+        // As mentioned above, batches are inserted into the trace with compaction
+        // level set to 0.
+        self.batches.push(BlobTraceBatchMeta {
+            key,
+            desc,
+            level: 0,
+        });
         Ok(())
     }
 
@@ -121,10 +161,97 @@ impl<K: Data, V: Data> BlobTrace<K, V> {
     ) -> Result<TraceSnapshot<K, V>, Error> {
         let ts_upper = self.ts_upper();
         let mut updates = Vec::with_capacity(self.batches.len());
-        for (_, key) in self.batches.iter() {
-            updates.push(blob.get_trace_batch(key)?);
+        for meta in self.batches.iter() {
+            updates.push(blob.get_trace_batch(&meta.key)?);
         }
         Ok(TraceSnapshot { ts_upper, updates })
+    }
+
+    /// Merge two batches into one, forwarding all updates not beyond the current
+    /// `since` frontier to the `since` frontier.
+    fn merge<L: Blob>(
+        &mut self,
+        first: &BlobTraceBatchMeta,
+        second: &BlobTraceBatchMeta,
+        blob: &mut BlobCache<K, V, L>,
+    ) -> Result<BlobTraceBatchMeta, Error> {
+        if first.desc.upper() != second.desc.lower() {
+            return Err(Error::from(format!(
+                "invalid merge of non-consecutive batches {:?} and {:?}",
+                first, second
+            )));
+        }
+
+        // Sanity check that both batches being merged are at identical compaction
+        // levels.
+        debug_assert_eq!(first.level, second.level);
+        let merged_level = first.level + 1;
+
+        let desc = Description::new(
+            first.desc.lower().clone(),
+            second.desc.upper().clone(),
+            self.since.clone(),
+        );
+
+        let mut updates = vec![];
+
+        updates.extend(blob.get_trace_batch(&first.key)?.updates.iter().cloned());
+        updates.extend(blob.get_trace_batch(&second.key)?.updates.iter().cloned());
+
+        // TODO: use antichain more idiomatically.
+        let since_time = self.since[0];
+        for ((_, _), t, _) in updates.iter_mut() {
+            if *t < since_time {
+                *t = since_time;
+            }
+        }
+
+        differential_dataflow::consolidation::consolidate_updates(&mut updates);
+
+        let new_batch = BlobTraceBatch {
+            desc: desc.clone(),
+            updates,
+        };
+
+        let key = self.new_blob_key();
+        // TODO: actually clear the unwanted batches from the blob storage
+        blob.set_trace_batch(key.clone(), new_batch)?;
+
+        Ok(BlobTraceBatchMeta {
+            key,
+            desc,
+            level: merged_level,
+        })
+    }
+
+    /// Take one step towards compacting the trace.
+    ///
+    /// Returns true if the trace was modified, false otherwise.
+    pub fn step<L: Blob>(&mut self, blob: &mut BlobCache<K, V, L>) -> Result<bool, Error> {
+        // TODO: should we remember our position in this list?
+        for i in 1..self.batches.len() {
+            if (self.batches[i - 1].level == self.batches[i].level)
+                && PartialOrder::less_equal(self.batches[i].desc.upper(), &self.since)
+            {
+                let first = self.batches[i - 1].clone();
+                let second = self.batches[i].clone();
+
+                let new_batch = self.merge(&first, &second, blob)?;
+
+                // TODO: more performant way to do this?
+                self.batches.remove(i);
+                self.batches[i - 1] = new_batch;
+
+                // Sanity check that the modified list of batches satisfies
+                // all invariants.
+                if cfg!(any(debug, test)) {
+                    self.meta().validate()?;
+                }
+
+                return Ok(true);
+            }
+        }
+        Ok(false)
     }
 
     /// Update the compaction frontier to `since`.
@@ -169,20 +296,25 @@ impl<K: Clone, V: Clone> Snapshot<K, V> for TraceSnapshot<K, V> {
 
 #[cfg(test)]
 mod tests {
+    use crate::indexed::encoding::Id;
+    use crate::indexed::SnapshotExt;
+    use crate::mem::MemBlob;
+
     use super::*;
 
     #[test]
     fn test_allow_compaction() -> Result<(), Error> {
         let mut t: BlobTrace<String, String> = BlobTrace::new(BlobTraceMeta {
             id: Id(0),
-            batches: vec![(
-                Description::new(
+            batches: vec![BlobTraceBatchMeta {
+                key: "key1".to_string(),
+                desc: Description::new(
                     Antichain::from_elem(0),
                     Antichain::from_elem(10),
                     Antichain::from_elem(5),
                 ),
-                "key1".to_string(),
-            )],
+                level: 1,
+            }],
             since: Antichain::from_elem(5),
             next_blob_id: 0,
         });
@@ -190,7 +322,7 @@ mod tests {
         // Normal case: advance since frontier.
         t.allow_compaction(Antichain::from_elem(6))?;
 
-        // Allow compaction at the same since frontier.
+        // Repeat same since frontier.
         assert_eq!(t.allow_compaction(Antichain::from_elem(6)),
             Err(Error::from("invalid compaction less than or equal to trace since Antichain { elements: [6] }: Antichain { elements: [6] }")));
 
@@ -205,6 +337,82 @@ mod tests {
         // Advance since frontier beyond upper
         assert_eq!(t.allow_compaction(Antichain::from_elem(11)),
             Err(Error::from("invalid compaction at or in advance of trace upper Antichain { elements: [10] }: Antichain { elements: [11] }")));
+
+        Ok(())
+    }
+
+    #[test]
+    fn trace_compact() -> Result<(), Error> {
+        let mut blob = BlobCache::new(MemBlob::new("trace_compact")?);
+        let mut t = BlobTrace::new(BlobTraceMeta::new(Id(0)));
+
+        let batch = BlobTraceBatch {
+            desc: Description::new(
+                Antichain::from_elem(0),
+                Antichain::from_elem(1),
+                Antichain::from_elem(0),
+            ),
+            updates: vec![(("k".to_string(), "v".to_string()), 0, 1)],
+        };
+
+        assert_eq!(t.append(batch, &mut blob), Ok(()));
+        let batch = BlobTraceBatch {
+            desc: Description::new(
+                Antichain::from_elem(1),
+                Antichain::from_elem(3),
+                Antichain::from_elem(0),
+            ),
+            updates: vec![(("k".to_string(), "v".to_string()), 2, 1)],
+        };
+        assert_eq!(t.append(batch, &mut blob), Ok(()));
+
+        let batch = BlobTraceBatch {
+            desc: Description::new(
+                Antichain::from_elem(3),
+                Antichain::from_elem(9),
+                Antichain::from_elem(0),
+            ),
+            updates: vec![(("k".to_string(), "v".to_string()), 5, 1)],
+        };
+        assert_eq!(t.append(batch, &mut blob), Ok(()));
+
+        t.allow_compaction(Antichain::from_elem(3))?;
+        t.step(&mut blob)?;
+        let batch_meta: Vec<_> = t
+            .batches
+            .iter()
+            .map(|meta| {
+                (
+                    meta.key.clone(),
+                    (
+                        meta.desc.lower()[0],
+                        meta.desc.upper()[0],
+                        meta.desc.since()[0],
+                    ),
+                    meta.level,
+                )
+            })
+            .collect();
+
+        assert_eq!(
+            batch_meta,
+            vec![
+                ("Id(0)-trace-3".to_string(), (0, 3, 3), 1),
+                ("Id(0)-trace-2".to_string(), (3, 9, 0), 0)
+            ]
+        );
+
+        let snapshot = t.snapshot(&blob)?;
+
+        let updates = snapshot.read_to_end();
+
+        assert_eq!(
+            updates,
+            vec![
+                (("k".to_string(), "v".to_string()), 3, 2),
+                (("k".to_string(), "v".to_string()), 5, 1)
+            ]
+        );
 
         Ok(())
     }


### PR DESCRIPTION
~This pr is not ready for merging and only exists to talk about the approach!~

~This commit introduces a prototype compaction function which attempts to compact a
trace up to a `as_of` time, but instead of compacting all updates <= as_of, it merely
finds the subrange of batches containing times < as_of and compacts them into a single
batch and forwards their updates to `max(batch.upper()) - 1`.~

Future work:

* ~Actually compact up to as_of (this requires potentially splitting a batch in two)~ decided against doing this as differential does not do this.
* Push the computationally intensive work of reading batches and consolidating them onto
  a separate thread -- will do this in a separate commit
* ~Figure out a better interface between the Indexed, Trace, and Cache layers (right now we
  rediscover the Id for the Trace by looking inside a previously persisted batch)~ addressed in a separate commit