### PR TITLE
testdrive: allow transactions to span multiple $ postgres-execute blocks

### DIFF
--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -115,6 +115,7 @@ pub struct State {
     sqs_client: SqsClient,
     sqs_queues_created: BTreeSet<String>,
     default_timeout: Duration,
+    postgres_clients: HashMap<String, tokio_postgres::Client>,
 }
 
 #[derive(Clone)]
@@ -437,6 +438,9 @@ pub fn build(cmds: Vec<PosCommand>, state: &State) -> Result<Vec<PosAction>, Err
                     }
                     "kinesis-ingest" => Box::new(kinesis::build_ingest(builtin).map_err(wrap_err)?),
                     "kinesis-verify" => Box::new(kinesis::build_verify(builtin).map_err(wrap_err)?),
+                    "postgres-connect" => {
+                        Box::new(postgres::build_connect(builtin).map_err(wrap_err)?)
+                    }
                     "postgres-execute" => {
                         Box::new(postgres::build_execute(builtin).map_err(wrap_err)?)
                     }
@@ -726,6 +730,7 @@ pub async fn create_state(
         sqs_client,
         sqs_queues_created: BTreeSet::new(),
         default_timeout: config.default_timeout,
+        postgres_clients: HashMap::new(),
     };
     Ok((state, pgconn_task))
 }

--- a/src/testdrive/src/action/postgres.rs
+++ b/src/testdrive/src/action/postgres.rs
@@ -7,8 +7,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+mod connect;
 mod execute;
 mod verify_slot;
 
+pub use connect::build_connect;
 pub use execute::build_execute;
 pub use verify_slot::build_verify_slot;

--- a/src/testdrive/src/action/postgres/connect.rs
+++ b/src/testdrive/src/action/postgres/connect.rs
@@ -1,0 +1,43 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use async_trait::async_trait;
+
+use crate::action::{Action, State};
+use crate::parser::BuiltinCommand;
+use crate::util::postgres::postgres_client;
+
+pub struct ConnectAction {
+    name: String,
+    url: String,
+}
+
+pub fn build_connect(mut cmd: BuiltinCommand) -> Result<ConnectAction, String> {
+    let name = cmd.args.string("name")?;
+    if name.starts_with("postgres://") {
+        return Err("connection name can not be url".into());
+    }
+
+    let url = cmd.args.string("url")?;
+    cmd.args.done()?;
+    Ok(ConnectAction { name, url })
+}
+
+#[async_trait]
+impl Action for ConnectAction {
+    async fn undo(&self, _: &mut State) -> Result<(), String> {
+        Ok(())
+    }
+
+    async fn redo(&self, state: &mut State) -> Result<(), String> {
+        let client = postgres_client(&self.url).await?;
+        state.postgres_clients.insert(self.name.clone(), client);
+        Ok(())
+    }
+}

--- a/src/testdrive/src/util/postgres.rs
+++ b/src/testdrive/src/util/postgres.rs
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use tokio_postgres::config::Host;
-use tokio_postgres::Config;
+use tokio_postgres::{Client, Config, NoTls};
 use url::Url;
 
 use crate::error::{Error, ResultExt};
@@ -50,4 +50,15 @@ pub fn config_url(config: &Config) -> Result<Url, Error> {
     }
 
     Ok(url)
+}
+
+pub async fn postgres_client(url: &String) -> Result<Client, String> {
+    let (client, connection) = tokio_postgres::connect(url, NoTls)
+        .await
+        .map_err(|e| format!("connecting to postgres: {}", e))?;
+
+    println!("Connecting to PostgreSQL server at {}...", url);
+    tokio::spawn(connection);
+
+    Ok(client)
 }

--- a/test/testdrive/testdrive.td
+++ b/test/testdrive/testdrive.td
@@ -140,3 +140,24 @@ $ kafka-verify format=avro sink=materialize.public.kafka_ingest_repeat_sink sort
 $ kafka-verify format=avro sink=materialize.public.kafka_verify_regexp_sink sort-messages=true
 {"before": null, "after": {"row": {"a": "UID"}}}
 {"before": null, "after": {"row": {"a": "UID"}}}
+
+# $ postgresql-connect
+
+> CREATE TABLE postgres_connect (f1 INTEGER);
+
+$ postgres-connect name=conn1 url=postgres://materialize:materialize@${testdrive.materialized-addr}
+
+$ postgres-execute connection=conn1
+BEGIN;
+INSERT INTO postgres_connect VALUES (1);
+
+# Table is still empty, the transaction we just started is not committed yet
+> SELECT COUNT(*) = 0 FROM postgres_connect;
+true
+
+$ postgres-execute connection=conn1
+INSERT INTO postgres_connect VALUES (2);
+COMMIT;
+
+> SELECT COUNT(*) = 2 FROM postgres_connect;
+true


### PR DESCRIPTION
Introduce a dedicated $ postgres-connect action that creates a
Postgres connection and allows it to be reused over multiple
$ postgres-execute actions.

The prior behaviour: specifying the connection URL in $ postgres-execute
is retained for backwards compatibility with existing .td tests.

---

This is needed so that interesting transaction interleavings can be created on the Postgres side for the purpose of Debezium testing. It also allows certain concurrency tests to be written against Mz as well.