### PR TITLE
s3 source: Only mark objects seen after they have been successfully downloaded

### DIFF
--- a/src/dataflow/src/source/s3.rs
+++ b/src/dataflow/src/source/s3.rs
@@ -617,13 +617,12 @@ async fn download_object(
     };
 
     // If the Content-Type does not match the compression specified for this
-    // source, emit a debug warning messages and ignore this object
+    // source, emit a debug message and trust the user-specified compression
     if let Some(s) = obj.content_encoding.as_deref() {
         match (s, compression) {
             ("gzip", Compression::Gzip) => (),
             ("identity", Compression::None) => (),
-            // TODO: switch to `("identity" | "gzip", _)` when or_patterns stabilizes
-            ("identity", _) | ("gzip", _) => {
+            ("identity" | "gzip", _) => {
                 log::debug!("object {} has mismatched Content-Type: {}", key, s)
             }
             _ => log::debug!("object {} has unrecognized Content-Type: {}", key, s),

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -447,6 +447,9 @@ pub fn build(cmds: Vec<PosCommand>, state: &State) -> Result<Vec<PosAction>, Err
                         Box::new(s3::build_create_bucket(builtin).map_err(wrap_err)?)
                     }
                     "s3-put-object" => Box::new(s3::build_put_object(builtin).map_err(wrap_err)?),
+                    "s3-delete-objects" => {
+                        Box::new(s3::build_delete_object(builtin).map_err(wrap_err)?)
+                    }
                     "s3-add-notifications" => {
                         Box::new(s3::build_add_notifications(builtin).map_err(wrap_err)?)
                     }

--- a/src/testdrive/src/action/s3.rs
+++ b/src/testdrive/src/action/s3.rs
@@ -17,9 +17,9 @@ use flate2::write::GzEncoder;
 use flate2::Compression as Flate2Compression;
 use rusoto_core::{ByteStream, RusotoError};
 use rusoto_s3::{
-    CreateBucketConfiguration, CreateBucketError, CreateBucketRequest,
-    GetBucketNotificationConfigurationRequest, PutBucketNotificationConfigurationRequest,
-    PutObjectRequest, QueueConfiguration, S3,
+    CreateBucketConfiguration, CreateBucketError, CreateBucketRequest, Delete,
+    DeleteObjectsRequest, GetBucketNotificationConfigurationRequest, ObjectIdentifier,
+    PutBucketNotificationConfigurationRequest, PutObjectRequest, QueueConfiguration, S3,
 };
 use rusoto_sqs::{
     CreateQueueError, CreateQueueRequest, DeleteMessageBatchRequest,
@@ -135,6 +135,54 @@ impl Action for PutObjectAction {
             .await
             .map(|_| ())
             .map_err(|e| format!("putting s3 object: {}", e))
+    }
+}
+
+pub struct DeleteObjectAction {
+    bucket_prefix: String,
+    keys: Vec<String>,
+}
+
+pub fn build_delete_object(mut cmd: BuiltinCommand) -> Result<DeleteObjectAction, String> {
+    let bucket_prefix = format!("testdrive-{}", cmd.args.string("bucket")?);
+    cmd.args.done()?;
+    Ok(DeleteObjectAction {
+        bucket_prefix,
+        keys: cmd.input,
+    })
+}
+
+#[async_trait]
+impl Action for DeleteObjectAction {
+    async fn undo(&self, _state: &mut State) -> Result<(), String> {
+        Ok(())
+    }
+
+    async fn redo(&self, state: &mut State) -> Result<(), String> {
+        let bucket = format!("{}-{}", self.bucket_prefix, state.seed);
+        println!("Deleting S3 objects {}: {}", bucket, self.keys.join(", "));
+        let result = state
+            .s3_client
+            .delete_objects(DeleteObjectsRequest {
+                bucket,
+                delete: Delete {
+                    objects: self
+                        .keys
+                        .iter()
+                        .cloned()
+                        .map(|key| ObjectIdentifier {
+                            key,
+                            version_id: None,
+                        })
+                        .collect(),
+                    quiet: None,
+                },
+                ..Default::default()
+            })
+            .await
+            .map(|_| ())
+            .map_err(|e| format!("deleting s3 objects: {}", e));
+        result
     }
 }
 

--- a/test/testdrive/disabled/s3-sqs-gh7146.td
+++ b/test/testdrive/disabled/s3-sqs-gh7146.td
@@ -1,0 +1,203 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+
+# gh7146: make sure that after dropping and recreating an S3 source
+# and deleting and re-uploading all the s3 keys the data is in order.
+
+$ s3-create-bucket bucket=philip-stoev-materialize
+$ s3-add-notifications bucket=philip-stoev-materialize queue=philip-stoev-materialize sqs-validation-timeout=5m
+
+> CREATE MATERIALIZED SOURCE s3
+  FROM S3
+  DISCOVER OBJECTS MATCHING '**/*.csv'
+  USING BUCKET SCAN 'testdrive-philip-stoev-materialize-${testdrive.seed}',
+  SQS NOTIFICATIONS 'testdrive-philip-stoev-materialize-${testdrive.seed}'
+  WITH (
+    region = '${testdrive.aws-region}',
+    endpoint = '${testdrive.aws-endpoint}',
+    access_key_id = '${testdrive.aws-access-key-id}',
+    secret_access_key = '${testdrive.aws-secret-access-key}',
+    token = '${testdrive.aws-token}'
+  )
+  FORMAT CSV WITH 3 COLUMNS;
+
+
+> SELECT mz_internal.mz_sleep(10)
+<null>
+
+$ s3-put-object bucket=philip-stoev-materialize key=1.csv
+1,1, x
+
+> SELECT mz_internal.mz_sleep(0.2)
+<null>
+
+$ s3-put-object bucket=philip-stoev-materialize key=2.csv
+2,1, x
+
+> SELECT mz_internal.mz_sleep(0.2)
+<null>
+
+$ s3-put-object bucket=philip-stoev-materialize key=3.csv
+3,1, x
+
+> SELECT mz_internal.mz_sleep(0.2)
+<null>
+
+$ s3-put-object bucket=philip-stoev-materialize key=4.csv
+4,1, x
+
+> SELECT mz_internal.mz_sleep(0.2)
+<null>
+
+$ s3-put-object bucket=philip-stoev-materialize key=5.csv
+5,1, x
+
+> SELECT mz_internal.mz_sleep(0.2)
+<null>
+
+$ s3-put-object bucket=philip-stoev-materialize key=6.csv
+6,1, x
+
+> SELECT mz_internal.mz_sleep(0.2)
+<null>
+
+$ s3-put-object bucket=philip-stoev-materialize key=7.csv
+7,1, x
+
+> SELECT mz_internal.mz_sleep(0.2)
+<null>
+
+$ s3-put-object bucket=philip-stoev-materialize key=8.csv
+8,1, x
+
+> SELECT mz_internal.mz_sleep(0.2)
+<null>
+
+$ s3-put-object bucket=philip-stoev-materialize key=9.csv
+9,1, x
+
+> SELECT mz_internal.mz_sleep(0.2)
+<null>
+
+$ s3-put-object bucket=philip-stoev-materialize key=10.csv
+10,1, x
+
+> SELECT mz_internal.mz_sleep(0.2)
+<null>
+
+
+> DROP SOURCE s3;
+
+$ s3-delete-objects bucket=philip-stoev-materialize
+1.csv
+2.csv
+3.csv
+4.csv
+5.csv
+6.csv
+7.csv
+8.csv
+9.csv
+10.csv
+
+> SELECT mz_internal.mz_sleep(10)
+<null>
+
+
+> CREATE MATERIALIZED SOURCE s3
+  FROM S3
+  DISCOVER OBJECTS MATCHING '**/*.csv'
+  USING BUCKET SCAN 'testdrive-philip-stoev-materialize-${testdrive.seed}',
+  SQS NOTIFICATIONS 'testdrive-philip-stoev-materialize-${testdrive.seed}'
+  WITH (
+    region = '${testdrive.aws-region}',
+    endpoint = '${testdrive.aws-endpoint}',
+    access_key_id = '${testdrive.aws-access-key-id}',
+    secret_access_key = '${testdrive.aws-secret-access-key}',
+    token = '${testdrive.aws-token}'
+  )
+  FORMAT CSV WITH 3 COLUMNS;
+
+> SELECT mz_internal.mz_sleep(40)
+<null>
+
+# We create 1 key that never existed before
+$ s3-put-object bucket=philip-stoev-materialize key=0.csv
+10,1, x
+
+> SELECT mz_internal.mz_sleep(0.2)
+<null>
+
+$ s3-put-object bucket=philip-stoev-materialize key=1.csv
+11,1, x
+
+> SELECT mz_internal.mz_sleep(0.2)
+<null>
+
+$ s3-put-object bucket=philip-stoev-materialize key=2.csv
+12,1, x
+
+> SELECT mz_internal.mz_sleep(0.2)
+<null>
+
+$ s3-put-object bucket=philip-stoev-materialize key=3.csv
+13,1, x
+
+> SELECT mz_internal.mz_sleep(0.2)
+<null>
+
+$ s3-put-object bucket=philip-stoev-materialize key=4.csv
+14,1, x
+
+> SELECT mz_internal.mz_sleep(0.2)
+<null>
+
+$ s3-put-object bucket=philip-stoev-materialize key=5.csv
+15,1, x
+
+> SELECT mz_internal.mz_sleep(0.2)
+<null>
+
+$ s3-put-object bucket=philip-stoev-materialize key=6.csv
+16,1, x
+
+> SELECT mz_internal.mz_sleep(0.2)
+<null>
+
+$ s3-put-object bucket=philip-stoev-materialize key=7.csv
+17,1, x
+
+> SELECT mz_internal.mz_sleep(0.2)
+<null>
+
+$ s3-put-object bucket=philip-stoev-materialize key=8.csv
+18,1, x
+
+> SELECT mz_internal.mz_sleep(0.2)
+<null>
+
+$ s3-put-object bucket=philip-stoev-materialize key=9.csv
+19,1, x
+
+> SELECT mz_internal.mz_sleep(0.2)
+<null>
+
+$ s3-put-object bucket=philip-stoev-materialize key=10.csv
+20,1, x
+
+> SELECT mz_internal.mz_sleep(0.2)
+<null>
+
+# Another key that did not exist before
+$ s3-put-object bucket=philip-stoev-materialize key=11.csv
+21,1, x
+
+> SELECT COUNT(*), MIN(column1), MAX(column1) FROM s3
+12 10 21

--- a/test/testdrive/disabled/s3-sqs-repeated.td
+++ b/test/testdrive/disabled/s3-sqs-repeated.td
@@ -1,0 +1,87 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# These tests are flaky and take a while to ensure a timeout inside of
+# materialized is reached, both of which need to be resolved before this can be
+# enabled.
+#
+# Flakiness documented here: https://github.com/MaterializeInc/materialize/issues/6355
+#
+# We'd also want to be able to explicitly set the retry timeout inside this
+# file instead of relying on an arbitrary number, which probably depends on
+# https://github.com/MaterializeInc/materialize/issues/7115
+
+> DROP SOURCE IF EXISTS s3_source
+
+$ s3-create-bucket bucket=sqs-repeated
+$ s3-add-notifications bucket=sqs-repeated queue=sqs-repeated sqs-validation-timeout=5m
+
+$ s3-put-object bucket=sqs-repeated key=1
+1
+
+# give aws time to propagate the mssages
+> SELECT mz_internal.mz_sleep(10)
+<null>
+
+$ s3-delete-objects bucket=sqs-repeated
+1
+
+> CREATE MATERIALIZED SOURCE s3_source
+  FROM S3
+  DISCOVER OBJECTS USING
+  SQS NOTIFICATIONS 'testdrive-sqs-repeated-${testdrive.seed}'
+  WITH (
+    region = '${testdrive.aws-region}',
+    endpoint = '${testdrive.aws-endpoint}',
+    access_key_id = '${testdrive.aws-access-key-id}',
+    secret_access_key = '${testdrive.aws-secret-access-key}',
+    token = '${testdrive.aws-token}'
+  )
+  FORMAT TEXT;
+
+# Give it time to error read objects that are in the queue but don't exist
+#
+# The default retry timeout for object downloads is 30 seconds
+> SELECT mz_internal.mz_sleep(40)
+<null>
+
+$ s3-put-object bucket=sqs-repeated key=1
+1
+
+$ s3-put-object bucket=sqs-repeated key=2
+2
+
+$ s3-put-object bucket=sqs-repeated key=3
+3
+
+$ s3-put-object bucket=sqs-repeated key=4
+4
+
+$ s3-put-object bucket=sqs-repeated key=5
+5
+
+$ s3-put-object bucket=sqs-repeated key=6
+6
+
+$ s3-put-object bucket=sqs-repeated key=7
+7
+
+$ s3-put-object bucket=sqs-repeated key=8
+8
+
+$ s3-put-object bucket=sqs-repeated key=9
+9
+
+$ s3-put-object bucket=sqs-repeated key=10
+10
+
+> SELECT count(*) FROM s3_source
+10
+
+> DROP SOURCE s3_source


### PR DESCRIPTION
Plausibly this is the fix for #7146, but I have not actually been able to
reproduce that issue following its instructions closely so I'm not certain.

There are several commits in this PR that all helped code clarity and diagnostics in service of diagnosing the bug now and in the future, only the last two commits should have an effect on whether or not it is triggered.