### PR TITLE
*: prefer Diff over isize whenever possible

### DIFF
--- a/src/coord/src/catalog/builtin_table_updates.rs
+++ b/src/coord/src/catalog/builtin_table_updates.rs
@@ -14,7 +14,7 @@ use dataflow_types::{AvroOcfSinkConnector, KafkaSinkConnector};
 use expr::{GlobalId, MirScalarExpr};
 use ore::collections::CollectionExt;
 use repr::adt::array::ArrayDimension;
-use repr::{Datum, Row};
+use repr::{Datum, Diff, Row};
 use sql::ast::{CreateIndexStatement, Statement};
 use sql::names::DatabaseSpecifier;
 
@@ -36,11 +36,11 @@ pub struct BuiltinTableUpdate {
     /// The data to put into the table.
     pub row: Row,
     /// The diff of the data.
-    pub diff: isize,
+    pub diff: Diff,
 }
 
 impl Catalog {
-    pub(super) fn pack_database_update(&self, name: &str, diff: isize) -> BuiltinTableUpdate {
+    pub(super) fn pack_database_update(&self, name: &str, diff: Diff) -> BuiltinTableUpdate {
         let database = &self.by_name[name];
         BuiltinTableUpdate {
             id: MZ_DATABASES.id,
@@ -57,7 +57,7 @@ impl Catalog {
         &self,
         database_spec: &DatabaseSpecifier,
         schema_name: &str,
-        diff: isize,
+        diff: Diff,
     ) -> BuiltinTableUpdate {
         let (database_id, schema) = match database_spec {
             DatabaseSpecifier::Ambient => (None, &self.ambient_schemas[schema_name]),
@@ -78,7 +78,7 @@ impl Catalog {
         }
     }
 
-    pub(super) fn pack_role_update(&self, name: &str, diff: isize) -> BuiltinTableUpdate {
+    pub(super) fn pack_role_update(&self, name: &str, diff: Diff) -> BuiltinTableUpdate {
         let role = &self.roles[name];
         BuiltinTableUpdate {
             id: MZ_ROLES.id,
@@ -91,7 +91,7 @@ impl Catalog {
         }
     }
 
-    pub(super) fn pack_item_update(&self, id: GlobalId, diff: isize) -> Vec<BuiltinTableUpdate> {
+    pub(super) fn pack_item_update(&self, id: GlobalId, diff: Diff) -> Vec<BuiltinTableUpdate> {
         let entry = self.get_by_id(&id);
         let id = entry.id();
         let oid = entry.oid();
@@ -142,7 +142,7 @@ impl Catalog {
         oid: u32,
         schema_id: i64,
         name: &str,
-        diff: isize,
+        diff: Diff,
     ) -> Vec<BuiltinTableUpdate> {
         vec![BuiltinTableUpdate {
             id: MZ_TABLES.id,
@@ -163,7 +163,7 @@ impl Catalog {
         schema_id: i64,
         name: &str,
         source: &Source,
-        diff: isize,
+        diff: Diff,
     ) -> Vec<BuiltinTableUpdate> {
         vec![BuiltinTableUpdate {
             id: MZ_SOURCES.id,
@@ -185,7 +185,7 @@ impl Catalog {
         oid: u32,
         schema_id: i64,
         name: &str,
-        diff: isize,
+        diff: Diff,
     ) -> Vec<BuiltinTableUpdate> {
         vec![BuiltinTableUpdate {
             id: MZ_VIEWS.id,
@@ -207,7 +207,7 @@ impl Catalog {
         schema_id: i64,
         name: &str,
         sink: &Sink,
-        diff: isize,
+        diff: Diff,
     ) -> Vec<BuiltinTableUpdate> {
         let mut updates = vec![];
         if let Sink {
@@ -268,7 +268,7 @@ impl Catalog {
         oid: u32,
         name: &str,
         index: &Index,
-        diff: isize,
+        diff: Diff,
     ) -> Vec<BuiltinTableUpdate> {
         let mut updates = vec![];
 
@@ -330,7 +330,7 @@ impl Catalog {
         schema_id: i64,
         name: &str,
         typ: &Type,
-        diff: isize,
+        diff: Diff,
     ) -> Vec<BuiltinTableUpdate> {
         let generic_update = BuiltinTableUpdate {
             id: MZ_TYPES.id,
@@ -374,7 +374,7 @@ impl Catalog {
         schema_id: i64,
         name: &str,
         func: &Func,
-        diff: isize,
+        diff: Diff,
     ) -> Vec<BuiltinTableUpdate> {
         let mut updates = vec![];
         for func_impl_details in func.inner.func_impls() {

--- a/src/coord/src/coord/prometheus.rs
+++ b/src/coord/src/coord/prometheus.rs
@@ -18,7 +18,7 @@ use std::{
 
 use chrono::NaiveDateTime;
 use prometheus::{proto::MetricType, Registry};
-use repr::{Datum, Row, Timestamp};
+use repr::{Datum, Diff, Row, Timestamp};
 use tokio::sync::mpsc::UnboundedSender;
 
 use crate::catalog::{builtin::BuiltinTable, BuiltinTableUpdate};
@@ -228,7 +228,7 @@ impl<'a> Scraper<'a> {
             .expect("Sending metric reading retraction messages");
     }
 
-    fn send_metadata_update<I: IntoIterator<Item = Row>>(&self, updates: I, diff: isize) {
+    fn send_metadata_update<I: IntoIterator<Item = Row>>(&self, updates: I, diff: Diff) {
         let id = MZ_PROMETHEUS_METRICS.id;
         self.internal_tx
             .send(Message::InsertBuiltinTableUpdates(TimestampedUpdate {

--- a/src/coord/src/session.rs
+++ b/src/coord/src/session.rs
@@ -19,7 +19,7 @@ use derivative::Derivative;
 use futures::Stream;
 
 use expr::GlobalId;
-use repr::{Datum, Row, ScalarType, Timestamp};
+use repr::{Datum, Diff, Row, ScalarType, Timestamp};
 use sql::ast::{Raw, Statement};
 use sql::plan::{Params, PlanContext, StatementDesc};
 
@@ -456,7 +456,7 @@ pub struct WriteOp {
     /// The target table.
     pub id: GlobalId,
     /// The data rows.
-    pub rows: Vec<(Row, isize)>,
+    pub rows: Vec<(Row, Diff)>,
 }
 
 /// The action to take during end_transaction.

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -34,7 +34,7 @@ use expr::{GlobalId, MirRelationExpr, MirScalarExpr, OptimizedMirRelationExpr, P
 use interchange::avro::{self, DebeziumDeduplicationStrategy};
 use interchange::protobuf::{decode_descriptors, validate_descriptors};
 use kafka_util::KafkaAddrs;
-use repr::{ColumnName, ColumnType, RelationDesc, RelationType, Row, ScalarType, Timestamp};
+use repr::{ColumnName, ColumnType, Diff, RelationDesc, RelationType, Row, ScalarType, Timestamp};
 
 /// The response from a `Peek`.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
@@ -60,7 +60,7 @@ impl PeekResponse {
 pub struct Update {
     pub row: Row,
     pub timestamp: u64,
-    pub diff: isize,
+    pub diff: Diff,
 }
 
 /// A commonly used name for dataflows contain MIR expressions.

--- a/src/dataflow/src/render/context.rs
+++ b/src/dataflow/src/render/context.rs
@@ -29,15 +29,13 @@ use timely::progress::{Antichain, Timestamp};
 
 use dataflow_types::{DataflowDescription, DataflowError};
 use expr::{GlobalId, Id, MapFilterProject, MirScalarExpr};
-use repr::{Row, RowArena};
+use repr::{Diff, Row, RowArena};
 
 /// A trace handle for key-only data.
 pub type TraceKeyHandle<K, T, R> = TraceAgent<OrdKeySpine<K, T, R>>;
 
 /// A trace handle for key-value data.
 pub type TraceValHandle<K, V, T, R> = TraceAgent<OrdValSpine<K, V, T, R>>;
-
-pub type Diff = isize;
 
 // Local type definition to avoid the horror in signatures.
 pub type Arrangement<S, V> = Arranged<S, TraceValHandle<V, V, <S as ScopeParent>::Timestamp, Diff>>;

--- a/src/dataflow/src/render/join/delta_join.rs
+++ b/src/dataflow/src/render/join/delta_join.rs
@@ -23,7 +23,7 @@ use timely::dataflow::Scope;
 
 use dataflow_types::DataflowError;
 use expr::{JoinInputMapper, MapFilterProject, MirScalarExpr};
-use repr::{Row, RowArena};
+use repr::{Diff, Row, RowArena};
 use timely::progress::Antichain;
 
 use super::super::context::{ArrangementFlavor, Context};
@@ -506,7 +506,7 @@ fn build_halfjoin<G, Tr, CF>(
 )
 where
     G: Scope<Timestamp = repr::Timestamp>,
-    Tr: TraceReader<Time = G::Timestamp, Key = Row, Val = Row, R = isize> + Clone + 'static,
+    Tr: TraceReader<Time = G::Timestamp, Key = Row, Val = Row, R = Diff> + Clone + 'static,
     Tr::Batch: BatchReader<Tr::Key, Tr::Val, Tr::Time, Tr::R>,
     Tr::Cursor: Cursor<Tr::Key, Tr::Val, Tr::Time, Tr::R>,
     CF: Fn(&G::Timestamp, &G::Timestamp) -> bool + 'static,
@@ -577,7 +577,7 @@ fn build_update_stream<G, Tr>(
 ) -> (Collection<G, Row>, Collection<G, DataflowError>)
 where
     G: Scope<Timestamp = repr::Timestamp>,
-    Tr: TraceReader<Time = G::Timestamp, Key = Row, Val = Row, R = isize> + Clone + 'static,
+    Tr: TraceReader<Time = G::Timestamp, Key = Row, Val = Row, R = Diff> + Clone + 'static,
     Tr::Batch: BatchReader<Tr::Key, Tr::Val, Tr::Time, Tr::R>,
     Tr::Cursor: Cursor<Tr::Key, Tr::Val, Tr::Time, Tr::R>,
 {

--- a/src/dataflow/src/render/join/linear_join.rs
+++ b/src/dataflow/src/render/join/linear_join.rs
@@ -21,11 +21,11 @@ use timely::progress::{timestamp::Refines, Timestamp};
 
 use dataflow_types::*;
 use expr::{MapFilterProject, MirScalarExpr};
-use repr::{Row, RowArena};
+use repr::{Diff, Row, RowArena};
 
 use crate::operator::CollectionExt;
 use crate::render::context::CollectionBundle;
-use crate::render::context::{Arrangement, ArrangementFlavor, ArrangementImport, Context, Diff};
+use crate::render::context::{Arrangement, ArrangementFlavor, ArrangementImport, Context};
 use crate::render::datum_vec::DatumVec;
 use crate::render::join::{JoinBuildState, JoinClosure};
 

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -590,7 +590,7 @@ pub mod plan {
         EvalError, Id, JoinInputMapper, LocalId, MapFilterProject, MirRelationExpr, MirScalarExpr,
         OptimizedMirRelationExpr, TableFunc,
     };
-    use repr::{Datum, Row};
+    use repr::{Datum, Diff, Row};
 
     /// A rendering plan with all conditional logic removed.
     ///
@@ -604,7 +604,7 @@ pub mod plan {
         /// A collection containing a pre-determined collection.
         Constant {
             /// Explicit update triples for the collection.
-            rows: Result<Vec<(Row, repr::Timestamp, isize)>, EvalError>,
+            rows: Result<Vec<(Row, repr::Timestamp, Diff)>, EvalError>,
         },
         /// A reference to a bound collection.
         ///

--- a/src/dataflow/src/render/threshold.rs
+++ b/src/dataflow/src/render/threshold.rs
@@ -83,7 +83,7 @@ where
     G::Timestamp: Lattice + Refines<T>,
     T: Timestamp + Lattice,
     R: ReduceCore<G, Row, Row, Diff>,
-    L: Fn(&isize) -> bool + 'static,
+    L: Fn(&Diff) -> bool + 'static,
 {
     arrangement.reduce_abelian(name, move |_k, s, t| {
         for (record, count) in s.iter() {

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -1069,7 +1069,7 @@ pub mod plan {
 
     use crate::{BinaryFunc, EvalError, MapFilterProject, MirScalarExpr, NullaryFunc};
     use repr::adt::numeric::Numeric;
-    use repr::{Datum, Row, RowArena, ScalarType};
+    use repr::{Datum, Diff, Row, RowArena, ScalarType};
 
     /// A wrapper type which indicates it is safe to simply evaluate all expressions.
     #[derive(Clone, Debug)]
@@ -1323,10 +1323,9 @@ pub mod plan {
             datums: &'b mut Vec<Datum<'a>>,
             arena: &'a RowArena,
             time: repr::Timestamp,
-            diff: isize,
-        ) -> impl Iterator<
-            Item = Result<(Row, repr::Timestamp, isize), (EvalError, repr::Timestamp, isize)>,
-        > {
+            diff: Diff,
+        ) -> impl Iterator<Item = Result<(Row, repr::Timestamp, Diff), (EvalError, repr::Timestamp, Diff)>>
+        {
             match self.mfp.evaluate_inner(datums, &arena) {
                 Err(e) => {
                     return Some(Err((e, time, diff)))

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 
 use lowertest::MzEnumReflect;
 use ore::collections::CollectionExt;
-use repr::{ColumnType, Datum, RelationType, Row};
+use repr::{ColumnType, Datum, Diff, RelationType, Row};
 
 use self::func::{AggregateFunc, TableFunc};
 use crate::explain::ViewExplanation;
@@ -41,7 +41,7 @@ pub enum MirRelationExpr {
     /// The runtime memory footprint of this operator is zero.
     Constant {
         /// Rows of the constant collection and their multiplicities.
-        rows: Result<Vec<(Row, isize)>, EvalError>,
+        rows: Result<Vec<(Row, Diff)>, EvalError>,
         /// Schema of the collection.
         typ: RelationType,
     },
@@ -639,7 +639,7 @@ impl MirRelationExpr {
 
     /// Constructs a constant collection from specific rows and schema, where
     /// each row can have an arbitrary multiplicity.
-    pub fn constant_diff(rows: Vec<(Vec<Datum>, isize)>, typ: RelationType) -> Self {
+    pub fn constant_diff(rows: Vec<(Vec<Datum>, Diff)>, typ: RelationType) -> Self {
         for (row, _diff) in &rows {
             for (datum, column_typ) in row.iter().zip(typ.column_types.iter()) {
                 assert!(

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -34,7 +34,7 @@ use serde::{Deserialize, Serialize};
 
 use ::expr::{GlobalId, RowSetFinishing};
 use dataflow_types::{SinkConnectorBuilder, SinkEnvelope, SourceConnector};
-use repr::{ColumnName, RelationDesc, Row, ScalarType, Timestamp};
+use repr::{ColumnName, Diff, RelationDesc, Row, ScalarType, Timestamp};
 
 use crate::ast::{ExplainOptions, ExplainStage, Expr, FetchDirection, ObjectType, Raw, Statement};
 use crate::names::{DatabaseSpecifier, FullName, SchemaName};
@@ -254,7 +254,7 @@ pub struct ExplainPlan {
 #[derive(Debug)]
 pub struct SendDiffsPlan {
     pub id: GlobalId,
-    pub updates: Vec<(Row, isize)>,
+    pub updates: Vec<(Row, Diff)>,
     pub affected_rows: usize,
     pub kind: MutationKind,
 }

--- a/src/transform/src/reduction.rs
+++ b/src/transform/src/reduction.rs
@@ -13,7 +13,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::iter;
 
 use expr::{AggregateExpr, EvalError, MirRelationExpr, MirScalarExpr, TableFunc};
-use repr::{Datum, Row, RowArena};
+use repr::{Datum, Diff, Row, RowArena};
 
 use crate::{TransformArgs, TransformError};
 
@@ -370,8 +370,8 @@ impl FoldConstants {
     fn fold_reduce_constant(
         group_key: &[MirScalarExpr],
         aggregates: &[AggregateExpr],
-        rows: &[(Row, isize)],
-    ) -> Result<Vec<(Row, isize)>, EvalError> {
+        rows: &[(Row, Diff)],
+    ) -> Result<Vec<(Row, Diff)>, EvalError> {
         // Build a map from `group_key` to `Vec<Vec<an, ..., a1>>)`,
         // where `an` is the input to the nth aggregate function in
         // `aggregates`.
@@ -445,8 +445,8 @@ impl FoldConstants {
     fn fold_flat_map_constant(
         func: &TableFunc,
         exprs: &[MirScalarExpr],
-        rows: &[(Row, isize)],
-    ) -> Result<Vec<(Row, isize)>, EvalError> {
+        rows: &[(Row, Diff)],
+    ) -> Result<Vec<(Row, Diff)>, EvalError> {
         let mut new_rows = Vec::new();
         let mut row_packer = Row::default();
         for (input_row, diff) in rows {
@@ -469,8 +469,8 @@ impl FoldConstants {
 
     fn fold_filter_constant(
         predicates: &[MirScalarExpr],
-        rows: &[(Row, isize)],
-    ) -> Result<Vec<(Row, isize)>, EvalError> {
+        rows: &[(Row, Diff)],
+    ) -> Result<Vec<(Row, Diff)>, EvalError> {
         let mut new_rows = Vec::new();
         'outer: for (row, diff) in rows {
             let datums = row.unpack();


### PR DESCRIPTION
This pr extracts the minimally intrusive set of changes from #7381 

The first commit removes the Diff redefinition in `src/dataflow/src/render/context.rs` and the second commit replaces `isize` for `Diff` in a number of places (intentionally not all) where we were using `isize` to mean "a logical diff".