### PR TITLE
Add ResultExt::map_err_to_string and others to preserve error message context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1187,6 +1187,7 @@ dependencies = [
  "expr",
  "lazy_static",
  "lowertest",
+ "ore",
  "proc-macro2",
  "repr",
  "repr_test_util",

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -36,7 +36,7 @@ use dataflow_types::{
     PeekResponse, SourceConnector, TimestampSourceUpdate, Update,
 };
 use expr::{GlobalId, PartitionId, RowSetFinishing};
-use ore::now::NowFn;
+use ore::{now::NowFn, result::ResultExt};
 use repr::{Diff, Row, RowArena, Timestamp};
 
 use crate::arrangement::manager::{TraceBundle, TraceManager};
@@ -1112,7 +1112,7 @@ impl PendingPeek {
                 if let Some(result) = self
                     .map_filter_project
                     .evaluate(&mut datums, &arena)
-                    .map_err(|e| e.to_string())?
+                    .map_err_to_string()?
                 {
                     let mut copies = 0;
                     cursor.map_times(&storage, |time, diff| {

--- a/src/expr-test-util/Cargo.toml
+++ b/src/expr-test-util/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 expr = {path = "../expr"}
 lazy_static = "1.4.0"
 lowertest = {path = "../lowertest"}
+ore = { path = "../ore" }
 proc-macro2 = "1.0.27"
 repr = {path = "../repr"}
 repr_test_util = {path = "../repr-test-util"}

--- a/src/expr-test-util/src/lib.rs
+++ b/src/expr-test-util/src/lib.rs
@@ -15,6 +15,7 @@ use proc_macro2::TokenTree;
 use expr::explain::ViewExplanation;
 use expr::*;
 use lowertest::*;
+use ore::result::ResultExt;
 use repr::{ColumnType, Datum, RelationType, Row, ScalarType};
 use repr_test_util::{get_datum_from_str, get_scalar_type_or_default};
 
@@ -164,10 +165,7 @@ impl MirScalarExprDeserializeContext {
     fn build_column(&mut self, token: Option<TokenTree>) -> Result<MirScalarExpr, String> {
         if let Some(TokenTree::Literal(literal)) = token {
             return Ok(MirScalarExpr::Column(
-                literal
-                    .to_string()
-                    .parse::<usize>()
-                    .map_err(|s| s.to_string())?,
+                literal.to_string().parse::<usize>().map_err_to_string()?,
             ));
         }
         Err(format!("Invalid column specification {:?}", token))
@@ -217,9 +215,7 @@ impl TestDeserializeContext for MirScalarExprDeserializeContext {
             None
         };
         match result {
-            Some(result) => Ok(Some(
-                serde_json::to_string(&result).map_err(|e| e.to_string())?,
-            )),
+            Some(result) => Ok(Some(serde_json::to_string(&result).map_err_to_string()?)),
             None => Ok(None),
         }
     }
@@ -427,9 +423,7 @@ impl<'a> TestDeserializeContext for MirRelationExprDeserializeContext<'a> {
                     if let Some(result) =
                         self.build_special_mir_if_able(first_arg, rest_of_stream)?
                     {
-                        return Ok(Some(
-                            serde_json::to_string(&result).map_err(|e| e.to_string())?,
-                        ));
+                        return Ok(Some(serde_json::to_string(&result).map_err_to_string()?));
                     }
                 } else if type_name == "usize" {
                     if let TokenTree::Punct(punct) = first_arg {

--- a/src/lowertest/src/lib.rs
+++ b/src/lowertest/src/lib.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 use proc_macro2::{Delimiter, TokenStream, TokenTree};
 use serde::de::DeserializeOwned;
 
-use ore::str::separated;
+use ore::{result::ResultExt, str::separated};
 
 pub use lowertest_derive::{gen_reflect_info_func, MzEnumReflect, MzStructReflect};
 
@@ -53,7 +53,7 @@ pub trait MzStructReflect {
 }
 
 pub fn parse_str(s: &str) -> Result<TokenStream, String> {
-    s.parse::<TokenStream>().map_err(|e| e.to_string())
+    s.parse::<TokenStream>().map_err_to_string()
 }
 
 /// If the `stream_iter` is not empty, deserialize the next `TokenTree` into a `D`.

--- a/src/lowertest/tests/test_runner.rs
+++ b/src/lowertest/tests/test_runner.rs
@@ -14,6 +14,7 @@ mod tests {
     use std::collections::HashMap;
 
     use lazy_static::lazy_static;
+    use ore::result::ResultExt;
     use proc_macro2::{TokenStream, TokenTree};
     use serde::{Deserialize, Serialize};
 
@@ -136,10 +137,7 @@ mod tests {
                 }
             } else if type_name == "usize" {
                 if let TokenTree::Literal(literal) = first_arg {
-                    let litval = literal
-                        .to_string()
-                        .parse::<usize>()
-                        .map_err(|e| e.to_string())?;
+                    let litval = literal.to_string().parse::<usize>().map_err_to_string()?;
                     return Ok(Some(format!("{}", litval + 1)));
                 }
             }
@@ -148,10 +146,7 @@ mod tests {
     }
 
     fn build(s: &str, args: &HashMap<String, Vec<String>>) -> Result<String, String> {
-        let stream = s
-            .to_string()
-            .parse::<TokenStream>()
-            .map_err(|e| e.to_string())?;
+        let stream = s.to_string().parse::<TokenStream>().map_err_to_string()?;
         let result: Option<TestEnum> = if args.get("override").is_some() {
             deserialize_optional(
                 &mut stream.into_iter(),

--- a/src/materialized/src/bin/materialized/sys.rs
+++ b/src/materialized/src/bin/materialized/sys.rs
@@ -48,6 +48,7 @@ pub fn adjust_rlimits() {
 
     #[cfg(target_os = "macos")]
     let hard = {
+        use ore::result::ResultExt;
         use std::cmp;
         use std::convert::TryFrom;
         use sysctl::Sysctl;
@@ -58,7 +59,7 @@ pub fn adjust_rlimits() {
         // cause the call to setrlimit below to fail.
         let res = sysctl::Ctl::new("kern.maxfilesperproc")
             .and_then(|ctl| ctl.value())
-            .map_err(|e| e.to_string())
+            .map_err_to_string()
             .and_then(|v| match v {
                 sysctl::CtlValue::Int(v) => usize::try_from(v)
                     .map_err(|_| format!("kern.maxfilesperproc unexpectedly negative: {}", v)),

--- a/src/ore/src/display.rs
+++ b/src/ore/src/display.rs
@@ -13,50 +13,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Result utilities.
+//! Display utilities.
 
-use crate::display::DisplayExt;
+use std::fmt::Display;
 
-/// Extension methods for [`std::result::Result`].
-pub trait ResultExt<T, E> {
-    /// Applies [`Into::into`] to a contained [`Err`] value, leaving an [`Ok`]
-    /// value untouched.
-    fn err_into<E2>(self) -> Result<T, E2>
-    where
-        E: Into<E2>;
-
-    /// Formats an [`Err`] value as a detailed error message, preserving any context information.
-    ///
-    /// This is equivalent to `format!("{:#}", err)`, except that it's easier to type.
-    fn err_to_string(&self) -> Option<String>
-    where
-        E: std::fmt::Display;
+/// Extension methods for [`std::fmt::Display`].
+pub trait DisplayExt {
+    /// Formats an object with the "alternative" format (`{:#}`) and returns it.
+    fn to_string_alt(&self) -> String;
 }
 
-impl<T, E> ResultExt<T, E> for Result<T, E> {
-    fn err_into<E2>(self) -> Result<T, E2>
-    where
-        E: Into<E2>,
-    {
-        self.map_err(|e| e.into())
-    }
-
-    fn err_to_string(&self) -> Option<String>
-    where
-        E: std::fmt::Display,
-    {
-        self.as_ref().err().map(DisplayExt::to_string_alt)
+impl<T: Display> DisplayExt for T {
+    fn to_string_alt(&self) -> String {
+        format!("{:#}", self)
     }
 }
 
 #[cfg(test)]
 mod test {
-    use std::fmt::Display;
-
     use super::*;
 
     #[test]
-    fn prints_err_alternate_repr() {
+    fn prints_alternate_repr() {
         struct Foo;
         impl Display for Foo {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -68,7 +46,6 @@ mod test {
             }
         }
 
-        let res: Result<(), Foo> = Err(Foo);
-        assert_eq!("success", res.err_to_string().unwrap());
+        assert_eq!(Foo.to_string_alt(), "success");
     }
 }

--- a/src/ore/src/lib.rs
+++ b/src/ore/src/lib.rs
@@ -30,6 +30,7 @@ pub mod cast;
 pub mod cli;
 pub mod codegen;
 pub mod collections;
+pub mod display;
 pub mod env;
 pub mod fmt;
 #[cfg(feature = "network")]

--- a/src/ore/src/result.rs
+++ b/src/ore/src/result.rs
@@ -31,6 +31,12 @@ pub trait ResultExt<T, E> {
     fn err_to_string(&self) -> Option<String>
     where
         E: std::fmt::Display;
+
+    /// Maps a `Result<T, E>` to `Result<T, String>` by converting the [`Err`] result into a string
+    /// using the "alternate" formatting.
+    fn map_err_to_string(self) -> Result<T, String>
+    where
+        E: std::fmt::Display;
 }
 
 impl<T, E> ResultExt<T, E> for Result<T, E> {
@@ -46,6 +52,13 @@ impl<T, E> ResultExt<T, E> for Result<T, E> {
         E: std::fmt::Display,
     {
         self.as_ref().err().map(DisplayExt::to_string_alt)
+    }
+
+    fn map_err_to_string(self) -> Result<T, String>
+    where
+        E: std::fmt::Display,
+    {
+        self.map_err(|e| DisplayExt::to_string_alt(&e))
     }
 }
 
@@ -69,6 +82,9 @@ mod test {
         }
 
         let res: Result<(), Foo> = Err(Foo);
-        assert_eq!("success", res.err_to_string().unwrap());
+        assert_eq!(Some("success".to_string()), res.err_to_string());
+
+        let res: Result<(), Foo> = Err(Foo);
+        assert_eq!(Err("success".to_string()), res.map_err_to_string());
     }
 }

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -18,6 +18,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use futures::future::FutureExt;
 use lazy_static::lazy_static;
+use ore::result::ResultExt as _;
 use rand::Rng;
 use rdkafka::ClientConfig;
 use regex::{Captures, Regex};
@@ -467,7 +468,8 @@ pub fn build(cmds: Vec<PosCommand>, state: &State) -> Result<Vec<PosAction>, Err
                             context.timeout = state.default_timeout;
                         } else {
                             context.timeout = repr::util::parse_duration(&duration)
-                                .map_err(|e| wrap_err(e.to_string()))?;
+                                .map_err_to_string()
+                                .map_err(wrap_err)?;
                         }
                         continue;
                     }

--- a/src/testdrive/src/action/avro_ocf.rs
+++ b/src/testdrive/src/action/avro_ocf.rs
@@ -15,6 +15,7 @@ use std::path::{self, PathBuf};
 
 use async_trait::async_trait;
 
+use ore::result::ResultExt;
 use ore::retry::Retry;
 
 use crate::action::{Action, Context, State, SyncAction};
@@ -57,9 +58,9 @@ impl SyncAction for WriteAction {
     fn redo(&self, state: &mut State) -> Result<(), String> {
         let path = state.temp_path.join(&self.path);
         println!("Writing to {}", path.display());
-        let mut file = File::create(path).map_err(|e| e.to_string())?;
-        let schema =
-            avro::parse_schema(&self.schema).map_err(|e| format!("parsing avro schema: {}", e))?;
+        let mut file = File::create(path).map_err_to_string()?;
+        let schema = avro::parse_schema(&self.schema)
+            .map_err(|e| format!("parsing avro schema: {:#}", e))?;
         let mut writer = Writer::with_codec_opt(schema, &mut file, self.codec);
         write_records(&mut writer, &self.records)?;
         file.sync_all()
@@ -96,8 +97,8 @@ impl SyncAction for AppendAction {
             .read(true)
             .write(true)
             .open(path)
-            .map_err(|e| e.to_string())?;
-        let mut writer = Writer::append_to(file).map_err(|e| e.to_string())?;
+            .map_err_to_string()?;
+        let mut writer = Writer::append_to(file).map_err_to_string()?;
         write_records(&mut writer, &self.records)?;
         Ok(())
     }
@@ -110,16 +111,16 @@ where
     let schema = writer.schema().clone();
     for record in records {
         let record = avro::from_json(
-            &serde_json::from_str(record).map_err(|e| format!("parsing avro datum: {}", e))?,
+            &serde_json::from_str(record).map_err(|e| format!("parsing avro datum: {:#}", e))?,
             schema.top_node(),
         )?;
         writer
             .append(record)
-            .map_err(|e| format!("writing avro record: {}", e))?;
+            .map_err(|e| format!("writing avro record: {:#}", e))?;
     }
     writer
         .flush()
-        .map_err(|e| format!("flushing avro writer: {}", e))?;
+        .map_err(|e| format!("flushing avro writer: {:#}", e))?;
     Ok(())
 }
 
@@ -163,7 +164,7 @@ impl Action for VerifyAction {
                         &[&self.sink],
                     )
                     .await
-                    .map_err(|e| format!("querying materialize: {}", e.to_string()))?;
+                    .map_err(|e| format!("querying materialize: {:#}", e))?;
                 let bytes: Vec<u8> = row.get("path");
                 Ok::<_, String>(PathBuf::from(OsString::from_vec(bytes)))
             })

--- a/src/testdrive/src/action/file.rs
+++ b/src/testdrive/src/action/file.rs
@@ -12,6 +12,7 @@ use std::str::FromStr;
 
 use async_compression::tokio::write::GzipEncoder;
 use async_trait::async_trait;
+use ore::result::ResultExt;
 use tokio::fs::OpenOptions;
 use tokio::io::{AsyncWrite, AsyncWriteExt};
 
@@ -91,18 +92,16 @@ impl Action for AppendAction {
             .append(true)
             .open(&path)
             .await
-            .map_err(|e| e.to_string())?;
+            .map_err_to_string()?;
 
         let mut file: Box<dyn AsyncWrite + Unpin + Send> = match self.compression {
             Compression::Gzip => Box::new(GzipEncoder::new(file)),
             Compression::None => Box::new(file),
         };
 
-        file.write_all(&self.contents)
-            .await
-            .map_err(|e| e.to_string())?;
+        file.write_all(&self.contents).await.map_err_to_string()?;
 
-        file.shutdown().await.map_err(|e| e.to_string())?;
+        file.shutdown().await.map_err_to_string()?;
         Ok(())
     }
 }
@@ -126,8 +125,6 @@ impl Action for DeleteAction {
     async fn redo(&self, state: &mut State) -> Result<(), String> {
         let path = state.temp_path.join(&self.path);
         println!("Deleting file {}", path.display());
-        tokio::fs::remove_file(&path)
-            .await
-            .map_err(|e| e.to_string())
+        tokio::fs::remove_file(&path).await.map_err_to_string()
     }
 }

--- a/src/testdrive/src/action/http.rs
+++ b/src/testdrive/src/action/http.rs
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use async_trait::async_trait;
+use ore::result::ResultExt;
 
 use crate::action::{Action, State};
 use crate::parser::BuiltinCommand;
@@ -52,14 +53,10 @@ impl Action for RequestAction {
             request = request.header(CONTENT_TYPE, value);
         }
 
-        let response = request.send().await.map_err(|e| e.to_string())?;
+        let response = request.send().await.map_err_to_string()?;
         let status = response.status();
 
-        println!(
-            "{}\n{}",
-            status,
-            response.text().await.map_err(|e| e.to_string())?
-        );
+        println!("{}\n{}", status, response.text().await.map_err_to_string()?);
 
         if status.is_success() {
             Ok(())

--- a/src/testdrive/src/action/kafka/add_partitions.rs
+++ b/src/testdrive/src/action/kafka/add_partitions.rs
@@ -11,6 +11,7 @@ use std::cmp;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use ore::result::ResultExt;
 use rdkafka::admin::NewPartitions;
 use rdkafka::producer::Producer;
 
@@ -71,7 +72,7 @@ impl Action for AddPartitionsAction {
             .kafka_admin
             .create_partitions(&[partitions], &state.kafka_admin_opts)
             .await
-            .map_err(|e| e.to_string())?;
+            .map_err_to_string()?;
         if res.len() != 1 {
             return Err(format!(
                 "kafka partition addition returned {} results, but exactly one result was expected",
@@ -92,7 +93,7 @@ impl Action for AddPartitionsAction {
                         Some(&topic_name),
                         Some(cmp::max(state.default_timeout, Duration::from_secs(1))),
                     )
-                    .map_err(|e| e.to_string())?;
+                    .map_err_to_string()?;
                 if metadata.topics().len() != 1 {
                     return Err("metadata fetch returned no topics".to_string());
                 }

--- a/src/testdrive/src/action/kafka/create_topic.rs
+++ b/src/testdrive/src/action/kafka/create_topic.rs
@@ -12,6 +12,7 @@ use std::convert::TryFrom;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use ore::result::ResultExt;
 use rdkafka::admin::{NewTopic, TopicReplication};
 use rdkafka::error::RDKafkaErrorCode;
 use rdkafka::producer::Producer;
@@ -54,7 +55,7 @@ impl Action for CreateTopicAction {
                 None,
                 Some(cmp::max(Duration::from_secs(1), state.default_timeout)),
             )
-            .map_err(|e| e.to_string())?;
+            .map_err_to_string()?;
 
         let stale_kafka_topics: Vec<_> = metadata
             .topics()
@@ -171,7 +172,7 @@ impl Action for CreateTopicAction {
         .set("compression.type", &self.compression);
         kafka_util::admin::create_topic(&state.kafka_admin, &state.kafka_admin_opts, &new_topic)
             .await
-            .map_err(|e| e.to_string())?;
+            .map_err_to_string()?;
         state.kafka_topics.insert(topic_name, self.partitions);
         Ok(())
     }

--- a/src/testdrive/src/action/s3.rs
+++ b/src/testdrive/src/action/s3.rs
@@ -15,6 +15,7 @@ use std::time::{Duration, Instant};
 use async_trait::async_trait;
 use flate2::write::GzEncoder;
 use flate2::Compression as Flate2Compression;
+use ore::result::ResultExt;
 use rusoto_core::{ByteStream, RusotoError};
 use rusoto_s3::{
     CreateBucketConfiguration, CreateBucketError, CreateBucketRequest,
@@ -156,7 +157,7 @@ pub fn build_add_notifications(mut cmd: BuiltinCommand) -> Result<AddBucketNotif
     let sqs_validation_timeout = cmd
         .args
         .opt_string("sqs-validation-timeout")
-        .map(|t| repr::util::parse_duration(&t).map_err(|e| e.to_string()))
+        .map(|t| repr::util::parse_duration(&t).map_err_to_string())
         .transpose()?;
     cmd.args.done()?;
     Ok(AddBucketNotifications {

--- a/src/testdrive/src/action/sleep.rs
+++ b/src/testdrive/src/action/sleep.rs
@@ -10,6 +10,7 @@
 use std::thread;
 use std::time::Duration;
 
+use ore::result::ResultExt;
 use rand::Rng;
 
 use crate::action::{State, SyncAction};
@@ -22,7 +23,7 @@ pub struct SleepAction {
 
 pub fn build_random_sleep(mut cmd: BuiltinCommand) -> Result<SleepAction, String> {
     let arg = cmd.args.string("duration")?;
-    let duration = repr::util::parse_duration(&arg).map_err(|e| e.to_string())?;
+    let duration = repr::util::parse_duration(&arg).map_err_to_string()?;
     Ok(SleepAction {
         duration,
         random: true,
@@ -31,7 +32,7 @@ pub fn build_random_sleep(mut cmd: BuiltinCommand) -> Result<SleepAction, String
 
 pub fn build_sleep(mut cmd: BuiltinCommand) -> Result<SleepAction, String> {
     let arg = cmd.args.string("duration")?;
-    let duration = repr::util::parse_duration(&arg).map_err(|e| e.to_string())?;
+    let duration = repr::util::parse_duration(&arg).map_err_to_string()?;
     Ok(SleepAction {
         duration,
         random: false,

--- a/src/testdrive/src/action/sql.rs
+++ b/src/testdrive/src/action/sql.rs
@@ -15,6 +15,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use md5::{Digest, Md5};
+use ore::result::ResultExt;
 use postgres_array::Array;
 use tokio_postgres::error::DbError;
 use tokio_postgres::row::Row;
@@ -167,17 +168,17 @@ impl Action for SqlAction {
                 | Statement::DropDatabase { .. }
                 | Statement::DropObjects { .. } => {
                     let disk_state = Catalog::open_debug(path, ore::now::now_zero)
-                        .map_err(|e| e.to_string())?
+                        .map_err_to_string()?
                         .dump();
                     let mem_state = reqwest::get(&format!(
                         "http://{}/internal/catalog",
                         state.materialized_addr,
                     ))
                     .await
-                    .map_err(|e| e.to_string())?
+                    .map_err_to_string()?
                     .text()
                     .await
-                    .map_err(|e| e.to_string())?;
+                    .map_err_to_string()?;
                     if disk_state != mem_state {
                         return Err(format!(
                             "the on-disk state of the catalog does not match its in-memory state\n\

--- a/src/testdrive/src/format/avro.rs
+++ b/src/testdrive/src/format/avro.rs
@@ -19,9 +19,9 @@
 
 use std::collections::HashMap;
 use std::convert::{TryFrom, TryInto};
-use std::num::TryFromIntError;
 
 use mz_avro::types::AvroMap;
+use ore::result::ResultExt;
 use regex::Regex;
 
 use serde_json::Value as JsonValue;
@@ -42,10 +42,7 @@ pub fn from_json(json: &JsonValue, schema: SchemaNode) -> Result<Value, String> 
         (JsonValue::Null, SchemaPiece::Null) => Ok(Value::Null),
         (JsonValue::Bool(b), SchemaPiece::Boolean) => Ok(Value::Boolean(*b)),
         (JsonValue::Number(ref n), SchemaPiece::Int) => Ok(Value::Int(
-            n.as_i64()
-                .unwrap()
-                .try_into()
-                .map_err(|e: TryFromIntError| e.to_string())?,
+            n.as_i64().unwrap().try_into().map_err_to_string()?,
         )),
         (JsonValue::Number(ref n), SchemaPiece::Long) => Ok(Value::Long(n.as_i64().unwrap())),
         (JsonValue::Number(ref n), SchemaPiece::Float) => {
@@ -116,11 +113,11 @@ pub fn from_json(json: &JsonValue, schema: SchemaNode) -> Result<Value, String> 
             }
         }
         (JsonValue::String(s), SchemaPiece::Json) => {
-            let j = serde_json::from_str(s).map_err(|e| e.to_string())?;
+            let j = serde_json::from_str(s).map_err_to_string()?;
             Ok(Value::Json(j))
         }
         (JsonValue::String(s), SchemaPiece::Uuid) => {
-            let u = uuid::Uuid::parse_str(&s).map_err(|e| e.to_string())?;
+            let u = uuid::Uuid::parse_str(&s).map_err_to_string()?;
             Ok(Value::Uuid(u))
         }
         (JsonValue::String(s), SchemaPiece::Enum { symbols, .. }) => {


### PR DESCRIPTION
This PR adds the following methods:

* `ResultExt::map_err_to_string` - to perform the (very common) conversion of Err(something that's Display) -> Err(error message as String), preserving all the context & additional information that we add with anyhow.
* `ResultExt::err_to_string` - to extract the error message from a Result reference (not sure this is useful, but it was possible)
* `DisplayExt::to_string_alt` - like to_string, but the equivalent of `format!("{:#}", obj)` instead of `{}`.

They all allow formatting error values as detailed strings, preserving any context that might have been added to the error.

Then, we adjust the call sites for `.map_err(|e| e.to_string())` to use `.map_err_to_string()` and do some more format-string readjustment to preserve as much context on errors as possible.