### PR TITLE
Shuffle rather than consolidate source data

### DIFF
--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -408,8 +408,8 @@ where
                 };
 
                 // Force a shuffling of data in case sources are not uniformly distributed.
-                use differential_dataflow::operators::Consolidate;
-                collection = collection.consolidate();
+                use timely::dataflow::operators::Exchange;
+                collection = collection.inner.exchange(|x| x.hashed()).as_collection();
 
                 // Implement source filtering and projection.
                 // At the moment this is strictly optional, but we perform it anyhow
@@ -494,6 +494,10 @@ where
                             .as_collection();
                     }
                 }
+
+                // Consolidate the results, as there may now be cancellations.
+                use differential_dataflow::operators::consolidate::ConsolidateStream;
+                collection = collection.consolidate_stream();
 
                 // Introduce the stream by name, as an unarranged collection.
                 self.insert_id(


### PR DESCRIPTION
This replaces a `consolidate` with an `exchange`, after source load. The intent was to introduce shuffling of records to balance subsequent work, but it was blocking on large loads at a single time (forming the appropriate batch). After the MFP and `as_of` work, I put a `consolidate_stream` in that will opportunistically consolidate the stream (it consolidates each message, rather than the entire timestamp; so not guaranteed total consolidation).