### PR TITLE
persist: preliminary changes to make working with Trace and Future easier

### DIFF
--- a/src/persist/src/indexed/encoding.rs
+++ b/src/persist/src/indexed/encoding.rs
@@ -117,8 +117,6 @@ pub struct BlobTraceMeta {
 /// - The updates field is non-empty.
 #[derive(Clone, Debug, Abomonation)]
 pub struct BlobFutureBatch<K, V> {
-    /// Id of the stream this batch belongs to.
-    pub id: Id,
     /// Which updates are included in this batch.
     pub desc: Description<SeqNo>,
     /// The updates themselves.
@@ -143,8 +141,6 @@ pub struct BlobFutureBatch<K, V> {
 /// for checksum and encryption?
 #[derive(Clone, Debug, Abomonation)]
 pub struct BlobTraceBatch<K, V> {
-    /// Id of the trace this batch belongs to.
-    pub id: Id,
     /// Which updates are included in this batch.
     pub desc: Description<u64>,
     /// The updates themselves.
@@ -488,7 +484,6 @@ mod tests {
     fn future_batch_validate() {
         // Normal case
         let b = BlobFutureBatch {
-            id: Id(0),
             desc: seqno_desc(0, 2),
             updates: vec![update_with_ts(0), update_with_ts(1)],
         };
@@ -496,7 +491,6 @@ mod tests {
 
         // Empty
         let b: BlobFutureBatch<String, String> = BlobFutureBatch {
-            id: Id(0),
             desc: seqno_desc(0, 2),
             updates: vec![],
         };
@@ -504,7 +498,6 @@ mod tests {
 
         // Invalid desc
         let b: BlobFutureBatch<String, String> = BlobFutureBatch {
-            id: Id(0),
             desc: seqno_desc(2, 0),
             updates: vec![],
         };
@@ -517,7 +510,6 @@ mod tests {
 
         // Empty desc
         let b: BlobFutureBatch<String, String> = BlobFutureBatch {
-            id: Id(0),
             desc: seqno_desc(0, 0),
             updates: vec![],
         };
@@ -530,7 +522,6 @@ mod tests {
 
         // Not sorted by time
         let b = BlobFutureBatch {
-            id: Id(0),
             desc: seqno_desc(0, 2),
             updates: vec![update_with_ts(1), update_with_ts(0)],
         };
@@ -543,7 +534,6 @@ mod tests {
 
         // Not consolidated
         let b = BlobFutureBatch {
-            id: Id(0),
             desc: seqno_desc(0, 2),
             updates: vec![update_with_ts(0), update_with_ts(0)],
         };
@@ -554,7 +544,6 @@ mod tests {
 
         // Invalid update
         let b: BlobFutureBatch<String, String> = BlobFutureBatch {
-            id: Id(0),
             desc: seqno_desc(0, 1),
             updates: vec![(("0".into(), "0".into()), 0, 0)],
         };
@@ -568,7 +557,6 @@ mod tests {
     fn trace_batch_validate() {
         // Normal case
         let b = BlobTraceBatch {
-            id: Id(0),
             desc: u64_desc(0, 2),
             updates: vec![update_with_key(0, "0"), update_with_key(1, "1")],
         };
@@ -576,7 +564,6 @@ mod tests {
 
         // Empty
         let b: BlobTraceBatch<String, String> = BlobTraceBatch {
-            id: Id(0),
             desc: u64_desc(0, 2),
             updates: vec![],
         };
@@ -584,7 +571,6 @@ mod tests {
 
         // Invalid desc
         let b: BlobTraceBatch<String, String> = BlobTraceBatch {
-            id: Id(0),
             desc: u64_desc(2, 0),
             updates: vec![],
         };
@@ -597,7 +583,6 @@ mod tests {
 
         // Empty desc
         let b: BlobTraceBatch<String, String> = BlobTraceBatch {
-            id: Id(0),
             desc: u64_desc(0, 0),
             updates: vec![],
         };
@@ -610,7 +595,6 @@ mod tests {
 
         // Not sorted by key
         let b = BlobTraceBatch {
-            id: Id(0),
             desc: u64_desc(0, 2),
             updates: vec![update_with_key(0, "1"), update_with_key(1, "0")],
         };
@@ -623,7 +607,6 @@ mod tests {
 
         // Not consolidated
         let b = BlobTraceBatch {
-            id: Id(0),
             desc: u64_desc(0, 2),
             updates: vec![update_with_key(0, "0"), update_with_key(0, "0")],
         };
@@ -634,7 +617,6 @@ mod tests {
 
         // Update "before" desc
         let b = BlobTraceBatch {
-            id: Id(0),
             desc: u64_desc(1, 2),
             updates: vec![update_with_key(0, "0")],
         };
@@ -642,7 +624,6 @@ mod tests {
 
         // Update "after" desc
         let b = BlobTraceBatch {
-            id: Id(0),
             desc: u64_desc(1, 2),
             updates: vec![update_with_key(2, "0")],
         };
@@ -650,7 +631,6 @@ mod tests {
 
         // Invalid update
         let b: BlobTraceBatch<String, String> = BlobTraceBatch {
-            id: Id(0),
             desc: u64_desc(0, 1),
             updates: vec![(("0".into(), "0".into()), 0, 0)],
         };

--- a/src/persist/src/indexed/future.rs
+++ b/src/persist/src/indexed/future.rs
@@ -180,7 +180,6 @@ impl<K: Clone, V: Clone> Snapshot<K, V> for FutureSnapshot<K, V> {
 
 #[cfg(test)]
 mod tests {
-    use crate::indexed::encoding::Id;
     use crate::mem::MemBlob;
 
     use super::*;
@@ -195,7 +194,6 @@ mod tests {
 
         // ts < ts_lower.data()[0] is disallowed
         let batch = BlobFutureBatch {
-            id: Id(0),
             desc: Description::new(
                 Antichain::from_elem(SeqNo(0)),
                 Antichain::from_elem(SeqNo(1)),
@@ -212,7 +210,6 @@ mod tests {
 
         // ts == ts_lower.data()[0] is allowed
         let batch = BlobFutureBatch {
-            id: Id(0),
             desc: Description::new(
                 Antichain::from_elem(SeqNo(0)),
                 Antichain::from_elem(SeqNo(1)),

--- a/src/persist/src/indexed/future.rs
+++ b/src/persist/src/indexed/future.rs
@@ -49,9 +49,9 @@ pub struct BlobFuture<K, V> {
 impl<K: Data, V: Data> BlobFuture<K, V> {
     /// Returns a BlobFuture re-instantiated with the previously serialized
     /// state.
-    pub fn new(id: Id, meta: BlobFutureMeta) -> Self {
+    pub fn new(meta: BlobFutureMeta) -> Self {
         BlobFuture {
-            id,
+            id: meta.id,
             next_blob_id: meta.next_blob_id,
             ts_lower: meta.ts_lower,
             batches: meta.batches,
@@ -70,6 +70,7 @@ impl<K: Data, V: Data> BlobFuture<K, V> {
     /// Serializes the state of this BlobFuture for later re-instantiation.
     pub fn meta(&self) -> BlobFutureMeta {
         BlobFutureMeta {
+            id: self.id,
             ts_lower: self.ts_lower.clone(),
             batches: self.batches.clone(),
             next_blob_id: self.next_blob_id,
@@ -195,14 +196,12 @@ mod tests {
     #[test]
     fn append_ts_lower_invariant() -> Result<(), Error> {
         let mut blob = BlobCache::new(MemBlob::new("append_ts_lower_invariant")?);
-        let mut f = BlobFuture::new(
-            Id(0),
-            BlobFutureMeta {
-                ts_lower: Antichain::from_elem(2),
-                batches: vec![],
-                next_blob_id: 0,
-            },
-        );
+        let mut f = BlobFuture::new(BlobFutureMeta {
+            id: Id(0),
+            ts_lower: Antichain::from_elem(2),
+            batches: vec![],
+            next_blob_id: 0,
+        });
 
         // ts < ts_lower.data()[0] is disallowed
         let batch = BlobFutureBatch {
@@ -236,14 +235,12 @@ mod tests {
 
     #[test]
     fn truncate_regress() {
-        let mut f: BlobFuture<String, String> = BlobFuture::new(
-            Id(0),
-            BlobFutureMeta {
-                ts_lower: Antichain::from_elem(2),
-                batches: vec![],
-                next_blob_id: 0,
-            },
-        );
+        let mut f: BlobFuture<String, String> = BlobFuture::new(BlobFutureMeta {
+            id: Id(0),
+            ts_lower: Antichain::from_elem(2),
+            batches: vec![],
+            next_blob_id: 0,
+        });
         assert_eq!(f.truncate(Antichain::from_elem(2)), Ok(()));
         assert_eq!(
             f.truncate(Antichain::from_elem(1)),

--- a/src/persist/src/indexed/mod.rs
+++ b/src/persist/src/indexed/mod.rs
@@ -27,7 +27,9 @@ use timely::PartialOrder;
 
 use crate::error::Error;
 use crate::indexed::cache::BlobCache;
-use crate::indexed::encoding::{BlobFutureBatch, BlobMeta, BlobTraceBatch, BufferEntry, Id};
+use crate::indexed::encoding::{
+    BlobFutureBatch, BlobFutureMeta, BlobMeta, BlobTraceBatch, BlobTraceMeta, BufferEntry, Id,
+};
 use crate::indexed::future::{BlobFuture, FutureSnapshot};
 use crate::indexed::trace::{BlobTrace, TraceSnapshot};
 use crate::storage::{Blob, Buffer, SeqNo};
@@ -68,7 +70,6 @@ use crate::Data;
 /// for indexed use, instead of the current situation, which is more complicated
 /// to reason about.
 pub struct Indexed<K, V, U: Buffer, L: Blob> {
-    last_file_id: u64,
     next_stream_id: Id,
     futures_seqno_upper: SeqNo,
     // This is conceptually a map from `String` -> `Id`, but lookups are rare
@@ -90,15 +91,14 @@ impl<K: Data, V: Data, U: Buffer, L: Blob> Indexed<K, V, U, L> {
         let futures = meta
             .futures
             .into_iter()
-            .map(|(id, meta)| (id, BlobFuture::new(meta)))
+            .map(|(id, meta)| (id, BlobFuture::new(id, meta)))
             .collect();
         let traces = meta
             .traces
             .into_iter()
-            .map(|(id, meta)| (id, BlobTrace::new(meta)))
+            .map(|(id, meta)| (id, BlobTrace::new(id, meta)))
             .collect();
         let indexed = Indexed {
-            last_file_id: meta.last_file_id,
             next_stream_id: meta.next_stream_id,
             futures_seqno_upper: meta.futures_seqno_upper,
             id_mapping: meta.id_mapping,
@@ -123,12 +123,6 @@ impl<K: Data, V: Data, U: Buffer, L: Blob> Indexed<K, V, U, L> {
         Ok(())
     }
 
-    fn new_blob_key(&mut self) -> String {
-        let file_id = self.last_file_id;
-        self.last_file_id = file_id + 1;
-        file_id.to_string()
-    }
-
     /// Creates, if necessary, a new future and trace with the given external
     /// stream name, returning the corresponding internal stream id.
     ///
@@ -144,8 +138,12 @@ impl<K: Data, V: Data, U: Buffer, L: Blob> Indexed<K, V, U, L> {
                 id
             }
         };
-        self.futures.entry(id).or_default();
-        self.traces.entry(id).or_default();
+        self.futures
+            .entry(id)
+            .or_insert_with_key(|id| BlobFuture::new(*id, BlobFutureMeta::default()));
+        self.traces
+            .entry(id)
+            .or_insert_with_key(|id| BlobTrace::new(*id, BlobTraceMeta::default()));
         id
     }
 
@@ -281,8 +279,7 @@ impl<K: Data, V: Data, U: Buffer, L: Blob> Indexed<K, V, U, L> {
             ),
             updates,
         };
-        let key = self.new_blob_key();
-        self.append_future(id, key, batch)?;
+        self.append_future(id, batch)?;
 
         Ok(())
     }
@@ -317,7 +314,6 @@ impl<K: Data, V: Data, U: Buffer, L: Blob> Indexed<K, V, U, L> {
         // amortize the work of doing so across frequent seal calls? All the
         // physical movement could live in `step`.
 
-        let key = self.new_blob_key();
         let future = self
             .futures
             .get_mut(&id)
@@ -352,39 +348,29 @@ impl<K: Data, V: Data, U: Buffer, L: Blob> Indexed<K, V, U, L> {
 
         // ...and atomically swapping that snapshot's data into trace.
         let batch = BlobTraceBatch { desc, updates };
-        self.append_trace(id, key, batch)
+        self.append_trace(id, batch)
 
         // TODO: This is a good point to compact future. The data that's been
         // moved is still there but now irrelevant. It may also be a good time
         // to compact trace.
     }
 
-    /// Appends the given `batch` to the trace for `id`, writing the data at
-    /// `key` in the blob storage.
+    /// Appends the given `batch` to the future for `id`, writing the data into
+    /// blob storage.
     ///
     /// The caller is responsible for updating META after they've finished
     /// updating futures.
-    fn append_future(
-        &mut self,
-        id: Id,
-        key: String,
-        batch: BlobFutureBatch<K, V>,
-    ) -> Result<(), Error> {
+    fn append_future(&mut self, id: Id, batch: BlobFutureBatch<K, V>) -> Result<(), Error> {
         let future = self
             .futures
             .get_mut(&id)
             .ok_or_else(|| Error::from(format!("never registered: {:?}", id)))?;
-        future.append(key, batch, &mut self.blob)
+        future.append(batch, &mut self.blob)
     }
 
-    /// Appends the given `batch` to the trace for `id`, writing the data at
-    /// `key` in the blob storage.
-    fn append_trace(
-        &mut self,
-        id: Id,
-        key: String,
-        batch: BlobTraceBatch<K, V>,
-    ) -> Result<(), Error> {
+    /// Appends the given `batch` to the trace for `id`, writing the data into
+    /// blob storage.
+    fn append_trace(&mut self, id: Id, batch: BlobTraceBatch<K, V>) -> Result<(), Error> {
         let trace = self
             .traces
             .get_mut(&id)
@@ -394,7 +380,7 @@ impl<K: Data, V: Data, U: Buffer, L: Blob> Indexed<K, V, U, L> {
             .get_mut(&id)
             .ok_or_else(|| Error::from(format!("never registered: {:?}", id)))?;
         let new_future_ts_lower = batch.desc.upper().clone();
-        trace.append(key, batch, &mut self.blob)?;
+        trace.append(batch, &mut self.blob)?;
         future.truncate(new_future_ts_lower)?;
 
         // Atomically update the meta with both the trace and future changes.
@@ -406,7 +392,6 @@ impl<K: Data, V: Data, U: Buffer, L: Blob> Indexed<K, V, U, L> {
 
     fn serialize_meta(&self) -> BlobMeta {
         BlobMeta {
-            last_file_id: self.last_file_id,
             next_stream_id: self.next_stream_id,
             futures_seqno_upper: self.futures_seqno_upper,
             id_mapping: self.id_mapping.clone(),

--- a/src/persist/src/indexed/mod.rs
+++ b/src/persist/src/indexed/mod.rs
@@ -91,12 +91,12 @@ impl<K: Data, V: Data, U: Buffer, L: Blob> Indexed<K, V, U, L> {
         let futures = meta
             .futures
             .into_iter()
-            .map(|(id, meta)| (id, BlobFuture::new(id, meta)))
+            .map(|meta| (meta.id, BlobFuture::new(meta)))
             .collect();
         let traces = meta
             .traces
             .into_iter()
-            .map(|(id, meta)| (id, BlobTrace::new(id, meta)))
+            .map(|meta| (meta.id, BlobTrace::new(meta)))
             .collect();
         let indexed = Indexed {
             next_stream_id: meta.next_stream_id,
@@ -140,10 +140,10 @@ impl<K: Data, V: Data, U: Buffer, L: Blob> Indexed<K, V, U, L> {
         };
         self.futures
             .entry(id)
-            .or_insert_with_key(|id| BlobFuture::new(*id, BlobFutureMeta::default()));
+            .or_insert_with_key(|id| BlobFuture::new(BlobFutureMeta::new(*id)));
         self.traces
             .entry(id)
-            .or_insert_with_key(|id| BlobTrace::new(*id, BlobTraceMeta::default()));
+            .or_insert_with_key(|id| BlobTrace::new(BlobTraceMeta::new(*id)));
         id
     }
 
@@ -398,13 +398,9 @@ impl<K: Data, V: Data, U: Buffer, L: Blob> Indexed<K, V, U, L> {
             futures: self
                 .futures
                 .iter()
-                .map(|(id, future)| (*id, future.meta()))
+                .map(|(_, future)| future.meta())
                 .collect(),
-            traces: self
-                .traces
-                .iter()
-                .map(|(id, trace)| (*id, trace.meta()))
-                .collect(),
+            traces: self.traces.iter().map(|(_, trace)| trace.meta()).collect(),
         }
     }
 

--- a/src/persist/src/indexed/trace.rs
+++ b/src/persist/src/indexed/trace.rs
@@ -50,13 +50,13 @@ pub struct BlobTrace<K, V> {
 impl<K: Data, V: Data> BlobTrace<K, V> {
     /// Returns a BlobTrace re-instantiated with the previously serialized
     /// state.
-    pub fn new(id: Id, meta: BlobTraceMeta) -> Self {
+    pub fn new(meta: BlobTraceMeta) -> Self {
         let mut since = Antichain::from_elem(Timestamp::minimum());
         for (desc, _) in meta.batches.iter() {
             since = since.join(desc.since());
         }
         BlobTrace {
-            id,
+            id: meta.id,
             next_blob_id: meta.next_blob_id,
             since: since,
             batches: meta.batches,
@@ -74,6 +74,7 @@ impl<K: Data, V: Data> BlobTrace<K, V> {
     /// Serializes the state of this BlobTrace for later re-instantiation.
     pub fn meta(&self) -> BlobTraceMeta {
         BlobTraceMeta {
+            id: self.id,
             batches: self.batches.clone(),
             next_blob_id: self.next_blob_id,
         }


### PR DESCRIPTION
These commits change the API between the `Indexed`, `Future`/ `Trace` and `Blob` layers in order to make future compaction work easier.

The first commit gets rid of the `id` field inside batches as this field was never being read.

The second commit makes it so that `Indexed` layer calls `append` to `Future` and `Trace` which themselves pick the appropriate keys. As a result now `Blob` keys can more easily encode semantic information. 

The third commit folds the `Id` information into `BlobTraceMeta` and `BlobFutureMeta` to make everything easier to use / harder to misuse. This commit is purely a refactor / not a functional change.