### PR TITLE
play: use some Materialize idioms in json-flattened-view-gen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1968,10 +1968,11 @@ checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 name = "json-flattened-view-gen"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "ore",
  "serde",
  "serde_json",
  "structopt",
- "thiserror",
 ]
 
 [[package]]

--- a/play/json-flattened-view-gen/Cargo.toml
+++ b/play/json-flattened-view-gen/Cargo.toml
@@ -1,15 +1,14 @@
 [package]
 name = "json-flattened-view-gen"
 version = "0.1.0"
-edition = "2018"
 authors = ["Materialize, Inc."]
 license = "Apache-2.0"
+edition = "2018"
 publish = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-serde = "1"
-serde_json = "1"
-structopt = "0.3"
-thiserror = "1"
+anyhow = "1.0.42"
+serde = "1.0.126"
+serde_json = "1.0.64"
+structopt = "0.3.22"
+ore = { path = "../../src/ore" }


### PR DESCRIPTION
This commit contains just a few minor changes to the
json-flattened-view-gen program based on Materialize style:

  * Sorting of Cargo.toml via `cargo manifmt`.
  * Use of `anyhow::Error` instead of `thiserror`. We try to use
    `anyhow::Error` whenever errors don't need to be programatically
    handled (as is the case here), and manually-written error enums
    otherwise.
  * Use of the `ore::cli::parse_args` helper to handle interaction with
    structopt, for consistency with our other CLI tools.