### PR TITLE
repr: support chrono leap seconds

### DIFF
--- a/src/repr/tests/strconv.rs
+++ b/src/repr/tests/strconv.rs
@@ -97,6 +97,10 @@ fn test_parse_time() {
     run_test_parse_time("01:02:03", NaiveTime::from_hms(1, 2, 3));
     run_test_parse_time("02:03.456", NaiveTime::from_hms_nano(0, 2, 3, 456_000_000));
     run_test_parse_time("01:02", NaiveTime::from_hms(1, 2, 0));
+
+    // Regression for #6272.
+    run_test_parse_time("9::60", NaiveTime::from_hms_nano(9, 0, 59, 1_000_000_000));
+
     fn run_test_parse_time(s: &str, t: NaiveTime) {
         assert_eq!(strconv::parse_time(s).unwrap(), t);
     }

--- a/test/sqllogictest/dates-times.slt
+++ b/test/sqllogictest/dates-times.slt
@@ -1084,3 +1084,19 @@ SELECT '"2020!03-17 #?~T~02:36:56#"'::timestamp;
 
 query error invalid input syntax for type timestamp: have unprocessed tokens 56
 select TIMESTAMP '"2020-03-17 ~02:36:~56~"';
+
+# Regression for #6272. These match postgres.
+query TTT
+select '9::60'::time, '9:59:60'::time, '9::59.999999'::time
+----
+09:01:00 10:00:00 09:00:59.999999
+
+# TODO: Postgres returns 09:01:00 for this.
+query T
+select '9::59.999999999'::time
+----
+09:00:59.999999
+
+# TODO: Postgres supports this as 09:01:00.1.
+statement error invalid input syntax for type time: NANOSECOND
+select '9::60.1'::time


### PR DESCRIPTION
60 is a supported number of seconds in postgres, and in our datetime
parsing. However chrono expects seconds to be limited to 59 and allows a
leap second to be put into the nanosecond part. Have our validation logic
do that conversion. This should maybe happen in another place, but we have
other known problems and just preventing a panic is good enough for now.

We still have differences from postgres, but one less panic.

Fixes #7432
Fixes #6272