### PR TITLE
http-util: support no_proxy environment variable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1624,9 +1624,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7245cd7449cc792608c3c8a9eaf69bd4eabbabf802713748fd739c98b82f0747"
+checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
 dependencies = [
  "bytes",
  "fnv",
@@ -1647,9 +1647,12 @@ dependencies = [
 name = "http-util"
 version = "0.0.0"
 dependencies = [
+ "http",
  "hyper",
  "hyper-proxy",
  "hyper-tls",
+ "ipnet",
+ "lazy_static",
  "log",
  "reqwest",
 ]
@@ -1880,9 +1883,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
+checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
 name = "itertools"

--- a/doc/user/content/cli/_index.md
+++ b/doc/user/content/cli/_index.md
@@ -350,6 +350,21 @@ Using these parameters correctly requires substantial knowledge about how
 the underlying Timely and Differential Dataflow engines work. Typically you
 should only set these parameters in consultation with Materialize engineers.
 
+## Special environment variables
+
+Materialize respects several environment variables that have conventional
+meanings in Unix systems.
+
+### HTTP proxies
+
+The `http_proxy`, `https_proxy`, `all_proxy`, and `no_proxy` environment
+variables specify a proxy to use for outgoing HTTP and HTTPS traffic. There is
+no precise specification of how these variables behave, but Materialize's
+behavior generally matches the behavior of other HTTP clients.
+
+For precise details of Materialize's behavior, consult our
+[developer docs](https://dev.materialize.com/api/rust/http_util/index.html#System_proxy_configuration).
+
 [gh-feature]: https://github.com/MaterializeInc/materialize/issues/new?labels=C-feature&template=feature.md
 [scv]: /sql/show-create-view
 [scs]: /sql/show-create-source

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -48,6 +48,12 @@ Wrap your release notes at the 80 character mark.
 
 {{% version-header v0.8.4 %}}
 
+- **Breaking change.** The `HTTP_PROXY` variable is no longer respected. Use
+  `http_proxy` instead.
+
+- Respect the [`no_proxy` environment variable](/cli/#http-proxies) to exclude
+  certain hosts from the configured HTTP/HTTPS proxy, if any.
+
 {{% version-header v0.8.3 %}}
 
 - The `MZ_LOG` environment variable is no longer recognized. Setting the log

--- a/src/aws-util/src/client.rs
+++ b/src/aws-util/src/client.rs
@@ -24,10 +24,10 @@ use rusoto_sqs::SqsClient;
 
 use crate::aws::ConnectInfo;
 
-/// Get an [`HttpClient`]  that respects the `http_proxy` environment variables
-pub(crate) fn http() -> Result<HttpClient<http_util::ProxiedConnector>, anyhow::Error> {
+/// Gets an [`HttpClient`] that respects the system proxy configuration.
+pub(crate) fn http() -> Result<HttpClient<http_util::hyper::Connector>, anyhow::Error> {
     Ok(HttpClient::from_connector(
-        http_util::connector().map_err(|e| anyhow!(e))?,
+        http_util::hyper::connector().map_err(|e| anyhow!(e))?,
     ))
 }
 

--- a/src/ccsr/src/config.rs
+++ b/src/ccsr/src/config.rs
@@ -7,7 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use anyhow::Context;
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
 
@@ -64,8 +63,7 @@ impl ClientConfig {
 
     /// Builds the [`Client`].
     pub fn build(self) -> Result<Client, anyhow::Error> {
-        let mut builder = http_util::reqwest_client_builder()
-            .context("Creating HTTP client for schema registry")?;
+        let mut builder = http_util::reqwest::client_builder();
 
         for root_cert in self.root_certs {
             builder = builder.add_root_certificate(root_cert.into());

--- a/src/http-util/Cargo.toml
+++ b/src/http-util/Cargo.toml
@@ -7,8 +7,11 @@ edition = "2018"
 publish = false
 
 [dependencies]
+http = "0.2.4"
 hyper = "0.14.10"
 hyper-proxy = "0.9.1"
 hyper-tls = "0.5.0"
+ipnet = "2.3.1"
+lazy_static = "1.1.1"
 log = "0.4.13"
 reqwest = "0.11.4"

--- a/src/http-util/src/hyper.rs
+++ b/src/http-util/src/hyper.rs
@@ -1,0 +1,52 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Adapters for [`hyper`].
+
+use std::error::Error;
+
+use hyper::client::HttpConnector;
+use hyper_proxy::{Proxy, ProxyConnector};
+use hyper_tls::HttpsConnector;
+
+use crate::proxy::PROXY_CONFIG;
+
+/// A proxying HTTPS connector for hyper.
+pub type Connector = ProxyConnector<HttpsConnector<HttpConnector>>;
+
+/// Create a `hyper` connector that obeys the system proxy configuration.
+///
+/// For details about the system proxy configuration, see the
+/// [crate documentation](crate).
+pub fn connector() -> Result<Connector, Box<dyn Error + Send + Sync>> {
+    let mut connector = ProxyConnector::new(HttpsConnector::new())?;
+
+    if let Some(http_proxy) = PROXY_CONFIG.http_proxy() {
+        let matches = move |scheme: Option<&str>, host: Option<&str>, port| {
+            scheme == Some("http") && !PROXY_CONFIG.exclude(scheme, host, port)
+        };
+        connector.add_proxy(Proxy::new(matches, http_proxy.clone()));
+    }
+
+    if let Some(https_proxy) = PROXY_CONFIG.https_proxy() {
+        let matches = move |scheme: Option<&str>, host: Option<&str>, port| {
+            scheme == Some("https") && !PROXY_CONFIG.exclude(scheme, host, port)
+        };
+        connector.add_proxy(Proxy::new(matches, https_proxy.clone()));
+    }
+
+    if let Some(all_proxy) = PROXY_CONFIG.all_proxy() {
+        let matches = move |scheme: Option<&str>, host: Option<&str>, port| {
+            !PROXY_CONFIG.exclude(scheme, host, port)
+        };
+        connector.add_proxy(Proxy::new(matches, all_proxy.clone()));
+    }
+
+    Ok(connector)
+}

--- a/src/http-util/src/lib.rs
+++ b/src/http-util/src/lib.rs
@@ -7,85 +7,81 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! Utilities for constructing HTTP Clients
+#![deny(missing_docs)]
 
-use hyper::Uri;
-use hyper_proxy::{Intercept, Proxy, ProxyConnector};
-use hyper_tls::HttpsConnector;
-use log::debug;
+//! HTTP utilities.
+//!
+//! This crate constructs HTTP clients that respect the system's proxy
+//! configuration.
+//!
+//! # System proxy configuration
+//!
+//! The system's proxy configuration is governed by four environment variables,
+//! `http_proxy`, `https_proxy`, `all_proxy`, and `no_proxy`, whose meanings are
+//! nonstandard and vary widely from tool to tool. Materialize implements a
+//! subset of the behavior that has been empirically determined to be common to
+//! many other HTTP clients.
+//!
+//! With the exception of `http_proxy`, environment variables may be specified
+//! in all lowercase, as written above, or in all uppercase (e.g, `HTTPS_PROXY`)
+//! (http_proxy` is accepted in lowercase only because the variable `HTTP_PROXY`
+//! can be controlled by attackers in CGI environments, as in
+//! [golang/go#16405].) If an environment variable is specified in both
+//! lowercase and uppercase, the lowercase variable takes precedence.
+//!
+//! ## Proxy selection
+//!
+//! The `http_proxy` and `https_proxy` environment variables specify the URL of
+//! a proxy server to use when routing HTTP and HTTPS traffic, respectively. The
+//! `all_proxy` environment variable specifies a proxy server that applies to
+//! both HTTP and HTTPS traffic. `http_proxy` and `https_proxy` take precedence
+//! over `all_proxy`.
+//!
+//! ## Proxy exclusions
+//!
+//! The `no_proxy` environment variable is a comma-separated list specifying
+//! hosts to exclude from proxying. It takes precedence over the other
+//! environment variables. Each entry in the list must be:
+//!
+//!   * an IP address followed by an optional port (e.g., `1.2.3.4`,
+//!     `1.2.3.4:80`, `::1`, `[::1]`, or `[::1]:80`),
+//!   * an IP address prefix in CIDR notation (e.g., `1.1.0.0/16`), or
+//!   * a domain name followed by an optional port (e.g., `foo.com`).
+//!
+//! Whitespace surrounding an entry is ignored.
+//!
+//! IPv6 addresses cannot contain whitespace inside the `[` and `]` characters
+//! or they will be treated as domains. IPv6 addresses that are followed by a
+//! port specification must be surrounded by `[` and `]` or the port will be
+//! considered part of the IPv6 address. (The implementation technically allows
+//! IPv4 addresses to be wrapped in square brackets as well, for compatibility
+//! with other tools, but this should not be relied upon.)
+//!
+//! `no_proxy` matching never involves DNS resolution, so a `no_proxy` value of
+//! `1.2.3.4` will exclude requests that literally mention the IP in the URL
+//! (e.g., `http://1.2.3.4`) from proxying, but not requests to
+//! `http://domainthatresolvesto1234`.
+//!
+//! Domain names in `no_proxy` match all subdomains, so a `no_proxy` value of
+//! `materialize.com` will exclude requests to both `materialize.com` and
+//! `cloud.materialize.com` from proxying. For compatibility with other tools,
+//! domain names can include one optional `.` character at the start, which is
+//! ignored.
+//!
+//! Invalid entries in the list are silently ignored.
+//!
+//! If the `no_proxy` environment variable is set to the special value `*`, then
+//! all addresses will be excluded from proxying.
+//!
+//! ## See also
+//!
+//! For further details on these environment variables, see the GitLab blog
+//! article ["We need to talk: can we standardize NO_PROXY?"][gitlab-blog].
+//!
+//! [golang/go#16405]: https://github.com/golang/go/issues/16405
+//! [gitlab-blog]: https://about.gitlab.com/blog/2021/01/27/we-need-to-talk-no-proxy/
 
-/// A proxied HTTP Connector
-pub type ProxiedConnector = ProxyConnector<HttpsConnector<hyper::client::HttpConnector>>;
+mod proxy;
 
-/// Get an [`ProxiedConnector`] that respects the `http_proxy` environment variables
-///
-/// This can be used with [`hyper::client::Builder::build`] to create a client that uses the proxy.
-/// Anywhere that expects a [`hyper::client::HttpConnector`] might be able to use the output of this, as
-/// well.
-pub fn connector() -> Result<ProxiedConnector, Box<dyn std::error::Error + Send + Sync>> {
-    let inner = HttpsConnector::new();
-    let mut connector = ProxyConnector::new(inner)?;
-    for var in &["http_proxy", "HTTP_PROXY"] {
-        if let Ok(proxy_url) = std::env::var(var) {
-            let proxy = Proxy::new(Intercept::Http, proxy_url.parse::<Uri>()?);
-            connector.add_proxy(proxy);
-            debug!("Using HTTP proxy: {}", proxy_url);
-            break;
-        }
-    }
-
-    for var in &["https_proxy", "HTTPS_PROXY"] {
-        if let Ok(proxy_url) = std::env::var(var) {
-            let proxy = Proxy::new(Intercept::Https, proxy_url.parse::<Uri>()?);
-            connector.add_proxy(proxy);
-            debug!("Using HTTPS proxy: {}", proxy_url);
-            break;
-        }
-    }
-
-    for var in &["all_proxy", "ALL_PROXY"] {
-        if let Ok(proxy_url) = std::env::var(var) {
-            let proxy = Proxy::new(Intercept::All, proxy_url.parse::<Uri>()?);
-            connector.add_proxy(proxy);
-            debug!("Using HTTP/HTTPS proxy: {}", proxy_url);
-            break;
-        }
-    }
-
-    Ok(connector)
-}
-
-/// Create a `reqwest` client builder that obeys `http_proxy` environment variables
-pub fn reqwest_client_builder() -> Result<reqwest::ClientBuilder, reqwest::Error> {
-    let mut builder = reqwest::ClientBuilder::new();
-    for var in &["http_proxy", "HTTP_PROXY"] {
-        if let Ok(proxy_url) = std::env::var(var) {
-            debug!("Using HTTP proxy for reqwest: {}", proxy_url);
-            builder = builder.proxy(reqwest::Proxy::http(proxy_url)?);
-            break;
-        }
-    }
-
-    for var in &["https_proxy", "HTTPS_PROXY"] {
-        if let Ok(proxy_url) = std::env::var(var) {
-            debug!("Using HTTPS proxy for reqwest: {}", proxy_url);
-            builder = builder.proxy(reqwest::Proxy::https(proxy_url)?);
-            break;
-        }
-    }
-
-    for var in &["all_proxy", "ALL_PROXY"] {
-        if let Ok(proxy_url) = std::env::var(var) {
-            debug!("Using HTTP/HTTPS proxy for reqwest: {}", proxy_url);
-            builder = builder.proxy(reqwest::Proxy::all(proxy_url)?);
-            break;
-        }
-    }
-
-    Ok(builder)
-}
-
-/// Create a `reqwest` client that obeys `http_proxy` environment variables
-pub fn reqwest_client() -> Result<reqwest::Client, reqwest::Error> {
-    Ok(reqwest_client_builder()?.build()?)
-}
+pub mod hyper;
+pub mod reqwest;

--- a/src/http-util/src/proxy.rs
+++ b/src/http-util/src/proxy.rs
@@ -1,0 +1,407 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! System proxy configuration guts.
+//!
+//! This module analyzes the system proxy configuration as described in the
+//! crate root. If you update the behavior here, please update the description
+//! there.
+
+use std::env;
+use std::net::IpAddr;
+use std::str::FromStr;
+
+use http::uri::{Authority, Uri};
+use ipnet::IpNet;
+use lazy_static::lazy_static;
+
+use self::matchers::{DomainMatcher, IpMatcher};
+
+lazy_static! {
+    pub static ref PROXY_CONFIG: ProxyConfig = load_system_config();
+}
+
+fn load_system_config() -> ProxyConfig {
+    fn get_any_env(names: &[&str]) -> Option<String> {
+        let val = names
+            .iter()
+            .map(|n| env::var(n))
+            .find(|v| *v != Err(env::VarError::NotPresent));
+        match val {
+            Some(Ok(val)) => Some(val),
+            Some(Err(e)) => {
+                log::warn!("ignoring invalid configuration for {}: {}", names[0], e);
+                None
+            }
+            None => None,
+        }
+    }
+
+    fn parse_env_uri(names: &[&str]) -> Option<Uri> {
+        match get_any_env(names)?.parse() {
+            Ok(uri) => Some(uri),
+            Err(e) => {
+                log::warn!("ignoring invalid configuration for {}: {}", names[0], e);
+                None
+            }
+        }
+    }
+
+    let http_proxy = parse_env_uri(&["http_proxy"]);
+    let https_proxy = parse_env_uri(&["https_proxy", "HTTPS_PROXY"]);
+    let all_proxy = parse_env_uri(&["all_proxy", "ALL_PROXY"]);
+    let no_proxy = get_any_env(&["no_proxy", "NO_PROXY"])
+        .map(|s| NoProxy::parse(&s))
+        .unwrap_or(NoProxy::None);
+
+    ProxyConfig {
+        http_proxy,
+        https_proxy,
+        all_proxy,
+        no_proxy,
+    }
+}
+
+/// The analyzed proxy configuration.
+#[derive(Debug, Clone)]
+pub struct ProxyConfig {
+    http_proxy: Option<Uri>,
+    https_proxy: Option<Uri>,
+    all_proxy: Option<Uri>,
+    no_proxy: NoProxy,
+}
+
+impl ProxyConfig {
+    /// Returns the proxy to use for HTTP requests, if any.
+    pub fn http_proxy(&self) -> Option<&Uri> {
+        self.http_proxy.as_ref()
+    }
+
+    /// Returns the proxy to use for HTTPS requests, if any.
+    pub fn https_proxy(&self) -> Option<&Uri> {
+        self.https_proxy.as_ref()
+    }
+
+    /// Returns the proxy to use for HTTP or HTTPS requests, if any.
+    ///
+    /// The proxies returned by [`ProxyConfig::http_proxy`] and
+    /// [`ProxyConfig::https_proxy`] take precedence if present.
+    pub fn all_proxy(&self) -> Option<&Uri> {
+        self.all_proxy.as_ref()
+    }
+
+    /// Reports whether the request composed of the given URL scheme, host, and
+    /// port should be excluded from proxying.
+    pub fn exclude(&self, scheme: Option<&str>, host: Option<&str>, port: Option<u16>) -> bool {
+        self.no_proxy.matches(scheme, host, port)
+    }
+}
+
+#[derive(Debug, Clone)]
+enum NoProxy {
+    None,
+    Some {
+        ips: Vec<matchers::IpMatcher>,
+        hosts: Vec<matchers::DomainMatcher>,
+    },
+    All,
+}
+
+impl NoProxy {
+    fn parse(s: &str) -> NoProxy {
+        match s.trim() {
+            "" => NoProxy::None,
+            "*" => NoProxy::All,
+            _ => {
+                let mut ips = vec![];
+                let mut hosts = vec![];
+                for host in s.split(',') {
+                    let host = host.trim();
+
+                    // If the entire entry is a CIDR-formatted IP prefix,
+                    // we're done. To match Go, we don't allow these to carry
+                    // port constraints.
+                    if let Ok(net) = IpNet::from_str(host) {
+                        ips.push(IpMatcher::from_net(net));
+                        continue;
+                    }
+
+                    // See if we can split into a host and port. Ignore errors,
+                    // because bare IPv6 addresses are not valid authorities but
+                    // they *are* valid in `no_proxy`.
+                    let authority = Authority::from_str(host).ok();
+                    let (mut host, port) = match &authority {
+                        Some(authority) => (authority.host(), authority.port_u16()),
+                        None => (host, None),
+                    };
+
+                    // Trim the brackets surrounding an IPv6 address, if
+                    // present.
+                    if let Some(h) = host.strip_prefix('[') {
+                        if let Some(h) = h.strip_suffix(']') {
+                            host = h;
+                        }
+                    }
+
+                    // If we've trimmed off so much that the host is now empty,
+                    // just ignore this entry.
+                    if host.is_empty() {
+                        continue;
+                    }
+
+                    // If it parses as an IP address, treat it as such.
+                    // Otherwise treat it as a domain name.
+                    if let Ok(addr) = IpAddr::from_str(host) {
+                        ips.push(IpMatcher::from_addr(addr, port))
+                    } else {
+                        hosts.push(DomainMatcher::new(host, port))
+                    }
+                }
+                NoProxy::Some { ips, hosts }
+            }
+        }
+    }
+
+    fn matches(&self, scheme: Option<&str>, host: Option<&str>, port: Option<u16>) -> bool {
+        match self {
+            NoProxy::None => false,
+            NoProxy::All => true,
+            NoProxy::Some { ips, hosts } => {
+                // If the host is missing, no proxying is required.
+                //
+                // NOTE(benesch): is the host ever missing in practice?
+                let host = match host {
+                    Some(host) => host.to_lowercase(),
+                    None => return false,
+                };
+
+                // Trim the brackets surrounding an IPv6 address, if
+                // present.
+                let mut host = host.as_str();
+                if let Some(h) = host.strip_prefix('[') {
+                    if let Some(h) = h.strip_suffix(']') {
+                        host = h;
+                    }
+                }
+
+                // We need a port, but we can infer it from the scheme if
+                // necessary. If we have an unknown scheme and port, just give
+                // up, though it doesn't seem like this will happen in practice.
+                let port = match (scheme, port) {
+                    (_, Some(port)) => port,
+                    (Some("https"), None) => 443,
+                    (Some("http"), None) => 80,
+                    _ => return false,
+                };
+
+                // If it parses as an IP address, try to find an IP address
+                // exclusion that applies. Otherwise try to find a domain
+                // exclusion that applies.
+                if let Ok(addr) = IpAddr::from_str(host) {
+                    ips.iter().any(|m| m.matches(addr, port))
+                } else {
+                    hosts.iter().any(|m| m.matches(host, port))
+                }
+            }
+        }
+    }
+}
+
+mod matchers {
+    use std::net::IpAddr;
+
+    use ipnet::IpNet;
+
+    #[derive(Debug, Clone)]
+    pub struct IpMatcher {
+        net: IpNet,
+        port: Option<u16>,
+    }
+
+    impl IpMatcher {
+        pub fn from_net(net: IpNet) -> IpMatcher {
+            IpMatcher { net, port: None }
+        }
+
+        pub fn from_addr(mut addr: IpAddr, port: Option<u16>) -> IpMatcher {
+            Self::normalize_addr(&mut addr);
+            IpMatcher {
+                net: addr.into(),
+                port,
+            }
+        }
+
+        pub fn matches(&self, mut addr: IpAddr, port: u16) -> bool {
+            Self::normalize_addr(&mut addr);
+            self.net.contains(&addr) && (self.port.is_none() || self.port == Some(port))
+        }
+
+        fn normalize_addr(addr: &mut IpAddr) {
+            // Normalize IPv4-mapped IPv6 addresses to IPv4.
+            if let IpAddr::V6(v6_addr) = addr {
+                if let Some(v4_addr) = v6_addr.to_ipv4() {
+                    *addr = IpAddr::V4(v4_addr);
+                }
+            }
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    pub struct DomainMatcher {
+        domain: String,
+        port: Option<u16>,
+    }
+
+    impl DomainMatcher {
+        pub fn new(host: &str, port: Option<u16>) -> DomainMatcher {
+            let mut domain = host.to_lowercase();
+            // We ensure that the domain starts with a `.`, as in
+            // `.materialize.com`, so that we can match `re.materialize.com` but
+            // not `rematerialize.com`.
+            if !domain.starts_with('.') {
+                domain.insert(0, '.')
+            }
+            DomainMatcher { domain, port }
+        }
+
+        pub fn matches(&self, host: &str, port: u16) -> bool {
+            debug_assert_eq!(&self.domain[0..1], ".");
+            (host == &self.domain[1..] || host.ends_with(&self.domain))
+                && (self.port.is_none() || self.port == Some(port))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use http::Uri;
+
+    use super::NoProxy;
+
+    #[test]
+    fn test_no_proxy() {
+        struct TestCase {
+            no_proxy: &'static str,
+            matches: &'static [&'static str],
+            nonmatches: &'static [&'static str],
+        }
+
+        let test_cases = &[
+            // Adapted from Python's urllib.
+            TestCase {
+                no_proxy: "localhost, anotherdomain.com, newdomain.com:1234, .d.o.t",
+                matches: &[
+                    "http://localhost",
+                    "http://LocalHost",
+                    "http://LOCALHOST",
+                    "http://newdomain.com:1234",
+                    "http://foo.d.o.t",
+                    "http://d.o.t",
+                    "http://anotherdomain.com:8888",
+                    "http://www.newdomain.com:1234",
+                ],
+                nonmatches: &[
+                    "http://prelocalhost",
+                    "http://newdomain.com",
+                    "http://newdomain.com:1235",
+                ],
+            },
+            // Adapted from Go's golang.org/x/net/http/httpproxy package.
+            TestCase {
+                no_proxy: "foobar.com, .barbaz.net, \
+                           192.168.1.1, 192.168.1.2:81, 192.168.1.3:80, 10.0.0.0/30, \
+                           2001:db8::52:0:1, [2001:db8::52:0:2]:443, [2001:db8::52:0:3]:80, \
+                           2002:db8:a::45/64",
+                matches: &[
+                    "http://192.168.1.1",
+                    "http://192.168.1.3",
+                    "http://10.0.0.2",
+                    "http://[2001:db8::52:0:1]",
+                    "http://[2001:db8::52:0:3]",
+                    "http://[2002:db8:a::123]",
+                    "http://www.barbaz.net",
+                    "http://barbaz.net",
+                    "http://foobar.com",
+                    "http://www.foobar.com",
+                ],
+                nonmatches: &[
+                    "http://192.168.1.2",
+                    "http://192.168.1.4",
+                    "http://[2001:db8::52:0:2]",
+                    "http://[fe80::424b:c8be:1643:a1b6]",
+                    "http://foofoobar.com",
+                    "http://baz.com",
+                    "http://localhost.net",
+                    "http://local.localhost",
+                    "http://barbarbaz.net",
+                ],
+            },
+            // SSL port inference.
+            TestCase {
+                no_proxy: "example.com:443",
+                matches: &["https://example.com"],
+                nonmatches: &["http://example.com"],
+            },
+            // Wildcards. Also adapted from Python's urllib.
+            TestCase {
+                no_proxy: "*",
+                matches: &["http://newdomain.com", "http://newdomain.com:1234"],
+                nonmatches: &[],
+            },
+            TestCase {
+                no_proxy: "*, anotherdomain.com",
+                matches: &["http://anotherdomain.com"],
+                nonmatches: &["http://newdomain.com", "http://newdomain.com:1234"],
+            },
+            // Empty entries.
+            TestCase {
+                no_proxy: ",  , []",
+                matches: &[],
+                nonmatches: &["http://anydomain.com"],
+            },
+            // IPv4-mapped IPv6 addresses.
+            TestCase {
+                no_proxy: "::ffff:192.168.1.1",
+                matches: &["http://192.168.1.1", "http://[::ffff:192.168.1.1]"],
+                nonmatches: &["http://192.168.1.2", "http://[::ffff:192.168.1.2]"],
+            },
+            TestCase {
+                no_proxy: "192.168.1.1",
+                matches: &["http://192.168.1.1", "http://[::ffff:192.168.1.1]"],
+                nonmatches: &["http://192.168.1.2", "http://[::ffff:192.168.1.2]"],
+            },
+        ];
+
+        for test_case in test_cases {
+            let no_proxy = NoProxy::parse(test_case.no_proxy);
+
+            for uri in test_case.matches {
+                let uri = Uri::from_str(uri).unwrap();
+                assert!(
+                    no_proxy.matches(uri.scheme_str(), uri.host(), uri.port_u16()),
+                    "no_proxy '{}' did not match '{}' as expected",
+                    test_case.no_proxy,
+                    uri,
+                );
+            }
+
+            for uri in test_case.nonmatches {
+                let uri = Uri::from_str(uri).unwrap();
+                assert!(
+                    !no_proxy.matches(uri.scheme_str(), uri.host(), uri.port_u16()),
+                    "no_proxy '{}' unexpectedly matched '{}'",
+                    test_case.no_proxy,
+                    uri,
+                );
+            }
+        }
+    }
+}

--- a/src/http-util/src/reqwest.rs
+++ b/src/http-util/src/reqwest.rs
@@ -1,0 +1,52 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Adapters for `reqwest`.
+
+use reqwest::ClientBuilder;
+
+use crate::proxy::PROXY_CONFIG;
+
+/// Creates a `reqwest` client builder that obeys the system proxy
+/// configuration.
+///
+/// For details about the system proxy configuration, see the
+/// [crate documentation](crate).
+pub fn client_builder() -> ClientBuilder {
+    let proxy = reqwest::Proxy::custom(move |url| {
+        if PROXY_CONFIG.exclude(Some(url.scheme()), url.host_str(), url.port()) {
+            return None;
+        }
+        if let Some(http_proxy) = PROXY_CONFIG.http_proxy() {
+            if url.scheme() == "http" {
+                return Some(http_proxy.to_string());
+            }
+        }
+        if let Some(https_proxy) = PROXY_CONFIG.https_proxy() {
+            if url.scheme() == "https" {
+                return Some(https_proxy.to_string());
+            }
+        }
+        if let Some(all_proxy) = PROXY_CONFIG.all_proxy() {
+            return Some(all_proxy.to_string());
+        }
+        None
+    });
+    reqwest::ClientBuilder::new().proxy(proxy)
+}
+
+/// Creates a `reqwest` client that obeys the system proxy configuration.
+///
+/// For details about the system proxy configuration, see the
+/// [crate documentation](crate).
+pub fn client() -> reqwest::Client {
+    client_builder()
+        .build()
+        .expect("reqwest::Client known to be valid")
+}

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -499,7 +499,13 @@ swap: {swap_total}KB total, {swap_used}KB used",
         dep_versions = build_info().join("\n"),
         invocation = {
             use shell_words::quote as escape;
-            env::vars()
+            env::vars_os()
+                .map(|(name, value)| {
+                    (
+                        name.to_string_lossy().into_owned(),
+                        value.to_string_lossy().into_owned(),
+                    )
+                })
                 .filter(|(name, _value)| name.starts_with("MZ_"))
                 .map(|(name, value)| format!("{}={}", escape(&name), escape(&value)))
                 .chain(env::args().into_iter().map(|arg| escape(&arg).into_owned()))

--- a/src/materialized/src/telemetry.rs
+++ b/src/materialized/src/telemetry.rs
@@ -110,7 +110,7 @@ async fn report_one(config: &Config) -> Result<semver::Version, anyhow::Error> {
                 .coord_client
                 .system_execute_one(&TELEMETRY_QUERY)
                 .await?;
-            let response = http_util::reqwest_client()?
+            let response = http_util::reqwest::client()
                 .post(format!(
                     "https://{}/api/telemetry/{}",
                     config.domain, config.cluster_id

--- a/test/testdrive/mzcompose.yml
+++ b/test/testdrive/mzcompose.yml
@@ -77,11 +77,20 @@ mzworkflows:
 
   ci-proxy-failure:
     env:
-      ALL_PROXY: '#nonsense'
+      ALL_PROXY: http://localhost:1234
       TD_TEST: 'proxy/proxy-failure.td'
     steps:
       - step: workflow
         workflow: testdrive
+
+  ci-proxy-no-proxy:
+    env:
+      ALL_PROXY: http://localhost:1234
+      NO_PROXY: schema-registry, amazonaws.com
+      TD_TEST: 'avro-registry.td esoteric/s3.td'
+    steps:
+      - step: workflow
+        workflow: ci
 
   start-deps:
     steps:
@@ -140,6 +149,7 @@ services:
     - AWS_SECRET_ACCESS_KEY
     - AWS_SESSION_TOKEN
     - ALL_PROXY
+    - NO_PROXY
     volumes:
     - mzdata:/share/mzdata
     - tmp:/share/tmp

--- a/test/testdrive/proxy/proxy-failure.td
+++ b/test/testdrive/proxy/proxy-failure.td
@@ -13,7 +13,7 @@
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-doesntmatter-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE DEBEZIUM
-Creating HTTP client for schema registry: builder error: builder error: relative URL without a base
+error trying to connect: tcp connect error: Cannot assign requested address (os error 99)
 
 ! CREATE MATERIALIZED SOURCE s3_all
   FROM S3 DISCOVER OBJECTS USING BUCKET SCAN 'doesnt-matter'
@@ -25,4 +25,4 @@ Creating HTTP client for schema registry: builder error: builder error: relative
     token = '${testdrive.aws-token}'
   )
   FORMAT TEXT;
-Using statically provided credentials: creating HTTP client for AWS STS Account verification: invalid format
+Using statically provided credentials: retrieving AWS account ID: Error during dispatch: error trying to connect: tcp connect error: Cannot assign requested address (os error 99)


### PR DESCRIPTION
Add support for the semi-standard no_proxy environment variable using a
delicate mix of Go, Python, and Curl semantics. The exact semantics of
our implementation are described in detail in the http-util crate root.

I also changed the error reporting semantics for bad proxy
configurations. In other langauges, bad proxy configurations are
gracefully but silently ignored. This commit does the same for us,
except that we'll log a warning about the error at startup.

Note that I originally set out to snag reqwest's no_proxy implementation
[0], but after staring at it for a while I decided its semantics were
unlike any other established client's, and so wrote a from scratch
implementation that I think will work for 99% of folks.

Fix #6405.

[0]: https://github.com/seanmonstar/reqwest/blob/e6a1a09f0904e06de4ff1317278798c4ed28af66/src/proxy.rs#L368-L447