### PR TITLE
Preform physical transforms just before rendering

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -1793,7 +1793,7 @@ impl Catalog {
                 depends_on,
             }),
             Plan::CreateSource(CreateSourcePlan { source, .. }) => {
-                let mut optimizer = Optimizer::default();
+                let mut optimizer = Optimizer::for_view();
                 let optimized_expr = optimizer.optimize(source.expr, self.indexes())?;
                 let transformed_desc = RelationDesc::new(optimized_expr.typ(), source.column_names);
                 CatalogItem::Source(Source {
@@ -1807,7 +1807,7 @@ impl Catalog {
             Plan::CreateView(CreateViewPlan {
                 view, depends_on, ..
             }) => {
-                let mut optimizer = Optimizer::default();
+                let mut optimizer = Optimizer::for_view();
                 let optimized_expr = optimizer.optimize(view.expr, self.indexes())?;
                 let desc = RelationDesc::new(optimized_expr.typ(), view.column_names);
                 CatalogItem::View(View {

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -2772,7 +2772,7 @@ impl Coordinator {
                     &optimized_plan,
                     &mut dataflow,
                 );
-                transform::optimize_dataflow(&mut dataflow);
+                transform::optimize_dataflow(&mut dataflow, self.catalog.indexes());
                 let catalog = self.catalog.for_session(session);
                 let mut explanation =
                     dataflow_types::Explanation::new_from_dataflow(&dataflow, &catalog);
@@ -3171,7 +3171,7 @@ impl Coordinator {
             }
 
             // Optimize the dataflow across views, and any other ways that appeal.
-            transform::optimize_dataflow(&mut dataflow);
+            transform::optimize_dataflow(&mut dataflow, self.catalog.indexes());
             let dataflow_plan = dataflow::Plan::finalize_dataflow(dataflow)
                 .expect("Dataflow planning failed; unrecoverable error");
             dataflow_plans.push(dataflow_plan);
@@ -3400,7 +3400,7 @@ pub async fn serve(
             let mut coord = Coordinator {
                 worker_guards,
                 worker_txs,
-                optimizer: Default::default(),
+                optimizer: Optimizer::for_view(),
                 catalog,
                 symbiosis,
                 indexes: ArrangementFrontiers::default(),
@@ -3550,7 +3550,7 @@ pub fn serve_debug(
         let mut coord = Coordinator {
             worker_guards,
             worker_txs: vec![worker_tx],
-            optimizer: Default::default(),
+            optimizer: Optimizer::for_view(),
             catalog,
             symbiosis: None,
             indexes: ArrangementFrontiers::default(),

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -192,7 +192,8 @@ pub struct Config<'a> {
 pub struct Coordinator {
     worker_guards: WorkerGuards<()>,
     worker_txs: Vec<crossbeam_channel::Sender<SequencedCommand>>,
-    optimizer: Optimizer,
+    /// Optimizer instance for logical optimization of views.
+    view_optimizer: Optimizer,
     catalog: Catalog,
     symbiosis: Option<symbiosis::Postgres>,
     /// Maps (global Id of arrangement) -> (frontier information). This tracks the
@@ -1720,7 +1721,7 @@ impl Coordinator {
                 ..
             } = plan;
             let optimized_expr = self
-                .optimizer
+                .view_optimizer
                 .optimize(source.expr, self.catalog.indexes())?;
             let transformed_desc = RelationDesc::new(optimized_expr.0.typ(), source.column_names);
             let source = catalog::Source {
@@ -3035,7 +3036,7 @@ impl Coordinator {
         style: ExprPrepStyle,
     ) -> Result<OptimizedMirRelationExpr, CoordError> {
         if let ExprPrepStyle::Static = style {
-            let mut opt_expr = self.optimizer.optimize(expr, self.catalog.indexes())?;
+            let mut opt_expr = self.view_optimizer.optimize(expr, self.catalog.indexes())?;
             opt_expr.0.try_visit_mut(&mut |e| {
                 // Carefully test filter expressions, which may represent temporal filters.
                 if let expr::MirRelationExpr::Filter { input, predicates } = &*e {
@@ -3056,7 +3057,7 @@ impl Coordinator {
             // constant expression that originally contains a global get? Is
             // there anything not containing a global get that cannot be
             // optimized to a constant expression?
-            Ok(self.optimizer.optimize(expr, self.catalog.indexes())?)
+            Ok(self.view_optimizer.optimize(expr, self.catalog.indexes())?)
         }
     }
 
@@ -3400,7 +3401,7 @@ pub async fn serve(
             let mut coord = Coordinator {
                 worker_guards,
                 worker_txs,
-                optimizer: Optimizer::for_view(),
+                view_optimizer: Optimizer::for_view(),
                 catalog,
                 symbiosis,
                 indexes: ArrangementFrontiers::default(),
@@ -3550,7 +3551,7 @@ pub fn serve_debug(
         let mut coord = Coordinator {
             worker_guards,
             worker_txs: vec![worker_tx],
-            optimizer: Optimizer::for_view(),
+            view_optimizer: Optimizer::for_view(),
             catalog,
             symbiosis: None,
             indexes: ArrangementFrontiers::default(),

--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -134,15 +134,16 @@ impl<'a> DataflowBuilder<'a> {
 
             // TODO: indexes should be imported after the optimization process, and only those
             // actually used by the optimized plan
-            let indexes = &self.catalog.indexes()[&get_id];
-            for (id, keys) in indexes.iter() {
-                let on_entry = self.catalog.get_by_id(&get_id);
-                let on_type = on_entry.desc().unwrap().typ().clone();
-                let index_desc = IndexDesc {
-                    on_id: get_id,
-                    keys: keys.clone(),
-                };
-                dataflow.import_index(*id, index_desc, on_type, *view_id);
+            if let Some(indexes) = self.catalog.indexes().get(&get_id) {
+                for (id, keys) in indexes.iter() {
+                    let on_entry = self.catalog.get_by_id(&get_id);
+                    let on_type = on_entry.desc().unwrap().typ().clone();
+                    let index_desc = IndexDesc {
+                        on_id: get_id,
+                        keys: keys.clone(),
+                    };
+                    dataflow.import_index(*id, index_desc, on_type, *view_id);
+                }
             }
         }
         dataflow.insert_view(*view_id, view.clone());

--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -131,31 +131,20 @@ impl<'a> DataflowBuilder<'a> {
         // TODO: We only need to import Get arguments for which we cannot find arrangements.
         for get_id in view.global_uses() {
             self.import_into_dataflow(&get_id, dataflow);
-        }
-        // Collect sources, views, and indexes used.
-        view.visit(&mut |e| {
-            if let MirRelationExpr::ArrangeBy { input, keys } = e {
-                if let MirRelationExpr::Get {
-                    id: Id::Global(on_id),
-                    typ,
-                } = &**input
-                {
-                    for key_set in keys {
-                        let index_desc = IndexDesc {
-                            on_id: *on_id,
-                            keys: key_set.to_vec(),
-                        };
-                        // If the arrangement exists, import it. It may not exist, in which
-                        // case we should import the source to be sure that we have access
-                        // to the collection to arrange it ourselves.
-                        let indexes = &self.catalog.indexes()[on_id];
-                        if let Some((id, _)) = indexes.iter().find(|(_id, keys)| keys == key_set) {
-                            dataflow.import_index(*id, index_desc, typ.clone(), *view_id);
-                        }
-                    }
-                }
+
+            // TODO: indexes should be imported after the optimization process, and only those
+            // actually used by the optimized plan
+            let indexes = &self.catalog.indexes()[&get_id];
+            for (id, keys) in indexes.iter() {
+                let on_entry = self.catalog.get_by_id(&get_id);
+                let on_type = on_entry.desc().unwrap().typ().clone();
+                let index_desc = IndexDesc {
+                    on_id: get_id,
+                    keys: keys.clone(),
+                };
+                dataflow.import_index(*id, index_desc, on_type, *view_id);
             }
-        });
+        }
         dataflow.insert_view(*view_id, view.clone());
     }
 

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -328,7 +328,7 @@ impl Optimizer {
         Self { transforms }
     }
 
-    /// Optimizes the supplied relation expression.
+    /// Optimizes the supplied relation expression returning an optimized relation.
     pub fn optimize(
         &mut self,
         mut relation: MirRelationExpr,
@@ -338,7 +338,7 @@ impl Optimizer {
         Ok(expr::OptimizedMirRelationExpr(relation))
     }
 
-    /// Optimizes the supplied relation expression.
+    /// Optimizes the supplied relation expression in place.
     fn transform(
         &self,
         relation: &mut MirRelationExpr,

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -225,28 +225,8 @@ pub struct Optimizer {
 }
 
 impl Optimizer {
-    /// Optimizes the supplied relation expression.
-    fn transform(
-        &self,
-        relation: &mut MirRelationExpr,
-        indexes: &HashMap<GlobalId, Vec<(GlobalId, Vec<MirScalarExpr>)>>,
-    ) -> Result<(), TransformError> {
-        let mut id_gen = Default::default();
-        for transform in self.transforms.iter() {
-            transform.transform(
-                relation,
-                TransformArgs {
-                    id_gen: &mut id_gen,
-                    indexes,
-                },
-            )?;
-        }
-        Ok(())
-    }
-}
-
-impl Default for Optimizer {
-    fn default() -> Self {
+    /// Builds a logical optimizer that only performs logical transformations.
+    pub fn for_view() -> Self {
         let transforms: Vec<Box<dyn crate::Transform + Send>> = vec![
             // 1. Structure-agnostic cleanup
             Box::new(crate::topk_elision::TopKElision),
@@ -293,11 +273,19 @@ impl Default for Optimizer {
                     Box::new(crate::FuseAndCollapse::default()),
                 ],
             }),
-            // Logical transforms are above this line. Physical transforms are
-            // below this line.
-            // TODO: split these transforms into two sets so that physical
-            // transforms only run once?
-            // Implementation transformations
+        ];
+        Self { transforms }
+    }
+
+    /// Builds a physical optimizer.
+    ///
+    /// Performs logical transformations followed by all physical ones.
+    /// This is meant to be used for optimizing each view within a dataflow
+    /// once view inlining has already happened, right before dataflow
+    /// rendering.
+    pub fn for_dataflow() -> Self {
+        // Implementation transformations
+        let transforms: Vec<Box<dyn crate::Transform + Send>> = vec![
             Box::new(crate::Fixpoint {
                 limit: 100,
                 transforms: vec![
@@ -320,19 +308,9 @@ impl Default for Optimizer {
             Box::new(crate::fusion::project::Project),
             Box::new(crate::reduction::FoldConstants),
         ];
-        Self { transforms }
-    }
-}
-
-impl Optimizer {
-    /// Optimizes the supplied relation expression.
-    pub fn optimize(
-        &mut self,
-        mut relation: MirRelationExpr,
-        indexes: &HashMap<GlobalId, Vec<(GlobalId, Vec<MirScalarExpr>)>>,
-    ) -> Result<expr::OptimizedMirRelationExpr, TransformError> {
-        self.transform(&mut relation, indexes)?;
-        Ok(expr::OptimizedMirRelationExpr(relation))
+        let mut optimizer = Self::for_view();
+        optimizer.transforms.extend(transforms);
+        optimizer
     }
 
     /// Simple fusion and elision transformations to render the query readable.
@@ -348,5 +326,34 @@ impl Optimizer {
             Box::new(crate::fusion::join::Join),
         ];
         Self { transforms }
+    }
+
+    /// Optimizes the supplied relation expression.
+    pub fn optimize(
+        &mut self,
+        mut relation: MirRelationExpr,
+        indexes: &HashMap<GlobalId, Vec<(GlobalId, Vec<MirScalarExpr>)>>,
+    ) -> Result<expr::OptimizedMirRelationExpr, TransformError> {
+        self.transform(&mut relation, indexes)?;
+        Ok(expr::OptimizedMirRelationExpr(relation))
+    }
+
+    /// Optimizes the supplied relation expression.
+    fn transform(
+        &self,
+        relation: &mut MirRelationExpr,
+        indexes: &HashMap<GlobalId, Vec<(GlobalId, Vec<MirScalarExpr>)>>,
+    ) -> Result<(), TransformError> {
+        let mut id_gen = Default::default();
+        for transform in self.transforms.iter() {
+            transform.transform(
+                relation,
+                TransformArgs {
+                    id_gen: &mut id_gen,
+                    indexes,
+                },
+            )?;
+        }
+        Ok(())
     }
 }

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -52,7 +52,7 @@ mod tests {
 
         match test_type {
             TestType::Opt => {
-                let mut opt: Optimizer = Default::default();
+                let mut opt = Optimizer::for_dataflow();
                 rel = opt.optimize(rel, &HashMap::new()).unwrap().into_inner();
 
                 Ok(cat.generate_explanation(&rel, args.get("format")))
@@ -61,7 +61,7 @@ mod tests {
             TestType::Steps => {
                 // TODO(justin): this thing does not currently peek into fixpoints, so it's not
                 // that helpful for optimizations that involve those (which is most of them).
-                let opt: Optimizer = Default::default();
+                let opt = Optimizer::for_dataflow();
                 let mut out = String::new();
                 // Buffer of the names of the transformations that have been applied with no changes.
                 let mut no_change: Vec<String> = Vec::new();

--- a/test/sqllogictest/transform/lifting.slt
+++ b/test/sqllogictest/transform/lifting.slt
@@ -637,40 +637,51 @@ EOF
 query T multiline
 explain select min(a) from t_pk where a between 38 and 195 and a = (select a from t where a = 1308);
 ----
-%0 =
+%0 = Let l0 =
+| Get materialize.public.t (u1)
+| Filter (#0 = 1308)
+
+%1 =
 | Get materialize.public.t_pk (u3)
 | ArrangeBy (#0)
 
-%1 =
-| Get materialize.public.t (u1)
-| Filter (#0 = 1308)
+%2 =
+| Get %0 (l0)
+| Project (#0)
+
+%3 =
+| Get %0 (l0)
 | Reduce group=()
 | | agg count(true)
 | Filter (err: more than one record produced in subquery), (#0 > 1)
 | Map (err: more than one record produced in subquery)
+| Project (#1)
 
-%2 = Let l0 =
-| Join %0 %1 (= #0 #3)
-| | implementation = Differential %1 %0.(#0)
+%4 =
+| Union %2 %3
+
+%5 = Let l1 =
+| Join %1 %4 (= #0 #2)
+| | implementation = Differential %4 %1.(#0)
 | | demand = (#0)
 | Filter (#0 <= 195), (#0 >= 38)
 | Reduce group=()
 | | agg min(#0)
 
-%3 =
-| Get %2 (l0)
+%6 =
+| Get %5 (l1)
 | Negate
 | Project ()
 
-%4 =
+%7 =
 | Constant ()
 
-%5 =
-| Union %3 %4
+%8 =
+| Union %6 %7
 | Map null
 
-%6 =
-| Union %2 %5
+%9 =
+| Union %5 %8
 
 EOF
 

--- a/test/sqllogictest/transform/predicate_pushdown.slt
+++ b/test/sqllogictest/transform/predicate_pushdown.slt
@@ -155,7 +155,7 @@ SELECT * FROM t1, t2 WHERE t1.f1 = t2.f1 AND t1.f2 = t2.f2 AND t1.f1 + t2.f2 = t
 | |   delta %0 %1.(#0, #1)
 | |   delta %1 %0.(#0, #1)
 | | demand = (#0, #1)
-| Filter !(isnull(#0)), !(isnull(#1))
+| Filter !(isnull(#0)), !(isnull(#1)), ((#0 + #1) = (#0 + #1))
 | Project (#0, #1, #0, #1)
 
 EOF


### PR DESCRIPTION
Add two constructors for the optimizer, with different sets
of transformations: one meant to be used for logical optimization
on views; and one that performs a full optimization pass, including
physical optimizations, meant to be applied on dataflows right
before rendering them.

Fixes #5108 