### PR TITLE
Throw an error for unsupported outer joins in comma join

### DIFF
--- a/test/sqllogictest/cockroach/apply_join.slt
+++ b/test/sqllogictest/cockroach/apply_join.slt
@@ -82,7 +82,7 @@ INSERT INTO table9 VALUES (
   '2020-05-26 14:23:36.157383-04'
 )
 
-query B
+query error full/right outer joins in comma join not yet supported, see https://github.com/MaterializeInc/materialize/issues/6875 for more details
 SELECT
   true
 FROM
@@ -127,8 +127,6 @@ WHERE
     )
 LIMIT
     89;
-----
-true
 
 # Regression test for #37454: untyped null produced at top level.
 

--- a/test/sqllogictest/outer_join.slt
+++ b/test/sqllogictest/outer_join.slt
@@ -37,4 +37,3 @@ query III
 SELECT * FROM a, b left join c on b = c;
 ----
 1  2  NULL
-

--- a/test/sqllogictest/outer_join.slt
+++ b/test/sqllogictest/outer_join.slt
@@ -1,0 +1,40 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+mode cockroach
+
+statement ok
+CREATE TABLE a(a INTEGER);
+
+statement ok
+CREATE TABLE b(b INTEGER);
+
+statement ok
+CREATE TABLE c(c INTEGER);
+
+statement ok
+INSERT INTO a VALUES (1);
+
+statement ok
+INSERT INTO b VALUES (2);
+
+statement ok
+INSERT INTO c VALUES (3);
+
+query error full/right outer joins in comma join not yet supported, see https://github.com/MaterializeInc/materialize/issues/6875
+SELECT * FROM a, b full join c on b = c;
+
+query error full/right outer joins in comma join not yet supported, see https://github.com/MaterializeInc/materialize/issues/6875
+SELECT * FROM a, b right join c on b = c;
+
+query III
+SELECT * FROM a, b left join c on b = c;
+----
+1  2  NULL
+


### PR DESCRIPTION
Throw an error when the planner tries to push down the current
comma join to the left-most side of a join tree involving either
right or full outer join, since otherwise the planner would build
a wrong join tree leading to wrong results.

Left joins are allowed since, even though the resulting plan may
not be optimal, it is semantically equivalent, ie. leads to the
same query results.