### PR TITLE
ore: introduce optional assertions framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,6 +731,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e98e2ad1a782e33928b96fc3948e7c355e5af34ba4de7670fe8bac2a3b2006d"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "darling"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2539,6 +2549,7 @@ dependencies = [
  "bytes",
  "chrono",
  "crossbeam-utils",
+ "ctor",
  "either",
  "futures",
  "openssl",

--- a/ci/test/cargo-test/mzcompose.yml
+++ b/ci/test/cargo-test/mzcompose.yml
@@ -27,6 +27,7 @@ services:
     - ZOOKEEPER_ADDR=zookeeper:2181
     - KAFKA_ADDRS=kafka:9092
     - SCHEMA_REGISTRY_URL=http://schema-registry:8081
+    - MZ_SOFT_ASSERTIONS=1
     propagate-uid-gid: true
     depends_on: [kafka, zookeeper, schema-registry]
   zookeeper:

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -7,11 +7,11 @@ edition = "2018"
 publish = false
 
 [features]
-default = ["network", "cli", "test", "chrono", "metrics"]
-network = ["tokio", "tokio-openssl", "async-trait", "futures", "smallvec", "bytes", "openssl"]
-metrics = ["prometheus"]
+default = ["network", "chrono", "cli", "metrics", "test"]
 cli = ["structopt"]
-test = ["tracing-subscriber"]
+metrics = ["prometheus"]
+network = ["async-trait", "bytes", "futures", "openssl", "smallvec", "tokio-openssl", "tokio"]
+test = ["ctor", "tracing-subscriber"]
 
 # NB: ore is meant to be an extension of the Rust stdlib. To keep it
 # lightweight, dependencies on external crates should be avoided if possible. If
@@ -23,6 +23,7 @@ test = ["tracing-subscriber"]
 async-trait = { version = "0.1.50", optional = true }
 bytes = { version = "1.0.1", optional = true }
 chrono = { version = "0.4.0", default-features = false, features = ["std"], optional = true }
+ctor = { version = "0.1.20", optional = true }
 either = "1.6.1"
 futures = { version = "0.3.16", optional = true }
 # This isn't directly imported by anything, but it's required at link time. The

--- a/src/ore/src/lib.rs
+++ b/src/ore/src/lib.rs
@@ -21,10 +21,8 @@
 
 #![deny(missing_docs, missing_debug_implementations)]
 
-// This module presently only contains macros. Macros are always exported at the
-// root of a crate, so this module is not public as it would appear empty.
-mod assert;
-
+#[cfg(feature = "test")]
+pub mod assert;
 pub mod cast;
 #[cfg(feature = "cli")]
 pub mod cli;

--- a/test/sqllogictest/mzcompose.yml
+++ b/test/sqllogictest/mzcompose.yml
@@ -41,6 +41,7 @@ services:
     - PGUSER=postgres
     - PGHOST=postgres
     - PGPASSWORD=postgres
+    - MZ_SOFT_ASSERTIONS=1
     depends_on: [postgres]
   postgres:
     image: postgres:11.4

--- a/test/testdrive/mzcompose.yml
+++ b/test/testdrive/mzcompose.yml
@@ -145,6 +145,7 @@ services:
     environment:
     - MZ_DEV=1
     - MZ_LOG_FILTER
+    - MZ_SOFT_ASSERTIONS=1
     - AWS_ACCESS_KEY_ID
     - AWS_SECRET_ACCESS_KEY
     - AWS_SESSION_TOKEN


### PR DESCRIPTION
WARNING: haven't actually tested this yet.

----

Optional assertions are like debug asserts but they can be enabled at
runtime in release builds by setting the MZ_OPTIONAL_ASSERTIONS
environment variable.

Use this new framework to upgrade some error logs to panics when
optional assertions are enabled, then enable optional assertions in
several CI jobs.

Fix #7473.
Supersedes #7475.