### PR TITLE
persist: enable unreliable storage nemesis

### DIFF
--- a/src/persist/benches/snapshot.rs
+++ b/src/persist/benches/snapshot.rs
@@ -77,7 +77,7 @@ where
 pub fn bench_mem_snapshots(c: &mut Criterion) {
     bench_indexed_snapshots(c, "mem", |path| {
         let name = format!("snapshot_bench_{}", path);
-        Indexed::new(MemBuffer::new(&name)?, MemBlob::new(&name)?)
+        Indexed::new(MemBuffer::new(&name), MemBlob::new(&name))
     });
 }
 

--- a/src/persist/benches/writer.rs
+++ b/src/persist/benches/writer.rs
@@ -26,8 +26,7 @@ fn bench_write_sync<U: Buffer>(writer: &mut U, data: Vec<u8>, b: &mut Bencher) {
 pub fn bench_writes(c: &mut Criterion) {
     let data = "entry0".as_bytes().to_vec();
 
-    let mut mem_buffer =
-        MemBuffer::new("mem_buffer_bench").expect("creating a MemBuffer cannot fail");
+    let mut mem_buffer = MemBuffer::new("mem_buffer_bench");
     c.bench_function("mem_write_sync", |b| {
         bench_write_sync(&mut mem_buffer, data.clone(), b)
     });

--- a/src/persist/src/file.rs
+++ b/src/persist/src/file.rs
@@ -258,15 +258,15 @@ impl Buffer for FileBuffer {
         Ok(())
     }
 
-    fn close(&mut self) -> Result<(), Error> {
+    fn close(&mut self) -> Result<bool, Error> {
         if let Ok(base_dir) = self.ensure_open() {
             let lockfile_path = Self::lockfile_path(&base_dir);
             fs::remove_file(lockfile_path)?;
             self.base_dir = None;
-            Ok(())
+            Ok(true)
         } else {
             // Already closed. Close implementations must be idempotent.
-            Ok(())
+            Ok(false)
         }
     }
 }
@@ -346,15 +346,15 @@ impl Blob for FileBlob {
         Ok(())
     }
 
-    fn close(&mut self) -> Result<(), Error> {
+    fn close(&mut self) -> Result<bool, Error> {
         if let Some(base_dir) = self.base_dir.as_ref() {
             let lockfile_path = Self::lockfile_path(&base_dir);
             fs::remove_file(lockfile_path)?;
             self.base_dir = None;
-            Ok(())
+            Ok(true)
         } else {
             // Already closed. Close implementations must be idempotent.
-            Ok(())
+            Ok(false)
         }
     }
 }

--- a/src/persist/src/indexed/cache.rs
+++ b/src/persist/src/indexed/cache.rs
@@ -64,8 +64,9 @@ impl<K: Data, V: Data, L: Blob> BlobCache<K, V, L> {
     /// Synchronously closes the cache, releasing exclusive-writer locks and
     /// causing all future commands to error.
     ///
-    /// This method is idempotent.
-    pub fn close(&mut self) -> Result<(), Error> {
+    /// This method is idempotent. Returns true if the buffer had not
+    /// previously been closed.
+    pub fn close(&mut self) -> Result<bool, Error> {
         self.blob.lock()?.close()
     }
 

--- a/src/persist/src/indexed/future.rs
+++ b/src/persist/src/indexed/future.rs
@@ -194,8 +194,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn append_ts_lower_invariant() -> Result<(), Error> {
-        let mut blob = BlobCache::new(MemBlob::new("append_ts_lower_invariant")?);
+    fn append_ts_lower_invariant() {
+        let mut blob = BlobCache::new(MemBlob::new("append_ts_lower_invariant"));
         let mut f = BlobFuture::new(BlobFutureMeta {
             id: Id(0),
             ts_lower: Antichain::from_elem(2),
@@ -229,8 +229,6 @@ mod tests {
             updates: vec![(("k".to_string(), "v".to_string()), 2, 1)],
         };
         assert_eq!(f.append(batch, &mut blob), Ok(()));
-
-        Ok(())
     }
 
     #[test]

--- a/src/persist/src/indexed/mod.rs
+++ b/src/persist/src/indexed/mod.rs
@@ -517,8 +517,8 @@ mod tests {
         ];
 
         let mut i = Indexed::new(
-            MemBuffer::new("single_stream")?,
-            MemBlob::new("single_stream")?,
+            MemBuffer::new("single_stream"),
+            MemBlob::new("single_stream"),
         )?;
         let id = i.register("0");
 
@@ -573,8 +573,8 @@ mod tests {
         ];
 
         let mut i = Indexed::new(
-            MemBuffer::new("batch_sorting")?,
-            MemBlob::new("batch_sorting")?,
+            MemBuffer::new("batch_sorting"),
+            MemBlob::new("batch_sorting"),
         )?;
         let id = i.register("0");
 
@@ -600,8 +600,8 @@ mod tests {
         ];
 
         let mut i = Indexed::new(
-            MemBuffer::new("batch_consolidation")?,
-            MemBlob::new("batch_consolidation")?,
+            MemBuffer::new("batch_consolidation"),
+            MemBlob::new("batch_consolidation"),
         )?;
         let id = i.register("0");
 
@@ -629,8 +629,8 @@ mod tests {
     #[test]
     fn batch_future_empty() -> Result<(), Box<dyn Error>> {
         let mut i = Indexed::new(
-            MemBuffer::new("batch_future_empty")?,
-            MemBlob::new("batch_future_empty")?,
+            MemBuffer::new("batch_future_empty"),
+            MemBlob::new("batch_future_empty"),
         )?;
         let id = i.register("0");
 
@@ -659,8 +659,8 @@ mod tests {
     #[test]
     fn drain_buf_validate() -> Result<(), IndexedError> {
         let mut i = Indexed::new(
-            MemBuffer::new("drain_buf_validate")?,
-            MemBlob::new("drain_buf_validate")?,
+            MemBuffer::new("drain_buf_validate"),
+            MemBlob::new("drain_buf_validate"),
         )?;
         let id = i.register("0");
 

--- a/src/persist/src/indexed/runtime.rs
+++ b/src/persist/src/indexed/runtime.rs
@@ -387,8 +387,8 @@ mod tests {
             (("key2".to_string(), "val2".to_string()), 1, 1),
         ];
 
-        let buffer = MemBuffer::new("runtime")?;
-        let blob = MemBlob::new("runtime")?;
+        let buffer = MemBuffer::new("runtime");
+        let blob = MemBlob::new("runtime");
         let mut runtime = start(buffer, blob)?;
 
         let (mut write, meta) = runtime.create_or_load("0")?.into_inner();
@@ -412,8 +412,8 @@ mod tests {
             (("key2".to_string(), "val2".to_string()), 1, 1),
         ];
 
-        let buffer = MemBuffer::new("concurrent")?;
-        let blob = MemBlob::new("concurrent")?;
+        let buffer = MemBuffer::new("concurrent");
+        let blob = MemBlob::new("concurrent");
         let client1 = start(buffer, blob)?;
         let _ = client1.create_or_load("0")?;
 

--- a/src/persist/src/nemesis/generator.rs
+++ b/src/persist/src/nemesis/generator.rs
@@ -48,12 +48,7 @@ impl GeneratorConfig {
 
 impl Default for GeneratorConfig {
     fn default() -> Self {
-        let mut config = Self::all_operations();
-        // TODO: These catch various bugs so disable them until the bugs are
-        // fixed.
-        config.storage_available = 0;
-        config.storage_unavailable = 0;
-        config
+        Self::all_operations()
     }
 }
 

--- a/src/persist/src/unreliable.rs
+++ b/src/persist/src/unreliable.rs
@@ -156,8 +156,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn buffer() -> Result<(), Error> {
-        let (mut buffer, mut handle) = UnreliableBuffer::new(MemBuffer::new("unreliable")?);
+    fn buffer() {
+        let (mut buffer, mut handle) = UnreliableBuffer::new(MemBuffer::new("unreliable"));
 
         // Initially starts reliable.
         assert!(buffer.write_sync(vec![]).is_ok());
@@ -175,13 +175,11 @@ mod tests {
         assert!(buffer.write_sync(vec![]).is_ok());
         assert!(buffer.snapshot(|_, _| { Ok(()) }).is_ok());
         assert!(buffer.truncate(SeqNo(2)).is_ok());
-
-        Ok(())
     }
 
     #[test]
-    fn blob() -> Result<(), Error> {
-        let (mut blob, mut handle) = UnreliableBlob::new(MemBlob::new("unreliable")?);
+    fn blob() {
+        let (mut blob, mut handle) = UnreliableBlob::new(MemBlob::new("unreliable"));
 
         // Initially starts reliable.
         assert!(blob.set("a", b"1".to_vec(), true).is_ok());
@@ -196,7 +194,5 @@ mod tests {
         handle.make_available();
         assert!(blob.set("a", b"3".to_vec(), true).is_ok());
         assert!(blob.get("a").is_ok());
-
-        Ok(())
     }
 }

--- a/src/persist/src/unreliable.rs
+++ b/src/persist/src/unreliable.rs
@@ -106,9 +106,15 @@ impl<U: Buffer> Buffer for UnreliableBuffer<U> {
         self.buf.truncate(upper)
     }
 
-    fn close(&mut self) -> Result<(), Error> {
+    fn close(&mut self) -> Result<bool, Error> {
+        // TODO: This check_unavailable is a different order from the others
+        // mostly for convenience in the nemesis tests. While we do want to
+        // prevent a normal read/write from going though when the storage is
+        // unavailable, it makes for a very uninteresting test if we can't clean
+        // up LOCK files. OTOH this feels like a smell, revisit.
+        let did_work = self.buf.close()?;
         self.handle.check_unavailable("buffer close")?;
-        self.buf.close()
+        Ok(did_work)
     }
 }
 
@@ -143,9 +149,15 @@ impl<L: Blob> Blob for UnreliableBlob<L> {
         self.blob.set(key, value, allow_overwrite)
     }
 
-    fn close(&mut self) -> Result<(), Error> {
+    fn close(&mut self) -> Result<bool, Error> {
+        // TODO: This check_unavailable is a different order from the others
+        // mostly for convenience in the nemesis tests. While we do want to
+        // prevent a normal read/write from going though when the storage is
+        // unavailable, it makes for a very uninteresting test if we can't clean
+        // up LOCK files. OTOH this feels like a smell, revisit.
+        let did_work = self.blob.close()?;
         self.handle.check_unavailable("blob close")?;
-        self.blob.close()
+        Ok(did_work)
     }
 }
 


### PR DESCRIPTION
This includes several bugfixes necessary to make the nemesis test pass:
- Indexed::new now closes the Blob and Buffer it was given when
  returning an error
- RuntimeCore::stop now waits for the thread handle to join before
  returning an error.
- nemesis's Direct::stream is now fallible and returns a Result (errors
  if the storage is down).