### PR TITLE
ddl,sinks: rename Kafka setting exactly_once to reuse_topic

### DIFF
--- a/doc/user/content/sql/create-sink.md
+++ b/doc/user/content/sql/create-sink.md
@@ -54,7 +54,7 @@ Field                | Value type | Description
 ---------------------|------------|------------
 `partition_count`    | `int`      | Set the sink Kafka topic's partition count. This defaults to -1 (use the broker default).
 `replication_factor` | `int`      | Set the sink Kafka topic's replication factor. This defaults to -1 (use the broker default).
-`exactly_once`  | `bool`   |  Use the existing Kafka topic after Materialize restarts, instead of creating a new one. `consistency_topic` is required if true. The default is false.
+`reuse_topic`        | `bool`     | Use the existing Kafka topic after Materialize restarts, instead of creating a new one. `consistency_topic` is required if true. The default is false.
 `consistency_topic`  | `text`     | Makes the sink emit additional [consistency metadata](#consistency-metadata). Only valid for Kafka sinks.
 `security_protocol`  | `text`     | Use [`ssl`](#ssl-with-options) or, for [Kerberos](#kerberos-with-options), `sasl_plaintext`, `sasl-scram-sha-256`, or `sasl-sha-512` to connect to the Kafka cluster.
 `acks`               | `text`     | Sets the number of Kafka replicas that must acknowledge Materialize writes. Accepts values [-1,1000]. `-1` (the default) specifies all replicas.
@@ -175,7 +175,7 @@ This is currently available only for Kafka sources and the views based on them.
 
 When you create a sink, you must:
 
-* Enable the `exactly_once` switch.
+* Enable the `reuse_topic` switch.
 * Specify a [consistency topic](#consistency-metadata) to store the information that Materialize will use to identify the last completed write. The names of the sink topic and the sink consistency topic must be unique across all sinks in the system.
 
 The sink consistency topic cannot be written to by any other process, and both the sink topic and the sink consistency topic need to be set to infinite data retention.
@@ -310,7 +310,7 @@ FORMAT AVRO USING
 #### With topic reuse enabled after restart
 
 ```sql
-CREATE SINK my_sink FROM data_schema_inline INTO KAFKA BROKER 'localhost:9092' TOPIC 'my_one_and_only_sink_topic' WITH (exactly_once=true, consistency_topic='my_consistency_topic') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081';
+CREATE SINK my_sink FROM data_schema_inline INTO KAFKA BROKER 'localhost:9092' TOPIC 'my_one_and_only_sink_topic' WITH (reuse_topic=true, consistency_topic='my_consistency_topic') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081';
 ```
 
 #### From materialized views

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -1138,7 +1138,9 @@ pub struct KafkaSinkConnectorBuilder {
     pub consistency_value_schema: Option<String>,
     pub config_options: BTreeMap<String, String>,
     pub ccsr_config: ccsr::ClientConfig,
-    pub exactly_once: bool,
+    // Forces the sink to always write to the same topic across restarts instead
+    // of picking a new topic each time.
+    pub reuse_topic: bool,
     // Source dependencies for exactly-once sinks.
     pub transitive_source_dependencies: Vec<GlobalId>,
 }

--- a/test/kafka-exactly-once/before-restart.td
+++ b/test/kafka-exactly-once/before-restart.td
@@ -76,7 +76,7 @@ $ kafka-create-topic topic=input
 
 > CREATE SINK output_rt FROM input_rt
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-rt-sink-${testdrive.seed}'
-  WITH (exactly_once=true, consistency_topic='output-rt-sink-consistency-${testdrive.seed}')
+  WITH (reuse_topic=true, consistency_topic='output-rt-sink-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 > CREATE MATERIALIZED SOURCE input_byo
@@ -86,7 +86,7 @@ $ kafka-create-topic topic=input
 
 > CREATE SINK output_byo FROM input_byo
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-byo-sink-${testdrive.seed}'
-  WITH (exactly_once=true, consistency_topic='output-byo-sink-consistency-${testdrive.seed}')
+  WITH (reuse_topic=true, consistency_topic='output-byo-sink-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 $ kafka-ingest format=avro topic=input-consistency timestamp=1 schema=${trxschemakey}

--- a/test/testdrive/kafka-exactly-once-sink.td
+++ b/test/testdrive/kafka-exactly-once-sink.td
@@ -72,64 +72,64 @@ New York,NY,10004
 
 > CREATE SINK output1 FROM input_kafka_byo
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output1-view-${testdrive.seed}'
-  WITH (exactly_once=true, consistency_topic='output1-view-consistency-${testdrive.seed}')
+  WITH (reuse_topic=true, consistency_topic='output1-view-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 > CREATE SINK output2 FROM input_kafka_no_byo
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output2-view-${testdrive.seed}'
-  WITH (exactly_once=true, consistency_topic='output2-view-consistency-${testdrive.seed}')
+  WITH (reuse_topic=true, consistency_topic='output2-view-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 ! CREATE SINK output3 FROM input_table
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output3-view-${testdrive.seed}'
-  WITH (exactly_once=true, consistency_topic='output3-view-consistency-${testdrive.seed}')
+  WITH (reuse_topic=true, consistency_topic='output3-view-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-all inputs of an exactly-once Kafka sink must be sources, materialize.public.input_table is not
+reuse_topic requires that sink input dependencies are sources, materialize.public.input_table is not
 
 > CREATE SINK output4 FROM input_kafka_byo_mview
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output4-view-${testdrive.seed}'
-  WITH (exactly_once=true, consistency_topic='output4-view-consistency-${testdrive.seed}')
+  WITH (reuse_topic=true, consistency_topic='output4-view-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 > CREATE SINK output4_view FROM input_kafka_byo_mview_view
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output4b-view-${testdrive.seed}'
-  WITH (exactly_once=true, consistency_topic='output4b-view-consistency-${testdrive.seed}')
+  WITH (reuse_topic=true, consistency_topic='output4b-view-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 > CREATE SINK output5 FROM input_kafka_no_byo_mview
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output5-view-${testdrive.seed}'
-  WITH (exactly_once=true, consistency_topic='output5-view-consistency-${testdrive.seed}')
+  WITH (reuse_topic=true, consistency_topic='output5-view-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 > CREATE SINK output5_view FROM input_kafka_no_byo_mview_view
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output5b-view-${testdrive.seed}'
-  WITH (exactly_once=true, consistency_topic='output5b-view-consistency-${testdrive.seed}')
+  WITH (reuse_topic=true, consistency_topic='output5b-view-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 ! CREATE SINK output6 FROM input_table_mview
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output6-view-${testdrive.seed}'
-  WITH (exactly_once=true, consistency_topic='output6-view-consistency-${testdrive.seed}')
+  WITH (reuse_topic=true, consistency_topic='output6-view-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-all inputs of an exactly-once Kafka sink must be sources, materialize.public.input_table is not
+reuse_topic requires that sink input dependencies are sources, materialize.public.input_table is not
 
 ! CREATE SINK output7 FROM input_values_view
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output7-view-${testdrive.seed}'
-  WITH (exactly_once=true, consistency_topic='output7-view-consistency-${testdrive.seed}')
+  WITH (reuse_topic=true, consistency_topic='output7-view-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-all inputs of an exactly-once Kafka sink must be sources, materialize.public.input_values_view is not
+reuse_topic requires that sink input dependencies are sources, materialize.public.input_values_view is not
 
 ! CREATE SINK output8 FROM input_values_mview
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output8-view-${testdrive.seed}'
-  WITH (exactly_once=true, consistency_topic='output8-view-consistency-${testdrive.seed}')
+  WITH (reuse_topic=true, consistency_topic='output8-view-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-all inputs of an exactly-once Kafka sink must be sources, materialize.public.input_values_mview is not
+reuse_topic requires that sink input dependencies are sources, materialize.public.input_values_mview is not
 
 > CREATE SINK output12 FROM input_kafka_no_byo_derived_table
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output12-view-${testdrive.seed}'
-  WITH (exactly_once=true, consistency_topic='output12-view-consistency-${testdrive.seed}')
+  WITH (reuse_topic=true, consistency_topic='output12-view-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 > CREATE SINK output13 FROM input_csv
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output13-view-${testdrive.seed}'
-  WITH (exactly_once=true, consistency_topic='output13-view-consistency-${testdrive.seed}')
+  WITH (reuse_topic=true, consistency_topic='output13-view-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'


### PR DESCRIPTION
This better describes the user-facing effect and will make it easier to
document.

We now refer to the setting as reuse_topic up until
KafkaSinkConnectorBuilder. Internal code, starting with
KafkaSinkConnector refers to it as exactly_once, which is still the
underlying implementation mechanism.