### PR TITLE
sql: refactor ScalarType's Eq + fix numeric list scale deficiencies

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -5404,7 +5404,7 @@ impl VariadicFunc {
                 debug_assert!(
                     input_types
                         .windows(2)
-                        .all(|w| w[0].scalar_type == w[1].scalar_type),
+                        .all(|w| w[0].scalar_type.base_eq(&w[1].scalar_type)),
                     "coalesce inputs did not have uniform type: {:?}",
                     input_types
                 );
@@ -5418,7 +5418,7 @@ impl VariadicFunc {
             JsonbBuildArray | JsonbBuildObject => ScalarType::Jsonb.nullable(true),
             ArrayCreate { elem_type } => {
                 debug_assert!(
-                    input_types.iter().all(|t| t.scalar_type == *elem_type),
+                    input_types.iter().all(|t| t.scalar_type.base_eq(elem_type)),
                     "Args to ArrayCreate should have types that are compatible with the elem_type"
                 );
                 match elem_type {
@@ -5429,7 +5429,7 @@ impl VariadicFunc {
             ArrayToString { .. } => ScalarType::String.nullable(true),
             ListCreate { elem_type } => {
                 debug_assert!(
-                    input_types.iter().all(|t| t.scalar_type == *elem_type),
+                    input_types.iter().all(|t| t.scalar_type.base_eq(elem_type)),
                     "Args to ListCreate should have types that are compatible with the elem_type"
                 );
                 ScalarType::List {

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -3099,11 +3099,15 @@ impl BinaryFunc {
                 ScalarType::Int64.nullable(true)
             }
 
-            ListListConcat | ListElementConcat => {
-                input1_type.scalar_type.unscale_any_numeric().nullable(true)
-            }
+            ListListConcat | ListElementConcat => input1_type
+                .scalar_type
+                .default_embedded_value()
+                .nullable(true),
 
-            ElementListConcat => input2_type.scalar_type.unscale_any_numeric().nullable(true),
+            ElementListConcat => input2_type
+                .scalar_type
+                .default_embedded_value()
+                .nullable(true),
 
             DigestString | DigestBytes => ScalarType::Bytes.nullable(true),
             Position => ScalarType::Int32.nullable(in_nullable),
@@ -3983,7 +3987,7 @@ impl UnaryFunc {
             | CastInPlace { return_ty } => (return_ty.clone()).nullable(nullable),
 
             CastList1ToList2 { return_ty, .. } | CastStringToList { return_ty, .. } => {
-                return_ty.unscale_any_numeric().nullable(false)
+                return_ty.default_embedded_value().nullable(false)
             }
 
             CeilFloat32 | FloorFloat32 | RoundFloat32 => ScalarType::Float32.nullable(nullable),

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -901,7 +901,7 @@ impl MirScalarExpr {
             MirScalarExpr::If { cond: _, then, els } => {
                 let then_type = then.typ(relation_type);
                 let else_type = els.typ(relation_type);
-                debug_assert!(then_type.scalar_type == else_type.scalar_type);
+                debug_assert!(then_type.scalar_type.base_eq(&else_type.scalar_type));
                 ColumnType {
                     nullable: then_type.nullable || else_type.nullable,
                     scalar_type: then_type.scalar_type,

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -49,7 +49,7 @@ fn return_true() -> bool {
 impl ColumnType {
     pub fn union(&self, other: &Self) -> Result<Self, anyhow::Error> {
         match (self.scalar_type.clone(), other.scalar_type.clone()) {
-            (scalar_type, other_scalar_type) if scalar_type == other_scalar_type => {
+            (scalar_type, other_scalar_type) if scalar_type.base_eq(&other_scalar_type) => {
                 Ok(ColumnType {
                     scalar_type: scalar_type,
                     nullable: self.nullable || other.nullable,

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -814,27 +814,29 @@ impl<'a> ScalarType {
         dims
     }
 
-    /// Returns `self` with any values equal to [`ScalarType::Numeric`] with their
-    /// `scale` set to `None`.
-    pub fn unscale_any_numeric(&self) -> ScalarType {
+    /// Returns `self` with any embedded values set to a value appropriate for a
+    /// collection of the type. Namely, this should set optional scales or
+    /// limits to `None`.
+    pub fn default_embedded_value(&self) -> ScalarType {
         use ScalarType::*;
         match self {
-            Numeric { scale: Some(..) } => Numeric { scale: None },
             List {
                 element_type,
                 custom_oid: None,
             } => List {
-                element_type: Box::new(element_type.unscale_any_numeric()),
+                element_type: Box::new(element_type.default_embedded_value()),
                 custom_oid: None,
             },
             Map {
                 value_type,
                 custom_oid: None,
             } => Map {
-                value_type: Box::new(value_type.unscale_any_numeric()),
+                value_type: Box::new(value_type.default_embedded_value()),
                 custom_oid: None,
             },
-            _ => self.clone(),
+            Array(a) => Array(Box::new(a.default_embedded_value())),
+            Numeric { .. } => Numeric { scale: None },
+            v => v.clone(),
         }
     }
 

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -9,7 +9,7 @@
 
 use std::convert::TryFrom;
 use std::fmt::{self, Write};
-use std::hash::{Hash, Hasher};
+use std::hash::Hash;
 
 use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 use dec::OrderedDecimal;
@@ -669,7 +669,19 @@ impl fmt::Display for Datum<'_> {
 ///
 /// There is a direct correspondence between `Datum` variants and `ScalarType`
 /// variants.
-#[derive(Clone, Debug, Eq, Serialize, Deserialize, Ord, PartialOrd, EnumKind, MzEnumReflect)]
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    Ord,
+    PartialOrd,
+    Hash,
+    EnumKind,
+    MzEnumReflect,
+)]
 #[enum_kind(ScalarBaseType, derive(Hash))]
 pub enum ScalarType {
     /// The type of [`Datum::True`] and [`Datum::False`].
@@ -880,48 +892,44 @@ impl<'a> ScalarType {
             _ => false,
         }
     }
-}
 
-/// NOTE: `ScalarType` equality is complicated by variants that store values.
-/// While we might want to handle stored values in one manner most of the time,
-/// that same approach might be insufficient in some cases.
-///
-/// When assessing unexpected behavior with type planning, it's worthwhile to
-/// see if the default equality is overridden in some other part of the code,
-/// e.g. when deciding how to handle potential casts between types.
-impl PartialEq for ScalarType {
-    fn eq(&self, other: &Self) -> bool {
+    /// Determines equality among scalar types that acknowledges custom OIDs,
+    /// but ignores other embedded values.
+    ///
+    /// In most situations, you want to use `base_eq` rather than `ScalarType`'s
+    /// implementation of `Eq`. `base_eq` expresses the semantics of direct type
+    /// interoperability whereas `Eq` expresses an exact comparison between the
+    /// values.
+    ///
+    /// For instance, `base_eq` signals that e.g. two [`ScalarType::Numeric`]
+    /// values can be added together, irrespective of their embedded scale. In
+    /// contrast, two `Numeric` values with different scales are never `Eq` to
+    /// one another.
+    pub fn base_eq(&self, other: &ScalarType) -> bool {
         use ScalarType::*;
         match (self, other) {
-            (Bool, Bool)
-            | (Int16, Int16)
-            | (Int32, Int32)
-            | (Int64, Int64)
-            | (Float32, Float32)
-            | (Float64, Float64)
-            | (Date, Date)
-            | (Time, Time)
-            | (Timestamp, Timestamp)
-            | (TimestampTz, TimestampTz)
-            | (Interval, Interval)
-            | (Bytes, Bytes)
-            | (String, String)
-            | (Uuid, Uuid)
-            | (Jsonb, Jsonb)
-            | (Oid, Oid)
-            | (Numeric { .. }, Numeric { .. }) => true,
             (
                 List {
-                    element_type: element_l,
+                    element_type: l,
                     custom_oid: oid_l,
                 },
                 List {
-                    element_type: element_r,
+                    element_type: r,
                     custom_oid: oid_r,
                 },
-            ) => element_l.eq(element_r) && oid_l == oid_r,
+            )
+            | (
+                Map {
+                    value_type: l,
+                    custom_oid: oid_l,
+                },
+                Map {
+                    value_type: r,
+                    custom_oid: oid_r,
+                },
+            ) => l.base_eq(r) && oid_l == oid_r,
 
-            (Array(a), Array(b)) => a.eq(b),
+            (Array(a), Array(b)) => a.base_eq(b),
             (
                 Record {
                     fields: fields_a,
@@ -934,93 +942,7 @@ impl PartialEq for ScalarType {
                     custom_name: name_b,
                 },
             ) => fields_a.eq(fields_b) && oid_a == oid_b && name_a == name_b,
-            (
-                Map {
-                    value_type: value_l,
-                    custom_oid: oid_l,
-                },
-                Map {
-                    value_type: value_r,
-                    custom_oid: oid_r,
-                },
-            ) => value_l.eq(value_r) && oid_l == oid_r,
-
-            (Bool, _)
-            | (Int16, _)
-            | (Int32, _)
-            | (Int64, _)
-            | (Float32, _)
-            | (Float64, _)
-            | (Date, _)
-            | (Time, _)
-            | (Timestamp, _)
-            | (TimestampTz, _)
-            | (Interval, _)
-            | (Bytes, _)
-            | (String, _)
-            | (Jsonb, _)
-            | (Uuid, _)
-            | (Array(_), _)
-            | (List { .. }, _)
-            | (Record { .. }, _)
-            | (Oid, _)
-            | (Map { .. }, _)
-            | (Numeric { .. }, _) => false,
-        }
-    }
-}
-
-impl Hash for ScalarType {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        use ScalarType::*;
-        match self {
-            Bool => state.write_u8(0),
-            Int16 => state.write_u8(1),
-            Int32 => state.write_u8(2),
-            Int64 => state.write_u8(3),
-            Float32 => state.write_u8(4),
-            Float64 => state.write_u8(5),
-            Numeric { .. } => state.write_u8(6),
-            Date => state.write_u8(7),
-            Time => state.write_u8(8),
-            Timestamp => state.write_u8(9),
-            TimestampTz => state.write_u8(10),
-            Interval => state.write_u8(11),
-            Bytes => state.write_u8(12),
-            String => state.write_u8(13),
-            Jsonb => state.write_u8(14),
-            Array(t) => {
-                state.write_u8(15);
-                t.hash(state);
-            }
-            List {
-                element_type,
-                custom_oid,
-            } => {
-                state.write_u8(16);
-                element_type.hash(state);
-                custom_oid.hash(state);
-            }
-            Record {
-                fields,
-                custom_oid,
-                custom_name,
-            } => {
-                state.write_u8(17);
-                fields.hash(state);
-                custom_oid.hash(state);
-                custom_name.hash(state);
-            }
-            Uuid => state.write_u8(18),
-            Oid => state.write_u8(19),
-            Map {
-                value_type,
-                custom_oid,
-            } => {
-                state.write_u8(20);
-                value_type.hash(state);
-                custom_oid.hash(state);
-            }
+            (s, o) => ScalarBaseType::from(s) == ScalarBaseType::from(o),
         }
     }
 }

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -736,7 +736,7 @@ impl ParamType {
 impl PartialEq<ScalarType> for ParamType {
     fn eq(&self, other: &ScalarType) -> bool {
         match self {
-            ParamType::Plain(s) => s == other,
+            ParamType::Plain(s) => s.base_eq(other),
             // Pseudotypes never equal concrete types
             _ => false,
         }
@@ -1100,7 +1100,7 @@ fn coerce_args_to_types(
 /// Provides shorthand for converting `Vec<ScalarType>` into `Vec<ParamType>`.
 macro_rules! params {
     ($p:ident...) => { ParamList::Variadic($p.into())};
-    ($($p:expr),*)      => { ParamList::Exact(vec![$($p.into(),)*]) };
+    ($($p:expr),*) => { ParamList::Exact(vec![$($p.into(),)*]) };
 }
 
 /// Constructs builtin function map.

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -999,7 +999,9 @@ fn plan_set_expr(
             let (left_expr, left_scope) = plan_set_expr(qcx, left)?;
             let (right_expr, _right_scope) = plan_set_expr(qcx, right)?;
 
-            // TODO(jamii) this type-checking is redundant with HirRelationExpr::typ, but currently it seems that we need both because HirRelationExpr::typ is not allowed to return errors
+            // TODO(jamii) this type-checking is redundant with
+            // HirRelationExpr::typ, but currently it seems that we need both
+            // because HirRelationExpr::typ is not allowed to return errors
             let left_types = qcx.relation_type(&left_expr).column_types;
             let right_types = qcx.relation_type(&right_expr).column_types;
             if left_types.len() != right_types.len() {

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -2602,7 +2602,7 @@ fn plan_list(
 ) -> Result<CoercibleScalarExpr, anyhow::Error> {
     let (elem_type, exprs) = if exprs.is_empty() {
         if let Some(ScalarType::List { element_type, .. }) = type_hint {
-            ((**element_type).clone(), vec![])
+            (element_type.default_embedded_value(), vec![])
         } else {
             bail!("cannot determine type of empty list");
         }
@@ -2621,7 +2621,7 @@ fn plan_list(
             });
         }
         let out = coerce_homogeneous_exprs("LIST expression", ecx, out, type_hint)?;
-        (ecx.scalar_type(&out[0]), out)
+        (ecx.scalar_type(&out[0]).default_embedded_value(), out)
     };
     Ok(HirScalarExpr::CallVariadic {
         func: VariadicFunc::ListCreate { elem_type },

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -329,7 +329,7 @@ fn get_cast(
     use CastContext::*;
 
     if match (from, to) {
-        // APD values are only rescaled if:
+        // Numeric values pass through and are only rescaled if:
         // - CastContext is either Assignment or Explicit
         // - `to` has a specified scale that differs from `from`'s
         (
@@ -338,7 +338,7 @@ fn get_cast(
                 scale: to_scale @ Some(..),
             },
         ) if ccx != Implicit => from_scale == to_scale,
-        _ => from == to,
+        _ => from.base_eq(to),
     } {
         return Some(Box::new(|expr| expr));
     }
@@ -478,7 +478,7 @@ pub fn guess_best_common_type(
         return Some(ScalarType::String);
     }
 
-    if known_types.iter().all(|t| *t == known_types[0]) {
+    if known_types.iter().all(|t| t.base_eq(&known_types[0])) {
         return Some(known_types[0].clone());
     }
 
@@ -497,7 +497,7 @@ pub fn guess_best_common_type(
             ScalarType::Int16 => 1,
             ScalarType::Int32 => 2,
             ScalarType::Int64 => 3,
-            ScalarType::Numeric { scale: None } => 4,
+            ScalarType::Numeric { .. } => 4,
             ScalarType::Float32 => 5,
             ScalarType::Float64 => 6,
             // TypeCategory::DateTime

--- a/test/sqllogictest/list.slt
+++ b/test/sqllogictest/list.slt
@@ -2140,9 +2140,9 @@ SELECT ('{1.2,2.3}'::numeric_list_c)::text;
 {1.2,2.3}
 
 query T
-SELECT ('{1.2,2.3}'::numeric_list_c::numeric(38,5) list)::text;
+SELECT ('{1.2,2.34567890}'::numeric_list_c::numeric(38,5) list)::text;
 ----
-{1.20000,2.30000}
+{1.2,2.34568}
 
 query T
 SELECT ('{1.2,2.3}'::numeric(38,5) list::numeric_list_c)::text;

--- a/test/sqllogictest/list.slt
+++ b/test/sqllogictest/list.slt
@@ -1703,7 +1703,7 @@ SELECT (LIST[1] || '{2}')::text
 ----
 {1,2}
 
-# Differently scaled decimals are implicitly castable to one another
+# Differently scaled numerics are implicitly castable to one another
 query T
 SELECT ('{1.2}'::numeric(38,5) list || '{2.3}'::numeric(38,0) list)::text;
 ----
@@ -1714,6 +1714,17 @@ query T
 SELECT ('{{1.2}}'::numeric(38,5) list list || '{{2.3}}'::numeric(38,0) list list)::text;
 ----
 {{1.2},{2}}
+
+# Determining common list element type for numerics does not rescale values
+query T
+SELECT LIST[1.234::numeric(39,2), 2.345]::text;
+----
+{1.23,2.345}
+
+query T
+SELECT LIST[1.234::numeric(39,2), 2.345]::numeric(39, 2) list::text;
+----
+{1.23,2.35}
 
 # 🔬🔬🔬 list + element
 

--- a/test/testdrive/numeric.td
+++ b/test/testdrive/numeric.td
@@ -23,3 +23,12 @@ a    eq_zero
 ------------
 0    true
 0.01 false
+
+# Ensure values are rescaled on insert
+> INSERT INTO numeric_insertions VALUES (1.2345);
+> SELECT a FROM numeric_values ORDER BY a
+a
+----
+0
+0.01
+1.23


### PR DESCRIPTION
@benesch mentioned he'd like `ScalarType`'s `Eq` derived rather than hand-rolled, so this PR does that. While I was mucking around in this code, I realized there were some deficiencies in how we scaled `numeric list`s, which I also fixed.