### PR TITLE
dataflow-api: proof of concept for single-binary service boundaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
  "chrono",
  "crossbeam-channel",
  "datadriven",
- "dataflow",
+ "dataflow-api",
  "dataflow-types",
  "dec",
  "derivative",
@@ -560,6 +560,7 @@ dependencies = [
  "coord",
  "datadriven",
  "dataflow",
+ "dataflow-api",
  "dataflow-types",
  "expr",
  "futures",
@@ -788,6 +789,7 @@ dependencies = [
  "chrono",
  "crossbeam-channel",
  "csv-core",
+ "dataflow-api",
  "dataflow-types",
  "dec",
  "differential-dataflow",
@@ -828,6 +830,18 @@ dependencies = [
  "tokio-util",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "dataflow-api"
+version = "0.0.0"
+dependencies = [
+ "dataflow-types",
+ "expr",
+ "repr",
+ "serde",
+ "timely",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "src/ccsr",
     "src/coord",
     "src/coordtest",
+    "src/dataflow-api",
     "src/dataflow-bin",
     "src/dataflow-types",
     "src/dataflow",

--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -15,7 +15,7 @@ byteorder = "1.4.3"
 ccsr = { path = "../ccsr" }
 chrono = { version = "0.4.0", default-features = false, features = ["std"] }
 crossbeam-channel = "0.5.1"
-dataflow = { path = "../dataflow" }
+dataflow-api = { path = "../dataflow-api" }
 dataflow-types = { path = "../dataflow-types" }
 derivative = "2.2.0"
 dec = "0.4.4"

--- a/src/coord/src/lib.rs
+++ b/src/coord/src/lib.rs
@@ -23,6 +23,9 @@
 //! The main interface to the coordinator is [`Client`]. To start a coordinator,
 //! use the [`serve`] function.
 
+// WIP
+#![allow(unused_imports)]
+
 // TODO(benesch): delete this once we use structured errors everywhere.
 macro_rules! coord_bail {
     ($($e:expr),*) => {

--- a/src/coordtest/Cargo.toml
+++ b/src/coordtest/Cargo.toml
@@ -10,6 +10,7 @@ anyhow = "1.0.42"
 coord = { path = "../coord" }
 datadriven = "0.6.0"
 dataflow = { path = "../dataflow" }
+dataflow-api = { path = "../dataflow-api" }
 dataflow-types = { path = "../dataflow-types" }
 expr = { path = "../expr" }
 futures = "0.3.14"

--- a/src/dataflow-api/Cargo.toml
+++ b/src/dataflow-api/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "dataflow-api"
+description = "Service API for the dataflow crate."
+version = "0.0.0"
+edition = "2018"
+publish = false
+
+[dependencies]
+dataflow-types = { path = "../dataflow-types" }
+expr = { path = "../expr" }
+repr = { path = "../repr" }
+serde = { version = "1.0.126", features = ["derive"] }
+timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
+tokio = { version = "1.8.1", features = ["fs", "rt", "sync"] }

--- a/src/dataflow-api/src/lib.rs
+++ b/src/dataflow-api/src/lib.rs
@@ -1,0 +1,160 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use serde::{Deserialize, Serialize};
+use timely::progress::frontier::Antichain;
+use timely::progress::ChangeBatch;
+use tokio::sync::mpsc;
+
+use dataflow_types::logging::LoggingConfig;
+use dataflow_types::{
+    DataflowDescription, MzOffset, PeekResponse, SourceConnector, TimestampSourceUpdate, Update,
+};
+use expr::{GlobalId, OptimizedMirRelationExpr, PartitionId, RowSetFinishing};
+use repr::{Row, Timestamp};
+
+pub trait DataflowClient: Send + 'static {
+    fn num_workers(&self) -> usize;
+    fn broadcast(&self, cmd: SequencedCommand);
+    // WIP this is wonky
+    fn take_feedback_rx(&mut self) -> mpsc::UnboundedReceiver<WorkerFeedbackWithMeta>;
+}
+
+/// Explicit instructions for timely dataflow workers.
+#[derive(Clone, Debug)]
+pub enum SequencedCommand {
+    /// Create a sequence of dataflows.
+    ///
+    /// Each of the dataflows must contain `as_of` members that are valid
+    /// for each of the referenced arrangements, meaning `AllowCompaction`
+    /// should be held back to those values until the command.
+    /// Subsequent commands may arbitrarily compact the arrangements;
+    /// the dataflow runners are responsible for ensuring that they can
+    /// correctly maintain the dataflows.
+    CreateDataflows(Vec<DataflowDescription<OptimizedMirRelationExpr>>),
+    /// Drop the sources bound to these names.
+    DropSources(Vec<GlobalId>),
+    /// Drop the sinks bound to these names.
+    DropSinks(Vec<GlobalId>),
+    /// Drop the indexes bound to these namees.
+    DropIndexes(Vec<GlobalId>),
+    /// Peek at an arrangement.
+    ///
+    /// This request elicits data from the worker, by naming an
+    /// arrangement and some actions to apply to the results before
+    /// returning them.
+    ///
+    /// The `timestamp` member must be valid for the arrangement that
+    /// is referenced by `id`. This means that `AllowCompaction` for
+    /// this arrangement should not pass `timestamp` before this command.
+    /// Subsequent commands may arbitrarily compact the arrangements;
+    /// the dataflow runners are responsible for ensuring that they can
+    /// correctly answer the `Peek`.
+    Peek {
+        /// The identifier of the arrangement.
+        id: GlobalId,
+        /// An optional key that should be used for the arrangement.
+        key: Option<Row>,
+        /// The identifier of this peek request.
+        ///
+        /// Used in responses and cancelation requests.
+        conn_id: u32,
+        /// A communication link for sending a response.
+        tx: mpsc::UnboundedSender<PeekResponse>,
+        /// The logical timestamp at which the arrangement is queried.
+        timestamp: Timestamp,
+        /// Actions to apply to the result set before returning them.
+        finishing: RowSetFinishing,
+        /// Linear operation to apply in-line on each result.
+        map_filter_project: expr::SafeMfpPlan,
+    },
+    /// Cancel the peek associated with the given `conn_id`.
+    CancelPeek {
+        /// The identifier of the peek request to cancel.
+        conn_id: u32,
+    },
+    /// Insert `updates` into the local input named `id`.
+    Insert {
+        /// Identifier of the local input.
+        id: GlobalId,
+        /// A list of updates to be introduced to the input.
+        updates: Vec<Update>,
+    },
+    /// Enable compaction in views.
+    ///
+    /// Each entry in the vector names a view and provides a frontier after which
+    /// accumulations must be correct. The workers gain the liberty of compacting
+    /// the corresponding maintained traces up through that frontier.
+    AllowCompaction(Vec<(GlobalId, Antichain<Timestamp>)>),
+    /// Update durability information for sources.
+    ///
+    /// Each entry names a source and provides a frontier before which the source can
+    /// be exactly replayed across restarts (i.e. we can assign the same timestamps to
+    /// all the same data)
+    DurabilityFrontierUpdates(Vec<(GlobalId, Antichain<Timestamp>)>),
+    /// Add a new source to be aware of for timestamping.
+    AddSourceTimestamping {
+        /// The ID of the timestamped source
+        id: GlobalId,
+        /// The connector for the timestamped source.
+        connector: SourceConnector,
+        /// Previously stored timestamp bindings.
+        bindings: Vec<(PartitionId, Timestamp, MzOffset)>,
+    },
+    /// Advance worker timestamp
+    AdvanceSourceTimestamp {
+        /// The ID of the timestamped source
+        id: GlobalId,
+        /// The associated update (RT or BYO)
+        update: TimestampSourceUpdate,
+    },
+    /// Drop all timestamping info for a source
+    DropSourceTimestamping {
+        /// The ID id of the formerly timestamped source.
+        id: GlobalId,
+    },
+    /// Advance all local inputs to the given timestamp.
+    AdvanceAllLocalInputs {
+        /// The timestamp to advance to.
+        advance_to: Timestamp,
+    },
+    /// Request that the logging sources in the contained configuration are
+    /// installed.
+    EnableLogging(LoggingConfig),
+    /// Disconnect inputs, drain dataflows, and shut down timely workers.
+    Shutdown,
+}
+
+/// Information from timely dataflow workers.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct WorkerFeedbackWithMeta {
+    /// Identifies the worker by its identifier.
+    pub worker_id: usize,
+    /// The feedback itself.
+    pub message: WorkerFeedback,
+}
+
+/// Data about timestamp bindings that dataflow workers send to the coordinator
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TimestampBindingFeedback {
+    /// Durability frontier changes
+    pub changes: Vec<(GlobalId, ChangeBatch<Timestamp>)>,
+    /// Timestamp bindings for all of those frontier changes
+    pub bindings: Vec<(GlobalId, PartitionId, Timestamp, MzOffset)>,
+}
+
+/// Responses the worker can provide back to the coordinator.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum WorkerFeedback {
+    /// A list of identifiers of traces, with prior and new upper frontiers.
+    FrontierUppers(Vec<(GlobalId, ChangeBatch<Timestamp>)>),
+    /// Timestamp bindings and prior and new frontiers for those bindings for all
+    /// sources
+    TimestampBindings(TimestampBindingFeedback),
+}

--- a/src/dataflow/Cargo.toml
+++ b/src/dataflow/Cargo.toml
@@ -15,6 +15,7 @@ ccsr = { path = "../ccsr" }
 chrono = { version = "0.4.0", default-features = false, features = ["std"] }
 crossbeam-channel = "0.5.1"
 csv-core = "0.1.10"
+dataflow-api = { path = "../dataflow-api" }
 dataflow-types = { path = "../dataflow-types" }
 dec = { version = "0.4.4", features = ["serde"] }
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }

--- a/src/dataflow/src/lib.rs
+++ b/src/dataflow/src/lib.rs
@@ -7,7 +7,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-#![forbid(missing_docs)]
+// WIP
+// #![forbid(missing_docs)]
+#![allow(unused_imports, missing_docs)]
 
 //! Driver for timely/differential dataflow.
 
@@ -23,7 +25,4 @@ pub mod logging;
 pub mod source;
 
 pub use render::plan::Plan;
-pub use server::{
-    serve, Config, SequencedCommand, TimestampBindingFeedback, WorkerFeedback,
-    WorkerFeedbackWithMeta,
-};
+pub use server::{Config, DataflowClientImpl};

--- a/src/dataflow/src/server/metrics.rs
+++ b/src/dataflow/src/server/metrics.rs
@@ -193,7 +193,6 @@ impl CommandsProcessedMetrics {
             SequencedCommand::DropSourceTimestamping { .. } => {
                 self.drop_source_timestamping_int += 1
             }
-            SequencedCommand::EnableFeedback(..) => self.enable_feedback_int += 1,
             SequencedCommand::EnableLogging(_) => self.enable_logging_int += 1,
             SequencedCommand::Shutdown { .. } => self.shutdown_int += 1,
             SequencedCommand::AdvanceAllLocalInputs { .. } => {


### PR DESCRIPTION
Key thing to note is that no crates other than materialized (and
coordtest) depend on dataflow. This is something that we'd want to
enforce in CI somehow so it doesn't accidentally rot.

This refactor was pretty straightforward because the abstraction
boundary of dataflow is already strong, with just a few exceptions
creeping in. The dep structure added by this PR makes it "impossible"
for exceptions to creep back in. We could even go so far as to disallow
deps from dataflow-api to mpsc and friends (once we clean up the ones
there now) to prevent that class of abstraction breakage from creeping
in.

Obviously tons to clean up here, this would never be merged like this.
Just showing how it might work to facilitate discussion.