### PR TITLE
Switch from jemallocator to tikv-jemallocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1912,38 +1912,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
-name = "jemalloc-ctl"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c502a5ff9dd2924f1ed32ba96e3b65735d837b4bfd978d3161b1702e66aca4b7"
-dependencies = [
- "jemalloc-sys",
- "libc",
- "paste",
-]
-
-[[package]]
-name = "jemalloc-sys"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45"
-dependencies = [
- "cc",
- "fs_extra",
- "libc",
-]
-
-[[package]]
-name = "jemallocator"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69"
-dependencies = [
- "jemalloc-sys",
- "libc",
-]
-
-[[package]]
 name = "jobserver"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2168,7 +2136,6 @@ dependencies = [
  "hyper-openssl",
  "include_dir",
  "itertools 0.10.1",
- "jemallocator",
  "kafka-util",
  "krb5-src",
  "lazy_static",
@@ -2207,6 +2174,7 @@ dependencies = [
  "sysinfo",
  "tar",
  "tempfile",
+ "tikv-jemallocator",
  "timely",
  "tokio",
  "tokio-openssl",
@@ -3101,11 +3069,11 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "backtrace",
- "jemalloc-ctl",
  "lazy_static",
  "pprof",
  "serde",
  "tempfile",
+ "tikv-jemalloc-ctl",
  "tokio",
 ]
 
@@ -4435,6 +4403,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "tikv-jemalloc-ctl"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28c80e4338857639f443169a601fafe49866aed8d7a8d565c2f5bfb1a021adf"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.4.1+5.2.1-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a26331b05179d4cb505c8d6814a7e18d298972f0a551b0e3cefccff927f86d3"
+dependencies = [
+ "cc",
+ "fs_extra",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c14a5a604eb8715bc5785018a37d00739b180bcf609916ddf4393d33d49ccdf"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -93,7 +93,7 @@ uuid = "0.8.2"
 #
 # See: https://github.com/jemalloc/jemalloc/issues/956#issuecomment-316224733
 prof = { path = "../prof", features = ["jemalloc"] }
-jemallocator = { version = "0.3.0", features = ["profiling", "stats", "unprefixed_malloc_on_supported_platforms", "background_threads"] }
+tikv-jemallocator = { version = "0.4.1", features = ["profiling", "stats", "unprefixed_malloc_on_supported_platforms", "background_threads"] }
 
 [dev-dependencies]
 assert_cmd = "1.0.7"

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -46,7 +46,7 @@ mod telemetry;
 // [2]: https://github.com/jemalloc/jemalloc/issues/1467
 #[cfg(not(target_os = "macos"))]
 #[global_allocator]
-static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 pub const BUILD_INFO: BuildInfo = BuildInfo {
     version: env!("CARGO_PKG_VERSION"),

--- a/src/prof/Cargo.toml
+++ b/src/prof/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.42"
 backtrace = "0.3.60"
-jemalloc-ctl = { version = "0.3.0", features = ["use_std"], optional = true }
+tikv-jemalloc-ctl = { version = "0.4.1", features = ["use_std"], optional = true }
 lazy_static = "1.4.0"
 pprof = "0.4.4"
 serde = { version = "1.0.126", features = ["derive"] }
@@ -17,4 +17,4 @@ tokio = { version = "1.8.1", features = ["time"] }
 
 [features]
 # Whether to enable profiling features that depend on jemalloc.
-jemalloc = ["jemalloc-ctl"]
+jemalloc = ["tikv-jemalloc-ctl"]

--- a/src/prof/src/jemalloc.rs
+++ b/src/prof/src/jemalloc.rs
@@ -18,9 +18,9 @@ use std::{ffi::CString, io::BufRead, time::Instant};
 use tokio::sync::Mutex;
 
 use anyhow::bail;
-use jemalloc_ctl::{epoch, raw, stats};
 use lazy_static::lazy_static;
 use tempfile::NamedTempFile;
+use tikv_jemalloc_ctl::{epoch, raw, stats};
 
 use super::{ProfStartTime, StackProfile, WeightedStack};
 
@@ -155,7 +155,7 @@ impl JemallocProfCtl {
         self.md
     }
 
-    pub fn activate(&mut self) -> Result<(), jemalloc_ctl::Error> {
+    pub fn activate(&mut self) -> Result<(), tikv_jemalloc_ctl::Error> {
         // SAFETY: "prof.active" is documented as being writable and taking a bool:
         // http://jemalloc.net/jemalloc.3.html#prof.active
         unsafe { raw::write(b"prof.active\0", true) }?;
@@ -165,7 +165,7 @@ impl JemallocProfCtl {
         Ok(())
     }
 
-    pub fn deactivate(&mut self) -> Result<(), jemalloc_ctl::Error> {
+    pub fn deactivate(&mut self) -> Result<(), tikv_jemalloc_ctl::Error> {
         // SAFETY: "prof.active" is documented as being writable and taking a bool:
         // http://jemalloc.net/jemalloc.3.html#prof.active
         unsafe { raw::write(b"prof.active\0", false) }?;
@@ -186,7 +186,7 @@ impl JemallocProfCtl {
     pub fn dump_stats(&mut self) -> anyhow::Result<String> {
         // Try to avoid allocations within `stats_print`
         let mut buf = Vec::with_capacity(1 << 20);
-        jemalloc_ctl::stats_print::stats_print(&mut buf, Default::default())?;
+        tikv_jemalloc_ctl::stats_print::stats_print(&mut buf, Default::default())?;
         Ok(String::from_utf8(buf)?)
     }
 


### PR DESCRIPTION
The original jemallocator crate has not been updated for two years.

Fixes #7500.

Signed-off-by: Moritz Hoffmann <mh@materialize.com>