### PR TITLE
doc: Make Hugo more reliably pick up generate.sh changes

### DIFF
--- a/doc/user/sql-grammar/generate.sh
+++ b/doc/user/sql-grammar/generate.sh
@@ -18,7 +18,7 @@ cd "$(dirname "$0")"
 dest=../layouts/partials/sql-grammar
 
 # Clean up files from last run.
-rm -rf scratch $dest
+rm -rf scratch
 
 # Run the railroad diagram generator, using a pinned version from our custom
 # fork.
@@ -38,4 +38,10 @@ mkdir scratch
         fi
     done
 )
+
+rm -rf $dest
 mv scratch $dest
+
+# ping hugo again
+sleep 3
+touch "$dest"/*


### PR DESCRIPTION
I've had a lot of trouble with Hugo apparently getting confused by the changes
from generate.sh, even with --disableFastRender --ignoreCache,

Moving the `rm` to just before the mv causes Hugo to not throw errors about
being unable to generate pages.

The second sleep and hot-swap seems to cause hugo to reliably notice that the
diagrams have been updated and that the site should be rebuilt.