### PR TITLE
python: Update some dependencies that black requires be recent

### DIFF
--- a/misc/python/requirements.txt
+++ b/misc/python/requirements.txt
@@ -1,7 +1,7 @@
-click==7.1.1
+click==8.0.1
 pg8000==1.15.2
 PyMySQL==0.9.3
 pyyaml==5.4
 semver==2.9.1
-toml==0.10.0
+toml==0.10.2
 typing-extensions==3.7.4.2


### PR DESCRIPTION
Black depends on a newer click and toml than we were using, and click 8.x
includes meaningful improvements to its type annotations so is worth doing for
that alone.