### PR TITLE
switch to Materialize fork of tikv-jemallocator to fix profiling bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4408,8 +4408,7 @@ dependencies = [
 [[package]]
 name = "tikv-jemalloc-ctl"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28c80e4338857639f443169a601fafe49866aed8d7a8d565c2f5bfb1a021adf"
+source = "git+https://github.com/MaterializeInc/jemallocator#21b277d1bce952bbfc4e9679dcb1d31c874ccf09"
 dependencies = [
  "libc",
  "paste",
@@ -4419,8 +4418,7 @@ dependencies = [
 [[package]]
 name = "tikv-jemalloc-sys"
 version = "0.4.1+5.2.1-patched"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a26331b05179d4cb505c8d6814a7e18d298972f0a551b0e3cefccff927f86d3"
+source = "git+https://github.com/MaterializeInc/jemallocator#21b277d1bce952bbfc4e9679dcb1d31c874ccf09"
 dependencies = [
  "cc",
  "fs_extra",
@@ -4430,8 +4428,7 @@ dependencies = [
 [[package]]
 name = "tikv-jemallocator"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c14a5a604eb8715bc5785018a37d00739b180bcf609916ddf4393d33d49ccdf"
+source = "git+https://github.com/MaterializeInc/jemallocator#21b277d1bce952bbfc4e9679dcb1d31c874ccf09"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",

--- a/deny.toml
+++ b/deny.toml
@@ -47,6 +47,7 @@ allow-git = [
     "https://github.com/MaterializeInc/rust-postgres-array.git",
     "https://github.com/MaterializeInc/rust-prometheus.git",
     "https://github.com/MaterializeInc/serde-protobuf.git",
+    "https://github.com/MaterializeInc/jemallocator.git",
     "https://github.com/TimelyDataflow/timely-dataflow",
     "https://github.com/TimelyDataflow/differential-dataflow.git",
     "https://github.com/fede1024/rust-rdkafka.git",

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -93,7 +93,7 @@ uuid = "0.8.2"
 #
 # See: https://github.com/jemalloc/jemalloc/issues/956#issuecomment-316224733
 prof = { path = "../prof", features = ["jemalloc"] }
-tikv-jemallocator = { version = "0.4.1", features = ["profiling", "stats", "unprefixed_malloc_on_supported_platforms", "background_threads"] }
+tikv-jemallocator = { version = "0.4.1", features = ["profiling", "stats", "unprefixed_malloc_on_supported_platforms", "background_threads"] , git = "https://github.com/MaterializeInc/jemallocator" }
 
 [dev-dependencies]
 assert_cmd = "1.0.7"

--- a/src/prof/Cargo.toml
+++ b/src/prof/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.42"
 backtrace = "0.3.60"
-tikv-jemalloc-ctl = { version = "0.4.1", features = ["use_std"], optional = true }
+tikv-jemalloc-ctl = { version = "0.4.1", features = ["use_std"], optional = true, git = "https://github.com/MaterializeInc/jemallocator" }
 lazy_static = "1.4.0"
 pprof = "0.4.4"
 serde = { version = "1.0.126", features = ["derive"] }


### PR DESCRIPTION
Apparently a bug in sampling/profiling was introduced in jemalloc 5.2.1, and fixed shortly thereafter on the dev branch. Since jemalloc has not had a release in 2 years, it doesn’t make sense to wait around for this to go out. Thus we fork tikv-jemallocator and update it to depend on a fork of tikv/jemalloc (itself a fork of jemalloc/jemalloc) with the bug fix cherry-picked.

As a follow-up, we should submit this to the tikv folks, so that we can avoid carrying around a fork of a fork indefinitely.

The actual content of this change is one cherry-picked commit in jemalloc, whose content can be seen here: https://github.com/MaterializeInc/jemalloc/commit/bb1b6dd8390bad91367f6251ce401f5b771d4cdd

With this commit applied, memory flamegraphs work again.