### PR TITLE
sources,sinks: de-experimentalize RT timestamp binding persistence (AKA exactly-once sinks)

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -54,6 +54,10 @@ Wrap your release notes at the 80 character mark.
 - Respect the [`no_proxy` environment variable](/cli/#http-proxies) to exclude
   certain hosts from the configured HTTP/HTTPS proxy, if any.
 
+- Add [`reuse_topic`](/sql/create-sink/#enabling-topic-reuse-after-restart) as
+  a beta feature for Kafka Sinks. This allows re-using the output topic across
+  restarts of Materialize.
+
 {{% version-header v0.8.3 %}}
 - The `MZ_LOG` environment variable is no longer recognized. Setting the log
   level can be done using the `--log-filter` command line parameter or the

--- a/doc/user/content/sql/create-sink.md
+++ b/doc/user/content/sql/create-sink.md
@@ -54,8 +54,8 @@ Field                | Value type | Description
 ---------------------|------------|------------
 `partition_count`    | `int`      | Set the sink Kafka topic's partition count. This defaults to -1 (use the broker default).
 `replication_factor` | `int`      | Set the sink Kafka topic's replication factor. This defaults to -1 (use the broker default).
-`reuse_topic`        | `bool`     | Use the existing Kafka topic after Materialize restarts, instead of creating a new one. `consistency_topic` is required if true. The default is false.
-`consistency_topic`  | `text`     | Makes the sink emit additional [consistency metadata](#consistency-metadata). Only valid for Kafka sinks.
+`reuse_topic`        | `bool`     | Use the existing Kafka topic after Materialize restarts, instead of creating a new one. The default is false.
+`consistency_topic`  | `text`     | Makes the sink emit additional [consistency metadata](#consistency-metadata). Only valid for Kafka sinks. If `reuse_topic` is `true`, a default `consistency_topic` will be used when not explicitly set. The default consistency topic name is formed by appending `-consistency` to the output topic name.
 `security_protocol`  | `text`     | Use [`ssl`](#ssl-with-options) or, for [Kerberos](#kerberos-with-options), `sasl_plaintext`, `sasl-scram-sha-256`, or `sasl-sha-512` to connect to the Kafka cluster.
 `acks`               | `text`     | Sets the number of Kafka replicas that must acknowledge Materialize writes. Accepts values [-1,1000]. `-1` (the default) specifies all replicas.
 
@@ -178,7 +178,7 @@ This is currently available only for Kafka sources and the views based on them.
 When you create a sink, you must:
 
 * Enable the `reuse_topic` switch.
-* Specify a [consistency topic](#consistency-metadata) to store the information that Materialize will use to identify the last completed write. The names of the sink topic and the sink consistency topic must be unique across all sinks in the system.
+* Optionally specify a [consistency topic](#consistency-metadata) to store the information that Materialize will use to identify the last completed write. The names of the sink topic and the sink consistency topic must be unique across all sinks in the system. If not specified, a default consistency topic name will be created by appending `-consistency` to the output topic name.
 
 The sink consistency topic cannot be written to by any other process, including another Materialize instance or another sink.
 
@@ -219,6 +219,8 @@ In addition to the inline information, Materialize creates a new "consistency to
 ```nofmt
 {consistency_topic_prefix}-{sink_global_id}-{materialize-startup-time}-{nonce}
 ```
+
+**Note:** With `reuse_topic` enabled, this schema for topic naming is ignored. Instead, the topic name specified via the `consistency_topic` option is used as is.
 
 Each message in the consistency topic has the schema below.
 ```

--- a/doc/user/content/sql/create-sink.md
+++ b/doc/user/content/sql/create-sink.md
@@ -98,7 +98,7 @@ they occur. To only see results after the sink is created, specify `WITHOUT SNAP
 
 - Materialize currently only supports Avro-formatted sinks that write to either a topic or an Avro object container file.
 - For most sinks, Materialize creates new, distinct topics and files for each sink on restart.
-- For Avro-formatted Kafka sinks, an experimental feature enables the use of the same topic after restart. For details, see [Enabling topic reuse after restart](#enabling-topic-reuse-after-restart).
+- For Avro-formatted Kafka sinks, a beta feature enables the use of the same topic after restart. For details, see [Enabling topic reuse after restart](#enabling-topic-reuse-after-restart).
 - Materialize stores information about actual topic names and actual file names in the `mz_kafka_sinks` and `mz_avro_ocf_sinks` log sources. See the [examples](#examples) below for more details.
 - Materialize generates Avro schemas for views and sources that are stored in sinks.
 - Materialize can also optionally emit transaction information for changes. This is only supported for Kafka sinks and adds transaction id information inline with the data, and adds a separate transaction metadata topic.
@@ -169,7 +169,7 @@ You can find the topic name for each Kafka sink by querying `mz_kafka_sinks`.
 
 #### Enabling topic reuse after restart
 
-{{< experimental v0.8.2 />}}
+{{< beta v0.8.4 />}}
 
 By default, Materialize creates new, distinct topics for sinks after each restart. To enable the reuse of the existing topic instead, Materialize must be able to reconstruct the prior history of the sinked object and all objects on which it is dependent--that is, events must have replayable timestamps--and must ensure that no other processes write to the output topic.
 
@@ -182,7 +182,7 @@ When you create a sink, you must:
 
 The sink consistency topic cannot be written to by any other process, including another Materialize instance or another sink.
 
-Because this feature is still experimental, we strongly suggest that you start with test data, rather than with production. Please [escalate](https://github.com/MaterializeInc/materialize/issues/new/choose) any issues to us.
+Because this feature is still in beta, we strongly suggest that you start with test data, rather than with production. Please [escalate](https://github.com/MaterializeInc/materialize/issues/new/choose) any issues to us.
 
 #### Consistency metadata
 

--- a/doc/user/layouts/shortcodes/beta.html
+++ b/doc/user/layouts/shortcodes/beta.html
@@ -4,4 +4,10 @@
     is in beta. It may have performance or stability issues and is not subject
     to our <a href="{{ "/versions/#backwards-compatibility" | relURL }}">backwards compatibility</a>
     guarantee.
+
+    {{if in (apply $.Site.Params.versions "index" "." "name") (.Get 0)}}
+    <em>Available since {{.Get 0}}.</em>
+    {{else}}
+    <em>Available only in <a href="{{"/versions/#unstable-builds"|relURL}}">unstable builds</a>.</em>
+    {{end}}
 </div>

--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -117,6 +117,10 @@ where
 
         for id in &self.transitive_source_dependencies {
             if let Some(history) = render_state.ts_histories.get(id) {
+                // As soon as we have one sink that depends on a given source,
+                // that source needs to persist timestamp bindings.
+                history.enable_persistence();
+
                 let mut history_bindings = history.clone();
                 // We don't want these to block compaction
                 // ever.

--- a/src/dataflow/src/source/timestamp.rs
+++ b/src/dataflow/src/source/timestamp.rs
@@ -271,6 +271,8 @@ pub struct TimestampBindingBox {
     /// Never persist these bindings. This is used for BYO, where the bindings
     /// are stored externally already.
     never_requires_persistence: bool,
+    /// Whether or not these timestamp bindings need to be persisted.
+    requires_persistence: bool,
 }
 
 impl TimestampBindingBox {
@@ -285,6 +287,7 @@ impl TimestampBindingBox {
             durability_frontier: Antichain::from_elem(TimelyTimestamp::minimum()),
             proposer: timestamp_update_interval.map(|i| TimestampProposer::new(i, now)),
             never_requires_persistence,
+            requires_persistence: false,
         }
     }
 
@@ -560,7 +563,17 @@ impl TimestampBindingRc {
 
     /// Whether or not these timestamp bindings must be persisted.
     pub fn requires_persistence(&self) -> bool {
-        !self.wrapper.borrow().never_requires_persistence
+        let inner = self.wrapper.borrow();
+        if inner.never_requires_persistence {
+            false
+        } else {
+            inner.requires_persistence
+        }
+    }
+
+    /// Enables persistence for these bindings.
+    pub fn enable_persistence(&self) {
+        self.wrapper.borrow_mut().requires_persistence = true;
     }
 }
 

--- a/src/dataflow/src/source/timestamp.rs
+++ b/src/dataflow/src/source/timestamp.rs
@@ -268,15 +268,23 @@ pub struct TimestampBindingBox {
     durability_frontier: Antichain<Timestamp>,
     /// Generates new timestamps for RT sources
     proposer: Option<TimestampProposer>,
+    /// Never persist these bindings. This is used for BYO, where the bindings
+    /// are stored externally already.
+    never_requires_persistence: bool,
 }
 
 impl TimestampBindingBox {
-    fn new(timestamp_update_interval: Option<u64>, now: NowFn) -> Self {
+    fn new(
+        timestamp_update_interval: Option<u64>,
+        now: NowFn,
+        never_requires_persistence: bool,
+    ) -> Self {
         Self {
             partitions: HashMap::new(),
             compaction_frontier: MutableAntichain::new_bottom(TimelyTimestamp::minimum()),
             durability_frontier: Antichain::from_elem(TimelyTimestamp::minimum()),
             proposer: timestamp_update_interval.map(|i| TimestampProposer::new(i, now)),
+            never_requires_persistence,
         }
     }
 
@@ -428,10 +436,15 @@ pub struct TimestampBindingRc {
 
 impl TimestampBindingRc {
     /// Create a new instance of `TimestampBindingRc`.
-    pub fn new(timestamp_update_interval: Option<u64>, now: NowFn) -> Self {
+    pub fn new(
+        timestamp_update_interval: Option<u64>,
+        now: NowFn,
+        never_requires_persistence: bool,
+    ) -> Self {
         let wrapper = Rc::new(RefCell::new(TimestampBindingBox::new(
             timestamp_update_interval,
             now,
+            never_requires_persistence,
         )));
 
         let ret = Self {
@@ -543,6 +556,11 @@ impl TimestampBindingRc {
     /// Returns the current durability frontier
     pub fn durability_frontier(&self) -> Antichain<Timestamp> {
         self.wrapper.borrow().durability_frontier.clone()
+    }
+
+    /// Whether or not these timestamp bindings must be persisted.
+    pub fn requires_persistence(&self) -> bool {
+        !self.wrapper.borrow().never_requires_persistence
     }
 }
 

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -22,7 +22,7 @@ use anyhow::{anyhow, bail};
 use aws_arn::ARN;
 use globset::GlobBuilder;
 use itertools::Itertools;
-use log::error;
+use log::{debug, error};
 use regex::Regex;
 use reqwest::Url;
 
@@ -1261,6 +1261,23 @@ fn kafka_sink_builder(
         Some(_) => bail!("consistency_topic must be a string"),
     };
 
+    let reuse_topic = match with_options.remove("reuse_topic") {
+        Some(Value::Boolean(b)) => b,
+        None => false,
+        Some(_) => bail!("reuse_topic must be a boolean"),
+    };
+
+    let consistency_topic = if reuse_topic && consistency_topic.is_none() {
+        let default_consistency_topic = format!("{}-consistency", topic_prefix);
+        debug!(
+            "Using default consistency topic '{}' for topic '{}'",
+            default_consistency_topic, topic_prefix
+        );
+        Some(default_consistency_topic)
+    } else {
+        consistency_topic
+    };
+
     let config_options = kafka_util::extract_config(with_options)?;
 
     let format = match format {
@@ -1307,16 +1324,6 @@ fn kafka_sink_builder(
     };
 
     let broker_addrs = broker.parse()?;
-
-    let reuse_topic = match with_options.remove("reuse_topic") {
-        Some(Value::Boolean(b)) => b,
-        None => false,
-        Some(_) => bail!("reuse_topic must be a boolean"),
-    };
-
-    if reuse_topic && consistency_topic.is_none() {
-        bail!("reuse_topic requires a consistency topic");
-    }
 
     let transitive_source_dependencies: Vec<_> = if reuse_topic {
         for item in root_dependencies.iter() {

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1244,7 +1244,6 @@ pub fn plan_create_views(
 
 #[allow(clippy::too_many_arguments)]
 fn kafka_sink_builder(
-    scx: &StatementContext,
     format: Option<Format<Raw>>,
     with_options: &mut BTreeMap<String, Value>,
     broker: String,
@@ -1333,8 +1332,6 @@ fn kafka_sink_builder(
                     "reuse_topic requires that sink input dependencies are replayable, {} is not",
                     item.name()
                 );
-                } else if !item.source_connector()?.is_byo() {
-                    scx.require_experimental_mode("Exactly-once sinks")?;
                 }
             } else if item.item_type() != CatalogItemType::Source {
                 bail!(
@@ -1543,7 +1540,6 @@ pub fn plan_create_sink(
     let connector_builder = match connector {
         Connector::File { .. } => unsupported!("file sinks"),
         Connector::Kafka { broker, topic, .. } => kafka_sink_builder(
-            scx,
             format,
             &mut with_options,
             broker,

--- a/test/kafka-exactly-once/before-restart.td
+++ b/test/kafka-exactly-once/before-restart.td
@@ -76,7 +76,7 @@ $ kafka-create-topic topic=input
 
 > CREATE SINK output_rt FROM input_rt
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-rt-sink-${testdrive.seed}'
-  WITH (reuse_topic=true, consistency_topic='output-rt-sink-consistency-${testdrive.seed}')
+  WITH (reuse_topic=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 > CREATE MATERIALIZED SOURCE input_byo
@@ -86,7 +86,7 @@ $ kafka-create-topic topic=input
 
 > CREATE SINK output_byo FROM input_byo
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-byo-sink-${testdrive.seed}'
-  WITH (reuse_topic=true, consistency_topic='output-byo-sink-consistency-${testdrive.seed}')
+  WITH (reuse_topic=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 $ kafka-ingest format=avro topic=input-consistency timestamp=1 schema=${trxschemakey}

--- a/test/testdrive/kafka-exactly-once-sink.td
+++ b/test/testdrive/kafka-exactly-once-sink.td
@@ -96,67 +96,73 @@ New York,NY,10004
 
 > CREATE SINK output1 FROM input_kafka_byo
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output1-view-${testdrive.seed}'
-  WITH (reuse_topic=true, consistency_topic='output1-view-consistency-${testdrive.seed}')
+  WITH (reuse_topic=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 > CREATE SINK output2 FROM input_kafka_no_byo
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output2-view-${testdrive.seed}'
-  WITH (reuse_topic=true, consistency_topic='output2-view-consistency-${testdrive.seed}')
+  WITH (reuse_topic=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 ! CREATE SINK output3 FROM input_table
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output3-view-${testdrive.seed}'
-  WITH (reuse_topic=true, consistency_topic='output3-view-consistency-${testdrive.seed}')
+  WITH (reuse_topic=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 reuse_topic requires that sink input dependencies are sources, materialize.public.input_table is not
 
 > CREATE SINK output4 FROM input_kafka_byo_mview
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output4-view-${testdrive.seed}'
-  WITH (reuse_topic=true, consistency_topic='output4-view-consistency-${testdrive.seed}')
+  WITH (reuse_topic=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 > CREATE SINK output4_view FROM input_kafka_byo_mview_view
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output4b-view-${testdrive.seed}'
-  WITH (reuse_topic=true, consistency_topic='output4b-view-consistency-${testdrive.seed}')
+  WITH (reuse_topic=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 > CREATE SINK output5 FROM input_kafka_no_byo_mview
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output5-view-${testdrive.seed}'
-  WITH (reuse_topic=true, consistency_topic='output5-view-consistency-${testdrive.seed}')
+  WITH (reuse_topic=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 > CREATE SINK output5_view FROM input_kafka_no_byo_mview_view
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output5b-view-${testdrive.seed}'
-  WITH (reuse_topic=true, consistency_topic='output5b-view-consistency-${testdrive.seed}')
+  WITH (reuse_topic=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 ! CREATE SINK output6 FROM input_table_mview
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output6-view-${testdrive.seed}'
-  WITH (reuse_topic=true, consistency_topic='output6-view-consistency-${testdrive.seed}')
+  WITH (reuse_topic=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 reuse_topic requires that sink input dependencies are sources, materialize.public.input_table is not
 
 ! CREATE SINK output7 FROM input_values_view
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output7-view-${testdrive.seed}'
-  WITH (reuse_topic=true, consistency_topic='output7-view-consistency-${testdrive.seed}')
+  WITH (reuse_topic=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 reuse_topic requires that sink input dependencies are sources, materialize.public.input_values_view is not
 
 ! CREATE SINK output8 FROM input_values_mview
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output8-view-${testdrive.seed}'
-  WITH (reuse_topic=true, consistency_topic='output8-view-consistency-${testdrive.seed}')
+  WITH (reuse_topic=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 reuse_topic requires that sink input dependencies are sources, materialize.public.input_values_mview is not
 
 > CREATE SINK output12 FROM input_kafka_no_byo_derived_table
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output12-view-${testdrive.seed}'
-  WITH (reuse_topic=true, consistency_topic='output12-view-consistency-${testdrive.seed}')
+  WITH (reuse_topic=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 > CREATE SINK output13 FROM input_csv
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output13-view-${testdrive.seed}'
-  WITH (reuse_topic=true, consistency_topic='output13-view-consistency-${testdrive.seed}')
+  WITH (reuse_topic=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+
+> CREATE SINK output14_custom_consistency_topic FROM input_kafka_byo
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output1-view-${testdrive.seed}'
+  WITH (reuse_topic=true, consistency_topic='output14-custom-consistency-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+
 
 # ensure that the sink works with log compaction enabled on the consistency topic
 
@@ -174,7 +180,7 @@ $ kafka-create-topic topic=compaction-test-output-consistency compaction=true
 
 > CREATE SINK compaction_test_sink FROM compaction_test_input
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'compaction-test-output-${testdrive.seed}'
-  WITH (reuse_topic=true, consistency_topic = 'testdrive-compaction-test-output-consistency-${testdrive.seed}') FORMAT AVRO
+  WITH (reuse_topic=true) FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' ENVELOPE DEBEZIUM
 
 $ kafka-ingest format=avro topic=compaction-test-input schema=${schema} timestamp=1


### PR DESCRIPTION
The title describes what it does underneath, but what it really does is de-experimentalize exactly-once (aka reuse_topic) sinks with real-time timestamping sources.

This also disables binding persistence for BYO sources, because those are already "persisted" externally, in the BYO topic. We therefore always pull the durability frontier to +Inf.

This also contains a second commit that enables timestamp persistence only when required by sinks. I'm not sure whether we want this, though.

The first commit is part of #7513.