### PR TITLE
Remove some incorrect docs for the CI base image

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -16,12 +16,8 @@ meaning the build configuration can be versioned alongside the code it builds.
 Within this folder, each subdirectory corresponds to one pipeline.
 
 To isolate the build environment, each pipeline runs in a bespoke Docker
-container. Modifying a pipeline's build environment is a three step process.
-First, adjust the appropriate Dockerfile. Second, run `bin/ci-image push
-PIPELINE` to build a new Docker image, tag it with the current date and time,
-and push it to Docker Hub. You'll need Docker credentials for this step.
-Finally, update the image configuration in the pipeline.yml configuration file
-with the new image tag.
+container. See [builder/README.md](./builder/README.md) for instructions on
+updating the image.
 
 Note that more complicated pipelines use [Docker Compose] to manage spinning up
 other services, like ZooKeeper.


### PR DESCRIPTION
Instead link to the primary README for the builder image.