### PR TITLE
support JSON-encoded Kafka sinks

### DIFF
--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -1139,12 +1139,14 @@ pub enum KafkaSinkFormat {
         value_schema: String,
         ccsr_config: ccsr::ClientConfig,
     },
+    Json,
 }
 
 impl KafkaSinkFormat {
-    pub fn ccsr_config(&self) -> &ccsr::ClientConfig {
+    pub fn ccsr_config(&self) -> Option<&ccsr::ClientConfig> {
         match self {
-            KafkaSinkFormat::Avro { ccsr_config, .. } => &ccsr_config,
+            KafkaSinkFormat::Avro { ccsr_config, .. } => Some(&ccsr_config),
+            KafkaSinkFormat::Json => None,
         }
     }
 }

--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -19,8 +19,8 @@ pub use envelope_cdc_v2 as cdc_v2;
 
 pub use self::decode::{Decoder, DiffPair};
 pub use self::encode::{
-    column_names_and_types, encode_datums_as_avro, encode_debezium_transaction_unchecked,
-    get_debezium_transaction_schema, AvroEncoder, AvroSchemaGenerator,
+    encode_datums_as_avro, encode_debezium_transaction_unchecked, get_debezium_transaction_schema,
+    AvroEncoder, AvroSchemaGenerator,
 };
 pub use self::envelope_debezium::{DebeziumDecodeState, DebeziumDeduplicationStrategy};
 pub use self::schema::{

--- a/src/interchange/src/avro/envelope_cdc_v2.rs
+++ b/src/interchange/src/avro/envelope_cdc_v2.rs
@@ -25,6 +25,8 @@ use mz_avro::{
 };
 use std::{cell::RefCell, rc::Rc};
 
+use crate::encode::column_names_and_types;
+
 use super::RowWrapper;
 
 pub fn extract_data_columns<'a>(schema: &'a Schema) -> anyhow::Result<SchemaNode<'a>> {
@@ -50,7 +52,7 @@ pub struct Encoder {
 impl Encoder {
     /// Creates a new CDCv2 encoder from a relation description.
     pub fn new(desc: RelationDesc) -> Self {
-        let columns = super::column_names_and_types(desc);
+        let columns = column_names_and_types(desc);
         let row_schema = super::build_row_schema_json(&columns, "data");
         let schema = build_schema(row_schema);
         Self { columns, schema }
@@ -270,7 +272,8 @@ mod tests {
             .with_named_column("price", ScalarType::Float64.nullable(true));
 
         let encoder = Encoder::new(desc.clone());
-        let row_schema = build_row_schema_json(&crate::avro::column_names_and_types(desc), "data");
+        let row_schema =
+            build_row_schema_json(&crate::encode::column_names_and_types(desc), "data");
         let schema = build_schema(row_schema);
 
         let values = vec![

--- a/src/interchange/src/encode.rs
+++ b/src/interchange/src/encode.rs
@@ -7,7 +7,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use repr::Row;
+use std::collections::HashSet;
+
+use repr::{ColumnName, ColumnType, Datum, RelationDesc, Row};
 
 pub trait Encode {
     fn get_format_name(&self) -> &str;
@@ -15,4 +17,48 @@ pub trait Encode {
     fn encode_key_unchecked(&self, row: Row) -> Vec<u8>;
 
     fn encode_value_unchecked(&self, row: Row) -> Vec<u8>;
+}
+
+/// Bundled information sufficient to encode Datums.
+#[derive(Debug)]
+pub struct TypedDatum<'a> {
+    pub datum: Datum<'a>,
+    pub typ: ColumnType,
+}
+
+impl<'a> TypedDatum<'a> {
+    /// Pairs a datum and its type, for encoding.
+    pub fn new(datum: Datum<'a>, typ: ColumnType) -> Self {
+        Self { datum, typ }
+    }
+}
+
+/// Extracts deduplicated column names and types from a relation description.
+pub fn column_names_and_types(desc: RelationDesc) -> Vec<(ColumnName, ColumnType)> {
+    // Invent names for columns that don't have a name.
+    let mut columns: Vec<_> = desc
+        .into_iter()
+        .enumerate()
+        .map(|(i, (name, ty))| match name {
+            None => (ColumnName::from(format!("column{}", i + 1)), ty),
+            Some(name) => (name, ty),
+        })
+        .collect();
+
+    // Deduplicate names.
+    let mut seen = HashSet::new();
+    for (name, _ty) in &mut columns {
+        let stem_len = name.as_str().len();
+        let mut i = 1;
+        while seen.contains(name) {
+            name.as_mut_str().truncate(stem_len);
+            if name.as_str().ends_with(|c: char| c.is_ascii_digit()) {
+                name.as_mut_str().push('_');
+            }
+            name.as_mut_str().push_str(&i.to_string());
+            i += 1;
+        }
+        seen.insert(name);
+    }
+    columns
 }

--- a/src/interchange/src/envelopes.rs
+++ b/src/interchange/src/envelopes.rs
@@ -10,7 +10,8 @@
 use std::iter;
 use std::rc::Rc;
 
-use crate::avro::{column_names_and_types, DiffPair};
+use crate::avro::DiffPair;
+use crate::encode::column_names_and_types;
 use differential_dataflow::{
     lattice::Lattice,
     trace::BatchReader,

--- a/src/interchange/src/json.rs
+++ b/src/interchange/src/json.rs
@@ -8,10 +8,205 @@
 // by the Apache License, Version 2.0.
 
 use std::collections::HashSet;
+use std::fmt;
 
+use itertools::Itertools;
+
+use repr::adt::jsonb::JsonbRef;
 use repr::adt::numeric::{NUMERIC_AGG_MAX_PRECISION, NUMERIC_DATUM_MAX_PRECISION};
-use repr::{ColumnName, ColumnType, ScalarType};
-use serde_json::json;
+use repr::{ColumnName, ColumnType, Datum, RelationDesc, ScalarType};
+use serde_json::{json, Map};
+
+use crate::encode::{column_names_and_types, Encode, TypedDatum};
+
+// Manages encoding of JSON-encoded bytes
+pub struct JsonEncoder {
+    key_columns: Option<Vec<(ColumnName, ColumnType)>>,
+    value_columns: Vec<(ColumnName, ColumnType)>,
+}
+
+impl JsonEncoder {
+    pub fn new(key_desc: Option<RelationDesc>, value_desc: RelationDesc) -> Self {
+        JsonEncoder {
+            key_columns: if let Some(desc) = key_desc {
+                Some(column_names_and_types(desc))
+            } else {
+                None
+            },
+            value_columns: column_names_and_types(value_desc),
+        }
+    }
+
+    pub fn encode_row(&self, row: repr::Row, names_types: &[(ColumnName, ColumnType)]) -> Vec<u8> {
+        let value = encode_datums_as_json(row.iter(), names_types);
+        value.to_string().into_bytes()
+    }
+}
+
+impl Encode for JsonEncoder {
+    fn get_format_name(&self) -> &str {
+        "json"
+    }
+
+    fn encode_key_unchecked(&self, row: repr::Row) -> Vec<u8> {
+        self.encode_row(
+            row,
+            self.key_columns.as_ref().expect("key schema must exist"),
+        )
+    }
+
+    fn encode_value_unchecked(&self, row: repr::Row) -> Vec<u8> {
+        self.encode_row(row, &self.value_columns)
+    }
+}
+
+impl fmt::Debug for JsonEncoder {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("JsonEncoder")
+            .field(
+                "schema",
+                &format!("{:?}", build_row_schema_json(&self.value_columns, "schema")),
+            )
+            .finish()
+    }
+}
+
+/// Encodes a sequence of `Datum` as JSON, using supplied column names and types.
+pub fn encode_datums_as_json<'a, I>(
+    datums: I,
+    names_types: &[(ColumnName, ColumnType)],
+) -> serde_json::value::Value
+where
+    I: IntoIterator<Item = Datum<'a>>,
+{
+    let mut name_idx = 0;
+    let value_fields = names_types
+        .iter()
+        .zip_eq(datums)
+        .map(|((name, typ), datum)| {
+            let name = name.as_str().to_owned();
+            (
+                name,
+                TypedDatum::new(datum, typ.clone()).json(&mut move || {
+                    let ret = format!("record{}", name_idx);
+                    name_idx += 1;
+                    ret
+                }),
+            )
+        })
+        .collect();
+    serde_json::value::Value::Object(value_fields)
+}
+
+pub trait ToJson {
+    /// Transforms this value to a JSON value.
+    fn json<F: FnMut() -> String>(self, namer: &mut F) -> serde_json::value::Value;
+}
+
+impl<'a> ToJson for TypedDatum<'_> {
+    fn json<F: FnMut() -> String>(self, namer: &mut F) -> serde_json::value::Value {
+        let TypedDatum { datum, typ } = self;
+        if typ.nullable && datum.is_null() {
+            serde_json::value::Value::Null
+        } else {
+            match &typ.scalar_type {
+                ScalarType::Bool => json!(datum.unwrap_bool()),
+                ScalarType::Int16 => json!(datum.unwrap_int16()),
+                ScalarType::Int32 | ScalarType::Oid => json!(datum.unwrap_int32()),
+                ScalarType::Int64 => json!(datum.unwrap_int64()),
+                ScalarType::Float32 => json!(datum.unwrap_float32()),
+                ScalarType::Float64 => json!(datum.unwrap_float64()),
+                ScalarType::Numeric { .. } => {
+                    json!(datum.unwrap_numeric().0.to_standard_notation_string())
+                }
+                // https://stackoverflow.com/questions/10286204/what-is-the-right-json-date-format
+                ScalarType::Date => {
+                    serde_json::value::Value::String(format!("{:?}", datum.unwrap_date()))
+                }
+                ScalarType::Time => {
+                    serde_json::value::Value::String(format!("{:?}", datum.unwrap_time()))
+                }
+                ScalarType::Timestamp => serde_json::value::Value::String(format!(
+                    "{:?}",
+                    datum.unwrap_timestamp().timestamp_millis()
+                )),
+                ScalarType::TimestampTz => serde_json::value::Value::String(format!(
+                    "{:?}",
+                    datum.unwrap_timestamptz().timestamp_millis()
+                )),
+                ScalarType::Interval => {
+                    serde_json::value::Value::String(format!("{}", datum.unwrap_interval()))
+                }
+                ScalarType::Bytes => json!(datum.unwrap_bytes()),
+                ScalarType::String => json!(datum.unwrap_str()),
+                ScalarType::Jsonb => JsonbRef::from_datum(datum).to_serde_json(),
+                ScalarType::Uuid => json!(datum.unwrap_uuid()),
+                ScalarType::Array(element_type) | ScalarType::List { element_type, .. } => {
+                    let list = match typ.scalar_type {
+                        ScalarType::Array(_) => datum.unwrap_array().elements(),
+                        ScalarType::List { .. } => datum.unwrap_list(),
+                        _ => unreachable!(),
+                    };
+                    let values = list
+                        .into_iter()
+                        .map(|datum| {
+                            let datum = TypedDatum::new(
+                                datum,
+                                ColumnType {
+                                    nullable: true,
+                                    scalar_type: (**element_type).clone(),
+                                },
+                            );
+                            datum.json(namer)
+                        })
+                        .collect();
+                    serde_json::value::Value::Array(values)
+                }
+                ScalarType::Record {
+                    fields,
+                    custom_name,
+                    ..
+                } => {
+                    let list = datum.unwrap_list();
+                    let fields: Map<String, serde_json::value::Value> = fields
+                        .iter()
+                        .zip(list.into_iter())
+                        .map(|((name, typ), datum)| {
+                            let name = name.to_string();
+                            let datum = TypedDatum::new(datum, typ.clone());
+                            let value = datum.json(namer);
+                            (name, value)
+                        })
+                        .collect();
+
+                    let name = match custom_name {
+                        Some(name) => name.clone(),
+                        None => namer(),
+                    };
+                    json!({ name: fields })
+                }
+                ScalarType::Map { value_type, .. } => {
+                    let map = datum.unwrap_map();
+                    let elements = map
+                        .into_iter()
+                        .map(|(key, datum)| {
+                            let datum = TypedDatum::new(
+                                datum,
+                                ColumnType {
+                                    nullable: true,
+                                    scalar_type: (**value_type).clone(),
+                                },
+                            );
+                            let value = datum.json(namer);
+                            (key.to_string(), value)
+                        })
+                        .collect();
+                    serde_json::value::Value::Object(elements)
+                }
+            }
+        }
+    }
+}
 
 fn build_row_schema_field<F: FnMut() -> String>(
     namer: &mut F,

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1300,11 +1300,15 @@ fn kafka_sink_builder(
                 ccsr_config,
             }
         }
-        _ => {
-            // TODO@jldlaughlin: if format is not Avro with schema, fail if
-            // user has provided a consistency topic!
-            unsupported!("non-confluent schema registry avro sinks")
+        Some(Format::Json) => {
+            if consistency_topic.is_some() {
+                // todo@jldlaughlin: fix this!
+                unsupported!("JSON sink with consistency topic")
+            }
+            KafkaSinkFormat::Json
         }
+        Some(format) => unsupported!(format!("sink format {:?}", format)),
+        None => unsupported!("sink without format"),
     };
 
     let broker_addrs = broker.parse()?;

--- a/src/testdrive/src/action/kafka/verify.rs
+++ b/src/testdrive/src/action/kafka/verify.rs
@@ -20,8 +20,13 @@ use tokio::pin;
 use tokio_stream::StreamExt;
 
 use crate::action::{Action, Context, State};
-use crate::format::avro;
+use crate::format::{avro, json};
 use crate::parser::BuiltinCommand;
+
+pub enum SinkFormat {
+    Avro,
+    Json { key: bool },
+}
 
 pub enum SinkConsistencyFormat {
     Debezium,
@@ -29,6 +34,7 @@ pub enum SinkConsistencyFormat {
 
 pub struct VerifyAction {
     sink: String,
+    format: SinkFormat,
     consistency: Option<SinkConsistencyFormat>,
     sort_messages: bool,
     expected_messages: Vec<String>,
@@ -36,7 +42,13 @@ pub struct VerifyAction {
 }
 
 pub fn build_verify(mut cmd: BuiltinCommand, context: Context) -> Result<VerifyAction, String> {
-    let _format = cmd.args.string("format")?;
+    let format = match cmd.args.string("format")?.as_str() {
+        "avro" => SinkFormat::Avro,
+        "json" => SinkFormat::Json {
+            key: cmd.args.parse("key")?,
+        },
+        f => return Err(format!("unknown format: {}", f)),
+    };
     let sink = cmd.args.string("sink")?;
     let consistency = match cmd.args.opt_string("consistency").as_deref() {
         Some("debezium") => Some(SinkConsistencyFormat::Debezium),
@@ -49,6 +61,7 @@ pub fn build_verify(mut cmd: BuiltinCommand, context: Context) -> Result<VerifyA
     cmd.args.done()?;
     Ok(VerifyAction {
         sink,
+        format,
         consistency,
         sort_messages,
         expected_messages,
@@ -112,30 +125,8 @@ impl Action for VerifyAction {
 
         println!("Verifying results in Kafka topic {}", topic);
 
-        let value_schema = state
-            .ccsr_client
-            .get_schema_by_subject(&format!("{}-value", topic))
-            .await
-            .map_err(|e| format!("fetching schema: {}", e))?
-            .raw;
-
-        let key_schema = state
-            .ccsr_client
-            .get_schema_by_subject(&format!("{}-key", topic))
-            .await
-            .ok()
-            .map(|key_schema| {
-                avro::parse_schema(&key_schema.raw)
-                    .map_err(|e| format!("parsing avro schema: {}", e))
-            })
-            .transpose()?;
-
         let mut config = state.kafka_config.clone();
         config.set("enable.auto.offset.store", "false");
-
-        let value_schema =
-            avro::parse_schema(&value_schema).map_err(|e| format!("parsing avro schema: {}", e))?;
-        let value_schema = &value_schema;
 
         let consumer: StreamConsumer = config
             .create()
@@ -151,51 +142,112 @@ impl Action for VerifyAction {
             .timeout(cmp::max(state.default_timeout, Duration::from_secs(15)));
         pin!(message_stream);
 
-        let mut actual_messages = vec![];
-
         // Collect all messages that arrive without timing out. If we trip
         // the timeout, suppress the error and return what we have. This
         // is nicer than returning "timeout expired", as the user will
         // instead get an error message about the expected messages that
         // were missing.
+        let mut actual_bytes = vec![];
         while let Some(Ok(message)) = message_stream.next().await {
             let message = message.map_err_to_string()?;
-
             consumer
                 .store_offset(&message)
                 .map_err(|e| format!("storing message offset: {:#}", e))?;
+            actual_bytes.push((
+                message.key().and_then(|bytes| Some(bytes.to_owned())),
+                message.payload().and_then(|bytes| Some(bytes.to_owned())),
+            ));
+        }
 
-            let bytes = message.payload();
+        match &self.format {
+            SinkFormat::Avro => {
+                let value_schema = state
+                    .ccsr_client
+                    .get_schema_by_subject(&format!("{}-value", topic))
+                    .await
+                    .map_err(|e| format!("fetching schema: {}", e))?
+                    .raw;
 
-            let value_datum = match bytes {
-                None => None,
-                Some(bytes) => Some(avro_from_bytes(value_schema, bytes)?),
-            };
+                let key_schema = state
+                    .ccsr_client
+                    .get_schema_by_subject(&format!("{}-key", topic))
+                    .await
+                    .ok()
+                    .map(|key_schema| {
+                        avro::parse_schema(&key_schema.raw)
+                            .map_err(|e| format!("parsing avro schema: {}", e))
+                    })
+                    .transpose()?;
 
-            let key_datum = key_schema
-                .as_ref()
-                .map(|key_schema| {
-                    let bytes = match message.key() {
-                        Some(key) => key,
-                        None => return Err("empty message key".into()),
+                let value_schema = avro::parse_schema(&value_schema)
+                    .map_err(|e| format!("parsing avro schema: {}", e))?;
+                let value_schema = &value_schema;
+
+                let mut actual_messages = vec![];
+                for (key, value) in actual_bytes {
+                    let key_datum = key_schema
+                        .as_ref()
+                        .map(|key_schema| {
+                            let bytes = match key {
+                                Some(key) => key,
+                                None => return Err("empty message key".into()),
+                            };
+                            avro_from_bytes(key_schema, &bytes)
+                        })
+                        .transpose()?;
+                    let value_datum = match value {
+                        None => None,
+                        Some(bytes) => Some(avro_from_bytes(value_schema, &bytes)?),
                     };
-                    avro_from_bytes(key_schema, bytes)
-                })
-                .transpose()?;
-            actual_messages.push((key_datum, value_datum));
-        }
+                    actual_messages.push((key_datum, value_datum));
+                }
 
-        if self.sort_messages {
-            actual_messages.sort_by_key(|k| format!("{:?}", k.1));
-        }
+                if self.sort_messages {
+                    actual_messages.sort_by_key(|k| format!("{:?}", k.1));
+                }
 
-        avro::validate_sink(
-            key_schema.as_ref(),
-            value_schema,
-            &self.expected_messages,
-            &actual_messages,
-            &self.context.regex,
-            &self.context.regex_replacement,
-        )
+                avro::validate_sink(
+                    key_schema.as_ref(),
+                    value_schema,
+                    &self.expected_messages,
+                    &actual_messages,
+                    &self.context.regex,
+                    &self.context.regex_replacement,
+                )
+            }
+            SinkFormat::Json { key } => {
+                let mut actual_messages = vec![];
+                for (key, value) in actual_bytes {
+                    let key_datum =
+                        match key {
+                            None => None,
+                            Some(bytes) => Some(serde_json::from_slice(&bytes).map_err(|e| {
+                                format!("converting bytes to JSON {}", e.to_string())
+                            })?),
+                        };
+                    let value_datum =
+                        match value {
+                            None => None,
+                            Some(bytes) => Some(serde_json::from_slice(&bytes).map_err(|e| {
+                                format!("converting bytes to JSON {}", e.to_string())
+                            })?),
+                        };
+
+                    actual_messages.push((key_datum, value_datum));
+                }
+
+                if self.sort_messages {
+                    actual_messages.sort_by_key(|k| format!("{:?}", k.1));
+                }
+
+                json::validate_sink(
+                    *key,
+                    &self.expected_messages,
+                    &actual_messages,
+                    &self.context.regex,
+                    &self.context.regex_replacement,
+                )
+            }
+        }
     }
 }

--- a/src/testdrive/src/format.rs
+++ b/src/testdrive/src/format.rs
@@ -9,4 +9,5 @@
 
 pub mod avro;
 pub mod bytes;
+pub mod json;
 pub mod protobuf;

--- a/src/testdrive/src/format/json.rs
+++ b/src/testdrive/src/format/json.rs
@@ -1,0 +1,79 @@
+// Copyright 2018 Flavien Raynaud
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use regex::Regex;
+
+pub fn validate_sink<I>(
+    has_key: bool,
+    expected: I,
+    actual: &[(Option<serde_json::Value>, Option<serde_json::Value>)],
+    regex: &Option<Regex>,
+    regex_replacement: &String,
+) -> Result<(), String>
+where
+    I: IntoIterator,
+    I::Item: AsRef<str>,
+{
+    let expected: Vec<(Option<serde_json::Value>, Option<serde_json::Value>)> = expected
+        .into_iter()
+        .map(|v| {
+            let mut deserializer = serde_json::Deserializer::from_str(v.as_ref()).into_iter();
+            let key = if has_key {
+                match deserializer.next() {
+                    None => None,
+                    Some(r) => r.map_err(|e| format!("parsing JSON: {}", e))?,
+                }
+            } else {
+                None
+            };
+            let value = match deserializer.next() {
+                None => None,
+                Some(r) => r.map_err(|e| format!("parsing JSON: {}", e))?,
+            };
+            Ok((key, value))
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+    let mut expected = expected.iter();
+    let mut actual = actual.iter();
+    let mut index = 0..;
+    loop {
+        let i = index.next().expect("known to exist");
+        match (expected.next(), actual.next()) {
+            (Some(e), Some(a)) => {
+                let e_str = format!("{:#?}", e);
+                let a_str = match &regex {
+                    Some(regex) => regex
+                        .replace_all(&format!("{:#?}", a).to_string(), regex_replacement.as_str())
+                        .to_string(),
+                    _ => format!("{:#?}", a),
+                };
+
+                if e_str != a_str {
+                    return Err(format!(
+                        "record {} did not match\nexpected:\n{}\n\nactual:\n{}",
+                        i, e_str, a_str
+                    ));
+                }
+            }
+            (Some(e), None) => return Err(format!("missing record {}: {:#?}", i, e)),
+            (None, Some(a)) => return Err(format!("extra record {}: {:#?}", i, a)),
+            (None, None) => break,
+        }
+    }
+    let expected: Vec<_> = expected.map(|e| format!("{:#?}", e)).collect();
+    let actual: Vec<_> = actual.map(|a| format!("{:#?}", a)).collect();
+    if !expected.is_empty() {
+        Err(format!("missing records:\n{}", expected.join("\n")))
+    } else if !actual.is_empty() {
+        Err(format!("extra records:\n{}", actual.join("\n")))
+    } else {
+        Ok(())
+    }
+}

--- a/test/testdrive/kafka-json-sinks.td
+++ b/test/testdrive/kafka-json-sinks.td
@@ -1,0 +1,110 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> CREATE VIEW unnamed_cols AS SELECT 1, 2 AS b, 3;
+
+> CREATE SINK unnamed_cols_sink FROM unnamed_cols
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'unnamed-cols-sink'
+  FORMAT JSON
+
+$ kafka-verify format=json sink=materialize.public.unnamed_cols_sink key=false
+{"before": null, "after": {"row": {"column1": 1, "b": 2, "column3": 3}}}
+
+> CREATE SINK unnamed_cols_upsert FROM unnamed_cols
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'unnamed-upsert'
+  KEY (b)
+  FORMAT JSON
+  ENVELOPE UPSERT
+
+$ kafka-verify format=json sink=materialize.public.unnamed_cols_upsert key=true
+{"b": 2} {"column1": 1, "b": 2, "column3": 3}
+
+# Standard types
+
+> CREATE VIEW types_view AS
+  SELECT TRUE::boolean, FALSE::boolean, NULL,
+  123456789::bigint, 1234.5678::double, 1234.5678::decimal,
+  '2011-11-11 11:11:11.12345'::timestamp, '2011-11-11 11:11:11.12345+12'::timestamptz,
+  '2011-11-11'::date, '11:11:11.123456'::time,
+  INTERVAL '1 year',
+  '324373a5-7718-46b1-a7ea-4a7c9981fc4e'::uuid,
+  'текст'::bytea,
+  '{"a": 2}'::jsonb
+
+> CREATE SINK types_sink FROM types_view
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'types-sink'
+  FORMAT JSON
+
+# Due to limitations in $ kafka-verify, the entire expected JSON output needs to be provided on a single line
+$ kafka-verify format=json sink=materialize.public.types_sink key=false
+{"after":{"row":{"column1":true,"column10":"11:11:11.123456","column11":"1 year","column12":"324373a5-7718-46b1-a7ea-4a7c9981fc4e","column13":[209,130,208,181,208,186,209,129,209,130],"column14":{"a":2},"column2":false,"column3":null,"column4":123456789,"column5":1234.5678,"column6":"1234.5678","column7":"1321009871123","column8":"1320966671123","column9":"2011-11-11"}},"before":null}
+
+# Special characters
+
+> CREATE VIEW special_characters_view AS
+  SELECT 'текст', '"', '''', '\', E'a\n\tb'
+
+> CREATE SINK special_characters_sink FROM special_characters_view
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'special-characters-sink'
+  FORMAT JSON
+
+$ kafka-verify format=json sink=materialize.public.special_characters_sink key=false
+{"after":{"row":{"column1":"текст","column2":"\"","column3":"'","column4":"\\","column5":"a\n\tb"}},"before":null}
+
+# Record
+
+> CREATE VIEW record_view AS SELECT unnamed_cols FROM unnamed_cols;
+
+> CREATE SINK record_sink FROM record_view
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'record-sink'
+  FORMAT JSON
+
+$ kafka-verify format=json sink=materialize.public.record_sink key=false
+{"after":{"row":{"unnamed_cols":{"record0":{"b":2,"f1":1,"f3":3}}}},"before":null}
+
+# Duplicate column names
+> CREATE VIEW duplicate_cols AS SELECT 'a1' AS a, 'a1' AS a;
+
+> CREATE SINK duplicate_cols_sink FROM duplicate_cols
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'duplicate-cols-sink'
+  FORMAT JSON
+
+$ kafka-verify format=json sink=materialize.public.duplicate_cols_sink key=false
+{"after":{"row":{"a":"a1","a1":"a1"}},"before":null}
+
+# Complex types
+
+> CREATE TYPE int4_list AS LIST (element_type = int4);
+
+> CREATE TYPE int4_list_list AS LIST (element_type = int4_list);
+
+> CREATE TYPE int4_map AS MAP (key_type=text, value_type=int4);
+
+> CREATE TYPE int4_map_map AS MAP (key_type=text, value_type=int4_map);
+
+> CREATE VIEW complex_type_view AS SELECT '{{1,2},{3,4}}'::int4_list_list, '{a=>{b=>1, c=>2}, d=> {e=>3, f=>4}}'::int4_map_map;
+
+> CREATE SINK complex_type_sink FROM complex_type_view
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'complex-type-sink'
+  FORMAT JSON
+
+$ kafka-verify format=json sink=materialize.public.complex_type_sink key=false
+{"before": null, "after": {"row": {"column1": [[1,2],[3,4]], "column2": {"a":{"b":1, "c":2}, "d": {"e":3, "f":4}}}}}
+
+# testdrive will not automatically clean up types, so we need to do that ourselves
+
+> DROP VIEW complex_type_view CASCADE;
+
+> DROP TYPE int4_list_list;
+
+> DROP TYPE int4_list;
+
+> DROP TYPE int4_map_map;
+
+> DROP TYPE int4_map;

--- a/test/testdrive/kafka-sink-errors.td
+++ b/test/testdrive/kafka-sink-errors.td
@@ -201,5 +201,18 @@ creating admin client failed: Client creation error: Invalid sasl.kerberos.kinit
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 error registering kafka topic for sink
 
+#
+# FORMAT
+#
+
+! CREATE SINK invalid_format FROM v1
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
+sink without format not yet supported
+
+! CREATE SINK invalid_format FROM v1
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
+  FORMAT NO_SUCH_FORMAT
+found identifier "no_such_format"
+
 # Expect empty output
 > SHOW SINKS


### PR DESCRIPTION
Fixes https://github.com/MaterializeInc/materialize/issues/1540 with some caveats. JSON-encoded Kafka sinks:
- Do not publish schemas to the schema registry. (This was identified as an acceptable V0, although we'll likely want to publish schemas in the future.)
- Do not support consistency topics. There's nothing stopping us from having a JSON-encoded sink with an Avro-encoded consistency topic, which would be the next step. @aljoscha points out that it would be a bit more work to [support JSON-encoded consistency topics](https://github.com/MaterializeInc/materialize/pull/7505#discussion_r676598697) as well.

If this looks good I'll open a separate PR for docs!