### PR TITLE
antithesis: put libvoidstar.so in /usr/lib

### DIFF
--- a/test/antithesis/materialized/Dockerfile
+++ b/test/antithesis/materialized/Dockerfile
@@ -11,7 +11,7 @@ FROM ubuntu:bionic-20200403
 
 RUN apt-get update && apt-get -qy install ca-certificates
 
-COPY libvoidstar.so /usr/local/lib
+COPY libvoidstar.so /usr/lib
 RUN ldconfig
 
 COPY materialized /usr/local/bin/


### PR DESCRIPTION
as opposed to /usr/local/lib where it was being placed previously

---

I have given containers to Antithesis and they confirm that the change fixes the issue that triggered this PR.