### PR TITLE
dataflow: Use MzExchange type instead of default exchange

### DIFF
--- a/src/dataflow/src/lib.rs
+++ b/src/dataflow/src/lib.rs
@@ -11,6 +11,10 @@
 
 //! Driver for timely/differential dataflow.
 
+use differential_dataflow::lattice::Lattice;
+use differential_dataflow::{ExchangeData, Hashable};
+use timely::dataflow::channels::pact::Exchange;
+
 mod arrangement;
 mod decode;
 mod metrics;
@@ -24,3 +28,17 @@ pub mod source;
 
 pub use render::plan::Plan;
 pub use server::{serve, Command, Config, Response, TimestampBindingFeedback, WorkerFeedback};
+
+/// The exchange parallelization contract for Materialize.
+pub type MzExchange<D, F> = Exchange<D, F>;
+
+/// The default exchange function to distribute data for arrangements.
+pub fn arrange_exchange_fn<T, K, V, R>(update: &((K, V), T, R)) -> u64
+where
+    T: Lattice,
+    K: Hashable,
+    V: ExchangeData,
+    R: ExchangeData,
+{
+    update.0 .0.hashed().into()
+}

--- a/src/dataflow/src/logging/differential.rs
+++ b/src/dataflow/src/logging/differential.rs
@@ -20,6 +20,7 @@ use timely::logging::WorkerIdentifier;
 use super::{DifferentialLog, LogVariant};
 use crate::arrangement::manager::RowSpine;
 use crate::arrangement::KeysValsHandle;
+use crate::{arrange_exchange_fn, MzExchange};
 use repr::{Datum, Row, Timestamp};
 
 /// Constructs the logging dataflows and returns a logger and trace handles.
@@ -130,7 +131,10 @@ pub fn construct<A: Allocate>(
                             (row_packer.finish_and_reuse(), row)
                         }
                     })
-                    .arrange::<RowSpine<_, _, _, _>>()
+                    .arrange_core::<_, RowSpine<_, _, _, _>>(
+                        MzExchange::new(arrange_exchange_fn),
+                        "Arrange Differential Log",
+                    )
                     .trace;
                 result.insert(variant, (key_clone, trace));
             }

--- a/src/dataflow/src/logging/materialized.rs
+++ b/src/dataflow/src/logging/materialized.rs
@@ -21,6 +21,7 @@ use timely::logging::WorkerIdentifier;
 use super::{LogVariant, MaterializedLog};
 use crate::arrangement::manager::RowSpine;
 use crate::arrangement::KeysValsHandle;
+use crate::{arrange_exchange_fn, MzExchange};
 use expr::{GlobalId, SourceInstanceId};
 use repr::{Datum, Row, Timestamp};
 
@@ -565,7 +566,10 @@ pub fn construct<A: Allocate>(
                             (row_packer.finish_and_reuse(), row)
                         }
                     })
-                    .arrange::<RowSpine<_, _, _, _>>()
+                    .arrange_core::<_, RowSpine<_, _, _, _>>(
+                        MzExchange::new(arrange_exchange_fn),
+                        "Arrange Materialized Log",
+                    )
                     .trace;
                 result.insert(variant, (key_clone, trace));
             }

--- a/src/dataflow/src/logging/timely.rs
+++ b/src/dataflow/src/logging/timely.rs
@@ -25,6 +25,7 @@ use timely::logging::{ParkEvent, TimelyEvent, WorkerIdentifier};
 use super::{LogVariant, TimelyLog};
 use crate::arrangement::manager::RowSpine;
 use crate::arrangement::KeysValsHandle;
+use crate::{arrange_exchange_fn, MzExchange};
 use dataflow_types::logging::LoggingConfig;
 use repr::{datum_list_size, datum_size, Datum, Row, Timestamp};
 
@@ -437,7 +438,10 @@ pub fn construct<A: Allocate>(
                             (row_packer.finish_and_reuse(), row)
                         }
                     })
-                    .arrange::<RowSpine<_, _, _, _>>()
+                    .arrange_core::<_, RowSpine<_, _, _, _>>(
+                        MzExchange::new(arrange_exchange_fn),
+                        "Arrange Timely Log",
+                    )
                     .trace;
                 result.insert(variant, (key_clone, trace));
             }

--- a/src/dataflow/src/render/join/linear_join.rs
+++ b/src/dataflow/src/render/join/linear_join.rs
@@ -28,6 +28,7 @@ use crate::render::context::CollectionBundle;
 use crate::render::context::{Arrangement, ArrangementFlavor, ArrangementImport, Context};
 use crate::render::datum_vec::DatumVec;
 use crate::render::join::{JoinBuildState, JoinClosure};
+use crate::{arrange_exchange_fn, MzExchange};
 
 // TODO(mcsherry): Identical to `DeltaPathPlan`; consider unifying.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -322,7 +323,10 @@ where
             });
             errors.push(errs);
             use crate::arrangement::manager::RowSpine;
-            let arranged = keyed.arrange_named::<RowSpine<_, _, _, _>>(&format!("JoinStage"));
+            let arranged = keyed.arrange_core::<_, RowSpine<_, _, _, _>>(
+                MzExchange::new(arrange_exchange_fn),
+                &format!("JoinStage"),
+            );
             joined = JoinedFlavor::Local(arranged);
         }
 

--- a/src/dataflow/src/sink/tail.rs
+++ b/src/dataflow/src/sink/tail.rs
@@ -11,7 +11,7 @@ use std::any::Any;
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use differential_dataflow::operators::arrange::ArrangeByKey;
+use differential_dataflow::operators::arrange::Arrange;
 use differential_dataflow::trace::cursor::Cursor;
 use differential_dataflow::trace::BatchReader;
 use differential_dataflow::Collection;
@@ -34,8 +34,10 @@ use repr::{Datum, Diff, RelationDesc, Row, Timestamp};
 
 use crate::render::sinks::SinkRender;
 use crate::render::RenderState;
+use crate::{arrange_exchange_fn, MzExchange};
 
 use super::SinkBaseMetrics;
+use crate::arrangement::manager::RowSpine;
 
 impl<G> SinkRender<G> for TailSinkConnector
 where
@@ -107,7 +109,7 @@ fn tail<G>(
             let v = v.expect("tail must have values");
             (sink_id, v)
         })
-        .arrange_by_key()
+        .arrange_core::<_, RowSpine<_, _, _, _>>(MzExchange::new(arrange_exchange_fn), "Tail")
         .stream;
 
     let mut packer = Row::default();


### PR DESCRIPTION
Use the functionality introduced in https://github.com/TimelyDataflow/differential-dataflow/pull/332 to provide a default exchange implementation for all of Materialize. This PR will start to compile once the changes in Differential land.

Signed-off-by: Moritz Hoffmann <mh@materialize.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/7551)
<!-- Reviewable:end -->
