### PR TITLE
*: update API documentation link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ After using Materialize, if you'd like to contribute, extensive documentation on
 our development process is available in the [doc/developer](doc/developer) folder.
 
 Materialize is written entirely in Rust. Rust API documentation is hosted at
-<https://mtrlz.dev/api/>.
+<https://dev.materialize.com/api/rust/>.
 
 Prospective code contributors might find the [good first issue tag](https://github.com/MaterializeInc/materialize/issues?q=is%3Aopen+is%3Aissue+label%3A%22D-good+first+issue%22) useful.
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Materialize is built on top of [differential dataflow](https://github.com/Timely
 
 Materialize is written entirely in Rust.
 
-Developers can find docs at [doc/developer](doc/developer), and Rust API documentation is hosted at <https://mtrlz.dev/api/rust/>. The Materialize development roadmap is divided up into roughly month-long milestones, and [managed in GitHub](https://github.com/MaterializeInc/materialize/milestones?direction=asc&sort=due_date&state=open).
+Developers can find docs at [doc/developer](doc/developer), and Rust API documentation is hosted at <https://dev.materialize.com/api/rust/>. The Materialize development roadmap is divided up into roughly month-long milestones, and [managed in GitHub](https://github.com/MaterializeInc/materialize/milestones?direction=asc&sort=due_date&state=open).
 
 Contributions are welcome. Prospective code contributors might find the [good first issue tag](https://github.com/MaterializeInc/materialize/issues?q=is%3Aopen+is%3Aissue+label%3A%22D-good+first+issue%22) useful. We value all contributions equally, but bug reports are more equal.
 

--- a/ci/README.md
+++ b/ci/README.md
@@ -9,7 +9,7 @@ of commands that can be automatically triggered in response to pushes,
 new pull requests, or manual UI actions. We have multiple pipelines in this
 repository: the "test" pipeline, for example, runs `cargo test` on every PR,
 while the "deploy" pipeline builds the Rust API documentation and publishes
-it to mtrlz.dev after a merge to main.
+it to dev.materialize.com after a merge to main.
 
 Pipelines are configured with a YAML file that lives in version control,
 meaning the build configuration can be versioned alongside the code it builds.

--- a/doc/developer/guide.md
+++ b/doc/developer/guide.md
@@ -190,7 +190,7 @@ very inefficient. It is, however, excellent for manually taking Materialize
 for a spin without the hassle of setting up various Kafka topics and Avro
 schemas. It also powers our sqllogictest runner.
 
-See the [symbiosis crate documentation](https://mtrlz.dev/api/symbiosis) for
+See the [symbiosis crate documentation](https://dev.materialize.com/api/rust/symbiosis) for
 more details.
 
 **Note:** As of August 2020, we're laying the groundwork to phase out symbiosis

--- a/misc/python/materialize/__init__.py
+++ b/misc/python/materialize/__init__.py
@@ -24,5 +24,5 @@ Consider writing additional Python code when:
   * You've already written a Bash script whose complexity and maintainability
     has deteriorated as the script's responsibilities have grown.
 
-[materialized]: https://mtrlz.dev/api/materialized/index.html
+[materialized]: https://dev.materialize.com/api/rust/materialized/index.html
 """


### PR DESCRIPTION
The link on the README was broken so I updated it there and a few other places. There's still a few references to `mtrlz.dev` notably theres a reference to `internal.mtrlz.dev` in the ci readme that I didn't know what to do with. 