### PR TITLE
persist: extend nemesis to use allow_compaction

### DIFF
--- a/src/persist/src/nemesis/mod.rs
+++ b/src/persist/src/nemesis/mod.rs
@@ -65,7 +65,6 @@
 // - Impl of Runtime directly using Indexed
 // - Impl of Runtime with Timely workers running in threads
 // - Impl of Runtime with Timely workers running in processes
-// - Advancing the compaction frontier
 // - Storage (buffer/blob) with variable latency/slow requests
 // - Vary key size
 // - Non-uniform (zipfian) distribution of keys (any other distributions?)
@@ -119,6 +118,7 @@ pub struct Step {
 pub enum Req {
     Write(WriteReq),
     Seal(SealReq),
+    AllowCompaction(AllowCompactionReq),
     TakeSnapshot(TakeSnapshotReq),
     ReadSnapshot(ReadSnapshotReq),
     Restart,
@@ -130,6 +130,7 @@ pub enum Req {
 pub enum Res {
     Write(WriteReq, Result<WriteRes, Error>),
     Seal(SealReq, Result<(), Error>),
+    AllowCompaction(AllowCompactionReq, Result<(), Error>),
     TakeSnapshot(TakeSnapshotReq, Result<(), Error>),
     ReadSnapshot(ReadSnapshotReq, Result<ReadSnapshotRes, Error>),
     Restart(Result<(), Error>),
@@ -150,6 +151,12 @@ pub struct WriteRes {
 
 #[derive(Clone, Debug)]
 pub struct SealReq {
+    stream: String,
+    ts: u64,
+}
+
+#[derive(Clone, Debug)]
+pub struct AllowCompactionReq {
     stream: String,
     ts: u64,
 }

--- a/src/persist/src/nemesis/validator.rs
+++ b/src/persist/src/nemesis/validator.rs
@@ -18,8 +18,8 @@ use crate::nemesis::{
 use crate::storage::SeqNo;
 
 pub struct Validator {
-    sealed: HashMap<String, u64>,
-    allowed_compaction: HashMap<String, u64>,
+    seal_frontier: HashMap<String, u64>,
+    since_frontier: HashMap<String, u64>,
     writes_by_seqno: BTreeMap<(String, SeqNo), ((String, ()), u64, isize)>,
     available_snapshots: HashMap<SnapshotId, String>,
     errors: Vec<String>,
@@ -43,8 +43,8 @@ impl Validator {
 
     fn new() -> Self {
         Validator {
-            sealed: HashMap::new(),
-            allowed_compaction: HashMap::new(),
+            seal_frontier: HashMap::new(),
+            since_frontier: HashMap::new(),
             writes_by_seqno: BTreeMap::new(),
             available_snapshots: HashMap::new(),
             errors: Vec::new(),
@@ -102,7 +102,12 @@ impl Validator {
     fn step_write(&mut self, req_id: ReqId, req: WriteReq, res: Result<WriteRes, Error>) {
         let should_succeed = self.runtime_available
             && self.storage_available
-            && req.update.1 >= self.sealed.get(&req.stream).copied().unwrap_or_default();
+            && req.update.1
+                >= self
+                    .seal_frontier
+                    .get(&req.stream)
+                    .copied()
+                    .unwrap_or_default();
         self.check_success(req_id, &res, should_succeed);
         if let Ok(res) = res {
             self.writes_by_seqno
@@ -113,10 +118,15 @@ impl Validator {
     fn step_seal(&mut self, req_id: ReqId, req: SealReq, res: Result<(), Error>) {
         let should_succeed = self.runtime_available
             && self.storage_available
-            && req.ts > self.sealed.get(&req.stream).copied().unwrap_or_default();
+            && req.ts
+                > self
+                    .seal_frontier
+                    .get(&req.stream)
+                    .copied()
+                    .unwrap_or_default();
         self.check_success(req_id, &res, should_succeed);
         if let Ok(_) = res {
-            self.sealed.insert(req.stream, req.ts);
+            self.seal_frontier.insert(req.stream, req.ts);
         }
     }
 
@@ -130,14 +140,19 @@ impl Validator {
             && self.storage_available
             && req.ts
                 > self
-                    .allowed_compaction
+                    .since_frontier
                     .get(&req.stream)
                     .copied()
                     .unwrap_or_default()
-            && req.ts < self.sealed.get(&req.stream).copied().unwrap_or_default();
+            && req.ts
+                < self
+                    .seal_frontier
+                    .get(&req.stream)
+                    .copied()
+                    .unwrap_or_default();
         self.check_success(req_id, &res, should_succeed);
         if let Ok(_) = res {
-            self.allowed_compaction.insert(req.stream, req.ts);
+            self.since_frontier.insert(req.stream, req.ts);
         }
     }
 
@@ -172,6 +187,9 @@ impl Validator {
                     // TODO: This is also used by the implementation. Write a
                     // slower but more obvious impl of consolidation here and
                     // use it for validation.
+                    // TODO: The actual snapshot will eventually be compacted up
+                    // to some since frontier and the expected snapshot will need
+                    // to account for that when checking equality.
                     differential_dataflow::consolidation::consolidate_updates(&mut actual);
                     differential_dataflow::consolidation::consolidate_updates(&mut expected);
                     if actual != expected {


### PR DESCRIPTION
This commit teaches the nemesis test to support allow_compaction calls. At the moment
this just forwards the since frontier and doesn't actually compact anything so nothing
else has to change but going forward once compaction happens we will need to remember
the "since" time for each snapshot.