### PR TITLE
testdrive: Create dedicated error report at end

### DIFF
--- a/src/testdrive/src/main.rs
+++ b/src/testdrive/src/main.rs
@@ -203,13 +203,17 @@ async fn main() {
         }
     }
 
+    if config.ci_output {
+        print!("+++ ")
+    }
     if errors.is_empty() {
         println!("testdrive completed successfully.");
     } else {
-        eprintln!("{} errors were encountered during execution", errors.len());
+        println!("!!! Error Report");
+        println!("{} errors were encountered during execution", errors.len());
 
         if !error_files.is_empty() {
-            eprintln!("files involved: {}", error_files.join(" "));
+            println!("files involved: {}", error_files.join(" "));
         }
 
         process::exit(1);


### PR DESCRIPTION
Without this an error in any test file causes Buildkite to display the final
test file's (currently S3) output, with two small lines at the end being the
actual error report. Having an expanded successfully-completed test file is
misleading.

This change also makes it so that that there is less to scan to see exactly
what the error report is, which is hopefully good for folks new to the system.

This also converts a couple stderr lines to stdout lines, because testdrive
always prints to stdout.