### PR TITLE
coordtest: requeue skipped upper updates

### DIFF
--- a/src/coordtest/src/lib.rs
+++ b/src/coordtest/src/lib.rs
@@ -355,7 +355,7 @@ pub async fn run_test(mut tf: datadriven::TestFile) -> datadriven::TestFile {
                 }
                 "print-catalog" => {
                     let catalog = ct.make_catalog().await;
-                    format!("{:#?}", catalog)
+                    format!("{:#?}\n", catalog)
                 }
                 _ => panic!("unknown directive {}", tc.directive),
             };


### PR DESCRIPTION
Otherwise future updates to those IDs will cause assertion panics because
uppers are being retracted that don't exist.
