### PR TITLE
Testing: Support for MirRelationExpr::Reduce and TopK

### DIFF
--- a/src/expr-test-util/src/lib.rs
+++ b/src/expr-test-util/src/lib.rs
@@ -33,7 +33,7 @@ gen_reflect_info_func!(
         MirRelationExpr,
         JoinImplementation
     ],
-    [ColumnType, RelationType]
+    [AggregateExpr, ColumnOrder, ColumnType, RelationType]
 );
 
 lazy_static! {

--- a/src/expr-test-util/tests/testdata/rel
+++ b/src/expr-test-util/tests/testdata/rel
@@ -106,3 +106,47 @@ build
 | | demand = (#0, #1, #5)
 ----
 ----
+
+build
+(top_k (get y) [1] [0] 5 1)
+----
+----
+%0 =
+| Get y (u1)
+| TopK group=(#1) order=(#0 asc) limit=5 offset=1
+----
+----
+
+build
+(top_k (get y) [0 1] [(2 true)] )
+----
+----
+%0 =
+| Get y (u1)
+| TopK group=(#0, #1) order=(#2 desc) offset=0
+----
+----
+
+build
+(reduce (get y)
+    [(call_unary cast_int32_to_int64 #0)]
+    [(max_int64 #1) (sum_int32 #2 true)])
+----
+----
+%0 =
+| Get y (u1)
+| Reduce group=(i32toi64(#0))
+| | agg max(#1)
+| | agg sum(distinct #2)
+----
+----
+
+build
+(reduce (get y) [#2] [])
+----
+----
+%0 =
+| Get y (u1)
+| Distinct group=(#2)
+----
+----

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -16,7 +16,7 @@ use std::fmt;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
-use lowertest::MzEnumReflect;
+use lowertest::{MzEnumReflect, MzStructReflect};
 use ore::collections::CollectionExt;
 use repr::{ColumnType, Datum, Diff, RelationType, Row};
 
@@ -1367,11 +1367,12 @@ impl MirRelationExpr {
 }
 
 /// Specification for an ordering by a column.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, MzStructReflect)]
 pub struct ColumnOrder {
     /// The column index.
     pub column: usize,
     /// Whether to sort in descending order.
+    #[serde(default)]
     pub desc: bool,
 }
 
@@ -1402,13 +1403,14 @@ impl IdGen {
 }
 
 /// Describes an aggregation expression.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzStructReflect)]
 pub struct AggregateExpr {
     /// Names the aggregation function.
     pub func: AggregateFunc,
     /// An expression which extracts from each row the input to `func`.
     pub expr: MirScalarExpr,
     /// Should the aggregation be applied only to distinct results in each group.
+    #[serde(default)]
     pub distinct: bool,
 }
 

--- a/src/repr-test-util/src/lib.rs
+++ b/src/repr-test-util/src/lib.rs
@@ -18,6 +18,7 @@ use lowertest::{
     deserialize_optional, gen_reflect_info_func, GenericTestDeserializeContext, MzEnumReflect,
     MzStructReflect, ReflectedTypeInfo,
 };
+use repr::adt::numeric::Numeric;
 use repr::{ColumnType, Datum, ScalarType};
 
 /* #region Generate information required to construct arbitrary `ScalarType`*/
@@ -53,7 +54,7 @@ pub fn get_datum_from_str<'a>(litval: &'a str, littyp: &ScalarType) -> Result<Da
     }
     match littyp {
         ScalarType::Bool => Ok(Datum::from(parse_litval::<bool>(litval, "bool")?)),
-        ScalarType::Numeric { .. } => Ok(Datum::from(parse_litval::<i128>(litval, "i128")?)),
+        ScalarType::Numeric { .. } => Ok(Datum::from(parse_litval::<Numeric>(litval, "Numeric")?)),
         ScalarType::Int16 => Ok(Datum::from(parse_litval::<i16>(litval, "i16")?)),
         ScalarType::Int32 => Ok(Datum::from(parse_litval::<i32>(litval, "i32")?)),
         ScalarType::Int64 => Ok(Datum::from(parse_litval::<i64>(litval, "i64")?)),

--- a/src/repr-test-util/tests/testdata/datum
+++ b/src/repr-test-util/tests/testdata/datum
@@ -79,6 +79,11 @@ build-datum
 Int32(5)
 
 build-datum
+5.2 numeric
+----
+Numeric(OrderedDecimal(5.2))
+
+build-datum
 2 (list jsonb 100)
 ----
 error: Unsupported literal type List { element_type: Jsonb, custom_oid: Some(100) }


### PR DESCRIPTION
I wanted to add reduction pushdown tests, only to discover that I forgot to derive `MzStructReflect` for `AggregateExpr`. Also realized I forgot to derive the same for `ColumnOrder`.

Also, our new decimal implementation means that we no longer have to construct decimals from `i128`s.