### PR TITLE
decimal: fix some broken internal casts

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -981,13 +981,16 @@ fn ceil_float64<'a>(a: Datum<'a>) -> Datum<'a> {
 }
 
 fn ceil_numeric<'a>(a: Datum<'a>) -> Datum<'a> {
-    let mut a = a.unwrap_numeric();
+    let mut d = a.unwrap_numeric();
+    // ceil will be nop if has no fractional digits.
+    if d.0.exponent() >= 0 {
+        return a;
+    }
     let mut cx = numeric::cx_datum();
     cx.set_rounding(Rounding::Ceiling);
-    cx.round(&mut a.0);
-    // Avoids negative 0.
-    numeric::munge_numeric(&mut a.0).unwrap();
-    Datum::Numeric(a)
+    cx.round(&mut d.0);
+    numeric::munge_numeric(&mut d.0).unwrap();
+    Datum::Numeric(d)
 }
 
 fn floor_float32<'a>(a: Datum<'a>) -> Datum<'a> {
@@ -999,12 +1002,16 @@ fn floor_float64<'a>(a: Datum<'a>) -> Datum<'a> {
 }
 
 fn floor_numeric<'a>(a: Datum<'a>) -> Datum<'a> {
-    let mut a = a.unwrap_numeric();
+    let mut d = a.unwrap_numeric();
+    // floor will be nop if has no fractional digits.
+    if d.0.exponent() >= 0 {
+        return a;
+    }
     let mut cx = numeric::cx_datum();
     cx.set_rounding(Rounding::Floor);
-    cx.round(&mut a.0);
-    numeric::munge_numeric(&mut a.0).unwrap();
-    Datum::Numeric(a)
+    cx.round(&mut d.0);
+    numeric::munge_numeric(&mut d.0).unwrap();
+    Datum::Numeric(d)
 }
 
 fn round_float32<'a>(a: Datum<'a>) -> Datum<'a> {
@@ -1030,9 +1037,13 @@ fn round_float64<'a>(a: Datum<'a>) -> Datum<'a> {
 }
 
 fn round_numeric_unary<'a>(a: Datum<'a>) -> Datum<'a> {
-    let mut a = a.unwrap_numeric();
-    numeric::cx_datum().round(&mut a.0);
-    Datum::Numeric(a)
+    let mut d = a.unwrap_numeric();
+    // round will be nop if has no fractional digits.
+    if d.0.exponent() >= 0 {
+        return a;
+    }
+    numeric::cx_datum().round(&mut d.0);
+    Datum::Numeric(d)
 }
 
 fn round_numeric_binary<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {

--- a/test/testdrive/numeric.td
+++ b/test/testdrive/numeric.td
@@ -32,3 +32,12 @@ a
 0
 0.01
 1.23
+
+# This previously panicked due to a failed conversion from numeric to i128
+# statement ok
+> CREATE OR REPLACE MATERIALIZED VIEW numeric_cast_ok AS
+  SELECT 1
+  WHERE mz_logical_timestamp() > 1927418240000::numeric(38,0);
+
+> SELECT * FROM numeric_cast_ok;
+1

--- a/test/testdrive/temporal.td
+++ b/test/testdrive/temporal.td
@@ -266,3 +266,17 @@ Unsupported temporal predicate: `mz_logical_timestamp()` must be directly compar
 
 !CREATE MATERIALIZED VIEW v1 AS SELECT * FROM first_ts WHERE ts BETWEEN mz_logical_timestamp() AND mz_logical_timestamp() + 1;
 Unsupported temporal predicate: `mz_logical_timestamp()` must be directly compared to a non-temporal expression
+
+#
+# Numeric comparisons
+#
+
+# Checks that comparisons against mz_logical_timestamp using values with
+# fractional components are valid.
+
+> CREATE OR REPLACE MATERIALIZED VIEW numeric_trunc AS
+  SELECT 1
+  WHERE mz_logical_timestamp() > 1927418240000.1;
+
+> SELECT * FROM numeric_trunc;
+1


### PR DESCRIPTION
The underlying decimal library requires values' exponents be 0 when converting to integers, but input is often formed in a way that represents values with positive exponents. I failed to convert values to an exponent of zero before converting to integers in the places I've amended here.

@frankmcsherry I'd like to improve `linear.rs` a little more, but this bandaid at least fixes @andrioni 's issue, though will still panic on any value greater than an `i128`. I can get that fix in tomorrow, just a little too late for me to make meaningful progress on it tonight.