### PR TITLE
repr,sql: handle set operations on numerics another way

### DIFF
--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -2395,7 +2395,11 @@ lazy_static! {
                 params!(ArrayAny, ArrayAny) => BinaryFunc::Gte, 1075;
             },
             "=" => Scalar {
-                params!(Numeric, Numeric) => BinaryFunc::Eq, 1752;
+                params!(Numeric, Numeric) => Operation::binary(|_ecx, lhs, rhs| {
+                    let lhs = lhs.call_unary(UnaryFunc::CanonicalizeNumeric);
+                    let rhs = rhs.call_unary(UnaryFunc::CanonicalizeNumeric);
+                    Ok(rhs.call_binary(lhs, Eq))
+                }), 1752;
                 params!(Bool, Bool) => BinaryFunc::Eq, 91;
                 params!(Int16, Int16) => BinaryFunc::Eq, 94;
                 params!(Int32, Int32) => BinaryFunc::Eq, 96;

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -277,11 +277,11 @@ ORDER BY
 | Filter (#18 = "EUROPE")
 | Reduce group=(#0)
 | | agg min(#4)
-| ArrangeBy (#0, #1)
+| ArrangeBy (#0, canonnumeric(#1))
 
 %12 =
-| Join %5 %11 (= #0 #28) (= #19 #29)
-| | implementation = Differential %5 %11.(#0, #1)
+| Join %5 %11 (= #0 #28) (= canonnumeric(#19) canonnumeric(#29))
+| | implementation = Differential %5 %11.(#0, canonnumeric(#1))
 | | demand = (#0, #2, #10, #11, #13..#15, #22)
 | Project (#14, #10, #22, #0, #2, #11, #13, #15)
 
@@ -1087,7 +1087,7 @@ WHERE
 
 %6 =
 | Union %2 %5
-| Map ((100 * #0) / #1)
+| Map ((100.00 * #0) / #1)
 | Project (#2)
 
 EOF
@@ -1146,11 +1146,11 @@ ORDER BY
 | Get %0 (l0)
 | Reduce group=()
 | | agg max(#1)
-| ArrangeBy (#0)
+| ArrangeBy (canonnumeric(#0))
 
 %4 =
-| Join %1 %2 %3 (= #0 #7) (= #8 #9)
-| | implementation = Differential %1.(#0) %2.(#0) %3.(#0)
+| Join %1 %2 %3 (= #0 #7) (= canonnumeric(#8) canonnumeric(#9))
+| | implementation = Differential %1.(#0) %2.(#0) %3.(canonnumeric(#0))
 | | demand = (#0..#2, #4, #8)
 | Project (#0..#2, #4, #8)
 
@@ -1331,7 +1331,7 @@ WHERE
 
 %10 =
 | Union %6 %9
-| Map (#0 / 7)
+| Map (#0 / 7.0)
 | Project (#1)
 
 EOF
@@ -1796,7 +1796,7 @@ ORDER BY
 
 %1 =
 | Get materialize.public.customer (u15)
-| Filter ((((((("13" = substr(#4, 1, 2)) || ("31" = substr(#4, 1, 2))) || ("23" = substr(#4, 1, 2))) || ("29" = substr(#4, 1, 2))) || ("30" = substr(#4, 1, 2))) || ("18" = substr(#4, 1, 2))) || ("17" = substr(#4, 1, 2))), (#5 > 0)
+| Filter ((((((("13" = substr(#4, 1, 2)) || ("31" = substr(#4, 1, 2))) || ("23" = substr(#4, 1, 2))) || ("29" = substr(#4, 1, 2))) || ("30" = substr(#4, 1, 2))) || ("18" = substr(#4, 1, 2))) || ("17" = substr(#4, 1, 2))), (#5 > 0.00)
 | Reduce group=()
 | | agg sum(#5)
 | | agg count(true)


### PR DESCRIPTION
I'm not sure how much I like this, but it is maybe an option.

----

Rather than canonicalizing numeric data whenever we pack it into a Row,
instead only canonicalize numeric data before it heads into a set
operation, like UNION or DISTINCT. This means we preserve trailing zeros
whenever possible while still ensuring reasonable semantics for set
operations.

Note that we're still not quite PostgreSQL compatible on set operations.
When PostgreSQL encounters `DISTINCT ... VALUES (1.0), (1.00)`, it
promises to output `1.0` if you've specified an `ORDER BY`, because 1.0
appears first. But we'll output `1` because we always trim off trailing
zeros from all data that flows through a set operation.

Importantly, this approach should generalize reasonably well to the
`char` type, which has a similar issue around trailing whitespace.
`char` will be a bit harder, though, because we'll need to cast chars to
strings on the way in to set operations, and then cast them back to
chars on the way out.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/7572)
<!-- Reviewable:end -->
