### PR TITLE
source,kafka: clarify log message, change from warn! to info!

### DIFF
--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -402,8 +402,8 @@ impl SourceReader for KafkaSourceReader {
 
                 let last_offset = *last_offset_ref;
                 if offset <= last_offset {
-                    warn!(
-                        "Kafka message before expected offset: \
+                    info!(
+                        "Kafka message before expected offset, skipping: \
                              source {} (reading topic {}, partition {}) \
                              received offset {} expected offset {:?}",
                         self.source_name,


### PR DESCRIPTION
Having this as a warning is potentially too confusing for users. It's
totally fine for this to happen.