### PR TITLE
push down join equivalences with runtime constants

### DIFF
--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -244,12 +244,21 @@ impl PredicatePushdown {
                                     // `MirScalarExpr` to a join constraint, we
                                     // need to retain the `!isnull(col1)`
                                     // information.
-                                    pred_not_translated.push(
-                                        expr1
-                                            .clone()
-                                            .call_unary(UnaryFunc::IsNull)
-                                            .call_unary(UnaryFunc::Not),
-                                    );
+                                    if expr1.typ(&input_type).nullable {
+                                        pred_not_translated.push(
+                                            expr1
+                                                .clone()
+                                                .call_unary(UnaryFunc::IsNull)
+                                                .call_unary(UnaryFunc::Not),
+                                        );
+                                    } else if expr2.typ(&input_type).nullable {
+                                        pred_not_translated.push(
+                                            expr2
+                                                .clone()
+                                                .call_unary(UnaryFunc::IsNull)
+                                                .call_unary(UnaryFunc::Not),
+                                        );
+                                    }
                                     equivalences.push(vec![(**expr1).clone(), (**expr2).clone()]);
                                     continue;
                                 }
@@ -520,7 +529,7 @@ impl PredicatePushdown {
                 ..
             } => {
                 // The goal is to push
-                //   1) equivalences of the form `expr = literal`, where `expr`
+                //   1) equivalences of the form `expr = <runtime constant>`, where `expr`
                 //      comes from a single input.
                 //   2) equivalences of the form `expr1 = expr2`, where both
                 //      expressions come from the same single input.
@@ -547,25 +556,31 @@ impl PredicatePushdown {
                         return;
                     }
 
-                    if let Some(literal_pos) = equivalences[equivalence_pos]
+                    let runtime_constants = equivalences[equivalence_pos]
                         .iter()
-                        .position(|expr| expr.is_literal())
-                    {
-                        // Case 2: There is one literal in the equivalence class
-                        let literal = equivalences[equivalence_pos][literal_pos].clone();
-                        let gen_literal_equality_pred = |expr| {
-                            if literal.is_literal_null() {
-                                MirScalarExpr::CallUnary {
-                                    func: expr::UnaryFunc::IsNull,
-                                    expr: Box::new(expr),
-                                }
-                            } else {
-                                MirScalarExpr::CallBinary {
-                                    func: expr::BinaryFunc::Eq,
-                                    expr1: Box::new(expr),
-                                    expr2: Box::new(literal.clone()),
-                                }
+                        .filter(|expr| expr.support().is_empty())
+                        .cloned()
+                        .collect::<Vec<_>>();
+                    if !runtime_constants.is_empty() {
+                        // Case 2: There is at least one runtime constant the equivalence class
+                        let gen_literal_equality_preds = |expr: MirScalarExpr| {
+                            let mut equality_preds = Vec::new();
+                            for constant in runtime_constants.iter() {
+                                let pred = if constant.is_literal_null() {
+                                    MirScalarExpr::CallUnary {
+                                        func: expr::UnaryFunc::IsNull,
+                                        expr: Box::new(expr.clone()),
+                                    }
+                                } else {
+                                    MirScalarExpr::CallBinary {
+                                        func: expr::BinaryFunc::Eq,
+                                        expr1: Box::new(expr.clone()),
+                                        expr2: Box::new(constant.clone()),
+                                    }
+                                };
+                                equality_preds.push(pred);
                             }
+                            equality_preds
                         };
 
                         // Find all single input expressions in the equivalence
@@ -591,14 +606,14 @@ impl PredicatePushdown {
                             .collect::<Vec<_>>();
 
                         // For every single-input expression `expr`, we can push
-                        // down `expr = literal` and remove `expr` from the
+                        // down `expr = <runtime constant>` and remove `expr` from the
                         // equivalence class.
                         for (expr_pos, input, expr) in single_input_exprs.drain(..).rev() {
-                            push_downs[input].push(gen_literal_equality_pred(expr));
+                            push_downs[input].extend(gen_literal_equality_preds(expr));
                             equivalences[equivalence_pos].remove(expr_pos);
                         }
                     } else {
-                        // Case 3: There are no literals in the equivalence
+                        // Case 3: There are no constants in the equivalence
                         // class. Push a predicate for every pair of expressions
                         // in the equivalence that either belong to a single
                         // input or can be localized to a given input through

--- a/src/transform/tests/testdata/predicate-pushdown
+++ b/src/transform/tests/testdata/predicate-pushdown
@@ -72,7 +72,7 @@ build apply=PredicatePushdown
 | Get x (u0)
 
 %2 =
-| Join %0 %1 (= 1 mz_logical_timestamp())
+| Join %0 %1
 | | implementation = Unimplemented
 ----
 ----

--- a/src/transform/tests/testdata/predicate-pushdown
+++ b/src/transform/tests/testdata/predicate-pushdown
@@ -1,0 +1,124 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+cat
+(defsource x [int64 int64])
+----
+ok
+
+# check that equivalences involving runtime constants can be pushed down
+
+build apply=PredicatePushdown
+(join
+  [(get x)
+   (get x)]
+  [[#1 (call_nullary mz_logical_timestamp)]])
+----
+----
+%0 =
+| Get x (u0)
+| Filter (#1 = mz_logical_timestamp())
+
+%1 =
+| Get x (u0)
+
+%2 =
+| Join %0 %1
+| | implementation = Unimplemented
+----
+----
+
+build apply=PredicatePushdown
+(join
+  [(get x)
+   (get x)]
+  [[#1 #3 (call_nullary mz_logical_timestamp)]])
+----
+----
+%0 =
+| Get x (u0)
+| Filter (#1 = mz_logical_timestamp())
+
+%1 =
+| Get x (u0)
+| Filter (#1 = mz_logical_timestamp())
+
+%2 =
+| Join %0 %1
+| | implementation = Unimplemented
+----
+----
+
+# Join equivalence with several runtime constants
+
+build apply=PredicatePushdown
+(join
+  [(get x)
+   (get x)]
+  [[#1 1 (call_nullary mz_logical_timestamp)]])
+----
+----
+%0 =
+| Get x (u0)
+| Filter (#1 = 1), (#1 = mz_logical_timestamp())
+
+%1 =
+| Get x (u0)
+
+%2 =
+| Join %0 %1 (= 1 mz_logical_timestamp())
+| | implementation = Unimplemented
+----
+----
+
+# Check that equality filters with runtime constants don't get stuck in the join
+
+build apply=PredicatePushdown
+(filter
+  (join
+    [(get x)
+     (get x)]
+    [])
+  [(call_binary eq #1 (call_nullary mz_logical_timestamp))])
+----
+----
+%0 =
+| Get x (u0)
+| Filter (#1 = mz_logical_timestamp()), !(isnull(#1))
+
+%1 =
+| Get x (u0)
+
+%2 =
+| Join %0 %1
+| | implementation = Unimplemented
+----
+----
+
+build apply=PredicatePushdown
+(filter
+  (join
+    [(get x)
+     (get x)]
+    [])
+  [(call_binary eq (call_nullary mz_logical_timestamp) #1)])
+----
+----
+%0 =
+| Get x (u0)
+| Filter (#1 = mz_logical_timestamp()), !(isnull(#1))
+
+%1 =
+| Get x (u0)
+
+%2 =
+| Join %0 %1
+| | implementation = Unimplemented
+----
+----

--- a/test/sqllogictest/github-7585.slt
+++ b/test/sqllogictest/github-7585.slt
@@ -1,0 +1,24 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+mode cockroach
+
+statement ok
+CREATE TABLE t1(f1 int, f2 int)
+
+statement ok
+CREATE TABLE t2(f1 int, f2 int)
+
+query T multiline
+EXPLAIN SELECT FROM t1 LEFT JOIN t2 ON TRUE WHERE t1.f1 = t1.f2 + 4 AND t1.f1 IS NULL AND NOT t1.f2 = t1.f1
+----
+%0 =
+| Constant
+
+EOF

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -566,7 +566,7 @@ EXPLAIN SELECT name, id FROM v4362 WHERE name = (SELECT name FROM v4362 WHERE id
 | Get %0 (l0)
 | Reduce group=()
 | | agg count(true)
-| Filter (err: more than one record produced in subquery), (#0 > 1)
+| Filter (#0 > 1)
 | Map (err: more than one record produced in subquery)
 | Project (#1)
 

--- a/test/sqllogictest/transform/lifting.slt
+++ b/test/sqllogictest/transform/lifting.slt
@@ -653,7 +653,7 @@ explain select min(a) from t_pk where a between 38 and 195 and a = (select a fro
 | Get %0 (l0)
 | Reduce group=()
 | | agg count(true)
-| Filter (err: more than one record produced in subquery), (#0 > 1)
+| Filter (#0 > 1)
 | Map (err: more than one record produced in subquery)
 | Project (#1)
 
@@ -705,7 +705,7 @@ explain select min(a) from t where a between 38 and 195 and a = (select a from t
 | Get %0 (l0)
 | Reduce group=()
 | | agg count(true)
-| Filter (err: more than one record produced in subquery), (#0 > 1)
+| Filter (#0 > 1)
 | Map (err: more than one record produced in subquery)
 | Project (#1)
 

--- a/test/testdrive/temporal.td
+++ b/test/testdrive/temporal.td
@@ -250,6 +250,9 @@ ts
 "2000-01-01 00:00:00 UTC" "2199-12-31 00:00:00 UTC"
 "2000-01-01 00:00:00 UTC" "2199-12-31 00:00:00 UTC"
 
+> CREATE MATERIALIZED VIEW v2 AS SELECT * FROM first_ts a, first_ts b WHERE mz_logical_timestamp() = a.ts;
+
+> CREATE MATERIALIZED VIEW v3 AS SELECT * FROM first_ts a, first_ts b WHERE mz_logical_timestamp() = a.ts AND mz_logical_timestamp() = b.ts;
 
 #
 # Various errors in the placement of mz_logical_timestamp()


### PR DESCRIPTION
Pushable predicates can be extract from join equivalences with terms that are constant at runtime, such as mz_logical_timestamp and literals.

This PR generalizes the code that extracted pushable predicates from join equivalences with literals to any type of expression that is constant at runtime. It also covers the case when there are multiple runtime constants within the same equivalence.

Also, do not add `!isnull(expr)` predicates when converting a predicate into a join equivalence if `expr` is from a non-nullable type. This works around a missing transformation that removes them for any non-nullable expression and not just for columns (as ColumnKnowledge does).

Fixes #7579.