### PR TITLE
repr/numeric: add convenience functions for numeric->int internal casts

### DIFF
--- a/src/materialized/tests/util.rs
+++ b/src/materialized/tests/util.rs
@@ -7,7 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::convert::TryInto;
 use std::env;
 use std::error::Error;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
@@ -207,13 +206,11 @@ pub struct MzTimestamp(pub u64);
 
 impl<'a> FromSql<'a> for MzTimestamp {
     fn from_sql(ty: &Type, raw: &'a [u8]) -> Result<MzTimestamp, Box<dyn Error + Sync + Send>> {
-        let mut n = pgrepr::Numeric::from_sql(ty, raw)?;
-        if repr::adt::numeric::get_scale(&n.0 .0) != 0 {
-            return Err("scale of apd was not 0".into());
-        }
-        // Converting apd to int requires its exponent be zero.
-        repr::adt::numeric::rescale(&mut n.0 .0, 0).unwrap();
-        Ok(MzTimestamp(n.0 .0.try_into()?))
+        use numeric::TryFromNumeric;
+        use repr::adt::numeric;
+        let n = pgrepr::Numeric::from_sql(ty, raw)?;
+        let ts = u64::try_from_numeric(n.0 .0)?;
+        Ok(MzTimestamp(ts))
     }
 
     fn accepts(ty: &Type) -> bool {

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -763,9 +763,11 @@ pub fn eval_as_of<'a>(
     let evaled = ex.eval(&[], temp_storage)?;
 
     Ok(match ex.typ(desc.typ()).scalar_type {
-        ScalarType::Numeric { .. } => numeric::cx_datum()
-            .try_into_i128(evaled.unwrap_numeric().0)?
-            .try_into()?,
+        ScalarType::Numeric { .. } => {
+            use numeric::TryFromNumeric;
+            let ts = u64::try_from_numeric(evaled.unwrap_numeric().0)?;
+            ts.try_into()?
+        }
         ScalarType::Int16 => evaled.unwrap_int16().try_into()?,
         ScalarType::Int32 => evaled.unwrap_int32().try_into()?,
         ScalarType::Int64 => evaled.unwrap_int64().try_into()?,

--- a/test/sqllogictest/as_of.slt
+++ b/test/sqllogictest/as_of.slt
@@ -31,3 +31,26 @@ SELECT * FROM data AS OF now()
 1 2
 2 1
 3 1
+
+# This previously would panic on an internal conversion from numeric to
+# primitive int
+
+query II
+SELECT * FROM data AS OF 1927418240000::numeric;
+----
+1 1
+1 2
+2 1
+3 1
+
+query error out of range integral type conversion attempted
+SELECT * FROM data AS OF -1;
+
+query error decimal cannot be expressed in target primitive type
+SELECT * FROM data AS OF -1::numeric;
+
+query error decimal cannot be expressed in target primitive type
+SELECT * FROM data AS OF 1E38;
+
+query error out of range integral type conversion attempted
+SELECT * FROM data AS OF 1.2;


### PR DESCRIPTION
In reviewing #7571, @frankmcsherry points out that it would be much nicer to perform numeric to integer casts using a library, rather than inlining the code (poorly paraphrased).

I implemented this as a trait to save myself some typing. It differs from `Numeric`'s implementation for `TryFrom` for the same types by first attempting to rescale the value to a valid representation for the decimal library, which requires the value's exponent be 0.

Alternatively, I could change `Numeric` into a new type, i.e. `struct Numeric(Decimal<13>)` and implement the native `TryFrom` trait on that; this was a little less typing, but glad to pivot if that sits better with y'all.