### PR TITLE
sql-parser: add consistency topic format to Kafka connector

### DIFF
--- a/doc/user/content/sql/create-sink.md
+++ b/doc/user/content/sql/create-sink.md
@@ -42,9 +42,11 @@ Field | Use
 ------|-----
 **KAFKA BROKER** _host_ | The Kafka broker's host name without the security protocol, which is specified by the [`WITH` options](#with-options).) If you wish to specify multiple brokers (bootstrap servers) as an additional safeguard, use a comma-separated list. For example: `localhost:9092, localhost:9093`.
 **TOPIC** _topic&lowbar;prefix_ | The prefix used to generate the Kafka topic name to create and write to.
-**WITH OPTIONS (** _option&lowbar;_ **)** | Options affecting sink creation. For more details see [`WITH` options](#with-options).
-**CONFLUENT SCHEMA REGISTRY** _url_ | The URL of the Confluent schema registry to get schema information from.
 **KEY (** _key&lowbar;column&lowbar;list_ **)** | An optional list of columns to use for the Kafka key. If unspecified, the Kafka key is left unset. {{< version-added v0.5.1 />}}
+**WITH OPTIONS (** _option&lowbar;_ **)** | Options affecting sink creation. For more details see [`WITH` options](#with-options).
+**CONSISTENCY TOPIC** _consistency&lowbar;topic_ | Makes the sink emit additional [consistency metadata](#consistency-metadata) to the named topic. Only valid for Kafka sinks. If `reuse_topic` is `true`, a default consistency_topic will be used when not explicitly set. The default consistency topic name is formed by appending `-consistency` to the output topic name. {{< version-added v0.8.4 />}}
+**CONSISTENCY FORMAT** _format_ | The format of the Kafka consistency topic, defaults to Avro for Avro-encoded sinks. {{< version-added v0.8.4 />}}
+**CONFLUENT SCHEMA REGISTRY** _url_ | The URL of the Confluent schema registry to get schema information from.
 
 ### `WITH` options
 

--- a/doc/user/layouts/partials/sql-grammar/sink-kafka-connector.svg
+++ b/doc/user/layouts/partials/sql-grammar/sink-kafka-connector.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="539" height="355">
+<svg xmlns="http://www.w3.org/2000/svg" width="1075" height="469">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="126" height="32" rx="10"/>
@@ -23,116 +23,170 @@
    <rect x="325" y="3" width="90" height="32"/>
    <rect x="323" y="1" width="90" height="32" class="nonterminal"/>
    <text class="nonterminal" x="333" y="21">topic-prefix</text>
-   <rect x="127" y="113" width="46" height="32" rx="10"/>
-   <rect x="125"
+   <rect x="395" y="113" width="46" height="32" rx="10"/>
+   <rect x="393"
          y="111"
          width="46"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="135" y="131">KEY</text>
-   <rect x="193" y="113" width="24" height="32" rx="10"/>
-   <rect x="191"
+   <text class="terminal" x="403" y="131">KEY</text>
+   <rect x="461" y="113" width="24" height="32" rx="10"/>
+   <rect x="459"
          y="111"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="201" y="131">(</text>
-   <rect x="257" y="113" width="94" height="32"/>
-   <rect x="255" y="111" width="94" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="265" y="131">key_column</text>
-   <rect x="257" y="69" width="24" height="32" rx="10"/>
-   <rect x="255"
+   <text class="terminal" x="469" y="131">(</text>
+   <rect x="525" y="113" width="94" height="32"/>
+   <rect x="523" y="111" width="94" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="533" y="131">key_column</text>
+   <rect x="525" y="69" width="24" height="32" rx="10"/>
+   <rect x="523"
          y="67"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="265" y="87">,</text>
-   <rect x="391" y="113" width="24" height="32" rx="10"/>
-   <rect x="389"
+   <text class="terminal" x="533" y="87">,</text>
+   <rect x="659" y="113" width="24" height="32" rx="10"/>
+   <rect x="657"
          y="111"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="399" y="131">)</text>
-   <rect x="45" y="239" width="56" height="32" rx="10"/>
+   <text class="terminal" x="667" y="131">)</text>
+   <rect x="45" y="211" width="118" height="32" rx="10"/>
    <rect x="43"
-         y="237"
-         width="56"
+         y="209"
+         width="118"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="53" y="257">WITH</text>
-   <rect x="121" y="239" width="24" height="32" rx="10"/>
-   <rect x="119"
-         y="237"
-         width="24"
+   <text class="terminal" x="53" y="229">CONSISTENCY</text>
+   <rect x="183" y="211" width="62" height="32" rx="10"/>
+   <rect x="181"
+         y="209"
+         width="62"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="129" y="257">(</text>
-   <rect x="185" y="239" width="46" height="32"/>
-   <rect x="183" y="237" width="46" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="193" y="257">field</text>
-   <rect x="251" y="239" width="26" height="32" rx="10"/>
-   <rect x="249"
-         y="237"
-         width="26"
+   <text class="terminal" x="191" y="229">TOPIC</text>
+   <rect x="265" y="211" width="50" height="32"/>
+   <rect x="263" y="209" width="50" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="273" y="229">topic</text>
+   <rect x="355" y="243" width="118" height="32" rx="10"/>
+   <rect x="353"
+         y="241"
+         width="118"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="259" y="257">=</text>
-   <rect x="297" y="239" width="38" height="32"/>
-   <rect x="295" y="237" width="38" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="305" y="257">val</text>
-   <rect x="185" y="195" width="24" height="32" rx="10"/>
-   <rect x="183"
-         y="193"
-         width="24"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="193" y="213">,</text>
-   <rect x="375" y="239" width="24" height="32" rx="10"/>
-   <rect x="373"
-         y="237"
-         width="24"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="383" y="257">)</text>
-   <rect x="439" y="239" width="78" height="32" rx="10"/>
-   <rect x="437"
-         y="237"
+   <text class="terminal" x="363" y="261">CONSISTENCY</text>
+   <rect x="493" y="243" width="78" height="32" rx="10"/>
+   <rect x="491"
+         y="241"
          width="78"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="447" y="257">FORMAT</text>
-   <rect x="89" y="321" width="106" height="32" rx="10"/>
-   <rect x="87"
-         y="319"
+   <text class="terminal" x="501" y="261">FORMAT</text>
+   <rect x="591" y="243" width="106" height="32" rx="10"/>
+   <rect x="589"
+         y="241"
          width="106"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="97" y="339">AVRO USING</text>
-   <rect x="215" y="321" width="240" height="32" rx="10"/>
-   <rect x="213"
-         y="319"
+   <text class="terminal" x="599" y="261">AVRO USING</text>
+   <rect x="717" y="243" width="240" height="32" rx="10"/>
+   <rect x="715"
+         y="241"
          width="240"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="223" y="339">CONFLUENT SCHEMA REGISTRY</text>
-   <rect x="475" y="321" width="36" height="32"/>
-   <rect x="473" y="319" width="36" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="483" y="339">url</text>
+   <text class="terminal" x="725" y="261">CONFLUENT SCHEMA REGISTRY</text>
+   <rect x="977" y="243" width="36" height="32"/>
+   <rect x="975" y="241" width="36" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="985" y="261">url</text>
+   <rect x="313" y="353" width="56" height="32" rx="10"/>
+   <rect x="311"
+         y="351"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="321" y="371">WITH</text>
+   <rect x="389" y="353" width="24" height="32" rx="10"/>
+   <rect x="387"
+         y="351"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="397" y="371">(</text>
+   <rect x="453" y="353" width="46" height="32"/>
+   <rect x="451" y="351" width="46" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="461" y="371">field</text>
+   <rect x="519" y="353" width="26" height="32" rx="10"/>
+   <rect x="517"
+         y="351"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="527" y="371">=</text>
+   <rect x="565" y="353" width="38" height="32"/>
+   <rect x="563" y="351" width="38" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="573" y="371">val</text>
+   <rect x="453" y="309" width="24" height="32" rx="10"/>
+   <rect x="451"
+         y="307"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="461" y="327">,</text>
+   <rect x="643" y="353" width="24" height="32" rx="10"/>
+   <rect x="641"
+         y="351"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="651" y="371">)</text>
+   <rect x="707" y="353" width="78" height="32" rx="10"/>
+   <rect x="705"
+         y="351"
+         width="78"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="715" y="371">FORMAT</text>
+   <rect x="625" y="435" width="106" height="32" rx="10"/>
+   <rect x="623"
+         y="433"
+         width="106"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="633" y="453">AVRO USING</text>
+   <rect x="751" y="435" width="240" height="32" rx="10"/>
+   <rect x="749"
+         y="433"
+         width="240"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="759" y="453">CONFLUENT SCHEMA REGISTRY</text>
+   <rect x="1011" y="435" width="36" height="32"/>
+   <rect x="1009" y="433" width="36" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="1019" y="453">url</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m126 0 h10 m0 0 h10 m46 0 h10 m0 0 h10 m62 0 h10 m0 0 h10 m90 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-352 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m46 0 h10 m0 0 h10 m24 0 h10 m20 0 h10 m94 0 h10 m-134 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m114 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-114 0 h10 m24 0 h10 m0 0 h70 m20 44 h10 m24 0 h10 m-328 0 h20 m308 0 h20 m-348 0 q10 0 10 10 m328 0 q0 -10 10 -10 m-338 10 v14 m328 0 v-14 m-328 14 q0 10 10 10 m308 0 q10 0 10 -10 m-318 10 h10 m0 0 h298 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-454 126 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m56 0 h10 m0 0 h10 m24 0 h10 m20 0 h10 m46 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m38 0 h10 m-190 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m170 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-170 0 h10 m24 0 h10 m0 0 h126 m20 44 h10 m24 0 h10 m-394 0 h20 m374 0 h20 m-414 0 q10 0 10 10 m394 0 q0 -10 10 -10 m-404 10 v14 m394 0 v-14 m-394 14 q0 10 10 10 m374 0 q10 0 10 -10 m-384 10 h10 m0 0 h364 m20 -34 h10 m78 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-472 82 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m106 0 h10 m0 0 h10 m240 0 h10 m0 0 h10 m36 0 h10 m3 0 h-3"/>
-   <polygon points="529 335 537 331 537 339"/>
-   <polygon points="529 335 521 331 521 339"/>
+         d="m17 17 h2 m0 0 h10 m126 0 h10 m0 0 h10 m46 0 h10 m0 0 h10 m62 0 h10 m0 0 h10 m90 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-84 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m46 0 h10 m0 0 h10 m24 0 h10 m20 0 h10 m94 0 h10 m-134 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m114 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-114 0 h10 m24 0 h10 m0 0 h70 m20 44 h10 m24 0 h10 m-328 0 h20 m308 0 h20 m-348 0 q10 0 10 10 m328 0 q0 -10 10 -10 m-338 10 v14 m328 0 v-14 m-328 14 q0 10 10 10 m308 0 q10 0 10 -10 m-318 10 h10 m0 0 h298 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-722 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h998 m-1028 0 h20 m1008 0 h20 m-1048 0 q10 0 10 10 m1028 0 q0 -10 10 -10 m-1038 10 v12 m1028 0 v-12 m-1028 12 q0 10 10 10 m1008 0 q10 0 10 -10 m-1018 10 h10 m118 0 h10 m0 0 h10 m62 0 h10 m0 0 h10 m50 0 h10 m20 0 h10 m0 0 h668 m-698 0 h20 m678 0 h20 m-718 0 q10 0 10 10 m698 0 q0 -10 10 -10 m-708 10 v12 m698 0 v-12 m-698 12 q0 10 10 10 m678 0 q10 0 10 -10 m-688 10 h10 m118 0 h10 m0 0 h10 m78 0 h10 m0 0 h10 m106 0 h10 m0 0 h10 m240 0 h10 m0 0 h10 m36 0 h10 m42 -64 l2 0 m2 0 l2 0 m2 0 l2 0 m-804 174 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m56 0 h10 m0 0 h10 m24 0 h10 m20 0 h10 m46 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m38 0 h10 m-190 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m170 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-170 0 h10 m24 0 h10 m0 0 h126 m20 44 h10 m24 0 h10 m-394 0 h20 m374 0 h20 m-414 0 q10 0 10 10 m394 0 q0 -10 10 -10 m-404 10 v14 m394 0 v-14 m-394 14 q0 10 10 10 m374 0 q10 0 10 -10 m-384 10 h10 m0 0 h364 m20 -34 h10 m78 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-204 82 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m106 0 h10 m0 0 h10 m240 0 h10 m0 0 h10 m36 0 h10 m3 0 h-3"/>
+   <polygon points="1065 449 1073 445 1073 453"/>
+   <polygon points="1065 449 1057 445 1057 453"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -36,16 +36,16 @@ create_role ::=
     'CREATE' 'ROLE' role_name ('LOGIN' | 'NOLOGIN' | 'SUPERUSER' | 'NOSUPERUSER')*
 create_schema ::=
     'CREATE' 'SCHEMA' ('IF NOT EXISTS')? schema_name
-    create_sink ::=
-       'CREATE SINK' 'IF NOT EXISTS'? sink_name
-       'FROM' item_name
-       'INTO' (
-        sink_kafka_connector |
-       'AVRO OCF' path-prefix
-       )
-       ('ENVELOPE' ('DEBEZIUM'|'UPSERT'))?
-       ('WITH SNAPSHOT' | 'WITHOUT SNAPSHOT')?
-       ('AS OF' timestamp_expression)?
+create_sink ::=
+    'CREATE SINK' 'IF NOT EXISTS'? sink_name
+    'FROM' item_name
+    'INTO' (
+    sink_kafka_connector |
+    'AVRO OCF' path-prefix
+    )
+    ('ENVELOPE' ('DEBEZIUM'|'UPSERT'))?
+    ('WITH SNAPSHOT' | 'WITHOUT SNAPSHOT')?
+    ('AS OF' timestamp_expression)?
 create_source_avro_file ::=
   'CREATE' 'MATERIALIZED'? 'SOURCE' ('IF NOT EXISTS')? src_name
   ('(' (col_name) ( ( ',' col_name ) )* ( ',' key_constraint )? ')')?
@@ -320,6 +320,7 @@ join_type ::=
 sink_kafka_connector ::=
     'KAFKA BROKER' host 'TOPIC' topic-prefix
     ('KEY' '(' key_column ( ',' key_column )* ')')?
+    ('CONSISTENCY' 'TOPIC' topic ('CONSISTENCY' 'FORMAT' 'AVRO USING' 'CONFLUENT SCHEMA REGISTRY' url)?)?
     ('WITH' '(' ( field '=' val ) ( ( ',' field '=' val ) )* ')')?
     'FORMAT' 'AVRO USING' 'CONFLUENT SCHEMA REGISTRY' url
 lit_cast ::=

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -362,7 +362,7 @@ impl AstDisplay for DbzMode {
 impl_display!(DbzMode);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum Connector {
+pub enum Connector<T: AstInfo> {
     File {
         path: String,
         compression: Compression,
@@ -371,6 +371,7 @@ pub enum Connector {
         broker: String,
         topic: String,
         key: Option<Vec<Ident>>,
+        consistency: Option<KafkaConsistency<T>>,
     },
     Kinesis {
         arn: String,
@@ -402,7 +403,7 @@ pub enum Connector {
     },
 }
 
-impl AstDisplay for Connector {
+impl<T: AstInfo> AstDisplay for Connector<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
             Connector::File { path, compression } => {
@@ -414,7 +415,12 @@ impl AstDisplay for Connector {
                     f.write_node(compression);
                 }
             }
-            Connector::Kafka { broker, topic, key } => {
+            Connector::Kafka {
+                broker,
+                topic,
+                key,
+                consistency,
+            } => {
                 f.write_str("KAFKA BROKER '");
                 f.write_node(&display::escape_single_quote_string(broker));
                 f.write_str("'");
@@ -425,6 +431,9 @@ impl AstDisplay for Connector {
                     f.write_str(" KEY (");
                     f.write_node(&display::comma_separated(&key));
                     f.write_str(")");
+                }
+                if let Some(consistency) = consistency.as_ref() {
+                    f.write_node(consistency);
                 }
             }
             Connector::Kinesis { arn } => {
@@ -483,7 +492,27 @@ impl AstDisplay for Connector {
         }
     }
 }
-impl_display!(Connector);
+impl_display_t!(Connector);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct KafkaConsistency<T: AstInfo> {
+    pub topic: String,
+    pub topic_format: Option<Format<T>>,
+}
+
+impl<T: AstInfo> AstDisplay for KafkaConsistency<T> {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        f.write_str(" CONSISTENCY TOPIC '");
+        f.write_node(&display::escape_single_quote_string(&self.topic));
+        f.write_str("'");
+
+        if let Some(format) = self.topic_format.as_ref() {
+            f.write_str(" CONSISTENCY FORMAT ");
+            f.write_node(format);
+        }
+    }
+}
+impl_display_t!(KafkaConsistency);
 
 /// Information about upstream Postgres tables used for replication sources
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -354,7 +354,7 @@ impl_display!(CreateSchemaStatement);
 pub struct CreateSourceStatement<T: AstInfo> {
     pub name: UnresolvedObjectName,
     pub col_names: Vec<Ident>,
-    pub connector: Connector,
+    pub connector: Connector<T>,
     pub with_options: Vec<SqlOption<T>>,
     pub format: CreateSourceFormat<T>,
     pub key_envelope: CreateSourceKeyEnvelope,
@@ -414,7 +414,7 @@ impl_display_t!(CreateSourceStatement);
 pub struct CreateSinkStatement<T: AstInfo> {
     pub name: UnresolvedObjectName,
     pub from: UnresolvedObjectName,
-    pub connector: Connector,
+    pub connector: Connector<T>,
     pub with_options: Vec<SqlOption<T>>,
     pub format: Option<Format<T>>,
     pub envelope: Option<Envelope>,

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -60,6 +60,7 @@ Committed
 Compression
 Confluent
 Connection
+Consistency
 Constraint
 Copy
 Create

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -381,7 +381,7 @@ FORMAT BYTES
 ----
 CREATE SOURCE foo FROM KAFKA BROKER 'bar' TOPIC 'baz' WITH (consistency = 'lug', ssl_certificate_file = '/Path/to/file') FORMAT BYTES
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: Kafka { broker: "bar", topic: "baz", key: None }, with_options: [Value { name: Ident("consistency"), value: String("lug") }, Value { name: Ident("ssl_certificate_file"), value: String("/Path/to/file") }], format: Bare(Bytes), key_envelope: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: Kafka { broker: "bar", topic: "baz", key: None, consistency: None }, with_options: [Value { name: Ident("consistency"), value: String("lug") }, Value { name: Ident("ssl_certificate_file"), value: String("/Path/to/file") }], format: Bare(Bytes), key_envelope: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE MATERIALIZED SOURCE foo FROM FILE 'bar' FORMAT PROTOBUF MESSAGE
@@ -487,105 +487,105 @@ CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT 
 ----
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE KEY
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connector: Kafka { broker: "zubat", topic: "hoothoot", key: None }, with_options: [], format: KeyValue { key: Text, value: Text }, key_envelope: Included, envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connector: Kafka { broker: "zubat", topic: "hoothoot", key: None, consistency: None }, with_options: [], format: KeyValue { key: Text, value: Text }, key_envelope: Included, envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE KEY AS crobat ENVELOPE NONE
 ----
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE KEY AS crobat
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connector: Kafka { broker: "zubat", topic: "hoothoot", key: None }, with_options: [], format: KeyValue { key: Text, value: Text }, key_envelope: Named(Ident("crobat")), envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connector: Kafka { broker: "zubat", topic: "hoothoot", key: None, consistency: None }, with_options: [], format: KeyValue { key: Text, value: Text }, key_envelope: Named(Ident("crobat")), envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' VALUE FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' INCLUDE KEY ENVELOPE NONE
 ----
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' VALUE FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' INCLUDE KEY
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connector: Kafka { broker: "zubat", topic: "hoothoot", key: None }, with_options: [], format: KeyValue { key: Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [] }), value: Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [] }) }, key_envelope: Included, envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connector: Kafka { broker: "zubat", topic: "hoothoot", key: None, consistency: None }, with_options: [], format: KeyValue { key: Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [] }), value: Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [] }) }, key_envelope: Included, envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' ENVELOPE UPSERT
 ----
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' ENVELOPE UPSERT
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connector: Kafka { broker: "zubat", topic: "hoothoot", key: None }, with_options: [], format: Bare(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [] })), key_envelope: None, envelope: Upsert, if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connector: Kafka { broker: "zubat", topic: "hoothoot", key: None, consistency: None }, with_options: [], format: Bare(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [] })), key_envelope: None, envelope: Upsert, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USING SCHEMA 'string' ENVELOPE UPSERT FORMAT AVRO USING SCHEMA 'long'
 ----
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT AVRO USING SCHEMA 'long' VALUE FORMAT AVRO USING SCHEMA 'string' ENVELOPE UPSERT
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connector: Kafka { broker: "zubat", topic: "hoothoot", key: None }, with_options: [], format: KeyValue { key: Avro(Schema { schema: Inline("long"), with_options: [] }), value: Avro(Schema { schema: Inline("string"), with_options: [] }) }, key_envelope: None, envelope: Upsert, if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connector: Kafka { broker: "zubat", topic: "hoothoot", key: None, consistency: None }, with_options: [], format: KeyValue { key: Avro(Schema { schema: Inline("long"), with_options: [] }), value: Avro(Schema { schema: Inline("string"), with_options: [] }) }, key_envelope: None, envelope: Upsert, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USING SCHEMA 'string' WITH (confluent_wire_format = false) ENVELOPE NONE
 ----
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USING SCHEMA 'string' WITH (confluent_wire_format = false)
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connector: Kafka { broker: "zubat", topic: "hoothoot", key: None }, with_options: [], format: Bare(Avro(Schema { schema: Inline("string"), with_options: [WithOption { key: Ident("confluent_wire_format"), value: Some(Value(Boolean(false))) }] })), key_envelope: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connector: Kafka { broker: "zubat", topic: "hoothoot", key: None, consistency: None }, with_options: [], format: Bare(Avro(Schema { schema: Inline("string"), with_options: [WithOption { key: Ident("confluent_wire_format"), value: Some(Value(Boolean(false))) }] })), key_envelope: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT FORMAT TEXT
 ----
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connector: Kafka { broker: "zubat", topic: "hoothoot", key: None }, with_options: [], format: KeyValue { key: Text, value: Avro(Schema { schema: File("path"), with_options: [] }) }, key_envelope: None, envelope: Upsert, if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connector: Kafka { broker: "zubat", topic: "hoothoot", key: None, consistency: None }, with_options: [], format: KeyValue { key: Text, value: Avro(Schema { schema: File("path"), with_options: [] }) }, key_envelope: None, envelope: Upsert, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset=2) FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT FORMAT TEXT
 ----
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset = 2) KEY FORMAT TEXT VALUE FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka { broker: "broker", topic: "topic", key: None }, with_options: [Value { name: Ident("start_offset"), value: Number("2") }], format: KeyValue { key: Text, value: Avro(Schema { schema: File("path"), with_options: [] }) }, key_envelope: None, envelope: Upsert, if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka { broker: "broker", topic: "topic", key: None, consistency: None }, with_options: [Value { name: Ident("start_offset"), value: Number("2") }], format: KeyValue { key: Text, value: Avro(Schema { schema: File("path"), with_options: [] }) }, key_envelope: None, envelope: Upsert, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset=[]) FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT FORMAT TEXT
 ----
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset = []) KEY FORMAT TEXT VALUE FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka { broker: "broker", topic: "topic", key: None }, with_options: [Value { name: Ident("start_offset"), value: Array([]) }], format: KeyValue { key: Text, value: Avro(Schema { schema: File("path"), with_options: [] }) }, key_envelope: None, envelope: Upsert, if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka { broker: "broker", topic: "topic", key: None, consistency: None }, with_options: [Value { name: Ident("start_offset"), value: Array([]) }], format: KeyValue { key: Text, value: Avro(Schema { schema: File("path"), with_options: [] }) }, key_envelope: None, envelope: Upsert, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset=[2]) FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT FORMAT TEXT
 ----
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset = [2]) KEY FORMAT TEXT VALUE FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka { broker: "broker", topic: "topic", key: None }, with_options: [Value { name: Ident("start_offset"), value: Array([Number("2")]) }], format: KeyValue { key: Text, value: Avro(Schema { schema: File("path"), with_options: [] }) }, key_envelope: None, envelope: Upsert, if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka { broker: "broker", topic: "topic", key: None, consistency: None }, with_options: [Value { name: Ident("start_offset"), value: Array([Number("2")]) }], format: KeyValue { key: Text, value: Avro(Schema { schema: File("path"), with_options: [] }) }, key_envelope: None, envelope: Upsert, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset=[2, 40000000]) FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT FORMAT TEXT
 ----
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset = [2, 40000000]) KEY FORMAT TEXT VALUE FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka { broker: "broker", topic: "topic", key: None }, with_options: [Value { name: Ident("start_offset"), value: Array([Number("2"), Number("40000000")]) }], format: KeyValue { key: Text, value: Avro(Schema { schema: File("path"), with_options: [] }) }, key_envelope: None, envelope: Upsert, if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka { broker: "broker", topic: "topic", key: None, consistency: None }, with_options: [Value { name: Ident("start_offset"), value: Array([Number("2"), Number("40000000")]) }], format: KeyValue { key: Text, value: Avro(Schema { schema: File("path"), with_options: [] }) }, key_envelope: None, envelope: Upsert, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE source (a, b, PRIMARY KEY (a) NOT ENFORCED) FROM KAFKA BROKER 'broker' TOPIC 'topic'
 ----
 CREATE SOURCE source (a, b, PRIMARY KEY (a) NOT ENFORCED) FROM KAFKA BROKER 'broker' TOPIC 'topic'
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [Ident("a"), Ident("b")], connector: Kafka { broker: "broker", topic: "topic", key: None }, with_options: [], format: None, key_envelope: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: Some(PrimaryKeyNotEnforced { columns: [Ident("a")] }) })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [Ident("a"), Ident("b")], connector: Kafka { broker: "broker", topic: "topic", key: None, consistency: None }, with_options: [], format: None, key_envelope: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: Some(PrimaryKeyNotEnforced { columns: [Ident("a")] }) })
 
 parse-statement
 CREATE SOURCE source (a, PRIMARY KEY (a) NOT ENFORCED, b) FROM KAFKA BROKER 'broker' TOPIC 'topic'
 ----
 CREATE SOURCE source (a, b, PRIMARY KEY (a) NOT ENFORCED) FROM KAFKA BROKER 'broker' TOPIC 'topic'
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [Ident("a"), Ident("b")], connector: Kafka { broker: "broker", topic: "topic", key: None }, with_options: [], format: None, key_envelope: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: Some(PrimaryKeyNotEnforced { columns: [Ident("a")] }) })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [Ident("a"), Ident("b")], connector: Kafka { broker: "broker", topic: "topic", key: None, consistency: None }, with_options: [], format: None, key_envelope: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: Some(PrimaryKeyNotEnforced { columns: [Ident("a")] }) })
 
 parse-statement
 CREATE SOURCE source (PRIMARY KEY (a) NOT ENFORCED) FROM KAFKA BROKER 'broker' TOPIC 'topic'
 ----
 CREATE SOURCE source (PRIMARY KEY (a) NOT ENFORCED) FROM KAFKA BROKER 'broker' TOPIC 'topic'
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka { broker: "broker", topic: "topic", key: None }, with_options: [], format: None, key_envelope: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: Some(PrimaryKeyNotEnforced { columns: [Ident("a")] }) })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka { broker: "broker", topic: "topic", key: None, consistency: None }, with_options: [], format: None, key_envelope: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: Some(PrimaryKeyNotEnforced { columns: [Ident("a")] }) })
 
 parse-statement
 CREATE SOURCE source (PRIMARY, PRIMARY KEY (a) NOT ENFORCED) FROM KAFKA BROKER 'broker' TOPIC 'topic'
 ----
 CREATE SOURCE source (primary, PRIMARY KEY (a) NOT ENFORCED) FROM KAFKA BROKER 'broker' TOPIC 'topic'
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [Ident("primary")], connector: Kafka { broker: "broker", topic: "topic", key: None }, with_options: [], format: None, key_envelope: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: Some(PrimaryKeyNotEnforced { columns: [Ident("a")] }) })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [Ident("primary")], connector: Kafka { broker: "broker", topic: "topic", key: None, consistency: None }, with_options: [], format: None, key_envelope: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: Some(PrimaryKeyNotEnforced { columns: [Ident("a")] }) })
 
 parse-statement
 CREATE SOURCE source PRIMARY KEY (a) NOT ENFORCED FROM KAFKA BROKER 'broker' TOPIC 'topic'
@@ -655,14 +655,21 @@ CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' WITH (replication
 ----
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' WITH (replication_factor = 7) FORMAT BYTES WITH SNAPSHOT
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), from: UnresolvedObjectName([Ident("bar")]), connector: Kafka { broker: "baz", topic: "topic", key: None }, with_options: [Value { name: Ident("replication_factor"), value: Number("7") }], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), from: UnresolvedObjectName([Ident("bar")]), connector: Kafka { broker: "baz", topic: "topic", key: None, consistency: None }, with_options: [Value { name: Ident("replication_factor"), value: Number("7") }], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
 
 parse-statement
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) FORMAT BYTES
 ----
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) FORMAT BYTES WITH SNAPSHOT
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), from: UnresolvedObjectName([Ident("bar")]), connector: Kafka { broker: "baz", topic: "topic", key: Some([Ident("a"), Ident("b")]) }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), from: UnresolvedObjectName([Ident("bar")]), connector: Kafka { broker: "baz", topic: "topic", key: Some([Ident("a"), Ident("b")]), consistency: None }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
+
+parse-statement
+CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) CONSISTENCY TOPIC 'consistency' CONSISTENCY FORMAT BYTES FORMAT BYTES
+----
+CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) CONSISTENCY TOPIC 'consistency' CONSISTENCY FORMAT BYTES FORMAT BYTES WITH SNAPSHOT
+=>
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), from: UnresolvedObjectName([Ident("bar")]), connector: Kafka { broker: "baz", topic: "topic", key: Some([Ident("a"), Ident("b")]), consistency: Some(KafkaConsistency { topic: "consistency", topic_format: Some(Bytes) }) }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
 
 parse-statement
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY FORMAT BYTES

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -50,8 +50,8 @@ use crate::ast::{
     CreateSourceKeyEnvelope, CreateSourceStatement, CreateTableStatement, CreateTypeAs,
     CreateTypeStatement, CreateViewStatement, CreateViewsDefinitions, CreateViewsStatement,
     DataType, DbzMode, DropDatabaseStatement, DropObjectsStatement, Envelope, Expr, Format, Ident,
-    IfExistsBehavior, ObjectType, Raw, SqlOption, Statement, UnresolvedObjectName, Value,
-    ViewDefinition, WithOption,
+    IfExistsBehavior, KafkaConsistency, ObjectType, Raw, SqlOption, Statement,
+    UnresolvedObjectName, Value, ViewDefinition, WithOption,
 };
 use crate::catalog::{CatalogItem, CatalogItemType};
 use crate::kafka_util;
@@ -1245,6 +1245,7 @@ pub fn plan_create_views(
 #[allow(clippy::too_many_arguments)]
 fn kafka_sink_builder(
     format: Option<Format<Raw>>,
+    _consistency: Option<KafkaConsistency<Raw>>,
     with_options: &mut BTreeMap<String, Value>,
     broker: String,
     topic_prefix: String,
@@ -1539,8 +1540,14 @@ pub fn plan_create_sink(
 
     let connector_builder = match connector {
         Connector::File { .. } => unsupported!("file sinks"),
-        Connector::Kafka { broker, topic, .. } => kafka_sink_builder(
+        Connector::Kafka {
+            broker,
+            topic,
+            consistency,
+            ..
+        } => kafka_sink_builder(
             format,
+            consistency,
             &mut with_options,
             broker,
             topic,

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -349,7 +349,7 @@ pub fn purify(
 
 async fn purify_format(
     format: &mut CreateSourceFormat<Raw>,
-    connector: &mut Connector,
+    connector: &mut Connector<Raw>,
     envelope: &Envelope,
     col_names: &mut Vec<Ident>,
     file: Option<File>,
@@ -412,7 +412,7 @@ async fn purify_format(
 
 async fn purify_format_single(
     format: &mut Format<Raw>,
-    connector: &mut Connector,
+    connector: &mut Connector<Raw>,
     envelope: &Envelope,
     col_names: &mut Vec<Ident>,
     file: Option<File>,


### PR DESCRIPTION
A redo of #7592! 

This change updates the `CREATE SINK` syntax to accept new `CONSISTENCY TOPIC` and `CONSISTENCY FORMAT` parameters. This change is needed to expand our sink formats.

The new Kafka connector syntax looks like:
<img width="1086" alt="Screen Shot 2021-07-28 at 9 26 22 PM" src="https://user-images.githubusercontent.com/5766027/127431587-f40b4893-dd90-4a0c-a6c9-d9bf32ebf679.png">

It is definitely repetitive! I repeat `CONSISTENCY` for `FORMAT` to disambiguate from the general topic's `FORMAT`, which is parsed next.