### PR TITLE
sql-parser: add consistency information to CreateSink

### DIFF
--- a/doc/user/layouts/partials/sql-grammar/create-sink.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-sink.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="555" height="391">
+<svg xmlns="http://www.w3.org/2000/svg" width="939" height="517">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="112" height="32" rx="10"/>
@@ -28,84 +28,130 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="455" y="21">FROM</text>
-   <rect x="70" y="101" width="88" height="32"/>
-   <rect x="68" y="99" width="88" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="78" y="119">item_name</text>
-   <rect x="178" y="101" width="52" height="32" rx="10"/>
-   <rect x="176"
+   <rect x="262" y="101" width="88" height="32"/>
+   <rect x="260" y="99" width="88" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="270" y="119">item_name</text>
+   <rect x="370" y="101" width="52" height="32" rx="10"/>
+   <rect x="368"
          y="99"
          width="52"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="186" y="119">INTO</text>
-   <rect x="270" y="101" width="154" height="32"/>
-   <rect x="268" y="99" width="154" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="278" y="119">sink_kafka_connector</text>
-   <rect x="270" y="145" width="92" height="32" rx="10"/>
-   <rect x="268"
+   <text class="terminal" x="378" y="119">INTO</text>
+   <rect x="462" y="101" width="154" height="32"/>
+   <rect x="460" y="99" width="154" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="470" y="119">sink_kafka_connector</text>
+   <rect x="462" y="145" width="92" height="32" rx="10"/>
+   <rect x="460"
          y="143"
          width="92"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="278" y="163">AVRO OCF</text>
-   <rect x="382" y="145" width="86" height="32"/>
-   <rect x="380" y="143" width="86" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="390" y="163">path-prefix</text>
-   <rect x="45" y="227" width="92" height="32" rx="10"/>
-   <rect x="43"
+   <text class="terminal" x="470" y="163">AVRO OCF</text>
+   <rect x="574" y="145" width="86" height="32"/>
+   <rect x="572" y="143" width="86" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="582" y="163">path-prefix</text>
+   <rect x="349" y="227" width="92" height="32" rx="10"/>
+   <rect x="347"
          y="225"
          width="92"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="53" y="245">ENVELOPE</text>
-   <rect x="177" y="227" width="92" height="32" rx="10"/>
-   <rect x="175"
+   <text class="terminal" x="357" y="245">ENVELOPE</text>
+   <rect x="481" y="227" width="92" height="32" rx="10"/>
+   <rect x="479"
          y="225"
          width="92"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="185" y="245">DEBEZIUM</text>
-   <rect x="177" y="271" width="74" height="32" rx="10"/>
-   <rect x="175"
+   <text class="terminal" x="489" y="245">DEBEZIUM</text>
+   <rect x="481" y="271" width="74" height="32" rx="10"/>
+   <rect x="479"
          y="269"
          width="74"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="185" y="289">UPSERT</text>
-   <rect x="349" y="227" width="136" height="32" rx="10"/>
-   <rect x="347"
-         y="225"
+   <text class="terminal" x="489" y="289">UPSERT</text>
+   <rect x="45" y="353" width="160" height="32" rx="10"/>
+   <rect x="43"
+         y="351"
+         width="160"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="371">WITH CONSISTENCY</text>
+   <rect x="225" y="353" width="62" height="32" rx="10"/>
+   <rect x="223"
+         y="351"
+         width="62"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="233" y="371">TOPIC</text>
+   <rect x="307" y="353" width="50" height="32"/>
+   <rect x="305" y="351" width="50" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="315" y="371">topic</text>
+   <rect x="377" y="353" width="78" height="32" rx="10"/>
+   <rect x="375"
+         y="351"
+         width="78"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="385" y="371">FORMAT</text>
+   <rect x="475" y="353" width="106" height="32" rx="10"/>
+   <rect x="473"
+         y="351"
+         width="106"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="483" y="371">AVRO USING</text>
+   <rect x="601" y="353" width="240" height="32" rx="10"/>
+   <rect x="599"
+         y="351"
+         width="240"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="609" y="371">CONFLUENT SCHEMA REGISTRY</text>
+   <rect x="861" y="353" width="36" height="32"/>
+   <rect x="859" y="351" width="36" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="869" y="371">url</text>
+   <rect x="429" y="439" width="136" height="32" rx="10"/>
+   <rect x="427"
+         y="437"
          width="136"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="357" y="245">WITH SNAPSHOT</text>
-   <rect x="349" y="271" width="164" height="32" rx="10"/>
-   <rect x="347"
-         y="269"
+   <text class="terminal" x="437" y="457">WITH SNAPSHOT</text>
+   <rect x="429" y="483" width="164" height="32" rx="10"/>
+   <rect x="427"
+         y="481"
          width="164"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="357" y="289">WITHOUT SNAPSHOT</text>
-   <rect x="269" y="357" width="60" height="32" rx="10"/>
-   <rect x="267"
-         y="355"
+   <text class="terminal" x="437" y="501">WITHOUT SNAPSHOT</text>
+   <rect x="653" y="439" width="60" height="32" rx="10"/>
+   <rect x="651"
+         y="437"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="277" y="375">AS OF</text>
-   <rect x="349" y="357" width="158" height="32"/>
-   <rect x="347" y="355" width="158" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="357" y="375">timestamp_expression</text>
+   <text class="terminal" x="661" y="457">AS OF</text>
+   <rect x="733" y="439" width="158" height="32"/>
+   <rect x="731" y="437" width="158" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="741" y="457">timestamp_expression</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m112 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m20 -32 h10 m86 0 h10 m0 0 h10 m60 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-481 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m88 0 h10 m0 0 h10 m52 0 h10 m20 0 h10 m154 0 h10 m0 0 h44 m-238 0 h20 m218 0 h20 m-258 0 q10 0 10 10 m238 0 q0 -10 10 -10 m-248 10 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m92 0 h10 m0 0 h10 m86 0 h10 m22 -44 l2 0 m2 0 l2 0 m2 0 l2 0 m-507 94 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h254 m-284 0 h20 m264 0 h20 m-304 0 q10 0 10 10 m284 0 q0 -10 10 -10 m-294 10 v12 m284 0 v-12 m-284 12 q0 10 10 10 m264 0 q10 0 10 -10 m-274 10 h10 m92 0 h10 m20 0 h10 m92 0 h10 m-132 0 h20 m112 0 h20 m-152 0 q10 0 10 10 m132 0 q0 -10 10 -10 m-142 10 v24 m132 0 v-24 m-132 24 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m74 0 h10 m0 0 h18 m60 -76 h10 m0 0 h174 m-204 0 h20 m184 0 h20 m-224 0 q10 0 10 10 m204 0 q0 -10 10 -10 m-214 10 v12 m204 0 v-12 m-204 12 q0 10 10 10 m184 0 q10 0 10 -10 m-194 10 h10 m136 0 h10 m0 0 h28 m-194 -10 v20 m204 0 v-20 m-204 20 v24 m204 0 v-24 m-204 24 q0 10 10 10 m184 0 q10 0 10 -10 m-194 10 h10 m164 0 h10 m22 -76 l2 0 m2 0 l2 0 m2 0 l2 0 m-328 130 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h248 m-278 0 h20 m258 0 h20 m-298 0 q10 0 10 10 m278 0 q0 -10 10 -10 m-288 10 v12 m278 0 v-12 m-278 12 q0 10 10 10 m258 0 q10 0 10 -10 m-268 10 h10 m60 0 h10 m0 0 h10 m158 0 h10 m23 -32 h-3"/>
-   <polygon points="545 339 553 335 553 343"/>
-   <polygon points="545 339 537 335 537 343"/>
+         d="m17 17 h2 m0 0 h10 m112 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m20 -32 h10 m86 0 h10 m0 0 h10 m60 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-289 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m88 0 h10 m0 0 h10 m52 0 h10 m20 0 h10 m154 0 h10 m0 0 h44 m-238 0 h20 m218 0 h20 m-258 0 q10 0 10 10 m238 0 q0 -10 10 -10 m-248 10 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m92 0 h10 m0 0 h10 m86 0 h10 m22 -44 l2 0 m2 0 l2 0 m2 0 l2 0 m-395 94 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h254 m-284 0 h20 m264 0 h20 m-304 0 q10 0 10 10 m284 0 q0 -10 10 -10 m-294 10 v12 m284 0 v-12 m-284 12 q0 10 10 10 m264 0 q10 0 10 -10 m-274 10 h10 m92 0 h10 m20 0 h10 m92 0 h10 m-132 0 h20 m112 0 h20 m-152 0 q10 0 10 10 m132 0 q0 -10 10 -10 m-142 10 v24 m132 0 v-24 m-132 24 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m74 0 h10 m0 0 h18 m42 -76 l2 0 m2 0 l2 0 m2 0 l2 0 m-632 126 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h862 m-892 0 h20 m872 0 h20 m-912 0 q10 0 10 10 m892 0 q0 -10 10 -10 m-902 10 v12 m892 0 v-12 m-892 12 q0 10 10 10 m872 0 q10 0 10 -10 m-882 10 h10 m160 0 h10 m0 0 h10 m62 0 h10 m0 0 h10 m50 0 h10 m0 0 h10 m78 0 h10 m0 0 h10 m106 0 h10 m0 0 h10 m240 0 h10 m0 0 h10 m36 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-552 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h174 m-204 0 h20 m184 0 h20 m-224 0 q10 0 10 10 m204 0 q0 -10 10 -10 m-214 10 v12 m204 0 v-12 m-204 12 q0 10 10 10 m184 0 q10 0 10 -10 m-194 10 h10 m136 0 h10 m0 0 h28 m-194 -10 v20 m204 0 v-20 m-204 20 v24 m204 0 v-24 m-204 24 q0 10 10 10 m184 0 q10 0 10 -10 m-194 10 h10 m164 0 h10 m40 -76 h10 m0 0 h248 m-278 0 h20 m258 0 h20 m-298 0 q10 0 10 10 m278 0 q0 -10 10 -10 m-288 10 v12 m278 0 v-12 m-278 12 q0 10 10 10 m258 0 q10 0 10 -10 m-268 10 h10 m60 0 h10 m0 0 h10 m158 0 h10 m23 -32 h-3"/>
+   <polygon points="929 421 937 417 937 425"/>
+   <polygon points="929 421 921 417 921 425"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -36,16 +36,17 @@ create_role ::=
     'CREATE' 'ROLE' role_name ('LOGIN' | 'NOLOGIN' | 'SUPERUSER' | 'NOSUPERUSER')*
 create_schema ::=
     'CREATE' 'SCHEMA' ('IF NOT EXISTS')? schema_name
-    create_sink ::=
-       'CREATE SINK' 'IF NOT EXISTS'? sink_name
-       'FROM' item_name
-       'INTO' (
-        sink_kafka_connector |
-       'AVRO OCF' path-prefix
-       )
-       ('ENVELOPE' ('DEBEZIUM'|'UPSERT'))?
-       ('WITH SNAPSHOT' | 'WITHOUT SNAPSHOT')?
-       ('AS OF' timestamp_expression)?
+create_sink ::=
+    'CREATE SINK' 'IF NOT EXISTS'? sink_name
+    'FROM' item_name
+    'INTO' (
+    sink_kafka_connector |
+    'AVRO OCF' path-prefix
+    )
+    ('ENVELOPE' ('DEBEZIUM'|'UPSERT'))?
+    ('WITH CONSISTENCY' 'TOPIC' topic 'FORMAT' 'AVRO USING' 'CONFLUENT SCHEMA REGISTRY' url)?
+    ('WITH SNAPSHOT' | 'WITHOUT SNAPSHOT')?
+    ('AS OF' timestamp_expression)?
 create_source_avro_file ::=
   'CREATE' 'MATERIALIZED'? 'SOURCE' ('IF NOT EXISTS')? src_name
   ('(' (col_name) ( ( ',' col_name ) )* ( ',' key_constraint )? ')')?

--- a/src/coord/src/catalog/migrate.rs
+++ b/src/coord/src/catalog/migrate.rs
@@ -235,6 +235,7 @@ pub const CONTENT_MIGRATIONS: &[fn(&mut Catalog) -> Result<(), anyhow::Error>] =
                     with_options: _,
                     format: _,
                     envelope: _,
+                    consistency: _,
                     with_snapshot: _,
                     as_of,
                     if_not_exists: _,

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -203,6 +203,30 @@ impl<T: AstInfo> Format<T> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ConsistencyInfo<T: AstInfo> {
+    Kafka {
+        topic: String,
+        format: Option<Format<T>>,
+    },
+}
+
+impl<T: AstInfo> AstDisplay for ConsistencyInfo<T> {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        match self {
+            ConsistencyInfo::Kafka { topic, format } => {
+                f.write_str(" TOPIC '");
+                f.write_node(&display::escape_single_quote_string(topic));
+                f.write_str("'");
+                if let Some(format) = &format {
+                    f.write_str(" FORMAT ");
+                    f.write_node(format);
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum CreateSourceKeyEnvelope {
     /// `INCLUDE KEY` is absent
     None,

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -22,8 +22,9 @@ use std::fmt;
 
 use crate::ast::display::{self, AstDisplay, AstFormatter};
 use crate::ast::{
-    AstInfo, ColumnDef, Connector, CreateSourceFormat, CreateSourceKeyEnvelope, DataType, Envelope,
-    Expr, Format, Ident, KeyConstraint, Query, TableConstraint, UnresolvedObjectName, Value,
+    AstInfo, ColumnDef, Connector, ConsistencyInfo, CreateSourceFormat, CreateSourceKeyEnvelope,
+    DataType, Envelope, Expr, Format, Ident, KeyConstraint, Query, TableConstraint,
+    UnresolvedObjectName, Value,
 };
 
 /// A top-level statement (SELECT, INSERT, CREATE, etc.)
@@ -418,6 +419,7 @@ pub struct CreateSinkStatement<T: AstInfo> {
     pub with_options: Vec<SqlOption<T>>,
     pub format: Option<Format<T>>,
     pub envelope: Option<Envelope>,
+    pub consistency: Option<ConsistencyInfo<T>>,
     pub with_snapshot: bool,
     pub as_of: Option<Expr<T>>,
     pub if_not_exists: bool,
@@ -446,6 +448,10 @@ impl<T: AstInfo> AstDisplay for CreateSinkStatement<T> {
         if let Some(envelope) = &self.envelope {
             f.write_str(" ENVELOPE ");
             f.write_node(envelope);
+        }
+        if let Some(consistency) = &self.consistency {
+            f.write_str(" WITH CONSISTENCY");
+            f.write_node(consistency);
         }
         if self.with_snapshot {
             f.write_str(" WITH SNAPSHOT");

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -60,6 +60,7 @@ Committed
 Compression
 Confluent
 Connection
+Consistency
 Constraint
 Copy
 Create

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -641,28 +641,28 @@ CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT BYTES
 ----
 CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT BYTES WITH SNAPSHOT
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), from: UnresolvedObjectName([Ident("bar")]), connector: File { path: "baz", compression: None }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), from: UnresolvedObjectName([Ident("bar")]), connector: File { path: "baz", compression: None }, with_options: [], format: Some(Bytes), envelope: None, consistency: None, with_snapshot: true, as_of: None, if_not_exists: false })
 
 parse-statement
 CREATE SINK foo FROM bar INTO FILE 'baz' WITH SNAPSHOT FORMAT BYTES
 ----
 CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT BYTES WITH SNAPSHOT
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), from: UnresolvedObjectName([Ident("bar")]), connector: File { path: "baz", compression: None }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), from: UnresolvedObjectName([Ident("bar")]), connector: File { path: "baz", compression: None }, with_options: [], format: Some(Bytes), envelope: None, consistency: None, with_snapshot: true, as_of: None, if_not_exists: false })
 
 parse-statement
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' WITH (replication_factor = 7) FORMAT BYTES
 ----
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' WITH (replication_factor = 7) FORMAT BYTES WITH SNAPSHOT
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), from: UnresolvedObjectName([Ident("bar")]), connector: Kafka { broker: "baz", topic: "topic", key: None }, with_options: [Value { name: Ident("replication_factor"), value: Number("7") }], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), from: UnresolvedObjectName([Ident("bar")]), connector: Kafka { broker: "baz", topic: "topic", key: None }, with_options: [Value { name: Ident("replication_factor"), value: Number("7") }], format: Some(Bytes), envelope: None, consistency: None, with_snapshot: true, as_of: None, if_not_exists: false })
 
 parse-statement
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) FORMAT BYTES
 ----
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) FORMAT BYTES WITH SNAPSHOT
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), from: UnresolvedObjectName([Ident("bar")]), connector: Kafka { broker: "baz", topic: "topic", key: Some([Ident("a"), Ident("b")]) }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), from: UnresolvedObjectName([Ident("bar")]), connector: Kafka { broker: "baz", topic: "topic", key: Some([Ident("a"), Ident("b")]) }, with_options: [], format: Some(Bytes), envelope: None, consistency: None, with_snapshot: true, as_of: None, if_not_exists: false })
 
 parse-statement
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY FORMAT BYTES
@@ -676,49 +676,56 @@ CREATE SINK foo FROM bar INTO AVRO OCF 'baz'
 ----
 CREATE SINK foo FROM bar INTO AVRO OCF 'baz' WITH SNAPSHOT
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), from: UnresolvedObjectName([Ident("bar")]), connector: AvroOcf { path: "baz" }, with_options: [], format: None, envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), from: UnresolvedObjectName([Ident("bar")]), connector: AvroOcf { path: "baz" }, with_options: [], format: None, envelope: None, consistency: None, with_snapshot: true, as_of: None, if_not_exists: false })
 
 parse-statement
 CREATE SINK IF NOT EXISTS foo FROM bar INTO FILE 'baz' FORMAT BYTES
 ----
 CREATE SINK IF NOT EXISTS foo FROM bar INTO FILE 'baz' FORMAT BYTES WITH SNAPSHOT
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), from: UnresolvedObjectName([Ident("bar")]), connector: File { path: "baz", compression: None }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: true })
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), from: UnresolvedObjectName([Ident("bar")]), connector: File { path: "baz", compression: None }, with_options: [], format: Some(Bytes), envelope: None, consistency: None, with_snapshot: true, as_of: None, if_not_exists: true })
 
 parse-statement
 CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT BYTES AS OF 123
 ----
 CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT BYTES WITH SNAPSHOT AS OF 123
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), from: UnresolvedObjectName([Ident("bar")]), connector: File { path: "baz", compression: None }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: Some(Value(Number("123"))), if_not_exists: false })
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), from: UnresolvedObjectName([Ident("bar")]), connector: File { path: "baz", compression: None }, with_options: [], format: Some(Bytes), envelope: None, consistency: None, with_snapshot: true, as_of: Some(Value(Number("123"))), if_not_exists: false })
 
 parse-statement
 CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT BYTES WITHOUT SNAPSHOT AS OF 123
 ----
 CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT BYTES WITHOUT SNAPSHOT AS OF 123
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), from: UnresolvedObjectName([Ident("bar")]), connector: File { path: "baz", compression: None }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: false, as_of: Some(Value(Number("123"))), if_not_exists: false })
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), from: UnresolvedObjectName([Ident("bar")]), connector: File { path: "baz", compression: None }, with_options: [], format: Some(Bytes), envelope: None, consistency: None, with_snapshot: false, as_of: Some(Value(Number("123"))), if_not_exists: false })
 
 parse-statement
 CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT BYTES AS OF now()
 ----
 CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT BYTES WITH SNAPSHOT AS OF now()
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), from: UnresolvedObjectName([Ident("bar")]), connector: File { path: "baz", compression: None }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: Some(Function(Function { name: UnresolvedObjectName([Ident("now")]), args: Args([]), filter: None, over: None, distinct: false })), if_not_exists: false })
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), from: UnresolvedObjectName([Ident("bar")]), connector: File { path: "baz", compression: None }, with_options: [], format: Some(Bytes), envelope: None, consistency: None, with_snapshot: true, as_of: Some(Function(Function { name: UnresolvedObjectName([Ident("now")]), args: Args([]), filter: None, over: None, distinct: false })), if_not_exists: false })
 
 parse-statement
 CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH SNAPSHOT
 ----
 CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH SNAPSHOT
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), from: UnresolvedObjectName([Ident("bar")]), connector: File { path: "baz", compression: None }, with_options: [], format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [] })), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), from: UnresolvedObjectName([Ident("bar")]), connector: File { path: "baz", compression: None }, with_options: [], format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [] })), envelope: None, consistency: None, with_snapshot: true, as_of: None, if_not_exists: false })
 
 parse-statement
 CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (a = 'b') WITH SNAPSHOT
 ----
 CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (a = 'b') WITH SNAPSHOT
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), from: UnresolvedObjectName([Ident("bar")]), connector: File { path: "baz", compression: None }, with_options: [], format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [Value { name: Ident("a"), value: String("b") }] })), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), from: UnresolvedObjectName([Ident("bar")]), connector: File { path: "baz", compression: None }, with_options: [], format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [Value { name: Ident("a"), value: String("b") }] })), envelope: None, consistency: None, with_snapshot: true, as_of: None, if_not_exists: false })
+
+parse-statement
+CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (a = 'b') WITH CONSISTENCY TOPIC 'topic' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH SNAPSHOT
+----
+CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (a = 'b') WITH CONSISTENCY TOPIC 'topic' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH SNAPSHOT
+=>
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), from: UnresolvedObjectName([Ident("bar")]), connector: File { path: "baz", compression: None }, with_options: [], format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [Value { name: Ident("a"), value: String("b") }] })), envelope: None, consistency: Some(Kafka { topic: "topic", format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [] })) }), with_snapshot: true, as_of: None, if_not_exists: false })
 
 parse-statement
 CREATE SINK IF EXISTS foo FROM bar INTO 'baz'

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -301,6 +301,7 @@ pub fn create_statement(
             with_options: _,
             format: _,
             envelope: _,
+            consistency: _,
             with_snapshot: _,
             as_of: _,
             if_not_exists,


### PR DESCRIPTION
We're in the process of [adding additional format options for sinks](https://github.com/MaterializeInc/materialize/pull/7545). In order to complete that work, we need to allow users to specify the desired format of their sinks' consistency topics.

This PR updates the `CREATE SINK` syntax to take a new, optional `WITH CONSISTENCY` argument. We can continue to support the old `consistency_topic` with option, maintaining backwards compatibility. The new syntax looks like:
<img width="1024" alt="Screen Shot 2021-07-28 at 3 14 28 PM" src="https://user-images.githubusercontent.com/5766027/127403862-b665db6a-8fa9-4769-b6e0-4cbaa173043a.png">

Note: this approach is not what was discussed on Slack! I prefer this change because it keeps the consistency information tied to the `CreateSink` object, rather than the `KafkaConnector` object that is also used for sources. However, I'm happy [to switch](https://github.com/MaterializeInc/materialize/pull/7589) if others feel differently!