### PR TITLE
*: remove some unused async

### DIFF
--- a/src/aws-util/src/client.rs
+++ b/src/aws-util/src/client.rs
@@ -57,7 +57,7 @@ wrapped in an [`AutoRefreshingProvider`].
 The [`AutoRefreshingProvider`] caches the underlying provider's AWS credentials,
 automatically fetching updated credentials if they've expired.
 "]
-pub async fn $name(conn_info: ConnectInfo) -> Result<$client, anyhow::Error> {
+pub fn $name(conn_info: ConnectInfo) -> Result<$client, anyhow::Error> {
     let request_dispatcher = http().context(
         concat!("creating HTTP client for ", $client_name))?;
     let the_client = if let Some(creds) = conn_info.credentials {

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -55,6 +55,7 @@ use futures::stream::{self, StreamExt};
 use itertools::Itertools;
 use lazy_static::lazy_static;
 use ore::metrics::MetricsRegistry;
+use ore::retry::Retry;
 use rand::Rng;
 use repr::adt::numeric;
 use timely::communication::WorkerGuards;
@@ -2956,8 +2957,21 @@ impl Coordinator {
         if !indexes_to_drop.is_empty() {
             self.drop_indexes(indexes_to_drop);
         }
-        for (conn, slot_names) in replication_slots_to_drop {
-            postgres_util::drop_replication_slots(&conn, &slot_names).await?;
+
+        // We don't want to block the coordinator on an external postgres server, so
+        // move the drop slots to a separate task. This does mean that a failed drop
+        // slot won't bubble up to the user as an error message. However, even if it
+        // did (and how the code previously worked), mz has already dropped it from our
+        // catalog, and so we wouldn't be able to retry anyway.
+        if !replication_slots_to_drop.is_empty() {
+            tokio::spawn(async move {
+                for (conn, slot_names) in replication_slots_to_drop {
+                    // Try to drop the replication slots, but give up after a while.
+                    let _ = Retry::default()
+                        .retry(|_state| postgres_util::drop_replication_slots(&conn, &slot_names))
+                        .await;
+                }
+            });
         }
 
         Ok(())

--- a/src/coord/src/sink_connector.rs
+++ b/src/coord/src/sink_connector.rs
@@ -65,7 +65,7 @@ fn get_next_message(
 }
 
 // Retrieves the latest committed timestamp from the consistency topic
-async fn get_latest_ts(
+fn get_latest_ts(
     consistency_topic: &str,
     consumer: &mut BaseConsumer,
     timeout: Duration,
@@ -434,7 +434,6 @@ async fn build_kafka(
                 .context("creating consumer client failed")?;
 
             get_latest_ts(&consistency_topic, &mut consumer, Duration::from_secs(5))
-                .await
                 .context("error restarting from existing kafka consistency topic for sink")?
         } else {
             None

--- a/src/dataflow/src/source/kinesis.rs
+++ b/src/dataflow/src/source/kinesis.rs
@@ -231,7 +231,7 @@ async fn create_state(
     ),
     anyhow::Error,
 > {
-    let kinesis_client = aws_util::client::kinesis(c.aws_info).await?;
+    let kinesis_client = aws_util::client::kinesis(c.aws_info)?;
 
     let shard_set: HashSet<String> = get_shard_ids(&kinesis_client, &c.stream_name).await?;
     let mut shard_queue: VecDeque<(String, Option<String>)> = VecDeque::new();

--- a/src/dataflow/src/source/s3.rs
+++ b/src/dataflow/src/source/s3.rs
@@ -104,7 +104,7 @@ async fn download_objects_task(
     compression: Compression,
     metrics: SourceBaseMetrics,
 ) {
-    let client = match aws_util::client::s3(aws_info).await {
+    let client = match aws_util::client::s3(aws_info) {
         Ok(client) => client,
         Err(e) => {
             tx.send(Err(S3Error::ClientConstructionFailed(e)))
@@ -224,7 +224,7 @@ async fn scan_bucket_task(
     tx: tokio_mpsc::Sender<S3Result<KeyInfo>>,
     base_metrics: SourceBaseMetrics,
 ) {
-    let client = match aws_util::client::s3(aws_info).await {
+    let client = match aws_util::client::s3(aws_info) {
         Ok(client) => client,
         Err(e) => {
             tx.send(Err(S3Error::ClientConstructionFailed(e)))
@@ -355,7 +355,7 @@ async fn read_sqs_task(
         source_id
     );
 
-    let client = match aws_util::client::sqs(aws_info).await {
+    let client = match aws_util::client::sqs(aws_info) {
         Ok(client) => client,
         Err(e) => {
             tx.send(Err(S3Error::ClientConstructionFailed(e)))

--- a/src/materialized/src/http.rs
+++ b/src/materialized/src/http.rs
@@ -174,36 +174,28 @@ impl Server {
 
                 let res = match (req.method(), req.uri().path()) {
                     (&Method::GET, "/") => root::handle_home(req, &mut coord_client).await,
-                    (&Method::GET, "/metrics") => {
-                        metrics::handle_prometheus(
-                            req,
-                            &mut coord_client,
-                            start_time,
-                            &metrics_registry,
-                            &global_metrics,
-                        )
-                        .await
-                    }
-                    (&Method::GET, "/status") => {
-                        metrics::handle_status(
-                            req,
-                            &mut coord_client,
-                            start_time,
-                            &metrics_registry,
-                            &global_metrics,
-                        )
-                        .await
-                    }
+                    (&Method::GET, "/metrics") => metrics::handle_prometheus(
+                        req,
+                        &mut coord_client,
+                        start_time,
+                        &metrics_registry,
+                        &global_metrics,
+                    ),
+                    (&Method::GET, "/status") => metrics::handle_status(
+                        req,
+                        &mut coord_client,
+                        start_time,
+                        &metrics_registry,
+                        &global_metrics,
+                    ),
                     (&Method::GET, "/prof") => prof::handle_prof(req, &mut coord_client).await,
-                    (&Method::GET, "/memory") => {
-                        memory::handle_memory(req, &mut coord_client).await
-                    }
+                    (&Method::GET, "/memory") => memory::handle_memory(req, &mut coord_client),
                     (&Method::POST, "/prof") => prof::handle_prof(req, &mut coord_client).await,
                     (&Method::POST, "/sql") => sql::handle_sql(req, &mut coord_client).await,
                     (&Method::GET, "/internal/catalog") => {
                         catalog::handle_internal_catalog(req, &mut coord_client).await
                     }
-                    _ => root::handle_static(req, &mut coord_client).await,
+                    _ => root::handle_static(req, &mut coord_client),
                 };
                 coord_client.terminate().await;
                 res

--- a/src/materialized/src/http/memory.rs
+++ b/src/materialized/src/http/memory.rs
@@ -19,7 +19,7 @@ struct MemoryTemplate<'a> {
     version: &'a str,
 }
 
-pub async fn handle_memory(
+pub fn handle_memory(
     _: Request<Body>,
     _: &mut coord::SessionClient,
 ) -> Result<Response<Body>, anyhow::Error> {

--- a/src/materialized/src/http/metrics.rs
+++ b/src/materialized/src/http/metrics.rs
@@ -46,7 +46,7 @@ fn load_prom_metrics(
     result
 }
 
-pub async fn handle_prometheus(
+pub fn handle_prometheus(
     _: Request<Body>,
     _: &mut coord::SessionClient,
     start_time: Instant,
@@ -65,7 +65,7 @@ pub async fn handle_prometheus(
     Ok(Response::new(Body::from(buffer)))
 }
 
-pub async fn handle_status(
+pub fn handle_status(
     _: Request<Body>,
     _: &mut coord::SessionClient,
     start_time: Instant,

--- a/src/materialized/src/http/root.rs
+++ b/src/materialized/src/http/root.rs
@@ -37,14 +37,14 @@ pub fn handle_home(
     }))
 }
 
-pub async fn handle_static(
+pub fn handle_static(
     req: Request<Body>,
     _: &mut coord::SessionClient,
 ) -> Result<Response<Body>, anyhow::Error> {
     if req.method() == Method::GET {
         let path = req.uri().path();
         let path = path.strip_prefix("/").unwrap_or(path);
-        match get_static_file(path).await {
+        match get_static_file(path) {
             Some(body) => Ok(Response::new(body)),
             None => Ok(util::error_response(StatusCode::NOT_FOUND, "not found")),
         }
@@ -57,7 +57,7 @@ pub async fn handle_static(
 const STATIC_DIR: include_dir::Dir = include_dir::include_dir!("src/http/static");
 
 #[cfg(not(feature = "dev-web"))]
-async fn get_static_file(path: &str) -> Option<Body> {
+fn get_static_file(path: &str) -> Option<Body> {
     STATIC_DIR.get_file(path).map(|f| Body::from(f.contents()))
 }
 

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -691,17 +691,17 @@ pub async fn create_state(
     )
     .expect("both parts of AWS Credentials are present");
 
-    let kinesis_client = aws_util::client::kinesis(aws_info.clone()).await.err_hint(
+    let kinesis_client = aws_util::client::kinesis(aws_info.clone()).err_hint(
         "creating Kinesis client",
         &[format!("region: {}", aws_info.region.name())],
     )?;
 
-    let s3_client = aws_util::client::s3(aws_info.clone()).await.err_hint(
+    let s3_client = aws_util::client::s3(aws_info.clone()).err_hint(
         "creating S3 client",
         &[format!("region: {}", aws_info.region.name(),)],
     )?;
 
-    let sqs_client = aws_util::client::sqs(aws_info.clone()).await.err_hint(
+    let sqs_client = aws_util::client::sqs(aws_info.clone()).err_hint(
         "creating SQS client",
         &[format!("region: {}", aws_info.region.name(),)],
     )?;

--- a/test/performance/perf-kinesis/src/main.rs
+++ b/test/performance/perf-kinesis/src/main.rs
@@ -63,7 +63,7 @@ async fn run() -> Result<(), anyhow::Error> {
     // Initialize test resources in Kinesis.
     let region: Region = args.aws_region.parse().context("parsing AWS region")?;
     let kinesis_client =
-        aws_util::client::kinesis(aws::ConnectInfo::new(region, None, None, None)?).await?;
+        aws_util::client::kinesis(aws::ConnectInfo::new(region, None, None, None)?)?;
     let stream_arn =
         kinesis::create_stream(&kinesis_client, &stream_name, args.shard_count).await?;
     log::info!("Created Kinesis stream {}", stream_name);

--- a/test/performance/s3-datagen/src/main.rs
+++ b/test/performance/s3-datagen/src/main.rs
@@ -101,9 +101,7 @@ async fn run() -> anyhow::Result<()> {
     let conn_info =
         aws_util::aws::ConnectInfo::new(rusoto_core::Region::default(), None, None, None)?;
 
-    let client = aws_util::client::s3(conn_info)
-        .await
-        .context("creating s3 client")?;
+    let client = aws_util::client::s3(conn_info).context("creating s3 client")?;
 
     let first_object_key = format!("{}{:>05}", args.key_prefix, 0);
 


### PR DESCRIPTION
This is with some help of the `unused_async` clippy lint which is upcoming
rust 1.54. These functions overly complicate readers of the code.
