### PR TITLE
Make SequencedCommand serializable and deserializable

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -3706,7 +3706,7 @@ pub fn serve_debug(
         now: get_debug_timestamp,
         metrics_registry,
         persist: persist.persister,
-        feedback_tx: feedback_tx.clone(),
+        feedback_tx,
     })
     .unwrap();
 

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -3668,7 +3668,6 @@ pub fn serve_debug(
     Client,
     tokio::sync::mpsc::UnboundedSender<WorkerFeedbackWithMeta>,
     tokio::sync::mpsc::UnboundedReceiver<WorkerFeedbackWithMeta>,
-    tokio::sync::mpsc::UnboundedSender<WorkerFeedbackWithMeta>,
     Arc<Mutex<u64>>,
 ) {
     lazy_static! {
@@ -3792,7 +3791,6 @@ pub fn serve_debug(
         client,
         inner_feedback_tx,
         inner_feedback_rx,
-        feedback_tx,
         DEBUG_TIMESTAMP.clone(),
     )
 }

--- a/src/coordtest/src/lib.rs
+++ b/src/coordtest/src/lib.rs
@@ -147,7 +147,9 @@ impl CoordTest {
     async fn drain_uppers(&mut self, exclude: &HashSet<GlobalId>) {
         let mut msgs = vec![];
         loop {
+            println!("Reading");
             if let Some(Some(mut msg)) = self.dataflow_feedback_rx.recv().now_or_never() {
+                println!("RECVD: {:?}", msg);
                 // Filter out requested ids.
                 if let WorkerFeedback::FrontierUppers(uppers) = &mut msg.message {
                     // Requeue excluded uppers so future wait-sql directives don't always have to
@@ -259,6 +261,7 @@ pub async fn run_test(mut tf: datadriven::TestFile) -> datadriven::TestFile {
 
                     let start = Instant::now();
                     loop {
+                        println!("Draining uppers");
                         ct.drain_uppers(&exclude_uppers).await;
                         let query = ct.rewrite_query(&tc.input);
                         let results = ct

--- a/src/coordtest/src/lib.rs
+++ b/src/coordtest/src/lib.rs
@@ -81,8 +81,10 @@ pub struct CoordTest {
     coord_feedback_tx: mpsc::UnboundedSender<WorkerFeedbackWithMeta>,
     client: Option<Client>,
     _handle: JoinOnDropHandle<()>,
-    dataflow_feedback_tx: mpsc::UnboundedSender<WorkerFeedbackWithMeta>,
     dataflow_feedback_rx: mpsc::UnboundedReceiver<WorkerFeedbackWithMeta>,
+    // Keep a queue of messages in the order received from dataflow_feedback_rx so
+    // we can safely modify or inject things and maintain original message order.
+    queued_feedback: Vec<WorkerFeedbackWithMeta>,
     _catalog_file: NamedTempFile,
     temp_dir: TempDir,
     uppers: HashMap<GlobalId, Timestamp>,
@@ -95,19 +97,12 @@ impl CoordTest {
     pub async fn new() -> anyhow::Result<Self> {
         let catalog_file = NamedTempFile::new()?;
         let metrics_registry = MetricsRegistry::new();
-        let (
-            handle,
-            client,
-            coord_feedback_tx,
-            dataflow_feedback_rx,
-            dataflow_feedback_tx,
-            timestamp,
-        ) = coord::serve_debug(catalog_file.path(), metrics_registry.clone());
+        let (handle, client, coord_feedback_tx, dataflow_feedback_rx, timestamp) =
+            coord::serve_debug(catalog_file.path(), metrics_registry.clone());
         let coordtest = CoordTest {
             _handle: handle,
             client: Some(client),
             coord_feedback_tx,
-            dataflow_feedback_tx,
             dataflow_feedback_rx,
             _catalog_file: catalog_file,
             temp_dir: tempfile::tempdir().unwrap(),
@@ -115,6 +110,7 @@ impl CoordTest {
             _verbose: std::env::var_os("COORDTEST_VERBOSE").is_some(),
             timestamp,
             _metrics_registry: metrics_registry,
+            queued_feedback: Vec::new(),
         };
         Ok(coordtest)
     }
@@ -144,34 +140,74 @@ impl CoordTest {
         r
     }
 
-    async fn drain_uppers(&mut self, exclude: &HashSet<GlobalId>) {
-        let mut msgs = vec![];
+    fn drain_feedback_msgs(&mut self) {
         loop {
-            println!("Reading");
-            if let Some(Some(mut msg)) = self.dataflow_feedback_rx.recv().now_or_never() {
-                println!("RECVD: {:?}", msg);
-                // Filter out requested ids.
-                if let WorkerFeedback::FrontierUppers(uppers) = &mut msg.message {
-                    // Requeue excluded uppers so future wait-sql directives don't always have to
-                    // specify the same exclude list forever.
-                    let mut requeue = uppers.clone();
-                    requeue.retain(|(id, _data)| exclude.contains(id));
-                    if !requeue.is_empty() {
-                        msgs.push(WorkerFeedbackWithMeta {
-                            worker_id: msg.worker_id,
-                            message: WorkerFeedback::FrontierUppers(requeue),
-                        });
-                    }
-                    uppers.retain(|(id, _data)| !exclude.contains(id));
-                }
-                self.coord_feedback_tx.send(msg).unwrap();
+            if let Some(Some(msg)) = self.dataflow_feedback_rx.recv().now_or_never() {
+                self.queued_feedback.push(msg);
             } else {
-                for msg in msgs {
-                    self.dataflow_feedback_tx.send(msg).unwrap();
-                }
                 return;
             }
         }
+    }
+
+    // Drains messages from the queue into coord, extracting and requeueing
+    // excluded uppers.
+    async fn drain_skip_uppers(&mut self, exclude_uppers: &HashSet<GlobalId>) {
+        self.drain_feedback_msgs();
+        let mut to_send = vec![];
+        let mut to_queue = vec![];
+        for mut msg in self.queued_feedback.drain(..) {
+            // Filter out requested ids.
+            if let WorkerFeedback::FrontierUppers(uppers) = &mut msg.message {
+                // Requeue excluded uppers so future wait-sql directives don't always have to
+                // specify the same exclude list forever.
+                let mut requeue = uppers.clone();
+                requeue.retain(|(id, _data)| exclude_uppers.contains(id));
+                if !requeue.is_empty() {
+                    to_queue.push(WorkerFeedbackWithMeta {
+                        worker_id: msg.worker_id,
+                        message: WorkerFeedback::FrontierUppers(requeue),
+                    });
+                }
+                uppers.retain(|(id, _data)| !exclude_uppers.contains(id));
+            }
+            to_send.push(msg);
+        }
+        for msg in to_send {
+            self.coord_feedback_tx.send(msg).unwrap();
+        }
+        self.queued_feedback = to_queue;
+    }
+
+    // Processes PeekResponse messages until rows has a response.
+    async fn wait_for_peek(
+        &mut self,
+        mut rows: std::pin::Pin<Box<dyn Future<Output = PeekResponse>>>,
+    ) -> PeekResponse {
+        loop {
+            if let futures::task::Poll::Ready(rows) = futures::poll!(rows.as_mut()) {
+                return rows;
+            }
+            self.drain_peek_response();
+        }
+    }
+
+    // Drains PeekResponse messages from the queue into coord.
+    fn drain_peek_response(&mut self) {
+        self.drain_feedback_msgs();
+        let mut to_send = vec![];
+        let mut to_queue = vec![];
+        for msg in self.queued_feedback.drain(..) {
+            if let WorkerFeedback::PeekResponse(..) = msg.message {
+                to_send.push(msg);
+            } else {
+                to_queue.push(msg);
+            }
+        }
+        for msg in to_send {
+            self.coord_feedback_tx.send(msg).unwrap();
+        }
+        self.queued_feedback = to_queue;
     }
 
     async fn make_catalog(&self) -> Catalog {
@@ -241,7 +277,7 @@ pub async fn run_test(mut tf: datadriven::TestFile) -> datadriven::TestFile {
                     for r in results {
                         strs.push(match r {
                             ExecuteResponse::SendingRows(rows) => {
-                                format!("{:#?}", rows.await)
+                                format!("{:#?}", ct.wait_for_peek(rows).await)
                             }
                             r => format!("{:#?}", r),
                         });
@@ -261,8 +297,7 @@ pub async fn run_test(mut tf: datadriven::TestFile) -> datadriven::TestFile {
 
                     let start = Instant::now();
                     loop {
-                        println!("Draining uppers");
-                        ct.drain_uppers(&exclude_uppers).await;
+                        ct.drain_skip_uppers(&exclude_uppers).await;
                         let query = ct.rewrite_query(&tc.input);
                         let results = ct
                             .with_sc(|sc| Box::pin(async move { sql(sc, query).await }))
@@ -272,20 +307,23 @@ pub async fn run_test(mut tf: datadriven::TestFile) -> datadriven::TestFile {
                             Ok(result) => {
                                 for r in result {
                                     match r {
-                                        ExecuteResponse::SendingRows(rows) => match rows.await {
-                                            PeekResponse::Rows(rows) => {
-                                                for row in rows {
-                                                    for col in row.iter() {
-                                                        if col != Datum::True {
-                                                            failed = Err(anyhow!("datum != true"));
+                                        ExecuteResponse::SendingRows(rows) => {
+                                            match ct.wait_for_peek(rows).await {
+                                                PeekResponse::Rows(rows) => {
+                                                    for row in rows {
+                                                        for col in row.iter() {
+                                                            if col != Datum::True {
+                                                                failed =
+                                                                    Err(anyhow!("datum != true"));
+                                                            }
                                                         }
                                                     }
                                                 }
+                                                r => {
+                                                    failed = Err(anyhow!("{:?}", r));
+                                                }
                                             }
-                                            r => {
-                                                failed = Err(anyhow!("{:?}", r));
-                                            }
-                                        },
+                                        }
                                         _ => panic!("expected SendingRows"),
                                     };
                                 }

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -25,7 +25,6 @@ use log::warn;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use timely::progress::frontier::Antichain;
-use tokio::sync::mpsc;
 use url::Url;
 use uuid::Uuid;
 
@@ -53,6 +52,17 @@ impl PeekResponse {
             }
         }
     }
+}
+
+/// Various responses that can be communicated about the progress of a TAIL command.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub enum TailResponse {
+    /// Rows that should be returned in order to the client.
+    Rows(Vec<Row>),
+    /// Sent once the stream is complete. Indicates the end.
+    Complete,
+    /// The TAIL dataflow was dropped before completing. Indicates the end.
+    Dropped,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -1090,8 +1100,6 @@ impl SinkConnector {
 
 #[derive(Clone, Debug, Serialize)]
 pub struct TailSinkConnector {
-    #[serde(skip)]
-    pub tx: mpsc::UnboundedSender<Vec<Row>>,
     pub emit_progress: bool,
     pub object_columns: usize,
     pub value_desc: RelationDesc,

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -84,7 +84,7 @@ pub struct BuildDesc<View> {
 }
 
 /// A description of a dataflow to construct and results to surface.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct DataflowDescription<View> {
     /// Sources made available to the dataflow.
     pub source_imports: BTreeMap<GlobalId, (SourceDesc, GlobalId)>,
@@ -628,7 +628,7 @@ pub struct SourceDesc {
 }
 
 /// A sink for updates to a relational collection.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SinkDesc {
     pub from: GlobalId,
     pub from_desc: RelationDesc,
@@ -1013,7 +1013,7 @@ pub enum S3KeySource {
     SqsNotifications { queue: String },
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum SinkConnector {
     Kafka(KafkaSinkConnector),
     Tail(TailSinkConnector),
@@ -1098,7 +1098,7 @@ impl SinkConnector {
     }
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TailSinkConnector {
     pub emit_progress: bool,
     pub object_columns: usize,

--- a/src/dataflow/src/render/join/delta_join.rs
+++ b/src/dataflow/src/render/join/delta_join.rs
@@ -18,6 +18,7 @@
 //! not create any new stateful operators.
 
 #![allow(clippy::op_ref)]
+use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use timely::dataflow::Scope;
 
@@ -38,7 +39,7 @@ use crate::render::join::{JoinBuildState, JoinClosure};
 /// in arrangements for other join inputs. These lookups require specific
 /// instructions about which expressions to use as keys. Along the way,
 /// various closures are applied to filter and project as early as possible.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct DeltaJoinPlan {
     /// The set of path plans.
     ///
@@ -48,7 +49,7 @@ pub struct DeltaJoinPlan {
 }
 
 /// A delta query path is implemented by a sequences of stages,
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct DeltaPathPlan {
     /// The relation whose updates seed the dataflow path.
     source_relation: usize,
@@ -65,7 +66,7 @@ pub struct DeltaPathPlan {
 }
 
 /// A delta query stage performs a stream lookup into an arrangement.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct DeltaStagePlan {
     /// The relation index into which we will look up.
     lookup_relation: usize,

--- a/src/dataflow/src/render/join/linear_join.rs
+++ b/src/dataflow/src/render/join/linear_join.rs
@@ -16,6 +16,7 @@ use differential_dataflow::trace::BatchReader;
 use differential_dataflow::trace::Cursor;
 use differential_dataflow::trace::TraceReader;
 use differential_dataflow::Collection;
+use serde::{Deserialize, Serialize};
 use timely::dataflow::Scope;
 use timely::progress::{timestamp::Refines, Timestamp};
 
@@ -30,7 +31,7 @@ use crate::render::datum_vec::DatumVec;
 use crate::render::join::{JoinBuildState, JoinClosure};
 
 // TODO(mcsherry): Identical to `DeltaPathPlan`; consider unifying.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct LinearJoinPlan {
     /// The source relation from which we start the join.
     source_relation: usize,
@@ -47,7 +48,7 @@ pub struct LinearJoinPlan {
 }
 
 // TODO(mcsherry): Identical to `DeltaStagePlan`; consider unifying.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct LinearStagePlan {
     /// The relation index into which we will look up.
     lookup_relation: usize,

--- a/src/dataflow/src/render/join/mod.rs
+++ b/src/dataflow/src/render/join/mod.rs
@@ -32,6 +32,8 @@ mod linear_join;
 
 use std::collections::HashMap;
 
+use serde::{Deserialize, Serialize};
+
 use expr::{MapFilterProject, MirScalarExpr};
 use repr::{Datum, Row, RowArena};
 
@@ -39,7 +41,7 @@ pub use delta_join::DeltaJoinPlan;
 pub use linear_join::LinearJoinPlan;
 
 /// A complete enumeration of possible join plans to render.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum JoinPlan {
     Linear(LinearJoinPlan),
     Delta(DeltaJoinPlan),
@@ -51,7 +53,7 @@ pub enum JoinPlan {
 /// as there is a relationship between the borrowed lifetime of the closed-over
 /// state and the arguments it takes when invoked. It was not clear how to do
 /// this with a Rust closure (glorious battle was waged, but ultimately lost).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 struct JoinClosure {
     ready_equivalences: Vec<Vec<MirScalarExpr>>,
     before: expr::SafeMfpPlan,

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -162,6 +162,11 @@ pub struct RenderState {
     pub metrics: Metrics,
     /// Handle to the persistence runtime. None if disabled.
     pub persist: Option<RuntimeClient<Vec<u8>, ()>>,
+    /// Shared buffer with TAIL operator instances by which they can respond.
+    ///
+    /// The entries are pairs of sink identifier (to identify the tail instance)
+    /// and the response itself.
+    pub tail_response_buffer: Rc<RefCell<Vec<(GlobalId, TailResponse)>>>,
 }
 
 /// A container for "tokens" that are relevant to an in-construction dataflow.

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -630,7 +630,7 @@ pub mod plan {
     /// compelling ways to represent renderable plans. Several stages have already
     /// encapsulated much of their logic in their own stage-specific plans, and we
     /// expect more of the plans to do the same in the future, without consultation.
-    #[derive(Clone, Debug)]
+    #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
     pub enum Plan {
         /// A collection containing a pre-determined collection.
         Constant {

--- a/src/dataflow/src/render/reduce.rs
+++ b/src/dataflow/src/render/reduce.rs
@@ -119,7 +119,7 @@ enum ReductionType {
 /// shape / general computation of the rendered dataflow graph
 /// in this plan, and then make actually rendering the graph
 /// be as simple (and compiler verifiable) as possible.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum ReducePlan {
     /// Plan for not computing any aggregations, just determining the set of
     /// distinct keys.
@@ -148,7 +148,7 @@ pub enum ReducePlan {
 /// apply only to the distinct set of values. We need
 /// to apply a distinct operator to those before we
 /// combine them with everything else.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AccumulablePlan {
     /// All of the aggregations we were asked to compute, stored
     /// in order.
@@ -169,7 +169,7 @@ pub struct AccumulablePlan {
 /// with monotonic plans, but otherwise, we need to render
 /// them with a reduction tree that splits the inputs into
 /// small, and then progressively larger, buckets
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum HierarchicalPlan {
     /// Plan hierarchical aggregations under monotonic inputs.
     Monotonic(MonotonicPlan),
@@ -185,7 +185,7 @@ pub enum HierarchicalPlan {
 /// append only, so we can change our computation to
 /// only retain the "best" value in the diff field, instead
 /// of holding onto all values.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MonotonicPlan {
     /// All of the aggregations we were asked to compute.
     aggr_funcs: Vec<AggregateFunc>,
@@ -204,7 +204,7 @@ pub struct MonotonicPlan {
 /// fraction of the original input) and redo the reduction in another
 /// layer. Effectively, we'll construct a min / max heap out of a series
 /// of reduce operators (each one is a separate layer).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct BucketedPlan {
     /// All of the aggregations we were asked to compute.
     aggr_funcs: Vec<AggregateFunc>,
@@ -230,7 +230,7 @@ pub struct BucketedPlan {
 /// were only asked to compute a single aggregation, we can skip
 /// that step and return the arrangement provided by computing the aggregation
 /// directly.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum BasicPlan {
     /// Plan for rendering a single basic aggregation. Here, the
     /// first element denotes the index in the set of inputs
@@ -248,7 +248,7 @@ pub enum BasicPlan {
 /// types.
 ///
 /// TODO: could we express this as a delta join
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct CollationPlan {
     /// Accumulable aggregation results to collate, if any.
     accumulable: Option<AccumulablePlan>,
@@ -605,7 +605,7 @@ where
 }
 
 /// Plan for extracting keys and values in preparation for a reduction.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct KeyValPlan {
     /// Extracts the columns used as the key.
     key_plan: expr::SafeMfpPlan,

--- a/src/dataflow/src/render/threshold.rs
+++ b/src/dataflow/src/render/threshold.rs
@@ -31,12 +31,13 @@ use timely::dataflow::Scope;
 use timely::progress::{timestamp::Refines, Timestamp};
 
 use repr::{Diff, Row};
+use serde::{Deserialize, Serialize};
 
 use crate::render::context::CollectionBundle;
 use crate::render::context::{ArrangementFlavor, Context};
 
 /// A plan describing how to compute a threshold operation.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum ThresholdPlan {
     /// Basic threshold maintains all positive inputs.
     Basic(BasicThresholdPlan),
@@ -68,7 +69,7 @@ impl ThresholdPlan {
 }
 
 /// A plan to maintain all inputs with positive counts.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct BasicThresholdPlan {
     /// The number of columns in the input and output.
     arity: usize,
@@ -76,7 +77,7 @@ pub struct BasicThresholdPlan {
 
 /// A plan to maintain all inputs with negative counts, which are subtracted from the output
 /// in order to maintain an equivalent collection compared to [BasicThresholdPlan].
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RetractionsThresholdPlan {
     /// The number of columns in the input and output.
     arity: usize,

--- a/src/dataflow/src/render/top_k.rs
+++ b/src/dataflow/src/render/top_k.rs
@@ -24,6 +24,7 @@ use differential_dataflow::operators::Consolidate;
 use differential_dataflow::trace::implementations::ord::OrdValSpine;
 use differential_dataflow::AsCollection;
 use differential_dataflow::Collection;
+use serde::{Deserialize, Serialize};
 use timely::dataflow::Scope;
 
 use expr::ColumnOrder;
@@ -33,7 +34,7 @@ use crate::render::context::CollectionBundle;
 use crate::render::context::Context;
 
 /// A plan encapsulating different variants to compute a TopK operation.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum TopKPlan {
     /// A plan for Top1 for monotonic inputs.
     MonotonicTop1(MonotonicTop1Plan),
@@ -109,7 +110,7 @@ impl TopKPlan {
 /// differential's semantics. (2) is especially interesting because Kafka is
 /// monotonic with an ENVELOPE of NONE, which is the default for ENVELOPE in
 /// Materialize and commonly used by users.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MonotonicTop1Plan {
     /// The columns that form the key for each group.
     group_key: Vec<usize>,
@@ -118,7 +119,7 @@ pub struct MonotonicTop1Plan {
 }
 
 /// A plan for monotonic TopKs with an offset of 0 and an arbitrary limit.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MonotonicTopKPlan {
     /// The columns that form the key for each group.
     group_key: Vec<usize>,
@@ -132,7 +133,7 @@ pub struct MonotonicTopKPlan {
 }
 
 /// A plan for generic TopKs that don't fit any more specific category.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct BasicTopKPlan {
     /// The columns that form the key for each group.
     group_key: Vec<usize>,

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -60,7 +60,7 @@ mod metrics;
 static TS_BINDING_FEEDBACK_INTERVAL_MS: u128 = 1_000;
 
 /// Explicit instructions for timely dataflow workers.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum SequencedCommand {
     /// Create a sequence of dataflows.
     ///

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -155,8 +155,6 @@ pub enum SequencedCommand {
         /// The timestamp to advance to.
         advance_to: Timestamp,
     },
-    // /// Request that feedback is streamed to the provided channel.
-    // EnableFeedback(mpsc::UnboundedSender<WorkerFeedbackWithMeta>),
     /// Request that the logging sources in the contained configuration are
     /// installed.
     EnableLogging(LoggingConfig),

--- a/src/dataflow/src/server/metrics.rs
+++ b/src/dataflow/src/server/metrics.rs
@@ -206,7 +206,6 @@ impl CommandsProcessedMetrics {
             SequencedCommand::DropSourceTimestamping { .. } => {
                 self.drop_source_timestamping_int += 1
             }
-            SequencedCommand::EnableFeedback(..) => self.enable_feedback_int += 1,
             SequencedCommand::EnableLogging(_) => self.enable_logging_int += 1,
             SequencedCommand::Shutdown { .. } => self.shutdown_int += 1,
             SequencedCommand::AdvanceAllLocalInputs { .. } => {

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -1065,6 +1065,7 @@ pub fn memoize_expr(
 
 pub mod plan {
 
+    use serde::{Deserialize, Serialize};
     use std::convert::TryFrom;
 
     use crate::{BinaryFunc, EvalError, MapFilterProject, MirScalarExpr, NullaryFunc};
@@ -1072,7 +1073,7 @@ pub mod plan {
     use repr::{Datum, Diff, Row, RowArena, ScalarType};
 
     /// A wrapper type which indicates it is safe to simply evaluate all expressions.
-    #[derive(Clone, Debug)]
+    #[derive(Clone, Debug, Serialize, Deserialize)]
     pub struct SafeMfpPlan {
         mfp: MapFilterProject,
     }


### PR DESCRIPTION
This WIP PR moves peek responses back to the coordinator as data, who then communicates along the `mpsc`s to the recipients. The intent is that the prior behavior is preserved, including sending multiple cancellations as if from all outstanding workers, because I don't know how the protocol on the other end of the channel works.

Still to do: CI probably breaks five different ways, but at least we'll see.