### PR TITLE
limit CPUs used to lower of physical or logical cores

### DIFF
--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -486,7 +486,7 @@ fn run(args: Args) -> Result<(), anyhow::Error> {
 
     // When inside a cgroup with a cpu limit,
     // the logical cpus can be lower than the physical cpus.
-    let ncpus_useful = cmp::min(num_cpus::get(), num_cpus::get_physical());
+    let ncpus_useful = usize::max(1, cmp::min(num_cpus::get(), num_cpus::get_physical()));
 
     // Print system information as the very first thing in the logs. The goal is
     // to increase the probability that we can reproduce a reported bug if all


### PR DESCRIPTION
If inside a cgroup with a cpu limit, the logical cores could be lower
than the physical cores.

This is especially likely when running using systemd, docker, or
kubernetes.

Resolves #7583