### PR TITLE
sql: update dec library for new primitive cast semantics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,9 +876,9 @@ dependencies = [
 
 [[package]]
 name = "dec"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c55ce0ff46dd9b2b36ce70c8fc865bae488dbae97353b1900d1794d44a1a52d1"
+checksum = "0c2bbc59a6735d2f5bc4befd3300c9b75cc6ed66165e92b741da0a58c07ea04d"
 dependencies = [
  "decnumber-sys",
  "libc",

--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -18,7 +18,7 @@ crossbeam-channel = "0.5.1"
 dataflow = { path = "../dataflow" }
 dataflow-types = { path = "../dataflow-types" }
 derivative = "2.2.0"
-dec = "0.4.4"
+dec = "0.4.5"
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 expr = { path = "../expr" }
 futures = "0.3.16"

--- a/src/dataflow/Cargo.toml
+++ b/src/dataflow/Cargo.toml
@@ -16,7 +16,7 @@ chrono = { version = "0.4.0", default-features = false, features = ["std"] }
 crossbeam-channel = "0.5.1"
 csv-core = "0.1.10"
 dataflow-types = { path = "../dataflow-types" }
-dec = { version = "0.4.4", features = ["serde"] }
+dec = { version = "0.4.5", features = ["serde"] }
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 dogsdogsdogs = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 expr = { path = "../expr" }

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -10,7 +10,7 @@ aho-corasick = "0.7.18"
 anyhow = "1.0.42"
 chrono = { version = "0.4.0", default-features = false, features = ["clock", "std"] }
 csv = "1.1.6"
-dec = "0.4.4"
+dec = "0.4.5"
 encoding = "0.2.0"
 enum-iterator = "0.7.0"
 hex = "0.4.3"

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -419,6 +419,7 @@ fn cast_numeric_to_int16<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let mut a = a.unwrap_numeric().0;
     let mut cx = numeric::cx_datum();
     cx.round(&mut a);
+    cx.clear_status();
     let i = cx.try_into_i32(a).map_err(|_| EvalError::Int16OutOfRange)?;
     match i16::try_from(i) {
         Ok(i) => Ok(Datum::from(i)),
@@ -430,6 +431,7 @@ fn cast_numeric_to_int32<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let mut a = a.unwrap_numeric().0;
     let mut cx = numeric::cx_datum();
     cx.round(&mut a);
+    cx.clear_status();
     match cx.try_into_i32(a) {
         Ok(i) => Ok(Datum::from(i)),
         Err(_) => Err(EvalError::Int32OutOfRange),
@@ -440,6 +442,7 @@ fn cast_numeric_to_int64<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let mut a = a.unwrap_numeric().0;
     let mut cx = numeric::cx_datum();
     cx.round(&mut a);
+    cx.clear_status();
     match cx.try_into_i64(a) {
         Ok(i) => Ok(Datum::from(i)),
         Err(_) => Err(EvalError::Int64OutOfRange),

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -17,7 +17,7 @@ base64 = "0.13.0"
 byteorder = "1.4.3"
 ccsr = { path = "../ccsr" }
 chrono = { version = "0.4.0", default-features = false, features = ["std"] }
-dec = "0.4.4"
+dec = "0.4.5"
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 futures = "0.3.16"
 hex = "0.4.3"

--- a/src/materialized/tests/util.rs
+++ b/src/materialized/tests/util.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::convert::TryInto;
+use std::convert::TryFrom;
 use std::env;
 use std::error::Error;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
@@ -214,13 +214,8 @@ pub struct MzTimestamp(pub u64);
 
 impl<'a> FromSql<'a> for MzTimestamp {
     fn from_sql(ty: &Type, raw: &'a [u8]) -> Result<MzTimestamp, Box<dyn Error + Sync + Send>> {
-        let mut n = pgrepr::Numeric::from_sql(ty, raw)?;
-        if repr::adt::numeric::get_scale(&n.0 .0) != 0 {
-            return Err("scale of apd was not 0".into());
-        }
-        // Converting apd to int requires its exponent be zero.
-        repr::adt::numeric::rescale(&mut n.0 .0, 0).unwrap();
-        Ok(MzTimestamp(n.0 .0.try_into()?))
+        let n = pgrepr::Numeric::from_sql(ty, raw)?;
+        Ok(MzTimestamp(u64::try_from(n.0 .0)?))
     }
 
     fn accepts(ty: &Type) -> bool {

--- a/src/pgrepr/Cargo.toml
+++ b/src/pgrepr/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 byteorder = "1.4.3"
 bytes = "1.0.1"
 chrono = { version = "0.4.0", default-features = false, features = ["std"] }
-dec = "0.4.4"
+dec = "0.4.5"
 lazy_static = "1.4.0"
 ore = { path = "../ore" }
 postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres", branch = "mz-0.7.2", features = ["with-chrono-0_4", "with-uuid-0_8"] }

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -18,7 +18,7 @@ anyhow = "1.0.42"
 byteorder = "1.4.3"
 chrono = { version = "0.4.0", default-features = false, features = ["serde", "std"] }
 chrono-tz = { version = "0.5.0", features = ["serde"] }
-dec = "0.4.4"
+dec = "0.4.5"
 enum-kinds = "0.5.0"
 fast-float = "0.2.0"
 hex = "0.4.3"

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -13,7 +13,7 @@ build-info = { path = "../build-info" }
 ccsr = { path = "../ccsr" }
 chrono = { version = "0.4.0", default-features = false, features = ["clock", "std"] }
 dataflow-types = { path = "../dataflow-types" }
-dec = "0.4.4"
+dec = "0.4.5"
 enum-kinds = "0.5.0"
 expr = { path = "../expr" }
 futures = "0.3.16"

--- a/test/sqllogictest/as_of.slt
+++ b/test/sqllogictest/as_of.slt
@@ -31,3 +31,26 @@ SELECT * FROM data AS OF now()
 1 2
 2 1
 3 1
+
+# This previously would panic on an internal conversion from numeric to
+# primitive int
+
+query II
+SELECT * FROM data AS OF 192741824E4::numeric;
+----
+1 1
+1 2
+2 1
+3 1
+
+query error out of range integral type conversion attempted
+SELECT * FROM data AS OF -1;
+
+query error decimal cannot be expressed in target primitive type
+SELECT * FROM data AS OF -1::numeric;
+
+query error decimal cannot be expressed in target primitive type
+SELECT * FROM data AS OF 1E38;
+
+query error decimal cannot be expressed in target primitive type
+SELECT * FROM data AS OF 1.2;


### PR DESCRIPTION
Previously our decimal library required values to have an
exponent of 0 when performing casts to primitive integers or it
would fail. The newest release is more forgiving about the values
it acceppts, so we are bumping the version and using the new
implementation in a few places.