### PR TITLE
github: add materialize cloud install option

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -28,6 +28,7 @@ $ materialized -v
 * [ ] macOS release tarball
 * [ ] Homebrew tap
 * [ ] Built from source
+* [ ] Materialize Cloud
 
 ### What was the issue?
 


### PR DESCRIPTION
Adds Materialize Cloud install option to bug report template.