### PR TITLE
coord: seal all persisted tables in a single operation for efficiency

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -57,7 +57,7 @@ use lazy_static::lazy_static;
 use ore::metrics::MetricsRegistry;
 use ore::retry::Retry;
 use persist::error::Error as PersistError;
-use persist::indexed::runtime::{CmdResponse, MultiWriteHandle};
+use persist::indexed::runtime::CmdResponse;
 use persist::storage::SeqNo;
 use rand::Rng;
 use repr::adt::numeric;
@@ -543,22 +543,12 @@ impl Coordinator {
         }
         // These can occasionally be equal, so ignore the update in that case.
         if next_ts > self.closed_up_to {
-            if self.catalog.user_table_persistence_enabled() {
+            if let Some(persist_multi) = self.catalog.persist_multi_details() {
                 // Close out the timestamp for persisted tables.
-                //
-                // TODO: Allow sealing multiple streams at once to reduce the
-                // overhead.
                 let (tx, rx) = std::sync::mpsc::channel();
-                for entry in self.catalog.entries() {
-                    if let CatalogItem::Table(Table {
-                        persist: Some(persist),
-                        ..
-                    }) = entry.item()
-                    {
-                        persist.write_handle.seal(next_ts, tx.clone().into());
-                    }
-                }
-                drop(tx);
+                persist_multi
+                    .write_handle
+                    .seal(&persist_multi.all_table_ids, next_ts, tx.into());
                 for res in rx {
                     if let Err(err) = res {
                         // TODO: Linearizability relies on this, bubble up the error instead.
@@ -2257,8 +2247,12 @@ impl Coordinator {
                             if !volatile_updates.is_empty() {
                                 coord_bail!("transaction had mixed persistent and volatile writes");
                             }
-                            let persist_multi = MultiWriteHandle::new(&persist_streams)
-                                .map_err(|err| anyhow!("{}", err))?;
+                            let persist_multi =
+                                self.catalog.persist_multi_details().ok_or_else(|| {
+                                    anyhow!(
+                                        "internal error: persist_multi_details invariant violated"
+                                    )
+                                })?;
                             let (tx, rx) = oneshot::channel();
                             let callback = Box::new(move |res: Result<SeqNo, PersistError>| {
                                 let res = res
@@ -2267,6 +2261,7 @@ impl Coordinator {
                                 let _ = tx.send(res);
                             });
                             persist_multi
+                                .write_handle
                                 .write_atomic(persist_updates, CmdResponse::Callback(callback));
                             return Ok(Some(rx));
                         } else {

--- a/src/coord/src/persistcfg.rs
+++ b/src/coord/src/persistcfg.rs
@@ -13,11 +13,12 @@ use std::path::PathBuf;
 
 use anyhow::anyhow;
 use persist::error::Error;
+use persist::indexed::encoding::Id;
 use serde::Serialize;
 
 use expr::GlobalId;
 use persist::file::{FileBlob, FileBuffer};
-use persist::indexed::runtime::{self, RuntimeClient, StreamWriteHandle};
+use persist::indexed::runtime::{self, MultiWriteHandle, RuntimeClient, StreamWriteHandle};
 
 /// Configuration of the persistence runtime and features.
 #[derive(Clone, Debug)]
@@ -115,4 +116,10 @@ pub struct PersistDetails {
     pub stream_name: String,
     #[serde(skip)]
     pub write_handle: StreamWriteHandle<Vec<u8>, ()>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PersistMultiDetails {
+    pub all_table_ids: Vec<Id>,
+    pub write_handle: MultiWriteHandle<Vec<u8>, ()>,
 }

--- a/src/persist/benches/snapshot.rs
+++ b/src/persist/benches/snapshot.rs
@@ -68,7 +68,7 @@ where
         bench_snapshot(&i, id, data_len, b)
     });
     // Seal the updates to move them all to the trace
-    i.seal(id, 100_001).expect("sealing update times");
+    i.seal(vec![id], 100_001).expect("sealing update times");
     c.bench_function(&format!("{}_trace_snapshot", name), |b| {
         bench_snapshot(&i, id, data_len, b)
     });


### PR DESCRIPTION
The multi-seal ability is newly exposed by persist in the preceding
commit. It would be unacceptably performance to recompute a new
MultiStreamHandle for every call to `advance_local_inputs` so instead
store it on Catalog and recompute it when it changes (tables are added
removed). Then, since we now have a nicely maintained MultiStreamHandle
available, use it in end transaction instead of constructing a one-off
one there.