### PR TITLE
MIR testing: Roundtrip support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3438,9 +3438,11 @@ dependencies = [
 name = "repr_test_util"
 version = "0.0.0"
 dependencies = [
+ "chrono",
  "datadriven",
  "lazy_static",
  "lowertest",
+ "ore",
  "proc-macro2",
  "repr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1202,6 +1202,7 @@ dependencies = [
  "proc-macro2",
  "repr",
  "repr_test_util",
+ "serde",
  "serde_json",
 ]
 

--- a/src/expr-test-util/Cargo.toml
+++ b/src/expr-test-util/Cargo.toml
@@ -13,6 +13,7 @@ ore = { path = "../ore" }
 proc-macro2 = "1.0.28"
 repr = {path = "../repr"}
 repr_test_util = {path = "../repr-test-util"}
+serde = { version = "1.0.126", features = ["derive"] }
 serde_json = "1.0.66"
 
 [dev-dependencies]

--- a/src/expr-test-util/README.md
+++ b/src/expr-test-util/README.md
@@ -1,5 +1,11 @@
 # Utility to create arbitrary MIRs
 
+## Limitations
+
+`EvalError`s are not yet supported and thus scalar subqueries are not
+supported.
+https://github.com/MaterializeInc/materialize/issues/7657
+
 ## Syntax
 
 See the README for the [lowertest](../lowertest/README.md) crate for the
@@ -58,7 +64,7 @@ But if you want to convert the JSON string into the more readable test syntax, f
 
 1. Copy the JSON string to a file that looks like this:
    ```
-   rel-to-spec
+   rel-to-test
    <JSON version of your MIR>
    ----
    ```
@@ -68,7 +74,7 @@ But if you want to convert the JSON string into the more readable test syntax, f
 3. On the command line, run `cd <this directory>; REWRITE=1 cargo test`. Your
    file should be rewritten so it looks like this:
    ```
-   rel-to-spec
+   rel-to-test
    <JSON version of your MIR>
    ----
    ----

--- a/src/expr-test-util/README.md
+++ b/src/expr-test-util/README.md
@@ -1,0 +1,80 @@
+# Utility to create arbitrary MIRs
+
+## Syntax
+
+See the README for the [lowertest](../lowertest/README.md) crate for the
+standard syntax.
+
+The following variants of `MirScalarExpr` have non-standard syntax:
+1. Literal -> the syntax is `(<literal> <scalar type>)` or `<literal>`.
+    If `<scalar type>` is not specified, then literals will be assigned
+    default types:
+   * true/false become Bool
+   * numbers become Int64
+   * strings become String
+2. Column -> the syntax is `#n`, where n is the column number.
+
+The following variants of `MirRelationExpr` have non-standard syntax:
+1. Let -> the syntax is `(let x <value> <body>)` where x is an ident that
+    should not match any existing ident in any Let statement in
+    `<value>`.
+2. Get -> the syntax is `(get x)`, where x is an ident that refers to a
+    pre-defined source or an ident defined in a let.
+3. Union -> the syntax is `(union <input1> .. <inputn>)`.
+4. Constant -> the syntax is
+    ```
+    (constant
+    [[<row1literal1>..<row1literaln>]..[<rowiliteral1>..<rowiliteraln>]]
+    <RelationType>
+    )
+    ```
+
+## Unit testing
+
+The tests in this crate are meant to:
+1. Test that arbitrary MIR creation works.
+2. Give examples for how unit testing with MIRs work.
+
+To create arbitrary MIRs in unit tests of functions on MIRs, import this crate
+as a dev dependency to the crate you are testing.
+
+## Debugging
+
+To figure out why a particular optimized plan was generated for a particular SQL
+query, you may want to extract the MirRelationExpr at some point during the
+planning process and then run some tests to experiment with how transformations
+affect the MIR, to figure out what are the minimal elements that an MIR should
+have to reproduce the behavior, etc. etc.
+
+1. Add `println!("{}", <MIR variable name>.json())` to the place in the code of
+   your choosing so it will print out your MIR serialized into a JSON string.
+2. Run your SQL query.
+
+At this point, you could just copy the JSON string into a test of your choice
+and convert the JSON string back into a `MirRelationExpr` with the line
+`let variable: MirRelationExpr = serde_json::from_str(<the_json_string>)?;`
+
+But if you want to convert the JSON string into the more readable test syntax, follow these steps:
+
+1. Copy the JSON string to a file that looks like this:
+   ```
+   rel-to-spec
+   <JSON version of your MIR>
+   ----
+   ```
+2. In the line in [tests/test_runner.rs] beginning with
+   `datadriven::walk("tests/testdata"`, change `"tests/testdata"` to point to
+   the file created in the previous step.
+3. On the command line, run `cd <this directory>; REWRITE=1 cargo test`. Your
+   file should be rewritten so it looks like this:
+   ```
+   rel-to-spec
+   <JSON version of your MIR>
+   ----
+   ----
+   <commands to register in the test catalog the sources that your MIR references>
+
+   <specification to create your MIR in unit tests>
+   ----
+   ----
+   ```

--- a/src/expr-test-util/src/lib.rs
+++ b/src/expr-test-util/src/lib.rs
@@ -19,7 +19,7 @@ use lowertest::*;
 use ore::result::ResultExt;
 use ore::str::separated;
 use repr::{ColumnType, Datum, RelationType, Row, ScalarType};
-use repr_test_util::{get_datum_from_str, get_scalar_type_or_default, unquote_string};
+use repr_test_util::*;
 
 gen_reflect_info_func!(
     produce_rti,
@@ -250,7 +250,7 @@ impl TestDeserializeContext for MirScalarExprDeserializeContext {
                                 let row: Row = serde_json::from_value(inner_data.clone()).unwrap();
                                 let result = format!(
                                     "({} {})",
-                                    row.unpack_first(),
+                                    datum_to_test_spec(row.unpack_first()),
                                     from_json(
                                         &serde_json::to_value(&column_type.scalar_type).unwrap(),
                                         "ScalarType",
@@ -566,6 +566,8 @@ impl<'a> TestDeserializeContext for MirRelationExprDeserializeContext<'a> {
                                                 separated(
                                                     " ",
                                                     row.unpack()
+                                                        .into_iter()
+                                                        .map(|d| datum_to_test_spec(d))
                                                 )
                                             ))
                                         }

--- a/src/expr-test-util/tests/test_runner.rs
+++ b/src/expr-test-util/tests/test_runner.rs
@@ -9,6 +9,44 @@
 
 mod test {
     use expr_test_util::*;
+    use lowertest::{from_json, GenericTestDeserializeContext, TestDeserializeContext};
+    use ore::result::ResultExt;
+    use ore::str::separated;
+    use serde::de::DeserializeOwned;
+    use serde::Serialize;
+
+    fn roundtrip<F, T, G, C>(
+        s: &str,
+        type_name: &str,
+        build_obj: F,
+        ctx_gen: G,
+    ) -> Result<T, String>
+    where
+        T: DeserializeOwned + Serialize + Eq + Clone,
+        F: Fn(&str) -> Result<T, String>,
+        C: TestDeserializeContext,
+        G: Fn() -> C,
+    {
+        let result: T = build_obj(s)?;
+        let json = serde_json::to_value(result.clone()).map_err_to_string()?;
+        let new_s = from_json(&json, type_name, &RTI, &mut ctx_gen());
+        let new_result = build_obj(&new_s)?;
+        if new_result.eq(&result) {
+            Ok(result)
+        } else {
+            Err(format!(
+                "Round trip failed. New spec:\n{}
+            Original {type_name}:\n{}
+            New {type_name}:\n{}
+            JSON for original {type_name}:\n{}",
+                new_s,
+                serde_json::to_string_pretty(&result).unwrap(),
+                serde_json::to_string_pretty(&new_result).unwrap(),
+                json.to_string(),
+                type_name = type_name
+            ))
+        }
+    }
 
     #[test]
     fn run() {
@@ -21,24 +59,38 @@ mod test {
                         Err(err) => format!("error: {}\n", err),
                     },
                     // tests that we can build `MirScalarExpr`s
-                    "build-scalar" => match build_scalar(&s.input) {
-                        Ok(scalar) => format!("{}\n", scalar.to_string()),
-                        Err(err) => format!("error: {}\n", err),
-                    },
-                    "build" => match build_rel(&s.input, &catalog) {
-                        // Generally, explanations for fully optimized queries
-                        // are not allowed to have whitespace at the end;
-                        // however, a partially optimized query can.
-                        // Since clippy rejects test results with trailing
-                        // whitespace, remove whitespace before comparing results.
-                        Ok(rel) => format!(
-                            "{}\n",
-                            catalog
-                                .generate_explanation(&rel, s.args.get("format"))
-                                .trim_end()
-                        ),
-                        Err(err) => format!("error: {}\n", err),
-                    },
+                    "build-scalar" => {
+                        match roundtrip(
+                            &s.input,
+                            "MirScalarExpr",
+                            |s| build_scalar(s),
+                            || MirScalarExprDeserializeContext::default(),
+                        ) {
+                            Ok(scalar) => format!("{}\n", scalar),
+                            Err(err) => format!("error: {}\n", err),
+                        }
+                    }
+                    "build" => {
+                        match roundtrip(
+                            &s.input,
+                            "MirRelationExpr",
+                            |s| build_rel(s, &catalog),
+                            || MirRelationExprDeserializeContext::new(&catalog),
+                        ) {
+                            // Generally, explanations for fully optimized queries
+                            // are not allowed to have whitespace at the end;
+                            // however, a partially optimized query can.
+                            // Since clippy rejects test results with trailing
+                            // whitespace, remove whitespace before comparing results.
+                            Ok(rel) => format!(
+                                "{}\n",
+                                catalog
+                                    .generate_explanation(&rel, s.args.get("format"))
+                                    .trim_end()
+                            ),
+                            Err(err) => format!("error: {}\n", err),
+                        }
+                    }
                     _ => panic!("unknown directive: {}", s.directive),
                 }
             })

--- a/src/expr-test-util/tests/test_runner.rs
+++ b/src/expr-test-util/tests/test_runner.rs
@@ -91,6 +91,36 @@ mod test {
                             Err(err) => format!("error: {}\n", err),
                         }
                     }
+                    "rel-to-test" => {
+                        let mut ctx = MirRelationExprDeserializeContext::new(&catalog);
+                        let spec = from_json(
+                            &serde_json::from_str(&s.input).unwrap(),
+                            "MirRelationExpr",
+                            &RTI,
+                            &mut ctx,
+                        );
+                        let mut source_defs = ctx
+                            .list_scope_references()
+                            .map(|(name, typ)| {
+                                format!(
+                                    "(defsource {} {})",
+                                    name,
+                                    from_json(
+                                        &serde_json::to_value(typ).unwrap(),
+                                        "RelationType",
+                                        &RTI,
+                                        &mut GenericTestDeserializeContext::default()
+                                    )
+                                )
+                            })
+                            .collect::<Vec<_>>();
+                        source_defs.sort();
+                        format!(
+                            "cat\n{}\n----\nok\n\n{}\n",
+                            separated("\n", source_defs),
+                            spec
+                        )
+                    }
                     _ => panic!("unknown directive: {}", s.directive),
                 }
             })

--- a/src/expr-test-util/tests/testdata/rel
+++ b/src/expr-test-util/tests/testdata/rel
@@ -150,3 +150,19 @@ build
 | Distinct group=(#2)
 ----
 ----
+
+build
+(union [(map (get x) [(null int32)]) (get y)])
+----
+----
+%0 =
+| Get x (u0)
+| Map null
+
+%1 =
+| Get y (u1)
+
+%2 =
+| Union %0 %1
+----
+----

--- a/src/expr-test-util/tests/testdata/scalar
+++ b/src/expr-test-util/tests/testdata/scalar
@@ -46,3 +46,8 @@ build-scalar
 (call_unary is_null null)
 ----
 isnull(null)
+
+build-scalar
+("1999-12-31 23:42:23.342" timestamp)
+----
+1999-12-31 23:42:23.342

--- a/src/expr-test-util/tests/testdata/tospec
+++ b/src/expr-test-util/tests/testdata/tospec
@@ -1,0 +1,96 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test 1: We can take MirRelationExpr serialized as JSON and get:
+# * the catalog commands for registering the sources that MirRelationExpr
+#   references.
+# * the MirRelationExpr in unit test specification form.
+
+rel-to-test
+{"Reduce":{"input":{"Filter":{"input":{"Join":{"inputs":[{"Get":{"id":{"Global":{"User":6}},"typ":{"column_types":[{"scalar_type":"Int16","nullable":false},{"scalar_type":"Int16","nullable":false},{"scalar_type":"Int32","nullable":false},{"scalar_type":"String","nullable":true},{"scalar_type":"String","nullable":true},{"scalar_type":"String","nullable":true},{"scalar_type":"String","nullable":true},{"scalar_type":"String","nullable":true},{"scalar_type":"String","nullable":true},{"scalar_type":"String","nullable":true},{"scalar_type":"String","nullable":true},{"scalar_type":"String","nullable":true},{"scalar_type":"Date","nullable":true},{"scalar_type":"String","nullable":true},{"scalar_type":{"Numeric":{"scale":2}},"nullable":true},{"scalar_type":{"Numeric":{"scale":4}},"nullable":true},{"scalar_type":{"Numeric":{"scale":2}},"nullable":true},{"scalar_type":{"Numeric":{"scale":2}},"nullable":true},{"scalar_type":"Int16","nullable":true},{"scalar_type":"Int16","nullable":true},{"scalar_type":"String","nullable":true},{"scalar_type":"Int32","nullable":true}],"keys":[[0,1,2]]}}},{"Get":{"id":{"Global":{"User":16}},"typ":{"column_types":[{"scalar_type":"Int32","nullable":false},{"scalar_type":"Int16","nullable":false},{"scalar_type":"Int32","nullable":false},{"scalar_type":"Int16","nullable":true},{"scalar_type":"Date","nullable":true},{"scalar_type":"Int16","nullable":true},{"scalar_type":"Int16","nullable":true},{"scalar_type":"Int16","nullable":true}],"keys":[[0,1,2]]}}},{"Get":{"id":{"Global":{"User":19}},"typ":{"column_types":[{"scalar_type":"Int32","nullable":false},{"scalar_type":"Int16","nullable":false},{"scalar_type":"Int32","nullable":false},{"scalar_type":"Int16","nullable":false},{"scalar_type":"Int32","nullable":true},{"scalar_type":"Int32","nullable":true},{"scalar_type":"Date","nullable":true},{"scalar_type":"Int16","nullable":true},{"scalar_type":{"Numeric":{"scale":2}},"nullable":true},{"scalar_type":"String","nullable":true}],"keys":[[0,1,2,3]]}}},{"Get":{"id":{"Global":{"User":26}},"typ":{"column_types":[{"scalar_type":"Int32","nullable":false},{"scalar_type":"Int32","nullable":false},{"scalar_type":"Int16","nullable":true},{"scalar_type":"String","nullable":true},{"scalar_type":"String","nullable":true},{"scalar_type":"String","nullable":true},{"scalar_type":"String","nullable":true},{"scalar_type":"String","nullable":true},{"scalar_type":"String","nullable":true},{"scalar_type":"String","nullable":true},{"scalar_type":"String","nullable":true},{"scalar_type":"String","nullable":true},{"scalar_type":"String","nullable":true},{"scalar_type":"Int32","nullable":true},{"scalar_type":"Int16","nullable":true},{"scalar_type":"Int16","nullable":true},{"scalar_type":"String","nullable":true},{"scalar_type":"Int32","nullable":false}],"keys":[[0,1]]}}},{"Get":{"id":{"Global":{"User":34}},"typ":{"column_types":[{"scalar_type":"Int16","nullable":false},{"scalar_type":"String","nullable":false},{"scalar_type":"String","nullable":false},{"scalar_type":"Int16","nullable":false},{"scalar_type":"String","nullable":false},{"scalar_type":{"Numeric":{"scale":2}},"nullable":false},{"scalar_type":"String","nullable":false}],"keys":[[0]]}}},{"Get":{"id":{"Global":{"User":31}},"typ":{"column_types":[{"scalar_type":"Int16","nullable":false},{"scalar_type":"String","nullable":false},{"scalar_type":"Int16","nullable":false},{"scalar_type":"String","nullable":false}],"keys":[[0]]}}},{"Get":{"id":{"Global":{"User":37}},"typ":{"column_types":[{"scalar_type":"Int16","nullable":false},{"scalar_type":"String","nullable":false},{"scalar_type":"String","nullable":false}],"keys":[[0]]}}}],"equivalences":[],"demand":null,"implementation":"Unimplemented"}},"predicates":[{"CallBinary":{"func":"Eq","expr1":{"Column":0},"expr2":{"Column":25}}},{"CallBinary":{"func":"Eq","expr1":{"Column":1},"expr2":{"Column":23}}},{"CallBinary":{"func":"Eq","expr1":{"Column":2},"expr2":{"Column":24}}},{"CallBinary":{"func":"Eq","expr1":{"Column":21},"expr2":{"CallUnary":{"func":"CastInt16ToInt32","expr":{"Column":61}}}}},{"CallBinary":{"func":"Eq","expr1":{"Column":22},"expr2":{"Column":30}}},{"CallBinary":{"func":"Eq","expr1":{"Column":23},"expr2":{"Column":31}}},{"CallBinary":{"func":"Eq","expr1":{"Column":24},"expr2":{"Column":32}}},{"CallBinary":{"func":"Eq","expr1":{"Column":32},"expr2":{"Column":41}}},{"CallBinary":{"func":"Eq","expr1":{"Column":34},"expr2":{"Column":40}}},{"CallBinary":{"func":"Eq","expr1":{"Column":57},"expr2":{"CallUnary":{"func":"CastInt16ToInt32","expr":{"Column":58}}}}},{"CallBinary":{"func":"Eq","expr1":{"Column":61},"expr2":{"Column":65}}},{"CallBinary":{"func":"Eq","expr1":{"Column":67},"expr2":{"Column":69}}},{"CallBinary":{"func":"Eq","expr1":{"Column":70},"expr2":{"Literal":[{"Ok":{"data":[17,6,69,85,82,79,80,69]}},{"scalar_type":"String","nullable":false}]}}},{"CallBinary":{"func":"Gte","expr1":{"CallUnary":{"func":"CastDateToTimestamp","expr":{"Column":26}}},"expr2":{"Literal":[{"Ok":{"data":[10,46,224,250,0,0,0,0,0,0,0,0,0]}},{"scalar_type":"Timestamp","nullable":false}]}}}]}},"group_key":[{"Column":66}],"aggregates":[{"func":"SumNumeric","expr":{"Column":38},"distinct":false}],"monotonic":false,"expected_group_size":null}}
+----
+----
+cat
+(defsource u16 ([(Int32 false) (Int16 false) (Int32 false) (Int16 true) (Date true) (Int16 true) (Int16 true) (Int16 true)] [[0 1 2]]))
+(defsource u19 ([(Int32 false) (Int16 false) (Int32 false) (Int16 false) (Int32 true) (Int32 true) (Date true) (Int16 true) ((Numeric 2) true) (String true)] [[0 1 2 3]]))
+(defsource u26 ([(Int32 false) (Int32 false) (Int16 true) (String true) (String true) (String true) (String true) (String true) (String true) (String true) (String true) (String true) (String true) (Int32 true) (Int16 true) (Int16 true) (String true) (Int32 false)] [[0 1]]))
+(defsource u31 ([(Int16 false) (String false) (Int16 false) (String false)] [[0]]))
+(defsource u34 ([(Int16 false) (String false) (String false) (Int16 false) (String false) ((Numeric 2) false) (String false)] [[0]]))
+(defsource u37 ([(Int16 false) (String false) (String false)] [[0]]))
+(defsource u6 ([(Int16 false) (Int16 false) (Int32 false) (String true) (String true) (String true) (String true) (String true) (String true) (String true) (String true) (String true) (Date true) (String true) ((Numeric 2) true) ((Numeric 4) true) ((Numeric 2) true) ((Numeric 2) true) (Int16 true) (Int16 true) (String true) (Int32 true)] [[0 1 2]]))
+----
+ok
+
+(Reduce (Filter (Join [(get u6) (get u16) (get u19) (get u26) (get u34) (get u31) (get u37)] [] null Unimplemented) [(CallBinary Eq #0 #25) (CallBinary Eq #1 #23) (CallBinary Eq #2 #24) (CallBinary Eq #21 (CallUnary CastInt16ToInt32 #61)) (CallBinary Eq #22 #30) (CallBinary Eq #23 #31) (CallBinary Eq #24 #32) (CallBinary Eq #32 #41) (CallBinary Eq #34 #40) (CallBinary Eq #57 (CallUnary CastInt16ToInt32 #58)) (CallBinary Eq #61 #65) (CallBinary Eq #67 #69) (CallBinary Eq #70 ("EUROPE" String)) (CallBinary Gte (CallUnary CastDateToTimestamp #26) ("2007-01-02 00:00:00" Timestamp))]) [#66] [(SumNumeric #38 false)] false null)
+----
+----
+
+# Test 2: Make sure that the output of Test 1 are valid test specifications.
+
+cat
+(defsource u16 ([(Int32 false) (Int16 false) (Int32 false) (Int16 true) (Date true) (Int16 true) (Int16 true) (Int16 true)] [[0 1 2]]))
+(defsource u19 ([(Int32 false) (Int16 false) (Int32 false) (Int16 false) (Int32 true) (Int32 true) (Date true) (Int16 true) ((Numeric 2) true) (String true)] [[0 1 2 3]]))
+(defsource u26 ([(Int32 false) (Int32 false) (Int16 true) (String true) (String true) (String true) (String true) (String true) (String true) (String true) (String true) (String true) (String true) (Int32 true) (Int16 true) (Int16 true) (String true) (Int32 false)] [[0 1]]))
+(defsource u31 ([(Int16 false) (String false) (Int16 false) (String false)] [[0]]))
+(defsource u34 ([(Int16 false) (String false) (String false) (Int16 false) (String false) ((Numeric 2) false) (String false)] [[0]]))
+(defsource u37 ([(Int16 false) (String false) (String false)] [[0]]))
+(defsource u6 ([(Int16 false) (Int16 false) (Int32 false) (String true) (String true) (String true) (String true) (String true) (String true) (String true) (String true) (String true) (Date true) (String true) ((Numeric 2) true) ((Numeric 4) true) ((Numeric 2) true) ((Numeric 2) true) (Int16 true) (Int16 true) (String true) (Int32 true)] [[0 1 2]]))
+----
+ok
+
+build
+(Filter
+    (Join [(get u6) (get u16) (get u19) (get u26) (get u34) (get
+        u31) (get u37)] [] null Unimplemented)
+    [(CallBinary Eq #0 #25)
+    (CallBinary Eq #1 #23)
+    (CallBinary Eq #2 #24)
+    (CallBinary Eq #21 (CallUnary CastInt16ToInt32 #61))
+    (CallBinary Eq #22 #30)
+    (CallBinary Eq #23 #31)
+    (CallBinary Eq #24 #32)
+    (CallBinary Eq #32 #41)
+    (CallBinary Eq #34 #40)
+    (CallBinary Eq #57 (CallUnary CastInt16ToInt32 #58))
+    (CallBinary Eq #61 #65)
+    (CallBinary Eq #67 #69)
+    (CallBinary Eq #70 ("EUROPE" String))
+    (CallBinary Gte (CallUnary CastDateToTimestamp #26)
+        ("2007-01-02 00:00:00" Timestamp))
+    ]
+)
+----
+----
+%0 =
+| Get u6 (u6)
+
+%1 =
+| Get u16 (u0)
+
+%2 =
+| Get u19 (u1)
+
+%3 =
+| Get u26 (u2)
+
+%4 =
+| Get u34 (u4)
+
+%5 =
+| Get u31 (u3)
+
+%6 =
+| Get u37 (u5)
+
+%7 =
+| Join %0 %1 %2 %3 %4 %5 %6
+| | implementation = Unimplemented
+| Filter (#0 = #25), (#1 = #23), (#2 = #24), (#21 = i16toi32(#61)), (#22 = #30), (#23 = #31), (#24 = #32), (#32 = #41), (#34 = #40), (#57 = i16toi32(#58)), (#61 = #65), (#67 = #69), (#70 = "EUROPE"), (datetots(#26) >= 2007-01-02 00:00:00)
+----
+----

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -1223,6 +1223,11 @@ impl MirRelationExpr {
         ViewExplanation::new(self, &DummyHumanizer).to_string()
     }
 
+    /// Print this MirRelationExpr to a JSON-formatted string.
+    pub fn json(&self) -> String {
+        serde_json::to_string(self).unwrap()
+    }
+
     /// Pretty-print this MirRelationExpr to a string with type information.
     pub fn pretty_typed(&self) -> String {
         let mut explanation = ViewExplanation::new(self, &DummyHumanizer);

--- a/src/expr/tests/test_runner.rs
+++ b/src/expr/tests/test_runner.rs
@@ -11,12 +11,12 @@ mod test {
     use expr::canonicalize::canonicalize_predicates;
     use expr::MirScalarExpr;
     use expr_test_util::*;
-    use lowertest::{deserialize, parse_str};
+    use lowertest::{deserialize, tokenize};
     use ore::str::separated;
     use repr::RelationType;
 
     fn reduce(s: &str) -> Result<MirScalarExpr, String> {
-        let mut input_stream = parse_str(&s)?.into_iter();
+        let mut input_stream = tokenize(&s)?.into_iter();
         let mut ctx = MirScalarExprDeserializeContext::default();
         let mut scalar: MirScalarExpr =
             deserialize(&mut input_stream, "MirScalarExpr", &RTI, &mut ctx)?;
@@ -26,7 +26,7 @@ mod test {
     }
 
     fn test_canonicalize_pred(s: &str) -> Result<Vec<MirScalarExpr>, String> {
-        let mut input_stream = parse_str(&s)?.into_iter();
+        let mut input_stream = tokenize(&s)?.into_iter();
         let mut ctx = MirScalarExprDeserializeContext::default();
         let mut predicates: Vec<MirScalarExpr> =
             deserialize(&mut input_stream, "Vec<MirScalarExpr>", &RTI, &mut ctx)?;

--- a/src/lowertest/src/lib.rs
+++ b/src/lowertest/src/lib.rs
@@ -15,6 +15,7 @@ use std::collections::HashMap;
 
 use proc_macro2::{Delimiter, TokenStream, TokenTree};
 use serde::de::DeserializeOwned;
+use serde_json::Value;
 
 use ore::{result::ResultExt, str::separated};
 
@@ -52,9 +53,23 @@ pub trait MzStructReflect {
     fn mz_struct_reflect() -> (Vec<&'static str>, Vec<&'static str>);
 }
 
-pub fn parse_str(s: &str) -> Result<TokenStream, String> {
+/* #region Utilities */
+
+/// Converts `s` into a [proc_macro2::TokenStream]
+pub fn tokenize(s: &str) -> Result<TokenStream, String> {
     s.parse::<TokenStream>().map_err_to_string()
 }
+
+/// Changes `"\"foo\""` to `"foo"`
+pub fn unquote(s: &str) -> String {
+    if s.starts_with('"') && s.ends_with('"') {
+        s[1..(s.len() - 1)].replace("\\\"", "\"")
+    } else {
+        s.to_string()
+    }
+}
+
+/* #endregion */
 
 /// If the `stream_iter` is not empty, deserialize the next `TokenTree` into a `D`.
 ///
@@ -135,18 +150,7 @@ where
     C: TestDeserializeContext,
     I: Iterator<Item = TokenTree>,
 {
-    // Normalize the type name by stripping whitespace.
-    let type_name = type_name.replace(" ", "");
-    // Eliminate outer `Option<>` and `Box<>` from type names because they are
-    // inconsequential when it comes to creating a correctly deserializable JSON
-    // string.
-    let type_name = if type_name.starts_with("Option<") && type_name.ends_with('>') {
-        &type_name[7..(type_name.len() - 1)]
-    } else if type_name.starts_with("Box<") && type_name.ends_with('>') {
-        &type_name[4..(type_name.len() - 1)]
-    } else {
-        &type_name
-    };
+    let type_name = &normalize_type_name(type_name);
     if let Some(first_arg) = stream_iter.next() {
         // If the type refers to an enum or struct defined by us, go to a
         // special branch that allows reuse of code paths for the
@@ -257,7 +261,7 @@ pub struct ReflectedTypeInfo {
 /// * strings and positive numeric values (like 1 or 1.1) to be `Literal`s.
 /// * negative numeric values to be a `Punct('-')` followed by a `Literal`.
 pub trait TestDeserializeContext {
-    /// Override the way that `first_arg` is resolved.
+    /// Override the way that `first_arg` is resolved to JSON.
     ///
     /// `first_arg` is the first `TokenTree` of the `TokenStream`.
     /// `rest_of_stream` contains a reference to the rest of the stream.
@@ -275,6 +279,18 @@ pub trait TestDeserializeContext {
     ) -> Result<Option<String>, String>
     where
         I: Iterator<Item = TokenTree>;
+
+    /// Converts `json` back to the extended syntax specified by
+    /// [TestDeserializeContext::override_syntax<I>].
+    ///
+    /// Returns `Some(value)` if `json` has been resolved.
+    /// Returns `None` is `json` should be resolved in the default manner.
+    fn reverse_syntax_override(
+        &mut self,
+        json: &Value,
+        type_name: &str,
+        rti: &ReflectedTypeInfo,
+    ) -> Option<String>;
 }
 
 /// Default `TestDeserializeContext`.
@@ -296,9 +312,18 @@ impl TestDeserializeContext for GenericTestDeserializeContext {
     {
         Ok(None)
     }
+
+    fn reverse_syntax_override(
+        &mut self,
+        _: &Value,
+        _: &str,
+        _: &ReflectedTypeInfo,
+    ) -> Option<String> {
+        None
+    }
 }
 
-/* #region helper functions */
+/* #region helper functions for `to_json` */
 
 /// Converts all `TokenTree`s into JSON deserializable to `type_name`.
 fn parse_as_vec<I, C>(
@@ -331,30 +356,11 @@ where
     C: TestDeserializeContext,
     I: Iterator<Item = TokenTree>,
 {
-    let mut next_elem_begin = 0;
+    let mut prev_elem_end = 0;
     let mut result = Vec::new();
-    loop {
-        // The elements of the tuple can be a plain type, a nested tuple, or a
-        // Box/Vec/Option with the argument being nested tuple.
-        // `type1, (type2, type3), Vec<(type4, type5)>`
-        // Thus, the type of the next element is whatever comes before the
-        // next comma. Unless... a '(' comes from before the next comma, which
-        // means it is a nested tuple, and the type of the next element is
-        // whatever comes before the comma after the last ')'.
-        let mut next_elem_end = type_name[next_elem_begin..]
-            .find(',')
-            .unwrap_or_else(|| type_name.len());
-        if let Some(l_paren_pos) = type_name[next_elem_begin..].find('(') {
-            if l_paren_pos < next_elem_end {
-                if let Some(r_paren_pos) = type_name[next_elem_begin..].rfind(')') {
-                    next_elem_end = next_elem_begin
-                        + r_paren_pos
-                        + type_name[(next_elem_begin + r_paren_pos)..]
-                            .find(',')
-                            .unwrap_or_else(|| type_name.len());
-                }
-            }
-        };
+    while let Some((next_elem_begin, next_elem_end)) =
+        find_next_type_in_tuple(type_name, prev_elem_end)
+    {
         match to_json(
             stream_iter,
             &type_name[next_elem_begin..next_elem_end],
@@ -366,13 +372,7 @@ where
             // elements of the tuple are optional.
             None => break,
         }
-        if next_elem_end < type_name.len() {
-            //skip over the comma
-            next_elem_begin = next_elem_end + 1;
-        } else {
-            // assume that that we have reached the end of the tuple.
-            break;
-        }
+        prev_elem_end = next_elem_end;
     }
     Ok(result)
 }
@@ -593,4 +593,184 @@ where
         }
     }
 }
+
+/* #endregion */
+
+/// Converts serialized JSON to the syntax that [to_json] handles.
+///
+/// `json` is assumed to have been produced by serializing an object of type
+/// `type_name`.
+/// `ctx` is responsible for converting serialized JSON to any syntax
+/// extensions or overrides.
+pub fn from_json<C>(json: &Value, type_name: &str, rti: &ReflectedTypeInfo, ctx: &mut C) -> String
+where
+    C: TestDeserializeContext,
+{
+    let type_name = normalize_type_name(type_name);
+    if let Some(result) = ctx.reverse_syntax_override(json, &type_name, rti) {
+        return result;
+    }
+    if let Some((names, types)) = rti.struct_dict.get(&type_name[..]) {
+        format!("({})", from_json_fields(json, names, types, rti, ctx))
+    } else if let Some(enum_dict) = rti.enum_dict.get(&type_name[..]) {
+        match json {
+            // A unit enum in JSON is `"variant"`. In the spec it is `variant`.
+            Value::String(s) => unquote(s),
+            // An enum with fields is `{"variant": <fields>}` in JSON. In the
+            // spec it is `(variant field1 .. fieldn).
+            Value::Object(map) => {
+                // Each enum instance only belongs to one variant.
+                assert_eq!(
+                    map.len(),
+                    1,
+                    "Multivariant instance {:?} found for enum {}",
+                    map,
+                    type_name
+                );
+                for (variant, data) in map.iter() {
+                    if let Some((names, types)) = enum_dict.get(&variant[..]) {
+                        return format!(
+                            "({} {})",
+                            variant.to_string(),
+                            from_json_fields(data, names, types, rti, ctx)
+                        );
+                    }
+                }
+                unreachable!()
+            }
+            _ => unreachable!("Invalid json {:?} for enum type {}", json, type_name),
+        }
+    } else {
+        match json {
+            Value::Array(members) => {
+                let result = if type_name.starts_with("Vec<") && type_name.ends_with('>') {
+                    // This is a Vec<something>.
+                    members
+                        .iter()
+                        .map(|v| from_json(v, &type_name[4..(type_name.len() - 1)], rti, ctx))
+                        .collect::<Vec<_>>()
+                } else {
+                    // This is a tuple.
+                    let mut result = Vec::new();
+                    let type_name = &type_name[1..(type_name.len() - 1)];
+                    let mut prev_elem_end = 0;
+                    let mut members_iter = members.into_iter();
+                    while let Some((next_elem_begin, next_elem_end)) =
+                        find_next_type_in_tuple(type_name, prev_elem_end)
+                    {
+                        match members_iter.next() {
+                            Some(elem) => result.push(from_json(
+                                elem,
+                                &type_name[next_elem_begin..next_elem_end],
+                                rti,
+                                ctx,
+                            )),
+                            // we have reached the end of the tuple.
+                            None => break,
+                        }
+                        prev_elem_end = next_elem_end;
+                    }
+                    result
+                };
+                // The spec for both is `[elem1 .. elemn]`
+                format!("[{}]", separated(" ", result))
+            }
+            Value::Object(map) => {
+                unreachable!("Invalid map {:?} found for type {}", map, type_name)
+            }
+            other => other.to_string(),
+        }
+    }
+}
+
+fn from_json_fields<C>(
+    v: &Value,
+    f_names: &[&'static str],
+    f_types: &[&'static str],
+    rti: &ReflectedTypeInfo,
+    ctx: &mut C,
+) -> String
+where
+    C: TestDeserializeContext,
+{
+    match v {
+        // Named fields are specified as
+        // `{"field1_name": field1, .. "fieldn_name": fieldn}`
+        // not necessarily in that order because maps are unordered.
+        // Thus, when converting named fields to the test spec, it is necessary
+        // to retrieve values from the map in the order given by `f_names`.
+        Value::Object(map) if !f_names.is_empty() => {
+            let mut fields = Vec::with_capacity(f_types.len());
+            for (name, typ) in f_names.iter().zip(f_types.iter()) {
+                fields.push(from_json(&map[*name], typ, rti, ctx))
+            }
+            separated(" ", fields).to_string()
+        }
+        // Multiple unnamed fields are specified as `[field1 .. fieldn]` in
+        // JSON.
+        Value::Array(inner) if f_types.len() > 1 => {
+            let mut fields = Vec::with_capacity(f_types.len());
+            for (v, typ) in inner.iter().zip(f_types.iter()) {
+                fields.push(from_json(v, typ, rti, ctx))
+            }
+            separated(" ", fields).to_string()
+        }
+        // A single unnamed field is specified as `field` in JSON.
+        other => from_json(other, f_types.first().unwrap(), rti, ctx),
+    }
+}
+
+/* #region Helper functions common to both spec-to-JSON and the JSON-to-spec
+transformations. */
+
+fn normalize_type_name(type_name: &str) -> String {
+    // Normalize the type name by stripping whitespace.
+    let type_name = type_name.replace(" ", "");
+    // Eliminate outer `Option<>` and `Box<>` from type names because they are
+    // inconsequential when it comes to creating a correctly deserializable JSON
+    // string.
+    let type_name = if type_name.starts_with("Option<") && type_name.ends_with('>') {
+        &type_name[7..(type_name.len() - 1)]
+    } else if type_name.starts_with("Box<") && type_name.ends_with('>') {
+        &type_name[4..(type_name.len() - 1)]
+    } else {
+        &type_name
+    };
+    type_name.to_string()
+}
+
+fn find_next_type_in_tuple(type_name: &str, prev_elem_end: usize) -> Option<(usize, usize)> {
+    let current_elem_begin = if prev_elem_end > 0 {
+        //skip over the comma
+        prev_elem_end + 1
+    } else {
+        prev_elem_end
+    };
+    if current_elem_begin >= type_name.len() {
+        return None;
+    }
+    // The elements of the tuple can be a plain type, a nested tuple, or a
+    // Box/Vec/Option with the argument being nested tuple.
+    // `type1, (type2, type3), Vec<(type4, type5)>`
+    // Thus, the type of the next element is whatever comes before the
+    // next comma. Unless... a '(' comes from before the next comma, which
+    // means it is a nested tuple, and the type of the next element is
+    // whatever comes before the comma after the last ')'.
+    let mut current_elem_end = type_name[current_elem_begin..]
+        .find(',')
+        .unwrap_or_else(|| type_name.len());
+    if let Some(l_paren_pos) = type_name[current_elem_begin..].find('(') {
+        if l_paren_pos < current_elem_end {
+            if let Some(r_paren_pos) = type_name[current_elem_begin..].rfind(')') {
+                current_elem_end = current_elem_begin
+                    + r_paren_pos
+                    + type_name[(current_elem_begin + r_paren_pos)..]
+                        .find(',')
+                        .unwrap_or_else(|| type_name.len());
+            }
+        }
+    };
+    return Some((current_elem_begin, current_elem_end));
+}
+
 /* #endregion */

--- a/src/lowertest/tests/testdata/build
+++ b/src/lowertest/tests/testdata/build
@@ -69,6 +69,8 @@ build
 ----
 Some(SingleUnnamedField(SingleUnnamedArg(-1.1)))
 
+# single field is a literal
+
 build
 (single_unnamed_field 2.2)
 ----
@@ -102,6 +104,18 @@ build
 (multi_unnamed_fields ([], "bar") ([false null true]) (single_named_field [0 10 11]))
 ----
 Some(MultiUnnamedFields(MultiUnnamedArg([], "bar"), MultiNamedArg { fizz: [Some(false), None, Some(true)], bizz: [] }, SingleNamedField { foo: [0, 10, 11] }))
+
+build
+(single_unnamed_field2 [-1 4 -2 0])
+----
+Some(SingleUnnamedField2([-1, 4, -2, 0]))
+
+#single field is a struct with named fields
+
+build
+(single_unnamed_field3 ([true false false null] [[[-1.25 true] [1.24 false]]]))
+----
+Some(SingleUnnamedField3(MultiNamedArg { fizz: [Some(true), Some(false), Some(false), None], bizz: [[(SingleUnnamedArg(-1.25), true), (SingleUnnamedArg(1.24), false)]] }))
 
 # Arguments are assumed to be part of an outer struct/enum
 # unless enclosed in parentheses.

--- a/src/lowertest/tests/testdata/build-override
+++ b/src/lowertest/tests/testdata/build-override
@@ -59,6 +59,18 @@ build override=true
 Some(SingleUnnamedField(SingleUnnamedArg(2.2)))
 
 build override=true
+(single_unnamed_field2 [-1 4 -2 0])
+----
+Some(SingleUnnamedField2([-1, 4, -2, 0]))
+
+#single field is a struct with named fields
+
+build override=true
+(single_unnamed_field3 ([true false false null] [[[-1.25 true] [1.24 false]]]))
+----
+Some(SingleUnnamedField3(MultiNamedArg { fizz: [Some(true), Some(false), Some(false), None], bizz: [[(SingleUnnamedArg(-1.25), true), (SingleUnnamedArg(1.24), false)]] }))
+
+build override=true
 (multi_unnamed_fields_2 false unit)
 ----
 Some(MultiUnnamedFields2(OptionalArg(false, (0.0, 0)), FirstArgEnum { test_enum: Unit, second_arg: "" }, ""))

--- a/src/repr-test-util/Cargo.toml
+++ b/src/repr-test-util/Cargo.toml
@@ -6,8 +6,10 @@ edition = "2018"
 publish = false
 
 [dependencies]
+chrono = { version = "0.4.0", default-features = false, features = ["serde", "std"] }
 lazy_static = "1.4.0"
 lowertest = {path = "../lowertest"}
+ore = {path = "../ore"}
 repr = {path = "../repr"}
 proc-macro2 = "1.0.28"
 

--- a/src/repr-test-util/tests/test_runner.rs
+++ b/src/repr-test-util/tests/test_runner.rs
@@ -10,16 +10,29 @@
 #[cfg(test)]
 mod tests {
     use lowertest::tokenize;
-    use repr::{Datum, ScalarType};
-    use repr_test_util::{get_datum_from_str, get_scalar_type_or_default};
+    use repr::ScalarType;
+    use repr_test_util::{get_datum_from_str, get_scalar_type_or_default, unquote_string};
 
-    fn build_datum<'a>(s: &'a str) -> Result<Datum<'a>, String> {
+    fn build_datum(s: &str) -> Result<String, String> {
+        // 1) Convert test spec to the datum.
         let s = s.trim();
         let (litval, scalar_type) = s.split_at(
             s.find(|c| [' ', '\t', '\n'].contains(&c))
                 .unwrap_or_else(|| s.len()),
         );
-        get_datum_from_str(litval, &build_scalar_type_inner(litval, scalar_type)?)
+        let scalar_type = build_scalar_type_inner(litval, scalar_type)?;
+        let unquoted_litval = unquote_string(litval, &scalar_type);
+        let datum = get_datum_from_str(&unquoted_litval[..], &scalar_type)?;
+        // 2) It should be possible to convert the datum back to the test spec.
+        let roundtrip_s = datum_to_test_spec(datum);
+        if roundtrip_s != litval {
+            Err(format!(
+                "Round trip failed. Old spec: {}. New spec: {}.",
+                litval, roundtrip_s
+            ))
+        } else {
+            Ok(format!("{:?}", datum))
+        }
     }
 
     fn build_scalar_type(s: &str) -> Result<ScalarType, String> {
@@ -40,7 +53,7 @@ mod tests {
                         Err(err) => format!("error: {}\n", err),
                     },
                     "build-datum" => match build_datum(&s.input) {
-                        Ok(datum) => format!("{:?}\n", datum),
+                        Ok(result) => format!("{}\n", result),
                         Err(err) => format!("error: {}\n", err),
                     },
                     _ => panic!("unknown directive: {}", s.directive),

--- a/src/repr-test-util/tests/test_runner.rs
+++ b/src/repr-test-util/tests/test_runner.rs
@@ -11,17 +11,28 @@
 mod tests {
     use lowertest::tokenize;
     use repr::ScalarType;
-    use repr_test_util::{get_datum_from_str, get_scalar_type_or_default, unquote_string};
+    use repr_test_util::{
+        datum_to_test_spec, get_datum_from_str, get_scalar_type_or_default, unquote_string,
+    };
 
     fn build_datum(s: &str) -> Result<String, String> {
         // 1) Convert test spec to the datum.
         let s = s.trim();
-        let (litval, scalar_type) = s.split_at(
-            s.find(|c| [' ', '\t', '\n'].contains(&c))
-                .unwrap_or_else(|| s.len()),
-        );
+        let (litval, scalar_type) = if s.starts_with('"') {
+            s.split_at(
+                s[1..]
+                    .rfind(|c| '"' == c)
+                    .map(|i| i + 2)
+                    .unwrap_or_else(|| s.len()),
+            )
+        } else {
+            s.split_at(
+                s.find(|c| [' ', '\t', '\n'].contains(&c))
+                    .unwrap_or_else(|| s.len()),
+            )
+        };
         let scalar_type = build_scalar_type_inner(litval, scalar_type)?;
-        let unquoted_litval = unquote_string(litval, &scalar_type);
+        let unquoted_litval = unquote_string(&litval, &scalar_type);
         let datum = get_datum_from_str(&unquoted_litval[..], &scalar_type)?;
         // 2) It should be possible to convert the datum back to the test spec.
         let roundtrip_s = datum_to_test_spec(datum);

--- a/src/repr-test-util/tests/test_runner.rs
+++ b/src/repr-test-util/tests/test_runner.rs
@@ -9,7 +9,7 @@
 
 #[cfg(test)]
 mod tests {
-    use lowertest::parse_str;
+    use lowertest::tokenize;
     use repr::{Datum, ScalarType};
     use repr_test_util::{get_datum_from_str, get_scalar_type_or_default};
 
@@ -27,7 +27,7 @@ mod tests {
     }
 
     fn build_scalar_type_inner(litval: &str, s: &str) -> Result<ScalarType, String> {
-        get_scalar_type_or_default(litval, &mut parse_str(s)?.into_iter())
+        get_scalar_type_or_default(litval, &mut tokenize(s)?.into_iter())
     }
 
     #[test]

--- a/src/repr-test-util/tests/testdata/datum
+++ b/src/repr-test-util/tests/testdata/datum
@@ -64,6 +64,16 @@ build-datum
 String("hello")
 
 build-datum
+"hel\"lo" string
+----
+String("hel\"lo")
+
+build-datum
+"\"hello\"" string
+----
+String("\"hello\"")
+
+build-datum
 null string
 ----
 Null

--- a/src/repr-test-util/tests/testdata/datum
+++ b/src/repr-test-util/tests/testdata/datum
@@ -94,6 +94,16 @@ build-datum
 Numeric(OrderedDecimal(5.2))
 
 build-datum
+"2021-01-02 00:12:59" timestamp
+----
+Timestamp(2021-01-02T00:12:59)
+
+build-datum
+"1999-12-31 23:42:23.342" timestamp
+----
+Timestamp(1999-12-31T23:42:23.342)
+
+build-datum
 2 (list jsonb 100)
 ----
 error: Unsupported literal type List { element_type: Jsonb, custom_oid: Some(100) }


### PR DESCRIPTION
This PR was inspired by finding that often times, there is a SQL query that plans strangely, and it would be nice to just grab the `MirRelationExpr` object at some intermediate step in the transform process to run tests on it and see how it reacts to different transforms. 

We currently have the transformation (readable syntax) -> JSON -> MirRelationExpr. This PR is for doing the reverse transformation, namely MirRelationExpr -> JSON -> (readable syntax). 

I realized just as I was posting the PR that if we just wanted to grab the MirRelationExpr` object at some intermediate step in the transform process, we don't need the JSON -> (readable syntax) transform because we could
1. just add a `println` in the transform process that prints out the MirRelationExpr in serialized JSON form.
2. copy the serialized JSON into some test and deserialize it back into the `MirRelationExpr`.

Oops. But hopefully the ability to roundtrip the test syntax will come in handy for some debugging cases and in the future for things like test migration.

Outside the scope of the PR:
1. Pretty-printing what comes out after the roundtrip.
2. Maybe in the future, we want the JSON -> (readable syntax) transformation to happen via less steps than what is in the README https://github.com/wangandi/materialize/blob/roundtrip/src/expr-test-util/README.md#debugging.

Other changes:
* String datums were not being constructed correctly if it contained `"`. For example, the test spec `"\"hello\""` should be translated to the string datum `"hello"`. Instead, it was being translated to the string datum `\"hello\`. This has been fixed.
* Allow creating Timestamp datums. The syntax is `("2000-01-01 00:00:00 " timestamp)`
* The syntax to create a `MirRelationExpr::Constant` is now 
  `(constant [[<row1literal1>..<row1literaln>]..[<rowiliteral1>..<rowiliteraln>]] <RelationType>)` whereas it used to be 
  `(constant [[<row1literal1>..<row1literaln>]..[<rowiliteral1>..<rowiliteraln>]] [<scalartype1>..<scalartypen>])` . Since `nullable` is an optional field of `ColumnType`, and `keys` is an optional field of `RelationType`, all existing tests still work; it's just that the syntax is more flexible now.

For ease of reviewing, I've tried to break the PR into commits consisting of related changes. I recommend hiding whitespace changes. 