### PR TITLE
interchange: disallow Protobuf messages with unsigned integers

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -48,6 +48,15 @@ Wrap your release notes at the 80 character mark.
 
 {{% version-header v0.8.4 %}}
 
+- **Breaking change.** Reject [Protobuf sources] whose schemas contain
+  unsigned integer types (`uint32`, `uint64`, `fixed32`, and `fixed64`).
+  Materialize previously converted these types to
+  [`numeric`](/sql/types/numeric).
+
+  A future version of Materialize is likely to support unsigned integers
+  natively, at which point the aforementioned Protobuf types will be converted
+  to the appropriate Materialize types.
+
 - **Breaking change.** The `HTTP_PROXY` variable is no longer respected. Use
   `http_proxy` instead.
 

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -38,7 +38,7 @@ sha2 = "0.9.5"
 smallvec = "1.5.1"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 url = "2.2.2"
-uuid = "0.8.2"
+uuid = { version = "0.8.2", features = ["serde"] }
 
 [dev-dependencies]
 criterion = "0.3.4"

--- a/src/interchange/testdata/fuzz.proto
+++ b/src/interchange/testdata/fuzz.proto
@@ -20,8 +20,6 @@ message TestRecord {
   string string_field = 2;
   int64 int64_field = 3;
   Color color_field = 4;
-  uint32 uint_field = 5;
-  uint64 uint64_field = 6;
   float float_field = 7;
   double double_field = 8;
 }

--- a/src/testdrive/src/format/protobuf/simple.proto
+++ b/src/testdrive/src/format/protobuf/simple.proto
@@ -34,3 +34,19 @@ message RepeatedStruct {
   repeated Struct struct_field = 1;
   repeated string st_repeated = 2;
 }
+
+message UInt32 {
+  uint32 f = 1;
+}
+
+message UInt64 {
+  uint64 f = 1;
+}
+
+message Fixed32 {
+  fixed32 f = 1;
+}
+
+message Fixed64 {
+  fixed64 f = 1;
+}

--- a/test/testdrive/protobuf.td
+++ b/test/testdrive/protobuf.td
@@ -17,6 +17,26 @@ Recursive types are not supported: .Self
   FORMAT PROTOBUF MESSAGE '.Mutual1' USING SCHEMA '${testdrive.protobuf-descriptors}'
 Recursive types are not supported: .Mutual1
 
+! CREATE SOURCE bad FROM
+  KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-messages-${testdrive.seed}'
+  FORMAT PROTOBUF MESSAGE '.UInt32' USING SCHEMA '${testdrive.protobuf-descriptors}'
+Protobuf type "uint32" is not supported
+
+! CREATE SOURCE bad FROM
+  KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-messages-${testdrive.seed}'
+  FORMAT PROTOBUF MESSAGE '.UInt64' USING SCHEMA '${testdrive.protobuf-descriptors}'
+Protobuf type "uint64" is not supported
+
+! CREATE SOURCE bad FROM
+  KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-messages-${testdrive.seed}'
+  FORMAT PROTOBUF MESSAGE '.Fixed32' USING SCHEMA '${testdrive.protobuf-descriptors}'
+Protobuf type "fixed32" is not supported
+
+! CREATE SOURCE bad FROM
+  KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-messages-${testdrive.seed}'
+  FORMAT PROTOBUF MESSAGE '.Fixed64' USING SCHEMA '${testdrive.protobuf-descriptors}'
+Protobuf type "fixed64" is not supported
+
 > CREATE SOURCE protomessages FROM
   KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-messages-${testdrive.seed}'
   FORMAT PROTOBUF MESSAGE '.Struct' USING SCHEMA '${testdrive.protobuf-descriptors}'


### PR DESCRIPTION
rustfmt went a little crazy here but the actual diff is quite small, sorry!

----

We are increasingly considering adding unsigned integer types to
Materialize. If we do so, we will certainly want to change the ingestion
of "uint32" and "uint64" types in Protobuf messages to their
corresponding unsigned types in Materialize.

We currently ingest these types as "numeric", which is capable of
representing all 32- and 64-bit unsigned integers, but loses information
about the "unsigned" constraint. This wart would be particularly
noticeable in a world with Protobuf sinks, where the following setup

    message Message {
      uint32 field f = 1;
    }

    CREATE SOURCE src ... FORMAT PROTOBUF MESSAGE '.Message' ...
    CREATE SINK ... FROM src FORMAT PROTOBUF MESSAGE '.Message' ...

would yield a sink that wrote Protobuf messages containing a decimal
type instead of uint32.

To leave our options open, this commit proposes disabling use of
Materialize with unsigned types entirely. While this might break some
users, we're almost certain we'll need to make a breaking change here
eventually, so better to do it sooner rather than later. If we do get
complaints, we can prioritize the unsigned integer work.