### PR TITLE
docs,sql: temporarily remove CONSISTENCY TOPIC and FORMAT

### DIFF
--- a/doc/user/content/sql/create-sink.md
+++ b/doc/user/content/sql/create-sink.md
@@ -44,8 +44,6 @@ Field | Use
 **TOPIC** _topic&lowbar;prefix_ | The prefix used to generate the Kafka topic name to create and write to.
 **KEY (** _key&lowbar;column&lowbar;list_ **)** | An optional list of columns to use for the Kafka key. If unspecified, the Kafka key is left unset. {{< version-added v0.5.1 />}}
 **WITH OPTIONS (** _option&lowbar;_ **)** | Options affecting sink creation. For more details see [`WITH` options](#with-options).
-**CONSISTENCY TOPIC** _consistency&lowbar;topic_ | Makes the sink emit additional [consistency metadata](#consistency-metadata) to the named topic. Only valid for Kafka sinks. If `reuse_topic` is `true`, a default consistency_topic will be used when not explicitly set. The default consistency topic name is formed by appending `-consistency` to the output topic name. {{< version-added v0.8.4 />}}
-**CONSISTENCY FORMAT** _format_ | The format of the Kafka consistency topic, defaults to Avro for Avro-encoded sinks. {{< version-added v0.8.4 />}}
 **CONFLUENT SCHEMA REGISTRY** _url_ | The URL of the Confluent schema registry to get schema information from.
 
 ### `WITH` options

--- a/doc/user/layouts/partials/sql-grammar/sink-kafka-connector.svg
+++ b/doc/user/layouts/partials/sql-grammar/sink-kafka-connector.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1075" height="469">
+<svg xmlns="http://www.w3.org/2000/svg" width="539" height="355">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="126" height="32" rx="10"/>
@@ -23,170 +23,116 @@
    <rect x="325" y="3" width="90" height="32"/>
    <rect x="323" y="1" width="90" height="32" class="nonterminal"/>
    <text class="nonterminal" x="333" y="21">topic-prefix</text>
-   <rect x="395" y="113" width="46" height="32" rx="10"/>
-   <rect x="393"
+   <rect x="127" y="113" width="46" height="32" rx="10"/>
+   <rect x="125"
          y="111"
          width="46"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="403" y="131">KEY</text>
-   <rect x="461" y="113" width="24" height="32" rx="10"/>
-   <rect x="459"
+   <text class="terminal" x="135" y="131">KEY</text>
+   <rect x="193" y="113" width="24" height="32" rx="10"/>
+   <rect x="191"
          y="111"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="469" y="131">(</text>
-   <rect x="525" y="113" width="94" height="32"/>
-   <rect x="523" y="111" width="94" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="533" y="131">key_column</text>
-   <rect x="525" y="69" width="24" height="32" rx="10"/>
-   <rect x="523"
+   <text class="terminal" x="201" y="131">(</text>
+   <rect x="257" y="113" width="94" height="32"/>
+   <rect x="255" y="111" width="94" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="265" y="131">key_column</text>
+   <rect x="257" y="69" width="24" height="32" rx="10"/>
+   <rect x="255"
          y="67"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="533" y="87">,</text>
-   <rect x="659" y="113" width="24" height="32" rx="10"/>
-   <rect x="657"
+   <text class="terminal" x="265" y="87">,</text>
+   <rect x="391" y="113" width="24" height="32" rx="10"/>
+   <rect x="389"
          y="111"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="667" y="131">)</text>
-   <rect x="45" y="211" width="118" height="32" rx="10"/>
+   <text class="terminal" x="399" y="131">)</text>
+   <rect x="45" y="239" width="56" height="32" rx="10"/>
    <rect x="43"
-         y="209"
-         width="118"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="53" y="229">CONSISTENCY</text>
-   <rect x="183" y="211" width="62" height="32" rx="10"/>
-   <rect x="181"
-         y="209"
-         width="62"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="191" y="229">TOPIC</text>
-   <rect x="265" y="211" width="50" height="32"/>
-   <rect x="263" y="209" width="50" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="273" y="229">topic</text>
-   <rect x="355" y="243" width="118" height="32" rx="10"/>
-   <rect x="353"
-         y="241"
-         width="118"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="363" y="261">CONSISTENCY</text>
-   <rect x="493" y="243" width="78" height="32" rx="10"/>
-   <rect x="491"
-         y="241"
-         width="78"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="501" y="261">FORMAT</text>
-   <rect x="591" y="243" width="106" height="32" rx="10"/>
-   <rect x="589"
-         y="241"
-         width="106"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="599" y="261">AVRO USING</text>
-   <rect x="717" y="243" width="240" height="32" rx="10"/>
-   <rect x="715"
-         y="241"
-         width="240"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="725" y="261">CONFLUENT SCHEMA REGISTRY</text>
-   <rect x="977" y="243" width="36" height="32"/>
-   <rect x="975" y="241" width="36" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="985" y="261">url</text>
-   <rect x="313" y="353" width="56" height="32" rx="10"/>
-   <rect x="311"
-         y="351"
+         y="237"
          width="56"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="321" y="371">WITH</text>
-   <rect x="389" y="353" width="24" height="32" rx="10"/>
-   <rect x="387"
-         y="351"
+   <text class="terminal" x="53" y="257">WITH</text>
+   <rect x="121" y="239" width="24" height="32" rx="10"/>
+   <rect x="119"
+         y="237"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="397" y="371">(</text>
-   <rect x="453" y="353" width="46" height="32"/>
-   <rect x="451" y="351" width="46" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="461" y="371">field</text>
-   <rect x="519" y="353" width="26" height="32" rx="10"/>
-   <rect x="517"
-         y="351"
+   <text class="terminal" x="129" y="257">(</text>
+   <rect x="185" y="239" width="46" height="32"/>
+   <rect x="183" y="237" width="46" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="193" y="257">field</text>
+   <rect x="251" y="239" width="26" height="32" rx="10"/>
+   <rect x="249"
+         y="237"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="527" y="371">=</text>
-   <rect x="565" y="353" width="38" height="32"/>
-   <rect x="563" y="351" width="38" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="573" y="371">val</text>
-   <rect x="453" y="309" width="24" height="32" rx="10"/>
-   <rect x="451"
-         y="307"
+   <text class="terminal" x="259" y="257">=</text>
+   <rect x="297" y="239" width="38" height="32"/>
+   <rect x="295" y="237" width="38" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="305" y="257">val</text>
+   <rect x="185" y="195" width="24" height="32" rx="10"/>
+   <rect x="183"
+         y="193"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="461" y="327">,</text>
-   <rect x="643" y="353" width="24" height="32" rx="10"/>
-   <rect x="641"
-         y="351"
+   <text class="terminal" x="193" y="213">,</text>
+   <rect x="375" y="239" width="24" height="32" rx="10"/>
+   <rect x="373"
+         y="237"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="651" y="371">)</text>
-   <rect x="707" y="353" width="78" height="32" rx="10"/>
-   <rect x="705"
-         y="351"
+   <text class="terminal" x="383" y="257">)</text>
+   <rect x="439" y="239" width="78" height="32" rx="10"/>
+   <rect x="437"
+         y="237"
          width="78"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="715" y="371">FORMAT</text>
-   <rect x="625" y="435" width="106" height="32" rx="10"/>
-   <rect x="623"
-         y="433"
+   <text class="terminal" x="447" y="257">FORMAT</text>
+   <rect x="89" y="321" width="106" height="32" rx="10"/>
+   <rect x="87"
+         y="319"
          width="106"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="633" y="453">AVRO USING</text>
-   <rect x="751" y="435" width="240" height="32" rx="10"/>
-   <rect x="749"
-         y="433"
+   <text class="terminal" x="97" y="339">AVRO USING</text>
+   <rect x="215" y="321" width="240" height="32" rx="10"/>
+   <rect x="213"
+         y="319"
          width="240"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="759" y="453">CONFLUENT SCHEMA REGISTRY</text>
-   <rect x="1011" y="435" width="36" height="32"/>
-   <rect x="1009" y="433" width="36" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="1019" y="453">url</text>
+   <text class="terminal" x="223" y="339">CONFLUENT SCHEMA REGISTRY</text>
+   <rect x="475" y="321" width="36" height="32"/>
+   <rect x="473" y="319" width="36" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="483" y="339">url</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m126 0 h10 m0 0 h10 m46 0 h10 m0 0 h10 m62 0 h10 m0 0 h10 m90 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-84 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m46 0 h10 m0 0 h10 m24 0 h10 m20 0 h10 m94 0 h10 m-134 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m114 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-114 0 h10 m24 0 h10 m0 0 h70 m20 44 h10 m24 0 h10 m-328 0 h20 m308 0 h20 m-348 0 q10 0 10 10 m328 0 q0 -10 10 -10 m-338 10 v14 m328 0 v-14 m-328 14 q0 10 10 10 m308 0 q10 0 10 -10 m-318 10 h10 m0 0 h298 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-722 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h998 m-1028 0 h20 m1008 0 h20 m-1048 0 q10 0 10 10 m1028 0 q0 -10 10 -10 m-1038 10 v12 m1028 0 v-12 m-1028 12 q0 10 10 10 m1008 0 q10 0 10 -10 m-1018 10 h10 m118 0 h10 m0 0 h10 m62 0 h10 m0 0 h10 m50 0 h10 m20 0 h10 m0 0 h668 m-698 0 h20 m678 0 h20 m-718 0 q10 0 10 10 m698 0 q0 -10 10 -10 m-708 10 v12 m698 0 v-12 m-698 12 q0 10 10 10 m678 0 q10 0 10 -10 m-688 10 h10 m118 0 h10 m0 0 h10 m78 0 h10 m0 0 h10 m106 0 h10 m0 0 h10 m240 0 h10 m0 0 h10 m36 0 h10 m42 -64 l2 0 m2 0 l2 0 m2 0 l2 0 m-804 174 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m56 0 h10 m0 0 h10 m24 0 h10 m20 0 h10 m46 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m38 0 h10 m-190 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m170 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-170 0 h10 m24 0 h10 m0 0 h126 m20 44 h10 m24 0 h10 m-394 0 h20 m374 0 h20 m-414 0 q10 0 10 10 m394 0 q0 -10 10 -10 m-404 10 v14 m394 0 v-14 m-394 14 q0 10 10 10 m374 0 q10 0 10 -10 m-384 10 h10 m0 0 h364 m20 -34 h10 m78 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-204 82 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m106 0 h10 m0 0 h10 m240 0 h10 m0 0 h10 m36 0 h10 m3 0 h-3"/>
-   <polygon points="1065 449 1073 445 1073 453"/>
-   <polygon points="1065 449 1057 445 1057 453"/>
+         d="m17 17 h2 m0 0 h10 m126 0 h10 m0 0 h10 m46 0 h10 m0 0 h10 m62 0 h10 m0 0 h10 m90 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-352 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m46 0 h10 m0 0 h10 m24 0 h10 m20 0 h10 m94 0 h10 m-134 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m114 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-114 0 h10 m24 0 h10 m0 0 h70 m20 44 h10 m24 0 h10 m-328 0 h20 m308 0 h20 m-348 0 q10 0 10 10 m328 0 q0 -10 10 -10 m-338 10 v14 m328 0 v-14 m-328 14 q0 10 10 10 m308 0 q10 0 10 -10 m-318 10 h10 m0 0 h298 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-454 126 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m56 0 h10 m0 0 h10 m24 0 h10 m20 0 h10 m46 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m38 0 h10 m-190 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m170 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-170 0 h10 m24 0 h10 m0 0 h126 m20 44 h10 m24 0 h10 m-394 0 h20 m374 0 h20 m-414 0 q10 0 10 10 m394 0 q0 -10 10 -10 m-404 10 v14 m394 0 v-14 m-394 14 q0 10 10 10 m374 0 q10 0 10 -10 m-384 10 h10 m0 0 h364 m20 -34 h10 m78 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-472 82 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m106 0 h10 m0 0 h10 m240 0 h10 m0 0 h10 m36 0 h10 m3 0 h-3"/>
+   <polygon points="529 335 537 331 537 339"/>
+   <polygon points="529 335 521 331 521 339"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -320,7 +320,6 @@ join_type ::=
 sink_kafka_connector ::=
     'KAFKA BROKER' host 'TOPIC' topic-prefix
     ('KEY' '(' key_column ( ',' key_column )* ')')?
-    ('CONSISTENCY' 'TOPIC' topic ('CONSISTENCY' 'FORMAT' 'AVRO USING' 'CONFLUENT SCHEMA REGISTRY' url)?)?
     ('WITH' '(' ( field '=' val ) ( ( ',' field '=' val ) )* ')')?
     'FORMAT' 'AVRO USING' 'CONFLUENT SCHEMA REGISTRY' url
 lit_cast ::=

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1245,7 +1245,7 @@ pub fn plan_create_views(
 #[allow(clippy::too_many_arguments)]
 fn kafka_sink_builder(
     format: Option<Format<Raw>>,
-    _consistency: Option<KafkaConsistency<Raw>>,
+    consistency: Option<KafkaConsistency<Raw>>,
     with_options: &mut BTreeMap<String, Value>,
     broker: String,
     topic_prefix: String,
@@ -1255,6 +1255,9 @@ fn kafka_sink_builder(
     topic_suffix_nonce: String,
     root_dependencies: &[&dyn CatalogItem],
 ) -> Result<SinkConnectorBuilder, anyhow::Error> {
+    if consistency.is_some() {
+        unsupported!("CONSISTENCY TOPIC and CONSISTENCY FORMAT");
+    }
     let consistency_topic = match with_options.remove("consistency_topic") {
         None => None,
         Some(Value::String(topic)) => Some(topic),

--- a/test/testdrive/kafka-exactly-once-sink.td
+++ b/test/testdrive/kafka-exactly-once-sink.td
@@ -163,7 +163,6 @@ reuse_topic requires that sink input dependencies are sources, materialize.publi
   WITH (reuse_topic=true, consistency_topic='output14-custom-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
-
 # ensure that the sink works with log compaction enabled on the consistency topic
 
 $ kafka-create-topic topic=compaction-test-input-consistency
@@ -228,3 +227,25 @@ $ kafka-verify format=avro sink=materialize.public.rt_binding_consistency_test_s
 $ kafka-verify format=avro sink=materialize.public.rt_binding_consistency_test_sink consistency=debezium
 {"id": "<TIMESTAMP>", "status": "BEGIN", "event_count": null, "data_collections": null}
 {"id": "<TIMESTAMP>", "status": "END", "event_count": {"long": 1}, "data_collections": {"array": [{"event_count": 1, "data_collection": "rt-binding-consistency-test-output-${testdrive.seed}"}]}}
+
+# Test that we bail out if CONSISTENCY TOPIC or CONSISTENCY FORMAT are provided
+! CREATE SINK compaction_test_sink FROM compaction_test_input
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'compaction-test-output-${testdrive.seed}'
+  CONSISTENCY TOPIC 'fail'
+  WITH (reuse_topic=true) FORMAT AVRO
+  USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' ENVELOPE DEBEZIUM
+CONSISTENCY TOPIC and CONSISTENCY FORMAT not yet supported
+
+! CREATE SINK compaction_test_sink FROM compaction_test_input
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'compaction-test-output-${testdrive.seed}'
+  CONSISTENCY FORMAT JSON
+  WITH (reuse_topic=true) FORMAT AVRO
+  USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' ENVELOPE DEBEZIUM
+Expected end of statement, found CONSISTENCY
+
+! CREATE SINK compaction_test_sink FROM compaction_test_input
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'compaction-test-output-${testdrive.seed}'
+  CONSISTENCY TOPIC 'fail' CONSISTENCY FORMAT JSON
+  WITH (reuse_topic=true) FORMAT AVRO
+  USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' ENVELOPE DEBEZIUM
+CONSISTENCY TOPIC and CONSISTENCY FORMAT not yet supported


### PR DESCRIPTION
Temporarily removes the ability to specify a `CONSISTENCY TOPIC` or `CONSISTENCY FORMAT` for Kafka sinks. These options will be added back in once they're fully implemented.

This replaces https://github.com/MaterializeInc/materialize/pull/7606, where I realized I couldn't write a very satisfactory test.
