### PR TITLE
Add a metrics registry for "third parties"

### DIFF
--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -93,6 +93,22 @@ struct Args {
     #[structopt(long, hidden = true)]
     safe: bool,
 
+    /// The address on which metrics visible to "third parties" get exposed.
+    ///
+    /// These metrics are structured to allow an infrastructure provider to monitor an installation
+    /// without needing access to more sensitive data, like names of sources/sinks.
+    ///
+    /// This address is never served TLS-encrypted or authenticated, and while only "non-sensitive"
+    /// metrics are served from it, care should be taken to not expose the listen address to the
+    /// public internet or other unauthorized parties.
+    #[structopt(
+        long,
+        hidden = true,
+        value_name = "HOST:PORT",
+        env = "MZ_THIRD_PARTY_METRICS_ADDR"
+    )]
+    third_party_metrics_listen_addr: Option<SocketAddr>,
+
     /// Enable persistent tables. Has to be used with --experimental.
     #[structopt(long, hidden = true)]
     persistent_tables: bool,
@@ -603,6 +619,7 @@ swap: {swap_total}KB total, {swap_used}KB used",
         logical_compaction_window: args.logical_compaction_window,
         timestamp_frequency: args.timestamp_frequency,
         listen_addr: args.listen_addr,
+        third_party_metrics_listen_addr: args.third_party_metrics_listen_addr,
         tls,
         data_directory,
         symbiosis_url: args.symbiosis,

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -43,6 +43,7 @@ use itertools::Itertools;
 use lazy_static::lazy_static;
 use log::info;
 use ore::metric;
+use ore::metrics::ThirdPartyMetric;
 use ore::metrics::{IntCounterVec, MetricsRegistry};
 use structopt::StructOpt;
 use sysinfo::{ProcessorExt, SystemExt};
@@ -427,11 +428,12 @@ fn run(args: Args) -> Result<(), anyhow::Error> {
             // otherwise.
             .add_directive("panic=error".parse().unwrap());
 
-        let log_message_counter: IntCounterVec = metrics_registry.register(metric!(
-            name: "mz_log_message_total",
-            help: "The number of log messages produced by this materialized instance",
-            var_labels: ["severity"],
-        ));
+        let log_message_counter: ThirdPartyMetric<IntCounterVec> = metrics_registry
+            .register_third_party_visible(metric!(
+                name: "mz_log_message_total",
+                help: "The number of log messages produced by this materialized instance",
+                var_labels: ["severity"],
+            ));
 
         match args.log_file.as_deref() {
             Some("stderr") => {

--- a/src/materialized/src/bin/materialized/tracing.rs
+++ b/src/materialized/src/bin/materialized/tracing.rs
@@ -9,6 +9,7 @@
 
 use std::marker::PhantomData;
 
+use ore::metrics::ThirdPartyMetric;
 use prometheus::IntCounterVec;
 use tracing::span::{Attributes, Record};
 use tracing::subscriber::Interest;
@@ -122,13 +123,13 @@ where
 /// A tracing `Layer` that allows hooking into the reporting/filtering chain for log messages,
 /// incrementing a counter for the severity of messages reported.
 pub struct MetricsRecorderLayer<S> {
-    counter: IntCounterVec,
+    counter: ThirdPartyMetric<IntCounterVec>,
     _inner: PhantomData<S>,
 }
 
 impl<S> MetricsRecorderLayer<S> {
     /// Construct a metrics-recording layer.
-    pub fn new(counter: IntCounterVec) -> Self {
+    pub fn new(counter: ThirdPartyMetric<IntCounterVec>) -> Self {
         Self {
             counter,
             _inner: PhantomData,
@@ -143,7 +144,7 @@ where
     fn on_event(&self, ev: &Event<'_>, _ctx: Context<'_, S>) {
         let metadata = ev.metadata();
         self.counter
-            .with_label_values(&[&metadata.level().to_string()])
+            .third_party_metric_with_label_values(&[&metadata.level().to_string()])
             .inc();
     }
 }
@@ -154,16 +155,20 @@ mod test {
 
     use super::MetricsRecorderLayer;
     use log::{error, info, warn};
-    use prometheus::{IntCounterVec, Opts, Registry};
+    use ore::metric;
+    use ore::metrics::{MetricsRegistry, ThirdPartyMetric};
+    use prometheus::IntCounterVec;
     use tracing_subscriber::layer::SubscriberExt;
     use tracing_subscriber::util::SubscriberInitExt;
 
     #[test]
     fn increments_per_sev_counter() {
-        let counter_opts = Opts::new("test_counter", "test counter help");
-        let counter = IntCounterVec::new(counter_opts, &["severity"]).unwrap();
-        let r = Registry::new();
-        r.register(Box::new(counter.clone())).unwrap();
+        let r = MetricsRegistry::new();
+        let counter: ThirdPartyMetric<IntCounterVec> = r.register_third_party_visible(metric!(
+            name: "test_counter",
+            help: "a test counter",
+            var_labels: ["severity"],
+        ));
         tracing_subscriber::registry()
             .with(MetricsRecorderLayer::new(counter))
             .init();
@@ -172,6 +177,8 @@ mod test {
         (0..5).for_each(|_| warn!("a warning"));
         error!("test error");
         error!("test error");
+
+        println!("gathered: {:?}", r.gather());
 
         let metric = r
             .gather()

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -109,6 +109,8 @@ pub struct Config {
     // === Connection options. ===
     /// The IP address and port to listen on.
     pub listen_addr: SocketAddr,
+    /// The IP address and port to serve the "third party" metrics registry from.
+    pub third_party_metrics_listen_addr: Option<SocketAddr>,
     /// TLS encryption configuration.
     pub tls: Option<TlsConfig>,
 

--- a/src/materialized/tests/util.rs
+++ b/src/materialized/tests/util.rs
@@ -141,6 +141,7 @@ pub fn start_server(config: Config) -> Result<Server, Box<dyn Error>> {
         introspection_frequency: Duration::from_secs(1),
         metrics_registry: metrics_registry.clone(),
         persist: PersistConfig::disabled(),
+        third_party_metrics_listen_addr: None,
     }))?;
     let server = Server {
         inner,

--- a/src/ore/src/metrics/tests.rs
+++ b/src/ore/src/metrics/tests.rs
@@ -1,0 +1,71 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+#[test]
+fn metrics_registry() {
+    let reg = MetricsRegistry::new();
+    let counter: UIntCounter = reg.register(metric!(
+        name: "test_counter",
+        help: "a counter for testing"
+    ));
+    counter.inc();
+
+    let readings = reg.gather();
+    assert_eq!(readings.len(), 1);
+}
+
+#[test]
+fn anon_metrics_registry() {
+    let reg = MetricsRegistry::new();
+    let counter_anon: ThirdPartyMetric<UIntCounter> = reg.register_third_party_visible(metric!(
+        name: "test_counter_third_party",
+        help: "an third_party counter for testing"
+    ));
+    let counter_reg: UIntCounter = reg.register(metric!(
+        name: "test_counter_normal",
+        help: "a regular counter for testing"
+    ));
+    counter_anon.inc();
+    counter_reg.inc();
+
+    let readings = reg.gather();
+    assert_eq!(readings.len(), 2);
+
+    let readings_anon = reg.gather_third_party_visible();
+    assert_eq!(readings_anon.len(), 1);
+    assert_eq!(readings_anon[0].get_name(), "test_counter_third_party");
+}
+
+#[test]
+fn thirdparty_metric_vecs() {
+    let reg = MetricsRegistry::new();
+    let cv: ThirdPartyMetric<UIntCounterVec> = reg.register_third_party_visible(metric!(
+        name: "test_counter_third_party",
+        help: "an third_party counter for testing",
+        var_labels: ["label"],
+    ));
+    let counter = cv
+        .get_third_party_metric_with_label_values(&["testing"])
+        .unwrap();
+    counter.inc();
+    let readings = reg.gather_third_party_visible();
+    assert_eq!(readings.len(), 1);
+    assert_eq!(readings[0].get_name(), "test_counter_third_party");
+    let metrics = readings[0].get_metric();
+    assert_eq!(metrics.len(), 1);
+    assert!((metrics[0].get_counter().get_value() - 1.0).abs() < f64::EPSILON);
+}

--- a/src/ore/src/metrics/third_party_metric.rs
+++ b/src/ore/src/metrics/third_party_metric.rs
@@ -1,0 +1,96 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use prometheus::{
+    core::{
+        Atomic, Collector, GenericCounter, GenericCounterVec, GenericGauge, GenericGaugeVec,
+        MetricVec, MetricVecBuilder,
+    },
+    Error, Histogram,
+};
+use std::ops::Deref;
+
+use super::{CounterVecExt, DeleteOnDropCounter, DeleteOnDropGauge, GaugeVecExt, PromLabelsExt};
+
+/// A metric that can be made accesible to cloud infrastructure/orchestrators, that won't betray the
+/// contents of the materialize instance that it details.
+#[derive(Debug)]
+pub struct ThirdPartyMetric<T: Collector + Clone> {
+    pub(super) inner: T,
+}
+
+// We allow people to get at non-variably-labeled metrics just like that - the assumption is that
+// they are already vetted at commit time & can't leak "variable" information.
+
+macro_rules! impl_deref {
+    ($other_type:ty) => {
+        impl<T> Deref for ThirdPartyMetric<$other_type>
+        where
+            T: Atomic + 'static,
+        {
+            type Target = $other_type;
+            fn deref(&self) -> &Self::Target {
+                &self.inner
+            }
+        }
+    };
+}
+
+impl_deref!(GenericCounter<T>);
+impl_deref!(GenericGauge<T>);
+
+impl Deref for ThirdPartyMetric<Histogram> {
+    type Target = Histogram;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+// Metric vectors take more care to not leak information, and so we force programmers to declare
+// that the metric they are making will be visible to potential third parties, so this can be
+// spotted in code review.
+
+impl<T: MetricVecBuilder> ThirdPartyMetric<MetricVec<T>> {
+    /// Creates a metric that can be scraped by a third party, with the given label values.
+    pub fn get_third_party_metric_with_label_values(&self, vals: &[&str]) -> Result<T::M, Error> {
+        self.inner.get_metric_with_label_values(vals)
+    }
+
+    /// Removes a metric with the given label values.
+    pub fn remove_label_values(&self, vals: &[&str]) -> Result<(), Error> {
+        self.inner.remove_label_values(vals)
+    }
+}
+
+impl<P: Atomic> ThirdPartyMetric<GenericCounterVec<P>> {
+    /// Creates a delete-on-drop counter that can be scraped by third parties.
+    pub fn get_third_party_delete_on_drop_counter<'a, L: PromLabelsExt<'a>>(
+        &self,
+        labels: L,
+    ) -> DeleteOnDropCounter<'a, P, L> {
+        self.inner.get_delete_on_drop_counter(labels)
+    }
+}
+
+impl<P: Atomic> ThirdPartyMetric<GenericGaugeVec<P>> {
+    /// Creates a delete-on-drop gauge that can be scraped by third parties.
+    pub fn get_third_party_delete_on_drop_gauge<'a, L: PromLabelsExt<'a>>(
+        &self,
+        labels: L,
+    ) -> DeleteOnDropGauge<'a, P, L> {
+        self.inner.get_delete_on_drop_gauge(labels)
+    }
+}

--- a/src/ore/src/metrics/third_party_metric.rs
+++ b/src/ore/src/metrics/third_party_metric.rs
@@ -73,6 +73,14 @@ impl<T: MetricVecBuilder> ThirdPartyMetric<MetricVec<T>> {
     pub fn remove_label_values(&self, vals: &[&str]) -> Result<(), Error> {
         self.inner.remove_label_values(vals)
     }
+
+    /// Creates a metric that can be scraped by a third party, with the given label values.
+    /// # Panics
+    /// Panics if the metric can not be created.
+    pub fn third_party_metric_with_label_values(&self, vals: &[&str]) -> T::M {
+        self.get_third_party_metric_with_label_values(vals)
+            .expect("creating a metric from values")
+    }
 }
 
 impl<P: Atomic> ThirdPartyMetric<GenericCounterVec<P>> {

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -547,6 +547,7 @@ impl Runner {
             introspection_frequency: Duration::from_secs(1),
             metrics_registry: MetricsRegistry::new(),
             persist: PersistConfig::disabled(),
+            third_party_metrics_listen_addr: None,
         };
         let server = materialized::serve(mz_config).await?;
         let client = connect(&server).await;


### PR DESCRIPTION
This PR contains some proof-of-concept code to support running a second registry on a secondary port, which serves only metrics that we allow to be served from there (i.e., opt into explicitly, reminding ourselves continuously that any variations of these metrics are also visible on that second registry).

The idea is that those metrics should be available to our cloud infrastructure, so we can more effectively monitor customer installations, without exposing these customers' more sensitive metrics to our infrastructure.

TODO:
- [x] actually build the HTTP scraping endpoint on a separate port & an option for turning it on
- [x] opt some more metrics into this registry
- [ ] maybe make a testdrive test?