### PR TITLE
persist: start replacing CmdResponse with Future

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2715,12 +2715,15 @@ dependencies = [
  "criterion",
  "crossbeam-channel",
  "differential-dataflow",
+ "futures-executor",
+ "futures-util",
  "log",
  "ore",
  "rand",
  "serde",
  "tempfile",
  "timely",
+ "tokio",
 ]
 
 [[package]]

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -20,9 +20,12 @@ abomonation = "0.7"
 abomonation_derive = "0.5"
 crossbeam-channel = "0.5"
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
+futures-util = "0.3.16"
+futures-executor = "0.3.16"
 log = "0.4.13"
 ore = { path = "../ore", default-features = false }
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
+tokio = { version = "1.9.0", default-features = false, features = ["macros", "sync"] }
 
 [dev-dependencies]
 criterion = "0.3.5"

--- a/src/persist/src/indexed/runtime.rs
+++ b/src/persist/src/indexed/runtime.rs
@@ -14,7 +14,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::collections::HashSet;
 use std::fmt;
 use std::hash::{Hash, Hasher};
-use std::sync::{mpsc, Arc, Mutex};
+use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::Instant;
 
@@ -23,18 +23,19 @@ use log;
 use crate::error::Error;
 use crate::indexed::encoding::Id;
 use crate::indexed::{Indexed, IndexedSnapshot, ListenFn};
+use crate::pfuture::{Future, FutureHandle};
 use crate::storage::{Blob, Buffer, SeqNo};
 use crate::Data;
 
 enum Cmd<K, V> {
-    Register(String, CmdResponse<Id>),
-    Destroy(String, CmdResponse<bool>),
-    Write(Vec<(Id, Vec<((K, V), u64, isize)>)>, CmdResponse<SeqNo>),
-    Seal(Vec<Id>, u64, CmdResponse<()>),
-    AllowCompaction(Id, u64, CmdResponse<()>),
-    Snapshot(Id, CmdResponse<IndexedSnapshot<K, V>>),
-    Listen(Id, ListenFn<K, V>, CmdResponse<()>),
-    Stop(CmdResponse<()>),
+    Register(String, FutureHandle<Id>),
+    Destroy(String, FutureHandle<bool>),
+    Write(Vec<(Id, Vec<((K, V), u64, isize)>)>, FutureHandle<SeqNo>),
+    Seal(Vec<Id>, u64, FutureHandle<()>),
+    AllowCompaction(Id, u64, FutureHandle<()>),
+    Snapshot(Id, FutureHandle<IndexedSnapshot<K, V>>),
+    Listen(Id, ListenFn<K, V>, FutureHandle<()>),
+    Stop(FutureHandle<()>),
 }
 
 /// Starts the runtime in a [std::thread].
@@ -72,61 +73,6 @@ where
     })
 }
 
-/// A receiver for the `Result<T, Error>` response of an asynchronous command.
-pub enum CmdResponse<T> {
-    /// No response is desired.
-    Ignore,
-    /// A single channel send per command call.
-    ///
-    /// It is supported for multiple command results to be sent to the same
-    /// channel by cloning the sender. This even works if they are different
-    /// types of command, but the expected usage is to issue N writes and then
-    /// wait on them all by receiving N times.
-    ///
-    /// NB: The given Sender may be dropped without having received a message if
-    /// the runtime is shut down.
-    StdChannel(mpsc::Sender<Result<T, Error>>),
-    /// A callback executed once.
-    ///
-    /// NB: This isn't guaranteed to get called because of a race with runtime
-    /// shutdown.
-    Callback(Box<dyn FnOnce(Result<T, Error>) + Send + 'static>),
-    // TODO: Add a std::future::Future variant to better play with async? I
-    // think the Future impl would be pretty straightforward.
-}
-
-impl<T> From<mpsc::Sender<Result<T, Error>>> for CmdResponse<T> {
-    fn from(c: mpsc::Sender<Result<T, Error>>) -> Self {
-        CmdResponse::StdChannel(c)
-    }
-}
-
-impl<T> From<Box<dyn FnOnce(Result<T, Error>) + Send + 'static>> for CmdResponse<T> {
-    fn from(c: Box<dyn FnOnce(Result<T, Error>) + Send + 'static>) -> Self {
-        CmdResponse::Callback(c)
-    }
-}
-
-impl<T> CmdResponse<T> {
-    pub(crate) fn send(self, t: Result<T, Error>) {
-        match self {
-            CmdResponse::Ignore => {}
-            CmdResponse::Callback(c) => c(t),
-            CmdResponse::StdChannel(c) => {
-                if let Err(mpsc::SendError(_)) = c.send(t) {
-                    // The SendError docs indicate that this only happens if the
-                    // receiver was dropped. If the client that sent this cmd
-                    // has hung up (imagine an INSERT spawned a Cmd::Write, but
-                    // the pgwire connection has been severed while it synced to
-                    // disk), then no one is listening and that's okay.
-                }
-                // Defensively drop c, just to make it obvious.
-                drop(c)
-            }
-        }
-    }
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 struct RuntimeId(u64);
 
@@ -154,37 +100,23 @@ impl<K, V> RuntimeCore<K, V> {
             match cmd {
                 Cmd::Stop(res) => {
                     // Already stopped: no-op.
-                    res.send(Ok(()))
+                    res.fill(Ok(()))
                 }
-                Cmd::Register(_, res) => {
-                    res.send(Err(Error::from("register cmd sent to stopped runtime")))
-                }
-                Cmd::Destroy(_, res) => {
-                    res.send(Err(Error::from("destroy cmd sent to stopped runtime")))
-                }
-                Cmd::Write(_, res) => {
-                    res.send(Err(Error::from("write cmd sent to stopped runtime")))
-                }
-                Cmd::Seal(_, _, res) => {
-                    res.send(Err(Error::from("seal cmd sent to stopped runtime")))
-                }
-                Cmd::AllowCompaction(_, _, res) => res.send(Err(Error::from(
-                    "allow_compaction cmd sent to stopped runtime",
-                ))),
-                Cmd::Snapshot(_, res) => {
-                    res.send(Err(Error::from("snapshot cmd sent to stopped runtime")))
-                }
-                Cmd::Listen(_, _, res) => {
-                    res.send(Err(Error::from("listen cmd sent to stopped runtime")))
-                }
+                Cmd::Register(_, res) => res.fill(Err(Error::RuntimeShutdown)),
+                Cmd::Destroy(_, res) => res.fill(Err(Error::RuntimeShutdown)),
+                Cmd::Write(_, res) => res.fill(Err(Error::RuntimeShutdown)),
+                Cmd::Seal(_, _, res) => res.fill(Err(Error::RuntimeShutdown)),
+                Cmd::AllowCompaction(_, _, res) => res.fill(Err(Error::RuntimeShutdown)),
+                Cmd::Snapshot(_, res) => res.fill(Err(Error::RuntimeShutdown)),
+                Cmd::Listen(_, _, res) => res.fill(Err(Error::RuntimeShutdown)),
             }
         }
     }
 
     fn stop(&self) -> Result<(), Error> {
         if let Some(handle) = self.handle.lock()?.take() {
-            let (tx, rx) = mpsc::channel();
-            self.send(Cmd::Stop(tx.into()));
+            let (tx, rx) = Future::new();
+            self.send(Cmd::Stop(tx));
             // NB: Make sure there are no early returns before this `join`,
             // otherwise the runtime thread might still be cleaning up when this
             // returns (flushing out final writes, cleaning up LOCK files, etc).
@@ -197,7 +129,7 @@ impl<K, V> RuntimeCore<K, V> {
                 // put the panic message in this log.
                 log::error!("persist runtime thread panic'd");
             }
-            rx.recv().map_err(|_| Error::RuntimeShutdown)?
+            rx.recv()
         } else {
             Ok(())
         }
@@ -263,9 +195,9 @@ impl<K: Clone, V: Clone> RuntimeClient<K, V> {
         &self,
         id: &str,
     ) -> Result<(StreamWriteHandle<K, V>, StreamReadHandle<K, V>), Error> {
-        let (tx, rx) = mpsc::channel();
-        self.core.send(Cmd::Register(id.to_owned(), tx.into()));
-        let id = rx.recv().map_err(|_| Error::RuntimeShutdown)??;
+        let (tx, rx) = Future::new();
+        self.core.send(Cmd::Register(id.to_owned(), tx));
+        let id = rx.recv()?;
         let write = StreamWriteHandle::new(id, self.clone());
         let meta = StreamReadHandle::new(id, self.clone());
         Ok((write, meta))
@@ -275,8 +207,8 @@ impl<K: Clone, V: Clone> RuntimeClient<K, V> {
     /// streams with the given ids.
     ///
     /// The ids must have previously been registered.
-    fn write(&self, updates: Vec<(Id, Vec<((K, V), u64, isize)>)>, res: CmdResponse<SeqNo>) {
-        self.core.send(Cmd::Write(updates, res))
+    fn write(&self, updates: Vec<(Id, Vec<((K, V), u64, isize)>)>, res: FutureHandle<SeqNo>) {
+        self.core.send(Cmd::Write(updates, res.into()));
     }
 
     /// Asynchronously advances the "sealed" frontier for the streams with the
@@ -284,7 +216,7 @@ impl<K: Clone, V: Clone> RuntimeClient<K, V> {
     /// for those ids.
     ///
     /// The ids must have previously been registered.
-    fn seal(&self, ids: &[Id], ts: u64, res: CmdResponse<()>) {
+    fn seal(&self, ids: &[Id], ts: u64, res: FutureHandle<()>) {
         self.core.send(Cmd::Seal(ids.to_vec(), ts, res))
     }
 
@@ -294,7 +226,7 @@ impl<K: Clone, V: Clone> RuntimeClient<K, V> {
     /// can later be advanced to for this id.
     ///
     /// The id must have previously been registered.
-    fn allow_compaction(&self, id: Id, ts: u64, res: CmdResponse<()>) {
+    fn allow_compaction(&self, id: Id, ts: u64, res: FutureHandle<()>) {
         self.core.send(Cmd::AllowCompaction(id, ts, res))
     }
 
@@ -304,13 +236,13 @@ impl<K: Clone, V: Clone> RuntimeClient<K, V> {
     /// This snapshot is guaranteed to include any previous writes.
     ///
     /// The id must have previously been registered.
-    fn snapshot(&self, id: Id, res: CmdResponse<IndexedSnapshot<K, V>>) {
+    fn snapshot(&self, id: Id, res: FutureHandle<IndexedSnapshot<K, V>>) {
         self.core.send(Cmd::Snapshot(id, res))
     }
 
     /// Asynchronously registers a callback to be invoked on successful writes
     /// and seals.
-    fn listen(&self, id: Id, listen_fn: ListenFn<K, V>, res: CmdResponse<()>) {
+    fn listen(&self, id: Id, listen_fn: ListenFn<K, V>, res: FutureHandle<()>) {
         self.core.send(Cmd::Listen(id, listen_fn, res))
     }
 
@@ -327,9 +259,9 @@ impl<K: Clone, V: Clone> RuntimeClient<K, V> {
     /// This method is idempotent and returns true if the stream was actually
     /// destroyed, false if the stream had already been destroyed previously.
     pub fn destroy(&mut self, id: &str) -> Result<bool, Error> {
-        let (tx, rx) = mpsc::channel();
-        self.core.send(Cmd::Destroy(id.to_owned(), tx.into()));
-        rx.recv().map_err(|_| Error::RuntimeShutdown)?
+        let (tx, rx) = Future::new();
+        self.core.send(Cmd::Destroy(id.to_owned(), tx));
+        rx.recv()
     }
 }
 
@@ -362,14 +294,18 @@ impl<K: Clone, V: Clone> StreamWriteHandle<K, V> {
     }
 
     /// Synchronously writes (Key, Value, Time, Diff) updates.
-    pub fn write(&self, updates: &[((K, V), u64, isize)], res: CmdResponse<SeqNo>) {
-        self.runtime.write(vec![(self.id, updates.to_vec())], res);
+    pub fn write(&self, updates: &[((K, V), u64, isize)]) -> Future<SeqNo> {
+        let (tx, rx) = Future::new();
+        self.runtime.write(vec![(self.id, updates.to_vec())], tx);
+        rx
     }
 
     /// Closes the stream at the given timestamp, migrating data strictly less
     /// than it into the trace.
-    pub fn seal(&self, upper: u64, res: CmdResponse<()>) {
-        self.runtime.seal(&[self.id], upper, res);
+    pub fn seal(&self, upper: u64) -> Future<()> {
+        let (tx, rx) = Future::new();
+        self.runtime.seal(&[self.id], upper, tx);
+        rx
     }
 }
 
@@ -426,21 +362,19 @@ impl<K: Clone, V: Clone> MultiWriteHandle<K, V> {
     //
     // TODO: This could take &StreamWriteHandle instead of Id to avoid surfacing
     // Id to users, but that would require an extra Vec. Revisit.
-    pub fn write_atomic(
-        &self,
-        updates: Vec<(Id, Vec<((K, V), u64, isize)>)>,
-        res: CmdResponse<SeqNo>,
-    ) {
+    pub fn write_atomic(&self, updates: Vec<(Id, Vec<((K, V), u64, isize)>)>) -> Future<SeqNo> {
+        let (tx, rx) = Future::new();
         for (id, _) in updates.iter() {
             if !self.ids.contains(id) {
-                res.send(Err(Error::from(format!(
+                tx.fill(Err(Error::from(format!(
                     "MultiWriteHandle cannot write to stream: {:?}",
                     id
                 ))));
-                return;
+                return rx;
             }
         }
-        self.runtime.write(updates, res)
+        self.runtime.write(updates, tx);
+        rx
     }
 
     /// Closes the streams at the given timestamp, migrating data strictly less
@@ -448,17 +382,19 @@ impl<K: Clone, V: Clone> MultiWriteHandle<K, V> {
     ///
     /// Ids may not be duplicated (this is equivalent to sealing the stream
     /// twice at the same timestamp, which we currently disallow).
-    pub fn seal(&self, ids: &[Id], upper: u64, res: CmdResponse<()>) {
+    pub fn seal(&self, ids: &[Id], upper: u64) -> Future<()> {
+        let (tx, rx) = Future::new();
         for id in ids {
             if !self.ids.contains(id) {
-                res.send(Err(Error::from(format!(
+                tx.fill(Err(Error::from(format!(
                     "MultiWriteHandle cannot seal stream: {:?}",
                     id
                 ))));
-                return;
+                return rx;
             }
         }
-        self.runtime.seal(ids, upper, res)
+        self.runtime.seal(ids, upper, tx);
+        rx
     }
 }
 
@@ -488,23 +424,23 @@ impl<K: Clone, V: Clone> StreamReadHandle<K, V> {
     /// Returns a consistent snapshot of all previously persisted stream data.
     pub fn snapshot(&self) -> Result<IndexedSnapshot<K, V>, Error> {
         // TODO: Make snapshot signature non-blocking.
-        let (rx, tx) = mpsc::channel();
-        self.runtime.snapshot(self.id, rx.into());
-        tx.recv()
-            .map_err(|_| Error::RuntimeShutdown)
-            .and_then(std::convert::identity)
+        let (tx, rx) = Future::new();
+        self.runtime.snapshot(self.id, tx);
+        rx.recv()
     }
 
     /// Registers a callback to be invoked on successful writes and seals.
     pub fn listen(&self, listen_fn: ListenFn<K, V>) -> Result<(), Error> {
-        let (rx, tx) = mpsc::channel();
-        self.runtime.listen(self.id, listen_fn, rx.into());
-        tx.recv().map_err(|_| Error::RuntimeShutdown)?
+        let (tx, rx) = Future::new();
+        self.runtime.listen(self.id, listen_fn, tx);
+        rx.recv()
     }
 
     /// Unblocks compaction for updates at or before `since`.
-    pub fn allow_compaction(&mut self, since: u64, res: CmdResponse<()>) {
-        self.runtime.allow_compaction(self.id, since, res);
+    pub fn allow_compaction(&mut self, since: u64) -> Future<()> {
+        let (tx, rx) = Future::new();
+        self.runtime.allow_compaction(self.id, since, tx);
+        rx
     }
 }
 
@@ -528,38 +464,38 @@ impl<K: Data, V: Data, U: Buffer, L: Blob> RuntimeImpl<K, V, U, L> {
         };
         match cmd {
             Cmd::Stop(res) => {
-                res.send(self.indexed.close());
+                res.fill(self.indexed.close());
                 return false;
             }
             Cmd::Register(id, res) => {
                 let r = self.indexed.register(&id);
-                res.send(r);
+                res.fill(r);
             }
             Cmd::Destroy(id, res) => {
                 let r = self.indexed.destroy(&id);
-                res.send(r);
+                res.fill(r);
             }
             Cmd::Write(updates, res) => {
                 let write_res = self.indexed.write_sync(updates);
                 // TODO: Move this to a Cmd::Tick or something.
                 let step_res = self.indexed.step();
-                res.send(step_res.and_then(|_| write_res));
+                res.fill(step_res.and_then(|_| write_res));
             }
             Cmd::Seal(ids, ts, res) => {
                 let r = self.indexed.seal(ids, ts);
-                res.send(r);
+                res.fill(r);
             }
             Cmd::AllowCompaction(id, ts, res) => {
                 let r = self.indexed.allow_compaction(id, ts);
-                res.send(r);
+                res.fill(r);
             }
             Cmd::Snapshot(id, res) => {
                 let r = self.indexed.snapshot(id);
-                res.send(r);
+                res.fill(r);
             }
             Cmd::Listen(id, listen_fn, res) => {
                 let r = self.indexed.listen(id, listen_fn);
-                res.send(r);
+                res.fill(r);
             }
         }
         return true;
@@ -573,12 +509,6 @@ mod tests {
 
     use super::*;
 
-    fn block_on<T, F: FnOnce(CmdResponse<T>)>(f: F) -> Result<T, Error> {
-        let (tx, rx) = mpsc::channel();
-        f(tx.into());
-        rx.recv().map_err(|_| Error::RuntimeShutdown)?
-    }
-
     #[test]
     fn runtime() -> Result<(), Error> {
         let data = vec![
@@ -591,7 +521,7 @@ mod tests {
         let mut runtime = start(buffer, blob)?;
 
         let (write, meta) = runtime.create_or_load("0")?;
-        block_on(|res| write.write(&data, res))?;
+        write.write(&data).recv()?;
         let snap = meta.snapshot()?;
         assert_eq!(snap.read_to_end(), data);
 
@@ -620,7 +550,7 @@ mod tests {
         let mut client2 = client1.clone();
         drop(client1);
         let (write, meta) = client2.create_or_load("0")?;
-        block_on(|res| write.write(&data, res))?;
+        write.write(&data).recv()?;
         let snap = meta.snapshot()?;
         assert_eq!(snap.read_to_end(), data);
         client2.stop()?;
@@ -641,14 +571,14 @@ mod tests {
         // blob and allowing them to be reused in the next Indexed.
         let mut persister = registry.open("path", "restart-1")?;
         let (write, _) = persister.create_or_load("0")?;
-        block_on(|res| write.write(&data[0..1], res))?;
+        write.write(&data[0..1]).recv()?;
         assert_eq!(persister.stop(), Ok(()));
 
         // Shutdown happens if all handles are dropped, even if we don't call
         // stop.
         let persister = registry.open("path", "restart-2")?;
         let (write, _) = persister.create_or_load("0")?;
-        block_on(|res| write.write(&data[1..2], res))?;
+        write.write(&data[1..2]).recv()?;
         drop(write);
         drop(persister);
 
@@ -690,29 +620,29 @@ mod tests {
             (c1s1.stream_id(), data[..1].to_vec()),
             (c1s2.stream_id(), data[1..].to_vec()),
         ];
-        block_on(|res| multi.write_atomic(updates, res))?;
+        multi.write_atomic(updates).recv()?;
         assert_eq!(c1s1_read.snapshot()?.read_to_end(), data[..1].to_vec());
         assert_eq!(c1s2_read.snapshot()?.read_to_end(), data[1..].to_vec());
 
         // Normal seal
         let ids = &[c1s1.stream_id(), c1s2.stream_id()];
-        block_on(|res| multi.seal(ids, 2, res))?;
+        multi.seal(ids, 2).recv()?;
         // We don't expose reading the seal directly, so hack it a bit here by
         // verifying that we can't re-seal at the same timestamp (which is
         // disallowed).
         let expected_seal_err = Err(Error::from("invalid batch bounds: Description { lower: Antichain { elements: [2] }, upper: Antichain { elements: [2] }, since: Antichain { elements: [0] } }"));
-        assert_eq!(block_on(|res| c1s1.seal(2, res)), expected_seal_err);
-        assert_eq!(block_on(|res| c1s2.seal(2, res)), expected_seal_err);
+        assert_eq!(c1s1.seal(2).recv(), expected_seal_err);
+        assert_eq!(c1s2.seal(2).recv(), expected_seal_err);
 
         // Cannot write to streams not specified during construction.
         let (c1s3, _) = client1.create_or_load("3")?;
-        assert!(
-            block_on(|res| multi.write_atomic(vec![(c1s3.stream_id(), data.clone())], res))
-                .is_err()
-        );
+        assert!(multi
+            .write_atomic(vec![(c1s3.stream_id(), data)])
+            .recv()
+            .is_err());
 
         // Cannot seal streams not specified during construction.
-        assert!(block_on(|res| multi.seal(&[c1s3.stream_id()], 3, res)).is_err());
+        assert!(multi.seal(&[c1s3.stream_id()], 3).recv().is_err());
 
         Ok(())
     }

--- a/src/persist/src/lib.rs
+++ b/src/persist/src/lib.rs
@@ -27,6 +27,8 @@ pub mod mem;
 #[cfg(test)]
 pub mod nemesis;
 pub mod operators;
+// TODO: Rename this to future once we rename indexed::future to unsealed.
+pub mod pfuture;
 pub mod storage;
 pub mod unreliable;
 

--- a/src/persist/src/pfuture.rs
+++ b/src/persist/src/pfuture.rs
@@ -1,0 +1,65 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Public concrete implementation of [std::future::Future].
+
+use futures_util::FutureExt;
+use tokio::sync::oneshot;
+
+use crate::error::Error;
+
+/// The result of an asynchronous computation.
+///
+/// Unlike [std::future::Future], the computation will complete even if this is
+/// dropped.
+pub struct Future<T>(oneshot::Receiver<Result<T, Error>>);
+
+impl<T> Future<T> {
+    pub(crate) fn new() -> (FutureHandle<T>, Future<T>) {
+        let (tx, rx) = oneshot::channel();
+        (FutureHandle(tx), Future(rx))
+    }
+
+    fn flatten_err(res: Result<Result<T, Error>, oneshot::error::RecvError>) -> Result<T, Error> {
+        match res {
+            Ok(x) => x,
+            // The sender will only hang up if the runtime is no longer running.
+            Err(oneshot::error::RecvError { .. }) => Err(Error::RuntimeShutdown),
+        }
+    }
+
+    /// Blocks and synchronously receives the result.
+    //
+    // TODO: Make this cfg(test) or behind a feature gate.
+    pub fn recv(self) -> Result<T, Error> {
+        futures_executor::block_on(self.into_future())
+    }
+
+    /// Convert this into a [std::future::Future].
+    ///
+    /// The computation represented by self will complete regardless of whether
+    /// the returned Future is polled to completion, but anything derived from
+    /// the returned [std::future::Future] (map, etc) is subject to the normal
+    /// rules.
+    //
+    // TODO: Is it possible for this to impl [std::future::Future] directly?
+    pub fn into_future(self) -> impl std::future::Future<Output = Result<T, Error>> {
+        self.0.map(Self::flatten_err)
+    }
+}
+
+/// A handle for filling the result of an asynchronous computation.
+pub(crate) struct FutureHandle<T>(oneshot::Sender<Result<T, Error>>);
+
+impl<T> FutureHandle<T> {
+    pub(crate) fn fill(self, res: Result<T, Error>) {
+        // Don't care if the receiver hung up.
+        let _ = self.0.send(res);
+    }
+}


### PR DESCRIPTION
The original idea behind CmdResponse (plumbing a channel all the way
from persist to pgwire) hasn't ended up working out. It turns out that
callers of write and seal just want a std::future::Future, so give them
one.

The persist Future is powered by a oneshot::channel(), but hide this
implementation detail. Bonus: This much more elegantly handles channel
errors than what we had before.