### PR TITLE
Improve temporal filter error text

### DIFF
--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -1247,7 +1247,7 @@ pub mod plan {
                         || *expr1 != MirScalarExpr::CallNullary(NullaryFunc::MzLogicalTimestamp)
                     {
                         return Err(format!(
-                            "Unsupported temporal predicate. Note: `mz_logical_timestamp()` must be directly compared to a numeric non-temporal expression; if it is compared to a non-numeric type, consider casting it to numeric. Expression found: {:?}",
+                            "Unsupported temporal predicate. Note: `mz_logical_timestamp()` must be directly compared to a numeric non-temporal expression; if it is compared to a non-numeric type, consider casting that type to numeric. Expression found: {:?}",
                             MirScalarExpr::CallBinary { func, expr1, expr2 },
                             ));
                     }
@@ -1296,7 +1296,7 @@ pub mod plan {
                     }
                 } else {
                     return Err(format!(
-                        "Unsupported temporal predicate. Note: `mz_logical_timestamp()` must be directly compared to a numeric non-temporal expression; if it is compared to a non-numeric type, consider casting it to numeric. Expression found: {:?}",
+                        "Unsupported temporal predicate. Note: `mz_logical_timestamp()` must be directly compared to a numeric non-temporal expression; if it is compared to a non-numeric type, consider casting that type to numeric. Expression found: {:?}",
                         predicate,
                         ));
                 }

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -1246,7 +1246,10 @@ pub mod plan {
                     if expr2.contains_temporal()
                         || *expr1 != MirScalarExpr::CallNullary(NullaryFunc::MzLogicalTimestamp)
                     {
-                        return Err("Unsupported temporal predicate: `mz_logical_timestamp()` must be directly compared to a non-temporal expression ".to_string());
+                        return Err(format!(
+                            "Unsupported temporal predicate. Note: `mz_logical_timestamp()` must be directly compared to a numeric non-temporal expression; if it is compared to a non-numeric type, consider casting it to numeric. Expression found: {:?}",
+                            MirScalarExpr::CallBinary { func, expr1, expr2 },
+                            ));
                     }
 
                     // We'll need to use this a fair bit.
@@ -1292,7 +1295,10 @@ pub mod plan {
                         }
                     }
                 } else {
-                    return Err("Unsupported temporal predicate: `mz_logical_timestamp()` must be directly compared to a non-temporal expression ".to_string());
+                    return Err(format!(
+                        "Unsupported temporal predicate. Note: `mz_logical_timestamp()` must be directly compared to a numeric non-temporal expression; if it is compared to a non-numeric type, consider casting it to numeric. Expression found: {:?}",
+                        predicate,
+                        ));
                 }
             }
 

--- a/test/testdrive/temporal.td
+++ b/test/testdrive/temporal.td
@@ -262,13 +262,13 @@ ts
 Unsupported binary temporal operation: NotEq
 
 !CREATE MATERIALIZED VIEW v1 AS SELECT * FROM first_ts WHERE mz_logical_timestamp() + 1 = ts;
-Unsupported temporal predicate: `mz_logical_timestamp()` must be directly compared to a non-temporal expression
+Unsupported temporal predicate. Note: `mz_logical_timestamp()` must be directly compared to a numeric non-temporal expression; if it is compared to a non-numeric type, consider casting that type to numeric. Expression found: CallBinary { func: Eq, expr1: CallUnary { func: CastInt64ToNumeric(None), expr: Column(0) }, expr2: CallBinary { func: AddNumeric, expr1: CallNullary(MzLogicalTimestamp), expr2: Literal(Ok(Row{[Numeric(OrderedDecimal(1))]}), ColumnType { scalar_type: Numeric { scale: None }, nullable: false }) } }
 
 !CREATE MATERIALIZED VIEW v1 AS SELECT * FROM first_ts WHERE mz_logical_timestamp() > ts OR ts = 1;
-Unsupported temporal predicate: `mz_logical_timestamp()` must be directly compared to a non-temporal expression
+Unsupported temporal predicate. Note: `mz_logical_timestamp()` must be directly compared to a numeric non-temporal expression; if it is compared to a non-numeric type, consider casting that type to numeric. Expression found: CallBinary { func: Or, expr1: CallBinary { func: Eq, expr1: Column(0), expr2: Literal(Ok(Row{[Int64(1)]}), ColumnType { scalar_type: Int64, nullable: false }) }, expr2: CallBinary { func: Gt, expr1: CallNullary(MzLogicalTimestamp), expr2: CallUnary { func: CastInt64ToNumeric(None), expr: Column(0) } } }
 
 !CREATE MATERIALIZED VIEW v1 AS SELECT * FROM first_ts WHERE ts BETWEEN mz_logical_timestamp() AND mz_logical_timestamp() + 1;
-Unsupported temporal predicate: `mz_logical_timestamp()` must be directly compared to a non-temporal expression
+Unsupported temporal predicate. Note: `mz_logical_timestamp()` must be directly compared to a numeric non-temporal expression; if it is compared to a non-numeric type, consider casting that type to numeric. Expression found: CallBinary { func: Lte, expr1: Column(1), expr2: CallBinary { func: AddNumeric, expr1: CallNullary(MzLogicalTimestamp), expr2: Literal(Ok(Row{[Numeric(OrderedDecimal(1))]}), ColumnType { scalar_type: Numeric { scale: None }, nullable: false }) } }
 
 #
 # Numeric comparisons


### PR DESCRIPTION
Based on a limited amount of user feedback, add some helpful tips and evidence to the error message about temporal filter types. We bump up the existing error with a hint (to cast other terms to numeric) and the expression that we found. For example:
```
materialize=> create materialized view quux as select * from foo where mz_logical_timestamp() > extract(epoch from a);
ERROR:  "Unsupported temporal predicate. Note: `mz_logical_timestamp()` must be directly compared to a numeric non-temporal expression; if it is compared to a non-numeric type, consider casting that type to numeric. Expression found: CallBinary { func: Gt, expr1: CallUnary { func: CastNumericToFloat64, expr: CallNullary(MzLogicalTimestamp) }, expr2: CallUnary { func: DatePartTimestamp(Epoch), expr: Column(0) } }"
```
I'm not sure if we want to scare people with our expression trees, but it seems helpful for reporting errors back, and potentially communicating the bad thing that has happened.

fixes #7164