### PR TITLE
upgrade test: fix mzcompose.yml to conform to new format

### DIFF
--- a/test/upgrade/mzcompose.yml
+++ b/test/upgrade/mzcompose.yml
@@ -213,7 +213,7 @@ services:
   zookeeper:
     image: confluentinc/cp-zookeeper:5.5.4
     environment:
-      - ZOOKEEPER_CLIENT_PORT: 2181
+      - ZOOKEEPER_CLIENT_PORT=2181
 
   kafka:
     image: confluentinc/cp-kafka:5.5.4


### PR DESCRIPTION
the environment sections need to be in a KEY=VALUE format
rather than KEY: VALUE

@benesch FYI