### PR TITLE
muse: completely move RT timestamping to coordinator, make generic over sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1597,9 +1597,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hex-literal"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76505e26b6ca3bbdbbb360b68472abbb80998c5fa5dc43672eca34f28258e138"
+checksum = "21e4590e13640f19f249fe3e4eca5113bc4289f2497710378190e7f4bd96f45b"
 
 [[package]]
 name = "hmac"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4405,18 +4405,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.20"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
+checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.20"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
+checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,6 +1176,7 @@ dependencies = [
  "serde_json",
  "sha-1",
  "sha2",
+ "timely",
  "uncased",
 ]
 

--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -104,7 +104,7 @@ pub struct Catalog {
     ambient_schemas: BTreeMap<String, Schema>,
     temporary_schemas: HashMap<u32, Schema>,
     roles: HashMap<String, Role>,
-    storage: Arc<Mutex<storage::Connection>>,
+    pub storage: Arc<Mutex<storage::Connection>>,
     oid_counter: u32,
     config: sql::catalog::CatalogConfig,
 }

--- a/src/coord/src/coord/arrangement_state.rs
+++ b/src/coord/src/coord/arrangement_state.rs
@@ -105,10 +105,6 @@ pub struct Frontiers<T: Timestamp> {
     /// The most recent frontier for new data.
     /// All further changes will be in advance of this bound.
     pub upper: MutableAntichain<T>,
-    /// The most recent frontier for durable data.
-    /// All data at times in advance of this frontier have not yet been
-    /// durably persisted and may not be replayable across restarts.
-    pub durability: MutableAntichain<T>,
     /// The compaction frontier.
     /// All peeks in advance of this frontier will be correct,
     /// but peeks not in advance of this frontier may not be.
@@ -140,10 +136,8 @@ impl<T: Timestamp + Copy> Frontiers<T> {
         // Upper must always start at minimum ("0"), even if we initialize since to
         // something in advance of it.
         upper.update_iter(Some((T::minimum(), workers as i64)));
-        let durability = upper.clone();
         let frontier = Self {
             upper,
-            durability,
             since: Rc::new(RefCell::new(MutableAntichain::new())),
             compaction_window_ms,
             since_action: Rc::new(RefCell::new(since_action)),

--- a/src/coordtest/src/lib.rs
+++ b/src/coordtest/src/lib.rs
@@ -136,9 +136,8 @@ impl CoordTest {
         loop {
             if let Some(Some(mut msg)) = self.dataflow_feedback_rx.recv().now_or_never() {
                 // Filter out requested ids.
-                if let WorkerFeedback::FrontierUppers(uppers) = &mut msg.message {
-                    uppers.retain(|(id, _data)| !exclude.contains(id));
-                }
+                let WorkerFeedback::FrontierUppers(uppers) = &mut msg.message;
+                uppers.retain(|(id, _data)| !exclude.contains(id));
                 self.coord_feedback_tx.send(msg).unwrap();
             } else {
                 return;

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -859,6 +859,75 @@ impl ExternalSourceConnector {
     }
 }
 
+impl ProtoSource for KafkaSourceConnector {
+    type SourceTimestamp = PartitionOffset;
+    type Partition = PartitionId;
+
+    type FrontierDiscoverer = RtKafkaDiscoverer;
+
+    type PartitionDiscoverer = RtKafkaDiscoverer;
+
+    fn create_frontier_discoverer(&self) -> Self::FrontierDiscoverer {
+        todo!()
+    }
+
+    fn create_partition_discoverer(&self) -> Self::PartitionDiscoverer {
+        todo!()
+    }
+}
+
+pub struct RtKafkaDiscoverer {}
+
+impl SourceFrontierDiscoverer for RtKafkaDiscoverer {
+    type SourceTimestamp = PartitionOffset;
+
+    fn get_available_frontier(&self) -> Result<Antichain<Self::SourceTimestamp>, anyhow::Error> {
+        todo!()
+    }
+
+    fn id(&self) -> GlobalId {
+        todo!()
+    }
+
+    fn update_interval(&self) -> Duration {
+        todo!()
+    }
+}
+
+impl SourcePartitionDiscoverer for RtKafkaDiscoverer {
+    type Partition = PartitionId;
+
+    fn get_available_partitions(&self) -> Result<Vec<Self::Partition>, anyhow::Error> {
+        todo!()
+    }
+}
+
+pub trait ProtoSource {
+    type SourceTimestamp;
+    type Partition;
+    type FrontierDiscoverer: SourceFrontierDiscoverer<SourceTimestamp = Self::SourceTimestamp>;
+    type PartitionDiscoverer: SourcePartitionDiscoverer<Partition = Self::Partition>;
+
+    // For this to work, SourceReader needs to be in dataflow-types, which is
+    // the common package that both dataflow and coord have as dependency.
+    //
+    // Actual source implementations would only depend on dataflow-types and
+    // live in their own sources package.
+
+    // type SourceReader: SourceReader<SourceTimestamp = Self::SourceTimestamp>;
+
+    /// Creates a [`SourceFrontierDiscoverer`] for this source.
+    fn create_frontier_discoverer(&self) -> Self::FrontierDiscoverer;
+
+    /// Creates a [`SourcePartitionDiscoverer`] for this source.
+    fn create_partition_discoverer(&self) -> Self::PartitionDiscoverer;
+
+    // Creates a [`SourceReader`] for this source.
+    //
+    // Doesn't work, see above.
+    // fn create_source_reader(&self) -> Self::SourceReader;
+}
+
 /// This name is horrible and should maybe be `DiscoverSourceFrontier`, but `SourceReader` is also
 /// called `SourceReader` and not `ReadSource`...
 pub trait SourceFrontierDiscoverer {

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -893,19 +893,14 @@ pub struct KafkaOffset {
     pub offset: i64,
 }
 
-/// Structure wrapping a timestamp update from a source
-/// If RT, contains a partition count
-/// If BYO, contains a tuple (PartitionCount, PartitionID, Timestamp, Offset),
-/// which informs workers that messages with Offset on PartititionId will be timestamped
-/// with Timestamp.
+/// Timestamp binding update for a source. Contains a
+/// (PartitionID, Timestamp, Offset), which informs workers that messages with
+/// Offset on PartititionId will be timestamped with Timestamp.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum TimestampSourceUpdate {
-    /// Update for an RT source: contains a new partition to add to this source.
-    RealTime(PartitionId),
-    /// Timestamp update for a BYO source: contains a PartitionID, Timestamp,
-    /// MzOffset tuple. This tuple informs workers that messages with Offset on
-    /// PartitionId will be timestamped with Timestamp.
-    BringYourOwn(PartitionId, u64, MzOffset),
+pub struct TimestampSourceUpdate {
+    pub pid: PartitionId,
+    pub timestamp: Timestamp,
+    pub offset: MzOffset,
 }
 
 /// Convert from KafkaOffset to MzOffset (1-indexed)

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -859,6 +859,32 @@ impl ExternalSourceConnector {
     }
 }
 
+/// This name is horrible and should maybe be `DiscoverSourceFrontier`, but `SourceReader` is also
+/// called `SourceReader` and not `ReadSource`...
+pub trait SourceFrontierDiscoverer {
+    type SourceTimestamp;
+
+    /// Returns the timestamp frontier of source data that is available for reading. Any data that
+    /// becomes newly available in the future will be beyond this frontier.
+    fn get_available_frontier(&self) -> Result<Antichain<Self::SourceTimestamp>, anyhow::Error>;
+
+    /// Returns the [`GlobalId`] of this source.
+    fn id(&self) -> GlobalId;
+
+    /// Returns the preferred refresh interval. It possible, [`get_available_frontier`] will be
+    /// called based on this.
+    fn update_interval(&self) -> Duration;
+}
+
+/// This name is horrible and should maybe be `DiscoverSourcePartitions`, but `SourceReader` is also
+/// called `SourceReader` anot not `ReadSource`...
+pub trait SourcePartitionDiscoverer {
+    type Partition;
+
+    /// Returns the partitions that are available for this source.
+    fn get_available_partitions(&self) -> Result<Vec<Self::Partition>, anyhow::Error>;
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum Consistency {
     BringYourOwn(BringYourOwn),

--- a/src/dataflow/src/lib.rs
+++ b/src/dataflow/src/lib.rs
@@ -23,7 +23,4 @@ pub mod logging;
 pub mod source;
 
 pub use render::plan::Plan;
-pub use server::{
-    serve, Config, SequencedCommand, TimestampBindingFeedback, WorkerFeedback,
-    WorkerFeedbackWithMeta,
-};
+pub use server::{serve, Config, SequencedCommand, WorkerFeedback, WorkerFeedbackWithMeta};

--- a/src/dataflow/src/render/sinks.rs
+++ b/src/dataflow/src/render/sinks.rs
@@ -207,20 +207,6 @@ where
 
         match sink.connector.clone() {
             SinkConnector::Kafka(c) => {
-                // Extract handles to the relevant source timestamp histories the sink
-                // needs to hear from before it can write data out to Kafka.
-                let mut source_ts_histories = Vec::new();
-
-                for id in &c.transitive_source_dependencies {
-                    if let Some(history) = render_state.ts_histories.get(id) {
-                        let mut history_bindings = history.clone();
-                        // We don't want these to block compaction
-                        // ever.
-                        history_bindings.set_compaction_frontier(Antichain::new().borrow());
-                        source_ts_histories.push(history_bindings);
-                    }
-                }
-
                 // TODO: this is a brittle way to indicate the worker that will write to the sink
                 // because it relies on us continuing to hash on the sink_id, with the same hash
                 // function, and for the Exchange pact to continue to distribute by modulo number
@@ -236,7 +222,6 @@ where
                     sink.key_desc.clone(),
                     sink.value_desc.clone(),
                     sink.as_of.clone(),
-                    source_ts_histories,
                     shared_frontier.clone(),
                 );
 

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -10,7 +10,6 @@
 //! An interactive dataflow server.
 
 use std::collections::HashMap;
-use std::convert::TryInto;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
@@ -18,6 +17,7 @@ use differential_dataflow::operators::arrange::arrangement::Arrange;
 use differential_dataflow::trace::cursor::Cursor;
 use differential_dataflow::trace::TraceReader;
 use differential_dataflow::Collection;
+use log::debug;
 use serde::{Deserialize, Serialize};
 use timely::communication::initialize::WorkerGuards;
 use timely::communication::Allocate;
@@ -32,8 +32,8 @@ use tokio::sync::mpsc;
 
 use dataflow_types::logging::LoggingConfig;
 use dataflow_types::{
-    Consistency, DataflowDescription, DataflowError, ExternalSourceConnector, MzOffset,
-    PeekResponse, SourceConnector, TimestampSourceUpdate, Update,
+    Consistency, DataflowDescription, DataflowError, ExternalSourceConnector, PeekResponse,
+    SourceConnector, TimestampSourceUpdate, Update,
 };
 use expr::{GlobalId, PartitionId, RowSetFinishing};
 use ore::{now::NowFn, result::ResultExt};
@@ -48,10 +48,6 @@ use crate::server::metrics::Metrics;
 use crate::source::timestamp::TimestampBindingRc;
 
 mod metrics;
-
-/// How frequently each dataflow worker sends timestamp binding updates
-/// back to the coordinator.
-static TS_BINDING_FEEDBACK_INTERVAL_MS: u128 = 1_000;
 
 /// Explicit instructions for timely dataflow workers.
 #[derive(Clone, Debug)]
@@ -105,27 +101,19 @@ pub enum SequencedCommand {
     /// accumulations must be correct. The workers gain the liberty of compacting
     /// the corresponding maintained traces up through that frontier.
     AllowCompaction(Vec<(GlobalId, Antichain<Timestamp>)>),
-    /// Update durability information for sources.
-    ///
-    /// Each entry names a source and provides a frontier before which the source can
-    /// be exactly replayed across restarts (i.e. we can assign the same timestamps to
-    /// all the same data)
-    DurabilityFrontierUpdates(Vec<(GlobalId, Antichain<Timestamp>)>),
     /// Add a new source to be aware of for timestamping.
     AddSourceTimestamping {
         /// The ID of the timestamped source
         id: GlobalId,
         /// The connector for the timestamped source.
         connector: SourceConnector,
-        /// Previously stored timestamp bindings.
-        bindings: Vec<(PartitionId, Timestamp, MzOffset)>,
     },
     /// Advance worker timestamp
     AdvanceSourceTimestamp {
         /// The ID of the timestamped source
         id: GlobalId,
         /// The associated update (RT or BYO)
-        update: TimestampSourceUpdate,
+        update: Vec<TimestampSourceUpdate>,
     },
     /// Drop all timestamping info for a source
     DropSourceTimestamping {
@@ -155,23 +143,11 @@ pub struct WorkerFeedbackWithMeta {
     pub message: WorkerFeedback,
 }
 
-/// Data about timestamp bindings that dataflow workers send to the coordinator
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct TimestampBindingFeedback {
-    /// Durability frontier changes
-    pub changes: Vec<(GlobalId, ChangeBatch<Timestamp>)>,
-    /// Timestamp bindings for all of those frontier changes
-    pub bindings: Vec<(GlobalId, PartitionId, Timestamp, MzOffset)>,
-}
-
 /// Responses the worker can provide back to the coordinator.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum WorkerFeedback {
     /// A list of identifiers of traces, with prior and new upper frontiers.
     FrontierUppers(Vec<(GlobalId, ChangeBatch<Timestamp>)>),
-    /// Timestamp bindings and prior and new frontiers for those bindings for all
-    /// sources
-    TimestampBindings(TimestampBindingFeedback),
 }
 
 /// Configures a dataflow server.
@@ -232,8 +208,6 @@ pub fn serve(config: Config) -> Result<WorkerGuards<()>, String> {
                 pending_peeks: Vec::new(),
                 feedback_tx: None,
                 reported_frontiers: HashMap::new(),
-                reported_bindings_frontiers: HashMap::new(),
-                last_bindings_feedback: Instant::now(),
                 metrics: Metrics::for_worker_id(worker_idx),
                 experimental_mode,
                 now,
@@ -265,10 +239,6 @@ where
     feedback_tx: Option<mpsc::UnboundedSender<WorkerFeedbackWithMeta>>,
     /// Tracks the frontier information that has been sent over `feedback_tx`.
     reported_frontiers: HashMap<GlobalId, Antichain<Timestamp>>,
-    /// Tracks the timestamp binding durability information that has been sent over `feedback_tx`.
-    reported_bindings_frontiers: HashMap<GlobalId, Antichain<Timestamp>>,
-    /// Tracks the last time we sent binding durability info over `feedback_tx`.
-    last_bindings_feedback: Instant,
     /// Metrics bundle.
     metrics: Metrics,
     /// Whether the server is running in experimental mode
@@ -440,8 +410,6 @@ where
 
             // Report frontier information back the coordinator.
             self.report_frontiers();
-            self.update_rt_timestamps();
-            self.report_timestamp_bindings();
 
             // Handle any received commands.
             let cmds: Vec<_> = self.command_rx.try_iter().collect();
@@ -548,87 +516,6 @@ where
                     })
                     .expect("feedback receiver should not drop first");
             }
-        }
-    }
-
-    /// Send information about new timestamp bindings created by dataflow workers back to
-    /// the coordinator.
-    ///
-    /// Only enabled when running in experimental mode for now.
-    fn report_timestamp_bindings(&mut self) {
-        // Do nothing if dataflow workers can't send feedback or if not enough time has elapsed since
-        // the last time we reported timestamp bindings.
-        if !self.experimental_mode
-            || self.feedback_tx.is_none()
-            || self.last_bindings_feedback.elapsed().as_millis() < TS_BINDING_FEEDBACK_INTERVAL_MS
-        {
-            return;
-        }
-
-        let mut changes = Vec::new();
-        let mut bindings = Vec::new();
-        let mut new_frontier = Antichain::new();
-
-        // Need to go through all sources that are generating timestamp bindings, and extract their upper frontiers.
-        // If that frontier is different than the durability frontier we've previously reported then we also need to
-        // get the new bindings we've produced and send them to the coordinator.
-        for (id, history) in self.render_state.ts_histories.iter() {
-            // Read the upper frontier and compare to what we've reported.
-            history.read_upper(&mut new_frontier);
-            let prev_frontier = self
-                .reported_bindings_frontiers
-                .get_mut(&id)
-                .expect("Frontier missing!");
-            assert!(<_ as PartialOrder>::less_equal(
-                prev_frontier,
-                &new_frontier
-            ));
-            if prev_frontier != &new_frontier {
-                let mut change_batch = ChangeBatch::new();
-                for time in prev_frontier.elements().iter() {
-                    change_batch.update(time.clone(), -1);
-                }
-                for time in new_frontier.elements().iter() {
-                    change_batch.update(time.clone(), 1);
-                }
-                change_batch.compact();
-                if !change_batch.is_empty() {
-                    changes.push((*id, change_batch));
-                }
-                // Add all timestamp bindings we know about between the old and new frontier.
-                bindings.extend(
-                    history
-                        .get_bindings_in_range(prev_frontier.borrow(), new_frontier.borrow())
-                        .into_iter()
-                        .map(|(pid, ts, offset)| (*id, pid, ts, offset)),
-                );
-                prev_frontier.clone_from(&new_frontier);
-            }
-        }
-
-        if !changes.is_empty() || !bindings.is_empty() {
-            self.feedback_tx
-                .as_mut()
-                .expect("known to exist")
-                .send(WorkerFeedbackWithMeta {
-                    worker_id: self.timely_worker.index(),
-                    message: WorkerFeedback::TimestampBindings(TimestampBindingFeedback {
-                        changes,
-                        bindings,
-                    }),
-                })
-                .expect("feedback receiver should not drop first");
-        }
-        self.last_bindings_feedback = Instant::now();
-    }
-    /// Instruct all real-time sources managed by the worker to close their current
-    /// timestamp and move to the next wall clock time.
-    ///
-    /// Needs to be called periodically (ideally once per "timestamp_frequency" in order
-    /// for real time sources to make progress.
-    fn update_rt_timestamps(&self) {
-        for (_, history) in self.render_state.ts_histories.iter() {
-            history.update_timestamp();
         }
     }
 
@@ -794,13 +681,6 @@ where
                     }
                 }
             }
-            SequencedCommand::DurabilityFrontierUpdates(list) => {
-                for (id, frontier) in list {
-                    if let Some(ts_history) = self.render_state.ts_histories.get_mut(&id) {
-                        ts_history.set_durability_frontier(frontier.borrow());
-                    }
-                }
-            }
 
             SequencedCommand::EnableFeedback(tx) => {
                 self.feedback_tx = Some(tx);
@@ -813,63 +693,46 @@ where
                 self.render_state.traces.del_all_traces();
                 self.shutdown_logging();
             }
-            SequencedCommand::AddSourceTimestamping {
-                id,
-                connector,
-                bindings,
-            } => {
+            SequencedCommand::AddSourceTimestamping { id, connector } => {
                 let source_timestamp_data = if let SourceConnector::External {
                     connector,
                     consistency,
-                    ts_frequency,
+                    ts_frequency: _,
                     ..
                 } = connector
                 {
-                    let byo_default = TimestampBindingRc::new(None, self.now);
-                    let rt_default = TimestampBindingRc::new(
-                        Some(ts_frequency.as_millis().try_into().unwrap()),
-                        self.now,
-                    );
+                    let timestamp_bindings = TimestampBindingRc::new();
+
                     match (connector, consistency) {
                         (ExternalSourceConnector::Kafka(_), Consistency::BringYourOwn(_)) => {
-                            byo_default.add_partition(PartitionId::Kafka(0));
-                            // NB: mark BYO sources as fully durable when not running in experimental
-                            // because, because we don't actually write durability updates in that context
-                            // but we still rely on BYO sources being default durable for EOS.
-                            // Need to remove this when we move RT EOS sinks to non-experimental
-                            // status.
-                            if !self.experimental_mode {
-                                byo_default.set_durability_frontier(Antichain::new().borrow());
-                            }
-                            Some(byo_default)
+                            Some(timestamp_bindings)
                         }
                         (ExternalSourceConnector::Kafka(_), Consistency::RealTime) => {
-                            rt_default.add_partition(PartitionId::Kafka(0));
-                            Some(rt_default)
+                            Some(timestamp_bindings)
                         }
                         (ExternalSourceConnector::AvroOcf(_), Consistency::BringYourOwn(_)) => {
-                            byo_default.add_partition(PartitionId::None);
-                            Some(byo_default)
+                            timestamp_bindings.add_partition(PartitionId::None);
+                            Some(timestamp_bindings)
                         }
                         (ExternalSourceConnector::AvroOcf(_), Consistency::RealTime) => {
-                            rt_default.add_partition(PartitionId::None);
-                            Some(rt_default)
+                            timestamp_bindings.add_partition(PartitionId::None);
+                            Some(timestamp_bindings)
                         }
                         (ExternalSourceConnector::File(_), Consistency::BringYourOwn(_)) => {
-                            byo_default.add_partition(PartitionId::None);
-                            Some(byo_default)
+                            timestamp_bindings.add_partition(PartitionId::None);
+                            Some(timestamp_bindings)
                         }
                         (ExternalSourceConnector::File(_), Consistency::RealTime) => {
-                            rt_default.add_partition(PartitionId::None);
-                            Some(rt_default)
+                            timestamp_bindings.add_partition(PartitionId::None);
+                            Some(timestamp_bindings)
                         }
                         (ExternalSourceConnector::Kinesis(_), Consistency::RealTime) => {
-                            rt_default.add_partition(PartitionId::None);
-                            Some(rt_default)
+                            timestamp_bindings.add_partition(PartitionId::None);
+                            Some(timestamp_bindings)
                         }
                         (ExternalSourceConnector::S3(_), Consistency::RealTime) => {
-                            rt_default.add_partition(PartitionId::None);
-                            Some(rt_default)
+                            timestamp_bindings.add_partition(PartitionId::None);
+                            Some(timestamp_bindings)
                         }
                         (ExternalSourceConnector::Kinesis(_), Consistency::BringYourOwn(_)) => {
                             log::error!("BYO timestamping not supported for Kinesis sources");
@@ -902,40 +765,37 @@ where
 
                 // Add any timestamp bindings that we were already aware of on restart.
                 if let Some(data) = source_timestamp_data {
-                    for (pid, timestamp, offset) in bindings {
-                        data.add_partition(pid.clone());
-                        data.add_binding(pid, timestamp, offset, false);
-                    }
-
                     let prev = self.render_state.ts_histories.insert(id, data);
                     assert!(prev.is_none());
                     self.reported_frontiers.insert(id, Antichain::from_elem(0));
-                    self.reported_bindings_frontiers
-                        .insert(id, Antichain::from_elem(0));
-                } else {
-                    assert!(bindings.is_empty());
                 }
             }
             SequencedCommand::AdvanceSourceTimestamp { id, update } => {
                 if let Some(history) = self.render_state.ts_histories.get_mut(&id) {
-                    match update {
-                        TimestampSourceUpdate::BringYourOwn(pid, timestamp, offset) => {
-                            // TODO: change the interface between the dataflow server and the
-                            // timestamper. Specifically, we probably want to inform the timestamper
-                            // of the timestamps we already know about so that it doesn't send us
-                            // duplicate copies again.
+                    for update in update {
+                        match update {
+                            TimestampSourceUpdate {
+                                pid,
+                                timestamp,
+                                offset,
+                            } => {
+                                // TODO: change the interface between the dataflow server and the
+                                // timestamper. Specifically, we probably want to inform the timestamper
+                                // of the timestamps we already know about so that it doesn't send us
+                                // duplicate copies again.
 
-                            let mut upper = Antichain::new();
-                            history.read_upper(&mut upper);
+                                let mut upper = Antichain::new();
+                                history.read_upper(&mut upper);
 
-                            if upper.less_equal(&timestamp) {
-                                history.add_binding(pid, timestamp, offset + 1, false);
+                                debug!(
+                                    "Adding binding from coordinator: {}, {}, {}",
+                                    pid, timestamp, offset
+                                );
+                                history.add_partition(pid.clone());
+                                history.add_binding(pid, timestamp, offset + 1);
                             }
-                        }
-                        TimestampSourceUpdate::RealTime(new_partition) => {
-                            history.add_partition(new_partition);
-                        }
-                    };
+                        };
+                    }
 
                     let sources = self
                         .render_state
@@ -964,7 +824,6 @@ where
                 }
 
                 self.reported_frontiers.remove(&id);
-                self.reported_bindings_frontiers.remove(&id);
             }
         }
     }

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -784,23 +784,14 @@ where
                     for timestamp_binding in timestamp_bindings {
                         match timestamp_binding {
                             TimestampSourceUpdate {
-                                pid,
+                                frontier,
                                 timestamp,
-                                offset,
                             } => {
-                                // TODO: change the interface between the dataflow server and the
-                                // timestamper. Specifically, we probably want to inform the timestamper
-                                // of the timestamps we already know about so that it doesn't send us
-                                // duplicate copies again.
-
-                                let mut upper = Antichain::new();
-                                history.read_upper(&mut upper);
-
                                 debug!(
-                                    "Adding binding from coordinator: {}, {}, {}",
-                                    pid, timestamp, offset
+                                    "Adding binding from coordinator: {:?}, {}",
+                                    frontier, timestamp
                                 );
-                                history.add_binding(pid, timestamp, offset + 1);
+                                history.add_binding((frontier, timestamp));
                             }
                         };
                     }

--- a/src/dataflow/src/server/metrics.rs
+++ b/src/dataflow/src/server/metrics.rs
@@ -103,8 +103,6 @@ struct CommandsProcessedMetrics {
     insert: IntCounter,
     allow_compaction_int: i32,
     allow_compaction: IntCounter,
-    durability_frontier_updates_int: i32,
-    durability_frontier_updates: IntCounter,
     append_log_int: i32,
     append_log: IntCounter,
     add_source_timestamping_int: i32,
@@ -147,9 +145,6 @@ impl CommandsProcessedMetrics {
             allow_compaction_int: 0,
             allow_compaction: COMMANDS_PROCESSED_RAW
                 .with_label_values(&[worker, "allow_compaction"]),
-            durability_frontier_updates_int: 0,
-            durability_frontier_updates: COMMANDS_PROCESSED_RAW
-                .with_label_values(&[worker, "durability_frontier_updates"]),
             append_log_int: 0,
             append_log: COMMANDS_PROCESSED_RAW.with_label_values(&[worker, "append_log"]),
             add_source_timestamping_int: 0,
@@ -183,9 +178,6 @@ impl CommandsProcessedMetrics {
             SequencedCommand::CancelPeek { .. } => self.cancel_peek_int += 1,
             SequencedCommand::Insert { .. } => self.insert_int += 1,
             SequencedCommand::AllowCompaction(..) => self.allow_compaction_int += 1,
-            SequencedCommand::DurabilityFrontierUpdates(..) => {
-                self.durability_frontier_updates_int += 1
-            }
             SequencedCommand::AddSourceTimestamping { .. } => self.add_source_timestamping_int += 1,
             SequencedCommand::AdvanceSourceTimestamp { .. } => {
                 self.advance_source_timestamp_int += 1
@@ -236,11 +228,6 @@ impl CommandsProcessedMetrics {
             self.allow_compaction
                 .inc_by(self.allow_compaction_int as i64);
             self.allow_compaction_int = 0;
-        }
-        if self.durability_frontier_updates_int > 0 {
-            self.durability_frontier_updates
-                .inc_by(self.durability_frontier_updates_int as i64);
-            self.durability_frontier_updates_int = 0;
         }
         if self.add_source_timestamping_int > 0 {
             self.add_source_timestamping

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -30,6 +30,7 @@ serde = { version = "1.0.126", features = ["derive"] }
 serde_json = "1.0.64"
 sha-1 = "0.9.7"
 sha2 = "0.9.5"
+timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 uncased = "0.9.6"
 
 [dev-dependencies]

--- a/src/expr/src/id.rs
+++ b/src/expr/src/id.rs
@@ -13,6 +13,8 @@ use std::str::FromStr;
 use anyhow::{anyhow, Error};
 use serde::{Deserialize, Serialize};
 
+use timely::order::PartialOrder;
+
 /// An opaque identifier for a dataflow component. In other words, identifies
 /// the target of a [`MirRelationExpr::Get`](crate::MirRelationExpr::Get).
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
@@ -135,6 +137,15 @@ impl fmt::Display for SourceInstanceId {
 pub enum PartitionId {
     Kafka(i32),
     None,
+}
+
+impl PartialOrder for PartitionId {
+    fn less_equal(&self, other: &Self) -> bool {
+        match (self, other) {
+            (PartitionId::Kafka(s), PartitionId::Kafka(o)) => s <= o,
+            _ => false,
+        }
+    }
 }
 
 impl fmt::Display for PartitionId {

--- a/src/expr/src/id.rs
+++ b/src/expr/src/id.rs
@@ -133,7 +133,7 @@ impl fmt::Display for SourceInstanceId {
 /// Unique identifier for each part of a whole source.
 ///     Kafka -> partition
 ///     None -> sources that have no notion of partitioning (e.g file sources)
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub enum PartitionId {
     Kafka(i32),
     None,

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -123,7 +123,7 @@ askama_shared = { version = "0.11.1", features = ["config"] }
 cc = "1.0.69"
 flate2 = "1.0.20"
 hex = "0.4.3"
-hex-literal = "0.3.2"
+hex-literal = "0.3.3"
 reqwest = { version = "0.11.4", features = ["blocking"] }
 sha2 = "0.9.5"
 tar = "0.4.35"

--- a/test/bench/avro-insert/create_views/views/insert_views.sql
+++ b/test/bench/avro-insert/create_views/views/insert_views.sql
@@ -10,6 +10,7 @@
 CREATE SOURCE source_insertavrotest
 FROM KAFKA BROKER 'kafka:9092'
 TOPIC 'insertavrotest'
+WITH (topic_metadata_refresh_interval_ms = 10)
 FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://schema-registry:8081'
 ENVELOPE NONE;
 

--- a/test/bench/avro-upsert/create_views/views/insert_views.sql
+++ b/test/bench/avro-upsert/create_views/views/insert_views.sql
@@ -10,6 +10,7 @@
 CREATE SOURCE source_insertavrotest
 FROM KAFKA BROKER 'kafka:9092'
 TOPIC 'upsertavrotest'
+WITH (topic_metadata_refresh_interval_ms = 10)
 FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://schema-registry:8081'
 ENVELOPE NONE;
 

--- a/test/bench/avro-upsert/create_views/views/upsert_views.sql
+++ b/test/bench/avro-upsert/create_views/views/upsert_views.sql
@@ -10,6 +10,7 @@
 CREATE SOURCE source_upsertavrotest
 FROM KAFKA BROKER 'kafka:9092'
 TOPIC 'upsertavrotest'
+WITH (topic_metadata_refresh_interval_ms = 10)
 FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://schema-registry:8081'
 ENVELOPE UPSERT
 FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://schema-registry:8081';

--- a/test/bench/kafka-sink-avro-debezium/create_sink/sinks/no-consistency-no-exactly-once-sink.sql
+++ b/test/bench/kafka-sink-avro-debezium/create_sink/sinks/no-consistency-no-exactly-once-sink.sql
@@ -10,6 +10,7 @@
 CREATE SOURCE append_source
 FROM KAFKA BROKER 'kafka:9092'
 TOPIC 'plain_avro_records'
+WITH (topic_metadata_refresh_interval_ms = 10)
 FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://schema-registry:8081'
 ENVELOPE NONE;
 


### PR DESCRIPTION
This is the result of the last couple of Skunkworks Fridays. I'm now at a stage where I'm happy with the result and it's presentable. I could work more on it if we want to merge this (or something like it), but I could also move on to other things.

The end result is a simplification/refactoring of the timestamping code, along with a clear description (in the form of Traits) of the requirements and the contract between source implementations and the framework.Also: I think this is a form of implementation of reclocking.

This doesn't pass CI, but it's possible to run the `avro-upsert` benchmark. I believe the only reason we don't pass is because timestamping now doesn't work for sources other than Kafka.

_I don't want to steal the thunder from Petros's Source Trait work. This lead to a `ProtoSource` trait in the end, but I came to it from a different motivation/direction and I think it's somewhat orthogonal. :sweat_smile:_

## Motivation
 - move real-time timestamping from `dataflow` to coord
 - make `dataflow` as "dumb" as possible when it comes to timestamps
 - no back-and-forth between `dataflow` and `coord` for determining durable timestamp bindings

## Implementation

The salient results/features are:
 - Sources are now generic over the type of timestamp that they attach to data. We used to hard-code a combination of `PartitionId` and `MzOffset` as the de-facto source timestamp. Now this is generic.
 - Source must be able to report the _frontier of available data_ and available partitions. The `coordinator` uses those to mint bindings and send them to the `dataflow` layer.
 - The `dataflow` layer listens to bindings and holds data back until it has a binding. It never mints bindings itself. The `dataflow` layer doesn't know about real-time timestamping or BYO.
 - The `SourceReader` must be able to present a _read frontier_. The framework uses this to determine when to close real-time timestamps.
 - *No more durability frontier*. We tracked this separately from the "regular" frontier and sinks waited on it before emitting.

### New Traits

`ProtoSource` is what pulls the thing together. `SourceReader` is used by the `dataflow` layer. The discoverers are used only in `coord`, which will send bindings and available partitions to `dataflow`.

```rust
pub trait ProtoSource {
    type SourceTimestamp;
    type Partition;
    type FrontierDiscoverer: SourceFrontierDiscoverer<SourceTimestamp = Self::SourceTimestamp>;
    type PartitionDiscoverer: SourcePartitionDiscoverer<Partition = Self::Partition>;

    // For this to work, SourceReader needs to be in dataflow-types, which is
    // the common package that both dataflow and coord have as dependency.
    //
    // Actual source implementations would only depend on dataflow-types and
    // live in their own sources package.

    // type SourceReader: SourceReader<SourceTimestamp = Self::SourceTimestamp>;

    /// Creates a [`SourceFrontierDiscoverer`] for this source.
    fn create_frontier_discoverer(&self) -> Self::FrontierDiscoverer;

    /// Creates a [`SourcePartitionDiscoverer`] for this source.
    fn create_partition_discoverer(&self) -> Self::PartitionDiscoverer;

    // Creates a [`SourceReader`] for this source.
    //
    // Doesn't work, see above.
    // fn create_source_reader(&self) -> Self::SourceReader;
}

/// This name is horrible and should maybe be `DiscoverSourceFrontier`, but `SourceReader` is also
/// called `SourceReader` and not `ReadSource`...
pub trait SourceFrontierDiscoverer {
    type SourceTimestamp;

    /// Returns the timestamp frontier of source data that is available for reading. Any data that
    /// becomes newly available in the future will be beyond this frontier.
    fn get_available_frontier(&self) -> Result<Antichain<Self::SourceTimestamp>, anyhow::Error>;

    /// Returns the [`GlobalId`] of this source.
    fn id(&self) -> GlobalId;

    /// Returns the preferred refresh interval. It possible, [`get_available_frontier`] will be
    /// called based on this.
    fn update_interval(&self) -> Duration;
}

/// This name is horrible and should maybe be `DiscoverSourcePartitions`, but `SourceReader` is also
/// called `SourceReader` anot not `ReadSource`...
pub trait SourcePartitionDiscoverer {
    type Partition;

    /// Returns the partitions that are available for this source.
    fn get_available_partitions(&self) -> Result<Vec<Self::Partition>, anyhow::Error>;
}
```
## Caveats
 - As mentioned above, it must be possible for sources to report a frontier of available data.
 - Data is only released into the dataflow layer once we have a bindings. If the frequency at which we mint new bindings is low, this will affect latency of new data showing up in results.

## "Experimental" Results

Naive benchmarks show that catch-up reads, i.e. reading a big, filled Kafka topic is about 4x faster with this new method of timestamping. Steady-state reading of a continuously growing topic has about the same performance/throughput.

## Future Work 
 - The traits are only implemented for Kafka so far.
 - The framework is not fully generic over the type of `SourceTimestamp`. We still use `PartitionOffset`, which is a combination of partition and offset, as before. The Traits are generic over this, though. And we could treat the `SourceTimestamp` as more of an opaque type but that requires some changes. For example, the timestamp persisting code (that persists to SQLite) assumes that we're persisting `(partition, offset)` bindings.
 - The `ProtoSource` trait is not really implemented because that's not possible with today's package structure. We would have to move `ProtoSource` to `dataflow-types` (which is a common dependency of `dataflow` and `coord`), then we could move source implementations to a separate `sources` package that only depends on `dataflow-types`. Both `coord` and `dataflow` can then depend on the sources. *But:* This would allow us to keep the implementation of a specific source in one place. Right now the code for source is spread across the `dataflow` and `coord` packages.
 - The timestamp assignment code is pretty naive, just iterating over bindings and taking the first one that "covers" the source timestamp.