### PR TITLE
persist: support per-stream key Codec and val Codec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3430,6 +3430,7 @@ dependencies = [
  "num-traits",
  "ordered-float",
  "ore",
+ "persist",
  "proptest",
  "rand",
  "regex",

--- a/src/coord/src/persistcfg.rs
+++ b/src/coord/src/persistcfg.rs
@@ -14,6 +14,7 @@ use std::path::PathBuf;
 use anyhow::anyhow;
 use persist::error::Error;
 use persist::indexed::encoding::Id;
+use repr::Row;
 use serde::Serialize;
 
 use expr::GlobalId;
@@ -74,7 +75,7 @@ impl PersistConfig {
 #[derive(Debug, Clone)]
 pub struct PersisterWithConfig {
     pub config: PersistConfig,
-    pub persister: Option<RuntimeClient<Vec<u8>, ()>>,
+    pub persister: Option<RuntimeClient>,
 }
 
 impl PersisterWithConfig {
@@ -115,11 +116,11 @@ impl PersisterWithConfig {
 pub struct PersistDetails {
     pub stream_name: String,
     #[serde(skip)]
-    pub write_handle: StreamWriteHandle<Vec<u8>, ()>,
+    pub write_handle: StreamWriteHandle<Row, ()>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PersistMultiDetails {
     pub all_table_ids: Vec<Id>,
-    pub write_handle: MultiWriteHandle<Vec<u8>, ()>,
+    pub write_handle: MultiWriteHandle<Row, ()>,
 }

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -161,7 +161,7 @@ pub struct RenderState {
     /// Metrics reported by all dataflows.
     pub metrics: Metrics,
     /// Handle to the persistence runtime. None if disabled.
-    pub persist: Option<RuntimeClient<Vec<u8>, ()>>,
+    pub persist: Option<RuntimeClient>,
     /// Shared buffer with TAIL operator instances by which they can respond.
     ///
     /// The entries are pairs of sink identifier (to identify the tail instance)

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -110,10 +110,7 @@ where
                             }
                         };
                         let (persist_ok_stream, decode_err_stream) =
-                            persist_ok_stream.ok_err(|((row, ()), ts, diff)| {
-                                let row = Row::decode(&row).map_err(|err| (err, ts, diff))?;
-                                Ok((row, ts, diff))
-                            });
+                            persist_ok_stream.ok_err(|((row, ()), ts, diff)| Ok((row, ts, diff)));
                         let persist_err_collection = persist_err_stream
                             .concat(&decode_err_stream)
                             .map(move |(err, ts, diff)| {

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -220,7 +220,7 @@ pub struct Config {
     /// Metrics registry through which dataflow metrics will be reported.
     pub metrics_registry: MetricsRegistry,
     /// Handle to the persistence runtime. None if disabled.
-    pub persist: Option<RuntimeClient<Vec<u8>, ()>>,
+    pub persist: Option<RuntimeClient>,
     /// Responses to commands should be sent into this channel.
     pub feedback_tx: mpsc::UnboundedSender<Response>,
 }

--- a/src/persist/benches/snapshot.rs
+++ b/src/persist/benches/snapshot.rs
@@ -19,10 +19,10 @@ use persist::mem::{MemBlob, MemBuffer};
 use persist::storage::{Blob, Buffer};
 
 fn read_full_snapshot<U: Buffer, L: Blob>(
-    index: &Indexed<String, String, U, L>,
+    index: &Indexed<U, L>,
     id: Id,
     expected_len: usize,
-) -> Vec<((String, String), u64, isize)> {
+) -> Vec<((Vec<u8>, Vec<u8>), u64, isize)> {
     let mut buf = Vec::with_capacity(expected_len);
     let mut snapshot = index.snapshot(id).expect("reading snapshot cannot fail");
 
@@ -33,7 +33,7 @@ fn read_full_snapshot<U: Buffer, L: Blob>(
 }
 
 fn bench_snapshot<U: Buffer, L: Blob>(
-    index: &Indexed<String, String, U, L>,
+    index: &Indexed<U, L>,
     id: Id,
     expected_len: usize,
     b: &mut Bencher,
@@ -45,15 +45,21 @@ fn bench_indexed_snapshots<U, L, F>(c: &mut Criterion, name: &str, mut new_fn: F
 where
     U: Buffer,
     L: Blob,
-    F: FnMut(usize) -> Result<Indexed<String, String, U, L>, Error>,
+    F: FnMut(usize) -> Result<Indexed<U, L>, Error>,
 {
     let data_len = 100_000;
     let data: Vec<_> = (0..data_len)
-        .map(|i| ((format!("key{}", i), format!("val{}", i)), i as u64, 1))
+        .map(|i| {
+            (
+                (format!("key{}", i).into(), format!("val{}", i).into()),
+                i as u64,
+                1,
+            )
+        })
         .collect();
 
     let mut i = new_fn(1).expect("creating index cannot fail");
-    let id = i.register("0").expect("registration succeeds");
+    let id = i.register("0", "", "").expect("registration succeeds");
 
     // Write the data out to the index's buffer.
     i.write_sync(vec![(id, data)])

--- a/src/persist/src/codec_impls.rs
+++ b/src/persist/src/codec_impls.rs
@@ -1,0 +1,69 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Implementations of [Codec] for stdlib types.
+
+use crate::Codec;
+
+impl Codec for () {
+    fn codec_name() -> &'static str {
+        "()"
+    }
+
+    fn size_hint(&self) -> usize {
+        0
+    }
+
+    fn encode<E: for<'a> Extend<&'a u8>>(&self, _buf: &mut E) {
+        // No-op.
+    }
+
+    fn decode<'a>(buf: &'a [u8]) -> Result<Self, String> {
+        if !buf.is_empty() {
+            return Err(format!("decode expected empty buf got {} bytes", buf.len()));
+        }
+        Ok(())
+    }
+}
+
+impl Codec for String {
+    fn codec_name() -> &'static str {
+        "String"
+    }
+
+    fn size_hint(&self) -> usize {
+        self.as_bytes().len()
+    }
+
+    fn encode<E: for<'a> Extend<&'a u8>>(&self, buf: &mut E) {
+        buf.extend(self.as_bytes())
+    }
+
+    fn decode<'a>(buf: &'a [u8]) -> Result<Self, String> {
+        String::from_utf8(buf.to_owned()).map_err(|err| err.to_string())
+    }
+}
+
+impl Codec for Vec<u8> {
+    fn codec_name() -> &'static str {
+        "Vec<u8>"
+    }
+
+    fn size_hint(&self) -> usize {
+        self.len()
+    }
+
+    fn encode<E: for<'a> Extend<&'a u8>>(&self, buf: &mut E) {
+        buf.extend(self)
+    }
+
+    fn decode<'a>(buf: &'a [u8]) -> Result<Self, String> {
+        Ok(buf.to_owned())
+    }
+}

--- a/src/persist/src/indexed/cache.rs
+++ b/src/persist/src/indexed/cache.rs
@@ -17,7 +17,6 @@ use abomonation::abomonated::Abomonated;
 use crate::error::Error;
 use crate::indexed::encoding::{BlobFutureBatch, BlobMeta, BlobTraceBatch};
 use crate::storage::Blob;
-use crate::Data;
 
 /// A disk-backed cache for objects in [Blob] storage.
 ///
@@ -32,14 +31,14 @@ use crate::Data;
 /// unpredictable. I think we probably want a soft limit and a hard limit where
 /// the soft limit does some alerting and the hard limit starts blocking (or
 /// erroring) until disk space frees up.
-pub struct BlobCache<K, V, L: Blob> {
+pub struct BlobCache<L: Blob> {
     blob: Arc<Mutex<L>>,
     // TODO: Use a disk-backed LRU cache.
-    future: Arc<Mutex<HashMap<String, Arc<BlobFutureBatch<K, V>>>>>,
-    trace: Arc<Mutex<HashMap<String, Arc<BlobTraceBatch<K, V>>>>>,
+    future: Arc<Mutex<HashMap<String, Arc<BlobFutureBatch>>>>,
+    trace: Arc<Mutex<HashMap<String, Arc<BlobTraceBatch>>>>,
 }
 
-impl<K, V, L: Blob> Clone for BlobCache<K, V, L> {
+impl<L: Blob> Clone for BlobCache<L> {
     fn clone(&self) -> Self {
         BlobCache {
             blob: self.blob.clone(),
@@ -49,7 +48,7 @@ impl<K, V, L: Blob> Clone for BlobCache<K, V, L> {
     }
 }
 
-impl<K: Data, V: Data, L: Blob> BlobCache<K, V, L> {
+impl<L: Blob> BlobCache<L> {
     const META_KEY: &'static str = "META";
 
     /// Returns a new, empty cache for the given [Blob] storage.
@@ -72,7 +71,7 @@ impl<K: Data, V: Data, L: Blob> BlobCache<K, V, L> {
 
     /// Returns the batch for the given key, blocking to fetch if it's not
     /// already in the cache.
-    pub fn get_future_batch(&self, key: &str) -> Result<Arc<BlobFutureBatch<K, V>>, Error> {
+    pub fn get_future_batch(&self, key: &str) -> Result<Arc<BlobFutureBatch>, Error> {
         {
             // New scope to ensure the cache lock is dropped during the
             // (expensive) get.
@@ -86,9 +85,8 @@ impl<K: Data, V: Data, L: Blob> BlobCache<K, V, L> {
             .lock()?
             .get(key)?
             .ok_or_else(|| Error::from(format!("no blob for key: {}", key)))?;
-        let batch: Abomonated<BlobFutureBatch<K, V>, Vec<u8>> =
-            unsafe { Abomonated::new(bytes) }
-                .ok_or_else(|| Error::from(format!("invalid batch at key: {}", key)))?;
+        let batch: Abomonated<BlobFutureBatch, Vec<u8>> = unsafe { Abomonated::new(bytes) }
+            .ok_or_else(|| Error::from(format!("invalid batch at key: {}", key)))?;
 
         // NB: Batch blobs are write-once, so we're not worried about the race
         // of two get calls for the same key.
@@ -101,11 +99,7 @@ impl<K: Data, V: Data, L: Blob> BlobCache<K, V, L> {
     }
 
     /// Writes a batch to backing [Blob] storage.
-    pub fn set_future_batch(
-        &mut self,
-        key: String,
-        batch: BlobFutureBatch<K, V>,
-    ) -> Result<(), Error> {
+    pub fn set_future_batch(&mut self, key: String, batch: BlobFutureBatch) -> Result<(), Error> {
         if key == Self::META_KEY {
             return Err(format!("cannot write trace batch to meta key: {}", Self::META_KEY).into());
         }
@@ -120,7 +114,7 @@ impl<K: Data, V: Data, L: Blob> BlobCache<K, V, L> {
 
     /// Returns the batch for the given key, blocking to fetch if it's not
     /// already in the cache.
-    pub fn get_trace_batch(&self, key: &str) -> Result<Arc<BlobTraceBatch<K, V>>, Error> {
+    pub fn get_trace_batch(&self, key: &str) -> Result<Arc<BlobTraceBatch>, Error> {
         {
             // New scope to ensure the cache lock is dropped during the
             // (expensive) get.
@@ -134,7 +128,7 @@ impl<K: Data, V: Data, L: Blob> BlobCache<K, V, L> {
             .lock()?
             .get(key)?
             .ok_or_else(|| Error::from(format!("no blob for key: {}", key)))?;
-        let batch: Abomonated<BlobTraceBatch<K, V>, Vec<u8>> = unsafe { Abomonated::new(bytes) }
+        let batch: Abomonated<BlobTraceBatch, Vec<u8>> = unsafe { Abomonated::new(bytes) }
             .ok_or_else(|| Error::from(format!("invalid batch at key: {}", key)))?;
 
         // NB: Batch blobs are write-once, so we're not worried about the race
@@ -148,11 +142,7 @@ impl<K: Data, V: Data, L: Blob> BlobCache<K, V, L> {
     }
 
     /// Writes a batch to backing [Blob] storage.
-    pub fn set_trace_batch(
-        &mut self,
-        key: String,
-        batch: BlobTraceBatch<K, V>,
-    ) -> Result<(), Error> {
+    pub fn set_trace_batch(&mut self, key: String, batch: BlobTraceBatch) -> Result<(), Error> {
         if key == Self::META_KEY {
             return Err(format!("cannot write trace batch to meta key: {}", Self::META_KEY).into());
         }

--- a/src/persist/src/lib.rs
+++ b/src/persist/src/lib.rs
@@ -18,8 +18,7 @@
 
 use std::fmt;
 
-use abomonation::Abomonation;
-
+pub mod codec_impls;
 pub mod error;
 pub mod file;
 pub mod indexed;
@@ -60,7 +59,36 @@ pub mod unreliable;
 // - Equality edge cases around all the various timestamp/frontier checks.
 
 /// A type usable as a persisted key or value.
-///
-/// TODO: Replace Abomonation with something like an Encode+Decode trait.
-pub trait Data: Clone + Abomonation + fmt::Debug + Ord {}
-impl<T: Clone + Abomonation + fmt::Debug + Ord> Data for T {}
+pub trait Data: Clone + Codec + fmt::Debug + Ord {}
+impl<T: Clone + Codec + fmt::Debug + Ord> Data for T {}
+
+/// Encoding and decoding operations for a type usable as a persisted key or
+/// value.
+pub trait Codec: Sized + 'static {
+    /// Name of the codec.
+    ///
+    /// This name is stored for the key and value when a stream is first created
+    /// and the same key and value codec must be used for that stream afterward.
+    fn codec_name() -> &'static str;
+    /// A hint of the encoded size of self.
+    fn size_hint(&self) -> usize;
+    /// Encode a key or value for permanent storage.
+    ///
+    /// This must perfectly round-trip Self through [Codec::decode]. If the
+    /// encode function for this codec ever changes, decode must be able to
+    /// handle bytes output by all previous versions of encode.
+    fn encode<E: for<'a> Extend<&'a u8>>(&self, buf: &mut E);
+    /// Decode a key or value previous encoded with this codec's
+    /// [Codec::encode].
+    ///
+    /// This must perfectly round-trip Self through [Codec::encode]. If the
+    /// encode function for this codec ever changes, decode must be able to
+    /// handle bytes output by all previous versions of encode.
+    ///
+    /// It should also gracefully handle data encoded by future versions of
+    /// encode (likely with an error).
+    //
+    // TODO: Mechanically, this could return a ref to the original bytes
+    // without any copies, see if we can make the types work out for that.
+    fn decode<'a>(buf: &'a [u8]) -> Result<Self, String>;
+}

--- a/src/persist/src/mem.rs
+++ b/src/persist/src/mem.rs
@@ -19,7 +19,6 @@ use crate::error::Error;
 use crate::indexed::runtime::{self, RuntimeClient};
 use crate::storage::{Blob, Buffer, SeqNo};
 use crate::unreliable::{UnreliableBlob, UnreliableBuffer, UnreliableHandle};
-use crate::Data;
 
 struct MemBufferCore {
     seqno: Range<SeqNo>,
@@ -291,27 +290,19 @@ impl MemRegistry {
     }
 
     /// Open a [RuntimeClient] associated with `path`.
-    pub fn open<K, V>(&mut self, path: &str, lock_info: &str) -> Result<RuntimeClient<K, V>, Error>
-    where
-        K: Data + Send + Sync + 'static,
-        V: Data + Send + Sync + 'static,
-    {
+    pub fn open(&mut self, path: &str, lock_info: &str) -> Result<RuntimeClient, Error> {
         let buffer = self.buffer(path, lock_info)?;
         let blob = self.blob(path, lock_info)?;
         runtime::start(buffer, blob)
     }
 
     /// Open a [RuntimeClient] with unreliable storage associated with `path`.
-    pub fn open_unreliable<K, V>(
+    pub fn open_unreliable(
         &mut self,
         path: &str,
         lock_info: &str,
         unreliable: UnreliableHandle,
-    ) -> Result<RuntimeClient<K, V>, Error>
-    where
-        K: Data + Send + Sync + 'static,
-        V: Data + Send + Sync + 'static,
-    {
+    ) -> Result<RuntimeClient, Error> {
         let buffer = self.buffer(path, lock_info)?;
         let buffer = UnreliableBuffer::from_handle(buffer, unreliable.clone());
         let blob = self.blob(path, lock_info)?;

--- a/src/persist/src/operators/mod.rs
+++ b/src/persist/src/operators/mod.rs
@@ -13,16 +13,17 @@
 use timely::dataflow::operators::generic::operator;
 use timely::dataflow::operators::ToStream;
 use timely::dataflow::{Scope, Stream};
-use timely::Data;
+use timely::Data as TimelyData;
 
 use crate::indexed::runtime::StreamReadHandle;
 use crate::indexed::Snapshot;
+use crate::Codec;
 
 pub mod input;
 pub mod source;
 pub mod stream;
 
-fn replay<G: Scope<Timestamp = u64>, K: Data, V: Data>(
+fn replay<G: Scope<Timestamp = u64>, K: TimelyData + Codec, V: TimelyData + Codec>(
     scope: &mut G,
     read: &StreamReadHandle<K, V>,
 ) -> (
@@ -34,19 +35,40 @@ fn replay<G: Scope<Timestamp = u64>, K: Data, V: Data>(
     // shard up the responsibility between all the workers.
     if scope.index() == 0 {
         // TODO: Do this with a timely operator that reads the snapshot.
-        let (mut buf, mut errors) = (Vec::new(), Vec::new());
+        let (mut buf, mut ok, mut errors) = (Vec::new(), Vec::new(), Vec::new());
         match read.snapshot() {
-            Ok(mut snap) => while snap.read(&mut buf) {},
+            Ok(mut snap) => {
+                while snap.read(&mut buf) {
+                    for update in buf.drain(..) {
+                        match flatten_decoded_update(update) {
+                            Ok(u) => ok.push(u),
+                            Err(errs) => errors.extend(errs),
+                        }
+                    }
+                }
+            }
             Err(err) => {
                 // TODO: Figure out how to make these retractable.
                 let err_str = format!("replaying persisted data: {}", err);
                 errors.push((err_str, 0u64, 1isize));
             }
         }
-        let ok_previous = buf.into_iter().to_stream(scope);
+        let ok_previous = ok.into_iter().to_stream(scope);
         let err_previous = errors.into_iter().to_stream(scope);
         (ok_previous, err_previous)
     } else {
         (operator::empty(scope), operator::empty(scope))
+    }
+}
+
+fn flatten_decoded_update<K, V>(
+    update: ((Result<K, String>, Result<V, String>), u64, isize),
+) -> Result<((K, V), u64, isize), Vec<(String, u64, isize)>> {
+    let ((k, v), ts, diff) = update;
+    match (k, v) {
+        (Ok(k), Ok(v)) => Ok(((k, v), ts, diff)),
+        (Err(k_err), Ok(_)) => Err(vec![(k_err, ts, diff)]),
+        (Ok(_), Err(v_err)) => Err(vec![(v_err, ts, diff)]),
+        (Err(k_err), Err(v_err)) => Err(vec![(k_err, ts, diff), (v_err, ts, diff)]),
     }
 }

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -28,6 +28,7 @@ lowertest = { path = "../lowertest"}
 num-traits = "0.2.14"
 ordered-float = { version = "2.7.0", features = ["serde"] }
 ore = { path = "../ore", features = ["bytes"] }
+persist = { path = "../persist" }
 regex = "1.5.4"
 ryu = "1.0.5"
 serde = { version = "1.0.127", features = ["derive"] }

--- a/src/repr/src/row/encoding.rs
+++ b/src/repr/src/row/encoding.rs
@@ -51,19 +51,28 @@
 use std::io::Read;
 
 use ore::cast::CastFrom;
+use persist::Codec;
 
 use crate::Row;
 
-impl Row {
-    const CURRENT_VERSION: u8 = 0u8;
+const CURRENT_VERSION: u8 = 0u8;
+
+impl Codec for Row {
+    fn codec_name() -> &'static str {
+        "RowExperimental"
+    }
+
+    fn size_hint(&self) -> usize {
+        1 + 8 + self.data.len()
+    }
 
     /// Encodes a row into the permanent storage format.
     ///
     /// This perfectly round-trips through [Row::decode]. It's guaranteed to be
     /// readable by future versions of Materialize through v(TODO: Figure out
     /// our policy).
-    pub fn encode<E: for<'a> Extend<&'a u8>>(&self, buf: &mut E) {
-        buf.extend(&[Self::CURRENT_VERSION]);
+    fn encode<E: for<'a> Extend<&'a u8>>(&self, buf: &mut E) {
+        buf.extend(&[CURRENT_VERSION]);
         // TODO: Storing the length here will be pretty wasteful. Revisit.
         let len: u64 = u64::cast_from(self.data.len());
         buf.extend(&len.to_le_bytes());
@@ -77,7 +86,7 @@ impl Row {
     /// our policy).
     //
     // TODO: Return a RowRef instead?
-    pub fn decode(buf: &[u8]) -> Result<Row, String> {
+    fn decode(buf: &[u8]) -> Result<Row, String> {
         let mut buf = buf;
 
         let mut version_raw = [0u8; 1];
@@ -86,7 +95,7 @@ impl Row {
         // Only one version supported at the moment. This will get more
         // complicated once we change the format and have to migrate old formats
         // to the current one.
-        if version_raw[0] != Self::CURRENT_VERSION {
+        if version_raw[0] != CURRENT_VERSION {
             return Err("unknown version".into());
         }
 
@@ -110,6 +119,8 @@ impl Row {
 
 #[cfg(test)]
 mod tests {
+    use persist::Codec;
+
     use crate::{Datum, Row};
 
     // TODO: datadriven golden tests for various interesting Datums and Rows to


### PR DESCRIPTION
Benefits:
- A timely stream of mz's Row can now be used directly.
- In the future, we can special-case val=() like differential dataflow's
  Trace does.
- RuntimeClient is no longer parameterized with <K, V>, which was always
  weird.
- Encoding happens before sending anything to RuntimeClient. This means
  it happens in the caller's thread instead of the runtime one.
- Decoding a snapshot happens after being received from RuntimeClient.
  This means it also happens in the caller's thread. (Decoding a
  ListenFn still happens in the wrong place, but I think we anyway need
  to make Listen based on channels or std::future::Streams instead of
  the current callbacks.)
- The encoding of BufferEntry, BlobFutureBatch, and BlobTraceBatch is
  now simpler.