### PR TITLE
testdrive: Fix the parsing of "? EXPLAIN" actions

### DIFF
--- a/doc/developer/testdrive.md
+++ b/doc/developer/testdrive.md
@@ -328,6 +328,23 @@ Note that you can provide a string that is a substring of the expected error. Th
 
 By default, `testdrive` will run all `>` and `!` statements in a single connection. A limited form of multiple connections is provided by the `$ postgres-connect` action. See the "Connecting to databases over the pgwire protocol" section below.
 
+## Executing an `EXPLAIN` statement
+
+Since the output of `EXPLAIN` is a multi-line string, a separate `? EXPLAIN` action is provided:
+
+```
+$ set-regex match=u\d+ replacement=UID
+
+? EXPLAIN SELECT * FROM t1 AS a1, t1 AS a2 WHERE a1.f1 IS NOT NULL;
+%0 =
+| Get materialize.public.t1 (UID)
+| Filter !(isnull(#0))
+| ArrangeBy ()
+...
+```
+
+As the `EXPLAIN` output contains parts that change between invocations, a `$ set-regex` is required to produce a stable test.
+
 # Using Variables
 
 > :warning: **all testdrive variables are initialized to their ultimate value at the start of the test**

--- a/src/testdrive/src/parser.rs
+++ b/src/testdrive/src/parser.rs
@@ -197,8 +197,9 @@ fn parse_explain_sql(line_reader: &mut LineReader) -> Result<SqlCommand, InputEr
     // need directly, but that would require a large refactor.
     let mut expected_output: String = line_reader
         .inner
-        .chars()
-        .take_while(|c| !is_sigil(Some(*c)))
+        .lines()
+        .take_while(|l| !is_sigil(l.chars().next()))
+        .map(|l| format!("{}\n", l))
         .collect();
     slurp_all(line_reader);
     while expected_output.ends_with("\n\n") {

--- a/test/testdrive/testdrive.td
+++ b/test/testdrive/testdrive.td
@@ -43,9 +43,10 @@ row 2
 
 $ set-regex match=u\d+ replacement=UID
 
-? EXPLAIN SELECT * FROM t1, t1;
+? EXPLAIN SELECT * FROM t1 AS a1, t1 AS a2 WHERE a1.f1 IS NOT NULL;
 %0 =
 | Get materialize.public.t1 (UID)
+| Filter !(isnull(#0))
 | ArrangeBy ()
 
 %1 =


### PR DESCRIPTION
Previously, the ? EXPLAIN action would become confused by the
presence of a "!" on a Filter line, as "!" is considered
a special character in testdrive.

To avoid this, parse the ? EXPLAIN section of the .td file in
lines rather than characters and terminate only if the first
character of the line is a special character.

Add ? EXPLAIN to the documentation.