### PR TITLE
(docs) Add "Sinks" to "Connect" in the sidebar

### DIFF
--- a/doc/user/config.toml
+++ b/doc/user/config.toml
@@ -58,6 +58,12 @@ url = "/sql/create-source"
 weight= 2
 
 [[menu.main]]
+name = "Sinks"
+parent = "connections"
+url = "/sql/create-sink"
+weight= 3
+
+[[menu.main]]
 identifier = "sql"
 name = "SQL"
 weight = 70

--- a/doc/user/content/connect/materialize-cdc.md
+++ b/doc/user/content/connect/materialize-cdc.md
@@ -4,7 +4,7 @@ description: "The Materialize CDC format is a format for change datafeeds that h
 menu:
   main:
     parent: "connections"
-    weight: 3
+    weight: 4
 ---
 
 Change data capture (CDC) tools provide feeds that record any changes to a database. Typically, the feeds are then saved to another platform, like Kafka, for storage or processing. However, sometimes the stream can have missing or duplicate records, or records can be received out of order. For example, if a CDC tool crashes while writing a record, it may retry and write the record again, resulting in a duplicate entry.

--- a/doc/user/content/sql/create-sink.md
+++ b/doc/user/content/sql/create-sink.md
@@ -2,6 +2,8 @@
 title: "CREATE SINK"
 description: "`CREATE SINK` sends data from Materialize to an external sink."
 menu:
+  # This should also have a "non-content entry" under Connect, which is
+  # configured in doc/user/config.toml
   main:
     parent: 'sql'
 ---


### PR DESCRIPTION
The sidebar only lists sources under "Connect". This PR adds a "non-content entry" also for the sink docs.

<img width="275" alt="Screenshot 2021-08-03 at 13 43 48" src="https://user-images.githubusercontent.com/23521087/128009888-15691a6b-8bda-4e1b-a8d1-199d92dca39d.png">
