### PR TITLE
kafka-matrix: fix mzcompose.yml to accommodate latest Kafka

### DIFF
--- a/test/kafka-matrix/mzcompose.yml
+++ b/test/kafka-matrix/mzcompose.yml
@@ -159,6 +159,8 @@ services:
       - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092
       - KAFKA_AUTO_CREATE_TOPICS_ENABLE=false
       - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+      - KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=1
+      - KAFKA_TRANSACTION_STATE_LOG_MIN_ISR=1
   schema-registry:
     image: confluentinc/cp-schema-registry:$KAFKA_VERSION
     environment:


### PR DESCRIPTION
Kafka has introduced two new settings that affect the
__transaction_state topic. In order for the testdrive tests
to be able to run against a single-node kafka cluster,
we need to set the following two environment variables:
 KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=1
 KAFKA_TRANSACTION_STATE_LOG_MIN_ISR=1

----

@benesch this is yet another example that service startup needs to be centralized in a single .py file. I am fixing the `kafka-matrix/mzcompose.yml` file, but if we switch all of our other kafka-using tests, all of their `mzcompose.yml` files will need to be patched as well.