### PR TITLE
Rebrand SequencedCommand and WorkerFeedbackWithMeta

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -71,7 +71,8 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 
 use build_info::BuildInfo;
 use dataflow::{
-    SequencedCommand, TimestampBindingFeedback, WorkerFeedback, WorkerFeedbackWithMeta,
+    Command as DataflowCommand, Response as DataflowResponse, TimestampBindingFeedback,
+    WorkerFeedback,
 };
 use dataflow_types::logging::LoggingConfig as DataflowLoggingConfig;
 use dataflow_types::{
@@ -131,7 +132,7 @@ mod prometheus;
 #[derive(Debug)]
 pub enum Message {
     Command(Command),
-    Worker(WorkerFeedbackWithMeta),
+    Worker(DataflowResponse),
     AdvanceSourceTimestamp(AdvanceSourceTimestamp),
     StatementReady(StatementReady),
     SinkConnectorReady(SinkConnectorReady),
@@ -200,7 +201,7 @@ pub struct Config<'a> {
 /// Glues the external world to the Timely workers.
 pub struct Coordinator {
     worker_guards: WorkerGuards<()>,
-    worker_txs: Vec<crossbeam_channel::Sender<SequencedCommand>>,
+    worker_txs: Vec<crossbeam_channel::Sender<DataflowCommand>>,
     /// Optimizer instance for logical optimization of views.
     view_optimizer: Optimizer,
     catalog: Catalog,
@@ -382,7 +383,7 @@ impl Coordinator {
                     if BUILTINS.logs().any(|log| log.index_id == entry.id()) {
                         // Indexes on logging views are special, as they are
                         // already installed in the dataflow plane via
-                        // `SequencedCommand::EnableLogging`. Just teach the
+                        // `dataflow::Command::EnableLogging`. Just teach the
                         // coordinator of their existence, without creating a
                         // dataflow for the index.
                         //
@@ -492,7 +493,7 @@ impl Coordinator {
         mut self,
         internal_cmd_rx: mpsc::UnboundedReceiver<Message>,
         cmd_rx: mpsc::UnboundedReceiver<Command>,
-        feedback_rx: mpsc::UnboundedReceiver<WorkerFeedbackWithMeta>,
+        feedback_rx: mpsc::UnboundedReceiver<DataflowResponse>,
         _timestamper_thread_handle: JoinOnDropHandle<()>,
         _metric_thread_handle: Option<JoinOnDropHandle<()>>,
     ) {
@@ -565,7 +566,7 @@ impl Coordinator {
                 }
             }
 
-            self.broadcast(SequencedCommand::AdvanceAllLocalInputs {
+            self.broadcast(DataflowCommand::AdvanceAllLocalInputs {
                 advance_to: next_ts,
             });
             self.closed_up_to = next_ts;
@@ -574,10 +575,10 @@ impl Coordinator {
 
     fn message_worker(
         &mut self,
-        WorkerFeedbackWithMeta {
+        DataflowResponse {
             worker_id: _,
             message,
-        }: WorkerFeedbackWithMeta,
+        }: DataflowResponse,
     ) {
         match message {
             WorkerFeedback::PeekResponse(conn_id, response) => {
@@ -686,7 +687,7 @@ impl Coordinator {
 
                 // Announce the new frontiers that have been durably persisted.
                 if !durability_updates.is_empty() {
-                    self.broadcast(SequencedCommand::DurabilityFrontierUpdates(
+                    self.broadcast(DataflowCommand::DurabilityFrontierUpdates(
                         durability_updates,
                     ));
                 }
@@ -764,14 +765,14 @@ impl Coordinator {
             .as_ref()
             .map(|tx| tx.send(ScraperMessage::Shutdown).unwrap());
         self.ts_tx.send(TimestampMessage::Shutdown).unwrap();
-        self.broadcast(SequencedCommand::Shutdown);
+        self.broadcast(DataflowCommand::Shutdown);
     }
 
     fn message_advance_source_timestamp(
         &mut self,
         AdvanceSourceTimestamp { id, update }: AdvanceSourceTimestamp,
     ) {
-        self.broadcast(SequencedCommand::AdvanceSourceTimestamp { id, update });
+        self.broadcast(DataflowCommand::AdvanceSourceTimestamp { id, update });
     }
 
     fn message_command(&mut self, cmd: Command) {
@@ -1184,7 +1185,7 @@ impl Coordinator {
             .collect();
 
         if !since_updates.is_empty() {
-            self.broadcast(SequencedCommand::AllowCompaction(since_updates));
+            self.broadcast(DataflowCommand::AllowCompaction(since_updates));
         }
     }
 
@@ -1312,7 +1313,7 @@ impl Coordinator {
                 }
             }
             // Allow dataflow to cancel any pending peeks.
-            self.broadcast(SequencedCommand::CancelPeek { conn_id });
+            self.broadcast(DataflowCommand::CancelPeek { conn_id });
 
             // Inform the target session (if it asks) about the cancellation.
             let _ = conn_meta.cancel_tx.send(Cancelled::Cancelled);
@@ -2297,7 +2298,7 @@ impl Coordinator {
                         // Write all updates, both persistent and volatile.
                         // Persistence takes care of introducing anything it
                         // writes to the dataflow, so we only need a
-                        // SequencedCommand::Insert for the volatile updates.
+                        // Command::Insert for the volatile updates.
                         if !persist_updates.is_empty() {
                             if !volatile_updates.is_empty() {
                                 coord_bail!("transaction had mixed persistent and volatile writes");
@@ -2321,7 +2322,7 @@ impl Coordinator {
                             return Ok(Some(rx));
                         } else {
                             for (id, updates) in volatile_updates {
-                                self.broadcast(SequencedCommand::Insert { id, updates });
+                                self.broadcast(DataflowCommand::Insert { id, updates });
                             }
                         }
                     }
@@ -2563,7 +2564,7 @@ impl Coordinator {
             // Insert the pending peek, and initialize to expect the number of workers.
             self.pending_peeks
                 .insert(session.conn_id(), (rows_tx, self.num_workers()));
-            self.broadcast(SequencedCommand::Peek {
+            self.broadcast(DataflowCommand::Peek {
                 id: index_id,
                 key: literal_row,
                 conn_id: session.conn_id(),
@@ -3090,13 +3091,13 @@ impl Coordinator {
                 self.catalog.delete_timestamp_bindings(id)?;
                 self.sources.remove(&id);
             }
-            self.broadcast(SequencedCommand::DropSources(sources_to_drop));
+            self.broadcast(DataflowCommand::DropSources(sources_to_drop));
         }
         if !sinks_to_drop.is_empty() {
             for id in sinks_to_drop.iter() {
                 self.sink_writes.remove(id);
             }
-            self.broadcast(SequencedCommand::DropSinks(sinks_to_drop));
+            self.broadcast(DataflowCommand::DropSinks(sinks_to_drop));
         }
         if !indexes_to_drop.is_empty() {
             self.drop_indexes(indexes_to_drop);
@@ -3159,7 +3160,7 @@ impl Coordinator {
                         timestamp,
                     })
                     .collect();
-                self.broadcast(SequencedCommand::Insert { id, updates })
+                self.broadcast(DataflowCommand::Insert { id, updates })
             }
         }
     }
@@ -3170,7 +3171,7 @@ impl Coordinator {
 
     fn drop_sinks(&mut self, dataflow_names: Vec<GlobalId>) {
         if !dataflow_names.is_empty() {
-            self.broadcast(SequencedCommand::DropSinks(dataflow_names));
+            self.broadcast(DataflowCommand::DropSinks(dataflow_names));
         }
     }
 
@@ -3182,7 +3183,7 @@ impl Coordinator {
             }
         }
         if !trace_keys.is_empty() {
-            self.broadcast(SequencedCommand::DropIndexes(trace_keys))
+            self.broadcast(DataflowCommand::DropIndexes(trace_keys))
         }
     }
 
@@ -3350,10 +3351,10 @@ impl Coordinator {
         }
 
         // Finalize the dataflow by broadcasting its construction to all workers.
-        self.broadcast(SequencedCommand::CreateDataflows(dataflow_plans));
+        self.broadcast(DataflowCommand::CreateDataflows(dataflow_plans));
     }
 
-    fn broadcast(&self, cmd: SequencedCommand) {
+    fn broadcast(&self, cmd: DataflowCommand) {
         for tx in &self.worker_txs {
             tx.send(cmd.clone())
                 .expect("worker command receiver should not drop first")
@@ -3375,7 +3376,7 @@ impl Coordinator {
                     self.ts_tx
                         .send(TimestampMessage::Add(source_id, s.connector.clone()))
                         .expect("Failed to send CREATE Instance notice to timestamper");
-                    self.broadcast(SequencedCommand::AddSourceTimestamping {
+                    self.broadcast(DataflowCommand::AddSourceTimestamping {
                         id: source_id,
                         connector: s.connector.clone(),
                         bindings,
@@ -3386,7 +3387,7 @@ impl Coordinator {
             self.ts_tx
                 .send(TimestampMessage::Drop(source_id))
                 .expect("Failed to send DROP Instance notice to timestamper");
-            self.broadcast(SequencedCommand::DropSourceTimestamping { id: source_id });
+            self.broadcast(DataflowCommand::DropSourceTimestamping { id: source_id });
         }
     }
 
@@ -3609,7 +3610,7 @@ pub async fn serve(
                 pending_tails: HashMap::new(),
             };
             if let Some(config) = &logging {
-                coord.broadcast(SequencedCommand::EnableLogging(DataflowLoggingConfig {
+                coord.broadcast(DataflowCommand::EnableLogging(DataflowLoggingConfig {
                     granularity_ns: config.granularity.as_nanos(),
                     active_logs: BUILTINS
                         .logs()
@@ -3628,7 +3629,7 @@ pub async fn serve(
                 // Explicitly drop the timestamper handle here so we can wait for
                 // the thread to return.
                 drop(timestamper_thread_handle);
-                coord.broadcast(SequencedCommand::Shutdown);
+                coord.broadcast(DataflowCommand::Shutdown);
                 return;
             }
             handle.block_on(coord.serve(
@@ -3661,8 +3662,8 @@ pub fn serve_debug(
 ) -> (
     JoinOnDropHandle<()>,
     Client,
-    tokio::sync::mpsc::UnboundedSender<WorkerFeedbackWithMeta>,
-    tokio::sync::mpsc::UnboundedReceiver<WorkerFeedbackWithMeta>,
+    tokio::sync::mpsc::UnboundedSender<DataflowResponse>,
+    tokio::sync::mpsc::UnboundedReceiver<DataflowResponse>,
     Arc<Mutex<u64>>,
 ) {
     lazy_static! {

--- a/src/coordtest/src/lib.rs
+++ b/src/coordtest/src/lib.rs
@@ -61,7 +61,7 @@ use coord::{
     session::{EndTransactionAction, Session},
     Client, ExecuteResponse, SessionClient,
 };
-use dataflow::{Response as DataflowResponse, WorkerFeedback};
+use dataflow::WorkerFeedback;
 use dataflow_types::PeekResponse;
 use expr::GlobalId;
 use ore::thread::JoinOnDropHandle;
@@ -78,13 +78,13 @@ use timely::progress::change_batch::ChangeBatch;
 // The field order matters a lot here so the various threads/tasks are shut
 // down without ever panicing.
 pub struct CoordTest {
-    coord_feedback_tx: mpsc::UnboundedSender<DataflowResponse>,
+    coord_feedback_tx: mpsc::UnboundedSender<dataflow::Response>,
     client: Option<Client>,
     _handle: JoinOnDropHandle<()>,
-    dataflow_feedback_rx: mpsc::UnboundedReceiver<DataflowResponse>,
+    dataflow_feedback_rx: mpsc::UnboundedReceiver<dataflow::Response>,
     // Keep a queue of messages in the order received from dataflow_feedback_rx so
     // we can safely modify or inject things and maintain original message order.
-    queued_feedback: Vec<DataflowResponse>,
+    queued_feedback: Vec<dataflow::Response>,
     _catalog_file: NamedTempFile,
     temp_dir: TempDir,
     uppers: HashMap<GlobalId, Timestamp>,
@@ -164,7 +164,7 @@ impl CoordTest {
                 let mut requeue = uppers.clone();
                 requeue.retain(|(id, _data)| exclude_uppers.contains(id));
                 if !requeue.is_empty() {
-                    to_queue.push(DataflowResponse {
+                    to_queue.push(dataflow::Response {
                         worker_id: msg.worker_id,
                         message: WorkerFeedback::FrontierUppers(requeue),
                     });
@@ -367,7 +367,7 @@ pub async fn run_test(mut tf: datadriven::TestFile) -> datadriven::TestFile {
                         updates.push((id, batch));
                     }
                     ct.coord_feedback_tx
-                        .send(DataflowResponse {
+                        .send(dataflow::Response {
                             worker_id: 0,
                             message: WorkerFeedback::FrontierUppers(updates),
                         })

--- a/src/coordtest/src/lib.rs
+++ b/src/coordtest/src/lib.rs
@@ -61,7 +61,7 @@ use coord::{
     session::{EndTransactionAction, Session},
     Client, ExecuteResponse, SessionClient,
 };
-use dataflow::{WorkerFeedback, WorkerFeedbackWithMeta};
+use dataflow::{Response as DataflowResponse, WorkerFeedback};
 use dataflow_types::PeekResponse;
 use expr::GlobalId;
 use ore::thread::JoinOnDropHandle;
@@ -78,13 +78,13 @@ use timely::progress::change_batch::ChangeBatch;
 // The field order matters a lot here so the various threads/tasks are shut
 // down without ever panicing.
 pub struct CoordTest {
-    coord_feedback_tx: mpsc::UnboundedSender<WorkerFeedbackWithMeta>,
+    coord_feedback_tx: mpsc::UnboundedSender<DataflowResponse>,
     client: Option<Client>,
     _handle: JoinOnDropHandle<()>,
-    dataflow_feedback_rx: mpsc::UnboundedReceiver<WorkerFeedbackWithMeta>,
+    dataflow_feedback_rx: mpsc::UnboundedReceiver<DataflowResponse>,
     // Keep a queue of messages in the order received from dataflow_feedback_rx so
     // we can safely modify or inject things and maintain original message order.
-    queued_feedback: Vec<WorkerFeedbackWithMeta>,
+    queued_feedback: Vec<DataflowResponse>,
     _catalog_file: NamedTempFile,
     temp_dir: TempDir,
     uppers: HashMap<GlobalId, Timestamp>,
@@ -164,7 +164,7 @@ impl CoordTest {
                 let mut requeue = uppers.clone();
                 requeue.retain(|(id, _data)| exclude_uppers.contains(id));
                 if !requeue.is_empty() {
-                    to_queue.push(WorkerFeedbackWithMeta {
+                    to_queue.push(DataflowResponse {
                         worker_id: msg.worker_id,
                         message: WorkerFeedback::FrontierUppers(requeue),
                     });
@@ -367,7 +367,7 @@ pub async fn run_test(mut tf: datadriven::TestFile) -> datadriven::TestFile {
                         updates.push((id, batch));
                     }
                     ct.coord_feedback_tx
-                        .send(WorkerFeedbackWithMeta {
+                        .send(DataflowResponse {
                             worker_id: 0,
                             message: WorkerFeedback::FrontierUppers(updates),
                         })

--- a/src/dataflow/src/lib.rs
+++ b/src/dataflow/src/lib.rs
@@ -23,7 +23,4 @@ pub mod logging;
 pub mod source;
 
 pub use render::plan::Plan;
-pub use server::{
-    serve, Config, SequencedCommand, TimestampBindingFeedback, WorkerFeedback,
-    WorkerFeedbackWithMeta,
-};
+pub use server::{serve, Command, Config, Response, TimestampBindingFeedback, WorkerFeedback};

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -88,7 +88,7 @@ where
         // This has a lot of potential for improvement in the near future.
         match src.connector.clone() {
             // Create a new local input (exposed as TABLEs to users). Data is inserted
-            // via SequencedCommand::Insert commands.
+            // via Command::Insert commands.
             SourceConnector::Local { persisted_name, .. } => {
                 let ((handle, capability), ok_stream, err_collection) = {
                     let ((handle, capability), ok_stream) = scope.new_unordered_input();

--- a/src/dataflow/src/server/metrics.rs
+++ b/src/dataflow/src/server/metrics.rs
@@ -15,7 +15,7 @@ use ore::{
     metrics::{IntCounter, IntCounterVec, IntGauge, IntGaugeVec},
 };
 
-use super::{PendingPeek, SequencedCommand};
+use super::{Command, PendingPeek};
 
 #[derive(Clone)]
 pub(super) struct ServerMetrics {
@@ -74,7 +74,7 @@ pub(super) struct WorkerMetrics {
 }
 
 impl WorkerMetrics {
-    pub(super) fn observe_command_queue(&self, commands: &[SequencedCommand]) {
+    pub(super) fn observe_command_queue(&self, commands: &[Command]) {
         self.command_queue.set(commands.len() as i64);
     }
 
@@ -83,7 +83,7 @@ impl WorkerMetrics {
     }
 
     /// Observe that we have executed a command. Must be paired with [`WorkerMetrics::observe_command_finish`]
-    pub(super) fn observe_command(&mut self, command: &SequencedCommand) {
+    pub(super) fn observe_command(&mut self, command: &Command) {
         self.commands_processed.observe(command)
     }
 
@@ -186,31 +186,23 @@ impl CommandsProcessedMetrics {
         }
     }
 
-    fn observe(&mut self, command: &SequencedCommand) {
+    fn observe(&mut self, command: &Command) {
         match command {
-            SequencedCommand::CreateDataflows(..) => self.create_dataflows_int += 1,
-            SequencedCommand::DropSources(..) => self.drop_sources_int += 1,
-            SequencedCommand::DropSinks(..) => self.drop_sinks_int += 1,
-            SequencedCommand::DropIndexes(..) => self.drop_indexes_int += 1,
-            SequencedCommand::Peek { .. } => self.peek_int += 1,
-            SequencedCommand::CancelPeek { .. } => self.cancel_peek_int += 1,
-            SequencedCommand::Insert { .. } => self.insert_int += 1,
-            SequencedCommand::AllowCompaction(..) => self.allow_compaction_int += 1,
-            SequencedCommand::DurabilityFrontierUpdates(..) => {
-                self.durability_frontier_updates_int += 1
-            }
-            SequencedCommand::AddSourceTimestamping { .. } => self.add_source_timestamping_int += 1,
-            SequencedCommand::AdvanceSourceTimestamp { .. } => {
-                self.advance_source_timestamp_int += 1
-            }
-            SequencedCommand::DropSourceTimestamping { .. } => {
-                self.drop_source_timestamping_int += 1
-            }
-            SequencedCommand::EnableLogging(_) => self.enable_logging_int += 1,
-            SequencedCommand::Shutdown { .. } => self.shutdown_int += 1,
-            SequencedCommand::AdvanceAllLocalInputs { .. } => {
-                self.advance_all_local_inputs_int += 1
-            }
+            Command::CreateDataflows(..) => self.create_dataflows_int += 1,
+            Command::DropSources(..) => self.drop_sources_int += 1,
+            Command::DropSinks(..) => self.drop_sinks_int += 1,
+            Command::DropIndexes(..) => self.drop_indexes_int += 1,
+            Command::Peek { .. } => self.peek_int += 1,
+            Command::CancelPeek { .. } => self.cancel_peek_int += 1,
+            Command::Insert { .. } => self.insert_int += 1,
+            Command::AllowCompaction(..) => self.allow_compaction_int += 1,
+            Command::DurabilityFrontierUpdates(..) => self.durability_frontier_updates_int += 1,
+            Command::AddSourceTimestamping { .. } => self.add_source_timestamping_int += 1,
+            Command::AdvanceSourceTimestamp { .. } => self.advance_source_timestamp_int += 1,
+            Command::DropSourceTimestamping { .. } => self.drop_source_timestamping_int += 1,
+            Command::EnableLogging(_) => self.enable_logging_int += 1,
+            Command::Shutdown { .. } => self.shutdown_int += 1,
+            Command::AdvanceAllLocalInputs { .. } => self.advance_all_local_inputs_int += 1,
         }
     }
 


### PR DESCRIPTION
Changes the names of these to `dataflow::Command` and `dataflow::Response`. We can change them again in the future if it turns out that `dataflow` should be piloted by other interfaces too, but for a while I suspect it will just be `coord`.

Imported into `coord` as `DataflowCommand` and `DataflowResponse`, though imo `dataflow::Command` and `dataflow::Response` looks even better. `Command` and `Response` are non-starters because there are other types with those names in scope.