### PR TITLE
Use struct init shorthand in one instantiation

### DIFF
--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -337,7 +337,7 @@ pub fn purify(
                                 name: view_name,
                                 columns: columns.iter().map(|c| c.name.clone()).collect(),
                                 with_options: vec![],
-                                query: query,
+                                query,
                             });
                         }
                         *definitions = CreateViewsDefinitions::Literal(views);


### PR DESCRIPTION
This is the pattern we use everywhere and it is also always the only error that
I have when I "go to next error" in pure.rs.