### PR TITLE
migrate: Give migrations names in error messages

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -61,12 +61,13 @@ production readiness.
   > `v0.5.10-dev` -> `v0.6.0` when they upgrade than upgrading and going from `v0.6.0-dev` ->
   > `v0.5.10`.
 
-  - [ ] Related to the above note, **if this is a feature release** (i.e. the
-    product team has decided that we are bumping the major or minor version) you
-    must also update the [release notes][]: the highest unreleased
-    version will be incorrect. It will be a patch version (i.e. the `Y` in
-    `W.X.Y`) instead of a major or minor version change (`W` or `X`), update the
-    release notes to reflect the version that is actually being released.
+  - Related to the above note, **if this is a feature release** (i.e. the product team has
+    decided that we are bumping the major or minor version) you must also update two items because
+    the highest unreleased version will be incorrect. It will be a patch version (i.e. the `Y` in
+    `W.X.Y`) instead of a major or minor version change (`W` or `X`), update the release notes to
+    reflect the version that is actually being released:
+    - [ ] The [release notes][]
+    - [ ] Some recent migration versions in `src/coord/src/catalog/migrate.rs`
 
 - [ ] Incorporate this tag into `main`'s history by preparing dev on top of it.
 

--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -839,9 +839,11 @@ impl Catalog {
         let mut catalog_content_version = catalog.storage().get_catalog_content_version()?;
 
         while CONTENT_MIGRATIONS.len() > catalog_content_version {
-            if let Err(e) = CONTENT_MIGRATIONS[catalog_content_version](&mut catalog) {
+            let migration = &CONTENT_MIGRATIONS[catalog_content_version];
+            if let Err(e) = (migration.command)(&mut catalog) {
                 return Err(Error::new(ErrorKind::FailedMigration {
                     last_version: catalog_content_version,
+                    name: migration.name,
                     cause: e.to_string(),
                 }));
             }

--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -844,6 +844,7 @@ impl Catalog {
                 return Err(Error::new(ErrorKind::FailedMigration {
                     last_version: catalog_content_version,
                     name: migration.name,
+                    introduced_for: migration.introduced_for,
                     cause: e.to_string(),
                 }));
             }

--- a/src/coord/src/catalog/error.rs
+++ b/src/coord/src/catalog/error.rs
@@ -55,6 +55,7 @@ pub enum ErrorKind {
     ExperimentalModeUnavailable,
     FailedMigration {
         last_version: usize,
+        name: &'static str,
         cause: String,
     },
 }
@@ -213,11 +214,12 @@ more details, see https://materialize.com/docs/cli#experimental-mode"#
             ),
             ErrorKind::FailedMigration {
                 last_version,
+                name,
                 cause,
             } => write!(
                 f,
-                "migration from catalog content version {} failed: {}",
-                last_version, cause,
+                "migration {} from catalog content version {} failed: {}",
+                name, last_version, cause,
             ),
         }
     }

--- a/src/coord/src/catalog/error.rs
+++ b/src/coord/src/catalog/error.rs
@@ -56,6 +56,7 @@ pub enum ErrorKind {
     FailedMigration {
         last_version: usize,
         name: &'static str,
+        introduced_for: &'static str,
         cause: String,
     },
 }
@@ -215,11 +216,12 @@ more details, see https://materialize.com/docs/cli#experimental-mode"#
             ErrorKind::FailedMigration {
                 last_version,
                 name,
+                introduced_for,
                 cause,
             } => write!(
                 f,
-                "migration {} from catalog content version {} failed: {}",
-                name, last_version, cause,
+                "migration {}-{} from catalog content version {} failed: {}",
+                name, introduced_for, last_version, cause,
             ),
         }
     }

--- a/src/coord/src/catalog/migrate.rs
+++ b/src/coord/src/catalog/migrate.rs
@@ -25,6 +25,7 @@ use crate::catalog::{MZ_CATALOG_SCHEMA, MZ_INTERNAL_SCHEMA, PG_CATALOG_SCHEMA};
 
 pub struct Migration {
     pub name: &'static str,
+    pub introduced_for: &'static str,
     pub command: fn(&mut Catalog) -> Result<(), anyhow::Error>,
 }
 
@@ -37,10 +38,9 @@ pub const CONTENT_MIGRATIONS: &[Migration] = &[
     // replanning the `CREATE` statement because the catalog still contains no
     // items at this point, e.g. attempting to plan any item with a dependency
     // will fail.
-    //
-    // Introduced for v0.6.1
     Migration {
         name: "rewrite-type-references",
+        introduced_for: "v0.6.1",
         command: |catalog: &mut Catalog| {
             struct TypeNormalizer;
 
@@ -149,10 +149,9 @@ pub const CONTENT_MIGRATIONS: &[Migration] = &[
     },
     // This was previously the place where the function name migration occurred;
     // however #5802 showed that the implementation was insufficient.
-    //
-    // Introduced for v0.7.0
     Migration {
         name: "function-name-removed",
+        introduced_for: "v0.7.0",
         command: |_: &mut Catalog| Ok(()),
     },
     // Rewrites all function references to have `pg_catalog` qualification; this
@@ -162,10 +161,9 @@ pub const CONTENT_MIGRATIONS: &[Migration] = &[
     //
     // The approach is to prepend `pg_catalog` to all `UnresolvedObjectName`
     // names that could refer to functions.
-    //
-    // Introduced for v0.7.1
     Migration {
         name: "use-pg-catalog",
+        introduced_for: "v0.7.1",
         command: |catalog: &mut Catalog| {
             fn normalize_function_name(name: &mut UnresolvedObjectName) {
                 if name.0.len() == 1 {
@@ -293,10 +291,9 @@ pub const CONTENT_MIGRATIONS: &[Migration] = &[
     // to include those magic bytes. In case we change the default to a
     // possibly more reasonable one in the future, we ensure that the current
     // default is encoded in the on-disk catalog.
-    //
-    // Introduced for v0.7.1
     Migration {
         name: "insert-default-confluent-wire-format",
+        introduced_for: "v0.7.1",
         command: |catalog: &mut Catalog| {
             let mut storage = catalog.storage();
             let items = storage.load_items()?;
@@ -347,10 +344,9 @@ pub const CONTENT_MIGRATIONS: &[Migration] = &[
     // Rewrites all table references to use their id as reference rather than
     // their name. This allows us to safely rename tables without having to
     // rewrite their dependents.
-    //
-    // Introduced for v0.7.1
     Migration {
         name: "use-id-for-table-format",
+        introduced_for: "v0.7.1",
         command: |catalog: &mut Catalog| {
             let cat = Catalog::load_catalog_items(catalog.clone())?;
             let cat = cat.for_system_session();

--- a/src/coord/src/catalog/migrate.rs
+++ b/src/coord/src/catalog/migrate.rs
@@ -23,7 +23,12 @@ use sql::plan::resolve_names_stmt;
 use crate::catalog::{Catalog, SerializedCatalogItem};
 use crate::catalog::{MZ_CATALOG_SCHEMA, MZ_INTERNAL_SCHEMA, PG_CATALOG_SCHEMA};
 
-pub const CONTENT_MIGRATIONS: &[fn(&mut Catalog) -> Result<(), anyhow::Error>] = &[
+pub struct Migration {
+    pub name: &'static str,
+    pub command: fn(&mut Catalog) -> Result<(), anyhow::Error>,
+}
+
+pub const CONTENT_MIGRATIONS: &[Migration] = &[
     // Rewrites all built-in type references to have `pg_catalog` qualification;
     // this is necessary to support resolving all type names to the catalog.
     //
@@ -34,116 +39,122 @@ pub const CONTENT_MIGRATIONS: &[fn(&mut Catalog) -> Result<(), anyhow::Error>] =
     // will fail.
     //
     // Introduced for v0.6.1
-    |catalog: &mut Catalog| {
-        struct TypeNormalizer;
+    Migration {
+        name: "rewrite-type-references",
+        command: |catalog: &mut Catalog| {
+            struct TypeNormalizer;
 
-        impl<'ast> VisitMut<'ast, Raw> for TypeNormalizer {
-            fn visit_data_type_mut(&mut self, data_type: &'ast mut DataType<Raw>) {
-                if let DataType::Other { name, .. } = data_type {
-                    let mut unresolved_name = name.name().clone();
-                    if unresolved_name.0.len() == 1 {
-                        unresolved_name = UnresolvedObjectName(vec![
-                            Ident::new(PG_CATALOG_SCHEMA),
-                            unresolved_name.0.remove(0),
-                        ]);
-                    }
-                    *name = match name {
-                        RawName::Name(_) => RawName::Name(unresolved_name),
-                        RawName::Id(id, _) => RawName::Id(id.clone(), unresolved_name),
-                    }
-                }
-            }
-        }
-
-        let mut storage = catalog.storage();
-        let items = storage.load_items()?;
-        let tx = storage.transaction()?;
-
-        for (id, name, def) in items {
-            let SerializedCatalogItem::V1 {
-                create_sql,
-                eval_env,
-            } = serde_json::from_slice(&def)?;
-
-            let mut stmt = sql::parse::parse(&create_sql)?.into_element();
-            match &mut stmt {
-                Statement::CreateTable(CreateTableStatement {
-                    name: _,
-                    columns,
-                    constraints: _,
-                    with_options: _,
-                    if_not_exists: _,
-                    temporary: _,
-                }) => {
-                    for c in columns {
-                        TypeNormalizer.visit_column_def_mut(c);
-                    }
-                }
-
-                Statement::CreateView(CreateViewStatement {
-                    temporary: _,
-                    materialized: _,
-                    if_exists: _,
-                    definition:
-                        ViewDefinition {
-                            name: _,
-                            columns: _,
-                            query,
-                            with_options: _,
-                        },
-                }) => TypeNormalizer.visit_query_mut(query),
-
-                Statement::CreateIndex(CreateIndexStatement {
-                    name: _,
-                    on_name: _,
-                    key_parts,
-                    with_options,
-                    if_not_exists: _,
-                }) => {
-                    if let Some(key_parts) = key_parts {
-                        for key_part in key_parts {
-                            TypeNormalizer.visit_expr_mut(key_part);
+            impl<'ast> VisitMut<'ast, Raw> for TypeNormalizer {
+                fn visit_data_type_mut(&mut self, data_type: &'ast mut DataType<Raw>) {
+                    if let DataType::Other { name, .. } = data_type {
+                        let mut unresolved_name = name.name().clone();
+                        if unresolved_name.0.len() == 1 {
+                            unresolved_name = UnresolvedObjectName(vec![
+                                Ident::new(PG_CATALOG_SCHEMA),
+                                unresolved_name.0.remove(0),
+                            ]);
+                        }
+                        *name = match name {
+                            RawName::Name(_) => RawName::Name(unresolved_name),
+                            RawName::Id(id, _) => RawName::Id(id.clone(), unresolved_name),
                         }
                     }
-                    for with_option in with_options {
-                        TypeNormalizer.visit_with_option_mut(with_option);
-                    }
                 }
-
-                Statement::CreateType(CreateTypeStatement {
-                    name: _,
-                    as_type: _,
-                    with_options,
-                }) => {
-                    for option in with_options {
-                        TypeNormalizer.visit_sql_option_mut(option);
-                    }
-                }
-
-                // At the time the migration was written, sinks and sources
-                // could not contain references to types.
-                Statement::CreateSource(_) | Statement::CreateSink(_) => continue,
-
-                _ => bail!("catalog item contained inappropriate statement: {}", stmt),
             }
 
-            let serialized_item = SerializedCatalogItem::V1 {
-                create_sql: stmt.to_ast_string_stable(),
-                eval_env,
-            };
+            let mut storage = catalog.storage();
+            let items = storage.load_items()?;
+            let tx = storage.transaction()?;
 
-            let serialized_item =
-                serde_json::to_vec(&serialized_item).expect("catalog serialization cannot fail");
-            tx.update_item(id, &name.item, &serialized_item)?;
-        }
-        tx.commit()?;
-        Ok(())
+            for (id, name, def) in items {
+                let SerializedCatalogItem::V1 {
+                    create_sql,
+                    eval_env,
+                } = serde_json::from_slice(&def)?;
+
+                let mut stmt = sql::parse::parse(&create_sql)?.into_element();
+                match &mut stmt {
+                    Statement::CreateTable(CreateTableStatement {
+                        name: _,
+                        columns,
+                        constraints: _,
+                        with_options: _,
+                        if_not_exists: _,
+                        temporary: _,
+                    }) => {
+                        for c in columns {
+                            TypeNormalizer.visit_column_def_mut(c);
+                        }
+                    }
+
+                    Statement::CreateView(CreateViewStatement {
+                        temporary: _,
+                        materialized: _,
+                        if_exists: _,
+                        definition:
+                            ViewDefinition {
+                                name: _,
+                                columns: _,
+                                query,
+                                with_options: _,
+                            },
+                    }) => TypeNormalizer.visit_query_mut(query),
+
+                    Statement::CreateIndex(CreateIndexStatement {
+                        name: _,
+                        on_name: _,
+                        key_parts,
+                        with_options,
+                        if_not_exists: _,
+                    }) => {
+                        if let Some(key_parts) = key_parts {
+                            for key_part in key_parts {
+                                TypeNormalizer.visit_expr_mut(key_part);
+                            }
+                        }
+                        for with_option in with_options {
+                            TypeNormalizer.visit_with_option_mut(with_option);
+                        }
+                    }
+
+                    Statement::CreateType(CreateTypeStatement {
+                        name: _,
+                        as_type: _,
+                        with_options,
+                    }) => {
+                        for option in with_options {
+                            TypeNormalizer.visit_sql_option_mut(option);
+                        }
+                    }
+
+                    // At the time the migration was written, sinks and sources
+                    // could not contain references to types.
+                    Statement::CreateSource(_) | Statement::CreateSink(_) => continue,
+
+                    _ => bail!("catalog item contained inappropriate statement: {}", stmt),
+                }
+
+                let serialized_item = SerializedCatalogItem::V1 {
+                    create_sql: stmt.to_ast_string_stable(),
+                    eval_env,
+                };
+
+                let serialized_item = serde_json::to_vec(&serialized_item)
+                    .expect("catalog serialization cannot fail");
+                tx.update_item(id, &name.item, &serialized_item)?;
+            }
+            tx.commit()?;
+            Ok(())
+        },
     },
     // This was previously the place where the function name migration occurred;
     // however #5802 showed that the implementation was insufficient.
     //
     // Introduced for v0.7.0
-    |_: &mut Catalog| Ok(()),
+    Migration {
+        name: "function-name-removed",
+        command: |_: &mut Catalog| Ok(()),
+    },
     // Rewrites all function references to have `pg_catalog` qualification; this
     // is necessary to support resolving all built-in functions to the catalog.
     // (At the time of writing Materialize did not support user-defined
@@ -153,117 +164,121 @@ pub const CONTENT_MIGRATIONS: &[fn(&mut Catalog) -> Result<(), anyhow::Error>] =
     // names that could refer to functions.
     //
     // Introduced for v0.7.1
-    |catalog: &mut Catalog| {
-        fn normalize_function_name(name: &mut UnresolvedObjectName) {
-            if name.0.len() == 1 {
-                let func_name = name.to_string();
-                for (schema, funcs) in &[
-                    (PG_CATALOG_SCHEMA, &*sql::func::PG_CATALOG_BUILTINS),
-                    (MZ_CATALOG_SCHEMA, &*sql::func::MZ_CATALOG_BUILTINS),
-                    (MZ_INTERNAL_SCHEMA, &*sql::func::MZ_INTERNAL_BUILTINS),
-                ] {
-                    if funcs.contains_key(func_name.as_str()) {
-                        *name = UnresolvedObjectName(vec![Ident::new(*schema), name.0.remove(0)]);
-                        break;
-                    }
-                }
-            }
-        }
-
-        struct FuncNormalizer;
-
-        impl<'ast> VisitMut<'ast, Raw> for FuncNormalizer {
-            fn visit_function_mut(&mut self, func: &'ast mut Function<Raw>) {
-                normalize_function_name(&mut func.name);
-                // Function args can be functions themselves, so let the visitor
-                // find them.
-                visit_mut::visit_function_mut(self, func)
-            }
-            fn visit_table_factor_mut(&mut self, table_factor: &'ast mut TableFactor<Raw>) {
-                if let TableFactor::Function { ref mut name, .. } = table_factor {
-                    normalize_function_name(name);
-                }
-                // Function args can be functions themselves, so let the visitor
-                // find them.
-                visit_mut::visit_table_factor_mut(self, table_factor)
-            }
-        }
-
-        let mut storage = catalog.storage();
-        let items = storage.load_items()?;
-        let tx = storage.transaction()?;
-
-        for (id, name, def) in items {
-            let SerializedCatalogItem::V1 {
-                create_sql,
-                eval_env,
-            } = serde_json::from_slice(&def)?;
-
-            let mut stmt = sql::parse::parse(&create_sql)?.into_element();
-            match &mut stmt {
-                Statement::CreateView(CreateViewStatement {
-                    temporary: _,
-                    materialized: _,
-                    if_exists: _,
-                    definition:
-                        ViewDefinition {
-                            name: _,
-                            columns: _,
-                            query,
-                            with_options: _,
-                        },
-                }) => FuncNormalizer.visit_query_mut(query),
-
-                Statement::CreateIndex(CreateIndexStatement {
-                    name: _,
-                    on_name: _,
-                    key_parts,
-                    with_options: _,
-                    if_not_exists: _,
-                }) => {
-                    if let Some(key_parts) = key_parts {
-                        for key_part in key_parts {
-                            FuncNormalizer.visit_expr_mut(key_part);
+    Migration {
+        name: "use-pg-catalog",
+        command: |catalog: &mut Catalog| {
+            fn normalize_function_name(name: &mut UnresolvedObjectName) {
+                if name.0.len() == 1 {
+                    let func_name = name.to_string();
+                    for (schema, funcs) in &[
+                        (PG_CATALOG_SCHEMA, &*sql::func::PG_CATALOG_BUILTINS),
+                        (MZ_CATALOG_SCHEMA, &*sql::func::MZ_CATALOG_BUILTINS),
+                        (MZ_INTERNAL_SCHEMA, &*sql::func::MZ_INTERNAL_BUILTINS),
+                    ] {
+                        if funcs.contains_key(func_name.as_str()) {
+                            *name =
+                                UnresolvedObjectName(vec![Ident::new(*schema), name.0.remove(0)]);
+                            break;
                         }
                     }
                 }
-
-                Statement::CreateSink(CreateSinkStatement {
-                    name: _,
-                    from: _,
-                    connector: _,
-                    with_options: _,
-                    format: _,
-                    envelope: _,
-                    with_snapshot: _,
-                    as_of,
-                    if_not_exists: _,
-                }) => {
-                    if let Some(expr) = as_of {
-                        FuncNormalizer.visit_expr_mut(expr);
-                    }
-                }
-
-                // At the time the migration was written, tables, sources, and
-                // types could not contain references to functions.
-                Statement::CreateTable(_)
-                | Statement::CreateSource(_)
-                | Statement::CreateType(_) => continue,
-
-                _ => bail!("catalog item contained inappropriate statement: {}", stmt),
             }
 
-            let serialized_item = SerializedCatalogItem::V1 {
-                create_sql: stmt.to_ast_string_stable(),
-                eval_env,
-            };
+            struct FuncNormalizer;
 
-            let serialized_item =
-                serde_json::to_vec(&serialized_item).expect("catalog serialization cannot fail");
-            tx.update_item(id, &name.item, &serialized_item)?;
-        }
-        tx.commit()?;
-        Ok(())
+            impl<'ast> VisitMut<'ast, Raw> for FuncNormalizer {
+                fn visit_function_mut(&mut self, func: &'ast mut Function<Raw>) {
+                    normalize_function_name(&mut func.name);
+                    // Function args can be functions themselves, so let the visitor
+                    // find them.
+                    visit_mut::visit_function_mut(self, func)
+                }
+                fn visit_table_factor_mut(&mut self, table_factor: &'ast mut TableFactor<Raw>) {
+                    if let TableFactor::Function { ref mut name, .. } = table_factor {
+                        normalize_function_name(name);
+                    }
+                    // Function args can be functions themselves, so let the visitor
+                    // find them.
+                    visit_mut::visit_table_factor_mut(self, table_factor)
+                }
+            }
+
+            let mut storage = catalog.storage();
+            let items = storage.load_items()?;
+            let tx = storage.transaction()?;
+
+            for (id, name, def) in items {
+                let SerializedCatalogItem::V1 {
+                    create_sql,
+                    eval_env,
+                } = serde_json::from_slice(&def)?;
+
+                let mut stmt = sql::parse::parse(&create_sql)?.into_element();
+                match &mut stmt {
+                    Statement::CreateView(CreateViewStatement {
+                        temporary: _,
+                        materialized: _,
+                        if_exists: _,
+                        definition:
+                            ViewDefinition {
+                                name: _,
+                                columns: _,
+                                query,
+                                with_options: _,
+                            },
+                    }) => FuncNormalizer.visit_query_mut(query),
+
+                    Statement::CreateIndex(CreateIndexStatement {
+                        name: _,
+                        on_name: _,
+                        key_parts,
+                        with_options: _,
+                        if_not_exists: _,
+                    }) => {
+                        if let Some(key_parts) = key_parts {
+                            for key_part in key_parts {
+                                FuncNormalizer.visit_expr_mut(key_part);
+                            }
+                        }
+                    }
+
+                    Statement::CreateSink(CreateSinkStatement {
+                        name: _,
+                        from: _,
+                        connector: _,
+                        with_options: _,
+                        format: _,
+                        envelope: _,
+                        with_snapshot: _,
+                        as_of,
+                        if_not_exists: _,
+                    }) => {
+                        if let Some(expr) = as_of {
+                            FuncNormalizer.visit_expr_mut(expr);
+                        }
+                    }
+
+                    // At the time the migration was written, tables, sources, and
+                    // types could not contain references to functions.
+                    Statement::CreateTable(_)
+                    | Statement::CreateSource(_)
+                    | Statement::CreateType(_) => continue,
+
+                    _ => bail!("catalog item contained inappropriate statement: {}", stmt),
+                }
+
+                let serialized_item = SerializedCatalogItem::V1 {
+                    create_sql: stmt.to_ast_string_stable(),
+                    eval_env,
+                };
+
+                let serialized_item = serde_json::to_vec(&serialized_item)
+                    .expect("catalog serialization cannot fail");
+                tx.update_item(id, &name.item, &serialized_item)?;
+            }
+            tx.commit()?;
+            Ok(())
+        },
     },
     // Insert default value for confluent_wire_format
     //
@@ -280,86 +295,92 @@ pub const CONTENT_MIGRATIONS: &[fn(&mut Catalog) -> Result<(), anyhow::Error>] =
     // default is encoded in the on-disk catalog.
     //
     // Introduced for v0.7.1
-    |catalog: &mut Catalog| {
-        let mut storage = catalog.storage();
-        let items = storage.load_items()?;
-        let tx = storage.transaction()?;
+    Migration {
+        name: "insert-default-confluent-wire-format",
+        command: |catalog: &mut Catalog| {
+            let mut storage = catalog.storage();
+            let items = storage.load_items()?;
+            let tx = storage.transaction()?;
 
-        for (id, name, def) in items {
-            let SerializedCatalogItem::V1 {
-                create_sql,
-                eval_env,
-            } = serde_json::from_slice(&def)?;
+            for (id, name, def) in items {
+                let SerializedCatalogItem::V1 {
+                    create_sql,
+                    eval_env,
+                } = serde_json::from_slice(&def)?;
 
-            let mut stmt = sql::parse::parse(&create_sql)?.into_element();
+                let mut stmt = sql::parse::parse(&create_sql)?.into_element();
 
-            // the match arm is long enough that this is easier to understand
-            #[allow(clippy::single_match)]
-            match stmt {
-                Statement::CreateSource(CreateSourceStatement {
-                    format:
-                        CreateSourceFormat::Bare(Format::Avro(AvroSchema::Schema {
-                            ref mut with_options,
-                            ..
-                        })),
-                    ..
-                }) => {
-                    if with_options.is_empty() {
-                        with_options.push(WithOption {
-                            key: Ident::new("confluent_wire_format"),
-                            value: Some(WithOptionValue::Value(Value::Boolean(true))),
-                        })
+                // the match arm is long enough that this is easier to understand
+                #[allow(clippy::single_match)]
+                match stmt {
+                    Statement::CreateSource(CreateSourceStatement {
+                        format:
+                            CreateSourceFormat::Bare(Format::Avro(AvroSchema::Schema {
+                                ref mut with_options,
+                                ..
+                            })),
+                        ..
+                    }) => {
+                        if with_options.is_empty() {
+                            with_options.push(WithOption {
+                                key: Ident::new("confluent_wire_format"),
+                                value: Some(WithOptionValue::Value(Value::Boolean(true))),
+                            })
+                        }
                     }
+                    _ => {}
                 }
-                _ => {}
+
+                let serialized_item = SerializedCatalogItem::V1 {
+                    create_sql: stmt.to_ast_string_stable(),
+                    eval_env,
+                };
+
+                let serialized_item = serde_json::to_vec(&serialized_item)
+                    .expect("catalog serialization cannot fail");
+                tx.update_item(id, &name.item, &serialized_item)?;
             }
-
-            let serialized_item = SerializedCatalogItem::V1 {
-                create_sql: stmt.to_ast_string_stable(),
-                eval_env,
-            };
-
-            let serialized_item =
-                serde_json::to_vec(&serialized_item).expect("catalog serialization cannot fail");
-            tx.update_item(id, &name.item, &serialized_item)?;
-        }
-        tx.commit()?;
-        Ok(())
+            tx.commit()?;
+            Ok(())
+        },
     },
     // Rewrites all table references to use their id as reference rather than
     // their name. This allows us to safely rename tables without having to
     // rewrite their dependents.
     //
     // Introduced for v0.7.1
-    |catalog: &mut Catalog| {
-        let cat = Catalog::load_catalog_items(catalog.clone())?;
-        let cat = cat.for_system_session();
+    Migration {
+        name: "use-id-for-table-format",
+        command: |catalog: &mut Catalog| {
+            let cat = Catalog::load_catalog_items(catalog.clone())?;
+            let cat = cat.for_system_session();
 
-        let items = catalog.storage().load_items()?;
-        let mut storage = catalog.storage();
-        let tx = storage.transaction()?;
+            let items = catalog.storage().load_items()?;
+            let mut storage = catalog.storage();
+            let tx = storage.transaction()?;
 
-        for (id, name, def) in items {
-            let SerializedCatalogItem::V1 {
-                create_sql,
-                eval_env,
-            } = serde_json::from_slice(&def)?;
+            for (id, name, def) in items {
+                let SerializedCatalogItem::V1 {
+                    create_sql,
+                    eval_env,
+                } = serde_json::from_slice(&def)?;
 
-            let stmt = sql::parse::parse(&create_sql)?.into_element();
+                let stmt = sql::parse::parse(&create_sql)?.into_element();
 
-            let resolved = resolve_names_stmt(&cat, stmt.clone()).unwrap();
+                let resolved = resolve_names_stmt(&cat, stmt.clone()).unwrap();
 
-            let serialized_item = SerializedCatalogItem::V1 {
-                create_sql: resolved.to_ast_string_stable(),
-                eval_env,
-            };
+                let serialized_item = SerializedCatalogItem::V1 {
+                    create_sql: resolved.to_ast_string_stable(),
+                    eval_env,
+                };
 
-            let serialized_item =
-                serde_json::to_vec(&serialized_item).expect("catalog serialization cannot fail");
-            tx.update_item(id, &name.item, &serialized_item)?;
-        }
-        tx.commit()?;
-        Ok(())
+                let serialized_item = serde_json::to_vec(&serialized_item)
+                    .expect("catalog serialization cannot fail");
+                tx.update_item(id, &name.item, &serialized_item)?;
+            }
+            tx.commit()?;
+            Ok(())
+        },
     },
     // Add new migrations here.
     //


### PR DESCRIPTION
Having to just count where you are in the migrate list if things go awry in a
migration is much more annoying than it's worth.

This looks huge, but is not if you ignore whitespace changes.