### PR TITLE
docs: JSON Kafka sinks and consistency topics

### DIFF
--- a/doc/user/content/sql/create-sink.md
+++ b/doc/user/content/sql/create-sink.md
@@ -45,6 +45,8 @@ Field | Use
 **KAFKA BROKER** _host_ | The Kafka broker's host name without the security protocol, which is specified by the [`WITH` options](#with-options).) If you wish to specify multiple brokers (bootstrap servers) as an additional safeguard, use a comma-separated list. For example: `localhost:9092, localhost:9093`.
 **TOPIC** _topic&lowbar;prefix_ | The prefix used to generate the Kafka topic name to create and write to.
 **KEY (** _key&lowbar;column&lowbar;list_ **)** | An optional list of columns to use for the Kafka key. If unspecified, the Kafka key is left unset. {{< version-added v0.5.1 />}}
+**CONSISTENCY TOPIC** _consistency&lowbar;topic_ | Makes the sink emit additional [consistency metadata](#consistency-metadata) to the named topic. Only valid for Kafka sinks. If `reuse_topic` is `true`, a default consistency_topic will be used when not explicitly set. The default consistency topic name is formed by appending `-consistency` to the output topic name. {{< version-added v0.8.4 />}}
+**CONSISTENCY FORMAT** _format_ | The format of the Kafka consistency topic. Defaults to the format of the sink if not provided. {{< version-added v0.8.4 />}}
 **WITH OPTIONS (** _option&lowbar;_ **)** | Options affecting sink creation. For more details see [`WITH` options](#with-options).
 **CONFLUENT SCHEMA REGISTRY** _url_ | The URL of the Confluent schema registry to get schema information from.
 
@@ -98,11 +100,13 @@ they occur. To only see results after the sink is created, specify `WITHOUT SNAP
 
 ## Detail
 
-- Materialize currently only supports Avro-formatted sinks that write to either a topic or an Avro object container file.
+- Materialize currently only supports the following sinks:
+    - Avro-formtted sinks that write to either a topic or an Avro object container file.
+    - JSON-formatted sinks that write to a topic.
 - For most sinks, Materialize creates new, distinct topics and files for each sink on restart.
-- For Avro-formatted Kafka sinks, a beta feature enables the use of the same topic after restart. For details, see [Enabling topic reuse after restart](#enabling-topic-reuse-after-restart).
+- A beta feature enables the use of the same topic after restart. For details, see [Enabling topic reuse after restart](#enabling-topic-reuse-after-restart).
 - Materialize stores information about actual topic names and actual file names in the `mz_kafka_sinks` and `mz_avro_ocf_sinks` log sources. See the [examples](#examples) below for more details.
-- Materialize generates Avro schemas for views and sources that are stored in sinks.
+- For Avro-formatted sinks, Materialize generates Avro schemas for views and sources that are stored in the sink.
 - Materialize can also optionally emit transaction information for changes. This is only supported for Kafka sinks and adds transaction id information inline with the data, and adds a separate transaction metadata topic.
 
 ### Debezium envelope details
@@ -159,10 +163,14 @@ Note that:
 
 ### Kafka sinks
 
-When creating Kafka sinks, Materialize uses the Kafka Admin API to create a new topic, and registers its Avro schema in the Confluent Schema Registry. Materialize names the new topic using the format below.
+When creating sinks, Materialize will either reuse the last sink topic (if `reuse_topic` is `true`) or it will generate a new topic name using the format below.
 ```nofmt
 {topic_prefix}-{sink_global_id}-{materialize-startup-time}-{nonce}
 ```
+If the topic does not exist, Materialize will use the Kafka Admin API to create the topic.
+
+For Avro-encoded sinks, Materialize will publish the sink's Avro schema to the Confluent Schema Registry. Materialize will not publish schemas for JSON-encoded sinks.
+
 **Note:** With `reuse_topic` enabled, this schema for topic naming is ignored. Instead, the topic name specified in the sink definition is used as is.
 
 You can find the topic name for each Kafka sink by querying `mz_kafka_sinks`.
@@ -180,9 +188,12 @@ This is currently available only for Kafka sources and the views based on them.
 When you create a sink, you must:
 
 * Enable the `reuse_topic` switch.
-* Optionally specify a [consistency topic](#consistency-metadata) to store the information that Materialize will use to identify the last completed write. The names of the sink topic and the sink consistency topic must be unique across all sinks in the system. If not specified, a default consistency topic name will be created by appending `-consistency` to the output topic name.
+* Optionally specify the name of a [consistency topic](#consistency-metadata) to store the information that Materialize will use to identify the last completed write. The names of the sink topic and the sink consistency topic must be unique across all sinks in the system. The name of the consistency topic may be provided via:
+    * The `CONSISTENCY TOPIC` parameter.
+    * The `consistency_topic` WITH option. **Note:** This option is only available to support backwards-compatibility. You will not be able to indicate `consistency_topic` and `CONSISTENCY TOPIC` or `CONSISTENCY FORMAT` simultaneously.
 
-The sink consistency topic cannot be written to by any other process, including another Materialize instance or another sink.
+  If not specified, a default consistency topic name will be created by appending `-consistency` to the output topic name.
+* The sink consistency topic cannot be written to by any other process, including another Materialize instance or another sink.
 
 Because this feature is still in beta, we strongly suggest that you start with test data, rather than with production. Please [escalate](https://github.com/MaterializeInc/materialize/issues/new/choose) any issues to us.
 
@@ -295,7 +306,7 @@ You can query `mz_avro_ocf_sinks` to get file name information for each Avro OCF
 
 ## Examples
 
-### Kafka sinks
+### Avro sinks
 
 #### From sources
 
@@ -411,6 +422,56 @@ JOIN mz_avro_ocf_sinks ON mz_sinks.id = mz_avro_ocf_sinks.sink_id
  u10       | quotes_sink       | /path/to/sink-file-u10-1586108399-8671224166353132585.ocf
  u11       | frank_quotes_sink | /path/to/frank-sink-file-u11-1586108399-8671224166353132585.ocf
 ```
+
+### JSON sinks
+
+#### From sources
+
+```sql
+CREATE SOURCE quotes
+FROM KAFKA BROKER 'localhost' TOPIC 'quotes'
+FORMAT AVRO USING
+    CONFLUENT SCHEMA REGISTRY 'http://localhost:8081';
+```
+```sql
+CREATE SINK quotes_sink
+FROM quotes
+INTO KAFKA BROKER 'localhost' TOPIC 'quotes-sink'
+FORMAT JSON;
+```
+
+#### With topic reuse enabled after restart
+
+```sql
+CREATE SINK quotes_sink
+FROM quotes
+INTO KAFKA BROKER 'localhost:9092' TOPIC 'quotes-eo-sink'
+    CONSISTENCY TOPIC 'quotes-eo-sink-consistency'
+    CONSISTENCY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081'
+WITH (reuse_topic=true)
+FORMAT JSON;
+```
+
+#### From materialized views
+
+```sql
+CREATE SOURCE quotes
+FROM KAFKA BROKER 'localhost' TOPIC 'quotes'
+FORMAT AVRO USING
+    CONFLUENT SCHEMA REGISTRY 'http://localhost:8081';
+```
+```sql
+CREATE MATERIALIZED VIEW frank_quotes AS
+    SELECT * FROM quotes
+    WHERE attributed_to = 'Frank McSherry';
+```
+```sql
+CREATE SINK frank_quotes_sink
+FROM frank_quotes
+INTO KAFKA BROKER 'localhost' TOPIC 'frank-quotes-sink'
+FORMAT JSON;
+```
+
 
 ## Related pages
 

--- a/doc/user/layouts/partials/sql-grammar/sink-kafka-connector.svg
+++ b/doc/user/layouts/partials/sql-grammar/sink-kafka-connector.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="539" height="355">
+<svg xmlns="http://www.w3.org/2000/svg" width="1075" height="513">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="126" height="32" rx="10"/>
@@ -23,116 +23,178 @@
    <rect x="325" y="3" width="90" height="32"/>
    <rect x="323" y="1" width="90" height="32" class="nonterminal"/>
    <text class="nonterminal" x="333" y="21">topic-prefix</text>
-   <rect x="127" y="113" width="46" height="32" rx="10"/>
-   <rect x="125"
+   <rect x="395" y="113" width="46" height="32" rx="10"/>
+   <rect x="393"
          y="111"
          width="46"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="135" y="131">KEY</text>
-   <rect x="193" y="113" width="24" height="32" rx="10"/>
-   <rect x="191"
+   <text class="terminal" x="403" y="131">KEY</text>
+   <rect x="461" y="113" width="24" height="32" rx="10"/>
+   <rect x="459"
          y="111"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="201" y="131">(</text>
-   <rect x="257" y="113" width="94" height="32"/>
-   <rect x="255" y="111" width="94" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="265" y="131">key_column</text>
-   <rect x="257" y="69" width="24" height="32" rx="10"/>
-   <rect x="255"
+   <text class="terminal" x="469" y="131">(</text>
+   <rect x="525" y="113" width="94" height="32"/>
+   <rect x="523" y="111" width="94" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="533" y="131">key_column</text>
+   <rect x="525" y="69" width="24" height="32" rx="10"/>
+   <rect x="523"
          y="67"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="265" y="87">,</text>
-   <rect x="391" y="113" width="24" height="32" rx="10"/>
-   <rect x="389"
+   <text class="terminal" x="533" y="87">,</text>
+   <rect x="659" y="113" width="24" height="32" rx="10"/>
+   <rect x="657"
          y="111"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="399" y="131">)</text>
-   <rect x="45" y="239" width="56" height="32" rx="10"/>
+   <text class="terminal" x="667" y="131">)</text>
+   <rect x="45" y="211" width="118" height="32" rx="10"/>
    <rect x="43"
-         y="237"
-         width="56"
+         y="209"
+         width="118"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="53" y="257">WITH</text>
-   <rect x="121" y="239" width="24" height="32" rx="10"/>
-   <rect x="119"
-         y="237"
-         width="24"
+   <text class="terminal" x="53" y="229">CONSISTENCY</text>
+   <rect x="183" y="211" width="62" height="32" rx="10"/>
+   <rect x="181"
+         y="209"
+         width="62"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="129" y="257">(</text>
-   <rect x="185" y="239" width="46" height="32"/>
-   <rect x="183" y="237" width="46" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="193" y="257">field</text>
-   <rect x="251" y="239" width="26" height="32" rx="10"/>
-   <rect x="249"
-         y="237"
-         width="26"
+   <text class="terminal" x="191" y="229">TOPIC</text>
+   <rect x="265" y="211" width="50" height="32"/>
+   <rect x="263" y="209" width="50" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="273" y="229">topic</text>
+   <rect x="355" y="243" width="118" height="32" rx="10"/>
+   <rect x="353"
+         y="241"
+         width="118"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="259" y="257">=</text>
-   <rect x="297" y="239" width="38" height="32"/>
-   <rect x="295" y="237" width="38" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="305" y="257">val</text>
-   <rect x="185" y="195" width="24" height="32" rx="10"/>
-   <rect x="183"
-         y="193"
-         width="24"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="193" y="213">,</text>
-   <rect x="375" y="239" width="24" height="32" rx="10"/>
-   <rect x="373"
-         y="237"
-         width="24"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="383" y="257">)</text>
-   <rect x="439" y="239" width="78" height="32" rx="10"/>
-   <rect x="437"
-         y="237"
+   <text class="terminal" x="363" y="261">CONSISTENCY</text>
+   <rect x="493" y="243" width="78" height="32" rx="10"/>
+   <rect x="491"
+         y="241"
          width="78"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="447" y="257">FORMAT</text>
-   <rect x="89" y="321" width="106" height="32" rx="10"/>
-   <rect x="87"
-         y="319"
+   <text class="terminal" x="501" y="261">FORMAT</text>
+   <rect x="591" y="243" width="106" height="32" rx="10"/>
+   <rect x="589"
+         y="241"
          width="106"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="97" y="339">AVRO USING</text>
-   <rect x="215" y="321" width="240" height="32" rx="10"/>
-   <rect x="213"
-         y="319"
+   <text class="terminal" x="599" y="261">AVRO USING</text>
+   <rect x="717" y="243" width="240" height="32" rx="10"/>
+   <rect x="715"
+         y="241"
          width="240"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="223" y="339">CONFLUENT SCHEMA REGISTRY</text>
-   <rect x="475" y="321" width="36" height="32"/>
-   <rect x="473" y="319" width="36" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="483" y="339">url</text>
+   <text class="terminal" x="725" y="261">CONFLUENT SCHEMA REGISTRY</text>
+   <rect x="977" y="243" width="36" height="32"/>
+   <rect x="975" y="241" width="36" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="985" y="261">url</text>
+   <rect x="313" y="353" width="56" height="32" rx="10"/>
+   <rect x="311"
+         y="351"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="321" y="371">WITH</text>
+   <rect x="389" y="353" width="24" height="32" rx="10"/>
+   <rect x="387"
+         y="351"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="397" y="371">(</text>
+   <rect x="453" y="353" width="46" height="32"/>
+   <rect x="451" y="351" width="46" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="461" y="371">field</text>
+   <rect x="519" y="353" width="26" height="32" rx="10"/>
+   <rect x="517"
+         y="351"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="527" y="371">=</text>
+   <rect x="565" y="353" width="38" height="32"/>
+   <rect x="563" y="351" width="38" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="573" y="371">val</text>
+   <rect x="453" y="309" width="24" height="32" rx="10"/>
+   <rect x="451"
+         y="307"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="461" y="327">,</text>
+   <rect x="643" y="353" width="24" height="32" rx="10"/>
+   <rect x="641"
+         y="351"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="651" y="371">)</text>
+   <rect x="707" y="353" width="78" height="32" rx="10"/>
+   <rect x="705"
+         y="351"
+         width="78"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="715" y="371">FORMAT</text>
+   <rect x="605" y="435" width="106" height="32" rx="10"/>
+   <rect x="603"
+         y="433"
+         width="106"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="613" y="453">AVRO USING</text>
+   <rect x="731" y="435" width="240" height="32" rx="10"/>
+   <rect x="729"
+         y="433"
+         width="240"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="739" y="453">CONFLUENT SCHEMA REGISTRY</text>
+   <rect x="991" y="435" width="36" height="32"/>
+   <rect x="989" y="433" width="36" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="999" y="453">url</text>
+   <rect x="605" y="479" width="54" height="32" rx="10"/>
+   <rect x="603"
+         y="477"
+         width="54"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="613" y="497">JSON</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m126 0 h10 m0 0 h10 m46 0 h10 m0 0 h10 m62 0 h10 m0 0 h10 m90 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-352 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m46 0 h10 m0 0 h10 m24 0 h10 m20 0 h10 m94 0 h10 m-134 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m114 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-114 0 h10 m24 0 h10 m0 0 h70 m20 44 h10 m24 0 h10 m-328 0 h20 m308 0 h20 m-348 0 q10 0 10 10 m328 0 q0 -10 10 -10 m-338 10 v14 m328 0 v-14 m-328 14 q0 10 10 10 m308 0 q10 0 10 -10 m-318 10 h10 m0 0 h298 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-454 126 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m56 0 h10 m0 0 h10 m24 0 h10 m20 0 h10 m46 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m38 0 h10 m-190 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m170 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-170 0 h10 m24 0 h10 m0 0 h126 m20 44 h10 m24 0 h10 m-394 0 h20 m374 0 h20 m-414 0 q10 0 10 10 m394 0 q0 -10 10 -10 m-404 10 v14 m394 0 v-14 m-394 14 q0 10 10 10 m374 0 q10 0 10 -10 m-384 10 h10 m0 0 h364 m20 -34 h10 m78 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-472 82 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m106 0 h10 m0 0 h10 m240 0 h10 m0 0 h10 m36 0 h10 m3 0 h-3"/>
-   <polygon points="529 335 537 331 537 339"/>
-   <polygon points="529 335 521 331 521 339"/>
+         d="m17 17 h2 m0 0 h10 m126 0 h10 m0 0 h10 m46 0 h10 m0 0 h10 m62 0 h10 m0 0 h10 m90 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-84 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m46 0 h10 m0 0 h10 m24 0 h10 m20 0 h10 m94 0 h10 m-134 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m114 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-114 0 h10 m24 0 h10 m0 0 h70 m20 44 h10 m24 0 h10 m-328 0 h20 m308 0 h20 m-348 0 q10 0 10 10 m328 0 q0 -10 10 -10 m-338 10 v14 m328 0 v-14 m-328 14 q0 10 10 10 m308 0 q10 0 10 -10 m-318 10 h10 m0 0 h298 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-722 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h998 m-1028 0 h20 m1008 0 h20 m-1048 0 q10 0 10 10 m1028 0 q0 -10 10 -10 m-1038 10 v12 m1028 0 v-12 m-1028 12 q0 10 10 10 m1008 0 q10 0 10 -10 m-1018 10 h10 m118 0 h10 m0 0 h10 m62 0 h10 m0 0 h10 m50 0 h10 m20 0 h10 m0 0 h668 m-698 0 h20 m678 0 h20 m-718 0 q10 0 10 10 m698 0 q0 -10 10 -10 m-708 10 v12 m698 0 v-12 m-698 12 q0 10 10 10 m678 0 q10 0 10 -10 m-688 10 h10 m118 0 h10 m0 0 h10 m78 0 h10 m0 0 h10 m106 0 h10 m0 0 h10 m240 0 h10 m0 0 h10 m36 0 h10 m42 -64 l2 0 m2 0 l2 0 m2 0 l2 0 m-804 174 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m56 0 h10 m0 0 h10 m24 0 h10 m20 0 h10 m46 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m38 0 h10 m-190 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m170 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-170 0 h10 m24 0 h10 m0 0 h126 m20 44 h10 m24 0 h10 m-394 0 h20 m374 0 h20 m-414 0 q10 0 10 10 m394 0 q0 -10 10 -10 m-404 10 v14 m394 0 v-14 m-394 14 q0 10 10 10 m374 0 q10 0 10 -10 m-384 10 h10 m0 0 h364 m20 -34 h10 m78 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-244 82 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m106 0 h10 m0 0 h10 m240 0 h10 m0 0 h10 m36 0 h10 m-462 0 h20 m442 0 h20 m-482 0 q10 0 10 10 m462 0 q0 -10 10 -10 m-472 10 v24 m462 0 v-24 m-462 24 q0 10 10 10 m442 0 q10 0 10 -10 m-452 10 h10 m54 0 h10 m0 0 h368 m23 -44 h-3"/>
+   <polygon points="1065 449 1073 445 1073 453"/>
+   <polygon points="1065 449 1057 445 1057 453"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -320,8 +320,9 @@ join_type ::=
 sink_kafka_connector ::=
     'KAFKA BROKER' host 'TOPIC' topic-prefix
     ('KEY' '(' key_column ( ',' key_column )* ')')?
+    ('CONSISTENCY' 'TOPIC' topic ('CONSISTENCY' 'FORMAT' 'AVRO USING' 'CONFLUENT SCHEMA REGISTRY' url)?)?
     ('WITH' '(' ( field '=' val ) ( ( ',' field '=' val ) )* ')')?
-    'FORMAT' 'AVRO USING' 'CONFLUENT SCHEMA REGISTRY' url
+    'FORMAT' ('AVRO USING' 'CONFLUENT SCHEMA REGISTRY' url | 'JSON')
 lit_cast ::=
   type val
 op_cast ::=


### PR DESCRIPTION
Updates the `CREATE SINK` docs to include JSON-formatted Kafka sinks and consistency topic information.

<img width="1099" alt="Screen Shot 2021-08-03 at 2 10 09 PM" src="https://user-images.githubusercontent.com/5766027/128088633-74bfad5f-5026-4006-903c-c77ed915a52c.png">
