### PR TITLE
coord: make the metrics scraper async

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -48,6 +48,10 @@ Wrap your release notes at the 80 character mark.
 
 {{% version-header v0.8.4 %}}
 
+- Change the type of the [`mz_metrics`](/sql/system-catalog#mz_metrics).`time`
+  column from [`timestamp`] to [`timestamp with time zone`] to better reflect
+  that the timestamp is in UTC.
+
 - **Breaking change.** Reject [Protobuf sources] whose schemas contain
   unsigned integer types (`uint32`, `uint64`, `fixed32`, and `fixed64`).
   Materialize previously converted these types to

--- a/doc/user/content/sql/system-catalog.md
+++ b/doc/user/content/sql/system-catalog.md
@@ -355,12 +355,12 @@ The `mz_metrics` table contains recordings for each [Prometheus
 metric](/ops/monitoring#prometheus) in the system that is a counter or gauge.
 The values are recorded every second and retained for five minutes.
 
-Field    | Type                 | Meaning
----------|----------------------|--------
-`metric` | [`text`]             | The name of the metric.
-`time`   | [`timestamp`]        | The time at which the metric was recorded.
-`labels` | [`jsonb`]            | The metric's labels and their associated values as a JSON object.
-`value`  | [`double precision`] | The value of the counter or gauge.
+Field    | Type                         | Meaning
+---------|------------------------------|--------
+`metric` | [`text`]                     | The name of the metric.
+`time`   | [`timestamp with time zone`] | The time at which the metric was recorded.
+`labels` | [`jsonb`]                    | The metric's labels and their associated values as a JSON object.
+`value`  | [`double precision`]         | The value of the counter or gauge.
 
 ### `mz_metrics_meta`
 
@@ -682,6 +682,7 @@ Materialize with minor changes to the `pg_catalog` compatibility shim.
 [`oid`]: /sql/types/oid
 [`text`]: /sql/types/text
 [`timestamp`]: /sql/types/timestamp
+[`timestamp with time zone`]: /sql/types/timestamp
 [gh-issue]: https://github.com/MaterializeInc/materialize/issues/new?labels=C-feature&template=feature.md
 [oid]: /sql/types/oid
 [`text array`]: /sql/types/array

--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -835,7 +835,7 @@ lazy_static! {
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
                 .with_named_column("metric", ScalarType::String.nullable(false))
-                .with_named_column("time", ScalarType::Timestamp.nullable(false))
+                .with_named_column("time", ScalarType::TimestampTz.nullable(false))
                 .with_named_column("labels", ScalarType::Jsonb.nullable(false))
                 .with_named_column("value", ScalarType::Float64.nullable(false))
                 .with_key(vec![0, 1, 2]),

--- a/src/coord/src/coord/prometheus.rs
+++ b/src/coord/src/coord/prometheus.rs
@@ -7,38 +7,37 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! A task that scrapes materialized's prometheus metrics and sends them to our logging tables.
+//! A helper that scrapes materialized's prometheus metrics and produces
+//! updates for the mz_metrics table.
 
 use std::collections::HashMap;
-use std::thread;
-use std::time::Duration;
+use std::convert::TryFrom;
+use std::pin::Pin;
 
+use anyhow::anyhow;
 use chrono::{DateTime, Utc};
+use futures::stream::{self, Stream, StreamExt};
+use prometheus::proto::MetricType;
+use tokio::time::{self, Duration};
+use tokio_stream::wrappers::IntervalStream;
+
 use ore::metrics::MetricsRegistry;
 use ore::now;
-use prometheus::proto::MetricType;
 use repr::{Datum, Diff, Row};
-use tokio::sync::mpsc::UnboundedSender;
 
 use crate::catalog::builtin::{
     BuiltinTable, MZ_PROMETHEUS_HISTOGRAMS, MZ_PROMETHEUS_METRICS, MZ_PROMETHEUS_READINGS,
 };
 use crate::catalog::BuiltinTableUpdate;
-use crate::coord::{Message, TimestampedUpdate};
+use crate::coord::{LoggingConfig, Message, TimestampedUpdate};
 
-/// Scrapes the prometheus registry in a regular interval and submits a batch of metric data to a
-/// logging worker, to be inserted into a table.
+/// Scrapes the prometheus registry when asked and produces a batch of metric
+/// data that can be inserted into the built-in `mz_metrics` table.
 pub struct Scraper {
-    interval: Duration,
+    interval: Option<Duration>,
     retain_for: u64,
     registry: MetricsRegistry,
-    command_rx: std::sync::mpsc::Receiver<ScraperMessage>,
-    internal_tx: UnboundedSender<super::Message>,
-}
-
-#[derive(Clone, PartialEq, Debug)]
-pub enum ScraperMessage {
-    Shutdown,
+    metadata: HashMap<Row, u64>,
 }
 
 fn convert_metrics_to_value_rows<
@@ -128,111 +127,143 @@ fn metric_family_metadata(family: &prometheus::proto::MetricFamily) -> Row {
     ])
 }
 
+fn add_expiring_update(
+    table: &BuiltinTable,
+    updates: Vec<Row>,
+    retain_for: u64,
+    out: &mut Vec<TimestampedUpdate>,
+) {
+    // TODO: Make this send both records in the same message so we can
+    // persist them atomically. Otherwise, we may end up with permanent
+    // orphans if a restart/crash happens at the wrong time.
+    let id = table.id;
+    out.push(TimestampedUpdate {
+        updates: updates
+            .iter()
+            .cloned()
+            .map(|row| BuiltinTableUpdate { id, row, diff: 1 })
+            .collect(),
+        timestamp_offset: 0,
+    });
+    out.push(TimestampedUpdate {
+        updates: updates
+            .iter()
+            .cloned()
+            .map(|row| BuiltinTableUpdate { id, row, diff: -1 })
+            .collect(),
+        timestamp_offset: retain_for,
+    });
+}
+
+fn add_metadata_update<'a, I: IntoIterator<Item = Row>>(
+    updates: I,
+    diff: Diff,
+    retain_for: u64,
+    out: &mut Vec<TimestampedUpdate>,
+) {
+    let id = MZ_PROMETHEUS_METRICS.id;
+    out.push(TimestampedUpdate {
+        updates: updates
+            .into_iter()
+            .map(|row| BuiltinTableUpdate { id, row, diff })
+            .collect(),
+        timestamp_offset: retain_for,
+    });
+}
+
 impl Scraper {
+    /// Constructs a new metrics scraper for the specified registry.
+    ///
+    /// The logging configuration specifies what metrics to scrape and how long
+    /// to retain them for. If the logging configuration is none, scraping is
+    /// disabled.
     pub fn new(
-        interval: Duration,
-        retain_for: Duration,
+        logging_config: Option<&LoggingConfig>,
         registry: MetricsRegistry,
-        command_rx: std::sync::mpsc::Receiver<ScraperMessage>,
-        internal_tx: UnboundedSender<super::Message>,
-    ) -> Self {
-        let retain_for = retain_for.as_millis() as u64;
-        Scraper {
+    ) -> Result<Scraper, anyhow::Error> {
+        let (interval, retain_for) = match logging_config {
+            Some(config) => {
+                let interval = Some(config.granularity);
+                let retain_for = u64::try_from(config.retain_readings_for.as_millis())
+                    .map_err(|_| anyhow!("scraper retention duration does not fit in an i64"))?;
+                (interval, retain_for)
+            }
+            None => (None, 0),
+        };
+        Ok(Scraper {
             interval,
             retain_for,
             registry,
-            command_rx,
-            internal_tx,
+            metadata: HashMap::new(),
+        })
+    }
+
+    /// Produces a stream that yields a `Message::ScrapeMetrics` at the desired
+    /// scrape frequency.
+    ///
+    /// If the scraper is disabled, this stream will yield no items.
+    pub fn tick_stream(&self) -> Pin<Box<dyn Stream<Item = Message> + Send>> {
+        match self.interval {
+            None => stream::empty().boxed(),
+            Some(interval) => IntervalStream::new(time::interval(interval))
+                .map(|_| Message::ScrapeMetrics)
+                .boxed(),
         }
     }
 
-    /// Run forever: Scrape the metrics registry once per interval, telling the coordinator to
-    /// insert the values and meta-info in internal tables.
-    pub fn run(&mut self) {
-        let mut metadata: HashMap<Row, u64> = HashMap::new();
-        loop {
-            thread::sleep(self.interval);
+    /// Scrapes the metrics once, producing a batch of updates that should be
+    /// inserted into the `mz_metrics` table.
+    pub fn scrape_once(&mut self) -> Vec<TimestampedUpdate> {
+        let now = now::system_time();
+        let timestamp = now::to_datetime(now);
 
-            let now = now::system_time();
-            let timestamp = now::to_datetime(now);
+        let metric_fams = self.registry.gather();
 
-            if let Ok(cmd) = self.command_rx.try_recv() {
-                match cmd {
-                    ScraperMessage::Shutdown => return,
-                }
-            }
+        let mut out = vec![];
 
-            let metric_fams = self.registry.gather();
+        let (value_readings, meta_value) =
+            convert_metrics_to_value_rows(timestamp, metric_fams.iter());
+        add_expiring_update(
+            &MZ_PROMETHEUS_READINGS,
+            value_readings,
+            self.retain_for,
+            &mut out,
+        );
 
-            let (value_readings, meta_value) =
-                convert_metrics_to_value_rows(timestamp, metric_fams.iter());
-            self.send_expiring_update(&MZ_PROMETHEUS_READINGS, value_readings);
+        let (histo_readings, meta_histo) =
+            convert_metrics_to_histogram_rows(timestamp, metric_fams.iter());
+        add_expiring_update(
+            &MZ_PROMETHEUS_HISTOGRAMS,
+            histo_readings,
+            self.retain_for,
+            &mut out,
+        );
 
-            let (histo_readings, meta_histo) =
-                convert_metrics_to_histogram_rows(timestamp, metric_fams.iter());
-            self.send_expiring_update(&MZ_PROMETHEUS_HISTOGRAMS, histo_readings);
+        // Find any metric metadata we need to add:
+        let retain_for = self.retain_for;
+        let missing = meta_value
+            .into_iter()
+            .chain(meta_histo.into_iter())
+            .filter(|metric| {
+                self.metadata
+                    .insert(metric.clone(), now + retain_for)
+                    .is_none()
+            });
+        add_metadata_update(missing, 1, retain_for, &mut out);
 
-            // Find any metric metadata we need to add:
-            let missing = meta_value
-                .into_iter()
-                .chain(meta_histo.into_iter())
-                .filter(|metric| {
-                    metadata
-                        .insert(metric.clone(), now + self.retain_for)
-                        .is_none()
-                });
-            self.send_metadata_update(missing, 1);
+        // Expire any that can now go (I would love HashMap.drain_filter here):
+        add_metadata_update(
+            self.metadata
+                .iter()
+                .filter(|(_, &retention)| retention <= now)
+                .map(|(row, _)| row)
+                .cloned(),
+            -1,
+            retain_for,
+            &mut out,
+        );
+        self.metadata.retain(|_, &mut retention| retention > now);
 
-            // Expire any that can now go (I would love HashMap.drain_filter here):
-            self.send_metadata_update(
-                metadata
-                    .iter()
-                    .filter(|(_, &retention)| retention <= now)
-                    .map(|(row, _)| row)
-                    .cloned(),
-                -1,
-            );
-            metadata.retain(|_, &mut retention| retention > now);
-        }
-    }
-
-    fn send_expiring_update(&self, table: &BuiltinTable, updates: Vec<Row>) {
-        // TODO: Make this send both records in the same message so we can
-        // persist them atomically. Otherwise, we may end up with permanent
-        // orphans if a restart/crash happens at the wrong time.
-        let id = table.id;
-        self.internal_tx
-            .send(Message::InsertBuiltinTableUpdates(TimestampedUpdate {
-                updates: updates
-                    .iter()
-                    .cloned()
-                    .map(|row| BuiltinTableUpdate { id, row, diff: 1 })
-                    .collect(),
-                timestamp_offset: 0,
-            }))
-            .expect("Sending positive metric reading messages");
-        self.internal_tx
-            .send(Message::InsertBuiltinTableUpdates(TimestampedUpdate {
-                updates: updates
-                    .iter()
-                    .cloned()
-                    .map(|row| BuiltinTableUpdate { id, row, diff: -1 })
-                    .collect(),
-                timestamp_offset: self.retain_for,
-            }))
-            .expect("Sending metric reading retraction messages");
-    }
-
-    fn send_metadata_update<I: IntoIterator<Item = Row>>(&self, updates: I, diff: Diff) {
-        let id = MZ_PROMETHEUS_METRICS.id;
-        self.internal_tx
-            .send(Message::InsertBuiltinTableUpdates(TimestampedUpdate {
-                updates: updates
-                    .into_iter()
-                    .map(|row| BuiltinTableUpdate { id, row, diff })
-                    .collect(),
-                timestamp_offset: self.retain_for,
-            }))
-            .expect("Sending metric metadata message");
+        out
     }
 }


### PR DESCRIPTION
Make the coordinator's Prometheus metric scraper an async task rather
than a thread. This way it can be hosted on Tokio's thread pool and is
slightly more resource efficient; it's also much easier to abort tasks
than threads.

The reason the scraper was its own thread is because it was modeled
after the timestamper thread... which was a flawed example to copy.
Getting rid of the timestamper thread is a separate task, but at least
now the scraper is an example of a coord task that is doing it "right".