### PR TITLE
Avoid cross joins by converting reduced filter expressions into join equivalences

### DIFF
--- a/src/transform/tests/testdata/predicate-pushdown
+++ b/src/transform/tests/testdata/predicate-pushdown
@@ -122,3 +122,101 @@ build apply=PredicatePushdown
 | | implementation = Unimplemented
 ----
 ----
+
+# extract_equal_or_both_null
+
+build apply=PredicatePushdown
+(filter
+  (join
+    [(get x)
+     (get x)]
+    [])
+  [(call_binary or
+     (call_binary and (call_unary is_null #0) (call_unary is_null #2))
+     (call_binary eq #0 (call_binary add_int_64 #2 1))
+    )])
+----
+----
+%0 =
+| Get x (u0)
+
+%1 =
+| Get x (u0)
+
+%2 =
+| Join %0 %1 (= #0 (#2 + 1))
+| | implementation = Unimplemented
+----
+----
+
+build apply=PredicatePushdown
+(filter
+  (join
+    [(get x)
+     (get x)]
+    [])
+  [(call_binary or
+     (call_binary and (call_unary is_null #0) (call_unary is_null (call_binary add_int_64 #2 1)))
+     (call_binary eq #0 (call_binary add_int_64 #2 1))
+    )])
+----
+----
+%0 =
+| Get x (u0)
+
+%1 =
+| Get x (u0)
+
+%2 =
+| Join %0 %1 (= #0 (#2 + 1))
+| | implementation = Unimplemented
+----
+----
+
+build apply=PredicatePushdown
+(filter
+  (join
+    [(get x)
+     (get x)]
+    [])
+  [(call_binary or
+     (call_binary and (call_unary is_null #0) (call_binary and (call_unary is_null #2) (call_unary is_null #0)))
+     (call_binary eq #0 #2)
+    )])
+----
+----
+%0 =
+| Get x (u0)
+
+%1 =
+| Get x (u0)
+
+%2 =
+| Join %0 %1 (= #0 #2)
+| | implementation = Unimplemented
+----
+----
+
+build apply=PredicatePushdown
+(filter
+  (join
+    [(get x)
+     (get x)]
+    [])
+  [(call_binary or
+     (call_binary and (call_unary is_null #0) (call_binary and (call_unary is_null #2) (call_unary is_null #0)))
+     (call_binary eq #0 (call_binary add_int_64 #2 1))
+    )])
+----
+----
+%0 =
+| Get x (u0)
+
+%1 =
+| Get x (u0)
+
+%2 =
+| Join %0 %1 (= #0 (#2 + 1))
+| | implementation = Unimplemented
+----
+----

--- a/test/sqllogictest/transform/predicate_pushdown.slt
+++ b/test/sqllogictest/transform/predicate_pushdown.slt
@@ -159,3 +159,58 @@ SELECT * FROM t1, t2 WHERE t1.f1 = t2.f1 AND t1.f2 = t2.f2 AND t1.f1 + t2.f2 = t
 | Project (#0, #1, #0, #1)
 
 EOF
+
+# #7684 avoidable cross joins
+query T multiline
+EXPLAIN
+select * from t1, t2 where t1.f1 = t2.f1 + 1 or (t1.f1 is null and t2.f1 is null);
+----
+%0 =
+| Get materialize.public.t1 (u5)
+| ArrangeBy (#0)
+
+%1 =
+| Get materialize.public.t2 (u7)
+
+%2 =
+| Join %0 %1 (= #0 (#2 + 1))
+| | implementation = Differential %1 %0.(#0)
+| | demand = (#0..#3)
+
+EOF
+
+query T multiline
+EXPLAIN
+select * from t1, t2 where t1.f1 = t2.f1 + 1 or (t1.f1 is null and (t2.f1 + 1) is null);
+----
+%0 =
+| Get materialize.public.t1 (u5)
+| ArrangeBy (#0)
+
+%1 =
+| Get materialize.public.t2 (u7)
+
+%2 =
+| Join %0 %1 (= #0 (#2 + 1))
+| | implementation = Differential %1 %0.(#0)
+| | demand = (#0..#3)
+
+EOF
+
+query T multiline
+EXPLAIN
+select * from t1, t2 where t2.f1 = t1.f1 + 1 or (t1.f1 is null and (t2.f1 + 1) is null);
+----
+%0 =
+| Get materialize.public.t1 (u5)
+| ArrangeBy ((#0 + 1))
+
+%1 =
+| Get materialize.public.t2 (u7)
+
+%2 =
+| Join %0 %1 (= #2 (#0 + 1))
+| | implementation = Differential %1 %0.((#0 + 1))
+| | demand = (#0..#3)
+
+EOF

--- a/test/sqllogictest/transform/predicate_pushdown.slt
+++ b/test/sqllogictest/transform/predicate_pushdown.slt
@@ -214,3 +214,21 @@ select * from t1, t2 where t2.f1 = t1.f1 + 1 or (t1.f1 is null and (t2.f1 + 1) i
 | | demand = (#0..#3)
 
 EOF
+
+query T multiline
+EXPLAIN
+select * from t1, t2 where t2.f1 = t1.f1 + 1 or (t1.f1 is null and ((t2.f1 + 1) is null and t1.f1 is null));
+----
+%0 =
+| Get materialize.public.t1 (u5)
+| ArrangeBy ((#0 + 1))
+
+%1 =
+| Get materialize.public.t2 (u7)
+
+%2 =
+| Join %0 %1 (= #2 (#0 + 1))
+| | implementation = Differential %1 %0.((#0 + 1))
+| | demand = (#0..#3)
+
+EOF


### PR DESCRIPTION
Fixes #7684.