### PR TITLE
Reduce the amount of duplicate code in per-dataflow-worker metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,6 +803,8 @@ dependencies = [
  "dec",
  "differential-dataflow",
  "dogsdogsdogs",
+ "enum-iterator",
+ "enum-kinds",
  "expr",
  "flate2",
  "futures",
@@ -814,6 +816,7 @@ dependencies = [
  "lazy_static",
  "log",
  "mz-avro",
+ "num_enum",
  "ore",
  "pdqselect",
  "persist",
@@ -832,6 +835,7 @@ dependencies = [
  "rusoto_sqs",
  "serde",
  "serde_json",
+ "serde_variant",
  "tempfile",
  "timely",
  "tokio",
@@ -2429,9 +2433,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5adf0198d427ee515335639f275e806ca01acf9f07d7cf14bb36a10532a6169"
+checksum = "ee2c8fd66061a707503d515639b8af10fd3807a5b5ee6959f7ff1bd303634bd5"
 dependencies = [
  "derivative",
  "num_enum_derive",
@@ -2439,9 +2443,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1def5a3f69d4707d8a040b12785b98029a39e8c610ae685c7f6265669767482"
+checksum = "474fd1d096da3ad17084694eebed40ba09c4a36c5255cd772bd8b98859cc562e"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -3823,6 +3827,15 @@ dependencies = [
  "form_urlencoded",
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_variant"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60c53d80400dbb87d4b422c3396145fa5736b13ebfed5c62105b7dc8d1cba5cf"
+dependencies = [
  "serde",
 ]
 

--- a/src/dataflow/Cargo.toml
+++ b/src/dataflow/Cargo.toml
@@ -19,6 +19,8 @@ dataflow-types = { path = "../dataflow-types" }
 dec = { version = "0.4.5", features = ["serde"] }
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 dogsdogsdogs = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
+enum-iterator = "0.7.0"
+enum-kinds = "0.5.0"
 expr = { path = "../expr" }
 flate2 = "1.0.20"
 futures = "0.3.16"
@@ -30,6 +32,7 @@ kafka-util = { path = "../kafka-util" }
 lazy_static = "1.4.0"
 log = "0.4.13"
 mz-avro = { path = "../avro", features = ["snappy"] }
+num_enum = "0.5.3"
 ore = { path = "../ore" }
 pdqselect = "0.1.0"
 persist = { path = "../persist" }
@@ -48,6 +51,7 @@ rusoto_s3 = "0.47.0"
 rusoto_sqs = "0.47.0"
 serde = { version = "1.0.127", features = ["derive"] }
 serde_json = "1.0.66"
+serde_variant = "0.1.0"
 tempfile = "3.2.0"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 tokio = { version = "1.9.0", features = ["fs", "rt", "sync"] }

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -18,6 +18,9 @@ use differential_dataflow::operators::arrange::arrangement::Arrange;
 use differential_dataflow::trace::cursor::Cursor;
 use differential_dataflow::trace::TraceReader;
 use differential_dataflow::Collection;
+use enum_iterator::IntoEnumIterator;
+use enum_kinds::EnumKind;
+use num_enum::IntoPrimitive;
 use ore::metrics::MetricsRegistry;
 use serde::{Deserialize, Serialize};
 use timely::communication::initialize::WorkerGuards;
@@ -60,7 +63,14 @@ mod metrics;
 static TS_BINDING_FEEDBACK_INTERVAL_MS: u128 = 1_000;
 
 /// Explicit instructions for timely dataflow workers.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, EnumKind)]
+#[enum_kind(
+    CommandKind,
+    derive(Serialize, IntoPrimitive, IntoEnumIterator),
+    repr(usize),
+    serde(rename_all = "snake_case"),
+    doc = "The kind of command that was received"
+)]
 pub enum Command {
     /// Create a sequence of dataflows.
     ///


### PR DESCRIPTION
This PR reduces the number of duplicate names you have to type if you introduce a `Command` to the dataflow server, and reduces the number of metrics that are present but never get updated. We do this by making the cache/counters live on an array and index that array by the Command kind that was processed.