### PR TITLE
*: reduce all "deny" and "forbid" lints to "warn"

### DIFF
--- a/demo/billing/src/main.rs
+++ b/demo/billing/src/main.rs
@@ -16,7 +16,7 @@
 //! Further details can be found on the Materialize docs:
 //! <https://materialize.com/docs/demos/microservice/>
 
-#![deny(missing_debug_implementations, missing_docs)]
+#![warn(missing_debug_implementations, missing_docs)]
 
 use std::process;
 use std::sync::Arc;

--- a/src/aws-util/src/lib.rs
+++ b/src/aws-util/src/lib.rs
@@ -9,7 +9,7 @@
 
 //! Internal AWS utility library for Materialize.
 
-#![deny(missing_docs, missing_debug_implementations)]
+#![warn(missing_docs, missing_debug_implementations)]
 
 pub mod aws;
 pub mod client;

--- a/src/ccsr/src/lib.rs
+++ b/src/ccsr/src/lib.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-#![deny(missing_debug_implementations)]
+#![warn(missing_debug_implementations)]
 
 //! The `ccsr` crate provides an ergonomic API client for Confluent-compatible
 //! schema registries (CCSRs).

--- a/src/coord/src/session.rs
+++ b/src/coord/src/session.rs
@@ -9,7 +9,7 @@
 
 //! Per-connection configuration parameters and state.
 
-#![forbid(missing_docs)]
+#![warn(missing_docs)]
 
 use std::collections::HashMap;
 use std::mem;

--- a/src/dataflow/src/lib.rs
+++ b/src/dataflow/src/lib.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-#![forbid(missing_docs)]
+#![warn(missing_docs)]
 
 //! Driver for timely/differential dataflow.
 

--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -9,7 +9,7 @@
 
 //! Core expression language.
 
-#![deny(missing_debug_implementations)]
+#![warn(missing_debug_implementations)]
 
 use std::fmt;
 use std::ops::Deref;

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-#![deny(missing_docs)]
+#![warn(missing_docs)]
 
 use std::cmp::Ordering;
 use std::collections::HashSet;

--- a/src/http-proxy/src/lib.rs
+++ b/src/http-proxy/src/lib.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![deny(missing_docs)]
+#![warn(missing_docs)]
 #![cfg_attr(nightly_doc_features, feature(doc_cfg))]
 
 //! [<img src="https://materialize.com/wp-content/uploads/2020/01/materialize_logo_primary.png" width=180 align=right>](https://materialize.com)

--- a/src/interchange/src/lib.rs
+++ b/src/interchange/src/lib.rs
@@ -9,7 +9,7 @@
 
 //! Translations for various data serialization formats.
 
-#![deny(missing_debug_implementations)]
+#![warn(missing_debug_implementations)]
 
 pub mod avro;
 pub mod encode;

--- a/src/kafka-util/src/lib.rs
+++ b/src/kafka-util/src/lib.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-#![deny(missing_docs)]
+#![warn(missing_docs)]
 
 //! Utilities for working with Kafka.
 

--- a/src/metabase/src/lib.rs
+++ b/src/metabase/src/lib.rs
@@ -18,7 +18,7 @@
 //!
 //! [Metabase]: https://metabase.com
 
-#![deny(missing_debug_implementations)]
+#![warn(missing_debug_implementations)]
 
 use std::fmt;
 use std::time::Duration;

--- a/src/ore/src/lib.rs
+++ b/src/ore/src/lib.rs
@@ -19,7 +19,7 @@
 //! Modules are included in this crate when they are broadly useful but too
 //! small to warrant their own crate.
 
-#![deny(missing_docs, missing_debug_implementations)]
+#![warn(missing_docs, missing_debug_implementations)]
 
 #[cfg(feature = "test")]
 pub mod assert;

--- a/src/pgrepr/src/lib.rs
+++ b/src/pgrepr/src/lib.rs
@@ -16,8 +16,8 @@
 //! `Value`s are easily converted to and from [`repr::Datum`]s. See, for
 //! example, the [`values_from_row`] function.
 
-#![deny(clippy::as_conversions)]
-#![deny(missing_docs)]
+#![warn(clippy::as_conversions)]
+#![warn(missing_docs)]
 
 mod format;
 mod types;

--- a/src/pgwire/src/lib.rs
+++ b/src/pgwire/src/lib.rs
@@ -20,7 +20,7 @@
 //!   * [CockroachDB pgwire implementation](https://github.com/cockroachdb/cockroach/tree/master/pkg/sql/pgwire)
 //!   * ["Postgres on the wire" PGCon talk](https://www.pgcon.org/2014/schedule/attachments/330_postgres-for-the-wire.pdf)
 
-#![deny(clippy::as_conversions)]
+#![warn(clippy::as_conversions)]
 
 mod codec;
 mod message;

--- a/src/protoc/src/lib.rs
+++ b/src/protoc/src/lib.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-#![forbid(missing_docs)]
+#![warn(missing_docs)]
 
 //! A pure Rust protobuf compiler.
 //!

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -20,7 +20,7 @@
 //! * [`RelationDesc`] describes what it takes to extend a `Row` vertically, and
 //!   corresponds most closely to what is returned from querying our dataflows
 
-#![deny(missing_debug_implementations)]
+#![warn(missing_debug_implementations)]
 
 mod relation;
 mod row;

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-#![forbid(missing_docs)]
+#![warn(missing_docs)]
 
 //! Catalog abstraction layer.
 

--- a/src/sql/src/lib.rs
+++ b/src/sql/src/lib.rs
@@ -63,7 +63,7 @@
 //!
 //! [`Plan`]: crate::plan::Plan
 
-#![deny(missing_debug_implementations)]
+#![warn(missing_debug_implementations)]
 
 macro_rules! unsupported {
     ($feature:expr) => {

--- a/src/testdrive/src/lib.rs
+++ b/src/testdrive/src/lib.rs
@@ -9,7 +9,7 @@
 
 //! Integration test driver for Materialize.
 
-#![deny(missing_docs)]
+#![warn(missing_docs)]
 
 use std::fs::File;
 use std::io::{self, Read};

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -18,8 +18,8 @@
 //! The crate also contains the beginnings of whole-dataflow optimization,
 //! which uses the same analyses but spanning multiple dataflow elements.
 
-#![forbid(missing_docs)]
-#![deny(missing_debug_implementations)]
+#![warn(missing_docs)]
+#![warn(missing_debug_implementations)]
 
 use std::collections::HashMap;
 use std::error::Error;

--- a/test/performance/perf-upsert/src/main.rs
+++ b/test/performance/perf-upsert/src/main.rs
@@ -9,7 +9,7 @@
 
 //! Performance test for Materialize Upsert sources
 
-#![deny(missing_debug_implementations, missing_docs)]
+#![warn(missing_debug_implementations, missing_docs)]
 
 use std::process;
 use std::sync::Arc;

--- a/test/smith/src/main.rs
+++ b/test/smith/src/main.rs
@@ -10,7 +10,7 @@
 //! Fuzz test Materialize using the Smith fuzzer
 //! available at <https://api.jibson.dev/smith>
 
-#![deny(missing_debug_implementations, missing_docs)]
+#![warn(missing_debug_implementations, missing_docs)]
 
 use std::process;
 


### PR DESCRIPTION
Lints at the deny/forbid level can be very frustrating when developing,
because you're forced to comply with the lint even when you're still
prototyping, just to get your code to compile.

This commit downgrades all these lints to "warn", to optimize for the
development experience. In CI, these lints are still enforced at the
"deny" level by our Clippy configuration, which upgrades all warnings to
hard errors.

The one glitch here is that `forbid` used to prevent submodules from
re-enabling the forbidden lint. I propose that we solve this socially,
by making it taboo to add `#![allow(missing_docs)]` unless you've gotten
buy-in from the overall owner of that area of the codebase.