### PR TITLE
coord: enable select sys table persistence behind a flag (default off)

### DIFF
--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -833,9 +833,10 @@ lazy_static! {
                 .with_key(vec![0, 1, 2]),
         id: GlobalId::System(4043),
         index_id: GlobalId::System(4044),
-        // TODO: Enable this once persistence compaction is moved into its own
-        // thread.
-        persistent: false,
+        // Note that the `system_table_enabled` field of PersistConfig (hooked
+        // up to --persistent-system-tables) also has to be true for this to be
+        // persisted.
+        persistent: true,
     };
     pub static ref MZ_PROMETHEUS_METRICS: BuiltinTable = BuiltinTable {
         name: "mz_metrics_meta",
@@ -861,9 +862,10 @@ lazy_static! {
                 .with_key(vec![0, 1, 2]),
         id: GlobalId::System(4047),
         index_id: GlobalId::System(4048),
-        // TODO: Enable this once persistence compaction is moved into its own
-        // thread.
-        persistent: false,
+        // Note that the `system_table_enabled` field of PersistConfig (hooked
+        // up to --persistent-system-tables) also has to be true for this to be
+        // persisted.
+        persistent: true,
     };
 }
 

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1657,7 +1657,7 @@ impl Coordinator {
         index_depends_on.push(table_id);
         let persist = self
             .catalog
-            .persist_details(table_id)
+            .persist_details(table_id, &name)
             .map_err(|err| anyhow!("{}", err))?;
         let table = catalog::Table {
             create_sql: table.create_sql,

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -110,9 +110,13 @@ struct Args {
     )]
     third_party_metrics_listen_addr: Option<SocketAddr>,
 
-    /// Enable persistent tables. Has to be used with --experimental.
+    /// Enable persistent user tables. Has to be used with --experimental.
     #[structopt(long, hidden = true)]
-    persistent_tables: bool,
+    persistent_user_tables: bool,
+
+    /// Enable persistent system tables. Has to be used with --experimental.
+    #[structopt(long, hidden = true)]
+    persistent_system_tables: bool,
 
     // === Timely worker configuration. ===
     /// Number of dataflow worker threads.
@@ -603,10 +607,17 @@ swap: {swap_total}KB total, {swap_used}KB used{swap_limit}",
 
     // Configure persistence core.
     let persist_config = {
-        let user_table_enabled = if args.experimental && args.persistent_tables {
+        let user_table_enabled = if args.experimental && args.persistent_user_tables {
             true
-        } else if args.persistent_tables {
-            bail!("cannot specify --persistent-tables without --experimental");
+        } else if args.persistent_user_tables {
+            bail!("cannot specify --persistent-user-tables without --experimental");
+        } else {
+            false
+        };
+        let system_table_enabled = if args.experimental && args.persistent_system_tables {
+            true
+        } else if args.persistent_system_tables {
+            bail!("cannot specify --persistent-system-tables without --experimental");
         } else {
             false
         };
@@ -623,6 +634,7 @@ swap: {swap_total}KB total, {swap_used}KB used{swap_limit}",
             buffer_path: data_directory.join("persist").join("buffer"),
             blob_path: data_directory.join("persist").join("blob"),
             user_table_enabled,
+            system_table_enabled,
             lock_info,
         }
     };


### PR DESCRIPTION
Rename --persistent_tables to --persistent_user_tables and add
--persistent_system_tables. The latter currently defaults to off and
when on, only opts in the system tables that have self-elected to be
persisted (mz_metrics and mz_metrics_histogram). Once we've stabilized
persistence, we'll default --persistent_system_tables to on, but keep
the flag as a CYA.

Along the way, fix a bug where turning on persisted system tables also
created an unnecessary persistent stream for all system views.

Also improve the persistent stream naming, which would have helped debug
what was going on with this view bug.