### PR TITLE
Framework for defining functions as individual units

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1320,6 +1320,7 @@ dependencies = [
  "num_enum",
  "ordered-float",
  "ore",
+ "paste",
  "pdqselect",
  "pgrepr",
  "proc-macro2",

--- a/src/expr-test-util/src/lib.rs
+++ b/src/expr-test-util/src/lib.rs
@@ -14,6 +14,7 @@ use proc_macro2::TokenTree;
 use serde_json::Value;
 
 use expr::explain::ViewExplanation;
+use expr::func::Not;
 use expr::*;
 use lowertest::*;
 use ore::result::ResultExt;
@@ -35,7 +36,7 @@ gen_reflect_info_func!(
         MirRelationExpr,
         JoinImplementation
     ],
-    [AggregateExpr, ColumnOrder, ColumnType, RelationType]
+    [AggregateExpr, ColumnOrder, ColumnType, RelationType, Not]
 );
 
 lazy_static! {

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -33,6 +33,7 @@ serde_json = "1.0.67"
 sha-1 = "0.9.8"
 sha2 = "0.9.6"
 uncased = "0.9.6"
+paste = "1"
 
 [dev-dependencies]
 datadriven = "0.6.0"

--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -40,7 +40,7 @@ pub use relation::{
     compare_columns, AggregateExpr, ColumnOrder, IdGen, JoinImplementation, MirRelationExpr,
     RowSetFinishing,
 };
-pub use scalar::func::{BinaryFunc, NullaryFunc, UnaryFunc, VariadicFunc};
+pub use scalar::func::{self, BinaryFunc, NullaryFunc, UnaryFunc, VariadicFunc};
 pub use scalar::{like_pattern, EvalError, MirScalarExpr};
 
 /// A [`MirRelationExpr`] that claims to have been optimized, e.g., by an

--- a/src/expr/src/relation/canonicalize.rs
+++ b/src/expr/src/relation/canonicalize.rs
@@ -183,7 +183,7 @@ pub fn canonicalize_predicates(predicates: &mut Vec<MirScalarExpr>, input_type: 
         // Otherwise, replace every instance of `p` in every other predicate
         // with `true`.
         if let MirScalarExpr::CallUnary {
-            func: UnaryFunc::Not,
+            func: UnaryFunc::Not(func::Not),
             expr,
         } = &predicate_to_apply
         {
@@ -246,7 +246,7 @@ fn replace_subexpr_and_reduce(
                     {
                         if negation == *l_func && l_expr1 == r_expr1 && l_expr2 == r_expr2 {
                             *e = MirScalarExpr::CallUnary {
-                                func: UnaryFunc::Not,
+                                func: UnaryFunc::Not(func::Not),
                                 expr: Box::new(replace_with.clone()),
                             };
                             changed = true;
@@ -265,7 +265,7 @@ fn replace_subexpr_and_reduce(
 /// Returns the inner operand if the given predicate is an IS NOT NULL expression.
 fn is_not_null(predicate: &MirScalarExpr) -> Option<MirScalarExpr> {
     if let MirScalarExpr::CallUnary {
-        func: UnaryFunc::Not,
+        func: UnaryFunc::Not(func::Not),
         expr,
     } = &predicate
     {

--- a/src/expr/src/relation/canonicalize.rs
+++ b/src/expr/src/relation/canonicalize.rs
@@ -10,7 +10,7 @@
 //! Utility functions to transform parts of a single `MirRelationExpr`
 //! into canonical form.
 
-use crate::{BinaryFunc, MirScalarExpr, UnaryFunc};
+use crate::{func, BinaryFunc, MirScalarExpr, UnaryFunc};
 use repr::{Datum, RelationType, ScalarType};
 
 /// Canonicalize equivalence classes of a join.

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -411,7 +411,7 @@ impl MirRelationExpr {
                     predicate.non_null_requirements(&mut nonnull_required_columns);
                     // Test for explicit checks that a column is non-null.
                     if let MirScalarExpr::CallUnary {
-                        func: UnaryFunc::Not,
+                        func: UnaryFunc::Not(scalar_func::Not),
                         expr,
                     } = predicate
                     {

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -23,7 +23,8 @@ use repr::{ColumnType, Datum, Diff, RelationType, Row};
 use self::func::{AggregateFunc, TableFunc};
 use crate::explain::ViewExplanation;
 use crate::{
-    DummyHumanizer, EvalError, ExprHumanizer, GlobalId, Id, LocalId, MirScalarExpr, UnaryFunc,
+    func as scalar_func, DummyHumanizer, EvalError, ExprHumanizer, GlobalId, Id, LocalId,
+    MirScalarExpr, UnaryFunc,
 };
 
 pub mod canonicalize;

--- a/src/expr/src/scalar/func/impls.rs
+++ b/src/expr/src/scalar/func/impls.rs
@@ -1,0 +1,8 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.

--- a/src/expr/src/scalar/func/impls/not.rs
+++ b/src/expr/src/scalar/func/impls/not.rs
@@ -7,6 +7,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-mod not;
-
-pub use not::Not;
+sqlfunc!(
+    #[sqlname = "!"]
+    fn not(a: bool) -> bool {
+        !a
+    }
+);

--- a/src/expr/src/scalar/func/macros.rs
+++ b/src/expr/src/scalar/func/macros.rs
@@ -1,0 +1,280 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+/// This macro generates a definition of a UnaryFunc variant and automatically implements
+/// `UnaryFuncTrait` for it based on the provided function.
+///
+/// The macro can be applied to unary functions that adhere to the following constraints:
+/// * The input is eagerly evaluatated
+/// * The function doesn't preserve uniquencess
+///
+/// Functions that don't adhere to the above constraints need to have their UnaryFuncTrait
+/// implementation defined manually and have full control over their eval phase and other
+/// characteristics.
+///
+/// The macro implements a set of elision rules for automatically determining whether a given
+/// function propagates or introduces nulls. The rules are summarized in the following table:
+///
+/// Input type  | Output type  | Propagates NULL  | Introduces NULL | Preserves uniqueness
+/// ------------+--------------+------------------+-----------------+---------------------
+/// `Option<T>` | `Option<T>`  | Not elided       | Not elided      | Not elided
+/// `Option<T>` | `T`          | `false`          | `false`         | false
+/// `T`         | `Option<T>`  | `true`           | `true`          | false
+/// `T`         | `T`          | `true`           | `false`         | false
+///
+/// For the non elided case the attributes `sqlname`, `propagates_nulls`, `introduces_nulls`, and
+/// `preserves_uniqueness` must be specified:
+///
+/// ```
+/// sqlfunc!(
+///     #[sqlname = "foo"]
+///     #[propagates_nulls = false]
+///     #[introduces_nulls = true]
+///     #[preserves_uniqueness = true]
+///     fn foo(a: Option<bool>) -> Option<bool> {
+///         unimplemented!()
+///     }
+/// ```
+///
+///
+/// ```
+/// /// This SQL function will be named "booltoi32". It propagates nulls and doesn't introduce them
+/// sqlfunc!(
+///     fn booltoi32(a: bool) -> i32 {
+///         a as i32
+///     }
+/// );
+/// ```
+///
+/// A custom name can be given as the first parameter to the macro:
+/// ```
+/// /// This SQL function will be named "isnull". It doesn't propagate nor introduce nulls
+/// sqlfunc!(
+///     #[sqlname = "isnull"]
+///     fn is_null(a: Option<i32>) -> bool {
+///         a.is_none()
+///     }
+/// );
+/// ```
+macro_rules! sqlfunc {
+    (
+        #[sqlname = $name:expr]
+        #[propagates_nulls = $propagates_nulls:literal]
+        #[introduces_nulls = $introduces_nulls:literal]
+        #[preserves_uniqueness = $preserves_uniqueness:literal]
+        fn $fn_name:ident($param_name:ident: Option<$param_ty:ty>) -> Option<$ret_ty:ty>
+            $body:block
+    ) => {
+        use std::convert::TryInto;
+        use std::fmt;
+
+        use paste::paste;
+        use repr::{ColumnType, Datum, FromTy, RowArena, ScalarType};
+        use serde::{Deserialize, Serialize};
+        use lowertest::MzStructReflect;
+
+        use crate::scalar::func::UnaryFuncTrait;
+        use crate::{EvalError, MirScalarExpr};
+
+        paste! {
+            #[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzStructReflect)]
+            pub struct [<$fn_name:camel>];
+
+            impl UnaryFuncTrait for [<$fn_name:camel>] {
+                fn eval<'a>(
+                    &'a self,
+                    datums: &[Datum<'a>],
+                    temp_storage: &'a RowArena,
+                    a: &'a MirScalarExpr,
+                ) -> Result<Datum<'a>, EvalError> {
+                    // Define the provided function privately
+                    fn $fn_name($param_name: Option<$param_ty>) -> Option<$ret_ty> {
+                        $body
+                    }
+
+                    // Evaluate the argument and convert it to the concrete type that the
+                    // implementation expects. This cannot fail here because the expression is
+                    // already typechecked.
+                    let a: Option<$param_ty> = a
+                        .eval(datums, temp_storage)?
+                        .try_into()
+                        .expect("expression already typechecked");
+
+                    Ok($fn_name(a).into())
+                }
+
+                fn output_type(&self, input_type: ColumnType) -> ColumnType {
+                    // Use the FromTy trait to convert the Rust type into our runtime type
+                    // representation
+                    <ScalarType as FromTy<$ret_ty>>::from_ty()
+                        .nullable($propagates_nulls && input_type.nullable || $introduces_nulls)
+                }
+
+                fn propagates_nulls(&self) -> bool {
+                    $propagates_nulls
+                }
+
+                fn introduces_nulls(&self) -> bool {
+                    $introduces_nulls
+                }
+
+                fn preserves_uniqueness(&self) -> bool {
+                    $preserves_uniqueness
+                }
+            }
+
+            impl From<[<$fn_name:camel>]> for crate::UnaryFunc {
+                fn from(variant: [<$fn_name:camel>]) -> Self {
+                    Self::[<$fn_name:camel>](variant)
+                }
+            }
+
+            impl fmt::Display for [<$fn_name:camel>] {
+                fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                    f.write_str($name)
+                }
+            }
+        }
+    };
+
+    // First, expand the function name into an attribute, if it was omitted
+    (
+        fn $fn_name:ident $($tail:tt)*
+    ) => {
+        sqlfunc!(
+            #[sqlname = stringify!($fn_name)]
+            fn $fn_name $($tail)*
+        );
+    };
+
+    // Then, check if omitting the attributes is ok
+    (
+        #[sqlname = $name:expr]
+        fn $fn_name:ident($param_name:ident: Option<$param_ty:ty>) -> Option<$ret_ty:ty>
+            $body:block
+    ) => {
+        compile_error!(
+            "missing `propagates_nulls` and `introduces_nulls` attributes.\n       \
+            These properties cannot be elided when both input and output are optional"
+        );
+    };
+
+    // The function takes optional arguments and returns non optional, therefore it doesn't
+    // propagate nulls
+    (
+        #[sqlname = $name:expr]
+        fn $fn_name:ident($param_name:ident: Option<$param_ty:ty>) -> $ret_ty:ty
+            $body:block
+    ) => {
+        sqlfunc!(
+            #[sqlname = $name]
+            #[propagates_nulls = false]
+            #[introduces_nulls = false]
+            #[preserves_uniqueness = false]
+            fn $fn_name($param_name: Option<$param_ty>) -> Option<$ret_ty> {
+                Some($body)
+            }
+        );
+    };
+
+    // The function takes non-optional arguments and returns optional, therefore it propagates
+    // nulls and introduces nulls too
+    (
+        #[sqlname = $name:expr]
+        fn $fn_name:ident($param_name:ident: $param_ty:ty) -> Option<$ret_ty:ty>
+            $body:block
+    ) => {
+        sqlfunc!(
+            #[sqlname = $name]
+            #[propagates_nulls = true]
+            #[introduces_nulls = true]
+            #[preserves_uniqueness = false]
+            fn $fn_name($param_name: Option<$param_ty>) -> Option<$ret_ty> {
+                let $param_name = $param_name?;
+                $body
+            }
+        );
+    };
+
+    // The function takes non-optional arguments and returns non optional, therefore it propagates
+    // nulls but doesn't introduce them
+    (
+        #[sqlname = $name:expr]
+        fn $fn_name:ident($param_name:ident: $param_ty:ty) -> $ret_ty:ty
+            $body:block
+    ) => {
+        sqlfunc!(
+            #[sqlname = $name]
+            #[propagates_nulls = true]
+            #[introduces_nulls = false]
+            #[preserves_uniqueness = false]
+            fn $fn_name($param_name: Option<$param_ty>) -> Option<$ret_ty> {
+                let $param_name = $param_name?;
+                Some($body)
+            }
+        );
+    };
+}
+
+/// Temporary macro that generates the equivalent of what enum_dispatch will do in the future. We
+/// need this manual macro implementation to delegate to the previous manual implementation for
+/// variants that use the old definitions.
+///
+/// Once everything is handled by this macro we can remove it and replace it with `enum_dispatch`
+macro_rules! derive_unary {
+    ($($name:ident),*) => {
+        impl UnaryFunc {
+            pub fn eval<'a>(
+                &'a self,
+                datums: &[Datum<'a>],
+                temp_storage: &'a RowArena,
+                a: &'a MirScalarExpr,
+            ) -> Result<Datum<'a>, EvalError> {
+                match self {
+                    $(Self::$name(f) => f.eval(datums, temp_storage, a),)*
+                    _ => self.eval_manual(datums, temp_storage, a),
+                }
+            }
+
+            pub fn output_type(&self, input_type: ColumnType) -> ColumnType {
+                match self {
+                    $(Self::$name(f) => f.output_type(input_type),)*
+                    _ => self.output_type_manual(input_type),
+                }
+            }
+            pub fn propagates_nulls(&self) -> bool {
+                match self {
+                    $(Self::$name(f) => f.propagates_nulls(),)*
+                    _ => self.propagates_nulls_manual(),
+                }
+            }
+            pub fn introduces_nulls(&self) -> bool {
+                match self {
+                    $(Self::$name(f) => f.introduces_nulls(),)*
+                    _ => self.introduces_nulls_manual(),
+                }
+            }
+            pub fn preserves_uniqueness(&self) -> bool {
+                match self {
+                    $(Self::$name(f) => f.preserves_uniqueness(),)*
+                    _ => self.preserves_uniqueness_manual(),
+                }
+            }
+        }
+
+        impl fmt::Display for UnaryFunc {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                match self {
+                    $(Self::$name(func) => func.fmt(f),)*
+                    _ => self.fmt_manual(f),
+                }
+            }
+        }
+    }
+}

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -605,13 +605,13 @@ impl MirScalarExpr {
                                 (Some(Ok(Datum::False)), _) => {
                                     *e = cond
                                         .take()
-                                        .call_unary(UnaryFunc::Not)
+                                        .call_unary(UnaryFunc::Not(func::Not))
                                         .call_binary(els.take(), BinaryFunc::And);
                                 }
                                 (_, Some(Ok(Datum::True))) => {
                                     *e = cond
                                         .take()
-                                        .call_unary(UnaryFunc::Not)
+                                        .call_unary(UnaryFunc::Not(func::Not))
                                         .call_binary(then.take(), BinaryFunc::Or);
                                 }
                                 (_, Some(Ok(Datum::False))) => {
@@ -630,7 +630,7 @@ impl MirScalarExpr {
                 match e {
                     // 2) Push down not expressions
                     MirScalarExpr::CallUnary { func, expr } => {
-                        if *func == UnaryFunc::Not {
+                        if *func == UnaryFunc::Not(func::Not) {
                             match &mut **expr {
                                 MirScalarExpr::CallBinary { expr1, expr2, func } => {
                                     // Transforms `NOT(a <op> b)` to `a negate(<op>) b`
@@ -648,7 +648,7 @@ impl MirScalarExpr {
                                 // Two negates cancel each other out.
                                 MirScalarExpr::CallUnary {
                                     expr: inner_expr,
-                                    func: UnaryFunc::Not,
+                                    func: UnaryFunc::Not(func::Not),
                                 } => *e = inner_expr.take(),
                                 _ => {}
                             }
@@ -713,7 +713,7 @@ impl MirScalarExpr {
     fn demorgans(&mut self) {
         if let MirScalarExpr::CallUnary {
             expr: inner,
-            func: UnaryFunc::Not,
+            func: UnaryFunc::Not(func::Not),
         } = self
         {
             if let MirScalarExpr::CallBinary { expr1, expr2, func } = &mut **inner {
@@ -721,11 +721,11 @@ impl MirScalarExpr {
                     BinaryFunc::And => {
                         let inner0 = MirScalarExpr::CallUnary {
                             expr: Box::new(expr1.take()),
-                            func: UnaryFunc::Not,
+                            func: UnaryFunc::Not(func::Not),
                         };
                         let inner1 = MirScalarExpr::CallUnary {
                             expr: Box::new(expr2.take()),
-                            func: UnaryFunc::Not,
+                            func: UnaryFunc::Not(func::Not),
                         };
                         *self = MirScalarExpr::CallBinary {
                             expr1: Box::new(inner0),
@@ -736,11 +736,11 @@ impl MirScalarExpr {
                     BinaryFunc::Or => {
                         let inner0 = MirScalarExpr::CallUnary {
                             expr: Box::new(expr1.take()),
-                            func: UnaryFunc::Not,
+                            func: UnaryFunc::Not(func::Not),
                         };
                         let inner1 = MirScalarExpr::CallUnary {
                             expr: Box::new(expr2.take()),
-                            func: UnaryFunc::Not,
+                            func: UnaryFunc::Not(func::Not),
                         };
                         *self = MirScalarExpr::CallBinary {
                             expr1: Box::new(inner0),

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -34,7 +34,7 @@ pub use relation::{ColumnName, ColumnType, RelationDesc, RelationType};
 pub use row::{
     datum_list_size, datum_size, datums_size, row_size, DatumList, DatumMap, Row, RowArena, RowRef,
 };
-pub use scalar::{Datum, ScalarBaseType, ScalarType};
+pub use scalar::{Datum, FromTy, ScalarBaseType, ScalarType};
 
 // Concrete types used throughout Materialize for the generic parameters in Timely/Differential Dataflow.
 /// System-wide timestamp type.

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -104,6 +104,30 @@ pub enum Datum<'a> {
     Null,
 }
 
+impl TryFrom<Datum<'_>> for bool {
+    type Error = ();
+    fn try_from(from: Datum<'_>) -> Result<Self, Self::Error> {
+        match from {
+            Datum::False => Ok(false),
+            Datum::True => Ok(true),
+            _ => Err(()),
+        }
+    }
+}
+
+impl TryFrom<Datum<'_>> for Option<bool> {
+    type Error = ();
+
+    fn try_from(datum: Datum<'_>) -> Result<Self, Self::Error> {
+        match datum {
+            Datum::Null => Ok(None),
+            Datum::False => Ok(Some(false)),
+            Datum::True => Ok(Some(true)),
+            _ => Err(()),
+        }
+    }
+}
+
 impl<'a> Datum<'a> {
     /// Reports whether this datum is null (i.e., is [`Datum::Null`]).
     pub fn is_null(&self) -> bool {
@@ -456,8 +480,8 @@ impl<'a> Datum<'a> {
     }
 }
 
-impl From<bool> for Datum<'static> {
-    fn from(b: bool) -> Datum<'static> {
+impl<'a> From<bool> for Datum<'a> {
+    fn from(b: bool) -> Datum<'a> {
         if b {
             Datum::True
         } else {
@@ -785,6 +809,29 @@ pub enum ScalarType {
     },
     /// A PostgreSQL function name.
     RegProc,
+}
+
+/// [FromTy] is a utility trait for [ScalarType] that defines a mapping between a Rust type T and
+/// its runtime representation as a ScalarType. Not all ScalarType variants have a 1-1 mapping to a
+/// Rust type but for those variants can simply be ignored.
+///
+/// The main usecase of FromTy is to use rustc's inference to lift type information from compile
+/// time to runtime, a primitive form of reflection. See the implementation of the `fn_unary` macro
+/// in `expr` for an example use of this trait.
+pub trait FromTy<T> {
+    fn from_ty() -> Self;
+}
+
+impl FromTy<bool> for ScalarType {
+    fn from_ty() -> Self {
+        Self::Bool
+    }
+}
+
+impl FromTy<String> for ScalarType {
+    fn from_ty() -> Self {
+        Self::String
+    }
 }
 
 impl<'a> ScalarType {

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -2304,7 +2304,7 @@ lazy_static! {
                 params!(String, String) => Operation::binary(|_ecx, lhs, rhs| {
                     Ok(lhs
                         .call_binary(rhs, IsLikePatternMatch { case_insensitive: true })
-                        .call_unary(UnaryFunc::Not))
+                        .call_unary(UnaryFunc::Not(func::Not)))
                 }), 1628;
             },
 
@@ -2323,13 +2323,13 @@ lazy_static! {
                 params!(String, String) => Operation::binary(|_ecx, lhs, rhs| {
                     Ok(lhs
                         .call_binary(rhs, IsLikePatternMatch { case_insensitive: false })
-                        .call_unary(UnaryFunc::Not))
+                        .call_unary(UnaryFunc::Not(func::Not)))
                 }), 1210;
                 params!(Char, String) => Operation::binary(|ecx, lhs, rhs| {
                     let length = ecx.scalar_type(&lhs).unwrap_char_varchar_length();
                     Ok(lhs.call_unary(UnaryFunc::PadChar { length })
                         .call_binary(rhs, IsLikePatternMatch { case_insensitive: false })
-                        .call_unary(UnaryFunc::Not)
+                        .call_unary(UnaryFunc::Not(func::Not))
                     )
                 }), 1212;
             },
@@ -2359,13 +2359,13 @@ lazy_static! {
                 params!(String, String) => Operation::binary(|_ecx, lhs, rhs| {
                     Ok(lhs
                         .call_binary(rhs, IsRegexpMatch { case_insensitive: false })
-                        .call_unary(UnaryFunc::Not))
+                        .call_unary(UnaryFunc::Not(func::Not)))
                 }), 642;
                 params!(Char, String) => Operation::binary(|ecx, lhs, rhs| {
                     let length = ecx.scalar_type(&lhs).unwrap_char_varchar_length();
                     Ok(lhs.call_unary(UnaryFunc::PadChar { length })
                         .call_binary(rhs, IsRegexpMatch { case_insensitive: true })
-                        .call_unary(UnaryFunc::Not)
+                        .call_unary(UnaryFunc::Not(func::Not))
                     )
                 }), 1056;
             },
@@ -2373,13 +2373,13 @@ lazy_static! {
                 params!(String, String) => Operation::binary(|_ecx, lhs, rhs| {
                     Ok(lhs
                         .call_binary(rhs, IsRegexpMatch { case_insensitive: true })
-                        .call_unary(UnaryFunc::Not))
+                        .call_unary(UnaryFunc::Not(func::Not)))
                 }), 1229;
                 params!(Char, String) => Operation::binary(|ecx, lhs, rhs| {
                     let length = ecx.scalar_type(&lhs).unwrap_char_varchar_length();
                     Ok(lhs.call_unary(UnaryFunc::PadChar { length })
                         .call_binary(rhs, IsRegexpMatch { case_insensitive: true })
-                        .call_unary(UnaryFunc::Not)
+                        .call_unary(UnaryFunc::Not(func::Not))
                     )
                 }), 1235;
             },

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -21,6 +21,7 @@ use chrono::{DateTime, Utc};
 use itertools::Itertools;
 use lazy_static::lazy_static;
 
+use expr::func;
 use ore::collections::CollectionExt;
 use pgrepr::oid;
 use repr::{ColumnName, ColumnType, Datum, RelationType, Row, ScalarBaseType, ScalarType};

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -28,7 +28,7 @@ use std::iter;
 use std::mem;
 
 use anyhow::{anyhow, bail, ensure, Context};
-use expr::LocalId;
+use expr::{func as expr_func, LocalId};
 use itertools::Itertools;
 use ore::str::StrExt;
 use sql_parser::ast::display::{AstDisplay, AstFormatter};

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -2363,7 +2363,7 @@ pub fn plan_expr<'a>(
         Expr::Not { expr } => {
             let ecx = ecx.with_name("NOT argument");
             HirScalarExpr::CallUnary {
-                func: UnaryFunc::Not,
+                func: UnaryFunc::Not(expr_func::Not),
                 expr: Box::new(plan_expr(&ecx, expr)?.type_as(&ecx, &ScalarType::Bool)?),
             }
             .into()
@@ -2946,7 +2946,7 @@ fn plan_is_null_expr<'a>(
     };
     if not {
         expr = HirScalarExpr::CallUnary {
-            func: UnaryFunc::Not,
+            func: UnaryFunc::Not(expr_func::Not),
             expr: Box::new(expr),
         }
     }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -239,7 +239,7 @@ fn plan_dbz_flatten_one(
         input: Box::new(HirRelationExpr::Filter {
             input: Box::new(input),
             predicates: vec![HirScalarExpr::CallUnary {
-                func: UnaryFunc::Not,
+                func: UnaryFunc::Not(func::Not),
                 expr: Box::new(HirScalarExpr::CallUnary {
                     func: UnaryFunc::IsNull,
                     expr: Box::new(HirScalarExpr::Column(ColumnRef {

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -34,7 +34,7 @@ use dataflow_types::{
     PubNubSourceConnector, RegexEncoding, S3SourceConnector, SinkConnectorBuilder, SinkEnvelope,
     SourceConnector, SourceDataEncoding, SourceEnvelope, Timeline,
 };
-use expr::{GlobalId, MirRelationExpr, TableFunc, UnaryFunc};
+use expr::{func, GlobalId, MirRelationExpr, TableFunc, UnaryFunc};
 use interchange::avro::{self, AvroSchemaGenerator, DebeziumDeduplicationStrategy};
 use interchange::envelopes;
 use ore::collections::CollectionExt;

--- a/src/sql/src/plan/transform_expr.rs
+++ b/src/sql/src/plan/transform_expr.rs
@@ -243,13 +243,13 @@ pub fn try_simplify_quantified_comparisons(expr: &mut HirRelationExpr) {
                         let expr = expr.take();
                         let filter = expr
                             .clone()
-                            .call_unary(UnaryFunc::Not)
+                            .call_unary(UnaryFunc::Not(func::Not))
                             .call_binary(expr.call_unary(UnaryFunc::IsNull), BinaryFunc::Or);
                         *e = input
                             .take()
                             .filter(vec![filter])
                             .exists()
-                            .call_unary(UnaryFunc::Not);
+                            .call_unary(UnaryFunc::Not(func::Not));
                     }
                     _ => (),
                 }

--- a/src/sql/src/plan/transform_expr.rs
+++ b/src/sql/src/plan/transform_expr.rs
@@ -14,6 +14,7 @@ use std::mem;
 
 use lazy_static::lazy_static;
 
+use expr::func;
 use repr::{ColumnType, RelationType, ScalarType};
 
 use crate::plan::expr::{

--- a/src/transform/src/column_knowledge.rs
+++ b/src/transform/src/column_knowledge.rs
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 
 use itertools::Itertools;
 
-use expr::{EvalError, MirRelationExpr, MirScalarExpr, UnaryFunc};
+use expr::{func, EvalError, MirRelationExpr, MirScalarExpr, UnaryFunc};
 use repr::{ColumnType, RelationType, ScalarType};
 use repr::{Datum, Row};
 

--- a/src/transform/src/column_knowledge.rs
+++ b/src/transform/src/column_knowledge.rs
@@ -139,7 +139,7 @@ impl ColumnKnowledge {
                         }
                     }
                     if let MirScalarExpr::CallUnary {
-                        func: UnaryFunc::Not,
+                        func: UnaryFunc::Not(func::Not),
                         expr,
                     } = predicate
                     {

--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -77,7 +77,7 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::TransformArgs;
-use expr::{AggregateFunc, Id, MirRelationExpr, MirScalarExpr};
+use expr::{func, AggregateFunc, Id, MirRelationExpr, MirScalarExpr};
 use itertools::Itertools;
 use repr::{Datum, ScalarType};
 

--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -249,14 +249,14 @@ impl PredicatePushdown {
                                             expr1
                                                 .clone()
                                                 .call_unary(UnaryFunc::IsNull)
-                                                .call_unary(UnaryFunc::Not),
+                                                .call_unary(UnaryFunc::Not(func::Not)),
                                         );
                                     } else if expr2.typ(&input_type).nullable {
                                         pred_not_translated.push(
                                             expr2
                                                 .clone()
                                                 .call_unary(UnaryFunc::IsNull)
-                                                .call_unary(UnaryFunc::Not),
+                                                .call_unary(UnaryFunc::Not(func::Not)),
                                         );
                                     }
                                     equivalences.push(vec![(**expr1).clone(), (**expr2).clone()]);


### PR DESCRIPTION
## Changes to UnaryFunc

Currently we have a giant enum called `UnaryFunc` with variants describing each (unary) SQL function that we support in materialize. This enum provides generic methods (e.g eval) that internally implemented by matching on the variant and dispatching to an appropriate free standing function.

While this works it results in hard to maintain code where to add a new variant you need to find all the match statements for all the methods provided and insert your code.

This PR aims to break up each `UnaryFunc` variant in its own separate type, that is then tied together by the central UnaryFunc enum. For example instead of:

```rust
enum UnaryFunc {
   Not
}
```

it defines a zero sized struct `Not` that is then part of the variant:

```rust
struct Not;

enum UnaryFunc {
    Not(Not)
}
```

The goals for this split is twofold. First, each individual variant type can implement the relevant SQL function methods (`eval()`, `propagates_nulls()`, `output_type()`, etc) as part of a trait implementation and do so in a separate file. Then, in the central `UnaryFunc` enum all we have to do is match on the variant and then just call the variant specific method on the contained zero sized value.

Second, once all variants have been converted into being separate types with a `UnaryFuncTrait` trait implemented we can throw away our manual `match`&call business and have it be automatically generated by [`enum_dispatch`](https://crates.io/crates/enum_dispatch). In this world, adding a new SQL function will be a matter of making a new small file based on the existing functions and the rest will be automatically handled.

## Helpers to implement `UnaryFuncTrait`

The PR also defines a `UnaryFuncTrait` trait (the name will be renamed back to `UnaryFunc` once we transform all the variants and move to enum_dispatch) that describes what a SQL function should do.

While it's certainly possible to define a ZST `struct Not;` and then `impl UnaryFuncTrait for Not` directly, most of the time the implementation is the same:

1. evaluatate the arguments
2. optionaly do null propagation 
3. evaluate the function
4. wrap the result in a Datum and return

For this reason this PR also introduces a `sqlfunc!()` macro that can wrap a normal rust function and produce the SQL implementation for you. An example use of this macro is in the PR by implementing `Not` with it.

This macro is able to automatically infer null propagation and null introduction properties depending on the types of the Rust function, but also allows to manually specify them for "weird" functions. See the doc comment on the macro for the full details on how it works.