### PR TITLE
lowertest: Support specifying zero-arg structs.

### DIFF
--- a/src/lowertest/README.md
+++ b/src/lowertest/README.md
@@ -14,7 +14,8 @@ syntax.
 
 Write:
 * an enum as `(variant_in_snake_case field1 field2 .. fieldn)`
-* a struct as `(field1 field2 .. fieldn)`
+* a struct with arguments as `(field1 field2 .. fieldn)`
+* a struct with no arguments as the empty string.
 * a `Vec` as `[elem1 elem2 .. elemn]`
 * a tuple as `{elem1 elem2 .. elemn}`
 * `None` or `null` as `null`

--- a/src/lowertest/tests/test_runner.rs
+++ b/src/lowertest/tests/test_runner.rs
@@ -20,6 +20,9 @@ mod tests {
     use serde_json::Value;
 
     #[derive(Debug, Deserialize, PartialEq, Serialize, MzStructReflect)]
+    struct ZeroArg;
+
+    #[derive(Debug, Deserialize, PartialEq, Serialize, MzStructReflect)]
     struct SingleUnnamedArg(Box<f64>);
 
     #[derive(Debug, Deserialize, PartialEq, Serialize, MzStructReflect)]
@@ -56,8 +59,11 @@ mod tests {
         SingleUnnamedField(SingleUnnamedArg),
         SingleUnnamedField2(Vec<i64>),
         SingleUnnamedField3(MultiNamedArg),
+        SingleUnnamedZeroArgField(ZeroArg),
         MultiUnnamedFields(MultiUnnamedArg, MultiNamedArg, Box<TestEnum>),
         MultiUnnamedFields2(OptionalArg, FirstArgEnum, #[serde(default)] String),
+        MultiUnnamedZeroArgFields(ZeroArg, ZeroArg),
+        MultiUnnamedFieldsFirstZeroArg(ZeroArg, OptionalArg),
         Unit,
     }
 
@@ -65,6 +71,7 @@ mod tests {
         produce_rti,
         [TestEnum],
         [
+            ZeroArg,
             SingleUnnamedArg,
             OptionalArg,
             MultiUnnamedArg,

--- a/src/lowertest/tests/testdata/build
+++ b/src/lowertest/tests/testdata/build
@@ -134,3 +134,33 @@ build
 (multi_unnamed_fields_2 true (unit "baz"))
 ----
 Some(MultiUnnamedFields2(OptionalArg(true, (0.0, 0)), FirstArgEnum { test_enum: Unit, second_arg: "baz" }, ""))
+
+build
+(single_unnamed_zero_arg_field)
+----
+Some(SingleUnnamedZeroArgField(ZeroArg))
+
+build
+single_unnamed_zero_arg_field
+----
+Some(SingleUnnamedZeroArgField(ZeroArg))
+
+build
+(multi_unnamed_zero_arg_fields)
+----
+Some(MultiUnnamedZeroArgFields(ZeroArg, ZeroArg))
+
+build
+multi_unnamed_zero_arg_fields
+----
+Some(MultiUnnamedZeroArgFields(ZeroArg, ZeroArg))
+
+build
+(multi_unnamed_fields_first_zero_arg true)
+----
+Some(MultiUnnamedFieldsFirstZeroArg(ZeroArg, OptionalArg(true, (0.0, 0))))
+
+build
+(multi_unnamed_fields_first_zero_arg (true [3.14 2]))
+----
+Some(MultiUnnamedFieldsFirstZeroArg(ZeroArg, OptionalArg(true, (3.14, 2))))

--- a/src/lowertest/tests/testdata/build-override
+++ b/src/lowertest/tests/testdata/build-override
@@ -95,6 +95,36 @@ build override=true
 ----
 Some(MultiUnnamedFields2(OptionalArg(true, (0.0, 0)), FirstArgEnum { test_enum: Unit, second_arg: "baz" }, ""))
 
+build override=true
+(single_unnamed_zero_arg_field)
+----
+Some(SingleUnnamedZeroArgField(ZeroArg))
+
+build override=true
+single_unnamed_zero_arg_field
+----
+Some(SingleUnnamedZeroArgField(ZeroArg))
+
+build override=true
+(multi_unnamed_zero_arg_fields)
+----
+Some(MultiUnnamedZeroArgFields(ZeroArg, ZeroArg))
+
+build override=true
+multi_unnamed_zero_arg_fields
+----
+Some(MultiUnnamedZeroArgFields(ZeroArg, ZeroArg))
+
+build override=true
+(multi_unnamed_fields_first_zero_arg true)
+----
+Some(MultiUnnamedFieldsFirstZeroArg(ZeroArg, OptionalArg(true, (0.0, 0))))
+
+build override=true
+(multi_unnamed_fields_first_zero_arg (true [3.14 2]))
+----
+Some(MultiUnnamedFieldsFirstZeroArg(ZeroArg, OptionalArg(true, (3.14, 2))))
+
 # Override tests.
 
 # Note that this is also a test that we are correctly


### PR DESCRIPTION
Part of fixing test failures in #7704.

`lowertest` had no support for zero-arg structs. Zero-arg structs can now be specified as the empty string.