### PR TITLE
dbt-materialize: bump to dbt 0.20.0

### DIFF
--- a/misc/dbt-materialize/dbt/include/materialize/macros/materializations/seed.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/materializations/seed.sql
@@ -55,7 +55,7 @@
   {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}
 
   {%- set agate_table = load_agate_table() -%}
-  {%- do store_result('agate_table', status='OK', agate_table=agate_table) -%}
+  {%- do store_result('agate_table', response='OK', agate_table=agate_table) -%}
 
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
 

--- a/misc/dbt-materialize/requirements.txt
+++ b/misc/dbt-materialize/requirements.txt
@@ -1,3 +1,3 @@
-dbt==0.18.1
-pytest-dbt-adapter==0.3.0
+dbt==0.20.0
+pytest-dbt-adapter==0.5.1
 ../dbt-materialize

--- a/misc/dbt-materialize/setup.py
+++ b/misc/dbt-materialize/setup.py
@@ -14,28 +14,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 from distutils.core import setup
+from pathlib import Path
 
 from setuptools import find_packages
 
-this_directory = os.path.abspath(os.path.dirname(__file__))
-with open(os.path.join(this_directory, "README.md")) as f:
-    long_description = f.read()
-
-package_name = "dbt-materialize"
-# This adapter's version, and its required dbt-postgres version, tracks the
-# target dbt version.
-target_package_version = "0.18.1"
-package_version_suffix = ".post4"
-package_version = "{}{}".format(target_package_version, package_version_suffix)
-description = """The Materialize adapter plugin for dbt (data build tool)"""
+# This adapter's version, and its required dbt-postgres version, track the
+# target dbt version. If you need to release a new version of this adapter
+# without bumping the dbt-postgres version, change version_suffix to ".post1",
+# ".post2", etc. Reset version_suffix back to "" when bumping the
+# dbt_postgres_version.
+dbt_postgres_version = "0.20.0"
+version_suffix = ""
 
 setup(
-    name=package_name,
-    version=package_version,
-    description=description,
-    long_description=long_description,
+    name="dbt-materialize",
+    version=f"{dbt_postgres_version}{version_suffix}",
+    description="The Materialize adapter plugin for dbt (data build tool).",
+    long_description=(Path(__file__).parent / "README.md").open().read(),
     long_description_content_type="text/markdown",
     author="Materialize, Inc.",
     author_email="support@materialize.io",
@@ -48,5 +44,5 @@ setup(
             "include/materialize/macros/**/*.sql",
         ]
     },
-    install_requires=["dbt-postgres=={}".format(target_package_version)],
+    install_requires=["dbt-postgres=={}".format(dbt_postgres_version)],
 )


### PR DESCRIPTION
The primary change here is bumping to dbt/dbt-postgres 0.20.0, per user
request. But I also took the opportunity to simplify the setup.py script
a bit.

Fix #7580.