### PR TITLE
testdrive: remove support for corrupting avro/protobuf

### DIFF
--- a/test/testdrive/avro-decode.td
+++ b/test/testdrive/avro-decode.td
@@ -194,8 +194,8 @@ Jokers
 # Test decoding of corrupted messages
 $ kafka-create-topic topic=avro-corrupted-values
 
-$ kafka-ingest format=avro topic=avro-corrupted-values schema=${reader-schema} publish=true corrupt-values=true timestamp=1
-{ "f0": {"f0_0": 9999, "f0_1": null}, "f1": {"long": 3456}, "f2": "Jokers", "f5": {"extra_variant": [0,1,2,3,4,5,6,7,8,9]}, "f6": {"key": 8372} }
+$ kafka-ingest format=bytes topic=avro-corrupted-values timestamp=1
+garbage
 
 > CREATE MATERIALIZED SOURCE avro_corrupted_values
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avro-corrupted-values-${testdrive.seed}'
@@ -207,12 +207,12 @@ Decode error: Text: avro deserialization error: wrong Confluent-style avro seria
 # Test decoding of corrupted messages without magic byte
 $ kafka-create-topic topic=avro-corrupted-values2
 
-$ kafka-ingest format=avro topic=avro-corrupted-values2 schema=${reader-schema} publish=true corrupt-values=true confluent-wire-format=false timestamp=1
-{ "f0": {"f0_0": 9999, "f0_1": null}, "f1": {"long": 3456}, "f2": "Jokers", "f5": {"extra_variant": [0,1,2,3,4,5,6,7,8,9]}, "f6": {"key": 8372} }
+$ kafka-ingest format=bytes topic=avro-corrupted-values2 timestamp=1
+garbage
 
 > CREATE MATERIALIZED SOURCE avro_corrupted_values2
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avro-corrupted-values2-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${reader-schema}' WITH (confluent_wire_format = false)
 
 ! SELECT f2 FROM avro_corrupted_values2
-Decode error: Text: avro deserialization error: Decode error: Decoding error: Expected non-negative integer, got -2
+Decode error: Text: avro deserialization error: Decode error: Decoding error: Expected non-negative integer, got -49

--- a/test/testdrive/protobuf.td
+++ b/test/testdrive/protobuf.td
@@ -69,9 +69,8 @@ $ kafka-ingest format=protobuf topic=messages message=struct timestamp=1
 
 $ kafka-create-topic topic=corrupted-messages
 
-$ kafka-ingest format=protobuf topic=corrupted-messages message=struct timestamp=1 corrupt-values=true
-{"int": 1, "bad_int": 1, "bin": "ONE", "st": "my-string"}
-{"int": 2, "bad_int": 2, "bin": "ONE", "st": "something-valid"}
+$ kafka-ingest format=bytes topic=corrupted-messages timestamp=1
+garbage
 
 ! SELECT * from corrupted_proto_messages
 Decode error: Text: protobuf deserialization error: Deserializing into rust object: protobuf error


### PR DESCRIPTION
Testdrive learned to write corrupt Avro and Protobuf data in #5995,
but... this feature is unnecessary. It is much easier to just write some
garbage bytes into the topics (that won't be valid Avro or Protobuf)
then go to the trouble of serializing correct Avro/Protobuf data and
then randomly permuting bytes.