### PR TITLE
persist: fix SELECT on persisted user tables

### DIFF
--- a/src/persist/src/indexed/runtime.rs
+++ b/src/persist/src/indexed/runtime.rs
@@ -606,8 +606,10 @@ impl<U: Buffer, L: Blob> RuntimeImpl<U, L> {
                 res.fill(step_res.and_then(|_| write_res));
             }
             Cmd::Seal(ids, ts, res) => {
-                let r = self.indexed.seal(ids, ts);
-                res.fill(r);
+                let seal_res = self.indexed.seal(ids, ts);
+                // TODO: Move this to a Cmd::Tick or something.
+                let step_res = self.indexed.step();
+                res.fill(step_res.and_then(|_| seal_res));
             }
             Cmd::AllowCompaction(id, ts, res) => {
                 let r = self.indexed.allow_compaction(id, ts);


### PR DESCRIPTION
Broken in #7686 which separated the physical work of seal into step, but
forgot to call step after seal. Probably time to do the Tick TODO soon,
which is the real fix here.

Also certainly time for us to have some sort of end-to-end sanity test
that would have caught this. In the meantime, manually verified this
fix.