### PR TITLE
persist: disable flaky nemesis operation

### DIFF
--- a/src/persist/src/nemesis/generator.rs
+++ b/src/persist/src/nemesis/generator.rs
@@ -51,7 +51,10 @@ impl GeneratorConfig {
 
 impl Default for GeneratorConfig {
     fn default() -> Self {
-        Self::all_operations()
+        let mut ops = Self::all_operations();
+        // TODO: Re-enable this once it's not flaky.
+        ops.allow_compaction_weight = 0;
+        ops
     }
 }
 


### PR DESCRIPTION
A git bisect reveals this is flaky as of 78cdb05, which is the commit
that added it.