### PR TITLE
expr: don't crash on long LIKE patterns

### DIFF
--- a/src/expr/src/scalar/like_pattern.rs
+++ b/src/expr/src/scalar/like_pattern.rs
@@ -64,5 +64,12 @@ pub fn build_regex(pattern: &str, flags: &str) -> Result<Regex, EvalError> {
             _ => return Err(EvalError::InvalidRegexFlag(f)),
         }
     }
-    Ok(regex.build().expect("regex constructed to be valid"))
+    match regex.build() {
+        Ok(regex) => Ok(regex),
+        Err(regex::Error::CompiledTooBig(_)) => Err(EvalError::LikePatternTooLong),
+        Err(e) => Err(EvalError::Internal(format!(
+            "build_regex produced invalid regex: {}",
+            e
+        ))),
+    }
 }

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -1035,6 +1035,7 @@ pub enum EvalError {
     ComplexOutOfRange(String),
     MultipleRowsFromSubquery,
     Undefined(String),
+    LikePatternTooLong,
 }
 
 impl fmt::Display for EvalError {
@@ -1115,6 +1116,9 @@ impl fmt::Display for EvalError {
             }
             EvalError::Undefined(s) => {
                 write!(f, "{} is undefined", s)
+            }
+            EvalError::LikePatternTooLong => {
+                write!(f, "LIKE pattern exceeds maximum length")
             }
         }
     }

--- a/test/sqllogictest/cockroach/like.slt
+++ b/test/sqllogictest/cockroach/like.slt
@@ -431,3 +431,8 @@ true
 
 query error unterminated escape sequence in LIKE
 SELECT 'a' LIKE '\'
+
+# Test massive LIKE patterns:
+
+query error LIKE pattern exceeds maximum length
+SELECT 'x' LIKE repeat('x', 367416)


### PR DESCRIPTION
It turns out that lowering LIKE patterns to regular expressions *can*
error if the LIKE pattern is too long. Surface a user-friendly error in
that case. For good measure, turn other regular expression build errors
that may arise into internal errors rather than panics, just in case
there are other issues lurking.

Fix #7747.