### PR TITLE
dataflow: remove serde_variant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -835,7 +835,6 @@ dependencies = [
  "rusoto_sqs",
  "serde",
  "serde_json",
- "serde_variant",
  "tempfile",
  "timely",
  "tokio",
@@ -3815,15 +3814,6 @@ dependencies = [
  "form_urlencoded",
  "itoa",
  "ryu",
- "serde",
-]
-
-[[package]]
-name = "serde_variant"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60c53d80400dbb87d4b422c3396145fa5736b13ebfed5c62105b7dc8d1cba5cf"
-dependencies = [
  "serde",
 ]
 

--- a/deny.toml
+++ b/deny.toml
@@ -33,6 +33,7 @@ allow = [
     "ISC",
     "MIT",
 ]
+copyleft = "deny"
 private = { ignore = true }
 
 [sources]
@@ -45,7 +46,6 @@ allow-git = [
     "https://github.com/MaterializeInc/rust-postgres-array.git",
     "https://github.com/MaterializeInc/rust-prometheus.git",
     "https://github.com/MaterializeInc/serde-protobuf.git",
-    "https://github.com/MaterializeInc/jemallocator.git",
     "https://github.com/TimelyDataflow/timely-dataflow",
     "https://github.com/TimelyDataflow/differential-dataflow.git",
     "https://github.com/fede1024/rust-rdkafka.git",

--- a/src/dataflow/Cargo.toml
+++ b/src/dataflow/Cargo.toml
@@ -51,7 +51,6 @@ rusoto_s3 = "0.47.0"
 rusoto_sqs = "0.47.0"
 serde = { version = "1.0.127", features = ["derive"] }
 serde_json = "1.0.66"
-serde_variant = "0.1.0"
 tempfile = "3.2.0"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 tokio = { version = "1.9.0", features = ["fs", "rt", "sync"] }

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -172,6 +172,29 @@ pub enum Command {
     Shutdown,
 }
 
+impl CommandKind {
+    /// Returns the name of the command kind.
+    fn name(self) -> &'static str {
+        match self {
+            CommandKind::AddSourceTimestamping => "add_source_timestamping",
+            CommandKind::AdvanceAllLocalInputs => "advance_all_local_inputs",
+            CommandKind::AdvanceSourceTimestamp => "advance_source_timestamp",
+            CommandKind::AllowCompaction => "allow_compaction",
+            CommandKind::CancelPeek => "cancel_peek",
+            CommandKind::CreateDataflows => "create_dataflows",
+            CommandKind::DropIndexes => "drop_indexes",
+            CommandKind::DropSinks => "drop_sinks",
+            CommandKind::DropSourceTimestamping => "drop_source_timestamping",
+            CommandKind::DropSources => "drop_sources",
+            CommandKind::DurabilityFrontierUpdates => "durability_frontier_updates",
+            CommandKind::EnableLogging => "enable_logging",
+            CommandKind::Insert => "insert",
+            CommandKind::Peek => "peek",
+            CommandKind::Shutdown => "shutdown",
+        }
+    }
+}
+
 /// Information from timely dataflow workers.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Response {

--- a/src/dataflow/src/server/metrics.rs
+++ b/src/dataflow/src/server/metrics.rs
@@ -15,7 +15,6 @@ use ore::{
     metric,
     metrics::{IntCounter, IntCounterVec, IntGauge, IntGaugeVec},
 };
-use serde_variant::to_variant_name;
 
 use super::{Command, CommandKind, PendingPeek};
 
@@ -107,16 +106,9 @@ impl CommandsProcessedMetrics {
         CommandsProcessedMetrics {
             cache: CommandKind::into_enum_iter().map(|_| 0).collect(),
             counters: CommandKind::into_enum_iter()
-                .map(|kind| {
-                    commands_processed_metric
-                        .with_label_values(&[worker, Self::seq_command_label(kind)])
-                })
+                .map(|kind| commands_processed_metric.with_label_values(&[worker, kind.name()]))
                 .collect(),
         }
-    }
-
-    fn seq_command_label(command: CommandKind) -> &'static str {
-        to_variant_name(&command).expect("Failed to convert enum with only unit variants")
     }
 
     fn observe(&mut self, command: CommandKind) {


### PR DESCRIPTION
@antifuchs a bit sad to lose the autogeneration but I didn't see another alternative on crates.io in a quick scan. I imagine someday we'll write the code to do this in Materialize, but for now I figured it's best to get rid of the GPL code ASAP.

----

serde_variant is GPLv3, so we can't use it. This commit replaces its
usage with a simple match statement for now. It also updates our
cargo-deny configuration to turn usage of copyleft licenses into a hard
error rather than a warning.