### PR TITLE
editorconfig: remove max_line_length directives

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,13 +12,6 @@ end_of_line = lf
 insert_final_newline = true
 indent_style = space
 indent_size = 4
-max_line_length = 100
-
-[COMMIT_EDITMSG]
-max_line_length = 72
-
-[*.md]
-max_line_length = 80
 
 [*.js]
 indent_size = 2

--- a/bin/pyfmt
+++ b/bin/pyfmt
@@ -14,4 +14,4 @@
 set -euo pipefail
 
 "$(dirname "$0")"/pyactivate --dev -m black --target-version py36 . "$@"
-"$(dirname "$0")"/pyactivate --dev -m isort --profile black -l 88 .
+"$(dirname "$0")"/pyactivate --dev -m isort --profile black .

--- a/test/lang/js/babel.config.js
+++ b/test/lang/js/babel.config.js
@@ -8,5 +8,8 @@
 // by the Apache License, Version 2.0.
 
 module.exports = {
-  presets: [["@babel/preset-env", { targets: { node: "current" } }], "@babel/preset-typescript"],
+  presets: [
+    ["@babel/preset-env", { targets: { node: "current" } }],
+    "@babel/preset-typescript",
+  ],
 };

--- a/test/lang/js/params.test.ts
+++ b/test/lang/js/params.test.ts
@@ -40,9 +40,9 @@ describe("query api", () => {
   });
 
   it("should include the prepared statement name in the error message", async () => {
-    await expect(client.query({ text: "SELECT $1", name: "foo" })).rejects.toThrow(
-      bindError({ expected: 1, actual: 0, name: "foo" }),
-    );
+    await expect(
+      client.query({ text: "SELECT $1", name: "foo" }),
+    ).rejects.toThrow(bindError({ expected: 1, actual: 0, name: "foo" }));
   });
 
   it("should allow queries with the correct number of parameters", async () => {


### PR DESCRIPTION
The max_line_length directive is not officially part of the EditorConfig
spec, and its current implementations have been contentious [[0]] [[1]]. The
tl;dr is that it is not clear whether to use max_line_length for soft
wrapping, hard wrapping, or just a visual display of a ruler, and
various tools and editors have different opinions.

Having the directive around is causing more trouble than its worth, in
my opinion. It overrode Vim's default line length for Git commit
messages [[2]], and caused isort to fight with black over the correct line
length [[3]]. There are probably other issues lurking.

So, this commit proposes removing the max_line_length directives from
our .editorconfig. We can reconsider if the EditorConfig project settles
on a meaning, or introduces a different directive like rulers [[4]].

[0]: https://github.com/editorconfig/editorconfig/issues/280
[1]: https://github.com/editorconfig/editorconfig/issues/387
[2]: https://github.com/MaterializeInc/materialize/commit/57574b6fcf1ae696f61a992458a27b7ef0c8e5eb
[3]: https://github.com/MaterializeInc/materialize/commit/5848bdd277f17d7fa20702dc90b8453a5d13cda9
[4]: https://github.com/editorconfig/editorconfig/issues/89