### PR TITLE
persist: de-flake allow_compaction on nemesis.

### DIFF
--- a/src/persist/src/nemesis/generator.rs
+++ b/src/persist/src/nemesis/generator.rs
@@ -51,9 +51,11 @@ impl GeneratorConfig {
 
 impl Default for GeneratorConfig {
     fn default() -> Self {
+        #[allow(unused_mut)]
         let mut ops = Self::all_operations();
-        // TODO: Re-enable this once it's not flaky.
-        ops.allow_compaction_weight = 0;
+        // NB: If we need to temporarily disable an operation in all the nemesis
+        // tests, set it to 0 here. (As opposed to clearing it in the impl of
+        // `all_operations`, which will break the Generator tests.)
         ops
     }
 }


### PR DESCRIPTION
The underlying issue was that we were not reverting logical changes made to
in-memory state when those changes could not be durably committed to disk.

This issue was present ever since we added the allow_compaction command to
the nemesis tests and its unclear to me why we only noticed it recently.

The larger fix for these sorts of issues will be batching up multiple commands
and committing them all together, which should then remove the problem of
having to reason about committing / reverting each individual command.