### PR TITLE
sql: future-proof unsupported! macro

### DIFF
--- a/src/sql/src/lib.rs
+++ b/src/sql/src/lib.rs
@@ -71,14 +71,14 @@ macro_rules! unsupported {
             feature: $feature.to_string(),
             issue_no: None,
         }
-        .into());
+        .into())
     };
     ($issue:expr, $feature:expr) => {
         return Err(crate::plan::error::PlanError::Unsupported {
             feature: $feature.to_string(),
             issue_no: Some($issue),
         }
-        .into());
+        .into())
     };
 }
 


### PR DESCRIPTION
trailing semicolons in macros are soon-to-be-deprecated, so just removing those that [we're getting warned about](https://buildkite.com/materialize/deploy/builds/4728#7c78d239-5f2d-46bc-aad4-db5290c3004a):

```
warning: trailing semicolon in macro used in expression position
    --> src/sql/src/lib.rs:74:17
     |
74   |         .into());
     |                 ^
     | 
    ::: src/sql/src/func.rs:1648:61
     |
1648 |                 params!(Any) => Operation::unary(|_ecx, _e| unsupported!("array_agg")), 4053;
     |                                                             ------------------------- in this macro invocation
     |
     = note: `#[warn(semicolon_in_expressions_from_macros)]` on by default
     = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
     = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
     = note: this warning originates in the macro `unsupported` (in Nightly builds, run with -Z macro-backtrace for more info)
```