### PR TITLE
persist: enable step to run on a specified interval.

### DIFF
--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -641,6 +641,9 @@ swap: {swap_total}KB total, {swap_used}KB used{swap_limit}",
             system_table_enabled,
             lock_reentrance_id,
             lock_info,
+            // TODO: this time is hardcoded for now, but eventually we
+            // will want to expose it as a CLI / per-stream option.
+            step_interval: Some(Duration::from_millis(100)),
         }
     };
 

--- a/src/persist/benches/snapshot.rs
+++ b/src/persist/benches/snapshot.rs
@@ -14,7 +14,7 @@ use criterion::{black_box, criterion_group, criterion_main, Bencher, Criterion};
 use persist::error::Error;
 use persist::file::{FileBlob, FileBuffer};
 use persist::indexed::encoding::Id;
-use persist::indexed::{Indexed, Snapshot};
+use persist::indexed::{Indexed, IndexedConfig, Snapshot};
 use persist::mem::{MemBlob, MemBuffer};
 use persist::storage::{Blob, Buffer, LockInfo};
 
@@ -84,7 +84,11 @@ pub fn bench_mem_snapshots(c: &mut Criterion) {
     bench_indexed_snapshots(c, "mem", |path| {
         let name = format!("snapshot_bench_{}", path);
         let lock_info = LockInfo::new_no_reentrance(name);
-        Indexed::new(MemBuffer::new(lock_info.clone()), MemBlob::new(lock_info))
+        Indexed::new(
+            MemBuffer::new(lock_info.clone()),
+            MemBlob::new(lock_info),
+            IndexedConfig::default(),
+        )
     });
 }
 
@@ -101,6 +105,7 @@ pub fn bench_file_snapshots(c: &mut Criterion) {
         Indexed::new(
             FileBuffer::new(buffer_dir, lock_info.clone())?,
             FileBlob::new(blob_dir, lock_info)?,
+            IndexedConfig::default(),
         )
     });
 }

--- a/src/persist/src/file.rs
+++ b/src/persist/src/file.rs
@@ -328,7 +328,8 @@ impl Blob for FileBlob {
             OpenOptions::new()
                 .write(true)
                 .create_new(true)
-                .open(file_path)?
+                .open(&file_path)
+                .map_err(|e| format!("unable to create file blob at {:?}: {:}", file_path, e))?
         };
         file.write_all(&value[..])?;
         file.sync_all()?;

--- a/src/persist/src/mem.rs
+++ b/src/persist/src/mem.rs
@@ -17,6 +17,7 @@ use ore::cast::CastFrom;
 
 use crate::error::Error;
 use crate::indexed::runtime::{self, RuntimeClient};
+use crate::indexed::IndexedConfig;
 use crate::storage::{Blob, Buffer, LockInfo, SeqNo};
 use crate::unreliable::{UnreliableBlob, UnreliableBuffer, UnreliableHandle};
 
@@ -312,7 +313,7 @@ impl MemRegistry {
         let lock_info = LockInfo::new_no_reentrance(lock_info.to_owned());
         let buffer = self.buffer(path, lock_info.clone())?;
         let blob = self.blob(path, lock_info)?;
-        runtime::start(buffer, blob)
+        runtime::start(buffer, blob, IndexedConfig::default())
     }
 
     /// Open a [RuntimeClient] with unreliable storage associated with `path`.
@@ -327,7 +328,7 @@ impl MemRegistry {
         let buffer = UnreliableBuffer::from_handle(buffer, unreliable.clone());
         let blob = self.blob(path, lock_info)?;
         let blob = UnreliableBlob::from_handle(blob, unreliable);
-        runtime::start(buffer, blob)
+        runtime::start(buffer, blob, IndexedConfig::default())
     }
 }
 

--- a/src/persist/src/nemesis/direct.rs
+++ b/src/persist/src/nemesis/direct.rs
@@ -14,6 +14,7 @@ use crate::error::Error;
 use crate::indexed::runtime::{
     self, DecodedSnapshot, RuntimeClient, StreamReadHandle, StreamWriteHandle,
 };
+use crate::indexed::IndexedConfig;
 use crate::nemesis::{
     AllowCompactionReq, Input, ReadSnapshotReq, ReadSnapshotRes, Req, Res, Runtime, SealReq,
     SnapshotId, Step, TakeSnapshotReq, WriteReq, WriteRes,
@@ -168,7 +169,9 @@ mod tests {
             let buf = UnreliableBuffer::from_handle(buf, unreliable.clone());
             let blob = FileBlob::new(blob_dir, ("reentrance0", "direct_file").into())?;
             let blob = UnreliableBlob::from_handle(blob, unreliable);
-            runtime::start(buf, blob)
+            // TODO: use a more realistic configuration that allows for some delay
+            // between when writes are submitted and moved to blob storage.
+            runtime::start(buf, blob, IndexedConfig::default())
         })
         .expect("initial start failed");
         // TODO: At the moment, running this for 100 steps takes a bit over a

--- a/src/persist/src/operators/input.rs
+++ b/src/persist/src/operators/input.rs
@@ -249,11 +249,11 @@ mod tests {
         let mut registry = MemRegistry::new();
         let mut unreliable = UnreliableHandle::default();
         let p = registry.open_unreliable("1", "error_stream", unreliable.clone())?;
+        let token = p.create_or_load::<(), ()>("error_stream")?;
         unreliable.make_unavailable();
 
         let recv = timely::execute_directly(move |worker| {
             worker.dataflow(|scope| {
-                let token = p.create_or_load::<(), ()>("error_stream").unwrap();
                 let (_, _, err_stream) = scope.new_persistent_unordered_input(token);
                 err_stream.capture()
             })

--- a/src/persist/src/operators/stream.rs
+++ b/src/persist/src/operators/stream.rs
@@ -138,11 +138,11 @@ mod tests {
         let mut registry = MemRegistry::new();
         let mut unreliable = UnreliableHandle::default();
         let p = registry.open_unreliable("1", "error_stream", unreliable.clone())?;
+        let token = p.create_or_load::<(), ()>("error_stream")?;
         unreliable.make_unavailable();
 
         let recv = timely::execute_directly(move |worker| {
             worker.dataflow(|scope| {
-                let token = p.create_or_load::<(), ()>("error_stream").unwrap();
                 let stream = operator::empty(scope);
                 let (_, err_stream) = stream.persist(token);
                 err_stream.capture()


### PR DESCRIPTION
This commit changes the behavior of Indexed::step to only do work once every
optionally specified time interval. If no interval is specified step does work
every time it is invoked.

I explored the design space of "make step into its own command like the other functions" but I couldn't figure out a good place to send periodic step commands to runtime. It seemed incorrect to have dataflow workers do this as part of their own loop, especially because different numbers of dataflow workers would lead to different numbers of step commands per second. Similarly, it seemed incorrect to have the coordinator send step commands as part of its main loop, where the only thing it does outside of handle messages is to advance times for table inserts and reads. It seemed most natural to have the RuntimeImpl periodically call step in its own loop, and for that to only trigger work every <X> milliseconds in prod, but be able to trigger work every time for deterministic tests. 