### PR TITLE
materialized: move uptime metric maintenance into callback

### DIFF
--- a/src/materialized/src/http/templates/status.html
+++ b/src/materialized/src/http/templates/status.html
@@ -6,7 +6,7 @@
 <p>
     materialized OK.<br/>
     handled {{ query_count }} queries so far.<br/>
-    up for {{ start_time.elapsed()|fmt("{:?}") }}
+    up for {{ uptime_seconds }} seconds
 </p>
 
 <pre>


### PR DESCRIPTION
Rather than running a task that updates the uptime Prometheus metric
periodically, use the new metrics registry to run a callback
whenever metrics are gathered. This avoids unnecessary background work
and keeps the uptime fresher to boot.

For good measure I also moved the server metrics struct to the
server_metrics module to keep the main server startup file a bit more
focused.