### PR TITLE
coord: hook up cluster_id to persist's reentrance lock id

### DIFF
--- a/src/coord/src/catalog/config.rs
+++ b/src/coord/src/catalog/config.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 
 use build_info::BuildInfo;
 
-use crate::persistcfg::PersisterWithConfig;
+use crate::persistcfg::PersistConfig;
 
 /// Configures a catalog.
 #[derive(Clone, Debug)]
@@ -33,8 +33,8 @@ pub struct Config<'a> {
     pub timestamp_frequency: Duration,
     /// Function to generate wall clock now; can be mocked.
     pub now: ore::now::NowFn,
-    /// Handle to persistence runtime and feature configuration.
-    pub persist: PersisterWithConfig,
+    /// Persistence subsystem configuration.
+    pub persist: PersistConfig,
     // Whether or not to skip catalog migrations
     pub skip_migrations: bool,
 }

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -48,7 +48,6 @@ use ore::metrics::ThirdPartyMetric;
 use ore::metrics::{IntCounterVec, MetricsRegistry};
 use structopt::StructOpt;
 use sysinfo::{ProcessorExt, SystemExt};
-use uuid::Uuid;
 
 use self::tracing::MetricsRecorderLayer;
 use materialized::TlsMode;
@@ -622,9 +621,6 @@ swap: {swap_total}KB total, {swap_used}KB used{swap_limit}",
         } else {
             false
         };
-        // TODO: Hook this up to the catalog cluster_id or something to actually
-        // enable reentrance.
-        let lock_reentrance_id = Uuid::new_v4().to_string();
         let lock_info = format!(
             "materialized {mz_version}\nos: {os}\nstart time: {start_time}\nnum workers: {num_workers}\n",
             mz_version = materialized::BUILD_INFO.human_version(),
@@ -639,7 +635,6 @@ swap: {swap_total}KB total, {swap_used}KB used{swap_limit}",
             blob_path: data_directory.join("persist").join("blob"),
             user_table_enabled,
             system_table_enabled,
-            lock_reentrance_id,
             lock_info,
         }
     };

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -217,9 +217,6 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
     let listener = TcpListener::bind(&config.listen_addr).await?;
     let local_addr = listener.local_addr()?;
 
-    // Initialize persistence runtime.
-    let persist = config.persist.init()?;
-
     // Initialize coordinator.
     let (coord_handle, coord_client) = coord::serve(coord::Config {
         workers,
@@ -233,7 +230,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
         safe_mode: config.safe_mode,
         build_info: &BUILD_INFO,
         metrics_registry: config.metrics_registry.clone(),
-        persist,
+        persist: config.persist,
     })
     .await?;
 


### PR DESCRIPTION
If an instance crashes (and so does not cleanly release its lock on the
selected persistence storage locations), this allows it to reacquire the
lock without operator intervention on restart while still maintaining
the writer exclusivity that persist requires.