### PR TITLE
deps: bump to secure version of tar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4212,9 +4212,9 @@ checksum = "36474e732d1affd3a6ed582781b3683df3d0563714c59c39591e8ff707cf078e"
 
 [[package]]
 name = "tar"
-version = "0.4.35"
+version = "0.4.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d779dc6aeff029314570f666ec83f19df7280bb36ef338442cfa8c604021b80"
+checksum = "8190d9cdacf6ee1b080605fd719b58d80a9fcbcea64db6744b26f743da02e447"
 dependencies = [
  "filetime",
  "libc",


### PR DESCRIPTION
Bump to a version of tar that isn't vulnerable to RUSTSEC-2021-0080.

For posterity, this vulnerability was not a security issue for us
because we only use the `tar` crate in a build script that downloads
packages from NPM, and NPM packages are allowed to execute arbitrary
code at installation time anyway.