### PR TITLE
persist: call Indexed::step less frequently.

### DIFF
--- a/src/persist/src/indexed/future.rs
+++ b/src/persist/src/indexed/future.rs
@@ -61,8 +61,8 @@ use crate::storage::{Blob, SeqNo};
 /// - TODO: Space usage.
 pub struct BlobFuture {
     id: Id,
-    // The next id used to assign a Blob key for this future.
-    next_blob_id: u64,
+    /// The next id used to assign a Blob key for this future.
+    pub next_blob_id: u64,
     // NB: This is a closed lower bound. When Indexed seals a time, only data
     // strictly before that time gets moved into the trace.
     ts_lower: Antichain<u64>,

--- a/src/persist/src/indexed/future.rs
+++ b/src/persist/src/indexed/future.rs
@@ -306,9 +306,8 @@ impl Snapshot<Vec<u8>, Vec<u8>> for FutureSnapshot {
                 .filter(|(_, ts, _)| self.ts_lower.less_equal(ts) && !self.ts_upper.less_equal(ts))
                 .map(|((key, val), ts, diff)| ((key.clone(), val.clone()), *ts, *diff));
             buf.extend(updates);
-            return true;
         }
-        false
+        !self.updates.is_empty()
     }
 }
 

--- a/src/persist/src/indexed/mod.rs
+++ b/src/persist/src/indexed/mod.rs
@@ -776,6 +776,12 @@ pub trait Snapshot<K, V> {
     /// A partial read of the data in the snapshot.
     ///
     /// Returns true if read needs to be called again for more data.
+    /// TODO: this API is easy to misuse (callers want to be able to say:
+    /// while foo.read() { do_stuff() }
+    /// where this API requires a more complicated control flow. If we instead
+    /// changed the semantics to "Return false when no more data has been added,
+    /// nor will ever be added to the destination" then we could support the
+    /// desired control flow.
     fn read<E: Extend<((K, V), u64, isize)>>(&mut self, buf: &mut E) -> bool;
 }
 

--- a/src/persist/src/indexed/runtime.rs
+++ b/src/persist/src/indexed/runtime.rs
@@ -443,6 +443,7 @@ impl<K: Codec, V: Codec> MultiWriteHandle<K, V> {
 
 /// A consistent snapshot of all data currently stored for an id, with keys and
 /// vals decoded.
+#[derive(Debug)]
 pub struct DecodedSnapshot<K, V> {
     snap: IndexedSnapshot,
     buf: Vec<((Vec<u8>, Vec<u8>), u64, isize)>,
@@ -473,10 +474,12 @@ impl<K: Codec + Ord, V: Codec + Ord> DecodedSnapshot<K, V> {
     pub fn read_to_end_flattened(&mut self) -> Result<Vec<((K, V), u64, isize)>, Error> {
         let mut res = Vec::new();
         let mut buf = Vec::new();
-        while self.read(&mut buf) {
-            for ((k, v), ts, diff) in buf.drain(..) {
-                res.push(((k?, v?), ts, diff));
-            }
+
+        // Read in all of the potentially decoded data.
+        while self.read(&mut buf) {}
+
+        for ((k, v), ts, diff) in buf.drain(..) {
+            res.push(((k?, v?), ts, diff));
         }
         res.sort();
         Ok(res)

--- a/src/persist/src/indexed/trace.rs
+++ b/src/persist/src/indexed/trace.rs
@@ -70,8 +70,8 @@ use crate::storage::Blob;
 /// - TODO: Space usage.
 pub struct BlobTrace {
     id: Id,
-    // The next ID used to assign a Blob key for this trace.
-    next_blob_id: u64,
+    /// The next ID used to assign a Blob key for this trace.
+    pub next_blob_id: u64,
     // NB: We may at some point need to break this up into separate logical and
     // physical compaction frontiers.
     since: Antichain<u64>,

--- a/src/persist/src/indexed/trace.rs
+++ b/src/persist/src/indexed/trace.rs
@@ -310,9 +310,8 @@ impl Snapshot<Vec<u8>, Vec<u8>> for TraceSnapshot {
     fn read<E: Extend<((Vec<u8>, Vec<u8>), u64, isize)>>(&mut self, buf: &mut E) -> bool {
         if let Some(batch) = self.updates.pop() {
             buf.extend(batch.updates.iter().cloned());
-            return true;
         }
-        false
+        !self.updates.is_empty()
     }
 }
 

--- a/src/persist/src/operators/input.rs
+++ b/src/persist/src/operators/input.rs
@@ -249,11 +249,11 @@ mod tests {
         let mut registry = MemRegistry::new();
         let mut unreliable = UnreliableHandle::default();
         let p = registry.open_unreliable("1", "error_stream", unreliable.clone())?;
+        let token = p.create_or_load::<(), ()>("error_stream").unwrap();
         unreliable.make_unavailable();
 
         let recv = timely::execute_directly(move |worker| {
             worker.dataflow(|scope| {
-                let token = p.create_or_load::<(), ()>("error_stream").unwrap();
                 let (_, _, err_stream) = scope.new_persistent_unordered_input(token);
                 err_stream.capture()
             })

--- a/src/persist/src/operators/stream.rs
+++ b/src/persist/src/operators/stream.rs
@@ -138,11 +138,11 @@ mod tests {
         let mut registry = MemRegistry::new();
         let mut unreliable = UnreliableHandle::default();
         let p = registry.open_unreliable("1", "error_stream", unreliable.clone())?;
+        let token = p.create_or_load::<(), ()>("error_stream").unwrap();
         unreliable.make_unavailable();
 
         let recv = timely::execute_directly(move |worker| {
             worker.dataflow(|scope| {
-                let token = p.create_or_load::<(), ()>("error_stream").unwrap();
                 let stream = operator::empty(scope);
                 let (_, err_stream) = stream.persist(token);
                 err_stream.capture()


### PR DESCRIPTION
This commit teaches the persistence runtime to try to grab as many commands as possible
execute them in a sequence, and then call Indexed::step rather than calling it after
every single write and read. Doing so should amortize the cost of creating Future and
Trace batches over more commands.