### PR TITLE
Allow Python based workflows

### DIFF
--- a/bin/pycheck
+++ b/bin/pycheck
@@ -31,6 +31,7 @@ try xargs bin/pyactivate --dev -m mypy \
     --no-error-summary \
     --namespace-packages \
     --explicit-package-bases \
+    --python-version 3.8 \
     <<< "$py_files"
 try bin/pyactivate --dev -m pytest -qq --doctest-modules misc/python
 

--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -18,9 +18,8 @@ import webbrowser
 from pathlib import Path
 from typing import IO, List, Optional, Sequence, Text, Tuple
 
-from typing_extensions import NoReturn
-
 from materialize import errors, mzbuild, mzcompose, spawn, ui
+from typing_extensions import NoReturn
 
 announce = ui.speaker("==> ")
 say = ui.speaker("")
@@ -117,7 +116,7 @@ def main(argv: List[str]) -> int:
 
         try:
             workflow = composition.get_workflow(
-                dict(os.environ), args.first_command_arg
+                args.first_command_arg, dict(os.environ)
             )
         except KeyError:
             # Restart any dependencies whose definitions have changed. This is
@@ -200,7 +199,9 @@ def list_compositions(repo: mzbuild.Repository) -> int:
 
 
 def list_workflows(composition: mzcompose.Composition) -> int:
-    for name in sorted(composition.workflows):
+    for name in sorted(
+        list(composition.yaml_workflows) + list(composition.python_funcs)
+    ):
         print(name)
     return 0
 

--- a/test/mzworkflows_py/README.md
+++ b/test/mzworkflows_py/README.md
@@ -1,0 +1,5 @@
+An example of python-based workflows that does not actually test anything.
+
+If the directory contains a file named mzworkflows.py, all functions
+from it that start with 'workflow_' will be made available for execution
+as if they are regular mzcompose.yml workflows.

--- a/test/mzworkflows_py/mzcompose
+++ b/test/mzworkflows_py/mzcompose
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# mzcompose — runs Docker Compose with Materialize customizations.
+
+exec "$(dirname "$0")/../../bin/mzcompose" "$@"

--- a/test/mzworkflows_py/mzcompose.yml
+++ b/test/mzworkflows_py/mzcompose.yml
@@ -1,0 +1,34 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+version: '3.7'
+
+mzworkflows:
+  mzworkflows_py:
+    steps:
+      - step: start-services
+        services: [materialized]
+
+      - step: wait-for-mz
+        service: materialized
+
+      - step: workflow
+        workflow: workflow_in_python
+
+services:
+  materialized:
+    mzbuild: materialized
+    command: >-
+      --data-directory=/share/mzdata1
+      --experimental
+      --disable-telemetry
+    ports:
+      - 6875
+    environment:
+      - MZ_DEV=1

--- a/test/mzworkflows_py/mzworkflows.py
+++ b/test/mzworkflows_py/mzworkflows.py
@@ -1,0 +1,14 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+import materialize.mzcompose
+
+
+def workflow_in_python(composition: materialize.mzcompose.Composition):
+    pass


### PR DESCRIPTION
@benesch  This implements your idea from #6439 . If you are OK with this approach, I have a further design that will allow the python workflows to start services so that you will not need to have a `.yml` file with a `services` section at all.