### PR TITLE
materialized: remove mz_server_scrape_metrics_times metric

### DIFF
--- a/src/materialized/src/http.rs
+++ b/src/materialized/src/http.rs
@@ -172,12 +172,9 @@ impl Server {
 
                 let res = match (req.method(), req.uri().path()) {
                     (&Method::GET, "/") => root::handle_home(req, &mut coord_client).await,
-                    (&Method::GET, "/metrics") => metrics::handle_prometheus(
-                        req,
-                        &metrics_registry,
-                        &global_metrics,
-                        MetricsVariant::Regular,
-                    ),
+                    (&Method::GET, "/metrics") => {
+                        metrics::handle_prometheus(req, &metrics_registry, MetricsVariant::Regular)
+                    }
                     (&Method::GET, "/status") => metrics::handle_status(
                         req,
                         &mut coord_client,
@@ -281,7 +278,6 @@ impl hyper::service::Service<Request<Body>> for ThirdPartyServer {
                     match metrics::handle_prometheus(
                         req,
                         &server.metrics_registry,
-                        &server.global_metrics,
                         metrics::MetricsVariant::ThirdPartyVisible,
                     ) {
                         Ok(response) => Ok(response),

--- a/src/materialized/src/http/metrics.rs
+++ b/src/materialized/src/http/metrics.rs
@@ -9,18 +9,16 @@
 
 //! Metrics HTTP endpoints.
 
-use crate::{Metrics, BUILD_INFO};
 use std::collections::{BTreeMap, BTreeSet};
-use std::time::Instant;
 
 use askama::Template;
 use hyper::{Body, Request, Response};
 use ore::metrics::MetricsRegistry;
-use prometheus::proto::MetricFamily;
 use prometheus::Encoder;
 
 use crate::http::util;
 use crate::server_metrics::PromMetric;
+use crate::{Metrics, BUILD_INFO};
 
 #[derive(Template)]
 #[template(path = "http/templates/status.html")]
@@ -37,62 +35,19 @@ pub enum MetricsVariant {
     ThirdPartyVisible,
 }
 
-impl MetricsVariant {
-    fn gather_from(&self, registry: &MetricsRegistry) -> Vec<MetricFamily> {
-        match self {
-            MetricsVariant::Regular => registry.gather(),
-            MetricsVariant::ThirdPartyVisible => registry.gather_third_party_visible(),
-        }
-    }
-
-    fn set_gather_duration_metric(&self, global_metrics: &Metrics, before_gather: &Instant) {
-        match self {
-            MetricsVariant::Regular => global_metrics
-                .request_metrics_gather
-                .set(Instant::elapsed(&before_gather).as_micros() as u64),
-            MetricsVariant::ThirdPartyVisible => global_metrics
-                .third_party_request_metrics_gather
-                .set(Instant::elapsed(&before_gather).as_micros() as u64),
-        }
-    }
-
-    fn set_encode_duration_metric(&self, global_metrics: &Metrics, start: &Instant) {
-        match self {
-            MetricsVariant::Regular => global_metrics
-                .request_metrics_encode
-                .set(Instant::elapsed(&start).as_micros() as u64),
-            MetricsVariant::ThirdPartyVisible => global_metrics
-                .third_party_request_metrics_encode
-                .set(Instant::elapsed(&start).as_micros() as u64),
-        }
-    }
-}
-
-/// Call [`prometheus::gather`], ensuring that all our metrics are up to date
-fn load_prom_metrics(
-    registry: &MetricsRegistry,
-    variant: MetricsVariant,
-    global_metrics: &Metrics,
-) -> Vec<prometheus::proto::MetricFamily> {
-    let before_gather = Instant::now();
-    let result = variant.gather_from(registry);
-    variant.set_gather_duration_metric(global_metrics, &before_gather);
-    result
-}
-
 /// Serves metrics from the selected metrics registry variant.
 pub fn handle_prometheus(
     _: Request<Body>,
     registry: &MetricsRegistry,
-    global_metrics: &Metrics,
     variant: MetricsVariant,
 ) -> Result<Response<Body>, anyhow::Error> {
-    let metric_families = load_prom_metrics(registry, variant, global_metrics);
+    let metric_families = match variant {
+        MetricsVariant::Regular => registry.gather(),
+        MetricsVariant::ThirdPartyVisible => registry.gather_third_party_visible(),
+    };
     let mut buffer = Vec::new();
     let encoder = prometheus::TextEncoder::new();
-    let start = Instant::now();
     encoder.encode(&metric_families, &mut buffer)?;
-    variant.set_encode_duration_metric(global_metrics, &start);
     Ok(Response::new(Body::from(buffer)))
 }
 
@@ -100,9 +55,9 @@ pub fn handle_status(
     _: Request<Body>,
     _: &mut coord::SessionClient,
     registry: &MetricsRegistry,
-    global_metrics: &Metrics,
+    _: &Metrics,
 ) -> Result<Response<Body>, anyhow::Error> {
-    let metric_families = load_prom_metrics(registry, MetricsVariant::Regular, global_metrics);
+    let metric_families = registry.gather();
 
     let desired_metrics = {
         let mut s = BTreeSet::new();

--- a/src/materialized/src/server_metrics.rs
+++ b/src/materialized/src/server_metrics.rs
@@ -18,8 +18,7 @@ use sysinfo::{ProcessorExt, SystemExt};
 use ore::cast::CastFrom;
 use ore::cgroup::{self, MemoryLimit};
 use ore::metric;
-use ore::metrics::ThirdPartyMetric;
-use ore::metrics::{ComputedGauge, MetricsRegistry, UIntGauge, UIntGaugeVec};
+use ore::metrics::{ComputedGauge, MetricsRegistry, UIntGauge};
 use ore::option::OptionExt;
 
 use crate::BUILD_INFO;
@@ -31,16 +30,6 @@ pub struct Metrics {
     pub worker_count: UIntGauge,
     /// The number of seconds that the system has been running.
     pub uptime: ComputedGauge,
-    /// The amount of time we spend gathering metrics in prometheus endpoints.
-    pub request_metrics_gather: UIntGauge,
-    /// The amount of time we spend encoding metrics in prometheus endpoints.
-    pub request_metrics_encode: UIntGauge,
-    /// The amount of time we spend gathering third-party metrics in prometheus
-    /// endpoints.
-    pub third_party_request_metrics_gather: UIntGauge,
-    /// The amount of time we spend encoding third-party metrics in prometheus
-    /// endpoints.
-    pub third_party_request_metrics_encode: UIntGauge,
 }
 
 impl Metrics {
@@ -91,23 +80,9 @@ impl Metrics {
             )
         };
 
-        let request_metrics: ThirdPartyMetric<UIntGaugeVec> = registry.register_third_party_visible(metric!(
-            name: "mz_server_scrape_metrics_times",
-            help: "how long it took to gather metrics, used for very low frequency high accuracy measures",
-            var_labels: ["action"],
-        ));
-
         Self {
             worker_count,
             uptime,
-            request_metrics_gather: request_metrics
-                .third_party_metric_with_label_values(&["gather"]),
-            request_metrics_encode: request_metrics
-                .third_party_metric_with_label_values(&["encode"]),
-            third_party_request_metrics_encode: request_metrics
-                .third_party_metric_with_label_values(&["gather_third_party"]),
-            third_party_request_metrics_gather: request_metrics
-                .third_party_metric_with_label_values(&["encode_third_party"]),
         }
     }
 }


### PR DESCRIPTION
Per @quodlibetor on Slack, Prometheus already tracks scrape timing
itself, so we don't need our own metric for it.