### PR TITLE
misc/www: add sudo to oneliners

### DIFF
--- a/doc/user/content/install.md
+++ b/doc/user/content/install.md
@@ -45,32 +45,30 @@ brew install MaterializeInc/materialize/materialized
 
 ```shell
 curl -L https://binaries.materialize.com/materialized-{{< version >}}-x86_64-apple-darwin.tar.gz \
-    | tar -xzC /usr/local --strip-components=1
+    | sudo tar -xzC /usr/local --strip-components=1
 ```
 
 ## Linux installation
 
 ### apt (Ubuntu, Debian, or variants)
 
-Run the following commands as root.
-
 **Note!** These instructions changed between versions 0.8.0 and 0.8.1. If you ran them
 previously, you may need to do so again to continue receiving updates.
 
 ```shell
 # Add the signing key for the Materialize apt repository
-apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 79DEC5E1B7AE7694
+sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 79DEC5E1B7AE7694
 # Add and update the repository
-sh -c 'echo "deb http://apt.materialize.com/ generic main" > /etc/apt/sources.list.d/materialize.list'
-apt update
+sudo sh -c 'echo "deb http://apt.materialize.com/ generic main" > /etc/apt/sources.list.d/materialize.list'
+sudo apt update
 # Install materialized
-apt install materialized
+sudo apt install materialized
 ```
 
 ### curl
 ```shell
 curl -L https://binaries.materialize.com/materialized-{{< version >}}-x86_64-unknown-linux-gnu.tar.gz \
-    | tar -xzC /usr/local --strip-components=1
+    | sudo tar -xzC /usr/local --strip-components=1
 ```
 
 ## Build from source

--- a/misc/www/index.html
+++ b/misc/www/index.html
@@ -37,12 +37,12 @@ by the Apache License, Version 2.0.
 
     <p>Linux one-liner:</p>
     <div class="code">
-      $ curl -L https://binaries.materialize.com/materialized-latest-x86_64-unknown-linux-gnu.tar.gz | tar -xzC /usr/local --strip-components=1
+      $ curl -L https://binaries.materialize.com/materialized-latest-x86_64-unknown-linux-gnu.tar.gz | sudo tar -xzC /usr/local --strip-components=1
     </div>
 
     <p>macOS one-liner:</p>
     <div class="code">
-      $ curl -L https://binaries.materialize.com/materialized-latest-x86_64-apple-darwin.tar.gz | tar -xzC /usr/local --strip-components=1
+      $ curl -L https://binaries.materialize.com/materialized-latest-x86_64-apple-darwin.tar.gz | sudo tar -xzC /usr/local --strip-components=1
     </div>
 
     <p>Resources:</p>


### PR DESCRIPTION
Unpacking a tarball into a nonwritable directory can fail with some very
obscure errors that have empirically resulted in confusion. Add `sudo`
to instructions to make it easier to copy/paste these commands.

One way to look at it is that people who run in configurations that
don't need sudo are likely to be savvy enough to remove sudo from the
commands, but the converse often isn't true.

Touches part of #7812.