### PR TITLE
materialized: remove most metrics from /status

### DIFF
--- a/src/materialized/src/http.rs
+++ b/src/materialized/src/http.rs
@@ -59,6 +59,7 @@ pub struct Config {
     pub coord_client: coord::Client,
     pub metrics_registry: MetricsRegistry,
     pub global_metrics: Metrics,
+    pub pgwire_metrics: pgwire::Metrics,
 }
 
 #[derive(Debug, Clone)]
@@ -79,6 +80,7 @@ pub struct Server {
     coord_client: coord::Client,
     metrics_registry: MetricsRegistry,
     global_metrics: Metrics,
+    pgwire_metrics: pgwire::Metrics,
 }
 
 impl Server {
@@ -88,6 +90,7 @@ impl Server {
             coord_client: config.coord_client,
             metrics_registry: config.metrics_registry,
             global_metrics: config.global_metrics,
+            pgwire_metrics: config.pgwire_metrics,
         }
     }
 
@@ -152,6 +155,7 @@ impl Server {
             let coord_client = self.coord_client.clone();
             let metrics_registry = self.metrics_registry.clone();
             let global_metrics = self.global_metrics.clone();
+            let pgwire_metrics = self.pgwire_metrics.clone();
             let future = async move {
                 let user = match user {
                     Ok(user) => user,
@@ -178,8 +182,8 @@ impl Server {
                     (&Method::GET, "/status") => metrics::handle_status(
                         req,
                         &mut coord_client,
-                        &metrics_registry,
                         &global_metrics,
+                        &pgwire_metrics,
                     ),
                     (&Method::GET, "/prof") => prof::handle_prof(req, &mut coord_client).await,
                     (&Method::GET, "/memory") => memory::handle_memory(req, &mut coord_client),

--- a/src/materialized/src/http/metrics.rs
+++ b/src/materialized/src/http/metrics.rs
@@ -9,15 +9,12 @@
 
 //! Metrics HTTP endpoints.
 
-use std::collections::{BTreeMap, BTreeSet};
-
 use askama::Template;
 use hyper::{Body, Request, Response};
 use ore::metrics::MetricsRegistry;
 use prometheus::Encoder;
 
 use crate::http::util;
-use crate::server_metrics::PromMetric;
 use crate::{Metrics, BUILD_INFO};
 
 #[derive(Template)]
@@ -26,7 +23,6 @@ struct StatusTemplate<'a> {
     version: &'a str,
     query_count: u64,
     uptime_seconds: f64,
-    metrics: Vec<&'a PromMetric<'a>>,
 }
 
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -54,82 +50,12 @@ pub fn handle_prometheus(
 pub fn handle_status(
     _: Request<Body>,
     _: &mut coord::SessionClient,
-    registry: &MetricsRegistry,
-    _: &Metrics,
+    global_metrics: &Metrics,
+    pgwire_metrics: &pgwire::Metrics,
 ) -> Result<Response<Body>, anyhow::Error> {
-    let metric_families = registry.gather();
-
-    let desired_metrics = {
-        let mut s = BTreeSet::new();
-        s.insert("mz_dataflow_events_read_total");
-        s.insert("mz_bytes_read_total");
-        s.insert("mz_worker_command_queue_size");
-        s.insert("mz_command_durations");
-        s
-    };
-
-    let mut uptime_seconds = 0.0;
-    let mut metrics = BTreeMap::new();
-    for metric in &metric_families {
-        let converted = PromMetric::from_metric_family(metric);
-        match converted {
-            Ok(m) => {
-                for m in m {
-                    match m {
-                        PromMetric::Counter { name, .. } => {
-                            if desired_metrics.contains(name) {
-                                metrics.insert(name.to_string(), m);
-                            }
-                        }
-                        PromMetric::Gauge { name, value, .. } => {
-                            if desired_metrics.contains(name) {
-                                metrics.insert(name.to_string(), m);
-                            }
-                            if name == "mz_server_metadata_seconds" {
-                                uptime_seconds = value;
-                            }
-                        }
-                        PromMetric::Histogram {
-                            name, ref labels, ..
-                        } => {
-                            if desired_metrics.contains(name) {
-                                metrics.insert(
-                                    format!("{}:{}", name, labels.get("command").unwrap_or(&"")),
-                                    m,
-                                );
-                            }
-                        }
-                    }
-                }
-            }
-            Err(_) => continue,
-        };
-    }
-    let mut query_count = metrics
-        .get("mz_command_durations:query")
-        .map(|m| {
-            if let PromMetric::Histogram { count, .. } = m {
-                *count
-            } else {
-                0
-            }
-        })
-        .unwrap_or(0);
-    query_count += metrics
-        .get("mz_command_durations:execute")
-        .map(|m| {
-            if let PromMetric::Histogram { count, .. } = m {
-                *count
-            } else {
-                0
-            }
-        })
-        .unwrap_or(0);
-
     Ok(util::template_response(StatusTemplate {
         version: BUILD_INFO.version,
-        query_count,
-        uptime_seconds,
-        metrics: metrics.values().collect(),
+        query_count: pgwire_metrics.query_count.get(),
+        uptime_seconds: global_metrics.uptime.get(),
     }))
 }

--- a/src/materialized/src/http/templates/status.html
+++ b/src/materialized/src/http/templates/status.html
@@ -4,14 +4,9 @@
 
 {% block content %}
 <p>
-    materialized OK.<br/>
-    handled {{ query_count }} queries so far.<br/>
-    up for {{ uptime_seconds }} seconds
+    materialized OK. <br>
+    Version v{{ version }}.<br>
+    Handled {{ query_count }} queries so far.<br>
+    Up for {{ uptime_seconds }} seconds.<br>
 </p>
-
-<pre>
-{% for metric in metrics %}
-{{ metric }}
-{% endfor %}
-</pre>
 {% endblock %}

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -258,18 +258,21 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
     // terminated, this task exits.
     let (drain_trigger, drain_tripwire) = oneshot::channel();
     tokio::spawn({
-        let mut mux = Mux::new();
-        mux.add_handler(pgwire::Server::new(pgwire::Config {
+        let pgwire_server = pgwire::Server::new(pgwire::Config {
             tls: pgwire_tls,
             coord_client: coord_client.clone(),
             metrics_registry: &metrics_registry,
-        }));
-        mux.add_handler(http::Server::new(http::Config {
+        });
+        let http_server = http::Server::new(http::Config {
             tls: http_tls,
             coord_client: coord_client.clone(),
             metrics_registry: metrics_registry,
             global_metrics: metrics,
-        }));
+            pgwire_metrics: pgwire_server.metrics(),
+        });
+        let mut mux = Mux::new();
+        mux.add_handler(pgwire_server);
+        mux.add_handler(http_server);
         async move {
             // TODO(benesch): replace with `listener.incoming()` if that is
             // restored when the `Stream` trait stabilizes.

--- a/src/materialized/src/server_metrics.rs
+++ b/src/materialized/src/server_metrics.rs
@@ -9,8 +9,6 @@
 
 //! Tools for interacting with Prometheus metrics
 
-use std::collections::BTreeMap;
-use std::fmt;
 use std::time::Instant;
 
 use sysinfo::{ProcessorExt, SystemExt};
@@ -84,96 +82,5 @@ impl Metrics {
             worker_count,
             uptime,
         }
-    }
-}
-
-#[derive(Debug)]
-pub enum PromMetric<'a> {
-    Counter {
-        name: &'a str,
-        value: f64,
-        labels: BTreeMap<&'a str, &'a str>,
-    },
-    Gauge {
-        name: &'a str,
-        value: f64,
-        labels: BTreeMap<&'a str, &'a str>,
-    },
-    Histogram {
-        name: &'a str,
-        count: u64,
-        labels: BTreeMap<&'a str, &'a str>,
-    },
-}
-
-impl fmt::Display for PromMetric<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fn fmt(
-            f: &mut fmt::Formatter,
-            name: &str,
-            value: impl fmt::Display,
-            labels: &BTreeMap<&str, &str>,
-        ) -> fmt::Result {
-            write!(f, "{} ", name)?;
-            for (n, v) in labels.iter() {
-                write!(f, "{}={} ", n, v)?;
-            }
-            writeln!(f, "{}", value)
-        }
-        match self {
-            PromMetric::Counter {
-                name,
-                value,
-                labels,
-            } => fmt(f, name, value, labels),
-            PromMetric::Gauge {
-                name,
-                value,
-                labels,
-            } => fmt(f, name, value, labels),
-            PromMetric::Histogram {
-                name,
-                count,
-                labels,
-            } => fmt(f, name, count, labels),
-        }
-    }
-}
-
-impl<'p> PromMetric<'p> {
-    pub fn from_metric_family<'a>(
-        m: &'a prometheus::proto::MetricFamily,
-    ) -> Result<Vec<PromMetric<'a>>, ()> {
-        use prometheus::proto::MetricType;
-        fn l2m(metric: &prometheus::proto::Metric) -> BTreeMap<&str, &str> {
-            metric
-                .get_label()
-                .iter()
-                .map(|lp| (lp.get_name(), lp.get_value()))
-                .collect()
-        }
-        m.get_metric()
-            .iter()
-            .map(|metric| {
-                Ok(match m.get_field_type() {
-                    MetricType::COUNTER => PromMetric::Counter {
-                        name: m.get_name(),
-                        value: metric.get_counter().get_value(),
-                        labels: l2m(metric),
-                    },
-                    MetricType::GAUGE => PromMetric::Gauge {
-                        name: m.get_name(),
-                        value: metric.get_gauge().get_value(),
-                        labels: l2m(metric),
-                    },
-                    MetricType::HISTOGRAM => PromMetric::Histogram {
-                        name: m.get_name(),
-                        count: metric.get_histogram().get_sample_count(),
-                        labels: l2m(metric),
-                    },
-                    _ => return Err(()),
-                })
-            })
-            .collect()
     }
 }

--- a/src/pgwire/src/lib.rs
+++ b/src/pgwire/src/lib.rs
@@ -28,5 +28,6 @@ mod metrics;
 mod protocol;
 mod server;
 
+pub use metrics::Metrics;
 pub use protocol::match_handshake;
 pub use server::{Config, Server, TlsConfig, TlsMode};

--- a/src/pgwire/src/metrics.rs
+++ b/src/pgwire/src/metrics.rs
@@ -17,6 +17,7 @@ pub struct Metrics {
     pub command_durations: HistogramVec,
     pub bytes_sent: UIntCounter,
     pub rows_returned: UIntCounter,
+    pub query_count: UIntCounter,
 }
 
 impl Metrics {
@@ -26,6 +27,11 @@ impl Metrics {
                 name: "mz_command_durations",
                 help: "how long individual commands took",
                 var_labels: ["command", "status"],
+            )),
+
+            query_count: registry.register(metric!(
+                name: "mz_query_count",
+                help: "total number of queries executed",
             )),
 
             rows_returned: registry.register(metric!(

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -274,6 +274,7 @@ where
                 portal_name,
                 max_rows,
             }) => {
+                self.metrics.query_count.inc();
                 let max_rows = match usize::try_from(max_rows) {
                     Ok(0) | Err(_) => ExecuteCount::All, // If `max_rows < 0`, no limit.
                     Ok(n) => ExecuteCount::Count(n),
@@ -365,6 +366,7 @@ where
             }
         }
 
+        self.metrics.query_count.inc();
         let result = match self.coord_client.execute(EMPTY_PORTAL.to_string()).await {
             Ok(response) => {
                 self.send_execute_response(

--- a/src/pgwire/src/server.rs
+++ b/src/pgwire/src/server.rs
@@ -19,6 +19,7 @@ use tokio::io::{self, AsyncRead, AsyncWrite, AsyncWriteExt, Interest, ReadBuf, R
 use tokio_openssl::SslStream;
 
 use ore::cast::CastFrom;
+use ore::metrics::MetricsRegistry;
 use ore::netio::AsyncReady;
 
 use crate::codec::{self, FramedConn, ACCEPT_SSL_ENCRYPTION, REJECT_ENCRYPTION};
@@ -38,7 +39,7 @@ pub struct Config<'a> {
     pub tls: Option<TlsConfig>,
 
     /// The registry that the pg wire server uses to report metrics.
-    pub metrics_registry: &'a ore::metrics::MetricsRegistry,
+    pub metrics_registry: &'a MetricsRegistry,
 }
 
 /// Configures a server's TLS encryption and authentication.
@@ -151,6 +152,10 @@ impl Server {
                 }
             }
         }
+    }
+
+    pub fn metrics(&self) -> Metrics {
+        self.metrics.clone()
     }
 }
 


### PR DESCRIPTION
Per @quodlibetor, it turns out folks weren't that interested in having a
set of human readable metrics on the /status page, and nearly everyone
who cares just wires up a Grafana dashboard using /metrics. So, ditch
most of the metrics on the /status page, keeping only the version, query
count, and uptime. This removes a bunch of hairy Prometheus-wrangling
code.

I also refactored the query count into a separate metric, so we don't
have to go trawling through histogram summaries to derive it.