### PR TITLE
materialized: use PID file for mutual exclusion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2144,6 +2144,7 @@ dependencies = [
  "pgrepr",
  "pgtest",
  "pgwire",
+ "pid-file",
  "postgres",
  "postgres-openssl",
  "postgres-protocol",
@@ -2814,6 +2815,16 @@ checksum = "a68318426de33640f02be62b4ae8eb1261be2efbc337b60c54d845bf4484e0d9"
 dependencies = [
  "siphasher",
  "uncased",
+]
+
+[[package]]
+name = "pid-file"
+version = "0.0.0"
+dependencies = [
+ "cc",
+ "libc",
+ "ore",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "src/ore",
     "src/peeker",
     "src/persist",
+    "src/pid-file",
     "src/pgrepr",
     "src/pgtest",
     "src/pgwire",

--- a/bin/lint
+++ b/bin/lint
@@ -56,6 +56,7 @@ copyright_files=$(grep -vE \
     -e '^ci/builder/(ssh_known_hosts|stable.stamp|nightly.stamp|crosstool.defconfig)$' \
     -e '^ci/www/public/_redirects$' \
     -e 'demo/chbench/chbench' \
+    -e 'src/pid-file/libbsd' \
     -e 'test/sqllogictest/postgres/testdata/.*\.data' \
     -e 'test/pgtest/.*\.pt' \
     -e 'test/coordtest/.*\.ct' \

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -60,6 +60,7 @@ openssl = { version = "0.10.35", features = ["vendored"] }
 openssl-sys = { version = "0.9.65", features = ["vendored"] }
 ore = { path = "../ore" }
 os_info = "3.0.6"
+pid-file = { path = "../pid-file" }
 pgwire = { path = "../pgwire" }
 prof = { path = "../prof" }
 prometheus = { git = "https://github.com/MaterializeInc/rust-prometheus.git", default-features = false }

--- a/src/pid-file/Cargo.toml
+++ b/src/pid-file/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "pid-file"
+description = "PID file management."
+version = "0.0.0"
+edition = "2018"
+publish = false
+
+[dependencies]
+libc = "0.2.99"
+ore = { path = "../ore", default-features = false }
+
+[dev-dependencies]
+tempfile = "3.2.0"
+
+[build-dependencies]
+cc = "1.0.69"

--- a/src/pid-file/build.rs
+++ b/src/pid-file/build.rs
@@ -1,0 +1,18 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+fn main() {
+    cc::Build::new()
+        .include("libbsd/include")
+        .define("_GNU_SOURCE", None)
+        .file("libbsd/src/flopen.c")
+        .file("libbsd/src/pidfile.c")
+        .file("libbsd/src/progname.c")
+        .compile("pidfile");
+}

--- a/src/pid-file/libbsd/README.md
+++ b/src/pid-file/libbsd/README.md
@@ -1,0 +1,20 @@
+# libbsd
+
+This directory contains the subset of [libbsd] that is relevant to PID file
+management.
+
+## Updating
+
+To update to a new version of libbsd, bump the version number in `update.sh`
+and then run the script.
+
+Note that only the files in `src` are managed by the script. You may need to
+adjust the `include/libutil.h` header by hand to account for changes to the
+libbsd functions. You may also need to pull in additional C files and adjust
+the `build.rs` build script accordingly.
+
+If any of the function signatures change, you'll also need to update the
+`extern` declarations in Rust. The set of functions is small enough that it's
+not worth using bindgen.
+
+[libbsd]: https://libbsd.freedesktop.org/wiki/

--- a/src/pid-file/libbsd/include/libutil.h
+++ b/src/pid-file/libbsd/include/libutil.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 1996  Peter Wemm <peter@FreeBSD.org>.
+ * All rights reserved.
+ * Copyright (c) 2002 Networks Associates Technology, Inc.
+ * All rights reserved.
+ *
+ * Portions of this software were developed for the FreeBSD Project by
+ * ThinkSec AS and NAI Labs, the Security Research Division of Network
+ * Associates, Inc.  under DARPA/SPAWAR contract N66001-01-C-8035
+ * ("CBOSS"), as part of the DARPA CHATS research program.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, is permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote
+ *    products derived from this software without specific prior written
+ *    permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $FreeBSD: src/lib/libutil/libutil.h,v 1.47 2008/04/23 00:49:12 scf Exp $
+ */
+
+const char *getprogname(void);
+void setprogname(const char *);
+
+struct pidfh;
+
+int flopen(const char *_path, int _flags, ...);
+int flopenat(int dirfd, const char *path, int flags, ...);
+
+struct pidfh *pidfile_open(const char *path, mode_t mode, pid_t *pidptr);
+int pidfile_fileno(const struct pidfh *pfh);
+int pidfile_write(struct pidfh *pfh);
+int pidfile_close(struct pidfh *pfh);
+int pidfile_remove(struct pidfh *pfh);

--- a/src/pid-file/libbsd/src/flopen.c
+++ b/src/pid-file/libbsd/src/flopen.c
@@ -1,0 +1,146 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
+ * Copyright (c) 2007-2009 Dag-Erling Coïdan Smørgrav
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer
+ *    in this position and unchanged.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/cdefs.h>
+#include <sys/file.h>
+#include <sys/stat.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdarg.h>
+#include <unistd.h>
+
+#include <libutil.h>
+
+/*
+ * Reliably open and lock a file.
+ *
+ * Please do not modify this code without first reading the revision history
+ * and discussing your changes with <des@freebsd.org>.  Don't be fooled by the
+ * code's apparent simplicity; there would be no need for this function if it
+ * was easy to get right.
+ */
+static int
+vflopenat(int dirfd, const char *path, int flags, va_list ap)
+{
+	int fd, operation, serrno, trunc;
+	struct stat sb, fsb;
+	mode_t mode;
+
+#ifdef O_EXLOCK
+	flags &= ~O_EXLOCK;
+#endif
+
+	mode = 0;
+	if (flags & O_CREAT) {
+		mode = (mode_t)va_arg(ap, int); /* mode_t promoted to int */
+	}
+
+        operation = LOCK_EX;
+        if (flags & O_NONBLOCK)
+                operation |= LOCK_NB;
+
+	trunc = (flags & O_TRUNC);
+	flags &= ~O_TRUNC;
+
+	for (;;) {
+		if ((fd = openat(dirfd, path, flags, mode)) == -1)
+			/* non-existent or no access */
+			return (-1);
+		if (flock(fd, operation) == -1) {
+			/* unsupported or interrupted */
+			serrno = errno;
+			(void)close(fd);
+			errno = serrno;
+			return (-1);
+		}
+		if (fstatat(dirfd, path, &sb, 0) == -1) {
+			/* disappeared from under our feet */
+			(void)close(fd);
+			continue;
+		}
+		if (fstat(fd, &fsb) == -1) {
+			/* can't happen [tm] */
+			serrno = errno;
+			(void)close(fd);
+			errno = serrno;
+			return (-1);
+		}
+		if (sb.st_dev != fsb.st_dev ||
+		    sb.st_ino != fsb.st_ino) {
+			/* changed under our feet */
+			(void)close(fd);
+			continue;
+		}
+		if (trunc && ftruncate(fd, 0) != 0) {
+			/* can't happen [tm] */
+			serrno = errno;
+			(void)close(fd);
+			errno = serrno;
+			return (-1);
+		}
+		/*
+		 * The following change is provided as a specific example to
+		 * avoid.
+		 */
+#if 0
+		if (fcntl(fd, F_SETFD, FD_CLOEXEC) != 0) {
+			serrno = errno;
+			(void)close(fd);
+			errno = serrno;
+			return (-1);
+		}
+#endif
+		return (fd);
+	}
+}
+
+int
+flopen(const char *path, int flags, ...)
+{
+	va_list ap;
+	int ret;
+
+	va_start(ap, flags);
+	ret = vflopenat(AT_FDCWD, path, flags, ap);
+	va_end(ap);
+	return (ret);
+}
+
+int
+flopenat(int dirfd, const char *path, int flags, ...)
+{
+	va_list ap;
+	int ret;
+
+	va_start(ap, flags);
+	ret = vflopenat(dirfd, path, flags, ap);
+	va_end(ap);
+	return (ret);
+}

--- a/src/pid-file/libbsd/src/pidfile.c
+++ b/src/pid-file/libbsd/src/pidfile.c
@@ -1,0 +1,279 @@
+/*-
+ * Copyright (c) 2005 Pawel Jakub Dawidek <pjd@FreeBSD.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHORS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/cdefs.h>
+#include <sys/param.h>
+#include <sys/file.h>
+#include <sys/stat.h>
+
+#include <err.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <libutil.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+struct pidfh {
+	int	pf_fd;
+	char	*pf_path;
+	dev_t	pf_dev;
+	ino_t	pf_ino;
+};
+
+static int _pidfile_remove(struct pidfh *pfh, int freeit);
+
+static int
+pidfile_verify(const struct pidfh *pfh)
+{
+	struct stat sb;
+
+	if (pfh == NULL || pfh->pf_fd == -1)
+		return (EINVAL);
+	/*
+	 * Check remembered descriptor.
+	 */
+	if (fstat(pfh->pf_fd, &sb) == -1)
+		return (errno);
+	if (sb.st_dev != pfh->pf_dev || sb.st_ino != pfh->pf_ino)
+		return (EINVAL);
+	return (0);
+}
+
+static int
+pidfile_read(const char *path, pid_t *pidptr)
+{
+	char buf[16], *endptr;
+	int error, fd, i;
+
+	fd = open(path, O_RDONLY);
+	if (fd == -1)
+		return (errno);
+
+	i = read(fd, buf, sizeof(buf) - 1);
+	error = errno;	/* Remember errno in case close() wants to change it. */
+	close(fd);
+	if (i == -1)
+		return (error);
+	else if (i == 0)
+		return (EAGAIN);
+	buf[i] = '\0';
+
+	*pidptr = strtol(buf, &endptr, 10);
+	if (endptr != &buf[i])
+		return (EINVAL);
+
+	return (0);
+}
+
+struct pidfh *
+pidfile_open(const char *path, mode_t mode, pid_t *pidptr)
+{
+	struct pidfh *pfh;
+	struct stat sb;
+	int error, fd, len, count;
+	struct timespec rqtp;
+
+	pfh = malloc(sizeof(*pfh));
+	if (pfh == NULL)
+		return (NULL);
+
+	if (path == NULL) {
+		len = asprintf(&pfh->pf_path, "/var/run/%s.pid", getprogname());
+		if (len < 0) {
+			free(pfh);
+			return (NULL);
+		}
+	} else
+		pfh->pf_path = strdup(path);
+
+	/*
+	 * Open the PID file and obtain exclusive lock.
+	 * We truncate PID file here only to remove old PID immediately,
+	 * PID file will be truncated again in pidfile_write(), so
+	 * pidfile_write() can be called multiple times.
+	 */
+	fd = flopen(pfh->pf_path,
+	    O_WRONLY | O_CREAT | O_TRUNC | O_NONBLOCK, mode);
+	if (fd == -1) {
+		if (errno == EWOULDBLOCK) {
+			if (pidptr == NULL) {
+				errno = EEXIST;
+			} else {
+				count = 20;
+				rqtp.tv_sec = 0;
+				rqtp.tv_nsec = 5000000;
+				for (;;) {
+					errno = pidfile_read(pfh->pf_path,
+					                     pidptr);
+					if (errno != EAGAIN || --count == 0)
+						break;
+					nanosleep(&rqtp, 0);
+				}
+				if (errno == EAGAIN)
+					*pidptr = -1;
+				if (errno == 0 || errno == EAGAIN)
+					errno = EEXIST;
+			}
+		}
+		error = errno;
+		free(pfh->pf_path);
+		free(pfh);
+		errno = error;
+		return (NULL);
+	}
+
+	/*
+	 * Remember file information, so in pidfile_write() we are sure we write
+	 * to the proper descriptor.
+	 */
+	if (fstat(fd, &sb) == -1) {
+		error = errno;
+		unlink(pfh->pf_path);
+		free(pfh->pf_path);
+		close(fd);
+		free(pfh);
+		errno = error;
+		return (NULL);
+	}
+
+	pfh->pf_fd = fd;
+	pfh->pf_dev = sb.st_dev;
+	pfh->pf_ino = sb.st_ino;
+
+	return (pfh);
+}
+
+int
+pidfile_write(struct pidfh *pfh)
+{
+	char pidstr[16];
+	int error, fd;
+
+	/*
+	 * Check remembered descriptor, so we don't overwrite some other
+	 * file if pidfile was closed and descriptor reused.
+	 */
+	errno = pidfile_verify(pfh);
+	if (errno != 0) {
+		/*
+		 * Don't close descriptor, because we are not sure if it's ours.
+		 */
+		return (-1);
+	}
+	fd = pfh->pf_fd;
+
+	/*
+	 * Truncate PID file, so multiple calls of pidfile_write() are allowed.
+	 */
+	if (ftruncate(fd, 0) == -1) {
+		error = errno;
+		_pidfile_remove(pfh, 0);
+		errno = error;
+		return (-1);
+	}
+
+	snprintf(pidstr, sizeof(pidstr), "%u", getpid());
+	if (pwrite(fd, pidstr, strlen(pidstr), 0) != (ssize_t)strlen(pidstr)) {
+		error = errno;
+		_pidfile_remove(pfh, 0);
+		errno = error;
+		return (-1);
+	}
+
+	return (0);
+}
+
+int
+pidfile_close(struct pidfh *pfh)
+{
+	int error;
+
+	error = pidfile_verify(pfh);
+	if (error != 0) {
+		errno = error;
+		return (-1);
+	}
+
+	if (close(pfh->pf_fd) == -1)
+		error = errno;
+	free(pfh->pf_path);
+	free(pfh);
+	if (error != 0) {
+		errno = error;
+		return (-1);
+	}
+	return (0);
+}
+
+static int
+_pidfile_remove(struct pidfh *pfh, int freeit)
+{
+	int error;
+
+	error = pidfile_verify(pfh);
+	if (error != 0) {
+		errno = error;
+		return (-1);
+	}
+
+	if (unlink(pfh->pf_path) == -1)
+		error = errno;
+	if (close(pfh->pf_fd) == -1) {
+		if (error == 0)
+			error = errno;
+	}
+	if (freeit) {
+		free(pfh->pf_path);
+		free(pfh);
+	} else
+		pfh->pf_fd = -1;
+	if (error != 0) {
+		errno = error;
+		return (-1);
+	}
+	return (0);
+}
+
+int
+pidfile_remove(struct pidfh *pfh)
+{
+
+	return (_pidfile_remove(pfh, 1));
+}
+
+int
+pidfile_fileno(const struct pidfh *pfh)
+{
+
+	if (pfh == NULL || pfh->pf_fd == -1) {
+		errno = EINVAL;
+		return (-1);
+	}
+	return (pfh->pf_fd);
+}

--- a/src/pid-file/libbsd/src/progname.c
+++ b/src/pid-file/libbsd/src/progname.c
@@ -1,0 +1,146 @@
+/*
+ * Copyright © 2006 Robert Millan
+ * Copyright © 2010-2012 Guillem Jover <guillem@hadrons.org>
+ * Copyright © 2018 Facebook, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL
+ * THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Rejected in glibc
+ * <https://sourceware.org/ml/libc-alpha/2006-03/msg00125.html>.
+ */
+
+#include <sys/param.h>
+#include <errno.h>
+#include <string.h>
+#include <stdlib.h>
+#ifdef _WIN32
+#include <Windows.h>
+#include <shlwapi.h>
+#endif
+
+#ifdef _WIN32
+#define LIBBSD_IS_PATHNAME_SEPARATOR(c) ((c) == '/' || (c) == '\\')
+#else
+#define LIBBSD_IS_PATHNAME_SEPARATOR(c) ((c) == '/')
+#endif
+
+#ifdef HAVE___PROGNAME
+extern const char *__progname;
+#else
+static const char *__progname = NULL;
+#endif
+
+const char *
+getprogname(void)
+{
+#if defined(HAVE_PROGRAM_INVOCATION_SHORT_NAME)
+	if (__progname == NULL)
+		__progname = program_invocation_short_name;
+#elif defined(HAVE_GETEXECNAME)
+	/* getexecname(3) returns an absolute pathname, normalize it. */
+	if (__progname == NULL)
+		setprogname(getexecname());
+#elif defined(_WIN32)
+	if (__progname == NULL) {
+		WCHAR *wpath = NULL;
+		WCHAR *wname = NULL;
+		WCHAR *wext = NULL;
+		DWORD wpathsiz = MAX_PATH / 2;
+		DWORD len, i;
+		char *mbname = NULL;
+		int mbnamesiz;
+
+		/* Use the Unicode version of this function to support long
+		 * paths. MAX_PATH isn't actually the maximum length of a
+		 * path in this case. */
+		do {
+			WCHAR *wpathnew;
+
+			wpathsiz *= 2;
+			wpathsiz = MIN(wpathsiz, UNICODE_STRING_MAX_CHARS);
+			wpathnew = reallocarray(wpath, wpathsiz, sizeof(*wpath));
+			if (wpathnew == NULL)
+				goto done;
+			wpath = wpathnew;
+
+			len = GetModuleFileNameW(NULL, wpath, wpathsiz);
+			if (wpathsiz == UNICODE_STRING_MAX_CHARS)
+				goto done;
+		} while (wpathsiz == len);
+		if (len == 0)
+			goto done;
+
+		/* GetModuleFileNameW() retrieves an absolute path. Locate the
+		 * filename now to only convert necessary characters and save
+		 * memory. */
+		wname = wpath;
+		for (i = len; i > 0; i--) {
+			if (LIBBSD_IS_PATHNAME_SEPARATOR(wpath[i - 1])) {
+				wname = wpath + i;
+				break;
+			}
+		}
+
+		/* Remove any trailing extension, such as '.exe', to make the
+		 * behavior mach the non-Windows systems. */
+		wext = PathFindExtensionW(wname);
+		wext[0] = '\0';
+
+		mbnamesiz = WideCharToMultiByte(CP_UTF8, 0, wname, -1, NULL,
+		                                0, NULL, NULL);
+		if (mbnamesiz == 0)
+			goto done;
+		mbname = malloc(mbnamesiz);
+		if (mbname == NULL)
+			goto done;
+		mbnamesiz = WideCharToMultiByte(CP_UTF8, 0, wname, -1, mbname,
+		                                mbnamesiz, NULL, NULL);
+		if (mbnamesiz == 0)
+			goto done;
+		__progname = mbname;
+		mbname = NULL;
+
+done:
+		free(wpath);
+		free(mbname);
+	}
+#endif
+
+	return __progname;
+}
+
+void
+setprogname(const char *progname)
+{
+	size_t i;
+
+	for (i = strlen(progname); i > 0; i--) {
+		if (LIBBSD_IS_PATHNAME_SEPARATOR(progname[i - 1])) {
+			__progname = progname + i;
+			return;
+		}
+	}
+	__progname = progname;
+}

--- a/src/pid-file/libbsd/update.sh
+++ b/src/pid-file/libbsd/update.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Updates to the hardcoded version of libbsd.
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+version=0.11.3
+
+set -x
+for ext in tar.xz tar.xz.asc; do
+    curl -fsSL "https://libbsd.freedesktop.org/releases/libbsd-$version.$ext" > "libbsd.$ext"
+done
+
+gpg --verify libbsd.tar.xz.asc libbsd.tar.xz
+
+tar tf libbsd.tar.xz
+tar --strip-components=1 -C libbsd -xf libbsd.tar.xz libbsd-"$version"/src/{flopen,pidfile,progname}.c
+rm libbsd.tar.xz libbsd.tar.xz.asc

--- a/src/pid-file/src/lib.rs
+++ b/src/pid-file/src/lib.rs
@@ -1,0 +1,175 @@
+// Copyright 2020 Andrej Shadura.
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// This file is derived from the bsd-pidfile-rs project, available at
+// https://github.com/andrewshadura/bsd-pidfile-rs. It was incorporated
+// directly into Materialize on August 12, 2020.
+//
+// The original source code is subject to the terms of the MIT license, a copy
+// of which can be found in the LICENSE file at the root of this repository.
+
+//! PID file management for daemons.
+//!
+//! The `pid-file` crate wraps the `pidfile` family of functions provided by BSD
+//! systems that provide mutual exclusion for daemons via PID files.
+//!
+//! Much of the code is inherited from [pidfile_rs], but the build system
+//! bundles the necessary subset of libbsd rather than relying on libbsd to be
+//! installed.
+//!
+//! [pidfile_rs]: https://docs.rs/pidfile_rs
+
+#![warn(missing_docs)]
+
+use std::convert::TryInto;
+use std::ffi::{CString, NulError};
+use std::fmt;
+use std::fs::Permissions;
+use std::io;
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::ptr;
+
+use ore::option::OptionExt;
+
+#[allow(non_camel_case_types)]
+#[repr(C)]
+struct pidfh {
+    private: [u8; 0],
+}
+
+extern "C" {
+    fn pidfile_open(
+        path: *const libc::c_char,
+        mode: libc::mode_t,
+        pid: *const libc::pid_t,
+    ) -> *mut pidfh;
+    fn pidfile_write(pfh: *mut pidfh) -> libc::c_int;
+    fn pidfile_remove(pfh: *mut pidfh) -> libc::c_int;
+}
+
+/// An open PID file.
+///
+/// A process that manages to construct this type holds an exclusive lock on the
+/// PID file.
+///
+/// Dropping the type will attempt to call [`remove`](PidFile::remove), but any
+/// errors will be suppressed. Call `remove` manually if you need to handle PID
+/// file removal errors.
+pub struct PidFile(*mut pidfh);
+
+impl PidFile {
+    /// Attempts to open and lock the specified PID file.
+    ///
+    /// If the file is already locked by another process, it returns
+    /// `Error::AlreadyRunning`.
+    pub fn open<P>(path: P) -> Result<PidFile, Error>
+    where
+        P: AsRef<Path>,
+    {
+        PidFile::open_with(path, Permissions::from_mode(0o600))
+    }
+
+    /// Like [`open`](PidFile::open), but opens the file with the specified
+    /// permissions rather than 0600.
+    pub fn open_with<P>(path: P, permissions: Permissions) -> Result<PidFile, Error>
+    where
+        P: AsRef<Path>,
+    {
+        let path_cstring = CString::new(path.as_ref().as_os_str().as_bytes())?;
+        let mut old_pid: libc::pid_t = -1;
+        let mode: libc::mode_t = permissions
+            .mode()
+            .try_into()
+            .expect("file permissions not valid libc::mode_t");
+        let f = unsafe { pidfile_open(path_cstring.as_ptr(), mode, &mut old_pid) };
+        if !f.is_null() {
+            let r = unsafe { pidfile_write(f) };
+            if r == 0 {
+                Ok(PidFile(f))
+            } else {
+                Err(Error::Io(io::Error::last_os_error()))
+            }
+        } else {
+            let err = io::Error::last_os_error();
+            if err.kind() == io::ErrorKind::AlreadyExists {
+                Err(Error::AlreadyRunning {
+                    pid: (old_pid != -1).then(|| old_pid),
+                })
+            } else {
+                Err(Error::Io(err))
+            }
+        }
+    }
+
+    /// Closes the PID file and removes it from the filesystem.
+    pub fn remove(mut self) -> Result<(), Error> {
+        let r = unsafe { pidfile_remove(self.0) };
+        // Set the pointer to null to prevent drop from calling remove again.
+        self.0 = ptr::null_mut();
+        if r == 0 {
+            Ok(())
+        } else {
+            Err(Error::Io(io::Error::last_os_error()))
+        }
+    }
+}
+
+impl Drop for PidFile {
+    fn drop(&mut self) {
+        // If the pointer is null, the PID file has already been removed.
+        if self.0 != ptr::null_mut() {
+            unsafe { pidfile_remove(self.0) };
+        }
+    }
+}
+
+/// A PID file-related error.
+#[derive(Debug)]
+pub enum Error {
+    /// An I/O error occurred.
+    Io(io::Error),
+    /// The provided path had embedded null bytes.
+    Nul(NulError),
+    /// Another process already has the lock on the requested PID file.
+    AlreadyRunning {
+        /// The PID of the existing process, if it is known.
+        pid: Option<i32>,
+    },
+}
+
+impl From<NulError> for Error {
+    fn from(e: NulError) -> Error {
+        Error::Nul(e)
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::Io(e) => write!(f, "unable to open PID file: {}", e),
+            Error::Nul(e) => write!(f, "PID file path contained null bytes: {}", e),
+            Error::AlreadyRunning { pid } => write!(
+                f,
+                "process already running (PID: {})",
+                pid.display_or("<unknown>")
+            ),
+        }
+    }
+}
+
+impl std::error::Error for Error {}

--- a/src/pid-file/tests/pid_file.rs
+++ b/src/pid-file/tests/pid_file.rs
@@ -1,0 +1,47 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+
+use pid_file::PidFile;
+
+#[test]
+fn test_pid_file_basics() -> Result<(), Box<dyn Error>> {
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("pidfile");
+
+    // Creating a PID file should create a file at the specified path.
+    let pid_file = PidFile::open(&path)?;
+    assert!(path.exists());
+
+    // Attempting to open the PID file again should fail.
+    match PidFile::open(&path) {
+        Err(pid_file::Error::AlreadyRunning { .. }) => (),
+        Ok(_) => panic!("unexpected success when opening pid file"),
+        Err(e) => return Err(e.into()),
+    }
+
+    // Dropping the PID file should remove it.
+    drop(pid_file);
+    assert!(!path.exists());
+
+    // Using the explicit `remove` method should work too.
+    let pid_file = PidFile::open(&path)?;
+    assert!(path.exists());
+    pid_file.remove()?;
+    assert!(!path.exists());
+
+    Ok(())
+}


### PR DESCRIPTION
cc @danhhz to check whether this will work for persistence, and @elindsey for assessing whether we're comfortable taking this C dependency.

----

Add a PID file to protect against multiple copies of materialized
running against the same mzdata directory simultaneous. The PID file
lives at mzdata/materialize.log.

Unfortunately we can't rely on SQLite to provide this mutual exclusion.
SQLite allows you to request exclusive access to a database file, but
our tests require the ability to introspect the SQLite database as
materialized is running.

Handling PID files is notoriously tricky, so this patch brings in some C
code from libbsd that is known to get the tricky bits right.

Fix #7816.