### PR TITLE
mzcompose: make "./mzcompose help" equivalent to "./mzcompose --help"

### DIFF
--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -32,7 +32,7 @@ def main(argv: List[str]) -> int:
     # Lightly parse the arguments so we know what to do.
     parser = ArgumentParser()
     args, unknown_args = parser.parse_known_args(argv)
-    if args.help:
+    if args.help or args.command == "help":
         parser.print_help()
         return 0
 


### PR DESCRIPTION
Fix #5636.