### PR TITLE
mzbuild: take over all responsibility for managing RUSTFLAGS

### DIFF
--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -202,7 +202,6 @@ ENV CPP=x86_64-unknown-linux-gnu-cpp
 ENV CC=x86_64-unknown-linux-gnu-cc
 ENV CXX=x86_64-unknown-linux-gnu-c++
 ENV LDFLAGS=-fuse-ld=lld
-ENV RUSTFLAGS="-C link-arg=-Wl,--compress-debug-sections=zlib -C link-arg=-fuse-ld=lld"
 ENV TARGET_CC=$CC
 ENV TARGET_CXX=$CXX
 ENV PATH=/opt/x-tools/x86_64-unknown-linux-gnu/bin:$PATH

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -243,7 +243,10 @@ class CargoBuild(CargoPreImage):
         self.bin = config.pop("bin", None)
         self.strip = config.pop("strip", True)
         self.extract = config.pop("extract", {})
-        self.rustflags = config.pop("rustflags", "")
+        self.rustflags = config.pop(
+            "rustflags",
+            "-C link-arg=-Wl,--compress-debug-sections=zlib -C link-arg=-fuse-ld=lld",
+        )
         if rd.coverage:
             self.rustflags += " -Zinstrument-coverage -C link-dead-code "
             # Nix generates some unresolved symbols that -Zinstrument-coverage


### PR DESCRIPTION
mzbuild learned to manage the RUSTFLAGS environment variable when it
learned to inject flags to generate code coverage. Unfortunately, in
doing so, it was overwriting the important linker flags set in the
Docker image to use lld and to compress debug info.

Fix the bug by putting mzbuild entirely in charge of setting the correct
RUSTFLAGS.

Notably, this should make the code coverage build use a lot less memory,
and therefore actually complete without OOMing.