### PR TITLE
coord,catalog,dataflow: add a status column for sources/views/tables/sink and update based on feedback from workers

### DIFF
--- a/doc/user/content/sql/show-sinks.md
+++ b/doc/user/content/sql/show-sinks.md
@@ -26,9 +26,9 @@ _schema&lowbar;name_ | The schema to show sinks from. Defaults to `public` in th
 `SHOW FULL SINKS`'s output is a table, with this structure:
 
 ```nofmt
- name  | type | volatile
--------+------+---------
- ...   | ...  | ...
+ name  | type | volatile | status
+-------+------+----------+-------
+ ...   | ...  | ...      | ...
 ```
 
 Field | Meaning
@@ -36,6 +36,7 @@ Field | Meaning
 **name** | The name of the sink
 **type** | Whether the sink was created by the `user` or the `system`
 **volatility** | Whether the sink is [volatile](/overview/volatility). Either `volatile`, `nonvolatile`, or `unknown`.
+**status** | Status of the sink. Can be one of `created` or `available`. An `available` sink is running as expected.
 
 {{< version-changed v0.5.0 >}}
 The output column is renamed from `SINKS` to `name`.

--- a/doc/user/content/sql/show-sources.md
+++ b/doc/user/content/sql/show-sources.md
@@ -26,9 +26,9 @@ _schema&lowbar;name_ | The schema to show sources from. Defaults to `public` in 
 `SHOW FULL SOURCES`'s output is a table, with this structure:
 
 ```nofmt
- name  | type | materialized | volatility
--------+------+--------------+-----------
- ...   | ...  | ...          | ...
+ name  | type | materialized | volatility | status
+-------+------+--------------+------------+-------
+ ...   | ...  | ...          | ...        + ...
 ```
 
 Field | Meaning
@@ -37,6 +37,7 @@ Field | Meaning
 **type** | Whether the source was created by the `user` or the `system`
 **materialized** | Does the source have an in-memory index? For more details, see [`CREATE INDEX`](../create-index)
 **volatility** | Whether the source is [volatile](/overview/volatility). Either `volatile`, `nonvolatile`, or `unknown`.
+**status**     | Status of the source. Can be one of `created` or `available`. Only `available` sources can be queried.
 
 {{< version-changed v0.5.0 >}}
 The output column is renamed from `SOURCES` to `name`.

--- a/doc/user/content/sql/show-views.md
+++ b/doc/user/content/sql/show-views.md
@@ -25,9 +25,9 @@ _schema&lowbar;name_ | The schema to show views from. Defaults to `public` in th
 `SHOW FULL VIEWS`'s output is a table, with this structure:
 
 ```nofmt
- name  | type | materialized | volatility
--------+------+--------------+-----------
- ...   | ...  | ...          | ...
+ name  | type | materialized | volatility | status
+-------+------+--------------+------------+-------
+ ...   | ...  | ...          | ...        | ...
 ```
 
 Field | Meaning
@@ -36,6 +36,7 @@ Field | Meaning
 **type** | Whether the view was created by the `user` or the `system`
 **materialized** | Does the view have an in-memory index? For more details, see [`CREATE INDEX`](../create-index)
 **volatility** | Whether the view is [volatile](/overview/volatility). Either `volatile`, `nonvolatile`, or `unknown`.
+**status**     | Status of the view. Can be one of `created` or `available`. Only `available` views can be queried.
 
 {{< version-changed v0.5.0 >}}
 The `Name`, `Type`, and `Materialized` columns are renamed to lowercase, i.e.,

--- a/doc/user/content/sql/system-catalog.md
+++ b/doc/user/content/sql/system-catalog.md
@@ -209,6 +209,7 @@ Field        | Type        | Meaning
 `name`       | [`text`]    | The name of the index.
 `on_id`      | [`text`]    | The ID of the relation on which the index is built.
 `volatility` | [`text`]    | Whether the the index is [volatile](/overview/volatility). Either `volatile`, `nonvolatile`, or `unknown`.
+`status`     | [`text`]    | Status of the index. Can be one of `created` or `available`. Only `available` indexes can be used for querying.
 
 ### `mz_index_columns`
 
@@ -568,6 +569,7 @@ Field            | Type        | Meaning
 `name`           | [`text`]    | The name of the sink.
 `connector_type` | [`text`]    | The type of the sink: `avro-ocf` or `kafka`.
 `volatility`     | [`text`]    | Whether the sink is [volatile](/overview/volatility). Either `volatile`, `nonvolatile`, or `unknown`.
+`status`         | [`text`]    | Status of the sink. Can be one of `created` or `available`. An `available` sink is running as expected.
 
 ### `mz_source_info`
 
@@ -595,6 +597,7 @@ Field            | Type       | Meaning
 `name`           | [`text`]   | The name of the source.
 `connector_type` | [`text`]   | The type of the source: `avro-ocf`, `file`, `kafka`, `kinesis`, `s3`, `postgres`, or `pubnub`.
 `volatility`     | [`text`]   | Whether the source is [volatile](/overview/volatility). Either `volatile`, `nonvolatile`, or `unknown`.
+`status`         | [`text`]   | Status of the source. Can be one of `created` or `available`. Only `available` sources can be queried.
 
 ### `mz_tables`
 
@@ -606,6 +609,7 @@ Field          | Type       | Meaning
 `oid`          | [`oid`]    | A [PostgreSQL-compatible OID][oid] for the table.
 `schema_id`    | [`bigint`] | The ID of the schema to which the table belongs.
 `name`         | [`text`]   | The name of the table.
+`status`       | [`text`]   | Status of the table. Can be one of `created` or `available`. Only `available` tables can be queried.
 
 ### `mz_types`
 
@@ -629,6 +633,7 @@ Field          | Type        | Meaning
 `schema_id`    | [`bigint`]  | The ID of the schema to which the view belongs.
 `name`         | [`text`]    | The name of the view.
 `volatility`   | [`text`]    | Whether the view is [volatile](/overview/volatility). Either `volatile`, `nonvolatile`, or `unknown`.
+`status`       | [`text`]    | Status of the view. Can be one of `created` or `available`. Only `available` views can be queried.
 
 ### `mz_worker_materialization_frontiers`
 

--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -717,7 +717,8 @@ lazy_static! {
             .with_named_column("id", ScalarType::String.nullable(false))
             .with_named_column("oid", ScalarType::Oid.nullable(false))
             .with_named_column("schema_id", ScalarType::Int64.nullable(false))
-            .with_named_column("name", ScalarType::String.nullable(false)),
+            .with_named_column("name", ScalarType::String.nullable(false))
+            .with_named_column("status", ScalarType::String.nullable(false)),
         id: GlobalId::System(4019),
         index_id: GlobalId::System(4020),
         persistent: false,

--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -691,7 +691,8 @@ lazy_static! {
             .with_named_column("oid", ScalarType::Oid.nullable(false))
             .with_named_column("name", ScalarType::String.nullable(false))
             .with_named_column("on_id", ScalarType::String.nullable(false))
-            .with_named_column("volatility", ScalarType::String.nullable(false)),
+            .with_named_column("volatility", ScalarType::String.nullable(false))
+            .with_named_column("status", ScalarType::String.nullable(false)),
         id: GlobalId::System(4015),
         index_id: GlobalId::System(4016),
         persistent: false,
@@ -730,7 +731,8 @@ lazy_static! {
             .with_named_column("schema_id", ScalarType::Int64.nullable(false))
             .with_named_column("name", ScalarType::String.nullable(false))
             .with_named_column("connector_type", ScalarType::String.nullable(false))
-            .with_named_column("volatility", ScalarType::String.nullable(false)),
+            .with_named_column("volatility", ScalarType::String.nullable(false))
+            .with_named_column("status", ScalarType::String.nullable(false)),
         id: GlobalId::System(4021),
         index_id: GlobalId::System(4022),
         persistent: false,
@@ -744,7 +746,8 @@ lazy_static! {
             .with_named_column("schema_id", ScalarType::Int64.nullable(false))
             .with_named_column("name", ScalarType::String.nullable(false))
             .with_named_column("connector_type", ScalarType::String.nullable(false))
-            .with_named_column("volatility", ScalarType::String.nullable(false)),
+            .with_named_column("volatility", ScalarType::String.nullable(false))
+            .with_named_column("status", ScalarType::String.nullable(false)),
         id: GlobalId::System(4023),
         index_id: GlobalId::System(4024),
         persistent: false,
@@ -757,7 +760,8 @@ lazy_static! {
             .with_named_column("oid", ScalarType::Oid.nullable(false))
             .with_named_column("schema_id", ScalarType::Int64.nullable(false))
             .with_named_column("name", ScalarType::String.nullable(false))
-            .with_named_column("volatility", ScalarType::String.nullable(false)),
+            .with_named_column("volatility", ScalarType::String.nullable(false))
+            .with_named_column("status", ScalarType::String.nullable(false)),
         id: GlobalId::System(4025),
         index_id: GlobalId::System(4026),
         persistent: false,

--- a/src/coord/src/catalog/builtin_table_updates.rs
+++ b/src/coord/src/catalog/builtin_table_updates.rs
@@ -151,6 +151,7 @@ impl Catalog {
                 Datum::Int32(oid as i32),
                 Datum::Int64(schema_id),
                 Datum::String(name),
+                Datum::String(self.status(&id).as_str()),
             ]),
             diff,
         }]

--- a/src/coord/src/catalog/builtin_table_updates.rs
+++ b/src/coord/src/catalog/builtin_table_updates.rs
@@ -174,6 +174,7 @@ impl Catalog {
                 Datum::String(name),
                 Datum::String(source.connector.name()),
                 Datum::String(self.is_volatile(id).as_str()),
+                Datum::String(self.status(&id).as_str()),
             ]),
             diff,
         }]
@@ -195,6 +196,7 @@ impl Catalog {
                 Datum::Int64(schema_id),
                 Datum::String(name),
                 Datum::String(self.is_volatile(id).as_str()),
+                Datum::String(self.status(&id).as_str()),
             ]),
             diff,
         }]
@@ -255,6 +257,7 @@ impl Catalog {
                     Datum::String(name),
                     Datum::String(connector.name()),
                     Datum::String(self.is_volatile(id).as_str()),
+                    Datum::String(self.status(&id).as_str()),
                 ]),
                 diff,
             });
@@ -287,6 +290,7 @@ impl Catalog {
                 Datum::String(name),
                 Datum::String(&index.on.to_string()),
                 Datum::String(self.is_volatile(id).as_str()),
+                Datum::String(self.status(&id).as_str()),
             ]),
             diff,
         });

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1799,6 +1799,7 @@ impl Coordinator {
                 connector: source.connector,
                 bare_desc: source.bare_desc,
                 desc: transformed_desc,
+                status: Default::default(),
             };
             let source_id = self.catalog.allocate_id()?;
             let source_oid = self.catalog.allocate_oid()?;
@@ -1887,6 +1888,7 @@ impl Coordinator {
                 envelope: sink.envelope,
                 with_snapshot,
                 depends_on,
+                status: Default::default(),
             }),
         };
         match self.catalog_transact(vec![op]) {
@@ -1957,6 +1959,7 @@ impl Coordinator {
                 None
             },
             depends_on,
+            status: Default::default(),
         };
         ops.push(catalog::Op::CreateItem {
             id: view_id,
@@ -2072,6 +2075,7 @@ impl Coordinator {
             on: index.on,
             conn_id: None,
             depends_on,
+            status: Default::default(),
         };
         let id = self.catalog.allocate_id()?;
         let oid = self.catalog.allocate_oid()?;
@@ -3816,6 +3820,7 @@ fn auto_generate_primary_idx(
             .collect(),
         conn_id,
         depends_on,
+        status: Default::default(),
     }
 }
 

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1718,6 +1718,7 @@ impl Coordinator {
             conn_id,
             depends_on,
             persist,
+            status: Default::default(),
         };
         let index_id = self.catalog.allocate_id()?;
         let mut index_name = name.clone();

--- a/src/coord/src/coord/dataflow_status.rs
+++ b/src/coord/src/coord/dataflow_status.rs
@@ -1,0 +1,99 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Types and methods for working with status updates from the dataflow layer.
+
+use std::collections::HashMap;
+
+use dataflow_types::DataflowStatusUpdate;
+use expr::GlobalId;
+
+/// A buffer for [`status updates`](DataflowStatusUpdate) coming in from
+/// workers/the dataflow layer.
+///
+/// We need to stash updates on created dataflows until we received the same
+/// update from all workers.
+pub struct DataflowStatusUpdateBuffer {
+    created_views: HashMap<GlobalId, usize>,
+    created_sinks: HashMap<GlobalId, usize>,
+    num_workers: usize,
+}
+
+impl DataflowStatusUpdateBuffer {
+    /// Creates a new [`DataflowStatusUpdateBuffer`] that expects updates
+    /// from the given number of workers.
+    pub fn new(num_workers: usize) -> Self {
+        DataflowStatusUpdateBuffer {
+            num_workers,
+            created_views: HashMap::new(),
+            created_sinks: HashMap::new(),
+        }
+    }
+
+    /// Updates internal state based on the given `update`. If we now have
+    /// updates from the expected number of workers for any dataflow, returns
+    /// an update that signals "global" updates for those dataflows.
+    pub fn add_update(&mut self, update: DataflowStatusUpdate) -> Option<DataflowStatusUpdate> {
+        match update {
+            DataflowStatusUpdate::CreatedDataflows {
+                created_indexes,
+                created_sinks,
+            } => self.process_created_dataflows(created_indexes, created_sinks),
+        }
+    }
+
+    fn process_created_dataflows(
+        &mut self,
+        created_indexes: Vec<GlobalId>,
+        created_sinks: Vec<GlobalId>,
+    ) -> Option<DataflowStatusUpdate> {
+        let mut result_created_indexes = Vec::new();
+        let mut result_created_sinks = Vec::new();
+
+        for id in created_indexes {
+            let num_updates = self
+                .created_views
+                .entry(id.clone())
+                .and_modify(|count| *count += 1)
+                .or_insert(1);
+
+            assert!(
+                *num_updates <= self.num_workers,
+                "got more updates than expected from workers"
+            );
+            if *num_updates == self.num_workers {
+                result_created_indexes.push(id);
+            }
+        }
+        for id in created_sinks {
+            let num_updates = self
+                .created_sinks
+                .entry(id.clone())
+                .and_modify(|count| *count += 1)
+                .or_insert(1);
+
+            assert!(
+                *num_updates <= self.num_workers,
+                "got more updates than expected from workers"
+            );
+            if *num_updates == self.num_workers {
+                result_created_sinks.push(id);
+            }
+        }
+
+        if !result_created_indexes.is_empty() || !result_created_sinks.is_empty() {
+            Some(DataflowStatusUpdate::CreatedDataflows {
+                created_indexes: result_created_indexes,
+                created_sinks: result_created_sinks,
+            })
+        } else {
+            None
+        }
+    }
+}

--- a/src/coord/tests/sql.rs
+++ b/src/coord/tests/sql.rs
@@ -67,6 +67,7 @@ fn datadriven() {
                             conn_id: None,
                             depends_on: vec![],
                             persist: None,
+                            status: Default::default(),
                         }),
                     );
                     id += 1;

--- a/src/coordtest/src/lib.rs
+++ b/src/coordtest/src/lib.rs
@@ -97,8 +97,9 @@ impl CoordTest {
     pub async fn new() -> anyhow::Result<Self> {
         let catalog_file = NamedTempFile::new()?;
         let metrics_registry = MetricsRegistry::new();
+        let num_workers = 1;
         let (handle, client, coord_feedback_tx, dataflow_feedback_rx, timestamp) =
-            coord::serve_debug(catalog_file.path(), metrics_registry.clone());
+            coord::serve_debug(catalog_file.path(), metrics_registry.clone(), num_workers);
         let coordtest = CoordTest {
             _handle: handle,
             client: Some(client),

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -65,6 +65,17 @@ pub enum TailResponse {
     Dropped,
 }
 
+/// Updates on the status of dataflows.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum DataflowStatusUpdate {
+    CreatedDataflows {
+        /// List of index IDs for which the requested dataflow was created.
+        created_indexes: Vec<GlobalId>,
+        /// List of sink IDs for which the requested dataflow was created.
+        created_sinks: Vec<GlobalId>,
+    },
+}
+
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 /// A batch of updates to be fed to a local input
 pub struct Update {

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -330,7 +330,8 @@ fn show_sources<'a>(
                 name,
                 mz_internal.mz_classify_object_id(id) AS type,
                 mz_internal.mz_is_materialized(id) AS materialized,
-                volatility
+                volatility,
+                status
             FROM mz_catalog.mz_sources
             WHERE schema_id = {}",
             schema.id(),
@@ -344,7 +345,7 @@ fn show_sources<'a>(
         )
     } else {
         format!(
-            "SELECT name, mz_internal.mz_classify_object_id(id) AS type, volatility
+            "SELECT name, mz_internal.mz_classify_object_id(id) AS type, volatility, status
             FROM mz_catalog.mz_sources
             WHERE schema_id = {} AND mz_internal.mz_is_materialized(id)",
             schema.id(),
@@ -377,7 +378,8 @@ fn show_views<'a>(
                 name,
                 mz_internal.mz_classify_object_id(id) AS type,
                 mz_internal.mz_is_materialized(id) AS materialized,
-                volatility
+                volatility,
+                status
              FROM mz_catalog.mz_views
              WHERE schema_id = {}",
             schema.id(),
@@ -391,7 +393,7 @@ fn show_views<'a>(
         )
     } else {
         format!(
-            "SELECT name, mz_internal.mz_classify_object_id(id) AS type, volatility
+            "SELECT name, mz_internal.mz_classify_object_id(id) AS type, volatility, status
              FROM mz_catalog.mz_views
              WHERE schema_id = {} AND mz_internal.mz_is_materialized(id)",
             schema.id(),
@@ -414,7 +416,7 @@ fn show_sinks<'a>(
 
     let query = if full {
         format!(
-            "SELECT name, mz_internal.mz_classify_object_id(id) AS type, volatility
+            "SELECT name, mz_internal.mz_classify_object_id(id) AS type, volatility, status
             FROM mz_catalog.mz_sinks
             WHERE schema_id = {}",
             schema.id(),

--- a/src/testdrive/src/action/sql.rs
+++ b/src/testdrive/src/action/sql.rs
@@ -117,9 +117,8 @@ impl Action for SqlAction {
             | CreateView(_) | CreateViews(_) | CreateTable(_) | CreateIndex(_) | CreateType(_)
             | CreateRole(_) | AlterObjectRename(_) | AlterIndexOptions(_) | Discard(_)
             | DropDatabase(_) | DropObjects(_) | SetVariable(_) | ShowDatabases(_)
-            | ShowObjects(_) | ShowIndexes(_) | ShowColumns(_) | ShowCreateView(_)
-            | ShowCreateSource(_) | ShowCreateTable(_) | ShowCreateSink(_) | ShowCreateIndex(_)
-            | ShowVariable(_) => false,
+            | ShowColumns(_) | ShowCreateView(_) | ShowCreateSource(_) | ShowCreateTable(_)
+            | ShowCreateSink(_) | ShowCreateIndex(_) | ShowVariable(_) => false,
             _ => true,
         };
 

--- a/test/testdrive/catalog-item-status.td
+++ b/test/testdrive/catalog-item-status.td
@@ -1,0 +1,204 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Boilerplate
+
+$ set schema={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"a", "type":"string"}
+        ]
+    }
+
+$ kafka-create-topic topic=input
+
+# Verify that builtin tables, views, and sources are always available.
+
+> SELECT COUNT(*) from mz_sources WHERE status = 'created' and id LIKE 's%'
+0
+
+> SELECT COUNT(*) > 0 from mz_sources WHERE status = 'available' and id LIKE 's%'
+true
+
+> SELECT COUNT(*) from mz_views WHERE status = 'created' and id LIKE 's%'
+0
+
+> SELECT COUNT(*) > 0 from mz_views WHERE status = 'available' and id LIKE 's%'
+true
+
+> SELECT COUNT(*) from mz_tables WHERE status = 'created' and id LIKE 's%'
+0
+
+> SELECT COUNT(*) > 0 from mz_tables WHERE status = 'available' and id LIKE 's%'
+true
+
+# Non-materialized sources are not available
+
+> CREATE SOURCE non_materialized_source (a)
+  FROM KAFKA BROKER '${testdrive.kafka-addr}'
+  TOPIC 'testdrive-input-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${schema}'
+  ENVELOPE NONE
+
+> SELECT name, status FROM mz_sources WHERE name = 'non_materialized_source'
+name status
+------------
+non_materialized_source created
+
+# creating an index makes sources available
+
+> CREATE DEFAULT INDEX ON non_materialized_source
+
+> SELECT name, status FROM mz_sources WHERE name = 'non_materialized_source'
+name status
+------------
+non_materialized_source available
+
+> CREATE INDEX my_idx ON non_materialized_source (a)
+
+> DROP INDEX non_materialized_source_primary_idx
+
+# dropping an index while others are still available makes the source stay
+# available
+> SELECT name, status FROM mz_sources WHERE name = 'non_materialized_source'
+name status
+------------
+non_materialized_source available
+
+# Materialized sources are available right away
+
+> CREATE MATERIALIZED SOURCE materialized_source (a)
+  FROM KAFKA BROKER '${testdrive.kafka-addr}'
+  TOPIC 'testdrive-input-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${schema}'
+  ENVELOPE NONE
+
+> SELECT name, status FROM mz_sources WHERE name = 'materialized_source'
+name status
+------------
+materialized_source available
+
+# dropping the index makes sources unavailable
+
+> DROP INDEX materialized_source_primary_idx
+
+> SELECT name, status FROM mz_sources WHERE name = 'materialized_source'
+name status
+------------
+materialized_source created
+
+# Tables are always available
+
+> CREATE TABLE test_table (a text)
+
+> SELECT name, status FROM mz_tables WHERE name = 'test_table'
+name status
+------------
+test_table available
+
+# Non-materialized views are not available
+
+> CREATE SOURCE view_source (a)
+  FROM KAFKA BROKER '${testdrive.kafka-addr}'
+  TOPIC 'testdrive-input-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${schema}'
+  ENVELOPE NONE
+
+> CREATE VIEW non_materialized_view as
+  SELECT * FROM view_source
+
+> SELECT name, status FROM mz_views WHERE name = 'non_materialized_view'
+name status
+------------
+non_materialized_view created
+
+# creating an index makes views available
+
+> CREATE DEFAULT INDEX ON non_materialized_view
+
+> SELECT name, status FROM mz_views WHERE name = 'non_materialized_view'
+name status
+------------
+non_materialized_view available
+
+# Materialized views are available right away
+
+> CREATE MATERIALIZED VIEW materialized_view as
+  SELECT * FROM view_source
+
+> SELECT name, status FROM mz_views WHERE name = 'materialized_view'
+name status
+------------
+materialized_view available
+
+# dropping the index makes views unavailable
+
+> DROP INDEX materialized_view_primary_idx
+
+> SELECT name, status FROM mz_views WHERE name = 'materialized_view'
+name status
+------------
+materialized_view created
+
+# Views that only have materialized inputs are available
+
+> CREATE MATERIALIZED SOURCE materialized_source_for_view (a)
+  FROM KAFKA BROKER '${testdrive.kafka-addr}'
+  TOPIC 'testdrive-input-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${schema}'
+  ENVELOPE NONE
+
+> CREATE VIEW non_materialized_view_from_materialized AS
+  SELECT * FROM materialized_source_for_view
+
+> SELECT name, status FROM mz_views WHERE name = 'non_materialized_view_from_materialized'
+name status
+------------
+non_materialized_view_from_materialized available
+
+
+# Complex view with multiple transitive inputs
+
+> CREATE SOURCE complex_non_materialized_source1 (a)
+  FROM KAFKA BROKER '${testdrive.kafka-addr}'
+  TOPIC 'testdrive-input-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${schema}'
+  ENVELOPE NONE
+
+> CREATE SOURCE complex_non_materialized_source2 (a)
+  FROM KAFKA BROKER '${testdrive.kafka-addr}'
+  TOPIC 'testdrive-input-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${schema}'
+  ENVELOPE NONE
+
+> CREATE MATERIALIZED VIEW complex_intermediate_view1 AS
+  SELECT * FROM complex_non_materialized_source1
+
+> CREATE VIEW complex_intermediate_view2 AS
+  SELECT * FROM complex_non_materialized_source2
+
+> CREATE VIEW complex_combined_view AS
+  SELECT * FROM complex_intermediate_view1
+  UNION ALL
+  SELECT * FROM complex_intermediate_view2
+
+# one of the dependent paths is not yet available
+> SELECT name, status FROM mz_views WHERE name = 'complex_combined_view'
+name status
+------------
+complex_combined_view created
+
+> CREATE DEFAULT INDEX ON complex_intermediate_view2
+
+# now all dependents is available
+> SELECT name, status FROM mz_views WHERE name = 'complex_combined_view'
+name status
+------------
+complex_combined_view available

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -318,24 +318,24 @@ mz_worker_materialization_frontiers
 > SHOW FULL SOURCES FROM mz_catalog
 name                                 type   materialized  volatility  status
 ----------------------------------------------------------------------------
-mz_arrangement_sharing               system true          volatile    created
-mz_arrangement_sizes                 system true          volatile    created
-mz_dataflow_channels                 system true          volatile    created
-mz_dataflow_operator_addresses       system true          volatile    created
-mz_dataflow_operator_reachability    system true          volatile    created
-mz_dataflow_operators                system true          volatile    created
-mz_kafka_broker_rtt                  system true          volatile    created
-mz_kafka_consumer_partitions         system true          volatile    created
-mz_materialization_dependencies      system true          volatile    created
-mz_materializations                  system true          volatile    created
-mz_message_counts                    system true          volatile    created
-mz_peek_active                       system true          volatile    created
-mz_peek_durations                    system true          volatile    created
-mz_scheduling_elapsed                system true          volatile    created
-mz_scheduling_histogram              system true          volatile    created
-mz_scheduling_parks                  system true          volatile    created
-mz_source_info                       system true          volatile    created
-mz_worker_materialization_frontiers  system true          volatile    created
+mz_arrangement_sharing               system true          volatile    available
+mz_arrangement_sizes                 system true          volatile    available
+mz_dataflow_channels                 system true          volatile    available
+mz_dataflow_operator_addresses       system true          volatile    available
+mz_dataflow_operator_reachability    system true          volatile    available
+mz_dataflow_operators                system true          volatile    available
+mz_kafka_broker_rtt                  system true          volatile    available
+mz_kafka_consumer_partitions         system true          volatile    available
+mz_materialization_dependencies      system true          volatile    available
+mz_materializations                  system true          volatile    available
+mz_message_counts                    system true          volatile    available
+mz_peek_active                       system true          volatile    available
+mz_peek_durations                    system true          volatile    available
+mz_scheduling_elapsed                system true          volatile    available
+mz_scheduling_histogram              system true          volatile    available
+mz_scheduling_parks                  system true          volatile    available
+mz_source_info                       system true          volatile    available
+mz_worker_materialization_frontiers  system true          volatile    available
 
 > SHOW TABLES FROM mz_catalog
 mz_array_types
@@ -479,21 +479,21 @@ mz_relations
 
 > SHOW FULL VIEWS FROM mz_catalog
 name                              type   materialized  volatility  status
--------------------------------------------------------------------------
-mz_dataflow_names                 system false         volatile    created
-mz_dataflow_operator_dataflows    system false         volatile    created
-mz_materialization_frontiers      system false         volatile    created
-mz_objects                        system false         volatile    created
-mz_perf_arrangement_records       system false         volatile    created
-mz_perf_dependency_frontiers      system false         volatile    created
-mz_perf_peek_durations_aggregates system false         volatile    created
-mz_perf_peek_durations_bucket     system false         volatile    created
-mz_perf_peek_durations_core       system false         volatile    created
-mz_records_per_dataflow           system false         volatile    created
-mz_records_per_dataflow_global    system false         volatile    created
-mz_records_per_dataflow_operator  system false         volatile    created
-mz_relations                      system false         volatile    created
-mz_catalog_names                  system false         volatile    created
+--------------------------------------------------------------------------
+mz_dataflow_names                 system false         volatile    available
+mz_dataflow_operator_dataflows    system false         volatile    available
+mz_materialization_frontiers      system false         volatile    available
+mz_objects                        system false         volatile    available
+mz_perf_arrangement_records       system false         volatile    available
+mz_perf_dependency_frontiers      system false         volatile    available
+mz_perf_peek_durations_aggregates system false         volatile    available
+mz_perf_peek_durations_bucket     system false         volatile    available
+mz_perf_peek_durations_core       system false         volatile    available
+mz_records_per_dataflow           system false         volatile    available
+mz_records_per_dataflow_global    system false         volatile    available
+mz_records_per_dataflow_operator  system false         volatile    available
+mz_relations                      system false         volatile    available
+mz_catalog_names                  system false         volatile    available
 
 > SHOW MATERIALIZED SOURCES FROM mz_catalog LIKE '%peek%';
 mz_peek_active

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -316,26 +316,26 @@ mz_source_info
 mz_worker_materialization_frontiers
 
 > SHOW FULL SOURCES FROM mz_catalog
-name                                 type   materialized  volatility
---------------------------------------------------------------------
-mz_arrangement_sharing               system true          volatile
-mz_arrangement_sizes                 system true          volatile
-mz_dataflow_channels                 system true          volatile
-mz_dataflow_operator_addresses       system true          volatile
-mz_dataflow_operator_reachability    system true          volatile
-mz_dataflow_operators                system true          volatile
-mz_kafka_broker_rtt                  system true          volatile
-mz_kafka_consumer_partitions         system true          volatile
-mz_materialization_dependencies      system true          volatile
-mz_materializations                  system true          volatile
-mz_message_counts                    system true          volatile
-mz_peek_active                       system true          volatile
-mz_peek_durations                    system true          volatile
-mz_scheduling_elapsed                system true          volatile
-mz_scheduling_histogram              system true          volatile
-mz_scheduling_parks                  system true          volatile
-mz_source_info                       system true          volatile
-mz_worker_materialization_frontiers  system true          volatile
+name                                 type   materialized  volatility  status
+----------------------------------------------------------------------------
+mz_arrangement_sharing               system true          volatile    created
+mz_arrangement_sizes                 system true          volatile    created
+mz_dataflow_channels                 system true          volatile    created
+mz_dataflow_operator_addresses       system true          volatile    created
+mz_dataflow_operator_reachability    system true          volatile    created
+mz_dataflow_operators                system true          volatile    created
+mz_kafka_broker_rtt                  system true          volatile    created
+mz_kafka_consumer_partitions         system true          volatile    created
+mz_materialization_dependencies      system true          volatile    created
+mz_materializations                  system true          volatile    created
+mz_message_counts                    system true          volatile    created
+mz_peek_active                       system true          volatile    created
+mz_peek_durations                    system true          volatile    created
+mz_scheduling_elapsed                system true          volatile    created
+mz_scheduling_histogram              system true          volatile    created
+mz_scheduling_parks                  system true          volatile    created
+mz_source_info                       system true          volatile    created
+mz_worker_materialization_frontiers  system true          volatile    created
 
 > SHOW TABLES FROM mz_catalog
 mz_array_types
@@ -478,22 +478,22 @@ mz_records_per_dataflow_operator
 mz_relations
 
 > SHOW FULL VIEWS FROM mz_catalog
-name                              type   materialized  volatility
------------------------------------------------------------------
-mz_dataflow_names                 system false         volatile
-mz_dataflow_operator_dataflows    system false         volatile
-mz_materialization_frontiers      system false         volatile
-mz_objects                        system false         volatile
-mz_perf_arrangement_records       system false         volatile
-mz_perf_dependency_frontiers      system false         volatile
-mz_perf_peek_durations_aggregates system false         volatile
-mz_perf_peek_durations_bucket     system false         volatile
-mz_perf_peek_durations_core       system false         volatile
-mz_records_per_dataflow           system false         volatile
-mz_records_per_dataflow_global    system false         volatile
-mz_records_per_dataflow_operator  system false         volatile
-mz_relations                      system false         volatile
-mz_catalog_names                  system false         volatile
+name                              type   materialized  volatility  status
+-------------------------------------------------------------------------
+mz_dataflow_names                 system false         volatile    created
+mz_dataflow_operator_dataflows    system false         volatile    created
+mz_materialization_frontiers      system false         volatile    created
+mz_objects                        system false         volatile    created
+mz_perf_arrangement_records       system false         volatile    created
+mz_perf_dependency_frontiers      system false         volatile    created
+mz_perf_peek_durations_aggregates system false         volatile    created
+mz_perf_peek_durations_bucket     system false         volatile    created
+mz_perf_peek_durations_core       system false         volatile    created
+mz_records_per_dataflow           system false         volatile    created
+mz_records_per_dataflow_global    system false         volatile    created
+mz_records_per_dataflow_operator  system false         volatile    created
+mz_relations                      system false         volatile    created
+mz_catalog_names                  system false         volatile    created
 
 > SHOW MATERIALIZED SOURCES FROM mz_catalog LIKE '%peek%';
 mz_peek_active

--- a/test/testdrive/materializations.td
+++ b/test/testdrive/materializations.td
@@ -37,18 +37,18 @@ Unable to automatically determine a timestamp for your query; this can happen if
   SELECT b, sum(a) FROM data GROUP BY b
 
 > SHOW FULL VIEWS
-name        type     materialized  volatility
----------------------------------------------
-data_view   user     false         unknown
-test1       user     true          unknown
+name        type     materialized  volatility  status
+-----------------------------------------------------
+data_view   user     false         unknown     created
+test1       user     true          unknown     created
 
 > SHOW MATERIALIZED VIEWS
 test1
 
 > SHOW FULL MATERIALIZED VIEWS
-name     type  volatility
--------------------------
-test1    user  unknown
+name     type  volatility  status
+---------------------------------
+test1    user  unknown     created
 
 > SELECT * FROM test1
 b  sum
@@ -167,9 +167,9 @@ catalog item 'materialize.public.idx1' is an index and so cannot be depended upo
 > DROP INDEX test5_primary_idx
 
 > SHOW FULL VIEWS LIKE 'test5'
-name        type     materialized  volatility
----------------------------------------------
-test5       user     true          unknown
+name        type     materialized  volatility  status
+-----------------------------------------------------
+test5       user     true          unknown     created
 
 > SELECT * from test5
 b  c
@@ -188,9 +188,9 @@ b  c
 Unable to automatically determine a timestamp for your query; this can happen if your query depends on non-materialized sources
 
 > SHOW FULL VIEWS LIKE 'test5'
-name        type     materialized  volatility
----------------------------------------------
-test5       user     false         unknown
+name        type     materialized  volatility  status
+-----------------------------------------------------
+test5       user     false         unknown     created
 
 # Test that materialized views can be even if it requires multiple layers of
 # recursing through the AST to find a source.
@@ -319,15 +319,15 @@ name
 mat_data
 
 > SHOW FULL SOURCES
-name     type materialized  volatility
---------------------------------------
-data     user false         unknown
-mat_data user true          unknown
+name     type materialized  volatility  status
+----------------------------------------------
+data     user false         unknown     created
+mat_data user true          unknown     created
 
 > SHOW FULL MATERIALIZED SOURCES
-name     type  volatility
--------------------------
-mat_data user  unknown
+name     type  volatility  status
+---------------------------------
+mat_data user  unknown     created
 
 # If there exists another index, dropping the primary index will not #
 # unmaterialize the source. This also tests creating a default index when the

--- a/test/testdrive/materializations.td
+++ b/test/testdrive/materializations.td
@@ -40,7 +40,7 @@ Unable to automatically determine a timestamp for your query; this can happen if
 name        type     materialized  volatility  status
 -----------------------------------------------------
 data_view   user     false         unknown     created
-test1       user     true          unknown     created
+test1       user     true          unknown     available
 
 > SHOW MATERIALIZED VIEWS
 test1
@@ -48,7 +48,7 @@ test1
 > SHOW FULL MATERIALIZED VIEWS
 name     type  volatility  status
 ---------------------------------
-test1    user  unknown     created
+test1    user  unknown     available
 
 > SELECT * FROM test1
 b  sum
@@ -169,7 +169,7 @@ catalog item 'materialize.public.idx1' is an index and so cannot be depended upo
 > SHOW FULL VIEWS LIKE 'test5'
 name        type     materialized  volatility  status
 -----------------------------------------------------
-test5       user     true          unknown     created
+test5       user     true          unknown     available
 
 > SELECT * from test5
 b  c
@@ -322,12 +322,12 @@ mat_data
 name     type materialized  volatility  status
 ----------------------------------------------
 data     user false         unknown     created
-mat_data user true          unknown     created
+mat_data user true          unknown     available
 
 > SHOW FULL MATERIALIZED SOURCES
 name     type  volatility  status
 ---------------------------------
-mat_data user  unknown     created
+mat_data user  unknown     available
 
 # If there exists another index, dropping the primary index will not #
 # unmaterialize the source. This also tests creating a default index when the

--- a/test/testdrive/sinks.td
+++ b/test/testdrive/sinks.td
@@ -89,13 +89,13 @@ snk4
 snk5
 
 > SHOW FULL SINKS
-name   type  volatility
------------------------
-snk1   user  unknown
-snk2   user  unknown
-snk3   user  unknown
-snk4   user  unknown
-snk5   user  unknown
+name   type  volatility  status
+----------------------------------
+snk1   user  unknown     created
+snk2   user  unknown     created
+snk3   user  unknown     created
+snk4   user  unknown     created
+snk5   user  unknown     created
 
 $ kafka-verify format=avro sink=materialize.public.snk1 sort-messages=true
 {"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "mz_line_no": 2}}}
@@ -184,18 +184,18 @@ $ kafka-verify format=avro sink=materialize.public.sink10 sort-messages=true
 {"before": null, "after": {"row":{"column1": 3}}}
 
 > SHOW FULL SINKS
-name        type  volatility
-----------------------------
-snk1        user  unknown
-snk2        user  unknown
-snk3        user  unknown
-snk4        user  unknown
-snk5        user  unknown
-snk6        user  unknown
-snk7        user  unknown
-snk8        user  unknown
-sink9       user  nonvolatile
-sink10      user  nonvolatile
+name        type  volatility   status
+----------------------------------------
+snk1        user  unknown      created
+snk2        user  unknown      created
+snk3        user  unknown      created
+snk4        user  unknown      created
+snk5        user  unknown      created
+snk6        user  unknown      created
+snk7        user  unknown      created
+snk8        user  unknown      created
+sink9       user  nonvolatile  created
+sink10      user  nonvolatile  created
 
 # test explicit partition count
 > CREATE SINK sink11 FROM foo

--- a/test/testdrive/sinks.td
+++ b/test/testdrive/sinks.td
@@ -91,11 +91,11 @@ snk5
 > SHOW FULL SINKS
 name   type  volatility  status
 ----------------------------------
-snk1   user  unknown     created
-snk2   user  unknown     created
-snk3   user  unknown     created
-snk4   user  unknown     created
-snk5   user  unknown     created
+snk1   user  unknown     available
+snk2   user  unknown     available
+snk3   user  unknown     available
+snk4   user  unknown     available
+snk5   user  unknown     available
 
 $ kafka-verify format=avro sink=materialize.public.snk1 sort-messages=true
 {"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "mz_line_no": 2}}}
@@ -186,16 +186,16 @@ $ kafka-verify format=avro sink=materialize.public.sink10 sort-messages=true
 > SHOW FULL SINKS
 name        type  volatility   status
 ----------------------------------------
-snk1        user  unknown      created
-snk2        user  unknown      created
-snk3        user  unknown      created
-snk4        user  unknown      created
-snk5        user  unknown      created
-snk6        user  unknown      created
-snk7        user  unknown      created
-snk8        user  unknown      created
-sink9       user  nonvolatile  created
-sink10      user  nonvolatile  created
+snk1        user  unknown      available
+snk2        user  unknown      available
+snk3        user  unknown      available
+snk4        user  unknown      available
+snk5        user  unknown      available
+snk6        user  unknown      available
+snk7        user  unknown      available
+snk8        user  unknown      available
+sink9       user  nonvolatile  available
+sink10      user  nonvolatile  available
 
 # test explicit partition count
 > CREATE SINK sink11 FROM foo


### PR DESCRIPTION
Right now, the status can be either `Created` or `Available`. Items will initially have status `Created` but are updated based on feedback from the workers.

The commits are self-contained and build on each other. The first one introduces the column in the system tables. The second commit introduces the feedback message and the status update logic. The rest are (trivial) docs/test changes.

I'm not yet 100% happy with the naming. Mostly, because items go from `Available` back to `Created` when their default indexes (indices?) are dropped.

Future PRs will extend this to reflect errors that are reported from the dataflow layer/workers.

Note: The `status` column somewhat duplicates the `materialized` column in, for example, the output of `SHOW FULL VIEWS`. Future changes that introduce a `Failed` and `Degraded` status will change that, though. The status field is already helpful for non-materialized views, where we now also report that they are available for querying if all dependent items are available/materialized.

## Notes for reviewers

- It might be helpful to first look at the new `catalog-item-status.td` test to understand the expected behavior.
- The `dataflow` layer only knows about dataflows for indexes and sinks while coord/catalog also keep track of sources, views, and some more. When updating the status of an index, we also update the status of the source or view that it indexes, if it is the default (first) index. Similarly, we need to update the status when dropping an index. Additionally, we recursively update the status of (non-materialized) views when any of their transitive inputs change.
- This adds a `DataflowStatusUpdate` to `WorkerFeedback`. It's a peer to `TailResponse` and friends.
- `DataflowStatusUpdate` currently differentiates between created views and sinks, although that differentiation doesn't matter to the coordinator. I can remove the distinction but I thought it might become necessary in the future. 
- Workers keep a buffer for updates in `render_state`, workers forward updates to the coordinator in `report_dataflow_status_updates`.
- I added a `DataflowStatusUpdateBuffer` in the coordinator that buffers updates from workers until we have received a "created" update from all workers for a given ID.
- The status in the catalog is transient. It's not persisted and will be re-discovered upon restart.
- Updating the "available" status based on feedback from the dataflow might seem like overkill, but it exercises the feedback and catalog-updating code paths. And, I think it's already a user benefit, because it allows checking which views are queryable.
- TAILs are not added as sinks in the catalog. I'm working around that, but we could think about adding them as a follow-up. Especially if we want to track failures.

Closes #7803.