### PR TITLE
persist: add nemesis coverage of PersistedSource operator

### DIFF
--- a/src/persist/src/nemesis/generator.rs
+++ b/src/persist/src/nemesis/generator.rs
@@ -200,27 +200,40 @@ impl ReqGenerator {
             .copied()
             .unwrap_or_default();
         let ts = stream_sealed_ts + rng.gen_range(0..5);
+        // This seal request might end up failing if (e.g. storage is down),
+        // but, unlike in Validator, optimistically updating the seal frontier
+        // here does no harm, it just bumps up the time at which we'll issue
+        // future seal requests.
+        state.seal_frontier.insert(stream.clone(), ts);
         Req::Seal(SealReq { stream, ts })
     }
 
     fn allow_compaction(rng: &mut SmallRng, state: &mut GeneratorState) -> Req {
         let stream = state.rng_stream(rng);
-        let ts = {
-            let base = if rng.gen_bool(0.5) {
-                state
-                    .since_frontier
-                    .get(&stream)
-                    .copied()
-                    .unwrap_or_default()
-            } else {
-                state
-                    .seal_frontier
-                    .get(&stream)
-                    .copied()
-                    .unwrap_or_default()
-            };
-
-            base + rng.gen_range(0..5)
+        let bonus = rng.gen_range(0..5);
+        let ts = if rng.gen_bool(0.5) {
+            let base = state
+                .since_frontier
+                .get(&stream)
+                .copied()
+                .unwrap_or_default();
+            let ts = base + bonus;
+            // This allow_compaction request might end up failing if (e.g.
+            // storage is down), but, unlike in Validator, optimistically
+            // updating the since frontier here does no harm, it just bumps up
+            // the time at which we'll issue future allow_compaction requests.
+            state.since_frontier.insert(stream.to_string(), ts);
+            ts
+        } else {
+            let base = state
+                .seal_frontier
+                .get(&stream)
+                .copied()
+                .unwrap_or_default();
+            let ts = base + bonus;
+            // This allow_compaction request is expected to fail, so don't
+            // update the since frontier.
+            ts
         };
         Req::AllowCompaction(AllowCompactionReq { stream, ts })
     }
@@ -390,7 +403,7 @@ mod tests {
     fn operations_while_runtime_down() {
         let (seed, config) = (0, GeneratorConfig::all_operations());
         let mut g = Generator::new(seed, config);
-        for _ in 0..100 {
+        for _ in 0..1000 {
             g.state.running = false;
             let input = g.gen().expect("some input should always be available");
             match input.req {
@@ -400,79 +413,124 @@ mod tests {
         }
     }
 
+    // Regression test for a bug where sealed writes would be generated even
+    // when disabled.
+    #[test]
+    fn seal_write_disabled() {
+        let (seed, mut config) = (0, GeneratorConfig::all_operations());
+        config.write_sealed_weight = 0;
+        let mut g = Generator::new(seed, config);
+        let mut counter = ReqCounter::default();
+        for _ in 0..1000 {
+            let input = g.gen().expect("some input should always be available");
+            counter.count(&input.req);
+        }
+        assert_eq!(counter.counts().write_sealed_weight, 0);
+    }
+
     // Generate random inputs until we've seen each type at least N times. This
     // both verifies that the config returned by `all_operations()` in fact
     // contains all operations as well as verifies that Generator actually
     // generates all of these operation types.
     #[test]
     fn all_operations() {
-        let mut closed_by_stream = HashMap::new();
-        let mut count_input = move |input: Input, counts: &mut GeneratorConfig| match input.req {
-            Req::Write(WriteReq::Single(r)) => {
-                if r.update.1 >= closed_by_stream.get(&r.stream).copied().unwrap_or_default() {
-                    counts.write_unsealed_weight += 1;
-                } else {
-                    counts.write_sealed_weight += 1;
-                }
-            }
-            Req::Write(WriteReq::Multi(_)) => {
-                counts.write_multi_weight += 1;
-            }
-            Req::ReadOutput(_) => {
-                counts.read_output_weight += 1;
-            }
-            Req::Seal(r) => {
-                let ts = cmp::max(
-                    r.ts,
-                    closed_by_stream.get(&r.stream).copied().unwrap_or_default(),
-                );
-                closed_by_stream.insert(r.stream, ts);
-                counts.seal_weight += 1;
-            }
-            Req::AllowCompaction(_) => {
-                counts.allow_compaction_weight += 1;
-            }
-            Req::TakeSnapshot(_) => {
-                counts.take_snapshot_weight += 1;
-            }
-            Req::ReadSnapshot(_) => {
-                counts.read_snapshot_weight += 1;
-            }
-            Req::Start => {
-                counts.start_weight += 1;
-            }
-            Req::Stop => {
-                counts.stop_weight += 1;
-            }
-            Req::StorageUnavailable => {
-                counts.storage_unavailable += 1;
-            }
-            Req::StorageAvailable => {
-                counts.storage_available += 1;
-            }
-        };
-
-        let mut counts = GeneratorConfig {
-            write_unsealed_weight: 0,
-            write_sealed_weight: 0,
-            write_multi_weight: 0,
-            read_output_weight: 0,
-            seal_weight: 0,
-            allow_compaction_weight: 0,
-            take_snapshot_weight: 0,
-            read_snapshot_weight: 0,
-            start_weight: 0,
-            stop_weight: 0,
-            storage_unavailable: 0,
-            storage_available: 0,
-        };
-
         const MIN_EACH_TYPE: u32 = 5;
         let (seed, config) = (0, GeneratorConfig::all_operations());
         let mut g = Generator::new(seed, config);
-        while !for_all_u32_fields(&counts, |x| x >= MIN_EACH_TYPE) {
+        let mut counter = ReqCounter::default();
+        while !for_all_u32_fields(counter.counts(), |x| x >= MIN_EACH_TYPE) {
             let input = g.gen().expect("some input should always be available");
-            count_input(input, &mut counts);
+            counter.count(&input.req)
+        }
+    }
+
+    struct ReqCounter {
+        counts: GeneratorConfig,
+        closed_by_stream: HashMap<String, u64>,
+    }
+
+    impl Default for ReqCounter {
+        fn default() -> Self {
+            let counts = GeneratorConfig {
+                write_unsealed_weight: 0,
+                write_sealed_weight: 0,
+                write_multi_weight: 0,
+                read_output_weight: 0,
+                seal_weight: 0,
+                allow_compaction_weight: 0,
+                take_snapshot_weight: 0,
+                read_snapshot_weight: 0,
+                start_weight: 0,
+                stop_weight: 0,
+                storage_unavailable: 0,
+                storage_available: 0,
+            };
+            ReqCounter {
+                counts,
+                closed_by_stream: HashMap::new(),
+            }
+        }
+    }
+
+    impl ReqCounter {
+        fn counts(&self) -> &GeneratorConfig {
+            &self.counts
+        }
+
+        fn count(&mut self, req: &Req) {
+            match req {
+                Req::Write(WriteReq::Single(r)) => {
+                    if r.update.1
+                        >= self
+                            .closed_by_stream
+                            .get(&r.stream)
+                            .copied()
+                            .unwrap_or_default()
+                    {
+                        self.counts.write_unsealed_weight += 1;
+                    } else {
+                        self.counts.write_sealed_weight += 1;
+                    }
+                }
+                Req::Write(WriteReq::Multi(_)) => {
+                    self.counts.write_multi_weight += 1;
+                }
+                Req::ReadOutput(_) => {
+                    self.counts.read_output_weight += 1;
+                }
+                Req::Seal(r) => {
+                    let ts = cmp::max(
+                        r.ts,
+                        self.closed_by_stream
+                            .get(&r.stream)
+                            .copied()
+                            .unwrap_or_default(),
+                    );
+                    self.closed_by_stream.insert(r.stream.clone(), ts);
+                    self.counts.seal_weight += 1;
+                }
+                Req::AllowCompaction(_) => {
+                    self.counts.allow_compaction_weight += 1;
+                }
+                Req::TakeSnapshot(_) => {
+                    self.counts.take_snapshot_weight += 1;
+                }
+                Req::ReadSnapshot(_) => {
+                    self.counts.read_snapshot_weight += 1;
+                }
+                Req::Start => {
+                    self.counts.start_weight += 1;
+                }
+                Req::Stop => {
+                    self.counts.stop_weight += 1;
+                }
+                Req::StorageUnavailable => {
+                    self.counts.storage_unavailable += 1;
+                }
+                Req::StorageAvailable => {
+                    self.counts.storage_available += 1;
+                }
+            }
         }
     }
 

--- a/src/persist/src/nemesis/generator.rs
+++ b/src/persist/src/nemesis/generator.rs
@@ -63,10 +63,6 @@ impl Default for GeneratorConfig {
         // NB: If we need to temporarily disable an operation in all the nemesis
         // tests, set it to 0 here. (As opposed to clearing it in the impl of
         // `all_operations`, which will break the Generator tests.)
-
-        // TODO: Re-enable this once we aren't duplicating the output of listen
-        // and snapshot.
-        ops.read_output_weight = 0;
         ops
     }
 }

--- a/src/persist/src/nemesis/mod.rs
+++ b/src/persist/src/nemesis/mod.rs
@@ -170,7 +170,7 @@ pub struct ReadOutputReq {
 
 #[derive(Clone, Debug)]
 pub struct ReadOutputRes {
-    contents: Vec<ListenEvent<Result<String, String>, Result<(), String>>>,
+    contents: Vec<ListenEvent<String, ()>>,
 }
 
 #[derive(Clone, Debug)]
@@ -234,7 +234,8 @@ impl<R: Runtime> Runner<R> {
 pub fn run<R: Runtime>(steps: usize, config: GeneratorConfig, runtime: R) {
     let seed =
         env::var("MZ_NEMESIS_SEED").map_or_else(|_| OsRng.next_u64(), |s| s.parse().unwrap());
-    eprintln!("MZ_NEMESIS_SEED={}", seed);
+    let steps = env::var("MZ_NEMESIS_STEPS").map_or(steps, |s| s.parse().unwrap());
+    eprintln!("MZ_NEMESIS_SEED={} MZ_NEMESIS_STEPS={}", seed, steps);
     let generator = Generator::new(seed, config);
     let runner = Runner::new(generator, runtime);
     let history = runner.run(steps);

--- a/src/persist/src/operators/source.rs
+++ b/src/persist/src/operators/source.rs
@@ -149,16 +149,6 @@ mod tests {
                     .expect("write was successful");
             }
             write.seal(6).recv().expect("seal was successful");
-
-            // TODO: we need this additional write to force a `step` so that
-            // data that has been sealed can move into trace, and be observed
-            // by the listener. Remove this once we either have `step` running
-            // in the background or a dedicated command to move data into
-            // future and trace.
-            write
-                .write(&[((6.to_string(), ()), 6, 1)])
-                .recv()
-                .expect("write was successful");
             recv
         });
 


### PR DESCRIPTION
We'll want to followup on the fairly drastic performance reduction in the direct_mem nemesis test. For posterity:

- direct_file seems unaffected (within the measurement bounds of my extremely unscientific experiments).
- direct_mem gets a bit slower with the seal fix (3279 -> 2895 in 20s), which makes sense given that we're now generating more writes that actually do work.
- it then gets a bit slower with the addition of the operator (2895 -> 1924 in 20s), which makes sense given that our snapshot replay impl in that operator currently reads it all in at construction time.
- it goes from (1924 -> 1771/1707/383 in 20s) if i add in only the step call in run/stop/seal respectively. this makes sense to me because the seal one is the only one gating by dataflow progress so we're introducing a barrier.
- where it gets really strange is if i put in the step calls in run and stop (but not seal), they are individually fast, but together go from (1924 -> 178 in 20s). the only theory i had about this was that it accidentally starts blocking on operator work (and thus an activator call), but step in timely is implemented as `self.step_or_park(Some(Duration::from_secs(0)))` which is documented in `step_or_park ` to not block if there's no work to do, so that's debunked. shruggie
- then the commit that moves the listener call earlier goes from (119 -> 157 in 20s), confirming that it does get faster

raw dataz

direct_file before this PR:
```
4 runs so far, 0 failures, over 5s
17 runs so far, 0 failures, over 10s
33 runs so far, 0 failures, over 15s
42 runs so far, 0 failures, over 20s
```

direct_file after this PR
```
9 runs so far, 0 failures, over 5s
19 runs so far, 0 failures, over 10s
29 runs so far, 0 failures, over 15s
37 runs so far, 0 failures, over 20s
```

direct_mem before this PR
```
766 runs so far, 0 failures, over 5s
1600 runs so far, 0 failures, over 10s
2419 runs so far, 0 failures, over 15s
3279 runs so far, 0 failures, over 20s
```

direct_mem after this PR
```
37 runs so far, 0 failures, over 5s
76 runs so far, 0 failures, over 10s
117 runs so far, 0 failures, over 15s
157 runs so far, 0 failures, over 20s
```

direct_mem after the seal fix (causing for more successful writes to be generated)
```
687 runs so far, 0 failures, over 5s
1421 runs so far, 0 failures, over 10s
2160 runs so far, 0 failures, over 15s
2895 runs so far, 0 failures, over 20s
```

direct_mem at the end of the second commit
```
26 runs so far, 0 failures, over 5s
58 runs so far, 0 failures, over 10s
89 runs so far, 0 failures, over 15s
119 runs so far, 0 failures, over 20s
```

no step calls at all
```
462 runs so far, 0 failures, over 5s
953 runs so far, 0 failures, over 10s
1444 runs so far, 0 failures, over 15s
1924 runs so far, 0 failures, over 20s
```

step only in seal
```
94 runs so far, 0 failures, over 5s
187 runs so far, 0 failures, over 10s
283 runs so far, 0 failures, over 15s
383 runs so far, 0 failures, over 20s
```

step only in run
```
420 runs so far, 0 failures, over 5s
872 runs so far, 0 failures, over 10s
1315 runs so far, 0 failures, over 15s
1771 runs so far, 0 failures, over 20s
```

step only in stop
```
364 runs so far, 0 failures, over 5s
803 runs so far, 0 failures, over 10s
1249 runs so far, 0 failures, over 15s
1707 runs so far, 0 failures, over 20s
```

step in run and stop
```
41 runs so far, 0 failures, over 5s
90 runs so far, 0 failures, over 10s
132 runs so far, 0 failures, over 15s
178 runs so far, 0 failures, over 20s
```