### PR TITLE
Add guide on enabling topic reuse.

### DIFF
--- a/doc/user/content/guides/node-js.md
+++ b/doc/user/content/guides/node-js.md
@@ -1,7 +1,7 @@
 ---
 title: "Node.js and Materialize"
 description: "Use Node.js to connect, insert, manage, query and stream from Materialize."
-weight: 10
+weight: 20
 menu:
   main:
     parent: guides

--- a/doc/user/content/guides/reuse-topic-for-kafka-sink.md
+++ b/doc/user/content/guides/reuse-topic-for-kafka-sink.md
@@ -16,7 +16,7 @@ This is currently available only for Kafka sources and the views based on them.
 When you create a sink, you must:
 
 - Enable the `reuse_topic` switch.
-- Optionally specify the name of a [consistency topic](#consistency-metadata) to store the information that Materialize will use to identify the last completed write. The names of the sink topic and the sink consistency topic must be unique across all sinks in the system. The name of the consistency topic may be provided via:
+- Optionally specify the name of a [consistency topic](sql/create-sink/#consistency-metadata) to store the information that Materialize will use to identify the last completed write. The names of the sink topic and the sink consistency topic must be unique across all sinks in the system. The name of the consistency topic may be provided via:
     * The `CONSISTENCY TOPIC` parameter.
     * The `consistency_topic` WITH option. **Note:** This option is only available to support backwards-compatibility. You will not be able to indicate `consistency_topic` and `CONSISTENCY TOPIC` or `CONSISTENCY FORMAT` simultaneously.
 

--- a/doc/user/content/guides/reuse-topic-for-kafka-sink.md
+++ b/doc/user/content/guides/reuse-topic-for-kafka-sink.md
@@ -1,7 +1,7 @@
 ---
-title: "Topic reuse for Kafka sinks"
-description: "Enable topic reuse for Kafka sinks."
-weight: 50
+title: "Kafka Sink Topic Reuse"
+description: "Enable topic reuse for Kafka sinks (exactly-once Kafka sinks)."
+weight: 10
 menu:
   main:
     parent: guides
@@ -9,14 +9,14 @@ menu:
 
 {{< beta v0.9.0 />}}
 
-By default, Materialize creates new, distinct topics for sinks after each restart. To enable the reuse of the existing topic instead, Materialize must be able to reconstruct the prior history of the sinked object and all objects on which it is dependent--that is, events must have replayable timestamps--and must ensure that no other processes write to the output topic.
+By default, Materialize creates new, distinct topics for sinks after each restart. To enable the reuse of the existing topic instead, Materialize must be able to reconstruct the prior history of the sinked object and all objects on which it is dependent--that is, events must have replayable timestamps--and must ensure that no other processes write to the output topic. This allows for exactly-once stream processing, meaning that each incoming event is processed exactly once, and no data is duplicated or goes unprocessed, even if the stream is disrupted or Materialize is restarted.
 
 This is currently available only for Kafka sources and the views based on them.
 
 When you create a sink, you must:
 
-- Enable the `reuse_topic` switch.
-- Optionally specify the name of a [consistency topic](sql/create-sink/#consistency-metadata) to store the information that Materialize will use to identify the last completed write. The names of the sink topic and the sink consistency topic must be unique across all sinks in the system. The name of the consistency topic may be provided via:
+- Enable the `reuse_topic` option.
+- Optionally specify the name of a [consistency topic](/sql/create-sink/#consistency-metadata) to store the information that Materialize will use to identify the last completed write. The names of the sink topic and the sink consistency topic must be unique across all sinks in the system. The name of the consistency topic may be provided via:
     * The `CONSISTENCY TOPIC` parameter.
     * The `consistency_topic` WITH option. **Note:** This option is only available to support backwards-compatibility. You will not be able to indicate `consistency_topic` and `CONSISTENCY TOPIC` or `CONSISTENCY FORMAT` simultaneously.
 

--- a/doc/user/content/guides/reuse-topic-for-kafka-sink.md
+++ b/doc/user/content/guides/reuse-topic-for-kafka-sink.md
@@ -1,0 +1,42 @@
+---
+title: "Topic reuse for Kafka sinks"
+description: "Enable topic reuse for Kafka sinks."
+weight: 50
+menu:
+  main:
+    parent: guides
+---
+
+{{< beta v0.9.0 />}}
+
+By default, Materialize creates new, distinct topics for sinks after each restart. To enable the reuse of the existing topic instead, Materialize must be able to reconstruct the prior history of the sinked object and all objects on which it is dependent--that is, events must have replayable timestamps--and must ensure that no other processes write to the output topic.
+
+This is currently available only for Kafka sources and the views based on them.
+
+When you create a sink, you must:
+
+- Enable the `reuse_topic` switch.
+- Optionally specify the name of a [consistency topic](#consistency-metadata) to store the information that Materialize will use to identify the last completed write. The names of the sink topic and the sink consistency topic must be unique across all sinks in the system. The name of the consistency topic may be provided via:
+    * The `CONSISTENCY TOPIC` parameter.
+    * The `consistency_topic` WITH option. **Note:** This option is only available to support backwards-compatibility. You will not be able to indicate `consistency_topic` and `CONSISTENCY TOPIC` or `CONSISTENCY FORMAT` simultaneously.
+
+    If not specified, a default consistency topic name will be created by appending `-consistency` to the output topic name.
+
+    The sink consistency topic cannot be written to by any other process, including another Materialize instance or another sink.
+
+Because this feature is still in beta, we strongly suggest that you start with test data, rather than with production. Please [escalate](https://github.com/MaterializeInc/materialize/issues/new/choose) any issues to us.
+
+## Example
+
+  ```sql
+  CREATE SINK quotes_sink
+  FROM quotes
+  INTO KAFKA BROKER 'localhost:9092' TOPIC 'quotes-eo-sink'
+  WITH (reuse_topic=true, consistency_topic='quotes-eo-sink-consistency')
+  FORMAT AVRO USING
+    CONFLUENT SCHEMA REGISTRY 'http://localhost:8081';
+```
+
+## Related topics
+
+* [`CREATE SINK`](/sql/create-sink/)

--- a/doc/user/content/guides/temporal-filters.md
+++ b/doc/user/content/guides/temporal-filters.md
@@ -1,7 +1,7 @@
 ---
 title: "Temporal Filters"
 description: "Perform time-windowed computation over temporal data."
-weight: 10
+weight: 30
 menu:
   main:
     parent: guides

--- a/doc/user/content/guides/top-k.md
+++ b/doc/user/content/guides/top-k.md
@@ -1,7 +1,7 @@
 ---
 title: "Top K by Group"
 description: "Find the top- or bottom-K elements in a group."
-weight: 20
+weight: 40
 aliases:
   - /sql/idioms
 menu:

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -69,7 +69,7 @@ Wrap your release notes at the 80 character mark.
 - Respect the [`no_proxy` environment variable](/cli/#http-proxies) to exclude
   certain hosts from the configured HTTP/HTTPS proxy, if any.
 
-- Add [`reuse_topic`](/sql/create-sink/#enabling-topic-reuse-after-restart) as
+- Add [`reuse_topic`](/sql/create-sink/#enabling-topic-reuse-after-restart-exactly-once-sinks) as
   a beta feature for Kafka Sinks. This allows re-using the output topic across
   restarts of Materialize.
 

--- a/doc/user/content/sql/create-sink.md
+++ b/doc/user/content/sql/create-sink.md
@@ -58,7 +58,7 @@ Field                | Value type | Description
 ---------------------|------------|------------
 `partition_count`    | `int`      | Set the sink Kafka topic's partition count. This defaults to -1 (use the broker default).
 `replication_factor` | `int`      | Set the sink Kafka topic's replication factor. This defaults to -1 (use the broker default).
-`reuse_topic`        | `bool`     | Use the existing Kafka topic after Materialize restarts, instead of creating a new one. The default is false.
+`reuse_topic`        | `bool`     | Use the existing Kafka topic after Materialize restarts, instead of creating a new one. The default is false. See [Enabling topic reuse after restart](/sql/create-sink/#enabling-topic-reuse-after-restart-exactly-once-sinks) for details.
 `consistency_topic`  | `text`     | Makes the sink emit additional [consistency metadata](#consistency-metadata). Only valid for Kafka sinks. If `reuse_topic` is `true`, a default `consistency_topic` will be used when not explicitly set. The default consistency topic name is formed by appending `-consistency` to the output topic name.
 `security_protocol`  | `text`     | Use [`ssl`](#ssl-with-options) or, for [Kerberos](#kerberos-with-options), `sasl_plaintext`, `sasl-scram-sha-256`, or `sasl-sha-512` to connect to the Kafka cluster.
 `acks`               | `text`     | Sets the number of Kafka replicas that must acknowledge Materialize writes. Accepts values [-1,1000]. `-1` (the default) specifies all replicas.
@@ -107,7 +107,7 @@ they occur. To only see results after the sink is created, specify `WITHOUT SNAP
     - Avro-formtted sinks that write to either a topic or an Avro object container file.
     - JSON-formatted sinks that write to a topic.
 - For most sinks, Materialize creates new, distinct topics and files for each sink on restart.
-- A beta feature enables the use of the same topic after restart. For details, see [Enabling topic reuse after restart](#enabling-topic-reuse-after-restart).
+- A beta feature enables the use of the same topic after restart. For details, see [Enabling topic reuse after restart](#enabling-topic-reuse-after-restart-exactly-once-sinks).
 - Materialize stores information about actual topic names and actual file names in the `mz_kafka_sinks` and `mz_avro_ocf_sinks` log sources. See the [examples](#examples) below for more details.
 - For Avro-formatted sinks, Materialize generates Avro schemas for views and sources that are stored in the sink.
 - Materialize can also optionally emit transaction information for changes. This is only supported for Kafka sinks and adds transaction id information inline with the data, and adds a separate transaction metadata topic.
@@ -180,17 +180,17 @@ You can find the topic name for each Kafka sink by querying `mz_kafka_sinks`.
 
 {{% kafka-sink-drop  %}}
 
-#### Enabling topic reuse after restart
+#### Enabling topic reuse after restart (exactly-once sinks)
 
 {{< beta v0.9.0 />}}
 
-By default, Materialize creates new, distinct topics for sinks after each restart. To enable the reuse of the existing topic instead, Materialize must be able to reconstruct the prior history of the sinked object and all objects on which it is dependent--that is, events must have replayable timestamps--and must ensure that no other processes write to the output topic.
+By default, Materialize creates new, distinct topics for sinks after each restart. To enable the reuse of the existing topic instead, Materialize must be able to reconstruct the prior history of the sinked object and all objects on which it is dependent--that is, events must have replayable timestamps--and must ensure that no other processes write to the output topic. This allows for exactly-once stream processing, meaning that each incoming event is processed exactly once, and no data is duplicated or goes unprocessed, even if the stream is disrupted or Materialize is restarted.
 
 This is currently available only for Kafka sources and the views based on them.
 
 When you create a sink, you must:
 
-* Enable the `reuse_topic` switch.
+* Enable the `reuse_topic` option.
 * Optionally specify the name of a [consistency topic](#consistency-metadata) to store the information that Materialize will use to identify the last completed write. The names of the sink topic and the sink consistency topic must be unique across all sinks in the system. The name of the consistency topic may be provided via:
     * The `CONSISTENCY TOPIC` parameter.
     * The `consistency_topic` WITH option. **Note:** This option is only available to support backwards-compatibility. You will not be able to indicate `consistency_topic` and `CONSISTENCY TOPIC` or `CONSISTENCY FORMAT` simultaneously.


### PR DESCRIPTION
Adding a guide on this because it's buried in `CREATE SINK`.