### PR TITLE
mzworkflows: allow Python workflows to run Steps

### DIFF
--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -18,9 +18,8 @@ import webbrowser
 from pathlib import Path
 from typing import IO, List, Optional, Sequence, Text, Tuple
 
-from typing_extensions import NoReturn
-
 from materialize import errors, mzbuild, mzcompose, spawn, ui
+from typing_extensions import NoReturn
 
 announce = ui.speaker("==> ")
 say = ui.speaker("")

--- a/test/mzworkflows_py/README.md
+++ b/test/mzworkflows_py/README.md
@@ -3,3 +3,6 @@ An example of python-based workflows that does not actually test anything.
 If the directory contains a file named mzworkflows.py, all functions
 from it that start with 'workflow_' will be made available for execution
 as if they are regular mzcompose.yml workflows.
+
+A Python workflow can call other Steps as methods to the Workflow,
+as shown in the mzworkflows.py example in this directory.

--- a/test/mzworkflows_py/mzcompose.yml
+++ b/test/mzworkflows_py/mzcompose.yml
@@ -9,18 +9,6 @@
 
 version: '3.7'
 
-mzworkflows:
-  mzworkflows_py:
-    steps:
-      - step: start-services
-        services: [materialized]
-
-      - step: wait-for-mz
-        service: materialized
-
-      - step: workflow
-        workflow: workflow_in_python
-
 services:
   materialized:
     mzbuild: materialized

--- a/test/mzworkflows_py/mzworkflows.py
+++ b/test/mzworkflows_py/mzworkflows.py
@@ -7,8 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-import materialize.mzcompose
+from materialize.mzcompose import Workflow
 
 
-def workflow_in_python(composition: materialize.mzcompose.Composition):
-    pass
+def workflow_in_python(w: Workflow):
+    w.start_services(services=["materialized"])
+    w.wait_for_mz(service="materialized")
+    w.kill_services(services=["materialized"])


### PR DESCRIPTION
Here is what I came up in terms of Python code to be able to run Steps. I decided to leverage your `@Step` annotation so that there is no need to add any additional code as more steps are added. As per your original idea I also install each step as a method under the same name, however as a classmethod to the `Steps` rather than `Composition` . Let me know if you agree.

The syntax of the test now becomes:

```
from materialize.mzcompose import Steps as S
from materialize.mzcompose import Workflow

def workflow_in_python(w: Workflow):
    S.start_services(w, services=["materialized"])
    S.wait_for_mz(w, service="materialized")
    S.kill_services(w, services=["materialized"])
```

Which is reasonably concise. What do you think? Thanks.


