### PR TITLE
Mention that /metrics is machine-readable

### DIFF
--- a/doc/user/content/ops/monitoring.md
+++ b/doc/user/content/ops/monitoring.md
@@ -114,12 +114,17 @@ The health check is not part of Materialize's stable interface.
 Backwards-incompatible changes to the health check may be made at any time.
 {{< /warning >}}
 
-Materialize supports a minimal HTTP health check at
-`http://<materialized_endpoint>/status`. The `/status` page can be used by schedulers
-which require an HTTP endpoint to verify liveness -- it returns HTTP 200 as
-long as materialized is running. To integrate Materialize with your monitoring
-infrastructure or for more machine-readable status information the [Prometheus metrics
-endpoint](#prometheus) can be used.
+Materialize supports a basic HTTP health check at `http://<materialized_hostname>:6875/status`.
+
+The health check returns HTTP status code 200 as long as Materialize has enough resources to respond
+to HTTP requests. It does not otherwise assess the state of the system.
+
+Use this endpoint to integrate Materialize with monitoring and orchestration tools that support HTTP health
+checks, like [Kubernetes liveness probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)
+or [AWS load balancer health checks](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/target-group-health-checks.html).
+
+To perform health checks that assess other metrics, consider using the [Prometheus metrics endpoint](#prometheus).
+
 
 ## Memory usage visualization
 

--- a/doc/user/content/ops/monitoring.md
+++ b/doc/user/content/ops/monitoring.md
@@ -114,7 +114,7 @@ The health check is not part of Materialize's stable interface.
 Backwards-incompatible changes to the health check may be made at any time.
 {{< /warning >}}
 
-Materialize supports a minimal, HTTP health check at
+Materialize supports a minimal HTTP health check at
 `http://<materialized_endpoint>/status`. The `/status` page can be used by schedulers
 which require an HTTP endpoint to verify liveness -- it returns HTTP 200 as
 long as materialized is running. To integrate Materialize with your monitoring

--- a/doc/user/content/ops/monitoring.md
+++ b/doc/user/content/ops/monitoring.md
@@ -114,8 +114,10 @@ The health check is not part of Materialize's stable interface.
 Backwards-incompatible changes to the health check may be made at any time.
 {{< /warning >}}
 
-Materialize supports a minimal HTTP health check endpoint at `http://<materialized
-host>:6875/status`.
+Materialize supports a minimal, human-readable HTTP health check endpoint at
+`http://<materialized host>:6875/status`. To check on the health of Materialize in
+a machine-readable format, the [metrics
+endpoint](https://materialize.com/docs/ops/monitoring/#prometheus) can be used.
 
 ## Memory usage visualization
 

--- a/doc/user/content/ops/monitoring.md
+++ b/doc/user/content/ops/monitoring.md
@@ -114,10 +114,12 @@ The health check is not part of Materialize's stable interface.
 Backwards-incompatible changes to the health check may be made at any time.
 {{< /warning >}}
 
-Materialize supports a minimal, human-readable HTTP health check endpoint at
-`http://<materialized host>:6875/status`. To check on the health of Materialize in
-a machine-readable format, the [metrics
-endpoint](https://materialize.com/docs/ops/monitoring/#prometheus) can be used.
+Materialize supports a minimal, HTTP health check at
+`http://<materialized_endpoint>/status`. The `/status` page can be used by schedulers
+which require an HTTP endpoint to verify liveness -- it returns HTTP 200 as
+long as materialized is running. To integrate Materialize with your monitoring
+infrastructure or for more machine-readable status information the [Prometheus metrics
+endpoint](#prometheus) can be used.
 
 ## Memory usage visualization
 


### PR DESCRIPTION
The objective of this change is to clarify that /status is meant to be human-readable, while /metrics is meant to be machine-readable.  

I debated (but decided against) going deeper into explanations how this could be used for liveness and/or readiness, but decided against that for now, until we make further progress on #7142 

cc @antifuchs 