### PR TITLE
mzcompose: allow service definitions in mzworkflows.py

### DIFF
--- a/test/mzworkflows_py/mzcompose.yml
+++ b/test/mzworkflows_py/mzcompose.yml
@@ -6,17 +6,3 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
-
-version: '3.7'
-
-services:
-  materialized:
-    mzbuild: materialized
-    command: >-
-      --data-directory=/share/mzdata1
-      --experimental
-      --disable-telemetry
-    ports:
-      - 6875
-    environment:
-      - MZ_DEV=1

--- a/test/mzworkflows_py/mzworkflows.py
+++ b/test/mzworkflows_py/mzworkflows.py
@@ -7,10 +7,13 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-from materialize.mzcompose import Workflow
+from materialize.mzcompose import Mz, Workflow
+
+mz = Mz()
+services = [mz]
 
 
 def workflow_in_python(w: Workflow):
-    w.start_services(services=["materialized"])
-    w.wait_for_mz(service="materialized")
-    w.kill_services(services=["materialized"])
+    w.start_services(services=[mz.name])
+    w.wait_for_mz(service=mz.name)
+    w.kill_services(services=[mz.name])


### PR DESCRIPTION
Now `mzworkflows.py` is allowed to have service definitions. In keeping with the declarative nature of `docker-compose`, we pre-declare the services in a `services` python variable that is then picked and merged with the service definitions from the `mzcompose.yml` file , if any. The rest follows the execution path that existed before.

So a test now looks like this:
```
mz = Mz()
services = [mz]


def workflow_in_python(w: Workflow):
    w.start_services(services=[mz.name])
    w.wait_for_mz(service=mz.name)
    w.kill_services(services=[mz.name])
```

And all the defaults around starting Mz are in a python class that is common for the entire framework.