### PR TITLE
ci: bump build pipeline to 60m

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -20,7 +20,7 @@ steps:
     command: bin/ci-builder run stable bin/pyactivate --dev -m ci.test.build
     inputs:
       - "*"
-    timeout_in_minutes: 30
+    timeout_in_minutes: 60
     agents:
       queue: builder
 


### PR DESCRIPTION
We're routinely hitting the 30m timeout.