### PR TITLE
pgrepr,pgwire: entirely disable the list/map binary encodings

### DIFF
--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -618,6 +618,30 @@ where
             }
         };
 
+        if let Some(desc) = stmt.desc().relation_desc.clone() {
+            for (format, ty) in result_formats.iter().zip(desc.iter_types()) {
+                match (format, &ty.scalar_type) {
+                    (pgrepr::Format::Binary, repr::ScalarType::List { .. }) => {
+                        return self
+                            .error(ErrorResponse::error(
+                                SqlState::PROTOCOL_VIOLATION,
+                                "binary encoding of list types is not implemented",
+                            ))
+                            .await;
+                    }
+                    (pgrepr::Format::Binary, repr::ScalarType::Map { .. }) => {
+                        return self
+                            .error(ErrorResponse::error(
+                                SqlState::PROTOCOL_VIOLATION,
+                                "binary encoding of map types is not implemented",
+                            ))
+                            .await;
+                    }
+                    _ => (),
+                }
+            }
+        }
+
         let desc = stmt.desc().clone();
         let stmt = stmt.sql().cloned();
         if let Err(err) =

--- a/test/lang/python/smoketest.py
+++ b/test/lang/python/smoketest.py
@@ -18,6 +18,32 @@ MATERIALIZED_URL = "postgresql://materialize@materialized:6875/materialize"
 
 
 class SmokeTest(unittest.TestCase):
+    def test_custom_types(self):
+        with psycopg3.connect(MATERIALIZED_URL, autocommit=True) as conn:
+            # Text encoding of lists and maps is supported...
+            with conn.cursor() as cur:
+                cur.execute("SELECT LIST[1, 2, 3]")
+                row = cur.fetchone()
+                self.assertEqual(row, ("{1,2,3}",))
+
+                cur.execute("SELECT '{a => 1, b => 2}'::map[text => int]")
+                row = cur.fetchone()
+                self.assertEqual(row, ("{a=>1,b=>2}",))
+
+            # ...but binary encoding is not.
+            with conn.cursor(binary=True) as cur:
+                with self.assertRaisesRegex(
+                    psycopg3.errors.ProtocolViolation,
+                    "binary encoding of list types is not implemented",
+                ):
+                    cur.execute("SELECT LIST[1, 2, 3]")
+
+                with self.assertRaisesRegex(
+                    psycopg3.errors.ProtocolViolation,
+                    "binary encoding of map types is not implemented",
+                ):
+                    cur.execute("SELECT '{a => 1, b => 2}'::map[text => int]")
+
     def test_sqlalchemy(self):
         engine = sqlalchemy.engine.create_engine(MATERIALIZED_URL)
         results = [[c1, c2] for c1, c2 in engine.execute("VALUES (1, 2), (3, 4)")]


### PR DESCRIPTION
@mjibson you convinced me that we can punt on this approximately forever, so I'm marking the tracking issues as closed, but left a big comment in the code in case someone ever does want to tackle this.

---

The binary encodings were previously a big hack that just used the text
encoding. We're comfortable not having binary encodings for these
custom types for now, but we don't want to commit ourselves to a *bad*
binary encoding, in case we want to introduce a proper binary encoding
in the future. So just prohibit using the binary encoding with these
types for now.

Fix #2997.
Fix #4628.