### PR TITLE
coord: expose table persistence name in mz_tables

### DIFF
--- a/doc/user/content/sql/system-catalog.md
+++ b/doc/user/content/sql/system-catalog.md
@@ -600,12 +600,13 @@ Field            | Type       | Meaning
 
 The `mz_tables` table contains a row for each table in the system.
 
-Field          | Type       | Meaning
----------------|------------|----------
-`id`           | [`text`]   | Materialize's unique ID for the table.
-`oid`          | [`oid`]    | A [PostgreSQL-compatible OID][oid] for the table.
-`schema_id`    | [`bigint`] | The ID of the schema to which the table belongs.
-`name`         | [`text`]   | The name of the table.
+Field            | Type       | Meaning
+-----------------|------------|----------
+`id`             | [`text`]   | Materialize's unique ID for the table.
+`oid`            | [`oid`]    | A [PostgreSQL-compatible OID][oid] for the table.
+`schema_id`      | [`bigint`] | The ID of the schema to which the table belongs.
+`name`           | [`text`]   | The name of the table.
+`persisted_name` | [`text`]   | The name of the table's persisted materialization, or `NULL` if the table is not being persisted.
 
 ### `mz_types`
 

--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -716,7 +716,8 @@ lazy_static! {
             .with_named_column("id", ScalarType::String.nullable(false))
             .with_named_column("oid", ScalarType::Oid.nullable(false))
             .with_named_column("schema_id", ScalarType::Int64.nullable(false))
-            .with_named_column("name", ScalarType::String.nullable(false)),
+            .with_named_column("name", ScalarType::String.nullable(false))
+            .with_named_column("persisted_name", ScalarType::String.nullable(true)),
         id: GlobalId::System(4019),
         index_id: GlobalId::System(4020),
         persistent: false,

--- a/src/coord/src/catalog/builtin_table_updates.rs
+++ b/src/coord/src/catalog/builtin_table_updates.rs
@@ -24,8 +24,8 @@ use crate::catalog::builtin::{
     MZ_ROLES, MZ_SCHEMAS, MZ_SINKS, MZ_SOURCES, MZ_TABLES, MZ_TYPES, MZ_VIEWS,
 };
 use crate::catalog::{
-    Catalog, CatalogItem, Func, Index, Sink, SinkConnector, SinkConnectorState, Source, Type,
-    TypeInner, SYSTEM_CONN_ID,
+    Catalog, CatalogItem, Func, Index, Sink, SinkConnector, SinkConnectorState, Source, Table,
+    Type, TypeInner, SYSTEM_CONN_ID,
 };
 
 /// An update to a built-in table.
@@ -103,7 +103,9 @@ impl Catalog {
         let name = &entry.name().item;
         let mut updates = match entry.item() {
             CatalogItem::Index(index) => self.pack_index_update(id, oid, name, index, diff),
-            CatalogItem::Table(_) => self.pack_table_update(id, oid, schema_id, name, diff),
+            CatalogItem::Table(table) => {
+                self.pack_table_update(id, oid, schema_id, name, table, diff)
+            }
             CatalogItem::Source(source) => {
                 self.pack_source_update(id, oid, schema_id, name, source, diff)
             }
@@ -142,8 +144,11 @@ impl Catalog {
         oid: u32,
         schema_id: i64,
         name: &str,
+        table: &Table,
         diff: Diff,
     ) -> Vec<BuiltinTableUpdate> {
+        let persisted_name_datum =
+            Datum::from(table.persist.as_ref().map(|p| p.stream_name.as_str()));
         vec![BuiltinTableUpdate {
             id: MZ_TABLES.id,
             row: Row::pack_slice(&[
@@ -151,6 +156,7 @@ impl Catalog {
                 Datum::Int32(oid as i32),
                 Datum::Int64(schema_id),
                 Datum::String(name),
+                persisted_name_datum,
             ]),
             diff,
         }]


### PR DESCRIPTION
Include the persistence name as a new nullable string column (NULL if
the name is not being persisted). Looks something like the following:

    materialize=> select * from mz_tables;
      id   |  oid  | schema_id |         name         |                  persisted_name
    -------+-------+-----------+----------------------+---------------------------------------------------
    ...
     s4007 | 20176 |         1 | mz_avro_ocf_sinks    |
     s4003 | 20172 |         1 | mz_view_foreign_keys |
     u1    | 20243 |         3 | foo                  | user-table-1-materialize.public.foo
     s4043 | 20212 |         1 | mz_metrics           | system-table-4043-mz_catalog.mz_metrics
     s4047 | 20216 |         1 | mz_metric_histograms | system-table-4047-mz_catalog.mz_metric_histograms