### PR TITLE
metrics frequency: Separate from instrospection frequency

### DIFF
--- a/doc/user/content/cli/_index.md
+++ b/doc/user/content/cli/_index.md
@@ -17,6 +17,7 @@ Flag | Default | Modifies
 [`--disable-telemetry`](#telemetry) | N/A | Disables telemetry reporting.
 [`--experimental`](#experimental-mode) | Disabled | *Dangerous.* Enable experimental features.
 [`--introspection-frequency`](#introspection-sources) | 1s | The frequency at which to update [introspection sources](#introspection-sources).
+[`--metrics_scraping-frequency`](#prometheus-metrics) | 1s | The frequency at which to update [prometheus metrics](#prometheus-metrics).
 [`--listen-addr`](#listen-address) | `0.0.0.0:6875` | Materialize node's host and port
 [`-l`](#compaction-window) / [`--logical-compaction-window`](#compaction-window) | 1ms | The amount of historical detail to retain in arrangements
 [`--log-file`](#log-file) | [`mzdata`](#data-directory)`/materialized.log` | Where to emit log messages
@@ -194,12 +195,27 @@ Higher frequencies provide more up-to-date introspection but increase load on
 the system. Lower frequencies increase staleness in exchange for decreased load.
 The default frequency is a good choice for most deployments.
 
+### Prometheus metrics
+
+{{< version-changed v0.9.1 >}}
+In prior versions of Materialize, the metrics scraping interval was linked to
+the introspection interval.
+{{< /version-changed >}}
+
+The `--metrics-scraping-frequency` option determines the frequency at which the
+prometheus metrics are collected. The default frequency is `1s`. To disable
+prometheus metrics collection entirely, use the special value `off`.
+
+Higher frequencies provide more up-to-date metrics but increase load on
+the system. Lower frequencies increase staleness in exchange for decreased load.
+The default frequency is a good choice for most deployments.
+
 {{< version-changed v0.7.3 >}}
 Materialize imports its own [Prometheus metrics](/ops/monitoring#prometheus)
 into the systems tables `mz_metrics` (counters and gauge readings),
 `mz_metric_histograms` (histogram distributions) and `mz_metrics_meta` (type
 information and help for each metric). These readings are imported once per
-`--introspection-frequency` period, and are retained for the duration given with
+`--metrics-scraping-frequency` period, and are retained for the duration given with
 `--retain-prometheus-metrics` (defaulting to 5 minutes). Higher retention
 periods lead to greater memory usage.
 {{< /version-changed >}}

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -52,6 +52,10 @@ Wrap your release notes at the 80 character mark.
   column from [`timestamp`] to [`timestamp with time zone`] to better reflect
   that the timestamp is in UTC.
 
+- The metrics scraping frequency is independent of the introspection frequency.
+  It is controlled with the new flag
+  [--metrics-scraping-frequency](/cli/#prometheus-metrics).
+
 - Add the `array_agg` function.
 
 - Add the `list_agg` function.

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -173,6 +173,7 @@ pub struct LoggingConfig {
     pub granularity: Duration,
     pub log_logging: bool,
     pub retain_readings_for: Duration,
+    pub metrics_scraping_frequency: Option<Duration>,
 }
 
 /// Configures a coordinator.

--- a/src/coord/src/coord/prometheus.rs
+++ b/src/coord/src/coord/prometheus.rs
@@ -183,7 +183,7 @@ impl Scraper {
     ) -> Result<Scraper, anyhow::Error> {
         let (interval, retain_for) = match logging_config {
             Some(config) => {
-                let interval = Some(config.granularity);
+                let interval = config.metrics_scraping_frequency;
                 let retain_for = u64::try_from(config.retain_readings_for.as_millis())
                     .map_err(|_| anyhow!("scraper retention duration does not fit in an i64"))?;
                 (interval, retain_for)

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -147,6 +147,9 @@ struct Args {
     /// Default frequency with which to advance timestamps
     #[structopt(long, env = "MZ_TIMESTAMP_FREQUENCY", hidden = true, parse(try_from_str =repr::util::parse_duration), value_name = "DURATION", default_value = "1s")]
     timestamp_frequency: Duration,
+    /// Default frequency with which to scrape prometheus metrics
+    #[structopt(long, env = "MZ_METRICS_SCRAPING_FREQUENCY", hidden = true, parse(try_from_str = parse_optional_duration), value_name = "DURATION", default_value = "1s")]
+    metrics_scraping_frequency: OptionalDuration,
 
     /// [ADVANCED] Timely progress tracking mode.
     #[structopt(long, env = "MZ_TIMELY_PROGRESS_MODE", value_name = "MODE", possible_values = &["eager", "demand"], default_value = "demand")]
@@ -359,12 +362,14 @@ fn run(args: Args) -> Result<(), anyhow::Error> {
     // Configure Timely and Differential workers.
     let log_logging = args.debug_introspection;
     let retain_readings_for = args.retain_prometheus_metrics;
+    let metrics_scraping_frequency = args.metrics_scraping_frequency;
     let logging = args
         .introspection_frequency
         .map(|granularity| coord::LoggingConfig {
             granularity,
             log_logging,
             retain_readings_for,
+            metrics_scraping_frequency,
         });
     if log_logging && logging.is_none() {
         bail!(

--- a/src/materialized/tests/util.rs
+++ b/src/materialized/tests/util.rs
@@ -126,6 +126,7 @@ pub fn start_server(config: Config) -> Result<Server, Box<dyn Error>> {
                 granularity,
                 log_logging: false,
                 retain_readings_for: granularity,
+                metrics_scraping_frequency: Some(granularity),
             }),
         timestamp_frequency: Duration::from_secs(1),
         logical_compaction_window: config.logical_compaction_window,


### PR DESCRIPTION
This allows to specify the metrics scraping frequency independently of the introspection frequency.

Signed-off-by: Moritz Hoffmann <mh@materialize.com>