### PR TITLE
persist: mark metrics as safe for third parties

### DIFF
--- a/src/ore/src/metrics/third_party_metric.rs
+++ b/src/ore/src/metrics/third_party_metric.rs
@@ -26,7 +26,7 @@ use super::{CounterVecExt, DeleteOnDropCounter, DeleteOnDropGauge, GaugeVecExt, 
 
 /// A metric that can be made accesible to cloud infrastructure/orchestrators, that won't betray the
 /// contents of the materialize instance that it details.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ThirdPartyMetric<T: Collector + Clone> {
     pub(super) inner: T,
 }

--- a/src/persist/src/indexed/metrics.rs
+++ b/src/persist/src/indexed/metrics.rs
@@ -12,7 +12,7 @@
 use std::time::Duration;
 
 use ore::metric;
-use ore::metrics::{MetricsRegistry, UIntCounter, UIntGauge};
+use ore::metrics::{MetricsRegistry, ThirdPartyMetric, UIntCounter, UIntGauge};
 
 // A helper function so we don't have to litter this as cast all over the place.
 //
@@ -28,112 +28,112 @@ pub(crate) fn metric_duration_ms(d: Duration) -> u64 {
 /// Persistence related monitoring metrics.
 #[derive(Clone, Debug)]
 pub struct Metrics {
-    pub(crate) stream_count: UIntGauge,
+    pub(crate) stream_count: ThirdPartyMetric<UIntGauge>,
     // TODO: pub(crate) stream_updated: UIntGauge,
-    pub(crate) meta_size_bytes: UIntGauge,
+    pub(crate) meta_size_bytes: ThirdPartyMetric<UIntGauge>,
 
-    pub(crate) future_blob_count: UIntGauge,
-    pub(crate) future_blob_bytes: UIntGauge,
+    pub(crate) future_blob_count: ThirdPartyMetric<UIntGauge>,
+    pub(crate) future_blob_bytes: ThirdPartyMetric<UIntGauge>,
 
-    pub(crate) trace_blob_count: UIntGauge,
-    pub(crate) trace_blob_bytes: UIntGauge,
+    pub(crate) trace_blob_count: ThirdPartyMetric<UIntGauge>,
+    pub(crate) trace_blob_bytes: ThirdPartyMetric<UIntGauge>,
 
-    // TODO: pub(crate) cmd_queue_ms: UIntGauge,
-    pub(crate) cmd_queue_in: UIntCounter,
+    // TODO: pub(crate) cmd_queue_ms: ThirdPartyMetric<UIntGauge>,
+    pub(crate) cmd_queue_in: ThirdPartyMetric<UIntCounter>,
 
-    pub(crate) cmd_run_count: UIntCounter,
-    pub(crate) cmd_run_ms: UIntCounter,
-    pub(crate) cmd_step_ms: UIntCounter,
-    // TODO: pub(crate) cmd_failed_count: UIntCounter,
+    pub(crate) cmd_run_count: ThirdPartyMetric<UIntCounter>,
+    pub(crate) cmd_run_ms: ThirdPartyMetric<UIntCounter>,
+    pub(crate) cmd_step_ms: ThirdPartyMetric<UIntCounter>,
+    // TODO: pub(crate) cmd_failed_count: ThirdPartyMetric<UIntCounter>,
 
     // TODO: Tag cmd_process_count with cmd type and remove this?
-    pub(crate) cmd_write_count: UIntCounter,
-    pub(crate) cmd_write_record_count: UIntCounter,
+    pub(crate) cmd_write_count: ThirdPartyMetric<UIntCounter>,
+    pub(crate) cmd_write_record_count: ThirdPartyMetric<UIntCounter>,
 
-    pub(crate) blob_write_count: UIntCounter,
-    pub(crate) blob_write_bytes: UIntCounter,
-    pub(crate) blob_write_ms: UIntCounter,
-    // TODO: pub(crate) blob_read_cache_bytes: UIntGauge,
-    // TODO: pub(crate) blob_read_cache_entry_count: UIntGauge,
-    pub(crate) blob_read_cache_hit_count: UIntCounter,
-    pub(crate) blob_read_cache_miss_count: UIntCounter,
-    pub(crate) blob_read_cache_fetch_bytes: UIntCounter,
-    // TODO: pub(crate) blob_read_error_count: UIntCounter,
+    pub(crate) blob_write_count: ThirdPartyMetric<UIntCounter>,
+    pub(crate) blob_write_bytes: ThirdPartyMetric<UIntCounter>,
+    pub(crate) blob_write_ms: ThirdPartyMetric<UIntCounter>,
+    // TODO: pub(crate) blob_read_cache_bytes: ThirdPartyMetric<UIntGauge>,
+    // TODO: pub(crate) blob_read_cache_entry_count: ThirdPartyMetric<UIntGauge>,
+    pub(crate) blob_read_cache_hit_count: ThirdPartyMetric<UIntCounter>,
+    pub(crate) blob_read_cache_miss_count: ThirdPartyMetric<UIntCounter>,
+    pub(crate) blob_read_cache_fetch_bytes: ThirdPartyMetric<UIntCounter>,
+    // TODO: pub(crate) blob_read_error_count: ThirdPartyMetric<UIntCounter>,
 }
 
 impl Metrics {
     /// Returns a new [Metrics] instance connected to the given registry.
     pub(crate) fn register_with(registry: &MetricsRegistry) -> Self {
         Metrics {
-            stream_count: registry.register(metric!(
+            stream_count: registry.register_third_party_visible(metric!(
                 name: "mz_persist_stream_count",
                 help: "count of non-destroyed persistent streams",
             )),
-            meta_size_bytes: registry.register(metric!(
+            meta_size_bytes: registry.register_third_party_visible(metric!(
                 name: "mz_persist_meta_size_bytes",
                 help: "size of the most recently generated META record",
             )),
-            future_blob_count: registry.register(metric!(
+            future_blob_count: registry.register_third_party_visible(metric!(
                 name: "mz_persist_future_blob_count",
                 help: "count of all blobs containing unsealed records",
             )),
-            future_blob_bytes: registry.register(metric!(
+            future_blob_bytes: registry.register_third_party_visible(metric!(
                 name: "mz_persist_future_blob_bytes",
                 help: "total size of all blobs containing unsealed records",
             )),
-            trace_blob_count: registry.register(metric!(
+            trace_blob_count: registry.register_third_party_visible(metric!(
                 name: "mz_persist_trace_blob_count",
                 help: "count of all blobs containing sealed records",
             )),
-            trace_blob_bytes: registry.register(metric!(
+            trace_blob_bytes: registry.register_third_party_visible(metric!(
                 name: "mz_persist_trace_blob_bytes",
                 help: "total size of all blobs containing sealed records",
             )),
-            cmd_queue_in: registry.register(metric!(
+            cmd_queue_in: registry.register_third_party_visible(metric!(
                 name: "mz_persist_cmd_queue_in",
                 help: "count of commands entering the runtime channel",
             )),
-            cmd_run_count: registry.register(metric!(
+            cmd_run_count: registry.register_third_party_visible(metric!(
                 name: "mz_persist_cmd_run_count",
                 help: "count of commands run",
             )),
-            cmd_run_ms: registry.register(metric!(
+            cmd_run_ms: registry.register_third_party_visible(metric!(
                 name: "mz_persist_cmd_run_ms",
                 help: "time spent running commands",
             )),
-            cmd_step_ms: registry.register(metric!(
+            cmd_step_ms: registry.register_third_party_visible(metric!(
                 name: "mz_persist_cmd_step_ms",
                 help: "time spent in step",
             )),
-            cmd_write_count: registry.register(metric!(
+            cmd_write_count: registry.register_third_party_visible(metric!(
                 name: "mz_persist_cmd_write_count",
                 help: "count of write commands run",
             )),
-            cmd_write_record_count: registry.register(metric!(
+            cmd_write_record_count: registry.register_third_party_visible(metric!(
                 name: "mz_persist_cmd_write_record_count",
                 help: "total count of records written in all streams",
             )),
-            blob_write_count: registry.register(metric!(
+            blob_write_count: registry.register_third_party_visible(metric!(
                 name: "mz_persist_blob_write_count",
                 help: "count of blob storage writes",
             )),
-            blob_write_bytes: registry.register(metric!(
+            blob_write_bytes: registry.register_third_party_visible(metric!(
                 name: "mz_persist_blob_write_bytes",
                 help: "total size written to blob storage",
             )),
-            blob_write_ms: registry.register(metric!(
+            blob_write_ms: registry.register_third_party_visible(metric!(
                 name: "mz_persist_blob_write_ms",
                 help: "time spent writing to blob storage",
             )),
-            blob_read_cache_hit_count: registry.register(metric!(
+            blob_read_cache_hit_count: registry.register_third_party_visible(metric!(
                 name: "mz_persist_blob_read_cache_hit_count",
                 help: "count of blob reads served by cached data",
             )),
-            blob_read_cache_miss_count: registry.register(metric!(
+            blob_read_cache_miss_count: registry.register_third_party_visible(metric!(
                 name: "mz_persist_blob_read_cache_miss_count",
                 help: "count of blob reads that had to be fetched",
             )),
-            blob_read_cache_fetch_bytes: registry.register(metric!(
+            blob_read_cache_fetch_bytes: registry.register_third_party_visible(metric!(
                 name: "mz_persist_blob_read_cache_fetch_bytes",
                 help: "total size of blob reads that had to be fetched",
             )),


### PR DESCRIPTION
They are all simple counters and gauges (so no interesting information
to leak) and this will be necessary to use them in the internal cloud
prometheus+grafana stack.