### PR TITLE
coord: allow booting mz w/ user indexes disabled

### DIFF
--- a/doc/user/content/cli/_index.md
+++ b/doc/user/content/cli/_index.md
@@ -29,6 +29,7 @@ Flag | Default | Modifies
 [`-w`](#worker-threads) / [`--workers`](#worker-threads) | NCPUs / 2 | Dataflow worker threads
 `-v` / `--version` | N/A | Print version and exit
 `-vv` | N/A | Print version and additional build information, and exit
+[`--disable-user-indexes`](#disable-user-indexes) | Disabled | Starts the node without creating any dataflows for user indexes.
 
 If a command line flag takes an argument, you can alternatively set that flag
 via an environment variable named after the flag. If both the environment
@@ -111,7 +112,7 @@ the port that Materialize listens on from the default `6875`.
 
 The `--logical-compaction-window` option specifies the duration of time for
 which Materialize is required to maintain full historical detail in its
-[arrangements](/overview/api-components#indexes). Note that compaction happens
+[arrangements][api-indexes]. Note that compaction happens
 lazily, so Materialize may retain more historical detail than requested, but it
 will never retain less.
 
@@ -350,6 +351,41 @@ Using these parameters correctly requires substantial knowledge about how
 the underlying Timely and Differential Dataflow engines work. Typically you
 should only set these parameters in consultation with Materialize engineers.
 
+### Disable user indexes
+
+{{< version-added v0.9.2 />}}
+
+{{< warning >}}
+This feature is primarily meant for advanced administrators of Materialize.
+{{< /warning >}}
+
+If you cannot boot a Materialize node because it runs out of memory, you can use
+the `--disable-user-indexes` to prevent Materialize from creating any
+[indexes][api-indexes] on user-created objects. For
+example, if you add a view that contains a cross join that causes your node to
+immediately run out of memory on boot, you can use `--disable-user-indexes` to
+boot the node and then drop the offending view.
+
+In this mode users...
+
+- Can access objects within the [system catalog][sys-cat] to help determine
+  which indexes are causing the crash.
+- Can only `SELECT` from user-created objects that do not rely on user-created
+  indexes. In essence, this means users can still `SELECT` from user-created...
+  - Tables, but they will never return any data.
+  - Views that contain only references to constant values or depend entirely on
+    system tables' indexes.
+- Cannot `INSERT` data into tables.
+- Can create new objects, but any created indexes will remain disabled.
+
+For assistance with this mode, see:
+
+- [Architecture over: Indexes][api-indexes]
+- [System catalog][sys-cat]
+- [`SHOW INDEX`](/sql/show-index)
+- [`DROP VIEW`](/sql/drop-view)
+- [`DROP INDEX`](/sql/drop-index)
+
 ## Special environment variables
 
 Materialize respects several environment variables that have conventional
@@ -365,6 +401,8 @@ behavior generally matches the behavior of other HTTP clients.
 For precise details of Materialize's behavior, consult the documentation of
 the [`mz_http_proxy`](https://docs.rs/mz_http_proxy) crate.
 
+[api-indexes]: /overview/api-components#indexes
 [gh-feature]: https://github.com/MaterializeInc/materialize/issues/new?labels=C-feature&template=feature.md
 [scv]: /sql/show-create-view
 [scs]: /sql/show-create-source
+[sys-cat]: /sql/system-catalog

--- a/doc/user/content/sql/show-index.md
+++ b/doc/user/content/sql/show-index.md
@@ -26,9 +26,9 @@ _on&lowbar;name_ | The name of the object whose indexes you want to show. This c
 `SHOW INDEX`'s output is a table, with this structure:
 
 ```nofmt
- on_name | key_name | seq_in_index | column_name | expression | nullable |
----------+----------+--------------+-------------+------------+----------+
- ...     | ...      | ...          | ...         | ...        | ...
+ on_name | key_name | seq_in_index | column_name | expression | nullable | enabled
+---------+----------+--------------+-------------+------------+----------+--------
+ ...     | ...      | ...          | ...         | ...        | ...      | ...
 ```
 
 Field | Meaning
@@ -39,6 +39,7 @@ Field | Meaning
 **column_name** | The indexed column.
 **expression** | An expression used to generate the column in the index.
 **null** | Is the column nullable?
+**enabled** | Does the index represent an [arrangement](/overview/arrangements/)? `false` only in the case of [Disabling user indexes](/cli/#disable-user-indexes).
 
 {{< version-changed v0.5.0 >}}
 The output columns are renamed from `On_name`, `Key_name`, `Column_name`,
@@ -65,9 +66,9 @@ SHOW FULL VIEWS;
 SHOW INDEXES FROM my_materialized_view;
 ```
 ```nofmt
- on_name | key_name | seq_in_index | column_name | expression | null
----------+----------+--------------+-------------+------------+-----
- ...     | ...      | ...          | ...         | ...        | ...
+ on_name | key_name | seq_in_index | column_name | expression | nullable | enabled
+---------+----------+--------------+-------------+------------+----------+--------
+ ...     | ...      | ...          | ...         | ...        | ...      | ...
 ```
 
 ## Related pages

--- a/doc/user/content/sql/system-catalog.md
+++ b/doc/user/content/sql/system-catalog.md
@@ -209,7 +209,7 @@ Field        | Type        | Meaning
 `name`       | [`text`]    | The name of the index.
 `on_id`      | [`text`]    | The ID of the relation on which the index is built.
 `volatility` | [`text`]    | Whether the the index is [volatile](/overview/volatility). Either `volatile`, `nonvolatile`, or `unknown`.
-`enabled`    | [`bool`]    | Whether or not the index is available for use, e.g. a user index with the startup option `--disable-user-indexes` applied.
+`enabled`    | [`bool`]    | Whether or not the index represents an [arrangement](/overview/arrangements/). `false` only in the case of [Disabling user indexes](/cli/#disable-user-indexes).
 
 ### `mz_index_columns`
 

--- a/doc/user/content/sql/system-catalog.md
+++ b/doc/user/content/sql/system-catalog.md
@@ -209,6 +209,7 @@ Field        | Type        | Meaning
 `name`       | [`text`]    | The name of the index.
 `on_id`      | [`text`]    | The ID of the relation on which the index is built.
 `volatility` | [`text`]    | Whether the the index is [volatile](/overview/volatility). Either `volatile`, `nonvolatile`, or `unknown`.
+`enabled`    | [`bool`]    | Whether or not the index is available for use, e.g. a user index with the startup option `--disable-user-indexes` applied.
 
 ### `mz_index_columns`
 

--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -104,7 +104,9 @@ pub struct Catalog {
     by_name: BTreeMap<String, Database>,
     by_id: CatalogEntryMap,
     by_oid: HashMap<u32, GlobalId>,
-    indexes: HashMap<GlobalId, Vec<(GlobalId, Vec<MirScalarExpr>)>>,
+    /// Contains only enabled indexes from objects in the catalog; does not
+    /// contain indexes disabled by e.g. the disable_user_indexes flag.
+    enabled_indexes: HashMap<GlobalId, Vec<(GlobalId, Vec<MirScalarExpr>)>>,
     ambient_schemas: BTreeMap<String, Schema>,
     temporary_schemas: HashMap<u32, Schema>,
     roles: HashMap<String, Role>,
@@ -328,6 +330,7 @@ pub struct Index {
     pub keys: Vec<MirScalarExpr>,
     pub conn_id: Option<u32>,
     pub depends_on: Vec<GlobalId>,
+    pub enabled: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -602,7 +605,7 @@ impl Catalog {
             by_name: BTreeMap::new(),
             by_id: CatalogEntryMap::new(BTreeMap::new()),
             by_oid: HashMap::new(),
-            indexes: HashMap::new(),
+            enabled_indexes: HashMap::new(),
             ambient_schemas: BTreeMap::new(),
             temporary_schemas: HashMap::new(),
             roles: HashMap::new(),
@@ -620,6 +623,7 @@ impl Catalog {
                 num_workers: config.num_workers,
                 timestamp_frequency: config.timestamp_frequency,
                 now: config.now,
+                disable_user_indexes: config.disable_user_indexes,
             },
             persist,
         };
@@ -736,6 +740,7 @@ impl Catalog {
                             ),
                             conn_id: None,
                             depends_on: vec![log.id],
+                            enabled: catalog.enable_index(&log.index_id),
                         }),
                     );
                 }
@@ -786,6 +791,7 @@ impl Catalog {
                             create_sql: index_sql,
                             conn_id: None,
                             depends_on: vec![table.id],
+                            enabled: catalog.enable_index(&table.index_id),
                         }),
                     );
                 }
@@ -952,6 +958,7 @@ impl Catalog {
             persist: PersistConfig::disabled(),
             skip_migrations: true,
             metrics_registry: &MetricsRegistry::new(),
+            disable_user_indexes: false,
         })?;
         Ok(catalog)
     }
@@ -1249,13 +1256,15 @@ impl Catalog {
 
         match entry.item() {
             CatalogItem::Table(_) | CatalogItem::Source(_) | CatalogItem::View(_) => {
-                self.indexes.insert(id, vec![]);
+                self.enabled_indexes.insert(id, vec![]);
             }
             CatalogItem::Index(index) => {
-                self.indexes
-                    .get_mut(&index.on)
-                    .unwrap()
-                    .push((id, index.keys.clone()));
+                if index.enabled {
+                    self.enabled_indexes
+                        .get_mut(&index.on)
+                        .unwrap()
+                        .push((id, index.keys.clone()));
+                }
             }
             CatalogItem::Func(_) | CatalogItem::Sink(_) | CatalogItem::Type(_) => (),
         }
@@ -1826,16 +1835,19 @@ impl Catalog {
                         .expect("catalog out of sync");
                     if let CatalogItem::Index(index) = &metadata.item {
                         let indexes = self
-                            .indexes
+                            .enabled_indexes
                             .get_mut(&index.on)
                             .expect("catalog out of sync");
-                        let i = indexes
-                            .iter()
-                            .position(|(idx_id, _keys)| *idx_id == id)
-                            .expect("catalog out of sync");
-                        indexes.remove(i);
+                        let i = indexes.iter().position(|(idx_id, _keys)| *idx_id == id);
+                        match i {
+                            Some(i) => {
+                                indexes.remove(i);
+                            }
+                            None if !index.enabled => {}
+                            None => panic!("catalog out of sync"),
+                        };
                     }
-                    self.indexes.remove(&id);
+                    self.enabled_indexes.remove(&id);
                 }
 
                 Action::UpdateItem { id, to_name, item } => {
@@ -1947,7 +1959,7 @@ impl Catalog {
             }),
             Plan::CreateSource(CreateSourcePlan { source, .. }) => {
                 let mut optimizer = Optimizer::for_view();
-                let optimized_expr = optimizer.optimize(source.expr, self.indexes())?;
+                let optimized_expr = optimizer.optimize(source.expr, self.enabled_indexes())?;
                 let transformed_desc = RelationDesc::new(optimized_expr.typ(), source.column_names);
                 CatalogItem::Source(Source {
                     create_sql: source.create_sql,
@@ -1961,7 +1973,7 @@ impl Catalog {
                 view, depends_on, ..
             }) => {
                 let mut optimizer = Optimizer::for_view();
-                let optimized_expr = optimizer.optimize(view.expr, self.indexes())?;
+                let optimized_expr = optimizer.optimize(view.expr, self.enabled_indexes())?;
                 let desc = RelationDesc::new(optimized_expr.typ(), view.column_names);
                 CatalogItem::View(View {
                     create_sql: view.create_sql,
@@ -1979,6 +1991,7 @@ impl Catalog {
                 keys: index.keys,
                 conn_id: None,
                 depends_on,
+                enabled: self.enable_index(&id),
             }),
             Plan::CreateSink(CreateSinkPlan {
                 sink,
@@ -2004,10 +2017,21 @@ impl Catalog {
         })
     }
 
-    /// Returns a mapping that indicates all indices that are available for
-    /// each item in the catalog.
-    pub fn indexes(&self) -> &HashMap<GlobalId, Vec<(GlobalId, Vec<MirScalarExpr>)>> {
-        &self.indexes
+    /// Determines the appropriate value for a [`Index`]'s `enabled` field.
+    ///
+    /// Note that it is the caller's responsibility to ensure that the `id` is
+    /// used for an `Index`.
+    pub fn enable_index(&self, id: &GlobalId) -> bool {
+        !self.config.disable_user_indexes || !id.is_user()
+    }
+
+    /// Returns a mapping that indicates all indices that are available for each
+    /// item in the catalog.
+    ///
+    /// Note that when `self.config.disable_user_indexes` is `true`, this does
+    /// not include any user indexes.
+    pub fn enabled_indexes(&self) -> &HashMap<GlobalId, Vec<(GlobalId, Vec<MirScalarExpr>)>> {
+        &self.enabled_indexes
     }
 
     /// Returns the default index for the specified `id`.
@@ -2017,7 +2041,7 @@ impl Catalog {
     pub fn default_index_for(&self, id: GlobalId) -> Option<GlobalId> {
         // The default index is just whatever index happens to appear first in
         // self.indexes.
-        self.indexes[&id].first().map(|(id, _keys)| *id)
+        self.enabled_indexes[&id].first().map(|(id, _keys)| *id)
     }
 
     /// Finds the nearest indexes that can satisfy the views or sources whose
@@ -2044,7 +2068,7 @@ impl Catalog {
                 return;
             }
 
-            if let Some((index_id, _)) = catalog.indexes[&id].first() {
+            if let Some((index_id, _)) = catalog.enabled_indexes[&id].first() {
                 indexes.push(*index_id);
                 return;
             }

--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -691,7 +691,8 @@ lazy_static! {
             .with_named_column("oid", ScalarType::Oid.nullable(false))
             .with_named_column("name", ScalarType::String.nullable(false))
             .with_named_column("on_id", ScalarType::String.nullable(false))
-            .with_named_column("volatility", ScalarType::String.nullable(false)),
+            .with_named_column("volatility", ScalarType::String.nullable(false))
+            .with_named_column("enabled", ScalarType::Bool.nullable(false)),
         id: GlobalId::System(4015),
         index_id: GlobalId::System(4016),
         persistent: false,

--- a/src/coord/src/catalog/builtin_table_updates.rs
+++ b/src/coord/src/catalog/builtin_table_updates.rs
@@ -285,6 +285,7 @@ impl Catalog {
             Statement::CreateIndex(CreateIndexStatement { key_parts, .. }) => key_parts.unwrap(),
             _ => unreachable!(),
         };
+
         updates.push(BuiltinTableUpdate {
             id: MZ_INDEXES.id,
             row: Row::pack_slice(&[
@@ -293,6 +294,7 @@ impl Catalog {
                 Datum::String(name),
                 Datum::String(&index.on.to_string()),
                 Datum::String(self.is_volatile(id).as_str()),
+                Datum::from(index.enabled),
             ]),
             diff,
         });

--- a/src/coord/src/catalog/config.rs
+++ b/src/coord/src/catalog/config.rs
@@ -40,4 +40,6 @@ pub struct Config<'a> {
     pub skip_migrations: bool,
     // The registry that catalog uses to report metrics.
     pub metrics_registry: &'a MetricsRegistry,
+    // Whether or not to prevent user indexes from being considered for use
+    pub disable_user_indexes: bool,
 }

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -185,6 +185,7 @@ pub struct Config<'a> {
     pub timestamp_frequency: Duration,
     pub logical_compaction_window: Option<Duration>,
     pub experimental_mode: bool,
+    pub disable_user_indexes: bool,
     pub safe_mode: bool,
     pub build_info: &'static BuildInfo,
     pub metrics_registry: MetricsRegistry,
@@ -387,8 +388,9 @@ impl Coordinator {
                         let frontiers = self.new_frontiers(entry.id(), Some(0), Some(1_000));
                         self.indexes.insert(entry.id(), frontiers);
                     } else {
-                        let df = self.dataflow_builder().build_index_dataflow(entry.id());
-                        self.ship_dataflow(df);
+                        self.dataflow_builder()
+                            .build_index_dataflow(entry.id())
+                            .map(|df| self.ship_dataflow(df));
                     }
                 }
                 _ => (), // Handled in next loop.
@@ -1691,6 +1693,7 @@ impl Coordinator {
             &table.desc,
             conn_id,
             index_depends_on,
+            self.catalog.enable_index(&index_id),
         );
         let table_oid = self.catalog.allocate_oid()?;
         let index_oid = self.catalog.allocate_oid()?;
@@ -1709,8 +1712,9 @@ impl Coordinator {
             },
         ]) {
             Ok(_) => {
-                let df = self.dataflow_builder().build_index_dataflow(index_id);
-                self.ship_dataflow(df);
+                self.dataflow_builder()
+                    .build_index_dataflow(index_id)
+                    .map(|df| self.ship_dataflow(df));
                 Ok(ExecuteResponse::CreatedTable { existed: false })
             }
             Err(CoordError::Catalog(catalog::Error {
@@ -1769,8 +1773,9 @@ impl Coordinator {
                 self.new_frontiers(source_id, Some(0), self.logical_compaction_window_ms);
             self.sources.insert(source_id, frontiers);
             if let Some(index_id) = idx_id {
-                let df = self.dataflow_builder().build_index_dataflow(index_id);
-                self.ship_dataflow(df);
+                self.dataflow_builder()
+                    .build_index_dataflow(index_id)
+                    .map(|df| self.ship_dataflow(df));
             }
         }
     }
@@ -1791,7 +1796,7 @@ impl Coordinator {
             } = plan;
             let optimized_expr = self
                 .view_optimizer
-                .optimize(source.expr, self.catalog.indexes())?;
+                .optimize(source.expr, self.catalog.enabled_indexes())?;
             let transformed_desc = RelationDesc::new(optimized_expr.0.typ(), source.column_names);
             let source = catalog::Source {
                 create_sql: source.create_sql,
@@ -1815,6 +1820,7 @@ impl Coordinator {
                     .catalog
                     .for_session(session)
                     .find_available_name(index_name);
+                let index_id = self.catalog.allocate_id()?;
                 let index = auto_generate_primary_idx(
                     index_name.item.clone(),
                     name,
@@ -1822,8 +1828,8 @@ impl Coordinator {
                     &source.desc,
                     None,
                     vec![source_id],
+                    self.catalog.enable_index(&index_id),
                 );
-                let index_id = self.catalog.allocate_id()?;
                 let index_oid = self.catalog.allocate_oid()?;
                 ops.push(catalog::Op::CreateItem {
                     id: index_id,
@@ -1971,6 +1977,7 @@ impl Coordinator {
                 .catalog
                 .for_session(session)
                 .find_available_name(index_name);
+            let index_id = self.catalog.allocate_id()?;
             let index = auto_generate_primary_idx(
                 index_name.item.clone(),
                 name,
@@ -1978,8 +1985,8 @@ impl Coordinator {
                 &view.desc,
                 view.conn_id,
                 vec![view_id],
+                self.catalog.enable_index(&index_id),
             );
-            let index_id = self.catalog.allocate_id()?;
             let index_oid = self.catalog.allocate_oid()?;
             ops.push(catalog::Op::CreateItem {
                 id: index_id,
@@ -2006,8 +2013,9 @@ impl Coordinator {
         match self.catalog_transact(ops) {
             Ok(()) => {
                 if let Some(index_id) = index_id {
-                    let df = self.dataflow_builder().build_index_dataflow(index_id);
-                    self.ship_dataflow(df);
+                    self.dataflow_builder()
+                        .build_index_dataflow(index_id)
+                        .map(|df| self.ship_dataflow(df));
                 }
                 Ok(ExecuteResponse::CreatedView { existed: false })
             }
@@ -2039,8 +2047,9 @@ impl Coordinator {
             Ok(()) => {
                 let mut dfs = vec![];
                 for index_id in index_ids {
-                    let df = self.dataflow_builder().build_index_dataflow(index_id);
-                    dfs.push(df);
+                    self.dataflow_builder()
+                        .build_index_dataflow(index_id)
+                        .map(|df| dfs.push(df));
                 }
                 self.ship_dataflows(dfs);
                 Ok(ExecuteResponse::CreatedView { existed: false })
@@ -2066,14 +2075,15 @@ impl Coordinator {
         for key in &mut index.keys {
             Self::prep_scalar_expr(key, ExprPrepStyle::Static)?;
         }
+        let id = self.catalog.allocate_id()?;
         let index = catalog::Index {
             create_sql: index.create_sql,
             keys: index.keys,
             on: index.on,
             conn_id: None,
             depends_on,
+            enabled: self.catalog.enable_index(&id),
         };
-        let id = self.catalog.allocate_id()?;
         let oid = self.catalog.allocate_oid()?;
         let op = catalog::Op::CreateItem {
             id,
@@ -2083,9 +2093,11 @@ impl Coordinator {
         };
         match self.catalog_transact(vec![op]) {
             Ok(()) => {
-                let df = self.dataflow_builder().build_index_dataflow(id);
-                self.ship_dataflow(df);
-                self.set_index_options(id, options);
+                self.dataflow_builder().build_index_dataflow(id).map(|df| {
+                    self.ship_dataflow(df);
+                    self.set_index_options(id, options);
+                });
+
                 Ok(ExecuteResponse::CreatedIndex { existed: false })
             }
             Err(CoordError::Catalog(catalog::Error {
@@ -2515,7 +2527,7 @@ impl Coordinator {
                 // values by predicate constraints in `map_filter_project`. If we find such
                 // an index, we can use it with the literal to perform look-ups at workers,
                 // and in principle avoid even contacting all but one worker (future work).
-                if let Some(indexes) = self.catalog.indexes().get(id) {
+                if let Some(indexes) = self.catalog.enabled_indexes().get(id) {
                     // Determine for each index identifier, an optional row literal as key.
                     // We want to extract the "best" option, where we prefer indexes with
                     // literals and long keys, then indexes at all, then exit correctly.
@@ -2920,7 +2932,7 @@ impl Coordinator {
                     &optimized_plan,
                     &mut dataflow,
                 );
-                transform::optimize_dataflow(&mut dataflow, self.catalog.indexes());
+                transform::optimize_dataflow(&mut dataflow, self.catalog.enabled_indexes());
                 let catalog = self.catalog.for_session(session);
                 let mut explanation =
                     dataflow_types::Explanation::new_from_dataflow(&dataflow, &catalog);
@@ -2948,7 +2960,19 @@ impl Coordinator {
         }]))?;
         Ok(match plan.kind {
             MutationKind::Delete => ExecuteResponse::Deleted(plan.affected_rows),
-            MutationKind::Insert => ExecuteResponse::Inserted(plan.affected_rows),
+            MutationKind::Insert => {
+                if self.catalog.config().disable_user_indexes {
+                    if self.catalog.enabled_indexes()[&plan.id].is_empty() {
+                        // Have to hard error here because we won't encounter the failure to
+                        // select an index until a panic occurs in the dataflow layer.
+                        return Err(CoordError::TableWithoutIndexes(
+                            self.catalog.get_by_id(&plan.id).name().to_string(),
+                        ));
+                    }
+                }
+
+                ExecuteResponse::Inserted(plan.affected_rows)
+            }
             MutationKind::Update => ExecuteResponse::Updated(plan.affected_rows),
         })
     }
@@ -3221,7 +3245,9 @@ impl Coordinator {
         style: ExprPrepStyle,
     ) -> Result<OptimizedMirRelationExpr, CoordError> {
         if let ExprPrepStyle::Static = style {
-            let mut opt_expr = self.view_optimizer.optimize(expr, self.catalog.indexes())?;
+            let mut opt_expr = self
+                .view_optimizer
+                .optimize(expr, self.catalog.enabled_indexes())?;
             opt_expr.0.try_visit_mut(&mut |e| {
                 // Carefully test filter expressions, which may represent temporal filters.
                 if let expr::MirRelationExpr::Filter { input, predicates } = &*e {
@@ -3242,7 +3268,9 @@ impl Coordinator {
             // constant expression that originally contains a global get? Is
             // there anything not containing a global get that cannot be
             // optimized to a constant expression?
-            Ok(self.view_optimizer.optimize(expr, self.catalog.indexes())?)
+            Ok(self
+                .view_optimizer
+                .optimize(expr, self.catalog.enabled_indexes())?)
         }
     }
 
@@ -3357,7 +3385,7 @@ impl Coordinator {
             }
 
             // Optimize the dataflow across views, and any other ways that appeal.
-            transform::optimize_dataflow(&mut dataflow, self.catalog.indexes());
+            transform::optimize_dataflow(&mut dataflow, self.catalog.enabled_indexes());
             let dataflow_plan = dataflow::Plan::finalize_dataflow(dataflow)
                 .expect("Dataflow planning failed; unrecoverable error");
             dataflow_plans.push(dataflow_plan);
@@ -3492,6 +3520,7 @@ pub async fn serve(
         timestamp_frequency,
         logical_compaction_window,
         experimental_mode,
+        disable_user_indexes,
         safe_mode,
         build_info,
         metrics_registry,
@@ -3521,6 +3550,7 @@ pub async fn serve(
         persist,
         skip_migrations: false,
         metrics_registry: &metrics_registry,
+        disable_user_indexes,
     })?;
     let cluster_id = catalog.config().cluster_id;
     let session_id = catalog.config().session_id;
@@ -3671,6 +3701,7 @@ pub fn serve_debug(
         persist: PersistConfig::disabled(),
         skip_migrations: false,
         metrics_registry: &MetricsRegistry::new(),
+        disable_user_indexes: false,
     })
     .unwrap();
 
@@ -3807,6 +3838,7 @@ fn auto_generate_primary_idx(
     on_desc: &RelationDesc,
     conn_id: Option<u32>,
     depends_on: Vec<GlobalId>,
+    enabled: bool,
 ) -> catalog::Index {
     let default_key = on_desc.typ().default_key();
     catalog::Index {
@@ -3818,6 +3850,7 @@ fn auto_generate_primary_idx(
             .collect(),
         conn_id,
         depends_on,
+        enabled,
     }
 }
 

--- a/src/coord/src/error.rs
+++ b/src/coord/src/error.rs
@@ -48,6 +48,8 @@ pub enum CoordError {
     },
     /// The specified feature is not permitted in safe mode.
     SafeModeViolation(String),
+    /// The named table has no active indexes to support the operation.
+    TableWithoutIndexes(String),
     /// An error occurred in a SQL catalog operation.
     SqlCatalog(sql::catalog::CatalogError),
     /// The transaction is in single-tail mode.
@@ -154,6 +156,13 @@ impl fmt::Display for CoordError {
             }
             CoordError::SafeModeViolation(feature) => {
                 write!(f, "cannot create {} in safe mode", feature)
+            }
+            CoordError::TableWithoutIndexes(table) => {
+                write!(
+                    f,
+                    "cannot access {} because it has no indexes enabled",
+                    table
+                )
             }
             CoordError::SqlCatalog(e) => e.fmt(f),
             CoordError::TailOnlyTransaction => {

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -680,7 +680,17 @@ to improve both our software and your queries! Please reach out at:
     );
 
     if args.disable_user_indexes {
-        eprintln!("Disabling user indexes.");
+        eprintln!(
+            "************************************************************************
+                                NOTE!
+************************************************************************
+Starting Materialize with user indexes disabled.
+
+For more details, see
+    https://materialize.com/docs/cli#user-indexes-disabled
+************************************************************************
+"
+        );
     }
 
     if args.experimental {

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -94,6 +94,9 @@ struct Args {
     #[structopt(long, hidden = true)]
     safe: bool,
 
+    #[structopt(long)]
+    disable_user_indexes: bool,
+
     /// The address on which metrics visible to "third parties" get exposed.
     ///
     /// These metrics are structured to allow an infrastructure provider to monitor an installation
@@ -651,6 +654,7 @@ swap: {swap_total}KB total, {swap_used}KB used{swap_limit}",
         data_directory,
         symbiosis_url: args.symbiosis,
         experimental_mode: args.experimental,
+        disable_user_indexes: args.disable_user_indexes,
         safe_mode: args.safe,
         telemetry,
         introspection_frequency: args
@@ -674,6 +678,10 @@ to improve both our software and your queries! Please reach out at:
 =======================================================================
 "
     );
+
+    if args.disable_user_indexes {
+        eprintln!("Disabling user indexes.");
+    }
 
     if args.experimental {
         eprintln!(

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -121,6 +121,8 @@ pub struct Config {
     pub symbiosis_url: Option<String>,
     /// Whether to permit usage of experimental features.
     pub experimental_mode: bool,
+    /// Whether to enable catalog-only mode.
+    pub disable_user_indexes: bool,
     /// Whether to run in safe mode.
     pub safe_mode: bool,
     /// Telemetry configuration.
@@ -231,6 +233,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
         timestamp_frequency: config.timestamp_frequency,
         logical_compaction_window: config.logical_compaction_window,
         experimental_mode: config.experimental_mode,
+        disable_user_indexes: config.disable_user_indexes,
         safe_mode: config.safe_mode,
         build_info: &BUILD_INFO,
         metrics_registry: config.metrics_registry.clone(),

--- a/src/materialized/tests/util.rs
+++ b/src/materialized/tests/util.rs
@@ -137,6 +137,7 @@ pub fn start_server(config: Config) -> Result<Server, Box<dyn Error>> {
         tls: config.tls,
         experimental_mode: config.experimental_mode,
         safe_mode: config.safe_mode,
+        disable_user_indexes: false,
         telemetry: None,
         introspection_frequency: Duration::from_secs(1),
         metrics_registry: metrics_registry.clone(),

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -349,6 +349,7 @@ impl ErrorResponse {
             CoordError::ReadOnlyParameter(_) => SqlState::CANT_CHANGE_RUNTIME_PARAM,
             CoordError::RelationOutsideTimeDomain { .. } => SqlState::INVALID_TRANSACTION_STATE,
             CoordError::SafeModeViolation(_) => SqlState::INTERNAL_ERROR,
+            CoordError::TableWithoutIndexes(..) => SqlState::INTERNAL_ERROR,
             CoordError::SqlCatalog(_) => SqlState::INTERNAL_ERROR,
             CoordError::TailOnlyTransaction => SqlState::INVALID_TRANSACTION_STATE,
             CoordError::Transform(_) => SqlState::INTERNAL_ERROR,

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -185,6 +185,8 @@ pub struct CatalogConfig {
     /// Function that returns a wall clock now time; can safely be mocked to return
     /// 0.
     pub now: NowFn,
+    /// Whether to prevent user indexes from being considered for use.
+    pub disable_user_indexes: bool,
 }
 
 /// A database in a [`Catalog`].
@@ -372,6 +374,7 @@ lazy_static! {
         num_workers: 0,
         timestamp_frequency: Duration::from_secs(1),
         now: now_zero,
+        disable_user_indexes: false,
     };
 }
 

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -2034,7 +2034,7 @@ lazy_static! {
                 ), oid::FUNC_MZ_CLASSIFY_OBJECT_ID_OID;
             },
             "mz_is_materialized" => Scalar {
-                params!(String) => sql_op!("EXISTS (SELECT 1 FROM mz_indexes WHERE on_id = $1)"),
+                params!(String) => sql_op!("EXISTS (SELECT 1 FROM mz_indexes WHERE on_id = $1 AND enabled)"),
                     oid::FUNC_MZ_IS_MATERIALIZED_OID;
             },
             "mz_render_typemod" => Scalar {

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -518,7 +518,8 @@ pub fn show_indexes<'a>(
             idx_cols.index_position AS seq_in_index,
             obj_cols.name AS column_name,
             idx_cols.on_expression AS expression,
-            idx_cols.nullable AS nullable
+            idx_cols.nullable AS nullable,
+            idxs.enabled AS enabled
         FROM
             mz_catalog.mz_indexes AS idxs
             JOIN mz_catalog.mz_index_columns AS idx_cols ON idxs.id = idx_cols.index_id

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -546,6 +546,7 @@ impl Runner {
             listen_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
             tls: None,
             experimental_mode: true,
+            disable_user_indexes: false,
             safe_mode: false,
             telemetry: None,
             introspection_frequency: Duration::from_secs(1),

--- a/test/disable-user-indexes/mzcompose
+++ b/test/disable-user-indexes/mzcompose
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# mzcompose — runs Docker Compose with Materialize customizations.
+
+exec "$(dirname "$0")/../../bin/mzcompose" "$@"

--- a/test/disable-user-indexes/mzcompose.yml
+++ b/test/disable-user-indexes/mzcompose.yml
@@ -1,0 +1,127 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+version: '3.7'
+
+mzworkflows:
+
+  disable-user-indexes:
+    steps:
+      - step: workflow
+        workflow: start-kafka
+      - step: workflow
+        workflow: user-indexes-enabled
+      - step: workflow
+        workflow: user-indexes-disabled
+      - step: down
+        destroy_volumes: true
+
+  start-kafka:
+    steps:
+      - step: start-services
+        services: [kafka, schema-registry]
+      - step: wait-for-tcp
+        host: kafka
+        port: 9092
+        timeout_secs: 120
+      - step: wait-for-tcp
+        host: schema-registry
+        port: 8081
+
+  user-indexes-enabled:
+    steps:
+      - step: start-services
+        services: [materialized]
+
+      - step: wait-for-mz
+
+      - step: run
+        service: testdrive-svc
+        command:
+           - user-indexes-enabled.td
+
+      - step: kill-services
+        services: [materialized]
+
+  user-indexes-disabled:
+    steps:
+      - step: run
+        service: materialized
+        daemon: true
+        force_service_name: true
+        command: >-
+          --disable-user-indexes
+          --data-directory=/share/mzdata
+          --experimental
+
+      - step: wait-for-mz
+
+      - step: run
+        service: testdrive-svc
+        command:
+           - user-indexes-disabled.td
+
+services:
+  # This should rightly have a dependency on materialized, but that we want to
+  # use it to connect to Materialized with user indexes enabled and disabled
+  # causes friction.
+  testdrive-svc:
+    mzbuild: testdrive
+    entrypoint:
+      - bash
+      - -c
+      - >-
+        testdrive
+        --kafka-addr=kafka:9092
+        --schema-registry-url=http://schema-registry:8081
+        --materialized-url=postgres://materialize@materialized:6875
+        --no-reset
+        --max-errors=1
+        $$*
+      - bash
+    volumes:
+      - .:/workdir
+
+  materialized:
+    mzbuild: materialized
+    command: >-
+      --data-directory=/share/mzdata
+      --experimental
+      --disable-telemetry
+    ports:
+      - 6875
+    environment:
+    - MZ_DEV=1
+    volumes:
+      - mzdata:/share/mzdata
+
+  zookeeper:
+    image: confluentinc/cp-zookeeper:5.5.4
+    environment:
+    - ZOOKEEPER_CLIENT_PORT=2181
+  kafka:
+    image: confluentinc/cp-kafka:5.5.4
+    environment:
+    - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+    - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092
+    - KAFKA_AUTO_CREATE_TOPICS_ENABLE=false
+    - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+    - KAFKA_CONFLUENT_SUPPORT_METRICS_ENABLE=false
+    - KAFKA_MIN_INSYNC_REPLICAS=1
+    - KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=1
+    - KAFKA_TRANSACTION_STATE_LOG_MIN_ISR=1
+  schema-registry:
+    image: confluentinc/cp-schema-registry:5.5.4
+    environment:
+    - SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=PLAINTEXT://kafka:9092
+    - SCHEMA_REGISTRY_HOST_NAME=localhost
+    depends_on: [kafka, zookeeper]
+
+volumes:
+  mzdata:

--- a/test/disable-user-indexes/user-indexes-disabled.td
+++ b/test/disable-user-indexes/user-indexes-disabled.td
@@ -1,0 +1,123 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Note that this requires `user-indexes-enabled.td` to have run first to
+# populate the catalog.
+
+# 🔬 Views + Sources
+
+# 🔬🔬 Successes
+
+# System views are selectable
+> SELECT count(*) FROM mz_databases
+1
+
+# Along with views derived from that view
+> SELECT * FROM logging_derived
+1
+
+# ...even if the view was materialized, because it will share the logging
+# table's arrangement
+> SELECT * FROM logging_derived_mat
+1
+
+> SHOW INDEXES FROM logging_derived_mat;
+on_name   key_name      seq_in_index  column_name  expression  nullable enabled
+-------------------------------------------------------------------------------
+
+# Views that embed a constant are selectable
+> SELECT * FROM constant
+1
+
+# 🔬🔬 Failures
+
+# Materialized views
+
+# mat_view is not considered materialized
+> SHOW MATERIALIZED VIEWS
+
+! SELECT * FROM mat_view
+Unable to automatically determine a timestamp for your query; this can happen if your query depends on non-materialized sources
+
+> SHOW INDEXES FROM mat_view;
+on_name   key_name              seq_in_index  column_name  expression  nullable enabled
+---------------------------------------------------------------------------------------
+mat_view  mat_view_primary_idx  1             sum          <null>      true     false
+mat_view  mv_drop_idx           1             sum          <null>      true     false
+
+> DROP INDEX mv_drop_idx;
+
+> SHOW INDEXES FROM mat_view;
+on_name   key_name              seq_in_index  column_name  expression  nullable enabled
+---------------------------------------------------------------------------------------
+mat_view  mat_view_primary_idx  1             sum          <null>      true     false
+
+# Materialized sources
+
+# mat_data is not considered materialized
+> SHOW MATERIALIZED SOURCES
+
+! SELECT * FROM mat_data
+Unable to automatically determine a timestamp for your query; this can happen if your query depends on non-materialized sources
+
+> SHOW INDEXES FROM mat_data;
+on_name   key_name              seq_in_index  column_name  expression  nullable enabled
+---------------------------------------------------------------------------------------
+mat_data  mat_data_primary_idx  1             a            <null>      false    false
+mat_data  ms_drop_idx           1             a            <null>      false    false
+
+> DROP INDEX ms_drop_idx;
+
+> SHOW INDEXES FROM mat_data;
+on_name   key_name              seq_in_index  column_name  expression  nullable enabled
+---------------------------------------------------------------------------------------
+mat_data  mat_data_primary_idx  1             a            <null>      false    false
+
+# 🔬 Sinks
+
+> CREATE SINK snk_indexes_disabled FROM data
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'snk_indexes_disabled'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+
+# No data written to sink without indexes
+$ kafka-verify format=avro sink=materialize.public.snk_indexes_enabled sort-messages=true
+
+# 🔬 Tables
+
+! INSERT INTO t VALUES (1)
+cannot access materialize.public.t because it has no indexes enabled
+
+# Selects work but are always empty
+> SELECT * FROM t
+
+> SHOW INDEXES FROM t;
+on_name   key_name      seq_in_index  column_name  expression  nullable enabled
+-----------------------------------------------------------------------------
+t         t_primary_idx 1             a            <null>      true     false
+t         t_drop_idx    1             a            <null>      true     false
+
+# 🔬 Indexes
+
+# Index are disabled upon creation
+> CREATE INDEX t_secondary_idx ON t(a+a);
+
+> SHOW INDEXES FROM t;
+on_name   key_name        seq_in_index  column_name  expression  nullable enabled
+-----------------------------------------------------------------------------
+t         t_primary_idx   1             a            <null>      true     false
+t         t_drop_idx      1             a            <null>      true     false
+t         t_secondary_idx 1             <null>       "a + a"     true     false
+
+> DROP INDEX t_drop_idx;
+
+> SHOW INDEXES FROM t;
+on_name   key_name        seq_in_index  column_name  expression  nullable enabled
+-----------------------------------------------------------------------------
+t         t_primary_idx   1             a            <null>      true     false
+t         t_secondary_idx 1             <null>       "a + a"     true     false

--- a/test/disable-user-indexes/user-indexes-enabled.td
+++ b/test/disable-user-indexes/user-indexes-enabled.td
@@ -1,0 +1,86 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# 🔬 Views
+
+> SELECT count(*) FROM mz_databases
+1
+
+> CREATE VIEW IF NOT EXISTS logging_derived AS SELECT count(*) FROM mz_databases
+> SELECT * FROM logging_derived
+1
+
+> CREATE VIEW IF NOT EXISTS logging_derived_mat AS SELECT count(*) FROM mz_databases
+> SELECT * FROM logging_derived_mat
+1
+
+> CREATE VIEW constant AS SELECT 1
+> SELECT * FROM constant
+1
+
+# 🔬 Views + Sources
+
+$ set schema={
+    "type": "record",
+    "name": "row",
+    "fields": [
+      {"name": "a", "type": "long"}
+    ]
+  }
+
+$ kafka-create-topic topic=data
+
+$ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
+{"a": 1}
+
+> CREATE SOURCE IF NOT EXISTS data
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${schema}'
+
+> CREATE MATERIALIZED VIEW IF NOT EXISTS mat_view AS
+  SELECT sum(a) FROM data
+
+> SELECT * FROM mat_view
+1
+
+> SHOW MATERIALIZED VIEWS
+mat_view
+
+> CREATE MATERIALIZED SOURCE IF NOT EXISTS mat_data
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${schema}'
+
+> SELECT * FROM mat_data
+1
+
+> SHOW MATERIALIZED SOURCES
+mat_data
+
+# 🔬 Sinks
+
+> CREATE SINK snk_indexes_enabled FROM data
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'snk_indexes_enabled'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+
+$ kafka-verify format=avro sink=materialize.public.snk_indexes_enabled sort-messages=true
+{"before": null, "after": {"row":{"a": 1}}}
+
+# 🔬 Tables
+
+> CREATE TABLE IF NOT EXISTS t (a int)
+
+> INSERT INTO t VALUES (1)
+
+> SELECT * FROM t
+1
+
+# 🔬 Indexes to drop
+> CREATE INDEX mv_drop_idx ON mat_view(sum);
+> CREATE INDEX ms_drop_idx ON mat_data(a);
+> CREATE INDEX t_drop_idx ON t(a);

--- a/test/testdrive/dependencies.td
+++ b/test/testdrive/dependencies.td
@@ -152,16 +152,16 @@ catalog item 'materialize.public.i1' is an index and so cannot be depended upon
 > CREATE INDEX i2 ON v2a(x*2);
 
 > SHOW INDEX in v2a;
-on_name   key_name         seq_in_index column_name expression  nullable
-------------------------------------------------------------------------
-v2a       i2               1            <null>      "x * 2"     false
-v2a       v2a_primary_idx  1            x           <null>      false
+on_name   key_name         seq_in_index column_name expression  nullable  enabled
+---------------------------------------------------------------------------------
+v2a       i2               1            <null>      "x * 2"     false     true
+v2a       v2a_primary_idx  1            x           <null>      false     true
 
 > SHOW INDEX in v2;
-on_name  key_name        seq_in_index column_name expression nullable
----------------------------------------------------------------------
-v2       i1              1            x           <null>     false
-v2       v2_primary_idx  1            x           <null>     false
+on_name  key_name        seq_in_index column_name expression nullable enabled
+-----------------------------------------------------------------------------
+v2       i1              1            x           <null>     false    true
+v2       v2_primary_idx  1            x           <null>     false    true
 
 # Test that dependent indexes do not prevent view deletion when restrict is specified
 # but do not cause deletion of dependent views
@@ -171,10 +171,10 @@ v2       v2_primary_idx  1            x           <null>     false
 unknown catalog item 'v2a'
 
 > SHOW INDEX in v2;
-on_name  key_name        seq_in_index   column_name expression nullable
------------------------------------------------------------------------
-v2       i1              1              x           <null>     false
-v2       v2_primary_idx  1              x           <null>     false
+on_name  key_name        seq_in_index   column_name expression nullable enabled
+-------------------------------------------------------------------------------
+v2       i1              1              x           <null>     false    true
+v2       v2_primary_idx  1              x           <null>     false    true
 
 ! DROP INDEX i2;
 unknown catalog item 'i2'
@@ -186,19 +186,19 @@ unknown catalog item 'i2'
 > CREATE INDEX i3 ON v4a(y);
 
 > SHOW INDEX in v4a;
-on_name  key_name         seq_in_index   column_name expression nullable
-------------------------------------------------------------------------
-v4a      i3               1              y           <null>     false
-v4a      v4a_primary_idx  1              y           <null>     false
+on_name  key_name         seq_in_index   column_name expression nullable  enabled
+---------------------------------------------------------------------------------
+v4a      i3               1              y           <null>     false     true
+v4a      v4a_primary_idx  1              y           <null>     false     true
 
 > CREATE INDEX i4 ON v4(x);
 
 > SHOW INDEX in v4;
-on_name  key_name        seq_in_index  column_name expression nullable
-----------------------------------------------------------------------
-v4       i4              1             x           <null>     false
-v4       v4_primary_idx  1             x           <null>     false
-v4       v4_primary_idx  2             y           <null>     false
+on_name  key_name        seq_in_index  column_name expression nullable  enabled
+-------------------------------------------------------------------------------
+v4       i4              1             x           <null>     false     true
+v4       v4_primary_idx  1             x           <null>     false     true
+v4       v4_primary_idx  2             y           <null>     false     true
 
 # Test cascade deletes associated indexes as well
 > DROP VIEW v4a CASCADE;
@@ -210,35 +210,35 @@ unknown catalog item 'v4a'
 unknown catalog item 'i3'
 
 > SHOW INDEX in v4;
-on_name  key_name        seq_in_index  column_name expression nullable
-----------------------------------------------------------------------
-v4       i4              1             x           <null>     false
-v4       v4_primary_idx  1             x           <null>     false
-v4       v4_primary_idx  2             y           <null>     false
+on_name  key_name        seq_in_index  column_name expression nullable  enabled
+-------------------------------------------------------------------------------
+v4       i4              1             x           <null>     false     true
+v4       v4_primary_idx  1             x           <null>     false     true
+v4       v4_primary_idx  2             y           <null>     false     true
 
 > CREATE MATERIALIZED VIEW v5 AS SELECT substr(y, 3, 2) as substr from v4;
 
 > CREATE INDEX i5 ON v5(substr);
 
 > SHOW INDEX in v5;
-on_name   key_name        seq_in_index  column_name expression nullable
---------------------------------------------------------------------
-v5        i5              1             substr      <null>     true
-v5        v5_primary_idx  1             substr      <null>     true
+on_name   key_name        seq_in_index  column_name expression nullable enabled
+-------------------------------------------------------------------------------
+v5        i5              1             substr      <null>     true     true
+v5        v5_primary_idx  1             substr      <null>     true     true
 
 > CREATE VIEW multicol AS SELECT 'a' AS a, 'b', 'c', 'd' AS d
 > CREATE INDEX i6 ON multicol (2, a, 4)
 > SHOW INDEX IN multicol
-on_name   key_name  seq_in_index column_name  expression   nullable
-------------------------------------------------------------------
-multicol  i6        1            ?column?     <null>       false
-multicol  i6        2            a            <null>       false
-multicol  i6        3            d            <null>       false
+on_name   key_name  seq_in_index column_name  expression   nullable enabled
+---------------------------------------------------------------------------
+multicol  i6        1            ?column?     <null>       false     true
+multicol  i6        2            a            <null>       false     true
+multicol  i6        3            d            <null>       false     true
 
 > SHOW INDEX IN multicol WHERE column_name = 'a'
-on_name   key_name  seq_in_index column_name  expression   nullable
--------------------------------------------------------------------
-multicol  i6        2            a            <null>       false
+on_name   key_name  seq_in_index column_name  expression   nullable enabled
+---------------------------------------------------------------------------
+multicol  i6        2            a            <null>       false    true
 
 # Test cascade deletes all indexes associated with cascaded views
 > DROP VIEW v4 CASCADE;
@@ -272,11 +272,11 @@ unknown catalog item 'i4'
 > CREATE INDEX j1 on s3(ascii(y))
 
 > SHOW INDEX in s3;
-on_name  key_name        seq_in_index  column_name expression             nullable
-----------------------------------------------------------------------------------
-s3       j1              1             <null>      "pg_catalog.ascii(y)"  false
-s3       s3_primary_idx  1             x           <null>                 false
-s3       s3_primary_idx  2             y           <null>                 false
+on_name  key_name        seq_in_index  column_name expression             nullable  enabled
+-------------------------------------------------------------------------------------------
+s3       j1              1             <null>      "pg_catalog.ascii(y)"  false     true
+s3       s3_primary_idx  1             x           <null>                 false     true
+s3       s3_primary_idx  2             y           <null>                 false     true
 
 > DROP SOURCE s3;
 
@@ -300,16 +300,16 @@ unknown catalog item 'j1'
 > CREATE INDEX j3 on w(z);
 
 > SHOW INDEX in s4;
-on_name  key_name        seq_in_index   column_name expression  nullable
-------------------------------------------------------------------------
-s4       j2              1               <null>      "x + 2"    false
-s4       s4_primary_idx  1               x           <null>     false
-s4       s4_primary_idx  2               y           <null>     false
+on_name  key_name        seq_in_index   column_name expression  nullable  enabled
+---------------------------------------------------------------------------------
+s4       j2              1               <null>      "x + 2"    false     true
+s4       s4_primary_idx  1               x           <null>     false     true
+s4       s4_primary_idx  2               y           <null>     false     true
 
 > SHOW INDEX in w;
-on_name  key_name   seq_in_index  column_name expression nullable
------------------------------------------------------------------
-w        j3         1             z           <null>     false
+on_name  key_name   seq_in_index  column_name expression nullable enabled
+-------------------------------------------------------------------------
+w        j3         1             z           <null>     false    true
 
 > DROP SOURCE s4 CASCADE;
 

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -38,117 +38,117 @@ position         name
 3                mz_obj_no
 
 > SHOW INDEXES FROM mz_data
-on_name  key_name             seq_in_index  column_name  expression  nullable
------------------------------------------------------------------------------
-mz_data  mz_data_primary_idx  1             a            <null>      false
-mz_data  mz_data_primary_idx  2             b            <null>      false
-mz_data  mz_data_primary_idx  3             mz_obj_no    <null>      false
+on_name  key_name             seq_in_index  column_name  expression  nullable enabled
+-------------------------------------------------------------------------------------
+mz_data  mz_data_primary_idx  1             a            <null>      false    true
+mz_data  mz_data_primary_idx  2             b            <null>      false    true
+mz_data  mz_data_primary_idx  3             mz_obj_no    <null>      false    true
 
 # Non-materialized views do not have indexes automatically created
 > CREATE SOURCE data
   FROM AVRO OCF '${testdrive.temp-dir}/data.ocf'
 
 > SHOW INDEXES FROM data
-on_name  key_name  seq_in_index  column_name  expression  nullable
-------------------------------------------------------------------
+on_name  key_name  seq_in_index  column_name  expression  nullable  enabled
+---------------------------------------------------------------------------
 
 # Views can have default indexes added
 > CREATE DEFAULT INDEX ON data
 
 > SHOW INDEXES FROM data
-on_name  key_name          seq_in_index column_name  expression  nullable
--------------------------------------------------------------------------
-data     data_primary_idx  1            a            <null>      false
-data     data_primary_idx  2            b            <null>      false
-data     data_primary_idx  3            mz_obj_no    <null>      false
+on_name  key_name          seq_in_index column_name  expression  nullable enabled
+---------------------------------------------------------------------------------
+data     data_primary_idx  1            a            <null>      false    true
+data     data_primary_idx  2            b            <null>      false    true
+data     data_primary_idx  3            mz_obj_no    <null>      false    true
 
 > CREATE DEFAULT INDEX ON mz_data
 
 > SHOW INDEXES FROM mz_data
-on_name  key_name              seq_in_index  column_name  expression  nullable
-------------------------------------------------------------------------------
-mz_data  mz_data_primary_idx   1             a            <null>      false
-mz_data  mz_data_primary_idx   2             b            <null>      false
-mz_data  mz_data_primary_idx   3             mz_obj_no    <null>      false
-mz_data  mz_data_primary_idx1  1             a            <null>      false
-mz_data  mz_data_primary_idx1  2             b            <null>      false
-mz_data  mz_data_primary_idx1  3             mz_obj_no    <null>      false
+on_name  key_name              seq_in_index  column_name  expression  nullable  enabled
+---------------------------------------------------------------------------------------
+mz_data  mz_data_primary_idx   1             a            <null>      false     true
+mz_data  mz_data_primary_idx   2             b            <null>      false     true
+mz_data  mz_data_primary_idx   3             mz_obj_no    <null>      false     true
+mz_data  mz_data_primary_idx1  1             a            <null>      false     true
+mz_data  mz_data_primary_idx1  2             b            <null>      false     true
+mz_data  mz_data_primary_idx1  3             mz_obj_no    <null>      false     true
 
 # Materialized views are synonymous with having an index automatically created
 > CREATE MATERIALIZED VIEW matv AS
   SELECT b, sum(a) FROM data GROUP BY b
 
 > SHOW INDEXES FROM matv
-on_name   key_name          seq_in_index column_name  expression  nullable
---------------------------------------------------------------------------
-matv      matv_primary_idx  1            b            <null>      false
+on_name   key_name          seq_in_index column_name  expression  nullable  enabled
+-----------------------------------------------------------------------------------
+matv      matv_primary_idx  1            b            <null>      false     true
 
 # Non-materialized views do not have indexes automatically created
 > CREATE VIEW data_view as SELECT * from data
 
 > SHOW INDEXES FROM data_view
-on_name  key_name  seq_in_index  column_name  expression  nullable
-------------------------------------------------------------------
+on_name  key_name  seq_in_index  column_name  expression  nullable  enabled
+---------------------------------------------------------------------------
 
 # Views can have default indexes added
 > CREATE DEFAULT INDEX ON data_view
 
 > SHOW INDEXES FROM data_view
-on_name    key_name               seq_in_index  column_name  expression  nullable
----------------------------------------------------------------------------------
-data_view  data_view_primary_idx  1             a            <null>      false
-data_view  data_view_primary_idx  2             b            <null>      false
-data_view  data_view_primary_idx  3             mz_obj_no    <null>      false
+on_name    key_name               seq_in_index  column_name  expression  nullable enabled
+-----------------------------------------------------------------------------------------
+data_view  data_view_primary_idx  1             a            <null>      false    true
+data_view  data_view_primary_idx  2             b            <null>      false    true
+data_view  data_view_primary_idx  3             mz_obj_no    <null>      false    true
 
 # Default indexes are equivalent in structure to indexes added automatically with the "MATERIALIZED" keyword
 > CREATE MATERIALIZED VIEW mz_data_view as SELECT * from data
 
 > SHOW INDEXES FROM mz_data_view
-on_name       key_name                  seq_in_index  column_name  expression  nullable
----------------------------------------------------------------------------------------
-mz_data_view  mz_data_view_primary_idx  1             a            <null>      false
-mz_data_view  mz_data_view_primary_idx  2             b            <null>      false
-mz_data_view  mz_data_view_primary_idx  3             mz_obj_no    <null>      false
+on_name       key_name                  seq_in_index  column_name  expression  nullable enabled
+-----------------------------------------------------------------------------------------------
+mz_data_view  mz_data_view_primary_idx  1             a            <null>      false    true
+mz_data_view  mz_data_view_primary_idx  2             b            <null>      false    true
+mz_data_view  mz_data_view_primary_idx  3             mz_obj_no    <null>      false    true
 
 # IF NOT EXISTS prevents adding multiple default indexes
 > CREATE DEFAULT INDEX IF NOT EXISTS ON data_view
 
 > SHOW INDEXES FROM data_view
-on_name    key_name               seq_in_index  column_name  expression  nullable
----------------------------------------------------------------------------------
-data_view  data_view_primary_idx  1             a            <null>      false
-data_view  data_view_primary_idx  2             b            <null>      false
-data_view  data_view_primary_idx  3             mz_obj_no    <null>      false
+on_name    key_name               seq_in_index  column_name  expression  nullable enabled
+-----------------------------------------------------------------------------------------
+data_view  data_view_primary_idx  1             a            <null>      false    true
+data_view  data_view_primary_idx  2             b            <null>      false    true
+data_view  data_view_primary_idx  3             mz_obj_no    <null>      false    true
 
 # IF NOT EXISTS works for both automatically and explicitly created default indexes
 > CREATE DEFAULT INDEX IF NOT EXISTS ON matv
 
 > SHOW INDEXES FROM matv
-on_name  key_name          seq_in_index  column_name  expression  nullable
---------------------------------------------------------------------------
-matv     matv_primary_idx  1             b            <null>      false
+on_name  key_name          seq_in_index  column_name  expression  nullable  enabled
+-----------------------------------------------------------------------------------
+matv     matv_primary_idx  1             b            <null>      false     true
 
 # Additional default indexes have the same structure as the first
 > CREATE DEFAULT INDEX ON matv
 
 > SHOW INDEXES FROM matv
-on_name  key_name           seq_in_index  column_name  expression  nullable
----------------------------------------------------------------------------
-matv     matv_primary_idx   1             b            <null>      false
-matv     matv_primary_idx1  1             b            <null>      false
+on_name  key_name           seq_in_index  column_name  expression  nullable enabled
+-----------------------------------------------------------------------------------
+matv     matv_primary_idx   1             b            <null>      false    true
+matv     matv_primary_idx1  1             b            <null>      false    true
 
 # Default indexes can be named
 > CREATE DEFAULT INDEX named_idx ON data_view
 
 > SHOW INDEXES FROM data_view
-on_name    key_name               seq_in_index  column_name  expression  nullable
----------------------------------------------------------------------------------
-data_view  data_view_primary_idx  1             a            <null>      false
-data_view  data_view_primary_idx  2             b            <null>      false
-data_view  data_view_primary_idx  3             mz_obj_no    <null>      false
-data_view  named_idx              1             a            <null>      false
-data_view  named_idx              2             b            <null>      false
-data_view  named_idx              3             mz_obj_no    <null>      false
+on_name    key_name               seq_in_index  column_name  expression  nullable enabled
+-----------------------------------------------------------------------------------------
+data_view  data_view_primary_idx  1             a            <null>      false    true
+data_view  data_view_primary_idx  2             b            <null>      false    true
+data_view  data_view_primary_idx  3             mz_obj_no    <null>      false    true
+data_view  named_idx              1             a            <null>      false    true
+data_view  named_idx              2             b            <null>      false    true
+data_view  named_idx              3             mz_obj_no    <null>      false    true
 
 > DROP INDEX data_view_primary_idx
 > DROP INDEX named_idx
@@ -157,9 +157,9 @@ data_view  named_idx              3             mz_obj_no    <null>      false
 > CREATE INDEX ON data_view(a)
 
 > SHOW INDEXES FROM data_view
-on_name    key_name           seq_in_index  column_name  expression  nullable
------------------------------------------------------------------------------
-data_view  data_view_a_idx    1             a            <null>      false
+on_name    key_name           seq_in_index  column_name  expression  nullable enabled
+-------------------------------------------------------------------------------------
+data_view  data_view_a_idx    1             a            <null>      false    true
 
 > DROP INDEX data_view_a_idx
 
@@ -168,12 +168,12 @@ data_view  data_view_a_idx    1             a            <null>      false
 > CREATE INDEX ON data_view(b - a, a)
 
 > SHOW INDEXES FROM data_view
-on_name    key_name               seq_in_index  column_name  expression  nullable
----------------------------------------------------------------------------------
-data_view  data_view_b_a_idx      2             a            <null>      false
-data_view  data_view_b_a_idx      1             b            <null>      false
-data_view  data_view_expr_a_idx   1             <null>       "b - a"     false
-data_view  data_view_expr_a_idx   2             a            <null>      false
+on_name    key_name               seq_in_index  column_name  expression  nullable enabled
+-----------------------------------------------------------------------------------------
+data_view  data_view_b_a_idx      2             a            <null>      false    true
+data_view  data_view_b_a_idx      1             b            <null>      false    true
+data_view  data_view_expr_a_idx   1             <null>       "b - a"     false    true
+data_view  data_view_expr_a_idx   2             a            <null>      false    true
 
 > DROP INDEX data_view_b_a_idx
 > DROP INDEX data_view_expr_a_idx
@@ -182,10 +182,10 @@ data_view  data_view_expr_a_idx   2             a            <null>      false
 > CREATE INDEX named_idx ON data_view (b - a, a)
 
 > SHOW INDEXES FROM data_view
-on_name    key_name    seq_in_index  column_name  expression  nullable
-----------------------------------------------------------------------
-data_view  named_idx   1             <null>       "b - a"     false
-data_view  named_idx   2             a            <null>      false
+on_name    key_name    seq_in_index  column_name  expression  nullable  enabled
+-------------------------------------------------------------------------------
+data_view  named_idx   1             <null>       "b - a"     false     true
+data_view  named_idx   2             a            <null>      false     true
 
 > DROP INDEX named_idx
 
@@ -194,10 +194,10 @@ data_view  named_idx   2             a            <null>      false
 > CREATE DEFAULT INDEX IF NOT EXISTS ON data_view
 
 > SHOW INDEXES FROM data_view
-on_name    key_name                seq_in_index  column_name  expression  nullable
-----------------------------------------------------------------------------------
-data_view  data_view_primary_idx   1             <null>       "b - a"     false
-data_view  data_view_primary_idx   2             a            <null>      false
+on_name    key_name                seq_in_index  column_name  expression  nullable  enabled
+-------------------------------------------------------------------------------------------
+data_view  data_view_primary_idx   1             <null>       "b - a"     false     true
+data_view  data_view_primary_idx   2             a            <null>      false     true
 
 > SHOW CREATE INDEX data_view_primary_idx
 Index                                    "Create Index"
@@ -212,16 +212,16 @@ materialize.public.data_view_primary_idx "CREATE INDEX \"data_view_primary_idx\"
 > CREATE INDEX ON foo (a + b)
 > CREATE INDEX ON foo (substr(z, 3))
 > SHOW INDEXES FROM foo
-foo  foo_primary_idx   1  a       <null>                     false
-foo  foo_primary_idx   2  b       <null>                     true
-foo  foo_primary_idx   3  z       <null>                     true
-foo  foo_expr_idx      1  <null>  "a + b"                    true
-foo  foo_expr_idx1     1  <null>  "pg_catalog.substr(z, 3)"  true
+foo  foo_primary_idx   1  a       <null>                     false  true
+foo  foo_primary_idx   2  b       <null>                     true   true
+foo  foo_primary_idx   3  z       <null>                     true   true
+foo  foo_expr_idx      1  <null>  "a + b"                    true   true
+foo  foo_expr_idx1     1  <null>  "pg_catalog.substr(z, 3)"  true   true
 > SHOW INDEXES FROM foo WHERE Column_name = 'b'
-foo  foo_primary_idx   2  b       <null>          true
+foo  foo_primary_idx   2  b       <null>          true  true
 > SHOW INDEXES FROM foo WHERE Column_name = 'noexist'
 > SHOW INDEXES FROM foo WHERE Key_name = 'foo_expr_idx'
-foo  foo_expr_idx      1  <null>  "a + b"         true
+foo  foo_expr_idx      1  <null>  "a + b"         true  true
 # TODO(justin): not handled in parser yet:
 #   SHOW INDEXES FROM v LIKE '%v'
 

--- a/test/testdrive/rename.td
+++ b/test/testdrive/rename.td
@@ -31,11 +31,11 @@ $ avro-ocf-write path=data.ocf schema=${writer-schema} codec=null
     SELECT * FROM mz_data
 
 > SHOW INDEXES FROM mz_view
-on_name  key_name             seq_in_index  column_name  expression  nullable
------------------------------------------------------------------------------
-mz_view  mz_view_primary_idx  1             a            <null>      false
-mz_view  mz_view_primary_idx  2             b            <null>      false
-mz_view  mz_view_primary_idx  3             mz_obj_no    <null>      false
+on_name  key_name             seq_in_index  column_name  expression  nullable enabled
+-------------------------------------------------------------------------------------
+mz_view  mz_view_primary_idx  1             a            <null>      false    true
+mz_view  mz_view_primary_idx  2             b            <null>      false    true
+mz_view  mz_view_primary_idx  3             mz_obj_no    <null>      false    true
 
 > CREATE VIEW dependent_view AS
     SELECT * FROM mz_view;
@@ -146,11 +146,11 @@ materialize.public.renamed_mz_view  "CREATE VIEW \"materialize\".\"public\".\"re
 
 # Item's indexes are properly re-attributed
 > SHOW INDEXES FROM renamed_mz_view
-on_name          key_name       seq_in_index  column_name expression nullable
------------------------------------------------------------------------------
-renamed_mz_view  renamed_index  1             a           <null>     false
-renamed_mz_view  renamed_index  2             b           <null>     false
-renamed_mz_view  renamed_index  3             mz_obj_no   <null>     false
+on_name          key_name       seq_in_index  column_name expression nullable enabled
+-------------------------------------------------------------------------------------
+renamed_mz_view  renamed_index  1             a           <null>     false    true
+renamed_mz_view  renamed_index  2             b           <null>     false    true
+renamed_mz_view  renamed_index  3             mz_obj_no   <null>     false    true
 
 > SHOW CREATE INDEX renamed_index
 Index               "Create Index"

--- a/test/testdrive/tables.td
+++ b/test/testdrive/tables.td
@@ -53,10 +53,10 @@ name
 ----
 
 > SHOW INDEXES FROM t;
-on_name  key_name       seq_in_index  column_name  expression  nullable
------------------------------------------------------------------------
-t        t_primary_idx  1             a            <null>      true
-t        t_primary_idx  2             b            <null>      false
+on_name  key_name       seq_in_index  column_name  expression  nullable enabled
+-------------------------------------------------------------------------------
+t        t_primary_idx  1             a            <null>      true     true
+t        t_primary_idx  2             b            <null>      false    true
 
 ! DROP INDEX t_primary_idx
 cannot drop 'materialize.public.t_primary_idx' as it is the default index for a table

--- a/test/testdrive/temporary.td
+++ b/test/testdrive/temporary.td
@@ -57,10 +57,10 @@ non-temporary items cannot depend on temporary item
 > CREATE TEMPORARY MATERIALIZED VIEW foo AS SELECT * FROM v
 
 > SHOW INDEXES FROM foo
- on_name    key_name         seq_in_index  column_name  expression  nullable
----------------------------------------------------------------------------
- foo        foo_primary_idx  1             column1      <null>      false
- foo        foo_primary_idx  2             column2      <null>      false
+ on_name    key_name         seq_in_index  column_name  expression  nullable  enabled
+-------------------------------------------------------------------------------------
+ foo        foo_primary_idx  1             column1      <null>      false     true
+ foo        foo_primary_idx  2             column2      <null>      false     true
 
 ! CREATE TEMP MATERIALIZED VIEW foo AS SELECT * FROM v
 catalog item 'foo' already exists
@@ -117,10 +117,10 @@ catalog item 'temp_t' already exists
 > INSERT INTO temp_t VALUES (1, 'testing')
 
 > SHOW INDEXES FROM temp_t
- on_name    key_name            seq_in_index  column_name  expression  nullable
----------------------------------------------------------------------------
- temp_t     temp_t_primary_idx  1             a            <null>      true
- temp_t     temp_t_primary_idx  2             b            <null>      false
+ on_name    key_name            seq_in_index  column_name  expression  nullable enabled
+---------------------------------------------------------------------------------------
+ temp_t     temp_t_primary_idx  1             a            <null>      true     true
+ temp_t     temp_t_primary_idx  2             b            <null>      false    true
 
 > DROP TABLE temp_t
 


### PR DESCRIPTION
Implements [**Booting without user indexes**](https://github.com/MaterializeInc/materialize/pull/7827/files#diff-8f32f7946073c15ed6e924c078205d622e11a819b39a6a6afcc440fdf875e83eR68) from the design doc.

I'm working on adding another test for this that boots in vanilla mode _after_ booting in `--disable-user-indexes`, but I tested it locally without issue, so am comfortable getting the code reviewed and will add that final test shortly.