### PR TITLE
Move Materialized source details out of individual CREATE SOURCE page

### DIFF
--- a/doc/user/content/sql/create-source/_index.md
+++ b/doc/user/content/sql/create-source/_index.md
@@ -20,6 +20,31 @@ Sources represent connections to resources outside Materialize that it can read
 data from. For more information, see [API Components:
 Sources](../../overview/api-components#sources).
 
+## Materialized source details
+
+Materializing a source keeps data it receives in an in-memory
+[index](/overview/api-components/#indexes), the presence of which makes the
+source directly queryable. In contrast, non-materialized sources cannot process
+queries directly; to access the data the source receives, you need to create
+[materialized views](/sql/create-materialized-view) that `SELECT` from the
+source.
+
+For a mental model, materializing the source is approximately equivalent to
+creating a non-materialized source, and then creating a materialized view from
+all of the source's columns:
+
+```sql
+CREATE SOURCE src ...;
+CREATE MATERIALIZED VIEW src_view AS SELECT * FROM src;
+```
+
+The actual implementation of materialized sources differs, though, by letting
+you refer to the source's name directly in queries.
+
+For more details about the impact of materializing sources (and implicitly
+creating an index), see [`CREATE INDEX`: Details &mdash; Memory
+footprint](/sql/create-index/#memory-footprint).
+
 ## Types of sources
 
 Materialize can connect to many different external sources of data, each with

--- a/doc/user/layouts/shortcodes/create-source/syntax-details.html
+++ b/doc/user/layouts/shortcodes/create-source/syntax-details.html
@@ -5,7 +5,7 @@
 
 Field | Use
 ------|-----
-**MATERIALIZED** | Materializes the source's data, which retains all data in memory and makes sources directly selectable. For more information, see [Materialized source details](#materialized-source-details).
+**MATERIALIZED** | Materializes the source's data, which retains all data in memory and makes sources directly selectable. For more information, see [Materialized source details](/sql/create-source/#materialized-source-details).
 _src&lowbar;name_ | The name for the source, which is used as its table name within SQL.
 _col&lowbar;name_ | Override default column name with the provided [identifier](../../identifiers). If used, a _col&lowbar;name_ must be provided for each column in the created source.
 {{ partial (printf "create-source/connector/%s/syntax" $connector ) . -}}
@@ -23,31 +23,6 @@ Field | Value type | Description
 {{ partial (printf "create-source/connector/%s/with-options" $connector ) . -}}
 
 ## Details
-
-### Materialized source details
-
-Materializing a source keeps data it receives in an in-memory
-[index](/overview/api-components/#indexes), the presence of which makes the
-source directly queryable. In contrast, non-materialized sources cannot process
-queries directly; to access the data the source receives, you need to create
-[materialized views](/sql/create-materialized-view) that `SELECT` from the
-source.
-
-For a mental model, materializing the source is approximately equivalent to
-creating a non-materialized source, and then creating a materialized view from
-all of the source's columns:
-
-```sql
-CREATE SOURCE src ...;
-CREATE MATERIALIZED VIEW src_view AS SELECT * FROM src;
-```
-
-The actual implementation of materialized sources differs, though, by letting
-you refer to the source's name directly in queries.
-
-For more details about the impact of materializing sources (and implicitly
-creating an index), see [`CREATE INDEX`: Details &mdash; Memory
-footprint](/sql/create-index/#memory-footprint).
 
 {{ partial (printf "create-source/connector/%s/details" $connector ) (dict "context" . "envelopes" $envelopes) -}}
 


### PR DESCRIPTION
I'm wondering if we should remove the code sample from this, especially since the same page is used for Connect > Sources and SQL > CREATE SOURCE.