### PR TITLE
testdrive: add protobuf CSR schemas

### DIFF
--- a/doc/developer/testdrive.md
+++ b/doc/developer/testdrive.md
@@ -387,6 +387,19 @@ For example, this test will pass:
 "${testdrive.seed}"
 ```
 
+#### `$ set name`
+
+Sets the variable to the possibly multi-line value that follows.
+
+```
+$ set schema
+syntax = "proto3";
+
+message SimpleId {
+  string id = 1;
+}
+```
+
 ## Variable reference
 
 The following variables are defined for every test. Many correspond to the command-line options passed to `testdrive`:

--- a/src/ccsr/src/client.rs
+++ b/src/ccsr/src/client.rs
@@ -12,7 +12,7 @@ use std::fmt;
 
 use reqwest::{Method, Url};
 use serde::de::DeserializeOwned;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use crate::config::Auth;
@@ -70,10 +70,15 @@ impl Client {
     /// Note that if a schema that is identical to an existing schema for the
     /// same subject is published, the ID of the existing schema will be
     /// returned.
-    pub async fn publish_schema(&self, subject: &str, schema: &str) -> Result<i32, PublishError> {
+    pub async fn publish_schema(
+        &self,
+        subject: &str,
+        schema: &str,
+        schema_type: SchemaType,
+    ) -> Result<i32, PublishError> {
         let req = self
             .make_request(Method::POST, format!("/subjects/{}/versions", subject))
-            .json(&json!({ "schema": schema }));
+            .json(&json!({ "schema": schema, "schemaType":  &schema_type }));
         let res: PublishResponse = send_request(req).await?;
         Ok(res.id)
     }
@@ -117,6 +122,14 @@ where
             }),
         }
     }
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum SchemaType {
+    Avro,
+    Protobuf,
+    Json,
 }
 
 /// A schema stored by a schema registry.

--- a/src/ccsr/tests/client.rs
+++ b/src/ccsr/tests/client.rs
@@ -16,7 +16,7 @@ use hyper::StatusCode;
 use hyper::{Body, Response};
 use lazy_static::lazy_static;
 
-use ccsr::{Client, DeleteError, GetByIdError, GetBySubjectError, PublishError};
+use ccsr::{Client, DeleteError, GetByIdError, GetBySubjectError, PublishError, SchemaType};
 
 lazy_static! {
     pub static ref SCHEMA_REGISTRY_URL: reqwest::Url = match env::var("SCHEMA_REGISTRY_URL") {
@@ -51,11 +51,13 @@ async fn test_client() -> Result<(), anyhow::Error> {
 
     assert_eq!(count_schemas(&client, "ccsr-test-").await?, 0);
 
-    let schema_v1_id = client.publish_schema("ccsr-test-schema", schema_v1).await?;
+    let schema_v1_id = client
+        .publish_schema("ccsr-test-schema", schema_v1, SchemaType::Avro)
+        .await?;
     assert!(schema_v1_id > 0);
 
     match client
-        .publish_schema("ccsr-test-schema", schema_v2_incompat)
+        .publish_schema("ccsr-test-schema", schema_v2_incompat, SchemaType::Avro)
         .await
     {
         Err(PublishError::IncompatibleSchema) => (),
@@ -68,13 +70,17 @@ async fn test_client() -> Result<(), anyhow::Error> {
         assert_raw_schemas_eq(schema_v1, &res.raw);
     }
 
-    let schema_v2_id = client.publish_schema("ccsr-test-schema", schema_v2).await?;
+    let schema_v2_id = client
+        .publish_schema("ccsr-test-schema", schema_v2, SchemaType::Avro)
+        .await?;
     assert!(schema_v2_id > 0);
     assert!(schema_v2_id > schema_v1_id);
 
     assert_eq!(
         schema_v1_id,
-        client.publish_schema("ccsr-test-schema", schema_v1).await?
+        client
+            .publish_schema("ccsr-test-schema", schema_v1, SchemaType::Avro)
+            .await?
     );
 
     {
@@ -95,7 +101,7 @@ async fn test_client() -> Result<(), anyhow::Error> {
     assert_eq!(count_schemas(&client, "ccsr-test-").await?, 1);
 
     client
-        .publish_schema("ccsr-test-another-schema", "\"int\"")
+        .publish_schema("ccsr-test-another-schema", "\"int\"", SchemaType::Avro)
         .await?;
     assert_eq!(count_schemas(&client, "ccsr-test-").await?, 2);
 
@@ -119,7 +125,10 @@ async fn test_client_errors() -> Result<(), anyhow::Error> {
     }
 
     // Publish-specific errors.
-    match client.publish_schema("ccsr-test-schema", "blah").await {
+    match client
+        .publish_schema("ccsr-test-schema", "blah", SchemaType::Avro)
+        .await
+    {
         Err(PublishError::InvalidSchema) => (),
         res => panic!("expected PublishError::InvalidSchema, got {:?}", res),
     }
@@ -144,7 +153,10 @@ async fn test_server_errors() -> Result<(), anyhow::Error> {
         r#"{ "error_code": 50001, "message": "overloaded; try again later" }"#,
     )?;
 
-    match client_graceful.publish_schema("foo", "bar").await {
+    match client_graceful
+        .publish_schema("foo", "bar", SchemaType::Avro)
+        .await
+    {
         Err(PublishError::Server {
             code: 50001,
             ref message,
@@ -184,7 +196,10 @@ async fn test_server_errors() -> Result<(), anyhow::Error> {
         r#"panic! an exception occured!"#,
     )?;
 
-    match client_crash.publish_schema("foo", "bar").await {
+    match client_crash
+        .publish_schema("foo", "bar", SchemaType::Avro)
+        .await
+    {
         Err(PublishError::Server {
             code: 500,
             ref message,

--- a/src/kafka-util/src/bin/kgen.rs
+++ b/src/kafka-util/src/bin/kgen.rs
@@ -612,7 +612,11 @@ async fn main() -> anyhow::Result<()> {
             let value_schema = args.avro_value_schema.as_ref().unwrap();
             let ccsr = ccsr::ClientConfig::new(args.schema_registry_url.clone()).build()?;
             let schema_id = ccsr
-                .publish_schema(&format!("{}-value", args.topic), &value_schema.to_string())
+                .publish_schema(
+                    &format!("{}-value", args.topic),
+                    &value_schema.to_string(),
+                    ccsr::SchemaType::Avro,
+                )
                 .await?;
             let generator =
                 RandomAvroGenerator::new(value_schema, &args.avro_value_distribution.unwrap());
@@ -637,7 +641,11 @@ async fn main() -> anyhow::Result<()> {
             let key_schema = args.avro_key_schema.as_ref().unwrap();
             let ccsr = ccsr::ClientConfig::new(args.schema_registry_url).build()?;
             let key_schema_id = ccsr
-                .publish_schema(&format!("{}-key", args.topic), &key_schema.to_string())
+                .publish_schema(
+                    &format!("{}-key", args.topic),
+                    &key_schema.to_string(),
+                    ccsr::SchemaType::Avro,
+                )
                 .await?;
             let generator =
                 RandomAvroGenerator::new(key_schema, &args.avro_key_distribution.unwrap());

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -481,10 +481,8 @@ async fn purify_source_format_single(
             _ => {}
         },
         Format::Protobuf(schema) => match schema {
-            ProtobufSchema::Csr { .. } => {
-                // todo@jldlaughlin: enable when CSR protobuf schemas are accepted!
-                // purify_csr_connector(connector, connector_options, envelope, csr_connector).await?
-                unsupported!("confluent schema registry protobuf schemas");
+            ProtobufSchema::Csr { csr_connector } => {
+                purify_csr_connector(connector, connector_options, envelope, csr_connector).await?
             }
             ProtobufSchema::InlineSchema { schema, .. } => {
                 if let sql_parser::ast::Schema::File(path) = schema {

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -488,7 +488,13 @@ pub fn build(cmds: Vec<PosCommand>, state: &State) -> Result<Vec<PosAction>, Err
                         Box::new(sleep::build_sleep(builtin).map_err(wrap_err)?)
                     }
                     "set" => {
-                        vars.extend(builtin.args);
+                        for (key, val) in builtin.args {
+                            if val.is_empty() {
+                                vars.insert(key, builtin.input.join("\n"));
+                            } else {
+                                vars.insert(key, val);
+                            }
+                        }
                         continue;
                     }
                     _ => {

--- a/src/testdrive/src/action/kafka/ingest.rs
+++ b/src/testdrive/src/action/kafka/ingest.rs
@@ -44,6 +44,8 @@ enum Format {
     },
     Protobuf {
         message: protobuf::MessageType,
+        schema: Option<String>,
+        confluent_wire_format: bool,
     },
     Bytes {
         terminator: Option<u8>,
@@ -158,9 +160,16 @@ pub fn build_ingest(mut cmd: BuiltinCommand) -> Result<IngestAction, String> {
             schema: cmd.args.string("schema")?,
             confluent_wire_format: cmd.args.opt_bool("confluent-wire-format")?.unwrap_or(true),
         },
-        "protobuf" => Format::Protobuf {
-            message: cmd.args.parse("message")?,
-        },
+        "protobuf" => {
+            let message = cmd.args.parse("message")?;
+            let schema = cmd.args.opt_parse::<String>("schema")?;
+            let confluent_wire_format = cmd.args.opt_bool("confluent-wire-format")?.unwrap_or(true);
+            Format::Protobuf {
+                message,
+                schema,
+                confluent_wire_format,
+            }
+        }
         "bytes" => Format::Bytes { terminator: None },
         f => return Err(format!("unknown format: {}", f)),
     };
@@ -169,9 +178,16 @@ pub fn build_ingest(mut cmd: BuiltinCommand) -> Result<IngestAction, String> {
             schema: cmd.args.string("key-schema")?,
             confluent_wire_format: cmd.args.opt_bool("confluent-wire-format")?.unwrap_or(true),
         }),
-        Some("protobuf") => Some(Format::Protobuf {
-            message: cmd.args.parse("key-message")?,
-        }),
+        Some("protobuf") => {
+            let message = cmd.args.parse("key-message")?;
+            let schema = cmd.args.opt_parse::<String>("key-schema")?;
+            let confluent_wire_format = cmd.args.opt_bool("confluent-wire-format")?.unwrap_or(true);
+            Some(Format::Protobuf {
+                message,
+                schema,
+                confluent_wire_format,
+            })
+        }
         Some("bytes") => Some(Format::Bytes {
             terminator: match cmd.args.opt_parse::<char>("key-terminator")? {
                 Some(c) if c.is_ascii() => Some(c as u8),
@@ -237,7 +253,7 @@ impl Action for IngestAction {
                     let schema_id = if self.publish {
                         let ccsr_subject = format!("{}-{}", topic_name, typ);
                         let schema_id = ccsr_client
-                            .publish_schema(&ccsr_subject, &schema)
+                            .publish_schema(&ccsr_subject, &schema, ccsr::SchemaType::Avro)
                             .await
                             .map_err(|e| format!("schema registry error: {}", e))?;
                         schema_id
@@ -252,7 +268,19 @@ impl Action for IngestAction {
                         confluent_wire_format,
                     })
                 }
-                Format::Protobuf { message } => Ok(Transcoder::Protobuf { message }),
+                Format::Protobuf {
+                    message, schema, ..
+                } => {
+                    if self.publish {
+                        let schema = schema.expect("schema");
+                        let ccsr_subject = format!("{}-{}", topic_name, typ);
+                        ccsr_client
+                            .publish_schema(&ccsr_subject, &schema, ccsr::SchemaType::Protobuf)
+                            .await
+                            .map_err(|e| format!("schema registry error: {}", e))?;
+                    }
+                    Ok(Transcoder::Protobuf { message })
+                }
                 Format::Bytes { terminator } => Ok(Transcoder::Bytes { terminator }),
             }
         };

--- a/src/testdrive/src/parser.rs
+++ b/src/testdrive/src/parser.rs
@@ -104,12 +104,16 @@ fn parse_builtin(line_reader: &mut LineReader) -> Result<BuiltinCommand, InputEr
     for el in builtin_reader {
         let (pos, token) = el?;
         let pieces: Vec<_> = token.splitn(2, '=').collect();
-        if pieces.len() != 2 {
-            return Err(InputError {
-                msg: "command argument is not in required key=value format".into(),
-                pos,
-            });
-        }
+        let pieces = match pieces.as_slice() {
+            [key, value] => vec![*key, *value],
+            [key] => vec![*key, ""],
+            _ => {
+                return Err(InputError {
+                    msg: "command argument is not in required key=value format".into(),
+                    pos,
+                });
+            }
+        };
         lazy_static! {
             static ref VALID_KEY_REGEX: Regex = Regex::new("^[a-z0-9\\-]*$").unwrap();
         }

--- a/src/testdrive/tests/cli.rs
+++ b/src/testdrive/tests/cli.rs
@@ -68,21 +68,6 @@ fn test_cmd_missing_name() {
 }
 
 #[test]
-fn test_cmd_arg_missing_value() {
-    cmd()
-        .write_stdin("$ cmd badarg")
-        .assert()
-        .failure()
-        .stderr(predicate::str::starts_with(
-            r#"<stdin>:1:7: error: command argument is not in required key=value format
-     |
-   1 | $ cmd badarg
-     |       ^
-"#,
-        ));
-}
-
-#[test]
 fn test_cmd_arg_bad_nesting_brace_close() {
     cmd()
         .write_stdin("$ cmd arg={}}")
@@ -185,24 +170,4 @@ fn test_ci_output_bad_file() {
             "error: reading tests: Is a directory",
         ))
         .stdout(predicate::str::contains("^^^ +++"));
-}
-
-#[test]
-fn test_ci_output_cmd_arg() {
-    cmd()
-        .arg("--ci-output")
-        .write_stdin("$ cmd badarg")
-        .assert()
-        .failure()
-        .stderr(predicate::str::starts_with(
-            r#"<stdin>:1:7: error: command argument is not in required key=value format
-     |
-   1 | $ cmd badarg
-     |       ^
-"#,
-        ))
-        .stdout(predicate::str::contains(
-            "--- ==> <stdin>
-^^^ +++",
-        ));
 }

--- a/test/testdrive/kafka-time-offset.td
+++ b/test/testdrive/kafka-time-offset.td
@@ -46,19 +46,19 @@ topic missing_topic does not exist
 
 $ kafka-create-topic topic=t1 partitions=3
 
-$ kafka-ingest format=bytes topic=t1 key-format=bytes key-terminator=: publish=true timestamp=1 partition=0
+$ kafka-ingest format=bytes topic=t1 key-format=bytes key-terminator=: timestamp=1 partition=0
 apple:apple
 banana:banana
 
-$ kafka-ingest format=bytes topic=t1 key-format=bytes key-terminator=: publish=true timestamp=2 partition=1
+$ kafka-ingest format=bytes topic=t1 key-format=bytes key-terminator=: timestamp=2 partition=1
 cherry:cherry
 date:date
 eggfruit:eggfruit
 
-$ kafka-ingest format=bytes topic=t1 key-format=bytes key-terminator=: publish=true timestamp=3 partition=1
+$ kafka-ingest format=bytes topic=t1 key-format=bytes key-terminator=: timestamp=3 partition=1
 fig:fig
 
-$ kafka-ingest format=bytes topic=t1 key-format=bytes key-terminator=: publish=true timestamp=4 partition=2
+$ kafka-ingest format=bytes topic=t1 key-format=bytes key-terminator=: timestamp=4 partition=2
 grape:grape
 
 > CREATE MATERIALIZED SOURCE append_time_offset_0
@@ -139,7 +139,7 @@ text      mz_offset
 
 $ kafka-add-partitions topic=t1 total-partitions=4
 
-$ kafka-ingest format=bytes topic=t1 key-format=bytes key-terminator=: publish=true timestamp=5 partition=3
+$ kafka-ingest format=bytes topic=t1 key-format=bytes key-terminator=: timestamp=5 partition=3
 hazelnut:hazelnut
 
 $ set-sql-timeout duration=60s
@@ -155,23 +155,23 @@ hazelnut  1
 
 $ kafka-create-topic topic=t2 partitions=3
 
-$ kafka-ingest format=bytes topic=t2 key-format=bytes key-terminator=: publish=true timestamp=1 partition=0
+$ kafka-ingest format=bytes topic=t2 key-format=bytes key-terminator=: timestamp=1 partition=0
 apple:apple
 banana:banana
 
-$ kafka-ingest format=bytes topic=t2 key-format=bytes key-terminator=: publish=true timestamp=1 partition=0
+$ kafka-ingest format=bytes topic=t2 key-format=bytes key-terminator=: timestamp=1 partition=0
 apple:
 
-$ kafka-ingest format=bytes topic=t2 key-format=bytes key-terminator=: publish=true timestamp=2 partition=1
+$ kafka-ingest format=bytes topic=t2 key-format=bytes key-terminator=: timestamp=2 partition=1
 cherry:cherry
 date:date
 eggfruit:eggfruit
 
-$ kafka-ingest format=bytes topic=t2 key-format=bytes key-terminator=: publish=true timestamp=3 partition=1
+$ kafka-ingest format=bytes topic=t2 key-format=bytes key-terminator=: timestamp=3 partition=1
 cherry:
 fig:fig
 
-$ kafka-ingest format=bytes topic=t2 key-format=bytes key-terminator=: publish=true timestamp=4 partition=2
+$ kafka-ingest format=bytes topic=t2 key-format=bytes key-terminator=: timestamp=4 partition=2
 grape:grape
 
 > CREATE MATERIALIZED SOURCE upsert_time_offset_0
@@ -253,7 +253,7 @@ key0      text      mz_offset
 
 $ kafka-add-partitions topic=t2 total-partitions=4
 
-$ kafka-ingest format=bytes topic=t2 key-format=bytes key-terminator=: publish=true timestamp=5 partition=3
+$ kafka-ingest format=bytes topic=t2 key-format=bytes key-terminator=: timestamp=5 partition=3
 hazelnut:hazelnut
 
 # It takes a while for new partitions to be consumed...
@@ -273,15 +273,15 @@ hazelnut  hazelnut  1
 
 $ kafka-create-topic topic=t3 partitions=1
 
-$ kafka-ingest format=bytes topic=t3 publish=true timestamp=1
+$ kafka-ingest format=bytes topic=t3 timestamp=1
 apple
 
 # Timestamp for June 2021
-$ kafka-ingest format=bytes topic=t3 publish=true timestamp=1622666300000
+$ kafka-ingest format=bytes topic=t3 timestamp=1622666300000
 banana
 
 # Timestamp for June 2099
-$ kafka-ingest format=bytes topic=t3 publish=true timestamp=4084108700000
+$ kafka-ingest format=bytes topic=t3 timestamp=4084108700000
 cherry
 
 > CREATE MATERIALIZED SOURCE relative_time_offset_30_years_ago

--- a/test/testdrive/kafka-upsert-sources-new-syntax.td
+++ b/test/testdrive/kafka-upsert-sources-new-syntax.td
@@ -97,7 +97,7 @@ mämmalmore    moose    42
 
 $ kafka-create-topic topic=textbytes
 
-$ kafka-ingest format=bytes topic=textbytes key-format=bytes key-terminator=: publish=true
+$ kafka-ingest format=bytes topic=textbytes key-format=bytes key-terminator=:
 fish:fish
 bìrd1:goose
 bírdmore:geese
@@ -131,7 +131,7 @@ fish          fish  1
 bírdmore      geese 3
 mammal1       moose 4
 
-$ kafka-ingest format=bytes topic=textbytes key-format=bytes key-terminator=: publish=true
+$ kafka-ingest format=bytes topic=textbytes key-format=bytes key-terminator=:
 bírdmore:géese
 mammalmore:moose
 mammal1:
@@ -145,7 +145,7 @@ bírdmore      g\xc3\xa9ese     6
 mammal1       mouse            9
 mammalmore    moose            7
 
-$ kafka-ingest format=bytes topic=textbytes key-format=bytes key-terminator=: publish=true
+$ kafka-ingest format=bytes topic=textbytes key-format=bytes key-terminator=:
 mammalmore:herd
 
 > select * from bytesbytes
@@ -156,7 +156,7 @@ b\xc3\xadrdmore  g\xc3\xa9ese     6
 mammal1          mouse            9
 mammalmore       herd             10
 
-$ kafka-ingest format=bytes topic=textbytes key-format=bytes key-terminator=: publish=true
+$ kafka-ingest format=bytes topic=textbytes key-format=bytes key-terminator=:
 bìrd1:
 fish:
 
@@ -181,7 +181,7 @@ $ kafka-create-topic topic=textproto
   VALUE FORMAT PROTOBUF MESSAGE '.Struct' USING SCHEMA FILE '${testdrive.protobuf-descriptors-file}'
   ENVELOPE UPSERT
 
-$ kafka-ingest format=protobuf message=struct topic=textproto key-format=bytes key-terminator=: publish=true
+$ kafka-ingest format=protobuf message=struct topic=textproto key-format=bytes key-terminator=:
 fish:{"int": 1, "bad_int": 1, "bin": "ONE", "st": "my-string"}
 bìrd1:{"int": 2, "bad_int": 2, "bin": "ONE", "st": "something-valid"}
 birdmore: {"int": 2, "bad_int": 2, "bin": "ONE", "st": "something-valid"}
@@ -196,7 +196,7 @@ fish 1 1 ONE my-string 1
 bìrd1 2 2 ONE something-valid 2
 birdmore 2 2 ONE something-valid 3
 
-$ kafka-ingest format=protobuf message=struct topic=textproto key-format=bytes key-terminator=: publish=true
+$ kafka-ingest format=protobuf message=struct topic=textproto key-format=bytes key-terminator=:
 mammal1: {"int": 2, "bad_int": 2, "bin": "ONE", "st": "something-valid"}
 bìrd1:
 birdmore: {"int": 2, "bad_int": 2, "bin": "ONE", "st": "stuff"}
@@ -222,7 +222,7 @@ mammalmore 2 2 ONE something-valid 10
 $ kafka-create-topic topic=nullkey
 
 # A null key should result in an error decoding that row but not a panic
-$ kafka-ingest format=bytes topic=nullkey key-format=bytes key-terminator=: publish=true
+$ kafka-ingest format=bytes topic=nullkey key-format=bytes key-terminator=:
 bird1:goose
 :geese
 mammal1:moose

--- a/test/testdrive/kafka-upsert-sources.td
+++ b/test/testdrive/kafka-upsert-sources.td
@@ -99,7 +99,7 @@ mämmalmore    moose    42
 
 $ kafka-create-topic topic=textbytes
 
-$ kafka-ingest format=bytes topic=textbytes key-format=bytes key-terminator=: publish=true
+$ kafka-ingest format=bytes topic=textbytes key-format=bytes key-terminator=:
 fish:fish
 bìrd1:goose
 bírdmore:geese
@@ -133,7 +133,7 @@ fish          fish  1
 bírdmore      geese 3
 mammal1       moose 4
 
-$ kafka-ingest format=bytes topic=textbytes key-format=bytes key-terminator=: publish=true
+$ kafka-ingest format=bytes topic=textbytes key-format=bytes key-terminator=:
 bírdmore:géese
 mammalmore:moose
 mammal1:
@@ -147,7 +147,7 @@ bírdmore      g\xc3\xa9ese     6
 mammal1       mouse            9
 mammalmore    moose            7
 
-$ kafka-ingest format=bytes topic=textbytes key-format=bytes key-terminator=: publish=true
+$ kafka-ingest format=bytes topic=textbytes key-format=bytes key-terminator=:
 mammalmore:herd
 
 > select * from bytesbytes
@@ -158,7 +158,7 @@ b\xc3\xadrdmore  g\xc3\xa9ese     6
 mammal1          mouse            9
 mammalmore       herd             10
 
-$ kafka-ingest format=bytes topic=textbytes key-format=bytes key-terminator=: publish=true
+$ kafka-ingest format=bytes topic=textbytes key-format=bytes key-terminator=:
 bìrd1:
 fish:
 
@@ -183,7 +183,7 @@ $ kafka-create-topic topic=textproto
   FORMAT PROTOBUF MESSAGE '.Struct' USING SCHEMA FILE '${testdrive.protobuf-descriptors-file}'
   ENVELOPE UPSERT FORMAT BYTES
 
-$ kafka-ingest format=protobuf message=struct topic=textproto key-format=bytes key-terminator=: publish=true
+$ kafka-ingest format=protobuf message=struct topic=textproto key-format=bytes key-terminator=:
 fish:{"int": 1, "bad_int": 1, "bin": "ONE", "st": "my-string"}
 bìrd1:{"int": 2, "bad_int": 2, "bin": "ONE", "st": "something-valid"}
 birdmore: {"int": 2, "bad_int": 2, "bin": "ONE", "st": "something-valid"}
@@ -198,7 +198,7 @@ fish 1 1 ONE my-string 1
 bìrd1 2 2 ONE something-valid 2
 birdmore 2 2 ONE something-valid 3
 
-$ kafka-ingest format=protobuf message=struct topic=textproto key-format=bytes key-terminator=: publish=true
+$ kafka-ingest format=protobuf message=struct topic=textproto key-format=bytes key-terminator=:
 mammal1: {"int": 2, "bad_int": 2, "bin": "ONE", "st": "something-valid"}
 bìrd1:
 birdmore: {"int": 2, "bad_int": 2, "bin": "ONE", "st": "stuff"}
@@ -224,7 +224,7 @@ mammalmore 2 2 ONE something-valid 10
 $ kafka-create-topic topic=nullkey
 
 # A null key should result in an error decoding that row but not a panic
-$ kafka-ingest format=bytes topic=nullkey key-format=bytes key-terminator=: publish=true
+$ kafka-ingest format=bytes topic=nullkey key-format=bytes key-terminator=:
 bird1:goose
 :geese
 mammal1:moose

--- a/test/testdrive/protobuf.td
+++ b/test/testdrive/protobuf.td
@@ -96,8 +96,19 @@ $ kafka-ingest format=protobuf topic=messages-partitioned message=struct timesta
   WITH (start_offset=[1,0])
   FORMAT PROTOBUF MESSAGE '.Struct' USING SCHEMA FILE '${testdrive.protobuf-descriptors-file}'
 
-! CREATE MATERIALIZED SOURCE protomessages_partitioned FROM
-  KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-messages-partitioned-${testdrive.seed}'
-  WITH (start_offset=[1,0])
+$ kafka-create-topic topic=tester
+
+$ set schema
+syntax = "proto3";
+
+message SimpleId {
+  string id = 1;
+}
+
+$ kafka-ingest topic=tester format=protobuf message=simpleid schema=${schema} publish=true
+{"id": "a"}
+
+! CREATE MATERIALIZED SOURCE tester
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-tester-${testdrive.seed}'
   FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 confluent schema registry protobuf schemas not yet supported


### PR DESCRIPTION
This change allows `testdrive` to publish Protobuf schemas to the running Confluent Schema Registry container. Another step in the direction of supporting Protobuf + CSR!

Note: I had to remove a lot of `publish=true` arguments from various `*.td` tests. Previous to this change, neither `format=protobuf` nor `format=byte` could have their schemas published to CSR--so these flags were no-ops!