### PR TITLE
Transform: Minimize the number of non-leaves in join equivalence expressions.

### DIFF
--- a/src/expr/src/relation/canonicalize.rs
+++ b/src/expr/src/relation/canonicalize.rs
@@ -15,8 +15,10 @@ use repr::{Datum, RelationType, ScalarType};
 
 /// Canonicalize equivalence classes of a join.
 ///
-/// This function makes it so that the same expression appears in only one
-/// equivalence class. It also sorts and dedups the equivalence classes.
+/// This function:
+/// * ensures the same expression appears in only one equivalence class.
+/// * ensures the equivalence classes are sorted and dedupped.
+/// * simplifies expressions to involve the least number of leaves.
 ///
 /// ```rust
 /// use expr::MirScalarExpr;
@@ -38,6 +40,64 @@ use repr::{Datum, RelationType, ScalarType};
 /// assert_eq!(expected, equivalences)
 /// ````
 pub fn canonicalize_equivalences(equivalences: &mut Vec<Vec<MirScalarExpr>>) {
+    // Calculate the number of leaves for each expression.
+    let mut to_reduce = equivalences
+        .drain(..)
+        .filter_map(|mut cls| {
+            let mut result = cls
+                .drain(..)
+                .map(|expr| (count_leaves(&expr), expr))
+                .collect::<Vec<_>>();
+            result.sort();
+            result.dedup();
+            if result.len() > 1 {
+                Some(result)
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let mut expressions_rewritten = true;
+    while expressions_rewritten {
+        expressions_rewritten = false;
+        for i in 0..to_reduce.len() {
+            // `to_reduce` will be borrowed as immutable, so in order to modify
+            // elements of `to_reduce[i]`, we are going to pop them out of
+            // `to_reduce[i]` and put the modified version in `new_equivalence`,
+            // which will then replace `to_reduce[i]`.
+            let mut new_equivalence = Vec::with_capacity(to_reduce[i].len());
+            while let Some((_, mut popped_expr)) = to_reduce[i].pop() {
+                popped_expr.visit_mut(&mut |e: &mut MirScalarExpr| {
+                    // If a simpler expression can be found that is equivalent
+                    // to e,
+                    if let Some(simpler_e) = to_reduce.iter().find_map(|cls| {
+                        if cls.iter().skip(1).position(|(_, expr)| e == expr).is_some() {
+                            Some(cls[0].1.clone())
+                        } else {
+                            None
+                        }
+                    }) {
+                        // Replace e with the simpler expression.
+                        *e = simpler_e;
+                        expressions_rewritten = true;
+                    }
+                });
+                new_equivalence.push((count_leaves(&popped_expr), popped_expr));
+            }
+            new_equivalence.sort();
+            new_equivalence.dedup();
+            to_reduce[i] = new_equivalence;
+        }
+    }
+
+    // Map away the leaf count.
+    *equivalences = to_reduce
+        .drain(..)
+        .map(|mut cls| cls.drain(..).map(|(_, expr)| expr).collect::<Vec<_>>())
+        .collect::<Vec<_>>();
+
+    // Fuse equivalence classes containing the same exprssion.
     for index in 1..equivalences.len() {
         for inner in 0..index {
             if equivalences[index]
@@ -49,19 +109,33 @@ pub fn canonicalize_equivalences(equivalences: &mut Vec<Vec<MirScalarExpr>>) {
             }
         }
     }
+
     for equivalence in equivalences.iter_mut() {
         equivalence.sort();
         equivalence.dedup();
     }
+
     equivalences.retain(|es| es.len() > 1);
     equivalences.sort();
+}
+
+fn count_leaves(expr: &MirScalarExpr) -> usize {
+    let mut leaf_count = 0;
+    expr.visit(&mut |e: &MirScalarExpr| {
+        if e.is_literal() {
+            leaf_count += 1
+        } else if let MirScalarExpr::Column(_) = e {
+            leaf_count += 1
+        }
+    });
+    leaf_count
 }
 
 /// Canonicalize predicates of a filter.
 ///
 /// This function reduces and canonicalizes the structure of each individual
 /// predicate. Then, it transforms predicates of the form "A and B" into two: "A"
-/// and "B". Aftewards, it reduces predicates based on information from other
+/// and "B". Afterwards, it reduces predicates based on information from other
 /// predicates in the set. Finally, it sorts and deduplicates the predicates.
 ///
 /// Additionally, it also removes IS NOT NULL predicates if there is another

--- a/src/expr/tests/testdata/reduce
+++ b/src/expr/tests/testdata/reduce
@@ -331,32 +331,7 @@ canonicalize
 !(isnull(#1))
 (!(isnull(#3)) || (#0 < #2))
 
-canonicalize-join
-[[#0 #0 #3] [(call_binary add_int32 #0 #0) (call_binary add_int32 #3 #3)]]
-----
-[#0 #3]
-
-canonicalize-join
-[[#0 #3 #3] [(call_binary add_int32 #0 #0) #1] [(call_binary add_int32 #3 #3) #2]]
-----
-[#0 #3]
-[#1 #2 (#0 + #0)]
-
-canonicalize-join
-[
-    [#0 #3]
-    [#1
-        (call_binary add_int32 (call_binary add_int32 #0 #0) #0)
-        (call_binary add_int32 (call_binary add_int32 #2 #2) #1)
-        (call_binary add_int32
-            (call_binary add_int32 #2 #2)
-            (call_binary add_int32 (call_binary add_int32 #3 #3) #3))
-        (call_binary add_int32 (call_binary add_int32 #3 #3) #3)
-    ]
-]
-----
-[#0 #3]
-[#1 ((#0 + #0) + #0) ((#2 + #2) + #1)]
+# expressions in equivalence classes only become simpler.
 
 canonicalize-join
 [[
@@ -399,6 +374,9 @@ canonicalize-join
 [#1 ((#0 + #0) + #0) ((#2 + #2) + #1)]
 [(#2 + #2) (#4 * #5)]
 
+# replacing expressions with simpler equivalent ones can result in the
+# collapsing of equivalence classes.
+
 canonicalize-join
 [
     [#0 #3]
@@ -416,3 +394,41 @@ canonicalize-join
 ----
 [#0 #3]
 [#1 (#0 + #0) (#1 + #0) (#1 + #1) ((#2 + #2) + #1) (#1 - #1) (#4 * #5)]
+
+canonicalize-join
+[[#0 #3 #3] [(call_binary add_int32 #0 #0) #1] [(call_binary add_int32 #3 #3) #2]]
+----
+[#0 #3]
+[#1 #2 (#0 + #0)]
+
+# replacing expressions with simpler equivalent ones can result in the
+# removal of redundant equivalence classes.
+
+canonicalize-join
+[[#0 #0 #3] [(call_binary add_int32 #0 #0) (call_binary add_int32 #3 #3)]]
+----
+[#0 #3]
+
+# test an equivalence class when the number of leaves are the same but the
+# number of nonleaves are not.
+
+canonicalize-join
+[[
+    (call_unary cast_int16_to_int32 #0)
+    (call_unary neg_int32 (call_unary cast_int16_to_int32 #0))
+    (call_unary neg_int32 (call_unary neg_int32 (call_unary cast_int16_to_int32
+    #0)))
+]]
+----
+[-(i16toi32(#0)) i16toi32(#0)]
+
+# literals don't get overwritten with equivalent expressions
+
+canonicalize-join
+[[
+    #0
+    (4 int32)
+    (call_binary add_int32 #1 (4 int32))
+]]
+----
+[#0 4 (#1 + 4)]

--- a/src/expr/tests/testdata/reduce
+++ b/src/expr/tests/testdata/reduce
@@ -432,3 +432,27 @@ canonicalize-join
 ]]
 ----
 [#0 4 (#1 + 4)]
+
+# functions on literals don't cause cycling
+canonicalize-join
+[
+    [#0 (4 int32)]
+    [(call_unary neg_int32 #0) (call_unary neg_int32 #1) (call_unary neg_int32 (4 int32))]
+    [(call_binary add_int32 #1 (call_unary neg_int32 #1)) #3]
+]
+----
+[#0 4]
+[#3 (#1 + -(4))]
+[-(#1) -(4)]
+
+canonicalize-join
+[
+    [#0 (4 int32)]
+    [(call_unary neg_int32 #0) (call_unary neg_int32 #1)]
+    [(call_unary neg_int32 #1) (call_unary neg_int32 (4 int32))]
+    [(call_binary add_int32 #1 (call_unary neg_int32 #1)) #3]
+]
+----
+[#0 4]
+[#3 (#1 + -(4))]
+[-(#1) -(4)]

--- a/src/expr/tests/testdata/reduce
+++ b/src/expr/tests/testdata/reduce
@@ -330,3 +330,89 @@ canonicalize
 ----
 !(isnull(#1))
 (!(isnull(#3)) || (#0 < #2))
+
+canonicalize-join
+[[#0 #0 #3] [(call_binary add_int32 #0 #0) (call_binary add_int32 #3 #3)]]
+----
+[#0 #3]
+
+canonicalize-join
+[[#0 #3 #3] [(call_binary add_int32 #0 #0) #1] [(call_binary add_int32 #3 #3) #2]]
+----
+[#0 #3]
+[#1 #2 (#0 + #0)]
+
+canonicalize-join
+[
+    [#0 #3]
+    [#1
+        (call_binary add_int32 (call_binary add_int32 #0 #0) #0)
+        (call_binary add_int32 (call_binary add_int32 #2 #2) #1)
+        (call_binary add_int32
+            (call_binary add_int32 #2 #2)
+            (call_binary add_int32 (call_binary add_int32 #3 #3) #3))
+        (call_binary add_int32 (call_binary add_int32 #3 #3) #3)
+    ]
+]
+----
+[#0 #3]
+[#1 ((#0 + #0) + #0) ((#2 + #2) + #1)]
+
+canonicalize-join
+[[
+    (call_binary and #0 (call_binary add_int32 #0 #0))
+    (call_binary add_int32 #0 #0)
+    (call_binary add_int32 #0 (call_binary add_int32 #0 #0))
+]]
+----
+[(#0 && (#0 + #0)) (#0 + #0) (#0 + (#0 + #0))]
+
+canonicalize-join
+[
+    [#0 #3]
+    [#1
+        (call_binary add_int32 (call_binary add_int32 #2 #2) #1)
+        (call_binary add_int32
+            (call_binary add_int32 #2 #2)
+            (call_binary add_int32 (call_binary add_int32 #0 #0) #0))
+        (call_binary add_int32 (call_binary add_int32 #3 #3) #3)
+    ]
+]
+----
+[#0 #3]
+[#1 ((#0 + #0) + #0) ((#2 + #2) + #1)]
+
+canonicalize-join
+[
+    [#0 #3]
+    [#1
+        (call_binary add_int32 (call_binary add_int32 #2 #2) #1)
+        (call_binary add_int32
+            (call_binary mul_int32 #4 #5)
+            (call_binary add_int32 (call_binary add_int32 #0 #0) #0))
+        (call_binary add_int32 (call_binary add_int32 #3 #3) #3)
+    ]
+    [(call_binary add_int32 #2 #2) (call_binary mul_int32 #4 #5)]
+]
+----
+[#0 #3]
+[#1 ((#0 + #0) + #0) ((#2 + #2) + #1)]
+[(#2 + #2) (#4 * #5)]
+
+canonicalize-join
+[
+    [#0 #3]
+    [#1
+        (call_binary add_int32 #0 #0)
+        (call_binary add_int32 (call_binary add_int32 #2 #2) #1)
+        (call_binary add_int32
+            (call_binary mul_int32 #4 #5)
+            (call_binary add_int32 (call_binary add_int32 #0 #0) #0))
+        (call_binary add_int32 (call_binary add_int32 #3 #3) #3)
+    ]
+    [(call_binary add_int32 #3 #3) (call_binary mul_int32 #4 #5) (call_binary
+    sub_int32 (call_binary add_int32 #3 #3) (call_binary mul_int32 #4 #5))]
+]
+----
+[#0 #3]
+[#1 (#0 + #0) (#1 + #0) (#1 + #1) ((#2 + #2) + #1) (#1 - #1) (#4 * #5)]

--- a/test/sqllogictest/transform/join_index.slt
+++ b/test/sqllogictest/transform/join_index.slt
@@ -268,34 +268,34 @@ CREATE INDEX bar_idx3 on bar(a + 4);
 query T multiline
 EXPLAIN PLAN FOR
 select foo.b, bar.b, baz.b
-FROM foo, bar, baz
+FROM bar, foo, baz
 where foo.a = bar.a
   and bar.a + 4 = baz.a
 ----
 %0 =
-| Get materialize.public.foo (u1)
-| ArrangeBy (#0)
-
-%1 =
 | Get materialize.public.bar (u3)
 | ArrangeBy ((#0 + 4))
+
+%1 =
+| Get materialize.public.foo (u1)
+| ArrangeBy (#0)
 
 %2 =
 | Get materialize.public.baz (u9)
 | ArrangeBy (#0)
 
 %3 =
-| Join %0 %1 %2 (= #0 #2) (= #4 (#2 + 4))
-| | implementation = Differential %2.(#0) %1.((#0 + 4)) %0.(#0)
+| Join %0 %1 %2 (= #0 #2) (= #4 (#0 + 4))
+| | implementation = Differential %2.(#0) %0.((#0 + 4)) %1.(#0)
 | | demand = (#0, #1, #3..#5)
 | Filter !(isnull(#0)), !(isnull(#4))
-| Project (#1, #3, #5)
+| Project (#3, #1, #5)
 
 EOF
 
 query III
 select foo.b, bar.b, baz.b
-FROM foo, bar, baz
+FROM bar, foo, baz
 where foo.a = bar.a
   and bar.a + 4 = baz.a
 ----
@@ -364,3 +364,51 @@ and bar.b - foo.b = foo.a / bar.a
 ----
 4
 3
+
+statement ok
+DROP INDEX baz_idx
+
+# materialize#8002: it would be nice if this join used the indexes on foo(a)
+# and bar(a+4)
+
+query T multiline
+EXPLAIN PLAN FOR
+select foo.b, bar.b, baz.b
+FROM foo, bar, baz
+where foo.a = bar.a
+  and foo.a + 4 = baz.a
+----
+%0 =
+| Get materialize.public.foo (u1)
+| Filter !(isnull(#0))
+| ArrangeBy ((#0 + 4))
+
+%1 =
+| Get materialize.public.bar (u3)
+| Filter !(isnull(#0))
+| ArrangeBy (#0)
+
+%2 =
+| Get materialize.public.baz (u9)
+| Filter !(isnull(#0))
+
+%3 =
+| Join %0 %1 %2 (= #0 #2) (= #4 (#0 + 4))
+| | implementation = Differential %2 %0.((#0 + 4)) %1.(#0)
+| | demand = (#1, #3, #5)
+| Project (#1, #3, #5)
+
+EOF
+
+query III
+select foo.b, bar.b, baz.b
+FROM bar, foo, baz
+where foo.a = bar.a
+  and bar.a + 4 = baz.a
+----
+4
+NULL
+0
+2
+3
+2

--- a/test/sqllogictest/transform/predicate_pushdown.slt
+++ b/test/sqllogictest/transform/predicate_pushdown.slt
@@ -155,7 +155,7 @@ SELECT * FROM t1, t2 WHERE t1.f1 = t2.f1 AND t1.f2 = t2.f2 AND t1.f1 + t2.f2 = t
 | |   delta %0 %1.(#0, #1)
 | |   delta %1 %0.(#0, #1)
 | | demand = (#0, #1)
-| Filter ((#0 + #1) = (#0 + #1))
+| Filter !(isnull(#0)), !(isnull(#1))
 | Project (#0, #1, #0, #1)
 
 EOF


### PR DESCRIPTION
Fixes the 100% CPU problem preventing #7471 from being merged.

Description of 100% CPU problem:
1. A join equivalence class that starts off looking like this: `(= #1 (#2 + (#2 + #1)) (#3 + (#3 + #3)))`
2. After predicatepullup + predicate pushdown, the join equivalence class has become this: `(= #1 (#2 + (#2 + #1)) (#2 + (#2 + (#3 + (#3 + #3)))) (#3 + (#3 + #3)))`
3. We automatically detect that `(#2 + (#2 + (#3 + (#3 + #3)))) = (#3 + (#3 + #3))` is a single-input predicate, so we push `(#2 + (#2 + (#3 + (#3 + #3)))) = (#3 + (#3 + #3))` down, and the join equivalence class becomes to `(= #1 (#2 + (#2 + #1)) (#2 + (#2 + (#3 + (#3 + #3))))`
4. Repeat steps 2 and 3. The join equivalence class now looks like this: `(= #1 (#2 + (#2 + #1)) (#2 + (#2 + (#2 + (#2 + (#3 + (#3 + #3)))))))`
5. And so on.

This PR fixes the 100% CPU problem at step 2 in the above process. We observe that the `(#3 + (#3 + #3))` in `(#2 + (#2 + (#3 + (#3 + #3))))` is equivalent to a simpler expression `#1`, so we replace `(#2 + (#2 + (#3 + (#3 + #3))))` with `(#2 + (#2 + #1))`. After dedupping, the equivalence class becomes `(= #1 (#2 + (#2 + #1)) (#3 + (#3 + #3)))`

EDIT: I realized that measuring complexity by the number of leaves:
* fails to capture the difference in complexity between one or more unary functions nested within each other, like ` -(#0)` vs `-(-(#0))`
* risks overwriting a constant with a column reference.

The new measure of complexity is that literals always have the least complexity, and then among all other expressions, they are ranked by the number of non-leaves. 