### PR TITLE
mzcompose: change propagate-uid-gid to propagate_uid_gid

### DIFF
--- a/ci/test/cargo-test/mzcompose.yml
+++ b/ci/test/cargo-test/mzcompose.yml
@@ -28,7 +28,7 @@ services:
     - KAFKA_ADDRS=kafka:9092
     - SCHEMA_REGISTRY_URL=http://schema-registry:8081
     - MZ_SOFT_ASSERTIONS=1
-    propagate-uid-gid: true
+    propagate_uid_gid: true
     depends_on: [kafka, zookeeper, schema-registry]
   zookeeper:
     image: confluentinc/cp-zookeeper:5.5.4

--- a/demo/billing/mzcompose.yml
+++ b/demo/billing/mzcompose.yml
@@ -67,7 +67,7 @@ services:
     depends_on: [kafka, schema-registry, materialized]
   dashboard:
     mzbuild: dashboard
-    propagate-uid-gid: true
+    propagate_uid_gid: true
     environment:
       - 'MATERIALIZED_URL=materialized:6875'
     ports:

--- a/demo/chbench/mzcompose.yml
+++ b/demo/chbench/mzcompose.yml
@@ -231,7 +231,7 @@ services:
   # All monitoring
   dashboard:
     mzbuild: dashboard
-    propagate-uid-gid: true
+    propagate_uid_gid: true
     environment:
     - MATERIALIZED_URL=materialized:6875
     ports:

--- a/doc/developer/mzbuild.md
+++ b/doc/developer/mzbuild.md
@@ -485,7 +485,7 @@ version: "3.7"
 services:
   materialized:
     mzbuild: materialized
-    propagate-uid-gid: true
+    propagate_uid_gid: true
 
 mzworkflows:
   NAME:
@@ -505,7 +505,7 @@ mzworkflows:
   If `mzbuild` is specified, neither of the standard properties `build` nor
   `image` should be specified.
 
-* `propagate-uid-gid` (bool) requests that the Docker image be run with the user
+* `propagate_uid_gid` (bool) requests that the Docker image be run with the user
   ID and group ID of the host user. It is equivalent to passing `--user $(id
   -u):$(id -g)` to `docker run`. The default is `false`.
 

--- a/misc/python/materialize/mzcompose.py
+++ b/misc/python/materialize/mzcompose.py
@@ -256,9 +256,9 @@ class Composition:
                 else:
                     self.images.append(image)
 
-                if "propagate-uid-gid" in config:
+                if "propagate_uid_gid" in config:
                     config["user"] = f"{os.getuid()}:{os.getgid()}"
-                    del config["propagate-uid-gid"]
+                    del config["propagate_uid_gid"]
 
             if self.repo.rd.coverage:
                 # Emit coverage information to a file in a directory that is
@@ -596,23 +596,18 @@ class Workflow:
         return self.composition.run(args, self.env, capture=capture)
 
 
-PythonServiceConfig = TypedDict(
-    "PythonServiceConfig",
-    {
-        "mzbuild": str,
-        "image": str,
-        "hostname": str,
-        "command": str,
-        "ports": List[int],
-        "environment": List[str],
-        "depends_on": List[str],
-        "entrypoint": List[str],
-        "volumes": List[str],
-        "propagate-uid-gid": bool,
-        "init": bool,
-    },
-    total=False,
-)
+class PythonServiceConfig(TypedDict, total=False):
+    mzbuild: str
+    image: str
+    hostname: str
+    command: str
+    ports: List[int]
+    environment: List[str]
+    depends_on: List[str]
+    entrypoint: List[str]
+    volumes: List[str]
+    propagate_uid_gid: bool
+    init: bool
 
 
 class PythonService:
@@ -787,7 +782,7 @@ class Testdrive(PythonService):
                 ],
                 "environment": environment,
                 "volumes": volumes,
-                "propagate-uid-gid": True,
+                "propagate_uid_gid": True,
                 "init": True,
             },
         )
@@ -815,7 +810,7 @@ class SqlLogicTest(PythonService):
                 "environment": environment,
                 "volumes": volumes,
                 "depends_on": depends_on,
-                "propagate-uid-gid": True,
+                "propagate_uid_gid": True,
                 "init": True,
             },
         )

--- a/misc/python/requirements-dev.txt
+++ b/misc/python/requirements-dev.txt
@@ -5,7 +5,7 @@ humanize==3.11.0
 isort==5.9.3
 flake8==3.9.2
 mypy==0.910
-pdoc3==0.8.1
+pdoc3==0.10.0
 prettytable==2.1.0
 pytest==5.4.2
 requests==2.23.0

--- a/test/bench/aggregations/mzcompose.yml
+++ b/test/bench/aggregations/mzcompose.yml
@@ -109,7 +109,7 @@ services:
   # All monitoring
   dashboard:
     mzbuild: dashboard
-    propagate-uid-gid: true
+    propagate_uid_gid: true
     environment:
       - 'MATERIALIZED_URL=materialized:6875'
     ports:

--- a/test/bench/avro-insert/mzcompose.yml
+++ b/test/bench/avro-insert/mzcompose.yml
@@ -110,7 +110,7 @@ services:
   # All monitoring
   dashboard:
     mzbuild: dashboard
-    propagate-uid-gid: true
+    propagate_uid_gid: true
     environment:
       - 'MATERIALIZED_URL=materialized:6875'
     ports:

--- a/test/bench/avro-upsert/mzcompose.yml
+++ b/test/bench/avro-upsert/mzcompose.yml
@@ -109,7 +109,7 @@ services:
   # All monitoring
   dashboard:
     mzbuild: dashboard
-    propagate-uid-gid: true
+    propagate_uid_gid: true
     environment:
       - 'MATERIALIZED_URL=materialized:6875'
     ports:

--- a/test/bench/kafka-sink-avro-debezium/mzcompose.yml
+++ b/test/bench/kafka-sink-avro-debezium/mzcompose.yml
@@ -103,7 +103,7 @@ services:
   # All monitoring
   dashboard:
     mzbuild: dashboard
-    propagate-uid-gid: true
+    propagate_uid_gid: true
     environment:
       - 'MATERIALIZED_URL=materialized:6875'
     ports:

--- a/test/debezium-avro/mzcompose.yml
+++ b/test/debezium-avro/mzcompose.yml
@@ -67,7 +67,7 @@ services:
     - .:/workdir
     - mzdata:/share/mzdata
     - tmp:/share/tmp
-    propagate-uid-gid: true
+    propagate_uid_gid: true
     init: true
     depends_on: [kafka, zookeeper, schema-registry, materialized, debezium]
   materialized:

--- a/test/kafka-exactly-once/mzcompose.yml
+++ b/test/kafka-exactly-once/mzcompose.yml
@@ -67,7 +67,7 @@ services:
     volumes:
       - .:/workdir
       - mzdata:/share/mzdata
-    propagate-uid-gid: true
+    propagate_uid_gid: true
     init: true
 
   materialized:

--- a/test/kafka-krb5/mzcompose.yml
+++ b/test/kafka-krb5/mzcompose.yml
@@ -99,7 +99,7 @@ services:
       - ../../:/workdir
       - secrets:/share/secrets
       - ./kdc/krb5.conf:/etc/krb5.conf
-    propagate-uid-gid: true
+    propagate_uid_gid: true
     init: true
     depends_on: [kdc, kafka, zookeeper, materialized, schema-registry]
 

--- a/test/kafka-matrix/mzcompose.yml
+++ b/test/kafka-matrix/mzcompose.yml
@@ -131,7 +131,7 @@ services:
       - mzdata:/share/mzdata
       - tmp:/share/tmp
       - ../testdrive:/tests
-    propagate-uid-gid: true
+    propagate_uid_gid: true
     init: true
     depends_on: [kafka, zookeeper, schema-registry, materialized]
   materialized:

--- a/test/performance/perf-upsert/mzcompose.yml
+++ b/test/performance/perf-upsert/mzcompose.yml
@@ -52,7 +52,7 @@ services:
     depends_on: [kafka, materialized]
   dashboard:
     mzbuild: dashboard
-    propagate-uid-gid: true
+    propagate_uid_gid: true
     environment:
       - 'MATERIALIZED_URL=materialized:6875'
     ports:

--- a/test/testdrive/mzcompose.yml
+++ b/test/testdrive/mzcompose.yml
@@ -138,7 +138,7 @@ services:
     - .:/workdir
     - mzdata:/share/mzdata
     - tmp:/share/tmp
-    propagate-uid-gid: true
+    propagate_uid_gid: true
     init: true
   materialized:
     mzbuild: materialized

--- a/test/upgrade/mzcompose.yml
+++ b/test/upgrade/mzcompose.yml
@@ -282,7 +282,7 @@ services:
       - mzdata:/share/mzdata
       - tmp:/share/tmp
       - ../testdrive:/tests
-    propagate-uid-gid: true
+    propagate_uid_gid: true
     init: true
     depends_on: [kafka, zookeeper, schema-registry, postgres]
 


### PR DESCRIPTION
The hyphens mean we can't use the normal method of declaring a
TypedDict, which causes bin/pydoc to fail. Docker Compose uses
underscores in its multi word keys, so this is more consistent anyway.