### PR TITLE
sql-parser: add alias for SESSION CHARACTERISTICS AS TRANSACTION

### DIFF
--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -50,6 +50,7 @@ Chain
 Channel
 Char
 Character
+Characteristics
 Check
 Close
 Coalesce

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -3361,7 +3361,15 @@ impl<'a> Parser<'a> {
                 variable,
                 value,
             }))
-        } else if variable.as_str().parse() == Ok(TRANSACTION) && modifier.is_none() {
+        } else if
+        // SET TRANSACTION transaction_mode
+        (variable.as_str().parse() == Ok(TRANSACTION) && modifier.is_none())
+            ||
+            // SET SESSION CHARACTERISTICS AS TRANSACTION transaction_mode
+            (modifier == Some(SESSION)
+                && variable.as_str().parse() == Ok(CHARACTERISTICS)
+                && self.parse_keywords(&[AS, TRANSACTION]))
+        {
             Ok(Statement::SetTransaction(SetTransactionStatement {
                 modes: self.parse_transaction_modes()?,
             }))

--- a/src/sql-parser/tests/testdata/txn
+++ b/src/sql-parser/tests/testdata/txn
@@ -125,6 +125,13 @@ SET TRANSACTION READ ONLY, READ WRITE, ISOLATION LEVEL SERIALIZABLE
 SetTransaction(SetTransactionStatement { modes: [AccessMode(ReadOnly), AccessMode(ReadWrite), IsolationLevel(Serializable)] })
 
 parse-statement
+SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL READ UNCOMMITTED
+----
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED
+=>
+SetTransaction(SetTransactionStatement { modes: [IsolationLevel(ReadUncommitted)] })
+
+parse-statement
 COMMIT
 ----
 COMMIT


### PR DESCRIPTION
This is an alias for SET TRANSACTION: https://www.postgresql.org/docs/current/sql-set-transaction.html