### PR TITLE
ci/deploy: fix twine paths during upload

### DIFF
--- a/ci/deploy/pypi.py
+++ b/ci/deploy/pypi.py
@@ -39,7 +39,6 @@ def main() -> None:
             dist_files = (path / "dist").iterdir()
             spawn.runv(
                 ["twine", "upload", *dist_files],
-                cwd=path,
                 env={
                     **os.environ,
                     "TWINE_USERNAME": "__token__",


### PR DESCRIPTION
The paths to the distributions are relative to the root of the
repository, so we don't need to run twine from that directory.