### PR TITLE
S3: support FORMAT CSV WITH HEADERS (col, ...)

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -54,7 +54,8 @@ Wrap your release notes at the 80 character mark.
   flag [--metrics-scraping-interval](/cli/#prometheus-metrics).
 
 - Allow users to specify the names of columns that must be present in CSV
-  objects with headers. {{% gh 7507 %}}
+  objects with headers {{% gh 7507 %}}, and support CSV with headers in S3. {{%
+  gh 7913 %}}
 
 {{% version-header v0.9.1 %}}
 

--- a/doc/user/content/sql/create-source/csv-s3.md
+++ b/doc/user/content/sql/create-source/csv-s3.md
@@ -25,7 +25,7 @@ contain multiple records serialized as CSV, separated by newlines.
 
 {{% create-source/syntax-details connector="s3" formats="csv" envelopes="append-only" keyConstraint=true %}}
 
-## Example
+## Example without CSV header
 
 Assuming there is an S3 bucket "analytics" that contains the following keys and
 associated content:
@@ -83,6 +83,38 @@ This creates a view that has the same properties as above, except it:
 
 * Has two columns (one *integer*, one *interval*)
 * Does not store the string data in memory after it has been parsed
+
+## Example with CSV header
+
+Use the `FORMAT CSV WITH HEADER (column, column2, ...)` syntax to validate and remove header rows
+when reading from an S3 bucket. The column names are required for S3 sources, unlike file sources.
+
+**users/2021/engagement-with-header.csv**
+```csv
+id,status,active time
+9999,active,8 hours
+888,inactive,
+777,active,3 hours
+```
+
+**users/2020/engagement-with-header.csv**
+```csv
+id,status,active time
+9999,active,750 hours
+888,inactive,
+777,active,1002 hours
+```
+
+Load all these keys, while renaming the columns from the headers provided in the CSV files using
+the following command:
+
+```sql
+CREATE MATERIALIZED SOURCE csv_example (user_id, status, usage) -- provide SQL names
+FROM S3 DISCOVER OBJECTS MATCHING '**/*.csv' USING BUCKET SCAN 'analytics'
+WITH (region = 'us-east-2')
+FORMAT CSV
+WITH HEADER (id, status, "active time"); -- expect a header for each file with these names
+```
 
 ## Related pages
 

--- a/src/dataflow/src/decode/csv.rs
+++ b/src/dataflow/src/decode/csv.rs
@@ -64,6 +64,12 @@ impl CsvDecoderState {
         }
     }
 
+    pub fn reset_for_new_object(&mut self) {
+        if self.header_names.is_some() {
+            self.next_row_is_header = true;
+        }
+    }
+
     pub fn decode(
         &mut self,
         chunk: &mut &[u8],

--- a/src/dataflow/src/decode/mod.rs
+++ b/src/dataflow/src/decode/mod.rs
@@ -299,7 +299,11 @@ impl DataDecoder {
         push_metadata: bool,
     ) -> Result<Option<Row>, DataflowError> {
         match &mut self.inner {
-            DataDecoderInner::Csv(csv) => csv.decode(bytes, upstream_coord, push_metadata),
+            DataDecoderInner::Csv(csv) => {
+                let result = csv.decode(bytes, upstream_coord, push_metadata);
+                csv.reset_for_new_object();
+                result
+            }
             DataDecoderInner::DelimitedBytes { format, .. } => {
                 let data = *bytes;
                 *bytes = &[][..];

--- a/test/testdrive/esoteric/s3.td
+++ b/test/testdrive/esoteric/s3.td
@@ -165,3 +165,41 @@ b3
 c1
 c2
 c3
+
+
+# CSV with headers
+
+$ s3-put-object bucket=test key=csv/a.csv
+id,value
+1,a
+2,a
+
+$ s3-put-object bucket=test key=csv/b.csv
+id,value
+3,b
+
+$ s3-put-object bucket=test key=csv/c.csv
+id,value
+4,c
+5,c
+
+> CREATE MATERIALIZED SOURCE s3_csv_headers
+  FROM S3 DISCOVER OBJECTS MATCHING 'csv/*'
+  USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
+  WITH (
+    region = '${testdrive.aws-region}',
+    endpoint = '${testdrive.aws-endpoint}',
+    access_key_id = '${testdrive.aws-access-key-id}',
+    secret_access_key = '${testdrive.aws-secret-access-key}',
+    token = '${testdrive.aws-token}'
+  )
+  FORMAT CSV WITH HEADER (id, value);
+
+> SELECT id, value FROM s3_csv_headers
+id value
+--------
+1  a
+2  a
+3  b
+4  c
+5  c


### PR DESCRIPTION
This supports headers in CSV objects in S3. Currently this requires that users
specify the header column names, and errors in header column names don't appear
until the first SELECT query executed against a materialized source.

Work is ongoing to make the column names optional and to make the validation
happen as part of purification, but this is a nice simple change that unblocks
the most important parts.

Fixes #7145