### PR TITLE
avro-decoder: Fix incorrect return from fn push_coords

### DIFF
--- a/src/interchange/src/avro/decode.rs
+++ b/src/interchange/src/avro/decode.rs
@@ -117,9 +117,9 @@ fn push_coords(coords: Option<DebeziumSourceCoordinates>, packer: &mut Row) -> R
         None => packer.push(Datum::Null),
     }
     if is_unknown {
-        Ok(())
-    } else {
         Err(())
+    } else {
+        Ok(())
     }
 }
 


### PR DESCRIPTION
The two branches of the if statement at the very bottom of the function
were reversed which was causing a bogus "Record with unrecognized source coordinates"
error to be printed in the log.

Fixes #6552