### PR TITLE
sql: accept lowercase timezone names

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -2579,8 +2579,15 @@ where
 
 /// Parses a named timezone like `EST` or `America/New_York`, or a fixed-offset timezone like `-05:00`.
 pub(crate) fn parse_timezone(tz: &str) -> Result<Timezone, EvalError> {
-    tz.parse()
-        .map_err(|_| EvalError::InvalidTimezone(tz.to_owned()))
+    let mut parsed = tz.parse();
+
+    // chrono_tz is case-sensitive. So, if the initial parse attempt was not
+    // successfull, try again as uppercase. This way specifying the timezone in lowercase will work
+    if let Err(_) = parsed {
+        parsed = tz.to_uppercase().as_str().parse();
+    }
+
+    parsed.map_err(|_| EvalError::InvalidTimezone(tz.to_owned()))
 }
 
 /// Converts the time `t`, which is assumed to be in UTC, to the timezone `tz`.

--- a/test/sqllogictest/timezone.slt
+++ b/test/sqllogictest/timezone.slt
@@ -94,3 +94,15 @@ query T
 SELECT TIMESTAMPTZ '2020-11-01 01:00:00 America/New_York'
 ----
 2020-11-01 06:00:00+00
+
+# Lowercase timezone names
+
+query T
+SELECT '2011-11-11 11:11:11'::TIMESTAMP AT TIME ZONE 'utc';
+----
+2011-11-11 11:11:11+00
+
+query T
+SELECT TIMEZONE('utc','2011-11-11 11:11:11');
+----
+2011-11-11 11:11:11


### PR DESCRIPTION
Postgres accepts lowercase timezone names such as 'utc', but Mz
does not since the chrono_tz crate is case-sensitive and the
case-sensitivity is not configurable.

To get the same behavior as Postgres, attempt to resolve a
timezone name both in its original case and as uppercase.

Fixes #7185