### PR TITLE
Fix mkrelease dependencies

### DIFF
--- a/bin/mkrelease
+++ b/bin/mkrelease
@@ -11,4 +11,4 @@
 
 # mkrelease -- Update documents for a release, per the release process
 
-exec "$(dirname "$0")"/pyactivate -m materialize.cli.mkrelease "$@"
+exec "$(dirname "$0")"/pyactivate --dev -m materialize.cli.mkrelease "$@"


### PR DESCRIPTION
mkrelease depends on `requests` which is required in dev mode but not general
mode. We are, I believe, generally trying to keep the install time and dependencies low for external users of the materialize Python scripts, and at this point no external-facing script depends on requests.

The three options here are:

* move `requests` into `requirements.txt` -- adds a collection of deps to
  external-facing requirements, slightly increasing install time and
  probability of failure.
* create a new `requirements-internal.txt` and associated infra -- seems complex
* this, just run mkrelease in dev mode, treating "dev" as both "internal" and
  "required for development". This should be pretty fine, as the people who use
  mkrelease probably already have the dev requirements installed.