### PR TITLE
coord: send each mz_metrics record and its future retraction atomically

### DIFF
--- a/src/coord/src/coord/prometheus.rs
+++ b/src/coord/src/coord/prometheus.rs
@@ -133,9 +133,9 @@ fn add_expiring_update(
     retain_for: u64,
     out: &mut Vec<TimestampedUpdate>,
 ) {
-    // TODO: Make this send both records in the same message so we can
-    // persist them atomically. Otherwise, we may end up with permanent
-    // orphans if a restart/crash happens at the wrong time.
+    // NB: This makes sure to send both records in the same message so we can
+    // persist them atomically. Otherwise, we may end up with permanent orphans
+    // if a restart/crash happens at the wrong time.
     let id = table.id;
     out.push(TimestampedUpdate {
         updates: updates


### PR DESCRIPTION
Otherwise, if we got a crash at the wrong time, we could have only one
of the two persisted, which would result in a permanent orphan.