### PR TITLE
S3: Eagerly exit SQS listener and Object downloader on shutdown

### DIFF
--- a/test/testdrive/esoteric/s3-sqs-gh7182.td
+++ b/test/testdrive/esoteric/s3-sqs-gh7182.td
@@ -1,0 +1,63 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# These tests are flaky: S3 has no guarantees about how long it takes for SQS notifications to get
+# set up. Even waiting 5 minutes isn't long enough to get failures down to below once a week.
+#
+# https://github.com/MaterializeInc/materialize/issues/6355
+
+# gh 7182: Ensure that messages are not lost after dropping and recreating an S3 source that
+# listens to an SQS queue
+
+
+$ set buk=mz-sqs-tst
+$ s3-create-bucket bucket=${buk}
+$ s3-add-notifications bucket=${buk} queue=${buk} sqs-validation-timeout=5m
+
+> CREATE MATERIALIZED SOURCE s3
+  FROM S3
+  DISCOVER OBJECTS MATCHING '**/*.csv' USING
+  SQS NOTIFICATIONS 'testdrive-${buk}-${testdrive.seed}'
+  WITH (
+    region = '${testdrive.aws-region}',
+    endpoint = '${testdrive.aws-endpoint}',
+    access_key_id = '${testdrive.aws-access-key-id}',
+    secret_access_key = '${testdrive.aws-secret-access-key}',
+    token = '${testdrive.aws-token}'
+  )
+  FORMAT TEXT;
+
+> DROP SOURCE s3;
+
+> CREATE MATERIALIZED SOURCE s3
+  FROM S3
+  DISCOVER OBJECTS MATCHING '**/*.csv' USING
+  SQS NOTIFICATIONS 'testdrive-${buk}-${testdrive.seed}'
+  WITH (
+    region = '${testdrive.aws-region}',
+    endpoint = '${testdrive.aws-endpoint}',
+    access_key_id = '${testdrive.aws-access-key-id}',
+    secret_access_key = '${testdrive.aws-secret-access-key}',
+    token = '${testdrive.aws-token}'
+  )
+  FORMAT TEXT;
+
+$ s3-put-object bucket=${buk} key=0.csv
+0
+
+$ s3-put-object bucket=${buk} key=1.csv
+1
+
+$ s3-put-object bucket=${buk} key=2.csv
+2
+
+> SELECT text FROM s3
+0
+1
+2


### PR DESCRIPTION
Before this change, it was guaranteed that SQS readers would successfully
process, and delete from the SQS queue, at least 1 message before they could
notice that the dataflow should shutdown.

This happened because of the way propagation of dataflow shutdown was
communicated:

* The S3SourceReader (which is the actual object that exists inside a dataflow)
  holds an mpsc Receiver, responsible for picking received *data* off of the
  `download_objects` queue.
* `download_objects` holds the sender for the dataflow. It also holds a receiver
  that is used by all of the SQSListener and BucketScanner tasks.

The dataflow notified the `download_objects` task that it shut down by dropping
its receiver, causing `tx.send`s to fail. Once the download_objects task failed
to send a message on the dataflow mpsc sender the task notifies upstream tasks
-- specifically for the case of the bug that we care about the `sqs_listener`
task -- by shutting down *its* mpsc receiver.

This all is sort of fine, except for the fact that download_objects could only
attempt to send data to the dataflow (and thus learn that it should shut down)
once it had received a message telling it that there was an object that it
should download. In the case of SQS queues, reading the message with the
"download this object" notification is destructive. So it's impossible for SQS
queues to shut down in this scheme without destroying at least one message
about what should be downloaded.

This is likely to be primarily a papercut, it should only be observable for
users who are doing exploration and constantly creating and recreating views
listening to SQS queues. Of course, these are exactly the people most likely to
bounce if Materialize seems to lose data in interactive use.

Fixes #7182