### PR TITLE
persist: wire up coordinator to allow compaction in persistence

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1184,6 +1184,53 @@ impl Coordinator {
         }
     }
 
+    /// Forward the subset of since updates that belong to persisted tables'
+    /// primary indexes to the persisted tables themselves.
+    ///
+    /// TODO: In the future the coordinator should perhaps track a table's upper and
+    /// since frontiers directly as it currently does for sources.
+    fn persisted_table_allow_compaction(&self, since_updates: &[(GlobalId, Antichain<Timestamp>)]) {
+        let mut table_since_updates = vec![];
+        for (id, frontier) in since_updates.iter() {
+            // Not all ids will be present in the catalog however, those that are
+            // in the catalog must also have their dependencies in the catalog as
+            // well.
+            let item = self.catalog.try_get_by_id(*id).map(|e| e.item());
+            if let Some(CatalogItem::Index(catalog::Index { on, .. })) = item {
+                if let CatalogItem::Table(catalog::Table {
+                    persist: Some(persist),
+                    ..
+                }) = self.catalog.get_by_id(on).item()
+                {
+                    if self.catalog.default_index_for(*on) == Some(*id) {
+                        table_since_updates
+                            .push((persist.write_handle.stream_id(), frontier.clone()));
+                    }
+                }
+            }
+        }
+
+        if !table_since_updates.is_empty() {
+            let persist_multi = match self.catalog.persist_multi_details() {
+                Some(multi) => multi,
+                None => {
+                    log::error!("internal error: persist_multi_details invariant violated");
+                    return;
+                }
+            };
+
+            let compaction_res = persist_multi
+                .write_handle
+                .allow_compaction(&table_since_updates);
+            let _ = tokio::spawn(async move {
+                if let Err(err) = compaction_res.into_future().await {
+                    // TODO: Do something smarter here
+                    log::error!("failed to compact persisted tables: {}", err);
+                }
+            });
+        }
+    }
+
     /// Perform maintenance work associated with the coordinator.
     ///
     /// Primarily, this involves sequencing compaction commands, which should be
@@ -1201,6 +1248,7 @@ impl Coordinator {
             .collect();
 
         if !since_updates.is_empty() {
+            self.persisted_table_allow_compaction(&since_updates);
             self.broadcast(dataflow::Command::AllowCompaction(since_updates));
         }
     }

--- a/src/persist/src/indexed/runtime.rs
+++ b/src/persist/src/indexed/runtime.rs
@@ -355,7 +355,7 @@ impl<K: Codec, V: Codec> StreamWriteHandle<K, V> {
     }
 
     /// Unblocks compaction for updates at or before `since`.
-    pub fn allow_compaction(&mut self, since: Antichain<u64>) -> Future<()> {
+    pub fn allow_compaction(&self, since: Antichain<u64>) -> Future<()> {
         let (tx, rx) = Future::new();
         self.runtime.allow_compaction(&[(self.id, since)], tx);
         rx


### PR DESCRIPTION
I think this is a reasonable first cut implementation for wiring up the coordinator to send allow compaction messages aka since frontier updates to the persistence crate.

Normally, since frontiers are derived from the upper frontier for the same object and the set of transactions, sinks and other interlopers who wish to hold the since frontier at a particular time. However, tables don't yet have a notion of upper frontiers so porting the standard approach used by indexes and sources is nontrivial. Instead, this commit teaches the coordinator to specifically inform the persistence crate of the table's default index's since frontier whenever it is updated. This approach is safe, because the default index can never be deleted unless the table itself is deleted, and there is never more than one default index. Additionally, this approach introduces no new state in the coordinator.

However, this approach introduces a small runtime cost in `maintenance` where we now iterate through all of the received since frontier updates and try to see if they came from an index backing a persisted table. 