### PR TITLE
mzbuild: fix double compile bug

### DIFF
--- a/misc/python/materialize/cli/mzimage.py
+++ b/misc/python/materialize/cli/mzimage.py
@@ -22,7 +22,11 @@ def main() -> int:
     args = parse_args()
     ui.Verbosity.init_from_env(explicit=None)
     root = Path(os.environ["MZ_ROOT"])
-    repo = mzbuild.Repository(root)
+    repo = mzbuild.Repository(
+        root,
+        release_mode=(args.build_mode == "release"),
+        coverage=args.coverage,
+    )
 
     if args.command == "list":
         for image in repo:
@@ -83,6 +87,17 @@ def parse_args() -> argparse.Namespace:
         subparser = add_subcommand(name, **kwargs)
         subparser.add_argument(
             "image", help="the name of an mzbuild image in this repository"
+        )
+        subparser.add_argument(
+            "--build-mode",
+            default="release",
+            choices=["dev", "release"],
+            help="whether to build in dev or release mode",
+        )
+        subparser.add_argument(
+            "--coverage",
+            help="whether to enable code coverage compilation flags",
+            action="store_true",
         )
         return subparser
 

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -280,7 +280,9 @@ class CargoBuild(CargoPreImage):
             )
         if self.extract:
             output = spawn.capture(
-                cargo_build + ["--message-format=json"], unicode=True
+                cargo_build + ["--message-format=json"],
+                unicode=True,
+                env=dict(os.environ, XCOMPILE_RUSTFLAGS=self.rustflags),
             )
             for line in output.split("\n"):
                 if line.strip() == "" or not line.startswith("{"):

--- a/misc/python/materialize/spawn.py
+++ b/misc/python/materialize/spawn.py
@@ -87,6 +87,7 @@ def capture(
     stdin: Union[None, int, IO[bytes]] = None,
     unicode: Literal[False] = ...,
     stderr_too: bool = False,
+    env: Optional[Dict[str, str]] = None,
 ) -> bytes:
     ...
 
@@ -99,6 +100,7 @@ def capture(
     *,
     unicode: Literal[True],
     stderr_too: bool = False,
+    env: Optional[Dict[str, str]] = None,
 ) -> str:
     ...
 
@@ -109,6 +111,7 @@ def capture(
     stdin: Union[None, int, IO[bytes]] = None,
     unicode: bool = False,
     stderr_too: bool = False,
+    env: Optional[Dict[str, str]] = None,
 ) -> Union[str, bytes]:
     """Capture the output of a subprocess.
 
@@ -136,5 +139,5 @@ def capture(
     """
     stderr = subprocess.STDOUT if stderr_too else None
     return subprocess.check_output(  # type: ignore
-        args, cwd=cwd, stdin=stdin, universal_newlines=unicode, stderr=stderr
+        args, cwd=cwd, stdin=stdin, universal_newlines=unicode, stderr=stderr, env=env
     )


### PR DESCRIPTION
CargoBuild.build invokes `cargo build` in *two* places. Be sure to pass
the same compilation flags in both places to avoid thrashing the cache.
This should substantially speed up builds in CI and local development.