### PR TITLE
coord,pgwire: plumb down implicit transaction failures to pgwire

### DIFF
--- a/test/pgtest/transactions.pt
+++ b/test/pgtest/transactions.pt
@@ -214,13 +214,13 @@ send
 Query {"query": "SELECT 1; DISCARD ALL;"}
 ----
 
-until
+until err_field_typs=C
 ReadyForQuery
 ----
 RowDescription {"fields":[{"name":"?column?"}]}
 DataRow {"fields":["1"]}
 CommandComplete {"tag":"SELECT 1"}
-ErrorResponse {"fields":[{"typ":"C","value":"25001"},{"typ":"M","value":"DISCARD ALL cannot be run inside a transaction block"}]}
+ErrorResponse {"fields":[{"typ":"C","value":"25001"}]}
 ReadyForQuery {"status":"I"}
 
 # Should fail within an explicit transaction.
@@ -230,14 +230,14 @@ Query {"query": "DISCARD ALL"}
 Query {"query": "ROLLBACK"}
 ----
 
-until
+until err_field_typs=C
 ReadyForQuery
 ReadyForQuery
 ReadyForQuery
 ----
 CommandComplete {"tag":"BEGIN"}
 ReadyForQuery {"status":"T"}
-ErrorResponse {"fields":[{"typ":"C","value":"25001"},{"typ":"M","value":"DISCARD ALL cannot be run inside a transaction block"}]}
+ErrorResponse {"fields":[{"typ":"C","value":"25001"}]}
 ReadyForQuery {"status":"E"}
 CommandComplete {"tag":"ROLLBACK"}
 ReadyForQuery {"status":"I"}
@@ -289,7 +289,7 @@ Sync
 Query {"query": "ROLLBACK"}
 ----
 
-until
+until err_field_typs=C
 ReadyForQuery
 ReadyForQuery
 ----
@@ -298,7 +298,7 @@ BindComplete
 CommandComplete {"tag":"BEGIN"}
 ParseComplete
 BindComplete
-ErrorResponse {"fields":[{"typ":"C","value":"25001"},{"typ":"M","value":"DISCARD ALL cannot be run inside a transaction block"}]}
+ErrorResponse {"fields":[{"typ":"C","value":"25001"}]}
 ReadyForQuery {"status":"E"}
 CommandComplete {"tag":"ROLLBACK"}
 ReadyForQuery {"status":"I"}
@@ -409,5 +409,34 @@ ReadyForQuery
 ----
 RowDescription {"fields":[{"name":"?column?"}]}
 DataRow {"fields":["45"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}
+
+# Verify a failed transaction should return rollback if commit is issued.
+
+send
+Query {"query": "BEGIN; SELECT 0; COMMIT"}
+Query {"query": "BEGIN; SELECT 0/0;"}
+Query {"query": "COMMIT"}
+Query {"query": "SELECT 1"}
+----
+
+until err_field_typs=M ignore=RowDescription
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+CommandComplete {"tag":"BEGIN"}
+DataRow {"fields":["0"]}
+CommandComplete {"tag":"SELECT 1"}
+CommandComplete {"tag":"COMMIT"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"BEGIN"}
+ErrorResponse {"fields":[{"typ":"M","value":"division by zero"}]}
+ReadyForQuery {"status":"E"}
+CommandComplete {"tag":"ROLLBACK"}
+ReadyForQuery {"status":"I"}
+DataRow {"fields":["1"]}
 CommandComplete {"tag":"SELECT 1"}
 ReadyForQuery {"status":"I"}

--- a/test/sqllogictest/transactions.slt
+++ b/test/sqllogictest/transactions.slt
@@ -361,3 +361,33 @@ SELECT * FROM v1;
 COMMIT;
 ----
 db error: ERROR: transactions can only reference nearby relations; "materialize.public.v1" referenced here, but only the following are available: "materialize.public.t", "materialize.public.t5727", "materialize.public.v", "materialize.public.v_primary_idx"
+
+simple conn=t1
+ROLLBACK;
+----
+COMPLETE 0
+
+# Verify an error is produce during write transactions if the commit fails.
+
+statement ok
+CREATE TABLE insert_fail (i int)
+
+statement ok
+INSERT INTO insert_fail VALUES (1)
+
+simple conn=t1
+BEGIN;
+INSERT into insert_fail VALUES (2);
+----
+COMPLETE 0
+COMPLETE 1
+
+simple conn=t2
+DROP table insert_fail;
+----
+COMPLETE 0
+
+simple conn=t1
+COMMIT;
+----
+db error: ERROR: unknown catalog item 'u21'


### PR DESCRIPTION
Previously we weren't sure where to send an error during an implicit
commit (at the end of a Query or Sync message). After direct comparison
with postgres, we have a clearer picture. I'm not sure how to exactly
induce this in postgres (have an INSERT succeed but then the implicit
transaction commit fail), but we can test a few nearby scenarios.

The difference we needed to observe is that for implicit transactions,
we don't care about the ExecuteResponse or tag at all, just that
an error happened. This greatly simplifies the error paths in
sequence_end_transaction and also means we don't need to change the tag
of the action should a failure occur.

Fixes #7926