### PR TITLE
Dataflow Optimization: Transfer monotonicity info through lets.

### DIFF
--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -255,33 +255,35 @@ pub mod monotonic {
 
     use dataflow_types::{DataflowDesc, SourceConnector, SourceEnvelope};
     use expr::MirRelationExpr;
-    use expr::{GlobalId, Id};
+    use expr::{GlobalId, Id, LocalId};
     use std::collections::HashSet;
 
     // Determines if a relation is monotonic, and applies any optimizations along the way.
-    fn is_monotonic(expr: &mut MirRelationExpr, sources: &HashSet<GlobalId>) -> bool {
+    fn is_monotonic(
+        expr: &mut MirRelationExpr,
+        sources: &HashSet<GlobalId>,
+        locals: &mut HashSet<LocalId>,
+    ) -> bool {
         match expr {
-            MirRelationExpr::Get { id, .. } => {
-                if let Id::Global(id) = id {
-                    sources.contains(id)
-                } else {
-                    false
-                }
-            }
-            MirRelationExpr::Project { input, .. } => is_monotonic(input, sources),
+            MirRelationExpr::Get { id, .. } => match id {
+                Id::Global(id) => sources.contains(id),
+                Id::Local(id) => locals.contains(id),
+                _ => false,
+            },
+            MirRelationExpr::Project { input, .. } => is_monotonic(input, sources, locals),
             MirRelationExpr::Filter { input, predicates } => {
-                let is_monotonic = is_monotonic(input, sources);
+                let is_monotonic = is_monotonic(input, sources, locals);
                 // Non-temporal predicates can introduce non-monotonicity, as they
                 // can result in the future removal of records.
                 // TODO: this could be improved to only restrict if upper bounds
                 // are present, as temporal lower bounds only delay introduction.
                 is_monotonic && !predicates.iter().any(|p| p.contains_temporal())
             }
-            MirRelationExpr::Map { input, .. } => is_monotonic(input, sources),
+            MirRelationExpr::Map { input, .. } => is_monotonic(input, sources, locals),
             MirRelationExpr::TopK {
                 input, monotonic, ..
             } => {
-                *monotonic = is_monotonic(input, sources);
+                *monotonic = is_monotonic(input, sources, locals);
                 false
             }
             MirRelationExpr::Reduce {
@@ -290,29 +292,30 @@ pub mod monotonic {
                 monotonic,
                 ..
             } => {
-                *monotonic = is_monotonic(input, sources);
+                *monotonic = is_monotonic(input, sources, locals);
                 // Reduce is monotonic iff its input is and it is a "distinct",
                 // with no aggregate values; otherwise it may need to retract.
                 *monotonic && aggregates.is_empty()
             }
             MirRelationExpr::Union { base, inputs } => {
-                let mut monotonic = is_monotonic(base, sources);
+                let mut monotonic = is_monotonic(base, sources, locals);
                 for input in inputs.iter_mut() {
-                    let monotonic_i = is_monotonic(input, sources);
+                    let monotonic_i = is_monotonic(input, sources, locals);
                     monotonic = monotonic && monotonic_i;
                 }
                 monotonic
             }
-            MirRelationExpr::ArrangeBy { input, .. } => is_monotonic(input, sources),
+            MirRelationExpr::ArrangeBy { input, .. }
+            | MirRelationExpr::DeclareKeys { input, .. } => is_monotonic(input, sources, locals),
             MirRelationExpr::FlatMap { input, func, .. } => {
-                let is_monotonic = is_monotonic(input, sources);
+                let is_monotonic = is_monotonic(input, sources, locals);
                 is_monotonic && func.preserves_monotonicity()
             }
             MirRelationExpr::Join { inputs, .. } => {
                 // If all inputs to the join are monotonic then so is the join.
                 let mut monotonic = true;
                 for input in inputs.iter_mut() {
-                    let monotonic_i = is_monotonic(input, sources);
+                    let monotonic_i = is_monotonic(input, sources, locals);
                     monotonic = monotonic && monotonic_i;
                 }
                 monotonic
@@ -320,11 +323,25 @@ pub mod monotonic {
             MirRelationExpr::Constant { rows: Ok(rows), .. } => {
                 rows.iter().all(|(_, diff)| diff > &0)
             }
-            MirRelationExpr::Threshold { input } => is_monotonic(input, sources),
-            // Let and Negate remain
-            _ => {
+            MirRelationExpr::Threshold { input } => is_monotonic(input, sources, locals),
+            MirRelationExpr::Let { id, value, body } => {
+                let prior = locals.remove(id);
+                if is_monotonic(value, sources, locals) {
+                    locals.insert(*id);
+                }
+                let result = is_monotonic(body, sources, locals);
+                if prior {
+                    locals.insert(*id);
+                } else {
+                    locals.remove(id);
+                }
+                result
+            }
+            // The default behavior.
+            // TODO: check that this is the behavior we want.
+            MirRelationExpr::Negate { .. } | MirRelationExpr::Constant { rows: Err(_), .. } => {
                 expr.visit1_mut(|e| {
-                    is_monotonic(e, sources);
+                    is_monotonic(e, sources, locals);
                 });
                 false
             }
@@ -346,7 +363,11 @@ pub mod monotonic {
 
         // Propagate predicate information from outputs to inputs.
         for build_desc in dataflow.objects_to_build.iter_mut() {
-            is_monotonic(build_desc.view.as_inner_mut(), &monotonic);
+            is_monotonic(
+                build_desc.view.as_inner_mut(),
+                &monotonic,
+                &mut HashSet::new(),
+            );
         }
     }
 }


### PR DESCRIPTION
Fixes the problem in #7371 where monotonicity information is not being transferred through a let.

Also, in `is_monotonic`, I am listing all enum variants so that there is a compile error if a new MirRelationExpr variant gets added.