### PR TITLE
coord: add temp workaround for noisy log message

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1192,6 +1192,17 @@ impl Coordinator {
     fn persisted_table_allow_compaction(&self, since_updates: &[(GlobalId, Antichain<Timestamp>)]) {
         let mut table_since_updates = vec![];
         for (id, frontier) in since_updates.iter() {
+            // HACK: Avoid the "failed to compact persisted tables" error log at
+            // startup, by not trying to allow compaction on the minimum
+            // timestamp. Real fix in #7977.
+            if !frontier
+                .elements()
+                .iter()
+                .any(|x| *x > Timestamp::minimum())
+            {
+                continue;
+            }
+
             // Not all ids will be present in the catalog however, those that are
             // in the catalog must also have their dependencies in the catalog as
             // well.


### PR DESCRIPTION
We're currently getting the following log message at every startup. The
real fix is being worked on in #7977, but in the meantime, avoid
spamming everyone.

    2021-08-21T00:45:08.608002Z ERROR coord::coord: failed to compact persisted tables: invalid compaction less than or equal to trace since Antichain { elements: [0] }: Antichain { elements: [0] }