### PR TITLE
sql: begin to support regproc

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -877,6 +877,9 @@ impl Catalog {
             for (_item_name, item_id) in &schema.items {
                 builtin_table_updates.extend(catalog.pack_item_update(*item_id, 1));
             }
+            for (_item_name, function_id) in &schema.functions {
+                builtin_table_updates.extend(catalog.pack_item_update(*function_id, 1));
+            }
         }
         for (db_name, db) in &catalog.by_name {
             builtin_table_updates.push(catalog.pack_database_update(db_name, 1));
@@ -885,6 +888,9 @@ impl Catalog {
                 builtin_table_updates.push(catalog.pack_schema_update(&db_spec, schema_name, 1));
                 for (_item_name, item_id) in &schema.items {
                     builtin_table_updates.extend(catalog.pack_item_update(*item_id, 1));
+                }
+                for (_item_name, function_id) in &schema.functions {
+                    builtin_table_updates.extend(catalog.pack_item_update(*function_id, 1));
                 }
             }
         }

--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -1271,9 +1271,9 @@ pub const PG_PROC: BuiltinView = BuiltinView {
     name: "pg_proc",
     schema: PG_CATALOG_SCHEMA,
     sql: "CREATE VIEW pg_proc AS SELECT
-    NULL::pg_catalog.oid AS oid,
-    NULL::pg_catalog.text AS proname
-    WHERE false",
+    oid,
+    name AS proname
+FROM mz_catalog.mz_functions",
     id: GlobalId::System(5021),
     needs_logs: false,
 };

--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -441,6 +441,18 @@ pub const TYPE_BPCHAR_ARRAY: BuiltinType = BuiltinType {
     pgtype: &postgres_types::Type::BPCHAR_ARRAY,
 };
 
+pub const TYPE_REGPROC: BuiltinType = BuiltinType {
+    schema: PG_CATALOG_SCHEMA,
+    id: GlobalId::System(1046),
+    pgtype: &postgres_types::Type::REGPROC,
+};
+
+pub const TYPE_REGPROC_ARRAY: BuiltinType = BuiltinType {
+    schema: PG_CATALOG_SCHEMA,
+    id: GlobalId::System(1047),
+    pgtype: &postgres_types::Type::REGPROC_ARRAY,
+};
+
 lazy_static! {
     pub static ref TYPE_LIST: BuiltinType = BuiltinType {
         schema: PG_CATALOG_SCHEMA,
@@ -1344,6 +1356,8 @@ lazy_static! {
             Builtin::Type(&TYPE_OID_ARRAY),
             Builtin::Type(&TYPE_RECORD),
             Builtin::Type(&TYPE_RECORD_ARRAY),
+            Builtin::Type(&TYPE_REGPROC),
+            Builtin::Type(&TYPE_REGPROC_ARRAY),
             Builtin::Type(&TYPE_INT2),
             Builtin::Type(&TYPE_INT2_ARRAY),
             Builtin::Type(&TYPE_TEXT),

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -4940,7 +4940,7 @@ where
     match &ty {
         Bool => strconv::format_bool(buf, d.unwrap_bool()),
         Int16 => strconv::format_int16(buf, d.unwrap_int16()),
-        Int32 | Oid => strconv::format_int32(buf, d.unwrap_int32()),
+        Int32 | Oid | RegProc => strconv::format_int32(buf, d.unwrap_int32()),
         Int64 => strconv::format_int64(buf, d.unwrap_int64()),
         Float32 => strconv::format_float32(buf, d.unwrap_float32()),
         Float64 => strconv::format_float64(buf, d.unwrap_float64()),

--- a/src/interchange/src/avro/encode.rs
+++ b/src/interchange/src/avro/encode.rs
@@ -289,7 +289,9 @@ impl<'a> mz_avro::types::ToAvro for TypedDatum<'a> {
             let mut val = match &typ.scalar_type {
                 ScalarType::Bool => Value::Boolean(datum.unwrap_bool()),
                 ScalarType::Int16 => Value::Int(i32::from(datum.unwrap_int16())),
-                ScalarType::Int32 | ScalarType::Oid => Value::Int(datum.unwrap_int32()),
+                ScalarType::Int32 | ScalarType::Oid | ScalarType::RegProc => {
+                    Value::Int(datum.unwrap_int32())
+                }
                 ScalarType::Int64 => Value::Long(datum.unwrap_int64()),
                 ScalarType::Float32 => Value::Float(datum.unwrap_float32()),
                 ScalarType::Float64 => Value::Double(datum.unwrap_float64()),

--- a/src/interchange/src/json.rs
+++ b/src/interchange/src/json.rs
@@ -132,7 +132,9 @@ impl<'a> ToJson for TypedDatum<'_> {
             match &typ.scalar_type {
                 ScalarType::Bool => json!(datum.unwrap_bool()),
                 ScalarType::Int16 => json!(datum.unwrap_int16()),
-                ScalarType::Int32 | ScalarType::Oid => json!(datum.unwrap_int32()),
+                ScalarType::Int32 | ScalarType::Oid | ScalarType::RegProc => {
+                    json!(datum.unwrap_int32())
+                }
                 ScalarType::Int64 => json!(datum.unwrap_int64()),
                 ScalarType::Float32 => json!(datum.unwrap_float32()),
                 ScalarType::Float64 => json!(datum.unwrap_float64()),
@@ -239,7 +241,9 @@ fn build_row_schema_field<F: FnMut() -> String>(
 ) -> serde_json::value::Value {
     let mut field_type = match &typ.scalar_type {
         ScalarType::Bool => json!("boolean"),
-        ScalarType::Int16 | ScalarType::Int32 | ScalarType::Oid => json!("int"),
+        ScalarType::Int16 | ScalarType::Int32 | ScalarType::Oid | ScalarType::RegProc => {
+            json!("int")
+        }
         ScalarType::Int64 => json!("long"),
         ScalarType::Float32 => json!("float"),
         ScalarType::Float64 => json!("double"),

--- a/src/pgrepr/src/types.rs
+++ b/src/pgrepr/src/types.rs
@@ -63,6 +63,8 @@ pub enum Type {
     TimestampTz,
     /// A universally unique identifier.
     Uuid,
+    /// A function name.
+    RegProc,
 }
 
 lazy_static! {
@@ -112,6 +114,7 @@ impl Type {
             postgres_types::Type::TIMESTAMP => Some(Type::Timestamp),
             postgres_types::Type::TIMESTAMPTZ => Some(Type::TimestampTz),
             postgres_types::Type::UUID => Some(Type::Uuid),
+            postgres_types::Type::REGPROC => Some(Type::RegProc),
             _ => None,
         }
     }
@@ -142,6 +145,7 @@ impl Type {
                 Type::Timestamp => &postgres_types::Type::TIMESTAMP_ARRAY,
                 Type::TimestampTz => &postgres_types::Type::TIMESTAMPTZ_ARRAY,
                 Type::Uuid => &postgres_types::Type::UUID_ARRAY,
+                Type::RegProc => &postgres_types::Type::REGPROC_ARRAY,
             },
             Type::Bool => &postgres_types::Type::BOOL,
             Type::Bytea => &postgres_types::Type::BYTEA,
@@ -165,6 +169,7 @@ impl Type {
             Type::Timestamp => &postgres_types::Type::TIMESTAMP,
             Type::TimestampTz => &postgres_types::Type::TIMESTAMPTZ,
             Type::Uuid => &postgres_types::Type::UUID,
+            Type::RegProc => &postgres_types::Type::REGPROC,
         }
     }
 
@@ -201,6 +206,7 @@ impl Type {
             &postgres_types::Type::INT8 => "bigint",
             &postgres_types::Type::TIMESTAMPTZ => "timestamp with time zone",
             &postgres_types::Type::VARCHAR => "character varying",
+            &postgres_types::Type::REGPROC_ARRAY => "regproc[]",
             other => other.name(),
         }
     }
@@ -239,6 +245,7 @@ impl Type {
             Type::Timestamp => 8,
             Type::TimestampTz => 8,
             Type::Uuid => 16,
+            Type::RegProc => 4,
         }
     }
 
@@ -282,6 +289,7 @@ impl Type {
             Type::Timestamp => ScalarType::Timestamp,
             Type::TimestampTz => ScalarType::TimestampTz,
             Type::Uuid => ScalarType::Uuid,
+            Type::RegProc => ScalarType::RegProc,
         }
     }
 }
@@ -321,6 +329,7 @@ impl From<&ScalarType> for Type {
             ScalarType::TimestampTz => Type::TimestampTz,
             ScalarType::Uuid => Type::Uuid,
             ScalarType::Numeric { .. } => Type::Numeric,
+            ScalarType::RegProc => Type::RegProc,
         }
     }
 }

--- a/src/pgrepr/src/value.rs
+++ b/src/pgrepr/src/value.rs
@@ -446,7 +446,7 @@ impl Value {
             Type::Float4 => Value::Float4(strconv::parse_float32(raw)?),
             Type::Float8 => Value::Float8(strconv::parse_float64(raw)?),
             Type::Int2 => Value::Int2(strconv::parse_int16(raw)?),
-            Type::Int4 | Type::Oid => Value::Int4(strconv::parse_int32(raw)?),
+            Type::Int4 | Type::Oid | Type::RegProc => Value::Int4(strconv::parse_int32(raw)?),
             Type::Int8 => Value::Int8(strconv::parse_int64(raw)?),
             Type::Interval => Value::Interval(Interval(strconv::parse_interval(raw)?)),
             Type::Jsonb => Value::Jsonb(Jsonb(strconv::parse_jsonb(raw)?)),
@@ -494,7 +494,9 @@ impl Value {
             Type::Float4 => f32::from_sql(ty.inner(), raw).map(Value::Float4),
             Type::Float8 => f64::from_sql(ty.inner(), raw).map(Value::Float8),
             Type::Int2 => i16::from_sql(ty.inner(), raw).map(Value::Int2),
-            Type::Int4 | Type::Oid => i32::from_sql(ty.inner(), raw).map(Value::Int4),
+            Type::Int4 | Type::Oid | Type::RegProc => {
+                i32::from_sql(ty.inner(), raw).map(Value::Int4)
+            }
             Type::Int8 => i64::from_sql(ty.inner(), raw).map(Value::Int8),
             Type::Interval => Interval::from_sql(ty.inner(), raw).map(Value::Interval),
             Type::Jsonb => Jsonb::from_sql(ty.inner(), raw).map(Value::Jsonb),
@@ -600,6 +602,7 @@ pub fn null_datum(ty: &Type) -> (Datum<'static>, ScalarType) {
                 custom_oid: None,
             }
         }
+        Type::RegProc => ScalarType::RegProc,
     };
     (Datum::Null, ty)
 }

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -782,6 +782,8 @@ pub enum ScalarType {
         value_type: Box<ScalarType>,
         custom_oid: Option<u32>,
     },
+    /// A PostgreSQL function name.
+    RegProc,
 }
 
 impl<'a> ScalarType {

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -24,7 +24,6 @@ use lazy_static::lazy_static;
 use ore::collections::CollectionExt;
 use pgrepr::oid;
 use repr::{ColumnName, ColumnType, Datum, RelationType, Row, ScalarBaseType, ScalarType};
-use sql_parser::ast::{Expr, Raw};
 
 use crate::names::PartialName;
 use crate::plan::expr::{
@@ -101,6 +100,7 @@ impl TypeCategory {
             | ScalarType::Int32
             | ScalarType::Int64
             | ScalarType::Oid
+            | ScalarType::RegProc
             | ScalarType::Numeric { .. } => Self::Numeric,
             ScalarType::Interval => Self::Timespan,
             ScalarType::List { .. } => Self::List,
@@ -229,60 +229,67 @@ impl<R> Operation<R> {
     }
 }
 
-// Constructs a definition for a built-in out of a static SQL expression.
+/// Backing implementation for sql_impl_func and sql_impl_cast. See those
+/// functions for details.
+pub fn sql_impl(
+    expr: &'static str,
+) -> impl Fn(&QueryContext, Vec<ScalarType>) -> Result<HirScalarExpr, anyhow::Error> {
+    let expr = sql_parser::parser::parse_expr(expr.into())
+        .expect("static function definition failed to parse");
+    move |qcx, types| {
+        // Reconstruct an expression context where the parameter types are
+        // bound to the types of the expressions in `args`.
+        let mut scx = qcx.scx.clone();
+        scx.param_types = Rc::new(RefCell::new(
+            types
+                .into_iter()
+                .enumerate()
+                .map(|(i, ty)| (i + 1, ty))
+                .collect(),
+        ));
+        let mut qcx = QueryContext::root(&scx, qcx.lifetime);
+
+        // Desugar the expression
+        let mut expr = expr.clone();
+        transform_ast::transform_expr(&scx, &mut expr)?;
+
+        let expr = query::resolve_names_expr(&mut qcx, expr)?;
+
+        let ecx = ExprContext {
+            qcx: &qcx,
+            name: "static function definition",
+            scope: &Scope::empty(None),
+            relation_type: &RelationType::empty(),
+            allow_aggregates: false,
+            allow_subqueries: true,
+        };
+
+        // Plan the expression.
+        query::plan_expr(&ecx, &expr)?.type_as_any(&ecx)
+    }
+}
+
+// Constructs a definition for a built-in function out of a static SQL
+// expression.
 //
 // The SQL expression should use the standard parameter syntax (`$1`, `$2`, ...)
-// to refer to the inputs to the function. For example, a built-in function
-// that takes two arguments and concatenates them with an arrow in between
-// could be defined like so:
+// to refer to the inputs to the function. For example, a built-in function that
+// takes two arguments and concatenates them with an arrow in between could be
+// defined like so:
 //
-//     sql_op!("$1 || '<->' || $2")
+//     sql_impl_func("$1 || '<->' || $2")
 //
 // The number of parameters in the SQL expression must exactly match the number
-// of parameters in the built-in's declaration. There is no support for
-// variadic functions.
-macro_rules! sql_op {
-    ($l:literal) => {{
-        lazy_static! {
-            static ref EXPR: Expr<Raw> = sql_parser::parser::parse_expr($l.into())
-                .expect("static function definition failed to parse");
-        }
-        Operation::variadic(move |ecx, args| {
-            // Reconstruct an expression context where the parameter types are
-            // bound to the types of the expressions in `args`.
-            let mut scx = ecx.qcx.scx.clone();
-            scx.param_types = Rc::new(RefCell::new(
-                args.iter()
-                    .enumerate()
-                    .map(|(i, e)| (i + 1, ecx.scalar_type(e)))
-                    .collect(),
-            ));
-            let mut qcx = QueryContext::root(&scx, ecx.qcx.lifetime);
-
-            // Desugar the expression
-            let mut expr = EXPR.clone();
-            transform_ast::transform_expr(&scx, &mut expr)?;
-
-            let expr = query::resolve_names_expr(&mut qcx, expr)?;
-
-            let ecx = ExprContext {
-                qcx: &qcx,
-                name: "static function definition",
-                scope: &Scope::empty(None),
-                relation_type: &RelationType::empty(),
-                allow_aggregates: false,
-                allow_subqueries: true,
-            };
-
-            // Plan the expression.
-            let mut expr = query::plan_expr(&ecx, &expr)?.type_as_any(&ecx)?;
-
-            // Replace the parameters with the actual arguments.
-            expr.splice_parameters(&args, 0);
-
-            Ok(expr)
-        })
-    }};
+// of parameters in the built-in's declaration. There is no support for variadic
+// functions.
+fn sql_impl_func(expr: &'static str) -> Operation<HirScalarExpr> {
+    let invoke = sql_impl(expr);
+    Operation::variadic(move |ecx, args| {
+        let types = args.iter().map(|arg| ecx.scalar_type(arg)).collect();
+        let mut out = invoke(&ecx.qcx, types)?;
+        out.splice_parameters(&args, 0);
+        Ok(out)
+    })
 }
 
 /// Describes a single function's implementation.
@@ -780,6 +787,7 @@ impl From<ScalarBaseType> for ParamType {
             Jsonb => ScalarType::Jsonb,
             Uuid => ScalarType::Uuid,
             Oid => ScalarType::Oid,
+            RegProc => ScalarType::RegProc,
             Array | List | Record | Map => {
                 panic!("cannot convert ScalarBaseType::{:?} to ParamType", s)
             }
@@ -1297,7 +1305,7 @@ lazy_static! {
                 params!(Float64) => UnaryFunc::Cot, 1607;
             },
             "current_schema" => Scalar {
-                params!() => sql_op!("current_schemas(false)[1]"), 1402;
+                params!() => sql_impl_func("current_schemas(false)[1]"), 1402;
             },
             "current_schemas" => Scalar {
                 params!(Bool) => Operation::unary(|ecx, e| {
@@ -1343,7 +1351,7 @@ lazy_static! {
                 params!(Numeric) => UnaryFunc::FloorNumeric, 1712;
             },
             "format_type" => Scalar {
-                params!(Oid, Int32) => sql_op!(
+                params!(Oid, Int32) => sql_impl_func(
                     "CASE
                         WHEN $1 IS NULL THEN NULL
                         ELSE coalesce((SELECT concat(name, mz_internal.mz_render_typemod($1, $2)) FROM mz_catalog.mz_types WHERE oid = $1), '???')
@@ -1467,7 +1475,7 @@ lazy_static! {
             "pg_encoding_to_char" => Scalar {
                 // Materialize only supports UT8-encoded databases. Return 'UTF8' if Postgres'
                 // encoding id for UTF8 (6) is provided, otherwise return 'NULL'.
-                params!(Int64) => sql_op!("CASE WHEN $1 = 6 THEN 'UTF8' ELSE NULL END"), 1597;
+                params!(Int64) => sql_impl_func("CASE WHEN $1 = 6 THEN 'UTF8' ELSE NULL END"), 1597;
             },
             // pg_get_expr is meant to convert the textual version of
             // pg_node_tree data into parseable expressions. However, we don't
@@ -1485,13 +1493,13 @@ lazy_static! {
                 }, 2509;
             },
             "pg_get_userbyid" => Scalar {
-                params!(Oid) => sql_op!("'unknown (OID=' || $1 || ')'"), 1642;
+                params!(Oid) => sql_impl_func("'unknown (OID=' || $1 || ')'"), 1642;
             },
             "pg_postmaster_start_time" => Scalar {
                 params!() => Operation::nullary(pg_postmaster_start_time), 2560;
             },
             "pg_table_is_visible" => Scalar {
-                params!(Oid) => sql_op!(
+                params!(Oid) => sql_impl_func(
                     "(SELECT s.name = ANY(current_schemas(true))
                      FROM mz_catalog.mz_objects o JOIN mz_catalog.mz_schemas s ON o.schema_id = s.id
                      WHERE o.oid = $1)"
@@ -2067,7 +2075,7 @@ lazy_static! {
                 }), oid::FUNC_MZ_AVG_PROMOTION_I32_OID;
             },
             "mz_classify_object_id" => Scalar {
-                params!(String) => sql_op!(
+                params!(String) => sql_impl_func(
                     "CASE
                         WHEN $1 LIKE 'u%' THEN 'user'
                         WHEN $1 LIKE 's%' THEN 'system'
@@ -2076,7 +2084,7 @@ lazy_static! {
                 ), oid::FUNC_MZ_CLASSIFY_OBJECT_ID_OID;
             },
             "mz_is_materialized" => Scalar {
-                params!(String) => sql_op!("EXISTS (SELECT 1 FROM mz_indexes WHERE on_id = $1 AND enabled)"),
+                params!(String) => sql_impl_func("EXISTS (SELECT 1 FROM mz_indexes WHERE on_id = $1 AND enabled)"),
                     oid::FUNC_MZ_IS_MATERIALIZED_OID;
             },
             "mz_render_typemod" => Scalar {

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -3165,6 +3165,7 @@ pub fn scalar_type_from_pg(ty: &pgrepr::Type) -> Result<ScalarType, anyhow::Erro
             bail!("internal error: can't convert from pg record to materialize record")
         }
         pgrepr::Type::Oid => Ok(ScalarType::Oid),
+        pgrepr::Type::RegProc => Ok(ScalarType::RegProc),
         pgrepr::Type::Map { value_type } => Ok(ScalarType::Map {
             value_type: Box::new(scalar_type_from_pg(value_type)?),
             custom_oid: None,

--- a/test/sqllogictest/types.slt
+++ b/test/sqllogictest/types.slt
@@ -337,6 +337,23 @@ SELECT '1'::pg_catalog.oid
 ----
 1
 
+# 🔬🔬 regproc
+
+query T
+SELECT '1'::regproc
+----
+1
+
+query T
+SELECT '1'::pg_catalog.regproc
+----
+1
+
+query T
+SELECT 'array_in'::pg_catalog.regproc
+----
+1
+
 # 🔬🔬🔬 oid alias
 
 query T


### PR DESCRIPTION
@mjibson I pushed this a bit further. The `text -> regproc` cast totally works now, and I figured out how to lose the macros entirely.

Known TODOs:

  Text output format. I think the type of the regproc datum needs to be
  a tuple of (proname, oid) to support this, rather than just oid,
  because we can't go looking up the proname at the time we go to do the
  textual encoding.

Errors when a function has more than one entry:

```
benesch=> select 'max'::regproc;
ERROR:  more than one function named "max"
LINE 1: select 'max'::regproc;
````

  Cast from int to regproc. This one is easy.