### PR TITLE
interchange,testdrive: unfork serde-protobuf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1211,28 +1211,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030a733c8287d6213886dd487564ff5c8f6aae10278b3588ed177f9d18f8d231"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2025,9 +2003,9 @@ dependencies = [
 
 [[package]]
 name = "linked-hash-map"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "linked_hash_set"
@@ -3791,14 +3769,15 @@ dependencies = [
 
 [[package]]
 name = "serde-protobuf"
-version = "0.8.2-alpha.0"
-source = "git+https://github.com/MaterializeInc/serde-protobuf.git?branch=add-iter-messages#d7c4767e6bb0238562e88c782084e750175b575b"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "386e6493f9a732832e6b595ac2757a3c8c9285f4ab0c27313b7696b1712c32e4"
 dependencies = [
- "failure",
  "linked-hash-map",
  "log",
  "protobuf",
  "serde",
+ "thiserror",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -46,7 +46,6 @@ allow-git = [
     "https://github.com/MaterializeInc/rust-postgres.git",
     "https://github.com/MaterializeInc/rust-postgres-array.git",
     "https://github.com/MaterializeInc/rust-prometheus.git",
-    "https://github.com/MaterializeInc/serde-protobuf.git",
     "https://github.com/TimelyDataflow/timely-dataflow",
     "https://github.com/TimelyDataflow/differential-dataflow.git",
     "https://github.com/fede1024/rust-rdkafka.git",

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -31,7 +31,7 @@ ore = { path = "../ore" }
 protobuf = "2.23.0"
 repr = { path = "../repr" }
 serde = { version = "1.0.127", features = ["derive"] }
-serde-protobuf = { git = "https://github.com/MaterializeInc/serde-protobuf.git", branch = "add-iter-messages" }
+serde-protobuf = "0.8.2"
 serde-value = "0.7.0"
 serde_json = "1.0.66"
 sha2 = "0.9.5"

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -40,7 +40,7 @@ rusoto_s3 = "0.47.0"
 rusoto_sqs = "0.47.0"
 rusoto_sts = "0.47.0"
 serde = "1.0.127"
-serde-protobuf = { git = "https://github.com/MaterializeInc/serde-protobuf.git", branch = "add-iter-messages" }
+serde-protobuf = "0.8.2"
 serde_json = "1.0.66"
 sql-parser = { path = "../sql-parser" }
 structopt = "0.3.22"


### PR DESCRIPTION
We forked serde-protobuf library to add one method to improve an error
message.  Empirically we have not been keeping up with maintenance of
our fork, so it's time to ditch the fork.

This commit swaps our fork for the latest official serde-protobuf
release. I left a TODO to restore the error message improvement if the
patch [0] from our fork is accepted upstream.

Notably, this commit removes the last usage of failure from our
codebase.

[0]: https://github.com/dflemstr/serde-protobuf/pull/9