### PR TITLE
deny: fix merge skew around usage of thiserror

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -25,11 +25,13 @@ name = "strum-macros"
 [[bans.deny]]
 name = "thiserror"
 wrappers = [
+    # Only list third-party crates here.
     "pprof",
     "proc-macro-crate",
     "prometheus",
     "pubnub-core",
     "pubnub-hyper",
+    "serde-protobuf",
     "sysctl",
 ]
 


### PR DESCRIPTION
serde-protobuf is third party and therefore is permitted to use
thiserror.