### PR TITLE
Deny the `unimplemented!` macro, it is too similar to `unsupported!`

### DIFF
--- a/bin/check
+++ b/bin/check
@@ -72,12 +72,14 @@ extra_lints=(
     # `println!("{:?}", obj)` instead.
     clippy::dbg_macro
 
-    # Prevent code containing the `todo!` macro from being merged to the main
-    # branch.
+    # Prevent code containing the `todo!` or `unimplemented!` macros from being
+    # merged to the main branch. Both of these crash the program.
     #
-    # To mark something as intentionally unimplemented, use the `unimplemented!`
-    # macro instead.
+    # To mark a SQL feature as intentionally unimplemented, use the
+    # `unsupported!` macro which returns an error. Or if you must, just
+    # explicitly crash: `panic!("unimplemented and unreachable")`.
     clippy::todo
+    clippy::unimplemented
 
     # Wildcard dependencies are, by definition, incorrect. It is impossible
     # to be compatible with all future breaking changes in a crate.

--- a/src/kafka-util/src/bin/kgen.rs
+++ b/src/kafka-util/src/bin/kgen.rs
@@ -360,8 +360,8 @@ impl<'a> RandomAvroGenerator<'a> {
                 let dist = string_dist(len_dist_json, rng);
                 self.strings.insert(p, Box::new(dist));
             }
-            SchemaPiece::Json => unimplemented!(),
-            SchemaPiece::Uuid => unimplemented!(),
+            SchemaPiece::Json => panic!("not generatable"),
+            SchemaPiece::Uuid => panic!("not generatable"),
             SchemaPiece::Array(inner) => {
                 let fn_ = field_name.unwrap();
                 let len_dist_json = annotations.get(&format!("{}.len", fn_)).unwrap();
@@ -370,7 +370,7 @@ impl<'a> RandomAvroGenerator<'a> {
                 let item_fn = format!("{}[]", fn_);
                 self.new_inner(node.step(&**inner), annotations, Some(&item_fn))
             }
-            SchemaPiece::Map(_) => unimplemented!(),
+            SchemaPiece::Map(_) => panic!("not generatable"),
             SchemaPiece::Union(us) => {
                 let variant_jsons = dist_json.expect(&err).as_array().unwrap();
                 assert!(variant_jsons.len() == us.variants().len());
@@ -400,8 +400,8 @@ impl<'a> RandomAvroGenerator<'a> {
                 doc: _,
                 symbols: _,
                 default_idx: _,
-            } => unimplemented!(),
-            SchemaPiece::Fixed { size: _ } => unimplemented!(),
+            } => panic!("not generatable"),
+            SchemaPiece::Fixed { size: _ } => panic!("not generatable"),
             SchemaPiece::ResolveIntTsMilli
             | SchemaPiece::ResolveIntTsMicro
             | SchemaPiece::ResolveDateTimestamp

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -11,9 +11,9 @@
 
 //! Catalog abstraction layer.
 
+use std::error::Error;
 use std::fmt;
 use std::time::{Duration, Instant};
-use std::{error::Error, unimplemented};
 
 use chrono::{DateTime, Utc, MIN_DATETIME};
 use dataflow_types::SourceConnector;
@@ -392,7 +392,7 @@ impl Catalog for DummyCatalog {
     }
 
     fn resolve_database(&self, _: &str) -> Result<&dyn CatalogDatabase, CatalogError> {
-        unimplemented!();
+        panic!("unimplemented for tests");
     }
 
     fn resolve_schema(
@@ -400,38 +400,38 @@ impl Catalog for DummyCatalog {
         _: Option<String>,
         _: &str,
     ) -> Result<&dyn CatalogSchema, CatalogError> {
-        unimplemented!();
+        panic!("unimplemented for tests");
     }
 
     fn resolve_role(&self, _: &str) -> Result<&dyn CatalogRole, CatalogError> {
-        unimplemented!();
+        panic!("unimplemented for tests");
     }
 
     fn resolve_item(&self, _: &PartialName) -> Result<&dyn CatalogItem, CatalogError> {
-        unimplemented!();
+        panic!("unimplemented for tests");
     }
 
     fn resolve_function(&self, _: &PartialName) -> Result<&dyn CatalogItem, CatalogError> {
-        unimplemented!();
+        panic!("unimplemented for tests");
     }
 
     fn list_items<'a>(
         &'a self,
         _: &SchemaName,
     ) -> Box<dyn Iterator<Item = &'a dyn CatalogItem> + 'a> {
-        unimplemented!();
+        panic!("unimplemented for tests");
     }
 
     fn get_item_by_id(&self, _: &GlobalId) -> &dyn CatalogItem {
-        unimplemented!();
+        panic!("unimplemented for tests");
     }
 
     fn try_get_item_by_id(&self, _: &GlobalId) -> Option<&dyn CatalogItem> {
-        unimplemented!();
+        panic!("unimplemented for tests");
     }
 
     fn get_item_by_oid(&self, _: &u32) -> &dyn CatalogItem {
-        unimplemented!();
+        panic!("unimplemented for tests");
     }
 
     fn item_exists(&self, _: &FullName) -> bool {


### PR DESCRIPTION
`unimplemented!` has almost made it through code review in a place that
`unsupported` was intended at least once, despite 5 people performing code
review (#7507). The unimplemented macro is just shorthand around
`panic!("unimplemented");` so require that if folks really want to panic.