### PR TITLE
persist: do not merge! persistent simple sources

### DIFF
--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -189,6 +189,12 @@ where
                     (usize::cast_from(src_id.hashed()) % scope.peers()) == scope.index()
                 };
 
+                let name = format!("{}-{}", connector.name(), uid);
+                let persistence_token = if let Some(persist) = &render_state.persist {
+                    Some(persist.create_or_load(&name).expect("WIP"))
+                } else {
+                    None
+                };
                 let timestamp_histories = render_state
                     .ts_histories
                     .get(&orig_id)
@@ -210,6 +216,7 @@ where
                     encoding: encoding.clone(),
                     now,
                     base_metrics,
+                    persistence_token,
                 };
 
                 let (collection, capability) =


### PR DESCRIPTION
this is an extreme prototype level demonstration of persisted pubnub / sse sources that is meant only for discussion.

I chose to work with simple sources as opposed to regular sources first because they have the simplest ingestion pipeline (just a single timely source operator) and pubnub / sse sources because they are fully ephemeral and will never repeat the same data twice, which means we don't need to track things like "what offset did we persist up to, and what offset should we start reading from".

Immediate learnings from this experiment:

- we need a way to thread compaction information to this persisted data. Theres a bit of a conceptual mismatch here because "compactions" only apply to differential arrangements, whereas this persist operator applies to timely streams / differential collections. My sense is that we're going to want something more like a "persisted arrangement" so that we can drive around physical and logical compactions and give other readers access to a stream of persisted batches but no strong feelings yet.
