### PR TITLE
sql: rename unsupported to bail_unsupported

### DIFF
--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1681,7 +1681,7 @@ lazy_static! {
             "array_agg" => Aggregate {
                 params!(NonVecAny) => Operation::unary(|ecx, e| {
                     if let ScalarType::Char {.. }  = ecx.scalar_type(&e) {
-                        unsupported!("array_agg on char");
+                        bail_unsupported!("array_agg on char");
                     };
                     // ArrayConcat excepts all inputs to be arrays, so wrap all input datums into
                     // arrays.
@@ -1691,13 +1691,13 @@ lazy_static! {
                     };
                     Ok((e_arr, AggregateFunc::ArrayConcat))
                 }), 2335;
-                params!(ArrayAny) => Operation::unary(|_ecx, _e| unsupported!("array_agg on arrays")), 4053;
+                params!(ArrayAny) => Operation::unary(|_ecx, _e| bail_unsupported!("array_agg on arrays")), 4053;
             },
             "bool_and" => Aggregate {
-                params!(Any) => Operation::unary(|_ecx, _e| unsupported!("bool_and")), 2517;
+                params!(Any) => Operation::unary(|_ecx, _e| bail_unsupported!("bool_and")), 2517;
             },
             "bool_or" => Aggregate {
-                params!(Any) => Operation::unary(|_ecx, _e| unsupported!("bool_or")), 2518;
+                params!(Any) => Operation::unary(|_ecx, _e| bail_unsupported!("bool_or")), 2518;
             },
             "count" => Aggregate {
                 params!() => Operation::nullary(|_ecx| {
@@ -1737,7 +1737,7 @@ lazy_static! {
                 params!(Numeric) => AggregateFunc::MinNumeric, oid::FUNC_MIN_NUMERIC_OID;
             },
             "json_agg" => Aggregate {
-                params!(Any) => Operation::unary(|_ecx, _e| unsupported!("json_agg")), 3175;
+                params!(Any) => Operation::unary(|_ecx, _e| bail_unsupported!("json_agg")), 3175;
             },
             "jsonb_agg" => Aggregate {
                 params!(Any) => Operation::unary(|ecx, e| {
@@ -1792,7 +1792,7 @@ lazy_static! {
                     };
                     Ok((e, AggregateFunc::StringAgg))
                 }), 3538;
-                params!(Bytes, Bytes) => Operation::binary(|_ecx, _l, _r| unsupported!("string_agg")), 3545;
+                params!(Bytes, Bytes) => Operation::binary(|_ecx, _l, _r| bail_unsupported!("string_agg")), 3545;
             },
             "sum" => Aggregate {
                 params!(Int16) => AggregateFunc::SumInt32, 2109;
@@ -1806,7 +1806,7 @@ lazy_static! {
                     // prevents `sum(NULL)` from choosing the `Float64`
                     // implementation, so that we match PostgreSQL's behavior.
                     // Plus we will one day want to support this overload.
-                    unsupported!("sum(interval)");
+                    bail_unsupported!("sum(interval)");
                 }), 2113;
             },
 
@@ -1920,7 +1920,7 @@ lazy_static! {
                 }), oid::FUNC_CSV_EXTRACT_OID;
             },
             "concat_agg" => Aggregate {
-                params!(Any) => Operation::unary(|_ecx, _e| unsupported!("concat_agg")), oid::FUNC_CONCAT_AGG_OID;
+                params!(Any) => Operation::unary(|_ecx, _e| bail_unsupported!("concat_agg")), oid::FUNC_CONCAT_AGG_OID;
             },
             "current_timestamp" => Scalar {
                 params!() => Operation::nullary(|ecx| plan_current_timestamp(ecx, "current_timestamp")), oid::FUNC_CURRENT_TIMESTAMP_OID;
@@ -1928,7 +1928,7 @@ lazy_static! {
             "list_agg" => Aggregate {
                 params!(Any) => Operation::unary(|ecx, e| {
                     if let ScalarType::Char {.. }  = ecx.scalar_type(&e) {
-                        unsupported!("list_agg on char");
+                        bail_unsupported!("list_agg on char");
                     };
                     // ListConcat excepts all inputs to be lists, so wrap all input datums into
                     // lists.
@@ -2607,6 +2607,6 @@ pub fn resolve_op(op: &str) -> Result<&'static [FuncImpl<HirScalarExpr>], anyhow
         // JsonDeletePath
         // JsonContainsPath
         // JsonApplyPathPredicate
-        None => unsupported!(op),
+        None => bail_unsupported!(op),
     }
 }

--- a/src/sql/src/lib.rs
+++ b/src/sql/src/lib.rs
@@ -65,7 +65,7 @@
 
 #![warn(missing_debug_implementations)]
 
-macro_rules! unsupported {
+macro_rules! bail_unsupported {
     ($feature:expr) => {
         return Err(crate::plan::error::PlanError::Unsupported {
             feature: $feature.to_string(),

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -914,7 +914,7 @@ fn plan_query(
         Some(Limit {
             quantity: _,
             with_ties: true,
-        }) => unsupported!("FETCH ... WITH TIES"),
+        }) => bail_unsupported!("FETCH ... WITH TIES"),
         Some(Limit {
             quantity: _,
             with_ties: _,
@@ -1692,7 +1692,7 @@ fn plan_table_with_joins<'a>(
                 JoinOperator::FullOuter(..) | JoinOperator::RightOuter(..)
             )
         {
-            unsupported!(6875, "full/right outer joins in comma join");
+            bail_unsupported!(6875, "full/right outer joins in comma join");
         }
         let (new_left, new_left_scope) =
             plan_table_factor(qcx, left, left_scope, &join.join_operator, &join.relation)?;
@@ -2542,7 +2542,7 @@ pub fn plan_expr<'a>(
             expr.select().into()
         }
 
-        Expr::Collate { .. } => unsupported!("COLLATE"),
+        Expr::Collate { .. } => bail_unsupported!("COLLATE"),
         Expr::Nested(_) => unreachable!("Expr::Nested not desugared"),
         Expr::InList { .. } => unreachable!("Expr::InList not desugared"),
         Expr::InSubquery { .. } => unreachable!("Expr::InSubquery not desugared"),
@@ -2601,7 +2601,7 @@ fn plan_array(
     };
 
     if matches!(elem_type, ScalarType::Char { .. }) {
-        unsupported!("char[]");
+        bail_unsupported!("char[]");
     }
 
     Ok(HirScalarExpr::CallVariadic {
@@ -2642,7 +2642,7 @@ fn plan_list(
     };
 
     if matches!(elem_type, ScalarType::Char { .. }) {
-        unsupported!("char list");
+        bail_unsupported!("char list");
     }
 
     Ok(HirScalarExpr::CallVariadic {
@@ -2705,7 +2705,7 @@ fn plan_aggregate(
     };
 
     if sql_func.over.is_some() {
-        unsupported!(213, "window functions");
+        bail_unsupported!(213, "window functions");
     }
 
     let name = normalize::unresolved_object_name(sql_func.name.clone())?;
@@ -2758,7 +2758,7 @@ fn plan_aggregate(
         }
     });
     if seen_outer && !seen_inner {
-        unsupported!(
+        bail_unsupported!(
             3720,
             "aggregate functions that refer exclusively to outer columns"
         );
@@ -2865,7 +2865,7 @@ fn plan_function<'a>(
             bail!("aggregate functions are not allowed in {}", ecx.name);
         }
         Func::Table(_) => {
-            unsupported!(
+            bail_unsupported!(
                 1546,
                 format!("table function ({}) in scalar position", name)
             );
@@ -2874,7 +2874,7 @@ fn plan_function<'a>(
     };
 
     if over.is_some() {
-        unsupported!(213, "window functions");
+        bail_unsupported!(213, "window functions");
     }
     if *distinct {
         bail!(
@@ -3006,7 +3006,7 @@ fn plan_literal<'a>(l: &'a Value) -> Result<CoercibleScalarExpr, anyhow::Error> 
                 (Datum::Numeric(d), ScalarType::Numeric { scale: None })
             }
         }
-        Value::HexString(_) => unsupported!(3114, "hex string literals"),
+        Value::HexString(_) => bail_unsupported!(3114, "hex string literals"),
         Value::Boolean(b) => match b {
             false => (Datum::False, ScalarType::Bool),
             true => (Datum::True, ScalarType::Bool),

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -73,7 +73,7 @@ pub fn describe_update(
     _: &StatementContext,
     _: UpdateStatement<Raw>,
 ) -> Result<StatementDesc, anyhow::Error> {
-    unsupported!("UPDATE statements")
+    bail_unsupported!("UPDATE statements")
 }
 
 pub fn plan_update(
@@ -81,14 +81,14 @@ pub fn plan_update(
     _: UpdateStatement<Raw>,
     _: &Params,
 ) -> Result<Plan, anyhow::Error> {
-    unsupported!("UPDATE statements")
+    bail_unsupported!("UPDATE statements")
 }
 
 pub fn describe_delete(
     _: &StatementContext,
     _: DeleteStatement<Raw>,
 ) -> Result<StatementDesc, anyhow::Error> {
-    unsupported!("DELETE statements")
+    bail_unsupported!("DELETE statements")
 }
 
 pub fn plan_delete(
@@ -96,7 +96,7 @@ pub fn plan_delete(
     _: DeleteStatement<Raw>,
     _: &Params,
 ) -> Result<Plan, anyhow::Error> {
-    unsupported!("DELETE statements")
+    bail_unsupported!("DELETE statements")
 }
 
 pub fn describe_select(

--- a/src/sql/src/plan/statement/scl.rs
+++ b/src/sql/src/plan/statement/scl.rs
@@ -45,7 +45,7 @@ pub fn plan_set_variable(
     }: SetVariableStatement,
 ) -> Result<Plan, anyhow::Error> {
     if local {
-        unsupported!("SET LOCAL");
+        bail_unsupported!("SET LOCAL");
     }
     Ok(Plan::SetVariable(SetVariablePlan {
         name: variable.to_string(),
@@ -100,8 +100,8 @@ pub fn plan_discard(
     match target {
         DiscardTarget::All => Ok(Plan::DiscardAll),
         DiscardTarget::Temp => Ok(Plan::DiscardTemp),
-        DiscardTarget::Sequences => unsupported!("DISCARD SEQUENCES"),
-        DiscardTarget::Plans => unsupported!("DISCARD PLANS"),
+        DiscardTarget::Sequences => bail_unsupported!("DISCARD SEQUENCES"),
+        DiscardTarget::Plans => bail_unsupported!("DISCARD PLANS"),
     }
 }
 

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -229,7 +229,7 @@ pub fn show_objects<'a>(
         ObjectType::Sink => show_sinks(scx, full, from, filter),
         ObjectType::Type => show_types(scx, extended, full, from, filter),
         ObjectType::Object => show_all_objects(scx, extended, full, from, filter),
-        ObjectType::Role => unsupported!("SHOW ROLES"),
+        ObjectType::Role => bail_unsupported!("SHOW ROLES"),
         ObjectType::Index => unreachable!("SHOW INDEX handled separately"),
     }
 }
@@ -512,7 +512,7 @@ pub fn show_indexes<'a>(
     }: ShowIndexesStatement<Raw>,
 ) -> Result<ShowSelect<'a>, anyhow::Error> {
     if extended {
-        unsupported!("SHOW EXTENDED INDEXES")
+        bail_unsupported!("SHOW EXTENDED INDEXES")
     }
     let from = scx.resolve_item(table_name)?;
     if from.item_type() != CatalogItemType::View
@@ -558,10 +558,10 @@ pub fn show_columns<'a>(
     }: ShowColumnsStatement<Raw>,
 ) -> Result<ShowSelect<'a>, anyhow::Error> {
     if extended {
-        unsupported!("SHOW EXTENDED COLUMNS");
+        bail_unsupported!("SHOW EXTENDED COLUMNS");
     }
     if full {
-        unsupported!("SHOW FULL COLUMNS");
+        bail_unsupported!("SHOW FULL COLUMNS");
     }
 
     let entry = scx.resolve_item(table_name)?;

--- a/src/sql/src/plan/statement/tcl.rs
+++ b/src/sql/src/plan/statement/tcl.rs
@@ -36,14 +36,14 @@ pub fn describe_set_transaction(
     _: &StatementContext,
     _: SetTransactionStatement,
 ) -> Result<StatementDesc, anyhow::Error> {
-    unsupported!("SET TRANSACTION")
+    bail_unsupported!("SET TRANSACTION")
 }
 
 pub fn plan_set_transaction(
     _: &StatementContext,
     _: SetTransactionStatement,
 ) -> Result<Plan, anyhow::Error> {
-    unsupported!("SET TRANSACTION")
+    bail_unsupported!("SET TRANSACTION")
 }
 
 pub fn describe_rollback(


### PR DESCRIPTION
The intent is to make it clearer that this macro returns an error, like
bail, rather than panics, like unimplemented.

h/t @umanwizard