### PR TITLE
sql: initial support for regproc

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -877,6 +877,9 @@ impl Catalog {
             for (_item_name, item_id) in &schema.items {
                 builtin_table_updates.extend(catalog.pack_item_update(*item_id, 1));
             }
+            for (_item_name, function_id) in &schema.functions {
+                builtin_table_updates.extend(catalog.pack_item_update(*function_id, 1));
+            }
         }
         for (db_name, db) in &catalog.by_name {
             builtin_table_updates.push(catalog.pack_database_update(db_name, 1));
@@ -885,6 +888,9 @@ impl Catalog {
                 builtin_table_updates.push(catalog.pack_schema_update(&db_spec, schema_name, 1));
                 for (_item_name, item_id) in &schema.items {
                     builtin_table_updates.extend(catalog.pack_item_update(*item_id, 1));
+                }
+                for (_item_name, function_id) in &schema.functions {
+                    builtin_table_updates.extend(catalog.pack_item_update(*function_id, 1));
                 }
             }
         }

--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -1271,9 +1271,9 @@ pub const PG_PROC: BuiltinView = BuiltinView {
     name: "pg_proc",
     schema: PG_CATALOG_SCHEMA,
     sql: "CREATE VIEW pg_proc AS SELECT
-    NULL::pg_catalog.oid AS oid,
-    NULL::pg_catalog.text AS proname
-    WHERE false",
+    oid,
+    name AS proname
+FROM mz_catalog.mz_functions",
     id: GlobalId::System(5021),
     needs_logs: false,
 };

--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -441,6 +441,18 @@ pub const TYPE_BPCHAR_ARRAY: BuiltinType = BuiltinType {
     pgtype: &postgres_types::Type::BPCHAR_ARRAY,
 };
 
+pub const TYPE_REGPROC: BuiltinType = BuiltinType {
+    schema: PG_CATALOG_SCHEMA,
+    id: GlobalId::System(1046),
+    pgtype: &postgres_types::Type::REGPROC,
+};
+
+pub const TYPE_REGPROC_ARRAY: BuiltinType = BuiltinType {
+    schema: PG_CATALOG_SCHEMA,
+    id: GlobalId::System(1047),
+    pgtype: &postgres_types::Type::REGPROC_ARRAY,
+};
+
 lazy_static! {
     pub static ref TYPE_LIST: BuiltinType = BuiltinType {
         schema: PG_CATALOG_SCHEMA,
@@ -1344,6 +1356,8 @@ lazy_static! {
             Builtin::Type(&TYPE_OID_ARRAY),
             Builtin::Type(&TYPE_RECORD),
             Builtin::Type(&TYPE_RECORD_ARRAY),
+            Builtin::Type(&TYPE_REGPROC),
+            Builtin::Type(&TYPE_REGPROC_ARRAY),
             Builtin::Type(&TYPE_INT2),
             Builtin::Type(&TYPE_INT2_ARRAY),
             Builtin::Type(&TYPE_TEXT),

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -4044,7 +4044,7 @@ impl UnaryFunc {
 
             CastInt32ToOid => ScalarType::Oid.nullable(nullable),
             CastInt32ToRegProc => ScalarType::RegProc.nullable(nullable),
-            CastOidToInt32 => ScalarType::Oid.nullable(nullable),
+            CastOidToInt32 => ScalarType::Int32.nullable(nullable),
             CastRegProcToOid => ScalarType::Oid.nullable(nullable),
             CastOidToRegProc => ScalarType::RegProc.nullable(nullable),
 

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -3556,10 +3556,13 @@ pub enum UnaryFunc {
     CastInt32ToFloat32,
     CastInt32ToFloat64,
     CastInt32ToOid,
+    CastInt32ToRegProc,
     CastInt32ToInt16,
     CastInt32ToInt64,
     CastInt32ToString,
     CastOidToInt32,
+    CastOidToRegProc,
+    CastRegProcToOid,
     CastInt64ToInt16,
     CastInt64ToInt32,
     CastInt16ToNumeric(Option<u8>),
@@ -3788,9 +3791,12 @@ impl UnaryFunc {
             UnaryFunc::CastInt32ToInt16 => cast_int32_to_int16(a),
             UnaryFunc::CastInt32ToInt64 => Ok(cast_int32_to_int64(a)),
             UnaryFunc::CastInt32ToOid => Ok(a),
+            UnaryFunc::CastInt32ToRegProc => Ok(a),
             UnaryFunc::CastInt32ToNumeric(scale) => cast_int32_to_numeric(a, *scale),
             UnaryFunc::CastInt32ToString => Ok(cast_int32_to_string(a, temp_storage)),
             UnaryFunc::CastOidToInt32 => Ok(a),
+            UnaryFunc::CastRegProcToOid => Ok(a),
+            UnaryFunc::CastOidToRegProc => Ok(a),
             UnaryFunc::CastInt64ToInt16 => cast_int64_to_int16(a),
             UnaryFunc::CastInt64ToInt32 => cast_int64_to_int32(a),
             UnaryFunc::CastInt64ToBool => Ok(cast_int64_to_bool(a)),
@@ -4037,7 +4043,10 @@ impl UnaryFunc {
             | CastJsonbToNumeric(scale) => ScalarType::Numeric { scale: *scale }.nullable(nullable),
 
             CastInt32ToOid => ScalarType::Oid.nullable(nullable),
+            CastInt32ToRegProc => ScalarType::RegProc.nullable(nullable),
             CastOidToInt32 => ScalarType::Oid.nullable(nullable),
+            CastRegProcToOid => ScalarType::Oid.nullable(nullable),
+            CastOidToRegProc => ScalarType::RegProc.nullable(nullable),
 
             CastStringToDate | CastTimestampToDate | CastTimestampTzToDate => {
                 ScalarType::Date.nullable(nullable)
@@ -4217,7 +4226,8 @@ impl UnaryFunc {
             | CastFloat32ToNumeric(_)
             | CastFloat64ToNumeric(_)
             | CastJsonbToNumeric(_) => false,
-            CastInt32ToOid | CastOidToInt32 => false,
+            CastInt32ToOid | CastOidToInt32 | CastInt32ToRegProc | CastRegProcToOid
+            | CastOidToRegProc => false,
             CastStringToDate | CastTimestampToDate | CastTimestampTzToDate => false,
             CastStringToTime | CastIntervalToTime | TimezoneTime { .. } => false,
             CastStringToTimestamp
@@ -4322,9 +4332,12 @@ impl fmt::Display for UnaryFunc {
             UnaryFunc::CastInt32ToInt16 => f.write_str("i32toi16"),
             UnaryFunc::CastInt32ToInt64 => f.write_str("i32toi64"),
             UnaryFunc::CastInt32ToOid => f.write_str("i32tooid"),
+            UnaryFunc::CastInt32ToRegProc => f.write_str("i32toregproc"),
             UnaryFunc::CastInt32ToString => f.write_str("i32tostr"),
             UnaryFunc::CastInt32ToNumeric(..) => f.write_str("i32tonumeric"),
             UnaryFunc::CastOidToInt32 => f.write_str("oidtoi32"),
+            UnaryFunc::CastRegProcToOid => f.write_str("regproctooid"),
+            UnaryFunc::CastOidToRegProc => f.write_str("oidtoregproc"),
             UnaryFunc::CastInt64ToInt16 => f.write_str("i64toi16"),
             UnaryFunc::CastInt64ToInt32 => f.write_str("i64toi32"),
             UnaryFunc::CastInt64ToBool => f.write_str("i64tobool"),
@@ -4955,7 +4968,7 @@ where
     match &ty {
         Bool => strconv::format_bool(buf, d.unwrap_bool()),
         Int16 => strconv::format_int16(buf, d.unwrap_int16()),
-        Int32 | Oid => strconv::format_int32(buf, d.unwrap_int32()),
+        Int32 | Oid | RegProc => strconv::format_int32(buf, d.unwrap_int32()),
         Int64 => strconv::format_int64(buf, d.unwrap_int64()),
         Float32 => strconv::format_float32(buf, d.unwrap_float32()),
         Float64 => strconv::format_float64(buf, d.unwrap_float64()),

--- a/src/interchange/src/avro/encode.rs
+++ b/src/interchange/src/avro/encode.rs
@@ -289,7 +289,9 @@ impl<'a> mz_avro::types::ToAvro for TypedDatum<'a> {
             let mut val = match &typ.scalar_type {
                 ScalarType::Bool => Value::Boolean(datum.unwrap_bool()),
                 ScalarType::Int16 => Value::Int(i32::from(datum.unwrap_int16())),
-                ScalarType::Int32 | ScalarType::Oid => Value::Int(datum.unwrap_int32()),
+                ScalarType::Int32 | ScalarType::Oid | ScalarType::RegProc => {
+                    Value::Int(datum.unwrap_int32())
+                }
                 ScalarType::Int64 => Value::Long(datum.unwrap_int64()),
                 ScalarType::Float32 => Value::Float(datum.unwrap_float32()),
                 ScalarType::Float64 => Value::Double(datum.unwrap_float64()),

--- a/src/interchange/src/json.rs
+++ b/src/interchange/src/json.rs
@@ -132,7 +132,9 @@ impl<'a> ToJson for TypedDatum<'_> {
             match &typ.scalar_type {
                 ScalarType::Bool => json!(datum.unwrap_bool()),
                 ScalarType::Int16 => json!(datum.unwrap_int16()),
-                ScalarType::Int32 | ScalarType::Oid => json!(datum.unwrap_int32()),
+                ScalarType::Int32 | ScalarType::Oid | ScalarType::RegProc => {
+                    json!(datum.unwrap_int32())
+                }
                 ScalarType::Int64 => json!(datum.unwrap_int64()),
                 ScalarType::Float32 => json!(datum.unwrap_float32()),
                 ScalarType::Float64 => json!(datum.unwrap_float64()),
@@ -239,7 +241,9 @@ fn build_row_schema_field<F: FnMut() -> String>(
 ) -> serde_json::value::Value {
     let mut field_type = match &typ.scalar_type {
         ScalarType::Bool => json!("boolean"),
-        ScalarType::Int16 | ScalarType::Int32 | ScalarType::Oid => json!("int"),
+        ScalarType::Int16 | ScalarType::Int32 | ScalarType::Oid | ScalarType::RegProc => {
+            json!("int")
+        }
         ScalarType::Int64 => json!("long"),
         ScalarType::Float32 => json!("float"),
         ScalarType::Float64 => json!("double"),

--- a/src/pgrepr/src/oid.rs
+++ b/src/pgrepr/src/oid.rs
@@ -69,4 +69,5 @@ pub const FUNC_MAX_NUMERIC_OID: u32 = 16_441;
 pub const FUNC_MIN_NUMERIC_OID: u32 = 16_442;
 pub const FUNC_MZ_AVG_PROMOTION_I16_OID: u32 = 16_443;
 pub const FUNC_LIST_AGG_OID: u32 = 16_444;
-// next ID: 16_445
+pub const FUNC_MZ_ERROR_IF_NULL_OID: u32 = 16_445;
+// next ID: 16_446

--- a/src/pgrepr/src/types.rs
+++ b/src/pgrepr/src/types.rs
@@ -63,6 +63,8 @@ pub enum Type {
     TimestampTz,
     /// A universally unique identifier.
     Uuid,
+    /// A function name.
+    RegProc,
 }
 
 lazy_static! {
@@ -112,6 +114,7 @@ impl Type {
             postgres_types::Type::TIMESTAMP => Some(Type::Timestamp),
             postgres_types::Type::TIMESTAMPTZ => Some(Type::TimestampTz),
             postgres_types::Type::UUID => Some(Type::Uuid),
+            postgres_types::Type::REGPROC => Some(Type::RegProc),
             _ => None,
         }
     }
@@ -142,6 +145,7 @@ impl Type {
                 Type::Timestamp => &postgres_types::Type::TIMESTAMP_ARRAY,
                 Type::TimestampTz => &postgres_types::Type::TIMESTAMPTZ_ARRAY,
                 Type::Uuid => &postgres_types::Type::UUID_ARRAY,
+                Type::RegProc => &postgres_types::Type::REGPROC_ARRAY,
             },
             Type::Bool => &postgres_types::Type::BOOL,
             Type::Bytea => &postgres_types::Type::BYTEA,
@@ -165,6 +169,7 @@ impl Type {
             Type::Timestamp => &postgres_types::Type::TIMESTAMP,
             Type::TimestampTz => &postgres_types::Type::TIMESTAMPTZ,
             Type::Uuid => &postgres_types::Type::UUID,
+            Type::RegProc => &postgres_types::Type::REGPROC,
         }
     }
 
@@ -201,6 +206,7 @@ impl Type {
             &postgres_types::Type::INT8 => "bigint",
             &postgres_types::Type::TIMESTAMPTZ => "timestamp with time zone",
             &postgres_types::Type::VARCHAR => "character varying",
+            &postgres_types::Type::REGPROC_ARRAY => "regproc[]",
             other => other.name(),
         }
     }
@@ -239,6 +245,7 @@ impl Type {
             Type::Timestamp => 8,
             Type::TimestampTz => 8,
             Type::Uuid => 16,
+            Type::RegProc => 4,
         }
     }
 
@@ -282,6 +289,7 @@ impl Type {
             Type::Timestamp => ScalarType::Timestamp,
             Type::TimestampTz => ScalarType::TimestampTz,
             Type::Uuid => ScalarType::Uuid,
+            Type::RegProc => ScalarType::RegProc,
         }
     }
 }
@@ -321,6 +329,7 @@ impl From<&ScalarType> for Type {
             ScalarType::TimestampTz => Type::TimestampTz,
             ScalarType::Uuid => Type::Uuid,
             ScalarType::Numeric { .. } => Type::Numeric,
+            ScalarType::RegProc => Type::RegProc,
         }
     }
 }

--- a/src/pgrepr/src/value.rs
+++ b/src/pgrepr/src/value.rs
@@ -105,6 +105,7 @@ impl Value {
             (Datum::Int16(i), ScalarType::Int16) => Some(Value::Int2(i)),
             (Datum::Int32(i), ScalarType::Int32) => Some(Value::Int4(i)),
             (Datum::Int32(i), ScalarType::Oid) => Some(Value::Int4(i)),
+            (Datum::Int32(i), ScalarType::RegProc) => Some(Value::Int4(i)),
             (Datum::Int64(i), ScalarType::Int64) => Some(Value::Int8(i)),
             (Datum::Float32(f), ScalarType::Float32) => Some(Value::Float4(*f)),
             (Datum::Float64(f), ScalarType::Float64) => Some(Value::Float8(*f)),
@@ -446,7 +447,7 @@ impl Value {
             Type::Float4 => Value::Float4(strconv::parse_float32(raw)?),
             Type::Float8 => Value::Float8(strconv::parse_float64(raw)?),
             Type::Int2 => Value::Int2(strconv::parse_int16(raw)?),
-            Type::Int4 | Type::Oid => Value::Int4(strconv::parse_int32(raw)?),
+            Type::Int4 | Type::Oid | Type::RegProc => Value::Int4(strconv::parse_int32(raw)?),
             Type::Int8 => Value::Int8(strconv::parse_int64(raw)?),
             Type::Interval => Value::Interval(Interval(strconv::parse_interval(raw)?)),
             Type::Jsonb => Value::Jsonb(Jsonb(strconv::parse_jsonb(raw)?)),
@@ -494,7 +495,9 @@ impl Value {
             Type::Float4 => f32::from_sql(ty.inner(), raw).map(Value::Float4),
             Type::Float8 => f64::from_sql(ty.inner(), raw).map(Value::Float8),
             Type::Int2 => i16::from_sql(ty.inner(), raw).map(Value::Int2),
-            Type::Int4 | Type::Oid => i32::from_sql(ty.inner(), raw).map(Value::Int4),
+            Type::Int4 | Type::Oid | Type::RegProc => {
+                i32::from_sql(ty.inner(), raw).map(Value::Int4)
+            }
             Type::Int8 => i64::from_sql(ty.inner(), raw).map(Value::Int8),
             Type::Interval => Interval::from_sql(ty.inner(), raw).map(Value::Interval),
             Type::Jsonb => Jsonb::from_sql(ty.inner(), raw).map(Value::Jsonb),
@@ -600,6 +603,7 @@ pub fn null_datum(ty: &Type) -> (Datum<'static>, ScalarType) {
                 custom_oid: None,
             }
         }
+        Type::RegProc => ScalarType::RegProc,
     };
     (Datum::Null, ty)
 }

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -394,6 +394,7 @@ impl<'a> Datum<'a> {
                     (Datum::Int16(_), _) => false,
                     (Datum::Int32(_), ScalarType::Int32) => true,
                     (Datum::Int32(_), ScalarType::Oid) => true,
+                    (Datum::Int32(_), ScalarType::RegProc) => true,
                     (Datum::Int32(_), _) => false,
                     (Datum::Int64(_), ScalarType::Int64) => true,
                     (Datum::Int64(_), _) => false,
@@ -782,6 +783,8 @@ pub enum ScalarType {
         value_type: Box<ScalarType>,
         custom_oid: Option<u32>,
     },
+    /// A PostgreSQL function name.
+    RegProc,
 }
 
 impl<'a> ScalarType {

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -2081,6 +2081,11 @@ lazy_static! {
                     END"
                 ), oid::FUNC_MZ_CLASSIFY_OBJECT_ID_OID;
             },
+            "mz_error_if_null" => Scalar {
+                // If the first argument is NULL, returns an EvalError::Internal whose error
+                // message is the second argument.
+                params!(Any, String) => VariadicFunc::ErrorIfNull, oid::FUNC_MZ_ERROR_IF_NULL_OID;
+            },
             "mz_is_materialized" => Scalar {
                 params!(String) => sql_impl_func("EXISTS (SELECT 1 FROM mz_indexes WHERE on_id = $1 AND enabled)"),
                     oid::FUNC_MZ_IS_MATERIALIZED_OID;

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -100,6 +100,7 @@ impl TypeCategory {
             | ScalarType::Int32
             | ScalarType::Int64
             | ScalarType::Oid
+            | ScalarType::RegProc
             | ScalarType::Numeric { .. } => Self::Numeric,
             ScalarType::Interval => Self::Timespan,
             ScalarType::List { .. } => Self::List,
@@ -786,6 +787,7 @@ impl From<ScalarBaseType> for ParamType {
             Jsonb => ScalarType::Jsonb,
             Uuid => ScalarType::Uuid,
             Oid => ScalarType::Oid,
+            RegProc => ScalarType::RegProc,
             Array | List | Record | Map => {
                 panic!("cannot convert ScalarBaseType::{:?} to ParamType", s)
             }

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -3165,6 +3165,7 @@ pub fn scalar_type_from_pg(ty: &pgrepr::Type) -> Result<ScalarType, anyhow::Erro
             bail!("internal error: can't convert from pg record to materialize record")
         }
         pgrepr::Type::Oid => Ok(ScalarType::Oid),
+        pgrepr::Type::RegProc => Ok(ScalarType::RegProc),
         pgrepr::Type::Map { value_type } => Ok(ScalarType::Map {
             value_type: Box::new(scalar_type_from_pg(value_type)?),
             custom_oid: None,

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -25,6 +25,19 @@ use repr::{ColumnName, ColumnType, Datum, RelationType, ScalarBaseType, ScalarTy
 use super::expr::{CoercibleScalarExpr, ColumnRef, HirScalarExpr, UnaryFunc};
 use super::query::{ExprContext, QueryContext};
 use super::scope::Scope;
+use crate::func;
+
+/// Like func::sql_impl_func, but for casts.
+fn sql_impl_cast(expr: &'static str) -> CastTemplate {
+    let invoke = func::sql_impl(expr);
+    CastTemplate::new(move |ecx, _ccx, from_type, _to_type| {
+        let mut out = invoke(&ecx.qcx, vec![from_type.clone()]).ok()?;
+        Some(move |e| {
+            out.splice_parameters(&[e], 0);
+            out
+        })
+    })
+}
 
 /// A cast is a function that takes a `ScalarExpr` to another `ScalarExpr`.
 type Cast = Box<dyn FnOnce(HirScalarExpr) -> HirScalarExpr>;
@@ -130,6 +143,7 @@ lazy_static! {
             //INT32
             (Int32, Bool) => Explicit: CastInt32ToBool,
             (Int32, Oid) => Implicit: CastInt32ToOid,
+            (Int32, RegProc) => Implicit: CastInt32ToRegProc,
             (Int32, Int16) => Assignment: CastInt32ToInt16,
             (Int32, Int64) => Implicit: CastInt32ToInt64,
             (Int32, Float32) => Implicit: CastInt32ToFloat32,
@@ -155,6 +169,10 @@ lazy_static! {
             // OID
             (Oid, Int32) => Assignment: CastOidToInt32,
             (Oid, String) => Explicit: CastInt32ToString,
+            (Oid, RegProc) => Assignment: CastOidToRegProc,
+
+            // REGPROC
+            (RegProc,Oid) => Assignment: CastRegProcToOid,
 
             // FLOAT32
             (Float32, Int16) => Assignment: CastFloat32ToInt16,
@@ -210,6 +228,29 @@ lazy_static! {
             (String, Int32) => Explicit: CastStringToInt32,
             (String, Int64) => Explicit: CastStringToInt64,
             (String, Oid) => Explicit: CastStringToInt32,
+            // A regproc represents a function by oid. Converting from string to regproc
+            // does a lookup of the function name and expects exactly one function to
+            // match it. You can also specify (in postgres) a string that's a valid
+            // int4 and it'll happily cast it (without verifying that the int4 matches
+            // a function oid). To support this, use a SQL expression that checks if
+            // the input might be a valid int4 with a regex, otherwise try to lookup in
+            // mz_functions. CASE will return NULL if the subquery returns zero results,
+            // so use mz_error_if_null to coerce that into an error. This is hacky and
+            // incomplete in a few ways, but gets us close enough to making drivers happy.
+            // TODO: Support the correct error code for does not exist (42883).
+            (String, RegProc) => Explicit: sql_impl_cast("(
+                SELECT
+                    CASE
+                    WHEN $1 ~ '^\\d+$' THEN $1::oid::pg_catalog.regproc
+                    ELSE (
+                        mz_internal.mz_error_if_null(
+                            (SELECT oid::pg_catalog.regproc FROM mz_catalog.mz_functions WHERE name = $1),
+                            'function \"' || $1 || '\" does not exist'
+                        )
+                    )
+                    END
+            )"),
+
             (String, Float32) => Explicit: CastStringToFloat32,
             (String, Float64) => Explicit: CastStringToFloat64,
             (String, Numeric) => Explicit: CastTemplate::new(|_ecx, _ccx, _from_type, to_type| {

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -313,6 +313,7 @@ impl<'a> FromSql<'a> for Slt {
             PgType::JSONB => Self(Value::Jsonb(Jsonb::from_sql(ty, raw)?)),
             PgType::NUMERIC => Self(Value::Numeric(Numeric::from_sql(ty, raw)?)),
             PgType::OID => Self(Value::Int4(types::oid_from_sql(raw)? as i32)),
+            PgType::REGPROC => Self(Value::Int4(types::oid_from_sql(raw)? as i32)),
             PgType::TEXT | PgType::BPCHAR | PgType::VARCHAR => {
                 Self(Value::Text(types::text_from_sql(raw)?.to_string()))
             }
@@ -385,6 +386,7 @@ impl<'a> FromSql<'a> for Slt {
                 | PgType::JSONB
                 | PgType::NUMERIC
                 | PgType::OID
+                | PgType::REGPROC
                 | PgType::RECORD
                 | PgType::TEXT
                 | PgType::BPCHAR

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -1110,3 +1110,11 @@ SELECT a, b, mz_row_size(col_size.*) FROM col_size ORDER BY a
 ----
 1  2  77
 NULL  NULL  32
+
+query error mz_errored
+SELECT mz_internal.mz_error_if_null(NULL, 'mz_errored')
+
+query I
+SELECT mz_internal.mz_error_if_null(1, '')
+----
+1

--- a/test/sqllogictest/types.slt
+++ b/test/sqllogictest/types.slt
@@ -337,6 +337,61 @@ SELECT '1'::pg_catalog.oid
 ----
 1
 
+# 🔬🔬 regproc
+
+query T
+SELECT 1::regproc
+----
+1
+
+query T
+SELECT 1::int4::regproc
+----
+1
+
+query T
+SELECT 1::oid::regproc
+----
+1
+
+query T
+SELECT 1::oid::regproc::oid
+----
+1
+
+query T
+SELECT '1'::regproc
+----
+1
+
+query T
+SELECT '1'::pg_catalog.regproc
+----
+1
+
+query error CAST does not support casting from regproc to text
+SELECT '1'::regproc::text
+
+query error CAST does not support casting from regproc to text
+SELECT 'now'::regproc::text
+
+query T
+SELECT 'now'::regproc
+----
+1299
+
+query T
+SELECT 'now'::regproc::oid
+----
+1299
+
+# TODO: improve this error message to match postgres.
+query error more than one record produced in subquery
+SELECT 'max'::regproc
+
+query error function "nonexistent" does not exist
+SELECT 'nonexistent'::regproc
+
 # 🔬🔬🔬 oid alias
 
 query T

--- a/test/sqllogictest/types.slt
+++ b/test/sqllogictest/types.slt
@@ -337,6 +337,21 @@ SELECT '1'::pg_catalog.oid
 ----
 1
 
+query I
+SELECT 1::oid
+----
+1
+
+query I
+SELECT 1::int4::oid
+----
+1
+
+query I
+SELECT 1::int4::oid::int4
+----
+1
+
 # 🔬🔬 regproc
 
 query T

--- a/test/testdrive/types.td
+++ b/test/testdrive/types.td
@@ -30,6 +30,7 @@ _jsonb
 _numeric
 _oid
 _record
+_regproc
 _text
 _time
 _timestamp
@@ -57,6 +58,7 @@ map
 numeric
 oid
 record
+regproc
 text
 time
 timestamp
@@ -82,6 +84,7 @@ _jsonb           system
 _numeric         system
 _oid             system
 _record          system
+_regproc         system
 _text            system
 _time            system
 _timestamp       system
@@ -108,6 +111,7 @@ list             system
 map              system
 numeric          system
 oid              system
+regproc          system
 record           system
 text             system
 time             system


### PR DESCRIPTION
This isn't the full support for jdbc which is requires `array_in` in `pg_proc`, but is most of the work for it.