### PR TITLE
[dataflow] Choose most expressions as key for `Get`

### DIFF
--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -877,7 +877,7 @@ pub mod plan {
                         .filter_map(|key| {
                             mfp.literal_constraints(key).map(|val| (key.clone(), val))
                         })
-                        .next();
+                        .max_by_key(|(key, _val)| key.len());
                     // If we discover a literal constraint, we can discard other arrangements.
                     if let Some((key, _)) = &key_val {
                         in_keys = vec![key.clone()];
@@ -1112,7 +1112,7 @@ pub mod plan {
                 let key_val = keys
                     .iter()
                     .filter_map(|key| mfp.literal_constraints(key).map(|val| (key.clone(), val)))
-                    .next();
+                    .max_by_key(|(key, _val)| key.len());
                 plan = Plan::Mfp {
                     input: Box::new(plan),
                     mfp,


### PR DESCRIPTION
This PR changes the logic to pick which arrangement to use for indexed access to arrangements. Previously, it would just pick the first arrangement whose key was a literal; now it picks the arrangement with the longest key that is a literal. Another option I considered was to pick the longest encoded literal (we have the `row` at hand, and that could be a proxy for its entropy). I'm not sure the best way to choose between them, but this seems better than what it was before, as we will always prefer strictly larger attribute sets.