### PR TITLE
transform/reduction: Avoid copying constants

### DIFF
--- a/src/transform/src/reduction.rs
+++ b/src/transform/src/reduction.rs
@@ -373,11 +373,11 @@ impl FoldConstants {
         {
             // Reduce down to canonical representation.
             let mut accum = HashMap::new();
-            for (row, cnt) in rows.iter() {
-                *accum.entry(row.clone()).or_insert(0) += cnt;
+            for (row, cnt) in rows.drain(..) {
+                *accum.entry(row).or_insert(0) += cnt;
             }
             accum.retain(|_k, v| v != &0);
-            rows.clear();
+            // `rows` cleared by drain.
             rows.extend(accum.into_iter());
             rows.sort();
 


### PR DESCRIPTION
Signed-off-by: Moritz Hoffmann <mh@materialize.com>