### PR TITLE
sql: support array_in and regproc equality

### DIFF
--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1229,6 +1229,9 @@ lazy_static! {
                 params!(Float32) => UnaryFunc::AbsFloat32, 1394;
                 params!(Float64) => UnaryFunc::AbsFloat64, 1395;
             },
+            "array_in" => Scalar {
+                params!(String, Oid, Int32) => Operation::unary(|_ecx, _e| bail_unsupported!("array_in")), 750;
+            },
             "array_length" => Scalar {
                 params![ArrayAny, Int64] => BinaryFunc::ArrayLength, 2176;
             },

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -172,7 +172,7 @@ lazy_static! {
             (Oid, RegProc) => Assignment: CastOidToRegProc,
 
             // REGPROC
-            (RegProc,Oid) => Assignment: CastRegProcToOid,
+            (RegProc,Oid) => Implicit: CastRegProcToOid,
 
             // FLOAT32
             (Float32, Int16) => Assignment: CastFloat32ToInt16,

--- a/test/lang/java/smoketest/SmokeTest.java
+++ b/test/lang/java/smoketest/SmokeTest.java
@@ -12,11 +12,13 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Types;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
+import org.postgresql.jdbc.TypeInfoCache;
 
 class SmokeTest {
     private Connection conn;
@@ -72,5 +74,13 @@ class SmokeTest {
         Assertions.assertEquals("2010-01-02 00:00:00", rs.getString(1));
         rs.close();
         stmt.close();
+    }
+
+    @Test
+    void testGetSqlType() throws SQLException, ClassNotFoundException {
+        Class.forName("org.postgresql.core.BaseConnection");
+        TypeInfoCache ic = new TypeInfoCache(conn.unwrap(org.postgresql.core.BaseConnection.class), 0);
+        Assertions.assertEquals(ic.getSQLType("int2"), Types.SMALLINT);
+        Assertions.assertEquals(ic.getSQLType("_int2"), Types.ARRAY);
     }
 }

--- a/test/sqllogictest/types.slt
+++ b/test/sqllogictest/types.slt
@@ -407,6 +407,16 @@ SELECT 'max'::regproc
 query error function "nonexistent" does not exist
 SELECT 'nonexistent'::regproc
 
+query T
+SELECT 'array_in'::regproc
+----
+750
+
+query B
+SELECT 750 = 'array_in'::regproc
+----
+true
+
 # 🔬🔬🔬 oid alias
 
 query T


### PR DESCRIPTION
This enables pgjdbc's getSQLType method.

Fixes #7790