### PR TITLE
Transform testing: Trim spaces from end of all lines of an explanation

### DIFF
--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -229,7 +229,9 @@ mod tests {
                         // however, a partially optimized query can.
                         // Since clippy rejects test results with trailing
                         // whitespace, remove whitespace before comparing results.
-                        Ok(msg) => format!("{}\n", msg.trim_end().to_string()),
+                        Ok(msg) => {
+                            format!("{}", separated("\n", msg.split('\n').map(|s| s.trim_end())))
+                        }
                         Err(err) => format!("error: {}\n", err),
                     },
                     "opt" => match run_testcase(&s.input, &catalog, &s.args, TestType::Opt) {

--- a/src/transform/tests/testdata/projection-extraction
+++ b/src/transform/tests/testdata/projection-extraction
@@ -1,0 +1,21 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+cat
+(defsource x [int64 int64])
+----
+ok
+
+build apply=ProjectionExtraction
+(map (get x) [#1 #0])
+----
+%0 =
+| Get x (u0)
+| Map
+| Project (#0, #1, #1, #0)


### PR DESCRIPTION
Split off from #7864.

Clippy rejects test results with spaces at the end of a line, but explanations for partially optimized queries can have a space at the end of a line. Partially optimized queries appear in transform unit tests.

My previous fix for this only removed the space at the end of the last line of the explanation. Now spaces get removed from the end of each line in the explanation.