### PR TITLE
coord: use 'array_in'::regproc in pg_type builtin view

### DIFF
--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -1263,9 +1263,7 @@ pub const PG_TYPE: BuiltinView = BuiltinView {
         0
     )
         AS typarray,
-    -- Unfortunately we cannot use 'array_in'::pg_catalog.regproc, so hard code the
-    -- array_in oid.
-    (CASE mztype WHEN 'a' THEN 750 ELSE NULL END)::pg_catalog.regproc AS typinput,
+    (CASE mztype WHEN 'a' THEN 'array_in'::pg_catalog.regproc ELSE NULL END) AS typinput,
     NULL::pg_catalog.oid AS typreceive,
     false::pg_catalog.bool AS typnotnull,
     0::pg_catalog.oid AS typbasetype

--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -1263,7 +1263,7 @@ pub const PG_TYPE: BuiltinView = BuiltinView {
         0
     )
         AS typarray,
-    (CASE mztype WHEN 'a' THEN 'array_in'::pg_catalog.regproc ELSE NULL END) AS typinput,
+    (CASE mztype WHEN 'a' THEN 'array_in' ELSE NULL END)::pg_catalog.regproc AS typinput,
     NULL::pg_catalog.oid AS typreceive,
     false::pg_catalog.bool AS typnotnull,
     0::pg_catalog.oid AS typbasetype

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -241,6 +241,7 @@ lazy_static! {
             (String, RegProc) => Explicit: sql_impl_cast("(
                 SELECT
                     CASE
+                    WHEN $1 IS NULL THEN NULL
                     WHEN $1 ~ '^\\d+$' THEN $1::pg_catalog.oid::pg_catalog.regproc
                     ELSE (
                         mz_internal.mz_error_if_null(

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -241,7 +241,7 @@ lazy_static! {
             (String, RegProc) => Explicit: sql_impl_cast("(
                 SELECT
                     CASE
-                    WHEN $1 ~ '^\\d+$' THEN $1::oid::pg_catalog.regproc
+                    WHEN $1 ~ '^\\d+$' THEN $1::pg_catalog.oid::pg_catalog.regproc
                     ELSE (
                         mz_internal.mz_error_if_null(
                             (SELECT oid::pg_catalog.regproc FROM mz_catalog.mz_functions WHERE name = $1),

--- a/test/sqllogictest/types.slt
+++ b/test/sqllogictest/types.slt
@@ -417,6 +417,18 @@ SELECT 750 = 'array_in'::regproc
 ----
 true
 
+statement ok
+CREATE TABLE text_to_regproc (a text);
+
+statement ok
+INSERT INTO text_to_regproc VALUES (NULL), ('array_in');
+
+query I
+SELECT a::regproc FROM text_to_regproc ORDER BY a
+----
+750
+NULL
+
 # 🔬🔬🔬 oid alias
 
 query T


### PR DESCRIPTION
Looks like you'd just forgotten to qualify the reference to oid in #8025!