### PR TITLE
persist: introduce a placeholder impl of Log to prevent accidental usage

### DIFF
--- a/src/coord/src/persistcfg.rs
+++ b/src/coord/src/persistcfg.rs
@@ -12,22 +12,20 @@
 use std::path::PathBuf;
 
 use ore::metrics::MetricsRegistry;
-use persist::error::Error;
+use persist::error::{Error, ErrorLog};
 use persist::indexed::encoding::Id;
 use persist::storage::LockInfo;
 use repr::Row;
 use serde::Serialize;
 
 use expr::GlobalId;
-use persist::file::{FileBlob, FileLog};
+use persist::file::FileBlob;
 use persist::indexed::runtime::{self, MultiWriteHandle, RuntimeClient, StreamWriteHandle};
 use uuid::Uuid;
 
 /// Configuration of the persistence runtime and features.
 #[derive(Clone, Debug)]
 pub struct PersistConfig {
-    /// A directory under which un-indexed WAL-like writes are quickly stored.
-    pub log_path: PathBuf,
     /// A directory under which larger batches of indexed data are stored. This
     /// will eventually be S3 for Cloud.
     pub blob_path: PathBuf,
@@ -50,7 +48,6 @@ pub struct PersistConfig {
 impl PersistConfig {
     pub fn disabled() -> Self {
         PersistConfig {
-            log_path: Default::default(),
             blob_path: Default::default(),
             user_table_enabled: false,
             system_table_enabled: false,
@@ -69,7 +66,7 @@ impl PersistConfig {
         let persister = if self.user_table_enabled || self.system_table_enabled {
             let lock_reentrance_id = catalog_id.to_string();
             let lock_info = LockInfo::new(lock_reentrance_id, self.lock_info.clone())?;
-            let log = FileLog::new(&self.log_path, lock_info.clone())?;
+            let log = ErrorLog;
             let blob = FileBlob::new(&self.blob_path, lock_info)?;
             let persister = runtime::start(log, blob, reg)?;
             Some(persister)

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -639,7 +639,6 @@ swap: {swap_total}KB total, {swap_used}KB used{swap_limit}",
         PersistConfig {
             // TODO: These paths are hardcoded for now, but we'll want to make
             // them configurable once we add additional Log and Blob impls.
-            log_path: data_directory.join("persist").join("log"),
             blob_path: data_directory.join("persist").join("blob"),
             user_table_enabled,
             system_table_enabled,

--- a/src/persist/src/error.rs
+++ b/src/persist/src/error.rs
@@ -9,8 +9,11 @@
 
 //! Persistence related errors.
 
+use std::ops::Range;
 use std::sync::Arc;
 use std::{error, fmt, io, sync};
+
+use crate::storage::{Log, SeqNo};
 
 /// A persistence related error.
 #[derive(Debug, Clone)]
@@ -76,5 +79,41 @@ impl<'a> From<&'a str> for Error {
 impl<T> From<sync::PoisonError<T>> for Error {
     fn from(e: sync::PoisonError<T>) -> Self {
         Error::String(format!("poison: {}", e))
+    }
+}
+
+/// A stub implementation of [Log] that always returns errors.
+///
+/// This exists to let us keep the (surprisingly non-trivial) Log plumbing while
+/// we don't actually use it, but without the risk of accidentally using it.
+pub struct ErrorLog;
+
+impl Log for ErrorLog {
+    fn write_sync(&mut self, _buf: Vec<u8>) -> Result<SeqNo, Error> {
+        Err(Error::from(
+            "ErrorLog method unexpectedly called, please report a bug: write_sync",
+        ))
+    }
+
+    fn snapshot<F>(&self, _logic: F) -> Result<Range<SeqNo>, Error>
+    where
+        F: FnMut(SeqNo, &[u8]) -> Result<(), Error>,
+    {
+        Err(Error::from(
+            "ErrorLog method unexpectedly called, please report a bug: snapshot",
+        ))
+    }
+
+    fn truncate(&mut self, _upper: SeqNo) -> Result<(), Error> {
+        Err(Error::from(
+            "ErrorLog method unexpectedly called, please report a bug: snapshot",
+        ))
+    }
+
+    fn close(&mut self) -> Result<bool, Error> {
+        // This one should actually be used, so implement it. The bool result is
+        // only used for logging when a Log impl was dropped without being
+        // closed, so it's safe to always return false.
+        Ok(false)
     }
 }


### PR DESCRIPTION
This exists to let us keep the (surprisingly non-trivial) Log plumbing
while we don't actually use it, but without the risk of accidentally
using it.

Found by Ruchir