### PR TITLE
persist: version the serialization of BlobMeta

### DIFF
--- a/src/persist/src/lib.rs
+++ b/src/persist/src/lib.rs
@@ -69,6 +69,11 @@ pub trait Codec: Sized + 'static {
     /// and the same key and value codec must be used for that stream afterward.
     fn codec_name() -> &'static str;
     /// A hint of the encoded size of self.
+    ///
+    /// No correctness guarantees are made about the return value of this
+    /// function, it's used purely to pre-size buffers.
+    //
+    // TODO: Give this the same signature and semantics as Iterator::size_hint.
     fn size_hint(&self) -> usize;
     /// Encode a key or value for permanent storage.
     ///


### PR DESCRIPTION
Because we're temporarily using abomonation as our serialization format,
any changes to the structure of the BlobMeta struct (or the many structs
included in it) will change our on disk representation in a non
backwards-compatible way. The "META" key in Blob storage is the very
first thing read by persist on startup and the encoding used for it is
also perfectly predictive of the encoding of BlobUnsealedBatch and
BlobTraceBatch (the other two things we serialize).

This will allow us to gracefully detect changes at startup and react to
them. MZ is not (yet) a system of record, so in the short-term
(persisting mz_metrics) we are free to simply delete the data. In the
medium-term (fast restarts for kafka sources), we'll make an effort to
decode old data. In the long-term (1.0), we'll have
backward-compatibility guarantees.

A followup PR will close this loop and, on startup, wipe the entirety of
persisted data if an unsupported version is detected (safe for the
reason described above), before initializing a new copy and proceeding
on.