### PR TITLE
editorconfig: Markdown line length 80

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -33,3 +33,6 @@ indent_size = 2
 
 [Makefile]
 indent_style = tab
+
+[*.md]
+max_line_length = 80


### PR DESCRIPTION
Signed-off-by: Moritz Hoffmann <mh@materialize.com>