### PR TITLE
Set initial auth timeout to 10 seconds uniformly

### DIFF
--- a/src/aws-util/src/aws.rs
+++ b/src/aws-util/src/aws.rs
@@ -18,6 +18,10 @@ use rusoto_sts::{GetCallerIdentityRequest, Sts, StsClient};
 use serde::{Deserialize, Serialize};
 use tokio::time::{self, Duration};
 
+/// How long Materialize waits for various parts of initial authorization
+// TODO(#7115): Make this configurable everywhere it is used
+pub const AUTH_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// Information required to connnect to AWS
 ///
 /// Credentials are optional because in most cases users should use the

--- a/src/aws-util/src/client.rs
+++ b/src/aws-util/src/client.rs
@@ -12,8 +12,6 @@
 //! The functions in this module all configure a client for an AWS service
 //! using a uniform credentials pattern.
 
-use std::time::Duration;
-
 use anyhow::{anyhow, Context};
 use log::debug;
 use rusoto_core::HttpClient;
@@ -72,7 +70,7 @@ pub fn $name(conn_info: ConnectInfo) -> Result<$client, anyhow::Error> {
         );
         let mut provider = ChainProvider::new();
 
-        provider.set_timeout(Duration::from_secs(10));
+        provider.set_timeout($crate::aws::AUTH_TIMEOUT);
         let provider =
             AutoRefreshingProvider::new(provider).context(
                 concat!("generating AWS credentials refreshing provider for ", $client_name))?;

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -16,11 +16,11 @@ use std::future::Future;
 
 use anyhow::{anyhow, bail, ensure, Context};
 use aws_arn::ARN;
+use aws_util::aws;
 use itertools::Itertools;
 use tokio::fs::File;
 use tokio::io::AsyncBufReadExt;
 use tokio::task;
-use tokio::time::Duration;
 use uuid::Uuid;
 
 use dataflow_types::{ExternalSourceConnector, PostgresSourceConnector, SourceConnector};
@@ -164,8 +164,7 @@ pub fn purify(
                 }
                 CreateSourceConnector::S3 { .. } => {
                     let aws_info = normalize::aws_connect_info(&mut with_options_map, None)?;
-                    aws_util::aws::validate_credentials(aws_info.clone(), Duration::from_secs(1))
-                        .await?;
+                    aws::validate_credentials(aws_info.clone(), aws::AUTH_TIMEOUT).await?;
                 }
                 CreateSourceConnector::Kinesis { arn } => {
                     let region = arn
@@ -176,7 +175,7 @@ pub fn purify(
 
                     let aws_info =
                         normalize::aws_connect_info(&mut with_options_map, Some(region.into()))?;
-                    aws_util::aws::validate_credentials(aws_info, Duration::from_secs(1)).await?;
+                    aws::validate_credentials(aws_info, aws::AUTH_TIMEOUT).await?;
                 }
                 CreateSourceConnector::Postgres {
                     conn,


### PR DESCRIPTION
In some network environments it can take 5 seconds for the initial get-caller-identity call.

Related to #7115.