### PR TITLE
coord: save each table's persist name in the catalog

### DIFF
--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -871,6 +871,8 @@ lazy_static! {
                 .with_named_column("labels", ScalarType::Jsonb.nullable(false))
                 .with_named_column("value", ScalarType::Float64.nullable(false))
                 .with_key(vec![0, 1, 2]),
+        // NB: Until the end of our persisted system tables experiment, give
+        // persist team a heads up if you change this id, please!
         id: GlobalId::System(4043),
         index_id: GlobalId::System(4044),
         // Note that the `system_table_enabled` field of PersistConfig (hooked
@@ -900,6 +902,8 @@ lazy_static! {
                 .with_named_column("bound", ScalarType::Float64.nullable(false))
                 .with_named_column("count", ScalarType::Int64.nullable(false))
                 .with_key(vec![0, 1, 2]),
+        // NB: Until the end of our persisted system tables experiment, give
+        // persist team a heads up if you change this id, please!
         id: GlobalId::System(4047),
         index_id: GlobalId::System(4048),
         // Note that the `system_table_enabled` field of PersistConfig (hooked

--- a/src/coord/src/catalog/migrate.rs
+++ b/src/coord/src/catalog/migrate.rs
@@ -35,6 +35,7 @@ where
         let SerializedCatalogItem::V1 {
             create_sql,
             eval_env,
+            persist_name,
         } = serde_json::from_slice(&def)?;
         let mut stmt = sql::parse::parse(&create_sql)?.into_element();
 
@@ -43,6 +44,7 @@ where
         let serialized_item = SerializedCatalogItem::V1 {
             create_sql: stmt.to_ast_string_stable(),
             eval_env,
+            persist_name,
         };
 
         let serialized_item =

--- a/src/coord/src/persistcfg.rs
+++ b/src/coord/src/persistcfg.rs
@@ -90,15 +90,14 @@ impl PersisterWithConfig {
     fn stream_name(&self, id: GlobalId, pretty: &str) -> Option<String> {
         match id {
             GlobalId::User(id) if self.config.user_table_enabled => {
-                // TODO: This needs to be written down somewhere in the catalog
-                // in case we need to change the naming at some point. See
-                // related TODO in Catalog::deserialize_item.
+                // NB: This gets written down in the catalog, so it should be
+                // safe to change the naming, if necessary. See
+                // Catalog::deserialize_item.
                 Some(format!("user-table-{:?}-{}", id, pretty))
             }
             GlobalId::System(id) if self.config.system_table_enabled => {
-                // TODO: This needs to be written down somewhere in the catalog
-                // in case we need to change the naming at some point. See
-                // related TODO in Catalog::deserialize_item.
+                // NB: Until the end of our persisted system tables experiment, give
+                // persist team a heads up if you change this, please!
                 Some(format!("system-table-{:?}-{}", id, pretty))
             }
             _ => None,
@@ -106,11 +105,18 @@ impl PersisterWithConfig {
     }
 
     pub fn details(&self, id: GlobalId, pretty: &str) -> Result<Option<PersistDetails>, Error> {
-        let persister = match self.persister.as_ref() {
+        self.details_from_name(self.stream_name(id, pretty))
+    }
+
+    pub fn details_from_name(
+        &self,
+        stream_name: Option<String>,
+    ) -> Result<Option<PersistDetails>, Error> {
+        let stream_name = match stream_name {
             Some(x) => x,
             None => return Ok(None),
         };
-        let stream_name = match self.stream_name(id, pretty) {
+        let persister = match self.persister.as_ref() {
             Some(x) => x,
             None => return Ok(None),
         };


### PR DESCRIPTION
And use it on startup if it's present instead of generating one from
scratch. This fixes a class of bugs: any of renaming a table, changing
the hardcoded id of a persisted system table, or changing the persist
name generation logic (PersisterWithConfig::stream_name) would
disassociate and orphan the previously persisted data for that table.

Fix manually verified by renaming a persisted user name. Test is being
tracked in MaterializeInc/database-issues#2430.