### PR TITLE
sql: add bool_and and bool_or

### DIFF
--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -30,6 +30,12 @@
       Returns `numeric` if `x` is `int`, `double` if `x` is `real`, else returns
       same type as `x`.
 
+  - signature: 'bool_and(x: T) -> T'
+    description: _NULL_ if all values of `x` are _NULL_, otherwise true if all values of `x` are true, otherwise false.
+
+  - signature: 'bool_or(x: T) -> T'
+    description: _NULL_ if all values of `x` are _NULL_, otherwise true if any values of `x` are true, otherwise false.
+
   - signature: 'count(x: T) -> int'
     description: Number of non-_NULL_ inputs.
 

--- a/src/sql-parser/src/ast/defs/expr.rs
+++ b/src/sql-parser/src/ast/defs/expr.rs
@@ -578,6 +578,13 @@ impl<T: AstInfo> Expr<T> {
         self.binop(Op::bare("/"), right)
     }
 
+    pub fn cast(self, data_type: T::DataType) -> Expr<T> {
+        Expr::Cast {
+            expr: Box::new(self),
+            data_type,
+        }
+    }
+
     pub fn call(name: Vec<&str>, args: Vec<Expr<T>>) -> Expr<T> {
         Expr::Function(Function {
             name: UnresolvedObjectName(name.into_iter().map(Into::into).collect()),

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -2580,10 +2580,10 @@ pub static PG_CATALOG_BUILTINS: Lazy<HashMap<&'static str, Func>> = Lazy::new(||
             params!(ArrayAny) => Operation::unary(|_ecx, _e| bail_unsupported!("array_agg on arrays")) => ArrayAny, 4053;
         },
         "bool_and" => Aggregate {
-            params!(Any) => Operation::unary(|_ecx, _e| bail_unsupported!("bool_and")) => Bool, 2517;
+            params!(Bool) => Operation::nullary(|_ecx| catalog_name_only!("bool_and")) => Bool, 2517;
         },
         "bool_or" => Aggregate {
-            params!(Any) => Operation::unary(|_ecx, _e| bail_unsupported!("bool_or")) => Bool, 2518;
+            params!(Bool) => Operation::nullary(|_ecx| catalog_name_only!("bool_or")) => Bool, 2518;
         },
         "count" => Aggregate {
             params!() => Operation::nullary(|_ecx| {

--- a/test/sqllogictest/cockroach/aggregate.slt
+++ b/test/sqllogictest/cockroach/aggregate.slt
@@ -62,12 +62,12 @@ SELECT min(v), max(v), count(v), avg(v), sum(v), stddev(v), variance(v) FROM kv
 ----
 NULL NULL 0 NULL NULL NULL NULL
 
-statement error supported
+query B
 SELECT bool_and(v = 1) FROM kv
 ----
 NULL
 
-statement error supported
+query B
 SELECT bool_or(v = 1) FROM kv
 ----
 NULL
@@ -871,29 +871,34 @@ true
 statement ok
 CREATE TABLE bools (b BOOL)
 
-query error supported
+query BB
 SELECT bool_and(b), bool_or(b) FROM bools
+----
+NULL NULL
 
 statement OK
 INSERT INTO bools VALUES (true), (true), (true)
 
-query error supported
+query BB
 SELECT bool_and(b), bool_or(b) FROM bools
+----
+true true
 
 statement OK
 INSERT INTO bools VALUES (false), (false)
 
-query error supported
+query BB
 SELECT bool_and(b), bool_or(b) FROM bools
+----
+false true
 
-# not supported yet
-# statement OK
-# DELETE FROM bools WHERE b
-#
-# query BB
-# SELECT bool_and(b), bool_or(b) FROM bools
-# ----
-# false false
+statement OK
+DELETE FROM bools WHERE b
+
+query BB
+SELECT bool_and(b), bool_or(b) FROM bools
+----
+false false
 
 query error concat_agg not yet supported
 SELECT concat_agg(s) FROM (SELECT s FROM kv ORDER BY k)


### PR DESCRIPTION
Fixes #17349.
Fixes https://github.com/MaterializeInc/materialize/issues/3154.

**Release note:** Add the PostgreSQL-compatible `bool_and` and `bool_or` aggregate functions, which compute whether a column contains all `true` values or at least one `true` value, respectively.