### PR TITLE
.github: add a PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,55 @@
+### Motivation
+
+<!--
+
+Which of the following best describes the motivation behind this PR?
+
+  * This PR fixes a recognized bug. [Link to issue.]
+
+  * This PR adds a known-desirable feature. [Link to issue.]
+
+  * This PR fixes a previously unreported bug.
+
+    [Describe the bug in detail, as if you were filing a bug report.]
+
+  * This PR adds a feature that has not yet been specified.
+
+    [Write a brief specification for the feature, including justification
+     for its inclusion in Materialize, as if you were writing the original
+     feature specification.]
+
+   * This PR refactors existing code.
+
+    [Describe what was wrong with the existing code, if it is not obvious.]
+
+-->
+
+### Description
+
+<!--
+
+Describe the contents of the PR briefly but completely.
+
+If you write detailed commit messages, it is acceptable to copy/paste them
+here, or write "see commit messages for details."
+
+-->
+
+### Tips for reviewer
+
+<!--
+
+Leave some tips for your reviewer, like:
+
+    * The diff is much smaller if viewed with whitespace hidden.
+    * [Some function/module/file] deserves extra attention.
+    * [Some function/module/file] is pure code movement and only needs a skim.
+
+Delete this section if no tips.
+
+-->
+
+### Checklist
+
+[ ] This PR has adequate test coverage.
+[ ] This PR adds a release note for any user-facing behavior changes.


### PR DESCRIPTION
Add a pull request template to remind authors to:

  * Describe their motiviation in addition to the contents of the
    change.

  * Add tests to their PR.

  * Add a release note to their PR, if necessary.