### PR TITLE
Dataflow/optimization: Fix MFP inlining so it doesn't always happen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1322,6 +1322,7 @@ dependencies = [
  "ore",
  "pdqselect",
  "pgrepr",
+ "proc-macro2",
  "regex",
  "regex-syntax",
  "repr",

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -38,3 +38,4 @@ uncased = "0.9.6"
 datadriven = "0.6.0"
 expr_test_util = { path = "../expr-test-util"}
 ore = { path = "../ore" }
+proc-macro2 = "1.0.28"

--- a/src/expr/tests/testdata/mfp
+++ b/src/expr/tests/testdata/mfp
@@ -1,0 +1,44 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# The syntax for an mfp test is `<input_arity> [<commands>]`
+# The syntax for a command is `<name_of_command> [<args>]`
+
+mfp
+1
+map [(call_binary add_int64 #0 1) (call_binary add_int64 (call_binary add_int64 #0 1) 1)]
+filter [(call_binary eq #2 3)]
+project [0 1 2]
+optimize
+----
+[(#0 + 1) (#1 + 1)]
+[(#2 = 3)]
+[0 1 2]
+
+mfp
+1
+map [(call_binary add_int64 #0 1) (call_binary add_int64 (call_binary add_int64 #0 1) 1)]
+filter [(call_binary eq #2 3)]
+project [2]
+optimize
+----
+[((#0 + 1) + 1)]
+[(#1 = 3)]
+[1]
+
+mfp
+1
+map [(call_binary add_int64 #0 1) (call_binary add_int64 (call_binary add_int64 #0 1) 1)]
+filter [(call_binary eq #1 3)]
+project [2]
+optimize
+----
+[(#0 + 1) (#1 + 1)]
+[(#1 = 3)]
+[2]


### PR DESCRIPTION
Split from #7864 

I found out that this MFP (which is around a one-column input)
```
| Map (#0 + 1) ((#0 + 1) + 1)
| Filter (#2 = 3)
| Project [0..2]
```
was being optimized like this; i.e. inlining was always happening.
```
| Map (#0 + 1) ((#0 + 1) + 1)
| Filter (((#0 + 1) + 1)= 3)
| Project [0..2]
```

---------

This is how it was happening:
The MFP after the memoize step looks like this:
```
| Map (#0 + 1) #1 (#2 + 1) #3 (#4 + 1)
| Filter (#5 = 3)
| Project (0, 2, 4)
```
We determine that an expression can be inlined if either of the following apply:
* if it has only one reference
* if it is a column reference.
We calculate the number of references to the five expressions in the map above as `[1, 2, 1, 2, 1]`. Thus all expressions can be inlined.

---------

The fix is that if a column reference expression has more than one reference, those references should also be applied to the reference count of the column being referenced.

The true reference count of the expressions in the map above should be `[2, 2, 2, 2, 1]` since `(#0 + 1)` and `(#2 + 1)` are actually needed in two places.

The correct optimization for the MFP in this example is:
```
| Map (#0 + 1) (#1 + 1)
| Filter (#2 = 3)
| Project (0..2)
```
----------
Note: It can be argued that this example would be better off optimized as 
```
| Map (#0 + 1) (#0 + 2)
| Filter (#0 + 2 = 3)
| Project (0..2)
```
or 
```
| Filter (#0 = 1)
| Map 1 2
```
but this scope is just concerned with correcting the inlining behavior.