### PR TITLE
kafka: allow manual override of `enable.idempotence`

### DIFF
--- a/src/sql/src/kafka_util.rs
+++ b/src/sql/src/kafka_util.rs
@@ -235,6 +235,7 @@ pub fn extract_config(
             Config::path("ssl_key_location"),
             Config::string("ssl_key_password").include_env_var(),
             Config::new("transaction_timeout_ms", ValType::Number(0, i32::MAX)),
+            Config::new("enable_idempotence", ValType::Boolean),
         ],
     )
 }


### PR DESCRIPTION
We hard-enable this in our producer but some users want to produce to
systems that don't support Producer IDs.

Allowing manual override will unblock them, but this setting is
potentially dangerous because it can (will?) lead to duplicate records
being produced.