### PR TITLE
sinks: make Kafka sink builder generic over GenerateAvroSchema

### DIFF
--- a/src/dataflow/src/sink/avro_ocf.rs
+++ b/src/dataflow/src/sink/avro_ocf.rs
@@ -20,7 +20,7 @@ use timely::dataflow::Scope;
 
 use dataflow_types::{AvroOcfSinkConnector, SinkDesc};
 use expr::GlobalId;
-use interchange::avro::{encode_datums_as_avro, AvroSchemaGenerator};
+use interchange::avro::{encode_datums_as_avro, AvroSchemaGenerator, GenerateAvroSchema};
 use repr::{Diff, RelationDesc, Row, Timestamp};
 use timely::dataflow::scopes::Child;
 
@@ -90,7 +90,7 @@ fn avro_ocf<G>(
         v
     });
     let (schema, columns) = {
-        let schema_generator = AvroSchemaGenerator::new(None, desc, false);
+        let schema_generator = <AvroSchemaGenerator as GenerateAvroSchema>::new(None, desc, false);
         let schema = schema_generator.value_writer_schema().clone();
         let columns = schema_generator.value_columns().to_vec();
         (schema, columns)

--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -42,7 +42,7 @@ use dataflow_types::{
     KafkaSinkConnector, KafkaSinkConsistencyConnector, PublishedSchemaInfo, SinkAsOf, SinkDesc,
 };
 use expr::GlobalId;
-use interchange::avro::{self, AvroEncoder, AvroSchemaGenerator};
+use interchange::avro::{self, AvroEncoder, AvroSchemaGenerator, GenerateAvroSchema};
 use interchange::encode::Encode;
 use ore::cast::CastFrom;
 use repr::{Datum, Diff, RelationDesc, Row, Timestamp};
@@ -587,8 +587,11 @@ where
             key_schema_id,
             value_schema_id,
         }) => {
-            let schema_generator =
-                AvroSchemaGenerator::new(key_desc, value_desc, connector.consistency.is_some());
+            let schema_generator = <AvroSchemaGenerator as GenerateAvroSchema>::new(
+                key_desc,
+                value_desc,
+                connector.consistency.is_some(),
+            );
             let encoder = AvroEncoder::new(schema_generator, key_schema_id, value_schema_id);
             encode_stream(
                 stream,

--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -20,7 +20,7 @@ pub use envelope_cdc_v2 as cdc_v2;
 pub use self::decode::{Decoder, DiffPair};
 pub use self::encode::{
     encode_datums_as_avro, encode_debezium_transaction_unchecked, get_debezium_transaction_schema,
-    AvroEncoder, AvroSchemaGenerator,
+    AvroEncoder, AvroSchemaGenerator, GenerateAvroSchema,
 };
 pub use self::envelope_debezium::{DebeziumDecodeState, DebeziumDeduplicationStrategy};
 pub use self::schema::{

--- a/src/interchange/src/avro/encode.rs
+++ b/src/interchange/src/avro/encode.rs
@@ -121,6 +121,22 @@ fn encode_message_unchecked(
     buf
 }
 
+pub trait GenerateAvroSchema {
+    fn new(
+        key_desc: Option<RelationDesc>,
+        value_desc: RelationDesc,
+        include_transaction: bool,
+    ) -> Self;
+
+    fn value_writer_schema(&self) -> &Schema;
+
+    fn value_columns(&self) -> &[(ColumnName, ColumnType)];
+
+    fn key_writer_schema(&self) -> Option<&Schema>;
+
+    fn key_columns(&self) -> Option<&[(ColumnName, ColumnType)]>;
+}
+
 /// Generates key and value Avro schemas
 pub struct AvroSchemaGenerator {
     value_columns: Vec<(ColumnName, ColumnType)>,
@@ -128,8 +144,8 @@ pub struct AvroSchemaGenerator {
     writer_schema: Schema,
 }
 
-impl AvroSchemaGenerator {
-    pub fn new(
+impl GenerateAvroSchema for AvroSchemaGenerator {
+    fn new(
         key_desc: Option<RelationDesc>,
         value_desc: RelationDesc,
         include_transaction: bool,
@@ -175,19 +191,19 @@ impl AvroSchemaGenerator {
         }
     }
 
-    pub fn value_writer_schema(&self) -> &Schema {
+    fn value_writer_schema(&self) -> &Schema {
         &self.writer_schema
     }
 
-    pub fn value_columns(&self) -> &[(ColumnName, ColumnType)] {
+    fn value_columns(&self) -> &[(ColumnName, ColumnType)] {
         &self.value_columns
     }
 
-    pub fn key_writer_schema(&self) -> Option<&Schema> {
+    fn key_writer_schema(&self) -> Option<&Schema> {
         self.key_info.as_ref().map(|KeyInfo { schema, .. }| schema)
     }
 
-    pub fn key_columns(&self) -> Option<&[(ColumnName, ColumnType)]> {
+    fn key_columns(&self) -> Option<&[(ColumnName, ColumnType)]> {
         self.key_info
             .as_ref()
             .map(|KeyInfo { columns, .. }| columns.as_slice())


### PR DESCRIPTION
This will allow us to plug in a CDCv2 schema generator in the future.