### PR TITLE
Revert "avro: fix parsing of nested types"

### DIFF
--- a/src/avro/src/schema.rs
+++ b/src/avro/src/schema.rs
@@ -908,10 +908,13 @@ impl SchemaParser {
                     }
                 }
             }),
-            Some(&Value::Object(ref data)) => self.parse_complex(default_namespace, data),
-            _ => Err(
-                ParseSchemaError::new(format!("No `type` in complex type {:?}", complex)).into(),
-            ),
+            Some(&Value::Object(ref data)) => match data.get("type") {
+                Some(ref value) => self.parse_inner(default_namespace, value),
+                None => Err(
+                    ParseSchemaError::new(format!("Unknown complex type: {:?}", complex)).into(),
+                ),
+            },
+            _ => Err(ParseSchemaError::new("No `type` in complex type").into()),
         }
     }
 
@@ -2249,26 +2252,6 @@ mod tests {
                     position: 1,
                 },
             ],
-            lookup,
-        };
-
-        check_schema(schema, expected);
-    }
-
-    #[test]
-    fn test_nested_record_schema() {
-        let schema = r#"
-                {
-                    "name" : "test",
-                    "type" : {"type": "record", "name": "inner", "fields": []}
-                }
-        "#;
-
-        let lookup = HashMap::new();
-
-        let expected = SchemaPiece::Record {
-            doc: None,
-            fields: vec![],
             lookup,
         };
 


### PR DESCRIPTION
This reverts commit b534ce690746fd413a38bb05b2bc26763b3a0c98.

The Avro spec is not very clear on this, but the schema registry rejects
schemas that have nested/recursive record types.