### PR TITLE
(docs) Style update to fix image refs, tabs and nav

### DIFF
--- a/doc/user/assets/sass/_content.scss
+++ b/doc/user/assets/sass/_content.scss
@@ -478,10 +478,11 @@ a {
       }
     }
   }
+
   .tab-pane {
     display: none;
     padding: 1rem 0;
-    
+
     &.active {
       display: block;
     }

--- a/doc/user/assets/sass/_content.scss
+++ b/doc/user/assets/sass/_content.scss
@@ -134,7 +134,7 @@ a {
     /* Style external links with a "open in new window" icon. */
     &[href*="//"]:not([href*="materialize.com"])::after {
         content: "";
-        background-image: url('/images/icon_external_link.svg');
+        background-image: url('../images/icon_external_link.svg');
         width: 16px;
         height: 16px;
         display: inline-block;
@@ -438,47 +438,54 @@ a {
 }
 
 // Navigation tabs (tab+tabs.html)
+.code-tabs {
+  margin: 1rem 0;
 
-.nav-tabs {
-  position: unset;
-  width: unset;
-}
+  .nav-tabs {
+    list-style: none;
+    padding: 0;
+    border-bottom: 1px solid #9C86E0;
 
-.tab-content > .tab-pane {
-  display: none;
-}
+    li {
+      display: inline-block;
+      margin: 0 .125rem;
+      padding: 0;
+      background: $faded-purple-v2;
+      position: relative;
+      bottom: -1px;
 
-.tab-pane {
-  padding: 3px 0px;
-  border-top: 1px solid $grey;
-}
+      a {
+        color: $medium-purple-v2;
+        display: block;
+        padding: 0.5rem 2rem;
+        font-size: 1rem;
 
-.tab-pane {
-  padding: 3px 0px;
-}
+        &:hover {
+          color: $purple;
+          border-bottom: none;
+        }
+      }
 
-.tab-content > .active {
-  display: block;
-  padding: 15px 0px 15px 0px
-}
+      &.active {
+        background: $white-v2;
+        border-radius: 2px 2px 0 0;
+        border:1px solid #9C86E0;
+        border-bottom-color: $white;
 
-.nav-tabs {
-  color: $grey-light;
-  list-style-type: none;
-  margin: 0;
-  padding: 0;
-  overflow: hidden;
-}
-
-.nav-tabs > li {
-  color: #0f0f0f;
-  float: left;
-}
-
-.nav-tabs > li > a {
-  display: block;
-  padding: 5px 10px;
-  font-size: 16px;
+        a {
+            color: $off-black;
+        }
+      }
+    }
+  }
+  .tab-pane {
+    display: none;
+    padding: 1rem 0;
+    
+    &.active {
+      display: block;
+    }
+  }
 }
 
 pre {
@@ -488,30 +495,21 @@ pre {
   line-height: 1;
 }
 
-.code-tabs {
-  margin: 10px 0px 0px 0px;
-}
+.callout {
+  background-color: $faded-purple-v2;
+  border-radius: 3px;
+  padding: 2rem 2.5rem;
+  margin: 2rem 0;
 
-.nav-tabs > li.active > a, .nav-tabs > li > a:hover {
-  color: $purple !important;
-  background: $purple-1;
+  > :first-child {
+    margin-top: 0;
+  }
 
-  .callout {
-    background-color: $faded-purple-v2;
-    border-radius: 3px;
-    padding: 2rem 2.5rem;
-    margin: 2rem 0;
+  .cta {
+    margin: 1rem 1rem 1rem 0;
 
-    > :first-child {
-      margin-top: 0;
-    }
-
-    .cta {
-      margin: 1rem 1rem 1rem 0;
-
-      &.secondary {
-        background: #FFF;
-      }
+    &.secondary {
+    background: #FFF;
     }
   }
 }
@@ -560,16 +558,16 @@ pre {
   }
 
   &.book::before {
-    background-image:url('/images/icon_book.png');
+    background-image:url('../images/icon_book.png');
   }
   &.bulb::before {
-    background-image:url('/images/icon_bulb.png');
+    background-image:url('../images/icon_bulb.png');
   }
   &.doc::before {
-    background-image:url('/images/icon_doc.png');
+    background-image:url('../images/icon_doc.png');
   }
   &.touch::before {
-    background-image:url('/images/icon_touch.png');
+    background-image:url('../images/icon_touch.png');
   }
 
   .title {

--- a/doc/user/content/_index.md
+++ b/doc/user/content/_index.md
@@ -1,8 +1,6 @@
 ---
 title: "Materialize Docs"
 htmltitle: "Home"
-linktitle: "Docs Home"
-menu: "main"
 disable_toc: true
 disable_list: true
 disable_h1: true

--- a/doc/user/layouts/partials/header.html
+++ b/doc/user/layouts/partials/header.html
@@ -16,7 +16,7 @@
       <a role="menuitem" class="active" href="https://materialize.com/docs/">Docs</a>
       <a role="menuitem" class="hoverable" href="https://materialize.com/product/">Product</a>
       <a role="menuitem" class="hoverable" href="https://materialize.com/solutions/">Use Cases</a>
-      <a role="menuitem" class="hoverable" href="https://materialize.com/resources/">Resources</a>
+      <a role="menuitem" class="hoverable" href="https://materialize.com/blog/">Blog</a>
       <a role="menuitem" class="hoverable" href="https://materialize.com/company/">Company</a>
     </div>
     <a class="secondary" role="menuitem" href="https://cloud.materialize.com/">Log In</a>
@@ -25,9 +25,9 @@
 </nav>
 
 <header class="flex_wrap">
-  <div class="primary gradient_text">
+  <a href="https://materialize.com/docs/" class="primary gradient_text">
     Materialize Documentation
-  </div>
+  </a>
   <div class="flex_grow text_right">
   <a class="btn" href="https://materialize.com/s/chat">
     <svg width="21" height="21" viewBox="0 0 21 21" fill="currentColor" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
Three follow-up fixes from style update in docs:

1. Fix image URL() references in CSS to work whether site is rendered in `/docs` subdirectory or not:
2. Update tabs styling to follow KNI guidance
3. Update nav to switch "Resources" link to "Blog"