### PR TITLE
Various changes to release.json

### DIFF
--- a/misc/load-tests/release.json
+++ b/misc/load-tests/release.json
@@ -1,9 +1,9 @@
 {
     "name": "chbench",
     "launch_script": "MZ_WORKERS=4 bin/mzcompose --mz-find chbench run cloud-load-test",
-    "instance_type": "r5ad.4xlarge",
+    "instance_type": "r5a.4xlarge",
     "ami": "ami-0b29b6e62f2343b46",
-    "size_gb": 64,
+    "size_gb": 200,
     "tags": {
         "scrape_benchmark_numbers": "true",
         "lt_name": "release-chbench",
@@ -15,25 +15,9 @@
 }
 
 {
-    "name": "billing-demo",
-    "launch_script": "MZ_WORKERS=4 bin/mzcompose --mz-find billing run cloud-load-test",
-    "instance_type": "r5ad.4xlarge",
-    "ami": "ami-0b29b6e62f2343b46",
-    "size_gb": 64,
-    "tags": {
-        "scrape_benchmark_numbers": "true",
-        "lt_name": "release-billing-demo",
-        "purpose": "load_test",
-        "mzconduct_workflow": "cloud-load-test",
-        "test": "billing",
-        "environment": "scratch"
-    }
-}
-
-{
     "name": "kinesis",
     "launch_script": "MZ_WORKERS=4 bin/mzcompose --mz-find perf-kinesis run cloud-load-test",
-    "instance_type": "r5ad.4xlarge",
+    "instance_type": "r5a.4xlarge",
     "ami": "ami-0b29b6e62f2343b46",
     "size_gb": 64,
     "tags": {
@@ -49,7 +33,7 @@
 {
     "name": "chaos",
     "launch_script": "MZ_WORKERS=4 bin/mzcompose --mz-find chaos run test-bytes-to-kafka",
-    "instance_type": "r5ad.4xlarge",
+    "instance_type": "r5a.4xlarge",
     "ami": "ami-0b29b6e62f2343b46",
     "size_gb": 64,
     "tags": {


### PR DESCRIPTION
* Change r5ad instances to r5a. We were not using the 400 GB of instance
  storage anyway, so we were paying extra for something with no practical difference.

* Bump local storage on chbench; otherwise, the load generator will
  cause Kafka to use the whole disk before the 24-hour test is over.

* Temporarily get rid of the billing-demo tests. I will do some
  future work to make them useful again; see the [discussion in Slack]
  for details.

[discussion in Slack]: https://materializeinc.slack.com/archives/CTESPM7FU/p1629740066090700