### PR TITLE
defer MirRelationExpr::typ calls

### DIFF
--- a/src/transform/src/fusion/union.rs
+++ b/src/transform/src/fusion/union.rs
@@ -39,7 +39,6 @@ impl Union {
     /// Nested negated unions are merged into the parent one by pushing
     /// the Negate to all their branches.
     pub fn action(&self, relation: &mut MirRelationExpr) {
-        let relation_type = relation.typ();
         if let MirRelationExpr::Union { base, inputs } = relation {
             let can_fuse = iter::once(&**base).chain(&*inputs).any(|input| -> bool {
                 match input {
@@ -76,6 +75,7 @@ impl Union {
                         _ => new_inputs.push(outer_input),
                     }
                 }
+                let relation_type = relation.typ();
                 *relation = MirRelationExpr::union_many(new_inputs, relation_type);
             }
         }


### PR DESCRIPTION
### Motivation

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug. [Link to issue.]

  * This PR adds a known-desirable feature. [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

 * This PR refactors existing code.

`MirRelationExpr::typ` is an expensive method used widely in the transform crate. Given its cost, it should be called only when it's clear that its information is needed. This PR touches several transforms where this method was being called "just in case". This leads to a 23% improvement in the optimization time using TPC-H query 20 as reference. Data [here](https://docs.google.com/spreadsheets/d/1YN5-ONGY05TVxps3KIaC_lUu5aN-lHEPljnM4YH-zIk/edit?usp=sharing).

### Description

<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details."

-->

Defers calling `MirRelationExpr::typ` in several transforms.

Times were taken with the following patch explaining the query 100 times:

```
diff --git a/src/transform/src/lib.rs b/src/transform/src/lib.rs
index d19dcd50b..66275344e 100644
--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -356,7 +356,9 @@ impl Optimizer {
         relation: &mut MirRelationExpr,
         indexes: &HashMap<GlobalId, Vec<(GlobalId, Vec<MirScalarExpr>)>>,
     ) -> Result<(), TransformError> {
+        use std::time::Instant;
         let mut id_gen = Default::default();
+        let start = Instant::now();
         for transform in self.transforms.iter() {
             transform.transform(
                 relation,
@@ -366,6 +368,8 @@ impl Optimizer {
                 },
             )?;
         }
+        let duration = start.elapsed();
+        println!("Time elapsed Optimizer::transform is: {:?}", duration);
         Ok(())
     }
 }

```

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

[ ] This PR has adequate test coverage.
[ ] This PR adds a release note for any user-facing behavior changes.

Since we are not keeping track of compilation times, regressions will go unnoticed.
