### PR TITLE
chaos: Kafka requires Zookeeper to be present at startup

### DIFF
--- a/test/chaos/mzcompose.yml
+++ b/test/chaos/mzcompose.yml
@@ -161,6 +161,11 @@ mzworkflows:
   start-everything:
     steps:
       - step: start-services
+        services: [zookeeper]
+      - step: wait-for-tcp
+        host: zookeeper
+        port: 2181
+      - step: start-services
         services: [materialized, kafka, schema-registry]
       - step: wait-for-tcp
         host: kafka


### PR DESCRIPTION
This (locally) fixes the issues that we've had in the last couple releases. It seems like Kafka eventually gives up if Zookeeper isn't available at startup, but does successfully keep trying once it has connected at least once.