### PR TITLE
Fix 8119 with revised DD

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1059,7 +1059,7 @@ dependencies = [
 [[package]]
 name = "differential-dataflow"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#8a5efd76970f69d3c012574eaecdf9c2ab1c0bfc"
+source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#8cdc53423e4f02dc3f9b4d9c196d364586a4a22b"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -1114,7 +1114,7 @@ checksum = "923dea538cea0aa3025e8685b20d6ee21ef99c4f77e954a30febbaac5ec73a97"
 [[package]]
 name = "dogsdogsdogs"
 version = "0.1.0"
-source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#8a5efd76970f69d3c012574eaecdf9c2ab1c0bfc"
+source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#8cdc53423e4f02dc3f9b4d9c196d364586a4a22b"
 dependencies = [
  "abomonation",
  "abomonation_derive",


### PR DESCRIPTION
### Motivation

  * This PR fixes a recognized bug: #8119

### Description

DD had a very assertive assert that would panic in debug builds using existing DD operators. They should be fixed, but in the meantime the assert has been made less assertive.

### Checklist

[ ] This PR has adequate test coverage.
[x ] This PR adds a release note for any user-facing behavior changes.

We do not test debug builds, so test coverage is not great.

Fixes #8119