### PR TITLE
sql: fix max(int2) func selection

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -60,6 +60,8 @@ Wrap your release notes at the 80 character mark.
   objects with headers {{% gh 7507 %}}, and support CSV with headers in S3. {{%
   gh 7913 %}}
 
+- Fix a bug that caused a panic when computing the `max` of `int2` values.
+
 {{% version-header v0.9.1 %}}
 
 - Change the type of the [`mz_metrics`](/sql/system-catalog#mz_metrics).`time`

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1719,7 +1719,7 @@ lazy_static! {
             },
             "max" => Aggregate {
                 params!(Bool) => AggregateFunc::MaxBool, oid::FUNC_MAX_BOOL_OID;
-                params!(Int16) => AggregateFunc::MaxInt32, 2117;
+                params!(Int16) => AggregateFunc::MaxInt16, 2117;
                 params!(Int32) => AggregateFunc::MaxInt32, 2116;
                 params!(Int64) => AggregateFunc::MaxInt64, 2115;
                 params!(Float32) => AggregateFunc::MaxFloat32, 2119;

--- a/test/sqllogictest/aggregates.slt
+++ b/test/sqllogictest/aggregates.slt
@@ -285,3 +285,14 @@ SELECT count()
 
 query error arguments cannot be implicitly cast to any implementation's parameters
 SELECT sum(*)
+
+# Ensure int2 has its own max implementation
+query I
+SELECT max(column1) FROM (VALUES (1::int2), (-1::int2));
+----
+1
+
+query T
+SELECT pg_typeof(max(column1)) FROM (VALUES (1::int2), (-1::int2));
+----
+smallint


### PR DESCRIPTION
### Motivation
This PR fixes a previously unreported bug.

If attempting to perform a `max` aggregation on an `int2` column, you would encounter a panic as Materialize attempted to unwrap the `int2` as an `int4`.

### Description

This PR makes sure that the proper dataflow function is invoked when calls to `max` receive `int2` args.

### Checklist

[x] This PR has adequate test coverage.
[x] This PR adds a release note for any user-facing behavior changes.
