### PR TITLE
smarter way of comparing union branches for cancellation

### DIFF
--- a/src/transform/src/union_cancel.rs
+++ b/src/transform/src/union_cancel.rs
@@ -26,13 +26,22 @@ impl crate::Transform for UnionBranchCancellation {
     }
 }
 
+/// Result of the comparison of two branches of a union for cancellation
+/// purposes.
 enum BranchCmp {
+    /// The two branches are equivalent in the sense the the produce the
+    /// same exact results.
     Equivalent,
+    /// The two branches are equivalent, but one of them produces negated
+    /// row count values, and hence, they cancel each other.
     Inverse,
+    /// The two branches are not equivalent in any way.
     Distinct,
 }
 
 impl BranchCmp {
+    /// Modify the result of the comparison when a Negate operator is
+    /// found at the top of one the branches just compared.
     fn inverse(self) -> Self {
         match self {
             BranchCmp::Equivalent => BranchCmp::Inverse,
@@ -75,6 +84,10 @@ impl UnionBranchCancellation {
         Ok(())
     }
 
+    /// Compares two branches to check whether they produce the same results but
+    /// with negated row count values, ie. one of them contains an extra Negate operator.
+    /// Negate operators may appear interleaved with Map, Filter and Project
+    /// operators, but these operators must appear in the same order in both branches.
     fn compare_branches(relation: &MirRelationExpr, other: &MirRelationExpr) -> BranchCmp {
         match (relation, other) {
             (

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -206,6 +206,9 @@ mod tests {
             )),
             "ProjectionLifting" => Ok(Box::new(transform::projection_lifting::ProjectionLifting)),
             "ReductionPushdown" => Ok(Box::new(transform::reduction_pushdown::ReductionPushdown)),
+            "UnionBranchCancellation" => {
+                Ok(Box::new(transform::union_cancel::UnionBranchCancellation))
+            }
             _ => Err(anyhow!(
                 "no transform named {} (you might have to add it to get_transform)",
                 name

--- a/src/transform/tests/testdata/union_cancel
+++ b/src/transform/tests/testdata/union_cancel
@@ -1,0 +1,388 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test that the test runner can properly construct sources with keys
+# and report on key information in plans
+
+cat
+(defsource x [int64 int64])
+----
+ok
+
+# equivalent branches can't be cancelled
+
+build apply=UnionBranchCancellation
+(union [(negate (get x)) (negate (get x))])
+----
+----
+%0 =
+| Get x (u0)
+| Negate
+
+%1 =
+| Get x (u0)
+| Negate
+
+%2 =
+| Union %0 %1
+----
+----
+
+build apply=UnionBranchCancellation
+(union [(get x) (get x)])
+----
+----
+%0 =
+| Get x (u0)
+
+%1 =
+| Get x (u0)
+
+%2 =
+| Union %0 %1
+----
+----
+
+build apply=UnionBranchCancellation
+(union [(project (get x) [0]) (project (get x) [0])])
+----
+----
+%0 =
+| Get x (u0)
+| Project (#0)
+
+%1 =
+| Get x (u0)
+| Project (#0)
+
+%2 =
+| Union %0 %1
+----
+----
+
+build apply=UnionBranchCancellation
+(union [(map (get x) [#0]) (project (get x) [#0])])
+----
+----
+%0 =
+| Get x (u0)
+| Map #0
+
+%1 =
+| Get x (u0)
+| Project (#0)
+
+%2 =
+| Union %0 %1
+----
+----
+
+build apply=UnionBranchCancellation
+(union [(filter (get x) [#0]) (project (get x) [#0])])
+----
+----
+%0 =
+| Get x (u0)
+| Filter #0
+
+%1 =
+| Get x (u0)
+| Project (#0)
+
+%2 =
+| Union %0 %1
+----
+----
+
+build apply=UnionBranchCancellation
+(union [(negate (filter (get x) [#0])) (project (negate (get x)) [#0])])
+----
+----
+%0 =
+| Get x (u0)
+| Filter #0
+| Negate
+
+%1 =
+| Get x (u0)
+| Negate
+| Project (#0)
+
+%2 =
+| Union %0 %1
+----
+----
+
+# negated branches
+
+build apply=UnionBranchCancellation
+(union [(get x) (negate (get x))])
+----
+----
+%0 =
+| Constant
+
+%1 =
+| Constant
+
+%2 =
+| Union %0 %1
+----
+----
+
+build apply=UnionBranchCancellation
+(union [(project (get x) [0]) (project (negate (get x)) [0])])
+----
+----
+%0 =
+| Constant
+
+%1 =
+| Constant
+
+%2 =
+| Union %0 %1
+----
+----
+
+build apply=UnionBranchCancellation
+(union [(project (negate (get x)) [0]) (project (get x) [0])])
+----
+----
+%0 =
+| Constant
+
+%1 =
+| Constant
+
+%2 =
+| Union %0 %1
+----
+----
+
+build apply=UnionBranchCancellation
+(union [(map (get x) [#0]) (map (negate (get x)) [#0])])
+----
+----
+%0 =
+| Constant
+
+%1 =
+| Constant
+
+%2 =
+| Union %0 %1
+----
+----
+
+build apply=UnionBranchCancellation
+(union [(map (negate (get x)) [#0]) (map (get x) [#0])])
+----
+----
+%0 =
+| Constant
+
+%1 =
+| Constant
+
+%2 =
+| Union %0 %1
+----
+----
+
+build apply=UnionBranchCancellation
+(union [(filter (get x) [#0]) (filter (negate (get x)) [#0])])
+----
+----
+%0 =
+| Constant
+
+%1 =
+| Constant
+
+%2 =
+| Union %0 %1
+----
+----
+
+build apply=UnionBranchCancellation
+(union [(filter (negate (get x)) [#0]) (filter (get x) [#0])])
+----
+----
+%0 =
+| Constant
+
+%1 =
+| Constant
+
+%2 =
+| Union %0 %1
+----
+----
+
+build apply=UnionBranchCancellation
+(union [(map (get x) [#0]) (map (negate (get x)) [#1])])
+----
+----
+%0 =
+| Get x (u0)
+| Map #0
+
+%1 =
+| Get x (u0)
+| Negate
+| Map #1
+
+%2 =
+| Union %0 %1
+----
+----
+
+build apply=UnionBranchCancellation
+(union [(map (filter (get x) [#0]) [#0]) (map (filter (negate (get x)) [#0]) [#0])])
+----
+----
+%0 =
+| Constant
+
+%1 =
+| Constant
+
+%2 =
+| Union %0 %1
+----
+----
+
+build apply=UnionBranchCancellation
+(union [(map (filter (negate (get x)) [#0]) [#0]) (map (filter (get x) [#0]) [#0])])
+----
+----
+%0 =
+| Constant
+
+%1 =
+| Constant
+
+%2 =
+| Union %0 %1
+----
+----
+
+# map -> filter in the same order, but with a Negate in between
+build apply=UnionBranchCancellation
+(union [(map (filter (get x) [#0]) [#0]) (map (negate (filter (get x) [#0])) [#0])])
+----
+----
+%0 =
+| Constant
+
+%1 =
+| Constant
+
+%2 =
+| Union %0 %1
+----
+----
+
+build apply=UnionBranchCancellation
+(union [(map (negate (filter (get x) [#0])) [#0]) (map (filter (get x) [#0]) [#0])])
+----
+----
+%0 =
+| Constant
+
+%1 =
+| Constant
+
+%2 =
+| Union %0 %1
+----
+----
+
+# map -> filter in different order, branches can't be cancelled
+build apply=UnionBranchCancellation
+(union [(filter (map (get x) [#0]) [#0]) (map (filter (negate (get x)) [#0]) [#0])])
+----
+----
+%0 =
+| Get x (u0)
+| Map #0
+| Filter #0
+
+%1 =
+| Get x (u0)
+| Negate
+| Filter #0
+| Map #0
+
+%2 =
+| Union %0 %1
+----
+----
+
+# first two branches cancel each other, but not the third one
+build apply=UnionBranchCancellation
+(union [(map (negate (get x)) [#0]) (map (get x) [#0]) (map (negate (get x)) [#0])])
+----
+----
+%0 =
+| Constant
+
+%1 =
+| Constant
+
+%2 =
+| Get x (u0)
+| Negate
+| Map #0
+
+%3 =
+| Union %0 %1 %2
+----
+----
+
+build apply=UnionBranchCancellation
+(union [(map (negate (get x)) [#0]) (map (get x) [#0]) (map (get x) [#0])])
+----
+----
+%0 =
+| Constant
+
+%1 =
+| Constant
+
+%2 =
+| Get x (u0)
+| Map #0
+
+%3 =
+| Union %0 %1 %2
+----
+----
+
+# first and third cancel each other
+build apply=UnionBranchCancellation
+(union [(map (negate (get x)) [#0]) (map (negate (get x)) [#0]) (map (get x) [#0])])
+----
+----
+%0 =
+| Constant
+
+%1 =
+| Get x (u0)
+| Negate
+| Map #0
+
+%2 =
+| Constant
+
+%3 =
+| Union %0 %1 %2
+----
+----

--- a/test/sqllogictest/column_knowledge.slt
+++ b/test/sqllogictest/column_knowledge.slt
@@ -453,32 +453,9 @@ EOF
 query T multiline
 EXPLAIN SELECT * FROM t4 AS a1 LEFT JOIN t4 AS a2 USING (f1, f2) WHERE a1.f1 = 123 AND a1.f2 = 234;
 ----
-%0 = Let l0 =
+%0 =
 | Get materialize.public.t4 (u7)
 | Filter (#0 = 123), (#1 = 234)
-
-%1 =
-| Get %0 (l0)
-| Project (#0, #1, #0, #1)
-
-%2 =
-| Get %0 (l0)
-| Negate
-| Map 123, 234
-| Project (#2, #3)
-
-%3 =
-| Get %0 (l0)
-| Map 123, 234
-| Project (#2, #3)
-
-%4 =
-| Union %2 %3
-| Map null, null
-
-%5 =
-| Union %1 %4
-| Project (#0, #1)
 
 EOF
 
@@ -489,32 +466,9 @@ EOF
 query T multiline
 EXPLAIN SELECT * FROM t4 AS a1 LEFT JOIN t4 AS a2 USING (f1, f2) WHERE a1.f1 = 123 AND a2.f2 = 234;
 ----
-%0 = Let l0 =
+%0 =
 | Get materialize.public.t4 (u7)
 | Filter (#0 = 123), (#1 = 234)
-
-%1 =
-| Get %0 (l0)
-| Project (#0, #1, #0, #1)
-
-%2 =
-| Get %0 (l0)
-| Negate
-| Map 123, 234
-| Project (#2, #3)
-
-%3 =
-| Get %0 (l0)
-| Map 123, 234
-| Project (#2, #3)
-
-%4 =
-| Union %2 %3
-| Map null, null
-
-%5 =
-| Union %1 %4
-| Project (#0, #1)
 
 EOF
 


### PR DESCRIPTION
### Motivation

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug. [Link to issue.]

  * This PR adds a known-desirable feature. [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

* This PR adds a known-desirable feature. #8029

### Description

<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details."

-->

Allow negate operators to be interleaved between Map, Filter and Project when comparing whether two branches of a union are cancellable, instead of just lifting the Negate operators towards the Union.

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [x] This PR has adequate test coverage.
- [ ] This PR adds a release note for any user-facing behavior changes.

Fixes #8029.