### PR TITLE
dataflow: ignore trailing newline characters when decoding files

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -49,6 +49,8 @@ Wrap your release notes at the 80 character mark.
 {{% version-header v0.9.3 %}}
 
 - Fix a bug that caused a panic when computing the `max` of `int2` values.
+- Trailing newline characters of POSIX compliant files will no longer be
+  decoded as an empty byte row {{% gh 8142 %}}
 
 - Support `ORDER BY` in aggregate functions.
 

--- a/src/dataflow/src/decode/mod.rs
+++ b/src/dataflow/src/decode/mod.rs
@@ -305,9 +305,14 @@ impl DataDecoder {
                 result
             }
             DataDecoderInner::DelimitedBytes { format, .. } => {
-                let data = *bytes;
-                *bytes = &[][..];
-                format.decode(data, upstream_coord, push_metadata)
+                let data = std::mem::take(bytes);
+                // If we hit EOF with no bytes left in the buffer it means the file had a trailing
+                // \n character that can be ignored. Otherwise, we decode the final bytes as normal
+                if data.is_empty() {
+                    Ok(None)
+                } else {
+                    format.decode(data, upstream_coord, push_metadata)
+                }
             }
             _ => Ok(None),
         }

--- a/src/testdrive/src/action/file.rs
+++ b/src/testdrive/src/action/file.rs
@@ -63,11 +63,15 @@ fn build_path(cmd: &mut BuiltinCommand) -> Result<String, String> {
 pub fn build_append(mut cmd: BuiltinCommand) -> Result<AppendAction, String> {
     let path = build_path(&mut cmd)?;
     let compression = build_compression(&mut cmd)?;
+    let trailing_newline = cmd.args.opt_bool("trailing-newline")?.unwrap_or(true);
     cmd.args.done()?;
     let mut contents = vec![];
     for line in cmd.input {
         contents.extend(bytes::unescape(line.as_bytes())?);
         contents.push(b'\n');
+    }
+    if !trailing_newline {
+        contents.pop();
     }
     Ok(AppendAction {
         path,

--- a/test/testdrive/github-7290.td
+++ b/test/testdrive/github-7290.td
@@ -1,0 +1,32 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ file-append path=posix.txt
+foo
+bar
+
+> CREATE MATERIALIZED SOURCE posix
+  FROM FILE '${testdrive.temp-dir}/posix.txt'
+  FORMAT BYTES;
+
+> SELECT data FROM posix ORDER BY mz_line_no;
+foo
+bar
+
+$ file-append path=non_posix.txt trailing-newline=false
+foo
+bar
+
+> CREATE MATERIALIZED SOURCE non_posix
+  FROM FILE '${testdrive.temp-dir}/non_posix.txt'
+  FORMAT BYTES;
+
+> SELECT data FROM non_posix ORDER BY mz_line_no;
+foo
+bar


### PR DESCRIPTION
### Motivation

  * This PR fixes a recognized bug. #7290

### Description



### Checklist

- [x] This PR has adequate test coverage.
- [x] This PR adds a release note for any user-facing behavior changes.
