### PR TITLE
coord: partial SQL linearizability

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -30,7 +30,7 @@ use repr::Timestamp;
 use serde::{Deserialize, Serialize};
 
 use build_info::DUMMY_BUILD_INFO;
-use dataflow_types::{SinkConnector, SinkConnectorBuilder, SourceConnector, Timeline};
+use dataflow_types::{SinkConnector, SinkConnectorBuilder, SourceConnector, TimelineId};
 use expr::{ExprHumanizer, GlobalId, MirScalarExpr, OptimizedMirRelationExpr};
 use persist::error::Error as PersistError;
 use persist::indexed::runtime::RuntimeClient as PersistClient;
@@ -286,8 +286,8 @@ pub struct Table {
 impl Table {
     // The Coordinator controls insertions for tables (including system tables),
     // so they are realtime.
-    pub fn timeline(&self) -> Timeline {
-        Timeline::EpochMilliseconds
+    pub fn timeline(&self) -> TimelineId {
+        TimelineId::EpochMilliseconds
     }
 }
 
@@ -711,7 +711,7 @@ impl Catalog {
                             create_sql: "TODO".to_string(),
                             optimized_expr,
                             connector: dataflow_types::SourceConnector::Local {
-                                timeline: Timeline::EpochMilliseconds,
+                                timeline: TimelineId::EpochMilliseconds,
                                 persisted_name: None,
                             },
                             bare_desc: log.variant.desc(),

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -712,7 +712,7 @@ pub enum Compression {
 /// instantiations. These attached data types should be expanded in the future
 /// if we need to tell apart more kinds of sources.
 #[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Serialize, Deserialize, Hash)]
-pub enum Timeline {
+pub enum TimelineId {
     /// EpochMilliseconds means the timestamp is the number of milliseconds since
     /// the Unix epoch.
     EpochMilliseconds,
@@ -748,10 +748,10 @@ pub enum SourceConnector {
         key_envelope: KeyEnvelope,
         consistency: Consistency,
         ts_frequency: Duration,
-        timeline: Timeline,
+        timeline: TimelineId,
     },
     Local {
-        timeline: Timeline,
+        timeline: TimelineId,
         persisted_name: Option<String>,
     },
 }
@@ -799,7 +799,7 @@ impl SourceConnector {
         }
     }
 
-    pub fn timeline(&self) -> Timeline {
+    pub fn timeline(&self) -> TimelineId {
         match self {
             SourceConnector::External { timeline, .. } => timeline.clone(),
             SourceConnector::Local { timeline, .. } => timeline.clone(),

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -36,7 +36,7 @@ use dataflow_types::{
     KafkaSourceConnector, KeyEnvelope, KinesisSourceConnector, PostgresSourceConnector,
     ProtobufEncoding, PubNubSourceConnector, RegexEncoding, S3SourceConnector,
     SinkConnectorBuilder, SinkEnvelope, SourceConnector, SourceDataEncoding, SourceEnvelope,
-    Timeline,
+    TimelineId,
 };
 use expr::{func, GlobalId, MirRelationExpr, TableFunc, UnaryFunc};
 use interchange::avro::{self, AvroSchemaGenerator, DebeziumDeduplicationStrategy};
@@ -876,18 +876,18 @@ pub fn plan_create_source(
     // Allow users to specify a timeline. If they do not, determine a default timeline for the source.
     let timeline = if let Some(timeline) = with_options.remove("timeline") {
         match timeline {
-            Value::String(timeline) => Timeline::User(timeline),
+            Value::String(timeline) => TimelineId::User(timeline),
             v => bail!("unsupported timeline value {}", v.to_ast_string()),
         }
     } else {
         match (&consistency, &envelope) {
             (_, SourceEnvelope::CdcV2) => match with_options.remove("epoch_ms_timeline") {
-                None => Timeline::External(name.to_string()),
-                Some(Value::Boolean(true)) => Timeline::EpochMilliseconds,
+                None => TimelineId::External(name.to_string()),
+                Some(Value::Boolean(true)) => TimelineId::EpochMilliseconds,
                 Some(v) => bail!("unsupported epoch_ms_timeline value {}", v),
             },
-            (Consistency::RealTime, _) => Timeline::EpochMilliseconds,
-            (Consistency::BringYourOwn(byo), _) => Timeline::Counter(byo.clone()),
+            (Consistency::RealTime, _) => TimelineId::EpochMilliseconds,
+            (Consistency::BringYourOwn(byo), _) => TimelineId::Counter(byo.clone()),
         }
     };
 

--- a/test/coordtest/linearizability.ct
+++ b/test/coordtest/linearizability.ct
@@ -54,9 +54,13 @@ append-file name=s1
 3
 ----
 
+set-upper-filter
+materialize.public.v2_primary_idx
+----
+
 # Wait for the append to s1, but prevent increasing the since and upper
 # of v2 so its timestamp is < v1's.
-wait-sql exclude-uppers=materialize.public.v2_primary_idx
+wait-sql
 SELECT c = 2 FROM v1;
 ----
 
@@ -88,8 +92,8 @@ Rows(
     ],
 )
 
-# But when combined, the count for v1 is 1, which means we have chosen
-# an older timestamp and thus are not linearizable.
+# When combined, the count for v1 is 2, which means we have chosen a timestamp
+# in advance of v2's upper due to the linearizability guarantees.
 sql
 SELECT * FROM v1, v2;
 ----
@@ -97,10 +101,67 @@ Rows(
     [
         Row{[
             Int64(
-                1,
+                2,
             ),
             Int64(
                 1,
+            ),
+        ]},
+    ],
+)
+
+# Create a non-tailed source so the timestamps are closed. This causes
+# determine_timestamp to use u64::max, and we want to test that that timestamp
+# doesn't get propogated to the linearizability tracker which would prevent all
+# future realtime timeline queries.
+sql
+CREATE MATERIALIZED SOURCE s1_closed (a)
+FROM FILE '<TEMP>/s1'
+FORMAT TEXT;
+----
+CreatedSource {
+    existed: false,
+}
+
+wait-sql
+SELECT count(*) = 2 FROM s1_closed;
+----
+
+sql
+SELECT count(*) FROM s1_closed AS OF 0
+----
+Rows(
+    [
+        Row{[
+            Int64(
+                0,
+            ),
+        ]},
+    ],
+)
+
+# Ensure we don't choose the max timestamp.
+sql
+SELECT mz_logical_timestamp() != 18446744073709551615 FROM s1_closed LIMIT 1
+----
+Rows(
+    [
+        Row{[
+            True,
+        ]},
+    ],
+)
+
+# Verify we can read from v1 (this ensures the linearizability tracker didn't
+# bump to end-of-time due to the closed file source).
+sql
+SELECT * FROM v1;
+----
+Rows(
+    [
+        Row{[
+            Int64(
+                2,
             ),
         ]},
     ],

--- a/test/testdrive/csv-sources.td
+++ b/test/testdrive/csv-sources.td
@@ -79,10 +79,10 @@ true
 true
 true
 
-# The timestamp chosen when reading from a static CSV should be the end of time,
-# since the definition of "static" means "will never change again".
-> SELECT count(*), mz_logical_timestamp() FROM static_csv
-4  18446744073709551615
+# A static source means it will never change again, so we should be able to
+# read it at the end of time.
+> SELECT count(*) FROM static_csv AS OF 18446744073709551615
+4
 
 # Static CSV with automatic headers.
 > CREATE MATERIALIZED SOURCE static_csv_header

--- a/test/testdrive/timestamps-debezium-kafka.td
+++ b/test/testdrive/timestamps-debezium-kafka.td
@@ -138,36 +138,40 @@ $ kafka-ingest format=avro topic=consistency timestamp=1 schema=${trxschema}
 {"status":"BEGIN","id":"3","event_count":null,"data_collections":null}
 {"status":"END","id":"3","event_count":{"long": 3},"data_collections":{"array": [{"event_count": 2, "data_collection": "testdrive-foo-${testdrive.seed}"},{"event_count": 1, "data_collection": "testdrive-bar-${testdrive.seed}"}]}}
 
-> SELECT * FROM foo;
-b  sum
-------
-1  1
-2  2
+> SELECT mz_logical_timestamp() t, * FROM foo;
+t b  sum
+--------
+2 1  1
+2 2  2
 
-> SELECT * FROM bar;
-b  sum
-------
-1  10
-3  30
+# At this point, foo is still waiting on another row, and so is still at
+# timestamp 2. bar however has received its row and so has advanced to 3. If
+# we select from bar now, the linearizability timestamp will get bumped to
+# 3. Instead, select from the join so the linearizability timestamp stays at 2.
+> SELECT mz_logical_timestamp() t, * FROM join;
+t b sum sum
+-----------
+2 1  1  10
 
-> SELECT * FROM join;
-b sum sum
----------
-1  1  10
+> SELECT mz_logical_timestamp() t, * FROM bar;
+t b  sum
+--------
+3 1  10
+3 3  30
 
 $ kafka-ingest format=avro topic=foo schema=${schema} timestamp=1
 {"before": null, "after": {"row": {"a": 4, "b": 4}}}
 
-> SELECT * FROM foo;
-b  sum
-------
-1  1
-2  2
-3  3
-4  4
+> SELECT mz_logical_timestamp() t, * FROM foo;
+t b  sum
+--------
+3 1  1
+3 2  2
+3 3  3
+3 4  4
 
-> SELECT * FROM join;
-b sum sum
----------
-1  1  10
-3  3  30
+> SELECT mz_logical_timestamp() t, * FROM join;
+t b sum sum
+-----------
+3 1  1  10
+3 3  3  30

--- a/test/testdrive/transactions-timedomain-nonmaterialized.td
+++ b/test/testdrive/transactions-timedomain-nonmaterialized.td
@@ -101,3 +101,14 @@ Transactions can only reference objects in the same timedomain
 3
 
 > COMMIT
+
+# Ensure that a transaction with an initial query on a static view opts itself
+# in to the system timeline correctly.
+> CREATE TABLE t (i INT);
+> CREATE VIEW v_static AS VALUES (1)
+> BEGIN
+> SELECT * FROM v_static
+1
+
+> SELECT * FROM t
+> COMMIT


### PR DESCRIPTION
### Motivation

This PR adds partial support for SQL linearizability. See #6747, #5073, and #7355.

### Description

Use a new Timeline struct to keep track of linearizability per
timeline. When we need to create a read or write timestamp, use the
Timeline struct to ensure we are producing a timestamp that meets that
guarantee.

This is not a full solution (see #6747 for a tracking list).

### Checklist

- [x] This PR has adequate test coverage.
- [ ] This PR adds a release note for any user-facing behavior changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/8156)
<!-- Reviewable:end -->
