### PR TITLE
dataflow: Alias the spine type

### DIFF
--- a/src/dataflow/src/arrangement/manager.rs
+++ b/src/dataflow/src/arrangement/manager.rs
@@ -14,8 +14,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 
 use differential_dataflow::operators::arrange::TraceAgent;
-use differential_dataflow::trace::implementations::ord::{OrdKeyBatch, OrdValBatch};
-use differential_dataflow::trace::implementations::spine_fueled::Spine;
+use differential_dataflow::trace::implementations::ord::{OrdKeySpine, OrdValSpine};
 use differential_dataflow::trace::TraceReader;
 use ore::metric;
 use ore::metrics::{
@@ -28,12 +27,13 @@ use dataflow_types::DataflowError;
 use expr::GlobalId;
 use repr::{Diff, Row, Timestamp};
 
-pub type OrdKeySpine<K, T, R, O = usize> = Spine<K, (), T, R, Rc<OrdKeyBatch<K, T, R, O>>>;
-pub type OrdValSpine<K, V, T, R, O = usize> = Spine<K, V, T, R, Rc<OrdValBatch<K, V, T, R, O>>>;
-pub type TraceKeyHandle<K, T, R> = TraceAgent<OrdKeySpine<K, T, R>>;
-pub type TraceValHandle<K, V, T, R> = TraceAgent<OrdValSpine<K, V, T, R>>;
-pub type KeysValsHandle = TraceValHandle<Row, Row, Timestamp, Diff>;
-pub type ErrsHandle = TraceKeyHandle<DataflowError, Timestamp, Diff>;
+pub type RowSpine<K, V, T, R, O = usize> = OrdValSpine<K, V, T, R, O>;
+pub type ErrSpine<K, T, R, O = usize> = OrdKeySpine<K, T, R, O>;
+
+pub type TraceRowHandle<K, V, T, R> = TraceAgent<RowSpine<K, V, T, R>>;
+pub type TraceErrHandle<K, T, R> = TraceAgent<ErrSpine<K, T, R>>;
+pub type KeysValsHandle = TraceRowHandle<Row, Row, Timestamp, Diff>;
+pub type ErrsHandle = TraceErrHandle<DataflowError, Timestamp, Diff>;
 
 use prometheus::core::{AtomicF64, AtomicU64};
 use std::time::Instant;

--- a/src/dataflow/src/logging/differential.rs
+++ b/src/dataflow/src/logging/differential.rs
@@ -18,6 +18,7 @@ use timely::dataflow::operators::capture::EventLink;
 use timely::logging::WorkerIdentifier;
 
 use super::{DifferentialLog, LogVariant};
+use crate::arrangement::manager::RowSpine;
 use crate::arrangement::KeysValsHandle;
 use repr::{Datum, Row, Timestamp};
 
@@ -114,7 +115,7 @@ pub fn construct<A: Allocate>(
             (LogVariant::Differential(DifferentialLog::Sharing), sharing),
         ];
 
-        use differential_dataflow::operators::arrange::arrangement::ArrangeByKey;
+        use differential_dataflow::operators::arrange::arrangement::Arrange;
         let mut result = std::collections::HashMap::new();
         for (variant, collection) in logs {
             if config.active_logs.contains_key(&variant) {
@@ -129,7 +130,7 @@ pub fn construct<A: Allocate>(
                             (row_packer.finish_and_reuse(), row)
                         }
                     })
-                    .arrange_by_key()
+                    .arrange::<RowSpine<_, _, _, _>>()
                     .trace;
                 result.insert(variant, (key_clone, trace));
             }

--- a/src/dataflow/src/logging/materialized.rs
+++ b/src/dataflow/src/logging/materialized.rs
@@ -19,6 +19,7 @@ use timely::dataflow::operators::generic::operator::Operator;
 use timely::logging::WorkerIdentifier;
 
 use super::{LogVariant, MaterializedLog};
+use crate::arrangement::manager::RowSpine;
 use crate::arrangement::KeysValsHandle;
 use expr::{GlobalId, SourceInstanceId};
 use repr::{Datum, Row, Timestamp};
@@ -549,7 +550,7 @@ pub fn construct<A: Allocate>(
             ),
         ];
 
-        use differential_dataflow::operators::arrange::arrangement::ArrangeByKey;
+        use differential_dataflow::operators::arrange::arrangement::Arrange;
         let mut result = std::collections::HashMap::new();
         for (variant, collection) in logs {
             if config.active_logs.contains_key(&variant) {
@@ -564,7 +565,7 @@ pub fn construct<A: Allocate>(
                             (row_packer.finish_and_reuse(), row)
                         }
                     })
-                    .arrange_by_key()
+                    .arrange::<RowSpine<_, _, _, _>>()
                     .trace;
                 result.insert(variant, (key_clone, trace));
             }

--- a/src/dataflow/src/logging/timely.rs
+++ b/src/dataflow/src/logging/timely.rs
@@ -23,6 +23,7 @@ use timely::dataflow::Scope;
 use timely::logging::{ParkEvent, TimelyEvent, WorkerIdentifier};
 
 use super::{LogVariant, TimelyLog};
+use crate::arrangement::manager::RowSpine;
 use crate::arrangement::KeysValsHandle;
 use dataflow_types::logging::LoggingConfig;
 use repr::{datum_list_size, datum_size, Datum, Row, Timestamp};
@@ -409,7 +410,7 @@ pub fn construct<A: Allocate>(
             }
         });
 
-        use differential_dataflow::operators::arrange::arrangement::ArrangeByKey;
+        use differential_dataflow::operators::arrange::arrangement::Arrange;
 
         // Restrict results by those logs that are meant to be active.
         let logs = vec![
@@ -436,7 +437,7 @@ pub fn construct<A: Allocate>(
                             (row_packer.finish_and_reuse(), row)
                         }
                     })
-                    .arrange_by_key()
+                    .arrange::<RowSpine<_, _, _, _>>()
                     .trace;
                 result.insert(variant, (key_clone, trace));
             }

--- a/src/dataflow/src/render/join/linear_join.rs
+++ b/src/dataflow/src/render/join/linear_join.rs
@@ -11,7 +11,6 @@ use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::arrangement::Arrange;
 use differential_dataflow::operators::arrange::arrangement::Arranged;
 use differential_dataflow::operators::join::JoinCore;
-use differential_dataflow::trace::implementations::ord::OrdValSpine;
 use differential_dataflow::trace::BatchReader;
 use differential_dataflow::trace::Cursor;
 use differential_dataflow::trace::TraceReader;
@@ -322,7 +321,8 @@ where
                 }
             });
             errors.push(errs);
-            let arranged = keyed.arrange_named::<OrdValSpine<_, _, _, _>>(&format!("JoinStage"));
+            use crate::arrangement::manager::RowSpine;
+            let arranged = keyed.arrange_named::<RowSpine<_, _, _, _>>(&format!("JoinStage"));
             joined = JoinedFlavor::Local(arranged);
         }
 

--- a/src/dataflow/src/render/threshold.rs
+++ b/src/dataflow/src/render/threshold.rs
@@ -26,13 +26,13 @@ use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::{Arranged, TraceAgent};
 use differential_dataflow::operators::reduce::ReduceCore;
 use differential_dataflow::operators::Consolidate;
-use differential_dataflow::trace::implementations::ord::OrdValSpine;
 use timely::dataflow::Scope;
 use timely::progress::{timestamp::Refines, Timestamp};
 
 use repr::{Diff, Row};
 use serde::{Deserialize, Serialize};
 
+use crate::arrangement::manager::RowSpine;
 use crate::render::context::CollectionBundle;
 use crate::render::context::{ArrangementFlavor, Context};
 
@@ -101,7 +101,7 @@ fn threshold_arrangement<G, T, R, L>(
     arrangement: &R,
     name: &str,
     logic: L,
-) -> Arranged<G, TraceAgent<OrdValSpine<Row, Row, G::Timestamp, Diff>>>
+) -> Arranged<G, TraceAgent<RowSpine<Row, Row, G::Timestamp, Diff>>>
 where
     G: Scope,
     G::Timestamp: Lattice + Refines<T>,


### PR DESCRIPTION
This change has been extracted from the columnation PR #6763 to only
contain changes unrelated to columnation.

Signed-off-by: Moritz Hoffmann <mh@materialize.com>

### Motivation

 * This PR refactors existing code: It extracts a common type alias for all arrangement types in Materialize. It is extracted from https://github.com/MaterializeInc/materialize/pull/6763.

### Description

This PR is a part of a bigger PR to introduce columnar data format in arrangements. It introduces type aliases for the spines Materialize uses for its arrangements and uses the aliases in all relevant places.

### Checklist

- [ ] This PR has adequate test coverage.
- [ ] This PR adds a release note for any user-facing behavior changes.
