### PR TITLE
testdrive: test protobuf + CSR schemas with imports

### DIFF
--- a/src/ccsr/tests/client.rs
+++ b/src/ccsr/tests/client.rs
@@ -52,12 +52,17 @@ async fn test_client() -> Result<(), anyhow::Error> {
     assert_eq!(count_schemas(&client, "ccsr-test-").await?, 0);
 
     let schema_v1_id = client
-        .publish_schema("ccsr-test-schema", schema_v1, SchemaType::Avro)
+        .publish_schema("ccsr-test-schema", schema_v1, SchemaType::Avro, &[])
         .await?;
     assert!(schema_v1_id > 0);
 
     match client
-        .publish_schema("ccsr-test-schema", schema_v2_incompat, SchemaType::Avro)
+        .publish_schema(
+            "ccsr-test-schema",
+            schema_v2_incompat,
+            SchemaType::Avro,
+            &[],
+        )
         .await
     {
         Err(PublishError::IncompatibleSchema) => (),
@@ -71,7 +76,7 @@ async fn test_client() -> Result<(), anyhow::Error> {
     }
 
     let schema_v2_id = client
-        .publish_schema("ccsr-test-schema", schema_v2, SchemaType::Avro)
+        .publish_schema("ccsr-test-schema", schema_v2, SchemaType::Avro, &[])
         .await?;
     assert!(schema_v2_id > 0);
     assert!(schema_v2_id > schema_v1_id);
@@ -79,7 +84,7 @@ async fn test_client() -> Result<(), anyhow::Error> {
     assert_eq!(
         schema_v1_id,
         client
-            .publish_schema("ccsr-test-schema", schema_v1, SchemaType::Avro)
+            .publish_schema("ccsr-test-schema", schema_v1, SchemaType::Avro, &[])
             .await?
     );
 
@@ -101,7 +106,7 @@ async fn test_client() -> Result<(), anyhow::Error> {
     assert_eq!(count_schemas(&client, "ccsr-test-").await?, 1);
 
     client
-        .publish_schema("ccsr-test-another-schema", "\"int\"", SchemaType::Avro)
+        .publish_schema("ccsr-test-another-schema", "\"int\"", SchemaType::Avro, &[])
         .await?;
     assert_eq!(count_schemas(&client, "ccsr-test-").await?, 2);
 
@@ -126,10 +131,10 @@ async fn test_client_errors() -> Result<(), anyhow::Error> {
 
     // Publish-specific errors.
     match client
-        .publish_schema("ccsr-test-schema", "blah", SchemaType::Avro)
+        .publish_schema("ccsr-test-schema", "blah", SchemaType::Avro, &[])
         .await
     {
-        Err(PublishError::InvalidSchema) => (),
+        Err(PublishError::InvalidSchema { .. }) => (),
         res => panic!("expected PublishError::InvalidSchema, got {:?}", res),
     }
 
@@ -154,7 +159,7 @@ async fn test_server_errors() -> Result<(), anyhow::Error> {
     )?;
 
     match client_graceful
-        .publish_schema("foo", "bar", SchemaType::Avro)
+        .publish_schema("foo", "bar", SchemaType::Avro, &[])
         .await
     {
         Err(PublishError::Server {
@@ -197,7 +202,7 @@ async fn test_server_errors() -> Result<(), anyhow::Error> {
     )?;
 
     match client_crash
-        .publish_schema("foo", "bar", SchemaType::Avro)
+        .publish_schema("foo", "bar", SchemaType::Avro, &[])
         .await
     {
         Err(PublishError::Server {

--- a/src/coord/src/sink_connector.rs
+++ b/src/coord/src/sink_connector.rs
@@ -314,7 +314,12 @@ async fn publish_kafka_schemas(
     value_schema_type: ccsr::SchemaType,
 ) -> Result<(Option<i32>, i32), CoordError> {
     let value_schema_id = ccsr
-        .publish_schema(&format!("{}-value", topic), value_schema, value_schema_type)
+        .publish_schema(
+            &format!("{}-value", topic),
+            value_schema,
+            value_schema_type,
+            &[],
+        )
         .await
         .context("unable to publish value schema to registry in kafka sink")?;
 
@@ -323,7 +328,7 @@ async fn publish_kafka_schemas(
             CoordError::Unstructured(anyhow!("expected schema type for key schema"))
         })?;
         Some(
-            ccsr.publish_schema(&format!("{}-key", topic), key_schema, key_schema_type)
+            ccsr.publish_schema(&format!("{}-key", topic), key_schema, key_schema_type, &[])
                 .await
                 .context("unable to publish key schema to registry in kafka sink")?,
         )

--- a/src/kafka-util/src/bin/kgen.rs
+++ b/src/kafka-util/src/bin/kgen.rs
@@ -616,6 +616,7 @@ async fn main() -> anyhow::Result<()> {
                     &format!("{}-value", args.topic),
                     &value_schema.to_string(),
                     ccsr::SchemaType::Avro,
+                    &[],
                 )
                 .await?;
             let generator =
@@ -645,6 +646,7 @@ async fn main() -> anyhow::Result<()> {
                     &format!("{}-key", args.topic),
                     &key_schema.to_string(),
                     ccsr::SchemaType::Avro,
+                    &[],
                 )
                 .await?;
             let generator =

--- a/src/testdrive/build.rs
+++ b/src/testdrive/build.rs
@@ -15,5 +15,6 @@ fn main() {
         .input("src/format/protobuf/recursive.proto")
         .input("src/format/protobuf/simple.proto")
         .input("src/format/protobuf/nested.proto")
+        .input("src/format/protobuf/imported.proto")
         .build_script_exec();
 }

--- a/src/testdrive/src/action/kafka/ingest.rs
+++ b/src/testdrive/src/action/kafka/ingest.rs
@@ -130,6 +130,9 @@ impl Transcoder {
                         Self::decode_json::<_, protobuf::gen::nested::NestedOuter>(row)?
                             .map(convert)
                     }
+                    protobuf::MessageType::Imported => {
+                        Self::decode_json::<_, protobuf::gen::imported::Imported>(row)?.map(convert)
+                    }
                 };
                 let val = if let Some(decoded) = val {
                     decoded
@@ -257,7 +260,7 @@ impl Action for IngestAction {
                     let schema_id = if self.publish {
                         let ccsr_subject = format!("{}-{}", topic_name, typ);
                         let schema_id = ccsr_client
-                            .publish_schema(&ccsr_subject, &schema, ccsr::SchemaType::Avro)
+                            .publish_schema(&ccsr_subject, &schema, ccsr::SchemaType::Avro, &[])
                             .await
                             .map_err(|e| format!("schema registry error: {}", e))?;
                         schema_id
@@ -279,7 +282,7 @@ impl Action for IngestAction {
                         let schema = schema.expect("schema");
                         let ccsr_subject = format!("{}-{}", topic_name, typ);
                         ccsr_client
-                            .publish_schema(&ccsr_subject, &schema, ccsr::SchemaType::Protobuf)
+                            .publish_schema(&ccsr_subject, &schema, ccsr::SchemaType::Protobuf, &[])
                             .await
                             .map_err(|e| format!("schema registry error: {}", e))?;
                     }

--- a/src/testdrive/src/format/protobuf.rs
+++ b/src/testdrive/src/format/protobuf.rs
@@ -22,6 +22,7 @@ pub enum MessageType {
     Measurement,
     SimpleId,
     NestedOuter,
+    Imported,
 }
 
 impl FromStr for MessageType {
@@ -34,6 +35,7 @@ impl FromStr for MessageType {
             "measurement" => Ok(MessageType::Measurement),
             "simpleid" => Ok(MessageType::SimpleId),
             "nested" => Ok(MessageType::NestedOuter),
+            "imported" => Ok(MessageType::Imported),
             _ => Err(format!(
                 "testdrive: unknown built-in protobuf message: {}",
                 s

--- a/src/testdrive/src/format/protobuf/imported.proto
+++ b/src/testdrive/src/format/protobuf/imported.proto
@@ -1,0 +1,16 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+syntax = "proto3";
+
+import 'simple.proto';
+
+message Imported {
+    SimpleId id = 1;
+}

--- a/test/testdrive/protobuf.td
+++ b/test/testdrive/protobuf.td
@@ -96,7 +96,7 @@ $ kafka-ingest format=protobuf topic=messages-partitioned message=struct timesta
   WITH (start_offset=[1,0])
   FORMAT PROTOBUF MESSAGE '.Struct' USING SCHEMA FILE '${testdrive.protobuf-descriptors-file}'
 
-$ kafka-create-topic topic=tester
+$ kafka-create-topic topic=simple
 
 $ set schema
 syntax = "proto3";
@@ -105,23 +105,64 @@ message SimpleId {
   string id = 1;
 }
 
-$ kafka-ingest topic=tester format=protobuf schema=${schema} message=simpleid publish=true
+$ kafka-ingest topic=simple format=protobuf schema=${schema} message=simpleid publish=true
 {"id": "a"}
 {"id": "b"}
 
-> CREATE MATERIALIZED SOURCE tester
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-tester-${testdrive.seed}'
+> CREATE MATERIALIZED SOURCE simple
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-simple-${testdrive.seed}'
   FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
-> SHOW COLUMNS FROM tester
+> SHOW COLUMNS FROM simple
 id         true   text
 mz_offset  false  bigint
 
-> SELECT * FROM tester
+> SELECT * FROM simple
 id   mz_offset
 ------------
 a    1
 b    2
+
+$ kafka-create-topic topic=imported
+
+$ set schema
+syntax = "proto3";
+
+import 'simple.proto';
+
+message Imported {
+    SimpleId id = 1;
+}
+
+$ http-request method=POST url=${testdrive.schema-registry-url}subjects/testdrive-imported-${testdrive.seed}-value/versions content-type=application/json
+{
+    "schema": "syntax = \"proto3\"; import 'simple.proto'; message Imported { SimpleId id = 1; }",
+    "schemaType": "PROTOBUF",
+    "references": [{
+        "name": "simple.proto",
+        "subject": "testdrive-simple-${testdrive.seed}-value",
+        "version": 1
+    }]
+}
+
+$ kafka-ingest topic=imported format=protobuf schema=${schema} message=imported
+{"id": {"id": "a"}}
+{"id": {"id": "b"}}
+
+! CREATE MATERIALIZED SOURCE imported_csr
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-imported-${testdrive.seed}'
+  FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+unsupported protobuf schema reference simple.proto
+
+> CREATE MATERIALIZED SOURCE meep
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-imported-${testdrive.seed}'
+  FORMAT PROTOBUF MESSAGE '.Imported' USING SCHEMA FILE '${testdrive.protobuf-descriptors-file}'
+
+> SELECT * FROM meep
+id                  mz_offset
+--------------------------
+"{\"id\":\"a\"}"   1
+"{\"id\":\"b\"}"   2
 
 $ kafka-create-topic topic=nested-proto
 
@@ -165,7 +206,6 @@ message NestedInner {
 
   Binary binary = 11;
 }
-
 
 $ kafka-ingest topic=nested-proto format=protobuf schema=${schema} message=nested publish=true
 {"double": 1.1, "float": 2.2, "int32": -100, "int64": 200, "sint32": 987234, "sint64": 129387981723, "sfixed32": 123, "sfixed64": 567, "bool": true, "string": "hey", "bytes": [102, 111, 111], "binary": "ZERO", "nested": []}


### PR DESCRIPTION
### Motivation

We've just merged protobuf + CSR support for sources, but I failed to add tests for protobuf + CSR schemas with imports. Nikhil pointed out that we should add those tests [here](https://github.com/MaterializeInc/materialize/issues/7335#issuecomment-912193882).

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug. [Link to issue.]

  * This PR adds a known-desirable feature. [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

### Description

This PR makes a few changes:
1. Updates the ccsr Client `PublishResponse` to include the actual text of invalid schema errors. (It previously always said there was an issue with the avro schema, but we're now publishing protobuf schemas, as well!)
2. Adds a new `kafka-publish-schema` testdrive action. This is necessary to publish protobuf schemas with imports.
3. Adds two test cases for protobuf schemas with imports.

<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details."

-->

### Checklist

- [X] This PR has adequate test coverage.
- [X] This PR adds a release note for any user-facing behavior changes.
