### PR TITLE
doc: re-add RM Neue fonts for railroad diagrams

### DIFF
--- a/doc/user/assets/sass/_fonts.scss
+++ b/doc/user/assets/sass/_fonts.scss
@@ -1,1 +1,65 @@
 @import url('https://fonts.googleapis.com/css2?family=Encode+Sans+Expanded:wght@100;300&family=Fira+Code&family=Inter:wght@300;400;500;700&display=swap');
+
+@font-face {
+  font-family: "RM Neue";
+  src: url("https://materialize.com/wp-content/themes/materialize/fonts/RMNeue-Bold.woff2") format("woff2"),
+    url("https://materialize.com/wp-content/themes/materialize/fonts/RMNeue-Bold.woff") format("woff");
+  font-weight: bold;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: "RM Neue";
+  src: url("https://materialize.com/wp-content/themes/materialize/fonts/RMNeue-BoldItalic.woff2") format("woff2"),
+    url("https://materialize.com/wp-content/themes/materialize/fonts/RMNeue-Bold.woff") format("woff");
+  font-weight: bold;
+  font-style: italic;
+}
+
+@font-face {
+  font-family: "RM Neue";
+  src: url("https://materialize.com/wp-content/themes/materialize/fonts/RMNeue-SemiBold.woff2") format("woff2"),
+    url("https://materialize.com/wp-content/themes/materialize/fonts/RMNeue-SemiBold.woff") format("woff");
+  font-weight: 600;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: "RM Neue";
+  src: url("https://materialize.com/wp-content/themes/materialize/fonts/RMNeue-SemiBoldItalic.woff2") format("woff2"),
+    url("https://materialize.com/wp-content/themes/materialize/fonts/RMNeue-SemiBoldItalic.woff") format("woff");
+  font-weight: 600;
+  font-style: italic;
+}
+
+@font-face {
+  font-family: "RM Neue";
+  src: url("https://materialize.com/wp-content/themes/materialize/fonts/RMNeue-Regular.woff2") format("woff2"),
+    url("https://materialize.com/wp-content/themes/materialize/fonts/RMNeue-Regular.woff") format("woff");
+  font-weight: 500;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: "RM Neue";
+  src: url("https://materialize.com/wp-content/themes/materialize/fonts/RMNeue-Italic.woff2") format("woff2"),
+    url("https://materialize.com/wp-content/themes/materialize/fonts/RMNeue-Italic.woff") format("woff");
+  font-weight: 500;
+  font-style: italic;
+}
+
+@font-face {
+  font-family: "RM Neue";
+  src: url("https://materialize.com/wp-content/themes/materialize/fonts/RMNeue-Light.woff2") format("woff2"),
+    url("https://materialize.com/wp-content/themes/materialize/fonts/RMNeue-Light.woff") format("woff");
+  font-weight: normal;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: "RM Neue";
+  src: url("https://materialize.com/wp-content/themes/materialize/fonts/RMNeue-LightItalic.woff2") format("woff2"),
+    url("https://materialize.com/wp-content/themes/materialize/fonts/RMNeue-LightItalic.woff") format("woff");
+  font-weight: normal;
+  font-style: italic;
+}


### PR DESCRIPTION
### Description

The font of railroad diagrams was accidentally removed here https://github.com/MaterializeInc/materialize/pull/8128

This PR re-adds them
