### PR TITLE
test: DSL support for literal errors

### DIFF
--- a/src/expr-test-util/src/lib.rs
+++ b/src/expr-test-util/src/lib.rs
@@ -33,7 +33,8 @@ gen_reflect_info_func!(
         TableFunc,
         AggregateFunc,
         MirRelationExpr,
-        JoinImplementation
+        JoinImplementation,
+        EvalError,
     ],
     [AggregateExpr, ColumnOrder, ColumnType, RelationType]
 );
@@ -193,12 +194,14 @@ impl ExprHumanizer for TestCatalog {
 /// Extends the test case syntax to support `MirScalarExpr`s
 ///
 /// The following variants of `MirScalarExpr` have non-standard syntax:
-/// Literal -> the syntax is `(<literal> <scalar type>)` or `<literal>`.
+/// Literal -> the syntax is `(ok <literal> <scalar type>)`, `<literal>`
+/// or (err <eval error> <scalar type>). Note that `ok` token can be omitted.
 /// If `<scalar type>` is not specified, then literals will be assigned
 /// default types:
 /// * true/false become Bool
 /// * numbers become Int64
 /// * strings become String
+/// * Bool for literal errors
 /// Column -> the syntax is `#n`, where n is the column number.
 #[derive(Default)]
 pub struct MirScalarExprDeserializeContext;
@@ -214,6 +217,50 @@ impl MirScalarExprDeserializeContext {
     }
 
     fn build_literal_if_able<I>(
+        &mut self,
+        first_arg: TokenTree,
+        rest_of_stream: &mut I,
+        rti: &ReflectedTypeInfo,
+    ) -> Result<Option<MirScalarExpr>, String>
+    where
+        I: Iterator<Item = TokenTree>,
+    {
+        match &first_arg {
+            TokenTree::Ident(i) if i.to_string().to_ascii_lowercase() == "ok" => {
+                // literal definition is mandatory after OK token
+                let first_arg = if let Some(first_arg) = rest_of_stream.next() {
+                    first_arg
+                } else {
+                    return Err(format!("expected literal after {:?}", i));
+                };
+                match self.build_literal_ok_if_able(first_arg, rest_of_stream) {
+                    Ok(Some(l)) => Ok(Some(l)),
+                    _ => Err(format!("expected literal after {:?}", i)),
+                }
+            }
+            TokenTree::Ident(i) if i.to_string().to_ascii_lowercase() == "err" => {
+                let error = deserialize(
+                    rest_of_stream,
+                    "EvalError",
+                    rti,
+                    &mut GenericTestDeserializeContext::default(),
+                )?;
+                let typ: Option<ScalarType> = deserialize_optional(
+                    rest_of_stream,
+                    "ScalarType",
+                    rti,
+                    &mut GenericTestDeserializeContext::default(),
+                )?;
+                Ok(Some(MirScalarExpr::literal(
+                    Err(error),
+                    typ.unwrap_or(ScalarType::Bool),
+                )))
+            }
+            _ => self.build_literal_ok_if_able(first_arg, rest_of_stream),
+        }
+    }
+
+    fn build_literal_ok_if_able<I>(
         &mut self,
         first_arg: TokenTree,
         rest_of_stream: &mut I,
@@ -240,7 +287,7 @@ impl TestDeserializeContext for MirScalarExprDeserializeContext {
         first_arg: TokenTree,
         rest_of_stream: &mut I,
         type_name: &str,
-        _rti: &ReflectedTypeInfo,
+        rti: &ReflectedTypeInfo,
     ) -> Result<Option<String>, String>
     where
         I: Iterator<Item = TokenTree>,
@@ -251,7 +298,7 @@ impl TestDeserializeContext for MirScalarExprDeserializeContext {
                     Some(self.build_column(rest_of_stream.next())?)
                 }
                 TokenTree::Group(_) => None,
-                symbol => self.build_literal_if_able(symbol, rest_of_stream)?,
+                symbol => self.build_literal_if_able(symbol, rest_of_stream, rti)?,
             }
         } else {
             None
@@ -278,22 +325,34 @@ impl TestDeserializeContext for MirScalarExprDeserializeContext {
                     "Literal" => {
                         let column_type: ColumnType =
                             serde_json::from_value(data.as_array().unwrap()[1].clone()).unwrap();
-                        match data.as_array().unwrap()[0].as_object().unwrap().get("Ok") {
-                            Some(inner_data) => {
-                                let row: Row = serde_json::from_value(inner_data.clone()).unwrap();
-                                let result = format!(
-                                    "({} {})",
-                                    datum_to_test_spec(row.unpack_first()),
-                                    from_json(
-                                        &serde_json::to_value(&column_type.scalar_type).unwrap(),
-                                        "ScalarType",
-                                        rti,
-                                        self
-                                    )
-                                );
-                                return Some(result);
-                            }
-                            None => unreachable!("Literal errors are not supported"),
+                        let obj = data.as_array().unwrap()[0].as_object().unwrap();
+                        if let Some(inner_data) = obj.get("Ok") {
+                            let row: Row = serde_json::from_value(inner_data.clone()).unwrap();
+                            let result = format!(
+                                "({} {})",
+                                datum_to_test_spec(row.unpack_first()),
+                                from_json(
+                                    &serde_json::to_value(&column_type.scalar_type).unwrap(),
+                                    "ScalarType",
+                                    rti,
+                                    self
+                                )
+                            );
+                            return Some(result);
+                        } else if let Some(inner_data) = obj.get("Err") {
+                            let result = format!(
+                                "(err {} {})",
+                                from_json(&inner_data, "EvalError", rti, self),
+                                from_json(
+                                    &serde_json::to_value(&column_type.scalar_type).unwrap(),
+                                    "ScalarType",
+                                    rti,
+                                    self
+                                ),
+                            );
+                            return Some(result);
+                        } else {
+                            unreachable!("Literal errors are not supported");
                         }
                     }
                     _ => {}

--- a/src/expr-test-util/tests/testdata/rel
+++ b/src/expr-test-util/tests/testdata/rel
@@ -110,46 +110,34 @@ build
 build
 (top_k (get y) [1] [0] 5 1)
 ----
-----
 %0 =
 | Get y (u1)
 | TopK group=(#1) order=(#0 asc) limit=5 offset=1
-----
-----
 
 build
 (top_k (get y) [0 1] [(2 true)] )
 ----
-----
 %0 =
 | Get y (u1)
 | TopK group=(#0, #1) order=(#2 desc) offset=0
-----
-----
 
 build
 (reduce (get y)
     [(call_unary cast_int32_to_int64 #0)]
     [(max_int64 #1) (sum_int32 #2 true)])
 ----
-----
 %0 =
 | Get y (u1)
 | Reduce group=(i32toi64(#0))
 | | agg max(#1)
 | | agg sum(distinct #2)
-----
-----
 
 build
 (reduce (get y) [#2] [])
 ----
-----
 %0 =
 | Get y (u1)
 | Distinct group=(#2)
-----
-----
 
 build
 (union [(map (get x) [(null int32)]) (get y)])
@@ -166,3 +154,38 @@ build
 | Union %0 %1
 ----
 ----
+
+build
+(filter
+  (get x)
+  [(err multiple_rows_from_subquery)])
+----
+%0 =
+| Get x (u0)
+| Filter (err: more than one record produced in subquery)
+
+build format=types
+(map
+  (get x)
+  [(err multiple_rows_from_subquery)])
+----
+%0 =
+| Get x (u0)
+| | types = (Int32?, Int64?)
+| | keys = ()
+| Map (err: more than one record produced in subquery)
+| | types = (Int32?, Int64?, Bool)
+| | keys = ()
+
+build format=types
+(map
+  (get x)
+  [(err multiple_rows_from_subquery int64)])
+----
+%0 =
+| Get x (u0)
+| | types = (Int32?, Int64?)
+| | keys = ()
+| Map (err: more than one record produced in subquery)
+| | types = (Int32?, Int64?, Int64)
+| | keys = ()

--- a/src/expr-test-util/tests/testdata/scalar
+++ b/src/expr-test-util/tests/testdata/scalar
@@ -51,3 +51,43 @@ build-scalar
 ("1999-12-31 23:42:23.342" timestamp)
 ----
 1999-12-31 23:42:23.342
+
+build-scalar
+(err division_by_zero)
+----
+(err: division by zero)
+
+build-scalar
+(err float_overflow)
+----
+(err: value out of range: overflow)
+
+build-scalar
+(ok true)
+----
+true
+
+build-scalar
+(ok "1999-12-31 23:42:23.342" timestamp)
+----
+1999-12-31 23:42:23.342
+
+build-scalar
+(ok "1999-12-31 23:42:23.342")
+----
+"1999-12-31 23:42:23.342"
+
+build-scalar
+(ok)
+----
+error: expected literal after Ident(ok)
+
+build-scalar
+(ok (ok true))
+----
+error: expected literal after Ident(ok)
+
+build-scalar
+(err)
+----
+error: Empty spec for type EvalError

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -985,7 +985,9 @@ impl fmt::Display for MirScalarExpr {
     }
 }
 
-#[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
+#[derive(
+    Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzEnumReflect,
+)]
 pub enum EvalError {
     DivisionByZero,
     FloatOverflow,


### PR DESCRIPTION
### Motivation

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug. [Link to issue.]

  * This PR adds a known-desirable feature. [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

This PR adds a known-desirable feature #7657.

### Description

<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details."

-->

This PR extends the DSL used for testing the MIR layer, adding support for literal errors. The following syntax will be accepted as a literal when parsing a `MirScalarExpr`:

```
<literal>
(<literal>)
(<literal> <scalar type>)
(ok <literal> <scalar type>)
(err <eval error>)
(err <eval error> <scalar type>)
```

The default value for `<scalar type>` in literal errors if omitted is `bool` for convenience (literal errors will be used mostly in filters).

A separate patch will add support for errors in `Constant` operator.

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [x] This PR has adequate test coverage.
- [Nothing users can see here] This PR adds a release note for any user-facing behavior changes.

Fixes #7657.