### PR TITLE
sqllogictest: add a fail-fast flag

### DIFF
--- a/src/sqllogictest/src/main.rs
+++ b/src/sqllogictest/src/main.rs
@@ -49,6 +49,9 @@ struct Args {
     /// Path to sqllogictest script to run.
     #[structopt(value_name = "PATH", required = true)]
     paths: Vec<String>,
+    /// Stop on first failure.
+    #[structopt(long)]
+    fail_fast: bool,
 }
 
 #[tokio::main]
@@ -64,6 +67,7 @@ async fn main() {
         verbosity: args.verbosity,
         workers: args.workers,
         no_fail: args.no_fail,
+        fail_fast: args.fail_fast,
     };
 
     if args.rewrite_results {

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -922,6 +922,7 @@ pub struct RunConfig<'a> {
     pub verbosity: usize,
     pub workers: usize,
     pub no_fail: bool,
+    pub fail_fast: bool,
 }
 
 fn print_record(config: &RunConfig<'_>, record: &Record) {
@@ -974,6 +975,10 @@ pub async fn run_string(
         outcomes.0[outcome.code()] += 1;
 
         if let Outcome::Bail { .. } = outcome {
+            break;
+        }
+
+        if config.fail_fast && !outcome.success() {
             break;
         }
     }


### PR DESCRIPTION
Useful when debugging and you want to reduce logging output.