### PR TITLE
persist: make a single-path variant of MemRegistry

### DIFF
--- a/src/persist/benches/snapshot.rs
+++ b/src/persist/benches/snapshot.rs
@@ -15,7 +15,7 @@ use ore::metrics::MetricsRegistry;
 use persist::error::Error;
 use persist::file::{FileBlob, FileLog};
 use persist::indexed::runtime::{self, RuntimeClient, StreamReadHandle};
-use persist::mem::{MemBlob, MemLog};
+use persist::mem::MemRegistry;
 use persist::storage::LockInfo;
 use persist::Codec;
 
@@ -77,15 +77,7 @@ where
 }
 
 pub fn bench_mem_snapshots(c: &mut Criterion) {
-    bench_runtime_snapshots(c, "mem", |path| {
-        let name = format!("snapshot_bench_{}", path);
-        let lock_info = LockInfo::new_no_reentrance(name);
-        runtime::start(
-            MemLog::new(lock_info.clone()),
-            MemBlob::new(lock_info),
-            &MetricsRegistry::new(),
-        )
-    });
+    bench_runtime_snapshots(c, "mem", |_path| MemRegistry::new().runtime_no_reentrance());
 }
 
 pub fn bench_file_snapshots(c: &mut Criterion) {

--- a/src/persist/benches/writer.rs
+++ b/src/persist/benches/writer.rs
@@ -12,7 +12,7 @@
 use criterion::{criterion_group, criterion_main, Bencher, Criterion};
 
 use persist::file::FileLog;
-use persist::mem::MemLog;
+use persist::mem::MemRegistry;
 use persist::storage::{LockInfo, Log};
 
 fn bench_write_sync<L: Log>(writer: &mut L, data: Vec<u8>, b: &mut Bencher) {
@@ -26,7 +26,9 @@ fn bench_write_sync<L: Log>(writer: &mut L, data: Vec<u8>, b: &mut Bencher) {
 pub fn bench_writes(c: &mut Criterion) {
     let data = "entry0".as_bytes().to_vec();
 
-    let mut mem_log = MemLog::new(LockInfo::new_no_reentrance("mem_log_bench".to_owned()));
+    let mut mem_log = MemRegistry::new()
+        .log_no_reentrance()
+        .expect("creating a MemLog cannot fail");
     c.bench_function("mem_write_sync", |b| {
         bench_write_sync(&mut mem_log, data.clone(), b)
     });

--- a/src/persist/src/indexed/mod.rs
+++ b/src/persist/src/indexed/mod.rs
@@ -1093,7 +1093,7 @@ mod tests {
 
     use crate::error::Error as IndexedError;
     use crate::future::Future;
-    use crate::mem::{MemBlob, MemLog};
+    use crate::mem::MemRegistry;
 
     use super::*;
 
@@ -1120,11 +1120,7 @@ mod tests {
             (("2".into(), "".into()), 2, 1),
         ];
 
-        let mut i = Indexed::new(
-            MemLog::new_no_reentrance("single_stream"),
-            MemBlob::new_no_reentrance("single_stream"),
-            Metrics::default(),
-        )?;
+        let mut i = MemRegistry::new().indexed_no_reentrance()?;
         let id = block_on(|res| i.register("0", "()", "()", res))?;
 
         // Empty things are empty.
@@ -1221,11 +1217,7 @@ mod tests {
             (("2".into(), "".into()), 1, 1),
         ];
 
-        let mut i = Indexed::new(
-            MemLog::new_no_reentrance("batch_sorting"),
-            MemBlob::new_no_reentrance("batch_sorting"),
-            Metrics::default(),
-        )?;
+        let mut i = MemRegistry::new().indexed_no_reentrance()?;
         let id = block_on(|res| i.register("0", "", "", res))?;
 
         // Write the data and move it into the unsealed part of the index, which
@@ -1256,11 +1248,7 @@ mod tests {
             (("1".into(), "".into()), 1, 1),
         ];
 
-        let mut i = Indexed::new(
-            MemLog::new_no_reentrance("batch_consolidation"),
-            MemBlob::new_no_reentrance("batch_consolidation"),
-            Metrics::default(),
-        )?;
+        let mut i = MemRegistry::new().indexed_no_reentrance()?;
         let id = block_on(|res| i.register("0", "", "", res))?;
 
         // Write the data and move it into the unsealed part of the index, which
@@ -1294,11 +1282,7 @@ mod tests {
 
     #[test]
     fn batch_unsealed_empty() -> Result<(), Box<dyn Error>> {
-        let mut i = Indexed::new(
-            MemLog::new_no_reentrance("batch_unsealed_empty"),
-            MemBlob::new_no_reentrance("batch_unsealed_empty"),
-            Metrics::default(),
-        )?;
+        let mut i = MemRegistry::new().indexed_no_reentrance()?;
         let id = block_on(|res| i.register("0", "", "", res))?;
 
         // Write an empty set of updates and try to move it into the unsealed part
@@ -1324,11 +1308,7 @@ mod tests {
     // non-adjacent seqno boundaries (which violates our invariants).
     #[test]
     fn regression_non_sequential_unsealed_batches() -> Result<(), IndexedError> {
-        let mut i = Indexed::new(
-            MemLog::new_no_reentrance("lock"),
-            MemBlob::new_no_reentrance("lock"),
-            Metrics::default(),
-        )?;
+        let mut i = MemRegistry::new().indexed_no_reentrance()?;
 
         // First is some stream is registered, written to, and step'd, moving
         // seqno 0..X into unsealed. Then a second stream is registered, written
@@ -1360,11 +1340,7 @@ mod tests {
 
     #[test]
     fn test_destroy() -> Result<(), IndexedError> {
-        let mut i = Indexed::new(
-            MemLog::new_no_reentrance("destroy"),
-            MemBlob::new_no_reentrance("destroy"),
-            Metrics::default(),
-        )?;
+        let mut i = MemRegistry::new().indexed_no_reentrance()?;
 
         let _ = block_on(|res| i.register("stream", "", "", res))?;
 
@@ -1395,11 +1371,7 @@ mod tests {
 
     #[test]
     fn codec_mismatch() -> Result<(), IndexedError> {
-        let mut i = Indexed::new(
-            MemLog::new_no_reentrance("codec_mismatch"),
-            MemBlob::new_no_reentrance("codec_mismatch"),
-            Metrics::default(),
-        )?;
+        let mut i = MemRegistry::new().indexed_no_reentrance()?;
 
         let _ = block_on(|res| i.register("stream", "key", "val", res))?;
 

--- a/src/persist/src/indexed/trace.rs
+++ b/src/persist/src/indexed/trace.rs
@@ -373,7 +373,7 @@ mod tests {
     use crate::indexed::encoding::Id;
     use crate::indexed::metrics::Metrics;
     use crate::indexed::SnapshotExt;
-    use crate::mem::MemBlob;
+    use crate::mem::MemRegistry;
 
     use super::*;
 
@@ -459,10 +459,7 @@ mod tests {
 
     #[test]
     fn trace_compact() -> Result<(), Error> {
-        let mut blob = BlobCache::new(
-            Metrics::default(),
-            MemBlob::new_no_reentrance("trace_compact"),
-        );
+        let mut blob = BlobCache::new(Metrics::default(), MemRegistry::new().blob_no_reentrance()?);
         let mut t = Trace::new(TraceMeta::new(Id(0)));
         t.update_seal(10);
 

--- a/src/persist/src/mem.rs
+++ b/src/persist/src/mem.rs
@@ -17,7 +17,9 @@ use ore::cast::CastFrom;
 use ore::metrics::MetricsRegistry;
 
 use crate::error::Error;
+use crate::indexed::metrics::Metrics;
 use crate::indexed::runtime::{self, RuntimeClient};
+use crate::indexed::Indexed;
 use crate::storage::{Blob, LockInfo, Log, SeqNo};
 use crate::unreliable::{UnreliableBlob, UnreliableHandle, UnreliableLog};
 
@@ -293,23 +295,96 @@ impl Blob for MemBlob {
     }
 }
 
+/// An in-memory representation of a [Log] and [Blob] that can be reused
+/// across dataflows
+#[derive(Clone)]
+pub struct MemRegistry {
+    log: Arc<Mutex<MemLogCore>>,
+    blob: Arc<Mutex<MemBlobCore>>,
+}
+
+impl MemRegistry {
+    /// Constructs a new, empty [MemRegistry]
+    pub fn new() -> Self {
+        let mut log = MemLog::new(LockInfo::new_no_reentrance("".into()));
+        log.close()
+            .expect("newly opened MemLog close is infallible");
+        let mut blob = MemBlob::new(LockInfo::new_no_reentrance("".into()));
+        blob.close()
+            .expect("newly opened MemBlob close is infallible");
+        MemRegistry {
+            log: log.core.clone(),
+            blob: blob.core.clone(),
+        }
+    }
+
+    /// Opens the [MemLog] contained by this registry.
+    pub fn log_no_reentrance(&self) -> Result<MemLog, Error> {
+        MemLog::open(
+            self.log.clone(),
+            LockInfo::new_no_reentrance("MemRegistry".to_owned()),
+        )
+    }
+
+    /// Opens the [MemBlob] contained by this registry.
+    pub fn blob_no_reentrance(&self) -> Result<MemBlob, Error> {
+        MemBlob::open(
+            self.blob.clone(),
+            LockInfo::new_no_reentrance("MemRegistry".to_owned()),
+        )
+    }
+
+    /// Returns a [RuntimeClient] using the [MemLog] and [MemBlob] contained by
+    /// this registry.
+    pub fn indexed_no_reentrance(&mut self) -> Result<Indexed<MemLog, MemBlob>, Error> {
+        let log = self.log_no_reentrance()?;
+        let blob = self.blob_no_reentrance()?;
+        let metrics = Metrics::register_with(&MetricsRegistry::new());
+        Indexed::new(log, blob, metrics)
+    }
+
+    /// Starts a [RuntimeClient] using the [MemLog] and [MemBlob] contained by
+    /// this registry.
+    pub fn runtime_no_reentrance(&mut self) -> Result<RuntimeClient, Error> {
+        let log = self.log_no_reentrance()?;
+        let blob = self.blob_no_reentrance()?;
+        runtime::start(log, blob, &MetricsRegistry::new())
+    }
+
+    /// Open a [RuntimeClient] with unreliable storage backed by the given
+    /// [`UnreliableHandle`].
+    pub fn runtime_unreliable(
+        &mut self,
+        unreliable: UnreliableHandle,
+    ) -> Result<RuntimeClient, Error> {
+        let log = self.log_no_reentrance()?;
+        let log = UnreliableLog::from_handle(log, unreliable.clone());
+        let blob = self.blob_no_reentrance()?;
+        let blob = UnreliableBlob::from_handle(blob, unreliable);
+        runtime::start(log, blob, &MetricsRegistry::new())
+    }
+}
+
 /// An in-memory representation of a set of [Log]s and [Blob]s that can be reused
 /// across dataflows
-pub struct MemRegistry {
+#[cfg(test)]
+pub struct MemMultiRegistry {
     log_by_path: HashMap<String, Arc<Mutex<MemLogCore>>>,
     blob_by_path: HashMap<String, Arc<Mutex<MemBlobCore>>>,
 }
 
-impl MemRegistry {
-    /// Constructs a new, empty MemRegistry
+#[cfg(test)]
+impl MemMultiRegistry {
+    /// Constructs a new, empty [MemMultiRegistry].
     pub fn new() -> Self {
-        MemRegistry {
+        MemMultiRegistry {
             log_by_path: HashMap::new(),
             blob_by_path: HashMap::new(),
         }
     }
 
-    fn log(&mut self, path: &str, lock_info: LockInfo) -> Result<MemLog, Error> {
+    /// Opens the [MemLog] associated with `path`.
+    pub fn log(&mut self, path: &str, lock_info: LockInfo) -> Result<MemLog, Error> {
         if let Some(log) = self.log_by_path.get(path) {
             MemLog::open(log.clone(), lock_info)
         } else {
@@ -338,21 +413,6 @@ impl MemRegistry {
         let blob = self.blob(path, lock_info)?;
         runtime::start(log, blob, &MetricsRegistry::new())
     }
-
-    /// Open a [RuntimeClient] with unreliable storage associated with `path`.
-    pub fn open_unreliable(
-        &mut self,
-        path: &str,
-        lock_info: &str,
-        unreliable: UnreliableHandle,
-    ) -> Result<RuntimeClient, Error> {
-        let lock_info = LockInfo::new_no_reentrance(lock_info.to_owned());
-        let log = self.log(path, lock_info.clone())?;
-        let log = UnreliableLog::from_handle(log, unreliable.clone());
-        let blob = self.blob(path, lock_info)?;
-        let blob = UnreliableBlob::from_handle(blob, unreliable);
-        runtime::start(log, blob, &MetricsRegistry::new())
-    }
 }
 
 #[cfg(test)]
@@ -363,13 +423,13 @@ mod tests {
 
     #[test]
     fn mem_log() -> Result<(), Error> {
-        let mut registry = MemRegistry::new();
+        let mut registry = MemMultiRegistry::new();
         log_impl_test(move |t| registry.log(t.path, (t.reentrance_id, "log_impl_test").into()))
     }
 
     #[test]
     fn mem_blob() -> Result<(), Error> {
-        let mut registry = MemRegistry::new();
+        let mut registry = MemMultiRegistry::new();
         blob_impl_test(move |t| registry.blob(t.path, (t.reentrance_id, "blob_impl_test").into()))
     }
 }

--- a/src/persist/src/nemesis/direct.rs
+++ b/src/persist/src/nemesis/direct.rs
@@ -282,10 +282,8 @@ mod tests {
     #[test]
     fn direct_mem() {
         let mut registry = MemRegistry::new();
-        let direct = Direct::new(move |unreliable| {
-            registry.open_unreliable("direct_mem", "direct_mem", unreliable)
-        })
-        .expect("initial start failed");
+        let direct = Direct::new(move |unreliable| registry.runtime_unreliable(unreliable))
+            .expect("initial start failed");
         nemesis::run(100, GeneratorConfig::default(), direct)
     }
 
@@ -321,10 +319,8 @@ mod tests {
             ..Default::default()
         };
         let mut registry = MemRegistry::new();
-        let direct = Direct::new(move |unreliable| {
-            registry.open_unreliable("direct_mzlike", "direct_mzlike", unreliable)
-        })
-        .expect("initial start failed");
+        let direct = Direct::new(move |unreliable| registry.runtime_unreliable(unreliable))
+            .expect("initial start failed");
         nemesis::run(100, config, direct)
     }
 }


### PR DESCRIPTION
### Motivation

   * This PR refactors existing code.

### Description

Most places only need a single-path, non-reentrant version so provide that and clean up lots of distracting strings in tests.

### Checklist

- [x] This PR has adequate test coverage.
- [x] This PR adds a release note for any user-facing behavior changes.
