### PR TITLE
Utilities for handling recoverable errors

### DIFF
--- a/src/ore/src/result.rs
+++ b/src/ore/src/result.rs
@@ -17,6 +17,15 @@
 
 use crate::display::DisplayExt;
 
+/// Error wrapper that conveys severity information
+#[derive(Debug)]
+pub enum Severity<E> {
+    /// A recoverable error
+    Recoverable(E),
+    /// A fatal error
+    Fatal(E),
+}
+
 /// Extension methods for [`std::result::Result`].
 pub trait ResultExt<T, E> {
     /// Applies [`Into::into`] to a contained [`Err`] value, leaving an [`Ok`]
@@ -37,6 +46,12 @@ pub trait ResultExt<T, E> {
     fn map_err_to_string(self) -> Result<T, String>
     where
         E: std::fmt::Display;
+
+    /// Mark an error as recoverable
+    fn recoverable(self) -> Result<T, Severity<E>>;
+
+    /// Mark an error as fatal
+    fn fatal(self) -> Result<T, Severity<E>>;
 }
 
 impl<T, E> ResultExt<T, E> for Result<T, E> {
@@ -59,6 +74,14 @@ impl<T, E> ResultExt<T, E> for Result<T, E> {
         E: std::fmt::Display,
     {
         self.map_err(|e| DisplayExt::to_string_alt(&e))
+    }
+
+    fn recoverable(self) -> Result<T, Severity<E>> {
+        self.map_err(Severity::Recoverable)
+    }
+
+    fn fatal(self) -> Result<T, Severity<E>> {
+        self.map_err(Severity::Fatal)
     }
 }
 


### PR DESCRIPTION
### Motivation

Our postgres source implementation included a bespoke implementation of a recoverable error type together with a `try_fatal!` and `try_recoverable!` macro that automatically propagated the errors upwards (a la the original rust `try!` macro). Other source types also include a bespoke implementation of such semantics. The motivation of this PR is to unify error handling for recoverable/fatal errors.

### Description

This PR defines a `Severity` enum in the `ore` crate and  two additional methods on `Result`, `recoverable()` and `fatal()`. Calling any of these methods is just sugar for `res.map_err(Severity::Recoverable)` and `res.map_err(Severity::Fatal)`. The macros have been removed in favour of the two utility methods that are compatible with the `?` operator.

When writing a fallible function that can experience both fatal and recoverable errors you can express it like so:

```rust
fn maybe_recoverable() -> Result<(), Severity<MyError>> {
    // do some recoverable work
    do_stuff1().recoverable()?;
    // must succeed or else it's fatal
    do_stuff().fatal()?
}
```

The postgres implementation has been adapted to this new recoverable error scheme as a demonstration of its use. Upon merging we can use these utilities in other types of source as well.
### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [ ] This PR has adequate test coverage.
- [ ] This PR adds a release note for any user-facing behavior changes.
