### PR TITLE
Don't emit schemaType when it's avro

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -52,6 +52,8 @@ Wrap your release notes at the 80 character mark.
 
 - Support `ORDER BY` in aggregate functions.
 
+- Fix a bug that prevented creating Avro sinks on old versions of Confluent Platform
+
 {{% version-header v0.9.2 %}}
 
 - The metrics scraping interval to populate


### PR DESCRIPTION
### Motivation

  Fixes #8201 

### Description

When we added support for JSON sinks, we started passing `schemaType` in Confluent Schema Registry requests. Unfortunately, this field is not accepted by some old versions of CSR. The workaround is to omit the field when it's Avro, relying on CSR's behavior of assuming avro by default.

We don't explicitly promise to support  any particular range of CSR versions, but this is easy enough that it's worth doing regardless.

### Checklist

- [ ] This PR has adequate test coverage.
        No tests for now -- I'll speak to Eli/Philip about whether we should add 5.2 to our backwards compatibility test suite, once the latter gets back from vacation.
- [x] This PR adds a release note for any user-facing behavior changes.