### PR TITLE
persist: make getting a snapshot fast (don't block on fetching the data)

### DIFF
--- a/src/persist/src/future.rs
+++ b/src/persist/src/future.rs
@@ -18,6 +18,7 @@ use crate::error::Error;
 ///
 /// Unlike [std::future::Future], the computation will complete even if this is
 /// dropped.
+#[derive(Debug)]
 pub struct Future<T>(oneshot::Receiver<Result<T, Error>>);
 
 impl<T> Future<T> {

--- a/src/persist/src/indexed/mod.rs
+++ b/src/persist/src/indexed/mod.rs
@@ -984,7 +984,7 @@ impl<L: Log, B: Blob> Indexed<L, B> {
             .get(&id)
             .ok_or_else(|| Error::from(format!("never registered: {:?}", id)))?;
         let seal_frontier = trace.get_seal();
-        let trace = trace.snapshot(&self.blob)?;
+        let trace = trace.snapshot(&self.blob);
         let unsealed = unsealed.snapshot(trace.ts_upper.clone(), Antichain::new(), &self.blob)?;
 
         Ok(IndexedSnapshot(

--- a/src/persist/src/indexed/mod.rs
+++ b/src/persist/src/indexed/mod.rs
@@ -833,7 +833,16 @@ impl<L: Log, B: Blob> Indexed<L, B> {
             {
                 let mut snap =
                     unsealed.snapshot(desc.lower().clone(), desc.upper().clone(), &self.blob)?;
-                while snap.read(&mut updates) {}
+                let mut more = true;
+                while more {
+                    match snap.read(&mut updates) {
+                        Ok(m) => more = m,
+                        Err(err) => {
+                            self.restore();
+                            return Err(format!("failed to fetch snapshot: {}", err).into());
+                        }
+                    };
+                }
             }
 
             // Trace batches are required to be sorted and consolidated by ((k, v), t)
@@ -1035,18 +1044,18 @@ pub trait Snapshot<K, V> {
     /// changed the semantics to "Return false when no more data has been added,
     /// nor will ever be added to the destination" then we could support the
     /// desired control flow.
-    fn read<E: Extend<((K, V), u64, isize)>>(&mut self, buf: &mut E) -> bool;
+    fn read<E: Extend<((K, V), u64, isize)>>(&mut self, buf: &mut E) -> Result<bool, Error>;
 }
 
 /// Extension methods on `Snapshot<K, V>` for use in tests.
 #[cfg(test)]
 pub trait SnapshotExt<K: Ord, V: Ord>: Snapshot<K, V> + Sized {
     /// A full read of the data in the snapshot.
-    fn read_to_end(mut self) -> Vec<((K, V), u64, isize)> {
+    fn read_to_end(mut self) -> Result<Vec<((K, V), u64, isize)>, Error> {
         let mut buf = Vec::new();
-        while self.read(&mut buf) {}
+        while self.read(&mut buf)? {}
         buf.sort();
-        buf
+        Ok(buf)
     }
 }
 
@@ -1081,8 +1090,11 @@ impl IndexedSnapshot {
 }
 
 impl Snapshot<Vec<u8>, Vec<u8>> for IndexedSnapshot {
-    fn read<E: Extend<((Vec<u8>, Vec<u8>), u64, isize)>>(&mut self, buf: &mut E) -> bool {
-        self.0.read(buf) || self.1.read(buf)
+    fn read<E: Extend<((Vec<u8>, Vec<u8>), u64, isize)>>(
+        &mut self,
+        buf: &mut E,
+    ) -> Result<bool, Error> {
+        Ok(self.0.read(buf)? || self.1.read(buf)?)
     }
 }
 
@@ -1126,8 +1138,8 @@ mod tests {
         // Empty things are empty.
         let IndexedSnapshot(unsealed, trace, seqno, seal_frontier) =
             block_on(|res| i.snapshot(id, res))?;
-        assert_eq!(unsealed.read_to_end(), vec![]);
-        assert_eq!(trace.read_to_end(), vec![]);
+        assert_eq!(unsealed.read_to_end()?, vec![]);
+        assert_eq!(trace.read_to_end()?, vec![]);
         assert_eq!(seqno.0, 0);
         assert_eq!(seal_frontier.elements(), &[0]);
 
@@ -1149,22 +1161,22 @@ mod tests {
         block_on_drain(&mut i, |i, handle| {
             i.write(vec![(id, updates.clone())], handle)
         })?;
-        assert_eq!(block_on(|res| i.snapshot(id, res))?.read_to_end(), updates);
+        assert_eq!(block_on(|res| i.snapshot(id, res))?.read_to_end()?, updates);
         let IndexedSnapshot(unsealed, trace, seqno, seal_frontier) =
             block_on(|res| i.snapshot(id, res))?;
-        assert_eq!(unsealed.read_to_end(), updates);
-        assert_eq!(trace.read_to_end(), vec![]);
+        assert_eq!(unsealed.read_to_end()?, updates);
+        assert_eq!(trace.read_to_end()?, vec![]);
         assert_eq!(seqno.0, 1);
         assert_eq!(seal_frontier.elements(), &[0]);
 
         // After a step, it's all still in the unsealed as nothing has been sealed
         // yet.
         i.step()?;
-        assert_eq!(block_on(|res| i.snapshot(id, res))?.read_to_end(), updates);
+        assert_eq!(block_on(|res| i.snapshot(id, res))?.read_to_end()?, updates);
         let IndexedSnapshot(unsealed, trace, seqno, seal_frontier) =
             block_on(|res| i.snapshot(id, res))?;
-        assert_eq!(unsealed.read_to_end(), updates);
-        assert_eq!(trace.read_to_end(), vec![]);
+        assert_eq!(unsealed.read_to_end()?, updates);
+        assert_eq!(trace.read_to_end()?, vec![]);
         assert_eq!(seqno.0, 1);
         assert_eq!(seal_frontier.elements(), &[0]);
 
@@ -1173,22 +1185,22 @@ mod tests {
         // is still in the unsealed.
         block_on_drain(&mut i, |i, handle| i.seal(vec![id], 2, handle))?;
         i.step()?;
-        assert_eq!(block_on(|res| i.snapshot(id, res))?.read_to_end(), updates);
+        assert_eq!(block_on(|res| i.snapshot(id, res))?.read_to_end()?, updates);
         let IndexedSnapshot(unsealed, trace, seqno, seal_frontier) =
             block_on(|res| i.snapshot(id, res))?;
-        assert_eq!(unsealed.read_to_end(), updates[1..]);
-        assert_eq!(trace.read_to_end(), updates[..1]);
+        assert_eq!(unsealed.read_to_end()?, updates[1..]);
+        assert_eq!(trace.read_to_end()?, updates[..1]);
         assert_eq!(seqno.0, 1);
         assert_eq!(seal_frontier.elements(), &[2]);
 
         // All the data has been sealed, so it's now all in the trace.
         block_on_drain(&mut i, |i, handle| i.seal(vec![id], 3, handle))?;
         i.step()?;
-        assert_eq!(block_on(|res| i.snapshot(id, res))?.read_to_end(), updates);
+        assert_eq!(block_on(|res| i.snapshot(id, res))?.read_to_end()?, updates);
         let IndexedSnapshot(unsealed, trace, seqno, seal_frontier) =
             block_on(|res| i.snapshot(id, res))?;
-        assert_eq!(unsealed.read_to_end(), vec![]);
-        assert_eq!(trace.read_to_end(), updates);
+        assert_eq!(unsealed.read_to_end()?, vec![]);
+        assert_eq!(trace.read_to_end()?, updates);
         assert_eq!(seqno.0, 1);
         assert_eq!(seal_frontier.elements(), &[3]);
 
@@ -1236,8 +1248,8 @@ mod tests {
 
         // Sanity check that all the data made it into trace as expected.
         let IndexedSnapshot(unsealed, trace, _, _) = block_on(|res| i.snapshot(id, res))?;
-        assert_eq!(unsealed.read_to_end(), vec![]);
-        assert_eq!(trace.read_to_end(), updates);
+        assert_eq!(unsealed.read_to_end()?, vec![]);
+        assert_eq!(trace.read_to_end()?, updates);
         Ok(())
     }
 
@@ -1274,8 +1286,8 @@ mod tests {
 
         // Sanity check that all the data made it into trace as expected.
         let IndexedSnapshot(unsealed, trace, _, _) = block_on(|res| i.snapshot(id, res))?;
-        assert_eq!(unsealed.read_to_end(), vec![]);
-        assert_eq!(trace.read_to_end(), vec![(("1".into(), "".into()), 1, 4)]);
+        assert_eq!(unsealed.read_to_end()?, vec![]);
+        assert_eq!(trace.read_to_end()?, vec![(("1".into(), "".into()), 1, 4)]);
 
         Ok(())
     }

--- a/src/persist/src/indexed/runtime.rs
+++ b/src/persist/src/indexed/runtime.rs
@@ -526,7 +526,7 @@ impl<K: Codec + Ord, V: Codec + Ord> DecodedSnapshot<K, V> {
         let mut buf = Vec::new();
 
         // Read in all of the potentially decoded data.
-        while self.read(&mut buf) {}
+        while self.read(&mut buf)? {}
 
         for ((k, v), ts, diff) in buf.drain(..) {
             res.push(((k?, v?), ts, diff));
@@ -540,14 +540,14 @@ impl<K: Codec, V: Codec> Snapshot<Result<K, String>, Result<V, String>> for Deco
     fn read<E: Extend<((Result<K, String>, Result<V, String>), u64, isize)>>(
         &mut self,
         buf: &mut E,
-    ) -> bool {
-        let ret = self.snap.read(&mut self.buf);
+    ) -> Result<bool, Error> {
+        let ret = self.snap.read(&mut self.buf)?;
         buf.extend(self.buf.drain(..).map(|((k, v), ts, diff)| {
             let k = K::decode(&k);
             let v = V::decode(&v);
             ((k, v), ts, diff)
         }));
-        ret
+        Ok(ret)
     }
 }
 

--- a/src/persist/src/indexed/trace.rs
+++ b/src/persist/src/indexed/trace.rs
@@ -360,11 +360,14 @@ pub struct TraceSnapshot {
 }
 
 impl Snapshot<Vec<u8>, Vec<u8>> for TraceSnapshot {
-    fn read<E: Extend<((Vec<u8>, Vec<u8>), u64, isize)>>(&mut self, buf: &mut E) -> bool {
+    fn read<E: Extend<((Vec<u8>, Vec<u8>), u64, isize)>>(
+        &mut self,
+        buf: &mut E,
+    ) -> Result<bool, Error> {
         if let Some(batch) = self.updates.pop() {
             buf.extend(batch.updates.iter().cloned());
         }
-        !self.updates.is_empty()
+        Ok(!self.updates.is_empty())
     }
 }
 
@@ -527,7 +530,7 @@ mod tests {
         assert_eq!(snapshot.since, Antichain::from_elem(3));
         assert_eq!(snapshot.ts_upper, Antichain::from_elem(9));
 
-        let updates = snapshot.read_to_end();
+        let updates = snapshot.read_to_end()?;
 
         assert_eq!(
             updates,
@@ -582,7 +585,7 @@ mod tests {
         assert_eq!(snapshot.since, Antichain::from_elem(10));
         assert_eq!(snapshot.ts_upper, Antichain::from_elem(10));
 
-        let updates = snapshot.read_to_end();
+        let updates = snapshot.read_to_end()?;
 
         assert_eq!(
             updates,

--- a/src/persist/src/storage.rs
+++ b/src/persist/src/storage.rs
@@ -67,7 +67,7 @@ pub trait Log {
 ///
 /// - Invariant: Implementations are responsible for ensuring that they are
 ///   exclusive writers to this location.
-pub trait Blob {
+pub trait Blob: Send + 'static {
     /// Returns a reference to the value corresponding to the key.
     fn get(&self, key: &str) -> Result<Option<Vec<u8>>, Error>;
 


### PR DESCRIPTION
### Description

persist: make getting a snapshot fast (don't block on fetching the data)

Previously, taking a snapshot would fetch any batches that weren't in the BlobCache. This is called in dataflow construction, which is expected to be fast. Instead, we start the fetches in the background and block on them
just-in-time as the snapshot is iterated. 

### Checklist

- [x] This PR has adequate test coverage.
- [x] This PR adds a release note for any user-facing behavior changes.
