### PR TITLE
deps: upgrade to num-bigint v0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2594,9 +2594,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d047c1062aa51e256408c560894e5251f08925980e53cf1aa5bd00eec6512"
+checksum = "74e768dff5fb39a41b3bcd30bb25cf989706c90d028d1ad71971987aa309d535"
 dependencies = [
  "autocfg",
  "num-integer",


### PR DESCRIPTION
num-bigint v0.4.0 failed to compile on the latest nightly, which was
breaking our docs deployment job.
