### PR TITLE
expand kafka regression coverage

### DIFF
--- a/test/kafka-matrix/mzcompose.yml
+++ b/test/kafka-matrix/mzcompose.yml
@@ -25,10 +25,10 @@ mzworkflows:
         workflow: kafka-6_0_2
 
       - step: workflow
-        workflow: kafka-5_5_3
+        workflow: kafka-5_0_0
 
       - step: workflow
-        workflow: kafka-5_4_3
+        workflow: kafka-4_0_0
 
   kafka-latest:
     env:
@@ -59,16 +59,16 @@ mzworkflows:
       - step: workflow
         workflow: test-kafka
 
-  kafka-5_5_3:
+  kafka-5_0_0:
     env:
-      KAFKA_VERSION: 5.5.4
+      KAFKA_VERSION: 5.0.0
     steps:
       - step: workflow
         workflow: test-kafka
 
-  kafka-5_4_3:
+  kafka-4_0_0:
     env:
-      KAFKA_VERSION: 5.4.3
+      KAFKA_VERSION: 4.0.0
     steps:
       - step: workflow
         workflow: test-kafka

--- a/test/testdrive/kafka-compression.td
+++ b/test/testdrive/kafka-compression.td
@@ -47,23 +47,3 @@ world
 > SELECT text FROM lz4
 hello
 world
-
-$ kafka-create-topic topic=zstd compression=zstd
-
-$ kafka-ingest format=bytes topic=zstd timestamp=1
-hello
-world
-
-> CREATE MATERIALIZED SOURCE zstd
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-zstd-${testdrive.seed}'
-  FORMAT TEXT
-> SELECT text FROM zstd
-hello
-world
-
-> CREATE MATERIALIZED SOURCE zstd_fast_forwarded
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-zstd-${testdrive.seed}'
-  WITH (start_offset=1)
-  FORMAT TEXT
-> SELECT text FROM zstd_fast_forwarded
-world

--- a/test/testdrive/zstd-kafka-compression.td
+++ b/test/testdrive/zstd-kafka-compression.td
@@ -1,0 +1,30 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test support for zstd compressed Kafka topics.
+
+$ kafka-create-topic topic=zstd compression=zstd
+
+$ kafka-ingest format=bytes topic=zstd timestamp=1
+hello
+world
+
+> CREATE MATERIALIZED SOURCE zstd
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-zstd-${testdrive.seed}'
+  FORMAT TEXT
+> SELECT text FROM zstd
+hello
+world
+
+> CREATE MATERIALIZED SOURCE zstd_fast_forwarded
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-zstd-${testdrive.seed}'
+  WITH (start_offset=1)
+  FORMAT TEXT
+> SELECT text FROM zstd_fast_forwarded
+world


### PR DESCRIPTION
Adding regression coverage for confluent 5 (kafka 2) and confluent 4
(kafka 1).

The only thing that needs to be dropped for this is the zstd compression
test - I've taken the somewhat hacky but expedient step of moving that
to a separate td file.

I'm dropping coverage for the other 5.x versions. They seem redundant
and it'll free up capacity for these new checks, but I don't have strong
feelings one way or the other.

I've tested this locally with `./mzcompose run kafka-5_0_0` and `./mzcompose run kafka-4_0_0`, and verified that this would have caught #8201.

### Checklist

- [X] This PR has adequate test coverage.
- [X] This PR adds a release note for any user-facing behavior changes.
