### PR TITLE
reduce metric interval parameters for kafka matrix test

### DIFF
--- a/test/kafka-matrix/mzcompose.yml
+++ b/test/kafka-matrix/mzcompose.yml
@@ -140,6 +140,8 @@ services:
       --data-directory=/share/mzdata
       -w1 --experimental
       --disable-telemetry
+      --retain-prometheus-metrics 1s
+      --metrics-scraping-interval 1s
     ports:
       - 6875
     environment:


### PR DESCRIPTION
We have tests in kafka-stats.td that check that these metrics are
populated. By default materialize has a fairly long collection interval,
causing these tests to fail. This brings the Kafka matrix test in line
with the interval config parameters we use for the testdrive suite.

Fixes nightly CI runs. Verified locally with `./mzcompose run kafka-latest` failing before and passing after.

- [X] This PR has adequate test coverage.
- [X] This PR adds a release note for any user-facing behavior changes.
