### PR TITLE
upgrade: Add an "upgrade-from-latest-to-current-source" test

### DIFF
--- a/misc/python/materialize/cli/mkrelease.py
+++ b/misc/python/materialize/cli/mkrelease.py
@@ -373,7 +373,7 @@ def update_upgrade_tests_inner(released_version: Version, force: bool = False) -
     found = False
     for i, line in enumerate(contents):
         if "mkrelease.py will place new versions here" in line:
-            contents.insert(i - 2, step)
+            contents.insert(i - 1, step)
             found = True
             break
     if not found:

--- a/misc/python/materialize/cli/mkrelease.py
+++ b/misc/python/materialize/cli/mkrelease.py
@@ -162,7 +162,7 @@ def finish(create_branch: Optional[str], affect_remote: bool) -> None:
         affect_remote=affect_remote,
     )
 
-    update_upgrade_tests_inner(new_version)
+    update_upgrade_tests_inner(new_version, force=False)
     checkout = None
     incorporate_inner(
         create_branch, checkout, affect_remote, fetch=False, is_finish=True
@@ -326,19 +326,26 @@ def update_versions_list(released_version: Version) -> None:
 
 @cli.command()
 @click.argument("released_version", type=Version.parse, default=None)
-def update_upgrade_tests(released_version: Optional[Version]) -> None:
+@click.option(
+    "--force",
+    default=False,
+    is_flag=True,
+    help="Always update list of possible upgrade tests, "
+    "whether or not there are any current_source files to rename",
+)
+def update_upgrade_tests(released_version: Optional[Version], force: bool) -> None:
     """
     Update the test/upgrade/mzcompose.yml file
 
     This is done automatically as part of the 'finish' step, this command only
-    exists in case things go wrong.
+    exists for testing or in case things go wrong.
     """
     if released_version is None:
         released_version = get_latest_tag(fetch=False)
-    update_upgrade_tests_inner(released_version)
+    update_upgrade_tests_inner(released_version, force=force)
 
 
-def update_upgrade_tests_inner(released_version: Version) -> None:
+def update_upgrade_tests_inner(released_version: Version, force: bool = False) -> None:
     if released_version.prerelease is not None:
         say("Not updating upgrade tests for prerelease")
         return
@@ -349,7 +356,7 @@ def update_upgrade_tests_inner(released_version: Version) -> None:
     need_upgrade = [
         str(p) for p in upgrade_dir.glob("*current_source*") if "example" not in str(p)
     ]
-    if not need_upgrade:
+    if not need_upgrade and not force:
         return
     for path in need_upgrade:
         spawn.runv(["git", "mv", path, path.replace("current_source", version)])

--- a/test/upgrade/mzcompose.yml
+++ b/test/upgrade/mzcompose.yml
@@ -46,6 +46,9 @@ mzworkflows:
 
       # DO NOT REMOVE: mkrelease.py will place new versions here
 
+      - step: workflow
+        workflow: upgrade-from-latest
+
   upgrade-from-0_6_1:
     env:
       UPGRADE_FROM_VERSION: v0.6.1
@@ -105,6 +108,22 @@ mzworkflows:
   upgrade-from-0_9_2:
     env:
       UPGRADE_FROM_VERSION: v0.9.2
+      TESTS: any_version|v0.6.1|v0.7.3|v0.8.0|v0.8.1|v0.8.2|v0.8.3|v0.9.0|v0.9.2
+    steps:
+      - step: workflow
+        workflow: test-upgrade-from-version
+
+  upgrade-from-0_9_3:
+    env:
+      UPGRADE_FROM_VERSION: v0.9.3
+      TESTS: any_version|v0.6.1|v0.7.3|v0.8.0|v0.8.1|v0.8.2|v0.8.3|v0.9.0|v0.9.2
+    steps:
+      - step: workflow
+        workflow: test-upgrade-from-version
+
+  upgrade-from-latest:
+    env:
+      UPGRADE_FROM_VERSION: latest
       TESTS: any_version|v0.6.1|v0.7.3|v0.8.0|v0.8.1|v0.8.2|v0.8.3|v0.9.0|v0.9.2
     steps:
       - step: workflow


### PR DESCRIPTION
### Motivation

Always test that the current source can build from the latest released version.
This specific test would have caught #8202, and generally knowing that the next
version of materialize will load the catalog of the previous version is a good
base case to test.

### Description

This is similiar to, but distinct from, the revert that happened in #7839. We do
not expose `latest` as a create-in or check-from target -- i.e.
`create-in-latest_version*` doesn't do anything. Instead, create a new upgrade
test that the current source can build from the latest released version.

### Checklist

We don't have tests for bin/mkrelease, but I added a flag to make it easier to test, so now we have:

``` console
$ bin/mkrelease update-upgrade-tests --force 0.9.3
> git commit -a -m 'Rename 0 current_source upgrade tests to v0.9.3'
[upgrade-test-latest dec73e900] Rename 0 current_source upgrade tests to v0.9.3
 1 file changed, 13 insertions(+), 2 deletions(-)

$ git show @
commit dec73e9005076ccf0b8302a76ed5118059758453 (HEAD -> upgrade-test-latest)
Author: Brandon W Maister <bwm@materialize.io>
Date:   Wed Sep 8 16:25:42 2021 -0400

    Rename 0 current_source upgrade tests to v0.9.3

diff --git a/test/upgrade/mzcompose.yml b/test/upgrade/mzcompose.yml
index 2b081ee5d..338d14212 100644
--- a/test/upgrade/mzcompose.yml
+++ b/test/upgrade/mzcompose.yml
@@ -44,6 +44,9 @@ mzworkflows:
       - step: workflow
         workflow: upgrade-from-0_9_2

+      - step: workflow
+        workflow: upgrade-from-0_9_3
+
       # DO NOT REMOVE: mkrelease.py will place new versions here

       - step: workflow
@@ -121,10 +124,18 @@ mzworkflows:
       - step: workflow
         workflow: test-upgrade-from-version

+  upgrade-from-0_9_3:
+    env:
+      UPGRADE_FROM_VERSION: v0.9.3
+      TESTS: any_version|v0.6.1|v0.7.3|v0.8.0|v0.8.1|v0.8.2|v0.8.3|v0.9.0|v0.9.2|v0.9.3
+    steps:
+      - step: workflow
+        workflow: test-upgrade-from-version
+
   upgrade-from-latest:
     env:
       UPGRADE_FROM_VERSION: latest
-      TESTS: any_version|v0.6.1|v0.7.3|v0.8.0|v0.8.1|v0.8.2|v0.8.3|v0.9.0|v0.9.2
+      TESTS: any_version|v0.6.1|v0.7.3|v0.8.0|v0.8.1|v0.8.2|v0.8.3|v0.9.0|v0.9.2|v0.9.3
     steps:
       - step: workflow
         workflow: test-upgrade-from-version
@@ -132,7 +143,7 @@ mzworkflows:
   upgrade-from-current-source:
     env:
       UPGRADE_FROM_VERSION: current_source
-      TESTS: any_version|v0.6.1|v0.7.3|v0.8.0|v0.8.1|v0.8.2|v0.8.3|v0.9.0|v0.9.2|current_source
+      TESTS: any_version|v0.6.1|v0.7.3|v0.8.0|v0.8.1|v0.8.2|v0.8.3|v0.9.0|v0.9.2|v0.9.3|current_source
     steps:
       - step: workflow
         workflow: test-upgrade-from-current-source
```