### PR TITLE
exclude protobuf schema registry tests from redpanda nightly

### DIFF
--- a/test/testdrive/mzcompose.yml
+++ b/test/testdrive/mzcompose.yml
@@ -28,8 +28,9 @@ mzworkflows:
   #
   # Specify the `TD_TEST` environment variable to select a specific test to run.
   # Otherwise, this workflow runs against the test files in this directory that
-  # use a Kafka action but do *not* use `kafka-add-partition`, as Redpanda does
-  # not yet support dynamically adding partitions to a topic.
+  # use a Kafka action but do *not* use:
+  # - `kafka-add-partition`(Redpanda does not yet support dynamically adding partitions to a topic)
+  # - `format=protobuf` with `publish=true` (Redpanda does not support schema publication for protobuf/json)
   testdrive-redpanda:
     steps:
       - step: start-services
@@ -52,7 +53,7 @@ mzworkflows:
           --kafka-addr=redpanda:9092
           --schema-registry-url=http://redpanda:8081
           --materialized-url=postgres://materialize@materialized:6875
-          ${TD_TEST:-$(grep -lF '$ kafka' $(grep -LF '$ kafka-add-partitions' *.td))}
+          ${TD_TEST:-$(grep -lF '$ kafka' $(grep -LF '$ kafka-add-partitions' $(grep -L '$ kafka-ingest.\+format=protobuf.\+publish=true' *.td)))}
 
   # Run tests, requires AWS credentials to be present. See guide-testing for
   # details.


### PR DESCRIPTION
Redpanda's schema registry does not currently support registering
schemas other than Avro.

We recently added protobuf schema registry support. This change excludes
the tests for that feature from the Redpanda nightly run.

Local check to make sure that this test is the only test excluded with
the new glob:
```
[eli@worktop:~/code/materialize/test/testdrive]
$ grep -lF '$ kafka' $(grep -LF '$ kafka-add-partitions' $(grep -L '$ kafka-ingest.\+format=protobuf.\+publish=true' *.td)) > new
[eli@worktop:~/code/materialize/test/testdrive]
$ grep -lF '$ kafka' $(grep -LF '$ kafka-add-partitions' *.td) > old
[eli@worktop:~/code/materialize/test/testdrive]
$ diff old new
56d55
< protobuf.td
```

Also ran `./mzcompose run testdrive-redpanda` to verify that the full
suite now passes.

### Checklist

- [X] This PR has adequate test coverage.
- [X] This PR adds a release note for any user-facing behavior changes.
