### PR TITLE
Support fallible SQL functions in `sqlfunc!` macro

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -273,92 +273,10 @@ fn cast_int64_to_string<'a>(a: Datum<'a>, temp_storage: &'a RowArena) -> Datum<'
     Datum::String(temp_storage.push_string(buf))
 }
 
-fn cast_float32_to_int16<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
-    let f = round_float32(a).unwrap_float32();
-    if (f >= (i16::MIN as f32)) && (f < -(i16::MIN as f32)) {
-        Ok(Datum::from(f as i16))
-    } else {
-        Err(EvalError::Int16OutOfRange)
-    }
-}
-
-fn cast_float32_to_int32<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
-    let f = round_float32(a).unwrap_float32();
-    // This condition is delicate because i32::MIN can be represented exactly by
-    // an f32 but not i32::MAX. We follow PostgreSQL's approach here.
-    //
-    // See: https://github.com/postgres/postgres/blob/ca3b37487/src/include/c.h#L1074-L1096
-    if (f >= (i32::MIN as f32)) && (f < -(i32::MIN as f32)) {
-        Ok(Datum::from(f as i32))
-    } else {
-        Err(EvalError::Int32OutOfRange)
-    }
-}
-
-fn cast_float32_to_int64<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
-    let f = round_float32(a).unwrap_float32();
-    // This condition is delicate because i64::MIN can be represented exactly by
-    // an f32 but not i64::MAX. We follow PostgreSQL's approach here.
-    //
-    // See: https://github.com/postgres/postgres/blob/ca3b37487/src/include/c.h#L1074-L1096
-    if (f >= (i64::MIN as f32)) && (f < -(i64::MIN as f32)) {
-        Ok(Datum::from(f as i64))
-    } else {
-        Err(EvalError::Int64OutOfRange)
-    }
-}
-
 fn cast_float32_to_string<'a>(a: Datum<'a>, temp_storage: &'a RowArena) -> Datum<'a> {
     let mut buf = String::new();
     strconv::format_float32(&mut buf, a.unwrap_float32());
     Datum::String(temp_storage.push_string(buf))
-}
-
-fn cast_float64_to_int16<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
-    let f = round_float64(a).unwrap_float64();
-    if (f >= (i16::MIN as f64)) && (f < -(i16::MIN as f64)) {
-        Ok(Datum::from(f as i16))
-    } else {
-        Err(EvalError::Int16OutOfRange)
-    }
-}
-
-fn cast_float64_to_int32<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
-    let f = round_float64(a).unwrap_float64();
-    // This condition is delicate because i32::MIN can be represented exactly by
-    // an f64 but not i32::MAX. We follow PostgreSQL's approach here.
-    //
-    // See: https://github.com/postgres/postgres/blob/ca3b37487/src/include/c.h#L1074-L1096
-    if (f >= (i32::MIN as f64)) && (f < -(i32::MIN as f64)) {
-        Ok(Datum::from(f as i32))
-    } else {
-        Err(EvalError::Int32OutOfRange)
-    }
-}
-
-fn cast_float64_to_int64<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
-    let f = round_float64(a).unwrap_float64();
-    // This condition is delicate because i64::MIN can be represented exactly by
-    // an f64 but not i64::MAX. We follow PostgreSQL's approach here.
-    //
-    // See: https://github.com/postgres/postgres/blob/ca3b37487/src/include/c.h#L1074-L1096
-    if (f >= (i64::MIN as f64)) && (f < -(i64::MIN as f64)) {
-        Ok(Datum::from(f as i64))
-    } else {
-        Err(EvalError::Int64OutOfRange)
-    }
-}
-
-fn cast_float64_to_float32<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
-    let a = a.unwrap_float64();
-    let result = a as f32;
-    if result.is_infinite() && !a.is_infinite() {
-        Err(EvalError::FloatOverflow)
-    } else if result == 0.0 && a != 0.0 {
-        Err(EvalError::FloatUnderflow)
-    } else {
-        Ok(Datum::from(result))
-    }
 }
 
 fn cast_float32_to_numeric<'a>(a: Datum<'a>, scale: Option<u8>) -> Result<Datum<'a>, EvalError> {
@@ -821,7 +739,7 @@ fn cast_jsonb_to_int16<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
 fn cast_jsonb_to_int32<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     match a {
         Datum::Int64(_) => cast_int64_to_int32(a),
-        Datum::Float64(_) => cast_float64_to_int32(a),
+        Datum::Float64(f) => cast_float64_to_int32(Some(*f)).map(|f| f.into()),
         _ => Err(EvalError::InvalidJsonbCast {
             from: jsonb_type(a).into(),
             to: "integer".into(),
@@ -832,7 +750,7 @@ fn cast_jsonb_to_int32<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
 fn cast_jsonb_to_int64<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     match a {
         Datum::Int64(_) => Ok(a),
-        Datum::Float64(_) => cast_float64_to_int64(a),
+        Datum::Float64(f) => cast_float64_to_int64(Some(*f)).map(|f| f.into()),
         _ => Err(EvalError::InvalidJsonbCast {
             from: jsonb_type(a).into(),
             to: "bigint".into(),
@@ -843,7 +761,7 @@ fn cast_jsonb_to_int64<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
 fn cast_jsonb_to_float32<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     match a {
         Datum::Int64(_) => Ok(cast_int64_to_float32(a)),
-        Datum::Float64(_) => cast_float64_to_float32(a),
+        Datum::Float64(f) => cast_float64_to_float32(Some(*f)).map(|f| f.into()),
         _ => Err(EvalError::InvalidJsonbCast {
             from: jsonb_type(a).into(),
             to: "real".into(),
@@ -1043,28 +961,6 @@ fn floor_numeric<'a>(a: Datum<'a>) -> Datum<'a> {
     cx.round(&mut d.0);
     numeric::munge_numeric(&mut d.0).unwrap();
     Datum::Numeric(d)
-}
-
-fn round_float32<'a>(a: Datum<'a>) -> Datum<'a> {
-    // f32::round violates IEEE 754 by rounding ties away from zero rather than
-    // to nearest even. There appears to be no way to round ties to nearest even
-    // in Rust natively, so bail out to C.
-    extern "C" {
-        fn rintf(f: f32) -> f32;
-    }
-    let a = a.unwrap_float32();
-    Datum::from(unsafe { rintf(a) })
-}
-
-fn round_float64<'a>(a: Datum<'a>) -> Datum<'a> {
-    // f64::round violates IEEE 754 by rounding ties away from zero rather than
-    // to nearest even. There appears to be no way to round ties to nearest even
-    // in Rust natively, so bail out to C.
-    extern "C" {
-        fn rint(f: f64) -> f64;
-    }
-    let a = a.unwrap_float64();
-    Datum::from(unsafe { rint(a) })
 }
 
 fn round_numeric_unary<'a>(a: Datum<'a>) -> Datum<'a> {
@@ -3567,17 +3463,17 @@ pub enum UnaryFunc {
     CastInt64ToFloat32,
     CastInt64ToFloat64,
     CastInt64ToString,
-    CastFloat32ToInt16,
-    CastFloat32ToInt32,
-    CastFloat32ToInt64,
+    CastFloat32ToInt16(CastFloat32ToInt16),
+    CastFloat32ToInt32(CastFloat32ToInt32),
+    CastFloat32ToInt64(CastFloat32ToInt64),
     CastFloat32ToFloat64(CastFloat32ToFloat64),
     CastFloat32ToString,
     CastFloat32ToNumeric(Option<u8>),
     CastFloat64ToNumeric(Option<u8>),
-    CastFloat64ToInt16,
-    CastFloat64ToInt32,
-    CastFloat64ToInt64,
-    CastFloat64ToFloat32,
+    CastFloat64ToInt16(CastFloat64ToInt16),
+    CastFloat64ToInt32(CastFloat64ToInt32),
+    CastFloat64ToInt64(CastFloat64ToInt64),
+    CastFloat64ToFloat32(CastFloat64ToFloat32),
     CastFloat64ToString,
     CastNumericToFloat32,
     CastNumericToFloat64,
@@ -3712,8 +3608,8 @@ pub enum UnaryFunc {
     JsonbTypeof,
     JsonbStripNulls,
     JsonbPretty,
-    RoundFloat32,
-    RoundFloat64,
+    RoundFloat32(RoundFloat32),
+    RoundFloat64(RoundFloat64),
     RoundNumeric,
     TrimWhitespace,
     TrimLeadingWhitespace,
@@ -3747,6 +3643,15 @@ derive_unary!(
     NegFloat64,
     AbsFloat32,
     AbsFloat64,
+    RoundFloat32,
+    RoundFloat64,
+    CastFloat32ToInt16,
+    CastFloat32ToInt32,
+    CastFloat32ToInt64,
+    CastFloat64ToInt16,
+    CastFloat64ToInt32,
+    CastFloat64ToInt64,
+    CastFloat64ToFloat32,
     CastFloat32ToFloat64
 );
 
@@ -3769,6 +3674,15 @@ impl UnaryFunc {
             | NegFloat64(_)
             | AbsFloat32(_)
             | AbsFloat64(_)
+            | RoundFloat32(_)
+            | RoundFloat64(_)
+            | CastFloat32ToInt16(_)
+            | CastFloat32ToInt32(_)
+            | CastFloat32ToInt64(_)
+            | CastFloat64ToInt16(_)
+            | CastFloat64ToInt32(_)
+            | CastFloat64ToInt64(_)
+            | CastFloat64ToFloat32(_)
             | CastFloat32ToFloat64(_) => unreachable!(),
             IsNull => Ok(is_null(a)),
             NegInt16 => Ok(neg_int16(a)),
@@ -3810,14 +3724,7 @@ impl UnaryFunc {
             CastInt64ToFloat32 => Ok(cast_int64_to_float32(a)),
             CastInt64ToFloat64 => Ok(cast_int64_to_float64(a)),
             CastInt64ToString => Ok(cast_int64_to_string(a, temp_storage)),
-            CastFloat32ToInt16 => cast_float32_to_int16(a),
-            CastFloat32ToInt32 => cast_float32_to_int32(a),
-            CastFloat32ToInt64 => cast_float32_to_int64(a),
             CastFloat32ToString => Ok(cast_float32_to_string(a, temp_storage)),
-            CastFloat64ToInt16 => cast_float64_to_int16(a),
-            CastFloat64ToInt32 => cast_float64_to_int32(a),
-            CastFloat64ToInt64 => cast_float64_to_int64(a),
-            CastFloat64ToFloat32 => cast_float64_to_float32(a),
             CastFloat64ToString => Ok(cast_float64_to_string(a, temp_storage)),
             CastStringToBool => cast_string_to_bool(a),
             CastStringToBytes => cast_string_to_bytes(a, temp_storage),
@@ -3921,8 +3828,6 @@ impl UnaryFunc {
             JsonbTypeof => Ok(jsonb_typeof(a)),
             JsonbStripNulls => Ok(jsonb_strip_nulls(a, temp_storage)),
             JsonbPretty => Ok(jsonb_pretty(a, temp_storage)),
-            RoundFloat32 => Ok(round_float32(a)),
-            RoundFloat64 => Ok(round_float64(a)),
             RoundNumeric => Ok(round_numeric_unary(a)),
             TrimWhitespace => Ok(trim_whitespace(a)),
             TrimLeadingWhitespace => Ok(trim_leading_whitespace(a)),
@@ -3966,6 +3871,15 @@ impl UnaryFunc {
             | NegFloat64(_)
             | AbsFloat32(_)
             | AbsFloat64(_)
+            | RoundFloat32(_)
+            | RoundFloat64(_)
+            | CastFloat32ToInt16(_)
+            | CastFloat32ToInt32(_)
+            | CastFloat32ToInt64(_)
+            | CastFloat64ToInt16(_)
+            | CastFloat64ToInt32(_)
+            | CastFloat64ToInt64(_)
+            | CastFloat64ToFloat32(_)
             | CastFloat32ToFloat64(_) => unreachable!(),
             IsNull => ScalarType::Bool.nullable(nullable),
 
@@ -4008,24 +3922,22 @@ impl UnaryFunc {
             | Upper
             | Lower => ScalarType::String.nullable(nullable),
 
-            CastStringToFloat32 | CastFloat64ToFloat32 | CastInt16ToFloat32
-            | CastInt32ToFloat32 | CastInt64ToFloat32 | CastNumericToFloat32 => {
-                ScalarType::Float32.nullable(nullable)
-            }
+            CastStringToFloat32 | CastInt16ToFloat32 | CastInt32ToFloat32 | CastInt64ToFloat32
+            | CastNumericToFloat32 => ScalarType::Float32.nullable(nullable),
 
             CastStringToFloat64 | CastInt16ToFloat64 | CastInt32ToFloat64 | CastInt64ToFloat64
             | CastNumericToFloat64 => ScalarType::Float64.nullable(nullable),
 
-            CastStringToInt16 | CastInt32ToInt16 | CastInt64ToInt16 | CastFloat32ToInt16
-            | CastFloat64ToInt16 | CastNumericToInt16 => ScalarType::Int16.nullable(nullable),
-
-            CastBoolToInt32 | CastStringToInt32 | CastInt16ToInt32 | CastInt64ToInt32
-            | CastFloat32ToInt32 | CastFloat64ToInt32 | CastNumericToInt32 => {
-                ScalarType::Int32.nullable(nullable)
+            CastStringToInt16 | CastInt32ToInt16 | CastInt64ToInt16 | CastNumericToInt16 => {
+                ScalarType::Int16.nullable(nullable)
             }
 
-            CastStringToInt64 | CastInt16ToInt64 | CastInt32ToInt64 | CastFloat32ToInt64
-            | CastFloat64ToInt64 | CastNumericToInt64 => ScalarType::Int64.nullable(nullable),
+            CastBoolToInt32 | CastStringToInt32 | CastInt16ToInt32 | CastInt64ToInt32
+            | CastNumericToInt32 => ScalarType::Int32.nullable(nullable),
+
+            CastStringToInt64 | CastInt16ToInt64 | CastInt32ToInt64 | CastNumericToInt64 => {
+                ScalarType::Int64.nullable(nullable)
+            }
 
             CastStringToNumeric(scale)
             | CastInt16ToNumeric(scale)
@@ -4086,8 +3998,8 @@ impl UnaryFunc {
                 ScalarType::VarChar { length: *length }.nullable(nullable)
             }
 
-            CeilFloat32 | FloorFloat32 | RoundFloat32 => ScalarType::Float32.nullable(nullable),
-            CeilFloat64 | FloorFloat64 | RoundFloat64 => ScalarType::Float64.nullable(nullable),
+            CeilFloat32 | FloorFloat32 => ScalarType::Float32.nullable(nullable),
+            CeilFloat64 | FloorFloat64 => ScalarType::Float64.nullable(nullable),
 
             NegInt16 | NegInt32 | NegInt64 | NegInterval | AbsInt16 | AbsInt32 | AbsInt64 => {
                 input_type
@@ -4159,6 +4071,15 @@ impl UnaryFunc {
             | NegFloat64(_)
             | AbsFloat32(_)
             | AbsFloat64(_)
+            | RoundFloat32(_)
+            | RoundFloat64(_)
+            | CastFloat32ToInt16(_)
+            | CastFloat32ToInt32(_)
+            | CastFloat32ToInt64(_)
+            | CastFloat64ToInt16(_)
+            | CastFloat64ToInt32(_)
+            | CastFloat64ToInt64(_)
+            | CastFloat64ToFloat32(_)
             | CastFloat32ToFloat64(_) => unreachable!(),
             // These return null when their input is SQL null.
             CastJsonbToString | CastJsonbToInt16 | CastJsonbToInt32 | CastJsonbToInt64
@@ -4210,16 +4131,14 @@ impl UnaryFunc {
             | TrimTrailingWhitespace
             | Upper
             | Lower => false,
-            CastStringToFloat32 | CastFloat64ToFloat32 | CastInt32ToFloat32
-            | CastInt16ToFloat32 | CastInt64ToFloat32 | CastNumericToFloat32 => false,
+            CastStringToFloat32 | CastInt32ToFloat32 | CastInt16ToFloat32 | CastInt64ToFloat32
+            | CastNumericToFloat32 => false,
             CastStringToFloat64 | CastInt32ToFloat64 | CastInt16ToFloat64 | CastInt64ToFloat64
             | CastNumericToFloat64 => false,
-            CastStringToInt16 | CastInt32ToInt16 | CastInt64ToInt16 | CastFloat32ToInt16
-            | CastFloat64ToInt16 | CastNumericToInt16 => false,
+            CastStringToInt16 | CastInt32ToInt16 | CastInt64ToInt16 | CastNumericToInt16 => false,
             CastBoolToInt32 | CastStringToInt32 | CastInt16ToInt32 | CastInt64ToInt32
-            | CastFloat32ToInt32 | CastFloat64ToInt32 | CastNumericToInt32 => false,
-            CastStringToInt64 | CastInt16ToInt64 | CastInt32ToInt64 | CastFloat32ToInt64
-            | CastFloat64ToInt64 | CastNumericToInt64 => false,
+            | CastNumericToInt32 => false,
+            CastStringToInt64 | CastInt16ToInt64 | CastInt32ToInt64 | CastNumericToInt64 => false,
             CastStringToNumeric(_)
             | CastInt16ToNumeric(_)
             | CastInt32ToNumeric(_)
@@ -4251,8 +4170,8 @@ impl UnaryFunc {
             DatePartInterval(_) | DatePartTimestamp(_) | DatePartTimestampTz(_) => false,
             DateTruncTimestamp(_) | DateTruncTimestampTz(_) => false,
             NegInt16 | NegInt32 | NegInt64 | NegInterval | AbsInt16 | AbsInt32 | AbsInt64 => false,
-            CeilFloat32 | FloorFloat32 | RoundFloat32 => false,
-            CeilFloat64 | FloorFloat64 | RoundFloat64 => false,
+            CeilFloat32 | FloorFloat32 => false,
+            CeilFloat64 | FloorFloat64 => false,
             Log10 | Ln | Exp | Cos | Cosh | Sin | Sinh | Tan | Tanh | Cot | SqrtFloat64
             | CbrtFloat64 => false,
             PgColumnSize | MzRowSize => false,
@@ -4273,6 +4192,15 @@ impl UnaryFunc {
             | NegFloat64(_)
             | AbsFloat32(_)
             | AbsFloat64(_)
+            | RoundFloat32(_)
+            | RoundFloat64(_)
+            | CastFloat32ToInt16(_)
+            | CastFloat32ToInt32(_)
+            | CastFloat32ToInt64(_)
+            | CastFloat64ToInt16(_)
+            | CastFloat64ToInt32(_)
+            | CastFloat64ToInt64(_)
+            | CastFloat64ToFloat32(_)
             | CastFloat32ToFloat64(_) => unreachable!(),
             NegInt16
             | NegInt32
@@ -4309,6 +4237,15 @@ impl UnaryFunc {
             | NegFloat64(_)
             | AbsFloat32(_)
             | AbsFloat64(_)
+            | RoundFloat32(_)
+            | RoundFloat64(_)
+            | CastFloat32ToInt16(_)
+            | CastFloat32ToInt32(_)
+            | CastFloat32ToInt64(_)
+            | CastFloat64ToInt16(_)
+            | CastFloat64ToInt32(_)
+            | CastFloat64ToInt64(_)
+            | CastFloat64ToFloat32(_)
             | CastFloat32ToFloat64(_) => unreachable!(),
             IsNull => f.write_str("isnull"),
             NegInt16 => f.write_str("-"),
@@ -4348,15 +4285,8 @@ impl UnaryFunc {
             CastInt64ToFloat32 => f.write_str("i64tof32"),
             CastInt64ToFloat64 => f.write_str("i64tof64"),
             CastInt64ToString => f.write_str("i64tostr"),
-            CastFloat32ToInt64 => f.write_str("f32toi64"),
             CastFloat32ToString => f.write_str("f32tostr"),
-            CastFloat32ToInt16 => f.write_str("f32toi16"),
-            CastFloat32ToInt32 => f.write_str("f32toi32"),
             CastFloat32ToNumeric(_) => f.write_str("f32tonumeric"),
-            CastFloat64ToInt16 => f.write_str("f64toi16"),
-            CastFloat64ToInt32 => f.write_str("f64toi32"),
-            CastFloat64ToInt64 => f.write_str("f64toi64"),
-            CastFloat64ToFloat32 => f.write_str("f64tof32"),
             CastFloat64ToString => f.write_str("f64tostr"),
             CastFloat64ToNumeric(_) => f.write_str("f32tonumeric"),
             CastNumericToInt16 => f.write_str("numerictoi16"),
@@ -4448,8 +4378,6 @@ impl UnaryFunc {
             JsonbTypeof => f.write_str("jsonb_typeof"),
             JsonbStripNulls => f.write_str("jsonb_strip_nulls"),
             JsonbPretty => f.write_str("jsonb_pretty"),
-            RoundFloat32 => f.write_str("roundf32"),
-            RoundFloat64 => f.write_str("roundf64"),
             RoundNumeric => f.write_str("roundnumeric"),
             TrimWhitespace => f.write_str("btrim"),
             TrimLeadingWhitespace => f.write_str("ltrim"),

--- a/src/expr/src/scalar/func/impls/float.rs
+++ b/src/expr/src/scalar/func/impls/float.rs
@@ -38,13 +38,6 @@ sqlfunc!(
 );
 
 sqlfunc!(
-    #[sqlname = "f32tof64"]
-    fn cast_float32_to_float64(a: f32) -> f64 {
-        a.into()
-    }
-);
-
-sqlfunc!(
     #[sqlname = "roundf32"]
     fn round_float32(a: f32) -> f32 {
         // f32::round violates IEEE 754 by rounding ties away from zero rather than
@@ -67,6 +60,34 @@ sqlfunc!(
             fn rint(f: f64) -> f64;
         }
         unsafe { rint(a) }
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "ceilf32"]
+    fn ceil_float32(a: f32) -> f32 {
+        a.ceil()
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "ceilf64"]
+    fn ceil_float64(a: f64) -> f64 {
+        a.ceil()
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "floorf32"]
+    fn floor_float32(a: f32) -> f32 {
+        a.floor()
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "floorf64"]
+    fn floor_float64(a: f64) -> f64 {
+        a.floor()
     }
 );
 
@@ -169,5 +190,12 @@ sqlfunc!(
         } else {
             Ok(result)
         }
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "f32tof64"]
+    fn cast_float32_to_float64(a: f32) -> f64 {
+        a.into()
     }
 );

--- a/src/expr/src/scalar/func/impls/float.rs
+++ b/src/expr/src/scalar/func/impls/float.rs
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use crate::EvalError;
+
 sqlfunc!(
     #[sqlname = "-"]
     fn neg_float32(a: f32) -> f32 {
@@ -39,5 +41,133 @@ sqlfunc!(
     #[sqlname = "f32tof64"]
     fn cast_float32_to_float64(a: f32) -> f64 {
         a.into()
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "roundf32"]
+    fn round_float32(a: f32) -> f32 {
+        // f32::round violates IEEE 754 by rounding ties away from zero rather than
+        // to nearest even. There appears to be no way to round ties to nearest even
+        // in Rust natively, so bail out to C.
+        extern "C" {
+            fn rintf(f: f32) -> f32;
+        }
+        unsafe { rintf(a) }
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "roundf64"]
+    fn round_float64(a: f64) -> f64 {
+        // f64::round violates IEEE 754 by rounding ties away from zero rather than
+        // to nearest even. There appears to be no way to round ties to nearest even
+        // in Rust natively, so bail out to C.
+        extern "C" {
+            fn rint(f: f64) -> f64;
+        }
+        unsafe { rint(a) }
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "f32toi16"]
+    fn cast_float32_to_int16(a: f32) -> Result<i16, EvalError> {
+        let f = round_float32(Some(a))?.unwrap();
+        if (f >= (i16::MIN as f32)) && (f < -(i16::MIN as f32)) {
+            Ok(f as i16)
+        } else {
+            Err(EvalError::Int16OutOfRange)
+        }
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "f32toi32"]
+    fn cast_float32_to_int32(a: f32) -> Result<i32, EvalError> {
+        let f = round_float32(Some(a))?.unwrap();
+        // This condition is delicate because i32::MIN can be represented exactly by
+        // an f32 but not i32::MAX. We follow PostgreSQL's approach here.
+        //
+        // See: https://github.com/postgres/postgres/blob/ca3b37487/src/include/c.h#L1074-L1096
+        if (f >= (i32::MIN as f32)) && (f < -(i32::MIN as f32)) {
+            Ok(f as i32)
+        } else {
+            Err(EvalError::Int32OutOfRange)
+        }
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "f32toi64"]
+    fn cast_float32_to_int64(a: f32) -> Result<i64, EvalError> {
+        let f = round_float32(Some(a))?.unwrap();
+        // This condition is delicate because i64::MIN can be represented exactly by
+        // an f32 but not i64::MAX. We follow PostgreSQL's approach here.
+        //
+        // See: https://github.com/postgres/postgres/blob/ca3b37487/src/include/c.h#L1074-L1096
+        if (f >= (i64::MIN as f32)) && (f < -(i64::MIN as f32)) {
+            Ok(f as i64)
+        } else {
+            Err(EvalError::Int64OutOfRange)
+        }
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "f64toi16"]
+    fn cast_float64_to_int16(a: f64) -> Result<i16, EvalError> {
+        let f = round_float64(Some(a))?.unwrap();
+        if (f >= (i16::MIN as f64)) && (f < -(i16::MIN as f64)) {
+            Ok(f as i16)
+        } else {
+            Err(EvalError::Int16OutOfRange)
+        }
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "f64toi32"]
+    fn cast_float64_to_int32(a: f64) -> Result<i32, EvalError> {
+        let f = round_float64(Some(a))?.unwrap();
+        // This condition is delicate because i32::MIN can be represented exactly by
+        // an f64 but not i32::MAX. We follow PostgreSQL's approach here.
+        //
+        // See: https://github.com/postgres/postgres/blob/ca3b37487/src/include/c.h#L1074-L1096
+        if (f >= (i32::MIN as f64)) && (f < -(i32::MIN as f64)) {
+            Ok(f as i32)
+        } else {
+            Err(EvalError::Int32OutOfRange)
+        }
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "f64toi64"]
+    fn cast_float64_to_int64(a: f64) -> Result<i64, EvalError> {
+        let f = round_float64(Some(a))?.unwrap();
+        // This condition is delicate because i64::MIN can be represented exactly by
+        // an f64 but not i64::MAX. We follow PostgreSQL's approach here.
+        //
+        // See: https://github.com/postgres/postgres/blob/ca3b37487/src/include/c.h#L1074-L1096
+        if (f >= (i64::MIN as f64)) && (f < -(i64::MIN as f64)) {
+            Ok(f as i64)
+        } else {
+            Err(EvalError::Int64OutOfRange)
+        }
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "f64tof32"]
+    fn cast_float64_to_float32(a: f64) -> Result<f32, EvalError> {
+        let result = a as f32;
+        if result.is_infinite() && !a.is_infinite() {
+            Err(EvalError::FloatOverflow)
+        } else if result == 0.0 && a != 0.0 {
+            Err(EvalError::FloatUnderflow)
+        } else {
+            Ok(result)
+        }
     }
 );

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -888,6 +888,24 @@ impl FromTy<f64> for ScalarType {
     }
 }
 
+impl FromTy<i16> for ScalarType {
+    fn from_ty() -> Self {
+        Self::Int16
+    }
+}
+
+impl FromTy<i32> for ScalarType {
+    fn from_ty() -> Self {
+        Self::Int32
+    }
+}
+
+impl FromTy<i64> for ScalarType {
+    fn from_ty() -> Self {
+        Self::Int64
+    }
+}
+
 impl<'a> ScalarType {
     /// Returns the contained numeric scale.
     ///

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1310,8 +1310,8 @@ lazy_static! {
                 params!(Float64) => UnaryFunc::CbrtFloat64, 1345;
             },
             "ceil" => Scalar {
-                params!(Float32) => UnaryFunc::CeilFloat32, oid::FUNC_CEIL_F32_OID;
-                params!(Float64) => UnaryFunc::CeilFloat64, 2308;
+                params!(Float32) => UnaryFunc::CeilFloat32(func::CeilFloat32), oid::FUNC_CEIL_F32_OID;
+                params!(Float64) => UnaryFunc::CeilFloat64(func::CeilFloat64), 2308;
                 params!(Numeric) => UnaryFunc::CeilNumeric, 1711;
             },
             "char_length" => Scalar {
@@ -1391,8 +1391,8 @@ lazy_static! {
                 params!(Numeric) => UnaryFunc::ExpNumeric, 1732;
             },
             "floor" => Scalar {
-                params!(Float32) => UnaryFunc::FloorFloat32, oid::FUNC_FLOOR_F32_OID;
-                params!(Float64) => UnaryFunc::FloorFloat64, 2309;
+                params!(Float32) => UnaryFunc::FloorFloat32(func::FloorFloat32), oid::FUNC_FLOOR_F32_OID;
+                params!(Float64) => UnaryFunc::FloorFloat64(func::FloorFloat64), 2309;
                 params!(Numeric) => UnaryFunc::FloorNumeric, 1712;
             },
             "format_type" => Scalar {

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1594,8 +1594,8 @@ lazy_static! {
                 params!(String, Int32) => BinaryFunc::Right, 3061;
             },
             "round" => Scalar {
-                params!(Float32) => UnaryFunc::RoundFloat32, oid::FUNC_ROUND_F32_OID;
-                params!(Float64) => UnaryFunc::RoundFloat64, 1342;
+                params!(Float32) => UnaryFunc::RoundFloat32(func::RoundFloat32), oid::FUNC_ROUND_F32_OID;
+                params!(Float64) => UnaryFunc::RoundFloat64(func::RoundFloat64), 1342;
                 params!(Numeric) => UnaryFunc::RoundNumeric, 1708;
                 params!(Numeric, Int32) => BinaryFunc::RoundNumeric, 1707;
             },

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -175,9 +175,9 @@ lazy_static! {
             (RegProc,Oid) => Implicit: CastRegProcToOid,
 
             // FLOAT32
-            (Float32, Int16) => Assignment: CastFloat32ToInt16,
-            (Float32, Int32) => Assignment: CastFloat32ToInt32,
-            (Float32, Int64) => Assignment: CastFloat32ToInt64,
+            (Float32, Int16) => Assignment: CastFloat32ToInt16(func::CastFloat32ToInt16),
+            (Float32, Int32) => Assignment: CastFloat32ToInt32(func::CastFloat32ToInt32),
+            (Float32, Int64) => Assignment: CastFloat32ToInt64(func::CastFloat32ToInt64),
             (Float32, Float64) => Implicit: CastFloat32ToFloat64(func::CastFloat32ToFloat64),
             (Float32, Numeric) => Assignment: CastTemplate::new(|_ecx, _ccx, _from_type, to_type| {
                 let s = to_type.unwrap_numeric_scale();
@@ -186,10 +186,10 @@ lazy_static! {
             (Float32, String) => Assignment: CastFloat32ToString,
 
             // FLOAT64
-            (Float64, Int16) => Assignment: CastFloat64ToInt16,
-            (Float64, Int32) => Assignment: CastFloat64ToInt32,
-            (Float64, Int64) => Assignment: CastFloat64ToInt64,
-            (Float64, Float32) => Assignment: CastFloat64ToFloat32,
+            (Float64, Int16) => Assignment: CastFloat64ToInt16(func::CastFloat64ToInt16),
+            (Float64, Int32) => Assignment: CastFloat64ToInt32(func::CastFloat64ToInt32),
+            (Float64, Int64) => Assignment: CastFloat64ToInt64(func::CastFloat64ToInt64),
+            (Float64, Float32) => Assignment: CastFloat64ToFloat32(func::CastFloat64ToFloat32),
             (Float64, Numeric) => Assignment: CastTemplate::new(|_ecx, _ccx, _from_type, to_type| {
                 let s = to_type.unwrap_numeric_scale();
                 Some(move |e: HirScalarExpr| e.call_unary(CastFloat64ToNumeric(s)))


### PR DESCRIPTION
### Motivation

Continues the saga of moving SQL functions under enum_dispatch

### Description

The `sqlfunc!` macro has been updated to allow fallible function signatures. Using this new functionality a few more fallible float functions have been implemented.

### Tips for reviewer

Commits are split semantically

### Checklist

- [ ] This PR has adequate test coverage.
- [ ] This PR adds a release note for any user-facing behavior changes.
