### PR TITLE
Generalize sources and sinks to non-`Child` scopes

### DIFF
--- a/src/dataflow/src/render/sinks.rs
+++ b/src/dataflow/src/render/sinks.rs
@@ -16,7 +16,6 @@ use std::rc::Rc;
 
 use differential_dataflow::operators::arrange::arrangement::ArrangeByKey;
 use differential_dataflow::{Collection, Hashable};
-use timely::dataflow::scopes::Child;
 use timely::dataflow::Scope;
 
 use dataflow_types::*;
@@ -28,7 +27,7 @@ use crate::render::context::Context;
 use crate::render::{RelevantTokens, RenderState};
 use crate::sink::SinkBaseMetrics;
 
-impl<'g, G> Context<Child<'g, G, G::Timestamp>, Row, Timestamp>
+impl<G> Context<G, Row, Timestamp>
 where
     G: Scope<Timestamp = Timestamp>,
 {
@@ -85,11 +84,11 @@ where
     }
 }
 
-fn apply_sink_envelope<'a, G>(
+fn apply_sink_envelope<G>(
     sink: &SinkDesc,
     sink_render: &Box<dyn SinkRender<G>>,
-    collection: Collection<Child<'a, G, G::Timestamp>, Row, Diff>,
-) -> Collection<Child<'a, G, G::Timestamp>, (Option<Row>, Option<Row>), Diff>
+    collection: Collection<G, Row, Diff>,
+) -> Collection<G, (Option<Row>, Option<Row>), Diff>
 where
     G: Scope<Timestamp = Timestamp>,
 {
@@ -210,7 +209,7 @@ where
         render_state: &mut RenderState,
         sink: &SinkDesc,
         sink_id: GlobalId,
-        sinked_collection: Collection<Child<G, G::Timestamp>, (Option<Row>, Option<Row>), Diff>,
+        sinked_collection: Collection<G, (Option<Row>, Option<Row>), Diff>,
         metrics: &SinkBaseMetrics,
     ) -> Option<Box<dyn Any>>
     where

--- a/src/dataflow/src/sink/avro_ocf.rs
+++ b/src/dataflow/src/sink/avro_ocf.rs
@@ -22,7 +22,6 @@ use dataflow_types::{AvroOcfSinkConnector, SinkDesc};
 use expr::GlobalId;
 use interchange::avro::{encode_datums_as_avro, AvroSchemaGenerator};
 use repr::{Diff, RelationDesc, Row, Timestamp};
-use timely::dataflow::scopes::Child;
 
 use crate::render::sinks::SinkRender;
 use crate::render::RenderState;
@@ -58,7 +57,7 @@ where
         _render_state: &mut RenderState,
         _sink: &SinkDesc,
         sink_id: GlobalId,
-        sinked_collection: Collection<Child<G, G::Timestamp>, (Option<Row>, Option<Row>), Diff>,
+        sinked_collection: Collection<G, (Option<Row>, Option<Row>), Diff>,
         _metrics: &SinkBaseMetrics,
     ) -> Option<Box<dyn Any>>
     where

--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -32,7 +32,6 @@ use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use timely::dataflow::operators::generic::{FrontieredInputHandle, InputHandle, OutputHandle};
 use timely::dataflow::operators::{Capability, Map};
-use timely::dataflow::scopes::Child;
 use timely::dataflow::{Scope, Stream};
 use timely::progress::frontier::AntichainRef;
 use timely::progress::Antichain;
@@ -86,7 +85,7 @@ where
         render_state: &mut RenderState,
         sink: &SinkDesc,
         sink_id: GlobalId,
-        sinked_collection: Collection<Child<G, G::Timestamp>, (Option<Row>, Option<Row>), Diff>,
+        sinked_collection: Collection<G, (Option<Row>, Option<Row>), Diff>,
         metrics: &SinkBaseMetrics,
     ) -> Option<Box<dyn Any>>
     where

--- a/src/dataflow/src/sink/tail.rs
+++ b/src/dataflow/src/sink/tail.rs
@@ -19,7 +19,6 @@ use differential_dataflow::Collection;
 use itertools::Itertools;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::Operator;
-use timely::dataflow::scopes::Child;
 use timely::dataflow::Scope;
 use timely::progress::frontier::AntichainRef;
 use timely::progress::timestamp::Timestamp as TimelyTimestamp;
@@ -66,7 +65,7 @@ where
         render_state: &mut RenderState,
         sink: &SinkDesc,
         sink_id: GlobalId,
-        sinked_collection: Collection<Child<G, G::Timestamp>, (Option<Row>, Option<Row>), Diff>,
+        sinked_collection: Collection<G, (Option<Row>, Option<Row>), Diff>,
         _metrics: &SinkBaseMetrics,
     ) -> Option<Box<dyn Any>>
     where
@@ -86,7 +85,7 @@ where
 }
 
 fn tail<G>(
-    sinked_collection: Collection<Child<G, G::Timestamp>, (Option<Row>, Option<Row>), Diff>,
+    sinked_collection: Collection<G, (Option<Row>, Option<Row>), Diff>,
     sink_id: GlobalId,
     connector: TailSinkConnector,
     tail_response_buffer: Rc<RefCell<Vec<(GlobalId, TailResponse)>>>,


### PR DESCRIPTION
### Motivation

This PR removes an internal restriction of sources and sinks to `Child` scopes that have the same timestamp as their parent (a "region"). There does not seem to be a reason to make this restriction, at least not evident in the code (which compiles without the restriction).

### Description

Many instances of `Child<'g, G, G::Timestamp>` are replaced by `G`.

### Checklist

- [x] This PR has adequate test coverage.
- [x] This PR adds a release note for any user-facing behavior changes.
