### PR TITLE
sql: error on unsupported transaction options

### DIFF
--- a/test/sqllogictest/transactions.slt
+++ b/test/sqllogictest/transactions.slt
@@ -391,3 +391,27 @@ simple conn=t1
 COMMIT;
 ----
 db error: ERROR: unknown catalog item 'u21'
+
+# Test transaction syntax that we don't support.
+
+statement error READ WRITE not yet supported
+BEGIN READ WRITE
+
+statement ok
+BEGIN ISOLATION LEVEL SERIALIZABLE
+
+statement error CHAIN not yet supported
+COMMIT AND CHAIN
+
+statement error CHAIN not yet supported
+ROLLBACK AND CHAIN
+
+statement ok
+ROLLBACK
+
+# This is a noop, but is supported syntax.
+statement ok
+BEGIN ISOLATION LEVEL REPEATABLE READ
+
+statement ok
+COMMIT


### PR DESCRIPTION
### Motivation

This PR fixes a previously unreported bug.

### Description

We previously parsed these, but incorrectly ignored them. Detect and
error on the things we don't support.

### Checklist

- [x] This PR has adequate test coverage.
- [x] This PR adds a release note for any user-facing behavior changes.
