### PR TITLE
sql-parser: remove dependency on repr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4309,7 +4309,6 @@ dependencies = [
  "ore",
  "phf",
  "phf_codegen",
- "repr",
  "stacker",
  "uncased",
  "unicode-width",

--- a/src/repr/src/adt/datetime.rs
+++ b/src/repr/src/adt/datetime.rs
@@ -1885,6 +1885,15 @@ mod test {
     use super::*;
 
     #[test]
+    fn iterate_datetimefield() {
+        use DateTimeField::*;
+        assert_eq!(
+            Year.into_iter().take(10).collect::<Vec<_>>(),
+            vec![Month, Day, Hour, Minute, Second]
+        )
+    }
+
+    #[test]
     fn test_datetimefieldvalue_div() {
         let test_cases = vec![
             (

--- a/src/sql-parser/Cargo.toml
+++ b/src/sql-parser/Cargo.toml
@@ -13,7 +13,6 @@ lazy_static = "1.4.0"
 log = "0.4.13"
 ore = { path = "../ore"}
 phf = { version = "0.10.0", features = ["uncased"] }
-repr = { path = "../repr" }
 stacker = "0.1.14"
 uncased = "0.9.6"
 

--- a/src/sql-parser/src/ast/defs/value.rs
+++ b/src/sql-parser/src/ast/defs/value.rs
@@ -19,8 +19,7 @@
 // limitations under the License.
 
 use std::fmt;
-
-use repr::adt::datetime::DateTimeField;
+use std::str::FromStr;
 
 use crate::ast::defs::AstInfo;
 use crate::ast::display::{self, AstDisplay, AstFormatter};
@@ -136,6 +135,45 @@ impl AstDisplay for Value {
 }
 impl_display!(Value);
 
+#[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash)]
+pub enum DateTimeField {
+    Year,
+    Month,
+    Day,
+    Hour,
+    Minute,
+    Second,
+}
+
+impl fmt::Display for DateTimeField {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(match self {
+            DateTimeField::Year => "YEAR",
+            DateTimeField::Month => "MONTH",
+            DateTimeField::Day => "DAY",
+            DateTimeField::Hour => "HOUR",
+            DateTimeField::Minute => "MINUTE",
+            DateTimeField::Second => "SECOND",
+        })
+    }
+}
+
+impl FromStr for DateTimeField {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.to_uppercase().as_ref() {
+            "YEAR" | "YEARS" | "Y" => Ok(Self::Year),
+            "MONTH" | "MONTHS" | "MON" | "MONS" => Ok(Self::Month),
+            "DAY" | "DAYS" | "D" => Ok(Self::Day),
+            "HOUR" | "HOURS" | "H" => Ok(Self::Hour),
+            "MINUTE" | "MINUTES" | "M" => Ok(Self::Minute),
+            "SECOND" | "SECONDS" | "S" => Ok(Self::Second),
+            _ => Err(format!("invalid DateTimeField: {}", s)),
+        }
+    }
+}
+
 /// An intermediate value for Intervals, which tracks all data from
 /// the user, as well as the computed ParsedDateTime.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -164,20 +202,6 @@ impl Default for IntervalValue {
             precision_low: DateTimeField::Second,
             fsec_max_precision: None,
         }
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn iterate_datetimefield() {
-        use DateTimeField::*;
-        assert_eq!(
-            Year.into_iter().take(10).collect::<Vec<_>>(),
-            vec![Month, Day, Hour, Minute, Second]
-        )
     }
 }
 

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -28,7 +28,6 @@ use log::{debug, warn};
 
 use ore::collections::CollectionExt;
 use ore::option::OptionExt;
-use repr::adt::datetime::DateTimeField;
 
 use crate::ast::*;
 use crate::keywords::*;


### PR DESCRIPTION
### Motivation

This PR does a small refactor to remove a package dependency.

### Description

repr and sql-parser share a single, tiny data structure, but otherwise
don't know about each other. Duplicate this type so the crates don't
depend on each other. For users of just sql-parser, this reduces total
dependencies (not really a problem for materialize directly). Materialize
gets the benefit that some of our larger crates are no longer coupled,
at the cost of a small transform function.
