### PR TITLE
(docs) add redirect from old to new cloud quickstart url

### DIFF
--- a/doc/user/content/cloud/get-started-with-cloud.md
+++ b/doc/user/content/cloud/get-started-with-cloud.md
@@ -8,6 +8,7 @@ menu:
 aliases:
   - materialize-cloud-quickstart
   - materialize-cloud-get-started
+  - /docs/cloud/quickstart
 ---
 
 {{< cloud-notice >}}


### PR DESCRIPTION
Quick fix to ensure `/docs/cloud/quickstart/` redirects to `/docs/cloud/get-started-with-cloud/`