### PR TITLE
*: reduce dependencies on ore by sql-parser

### DIFF
--- a/src/sql-parser/Cargo.toml
+++ b/src/sql-parser/Cargo.toml
@@ -11,7 +11,7 @@ enum-kinds = "0.5.1"
 itertools = "0.10.1"
 lazy_static = "1.4.0"
 log = "0.4.13"
-ore = { path = "../ore"}
+ore = { path = "../ore", default-features = false }
 phf = { version = "0.10.0", features = ["uncased"] }
 stacker = "0.1.14"
 uncased = "0.9.6"
@@ -23,7 +23,7 @@ unicode-width = "0.1.8"
 
 [build-dependencies]
 anyhow = "1.0.43"
-ore = { path = "../ore" }
+ore = { path = "../ore", default-features = false }
 phf = { version = "0.10.0", features = ["uncased"] }
 phf_codegen = { version = "0.10.0" }
 uncased = "0.9.6"

--- a/src/walkabout/Cargo.toml
+++ b/src/walkabout/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 anyhow = "1.0.43"
 fstrings = "0.2.3"
 itertools = "0.10.1"
-ore = { path = "../ore" }
+ore = { path = "../ore", default-features = false }
 quote = "1.0.9"
 syn = { version = "1.0.76", features = ["extra-traits", "full", "parsing"] }
 


### PR DESCRIPTION
This makes sql-parser build without pulling in the default ore features, reducing it's transitive dependencies significantly.