### PR TITLE
Revert "materialized: enable persistent system tables by default"

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -54,12 +54,6 @@ Wrap your release notes at the 80 character mark.
 
 - Support `ORDER BY` in aggregate functions.
 
-- Persist the `mz_metrics` and `mz_metric_histogram` system tables and rehydrate
-  the previous contents on restart. This is a small test of the system that will
-  power upcoming persistence features. Users are free to opt out of this test
-  by setting the `--disable_persistent_system_tables_test` flag to "true".
-
-
 {{% version-header v0.9.3 %}}
 
 - Fix a bug that prevented creating Avro sinks on old versions of Confluent Platform

--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -877,8 +877,8 @@ lazy_static! {
         id: GlobalId::System(4043),
         index_id: GlobalId::System(4044),
         // Note that the `system_table_enabled` field of PersistConfig (hooked
-        // up to --disable_persistent_system_tables_test) also has to be true
-        // for this to be persisted.
+        // up to --persistent-system-tables) also has to be true for this to be
+        // persisted.
         persistent: true,
     };
     pub static ref MZ_PROMETHEUS_METRICS: BuiltinTable = BuiltinTable {
@@ -908,8 +908,8 @@ lazy_static! {
         id: GlobalId::System(4047),
         index_id: GlobalId::System(4048),
         // Note that the `system_table_enabled` field of PersistConfig (hooked
-        // up to --disable_persistent_system_tables_test) also has to be true
-        // for this to be persisted.
+        // up to --persistent-system-tables) also has to be true for this to be
+        // persisted.
         persistent: true,
     };
 }

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -117,15 +117,9 @@ struct Args {
     #[structopt(long, hidden = true)]
     persistent_user_tables: bool,
 
-    /// Disable persistence of all system tables.
-    ///
-    /// This is a test of the upcoming persistence system. The data is stored on
-    /// the filesystem in a sub-directory of the Materialize data_directory.
-    /// This test is enabled by default to allow us to collect data from a
-    /// variety of deployments, but setting this flag to true to opt out of the
-    /// test is always safe.
-    #[structopt(long)]
-    disable_persistent_system_tables_test: bool,
+    /// Enable persistent system tables. Has to be used with --experimental.
+    #[structopt(long, hidden = true)]
+    persistent_system_tables: bool,
 
     // === Timely worker configuration. ===
     /// Number of dataflow worker threads.
@@ -628,7 +622,13 @@ swap: {swap_total}KB total, {swap_used}KB used{swap_limit}",
         } else {
             false
         };
-        let system_table_enabled = !args.disable_persistent_system_tables_test;
+        let system_table_enabled = if args.experimental && args.persistent_system_tables {
+            true
+        } else if args.persistent_system_tables {
+            bail!("cannot specify --persistent-system-tables without --experimental");
+        } else {
+            false
+        };
         let lock_info = format!(
             "materialized {mz_version}\nos: {os}\nstart time: {start_time}\nnum workers: {num_workers}\n",
             mz_version = materialized::BUILD_INFO.human_version(),


### PR DESCRIPTION
Reverts MaterializeInc/materialize#8031

https://github.com/MaterializeInc/materialize/issues/8253 found an issue where a high load of SQL SELECTs cause persistence compaction to be overeager, causing unexpectedly high disk usage. I'm still writing up the details on that issue, but there's a release being cut today, so merging this revert now while we fix it.