### PR TITLE
doc: remove JSON Kafka sinks from known limitations

### DIFF
--- a/doc/user/content/known-limitations.md
+++ b/doc/user/content/known-limitations.md
@@ -42,7 +42,6 @@ tag](https://github.com/MaterializeInc/materialize/issues?q=is%3Aopen+is%3Aissue
 ### Kafka
 
 - Protobuf data for Kafka sinks is not supported {{% gh 1541 %}}
-- JSON-encoded data for Kafka sinks is not supported {{% gh 1540 %}}
 
 ### Kinesis
 


### PR DESCRIPTION
### Motivation

This PR corrects information in our [Known Limitations page](https://materialize.com/docs/known-limitations/#kafka).

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug. [Link to issue.]

  * This PR adds a known-desirable feature. [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

### Description

We are able to send JSON-encoded data to Kafka sinks as of https://github.com/MaterializeInc/materialize/pull/7545 and https://github.com/MaterializeInc/materialize/pull/7608. This change was documented in https://github.com/MaterializeInc/materialize/pull/7673, but I missed the note on the Known Limitations page! 

(Thank you to @bbigras for pointing this out!)

<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details."

-->

### Checklist

- [X] This PR has adequate test coverage.
- [X] This PR adds a release note for any user-facing behavior changes.
