### PR TITLE
Exactly once

### DIFF
--- a/doc/user/content/cloud/get-started-with-cloud.md
+++ b/doc/user/content/cloud/get-started-with-cloud.md
@@ -13,8 +13,6 @@ aliases:
 
 {{< cloud-notice >}}
 
-this is a test
-
 This guide walks you through getting started with Materialize Cloud, from setting up an account to creating your first materialized view on top of streaming data. We'll cover:
 
 * Signing up for Materialize Cloud

--- a/doc/user/content/cloud/get-started-with-cloud.md
+++ b/doc/user/content/cloud/get-started-with-cloud.md
@@ -13,6 +13,8 @@ aliases:
 
 {{< cloud-notice >}}
 
+this is a test
+
 This guide walks you through getting started with Materialize Cloud, from setting up an account to creating your first materialized view on top of streaming data. We'll cover:
 
 * Signing up for Materialize Cloud

--- a/doc/user/content/guides/reuse-topic-for-kafka-sink.md
+++ b/doc/user/content/guides/reuse-topic-for-kafka-sink.md
@@ -9,7 +9,8 @@ menu:
 
 {{< beta v0.9.0 />}}
 
-By default, Materialize creates new, distinct topics for sinks after each restart. To enable the reuse of the existing topic instead and provide exactly-once processing guarantees, Materialize must be able to do two things:
+By default, Materialize creates new, distinct topics for sinks after each restart. To enable the reuse of the existing topic instead and provide exactly-once processing guarantees, Materialize must be able to do two
+things:
 
 * Reconstruct the history of the sinked object and all the objects on which it depends, based on the replayable timestamps of their source events.
 * Ensure that no other processes write to the output topic.

--- a/doc/user/content/guides/reuse-topic-for-kafka-sink.md
+++ b/doc/user/content/guides/reuse-topic-for-kafka-sink.md
@@ -9,7 +9,7 @@ menu:
 
 {{< beta v0.9.0 />}}
 
-By default, Materialize creates new, distinct topics for sinks after each restart. To enable the reuse of the existing topic instead, Materialize must be able to reconstruct the prior history of the sinked object and all objects on which it is dependent--that is, events must have replayable timestamps--and must ensure that no other processes write to the output topic. This allows for exactly-once stream processing, meaning that each incoming event is processed exactly once, and no data is duplicated or goes unprocessed, even if the stream is disrupted or Materialize is restarted.
+By default, Materialize creates new, distinct topics for sinks after each restart. To enable the reuse of the existing topic instead, Materialize must be able to reconstruct the prior history of the sinked object and all objects on which it is dependent--that is, events must have replayable timestamps--and must ensure that no other processes write to the output topic. This allows for exactly-once stream processing, meaning that each incoming event affects the final results exactly once, and no data is duplicated or goes unprocessed, even if the stream is disrupted or Materialize is restarted.
 
 This is currently available only for Kafka sources and the views based on them.
 

--- a/doc/user/content/sql/create-sink.md
+++ b/doc/user/content/sql/create-sink.md
@@ -184,7 +184,7 @@ You can find the topic name for each Kafka sink by querying `mz_kafka_sinks`.
 
 {{< beta v0.9.0 />}}
 
-By default, Materialize creates new, distinct topics for sinks after each restart. To enable the reuse of the existing topic instead, Materialize must be able to reconstruct the prior history of the sinked object and all objects on which it is dependent--that is, events must have replayable timestamps--and must ensure that no other processes write to the output topic. This allows for exactly-once stream processing, meaning that each incoming event is processed exactly once, and no data is duplicated or goes unprocessed, even if the stream is disrupted or Materialize is restarted.
+By default, Materialize creates new, distinct topics for sinks after each restart. To enable the reuse of the existing topic instead, Materialize must be able to reconstruct the prior history of the sinked object and all objects on which it is dependent--that is, events must have replayable timestamps--and must ensure that no other processes write to the output topic. This allows for exactly-once stream processing, meaning that each incoming event affects the final results exactly once, and no data is duplicated or goes unprocessed, even if the stream is disrupted or Materialize is restarted.
 
 This is currently available only for Kafka sources and the views based on them.
 


### PR DESCRIPTION
### Motivation


  * This PR fixes a previously unreported bug. 
  * Our definition of "exactly once processing" caused some confusion, because it implied we never reprocessed data after restart. The topic must be reingested to identify where processing left off.

### Description

See commit message for details.

### Tips for reviewer 

### Checklist

- [x] This PR has adequate test coverage.
- [x] This PR adds a release note for any user-facing behavior changes.
