### PR TITLE
Deploy entire "misc/python" directory as package to remote machine in cloudbench

### DIFF
--- a/doc/developer/cloudbench.md
+++ b/doc/developer/cloudbench.md
@@ -30,10 +30,10 @@ Launching benchmarks is done with the `bin/cloudbench start` subcommand. It take
 
 For example, the following command:
 ```
-bin/cloudbench start --profile confluent --trials 3 --revs HEAD,'HEAD^' misc/python/materialize/benches/avro_ingest.py -r 100000000 -n 10
+bin/cloudbench start --profile confluent --trials 3 --revs HEAD,'HEAD^' materialize.benches.avro_ingest -r 100000000 -n 10
 ```
 
-launches 12 machines: two git revisions, three clusters per revision, and two machines per cluster. It then runs `misc/python/materialize/benches/avro_ingest.py -r 100000000 -n 10`
+launches 12 machines: two git revisions, three clusters per revision, and two machines per cluster. It then runs the module `misc.benches.avro_ingest`, defined in the file `misc/python/materialize/benches/avro_ingest.py`, with the arguments `-r 100000000 -n 10`
 on 6 of those machines (one per cluster; the other machine is for the Confulent platform).
 
 ## Checking results

--- a/misc/python/materialize/benches/avro_ingest.py
+++ b/misc/python/materialize/benches/avro_ingest.py
@@ -167,7 +167,6 @@ def main() -> None:
     kgen_launcher = Thread(target=generate_data, args=[ns.records])
     kgen_launcher.start()
     kgen_launcher.join()
-    os.dup2(old_stdout, 1)
 
     cid_path = Path("docker.cid")
     cid = ""
@@ -176,6 +175,7 @@ def main() -> None:
     while not cid:
         with open(cid_path) as f:
             cid = f.read()
+    os.dup2(old_stdout, 1)
     os.remove(cid_path)
     conn = psycopg2.connect("host=localhost port=6875 user=materialize")
     conn.autocommit = True

--- a/misc/python/materialize/cli/cloudbench.py
+++ b/misc/python/materialize/cli/cloudbench.py
@@ -181,7 +181,7 @@ def start(ns: argparse.Namespace) -> None:
     os.chdir(os.environ["MZ_ROOT"])
 
     mz_launch_script = f"""echo {shlex.quote(base64.b64encode(pkg_data).decode('utf-8'))} | base64 -d > mz.tar.gz
-python3 -m venv /tmp/mzenv >&2 
+python3 -m venv /tmp/mzenv >&2
 . /tmp/mzenv/bin/activate >&2
 python3 -m pip install --upgrade pip >&2
 pip3 install ./mz.tar.gz[dev] >&2

--- a/misc/python/materialize/cli/cloudbench.py
+++ b/misc/python/materialize/cli/cloudbench.py
@@ -22,8 +22,7 @@ import time
 from datetime import timedelta
 from typing import List, NamedTuple, Optional, cast
 
-from materialize import git, scratch, util
-from materialize import spawn
+from materialize import git, scratch, spawn, util
 from materialize.cli.scratch import (
     DEFAULT_INSTPROF_NAME,
     DEFAULT_SG_ID,
@@ -42,7 +41,7 @@ from materialize.scratch import (
 # This is duplicated with the one in cli/scratch.
 # TODO - factor it out.
 def main() -> None:
-    os.chdir(os.environ['MZ_ROOT'])
+    os.chdir(os.environ["MZ_ROOT"])
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest="subcommand", required=True)
     for cmd_name, configure, run in [
@@ -174,12 +173,12 @@ def start(ns: argparse.Namespace) -> None:
     script_args = " ".join((shlex.quote(arg) for arg in bench_script[1:]))
 
     # zip up the `misc` repository, for shipment to the remote machine
-    os.chdir('misc/python')
+    os.chdir("misc/python")
     spawn.runv(["python3", "./setup.py", "sdist"])
 
     with open("./dist/materialize-0.0.0.tar.gz", "rb") as f:
         pkg_data = f.read()
-    os.chdir(os.environ['MZ_ROOT'])
+    os.chdir(os.environ["MZ_ROOT"])
 
     mz_launch_script = f"""echo {shlex.quote(base64.b64encode(pkg_data).decode('utf-8'))} | base64 -d > mz.tar.gz
 python3 -m venv /tmp/mzenv >&2 
@@ -219,6 +218,7 @@ echo $? > ~/bench_exit_code
                 ami="ami-0b29b6e62f2343b46",
                 tags={},
                 size_gb=1000,
+                checkout=False,
             ),
         ]
     else:

--- a/misc/python/materialize/cli/scratch/create.py
+++ b/misc/python/materialize/cli/scratch/create.py
@@ -89,6 +89,7 @@ def run(args: argparse.Namespace) -> None:
             ami=obj["ami"],
             tags=obj.get("tags", dict()),
             size_gb=obj["size_gb"],
+            checkout=obj.get("checkout", True),
         )
         for obj in multi_json(sys.stdin.read())
     ]

--- a/misc/python/setup.py
+++ b/misc/python/setup.py
@@ -27,7 +27,6 @@ setup(
     install_requires=requires("requirements.txt"),
     extras_require={
         "dev": requires("requirements-dev.txt"),
-        "ci": requires("requirements-ci.txt"),
     },
     package_data={"materialize": ["py.typed"]},
     include_package_data=True,


### PR DESCRIPTION
The idea here is to allow people to run their local version of benchmark scripts against whatever version of Materialize they want, even those from the past.

It works by packaging up a separate copy of the `misc/python` code independently of the repo, and deploying that to the ec2 host, where it is installed in a venv. Thus it is not affected by checking out old versions of the Materialize repo for running against.