### PR TITLE
coord: send warning on implicit txn w/ only COMMIT or ROLLBACK

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -54,6 +54,9 @@ Wrap your release notes at the 80 character mark.
 
 - Support `ORDER BY` in aggregate functions.
 
+- When issuing `COMMIT` or `ROLLBACK` commands outside of an explicit
+  transaction, always return a warning. Previously, the warning could be suppressed.
+
 {{% version-header v0.9.3 %}}
 
 - Fix a bug that prevented creating Avro sinks on old versions of Confluent Platform

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -2292,10 +2292,6 @@ impl Coordinator {
         mut session: Session,
         mut action: EndTransactionAction,
     ) {
-        let was_implicit = matches!(
-            session.transaction(),
-            TransactionStatus::InTransactionImplicit(_)
-        );
         // If the transaction has failed, we can only rollback.
         if let (EndTransactionAction::Commit, TransactionStatus::Failed(_)) =
             (&action, session.transaction())
@@ -2304,7 +2300,7 @@ impl Coordinator {
         }
         let response = ExecuteResponse::TransactionExited {
             tag: action.tag(),
-            was_implicit,
+            was_implicit: session.transaction().is_implicit(),
         };
         let rx = self.sequence_end_transaction_inner(&mut session, &action);
         match rx {

--- a/src/coord/src/session.rs
+++ b/src/coord/src/session.rs
@@ -414,6 +414,17 @@ impl TransactionStatus {
             | TransactionStatus::Failed(txn) => Some(txn),
         }
     }
+
+    /// Expresses whether or not the transaction was implicitly started.
+    /// However, its negation does not imply explicitly started.
+    pub fn is_implicit(&self) -> bool {
+        match self {
+            TransactionStatus::Started(_) | TransactionStatus::InTransactionImplicit(_) => true,
+            TransactionStatus::Default
+            | TransactionStatus::InTransaction(_)
+            | TransactionStatus::Failed(_) => false,
+        }
+    }
 }
 
 impl Default for TransactionStatus {

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -440,11 +440,7 @@ where
 
         // Implicit transactions are closed at the end of a Query message.
         {
-            let implicit = matches!(
-                self.coord_client.session().transaction(),
-                TransactionStatus::Started(_) | TransactionStatus::InTransactionImplicit(_)
-            );
-            if implicit {
+            if self.coord_client.session().transaction().is_implicit() {
                 self.commit_transaction().await?;
             }
         }
@@ -900,12 +896,8 @@ where
     }
 
     async fn sync(&mut self) -> Result<State, io::Error> {
-        // Close the current transaction if we are not in an explicit transaction.
-        let started = matches!(
-            self.coord_client.session().transaction(),
-            TransactionStatus::Started(_)
-        );
-        if started {
+        // Close the current transaction if we are in an implicit transaction.
+        if self.coord_client.session().transaction().is_implicit() {
             self.commit_transaction().await?;
         }
         return self.ready().await;

--- a/test/pgtest/transactions.pt
+++ b/test/pgtest/transactions.pt
@@ -141,9 +141,13 @@ ReadyForQuery {"status":"I"}
 send
 Query {"query": "SELECT 1; COMMIT; SELECT 2"}
 Query {"query": "SELECT 3; ROLLBACK; SELECT 4"}
+Query {"query": "COMMIT;"}
+Query {"query": "ROLLBACK;"}
 ----
 
 until
+ReadyForQuery
+ReadyForQuery
 ReadyForQuery
 ReadyForQuery
 ----
@@ -164,6 +168,12 @@ CommandComplete {"tag":"ROLLBACK"}
 RowDescription {"fields":[{"name":"?column?"}]}
 DataRow {"fields":["4"]}
 CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}
+NoticeResponse {"fields":[{"typ":"C","value":"25P01"},{"typ":"M","value":"there is no transaction in progress"}]}
+CommandComplete {"tag":"COMMIT"}
+ReadyForQuery {"status":"I"}
+NoticeResponse {"fields":[{"typ":"C","value":"25P01"},{"typ":"M","value":"there is no transaction in progress"}]}
+CommandComplete {"tag":"ROLLBACK"}
 ReadyForQuery {"status":"I"}
 
 send


### PR DESCRIPTION
### Motivation

This PR fixes a previously unreported bug.
### What version of Materialize are you using?

```
$ materialized -v
v0.9.4-dev (b696c34fd)
```

#### How did you install Materialize?

<!-- Choose one. -->

* [ ] Docker image
* [ ] Linux release tarball
* [ ] APT package
* [ ] macOS release tarball
* [ ] Homebrew tap
* [x] Built from source
* [ ] Materialize Cloud

#### What was the issue?

When issuing a command that is only `COMMIT;` or `ROLLBACK;`, we were not warning users that they were not in a transaction. This differs from Postgres' behavior, e.g.

```
sean=# COMMIT;
WARNING:  there is no transaction in progress
COMMIT
```

We instead elided the warning response to the user.

#### Is the issue reproducible? If so, please provide reproduction instructions.

1. Connect to MZ using e.g. `psql`
2. Issue `COMMIT;`

You will receive the response `COMMIT` without a warning message.

### Description

We previously did not have a canonical notion of what implicit transactions were. The area of the code that started implicit transactions (`coord::session::Session::start_transaction_implicit`) could generate two distinct `TransactionStatus` values, but code that roughly expressed that it cared about implicit transactions did not uniformly check for both statuses.

To solve this, I added a `bool`-generating method to check for the `TransactionStatus`es that `coord::session::Session::start_transaction_implicit` generates.

This refactor has the benefit of solving the UX wart identified in this issue and hopefully preventing others in the future.

### Checklist

- [x] This PR has adequate test coverage.
- [x] This PR adds a release note for any user-facing behavior changes.
