### PR TITLE
`sqlfunc!` support for SQL funcs that return owned non-Copy values

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -273,12 +273,6 @@ fn cast_int64_to_string<'a>(a: Datum<'a>, temp_storage: &'a RowArena) -> Datum<'
     Datum::String(temp_storage.push_string(buf))
 }
 
-fn cast_float32_to_string<'a>(a: Datum<'a>, temp_storage: &'a RowArena) -> Datum<'a> {
-    let mut buf = String::new();
-    strconv::format_float32(&mut buf, a.unwrap_float32());
-    Datum::String(temp_storage.push_string(buf))
-}
-
 fn cast_float32_to_numeric<'a>(a: Datum<'a>, scale: Option<u8>) -> Result<Datum<'a>, EvalError> {
     let a = a.unwrap_float32();
     if a.is_infinite() {
@@ -3427,7 +3421,7 @@ pub enum UnaryFunc {
     CastFloat32ToInt32(CastFloat32ToInt32),
     CastFloat32ToInt64(CastFloat32ToInt64),
     CastFloat32ToFloat64(CastFloat32ToFloat64),
-    CastFloat32ToString,
+    CastFloat32ToString(CastFloat32ToString),
     CastFloat32ToNumeric(Option<u8>),
     CastFloat64ToNumeric(Option<u8>),
     CastFloat64ToInt16(CastFloat64ToInt16),
@@ -3617,6 +3611,7 @@ derive_unary!(
     CastFloat64ToInt64,
     CastFloat32ToFloat64,
     CastFloat64ToFloat32,
+    CastFloat32ToString,
     PgColumnSize,
     MzRowSize,
     IsNull
@@ -3657,6 +3652,7 @@ impl UnaryFunc {
             | PgColumnSize(_)
             | MzRowSize(_)
             | IsNull(_)
+            | CastFloat32ToString(_)
             | CastFloat32ToFloat64(_) => unreachable!(),
             NegInt16 => Ok(neg_int16(a)),
             NegInt32 => Ok(neg_int32(a)),
@@ -3697,7 +3693,6 @@ impl UnaryFunc {
             CastInt64ToFloat32 => Ok(cast_int64_to_float32(a)),
             CastInt64ToFloat64 => Ok(cast_int64_to_float64(a)),
             CastInt64ToString => Ok(cast_int64_to_string(a, temp_storage)),
-            CastFloat32ToString => Ok(cast_float32_to_string(a, temp_storage)),
             CastFloat64ToString => Ok(cast_float64_to_string(a, temp_storage)),
             CastStringToBool => cast_string_to_bool(a),
             CastStringToBytes => cast_string_to_bytes(a, temp_storage),
@@ -3854,6 +3849,7 @@ impl UnaryFunc {
             | PgColumnSize(_)
             | MzRowSize(_)
             | IsNull(_)
+            | CastFloat32ToString(_)
             | CastFloat32ToFloat64(_) => unreachable!(),
 
             Ascii | CharLength | BitLengthBytes | BitLengthString | ByteLengthBytes
@@ -3875,7 +3871,6 @@ impl UnaryFunc {
             | CastInt16ToString
             | CastInt32ToString
             | CastInt64ToString
-            | CastFloat32ToString
             | CastFloat64ToString
             | CastNumericToString
             | CastDateToString
@@ -4054,6 +4049,7 @@ impl UnaryFunc {
             | PgColumnSize(_)
             | MzRowSize(_)
             | IsNull(_)
+            | CastFloat32ToString(_)
             | CastFloat32ToFloat64(_) => unreachable!(),
             // These return null when their input is SQL null.
             CastJsonbToString | CastJsonbToInt16 | CastJsonbToInt32 | CastJsonbToInt64
@@ -4087,7 +4083,6 @@ impl UnaryFunc {
             | CastInt16ToString
             | CastInt32ToString
             | CastInt64ToString
-            | CastFloat32ToString
             | CastFloat64ToString
             | CastNumericToString
             | CastDateToString
@@ -4180,6 +4175,7 @@ impl UnaryFunc {
             | PgColumnSize(_)
             | MzRowSize(_)
             | IsNull(_)
+            | CastFloat32ToString(_)
             | CastFloat32ToFloat64(_) => unreachable!(),
             NegInt16
             | NegInt32
@@ -4196,7 +4192,6 @@ impl UnaryFunc {
             | CastInt32ToInt64
             | CastInt32ToString
             | CastInt64ToString
-            | CastFloat32ToString
             | CastFloat64ToString
             | CastStringToBytes
             | CastDateToTimestamp
@@ -4232,6 +4227,7 @@ impl UnaryFunc {
             | PgColumnSize(_)
             | MzRowSize(_)
             | IsNull(_)
+            | CastFloat32ToString(_)
             | CastFloat32ToFloat64(_) => unreachable!(),
             NegInt16 => f.write_str("-"),
             NegInt32 => f.write_str("-"),
@@ -4270,7 +4266,6 @@ impl UnaryFunc {
             CastInt64ToFloat32 => f.write_str("i64tof32"),
             CastInt64ToFloat64 => f.write_str("i64tof64"),
             CastInt64ToString => f.write_str("i64tostr"),
-            CastFloat32ToString => f.write_str("f32tostr"),
             CastFloat32ToNumeric(_) => f.write_str("f32tonumeric"),
             CastFloat64ToString => f.write_str("f64tostr"),
             CastFloat64ToNumeric(_) => f.write_str("f32tonumeric"),

--- a/src/expr/src/scalar/func/impls/float.rs
+++ b/src/expr/src/scalar/func/impls/float.rs
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use crate::EvalError;
+use repr::strconv;
 
 sqlfunc!(
     #[sqlname = "-"]
@@ -197,5 +198,14 @@ sqlfunc!(
     #[sqlname = "f32tof64"]
     fn cast_float32_to_float64(a: f32) -> f64 {
         a.into()
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "f32tostr"]
+    fn cast_float32_to_string(a: f32) -> String {
+        let mut s = String::new();
+        strconv::format_float32(&mut s, a);
+        s
     }
 );

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -34,7 +34,7 @@ pub use relation::{ColumnName, ColumnType, RelationDesc, RelationType};
 pub use row::{
     datum_list_size, datum_size, datums_size, row_size, DatumList, DatumMap, Row, RowArena, RowRef,
 };
-pub use scalar::{Datum, FromTy, ScalarBaseType, ScalarType};
+pub use scalar::{Datum, FromTy, ScalarBaseType, ScalarType, WithArena};
 
 // Concrete types used throughout Materialize for the generic parameters in Timely/Differential Dataflow.
 /// System-wide timestamp type.

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -532,32 +532,32 @@ impl<'a> From<bool> for Datum<'a> {
     }
 }
 
-impl From<i16> for Datum<'static> {
-    fn from(i: i16) -> Datum<'static> {
+impl<'a> From<i16> for Datum<'a> {
+    fn from(i: i16) -> Datum<'a> {
         Datum::Int16(i)
     }
 }
 
-impl From<i32> for Datum<'static> {
-    fn from(i: i32) -> Datum<'static> {
+impl<'a> From<i32> for Datum<'a> {
+    fn from(i: i32) -> Datum<'a> {
         Datum::Int32(i)
     }
 }
 
-impl From<i64> for Datum<'static> {
-    fn from(i: i64) -> Datum<'static> {
+impl<'a> From<i64> for Datum<'a> {
+    fn from(i: i64) -> Datum<'a> {
         Datum::Int64(i)
     }
 }
 
-impl From<OrderedFloat<f32>> for Datum<'static> {
-    fn from(f: OrderedFloat<f32>) -> Datum<'static> {
+impl<'a> From<OrderedFloat<f32>> for Datum<'a> {
+    fn from(f: OrderedFloat<f32>) -> Datum<'a> {
         Datum::Float32(f)
     }
 }
 
-impl From<OrderedFloat<f64>> for Datum<'static> {
-    fn from(f: OrderedFloat<f64>) -> Datum<'static> {
+impl<'a> From<OrderedFloat<f64>> for Datum<'a> {
+    fn from(f: OrderedFloat<f64>) -> Datum<'a> {
         Datum::Float64(f)
     }
 }
@@ -574,20 +574,20 @@ impl<'a> From<f64> for Datum<'a> {
     }
 }
 
-impl From<i128> for Datum<'static> {
-    fn from(d: i128) -> Datum<'static> {
+impl<'a> From<i128> for Datum<'a> {
+    fn from(d: i128) -> Datum<'a> {
         Datum::Numeric(OrderedDecimal(Numeric::try_from(d).unwrap()))
     }
 }
 
-impl From<Numeric> for Datum<'static> {
-    fn from(n: Numeric) -> Datum<'static> {
+impl<'a> From<Numeric> for Datum<'a> {
+    fn from(n: Numeric) -> Datum<'a> {
         Datum::Numeric(OrderedDecimal(n))
     }
 }
 
-impl From<chrono::Duration> for Datum<'static> {
-    fn from(duration: chrono::Duration) -> Datum<'static> {
+impl<'a> From<chrono::Duration> for Datum<'a> {
+    fn from(duration: chrono::Duration) -> Datum<'a> {
         Datum::Interval(
             Interval::new(
                 0,
@@ -599,8 +599,8 @@ impl From<chrono::Duration> for Datum<'static> {
     }
 }
 
-impl From<Interval> for Datum<'static> {
-    fn from(other: Interval) -> Datum<'static> {
+impl<'a> From<Interval> for Datum<'a> {
+    fn from(other: Interval) -> Datum<'a> {
         Datum::Interval(other)
     }
 }
@@ -641,8 +641,8 @@ impl<'a> From<DateTime<Utc>> for Datum<'a> {
     }
 }
 
-impl From<Uuid> for Datum<'static> {
-    fn from(uuid: Uuid) -> Datum<'static> {
+impl<'a> From<Uuid> for Datum<'a> {
+    fn from(uuid: Uuid) -> Datum<'a> {
         Datum::Uuid(uuid)
     }
 }

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -183,7 +183,7 @@ lazy_static! {
                 let s = to_type.unwrap_numeric_scale();
                 Some(move |e: HirScalarExpr| e.call_unary(CastFloat32ToNumeric(s)))
             }),
-            (Float32, String) => Assignment: CastFloat32ToString,
+            (Float32, String) => Assignment: CastFloat32ToString(func::CastFloat32ToString),
 
             // FLOAT64
             (Float64, Int16) => Assignment: CastFloat64ToInt16(func::CastFloat64ToInt16),


### PR DESCRIPTION
### Description

Datums have `From` implementation for primitive, Copy types like `i32`, `f32` etc but it's not possible to provide an implementation of `From<String>` since Datums hold `str` references in their `String` variant.

Traditionally we have been handling this by passing around a `temp_storage: RowArena` parameter that can be thought of as the allocation context of the current function call where a String can be stored in and a reference can be extracted out of it to produce a `Datum::String` variant.

This PR takes this pattern and puts it in a named struct `WithArena<T>` that is simply a wrapper over any T but it also carries with it an allocation context.

This allows us to provide `From<WithArena<String>>` and `From<WithArena<Vec<u8>>`implementations for `Datum` that automatically store their owned data in the arena and construct the appropriate variant.

Using the above machinery an example implementation is provided for `cast_float32_to_string` to keep the PR short. Once this is merged, another PR will follow with all the other String returning functions ported.

### Tips for reviewer

Review commit by commit recommended

### Checklist

- [ ] This PR has adequate test coverage.
- [ ] This PR adds a release note for any user-facing behavior changes.
