### PR TITLE
Typ with input types

### DIFF
--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -243,7 +243,54 @@ impl MirRelationExpr {
     /// relation expression, drawing from the types of base collections.
     /// As such, this is not an especially cheap method, and should be used
     /// judiciously.
+    ///
+    /// The relation type is computed incrementally with a recursive post-order
+    /// traversal, that accumulates the input types for the relations yet to be
+    /// visited in `type_stack`.
     pub fn typ(&self) -> RelationType {
+        let mut type_stack = Vec::new();
+        self.visit_pre_post(
+            &mut |e: &MirRelationExpr| -> Option<Vec<&MirRelationExpr>> {
+                if let MirRelationExpr::Let { body, .. } = &e {
+                    // Do not traverse the value sub-graph, since it's not relevant for
+                    // determing the relation type of Let operators.
+                    Some(vec![&*body])
+                } else {
+                    None
+                }
+            },
+            &mut |e: &MirRelationExpr| {
+                if let MirRelationExpr::Let { .. } = &e {
+                    let body_typ = type_stack.pop().unwrap();
+                    // Insert a dummy relation type for the value, since `typ_with_input_types`
+                    // won't look at it, but expects the relation type of the body to be second.
+                    type_stack.push(RelationType::empty());
+                    type_stack.push(body_typ);
+                }
+                let num_inputs = e.num_inputs();
+                let relation_type =
+                    e.typ_with_input_types(&type_stack[type_stack.len() - num_inputs..]);
+                type_stack.truncate(type_stack.len() - num_inputs);
+                type_stack.push(relation_type);
+            },
+        );
+        assert_eq!(type_stack.len(), 1);
+        type_stack.pop().unwrap()
+    }
+
+    /// Reports the schema of the relation given the schema of the input relations.
+    ///
+    /// `input_types` is required to contain the schemas for the input relations of
+    /// the current relation in the same order as they are visited by `try_visit1`
+    /// method, even though not all may be used for computing the schema of the
+    /// current relation. For example, `Let` expects two input types, one for the
+    /// value relation and one for the body, in that order, but only the one for the
+    /// body is used to determine the type of the `Let` relation.
+    ///
+    /// It is meant to be used during post-order traversals to compute relation
+    /// schemas incrementally.
+    pub fn typ_with_input_types(&self, input_types: &[RelationType]) -> RelationType {
+        assert_eq!(self.num_inputs(), input_types.len());
         match self {
             MirRelationExpr::Constant { rows, typ } => {
                 if let Ok(rows) = rows {
@@ -289,16 +336,16 @@ impl MirRelationExpr {
                 }
             }
             MirRelationExpr::Get { typ, .. } => typ.clone(),
-            MirRelationExpr::Let { body, .. } => body.typ(),
-            MirRelationExpr::Project { input, outputs } => {
-                let input_typ = input.typ();
+            MirRelationExpr::Let { .. } => input_types.last().unwrap().clone(),
+            MirRelationExpr::Project { input: _, outputs } => {
+                let input_typ = &input_types[0];
                 let mut output_typ = RelationType::new(
                     outputs
                         .iter()
                         .map(|&i| input_typ.column_types[i].clone())
                         .collect(),
                 );
-                for keys in input_typ.keys {
+                for keys in input_typ.keys.iter() {
                     if keys.iter().all(|k| outputs.contains(k)) {
                         output_typ = output_typ.with_key(
                             keys.iter()
@@ -309,8 +356,8 @@ impl MirRelationExpr {
                 }
                 output_typ
             }
-            MirRelationExpr::Map { input, scalars } => {
-                let mut typ = input.typ();
+            MirRelationExpr::Map { scalars, .. } => {
+                let mut typ = input_types[0].clone();
                 let arity = typ.column_types.len();
 
                 let mut remappings = Vec::new();
@@ -361,13 +408,8 @@ impl MirRelationExpr {
 
                 typ
             }
-            MirRelationExpr::FlatMap {
-                input,
-                func,
-                exprs: _,
-                demand: _,
-            } => {
-                let mut input_typ = input.typ();
+            MirRelationExpr::FlatMap { func, .. } => {
+                let mut input_typ = input_types[0].clone();
                 input_typ
                     .column_types
                     .extend(func.output_type().column_types);
@@ -375,11 +417,11 @@ impl MirRelationExpr {
                 let typ = RelationType::new(input_typ.column_types);
                 typ
             }
-            MirRelationExpr::Filter { input, predicates } => {
+            MirRelationExpr::Filter { predicates, .. } => {
                 // A filter inherits the keys of its input unless the filters
                 // have reduced the input to a single row, in which case the
                 // keys of the input are `()`.
-                let mut input_typ = input.typ();
+                let mut input_typ = input_types[0].clone();
                 let cols_equal_to_literal = predicates
                     .iter()
                     .filter_map(|p| {
@@ -433,13 +475,7 @@ impl MirRelationExpr {
                 }
                 input_typ
             }
-            MirRelationExpr::Join {
-                inputs,
-                equivalences,
-                ..
-            } => {
-                let input_types = inputs.iter().map(|i| i.typ()).collect::<Vec<_>>();
-
+            MirRelationExpr::Join { equivalences, .. } => {
                 // Iterating and cloning types inside the flat_map() avoids allocating Vec<>,
                 // as clones are directly added to column_types Vec<>.
                 let column_types = input_types
@@ -452,7 +488,7 @@ impl MirRelationExpr {
                 // used. Otherwise, Materialize may potentially end up in an
                 // infinite loop.
                 let input_mapper =
-                    join_input_mapper::JoinInputMapper::new_from_input_types(&input_types);
+                    join_input_mapper::JoinInputMapper::new_from_input_types(input_types);
 
                 let global_keys = input_mapper.global_keys(
                     &input_types
@@ -468,18 +504,17 @@ impl MirRelationExpr {
                 typ
             }
             MirRelationExpr::Reduce {
-                input,
                 group_key,
                 aggregates,
                 ..
             } => {
-                let input_typ = input.typ();
+                let input_typ = &input_types[0];
                 let mut column_types = group_key
                     .iter()
-                    .map(|e| e.typ(&input_typ))
+                    .map(|e| e.typ(input_typ))
                     .collect::<Vec<_>>();
                 for agg in aggregates {
-                    column_types.push(agg.typ(&input_typ));
+                    column_types.push(agg.typ(input_typ));
                 }
                 let mut result = RelationType::new(column_types);
                 // The group key should form a key, but we might already have
@@ -512,32 +547,31 @@ impl MirRelationExpr {
                 result
             }
             MirRelationExpr::TopK {
-                input,
-                group_key,
-                limit,
-                ..
+                group_key, limit, ..
             } => {
                 // If `limit` is `Some(1)` then the group key will become
                 // a unique key, as there will be only one record with that key.
-                let mut typ = input.typ();
+                let mut typ = input_types[0].clone();
                 if limit == &Some(1) {
                     typ = typ.with_key(group_key.clone())
                 }
                 typ
             }
-            MirRelationExpr::Negate { input } => {
+            MirRelationExpr::Negate { input: _ } => {
                 // Although negate may have distinct records for each key,
                 // the multiplicity is -1 rather than 1. This breaks many
                 // of the optimization uses of "keys".
-                let mut typ = input.typ();
+                let mut typ = input_types[0].clone();
                 typ.keys.clear();
                 typ
             }
-            MirRelationExpr::Threshold { input } => input.typ(),
+            MirRelationExpr::Threshold { .. } => input_types[0].clone(),
             MirRelationExpr::Union { base, inputs } => {
-                let mut base_cols = base.typ().column_types;
-                for input in inputs {
-                    for (base_col, col) in base_cols.iter_mut().zip_eq(input.typ().column_types) {
+                let mut base_cols = input_types[0].column_types.clone();
+                for input_type in input_types.iter().skip(1) {
+                    for (base_col, col) in
+                        base_cols.iter_mut().zip_eq(input_type.column_types.iter())
+                    {
                         *base_col = base_col
                             .union(&col)
                             .map_err(|e| format!("{}\nIn {:#?}", e, self))
@@ -618,8 +652,10 @@ impl MirRelationExpr {
                 RelationType::new(base_cols).with_keys(keys)
                 // Important: do not inherit keys of either input, as not unique.
             }
-            MirRelationExpr::ArrangeBy { input, .. } => input.typ(),
-            MirRelationExpr::DeclareKeys { input, keys } => input.typ().with_keys(keys.clone()),
+            MirRelationExpr::ArrangeBy { .. } => input_types[0].clone(),
+            MirRelationExpr::DeclareKeys { keys, .. } => {
+                input_types[0].clone().with_keys(keys.clone())
+            }
         }
     }
 
@@ -652,6 +688,13 @@ impl MirRelationExpr {
             MirRelationExpr::ArrangeBy { input, .. } => input.arity(),
             MirRelationExpr::DeclareKeys { input, .. } => input.arity(),
         }
+    }
+
+    /// The number of child relations this relation has.
+    pub fn num_inputs(&self) -> usize {
+        let mut count = 0;
+        self.visit1(|_| count += 1);
+        count
     }
 
     /// Constructs a constant collection from specific rows and schema, where
@@ -1127,6 +1170,27 @@ impl MirRelationExpr {
     {
         f(self);
         self.visit1_mut(|e| e.visit_mut_pre(f))
+    }
+
+    /// A generalization of `visit`. The function `pre` runs on a
+    /// `MirRelationExpr` before it runs on any of the child `MirRelationExpr`s.
+    /// The function `post` runs on child `MirRelationExpr`s first before the
+    /// parent. Optionally, `pre` can return which child `MirRelationExpr`s, if
+    /// any, should be visited (default is to visit all children).
+    pub fn visit_pre_post<F1, F2>(&self, pre: &mut F1, post: &mut F2)
+    where
+        F1: FnMut(&Self) -> Option<Vec<&MirRelationExpr>>,
+        F2: FnMut(&Self),
+    {
+        let to_visit = pre(self);
+        if let Some(to_visit) = to_visit {
+            for e in to_visit {
+                e.visit_pre_post(pre, post);
+            }
+        } else {
+            self.visit1(|e| e.visit_pre_post(pre, post));
+        }
+        post(self);
     }
 
     /// Fallible visitor for the [`MirScalarExpr`]s in the relation expression.

--- a/src/transform/src/demand.rs
+++ b/src/transform/src/demand.rs
@@ -54,7 +54,14 @@ impl Demand {
         mut columns: HashSet<usize>,
         gets: &mut HashMap<Id, HashSet<usize>>,
     ) {
-        let relation_type = relation.typ();
+        // A valid relation type is only needed for Maps, but we can't borrow
+        // the relation in the corresponding branch of the match statement, since
+        // it is already borrowed mutably.
+        let relation_type = if matches!(relation, MirRelationExpr::Map { .. }) {
+            Some(relation.typ())
+        } else {
+            None
+        };
         match relation {
             MirRelationExpr::Constant { .. } => {
                 // Nothing clever to do with constants, that I can think of.
@@ -83,6 +90,7 @@ impl Demand {
                 );
             }
             MirRelationExpr::Map { input, scalars } => {
+                let relation_type = relation_type.as_ref().unwrap();
                 let arity = input.arity();
                 // contains columns whose supports have yet to be explored
                 let mut new_columns = columns.clone();

--- a/src/transform/src/reduction.rs
+++ b/src/transform/src/reduction.rs
@@ -13,7 +13,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::iter;
 
 use expr::{AggregateExpr, EvalError, MirRelationExpr, MirScalarExpr, TableFunc};
-use repr::{Datum, Diff, Row, RowArena};
+use repr::{Datum, Diff, RelationType, Row, RowArena};
 
 use crate::{TransformArgs, TransformError};
 
@@ -34,7 +34,16 @@ impl crate::Transform for FoldConstants {
         relation: &mut MirRelationExpr,
         _: TransformArgs,
     ) -> Result<(), TransformError> {
-        relation.try_visit_mut(&mut |e| self.action(e))
+        let mut type_stack = Vec::new();
+        relation.try_visit_mut(&mut |e| -> Result<(), TransformError> {
+            let num_inputs = e.num_inputs();
+            let input_types = &type_stack[type_stack.len() - num_inputs..];
+            let mut relation_type = e.typ_with_input_types(input_types);
+            self.action(e, &mut relation_type, input_types)?;
+            type_stack.truncate(type_stack.len() - num_inputs);
+            type_stack.push(relation_type);
+            Ok(())
+        })
     }
 }
 
@@ -44,8 +53,12 @@ impl FoldConstants {
     /// This transform will cease optimization if it encounters constant collections
     /// that are larger than `self.limit`, if that is set. It is not guaranteed that
     /// a constant input within the limit will be reduced to a `Constant` variant.
-    pub fn action(&self, relation: &mut MirRelationExpr) -> Result<(), TransformError> {
-        let relation_type = relation.typ();
+    pub fn action(
+        &self,
+        relation: &mut MirRelationExpr,
+        relation_type: &mut RelationType,
+        input_types: &[RelationType],
+    ) -> Result<(), TransformError> {
         match relation {
             MirRelationExpr::Constant { .. } => { /* handled after match */ }
             MirRelationExpr::Get { .. } => {}
@@ -57,13 +70,13 @@ impl FoldConstants {
                 monotonic: _,
                 expected_group_size: _,
             } => {
-                let input_typ = input.typ();
+                let input_typ = input_types.first().unwrap();
                 // Reduce expressions to their simplest form.
                 for key in group_key.iter_mut() {
-                    key.reduce(&input_typ);
+                    key.reduce(input_typ);
                 }
                 for aggregate in aggregates.iter_mut() {
-                    aggregate.expr.reduce(&input_typ);
+                    aggregate.expr.reduce(input_typ);
                 }
 
                 // Guard against evaluating expression that may contain temporal expressions.
@@ -80,7 +93,7 @@ impl FoldConstants {
                     };
                     *relation = MirRelationExpr::Constant {
                         rows: new_rows,
-                        typ: relation_type,
+                        typ: relation_type.clone(),
                     };
                 }
             }
@@ -114,7 +127,7 @@ impl FoldConstants {
                 // relation type; although we could in principle use `relation_type` here,
                 // we shouldn't rely on `reduce` not looking at its cardinality to assess
                 // the number of columns.
-                let input_arity = input.arity();
+                let input_arity = input_types.first().unwrap().arity();
                 for (index, scalar) in scalars.iter_mut().enumerate() {
                     let mut current_type = repr::RelationType::new(
                         relation_type.column_types[..(input_arity + index)].to_vec(),
@@ -150,7 +163,7 @@ impl FoldConstants {
                     };
                     *relation = MirRelationExpr::Constant {
                         rows: new_rows,
-                        typ: relation_type,
+                        typ: relation_type.clone(),
                     };
                 }
             }
@@ -160,9 +173,9 @@ impl FoldConstants {
                 exprs,
                 demand: _,
             } => {
-                let input_typ = input.typ();
+                let input_typ = input_types.first().unwrap();
                 for expr in exprs.iter_mut() {
-                    expr.reduce(&input_typ);
+                    expr.reduce(input_typ);
                 }
 
                 // Guard against evaluating expression that may contain temporal expressions.
@@ -180,22 +193,22 @@ impl FoldConstants {
                         Ok(Some(rows)) => {
                             *relation = MirRelationExpr::Constant {
                                 rows: Ok(rows),
-                                typ: relation_type,
+                                typ: relation_type.clone(),
                             };
                         }
                         Err(err) => {
                             *relation = MirRelationExpr::Constant {
                                 rows: Err(err),
-                                typ: relation_type,
+                                typ: relation_type.clone(),
                             };
                         }
                     };
                 }
             }
             MirRelationExpr::Filter { input, predicates } => {
-                let input_typ = input.typ();
+                let input_typ = input_types.first().unwrap();
                 for predicate in predicates.iter_mut() {
-                    predicate.reduce(&input_typ);
+                    predicate.reduce(input_typ);
                 }
                 predicates.retain(|p| !p.is_literal_true());
 
@@ -219,7 +232,7 @@ impl FoldConstants {
                     };
                     *relation = MirRelationExpr::Constant {
                         rows: new_rows,
-                        typ: relation_type,
+                        typ: relation_type.clone(),
                     };
                 }
             }
@@ -239,7 +252,7 @@ impl FoldConstants {
                     };
                     *relation = MirRelationExpr::Constant {
                         rows: new_rows,
-                        typ: relation_type,
+                        typ: relation_type.clone(),
                     };
                 }
             }
@@ -256,7 +269,7 @@ impl FoldConstants {
                 }) {
                     *relation = MirRelationExpr::Constant {
                         rows: Err(e.clone()),
-                        typ: relation_type,
+                        typ: relation_type.clone(),
                     };
                 } else if inputs
                     .iter()
@@ -315,7 +328,7 @@ impl FoldConstants {
 
                     *relation = MirRelationExpr::Constant {
                         rows: Ok(old_rows),
-                        typ: relation_type,
+                        typ: relation_type.clone(),
                     };
                 }
                 // TODO: General constant folding for all constant inputs.
@@ -330,7 +343,7 @@ impl FoldConstants {
                 {
                     *relation = MirRelationExpr::Constant {
                         rows: Err(e.clone()),
-                        typ: relation_type,
+                        typ: relation_type.clone(),
                     };
                 } else {
                     let mut rows = vec![];
@@ -352,7 +365,7 @@ impl FoldConstants {
                         });
                     }
 
-                    *relation = MirRelationExpr::union_many(new_inputs, relation_type);
+                    *relation = MirRelationExpr::union_many(new_inputs, relation_type.clone());
                 }
             }
             MirRelationExpr::ArrangeBy { input, .. } => {
@@ -392,6 +405,7 @@ impl FoldConstants {
                     }
                 }
             }
+            *relation_type = typ.clone();
         }
 
         Ok(())

--- a/src/transform/tests/testdata/typ
+++ b/src/transform/tests/testdata/typ
@@ -1,0 +1,162 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test that the test runner can properly construct sources with keys
+# and report on key information in plans
+
+cat
+(defsource x ([int32 int64 int32]))
+(defsource y ([int64 int32 int32]))
+----
+ok
+
+build format=types
+(union [(get x) (get x) (get x)])
+----
+----
+%0 =
+| Get x (u0)
+| | types = (Int32?, Int64?, Int32?)
+| | keys = ()
+
+%1 =
+| Get x (u0)
+| | types = (Int32?, Int64?, Int32?)
+| | keys = ()
+
+%2 =
+| Get x (u0)
+| | types = (Int32?, Int64?, Int32?)
+| | keys = ()
+
+%3 =
+| Union %0 %1 %2
+| | types = (Int32?, Int64?, Int32?)
+| | keys = ()
+----
+----
+
+build format=types
+(union [(get x) (project (get y) [#1 #0 #2])])
+----
+----
+%0 =
+| Get x (u0)
+| | types = (Int32?, Int64?, Int32?)
+| | keys = ()
+
+%1 =
+| Get y (u1)
+| | types = (Int64?, Int32?, Int32?)
+| | keys = ()
+| Project (#1, #0, #2)
+| | types = (Int32?, Int64?, Int32?)
+| | keys = ()
+
+%2 =
+| Union %0 %1
+| | types = (Int32?, Int64?, Int32?)
+| | keys = ()
+----
+----
+
+build format=types
+(union [(project (get y) [#1 #0 #2]) (get x)])
+----
+----
+%0 =
+| Get y (u1)
+| | types = (Int64?, Int32?, Int32?)
+| | keys = ()
+| Project (#1, #0, #2)
+| | types = (Int32?, Int64?, Int32?)
+| | keys = ()
+
+%1 =
+| Get x (u0)
+| | types = (Int32?, Int64?, Int32?)
+| | keys = ()
+
+%2 =
+| Union %0 %1
+| | types = (Int32?, Int64?, Int32?)
+| | keys = ()
+----
+----
+
+build format=types
+(let z (project (get y) [#1 #0 #2])
+    (union [(get x) (get z)]))
+----
+----
+%0 = Let l0 =
+| Get y (u1)
+| | types = (Int64?, Int32?, Int32?)
+| | keys = ()
+| Project (#1, #0, #2)
+| | types = (Int32?, Int64?, Int32?)
+| | keys = ()
+
+%1 =
+| Get x (u0)
+| | types = (Int32?, Int64?, Int32?)
+| | keys = ()
+
+%2 =
+| Union %1 %0
+| | types = (Int32?, Int64?, Int32?)
+| | keys = ()
+| | types = (Int32?, Int64?, Int32?)
+| | keys = ()
+----
+----
+
+build format=types
+(let z (project (get y) [#1 #0 #2])
+    (union [(get z) (get z)]))
+----
+----
+%0 = Let l0 =
+| Get y (u1)
+| | types = (Int64?, Int32?, Int32?)
+| | keys = ()
+| Project (#1, #0, #2)
+| | types = (Int32?, Int64?, Int32?)
+| | keys = ()
+
+%1 =
+| Union %0 %0
+| | types = (Int32?, Int64?, Int32?)
+| | keys = ()
+| | types = (Int32?, Int64?, Int32?)
+| | keys = ()
+----
+----
+
+build format=types
+(join [(get x) (get y)] [])
+----
+----
+%0 =
+| Get x (u0)
+| | types = (Int32?, Int64?, Int32?)
+| | keys = ()
+
+%1 =
+| Get y (u1)
+| | types = (Int64?, Int32?, Int32?)
+| | keys = ()
+
+%2 =
+| Join %0 %1
+| | implementation = Unimplemented
+| | types = (Int32?, Int64?, Int32?, Int64?, Int32?, Int32?)
+| | keys = ()
+----
+----


### PR DESCRIPTION
### Motivation

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug. [Link to issue.]

  * This PR adds a known-desirable feature. [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

This PR refactors existing code. Fixes #6615

### Description

<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details."

-->

Add a new `typ_with_input_types` method in `MirRelationExpr` that takes the relation types of the input relations, so that it can be used during a post-order traversal, as many transforms do. As a proof of concept, `FoldConstants` transform has been modified to use this new method.

4.8% improvement of the optimization time. Line 13 in the following spreadsheet:

https://docs.google.com/spreadsheets/d/1XKMcX7oJe7AVCYDXRpsck-cuNmZxbrsr35Sqa3bsmvQ/edit?usp=sharing

Since the improvement is small (within noise level), I had to disable cpu boosting and frequency scaling to clearly see a reproducible stable improvement.

### Tips for reviewer

The first commit is just a unit test for the typ method to verify the refactoring is correct.

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [x] This PR has adequate test coverage.
- [nothing visible changes here] This PR adds a release note for any user-facing behavior changes.
