### PR TITLE
Support for complex return types in `sqlfunc!`

### DIFF
--- a/src/expr/src/scalar/func/impls/float.rs
+++ b/src/expr/src/scalar/func/impls/float.rs
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use crate::EvalError;
+use chrono::{DateTime, NaiveDateTime, Utc};
 use repr::strconv;
 
 sqlfunc!(
@@ -207,5 +208,35 @@ sqlfunc!(
         let mut s = String::new();
         strconv::format_float32(&mut s, a);
         s
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "mz_sleep"]
+    fn sleep(a: f64) -> Option<DateTime<Utc>> {
+        let duration = std::time::Duration::from_secs_f64(a);
+        std::thread::sleep(duration);
+        None
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "tots"]
+    fn to_timestamp(f: f64) -> Option<DateTime<Utc>> {
+        if !f.is_finite() {
+            None
+        } else {
+            let secs = f.trunc() as i64;
+            // NOTE(benesch): PostgreSQL has microsecond precision in its timestamps,
+            // while chrono has nanosecond precision. While we normally accept
+            // nanosecond precision, here we round to the nearest microsecond because
+            // f64s lose quite a bit of accuracy in the nanosecond digits when dealing
+            // with common Unix timestamp values (> 1 billion).
+            let nanosecs = ((f.fract() * 1_000_000.0).round() as u32) * 1_000;
+            match NaiveDateTime::from_timestamp_opt(secs as i64, nanosecs as u32) {
+                Some(ts) => Some(DateTime::<Utc>::from_utc(ts, Utc)),
+                None => None,
+            }
+        }
     }
 );

--- a/src/expr/src/scalar/func/macros.rs
+++ b/src/expr/src/scalar/func/macros.rs
@@ -146,7 +146,10 @@ macro_rules! sqlfunc {
         }
     };
 
-    // First, expand the function name into an attribute, if it was omitted
+    // Here follow 3 stages of transformations for the cases where the user didn't provide a fully
+    // specified function signature as expected by the rule above.
+
+    // Stage 0: Expand the function name into an attribute, if it was omitted
     (
         fn $fn_name:ident $($tail:tt)*
     ) => {
@@ -155,35 +158,73 @@ macro_rules! sqlfunc {
             fn $fn_name $($tail)*
         );
     };
-    // Then, make the function fallible if it wasn't
+
+    // Stage 1: Convert function to fallible, if it wasn't already
+
+    // It is important that we check if the return type matches Result<Option<T>>, Result<T>,
+    // Option<T>, and T in that order because once a type is matched by a `ty` typed metavariable
+    // it can no longer be destructured syntactically. So if `$ret_ty:ty` matched
+    // `Result<Option<T>>` as a unit we would no longer be able to infer information about the
+    // structure of the type and therefore wouldn't be able to apply the elision rules.
     (
         #[sqlname = $name:expr]
-        fn $fn_name:ident $params:tt -> $ret_ty:tt
+        fn $fn_name:ident $params:tt -> Result<Option<$ret_ty:ty>, EvalError>
             $body:block
     ) => {
         sqlfunc!(
+            @stage2
             #[sqlname = $name]
-            fn $fn_name $params -> Result<$ret_ty, EvalError> {
-                Ok($body)
+            fn $fn_name $params -> Result<Option<$ret_ty>, EvalError> {
+                $body
             }
         );
     };
     (
         #[sqlname = $name:expr]
-        fn $fn_name:ident $params:tt -> Option<$ret_ty:tt>
+        fn $fn_name:ident $params:tt -> Result<$ret_ty:ty, EvalError>
             $body:block
     ) => {
         sqlfunc!(
+            @stage2
+            #[sqlname = $name]
+            fn $fn_name $params -> Result<$ret_ty, EvalError> {
+                $body
+            }
+        );
+    };
+    (
+        #[sqlname = $name:expr]
+        fn $fn_name:ident $params:tt -> Option<$ret_ty:ty>
+            $body:block
+    ) => {
+        sqlfunc!(
+            @stage2
             #[sqlname = $name]
             fn $fn_name $params -> Result<Option<$ret_ty>, EvalError> {
                 Ok($body)
             }
         );
     };
-
-
-    // Then, check if omitting the attributes is ok
     (
+        #[sqlname = $name:expr]
+        fn $fn_name:ident $params:tt -> $ret_ty:ty
+            $body:block
+    ) => {
+        sqlfunc!(
+            @stage2
+            #[sqlname = $name]
+            fn $fn_name $params -> Result<$ret_ty, EvalError> {
+                Ok($body)
+            }
+        );
+    };
+
+
+    // Stage 2: Apply the elision rules to find out if the function propagates or introduces nulls
+
+    // We can't infer in this case, bail out with a nice error message
+    (
+        @stage2
         #[sqlname = $name:expr]
         fn $fn_name:ident($param_name:ident: Option<$param_ty:ty>) -> Result<Option<$ret_ty:ty>, EvalError>
             $body:block
@@ -197,6 +238,7 @@ macro_rules! sqlfunc {
     // The function takes optional arguments and returns non optional, therefore it doesn't
     // propagate nulls
     (
+        @stage2
         #[sqlname = $name:expr]
         fn $fn_name:ident($param_name:ident: Option<$param_ty:ty>) -> Result<$ret_ty:ty, EvalError>
             $body:block
@@ -215,6 +257,7 @@ macro_rules! sqlfunc {
     // The function takes non-optional arguments and returns optional, therefore it propagates
     // nulls and introduces nulls too
     (
+        @stage2
         #[sqlname = $name:expr]
         fn $fn_name:ident($param_name:ident: $param_ty:ty) -> Result<Option<$ret_ty:ty>, EvalError>
             $body:block
@@ -237,6 +280,7 @@ macro_rules! sqlfunc {
     // The function takes non-optional arguments and returns non optional, therefore it propagates
     // nulls but doesn't introduce them
     (
+        @stage2
         #[sqlname = $name:expr]
         fn $fn_name:ident($param_name:ident: $param_ty:ty) -> Result<$ret_ty:ty, EvalError>
             $body:block

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -964,6 +964,12 @@ impl FromTy<i64> for ScalarType {
     }
 }
 
+impl FromTy<DateTime<Utc>> for ScalarType {
+    fn from_ty() -> Self {
+        Self::TimestampTz
+    }
+}
+
 impl<'a> ScalarType {
     /// Returns the contained numeric scale.
     ///

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1694,7 +1694,7 @@ lazy_static! {
                 }), 3787;
             },
             "to_timestamp" => Scalar {
-                params!(Float64) => UnaryFunc::ToTimestamp, 1158;
+                params!(Float64) => UnaryFunc::ToTimestamp(func::ToTimestamp), 1158;
             },
             "upper" => Scalar {
                 params!(String) => UnaryFunc::Upper, 871;
@@ -2147,7 +2147,7 @@ lazy_static! {
                 params!() => Operation::nullary(mz_session_id), oid::FUNC_MZ_SESSION_ID_OID;
             },
             "mz_sleep" => Scalar {
-                params!(Float64) => UnaryFunc::Sleep, oid::FUNC_MZ_SLEEP_OID;
+                params!(Float64) => UnaryFunc::Sleep(func::Sleep), oid::FUNC_MZ_SLEEP_OID;
             }
         }
     };


### PR DESCRIPTION
### Description

This PR reworks the return type matching metavariables in `sqlfunc!` to be able to match return types that are more than one token. This enables defining functions that return e.g `DateTime<Utc>`. 

A couple of unary functions returning `DateTime<Utc>` are included in this PR

### Tips for reviewer

Commit by commit is recommended

### Checklist

- [ ] This PR has adequate test coverage.
- [ ] This PR adds a release note for any user-facing behavior changes.
