### PR TITLE
Support generic `Datum` arguments in sqlfunc!

### DIFF
--- a/src/expr-test-util/src/lib.rs
+++ b/src/expr-test-util/src/lib.rs
@@ -14,7 +14,7 @@ use proc_macro2::TokenTree;
 use serde_json::Value;
 
 use expr::explain::ViewExplanation;
-use expr::func::Not;
+use expr::func::{IsNull, Not};
 use expr::*;
 use lowertest::*;
 use ore::result::ResultExt;
@@ -37,7 +37,14 @@ gen_reflect_info_func!(
         JoinImplementation,
         EvalError,
     ],
-    [AggregateExpr, ColumnOrder, ColumnType, RelationType, Not]
+    [
+        AggregateExpr,
+        ColumnOrder,
+        ColumnType,
+        RelationType,
+        IsNull,
+        Not
+    ]
 );
 
 lazy_static! {

--- a/src/expr/src/relation/canonicalize.rs
+++ b/src/expr/src/relation/canonicalize.rs
@@ -232,7 +232,7 @@ pub fn canonicalize_predicates(predicates: &mut Vec<MirScalarExpr>, input_type: 
                 continue;
             }
         } else if let MirScalarExpr::CallUnary {
-            func: UnaryFunc::IsNull,
+            func: UnaryFunc::IsNull(func::IsNull),
             expr,
         } = &predicate_to_apply
         {
@@ -370,7 +370,7 @@ fn is_not_null(predicate: &MirScalarExpr) -> Option<MirScalarExpr> {
     } = &predicate
     {
         if let MirScalarExpr::CallUnary {
-            func: UnaryFunc::IsNull,
+            func: UnaryFunc::IsNull(func::IsNull),
             expr,
         } = &**expr
         {

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -416,7 +416,7 @@ impl MirRelationExpr {
                     } = predicate
                     {
                         if let MirScalarExpr::CallUnary {
-                            func: UnaryFunc::IsNull,
+                            func: UnaryFunc::IsNull(scalar_func::IsNull),
                             expr,
                         } = &**expr
                         {

--- a/src/expr/src/scalar/func/impls.rs
+++ b/src/expr/src/scalar/func/impls.rs
@@ -7,8 +7,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+mod datum;
 mod float;
 mod not;
 
+pub use datum::*;
 pub use float::*;
 pub use not::Not;

--- a/src/expr/src/scalar/func/impls/datum.rs
+++ b/src/expr/src/scalar/func/impls/datum.rs
@@ -1,0 +1,59 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::EvalError;
+use repr::Datum;
+use std::convert::TryFrom;
+
+sqlfunc!(
+    #[sqlname = "isnull"]
+    #[propagates_nulls = false]
+    #[introduces_nulls = false]
+    #[preserves_uniqueness = false]
+    fn is_null(a: Datum<'_>) -> Result<Option<bool>, EvalError> {
+        Ok(Some(a == Datum::Null))
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "pg_column_size"]
+    #[propagates_nulls = true]
+    #[introduces_nulls = false]
+    #[preserves_uniqueness = false]
+    fn pg_column_size(a: Datum<'_>) -> Result<Option<i32>, EvalError> {
+        match a {
+            Datum::Null => Ok(None),
+            d => {
+                let sz = repr::datum_size(&d);
+                i32::try_from(sz)
+                    .map(Some)
+                    .or(Err(EvalError::Int32OutOfRange))
+            }
+        }
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "mz_row_size"]
+    #[propagates_nulls = true]
+    #[introduces_nulls = false]
+    #[preserves_uniqueness = false]
+    // Return the number of bytes this Record (List) datum would use if packed as a Row.
+    fn mz_row_size(a: Datum<'_>) -> Result<Option<i32>, EvalError> {
+        match a {
+            Datum::Null => Ok(None),
+            d => {
+                let sz = repr::row_size(d.unwrap_list().iter());
+                i32::try_from(sz)
+                    .map(Some)
+                    .or(Err(EvalError::Int32OutOfRange))
+            }
+        }
+    }
+);

--- a/src/expr/src/scalar/func/macros.rs
+++ b/src/expr/src/scalar/func/macros.rs
@@ -69,11 +69,11 @@ macro_rules! sqlfunc {
         #[propagates_nulls = $propagates_nulls:literal]
         #[introduces_nulls = $introduces_nulls:literal]
         #[preserves_uniqueness = $preserves_uniqueness:literal]
-        fn $fn_name:ident($param_name:ident: Option<$param_ty:ty>) -> Result<Option<$ret_ty:ty>, EvalError>
+        fn $fn_name:ident($param_name:ident: $param_ty:ty) -> Result<Option<$ret_ty:ty>, EvalError>
             $body:block
     ) => {
         paste::paste! {
-            pub fn $fn_name($param_name: Option<$param_ty>) -> Result<Option<$ret_ty>, crate::EvalError> {
+            pub fn $fn_name($param_name: $param_ty) -> Result<Option<$ret_ty>, crate::EvalError> {
                 $body
             }
 
@@ -101,7 +101,7 @@ macro_rules! sqlfunc {
                         // Evaluate the argument and convert it to the concrete type that the
                         // implementation expects. This cannot fail here because the expression is
                         // already typechecked.
-                        let a: Option<$param_ty> = a
+                        let a: $param_ty = a
                             .eval(datums, temp_storage)?
                             .try_into()
                             .expect("expression already typechecked");

--- a/src/expr/src/scalar/func/macros.rs
+++ b/src/expr/src/scalar/func/macros.rs
@@ -250,6 +250,152 @@ macro_rules! sqlfunc {
     };
 }
 
+#[cfg(test)]
+mod test {
+    use crate::scalar::func::UnaryFuncTrait;
+    use repr::ScalarType;
+
+    sqlfunc!(
+        #[sqlname = "INFALLIBLE"]
+        fn infallible1(a: f32) -> f32 {
+            a
+        }
+    );
+
+    sqlfunc!(
+        fn infallible2(a: Option<f32>) -> f32 {
+            a.unwrap_or_default()
+        }
+    );
+
+    sqlfunc!(
+        fn infallible3(a: f32) -> Option<f32> {
+            Some(a)
+        }
+    );
+
+    #[test]
+    fn elision_rules_infallible() {
+        assert_eq!(format!("{}", Infallible1), "INFALLIBLE");
+        assert!(Infallible1.propagates_nulls());
+        assert!(!Infallible1.introduces_nulls());
+
+        assert!(!Infallible2.propagates_nulls());
+        assert!(!Infallible2.introduces_nulls());
+
+        assert!(Infallible3.propagates_nulls());
+        assert!(Infallible3.introduces_nulls());
+    }
+
+    #[test]
+    fn output_types_infallible() {
+        assert_eq!(
+            Infallible1.output_type(ScalarType::Float32.nullable(true)),
+            ScalarType::Float32.nullable(true)
+        );
+        assert_eq!(
+            Infallible1.output_type(ScalarType::Float32.nullable(false)),
+            ScalarType::Float32.nullable(false)
+        );
+
+        assert_eq!(
+            Infallible2.output_type(ScalarType::Float32.nullable(true)),
+            ScalarType::Float32.nullable(false)
+        );
+        assert_eq!(
+            Infallible2.output_type(ScalarType::Float32.nullable(false)),
+            ScalarType::Float32.nullable(false)
+        );
+
+        assert_eq!(
+            Infallible3.output_type(ScalarType::Float32.nullable(true)),
+            ScalarType::Float32.nullable(true)
+        );
+        assert_eq!(
+            Infallible3.output_type(ScalarType::Float32.nullable(false)),
+            ScalarType::Float32.nullable(true)
+        );
+    }
+
+    sqlfunc!(
+        fn fallible1(a: f32) -> Result<f32, EvalError> {
+            Ok(a)
+        }
+    );
+
+    sqlfunc!(
+        fn fallible2(a: Option<f32>) -> Result<f32, EvalError> {
+            Ok(a.unwrap_or_default())
+        }
+    );
+
+    sqlfunc!(
+        fn fallible3(a: f32) -> Result<Option<f32>, EvalError> {
+            Ok(Some(a))
+        }
+    );
+
+    #[test]
+    fn elision_rules_fallible() {
+        assert!(Fallible1.propagates_nulls());
+        assert!(!Fallible1.introduces_nulls());
+
+        assert!(!Fallible2.propagates_nulls());
+        assert!(!Fallible2.introduces_nulls());
+
+        assert!(Fallible3.propagates_nulls());
+        assert!(Fallible3.introduces_nulls());
+    }
+
+    #[test]
+    fn output_types_fallible() {
+        assert_eq!(
+            Fallible1.output_type(ScalarType::Float32.nullable(true)),
+            ScalarType::Float32.nullable(true)
+        );
+        assert_eq!(
+            Fallible1.output_type(ScalarType::Float32.nullable(false)),
+            ScalarType::Float32.nullable(false)
+        );
+
+        assert_eq!(
+            Fallible2.output_type(ScalarType::Float32.nullable(true)),
+            ScalarType::Float32.nullable(false)
+        );
+        assert_eq!(
+            Fallible2.output_type(ScalarType::Float32.nullable(false)),
+            ScalarType::Float32.nullable(false)
+        );
+
+        assert_eq!(
+            Fallible3.output_type(ScalarType::Float32.nullable(true)),
+            ScalarType::Float32.nullable(true)
+        );
+        assert_eq!(
+            Fallible3.output_type(ScalarType::Float32.nullable(false)),
+            ScalarType::Float32.nullable(true)
+        );
+    }
+
+    sqlfunc!(
+        #[sqlname = "foobar"]
+        #[propagates_nulls = false]
+        #[introduces_nulls = true]
+        #[preserves_uniqueness = true]
+        fn explicit(a: Option<f64>) -> Result<Option<f64>, EvalError> {
+            Ok(a)
+        }
+    );
+
+    #[test]
+    fn explicit_annotation() {
+        assert_eq!(format!("{}", Explicit), "foobar");
+        assert!(!Explicit.propagates_nulls());
+        assert!(Explicit.introduces_nulls());
+        assert!(Explicit.preserves_uniqueness());
+    }
+}
+
 /// Temporary macro that generates the equivalent of what enum_dispatch will do in the future. We
 /// need this manual macro implementation to delegate to the previous manual implementation for
 /// variants that use the old definitions.

--- a/src/expr/src/scalar/func/macros.rs
+++ b/src/expr/src/scalar/func/macros.rs
@@ -129,12 +129,6 @@ macro_rules! sqlfunc {
                     }
                 }
 
-                impl From<[<$fn_name:camel>]> for crate::UnaryFunc {
-                    fn from(variant: [<$fn_name:camel>]) -> Self {
-                        Self::[<$fn_name:camel>](variant)
-                    }
-                }
-
                 impl fmt::Display for [<$fn_name:camel>] {
                     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                         f.write_str($name)
@@ -310,5 +304,13 @@ macro_rules! derive_unary {
                 }
             }
         }
+
+        $(
+            impl From<$name> for crate::UnaryFunc {
+                fn from(variant: $name) -> Self {
+                    Self::$name(variant)
+                }
+            }
+        )*
     }
 }

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -329,7 +329,7 @@ impl MirScalarExpr {
                         // 1a) Decompose IsNull expressions into a disjunction
                         // of simpler IsNull subexpressions
                         MirScalarExpr::CallUnary { func, expr } => {
-                            if *func == UnaryFunc::IsNull {
+                            if *func == UnaryFunc::IsNull(func::IsNull) {
                                 if let Some(expr) = expr.decompose_is_null() {
                                     *e = expr
                                 }
@@ -688,8 +688,8 @@ impl MirScalarExpr {
             // (<expr1> <op> <expr2>) IS NULL can often be simplified to
             // (<expr1> IS NULL) OR (<expr2> IS NULL).
             if func.propagates_nulls() && !func.introduces_nulls() {
-                let expr1 = expr1.take().call_unary(UnaryFunc::IsNull);
-                let expr2 = expr2.take().call_unary(UnaryFunc::IsNull);
+                let expr1 = expr1.take().call_unary(UnaryFunc::IsNull(func::IsNull));
+                let expr2 = expr2.take().call_unary(UnaryFunc::IsNull(func::IsNull));
                 return Some(expr1.call_binary(expr2, BinaryFunc::Or));
             }
         } else if let MirScalarExpr::CallUnary {

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1506,7 +1506,7 @@ lazy_static! {
                 }), 1215;
             },
             "pg_column_size" => Scalar {
-                params!(Any) => UnaryFunc::PgColumnSize, 1269;
+                params!(Any) => UnaryFunc::PgColumnSize(func::PgColumnSize), 1269;
             },
             "mz_row_size" => Scalar {
                 params!(Any) => Operation::unary(|ecx, e| {
@@ -1514,7 +1514,7 @@ lazy_static! {
                     if !matches!(s, ScalarType::Record{..}) {
                         bail!("mz_row_size requires a record type");
                     }
-                    Ok(e.call_unary(UnaryFunc::MzRowSize))
+                    Ok(e.call_unary(UnaryFunc::MzRowSize(func::MzRowSize)))
                 }), oid::FUNC_MZ_ROW_SIZE;
             },
             "pg_encoding_to_char" => Scalar {

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -593,7 +593,7 @@ impl HirScalarExpr {
                                 expr2: Box::new(SS::literal_ok(Datum::False, ScalarType::Bool)),
                             }),
                             expr2: Box::new(SS::CallUnary {
-                                func: expr::UnaryFunc::IsNull,
+                                func: expr::UnaryFunc::IsNull(expr::func::IsNull),
                                 expr: Box::new(cond_expr.clone()),
                             }),
                         }]);

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -3016,7 +3016,7 @@ fn plan_is_null_expr<'a>(
     // means we wind up supporting both.
     let expr = plan_expr(ecx, inner)?.type_as_any(ecx)?;
     let mut expr = HirScalarExpr::CallUnary {
-        func: UnaryFunc::IsNull,
+        func: UnaryFunc::IsNull(expr_func::IsNull),
         expr: Box::new(expr),
     };
     if not {

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -244,7 +244,7 @@ fn plan_dbz_flatten_one(
             predicates: vec![HirScalarExpr::CallUnary {
                 func: UnaryFunc::Not(func::Not),
                 expr: Box::new(HirScalarExpr::CallUnary {
-                    func: UnaryFunc::IsNull,
+                    func: UnaryFunc::IsNull(func::IsNull),
                     expr: Box::new(HirScalarExpr::Column(ColumnRef {
                         level: 0,
                         column: bare_column,

--- a/src/sql/src/plan/transform_expr.rs
+++ b/src/sql/src/plan/transform_expr.rs
@@ -244,7 +244,10 @@ pub fn try_simplify_quantified_comparisons(expr: &mut HirRelationExpr) {
                         let filter = expr
                             .clone()
                             .call_unary(UnaryFunc::Not(func::Not))
-                            .call_binary(expr.call_unary(UnaryFunc::IsNull), BinaryFunc::Or);
+                            .call_binary(
+                                expr.call_unary(UnaryFunc::IsNull(func::IsNull)),
+                                BinaryFunc::Or,
+                            );
                         *e = input
                             .take()
                             .filter(vec![filter])

--- a/src/transform/src/column_knowledge.rs
+++ b/src/transform/src/column_knowledge.rs
@@ -144,7 +144,7 @@ impl ColumnKnowledge {
                     } = predicate
                     {
                         if let MirScalarExpr::CallUnary {
-                            func: UnaryFunc::IsNull,
+                            func: UnaryFunc::IsNull(func::IsNull),
                             expr,
                         } = &**expr
                         {
@@ -386,7 +386,7 @@ pub fn optimize(
                     let knowledge = knowledge_stack.pop().unwrap();
                     if knowledge.value.is_some() {
                         e.reduce(input_type);
-                    } else if func == &UnaryFunc::IsNull && !knowledge.nullable {
+                    } else if func == &UnaryFunc::IsNull(func::IsNull) && !knowledge.nullable {
                         *e = MirScalarExpr::literal_ok(Datum::False, ScalarType::Bool);
                     };
                     DatumKnowledge::from(&*e)

--- a/src/transform/src/nonnullable.rs
+++ b/src/transform/src/nonnullable.rs
@@ -15,7 +15,7 @@
 // TODO(frank): evaluate for redundancy with `column_knowledge`, or vice-versa.
 
 use crate::TransformArgs;
-use expr::{AggregateExpr, AggregateFunc, MirRelationExpr, MirScalarExpr, UnaryFunc};
+use expr::{func, AggregateExpr, AggregateFunc, MirRelationExpr, MirScalarExpr, UnaryFunc};
 use repr::{Datum, RelationType, ScalarType};
 
 /// Harvests information about non-nullability of columns from sources.
@@ -84,7 +84,7 @@ fn scalar_contains_isnull(expr: &MirScalarExpr) -> bool {
     let mut result = false;
     expr.visit(&mut |e| {
         if let MirScalarExpr::CallUnary {
-            func: UnaryFunc::IsNull,
+            func: UnaryFunc::IsNull(func::IsNull),
             ..
         } = e
         {
@@ -99,7 +99,7 @@ fn scalar_nonnullable(expr: &mut MirScalarExpr, metadata: &RelationType) {
     // Tests for null can be replaced by "false" for non-nullable columns.
     expr.visit_mut(&mut |e| {
         if let MirScalarExpr::CallUnary {
-            func: UnaryFunc::IsNull,
+            func: UnaryFunc::IsNull(func::IsNull),
             expr,
         } = e
         {

--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -248,14 +248,14 @@ impl PredicatePushdown {
                                         pred_not_translated.push(
                                             expr1
                                                 .clone()
-                                                .call_unary(UnaryFunc::IsNull)
+                                                .call_unary(UnaryFunc::IsNull(func::IsNull))
                                                 .call_unary(UnaryFunc::Not(func::Not)),
                                         );
                                     } else if expr2.typ(&input_type).nullable {
                                         pred_not_translated.push(
                                             expr2
                                                 .clone()
-                                                .call_unary(UnaryFunc::IsNull)
+                                                .call_unary(UnaryFunc::IsNull(func::IsNull))
                                                 .call_unary(UnaryFunc::Not(func::Not)),
                                         );
                                     }
@@ -534,7 +534,7 @@ impl PredicatePushdown {
                             for constant in runtime_constants.iter() {
                                 let pred = if constant.is_literal_null() {
                                     MirScalarExpr::CallUnary {
-                                        func: expr::UnaryFunc::IsNull,
+                                        func: expr::UnaryFunc::IsNull(func::IsNull),
                                         expr: Box::new(expr.clone()),
                                     }
                                 } else {
@@ -666,11 +666,11 @@ impl PredicatePushdown {
                                         expr2: Box::new(MirScalarExpr::CallBinary {
                                             func: BinaryFunc::And,
                                             expr1: Box::new(MirScalarExpr::CallUnary {
-                                                func: UnaryFunc::IsNull,
+                                                func: UnaryFunc::IsNull(func::IsNull),
                                                 expr: Box::new(expr2.clone()),
                                             }),
                                             expr2: Box::new(MirScalarExpr::CallUnary {
-                                                func: UnaryFunc::IsNull,
+                                                func: UnaryFunc::IsNull(func::IsNull),
                                                 expr: Box::new(expr1.clone()),
                                             }),
                                         }),
@@ -806,8 +806,12 @@ impl PredicatePushdown {
                 expr2: eqinnerexpr2,
             } = &mut **expr2
             {
-                let isnull1 = eqinnerexpr1.clone().call_unary(UnaryFunc::IsNull);
-                let isnull2 = eqinnerexpr2.clone().call_unary(UnaryFunc::IsNull);
+                let isnull1 = eqinnerexpr1
+                    .clone()
+                    .call_unary(UnaryFunc::IsNull(func::IsNull));
+                let isnull2 = eqinnerexpr2
+                    .clone()
+                    .call_unary(UnaryFunc::IsNull(func::IsNull));
                 let both_null = isnull1.call_binary(isnull2, BinaryFunc::And);
 
                 if Self::extract_reduced_conjunction_terms(both_null, relation_type)

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -69,8 +69,11 @@ mod tests {
         format_type: &FormatType,
     ) -> String {
         match format_type {
-            FormatType::Test => json_to_spec(&serde_json::to_string(rel).unwrap(), cat).0,
-            FormatType::Json => serde_json::to_string(rel).unwrap(),
+            FormatType::Test => format!(
+                "{}\n",
+                json_to_spec(&serde_json::to_string(rel).unwrap(), cat).0
+            ),
+            FormatType::Json => format!("{}\n", serde_json::to_string(rel).unwrap()),
             FormatType::Explain(format) => cat.generate_explanation(rel, *format),
         }
     }

--- a/src/transform/tests/testdata/steps
+++ b/src/transform/tests/testdata/steps
@@ -7,10 +7,17 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+# Demonstrates how the "steps" command works.
+
+# Results will need to be rewritten if any transforms get renamed or if the
+# sequence of transforms changes.
+
 cat
 (defsource x [bool bool])
 ----
 ok
+
+# Test #1: steps with all default arguments.
 
 steps
 (union
@@ -105,34 +112,71 @@ Final:
 ----
 ----
 
+# Test #2: steps with non-default input and output format.
+# If MirRelationExpr or any enum or struct it depends on changes, then this
+# test needs to be rewritten.
+
 steps in=json format=test
-{"Filter":{"input":{"Join":{"inputs":[{"Get":{"id":{"Global":{"User":210}},"typ":{"column_types":[{"scalar_type":"Int64","nullable":true},{"scalar_type":"Int64","nullable":true}],"keys":[]}}},{"Get":{"id":{"Global":{"User":0}},"typ":{"column_types":[{"scalar_type":"Int64","nullable":true},{"scalar_type":"Int64","nullable":true}],"keys":[]}}}],"equivalences":[],"demand":null,"implementation":"Unimplemented"}},"predicates":[{"CallBinary":{"func":"Or","expr1":{"CallBinary":{"func":"And","expr1":{"CallUnary":{"func":"IsNull","expr":{"Column":0}}},"expr2":{"CallUnary":{"func":"IsNull","expr":{"Column":2}}}}},"expr2":{"CallBinary":{"func":"Eq","expr1":{"Column":0},"expr2":{"CallBinary":{"func":"AddInt64","expr1":{"Column":2},"expr2":{"Literal":[{"Ok":{"data":[5,1,0,0,0,0,0,0,0]}},{"scalar_type":"Int64","nullable":false}]}}}}}}}]}}
+{"Filter":{"input":{"Join":{"inputs":[{"Get":{"id":{"Global":{"User":1}},"typ":{"column_types":[{"scalar_type":"Int64","nullable":true},{"scalar_type":"Int64","nullable":true}],"keys":[]}}},{"Get":{"id":{"Global":{"User":0}},"typ":{"column_types":[{"scalar_type":"Bool","nullable":true},{"scalar_type":"Bool","nullable":true}],"keys":[]}}}],"equivalences":[],"demand":null,"implementation":"Unimplemented"}},"predicates":[{"CallBinary":{"func":"Or","expr1":{"CallBinary":{"func":"And","expr1":{"CallUnary":{"func":{"IsNull":null},"expr":{"Column":0}}},"expr2":{"CallUnary":{"func":{"IsNull":null},"expr":{"Column":2}}}}},"expr2":{"CallBinary":{"func":"Eq","expr1":{"Column":0},"expr2":{"CallBinary":{"func":"AddInt64","expr1":{"Column":2},"expr2":{"Literal":[{"Ok":{"data":[5,1,0,0,0,0,0,0,0]}},{"scalar_type":"Int64","nullable":false}]}}}}}}}]}}
 ----
-(Filter (Join [(get u210) (get x)] [] null Unimplemented) [(CallBinary Or (CallBinary And (CallUnary IsNull #0) (CallUnary IsNull #2)) (CallBinary Eq #0 (CallBinary AddInt64 #2 (1 Int64))))])
+----
+(Filter (Join [(get u1) (get x)] [] null Unimplemented) [(CallBinary Or (CallBinary And (CallUnary (IsNull ) #0) (CallUnary (IsNull ) #2)) (CallBinary Eq #0 (CallBinary AddInt64 #2 (1 Int64))))])
+
 ====
 No change: TopKElision, NonNullRequirements, Fixpoint { transforms: [FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting, Map, Negate, Filter, Project, Join, InlineLet { inline_mfp: false }, Reduce, Union, UnionBranchCancellation, UpdateLet, RedundantJoin, FoldConstants { limit: Some(10000) }] }], limit: 100 }
 ====
 Applied Fixpoint { transforms: [PredicatePushdown, NonNullable, ColumnKnowledge, Demand, FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting, Map, Negate, Filter, Project, Join, InlineLet { inline_mfp: false }, Reduce, Union, UnionBranchCancellation, UpdateLet, RedundantJoin, FoldConstants { limit: Some(10000) }] }], limit: 100 }:
-(Join [(get u210) (get x)] [[#0 (CallBinary AddInt64 #2 (1 Int64))]] null Unimplemented)
+(Join [(get u1) (get x)] [[#0 (CallBinary AddInt64 #2 (1 Int64))]] null Unimplemented)
+
 ====
 No change: Fixpoint { transforms: [ReductionPushdown, ReduceElision, LiteralLifting, RelationCSE, InlineLet { inline_mfp: false }, UpdateLet, FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting, Map, Negate, Filter, Project, Join, InlineLet { inline_mfp: false }, Reduce, Union, UnionBranchCancellation, UpdateLet, RedundantJoin, FoldConstants { limit: Some(10000) }] }], limit: 100 }, ProjectionPushdown, UpdateLet, InlineLet { inline_mfp: true }
 ====
 Applied Fixpoint { transforms: [JoinImplementation, ColumnKnowledge, FoldConstants { limit: Some(10000) }, Demand, LiteralLifting], limit: 100 }:
-(Join [(ArrangeBy (get u210) [[#0]]) (get x)] [[#0 (CallBinary AddInt64 #2 (1 Int64))]] null (Differential [1 null] [[0 [#0]]]))
+(Join [(ArrangeBy (get u1) [[#0]]) (get x)] [[#0 (CallBinary AddInt64 #2 (1 Int64))]] null (Differential [1 null] [[0 [#0]]]))
+
 ====
 No change: ReductionPushdown, CanonicalizeMfp
 ====
 Applied RelationCSE:
-(let l0 (get u210) (let l1 (ArrangeBy (get l0) [[#0]]) (let l2 (get x) (let l3 (Join [(get l1) (get l2)] [[#0 (CallBinary AddInt64 #2 (1 Int64))]] null (Differential [1 null] [[0 [#0]]])) (get l3)))))
+(let l0 (get u1) (let l1 (ArrangeBy (get l0) [[#0]]) (let l2 (get x) (let l3 (Join [(get l1) (get l2)] [[#0 (CallBinary AddInt64 #2 (1 Int64))]] null (Differential [1 null] [[0 [#0]]])) (get l3)))))
+
 ====
 Applied InlineLet { inline_mfp: false }:
-(Join [(ArrangeBy (get u210) [[#0]]) (get x)] [[#0 (CallBinary AddInt64 #2 (1 Int64))]] null (Differential [1 null] [[0 [#0]]]))
+(Join [(ArrangeBy (get u1) [[#0]]) (get x)] [[#0 (CallBinary AddInt64 #2 (1 Int64))]] null (Differential [1 null] [[0 [#0]]]))
+
 ====
 No change: UpdateLet, FoldConstants { limit: Some(10000) }
 ====
 Final:
-(Join [(ArrangeBy (get u210) [[#0]]) (get x)] [[#0 (CallBinary AddInt64 #2 (1 Int64))]] null (Differential [1 null] [[0 [#0]]]))
+(Join [(ArrangeBy (get u1) [[#0]]) (get x)] [[#0 (CallBinary AddInt64 #2 (1 Int64))]] null (Differential [1 null] [[0 [#0]]]))
+
 ====
 ====
 Catalog defs:
-(defsource u210 ([(Int64 true) (Int64 true)] []))
+(defsource u1 ([(Int64 true) (Int64 true)] []))
+----
+----
+
+## #region Code to generate the rewritten version for Test #2
+
+cat
+(defsource u1 ([(Int64 true) (Int64 true)] []))
+----
+ok
+
+# Run `REWRITE=1 cargo test` from this directory, then copy the result of the
+# test below as the rewritten version of Test #2. If the result ends up being an error,
+# fix the syntax of the test below, then try again.
+
+build format=json
+(Filter
+    (Join [(get u1) (get x)] [])
+    [
+        (CallBinary Or (CallBinary And (CallUnary IsNull #0) (CallUnary IsNull #2))
+        (CallBinary Eq #0 (CallBinary AddInt64 #2 (1 Int64))))
+    ]
+)
+----
+{"Filter":{"input":{"Join":{"inputs":[{"Get":{"id":{"Global":{"User":1}},"typ":{"column_types":[{"scalar_type":"Int64","nullable":true},{"scalar_type":"Int64","nullable":true}],"keys":[]}}},{"Get":{"id":{"Global":{"User":0}},"typ":{"column_types":[{"scalar_type":"Bool","nullable":true},{"scalar_type":"Bool","nullable":true}],"keys":[]}}}],"equivalences":[],"demand":null,"implementation":"Unimplemented"}},"predicates":[{"CallBinary":{"func":"Or","expr1":{"CallBinary":{"func":"And","expr1":{"CallUnary":{"func":{"IsNull":null},"expr":{"Column":0}}},"expr2":{"CallUnary":{"func":{"IsNull":null},"expr":{"Column":2}}}}},"expr2":{"CallBinary":{"func":"Eq","expr1":{"Column":0},"expr2":{"CallBinary":{"func":"AddInt64","expr1":{"Column":2},"expr2":{"Literal":[{"Ok":{"data":[5,1,0,0,0,0,0,0,0]}},{"scalar_type":"Int64","nullable":false}]}}}}}}}]}}
+
+## #endregion


### PR DESCRIPTION
### Description

This PR changes the `sqlfunc!` to relax the requirements of the parameter type. Previously the parameter type had to be in the form of `Option<T>` but this isn't necessary if the user uses the fully explicit syntax.

So now the final rule of the macro, that defines the fully explicit syntax, can work with any parameter type so long as it can be converted into a Datum. This allows the parameter itself to be `Datum`, since the conversion is trivial, which in turns allows us to define functions like `is_null` with `sqlfunc!` that operate on a generic datum but return a concrete type (like `bool`).

This PR also adds a bunch of tests that verify that the macro applies the elision rules correctly in all cases.

### Tips for reviewer

The diff is large mainly because we use `IsNull` in lots of places so review commit by commit is recommended

### Checklist

- [x] This PR has adequate test coverage.
