### PR TITLE
make avro_ingest.py work with versions of Mz before #7922

### DIFF
--- a/misc/python/materialize/benches/avro_ingest.py
+++ b/misc/python/materialize/benches/avro_ingest.py
@@ -194,7 +194,10 @@ def main() -> None:
                 n = cur.fetchone()[0]
                 if n == ns.records:
                     break
-            except psycopg2.errors.SqlStatementNotYetComplete:
+            except (
+                psycopg2.errors.SqlStatementNotYetComplete,
+                psycopg2.errors.InternalError,
+            ):
                 pass
             time.sleep(1)
         prev = print_stats(cid, prev)


### PR DESCRIPTION
### Motivation

Which of the following best describes the motivation behind this PR?

  * This PR fixes a previously unreported bug.

`avro_ingest.py` aborts with an exception on versions of Materialize before #7922, because the error they return for "no finished timestamps" corresponds to a different type in psycopg2.

### Checklist

- [ ] This PR has adequate test coverage.
- [ ] This PR adds a release note for any user-facing behavior changes.
