### PR TITLE
Expr: Remove demand field from join and flatmap.

### DIFF
--- a/doc/developer/arrangements.md
+++ b/doc/developer/arrangements.md
@@ -255,12 +255,6 @@ It is not uncommon to re-use this arrangement, as we find that such groupings ar
 The `mz_arrangement_sharing` logging source reports the number of times each arrangement is shared.
 An arrangement is identified by the worker and operator that created it.
 
-## Caveats: Demand Analysis
-
-When users present queries and views to us, we can determine that some fields are not required.
-We blank out any field that is not required.
-This can reduce the number of distinct `data` in an arrangement, which will reduce the size of the arrangement.
-
 ## Caveats: Delta Joins
 
 In certain circumstances, we plan `Join` operators using a different pattern which avoids the intermediate arrangements.
@@ -278,3 +272,15 @@ But, we would also need to create similar dataflow graphs for each of `In2`, `In
 In each case they only require arrangements of the input, but they may be by different keys.
 
 If a `Join` is implemented by a Delta Join pattern, it will create zero additional arrangements.
+
+## Caveats: Demand Analysis
+
+> Obsolete as of v0.9.4. We now delete fields that are not required
+> instead of blanking them out. Plans prior to v0.9.4 will show something like
+> `| | demand = (#6, #8, #12, #15, #22, #23, #27)` for the `Join` and `FlatMap`
+> operators, listing which field will be blanked out.
+
+When users present queries and views to us, we can determine that some fields are not required.
+We blank out any field that is not required.
+This can reduce the number of distinct `data` in an arrangement, which will
+reduce the size of the arrangement.

--- a/doc/developer/arrangements.md
+++ b/doc/developer/arrangements.md
@@ -275,12 +275,12 @@ If a `Join` is implemented by a Delta Join pattern, it will create zero addition
 
 ## Caveats: Demand Analysis
 
-> Obsolete as of v0.9.4. We now delete fields that are not required
-> instead of blanking them out. Plans prior to v0.9.4 will show something like
-> `| | demand = (#6, #8, #12, #15, #22, #23, #27)` for the `Join` and `FlatMap`
-> operators, listing which field will be blanked out.
+> Obsolete for `Join` and `FlatMap` as of v0.9.4. We now delete fields that are
+> not required instead of blanking them out. Plans prior to v0.9.4 will show
+> something like `| | demand = (#6, #8, #12, #15, #22, #23, #27)` for the
+> `Join` and `FlatMap` operators, listing which field will be blanked out.
 
-When users present queries and views to us, we can determine that some fields are not required.
-We blank out any field that is not required.
-This can reduce the number of distinct `data` in an arrangement, which will
-reduce the size of the arrangement.
+When users present queries and views to us, we can determine that some fields
+are not required and blank out them out. This can reduce the number of distinct
+`data` in an arrangement, which will reduce the size of the arrangement.
+Currently, we blank out fields not required when importing sources.

--- a/doc/user/content/sql/explain.md
+++ b/doc/user/content/sql/explain.md
@@ -165,7 +165,6 @@ example is the choice of implementation in the `Join` operator.
 | |   delta %0 %1.(#1) %2.(#0)
 | |   delta %1 %0.(#0) %2.(#0)
 | |   delta %2 %1.(#0) %0.(#0)
-| | demand = (#6, #8, #12, #15, #22, #23, #27)
 | Filter (#6 = "BUILDING"), (#12 < 1995-03-15), (#27 > 1995-03-15)
 | Reduce group=(#8, #12, #15) sum((#22 * (100dec - #23)))
 | Project (#0, #3, #1, #2)

--- a/src/dataflow/src/render/join/mod.rs
+++ b/src/dataflow/src/render/join/mod.rs
@@ -233,7 +233,7 @@ struct JoinBuildState {
     /// The linear operator logic (maps, filters, and projection) that remains to be applied
     /// to the output of the join.
     ///
-    /// We we advance through the construction of the join dataflow, we may be able to peel
+    /// When we advance through the construction of the join dataflow, we may be able to peel
     /// off some of this work, ideally reducing `mfp` to something nearly the identity.
     mfp: MapFilterProject,
 }

--- a/src/expr-test-util/tests/testdata/rel
+++ b/src/expr-test-util/tests/testdata/rel
@@ -87,7 +87,6 @@ build
 (join
     [(get y) (get y)]
     [[#0 #3]]
-    [0 1 5]
     (delta_query [[[0 [#0]] [1 [#0]]]
                   [[1 [#0]] [0 [#0]]]]))
 ----
@@ -103,7 +102,6 @@ build
 | | implementation = DeltaQuery
 | |   delta %0 %0.(#0) %1.(#0)
 | |   delta %1 %1.(#0) %0.(#0)
-| | demand = (#0, #1, #5)
 ----
 ----
 

--- a/src/expr-test-util/tests/testdata/tospec
+++ b/src/expr-test-util/tests/testdata/tospec
@@ -27,7 +27,7 @@ cat
 ----
 ok
 
-(Reduce (Filter (Join [(get u6) (get u16) (get u19) (get u26) (get u34) (get u31) (get u37)] [] null Unimplemented) [(CallBinary Eq #0 #25) (CallBinary Eq #1 #23) (CallBinary Eq #2 #24) (CallBinary Eq #21 (CallUnary CastInt16ToInt32 #61)) (CallBinary Eq #22 #30) (CallBinary Eq #23 #31) (CallBinary Eq #24 #32) (CallBinary Eq #32 #41) (CallBinary Eq #34 #40) (CallBinary Eq #57 (CallUnary CastInt16ToInt32 #58)) (CallBinary Eq #61 #65) (CallBinary Eq #67 #69) (CallBinary Eq #70 ("EUROPE" String)) (CallBinary Gte (CallUnary CastDateToTimestamp #26) ("2007-01-02 00:00:00" Timestamp))]) [#66] [(SumNumeric #38 false)] false null)
+(Reduce (Filter (Join [(get u6) (get u16) (get u19) (get u26) (get u34) (get u31) (get u37)] [] Unimplemented) [(CallBinary Eq #0 #25) (CallBinary Eq #1 #23) (CallBinary Eq #2 #24) (CallBinary Eq #21 (CallUnary CastInt16ToInt32 #61)) (CallBinary Eq #22 #30) (CallBinary Eq #23 #31) (CallBinary Eq #24 #32) (CallBinary Eq #32 #41) (CallBinary Eq #34 #40) (CallBinary Eq #57 (CallUnary CastInt16ToInt32 #58)) (CallBinary Eq #61 #65) (CallBinary Eq #67 #69) (CallBinary Eq #70 ("EUROPE" String)) (CallBinary Gte (CallUnary CastDateToTimestamp #26) ("2007-01-02 00:00:00" Timestamp))]) [#66] [(SumNumeric #38 false)] false null)
 ----
 ----
 
@@ -45,26 +45,30 @@ cat
 ok
 
 build
-(Filter
-    (Join [(get u6) (get u16) (get u19) (get u26) (get u34) (get
-        u31) (get u37)] [] null Unimplemented)
-    [(CallBinary Eq #0 #25)
-    (CallBinary Eq #1 #23)
-    (CallBinary Eq #2 #24)
-    (CallBinary Eq #21 (CallUnary CastInt16ToInt32 #61))
-    (CallBinary Eq #22 #30)
-    (CallBinary Eq #23 #31)
-    (CallBinary Eq #24 #32)
-    (CallBinary Eq #32 #41)
-    (CallBinary Eq #34 #40)
-    (CallBinary Eq #57 (CallUnary CastInt16ToInt32 #58))
-    (CallBinary Eq #61 #65)
-    (CallBinary Eq #67 #69)
-    (CallBinary Eq #70 ("EUROPE" String))
-    (CallBinary Gte (CallUnary CastDateToTimestamp #26)
-        ("2007-01-02 00:00:00" Timestamp))
-    ]
-)
+(Reduce
+    (Filter
+        (Join [(get u6) (get u16) (get u19) (get u26) (get u34) (get u31) (get
+        u37)] [] Unimplemented)
+        [(CallBinary Eq #0 #25)
+        (CallBinary Eq #1 #23)
+        (CallBinary Eq #2 #24)
+        (CallBinary Eq #21 (CallUnary CastInt16ToInt32 #61))
+        (CallBinary Eq #22 #30)
+        (CallBinary Eq #23 #31)
+        (CallBinary Eq #24 #32)
+        (CallBinary Eq #32 #41)
+        (CallBinary Eq #34 #40)
+        (CallBinary Eq #57 (CallUnary CastInt16ToInt32 #58))
+        (CallBinary Eq #61 #65)
+        (CallBinary Eq #67 #69)
+        (CallBinary Eq #70 ("EUROPE" String))
+        (CallBinary Gte (CallUnary CastDateToTimestamp #26) ("2007-01-02
+        00:00:00" Timestamp))
+        ])
+    [#66]
+    [(SumNumeric #38 false)]
+    false
+    null)
 ----
 ----
 %0 =
@@ -92,5 +96,7 @@ build
 | Join %0 %1 %2 %3 %4 %5 %6
 | | implementation = Unimplemented
 | Filter (#0 = #25), (#1 = #23), (#2 = #24), (#21 = i16toi32(#61)), (#22 = #30), (#23 = #31), (#24 = #32), (#32 = #41), (#34 = #40), (#57 = i16toi32(#58)), (#61 = #65), (#67 = #69), (#70 = "EUROPE"), (datetots(#26) >= 2007-01-02 00:00:00)
+| Reduce group=(#66)
+| | agg sum(#38)
 ----
 ----

--- a/src/expr/src/explain.rs
+++ b/src/expr/src/explain.rs
@@ -233,22 +233,13 @@ impl<'a> ViewExplanation<'a> {
                 writeln!(f, "| Project {}", bracketed("(", ")", Indices(outputs)))?
             }
             Map { scalars, .. } => writeln!(f, "| Map {}", separated(", ", scalars))?,
-            FlatMap {
-                func,
-                exprs,
-                demand,
-                ..
-            } => {
+            FlatMap { func, exprs, .. } => {
                 writeln!(f, "| FlatMap {}({})", func, separated(", ", exprs))?;
-                if let Some(demand) = demand {
-                    writeln!(f, "| | demand = {}", bracketed("(", ")", Indices(demand)))?;
-                }
             }
             Filter { predicates, .. } => writeln!(f, "| Filter {}", separated(", ", predicates))?,
             Join {
                 inputs,
                 equivalences,
-                demand,
                 implementation,
             } => {
                 write!(
@@ -278,9 +269,6 @@ impl<'a> ViewExplanation<'a> {
                 writeln!(f)?;
                 write!(f, "| | implementation = ")?;
                 self.fmt_join_implementation(f, inputs, implementation)?;
-                if let Some(demand) = demand {
-                    writeln!(f, "| | demand = {}", bracketed("(", ")", Indices(demand)))?;
-                }
             }
             Reduce {
                 group_key,

--- a/src/transform/src/column_knowledge.rs
+++ b/src/transform/src/column_knowledge.rs
@@ -98,12 +98,7 @@ impl ColumnKnowledge {
                 }
                 input_knowledge
             }
-            MirRelationExpr::FlatMap {
-                input,
-                func,
-                exprs,
-                demand: _,
-            } => {
+            MirRelationExpr::FlatMap { input, func, exprs } => {
                 let mut input_knowledge =
                     ColumnKnowledge::harvest(input, knowledge, knowledge_stack)?;
                 let input_typ = input.typ();

--- a/src/transform/src/demand.rs
+++ b/src/transform/src/demand.rs
@@ -126,11 +126,7 @@ impl Demand {
                 input,
                 func: _,
                 exprs,
-                demand,
             } => {
-                let mut sorted = columns.iter().cloned().collect::<Vec<_>>();
-                sorted.sort_unstable();
-                *demand = Some(sorted);
                 // A FlatMap which returns zero rows acts like a filter
                 // so we always need to execute it
                 for expr in exprs {
@@ -150,7 +146,6 @@ impl Demand {
             MirRelationExpr::Join {
                 inputs,
                 equivalences,
-                demand: _,
                 implementation: _,
             } => {
                 let input_mapper = JoinInputMapper::new(inputs);

--- a/src/transform/src/fusion/join.rs
+++ b/src/transform/src/fusion/join.rs
@@ -190,7 +190,6 @@ impl JoinBuilder {
             _ => MirRelationExpr::Join {
                 inputs: self.inputs,
                 equivalences: self.equivalences,
-                demand: None,
                 implementation: expr::JoinImplementation::Unimplemented,
             },
         };

--- a/src/transform/src/join_implementation.rs
+++ b/src/transform/src/join_implementation.rs
@@ -208,7 +208,6 @@ mod delta_queries {
         if let MirRelationExpr::Join {
             inputs,
             equivalences,
-            demand: _,
             implementation,
         } = &mut new_join
         {
@@ -277,7 +276,6 @@ mod differential {
         if let MirRelationExpr::Join {
             inputs,
             equivalences,
-            demand: _,
             implementation,
         } = &mut new_join
         {

--- a/src/transform/src/map_lifting.rs
+++ b/src/transform/src/map_lifting.rs
@@ -340,12 +340,7 @@ impl LiteralLifting {
 
                 result
             }
-            MirRelationExpr::FlatMap {
-                input,
-                func,
-                exprs,
-                demand: _,
-            } => {
+            MirRelationExpr::FlatMap { input, func, exprs } => {
                 let literals = self.action(input, gets);
                 if !literals.is_empty() {
                     let input_arity = input.arity();
@@ -389,7 +384,6 @@ impl LiteralLifting {
             MirRelationExpr::Join {
                 inputs,
                 equivalences,
-                demand,
                 implementation,
             } => {
                 // before lifting, save the original shape of the inputs
@@ -418,7 +412,6 @@ impl LiteralLifting {
                 }
 
                 if input_literals.iter().any(|l| !l.is_empty()) {
-                    *demand = None;
                     *implementation = expr::JoinImplementation::Unimplemented;
 
                     // We should be able to install any literals in the

--- a/src/transform/src/nonnull_requirements.rs
+++ b/src/transform/src/nonnull_requirements.rs
@@ -111,12 +111,7 @@ impl NonNullRequirements {
                     self.action(input, columns, gets);
                 }
             }
-            MirRelationExpr::FlatMap {
-                input,
-                func,
-                exprs,
-                demand: _,
-            } => {
+            MirRelationExpr::FlatMap { input, func, exprs } => {
                 // Columns whose number is smaller than arity refer to
                 // columns of `input`. Columns whose number is
                 // greater than or equal to the arity refer to columns created

--- a/src/transform/src/projection_pushdown.rs
+++ b/src/transform/src/projection_pushdown.rs
@@ -144,12 +144,7 @@ impl ProjectionPushdown {
 
                 columns_to_pushdown.into_iter().collect()
             }
-            MirRelationExpr::FlatMap {
-                input,
-                func,
-                exprs,
-                demand: _,
-            } => {
+            MirRelationExpr::FlatMap { input, func, exprs } => {
                 let inner_arity = input.arity();
                 // A FlatMap which returns zero rows acts like a filter
                 // so we always need to execute it

--- a/src/transform/src/reduction.rs
+++ b/src/transform/src/reduction.rs
@@ -183,12 +183,7 @@ impl FoldConstants {
                     };
                 }
             }
-            MirRelationExpr::FlatMap {
-                input,
-                func,
-                exprs,
-                demand: _,
-            } => {
+            MirRelationExpr::FlatMap { input, func, exprs } => {
                 let input_typ = input_types.first().unwrap();
                 for expr in exprs.iter_mut() {
                     expr.reduce(input_typ);

--- a/src/transform/src/redundant_join.rs
+++ b/src/transform/src/redundant_join.rs
@@ -90,7 +90,6 @@ impl RedundantJoin {
             MirRelationExpr::Join {
                 inputs,
                 equivalences,
-                demand,
                 implementation,
             } => {
                 // This logic first applies what it has learned about its input provenance,
@@ -169,8 +168,7 @@ impl RedundantJoin {
                     }
                     expr::canonicalize::canonicalize_equivalences(equivalences, &input_types);
 
-                    // Unset demand and implementation, as irrevocably hosed by this transformation.
-                    *demand = None;
+                    // Unset implementation, as irrevocably hosed by this transformation.
                     *implementation = expr::JoinImplementation::Unimplemented;
 
                     *relation = relation.take_dangerous().project(projection);

--- a/src/transform/tests/testdata/steps
+++ b/src/transform/tests/testdata/steps
@@ -120,35 +120,35 @@ steps in=json format=test
 {"Filter":{"input":{"Join":{"inputs":[{"Get":{"id":{"Global":{"User":1}},"typ":{"column_types":[{"scalar_type":"Int64","nullable":true},{"scalar_type":"Int64","nullable":true}],"keys":[]}}},{"Get":{"id":{"Global":{"User":0}},"typ":{"column_types":[{"scalar_type":"Bool","nullable":true},{"scalar_type":"Bool","nullable":true}],"keys":[]}}}],"equivalences":[],"demand":null,"implementation":"Unimplemented"}},"predicates":[{"CallBinary":{"func":"Or","expr1":{"CallBinary":{"func":"And","expr1":{"CallUnary":{"func":{"IsNull":null},"expr":{"Column":0}}},"expr2":{"CallUnary":{"func":{"IsNull":null},"expr":{"Column":2}}}}},"expr2":{"CallBinary":{"func":"Eq","expr1":{"Column":0},"expr2":{"CallBinary":{"func":"AddInt64","expr1":{"Column":2},"expr2":{"Literal":[{"Ok":{"data":[5,1,0,0,0,0,0,0,0]}},{"scalar_type":"Int64","nullable":false}]}}}}}}}]}}
 ----
 ----
-(Filter (Join [(get u1) (get x)] [] null Unimplemented) [(CallBinary Or (CallBinary And (CallUnary (IsNull ) #0) (CallUnary (IsNull ) #2)) (CallBinary Eq #0 (CallBinary AddInt64 #2 (1 Int64))))])
+(Filter (Join [(get u1) (get x)] [] Unimplemented) [(CallBinary Or (CallBinary And (CallUnary (IsNull ) #0) (CallUnary (IsNull ) #2)) (CallBinary Eq #0 (CallBinary AddInt64 #2 (1 Int64))))])
 
 ====
 No change: TopKElision, NonNullRequirements, Fixpoint { transforms: [FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting, Map, Negate, Filter, Project, Join, InlineLet { inline_mfp: false }, Reduce, Union, UnionBranchCancellation, UpdateLet, RedundantJoin, FoldConstants { limit: Some(10000) }] }], limit: 100 }
 ====
 Applied Fixpoint { transforms: [PredicatePushdown, NonNullable, ColumnKnowledge, Demand, FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting, Map, Negate, Filter, Project, Join, InlineLet { inline_mfp: false }, Reduce, Union, UnionBranchCancellation, UpdateLet, RedundantJoin, FoldConstants { limit: Some(10000) }] }], limit: 100 }:
-(Join [(get u1) (get x)] [[#0 (CallBinary AddInt64 #2 (1 Int64))]] null Unimplemented)
+(Join [(get u1) (get x)] [[#0 (CallBinary AddInt64 #2 (1 Int64))]] Unimplemented)
 
 ====
 No change: Fixpoint { transforms: [ReductionPushdown, ReduceElision, LiteralLifting, RelationCSE, InlineLet { inline_mfp: false }, UpdateLet, FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting, Map, Negate, Filter, Project, Join, InlineLet { inline_mfp: false }, Reduce, Union, UnionBranchCancellation, UpdateLet, RedundantJoin, FoldConstants { limit: Some(10000) }] }], limit: 100 }, ProjectionPushdown, UpdateLet, Map, Fixpoint { transforms: [Join, RedundantJoin, Project, Union, UnionBranchCancellation, RelationCSE, InlineLet { inline_mfp: true }], limit: 100 }
 ====
 Applied Fixpoint { transforms: [JoinImplementation, ColumnKnowledge, FoldConstants { limit: Some(10000) }, Demand, LiteralLifting], limit: 100 }:
-(Join [(ArrangeBy (get u1) [[#0]]) (get x)] [[#0 (CallBinary AddInt64 #2 (1 Int64))]] null (Differential [1 null] [[0 [#0]]]))
+(Join [(ArrangeBy (get u1) [[#0]]) (get x)] [[#0 (CallBinary AddInt64 #2 (1 Int64))]] (Differential [1 null] [[0 [#0]]]))
 
 ====
 No change: ReductionPushdown, CanonicalizeMfp
 ====
 Applied RelationCSE:
-(let l0 (get u1) (let l1 (ArrangeBy (get l0) [[#0]]) (let l2 (get x) (let l3 (Join [(get l1) (get l2)] [[#0 (CallBinary AddInt64 #2 (1 Int64))]] null (Differential [1 null] [[0 [#0]]])) (get l3)))))
+(let l0 (get u1) (let l1 (ArrangeBy (get l0) [[#0]]) (let l2 (get x) (let l3 (Join [(get l1) (get l2)] [[#0 (CallBinary AddInt64 #2 (1 Int64))]] (Differential [1 null] [[0 [#0]]])) (get l3)))))
 
 ====
 Applied InlineLet { inline_mfp: false }:
-(Join [(ArrangeBy (get u1) [[#0]]) (get x)] [[#0 (CallBinary AddInt64 #2 (1 Int64))]] null (Differential [1 null] [[0 [#0]]]))
+(Join [(ArrangeBy (get u1) [[#0]]) (get x)] [[#0 (CallBinary AddInt64 #2 (1 Int64))]] (Differential [1 null] [[0 [#0]]]))
 
 ====
 No change: UpdateLet, FoldConstants { limit: Some(10000) }
 ====
 Final:
-(Join [(ArrangeBy (get u1) [[#0]]) (get x)] [[#0 (CallBinary AddInt64 #2 (1 Int64))]] null (Differential [1 null] [[0 [#0]]]))
+(Join [(ArrangeBy (get u1) [[#0]]) (get x)] [[#0 (CallBinary AddInt64 #2 (1 Int64))]] (Differential [1 null] [[0 [#0]]]))
 
 ====
 ====
@@ -177,6 +177,6 @@ build format=json
     ]
 )
 ----
-{"Filter":{"input":{"Join":{"inputs":[{"Get":{"id":{"Global":{"User":1}},"typ":{"column_types":[{"scalar_type":"Int64","nullable":true},{"scalar_type":"Int64","nullable":true}],"keys":[]}}},{"Get":{"id":{"Global":{"User":0}},"typ":{"column_types":[{"scalar_type":"Bool","nullable":true},{"scalar_type":"Bool","nullable":true}],"keys":[]}}}],"equivalences":[],"demand":null,"implementation":"Unimplemented"}},"predicates":[{"CallBinary":{"func":"Or","expr1":{"CallBinary":{"func":"And","expr1":{"CallUnary":{"func":{"IsNull":null},"expr":{"Column":0}}},"expr2":{"CallUnary":{"func":{"IsNull":null},"expr":{"Column":2}}}}},"expr2":{"CallBinary":{"func":"Eq","expr1":{"Column":0},"expr2":{"CallBinary":{"func":"AddInt64","expr1":{"Column":2},"expr2":{"Literal":[{"Ok":{"data":[5,1,0,0,0,0,0,0,0]}},{"scalar_type":"Int64","nullable":false}]}}}}}}}]}}
+{"Filter":{"input":{"Join":{"inputs":[{"Get":{"id":{"Global":{"User":1}},"typ":{"column_types":[{"scalar_type":"Int64","nullable":true},{"scalar_type":"Int64","nullable":true}],"keys":[]}}},{"Get":{"id":{"Global":{"User":0}},"typ":{"column_types":[{"scalar_type":"Bool","nullable":true},{"scalar_type":"Bool","nullable":true}],"keys":[]}}}],"equivalences":[],"implementation":"Unimplemented"}},"predicates":[{"CallBinary":{"func":"Or","expr1":{"CallBinary":{"func":"And","expr1":{"CallUnary":{"func":{"IsNull":null},"expr":{"Column":0}}},"expr2":{"CallUnary":{"func":{"IsNull":null},"expr":{"Column":2}}}}},"expr2":{"CallBinary":{"func":"Eq","expr1":{"Column":0},"expr2":{"CallBinary":{"func":"AddInt64","expr1":{"Column":2},"expr2":{"Literal":[{"Ok":{"data":[5,1,0,0,0,0,0,0,0]}},{"scalar_type":"Int64","nullable":false}]}}}}}}}]}}
 
 ## #endregion

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -215,7 +215,6 @@ EXPLAIN PLAN FOR SELECT * FROM x, generate_series(1, 10)
 %0 =
 | Get materialize.public.x (u3)
 | FlatMap generate_series(1, 10, 1)
-| | demand = (#0..#2)
 
 EOF
 
@@ -225,7 +224,6 @@ EXPLAIN PLAN FOR SELECT * FROM x, generate_series(1, a)
 %0 =
 | Get materialize.public.x (u3)
 | FlatMap generate_series(1, #0, 1)
-| | demand = (#0..#2)
 
 EOF
 
@@ -245,7 +243,6 @@ EXPLAIN PLAN FOR SELECT * FROM x x1, x x2, generate_series(x1.a, x2.a) WHERE x1.
 | | implementation = Differential %0 %1.(#1)
 | Project (#0..#2)
 | FlatMap generate_series(#0, #2, 1)
-| | demand = (#0..#3)
 | Project (#0..#2, #1, #3)
 
 EOF
@@ -266,7 +263,6 @@ EXPLAIN PLAN FOR SELECT * FROM x x1, x x2, generate_series(x1.a, x2.a) WHERE x1.
 | | implementation = Differential %0 %1.(#1)
 | Project (#0..#2)
 | FlatMap generate_series(#0, #2, 1)
-| | demand = (#0..#3)
 | Project (#0..#2, #1, #3)
 
 EOF
@@ -289,7 +285,6 @@ EXPLAIN PLAN FOR SELECT * FROM x x1, x x2, generate_series(x1.a, x2.b) AS x3(b) 
 | | implementation = Differential %0 %1.(#1)
 | Project (#0..#2)
 | FlatMap generate_series(#0, #1, 1)
-| | demand = (#0..#3)
 | Filter (#0 = #3)
 | Project (#0..#2, #1, #3)
 

--- a/test/sqllogictest/transform/lifting.slt
+++ b/test/sqllogictest/transform/lifting.slt
@@ -298,7 +298,6 @@ explain select * from (select 1 as a from t), generate_series(a+1, 4);
 | Get materialize.public.t (u1)
 | Project ()
 | FlatMap generate_series(2, 4, 1)
-| | demand = (#0)
 | Map 1
 | Project (#1, #0)
 


### PR DESCRIPTION
### Motivation

Followup task for #7864. 

### Description

Removes the demand field from `MirRelationExpr::Join` and `MirRelationExpr::FlatMap`, as projection pushdown has made them unnecessary.

### Tips for reviewer

It's ok to remove the demand from the FlatMaps in `test/sqllogictest/table_func.slt` without replacing it with a Project because all columns are demanded.

### (EDIT: Formerly) Open questions

> Should the demand field be removed from design docs containing example Join/FlatMap plans? Should the description of how demand works be removed from the [developer docs](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/arrangements.md#caveats-demand-analysis)?

People on our company slack said
* they preferred to keep a record of what demand used to do
* the demand field should not be removed from past design docs.

### Current open questions

Does this need a release note?

### Checklist

- [ ] This PR has adequate test coverage.
   Tests currently pass, so I should have properly removed all the demand fields.

No release note since EXPLAIN is not part of the stable interace.
