### PR TITLE
sql-parser: allow keywords in field access expressions

### DIFF
--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1014,6 +1014,12 @@ impl<'a> Parser<'a> {
                     expr: Box::new(expr),
                     field: Ident::new(id),
                 }),
+                // Per PostgreSQL, even reserved keywords are ok after a field
+                // access operator.
+                Some(Token::Keyword(kw)) => Ok(Expr::FieldAccess {
+                    expr: Box::new(expr),
+                    field: kw.into_ident(),
+                }),
                 Some(Token::Star) => Ok(Expr::WildcardAccess(Box::new(expr))),
                 unexpected => self.expected(
                     self.peek_prev_pos(),

--- a/src/sql-parser/tests/testdata/scalar
+++ b/src/sql-parser/tests/testdata/scalar
@@ -472,6 +472,16 @@ parse-scalar
 FieldAccess { expr: Nested(Identifier([Ident("x")])), field: Ident("a") }
 
 parse-scalar
+(x).order
+----
+FieldAccess { expr: Nested(Identifier([Ident("x")])), field: Ident("order") }
+
+parse-scalar
+(x).date
+----
+FieldAccess { expr: Nested(Identifier([Ident("x")])), field: Ident("date") }
+
+parse-scalar
 (x).a.b.c
 ----
 FieldAccess { expr: FieldAccess { expr: FieldAccess { expr: Nested(Identifier([Ident("x")])), field: Ident("a") }, field: Ident("b") }, field: Ident("c") }


### PR DESCRIPTION
### Motivation

This PR fixes a recognized bug. #8278

### Description

Per PostgreSQL, even reserved keywords are acceptable after a field
access operator.

### Checklist

- [x] This PR has adequate test coverage.
- [ ] This PR adds a release note for any user-facing behavior changes.
