### PR TITLE
Explain: Fix demand propagation.

### DIFF
--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -185,11 +185,21 @@ fn optimize_dataflow_demand(dataflow: &mut DataflowDesc) {
             .extend(0..dataflow.arity_of(&input_id));
     }
 
-    // Propagate demand information from outputs to inputs.
     for build_desc in dataflow.objects_to_build.iter_mut().rev() {
         let transform = crate::demand::Demand;
         if let Some(columns) = demand.get(&Id::Global(build_desc.id)).clone() {
+            // Propagate demand information from outputs to inputs.
             transform.action(build_desc.view.as_inner_mut(), columns.clone(), &mut demand);
+        } else if dataflow.index_exports.is_empty() && dataflow.sink_exports.is_empty() {
+            // If there are no outputs (which happens if we just want to build
+            // a plan explanation), then demand all columns from views that are
+            // not depended on by another view.
+            let arity = build_desc.view.arity();
+            transform.action(
+                build_desc.view.as_inner_mut(),
+                (0..arity).collect(),
+                &mut demand,
+            );
         }
     }
 

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -164,6 +164,10 @@ fn optimize_dataflow_relations(
 }
 
 /// Pushes demand information from published outputs to dataflow inputs.
+///
+/// Dataflows that exist for the sake of generating plan explanations do not
+/// have published outputs. In this case, we push demand information from views
+/// not depended on by other views to dataflow inputs.
 fn optimize_dataflow_demand(dataflow: &mut DataflowDesc) {
     let mut demand = HashMap::new();
 
@@ -190,7 +194,7 @@ fn optimize_dataflow_demand(dataflow: &mut DataflowDesc) {
         if let Some(columns) = demand.get(&Id::Global(build_desc.id)).clone() {
             // Propagate demand information from outputs to inputs.
             transform.action(build_desc.view.as_inner_mut(), columns.clone(), &mut demand);
-        } else if dataflow.index_exports.is_empty() && dataflow.sink_exports.is_empty() {
+        } else if build_desc.id == GlobalId::Explain {
             // If there are no outputs (which happens if we just want to build
             // a plan explanation), then demand all columns from views that are
             // not depended on by another view.

--- a/test/testdrive/source-linear-operators.td
+++ b/test/testdrive/source-linear-operators.td
@@ -44,7 +44,7 @@ Query:
 | Get materialize.public.data (UID)
 | Filter (#0 = 1)
 
-? EXPLAIN PLAN FOR SELECT b from data_view where b = 1 
+? EXPLAIN PLAN FOR SELECT b from data_view where b = 1
 Source materialize.public.data (UID):
 | Filter (#1 = 1)
 | Project (#1)

--- a/test/testdrive/source-linear-operators.td
+++ b/test/testdrive/source-linear-operators.td
@@ -34,5 +34,23 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
 
 $ set-regex match=u\d+ replacement=UID
 
-> EXPLAIN PLAN FOR SELECT * from data_view where a = 1
-"Source materialize.public.data (UID):\n| Filter (#0 = 1)\n| Project (#0, #1)\n\nQuery:\n%0 =\n| Get materialize.public.data (UID)\n| Filter (#0 = 1)\n"
+? EXPLAIN PLAN FOR SELECT * from data_view where a = 1
+Source materialize.public.data (UID):
+| Filter (#0 = 1)
+| Project (#0, #1)
+
+Query:
+%0 =
+| Get materialize.public.data (UID)
+| Filter (#0 = 1)
+
+? EXPLAIN PLAN FOR SELECT b from data_view where b = 1 
+Source materialize.public.data (UID):
+| Filter (#1 = 1)
+| Project (#1)
+
+Query:
+%0 =
+| Get materialize.public.data (UID)
+| Filter (#1 = 1)
+| Project (#1)


### PR DESCRIPTION
### Motivation

  * This PR fixes a previously unreported bug.

In the query below, only two columns from the source are being demanded, but our plan explanation is showing all 14 columns being demanded.
 
```
explain select route_id,
  CASE WHEN route_desc LIKE '%Bus'
    THEN route_short_name
    ELSE route_long_name
    END AS route_name from mbta_routes;
                 Optimized Plan                 
------------------------------------------------
 Source materialize.public.mbta_routes (u3117):+
 | Filter                                      +
 | Project (#0..#13)                           +
                                               +
 Query:                                        +
 %0 =                                          +
 | Get materialize.public.mbta_routes (u3117)  +
 | Map if "^.*Bus$" ~(#4) then {#2} else {#3}  +
 | Project (#0, #14)                           +
```

It turns out that if you were to create a materialized view based on the query, the demand propagates to the source fine, so the problem is entirely in the explain code.

The bug is caused by the fact that to generate an explanation, we create a dummy dataflow with no exports. `optimize_dataflow_demand` propagates demands from the exports to the imports, so the lack of exports means no demand gets propagated in the dummy dataflow.

### Description

In this PR, I have chosen to fix the issue by propagating demand from all independent views in the dataflow to the imports when a dataflow has no exports.

An alternative way of fixing the bug would be to add a dummy export to the dummy dataflow that points at the view we are trying to explain, but it seemed onerous. It would be necessary to either bypass registering the dummy export with the catalog or ensure that the dummy export is removed after the explanation is generated.

### Checklist

- [x] This PR has adequate test coverage.
- [ ] This PR adds a release note for any user-facing behavior changes.
