### PR TITLE
coord: use all indexes per id in timestamp determination

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -2171,8 +2171,10 @@ impl Catalog {
                 return;
             }
 
-            if let Some((index_id, _)) = catalog.enabled_indexes[&id].first() {
-                indexes.push(*index_id);
+            // Include all indexes on an id so the dataflow builder can safely use any
+            // of them.
+            if !catalog.enabled_indexes[&id].is_empty() {
+                indexes.extend(catalog.enabled_indexes[&id].iter().map(|(id, _)| id));
                 return;
             }
 

--- a/test/testdrive/github-8241.td
+++ b/test/testdrive/github-8241.td
@@ -1,0 +1,44 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> CREATE TABLE t1 (f1 INTEGER, f2 INTEGER);
+
+> CREATE INDEX i1 ON t1 (f2);
+
+> CREATE VIEW v1 AS SELECT * FROM t1;
+
+$ postgres-connect name=conn1 url=postgres://materialize:materialize@${testdrive.materialized-addr}
+
+$ postgres-connect name=conn2 url=postgres://materialize:materialize@${testdrive.materialized-addr}
+
+$ postgres-execute connection=conn1
+BEGIN;
+SELECT * FROM v1;
+
+$ postgres-execute connection=conn2
+BEGIN;
+SELECT * FROM v1;
+
+$ postgres-execute connection=conn1
+SELECT * FROM v1;
+
+$ postgres-execute connection=conn2
+SELECT * FROM v1;
+
+$ postgres-execute connection=conn1
+SELECT * FROM v1;
+
+$ postgres-execute connection=conn2
+SELECT * FROM v1;
+
+$ postgres-execute connection=conn1
+SELECT * FROM v1;
+
+$ postgres-execute connection=conn2
+SELECT * FROM v1;


### PR DESCRIPTION
### Motivation

This PR fixes a recognized bug. #8241

### Description

Previously determine_timestamp would only use the first index per
id. If there were multiple indexes with different sinces, and the
second (not included) index had a higher since, it would not bump the
timestamp forward to that later since. Then later on if the non-fast path
branch of sequence_peek was taken, the dataflow builder would import
both indexes. When ship_dataflow saw that, it would panic because the
requested timestamp was before one of the imported indexes.

This was easily triggerable if a transaction was started which would
prevent compaction of the first index, but not of the second. Further
statements in the transaction could then use an index that had not had
its compaction held back.

Fix this by including all indexes from an id.

### Checklist

- [x] This PR has adequate test coverage.
- [x] This PR adds a release note for any user-facing behavior changes.
