### PR TITLE
doc: update CREATE SINK details

### DIFF
--- a/doc/user/content/sql/create-sink.md
+++ b/doc/user/content/sql/create-sink.md
@@ -29,6 +29,8 @@ Field | Use
 _sink&lowbar;name_ | A name for the sink. This name is only used within Materialize.
 _item&lowbar;name_ | The name of the source or view you want to send to the sink.
 **AVRO OCF** _path_ | The absolute path and file name of the Avro Object Container file (OCF) to create and write to. The filename will be modified to let Materialize create a unique file each time Materialize starts, but the file extension will not be modified. You can find more details [here](#avro-ocf-sinks).
+**WITH (** _option&lowbar;list_ **)** | Options affecting sink creation. For more detail, see [`WITH` options](#with-options).
+**FORMAT** _sink&lowbar;format&lowbar;spec_ | The data format of the sink. For more detail, see [`FORMAT`](#format).
 **ENVELOPE DEBEZIUM** | The generated schemas have a [Debezium-style diff envelope](#debezium-envelope-details) to capture changes in the input view or source. This is the default.
 **ENVELOPE UPSERT** | The sink emits data with upsert semantics: updates and inserts for the given key are expressed as a value, and deletes are expressed as a null value payload in Kafka. For more detail, see [Upsert source details](/sql/create-source/text-kafka/#upsert-envelope-details).
 
@@ -47,8 +49,17 @@ Field | Use
 **KEY (** _key&lowbar;column&lowbar;list_ **)** | An optional list of columns to use for the Kafka key. If unspecified, the Kafka key is left unset. {{< version-added v0.5.1 />}}
 **CONSISTENCY TOPIC** _consistency&lowbar;topic_ | Makes the sink emit additional [consistency metadata](#consistency-metadata) to the named topic. Only valid for Kafka sinks. If `reuse_topic` is `true`, a default consistency_topic will be used when not explicitly set. The default consistency topic name is formed by appending `-consistency` to the output topic name. {{< version-added v0.8.4 />}}
 **CONSISTENCY FORMAT** _format_ | The format of the Kafka consistency topic. Defaults to the format of the sink if not provided. {{< version-added v0.8.4 />}}
-**WITH OPTIONS (** _option&lowbar;_ **)** | Options affecting sink creation. For more details see [`WITH` options](#with-options).
+**WITH (** _option&lowbar;list_ **)** | Options affecting Materialize's connection to Kafka. For more detail, see [Kafka connector `WITH` options](#kafka-connector-with-options).
 **CONFLUENT SCHEMA REGISTRY** _url_ | The URL of the Confluent schema registry to get schema information from.
+
+### Kafka connector `WITH` options
+
+The following options are valid within the Kafka connector's `WITH` clause.
+
+Field                | Value type | Description
+---------------------|------------|------------
+`username `          | `text`     | The Kafka username.
+`password `          | `text`     | The Kafka password.
 
 ### `WITH` options
 
@@ -95,6 +106,12 @@ the environment variable's presence to boot Materialize.
 `sasl_kerberos_principal` | `text` | Materialize Kerberos principal name. Required if `sasl_mechanisms` is `GSSAPI`.
 `sasl_kerberos_service_name` | `text` | Kafka's service name on its host, i.e. the service principal name not including `/hostname@REALM`. Required if `sasl_mechanisms` is `GSSAPI`.
 
+### `FORMAT`
+
+The data format of the emitted records.
+
+{{< diagram "sink-format-spec.svg" >}}
+
 ### `WITH SNAPSHOT` or `WITHOUT SNAPSHOT`
 
 By default, each `SINK` is created with a `SNAPSHOT` which contains the consolidated results of the
@@ -103,7 +120,7 @@ they occur. To only see results after the sink is created, specify `WITHOUT SNAP
 
 ## Detail
 
-- Materialize currently only supports the following sinks:
+- Materialize currently only supports the following [sink formats](#format):
     - Avro-formatted sinks that write to either a topic or an Avro object container file.
     - JSON-formatted sinks that write to a topic.
 - For most sinks, Materialize creates new, distinct topics and files for each sink on restart.

--- a/doc/user/layouts/partials/sql-grammar/create-sink.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-sink.svg
@@ -1,100 +1,157 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="571" height="309">
-   <polygon points="11 17 3 13 3 21"/>
-   <polygon points="19 17 11 13 11 21"/>
-   <rect x="33" y="3" width="114" height="32" rx="10"/>
-   <rect x="31"
+<svg xmlns="http://www.w3.org/2000/svg" width="611" height="549">
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="114" height="32" rx="10"/>
+   <rect x="29"
          y="1"
          width="114"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="41" y="21">CREATE SINK</text>
-   <rect x="187" y="35" width="120" height="32" rx="10"/>
-   <rect x="185"
+   <text class="terminal" x="39" y="21">CREATE SINK</text>
+   <rect x="185" y="35" width="120" height="32" rx="10"/>
+   <rect x="183"
          y="33"
          width="120"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="195" y="53">IF NOT EXISTS</text>
-   <rect x="347" y="3" width="88" height="32"/>
-   <rect x="345" y="1" width="88" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="355" y="21">sink_name</text>
-   <rect x="455" y="3" width="60" height="32" rx="10"/>
-   <rect x="453"
+   <text class="terminal" x="193" y="53">IF NOT EXISTS</text>
+   <rect x="345" y="3" width="88" height="32"/>
+   <rect x="343" y="1" width="88" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="353" y="21">sink_name</text>
+   <rect x="453" y="3" width="60" height="32" rx="10"/>
+   <rect x="451"
          y="1"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="463" y="21">FROM</text>
-   <rect x="72" y="101" width="90" height="32"/>
-   <rect x="70" y="99" width="90" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="80" y="119">item_name</text>
-   <rect x="182" y="101" width="54" height="32" rx="10"/>
-   <rect x="180"
+   <text class="terminal" x="461" y="21">FROM</text>
+   <rect x="113" y="101" width="90" height="32"/>
+   <rect x="111" y="99" width="90" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="121" y="119">item_name</text>
+   <rect x="223" y="101" width="54" height="32" rx="10"/>
+   <rect x="221"
          y="99"
          width="54"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="190" y="119">INTO</text>
-   <rect x="276" y="101" width="162" height="32"/>
-   <rect x="274" y="99" width="162" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="284" y="119">sink_kafka_connector</text>
-   <rect x="276" y="145" width="94" height="32" rx="10"/>
-   <rect x="274"
+   <text class="terminal" x="231" y="119">INTO</text>
+   <rect x="317" y="101" width="162" height="32"/>
+   <rect x="315" y="99" width="162" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="325" y="119">sink_kafka_connector</text>
+   <rect x="317" y="145" width="94" height="32" rx="10"/>
+   <rect x="315"
          y="143"
          width="94"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="284" y="163">AVRO OCF</text>
-   <rect x="390" y="145" width="94" height="32"/>
-   <rect x="388" y="143" width="94" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="398" y="163">path-prefix</text>
-   <rect x="45" y="231" width="94" height="32" rx="10"/>
+   <text class="terminal" x="325" y="163">AVRO OCF</text>
+   <rect x="431" y="145" width="50" height="32"/>
+   <rect x="429" y="143" width="50" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="439" y="163">path</text>
+   <rect x="45" y="255" width="58" height="32" rx="10"/>
    <rect x="43"
-         y="229"
+         y="253"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="273">WITH</text>
+   <rect x="123" y="255" width="26" height="32" rx="10"/>
+   <rect x="121"
+         y="253"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="131" y="273">(</text>
+   <rect x="189" y="255" width="104" height="32"/>
+   <rect x="187" y="253" width="104" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="197" y="273">option_name</text>
+   <rect x="333" y="287" width="28" height="32" rx="10"/>
+   <rect x="331"
+         y="285"
+         width="28"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="341" y="305">=</text>
+   <rect x="381" y="287" width="102" height="32"/>
+   <rect x="379" y="285" width="102" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="389" y="305">option_value</text>
+   <rect x="189" y="211" width="24" height="32" rx="10"/>
+   <rect x="187"
+         y="209"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="197" y="229">,</text>
+   <rect x="543" y="255" width="26" height="32" rx="10"/>
+   <rect x="541"
+         y="253"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="551" y="273">)</text>
+   <rect x="190" y="385" width="80" height="32" rx="10"/>
+   <rect x="188"
+         y="383"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="198" y="403">FORMAT</text>
+   <rect x="290" y="385" width="134" height="32"/>
+   <rect x="288" y="383" width="134" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="298" y="403">sink_format_spec</text>
+   <rect x="85" y="471" width="94" height="32" rx="10"/>
+   <rect x="83"
+         y="469"
          width="94"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="53" y="249">ENVELOPE</text>
-   <rect x="179" y="231" width="92" height="32" rx="10"/>
-   <rect x="177"
-         y="229"
+   <text class="terminal" x="93" y="489">ENVELOPE</text>
+   <rect x="219" y="471" width="92" height="32" rx="10"/>
+   <rect x="217"
+         y="469"
          width="92"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="187" y="249">DEBEZIUM</text>
-   <rect x="179" y="275" width="76" height="32" rx="10"/>
-   <rect x="177"
-         y="273"
+   <text class="terminal" x="227" y="489">DEBEZIUM</text>
+   <rect x="219" y="515" width="76" height="32" rx="10"/>
+   <rect x="217"
+         y="513"
          width="76"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="187" y="293">UPSERT</text>
-   <rect x="351" y="231" width="142" height="32" rx="10"/>
-   <rect x="349"
-         y="229"
+   <text class="terminal" x="227" y="533">UPSERT</text>
+   <rect x="391" y="471" width="142" height="32" rx="10"/>
+   <rect x="389"
+         y="469"
          width="142"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="359" y="249">WITH SNAPSHOT</text>
-   <rect x="351" y="275" width="172" height="32" rx="10"/>
-   <rect x="349"
-         y="273"
+   <text class="terminal" x="399" y="489">WITH SNAPSHOT</text>
+   <rect x="391" y="515" width="172" height="32" rx="10"/>
+   <rect x="389"
+         y="513"
          width="172"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="359" y="293">WITHOUT SNAPSHOT</text>
+   <text class="terminal" x="399" y="533">WITHOUT SNAPSHOT</text>
    <path class="line"
-         d="m19 17 h2 m0 0 h10 m114 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m88 0 h10 m0 0 h10 m60 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-487 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m90 0 h10 m0 0 h10 m54 0 h10 m20 0 h10 m162 0 h10 m0 0 h46 m-248 0 h20 m228 0 h20 m-268 0 q10 0 10 10 m248 0 q0 -10 10 -10 m-258 10 v24 m248 0 v-24 m-248 24 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m94 0 h10 m0 0 h10 m94 0 h10 m22 -44 l2 0 m2 0 l2 0 m2 0 l2 0 m-523 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h256 m-286 0 h20 m266 0 h20 m-306 0 q10 0 10 10 m286 0 q0 -10 10 -10 m-296 10 v12 m286 0 v-12 m-286 12 q0 10 10 10 m266 0 q10 0 10 -10 m-276 10 h10 m94 0 h10 m20 0 h10 m92 0 h10 m-132 0 h20 m112 0 h20 m-152 0 q10 0 10 10 m132 0 q0 -10 10 -10 m-142 10 v24 m132 0 v-24 m-132 24 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m76 0 h10 m0 0 h16 m60 -76 h10 m0 0 h182 m-212 0 h20 m192 0 h20 m-232 0 q10 0 10 10 m212 0 q0 -10 10 -10 m-222 10 v12 m212 0 v-12 m-212 12 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m142 0 h10 m0 0 h30 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m172 0 h10 m23 -76 h-3"/>
-   <polygon points="561 213 569 209 569 217"/>
-   <polygon points="561 213 553 209 553 217"/>
+         d="m17 17 h2 m0 0 h10 m114 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m88 0 h10 m0 0 h10 m60 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-444 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m90 0 h10 m0 0 h10 m54 0 h10 m20 0 h10 m162 0 h10 m0 0 h2 m-204 0 h20 m184 0 h20 m-224 0 q10 0 10 10 m204 0 q0 -10 10 -10 m-214 10 v24 m204 0 v-24 m-204 24 q0 10 10 10 m184 0 q10 0 10 -10 m-194 10 h10 m94 0 h10 m0 0 h10 m50 0 h10 m22 -44 l2 0 m2 0 l2 0 m2 0 l2 0 m-520 154 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m104 0 h10 m20 0 h10 m0 0 h160 m-190 0 h20 m170 0 h20 m-210 0 q10 0 10 10 m190 0 q0 -10 10 -10 m-200 10 v12 m190 0 v-12 m-190 12 q0 10 10 10 m170 0 q10 0 10 -10 m-180 10 h10 m28 0 h10 m0 0 h10 m102 0 h10 m-334 -32 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m334 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-334 0 h10 m24 0 h10 m0 0 h290 m20 44 h10 m26 0 h10 m-564 0 h20 m544 0 h20 m-584 0 q10 0 10 10 m564 0 q0 -10 10 -10 m-574 10 v46 m564 0 v-46 m-564 46 q0 10 10 10 m544 0 q10 0 10 -10 m-554 10 h10 m0 0 h534 m22 -66 l2 0 m2 0 l2 0 m2 0 l2 0 m-463 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h244 m-274 0 h20 m254 0 h20 m-294 0 q10 0 10 10 m274 0 q0 -10 10 -10 m-284 10 v12 m274 0 v-12 m-274 12 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h10 m134 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-423 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h256 m-286 0 h20 m266 0 h20 m-306 0 q10 0 10 10 m286 0 q0 -10 10 -10 m-296 10 v12 m286 0 v-12 m-286 12 q0 10 10 10 m266 0 q10 0 10 -10 m-276 10 h10 m94 0 h10 m20 0 h10 m92 0 h10 m-132 0 h20 m112 0 h20 m-152 0 q10 0 10 10 m132 0 q0 -10 10 -10 m-142 10 v24 m132 0 v-24 m-132 24 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m76 0 h10 m0 0 h16 m60 -76 h10 m0 0 h182 m-212 0 h20 m192 0 h20 m-232 0 q10 0 10 10 m212 0 q0 -10 10 -10 m-222 10 v12 m212 0 v-12 m-212 12 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m142 0 h10 m0 0 h30 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m172 0 h10 m23 -76 h-3"/>
+   <polygon points="601 453 609 449 609 457"/>
+   <polygon points="601 453 593 449 593 457"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/sink-format-spec.svg
+++ b/doc/user/layouts/partials/sql-grammar/sink-format-spec.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="733" height="157">
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="51" y="3" width="110" height="32" rx="10"/>
+   <rect x="49"
+         y="1"
+         width="110"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="21">AVRO USING</text>
+   <rect x="201" y="3" width="246" height="32" rx="10"/>
+   <rect x="199"
+         y="1"
+         width="246"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="209" y="21">CONFLUENT SCHEMA REGISTRY</text>
+   <rect x="467" y="3" width="36" height="32"/>
+   <rect x="465" y="1" width="36" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="475" y="21">url</text>
+   <rect x="543" y="35" width="102" height="32"/>
+   <rect x="541" y="33" width="102" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="551" y="53">with_options</text>
+   <rect x="201" y="79" width="82" height="32" rx="10"/>
+   <rect x="199"
+         y="77"
+         width="82"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="209" y="97">SCHEMA</text>
+   <rect x="303" y="79" width="48" height="32" rx="10"/>
+   <rect x="301"
+         y="77"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="311" y="97">FILE</text>
+   <rect x="371" y="79" width="132" height="32"/>
+   <rect x="369" y="77" width="132" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="379" y="97">schema_file_path</text>
+   <rect x="51" y="123" width="58" height="32" rx="10"/>
+   <rect x="49"
+         y="121"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="141">JSON</text>
+   <path class="line"
+         d="m17 17 h2 m20 0 h10 m110 0 h10 m20 0 h10 m246 0 h10 m0 0 h10 m36 0 h10 m20 0 h10 m0 0 h112 m-142 0 h20 m122 0 h20 m-162 0 q10 0 10 10 m142 0 q0 -10 10 -10 m-152 10 v12 m142 0 v-12 m-142 12 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m102 0 h10 m-484 -32 h20 m484 0 h20 m-524 0 q10 0 10 10 m504 0 q0 -10 10 -10 m-514 10 v56 m504 0 v-56 m-504 56 q0 10 10 10 m484 0 q10 0 10 -10 m-494 10 h10 m82 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m132 0 h10 m0 0 h162 m-654 -76 h20 m654 0 h20 m-694 0 q10 0 10 10 m674 0 q0 -10 10 -10 m-684 10 v100 m674 0 v-100 m-674 100 q0 10 10 10 m654 0 q10 0 10 -10 m-664 10 h10 m58 0 h10 m0 0 h576 m23 -120 h-3"/>
+   <polygon points="723 17 731 13 731 21"/>
+   <polygon points="723 17 715 13 715 21"/>
+</svg>

--- a/doc/user/layouts/partials/sql-grammar/sink-kafka-connector.svg
+++ b/doc/user/layouts/partials/sql-grammar/sink-kafka-connector.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1099" height="485">
+<svg xmlns="http://www.w3.org/2000/svg" width="1099" height="435">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="130" height="32" rx="10"/>
@@ -112,46 +112,54 @@
    <rect x="1001" y="243" width="36" height="32"/>
    <rect x="999" y="241" width="36" height="32" class="nonterminal"/>
    <text class="nonterminal" x="1009" y="261">url</text>
-   <rect x="450" y="341" width="102" height="32"/>
-   <rect x="448" y="339" width="102" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="458" y="359">with_options</text>
-   <rect x="592" y="309" width="80" height="32" rx="10"/>
-   <rect x="590"
-         y="307"
-         width="80"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="600" y="327">FORMAT</text>
-   <rect x="619" y="407" width="110" height="32" rx="10"/>
-   <rect x="617"
-         y="405"
-         width="110"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="627" y="425">AVRO USING</text>
-   <rect x="749" y="407" width="246" height="32" rx="10"/>
-   <rect x="747"
-         y="405"
-         width="246"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="757" y="425">CONFLUENT SCHEMA REGISTRY</text>
-   <rect x="1015" y="407" width="36" height="32"/>
-   <rect x="1013" y="405" width="36" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="1023" y="425">url</text>
-   <rect x="619" y="451" width="58" height="32" rx="10"/>
-   <rect x="617"
-         y="449"
+   <rect x="527" y="353" width="58" height="32" rx="10"/>
+   <rect x="525"
+         y="351"
          width="58"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="627" y="469">JSON</text>
+   <text class="terminal" x="535" y="371">WITH</text>
+   <rect x="605" y="353" width="26" height="32" rx="10"/>
+   <rect x="603"
+         y="351"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="613" y="371">(</text>
+   <rect x="671" y="353" width="104" height="32"/>
+   <rect x="669" y="351" width="104" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="679" y="371">option_name</text>
+   <rect x="815" y="385" width="28" height="32" rx="10"/>
+   <rect x="813"
+         y="383"
+         width="28"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="823" y="403">=</text>
+   <rect x="863" y="385" width="102" height="32"/>
+   <rect x="861" y="383" width="102" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="871" y="403">option_value</text>
+   <rect x="671" y="309" width="24" height="32" rx="10"/>
+   <rect x="669"
+         y="307"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="679" y="327">,</text>
+   <rect x="1025" y="353" width="26" height="32" rx="10"/>
+   <rect x="1023"
+         y="351"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="1033" y="371">)</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m130 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m98 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-93 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m48 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m98 0 h10 m-138 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m118 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-118 0 h10 m24 0 h10 m0 0 h74 m20 44 h10 m26 0 h10 m-338 0 h20 m318 0 h20 m-358 0 q10 0 10 10 m338 0 q0 -10 10 -10 m-348 10 v14 m338 0 v-14 m-338 14 q0 10 10 10 m318 0 q10 0 10 -10 m-328 10 h10 m0 0 h308 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-739 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h1022 m-1052 0 h20 m1032 0 h20 m-1072 0 q10 0 10 10 m1052 0 q0 -10 10 -10 m-1062 10 v12 m1052 0 v-12 m-1052 12 q0 10 10 10 m1032 0 q10 0 10 -10 m-1042 10 h10 m122 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m52 0 h10 m20 0 h10 m0 0 h684 m-714 0 h20 m694 0 h20 m-734 0 q10 0 10 10 m714 0 q0 -10 10 -10 m-724 10 v12 m714 0 v-12 m-714 12 q0 10 10 10 m694 0 q10 0 10 -10 m-704 10 h10 m122 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m110 0 h10 m0 0 h10 m246 0 h10 m0 0 h10 m36 0 h10 m42 -64 l2 0 m2 0 l2 0 m2 0 l2 0 m-691 130 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h112 m-142 0 h20 m122 0 h20 m-162 0 q10 0 10 10 m142 0 q0 -10 10 -10 m-152 10 v12 m142 0 v-12 m-142 12 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m102 0 h10 m20 -32 h10 m80 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-117 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m110 0 h10 m0 0 h10 m246 0 h10 m0 0 h10 m36 0 h10 m-472 0 h20 m452 0 h20 m-492 0 q10 0 10 10 m472 0 q0 -10 10 -10 m-482 10 v24 m472 0 v-24 m-472 24 q0 10 10 10 m452 0 q10 0 10 -10 m-462 10 h10 m58 0 h10 m0 0 h374 m23 -44 h-3"/>
-   <polygon points="1089 421 1097 417 1097 425"/>
-   <polygon points="1089 421 1081 417 1081 425"/>
+         d="m17 17 h2 m0 0 h10 m130 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m98 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-93 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m48 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m98 0 h10 m-138 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m118 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-118 0 h10 m24 0 h10 m0 0 h74 m20 44 h10 m26 0 h10 m-338 0 h20 m318 0 h20 m-358 0 q10 0 10 10 m338 0 q0 -10 10 -10 m-348 10 v14 m338 0 v-14 m-338 14 q0 10 10 10 m318 0 q10 0 10 -10 m-328 10 h10 m0 0 h308 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-739 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h1022 m-1052 0 h20 m1032 0 h20 m-1072 0 q10 0 10 10 m1052 0 q0 -10 10 -10 m-1062 10 v12 m1052 0 v-12 m-1052 12 q0 10 10 10 m1032 0 q10 0 10 -10 m-1042 10 h10 m122 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m52 0 h10 m20 0 h10 m0 0 h684 m-714 0 h20 m694 0 h20 m-734 0 q10 0 10 10 m714 0 q0 -10 10 -10 m-724 10 v12 m714 0 v-12 m-714 12 q0 10 10 10 m694 0 q10 0 10 -10 m-704 10 h10 m122 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m110 0 h10 m0 0 h10 m246 0 h10 m0 0 h10 m36 0 h10 m42 -64 l2 0 m2 0 l2 0 m2 0 l2 0 m-614 174 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m104 0 h10 m20 0 h10 m0 0 h160 m-190 0 h20 m170 0 h20 m-210 0 q10 0 10 10 m190 0 q0 -10 10 -10 m-200 10 v12 m190 0 v-12 m-190 12 q0 10 10 10 m170 0 q10 0 10 -10 m-180 10 h10 m28 0 h10 m0 0 h10 m102 0 h10 m-334 -32 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m334 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-334 0 h10 m24 0 h10 m0 0 h290 m20 44 h10 m26 0 h10 m-564 0 h20 m544 0 h20 m-584 0 q10 0 10 10 m564 0 q0 -10 10 -10 m-574 10 v46 m564 0 v-46 m-564 46 q0 10 10 10 m544 0 q10 0 10 -10 m-554 10 h10 m0 0 h534 m23 -66 h-3"/>
+   <polygon points="1089 367 1097 363 1097 371"/>
+   <polygon points="1089 367 1081 363 1081 371"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -47,8 +47,10 @@ create_sink ::=
     'FROM' item_name
     'INTO' (
     sink_kafka_connector |
-    'AVRO OCF' path-prefix
+    'AVRO OCF' path
     )
+    ( 'WITH' '(' (option_name ('=' option_value)?) ( ',' (option_name ('=' option_value)?) )* ')' )?
+    ('FORMAT' sink_format_spec)?
     ('ENVELOPE' ('DEBEZIUM'|'UPSERT'))?
     ('WITH SNAPSHOT' | 'WITHOUT SNAPSHOT')?
 create_source_avro_file ::=
@@ -284,6 +286,12 @@ format_spec ::=
   'CSV WITH' ('HEADER' ( '(' col_name (',' col_name)* ')' )? | n 'COLUMNS') ('DELIMITED BY' char)? |
   'TEXT' |
   'BYTES'
+sink_format_spec ::=
+  'AVRO USING' (
+        'CONFLUENT SCHEMA REGISTRY' url with_options? |
+        'SCHEMA' 'FILE' schema_file_path
+        ) |
+  'JSON'
 key_constraint ::= ('PRIMARY KEY' '(' (col_name) ( ( ',' col_name ) )* ')' 'NOT ENFORCED')
 func_at_time_zone ::=
     'SELECT' ( 'TIMESTAMP' | 'TIMESTAMPTZ' ) ('timestamp' | 'timestamptz') 'AT TIME ZONE' 'zone::type'
@@ -312,8 +320,7 @@ sink_kafka_connector ::=
     'KAFKA BROKER' host 'TOPIC' topic-prefix
     ('KEY' '(' key_column ( ',' key_column )* ')')?
     ('CONSISTENCY' 'TOPIC' topic ('CONSISTENCY' 'FORMAT' 'AVRO USING' 'CONFLUENT SCHEMA REGISTRY' url)?)?
-    with_options?
-    'FORMAT' ('AVRO USING' 'CONFLUENT SCHEMA REGISTRY' url | 'JSON')
+    ( 'WITH' '(' (option_name ('=' option_value)?) ( ',' (option_name ('=' option_value)?) )* ')' )?
 lit_cast ::=
   type val
 op_cast ::=


### PR DESCRIPTION
### Motivation

This PR updates our [`CREATE SINK` documentation](https://materialize.com/docs/sql/create-sink/#with-options), which had fallen a bit behind our [`CREATE SINK` functionality](https://github.com/MaterializeInc/materialize/blob/main/src/sql-parser/src/parser.rs#L1731).

### Description

Our `CREATE SINK` documentation is missing two things:
1. Where the user should place their `WITH (...)` clause.
2. The `FORMAT` clause.

I've added both in this PR. I generated the new diagrams and spun up a local docs site using Hugo. Here's how the updates look:

<img width="752" alt="Screen Shot 2021-09-14 at 7 31 38 PM" src="https://user-images.githubusercontent.com/5766027/133361123-bd608ff1-a3d2-46b1-9402-8ab4adac51e6.png">
<img width="1069" alt="Screen Shot 2021-09-14 at 7 34 45 PM" src="https://user-images.githubusercontent.com/5766027/133361129-e875590a-7931-41af-a58e-0d1c82019883.png">
<img width="784" alt="Screen Shot 2021-09-14 at 2 55 13 PM" src="https://user-images.githubusercontent.com/5766027/133339708-03fe0fdc-cf54-4445-8728-9a2da01d020f.png">


### Checklist

- [X] This PR has adequate test coverage.
- [X] This PR adds a release note for any user-facing behavior changes.
