### PR TITLE
Optimization: Move inter-view filter + demand propagation between logical and physical transforms.

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -2015,7 +2015,7 @@ impl Catalog {
                 })
             }
             Plan::CreateSource(CreateSourcePlan { source, .. }) => {
-                let mut optimizer = Optimizer::for_view();
+                let mut optimizer = Optimizer::logical_optimizer();
                 let optimized_expr = optimizer.optimize(source.expr, self.enabled_indexes())?;
                 let transformed_desc = RelationDesc::new(optimized_expr.typ(), source.column_names);
                 CatalogItem::Source(Source {
@@ -2027,7 +2027,7 @@ impl Catalog {
                 })
             }
             Plan::CreateView(CreateViewPlan { view, .. }) => {
-                let mut optimizer = Optimizer::for_view();
+                let mut optimizer = Optimizer::logical_optimizer();
                 let optimized_expr = optimizer.optimize(view.expr, self.enabled_indexes())?;
                 let desc = RelationDesc::new(optimized_expr.typ(), view.column_names);
                 CatalogItem::View(View {

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -3773,7 +3773,7 @@ pub async fn serve(
             let mut coord = Coordinator {
                 worker_guards,
                 worker_txs,
-                view_optimizer: Optimizer::for_view(),
+                view_optimizer: Optimizer::logical_optimizer(),
                 catalog,
                 symbiosis,
                 indexes: ArrangementFrontiers::default(),
@@ -3934,7 +3934,7 @@ pub fn serve_debug(
         let mut coord = Coordinator {
             worker_guards,
             worker_txs: vec![worker_tx],
-            view_optimizer: Optimizer::for_view(),
+            view_optimizer: Optimizer::logical_optimizer(),
             catalog,
             symbiosis: None,
             indexes: ArrangementFrontiers::default(),

--- a/src/dataflow-types/src/explain.rs
+++ b/src/dataflow-types/src/explain.rs
@@ -127,11 +127,13 @@ impl<'a> fmt::Display for Explanation<'a> {
                     .unwrap_or_else(|| "?".to_owned()),
                 id,
             )?;
-            writeln!(
-                f,
-                "| Filter {}",
-                separated(", ", operator.predicates.iter())
-            )?;
+            if !operator.predicates.is_empty() {
+                writeln!(
+                    f,
+                    "| Filter {}",
+                    separated(", ", operator.predicates.iter())
+                )?;
+            }
             writeln!(
                 f,
                 "| Project {}",

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -321,9 +321,7 @@ impl Optimizer {
             Box::new(crate::update_let::UpdateLet),
             Box::new(crate::reduction::FoldConstants { limit: Some(10000) }),
         ];
-        let mut optimizer = Self::for_view();
-        optimizer.transforms.extend(transforms);
-        optimizer
+        Self { transforms }
     }
 
     /// Simple fusion and elision transformations to render the query readable.

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -229,7 +229,7 @@ pub struct Optimizer {
 
 impl Optimizer {
     /// Builds a logical optimizer that only performs logical transformations.
-    pub fn for_view() -> Self {
+    pub fn logical_optimizer() -> Self {
         let transforms: Vec<Box<dyn crate::Transform + Send>> = vec![
             // 1. Structure-agnostic cleanup
             Box::new(crate::topk_elision::TopKElision),
@@ -291,7 +291,7 @@ impl Optimizer {
     /// This is meant to be used for optimizing each view within a dataflow
     /// once view inlining has already happened, right before dataflow
     /// rendering.
-    pub fn for_dataflow() -> Self {
+    pub fn physical_optimizer() -> Self {
         // Implementation transformations
         let transforms: Vec<Box<dyn crate::Transform + Send>> = vec![
             Box::new(crate::projection_pushdown::ProjectionPushdown),

--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -98,54 +98,6 @@ impl crate::Transform for PredicatePushdown {
 }
 
 impl PredicatePushdown {
-    /// Pushes predicates down through the operator tree and extracts
-    /// The ones that should be pushed down to the next dataflow object
-    pub fn dataflow_transform(
-        &self,
-        relation: &mut MirRelationExpr,
-        get_predicates: &mut HashMap<Id, HashSet<MirScalarExpr>>,
-    ) {
-        // TODO(#2592): we want to replace everything inside the braces
-        // with the single line below
-        // `self.action(e, &mut get_predicates);`
-        // This is so that you have a series of dependent views
-        // A->B->C, you want to push propagated filters
-        // from A all the way past B to C if possible.
-        // Before this replacement can be done, we need to figure out
-        // replanning joins after the new predicates are pushed down.
-        match relation {
-            MirRelationExpr::Filter { input, predicates } => {
-                if let MirRelationExpr::Get { id, .. } = **input {
-                    // We can report the predicates upward in `get_predicates`,
-                    // but we are not yet able to delete them from the `Filter`.
-                    get_predicates
-                        .entry(id)
-                        .or_insert_with(|| predicates.iter().cloned().collect())
-                        .retain(|p| predicates.contains(p));
-                } else {
-                    self.dataflow_transform(input, get_predicates);
-                }
-            }
-            MirRelationExpr::Get { id, .. } => {
-                // If we encounter a `Get` that is not wrapped by a `Filter`,
-                // we should purge all predicates associated with the id.
-                // This is because it is as if there is an empty `Filter`
-                // just around the `Get`, and so no predicates can be pushed.
-                get_predicates
-                    .entry(*id)
-                    .or_insert_with(HashSet::new)
-                    .clear();
-            }
-            x => {
-                x.visit1_mut(|e| self.dataflow_transform(e, get_predicates));
-                // Prevent local predicate lists from escaping.
-                if let MirRelationExpr::Let { id, .. } = x {
-                    get_predicates.remove(&Id::Local(*id));
-                }
-            }
-        }
-    }
-
     /// Predicate pushdown
     ///
     /// This method looks for opportunities to push predicates toward
@@ -156,7 +108,7 @@ impl PredicatePushdown {
     /// applied to each `Get` expression, so that the predicate can
     /// then be pushed through to a `Let` binding, or to the external
     /// source of the data if the `Get` binds to another view.
-    fn action(
+    pub fn action(
         &self,
         relation: &mut MirRelationExpr,
         get_predicates: &mut HashMap<Id, HashSet<MirScalarExpr>>,

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -109,8 +109,8 @@ mod tests {
             FormatType::Explain(args.get(FORMAT))
         };
 
-        let mut logical_opt = Optimizer::for_view();
-        let mut physical_opt = Optimizer::for_dataflow();
+        let mut logical_opt = Optimizer::logical_optimizer();
+        let mut physical_opt = Optimizer::physical_optimizer();
 
         let out = match test_type {
             TestType::Opt => {

--- a/test/testdrive/source-linear-operators.td
+++ b/test/testdrive/source-linear-operators.td
@@ -7,50 +7,287 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# Test
+# Test that filter and demand information are properly progatated from a view
+# down to an unmaterialized source.
 
 $ set schema={
     "type": "record",
     "name": "row",
     "fields": [
-      {"name": "a", "type": "long"},
-      {"name": "b", "type": "long"}
+      {"name": "a", "type": ["long", "null"]},
+      {"name": "b", "type": ["long", "null"]},
+      {"name": "c", "type": ["long", "null"]},
+      {"name": "d", "type": ["long", "null"]}
     ]
   }
 
 $ kafka-create-topic topic=data
 
-$ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
-{"a": 1, "b": 1}
-{"a": 2, "b": 1}
-{"a": 3, "b": 1}
-{"a": 1, "b": 2}
+$ kafka-ingest format=avro topic=data schema=${schema}
+{"a": {"long": 1}, "b": {"long": 1}, "c": {"long": 3}, "d": {"long": 4}}
+{"a": {"long": 2}, "b": {"long": 1}, "c": {"long": 5}, "d": {"long": 4}}
+{"a": {"long": 3}, "b": {"long": 1}, "c": {"long": 3}, "d": {"long": 5}}
+{"a": {"long": 1}, "b": {"long": 2}, "c": {"long": 2}, "d": {"long": 3}}
 
 > CREATE SOURCE data
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
 
-> CREATE VIEW data_view as SELECT * from data
-
 $ set-regex match=u\d+ replacement=UID
 
-? EXPLAIN PLAN FOR SELECT * from data_view where a = 1
+# basic test: pushing filters down to sources
+
+? EXPLAIN PLAN FOR SELECT * from data where a = 1 and d = 3;
 Source materialize.public.data (UID):
-| Filter (#0 = 1)
+| Filter (#0 = 1), (#3 = 3)
+| Project (#0..#3)
+
+Query:
+%0 =
+| Get materialize.public.data (UID)
+| Filter (#0 = 1), (#3 = 3)
+
+> CREATE MATERIALIZED VIEW mv1 as SELECT * from data where a = 1 and d = 3;
+
+> SELECT * FROM mv1
+1 2 2 3
+
+> DROP VIEW mv1;
+
+# basic test: pushing demand down to sources
+
+? EXPLAIN PLAN FOR SELECT b from data where b = 1
+Source materialize.public.data (UID):
+| Filter (#1 = 1)
+| Project (#1)
+
+Query:
+%0 =
+| Get materialize.public.data (UID)
+| Filter (#1 = 1)
+| Project (#1)
+
+> CREATE MATERIALIZED VIEW mv as SELECT b from data where b = 1;
+
+> SELECT * FROM mv
+1
+1
+1
+
+> DROP VIEW mv;
+
+> CREATE VIEW inner_view as SELECT a, b, d from data where d = 4;
+
+# Filter gets pushed through intervening view.
+
+? EXPLAIN PLAN FOR SELECT b from inner_view where a = 1
+Source materialize.public.data (UID):
+| Filter (#0 = 1), (#3 = 4)
+| Project (#0, #1, #3)
+
+Query:
+%0 =
+| Get materialize.public.data (UID)
+| Filter (#0 = 1), (#3 = 4)
+| Project (#1)
+
+> CREATE MATERIALIZED VIEW mv as SELECT b from inner_view where a = 1
+
+> SELECT * FROM mv
+1
+
+> DROP VIEW mv;
+
+# Demand gets pushed through intervening view.
+
+? EXPLAIN PLAN FOR SELECT d from inner_view where a = 1
+Source materialize.public.data (UID):
+| Filter (#3 = 4), (#0 = 1)
+| Project (#0, #3)
+
+Query:
+%0 =
+| Get materialize.public.data (UID)
+| Filter (#0 = 1), (#3 = 4)
+| Project (#3)
+
+> CREATE MATERIALIZED VIEW mv as SELECT d from inner_view where a = 1
+
+> SELECT * FROM mv
+4
+
+> DROP VIEW mv;
+
+? EXPLAIN PLAN FOR SELECT s1.a from data s1, data s2 where s1.a = s2.b and s2.d = 4
+Source materialize.public.data (UID):
+| Project (#0, #1, #3)
+
+Query:
+%0 =
+| Get materialize.public.data (UID)
+| Filter !(isnull(#0))
+| Project (#0)
+| ArrangeBy (#0)
+
+%1 =
+| Get materialize.public.data (UID)
+| Filter !(isnull(#1)), (#3 = 4)
+| Project (#1)
+
+%2 =
+| Join %0 %1 (= #0 #1)
+| | implementation = Differential %1 %0.(#0)
+| Project (#0)
+
+> CREATE MATERIALIZED VIEW mv as SELECT s1.a from data s1, data s2 where s1.a = s2.b and s2.d = 4
+
+> SELECT * FROM mv
+1
+1
+1
+1
+
+> DROP VIEW mv;
+
+? EXPLAIN PLAN FOR SELECT s2.a from data s1, data s2 where s1.a = s2.b and s2.d = 4 and s1.d = 4
+Source materialize.public.data (UID):
+| Filter (#3 = 4)
+| Project (#0, #1, #3)
+
+Query:
+%0 =
+| Get materialize.public.data (UID)
+| Filter !(isnull(#0)), (#3 = 4)
+| Project (#0)
+| ArrangeBy (#0)
+
+%1 =
+| Get materialize.public.data (UID)
+| Filter !(isnull(#1)), (#3 = 4)
 | Project (#0, #1)
 
+%2 =
+| Join %0 %1 (= #0 #2)
+| | implementation = Differential %1 %0.(#0)
+| Project (#1)
+
+> CREATE MATERIALIZED VIEW mv as SELECT s2.a from data s1, data s2 where s1.a = s2.b and s2.d = 4 and s1.d = 4
+
+> SELECT * FROM mv
+1
+2
+
+> DROP VIEW mv;
+
+? EXPLAIN PLAN FOR SELECT s2.c from data s1, data s2 where s1.a = s2.a
+Source materialize.public.data (UID):
+| Filter !(isnull(#0))
+| Project (#0, #2)
+
 Query:
-%0 =
+%0 = Let l0 =
+| Get materialize.public.data (UID)
+| Filter !(isnull(#0))
+
+%1 =
+| Get %0 (l0)
+| Project (#0)
+| ArrangeBy (#0)
+
+%2 =
+| Get %0 (l0)
+| Project (#0, #2)
+
+%3 =
+| Join %1 %2 (= #0 #1)
+| | implementation = Differential %2 %1.(#0)
+| Project (#2)
+
+> CREATE MATERIALIZED VIEW mv as SELECT s2.c from data s1, data s2 where s1.a = s2.a
+
+> SELECT * FROM mv
+3
+5
+3
+2
+3
+2
+
+> DROP VIEW mv;
+
+? EXPLAIN PLAN FOR SELECT * FROM (SELECT a, sum(b) FROM data GROUP BY a UNION ALL SELECT a, (a + c)::numeric FROM data) WHERE a = 1
+Source materialize.public.data (UID):
+| Filter (#0 = 1)
+| Project (#0..#2)
+
+Query:
+%0 = Let l0 =
 | Get materialize.public.data (UID)
 | Filter (#0 = 1)
 
-? EXPLAIN PLAN FOR SELECT b from data_view where b = 1
-Source materialize.public.data (UID):
-| Filter (#1 = 1)
+%1 =
+| Get %0 (l0)
 | Project (#1)
+| Reduce group=()
+| | agg sum(#0)
+| Map 1
+| Project (#1, #0)
+
+%2 =
+| Get %0 (l0)
+| Map i64tonumeric((1 + #2))
+| Project (#0, #4)
+
+%3 =
+| Union %1 %2
+
+> CREATE MATERIALIZED VIEW mv as SELECT * FROM (SELECT a, sum(b) FROM data GROUP BY a UNION ALL SELECT a, (a + c)::numeric FROM data) WHERE a = 1
+
+> SELECT * FROM mv
+1 3
+1 3
+1 4
+
+> DROP VIEW mv;
+
+$ kafka-create-topic topic=data2
+
+$ kafka-ingest format=avro topic=data2 schema=${schema}
+{"a": {"long": 3}, "b": {"long": 2}, "c": null, "d": {"long": 4}}
+{"a": {"long": 2}, "b": {"long": 1}, "c": {"long": 5}, "d": null}
+
+> CREATE SOURCE data2
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data2-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${schema}'
+
+? EXPLAIN PLAN FOR SELECT a, c FROM data EXCEPT ALL SELECT a, c FROM data2 where d is null;
+Source materialize.public.data (UID):
+| Project (#0, #2)
+
+Source materialize.public.data2 (UID):
+| Filter isnull(#3)
+| Project (#0, #2, #3)
 
 Query:
 %0 =
 | Get materialize.public.data (UID)
-| Filter (#1 = 1)
-| Project (#1)
+| Project (#0, #2)
+
+%1 =
+| Get materialize.public.data2 (UID)
+| Filter isnull(#3)
+| Project (#0, #2)
+| Negate
+
+%2 =
+| Union %0 %1
+| Threshold
+
+> CREATE MATERIALIZED VIEW mv as SELECT a, c FROM data EXCEPT ALL SELECT a, c FROM data2 where d is null
+
+> SELECT * FROM mv
+1 2
+1 3
+3 3
+
+> DROP VIEW mv;

--- a/test/testdrive/source-linear-operators.td
+++ b/test/testdrive/source-linear-operators.td
@@ -37,7 +37,9 @@ $ set-regex match=u\d+ replacement=UID
 
 # basic test: pushing filters down to sources
 
-? EXPLAIN PLAN FOR SELECT * from data where a = 1 and d = 3;
+> CREATE MATERIALIZED VIEW mv as SELECT * from data where a = 1 and d = 3;
+
+? EXPLAIN PLAN FOR VIEW mv;
 Source materialize.public.data (UID):
 | Filter (#0 = 1), (#3 = 3)
 | Project (#0..#3)
@@ -47,16 +49,16 @@ Query:
 | Get materialize.public.data (UID)
 | Filter (#0 = 1), (#3 = 3)
 
-> CREATE MATERIALIZED VIEW mv1 as SELECT * from data where a = 1 and d = 3;
-
-> SELECT * FROM mv1
+> SELECT * FROM mv
 1 2 2 3
 
-> DROP VIEW mv1;
+> DROP VIEW mv;
 
 # basic test: pushing demand down to sources
 
-? EXPLAIN PLAN FOR SELECT b from data where b = 1
+> CREATE MATERIALIZED VIEW mv as SELECT b from data where b = 1;
+
+? EXPLAIN PLAN FOR VIEW mv;
 Source materialize.public.data (UID):
 | Filter (#1 = 1)
 | Project (#1)
@@ -66,8 +68,6 @@ Query:
 | Get materialize.public.data (UID)
 | Filter (#1 = 1)
 | Project (#1)
-
-> CREATE MATERIALIZED VIEW mv as SELECT b from data where b = 1;
 
 > SELECT * FROM mv
 1
@@ -80,7 +80,9 @@ Query:
 
 # Filter gets pushed through intervening view.
 
-? EXPLAIN PLAN FOR SELECT b from inner_view where a = 1
+> CREATE MATERIALIZED VIEW mv as SELECT b from inner_view where a = 1
+
+? EXPLAIN PLAN FOR VIEW mv;
 Source materialize.public.data (UID):
 | Filter (#0 = 1), (#3 = 4)
 | Project (#0, #1, #3)
@@ -91,8 +93,6 @@ Query:
 | Filter (#0 = 1), (#3 = 4)
 | Project (#1)
 
-> CREATE MATERIALIZED VIEW mv as SELECT b from inner_view where a = 1
-
 > SELECT * FROM mv
 1
 
@@ -100,7 +100,9 @@ Query:
 
 # Demand gets pushed through intervening view.
 
-? EXPLAIN PLAN FOR SELECT d from inner_view where a = 1
+> CREATE MATERIALIZED VIEW mv as SELECT d from inner_view where a = 1
+
+? EXPLAIN PLAN FOR VIEW mv;
 Source materialize.public.data (UID):
 | Filter (#3 = 4), (#0 = 1)
 | Project (#0, #3)
@@ -111,14 +113,14 @@ Query:
 | Filter (#0 = 1), (#3 = 4)
 | Project (#3)
 
-> CREATE MATERIALIZED VIEW mv as SELECT d from inner_view where a = 1
-
 > SELECT * FROM mv
 4
 
 > DROP VIEW mv;
 
-? EXPLAIN PLAN FOR SELECT s1.a from data s1, data s2 where s1.a = s2.b and s2.d = 4
+> CREATE MATERIALIZED VIEW mv as SELECT s1.a from data s1, data s2 where s1.a = s2.b and s2.d = 4
+
+? EXPLAIN PLAN FOR VIEW mv;
 Source materialize.public.data (UID):
 | Project (#0, #1, #3)
 
@@ -139,8 +141,6 @@ Query:
 | | implementation = Differential %1 %0.(#0)
 | Project (#0)
 
-> CREATE MATERIALIZED VIEW mv as SELECT s1.a from data s1, data s2 where s1.a = s2.b and s2.d = 4
-
 > SELECT * FROM mv
 1
 1
@@ -149,7 +149,11 @@ Query:
 
 > DROP VIEW mv;
 
-? EXPLAIN PLAN FOR SELECT s2.a from data s1, data s2 where s1.a = s2.b and s2.d = 4 and s1.d = 4
+# filters and demand can be inferred in more complicated queries
+
+> CREATE MATERIALIZED VIEW mv as SELECT s2.a from data s1, data s2 where s1.a = s2.b and s2.d = 4 and s1.d = 4
+
+? EXPLAIN PLAN FOR VIEW mv;
 Source materialize.public.data (UID):
 | Filter (#3 = 4)
 | Project (#0, #1, #3)
@@ -171,15 +175,15 @@ Query:
 | | implementation = Differential %1 %0.(#0)
 | Project (#1)
 
-> CREATE MATERIALIZED VIEW mv as SELECT s2.a from data s1, data s2 where s1.a = s2.b and s2.d = 4 and s1.d = 4
-
 > SELECT * FROM mv
 1
 2
 
 > DROP VIEW mv;
 
-? EXPLAIN PLAN FOR SELECT s2.c from data s1, data s2 where s1.a = s2.a
+> CREATE MATERIALIZED VIEW mv as SELECT s2.c from data s1, data s2 where s1.a = s2.a
+
+? EXPLAIN PLAN FOR VIEW mv;
 Source materialize.public.data (UID):
 | Filter !(isnull(#0))
 | Project (#0, #2)
@@ -203,8 +207,6 @@ Query:
 | | implementation = Differential %2 %1.(#0)
 | Project (#2)
 
-> CREATE MATERIALIZED VIEW mv as SELECT s2.c from data s1, data s2 where s1.a = s2.a
-
 > SELECT * FROM mv
 3
 5
@@ -215,7 +217,9 @@ Query:
 
 > DROP VIEW mv;
 
-? EXPLAIN PLAN FOR SELECT * FROM (SELECT a, sum(b) FROM data GROUP BY a UNION ALL SELECT a, (a + c)::numeric FROM data) WHERE a = 1
+> CREATE MATERIALIZED VIEW mv as SELECT * FROM (SELECT a, sum(b) FROM data GROUP BY a UNION ALL SELECT a, (a + c)::numeric FROM data) WHERE a = 1
+
+? EXPLAIN PLAN FOR VIEW mv;
 Source materialize.public.data (UID):
 | Filter (#0 = 1)
 | Project (#0..#2)
@@ -241,14 +245,14 @@ Query:
 %3 =
 | Union %1 %2
 
-> CREATE MATERIALIZED VIEW mv as SELECT * FROM (SELECT a, sum(b) FROM data GROUP BY a UNION ALL SELECT a, (a + c)::numeric FROM data) WHERE a = 1
-
 > SELECT * FROM mv
 1 3
 1 3
 1 4
 
 > DROP VIEW mv;
+
+# multiple source test
 
 $ kafka-create-topic topic=data2
 
@@ -260,7 +264,9 @@ $ kafka-ingest format=avro topic=data2 schema=${schema}
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data2-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
 
-? EXPLAIN PLAN FOR SELECT a, c FROM data EXCEPT ALL SELECT a, c FROM data2 where d is null;
+> CREATE MATERIALIZED VIEW mv as SELECT a, c FROM data EXCEPT ALL SELECT a, c FROM data2 where d is null
+
+? EXPLAIN PLAN FOR VIEW mv;
 Source materialize.public.data (UID):
 | Project (#0, #2)
 
@@ -282,8 +288,6 @@ Query:
 %2 =
 | Union %0 %1
 | Threshold
-
-> CREATE MATERIALIZED VIEW mv as SELECT a, c FROM data EXCEPT ALL SELECT a, c FROM data2 where d is null
 
 > SELECT * FROM mv
 1 2


### PR DESCRIPTION
### Motivation

First step towards projection pushdown across views.

On main, pushing filters and projects down through views is hindered by the fact we don't really know how to get filter and project information down through a join after the join's implementation has been decided. 

But now that we have a separation of logical and physical transforms, we can stick the filter + demand propagation to happen in between the set of logical and physical transforms, before join implementations are decided.

### Checklist

- [x] This PR has adequate test coverage.
- [ ] This PR adds a release note for any user-facing behavior changes.
