### PR TITLE
A few performance improvements in the optimizer

### DIFF
--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -628,7 +628,30 @@ impl MirRelationExpr {
     /// This number is determined from the type, which is determined recursively
     /// at non-trivial cost.
     pub fn arity(&self) -> usize {
-        self.typ().column_types.len()
+        match self {
+            MirRelationExpr::Constant { rows: _, typ } => typ.arity(),
+            MirRelationExpr::Get { typ, .. } => typ.arity(),
+            MirRelationExpr::Let { body, .. } => body.arity(),
+            MirRelationExpr::Project { input: _, outputs } => outputs.len(),
+            MirRelationExpr::Map { input, scalars } => input.arity() + scalars.len(),
+            MirRelationExpr::FlatMap { input, func, .. } => {
+                input.arity() + func.output_type().column_types.len()
+            }
+            MirRelationExpr::Filter { input, .. } => input.arity(),
+            MirRelationExpr::Join { inputs, .. } => inputs.iter().map(|i| i.arity()).sum(),
+            MirRelationExpr::Reduce {
+                input: _,
+                group_key,
+                aggregates,
+                ..
+            } => group_key.len() + aggregates.len(),
+            MirRelationExpr::TopK { input, .. } => input.arity(),
+            MirRelationExpr::Negate { input } => input.arity(),
+            MirRelationExpr::Threshold { input } => input.arity(),
+            MirRelationExpr::Union { base, inputs: _ } => base.arity(),
+            MirRelationExpr::ArrangeBy { input, .. } => input.arity(),
+            MirRelationExpr::DeclareKeys { input, .. } => input.arity(),
+        }
     }
 
     /// Constructs a constant collection from specific rows and schema, where


### PR DESCRIPTION
### Motivation

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug. [Link to issue.]

  * This PR adds a known-desirable feature. [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

This PR refactors existing code.

This PR adds two commits that lead to up to a 23% improvement in the optimization time.

### Description

<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details."

-->

The first commit removes an unnecessary call to the slow `typ` method for every node in the graph, for every execution of the union fusion transform.

The second commit adds an specialized implementation of the `arity` method that doesn't rely on the slow `typ` method.

The combined effect of both optimizations leads to improvements in 21 out the 22 TPCH queries of up to a 23%, with a 15% improvement on average.

The performance impact of these changes have been measured with the following patch that outputs the optimization time in `explain`'s output:

```
diff --git a/src/coord/src/coord.rs b/src/coord/src/coord.rs
index 53f56e1b1..8e841e2f3 100644
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -3026,9 +3026,12 @@ impl Coordinator {
             }
             ExplainStage::OptimizedPlan => {
                 self.validate_timeline(decorrelated_plan.global_uses())?;
+                use std::time::Instant;
+                let opt_start = Instant::now();
                 let optimized_plan =
                     self.prep_relation_expr(decorrelated_plan, ExprPrepStyle::Explain)?;
                 let mut dataflow = DataflowDesc::new(format!("explanation"));
+
                 self.dataflow_builder().import_view_into_dataflow(
                     // TODO: If explaining a view, pipe the actual id of the view.
                     &GlobalId::Explain,
@@ -3036,6 +3039,7 @@ impl Coordinator {
                     &mut dataflow,
                 );
                 transform::optimize_dataflow(&mut dataflow, self.catalog.enabled_indexes());
+                let opt_duration = opt_start.elapsed();
                 let catalog = self.catalog.for_session(session);
                 let mut explanation =
                     dataflow_types::Explanation::new_from_dataflow(&dataflow, &catalog);
@@ -3045,7 +3049,11 @@ impl Coordinator {
                 if options.typed {
                     explanation.explain_types();
                 }
-                explanation.to_string()
+                format!(
+                    "{}\n Optimization time: {}",
+                    explanation.to_string(),
+                    opt_duration.as_micros()
+                )
             }
         };
         let rows = vec![Row::pack_slice(&[Datum::from(&*explanation_string)])];


```

The results are available in this spreadsheet:

https://docs.google.com/spreadsheets/d/1ana1hmc0mtPD8a7DAY9BthN3XXnjHlK6xhuPHqQLuEI/edit?usp=sharing

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [ ] This PR has adequate test coverage.
- [ ] This PR adds a release note for any user-facing behavior changes.
