### PR TITLE
Store cloudbench results in S3

### DIFF
--- a/ci/load/periodic.py
+++ b/ci/load/periodic.py
@@ -45,6 +45,7 @@ def main() -> None:
         # Keep alive for at least a day
         int(datetime.datetime.now(datetime.timezone.utc).timestamp()) + 3600 * 24,
         "HEAD",
+        {},
     )
 
 

--- a/misc/load-tests/provision.bash
+++ b/misc/load-tests/provision.bash
@@ -26,4 +26,10 @@ usermod -aG docker ubuntu
 sudo -u ubuntu sh -c "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -q -y"
 apt install -y cmake
 
+# Install aws cli
+apt install -y unzip curl
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+unzip awscliv2.zip
+sudo ./aws/install
+
 touch /DONE

--- a/misc/python/materialize/cli/cloudbench.py
+++ b/misc/python/materialize/cli/cloudbench.py
@@ -198,6 +198,7 @@ else
     aws s3 cp - s3://mz-cloudbench/$MZ_CB_BENCH_ID/$MZ_CB_CLUSTER_ID-FAILURE.out < ~/mzscratch-startup.out >&2
     aws s3 cp - s3://mz-cloudbench/$MZ_CB_BENCH_ID/$MZ_CB_CLUSTER_ID-FAILURE.err < ~/mzscratch-startup.err
 fi
+sudo shutdown -h now # save some money
 """
 
     if ns.profile == "basic":

--- a/misc/python/materialize/cli/cloudbench.py
+++ b/misc/python/materialize/cli/cloudbench.py
@@ -10,17 +10,15 @@
 """Launch benchmark for a particular commit on cloud infrastructure, using bin/scratch"""
 
 import argparse
-import asyncio
 import base64
 import csv
 import itertools
-import json
 import os
 import shlex
 import sys
 import time
 from datetime import timedelta
-from typing import List, NamedTuple, Optional, cast
+from typing import List, NamedTuple, Optional, Union, cast
 
 import boto3
 
@@ -31,13 +29,7 @@ from materialize.cli.scratch import (
     DEFAULT_SUBNET_ID,
     check_required_vars,
 )
-from materialize.scratch import (
-    get_instances_by_tag,
-    instance_typedef_tags,
-    name,
-    print_instances,
-    run_ssm,
-)
+from materialize.scratch import print_instances
 
 
 # This is duplicated with the one in cli/scratch.
@@ -89,8 +81,11 @@ def configure_start(parser: argparse.ArgumentParser) -> None:
     )
 
 
-class BenchResult(NamedTuple):
-    exit_code: int
+class BenchSuccessResult(NamedTuple):
+    stdout: str
+
+
+class BenchFailureLogs(NamedTuple):
     stdout: str
     stderr: str
 
@@ -99,51 +94,69 @@ def configure_check(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("bench_id", type=str, nargs=1)
 
 
+BUCKET = "mz-cloudbench"
+
+
+def try_get_object(key: str) -> Optional[str]:
+    client = boto3.client("s3")
+    try:
+        result = client.get_object(Bucket=BUCKET, Key=key)
+        return result["Body"].read().decode("utf-8")
+    except client.exceptions.NoSuchKey:
+        return None
+
+
 def check(ns: argparse.Namespace) -> None:
     check_required_vars()
     bench_id = ns.bench_id[0]
-    insts = [
-        i
-        for i in get_instances_by_tag("bench_id", bench_id)
-        if (name(instance_typedef_tags(i)) or "").endswith("materialized")
-    ]
+
+    manifest = (
+        boto3.client("s3")
+        .get_object(Bucket=BUCKET, Key=f"{bench_id}/MANIFEST")["Body"]
+        .read()
+        .decode("utf-8")
+        .strip()
+    )
+    insts = manifest.split("\n")
     if not insts:
         raise RuntimeError(f"No instances found for bench ID {bench_id}")
-    results: List[Optional[BenchResult]] = [None for _ in insts]
+    results: List[Optional[Union[BenchSuccessResult, BenchFailureLogs]]] = [
+        None for _ in insts
+    ]
     not_done = list(range(len(results)))
-    script = """#!/usr/bin/env bash
-    if [[ -f /home/ubuntu/bench_exit_code ]]; then
-        jq -aRn "{\\"stdout\\": \\$out, \\"stderr\\": \\$err, \\"exit_code\\": $(cat /home/ubuntu/bench_exit_code)}" --rawfile out /home/ubuntu/mzscratch-startup.out --rawfile err /home/ubuntu/mzscratch-startup.err
-    else
-        echo '"NOT DONE"'
-    fi"""
     while not_done:
-        futures = [run_ssm(insts[i]["InstanceId"], [script]) for i in not_done]
-        loop = asyncio.get_event_loop()
-        new_results = loop.run_until_complete(asyncio.gather(*futures))
-        for result, i in zip(new_results, not_done):
-            json_result = json.loads(result.stdout)
-            if json_result != "NOT DONE":
-                results[i] = BenchResult(
-                    json_result["exit_code"],
-                    json_result["stdout"],
-                    json_result["stderr"],
-                )
+        for i in not_done:
+            maybe_result = try_get_object(f"{bench_id}/{insts[i]}.csv")
+            if maybe_result is None:
+                maybe_out = try_get_object(f"{bench_id}/{insts[i]}-FAILURE.out")
+                maybe_err = try_get_object(f"{bench_id}/{insts[i]}-FAILURE.err")
+                if (maybe_out is None) or (maybe_err is None):
+                    continue
+                results[i] = BenchFailureLogs(stdout=maybe_out, stderr=maybe_err)
+            else:
+                results[i] = BenchSuccessResult(stdout=maybe_result)
+
         not_done = [i for i in not_done if not results[i]]
         if not_done:
             print("Benchmark not done; waiting 60 seconds", file=sys.stderr)
             time.sleep(60)
     for r in results:
-        assert isinstance(r, BenchResult)
-    results = cast(List[BenchResult], results)
-    failed = [r for r in results if r.exit_code]
+        assert isinstance(r, BenchSuccessResult) or isinstance(r, BenchFailureLogs)
+    done_results = cast(List[Union[BenchFailureLogs, BenchSuccessResult]], results)
+    failed = [
+        (i, r) for i, r in enumerate(done_results) if isinstance(r, BenchFailureLogs)
+    ]
     if failed:
-        # TODO - something better here. Which hosts failed? Etc.
-        raise RuntimeError(
-            f"{len(failed)} runs FAILED! Check mzscratch-startup.err on the hosts for more details"
-        )
+        for i, f in failed:
+            print(
+                f"Run of instance {insts[i]} failed, stdout:\n{f.stdout}stderr:\n{f.stderr}",
+                file=sys.stderr,
+            )
+        raise RuntimeError(f"{len(failed)} runs FAILED!")
+    good_results = cast(List[BenchSuccessResult], done_results)
     readers = [
-        csv.DictReader(f"{line}\n" for line in r.stdout.split("\n")) for r in results
+        csv.DictReader(f"{line}\n" for line in r.stdout.split("\n"))
+        for r in good_results
     ]
     csv_results = ((d.values() for d in r) for r in readers)
     for r in readers:
@@ -158,9 +171,9 @@ def check(ns: argparse.Namespace) -> None:
         cast(List[str], readers[0].fieldnames) + ["InstanceIndex", "Rev", "Trial"]
     )
     for inst, r in zip(insts, csv_results):
-        tags = instance_typedef_tags(inst)
+        components = inst.split("-")
         for i, entry in enumerate(r):
-            w.writerow(itertools.chain(entry, (tags["bench_i"], tags["bench_rev"], i)))
+            w.writerow(itertools.chain(entry, (components[0], components[1], i)))
 
 
 def start(ns: argparse.Namespace) -> None:
@@ -193,10 +206,10 @@ MZ_ROOT=/home/ubuntu/materialize python3 -u -m {script_name} {script_args}
 result=$?
 echo $result > ~/bench_exit_code
 if [ $result -eq 0 ]; then
-    aws s3 cp - s3://mz-cloudbench/$MZ_CB_BENCH_ID/$MZ_CB_CLUSTER_ID.csv < ~/mzscratch-startup.out >&2
+    aws s3 cp - s3://{BUCKET}/$MZ_CB_BENCH_ID/$MZ_CB_CLUSTER_ID.csv < ~/mzscratch-startup.out >&2
 else
-    aws s3 cp - s3://mz-cloudbench/$MZ_CB_BENCH_ID/$MZ_CB_CLUSTER_ID-FAILURE.out < ~/mzscratch-startup.out >&2
-    aws s3 cp - s3://mz-cloudbench/$MZ_CB_BENCH_ID/$MZ_CB_CLUSTER_ID-FAILURE.err < ~/mzscratch-startup.err
+    aws s3 cp - s3://{BUCKET}/$MZ_CB_BENCH_ID/$MZ_CB_CLUSTER_ID-FAILURE.out < ~/mzscratch-startup.out >&2
+    aws s3 cp - s3://{BUCKET}/$MZ_CB_BENCH_ID/$MZ_CB_CLUSTER_ID-FAILURE.err < ~/mzscratch-startup.err
 fi
 sudo shutdown -h now # save some money
 """

--- a/misc/python/materialize/cli/scratch/create.py
+++ b/misc/python/materialize/cli/scratch/create.py
@@ -107,6 +107,7 @@ def run(args: argparse.Namespace) -> None:
         extra_tags,
         delete_after,
         args.git_rev,
+        extra_env={},
     )
 
     print("Launched instances:")

--- a/misc/python/materialize/scratch.py
+++ b/misc/python/materialize/scratch.py
@@ -332,6 +332,7 @@ def launch_cluster(
     extra_tags: Dict[str, str],
     delete_after: int,  # Unix timestamp.
     git_rev: str,
+    extra_env: Dict[str, str],
 ) -> List[Instance]:
     """Launch a cluster of instances with a given nonce"""
     instances = [
@@ -378,6 +379,8 @@ def launch_cluster(
         (f"{i.private_ip_address}\t{d.name}\n" for (i, d) in zip(instances, descs))
     )
 
+    env = [f"{k}={v}" for k, v in extra_env.items()]
+
     for i in instances:
         ssh.runv(
             [f"echo {shlex.quote(hosts_str)} | sudo tee -a /etc/hosts"],
@@ -393,6 +396,9 @@ def launch_cluster(
                     "cd",
                     "~/materialize",
                     ";",
+                ]
+                + env
+                + [
                     "nohup",
                     "bash",
                     "-c",


### PR DESCRIPTION
### Motivation

  * This PR adds a feature that has not yet been specified.

Storing cloudbench results on S3 is cheap, and lets us shut down the instances immediately, rather than leaving them on waiting for the user to download the benchmark results from the local disk.

### Description

* In the launch script generated by `bin/scratch create`, wait for the benchmarks to finish. If the benchmark exited with code 0, upload the results CSV to S3. Otherwise, record a failure by uploading the stdout and stderr to specially named files
* Upload a MANIFEST file in `bin/scratch create` with one line for each of the machines running the benchmark (so `bin/scratch check` knows how many files to wait for)
* In `bin/scratch check`, get results from S3 rather than from the local disk of the EC2 machines.