### PR TITLE
persist: fix bug making compaction too aggressive when under high request load

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -59,6 +59,11 @@ Wrap your release notes at the 80 character mark.
 - When issuing `COMMIT` or `ROLLBACK` commands outside of an explicit
   transaction, always return a warning. Previously, the warning could be suppressed.
 
+- Persist the `mz_metrics` and `mz_metric_histogram` system tables and rehydrate
+  the previous contents on restart. This is a small test of the system that will
+  power upcoming persistence features. Users are free to opt out of this test
+  by setting the `--disable_persistent_system_tables_test` flag to "true".
+
 {{% version-header v0.9.3 %}}
 
 - Fix a bug that prevented creating Avro sinks on old versions of Confluent Platform

--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -877,8 +877,8 @@ lazy_static! {
         id: GlobalId::System(4043),
         index_id: GlobalId::System(4044),
         // Note that the `system_table_enabled` field of PersistConfig (hooked
-        // up to --persistent-system-tables) also has to be true for this to be
-        // persisted.
+        // up to --disable_persistent_system_tables_test) also has to be true
+        // for this to be persisted.
         persistent: true,
     };
     pub static ref MZ_PROMETHEUS_METRICS: BuiltinTable = BuiltinTable {
@@ -908,8 +908,8 @@ lazy_static! {
         id: GlobalId::System(4047),
         index_id: GlobalId::System(4048),
         // Note that the `system_table_enabled` field of PersistConfig (hooked
-        // up to --persistent-system-tables) also has to be true for this to be
-        // persisted.
+        // up to --disable_persistent_system_tables_test) also has to be true
+        // for this to be persisted.
         persistent: true,
     };
 }

--- a/src/coord/src/persistcfg.rs
+++ b/src/coord/src/persistcfg.rs
@@ -20,7 +20,9 @@ use serde::Serialize;
 
 use expr::GlobalId;
 use persist::file::FileBlob;
-use persist::indexed::runtime::{self, MultiWriteHandle, RuntimeClient, StreamWriteHandle};
+use persist::indexed::runtime::{
+    self, MultiWriteHandle, RuntimeClient, RuntimeConfig, StreamWriteHandle,
+};
 use uuid::Uuid;
 
 /// Configuration of the persistence runtime and features.
@@ -68,7 +70,7 @@ impl PersistConfig {
             let lock_info = LockInfo::new(lock_reentrance_id, self.lock_info.clone())?;
             let log = ErrorLog;
             let blob = FileBlob::new(&self.blob_path, lock_info)?;
-            let persister = runtime::start(log, blob, reg)?;
+            let persister = runtime::start(RuntimeConfig::default(), log, blob, reg)?;
             Some(persister)
         } else {
             None

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -117,9 +117,15 @@ struct Args {
     #[structopt(long, hidden = true)]
     persistent_user_tables: bool,
 
-    /// Enable persistent system tables. Has to be used with --experimental.
-    #[structopt(long, hidden = true)]
-    persistent_system_tables: bool,
+    /// Disable persistence of all system tables.
+    ///
+    /// This is a test of the upcoming persistence system. The data is stored on
+    /// the filesystem in a sub-directory of the Materialize data_directory.
+    /// This test is enabled by default to allow us to collect data from a
+    /// variety of deployments, but setting this flag to true to opt out of the
+    /// test is always safe.
+    #[structopt(long)]
+    disable_persistent_system_tables_test: bool,
 
     // === Timely worker configuration. ===
     /// Number of dataflow worker threads.
@@ -622,13 +628,7 @@ swap: {swap_total}KB total, {swap_used}KB used{swap_limit}",
         } else {
             false
         };
-        let system_table_enabled = if args.experimental && args.persistent_system_tables {
-            true
-        } else if args.persistent_system_tables {
-            bail!("cannot specify --persistent-system-tables without --experimental");
-        } else {
-            false
-        };
+        let system_table_enabled = !args.disable_persistent_system_tables_test;
         let lock_info = format!(
             "materialized {mz_version}\nos: {os}\nstart time: {start_time}\nnum workers: {num_workers}\n",
             mz_version = materialized::BUILD_INFO.human_version(),

--- a/src/persist/benches/end_to_end.rs
+++ b/src/persist/benches/end_to_end.rs
@@ -24,7 +24,7 @@ use timely::Config;
 use ore::metrics::MetricsRegistry;
 use persist;
 use persist::file::{FileBlob, FileLog};
-use persist::indexed::runtime::{self, RuntimeClient, StreamWriteHandle};
+use persist::indexed::runtime::{self, RuntimeClient, RuntimeConfig, StreamWriteHandle};
 use persist::operators::source::PersistedSource;
 use persist::storage::LockInfo;
 
@@ -149,6 +149,7 @@ fn create_runtime(base_path: &Path, nonce: &str) -> Result<RuntimeClient, Error>
     let blob_dir = base_path.join(format!("blob_{}", nonce));
     let lock_info = LockInfo::new(format!("reentrance_{}", nonce), "no_details".to_owned())?;
     let runtime = runtime::start(
+        RuntimeConfig::default(),
         FileLog::new(log_dir, lock_info.clone())?,
         FileBlob::new(blob_dir, lock_info)?,
         &MetricsRegistry::new(),

--- a/src/persist/benches/snapshot.rs
+++ b/src/persist/benches/snapshot.rs
@@ -14,7 +14,7 @@ use criterion::{black_box, criterion_group, criterion_main, Bencher, Criterion};
 use ore::metrics::MetricsRegistry;
 use persist::error::Error;
 use persist::file::{FileBlob, FileLog};
-use persist::indexed::runtime::{self, RuntimeClient, StreamReadHandle};
+use persist::indexed::runtime::{self, RuntimeClient, RuntimeConfig, StreamReadHandle};
 use persist::mem::MemRegistry;
 use persist::storage::LockInfo;
 use persist::Codec;
@@ -89,6 +89,7 @@ pub fn bench_file_snapshots(c: &mut Criterion) {
             .join(format!("snapshot_bench_blob_{}", path));
         let lock_info = LockInfo::new_no_reentrance("snapshot_bench".to_owned());
         runtime::start(
+            RuntimeConfig::default(),
             FileLog::new(log_dir, lock_info.clone())?,
             FileBlob::new(blob_dir, lock_info)?,
             &MetricsRegistry::new(),

--- a/src/persist/examples/kafka_upsert.rs
+++ b/src/persist/examples/kafka_upsert.rs
@@ -18,7 +18,9 @@ use std::{cmp, env, process};
 use ore::metrics::MetricsRegistry;
 use ore::now::{system_time, NowFn};
 use persist::file::{FileBlob, FileLog};
-use persist::indexed::runtime::{self, RuntimeClient, StreamReadHandle, StreamWriteHandle};
+use persist::indexed::runtime::{
+    self, RuntimeClient, RuntimeConfig, StreamReadHandle, StreamWriteHandle,
+};
 use persist::storage::LockInfo;
 use persist::{Codec, Data};
 use timely::dataflow::channels::pact::Pipeline;
@@ -46,7 +48,7 @@ fn run(args: Vec<String>) -> Result<(), Box<dyn Error>> {
         let lock_info = LockInfo::new("kafka_upsert".into(), "nonce".into())?;
         let log = FileLog::new(base_dir.join("log"), lock_info.clone())?;
         let blob = FileBlob::new(base_dir.join("blob"), lock_info)?;
-        runtime::start(log, blob, &MetricsRegistry::new())?
+        runtime::start(RuntimeConfig::default(), log, blob, &MetricsRegistry::new())?
     };
 
     timely::execute_directly(|worker| {

--- a/src/persist/src/indexed/mod.rs
+++ b/src/persist/src/indexed/mod.rs
@@ -845,6 +845,14 @@ impl<L: Log, B: Blob> Indexed<L, B> {
                 }
             }
 
+            // Don't bother minting empty trace batches that we'll just have to
+            // compact later, it's wasteful of precious storage bandwidth and
+            // everything works perfectly well when the trace upper hasn't yet
+            // caught up to sealed.
+            if updates.is_empty() {
+                continue;
+            }
+
             // Trace batches are required to be sorted and consolidated by ((k, v), t)
             differential_dataflow::consolidation::consolidate_updates(&mut updates);
             updates_by_id.push((*id, seal, updates.clone()));

--- a/src/persist/src/mem.rs
+++ b/src/persist/src/mem.rs
@@ -18,7 +18,7 @@ use ore::metrics::MetricsRegistry;
 
 use crate::error::Error;
 use crate::indexed::metrics::Metrics;
-use crate::indexed::runtime::{self, RuntimeClient};
+use crate::indexed::runtime::{self, RuntimeClient, RuntimeConfig};
 use crate::indexed::Indexed;
 use crate::storage::{Blob, LockInfo, Log, SeqNo};
 use crate::unreliable::{UnreliableBlob, UnreliableHandle, UnreliableLog};
@@ -348,7 +348,12 @@ impl MemRegistry {
     pub fn runtime_no_reentrance(&mut self) -> Result<RuntimeClient, Error> {
         let log = self.log_no_reentrance()?;
         let blob = self.blob_no_reentrance()?;
-        runtime::start(log, blob, &MetricsRegistry::new())
+        runtime::start(
+            RuntimeConfig::for_tests(),
+            log,
+            blob,
+            &MetricsRegistry::new(),
+        )
     }
 
     /// Open a [RuntimeClient] with unreliable storage backed by the given
@@ -361,7 +366,12 @@ impl MemRegistry {
         let log = UnreliableLog::from_handle(log, unreliable.clone());
         let blob = self.blob_no_reentrance()?;
         let blob = UnreliableBlob::from_handle(blob, unreliable);
-        runtime::start(log, blob, &MetricsRegistry::new())
+        runtime::start(
+            RuntimeConfig::for_tests(),
+            log,
+            blob,
+            &MetricsRegistry::new(),
+        )
     }
 }
 
@@ -411,7 +421,12 @@ impl MemMultiRegistry {
         let lock_info = LockInfo::new_no_reentrance(lock_info.to_owned());
         let log = self.log(path, lock_info.clone())?;
         let blob = self.blob(path, lock_info)?;
-        runtime::start(log, blob, &MetricsRegistry::new())
+        runtime::start(
+            RuntimeConfig::for_tests(),
+            log,
+            blob,
+            &MetricsRegistry::new(),
+        )
     }
 }
 

--- a/src/persist/src/nemesis/direct.rs
+++ b/src/persist/src/nemesis/direct.rs
@@ -272,6 +272,7 @@ mod tests {
     use ore::metrics::MetricsRegistry;
 
     use crate::file::{FileBlob, FileLog};
+    use crate::indexed::runtime::RuntimeConfig;
     use crate::mem::MemRegistry;
     use crate::nemesis;
     use crate::nemesis::generator::GeneratorConfig;
@@ -296,7 +297,12 @@ mod tests {
             let log = UnreliableLog::from_handle(log, unreliable.clone());
             let blob = FileBlob::new(blob_dir, ("reentrance0", "direct_file").into())?;
             let blob = UnreliableBlob::from_handle(blob, unreliable);
-            runtime::start(log, blob, &MetricsRegistry::new())
+            runtime::start(
+                RuntimeConfig::for_tests(),
+                log,
+                blob,
+                &MetricsRegistry::new(),
+            )
         })
         .expect("initial start failed");
         // TODO: At the moment, running this for 100 steps takes a bit over a


### PR DESCRIPTION
### Motivation

  * This PR fixes a recognized bug. #8253

### Description

HACK: This rate limits how much we call step in response to workloads consisting entirely of write, seal, and allow_compaction (which is exactly what we expect in the common/steady state). At the moment, step is too aggressive about compaction if called in a tight loop, causing excess disk usage. This is exactly what happens if coord is getting steady read traffic over indexes derived directly or indirectly from tables (it continually seals).

The downside to this rate limiting is that it introduces artificial latency into filling the response futures we returned to the client as well as to updating listeners. The former blocks literally no critical paths in the initial persisted system tables test. The latter holds up reading from the system tables being persisted, which is considered an acceptable tradeoff for the short-term. In the long-term, we'll do something better (probably by using Buffer).

Closes #8253

### Checklist

- [x] This PR has adequate test coverage.
- [x] This PR adds a release note for any user-facing behavior changes.
