### PR TITLE
sql-parser,testdrive: fix CREATE SINK syntax bug

### DIFF
--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -597,19 +597,20 @@ impl_display_t!(CreateSinkConnector);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct KafkaConsistency<T: AstInfo> {
     pub topic: String,
-    pub topic_format: Option<Format<T>>,
+    pub format: Option<Format<T>>,
 }
 
 impl<T: AstInfo> AstDisplay for KafkaConsistency<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
-        f.write_str(" CONSISTENCY TOPIC '");
+        f.write_str(" WITH CONSISTENCY (TOPIC '");
         f.write_node(&display::escape_single_quote_string(&self.topic));
         f.write_str("'");
 
-        if let Some(format) = self.topic_format.as_ref() {
-            f.write_str(" CONSISTENCY FORMAT ");
+        if let Some(format) = self.format.as_ref() {
+            f.write_str(" FORMAT ");
             f.write_node(format);
         }
+        f.write_str(")");
     }
 }
 impl_display_t!(KafkaConsistency);

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1931,17 +1931,17 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_kafka_consistency(&mut self) -> Result<Option<KafkaConsistency<Raw>>, ParserError> {
-        if self.parse_keywords(&[CONSISTENCY, TOPIC]) {
+        if self.parse_keywords(&[WITH, CONSISTENCY]) {
+            self.expect_token(&Token::LParen)?;
+            self.expect_keyword(TOPIC)?;
             let topic = self.parse_literal_string()?;
-            let topic_format = if self.parse_keywords(&[CONSISTENCY, FORMAT]) {
+            let format = if self.parse_keyword(FORMAT) {
                 Some(self.parse_format()?)
             } else {
                 None
             };
-            Ok(Some(KafkaConsistency {
-                topic,
-                topic_format,
-            }))
+            self.expect_token(&Token::RParen)?;
+            Ok(Some(KafkaConsistency { topic, format }))
         } else {
             Ok(None)
         }

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -679,11 +679,39 @@ CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) FORMAT
 CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), from: UnresolvedObjectName([Ident("bar")]), connector: Kafka { broker: "baz", topic: "topic", key: Some([Ident("a"), Ident("b")]), consistency: None }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
 
 parse-statement
+CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) CONSISTENCY TOPIC 'consistency'
+----
+error: Expected end of statement, found CONSISTENCY
+CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) CONSISTENCY TOPIC 'consistency'
+                                                                          ^
+
+parse-statement
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) CONSISTENCY TOPIC 'consistency' CONSISTENCY FORMAT BYTES FORMAT BYTES
 ----
-CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) CONSISTENCY TOPIC 'consistency' CONSISTENCY FORMAT BYTES FORMAT BYTES WITH SNAPSHOT
+error: Expected end of statement, found CONSISTENCY
+CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) CONSISTENCY TOPIC 'consistency' CONSISTENCY FORMAT BYTES FORMAT BYTES
+                                                                          ^
+
+parse-statement
+CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) WITH CONSISTENCY (TOPIC 'consistency') FORMAT BYTES
+----
+CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) WITH CONSISTENCY (TOPIC 'consistency') FORMAT BYTES WITH SNAPSHOT
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), from: UnresolvedObjectName([Ident("bar")]), connector: Kafka { broker: "baz", topic: "topic", key: Some([Ident("a"), Ident("b")]), consistency: Some(KafkaConsistency { topic: "consistency", topic_format: Some(Bytes) }) }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), from: UnresolvedObjectName([Ident("bar")]), connector: Kafka { broker: "baz", topic: "topic", key: Some([Ident("a"), Ident("b")]), consistency: Some(KafkaConsistency { topic: "consistency", format: None }) }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
+
+parse-statement
+CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) WITH CONSISTENCY (TOPIC 'consistency' FORMAT BYTES) FORMAT BYTES
+----
+CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) WITH CONSISTENCY (TOPIC 'consistency' FORMAT BYTES) FORMAT BYTES WITH SNAPSHOT
+=>
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), from: UnresolvedObjectName([Ident("bar")]), connector: Kafka { broker: "baz", topic: "topic", key: Some([Ident("a"), Ident("b")]), consistency: Some(KafkaConsistency { topic: "consistency", format: Some(Bytes) }) }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
+
+parse-statement
+CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) WITH CONSISTENCY (TOPIC 'consistency' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (a = 'b')) FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (a = 'b')
+----
+CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) WITH CONSISTENCY (TOPIC 'consistency' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (a = 'b')) FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (a = 'b') WITH SNAPSHOT
+=>
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), from: UnresolvedObjectName([Ident("bar")]), connector: Kafka { broker: "baz", topic: "topic", key: Some([Ident("a"), Ident("b")]), consistency: Some(KafkaConsistency { topic: "consistency", format: Some(Avro(Csr { csr_connector: CsrConnector { url: "http://localhost:8081", seed: None, with_options: [Value { name: Ident("a"), value: String("b") }] } })) }) }, with_options: [], format: Some(Avro(Csr { csr_connector: CsrConnector { url: "http://localhost:8081", seed: None, with_options: [Value { name: Ident("a"), value: String("b") }] } })), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
 
 parse-statement
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY FORMAT BYTES

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1521,10 +1521,7 @@ fn get_kafka_sink_consistency_config(
     consistency_topic: Option<String>,
 ) -> Result<Option<(String, KafkaSinkFormat)>, anyhow::Error> {
     let result = match consistency {
-        Some(KafkaConsistency {
-            topic,
-            topic_format,
-        }) => match topic_format {
+        Some(KafkaConsistency { topic, format }) => match format {
             Some(Format::Avro(AvroSchema::Csr {
                 csr_connector:
                     CsrConnector {

--- a/test/testdrive/kafka-exactly-once-sink.td
+++ b/test/testdrive/kafka-exactly-once-sink.td
@@ -235,23 +235,23 @@ $ kafka-verify format=avro sink=materialize.public.rt_binding_consistency_test_s
 # Can't provide CONSISTENCY FORMAT without a TOPIC
 ! CREATE SINK double_avro FROM unnamed_cols
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'double-avro'
-  CONSISTENCY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+    WITH CONSISTENCY (FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}')
   WITH (consistency_topic='willfail')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-Expected end of statement, found CONSISTENCY
+Expected TOPIC, found FORMAT
 
 # Can't provide CONSISTENCY FORMAT and consistency_topic WITH option
 ! CREATE SINK double_avro FROM unnamed_cols
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'double-avro'
-    CONSISTENCY TOPIC 'topicname'
-    WITH (consistency_topic='willfail')
+    WITH CONSISTENCY (TOPIC 'topicname')
+  WITH (consistency_topic='willfail')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 Cannot specify consistency_topic and CONSISTENCY options simultaneously
 
 # Can't create sinks with JSON-encoded consistency topics
 ! CREATE SINK double_avro FROM unnamed_cols
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'double-avro'
-    CONSISTENCY TOPIC 'consistency-double-avro' CONSISTENCY FORMAT JSON
+    WITH CONSISTENCY (TOPIC 'consistency-double-avro' FORMAT JSON)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 CONSISTENCY FORMAT JSON not yet supported
 
@@ -259,19 +259,19 @@ CONSISTENCY FORMAT JSON not yet supported
 # of the sink, if valid
 > CREATE SINK default_avro FROM unnamed_cols
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'default-avro'
-    CONSISTENCY TOPIC 'consistency-default-avro'
+    WITH CONSISTENCY (TOPIC 'consistency-default-avro')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 # Fail to default to JSON
 ! CREATE SINK default_avro FROM unnamed_cols
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'default-avro'
-    CONSISTENCY TOPIC 'consistency-default-avro'
+    WITH CONSISTENCY (TOPIC 'consistency-default-avro')
   FORMAT JSON
 CONSISTENCY FORMAT JSON not yet supported
 
 > CREATE SINK double_avro FROM unnamed_cols
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'double-avro'
-    CONSISTENCY TOPIC 'consistency-double-avro' CONSISTENCY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+    WITH CONSISTENCY (TOPIC 'consistency-double-avro' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 $ kafka-verify format=avro sink=materialize.public.double_avro sort-messages=true
@@ -279,7 +279,7 @@ $ kafka-verify format=avro sink=materialize.public.double_avro sort-messages=tru
 
 > CREATE SINK json_avro FROM unnamed_cols
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'json-avro'
-    CONSISTENCY TOPIC 'consistency-json-avro' CONSISTENCY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+    WITH CONSISTENCY (TOPIC 'consistency-json-avro' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}')
   FORMAT JSON
 
 $ kafka-verify format=json sink=materialize.public.json_avro sort-messages=true key=false
@@ -287,32 +287,36 @@ $ kafka-verify format=json sink=materialize.public.json_avro sort-messages=true 
 
 ! CREATE SINK json_reuse_topic FROM unnamed_cols
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'json-reuse-topic'
-    WITH (reuse_topic=true)
+  WITH (reuse_topic=true)
   FORMAT JSON
 For FORMAT JSON, you need to manually specify an Avro consistency topic using 'CONSISTENCY TOPIC consistency_topic CONSISTENCY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY url'. The default of using a JSON consistency topic is not supported.
 
-> CREATE SINK json_reuse_topic FROM unnamed_cols
+! CREATE SINK json_reuse_topic FROM unnamed_cols
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'json-reuse-topic'
-    CONSISTENCY TOPIC 'consistency-json-avro' CONSISTENCY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-    WITH (reuse_topic=true)
+    WITH CONSISTENCY (TOPIC 'consistency-json-avro' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}')
+  WITH (reuse_topic=true)
   FORMAT JSON
+reuse_topic requires that sink input dependencies are sources, materialize.public.unnamed_cols is not
 
-$ kafka-verify format=json sink=materialize.public.json_reuse_topic sort-messages=true key=false
-{"before": null, "after": {"row": {"column1": 1, "b": 2, "column3": 3}}, "transaction": {"id": "0"}}
+> CREATE SINK json_reuse_topic FROM rt_binding_consistency_test_source
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'json-reuse-topic'
+    WITH CONSISTENCY (TOPIC 'consistency-json-avro' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}')
+  WITH (reuse_topic=true)
+  FORMAT JSON
 
 # Default consistency format is Avro if consistency_topic is used
 > CREATE SINK default_avro_2 FROM unnamed_cols
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'default-avro-2'
-    WITH (consistency_topic='default-consistency-avro')
+  WITH (consistency_topic='default-consistency-avro')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
-$ kafka-verify format=avro sink=materialize.public.default_avro sort-messages=true
+$ kafka-verify format=avro sink=materialize.public.default_avro_2 sort-messages=true
 {"before": null, "after": {"row": {"column1": 1, "b": 2, "column3": 3}}, "transaction": {"id": "0"}}
 
 > CREATE SINK json_avro_upsert_key FROM unnamed_cols
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'json-avro-upsert-key'
   KEY (b)
-    CONSISTENCY TOPIC 'consistency-json-avro-upsert-key' CONSISTENCY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+    WITH CONSISTENCY (TOPIC 'consistency-json-avro-upsert-key' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}')
   FORMAT JSON
   ENVELOPE UPSERT
 


### PR DESCRIPTION
### Motivation

Our current `CREATE SINK` syntax [has a bug](https://github.com/MaterializeInc/materialize/issues/8231). This PR updates the `CREATE SINK` syntax to eliminate ambiguity between the two sequential `WITH (..)` clauses. Internal discussion can be [found here](https://materializeinc.slack.com/archives/CMHDK0DK8/p1631740333231000).

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug. [Link to issue.]

  * This PR adds a known-desirable feature. [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

### Description

The following diagram illustrates the proposed syntax change. By introducing the consistency information with a new `WITH CONSISTENCY` clause, and by wrapping the `TOPIC` and `FORMAT` arguments in `()`, we can disambiguate sequential `WITH` options and fix the bug.

<img width="1025" alt="Screen Shot 2021-09-15 at 8 29 11 PM" src="https://user-images.githubusercontent.com/5766027/133544814-5ef7ee2d-2a5b-4ca0-b7d2-b31fb4d3f211.png">


<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details."

-->

### Tips for reviewer

So this PR is incomplete/a WIP because I am not totally sure how I'd migrate something like this. The other migrations in [`migrate.rs`](https://github.com/MaterializeInc/materialize/blob/main/src/coord/src/catalog/migrate.rs) require the stashed `create_sql` strings to still be parseable. Unfortunately, my proposed changes will not allow old `CREATE SINK` statements to be parsed.

I tried to add a new type of migration in the second commit, but I just stubbed it out because I'm not sure if it's totally unhinged. @sploiselle -- would you be able to give your expert migration guidance here? Once you do, I'll complete the PR.

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [ ] This PR has adequate test coverage.
- [ ] This PR adds a release note for any user-facing behavior changes.
