### PR TITLE
persist: forward timestamps to since when read through snapshot (bugfix)

### DIFF
--- a/src/persist/src/nemesis/validator.rs
+++ b/src/persist/src/nemesis/validator.rs
@@ -341,19 +341,9 @@ fn updates_eq(
 ) -> bool {
     // TODO: This is also used by the implementation. Write a slower but more
     // obvious impl of consolidation here and use it for validation.
-    //
-    // TODO: The actual snapshot will eventually be compacted up to some since
-    // frontier and the expected snapshot will need to account for that when
-    // checking equality.
 
-    for (_, t, _) in actual.iter_mut() {
-        for ts in since.elements().iter() {
-            if *t < *ts {
-                *t = *ts;
-            }
-        }
-    }
-
+    // The snapshot has been logically compacted to since, so update our
+    // expected to match.
     for (_, t, _) in expected.iter_mut() {
         for ts in since.elements().iter() {
             if *t < *ts {


### PR DESCRIPTION
The contract of since is that all lesser timestamps will be forwarded to it. We
do this physically during compaction, but don't have hard guarantees about how
long that takes, so we have to account for un-forwarded batches on reads.

Closes #8303

### Motivation

  * This PR fixes a recognized bug. #8303

### Checklist

- [x] This PR has adequate test coverage.
- [x] This PR adds a release note for any user-facing behavior changes.
