### PR TITLE
interchange: emit protobuf data as records

### DIFF
--- a/demo/billing/resources/billing.proto
+++ b/demo/billing/resources/billing.proto
@@ -26,7 +26,7 @@ message Record {
   google.protobuf.Timestamp interval_end = 3;
 
   string meter = 4; // What's being measured
-  uint32 value = 5;
+  int32 value = 5;
 
   ResourceInfo info = 6;
 }

--- a/demo/billing/src/randomizer.rs
+++ b/demo/billing/src/randomizer.rs
@@ -93,7 +93,7 @@ fn random_record(rng: &mut impl Rng, start_at: DateTime<Utc>, max_secs: i64) -> 
     record.set_interval_start(protobuf_timestamp(interval_start));
     record.set_interval_end(protobuf_timestamp(interval_end));
     record.set_meter(meter);
-    record.set_value(val as u32);
+    record.set_value(val as i32);
     record.set_info(ResourceInfo::random(rng));
 
     record

--- a/doc/user/content/demos/microservice.md
+++ b/doc/user/content/demos/microservice.md
@@ -119,7 +119,7 @@ message Record {
   google.protobuf.Timestamp interval_end = 3;   // Interval's end
 
   string meter = 4; // What's being measured
-  uint32 value = 5; // Quantity measured
+  int32 value = 5; // Quantity measured
 
   ResourceInfo info = 6; // Resource for this Record.
 }
@@ -191,27 +191,25 @@ FORMAT PROTOBUF MESSAGE 'billing.Batch'
 ### Normalizing data
 
 The data we receive from the new `billing_source` needs to be normalized from its original structure.
-
-Because we're using `Batch` as our top-level message, we can convert its
-`records` fields into `jsonb` using `jsonb_array_elements`. In Materialize, we
-accomplish this with a materialized view that parses the `jsonb` into a table
-with the columns we know we'll need:
+In Materialize, we can accomplish this with a materialized view:
 
 ```sql
 CREATE MATERIALIZED VIEW billing_records AS
     SELECT
-        r.value->>'id' id,
-        billing_source.id batch_id,
-        r.value->>'interval_start' interval_start,
-        r.value->>'interval_end' interval_end,
-        r.value->>'meter' meter,
-        (r.value->'value')::int value,
-        (r.value->'info'->'client_id')::int client_id,
-        (r.value->'info'->'vm_id')::int vm_id,
-        (r.value->'info'->'cpu_num')::int cpu_num,
-        (r.value->'info'->'memory_gb')::int memory_gb,
-        (r.value->'info'->'disk_gb')::int disk_gb
-    FROM billing_source, jsonb_array_elements(records) AS r;
+        (r).id,
+        id batch_id,
+        to_timestamp(((r).interval_start)."seconds")::text interval_start,
+        to_timestamp(((r).interval_end)."seconds")::text interval_end,
+        (r).meter,
+        ((r)."value")::int,
+        ((r).info).client_id::int,
+        ((r).info).vm_id::int,
+        ((r).info).cpu_num::int,
+        ((r).info).memory_gb::int,
+        ((r).info).disk_gb::int
+    FROM
+        billing_source,
+        unnest(records) as r;
 ```
 
 This makes `billing_records` a normalized view of our data that we can begin
@@ -222,18 +220,19 @@ SHOW COLUMNS FROM billing_records;
 ```
 ```nofmt
      name       | nullable |    type
-----------------+----------+-------------
- id             | true     | text
- batch_id       | true     | text
- interval_start | true     | timestamptz
- interval_end   | true     | timestamptz
- meter          | true     | text
- value          | true     | int4
- client_id      | true     | int4
- vm_id          | true     | int4
- cpu_num        | true     | int4
- memory_gb      | true     | int4
- disk_gb        | true     | int4
+----------------+----------+--------------------------
+ id             | t        | text
+ batch_id       | t        | text
+ interval_start | t        | timestamp with time zone
+ interval_end   | t        | timestamp with time zone
+ meter          | t        | text
+ value          | t        | integer
+ client_id      | t        | integer
+ vm_id          | t        | integer
+ cpu_num        | t        | integer
+ memory_gb      | t        | integer
+ disk_gb        | t        | integer
+(11 rows)
 ```
 
 ### Other source types
@@ -302,7 +301,7 @@ these columns have a relation, even though they do.
 ```sql
 CREATE MATERIALIZED VIEW billing_agg_by_month AS
     SELECT
-        substr AS month,
+        substr(interval_start, 0, 8) as month,
         client_id,
         meter,
         cpu_num,
@@ -311,7 +310,7 @@ CREATE MATERIALIZED VIEW billing_agg_by_month AS
         sum(value)
     FROM billing_records
     GROUP BY
-        substr(interval_start, 0, 8),
+        month,
         client_id,
         meter,
         cpu_num,
@@ -459,27 +458,12 @@ can see that Materialize is ingesting the `protobuf` data and normalizing it.
     We can query this view to see what our denormalized data looks like:
 
     ```sql
-    SELECT jsonb_pretty(records::jsonb) AS records FROM billing_raw_data LIMIT 1;
+    SELECT records FROM billing_raw_data LIMIT 1;
     ```
     ```nofmt
-                               records
-    --------------------------------------------------------------
-     [                                                           +
-       {                                                         +
-         "id": "IYLwLRskSjSC71wk8B_yoA",                         +
-         "info": {                                               +
-           "client_id": 1.0,                                     +
-           "cpu_num": 2.0,                                       +
-           "disk_gb": 128.0,                                     +
-           "memory_gb": 8.0,                                     +
-           "vm_id": 1293.0                                       +
-         },                                                      +
-         "interval_end": "2020-01-28T21:12:51.331566645+00:00",  +
-         "interval_start": "2020-01-28T21:02:21.331566645+00:00",+
-         "meter": "execution_time_ms",                           +
-         "value": 56.0                                           +
-       }                                                         +
-     ]
+                                                               records
+    -----------------------------------------------------------------------------------------------------------------------------
+     {"(43e0b30b-0022-4a90-9594-1977e8dce33a,\"(1632335022,0)\",\"(1632335121,0)\",execution_time_ms,44,\"(2,8,128,22,1375)\")"}
     ```
 
 1. Now, we can see what our normalization looks like (the `billing_records` view
@@ -509,13 +493,13 @@ can see that Materialize is ingesting the `protobuf` data and normalizing it.
     SELECT * FROM billing_agg_by_month ORDER BY sum DESC LIMIT 5;
     ```
     ```nofmt
-            month        | client_id |       meter       | cpu_num | memory_gb | disk_gb | sum
-    ---------------------+-----------+-------------------+---------+-----------+---------+------
-     2020-02-01 00:00:00 |        51 | execution_time_ms |       1 |         8 |     128 | 2871
-     2020-02-01 00:00:00 |         9 | execution_time_ms |       1 |         8 |     128 | 2808
-     2020-02-01 00:00:00 |        89 | execution_time_ms |       2 |        16 |     128 | 2711
-     2020-02-01 00:00:00 |        25 | execution_time_ms |       2 |        16 |     128 | 2650
-     2020-02-01 00:00:00 |        29 | execution_time_ms |       2 |        16 |     128 | 2614
+    month  | client_id |       meter       | cpu_num | memory_gb | disk_gb |  sum
+    ---------+-----------+-------------------+---------+-----------+---------+-------
+    2021-09 |        16 | execution_time_ms |       1 |        16 |     128 | 25330
+    2021-09 |        86 | execution_time_ms |       1 |        16 |     128 | 24587
+    2021-09 |        38 | execution_time_ms |       2 |         8 |     128 | 24575
+    2021-09 |        97 | execution_time_ms |       1 |        16 |     128 | 24488
+    2021-09 |        50 | execution_time_ms |       2 |        16 |     128 | 24319
     ```
 
 1. Now, we can look at our customers' monthly bills by selecting from
@@ -525,13 +509,13 @@ can see that Materialize is ingesting the `protobuf` data and normalizing it.
     SELECT * FROM billing_monthly_statement ORDER BY monthly_bill DESC LIMIT 5;
     ```
     ```nofmt
-            month        | client_id | execution_time_ms | cpu_num | memory_gb | monthly_bill
-   ---------------------+-----------+-------------------+---------+-----------+--------------
-   2020-02-01 00:00:00 |        29 |              2614 |       2 |        16 |          418
-   2020-02-01 00:00:00 |        55 |              2580 |       1 |        16 |          381
-   2020-02-01 00:00:00 |        14 |              2470 |       1 |        16 |          363
-   2020-02-01 00:00:00 |        78 |              2184 |       2 |        16 |          349
-   2020-02-01 00:00:00 |        51 |              2321 |       1 |        16 |          336
+    month  | client_id | execution_time_ms | cpu_num | memory_gb | monthly_bill
+    ---------+-----------+-------------------+---------+-----------+--------------
+    2021-09 |        51 |             22709 |       2 |        16 |         3542
+    2021-09 |        93 |             22134 |       2 |        16 |         3541
+    2021-09 |        58 |             23555 |       2 |        16 |         3533
+    2021-09 |        89 |             21936 |       2 |        16 |         3509
+    2021-09 |        55 |             22352 |       2 |        16 |         3486
     ```
 
 1. We an also perform arbitrary `SELECT`s on our views to explore new aggregations we might want to materialize with their own views. For example, we can view each user's total monthly bill:

--- a/src/interchange/src/protobuf.rs
+++ b/src/interchange/src/protobuf.rs
@@ -17,7 +17,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use serde_protobuf::descriptor::{Descriptors, FieldDescriptor, FieldLabel, FieldType};
 
 use ore::str::StrExt;
-use repr::{ColumnType, RelationDesc, RelationType, ScalarType};
+use repr::{ColumnName, ColumnType, RelationDesc, RelationType, ScalarType};
 
 fn proto_message_name(message_name: &str) -> String {
     // Prepend a . (following the serde-protobuf naming scheme to list root paths
@@ -30,92 +30,81 @@ fn proto_message_name(message_name: &str) -> String {
     }
 }
 
-fn validate_proto_field<'a>(
+fn derive_scalar_type_from_proto_field<'a>(
     seen_messages: &mut HashSet<&'a str>,
     field: &'a FieldDescriptor,
     descriptors: &'a Descriptors,
 ) -> Result<ScalarType> {
-    Ok(match field.field_label() {
+    let field_type = field.field_type(descriptors);
+    match field.field_label() {
         FieldLabel::Required => bail!("Required field {} not supported", field.name()),
         FieldLabel::Repeated => {
-            validate_proto_field_resolved(seen_messages, field, descriptors)?;
-            ScalarType::Jsonb
-        }
-        FieldLabel::Optional => match field.field_type(descriptors) {
-            FieldType::Bool => ScalarType::Bool,
-            FieldType::Int32 | FieldType::SInt32 | FieldType::SFixed32 => ScalarType::Int32,
-            FieldType::Int64 | FieldType::SInt64 | FieldType::SFixed64 => ScalarType::Int64,
-            FieldType::Enum(_) => ScalarType::String,
-            FieldType::Float => ScalarType::Float32,
-            FieldType::Double => ScalarType::Float64,
-            FieldType::UInt32 => bail!("Protobuf type \"uint32\" is not supported"),
-            FieldType::UInt64 => bail!("Protobuf type \"uint64\" is not supported"),
-            FieldType::Fixed32 => bail!("Protobuf type \"fixed32\" is not supported"),
-            FieldType::Fixed64 => bail!("Protobuf type \"fixed64\" is not supported"),
-            FieldType::String => ScalarType::String,
-            FieldType::Bytes => ScalarType::Bytes,
-            FieldType::Message(m) => {
-                if seen_messages.contains(m.name()) {
-                    bail!("Recursive types are not supported: {}", m.name());
-                }
-                seen_messages.insert(m.name());
-                for f in m.fields().iter() {
-                    validate_proto_field_resolved(seen_messages, &f, descriptors)?;
-                }
-                seen_messages.remove(m.name());
-                ScalarType::Jsonb
+            if let FieldType::Bytes = field_type {
+                bail!("Arrays or nested messages with bytes objects are not currently supported")
             }
-            FieldType::Group => bail!("Unions are currently not supported"),
-            FieldType::UnresolvedMessage(m) => bail!("Unresolved message {} not supported", m),
-            FieldType::UnresolvedEnum(e) => bail!("Unresolved enum {} not supported", e),
+        }
+        FieldLabel::Optional => (),
+    }
+
+    let typ = derive_scalar_type(seen_messages, field, descriptors)?;
+    Ok(match field.field_label() {
+        FieldLabel::Repeated => ScalarType::List {
+            element_type: Box::new(typ),
+            custom_oid: None,
         },
+        _ => typ,
     })
 }
 
-fn validate_proto_field_resolved<'a>(
+fn derive_scalar_type<'a>(
     seen_messages: &mut HashSet<&'a str>,
     field: &'a FieldDescriptor,
     descriptors: &'a Descriptors,
-) -> Result<()> {
-    match field.field_label() {
-        FieldLabel::Required => bail!("Required field {} not supported", field.name()),
-        FieldLabel::Repeated | FieldLabel::Optional => match field.field_type(descriptors) {
-            FieldType::Bool
-            | FieldType::Int32
-            | FieldType::SInt32
-            | FieldType::SFixed32
-            | FieldType::Int64
-            | FieldType::SInt64
-            | FieldType::SFixed64
-            | FieldType::UInt32
-            | FieldType::Fixed32
-            | FieldType::UInt64
-            | FieldType::Fixed64
-            | FieldType::Float
-            | FieldType::Double
-            | FieldType::String
-            | FieldType::Enum(_) => (),
-
-            FieldType::Message(m) => {
-                if seen_messages.contains(m.name()) {
-                    bail!("Recursive types are not supported: {}", m.name());
-                }
-                seen_messages.insert(m.name());
-                for f in m.fields().iter() {
-                    validate_proto_field_resolved(seen_messages, &f, descriptors)?;
-                }
-                seen_messages.remove(m.name());
+) -> Result<ScalarType> {
+    Ok(match field.field_type(descriptors) {
+        FieldType::Bool => ScalarType::Bool,
+        FieldType::Int32 | FieldType::SInt32 | FieldType::SFixed32 => ScalarType::Int32,
+        FieldType::Int64 | FieldType::SInt64 | FieldType::SFixed64 => ScalarType::Int64,
+        FieldType::Enum(_) => ScalarType::String,
+        FieldType::Float => ScalarType::Float32,
+        FieldType::Double => ScalarType::Float64,
+        FieldType::UInt32 => bail!("Protobuf type \"uint32\" is not supported"),
+        FieldType::UInt64 => bail!("Protobuf type \"uint64\" is not supported"),
+        FieldType::Fixed32 => bail!("Protobuf type \"fixed32\" is not supported"),
+        FieldType::Fixed64 => bail!("Protobuf type \"fixed64\" is not supported"),
+        FieldType::String => ScalarType::String,
+        FieldType::Bytes => ScalarType::Bytes,
+        FieldType::Message(m) => {
+            if seen_messages.contains(m.name()) {
+                bail!("Recursive types are not supported: {}", m.name());
             }
-            FieldType::Bytes => {
-                bail!("Arrays or nested messages with bytes objects are not currently supported")
+            seen_messages.insert(m.name());
+            let mut fields = Vec::with_capacity(m.fields().len());
+            for field in m.fields() {
+                let column_name = ColumnName::from(field.name());
+                let scalar_type =
+                    derive_scalar_type_from_proto_field(seen_messages, field, descriptors)?;
+                let nullable = match field.field_label() {
+                    FieldLabel::Optional => true,
+                    FieldLabel::Repeated | FieldLabel::Required => false,
+                };
+                let column_type = ColumnType {
+                    scalar_type,
+                    nullable,
+                };
+                fields.push((column_name, column_type))
             }
-            FieldType::Group => bail!("Unions are currently not supported"),
-            FieldType::UnresolvedMessage(a) => bail!("Nested message type {} unresolved", a),
-            FieldType::UnresolvedEnum(e) => bail!("Unresolved enum type {}", e),
-        },
-    }
-
-    Ok(())
+            seen_messages.remove(m.name());
+            ScalarType::Record {
+                fields,
+                custom_oid: None,
+                custom_name: None,
+            }
+        }
+        FieldType::Group => bail!("Unions are currently not supported"),
+        FieldType::UnresolvedMessage(m) => bail!("Unresolved message {} not supported", m),
+        FieldType::UnresolvedEnum(e) => bail!("Unresolved enum {} not supported", e),
+    })
 }
 
 pub fn decode_descriptors(descriptors: &[u8]) -> Result<decode::DecodedDescriptors> {
@@ -163,7 +152,11 @@ pub fn validate_descriptors(message_name: &str, descriptors: &Descriptors) -> Re
                 /// All the fields have to be optional, so mark a field as
                 /// nullable if it doesn't have any defaults
                 nullable: f.default_value().is_none(),
-                scalar_type: validate_proto_field(&mut seen_messages, &f, descriptors)?,
+                scalar_type: derive_scalar_type_from_proto_field(
+                    &mut seen_messages,
+                    &f,
+                    descriptors,
+                )?,
             })
         })
         .collect::<Result<Vec<_>>>()?;
@@ -201,6 +194,35 @@ mod tests {
         message: &MessageDescriptor,
         descriptors: &Descriptors,
     ) -> Result<(), Error> {
+        let check_types = |name: &str,
+                           field_type: FieldType,
+                           field_label: FieldLabel,
+                           scalar_type: &ScalarType| {
+            match (field_type, scalar_type) {
+            (FieldType::Bool, ScalarType::Bool)
+            | (FieldType::Int32, ScalarType::Int32)
+            | (FieldType::SInt32, ScalarType::Int32)
+            | (FieldType::SFixed32, ScalarType::Int32)
+            | (FieldType::Enum(_), ScalarType::String)
+            | (FieldType::Int64, ScalarType::Int64)
+            | (FieldType::SInt64, ScalarType::Int64)
+            | (FieldType::SFixed64, ScalarType::Int64)
+            | (FieldType::Float, ScalarType::Float32)
+            | (FieldType::Double, ScalarType::Float64)
+            | (FieldType::UInt32, ScalarType::Numeric {scale: Some(0)})
+            | (FieldType::Fixed32, ScalarType::Numeric {scale: Some(0)})
+            | (FieldType::UInt64, ScalarType::Numeric {scale: Some(0)})
+            | (FieldType::Fixed64, ScalarType::Numeric {scale: Some(0)})
+            | (FieldType::String, ScalarType::String)
+            | (FieldType::Bytes, ScalarType::Bytes)
+            | (FieldType::Message(_), ScalarType::Record { .. }) => return Ok(()),
+            | (ft, st) => bail!(
+                "Mismatched field types for proto field {:?} proto type {:?} label {:?} scalar type {:?}",
+                name, ft, field_label, st
+            ),
+        }
+        };
+
         for (field_descriptor, (column_name, column_type)) in
             message.fields().iter().zip(relation.iter())
         {
@@ -213,42 +235,33 @@ mod tests {
                 );
             }
 
-            match (
-                field_descriptor.field_type(descriptors),
-                field_descriptor.field_label(),
-                &column_type.scalar_type,
-            ) {
-                (FieldType::Bool, FieldLabel::Optional, ScalarType::Bool)
-                | (FieldType::Int32, FieldLabel::Optional, ScalarType::Int32)
-                | (FieldType::SInt32, FieldLabel::Optional, ScalarType::Int32)
-                | (FieldType::SFixed32, FieldLabel::Optional, ScalarType::Int32)
-                | (FieldType::Enum(_), FieldLabel::Optional, ScalarType::String)
-                | (FieldType::Int64, FieldLabel::Optional, ScalarType::Int64)
-                | (FieldType::SInt64, FieldLabel::Optional, ScalarType::Int64)
-                | (FieldType::SFixed64, FieldLabel::Optional, ScalarType::Int64)
-                | (FieldType::Float, FieldLabel::Optional, ScalarType::Float32)
-                | (FieldType::Double, FieldLabel::Optional, ScalarType::Float64)
-                | (FieldType::UInt32, FieldLabel::Optional, ScalarType::Numeric {scale: Some(0)})
-                | (FieldType::Fixed32, FieldLabel::Optional, ScalarType::Numeric {scale: Some(0)})
-                | (FieldType::UInt64, FieldLabel::Optional, ScalarType::Numeric {scale: Some(0)})
-                | (FieldType::Fixed64, FieldLabel::Optional, ScalarType::Numeric {scale: Some(0)})
-                | (FieldType::String, FieldLabel::Optional, &ScalarType::String)
-                | (FieldType::Bytes, FieldLabel::Optional, ScalarType::Bytes)
-                | (FieldType::Message(_), FieldLabel::Optional, ScalarType::Jsonb) => (),
-
-                (ft, FieldLabel::Optional, st) => bail!("Incorrect protobuf optional type {:?} mapping to Materialize type {:?}", ft, st),
-                (ft, FieldLabel::Repeated, ScalarType::Jsonb) => {
-                    match ft {
-                        FieldType::UnresolvedMessage(_) | FieldType::UnresolvedEnum(_) | FieldType::Group => {
-                            bail!("Unsupported repeated type {:?}", ft)
-                        }
-                        _ => (),
-                    }
+            match field_descriptor.field_label() {
+                FieldLabel::Required => {
+                    bail!("Unsupported required type {:?}", field_descriptor.name())
                 }
-                (ft, label, st) => bail!(
-                    "Mismatched field types for proto field {:?} proto type {:?} label {:?} relationtype {:?}",
-                    field_descriptor.name(), ft, label, st
-                ),
+                FieldLabel::Optional => check_types(
+                    field_descriptor.name(),
+                    field_descriptor.field_type(descriptors),
+                    FieldLabel::Optional,
+                    &column_type.scalar_type,
+                )?,
+                FieldLabel::Repeated => {
+                    let inner_typ =
+                        if let ScalarType::List { element_type, .. } = &column_type.scalar_type {
+                            *element_type.clone()
+                        } else {
+                            bail!(
+                                "Expected list for FieldLabel::Repeated, got {:?}",
+                                &column_type.scalar_type
+                            )
+                        };
+                    check_types(
+                        field_descriptor.name(),
+                        field_descriptor.field_type(descriptors),
+                        FieldLabel::Repeated,
+                        &inner_typ,
+                    )?
+                }
             }
         }
 
@@ -413,14 +426,11 @@ mod tests {
 
         let d = datums[0];
         if let Datum::List(d) = d {
-            let datumlist = d.iter().collect::<Vec<Datum>>();
+            let mut datumlist = d.iter().collect::<Vec<Datum>>();
+            datumlist.sort();
             assert_eq!(
                 datumlist,
-                vec![
-                    Datum::Float64(OrderedFloat::from(1.0)),
-                    Datum::Float64(OrderedFloat::from(2.0)),
-                    Datum::Float64(OrderedFloat::from(3.0))
-                ]
+                vec![Datum::Int32(1), Datum::Int32(2), Datum::Int32(3)]
             );
         } else {
             panic!("Expected the first field to be a list of datums!");
@@ -452,21 +462,22 @@ mod tests {
             .unwrap();
         let datums = row.iter().collect::<Vec<_>>();
         let d = datums[0];
-        if let Datum::Map(d) = d {
-            let datumdict = d.iter().collect::<Vec<(&str, Datum)>>();
+        if let Datum::List(d) = d {
+            let mut datumlist = d.iter().collect::<Vec<Datum>>();
+            datumlist.sort();
             assert_eq!(
-                datumdict,
+                datumlist,
                 vec![
-                    ("color_field", Datum::String("RED")),
-                    ("double_field", Datum::Float64(OrderedFloat::from(0.0))),
-                    ("float_field", Datum::Float64(OrderedFloat::from(0.0))),
-                    ("int64_field", Datum::Float64(OrderedFloat::from(0.0))),
-                    ("int_field", Datum::Float64(OrderedFloat::from(1.0))),
-                    ("string_field", Datum::String("one")),
+                    Datum::Int32(1),
+                    Datum::Float64(OrderedFloat(0.0)),
+                    Datum::Float64(OrderedFloat(0.0)),
+                    Datum::Float64(OrderedFloat(0.0)),
+                    Datum::String("RED"),
+                    Datum::String("one")
                 ]
-            );
+            )
         } else {
-            panic!("Expected the first field to be a dict of datums!");
+            panic!("Expected the first field to be a list of datums!");
         }
 
         assert_eq!(datums[1], Datum::Null);
@@ -490,33 +501,32 @@ mod tests {
         let datums = row2.iter().collect::<Vec<_>>();
 
         let d = datums[1];
-        if let Datum::Map(d) = d {
-            let datumdict = d.iter().collect::<Vec<(&str, Datum)>>();
+        if let Datum::List(d) = d {
+            let mut datumlist = d.iter().collect::<Vec<Datum>>();
+            datumlist.sort();
 
-            for (name, datum) in datumdict.iter() {
-                match (name, datum) {
-                    (&"string_field", Datum::List(d)) => {
-                        let datumlist = d.iter().collect::<Vec<Datum>>();
-                        assert_eq!(
-                            datumlist,
-                            vec![
-                                Datum::String("start"),
-                                Datum::String("two"),
-                                Datum::String("three"),
-                            ]
-                        );
-                    }
-                    (&"int_field", d) => {
-                        assert_eq!(*d, Datum::List(DatumList::empty()));
-                    }
-                    (&"double_field", d) => {
-                        assert_eq!(*d, Datum::List(DatumList::empty()));
-                    }
-                    _ => panic!("Nested arrays test failed"),
-                }
+            let first = datumlist[0];
+            assert_eq!(first, Datum::List(DatumList::empty()));
+
+            let second = datumlist[1];
+            assert_eq!(second, Datum::List(DatumList::empty()));
+
+            let third = datumlist[2];
+            if let Datum::List(dl) = third {
+                let third_datumlist = dl.iter().collect::<Vec<Datum>>();
+                assert_eq!(
+                    third_datumlist,
+                    vec![
+                        Datum::String("start"),
+                        Datum::String("two"),
+                        Datum::String("three"),
+                    ]
+                );
+            } else {
+                panic!("expected datum to be list")
             }
         } else {
-            panic!("Expected the second field to be a dict of datums!");
+            panic!("Expected the second field to be a list of datums!");
         }
     }
 
@@ -548,21 +558,22 @@ mod tests {
             let datumlist = d.iter().collect::<Vec<Datum>>();
 
             for datum in datumlist {
-                if let Datum::Map(d) = datum {
-                    let datumdict = d.iter().collect::<Vec<(&str, Datum)>>();
+                if let Datum::List(d) = datum {
+                    let mut inner_datumlist = d.iter().collect::<Vec<Datum>>();
+                    inner_datumlist.sort();
                     assert_eq!(
-                        datumdict,
+                        inner_datumlist,
                         vec![
-                            ("color_field", Datum::String("RED")),
-                            ("double_field", Datum::Float64(OrderedFloat::from(0.0))),
-                            ("float_field", Datum::Float64(OrderedFloat::from(0.0))),
-                            ("int64_field", Datum::Float64(OrderedFloat::from(0.0))),
-                            ("int_field", Datum::Float64(OrderedFloat::from(1.0))),
-                            ("string_field", Datum::String("")),
+                            Datum::Int32(1),
+                            Datum::Float64(OrderedFloat(0.0)),
+                            Datum::Float64(OrderedFloat(0.0)),
+                            Datum::Float64(OrderedFloat(0.0)),
+                            Datum::String(""),
+                            Datum::String("RED")
                         ]
-                    );
+                    )
                 } else {
-                    panic!("Expected the inner elements to be dicts of datums");
+                    panic!("Expected the inner elements to be lists of datums");
                 }
             }
         } else {

--- a/src/interchange/src/protobuf/decode.rs
+++ b/src/interchange/src/protobuf/decode.rs
@@ -9,7 +9,6 @@
 
 use anyhow::{anyhow, bail, Context, Result};
 
-use num_traits::ToPrimitive;
 use ordered_float::OrderedFloat;
 use serde::de::Deserialize;
 use serde_protobuf::de::Deserializer;
@@ -18,9 +17,9 @@ use serde_protobuf::value::Value as ProtoValue;
 use serde_value::Value as SerdeValue;
 
 use repr::adt::numeric::Numeric;
-use repr::{Datum, DatumList, Row};
+use repr::{ColumnType, Datum, DatumList, Row, ScalarType};
 
-use crate::protobuf::proto_message_name;
+use crate::protobuf::{proto_message_name, validate_descriptors};
 
 /// Manages required metadata to read protobuf
 #[derive(Debug)]
@@ -56,6 +55,7 @@ impl Decoder {
                 .map_err(|e| anyhow!("Creating an input stream to parse protobuf: {}", e))?;
         let deserialized_message =
             SerdeValue::deserialize(&mut deserializer).context("Deserializing into rust object")?;
+        let relation_type = validate_descriptors(&self.message_name, &self.descriptors)?;
 
         let msg_name = &self.message_name;
         let mut packer = &mut self.packer;
@@ -68,6 +68,7 @@ impl Decoder {
                     msg_name
                 )
             })?,
+            &relation_type.typ().column_types,
             &mut packer,
         )?;
         if push_metadata {
@@ -93,6 +94,7 @@ fn extract_row_into(
     deserialized_message: SerdeValue,
     descriptors: &Descriptors,
     message_descriptors: &MessageDescriptor,
+    column_types: &[ColumnType],
     packer: &mut Row,
 ) -> Result<()> {
     let deserialized_message = match deserialized_message {
@@ -101,12 +103,11 @@ fn extract_row_into(
     };
 
     // TODO: This is actually unpacking a row, it should always return json
-    for f in message_descriptors.fields().iter() {
+    for (f, column_type) in message_descriptors.fields().iter().zip(column_types) {
         let key = SerdeValue::String(f.name().to_string());
         let value = deserialized_message.get(&key);
-
         if let Some(value) = value {
-            json_from_serde_value(&value, packer, f, descriptors)?;
+            json_from_serde_value(&value, packer, f, descriptors, column_type)?;
         } else {
             packer.push(default_datum_from_field(f, descriptors)?);
         }
@@ -124,6 +125,7 @@ fn json_from_serde_value(
     packer: &mut Row,
     f: &FieldDescriptor,
     descriptors: &Descriptors,
+    column_type: &ColumnType,
 ) -> Result<()> {
     packer.push(match val {
         SerdeValue::Bool(true) => Datum::True,
@@ -142,13 +144,13 @@ fn json_from_serde_value(
         SerdeValue::Bytes(b) => Datum::Bytes(b),
         SerdeValue::Option(s) => {
             if let Some(s) = s {
-                return json_from_serde_value(&s, packer, f, descriptors);
+                return json_from_serde_value(&s, packer, f, descriptors, column_type);
             }
 
             default_datum_from_field(f, descriptors)?
         }
         SerdeValue::Seq(_) | SerdeValue::Map(_) => {
-            return json_nested_from_serde_value(val, packer, f, descriptors);
+            return nested_datum_from_serde_value(val, packer, f, descriptors, column_type);
         }
         SerdeValue::Char(_) | SerdeValue::Unit | SerdeValue::Newtype(_) => bail!(
             "Unsupported type for Datum from serde_value::Value: {:?}",
@@ -193,100 +195,129 @@ fn default_datum_from_field<'a>(
     }
 }
 
-fn datum_from_serde_proto<'a>(val: &'a ProtoValue) -> Result<Datum<'a>> {
-    match val {
-        ProtoValue::Bool(true) => Ok(Datum::True),
-        ProtoValue::Bool(false) => Ok(Datum::False),
-        ProtoValue::I32(i) => Ok(Datum::Int32(*i)),
-        ProtoValue::I64(i) => Ok(Datum::Int64(*i)),
-        ProtoValue::U32(u) => Ok(Datum::from(Numeric::from(*u))),
-        ProtoValue::U64(u) => Ok(Datum::from(Numeric::from(*u))),
-        ProtoValue::F32(f) => Ok(Datum::Float32((*f).into())),
-        ProtoValue::F64(f) => Ok(Datum::Float64((*f).into())),
-        ProtoValue::String(s) => Ok(Datum::String(s)),
-        ProtoValue::Bytes(b) => Ok(Datum::Bytes(b)),
-        _ => bail!("Unsupported type for Datum from serde_protobuf::Value"),
-    }
-}
-
-fn json_nested_from_serde_value(
+fn nested_datum_from_serde_value(
     val: &SerdeValue,
     packer: &mut Row,
     f: &FieldDescriptor,
     descriptors: &Descriptors,
+    column_type: &ColumnType,
 ) -> Result<()> {
     packer.push(match val {
         SerdeValue::Bool(true) => Datum::True,
         SerdeValue::Bool(false) => Datum::False,
-        SerdeValue::I8(i) => json_number(i)?,
-        SerdeValue::I16(i) => json_number(i)?,
-        SerdeValue::I32(i) => json_number(i)?,
-        SerdeValue::I64(i) => json_number(i)?,
-        SerdeValue::U8(i) => json_number(i)?,
-        SerdeValue::U16(i) => json_number(i)?,
-        SerdeValue::U32(i) => json_number(i)?,
-        SerdeValue::U64(i) => json_number(i)?,
-        SerdeValue::F32(f) => json_number(f)?,
-        SerdeValue::F64(f) => json_number(f)?,
+        SerdeValue::I8(i) => Datum::Int32(*i as i32),
+        SerdeValue::I16(i) => Datum::Int32(*i as i32),
+        SerdeValue::I32(i) => Datum::Int32(*i),
+        SerdeValue::I64(i) => Datum::Int64(*i),
+        SerdeValue::U8(i) => Datum::Int32(*i as i32),
+        SerdeValue::U16(i) => Datum::Int32(*i as i32),
+        SerdeValue::U32(u) => Datum::from(Numeric::from(*u)),
+        SerdeValue::U64(u) => Datum::from(Numeric::from(*u)),
+        SerdeValue::F32(f) => Datum::Float32((*f).into()),
+        SerdeValue::F64(f) => Datum::Float64((*f).into()),
         SerdeValue::String(s) => Datum::String(s),
         SerdeValue::Bytes(_) => {
             bail!("We don't currently support arrays or nested messages with bytes")
         }
         SerdeValue::Seq(s) => {
+            let inner_column_type = if let ColumnType {
+                scalar_type: ScalarType::List { element_type, .. },
+                ..
+            } = column_type
+            {
+                ColumnType {
+                    scalar_type: *element_type.clone(),
+                    nullable: true,
+                }
+            } else {
+                bail!("sequence must be of type list, found {:?}", column_type);
+            };
             return packer.push_list_with(|packer| {
                 for value in s {
-                    json_nested_from_serde_value(&value, packer, f, descriptors)?;
+                    nested_datum_from_serde_value(
+                        &value,
+                        packer,
+                        f,
+                        descriptors,
+                        &inner_column_type,
+                    )?;
                 }
                 Ok(())
             });
         }
         SerdeValue::Option(v) => {
             if let Some(v) = v {
-                return json_nested_from_serde_value(&v, packer, f, descriptors);
+                return nested_datum_from_serde_value(&v, packer, f, descriptors, column_type);
             }
 
             default_datum_from_field_nested(f, descriptors)?
         }
         SerdeValue::Map(m) => {
-            let mut kvs = m.iter().collect::<Vec<_>>();
-            kvs.sort_by(|(k1, _v1), (k2, _v2)| k1.cmp(k2));
-            kvs.dedup_by(|(k1, _v1), (k2, _v2)| k1 == k2);
-            return packer.push_dict_with(|packer| {
-                let nested_message_descriptor = f.field_type(descriptors);
-                for (k, v) in kvs {
-                    match k {
-                        SerdeValue::String(s) => {
+            let nested_message_descriptor = f.field_type(descriptors);
+            let pack_map = |packer: &mut Row,
+                            k: &SerdeValue,
+                            v: &SerdeValue,
+                            typ: &ColumnType,
+                            push_key: bool| {
+                match k {
+                    SerdeValue::String(s) => {
+                        if push_key {
                             packer.push(Datum::String(s.as_str()));
-
-                            let nested_message_descriptor = match nested_message_descriptor {
-                                FieldType::Message(m) => m,
-                                _ => bail!("Nested message is the wrong type"),
-                            };
-
-                            json_nested_from_serde_value(
-                                &v,
-                                packer,
-                                nested_message_descriptor
-                                    .field_by_name(s)
-                                    .expect("Expected this to work"),
-                                descriptors,
-                            )?;
                         }
-                        _ => bail!("Unrecognized value while trying to parse a nested message"),
+
+                        let nested_message_descriptor = match nested_message_descriptor {
+                            FieldType::Message(m) => m,
+                            _ => bail!("Nested message is the wrong type"),
+                        };
+
+                        nested_datum_from_serde_value(
+                            &v,
+                            packer,
+                            nested_message_descriptor
+                                .field_by_name(s)
+                                .expect("nested message to exist"),
+                            descriptors,
+                            typ,
+                        )?;
                     }
+                    _ => bail!("Unrecognized value while trying to parse a nested message"),
                 }
                 Ok(())
-            });
+            };
+
+            match &column_type.scalar_type {
+                ScalarType::Map { value_type, .. } => {
+                    let mut kvs = m.iter().collect::<Vec<_>>();
+                    kvs.sort_by(|(k1, _v1), (k2, _v2)| k1.cmp(k2));
+
+                    return packer.push_dict_with(|packer| {
+                        let typ = ColumnType {
+                            scalar_type: *value_type.clone(),
+                            nullable: true,
+                        };
+                        for (k, v) in kvs {
+                            pack_map(packer, k, v, &typ, true)?;
+                        }
+                        Ok(())
+                    });
+                }
+                ScalarType::Record { fields, .. } => {
+                    return packer.push_list_with(|packer| {
+                        for (n, typ) in fields {
+                            let (k, v) = m
+                                .get_key_value(&SerdeValue::String(n.to_string()))
+                                .expect("key value pair to exist");
+                            pack_map(packer, k, v, &typ, false)?;
+                        }
+                        Ok(())
+                    });
+                }
+                _ => bail!("Unsupported scalar type for map"),
+            }
         }
         _ => bail!("Unsupported types from serde_value"),
     });
     Ok(())
-}
-
-fn json_number<N: ToPrimitive + std::fmt::Display>(i: &N) -> Result<Datum<'static>> {
-    Ok(Datum::Float64(OrderedFloat::from(i.to_f64().ok_or_else(
-        || anyhow!("couldn't convert {} into an f64", i),
-    )?)))
 }
 
 fn default_datum_from_field_nested<'a>(
@@ -329,17 +360,25 @@ fn default_datum_from_field_nested<'a>(
     }
 }
 
-fn datum_from_serde_proto_nested<'a>(val: &'a ProtoValue) -> Result<Datum<'a>> {
+fn datum_from_serde_proto<'a>(val: &'a ProtoValue) -> Result<Datum<'a>> {
     match val {
         ProtoValue::Bool(true) => Ok(Datum::True),
         ProtoValue::Bool(false) => Ok(Datum::False),
-        ProtoValue::I32(i) => json_number(i),
-        ProtoValue::I64(i) => json_number(i),
-        ProtoValue::U32(u) => json_number(u),
-        ProtoValue::U64(u) => json_number(u),
-        ProtoValue::F32(f) => json_number(f),
-        ProtoValue::F64(f) => json_number(f),
+        ProtoValue::I32(i) => Ok(Datum::Int32(*i)),
+        ProtoValue::I64(i) => Ok(Datum::Int64(*i)),
+        ProtoValue::U32(u) => Ok(Datum::from(Numeric::from(*u))),
+        ProtoValue::U64(u) => Ok(Datum::from(Numeric::from(*u))),
+        ProtoValue::F32(f) => Ok(Datum::Float32((*f).into())),
+        ProtoValue::F64(f) => Ok(Datum::Float64((*f).into())),
         ProtoValue::String(s) => Ok(Datum::String(s)),
+        ProtoValue::Bytes(b) => Ok(Datum::Bytes(b)),
         _ => bail!("Unsupported type for Datum from serde_protobuf::Value"),
     }
+}
+
+fn datum_from_serde_proto_nested<'a>(val: &'a ProtoValue) -> Result<Datum<'a>> {
+    if let ProtoValue::Bytes(_) = val {
+        bail!("Nested bytes are not supported");
+    }
+    datum_from_serde_proto(val)
 }

--- a/src/testdrive/src/action/kafka/ingest.rs
+++ b/src/testdrive/src/action/kafka/ingest.rs
@@ -130,6 +130,10 @@ impl Transcoder {
                         Self::decode_json::<_, protobuf::gen::nested::NestedOuter>(row)?
                             .map(convert)
                     }
+                    protobuf::MessageType::SimpleNestedOuter => {
+                        Self::decode_json::<_, protobuf::gen::nested::SimpleNestedOuter>(row)?
+                            .map(convert)
+                    }
                     protobuf::MessageType::Imported => {
                         Self::decode_json::<_, protobuf::gen::imported::Imported>(row)?.map(convert)
                     }

--- a/src/testdrive/src/format/protobuf.rs
+++ b/src/testdrive/src/format/protobuf.rs
@@ -22,6 +22,7 @@ pub enum MessageType {
     Measurement,
     SimpleId,
     NestedOuter,
+    SimpleNestedOuter,
     Imported,
 }
 
@@ -35,6 +36,7 @@ impl FromStr for MessageType {
             "measurement" => Ok(MessageType::Measurement),
             "simpleid" => Ok(MessageType::SimpleId),
             "nested" => Ok(MessageType::NestedOuter),
+            "simple-nested" => Ok(MessageType::SimpleNestedOuter),
             "imported" => Ok(MessageType::Imported),
             _ => Err(format!(
                 "testdrive: unknown built-in protobuf message: {}",

--- a/src/testdrive/src/format/protobuf/billing.proto
+++ b/src/testdrive/src/format/protobuf/billing.proto
@@ -33,7 +33,7 @@ message Record {
   string interval_end = 2;
 
   string meter = 3; // What's being measured
-  uint32 value = 4;
+  int32 value = 4;
 
   repeated Measurement measurements = 7;
 }

--- a/src/testdrive/src/format/protobuf/nested.proto
+++ b/src/testdrive/src/format/protobuf/nested.proto
@@ -14,6 +14,14 @@ enum Binary {
   ONE = 1;
 }
 
+message SimpleNestedOuter {
+    SimpleNestedInner inner = 1;
+}
+
+message SimpleNestedInner {
+    string message = 1;
+}
+
 message NestedOuter {
   double double = 1;
   float float = 2;

--- a/test/testdrive/kafka-data-formats.td
+++ b/test/testdrive/kafka-data-formats.td
@@ -50,8 +50,8 @@ $ kafka-ingest format=protobuf topic=input_proto message=batch timestamp=1
 {"id": "2", "interval_start": "2020-01-01_00:00:10", "interval_end": "2020-01-01_00:00:19", "records": []}
 
 # Ensure we have the offset column imported:
-> SELECT * from input_proto;
-id interval_start        interval_end      records mz_offset
+> SELECT id, interval_start, interval_end, mz_offset from input_proto;
+id interval_start        interval_end      mz_offset
 ------------------------------------------------------------
-1  2020-01-01_00:00:00 2020-01-01_00:00:09 []      1
-2  2020-01-01_00:00:10 2020-01-01_00:00:19 []      2
+1  2020-01-01_00:00:00 2020-01-01_00:00:09 1
+2  2020-01-01_00:00:10 2020-01-01_00:00:19 2

--- a/test/testdrive/proto-billing.td
+++ b/test/testdrive/proto-billing.td
@@ -27,46 +27,49 @@ $ kafka-ingest format=protobuf topic=messages message=batch timestamp=10
 id              true text
 interval_end    true text
 interval_start  true text
-records         true jsonb
+records         true list
 mz_offset       false bigint
 
-> SELECT * FROM billing
-0 0                   0                   [] 3
-1 2020-01-01_00:00:00 2020-01-01_00:00:09 [] 1
-2 2020-01-01_00:00:10 2020-01-01_00:00:19 "[{\"interval_end\":\"2020-01-01_00:00:15\",\"interval_start\":\"2020-01-01_00:00:10\",\"measurements\":[{\"measured_value\":5.0,\"resource\":\"CPU\"},{\"measured_value\":128.0,\"resource\":\"MEM\"}],\"meter\":\"user\",\"value\":25.0},{\"interval_end\":\"2020-01-01_00:00:19\",\"interval_start\":\"2020-01-01_00:00:16\",\"measurements\":[{\"measured_value\":13.0,\"resource\":\"CPU\"},{\"measured_value\":256.0,\"resource\":\"MEM\"}],\"meter\":\"user\",\"value\":125.0}]" 2
+> SELECT id, interval_start, interval_end, mz_offset FROM billing
+0 0                   0                    3
+1 2020-01-01_00:00:00 2020-01-01_00:00:09  1
+2 2020-01-01_00:00:10 2020-01-01_00:00:19  2
 
 > SELECT
-    records->0->'value',
-    records->0->'measurements'->0->'measured_value',
-    records->0->>'meter',
-    records->1->'value',
-    records->1->'measurements'->1->'measured_value',
-    records->1->>'meter'
-  FROM billing
-  WHERE id = '2'
-25.0  5.0  user  125.0  256.0  user
+    (r)."value",
+    (r).meter,
+    (ms).resource,
+    (ms).measured_value
+  FROM
+    billing, unnest(records) as r, unnest((r).measurements) as ms
+ value  meter  resource  measured_value
+----------------------------------------
+    25  user   CPU                    5
+    25  user   MEM                  128
+   125  user   CPU                   13
+   125  user   MEM                  256
 
 # Do some destructuring over the nested records
 
-> SELECT r.value->>'meter' FROM billing, jsonb_array_elements(records) AS r
+> SELECT (r).meter FROM billing, unnest(records) AS r
 user
 user
 
 > CREATE MATERIALIZED VIEW billing_records AS
   SELECT
     billing.id,
-    r.value->>'interval_start' AS interval_start,
-    r.value->>'interval_end' AS interval_end,
-    r.value->>'meter' AS meter,
-    (r.value->'value')::float::int AS value,
-    r.value->'measurements' AS measurements
-  FROM billing, jsonb_array_elements(records) AS r
+    (r).interval_start AS interval_start,
+    (r).interval_end AS interval_end,
+    (r).meter AS meter,
+    ((r)."value")::float::int AS value,
+    (r).measurements AS measurements
+  FROM billing, unnest(records) AS r
 
 > SHOW COLUMNS FROM billing_records
 id              true  text
 interval_end    true  text
 interval_start  true  text
-measurements    true  jsonb
+measurements    true  list
 meter           true  text
 value           true  integer
 

--- a/test/testdrive/protobuf.td
+++ b/test/testdrive/protobuf.td
@@ -154,15 +154,13 @@ $ kafka-ingest topic=imported format=protobuf schema=${schema} message=imported
   FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 unsupported protobuf schema reference simple.proto
 
-> CREATE MATERIALIZED SOURCE meep
+> CREATE MATERIALIZED SOURCE imported_csr
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-imported-${testdrive.seed}'
   FORMAT PROTOBUF MESSAGE '.Imported' USING SCHEMA FILE '${testdrive.protobuf-descriptors-file}'
 
-> SELECT * FROM meep
-id                  mz_offset
---------------------------
-"{\"id\":\"a\"}"   1
-"{\"id\":\"b\"}"   2
+# Can't SELECT record types.
+> SELECT COUNT(*) FROM imported_csr
+2
 
 $ kafka-create-topic topic=nested-proto
 
@@ -208,16 +206,19 @@ message NestedInner {
 }
 
 $ kafka-ingest topic=nested-proto format=protobuf schema=${schema} message=nested publish=true
-{"double": 1.1, "float": 2.2, "int32": -100, "int64": 200, "sint32": 987234, "sint64": 129387981723, "sfixed32": 123, "sfixed64": 567, "bool": true, "string": "hey", "bytes": [102, 111, 111], "binary": "ZERO", "nested": []}
+{"double": 1.1, "float": 2.2, "int32": -100, "int64": 200, "sint32": 987234, "sint64": 129387981723, "sfixed32": 123, "sfixed64": 567, "bool": true, "string": "hey", "bytes": [102, 111, 111], "binary": "ZERO", "nested": [{"double": 1.1, "float": 2.2, "int32": -100, "int64": 200, "sint32": 987234, "sint64": 129387981723, "sfixed32": 123, "sfixed64": 567, "bool": true, "string": "hey", "bytes": [102, 111, 111], "binary": "ZERO"}]}
 
 > CREATE MATERIALIZED SOURCE nested_proto_inline FROM
   KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-nested-proto-${testdrive.seed}'
   FORMAT PROTOBUF MESSAGE '.NestedOuter' USING SCHEMA '${testdrive.protobuf-descriptors}'
 
-> SELECT * FROM nested_proto_inline
-double  float   int32   int64   sint32   sint64         sfixed32   sfixed64   bool   string   bytes   binary   nested   mz_offset
+> SELECT COUNT(*) FROM nested_proto_inline
+1
+
+> SELECT double, float, int32, int64, sint32, sint64, sfixed32, sfixed64, bool, string, bytes, binary, mz_offset FROM nested_proto_inline
+double  float   int32   int64   sint32   sint64         sfixed32   sfixed64   bool   string   bytes   binary  mz_offset
 ---------------------------------------------------------------------------------------------------------------------------
-1.1     2.2     -100    200     987234   129387981723   123        567        true   "hey"    "foo"   "ZERO"   []       1
+1.1     2.2     -100    200     987234   129387981723   123        567        true   "hey"    "foo"   "ZERO"  1
 
 > CREATE MATERIALIZED SOURCE nested_proto
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-nested-proto-${testdrive.seed}'
@@ -236,10 +237,61 @@ bool      true boolean
 string    true text
 bytes     true bytea
 binary    true text
-nested    true jsonb
+nested    true list
 mz_offset false  bigint
 
-> SELECT * FROM nested_proto
-double  float   int32   int64   sint32   sint64         sfixed32   sfixed64   bool   string   bytes   binary   nested   mz_offset
+> SELECT COUNT(*) FROM nested_proto
+1
+
+> SELECT double, float, int32, int64, sint32, sint64, sfixed32, sfixed64, bool, string, bytes, binary, mz_offset FROM nested_proto
+double  float   int32   int64   sint32   sint64         sfixed32   sfixed64   bool   string   bytes   binary   mz_offset
 --------------------------------------------------------------------------------------------------------------------------
-1.1     2.2     -100    200     987234   129387981723   123        567        true   "hey"    "foo"   "ZERO"  []       1
+1.1     2.2     -100    200     987234   129387981723   123        567        true   "hey"    "foo"   "ZERO"   1
+
+# Test records
+$ kafka-create-topic topic=simple_nested_proto
+
+> CREATE MATERIALIZED SOURCE simple_nested_proto
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-simple_nested_proto-${testdrive.seed}'
+  FORMAT PROTOBUF MESSAGE '.SimpleNestedOuter' USING SCHEMA '${testdrive.protobuf-descriptors}'
+
+$ kafka-ingest format=protobuf topic=simple_nested_proto message=simple-nested
+{"inner": {"message": "hello"}}
+{"inner": {"message": "world"}}
+
+> SHOW COLUMNS FROM simple_nested_proto
+name            nullable  type
+-------------------------------
+inner           true      record
+mz_offset       false     bigint
+
+> SELECT COUNT(*) FROM simple_nested_proto
+2
+
+$ kafka-create-topic topic=batch_proto
+
+> CREATE MATERIALIZED SOURCE batch_proto
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-batch_proto-${testdrive.seed}'
+  FORMAT PROTOBUF MESSAGE '.Batch' USING SCHEMA '${testdrive.protobuf-descriptors}'
+
+> SHOW COLUMNS FROM batch_proto
+name            nullable  type
+-------------------------------
+id              true      text
+interval_end    true      text
+interval_start  true      text
+mz_offset       false     bigint
+records         true      list
+
+$ kafka-ingest format=protobuf topic=batch_proto message=batch timestamp=1
+{"id": "1", "interval_start": "2020-01-01_00:00:00", "interval_end": "2020-01-01_00:00:09", "records": []}
+{"id": "2", "interval_start": "2020-01-01_00:00:10", "interval_end": "2020-01-01_00:00:19", "records": []}
+
+> SELECT COUNT(*) FROM batch_proto
+2
+
+> SELECT id, interval_start, interval_end, mz_offset FROM batch_proto
+ id  interval_start       interval_end         mz_offset
+------------------------------------------------------------------
+ 1   2020-01-01_00:00:00  2020-01-01_00:00:09  1
+ 2   2020-01-01_00:00:10  2020-01-01_00:00:19  2


### PR DESCRIPTION
### Motivation

Fix https://github.com/MaterializeInc/materialize/issues/7907.

### Description

This PR updates our decoding logic to emit [`records`](https://materialize.com/docs/sql/types/record/) instead of [`jsonb`](https://materialize.com/docs/sql/types/jsonb/) for Protobuf-formatted source data.

### Tips for reviewer

The actual change is contained in the first commit. The subsequent commits fix demos and tests after this change.

### Checklist

- [X] This PR has adequate test coverage.
- [X] This PR adds a release note for any user-facing behavior changes.
