### PR TITLE
coord: improve timedomain id txn verification to include indexes

### DIFF
--- a/test/sqllogictest/github-8241.slt
+++ b/test/sqllogictest/github-8241.slt
@@ -1,0 +1,37 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Regression test for https://github.com/MaterializeInc/materialize/issues/8241
+# See https://github.com/MaterializeInc/materialize/issues/8318
+
+# Verify that an index added after a transaction has started complains.
+
+statement ok
+CREATE TABLE t1 (f1 INTEGER, f2 INTEGER);
+
+statement ok
+CREATE INDEX i1 ON t1 (f2);
+
+statement ok
+CREATE VIEW v1 AS SELECT * FROM t1;
+
+simple conn=conn1
+BEGIN;
+SELECT * FROM v1;
+----
+COMPLETE 0
+COMPLETE 0
+
+statement ok
+CREATE INDEX i2 ON t1 (f2);
+
+simple conn=conn1
+SELECT * FROM v1;
+----
+db error: ERROR: transactions can only reference nearby relations; "materialize.public.i2" referenced here, but only the following are available: "materialize.public.i1", "materialize.public.t1", "materialize.public.t1_primary_idx", "materialize.public.v1"

--- a/test/sqllogictest/transactions.slt
+++ b/test/sqllogictest/transactions.slt
@@ -274,7 +274,7 @@ simple
 SELECT 1;
 SELECT * FROM t;
 ----
-db error: ERROR: transactions can only reference nearby relations; "materialize.public.t" referenced here, but none available
+db error: ERROR: transactions can only reference nearby relations; "materialize.public.t_primary_idx" referenced here, but none available
 
 statement ok
 CREATE SCHEMA other
@@ -286,7 +286,7 @@ simple
 SELECT * FROM t;
 SELECT * FROM other.t;
 ----
-db error: ERROR: transactions can only reference nearby relations; "materialize.other.t" referenced here, but only the following are available: "materialize.public.t", "materialize.public.t5727"
+db error: ERROR: transactions can only reference nearby relations; "materialize.other.t" referenced here, but only the following are available: "materialize.public.t", "materialize.public.t5727", "materialize.public.t5727_primary_idx", "materialize.public.t_primary_idx"
 
 # Verify that changed tables and views don't change during a transaction.
 
@@ -360,7 +360,7 @@ simple conn=t1
 SELECT * FROM v1;
 COMMIT;
 ----
-db error: ERROR: transactions can only reference nearby relations; "materialize.public.v1" referenced here, but only the following are available: "materialize.public.t", "materialize.public.t5727", "materialize.public.v", "materialize.public.v_primary_idx"
+db error: ERROR: transactions can only reference nearby relations; "materialize.public.v1" referenced here, but only the following are available: "materialize.public.t", "materialize.public.t5727", "materialize.public.t5727_primary_idx", "materialize.public.t_primary_idx", "materialize.public.v", "materialize.public.v_primary_idx"
 
 simple conn=t1
 ROLLBACK;


### PR DESCRIPTION
### Motivation

  * This PR fixes a recognized bug. #8241

### Description

The set of indexes could have changed after a transaction started, so
we need to verify that there's no new indexes that the dataflow builder
might use. This is hopefully a temporary workaround until #8318. It is
a bit unfortunate because it's a side effect from another sql session,
so we have gotten further away from serializability.

### Tips for reviewer

    * The diff is much smaller if viewed with whitespace hidden.

### Checklist

- [x] This PR has adequate test coverage.
- [x] This PR adds a release note for any user-facing behavior changes.
