### PR TITLE
S3 server-side resume using a resumable `AsyncRead` wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2800,6 +2800,7 @@ dependencies = [
  "either",
  "futures",
  "openssl",
+ "pin-project",
  "prometheus",
  "smallvec",
  "structopt",
@@ -3074,6 +3075,26 @@ dependencies = [
  "libc",
  "ore",
  "tempfile",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "576bc800220cc65dac09e99e97b08b358cfab6e17078de8dc5fee223bd2d0c08"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -29,6 +29,7 @@ futures = { version = "0.3.17", optional = true }
 # This isn't directly imported by anything, but it's required at link time. The
 # vendored feature is transitively depended upon by tokio-openssl.
 openssl = { version = "0.10.36", features = ["vendored"], optional = true  }
+pin-project = "1"
 prometheus = { git = "https://github.com/MaterializeInc/rust-prometheus.git", default-features = false, optional = true }
 smallvec = { version = "1.5.0", optional = true }
 structopt = { version = "0.3.23", optional = true }


### PR DESCRIPTION
### Motivation

In the event of an interruption to download an S3 object we are currently restarting the download from the beginning and discard the already downloaded bytes on the client side. This PR uses S3 `Range` headers to do the seeking on the server side.

### Description

To implement retries of the S3 reader stream our existing `ore::Retry` utlity has been generalized to be an async Stream of `RetryState`s. This stream of retry states is then used to implement both the pre-existing `Retry::retry` logic, but also to implement a new utility `RetryReader` that can take an `AsyncRead` factory function can appear to external users as a contiguous, uninterrupted stream.

`RetryReader` will re-attempt to construct the underlying reader based on its `Retry` settings which are identical to our `Retry` utility.

This `RetryReader` is then used in `dataflow::source::s3` to automatically re-connect to S3 and provide the appropriate range headers.

### Tips for reviewer

Commit by commit recommended

### Checklist

- [x] This PR has adequate test coverage.
- [ ] This PR adds a release note for any user-facing behavior changes.
