### PR TITLE
coord: improve same timedomain error text

### DIFF
--- a/doc/user/content/sql/begin.md
+++ b/doc/user/content/sql/begin.md
@@ -41,3 +41,14 @@ A second kind of **read-only** transaction can contain an initial [`TAIL`](/sql/
 A **write-only** transaction starts with an [`INSERT`](/sql/insert) and allows only `INSERT` statements.
 Different statements can reference different tables.
 On `COMMIT`, all statements from the transaction are committed at the same timestamp.
+
+### Same timedomain error
+
+A **read-only** transaction can produce an error with the text:
+
+> Transactions can only reference objects in the same timedomain.
+
+The first `SELECT` in a transaction assumes that any object in that `SELECT` and any other object in the same schemas are assumed to be possible query targets.
+If a later `SELECT` references another object, the transaction will fail.
+This can happen if the object is in a schema not referenced by the first `SELECT`.
+It can also happen if a new object (table, view, source, or index) was created after the transaction started, even if the new object is in the same schemas as the first `SELECT`.

--- a/src/coord/src/error.rs
+++ b/src/coord/src/error.rs
@@ -233,7 +233,8 @@ impl fmt::Display for CoordError {
             CoordError::RelationOutsideTimeDomain { relation, names } => {
                 write!(
                     f,
-                    "transactions can only reference nearby relations; {} referenced here, but {}",
+                    "Transactions can only reference objects in the same timedomain. See {}. {} referenced here, but {}",
+                    "https://materialize.com/docs/sql/begin/#same-timedomain-error",
                     relation.quoted(),
                     match names.is_empty() {
                         true => "none available".to_string(),

--- a/test/sqllogictest/github-8241.slt
+++ b/test/sqllogictest/github-8241.slt
@@ -34,4 +34,4 @@ CREATE INDEX i2 ON t1 (f2);
 simple conn=conn1
 SELECT * FROM v1;
 ----
-db error: ERROR: transactions can only reference nearby relations; "materialize.public.i2" referenced here, but only the following are available: "materialize.public.i1", "materialize.public.t1", "materialize.public.t1_primary_idx", "materialize.public.v1"
+db error: ERROR: Transactions can only reference objects in the same timedomain. See https://materialize.com/docs/sql/begin/#same-timedomain-error. "materialize.public.i2" referenced here, but only the following are available: "materialize.public.i1", "materialize.public.t1", "materialize.public.t1_primary_idx", "materialize.public.v1"

--- a/test/sqllogictest/transactions.slt
+++ b/test/sqllogictest/transactions.slt
@@ -274,7 +274,7 @@ simple
 SELECT 1;
 SELECT * FROM t;
 ----
-db error: ERROR: transactions can only reference nearby relations; "materialize.public.t" referenced here, but none available
+db error: ERROR: Transactions can only reference objects in the same timedomain. See https://materialize.com/docs/sql/begin/#same-timedomain-error. "materialize.public.t" referenced here, but none available
 
 statement ok
 CREATE SCHEMA other
@@ -286,7 +286,7 @@ simple
 SELECT * FROM t;
 SELECT * FROM other.t;
 ----
-db error: ERROR: transactions can only reference nearby relations; "materialize.other.t" referenced here, but only the following are available: "materialize.public.t", "materialize.public.t5727", "materialize.public.t5727_primary_idx", "materialize.public.t_primary_idx"
+db error: ERROR: Transactions can only reference objects in the same timedomain. See https://materialize.com/docs/sql/begin/#same-timedomain-error. "materialize.other.t" referenced here, but only the following are available: "materialize.public.t", "materialize.public.t5727", "materialize.public.t5727_primary_idx", "materialize.public.t_primary_idx"
 
 # Verify that changed tables and views don't change during a transaction.
 
@@ -360,7 +360,7 @@ simple conn=t1
 SELECT * FROM v1;
 COMMIT;
 ----
-db error: ERROR: transactions can only reference nearby relations; "materialize.public.v1" referenced here, but only the following are available: "materialize.public.t", "materialize.public.t5727", "materialize.public.t5727_primary_idx", "materialize.public.t_primary_idx", "materialize.public.v", "materialize.public.v_primary_idx"
+db error: ERROR: Transactions can only reference objects in the same timedomain. See https://materialize.com/docs/sql/begin/#same-timedomain-error. "materialize.public.v1" referenced here, but only the following are available: "materialize.public.t", "materialize.public.t5727", "materialize.public.t5727_primary_idx", "materialize.public.t_primary_idx", "materialize.public.v", "materialize.public.v_primary_idx"
 
 simple conn=t1
 ROLLBACK;

--- a/test/testdrive/timelines.td
+++ b/test/testdrive/timelines.td
@@ -261,5 +261,5 @@ At least one input has no complete timestamps yet
 > BEGIN;
 > SELECT * FROM input_table;
 ! SELECT * FROM source_byo;
-transactions can only reference nearby relations
+Transactions can only reference objects in the same timedomain
 > ROLLBACK;

--- a/test/testdrive/transactions-timedomain-nonmaterialized.td
+++ b/test/testdrive/transactions-timedomain-nonmaterialized.td
@@ -46,7 +46,7 @@ unable to automatically determine a query timestamp
 4
 
 ! SELECT c FROM unindexed ORDER BY c
-transactions can only reference nearby relations
+Transactions can only reference objects in the same timedomain
 
 > ROLLBACK
 
@@ -59,7 +59,7 @@ transactions can only reference nearby relations
 4
 
 ! SELECT * FROM v_unindexed
-transactions can only reference nearby relations
+Transactions can only reference objects in the same timedomain
 
 > ROLLBACK
 


### PR DESCRIPTION
### Motivation

This PR improves documentation for a confusing error.

### Description

This is a confusing error and it needed more explanation than can fit
in an error string. Try to document it more clearly along with some
possible causes.
