### PR TITLE
coord: cancel peek

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -48,6 +48,9 @@ Wrap your release notes at the 80 character mark.
 
 {{% version-header v0.9.5 %}}
 
+- Return control of canceled sessions (`ctrl + c`) while `SELECT` statements
+  await results. Previously, this could cause the session to never terminate.
+
 {{% version-header v0.9.4 %}}
 
 - Improve the performance of

--- a/src/coord/src/client.rs
+++ b/src/coord/src/client.rs
@@ -189,7 +189,7 @@ impl ConnClient {
                 conn_id,
                 secret_key,
             })
-            .expect("coordinator unexpectedly canceled request")
+            .expect("coordinator unexpectedly gone");
     }
 
     async fn send<T, F>(&mut self, f: F) -> T
@@ -307,6 +307,11 @@ impl SessionClient {
             tx,
         })
         .await
+    }
+
+    /// Cancels the query currently running on another connection.
+    pub async fn cancel_request(&mut self, conn_id: u32, secret_key: u32) {
+        self.inner.cancel_request(conn_id, secret_key).await
     }
 
     /// Ends a transaction.

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1380,14 +1380,13 @@ impl Coordinator {
 
             // Cancel the peek. We use an `if let` because the peek could be completed
             // and removed before the cancellation is received.
-            if let Some((channel, count)) = self.pending_peeks.get(&conn_id) {
-                for _ in 0..*count {
-                    channel
-                        .send(PeekResponse::Canceled)
-                        .expect("Peek channel closed prematurely");
-                }
+            if let Some((channel, _)) = self.pending_peeks.remove(&conn_id) {
+                channel
+                    .send(PeekResponse::Canceled)
+                    .expect("Peek channel closed prematurely");
             }
-            // Allow dataflow to cancel any pending peeks.
+
+            // Request dataflow to cancel any pending peeks.
             self.broadcast(dataflow::Command::CancelPeek { conn_id });
 
             // Inform the target session (if it asks) about the cancellation.

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1377,7 +1377,6 @@ impl Coordinator {
             if conn_meta.secret_key != secret_key {
                 return;
             }
-
             // Cancel the peek. We use an `if let` because the peek could be completed
             // and removed before the cancellation is received.
             if let Some((channel, _)) = self.pending_peeks.remove(&conn_id) {

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -897,7 +897,7 @@ where
 
             Command::CancelPeek { conn_id } => {
                 // Note that executing this command does not require responding
-                // to the coordinator, which will cancel the peek on its own.
+                // to the coordinator, which will cancel its copy of the peek itself.
                 let logger = &mut self.materialized_logger;
                 self.pending_peeks.retain(|peek| {
                     if peek.conn_id == conn_id {

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -896,6 +896,8 @@ where
             }
 
             Command::CancelPeek { conn_id } => {
+                // Note that executing this command does not require responding
+                // to the coordinator, which will cancel the peek on its own.
                 let logger = &mut self.materialized_logger;
                 self.pending_peeks.retain(|peek| {
                     if peek.conn_id == conn_id {

--- a/test/coordtest/cancel.ct
+++ b/test/coordtest/cancel.ct
@@ -1,0 +1,20 @@
+sql
+CREATE TABLE t (i INT);
+----
+CreatedTable {
+    existed: false,
+}
+
+async-sql
+now_1h
+SELECT * FROM t AS OF now()+'1h';
+----
+
+async-cancel
+now_1h
+----
+
+await-sql
+now_1h
+----
+Canceled


### PR DESCRIPTION
### Motivation

This PR fixes a recognized bug. https://github.com/MaterializeInc/materialize/pull/7263#issuecomment-919858040

### Description

Details about this code can be found [here](https://github.com/MaterializeInc/materialize/pull/7263#issuecomment-921047075).

The gist is that our cancel requests did not remove pending peeks from the coordinator, which meant cancellations did not properly terminate sessions while peeks were pending. This code changes that so on cancel, we simply remove the pending peek.

This PR includes an extension for `coordtest` to make this fix testable.

### Tips for reviewer

- @frankmcsherry Pinging you only because you had some input on the shape of the change in `src/coord/src/coord.rs`. Don't think this is actionable or interesting, but just closing the loop.

- Some changes to the module document markdown in `src/coordtest/src/lib.rs` are noise caused by adjusted the indentation for the `<li>`s. Sorry about that, but seemed all right as this is more conventional for markdown. The items to look at are `async-sql`, `async-cancel`, and `await-sql`.

- Putting `cancel_request` on the `SessionClient` feels odd, but `coordtest` only has `SessionClient` and this was the least intrusive way I could see of providing access to `ConnClient::cancel_request`. Is there a clearer way of thinking of `SessionClient` that would still make cancelation testable from `coordtest`?

### Checklist

- [x] This PR has adequate test coverage.
- [x] This PR adds a release note for any user-facing behavior changes.
