### PR TITLE
exclude isolation.level from admin client creation

### DIFF
--- a/src/coord/src/sink_connector.rs
+++ b/src/coord/src/sink_connector.rs
@@ -367,13 +367,15 @@ async fn build_kafka(
     };
     let topic = maybe_append_nonce(&builder.topic_prefix);
 
-    // Create Kafka topic with single partition.
+    // Create Kafka topic
     let mut config = ClientConfig::new();
     config.set("bootstrap.servers", &builder.broker_addrs.to_string());
     for (k, v) in builder.config_options.iter() {
         // Explicitly reject the statistics interval option here because its not
         // properly supported for this client.
-        if k != "statistics.interval.ms" {
+        // Explicitly reject isolation.level as it's a consumer-specific
+        // parameter and will generate a benign WARN for admin clients
+        if k != "statistics.interval.ms" && k != "isolation.level" {
             config.set(k, v);
         }
     }


### PR DESCRIPTION
isolation.level is a consumer-specific client option and will generate
benign but annoying WARNs when used for producer or admin clients.

We currently exclude isolation.level from the Kafka sink producers, but
weren't excluding it from the admin client used to initially create
Kafka topics.

Tested by creating a basic sink:
```
CREATE TABLE input_table (a bigint, b bigint);
CREATE SINK IF NOT EXISTS sink_t2 FROM input_table2 INTO KAFKA BROKER 'localhost:9092' topic 'test2' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081';
```
and observing that the WARN appears before but not after this change.

Fixes #8340

### Checklist

- [X] This PR has adequate test coverage.
- [X] This PR adds a release note for any user-facing behavior changes.
