### PR TITLE
Add support for SQL bitwise operators on integer types

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -48,7 +48,9 @@ Wrap your release notes at the 80 character mark.
 
 {{% version-header v0.9.5 %}}
 
-- Timezone parsing is now case insensitive to be compatible with PostgreSQL
+- Timezone parsing is now case insensitive to be compatible with PostgreSQL.
+
+- Add support for [bitwise operators on integers](/sql/functions/#numbers).
 
 {{% version-header v0.9.4 %}}
 

--- a/doc/user/content/sql/functions/_index.md
+++ b/doc/user/content/sql/functions/_index.md
@@ -54,6 +54,12 @@ Operator | Computes
 `*` | Multiplication
 `/` | Division
 `%` | Modulo
+`&` | Bitwise AND
+`|` | Bitwise OR
+`#` | Bitwise XOR
+`~` | Bitwise NOT
+`<<`| Bitwise left shift
+`>>`| Bitwise right shift
 
 ### String
 

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -382,6 +382,11 @@ impl<'a> Parser<'a> {
                 expr1: Box::new(self.parse_subexpr(Precedence::PrefixPlusMinus)?),
                 expr2: None,
             }),
+            Token::Op(op) if op == "~" => Ok(Expr::Op {
+                op,
+                expr1: Box::new(self.parse_subexpr(Precedence::Other)?),
+                expr2: None,
+            }),
             Token::Number(_) | Token::String(_) | Token::HexString(_) => {
                 self.prev_token();
                 Ok(Expr::Value(self.parse_value()?))

--- a/test/sqllogictest/arithmetic.slt
+++ b/test/sqllogictest/arithmetic.slt
@@ -519,3 +519,350 @@ SELECT 9223372036854775807::bigint+1::bigint
 
 query error numeric field overflow
 SELECT 9223372036854775807::bigint-(-1)::bigint
+
+### bitwise operators ###
+
+# dummy table and data needed for tests
+
+statement ok
+DROP TABLE IF EXISTS nums
+
+statement ok
+CREATE TABLE nums (
+  x1 int2,
+  x2 int2,
+  x3 int2,
+  y1 int4,
+  y2 int4,
+  y3 int4,
+  z1 int8,
+  z2 int8,
+  z3 int8
+)
+
+statement ok
+INSERT INTO nums VALUES (11, 12, 13, 21, 22, 23, 31, 32, 33)
+
+# negation
+
+query IIIII
+SELECT ~0, ~1, ~65535, ~2147483647, ~9223372036854775807
+----
+-1 -2 -65536 -2147483648 -9223372036854775808
+
+# bitwise and
+
+query IIIII
+SELECT
+    3 & 4,
+    7 & 4,
+    7 & 14,
+    1342579021 & 1035032143,
+    2309456347094635094 & 4321056356463245221
+----
+0 4 6 268435533 2307057198754714116
+
+# bitwise or
+
+query IIIII
+SELECT
+    3 | 4,
+    7 | 4,
+    7 | 14,
+    1342579021 | 1035032143,
+    2309456347094635094 | 4321056356463245221
+----
+7 7 15 2109175631 4323455504803166199
+
+# bitwise xor
+
+query IIIII
+SELECT
+    3 # 4,
+    7 # 4,
+    7 # 14,
+    1342579021 # 1035032143,
+    2309456347094635094 # 4321056356463245221
+----
+7 3 9 1840740098 2016398306048452083
+
+# bitwise left shift
+
+query IIII
+SELECT
+  no_bits,
+  1::int2 << no_bits as r2,
+  1::int4 << no_bits as r4,
+  1::int8 << no_bits as r8
+FROM
+  (VALUES
+    (-65), (-64), (-63),
+    (-49), (-48), (-47),
+    (-33), (-32), (-31),
+    (-17), (-16), (-15),
+    (-1),  ( 0 ), ( +1),
+    (+15), (+16), (+17),
+    (+31), (+32), (+33),
+    (+47), (+48), (+49),
+    (+63), (+64), (+65)
+  ) as params(no_bits)
+ORDER by
+  no_bits
+----
+-65        0   -2147483648   -9223372036854775808
+-64        1             1                      1
+-63        2             2                      2
+-49   -32768         32768                  32768
+-48        0         65536                  65536
+-47        0        131072                 131072
+-33        0   -2147483648             2147483648
+-32        1             1             4294967296
+-31        2             2             8589934592
+-17   -32768         32768        140737488355328
+-16        0         65536        281474976710656
+-15        0        131072        562949953421312
+ -1        0   -2147483648   -9223372036854775808
+  0        1             1                      1
+  1        2             2                      2
+ 15   -32768         32768                  32768
+ 16        0         65536                  65536
+ 17        0        131072                 131072
+ 31        0   -2147483648             2147483648
+ 32        1             1             4294967296
+ 33        2             2             8589934592
+ 47   -32768         32768        140737488355328
+ 48        0         65536        281474976710656
+ 49        0        131072        562949953421312
+ 63        0   -2147483648   -9223372036854775808
+ 64        1             1                      1
+ 65        2             2                      2
+
+# bitwise right shift
+
+query IIII
+SELECT
+  no_bits,
+  -32767::int2               >> no_bits as r2,
+  -2147483647::int4          >> no_bits as r4,
+  -9223372036854775807::int8 >> no_bits as r8
+FROM
+  (VALUES
+    (-65), (-64), (-63),
+    (-49), (-48), (-47),
+    (-33), (-32), (-31),
+    (-17), (-16), (-15),
+    (-1),  ( 0 ), ( +1),
+    (+15), (+16), (+17),
+    (+31), (+32), (+33),
+    (+47), (+48), (+49),
+    (+63), (+64), (+65)
+  ) as params(no_bits)
+ORDER by
+  no_bits
+----
+-65       -1            -1                     -1
+-64   -32767   -2147483647   -9223372036854775807
+-63   -16384   -1073741824   -4611686018427387904
+-49       -1        -65536       -281474976710656
+-48       -1        -32768       -140737488355328
+-47       -1        -16384        -70368744177664
+-33       -1            -1            -4294967296
+-32   -32767   -2147483647            -2147483648
+-31   -16384   -1073741824            -1073741824
+-17       -1        -65536                 -65536
+-16       -1        -32768                 -32768
+-15       -1        -16384                 -16384
+ -1       -1            -1                     -1
+  0   -32767   -2147483647   -9223372036854775807
+  1   -16384   -1073741824   -4611686018427387904
+ 15       -1        -65536       -281474976710656
+ 16       -1        -32768       -140737488355328
+ 17       -1        -16384        -70368744177664
+ 31       -1            -1            -4294967296
+ 32   -32767   -2147483647            -2147483648
+ 33   -16384   -1073741824            -1073741824
+ 47       -1        -65536                 -65536
+ 48       -1        -32768                 -32768
+ 49       -1        -16384                 -16384
+ 63       -1            -1                     -1
+ 64   -32767   -2147483647   -9223372036854775807
+ 65   -16384   -1073741824   -4611686018427387904
+
+# precedence between bitwise operators
+
+query III
+SELECT
+    5 >> 1  << 3  as implicit_l,
+   (5 >> 1) << 3  as explicit_l,
+    5 >> (1 << 3) as explicit_r
+----
+16 16 0
+
+query III
+SELECT
+    5 << 1  >> 3  as implicit_l,
+   (5 << 1) >> 3  as explicit_l,
+    5 << (1 >> 3) as explicit_r
+----
+1 1 5
+
+query T multiline
+EXPLAIN SELECT
+  x1 >> x2 << x3 as r1,
+  y1 << y2 >> y3 as r2
+FROM nums
+----
+%0 =
+| Get materialize.public.nums (u5)
+| Map ((#0 >> i16toi32(#1)) << i16toi32(#2)), ((#3 << #4) >> #5)
+| Project (#9, #10)
+
+EOF
+
+# precedence between bitwise operators and '&'
+
+query III
+SELECT
+    5 >> 1  & 12  as implicit_l,
+   (5 >> 1) & 12  as explicit_l,
+    5 >> (1 & 12) as explicit_r
+----
+0 0 5
+
+query III
+SELECT
+    5 << 1  & 12  as implicit_l,
+   (5 << 1) & 12  as explicit_l,
+    5 << (1 & 12) as explicit_r
+----
+8 8 5
+
+query T multiline
+EXPLAIN SELECT
+  x1 >> x2 & x3 as r1,
+  y1 << y2 & y3 as r2
+FROM nums
+----
+%0 =
+| Get materialize.public.nums (u5)
+| Map ((#0 >> i16toi32(#1)) & #2), ((#3 << #4) & #5)
+| Project (#9, #10)
+
+EOF
+
+# precedence between '&' and '|'
+
+query III
+SELECT
+   0  &  0  |  1  as implicit_l,
+  (0  &  0) |  1  as explicit_l,
+   0  & (0  |  1) as explicit_r
+----
+1 1 0
+
+query III
+SELECT
+   1  |  0  &  0  as implicit_l,
+  (1  |  0) &  0  as explicit_l,
+   1  | (0  &  0) as explicit_r
+----
+0 0 1
+
+query T multiline
+EXPLAIN SELECT
+  x1 & x2 | x3 as r1,
+  y1 & y2 | y3 as r2,
+  z1 & z2 | z3 as r3,
+  x1 & y2 | z3 as r4
+FROM nums
+----
+%0 =
+| Get materialize.public.nums (u5)
+| Map ((#0 & #1) | #2), ((#3 & #4) | #5), ((#6 & #7) | #8), (i32toi64((i16toi32(#0) & #4)) | #8)
+| Project (#9..#12)
+
+EOF
+
+# precedence between '&' and '#'
+
+query III
+SELECT
+   0  &  0  #  1  as implicit_l,
+  (0  &  0) #  1  as explicit_l,
+   0  & (0  #  1) as explicit_r
+----
+1 1 0
+
+query III
+SELECT
+   1  #  0  &  0  as implicit_l,
+  (1  #  0) &  0  as explicit_l,
+   1  # (0  &  0) as explicit_r
+----
+0 0 1
+
+query T multiline
+EXPLAIN SELECT
+  x1 # x2 & x3 as r1,
+  y1 # y2 & y3 as r2,
+  z1 # z2 & z3 as r3,
+  x1 # y2 & z3 as r4
+FROM nums
+----
+%0 =
+| Get materialize.public.nums (u5)
+| Map ((#0 # #1) & #2), ((#3 # #4) & #5), ((#6 # #7) & #8), (i32toi64((i16toi32(#0) # #4)) & #8)
+| Project (#9..#12)
+
+EOF
+
+# precedence between '|' and '#'
+
+query III
+SELECT
+   1  |  0  #  1  as implicit_l,
+  (1  |  0) #  1  as explicit_l,
+   1  | (0  #  1) as explicit_r
+----
+0 0 1
+
+query III
+SELECT
+   1  #  0  |  1  as implicit_l,
+  (1  #  0) |  1  as explicit_l,
+   1  # (0  |  1) as explicit_r
+----
+1 1 0
+
+query T multiline
+EXPLAIN SELECT
+  x1 # x2 | x3 as r1,
+  y1 # y2 | y3 as r2,
+  z1 # z2 | z3 as r3,
+  x1 # y2 | z3 as r4
+FROM nums
+----
+%0 =
+| Get materialize.public.nums (u5)
+| Map ((#0 # #1) | #2), ((#3 # #4) | #5), ((#6 # #7) | #8), (i32toi64((i16toi32(#0) # #4)) | #8)
+| Project (#9..#12)
+
+EOF
+
+# precedence between '~' and ("|", "&")
+
+query IIIIII
+SELECT
+   ~1 & 0  as def_and, ~(1 & 0)  as l_prec_and, (~1) & 0  as h_prec_and,
+   ~0 | 1  as def_or , ~(0 | 1)  as l_prec_or , (~0) | 1  as h_prec_or
+----
+0 -1 0 -1 -2 -1
+
+# precedence between '~' and ('+', '-')
+
+query IIIIII
+SELECT
+   ~1 + 1  as def_add, ~(1 + 1)  as l_prec_add, (~1) + 1  as h_prec_add,
+   ~1 - 2  as def_sub, ~(1 - 2)  as l_prec_sub, (~1) - 2  as h_prec_sub
+----
+-3 -3 -1 0 0 -4


### PR DESCRIPTION
### Motivation

Adds missing bitwise operators on integers as suggested in #7192.

### Description

Adds the following bitwise operators on `smallint`, `int`, and `bigint` types

- [x] Bitwise AND (`&`)
- [x] Bitwise XOR (`#`)
- [x] Bitwise OR (`|`)
- [x] Bitwise NOT (`~`)
- [x] Shift left (`<<`)
- [x] Shift right (`>>`)

### Tips for reviewer

- I used #5966 to figure out what changes are needed. 
- I had to add a new precedence for the bitwise NOT in order to maintain compatibility with Postgres (see diff in `parser.rs`). Note that this is different [from the CockroachDB semantics](https://www.cockroachlabs.com/docs/stable/postgresql-compatibility.html#precedence-of-unary) which are not aligned with Postgres.

### Checklist

- [x] This PR has adequate test coverage.
- [x] This PR adds a release note for any user-facing behavior changes.
