### PR TITLE
expr: avoid `MirRelationExpr::typ` calls in `JoinInputMapper`

### DIFF
--- a/src/expr/src/relation/join_input_mapper.rs
+++ b/src/expr/src/relation/join_input_mapper.rs
@@ -44,7 +44,7 @@ impl JoinInputMapper {
     /// Creates a new `JoinInputMapper` and calculates the mapping of global context
     /// columns to local context columns.
     pub fn new(inputs: &[MirRelationExpr]) -> Self {
-        Self::new_from_input_types(&inputs.iter().map(|i| i.typ()).collect::<Vec<_>>())
+        Self::new_from_input_arities(inputs.iter().map(|i| i.arity()).collect::<Vec<_>>())
     }
 
     /// Creates a new `JoinInputMapper` and calculates the mapping of global context
@@ -56,9 +56,16 @@ impl JoinInputMapper {
             .map(|t| t.column_types.len())
             .collect::<Vec<_>>();
 
+        Self::new_from_input_arities(arities)
+    }
+
+    /// Creates a new `JoinInputMapper` and calculates the mapping of global context
+    /// columns to local context columns. Using this method saves is more
+    /// efficient if input arities have been pre-calculated
+    pub fn new_from_input_arities(arities: Vec<usize>) -> Self {
         let mut offset = 0;
         let mut prior_arities = Vec::new();
-        for input in 0..types.len() {
+        for input in 0..arities.len() {
             prior_arities.push(offset);
             offset += arities[input];
         }


### PR DESCRIPTION
### Motivation

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug. [Link to issue.]

  * This PR adds a known-desirable feature. [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

This PR refactors existing code.

Performance improvement by removing more `typ` calls.

### Description

<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details."

-->

`MirRelationExpr::arity` is significantly cheaper than `MirRelationExpr::typ`,
and hence, should be used when possible.

Making `JoinInputMapper::new` use `arity` instead of `typ` results in 6%
improvement in the optimization time, with improvements in all TPCH
queries.

Perf results in https://docs.google.com/spreadsheets/d/1ana1hmc0mtPD8a7DAY9BthN3XXnjHlK6xhuPHqQLuEI/edit#gid=1721922614 

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [ ] This PR has adequate test coverage. (covered by existing tests)
- [ ] This PR adds a release note for any user-facing behavior changes.
