### PR TITLE
doc/user: avoid the term "Materialize node"

### DIFF
--- a/doc/user/content/cli/_index.md
+++ b/doc/user/content/cli/_index.md
@@ -18,7 +18,7 @@ Flag | Default | Modifies
 [`--experimental`](#experimental-mode) | Disabled | *Dangerous.* Enable experimental features.
 [`--introspection-frequency`](#introspection-sources) | 1s | The frequency at which to update [introspection sources](#introspection-sources).
 [`--metrics-scraping-interval`](#prometheus-metrics) | 30s | The update interval for the `mz_metrics` table, see [prometheus metrics](#prometheus-metrics).
-[`--listen-addr`](#listen-address) | `0.0.0.0:6875` | Materialize node's host and port
+[`--listen-addr`](#listen-address) | `0.0.0.0:6875` | The host and port on which to listen for HTTP and SQL connections
 [`-l`](#compaction-window) / [`--logical-compaction-window`](#compaction-window) | 1ms | The amount of historical detail to retain in arrangements
 [`--log-file`](#log-file) | [`mzdata`](#data-directory)`/materialized.log` | Where to emit log messages
 [`--log-filter`](#log-filter) | `info` | Which log messages to emit
@@ -30,7 +30,7 @@ Flag | Default | Modifies
 [`-w`](#worker-threads) / [`--workers`](#worker-threads) | NCPUs / 2 | Dataflow worker threads
 `-v` / `--version` | N/A | Print version and exit
 `-vv` | N/A | Print version and additional build information, and exit
-[`--disable-user-indexes`](#disable-user-indexes) | Disabled | Starts the node without creating any dataflows for user indexes.
+[`--disable-user-indexes`](#disable-user-indexes) | Disabled | Start without creating any dataflows for user indexes.
 
 If a command line flag takes an argument, you can alternatively set that flag
 via an environment variable named after the flag. If both the environment
@@ -316,8 +316,8 @@ your sources and views within Materialize** and will have to recreate them and
 re-ingest all of your data.
 
 Because of this volatility:
-- You can only start new nodes in experimental mode.
-- Nodes started in experimental mode must always be started in experimental
+- You can only initialize new servers in experimental mode.
+- Servers started in experimental mode must always be started in experimental
   mode.
 
 We recommend only using experimental mode to explore Materialize, i.e.
@@ -326,9 +326,9 @@ or things you'd like to see changed, let us know on [GitHub][gh-feature].
 
 #### Disabling experimental mode
 
-You cannot disable experimental mode for a node. You can, however, extract your
+You cannot disable experimental mode for a server. You can, however, extract your
 view and source definitions ([`SHOW CREATE VIEW`][scv], [`SHOW CREATE SOURCE`][scs],
-etc.), and then create a new node with those items.
+etc.), and then create a new server with those items.
 
 ### Telemetry
 
@@ -376,12 +376,12 @@ should only set these parameters in consultation with Materialize engineers.
 This feature is primarily meant for advanced administrators of Materialize.
 {{< /warning >}}
 
-If you cannot boot a Materialize node because it runs out of memory, you can use
+If you cannot boot a Materialize server because it runs out of memory, you can use
 the `--disable-user-indexes` to prevent Materialize from creating any
 [indexes][api-indexes] on user-created objects. For
-example, if you add a view that contains a cross join that causes your node to
+example, if you add a view that contains a cross join that causes your server to
 immediately run out of memory on boot, you can use `--disable-user-indexes` to
-boot the node and then drop the offending view.
+boot the server and then drop the offending view.
 
 In this mode users...
 

--- a/doc/user/content/cloud/account-limits.md
+++ b/doc/user/content/cloud/account-limits.md
@@ -44,10 +44,6 @@ Materialize Cloud doesn't support using local files as sources; you can otherwis
   **Local Files**  |  No |  Yes
   **Postgres**  | Yes | Yes
 
-#### Deployments
-
-The Materialize executable  is source-available and free on a single node, so deployment limits only depend on your hardware.
-
 #### Session termination
 
 We reserve the right to terminate a session in your Cloud deployment. This may happen after prolonged inactivity or in the event of planned maintenance work on Materialize Cloud, and doesn't affect catalog items (which are persisted across sessions).

--- a/doc/user/content/overview/architecture.md
+++ b/doc/user/content/overview/architecture.md
@@ -42,7 +42,7 @@ to communicate with `materialized`. We have a client called
 [`mzcli`](https://github.com/MaterializeInc/mzcli) that we recommend using, but
 it's just a modified wrapper around `pgcli`.
 
-Because this is a SQL shell, Materialize lets you interact with your node
+Because this is a SQL shell, Materialize lets you interact with your server
 through SQL statements sent over `pgwire` to an internal `queue`, where they are
 dequeued by a `sql` thread that parses the statement.
 

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -338,7 +338,7 @@ Wrap your release notes at the 80 character mark.
   versions, setting these parameters required a separate call to [`ALTER
   INDEX`](/sql/alter-index).
 
-- Fix a bug that prevented upgrading v0.6.1 or earlier nodes to v0.7.0 if they
+- Fix a bug that prevented upgrading deployments from v0.6.1 or earlier to v0.7.0 if they
   contained:
   -  Views whose embdedded queries contain functions whose arguments are functions {{% gh 5802 %}}.
   -  Sinks using `WITH SNAPSHOT AS OF` {{% gh 5808 %}}.
@@ -360,7 +360,7 @@ Wrap your release notes at the 80 character mark.
 
 {{% version-header v0.7.0 %}}
 
-- **Known issue.** You cannot upgrade nodes created with versions v0.6.1 or
+- **Known issue.** You cannot upgrade deployments created with versions v0.6.1 or
   earlier to v0.7.0 if they contain:
 
   -  Views whose embdedded queries contain functions whose arguments are functions {{% gh 5802 %}}.

--- a/doc/user/content/sql/types/list.md
+++ b/doc/user/content/sql/types/list.md
@@ -429,8 +429,7 @@ members must also have a length of 2.
 ### Custom types
 
 You can create [custom `list` types](/sql/types/#custom-types), which lets you
-create a named entry in your Materialize nodes' catalogs for a specific type of
-list.
+create a named entry in the catalog for a specific type of list.
 
 Currently, custom types only provides a shorthand for referring to
 otherwise-annoying-to-type names, but in the future will provide [binary

--- a/doc/user/content/sql/types/map.md
+++ b/doc/user/content/sql/types/map.md
@@ -71,8 +71,7 @@ SELECT '{a=>{b=>{c=>d}}}'::map[text=>map[text=>map[text=>text]]] as nested_map;
 ### Custom types
 
 You can create [custom `map` types](/sql/types/#custom-types), which lets you
-create a named entry in your Materialize nodes' catalogs for a specific type of
-`map`.
+create a named entry in the catalog for a specific type of `map`.
 
 Currently, custom types only provides a shorthand for referring to
 otherwise-annoying-to-type names, but in the future will provide [binary


### PR DESCRIPTION
@sploiselle WDYT? The impetus for this was that @aldeka snagged some of the "disable user indexes" copy for the cloud UI and it seemed extra confusing there to talk about "nodes" when the rest of the UI is consistent in talking about "deployments" or "servers". 

----

Since Materialize is a single-node system, I think it's a bit confusing
to use the term "node" to mean "Materialize server". It's familiar to
those of us used to CockroachDB terminology, or other distributed
systems, but I don't think it's immediately obvious to most users.  And
when we *do* support horizontal scalability, per the platform vision, I
think we're likely to say "Materialize worker node" or "Materialize
compute node" rather than just "Materialize node".

So, this commit rewrites all use of the term "node" in the docs to use
either "server", "deployment", or "catalog" instead, depending on the
context.
