### PR TITLE
coord: fix nondeterministic time domain error

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -52,6 +52,7 @@ use derivative::Derivative;
 use differential_dataflow::lattice::Lattice;
 use futures::future::{self, FutureExt, TryFutureExt};
 use futures::stream::{self, StreamExt};
+use itertools::Itertools;
 use lazy_static::lazy_static;
 use rand::Rng;
 use timely::communication::WorkerGuards;
@@ -2526,7 +2527,13 @@ impl Coordinator {
             // reference could be caused by a user specifying an object in a different
             // schema than the first query. An index could be caused by a CREATE INDEX
             // after the transaction started.
-            if let Some(id) = stmt_ids.difference(&read_txn.timedomain_ids).next() {
+            //
+            // The call to `sorted` ensures the error message is deterministic.
+            if let Some(id) = stmt_ids
+                .difference(&read_txn.timedomain_ids)
+                .sorted()
+                .next()
+            {
                 let mut names: Vec<_> = read_txn
                     .timedomain_ids
                     .iter()

--- a/test/sqllogictest/transactions.slt
+++ b/test/sqllogictest/transactions.slt
@@ -274,7 +274,7 @@ simple
 SELECT 1;
 SELECT * FROM t;
 ----
-db error: ERROR: transactions can only reference nearby relations; "materialize.public.t_primary_idx" referenced here, but none available
+db error: ERROR: transactions can only reference nearby relations; "materialize.public.t" referenced here, but none available
 
 statement ok
 CREATE SCHEMA other


### PR DESCRIPTION
Ensure that the CoordError::RelationOutsideTimeDomain error always
chooses the same global ID for display in the error message so that the
message is deterministic.

(We could alternatively have changed the test to accept both answers,
but deterministic error messages are a generally nice thing to have.)

Fix #8351.

### Motivation

  * This PR fixes a recognized bug. #8351

### Checklist

- [x] This PR has adequate test coverage.
- [x] This PR adds a release note for any user-facing behavior changes.
