### PR TITLE
persist: remove outdated TODO from kafka_upsert example

### DIFF
--- a/src/persist/examples/kafka_upsert.rs
+++ b/src/persist/examples/kafka_upsert.rs
@@ -104,9 +104,6 @@ where
     let timestamp_interval_ms = 5000;
     let now_fn = system_time;
 
-    // TODO: This is not correct, because we might not have data or
-    // bindings but still continue sealing up collections based on
-    // processing time.
     let start_ts = cmp::min(sealed_ts(&ts_read)?, sealed_ts(&out_read)?);
     println!("Restored start timestamp: {}", start_ts);
 


### PR DESCRIPTION
The comment was referring to the "old" method that a previous Kafka mock
example used to determine an upper seal ts. That one was iterating
through data and recording the highest seen timstamp.

@danhhz An easy one, to get warmed up.