### PR TITLE
repr: case insensitive matching of timezones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,13 +527,27 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2554a3155fec064362507487171dcc4edc3df60cb10f3a1fb10ed8094822b120"
+checksum = "64c01c1c607d25c71bbaa67c113d6c6b36c434744b4fd66691d711b5b1bc0c8b"
 dependencies = [
  "chrono",
- "parse-zoneinfo",
+ "chrono-tz-build",
+ "phf",
  "serde",
+ "uncased",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db058d493fb2f65f41861bfed7e3fe6335264a9f0f92710cab5bdf01fef09069"
+dependencies = [
+ "parse-zoneinfo",
+ "phf",
+ "phf_codegen",
+ "uncased",
 ]
 
 [[package]]

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -48,6 +48,8 @@ Wrap your release notes at the 80 character mark.
 
 {{% version-header v0.9.5 %}}
 
+- Timezone parsing is now case insensitive to be compatible with PostgreSQL
+
 {{% version-header v0.9.4 %}}
 
 - Improve the performance of

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -17,7 +17,7 @@ harness = false
 anyhow = "1.0.44"
 byteorder = "1.4.3"
 chrono = { version = "0.4.0", default-features = false, features = ["serde", "std"] }
-chrono-tz = { version = "0.5.0", features = ["serde"] }
+chrono-tz = { version = "0.6.0", features = ["serde", "case-insensitive"] }
 dec = "0.4.5"
 enum-kinds = "0.5.1"
 fast-float = "0.2.0"

--- a/src/repr/src/adt/datetime.rs
+++ b/src/repr/src/adt/datetime.rs
@@ -1789,7 +1789,7 @@ fn build_timezone_offset_second(tokens: &[TimeStrToken], value: &str) -> Result<
                 }
                 (Zulu, Zulu) => return Ok(Default::default()),
                 (TzName(val), TzName(_)) => {
-                    return match val.parse() {
+                    return match Tz::from_str_insensitive(val) {
                         Ok(tz) => Ok(Timezone::Tz(tz)),
                         Err(err) => Err(format!(
                             "Invalid timezone string ({}): {}. \
@@ -3429,6 +3429,10 @@ mod test {
             ("Pacific/Auckland", T(Tz::Pacific__Auckland)),
             ("America/New_York", T(Tz::America__New_York)),
             ("America/Los_Angeles", T(Tz::America__Los_Angeles)),
+            ("utc", T(Tz::UTC)),
+            ("pAcIfIc/AUcKlAnD", T(Tz::Pacific__Auckland)),
+            ("AMERICA/NEW_YORK", T(Tz::America__New_York)),
+            ("america/los_angeles", T(Tz::America__Los_Angeles)),
         ];
 
         for (timezone, expected) in test_cases.iter() {


### PR DESCRIPTION
### Motivation

Timezone parsing compatibility with postgres

Fixes #7185

### Description

Use new version of `chrono-tz` that can parse timezones in a case insensitive way. The new version also uses perfect hash tables instead of a big match arm which should be faster

### Checklist

- [x] This PR has adequate test coverage.
- [x] This PR adds a release note for any user-facing behavior changes.
