### PR TITLE
Attempt to create the Kafka topic for longer during chaos tests

### DIFF
--- a/test/chaos/src/main.rs
+++ b/test/chaos/src/main.rs
@@ -125,7 +125,7 @@ async fn bytes_to_kafka(args: Args) -> Result<(), anyhow::Error> {
         &[("enable.idempotence", "true")],
     )?;
     Retry::default()
-        .max_duration(Duration::from_secs(120))
+        .max_duration(Duration::from_secs(300))
         .retry(|_| {
             kafka_client.create_topic(
                 &topic,

--- a/test/chaos/src/main.rs
+++ b/test/chaos/src/main.rs
@@ -125,7 +125,7 @@ async fn bytes_to_kafka(args: Args) -> Result<(), anyhow::Error> {
         &[("enable.idempotence", "true")],
     )?;
     Retry::default()
-        .max_duration(Duration::from_secs(60))
+        .max_duration(Duration::from_secs(120))
         .retry(|_| {
             kafka_client.create_topic(
                 &topic,


### PR DESCRIPTION
This is causing release qualification chaos tests to fail, because Kafka sometimes takes longer than 60s to start