### PR TITLE
dataflow; expr: Reuse Row allocations for SafeMfp evaluations

### DIFF
--- a/src/dataflow/src/render/join/mod.rs
+++ b/src/dataflow/src/render/join/mod.rs
@@ -66,6 +66,7 @@ impl JoinClosure {
         &'a self,
         datums: &mut Vec<Datum<'a>>,
         temp_storage: &'a RowArena,
+        row: &'a mut Row,
     ) -> Result<Option<Row>, expr::EvalError> {
         for exprs in self.ready_equivalences.iter() {
             // Each list of expressions should be equal to the same value.
@@ -76,7 +77,7 @@ impl JoinClosure {
                 }
             }
         }
-        self.before.evaluate(datums, &temp_storage)
+        self.before.evaluate_into(datums, &temp_storage, row)
     }
 
     /// Construct an instance of the closure from available columns.

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -1248,6 +1248,8 @@ impl PendingPeek {
             cursor.seek_key(&storage, literal);
         }
 
+        let mut row_builder = Row::default();
+
         while cursor.key_valid(&storage) {
             while cursor.val_valid(&storage) {
                 // TODO: This arena could be maintained and reuse for longer
@@ -1263,7 +1265,7 @@ impl PendingPeek {
                 let mut datums = row.unpack();
                 if let Some(result) = self
                     .map_filter_project
-                    .evaluate(&mut datums, &arena)
+                    .evaluate_into(&mut datums, &arena, &mut row_builder)
                     .map_err_to_string()?
                 {
                     let mut copies = 0;

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -1160,6 +1160,9 @@ pub mod plan {
         /// occurs in the evaluation it is returned as an `Err` variant.
         /// As the evaluation exits early with failed predicates, it may
         /// miss some errors that would occur later in evaluation.
+        ///
+        /// The `row` is not cleared first, but emptied if the function
+        /// returns `Ok(Some(row)).
         #[inline(always)]
         pub fn evaluate_into<'a>(
             &'a self,
@@ -1171,6 +1174,7 @@ pub mod plan {
             if !passed_predicates {
                 Ok(None)
             } else {
+                row.clear();
                 row.extend(self.mfp.projection.iter().map(|c| datums[*c]));
                 Ok(Some(row.finish_and_reuse()))
             }

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -1180,36 +1180,11 @@ pub mod plan {
             }
         }
 
-        /// A version of `evaluate_into` which allocates a new Row.
-        ///
-        /// This version can be useful when one wants to capture the resulting datums into a new
-        /// row.
-        #[inline(always)]
-        #[deprecated]
-        pub fn evaluate<'a>(
-            &'a self,
-            datums: &mut Vec<Datum<'a>>,
-            arena: &'a RowArena,
-        ) -> Result<Option<Row>, EvalError> {
-            let passed_predicates = self.evaluate_inner(datums, arena)?;
-            if !passed_predicates {
-                Ok(None)
-            } else {
-                // We determine the capacity first, to ensure that we right-size
-                // the row allocation and need not re-allocate once it is formed.
-                let capacity = repr::datums_size(self.mfp.projection.iter().map(|c| datums[*c]));
-                let mut row = Row::with_capacity(capacity);
-                row.extend(self.mfp.projection.iter().map(|c| datums[*c]));
-                Ok(Some(row))
-            }
-        }
-
         /// A version of `evaluate` which produces an iterator over `Datum`
         /// as output.
         ///
-        /// This version is used internally by `evaluate` and can be useful
-        /// when one wants to capture the resulting datums without packing
-        /// and then unpacking a row.
+        /// This version can be usefulwhen one wants to capture the resulting
+        /// datums without packing and then unpacking a row.
         #[inline(always)]
         pub fn evaluate_iter<'b, 'a: 'b>(
             &'a self,


### PR DESCRIPTION
Currently, evaluating a SafeMfp either allocates a row or returns an
iterator. With this change, a third approach reusing an allocated Row is
added.

Signed-off-by: Moritz Hoffmann <mh@materialize.com>

### Motivation

This PR refactors existing code to avoid computing the length of a row repeatedly and instead reuse allocations.

### Description

The current `SafeMfpPlan::evaluate` function calculates the required length for each row individually. In many cases, this length remains constant throughput the lifetime of a dataflow. With this change, we provide a row with an allocation to build evaluate the MFP into. The final row is then copied, saving the cost to compute the required size.

### Checklist

- [ ] This PR has adequate test coverage.
- [ ] This PR adds a release note for any user-facing behavior changes.
