### PR TITLE
sql-parser: parse kafka consistency two ways

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -71,6 +71,9 @@ Wrap your release notes at the 80 character mark.
 - When issuing `COMMIT` or `ROLLBACK` commands outside of an explicit
   transaction, always return a warning. Previously, the warning could be suppressed.
 
+- Fix a bug in the `CREATE SINK` syntax by updating the optional `CONSISTENCY`
+  clause.
+
 {{% version-header v0.9.3 %}}
 
 - Fix a bug that prevented creating Avro sinks on old versions of Confluent Platform
@@ -679,7 +682,7 @@ Wrap your release notes at the 80 character mark.
 
 - When creating a Kafka sink, permit specifying the columns to include in the
   key of each record via the new `KEY` connector option in [`CREATE
-  SINK`](/sql/create-sink/#kafka-connector).
+  SINK`](/sql/create-sink).
 
 - Default to using a worker thread count equal to half of the machine's
   physical cores if the [`--workers`](/cli/#worker-threads) command-line

--- a/doc/user/layouts/partials/sql-grammar/consistency-format-spec.svg
+++ b/doc/user/layouts/partials/sql-grammar/consistency-format-spec.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="557" height="179">
+   <polygon points="11 17 3 13 3 21"/>
+   <polygon points="19 17 11 13 11 21"/>
+   <rect x="33" y="3" width="110" height="32" rx="10"/>
+   <rect x="31"
+         y="1"
+         width="110"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="41" y="21">AVRO USING</text>
+   <rect x="45" y="69" width="246" height="32" rx="10"/>
+   <rect x="43"
+         y="67"
+         width="246"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="87">CONFLUENT SCHEMA REGISTRY</text>
+   <rect x="311" y="69" width="36" height="32"/>
+   <rect x="309" y="67" width="36" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="319" y="87">url</text>
+   <rect x="387" y="101" width="102" height="32"/>
+   <rect x="385" y="99" width="102" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="395" y="119">with_options</text>
+   <rect x="45" y="145" width="82" height="32" rx="10"/>
+   <rect x="43"
+         y="143"
+         width="82"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="163">SCHEMA</text>
+   <rect x="147" y="145" width="48" height="32" rx="10"/>
+   <rect x="145"
+         y="143"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="155" y="163">FILE</text>
+   <rect x="215" y="145" width="132" height="32"/>
+   <rect x="213" y="143" width="132" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="223" y="163">schema_file_path</text>
+   <path class="line"
+         d="m19 17 h2 m0 0 h10 m110 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-162 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m246 0 h10 m0 0 h10 m36 0 h10 m20 0 h10 m0 0 h112 m-142 0 h20 m122 0 h20 m-162 0 q10 0 10 10 m142 0 q0 -10 10 -10 m-152 10 v12 m142 0 v-12 m-142 12 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m102 0 h10 m-484 -32 h20 m484 0 h20 m-524 0 q10 0 10 10 m504 0 q0 -10 10 -10 m-514 10 v56 m504 0 v-56 m-504 56 q0 10 10 10 m484 0 q10 0 10 -10 m-494 10 h10 m82 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m132 0 h10 m0 0 h162 m23 -76 h-3"/>
+   <polygon points="547 83 555 79 555 87"/>
+   <polygon points="547 83 539 79 539 87"/>
+</svg>

--- a/doc/user/layouts/partials/sql-grammar/create-sink.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-sink.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="571" height="309">
+<svg xmlns="http://www.w3.org/2000/svg" width="571" height="391">
    <polygon points="11 17 3 13 3 21"/>
    <polygon points="19 17 11 13 11 21"/>
    <rect x="33" y="3" width="114" height="32" rx="10"/>
@@ -28,73 +28,87 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="463" y="21">FROM</text>
-   <rect x="72" y="101" width="90" height="32"/>
-   <rect x="70" y="99" width="90" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="80" y="119">item_name</text>
-   <rect x="182" y="101" width="54" height="32" rx="10"/>
-   <rect x="180"
+   <rect x="94" y="101" width="90" height="32"/>
+   <rect x="92" y="99" width="90" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="102" y="119">item_name</text>
+   <rect x="204" y="101" width="54" height="32" rx="10"/>
+   <rect x="202"
          y="99"
          width="54"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="190" y="119">INTO</text>
-   <rect x="276" y="101" width="162" height="32"/>
-   <rect x="274" y="99" width="162" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="284" y="119">sink_kafka_connector</text>
-   <rect x="276" y="145" width="94" height="32" rx="10"/>
-   <rect x="274"
+   <text class="terminal" x="212" y="119">INTO</text>
+   <rect x="298" y="101" width="162" height="32"/>
+   <rect x="296" y="99" width="162" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="306" y="119">sink_kafka_connector</text>
+   <rect x="298" y="145" width="94" height="32" rx="10"/>
+   <rect x="296"
          y="143"
          width="94"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="284" y="163">AVRO OCF</text>
-   <rect x="390" y="145" width="94" height="32"/>
-   <rect x="388" y="143" width="94" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="398" y="163">path-prefix</text>
-   <rect x="45" y="231" width="94" height="32" rx="10"/>
+   <text class="terminal" x="306" y="163">AVRO OCF</text>
+   <rect x="412" y="145" width="50" height="32"/>
+   <rect x="410" y="143" width="50" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="420" y="163">path</text>
+   <rect x="73" y="227" width="136" height="32"/>
+   <rect x="71" y="225" width="136" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="81" y="245">sink_with_options</text>
+   <rect x="269" y="227" width="80" height="32" rx="10"/>
+   <rect x="267"
+         y="225"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="277" y="245">FORMAT</text>
+   <rect x="369" y="227" width="134" height="32"/>
+   <rect x="367" y="225" width="134" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="377" y="245">sink_format_spec</text>
+   <rect x="45" y="313" width="94" height="32" rx="10"/>
    <rect x="43"
-         y="229"
+         y="311"
          width="94"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="53" y="249">ENVELOPE</text>
-   <rect x="179" y="231" width="92" height="32" rx="10"/>
+   <text class="terminal" x="53" y="331">ENVELOPE</text>
+   <rect x="179" y="313" width="92" height="32" rx="10"/>
    <rect x="177"
-         y="229"
+         y="311"
          width="92"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="187" y="249">DEBEZIUM</text>
-   <rect x="179" y="275" width="76" height="32" rx="10"/>
+   <text class="terminal" x="187" y="331">DEBEZIUM</text>
+   <rect x="179" y="357" width="76" height="32" rx="10"/>
    <rect x="177"
-         y="273"
+         y="355"
          width="76"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="187" y="293">UPSERT</text>
-   <rect x="351" y="231" width="142" height="32" rx="10"/>
+   <text class="terminal" x="187" y="375">UPSERT</text>
+   <rect x="351" y="313" width="142" height="32" rx="10"/>
    <rect x="349"
-         y="229"
+         y="311"
          width="142"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="359" y="249">WITH SNAPSHOT</text>
-   <rect x="351" y="275" width="172" height="32" rx="10"/>
+   <text class="terminal" x="359" y="331">WITH SNAPSHOT</text>
+   <rect x="351" y="357" width="172" height="32" rx="10"/>
    <rect x="349"
-         y="273"
+         y="355"
          width="172"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="359" y="293">WITHOUT SNAPSHOT</text>
+   <text class="terminal" x="359" y="375">WITHOUT SNAPSHOT</text>
    <path class="line"
-         d="m19 17 h2 m0 0 h10 m114 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m88 0 h10 m0 0 h10 m60 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-487 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m90 0 h10 m0 0 h10 m54 0 h10 m20 0 h10 m162 0 h10 m0 0 h46 m-248 0 h20 m228 0 h20 m-268 0 q10 0 10 10 m248 0 q0 -10 10 -10 m-258 10 v24 m248 0 v-24 m-248 24 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m94 0 h10 m0 0 h10 m94 0 h10 m22 -44 l2 0 m2 0 l2 0 m2 0 l2 0 m-523 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h256 m-286 0 h20 m266 0 h20 m-306 0 q10 0 10 10 m286 0 q0 -10 10 -10 m-296 10 v12 m286 0 v-12 m-286 12 q0 10 10 10 m266 0 q10 0 10 -10 m-276 10 h10 m94 0 h10 m20 0 h10 m92 0 h10 m-132 0 h20 m112 0 h20 m-152 0 q10 0 10 10 m132 0 q0 -10 10 -10 m-142 10 v24 m132 0 v-24 m-132 24 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m76 0 h10 m0 0 h16 m60 -76 h10 m0 0 h182 m-212 0 h20 m192 0 h20 m-232 0 q10 0 10 10 m212 0 q0 -10 10 -10 m-222 10 v12 m212 0 v-12 m-212 12 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m142 0 h10 m0 0 h30 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m172 0 h10 m23 -76 h-3"/>
-   <polygon points="561 213 569 209 569 217"/>
-   <polygon points="561 213 553 209 553 217"/>
+         d="m19 17 h2 m0 0 h10 m114 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m88 0 h10 m0 0 h10 m60 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-465 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m90 0 h10 m0 0 h10 m54 0 h10 m20 0 h10 m162 0 h10 m0 0 h2 m-204 0 h20 m184 0 h20 m-224 0 q10 0 10 10 m204 0 q0 -10 10 -10 m-214 10 v24 m204 0 v-24 m-204 24 q0 10 10 10 m184 0 q10 0 10 -10 m-194 10 h10 m94 0 h10 m0 0 h10 m50 0 h10 m22 -44 l2 0 m2 0 l2 0 m2 0 l2 0 m-473 94 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h146 m-176 0 h20 m156 0 h20 m-196 0 q10 0 10 10 m176 0 q0 -10 10 -10 m-186 10 v12 m176 0 v-12 m-176 12 q0 10 10 10 m156 0 q10 0 10 -10 m-166 10 h10 m136 0 h10 m40 -32 h10 m0 0 h244 m-274 0 h20 m254 0 h20 m-294 0 q10 0 10 10 m274 0 q0 -10 10 -10 m-284 10 v12 m274 0 v-12 m-274 12 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h10 m134 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-542 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h256 m-286 0 h20 m266 0 h20 m-306 0 q10 0 10 10 m286 0 q0 -10 10 -10 m-296 10 v12 m286 0 v-12 m-286 12 q0 10 10 10 m266 0 q10 0 10 -10 m-276 10 h10 m94 0 h10 m20 0 h10 m92 0 h10 m-132 0 h20 m112 0 h20 m-152 0 q10 0 10 10 m132 0 q0 -10 10 -10 m-142 10 v24 m132 0 v-24 m-132 24 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m76 0 h10 m0 0 h16 m60 -76 h10 m0 0 h182 m-212 0 h20 m192 0 h20 m-232 0 q10 0 10 10 m212 0 q0 -10 10 -10 m-222 10 v12 m212 0 v-12 m-212 12 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m142 0 h10 m0 0 h30 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m172 0 h10 m23 -76 h-3"/>
+   <polygon points="561 295 569 291 569 299"/>
+   <polygon points="561 295 553 291 553 299"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/sink-format-spec.svg
+++ b/doc/user/layouts/partials/sql-grammar/sink-format-spec.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="733" height="157">
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="51" y="3" width="110" height="32" rx="10"/>
+   <rect x="49"
+         y="1"
+         width="110"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="21">AVRO USING</text>
+   <rect x="201" y="3" width="246" height="32" rx="10"/>
+   <rect x="199"
+         y="1"
+         width="246"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="209" y="21">CONFLUENT SCHEMA REGISTRY</text>
+   <rect x="467" y="3" width="36" height="32"/>
+   <rect x="465" y="1" width="36" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="475" y="21">url</text>
+   <rect x="543" y="35" width="102" height="32"/>
+   <rect x="541" y="33" width="102" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="551" y="53">with_options</text>
+   <rect x="201" y="79" width="82" height="32" rx="10"/>
+   <rect x="199"
+         y="77"
+         width="82"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="209" y="97">SCHEMA</text>
+   <rect x="303" y="79" width="48" height="32" rx="10"/>
+   <rect x="301"
+         y="77"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="311" y="97">FILE</text>
+   <rect x="371" y="79" width="132" height="32"/>
+   <rect x="369" y="77" width="132" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="379" y="97">schema_file_path</text>
+   <rect x="51" y="123" width="58" height="32" rx="10"/>
+   <rect x="49"
+         y="121"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="141">JSON</text>
+   <path class="line"
+         d="m17 17 h2 m20 0 h10 m110 0 h10 m20 0 h10 m246 0 h10 m0 0 h10 m36 0 h10 m20 0 h10 m0 0 h112 m-142 0 h20 m122 0 h20 m-162 0 q10 0 10 10 m142 0 q0 -10 10 -10 m-152 10 v12 m142 0 v-12 m-142 12 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m102 0 h10 m-484 -32 h20 m484 0 h20 m-524 0 q10 0 10 10 m504 0 q0 -10 10 -10 m-514 10 v56 m504 0 v-56 m-504 56 q0 10 10 10 m484 0 q10 0 10 -10 m-494 10 h10 m82 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m132 0 h10 m0 0 h162 m-654 -76 h20 m654 0 h20 m-694 0 q10 0 10 10 m674 0 q0 -10 10 -10 m-684 10 v100 m674 0 v-100 m-674 100 q0 10 10 10 m654 0 q10 0 10 -10 m-664 10 h10 m58 0 h10 m0 0 h576 m23 -120 h-3"/>
+   <polygon points="723 17 731 13 731 21"/>
+   <polygon points="723 17 715 13 715 21"/>
+</svg>

--- a/doc/user/layouts/partials/sql-grammar/sink-kafka-connector.svg
+++ b/doc/user/layouts/partials/sql-grammar/sink-kafka-connector.svg
@@ -1,157 +1,111 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1099" height="485">
-   <polygon points="9 17 1 13 1 21"/>
-   <polygon points="17 17 9 13 9 21"/>
-   <rect x="31" y="3" width="130" height="32" rx="10"/>
-   <rect x="29"
+<svg xmlns="http://www.w3.org/2000/svg" width="895" height="281">
+   <polygon points="11 17 3 13 3 21"/>
+   <polygon points="19 17 11 13 11 21"/>
+   <rect x="33" y="3" width="130" height="32" rx="10"/>
+   <rect x="31"
          y="1"
          width="130"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="39" y="21">KAFKA BROKER</text>
-   <rect x="181" y="3" width="48" height="32"/>
-   <rect x="179" y="1" width="48" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="189" y="21">host</text>
-   <rect x="249" y="3" width="64" height="32" rx="10"/>
-   <rect x="247"
+   <text class="terminal" x="41" y="21">KAFKA BROKER</text>
+   <rect x="183" y="3" width="48" height="32"/>
+   <rect x="181" y="1" width="48" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="191" y="21">host</text>
+   <rect x="251" y="3" width="64" height="32" rx="10"/>
+   <rect x="249"
          y="1"
          width="64"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="257" y="21">TOPIC</text>
-   <rect x="333" y="3" width="98" height="32"/>
-   <rect x="331" y="1" width="98" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="341" y="21">topic-prefix</text>
-   <rect x="402" y="113" width="48" height="32" rx="10"/>
-   <rect x="400"
+   <text class="terminal" x="259" y="21">TOPIC</text>
+   <rect x="335" y="3" width="98" height="32"/>
+   <rect x="333" y="1" width="98" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="343" y="21">topic-prefix</text>
+   <rect x="301" y="113" width="48" height="32" rx="10"/>
+   <rect x="299"
          y="111"
          width="48"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="410" y="131">KEY</text>
-   <rect x="470" y="113" width="26" height="32" rx="10"/>
-   <rect x="468"
+   <text class="terminal" x="309" y="131">KEY</text>
+   <rect x="369" y="113" width="26" height="32" rx="10"/>
+   <rect x="367"
          y="111"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="478" y="131">(</text>
-   <rect x="536" y="113" width="98" height="32"/>
-   <rect x="534" y="111" width="98" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="544" y="131">key_column</text>
-   <rect x="536" y="69" width="24" height="32" rx="10"/>
-   <rect x="534"
+   <text class="terminal" x="377" y="131">(</text>
+   <rect x="435" y="113" width="98" height="32"/>
+   <rect x="433" y="111" width="98" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="443" y="131">key_column</text>
+   <rect x="435" y="69" width="24" height="32" rx="10"/>
+   <rect x="433"
          y="67"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="544" y="87">,</text>
-   <rect x="674" y="113" width="26" height="32" rx="10"/>
-   <rect x="672"
+   <text class="terminal" x="443" y="87">,</text>
+   <rect x="573" y="113" width="26" height="32" rx="10"/>
+   <rect x="571"
          y="111"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="682" y="131">)</text>
-   <rect x="45" y="211" width="122" height="32" rx="10"/>
+   <text class="terminal" x="581" y="131">)</text>
+   <rect x="45" y="215" width="122" height="32" rx="10"/>
    <rect x="43"
-         y="209"
+         y="213"
          width="122"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="53" y="229">CONSISTENCY</text>
-   <rect x="187" y="211" width="64" height="32" rx="10"/>
+   <text class="terminal" x="53" y="233">CONSISTENCY</text>
+   <rect x="187" y="215" width="26" height="32" rx="10"/>
    <rect x="185"
-         y="209"
+         y="213"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="195" y="233">(</text>
+   <rect x="233" y="215" width="64" height="32" rx="10"/>
+   <rect x="231"
+         y="213"
          width="64"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="195" y="229">TOPIC</text>
-   <rect x="271" y="211" width="52" height="32"/>
-   <rect x="269" y="209" width="52" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="279" y="229">topic</text>
-   <rect x="363" y="243" width="122" height="32" rx="10"/>
-   <rect x="361"
-         y="241"
-         width="122"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="371" y="261">CONSISTENCY</text>
-   <rect x="505" y="243" width="80" height="32" rx="10"/>
-   <rect x="503"
-         y="241"
+   <text class="terminal" x="241" y="233">TOPIC</text>
+   <rect x="317" y="215" width="138" height="32"/>
+   <rect x="315" y="213" width="138" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="325" y="233">consistency_topic</text>
+   <rect x="495" y="247" width="80" height="32" rx="10"/>
+   <rect x="493"
+         y="245"
          width="80"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="513" y="261">FORMAT</text>
-   <rect x="605" y="243" width="110" height="32" rx="10"/>
-   <rect x="603"
-         y="241"
-         width="110"
+   <text class="terminal" x="503" y="265">FORMAT</text>
+   <rect x="595" y="247" width="186" height="32"/>
+   <rect x="593" y="245" width="186" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="603" y="265">consistency_format_spec</text>
+   <rect x="821" y="215" width="26" height="32" rx="10"/>
+   <rect x="819"
+         y="213"
+         width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="613" y="261">AVRO USING</text>
-   <rect x="735" y="243" width="246" height="32" rx="10"/>
-   <rect x="733"
-         y="241"
-         width="246"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="743" y="261">CONFLUENT SCHEMA REGISTRY</text>
-   <rect x="1001" y="243" width="36" height="32"/>
-   <rect x="999" y="241" width="36" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="1009" y="261">url</text>
-   <rect x="450" y="341" width="102" height="32"/>
-   <rect x="448" y="339" width="102" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="458" y="359">with_options</text>
-   <rect x="592" y="309" width="80" height="32" rx="10"/>
-   <rect x="590"
-         y="307"
-         width="80"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="600" y="327">FORMAT</text>
-   <rect x="619" y="407" width="110" height="32" rx="10"/>
-   <rect x="617"
-         y="405"
-         width="110"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="627" y="425">AVRO USING</text>
-   <rect x="749" y="407" width="246" height="32" rx="10"/>
-   <rect x="747"
-         y="405"
-         width="246"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="757" y="425">CONFLUENT SCHEMA REGISTRY</text>
-   <rect x="1015" y="407" width="36" height="32"/>
-   <rect x="1013" y="405" width="36" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="1023" y="425">url</text>
-   <rect x="619" y="451" width="58" height="32" rx="10"/>
-   <rect x="617"
-         y="449"
-         width="58"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="627" y="469">JSON</text>
+   <text class="terminal" x="829" y="233">)</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m130 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m98 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-93 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m48 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m98 0 h10 m-138 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m118 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-118 0 h10 m24 0 h10 m0 0 h74 m20 44 h10 m26 0 h10 m-338 0 h20 m318 0 h20 m-358 0 q10 0 10 10 m338 0 q0 -10 10 -10 m-348 10 v14 m338 0 v-14 m-338 14 q0 10 10 10 m318 0 q10 0 10 -10 m-328 10 h10 m0 0 h308 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-739 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h1022 m-1052 0 h20 m1032 0 h20 m-1072 0 q10 0 10 10 m1052 0 q0 -10 10 -10 m-1062 10 v12 m1052 0 v-12 m-1052 12 q0 10 10 10 m1032 0 q10 0 10 -10 m-1042 10 h10 m122 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m52 0 h10 m20 0 h10 m0 0 h684 m-714 0 h20 m694 0 h20 m-734 0 q10 0 10 10 m714 0 q0 -10 10 -10 m-724 10 v12 m714 0 v-12 m-714 12 q0 10 10 10 m694 0 q10 0 10 -10 m-704 10 h10 m122 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m110 0 h10 m0 0 h10 m246 0 h10 m0 0 h10 m36 0 h10 m42 -64 l2 0 m2 0 l2 0 m2 0 l2 0 m-691 130 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h112 m-142 0 h20 m122 0 h20 m-162 0 q10 0 10 10 m142 0 q0 -10 10 -10 m-152 10 v12 m142 0 v-12 m-142 12 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m102 0 h10 m20 -32 h10 m80 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-117 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m110 0 h10 m0 0 h10 m246 0 h10 m0 0 h10 m36 0 h10 m-472 0 h20 m452 0 h20 m-492 0 q10 0 10 10 m472 0 q0 -10 10 -10 m-482 10 v24 m472 0 v-24 m-472 24 q0 10 10 10 m452 0 q10 0 10 -10 m-462 10 h10 m58 0 h10 m0 0 h374 m23 -44 h-3"/>
-   <polygon points="1089 421 1097 417 1097 425"/>
-   <polygon points="1089 421 1081 417 1081 425"/>
+         d="m19 17 h2 m0 0 h10 m130 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m98 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-196 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m48 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m98 0 h10 m-138 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m118 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-118 0 h10 m24 0 h10 m0 0 h74 m20 44 h10 m26 0 h10 m-338 0 h20 m318 0 h20 m-358 0 q10 0 10 10 m338 0 q0 -10 10 -10 m-348 10 v14 m338 0 v-14 m-338 14 q0 10 10 10 m318 0 q10 0 10 -10 m-328 10 h10 m0 0 h308 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-638 70 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h812 m-842 0 h20 m822 0 h20 m-862 0 q10 0 10 10 m842 0 q0 -10 10 -10 m-852 10 v12 m842 0 v-12 m-842 12 q0 10 10 10 m822 0 q10 0 10 -10 m-832 10 h10 m122 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m138 0 h10 m20 0 h10 m0 0 h296 m-326 0 h20 m306 0 h20 m-346 0 q10 0 10 10 m326 0 q0 -10 10 -10 m-336 10 v12 m326 0 v-12 m-326 12 q0 10 10 10 m306 0 q10 0 10 -10 m-316 10 h10 m80 0 h10 m0 0 h10 m186 0 h10 m20 -32 h10 m26 0 h10 m23 -32 h-3"/>
+   <polygon points="885 197 893 193 893 201"/>
+   <polygon points="885 197 877 193 877 201"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -47,8 +47,10 @@ create_sink ::=
     'FROM' item_name
     'INTO' (
     sink_kafka_connector |
-    'AVRO OCF' path-prefix
+    'AVRO OCF' path
     )
+    ( sink_with_options )?
+    ('FORMAT' sink_format_spec)?
     ('ENVELOPE' ('DEBEZIUM'|'UPSERT'))?
     ('WITH SNAPSHOT' | 'WITHOUT SNAPSHOT')?
 create_source_avro_file ::=
@@ -284,6 +286,17 @@ format_spec ::=
   'CSV WITH' ('HEADER' ( '(' col_name (',' col_name)* ')' )? | n 'COLUMNS') ('DELIMITED BY' char)? |
   'TEXT' |
   'BYTES'
+sink_format_spec ::=
+  'AVRO USING' (
+        'CONFLUENT SCHEMA REGISTRY' url with_options? |
+        'SCHEMA' 'FILE' schema_file_path
+        ) |
+  'JSON'
+consistency_format_spec ::=
+  'AVRO USING' (
+        'CONFLUENT SCHEMA REGISTRY' url with_options? |
+        'SCHEMA' 'FILE' schema_file_path
+        )
 key_constraint ::= ('PRIMARY KEY' '(' (col_name) ( ( ',' col_name ) )* ')' 'NOT ENFORCED')
 func_at_time_zone ::=
     'SELECT' ( 'TIMESTAMP' | 'TIMESTAMPTZ' ) ('timestamp' | 'timestamptz') 'AT TIME ZONE' 'zone::type'
@@ -311,9 +324,7 @@ join_type ::=
 sink_kafka_connector ::=
     'KAFKA BROKER' host 'TOPIC' topic-prefix
     ('KEY' '(' key_column ( ',' key_column )* ')')?
-    ('CONSISTENCY' 'TOPIC' topic ('CONSISTENCY' 'FORMAT' 'AVRO USING' 'CONFLUENT SCHEMA REGISTRY' url)?)?
-    with_options?
-    'FORMAT' ('AVRO USING' 'CONFLUENT SCHEMA REGISTRY' url | 'JSON')
+    ('CONSISTENCY' '(' 'TOPIC' consistency_topic ('FORMAT' consistency_format_spec)? ')' )?
 lit_cast ::=
   type val
 op_cast ::=

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -602,14 +602,15 @@ pub struct KafkaConsistency<T: AstInfo> {
 
 impl<T: AstInfo> AstDisplay for KafkaConsistency<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
-        f.write_str(" CONSISTENCY TOPIC '");
+        f.write_str(" CONSISTENCY (TOPIC '");
         f.write_node(&display::escape_single_quote_string(&self.topic));
         f.write_str("'");
 
         if let Some(format) = self.topic_format.as_ref() {
-            f.write_str(" CONSISTENCY FORMAT ");
+            f.write_str(" FORMAT ");
             f.write_node(format);
         }
+        f.write_str(")");
     }
 }
 impl_display_t!(KafkaConsistency);

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1936,13 +1936,29 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_kafka_consistency(&mut self) -> Result<Option<KafkaConsistency<Raw>>, ParserError> {
-        if self.parse_keywords(&[CONSISTENCY, TOPIC]) {
+        if self.parse_keyword(CONSISTENCY) {
+            // We would prefer for all consistency parameters to be
+            // parenthesized, but for backwards compatibility we support an
+            // unparenthesized syntax that has some ambiguity issues
+            // (see #8231).
+            //
+            // Bad:
+            //     CONSISTENCY TOPIC 'foo' CONSISTENCY FORMAT 'bar' WITH (format_option = 'blah')
+            // Good:
+            //     CONSISTENCY (TOPIC 'foo' FORMAT 'bar' WITH (format_option = 'blah'))
+            let parenthesized = self.consume_token(&Token::LParen);
+            self.expect_keyword(TOPIC)?;
             let topic = self.parse_literal_string()?;
-            let topic_format = if self.parse_keywords(&[CONSISTENCY, FORMAT]) {
+            let topic_format = if (parenthesized && self.parse_keyword(FORMAT))
+                || (!parenthesized && self.parse_keywords(&[CONSISTENCY, FORMAT]))
+            {
                 Some(self.parse_format()?)
             } else {
                 None
             };
+            if parenthesized {
+                self.expect_token(&Token::RParen)?;
+            }
             Ok(Some(KafkaConsistency {
                 topic,
                 topic_format,

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -681,9 +681,37 @@ CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), fro
 parse-statement
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) CONSISTENCY TOPIC 'consistency' CONSISTENCY FORMAT BYTES FORMAT BYTES
 ----
-CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) CONSISTENCY TOPIC 'consistency' CONSISTENCY FORMAT BYTES FORMAT BYTES WITH SNAPSHOT
+CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) CONSISTENCY (TOPIC 'consistency' FORMAT BYTES) FORMAT BYTES WITH SNAPSHOT
 =>
 CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), from: UnresolvedObjectName([Ident("bar")]), connector: Kafka { broker: "baz", topic: "topic", key: Some([Ident("a"), Ident("b")]), consistency: Some(KafkaConsistency { topic: "consistency", topic_format: Some(Bytes) }) }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
+
+parse-statement
+CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) CONSISTENCY (TOPIC 'consistency') FORMAT BYTES
+----
+CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) CONSISTENCY (TOPIC 'consistency') FORMAT BYTES WITH SNAPSHOT
+=>
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), from: UnresolvedObjectName([Ident("bar")]), connector: Kafka { broker: "baz", topic: "topic", key: Some([Ident("a"), Ident("b")]), consistency: Some(KafkaConsistency { topic: "consistency", topic_format: None }) }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
+
+parse-statement
+CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) CONSISTENCY (TOPIC 'consistency' CONSISTENCY FORMAT BYTES) FORMAT BYTES
+----
+error: Expected right parenthesis, found CONSISTENCY
+CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) CONSISTENCY (TOPIC 'consistency' CONSISTENCY FORMAT BYTES) FORMAT BYTES
+                                                                                                           ^
+
+parse-statement
+CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) CONSISTENCY (TOPIC 'consistency' FORMAT BYTES) FORMAT BYTES
+----
+CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) CONSISTENCY (TOPIC 'consistency' FORMAT BYTES) FORMAT BYTES WITH SNAPSHOT
+=>
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), from: UnresolvedObjectName([Ident("bar")]), connector: Kafka { broker: "baz", topic: "topic", key: Some([Ident("a"), Ident("b")]), consistency: Some(KafkaConsistency { topic: "consistency", topic_format: Some(Bytes) }) }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
+
+parse-statement
+CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) CONSISTENCY (TOPIC 'consistency' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (username=user)) FORMAT BYTES
+----
+CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) CONSISTENCY (TOPIC 'consistency' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (username = user)) FORMAT BYTES WITH SNAPSHOT
+=>
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), from: UnresolvedObjectName([Ident("bar")]), connector: Kafka { broker: "baz", topic: "topic", key: Some([Ident("a"), Ident("b")]), consistency: Some(KafkaConsistency { topic: "consistency", topic_format: Some(Avro(Csr { csr_connector: CsrConnector { url: "http://localhost:8081", seed: None, with_options: [ObjectName { name: Ident("username"), object_name: UnresolvedObjectName([Ident("user")]) }] } })) }) }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
 
 parse-statement
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY FORMAT BYTES

--- a/test/testdrive/kafka-exactly-once-sink.td
+++ b/test/testdrive/kafka-exactly-once-sink.td
@@ -238,7 +238,7 @@ $ kafka-verify format=avro sink=materialize.public.rt_binding_consistency_test_s
   CONSISTENCY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   WITH (consistency_topic='willfail')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-Expected end of statement, found CONSISTENCY
+Expected TOPIC, found FORMAT
 
 # Can't provide CONSISTENCY FORMAT and consistency_topic WITH option
 ! CREATE SINK double_avro FROM unnamed_cols
@@ -277,6 +277,14 @@ CONSISTENCY FORMAT JSON not yet supported
 $ kafka-verify format=avro sink=materialize.public.double_avro sort-messages=true
 {"before": null, "after": {"row": {"column1": 1, "b": 2, "column3": 3}}, "transaction": {"id": "0"}}
 
+> CREATE SINK double_avro_2 FROM unnamed_cols
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'double-avro'
+    CONSISTENCY (TOPIC 'consistency-double-avro' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+
+$ kafka-verify format=avro sink=materialize.public.double_avro_2 sort-messages=true
+{"before": null, "after": {"row": {"column1": 1, "b": 2, "column3": 3}}, "transaction": {"id": "0"}}
+
 > CREATE SINK json_avro FROM unnamed_cols
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'json-avro'
     CONSISTENCY TOPIC 'consistency-json-avro' CONSISTENCY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
@@ -285,20 +293,44 @@ $ kafka-verify format=avro sink=materialize.public.double_avro sort-messages=tru
 $ kafka-verify format=json sink=materialize.public.json_avro sort-messages=true key=false
 {"before": null, "after": {"row": {"column1": 1, "b": 2, "column3": 3}}, "transaction": {"id": "0"}}
 
-! CREATE SINK json_reuse_topic FROM unnamed_cols
+> CREATE SINK json_avro_2 FROM unnamed_cols
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'json-avro'
+    CONSISTENCY (TOPIC 'consistency-json-avro' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}')
+  FORMAT JSON
+
+$ kafka-verify format=json sink=materialize.public.json_avro_2 sort-messages=true key=false
+{"before": null, "after": {"row": {"column1": 1, "b": 2, "column3": 3}}, "transaction": {"id": "0"}}
+
+! CREATE SINK json_reuse_topic_no_parens FROM unnamed_cols
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'json-reuse-topic'
     WITH (reuse_topic=true)
   FORMAT JSON
 For FORMAT JSON, you need to manually specify an Avro consistency topic using 'CONSISTENCY TOPIC consistency_topic CONSISTENCY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY url'. The default of using a JSON consistency topic is not supported.
 
-> CREATE SINK json_reuse_topic FROM unnamed_cols
+# This should succeed, but will incorrectly create a nonced topic.
+# See https://github.com/MaterializeInc/materialize/issues/8231.
+> CREATE SINK json_reuse_topic_no_parens FROM unnamed_cols
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'json-reuse-topic'
     CONSISTENCY TOPIC 'consistency-json-avro' CONSISTENCY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
     WITH (reuse_topic=true)
   FORMAT JSON
 
-$ kafka-verify format=json sink=materialize.public.json_reuse_topic sort-messages=true key=false
+$ kafka-verify format=json sink=materialize.public.json_reuse_topic_no_parens sort-messages=true key=false
 {"before": null, "after": {"row": {"column1": 1, "b": 2, "column3": 3}}, "transaction": {"id": "0"}}
+
+# This updated syntax will also succeed, creating a reusable topic.
+> CREATE SINK json_reuse_topic_with_parens FROM rt_binding_consistency_test_source
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'json-reuse-topic-2'
+    CONSISTENCY (TOPIC 'consistency-json-avro-2' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}')
+    WITH (reuse_topic=true)
+  FORMAT JSON
+
+# Same as above!
+> CREATE SINK json_reuse_topic_with_parens_and_with FROM rt_binding_consistency_test_source
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'json-reuse-topic-3'
+    CONSISTENCY (TOPIC 'consistency-json-avro-3' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' WITH (dummy='unused'))
+    WITH (reuse_topic=true)
+  FORMAT JSON
 
 # Default consistency format is Avro if consistency_topic is used
 > CREATE SINK default_avro_2 FROM unnamed_cols
@@ -317,4 +349,14 @@ $ kafka-verify format=avro sink=materialize.public.default_avro sort-messages=tr
   ENVELOPE UPSERT
 
 $ kafka-verify format=json sink=materialize.public.json_avro_upsert_key key=true
+{"b": 2} {"column1": 1, "b": 2, "column3": 3, "transaction": {"id": "0"}}
+
+> CREATE SINK json_avro_upsert_key_2 FROM unnamed_cols
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'json-avro-upsert-key'
+  KEY (b)
+    CONSISTENCY (TOPIC 'consistency-json-avro-upsert-key' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}')
+  FORMAT JSON
+  ENVELOPE UPSERT
+
+$ kafka-verify format=json sink=materialize.public.json_avro_upsert_key_2 key=true
 {"b": 2} {"column1": 1, "b": 2, "column3": 3, "transaction": {"id": "0"}}


### PR DESCRIPTION
### Motivation

Our `CREATE SINK` syntax has [a bug](https://github.com/MaterializeInc/materialize/issues/8231). This PR updates the parser to parse the corrected `CREATE SINK` syntax, without removing the broken one. The idea, which was discussed today in the SQL standup and [in Slack](https://materializeinc.slack.com/archives/CMHDK0DK8/p1632242364299100), is that we will deprecate the broken syntax in X versions. By not removing the broken syntax, we are avoiding a migration.

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug. [Link to issue.]

  * This PR adds a known-desirable feature. [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

### Description

This PR parses an updated `CONSISTENCY` clause, outlined by the following diagrams.

<img width="760" alt="Screen Shot 2021-09-21 at 4 13 09 PM" src="https://user-images.githubusercontent.com/5766027/134259672-015da989-67e3-428a-9f1b-497f01bc81c8.png">
<img width="760" alt="Screen Shot 2021-09-21 at 4 13 22 PM" src="https://user-images.githubusercontent.com/5766027/134259687-0c2711a5-f413-46d6-b196-736e803b2973.png">
<img width="760" alt="Screen Shot 2021-09-21 at 4 13 38 PM" src="https://user-images.githubusercontent.com/5766027/134259693-f455daf6-ab39-4fb6-a7df-4b4f129be7bf.png">



### Manual testing

I manually tested this change (without the `testdrive` magic) to ensure that the Kafka topics created for sinks were correctly nonced/not nonced.

The old syntax continues to cause bugs. The updated syntax will not nonce the created Kafka topic if `reuse_topic` is `true`, regardless of the consistency `FORMAT` clause.

<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details."

-->

### Checklist

- [X] This PR has adequate test coverage.
- [X] This PR adds a release note for any user-facing behavior changes.
