### PR TITLE
pg-cdc: handle unchanged toast values during updates

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -57,6 +57,9 @@ Wrap your release notes at the 80 character mark.
   power upcoming persistence features. Users are free to opt out of this test
   by setting the `--disable_persistent_system_tables_test` flag to "true".
 
+- PostgreSQL sources can now correctly handle TOAST columns when `REPLICA
+  IDENTITY` is set to `FULL`.
+
 {{% version-header v0.9.4 %}}
 
 - Improve the performance of

--- a/doc/user/content/sql/create-source/postgres.md
+++ b/doc/user/content/sql/create-source/postgres.md
@@ -67,13 +67,6 @@ If you stop or delete Materialize without first dropping the Postgres source, th
 
 - Materialize does not support changes to schemas for existing publications. You will need to drop the existing sources and then recreate them after creating new publications for the updated schemas.
 - Sources can only be created from publications that use [data types](/sql/types/) supported by Materialize. Attempts to create sources from publications which contain unsupported data types will fail with an error.
-- Materialize does not support [TOASTED](https://www.postgresql.org/docs/current/storage-toast.html) values except in append-only tables. Practically speaking, you can include rows with TOASTED values as long as they are never updated or deleted, or you can disable TOAST on the original Postgres table. If a TOASTED column is updated, the source will enter an errored state that renders all per-table views inaccessible.
-
-  To disable TOAST on a column, use the following command in Postgres:
-  ```
-  ALTER TABLE table_name ALTER COLUMN column_name
-  SET STORAGE PLAIN;
-  ```
 - Tables replicated into Materialize should not be truncated. If a table is truncated while replicated, the whole source becomes inaccessible and will not produce any data until it is re-created.
 - Since Postgres sources are materialized by default, Postgres table sources must be smaller than the available memory.
 

--- a/test/pg-cdc/toast-columns.td
+++ b/test/pg-cdc/toast-columns.td
@@ -1,0 +1,50 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Test that we can ingest unchanged toasted values
+#
+
+# Insert data pre-snapshot by generating 16kB of uncompressible data to force
+# TOASTed storage by concatenating 1024 random MD5 hashes, each being 128bit
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER USER postgres WITH replication;
+DROP SCHEMA IF EXISTS public CASCADE;
+DROP PUBLICATION IF EXISTS mz_source;
+
+CREATE SCHEMA public;
+
+CREATE TABLE t1 (a int, b text);
+ALTER TABLE t1 REPLICA IDENTITY FULL;
+
+INSERT INTO t1 SELECT 1, string_agg(md5(random()::text), '') FROM generate_series(1, 1024);
+INSERT INTO t1 SELECT 2, string_agg(md5(random()::text), '') FROM generate_series(1, 1024);
+
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+> CREATE MATERIALIZED SOURCE mz_source
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
+  PUBLICATION 'mz_source';
+
+> SELECT COUNT(*) > 0 FROM mz_source;
+true
+
+> CREATE VIEWS FROM SOURCE mz_source;
+
+> SELECT a, length(b) FROM t1;
+1 32768
+2 32768
+
+# Update the rows without touching the TOASTed column
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+UPDATE t1 SET a = 3;
+
+> SELECT a, length(b) FROM t1;
+3 32768
+3 32768


### PR DESCRIPTION
### Motivation

Fix #8362

### Description

Due to misunderstanding of the replication protocol the postgres source was previously was over-restrictive with respect to handling unchanged TOAST values.

In the general case, we can not ingest the placeholder value that the  replication protocol uses to indicate that a TOASTed column is unchanged.

However, when the table in question has `REPLICA IDENTITY FULL`, which is what we recommend anyway, the replication protocol will only use the placeholder value for the *after* value of a row during an update but for the *before* value.

Therefore, when we encounter an unchanged TOAST value placeholder in the after row, we can grab the previous value from the before row and send that in the dataflow.

Fixes #8362

### Checklist

- [x] This PR has adequate test coverage.
- [x] This PR adds a release note for any user-facing behavior changes.
