### PR TITLE
Prepare v0.9.6-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2240,7 +2240,7 @@ checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "materialized"
-version = "0.9.5-dev"
+version = "0.9.5-rc1"
 dependencies = [
  "anyhow",
  "askama",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2240,7 +2240,7 @@ checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "materialized"
-version = "0.9.5-rc1"
+version = "0.9.6-dev"
 dependencies = [
  "anyhow",
  "askama",

--- a/LICENSE
+++ b/LICENSE
@@ -13,7 +13,7 @@ Business Source License 1.1
 
 Licensor:                  Materialize, Inc.
 
-Licensed Work:             Materialize Version 0.9.5-dev
+Licensed Work:             Materialize Version 0.9.5-rc1
                            The Licensed Work is © 2021 Materialize, Inc.
 
 Additional Use Grant:      You may use one single server instance of the
@@ -29,7 +29,7 @@ Additional Use Grant:      You may use one single server instance of the
                            functionality of the Licensed Work by creating views
                            whose schemas are controlled by such third parties.
 
-Change Date:               September 17, 2025
+Change Date:               September 21, 2025
 
 Change License:            Apache License, Version 2.0
 

--- a/LICENSE
+++ b/LICENSE
@@ -13,7 +13,7 @@ Business Source License 1.1
 
 Licensor:                  Materialize, Inc.
 
-Licensed Work:             Materialize Version 0.9.5-rc1
+Licensed Work:             Materialize Version 0.9.6-dev
                            The Licensed Work is © 2021 Materialize, Inc.
 
 Additional Use Grant:      You may use one single server instance of the

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -46,6 +46,8 @@ Use relative links (/path/to/doc), not absolute links
 Wrap your release notes at the 80 character mark.
 {{< /comment >}}
 
+{{% version-header v0.9.6 %}}
+
 {{% version-header v0.9.5 %}}
 
 - Timezone parsing is now case insensitive to be compatible with PostgreSQL.
@@ -55,7 +57,7 @@ Wrap your release notes at the 80 character mark.
 - Persist the `mz_metrics` and `mz_metric_histogram` system tables and rehydrate
   the previous contents on restart. This is a small test of the system that will
   power upcoming persistence features. Users are free to opt out of this test
-  by setting the `--disable_persistent_system_tables_test` flag to "true".
+  by starting `materialized` with the `--disable-persistent-system-tables-test` flag.
 
 {{% version-header v0.9.4 %}}
 

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "materialized"
 description = "Streaming SQL materialized views."
-version = "0.9.5-rc1"
+version = "0.9.6-dev"
 authors = ["Materialize, Inc."]
 license = "proprietary"
 edition = "2018"

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "materialized"
 description = "Streaming SQL materialized views."
-version = "0.9.5-dev"
+version = "0.9.5-rc1"
 authors = ["Materialize, Inc."]
 license = "proprietary"
 edition = "2018"


### PR DESCRIPTION
Update one trivial release note change for persistent tables.

part of #8374 