### PR TITLE
persist: allow multiple workers to together concurrently read a snapshot

### DIFF
--- a/src/persist/benches/snapshot.rs
+++ b/src/persist/benches/snapshot.rs
@@ -15,6 +15,7 @@ use ore::metrics::MetricsRegistry;
 use persist::error::Error;
 use persist::file::{FileBlob, FileLog};
 use persist::indexed::runtime::{self, RuntimeClient, RuntimeConfig, StreamReadHandle};
+use persist::indexed::Snapshot;
 use persist::mem::MemRegistry;
 use persist::storage::LockInfo;
 use persist_types::Codec;
@@ -26,7 +27,8 @@ fn read_full_snapshot<K: Codec + Ord, V: Codec + Ord>(
     let buf = read
         .snapshot()
         .expect("reading snapshot cannot fail")
-        .read_to_end_flattened()
+        .into_iter()
+        .collect::<Result<Vec<_>, Error>>()
         .expect("fully reading snapshot cannot fail");
 
     assert_eq!(buf.len(), expected_len);

--- a/src/persist/src/golden_test.rs
+++ b/src/persist/src/golden_test.rs
@@ -14,6 +14,7 @@ use timely::progress::Antichain;
 
 use crate::error::{Error, ErrorLog};
 use crate::indexed::runtime::{self, RuntimeClient, RuntimeConfig};
+use crate::indexed::Snapshot;
 use crate::mem::{MemBlob, MemRegistry};
 use crate::nemesis::direct::Direct;
 use crate::nemesis::generator::{Generator, GeneratorConfig};
@@ -207,12 +208,13 @@ impl PersistState {
         let mut streams = Vec::new();
         for name in ('a'..='e').map(|x| x.to_string()) {
             let (_, read) = persist.create_or_load(&name)?;
-            let mut snap = read.snapshot()?;
-            let snap_data = snap.read_to_end_flattened()?;
+            let snap = read.snapshot()?;
+            let (seal, since) = (snap.get_seal(), snap.since());
+            let snap_data = snap.into_iter().collect::<Result<Vec<_>, Error>>()?;
             streams.push(PersistStreamState {
                 name,
-                seal: snap.get_seal(),
-                since: snap.since(),
+                seal,
+                since,
                 snap: snap_data,
             });
         }

--- a/src/persist/src/indexed/unsealed.rs
+++ b/src/persist/src/indexed/unsealed.rs
@@ -10,6 +10,8 @@
 //! A persistent, compacting data structure of `(Key, Value, Time, Diff)`
 //! updates, indexed by time.
 
+use std::collections::VecDeque;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use timely::progress::Antichain;
@@ -314,20 +316,78 @@ pub struct UnsealedSnapshot {
 }
 
 impl Snapshot<Vec<u8>, Vec<u8>> for UnsealedSnapshot {
-    fn read<E: Extend<((Vec<u8>, Vec<u8>), u64, isize)>>(
-        &mut self,
-        buf: &mut E,
-    ) -> Result<bool, Error> {
-        if let Some(batch) = self.batches.pop() {
-            let batch = batch.recv()?;
-            let updates = batch
-                .updates
-                .iter()
-                .filter(|(_, ts, _)| self.ts_lower.less_equal(ts) && !self.ts_upper.less_equal(ts))
-                .map(|((key, val), ts, diff)| ((key.clone(), val.clone()), *ts, *diff));
-            buf.extend(updates);
+    type Iter = UnsealedSnapshotIter;
+
+    fn into_iters(self, num_iters: NonZeroUsize) -> Vec<Self::Iter> {
+        let mut iters = Vec::with_capacity(num_iters.get());
+        iters.resize_with(num_iters.get(), || UnsealedSnapshotIter {
+            ts_lower: self.ts_lower.clone(),
+            ts_upper: self.ts_upper.clone(),
+            current_batch: Vec::new(),
+            batches: VecDeque::new(),
+        });
+        // TODO: This should probably distribute batches based on size, but for
+        // now it's simpler to round-robin them.
+        for (i, batch) in self.batches.into_iter().enumerate() {
+            let iter_idx = i % num_iters;
+            iters[iter_idx].batches.push_back(batch);
         }
-        Ok(!self.batches.is_empty())
+        iters
+    }
+}
+
+/// An [Iterator] representing one part of the data in a [UnsealedSnapshot].
+//
+// This intentionally stores the batches as a VecDeque so we can return the data
+// in roughly increasing timestamp order, but it's unclear if this is in any way
+// important.
+#[derive(Debug)]
+pub struct UnsealedSnapshotIter {
+    /// A closed lower bound on the times of contained updates.
+    ts_lower: Antichain<u64>,
+    /// An open upper bound on the times of the contained updates.
+    ts_upper: Antichain<u64>,
+
+    current_batch: Vec<((Vec<u8>, Vec<u8>), u64, isize)>,
+    batches: VecDeque<Future<Arc<BlobUnsealedBatch>>>,
+}
+
+impl Iterator for UnsealedSnapshotIter {
+    type Item = Result<((Vec<u8>, Vec<u8>), u64, isize), Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if !self.current_batch.is_empty() {
+                let update = self.current_batch.pop().unwrap();
+                return Some(Ok(update));
+            } else {
+                // current_batch is empty, find a new one.
+                let b = match self.batches.pop_front() {
+                    None => return None,
+                    Some(b) => b,
+                };
+                match b.recv() {
+                    Ok(b) => {
+                        // Reverse the updates so we can pop them off the back
+                        // in roughly increasing time order. At the same time,
+                        // enforce our filter before we clone them.
+                        let ts_lower = self.ts_lower.borrow();
+                        let ts_upper = self.ts_upper.borrow();
+                        self.current_batch.extend(
+                            b.updates
+                                .iter()
+                                .rev()
+                                .filter(|(_, ts, _)| {
+                                    ts_lower.less_equal(&ts) && !ts_upper.less_equal(&ts)
+                                })
+                                .cloned(),
+                        );
+                        continue;
+                    }
+                    Err(err) => return Some(Err(err)),
+                }
+            }
+        }
     }
 }
 

--- a/src/persist/src/lib.rs
+++ b/src/persist/src/lib.rs
@@ -33,14 +33,8 @@ pub mod golden_test;
 pub mod nemesis;
 
 // TODO
-// - This method of getting the metadata handle ends up being pretty clunky in
-//   practice. Maybe instead the user should pass in a mutable reference to a
-//   `Meta` they've constructed like `probe_with`?
-// - Error handling. Right now, there are a bunch of `expect`s and this likely
-//   needs to hook into the error streams that Materialize hands around.
 // - Backward compatibility of persisted data, particularly the encoded keys and
 //   values.
-// - Restarting with a different number of workers.
 // - Abomonation is convenient for prototyping, but we'll likely want to reuse
 //   one of the popular serialization libraries.
 // - Tighten up the jargon and usage of that jargon: write, update, persist,
@@ -48,11 +42,6 @@ pub mod nemesis;
 // - Think through all the <, <=, !<= usages and document them more correctly
 //   (aka replace before/after an antichain with in advance of/not in advance
 //   of).
-// - Clean up the various ways we pass a (sometimes encoded) entry/update
-//   around, there are many for no particular reason: returning an iterator,
-//   accepting a closure, accepting a mutable Vec, implementing Snapshot, etc.
-// - Meta TODO: These were my immediate thoughts but there's stuff I'm
-//   forgetting. Flesh this list out.
 
 // Testing edge cases:
 // - Failure while draining from log into unsealed.

--- a/src/persist/src/nemesis/direct.rs
+++ b/src/persist/src/nemesis/direct.rs
@@ -23,7 +23,7 @@ use crate::error::Error;
 use crate::indexed::runtime::{
     self, DecodedSnapshot, MultiWriteHandle, RuntimeClient, StreamReadHandle, StreamWriteHandle,
 };
-use crate::indexed::ListenEvent;
+use crate::indexed::{ListenEvent, SnapshotExt};
 use crate::nemesis::{
     AllowCompactionReq, Input, ReadOutputReq, ReadOutputRes, ReadSnapshotReq, ReadSnapshotRes, Req,
     Res, Runtime, SealReq, SnapshotId, Step, TakeSnapshotReq, WriteReq, WriteReqMulti,
@@ -231,14 +231,15 @@ impl Direct {
     }
 
     fn read_snapshot(&mut self, req: ReadSnapshotReq) -> Result<ReadSnapshotRes, Error> {
-        let mut snap = match self.snapshots.remove(&req.snap) {
+        let snap = match self.snapshots.remove(&req.snap) {
             Some(snap) => snap,
             None => return Err(format!("unknown snap: {:?}", req.snap).into()),
         };
-        let contents = snap.read_to_end_flattened()?;
+        let (seqno, since) = (snap.seqno().0, snap.since());
+        let contents = snap.read_to_end()?;
         Ok(ReadSnapshotRes {
-            seqno: snap.seqno().0,
-            since: snap.since(),
+            seqno,
+            since,
             contents,
         })
     }


### PR DESCRIPTION
Previously, a snapshot had to be read entirely in one place, limiting
the concurrency with which this can be done. This will soon become a
scaling bottleneck, so get ahead of it. This commit adds the ability to
break a snapshot into a given number of roughly equal pieces. At the
same time, it makes the iteration itself more idiomatic by implementing
the Iterator trait. (The previous iteration mechanism was my fault and
an ultimately doomed premature performance optimization.)

This is part 1 of 2. The next part will actually use this new ability in
persist's replay operator to give each worker an equal chunk of the
work.

### Motivation

  * This PR adds a feature that has not yet been specified.
