### PR TITLE
expr/MfpPlan: Make evaluate generic over the error type

### DIFF
--- a/src/dataflow/src/render/context.rs
+++ b/src/dataflow/src/render/context.rs
@@ -465,9 +465,7 @@ where
                 move |data, time, diff| {
                     let temp_storage = repr::RowArena::new();
                     let mut datums_local = datums.borrow_with(&data);
-                    mfp_plan
-                        .evaluate(&mut datums_local, &temp_storage, time.clone(), diff.clone())
-                        .map(|x| x.map_err(|(e, t, d)| (e.into(), t, d)))
+                    mfp_plan.evaluate(&mut datums_local, &temp_storage, time.clone(), diff.clone())
                 }
             });
 

--- a/src/dataflow/src/render/flat_map.rs
+++ b/src/dataflow/src/render/flat_map.rs
@@ -9,7 +9,6 @@
 
 use timely::dataflow::Scope;
 
-use dataflow_types::*;
 use expr::{MapFilterProject, MirScalarExpr, TableFunc};
 use repr::{Row, RowArena};
 
@@ -65,7 +64,6 @@ where
                         datums_local.extend(output_row.iter());
                         mfp_plan
                             .evaluate(&mut datums_local, temp_storage, time, diff * *r)
-                            .map(|x| x.map_err(|(e, t, r)| (DataflowError::from(e), t, r)))
                             .collect::<Vec<_>>()
                     })
                     .collect::<Vec<_>>()

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -498,10 +498,7 @@ where
                                     output_row.extend(iterator);
                                     // Each produced (time, diff) results in a copy of `output_row` in the output.
                                     // TODO: It would be nice to avoid the `output_row.clone()` for the last output.
-                                    times_diffs.map(move |time_diff| {
-                                        time_diff
-                                            .map_err(|(e, t, d)| (DataflowError::from(e), t, d))
-                                    })
+                                    times_diffs
                                 }
                             });
 

--- a/src/dataflow/src/render/upsert.rs
+++ b/src/dataflow/src/render/upsert.rs
@@ -143,12 +143,7 @@ where
             move |(row, time, diff)| {
                 let arena = repr::RowArena::new();
                 let mut datums_local = datums.borrow_with(&row);
-                let times_diffs = plan.evaluate(&mut datums_local, &arena, time, diff);
-                // Explicitly drop `datums_local` to release the borrow.
-                drop(datums_local);
-                times_diffs.map(move |time_diff| {
-                    time_diff.map_err(|(e, t, d)| (DataflowError::from(e), t, d))
-                })
+                plan.evaluate(&mut datums_local, &arena, time, diff)
             }
         });
 

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -1401,17 +1401,17 @@ pub mod plan {
         /// If `self` contains only non-temporal predicates, the result will either be `(time, diff)`,
         /// or an evaluation error. If `self contains temporal predicates, the results can be times
         /// that are greater than the input `time`, and may contain negated `diff` values.
-        pub fn evaluate<'b, 'a: 'b>(
+        pub fn evaluate<'b, 'a: 'b, E: From<EvalError>>(
             &'a self,
             datums: &'b mut Vec<Datum<'a>>,
             arena: &'a RowArena,
             time: repr::Timestamp,
             diff: Diff,
-        ) -> impl Iterator<Item = Result<(Row, repr::Timestamp, Diff), (EvalError, repr::Timestamp, Diff)>>
+        ) -> impl Iterator<Item = Result<(Row, repr::Timestamp, Diff), (E, repr::Timestamp, Diff)>>
         {
             match self.mfp.evaluate_inner(datums, &arena) {
                 Err(e) => {
-                    return Some(Err((e, time, diff)))
+                    return Some(Err((e.into(), time, diff)))
                         .into_iter()
                         .chain(None.into_iter());
                 }
@@ -1437,7 +1437,7 @@ pub mod plan {
                 if lower_bound.is_some() {
                     match l.eval(datums, &arena) {
                         Err(e) => {
-                            return Some(Err((e, time, diff)))
+                            return Some(Err((e.into(), time, diff)))
                                 .into_iter()
                                 .chain(None.into_iter());
                         }
@@ -1480,7 +1480,7 @@ pub mod plan {
                 if upper_bound != lower_bound {
                     match u.eval(datums, &arena) {
                         Err(e) => {
-                            return Some(Err((e, time, diff)))
+                            return Some(Err((e.into(), time, diff)))
                                 .into_iter()
                                 .chain(None.into_iter());
                         }


### PR DESCRIPTION
### Motivation

This PR refactors existing code to be easier to use.

### Description

Instead of forcing the output to `EvalError`, let the caller provide a type
that implements `From<EvalError>`. This helps avoiding explicit error
conversion in clients.

### Checklist

- [x] This PR has adequate test coverage: No specific tests for this change.
- [x] This PR adds a release note for any user-facing behavior changes: No user-visible change
