### PR TITLE
transform: avoid crash in InlineLet transform with very deep dataflows

### DIFF
--- a/test/sqllogictest/transform/scalability.slt
+++ b/test/sqllogictest/transform/scalability.slt
@@ -1,0 +1,827 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Queries that particulary stress the optimizer.
+# The passing criteria of the tests in this file is:
+#  1. they should not result in crashes
+#  2. they should not lead to planning issues, mostly fixpoint issues
+
+statement ok
+create table events(origin_id int, category_id int, payload jsonb, timestamp_col timestamp);
+
+statement ok
+create table origins(id int, category_id int);
+
+# Regression test for #8387
+# Ignoring the plan on purpose. We just want to check we can handle the query.
+statement ok
+EXPLAIN PLAN FOR
+SELECT
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days,
+    (SELECT max(timestamp_col)
+       FROM events
+      WHERE (payload->>'type' = 'foo1'
+         AND category_id = origins.category_id
+         AND origin_id = origins.id
+         AND mz_logical_timestamp() BETWEEN (1000 * CAST(extract(epoch from timestamp_col) AS numeric)) AND (1000 * CAST(extract(epoch from timestamp_col + interval '90' days) AS numeric))
+      )
+    ) AS quz__foo1_types__max_time__90days
+FROM
+    origins;


### PR DESCRIPTION
### Motivation

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug. [Link to issue.]

  * This PR adds a known-desirable feature. [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

This PR fixes a recognized bug. Fixes #8387

### Description

<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details."

-->

`RelationCSE` transform replaces almost every single node in the graph with a Let operator, which leads to a long list of chained `Let`s with that many subqueries. It relies on `InlineLet` transform to clean up after it. For that cleanup, `InlineLet` unnecessarily uses `take_safely` method, which performs a recursive call for computing the type of the expression being taken.

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [x] This PR has adequate test coverage.
- [ ] This PR adds a release note for any user-facing behavior changes.
