### PR TITLE
testdrive: Print sql up to the term width, instead of only 72 chars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4680,6 +4680,7 @@ dependencies = [
  "sql-parser",
  "structopt",
  "tempfile",
+ "term_size",
  "termcolor",
  "tiberius",
  "tokio",

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -46,6 +46,7 @@ sql-parser = { path = "../sql-parser" }
 structopt = "0.3.23"
 tempfile = "3.2.0"
 termcolor = "1.1.2"
+term_size = "0.3.2"
 tiberius = "0.6.4"
 tokio = "1.11.0"
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", branch = "mz-0.7.2", features = ["with-chrono-0_4", "with-serde_json-1"] }


### PR DESCRIPTION
72 characters is pretty short for most materialized views, this makes many
things easier to see while still keeping the testdrive output clearly readable.