### PR TITLE
Improve `DataflowDescription` interfaces

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -2653,7 +2653,14 @@ impl Coordinator {
                 dataflow.set_as_of(Antichain::from_elem(timestamp));
                 self.dataflow_builder()
                     .import_view_into_dataflow(&view_id, &source, &mut dataflow);
-                dataflow.export_index(index_id, view_id, typ, key);
+                dataflow.export_index(
+                    index_id,
+                    IndexDesc {
+                        on_id: view_id,
+                        keys: key,
+                    },
+                    typ,
+                );
                 self.ship_dataflow(dataflow);
             }
 

--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -185,7 +185,7 @@ impl<'a> DataflowBuilder<'a> {
         let on_id = index.on;
         let keys = index.keys.clone();
         self.import_into_dataflow(&on_id, &mut dataflow);
-        dataflow.export_index(id, on_id, on_type, keys);
+        dataflow.export_index(id, IndexDesc { on_id, keys }, on_type);
         Some(dataflow)
     }
 

--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -72,23 +72,32 @@ impl<'a> DataflowBuilder<'a> {
             match entry.item() {
                 CatalogItem::Table(table) => {
                     dataflow.import_source(
-                        entry.name().to_string(),
                         *id,
-                        SourceConnector::Local {
-                            timeline: table.timeline(),
-                            persisted_name: table.persist.as_ref().map(|p| p.stream_name.clone()),
+                        dataflow_types::SourceDesc {
+                            name: entry.name().to_string(),
+                            connector: SourceConnector::Local {
+                                timeline: table.timeline(),
+                                persisted_name: table
+                                    .persist
+                                    .as_ref()
+                                    .map(|p| p.stream_name.clone()),
+                            },
+                            operators: None,
+                            bare_desc: table.desc.clone(),
                         },
-                        table.desc.clone(),
                         *id,
                     );
                 }
                 CatalogItem::Source(source) => {
                     if source.optimized_expr.0.is_trivial_source() {
                         dataflow.import_source(
-                            entry.name().to_string(),
                             *id,
-                            source.connector.clone(),
-                            source.bare_desc.clone(),
+                            dataflow_types::SourceDesc {
+                                name: entry.name().to_string(),
+                                connector: source.connector.clone(),
+                                operators: None,
+                                bare_desc: source.bare_desc.clone(),
+                            },
                             *id,
                         );
                     } else {
@@ -96,10 +105,13 @@ impl<'a> DataflowBuilder<'a> {
                         // Install it as such (giving the source a global transient ID by which the view/transformation can refer to it)
                         let bare_source_id = GlobalId::Transient(transient_id);
                         dataflow.import_source(
-                            entry.name().to_string(),
                             bare_source_id,
-                            source.connector.clone(),
-                            source.bare_desc.clone(),
+                            dataflow_types::SourceDesc {
+                                name: entry.name().to_string(),
+                                connector: source.connector.clone(),
+                                operators: None,
+                                bare_desc: source.bare_desc.clone(),
+                            },
                             *id,
                         );
                         let mut transformation = source.optimized_expr.clone();
@@ -191,8 +203,17 @@ impl<'a> DataflowBuilder<'a> {
         let mut dataflow = DataflowDesc::new(name);
         dataflow.set_as_of(as_of.frontier.clone());
         self.import_into_dataflow(&from, &mut dataflow);
-        let from_type = self.catalog.get_by_id(&from).desc().unwrap().clone();
-        dataflow.export_sink(id, from, from_type, connector, envelope, as_of);
+        let from_desc = self.catalog.get_by_id(&from).desc().unwrap().clone();
+        dataflow.export_sink(
+            id,
+            dataflow_types::SinkDesc {
+                from,
+                from_desc,
+                connector,
+                envelope,
+                as_of,
+            },
+        );
         dataflow
     }
 }

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -142,20 +142,11 @@ impl DataflowDescription<OptimizedMirRelationExpr> {
     /// Imports a source and makes it available as `id`.
     pub fn import_source(
         &mut self,
-        name: String,
         id: GlobalId,
-        connector: SourceConnector,
-        bare_desc: RelationDesc,
+        description: SourceDesc,
         orig_id: GlobalId,
     ) {
-        let source_description = SourceDesc {
-            name,
-            connector,
-            operators: None,
-            bare_desc,
-        };
-        self.source_imports
-            .insert(id, (source_description, orig_id));
+        self.source_imports.insert(id, (description, orig_id));
     }
 
     /// Binds to `id` the relation expression `expr`.
@@ -191,21 +182,11 @@ impl DataflowDescription<OptimizedMirRelationExpr> {
     pub fn export_sink(
         &mut self,
         id: GlobalId,
-        from_id: GlobalId,
-        from_desc: RelationDesc,
-        connector: SinkConnector,
-        envelope: Option<SinkEnvelope>,
-        as_of: SinkAsOf,
+        description: SinkDesc,
     ) {
         self.sink_exports.push((
             id,
-            SinkDesc {
-                from: from_id,
-                from_desc,
-                connector,
-                envelope,
-                as_of,
-            },
+            description,
         ));
     }
 


### PR DESCRIPTION
This PR modifies the methods of `DataflowDescription` to accept `SourceDesc`, `IndexDesc`, and `SinkDesc` types, rather than a list of the structs' member variables, followed by locally constructing the descriptions. It means to make it clearer to users what the various arguments mean, e.g. the differences between the various `GlobalId` arguments.

It also begins the process of better documenting these methods, though this is harder than I imagined and requires a bit more archaeology to figure out what various things are actually used for.