### PR TITLE
doc: Release note version bump for Docs home page  

### DIFF
--- a/doc/user/content/_index.md
+++ b/doc/user/content/_index.md
@@ -43,7 +43,7 @@ accepts input data from a variety of streaming sources (like Kafka), data stores
 
 ## New &amp; updated
 
-- [Version 0.9.4 Release Notes](release-notes/#v0.9.4)
+- [Version 0.9.5 Release Notes](release-notes/#v0.9.5)
 - [Change Data Capture with Postgres Guide](/guides/cdc-postgres/)
 - [Kafka Sink Topic Reuse (Exactly-Once) Sinks Guide](/guides/reuse-topic-for-kafka-sink)
 

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -44,6 +44,8 @@ Use relative links (/path/to/doc), not absolute links
 (https://materialize.com/docs/path/to/doc).
 
 Wrap your release notes at the 80 character mark.
+
+Put breaking changes before other release notes.
 {{< /comment >}}
 
 {{% version-header v0.9.6 %}}


### PR DESCRIPTION
### Motivation

  * This PR updates documentation

### Description

 * Bump version of release notes on Docs home page
 * Update release note instructions to put breaking changes at the top of new version notes 
 

### Checklist

- [x] This PR has adequate test coverage.
- [ ] This PR adds a release note for any user-facing behavior changes.
