### PR TITLE
Fix inverted arguments in log_b(x) docs

### DIFF
--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -145,7 +145,7 @@
   - signature: 'log10(x: numeric) -> numeric'
     description: Base 10 logarithm of `x`, same as `log`
 
-  - signature: 'log(x: numeric, b: numeric) -> numeric'
+  - signature: 'log(b: numeric, x: numeric) -> numeric'
     description: Base `b` logarithm of `x`
 
   - signature: 'mod(x: N, y: N) -> N'


### PR DESCRIPTION
```
materialize=> select log(2, 64);
                   log                    
------------------------------------------
 5.99999999999999999999999999999999999999
(1 row)
```