### PR TITLE
sql/coord: support INSERT...SELECT

### DIFF
--- a/src/coord/src/error.rs
+++ b/src/coord/src/error.rs
@@ -43,6 +43,8 @@ pub enum CoordError {
     InvalidAlterOnDisabledIndex(String),
     /// The value for the specified parameter does not have the right type.
     InvalidParameterType(&'static (dyn Var + Send + Sync)),
+    /// The selection value for a table mutation operation refers to an invalid object.
+    InvalidTableMutationSelection,
     /// Expression violated a column's constraint
     ConstraintViolation(NotNullViolation),
     /// The named operation cannot be run in a transaction.
@@ -217,6 +219,9 @@ impl fmt::Display for CoordError {
                 p.name().quoted(),
                 p.type_name().quoted()
             ),
+            CoordError::InvalidTableMutationSelection => {
+                f.write_str("invalid selection: operation may only refer to user-defined tables")
+            }
             CoordError::ConstraintViolation(not_null_violation) => {
                 write!(f, "{}", not_null_violation)
             }

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -348,6 +348,7 @@ impl ErrorResponse {
             CoordError::IdExhaustionError => SqlState::INTERNAL_ERROR,
             CoordError::IncompleteTimestamp(_) => SqlState::SQL_STATEMENT_NOT_YET_COMPLETE,
             CoordError::InvalidParameterType(_) => SqlState::INVALID_PARAMETER_VALUE,
+            CoordError::InvalidTableMutationSelection => SqlState::INVALID_TRANSACTION_STATE,
             CoordError::ConstraintViolation(NotNullViolation(_)) => SqlState::NOT_NULL_VIOLATION,
             CoordError::OperationProhibitsTransaction(_) => SqlState::ACTIVE_SQL_TRANSACTION,
             CoordError::OperationRequiresTransaction(_) => SqlState::NO_ACTIVE_SQL_TRANSACTION,

--- a/test/testdrive/insert-select.td
+++ b/test/testdrive/insert-select.td
@@ -1,0 +1,138 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test INSERT INTO...SELECT. This must be a testdrive test to avoid symbiosis
+# in sqllogictest.
+
+> CREATE TABLE t (i INT, f REAL, t TEXT);
+> INSERT INTO t VALUES (1, 2, 'a'), (3, 4, 'b');
+
+> SELECT * FROM t ORDER BY i
+1 2 a
+3 4 b
+
+> CREATE TABLE u (i INT, f REAL, t TEXT);
+> INSERT INTO u VALUES (5, 6, 'c');
+
+> INSERT INTO t SELECT * FROM u;
+
+# Assignment casts are valid
+> CREATE TABLE bigger (i INT8, f FLOAT, t TEXT);
+> INSERT INTO bigger VALUES (7, 8, 'd');
+
+> INSERT INTO t SELECT * FROM bigger;
+
+# Obliquely go through SELECT * FROM ( VALUES ... )
+> INSERT INTO t SELECT * FROM (
+    VALUES (9.1::numeric, 10, 'e')
+  );
+
+> SELECT * FROM t ORDER BY i
+1 2 a
+3 4 b
+5 6 c
+7 8 d
+9 10 e
+
+! INSERT INTO t SELECT * FROM (
+    VALUES ('11', '12', 'f')
+  );
+column "i" is of type integer but expression is of type text
+
+> BEGIN
+
+> INSERT INTO t VALUES (11, 12, 'f')
+
+! INSERT INTO t SELECT * FROM (
+    VALUES (13, 14, 'g')
+  );
+cannot be run inside a transaction block
+
+> COMMIT
+
+> SELECT * FROM t ORDER BY i
+1 2 a
+3 4 b
+5 6 c
+7 8 d
+9 10 e
+
+> BEGIN
+
+! INSERT INTO t SELECT * FROM (
+    VALUES (11, 12, 'f')
+  );
+cannot be run inside a transaction block
+
+> COMMIT
+
+# Multiple connections
+
+> CREATE TABLE c (a int);
+> INSERT INTO c VALUES (1);
+
+> CREATE TABLE s (a int);
+
+$ postgres-connect name=writer url=postgres://materialize:materialize@${testdrive.materialized-addr}
+
+# In-flight txns don't affect updates/deletes, and vice versa
+
+$ postgres-execute connection=writer
+BEGIN;
+INSERT INTO s VALUES (2);
+INSERT INTO c VALUES (3);
+
+> INSERT INTO c SELECT * FROM s;
+
+> SELECT a FROM c
+1
+
+$ postgres-execute connection=writer
+
+INSERT INTO s VALUES (4);
+COMMIT;
+
+> INSERT INTO c SELECT * FROM s;
+
+> SELECT a FROM c
+1
+2
+3
+4
+
+> BEGIN;
+> SELECT a FROM c
+1
+2
+3
+4
+
+$ postgres-execute connection=writer
+INSERT INTO c SELECT * FROM s;
+
+> SELECT a FROM c
+1
+2
+3
+4
+
+> COMMIT;
+
+# Every value from s should be duplicated in c
+> SELECT a FROM s
+2
+4
+
+> SELECT a FROM c;
+1
+2
+2
+3
+4
+4

--- a/test/testdrive/insert-select.td
+++ b/test/testdrive/insert-select.td
@@ -72,6 +72,20 @@ cannot be run inside a transaction block
 
 > COMMIT
 
+> CREATE MATERIALIZED VIEW v (a, b, c) AS SELECT 11, 12::real, 'f';
+
+! INSERT INTO t SELECT * FROM v;
+invalid selection
+
+# Table check descends into select targets
+! INSERT INTO t (i, f, t) SELECT column1, column2, column3
+    FROM ( VALUES (11, 12, 'f') )
+    LEFT JOIN (
+        SELECT a, b, c FROM v
+    ) AS y
+    ON y.a = column1
+invalid selection
+
 # Multiple connections
 
 > CREATE TABLE c (a int);

--- a/test/testdrive/tables.td
+++ b/test/testdrive/tables.td
@@ -142,8 +142,7 @@ a      b
 2      "b"
 <null> "c"
 
-! INSERT INTO t SELECT * FROM t;
-INSERT statements referencing other relations are not supported
+> INSERT INTO t SELECT * FROM t WHERE a IS NULL;
 
 ! INSERT INTO t VALUES (1);
 null value in column "b" violates not-null constraint
@@ -184,6 +183,7 @@ a       b
 ------------
 1       "a"
 2       "b"
+<null>  "c"
 <null>  "c"
 3       "d"
 4       "e"

--- a/test/testdrive/update.td
+++ b/test/testdrive/update.td
@@ -63,7 +63,11 @@ invalid input syntax for type double precision
 > SELECT * FROM t
 4 6 xy
 
-> CREATE VIEW v AS SELECT 1 a;
+# Update subqueries can only reference other tables
+> CREATE MATERIALIZED VIEW v (a) AS SELECT 4;
+
+! UPDATE t SET i = i + 1 WHERE i IN (SELECT a FROM v);
+invalid selection
 
 ! UPDATE v SET a = 1
 cannot mutate view


### PR DESCRIPTION
### Motivation

This PR adds a known-desirable feature. https://github.com/MaterializeInc/materialize/issues/5188#issuecomment-759262331

### Description

`INSERT` previously only supported constant values. However, `INSERT...SELECT` is a natural extension of that and possible now that we have `ReadThenWritePlan`. We now determine if a value is a constant or some other expression and proceed accordingly. This required shifting some of the `INSERT` planning, but nothing too hairy.

### Tips for reviewer

### Checklist

- [x] This PR has adequate test coverage.
- [ ] This PR adds a release note for any user-facing behavior changes.
