### PR TITLE
sql+expr: move int unary funcs to sqlfunc!

### DIFF
--- a/src/expr-test-util/src/lib.rs
+++ b/src/expr-test-util/src/lib.rs
@@ -14,7 +14,7 @@ use proc_macro2::TokenTree;
 use serde_json::Value;
 
 use expr::explain::ViewExplanation;
-use expr::func::{IsNull, Not};
+use expr::func::{IsNull, NegInt32, Not};
 use expr::*;
 use lowertest::*;
 use ore::result::ResultExt;
@@ -43,6 +43,7 @@ gen_reflect_info_func!(
         ColumnType,
         RelationType,
         IsNull,
+        NegInt32,
         Not
     ]
 );

--- a/src/expr/src/relation/join_input_mapper.rs
+++ b/src/expr/src/relation/join_input_mapper.rs
@@ -377,7 +377,7 @@ mod tests {
         );
 
         let key20 = MirScalarExpr::CallUnary {
-            func: UnaryFunc::NegInt32,
+            func: UnaryFunc::NegInt32(crate::func::NegInt32),
             expr: Box::new(MirScalarExpr::Column(1)),
         };
         let key21 = MirScalarExpr::CallBinary {

--- a/src/expr/src/scalar/func/impls.rs
+++ b/src/expr/src/scalar/func/impls.rs
@@ -8,14 +8,16 @@
 // by the Apache License, Version 2.0.
 
 mod datum;
-mod float;
+mod float32;
+mod float64;
 mod int16;
 mod int32;
 mod int64;
 mod not;
 
 pub use datum::*;
-pub use float::*;
+pub use float32::*;
+pub use float64::*;
 pub use int16::*;
 pub use int32::*;
 pub use int64::*;

--- a/src/expr/src/scalar/func/impls/float32.rs
+++ b/src/expr/src/scalar/func/impls/float32.rs
@@ -1,0 +1,112 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::EvalError;
+use repr::strconv;
+
+sqlfunc!(
+    #[sqlname = "-"]
+    fn neg_float32(a: f32) -> f32 {
+        -a
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "abs"]
+    fn abs_float32(a: f32) -> f32 {
+        a.abs()
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "roundf32"]
+    fn round_float32(a: f32) -> f32 {
+        // f32::round violates IEEE 754 by rounding ties away from zero rather than
+        // to nearest even. There appears to be no way to round ties to nearest even
+        // in Rust natively, so bail out to C.
+        extern "C" {
+            fn rintf(f: f32) -> f32;
+        }
+        unsafe { rintf(a) }
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "ceilf32"]
+    fn ceil_float32(a: f32) -> f32 {
+        a.ceil()
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "floorf32"]
+    fn floor_float32(a: f32) -> f32 {
+        a.floor()
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "f32toi16"]
+    fn cast_float32_to_int16(a: f32) -> Result<i16, EvalError> {
+        let f = round_float32(Some(a))?.unwrap();
+        if (f >= (i16::MIN as f32)) && (f < -(i16::MIN as f32)) {
+            Ok(f as i16)
+        } else {
+            Err(EvalError::Int16OutOfRange)
+        }
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "f32toi32"]
+    fn cast_float32_to_int32(a: f32) -> Result<i32, EvalError> {
+        let f = round_float32(Some(a))?.unwrap();
+        // This condition is delicate because i32::MIN can be represented exactly by
+        // an f32 but not i32::MAX. We follow PostgreSQL's approach here.
+        //
+        // See: https://github.com/postgres/postgres/blob/ca3b37487/src/include/c.h#L1074-L1096
+        if (f >= (i32::MIN as f32)) && (f < -(i32::MIN as f32)) {
+            Ok(f as i32)
+        } else {
+            Err(EvalError::Int32OutOfRange)
+        }
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "f32toi64"]
+    fn cast_float32_to_int64(a: f32) -> Result<i64, EvalError> {
+        let f = round_float32(Some(a))?.unwrap();
+        // This condition is delicate because i64::MIN can be represented exactly by
+        // an f32 but not i64::MAX. We follow PostgreSQL's approach here.
+        //
+        // See: https://github.com/postgres/postgres/blob/ca3b37487/src/include/c.h#L1074-L1096
+        if (f >= (i64::MIN as f32)) && (f < -(i64::MIN as f32)) {
+            Ok(f as i64)
+        } else {
+            Err(EvalError::Int64OutOfRange)
+        }
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "f32tof64"]
+    fn cast_float32_to_float64(a: f32) -> f64 {
+        a.into()
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "f32tostr"]
+    fn cast_float32_to_string(a: f32) -> String {
+        let mut s = String::new();
+        strconv::format_float32(&mut s, a);
+        s
+    }
+);

--- a/src/expr/src/scalar/func/impls/float64.rs
+++ b/src/expr/src/scalar/func/impls/float64.rs
@@ -1,0 +1,254 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::EvalError;
+use chrono::{DateTime, NaiveDateTime, Utc};
+use repr::strconv;
+
+sqlfunc!(
+    #[sqlname = "-"]
+    fn neg_float64(a: f64) -> f64 {
+        -a
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "abs"]
+    fn abs_float64(a: f64) -> f64 {
+        a.abs()
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "roundf64"]
+    fn round_float64(a: f64) -> f64 {
+        // f64::round violates IEEE 754 by rounding ties away from zero rather than
+        // to nearest even. There appears to be no way to round ties to nearest even
+        // in Rust natively, so bail out to C.
+        extern "C" {
+            fn rint(f: f64) -> f64;
+        }
+        unsafe { rint(a) }
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "ceilf64"]
+    fn ceil_float64(a: f64) -> f64 {
+        a.ceil()
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "floorf64"]
+    fn floor_float64(a: f64) -> f64 {
+        a.floor()
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "f64toi16"]
+    fn cast_float64_to_int16(a: f64) -> Result<i16, EvalError> {
+        let f = round_float64(Some(a))?.unwrap();
+        if (f >= (i16::MIN as f64)) && (f < -(i16::MIN as f64)) {
+            Ok(f as i16)
+        } else {
+            Err(EvalError::Int16OutOfRange)
+        }
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "f64toi32"]
+    fn cast_float64_to_int32(a: f64) -> Result<i32, EvalError> {
+        let f = round_float64(Some(a))?.unwrap();
+        // This condition is delicate because i32::MIN can be represented exactly by
+        // an f64 but not i32::MAX. We follow PostgreSQL's approach here.
+        //
+        // See: https://github.com/postgres/postgres/blob/ca3b37487/src/include/c.h#L1074-L1096
+        if (f >= (i32::MIN as f64)) && (f < -(i32::MIN as f64)) {
+            Ok(f as i32)
+        } else {
+            Err(EvalError::Int32OutOfRange)
+        }
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "f64toi64"]
+    fn cast_float64_to_int64(a: f64) -> Result<i64, EvalError> {
+        let f = round_float64(Some(a))?.unwrap();
+        // This condition is delicate because i64::MIN can be represented exactly by
+        // an f64 but not i64::MAX. We follow PostgreSQL's approach here.
+        //
+        // See: https://github.com/postgres/postgres/blob/ca3b37487/src/include/c.h#L1074-L1096
+        if (f >= (i64::MIN as f64)) && (f < -(i64::MIN as f64)) {
+            Ok(f as i64)
+        } else {
+            Err(EvalError::Int64OutOfRange)
+        }
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "f64tof32"]
+    fn cast_float64_to_float32(a: f64) -> Result<f32, EvalError> {
+        let result = a as f32;
+        if result.is_infinite() && !a.is_infinite() {
+            Err(EvalError::FloatOverflow)
+        } else if result == 0.0 && a != 0.0 {
+            Err(EvalError::FloatUnderflow)
+        } else {
+            Ok(result)
+        }
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "f64tostr"]
+    fn cast_float64_to_string(a: f64) -> String {
+        let mut s = String::new();
+        strconv::format_float64(&mut s, a);
+        s
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "sqrtf64"]
+    fn sqrt_float64(a: f64) -> Result<f64, EvalError> {
+        if a < 0.0 {
+            return Err(EvalError::NegSqrt);
+        }
+        Ok(a.sqrt())
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "cbrtf64"]
+    fn cbrt_float64(a: f64) -> f64 {
+        a.cbrt()
+    }
+);
+
+sqlfunc!(
+    fn cos(a: f64) -> Result<f64, EvalError> {
+        if a.is_infinite() {
+            return Err(EvalError::InfinityOutOfDomain("cos".to_owned()));
+        }
+        Ok(a.cos())
+    }
+);
+
+sqlfunc!(
+    fn cosh(a: f64) -> f64 {
+        a.cosh()
+    }
+);
+
+sqlfunc!(
+    fn sin(a: f64) -> Result<f64, EvalError> {
+        if a.is_infinite() {
+            return Err(EvalError::InfinityOutOfDomain("sin".to_owned()));
+        }
+        Ok(a.sin())
+    }
+);
+
+sqlfunc!(
+    fn sinh(a: f64) -> f64 {
+        a.sinh()
+    }
+);
+
+sqlfunc!(
+    fn tan(a: f64) -> Result<f64, EvalError> {
+        if a.is_infinite() {
+            return Err(EvalError::InfinityOutOfDomain("tan".to_owned()));
+        }
+        Ok(a.tan())
+    }
+);
+
+sqlfunc!(
+    fn tanh(a: f64) -> f64 {
+        a.tanh()
+    }
+);
+
+sqlfunc!(
+    fn cot(a: f64) -> Result<f64, EvalError> {
+        if a.is_infinite() {
+            return Err(EvalError::InfinityOutOfDomain("cot".to_owned()));
+        }
+        Ok(1.0 / a.tan())
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "log10f64"]
+    fn log10(a: f64) -> Result<f64, EvalError> {
+        if a.is_sign_negative() {
+            return Err(EvalError::NegativeOutOfDomain("log10".to_owned()));
+        }
+        if a == 0.0 {
+            return Err(EvalError::ZeroOutOfDomain("log10".to_owned()));
+        }
+        Ok(a.log10())
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "lnf64"]
+    fn ln(a: f64) -> Result<f64, EvalError> {
+        if a.is_sign_negative() {
+            return Err(EvalError::NegativeOutOfDomain("ln".to_owned()));
+        }
+        if a == 0.0 {
+            return Err(EvalError::ZeroOutOfDomain("ln".to_owned()));
+        }
+        Ok(a.ln())
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "expf64"]
+    fn exp(a: f64) -> f64 {
+        a.exp()
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "mz_sleep"]
+    fn sleep(a: f64) -> Option<DateTime<Utc>> {
+        let duration = std::time::Duration::from_secs_f64(a);
+        std::thread::sleep(duration);
+        None
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "tots"]
+    fn to_timestamp(f: f64) -> Option<DateTime<Utc>> {
+        if !f.is_finite() {
+            None
+        } else {
+            let secs = f.trunc() as i64;
+            // NOTE(benesch): PostgreSQL has microsecond precision in its timestamps,
+            // while chrono has nanosecond precision. While we normally accept
+            // nanosecond precision, here we round to the nearest microsecond because
+            // f64s lose quite a bit of accuracy in the nanosecond digits when dealing
+            // with common Unix timestamp values (> 1 billion).
+            let nanosecs = ((f.fract() * 1_000_000.0).round() as u32) * 1_000;
+            match NaiveDateTime::from_timestamp_opt(secs as i64, nanosecs as u32) {
+                Some(ts) => Some(DateTime::<Utc>::from_utc(ts, Utc)),
+                None => None,
+            }
+        }
+    }
+);

--- a/src/expr/src/scalar/func/impls/int16.rs
+++ b/src/expr/src/scalar/func/impls/int16.rs
@@ -7,16 +7,23 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-mod datum;
-mod float;
-mod int16;
-mod int32;
-mod int64;
-mod not;
+sqlfunc!(
+    #[sqlname = "-"]
+    fn neg_int16(a: i16) -> i16 {
+        -a
+    }
+);
 
-pub use datum::*;
-pub use float::*;
-pub use int16::*;
-pub use int32::*;
-pub use int64::*;
-pub use not::Not;
+sqlfunc!(
+    #[sqlname = "~"]
+    fn bit_not_int16(a: i16) -> i16 {
+        !a
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "abs"]
+    fn abs_int16(a: i16) -> i16 {
+        a.abs()
+    }
+);

--- a/src/expr/src/scalar/func/impls/int32.rs
+++ b/src/expr/src/scalar/func/impls/int32.rs
@@ -7,16 +7,23 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-mod datum;
-mod float;
-mod int16;
-mod int32;
-mod int64;
-mod not;
+sqlfunc!(
+    #[sqlname = "-"]
+    fn neg_int32(a: i32) -> i32 {
+        -a
+    }
+);
 
-pub use datum::*;
-pub use float::*;
-pub use int16::*;
-pub use int32::*;
-pub use int64::*;
-pub use not::Not;
+sqlfunc!(
+    #[sqlname = "~"]
+    fn bit_not_int32(a: i32) -> i32 {
+        !a
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "abs"]
+    fn abs_int32(a: i32) -> i32 {
+        a.abs()
+    }
+);

--- a/src/expr/src/scalar/func/impls/int64.rs
+++ b/src/expr/src/scalar/func/impls/int64.rs
@@ -7,16 +7,23 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-mod datum;
-mod float;
-mod int16;
-mod int32;
-mod int64;
-mod not;
+sqlfunc!(
+    #[sqlname = "-"]
+    fn neg_int64(a: i64) -> i64 {
+        -a
+    }
+);
 
-pub use datum::*;
-pub use float::*;
-pub use int16::*;
-pub use int32::*;
-pub use int64::*;
-pub use not::Not;
+sqlfunc!(
+    #[sqlname = "~"]
+    fn bit_not_int64(a: i64) -> i64 {
+        !a
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "abs"]
+    fn abs_int64(a: i64) -> i64 {
+        a.abs()
+    }
+);

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -170,6 +170,69 @@ impl TryFrom<Datum<'_>> for Option<f64> {
     }
 }
 
+impl TryFrom<Datum<'_>> for i16 {
+    type Error = ();
+    fn try_from(from: Datum<'_>) -> Result<Self, Self::Error> {
+        match from {
+            Datum::Int16(i) => Ok(i),
+            _ => Err(()),
+        }
+    }
+}
+
+impl TryFrom<Datum<'_>> for Option<i16> {
+    type Error = ();
+    fn try_from(from: Datum<'_>) -> Result<Self, Self::Error> {
+        match from {
+            Datum::Null => Ok(None),
+            Datum::Int16(i) => Ok(Some(i)),
+            _ => Err(()),
+        }
+    }
+}
+
+impl TryFrom<Datum<'_>> for i32 {
+    type Error = ();
+    fn try_from(from: Datum<'_>) -> Result<Self, Self::Error> {
+        match from {
+            Datum::Int32(i) => Ok(i),
+            _ => Err(()),
+        }
+    }
+}
+
+impl TryFrom<Datum<'_>> for Option<i32> {
+    type Error = ();
+    fn try_from(from: Datum<'_>) -> Result<Self, Self::Error> {
+        match from {
+            Datum::Null => Ok(None),
+            Datum::Int32(i) => Ok(Some(i)),
+            _ => Err(()),
+        }
+    }
+}
+
+impl TryFrom<Datum<'_>> for i64 {
+    type Error = ();
+    fn try_from(from: Datum<'_>) -> Result<Self, Self::Error> {
+        match from {
+            Datum::Int64(i) => Ok(i),
+            _ => Err(()),
+        }
+    }
+}
+
+impl TryFrom<Datum<'_>> for Option<i64> {
+    type Error = ();
+    fn try_from(from: Datum<'_>) -> Result<Self, Self::Error> {
+        match from {
+            Datum::Null => Ok(None),
+            Datum::Int64(i) => Ok(Some(i)),
+            _ => Err(()),
+        }
+    }
+}
+
 impl<'a> Datum<'a> {
     /// Reports whether this datum is null (i.e., is [`Datum::Null`]).
     pub fn is_null(&self) -> bool {

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1848,7 +1848,7 @@ lazy_static! {
                 params!(Bytes, Bytes) => Operation::binary(|_ecx, _l, _r| bail_unsupported!("string_agg")), 3545;
             },
             "sum" => Aggregate {
-                params!(Int16) => AggregateFunc::SumInt32, 2109;
+                params!(Int16) => AggregateFunc::SumInt16, 2109;
                 params!(Int32) => AggregateFunc::SumInt32, 2108;
                 params!(Int64) => AggregateFunc::SumInt64, 2107;
                 params!(Float32) => AggregateFunc::SumFloat32, 2110;

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1264,9 +1264,9 @@ lazy_static! {
 
             // Scalars.
             "abs" => Scalar {
-                params!(Int16) => UnaryFunc::AbsInt16, 1398;
-                params!(Int32) => UnaryFunc::AbsInt32, 1397;
-                params!(Int64) => UnaryFunc::AbsInt64, 1396;
+                params!(Int16) => UnaryFunc::AbsInt16(func::AbsInt16), 1398;
+                params!(Int32) => UnaryFunc::AbsInt32(func::AbsInt32), 1397;
+                params!(Int64) => UnaryFunc::AbsInt64(func::AbsInt64), 1396;
                 params!(Numeric) => UnaryFunc::AbsNumeric, 1705;
                 params!(Float32) => UnaryFunc::AbsFloat32(func::AbsFloat32), 1394;
                 params!(Float64) => UnaryFunc::AbsFloat64(func::AbsFloat64), 1395;
@@ -2291,9 +2291,9 @@ lazy_static! {
                 params!(Numeric, Numeric) => AddNumeric, 1758;
             },
             "-" => Scalar {
-                params!(Int16) => UnaryFunc::NegInt32, 559;
-                params!(Int32) => UnaryFunc::NegInt32, 558;
-                params!(Int64) => UnaryFunc::NegInt64, 484;
+                params!(Int16) => UnaryFunc::NegInt16(func::NegInt16), 559;
+                params!(Int32) => UnaryFunc::NegInt32(func::NegInt32), 558;
+                params!(Int64) => UnaryFunc::NegInt64(func::NegInt64), 484;
                 params!(Float32) => UnaryFunc::NegFloat32(func::NegFloat32), 584;
                 params!(Float64) => UnaryFunc::NegFloat64(func::NegFloat64), 585;
                 params!(Numeric) => UnaryFunc::NegNumeric, 17510;
@@ -2412,9 +2412,9 @@ lazy_static! {
 
             // REGEX
             "~" => Scalar {
-                params!(Int16) => UnaryFunc::BitNotInt16, 1877;
-                params!(Int32) => UnaryFunc::BitNotInt32, 1883;
-                params!(Int64) => UnaryFunc::BitNotInt64, 1889;
+                params!(Int16) => UnaryFunc::BitNotInt16(func::BitNotInt16), 1877;
+                params!(Int32) => UnaryFunc::BitNotInt32(func::BitNotInt32), 1883;
+                params!(Int64) => UnaryFunc::BitNotInt64(func::BitNotInt64), 1889;
                 params!(String, String) => IsRegexpMatch { case_insensitive: false }, 641;
                 params!(Char, String) => Operation::binary(|ecx, lhs, rhs| {
                     let length = ecx.scalar_type(&lhs).unwrap_char_varchar_length();


### PR DESCRIPTION
### Motivation

This PR refactors existing code

### Description

Moving over `int`-using unary funcs.

I prefer this slightly more atomized structure for the different types because it makes cloning them for new types much easier, i.e. to generate the `int32` and `int64` files I just copied the `int16` file and replaced the number of bytes in the type. I realize this utility decreases as we saturate the primitive types we'll support, but given that we plan to do `uint`, I thought this might make that work simpler.

### Tips for reviewer

### Checklist

- [x] This PR has adequate test coverage.
- [x] This PR adds a release note for any user-facing behavior changes.
