### PR TITLE
Temporal filter clarifications

### DIFF
--- a/doc/user/content/guides/temporal-filters.md
+++ b/doc/user/content/guides/temporal-filters.md
@@ -28,7 +28,7 @@ Records that arrive late (that is, with a timestamp that is too old to pass the 
 
 ## Interactions with Materialize compaction
 
-Materialize periodically [compacts](/ops/deploymennt/#compaction) data to prevent memory usage from growing without bounds. This compaction does not affect temporal filters.
+Materialize periodically [compacts](/ops/deployment/#compaction) data to prevent memory usage from growing without bounds. This compaction does not affect temporal filters.
 
 ## Example
 

--- a/doc/user/content/guides/temporal-filters.md
+++ b/doc/user/content/guides/temporal-filters.md
@@ -11,7 +11,7 @@ You can use temporal filters to perform time-windowed computations over temporal
 
 Windows can be sliding or tumbling. Sliding windows are fixed-size time intervals that you drag over temporal data, like "Show me updates from the last ten seconds". Tumbling or hopping windows are sliding windows that slide one unit at a time, like "Show me updates from the last day for each one-hour interval".
 
-Temporal filters are defined using the function [`mz_logical_timestamp`](/sql/functions/now_and_mz_logical_timestamp). For a more detailed overview, see our blog post on [temporal filters](https://materialize.com/temporal-filters/).
+Temporal filters are defined using the function [`mz_logical_timestamp`](/sql/functions/now_and_mz_logical_timestamp), which represents the logical time at which the query executes, based on the system time defined by the system on which `materialized` is installed. For a more detailed overview, see our blog post on [temporal filters](https://materialize.com/temporal-filters/).
 
 ## Restrictions
 
@@ -21,6 +21,14 @@ You can only use `mz_logical_timestamp()` to establish a temporal filter in the 
 * As part of a conjunction phrase (`AND`), where `mz_logical_timestamp()` must be directly compared to [`numeric`](/sql/types/numeric) expressions not containing `mz_logical_timestamp()`.
 
 At the moment, you can't use the `!=` operator with `mz_logical_timestamp` (we're working on it).
+
+## Late-arriving data
+
+Records that arrive late (that is, with a timestamp that is too old to pass the filter) are not shown in the current window. Think of a temporal filter as being like a query to a database for records updated between certain timestamps: if the record is added to the database with a time before the earlier timestamp boundary, it will not appear in the query results.
+
+## Interactions with Materialize compaction
+
+Materialize periodically [compacts](/ops/deploymennt/#compaction) data to prevent memory usage from growing without bounds. This compaction does not affect temporal filters.
 
 ## Example
 
@@ -77,3 +85,7 @@ content |   insert_ts   |   delete_ts   | mz_logical_timestamp
 ```
 
 If you run the query again after 1.67 minutes, you'll see only two results, because the first result has aged out of the view.
+
+## Related pages
+
+* [`now` and `mz_logical_timestamp`](/sql/functions/now_and_mz_logical_timestamp)

--- a/doc/user/content/sql/functions/now_and_mz_logical_timestamp.md
+++ b/doc/user/content/sql/functions/now_and_mz_logical_timestamp.md
@@ -104,3 +104,7 @@ SELECT * FROM valid
  goodbye | 1621279636402 | 1621279836402
  welcome | 1621279636400 | 1621279786400
 ```
+
+## Related pages
+
+- [Temporal filters](/guides/temporal-filters)

--- a/doc/user/content/sql/select.md
+++ b/doc/user/content/sql/select.md
@@ -18,6 +18,9 @@ menu:
 To better understand the distinction between these uses, you should check out
 our [architecture overview](../../overview/architecture).
 
+You may also find it useful to review [`TAIL`](../tail), a more general form of a `SELECT`
+statement that produces a live stream of updates to a view.
+
 ## Conceptual framework
 
 The `SELECT` statement is the root of a SQL query, and is used both to
@@ -62,7 +65,7 @@ _join&lowbar;expr_ | A join expression; for more details, see our [`JOIN` docume
 **UNION** | Records present in `select_stmt` or `another_select_stmt`.<br/><br/>**DISTINCT** returns only unique rows from these results _(implied default)_.<br/><br/>With **ALL** specified, each record occurs a number of times equal to the sum of the times it occurs in each input statement.
 **INTERSECT** | Records present in both `select_stmt` and `another_select_stmt`.<br/><br/>**DISTINCT** returns only unique rows from these results _(implied default)_.<br/><br/>With **ALL** specified, each record occurs a number of times equal to the lesser of the times it occurs in each input statement.
 **EXCEPT** | Records present in `select_stmt` but not in `another_select_stmt`.<br/><br/>**DISTINCT** returns only unique rows from these results _(implied default)_.<br/><br/>With **ALL** specified, each record occurs a number of times equal to the times it occurs in `select_stmt` less the times it occurs in `another_select_stmt`, or not at all if the former is greater than latter.
-**AS OF** | If provided, `SELECT` will report the results at the supplied timestamp, meaning it reflects exactly those input updates at or before this timestamp.
+**AS OF** | If provided, `SELECT` will report the results at the supplied timestamp, meaning it reflects exactly those input updates at or before this timestamp. Note that `AS OF` [works differently](../tail#as-of) for `TAIL`, instead specifying the time at which a `TAIL` operation begins.
 
 ## Details
 
@@ -246,3 +249,4 @@ knowledge.
 - [`CREATE VIEW`](../create-view)
 - [`CREATE MATERIALIZED VIEW`](../create-materialized-view)
 - [`SHOW FULL VIEWS`](../show-views)
+- [`TAIL`](../tail)

--- a/doc/user/content/sql/timelines.md
+++ b/doc/user/content/sql/timelines.md
@@ -1,6 +1,7 @@
 ---
 title: "Timelines"
 description: "Timelines describe sources' meaning of time."
+weight: 20
 menu:
   main:
     parent: sql


### PR DESCRIPTION
### Motivation


  * This PR adds a known-desirable feature. [#8058] 
  
### Description

* Added reassurances about late-arriving data and Mz compaction not affecting temporal filters.
* Added cross references between TAIL and SELECT.
* Added brief definition of mz_logical_timestamp to temporal filters guide.

### Tips for reviewer

Open question: is there any way for users to estimate how much memory will be used by temporal filter, since that seems to have been the root concern of the initial customer question (https://materializecommunity.slack.com/archives/C015KDVS7EV/p1629896413161100)?

### Checklist

- [x] This PR has adequate test coverage.
- [ ] This PR adds a release note for any user-facing behavior changes.
