### PR TITLE
test: deflake test/testdrive/prometheus.td

### DIFF
--- a/test/testdrive/prometheus.td
+++ b/test/testdrive/prometheus.td
@@ -12,6 +12,27 @@
 
 # Some prometheus metrics should always exist
 
+# Some of the metrics queried in this test measure the amount of pending peeks. However, since
+# we only scrape metrics once per second, we occaisonally need to wait more than a second
+# between issuing peeks in order to make sure that the metric will reflect the accurate value.
+#
+# To be more explicit, the following can happen:
+# 1. We issue a SELECT at time T.
+# 2. We record that there is one pending PEEK in metrics.
+# 3. The SELECT from step 1. completes.
+# 4. We issue a SELECT to find out "how many pending PEEKs are there according to metrics?"
+# 5. The SELECT from step 4. completes, returning "1 pending PEEK" where we incorrectly
+#    expected there would be 0 pending PEEKs.
+#
+# In order to not run into this race, we need to make sure that metrics get recorded between
+# steps 3 and 4, which we can do through several mechanisms such as scraping metrics more
+# frequently. However, that makes running the test slower because for now, mz_metrics is persisted
+# to disk. Instead, by raising the timeout, we implicitly guarantee that as testdrive exponentially
+# backs off from issuing SELECTs, it will eventually wait more than 1 second between consecutive
+# SELECT statements, which is enough to guarantee that metrics will be scraped when they need
+# to in CI (where we scrape metrics every second).
+$ set-sql-timeout duration=60s
+
 > SELECT value > 0 AND labels ? 'os' FROM mz_metrics WHERE metric = 'mz_server_metadata_seconds'
   ORDER BY time DESC LIMIT 1
 true


### PR DESCRIPTION
Previously, the prometheus metrics testdrive test implicitly relied on metrics
getting updated between successive SQL statements. However, with the metrics-scraping-interval
set to 1 second, this was not always guaranteed with the default testdrive timeout
(which uses exponential backoff).

This commit bumps the testdrive SQL query timeout to ensure that at least one
second will always elapse between successive SELECTs in this test.

### Motivation

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug. [Link to issue.]

  * This PR adds a known-desirable feature. [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

### Description

<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details."

-->

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [ ] This PR has adequate test coverage.
- [ ] This PR adds a release note for any user-facing behavior changes.
