### PR TITLE
doc: fix typo on docs home page, shift Timelines page in SQL navigation.

### DIFF
--- a/doc/user/content/_index.md
+++ b/doc/user/content/_index.md
@@ -45,7 +45,7 @@ accepts input data from a variety of streaming sources (like Kafka), data stores
 
 - [Version 0.9.5 Release Notes](release-notes/#v0.9.5)
 - [Change Data Capture with Postgres Guide](/guides/cdc-postgres/)
-- [Kafka Sink Topic Reuse (Exactly-Once) Sinks Guide](/guides/reuse-topic-for-kafka-sink)
+- [Kafka Sink Topic Reuse (Exactly-Once Sinks) Guide](/guides/reuse-topic-for-kafka-sink)
 
 ## Learn more
 

--- a/doc/user/content/sql/timelines.md
+++ b/doc/user/content/sql/timelines.md
@@ -1,6 +1,7 @@
 ---
 title: "Timelines"
 description: "Timelines describe sources' meaning of time."
+weight: 20
 menu:
   main:
     parent: sql


### PR DESCRIPTION
Which of the following best describes the motivation behind this PR?


  * This PR fixes a previously unreported bug.

### Description

- Fix typo on docs home page
- Shift "Timelines" from bottom of SQL navigation
 

### Checklist

- [x] This PR has adequate test coverage.
- [ ] This PR adds a release note for any user-facing behavior changes.
