### PR TITLE
pgwire: don't chain row batches

### DIFF
--- a/src/coord/src/command.rs
+++ b/src/coord/src/command.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 
 use derivative::Derivative;
 use serde::Serialize;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::oneshot;
 
 use dataflow_types::PeekResponse;
 use expr::GlobalId;
@@ -25,7 +25,7 @@ use sql::plan::ExecuteTimeout;
 use tokio::sync::watch;
 
 use crate::error::CoordError;
-use crate::session::{EndTransactionAction, Session};
+use crate::session::{EndTransactionAction, RowBatchStream, Session};
 
 #[derive(Debug)]
 pub enum Command {
@@ -257,7 +257,7 @@ pub enum ExecuteResponse {
     /// Updates to the requested source or view will be streamed to the
     /// contained receiver.
     Tailing {
-        rx: mpsc::UnboundedReceiver<Vec<Row>>,
+        rx: RowBatchStream,
     },
     /// The specified number of rows were updated in the requested table.
     Updated(usize),

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -17,18 +17,18 @@ use std::mem;
 use byteorder::{ByteOrder, NetworkEndian};
 use expr::GlobalId;
 use futures::future::{BoxFuture, FutureExt};
-use futures::stream::{self, StreamExt};
 use itertools::izip;
 use log::debug;
 use message::decode_copy_text_format;
 use openssl::nid::Nid;
 use postgres::error::SqlState;
 use tokio::io::{self, AsyncRead, AsyncWrite, Interest};
+use tokio::sync::mpsc::unbounded_channel;
 use tokio::time::{self, Duration, Instant};
-use tokio_stream::wrappers::UnboundedReceiverStream;
 
 use coord::session::{
-    EndTransactionAction, Portal, PortalState, RowBatchStream, Session, TransactionStatus,
+    EndTransactionAction, InProgressRows, Portal, PortalState, RowBatchStream, Session,
+    TransactionStatus,
 };
 use coord::ExecuteResponse;
 use dataflow_types::PeekResponse;
@@ -1047,7 +1047,7 @@ where
                         self.send_rows(
                             row_desc,
                             portal_name,
-                            Box::new(stream::iter(vec![rows])),
+                            InProgressRows::single_batch(rows),
                             max_rows,
                             get_response,
                             fetch_portal_name,
@@ -1118,7 +1118,7 @@ where
                 self.send_rows(
                     row_desc,
                     portal_name,
-                    Box::new(UnboundedReceiverStream::new(rx)),
+                    InProgressRows::new(rx),
                     max_rows,
                     get_response,
                     fetch_portal_name,
@@ -1130,7 +1130,7 @@ where
                 let row_desc =
                     row_desc.expect("missing row description for ExecuteResponse::CopyTo");
                 let rows: RowBatchStream = match *resp {
-                    ExecuteResponse::Tailing { rx } => Box::new(UnboundedReceiverStream::new(rx)),
+                    ExecuteResponse::Tailing { rx } => rx,
                     ExecuteResponse::SendingRows(rx) => match rx.await {
                         // TODO(mjibson): This logic is duplicated from SendingRows. Dedup?
                         PeekResponse::Canceled => {
@@ -1146,7 +1146,11 @@ where
                                 .error(ErrorResponse::error(SqlState::INTERNAL_ERROR, text))
                                 .await;
                         }
-                        PeekResponse::Rows(rows) => Box::new(stream::iter(vec![rows])),
+                        PeekResponse::Rows(rows) => {
+                            let (tx, rx) = unbounded_channel();
+                            tx.send(rows).expect("send must succeed");
+                            rx
+                        }
                     },
                     _ => {
                         return self
@@ -1179,7 +1183,7 @@ where
         &mut self,
         row_desc: RelationDesc,
         portal_name: String,
-        mut rows: RowBatchStream,
+        mut rows: InProgressRows,
         max_rows: ExecuteCount,
         get_response: GetResponse,
         fetch_portal_name: Option<String>,
@@ -1229,10 +1233,16 @@ where
         loop {
             // Fetch next batch of rows, waiting for a possible requested timeout or
             // cancellation.
-            let batch = tokio::select! {
-                _ = time::sleep_until(deadline.unwrap_or_else(time::Instant::now)), if deadline.is_some() => FetchResult::Rows(None),
-                _ = self.coord_client.canceled() => FetchResult::Cancelled,
-                batch = rows.next() => FetchResult::Rows(batch),
+            let batch = if self.coord_client.canceled().now_or_never().is_some() {
+                FetchResult::Cancelled
+            } else if rows.current.is_some() {
+                FetchResult::Rows(rows.current.take())
+            } else {
+                tokio::select! {
+                    _ = time::sleep_until(deadline.unwrap_or_else(time::Instant::now)), if deadline.is_some() => FetchResult::Rows(None),
+                    _ = self.coord_client.canceled() => FetchResult::Cancelled,
+                    batch = rows.remaining.recv() => FetchResult::Rows(batch),
+                }
             };
 
             match batch {
@@ -1293,7 +1303,7 @@ where
                     // (if any) back and stop sending.
                     if want_rows == 0 {
                         if !batch_rows.is_empty() {
-                            rows = Box::new(stream::iter(vec![batch_rows]).chain(rows));
+                            rows.current = Some(batch_rows);
                         }
                         break;
                     }
@@ -1416,7 +1426,7 @@ where
                         ))
                     .await;
                 },
-                batch = stream.next() => match batch {
+                batch = stream.recv() => match batch {
                     None => break,
                     Some(rows) => {
                         count += rows.len();


### PR DESCRIPTION
### Motivation

  * This PR fixes a recognized bug. #8270

### Description

The `.chain()` call in `send_rows()` could cause a stack overflow if there
were a high number of batches being processed through `TAIL`. This was
occurring because each .chain would return a new Chain object, nesting
some other Chain. When there were enough, calling .next on them would
fill up the stack while they tried to get to the actual row batch.

This was part of the design because we needed some way to requeue the
current partial batch. Fix the problem by creating a specific location
for an existing batch to go. We can check it first, and only fetch the
next batch if it doesn't exist. When we have a remaining partial batch
it can be inserted back, removing the call to chain completely.

Previously RowBatchStream was a Box dyn because the object type could
either be an UnboundedReceiver or a Chain. Since it is now never a chain,
we can also take this opportunity to de-box-and-dyn the type and make
it concrete.

### Checklist

- [ ] This PR has adequate test coverage.
- [x] This PR adds a release note for any user-facing behavior changes.
