### PR TITLE
ci/test: enable persist external storage tests

### DIFF
--- a/ci/test/cargo-test/image/Dockerfile
+++ b/ci/test/cargo-test/image/Dockerfile
@@ -9,7 +9,9 @@
 
 MZFROM ubuntu-base
 
-RUN apt-get update && apt-get -qy install wait-for-it
+RUN apt-get update && apt-get -qy install \
+    ca-certificates \
+    wait-for-it
 
 COPY tests /tests/
 COPY run-tests /usr/local/bin

--- a/ci/test/cargo-test/mzcompose.yml
+++ b/ci/test/cargo-test/mzcompose.yml
@@ -28,6 +28,11 @@ services:
     - KAFKA_ADDRS=kafka:9092
     - SCHEMA_REGISTRY_URL=http://schema-registry:8081
     - MZ_SOFT_ASSERTIONS=1
+    - MZ_PERSIST_EXTERNAL_STORAGE_TEST_S3_BUCKET=mtlz-test-persist-1d-lifecycle-delete
+    - AWS_DEFAULT_REGION
+    - AWS_ACCESS_KEY_ID
+    - AWS_SECRET_ACCESS_KEY
+    - AWS_SESSION_TOKEN
     propagate_uid_gid: true
     depends_on: [kafka, zookeeper, schema-registry]
   zookeeper:

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -65,6 +65,7 @@ steps:
     depends_on: build
     timeout_in_minutes: 30
     plugins:
+      - ./ci/plugins/scratch-aws-access: ~
       - ./ci/plugins/mzcompose:
           composition: cargo-test
           run: app


### PR DESCRIPTION
Set the MZ_PERSIST_EXTERNAL_STORAGE_TEST_S3_BUCKET env to request that
persist run its external storage tests in CI. Also plumb through the
necessary credentials to make this work.

### Motivation

  * This PR adds a feature that has not yet been specified.
