### PR TITLE
doc: Press 's' to search

### DIFF
--- a/doc/user/assets/sass/_layout.scss
+++ b/doc/user/assets/sass/_layout.scss
@@ -50,6 +50,23 @@ body {
   left: 2.75rem;
 }
 
+.search_shortcut {
+    background: linear-gradient(-225deg,#d5dbe4,#f8f8f8);
+    border-radius: 3px;
+    box-shadow: inset 0 -2px 0 0 #cdcde6,inset 0 0 1px 1px #fff,0 1px 2px 1px rgba(30,35,90,0.4);;
+    color: #969faf;
+    display: block;
+    font-size: 16px;
+    line-height: 16px;
+    height: 18px;
+    pointer-events: none;
+    position: absolute;
+    right: 2.75rem;
+    text-align: center;
+    top: 2.125rem;
+    width: 20px;
+}
+
 #search-input {
   background-color: $white-v2;
   border-radius: 999px;

--- a/doc/user/layouts/_default/baseof.html
+++ b/doc/user/layouts/_default/baseof.html
@@ -52,6 +52,14 @@ by the Apache License, Version 2.0.  */}}
 
         /* Make external links open in new tabs */
         $('a[href*="//"]:not([href*="materialize.com"])').attr({target:"_blank", title:"External Link"});
+
+        /* s to search */
+        document.addEventListener("keyup", e => {
+          if (e.key !== "s" || e.ctrlKey || e.metaKey) return;
+          if (/^(?:input|textarea|select|button)$/i.test(e.target.tagName)) return;
+          e.preventDefault();
+          document.getElementById("search-input").focus();
+        });
     </script>
 </body>
 

--- a/doc/user/layouts/partials/sidebar.html
+++ b/doc/user/layouts/partials/sidebar.html
@@ -16,6 +16,7 @@
       </defs>
     </svg>
     <input id="search-input" placeholder="Search">
+    <span class="search_shortcut">s</span>
 
     <ul>
       {{ range .Site.Menus.main.ByWeight }}


### PR DESCRIPTION
### Motivation

Lots of other sites have standard features to focus the search tab with a keyboard shortcut. This PR adds a similar feature to Materialize docs to make searching just a keyboard shortcut away.

### Description

This PR adds functionality to focus the search bar in docs when a user has the browser window focused, isn't typing in another input, and hits the `s` key.

### Tips for reviewer

Check for correct functionality and display in Chrome, Firefox, Safari.
