### PR TITLE
materialized: hook up s3 persist storage to command line flags

### DIFF
--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -46,7 +46,7 @@ sql = { path = "../sql" }
 sql-parser = { path = "../sql-parser" }
 symbiosis = { path = "../symbiosis" }
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
-tokio = "1.12.0"
+tokio = { version = "1.12.0", features = ["rt"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", branch = "mz-0.7.2" }
 tokio-stream = "0.1.7"
 transform = { path = "../transform" }

--- a/src/coord/src/lib.rs
+++ b/src/coord/src/lib.rs
@@ -47,5 +47,7 @@ pub use crate::client::{Client, ConnClient, Handle, SessionClient};
 pub use crate::command::{Cancelled, ExecuteResponse, StartupMessage, StartupResponse};
 pub use crate::coord::{serve, serve_debug, Config, LoggingConfig};
 pub use crate::error::CoordError;
-pub use crate::persistcfg::{PersistConfig, PersisterWithConfig};
+pub use crate::persistcfg::{
+    PersistConfig, PersistFileStorage, PersistS3Storage, PersistStorage, PersisterWithConfig,
+};
 pub use crate::timestamp::Timestamper;

--- a/src/coord/src/persistcfg.rs
+++ b/src/coord/src/persistcfg.rs
@@ -9,14 +9,19 @@
 
 //! Materialize-specific persistence configuration.
 
+use std::convert::TryFrom;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use ore::metrics::MetricsRegistry;
 use persist::error::{Error, ErrorLog};
 use persist::indexed::encoding::Id;
+use persist::s3::{Config as S3Config, S3Blob};
 use persist::storage::LockInfo;
 use repr::Row;
 use serde::Serialize;
+use tokio::runtime::Runtime;
+use url::Url;
 
 use expr::GlobalId;
 use persist::file::FileBlob;
@@ -25,12 +30,64 @@ use persist::indexed::runtime::{
 };
 use uuid::Uuid;
 
+#[derive(Clone, Debug)]
+pub enum PersistStorage {
+    File(PersistFileStorage),
+    S3(PersistS3Storage),
+}
+
+impl TryFrom<String> for PersistStorage {
+    type Error = Error;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        let url = Url::parse(&value).map_err(|err| {
+            format!(
+                "failed to parse storage location {} as a url: {}",
+                &value, err
+            )
+        })?;
+        match url.scheme() {
+            "s3" => {
+                let bucket = url
+                    .host()
+                    .ok_or_else(|| format!("missing bucket: {}", &url))?
+                    .to_string();
+                let prefix = url
+                    .path()
+                    .strip_prefix('/')
+                    .unwrap_or_else(|| url.path())
+                    .to_string();
+                Ok(PersistStorage::S3(PersistS3Storage { bucket, prefix }))
+            }
+            p => Err(Error::from(format!("unknown storage provider: {}", p))),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct PersistFileStorage {
+    /// A directory under which larger batches of indexed data are stored.
+    pub blob_path: PathBuf,
+}
+
+#[derive(Clone, Debug)]
+pub struct PersistS3Storage {
+    /// An S3 bucket in which larger batches of indexed data are stored.
+    pub bucket: String,
+    /// A prefix prepended for all S3 object keys used by this storage. Empty is
+    /// fine.
+    pub prefix: String,
+}
+
 /// Configuration of the persistence runtime and features.
 #[derive(Clone, Debug)]
 pub struct PersistConfig {
-    /// A directory under which larger batches of indexed data are stored. This
-    /// will eventually be S3 for Cloud.
-    pub blob_path: PathBuf,
+    /// A runtime used for IO and cpu heavy work. The None case should only be
+    /// used for [PersistConfig::disabled] (which is an awkward artifact of us
+    /// currently initializing persistence in the Catalog startup).
+    pub runtime: Option<Arc<Runtime>>,
+    /// Where to store persisted data.
+    pub storage: PersistStorage,
     /// Whether to persist all user tables. This is extremely experimental and
     /// should not even be tried by users. It's initially here for end-to-end
     /// testing.
@@ -50,7 +107,8 @@ pub struct PersistConfig {
 impl PersistConfig {
     pub fn disabled() -> Self {
         PersistConfig {
-            blob_path: Default::default(),
+            runtime: None,
+            storage: PersistStorage::File(PersistFileStorage::default()),
             user_table_enabled: false,
             system_table_enabled: false,
             lock_info: Default::default(),
@@ -69,8 +127,29 @@ impl PersistConfig {
             let lock_reentrance_id = catalog_id.to_string();
             let lock_info = LockInfo::new(lock_reentrance_id, self.lock_info.clone())?;
             let log = ErrorLog;
-            let blob = FileBlob::new(&self.blob_path, lock_info)?;
-            let persister = runtime::start(RuntimeConfig::default(), log, blob, reg)?;
+            let persister = match &self.storage {
+                PersistStorage::File(s) => {
+                    let blob = FileBlob::new(&s.blob_path, lock_info)?;
+                    runtime::start(
+                        RuntimeConfig::default(),
+                        log,
+                        blob,
+                        reg,
+                        self.runtime.clone(),
+                    )
+                }
+                PersistStorage::S3(s) => {
+                    let config = S3Config::new(s.bucket.clone(), s.prefix.clone())?;
+                    let blob = S3Blob::new(config, lock_info)?;
+                    runtime::start(
+                        RuntimeConfig::default(),
+                        log,
+                        blob,
+                        reg,
+                        self.runtime.clone(),
+                    )
+                }
+            }?;
             Some(persister)
         } else {
             None

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -18,6 +18,7 @@
 //! [0]: https://paper.dropbox.com/doc/Materialize-architecture-plans--AYSu6vvUu7ZDoOEZl7DNi8UQAg-sZj5rhJmISdZSfK0WBxAl
 
 use std::cmp;
+use std::convert::TryFrom;
 use std::env;
 use std::ffi::CStr;
 use std::fmt;
@@ -38,7 +39,7 @@ use anyhow::{bail, Context};
 use backtrace::Backtrace;
 use chrono::Utc;
 use clap::AppSettings;
-use coord::PersistConfig;
+use coord::{PersistConfig, PersistFileStorage, PersistStorage};
 use itertools::Itertools;
 use lazy_static::lazy_static;
 use log::info;
@@ -126,6 +127,18 @@ struct Args {
     /// test is always safe.
     #[structopt(long)]
     disable_persistent_system_tables_test: bool,
+
+    /// An S3 location used to persist data, specified as s3://<bucket>/<path>.
+    ///
+    /// The `<path>` is a prefix prepended to all S3 object keys used for
+    /// persistence and allowed to be empty.
+    ///
+    /// Ignored if persistence is disabled. If unset, files stored under
+    /// `--data-directory/-D` are used instead. If set, S3 credentials and
+    /// region must be available in the process or environment: for details see
+    /// https://github.com/rusoto/rusoto/blob/rusoto-v0.47.0/AWS-CREDENTIALS.md.
+    #[structopt(long, hidden = true, default_value)]
+    persist_storage: String,
 
     // === Timely worker configuration. ===
     /// Number of dataflow worker threads.
@@ -629,6 +642,15 @@ swap: {swap_total}KB total, {swap_used}KB used{swap_limit}",
             false
         };
         let system_table_enabled = !args.disable_persistent_system_tables_test;
+        let storage = if args.persist_storage.is_empty() {
+            PersistStorage::File(PersistFileStorage {
+                blob_path: data_directory.join("persist").join("blob"),
+            })
+        } else if !args.experimental {
+            bail!("cannot specify --persist-storage without --experimental");
+        } else {
+            PersistStorage::try_from(args.persist_storage)?
+        };
         let lock_info = format!(
             "materialized {mz_version}\nos: {os}\nstart time: {start_time}\nnum workers: {num_workers}\n",
             mz_version = materialized::BUILD_INFO.human_version(),
@@ -637,9 +659,8 @@ swap: {swap_total}KB total, {swap_used}KB used{swap_limit}",
             num_workers = args.workers.0,
         );
         PersistConfig {
-            // TODO: These paths are hardcoded for now, but we'll want to make
-            // them configurable once we add additional Log and Blob impls.
-            blob_path: data_directory.join("persist").join("blob"),
+            runtime: Some(runtime.clone()),
+            storage,
             user_table_enabled,
             system_table_enabled,
             lock_info,

--- a/src/persist/benches/end_to_end.rs
+++ b/src/persist/benches/end_to_end.rs
@@ -153,6 +153,7 @@ fn create_runtime(base_path: &Path, nonce: &str) -> Result<RuntimeClient, Error>
         FileLog::new(log_dir, lock_info.clone())?,
         FileBlob::new(blob_dir, lock_info)?,
         &MetricsRegistry::new(),
+        None,
     )?;
     Ok(runtime)
 }

--- a/src/persist/benches/snapshot.rs
+++ b/src/persist/benches/snapshot.rs
@@ -95,6 +95,7 @@ pub fn bench_file_snapshots(c: &mut Criterion) {
             FileLog::new(log_dir, lock_info.clone())?,
             FileBlob::new(blob_dir, lock_info)?,
             &MetricsRegistry::new(),
+            None,
         )
     });
 }

--- a/src/persist/examples/kafka_upsert.rs
+++ b/src/persist/examples/kafka_upsert.rs
@@ -51,7 +51,13 @@ fn run(args: Vec<String>) -> Result<(), Box<dyn Error>> {
         let lock_info = LockInfo::new("kafka_upsert".into(), "nonce".into())?;
         let log = FileLog::new(base_dir.join("log"), lock_info.clone())?;
         let blob = FileBlob::new(base_dir.join("blob"), lock_info)?;
-        runtime::start(RuntimeConfig::default(), log, blob, &MetricsRegistry::new())?
+        runtime::start(
+            RuntimeConfig::default(),
+            log,
+            blob,
+            &MetricsRegistry::new(),
+            None,
+        )?
     };
 
     timely::execute_directly(|worker| {

--- a/src/persist/src/golden_test.rs
+++ b/src/persist/src/golden_test.rs
@@ -140,6 +140,7 @@ fn golden_state(blob_json: &str) -> Result<PersistState, Error> {
         ErrorLog,
         blob,
         &MetricsRegistry::new(),
+        None,
     )?;
     let state = PersistState::slurp_from(&persist)?;
     persist.stop()?;
@@ -157,6 +158,7 @@ fn current_state(reqs: &[Input]) -> Result<(PersistState, String), Error> {
             ErrorLog,
             blob,
             &MetricsRegistry::new(),
+            None,
         )
     })?;
     for req in reqs.iter() {

--- a/src/persist/src/mem.rs
+++ b/src/persist/src/mem.rs
@@ -351,6 +351,7 @@ impl MemRegistry {
             log,
             blob,
             &MetricsRegistry::new(),
+            None,
         )
     }
 
@@ -369,6 +370,7 @@ impl MemRegistry {
             log,
             blob,
             &MetricsRegistry::new(),
+            None,
         )
     }
 }
@@ -424,6 +426,7 @@ impl MemMultiRegistry {
             log,
             blob,
             &MetricsRegistry::new(),
+            None,
         )
     }
 }

--- a/src/persist/src/nemesis/direct.rs
+++ b/src/persist/src/nemesis/direct.rs
@@ -303,6 +303,7 @@ mod tests {
                 log,
                 blob,
                 &MetricsRegistry::new(),
+                None,
             )
         })
         .expect("initial start failed");


### PR DESCRIPTION
This allows selection of S3 as the storage used by persistence with a
new `--persist-s3-bucket` cli flag to `materialized`. The optional
`--persist-s3-prefix` flag can also be used to prepend to each of the
object keys. If `--persist-s3-bucket` is unset and persistence is
enabled, we fall back to using file storage in the data directory. S3
credentials and region must be available in the process or environment.

`--persist-s3-bucket` is only allowed with `--experimental`.

### Motivation

  * This PR adds a feature that has not yet been specified.
