### PR TITLE
release: Some changes to the template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -104,11 +104,12 @@ a release is published.
   issue links, one to point to the unreviewed PRs issue you went through above, and one
   to point to this issue:
 
-  > @relnotes-team the release is in progress, now's a great time to verify or
-  > prepare the release notes and any announcement posts.
-  > * release notes: https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md
-  > * All PRs in this release: https://github.com/MaterializeInc/materialize/issues/`<unreviewed PRs issue>`
-  > * Release: https://github.com/MaterializeInc/materialize/issues/`<this issue>`
+  ```text
+  @relnotes-team the release is in progress, now's a great time to verify or prepare the release notes and any announcement posts.
+  * release notes: https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md
+  * All PRs in this release: https://github.com/MaterializeInc/materialize/issues/<unreviewed PRs issue>
+  * Release: https://github.com/MaterializeInc/materialize/issues/<this issue>
+  ```
 
 ### Test the release candidate
 

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -2,6 +2,8 @@
 name: "Internal: release checklist"
 about: >
   A tracking issue for a new release of Materialize. Contributor use only.
+title: "Release: v"
+labels: release-tracker
 ---
 
 ## Current status: 🚢 Progressing 🚢


### PR DESCRIPTION
* Use a code block instead of block quote for a message template

  The block quote was getting picked up by slack and was kind of annoying

* Provide a template for the release issue title and labels

  The issue title just fills in what we mostly do already.

  The label will allow us to reliably refer to release issues from scripts.