### PR TITLE
Correct the SLT tests pipeline name

### DIFF
--- a/ci/deploy/pipeline.yml
+++ b/ci/deploy/pipeline.yml
@@ -34,7 +34,7 @@ steps:
     concurrency_group: deploy/pypi
 
   - label: ":bulb: Full SQL Logic Tests"
-    trigger: slt
+    trigger: sql-logic-tests
     async: true
     branches: "v*.*rc*"
     build:


### PR DESCRIPTION
This new name comes from the URL slug
(https://buildkite.com/materialize/sql-logic-tests) instead of the directory
name. I'm not sure where that url slug gets set, though.

This fixes current breakage on merge to main, e.g. https://buildkite.com/materialize/deploy/builds/5099