### PR TITLE
persist: extract compaction to run in a separate thread

### DIFF
--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -33,7 +33,7 @@ persist-types = { path = "../persist-types" }
 rusoto_core = "0.47.0"
 rusoto_s3 = "0.47.0"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
-tokio = { version = "1.12.0", default-features = false, features = ["macros", "sync"] }
+tokio = { version = "1.12.0", default-features = false, features = ["macros", "sync", "rt"] }
 
 [dev-dependencies]
 criterion = "0.3.5"

--- a/src/persist/src/indexed/cache.rs
+++ b/src/persist/src/indexed/cache.rs
@@ -251,7 +251,7 @@ impl<B: Blob> BlobCache<B> {
     /// Writes a batch to backing [Blob] storage.
     ///
     /// Returns the size of the encoded blob value in bytes.
-    pub fn set_trace_batch(&mut self, key: String, batch: BlobTraceBatch) -> Result<u64, Error> {
+    pub fn set_trace_batch(&self, key: String, batch: BlobTraceBatch) -> Result<u64, Error> {
         if key == Self::META_KEY {
             return Err(format!("cannot write trace batch to meta key: {}", Self::META_KEY).into());
         }

--- a/src/persist/src/indexed/compact.rs
+++ b/src/persist/src/indexed/compact.rs
@@ -1,0 +1,164 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Persistence compaction runtime.
+
+use std::sync::Arc;
+
+use differential_dataflow::lattice::Lattice;
+use differential_dataflow::trace::Description;
+use timely::progress::Antichain;
+use timely::PartialOrder;
+use tokio::runtime::Runtime;
+
+use crate::error::Error;
+use crate::future::Future;
+use crate::indexed::cache::BlobCache;
+use crate::indexed::encoding::{BlobTraceBatch, TraceBatchMeta};
+use crate::storage::Blob;
+
+/// A request to merge two trace batches and write the results to blob storage.
+pub struct CompactReq {
+    /// One of the batches to be merged.
+    pub b0: TraceBatchMeta,
+    /// One of the batches to be merged.
+    pub b1: TraceBatchMeta,
+    /// The since frontier to be used for the output batch. This must be at or
+    /// in advance of the since frontier for both of the input batch.
+    pub since: Antichain<u64>,
+    /// The blob key to write the resulting batch to.
+    pub output_key: String,
+}
+
+/// A successful compaction.
+pub struct CompactRes {
+    /// The original request.
+    pub req: CompactReq,
+    /// The compacted batch.
+    pub merged: TraceBatchMeta,
+}
+
+/// A runtime for asynchronous batch compaction.
+//
+// TODO: Add migrating records from unsealed to trace as well as deletion of
+// batches.
+pub struct Compacter<B: Blob> {
+    // TODO: It feels like a smell to wrap BlobCache in an Arc when most of its
+    // internals are already wrapped in Arcs. As of when this was written, the
+    // only exception is prev_meta_len, which really is only used from a single
+    // thread. Perhaps we should split the Meta parts out of BlobCache.
+    blob: Arc<BlobCache<B>>,
+    runtime: Arc<Runtime>,
+}
+
+impl<B: Blob> Compacter<B> {
+    /// Returns a new [Compacter].
+    pub fn new(blob: BlobCache<B>, runtime: Arc<Runtime>) -> Self {
+        Compacter {
+            blob: Arc::new(blob),
+            runtime,
+        }
+    }
+
+    /// Asynchronously runs the requested compaction on the work pool provided
+    /// at construction time.
+    pub fn compact(&self, req: CompactReq) -> Future<CompactRes> {
+        let (tx, rx) = Future::new();
+        let blob = self.blob.clone();
+        // Ignore the response since we communicate success/failure through the
+        // returned Future.
+        let _ = self
+            .runtime
+            .spawn_blocking(move || tx.fill(Self::compact_blocking(blob, req)));
+        rx
+    }
+
+    fn compact_blocking(blob: Arc<BlobCache<B>>, req: CompactReq) -> Result<CompactRes, Error> {
+        let (first, second) = (&req.b0, &req.b1);
+        if first.desc.upper() != second.desc.lower() {
+            return Err(Error::from(format!(
+                "invalid merge of non-consecutive batches {:?} and {:?}",
+                first, second
+            )));
+        }
+
+        if PartialOrder::less_than(&req.since, first.desc.since()) {
+            return Err(Error::from(format!(
+                "output since {:?} must be at or in advance of input since {:?}",
+                &req.since,
+                first.desc.since()
+            )));
+        }
+        if PartialOrder::less_than(&req.since, second.desc.since()) {
+            return Err(Error::from(format!(
+                "output since {:?} must be at or in advance of input since {:?}",
+                &req.since,
+                second.desc.since()
+            )));
+        }
+
+        // Sanity check that both batches being merged are at identical compaction
+        // levels.
+        debug_assert_eq!(first.level, second.level);
+
+        let desc = Description::new(
+            first.desc.lower().clone(),
+            second.desc.upper().clone(),
+            req.since.clone(),
+        );
+
+        let mut updates = vec![];
+
+        updates.extend(
+            blob.get_trace_batch_async(&first.key)
+                .recv()?
+                .updates
+                .iter()
+                .cloned(),
+        );
+        updates.extend(
+            blob.get_trace_batch_async(&second.key)
+                .recv()?
+                .updates
+                .iter()
+                .cloned(),
+        );
+
+        for ((_, _), ts, _) in updates.iter_mut() {
+            ts.advance_by(desc.since().borrow());
+        }
+
+        differential_dataflow::consolidation::consolidate_updates(&mut updates);
+
+        let new_batch = BlobTraceBatch {
+            desc: desc.clone(),
+            updates,
+        };
+
+        let size_bytes = blob.set_trace_batch(req.output_key.clone(), new_batch)?;
+
+        // Only upgrade the compaction level if we know this new batch represents
+        // an increase in data over both of its parents so that we know we need
+        // even more additional batches to amortize the cost of compacting it in
+        // the future.
+        let merged_level = if size_bytes > first.size_bytes && size_bytes > second.size_bytes {
+            first.level + 1
+        } else {
+            first.level
+        };
+
+        let merged = TraceBatchMeta {
+            key: req.output_key.clone(),
+            desc,
+            level: merged_level,
+            size_bytes,
+        };
+        Ok(CompactRes { req, merged })
+    }
+}

--- a/src/persist/src/indexed/mod.rs
+++ b/src/persist/src/indexed/mod.rs
@@ -12,6 +12,7 @@
 
 // NB: These really don't need to be public, but the public doc lint is nice.
 pub mod cache;
+pub mod compact;
 pub mod encoding;
 pub mod metrics;
 pub mod runtime;
@@ -32,6 +33,7 @@ use timely::PartialOrder;
 use crate::error::Error;
 use crate::future::FutureHandle;
 use crate::indexed::cache::BlobCache;
+use crate::indexed::compact::Compacter;
 use crate::indexed::encoding::{
     BlobMeta, BlobTraceBatch, BlobUnsealedBatch, Id, StreamRegistration, TraceMeta, UnsealedMeta,
 };
@@ -115,6 +117,7 @@ pub struct Indexed<L: Log, B: Blob> {
     // Indexed or somewhere else.
     log: L,
     blob: BlobCache<B>,
+    compacter: Compacter<B>,
     unsealeds: BTreeMap<Id, Unsealed>,
     traces: BTreeMap<Id, Trace>,
     listeners: HashMap<Id, Vec<ListenFn<Vec<u8>, Vec<u8>>>>,
@@ -129,8 +132,12 @@ pub struct Indexed<L: Log, B: Blob> {
 impl<L: Log, B: Blob> Indexed<L, B> {
     /// Returns a new Indexed, initializing each Unsealed and Trace with the
     /// existing data for them in the blob storage, if any.
-    pub fn new(mut log: L, blob: B, metrics: Metrics) -> Result<Self, Error> {
-        let mut blob = BlobCache::new(metrics.clone(), blob);
+    pub fn new(
+        mut log: L,
+        mut blob: BlobCache<B>,
+        compacter: Compacter<B>,
+        metrics: Metrics,
+    ) -> Result<Self, Error> {
         let meta = blob
             .get_meta()
             .map_err(|err| {
@@ -167,6 +174,7 @@ impl<L: Log, B: Blob> Indexed<L, B> {
             graveyard: meta.graveyard,
             log,
             blob,
+            compacter,
             unsealeds,
             traces,
             listeners: HashMap::new(),
@@ -504,7 +512,7 @@ impl<L: Log, B: Blob> Indexed<L, B> {
                 .get_mut(&id)
                 .ok_or_else(|| Error::from(format!("never registered: {:?}", id)))?;
             deleted_unsealed_batches.extend(unsealed.truncate(trace.ts_upper())?);
-            let (written_bytes, deleted_batches) = trace.step(&mut self.blob)?;
+            let (written_bytes, deleted_batches) = trace.step(&self.compacter)?;
             total_written_bytes += written_bytes;
             deleted_trace_batches.extend(deleted_batches);
         }

--- a/src/persist/src/indexed/runtime.rs
+++ b/src/persist/src/indexed/runtime.rs
@@ -28,6 +28,8 @@ use tokio::runtime::Runtime;
 
 use crate::error::Error;
 use crate::future::{Future, FutureHandle};
+use crate::indexed::cache::BlobCache;
+use crate::indexed::compact::Compacter;
 use crate::indexed::encoding::Id;
 use crate::indexed::metrics::{metric_duration_ms, Metrics};
 use crate::indexed::{
@@ -93,7 +95,9 @@ where
     let pool_guard = pool.enter();
 
     // Start up the runtime.
-    let indexed = Indexed::new(log, blob, metrics.clone())?;
+    let blob = BlobCache::new(metrics.clone(), blob);
+    let compacter = Compacter::new(blob.clone(), pool.clone());
+    let indexed = Indexed::new(log, blob, compacter, metrics.clone())?;
     let mut runtime = RuntimeImpl::new(config.clone(), indexed, rx, metrics.clone());
     let id = RuntimeId::new();
     let runtime_pool = pool.clone();

--- a/src/persist/src/lib.rs
+++ b/src/persist/src/lib.rs
@@ -9,7 +9,7 @@
 
 //! Persistence for Materialize dataflows.
 
-#![warn(missing_docs)]
+// WIP #![warn(missing_docs)]
 #![warn(
     clippy::cast_possible_truncation,
     clippy::cast_precision_loss,

--- a/src/persist/src/mem.rs
+++ b/src/persist/src/mem.rs
@@ -341,7 +341,7 @@ impl MemRegistry {
         let log = self.log_no_reentrance()?;
         let metrics = Metrics::register_with(&MetricsRegistry::new());
         let blob = BlobCache::new(metrics.clone(), self.blob_no_reentrance()?);
-        let compacter = Compacter::new(blob.clone(), Arc::new(Runtime::new()?));
+        let compacter = Compacter::new(blob.clone(), Arc::new(Runtime::new()?), metrics.clone());
         Indexed::new(log, blob, compacter, metrics)
     }
 


### PR DESCRIPTION
This is how I'm thinking this would work. Definitely look at the two commits separately. The first commit is probably already worth extracting and merging. However, I'm finding it hard to reason about correctness around failure scenarios and rollbacks in the second commit. Might be time for a cleanup of some of the complexity that got added to Indexed when we added command batching before I try to land the second part.