### PR TITLE
kafka create sink: add retention.ms and retention.bytes

### DIFF
--- a/doc/developer/guide.md
+++ b/doc/developer/guide.md
@@ -169,6 +169,9 @@ log` and `ps ... | grep` over the output of `confluent local services status`.
 Still, it's reliable enough to be more convenient than managing each service
 manually.
 
+When the confluent local services are running, they can be examined via a web
+UI which defaults to `localhost:9021`.
+
 ## Symbiosis mode
 
 For the convenience of developers, Materialize has a semi-secret "symbiosis"

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -51,6 +51,7 @@ Put breaking changes before other release notes.
 {{% version-header v0.9.7 %}}
 - Support the `IS TRUE`, `IS FALSE`, `IS UNKNOWN` operators (and their `NOT`
   variations). {{% gh 8455 %}}
+- Add support for retention settings on Kafka sinks.
 
 {{% version-header v0.9.6 %}}
 

--- a/doc/user/content/sql/create-sink.md
+++ b/doc/user/content/sql/create-sink.md
@@ -66,6 +66,12 @@ Field                | Value type | Description
 `consistency_topic`  | `text`     | Makes the sink emit additional [consistency metadata](#consistency-metadata). Only valid for Kafka sinks. If `reuse_topic` is `true`, a default `consistency_topic` will be used when not explicitly set. The default consistency topic name is formed by appending `-consistency` to the output topic name.
 `security_protocol`  | `text`     | Use [`ssl`](#ssl-with-options) or, for [Kerberos](#kerberos-with-options), `sasl_plaintext`, `sasl-scram-sha-256`, or `sasl-sha-512` to connect to the Kafka cluster.
 `acks`               | `text`     | Sets the number of Kafka replicas that must acknowledge Materialize writes. Accepts values [-1,1000]. `-1` (the default) specifies all replicas.
+`retention_ms`       | `long`     | Sets the maximum time Kafka will retain a log.  Accepts values [-1, ...]. `-1` specifics no time limit.  If not set, uses the server default.
+`retention_bytes`    | `long`     | Sets the maximum size a Kafka partion can grow before removing old logs.  Accepts values [-1, ...]. `-1` specifics no size limit.  If not set, uses the server default.
+
+{{< version-changed v0.9.7 >}}
+The `retention_ms` and `retention_bytes` options were added.
+{{< /version-changed >}}
 
 #### SSL `WITH` options
 

--- a/doc/user/content/sql/create-sink.md
+++ b/doc/user/content/sql/create-sink.md
@@ -66,8 +66,8 @@ Field                | Value type | Description
 `consistency_topic`  | `text`     | Makes the sink emit additional [consistency metadata](#consistency-metadata). Only valid for Kafka sinks. If `reuse_topic` is `true`, a default `consistency_topic` will be used when not explicitly set. The default consistency topic name is formed by appending `-consistency` to the output topic name.
 `security_protocol`  | `text`     | Use [`ssl`](#ssl-with-options) or, for [Kerberos](#kerberos-with-options), `sasl_plaintext`, `sasl-scram-sha-256`, or `sasl-sha-512` to connect to the Kafka cluster.
 `acks`               | `text`     | Sets the number of Kafka replicas that must acknowledge Materialize writes. Accepts values [-1,1000]. `-1` (the default) specifies all replicas.
-`retention_ms`       | `long`     | Sets the maximum time Kafka will retain a log.  Accepts values [-1, ...]. `-1` specifics no time limit.  If not set, uses the server default.
-`retention_bytes`    | `long`     | Sets the maximum size a Kafka partion can grow before removing old logs.  Accepts values [-1, ...]. `-1` specifics no size limit.  If not set, uses the server default.
+`retention_ms`       | `long`     | Sets the maximum time Kafka will retain a log.  Accepts values [-1, ...]. `-1` specifics no time limit.  If not set, uses the broker default.
+`retention_bytes`    | `long`     | Sets the maximum size a Kafka partion can grow before removing old logs.  Accepts values [-1, ...]. `-1` specifics no size limit.  If not set, uses the broker default.
 
 {{< version-changed v0.9.7 >}}
 The `retention_ms` and `retention_bytes` options were added.

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -1162,6 +1162,13 @@ pub struct KafkaSinkConnectorBuilder {
     pub reuse_topic: bool,
     // Source dependencies for exactly-once sinks.
     pub transitive_source_dependencies: Vec<GlobalId>,
+    pub retention: KafkaSinkConnectorRetention,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct KafkaSinkConnectorRetention {
+    pub retention_ms: Option<i64>,
+    pub retention_bytes: Option<i64>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -679,11 +679,11 @@ CREATE SINK foo FROM bar INTO FILE 'baz' WITH SNAPSHOT FORMAT BYTES
                               ^
 
 parse-statement
-CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' WITH (replication_factor = 7) FORMAT BYTES
+CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' WITH (replication_factor = 7, retention_ms = 10000, retention_bytes = 10000000000) FORMAT BYTES
 ----
-CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' WITH (replication_factor = 7) FORMAT BYTES WITH SNAPSHOT
+CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' WITH (replication_factor = 7, retention_ms = 10000, retention_bytes = 10000000000) FORMAT BYTES WITH SNAPSHOT
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), from: UnresolvedObjectName([Ident("bar")]), connector: Kafka { broker: "baz", topic: "topic", key: None, consistency: None }, with_options: [Value { name: Ident("replication_factor"), value: Number("7") }], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), from: UnresolvedObjectName([Ident("bar")]), connector: Kafka { broker: "baz", topic: "topic", key: None, consistency: None }, with_options: [Value { name: Ident("replication_factor"), value: Number("7") }, Value { name: Ident("retention_ms"), value: Number("10000") }, Value { name: Ident("retention_bytes"), value: Number("10000000000") }], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
 
 parse-statement
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) FORMAT BYTES

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -32,10 +32,11 @@ use reqwest::Url;
 use dataflow_types::{
     AvroEncoding, AvroOcfEncoding, AvroOcfSinkConnectorBuilder, BringYourOwn, ColumnSpec,
     Consistency, CsvEncoding, DataEncoding, DebeziumMode, ExternalSourceConnector,
-    FileSourceConnector, KafkaSinkConnectorBuilder, KafkaSinkFormat, KafkaSourceConnector,
-    KeyEnvelope, KinesisSourceConnector, PostgresSourceConnector, ProtobufEncoding,
-    PubNubSourceConnector, RegexEncoding, S3SourceConnector, SinkConnectorBuilder, SinkEnvelope,
-    SourceConnector, SourceDataEncoding, SourceEnvelope, Timeline,
+    FileSourceConnector, KafkaSinkConnectorBuilder, KafkaSinkConnectorRetention, KafkaSinkFormat,
+    KafkaSourceConnector, KeyEnvelope, KinesisSourceConnector, PostgresSourceConnector,
+    ProtobufEncoding, PubNubSourceConnector, RegexEncoding, S3SourceConnector,
+    SinkConnectorBuilder, SinkEnvelope, SourceConnector, SourceDataEncoding, SourceEnvelope,
+    Timeline,
 };
 use expr::{func, GlobalId, MirRelationExpr, TableFunc, UnaryFunc};
 use interchange::avro::{self, AvroSchemaGenerator, DebeziumDeduplicationStrategy};
@@ -1483,6 +1484,30 @@ fn kafka_sink_builder(
         );
     }
 
+    let retention_ms = match with_options.remove("retention_ms") {
+        None => None,
+        Some(Value::Number(n)) => Some(n.parse::<i64>()?),
+        Some(_) => bail!("retention ms for sink topics must be an integer"),
+    };
+
+    if retention_ms.unwrap_or(0) < -1 {
+        bail!("retention ms for sink topics must be greater than or equal to -1");
+    }
+
+    let retention_bytes = match with_options.remove("retention_bytes") {
+        None => None,
+        Some(Value::Number(n)) => Some(n.parse::<i64>()?),
+        Some(_) => bail!("retention bytes for sink topics must be an integer"),
+    };
+
+    if retention_bytes.unwrap_or(0) < -1 {
+        bail!("retention bytes for sink topics must be greater than or equal to -1");
+    }
+    let retention = KafkaSinkConnectorRetention {
+        retention_ms,
+        retention_bytes,
+    };
+
     let consistency_topic = consistency_config.clone().map(|config| config.0);
     let consistency_format = consistency_config.map(|config| config.1);
 
@@ -1502,6 +1527,7 @@ fn kafka_sink_builder(
         value_desc,
         reuse_topic,
         transitive_source_dependencies,
+        retention,
     }))
 }
 

--- a/test/testdrive/kafka-sink-errors.td
+++ b/test/testdrive/kafka-sink-errors.td
@@ -87,6 +87,37 @@ Invalid value for configuration property "request.required.acks" acks foo
 No such column: f2
 
 #
+# Retention options
+#
+! CREATE SINK invalid_retention_ms FROM v1
+  INTO KAFKA BROKER '${testdrive.kafka-addr}'
+  TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
+  WITH (retention_ms = a)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+retention ms for sink topics must be an integer
+
+! CREATE SINK invalid_retention_ms FROM v1
+  INTO KAFKA BROKER '${testdrive.kafka-addr}'
+  TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
+  WITH (retention_ms = -2)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+retention ms for sink topics must be greater than or equal to -1
+
+! CREATE SINK invalid_retention_bytes FROM v1
+  INTO KAFKA BROKER '${testdrive.kafka-addr}'
+  TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
+  WITH (retention_bytes = a)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+retention bytes for sink topics must be an integer
+
+! CREATE SINK invalid_retention_bytes FROM v1
+  INTO KAFKA BROKER '${testdrive.kafka-addr}'
+  TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
+  WITH (retention_bytes = -2)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+retention bytes for sink topics must be greater than or equal to -1
+
+#
 # Sink dependencies
 #
 

--- a/test/testdrive/sinks.td
+++ b/test/testdrive/sinks.td
@@ -73,10 +73,12 @@ name
 
 > CREATE SINK snk4 FROM v2
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'snk4'
+  WITH (retention_ms=1000000)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 > CREATE SINK snk5 FROM v3
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'snk5'
+  WITH (retention_bytes=1000000000000)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 > SHOW SINKS


### PR DESCRIPTION
### Motivation
Fixes https://github.com/MaterializeInc/materialize/issues/6467
<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug. [Link to issue.]

  * This PR adds a known-desirable feature. [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

### Description
Pass through `retention_ms` and `retention_bytes` to `retention.ms` and `retention.bytes`, respectively, when creating an kafka sink.  Do this via adding a new field to the `KafkaSinkConnectorBuilder`.

Importantly, these configuration flags are _not_ part of the `ClientConfig` so should not be included in `kafka_util::extract_config` but handled separately.
<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details."

-->

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [x] This PR has adequate test coverage.
- [x] This PR adds a release note for any user-facing behavior changes.
