### PR TITLE
Dataflow builder dustoff

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -2016,7 +2016,7 @@ impl Catalog {
             }
             Plan::CreateSource(CreateSourcePlan { source, .. }) => {
                 let mut optimizer = Optimizer::logical_optimizer();
-                let optimized_expr = optimizer.optimize(source.expr, self.enabled_indexes())?;
+                let optimized_expr = optimizer.optimize(source.expr)?;
                 let transformed_desc = RelationDesc::new(optimized_expr.typ(), source.column_names);
                 CatalogItem::Source(Source {
                     create_sql: source.create_sql,
@@ -2028,7 +2028,7 @@ impl Catalog {
             }
             Plan::CreateView(CreateViewPlan { view, .. }) => {
                 let mut optimizer = Optimizer::logical_optimizer();
-                let optimized_expr = optimizer.optimize(view.expr, self.enabled_indexes())?;
+                let optimized_expr = optimizer.optimize(view.expr)?;
                 let desc = RelationDesc::new(optimized_expr.typ(), view.column_names);
                 CatalogItem::View(View {
                     create_sql: view.create_sql,

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1993,9 +1993,7 @@ impl Coordinator {
                 materialized,
                 ..
             } = plan;
-            let optimized_expr = self
-                .view_optimizer
-                .optimize(source.expr, self.catalog.enabled_indexes())?;
+            let optimized_expr = self.view_optimizer.optimize(source.expr)?;
             let transformed_desc = RelationDesc::new(optimized_expr.0.typ(), source.column_names);
             let source = catalog::Source {
                 create_sql: source.create_sql,
@@ -3755,9 +3753,7 @@ impl Coordinator {
         style: ExprPrepStyle,
     ) -> Result<OptimizedMirRelationExpr, CoordError> {
         if let ExprPrepStyle::Static = style {
-            let mut opt_expr = self
-                .view_optimizer
-                .optimize(expr, self.catalog.enabled_indexes())?;
+            let mut opt_expr = self.view_optimizer.optimize(expr)?;
             opt_expr.0.try_visit_mut(&mut |e| {
                 // Carefully test filter expressions, which may represent temporal filters.
                 if let expr::MirRelationExpr::Filter { input, predicates } = &*e {
@@ -3778,9 +3774,7 @@ impl Coordinator {
             // constant expression that originally contains a global get? Is
             // there anything not containing a global get that cannot be
             // optimized to a constant expression?
-            Ok(self
-                .view_optimizer
-                .optimize(expr, self.catalog.enabled_indexes())?)
+            Ok(self.view_optimizer.optimize(expr)?)
         }
     }
 

--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -32,6 +32,28 @@ impl Coordinator {
             transient_id_counter: &mut self.transient_id_counter,
         }
     }
+
+    /// Prepares the arguments to an index build dataflow, by interrogating the catalog.
+    ///
+    /// Returns `None` if the index entry in the catalog in not enabled.
+    pub fn prepare_index_build(&self, index_id: &GlobalId) -> Option<(String, IndexDesc)> {
+        let index_entry = self.catalog.get_by_id(&index_id);
+        let index = match index_entry.item() {
+            CatalogItem::Index(index) => index,
+            _ => unreachable!("cannot create index dataflow on non-index"),
+        };
+        if !index.enabled {
+            None
+        } else {
+            Some((
+                index_entry.name().to_string(),
+                dataflow_types::IndexDesc {
+                    on_id: index.on,
+                    keys: index.keys.clone(),
+                },
+            ))
+        }
+    }
 }
 
 impl<'a> DataflowBuilder<'a> {
@@ -168,28 +190,18 @@ impl<'a> DataflowBuilder<'a> {
     }
 
     /// Builds a dataflow description for the index with the specified ID.
-    ///
-    /// Returns `None` if we infer that the specified index is disabled.
-    pub fn build_index_dataflow(&mut self, id: GlobalId) -> Option<DataflowDesc> {
-        let index_entry = self.catalog.get_by_id(&id);
-        let index = match index_entry.item() {
-            CatalogItem::Index(index) => index,
-            _ => unreachable!("cannot create index dataflow on non-index"),
-        };
-
-        // Disabled indexes should not have dataflows created for them.
-        if !index.enabled {
-            return None;
-        }
-
-        let on_entry = self.catalog.get_by_id(&index.on);
+    pub fn build_index_dataflow(
+        &mut self,
+        name: String,
+        id: GlobalId,
+        index_description: dataflow_types::IndexDesc,
+    ) -> DataflowDesc {
+        let on_entry = self.catalog.get_by_id(&index_description.on_id);
         let on_type = on_entry.desc().unwrap().typ().clone();
-        let mut dataflow = DataflowDesc::new(index_entry.name().to_string());
-        let on_id = index.on;
-        let keys = index.keys.clone();
-        self.import_into_dataflow(&on_id, &mut dataflow);
-        dataflow.export_index(id, IndexDesc { on_id, keys }, on_type);
-        Some(dataflow)
+        let mut dataflow = DataflowDesc::new(name);
+        self.import_into_dataflow(&index_description.on_id, &mut dataflow);
+        dataflow.export_index(id, index_description, on_type);
+        dataflow
     }
 
     /// Builds a dataflow description for the sink with the specified name,

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -340,17 +340,22 @@ impl Optimizer {
         Self { transforms }
     }
 
-    /// Optimizes the supplied relation expression returning an optimized relation.
+    /// Optimizes the supplied relation expression.
+    ///
+    /// These optimizations are performed with no information about available arrangements,
+    /// which makes them suitable for pre-optimization before dataflow deployment.
     pub fn optimize(
         &mut self,
         mut relation: MirRelationExpr,
-        indexes: &HashMap<GlobalId, Vec<(GlobalId, Vec<MirScalarExpr>)>>,
     ) -> Result<expr::OptimizedMirRelationExpr, TransformError> {
-        self.transform(&mut relation, indexes)?;
+        self.transform(&mut relation, &HashMap::new())?;
         Ok(expr::OptimizedMirRelationExpr(relation))
     }
 
-    /// Optimizes the supplied relation expression in place.
+    /// Optimizes the supplied relation expression in place, using available arrangements.
+    ///
+    /// This method should only be called with non-empty `indexes` when optimizing a dataflow,
+    /// as the optimizations may lock in the use of arrangements that may cease to exist.
     fn transform(
         &self,
         relation: &mut MirRelationExpr,

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -114,14 +114,8 @@ mod tests {
 
         let out = match test_type {
             TestType::Opt => {
-                rel = logical_opt
-                    .optimize(rel, &HashMap::new())
-                    .unwrap()
-                    .into_inner();
-                rel = physical_opt
-                    .optimize(rel, &HashMap::new())
-                    .unwrap()
-                    .into_inner();
+                rel = logical_opt.optimize(rel).unwrap().into_inner();
+                rel = physical_opt.optimize(rel).unwrap().into_inner();
 
                 convert_rel_to_string(&rel, &cat, &format_type)
             }


### PR DESCRIPTION
### Motivation

   * This PR refactors existing code.

This PR reorganizes optimization in the coordinator, and `DataflowBuilder`. 

### Description

The coordinator no longer calls optimization with enabled indexes, as this is a potential mis-optimization when the set of available indexes changes before dataflow building. Instead, available indexes are used (continue to be used) only in `DataflowDescription` optimization, in `transform/dataflow.rs`. This prevents the coordinator from needing to reason about which indexes to present as available to optimization.

`DataflowBuilder` is re-organized to make building of sinks and indexes depend on descriptions, respectively `SinkDesc` and `IndexDesc`. This information was previously partially extracted from the bound catalog, and meant that items to be built must already be installed in the catalog (reported as frustrating). They may now be installed, but will not be consulted and the description is used instead.

For index building, the prevention of building for disabled indexes is moved outside the `build_index_dataflow` method. A helper method `prepare_index_build` is added to `Coordinator` (in `dataflow_builder.rs`) which extracts the name to use, index description, and whether the index is enabled. This information is the supplied directly to the index builder, who more clearly just builds the described index.

### Tips for reviewer

This has not be tested yet, and we'll see what CI says. Ideally it changes functionality not at all, but if e.g. enabled index information were leaking in to optimization, this now prevents that and may result in different plans.

### Checklist

- [ ] This PR has adequate test coverage.
- [ ] This PR adds a release note for any user-facing behavior changes.
