### PR TITLE
Improve fast path logic

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -2785,8 +2785,6 @@ impl Coordinator {
 
         let dataflow_plan = self.finalize_dataflow(dataflow);
 
-        println!("{:?}", dataflow_plan);
-
         // At this point, `dataflow_plan` contains our best optimized dataflow.
         // It may be a `Constant`, a `Get`, or something we need to install to read out.
         // If there is exactly one object to build, and that object is a `Constant` or
@@ -2840,8 +2838,6 @@ impl Coordinator {
                 }
             }
         }
-
-        println!("EARLY: {:?}", early_exit);
 
         // There are three cases going forward, based on the variants of `early_exit`:
         // 1. `Some(Ok(rows))` indicates a constant expression that we can return.


### PR DESCRIPTION
### Motivation

Fixes #8269

### Description

The coordinator previously determined whether a `SELECT` statement could be "fast pathed" by checking a few things about the specific `SELECT` statement, independent of views it might reference. This was problematic if the query just listed the contents of another view, or something like that, as the query was essentially opaque and not fastpathable.

This PR changes the logic to *first* assemble a candidate dataflow, optimize it to the point that it is ready to ship, and then reflect on whether it is 1. a `Constant` expression, 2. a `Get` expression around an existing arrangement, 3. not one of those things and so requires building a dataflow.

### Tips for reviewer

There aren't many comments, but many of the deleted comments were incorrect and not maintained. I'll add them back in before anyone should try too hard to read this. Mostly just testing CI because idk how to do that locally.

### Checklist

- [ ] This PR has adequate test coverage.
- [ ] This PR adds a release note for any user-facing behavior changes.
