### PR TITLE
sql: Allow RESTRICT and CASCADE in DROP DATABASE

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -52,6 +52,9 @@ Put breaking changes before other release notes.
 - Support the `IS TRUE`, `IS FALSE`, `IS UNKNOWN` operators (and their `NOT`
   variations). {{% gh 8455 %}}
 
+- Support explicit `DROP DATABASE ... (CASCADE | RESTRICT)` statements.  The
+  default behavior remains CASCADE.
+
 {{% version-header v0.9.6 %}}
 
 - Correctly handle TOASTed columns when using PostgreSQL sources. {{% gh 8371 %}}

--- a/doc/user/content/sql/drop-database.md
+++ b/doc/user/content/sql/drop-database.md
@@ -19,9 +19,27 @@ Field | Use
 ------|-----
 **IF EXISTS** | Do not return an error if the specified database does not exist.
 _database&lowbar;name_ | The database you want to drop. For available databases, see [`SHOW DATABASES`](../show-databases).
+**CASCADE** | Remove the database and its dependent objects. _(Default)_
+**RESTRICT** | Do not remove this database if it contains any schemas.
 
 ## Example
 
+### Remove a database containing schemas
+You can use either of the following commands:
+
+- ```sql
+  DROP DATABASE my_db;
+  ```
+- ```sql
+  DROP DATABASE my_db CASCADE;
+  ```
+
+### Remove a database only if it contains no schemas
 ```sql
-SHOW DATABASES;
+DROP DATABASE my_db RESTRICT;
+```
+
+### Do not issue an error if attempting to remove a nonexistent database
+```sql
+DROP DATABASE IF EXISTS my_db;
 ```

--- a/doc/user/layouts/partials/sql-grammar/drop-database.svg
+++ b/doc/user/layouts/partials/sql-grammar/drop-database.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="527" height="69">
+<svg xmlns="http://www.w3.org/2000/svg" width="521" height="199">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="60" height="32" rx="10"/>
@@ -28,8 +28,24 @@
    <rect x="375" y="3" width="124" height="32"/>
    <rect x="373" y="1" width="124" height="32" class="nonterminal"/>
    <text class="nonterminal" x="383" y="21">database_name</text>
+   <rect x="383" y="121" width="90" height="32" rx="10"/>
+   <rect x="381"
+         y="119"
+         width="90"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="391" y="139">CASCADE</text>
+   <rect x="383" y="165" width="90" height="32" rx="10"/>
+   <rect x="381"
+         y="163"
+         width="90"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="391" y="183">RESTRICT</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m60 0 h10 m0 0 h10 m98 0 h10 m20 0 h10 m0 0 h96 m-126 0 h20 m106 0 h20 m-146 0 q10 0 10 10 m126 0 q0 -10 10 -10 m-136 10 v12 m126 0 v-12 m-126 12 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m86 0 h10 m20 -32 h10 m124 0 h10 m3 0 h-3"/>
-   <polygon points="517 17 525 13 525 21"/>
-   <polygon points="517 17 509 13 509 21"/>
+         d="m17 17 h2 m0 0 h10 m60 0 h10 m0 0 h10 m98 0 h10 m20 0 h10 m0 0 h96 m-126 0 h20 m106 0 h20 m-146 0 q10 0 10 10 m126 0 q0 -10 10 -10 m-136 10 v12 m126 0 v-12 m-126 12 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m86 0 h10 m20 -32 h10 m124 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-180 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h100 m-130 0 h20 m110 0 h20 m-150 0 q10 0 10 10 m130 0 q0 -10 10 -10 m-140 10 v12 m130 0 v-12 m-130 12 q0 10 10 10 m110 0 q10 0 10 -10 m-120 10 h10 m90 0 h10 m-120 -10 v20 m130 0 v-20 m-130 20 v24 m130 0 v-24 m-130 24 q0 10 10 10 m110 0 q10 0 10 -10 m-120 10 h10 m90 0 h10 m23 -76 h-3"/>
+   <polygon points="511 103 519 99 519 107"/>
+   <polygon points="511 103 503 99 503 107"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -246,7 +246,7 @@ insert ::=
 discard ::=
   'DISCARD' ('TEMP' | 'TEMPORARY' | 'ALL')
 drop_database ::=
-    'DROP' 'DATABASE' ('IF EXISTS')? database_name
+    'DROP' 'DATABASE' ('IF EXISTS')? database_name ('CASCADE' | 'RESTRICT')?
 drop_index ::=
     'DROP' 'INDEX' ('IF EXISTS')? index_name ('CASCADE' | 'RESTRICT')?
 drop_role ::=

--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -2568,22 +2568,6 @@ impl SessionCatalog for ConnCatalog<'_> {
             .resolve_function(&self.database, self.search_path, name, self.conn_id)?)
     }
 
-    fn list_items<'a>(
-        &'a self,
-        schema: &SchemaName,
-    ) -> Box<dyn Iterator<Item = &'a dyn sql::catalog::CatalogItem> + 'a> {
-        let schema = self
-            .catalog
-            .get_schema(&schema.database, &schema.schema, self.conn_id)
-            .unwrap();
-        Box::new(
-            schema
-                .items
-                .values()
-                .map(move |id| self.catalog.get_by_id(id) as &dyn sql::catalog::CatalogItem),
-        )
-    }
-
     fn try_get_item_by_id(&self, id: &GlobalId) -> Option<&dyn sql::catalog::CatalogItem> {
         self.catalog
             .try_get_by_id(*id)
@@ -2675,6 +2659,10 @@ impl sql::catalog::CatalogSchema for Schema {
 
     fn id(&self) -> i64 {
         self.id
+    }
+
+    fn has_items(&self) -> bool {
+        !self.items.is_empty()
     }
 }
 

--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -2568,16 +2568,6 @@ impl SessionCatalog for ConnCatalog<'_> {
             .resolve_function(&self.database, self.search_path, name, self.conn_id)?)
     }
 
-    fn database_has_schemas(&self, database: &str) -> bool {
-        !self
-            .catalog
-            .by_name
-            .get(database)
-            .unwrap()
-            .schemas
-            .is_empty()
-    }
-
     fn list_items<'a>(
         &'a self,
         schema: &SchemaName,
@@ -2671,6 +2661,10 @@ impl sql::catalog::CatalogDatabase for Database {
 
     fn id(&self) -> i64 {
         self.id
+    }
+
+    fn has_schemas(&self) -> bool {
+        !self.schemas.is_empty()
     }
 }
 

--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -2568,6 +2568,16 @@ impl SessionCatalog for ConnCatalog<'_> {
             .resolve_function(&self.database, self.search_path, name, self.conn_id)?)
     }
 
+    fn database_has_schemas(&self, database: &str) -> bool {
+        !self
+            .catalog
+            .by_name
+            .get(database)
+            .unwrap()
+            .schemas
+            .is_empty()
+    }
+
     fn list_items<'a>(
         &'a self,
         schema: &SchemaName,

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -904,7 +904,7 @@ impl_display!(DiscardTarget);
 pub struct DropDatabaseStatement {
     pub name: Ident,
     pub if_exists: bool,
-    pub cascade: bool,
+    pub restrict: bool,
 }
 
 impl AstDisplay for DropDatabaseStatement {
@@ -914,8 +914,8 @@ impl AstDisplay for DropDatabaseStatement {
             f.write_str("IF EXISTS ");
         }
         f.write_node(&self.name);
-        if self.cascade {
-            f.write_str(" CASCADE");
+        if self.restrict {
+            f.write_str(" RESTRICT");
         }
     }
 }

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -904,6 +904,7 @@ impl_display!(DiscardTarget);
 pub struct DropDatabaseStatement {
     pub name: Ident,
     pub if_exists: bool,
+    pub cascade: bool,
 }
 
 impl AstDisplay for DropDatabaseStatement {
@@ -913,6 +914,9 @@ impl AstDisplay for DropDatabaseStatement {
             f.write_str("IF EXISTS ");
         }
         f.write_node(&self.name);
+        if self.cascade {
+            f.write_str(" CASCADE");
+        }
     }
 }
 impl_display!(DropDatabaseStatement);

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2218,9 +2218,22 @@ impl<'a> Parser<'a> {
             DATABASE, INDEX, ROLE, SCHEMA, SINK, SOURCE, TABLE, TYPE, USER, VIEW,
         ]) {
             Some(DATABASE) => {
+                let if_exists = self.parse_if_exists()?;
+                let name = self.parse_identifier()?;
+                let cascade = self.parse_keyword(CASCADE);
+                let restrict = self.parse_keyword(RESTRICT);
+                let restrict_pos = self.peek_prev_pos();
+                if cascade && restrict {
+                    return parser_err!(
+                        self,
+                        restrict_pos,
+                        "Cannot specify both CASCADE and RESTRICT in DROP"
+                    );
+                }
                 return Ok(Statement::DropDatabase(DropDatabaseStatement {
-                    if_exists: self.parse_if_exists()?,
-                    name: self.parse_identifier()?,
+                    if_exists,
+                    name,
+                    cascade: !restrict,
                 }));
             }
             Some(INDEX) => ObjectType::Index,

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1307,7 +1307,12 @@ impl<'a> Parser<'a> {
     ) -> Result<Option<Keyword>, ParserError> {
         match self.parse_one_of_keywords(keywords) {
             Some(first) => {
-                if let Some(second) = self.parse_one_of_keywords(keywords) {
+                let remaining_keywords = keywords
+                    .iter()
+                    .cloned()
+                    .filter(|k| *k != first)
+                    .collect::<Vec<_>>();
+                if let Some(second) = self.parse_one_of_keywords(remaining_keywords.as_slice()) {
                     let second_pos = self.peek_prev_pos();
                     parser_err!(
                         self,

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2222,11 +2222,13 @@ impl<'a> Parser<'a> {
                 let name = self.parse_identifier()?;
                 let cascade = self.parse_keyword(CASCADE);
                 let restrict = self.parse_keyword(RESTRICT);
-                let restrict_pos = self.peek_prev_pos();
+                // Catch them in either order
+                let cascade = cascade || self.parse_keyword(CASCADE);
+                let second_pos = self.peek_prev_pos();
                 if cascade && restrict {
                     return parser_err!(
                         self,
-                        restrict_pos,
+                        second_pos,
                         "Cannot specify both CASCADE and RESTRICT in DROP"
                     );
                 }
@@ -2258,11 +2260,13 @@ impl<'a> Parser<'a> {
         let names = self.parse_comma_separated(Parser::parse_object_name)?;
         let cascade = self.parse_keyword(CASCADE);
         let restrict = self.parse_keyword(RESTRICT);
-        let restrict_pos = self.peek_prev_pos();
+        // Catch them in either order
+        let cascade = cascade || self.parse_keyword(CASCADE);
+        let second_pos = self.peek_prev_pos();
         if cascade && restrict {
             return parser_err!(
                 self,
-                restrict_pos,
+                second_pos,
                 "Cannot specify both CASCADE and RESTRICT in DROP"
             );
         }

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -933,7 +933,7 @@ DROP DATABASE mydb CASCADE RESTRICT
 parse-statement
 DROP DATABASE mydb RESTRICT CASCADE
 ----
-error: Expected end of statement, found CASCADE
+error: Cannot specify both CASCADE and RESTRICT in DROP
 DROP DATABASE mydb RESTRICT CASCADE
                             ^
 

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -891,16 +891,16 @@ CREATE INDEX IF EXISTS myschema.ind ON foo(b)
 parse-statement
 DROP DATABASE mydb
 ----
-DROP DATABASE mydb
+DROP DATABASE mydb CASCADE
 =>
-DropDatabase(DropDatabaseStatement { name: Ident("mydb"), if_exists: false })
+DropDatabase(DropDatabaseStatement { name: Ident("mydb"), if_exists: false, cascade: true })
 
 parse-statement
 DROP DATABASE IF EXISTS mydb
 ----
-DROP DATABASE IF EXISTS mydb
+DROP DATABASE IF EXISTS mydb CASCADE
 =>
-DropDatabase(DropDatabaseStatement { name: Ident("mydb"), if_exists: true })
+DropDatabase(DropDatabaseStatement { name: Ident("mydb"), if_exists: true, cascade: true })
 
 parse-statement
 DROP DATABASE mydb.nope
@@ -908,6 +908,34 @@ DROP DATABASE mydb.nope
 error: Expected end of statement, found dot
 DROP DATABASE mydb.nope
                   ^
+
+parse-statement
+DROP DATABASE mydb CASCADE
+----
+DROP DATABASE mydb CASCADE
+=>
+DropDatabase(DropDatabaseStatement { name: Ident("mydb"), if_exists: false, cascade: true })
+
+parse-statement
+DROP DATABASE mydb RESTRICT
+----
+DROP DATABASE mydb
+=>
+DropDatabase(DropDatabaseStatement { name: Ident("mydb"), if_exists: false, cascade: false })
+
+parse-statement
+DROP DATABASE mydb CASCADE RESTRICT
+----
+error: Cannot specify both CASCADE and RESTRICT in DROP
+DROP DATABASE mydb CASCADE RESTRICT
+                           ^
+
+parse-statement
+DROP DATABASE mydb RESTRICT CASCADE
+----
+error: Expected end of statement, found CASCADE
+DROP DATABASE mydb RESTRICT CASCADE
+                            ^
 
 parse-statement
 DROP SCHEMA mydb.myschema

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -891,16 +891,16 @@ CREATE INDEX IF EXISTS myschema.ind ON foo(b)
 parse-statement
 DROP DATABASE mydb
 ----
-DROP DATABASE mydb CASCADE
+DROP DATABASE mydb
 =>
-DropDatabase(DropDatabaseStatement { name: Ident("mydb"), if_exists: false, cascade: true })
+DropDatabase(DropDatabaseStatement { name: Ident("mydb"), if_exists: false, restrict: false })
 
 parse-statement
 DROP DATABASE IF EXISTS mydb
 ----
-DROP DATABASE IF EXISTS mydb CASCADE
+DROP DATABASE IF EXISTS mydb
 =>
-DropDatabase(DropDatabaseStatement { name: Ident("mydb"), if_exists: true, cascade: true })
+DropDatabase(DropDatabaseStatement { name: Ident("mydb"), if_exists: true, restrict: false })
 
 parse-statement
 DROP DATABASE mydb.nope
@@ -912,16 +912,16 @@ DROP DATABASE mydb.nope
 parse-statement
 DROP DATABASE mydb CASCADE
 ----
-DROP DATABASE mydb CASCADE
+DROP DATABASE mydb
 =>
-DropDatabase(DropDatabaseStatement { name: Ident("mydb"), if_exists: false, cascade: true })
+DropDatabase(DropDatabaseStatement { name: Ident("mydb"), if_exists: false, restrict: false })
 
 parse-statement
 DROP DATABASE mydb RESTRICT
 ----
-DROP DATABASE mydb
+DROP DATABASE mydb RESTRICT
 =>
-DropDatabase(DropDatabaseStatement { name: Ident("mydb"), if_exists: false, cascade: false })
+DropDatabase(DropDatabaseStatement { name: Ident("mydb"), if_exists: false, restrict: true })
 
 parse-statement
 DROP DATABASE mydb CASCADE RESTRICT
@@ -933,7 +933,7 @@ DROP DATABASE mydb CASCADE RESTRICT
 parse-statement
 DROP DATABASE mydb RESTRICT CASCADE
 ----
-error: Cannot specify both CASCADE and RESTRICT in DROP
+error: Cannot specify both RESTRICT and CASCADE in DROP
 DROP DATABASE mydb RESTRICT CASCADE
                             ^
 

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -938,6 +938,13 @@ DROP DATABASE mydb RESTRICT CASCADE
                             ^
 
 parse-statement
+DROP DATABASE mydb CASCADE CASCADE
+----
+error: Expected end of statement, found CASCADE
+DROP DATABASE mydb CASCADE CASCADE
+                           ^
+
+parse-statement
 DROP SCHEMA mydb.myschema
 ----
 DROP SCHEMA mydb.myschema

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -117,11 +117,6 @@ pub trait SessionCatalog: fmt::Debug + ExprHumanizer {
         schema: &SchemaName,
     ) -> Box<dyn Iterator<Item = &'a dyn CatalogItem> + 'a>;
 
-    /// Reports whether the specificied database contains any schemas.
-    ///
-    /// Panics if `database` does not specify a valid database.
-    fn database_has_schemas(&self, database: &str) -> bool;
-
     /// Gets an item by its ID.
     fn try_get_item_by_id(&self, id: &GlobalId) -> Option<&dyn CatalogItem>;
 
@@ -207,6 +202,9 @@ pub trait CatalogDatabase {
 
     /// Returns a stable ID for the database.
     fn id(&self) -> i64;
+
+    /// Returns whether the database contains schemas.
+    fn has_schemas(&self) -> bool;
 }
 
 /// A schema in a [`SessionCatalog`].
@@ -434,10 +432,6 @@ impl SessionCatalog for DummyCatalog {
         &'a self,
         _: &SchemaName,
     ) -> Box<dyn Iterator<Item = &'a dyn CatalogItem> + 'a> {
-        unimplemented!();
-    }
-
-    fn database_has_schemas(&self, _: &str) -> bool {
         unimplemented!();
     }
 

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -46,7 +46,7 @@ use crate::plan::statement::StatementDesc;
 ///     components based upon connection defaults, e.g., resolving the partial
 ///     name `view42` to the fully-specified name `materialize.public.view42`.
 ///
-///   * Lookup operations, like [`SessionCatalog::list_items`] or [`SessionCatalog::get_item_by_id`]. These retrieve
+///   * Lookup operations, like [`SessionCatalog::get_item_by_id`]. These retrieve
 ///     metadata about a catalog entity based on a fully-specified name that is
 ///     known to be valid (i.e., because the name was successfully resolved,
 ///     or was constructed based on the output of a prior lookup operation).

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -117,6 +117,11 @@ pub trait SessionCatalog: fmt::Debug + ExprHumanizer {
         schema: &SchemaName,
     ) -> Box<dyn Iterator<Item = &'a dyn CatalogItem> + 'a>;
 
+    /// Reports whether the specificied database contains any schemas.
+    ///
+    /// Panics if `database` does not specify a valid database.
+    fn database_has_schemas(&self, database: &str) -> bool;
+
     /// Gets an item by its ID.
     fn try_get_item_by_id(&self, id: &GlobalId) -> Option<&dyn CatalogItem>;
 
@@ -429,6 +434,10 @@ impl SessionCatalog for DummyCatalog {
         &'a self,
         _: &SchemaName,
     ) -> Box<dyn Iterator<Item = &'a dyn CatalogItem> + 'a> {
+        unimplemented!();
+    }
+
+    fn database_has_schemas(&self, _: &str) -> bool {
         unimplemented!();
     }
 

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -109,14 +109,6 @@ pub trait SessionCatalog: fmt::Debug + ExprHumanizer {
     /// functions within the catalog.
     fn resolve_function(&self, item_name: &PartialName) -> Result<&dyn CatalogItem, CatalogError>;
 
-    /// Lists the items in the specified schema in the specified database.
-    ///
-    /// Panics if `schema_name` does not specify a valid schema.
-    fn list_items<'a>(
-        &'a self,
-        schema: &SchemaName,
-    ) -> Box<dyn Iterator<Item = &'a dyn CatalogItem> + 'a>;
-
     /// Gets an item by its ID.
     fn try_get_item_by_id(&self, id: &GlobalId) -> Option<&dyn CatalogItem>;
 
@@ -214,6 +206,9 @@ pub trait CatalogSchema {
 
     /// Returns a stable ID for the schema.
     fn id(&self) -> i64;
+
+    /// Lists the `CatalogItem`s for the schema.
+    fn has_items(&self) -> bool;
 }
 
 /// A role in a [`SessionCatalog`].
@@ -425,13 +420,6 @@ impl SessionCatalog for DummyCatalog {
     }
 
     fn resolve_function(&self, _: &PartialName) -> Result<&dyn CatalogItem, CatalogError> {
-        unimplemented!();
-    }
-
-    fn list_items<'a>(
-        &'a self,
-        _: &SchemaName,
-    ) -> Box<dyn Iterator<Item = &'a dyn CatalogItem> + 'a> {
         unimplemented!();
     }
 

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2154,7 +2154,7 @@ pub fn plan_drop_database(
     let name = match scx.resolve_database_ident(name) {
         Ok(database) => {
             let name = String::from(database.name());
-            if restrict && scx.catalog.database_has_schemas(&name) {
+            if restrict && database.has_schemas() {
                 bail!(
                     "database '{}' cannot be dropped with RESTRICT while it contains schemas",
                     database.name(),

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2228,8 +2228,7 @@ pub fn plan_drop_schema(
                     schema.name()
                 );
             }
-            let mut items = scx.catalog.list_items(schema.name());
-            if !cascade && items.next().is_some() {
+            if !cascade && schema.has_items() {
                 bail!(
                     "schema '{}' cannot be dropped without CASCADE while it contains objects",
                     schema.name(),

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2148,15 +2148,15 @@ pub fn plan_drop_database(
     DropDatabaseStatement {
         name,
         if_exists,
-        cascade,
+        restrict,
     }: DropDatabaseStatement,
 ) -> Result<Plan, anyhow::Error> {
     let name = match scx.resolve_database_ident(name) {
         Ok(database) => {
             let name = String::from(database.name());
-            if !cascade && scx.catalog.database_has_schemas(&name) {
+            if restrict && scx.catalog.database_has_schemas(&name) {
                 bail!(
-                    "database '{}' cannot be dropped without CASCADE while it contains schemas",
+                    "database '{}' cannot be dropped with RESTRICT while it contains schemas",
                     database.name(),
                 );
             }

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -199,7 +199,7 @@ v2_primary_idx  user
 
 # DROP DATABASE does not support both RESTRICT and CASCADE.
 ! DROP DATABASE d RESTRICT CASCADE
-Expected end of statement, found CASCADE
+Cannot specify both CASCADE and RESTRICT in DROP
 ! DROP DATABASE d CASCADE RESTRICT
 Cannot specify both CASCADE and RESTRICT in DROP
 

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -197,11 +197,14 @@ v1_primary_idx  user
 v2              user
 v2_primary_idx  user
 
-# DROP DATABASE should not support RESTRICT or CASCADE.
+# DROP DATABASE does not support both RESTRICT and CASCADE.
+! DROP DATABASE d RESTRICT CASCADE
+Expected end of statement, found CASCADE
+! DROP DATABASE d CASCADE RESTRICT
+Cannot specify both CASCADE and RESTRICT in DROP
+
 ! DROP DATABASE d RESTRICT
-Expected end of statement, found RESTRICT
-! DROP DATABASE d RESTRICT
-Expected end of statement, found RESTRICT
+database 'd' cannot be dropped without CASCADE while it contains schemas
 
 # DROP DATABASE should succeed even when there are objects in the database.
 > DROP DATABASE d

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -202,6 +202,8 @@ v2_primary_idx  user
 Cannot specify both RESTRICT and CASCADE in DROP
 ! DROP DATABASE d CASCADE RESTRICT
 Cannot specify both CASCADE and RESTRICT in DROP
+! DROP DATABASE d CASCADE CASCADE
+Expected end of statement, found CASCADE
 
 ! DROP DATABASE d RESTRICT
 database 'd' cannot be dropped with RESTRICT while it contains schemas

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -199,12 +199,12 @@ v2_primary_idx  user
 
 # DROP DATABASE does not support both RESTRICT and CASCADE.
 ! DROP DATABASE d RESTRICT CASCADE
-Cannot specify both CASCADE and RESTRICT in DROP
+Cannot specify both RESTRICT and CASCADE in DROP
 ! DROP DATABASE d CASCADE RESTRICT
 Cannot specify both CASCADE and RESTRICT in DROP
 
 ! DROP DATABASE d RESTRICT
-database 'd' cannot be dropped without CASCADE while it contains schemas
+database 'd' cannot be dropped with RESTRICT while it contains schemas
 
 # DROP DATABASE should succeed even when there are objects in the database.
 > DROP DATABASE d


### PR DESCRIPTION
### Motivation
Fixes https://github.com/MaterializeInc/materialize/issues/2168
<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug. [Link to issue.]

  * This PR adds a known-desirable feature. [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

### Description
Add ability to use the `RESTRICT` or `CASCADE` keywords in a `DROP DATABASE` statement.  This retains `CASCADE` as the default behavior.
<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details."

-->

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [x] This PR has adequate test coverage.
- [x] This PR adds a release note for any user-facing behavior changes.
