### PR TITLE
coord: verify prepared statements on use

### DIFF
--- a/src/coord/src/command.rs
+++ b/src/coord/src/command.rs
@@ -51,6 +51,12 @@ pub enum Command {
         tx: oneshot::Sender<Response<()>>,
     },
 
+    VerifyPreparedStatement {
+        name: String,
+        session: Session,
+        tx: oneshot::Sender<Response<()>>,
+    },
+
     Execute {
         portal_name: String,
         session: Session,

--- a/src/coord/src/error.rs
+++ b/src/coord/src/error.rs
@@ -29,6 +29,8 @@ pub enum CoordError {
     },
     /// An error occurred in a catalog operation.
     Catalog(catalog::Error),
+    /// The cached plan or descriptor changed.
+    ChangedPlan,
     /// The specified session parameter is constrained to its current value.
     ConstrainedParameter(&'static (dyn Var + Send + Sync)),
     /// The cursor already exists.
@@ -215,6 +217,7 @@ impl fmt::Display for CoordError {
             CoordError::AutomaticTimestampFailure { .. } => {
                 f.write_str("unable to automatically determine a query timestamp")
             }
+            CoordError::ChangedPlan => f.write_str("cached plan must not change result type"),
             CoordError::Catalog(e) => e.fmt(f),
             CoordError::ConstrainedParameter(p) => write!(
                 f,

--- a/src/coord/src/session.rs
+++ b/src/coord/src/session.rs
@@ -239,8 +239,22 @@ impl Session {
     }
 
     /// Retrieves the prepared statement associated with `name`.
-    pub fn get_prepared_statement(&self, name: &str) -> Option<&PreparedStatement> {
+    ///
+    /// This is unverified and could be incorrect if the underlying catalog has
+    /// changed.
+    pub fn get_prepared_statement_unverified(&self, name: &str) -> Option<&PreparedStatement> {
         self.prepared_statements.get(name)
+    }
+
+    /// Retrieves the prepared statement associated with `name`.
+    ///
+    /// This is unverified and could be incorrect if the underlying catalog has
+    /// changed.
+    pub fn get_prepared_statement_mut_unverified(
+        &mut self,
+        name: &str,
+    ) -> Option<&mut PreparedStatement> {
+        self.prepared_statements.get_mut(name)
     }
 
     /// Returns the prepared statements for the session.
@@ -384,12 +398,22 @@ impl Session {
 pub struct PreparedStatement {
     sql: Option<Statement<Raw>>,
     desc: StatementDesc,
+    /// The most recent catalog revision that has verified this statement.
+    pub catalog_revision: u64,
 }
 
 impl PreparedStatement {
     /// Constructs a new prepared statement.
-    pub fn new(sql: Option<Statement<Raw>>, desc: StatementDesc) -> PreparedStatement {
-        PreparedStatement { sql, desc }
+    pub fn new(
+        sql: Option<Statement<Raw>>,
+        desc: StatementDesc,
+        catalog_revision: u64,
+    ) -> PreparedStatement {
+        PreparedStatement {
+            sql,
+            desc,
+            catalog_revision,
+        }
     }
 
     /// Returns the raw SQL string associated with this prepared statement,

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -341,6 +341,7 @@ impl ErrorResponse {
         let code = match e {
             CoordError::InvalidAlterOnDisabledIndex(_) => SqlState::INTERNAL_ERROR,
             CoordError::Catalog(_) => SqlState::INTERNAL_ERROR,
+            CoordError::ChangedPlan => SqlState::FEATURE_NOT_SUPPORTED,
             CoordError::ConstrainedParameter(_) => SqlState::INVALID_PARAMETER_VALUE,
             CoordError::AutomaticTimestampFailure { .. } => SqlState::INTERNAL_ERROR,
             CoordError::DuplicateCursor(_) => SqlState::DUPLICATE_CURSOR,

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -38,7 +38,7 @@ mod show;
 mod tcl;
 
 /// Describes the output of a SQL statement.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct StatementDesc {
     /// The shape of the rows produced by the statement, if the statement
     /// produces rows.

--- a/test/pgtest/desc.pt
+++ b/test/pgtest/desc.pt
@@ -1,0 +1,113 @@
+# Test that prepared statement describe works if the underlying SQL object is
+# replaced.
+
+send
+Query {"query": "CREATE TABLE t (a INT)"}
+Parse {"name": "q", "query": "SELECT * FROM t"}
+Describe {"variant": "S", "name": "q"}
+Sync
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+----
+CommandComplete {"tag":"CREATE TABLE"}
+ReadyForQuery {"status":"I"}
+ParseComplete
+ParameterDescription {"parameters":[]}
+RowDescription {"fields":[{"name":"a"}]}
+ReadyForQuery {"status":"I"}
+
+# Recreating the underlying object is fine.
+send
+Query {"query": "DROP TABLE t"}
+Query {"query": "CREATE TABLE t (a INT)"}
+Describe {"variant": "S", "name": "q"}
+Sync
+Query {"query": "EXECUTE q"}
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+CommandComplete {"tag":"DROP TABLE"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"CREATE TABLE"}
+ReadyForQuery {"status":"I"}
+ParameterDescription {"parameters":[]}
+RowDescription {"fields":[{"name":"a"}]}
+ReadyForQuery {"status":"I"}
+RowDescription {"fields":[{"name":"a"}]}
+CommandComplete {"tag":"SELECT 0"}
+ReadyForQuery {"status":"I"}
+
+# But changing it will break the prepared statement.
+send
+Query {"query": "DROP TABLE t"}
+Query {"query": "CREATE TABLE t (c INT, b INT)"}
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+----
+CommandComplete {"tag":"DROP TABLE"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"CREATE TABLE"}
+ReadyForQuery {"status":"I"}
+
+send
+Describe {"variant": "S", "name": "q"}
+Sync
+----
+
+# Postgres sends a ParameterDescription, but that seems wrong, so ignore it and
+# just look for the error.
+until ignore=ParameterDescription
+ReadyForQuery
+----
+ErrorResponse {"fields":[{"typ":"C","value":"0A000"},{"typ":"M","value":"cached plan must not change result type"}]}
+ReadyForQuery {"status":"I"}
+
+send
+Query {"query": "EXECUTE q"}
+----
+
+# TODO(mjibson): We send a RowDescription before the error. This isn't wrong
+# (feels about as wrong as Postgres sending ParameterDescription above), it's
+# just not what Postgres does, so ignore it to be in sync with them.
+until ignore=RowDescription
+ReadyForQuery
+----
+ErrorResponse {"fields":[{"typ":"C","value":"0A000"},{"typ":"M","value":"cached plan must not change result type"}]}
+ReadyForQuery {"status":"I"}
+
+# Changing it back fixes it.
+send
+Query {"query": "DROP TABLE t"}
+Query {"query": "CREATE TABLE t (a INT)"}
+Describe {"variant": "S", "name": "q"}
+Sync
+Query {"query": "EXECUTE q"}
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+CommandComplete {"tag":"DROP TABLE"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"CREATE TABLE"}
+ReadyForQuery {"status":"I"}
+ParameterDescription {"parameters":[]}
+RowDescription {"fields":[{"name":"a"}]}
+ReadyForQuery {"status":"I"}
+RowDescription {"fields":[{"name":"a"}]}
+CommandComplete {"tag":"SELECT 0"}
+ReadyForQuery {"status":"I"}

--- a/test/pgtest/prepare.pt
+++ b/test/pgtest/prepare.pt
@@ -131,29 +131,50 @@ ReadyForQuery {"status":"I"}
 CommandComplete {"tag":"DEALLOCATE"}
 ReadyForQuery {"status":"I"}
 
-# TODO(mjibson): Fix #8397.
-#send
-#Query {"query": "CREATE TABLE t (i INT)"}
-#Query {"query": "INSERT INTO t VALUES (1)"}
-#Query {"query": "PREPARE a AS SELECT * FROM t"}
-#Query {"query": "EXECUTE a"}
-#Query {"query": "DROP TABLE t"}
-#Query {"query": "EXECUTE a"}
-#Query {"query": "CREATE TABLE t (a TEXT, b FLOAT)"}
-#Query {"query": "INSERT INTO t VALUES ('a', 3)"}
-#Query {"query": "EXECUTE a"}
-#Query {"query": "DEALLOCATE a"}
-#----
-#
-#until
-#ReadyForQuery
-#ReadyForQuery
-#ReadyForQuery
-#ReadyForQuery
-#ReadyForQuery
-#ReadyForQuery
-#ReadyForQuery
-#ReadyForQuery
-#ReadyForQuery
-#ReadyForQuery
-#----
+send
+Query {"query": "CREATE TABLE t (i INT)"}
+Query {"query": "INSERT INTO t VALUES (1)"}
+Query {"query": "PREPARE a AS SELECT * FROM t"}
+Query {"query": "EXECUTE a"}
+Query {"query": "DROP TABLE t"}
+Query {"query": "EXECUTE a"}
+Query {"query": "CREATE TABLE t (a TEXT, b FLOAT)"}
+Query {"query": "INSERT INTO t VALUES ('a', 3)"}
+Query {"query": "EXECUTE a"}
+Query {"query": "DEALLOCATE a"}
+----
+
+# TODO(mjibson): Ignore RowDescription here, see desc.pt for why.
+until no_error_fields ignore=RowDescription
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+CommandComplete {"tag":"CREATE TABLE"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"INSERT 0 1"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"PREPARE"}
+ReadyForQuery {"status":"I"}
+DataRow {"fields":["1"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"DROP TABLE"}
+ReadyForQuery {"status":"I"}
+ErrorResponse {"fields":[]}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"CREATE TABLE"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"INSERT 0 1"}
+ReadyForQuery {"status":"I"}
+ErrorResponse {"fields":[]}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"DEALLOCATE"}
+ReadyForQuery {"status":"I"}


### PR DESCRIPTION
### Motivation

  * This PR fixes a recognized bug. #8397

  * This PR fixes a previously unreported bug.

    pgwire Describe messages assumed a transaction but it was not guaranteed to have been started.

### Description

Previously we would cache the StatementDesc and assume it didn't
change. Add some new APIs (and a forced trip through coord) to do the
re-verification. Use the catalog version as an optimization, allowing
us to ignore checking because we know it's still valid.

While testing this some panics were found in the pgwire Describe path
which assumed a transaction had started when it hadn't.

### Checklist

- [x] This PR has adequate test coverage.
- [x] This PR adds a release note for any user-facing behavior changes.
