### PR TITLE
coord: add indisprimary and indkey to pg_index

### DIFF
--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -1244,10 +1244,14 @@ pub const PG_INDEX: BuiltinView = BuiltinView {
     name: "pg_index",
     schema: PG_CATALOG_SCHEMA,
     sql: "CREATE VIEW pg_index AS SELECT
-    mz_indexes.oid as indexrelid,
-    mz_objects.oid as indrelid
+    mz_indexes.oid AS indexrelid,
+    mz_objects.oid AS indrelid,
+    false::pg_catalog.bool AS indisprimary,
+    pg_catalog.array_agg(mz_index_columns.on_position ORDER BY mz_index_columns.index_position) AS indkey
 FROM mz_catalog.mz_indexes
-JOIN mz_catalog.mz_objects ON mz_indexes.on_id = mz_objects.id",
+JOIN mz_catalog.mz_objects ON mz_indexes.on_id = mz_objects.id
+JOIN mz_catalog.mz_index_columns ON mz_index_columns.index_id = mz_indexes.id
+GROUP BY mz_indexes.oid, mz_objects.oid",
     id: GlobalId::System(5017),
     needs_logs: false,
 };

--- a/test/testdrive/pg-catalog.td
+++ b/test/testdrive/pg-catalog.td
@@ -36,10 +36,12 @@ name         nullable  type
  datacl      true      text[]
 
 > SHOW COLUMNS FROM pg_index
-name        nullable  type
+name         nullable  type
 --------------------------
-indexrelid  false     oid
-indrelid    false     oid
+indexrelid   false     oid
+indrelid     false     oid
+indisprimary false     boolean
+indkey       true      bigint[]
 
 > SHOW COLUMNS FROM pg_description
 name         nullable  type


### PR DESCRIPTION
### Motivation

  * This PR adds a feature that has not yet been specified.

    pg_index was missing some columns needed by pgjdbc.

### Description

Add some pg_index columns used by pgjdbc. We can use the new array_agg and order by features!

### Checklist

- [ ] This PR has adequate test coverage.
- [ ] This PR adds a release note for any user-facing behavior changes.
