### PR TITLE
sql: scalar window functions

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -129,6 +129,8 @@ List new features before bug fixes.
 
 - Fix a bug that caused a panic when using a query containing `STRING_AGG`
 
+- Support the `row_number` window function.
+
 {{% version-header v0.9.11 %}}
 
 - Disallow `UPDATE` and `DELETE` operations on tables when boot in

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -535,6 +535,12 @@
         Computes a hashed MAC of the given bytea `data` using the specified `key` and
         `type` algorithm. The supported hash algorithms are the same as for `digest`.
 
+- type: Window
+  description: Window functions perform calculations across sets of rows that are related to the current query.
+  functions:
+  - signature: 'row_number() -> int'
+    description: Returns the number of the current row within its partition, counting from 1.
+
 - type: System information
   description: Functions that return information about the system
   functions:

--- a/src/dataflow/src/render/reduce.rs
+++ b/src/dataflow/src/render/reduce.rs
@@ -1897,7 +1897,8 @@ fn reduction_type(func: &AggregateFunc) -> ReductionType {
         | AggregateFunc::JsonbObjectAgg { .. }
         | AggregateFunc::ArrayConcat { .. }
         | AggregateFunc::ListConcat { .. }
-        | AggregateFunc::StringAgg { .. } => ReductionType::Basic,
+        | AggregateFunc::StringAgg { .. }
+        | AggregateFunc::RowNumber { .. } => ReductionType::Basic,
     }
 }
 
@@ -2016,7 +2017,8 @@ pub mod monoids {
             | AggregateFunc::JsonbObjectAgg { .. }
             | AggregateFunc::ArrayConcat { .. }
             | AggregateFunc::ListConcat { .. }
-            | AggregateFunc::StringAgg { .. } => None,
+            | AggregateFunc::StringAgg { .. }
+            | AggregateFunc::RowNumber { .. } => None,
         }
     }
 }

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -34,6 +34,7 @@ use lowertest::MzEnumReflect;
 use ore::collections::CollectionExt;
 use ore::fmt::FormatBuffer;
 use ore::result::ResultExt;
+use ore::soft_assert;
 use ore::str::StrExt;
 use pgrepr::Type;
 use repr::adt::array::ArrayDimension;
@@ -5751,7 +5752,7 @@ impl VariadicFunc {
             }
             ArrayToString { .. } => ScalarType::String.nullable(true),
             ListCreate { elem_type } => {
-                debug_assert!(
+                soft_assert!(
                     input_types.iter().all(|t| t.scalar_type.base_eq(elem_type)),
                     "Args to ListCreate should have types that are compatible with the elem_type"
                 );

--- a/test/sqllogictest/aggregates.slt
+++ b/test/sqllogictest/aggregates.slt
@@ -243,7 +243,7 @@ query error Expected end of statement, found left parenthesis
 SELECT column1 FILTER (WHERE column1 = 1) FROM (VALUES (1))
 
 query error aggregate functions are not allowed in FILTER
-SELECT v, count(*) FILTER (WHERE count(*) > 5) FROM filter_test GROUP BY v
+SELECT v, count(*) FILTER (WHERE count(1) > 5) FROM filter_test GROUP BY v
 
 # These filter tests are Materialize-specific.
 

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -1,0 +1,153 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# This test may seem simple, but it is surprisingly good at verifying that
+# logical timestamp handling for internal inputs is sane.
+
+mode cockroach
+
+statement error window function row_number requires an OVER clause
+WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
+SELECT row_number() FROM t
+
+statement error aggregate window functions not yet supported
+WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
+SELECT array_agg(x) OVER () FROM t
+
+query IT
+WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
+SELECT row_number() OVER (ORDER BY x), x FROM t
+ORDER BY row_number
+----
+1  a
+2  b
+3  c
+
+query IT
+WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
+SELECT row_number() OVER (ORDER BY x DESC), x FROM t
+ORDER BY row_number
+----
+1  c
+2  b
+3  a
+
+query IT
+WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
+SELECT row_number() OVER (PARTITION BY y ORDER BY x), x FROM t
+ORDER BY row_number, x
+----
+1  a
+1  b
+2  c
+
+query IT
+WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
+SELECT row_number() OVER (PARTITION BY y ORDER BY x DESC), x FROM t
+ORDER BY row_number, x
+----
+1  b
+1  c
+2  a
+
+query IT
+WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
+SELECT row_number() OVER (PARTITION BY x ORDER BY x), x FROM t
+ORDER BY row_number, x
+----
+1  a
+1  b
+1  c
+
+query IT
+WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
+SELECT row_number() OVER (PARTITION BY NULL ORDER BY 10000) AS q, a1.x
+FROM t AS a1, t AS a2
+ORDER BY q DESC
+----
+9  c
+8  c
+7  c
+6  b
+5  b
+4  b
+3  a
+2  a
+1  a
+
+# Make sure a non-column expression following the window function is correctly
+# handled.
+query ITT
+WITH t (x) AS (VALUES ('a'))
+SELECT row_number() OVER (PARTITION BY NULL) AS q, x, 'b'
+FROM t
+----
+1 a b
+
+# Blocked on #8963
+#query II
+#SELECT row_number() OVER (), row_number() OVER ()
+#----
+#1 1
+
+# Blocked on #8963
+#query II
+#WITH t (x) AS (VALUES ('a'), ('b'))
+#SELECT row_number() OVER (), row_number() OVER () from t
+#----
+#1 1
+#2 2
+
+query T multiline
+EXPLAIN RAW PLAN FOR
+WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
+SELECT row_number() OVER (PARTITION BY x ORDER BY x), x FROM t
+ORDER BY row_number, x
+----
+%0 =
+| CallTable wrap2("a", 1, "b", 2, "c", 1)
+| Map row_number() over (#0) order by (#0)
+| Project (#2, #0)
+
+Finish order_by=(#0 asc, #1 asc) limit=none offset=0 project=(#0, #1)
+
+EOF
+
+query T multiline
+EXPLAIN DECORRELATED PLAN FOR
+WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
+SELECT row_number() OVER (PARTITION BY x ORDER BY x), x FROM t
+ORDER BY row_number, x
+----
+%0 = Let l0 =
+| Constant ()
+
+%1 = Let l1 =
+| Get %0 (l0)
+| FlatMap wrap2("a", 1, "b", 2, "c", 1)
+
+%2 = Let l2 =
+| Get %1 (l1)
+
+%3 =
+| Get %2 (l2)
+| Reduce group=(#0)
+| | agg row_number(record_create(list_create(record_create(#0, #1)), #0))
+| FlatMap unnest_list(#1)
+| Map record_get[0](record_get[1](#2))
+| Map record_get[1](record_get[1](#2))
+| Map record_get[0](#2)
+| Project (#3..#5)
+| Map #2
+| Project (#0, #1, #3)
+| Project (#2, #0)
+
+Finish order_by=(#0 asc, #1 asc) limit=none offset=0 project=(#0, #1)
+
+EOF


### PR DESCRIPTION
Add support for scalar window functions, starting with `row_number`. These are implemented using aggregate functions, and share the non-incremental performance of the `_agg` functions, and are thus discouraged from use in dataflows. The current goal of these is to support pgjdbc, but we now have a framework for easily adding other scalar window functions. Aggregate window functions should also be achievable now.

Partial support for #213
Informs #4471
Informs #3727

### Motivation

  * This PR adds a known-desirable feature. #213, #4471, #3727.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).