### PR TITLE
upgrade: add tests for persisted user tables

### DIFF
--- a/test/upgrade/README.md
+++ b/test/upgrade/README.md
@@ -8,13 +8,38 @@ This upgrade test framework serves to verify that objects created in a previous 
 The framework does the following:
 - fires an old version of Materialize
 - runs the applicable 'create-in' .td tests against it
-- kills the old version and starts a Materialize binary from your branch, preserving the mzdata directory across restarts
+- kills the old version and starts a Materialize binary from your current source, preserving the mzdata directory across restarts
 - runs the applicable 'check-from' .td tests
 
-Kafka and the Schema Registry are not restarted.
+The external services (Kafka, Schema Registry, Postgres) are not restarted.
 
-The "upgrade" from your branch back to your branch is also tested.
+The "upgrade" from your current source to your current source is also tested.
 
+## Running
+
+To run the entire sequence of tests:
+
+```
+./mzcompose down -v ; ./mzcompose run upgrade
+```
+
+To run the tests against a particular version and all following versions:
+
+```
+./mzcompose down -v ; MIN_TESTED_TAG=0.9.6 ./mzcompose run upgrade
+```
+
+To run the tests upgrading from the current source to the current source:
+
+```
+./mzcompose down -v ; MIN_TESTED_TAG=99.99.99 ./mzcompose run upgrade
+```
+
+To run just a particular test or tests:
+
+```
+./mzcompose down -v ; TD_GLOB=persistent-user-tables ./mzcompose run upgrade
+```
 
 ## Test naming convention
 

--- a/test/upgrade/check-from-any_version-avro-ocf-sink.td
+++ b/test/upgrade/check-from-any_version-avro-ocf-sink.td
@@ -9,10 +9,11 @@
 
 > INSERT INTO avro_ocf_table VALUES (3);
 
-# The restart has caused a new .ocf file to be created
-# Mz and $ avro-ocf-verify have no memory of the previous file
-# so we only verify that the record we just inserted in the source
-# appears in the sink
+# Make sure the OCF file has been created and populated before attempting to run $ avro-ocf-verify on it
+# As there is no way to wait precisely until that occurs, we have no option but to use mz_sleep()
+> SELECT mz_internal.mz_sleep(2);
+<null>
+
 $ avro-ocf-verify sink=materialize.public.avro_ocf_sink
 {"before": null, "after": {"row": {"f1": 3}}}
 

--- a/test/upgrade/check-from-v0.9.2-persistent-user-tables.td
+++ b/test/upgrade/check-from-v0.9.2-persistent-user-tables.td
@@ -1,0 +1,72 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> SELECT COUNT(*) = 1 FROM persistent_user_table;
+true
+
+> SELECT f1 FROM persistent_user_table;
+1234
+
+> SELECT LENGTH(f2) = 10 * 1024 * 1024 FROM persistent_user_table;
+true
+
+# Check that the table can still be inserted into
+
+> INSERT INTO persistent_user_table VALUES (1234, REPEAT('x', 1024 * 1024 * 10));
+
+> SELECT LENGTH(f2) = 10 * 1024 * 1024 FROM persistent_user_table;
+true
+true
+
+> SELECT * FROM persistent_user_table_view1;
+12340
+12340
+
+> SELECT * FROM persistent_user_table_view2;
+123400
+123400
+
+> SELECT * FROM persistent_schema.persistent_user_table;
+abc
+
+> SELECT * FROM persistent_user_table_txns;
+1
+2
+3
+4
+5
+11
+12
+13
+14
+15
+21
+22
+23
+24
+25
+
+> SELECT * FROM persistent_user_table_renamed;
+1234
+
+> INSERT INTO persistent_user_table1_for_sink VALUES (3);
+
+> INSERT INTO persistent_user_table2_for_sink VALUES (3);
+
+$ set-regex match=\d{13} replacement=<TIMESTAMP>
+
+$ kafka-verify format=avro sink=materialize.public.persistent_user_table1_sink sort-messages=true
+{"before":null,"after":{"row":{"f1":{"int":1}}},"transaction":{"id":"<TIMESTAMP>"}}
+{"before":null,"after":{"row":{"f1":{"int":2}}},"transaction":{"id":"<TIMESTAMP>"}}
+{"before":null,"after":{"row":{"f1":{"int":3}}},"transaction":{"id":"<TIMESTAMP>"}}
+
+$ kafka-verify format=avro sink=materialize.public.persistent_user_table2_sink sort-messages=true
+{"before":null,"after":{"row":{"f1":{"int":1}}},"transaction":{"id":"<TIMESTAMP>"}}
+{"before":null,"after":{"row":{"f1":{"int":2}}},"transaction":{"id":"<TIMESTAMP>"}}
+{"before":null,"after":{"row":{"f1":{"int":3}}},"transaction":{"id":"<TIMESTAMP>"}}

--- a/test/upgrade/create-in-any_version-avro-ocf-sink.td
+++ b/test/upgrade/create-in-any_version-avro-ocf-sink.td
@@ -9,8 +9,4 @@
 
 > CREATE TABLE avro_ocf_table (f1 INTEGER NOT NULL);
 
-> INSERT INTO avro_ocf_table VALUES (1);
-
 > CREATE SINK avro_ocf_sink FROM avro_ocf_table INTO AVRO OCF '${testdrive.temp-dir}/avro_ocf_sink.ocf'
-
-> INSERT INTO avro_ocf_table VALUES (2);

--- a/test/upgrade/create-in-v0.9.2-persistent-user-tables.td
+++ b/test/upgrade/create-in-v0.9.2-persistent-user-tables.td
@@ -1,0 +1,98 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> CREATE TABLE persistent_user_table (f1 INTEGER, f2 STRING);
+
+> INSERT INTO persistent_user_table VALUES (1234, REPEAT('x', 1024 * 1024 * 10));
+
+#
+# Views over said table
+#
+
+> CREATE VIEW persistent_user_table_view1 AS SELECT f1 * 10 FROM persistent_user_table;
+
+> CREATE MATERIALIZED VIEW persistent_user_table_view2 AS SELECT f1 * 100 FROM persistent_user_table;
+
+#
+# A table in some other schema
+#
+
+> DROP SCHEMA IF EXISTS persistent_schema;
+
+> CREATE SCHEMA persistent_schema;
+
+> CREATE TABLE persistent_schema.persistent_user_table (f1 TEXT);
+
+> INSERT INTO persistent_schema.persistent_user_table VALUES ('abc');
+
+#
+# Multi-row insert, multi-insert transactions
+#
+
+
+> CREATE TABLE persistent_user_table_txns (f1 INTEGER);
+
+> INSERT INTO persistent_user_table_txns VALUES (1),(2),(3),(4),(5);
+
+> BEGIN;
+
+> INSERT INTO persistent_user_table_txns VALUES (11),(12),(13),(14),(15);
+
+> INSERT INTO persistent_user_table_txns VALUES (21),(22),(23),(24),(25);
+
+> COMMIT;
+
+#
+# Rename a table after persisting
+#
+
+> CREATE TABLE persistent_user_table_rename (f1 INTEGER);
+
+> INSERT INTO persistent_user_table_rename VALUES (1234);
+
+> ALTER TABLE persistent_user_table_rename RENAME TO persistent_user_table_renamed;
+
+#
+# A sink based on a persistent table
+#
+
+> CREATE TABLE persistent_user_table1_for_sink (f1 INTEGER);
+
+> CREATE TABLE persistent_user_table2_for_sink (f1 INTEGER);
+
+> BEGIN
+
+> INSERT INTO persistent_user_table1_for_sink VALUES (1);
+
+> INSERT INTO persistent_user_table2_for_sink VALUES (1);
+
+> COMMIT
+
+> CREATE SINK persistent_user_table1_sink FROM persistent_user_table1_for_sink
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'persistent-user-table1-sink-${testdrive.seed}'
+  WITH (consistency_topic = 'persistent-user-table1-sink-consistency')
+  FORMAT AVRO
+  USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}';
+
+> CREATE SINK persistent_user_table2_sink FROM persistent_user_table2_for_sink
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'persistent-user-table2-sink-${testdrive.seed}'
+  WITH (consistency_topic = 'persistent-user-table2-sink-consistency')
+  FORMAT AVRO
+  USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}';
+
+> BEGIN
+
+> INSERT INTO persistent_user_table1_for_sink VALUES (2);
+
+> INSERT INTO persistent_user_table2_for_sink VALUES (2);
+
+> COMMIT
+
+> SELECT mz_internal.mz_sleep(5);
+<null>


### PR DESCRIPTION


### Motivation

We were missing upgrade tests for persistent user tables to guard against backward-incompatible changes in the on-disk formats. The hope is that now the test is present, it will gloriously fail if the on-disk format is changed, forcing a discussion and a decision on how to handle this (e.g. via versioning, which is not currently in place as far as I am aware).

### Description

- add multiple test scenarios dealing with persistent tables
- extend mzworkflows.py to allow for Mz command-line options to
  be passed only to versions that support them
- allow a specific test and versions to be targeted during test
  development using the MIN_TESTED_TAG and TD_GLOB environment variables:

./mzcompose down -v ; MIN_TESTED_TAG=0.9.6 TD_GLOB=persistent-user-tables ./mzcompose run upgrade

### Tips for reviewer



### Checklist

- [x] This PR has adequate test coverage.
- [ ] This PR adds a release note for any user-facing behavior changes.
