### PR TITLE
repr: reject year zero in YYYY-MM-DD date format

### DIFF
--- a/src/repr/src/adt/datetime.rs
+++ b/src/repr/src/adt/datetime.rs
@@ -787,6 +787,12 @@ impl ParsedDateTime {
         Ok(())
     }
     pub fn check_datelike_bounds(&mut self) -> Result<(), String> {
+        if let Some(year) = self.year {
+            // 1BC is not represented as year 0 in postgres
+            if year.unit == 0 {
+                return Err("YEAR cannot be zero".to_string());
+            }
+        }
         if let Some(month) = self.month {
             if month.unit < 1 || month.unit > 12 {
                 return Err(format!("MONTH must be [1, 12], got {}", month.unit));
@@ -913,10 +919,6 @@ fn fill_pdt_date(
                 } else {
                     val += 1900;
                 }
-            }
-            // 1BC is not represented as year 0 in postgres
-            if val == 0 {
-                return Err("YEAR cannot be zero".into());
             }
             pdt.year = Some(DateTimeFieldValue::new(val, 0));
             actual.pop_front();

--- a/src/repr/tests/strconv.rs
+++ b/src/repr/tests/strconv.rs
@@ -41,6 +41,10 @@ fn test_parse_date_errors() {
         "invalid input syntax for type date: YEAR cannot be zero: \"00000203\"",
     );
     run_test_parse_date_errors(
+        "0000-02-03",
+        "invalid input syntax for type date: YEAR cannot be zero: \"0000-02-03\"",
+    );
+    run_test_parse_date_errors(
         "0010230",
         "invalid input syntax for type date: invalid or out-of-range date: \"0010230\"",
     );


### PR DESCRIPTION
### Motivation

This PR fixes a previously unreported bug: the fact that it was possible to create timestamps with year zero in some cases, e.g. `'0000-01-01'::date`.

### Description

The check against year zero (which is not accepted by Postgres) was only being done in the branch that parses YYYYMMDD formatted dates, not YYYY-MM-DD ones. This moves it into the general date validation function, to ensure only valid dates can be constructed.

### Checklist

- [x] This PR has adequate test coverage.
- [ ] This PR adds a release note for any user-facing behavior changes.

### Notes

Should we add a release note in this case? It is technically a breaking change/change in behavior, but only because we were previously accepting invalid inputs.
