### PR TITLE
doc: Performance hit for setting Postgres tables to REPLICA IDENTITY FULL

### DIFF
--- a/doc/user/content/guides/cdc-postgres.md
+++ b/doc/user/content/guides/cdc-postgres.md
@@ -51,7 +51,7 @@ Before creating a source in Materialize, you need to ensure that the upstream da
 
     This setting determines the amount of information that is written to the WAL in `UPDATE` and `DELETE` operations. Setting it to `FULL` will include the previous values of all the table’s columns in the change events.
 
-    As a heads-up, you should expect a performance hit in the database from increased CPU usage.
+    As a heads-up, you should expect a performance hit in the database from increased CPU usage. For more information, see the [PostgreSQL documentation](https://www.postgresql.org/docs/current/logical-replication-publication.html).
 
 1. Create a [publication](https://www.postgresql.org/docs/current/logical-replication-publication.html) with the tables you want to replicate:
 
@@ -156,7 +156,7 @@ Before deploying a Debezium connector, you need to ensure that the upstream data
 
 1. Grant enough privileges to ensure Debezium can operate in the database. The specific privileges will depend on how much control you want to give to the replication user, so we recommend following the [Debezium documentation](https://debezium.io/documentation/reference/connectors/postgresql.html#postgresql-replication-user-privileges).
 
-1. Set the replica identity value for any tables that you want to replicate but which have **no primary key** defined:
+1. If a table that you want to replicate has a **primary key** defined, you can use your default replica identity value. If a table you want to replicate has **no primary key** defined, you must set the replica identity value to `FULL`:
 
     ```sql
     ALTER TABLE repl_table REPLICA IDENTITY FULL;
@@ -164,7 +164,7 @@ Before deploying a Debezium connector, you need to ensure that the upstream data
 
     This setting determines the amount of information that is written to the WAL in `UPDATE` and `DELETE` operations. Setting it to `FULL` will include the previous values of all the table’s columns in the change events.
 
-    As a heads-up, you should expect a performance hit in the database from increased CPU usage.
+    As a heads-up, you should expect a performance hit in the database from increased CPU usage. For more information, see the [PostgreSQL documentation](https://www.postgresql.org/docs/current/logical-replication-publication.html).
 
 ### Deploy Debezium
 

--- a/doc/user/content/sql/create-source/postgres.md
+++ b/doc/user/content/sql/create-source/postgres.md
@@ -91,6 +91,11 @@ Before you create a Postgres source in Materialize, you must complete the follow
     ALTER TABLE foo
     REPLICA IDENTITY FULL;
     ```
+
+    This setting determines the amount of information that is written to the WAL in `UPDATE` and `DELETE` operations. Setting it to `FULL` will include the previous values of all the table’s columns in the change events.
+
+    As a heads-up, you should expect a performance hit in the database from increased CPU usage. For more information, see the [PostgreSQL documentation](https://www.postgresql.org/docs/current/logical-replication-publication.html).
+    
 4. Create a publication containing all the tables you wish to query in Materialize:
 
     *For all tables in Postgres:*


### PR DESCRIPTION

### Motivation

  * This PR fixes a recognized bug. [#6371]

We recommend setting Postgres identity replication to FULL in some cases, but do not explain the potential performance hit.

### Description

- Restored note & added Postgres link for CDC with direct Postgres source
- Added note to direct Postgres source doc

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [ ] This PR has adequate test coverage.
- [ ] This PR adds a release note for any user-facing behavior changes.
