### PR TITLE
Detect and reject multiple materializations of single-mat sources

### DIFF
--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -348,6 +348,8 @@ impl ErrorResponse {
             CoordError::Eval(_) => SqlState::INTERNAL_ERROR,
             CoordError::IdExhaustionError => SqlState::INTERNAL_ERROR,
             CoordError::IncompleteTimestamp(_) => SqlState::SQL_STATEMENT_NOT_YET_COMPLETE,
+            // TODO: is there a better error code?
+            CoordError::InvalidMultipleMaterialization { .. } => SqlState::UNIQUE_VIOLATION,
             CoordError::InvalidParameterType(_) => SqlState::INVALID_PARAMETER_VALUE,
             CoordError::InvalidTableMutationSelection => SqlState::INVALID_TRANSACTION_STATE,
             CoordError::ConstraintViolation(NotNullViolation(_)) => SqlState::NOT_NULL_VIOLATION,

--- a/test/pg-cdc/mzcompose.yml
+++ b/test/pg-cdc/mzcompose.yml
@@ -38,6 +38,8 @@ services:
       - bash
     volumes:
       - .:/workdir
+    environment:
+      - TD_TEST
     depends_on: [materialized, postgres]
 
   materialized:

--- a/test/pg-cdc/single-materialization.td
+++ b/test/pg-cdc/single-materialization.td
@@ -1,0 +1,78 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Test that any replication slot can only be materialized once
+#
+
+
+# Insert data pre-snapshot
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER USER postgres WITH replication;
+DROP SCHEMA IF EXISTS public CASCADE;
+DROP PUBLICATION IF EXISTS mz_source;
+
+CREATE SCHEMA public;
+
+CREATE TABLE t1 (id SERIAL PRIMARY KEY, f1 BOOLEAN);
+ALTER TABLE t1 REPLICA IDENTITY FULL;
+
+CREATE TABLE t2 (id SERIAL PRIMARY KEY, t1_id INT REFERENCES t1(id), name VARCHAR);
+
+INSERT INTO t1(f1) VALUES ('true'),('false');
+
+INSERT INTO t2(t1_id, name) VALUES (1, 'example');
+
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+> CREATE SOURCE mz_source
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
+  PUBLICATION 'mz_source';
+
+> CREATE VIEWS FROM SOURCE mz_source;
+
+> CREATE MATERIALIZED VIEW t1_mat AS
+  SELECT * FROM t1
+
+> SELECT id, f1 FROM t1_mat;
+1 true
+2 false
+
+! CREATE MATERIALIZED VIEW t1_mat_dupe AS
+  SELECT * FROM t1
+Cannot create second materialization on mz_source, already materialized by t1_mat
+
+! CREATE MATERIALIZED VIEWS FROM SOURCE mz_source
+Cannot create second materialization on mz_source, already materialized by t1_mat
+
+> DROP VIEW t1_mat;
+
+> CREATE MATERIALIZED VIEW t1_mat AS SELECT * FROM t1
+
+! SELECT * FROM t1_mat;
+must be dropped and recreated
+
+> DROP SOURCE mz_source CASCADE;
+
+# verify that dropping things allows recreation
+
+> CREATE SOURCE mz_source
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
+  PUBLICATION 'mz_source';
+
+> CREATE VIEWS FROM SOURCE mz_source;
+
+> CREATE MATERIALIZED VIEW joiner AS
+  SELECT t2.id, t1.f1, t2.name
+  FROM t1
+  JOIN t2
+  ON   t1.id = t2.t1_id
+
+> SELECT * FROM joiner;
+1 true example

--- a/test/testdrive/esoteric/s3-sqs-multiple-denied.td
+++ b/test/testdrive/esoteric/s3-sqs-multiple-denied.td
@@ -1,0 +1,92 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set buk=mz-sqs-double-mat-test
+
+$ s3-create-bucket bucket=${buk}
+
+$ s3-add-notifications bucket=${buk} queue=${buk} sqs-validation-timeout=5m
+
+
+> CREATE SOURCE s3_double_mat
+  FROM S3
+  DISCOVER OBJECTS USING SQS NOTIFICATIONS 'testdrive-${buk}-${testdrive.seed}'
+    WITH (
+    region = '${testdrive.aws-region}',
+    endpoint = '${testdrive.aws-endpoint}',
+    access_key_id = '${testdrive.aws-access-key-id}',
+    secret_access_key = '${testdrive.aws-secret-access-key}',
+    token = '${testdrive.aws-token}'
+  )
+  FORMAT TEXT;
+
+> CREATE MATERIALIZED VIEW s3_double_mat_view AS
+  SELECT * FROM s3_double_mat
+
+> CREATE VIEW s3_double_mat_view_reuse AS
+  SELECT text FROM s3_double_mat_view
+
+! CREATE MATERIALIZED VIEW s3_double_mat_error AS
+  SELECT * FROM s3_double_mat
+Cannot create second materialization on s3_double_mat, already materialized by s3_double_mat_view
+
+# check that going through multiple unmaterialized views doesn't allow hiding from the error
+> CREATE VIEW s3_double_mat_unmaterialized AS
+  SELECT * FROM s3_double_mat
+
+> CREATE VIEW s3_double_mat_unmaterialized_extra AS
+  SELECT * FROM s3_double_mat_unmaterialized
+
+! CREATE MATERIALIZED VIEW s3_double_mat_unmaterialized_final AS
+  SELECT * FROM s3_double_mat_unmaterialized_extra
+Cannot create second materialization on s3_double_mat, already materialized by s3_double_mat_view
+
+# check that dropping and recreating a view succeeds
+
+> DROP VIEW s3_double_mat_view CASCADE
+
+> CREATE MATERIALIZED VIEW s3_double_mat_view_recreated AS
+  SELECT * FROM s3_double_mat
+
+# check that an already materialized item that goes through multiple
+# unmaterialized views doesn't sneak past the check
+
+> DROP VIEW s3_double_mat_view_recreated CASCADE
+
+> CREATE VIEW s3_double_mat_unmaterialized_2 AS
+  SELECT * FROM s3_double_mat
+
+> CREATE VIEW s3_double_mat_unmaterialized_extra_2 AS
+  SELECT * FROM s3_double_mat_unmaterialized_2
+
+> CREATE MATERIALIZED VIEW s3_double_mat_final_2 AS
+  SELECT * FROM s3_double_mat_unmaterialized_extra_2
+
+> CREATE MATERIALIZED VIEW s3_double_mat_final2_reuse AS
+  SELECT text FROM s3_double_mat_final_2
+
+! CREATE MATERIALIZED VIEW s3_double_mat_error AS
+  SELECT * FROM s3_double_mat
+Cannot create second materialization on s3_double_mat, already materialized by s3_double_mat_final_2
+
+> CREATE VIEW s3_double_mat_unmaterialized_3 AS
+  SELECT * FROM s3_double_mat
+
+> CREATE VIEW s3_double_mat_unmaterialized_extra_3 AS
+  SELECT * FROM s3_double_mat_unmaterialized_3
+
+! CREATE MATERIALIZED VIEW s3_double_mat_error_3 AS
+  SELECT * FROM s3_double_mat_unmaterialized_extra_3
+Cannot create second materialization on s3_double_mat, already materialized by s3_double_mat_final_2
+
+! CREATE INDEX s3_double_mat_custom_idx ON s3_double_mat (text)
+Cannot create second materialization on s3_double_mat, already materialized by s3_double_mat_final_2
+
+! CREATE DEFAULT INDEX ON s3_double_mat
+Cannot create second materialization on s3_double_mat, already materialized by s3_double_mat_final_2


### PR DESCRIPTION
### Motivation

Fixes #8203

### Description

As part of sequencing the creation of indexes and materialized views we now walk
all the existing indexes. If there are any existing materializations of items
that `require_single_materialization()` that are *not* going to be re-used by
this new index we through an error.

### Tips for reviewer

I had to move some code from the DataflowBuilder to the Catalog, because we
should use the exact same logic to determine dependencies in validation and
actual import of dataflows, and we can't reject sequencing items after they have
been created.

The most important thing to check here is that the testdrive tests capture all
the edge cases. I tried to think of everything, but adversarial review of the
tests would be welcome.

### Checklist

- [ ] This PR has adequate test coverage -- we need tests for postgres sources.
- [ ] This PR adds a release note for any user-facing behavior changes.