### PR TITLE
materialized: update support email

### DIFF
--- a/misc/dbt-materialize/setup.py
+++ b/misc/dbt-materialize/setup.py
@@ -34,7 +34,7 @@ setup(
     long_description=(Path(__file__).parent / "README.md").open().read(),
     long_description_content_type="text/markdown",
     author="Materialize, Inc.",
-    author_email="support@materialize.io",
+    author_email="support@materialize.com",
     url="https://github.com/MaterializeInc/dbt-materialize",
     packages=find_packages(),
     package_data={

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -698,7 +698,7 @@ to improve both our software and your queries! Please reach out at:
 
     Web: https://materialize.com
     GitHub issues: https://github.com/MaterializeInc/materialize/issues
-    Email: support@materialize.io
+    Email: support@materialize.com
     Twitter: @MaterializeInc
 =======================================================================
 "


### PR DESCRIPTION
### Motivation

  * This PR fixes a previously unreported bug

### Description

The company website and emails have been moved to `materialize.com` and we use `@materialize.com` on our webpage.

### Checklist

- [x] This PR has adequate test coverage.
- [x] This PR adds a release note for any user-facing behavior changes.
