### PR TITLE
transform/fusion/union: use a post-order traversal instead

### DIFF
--- a/src/transform/src/fusion/union.rs
+++ b/src/transform/src/fusion/union.rs
@@ -28,7 +28,7 @@ impl crate::Transform for Union {
         relation: &mut MirRelationExpr,
         _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
-        relation.visit_mut_pre(&mut |e| {
+        relation.visit_mut(&mut |e| {
             self.action(e);
         });
         Ok(())

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -222,6 +222,7 @@ mod tests {
             "UnionBranchCancellation" => {
                 Ok(Box::new(transform::union_cancel::UnionBranchCancellation))
             }
+            "UnionFusion" => Ok(Box::new(transform::fusion::union::Union)),
             _ => Err(anyhow!(
                 "no transform named {} (you might have to add it to get_transform)",
                 name

--- a/src/transform/tests/testdata/union-fusion
+++ b/src/transform/tests/testdata/union-fusion
@@ -1,0 +1,57 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+cat
+(defsource x [int64 int64])
+----
+ok
+
+build apply=UnionFusion
+(union [(get x) (union [(get x) (union [(get x) (get x)])])])
+----
+----
+%0 =
+| Get x (u0)
+
+%1 =
+| Get x (u0)
+
+%2 =
+| Get x (u0)
+
+%3 =
+| Get x (u0)
+
+%4 =
+| Union %0 %1 %2 %3
+----
+----
+
+build apply=UnionFusion
+(union [(get x) (union [(get x) (negate (union [(get x) (get x)]))])])
+----
+----
+%0 =
+| Get x (u0)
+
+%1 =
+| Get x (u0)
+
+%2 =
+| Get x (u0)
+| Negate
+
+%3 =
+| Get x (u0)
+| Negate
+
+%4 =
+| Union %0 %1 %2 %3
+----
+----


### PR DESCRIPTION
### Motivation

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug. [Link to issue.]

  * This PR adds a known-desirable feature. [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

This PR fixes a previously unreported bug.

### Description

<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details."

-->

Union fusion transform required two full pre-order traversals of the graph to squash three nested unions. Only one is needed when doing it in post-order.

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [x] This PR has adequate test coverage.
- [nothing changes here] This PR adds a release note for any user-facing behavior changes.
