### PR TITLE
logging: Extract large enum variants into Box

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -3979,7 +3979,7 @@ impl Coordinator {
                         .expect("Failed to send CREATE Instance notice to timestamper");
                     self.broadcast(dataflow::Command::AddSourceTimestamping {
                         id: source_id,
-                        connector: s.connector.clone(),
+                        connector: Box::new(s.connector.clone()),
                         bindings,
                     });
                 }

--- a/src/dataflow/src/lib.rs
+++ b/src/dataflow/src/lib.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-#![warn(missing_docs)]
+#![warn(missing_docs, variant_size_differences)]
 
 //! Driver for timely/differential dataflow.
 

--- a/src/dataflow/src/render/join/mod.rs
+++ b/src/dataflow/src/render/join/mod.rs
@@ -43,7 +43,7 @@ pub use linear_join::LinearJoinPlan;
 /// A complete enumeration of possible join plans to render.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum JoinPlan {
-    Linear(LinearJoinPlan),
+    Linear(Box<LinearJoinPlan>),
     Delta(DeltaJoinPlan),
 }
 

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -488,7 +488,7 @@ where
                     .collect();
                 match plan {
                     crate::render::join::JoinPlan::Linear(linear_plan) => {
-                        self.render_join(inputs, linear_plan, scope)
+                        self.render_join(inputs, *linear_plan, scope)
                     }
                     crate::render::join::JoinPlan::Delta(delta_plan) => {
                         self.render_delta_join(inputs, delta_plan, scope)
@@ -970,13 +970,16 @@ pub mod plan {
                     // Extract temporal predicates as joins cannot currently absorb them.
                     let plan = match implementation {
                         expr::JoinImplementation::Differential((start, _start_arr), order) => {
-                            JoinPlan::Linear(LinearJoinPlan::create_from(
-                                *start,
-                                equivalences,
-                                order,
-                                input_mapper,
-                                &mut mfp,
-                            ))
+                            JoinPlan::Linear(
+                                LinearJoinPlan::create_from(
+                                    *start,
+                                    equivalences,
+                                    order,
+                                    input_mapper,
+                                    &mut mfp,
+                                )
+                                .into(),
+                            )
                         }
                         expr::JoinImplementation::DeltaQuery(orders) => {
                             JoinPlan::Delta(DeltaJoinPlan::create_from(

--- a/src/dataflow/src/render/reduce.rs
+++ b/src/dataflow/src/render/reduce.rs
@@ -237,7 +237,7 @@ pub enum BasicPlan {
     /// Plan for rendering a single basic aggregation. Here, the
     /// first element denotes the index in the set of inputs
     /// that we are aggregating over.
-    Single(usize, AggregateExpr),
+    Single(usize, Box<AggregateExpr>),
     /// Plan for rendering multiple basic aggregations.
     /// These need to then be collated together in an additional
     /// reduction. Each element represents the:
@@ -440,7 +440,7 @@ impl ReducePlan {
                 if aggregates_list.len() == 1 {
                     ReducePlan::Basic(BasicPlan::Single(
                         aggregates_list[0].0,
-                        aggregates_list[0].1.clone(),
+                        Box::new(aggregates_list[0].1.clone()),
                     ))
                 } else {
                     ReducePlan::Basic(BasicPlan::Multiple(aggregates_list))
@@ -1198,6 +1198,8 @@ where
 
 /// Accumulates values for the various types of accumulable aggregations.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+// Numeric is 100 bytes
+#[allow(variant_size_differences)]
 enum AccumInner {
     /// Accumulates boolean values.
     Bool {

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -145,7 +145,7 @@ pub enum Command {
         /// The ID of the timestamped source
         id: GlobalId,
         /// The connector for the timestamped source.
-        connector: SourceConnector,
+        connector: Box<SourceConnector>,
         /// Previously stored timestamp bindings.
         bindings: Vec<(PartitionId, Timestamp, MzOffset)>,
     },
@@ -954,7 +954,7 @@ where
                     consistency,
                     ts_frequency,
                     ..
-                } = connector
+                } = *connector
                 {
                     let byo_default = TimestampBindingRc::new(None, self.now, true);
                     let rt_default = TimestampBindingRc::new(

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -49,7 +49,7 @@ use tokio::sync::{mpsc, RwLock, RwLockReadGuard};
 use self::metrics::SourceBaseMetrics;
 
 use super::source::util::source;
-use crate::logging::materialized::{Logger, MaterializedEvent};
+use crate::logging::materialized::{Logger, MaterializedEvent, SourceInfo};
 use crate::operator::StreamExt;
 use crate::source::timestamp::TimestampBindingRc;
 
@@ -823,13 +823,16 @@ impl Drop for SourceMetrics {
         // retract our partition from logging
         if let Some(logger) = self.logger.as_mut() {
             for (partition, metric) in self.partition_metrics.iter() {
-                logger.log(MaterializedEvent::SourceInfo {
-                    source_name: self.source_name.clone(),
-                    source_id: self.source_id,
-                    partition_id: partition.into(),
-                    offset: -metric.last_offset,
-                    timestamp: -metric.last_timestamp,
-                });
+                logger.log(MaterializedEvent::SourceInfo(
+                    SourceInfo {
+                        source_name: self.source_name.clone(),
+                        source_id: self.source_id,
+                        partition_id: partition.into(),
+                        offset: -metric.last_offset,
+                        timestamp: -metric.last_timestamp,
+                    }
+                    .into(),
+                ));
             }
         }
     }
@@ -860,13 +863,16 @@ impl PartitionMetrics {
         offset: i64,
         timestamp: i64,
     ) {
-        logger.log(MaterializedEvent::SourceInfo {
-            source_name: source_name.to_string(),
-            source_id,
-            partition_id: partition_id.into(),
-            offset: offset - self.last_offset,
-            timestamp: timestamp - self.last_timestamp,
-        });
+        logger.log(MaterializedEvent::SourceInfo(
+            SourceInfo {
+                source_name: source_name.to_string(),
+                source_id,
+                partition_id: partition_id.into(),
+                offset: offset - self.last_offset,
+                timestamp: timestamp - self.last_timestamp,
+            }
+            .into(),
+        ));
         self.last_offset = offset;
         self.last_timestamp = timestamp;
     }


### PR DESCRIPTION
### Motivation

This PR refactors existing code: It extracts some enum variants in `dataflow` into boxes to reduce the size of the enums.

### Description

Some of the enum variants used throughout the `dataflow` crate and its dependents are significantly larger than their peers, causing larger allocations than required in some cases. For example, `Command::AddSourceTimestamping` is 966 bytes and 3x larger than the next-largest element. By extracting the variant into a box, we move the allocation to the heap.

The PR adds the `variant_size_differences` lint on the `dataflow` crate, which warns if enum members have 3x different sizes. Some enums are explicitly permitted to violate this lint. The reduction implementation has a relatively large enum to store the difference, and I don't want to introduce a pointer deref here. In another place, a `Regex` is relatively large, but not concerning overall.

### Checklist

- [ ] This PR has adequate test coverage.
- [ ] This PR adds a release note for any user-facing behavior changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/8547)
<!-- Reviewable:end -->
