### PR TITLE
doc: table should be codeblock

### DIFF
--- a/doc/user/content/sql/tail.md
+++ b/doc/user/content/sql/tail.md
@@ -203,15 +203,17 @@ All further columns after `mz_progressed` will be `NULL` in the `true` case.
 Not all timestamps that appear will have a corresponding `mz_progressed` row.
 For example, the following is a valid sequence of updates:
 
-`mz_timestamp` | `mz_progressed` | `mz_diff` | `column1`
----------------|-----------------|-----------|----------------
-1              | `false`         | 1         | data
-1              | `false`         | 1         | more data
-2              | `false`         | 1         | even more data
-4              | `true`          | `NULL`    | `NULL`
+```nofmt
+mz_timestamp | mz_progressed | mz_diff | column1
+-------------|---------------|---------|--------------
+1            | false         | 1       | data
+2            | false         | 1       | more data
+3            | false         | 1       | even more data
+4            | true          | NULL    | NULL
+```
 
 Notice how Materialize did not emit explicit progress messages for timestamps
-`1`, `2`, or `3`. The receipt of the update at timestamp `2` implies that there
+`1` or `2`. The receipt of the update at timestamp `2` implies that there
 are no more updates for timestamp `1`, because timestamps are always presented
 in non-decreasing order. The receipt of the explicit progress message at
 timestamp `4` implies that there are no more updates for either timestamp


### PR DESCRIPTION
### Motivation

* Fixes bug
* 
### Description

A codeblock was formatted incorrectly as a table and missing a timestamp mentioned in the text.

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [x] This PR has adequate test coverage.
- [ ] This PR adds a release note for any user-facing behavior changes.
