### PR TITLE
persist: begin an abstraction for maintenance in a background threadpool

### DIFF
--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -33,7 +33,7 @@ persist-types = { path = "../persist-types" }
 rusoto_core = "0.47.0"
 rusoto_s3 = "0.47.0"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
-tokio = { version = "1.12.0", default-features = false, features = ["macros", "sync"] }
+tokio = { version = "1.12.0", default-features = false, features = ["macros", "sync", "rt"] }
 
 [dev-dependencies]
 criterion = "0.3.5"

--- a/src/persist/src/indexed/background.rs
+++ b/src/persist/src/indexed/background.rs
@@ -1,0 +1,244 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! A runtime for background asynchronous maintenance of stored data.
+
+use std::sync::Arc;
+
+use differential_dataflow::lattice::Lattice;
+use differential_dataflow::trace::Description;
+use timely::progress::Antichain;
+use timely::PartialOrder;
+use tokio::runtime::Runtime;
+
+use crate::error::Error;
+use crate::future::Future;
+use crate::indexed::cache::BlobCache;
+use crate::indexed::encoding::{BlobTraceBatch, TraceBatchMeta};
+use crate::storage::Blob;
+
+/// A request to merge two trace batches and write the results to blob storage.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CompactTraceReq {
+    /// One of the batches to be merged.
+    pub b0: TraceBatchMeta,
+    /// One of the batches to be merged.
+    pub b1: TraceBatchMeta,
+    /// The since frontier to be used for the output batch. This must be at or
+    /// in advance of the since frontier for both of the input batch.
+    pub since: Antichain<u64>,
+    /// The blob key to write the resulting batch to.
+    pub output_key: String,
+}
+
+/// A successful merge.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CompactTraceRes {
+    /// The original request, so the caller doesn't have to do this matching.
+    pub req: CompactTraceReq,
+    /// The compacted batch.
+    pub merged: TraceBatchMeta,
+}
+
+/// A runtime for background asynchronous maintenance of stored data.
+//
+// TODO: Add migrating records from unsealed to trace as well as deletion of
+// batches.
+pub struct Maintainer<B: Blob> {
+    // TODO: It feels like a smell to wrap BlobCache in an Arc when most of its
+    // internals are already wrapped in Arcs. As of when this was written, the
+    // only exception is prev_meta_len, which really is only used from a single
+    // thread. Perhaps we should split the Meta parts out of BlobCache.
+    blob: Arc<BlobCache<B>>,
+    runtime: Arc<Runtime>,
+}
+
+impl<B: Blob> Maintainer<B> {
+    /// Returns a new [Maintainer].
+    pub fn new(blob: BlobCache<B>, runtime: Arc<Runtime>) -> Self {
+        Maintainer {
+            blob: Arc::new(blob),
+            runtime,
+        }
+    }
+
+    /// Asynchronously runs the requested compaction on the work pool provided
+    /// at construction time.
+    pub fn compact_trace(&self, req: CompactTraceReq) -> Future<CompactTraceRes> {
+        let (tx, rx) = Future::new();
+        let blob = self.blob.clone();
+        // Ignore the spawn_blocking response since we communicate
+        // success/failure through the returned Future.
+        //
+        // TODO: Push the spawn_blocking down into the cpu-intensive bits and
+        // use spawn here once the storage traits are made async.
+        let _ = self
+            .runtime
+            .spawn_blocking(move || tx.fill(Self::compact_trace_blocking(blob, req)));
+        rx
+    }
+
+    fn compact_trace_blocking(
+        blob: Arc<BlobCache<B>>,
+        req: CompactTraceReq,
+    ) -> Result<CompactTraceRes, Error> {
+        if first.desc.upper() != second.desc.lower() {
+            return Err(Error::from(format!(
+                "invalid merge of non-consecutive batches {:?} and {:?}",
+                first, second
+            )));
+        }
+
+        // Sanity check that both batches being merged are at identical compaction
+        // levels.
+        debug_assert_eq!(first.level, second.level);
+
+        let desc = Description::new(
+            first.desc.lower().clone(),
+            second.desc.upper().clone(),
+            self.since.clone(),
+        );
+
+        let mut updates = vec![];
+
+        updates.extend(
+            blob.get_trace_batch_async(&first.key)
+                .recv()?
+                .updates
+                .iter()
+                .cloned(),
+        );
+        updates.extend(
+            blob.get_trace_batch_async(&second.key)
+                .recv()?
+                .updates
+                .iter()
+                .cloned(),
+        );
+
+        for ((_, _), t, _) in updates.iter_mut() {
+            for since_ts in self.since.elements().iter() {
+                if *t < *since_ts {
+                    *t = *since_ts;
+                }
+            }
+        }
+
+        differential_dataflow::consolidation::consolidate_updates(&mut updates);
+
+        let new_batch = BlobTraceBatch {
+            desc: desc.clone(),
+            updates,
+        };
+
+        let key = self.new_blob_key();
+        // TODO: actually clear the unwanted batches from the blob storage
+        let size_bytes = blob.set_trace_batch(key.clone(), new_batch)?;
+
+        // Only upgrade the compaction level if we know this new batch represents
+        // an increase in data over both of its parents so that we know we need
+        // even more additional batches to amortize the cost of compacting it in
+        // the future.
+        let merged_level = if size_bytes > first.size_bytes && size_bytes > second.size_bytes {
+            first.level + 1
+        } else {
+            first.level
+        };
+
+        Ok(TraceBatchMeta {
+            key,
+            desc,
+            level: merged_level,
+            size_bytes,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use differential_dataflow::trace::Description;
+    use tokio::runtime::Runtime;
+
+    use crate::indexed::metrics::Metrics;
+    use crate::mem::MemRegistry;
+
+    use super::*;
+
+    fn desc_from(lower: u64, upper: u64, since: u64) -> Description<u64> {
+        Description::new(
+            Antichain::from_elem(lower),
+            Antichain::from_elem(upper),
+            Antichain::from_elem(since),
+        )
+    }
+
+    #[test]
+    fn compact_trace() -> Result<(), Error> {
+        let blob = BlobCache::new(Metrics::default(), MemRegistry::new().blob_no_reentrance()?);
+        let maintainer = Maintainer::new(blob.clone(), Arc::new(Runtime::new()?));
+
+        let b0 = BlobTraceBatch {
+            desc: desc_from(0, 1, 0),
+            updates: vec![
+                (("k".into(), "v".into()), 0, 1),
+                (("k2".into(), "v2".into()), 0, 1),
+            ],
+        };
+        let b0_size_bytes = blob.set_trace_batch("b0".into(), b0.clone())?;
+
+        let b1 = BlobTraceBatch {
+            desc: desc_from(1, 3, 0),
+            updates: vec![
+                (("k".into(), "v".into()), 2, 1),
+                (("k3".into(), "v3".into()), 2, 1),
+            ],
+        };
+        let b1_size_bytes = blob.set_trace_batch("b1".into(), b1.clone())?;
+
+        let req = CompactTraceReq {
+            b0: TraceBatchMeta {
+                key: "b0".into(),
+                desc: b0.desc.clone(),
+                level: 0,
+                size_bytes: b0_size_bytes,
+            },
+            b1: TraceBatchMeta {
+                key: "b1".into(),
+                desc: b1.desc.clone(),
+                level: 0,
+                size_bytes: b1_size_bytes,
+            },
+            since: Antichain::from_elem(2),
+            output_key: "b2".into(),
+        };
+        let expected_res = CompactTraceRes {
+            req: req.clone(),
+            merged: TraceBatchMeta {
+                key: "b2".into(),
+                desc: desc_from(0, 3, 2),
+                level: 1,
+                size_bytes: 322,
+            },
+        };
+        assert_eq!(
+            maintainer.compact_trace(req).recv(),
+            Ok(expected_res.clone())
+        );
+
+        let b2 = blob.get_trace_batch_async("b2").recv()?;
+        let expected_updates = vec![
+            (("k".into(), "v".into()), 2, 2),
+            (("k2".into(), "v2".into()), 2, 1),
+            (("k3".into(), "v3".into()), 2, 1),
+        ];
+        assert_eq!(&b2.desc, &expected_res.merged.desc);
+        assert_eq!(&b2.updates, &expected_updates);
+        Ok(())
+    }
+}

--- a/src/persist/src/indexed/cache.rs
+++ b/src/persist/src/indexed/cache.rs
@@ -251,7 +251,7 @@ impl<B: Blob> BlobCache<B> {
     /// Writes a batch to backing [Blob] storage.
     ///
     /// Returns the size of the encoded blob value in bytes.
-    pub fn set_trace_batch(&mut self, key: String, batch: BlobTraceBatch) -> Result<u64, Error> {
+    pub fn set_trace_batch(&self, key: String, batch: BlobTraceBatch) -> Result<u64, Error> {
         if key == Self::META_KEY {
             return Err(format!("cannot write trace batch to meta key: {}", Self::META_KEY).into());
         }

--- a/src/persist/src/indexed/runtime.rs
+++ b/src/persist/src/indexed/runtime.rs
@@ -28,6 +28,8 @@ use tokio::runtime::Runtime;
 
 use crate::error::Error;
 use crate::future::{Future, FutureHandle};
+use crate::indexed::background::Maintainer;
+use crate::indexed::cache::BlobCache;
 use crate::indexed::encoding::Id;
 use crate::indexed::metrics::{metric_duration_ms, Metrics};
 use crate::indexed::{
@@ -93,7 +95,9 @@ where
     let pool_guard = pool.enter();
 
     // Start up the runtime.
-    let indexed = Indexed::new(log, blob, metrics.clone())?;
+    let blob = BlobCache::new(metrics.clone(), blob);
+    let maintainer = Maintainer::new(blob.clone(), pool.clone());
+    let indexed = Indexed::new(log, blob, maintainer, metrics.clone())?;
     let mut runtime = RuntimeImpl::new(config.clone(), indexed, rx, metrics.clone());
     let id = RuntimeId::new();
     let runtime_pool = pool.clone();

--- a/src/persist/src/indexed/trace.rs
+++ b/src/persist/src/indexed/trace.rs
@@ -17,12 +17,12 @@ use std::mem;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 
-use differential_dataflow::trace::Description;
 use timely::progress::{Antichain, Timestamp};
 use timely::PartialOrder;
 
 use crate::error::Error;
 use crate::future::Future;
+use crate::indexed::background::{CompactTraceReq, Maintainer};
 use crate::indexed::cache::BlobCache;
 use crate::indexed::encoding::{TraceBatchMeta, TraceMeta};
 use crate::indexed::{BlobTraceBatch, Id, Snapshot};
@@ -243,92 +243,13 @@ impl Trace {
         }
     }
 
-    /// Merge two batches into one, forwarding all updates not beyond the current
-    /// `since` frontier to the `since` frontier.
-    fn merge<B: Blob>(
-        &mut self,
-        first: &TraceBatchMeta,
-        second: &TraceBatchMeta,
-        blob: &mut BlobCache<B>,
-    ) -> Result<TraceBatchMeta, Error> {
-        if first.desc.upper() != second.desc.lower() {
-            return Err(Error::from(format!(
-                "invalid merge of non-consecutive batches {:?} and {:?}",
-                first, second
-            )));
-        }
-
-        // Sanity check that both batches being merged are at identical compaction
-        // levels.
-        debug_assert_eq!(first.level, second.level);
-
-        let desc = Description::new(
-            first.desc.lower().clone(),
-            second.desc.upper().clone(),
-            self.since.clone(),
-        );
-
-        let mut updates = vec![];
-
-        updates.extend(
-            blob.get_trace_batch_async(&first.key)
-                .recv()?
-                .updates
-                .iter()
-                .cloned(),
-        );
-        updates.extend(
-            blob.get_trace_batch_async(&second.key)
-                .recv()?
-                .updates
-                .iter()
-                .cloned(),
-        );
-
-        for ((_, _), t, _) in updates.iter_mut() {
-            for since_ts in self.since.elements().iter() {
-                if *t < *since_ts {
-                    *t = *since_ts;
-                }
-            }
-        }
-
-        differential_dataflow::consolidation::consolidate_updates(&mut updates);
-
-        let new_batch = BlobTraceBatch {
-            desc: desc.clone(),
-            updates,
-        };
-
-        let key = self.new_blob_key();
-        // TODO: actually clear the unwanted batches from the blob storage
-        let size_bytes = blob.set_trace_batch(key.clone(), new_batch)?;
-
-        // Only upgrade the compaction level if we know this new batch represents
-        // an increase in data over both of its parents so that we know we need
-        // even more additional batches to amortize the cost of compacting it in
-        // the future.
-        let merged_level = if size_bytes > first.size_bytes && size_bytes > second.size_bytes {
-            first.level + 1
-        } else {
-            first.level
-        };
-
-        Ok(TraceBatchMeta {
-            key,
-            desc,
-            level: merged_level,
-            size_bytes,
-        })
-    }
-
     /// Take one step towards compacting the trace.
     ///
     /// Returns a list of trace batches that can now be physically deleted after
     /// the compaction step is committed to durable storage.
     pub fn step<B: Blob>(
         &mut self,
-        blob: &mut BlobCache<B>,
+        maintainer: &Maintainer<B>,
     ) -> Result<(u64, Vec<TraceBatchMeta>), Error> {
         let mut written_bytes = 0;
         let mut deleted = vec![];
@@ -337,10 +258,17 @@ impl Trace {
             if (self.batches[i - 1].level == self.batches[i].level)
                 && PartialOrder::less_equal(self.batches[i].desc.upper(), &self.since)
             {
-                let first = self.batches[i - 1].clone();
-                let second = self.batches[i].clone();
+                let b0 = self.batches[i - 1].clone();
+                let b1 = self.batches[i].clone();
 
-                let mut new_batch = self.merge(&first, &second, blob)?;
+                let req = CompactTraceReq {
+                    b0,
+                    b1,
+                    since: self.since.clone(),
+                    output_key: self.new_blob_key(),
+                };
+                let res = maintainer.compact_trace(req).recv()?;
+                let mut new_batch = res.merged;
                 written_bytes += new_batch.size_bytes;
 
                 // TODO: more performant way to do this?
@@ -439,6 +367,9 @@ impl Iterator for TraceSnapshotIter {
 
 #[cfg(test)]
 mod tests {
+    use differential_dataflow::trace::Description;
+    use tokio::runtime::Runtime;
+
     use crate::indexed::encoding::Id;
     use crate::indexed::metrics::Metrics;
     use crate::indexed::SnapshotExt;
@@ -529,6 +460,7 @@ mod tests {
     #[test]
     fn trace_compact() -> Result<(), Error> {
         let mut blob = BlobCache::new(Metrics::default(), MemRegistry::new().blob_no_reentrance()?);
+        let maintainer = Maintainer::new(blob.clone(), Arc::new(Runtime::new()?));
         let mut t = Trace::new(TraceMeta::new(Id(0)));
         t.update_seal(10);
 
@@ -558,7 +490,7 @@ mod tests {
 
         t.validate_allow_compaction(&Antichain::from_elem(3))?;
         t.allow_compaction(Antichain::from_elem(3));
-        let (written_bytes, deleted_batches) = t.step(&mut blob)?;
+        let (written_bytes, deleted_batches) = t.step(&maintainer)?;
         // Change this to a >0 check if it starts to be a maintenance burden.
         assert_eq!(written_bytes, 322);
         assert_eq!(
@@ -570,7 +502,7 @@ mod tests {
         );
 
         // Check that step doesn't do anything when there's nothing to compact.
-        let (written_bytes, deleted_batches) = t.step(&mut blob)?;
+        let (written_bytes, deleted_batches) = t.step(&maintainer)?;
         assert_eq!(written_bytes, 0);
         assert_eq!(deleted_batches, vec![]);
 
@@ -617,7 +549,7 @@ mod tests {
         assert_eq!(t.append(batch, &mut blob), Ok(()));
         t.validate_allow_compaction(&Antichain::from_elem(10))?;
         t.allow_compaction(Antichain::from_elem(10));
-        let (written_bytes, deleted_batches) = t.step(&mut blob)?;
+        let (written_bytes, deleted_batches) = t.step(&maintainer)?;
         assert_eq!(written_bytes, 186);
         assert_eq!(
             deleted_batches

--- a/src/persist/src/mem.rs
+++ b/src/persist/src/mem.rs
@@ -15,8 +15,11 @@ use std::sync::{Arc, Mutex};
 
 use ore::cast::CastFrom;
 use ore::metrics::MetricsRegistry;
+use tokio::runtime::Runtime;
 
 use crate::error::Error;
+use crate::indexed::background::Maintainer;
+use crate::indexed::cache::BlobCache;
 use crate::indexed::metrics::Metrics;
 use crate::indexed::runtime::{self, RuntimeClient, RuntimeConfig};
 use crate::indexed::Indexed;
@@ -336,9 +339,10 @@ impl MemRegistry {
     /// this registry.
     pub fn indexed_no_reentrance(&mut self) -> Result<Indexed<MemLog, MemBlob>, Error> {
         let log = self.log_no_reentrance()?;
-        let blob = self.blob_no_reentrance()?;
         let metrics = Metrics::register_with(&MetricsRegistry::new());
-        Indexed::new(log, blob, metrics)
+        let blob = BlobCache::new(metrics.clone(), self.blob_no_reentrance()?);
+        let compacter = Maintainer::new(blob.clone(), Arc::new(Runtime::new()?));
+        Indexed::new(log, blob, compacter, metrics)
     }
 
     /// Starts a [RuntimeClient] using the [MemLog] and [MemBlob] contained by


### PR DESCRIPTION
This uses a threadpool for the cpu-intensive and io work, specifically
the `tokio::runtime::Runtime` used elsewhere in Materialize. Maintenance
work is done asynchronously and a response is returned as a Future.

To break this work into steps, the current Indexed runtime simply blocks
on this Future in the old call site. A followup will break the request
sending and response handling into separate places in Indexed, which is
non-trivial. That work will also have to ensure we don't send out the
same compaction requests repeatedly while waiting for a response, which
will require tracking a bit of state we hadn't before.

The implementation of compact_trace_blocking in this commit is identical
to the previous one in `Trace::merge`. All changes are made in the next
commit.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

Extracted from #8472
