### PR TITLE
pg-cdc: clamp limitless varchars to the correct limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3229,6 +3229,7 @@ dependencies = [
  "anyhow",
  "openssl",
  "postgres-openssl",
+ "repr",
  "sql-parser",
  "tokio",
  "tokio-postgres",

--- a/src/postgres-util/Cargo.toml
+++ b/src/postgres-util/Cargo.toml
@@ -10,5 +10,6 @@ anyhow = "1.0.44"
 openssl = { version = "0.10.36", features = ["vendored"] }
 postgres-openssl = { git = "https://github.com/MaterializeInc/rust-postgres", branch = "mz-0.7.2" }
 sql-parser = { path = "../sql-parser" }
+repr = { path = "../repr" }
 tokio = { version = "1.12.0", features = ["fs"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", branch = "mz-0.7.2" }

--- a/src/repr/src/adt/char.rs
+++ b/src/repr/src/adt/char.rs
@@ -6,13 +6,25 @@
 // As of the Change Date specified in that file, in accordance with
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
+use std::convert::TryFrom;
+
 use anyhow::bail;
 
 use super::util;
 
+// https://github.com/postgres/postgres/blob/REL_14_0/src/include/access/htup_details.h#L577-L584
+pub const MAX_LENGTH: i32 = 10_485_760;
+
 pub fn extract_typ_mod(typ_mod: &[u64]) -> Result<Option<usize>, anyhow::Error> {
-    let typ_mod =
-        util::extract_typ_mod::<usize>("character", typ_mod, &[("length", 1, 10_485_760)])?;
+    let typ_mod = util::extract_typ_mod::<usize>(
+        "character",
+        typ_mod,
+        &[(
+            "length",
+            1,
+            usize::try_from(MAX_LENGTH).expect("max length is positive"),
+        )],
+    )?;
     Ok(Some(*typ_mod.get(0).unwrap_or(&1)))
 }
 

--- a/src/repr/src/adt/varchar.rs
+++ b/src/repr/src/adt/varchar.rs
@@ -6,13 +6,25 @@
 // As of the Change Date specified in that file, in accordance with
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
+use std::convert::TryFrom;
+
 use anyhow::bail;
 
 use super::util;
 
+// https://github.com/postgres/postgres/blob/REL_14_0/src/include/access/htup_details.h#L577-L584
+pub const MAX_LENGTH: i32 = 10_485_760;
+
 pub fn extract_typ_mod(typ_mod: &[u64]) -> Result<Option<usize>, anyhow::Error> {
-    let typ_mod =
-        util::extract_typ_mod::<usize>("character varying", typ_mod, &[("length", 1, 10_485_760)])?;
+    let typ_mod = util::extract_typ_mod::<usize>(
+        "character varying",
+        typ_mod,
+        &[(
+            "length",
+            1,
+            usize::try_from(MAX_LENGTH).expect("max length is positive"),
+        )],
+    )?;
     Ok(typ_mod.get(0).cloned())
 }
 

--- a/test/pg-cdc/types-character.td
+++ b/test/pg-cdc/types-character.td
@@ -19,11 +19,11 @@ DROP PUBLICATION IF EXISTS mz_source;
 
 CREATE SCHEMA public;
 
-CREATE TABLE t1 (f1 VARCHAR(10), f2 CHAR(10), f3 TEXT);
+CREATE TABLE t1 (f1 VARCHAR(10), f2 CHAR(10), f3 TEXT, f4 varchar);
 ALTER TABLE t1 REPLICA IDENTITY FULL;
 
-INSERT INTO t1 VALUES ('abc', 'abc', 'abc');
-INSERT INTO t1 VALUES ('abc ', 'abc ', 'abc ');
+INSERT INTO t1 VALUES ('abc', 'abc', 'abc', 'abc');
+INSERT INTO t1 VALUES ('abc ', 'abc ', 'abc ', 'abc ');
 
 CREATE PUBLICATION mz_source FOR ALL TABLES;
 
@@ -40,21 +40,21 @@ true
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 INSERT INTO t1 SELECT * FROM t1;
 
-> SELECT pg_typeof(f1), pg_typeof(f2), pg_typeof(f3) FROM t1 LIMIT 1;
-"character varying" "character" "text"
+> SELECT pg_typeof(f1), pg_typeof(f2), pg_typeof(f3), pg_typeof(f4) FROM t1 LIMIT 1;
+"character varying" "character" "text" "character varying"
 
 > SELECT * FROM t1;
-"abc" "abc       " "abc"
-"abc" "abc       " "abc"
-"abc " "abc       " "abc "
-"abc " "abc       " "abc "
+"abc" "abc       " "abc" "abc"
+"abc" "abc       " "abc" "abc"
+"abc " "abc       " "abc " "abc "
+"abc " "abc       " "abc " "abc "
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
-UPDATE t1 SET f1 = 'klm', f2 = 'klm', f3 = 'klm' WHERE f1 = 'abc';
-UPDATE t1 SET f1 = 'xyz ', f2 = 'xyz ', f3 = 'xyz ' WHERE f1 = 'abc ';
+UPDATE t1 SET f1 = 'klm', f2 = 'klm', f3 = 'klm', f4 = 'klm' WHERE f1 = 'abc';
+UPDATE t1 SET f1 = 'xyz ', f2 = 'xyz ', f3 = 'xyz ', f4 = 'xyz ' WHERE f1 = 'abc ';
 
 > SELECT * FROM t1;
-"klm" "klm       " "klm"
-"klm" "klm       " "klm"
-"xyz " "xyz       " "xyz "
-"xyz " "xyz       " "xyz "
+"klm" "klm       " "klm" "klm"
+"klm" "klm       " "klm" "klm"
+"xyz " "xyz       " "xyz " "xyz "
+"xyz " "xyz       " "xyz " "xyz "


### PR DESCRIPTION
### Motivation

This PR fixes an issue reported by Gunjan Kaphle in our community slack: https://materializecommunity.slack.com/archives/C015KDVS7EV/p1633478637256700

### Description

Postgres and Materialize limit the length of char and varchar types to 10MB, but when we were translating limit-less varchar columns from upstream postgres databases (during a `CREATE VIEWS FROM SOURCE` statement) we were defaulting to i32::MAX, which is much larger than 10MB.

This patch exports the maximum length as a constant and uses that to set the length of limitless varchars so that the two values stay in sync even if we choose to increase the limit in the future

### Checklist

- [x] This PR has adequate test coverage.
