### PR TITLE
protoc: expose API to parse FileDescriptorSets more directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4303,6 +4303,7 @@ dependencies = [
  "postgres-protocol",
  "postgres-types",
  "postgres-util",
+ "protobuf",
  "protoc",
  "rdkafka",
  "regex",

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -29,6 +29,7 @@ pgrepr = { path = "../pgrepr" }
 postgres-protocol = { git = "https://github.com/MaterializeInc/rust-postgres", branch = "mz-0.7.2" }
 postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres", branch = "mz-0.7.2", features = ["with-chrono-0_4", "with-uuid-0_8"] }
 postgres-util = { path = "../postgres-util" }
+protobuf = "2.23.0"
 protoc = { path = "../../src/protoc" }
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "gssapi-vendored", "libz-static"] }
 regex = "1.5.4"


### PR DESCRIPTION
### Motivation

Following up on CR feedback that I think got missed! https://github.com/MaterializeInc/materialize/pull/8084#discussion_r701319138

### Description

This avoids roundtripping the FileDescriptorSet through a temporary
file. Incidentally it fixes a bug in the SQL purification that would
cause temporary directories to leak.

### Checklist

- [x] This PR has adequate test coverage.
- [x] This PR adds a release note for any user-facing behavior changes.
