### PR TITLE
Add a version check usable from cloud to the bug report instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -13,8 +13,17 @@ information in your bug report.
 
 ### What version of Materialize are you using?
 
+From the shell:
+
 ```
 $ materialized -v
+
+```
+
+Or from the SQL console:
+
+```
+materialize=> select mz_version();
 
 ```
 


### PR DESCRIPTION
`materialize -v` in the shell is not relevant to people on the cloud product.