### PR TITLE
Kick off the avro_ingest benchmark in the "periodic" CI test

### DIFF
--- a/ci/load/pipeline.yml
+++ b/ci/load/pipeline.yml
@@ -16,3 +16,9 @@ steps:
       AWS_DEFAULT_REGION: us-east-2
     plugins:
        - ./ci/plugins/scratch-aws-access
+  - command: bin/ci-builder run stable bin/pyactivate --dev -m materialize.cli.cloudbench start --profile confluent --trials 3 --revs HEAD  --append_metadata --s3_root mz-periodic-cloudbench/avro_ingest_periodic materialize.benches.avro_ingest -r 1000000 -n 10 -d big-records
+    timeout_in_minutes: 20
+    env:
+      AWS_DEFAULT_REGION: us-east-2
+    plugins:
+       - ./ci/plugins/scratch-aws-access


### PR DESCRIPTION
The results will get written to S3 and ingested in a Materialize cloud instance.