### PR TITLE
Add support for setting disable_user_indexes and name fields to mzcloud-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2514,7 +2514,7 @@ dependencies = [
 [[package]]
 name = "mzcloud"
 version = "1.0.0"
-source = "git+https://github.com/MaterializeInc/cloud-sdks#95185098556c91e7b4cfde2434d4ef4d979c8f92"
+source = "git+https://github.com/MaterializeInc/cloud-sdks#e3760f3c72df372b92d4586680a8582c38b27fb1"
 dependencies = [
  "reqwest",
  "serde",


### PR DESCRIPTION
### Motivation
  * This PR adds a known-desirable feature. https://github.com/MaterializeInc/cloud/issues/695
mzcloud-cli was missing support for setting disable-user-indexes mode and the name of the materialized deployment.

   * This PR refactors existing code.
I reordered the arguments to match the order in the structs in the SDK.


### Description

Adds support for setting disable-user-indexes mode and the name of the materialized deployment to mzcloud-cli.


### Checklist

- [ ] This PR has adequate test coverage.
- [ ] This PR adds a release note for any user-facing behavior changes.
