### PR TITLE
optimization: use dataflow::consolidate in FoldConstant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5051,6 +5051,7 @@ dependencies = [
  "anyhow",
  "datadriven",
  "dataflow-types",
+ "differential-dataflow",
  "expr",
  "expr_test_util",
  "itertools",

--- a/src/transform/Cargo.toml
+++ b/src/transform/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 
 [dependencies]
 dataflow-types = { path = "../dataflow-types" }
+differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 expr = { path = "../expr" }
 itertools = "0.10.1"
 repr = { path = "../repr" }

--- a/src/transform/src/reduction.rs
+++ b/src/transform/src/reduction.rs
@@ -9,7 +9,7 @@
 
 //! Replace operators on constants collections with constant collections.
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashSet};
 use std::iter;
 
 use expr::{AggregateExpr, EvalError, MirRelationExpr, MirScalarExpr, TableFunc};
@@ -385,14 +385,7 @@ impl FoldConstants {
         } = relation
         {
             // Reduce down to canonical representation.
-            let mut accum = HashMap::new();
-            for (row, cnt) in rows.drain(..) {
-                *accum.entry(row).or_insert(0) += cnt;
-            }
-            accum.retain(|_k, v| v != &0);
-            // `rows` cleared by drain.
-            rows.extend(accum.into_iter());
-            rows.sort();
+            differential_dataflow::consolidation::consolidate(rows);
 
             // Re-establish nullability of each column.
             for col_type in typ.column_types.iter_mut() {


### PR DESCRIPTION
Copying data into materialize from a stdin is slow (~10s for 100MB), with time mostly spent in the optimization stage, specifically with a lot of time spent in the `FoldConstant` optimization.  The current way in which we consolidate the constants is memory-inefficient and causes a lot of time to be spent in `memcpy`.  Replacing this with `differential_dataflow::consolidate::consolidate` brings a noticeable improvement in this benchmark.

Before:
`time` gives: `real    0m15.333s` and Instruments shows:
![Screen Shot 2021-10-08 at 17 56 06](https://user-images.githubusercontent.com/3459231/136628906-7b96888f-a569-4731-bad6-944113db7aa8.png)

After:
`time` gives: `real    0m7.158s` and Instruments shows:
![Screen Shot 2021-10-08 at 17 50 39](https://user-images.githubusercontent.com/3459231/136628929-51afcd9a-9bba-4b46-8a4b-5742982b1c43.png)

### Checklist

- [x] This PR has adequate test coverage.
- [x] This PR adds a release note for any user-facing behavior changes.
