### PR TITLE
test: Test for the limits of the product in various dimensions

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -47,3 +47,11 @@
     - ./ci/plugins/mzcompose:
         composition: upgrade
         run: upgrade
+
+- id: limits
+  label: "Product limits test"
+  plugins:
+    - ./ci/plugins/mzcompose:
+        composition: limits
+        run: limits
+  timeout_in_minutes: 20

--- a/misc/python/materialize/mzcompose.py
+++ b/misc/python/materialize/mzcompose.py
@@ -655,6 +655,7 @@ class PythonServiceConfig(TypedDict, total=False):
     depends_on: List[str]
     entrypoint: List[str]
     volumes: List[str]
+    deploy: Dict[str, Dict[str, Dict[str, str]]]
     propagate_uid_gid: bool
     init: bool
 
@@ -679,6 +680,7 @@ class Materialized(PythonService):
         hostname: Optional[str] = None,
         image: Optional[str] = None,
         port: int = 6875,
+        memory: Optional[str] = None,
         data_directory: str = "/share/mzdata",
         options: str = "",
         environment: List[str] = [
@@ -704,6 +706,11 @@ class Materialized(PythonService):
 
         if hostname:
             config["hostname"] = hostname
+
+        # Depending on the docker-compose version, this may either work or be ignored with a warning
+        # Unfortunately no portable way of setting the memory limit is known
+        if memory:
+            config["deploy"] = {"resources": {"limits": {"memory": memory}}}
 
         config.update(
             {

--- a/test/limits/README.md
+++ b/test/limits/README.md
@@ -1,0 +1,28 @@
+# Introduction
+
+The purpose of this framework is to test the product limits in various dimensions (e.g. number of kafka sources,
+number of tables in a join).
+
+Some of the limits are product-wide, most pertain to the various aspects of individual queries that
+pertain to the optimizer, e.g. "number of conditions over the same column in a WHERE clause".
+
+While the framework does not explicitly test for performance and can not intelligently flag regressions,
+in practice it is hoped that regressions will be caught by one of the following mechanisms:
+- a fixpoint panic if the optimizer is unable to transform a complex query to a stable tree
+- a stack overflow if a recursive algorithm is used anywhere during query processing
+- a testdrive of a global CI timeout if an O^M(N) algorithm is used. As we are using N = 1000 in most tests,
+  an algorithm with M ~ 3 should make things time out and fail in CI
+- a panic on massive memory leaks, as the Mz container runs with --memory 2G (when supported by docker-compose)
+
+# Running
+
+```
+./mzcompose down -v
+
+./mzcompose run limits
+```
+
+# Adding new content
+
+subclass the `Generator` class and define a `body()` class method that uses the provided iterators to generate the
+desired query in testdrive format and `print()` it.


### PR DESCRIPTION
Python code is used to generate queries that stress the product in
various dimensions, e.g. number of tables per join, which are then
fed to testdrive for execution.

See the provided README.md for details.

### Motivation

We had two bugs recently where Mz was crashing due to queries that were complex in a particular dimension. So Ufuk asked for this type of testing.

### Description

From the Readme:

# Introduction

The purpose of this framework is to test the product limits in various dimensions (e.g. number of kafka sources,
number of tables in a join).

Some of the limits are product-wide, most pertain to the various aspects of individual queries that 
pertain to the optimizer, e.g. "number of conditions over the same column in a WHERE clause".

While the framework does not explicitly test for performance and can not intelligently flag regressions,
in practice it is hoped that regressions will be caught by one of the following mechanisms:
- a fixpoint panic if the optimizer is unable to transform a complex query to a stable tree
- a stack overflow if a recursive algorithm is used anywhere during query processing
- a testdrive of a global CI timeout if an O^M(N) algorithm is used. As we are using N = 1000 in most tests,
  an algorithm with M ~ 3 should make things time out and fail in CI
- a panic on massive memory leaks, as the Mz container runs with --memory 2G

# Running

```
./mzcompose down -v

./mzcompose run limits
```

# Adding new content

subclass the `Generator` class and define a `body()` class method that uses the provided iterators to generate the
desired query in testdrive format and `print()` it.

### Tips for reviewer

@benesch I do not think there is a need to review each separate python snippet that generates a particular type of degenerate query, however if you could review the general approach (the first screenful of the file) and the integration with mzcompose/testdrive (the last screenfull), that would be much appreciated. Thanks!
 
### Checklist

- [x] This PR has adequate test coverage.
- [ ] This PR adds a release note for any user-facing behavior changes.
