### PR TITLE
repr: format BC era dates with BC identifier

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -112,6 +112,8 @@ Put breaking changes before other release notes, and mark them with
 - Fix a bug that inadvertently let users create an [`array`] with elements of
   type [`list`] or [`map`], which crashes Materialize. {{% gh 8672 %}}
 
+- Format dates before AD 1 with the BC notation instead of using negative dates.
+
 {{% version-header v0.9.8 %}}
 
 - Throw errors on floating point arithmetic overflow and underflow.

--- a/src/repr/src/strconv.rs
+++ b/src/repr/src/strconv.rs
@@ -30,7 +30,7 @@ use std::fmt;
 use std::num::FpCategory;
 
 use chrono::offset::{Offset, TimeZone};
-use chrono::{DateTime, Duration, NaiveDate, NaiveDateTime, NaiveTime, Timelike, Utc};
+use chrono::{DateTime, Datelike, Duration, NaiveDate, NaiveDateTime, NaiveTime, Timelike, Utc};
 use dec::OrderedDecimal;
 use fast_float::FastFloat;
 use lazy_static::lazy_static;
@@ -321,7 +321,11 @@ pub fn format_date<F>(buf: &mut F, d: NaiveDate) -> Nestable
 where
     F: FormatBuffer,
 {
-    write!(buf, "{}", d);
+    let (year_ad, year) = d.year_ce();
+    write!(buf, "{:04}-{}", year, d.format("%m-%d"));
+    if !year_ad {
+        write!(buf, " BC");
+    }
     Nestable::Yes
 }
 
@@ -361,8 +365,12 @@ pub fn format_timestamp<F>(buf: &mut F, ts: NaiveDateTime) -> Nestable
 where
     F: FormatBuffer,
 {
-    write!(buf, "{}", ts.format("%Y-%m-%d %H:%M:%S"));
+    let (year_ad, year) = ts.year_ce();
+    write!(buf, "{:04}-{}", year, ts.format("%m-%d %H:%M:%S"));
     format_nanos_to_micros(buf, ts.timestamp_subsec_nanos());
+    if !year_ad {
+        write!(buf, " BC");
+    }
     // This always needs escaping because of the whitespace
     Nestable::MayNeedEscaping
 }
@@ -398,9 +406,13 @@ pub fn format_timestamptz<F>(buf: &mut F, ts: DateTime<Utc>) -> Nestable
 where
     F: FormatBuffer,
 {
-    write!(buf, "{}", ts.format("%Y-%m-%d %H:%M:%S"));
+    let (year_ad, year) = ts.year_ce();
+    write!(buf, "{:04}-{}", year, ts.format("%m-%d %H:%M:%S"));
     format_nanos_to_micros(buf, ts.timestamp_subsec_nanos());
     write!(buf, "+00");
+    if !year_ad {
+        write!(buf, " BC");
+    }
     // This always needs escaping because of the whitespace
     Nestable::MayNeedEscaping
 }

--- a/src/repr/tests/strconv.rs
+++ b/src/repr/tests/strconv.rs
@@ -24,6 +24,7 @@ fn test_parse_date() {
     run_test_parse_date("20010203", NaiveDate::from_ymd(2001, 2, 3));
     run_test_parse_date("99990203", NaiveDate::from_ymd(9999, 2, 3));
     run_test_parse_date("2001-02-03", NaiveDate::from_ymd(2001, 2, 3));
+    run_test_parse_date("2001 02 03", NaiveDate::from_ymd(2001, 2, 3));
     run_test_parse_date("2001-02-03 04:05:06.789", NaiveDate::from_ymd(2001, 2, 3));
     fn run_test_parse_date(s: &str, n: NaiveDate) {
         assert_eq!(strconv::parse_date(s).unwrap(), n);
@@ -454,4 +455,189 @@ fn miri_test_format_list() {
         out,
         r#"{a,"a\"b","",NULL,"NULL",nUlL,"  spaces ","a,b","\\","a\\b\"c\\d\""}"#
     );
+}
+
+#[test]
+fn test_format_date() {
+    run_test_format_date(NaiveDate::from_ymd(20000, 2, 3), "20000-02-03");
+    run_test_format_date(NaiveDate::from_ymd(2000, 2, 3), "2000-02-03");
+    run_test_format_date(NaiveDate::from_ymd(200, 2, 3), "0200-02-03");
+    run_test_format_date(NaiveDate::from_ymd(20, 2, 3), "0020-02-03");
+    run_test_format_date(NaiveDate::from_ymd(2, 2, 3), "0002-02-03");
+    run_test_format_date(NaiveDate::from_ymd(0, 2, 3), "0001-02-03 BC");
+    run_test_format_date(NaiveDate::from_ymd(-1, 2, 3), "0002-02-03 BC");
+    run_test_format_date(NaiveDate::from_ymd(-19, 2, 3), "0020-02-03 BC");
+    run_test_format_date(NaiveDate::from_ymd(-199, 2, 3), "0200-02-03 BC");
+    run_test_format_date(NaiveDate::from_ymd(-1999, 2, 3), "2000-02-03 BC");
+
+    fn run_test_format_date(n: NaiveDate, e: &str) {
+        let mut buf = String::new();
+        strconv::format_date(&mut buf, n);
+        assert_eq!(buf, e);
+    }
+}
+
+#[test]
+fn test_format_timestamp() {
+    run_test_format_timestamp(
+        NaiveDate::from_ymd(20000, 2, 3).and_hms(4, 5, 6),
+        "20000-02-03 04:05:06",
+    );
+    run_test_format_timestamp(
+        NaiveDate::from_ymd(2000, 2, 3).and_hms(4, 5, 6),
+        "2000-02-03 04:05:06",
+    );
+    run_test_format_timestamp(
+        NaiveDate::from_ymd(2000, 2, 3).and_hms_nano(4, 5, 6, 789_000_000),
+        "2000-02-03 04:05:06.789",
+    );
+    run_test_format_timestamp(
+        NaiveDate::from_ymd(200, 2, 3).and_hms(4, 5, 6),
+        "0200-02-03 04:05:06",
+    );
+    run_test_format_timestamp(
+        NaiveDate::from_ymd(200, 2, 3).and_hms_nano(4, 5, 6, 789_000_000),
+        "0200-02-03 04:05:06.789",
+    );
+    run_test_format_timestamp(
+        NaiveDate::from_ymd(20, 2, 3).and_hms(4, 5, 6),
+        "0020-02-03 04:05:06",
+    );
+    run_test_format_timestamp(
+        NaiveDate::from_ymd(20, 2, 3).and_hms_nano(4, 5, 6, 789_000_000),
+        "0020-02-03 04:05:06.789",
+    );
+    run_test_format_timestamp(
+        NaiveDate::from_ymd(2, 2, 3).and_hms(4, 5, 6),
+        "0002-02-03 04:05:06",
+    );
+    run_test_format_timestamp(
+        NaiveDate::from_ymd(2, 2, 3).and_hms_nano(4, 5, 6, 789_000_000),
+        "0002-02-03 04:05:06.789",
+    );
+    run_test_format_timestamp(
+        NaiveDate::from_ymd(0, 2, 3).and_hms(4, 5, 6),
+        "0001-02-03 04:05:06 BC",
+    );
+    run_test_format_timestamp(
+        NaiveDate::from_ymd(-1, 2, 3).and_hms(4, 5, 6),
+        "0002-02-03 04:05:06 BC",
+    );
+    run_test_format_timestamp(
+        NaiveDate::from_ymd(-19, 2, 3).and_hms(4, 5, 6),
+        "0020-02-03 04:05:06 BC",
+    );
+    run_test_format_timestamp(
+        NaiveDate::from_ymd(-19, 2, 3).and_hms_nano(4, 5, 6, 789_000_000),
+        "0020-02-03 04:05:06.789 BC",
+    );
+    run_test_format_timestamp(
+        NaiveDate::from_ymd(-199, 2, 3).and_hms(4, 5, 6),
+        "0200-02-03 04:05:06 BC",
+    );
+    run_test_format_timestamp(
+        NaiveDate::from_ymd(-199, 2, 3).and_hms_nano(4, 5, 6, 789_000_000),
+        "0200-02-03 04:05:06.789 BC",
+    );
+    run_test_format_timestamp(
+        NaiveDate::from_ymd(-1999, 2, 3).and_hms(4, 5, 6),
+        "2000-02-03 04:05:06 BC",
+    );
+    run_test_format_timestamp(
+        NaiveDate::from_ymd(-1999, 2, 3).and_hms_nano(4, 5, 6, 789_000_000),
+        "2000-02-03 04:05:06.789 BC",
+    );
+
+    fn run_test_format_timestamp(n: NaiveDateTime, e: &str) {
+        let mut buf = String::new();
+        strconv::format_timestamp(&mut buf, n);
+        assert_eq!(buf, e);
+    }
+}
+
+#[test]
+fn test_format_timestamptz() {
+    run_test_format_timestamptz(
+        datetime_utc(20000, 2, 3, 4, 5, 6, 0),
+        "20000-02-03 04:05:06+00",
+    );
+    run_test_format_timestamptz(
+        datetime_utc(2000, 2, 3, 4, 5, 6, 0),
+        "2000-02-03 04:05:06+00",
+    );
+    run_test_format_timestamptz(
+        datetime_utc(2000, 2, 3, 4, 5, 6, 789_000_000),
+        "2000-02-03 04:05:06.789+00",
+    );
+    run_test_format_timestamptz(
+        datetime_utc(200, 2, 3, 4, 5, 6, 0),
+        "0200-02-03 04:05:06+00",
+    );
+    run_test_format_timestamptz(
+        datetime_utc(200, 2, 3, 4, 5, 6, 789_000_000),
+        "0200-02-03 04:05:06.789+00",
+    );
+    run_test_format_timestamptz(datetime_utc(20, 2, 3, 4, 5, 6, 0), "0020-02-03 04:05:06+00");
+    run_test_format_timestamptz(
+        datetime_utc(20, 2, 3, 4, 5, 6, 789_000_000),
+        "0020-02-03 04:05:06.789+00",
+    );
+    run_test_format_timestamptz(datetime_utc(2, 2, 3, 4, 5, 6, 0), "0002-02-03 04:05:06+00");
+    run_test_format_timestamptz(
+        datetime_utc(2, 2, 3, 4, 5, 6, 789_000_000),
+        "0002-02-03 04:05:06.789+00",
+    );
+    run_test_format_timestamptz(
+        datetime_utc(0, 2, 3, 4, 5, 6, 0),
+        "0001-02-03 04:05:06+00 BC",
+    );
+    run_test_format_timestamptz(
+        datetime_utc(-1, 2, 3, 4, 5, 6, 0),
+        "0002-02-03 04:05:06+00 BC",
+    );
+    run_test_format_timestamptz(
+        datetime_utc(-19, 2, 3, 4, 5, 6, 0),
+        "0020-02-03 04:05:06+00 BC",
+    );
+    run_test_format_timestamptz(
+        datetime_utc(-19, 2, 3, 4, 5, 6, 789_000_000),
+        "0020-02-03 04:05:06.789+00 BC",
+    );
+    run_test_format_timestamptz(
+        datetime_utc(-199, 2, 3, 4, 5, 6, 0),
+        "0200-02-03 04:05:06+00 BC",
+    );
+    run_test_format_timestamptz(
+        datetime_utc(-199, 2, 3, 4, 5, 6, 789_000_000),
+        "0200-02-03 04:05:06.789+00 BC",
+    );
+    run_test_format_timestamptz(
+        datetime_utc(-1999, 2, 3, 4, 5, 6, 0),
+        "2000-02-03 04:05:06+00 BC",
+    );
+    run_test_format_timestamptz(
+        datetime_utc(-1999, 2, 3, 4, 5, 6, 789_000_000),
+        "2000-02-03 04:05:06.789+00 BC",
+    );
+
+    fn datetime_utc(
+        year: i32,
+        month: u32,
+        day: u32,
+        hour: u32,
+        min: u32,
+        sec: u32,
+        nano: u32,
+    ) -> DateTime<Utc> {
+        DateTime::from_utc(
+            NaiveDate::from_ymd(year, month, day).and_hms_nano(hour, min, sec, nano),
+            Utc,
+        )
+    }
+
+    fn run_test_format_timestamptz(n: DateTime<Utc>, e: &str) {
+        let mut buf = String::new();
+        strconv::format_timestamptz(&mut buf, n);
+        assert_eq!(buf, e);
+    }
 }

--- a/test/sqllogictest/dates-times.slt
+++ b/test/sqllogictest/dates-times.slt
@@ -1100,3 +1100,35 @@ select '9::59.999999999'::time
 # TODO: Postgres supports this as 09:01:00.1.
 statement error invalid input syntax for type time: NANOSECOND
 select '9::60.1'::time
+
+# BC years are properly formatted
+# Using INTERVAL to work around the parser not supporting BC identifiers yet
+query T
+select '0001-02-24'::date - interval '1 YEAR'
+----
+0001-02-24 00:00:00 BC
+
+query T
+select ('0001-02-24'::date - interval '1 YEAR')::date
+----
+0001-02-24 BC
+
+query T
+select ('0001-01-01'::date - interval '1 DAY')::date
+----
+0001-12-31 BC
+
+query T
+select '0001-02-24 03:04:05'::timestamp - interval '1 YEAR'
+----
+0001-02-24 03:04:05 BC
+
+query T
+select '0001-02-24 03:04:05.6789'::timestamp - interval '1 YEAR'
+----
+0001-02-24 03:04:05.6789 BC
+
+query T
+select '0001-02-24 03:04:05.6789 +00:00'::timestamptz - interval '1 YEAR'
+----
+0001-02-24 03:04:05.6789+00 BC

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -106,28 +106,24 @@ SELECT date_trunc('millennium', TIMESTAMP '2000-11-26 15:56:46.241150')
 ----
 1001-01-01 00:00:00
 
-# TODO: PostgreSQL displays timestamps with 0 or negative year as (1 - year) BC, while we do not.
 # TODO: Currently we do not parse BC/AD and it's erroneously considered a named time zone, so INTERVAL is used.
-# This test should return:  0011-01-01 00:00:00 BC
 # Expects the decade to be rounded down for BC.
 query T
 SELECT date_trunc('decade', TIMESTAMP '0001-01-01 00:00:00.000000' - INTERVAL '2'YEAR)
 ----
--0010-01-01 00:00:00
+0011-01-01 00:00:00 BC
 
-# This test should return:  0100-01-01 00:00:00 BC
 # Expects the century to be rounded down for BC.
 query T
 SELECT date_trunc('century', TIMESTAMP '0001-01-01 00:00:00.000000' - INTERVAL '1'SECOND)
 ----
--0099-01-01 00:00:00
+0100-01-01 00:00:00 BC
 
-# This test should return:  1000-01-01 00:00:00 BC
 # Expects the millennium to be rounded down for BC.
 query T
 SELECT date_trunc('millennium', TIMESTAMP '0001-01-01 00:00:00.000000' - INTERVAL '1'SECOND)
 ----
--0999-01-01 00:00:00
+1000-01-01 00:00:00 BC
 
 query error unknown units 'bad'
 SELECT date_trunc('bad', TIMESTAMP '2019-11-26 15:56:46.241150')


### PR DESCRIPTION
### Motivation

Ensure the representation of BC era dates/timestamps (i.e. dates before AD 1) matches the Postgres one. This PR was split from #8559.

### Description

Add support in the date/time formatter for BC identifiers, instead of using the current negative date representation.

### Checklist

- [x] This PR has adequate test coverage.
- [x] This PR adds a release note for any user-facing behavior changes.
