### PR TITLE
deps: update nix to 0.20.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2386,9 +2386,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.6.1"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
 dependencies = [
  "autocfg",
 ]
@@ -2556,14 +2556,15 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.20.0"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa9b4819da1bc61c0ea48b63b7bc8604064dd43013e7cc325df098d49cd7c18a"
+checksum = "f5e06129fb611568ef4e868c14b326274959aa70ff7776e9d55323531c374945"
 dependencies = [
  "bitflags",
  "cc",
  "cfg-if",
  "libc",
+ "memoffset",
 ]
 
 [[package]]

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -54,7 +54,7 @@ libc = "0.2.103"
 log = "0.4.13"
 mz-http-proxy = { path = "../http-proxy", features = ["reqwest"] }
 mz-process-collector = { path = "../mz-process-collector" }
-nix = "0.20.0"
+nix = "0.20.2"
 num_cpus = "1.0.0"
 openssl = { version = "0.10.36", features = ["vendored"] }
 openssl-sys = { version = "0.9.67", features = ["vendored"] }


### PR DESCRIPTION
Triggered by this security advisory:

https://rustsec.org/advisories/RUSTSEC-2021-0119

