### PR TITLE
persist: only send seal commands that did not error to listeners.

### DIFF
--- a/src/persist/src/indexed/mod.rs
+++ b/src/persist/src/indexed/mod.rs
@@ -943,7 +943,9 @@ impl<L: Log, B: Blob> Indexed<L, B> {
     /// `sealed_frontier` for details.
     pub fn seal(&mut self, ids: Vec<Id>, seal_ts: u64, res: FutureHandle<()>) {
         let resp = self.do_seal(&ids, seal_ts);
-        self.pending.add_seals(ids, seal_ts);
+        if resp.is_ok() {
+            self.pending.add_seals(ids, seal_ts);
+        }
         self.pending.add_response(PendingResponse::Unit(res, resp));
     }
 

--- a/src/persist/src/operators/stream.rs
+++ b/src/persist/src/operators/stream.rs
@@ -916,6 +916,8 @@ mod tests {
         //  c) We seal up, even when never receiving any data.
         assert_eq!(
             vec![
+                Sealed::Condition(0),
+                Sealed::Primary(0),
                 Sealed::Condition(1),
                 Sealed::Primary(1),
                 Sealed::Condition(2),


### PR DESCRIPTION
This commit also fixes the conditional_seal test to account for sealing 0.

Previously, before we tracked pending seals in a hashtable, we ignored seal 0 because
we rederived what seal frontiers were different from the persisted state, and the
persisted state defaulted to 0.

