### PR TITLE
dataflow: more verbose error message when a peek returns negative mul…

### DIFF
--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -1245,7 +1245,7 @@ impl PendingPeek {
             });
             if copies < 0 {
                 return Err(format!(
-                    "Invalid data in source, saw retractions ({}) for row that does not exist: {}",
+                    "Invalid data in source errors, saw retractions ({}) for row that does not exist: {}",
                     copies * -1,
                     cursor.key(&storage),
                 ));


### PR DESCRIPTION
…tiplicity.

We recently spent some time debugging an issue where a SELECT statement returned a
negative multiplicity error.

This commit changes the error message to make things easier to debug. Specifically it,

1. Disambiguates whether the error happened from a data collection vs an error collection.
2. Reports the query time at which we aggregated this negative multiplicity.
3. Reports the set of (time, diff) pairs that contributed to this error.


Things I'm unsure of in this change:

1. Is this error message too internal / verbose / scary for users?
2. Should I also include the arrangement's upper and logical compaction frontiers?
3. Is it possible that this error might give engineers / users the wrong conclusion? e.g. if the query timestamp is t and we observe (data, t, -1) that could be because we received (data, t, -1) or we could have received any combination of (data, t, x), (data, t - k, y) ... that all got compacted into a single -1 record.

The nice thing about this debug output IMO is that its much more helpful if we run with --logical-compaction-window=off