### PR TITLE
persistence: Make min_step_interval configurable

### DIFF
--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -658,12 +658,21 @@ swap: {swap_total}KB total, {swap_used}KB used{swap_limit}",
             start_time = Utc::now(),
             num_workers = args.workers.0,
         );
+
+        // The min_step_interval knob allows tuning a tradeoff between latency and storage usage.
+        // As persist gets more sophisticated over time, we'll no longer need this knob,
+        // but in the meantime we need it to make tests reasonably performant.
+        // The --timestamp-frequency flag similarly gives testing a control over
+        // latency vs resource usage, so for simplicity we reuse it here."
+        let min_step_interval = args.timestamp_frequency;
+
         PersistConfig {
             runtime: Some(runtime.clone()),
             storage,
             user_table_enabled,
             system_table_enabled,
             lock_info,
+            min_step_interval,
         }
     };
 

--- a/src/persist/src/indexed/runtime.rs
+++ b/src/persist/src/indexed/runtime.rs
@@ -711,6 +711,7 @@ struct RuntimeImpl<L: Log, B: Blob> {
 /// Configuration for [start]ing a [RuntimeClient].
 #[derive(Debug, Clone)]
 pub struct RuntimeConfig {
+    /// Minimum step interval to use
     min_step_interval: Duration,
 }
 
@@ -731,6 +732,11 @@ impl RuntimeConfig {
         RuntimeConfig {
             min_step_interval: Duration::from_millis(1),
         }
+    }
+
+    /// A configuration with a configurable min_step_interval
+    pub fn with_min_step_interval(min_step_interval: Duration) -> Self {
+        RuntimeConfig { min_step_interval }
     }
 }
 


### PR DESCRIPTION


### Motivation

INSERT performance is limited to 1 tx/second under the default setting for min_step_interval, which hinders testing.

### Description

Allow the min_step_interval to be configurable via the
--timestamp-frequency command-line option. In practice,
the default remains the same (1s) but can be made much
lower in order to stress test persistent user tables.

### Tips for reviewer

I am almost positive I butchered the original intention of the code. So if this PR is unsalvageable, please let me know and I will open a ticket for this to be addressed professionally.

### Checklist

- [x] This PR has adequate test coverage.

Worked for me when tested manually.

- [ ] This PR adds a release note for any user-facing behavior changes.
