### PR TITLE
Update PR template to make it more clear what goes in relnotes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -52,4 +52,10 @@ Delete this section if no tips.
 ### Checklist
 
 - [ ] This PR has adequate test coverage.
-- [ ] This PR adds a release note for any user-facing behavior changes.
+- [ ] This PR adds a [release note][] for any user-facing behavior change, including
+  but not limited to:
+  * New Features
+  * Bug Fixes
+  * GitHub issues that are closed by this PR
+
+[release note]: https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#how-to-write-a-good-release-note


### PR DESCRIPTION
### Motivation

We've received feedback that it's very difficult for users to know when a GitHub issue that they're tracking lands in a release. This updates our PR template to match our new policy and more forcefully encourage folks to write notes.