### PR TITLE
doc/user: document what requires a release note

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,13 @@
+<!--
+
+Describe the contents of the PR briefly but completely.
+
+If you write detailed commit messages, it is acceptable to copy/paste them
+here, or write "see commit messages for details." If there is only one commit
+in the PR, GitHub will have already added its commit message above.
+
+-->
+
 ### Motivation
 
 <!--
@@ -24,17 +34,6 @@ Which of the following best describes the motivation behind this PR?
 
 -->
 
-### Description
-
-<!--
-
-Describe the contents of the PR briefly but completely.
-
-If you write detailed commit messages, it is acceptable to copy/paste them
-here, or write "see commit messages for details."
-
--->
-
 ### Tips for reviewer
 
 <!--
@@ -52,4 +51,5 @@ Delete this section if no tips.
 ### Checklist
 
 - [ ] This PR has adequate test coverage / QA involvement has been duly considered.
-- [ ] This PR adds a release note for any user-facing behavior changes.
+- [ ] This PR adds a release note for any
+  [user-facing behavior changes](/doc/user/content/release-notes.md#What-changes-require-a-release-note).

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -14,6 +14,53 @@ This page details changes between versions of Materialize, including:
 For information about available versions, see our [Versions page](/versions).
 
 {{< comment >}}
+# What changes require a release note?
+
+Any behavior change to a stable, user-visible API requires a release note.
+Roughly speaking, Materialize's stable APIs are:
+
+  * The syntax and semantics of all documented SQL statements.
+  * The observable behavior of any source or sink.
+  * The behavior of all documented command-line flags.
+
+For details, see the [backwards compatibility policy](/versions/#Backwards-compatibility).
+
+Notably, changes to experimental or unstable APIs should *not* have release
+notes. The point of having experimental and unstable APIs is to decrease the
+engineering burden when those features are changed. Instead, write a release
+note introducing the feature for the release in which the feature is
+de-experimentalized.
+
+Examples of changes that require release notes:
+
+  * The addition of a new, documented SQL function.
+  * The stabilization of a new source type.
+  * A bug fix that fixes a panic in any component.
+  * A bug fix that changes the output format of a particular data type in a
+    sink.
+
+Examples of changes that do not require release notes:
+
+  * **An improvement to the build system.** The build system is not user
+    visible.
+  * **The addition of a feature to testdrive.** Similarly, our test frameworks
+    are not user visible.
+  * **An upgrade of an internal Rust dependency.** Most dependency upgrades
+    do not result in user-visible changes. (If they do, document the change
+    itself, not the fact that the dependency was upgraded. Users care about
+    the visible behavior of Materialize, not its implementation!)
+
+Performance improvements are a borderline case. A small performance improvement
+does not need a release note, but a large performance improvement may warrant
+one if it results in a noticeable improvement for a large class of users or
+unlocks new use cases for Materialize. Examples of performance improvements
+that warrant a release note include:
+
+  * Improving the speed of Avro decoding by 2x
+  * Converting an O(n<sup>2</sup>) algorithm in the optimizer to an O(n)
+    algorithm so that queries with several dozen `UNION` operations can be
+    planned in a reasonable amount of time
+
 # How to write a good release note
 
 Every release note should be phrased in the imperative mood, like a Git
@@ -45,7 +92,8 @@ Use relative links (/path/to/doc), not absolute links
 
 Wrap your release notes at the 80 character mark.
 
-Put breaking changes before other release notes.
+Put breaking changes before other release notes, and mark them with
+`**Breaking change.**` at the start.
 {{< /comment >}}
 
 {{% version-header v0.9.9 %}}


### PR DESCRIPTION
This commit adds more words about what a "user-facing behavior change"
is. It also reorganizes the PR template per @danhhz's request so that
the commit message drops into the right spot in the template
automatically.

### Motivation

This PR is in response to a Slack discussion in the #release channel about missing release notes.

### Checklist

- [x] This PR has adequate test coverage.
- [x] This PR adds a release note for any user-facing behavior changes.
