### PR TITLE
doc/user: mark EXPLAIN as non-stable

### DIFF
--- a/doc/user/content/sql/explain.md
+++ b/doc/user/content/sql/explain.md
@@ -8,6 +8,13 @@ menu:
 
 `EXPLAIN` displays the plan used for a `SELECT` statement or a view.
 
+{{< warning >}}
+`EXPLAIN` is not part of Materialize's stable interface and is not subject to
+our [backwards compatibility](/versions/#backwards-compatibility) guarantee.
+The syntax and output of `EXPLAIN` may change arbitrarily in future versions of
+Materialize.
+{{< /warning >}}
+
 ## Conceptual framework
 
 To execute `SELECT` statements, Materialize generates a plan consisting of

--- a/doc/user/content/versions.md
+++ b/doc/user/content/versions.md
@@ -133,6 +133,7 @@ Materialize's stable interface:
     * The [health check endpoint](/ops/monitoring#health-check)
     * [Prometheus metrics](/ops/monitoring#prometheus)
   * Objects in the [system catalog](/sql/system-tables)
+  * The [`EXPLAIN`](/sql/explain) SQL statement
   * Any undocumented features or behavior
 
 These unstable interfaces are not subject to the backwards-compatibility policy.


### PR DESCRIPTION
We don't want to commit ourselves to any particular EXPLAIN format. Mark
it as non-stable in the documentation.

### Motivation

  * This PR fixes a previously unreported bug.

    Our `EXPLAIN` statement was marked as a stable interface, but in fact it changes arbitrarily from release to release.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any user-facing behavior changes.
