### PR TITLE
doc: Add timestamp_frequency_ms to Kinesis, S3, and file sources.

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -207,6 +207,8 @@ Put breaking changes before other release notes.
   `WITH` option for Kafka sources, which allows to set `start_offset` based on
   Kafka timestamps.
 
+- Add the [`timestamp_frequency_ms`] `WITH` option to Kinesis, S3, and file sources.
+
 - **Breaking change.** The `timezone(String, Time)` function can no
   longer be used in views.
 

--- a/doc/user/layouts/partials/aws-credentials-with-options.html
+++ b/doc/user/layouts/partials/aws-credentials-with-options.html
@@ -1,6 +1,7 @@
 `access_key_id` | `text` | A valid [access key ID](https://docs.aws.amazon.com/streams/latest/dev/controlling-access.html) for the AWS resource.
 `secret_access_key` | `text` | A valid [secret access key](https://docs.aws.amazon.com/streams/latest/dev/controlling-access.html) for the AWS resource.
 `token` | `text` | The session token associated with the credentials, if the credentials are temporary
+`timestamp_frequency_ms`| `int` | Default: `1000`. Sets the timestamping frequency in `ms`. Reflects how frequently the source advances its timestamp. This measure reflects how stale data in views will be. Lower values result in more-up-to-date views but may reduce throughput.
 
 If you do not provide credentials via with options then `materialized` will examine the standard
 AWS authorization chain:

--- a/doc/user/layouts/partials/create-source/connector/avro-ocf/with-options.html
+++ b/doc/user/layouts/partials/create-source/connector/avro-ocf/with-options.html
@@ -1,1 +1,2 @@
 `tail` | `boolean` | Continually check the file for new content; as new content arrives, process it using other `WITH` options.
+`timestamp_frequency_ms`| `int` | Default: `1000`. Sets the timestamping frequency in `ms`. Reflects how frequently the source advances its timestamp. This measure reflects how stale data in views will be. Lower values result in more-up-to-date views but may reduce throughput.

--- a/doc/user/layouts/partials/create-source/connector/file/with-options.html
+++ b/doc/user/layouts/partials/create-source/connector/file/with-options.html
@@ -1,1 +1,2 @@
 `tail` | `boolean` | Continually check the file for new content.
+`timestamp_frequency_ms`| `int` | Default: `1000`. Sets the timestamping frequency in `ms`. Reflects how frequently the source advances its timestamp. This measure reflects how stale data in views will be. Lower values result in more-up-to-date views but may reduce throughput.

--- a/doc/user/layouts/partials/create-source/connector/s3/with-options.html
+++ b/doc/user/layouts/partials/create-source/connector/s3/with-options.html
@@ -1,4 +1,5 @@
 `region` | `text` | **required** A valid AWS region.
+`timestamp_frequency_ms`| `int` | Default: `1000`. Sets the timestamping frequency in `ms`. Reflects how frequently the source advances its timestamp. This measure reflects how stale data in views will be. Lower values result in more-up-to-date views but may reduce throughput.
 
 #### AWS Credentials `WITH` options
 


### PR DESCRIPTION
Add release note

### Motivation

This PR documents a known-desirable feature [#7124]

### Description

Added `timestamp_frequency_ms` to WITH options for Kinesis, S3, and file sources.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any user-facing behavior changes.
