### PR TITLE
persist: remove next_blob_id

### DIFF
--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -34,6 +34,7 @@ rusoto_core = "0.47.0"
 rusoto_s3 = "0.47.0"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 tokio = { version = "1.12.0", default-features = false, features = ["macros", "sync", "rt"] }
+uuid = { version = "0.8.2", features = ["v4"] }
 
 [dev-dependencies]
 criterion = "0.3.5"
@@ -42,4 +43,3 @@ rand = { version = "0.8.4", features = [ "small_rng" ] }
 tempfile = "3.2.0"
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.68"
-uuid = { version = "0.8.2", features = ["v4"] }

--- a/src/persist/src/indexed/encoding.rs
+++ b/src/persist/src/indexed/encoding.rs
@@ -122,7 +122,9 @@ pub struct UnsealedMeta {
     pub ts_lower: Antichain<u64>,
     /// The batches that make up the Unsealed.
     pub batches: Vec<UnsealedBatchMeta>,
-    /// The next id used to assign a Blob key for this unsealed.
+
+    /// TODO: next_blob_id is deprecated, remove this once we can safely bump
+    /// BlobMeta::CURRENT_VERSION.
     pub next_blob_id: u64,
 }
 
@@ -169,7 +171,9 @@ pub struct TraceMeta {
     pub since: Antichain<u64>,
     /// Frontier this trace has been sealed up to.
     pub seal: Antichain<u64>,
-    /// The next id used to assign a Blob key for this trace.
+
+    /// TODO: next_blob_id is deprecated, remove this once we can safely bump
+    /// BlobMeta::CURRENT_VERSION.
     pub next_blob_id: u64,
 }
 

--- a/src/persist/src/indexed/mod.rs
+++ b/src/persist/src/indexed/mod.rs
@@ -284,38 +284,19 @@ impl<L: Log, B: Blob> Indexed<L, B> {
         self.id_mapping = meta.id_mapping;
         self.graveyard = meta.graveyard;
 
-        let mut restored_unsealeds: BTreeMap<Id, Unsealed> = meta
+        let restored_unsealeds: BTreeMap<Id, Unsealed> = meta
             .unsealeds
             .into_iter()
             .map(|meta| (meta.id, Unsealed::new(meta)))
             .collect();
 
-        // TODO: ideally we would be able to do something smarter here that didn't
-        // require manually remembering the next blob id. Also, since this state
-        // isn't stored in persistent storage, it can be an issue across restarts.
-        // One potentially reasonable fix is to assign blob keys based on stream
-        // id and the batch [lower, upper, since] description, instead of an opaque
-        // incrementing id. That way if we collide on a key on we know that it has
-        // the required data and we can happily reuse it.
-        for (id, restored_unsealed) in restored_unsealeds.iter_mut() {
-            if let Some(unsealed) = self.unsealeds.get(id) {
-                restored_unsealed.next_blob_id = unsealed.next_blob_id;
-            }
-        }
-
         self.unsealeds = restored_unsealeds;
 
-        let mut restored_traces: BTreeMap<Id, Trace> = meta
+        let restored_traces: BTreeMap<Id, Trace> = meta
             .traces
             .into_iter()
             .map(|meta| (meta.id, Trace::new(meta)))
             .collect();
-
-        for (id, restored_trace) in restored_traces.iter_mut() {
-            if let Some(trace) = self.traces.get(id) {
-                restored_trace.next_blob_id = trace.next_blob_id;
-            }
-        }
 
         self.traces = restored_traces;
     }

--- a/src/persist/src/indexed/unsealed.rs
+++ b/src/persist/src/indexed/unsealed.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 
 use timely::progress::Antichain;
 use timely::PartialOrder;
+use uuid::Uuid;
 
 use crate::error::Error;
 use crate::future::Future;
@@ -64,12 +65,14 @@ use crate::storage::{Blob, SeqNo};
 /// - TODO: Space usage.
 pub struct Unsealed {
     id: Id,
-    /// The next id used to assign a Blob key for this unsealed.
-    pub next_blob_id: u64,
     // NB: This is a closed lower bound. When Indexed seals a time, only data
     // strictly before that time gets moved into the trace.
     ts_lower: Antichain<u64>,
     batches: Vec<UnsealedBatchMeta>,
+
+    // TODO: next_blob_id is deprecated, remove this once we can safely bump
+    // BlobMeta::CURRENT_VERSION.
+    deprecated_next_blob_id: u64,
 }
 
 impl Unsealed {
@@ -78,18 +81,15 @@ impl Unsealed {
     pub fn new(meta: UnsealedMeta) -> Self {
         Unsealed {
             id: meta.id,
-            next_blob_id: meta.next_blob_id,
             ts_lower: meta.ts_lower,
             batches: meta.batches,
+            deprecated_next_blob_id: meta.next_blob_id,
         }
     }
 
     // Get a new key to write to the Blob store for this unsealed.
-    fn new_blob_key(&mut self) -> String {
-        let key = format!("{:?}-unsealed-{:?}", self.id, self.next_blob_id);
-        self.next_blob_id += 1;
-
-        key
+    fn new_blob_key() -> String {
+        Uuid::new_v4().to_string()
     }
 
     /// Serializes the state of this Unsealed for later re-instantiation.
@@ -98,7 +98,7 @@ impl Unsealed {
             id: self.id,
             ts_lower: self.ts_lower.clone(),
             batches: self.batches.clone(),
-            next_blob_id: self.next_blob_id,
+            next_blob_id: self.deprecated_next_blob_id,
         }
     }
 
@@ -119,7 +119,7 @@ impl Unsealed {
         batch: BlobUnsealedBatch,
         blob: &mut BlobCache<L>,
     ) -> Result<UnsealedBatchMeta, Error> {
-        let key = self.new_blob_key();
+        let key = Unsealed::new_blob_key();
         let desc = batch.desc.clone();
         let ts_upper = match batch.updates.last() {
             Some(upper) => upper.1,
@@ -401,6 +401,14 @@ mod tests {
 
     use super::*;
 
+    fn desc_from(lower: u64, upper: u64, since: u64) -> Description<SeqNo> {
+        Description::new(
+            Antichain::from_elem(SeqNo(lower)),
+            Antichain::from_elem(SeqNo(upper)),
+            Antichain::from_elem(SeqNo(since)),
+        )
+    }
+
     // Generate a list of ((k, v), t, 1) updates at all of the specified times.
     fn unsealed_updates(update_times: Vec<u64>) -> Vec<((Vec<u8>, Vec<u8>), u64, isize)> {
         update_times
@@ -455,6 +463,18 @@ mod tests {
         let snapshot = unsealed.snapshot(Antichain::from_elem(lo), hi, &blob)?;
         let updates = snapshot.read_to_end()?;
         Ok(updates)
+    }
+
+    // Keys are randomly generated, so clear them before we do any comparisons.
+    fn cleared_keys(batches: &[UnsealedBatchMeta]) -> Vec<UnsealedBatchMeta> {
+        batches
+            .iter()
+            .cloned()
+            .map(|mut b| {
+                b.key = "KEY".to_string();
+                b
+            })
+            .collect()
     }
 
     #[test]
@@ -535,11 +555,11 @@ mod tests {
         let snapshot_updates = slurp_from(&f, &blob, 0, None)?;
         assert_eq!(snapshot_updates, unsealed_updates(vec![0, 0, 1, 1]));
         assert_eq!(
-            f.batches,
+            cleared_keys(&f.batches),
             vec![
-                unsealed_batch_meta("Id(0)-unsealed-0", 0, 1, 0, 0, 0, 186),
-                unsealed_batch_meta("Id(0)-unsealed-1", 1, 2, 0, 1, 1, 186),
-                unsealed_batch_meta("Id(0)-unsealed-2", 2, 3, 0, 0, 1, 252),
+                unsealed_batch_meta("KEY", 0, 1, 0, 0, 0, 186),
+                unsealed_batch_meta("KEY", 1, 2, 0, 1, 1, 186),
+                unsealed_batch_meta("KEY", 2, 3, 0, 0, 1, 252),
             ],
         );
 
@@ -551,9 +571,9 @@ mod tests {
         assert_eq!(
             f.truncate(Antichain::from_elem(1))?
                 .into_iter()
-                .map(|b| b.key)
+                .map(|b| b.desc)
                 .collect::<Vec<_>>(),
-            vec!["Id(0)-unsealed-0".to_string()]
+            vec![desc_from(0, 1, 0)]
         );
 
         // Check that repeatedly truncating the same time bound does not modify the unsealed.
@@ -562,10 +582,10 @@ mod tests {
         let snapshot_updates = slurp_from(&f, &blob, 0, None)?;
         assert_eq!(snapshot_updates, unsealed_updates(vec![0, 1, 1]));
         assert_eq!(
-            f.batches,
+            cleared_keys(&f.batches),
             vec![
-                unsealed_batch_meta("Id(0)-unsealed-1", 1, 2, 0, 1, 1, 186),
-                unsealed_batch_meta("Id(0)-unsealed-2", 2, 3, 0, 0, 1, 252),
+                unsealed_batch_meta("KEY", 1, 2, 0, 1, 1, 186),
+                unsealed_batch_meta("KEY", 2, 3, 0, 0, 1, 252),
             ],
         );
 
@@ -573,12 +593,9 @@ mod tests {
         assert_eq!(
             f.truncate(Antichain::from_elem(2))?
                 .into_iter()
-                .map(|b| b.key)
+                .map(|b| b.desc)
                 .collect::<Vec<_>>(),
-            vec![
-                "Id(0)-unsealed-1".to_string(),
-                "Id(0)-unsealed-2".to_string()
-            ]
+            vec![desc_from(1, 2, 0), desc_from(2, 3, 0)]
         );
 
         // Check that truncate correctly handles the case where there are no more batches.
@@ -687,8 +704,8 @@ mod tests {
         assert_eq!(snapshot_updates, updates[1..]);
 
         assert_eq!(
-            f.batches,
-            vec![unsealed_batch_meta("Id(0)-unsealed-1", 0, 2, 0, 1, 2, 252)],
+            cleared_keys(&f.batches),
+            vec![unsealed_batch_meta("KEY", 0, 2, 0, 1, 2, 252)],
         );
 
         Ok(())


### PR DESCRIPTION
The latest update of nemesis (#8649) caught a bug where we were
attempting to reuse an id (and thus a key). We could track the bug down,
but for several reasons it's better to just remove next_blob_id
entirely.

- They are different than the other information in META in a critical
  way: everything else in META is revert-able to a previous state, but
  we can't revert next_blob_id because they might have been used.
  Indexed's revert has to jump through some hoops to deal with this,
  adding unnecessary complexity.
- Most of META itself is representable as a fixed number of collections
  (in the differential dataflow sense). This might be exploited in the
  near future to incrementally maintain META in storage. next_blob_id is
  one of the few (all fixable) exceptions to this pattern.
- Persist keys are meant to be opaque, but by not looking opaque, they
  subvert that expectation.

The big con is that keys are no longer deterministic, which is mostly a
hassle in unit tests.

### Motivation

  * This PR fixes a previously unreported bug.
