### PR TITLE
coord: include transitive view dependencies in timedomain

### DIFF
--- a/test/testdrive/transactions-timedomain-nonmaterialized.td
+++ b/test/testdrive/transactions-timedomain-nonmaterialized.td
@@ -101,3 +101,11 @@ Transactions can only reference objects in the same timedomain
 3
 
 > COMMIT
+
+# Regression for #8657
+# Ensure that views referencing other schemas are transitively included. Here,
+# pg_catalog is generally a view over mz_catalog.
+> BEGIN
+> SELECT c.oid FROM pg_catalog.pg_class c LIMIT 0;
+> SELECT pg_catalog.format_type(a.atttypid, a.atttypmod) FROM pg_catalog.pg_attribute a LIMIT 0;
+> COMMIT


### PR DESCRIPTION
### Motivation

  * This PR fixes a recognized bug. MaterializeInc/database-issues#2647

### Description

If a view depends on relations from other schemas, include those other
relations in the timedomain.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any user-facing behavior changes.
