### PR TITLE
persistence: Additional upgrade tests

### DIFF
--- a/test/upgrade/README.md
+++ b/test/upgrade/README.md
@@ -38,7 +38,7 @@ To run the tests upgrading from the current source to the current source:
 To run just a particular test or tests:
 
 ```
-./mzcompose down -v ; TD_GLOB=persistent-user-tables ./mzcompose run upgrade
+./mzcompose down -v ; TD_GLOB='persistent-user-tables*' ./mzcompose run upgrade
 ```
 
 ## Test naming convention

--- a/test/upgrade/check-from-v0.9.2-persistent-user-tables-diffs.td
+++ b/test/upgrade/check-from-v0.9.2-persistent-user-tables-diffs.td
@@ -1,0 +1,22 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Generate rows where diffs do not fit in a 32-bit integer
+
+> SELECT COUNT(*) = pow(2, 33)::bigint FROM persistent_user_table_large_positive_diff;
+true
+
+! SELECT * FROM persistent_user_table_negative_diff;
+Invalid data in source, saw retractions (1) for row that does not exist: [Null]
+
+! SELECT * FROM persistent_user_table_large_negative_diff;
+Invalid data in source, saw retractions (8589934592) for row that does not exist: [Null]
+
+> SELECT COUNT(*) = 0 FROM persistent_user_table_cancelling_diffs;
+true

--- a/test/upgrade/check-from-v0.9.2-persistent-user-tables-types.td
+++ b/test/upgrade/check-from-v0.9.2-persistent-user-tables-types.td
@@ -1,0 +1,33 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> SELECT f1 FROM persistence_timestamp_with_time_zone;
+"2007-02-01 09:04:05.123456 UTC"
+
+> SELECT f1::text FROM persistence_nested_array;
+"{{a,\"white space\"},{NULL,\"\"},{\"escape\\\"m\\\\e\",nUlL}}"
+
+> SELECT f1 FROM persistence_decimal;
+1234567890123456.1234567890123456
+
+> SELECT f1 FROM persistence_double;
+1234.5678
+
+> SELECT f1::text FROM persistence_bigint_list_table;
+{0,1}
+{9223372036854775807,-9223372036854775808}
+
+> SELECT f1::text FROM persistence_bigint_list_list_table;
+{{9223372036854775807,-9223372036854775808}}
+
+> SELECT f1::text FROM persistence_bigint_map_table;
+{abcdef=>9223372036854775807}
+
+> SELECT f1::text FROM persistence_bigint_map_map_table;
+"{abcdef=>{\"abc def\"=>-9223372036854775808}}"

--- a/test/upgrade/create-in-v0.9.2-persistent-user-tables-diffs.td
+++ b/test/upgrade/create-in-v0.9.2-persistent-user-tables-diffs.td
@@ -1,0 +1,28 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Generate rows where diffs do not fit in a 32-bit integer
+
+> CREATE TABLE persistent_user_table_large_positive_diff (f1 INTEGER);
+
+> INSERT INTO persistent_user_table_large_positive_diff SELECT * FROM repeat_row(pow(2, 33)::bigint);
+
+> CREATE TABLE persistent_user_table_negative_diff (f1 INTEGER);
+
+> INSERT INTO persistent_user_table_negative_diff SELECT * FROM repeat_row(-1);
+
+> CREATE TABLE persistent_user_table_large_negative_diff (f1 INTEGER);
+
+> INSERT INTO persistent_user_table_large_negative_diff SELECT * FROM repeat_row(-pow(2, 33)::bigint);
+
+> CREATE TABLE persistent_user_table_cancelling_diffs (f1 INTEGER);
+
+> INSERT INTO persistent_user_table_cancelling_diffs SELECT * FROM repeat_row(pow(2, 33)::bigint);
+
+> INSERT INTO persistent_user_table_cancelling_diffs SELECT * FROM repeat_row(-pow(2, 33)::bigint);

--- a/test/upgrade/create-in-v0.9.2-persistent-user-tables-types.td
+++ b/test/upgrade/create-in-v0.9.2-persistent-user-tables-types.td
@@ -1,0 +1,71 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Persist data of various types
+
+> CREATE TABLE persistence_timestamp_with_time_zone (f1 TIMESTAMP WITH TIME ZONE);
+
+> INSERT INTO persistence_timestamp_with_time_zone VALUES ('2007-02-01 15:04:05.123456+06');
+
+> CREATE TABLE persistence_nested_array (f1 text[][]);
+
+> INSERT INTO persistence_nested_array VALUES (ARRAY[ARRAY['a', 'white space'], ARRAY[NULL, ''], ARRAY['escape"m\e', 'nUlL']]);
+
+> CREATE TABLE persistence_decimal (f1 DECIMAL(32, 16));
+
+> INSERT INTO persistence_decimal VALUES (1234567890123456.1234567890123456);
+
+> CREATE TABLE persistence_double (f1 DOUBLE);
+
+> INSERT INTO persistence_double VALUES (1234.5678);
+
+#
+# custom types
+#
+
+> DROP TYPE IF EXISTS persistence_bigint_list_list;
+
+> DROP TYPE IF EXISTS persistence_bigint_list;
+
+> CREATE TYPE persistence_bigint_list AS LIST (element_type = bigint);
+
+> CREATE TABLE persistence_bigint_list_table (f1 persistence_bigint_list);
+
+> INSERT INTO persistence_bigint_list_table VALUES ('{0,1}'::persistence_bigint_list);
+
+> INSERT INTO persistence_bigint_list_table VALUES ('{9223372036854775807,-9223372036854775808}'::persistence_bigint_list);
+
+
+> CREATE TYPE persistence_bigint_list_list AS LIST (element_type = persistence_bigint_list);
+
+> CREATE TABLE persistence_bigint_list_list_table (f1 persistence_bigint_list_list);
+
+> INSERT INTO persistence_bigint_list_list_table VALUES ('{{9223372036854775807,-9223372036854775808}}'::persistence_bigint_list_list);
+
+
+> DROP TYPE IF EXISTS persistence_bigint_map_map;
+
+> DROP TYPE IF EXISTS persistence_bigint_map;
+
+> CREATE TYPE persistence_bigint_map AS MAP (key_type=text, value_type=bigint);
+
+> CREATE TABLE persistence_bigint_map_table (f1 persistence_bigint_map);
+
+> INSERT INTO persistence_bigint_map_table VALUES ('{abcdef=>9223372036854775807}'::persistence_bigint_map);
+
+
+> CREATE TYPE persistence_bigint_map_map AS MAP (key_type=text, value_type=persistence_bigint_map);
+
+> CREATE TABLE persistence_bigint_map_map_table (f1 persistence_bigint_map_map);
+
+> INSERT INTO persistence_bigint_map_map_table VALUES ('{abcdef=>{"abc def"=>-9223372036854775808}}'::persistence_bigint_map_map);
+
+# This panics, see https://github.com/MaterializeInc/materialize/issues/8672
+# > CREATE TABLE persistence_bigint_map_map_array_table (f1 persistence_bigint_map_map[][]);
+# > INSERT INTO persistence_bigint_map_map_array_table VALUES (ARRAY[ARRAY['{ab=>{"cd"=>123}}'::persistence_bigint_map_map, '{ab=>{"cd"=>123}}'::persistence_bigint_map_map], ARRAY['{ab=>{"cd"=>123}}'::persistence_bigint_map_map, '{ab=>{"cd"=>123}}'::persistence_bigint_map_map]]);


### PR DESCRIPTION
### Motivation

In light of recent discussions around the on-disk format for persistence, make sure that various values are represented in the test, especially those that do not neatly fit in u32.

### Description

- data types such as TIMESTAMP, DECIMAL,DOUBLE that are less frequently
  used elsewhere in the test suite
- complex/nested data types
- negative diff values; very large positive diff values and mutual cancellation

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any user-facing behavior changes.
