### PR TITLE
sql: prohibit creating map, list arrays

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -50,6 +50,9 @@ Put breaking changes before other release notes.
 
 {{% version-header v0.9.9 %}}
 
+- **Breaking change.** Fix a bug that inadvertently let users create `char
+  list` columns and custom types. This type is not meant to be supported.
+
 - Optimize some `(table).field1.field2` expressions to only generate the
   columns from `table` that are accessed subsequently. This avoids performance
   issues when extracting a single field from a table expression with several
@@ -57,6 +60,9 @@ Put breaking changes before other release notes.
   {{% gh 8596 %}}
 
 - Let users express `JOIN`-like `DELETE`s with `DELETE...USING`.
+
+- Fix a bug that inadvertently let users create an [`array`] with elements of
+  type [`list`] or [`map`], which crashes Materialize. {{% gh 8672 %}}
 
 {{% version-header v0.9.8 %}}
 
@@ -1347,6 +1353,7 @@ Put breaking changes before other release notes.
 * [What is Materialize?](/overview/what-is-materialize/)
 * [Architecture overview](/overview/architecture/)
 
+[`array`]: /sql/types/array/
 [`bytea`]: /sql/types/bytea
 [`ALTER INDEX`]: /sql/alter-index
 [`CREATE INDEX`]: /sql/create-index
@@ -1356,9 +1363,10 @@ Put breaking changes before other release notes.
 [`date`]: /sql/types/date
 [`double precision`]: /sql/types/float8
 [`interval`]: /sql/types/interval
+[`list`]: /sql/types/list/
+[`map`]: /sql/types/map/
 [`real`]: /sql/types/float4
 [`pgcrypto`]: https://www.postgresql.org/docs/current/pgcrypto.html
-[`real`]: /sql/types/real
 [`SHOW CREATE SOURCE`]: /sql/show-create-source
 [`SHOW CREATE VIEW`]: /sql/show-create-view
 [`text`]: /sql/types/text

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2041,17 +2041,17 @@ pub fn plan_create_type(
                 item_name.name().clone(),
             )?)?;
         let item_id = item.id();
-        if scx
-            .catalog
-            .try_get_lossy_scalar_type_by_id(&item_id)
-            .is_none()
-        {
-            bail!(
+        match scx.catalog.try_get_lossy_scalar_type_by_id(&item_id) {
+            None => bail!(
                 "{} must be of class type, but received {} which is of class {}",
                 key,
                 item.name(),
                 item.item_type()
-            );
+            ),
+            Some(ScalarType::Char { .. }) if as_type == CreateTypeAs::List => {
+                bail_unsupported!("char list")
+            }
+            _ => {}
         }
         ids.push(item_id);
     }

--- a/test/testdrive/array.td
+++ b/test/testdrive/array.td
@@ -19,3 +19,20 @@ array
 array
 ----
 {{a,b},{NULL,d}}
+
+! CREATE TABLE foobar (f1 int list[]);
+integer list[] not yet supported
+
+! SELECT ARRAY[LIST[1]];
+integer list[] not yet supported
+
+> CREATE TYPE bigint_list AS LIST (element_type=bigint);
+! CREATE TABLE bigint_list_arr (f1 bigint_list[]);
+bigint_list[] not yet supported
+
+! SELECT ARRAY['{a => 1}'::map[text=>int]];
+map[text=>integer][] not yet supported
+
+> CREATE TYPE bigint_map AS MAP (key_type=text, value_type=bigint);
+! CREATE TABLE bigint_map_map_array_table (f1 bigint_map[]);
+bigint_map[] not yet supported

--- a/test/testdrive/list.td
+++ b/test/testdrive/list.td
@@ -61,3 +61,9 @@ cannot drop materialize.public.bool: still depended upon by catalog item 'materi
 > DROP TYPE another_custom
 
 > DROP TYPE public.bool
+
+! CREATE TABLE f1 (a char list);
+char list not yet supported
+
+! CREATE TYPE test_schema.bool AS LIST (element_type=char)
+char list not yet supported


### PR DESCRIPTION
### Motivation

This PR fixes a recognized bug. MaterializeInc/database-issues#2654

### Description

We previously accepted list and map arrays in SQL planning, but did not support them in the coordinator. Arrays are an underdeveloped/largely unsupported type in Materialize, so rather than extend support for them, the most sane tack atm is to prevent them from getting planning.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any user-facing behavior changes.
