### PR TITLE
[WIP] sql+coord: support temporary indexes

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -740,6 +740,7 @@ impl Catalog {
                                 name,
                                 &log.variant.desc(),
                                 &log.variant.index_by(),
+                                false,
                             ),
                             conn_id: None,
                             depends_on: vec![log.id],
@@ -756,6 +757,7 @@ impl Catalog {
                         name.clone(),
                         &table.desc,
                         &index_columns,
+                        false,
                     );
                     let oid = catalog.allocate_oid()?;
                     let persist = if table.persistent {

--- a/src/coord/src/catalog/migrate.rs
+++ b/src/coord/src/catalog/migrate.rs
@@ -187,6 +187,7 @@ fn ast_rewrite_pg_catalog_char_to_text_0_9_1(
         }) => TypeNormalizer.visit_query_mut(query),
 
         Statement::CreateIndex(CreateIndexStatement {
+            is_temporary: _,
             name: _,
             on_name: _,
             key_parts,
@@ -332,6 +333,7 @@ fn ast_use_pg_catalog_0_7_1(stmt: &mut sql::ast::Statement<Raw>) -> Result<(), a
         }) => FuncNormalizer.visit_query_mut(query),
 
         Statement::CreateIndex(CreateIndexStatement {
+            is_temporary: _,
             name: _,
             on_name: _,
             key_parts,
@@ -430,6 +432,7 @@ fn ast_rewrite_type_references_0_6_1(
         }) => TypeNormalizer.visit_query_mut(query),
 
         Statement::CreateIndex(CreateIndexStatement {
+            is_temporary: _,
             name: _,
             on_name: _,
             key_parts,

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -675,6 +675,7 @@ impl_display_t!(CreateTableStatement);
 /// `CREATE INDEX`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CreateIndexStatement<T: AstInfo> {
+    pub is_temporary: bool,
     /// Optional index name.
     pub name: Option<Ident>,
     /// `ON` table or view name
@@ -689,6 +690,9 @@ pub struct CreateIndexStatement<T: AstInfo> {
 impl<T: AstInfo> AstDisplay for CreateIndexStatement<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("CREATE ");
+        if self.is_temporary {
+            f.write_str("TEMPORARY ");
+        }
         if self.key_parts.is_none() {
             f.write_str("DEFAULT ");
         }

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2097,6 +2097,8 @@ impl<'a> Parser<'a> {
         let default_index = self.parse_keyword(DEFAULT);
         self.expect_keyword(INDEX)?;
 
+        let is_temporary = self.parse_keyword(TEMPORARY) | self.parse_keyword(TEMP);
+
         let if_not_exists = self.parse_if_not_exists()?;
         let name = if self.parse_keyword(ON) {
             if if_not_exists && !default_index {
@@ -2131,6 +2133,7 @@ impl<'a> Parser<'a> {
         let with_options = self.parse_opt_with_options()?;
 
         Ok(Statement::CreateIndex(CreateIndexStatement {
+            is_temporary,
             name,
             on_name,
             key_parts,

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -345,6 +345,7 @@ pub fn create_statement(
         }
 
         Statement::CreateIndex(CreateIndexStatement {
+            is_temporary: _,
             name: _,
             on_name,
             key_parts,

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -382,6 +382,7 @@ pub struct View {
 pub struct Index {
     pub create_sql: String,
     pub on: GlobalId,
+    pub is_temporary: bool,
     pub keys: Vec<::expr::MirScalarExpr>,
     pub depends_on: Vec<GlobalId>,
 }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1886,6 +1886,7 @@ pub fn plan_create_index(
     mut stmt: CreateIndexStatement<Raw>,
 ) -> Result<Plan, anyhow::Error> {
     let CreateIndexStatement {
+        is_temporary,
         name,
         on_name,
         key_parts,
@@ -1966,6 +1967,7 @@ pub fn plan_create_index(
     *name = Some(Ident::new(index_name.item.clone()));
     *key_parts = Some(filled_key_parts);
     let if_not_exists = *if_not_exists;
+    let is_temporary = *is_temporary;
     let create_sql = normalize::create_statement(scx, Statement::CreateIndex(stmt))?;
     let mut depends_on = vec![on.id()];
     depends_on.extend(exprs_depend_on);
@@ -1975,6 +1977,7 @@ pub fn plan_create_index(
         index: Index {
             create_sql,
             on: on.id(),
+            is_temporary,
             keys,
             depends_on,
         },


### PR DESCRIPTION
This is a WIP--still needs to figure out how to ensure we don't build dataflows for non-temporary objects using these indexes, which might themselves be "on" non-temporary objects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/8682)
<!-- Reviewable:end -->
