### PR TITLE
sql/transform: bypass planning and optimization on known constant inputs

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -3956,7 +3956,7 @@ impl Coordinator {
         mut expr: MirRelationExpr,
         style: ExprPrepStyle,
     ) -> Result<OptimizedMirRelationExpr, CoordError> {
-        if let ExprPrepStyle::Static = style {
+        if let ExprPrepStyle::Static = &style {
             let mut opt_expr = self.view_optimizer.optimize(expr)?;
             opt_expr.0.try_visit_mut(&mut |e| {
                 // Carefully test filter expressions, which may represent temporal filters.
@@ -3974,11 +3974,19 @@ impl Coordinator {
             Ok(opt_expr)
         } else {
             expr.try_visit_scalars_mut(&mut |s| Self::prep_scalar_expr(s, style))?;
-            // TODO (wangandi): Is there anything that optimizes to a
-            // constant expression that originally contains a global get? Is
-            // there anything not containing a global get that cannot be
-            // optimized to a constant expression?
-            Ok(self.view_optimizer.optimize(expr)?)
+
+            if let (ExprPrepStyle::Write, expr::MirRelationExpr::Constant { .. }) = (&style, &expr)
+            {
+                // We don't perform any optimizations on an expression that is already
+                // a constant for writes, as we want to maximize bulk-insert throughput.
+                Ok(OptimizedMirRelationExpr(expr))
+            } else {
+                // TODO (wangandi): Is there anything that optimizes to a
+                // constant expression that originally contains a global get? Is
+                // there anything not containing a global get that cannot be
+                // optimized to a constant expression?
+                Ok(self.view_optimizer.optimize(expr)?)
+            }
         }
     }
 

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -652,6 +652,16 @@ pub fn plan_copy_from_rows(
         typ: typ.clone(),
     };
 
+    // Exit early with just the raw constant if we know that all columns are present
+    // and in the correct order. This lets us bypass expensive downstream optimizations
+    // more easily, as at every stage we know this expression is nothing more than
+    // a constant (as opposed to e.g. a constant with wiith an identity map and identity
+    // projection).
+    let default: Vec<_> = (0..desc.arity()).collect();
+    if columns == default {
+        return Ok(expr);
+    }
+
     // Fill in any omitted columns and rearrange into correct order
     let mut map_exprs = vec![];
     let mut project_key = Vec::with_capacity(desc.arity());


### PR DESCRIPTION
### Motivation

This PR makes `COPY FROM` faster by bypassing planning and optimizations for known constant inputs like `COPY ... FROM STDIN` when all columns are specified. I'm sure the sql / optimization teams likely either have better ways to achieve the same end, or have good reasons why one shouldn't write the special casing I've just written. I'd love to hear them! This is mostly meant as a prototype for discussion. This improves the performance of copy from by a factor of about 4x (~8 seconds -> ~1.8 seconds) for 100 million 110 byte rows which is the standard benchmark I've been using to test persistence.
