### PR TITLE
doc: Add Materialize status page link

### DIFF
--- a/doc/user/content/cloud/troubleshoot-cloud.md
+++ b/doc/user/content/cloud/troubleshoot-cloud.md
@@ -9,10 +9,16 @@ menu:
 
 {{< cloud-notice >}}
 
+
 We're working on other monitoring tools, but for now there are a few tools you can use for troubleshooting issues with Materialize Cloud:
 
+* Status check
 * Logs
 * Monitoring integrations
+
+## Status check
+
+You can check on the status of Materialize systems at [https://status.materialize.com](https://status.materialize.com). You can also sign up at the page to be notified of any incidents through email, text, Slack, or Atom or RSS feed.
 
 ## Logs
 

--- a/doc/user/layouts/partials/footer.html
+++ b/doc/user/layouts/partials/footer.html
@@ -1,3 +1,3 @@
 <footer class="footer">
-    &copy; {{ now.Format "2006" }} Materialize Inc. &mdash; <a href="https://materialize.com">Materialize Home</a> | <a href="https://materialize.com/blog">Blog</a> | <a href="https://materialize.com/contact">Contact</a> | <a href="https://materialize.com/privacy-policy/">Privacy Policy</a>
+    &copy; {{ now.Format "2006" }} Materialize Inc. &mdash; <a href="https://materialize.com">Materialize Home</a> | <a href="https://status.materialize.com">Status</a> | <a href="https://materialize.com/blog">Blog</a> | <a href="https://materialize.com/contact">Contact</a> | <a href="https://materialize.com/privacy-policy/">Privacy Policy</a>
 </footer>


### PR DESCRIPTION
Adds link to Materialize Status page to Docs header and footer and Cloud troubleshooting page.

### Motivation

  * This PR adds a known-desirable feature. [#8460 ]

 
### Tips for reviewer

The request was for the footer, but I think it might be worth adding to the header as well. I don't have a Materialize logo in the matching color, though. Let me know if I should keep or remove.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any
  [user-facing behavior changes](/doc/user/content/release-notes.md#What-changes-require-a-release-note).
