### PR TITLE
persist: re-enable read_output in nemesis

### DIFF
--- a/src/persist/src/golden_test.rs
+++ b/src/persist/src/golden_test.rs
@@ -113,6 +113,7 @@ fn golden() -> Result<(), Error> {
     config.storage_available = 0;
     config.start_weight = 0;
     config.stop_weight = 0;
+    config.read_output_weight = 0;
     let g = Generator::new(seed, config);
     let reqs = g.into_iter().take(100).collect::<Vec<_>>();
 

--- a/src/persist/src/nemesis/generator.rs
+++ b/src/persist/src/nemesis/generator.rs
@@ -63,10 +63,6 @@ impl Default for GeneratorConfig {
         // NB: If we need to temporarily disable an operation in all the nemesis
         // tests, set it to 0 here. (As opposed to clearing it in the impl of
         // `all_operations`, which will break the Generator tests.)
-
-        // TODO: re-enable when we can figure out how to make this work with
-        // trace compaction.
-        ops.read_output_weight = 0;
         ops
     }
 }


### PR DESCRIPTION
It was disabled when we added logical compaction to trace because we
didn't understand what the validator contract should be at the time.
It's clear now that MaterializeInc/database-issues#2635 is the answer here and in the meantime, we can
approximate it.
