### PR TITLE
sql: add current_database function

### DIFF
--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -534,6 +534,9 @@
     description: Returns the number of workers in use by the server.
   - signature: 'format_type(oid: int, typemod: int) -> text'
     description: Returns the canonical SQL name for the type specified by `oid` with `typemod` applied.
+  - signature: 'current_database() -> text'
+    description: >-
+      Returns the name of the current database.
   - signature: 'current_role() -> text'
     description: >-
       Alias for `current_user`.

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1367,6 +1367,12 @@ lazy_static! {
                     })
                 }), 1403;
             },
+            "current_database" => Scalar {
+                params!() => Operation::nullary(|ecx| {
+                    let datum = Datum::String(ecx.qcx.scx.catalog.default_database());
+                    Ok(HirScalarExpr::literal(datum, ScalarType::String))
+                }), 861;
+            },
             "current_user" => Scalar {
                 params!() => Operation::nullary(|ecx| {
                     let datum = Datum::String(ecx.qcx.scx.catalog.user());

--- a/test/sqllogictest/current_database.slt
+++ b/test/sqllogictest/current_database.slt
@@ -1,0 +1,26 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+mode cockroach
+
+query T
+SELECT current_database()
+----
+materialize
+
+statement ok
+CREATE DATABASE otherdb
+
+statement ok
+SET database TO otherdb
+
+query T
+SELECT current_database()
+----
+otherdb


### PR DESCRIPTION
### Motivation

This PR adds `current_database`, a builtin Postgres function which is used by DataGrip.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any
  [user-facing behavior changes](/doc/user/content/release-notes.md#What-changes-require-a-release-note).