### PR TITLE
Fix periodic tests to not automatically set the AWS profile

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -104,7 +104,6 @@ case "$cmd" in
             --env CI
             --env GPG_KEY
             --env PYPI_TOKEN
-            --env MZ_SCRATCH_NO_DEFAULT_ENV
         )
         if [[ -t 1 ]]; then
             args+=(--tty)

--- a/ci/load/pipeline.yml
+++ b/ci/load/pipeline.yml
@@ -10,17 +10,15 @@
 # Fires periodic load tests
 
 steps:
-  - command: bin/ci-builder run stable bin/pyactivate --dev -m ci.load.periodic
+  - command: bin/ci-builder run stable env MZ_SCRATCH_NO_DEFAULT_ENV=1 bin/pyactivate --dev -m ci.load.periodic
     timeout_in_minutes: 10
     env:
       AWS_DEFAULT_REGION: us-east-2
-      MZ_SCRATCH_NO_DEFAULT_ENV: yep
     plugins:
        - ./ci/plugins/scratch-aws-access
-  - command: bin/ci-builder run stable bin/pyactivate --dev -m materialize.cli.cloudbench start --profile confluent --trials 3 --revs HEAD  --append_metadata --s3_root mz-periodic-cloudbench/avro_ingest_periodic materialize.benches.avro_ingest -r 1000000 -n 10 -d big-records
+  - command: bin/ci-builder run stable env MZ_SCRATCH_NO_DEFAULT_ENV=1 bin/pyactivate --dev -m materialize.cli.cloudbench start --profile confluent --trials 3 --revs HEAD  --append_metadata --s3_root mz-periodic-cloudbench/avro_ingest_periodic materialize.benches.avro_ingest -r 1000000 -n 10 -d big-records
     timeout_in_minutes: 20
     env:
       AWS_DEFAULT_REGION: us-east-2
-      MZ_SCRATCH_NO_DEFAULT_ENV: yep
     plugins:
        - ./ci/plugins/scratch-aws-access


### PR DESCRIPTION
This was causing the `cloudbench` run that we kick off in Buildkite to fail looking for an `mz-scratch-admin` profile: https://buildkite.com/materialize/periodic-load-tests/builds/18#d41d342e-bbd9-4fa7-a9c7-953f4b5254d2