### PR TITLE
Suggest an order for release note items 

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -92,8 +92,13 @@ Use relative links (/path/to/doc), not absolute links
 
 Wrap your release notes at the 80 character mark.
 
+## Internal note order
+
 Put breaking changes before other release notes, and mark them with
 `**Breaking change.**` at the start.
+
+List new features before bug fixes.
+
 {{< /comment >}}
 
 {{% version-header v0.9.9 %}}


### PR DESCRIPTION


### Motivation

I propose to add a little more structure to the release notes by specifying an order for items in them: breaking changes first as currently, then new features, then bug fixes.
 

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any
  [user-facing behavior changes](/doc/user/content/release-notes.md#What-changes-require-a-release-note).
