### PR TITLE
doc: Configure Postgres CDC on Cloud services

### DIFF
--- a/doc/user/content/guides/cdc-mysql.md
+++ b/doc/user/content/guides/cdc-mysql.md
@@ -1,7 +1,7 @@
 ---
 title: "Change Data Capture (MySQL)"
 description: "How to create real-time materialized views from MySQL changelog data with Materialize."
-weight: 10
+weight:
 menu:
   main:
     parent: guides

--- a/doc/user/content/guides/cdc-postgres.md
+++ b/doc/user/content/guides/cdc-postgres.md
@@ -1,7 +1,7 @@
 ---
 title: "Change Data Capture (Postgres)"
 description: "How to create real-time materialized views from PostgreSQL changelog data with Materialize."
-weight: 10
+weight:
 menu:
   main:
     parent: guides
@@ -21,11 +21,13 @@ There are two ways to connect Materialize to a Postgres database for CDC:
 
 If Kafka is not part of your stack, you can use the [Postgres source](/sql/create-source/postgres/#postgresql-source-details) to connect directly to Materialize (v0.8.2+). This source uses Postgres’ native replication protocol to continuously ingest changes resulting from `INSERT`, `UPDATE` and `DELETE` operations in the upstream database.
 
-### Database Setup
+### Database setup
 
 **Minimum requirements:** Postgres 10+
 
-Before creating a source in Materialize, you need to ensure that the upstream database is configured to support [logical replication](https://www.postgresql.org/docs/10/logical-replication.html). As a _superuser_:
+Before creating a source in Materialize, you need to ensure that the upstream database is configured to support [logical replication](https://www.postgresql.org/docs/10/logical-replication.html).
+
+As a _superuser_:
 
 1. Check the [`wal_level` configuration](https://www.postgresql.org/docs/current/wal-configuration.html) setting:
 
@@ -35,7 +37,7 @@ Before creating a source in Materialize, you need to ensure that the upstream da
 
     The default value is `replica`. For CDC, you'll need to set it to `logical` in the database configuration file (`postgresql.conf`). Keep in mind that changing the `wal_level` requires a restart of the Postgres instance and can affect database performance.
 
-    **Note:** Additional steps may be required if you're using Postgres on [Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts.General.FeatureSupport.LogicalReplication) or [Cloud SQL](https://cloud.google.com/sql/docs/postgres/replication/configure-logical-replication#configuring-your-postgresql-instance).
+    **Note:** If you're using Postgres on a Cloud service like Amazon RDS, AWS Aurora, or Cloud SQL, you'll need to take some additional steps. For more information, see [Postgres in the Cloud](../postgres-cloud/).
 
 1. Grant the required privileges to the replication user:
 
@@ -140,11 +142,13 @@ GROUP BY field1;
 
 If Kafka is part of your stack, you can use [Debezium](https://debezium.io/) and the [Kafka source](/sql/create-source/avro-kafka/#debezium-envelope-details) to propagate CDC data from Postgres to Materialize. Debezium captures row-level changes resulting from `INSERT`, `UPDATE` and `DELETE` operations in the upstream database and publishes them as events to Kafka using Kafka Connect-compatible connectors.
 
-### Database Setup
+### Database setup
 
 **Minimum requirements:** Postgres 10+
 
-Before deploying a Debezium connector, you need to ensure that the upstream database is configured to support [logical replication](https://www.postgresql.org/docs/10/logical-replication.html). As a _superuser_:
+Before deploying a Debezium connector, you need to ensure that the upstream database is configured to support [logical replication](https://www.postgresql.org/docs/10/logical-replication.html).
+
+As a _superuser_:
 
 1. Check the [`wal_level` configuration](https://www.postgresql.org/docs/current/wal-configuration.html) setting:
 
@@ -154,7 +158,7 @@ Before deploying a Debezium connector, you need to ensure that the upstream data
 
     The default value is `replica`. For CDC, you'll need to set it to `logical` in the database configuration file (`postgresql.conf`). Keep in mind that changing the `wal_level` requires a restart of the Postgres instance and can affect database performance.
 
-    **Note:** Additional steps may be required if you're using Postgres on [Amazon RDS](https://debezium.io/documentation/reference/1.6/connectors/postgresql.html#postgresql-on-amazon-rds).
+    **Note:** If you're using Postgres on a Cloud service like Amazon RDS, AWS Aurora, or Cloud SQL, you'll need to take some additional steps. For more information, see [Postgres in the Cloud](../postgres-cloud/).
 
 1. Grant enough privileges to ensure Debezium can operate in the database. The specific privileges will depend on how much control you want to give to the replication user, so we recommend following the [Debezium documentation](https://debezium.io/documentation/reference/connectors/postgresql.html#postgresql-replication-user-privileges).
 

--- a/doc/user/content/guides/node-js.md
+++ b/doc/user/content/guides/node-js.md
@@ -1,7 +1,7 @@
 ---
 title: "Node.js and Materialize"
 description: "Use Node.js to connect, insert, manage, query and stream from Materialize."
-weight: 20
+weight:
 menu:
   main:
     parent: guides

--- a/doc/user/content/guides/postgres-cloud.md
+++ b/doc/user/content/guides/postgres-cloud.md
@@ -1,0 +1,129 @@
+---
+title: "Postgres in the Cloud"
+description: "How to configure Postgres CDC hosted on Cloud services"
+weight:
+menu:
+  main:
+    parent: guides
+aliases:
+---
+
+**Required:** PostgreSQL 10+
+
+It is possible to use a PostgreSQL database running on Amazon RDS, AWS Aurora, or Cloud SQL for [Change Data Capture](../cdc-postgres/) with Materialize, but it requires enabling logical replication in your PostgreSQL instances.
+
+Note that enabling logical replication may affect performance.
+
+## Amazon RDS
+
+The AWS user account requires the `rds_superuser` role to perform logical replication for the PostgreSQL database on Amazon RDS.
+
+As an account with the `rds_superuser` role, make these changes to the upstream database:
+
+1. Create a custom RDS parameter group with your instance and associate it with your instance. You will not be able to set custom parameters on the default RDS parameter groups.
+
+1. In the custom RDS parameter group, set the `rds.logical_replication` static parameter to `1`.
+
+1. The Materialize replica will need access to connect to the upstream database. This is usually controlled by IP address. If you are hosting your own installation of Materialize, add the replica's IP address in the security group for the RDS instance.
+
+    If you are using Materialize Cloud, you will need to make the RDS instance publicly accessible; Materialize Cloud instances do not have static IP addresses.
+
+1. Restart the database so all changes can take effect.
+
+1. Create a [publication](https://www.postgresql.org/docs/current/logical-replication-publication.html) with the tables you want to replicate:
+
+    _For specific tables:_
+
+    ```sql
+    CREATE PUBLICATION mz_source FOR TABLE table1, table2;
+    ```
+
+    _For all tables in Postgres:_
+
+    ```sql
+    CREATE PUBLICATION mz_source FOR ALL TABLES;
+    ```
+
+    The `mz_source` publication will contain the set of change events generated from the specified tables, and will later be used to ingest the replication stream. We strongly recommend that you **limit** publications only to the tables you need.
+
+For more information, see the [Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts.General.FeatureSupport.LogicalReplication) documentation.
+
+## AWS Aurora
+
+As a superuser, make these changes to the upstream database:
+
+1. Create a DB cluster parameter group for your instance. Use the following settings:
+
+    Set **Parameter group family** to your version of Aurora PostgreSQL.
+
+     Set **Type** to **DB Cluster Parameter Group**.
+
+1. In the DB cluster parameter group, set the `rds.logical_replication` static parameter to `1`.
+
+1. In the DB cluster parameter group, set `max_replication_slots`, `max_wal_senders`, `max_logical_replication_workers`, and `max_worker_processes parameters`  based on your expected usage.
+
+    Parameter | Recommended Minimum Value
+    ----------|--------------------------
+    **max_replication_slots** | The combined number of logical replication publications and subscriptions you plan to create.
+    **max_wal_senders** |  The number of logical replication slots that you intend to be active, or the number of active AWS DMS tasks for change data capture.
+    **max_logical_replication_workers**  |  The number of logical replication slots that you intend to be active, or the number of active AWS DMS tasks for change data capture.
+    **max_worker_processes**  | The combined values of `max_logical_replication_workers`, `autovacuum_max_workers`, and `max_parallel_workers`.
+
+1. The Materialize replica will need access to connect to the upstream database. This is usually controlled by IP address. If you are hosting your own installation of Materialize, add the replica's IP address in the security group for the DB instance.
+
+    If you are using Materialize Cloud, you will need to make the DB instance publicly accessible; Materialize Cloud instances do not have static IP addresses.
+
+1. Restart the database so all changes can take effect.
+
+1. Create a [publication](https://www.postgresql.org/docs/current/logical-replication-publication.html) with the tables you want to replicate:
+
+    _For specific tables:_
+
+    ```sql
+    CREATE PUBLICATION mz_source FOR TABLE table1, table2;
+    ```
+
+    _For all tables in Postgres:_
+
+    ```sql
+    CREATE PUBLICATION mz_source FOR ALL TABLES;
+    ```
+
+    The `mz_source` publication will contain the set of change events generated from the specified tables, and will later be used to ingest the replication stream. We strongly recommend that you **limit** publications only to the tables you need.
+
+For more information, see the [AWS Aurora](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Replication.Logical.html#AuroraPostgreSQL.Replication.Logical.Configure) documentation.
+
+## Cloud SQL
+
+As a user with the `cloudsqlsuperuser` role, make these changes to the upstream database:
+
+1. In the Google Cloud Console, set the `cloudsql.logical_decoding` to `on`. This enables logical replication.
+
+1. The Materialize replica will need access to connect to the upstream database. In the Google Cloud Console, enable access on the upstream database for the Materialize replica's IP address.
+
+      If you are using Materialize Cloud, you will need to make the Cloud SQL instance publically accessible; Materialize Cloud instances do not have static IP addresses.
+
+1. Restart the database to apply your changes.
+
+1. Create a [publication](https://www.postgresql.org/docs/current/logical-replication-publication.html) with the tables you want to replicate:
+
+    _For specific tables:_
+
+    ```sql
+    CREATE PUBLICATION mz_source FOR TABLE table1, table2;
+    ```
+
+    _For all tables in Postgres:_
+
+    ```sql
+    CREATE PUBLICATION mz_source FOR ALL TABLES;
+    ```
+
+    The `mz_source` publication will contain the set of change events generated from the specified tables, and will later be used to ingest the replication stream. We strongly recommend that you **limit** publications only to the tables you need.
+
+For more information, see the [Cloud SQL](https://cloud.google.com/sql/docs/postgres/replication/configure-logical-replication#configuring-your-postgresql-instance) documentation.
+
+## Related pages
+
+- [Change Data Capture with PostgreSQL](../cdc-postgres/)
+- [`CREATE SOURCE FROM POSTGRES`](/sql/create-source/postgres/)

--- a/doc/user/content/guides/reuse-topic-for-kafka-sink.md
+++ b/doc/user/content/guides/reuse-topic-for-kafka-sink.md
@@ -1,7 +1,7 @@
 ---
 title: "Kafka Sink Topic Reuse"
 description: "Enable topic reuse for Kafka sinks (exactly-once Kafka sinks)."
-weight: 10
+weight:
 menu:
   main:
     parent: guides

--- a/doc/user/content/guides/temporal-filters.md
+++ b/doc/user/content/guides/temporal-filters.md
@@ -1,7 +1,7 @@
 ---
 title: "Temporal Filters"
 description: "Perform time-windowed computation over temporal data."
-weight: 30
+weight:
 menu:
   main:
     parent: guides

--- a/doc/user/content/guides/top-k.md
+++ b/doc/user/content/guides/top-k.md
@@ -1,7 +1,7 @@
 ---
 title: "Top K by Group"
 description: "Find the top- or bottom-K elements in a group."
-weight: 40
+weight:
 aliases:
   - /sql/idioms
 menu:

--- a/doc/user/content/sql/create-source/postgres.md
+++ b/doc/user/content/sql/create-source/postgres.md
@@ -86,7 +86,9 @@ Postgres sources in Materialize require that upstream Postgres instances be [ver
 
 Before you create a Postgres source in Materialize, you must complete the following prerequisite steps in Postgres.
 
-1. Ensure the database configuration allows logical replication. For most configurations, it should suffice to set `wal_level = logical` in `postgresql.conf`, but additional steps may be required for Amazon RDS. See the [Amazon Relational Database Service Documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts.General.FeatureSupport.LogicalReplication) for details.
+1. Ensure the database configuration allows logical replication. For most configurations, it should suffice to set `wal_level = logical` in `postgresql.conf`.
+
+    **Note:** If you're using Postgres on a Cloud service like Amazon RDS, AWS Aurora, or Cloud SQL, you'll need to take some additional steps. For more information, see [Postgres in the Cloud](/guides/postgres-cloud/).
 
 2. Assign the user `REPLICATION` privileges:
     ```sql


### PR DESCRIPTION
Added instructions on configuring Amazon RDS and Cloud SQL for Postgres CDC.

### Motivation
 
  * This PR adds a known-desirable feature. [#7235 ]
 

### Tips for reviewer

Google has instructions about [configuring pglogical ](https://cloud.google.com/sql/docs/postgres/replication/configure-logical-replication) -- do we need to do that for the upstream database and/or for Materialize?

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any
  [user-facing behavior changes](/doc/user/content/release-notes.md#What-changes-require-a-release-note).
