### PR TITLE
dataflow,persist: wire persistence configs, this enables previously added persistence code

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -530,6 +530,7 @@ pub struct Source {
     pub connector: SourceConnector,
     pub bare_desc: RelationDesc,
     pub desc: RelationDesc,
+    pub persist_name: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -950,6 +951,7 @@ impl Catalog {
                             },
                             bare_desc: log.variant.desc(),
                             desc: log.variant.desc(),
+                            persist_name: None,
                         }),
                     );
                     let oid = catalog.allocate_oid()?;
@@ -2163,7 +2165,7 @@ impl Catalog {
             CatalogItem::Source(source) => SerializedCatalogItem::V1 {
                 create_sql: source.create_sql.clone(),
                 eval_env: None,
-                persist_name: None,
+                persist_name: source.persist_name.clone(),
             },
             CatalogItem::View(view) => SerializedCatalogItem::V1 {
                 create_sql: view.create_sql.clone(),
@@ -2230,6 +2232,7 @@ impl Catalog {
                     connector: source.connector,
                     bare_desc: source.bare_desc,
                     desc: transformed_desc,
+                    persist_name,
                 })
             }
             Plan::CreateView(CreateViewPlan { view, .. }) => {
@@ -2433,6 +2436,16 @@ impl Catalog {
 
     pub fn persist_multi_details(&self) -> Option<&PersistMultiDetails> {
         self.state.by_id.persist_multi_details()
+    }
+
+    pub fn source_persist_name(
+        &self,
+        id: GlobalId,
+        connector: &SourceConnector,
+        name: &FullName,
+    ) -> Option<String> {
+        self.persist
+            .source_stream_name(id, connector, &name.to_string())
     }
 }
 

--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -947,7 +947,6 @@ impl Catalog {
                             optimized_expr,
                             connector: dataflow_types::SourceConnector::Local {
                                 timeline: Timeline::EpochMilliseconds,
-                                persisted_name: None,
                             },
                             bare_desc: log.variant.desc(),
                             desc: log.variant.desc(),

--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -763,7 +763,8 @@ lazy_static! {
             .with_named_column("schema_id", ScalarType::Int64.nullable(false))
             .with_named_column("name", ScalarType::String.nullable(false))
             .with_named_column("connector_type", ScalarType::String.nullable(false))
-            .with_named_column("volatility", ScalarType::String.nullable(false)),
+            .with_named_column("volatility", ScalarType::String.nullable(false))
+            .with_named_column("persisted_name", ScalarType::String.nullable(true)),
         id: GlobalId::System(4021),
         index_id: GlobalId::System(4022),
         persistent: false,

--- a/src/coord/src/catalog/builtin_table_updates.rs
+++ b/src/coord/src/catalog/builtin_table_updates.rs
@@ -181,6 +181,7 @@ impl CatalogState {
         source: &Source,
         diff: Diff,
     ) -> Vec<BuiltinTableUpdate> {
+        let persisted_name_datum = Datum::from(source.persist_name.as_ref().map(|s| s.as_str()));
         vec![BuiltinTableUpdate {
             id: MZ_SOURCES.id,
             row: Row::pack_slice(&[
@@ -190,6 +191,7 @@ impl CatalogState {
                 Datum::String(name),
                 Datum::String(source.connector.name()),
                 Datum::String(self.is_volatile(id).as_str()),
+                persisted_name_datum,
             ]),
             diff,
         }]

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -2204,15 +2204,22 @@ impl Coordinator {
             } = plan;
             let optimized_expr = self.view_optimizer.optimize(source.expr)?;
             let transformed_desc = RelationDesc::new(optimized_expr.0.typ(), source.column_names);
+
+            let source_id = self.catalog.allocate_id()?;
+            let source_oid = self.catalog.allocate_oid()?;
+
+            let persist_name =
+                self.catalog
+                    .source_persist_name(source_id, &source.connector, &name);
+
             let source = catalog::Source {
                 create_sql: source.create_sql,
                 optimized_expr,
                 connector: source.connector,
                 bare_desc: source.bare_desc,
                 desc: transformed_desc,
+                persist_name,
             };
-            let source_id = self.catalog.allocate_id()?;
-            let source_oid = self.catalog.allocate_oid()?;
             ops.push(catalog::Op::CreateItem {
                 id: source_id,
                 oid: source_oid,

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -4527,7 +4527,6 @@ pub fn serve_debug(
                         GlobalId::System(_),
                         SourceConnector::Local {
                             timeline: Timeline::EpochMilliseconds,
-                            persisted_name: None,
                         },
                     )
                     | TimestampMessage::Add(

--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -117,7 +117,7 @@ impl<'a> DataflowBuilder<'a> {
                                 connector: source.connector.clone(),
                                 operators: None,
                                 bare_desc: source.bare_desc.clone(),
-                                persisted_name: None,
+                                persisted_name: source.persist_name.clone(),
                             },
                             *id,
                         );
@@ -132,7 +132,7 @@ impl<'a> DataflowBuilder<'a> {
                                 connector: source.connector.clone(),
                                 operators: None,
                                 bare_desc: source.bare_desc.clone(),
-                                persisted_name: None,
+                                persisted_name: source.persist_name.clone(),
                             },
                             *id,
                         );

--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -100,13 +100,10 @@ impl<'a> DataflowBuilder<'a> {
                             name: entry.name().to_string(),
                             connector: SourceConnector::Local {
                                 timeline: table.timeline(),
-                                persisted_name: table
-                                    .persist
-                                    .as_ref()
-                                    .map(|p| p.stream_name.clone()),
                             },
                             operators: None,
                             bare_desc: table.desc.clone(),
+                            persisted_name: table.persist.as_ref().map(|p| p.stream_name.clone()),
                         },
                         *id,
                     );
@@ -120,6 +117,7 @@ impl<'a> DataflowBuilder<'a> {
                                 connector: source.connector.clone(),
                                 operators: None,
                                 bare_desc: source.bare_desc.clone(),
+                                persisted_name: None,
                             },
                             *id,
                         );
@@ -134,6 +132,7 @@ impl<'a> DataflowBuilder<'a> {
                                 connector: source.connector.clone(),
                                 operators: None,
                                 bare_desc: source.bare_desc.clone(),
+                                persisted_name: None,
                             },
                             *id,
                         );

--- a/src/coord/src/persistcfg.rs
+++ b/src/coord/src/persistcfg.rs
@@ -13,6 +13,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
+use dataflow_types::{ExternalSourceConnector, SourceConnector, SourceEnvelope};
 use ore::metrics::MetricsRegistry;
 use persist::error::{Error, ErrorLog};
 use persist::indexed::encoding::Id;
@@ -96,6 +97,9 @@ pub struct PersistConfig {
     /// extremely experimental and should not even be tried by users. It's
     /// initially here for end-to-end testing.
     pub system_table_enabled: bool,
+    /// Whether to make Kafka Upserts persistent for fast restarts. This is
+    /// extremely experimental and should not even be tried by users.
+    pub kafka_upsert_source_enabled: bool,
     /// Unstructured information stored in the "lock" files created by the
     /// log and blob to ensure that they are exclusive writers to those
     /// locations. This should contain whatever information might be useful to
@@ -112,6 +116,7 @@ impl PersistConfig {
             storage: PersistStorage::File(PersistFileStorage::default()),
             user_table_enabled: false,
             system_table_enabled: false,
+            kafka_upsert_source_enabled: false,
             lock_info: Default::default(),
             min_step_interval: Duration::default(),
         }
@@ -125,7 +130,10 @@ impl PersistConfig {
         catalog_id: Uuid,
         reg: &MetricsRegistry,
     ) -> Result<PersisterWithConfig, Error> {
-        let persister = if self.user_table_enabled || self.system_table_enabled {
+        let persister = if self.user_table_enabled
+            || self.system_table_enabled
+            || self.kafka_upsert_source_enabled
+        {
             let lock_reentrance_id = catalog_id.to_string();
             let lock_info = LockInfo::new(lock_reentrance_id, self.lock_info.clone())?;
             let log = ErrorLog;
@@ -208,6 +216,27 @@ impl PersisterWithConfig {
             stream_name,
             write_handle,
         }))
+    }
+
+    pub fn source_stream_name(
+        &self,
+        id: GlobalId,
+        connector: &SourceConnector,
+        pretty: &str,
+    ) -> Option<String> {
+        match connector {
+            SourceConnector::External {
+                connector: ExternalSourceConnector::Kafka(_),
+                envelope: SourceEnvelope::Upsert,
+                ..
+            } if self.config.kafka_upsert_source_enabled => {
+                // NB: This gets written down in the catalog, so it should be
+                // safe to change the naming, if necessary. See
+                // Catalog::deserialize_item.
+                Some(format!("user-source-{}-{}", id, pretty))
+            }
+            _ => None,
+        }
     }
 }
 

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -647,6 +647,7 @@ pub struct SourceDesc {
     /// to the output of the source.
     pub operators: Option<LinearOperator>,
     pub bare_desc: RelationDesc,
+    pub persisted_name: Option<String>,
 }
 
 /// A sink for updates to a relational collection.
@@ -752,7 +753,6 @@ pub enum SourceConnector {
     },
     Local {
         timeline: Timeline,
-        persisted_name: Option<String>,
     },
 }
 

--- a/src/dataflow/src/render/upsert.rs
+++ b/src/dataflow/src/render/upsert.rs
@@ -11,7 +11,6 @@ use std::collections::{BTreeMap, HashMap};
 
 use differential_dataflow::hashable::Hashable;
 use differential_dataflow::lattice::Lattice;
-use differential_dataflow::{AsCollection, Collection};
 
 use timely::dataflow::channels::pact::Exchange;
 use timely::dataflow::operators::{Concat, Map, OkErr, Operator};
@@ -48,8 +47,8 @@ pub fn upsert<G>(
         PersistentUpsertConfig<Result<Row, DecodeError>, Result<Row, DecodeError>>,
     >,
 ) -> (
-    Collection<G, Row, Diff>,
-    Option<Collection<G, dataflow_types::DataflowError, Diff>>,
+    Stream<G, (Row, Timestamp, Diff)>,
+    Stream<G, (dataflow_types::DataflowError, Timestamp, Diff)>,
 )
 where
     G: Scope<Timestamp = Timestamp>,
@@ -239,7 +238,7 @@ where
         errs = errs.concat(&errs2);
     }
 
-    (oks.as_collection(), Some(errs.as_collection()))
+    (oks, errs)
 }
 
 /// Evaluates predicates and dummy column information.

--- a/src/persist/src/indexed/runtime.rs
+++ b/src/persist/src/indexed/runtime.rs
@@ -911,6 +911,30 @@ impl<L: Log, B: Blob> RuntimeImpl<L, B> {
     }
 }
 
+/// Returns the seal timestamp of the given collection.
+// TODO: There are some things we should change about this:
+//
+// 1. Getting the seal timestamp shouldn't require knowing the types of the collection. This can be
+//    achieved by adding a `get_seal(id)` method on `RuntimeClient`. Even better, the method should
+//    probably be `get_description()` and return a complete differential `Description` of the
+//    contained updates.
+//
+// 2. We need to figure out what our nomenclature should be around seal vs. upper vs. "a whole
+//    Description".
+//
+pub fn sealed_ts<K: persist_types::Codec, V: persist_types::Codec>(
+    read: &StreamReadHandle<K, V>,
+) -> Result<u64, Error> {
+    let seal_ts = read.snapshot()?.get_seal();
+
+    if let Some(sealed) = seal_ts.first() {
+        Ok(*sealed)
+    } else {
+        use timely::progress::Timestamp;
+        Ok(Timestamp::minimum())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use timely::dataflow::operators::capture::Extract;

--- a/src/persist/src/operators/upsert.rs
+++ b/src/persist/src/operators/upsert.rs
@@ -70,7 +70,7 @@ pub trait PersistentUpsert<G, K: Codec, V: Codec, T> {
 }
 
 /// Persist configuration for persistent upsert.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct PersistentUpsertConfig<K: Codec, V: Codec> {
     /// The timestamp up to which which data should be read when restoring.
     upper_seal_ts: u64,


### PR DESCRIPTION
This adds a new user-facing config `--persistent-kafka-upsert-source`
that only works when used with  `--experimental`. With this, users can
enable the previously added persistence code paths.

### Tips for reviewer

This is based on #8714 and #8745, so please ignore everything but the last four commits.

Commits have meaningful messages.

Here's the (not yet merged) design doc that outlines the general idea of the persistent Kafka source: https://github.com/aljoscha/materialize/blob/wip-persistent-kafka-source-v0-design-doc/doc/developer/design/20210923_persistent_kafka_source_v0.md

### Checklist

- [] This PR has adequate test coverage / QA involvement has been duly considered.
- [] This PR adds a release note for any
  [user-facing behavior changes](/doc/user/content/release-notes.md#What-changes-require-a-release-note).
