### PR TITLE
persist: in persistent_source(), build consistent operator graph

### DIFF
--- a/src/persist/src/operators/input.rs
+++ b/src/persist/src/operators/input.rs
@@ -12,9 +12,8 @@
 use persist_types::Codec;
 use timely::dataflow::channels::pushers::buffer::AutoflushSession;
 use timely::dataflow::channels::pushers::{Counter, Tee};
-use timely::dataflow::operators::generic::operator;
 use timely::dataflow::operators::unordered_input::UnorderedHandle;
-use timely::dataflow::operators::{ActivateCapability, Concat, Map, ToStream, UnorderedInput};
+use timely::dataflow::operators::{ActivateCapability, Concat, Map, UnorderedInput};
 use timely::dataflow::{Scope, Stream};
 use timely::scheduling::ActivateOnDrop;
 use timely::Data as TimelyData;
@@ -60,14 +59,8 @@ where
         let (write, read) = token;
 
         // Replay the previously persisted data, if any.
-        let (ok_previous, err_previous) = match read.snapshot() {
-            Err(err) => (
-                operator::empty(self),
-                // TODO: Figure out how to make these retractable.
-                vec![(format!("replaying persisted data: {}", err), 0, 1)].to_stream(self),
-            ),
-            Ok(snapshot) => self.replay(snapshot),
-        };
+        let snapshot = read.snapshot();
+        let (ok_previous, err_previous) = self.replay(snapshot);
 
         let ok_previous = ok_previous.map(|((k, _), ts, diff)| (k, ts, diff));
 

--- a/src/persist/src/operators/upsert.rs
+++ b/src/persist/src/operators/upsert.rs
@@ -114,10 +114,7 @@ where
         let operator_name = format!("persistent_upsert({})", name);
 
         let (restored_upsert_oks, _state_errs) = {
-            let snapshot = persist_config
-                .read_handle
-                .snapshot()
-                .expect("cannot take snapshot");
+            let snapshot = persist_config.read_handle.snapshot();
             let (restored_oks, restored_errs) = self.scope().replay(snapshot);
             let restored_upsert_oks = restored_oks.filter_and_retract_future_updates(
                 name,


### PR DESCRIPTION
Before, we were building different shapes of graphs depending on whether
taking the snapshot/listening would succeed or not.

Now, we handle the error cases internally, in the operators. To the
outside world, the shape of these operators is always the same now,
regardless of error cases. This deterministic graph construction on
multiple workers if important for timely dataflow to work correctly.

I added a second commit that fixes and re-enables the `multiple_workers()` test case.

@danhhz Not sure how I would write tests for this, because it's not visible from the
outside. I imagine the updated nemesis tests would cover this?

Fixes MaterializeInc/database-issues#2659

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any
  [user-facing behavior changes](/doc/user/content/release-notes.md#What-changes-require-a-release-note).
