### PR TITLE
sql: support copy from stdin format csv

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3028,6 +3028,7 @@ dependencies = [
  "bytes",
  "chrono",
  "coord",
+ "csv",
  "dataflow-types",
  "expr",
  "futures",

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -110,6 +110,8 @@ List new features before bug fixes.
 - Add the [`date_bin`](/sql/functions/date-bin) function, which is similar to
   `date_trunc` but supports "truncating" to arbitrary intervals.
 
+- Add support for the CSV format in [`COPY FROM`].
+
 - Fix incorrect results for a certain class of degenerate join queries.
 
 - Fix a bug in `pg_catalog.pg_attribute` that would incorrectly omit

--- a/doc/user/content/sql/copy-from.md
+++ b/doc/user/content/sql/copy-from.md
@@ -6,29 +6,66 @@ menu:
         parent: "sql"
 ---
 
-`COPY FROM` copies data into a table using the [Postgres `COPY` protocol](https://www.postgresql.org/docs/current/sql-copy.html).
+`COPY FROM` copies data into a table using the [Postgres `COPY` protocol][pg-copy-from].
 
 ## Syntax
 
 {{< diagram "copy-from.svg" >}}
 
-Field       | Use
-------------|-----
-_table_name_| The name of the table to be copied.
-_column_    | An optional list of columns to be copied. If no column list is specified, all columns of the table will be copied.
+Field | Use
+------|-----
+_table_name_ | Copy values to this table.
+**(**_column_...**)** | Correlate the inserted rows' columns to _table_name_'s columns by ordinal position, i.e. the first column of the row to insert is correlated to the first named column. <br/><br/>Without a column list, all columns must have data provided, and will be referenced using their order in the table. With a partial column list, all unreferenced columns will receive their default value.
 
 Supported `option` values:
 
-Name | Default value | Description
+Name | Permitted values| Default value | Description
 -----|---------------|------------
-`DELIMITER` | tab character | Specifies the character that separates columns within each row (line) of the file.
-`NULL` | `\N` (backslash-N) | Specifies the string that represents a null value.
+`FORMAT` | `TEXT`, `CSV` | `TEXT` | Sets the input formatting method. For more information see [Text formatting](#text-formatting), [CSV formatting](#csv-formatting).
+`DELIMITER` | Single-quoted one-byte character | Format-dependent | Overrides the format's default column delimiter.
+`NULL` | Single-quoted strings | Format-dependent | Specifies the string that represents a _NULL_ value.
+`QUOTE` | Single-quoted one-byte character | `"` | Specifies the character to signal a quoted string, which may contain the `DELIMITER` value (without beginning new columns). To include the `QUOTE` character itself in column, wrap the column's value in the `QUOTE` character and prefix all instance of the value you want to literally interpret with the `ESCAPE` value. _`FORMAT CSV` only_
+`ESCAPE` | Single-quoted strings | `QUOTE`'s value | Specifies the character to allow instances of the `QUOTE` character to be parsed literally as part of a column's value. _`FORMAT CSV` only_
 
-Rows are expected in `text` format, one per line, with columns separated by the
-`DELIMITER` character.
+Note that `DELIMITER` and `QUOTE` must use distinct values.
+
+## Details
+
+### Text formatting
+
+As described in the **Text Format** section of [PostgreSQL's documentation][pg-copy-from].
+
+### CSV formatting
+
+As described in the **CSV Format** section of [PostgreSQL's documentation][pg-copy-from]
+except that:
+
+- Single-column rows containing quoted end-of-data markers (e.g. `"\."`) will be
+  treated as end-of-data markers despite being quoted. In PostgreSQL, this data
+  would be escaped and would not terminate the data processing.
+
+- Quoted null strings will be parsed as nulls, despite being quoted. In
+  PostgreSQL, this data would be escaped.
+
+  To ensure proper null handling, we recommend specifying a unique string for
+  null values, and ensuring it is never quoted.
+
+- Unterminated quotes are allowed, i.e. they do not generate errors. In
+  PostgreSQL, all open unescaped quotation punctuation must have a matching
+  piece of unescaped quotation punctuation or it generates an error.
 
 ## Example
 
 ```sql
 COPY t FROM STDIN WITH (DELIMITER '|')
 ```
+
+```sql
+COPY t FROM STDIN (FORMAT CSV)
+```
+
+```sql
+COPY t FROM STDIN (DELIMITER '|')
+```
+
+[pg-copy-from]: https://www.postgresql.org/docs/14/sql-copy.html

--- a/src/pgwire/Cargo.toml
+++ b/src/pgwire/Cargo.toml
@@ -12,6 +12,7 @@ byteorder = "1.4.3"
 bytes = "1.1.0"
 chrono = { version = "0.4.0", default-features = false, features = ["std"] }
 coord = { path = "../coord" }
+csv = "1.1.6"
 dataflow-types = { path = "../dataflow-types" }
 expr = { path = "../expr" }
 futures = "0.3.17"

--- a/src/sql-parser/tests/testdata/copy
+++ b/src/sql-parser/tests/testdata/copy
@@ -49,6 +49,13 @@ COPY t TO STDOUT WITH (format = text)
 Copy(CopyStatement { relation: Table { name: UnresolvedObjectName([Ident("t")]), columns: [] }, direction: To, target: Stdout, options: [WithOption { key: Ident("format"), value: Some(ObjectName(UnresolvedObjectName([Ident("text")]))) }] })
 
 parse-statement
+COPY t FROM STDIN WITH (FORMAT CSV, DELIMETER '|')
+----
+COPY t FROM STDIN WITH (format = csv, delimeter = '|')
+=>
+Copy(CopyStatement { relation: Table { name: UnresolvedObjectName([Ident("t")]), columns: [] }, direction: From, target: Stdin, options: [WithOption { key: Ident("format"), value: Some(ObjectName(UnresolvedObjectName([Ident("csv")]))) }, WithOption { key: Ident("delimeter"), value: Some(Value(String("|"))) }] })
+
+parse-statement
 COPY t TO STDOUT (format = text)
 ----
 COPY t TO STDOUT WITH (format = text)

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -429,18 +429,21 @@ pub enum MutationKind {
     Delete,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum CopyFormat {
     Text,
     Csv,
     Binary,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CopyParams {
     pub format: CopyFormat,
     pub null: Option<String>,
     pub delimiter: Option<String>,
+    pub quote: Option<String>,
+    pub escape: Option<String>,
+    pub header: Option<bool>,
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -356,6 +356,9 @@ with_options! {
         format: String,
         delimiter: String,
         null: String,
+        escape: String,
+        quote: String,
+        header: bool,
     }
 }
 
@@ -399,6 +402,9 @@ pub fn plan_copy(
         format: CopyFormat::Text,
         delimiter: options.delimiter,
         null: options.null,
+        escape: options.escape,
+        quote: options.quote,
+        header: options.header,
     };
     if let Some(format) = options.format {
         copy_params.format = match format.to_lowercase().as_str() {

--- a/test/pgtest-mz/copy-from-csv.pt
+++ b/test/pgtest-mz/copy-from-csv.pt
@@ -1,0 +1,216 @@
+# Note that this file will not work on PG due to the lack of "strict" parsing
+# from the Rust CSV crate: https://github.com/BurntSushi/rust-csv/issues/77
+
+send
+Query {"query": "DROP TABLE IF EXISTS t"}
+----
+
+until ignore=NoticeResponse
+ReadyForQuery
+----
+CommandComplete {"tag":"DROP TABLE"}
+ReadyForQuery {"status":"I"}
+
+send
+Query {"query": "CREATE TABLE t (i INT8, t TEXT)"}
+----
+
+until
+ReadyForQuery
+----
+CommandComplete {"tag":"CREATE TABLE"}
+ReadyForQuery {"status":"I"}
+
+# Note that we cannot differentiate between empty string and the quoted empty
+# string, both of which will generate NULL in MZ.
+send
+Query {"query": "COPY t FROM STDIN WITH (FORMAT CSV)"}
+CopyData "1,one\n"
+CopyData "2,\"two\"\n"
+CopyData "3,\"\"\"three\"\"\"\n"
+CopyData "4,\"fo,ur\"\n"
+CopyData "5,\"\"\n"
+CopyData "6,\n"
+CopyData "7,\"seven\n"
+CopyData "8,eight\n"
+CopyDone
+Query {"query": "SELECT * FROM t ORDER BY i"}
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+----
+CopyIn {"format":"text","column_formats":["text","text"]}
+CommandComplete {"tag":"COPY 7"}
+ReadyForQuery {"status":"I"}
+RowDescription {"fields":[{"name":"i"},{"name":"t"}]}
+DataRow {"fields":["1","one"]}
+DataRow {"fields":["2","two"]}
+DataRow {"fields":["3","\"three\""]}
+DataRow {"fields":["4","fo,ur"]}
+DataRow {"fields":["5","NULL"]}
+DataRow {"fields":["6","NULL"]}
+DataRow {"fields":["7","seven\n8,eight\n"]}
+CommandComplete {"tag":"SELECT 7"}
+ReadyForQuery {"status":"I"}
+
+# Change options. Note that:
+# - After receiving terminating char, no other data should be accepted
+# - Quoted end of copy markers are still processed as end of copy markers
+send
+Query {"query": "DELETE FROM t"}
+Query {"query": "COPY t FROM STDIN WITH (FORMAT CSV, QUOTE '|', ESCAPE '#', NULL 'NS', HEADER true)"}
+CopyData "Header,IsIgnored\n"
+CopyData "1,NS\n"
+CopyData "2,|two|\n"
+CopyData "3,|#|three#||\n"
+CopyData "4,|fo,ur|\n"
+CopyData "5,\"five\"\n"
+CopyData "6,||\n"
+CopyData "|\\.|\n"
+CopyData "invalid data"
+CopyDone
+Query {"query": "SELECT * FROM t ORDER BY i"}
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+CommandComplete {"tag":"DELETE 7"}
+ReadyForQuery {"status":"I"}
+CopyIn {"format":"text","column_formats":["text","text"]}
+CommandComplete {"tag":"COPY 6"}
+ReadyForQuery {"status":"I"}
+RowDescription {"fields":[{"name":"i"},{"name":"t"}]}
+DataRow {"fields":["1","NULL"]}
+DataRow {"fields":["2","two"]}
+DataRow {"fields":["3","|three|"]}
+DataRow {"fields":["4","fo,ur"]}
+DataRow {"fields":["5","\"five\""]}
+DataRow {"fields":["6",""]}
+CommandComplete {"tag":"SELECT 6"}
+ReadyForQuery {"status":"I"}
+
+send
+Query {"query": "DELETE FROM t"}
+Query {"query": "COPY t FROM STDIN WITH (FORMAT CSV, DELIMITER '#', ESCAPE '#')"}
+CopyData "1#\"one\"\n"
+CopyData "2#\"#\"two#\"\"\n"
+CopyData "3#\"thr##ee\"\n"
+CopyDone
+Query {"query": "SELECT * FROM t ORDER BY i"}
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+CommandComplete {"tag":"DELETE 6"}
+ReadyForQuery {"status":"I"}
+CopyIn {"format":"text","column_formats":["text","text"]}
+CommandComplete {"tag":"COPY 3"}
+ReadyForQuery {"status":"I"}
+RowDescription {"fields":[{"name":"i"},{"name":"t"}]}
+DataRow {"fields":["1","one"]}
+DataRow {"fields":["2","\"two\""]}
+DataRow {"fields":["3","thr#ee"]}
+CommandComplete {"tag":"SELECT 3"}
+ReadyForQuery {"status":"I"}
+
+# ESCAPE defaults to QUOTE if not provided, and exhibits same behavior as
+# default.
+send
+Query {"query": "DELETE FROM t"}
+Query {"query": "COPY t FROM STDIN WITH (FORMAT CSV, QUOTE '#')"}
+CopyData "1,#one#\n"
+CopyData "2,###two###\n"
+CopyData "3,#thr##ee#\n"
+CopyDone
+Query {"query": "SELECT * FROM t ORDER BY i"}
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+CommandComplete {"tag":"DELETE 3"}
+ReadyForQuery {"status":"I"}
+CopyIn {"format":"text","column_formats":["text","text"]}
+CommandComplete {"tag":"COPY 3"}
+ReadyForQuery {"status":"I"}
+RowDescription {"fields":[{"name":"i"},{"name":"t"}]}
+DataRow {"fields":["1","one"]}
+DataRow {"fields":["2","#two#"]}
+DataRow {"fields":["3","thr#ee"]}
+CommandComplete {"tag":"SELECT 3"}
+ReadyForQuery {"status":"I"}
+
+# Invalid data
+send
+Query {"query": "COPY t FROM STDIN WITH (FORMAT CSV)"}
+CopyData "1\n"
+CopyDone
+Query {"query": "COPY t FROM STDIN WITH (FORMAT CSV)"}
+CopyData "1,2,3\n"
+CopyDone
+----
+
+until
+ErrorResponse
+ReadyForQuery
+ErrorResponse
+ReadyForQuery
+----
+CopyIn {"format":"text","column_formats":["text","text"]}
+ErrorResponse {"fields":[{"typ":"C","value":"22P04"},{"typ":"M","value":"missing data for column"}]}
+ReadyForQuery {"status":"I"}
+CopyIn {"format":"text","column_formats":["text","text"]}
+ErrorResponse {"fields":[{"typ":"C","value":"22P04"},{"typ":"M","value":"extra data after last expected column"}]}
+ReadyForQuery {"status":"I"}
+
+send
+Query {"query": "COPY t FROM STDIN WITH (FORMAT CSV, DELIMITER '||')"}
+Query {"query": "COPY t FROM STDIN WITH (FORMAT CSV, QUOTE '||')"}
+Query {"query": "COPY t FROM STDIN WITH (FORMAT CSV, ESCAPE '||')"}
+----
+
+until
+ErrorResponse
+ReadyForQuery
+ErrorResponse
+ReadyForQuery
+ErrorResponse
+ReadyForQuery
+----
+ErrorResponse {"fields":[{"typ":"C","value":"0A000"},{"typ":"M","value":"COPY delimiter must be a single one-byte character"}]}
+ReadyForQuery {"status":"I"}
+ErrorResponse {"fields":[{"typ":"C","value":"0A000"},{"typ":"M","value":"COPY quote must be a single one-byte character"}]}
+ReadyForQuery {"status":"I"}
+ErrorResponse {"fields":[{"typ":"C","value":"0A000"},{"typ":"M","value":"COPY escape must be a single one-byte character"}]}
+ReadyForQuery {"status":"I"}
+
+send
+Query {"query": "COPY t FROM STDIN WITH (FORMAT CSV, DELIMITER '\"')"}
+Query {"query": "COPY t FROM STDIN WITH (FORMAT CSV, QUOTE ',')"}
+Query {"query": "COPY t FROM STDIN WITH (FORMAT CSV, DELIMITER '!', QUOTE '!')"}
+----
+
+until
+ErrorResponse
+ReadyForQuery
+ErrorResponse
+ReadyForQuery
+ErrorResponse
+ReadyForQuery
+----
+ErrorResponse {"fields":[{"typ":"C","value":"0A000"},{"typ":"M","value":"COPY delimiter and quote must be different"}]}
+ReadyForQuery {"status":"I"}
+ErrorResponse {"fields":[{"typ":"C","value":"0A000"},{"typ":"M","value":"COPY delimiter and quote must be different"}]}
+ReadyForQuery {"status":"I"}
+ErrorResponse {"fields":[{"typ":"C","value":"0A000"},{"typ":"M","value":"COPY delimiter and quote must be different"}]}
+ReadyForQuery {"status":"I"}

--- a/test/pgtest/copy-from-2.pt
+++ b/test/pgtest/copy-from-2.pt
@@ -19,6 +19,8 @@ CommandComplete {"tag":"CREATE TABLE"}
 ReadyForQuery {"status":"I"}
 
 # COPY with both empty string and \N for NULL.
+# Note that after receiving the terminating char, no other data should be
+# accepted.
 send
 Query {"query": "COPY t FROM STDIN"}
 CopyData "1\tblah\n"
@@ -321,4 +323,36 @@ DataRow {"fields":["3",""]}
 DataRow {"fields":["4","NULL"]}
 DataRow {"fields":["5","NULL"]}
 CommandComplete {"tag":"SELECT 5"}
+ReadyForQuery {"status":"I"}
+
+send
+Query {"query": "COPY t FROM STDIN WITH (DELIMITER '||')"}
+----
+
+until
+ErrorResponse
+ReadyForQuery
+----
+ErrorResponse {"fields":[{"typ":"C","value":"0A000"},{"typ":"M","value":"COPY delimiter must be a single one-byte character"}]}
+ReadyForQuery {"status":"I"}
+
+send
+Query {"query": "COPY t FROM STDIN WITH (QUOTE '||')"}
+Query {"query": "COPY t FROM STDIN WITH (ESCAPE '||')"}
+Query {"query": "COPY t FROM STDIN WITH (HEADER true)"}
+----
+
+until
+ErrorResponse
+ReadyForQuery
+ErrorResponse
+ReadyForQuery
+ErrorResponse
+ReadyForQuery
+----
+ErrorResponse {"fields":[{"typ":"C","value":"0A000"},{"typ":"M","value":"COPY quote only available in CSV mode"}]}
+ReadyForQuery {"status":"I"}
+ErrorResponse {"fields":[{"typ":"C","value":"0A000"},{"typ":"M","value":"COPY escape only available in CSV mode"}]}
+ReadyForQuery {"status":"I"}
+ErrorResponse {"fields":[{"typ":"C","value":"0A000"},{"typ":"M","value":"COPY header only available in CSV mode"}]}
 ReadyForQuery {"status":"I"}


### PR DESCRIPTION
### Motivation

This PR adds a known-desirable feature, `COPY FROM ... (FORMAT CSV)` as part of Fivetran support https://github.com/MaterializeInc/materialize/issues/5188#issuecomment-759262331

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
