### PR TITLE
optimizer: relax invariant in fold_reduce_constant

### DIFF
--- a/src/transform/src/reduction.rs
+++ b/src/transform/src/reduction.rs
@@ -419,11 +419,14 @@ impl FoldConstants {
             // We currently maintain the invariant that any negative
             // multiplicities will be consolidated away before they
             // arrive at a reduce.
-            assert!(
-                *diff > 0,
-                "constant folding encountered reduce on collection \
-                             with non-positive multiplicities"
-            );
+
+            if *diff <= 0 {
+                return Err(EvalError::InvalidParameterValue(String::from(
+                    "constant folding encountered reduce on collection \
+                                               with non-positive multiplicities",
+                )));
+            }
+
             let datums = row.unpack();
             let temp_storage = RowArena::new();
             let key = group_key

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -314,6 +314,9 @@ SELECT abs(generate_series) FROM generate_series(-1, 2), repeat_row(generate_ser
 statement error  Negative multiplicity in constant result: -1
 SELECT * FROM (values ('a')), repeat_row(-1)
 
+statement error constant folding encountered reduce on collection with non-positive multiplicities
+SELECT (SELECT 1 FROM repeat_row(-1))
+
 query error unable to determine which implementation to use
 SELECT generate_series FROM generate_series(null, null, null)
 ----


### PR DESCRIPTION
Queries using experimental `repeat_row` had the ability to panic and hence crash materialize. It is not necessary to crash the process and it is better to return the error to the user.

### Motivation

This fixes bug report MaterializeInc/database-issues#2678 
