### PR TITLE
Have canonicalize_equivalences reduce expressions.

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -106,6 +106,9 @@ List new features before bug fixes.
 - Add the [`date_bin`](/sql/functions/date-bin) function, which is similar to
   `date_trunc` but supports "truncating" to arbitrary intervals.
 
+- Fix incorrect results for a certain class of degenerate join queries.
+  {{% gh 8747 %}}
+
 {{% version-header v0.9.11 %}}
 
 - Disallow `UPDATE` and `DELETE` operations on tables when boot in

--- a/src/dataflow/src/render/join/mod.rs
+++ b/src/dataflow/src/render/join/mod.rs
@@ -252,7 +252,7 @@ impl JoinBuildState {
             column_map.insert(column, column_map.len());
         }
         let mut equivalences = equivalences.to_vec();
-        expr::canonicalize::canonicalize_equivalences(&mut equivalences);
+        expr::canonicalize::canonicalize_equivalence_classes(&mut equivalences);
         Self {
             column_map,
             equivalences,

--- a/src/expr/src/relation/canonicalize.rs
+++ b/src/expr/src/relation/canonicalize.rs
@@ -13,11 +13,12 @@
 use crate::{func, BinaryFunc, MirScalarExpr, UnaryFunc};
 use repr::{Datum, RelationType, ScalarType};
 
-/// Canonicalize equivalence classes of a join.
+/// Canonicalize equivalence classes of a join and expressions contained in them.
+///
+/// `input_types` can be the `RelationType` of the join or the `RelationType` of
+/// the individual inputs of the join in order.
 ///
 /// This function:
-/// * ensures the same expression appears in only one equivalence class.
-/// * ensures the equivalence classes are sorted and dedupped.
 /// * simplifies expressions to involve the least number of non-literal nodes.
 ///   This ensures that we only replace expressions by "even simpler"
 ///   expressions and that repeated substitutions reduce the complexity of
@@ -25,27 +26,22 @@ use repr::{Datum, RelationType, ScalarType};
 ///   rule, we might repeatedly replace a simple expression with an equivalent
 ///   complex expression containing that (or another replaceable) simple
 ///   expression, and repeat indefinitely.
-///
-/// ```rust
-/// use expr::MirScalarExpr;
-/// use expr::canonicalize::canonicalize_equivalences;
-///
-/// let mut equivalences = vec![
-///     vec![MirScalarExpr::Column(1), MirScalarExpr::Column(4)],
-///     vec![MirScalarExpr::Column(3), MirScalarExpr::Column(5)],
-///     vec![MirScalarExpr::Column(0), MirScalarExpr::Column(3)],
-///     vec![MirScalarExpr::Column(2), MirScalarExpr::Column(2)],
-/// ];
-/// let expected = vec![
-///     vec![MirScalarExpr::Column(0),
-///         MirScalarExpr::Column(3),
-///         MirScalarExpr::Column(5)],
-///     vec![MirScalarExpr::Column(1), MirScalarExpr::Column(4)],
-/// ];
-/// canonicalize_equivalences(&mut equivalences);
-/// assert_eq!(expected, equivalences)
-/// ````
-pub fn canonicalize_equivalences(equivalences: &mut Vec<Vec<MirScalarExpr>>) {
+/// * reduces all expressions contained in `equivalences`.
+/// * Does everything that [canonicalize_equivalence_classes] does.
+pub fn canonicalize_equivalences(
+    equivalences: &mut Vec<Vec<MirScalarExpr>>,
+    input_types: &[RelationType],
+) {
+    // This only aggregates the column types of each input, not the
+    // keys of the inputs. It is unnecessary to aggregate the keys
+    // of the inputs since input keys are unnecessary for reducing
+    // `MirScalarExpr`s.
+    let input_typ = input_types
+        .iter()
+        .fold(RelationType::empty(), |mut typ, i| {
+            typ.column_types.extend_from_slice(&i.column_types[..]);
+            typ
+        });
     // Calculate the number of non-leaves for each expression.
     let mut to_reduce = equivalences
         .drain(..)
@@ -89,6 +85,7 @@ pub fn canonicalize_equivalences(equivalences: &mut Vec<Vec<MirScalarExpr>>) {
                         expressions_rewritten = true;
                     }
                 });
+                popped_expr.reduce(&input_typ);
                 new_equivalence.push((rank_complexity(&popped_expr), popped_expr));
             }
             new_equivalence.sort();
@@ -103,6 +100,34 @@ pub fn canonicalize_equivalences(equivalences: &mut Vec<Vec<MirScalarExpr>>) {
         .map(|mut cls| cls.drain(..).map(|(_, expr)| expr).collect::<Vec<_>>())
         .collect::<Vec<_>>();
 
+    canonicalize_equivalence_classes(equivalences);
+}
+
+/// Canonicalize only the equivalence classes of a join.
+///
+/// This function:
+/// * ensures the same expression appears in only one equivalence class.
+/// * ensures the equivalence classes are sorted and dedupped.
+/// ```rust
+/// use expr::MirScalarExpr;
+/// use expr::canonicalize::canonicalize_equivalence_classes;
+///
+/// let mut equivalences = vec![
+///     vec![MirScalarExpr::Column(1), MirScalarExpr::Column(4)],
+///     vec![MirScalarExpr::Column(3), MirScalarExpr::Column(5)],
+///     vec![MirScalarExpr::Column(0), MirScalarExpr::Column(3)],
+///     vec![MirScalarExpr::Column(2), MirScalarExpr::Column(2)],
+/// ];
+/// let expected = vec![
+///     vec![MirScalarExpr::Column(0),
+///         MirScalarExpr::Column(3),
+///         MirScalarExpr::Column(5)],
+///     vec![MirScalarExpr::Column(1), MirScalarExpr::Column(4)],
+/// ];
+/// canonicalize_equivalence_classes(&mut equivalences);
+/// assert_eq!(expected, equivalences)
+/// ````
+pub fn canonicalize_equivalence_classes(equivalences: &mut Vec<Vec<MirScalarExpr>>) {
     // Fuse equivalence classes containing the same exprssion.
     for index in 1..equivalences.len() {
         for inner in 0..index {

--- a/src/expr/tests/test_runner.rs
+++ b/src/expr/tests/test_runner.rs
@@ -71,13 +71,12 @@ mod test {
 
     fn test_canonicalize_equiv(s: &str) -> Result<Vec<Vec<MirScalarExpr>>, String> {
         let mut input_stream = tokenize(&s)?.into_iter();
-        let mut equivalences: Vec<Vec<MirScalarExpr>> = deserialize(
-            &mut input_stream,
-            "Vec<Vec<MirScalarExpr>>",
-            &RTI,
-            &mut MirScalarExprDeserializeContext::default(),
-        )?;
-        canonicalize_equivalences(&mut equivalences);
+        let mut ctx = MirScalarExprDeserializeContext::default();
+        let mut equivalences: Vec<Vec<MirScalarExpr>> =
+            deserialize(&mut input_stream, "Vec<Vec<MirScalarExpr>>", &RTI, &mut ctx)?;
+        let input_type: RelationType =
+            deserialize(&mut input_stream, "RelationType", &RTI, &mut ctx)?;
+        canonicalize_equivalences(&mut equivalences, &[input_type]);
         Ok(equivalences)
     }
 

--- a/src/expr/tests/testdata/reduce
+++ b/src/expr/tests/testdata/reduce
@@ -360,6 +360,7 @@ canonicalize-join
     (call_binary add_int32 #0 #0)
     (call_binary add_int32 #0 (call_binary add_int32 #0 #0))
 ]]
+[int32]
 ----
 [(#0 && (#0 + #0)) (#0 + #0) (#0 + (#0 + #0))]
 
@@ -374,6 +375,7 @@ canonicalize-join
         (call_binary add_int32 (call_binary add_int32 #3 #3) #3)
     ]
 ]
+[int32 int32 int32 int32]
 ----
 [#0 #3]
 [#1 ((#0 + #0) + #0) ((#2 + #2) + #1)]
@@ -390,6 +392,7 @@ canonicalize-join
     ]
     [(call_binary add_int32 #2 #2) (call_binary mul_int32 #4 #5)]
 ]
+[int32 int32 int32 int32 int32 int32]
 ----
 [#0 #3]
 [#1 ((#0 + #0) + #0) ((#2 + #2) + #1)]
@@ -412,12 +415,15 @@ canonicalize-join
     [(call_binary add_int32 #3 #3) (call_binary mul_int32 #4 #5) (call_binary
     sub_int32 (call_binary add_int32 #3 #3) (call_binary mul_int32 #4 #5))]
 ]
+[int32 int32 int32 int32 int32 int32]
 ----
 [#0 #3]
 [#1 (#0 + #0) (#1 + #0) (#1 + #1) ((#2 + #2) + #1) (#1 - #1) (#4 * #5)]
 
 canonicalize-join
-[[#0 #3 #3] [(call_binary add_int32 #0 #0) #1] [(call_binary add_int32 #3 #3) #2]]
+[[#0 #3 #3] [(call_binary add_int32 #0 #0) #1] [(call_binary add_int32 #3 #3)
+#2]]
+[int32 int32 int32 int32]
 ----
 [#0 #3]
 [#1 #2 (#0 + #0)]
@@ -427,6 +433,7 @@ canonicalize-join
 
 canonicalize-join
 [[#0 #0 #3] [(call_binary add_int32 #0 #0) (call_binary add_int32 #3 #3)]]
+[int32 int32 int32 int32]
 ----
 [#0 #3]
 
@@ -440,6 +447,7 @@ canonicalize-join
     (call_unary neg_int32 (call_unary neg_int32 (call_unary cast_int16_to_int32
     #0)))
 ]]
+[int32]
 ----
 [-(i16toi32(#0)) i16toi32(#0)]
 
@@ -451,6 +459,7 @@ canonicalize-join
     (4 int32)
     (call_binary add_int32 #1 (4 int32))
 ]]
+[int32 int32]
 ----
 [#0 4 (#1 + 4)]
 
@@ -461,10 +470,11 @@ canonicalize-join
     [(call_unary neg_int32 #0) (call_unary neg_int32 #1) (call_unary neg_int32 (4 int32))]
     [(call_binary add_int32 #1 (call_unary neg_int32 #1)) #3]
 ]
+[int32 int32 int32 int32]
 ----
 [#0 4]
-[#3 (#1 + -(4))]
-[-(#1) -(4)]
+[#3 (#1 + -4)]
+[-4 -(#1)]
 
 canonicalize-join
 [
@@ -473,7 +483,68 @@ canonicalize-join
     [(call_unary neg_int32 #1) (call_unary neg_int32 (4 int32))]
     [(call_binary add_int32 #1 (call_unary neg_int32 #1)) #3]
 ]
+[int32 int32 int32 int32]
 ----
 [#0 4]
-[#3 (#1 + -(4))]
-[-(#1) -(4)]
+[#3 (#1 + -4)]
+[-4 -(#1)]
+
+# expressions in join equivalences get reduced after simpler equivalent
+# expressions are substituted
+
+## constant folding
+
+canonicalize-join
+[
+    [0 (call_binary add_int64 0 #0)]
+    [1234 (call_binary add_int64 (call_binary add_int64 0 #0) 0)]
+]
+[int64]
+----
+[0 1234 (0 + #0)]
+
+## consecutive nots cancel each other
+
+canonicalize-join
+[
+    [(call_unary not #0) (call_binary (is_regexp_match true) #1 #2)]
+    [false (call_unary not (call_binary (is_regexp_match true) #1 #2))]
+]
+[bool string string]
+----
+[#0 false]
+[true (#1 ~* #2)]
+
+canonicalize-join
+[
+    [(call_unary not #0) (call_binary or #0 #1)]
+    [false (call_unary not (call_binary or #0 #1))]
+]
+[bool bool]
+----
+[#0 false]
+[#1 true]
+
+## demorgans
+
+canonicalize-join
+[
+    [ (call_binary and #2 #3) (call_variadic coalesce [#0 #1 false])]
+    [ #0 (call_binary or (call_variadic coalesce [#0 #1 false]) (call_binary and #2 #4))]
+]
+[bool bool bool bool bool]
+----
+[#0 (#2 && (#3 || #4))]
+[(#2 && #3) coalesce(#0, #1, false)]
+
+## decompose is_null
+
+canonicalize-join
+[
+    [ (call_binary add_int32 #2 #3) (call_variadic coalesce [#0 #1 false])]
+    [ #0 (call_unary is_null (call_variadic coalesce [#0 #1 false]))]
+]
+[int32 int32 int32 int32]
+----
+[#0 (isnull(#2) || isnull(#3))]
+[(#2 + #3) coalesce(#0, #1, false)]

--- a/src/transform/src/fusion/join.rs
+++ b/src/transform/src/fusion/join.rs
@@ -172,7 +172,7 @@ impl JoinBuilder {
     }
 
     fn build(mut self) -> MirRelationExpr {
-        expr::canonicalize::canonicalize_equivalences(&mut self.equivalences);
+        expr::canonicalize::canonicalize_equivalence_classes(&mut self.equivalences);
 
         // If `inputs` is now empty or a singleton (without constraints),
         // we can remove the join.

--- a/src/transform/src/join_implementation.rs
+++ b/src/transform/src/join_implementation.rs
@@ -85,10 +85,11 @@ impl JoinImplementation {
             ..
         } = relation
         {
-            // Canonicalize the equivalence classes
-            expr::canonicalize::canonicalize_equivalences(equivalences);
-
             let input_types = inputs.iter().map(|i| i.typ()).collect::<Vec<_>>();
+
+            // Canonicalize the equivalence classes
+            expr::canonicalize::canonicalize_equivalences(equivalences, &input_types);
+
             // Common information of broad utility.
             let input_mapper = JoinInputMapper::new_from_input_types(&input_types);
 

--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -226,7 +226,7 @@ impl PredicatePushdown {
                             pred_not_translated.push(predicate)
                         }
 
-                        expr::canonicalize::canonicalize_equivalences(equivalences);
+                        expr::canonicalize::canonicalize_equivalences(equivalences, &[input_type]);
 
                         // // Predicates to push at each input, and to retain.
                         let mut push_downs = vec![Vec::new(); inputs.len()];
@@ -468,10 +468,10 @@ impl PredicatePushdown {
                 //      comes from a single input.
                 //   2) equivalences of the form `expr1 = expr2`, where both
                 //      expressions come from the same single input.
+                let input_types = inputs.iter().map(|i| i.typ()).collect::<Vec<_>>();
+                expr::canonicalize::canonicalize_equivalences(equivalences, &input_types);
 
-                expr::canonicalize::canonicalize_equivalences(equivalences);
-
-                let input_mapper = expr::JoinInputMapper::new(inputs);
+                let input_mapper = expr::JoinInputMapper::new_from_input_types(&input_types);
                 // Predicates to push at each input, and to lift out the join.
                 let mut push_downs = vec![Vec::new(); inputs.len()];
 
@@ -670,7 +670,7 @@ impl PredicatePushdown {
                     };
                 }
 
-                expr::canonicalize::canonicalize_equivalences(equivalences);
+                expr::canonicalize::canonicalize_equivalences(equivalences, &input_types);
 
                 let new_inputs = inputs
                     .drain(..)

--- a/src/transform/src/redundant_join.rs
+++ b/src/transform/src/redundant_join.rs
@@ -167,7 +167,7 @@ impl RedundantJoin {
                             expr.permute(&projection[..]);
                         }
                     }
-                    expr::canonicalize::canonicalize_equivalences(equivalences);
+                    expr::canonicalize::canonicalize_equivalences(equivalences, &input_types);
 
                     // Unset demand and implementation, as irrevocably hosed by this transformation.
                     *demand = None;


### PR DESCRIPTION

### Motivation

Closes #8747.

The query mentioned in the ticket now has this plan:
```
materialize=> explain plan for SELECT  a2 .f2  + a1 .f2  + a2 .f2  FROM t2 a1  JOIN (  SELECT 0 AS f2 ) a2  ON a2 .f2  = a2 .f2  + a2 .f2  + a1 .f2  WHERE  a2 .f2  + a1 .f2  + a2 .f2  =  1234   ;
 Optimized Plan 
----------------
 %0 =          +
 | Constant    +
```

The issue was that `canonicalize_equivalences` was not reducing expressions after performing substitutions.
For the query in question, `canonicalize_equivalences` transformed the equivalences from
`(= 1234 ((0 + #1) + 0)) (= 0 (0 + #1))`
to
`(= 1234 (0 + 0)) (= 0 (0 + #1)`
but never reduced the `0+0` expression, so `PredicatePushdown` did not know that `0+0` was a literal.

Reducing expressions requires passing in the `ColumnType`s of the input into `canonicalize_equivalences`. Getting `ColumnType`s via `MirRelationExpr::typ()`is a relatively expensive. Also in src/dataflow, it is unclear how to even get the `ColumnType`. Thus, places that used to call `canonicalize_equivalences` where generating `ColumnType`s is undesirable now call `canonicalize_equivalence_classes`, a subset of what `canonicalize_equivalences` does without needing `ColumnType`s as an argument.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
