### PR TITLE
sql: add session_user function

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -105,6 +105,9 @@ List new features before bug fixes.
 
 - Evaluate TopK operators on constant inputs at query compile time.
 
+- Add the [`session_user`](/sql/functions/#system-information-func) system
+  information function.
+
 {{% version-header v0.9.9 %}}
 
 - **Breaking change.** Fix a bug that inadvertently let users create `char

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -547,6 +547,9 @@
   - signature: 'current_user() -> text'
     description: >-
       Returns the name of the user who executed the containing query.
+  - signature: 'session_user -> text'
+    description: >-
+      Returns the name of the user who executed the containing query.
   - signature: 'mz_row_size(expr: Record) -> int'
     description: Returns the number of bytes used to store a row.
 

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1379,6 +1379,12 @@ lazy_static! {
                     Ok(HirScalarExpr::literal(datum, ScalarType::String))
                 }), 745;
             },
+            "session_user" => Scalar {
+                params!() => Operation::nullary(|ecx| {
+                    let datum = Datum::String(ecx.qcx.scx.catalog.user());
+                    Ok(HirScalarExpr::literal(datum, ScalarType::String))
+                }), 746;
+            },
             "date_part" => Scalar {
                 params!(String, Interval) => BinaryFunc::DatePartInterval, 1172;
                 params!(String, Timestamp) => BinaryFunc::DatePartTimestamp, 2021;

--- a/src/sql/src/plan/transform_ast.rs
+++ b/src/sql/src/plan/transform_ast.rs
@@ -250,7 +250,9 @@ impl<'a> FuncRewriter<'a> {
                 let ident = normalize::ident(ident[0].clone());
                 let fn_ident = match ident.as_str() {
                     "current_role" => Some("current_user"),
-                    "current_schema" | "current_timestamp" | "current_user" => Some(ident.as_str()),
+                    "current_schema" | "current_timestamp" | "current_user" | "session_user" => {
+                        Some(ident.as_str())
+                    }
                     _ => None,
                 };
                 match fn_ident {

--- a/test/testdrive/system-functions.td
+++ b/test/testdrive/system-functions.td
@@ -19,6 +19,9 @@ true
 > SELECT current_user = current_role AND current_user != '';
 true
 
+> SELECT session_user = current_role AND session_user != '';
+true
+
 > SELECT now() - pg_postmaster_start_time() > interval '1 second' AND now() - pg_postmaster_start_time() < interval '1 year';
 true
 


### PR DESCRIPTION
This function is required for DBeaver compatibility.

### Motivation

This PR adds a system information function that is required for [DBeaver](https://dbeaver.io/) to work.

### Tips for reviewer

Same code as `current_user`, just created it as a separate function instead of a parser rewrite to keep its OID.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
