### PR TITLE
mzcloud cli support for getting logs from previous container

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2515,7 +2515,7 @@ dependencies = [
 [[package]]
 name = "mzcloud"
 version = "1.0.0"
-source = "git+https://github.com/MaterializeInc/cloud-sdks#921bacf7ba9288df2b25610a38e7fa2c7a48f25b"
+source = "git+https://github.com/MaterializeInc/cloud-sdks#3e17e134530d27a57c0c48c0746709596d8fd6af"
 dependencies = [
  "reqwest",
  "serde",

--- a/src/mzcloud-cli/src/bin/mzcloud.rs
+++ b/src/mzcloud-cli/src/bin/mzcloud.rs
@@ -214,12 +214,20 @@ enum DeploymentsCommand {
     Logs {
         /// ID of the deployment.
         id: String,
+
+        /// Get the logs for the previous execution, rather than the currently running one.
+        #[structopt(long)]
+        previous: bool,
     },
 
     /// Download the logs from a Materialize deployment.
     TailscaleLogs {
         /// ID of the deployment.
         id: String,
+
+        /// Get the logs for the previous execution, rather than the currently running one.
+        #[structopt(long)]
+        previous: bool,
     },
 
     /// Connect to a Materialize deployment using psql.
@@ -337,12 +345,12 @@ async fn handle_deployment_operations(
             fs::write(&output_file, &bytes)?;
             println!("Certificate bundle saved to {}", &output_file);
         }
-        DeploymentsCommand::Logs { id } => {
-            let logs = deployments_logs_retrieve(&config, &id).await?;
+        DeploymentsCommand::Logs { id, previous } => {
+            let logs = deployments_logs_retrieve(&config, &id, Some(previous)).await?;
             print!("{}", logs);
         }
-        DeploymentsCommand::TailscaleLogs { id } => {
-            let logs = deployments_tailscale_logs_retrieve(&config, &id).await?;
+        DeploymentsCommand::TailscaleLogs { id, previous } => {
+            let logs = deployments_tailscale_logs_retrieve(&config, &id, Some(previous)).await?;
             print!("{}", logs);
         }
         DeploymentsCommand::Psql { id } => {


### PR DESCRIPTION
Adds support for getting logs of the previous container to mzcloud cli.

### Motivation

  * This PR adds a feature that has not yet been specified.
Debugging materialize cloud restart loops is very difficult. Adding the ability to get the previous container's logs makes it much easier.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
