### PR TITLE
persist: require Debug impls on anything pub

### DIFF
--- a/src/persist/src/error.rs
+++ b/src/persist/src/error.rs
@@ -86,6 +86,7 @@ impl<T> From<sync::PoisonError<T>> for Error {
 ///
 /// This exists to let us keep the (surprisingly non-trivial) Log plumbing while
 /// we don't actually use it, but without the risk of accidentally using it.
+#[derive(Debug)]
 pub struct ErrorLog;
 
 impl Log for ErrorLog {

--- a/src/persist/src/file.rs
+++ b/src/persist/src/file.rs
@@ -22,12 +22,14 @@ use crate::storage::{Blob, LockInfo, Log, SeqNo};
 
 /// Inner struct handles to separate files that store the data and metadata about the
 /// most recently truncated sequence number for [FileLog].
+#[derive(Debug)]
 struct FileLogCore {
     dataz: File,
     metadata: File,
 }
 
 /// A naive implementation of [Log] backed by files.
+#[derive(Debug)]
 pub struct FileLog {
     base_dir: Option<PathBuf>,
     dataz: Arc<Mutex<FileLogCore>>,
@@ -267,6 +269,7 @@ impl Log for FileLog {
 }
 
 /// Implementation of [Blob] backed by files.
+#[derive(Debug)]
 pub struct FileBlob {
     base_dir: Option<PathBuf>,
 }

--- a/src/persist/src/future.rs
+++ b/src/persist/src/future.rs
@@ -58,6 +58,7 @@ impl<T> Future<T> {
 }
 
 /// A handle for filling the result of an asynchronous computation.
+#[derive(Debug)]
 pub struct FutureHandle<T>(oneshot::Sender<Result<T, Error>>);
 
 impl<T> FutureHandle<T> {

--- a/src/persist/src/indexed/background.rs
+++ b/src/persist/src/indexed/background.rs
@@ -49,6 +49,7 @@ pub struct CompactTraceRes {
 //
 // TODO: Add migrating records from unsealed to trace as well as deletion of
 // batches.
+#[derive(Debug)]
 pub struct Maintainer<B: Blob> {
     // TODO: It feels like a smell to wrap BlobCache in an Arc when most of its
     // internals are already wrapped in Arcs. As of when this was written, the

--- a/src/persist/src/indexed/cache.rs
+++ b/src/persist/src/indexed/cache.rs
@@ -39,6 +39,7 @@ use crate::storage::Blob;
 /// unpredictable. I think we probably want a soft limit and a hard limit where
 /// the soft limit does some alerting and the hard limit starts blocking (or
 /// erroring) until disk space frees up.
+#[derive(Debug)]
 pub struct BlobCache<B: Blob> {
     metrics: Metrics,
     blob: Arc<Mutex<B>>,

--- a/src/persist/src/indexed/runtime.rs
+++ b/src/persist/src/indexed/runtime.rs
@@ -392,7 +392,7 @@ where
 
 /// A handle that allows writes of ((Key, Value), Time, Diff) updates into an
 /// [crate::indexed::Indexed] via a [RuntimeClient].
-#[derive(Debug, PartialEq, Eq)]
+#[derive(PartialEq, Eq)]
 pub struct StreamWriteHandle<K, V> {
     id: Id,
     runtime: RuntimeClient,
@@ -406,6 +406,15 @@ impl<K, V> Clone for StreamWriteHandle<K, V> {
             runtime: self.runtime.clone(),
             _phantom: self._phantom,
         }
+    }
+}
+
+impl<K, V> fmt::Debug for StreamWriteHandle<K, V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StreamWriteHandle")
+            .field("id", &self.id)
+            .field("runtime", &self.runtime)
+            .finish()
     }
 }
 
@@ -627,6 +636,7 @@ impl<K: Codec, V: Codec> Snapshot<K, V> for DecodedSnapshot<K, V> {
 }
 
 /// An [Iterator] representing one part of the data in a [DecodedSnapshot].
+#[derive(Debug)]
 pub struct DecodedSnapshotIter<K, V> {
     iter: IndexedSnapshotIter,
     _phantom: PhantomData<(K, V)>,

--- a/src/persist/src/indexed/trace.rs
+++ b/src/persist/src/indexed/trace.rs
@@ -13,9 +13,9 @@
 //! This is directly a persistent analog of [differential_dataflow::trace::Trace].
 
 use std::collections::VecDeque;
-use std::mem;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
+use std::{fmt, mem};
 
 use timely::progress::{Antichain, Timestamp};
 use timely::PartialOrder;
@@ -74,6 +74,7 @@ use crate::storage::Blob;
 /// - The compaction levels across the list of batches in a trace are weakly decreasing
 ///   (non-increasing) when iterating from oldest to most recent time intervals.
 /// - TODO: Space usage.
+#[derive(Debug)]
 pub struct Trace {
     id: Id,
     // NB: We may at some point need to break this up into separate logical and
@@ -334,6 +335,15 @@ impl Default for TraceSnapshotIter {
             current_batch: Vec::new(),
             batches: VecDeque::new(),
         }
+    }
+}
+
+impl fmt::Debug for TraceSnapshotIter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TraceSnapshotIter")
+            .field("current_batch(len)", &self.current_batch.len())
+            .field("batches", &self.batches)
+            .finish()
     }
 }
 

--- a/src/persist/src/indexed/unsealed.rs
+++ b/src/persist/src/indexed/unsealed.rs
@@ -11,6 +11,7 @@
 //! updates, indexed by time.
 
 use std::collections::VecDeque;
+use std::fmt;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 
@@ -63,6 +64,7 @@ use crate::storage::{Blob, SeqNo};
 /// - All entries are after or equal to some time frontier and less than some
 ///   SeqNo.
 /// - TODO: Space usage.
+#[derive(Debug)]
 pub struct Unsealed {
     id: Id,
     // NB: This is a closed lower bound. When Indexed seals a time, only data
@@ -341,7 +343,6 @@ impl Snapshot<Vec<u8>, Vec<u8>> for UnsealedSnapshot {
 // This intentionally stores the batches as a VecDeque so we can return the data
 // in roughly increasing timestamp order, but it's unclear if this is in any way
 // important.
-#[derive(Debug)]
 pub struct UnsealedSnapshotIter {
     /// A closed lower bound on the times of contained updates.
     ts_lower: Antichain<u64>,
@@ -350,6 +351,17 @@ pub struct UnsealedSnapshotIter {
 
     current_batch: Vec<((Vec<u8>, Vec<u8>), u64, isize)>,
     batches: VecDeque<Future<Arc<BlobUnsealedBatch>>>,
+}
+
+impl fmt::Debug for UnsealedSnapshotIter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UnsealedSnapshotIter")
+            .field("ts_lower", &self.ts_lower)
+            .field("ts_upper", &self.ts_upper)
+            .field("current_batch(len)", &self.current_batch.len())
+            .field("batches", &self.batches)
+            .finish()
+    }
 }
 
 impl Iterator for UnsealedSnapshotIter {

--- a/src/persist/src/lib.rs
+++ b/src/persist/src/lib.rs
@@ -9,7 +9,7 @@
 
 //! Persistence for Materialize dataflows.
 
-#![warn(missing_docs)]
+#![warn(missing_docs, missing_debug_implementations)]
 #![warn(
     clippy::cast_possible_truncation,
     clippy::cast_precision_loss,

--- a/src/persist/src/mem.rs
+++ b/src/persist/src/mem.rs
@@ -26,6 +26,7 @@ use crate::indexed::Indexed;
 use crate::storage::{Blob, LockInfo, Log, SeqNo};
 use crate::unreliable::{UnreliableBlob, UnreliableHandle, UnreliableLog};
 
+#[derive(Debug)]
 struct MemLogCore {
     seqno: Range<SeqNo>,
     dataz: Vec<Vec<u8>>,
@@ -109,6 +110,7 @@ impl MemLogCore {
 }
 
 /// An in-memory implementation of [Log].
+#[derive(Debug)]
 pub struct MemLog {
     core: Arc<Mutex<MemLogCore>>,
 }
@@ -169,6 +171,7 @@ impl Log for MemLog {
     }
 }
 
+#[derive(Debug)]
 struct MemBlobCore {
     dataz: HashMap<String, Vec<u8>>,
     lock: Option<LockInfo>,
@@ -229,6 +232,7 @@ impl MemBlobCore {
 }
 
 /// An in-memory implementation of [Blob].
+#[derive(Debug)]
 pub struct MemBlob {
     core: Arc<Mutex<MemBlobCore>>,
 }
@@ -298,7 +302,7 @@ impl Blob for MemBlob {
 
 /// An in-memory representation of a [Log] and [Blob] that can be reused
 /// across dataflows
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct MemRegistry {
     log: Arc<Mutex<MemLogCore>>,
     blob: Arc<Mutex<MemBlobCore>>,
@@ -382,6 +386,7 @@ impl MemRegistry {
 /// An in-memory representation of a set of [Log]s and [Blob]s that can be reused
 /// across dataflows
 #[cfg(test)]
+#[derive(Debug)]
 pub struct MemMultiRegistry {
     log_by_path: HashMap<String, Arc<Mutex<MemLogCore>>>,
     blob_by_path: HashMap<String, Arc<Mutex<MemBlobCore>>>,

--- a/src/persist/src/nemesis/generator.rs
+++ b/src/persist/src/nemesis/generator.rs
@@ -67,6 +67,7 @@ impl Default for GeneratorConfig {
     }
 }
 
+#[derive(Debug)]
 struct GeneratorState {
     running: bool,
     seal_frontier: HashMap<String, u64>,
@@ -285,6 +286,7 @@ impl ReqGenerator {
     }
 }
 
+#[derive(Debug)]
 pub struct Generator {
     seed: u64,
     config: GeneratorConfig,

--- a/src/persist/src/nemesis/mod.rs
+++ b/src/persist/src/nemesis/mod.rs
@@ -210,6 +210,7 @@ pub trait Runtime {
     fn finish(self);
 }
 
+#[derive(Debug)]
 pub struct Runner<R: Runtime> {
     generator: Generator,
     runtime: R,

--- a/src/persist/src/nemesis/validator.rs
+++ b/src/persist/src/nemesis/validator.rs
@@ -21,6 +21,7 @@ use crate::nemesis::{
 };
 use crate::storage::SeqNo;
 
+#[derive(Debug)]
 pub struct Validator {
     seal_frontier: HashMap<String, u64>,
     since_frontier: HashMap<String, u64>,

--- a/src/persist/src/operators/input.rs
+++ b/src/persist/src/operators/input.rs
@@ -9,6 +9,8 @@
 
 //! A Timely Dataflow operator that synchronously persists stream input.
 
+use std::fmt;
+
 use persist_types::Codec;
 use timely::dataflow::channels::pushers::buffer::AutoflushSession;
 use timely::dataflow::channels::pushers::{Counter, Tee};
@@ -85,6 +87,7 @@ where
 }
 
 /// A persistent equivalent of [UnorderedHandle].
+#[derive(Debug)]
 pub struct PersistentUnorderedHandle<K: TimelyData> {
     write: Box<StreamWriteHandle<K, ()>>,
     handle: UnorderedHandle<u64, (K, u64, isize)>,
@@ -114,6 +117,15 @@ pub struct PersistentUnorderedSession<'b, K: timely::Data> {
             Counter<u64, (K, u64, isize), Tee<u64, (K, u64, isize)>>,
         >,
     >,
+}
+
+impl<'b, K: timely::Data> fmt::Debug for PersistentUnorderedSession<'b, K> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PersistentUnorderedSession")
+            .field("write", &self.write)
+            .field("session", &"...")
+            .finish()
+    }
 }
 
 impl<'b, K: timely::Data + Codec> PersistentUnorderedSession<'b, K> {

--- a/src/persist/src/operators/source.rs
+++ b/src/persist/src/operators/source.rs
@@ -20,7 +20,7 @@ use timely::progress::Antichain;
 use timely::Data as TimelyData;
 
 use crate::indexed::runtime::StreamReadHandle;
-use crate::indexed::ListenEvent;
+use crate::indexed::{ListenEvent, ListenFn};
 use crate::operators::replay::Replay;
 
 /// A Timely Dataflow operator that mirrors a persisted stream.
@@ -50,11 +50,11 @@ where
         Stream<G, (String, u64, isize)>,
     ) {
         let (listen_tx, listen_rx) = mpsc::channel();
-        let listen_fn = Box::new(move |e| {
+        let listen_fn = ListenFn(Box::new(move |e| {
             // TODO: If send fails, it means the operator is no longer running.
             // We should probably allow the listen to deregister itself.
             let _ = listen_tx.send(e);
-        });
+        }));
 
         let snapshot = read.listen(listen_fn);
 

--- a/src/persist/src/operators/stream.rs
+++ b/src/persist/src/operators/stream.rs
@@ -657,7 +657,7 @@ mod tests {
     use timely::dataflow::operators::Capture;
 
     use crate::error::Error;
-    use crate::indexed::{ListenEvent, SnapshotExt};
+    use crate::indexed::{ListenEvent, ListenFn, SnapshotExt};
     use crate::mem::MemRegistry;
     use crate::unreliable::UnreliableHandle;
 
@@ -834,24 +834,24 @@ mod tests {
 
         {
             let listen_tx = listen_tx.clone();
-            let listen_fn = Box::new(move |e| {
+            let listen_fn = ListenFn(Box::new(move |e| {
                 match e {
                     ListenEvent::Sealed(t) => listen_tx.send(Sealed::Primary(t)).unwrap(),
                     _ => panic!("unexpected data"),
                 };
                 ()
-            });
+            }));
 
             primary_read.listen(listen_fn)?;
         };
         {
-            let listen_fn = Box::new(move |e| {
+            let listen_fn = ListenFn(Box::new(move |e| {
                 match e {
                     ListenEvent::Sealed(t) => listen_tx.send(Sealed::Condition(t)).unwrap(),
                     _ => panic!("unexpected data"),
                 };
                 ()
-            });
+            }));
 
             condition_read.listen(listen_fn)?;
         };

--- a/src/persist/src/operators/upsert.rs
+++ b/src/persist/src/operators/upsert.rs
@@ -69,6 +69,7 @@ pub trait PersistentUpsert<G, K: Codec, V: Codec, T> {
 }
 
 /// Persist configuration for persistent upsert.
+#[derive(Debug)]
 pub struct PersistentUpsertConfig<K: Codec, V: Codec> {
     /// The timestamp up to which which data should be read when restoring.
     upper_seal_ts: u64,

--- a/src/persist/src/s3.rs
+++ b/src/persist/src/s3.rs
@@ -9,6 +9,8 @@
 
 //! An S3 implementation of [Blob] storage.
 
+use std::fmt;
+
 use aws_util::aws::ConnectInfo;
 use rusoto_core::{ByteStream, Region, RusotoError};
 use rusoto_s3::{
@@ -25,6 +27,16 @@ pub struct Config {
     client: S3Client,
     bucket: String,
     prefix: String,
+}
+
+impl fmt::Debug for Config {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Config")
+            .field("client", &"...")
+            .field("bucket", &self.bucket)
+            .field("prefix", &self.prefix)
+            .finish()
+    }
 }
 
 impl Config {
@@ -150,6 +162,7 @@ impl Config {
 // - Resolve what to do with LOCK, this impl is race-y.
 // - Everything on the s3 client is async, but the persist runtime is not. Make
 //   the Log and Blob traits async and figure out how to deal with the fallout.
+#[derive(Debug)]
 pub struct S3Blob {
     blob_async: S3BlobAsync,
 }
@@ -196,6 +209,16 @@ struct S3BlobAsync {
     client: Option<S3Client>,
     bucket: String,
     prefix: String,
+}
+
+impl fmt::Debug for S3BlobAsync {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("S3BlobAsync")
+            .field("client", &"...")
+            .field("bucket", &self.bucket)
+            .field("prefix", &self.prefix)
+            .finish()
+    }
 }
 
 impl S3BlobAsync {

--- a/src/persist/src/storage.rs
+++ b/src/persist/src/storage.rs
@@ -226,6 +226,7 @@ pub mod tests {
         Ok(entries)
     }
 
+    #[derive(Debug)]
     pub struct PathAndReentranceId<'a> {
         pub path: &'a str,
         pub reentrance_id: &'a str,

--- a/src/persist/src/unreliable.rs
+++ b/src/persist/src/unreliable.rs
@@ -15,13 +15,14 @@ use std::sync::{Arc, Mutex};
 use crate::error::Error;
 use crate::storage::{Blob, Log, SeqNo};
 
+#[derive(Debug)]
 struct UnreliableCore {
     unavailable: bool,
     // TODO: Delays, what else?
 }
 
 /// A handle for controlling the behavior of an unreliable delegate.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct UnreliableHandle {
     core: Arc<Mutex<UnreliableCore>>,
 }
@@ -68,6 +69,7 @@ impl UnreliableHandle {
 }
 
 /// An unreliable delegate to [Log].
+#[derive(Debug)]
 pub struct UnreliableLog<L> {
     handle: UnreliableHandle,
     log: L,
@@ -119,6 +121,7 @@ impl<L: Log> Log for UnreliableLog<L> {
 }
 
 /// An unreliable delegate to [Blob].
+#[derive(Debug)]
 pub struct UnreliableBlob<B> {
     handle: UnreliableHandle,
     blob: B,


### PR DESCRIPTION
Checked via a compile time warn lint. We've been adding them one by one
as needed to debug things (in my case, repeatedly because I haven't been
great about cleaning up and committing my debug logging with the fix).
Having Debug impls on everything pub seems to be a modern rust idiom and
there isn't a great reason not to do it in persist.

### Motivation

   * This PR refactors existing code.
