### PR TITLE
coord: catalog transactions

### DIFF
--- a/src/coord/src/catalog/builtin_table_updates.rs
+++ b/src/coord/src/catalog/builtin_table_updates.rs
@@ -25,7 +25,7 @@ use crate::catalog::builtin::{
     MZ_ROLES, MZ_SCHEMAS, MZ_SINKS, MZ_SOURCES, MZ_TABLES, MZ_TYPES, MZ_VIEWS,
 };
 use crate::catalog::{
-    Catalog, CatalogItem, Func, Index, Sink, SinkConnector, SinkConnectorState, Source, Table,
+    CatalogItem, CatalogState, Func, Index, Sink, SinkConnector, SinkConnectorState, Source, Table,
     Type, TypeInner, SYSTEM_CONN_ID,
 };
 
@@ -40,7 +40,7 @@ pub struct BuiltinTableUpdate {
     pub diff: Diff,
 }
 
-impl Catalog {
+impl CatalogState {
     pub(super) fn pack_database_update(&self, name: &str, diff: Diff) -> BuiltinTableUpdate {
         let database = &self.by_name[name];
         BuiltinTableUpdate {

--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -18,16 +18,16 @@ use super::*;
 
 /// Borrows of catalog and indexes sufficient to build dataflow descriptions.
 pub struct DataflowBuilder<'a> {
-    catalog: &'a Catalog,
-    indexes: &'a ArrangementFrontiers<Timestamp>,
-    transient_id_counter: &'a mut u64,
+    pub catalog: &'a CatalogState,
+    pub indexes: &'a ArrangementFrontiers<Timestamp>,
+    pub transient_id_counter: &'a mut u64,
 }
 
 impl Coordinator {
     /// Creates a new dataflow builder from the catalog and indexes in `self`.
-    pub fn dataflow_builder(&mut self) -> DataflowBuilder {
+    pub fn dataflow_builder<'a>(&'a mut self) -> DataflowBuilder {
         DataflowBuilder {
-            catalog: &self.catalog,
+            catalog: self.catalog.state(),
             indexes: &self.indexes,
             transient_id_counter: &mut self.transient_id_counter,
         }
@@ -36,8 +36,11 @@ impl Coordinator {
     /// Prepares the arguments to an index build dataflow, by interrogating the catalog.
     ///
     /// Returns `None` if the index entry in the catalog in not enabled.
-    pub fn prepare_index_build(&self, index_id: &GlobalId) -> Option<(String, IndexDesc)> {
-        let index_entry = self.catalog.get_by_id(&index_id);
+    pub fn prepare_index_build(
+        catalog: &CatalogState,
+        index_id: &GlobalId,
+    ) -> Option<(String, IndexDesc)> {
+        let index_entry = catalog.get_by_id(&index_id);
         let index = match index_entry.item() {
             CatalogItem::Index(index) => index,
             _ => unreachable!("cannot create index dataflow on non-index"),


### PR DESCRIPTION
Implement full catalog transactions by passing the proposed catalog to a closure that is able to error, failing the entire transaction. Make a dataflow builder that uses this catalog to build potential dataflow descriptors. In the future, these builder methods can return errors that will abort the transaction.

### Motivation

   * This PR refactors existing code.

The current code does not allow errors to occur after `catalog_transact` because we have no way to rollback the operations. This presents problems if we need to produce an error during dataflow desc building (which needs to use the new catalog when building).

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
