### PR TITLE
Reduce superfluous clones by taking owned args

### DIFF
--- a/src/dataflow/src/render/join/mod.rs
+++ b/src/dataflow/src/render/join/mod.rs
@@ -136,7 +136,7 @@ impl JoinClosure {
         // Next, partition `mfp` into `before` and `after`, the former of which can be
         // applied now.
         let (mut before, after) = std::mem::replace(mfp, MapFilterProject::new(mfp.input_arity))
-            .partition(columns, columns.len());
+            .partition(columns.clone(), columns.len());
 
         // Add any newly created columns to `columns`. These columns may be referenced
         // by `after`, and it will be important to track their locations.
@@ -304,7 +304,8 @@ impl JoinBuildState {
                 expr.permute_map(&column_map);
             }
         }
-        mfp.permute(&column_map, column_map.len());
+        let column_map_len = column_map.len();
+        mfp.permute(column_map, column_map_len);
         mfp.optimize();
 
         JoinClosure {

--- a/src/dataflow/src/render/reduce.rs
+++ b/src/dataflow/src/render/reduce.rs
@@ -644,10 +644,11 @@ impl KeyValPlan {
         for column in demand.iter() {
             demand_map.insert(*column, demand_map.len());
         }
-        key_mfp.permute(&demand_map, demand_map.len());
+        key_mfp.permute(demand_map.clone(), demand_map.len());
         key_mfp.optimize();
         let key_plan = key_mfp.into_plan().unwrap().into_nontemporal().unwrap();
-        val_mfp.permute(&demand_map, demand_map.len());
+        let demand_map_len = demand_map.len();
+        val_mfp.permute(demand_map, demand_map_len);
         val_mfp.optimize();
         let val_plan = val_mfp.into_plan().unwrap().into_nontemporal().unwrap();
 

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -427,7 +427,7 @@ impl MapFilterProject {
     /// // Partition `original` using the available columns and current input arity.
     /// // This informs `partition` which columns are available, where they can be found,
     /// // and how many columns are not relevant but should be preserved.
-    /// let (before, after) = original.partition(&available_columns, 5);
+    /// let (before, after) = original.partition(available_columns, 5);
     ///
     /// // `before` sees all five input columns, and should append `a + b + c`.
     /// assert_eq!(before, MapFilterProject::new(5).map(vec![
@@ -450,7 +450,7 @@ impl MapFilterProject {
     /// // may not need all inputs. The `demand()` and `permute()` methods can
     /// // optimize the representation.
     /// ```
-    pub fn partition(self, available: &HashMap<usize, usize>, input_arity: usize) -> (Self, Self) {
+    pub fn partition(self, available: HashMap<usize, usize>, input_arity: usize) -> (Self, Self) {
         // Map expressions, filter predicates, and projections for `before` and `after`.
         let mut before_expr = Vec::new();
         let mut before_pred = Vec::new();
@@ -507,7 +507,7 @@ impl MapFilterProject {
         // Map from prior output location to location in un-projected `before`.
         // This map is used to correct references in `before` but it should be
         // adjusted to reflect `before`s projection prior to use in `after`.
-        let mut before_map = available.clone();
+        let mut before_map = available;
         // Input columns include any additional undescribed columns that may
         // not be captured by the `available` argument, so we must independently
         // track the current number of columns (vs relying on `before_map.len()`).
@@ -624,9 +624,8 @@ impl MapFilterProject {
     /// The supplied `shuffle` may not list columns that are not "demanded" by the
     /// instance, and so we should ensure that `self` is optimized to not reference
     /// columns that are not demanded.
-    pub fn permute(&mut self, shuffle: &HashMap<usize, usize>, new_input_arity: usize) {
+    pub fn permute(&mut self, mut shuffle: HashMap<usize, usize>, new_input_arity: usize) {
         self.remove_undemanded();
-        let mut shuffle = shuffle.clone();
         let (mut map, mut filter, mut project) = self.as_map_filter_project();
         for index in 0..map.len() {
             // Intermediate columns are just shifted.

--- a/src/ore/src/metrics/delete_on_drop.rs
+++ b/src/ore/src/metrics/delete_on_drop.rs
@@ -162,12 +162,12 @@ impl<'a, L> DeleteOnDropHistogram<'a, L>
 where
     L: PromLabelsExt<'a>,
 {
-    fn from_metric_vector(vec: &HistogramVec, labels: L) -> Self {
-        let inner = labels.get_from_metric_vec(vec);
+    fn from_metric_vector(vec: HistogramVec, labels: L) -> Self {
+        let inner = labels.get_from_metric_vec(&vec);
         Self {
             inner,
             labels,
-            vec: vec.clone(),
+            vec,
             _phantom: &PhantomData,
         }
     }
@@ -215,12 +215,12 @@ where
     P: Atomic,
     L: PromLabelsExt<'a>,
 {
-    fn from_metric_vector(vec: &GenericCounterVec<P>, labels: L) -> Self {
-        let inner = labels.get_from_metric_vec(vec);
+    fn from_metric_vector(vec: GenericCounterVec<P>, labels: L) -> Self {
+        let inner = labels.get_from_metric_vec(&vec);
         Self {
             inner,
             labels,
-            vec: vec.clone(),
+            vec,
             _phantom: &PhantomData,
         }
     }
@@ -272,7 +272,7 @@ impl<P: Atomic> CounterVecExt for GenericCounterVec<P> {
         &self,
         labels: L,
     ) -> DeleteOnDropCounter<'a, Self::CounterType, L> {
-        DeleteOnDropCounter::from_metric_vector(self, labels)
+        DeleteOnDropCounter::from_metric_vector(self.clone(), labels)
     }
 }
 
@@ -294,7 +294,7 @@ impl HistogramVecExt for HistogramVec {
         &self,
         labels: L,
     ) -> DeleteOnDropHistogram<'a, L> {
-        DeleteOnDropHistogram::from_metric_vector(self, labels)
+        DeleteOnDropHistogram::from_metric_vector(self.clone(), labels)
     }
 }
 
@@ -316,12 +316,12 @@ where
     P: Atomic,
     L: PromLabelsExt<'a>,
 {
-    fn from_metric_vector(vec: &GenericGaugeVec<P>, labels: L) -> Self {
-        let inner = labels.get_from_metric_vec(vec);
+    fn from_metric_vector(vec: GenericGaugeVec<P>, labels: L) -> Self {
+        let inner = labels.get_from_metric_vec(&vec);
         Self {
             inner,
             labels,
-            vec: vec.clone(),
+            vec,
             _phantom: &PhantomData,
         }
     }
@@ -370,7 +370,7 @@ impl<P: Atomic> GaugeVecExt for GenericGaugeVec<P> {
         &self,
         labels: L,
     ) -> DeleteOnDropGauge<'a, Self::GaugeType, L> {
-        DeleteOnDropGauge::from_metric_vector(self, labels)
+        DeleteOnDropGauge::from_metric_vector(self.clone(), labels)
     }
 }
 

--- a/src/transform/src/join_implementation.rs
+++ b/src/transform/src/join_implementation.rs
@@ -411,10 +411,10 @@ fn implement_arrangements<'a>(
         if let Some(mut lifted_mfp) = lifted_mfp {
             lifted_mfp.permute(
                 // globalize all input column references
-                &(new_join_mapper
+                new_join_mapper
                     .local_columns(index)
-                    .zip(new_join_mapper.global_columns(index)))
-                .collect(),
+                    .zip(new_join_mapper.global_columns(index))
+                    .collect(),
                 // shift the position of scalars to be after the last input
                 // column
                 arity,


### PR DESCRIPTION
### Motivation

This is me experimenting with writing custom clippy lints and I wanted to see if I could find superfluous clones. Looks like we had a few so I fixed them.


#### This PR refactors existing code.

The affected functions were unconditionally cloning arguments that were references. This can lead to waste if the caller would otherwise be happy to move ownership of the value to the affected function.

This patch makes all of these functions require an owned arguments and push the responsibility of clone vs move to the caller. In a few places this has resulted in less clones overall.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
