### PR TITLE
persist: address TODO to handle the operator error output in nemesis

### DIFF
--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -99,7 +99,10 @@ where
                     (Some(persist), Some(stream_name)) => {
                         let persisted_stream = persist.create_or_load(&stream_name);
                         let (persist_ok_stream, persist_err_stream) = match persisted_stream {
-                            Ok((_, read)) => scope.persisted_source(&read),
+                            Ok((_, read)) => scope.persisted_source(&read).ok_err(|x| match x {
+                                (Ok(kv), ts, diff) => Ok((kv, ts, diff)),
+                                (Err(err), ts, diff) => Err((err, ts, diff)),
+                            }),
                             Err(err) => {
                                 let ok_stream = empty(scope);
                                 let (ts, diff) = (0, 1);

--- a/src/persist/src/indexed/runtime.rs
+++ b/src/persist/src/indexed/runtime.rs
@@ -914,12 +914,13 @@ impl<L: Log, B: Blob> RuntimeImpl<L, B> {
 #[cfg(test)]
 mod tests {
     use timely::dataflow::operators::capture::Extract;
-    use timely::dataflow::operators::{Capture, Probe};
+    use timely::dataflow::operators::{Capture, OkErr, Probe};
     use timely::dataflow::ProbeHandle;
 
     use crate::indexed::SnapshotExt;
     use crate::mem::{MemMultiRegistry, MemRegistry};
     use crate::operators::source::PersistedSource;
+    use crate::operators::split_ok_err;
 
     use super::*;
 
@@ -1132,7 +1133,8 @@ mod tests {
 
             let mut probe = ProbeHandle::new();
             let ok_stream = worker.dataflow(|scope| {
-                let (ok_stream, _err_stream) = scope.persisted_source(&read);
+                let (ok_stream, _err_stream) =
+                    scope.persisted_source(&read).ok_err(|x| split_ok_err(x));
                 ok_stream.probe_with(&mut probe).capture()
             });
 

--- a/src/persist/src/nemesis/mod.rs
+++ b/src/persist/src/nemesis/mod.rs
@@ -77,7 +77,6 @@ use rand::RngCore;
 use timely::progress::Antichain;
 
 use crate::error::Error;
-use crate::indexed::ListenEvent;
 use crate::nemesis::generator::{Generator, GeneratorConfig};
 use crate::nemesis::validator::Validator;
 
@@ -171,8 +170,16 @@ pub struct ReadOutputReq {
 }
 
 #[derive(Clone, Debug)]
+pub enum ReadOutputEvent<D> {
+    /// Records in the data stream.
+    Records(Vec<D>),
+    /// Progress of the data stream.
+    Sealed(u64),
+}
+
+#[derive(Clone, Debug)]
 pub struct ReadOutputRes {
-    contents: Vec<ListenEvent<String, ()>>,
+    contents: Vec<ReadOutputEvent<(Result<(String, ()), String>, u64, isize)>>,
 }
 
 #[derive(Clone, Debug)]

--- a/src/persist/src/operators/mod.rs
+++ b/src/persist/src/operators/mod.rs
@@ -15,3 +15,12 @@ pub mod replay;
 pub mod source;
 pub mod stream;
 pub mod upsert;
+
+pub(crate) fn split_ok_err<K, V>(
+    x: (Result<(K, V), String>, u64, isize),
+) -> Result<((K, V), u64, isize), (String, u64, isize)> {
+    match x {
+        (Ok(kv), ts, diff) => Ok((kv, ts, diff)),
+        (Err(err), ts, diff) => Err((err, ts, diff)),
+    }
+}

--- a/src/persist/src/operators/replay.rs
+++ b/src/persist/src/operators/replay.rs
@@ -11,7 +11,7 @@
 
 use persist_types::Codec;
 use timely::dataflow::operators::generic::operator;
-use timely::dataflow::operators::OkErr;
+use timely::dataflow::operators::Map;
 use timely::dataflow::{Scope, Stream};
 use timely::Data as TimelyData;
 
@@ -25,10 +25,7 @@ pub trait Replay<G: Scope<Timestamp = u64>, K: TimelyData, V: TimelyData> {
     fn replay(
         &self,
         snapshot: Result<DecodedSnapshot<K, V>, Error>,
-    ) -> (
-        Stream<G, ((K, V), u64, isize)>,
-        Stream<G, (String, u64, isize)>,
-    );
+    ) -> Stream<G, (Result<(K, V), String>, u64, isize)>;
 }
 
 impl<G, K, V> Replay<G, K, V> for G
@@ -40,10 +37,7 @@ where
     fn replay(
         &self,
         snapshot: Result<DecodedSnapshot<K, V>, Error>,
-    ) -> (
-        Stream<G, ((K, V), u64, isize)>,
-        Stream<G, (String, u64, isize)>,
-    ) {
+    ) -> Stream<G, (Result<(K, V), String>, u64, isize)> {
         // TODO: This currently works by only emitting the persisted
         // data on worker 0 because that was the simplest thing to do
         // initially. Instead, we should shard up the responsibility
@@ -92,31 +86,33 @@ where
                     }
                 }
             });
-        // TODO: Return the result_stream directly?
-        result_stream.ok_err(|x| {
-            x.map_err(|err| {
-                // TODO: Make the responsibility for retries in the presence of
-                // transient storage failures lie with the snapshot (with
-                // appropriate monitoring). At the limit, we should be able to
-                // retry even the compaction+deletion of a batch that we were
-                // supposed to fetch by grabbing the current version of META.
-                // However, note that there is a case where we well and truly
-                // have to give up: when the compaction frontier has advanced
-                // past the ts this snapshot is reading at.
-                //
-                // TODO: Figure out a meaningful timestamp to use here? As
-                // mentioned above, this error will eventually represent
-                // something totally unrecoverable, so it should probably go to
-                // the system errors (once that's built) instead of this
-                // err_stream. Aljoscha suggests that system errors likely won't
-                // have a timestamp in the source domain
-                // (https://github.com/MaterializeInc/materialize/pull/8212#issuecomment-915877541),
-                // so perhaps this problem just goes away at some point. In the
-                // meantime, we never downgrade capabilities on the err_stream
-                // until the operator is finished, so it technically works to
-                // emit it at ts=0 for now.
-                (err.to_string(), 0, 1)
-            })
+        result_stream.map(|x| {
+            match x {
+                Ok((kv, ts, diff)) => (Ok(kv), ts, diff),
+                Err(err) => {
+                    // TODO: Make the responsibility for retries in the presence
+                    // of transient storage failures lie with the snapshot (with
+                    // appropriate monitoring). At the limit, we should be able
+                    // to retry even the compaction+deletion of a batch that we
+                    // were supposed to fetch by grabbing the current version of
+                    // META. However, note that there is a case where we well
+                    // and truly have to give up: when the compaction frontier
+                    // has advanced past the ts this snapshot is reading at.
+                    //
+                    // TODO: Figure out a meaningful timestamp to use here? As
+                    // mentioned above, this error will eventually represent
+                    // something totally unrecoverable, so it should probably go
+                    // to the system errors (once that's built) instead of this
+                    // err_stream. Aljoscha suggests that system errors likely
+                    // won't have a timestamp in the source domain
+                    // (https://github.com/MaterializeInc/materialize/pull/8212#issuecomment-915877541),
+                    // so perhaps this problem just goes away at some point. In
+                    // the meantime, we never downgrade capabilities on the
+                    // err_stream until the operator is finished, so it
+                    // technically works to emit it at ts=0 for now.
+                    (Err(err.to_string()), 0, 1)
+                }
+            }
         })
     }
 }


### PR DESCRIPTION
Basically, we make no guarantees once an error has been output, so
nemesis allows anything. Technically, this could have run the entire
production path logic of filtering only the errors before the timestamp
the data is begin read at, consolidated those, and only consider it an
error if the resulting set was non-empty, but persist doesn't do
anything with retractable errors yet, so that seemed unnecessary.

Split out from the WIP nemesis concurrency mega-PR because this is
something we could have been doing all along and I'm looking for ways to
break that up.

The bigger change here is making the output of the PersistedSource
operator be a Result stream instead of the previous two streams (one for
data and one for errors) mostly because it was less plumbing in nemesis
and we'd been talking about doing this anyway. Lmk what you think, it's
also straightforward to revert that bit and handle two streams in
nemesis if we think this is premature.
