### PR TITLE
sql-parser,sql: move some semantic analysis out of the SQL parser

### DIFF
--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1749,7 +1749,7 @@ impl<'a> Parser<'a> {
             }
             envelope
         } else {
-            Default::default()
+            Envelope::None
         };
 
         Ok(Statement::CreateSource(CreateSourceStatement {

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -384,7 +384,7 @@ CreateViews(CreateViewsStatement { if_exists: Error, temporary: false, materiali
 parse-statement
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING SCHEMA 'baz'
 ----
-CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING SCHEMA 'baz'
+CREATE SOURCE foo FROM FILE 'bar' COMPRESSION NONE FORMAT AVRO USING SCHEMA 'baz'
 =>
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Bare(Avro(InlineSchema { schema: Inline("baz"), with_options: [] })), key_envelope: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
 
@@ -401,56 +401,56 @@ parse-statement
 CREATE MATERIALIZED SOURCE foo FROM FILE 'bar' FORMAT PROTOBUF MESSAGE
 'somemessage' USING SCHEMA FILE 'path'
 ----
-CREATE MATERIALIZED SOURCE foo FROM FILE 'bar' FORMAT PROTOBUF MESSAGE 'somemessage' USING SCHEMA FILE 'path'
+CREATE MATERIALIZED SOURCE foo FROM FILE 'bar' COMPRESSION NONE FORMAT PROTOBUF MESSAGE 'somemessage' USING SCHEMA FILE 'path'
 =>
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Bare(Protobuf(InlineSchema { message_name: "somemessage", schema: File("path") })), key_envelope: None, envelope: None, if_not_exists: false, materialized: true, key_constraint: None })
 
 parse-statement
 CREATE SOURCE IF NOT EXISTS foo FROM FILE 'bar' WITH (tail = true) FORMAT REGEX '(asdf)|(jkl)'
 ----
-CREATE SOURCE IF NOT EXISTS foo FROM FILE 'bar' WITH (tail = true) FORMAT REGEX '(asdf)|(jkl)'
+CREATE SOURCE IF NOT EXISTS foo FROM FILE 'bar' COMPRESSION NONE WITH (tail = true) FORMAT REGEX '(asdf)|(jkl)'
 =>
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [Value { name: Ident("tail"), value: Boolean(true) }], format: Bare(Regex("(asdf)|(jkl)")), key_envelope: None, envelope: None, if_not_exists: true, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE IF NOT EXISTS foo (one, two) FROM FILE 'bar' WITH (tail = true) FORMAT REGEX '(asdf)|(jkl)'
 ----
-CREATE SOURCE IF NOT EXISTS foo (one, two) FROM FILE 'bar' WITH (tail = true) FORMAT REGEX '(asdf)|(jkl)'
+CREATE SOURCE IF NOT EXISTS foo (one, two) FROM FILE 'bar' COMPRESSION NONE WITH (tail = true) FORMAT REGEX '(asdf)|(jkl)'
 =>
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [Ident("one"), Ident("two")], connector: File { path: "bar", compression: None }, with_options: [Value { name: Ident("tail"), value: Boolean(true) }], format: Bare(Regex("(asdf)|(jkl)")), key_envelope: None, envelope: None, if_not_exists: true, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE foo FROM FILE 'bar' WITH (tail = false) FORMAT CSV WITH HEADER
 ----
-CREATE SOURCE foo FROM FILE 'bar' WITH (tail = false) FORMAT CSV WITH HEADER
+CREATE SOURCE foo FROM FILE 'bar' COMPRESSION NONE WITH (tail = false) FORMAT CSV WITH HEADER
 =>
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [Value { name: Ident("tail"), value: Boolean(false) }], format: Bare(Csv { columns: Header { names: [] }, delimiter: ',' }), key_envelope: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE foo FROM FILE 'bar' WITH (tail = false) FORMAT CSV WITH HEADER (a, b, c)
 ----
-CREATE SOURCE foo FROM FILE 'bar' WITH (tail = false) FORMAT CSV WITH HEADER (a, b, c)
+CREATE SOURCE foo FROM FILE 'bar' COMPRESSION NONE WITH (tail = false) FORMAT CSV WITH HEADER (a, b, c)
 =>
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [Value { name: Ident("tail"), value: Boolean(false) }], format: Bare(Csv { columns: Header { names: [Ident("a"), Ident("b"), Ident("c")] }, delimiter: ',' }), key_envelope: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE foo FROM FILE 'bar' WITH (tail = false) FORMAT CSV WITH 3 COLUMNS
 ----
-CREATE SOURCE foo FROM FILE 'bar' WITH (tail = false) FORMAT CSV WITH 3 COLUMNS
+CREATE SOURCE foo FROM FILE 'bar' COMPRESSION NONE WITH (tail = false) FORMAT CSV WITH 3 COLUMNS
 =>
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [Value { name: Ident("tail"), value: Boolean(false) }], format: Bare(Csv { columns: Count(3), delimiter: ',' }), key_envelope: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE foo (one, two) FROM FILE 'bar' FORMAT CSV WITH HEADER
 ----
-CREATE SOURCE foo (one, two) FROM FILE 'bar' FORMAT CSV WITH HEADER
+CREATE SOURCE foo (one, two) FROM FILE 'bar' COMPRESSION NONE FORMAT CSV WITH HEADER
 =>
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [Ident("one"), Ident("two")], connector: File { path: "bar", compression: None }, with_options: [], format: Bare(Csv { columns: Header { names: [] }, delimiter: ',' }), key_envelope: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE foo FROM FILE 'bar' WITH (tail = true) FORMAT CSV WITH 3 COLUMNS DELIMITED BY '|'
 ----
-CREATE SOURCE foo FROM FILE 'bar' WITH (tail = true) FORMAT CSV WITH 3 COLUMNS DELIMITED BY '|'
+CREATE SOURCE foo FROM FILE 'bar' COMPRESSION NONE WITH (tail = true) FORMAT CSV WITH 3 COLUMNS DELIMITED BY '|'
 =>
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [Value { name: Ident("tail"), value: Boolean(true) }], format: Bare(Csv { columns: Count(3), delimiter: '|' }), key_envelope: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
 
@@ -471,35 +471,35 @@ CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]),
 parse-statement
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' ENVELOPE DEBEZIUM
 ----
-CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' ENVELOPE DEBEZIUM
+CREATE SOURCE foo FROM FILE 'bar' COMPRESSION NONE FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' ENVELOPE DEBEZIUM
 =>
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Bare(Avro(Csr { csr_connector: CsrConnector { url: "http://localhost:8081", seed: None, with_options: [] } })), key_envelope: None, envelope: Debezium(Plain), if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' SEED VALUE SCHEMA 'blah'
 ----
-CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' SEED VALUE SCHEMA 'blah'
+CREATE SOURCE foo FROM FILE 'bar' COMPRESSION NONE FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' SEED VALUE SCHEMA 'blah'
 =>
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Bare(Avro(Csr { csr_connector: CsrConnector { url: "http://localhost:8081", seed: Some(CsrSeed { key_schema: None, value_schema: "blah" }), with_options: [] } })), key_envelope: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' SEED KEY SCHEMA 'a' VALUE SCHEMA 'b'
 ----
-CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' SEED KEY SCHEMA 'a' VALUE SCHEMA 'b'
+CREATE SOURCE foo FROM FILE 'bar' COMPRESSION NONE FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' SEED KEY SCHEMA 'a' VALUE SCHEMA 'b'
 =>
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Bare(Avro(Csr { csr_connector: CsrConnector { url: "http://localhost:8081", seed: Some(CsrSeed { key_schema: Some("a"), value_schema: "b" }), with_options: [] } })), key_envelope: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (a = 'b') ENVELOPE DEBEZIUM
 ----
-CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (a = 'b') ENVELOPE DEBEZIUM
+CREATE SOURCE foo FROM FILE 'bar' COMPRESSION NONE FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (a = 'b') ENVELOPE DEBEZIUM
 =>
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Bare(Avro(Csr { csr_connector: CsrConnector { url: "http://localhost:8081", seed: None, with_options: [Value { name: Ident("a"), value: String("b") }] } })), key_envelope: None, envelope: Debezium(Plain), if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081'
 ----
-CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081'
+CREATE SOURCE foo FROM FILE 'bar' COMPRESSION NONE FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081'
 =>
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Bare(Avro(Csr { csr_connector: CsrConnector { url: "http://localhost:8081", seed: None, with_options: [] } })), key_envelope: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
 
@@ -646,14 +646,14 @@ CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("psychic"
 parse-statement
 CREATE SOURCE IF NOT EXISTS foo FROM FILE 'bar' FORMAT BYTES
 ----
-CREATE SOURCE IF NOT EXISTS foo FROM FILE 'bar' FORMAT BYTES
+CREATE SOURCE IF NOT EXISTS foo FROM FILE 'bar' COMPRESSION NONE FORMAT BYTES
 =>
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Bare(Bytes), key_envelope: None, envelope: None, if_not_exists: true, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE MATERIALIZED SOURCE foo FROM FILE 'bar' FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081'
 ----
-CREATE MATERIALIZED SOURCE foo FROM FILE 'bar' FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081'
+CREATE MATERIALIZED SOURCE foo FROM FILE 'bar' COMPRESSION NONE FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081'
 =>
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Bare(Protobuf(Csr { csr_connector: CsrConnector { url: "http://localhost:8081", seed: None, with_options: [] } })), key_envelope: None, envelope: None, if_not_exists: false, materialized: true, key_constraint: None })
 

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -415,7 +415,9 @@ pub fn plan_create_source(
         },
         None => scx.catalog.config().timestamp_frequency,
     };
-    if !matches!(connector, CreateSourceConnector::Kafka { .. }) && key_envelope.is_present() {
+    if *key_envelope != CreateSourceKeyEnvelope::None
+        && !matches!(connector, CreateSourceConnector::Kafka { .. })
+    {
         bail_unsupported!("INCLUDE KEY with non-Kafka sources");
     }
 
@@ -1161,7 +1163,9 @@ fn get_key_envelope(
     envelope: &Envelope,
     encoding: &SourceDataEncoding,
 ) -> Result<KeyEnvelope, anyhow::Error> {
-    if key_envelope.is_present() && matches!(envelope, Envelope::Debezium { .. }) {
+    if *key_envelope != CreateSourceKeyEnvelope::None
+        && matches!(envelope, Envelope::Debezium { .. })
+    {
         bail!("Cannot use INCLUDE KEY with ENVELOPE DEBEZIUM: Debezium values include all keys.");
     }
     Ok(match key_envelope {


### PR DESCRIPTION
The SQL parser is meant to perform syntactic analysis only. Move some
methods that specify semantics out of the parser, and perform that
analysis in the planner instead.

<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
