### PR TITLE
Unpatch headers crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1710,7 +1710,8 @@ dependencies = [
 [[package]]
 name = "headers"
 version = "0.3.5"
-source = "git+https://github.com/hyperium/headers#4cdea5614ef44f19415dbba38fb0b4efbf13accc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c4eb0471fcb85846d8b0690695ef354f9afb11cb03cac2e1d7c9253351afb0"
 dependencies = [
  "base64",
  "bitflags",
@@ -1725,7 +1726,8 @@ dependencies = [
 [[package]]
 name = "headers-core"
 version = "0.2.0"
-source = "git+https://github.com/hyperium/headers#4cdea5614ef44f19415dbba38fb0b4efbf13accc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
  "http",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,11 +74,3 @@ rustc-demangle = { opt-level = 3 }
 # it's unlikely we're going to get interactive access to a debugger in
 # production installations, but we still want useful crash reports.
 debug = 1
-
-# TODO - remove this once a release of `headers` without a dependency on `time`
-# goes out.
-#
-# We don't want to depend on `time` because it triggers
-# https://rustsec.org/advisories/RUSTSEC-2020-0071 .
-[patch.crates-io]
-headers = { git = "https://github.com/hyperium/headers" }

--- a/deny.toml
+++ b/deny.toml
@@ -75,5 +75,4 @@ allow-git = [
     "https://github.com/TimelyDataflow/timely-dataflow",
     "https://github.com/TimelyDataflow/differential-dataflow.git",
     "https://github.com/fede1024/rust-rdkafka.git",
-    "https://github.com/hyperium/headers",
 ]


### PR DESCRIPTION
New version that doesn't depend on `time` got released
