### PR TITLE
Separate position metadata handling from decoding stage

### DIFF
--- a/src/dataflow/src/decode/avro.rs
+++ b/src/dataflow/src/decode/avro.rs
@@ -11,7 +11,6 @@ use futures::executor::block_on;
 
 use dataflow_types::{DataflowError, DecodeError};
 use interchange::avro::{Decoder, EnvelopeType};
-use repr::Datum;
 use repr::Row;
 
 #[derive(Debug)]
@@ -46,16 +45,11 @@ impl AvroDecoderState {
     pub fn decode(
         &mut self,
         bytes: &mut &[u8],
-        coord: Option<i64>,
         upstream_time_millis: Option<i64>,
-        push_metadata: bool,
     ) -> Result<Option<Row>, DataflowError> {
-        match block_on(self.decoder.decode(bytes, coord, upstream_time_millis)) {
-            Ok(mut row) => {
+        match block_on(self.decoder.decode(bytes, upstream_time_millis)) {
+            Ok(row) => {
                 self.events_success += 1;
-                if push_metadata {
-                    row.push(Datum::from(coord))
-                }
                 Ok(Some(row))
             }
             Err(err) => Err(DataflowError::DecodeError(DecodeError::Text(format!(

--- a/src/dataflow/src/decode/protobuf.rs
+++ b/src/dataflow/src/decode/protobuf.rs
@@ -33,13 +33,8 @@ impl ProtobufDecoderState {
             events_error: 0,
         }
     }
-    pub fn get_value(
-        &mut self,
-        bytes: &[u8],
-        position: Option<i64>,
-        push_metadata: bool,
-    ) -> Option<Result<Row, DataflowError>> {
-        match self.decoder.decode(bytes, position, push_metadata) {
+    pub fn get_value(&mut self, bytes: &[u8]) -> Option<Result<Row, DataflowError>> {
+        match self.decoder.decode(bytes) {
             Ok(row) => {
                 if let Some(row) = row {
                     self.events_success += 1;

--- a/src/interchange/benches/avro.rs
+++ b/src/interchange/benches/avro.rs
@@ -402,7 +402,7 @@ pub fn bench_avro(c: &mut Criterion) {
     let mut bg = c.benchmark_group("avro");
     bg.throughput(Throughput::Bytes(len));
     bg.bench_function("decode", move |b| {
-        b.iter(|| black_box(block_on(decoder.decode(&mut buf.as_slice(), None, None)).unwrap()))
+        b.iter(|| black_box(block_on(decoder.decode(&mut buf.as_slice(), None)).unwrap()))
     });
     bg.finish();
 }

--- a/src/interchange/benches/protobuf.rs
+++ b/src/interchange/benches/protobuf.rs
@@ -72,7 +72,7 @@ pub fn bench_protobuf(c: &mut Criterion) {
     let mut bg = c.benchmark_group("protobuf");
     bg.throughput(Throughput::Bytes(len));
     bg.bench_function("decode", move |b| {
-        b.iter(|| black_box(decoder.decode(&buf, None, true).unwrap()))
+        b.iter(|| black_box(decoder.decode(&buf).unwrap()))
     });
     bg.finish();
 }

--- a/src/interchange/src/avro/decode.rs
+++ b/src/interchange/src/avro/decode.rs
@@ -161,7 +161,6 @@ impl Decoder {
     pub async fn decode(
         &mut self,
         bytes: &mut &[u8],
-        coord: Option<i64>,
         upstream_time_millis: Option<i64>,
     ) -> anyhow::Result<Row> {
         let (bytes2, resolved_schema) = self.csr_avro.resolve(bytes).await?;
@@ -213,13 +212,8 @@ impl Decoder {
             self.packer.finish_and_reuse()
         };
         log::trace!(
-            "[customer-data] Decoded row {:?}{} in {}",
+            "[customer-data] Decoded row {:?} in {}",
             result,
-            if let Some(coord) = coord {
-                format!(" at offset {}", coord)
-            } else {
-                format!("")
-            },
             self.debug_name
         );
         Ok(result)

--- a/src/interchange/src/avro/envelope_debezium/deduplication.rs
+++ b/src/interchange/src/avro/envelope_debezium/deduplication.rs
@@ -130,7 +130,7 @@ impl DebeziumDeduplicationStrategy {
                         &debug_name,
                         worker_index,
                         &row,
-                        // Debezium decoding always adds two extra rows to the end of the record: one with the deduplication position,
+                        // Debezium decoding always adds two extra columns to the end of the record: one with the deduplication position,
                         // and one with the upstream time in milliseconds.
                         // Since these are the last two datums in the row, they are at `arity - 2` and `arity - 1`, respectively.
                         arity - 2,

--- a/src/interchange/src/protobuf.rs
+++ b/src/interchange/src/protobuf.rs
@@ -362,7 +362,7 @@ mod tests {
 
         let mut decoder = get_decoder(".TestRecord");
         let row = decoder
-            .decode(&bytes, None, false)
+            .decode(&bytes)
             .expect("deserialize protobuf into a row")
             .unwrap();
         let datums = row.iter().collect::<Vec<_>>();
@@ -390,7 +390,7 @@ mod tests {
 
         let mut decoder = get_decoder(".TestRecord");
         let row = decoder
-            .decode(&bytes, None, false)
+            .decode(&bytes)
             .expect("deserialize protobuf into a row")
             .unwrap();
         let datums = row.iter().collect::<Vec<_>>();
@@ -417,7 +417,7 @@ mod tests {
 
         let mut decoder = get_decoder(".TestRepeatedRecord");
         let row = decoder
-            .decode(&bytes, None, false)
+            .decode(&bytes)
             .expect("deserialize protobuf into a row")
             .unwrap();
         let datums = row.iter().collect::<Vec<_>>();
@@ -455,7 +455,7 @@ mod tests {
 
         let mut decoder = get_decoder(".TestNestedRecord");
         let row = decoder
-            .decode(&bytes, None, false)
+            .decode(&bytes)
             .expect("deserialize protobuf into a row")
             .unwrap();
         let datums = row.iter().collect::<Vec<_>>();
@@ -493,7 +493,7 @@ mod tests {
             .expect("test failed to serialize to bytes");
 
         let row2 = decoder
-            .decode(&bytes, None, false)
+            .decode(&bytes)
             .expect("deserialize protobuf into a row")
             .unwrap();
         let datums = row2.iter().collect::<Vec<_>>();
@@ -546,7 +546,7 @@ mod tests {
 
         let mut decoder = get_decoder(".TestRepeatedNestedRecord");
         let row = decoder
-            .decode(&bytes, None, false)
+            .decode(&bytes)
             .expect("deserialize protobuf into a row")
             .unwrap();
         let datums = row.iter().collect::<Vec<_>>();

--- a/src/interchange/src/protobuf/decode.rs
+++ b/src/interchange/src/protobuf/decode.rs
@@ -43,12 +43,7 @@ impl Decoder {
         }
     }
 
-    pub fn decode(
-        &mut self,
-        bytes: &[u8],
-        position: Option<i64>,
-        push_metadata: bool,
-    ) -> Result<Option<Row>> {
+    pub fn decode(&mut self, bytes: &[u8]) -> Result<Option<Row>> {
         let input_stream = protobuf::CodedInputStream::from_bytes(bytes);
         let mut deserializer =
             Deserializer::for_named_message(&self.descriptors, &self.message_name, input_stream)
@@ -71,9 +66,6 @@ impl Decoder {
             &relation_type.typ().column_types,
             &mut packer,
         )?;
-        if push_metadata {
-            packer.push(Datum::from(position));
-        }
         Ok(Some(packer.finish_and_reuse()))
     }
 }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -856,14 +856,12 @@ pub fn plan_create_source(
         }
     }
 
-    // TODO(benesch): the available metadata columns should not depend
-    // on the format.
-    //
     // TODO(brennan): They should not depend on the envelope either. Figure out a way to
     // make all of this more tasteful.
-    if !matches!(encoding.value_ref(), DataEncoding::Avro { .. })
-        && !matches!(envelope, SourceEnvelope::Debezium(_, _))
-    {
+    if !matches!(
+        envelope,
+        SourceEnvelope::Debezium(_, _) | SourceEnvelope::CdcV2
+    ) {
         for (name, ty) in external_connector.metadata_columns() {
             bare_desc = bare_desc.with_named_column(name, ty);
         }

--- a/test/restart/user-indexes-disabled.td
+++ b/test/restart/user-indexes-disabled.td
@@ -77,6 +77,7 @@ unable to automatically determine a query timestamp
 on_name   key_name              seq_in_index  column_name  expression  nullable enabled
 ---------------------------------------------------------------------------------------
 mat_data  mat_data_primary_idx  1             a            <null>      false    false
+mat_data  mat_data_primary_idx  2             mz_offset    <null>      false    false
 mat_data  ms_drop_idx           1             a            <null>      false    false
 
 > DROP INDEX ms_drop_idx;
@@ -85,6 +86,7 @@ mat_data  ms_drop_idx           1             a            <null>      false    
 on_name   key_name              seq_in_index  column_name  expression  nullable enabled
 ---------------------------------------------------------------------------------------
 mat_data  mat_data_primary_idx  1             a            <null>      false    false
+mat_data  mat_data_primary_idx  2             mz_offset    <null>      false    false
 
 # 🔬🔬🔬🔬 Non-materialized views
 
@@ -184,12 +186,13 @@ mat_view
 on_name   key_name              seq_in_index  column_name  expression  nullable enabled
 ---------------------------------------------------------------------------------------
 mat_data  mat_data_primary_idx  1             a            <null>      false    true
+mat_data  mat_data_primary_idx  2             mz_offset    <null>      false    true
 
 > SHOW MATERIALIZED SOURCES
 mat_data
 
 > SELECT * FROM mat_data
-1
+1 1
 
 # 🔬🔬🔬 Non-materialized views
 
@@ -207,7 +210,7 @@ unable to automatically determine a query timestamp
 
 # With indexes enabled, data starts flowing to sinks
 $ kafka-verify format=avro sink=materialize.public.snk_indexes_disabled sort-messages=true
-{"before": null, "after": {"row":{"a": 1}}}
+{"before": null, "after": {"row":{"a": 1, "mz_offset": 1}}}
 
 # 🔬🔬 Tables
 

--- a/test/restart/user-indexes-enabled.td
+++ b/test/restart/user-indexes-enabled.td
@@ -64,7 +64,7 @@ logging_derived_mat
   FORMAT AVRO USING SCHEMA '${schema}'
 
 > SELECT * FROM mat_data
-1
+1 1
 
 > SHOW MATERIALIZED SOURCES
 mat_data
@@ -103,7 +103,7 @@ $ kafka-ingest format=avro topic=join-data schema=${join-schema} timestamp=1
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 $ kafka-verify format=avro sink=materialize.public.snk_indexes_enabled sort-messages=true
-{"before": null, "after": {"row":{"a": 1}}}
+{"before": null, "after": {"row":{"a": 1, "mz_offset": 1}}}
 
 # 🔬 Tables
 

--- a/test/testdrive/avro-decode-mismatched-types.td
+++ b/test/testdrive/avro-decode-mismatched-types.td
@@ -76,7 +76,7 @@ $ kafka-ingest format=avro topic=avro-types-int2long schema=${int} timestamp=1
   ENVELOPE NONE
 
 > SELECT * FROM avro_types_int2long
-123
+123 1
 
 #
 # int -> float
@@ -161,4 +161,4 @@ $ kafka-ingest format=avro topic=avro-types-string2bytes schema=${string} timest
   ENVELOPE NONE
 
 > SELECT * FROM avro_types_string2bytes
-"abc \\xd0\\xb0\\xd0\\xb1\\xd1\\x86"
+"abc \\xd0\\xb0\\xd0\\xb1\\xd1\\x86" 1

--- a/test/testdrive/avro-decode-temporal.td
+++ b/test/testdrive/avro-decode-temporal.td
@@ -25,10 +25,10 @@ $ kafka-ingest format=avro topic=avro-decode-date schema=${date} timestamp=1
   ENVELOPE NONE
 
 > SELECT * FROM avro_decode_date
-1969-12-31
-1970-01-01
-1970-01-02
-+35771-04-27
+1969-12-31 1
+1970-01-01 2
+1970-01-02 3
++35771-04-27 4
 
 # Time and time-millis do not appear to be decoded to a temporal data type, see rc/avro/tests/schema.rs
 
@@ -48,10 +48,10 @@ $ kafka-ingest format=avro topic=avro-decode-time-millis schema=${time-millis} t
   ENVELOPE NONE
 
 > SELECT * FROM avro_decode_time_millis
--1
-0
-1
-12345678
+-1 1
+0 2
+1 3
+12345678 4
 
 #
 # timestamp-millis
@@ -77,14 +77,14 @@ $ kafka-ingest format=avro topic=avro-decode-timestamp-millis schema=${timestamp
   ENVELOPE NONE
 
 > SELECT * FROM avro_decode_timestamp_millis
-"1970-01-01 00:00:00"
-"1970-01-01 00:00:00.001"
-"1970-01-01 00:00:00.010"
-"1970-01-01 00:00:00.100"
-"1970-01-01 00:00:01"
-"1970-01-01 00:00:10"
-"1970-01-01 00:01:01"
-"1970-01-15 06:56:07.890"
+"1970-01-01 00:00:00" 1
+"1970-01-01 00:00:00.001" 2
+"1970-01-01 00:00:00.010" 3
+"1970-01-01 00:00:00.100" 4
+"1970-01-01 00:00:01" 5
+"1970-01-01 00:00:10" 6
+"1970-01-01 00:01:01" 7
+"1970-01-15 06:56:07.890" 8
 
 #
 # timestamp-micros
@@ -110,14 +110,14 @@ $ kafka-ingest format=avro topic=avro-decode-timestamp-micros schema=${timestamp
   ENVELOPE NONE
 
 > SELECT * FROM avro_decode_timestamp_micros
-"1970-01-01 00:00:00"
-"1970-01-01 00:00:00.000001"
-"1970-01-01 00:00:00.000010"
-"1970-01-01 00:00:00.000100"
-"1970-01-01 00:00:00.001"
-"1970-01-01 00:00:00.010"
-"1970-01-01 00:01:01"
-"1970-01-01 00:20:34.567890"
+"1970-01-01 00:00:00" 1
+"1970-01-01 00:00:00.000001" 2
+"1970-01-01 00:00:00.000010" 3
+"1970-01-01 00:00:00.000100" 4
+"1970-01-01 00:00:00.001" 5
+"1970-01-01 00:00:00.010" 6
+"1970-01-01 00:01:01" 7
+"1970-01-01 00:20:34.567890" 8
 
 #
 # local-timestamp-millis is not decoded to a temporal type
@@ -142,13 +142,13 @@ $ kafka-ingest format=avro topic=avro-decode-local-timestamp-millis schema=${loc
   ENVELOPE NONE
 
 > SELECT * FROM avro_decode_local_timestamp_millis
-0
-1
-10
-100
-1000
-10000
-1234567890
+0 1
+1 2
+10 3
+100 4
+1000 5
+10000 6
+1234567890 7
 
 #
 # duration is not tested because there is no support for "fixed"

--- a/test/testdrive/avro-resolution-enums.td
+++ b/test/testdrive/avro-resolution-enums.td
@@ -33,6 +33,7 @@ $ kafka-ingest format=avro topic=resolution-enums schema=${enum-reader} publish=
 
 > SHOW COLUMNS FROM resolution_enums
 f1 false text
+mz_offset false bigint
 
 > SELECT f1 FROM resolution_enums
 E1

--- a/test/testdrive/avro-resolution-less-columns.td
+++ b/test/testdrive/avro-resolution-less-columns.td
@@ -28,7 +28,7 @@ $ kafka-ingest format=avro topic=resolution-2to1 schema=${1column} publish=true 
 {"f1": "val_f1b"}
 
 > SELECT * FROM resolution_2to1
-f1 f2
+f1 f2 mz_offset
 ---
-val_f1a val_f2a
-val_f1b default_f2
+val_f1a val_f2a 1
+val_f1b default_f2 2

--- a/test/testdrive/avro-resolution-more-columns.td
+++ b/test/testdrive/avro-resolution-more-columns.td
@@ -17,7 +17,7 @@ $ set 2columns={"type": "record", "name": "schema_more_columns", "fields": [ {"n
 $ kafka-create-topic topic=resolution-1to2
 
 $ kafka-ingest format=avro topic=resolution-1to2 schema=${1column} publish=true timestamp=1
-{"f1": "val_f1b"}
+{"f1": "val_f1a"}
 
 > CREATE MATERIALIZED SOURCE resolution_1to2
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-resolution-1to2-${testdrive.seed}'
@@ -25,10 +25,10 @@ $ kafka-ingest format=avro topic=resolution-1to2 schema=${1column} publish=true 
   ENVELOPE NONE
 
 $ kafka-ingest format=avro topic=resolution-1to2 schema=${2columns} publish=true timestamp=2
-{"f1": "val_f1a", "f2": "val_f2a"}
+{"f1": "val_f1b", "f2": "val_f2b"}
 
 > SELECT * FROM resolution_1to2
-f1
+f1 mz_offset
 ---
-val_f1a
-val_f1b
+val_f1a 1
+val_f1b 2

--- a/test/testdrive/fetch-concurrent-same-source.td
+++ b/test/testdrive/fetch-concurrent-same-source.td
@@ -38,18 +38,18 @@ true
 > DECLARE c2 CURSOR FOR SELECT * FROM fetch_concurrent_same_source;
 
 > FETCH ALL c1;
-123
-234
-345
+123 1
+234 2
+345 3
 
 > FETCH ALL c2;
-123
-234
-345
+123 1
+234 2
+345 3
 
 > DECLARE c3 CURSOR FOR SELECT * FROM fetch_concurrent_same_source;
 
 > FETCH ALL c3;
-123
-234
-345
+123 1
+234 2
+345 3

--- a/test/testdrive/fetch-concurrent-two-sources.td
+++ b/test/testdrive/fetch-concurrent-two-sources.td
@@ -56,19 +56,19 @@ true
 > DECLARE c2 CURSOR FOR SELECT * FROM fetch_concurrent_two_sources2_view;
 
 > FETCH 1 c1;
-12
+12 1
 
 > FETCH 1 c2;
-12
+12 1
 
 > FETCH 1 c1;
-23
+23 2
 
 > FETCH 1 c2;
-23
+23 2
 
 > FETCH 1 c1;
-34
+34 3
 
 > FETCH 1 c2;
-34
+34 3

--- a/test/testdrive/fetch-select-during-ingest.td
+++ b/test/testdrive/fetch-select-during-ingest.td
@@ -27,14 +27,14 @@ $ kafka-ingest format=avro topic=tail-fetch-during-ingest schema=${int} timestam
 {"f1": 123}
 
 > SELECT * FROM fetch_during_ingest;
-123
+123 1
 
 > BEGIN
 
 > DECLARE c CURSOR FOR SELECT * FROM fetch_during_ingest;
 
 > FETCH 1 c WITH (timeout='60s');
-123
+123 1
 
 $ kafka-ingest format=avro topic=tail-fetch-during-ingest schema=${int} timestamp=2
 {"f1": 234}
@@ -59,5 +59,5 @@ $ kafka-ingest format=avro topic=tail-fetch-during-ingest schema=${int} timestam
 > DECLARE c CURSOR FOR SELECT * FROM fetch_during_ingest;
 
 > FETCH 2 c WITH (timeout='60s');
-123
-234
+123 1
+234 2

--- a/test/testdrive/fetch-tail-during-ingest.td
+++ b/test/testdrive/fetch-tail-during-ingest.td
@@ -31,11 +31,11 @@ $ kafka-ingest format=avro topic=tail-fetch-during-ingest schema=${int} timestam
 {"f1": 123}
 
 > FETCH 1 c WITH (timeout='60s');
-<TIMESTAMP> 1 123
+<TIMESTAMP> 1 123 1
 
 $ kafka-ingest format=avro topic=tail-fetch-during-ingest schema=${int} timestamp=2
 {"f1": 234}
 
 # The row just inserted is ours to fetch
 > FETCH 1 c WITH (timeout='60s');
-<TIMESTAMP> 1 234
+<TIMESTAMP> 1 234 2

--- a/test/testdrive/fetch-tail-without-snapshot.td
+++ b/test/testdrive/fetch-tail-without-snapshot.td
@@ -27,9 +27,9 @@ $ kafka-ingest format=avro topic=tail-without-snapshot schema=${int} timestamp=1
   ENVELOPE NONE
 
 > SELECT * FROM tail_without_snapshot;
-123
-234
-345
+123 1
+234 2
+345 3
 
 > BEGIN
 
@@ -41,4 +41,4 @@ $ kafka-ingest format=avro topic=tail-without-snapshot schema=${int} timestamp=1
 {"f1": 567}
 
 > FETCH 1 FROM c WITH (timeout = '60s')
-<TIMESTAMP> 1 567
+<TIMESTAMP> 1 567 4

--- a/test/testdrive/kafka-avro-sources.td
+++ b/test/testdrive/kafka-avro-sources.td
@@ -221,10 +221,10 @@ $ kafka-ingest format=avro topic=non-dbz-data schema=${non-dbz-schema} timestamp
   ENVELOPE NONE
 
 > SELECT * FROM non_dbz_data
-a b
+a b mz_offset
 ---
-1 2
-2 3
+1 2 1
+2 3 2
 
 # Test an Avro source without a Debezium envelope starting at specified partition offsets.
 
@@ -243,9 +243,9 @@ $ kafka-ingest format=avro topic=non-dbz-data-multi-partition schema=${non-dbz-s
   ENVELOPE NONE
 
 > SELECT * FROM non_dbz_data_multi_partition
-a  b
------
-4  1
+a  b  mz_offset
+---------------
+4  1  1
 
 > CREATE MATERIALIZED SOURCE non_dbz_data_multi_partition_2
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-non-dbz-data-multi-partition-${testdrive.seed}'
@@ -254,10 +254,10 @@ a  b
   ENVELOPE NONE
 
 > SELECT * FROM non_dbz_data_multi_partition_2
-a  b
------
-1  2
-4  1
+a  b  mz_offset
+---------------
+1  2  1
+4  1  1
 
 > CREATE MATERIALIZED SOURCE non_dbz_data_multi_partition_fast_forwarded
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-non-dbz-data-multi-partition-${testdrive.seed}'
@@ -266,9 +266,9 @@ a  b
   ENVELOPE NONE
 
 > SELECT * FROM non_dbz_data_multi_partition_fast_forwarded
-a  b
-----
-1  2
+a  b  mz_offset
+---------------
+1  2  1
 
 > CREATE MATERIALIZED SOURCE non_dbz_data_multi_partition_fast_forwarded_2
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-non-dbz-data-multi-partition-${testdrive.seed}'
@@ -277,9 +277,9 @@ a  b
   ENVELOPE NONE
 
 > SELECT * FROM non_dbz_data_multi_partition_fast_forwarded_2
-a  b
-----
-4  1
+a  b  mz_offset
+---------------
+4  1  1
 
 # Test an Avro source without a Debezium envelope with specified offsets and varying partition numbers.
 
@@ -304,14 +304,14 @@ $ kafka-ingest format=avro topic=non-dbz-data-varying-partition schema=${non-dbz
   ENVELOPE NONE
 
 > SELECT * FROM non_dbz_data_varying_partition_2
-a  b
-----
-5  6
+a  b  mz_offset
+---------------
+5  6  1
 
 $ kafka-add-partitions topic=non-dbz-data-varying-partition total-partitions=2
 
 # Reading data that's ingested to a new partition takes longer than the default timeout.
-$ set-sql-timeout duration=60s
+$ set-sql-timeout duration=20s
 
 $ kafka-ingest format=avro topic=non-dbz-data-varying-partition schema=${non-dbz-schema} timestamp=1 partition=1
 {"a": 7, "b": 8}
@@ -320,18 +320,18 @@ $ kafka-ingest format=avro topic=non-dbz-data-varying-partition schema=${non-dbz
 # Because the start offset for any new partitions will be 0, the first record sent to the new
 # partition will be included.
 > SELECT * FROM non_dbz_data_varying_partition
-a  b
------
-7  8
-9  10
+a  b   mz_offset
+----------------
+7  8   1
+9  10  2
 
 # Because the start offsets erronously included an offset for partition 1 (which didn't exist at the time),
 # the first record ingested into partition 1 will be ignored.
 > SELECT * FROM non_dbz_data_varying_partition_2
-a  b
------
-5  6
-9  10
+a  b   mz_offset
+----------------
+5  6   1
+9  10  2
 
 # There should be two partitions for the last created source / consumer (non_dbz_data_varying_partition_2)
 > SELECT count(*) FROM mz_kafka_consumer_partitions GROUP BY source_id;
@@ -362,10 +362,10 @@ $ kafka-ingest format=avro topic=non-dbz-data-varying-partition schema=${non-dbz
 # Because the start offset for any new partitions will be 0, the first record sent to the new
 # partition will be included.
 > SELECT * FROM non_dbz_data_varying_partition_3
-a  b
------
-9  10
-11 12
+a  b   mz_offset
+----------------
+9  10  2
+11 12  1
 
 # There should three partitions for the last three sources / consumers (non_dbz_data_varying_partition_[123])
 > SELECT count(*) FROM mz_kafka_consumer_partitions GROUP BY source_id;
@@ -647,9 +647,9 @@ $ kafka-ingest format=avro topic=non-subset-key key-format=avro key-schema=${key
   ENVELOPE NONE
 
 > SELECT * FROM non_subset_key
-a
----
-"asdf"
+a       mz_offset
+-----------------
+"asdf"  1
 
 # Test that Postgres-style sources can be ingested.
 $ set pg-dbz-schema={

--- a/test/testdrive/kafka-avro-upsert-sinks.td
+++ b/test/testdrive/kafka-avro-upsert-sinks.td
@@ -48,14 +48,14 @@ $ kafka-ingest format=avro topic=upsert-avro key-format=avro key-schema=${upsert
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' ENVELOPE UPSERT
 
 $ kafka-verify format=avro sink=materialize.public.upsert_input_sink sort-messages=true
-{"key1": "fisch", "key2": 42} {"key1": "fisch", "key2": 42, "f1": "fish", "f2": 1000}
-{"key1": "fish", "key2": 2} {"key1": "fish", "key2": 2, "f1": "fish", "f2": 1000}
+{"key1": "fisch", "key2": 42} {"key1": "fisch", "key2": 42, "f1": "fish", "f2": 1000, "mz_offset": 2}
+{"key1": "fish", "key2": 2} {"key1": "fish", "key2": 2, "f1": "fish", "f2": 1000, "mz_offset": 1}
 
 $ kafka-ingest format=avro topic=upsert-avro key-format=avro key-schema=${upsert-keyschema} schema=${upsert-schema} publish=true
 {"key1": "fisch", "key2": 42} {"f1": "richtig, fisch", "f2": 2000}
 
 $ kafka-verify format=avro sink=materialize.public.upsert_input_sink
-{"key1": "fisch", "key2": 42} {"key1": "fisch", "key2": 42, "f1": "richtig, fisch", "f2": 2000}
+{"key1": "fisch", "key2": 42} {"key1": "fisch", "key2": 42, "f1": "richtig, fisch", "f2": 2000, "mz_offset": 3}
 
 # More complicated scenarios: super keys, consistency input/output
 

--- a/test/testdrive/kafka-include-key-sources.td
+++ b/test/testdrive/kafka-include-key-sources.td
@@ -50,9 +50,9 @@ INCLUDE KEY requires specifying KEY FORMAT .. VALUE FORMAT, got bare FORMAT
 column name "id" is ambiguous
 
 > SELECT * FROM avro_data_conflict
-id id b
--------
-1 2 3
+id id b mz_offset
+-----------------
+1 2 3   1
 
 > CREATE MATERIALIZED SOURCE avro_data_explicit (key_id, id, b)
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avro-data-${testdrive.seed}'
@@ -72,9 +72,9 @@ key_id id b
   INCLUDE KEY AS renamed_id
 
 > SELECT * FROM avro_data_as
-renamed_id id b
-------------
-1 2 3
+renamed_id  id  b  mz_offset
+----------------------------
+1           2   3  1
 
 
 > CREATE MATERIALIZED SOURCE avro_avro_data (key_id, id, b)
@@ -92,9 +92,9 @@ renamed_id id b
   ENVELOPE UPSERT
 
 > SELECT * FROM avro_data_upsert
-renamed id b
-------------
-1 2 3
+renamed  id  b  mz_offset
+-------------------------
+1        2   3  1
 
 $ set multikeyschema={
     "type": "record",
@@ -125,9 +125,9 @@ $ kafka-ingest format=avro key-format=avro topic=avro-data-record key-schema=${m
   ENVELOPE NONE
 
 > SELECT * FROM avro_key_record_flattened
-id geo a
---------
-1 nyc 99
+id geo a mz_offset
+------------------
+1 nyc 99 1
 
 > CREATE MATERIALIZED SOURCE avro_key_record_renamed
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avro-data-record-${testdrive.seed}'

--- a/test/testdrive/kafka-upsert-sources-new-syntax.td
+++ b/test/testdrive/kafka-upsert-sources-new-syntax.td
@@ -45,11 +45,11 @@ $ kafka-ingest format=avro topic=avroavro key-format=avro key-schema=${keyschema
   ENVELOPE UPSERT
 
 > SELECT * from avroavro
-key           f1       f2
----------------------------
-fish          fish     1000
-birdmore      geese    56
-mammalmore    moose    2
+key           f1       f2    mz_offset
+--------------------------------------
+fish          fish     1000  1
+birdmore      geese    56    6
+mammalmore    moose    2     9
 
 $ kafka-create-topic topic=textavro
 
@@ -75,12 +75,12 @@ $ file-append path=data-schema.json
   ENVELOPE UPSERT
 
 > select * from bytesavro
-key0          f1       f2
----------------------------
-fish          fish     1000
-b\xc3\xacrd1  goose    1
-birdmore      geese    2
-mammal1       moose    1
+key0          f1       f2    mz_offset
+--------------------------------------
+fish          fish     1000  1
+b\xc3\xacrd1  goose    1     2
+birdmore      geese    2     3
+mammal1       moose    1     4
 
 $ kafka-ingest format=avro topic=textavro key-format=bytes key-terminator=: schema=${schema} publish=true
 bìrd1:
@@ -89,11 +89,11 @@ mämmalmore: {"f1": "moose", "f2": 42}
 mammal1:
 
 > select * from textavro
-key0          f1       f2
----------------------------
-fish          fish     1000
-birdmore      geese    56
-mämmalmore    moose    42
+key0          f1       f2    mz_offset
+--------------------------------------
+fish          fish     1000  1
+birdmore      geese    56    6
+mämmalmore    moose    42    7
 
 $ kafka-create-topic topic=textbytes
 
@@ -273,12 +273,12 @@ $ kafka-ingest format=avro topic=realtimeavroavro key-format=avro key-schema=${k
 
 > CREATE MATERIALIZED VIEW realtimeavroavro_view as SELECT * from realtimeavroavro;
 
-> select f3, f4, f1, f2 from realtimeavroavro_view
-f3        f4      f1             f2
------------------------------------
-fire      yang    dog            42
-<null>    yin     sheep          54
-water     <null>  crocodile      7
+> select * from realtimeavroavro_view
+f3        f4      f1             f2  mz_offset
+----------------------------------------------
+fire      yang    dog            42  1
+<null>    yin     sheep          54  5
+water     <null>  crocodile      7   7
 
 # Ensure that Upsert sources work with `start_offset`
 > CREATE MATERIALIZED SOURCE realtimeavroavro_ff
@@ -290,10 +290,10 @@ water     <null>  crocodile      7
   ENVELOPE UPSERT
 
 > SELECT * FROM realtimeavroavro_ff
-f3        f1        f1           f2
------------------------------------
-<null>    yin       sheep        54
-water     <null>    crocodile    7
+f3        f1        f1           f2  mz_offset
+----------------------------------------------
+<null>    yin       sheep        54  5
+water     <null>    crocodile    7   7
 
 # ensure that having deletion on a key that never existed does not break anything
 $ kafka-ingest format=avro topic=realtimeavroavro key-format=avro key-schema=${keyschema2} schema=${schema} publish=true
@@ -307,12 +307,12 @@ $ kafka-ingest format=avro topic=realtimeavroavro key-format=avro key-schema=${k
 {"f3": {"string": "water"}, "f1": null}
 
 > select * from realtimeavroavro_view
-f3         f4          f1             f2
------------------------------------------
-fire       yang        dog            42
-air        qi          chicken        47
-<null>     yin         dog            243
-earth      dao         rhinoceros     211
+f3         f4          f1             f2   mz_offset
+----------------------------------------------------
+fire       yang        dog            42   1
+air        qi          chicken        47   13
+<null>     yin         dog            243  15
+earth      dao         rhinoceros     211  12
 
 $ kafka-create-topic topic=realtimefilteravro
 

--- a/test/testdrive/kafka-upsert-sources.td
+++ b/test/testdrive/kafka-upsert-sources.td
@@ -48,11 +48,11 @@ $ kafka-ingest format=avro topic=avroavro key-format=avro key-schema=${keyschema
   ENVELOPE UPSERT
 
 > SELECT * from avroavro
-key           f1       f2
----------------------------
-fish          fish     1000
-birdmore      geese    56
-mammalmore    moose    2
+key           f1       f2    mz_offset
+--------------------------------------
+fish          fish     1000  1
+birdmore      geese    56    6
+mammalmore    moose    2     9
 
 $ kafka-create-topic topic=textavro
 
@@ -77,12 +77,12 @@ $ file-append path=data-schema.json
   ENVELOPE UPSERT FORMAT TEXT
 
 > select * from bytesavro
-key0          f1       f2
----------------------------
-fish          fish     1000
-b\xc3\xacrd1  goose    1
-birdmore      geese    2
-mammal1       moose    1
+key0          f1       f2    mz_offset
+--------------------------------------
+fish          fish     1000  1
+b\xc3\xacrd1  goose    1     2
+birdmore      geese    2     3
+mammal1       moose    1     4
 
 $ kafka-ingest format=avro topic=textavro key-format=bytes key-terminator=: schema=${schema} publish=true
 bìrd1:
@@ -91,11 +91,11 @@ mämmalmore: {"f1": "moose", "f2": 42}
 mammal1:
 
 > select * from textavro
-key0          f1       f2
----------------------------
-fish          fish     1000
-birdmore      geese    56
-mämmalmore    moose    42
+key0          f1       f2    mz_offset
+--------------------------------------
+fish          fish     1000  1
+birdmore      geese    56    6
+mämmalmore    moose    42    7
 
 $ kafka-create-topic topic=textbytes
 
@@ -274,12 +274,12 @@ $ kafka-ingest format=avro topic=realtimeavroavro key-format=avro key-schema=${k
 
 > CREATE MATERIALIZED VIEW realtimeavroavro_view as SELECT * from realtimeavroavro;
 
-> select f3, f4, f1, f2 from realtimeavroavro_view
-f3        f4      f1             f2
------------------------------------
-fire      yang    dog            42
-<null>    yin     sheep          54
-water     <null>  crocodile      7
+> select * from realtimeavroavro_view
+f3        f4      f1             f2  mz_offset
+----------------------------------------------
+fire      yang    dog            42  1
+<null>    yin     sheep          54  5
+water     <null>  crocodile      7   7
 
 # Ensure that Upsert sources work with `start_offset`
 > CREATE MATERIALIZED SOURCE realtimeavroavro_ff
@@ -290,10 +290,10 @@ water     <null>  crocodile      7
   ENVELOPE UPSERT FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 > SELECT * FROM realtimeavroavro_ff
-f3        f1        f1           f2
------------------------------------
-<null>    yin       sheep        54
-water     <null>    crocodile    7
+f3        f1        f1           f2  mz_offset
+----------------------------------------------
+<null>    yin       sheep        54  5
+water     <null>    crocodile    7   7
 
 # ensure that having deletion on a key that never existed does not break anything
 $ kafka-ingest format=avro topic=realtimeavroavro key-format=avro key-schema=${keyschema2} schema=${schema} publish=true
@@ -307,12 +307,12 @@ $ kafka-ingest format=avro topic=realtimeavroavro key-format=avro key-schema=${k
 {"f3": {"string": "water"}, "f1": null}
 
 > select * from realtimeavroavro_view
-f3         f4          f1             f2
------------------------------------------
-fire       yang        dog            42
-air        qi          chicken        47
-<null>     yin         dog            243
-earth      dao         rhinoceros     211
+f3         f4          f1             f2   mz_offset
+----------------------------------------------------
+fire       yang        dog            42   1
+air        qi          chicken        47   13
+<null>     yin         dog            243  15
+earth      dao         rhinoceros     211  12
 
 $ kafka-create-topic topic=realtimefilteravro
 
@@ -534,19 +534,19 @@ $ kafka-ingest format=avro topic=input-pkne-flat schema=${schema}
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' ENVELOPE UPSERT
 
 $ kafka-verify format=avro sink=materialize.public.input_pkne_flat_a_sink sort-messages=true
-{"a": 1} {"a": 1, "b": 11}
-{"a": 2} {"a": 2, "b": 22}
-{"a": 3} {"a": 3, "b": 33}
+{"a": 1} {"a": 1, "b": 11, "mz_offset": 1}
+{"a": 2} {"a": 2, "b": 22, "mz_offset": 2}
+{"a": 3} {"a": 3, "b": 33, "mz_offset": 3}
 
 $ kafka-verify format=avro sink=materialize.public.input_pkne_flat_b_sink sort-messages=true
-{"b": 11} {"a": 1, "b": 11}
-{"b": 22} {"a": 2, "b": 22}
-{"b": 33} {"a": 3, "b": 33}
+{"b": 11} {"a": 1, "b": 11, "mz_offset": 1}
+{"b": 22} {"a": 2, "b": 22, "mz_offset": 2}
+{"b": 33} {"a": 3, "b": 33, "mz_offset": 3}
 
 $ kafka-verify format=avro sink=materialize.public.input_pkne_flat_ab_sink sort-messages=true
-{"a": 1, "b": 11} {"a": 1, "b": 11}
-{"a": 2, "b": 22} {"a": 2, "b": 22}
-{"a": 3, "b": 33} {"a": 3, "b": 33}
+{"a": 1, "b": 11} {"a": 1, "b": 11, "mz_offset": 1}
+{"a": 2, "b": 22} {"a": 2, "b": 22, "mz_offset": 2}
+{"a": 3, "b": 33} {"a": 3, "b": 33, "mz_offset": 3}
 
 $ set keyschema={
     "type": "record",
@@ -576,9 +576,9 @@ $ kafka-ingest topic=input-pkne-key key-format=avro key-schema=${keyschema} form
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' ENVELOPE UPSERT
 
 $ kafka-verify format=avro sink=materialize.public.input_pkne_key_sink sort-messages=true
-{"key1": "a"} {"key1": "a", "key2": 1, "a": 1, "b": 11}
-{"key1": "b"} {"key1": "b", "key2": 2, "a": 2, "b": 22}
-{"key1": "c"} {"key1": "c", "key2": 3, "a": 3, "b": 33}
+{"key1": "a"} {"key1": "a", "key2": 1, "a": 1, "b": 11, "mz_offset": 1}
+{"key1": "b"} {"key1": "b", "key2": 2, "a": 2, "b": 22, "mz_offset": 2}
+{"key1": "c"} {"key1": "c", "key2": 3, "a": 3, "b": 33, "mz_offset": 3}
 
 ! CREATE MATERIALIZED SOURCE avroavro (PRIMARY KEY (f1) NOT ENFORCED)
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avroavro-${testdrive.seed}'

--- a/test/testdrive/materializations.td
+++ b/test/testdrive/materializations.td
@@ -94,12 +94,12 @@ b  ?column?
 > CREATE DEFAULT INDEX ON data_view
 
 > SELECT * FROM data_view
-a  b
-----
-1  1
-2  1
-3  1
-1  2
+a  b  mz_offset
+---------------
+1  1  1
+2  1  2
+3  1  3
+1  2  4
 
 > CREATE VIEW test3 AS
   SELECT b, min(a) FROM data_view GROUP BY b
@@ -214,12 +214,12 @@ unable to automatically determine a query timestamp
 > CREATE INDEX data_view_idx on data_view(a)
 
 > SELECT * from data_view
-a b
----
-1 1
-2 1
-3 1
-1 2
+a b mz_offset
+-------------
+1 1 1
+2 1 2
+3 1 3
+1 2 4
 
 # Existing materialized dependencies can be selected from as normal.
 > SELECT * from test6
@@ -240,12 +240,12 @@ b  c
 > CREATE INDEX data_view_idx2 on data_view(a)
 
 > SELECT * from data_view
-a b
----
-1 1
-2 1
-3 1
-1 2
+a b mz_offset
+-------------
+1 1 1
+2 1 2
+3 1 3
+1 2 4
 
 > SELECT * from test6
 d
@@ -264,12 +264,12 @@ b  c
 > DROP INDEX data_view_idx
 
 > SELECT * from data_view
-a b
----
-1 1
-2 1
-3 1
-1 2
+a b mz_offset
+-------------
+1 1 1
+2 1 2
+3 1 3
+1 2 4
 
 > SELECT * from test6
 d
@@ -300,12 +300,12 @@ $ kafka-ingest format=avro topic=mat schema=${schema} timestamp=1
 {"a": 1, "b": 2}
 
 > SELECT * from mat_data
-a  b
-----
--1 0
--1 1
-3  4
-1  2
+a  b  mz_offset
+---------------
+-1 0  1
+-1 1  2
+3  4  3
+1  2  4
 
 > SHOW SOURCES
 name
@@ -386,16 +386,16 @@ $ kafka-ingest format=avro topic=mat schema=${schema} timestamp=2
 > CREATE INDEX mat_data_idx3 on mat_data(b)
 
 > SELECT * from mat_data
-a  b
-----
--1 0
--1 1
-3  4
-1  2
--3 0
--1 0
-0  4
-1  2
+a  b  mz_offset
+---------------
+-1 0  1
+-1 1  2
+3  4  3
+1  2  4
+-3 0  5
+-1 0  6
+0  4  7
+1  2  8
 
 > SELECT * from test7
 count

--- a/test/testdrive/primary-key-optimizations.td
+++ b/test/testdrive/primary-key-optimizations.td
@@ -59,14 +59,14 @@ $ kafka-ingest format=avro topic=t1 key-format=avro key-schema=${keyschema-2keys
 > EXPLAIN SELECT key2, key1 FROM t1 GROUP BY key1, key2, key2 || 'a';
 "%0 =| Get t1| Project (#1, #0)"
 
-> EXPLAIN SELECT DISTINCT key1, key2, nokey FROM t1;
+> EXPLAIN SELECT DISTINCT key1, key2, nokey, mz_offset FROM t1;
 "%0 =| Get t1"
 
-> EXPLAIN SELECT key1, key2, nokey FROM t1 GROUP BY key1, key2, nokey;
+> EXPLAIN SELECT key1, key2, nokey, mz_offset FROM t1 GROUP BY key1, key2, nokey, mz_offset;
 "%0 =| Get t1"
 
 > EXPLAIN SELECT key1, key2 FROM t1 GROUP BY key1, key2 HAVING key1 = 'a';
-"%0 =| Get t1| Filter (#0 = \"a\")| Map \"a\"| Project (#3, #1)"
+"%0 =| Get t1| Filter (#0 = \"a\")| Map \"a\"| Project (#4, #1)"
 
 # Optimization not possible - explicit distinct is present in plan
 
@@ -164,14 +164,14 @@ $ kafka-ingest format=avro topic=t1-pkne schema=${schema} publish=true
 > EXPLAIN SELECT key2, key1 FROM t1_pkne GROUP BY key1, key2, key2 || 'a';
 "%0 =| Get t1_pkne| Project (#1, #0)"
 
-> EXPLAIN SELECT DISTINCT key1, key2, nokey FROM t1_pkne;
+> EXPLAIN SELECT DISTINCT key1, key2, nokey, mz_offset FROM t1_pkne;
 "%0 =| Get t1_pkne"
 
-> EXPLAIN SELECT key1, key2, nokey FROM t1_pkne GROUP BY key1, key2, nokey;
+> EXPLAIN SELECT key1, key2, nokey, mz_offset FROM t1_pkne GROUP BY key1, key2, nokey, mz_offset;
 "%0 =| Get t1_pkne"
 
 > EXPLAIN SELECT key1, key2 FROM t1_pkne GROUP BY key1, key2 HAVING key1 = 'a';
-"%0 =| Get t1_pkne| Filter (#0 = \"a\")| Map \"a\"| Project (#3, #1)"
+"%0 =| Get t1_pkne| Filter (#0 = \"a\")| Map \"a\"| Project (#4, #1)"
 
 # Optimization not possible - explicit distinct is present in plan
 

--- a/test/testdrive/source-linear-operators.td
+++ b/test/testdrive/source-linear-operators.td
@@ -42,7 +42,7 @@ $ set-regex match=u\d+ replacement=UID
 ? EXPLAIN PLAN FOR VIEW mv;
 Source materialize.public.data (UID):
 | Filter (#0 = 1), (#3 = 3)
-| Project (#0..#3)
+| Project (#0..#4)
 
 Query:
 %0 =
@@ -50,7 +50,7 @@ Query:
 | Filter (#0 = 1), (#3 = 3)
 
 > SELECT * FROM mv
-1 2 2 3
+1 2 2 3 4
 
 > DROP VIEW mv;
 
@@ -240,7 +240,7 @@ Query:
 %2 =
 | Get %0 (l0)
 | Map i64tonumeric((1 + #2))
-| Project (#0, #4)
+| Project (#0, #5)
 
 %3 =
 | Union %1 %2

--- a/test/testdrive/testdrive.td
+++ b/test/testdrive/testdrive.td
@@ -126,8 +126,8 @@ $ kafka-ingest format=avro topic=kafka-ingest-repeat schema=${kafka-ingest-repea
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 $ kafka-verify format=avro sink=materialize.public.kafka_ingest_repeat_sink sort-messages=true
-{"before":null,"after":{"row":{"f1":"fish"}}}
-{"before":null,"after":{"row":{"f1":"fish"}}}
+{"before":null,"after":{"row":{"f1":"fish", "mz_offset": 1}}}
+{"before":null,"after":{"row":{"f1":"fish", "mz_offset": 2}}}
 
 # kafka-verify with regexp (the set-regexp from above is used
 


### PR DESCRIPTION
### Motivation
The decoding stage is responsible for transforming a timely stream of `SourceOutput` messages into a timely stream of `DecodeResult`. Previously, depending on the `push_metadata` flag, the format decoders would push the position metadata into the decoded row. However, `DecodeResult`s have a `position` field that carries the position metadata anyway.

In this patch format decoder implementations are made oblivious of the `position`[1] and `push_metadata` information and never produce this information in the output row.

Then, the downstream envelope stage of transforming the `DecodeResult` stream into a pure `Row` stream can choose whether or not it makes sense for the envelope to append the position metadata into the output `Row`.

Previously the rule for the `push_metadata` depended not just on the envelope type, but also on the format. Specifically, if the format was Avro the position metadata was being omitted. This chagne makes pushing the metadata into the final row depend only on the envelope type, which introduces a breaking change.

After this patch all envelopes except `DEBEZIUM` and `MATERIALIZE` will forward the position metadata into the final row.

The users that will observe a breaking change are all users using an Avro source (this does not include AvroOCF) with an envelope of `NONE` or `UPSERT`.

[1] The avro format decoder still needs access to position information because it's intermingled with debezium logic. The property of never pushing the metadata into the output Row still holds though, which is sufficient for this patch. Once the debezium logic is fully implemented on top of Rows the Avro decoder will be oblivious of position information.

### Tips for reviewer

Please review commit by commit. Each commit has detailed commit messages and the biggest part of this PR which is fixing up all the testcases has been bundled into a separate commit to facilitate reviewing.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
