### PR TITLE
coord: prevent UPDATE and DELETE with disable-user-indexes

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -103,6 +103,9 @@ List new features before bug fixes.
 
 {{% version-header v0.9.11 %}}
 
+- Disallow `UPDATE` and `DELETE` operations on tables when boot in
+  `--disable-user-indexes` mode.
+
 {{% version-header v0.9.10 %}}
 
 - Evaluate TopK operators on constant inputs at query compile time.

--- a/test/restart/user-indexes-disabled.td
+++ b/test/restart/user-indexes-disabled.td
@@ -105,6 +105,12 @@ $ kafka-verify format=avro sink=materialize.public.snk_indexes_disabled sort-mes
 ! INSERT INTO t VALUES (1)
 cannot perform operation on "materialize.public.t" while its default index ("materialize.public.t_primary_idx") is disabled
 
+! UPDATE t SET a = 1
+cannot perform operation on "materialize.public.t" while its default index ("materialize.public.t_primary_idx") is disabled
+
+! DELETE FROM t;
+cannot perform operation on "materialize.public.t" while its default index ("materialize.public.t_primary_idx") is disabled
+
 # Selects work but are always empty
 > SELECT * FROM t
 


### PR DESCRIPTION
### Motivation

When adding `UPDATE` and `DELETE` operations, I forgot to propagate the changes to the `--disable-user-indexes` code paths. This won't cause any issues in Materialize currently because tables are always empty on reboot, but once we persist data in tables across restarts, this would have crashed Materialize when trying to perform a write on a disabled index.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
