### PR TITLE
coord: add max_index_keys to pg_settings

### DIFF
--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -1399,9 +1399,10 @@ pub const PG_SETTINGS: BuiltinView = BuiltinView {
     name: "pg_settings",
     schema: PG_CATALOG_SCHEMA,
     sql: "CREATE VIEW pg_settings AS SELECT
-    NULL::pg_catalog.text AS name,
-    NULL::pg_catalog.text AS setting
-    WHERE false",
+    *
+FROM (VALUES
+    ('max_index_keys'::pg_catalog.text, '1000'::pg_catalog.text)
+) AS _ (name, setting)",
     id: GlobalId::System(5026),
     needs_logs: false,
 };


### PR DESCRIPTION
Needed for metabase. Postgres defaults to 32 for this (you have to
recompile to change it), but I don't think we have a real limit, so just
use a high number.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
