### PR TITLE
sql: support READ ONLY transaction mode

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -106,6 +106,8 @@ List new features before bug fixes.
 - Disallow `UPDATE` and `DELETE` operations on tables when boot in
   `--disable-user-indexes` mode.
 
+- Support the `READ ONLY` transaction mode.
+
 {{% version-header v0.9.10 %}}
 
 - Evaluate TopK operators on constant inputs at query compile time.

--- a/doc/user/content/sql/begin.md
+++ b/doc/user/content/sql/begin.md
@@ -16,6 +16,7 @@ Supported `transaction_mode` option values:
 Value | Description
 ------|----------
 `ISOLATION LEVEL SERIALIZABLE` | A no-op because transactions are always serializable. Lower isolation modes are also accepted, but treated identically to serializable.
+`READ ONLY` | Limits the transaction to read-only operations.
 
 ## Details
 

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1236,7 +1236,7 @@ impl Coordinator {
             } => {
                 let now = self.now_datetime();
                 let session = match implicit {
-                    None => session.start_transaction(now),
+                    None => session.start_transaction(now, None),
                     Some(stmts) => session.start_transaction_implicit(now, stmts),
                 };
                 let _ = tx.send(Response {
@@ -1790,10 +1790,10 @@ impl Coordinator {
             Plan::SetVariable(plan) => {
                 tx.send(self.sequence_set_variable(&mut session, plan), session);
             }
-            Plan::StartTransaction => {
+            Plan::StartTransaction(plan) => {
                 let duplicated =
                     matches!(session.transaction(), TransactionStatus::InTransaction(_));
-                let session = session.start_transaction(self.now_datetime());
+                let session = session.start_transaction(self.now_datetime(), plan.access);
                 tx.send(
                     Ok(ExecuteResponse::StartedTransaction { duplicated }),
                     session,

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -37,7 +37,10 @@ use ::expr::{GlobalId, RowSetFinishing};
 use dataflow_types::{SinkConnectorBuilder, SinkEnvelope, SourceConnector};
 use repr::{ColumnName, Diff, RelationDesc, Row, ScalarType, Timestamp};
 
-use crate::ast::{ExplainOptions, ExplainStage, Expr, FetchDirection, ObjectType, Raw, Statement};
+use crate::ast::{
+    ExplainOptions, ExplainStage, Expr, FetchDirection, ObjectType, Raw, Statement,
+    TransactionAccessMode,
+};
 use crate::names::{DatabaseSpecifier, FullName, SchemaName};
 
 pub(crate) mod error;
@@ -85,7 +88,7 @@ pub enum Plan {
     ShowAllVariables,
     ShowVariable(ShowVariablePlan),
     SetVariable(SetVariablePlan),
-    StartTransaction,
+    StartTransaction(StartTransactionPlan),
     CommitTransaction,
     AbortTransaction,
     Peek(PeekPlan),
@@ -107,6 +110,11 @@ pub enum Plan {
     Prepare(PreparePlan),
     Execute(ExecutePlan),
     Deallocate(DeallocatePlan),
+}
+
+#[derive(Debug)]
+pub struct StartTransactionPlan {
+    pub access: Option<TransactionAccessMode>,
 }
 
 #[derive(Debug)]

--- a/test/sqllogictest/transactions.slt
+++ b/test/sqllogictest/transactions.slt
@@ -415,9 +415,6 @@ db error: ERROR: unknown catalog item 'u21'
 
 # Test transaction syntax that we don't support.
 
-statement error READ WRITE not yet supported
-BEGIN READ WRITE
-
 statement ok
 BEGIN ISOLATION LEVEL SERIALIZABLE
 
@@ -436,3 +433,31 @@ BEGIN ISOLATION LEVEL REPEATABLE READ
 
 statement ok
 COMMIT
+
+# Access modes.
+
+statement ok
+BEGIN TRANSACTION READ WRITE
+
+statement ok
+COMMIT
+
+statement ok
+BEGIN TRANSACTION READ ONLY
+
+query I
+SELECT 1
+----
+1
+
+statement ok
+COMMIT
+
+statement ok
+BEGIN TRANSACTION READ ONLY
+
+statement error transaction in read-only mode
+INSERT INTO t (a) VALUES (1)
+
+statement ok
+ROLLBACK


### PR DESCRIPTION
Support explicit read only transactions.

### Motivation

  * This PR adds a known-desirable feature. This syntax is used by recent versions of metabase.

### Tips for reviewer

* The diff is much smaller if viewed with whitespace hidden.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
