### PR TITLE
Skeleton for QGM generation from Hir

### DIFF
--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -37,7 +37,7 @@ pub use relation::func::{AggregateFunc, TableFunc};
 pub use relation::func::{AnalyzedRegex, CaptureGroupDesc};
 pub use relation::join_input_mapper::JoinInputMapper;
 pub use relation::{
-    compare_columns, AggregateExpr, ColumnOrder, IdGen, JoinImplementation, MirRelationExpr,
+    compare_columns, AggregateExpr, ColumnOrder, JoinImplementation, MirRelationExpr,
     RowSetFinishing,
 };
 pub use scalar::func::{self, BinaryFunc, NullaryFunc, UnaryFunc, VariadicFunc};

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -18,6 +18,7 @@ use serde::{Deserialize, Serialize};
 
 use lowertest::{MzEnumReflect, MzStructReflect};
 use ore::collections::CollectionExt;
+use ore::id_gen::IdGen;
 use repr::{ColumnType, Datum, Diff, RelationType, Row};
 
 use self::func::{AggregateFunc, TableFunc};
@@ -1477,21 +1478,6 @@ impl fmt::Display for ColumnOrder {
             self.column.to_string(),
             if self.desc { "desc" } else { "asc" }
         )
-    }
-}
-
-/// Manages the allocation of locally unique IDs when building a [`MirRelationExpr`].
-#[derive(Debug, Default)]
-pub struct IdGen {
-    id: u64,
-}
-
-impl IdGen {
-    /// Allocates a new identifier and advances the generator.
-    pub fn allocate_id(&mut self) -> u64 {
-        let id = self.id;
-        self.id += 1;
-        id
     }
 }
 

--- a/src/ore/src/id_gen.rs
+++ b/src/ore/src/id_gen.rs
@@ -1,0 +1,31 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! ID generation utilities.
+
+/// Manages the allocation of unique IDs.
+#[derive(Debug, Default)]
+pub struct IdGen {
+    id: u64,
+}
+
+impl IdGen {
+    /// Allocates a new identifier and advances the generator.
+    pub fn allocate_id(&mut self) -> u64 {
+        let id = self.id;
+        self.id += 1;
+        id
+    }
+}

--- a/src/ore/src/lib.rs
+++ b/src/ore/src/lib.rs
@@ -36,6 +36,7 @@ pub mod fmt;
 pub mod future;
 pub mod hash;
 pub mod hint;
+pub mod id_gen;
 pub mod iter;
 pub mod lex;
 #[cfg(feature = "metrics")]

--- a/src/sql/src/lib.rs
+++ b/src/sql/src/lib.rs
@@ -92,3 +92,4 @@ pub mod normalize;
 pub mod parse;
 pub mod plan;
 pub mod pure;
+pub mod query_model;

--- a/src/sql/src/lib.rs
+++ b/src/sql/src/lib.rs
@@ -92,4 +92,5 @@ pub mod normalize;
 pub mod parse;
 pub mod plan;
 pub mod pure;
+#[cfg(test)]
 pub mod query_model;

--- a/src/sql/src/plan/explain.rs
+++ b/src/sql/src/plan/explain.rs
@@ -22,7 +22,8 @@ use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 
 use expr::explain::Indices;
-use expr::{ExprHumanizer, Id, IdGen, RowSetFinishing};
+use expr::{ExprHumanizer, Id, RowSetFinishing};
+use ore::id_gen::IdGen;
 use ore::str::{bracketed, separated};
 use repr::{RelationType, ScalarType};
 

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -129,7 +129,7 @@ impl HirRelationExpr {
                 }
             }
             mut other => {
-                let mut id_gen = expr::IdGen::default();
+                let mut id_gen = ore::id_gen::IdGen::default();
                 transform_expr::split_subquery_predicates(&mut other);
                 transform_expr::try_simplify_quantified_comparisons(&mut other);
                 expr::MirRelationExpr::constant(vec![vec![]], RelationType::new(vec![]))
@@ -154,7 +154,7 @@ impl HirRelationExpr {
     /// assignment of values to outer rows.
     fn applied_to(
         self,
-        id_gen: &mut expr::IdGen,
+        id_gen: &mut ore::id_gen::IdGen,
         get_outer: expr::MirRelationExpr,
         col_map: &ColumnMap,
     ) -> expr::MirRelationExpr {
@@ -547,7 +547,7 @@ impl HirScalarExpr {
     /// each of these references can be found.
     fn applied_to(
         self,
-        id_gen: &mut expr::IdGen,
+        id_gen: &mut ore::id_gen::IdGen,
         col_map: &ColumnMap,
         inner: &mut expr::MirRelationExpr,
         subquery_map: &Option<&HashMap<HirScalarExpr, usize>>,
@@ -710,7 +710,7 @@ impl HirScalarExpr {
     /// by the returned join that will hold their results.
     fn lower_subqueries(
         exprs: &[Self],
-        id_gen: &mut expr::IdGen,
+        id_gen: &mut ore::id_gen::IdGen,
         col_map: &ColumnMap,
         inner: expr::MirRelationExpr,
     ) -> (expr::MirRelationExpr, HashMap<HirScalarExpr, usize>) {
@@ -852,7 +852,7 @@ impl HirScalarExpr {
 /// The caller must supply the `apply` function that applies the rewritten
 /// `inner` to `outer`.
 fn branch<F>(
-    id_gen: &mut expr::IdGen,
+    id_gen: &mut ore::id_gen::IdGen,
     outer: expr::MirRelationExpr,
     col_map: &ColumnMap,
     mut inner: HirRelationExpr,
@@ -861,7 +861,7 @@ fn branch<F>(
 ) -> expr::MirRelationExpr
 where
     F: FnOnce(
-        &mut expr::IdGen,
+        &mut ore::id_gen::IdGen,
         HirRelationExpr,
         expr::MirRelationExpr,
         &ColumnMap,
@@ -990,7 +990,7 @@ where
 }
 
 fn apply_scalar_subquery(
-    id_gen: &mut expr::IdGen,
+    id_gen: &mut ore::id_gen::IdGen,
     outer: expr::MirRelationExpr,
     col_map: &ColumnMap,
     scalar_subquery: HirRelationExpr,
@@ -1044,7 +1044,7 @@ fn apply_scalar_subquery(
 }
 
 fn apply_existential_subquery(
-    id_gen: &mut expr::IdGen,
+    id_gen: &mut ore::id_gen::IdGen,
     outer: expr::MirRelationExpr,
     col_map: &ColumnMap,
     subquery_expr: HirRelationExpr,
@@ -1081,7 +1081,7 @@ fn apply_existential_subquery(
 impl AggregateExpr {
     fn applied_to(
         self,
-        id_gen: &mut expr::IdGen,
+        id_gen: &mut ore::id_gen::IdGen,
         col_map: &ColumnMap,
         inner: &mut expr::MirRelationExpr,
     ) -> expr::AggregateExpr {
@@ -1106,7 +1106,7 @@ fn attempt_outer_join(
     on: expr::MirScalarExpr,
     kind: JoinKind,
     oa: usize,
-    id_gen: &mut expr::IdGen,
+    id_gen: &mut ore::id_gen::IdGen,
 ) -> Option<expr::MirRelationExpr> {
     use expr::BinaryFunc;
 

--- a/src/sql/src/query_model/README.md
+++ b/src/sql/src/query_model/README.md
@@ -1,0 +1,29 @@
+# Query Graph Model
+
+This module contains the implementation of the Query Graph Model as specified
+[here](../../../../doc/developer/design/20210707_qgm_sql_high_level_representation.md).
+
+## Testing
+
+Tests around the Query Graph Model, for both the model generation logic and the
+model transformat logic, are usually `datadriven` tests that result in multiple
+`graphviz` graphs, that need to be rendered and visually validated. The following
+shell function extracts all the `graphviz` graphs containing in one of these tests
+and renders them as PNG files. The snippet after it shows how it can be used with
+one of these tests.
+
+
+```sh
+extract_graph() {
+    sed -n "/^digraph G {$/,/^}$/p" $1 | csplit --prefix $1- --suffix-format "%04d.dot" --elide-empty-files - '/^digraph G {$/' '{*}'
+    for i in $1-*.dot; do
+        dot -Tpng -O $i
+    done
+}
+```
+
+```
+$ extract_graph src/sql/tests/querymodel/basic
+...
+$ eog src/sql/tests/querymodel/basic*.png &
+```

--- a/src/sql/src/query_model/dot.rs
+++ b/src/sql/src/query_model/dot.rs
@@ -1,0 +1,256 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Generates a graphviz graph from a Query Graph Model.
+
+use crate::query_model::{BoxScalarExpr, BoxType, Model, Quantifier, QuantifierId, QueryBox};
+use itertools::Itertools;
+use std::cell::RefCell;
+use std::collections::{BTreeMap, HashSet};
+
+/// Generates a graphviz graph from a Query Graph Model, defined in the DOT language.
+/// See <https://graphviz.org/doc/info/lang.html>.
+pub(crate) struct DotGenerator {
+    output: String,
+    indent: u32,
+}
+
+impl DotGenerator {
+    pub fn new() -> Self {
+        Self {
+            output: String::new(),
+            indent: 0,
+        }
+    }
+
+    /// Generates a graphviz graph for the given model, labeled with `label`.
+    pub fn generate(mut self, model: &Model, label: &str) -> Result<String, anyhow::Error> {
+        self.new_line("digraph G {");
+        self.inc();
+        self.new_line("compound = true");
+        self.new_line("labeljust = l");
+        self.new_line(&format!("label=\"{}\"", label.trim()));
+        self.new_line("node [ shape = box ]");
+
+        // list of quantifiers for adding the edges connecting them to their
+        // input boxes after all boxes have been processed
+        let mut quantifiers = Vec::new();
+
+        model
+            .visit_pre_boxes(&mut |b: &RefCell<QueryBox>| -> Result<(), ()> {
+                let b = b.borrow();
+                let box_id = b.id;
+
+                self.new_line(&format!("subgraph cluster{} {{", box_id));
+                self.inc();
+                self.new_line(&format!(
+                    "label = \"Box{}:{}\"",
+                    box_id,
+                    Self::get_box_title(&b)
+                ));
+                self.new_line(&format!(
+                    "boxhead{} [ shape = record, label=\"{{ {} }}\" ]",
+                    box_id,
+                    Self::get_box_head(&b)
+                ));
+
+                self.new_line("{");
+                self.inc();
+                self.new_line("rank = same");
+
+                if b.quantifiers.len() > 0 {
+                    self.new_line("node [ shape = circle ]");
+                }
+
+                for q_id in b.quantifiers.iter() {
+                    quantifiers.push(*q_id);
+
+                    let q = model.get_quantifier(*q_id).borrow();
+                    self.new_line(&format!(
+                        "Q{0} [ label=\"Q{0}({1}){2}\" ]",
+                        q_id,
+                        q.quantifier_type,
+                        Self::get_quantifier_alias(&q)
+                    ));
+                }
+
+                self.add_correlation_info(model, &b);
+
+                self.dec();
+                self.new_line("}");
+                self.dec();
+                self.new_line("}");
+
+                Ok(())
+            })
+            .unwrap();
+
+        if quantifiers.len() > 0 {
+            self.new_line("edge [ arrowhead = none, style = dashed ]");
+            for q_id in quantifiers.iter() {
+                let q = model.get_quantifier(*q_id).borrow();
+                self.new_line(&format!(
+                    "Q{0} -> boxhead{1} [ lhead = cluster{1} ]",
+                    q_id, q.input_box
+                ));
+            }
+        }
+
+        self.dec();
+        self.new_line("}");
+        self.new_line(""); // final empty line
+        Ok(self.output)
+    }
+
+    fn get_box_title(b: &QueryBox) -> &'static str {
+        b.box_type.get_box_type_str()
+    }
+
+    fn get_box_head(b: &QueryBox) -> String {
+        let mut r = String::new();
+
+        r.push_str(&format!("Distinct: {:?}", b.distinct));
+
+        // The projection of the box
+        for (i, c) in b.columns.iter().enumerate() {
+            r.push_str(&format!("| {}: {}", i, c.expr));
+            if let Some(c) = &c.alias {
+                r.push_str(&format!(" as {}", c.as_str()));
+            }
+        }
+
+        // Per-type internal properties.
+        match &b.box_type {
+            BoxType::Select(select) => {
+                if let Some(order_key) = &select.order_key {
+                    r.push_str("| ORDER BY: ");
+                    for (i, key_item) in order_key.iter().enumerate() {
+                        if i > 0 {
+                            r.push_str(", ");
+                        }
+                        // @todo direction
+                        r.push_str(&format!("{}", key_item));
+                    }
+                }
+            }
+            BoxType::Grouping(grouping) => {
+                if !grouping.key.is_empty() {
+                    r.push_str("| GROUP BY: ");
+                    for (i, key_item) in grouping.key.iter().enumerate() {
+                        if i > 0 {
+                            r.push_str(", ");
+                        }
+                        r.push_str(&format!("{}", key_item));
+                    }
+                }
+            }
+            BoxType::Values(values) => {
+                for (i, row) in values.rows.iter().enumerate() {
+                    r.push_str(&format!("| ROW {}: ", i));
+                    for (i, value) in row.iter().enumerate() {
+                        if i > 0 {
+                            r.push_str(", ");
+                        }
+                        r.push_str(&format!("{}", value));
+                    }
+                }
+            }
+            _ => {}
+        }
+
+        // @todo predicates as arrows
+        if let Some(predicates) = match &b.box_type {
+            BoxType::Select(select) => Some(&select.predicates),
+            BoxType::OuterJoin(outer_join) => Some(&outer_join.predicates),
+            _ => None,
+        } {
+            for predicate in predicates.iter() {
+                r.push_str(&format!("| {}", predicate));
+            }
+        }
+
+        r
+    }
+
+    /// Adds red arrows from correlated quantifiers to the sibling quantifiers they
+    /// are correlated with.
+    fn add_correlation_info(&mut self, model: &Model, b: &QueryBox) {
+        let mut correlation_info: BTreeMap<QuantifierId, Vec<QuantifierId>> = BTreeMap::new();
+        for q_id in b.quantifiers.iter() {
+            // collect the column references from the current context within
+            // the subgraph under the current quantifier
+            let mut column_refs = HashSet::new();
+            let mut f = |inner_box: &RefCell<QueryBox>| -> Result<(), ()> {
+                inner_box.borrow().visit_expressions(
+                    &mut |expr: &BoxScalarExpr| -> Result<(), ()> {
+                        expr.collect_column_references_from_context(
+                            &b.quantifiers,
+                            &mut column_refs,
+                        );
+                        Ok(())
+                    },
+                )
+            };
+            let q = model.get_quantifier(*q_id).borrow();
+            model
+                .visit_pre_boxes_in_subgraph(&mut f, q.input_box)
+                .unwrap();
+            // collect the unique quantifiers referenced by the subgraph
+            // under the current quantifier
+            correlation_info.insert(
+                q.id,
+                column_refs
+                    .iter()
+                    .map(|c| c.quantifier_id)
+                    .sorted()
+                    .unique()
+                    .collect::<Vec<_>>(),
+            );
+        }
+
+        for (correlated_q, quantifiers) in correlation_info.iter() {
+            for q in quantifiers.iter() {
+                self.new_line(&format!(
+                    "Q{0} -> Q{1} [ label = \"correlation\", style = filled, color = red ]",
+                    correlated_q, q
+                ));
+            }
+        }
+    }
+
+    fn get_quantifier_alias(q: &Quantifier) -> String {
+        if let Some(alias) = &q.alias {
+            format!(" as {}", alias)
+        } else {
+            "".to_string()
+        }
+    }
+
+    fn inc(&mut self) {
+        self.indent += 1;
+    }
+
+    fn dec(&mut self) {
+        self.indent -= 1;
+    }
+
+    fn new_line(&mut self, s: &str) {
+        if !self.output.is_empty() && self.output.rfind('\n') != Some(self.output.len()) {
+            self.end_line();
+            for _ in 0..self.indent * 4 {
+                self.output.push(' ');
+            }
+        }
+        self.output.push_str(s);
+    }
+
+    fn end_line(&mut self) {
+        self.output.push('\n');
+    }
+}

--- a/src/sql/src/query_model/hir.rs
+++ b/src/sql/src/query_model/hir.rs
@@ -11,7 +11,10 @@
 
 use itertools::Itertools;
 
-use crate::query_model::{BoxId, BoxType, Model, QuantifierType, Values};
+use crate::plan::HirScalarExpr;
+use crate::query_model::{
+    BoxId, BoxScalarExpr, BoxType, Column, ColumnReference, Model, QuantifierType, Values,
+};
 
 use crate::plan::expr::HirRelationExpr;
 
@@ -56,6 +59,34 @@ impl FromHir {
                     rows: rows.iter().map(|_| Vec::new()).collect_vec(),
                 }))
             }
+            HirRelationExpr::Map { input, scalars } => {
+                let box_id = self.generate_select(input);
+                // @todo self-referencing Maps
+                for scalar in scalars.iter() {
+                    let expr = self.generate_expr(scalar, box_id);
+                    let b = self.model.get_box(box_id);
+                    b.borrow_mut().columns.push(Column { expr, alias: None });
+                }
+                box_id
+            }
+            HirRelationExpr::Project { input, outputs } => {
+                let input_box_id = self.generate_internal(input);
+                let select_id = self.model.make_select_box();
+                let quantifier_id =
+                    self.model
+                        .make_quantifier(QuantifierType::Foreach, input_box_id, select_id);
+                let mut select_box = self.model.get_box(select_id).borrow_mut();
+                for position in outputs {
+                    select_box.columns.push(Column {
+                        expr: BoxScalarExpr::ColumnReference(ColumnReference {
+                            quantifier_id,
+                            position: *position,
+                        }),
+                        alias: None,
+                    });
+                }
+                select_id
+            }
             _ => panic!("unsupported expression type"),
         }
     }
@@ -69,5 +100,34 @@ impl FromHir {
         let mut select_box = self.model.get_box(select_id).borrow_mut();
         select_box.add_all_input_columns(&self.model);
         select_id
+    }
+
+    fn generate_expr(&mut self, expr: &HirScalarExpr, context_box: BoxId) -> BoxScalarExpr {
+        match expr {
+            HirScalarExpr::Literal(row, col_type) => {
+                BoxScalarExpr::Literal(row.clone(), col_type.clone())
+            }
+            HirScalarExpr::Column(c) => {
+                assert!(c.level == 0, "correlated columns not yet supported");
+                BoxScalarExpr::ColumnReference(self.find_column_within_box(context_box, c.column))
+            }
+            _ => panic!("unsupported expression type"),
+        }
+    }
+
+    fn find_column_within_box(&self, box_id: BoxId, mut position: usize) -> ColumnReference {
+        let b = self.model.get_box(box_id).borrow();
+        for q_id in b.quantifiers.iter() {
+            let q = self.model.get_quantifier(*q_id).borrow();
+            let ib = self.model.get_box(q.input_box).borrow();
+            if position < ib.columns.len() {
+                return ColumnReference {
+                    quantifier_id: *q_id,
+                    position,
+                };
+            }
+            position -= ib.columns.len();
+        }
+        panic!("column not found")
     }
 }

--- a/src/sql/src/query_model/hir.rs
+++ b/src/sql/src/query_model/hir.rs
@@ -1,0 +1,73 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Generates a Query Graph Model from a [HirRelationExpr].
+
+use itertools::Itertools;
+
+use crate::query_model::{BoxId, BoxType, Model, QuantifierType, Values};
+
+use crate::plan::expr::HirRelationExpr;
+
+impl From<&HirRelationExpr> for Model {
+    fn from(expr: &HirRelationExpr) -> Model {
+        FromHir::generate(expr)
+    }
+}
+
+struct FromHir {
+    model: Model,
+}
+
+impl FromHir {
+    /// Generates a Query Graph Model for representing the given query.
+    fn generate(expr: &HirRelationExpr) -> Model {
+        let mut generator = FromHir {
+            model: Model::new(),
+        };
+        generator.model.top_box = generator.generate_select(expr);
+        generator.model
+    }
+
+    /// Generates a sub-graph representing the given expression, ensuring
+    /// that the resulting graph starts with a Select box.
+    fn generate_select(&mut self, expr: &HirRelationExpr) -> BoxId {
+        let mut box_id = self.generate_internal(expr);
+        if !self.model.get_box(box_id).borrow().is_select() {
+            box_id = self.wrap_within_select(box_id);
+        }
+        box_id
+    }
+
+    fn generate_internal(&mut self, expr: &HirRelationExpr) -> BoxId {
+        match expr {
+            // HirRelationExpr::Get { id, typ } => {
+            //     self.model.make_box(BoxType::BaseTable(BaseTable {}))
+            // }
+            HirRelationExpr::Constant { rows, typ } => {
+                assert!(typ.arity() == 0, "expressions are not yet supported",);
+                self.model.make_box(BoxType::Values(Values {
+                    rows: rows.iter().map(|_| Vec::new()).collect_vec(),
+                }))
+            }
+            _ => panic!("unsupported expression type"),
+        }
+    }
+
+    /// Returns a Select box ranging over the given box, projecting
+    /// all of its columns.
+    fn wrap_within_select(&mut self, box_id: BoxId) -> BoxId {
+        let select_id = self.model.make_select_box();
+        self.model
+            .make_quantifier(QuantifierType::Foreach, box_id, select_id);
+        let mut select_box = self.model.get_box(select_id).borrow_mut();
+        select_box.add_all_input_columns(&self.model);
+        select_id
+    }
+}

--- a/src/sql/src/query_model/mod.rs
+++ b/src/sql/src/query_model/mod.rs
@@ -1,0 +1,414 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::cell::RefCell;
+use std::collections::BTreeSet;
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+
+use ore::id_gen::IdGen;
+
+mod dot;
+mod scalar_expr;
+
+pub use scalar_expr::*;
+
+pub type QuantifierId = u64;
+pub type BoxId = u64;
+pub type QuantifierSet = BTreeSet<QuantifierId>;
+
+/// A Query Graph Model instance represents a SQL query.
+/// See: https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/20210707_qgm_sql_high_level_representation.md
+///
+/// In this representation, SQL queries are represented as a graph of operators,
+/// represented as boxes, that are connected via quantifiers. A top-level box
+/// represents the entry point of the query.
+///
+/// Each non-leaf box has a set of quantifiers, which are the inputs of the
+/// operation it represents. The quantifier adds information about how the
+/// relation represented by its input box is consumed by the parent box.
+#[derive(Debug)]
+pub struct Model {
+    /// The ID of the box representing the entry-point of the query.
+    pub top_box: BoxId,
+    /// All boxes in the query graph model.
+    boxes: HashMap<BoxId, Box<RefCell<QueryBox>>>,
+    /// Used for assigning unique IDs to query boxes.
+    box_id_gen: IdGen,
+    /// All quantifiers in the query graph model.
+    quantifiers: HashMap<QuantifierId, Box<RefCell<Quantifier>>>,
+    /// Used for assigning unique IDs to quantifiers.
+    quantifier_id_gen: IdGen,
+}
+
+/// A semantic operator within a Query Graph.
+#[derive(Debug)]
+pub struct QueryBox {
+    /// uniquely identifies the box within the model
+    pub id: BoxId,
+    /// the type of the box
+    pub box_type: BoxType,
+    /// the projection of the box
+    pub columns: Vec<Column>,
+    /// the input quantifiers of the box
+    pub quantifiers: QuantifierSet,
+    /// quantifiers ranging over this box
+    pub ranging_quantifiers: QuantifierSet,
+    /// whether this box must enforce the uniqueness of its output, it is
+    /// guaranteed by structure of the box or it must preserve duplicated
+    /// rows from its input boxes. See [DistinctOperation].
+    pub distinct: DistinctOperation,
+}
+
+/// A column projected by a `QueryBox`.
+#[derive(Debug)]
+pub struct Column {
+    pub expr: BoxScalarExpr,
+    pub alias: Option<Ident>,
+}
+
+/// Enum that describes the DISTINCT property of a `QueryBox`.
+#[derive(Debug)]
+pub enum DistinctOperation {
+    /// Distinctness of the output of the box must be enforced by
+    /// the box.
+    Enforce,
+    /// Distinctness of the output of the box is required, but
+    /// guaranteed by the structure of the box.
+    Guaranteed,
+    /// Distinctness of the output of the box is not required.
+    Preserve,
+}
+
+pub use sql_parser::ast::Ident;
+
+#[derive(Debug)]
+pub struct Quantifier {
+    /// uniquely identifiers the quantifier within the model
+    pub id: QuantifierId,
+    /// the type of the quantifier
+    pub quantifier_type: QuantifierType,
+    /// the input box of this quantifier
+    pub input_box: BoxId,
+    /// the box that owns this quantifier
+    pub parent_box: BoxId,
+    /// alias for name resolution purposes
+    pub alias: Option<Ident>,
+}
+
+#[derive(Debug)]
+pub enum QuantifierType {
+    /// An ALL subquery.
+    All,
+    /// An existential subquery (IN SELECT/EXISTS/ANY).
+    Existential,
+    /// A regular join operand where each row from its input
+    /// box must be consumed by the parent box operator.
+    Foreach,
+    /// The preserving side of an outer join. Only valid in
+    /// OuterJoin boxes.
+    PreservedForeach,
+    /// A scalar subquery that produces one row at most.
+    Scalar,
+}
+
+#[derive(Debug)]
+pub enum BoxType {
+    /// A table from the catalog.
+    BaseTable(BaseTable),
+    /// SQL's except operator
+    Except,
+    /// GROUP BY operator.
+    Grouping(Grouping),
+    /// SQL's intersect operator
+    Intersect,
+    /// OUTER JOIN operator. Contains one preserving quantifier
+    /// at most: exactly one for LEFT/RIGHT OUTER JOIN, none
+    /// for FULL OUTER JOIN.
+    OuterJoin(OuterJoin),
+    /// An operator that performs join, filter and project in
+    /// that order.
+    Select(Select),
+    /// The invocation of table function from the catalog.
+    TableFunction(TableFunction),
+    /// SQL's union operator
+    Union,
+    /// Operator that produces a set of rows, with potentially
+    /// correlated values.
+    Values(Values),
+}
+
+#[derive(Debug)]
+pub struct BaseTable {/* @todo table metadata from the catalog */}
+
+/// The content of a Grouping box.
+#[derive(Debug, Default)]
+pub struct Grouping {
+    pub key: Vec<Box<BoxScalarExpr>>,
+}
+
+/// The content of a OuterJoin box.
+#[derive(Debug, Default)]
+pub struct OuterJoin {
+    /// The predices in the ON clause of the outer join.
+    pub predicates: Vec<Box<BoxScalarExpr>>,
+}
+
+/// The content of a Select box.
+#[derive(Debug, Default)]
+pub struct Select {
+    /// The list of predicates applied by the box.
+    pub predicates: Vec<Box<BoxScalarExpr>>,
+    /// An optional ORDER BY key
+    pub order_key: Option<Vec<Box<BoxScalarExpr>>>,
+    /// An optional LIMIT clause
+    pub limit: Option<BoxScalarExpr>,
+    /// An optional OFFSET clause
+    pub offset: Option<BoxScalarExpr>,
+}
+
+#[derive(Debug, Default)]
+pub struct TableFunction {
+    pub parameters: Vec<Box<BoxScalarExpr>>,
+    // @todo function metadata from the catalog
+}
+
+#[derive(Debug, Default)]
+pub struct Values {
+    pub rows: Vec<Vec<Box<BoxScalarExpr>>>,
+}
+
+impl Model {
+    fn new() -> Self {
+        Self {
+            top_box: 0,
+            boxes: HashMap::new(),
+            box_id_gen: Default::default(),
+            quantifiers: HashMap::new(),
+            quantifier_id_gen: Default::default(),
+        }
+    }
+
+    fn make_box(&mut self, box_type: BoxType) -> BoxId {
+        let id = self.box_id_gen.allocate_id();
+        let b = Box::new(RefCell::new(QueryBox {
+            id,
+            box_type,
+            columns: Vec::new(),
+            quantifiers: QuantifierSet::new(),
+            ranging_quantifiers: QuantifierSet::new(),
+            distinct: DistinctOperation::Preserve,
+        }));
+        self.boxes.insert(id, b);
+        id
+    }
+
+    fn make_select_box(&mut self) -> BoxId {
+        self.make_box(BoxType::Select(Select::default()))
+    }
+
+    fn get_box(&self, box_id: BoxId) -> &RefCell<QueryBox> {
+        self.boxes.get(&box_id).expect("a valid box identifier")
+    }
+
+    /// Create a new quantifier and adds it to the parent box
+    fn make_quantifier(
+        &mut self,
+        quantifier_type: QuantifierType,
+        input_box: BoxId,
+        parent_box: BoxId,
+    ) -> QuantifierId {
+        let id = self.quantifier_id_gen.allocate_id();
+        let q = Box::new(RefCell::new(Quantifier {
+            id,
+            quantifier_type,
+            input_box,
+            parent_box,
+            alias: None,
+        }));
+        self.quantifiers.insert(id, q);
+        self.get_box(parent_box).borrow_mut().quantifiers.insert(id);
+        self.get_box(input_box)
+            .borrow_mut()
+            .ranging_quantifiers
+            .insert(id);
+        id
+    }
+
+    fn get_quantifier(&self, quantifier_id: QuantifierId) -> &RefCell<Quantifier> {
+        self.quantifiers
+            .get(&quantifier_id)
+            .expect("a valid quantifier identifier")
+    }
+
+    /// Visit boxes in the query graph in pre-order starting from `self.top_box`.
+    fn visit_pre_boxes<F, E>(&self, f: &mut F) -> Result<(), E>
+    where
+        F: FnMut(&RefCell<QueryBox>) -> Result<(), E>,
+    {
+        self.visit_pre_boxes_in_subgraph(f, self.top_box)
+    }
+
+    /// Visit boxes in the query graph in pre-order
+    fn visit_pre_boxes_in_subgraph<F, E>(&self, f: &mut F, start_box: BoxId) -> Result<(), E>
+    where
+        F: FnMut(&RefCell<QueryBox>) -> Result<(), E>,
+    {
+        let mut visited = HashSet::new();
+        let mut stack = vec![start_box];
+        while !stack.is_empty() {
+            let box_id = stack.pop().unwrap();
+            if visited.insert(box_id) {
+                let query_box = self.get_box(box_id);
+                f(query_box)?;
+
+                stack.extend(
+                    query_box
+                        .borrow()
+                        .quantifiers
+                        .iter()
+                        .rev()
+                        .map(|q| self.get_quantifier(*q).borrow().input_box),
+                );
+            }
+        }
+        Ok(())
+    }
+
+    /// Removes unreferenced objects from the model. May be invoked
+    /// several times during query rewrites.
+    #[allow(dead_code)]
+    fn garbage_collect(&mut self) {
+        let mut visited_boxes = HashSet::new();
+        let mut visited_quantifiers: HashSet<QuantifierId> = HashSet::new();
+
+        let _ = self.visit_pre_boxes(&mut |b| -> Result<(), ()> {
+            let b = b.borrow();
+            visited_boxes.insert(b.id);
+            visited_quantifiers.extend(b.quantifiers.iter());
+            Ok(())
+        });
+        self.boxes.retain(|b, _| visited_boxes.contains(b));
+        self.quantifiers
+            .retain(|q, _| visited_quantifiers.contains(q));
+    }
+}
+
+impl QueryBox {
+    /// Add all columns from the non-subquery input quantifiers of the box to the
+    /// projection of the box.
+    fn add_all_input_columns(&mut self, model: &Model) {
+        for quantifier_id in self.quantifiers.iter() {
+            let q = model.get_quantifier(*quantifier_id);
+            let bq = q.borrow();
+            if !bq.quantifier_type.is_subquery() {
+                let input_box = model.get_box(bq.input_box).borrow();
+                for (position, c) in input_box.columns.iter().enumerate() {
+                    let expr = BoxScalarExpr::ColumnReference(ColumnReference {
+                        quantifier_id: *quantifier_id,
+                        position,
+                    });
+                    self.columns.push(Column {
+                        expr,
+                        alias: c.alias.clone(),
+                    });
+                }
+            }
+        }
+    }
+
+    /// Visit all the expressions in this query box.
+    fn visit_expressions<F, E>(&self, f: &mut F) -> Result<(), E>
+    where
+        F: FnMut(&BoxScalarExpr) -> Result<(), E>,
+    {
+        for c in self.columns.iter() {
+            f(&c.expr)?;
+        }
+        match &self.box_type {
+            BoxType::Select(select) => {
+                for p in select.predicates.iter() {
+                    f(p)?;
+                }
+                if let Some(order_key) = &select.order_key {
+                    for p in order_key.iter() {
+                        f(p)?;
+                    }
+                }
+                if let Some(limit) = &select.limit {
+                    f(limit)?;
+                }
+                if let Some(offset) = &select.offset {
+                    f(offset)?;
+                }
+            }
+            BoxType::OuterJoin(outer_join) => {
+                for p in outer_join.predicates.iter() {
+                    f(p)?;
+                }
+            }
+            BoxType::Grouping(grouping) => {
+                for p in grouping.key.iter() {
+                    f(p)?;
+                }
+            }
+            BoxType::Values(values) => {
+                for row in values.rows.iter() {
+                    for value in row.iter() {
+                        f(value)?;
+                    }
+                }
+            }
+            BoxType::TableFunction(table_function) => {
+                for p in table_function.parameters.iter() {
+                    f(p)?;
+                }
+            }
+            BoxType::Except | BoxType::Union | BoxType::Intersect | BoxType::BaseTable(_) => {}
+        }
+        Ok(())
+    }
+}
+
+impl BoxType {
+    fn get_box_type_str(&self) -> &'static str {
+        match self {
+            BoxType::BaseTable(..) => "BaseTable",
+            BoxType::Except => "Except",
+            BoxType::Grouping(..) => "Grouping",
+            BoxType::Intersect => "Intersect",
+            BoxType::OuterJoin(..) => "OuterJoin",
+            BoxType::Select(..) => "Select",
+            BoxType::TableFunction(..) => "TableFunction",
+            BoxType::Union => "Union",
+            BoxType::Values(..) => "Values",
+        }
+    }
+}
+
+impl QuantifierType {
+    fn is_subquery(&self) -> bool {
+        match self {
+            QuantifierType::All | QuantifierType::Existential | QuantifierType::Scalar => true,
+            _ => false,
+        }
+    }
+}
+
+impl fmt::Display for QuantifierType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self {
+            QuantifierType::Foreach => write!(f, "F"),
+            QuantifierType::PreservedForeach => write!(f, "P"),
+            QuantifierType::Existential => write!(f, "E"),
+            QuantifierType::All => write!(f, "A"),
+            QuantifierType::Scalar => write!(f, "S"),
+        }
+    }
+}

--- a/src/sql/src/query_model/mod.rs
+++ b/src/sql/src/query_model/mod.rs
@@ -15,7 +15,10 @@ use std::fmt;
 use ore::id_gen::IdGen;
 
 mod dot;
+mod hir;
 mod scalar_expr;
+#[cfg(test)]
+mod test;
 
 pub use scalar_expr::*;
 
@@ -373,6 +376,10 @@ impl QueryBox {
             BoxType::Except | BoxType::Union | BoxType::Intersect | BoxType::BaseTable(_) => {}
         }
         Ok(())
+    }
+
+    fn is_select(&self) -> bool {
+        matches!(self.box_type, BoxType::Select(_))
     }
 }
 

--- a/src/sql/src/query_model/scalar_expr.rs
+++ b/src/sql/src/query_model/scalar_expr.rs
@@ -10,6 +10,8 @@
 use std::collections::HashSet;
 use std::fmt;
 
+use repr::*;
+
 use crate::query_model::{QuantifierId, QuantifierSet};
 
 /// Representation for scalar expressions within a query graph model.
@@ -35,6 +37,9 @@ pub enum BoxScalarExpr {
     /// A leaf column. Only allowed as standalone expressions in the
     /// projection of `BaseTable` and `TableFunction` boxes.
     BaseColumn(BaseColumn),
+    /// A literal value.
+    /// (A single datum stored as a row, because we can't own a Datum)
+    Literal(Row, ColumnType),
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
@@ -57,6 +62,9 @@ impl fmt::Display for BoxScalarExpr {
             BoxScalarExpr::BaseColumn(c) => {
                 write!(f, "C{}", c.position)
             }
+            BoxScalarExpr::Literal(row, _) => {
+                write!(f, "{}", row.unpack_first())
+            }
         }
     }
 }
@@ -74,7 +82,7 @@ impl BoxScalarExpr {
                     column_refs.insert(c.clone());
                 }
             }
-            Expr::BaseColumn(_) => {}
+            BoxScalarExpr::Literal(..) | BoxScalarExpr::BaseColumn(_) => {}
         }
     }
 }

--- a/src/sql/src/query_model/scalar_expr.rs
+++ b/src/sql/src/query_model/scalar_expr.rs
@@ -1,0 +1,80 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::HashSet;
+use std::fmt;
+
+use crate::query_model::{QuantifierId, QuantifierSet};
+
+/// Representation for scalar expressions within a query graph model.
+///
+/// Similar to HirScalarExpr but:
+/// * subqueries are represented as column references to the subquery
+///   quantifiers within the same box the expression belongs to,
+/// * aggregate expressions are considered scalar expressions here
+///   even though they are only valid in the context of a Grouping box,
+/// * column references are represented by a pair (quantifier ID, column
+///   position),
+/// * BaseColumn is used to represent leaf columns, only allowed in
+///   the projection of BaseTables and TableFunctions.
+///
+/// Scalar expressions only make sense within the context of a [QueryBox],
+/// and hence, their name.
+#[derive(Debug, PartialEq, Clone)]
+pub enum BoxScalarExpr {
+    /// A reference to a column from a quantifier that either lives in
+    /// the same box as the expression or is a sibling quantifier of
+    /// an ascendent box of the box that contains the expression.
+    ColumnReference(ColumnReference),
+    /// A leaf column. Only allowed as standalone expressions in the
+    /// projection of `BaseTable` and `TableFunction` boxes.
+    BaseColumn(BaseColumn),
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+pub struct ColumnReference {
+    pub quantifier_id: QuantifierId,
+    pub position: usize,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct BaseColumn {
+    pub position: usize,
+}
+
+impl fmt::Display for BoxScalarExpr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self {
+            BoxScalarExpr::ColumnReference(c) => {
+                write!(f, "Q{}.C{}", c.quantifier_id, c.position)
+            }
+            BoxScalarExpr::BaseColumn(c) => {
+                write!(f, "C{}", c.position)
+            }
+        }
+    }
+}
+
+impl BoxScalarExpr {
+    // @todo use a generic visit method
+    pub fn collect_column_references_from_context(
+        &self,
+        context: &QuantifierSet,
+        column_refs: &mut HashSet<ColumnReference>,
+    ) {
+        match &self {
+            BoxScalarExpr::ColumnReference(c) => {
+                if context.contains(&c.quantifier_id) {
+                    column_refs.insert(c.clone());
+                }
+            }
+            Expr::BaseColumn(_) => {}
+        }
+    }
+}

--- a/src/sql/src/query_model/test.rs
+++ b/src/sql/src/query_model/test.rs
@@ -1,0 +1,180 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::rc::Rc;
+
+use crate::catalog::{
+    CatalogConfig, CatalogDatabase, CatalogError, CatalogItem, CatalogRole, CatalogSchema,
+    SessionCatalog,
+};
+use crate::names::{FullName, PartialName};
+use crate::plan::query::QueryLifetime;
+use crate::plan::{StatementContext, StatementDesc};
+use build_info::DUMMY_BUILD_INFO;
+use chrono::MIN_DATETIME;
+use expr::{DummyHumanizer, ExprHumanizer, GlobalId};
+use lazy_static::lazy_static;
+use ore::now::{EpochMillis, NOW_ZERO};
+use repr::ScalarType;
+use std::time::{Duration, Instant};
+use uuid::Uuid;
+
+use crate::query_model;
+
+lazy_static! {
+    static ref DUMMY_CONFIG: CatalogConfig = CatalogConfig {
+        start_time: MIN_DATETIME,
+        start_instant: Instant::now(),
+        nonce: 0,
+        cluster_id: Uuid::from_u128(0),
+        session_id: Uuid::from_u128(0),
+        experimental_mode: false,
+        safe_mode: false,
+        build_info: &DUMMY_BUILD_INFO,
+        num_workers: 0,
+        timestamp_frequency: Duration::from_secs(1),
+        now: NOW_ZERO.clone(),
+        disable_user_indexes: false,
+    };
+}
+
+/// A dummy [`SessionCatalog`] implementation.
+///
+/// This implementation is suitable for use in tests that plan queries which are
+/// not demanding of the catalog, as many methods are unimplemented.
+#[derive(Debug)]
+pub struct TestCatalog;
+
+impl SessionCatalog for TestCatalog {
+    fn search_path(&self, _: bool) -> Vec<&str> {
+        vec!["dummy"]
+    }
+
+    fn user(&self) -> &str {
+        "dummy"
+    }
+
+    fn get_prepared_statement_desc(&self, _: &str) -> Option<&StatementDesc> {
+        None
+    }
+
+    fn default_database(&self) -> &str {
+        "dummy"
+    }
+
+    fn resolve_database(&self, _: &str) -> Result<&dyn CatalogDatabase, CatalogError> {
+        unimplemented!();
+    }
+
+    fn resolve_schema(
+        &self,
+        _: Option<String>,
+        _: &str,
+    ) -> Result<&dyn CatalogSchema, CatalogError> {
+        unimplemented!();
+    }
+
+    fn resolve_role(&self, _: &str) -> Result<&dyn CatalogRole, CatalogError> {
+        unimplemented!();
+    }
+
+    fn resolve_item(&self, _: &PartialName) -> Result<&dyn CatalogItem, CatalogError> {
+        unimplemented!();
+    }
+
+    fn resolve_function(&self, _: &PartialName) -> Result<&dyn CatalogItem, CatalogError> {
+        unimplemented!();
+    }
+
+    fn get_item_by_id(&self, _: &GlobalId) -> &dyn CatalogItem {
+        unimplemented!();
+    }
+
+    fn try_get_item_by_id(&self, _: &GlobalId) -> Option<&dyn CatalogItem> {
+        unimplemented!();
+    }
+
+    fn get_item_by_oid(&self, _: &u32) -> &dyn CatalogItem {
+        unimplemented!();
+    }
+
+    fn item_exists(&self, _: &FullName) -> bool {
+        false
+    }
+
+    fn try_get_lossy_scalar_type_by_id(&self, _: &GlobalId) -> Option<ScalarType> {
+        None
+    }
+
+    fn config(&self) -> &CatalogConfig {
+        &DUMMY_CONFIG
+    }
+
+    fn now(&self) -> EpochMillis {
+        (self.config().now)()
+    }
+}
+
+impl ExprHumanizer for TestCatalog {
+    fn humanize_id(&self, id: GlobalId) -> Option<String> {
+        DummyHumanizer.humanize_id(id)
+    }
+
+    fn humanize_scalar_type(&self, ty: &ScalarType) -> String {
+        DummyHumanizer.humanize_scalar_type(ty)
+    }
+}
+
+#[test]
+fn test_hir_generator() {
+    datadriven::walk("tests/querymodel", |f| {
+        let catalog = TestCatalog {};
+
+        let scx = &StatementContext::new(None, &catalog, Rc::new(RefCell::new(BTreeMap::new())));
+
+        f.run(move |s| -> String {
+            let build_stmt = |stmt| -> String {
+                if let sql_parser::ast::Statement::Select(query) = stmt {
+                    let planned_query = match crate::plan::query::plan_root_query(
+                        scx,
+                        query.query,
+                        QueryLifetime::Static,
+                    ) {
+                        Ok(planned_query) => planned_query,
+                        Err(e) => return format!("unable to plan query: {}: {}", s.input, e),
+                    };
+
+                    let model = query_model::Model::from(&planned_query.expr);
+
+                    match query_model::dot::DotGenerator::new().generate(&model, &s.input) {
+                        Ok(graph) => graph,
+                        Err(e) => format!("graph generation error: {}", e),
+                    }
+                } else {
+                    panic!("invalid query: {}", s.input);
+                }
+            };
+            match s.directive.as_str() {
+                "build" => {
+                    let stmts = match sql_parser::parser::parse_statements(&s.input) {
+                        Ok(stmts) => stmts,
+                        Err(e) => return format!("unable to parse SQL: {}: {}", s.input, e),
+                    };
+
+                    stmts
+                        .into_iter()
+                        .fold("".to_string(), |c, stmt| c + &build_stmt(stmt))
+                }
+                _ => panic!("unknown directive: {}", s.directive),
+            }
+        })
+    });
+}

--- a/src/sql/tests/querymodel/basic
+++ b/src/sql/tests/querymodel/basic
@@ -34,3 +34,108 @@ digraph G {
     edge [ arrowhead = none, style = dashed ]
     Q0 -> boxhead0 [ lhead = cluster0 ]
 }
+
+build
+select 1;
+----
+digraph G {
+    compound = true
+    labeljust = l
+    label="select 1;"
+    node [ shape = box ]
+    subgraph cluster1 {
+        label = "Box1:Select"
+        boxhead1 [ shape = record, label="{ Distinct: Preserve| 0: 1 }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q0 [ label="Q0(F)" ]
+        }
+    }
+    subgraph cluster0 {
+        label = "Box0:Values"
+        boxhead0 [ shape = record, label="{ Distinct: Preserve| ROW 0:  }" ]
+        {
+            rank = same
+        }
+    }
+    edge [ arrowhead = none, style = dashed ]
+    Q0 -> boxhead0 [ lhead = cluster0 ]
+}
+
+build
+select a, a from (select 1 as a);
+----
+digraph G {
+    compound = true
+    labeljust = l
+    label="select a, a from (select 1 as a);"
+    node [ shape = box ]
+    subgraph cluster2 {
+        label = "Box2:Select"
+        boxhead2 [ shape = record, label="{ Distinct: Preserve| 0: Q1.C0| 1: Q1.C0 }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q1 [ label="Q1(F)" ]
+        }
+    }
+    subgraph cluster1 {
+        label = "Box1:Select"
+        boxhead1 [ shape = record, label="{ Distinct: Preserve| 0: 1 }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q0 [ label="Q0(F)" ]
+        }
+    }
+    subgraph cluster0 {
+        label = "Box0:Values"
+        boxhead0 [ shape = record, label="{ Distinct: Preserve| ROW 0:  }" ]
+        {
+            rank = same
+        }
+    }
+    edge [ arrowhead = none, style = dashed ]
+    Q1 -> boxhead1 [ lhead = cluster1 ]
+    Q0 -> boxhead0 [ lhead = cluster0 ]
+}
+
+
+build
+select a, b, a from (select 1 as a, 2 as b);
+----
+digraph G {
+    compound = true
+    labeljust = l
+    label="select a, b, a from (select 1 as a, 2 as b);"
+    node [ shape = box ]
+    subgraph cluster2 {
+        label = "Box2:Select"
+        boxhead2 [ shape = record, label="{ Distinct: Preserve| 0: Q1.C0| 1: Q1.C1| 2: Q1.C0 }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q1 [ label="Q1(F)" ]
+        }
+    }
+    subgraph cluster1 {
+        label = "Box1:Select"
+        boxhead1 [ shape = record, label="{ Distinct: Preserve| 0: 1| 1: 2 }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q0 [ label="Q0(F)" ]
+        }
+    }
+    subgraph cluster0 {
+        label = "Box0:Values"
+        boxhead0 [ shape = record, label="{ Distinct: Preserve| ROW 0:  }" ]
+        {
+            rank = same
+        }
+    }
+    edge [ arrowhead = none, style = dashed ]
+    Q1 -> boxhead1 [ lhead = cluster1 ]
+    Q0 -> boxhead0 [ lhead = cluster0 ]
+}

--- a/src/sql/tests/querymodel/basic
+++ b/src/sql/tests/querymodel/basic
@@ -1,0 +1,36 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+build
+select;
+----
+digraph G {
+    compound = true
+    labeljust = l
+    label="select;"
+    node [ shape = box ]
+    subgraph cluster1 {
+        label = "Box1:Select"
+        boxhead1 [ shape = record, label="{ Distinct: Preserve }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q0 [ label="Q0(F)" ]
+        }
+    }
+    subgraph cluster0 {
+        label = "Box0:Values"
+        boxhead0 [ shape = record, label="{ Distinct: Preserve| ROW 0:  }" ]
+        {
+            rank = same
+        }
+    }
+    edge [ arrowhead = none, style = dashed ]
+    Q0 -> boxhead0 [ lhead = cluster0 ]
+}

--- a/src/transform/Cargo.toml
+++ b/src/transform/Cargo.toml
@@ -10,6 +10,7 @@ dataflow-types = { path = "../dataflow-types" }
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 expr = { path = "../expr" }
 itertools = "0.10.1"
+ore = { path = "../../src/ore" }
 repr = { path = "../repr" }
 
 [dev-dependencies]

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -15,7 +15,8 @@
 //! in which the views will be executed.
 
 use dataflow_types::{DataflowDesc, LinearOperator};
-use expr::{GlobalId, Id, IdGen, LocalId, MirRelationExpr, MirScalarExpr};
+use expr::{GlobalId, Id, LocalId, MirRelationExpr, MirScalarExpr};
+use ore::id_gen::IdGen;
 use std::collections::{BTreeSet, HashMap, HashSet};
 
 use crate::Optimizer;

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -25,9 +25,10 @@ use std::collections::HashMap;
 use std::error::Error;
 use std::fmt;
 
+use expr::GlobalId;
 use expr::MirRelationExpr;
 use expr::MirScalarExpr;
-use expr::{GlobalId, IdGen};
+use ore::id_gen::IdGen;
 
 pub mod canonicalize_mfp;
 pub mod column_knowledge;

--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -24,7 +24,8 @@
 //! or if we are not certain that the input is non-empty (e.g. join).
 //!
 //! ```rust
-//! use expr::{BinaryFunc, IdGen, MirRelationExpr, MirScalarExpr};
+//! use expr::{BinaryFunc, MirRelationExpr, MirScalarExpr};
+//! use ore::id_gen::IdGen;
 //! use repr::{ColumnType, Datum, RelationType, ScalarType};
 //!
 //! use transform::predicate_pushdown::PredicatePushdown;

--- a/src/transform/src/update_let.rs
+++ b/src/transform/src/update_let.rs
@@ -13,7 +13,8 @@
 use std::collections::HashMap;
 
 use crate::TransformArgs;
-use expr::{Id, IdGen, LocalId, MirRelationExpr};
+use expr::{Id, LocalId, MirRelationExpr};
+use ore::id_gen::IdGen;
 use repr::RelationType;
 
 /// Refreshes identifiers and types for local let bindings.


### PR DESCRIPTION
<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug. [Link to issue.]

  * This PR adds a known-desirable feature. [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

* This PR adds a known-desirable feature. #8073 

This PR is the first deliverable of the QGM effort (#8073). It contains the model definition as described in the corresponding design [doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/20210707_qgm_sql_high_level_representation.md), plus a module that converts queries from Hir into QGM.

The support for the rest of Hir's operator will be added in separate PRs.

Another followup PRs will contain the rewrite engine for transforming query graph models as well as the module for lowering QGM to Mir.

The code added by this PR is not used by the actual product and it's only compiled in test config, since it is only exercised by unit tests.

This is a subset of #8775.

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

This first commit contains the definition of the Query Graph Model as described [here](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/20210707_qgm_sql_high_level_representation.md), the representation that will be used for performing SQL-to-SQL transformations. It also includes code for generating graphviz graphs from query graph models. This generator will be used extensively for debugging and testing.

The second commit contains the skeleton of the module that converts Hir into QGM. It also includes a basic data driven test dumping the resulting graph. `TestCatalog` needs to be extended so that actual tables and views can be injected into it to test queries referencing actual catalog items.

The third commit adds a README file basically explaining how to render the graphviz graphs that are the output of the tests, for visually validating the.

The forth commit adds support for Hir's Map, Project and Literal. This is a commit that can be used as a reference when extending the Hir->QGM generator.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
