### PR TITLE
persist,dataflow: for persistent tables, make operator construction deterministic

### DIFF
--- a/src/persist/benches/end_to_end.rs
+++ b/src/persist/benches/end_to_end.rs
@@ -108,15 +108,15 @@ fn bench_read_persisted_source<M: Measurement>(
             let mut runtime =
                 create_runtime(&persistence_base_path, &nonce).expect("missing runtime");
 
-            let (_write, read) = runtime
+            let read = runtime
                 .create_or_load::<Vec<u8>, Vec<u8>>(&collection_id)
-                .expect("could not load persistent collection");
+                .map(|(_write, read)| read);
 
             let mut probe = ProbeHandle::new();
 
             worker.dataflow(|scope| {
                 scope
-                    .persisted_source(&read)
+                    .persisted_source(read)
                     .flat_map(move |(data, time, diff)| match data {
                         Err(_err) => None,
                         Ok((key, _value)) => Some({


### PR DESCRIPTION
Before, we were potentially constructing differently shaped operator
graphs on each worker, based on the result of the `create_or_load()`
call.

Now, we pass that result to `persistent_source()` and handle that error
internally. Meaning we don't construct a separate `Stream` of errors but
instead let the operator emit the error on its output.

Fixes MaterializeInc/database-issues#2688 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. I added a test, but we need to see if it fixes some of the bugs @philip-stoev discovered as well.
- [N/A] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
