### PR TITLE
Fix wrong results issue introduced by #8582

### DIFF
--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -211,19 +211,16 @@ impl HirRelationExpr {
                     //
                     // The sequential traversal is present as expressions are allowed to depend on the
                     // values of prior expressions.
-                    let first_scalar = input.arity();
-                    let num_scalars = scalars.len();
+                    let mut scalar_columns = Vec::new();
                     for scalar in scalars {
                         let scalar =
                             scalar.applied_to(id_gen, col_map, &mut input, &Some(&subquery_map));
                         input = input.map(vec![scalar]);
+                        scalar_columns.push(input.arity() - 1);
                     }
 
-                    input = input.project(
-                        (0..old_arity)
-                            .chain(first_scalar..first_scalar + num_scalars)
-                            .collect(),
-                    );
+                    // Discard any new columns added by the lowering of the scalar expressions
+                    input = input.project((0..old_arity).chain(scalar_columns).collect());
                 }
 
                 input

--- a/test/sqllogictest/scalar_subqueries_select_list.slt
+++ b/test/sqllogictest/scalar_subqueries_select_list.slt
@@ -973,3 +973,187 @@ NULL  NULL
 1  1
 2  2
 3  3
+
+query T multiline
+EXPLAIN TYPED RAW PLAN FOR SELECT CASE (SELECT 1) WHEN 1 THEN 0 ELSE 2 END, 'TEXT';
+----
+%0 =
+| Constant ()
+| | types = ()
+| | keys = ()
+| Map if (select(%1) = 1) then {0} els {2}, "TEXT"
+| | types = (integer, text)
+| | keys = ()
+| |
+| | %1 =
+| | | Constant ()
+| | | | types = ()
+| | | | keys = ()
+| | | Map 1
+| | | | types = (integer)
+| | | | keys = ()
+| |
+
+EOF
+
+query T multiline
+EXPLAIN TYPED DECORRELATED PLAN FOR SELECT CASE (SELECT 1) WHEN 1 THEN 0 ELSE 2 END, 'TEXT';
+----
+%0 = Let l0 =
+| Constant ()
+| | types = ()
+| | keys = (())
+
+%1 =
+| Constant ()
+| | types = ()
+| | keys = (())
+
+%2 = Let l1 =
+| Join %0 %1
+| | implementation = Unimplemented
+| | types = ()
+| | keys = (())
+
+%3 = Let l2 =
+| Get %2 (l1)
+| | types = ()
+| | keys = (())
+| | types = ()
+| | keys = (())
+
+%4 = Let l3 =
+| Constant ()
+| | types = ()
+| | keys = (())
+
+%5 =
+| Constant ()
+| | types = ()
+| | keys = (())
+
+%6 = Let l4 =
+| Join %4 %5
+| | implementation = Unimplemented
+| | types = ()
+| | keys = (())
+
+%7 = Let l5 =
+| Get %6 (l4)
+| | types = ()
+| | keys = (())
+| | types = ()
+| | keys = (())
+| Map 1
+| | types = (integer)
+| | keys = (())
+| Project (#0)
+| | types = (integer)
+| | keys = (())
+
+%8 =
+| Get %7 (l5)
+| | types = (integer)
+| | keys = (())
+| Reduce group=()
+| | agg count(true)
+| | types = (bigint)
+| | keys = (())
+| Filter (#0 > 1)
+| | types = (bigint)
+| | keys = (())
+| Project ()
+| | types = ()
+| | keys = (())
+| Map (err: more than one record produced in subquery)
+| | types = (integer)
+| | keys = (())
+
+%9 = Let l6 =
+| Union %7 %8
+| | types = (integer)
+| | keys = ()
+| | types = (integer)
+| | keys = ()
+
+%10 =
+| Get %9 (l6)
+| | types = (integer)
+| | keys = ()
+| Distinct group=()
+| | types = ()
+| | keys = (())
+| Negate
+| | types = ()
+| | keys = ()
+
+%11 =
+| Get %4 (l3)
+| | types = ()
+| | keys = (())
+| Distinct group=()
+| | types = ()
+| | keys = (())
+
+%12 =
+| Union %10 %11
+| | types = ()
+| | keys = ()
+
+%13 =
+| Join %12 %4
+| | implementation = Unimplemented
+| | types = ()
+| | keys = ()
+| Project ()
+| | types = ()
+| | keys = ()
+
+%14 =
+| Constant (null)
+| | types = (integer?)
+| | keys = (())
+
+%15 =
+| Join %13 %14
+| | implementation = Unimplemented
+| | types = (integer?)
+| | keys = ()
+
+%16 =
+| Union %9 %15
+| | types = (integer?)
+| | keys = ()
+| | types = (integer?)
+| | keys = ()
+
+%17 =
+| Join %3 %16
+| | implementation = Unimplemented
+| | types = (integer?)
+| | keys = ()
+| Project (#0)
+| | types = (integer?)
+| | keys = ()
+| | types = (integer?)
+| | keys = ()
+| | types = (integer?)
+| | keys = ()
+| Map if (#0 = 1) then {0} else {2}
+| | types = (integer?, integer)
+| | keys = ()
+| Map "TEXT"
+| | types = (integer?, integer, text)
+| | keys = ()
+| Project (#1, #2)
+| | types = (integer, text)
+| | keys = ()
+| | types = (integer, text)
+| | keys = ()
+
+EOF
+
+query IT
+SELECT CASE (SELECT 1) WHEN 1 THEN 0 ELSE 2 END, 'TEXT';
+----
+0  TEXT


### PR DESCRIPTION
<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug. [Link to issue.]

  * This PR adds a known-desirable feature. [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

This PR fixes a previously unreported bug. This fixes a wrong result issue introduced under #8582 when having scalar subqueries in the conditional statements in the projection list of a query.

```
materialize=> select case (select 1) when 1 then 0 else 2 end, 2;
 ?column? | ?column? 
----------+----------
        1 |        0
(1 row)
```

```
materialize=> select case (select 1) when 1 then 0 else 2 end, 'text';
ERROR:  internal error: column 1 is not of expected type ColumnType { scalar_type: String, nullable: false }: Int32(0)
materialize=>
```

Spotted by @mjibson's work under #8503.

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
