### PR TITLE
add a timeout to ccsr requests

### DIFF
--- a/src/ccsr/src/config.rs
+++ b/src/ccsr/src/config.rs
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::time::Duration;
+
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
 
@@ -75,6 +77,7 @@ impl ClientConfig {
 
         let inner = builder
             .redirect(reqwest::redirect::Policy::none())
+            .timeout(Duration::from_secs(60))
             .build()
             .unwrap();
 


### PR DESCRIPTION
Currently all ccsr requests get the reqwest client's default infinite
timeout. This can cause materialize to hang forever if it's eg. pointed
at a slow/malicious server, a server that isn't actually a schema
registry, etc.

This was noticed because
https://github.com/MaterializeInc/materialize/pull/8743 added a test
where the client points at something that isn't an actual schema
registry. When it gets a response back (even a 4xx or 5xx), the test
succeeds. Redpanda in nightlies does not throw an error for that test
and ended up in progress for hours until the CI run itself timed out.

Tested by re-running sinks.td against redpanda locally and seeing that
it no longer hangs forever.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
