### PR TITLE
coord: add type_oid to mz_columns

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -107,7 +107,11 @@ List new features before bug fixes.
   `date_trunc` but supports "truncating" to arbitrary intervals.
 
 - Fix incorrect results for a certain class of degenerate join queries.
-  {{% gh 8747 %}}
+
+- Fix a bug in `pg_catalog.pg_attribute` that would incorrectly omit
+  certain rows based on the underlying column type.
+
+- Add the `type_oid` column to [`mz_columns`](/sql/system-catalog#mz_columns).
 
 {{% version-header v0.9.11 %}}
 

--- a/doc/user/content/sql/system-catalog.md
+++ b/doc/user/content/sql/system-catalog.md
@@ -114,6 +114,7 @@ Field            | Type        | Meaning
 `nullable`       | [`boolean`] | Can the column contain a `NULL` value?
 `type`           | [`text`]    | The data type of the column.
 `default`        | [`text`]    | The default expression of the column.
+`type_oid`       | [`oid`]     | The OID of the type of the column (references `mz_types`).
 
 ### `mz_databases`
 

--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -709,7 +709,8 @@ lazy_static! {
             .with_named_column("position", ScalarType::Int64.nullable(false))
             .with_named_column("nullable", ScalarType::Bool.nullable(false))
             .with_named_column("type", ScalarType::String.nullable(false))
-            .with_named_column("default", ScalarType::String.nullable(true)),
+            .with_named_column("default", ScalarType::String.nullable(true))
+            .with_named_column("type_oid", ScalarType::Oid.nullable(false)),
         id: GlobalId::System(4013),
         index_id: GlobalId::System(4014),
         persistent: false,
@@ -1325,7 +1326,7 @@ pub const PG_ATTRIBUTE: BuiltinView = BuiltinView {
     sql: "CREATE VIEW pg_attribute AS SELECT
     mz_objects.oid as attrelid,
     mz_columns.name as attname,
-    mz_types.oid AS atttypid,
+    mz_columns.type_oid AS atttypid,
     pg_type.typlen AS attlen,
     position as attnum,
     -1::pg_catalog.int4 as atttypmod,
@@ -1335,8 +1336,7 @@ pub const PG_ATTRIBUTE: BuiltinView = BuiltinView {
     FALSE as attisdropped
 FROM mz_catalog.mz_objects
 JOIN mz_catalog.mz_columns ON mz_objects.id = mz_columns.id
-JOIN mz_catalog.mz_types ON mz_columns.type = mz_types.name
-JOIN pg_catalog.pg_type ON pg_type.oid = mz_types.oid",
+JOIN pg_catalog.pg_type ON pg_type.oid = mz_columns.type_oid",
     // Since this depends on pg_type, its id must be higher due to initialization
     // ordering.
     id: GlobalId::System(5020),

--- a/src/coord/src/catalog/builtin_table_updates.rs
+++ b/src/coord/src/catalog/builtin_table_updates.rs
@@ -126,6 +126,7 @@ impl CatalogState {
                     .as_ref()
                     .map(|d| Datum::String(d))
                     .unwrap_or(Datum::Null);
+                let pgtype = pgrepr::Type::from(&column_type.scalar_type);
                 updates.push(BuiltinTableUpdate {
                     id: MZ_COLUMNS.id,
                     row: Row::pack_slice(&[
@@ -137,8 +138,9 @@ impl CatalogState {
                         ),
                         Datum::Int64(i as i64 + 1),
                         Datum::from(column_type.nullable),
-                        Datum::String(pgrepr::Type::from(&column_type.scalar_type).name()),
+                        Datum::String(pgtype.name()),
                         default,
+                        Datum::Int32(pgtype.oid() as i32),
                     ]),
                     diff,
                 });

--- a/test/sqllogictest/pg_catalog.slt
+++ b/test/sqllogictest/pg_catalog.slt
@@ -1,0 +1,105 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+mode cockroach
+
+
+# Verify that pg_attribute works for all column types.
+statement ok
+CREATE TABLE coltypes(
+c__bool _bool,
+c__bpchar _bpchar,
+c__bytea _bytea,
+c__char _char,
+c__date _date,
+c__float4 _float4,
+c__float8 _float8,
+c__int2 _int2,
+c__int4 _int4,
+c__int8 _int8,
+c__interval _interval,
+c__jsonb _jsonb,
+c__numeric _numeric,
+c__oid _oid,
+c__regproc _regproc,
+c__text _text,
+c__time _time,
+c__timestamp _timestamp,
+c__timestamptz _timestamptz,
+c__uuid _uuid,
+c__varchar _varchar,
+c_bool bool,
+c_bpchar bpchar,
+c_bytea bytea,
+c_char char,
+c_date date,
+c_float4 float4,
+c_float8 float8,
+c_int2 int2,
+c_int4 int4,
+c_int8 int8,
+c_interval interval,
+c_jsonb jsonb,
+c_numeric numeric,
+c_oid oid,
+c_regproc regproc,
+c_text text,
+c_time time,
+c_timestamp timestamp,
+c_timestamptz timestamptz,
+c_uuid uuid,
+c_varchar varchar
+);
+----
+
+query IT
+SELECT atttypid, attname FROM pg_attribute WHERE attrelid = (SELECT oid FROM mz_tables WHERE name='coltypes') ORDER BY atttypid
+----
+16  c_bool
+17  c_bytea
+20  c_int8
+21  c_int2
+23  c_int4
+24  c_regproc
+25  c_text
+26  c_oid
+700  c_float4
+701  c_float8
+1000  c__bool
+1001  c__bytea
+1005  c__int2
+1007  c__int4
+1008  c__regproc
+1009  c__text
+1014  c__char
+1014  c__bpchar
+1015  c__varchar
+1016  c__int8
+1021  c__float4
+1022  c__float8
+1028  c__oid
+1042  c_char
+1042  c_bpchar
+1043  c_varchar
+1082  c_date
+1083  c_time
+1114  c_timestamp
+1115  c__timestamp
+1182  c__date
+1183  c__time
+1184  c_timestamptz
+1185  c__timestamptz
+1186  c_interval
+1187  c__interval
+1231  c__numeric
+1700  c_numeric
+2950  c_uuid
+2951  c__uuid
+3802  c_jsonb
+3807  c__jsonb


### PR DESCRIPTION
The `mz_columns.type` column is the SQL standard name, but `mz_types.name`
is the Postgres name, and these usually don't match. `pg_attribute`
incorrectly joined on these names.
    
Add a new column to mz_columns so it can be correctly joined with mz_types
and pg_types. Fix pg_attribute by using the type oid as the join key.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
