### PR TITLE
Alter logic for yielding from halfjoin

### DIFF
--- a/src/dataflow/src/render/join/delta_join.rs
+++ b/src/dataflow/src/render/join/delta_join.rs
@@ -548,7 +548,9 @@ where
         trace,
         |time| time.saturating_sub(1),
         comparison,
-        |timer, _count| timer.elapsed().ge(&std::time::Duration::from_millis(10)),
+        // TODO(mcsherry): investigate/establish trade-offs here; time based had problems,
+        // in that we seem to yield too much and do too little work when we do.
+        |_timer, count| count > 1_000_000,
         // TODO(mcsherry): consider `RefOrMut` in `half_join` interface to allow re-use.
         move |_key, stream_row, lookup_row, initial, time, diff1, diff2| {
             let temp_storage = RowArena::new();


### PR DESCRIPTION
This PR changes the optimistically aggressive 10ms yield time for `HalfJoin` to a more conservative 1M records, which ensures that at least some amount of work gets done, at the expense of potentially stalling for longer. This has the potential to mitigate some "spinning" behavior that folks are seeing with this operator.

It is also possible that there is just a bug in the `HalfJoin` implementation, rather than the yielding policy. At the moment we don't have a reproduction of this issue, so it is hard to know. This PR is meant to be something they can use to test.

fixes MaterializeInc/database-issues#2699