### PR TITLE
drop isolation level from producer config

### DIFF
--- a/src/coord/src/sink_connector.rs
+++ b/src/coord/src/sink_connector.rs
@@ -372,8 +372,9 @@ async fn build_kafka(
     config.set("bootstrap.servers", &builder.broker_addrs.to_string());
     for (k, v) in builder.config_options.iter() {
         // Explicitly reject the statistics interval option here because its not
-        // properly supported for this client.
-        if k != "statistics.interval.ms" {
+        // properly supported for this client. Explicitly reject isolation level
+        // as it's a consumer property and will generate WARNs.
+        if k != "statistics.interval.ms" && k != "isolation.level" {
             config.set(k, v);
         }
     }


### PR DESCRIPTION
I swear I've made this change before, but the git history disagrees with me. 

Removes some annoying WARNs from the kafka client.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
