### PR TITLE
prof: Export jemalloc stats as json if requested

### DIFF
--- a/src/prof/src/jemalloc.rs
+++ b/src/prof/src/jemalloc.rs
@@ -183,10 +183,12 @@ impl JemallocProfCtl {
         Ok(f.into_file())
     }
 
-    pub fn dump_stats(&mut self) -> anyhow::Result<String> {
+    pub fn dump_stats(&mut self, json_format: bool) -> anyhow::Result<String> {
         // Try to avoid allocations within `stats_print`
-        let mut buf = Vec::with_capacity(1 << 20);
-        tikv_jemalloc_ctl::stats_print::stats_print(&mut buf, Default::default())?;
+        let mut buf = Vec::with_capacity(1 << 22);
+        let mut options = tikv_jemalloc_ctl::stats_print::Options::default();
+        options.json_format = json_format;
+        tikv_jemalloc_ctl::stats_print::stats_print(&mut buf, options)?;
         Ok(String::from_utf8(buf)?)
     }
 


### PR DESCRIPTION
### Motivation

This PR adds a feature that has not yet been specified: It adds an option to export the jemalloc stats as JSON when the appropriate HTTP header is set.

`curl -H "Accept: application/json" http://localhost:6875/prof\?dump_stats`

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
