### PR TITLE
row: Efficient copy in finish_and_reuse

### DIFF
--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -1013,7 +1013,7 @@ impl Row {
     /// The intent is that `self`'s allocation can be used to pack additional
     /// rows, to reduce the amount of interaction with the allocator.
     pub fn finish_and_reuse(&mut self) -> Row {
-        let data = SmallVec::from(&self.data[..]);
+        let data = SmallVec::from_slice(&self.data[..]);
         self.data.clear();
         Row { data }
     }


### PR DESCRIPTION
The current `SmallVec::from(slice)` iterates over the slice's contents.
This change switches it to using the more efficient `from_slice`
constructor, which internally doesn't use iterators to copy the data.

Signed-off-by: Moritz Hoffmann <mh@materialize.com>

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
