### PR TITLE
transform: Avoid a clone for pretty error messages

### DIFF
--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -151,7 +151,7 @@ impl Transform for Fixpoint {
             )?;
         }
         Err(TransformError::Internal(format!(
-            "fixpoint looped too many times {:#?} {}",
+            "fixpoint looped too many times {:#?}; transformed relation: {}",
             self,
             relation.pretty()
         )))


### PR DESCRIPTION
The fixpoint transformation can fail, and in this case it produces a
pretty-printed error message. The issue at hands is that the implementation
unconditionally creates a clone of the input relation, which is only used
to show an error message, if there is an error.

While it is nice to have good error messages, they should not come with a
high runtime cost. For this reason, remove the original expression from
the message and only show the transformed relation.

Signed-off-by: Moritz Hoffmann <mh@materialize.com>

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
