### PR TITLE
deny.toml: ignore inapplicable advisory RUSTSEC-2020-0159

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,3 +1,14 @@
+[advisories]
+ignore = [
+    # chrono calls localtime_r, which can result in memory unsafety if another
+    # thread is simultaneously calling setenv. The likelihood of this happening
+    # in Materialize is exceptionally low (we don't call setenv directly
+    # anywhere, and it is unlikely that our dependencies do either). There is
+    # no easy fix for chrono (https://github.com/chronotope/chrono/issues/499),
+    # so we're just ignoring the advisory for now.
+    "RUSTSEC-2020-0159"
+]
+
 [bans]
 multiple-versions = "deny"
 skip = [


### PR DESCRIPTION
RUSTSEC-2020-0159 describes a situation that is inapplicable to
Materialize and for which there is no available fix upstream. So just
ignore the advisory. See the comment within the patch for details.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
