### PR TITLE
coord,sql: support `SET LOCAL` and transactional variables

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -108,6 +108,9 @@ List new features before bug fixes.
 
 - Support the `READ ONLY` transaction mode.
 
+- Support `SET` in transactions, as well as `SET LOCAL`. This unblocks
+a problem with PostgreSQL JDBC 42.3.0.
+
 {{% version-header v0.9.10 %}}
 
 - Evaluate TopK operators on constant inputs at query compile time.

--- a/src/coord/src/session.rs
+++ b/src/coord/src/session.rs
@@ -632,7 +632,7 @@ pub struct WriteOp {
 }
 
 /// The action to take during end_transaction.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EndTransactionAction {
     /// Commit the transaction.
     Commit,

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -158,7 +158,8 @@ where
     // Construct session.
     let mut session = Session::new(conn.id(), user);
     for (name, value) in params {
-        let _ = session.vars_mut().set(&name, &value);
+        let local = false;
+        let _ = session.vars_mut().set(&name, &value, local);
     }
 
     // Register session with coordinator.

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -220,6 +220,7 @@ pub struct ShowVariablePlan {
 pub struct SetVariablePlan {
     pub name: String,
     pub value: String,
+    pub local: bool,
 }
 
 #[derive(Debug)]

--- a/src/sql/src/plan/statement/scl.rs
+++ b/src/sql/src/plan/statement/scl.rs
@@ -44,9 +44,6 @@ pub fn plan_set_variable(
         value,
     }: SetVariableStatement,
 ) -> Result<Plan, anyhow::Error> {
-    if local {
-        bail_unsupported!("SET LOCAL");
-    }
     Ok(Plan::SetVariable(SetVariablePlan {
         name: variable.to_string(),
         value: match value {
@@ -54,6 +51,7 @@ pub fn plan_set_variable(
             SetVariableValue::Literal(lit) => lit.to_string(),
             SetVariableValue::Ident(ident) => ident.into_string(),
         },
+        local,
     }))
 }
 

--- a/test/lang/java/smoketest/pom.xml
+++ b/test/lang/java/smoketest/pom.xml
@@ -30,7 +30,7 @@ the Business Source License, use of this software will be governed
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.2.14</version>
+      <version>42.3.0</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/test/sqllogictest/vars.slt
+++ b/test/sqllogictest/vars.slt
@@ -1,0 +1,114 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+mode cockroach
+
+query T
+SHOW extra_float_digits
+----
+3
+
+statement ok
+SET extra_float_digits=2
+----
+
+query T
+SHOW extra_float_digits
+----
+2
+
+simple
+SET extra_float_digits=1;
+SHOW extra_float_digits;
+----
+COMPLETE 0
+1
+COMPLETE 1
+
+query T
+SHOW extra_float_digits
+----
+1
+
+simple
+SET extra_float_digits=0;
+SHOW extra_float_digits;
+ROLLBACK;
+----
+COMPLETE 0
+0
+COMPLETE 1
+COMPLETE 0
+
+query T
+SHOW extra_float_digits
+----
+1
+
+simple
+SET LOCAL extra_float_digits=-1;
+SHOW extra_float_digits;
+----
+COMPLETE 0
+-1
+COMPLETE 1
+
+query T
+SHOW extra_float_digits
+----
+1
+
+simple
+SET LOCAL extra_float_digits=-2;
+SHOW extra_float_digits;
+ROLLBACK
+----
+COMPLETE 0
+-2
+COMPLETE 1
+COMPLETE 0
+
+query T
+SHOW extra_float_digits
+----
+1
+
+# Test that a failed transaction will not commit var changes.
+
+statement ok
+CREATE TABLE t (i INT);
+
+simple conn=1
+SET extra_float_digits=-3;
+COMMIT;
+BEGIN;
+SET extra_float_digits=-4;
+INSERT INTO t VALUES (1);
+----
+COMPLETE 0
+COMPLETE 0
+COMPLETE 0
+COMPLETE 0
+COMPLETE 1
+
+simple conn=2
+DROP TABLE t;
+----
+COMPLETE 0
+
+simple conn=1
+COMMIT;
+----
+db error: ERROR: unknown catalog item 'u1'
+
+simple conn=1
+SHOW extra_float_digits
+----
+-3
+COMPLETE 1


### PR DESCRIPTION
@mjibson this is how I had envisioned jamming support for transactional variables into the `SessionVar` infrastructure way back when. Sorry, I tried to just write this out, but I had to actually bang on things to page them back in, and then the patch was mostly done. WDYT?

I think this comes out cleaner than cloning `Vars` on the start of every transaction. The downside with this approach is that you have to remember to update `end_transaction` manually with every new `SessionVar` you add, but that's mitigated by the exhaustive destruction. That sort of manual labor is also fundamental to the current design of the session variable infrastructure, and the rough thinking is that if it ever really becomes a problem, we can add a macro/codegen do cut out the repetitive bits.

