### PR TITLE
ci-builder: add a convenience command for opening a root shell

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -23,9 +23,10 @@ Manages the ci-builder Docker image, which contains the dependencies required
 to build, test, and deploy the code in this repository.
 
 Commands:
-    run      run a command in the ci-builder image
-    build    build and tag new version of the ci-builder image
-    push     push a new version of the ci-builder image to Docker Hub
+    run         run a command in the ci-builder image
+    build       build and tag new version of the ci-builder image
+    push        push a new version of the ci-builder image to Docker Hub
+    root-shell  open a root shell to the most recently started ci-builder container
 
 For details, consult ci/builder/README.md."
     exit 1
@@ -49,6 +50,7 @@ case "$channel" in
 esac
 
 tag_file=ci/builder/${channel%%-*}.stamp
+cid_file=ci/builder/.${channel%%-*}.cidfile
 
 rust_components=rustc,cargo,rust-std-x86_64-unknown-linux-gnu
 if [[ $rust_version = nightly ]]; then
@@ -85,6 +87,7 @@ case "$cmd" in
         ;;
     run)
         args=(
+            --cidfile "$cid_file"
             --rm --interactive
             --init
             --volume "$(pwd):$(pwd)"
@@ -148,7 +151,11 @@ case "$cmd" in
         else
             args+=(--user "$(id -u):1001")
         fi
+        rm -f "$cid_file"
         docker run "${args[@]}" "materialize/ci-builder:$(<"$tag_file")" "$@"
+        ;;
+    root-shell)
+        docker exec --interactive --tty --user 0:0 "$(<"$cid_file")" ci/builder/root-shell.sh
         ;;
     *)
         printf "unknown command %q\n" "$cmd"

--- a/ci/builder/.gitignore
+++ b/ci/builder/.gitignore
@@ -1,3 +1,4 @@
 /requirements.txt
 /requirements-dev.txt
 /requirements-ci.txt
+/*.cidfile

--- a/ci/builder/README.md
+++ b/ci/builder/README.md
@@ -59,9 +59,28 @@ After a successful push, the script will update stable.stamp with the new tag of
 the image. Commit the resulting diff, *including* the changes to the Dockerfile
 that were incorporated into the built image, and open a PR!
 
+## Acquiring root within the image
+
+When debugging issues with the image, it is occasionally useful to acquire root.
+You can't run `sudo` because the image does not have `sudo` installed.
+
+Instead, you can use the `root-shell` command. While running the image in one
+shell, open a new shell and run:
+
+```shell
+$ bin/ci-builder root-shell stable
+```
+
+That command will open a new root shell into the most recently launched
+ci-builder image. It will also run `apt-get update` so that you can use `apt
+install` to install any additional software you might need.
+
+When using the root shell, beware that if you create files as root on any
+shared volumes, those files will be owned by root *on your host machine*.
+
 ## Upgrading the Rust version
 
-1. Update the [`rust-toolchain.toml`] file with the desired version.
+1. Update the [rust-toolchain.toml] file with the desired version.
 
 2. Run:
 
@@ -100,7 +119,7 @@ $ bin/ci-builder push nightly-2001-02-03
 ```
 
 [bin/ci-builder]: /bin/ci-builder
-[rust-toolchain]: /rust-toolchain.toml
+[rust-toolchain.toml]: /rust-toolchain.toml
 [stable.stamp]: stable.stamp
 [nightly.stamp]: nightly.stamp
 [rust-toolstate]: https://rust-lang.github.io/rustup-components-history/

--- a/ci/builder/root-shell.sh
+++ b/ci/builder/root-shell.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# root-shell.sh — configures a root shell in the CI builder.
+
+apt-get update
+exec bash


### PR DESCRIPTION
When debugging the CI builder image, it's occasionally necessary to
acquire root within the container (e.g. to install additional software
via APT). Add a convenience command that wraps the `docker exec`
invocation.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
