### PR TITLE
repr: Add RowAllocator

### DIFF
--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -32,7 +32,8 @@ pub mod util;
 
 pub use relation::{ColumnName, ColumnType, NotNullViolation, RelationDesc, RelationType};
 pub use row::{
-    datum_list_size, datum_size, datums_size, row_size, DatumList, DatumMap, Row, RowArena, RowRef,
+    datum_list_size, datum_size, datums_size, row_size, DatumList, DatumMap, Row, RowAllocator,
+    RowArena, RowRef,
 };
 pub use scalar::{Datum, FromTy, ScalarBaseType, ScalarType, WithArena};
 


### PR DESCRIPTION
The current mechanism to avoid row reallocations is to extract a copy
of a row while leaving the allocation around for later. This is problematic
because it potentially leaves an allocated row around that will only be
used much later or never again.

The RowAllocator tries to mitigate this by not retaining an allocation but
remembering the maximal length of the previously produced rows. Once
borrowed, it allocates a row of the desired length. The row then can be
extracted, which also updates the length information.

Signed-off-by: Moritz Hoffmann <mh@materialize.com>

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
