### PR TITLE
Separate metadata non breaking

### DIFF
--- a/src/dataflow/src/decode/avro.rs
+++ b/src/dataflow/src/decode/avro.rs
@@ -11,7 +11,6 @@ use futures::executor::block_on;
 
 use dataflow_types::{DataflowError, DecodeError};
 use interchange::avro::{Decoder, EnvelopeType};
-use repr::Datum;
 use repr::Row;
 
 #[derive(Debug)]
@@ -46,16 +45,11 @@ impl AvroDecoderState {
     pub fn decode(
         &mut self,
         bytes: &mut &[u8],
-        coord: Option<i64>,
         upstream_time_millis: Option<i64>,
-        push_metadata: bool,
     ) -> Result<Option<Row>, DataflowError> {
-        match block_on(self.decoder.decode(bytes, coord, upstream_time_millis)) {
-            Ok(mut row) => {
+        match block_on(self.decoder.decode(bytes, upstream_time_millis)) {
+            Ok(row) => {
                 self.events_success += 1;
-                if push_metadata {
-                    row.push(Datum::from(coord))
-                }
                 Ok(Some(row))
             }
             Err(err) => Err(DataflowError::DecodeError(DecodeError::Text(format!(

--- a/src/dataflow/src/decode/protobuf.rs
+++ b/src/dataflow/src/decode/protobuf.rs
@@ -33,13 +33,8 @@ impl ProtobufDecoderState {
             events_error: 0,
         }
     }
-    pub fn get_value(
-        &mut self,
-        bytes: &[u8],
-        position: Option<i64>,
-        push_metadata: bool,
-    ) -> Option<Result<Row, DataflowError>> {
-        match self.decoder.decode(bytes, position, push_metadata) {
+    pub fn get_value(&mut self, bytes: &[u8]) -> Option<Result<Row, DataflowError>> {
+        match self.decoder.decode(bytes) {
             Ok(row) => {
                 if let Some(row) = row {
                     self.events_success += 1;

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -28,9 +28,7 @@ use dataflow_types::*;
 use expr::{GlobalId, Id, SourceInstanceId};
 use ore::cast::CastFrom;
 use ore::now::NowFn;
-use repr::RelationDesc;
-use repr::ScalarType;
-use repr::{Row, Timestamp};
+use repr::{Datum, RelationDesc, Row, ScalarType, Timestamp};
 
 use crate::decode::decode_cdcv2;
 use crate::decode::render_decode;
@@ -483,6 +481,14 @@ where
                                 SourceEnvelope::Upsert => {
                                     let upsert_operator_name = format!("{}-upsert", source_name);
 
+                                    // append position metadata to the output row
+                                    let results = results.map(|mut d| {
+                                        if let Some(Ok(ref mut row)) = d.value {
+                                            row.push(Datum::from(d.position));
+                                        }
+                                        d
+                                    });
+
                                     let (upsert_ok, upsert_err) = super::upsert::upsert(
                                         &upsert_operator_name,
                                         &results,
@@ -494,7 +500,7 @@ where
                                             .map(|config| config.upsert_config.clone()),
                                     );
 
-                                    // When persistence is enable we need to seal up both the
+                                    // When persistence is enabled we need to seal up both the
                                     // timestamp bindings and the upsert state. Otherwise, just
                                     // pass through.
                                     let upsert_ok = if let Some(source_persist_config) =
@@ -726,48 +732,63 @@ where
 {
     match key_envelope {
         KeyEnvelope::None => results
-            .flat_map(|DecodeResult { key: _, value, .. }| value)
+            .flat_map(
+                |DecodeResult {
+                     value, position, ..
+                 }| {
+                    value.map(|result| {
+                        let mut row = result?;
+                        row.push(Datum::from(position));
+                        Ok(row)
+                    })
+                },
+            )
             .ok_err(std::convert::identity),
         KeyEnvelope::Flattened | KeyEnvelope::LegacyUpsert => results
             .flat_map(flatten_key_value)
             .map(|maybe_kv| {
-                maybe_kv.map(|(mut key, value)| {
+                maybe_kv.map(|(mut key, value, position)| {
                     key.extend_by_row(&value);
+                    key.push(Datum::from(position));
                     key
                 })
             })
             .ok_err(std::convert::identity),
         KeyEnvelope::Named(_) => results
             .flat_map(flatten_key_value)
-            .map(|maybe_kv| match maybe_kv {
-                Ok((mut key, value)) => {
+            .map(|maybe_kv| {
+                maybe_kv.map(|(mut key, value, position)| {
                     // Named semantics rename a key that is a single column, and encode a
                     // multi-column field as a struct with that name
-                    match key.iter().count() {
-                        1 => {
-                            key.extend_by_row(&value);
-                            Ok(key)
-                        }
-                        _ => {
-                            let mut new_row = Row::default();
-                            new_row.push_list(key.iter());
-                            new_row.extend_by_row(&value);
-                            Ok(new_row)
-                        }
-                    }
-                }
-                Err(e) => Err(e),
+                    let mut row = if key.iter().nth(1).is_none() {
+                        key.extend_by_row(&value);
+                        key
+                    } else {
+                        let mut new_row = Row::default();
+                        new_row.push_list(key.iter());
+                        new_row.extend_by_row(&value);
+                        new_row
+                    };
+                    row.push(Datum::from(position));
+                    row
+                })
             })
             .ok_err(std::convert::identity),
     }
 }
 
 /// Handle possibly missing key or value portions of messages
-fn flatten_key_value(result: DecodeResult) -> Option<Result<(Row, Row), DataflowError>> {
-    let DecodeResult { key, value, .. } = result;
+fn flatten_key_value(
+    result: DecodeResult,
+) -> Option<Result<(Row, Row, Option<i64>), DataflowError>> {
+    let DecodeResult {
+        key,
+        value,
+        position,
+    } = result;
     match (key, value) {
         (Some(key), Some(value)) => match (key, value) {
-            (Ok(key), Ok(value)) => Some(Ok((key, value))),
+            (Ok(key), Ok(value)) => Some(Ok((key, value, position))),
             // always prioritize the value error if either or both have an error
             (_, Err(e)) => Some(Err(e)),
             (Err(e), _) => Some(Err(e)),

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -249,7 +249,7 @@ where
                     base_metrics,
                 };
 
-                let (collection, capability) = if let ExternalSourceConnector::PubNub(
+                let (mut collection, capability) = if let ExternalSourceConnector::PubNub(
                     pubnub_connector,
                 ) = connector
                 {
@@ -391,41 +391,93 @@ where
                                     .push(Rc::new(tok));
                             }
 
-                            // render debezium or regular upsert
+                            // render envelopes
                             match &envelope {
-                                SourceEnvelope::Debezium(_, DebeziumMode::Upsert) => {
-                                    let mut trackstate = (
-                                        HashMap::new(),
-                                        render_state
-                                            .metrics
-                                            .debezium_upsert_count_for(src_id, self.dataflow_id),
-                                    );
-                                    let results = results.flat_map(
-                                            move |DecodeResult { key, value, .. }| {
-                                                let (keys, metrics) = &mut trackstate;
-                                                #[rustfmt::skip]
-                                                let value = value.map(|value| {
-                                                    match key {
-                                                        None => Err::<_, DataflowError>(
-                                                            DecodeError::Text(
-                                                                "All upsert keys should decode to a value."
-                                                                    .to_string(),
-                                                            )
-                                                            .into(),
-                                                        ),
-                                                        Some(Err(e)) => Err(e),
-                                                        Some(Ok(key)) => {
-                                                            rewrite_for_upsert(value, keys, key, metrics)
+                                SourceEnvelope::Debezium(dedupe_strategy, mode) => {
+                                    let results = match mode {
+                                        DebeziumMode::Upsert => {
+                                            let mut trackstate = (
+                                                HashMap::new(),
+                                                render_state.metrics.debezium_upsert_count_for(
+                                                    src_id,
+                                                    self.dataflow_id,
+                                                ),
+                                            );
+                                            results.flat_map(
+                                                move |DecodeResult { key, value, .. }| {
+                                                    let (keys, metrics) = &mut trackstate;
+                                                    #[rustfmt::skip]
+                                                    let value = value.map(|value| {
+                                                        match key {
+                                                            None => Err::<_, DataflowError>(
+                                                                DecodeError::Text(
+                                                                    "All upsert keys should decode to a value."
+                                                                        .to_string(),
+                                                                )
+                                                                .into(),
+                                                            ),
+                                                            Some(Err(e)) => Err(e),
+                                                            Some(Ok(key)) => {
+                                                                rewrite_for_upsert(value, keys, key, metrics)
+                                                            }
                                                         }
-                                                    }
-                                                });
-                                                value
-                                            },
-                                        );
+                                                    });
+                                                    value
+                                                },
+                                            )
+                                        }
+                                        DebeziumMode::Plain => {
+                                            results.flat_map(|DecodeResult { value, .. }| value)
+                                        }
+                                    };
                                     let (stream, errors) = results.ok_err(std::convert::identity);
                                     let stream = stream.pass_through("decode-ok").as_collection();
                                     let errors =
                                         errors.pass_through("decode-errors").as_collection();
+
+                                    let dbz_key_indices = match &src.connector {
+                                        SourceConnector::External {
+                                            encoding:
+                                                SourceDataEncoding::KeyValue {
+                                                    key:
+                                                        DataEncoding::Avro(AvroEncoding {
+                                                            schema: key_schema,
+                                                            ..
+                                                        }),
+                                                    ..
+                                                },
+                                            ..
+                                        } => {
+                                            let fields = match &src.bare_desc.typ().column_types[0]
+                                                .scalar_type
+                                            {
+                                                ScalarType::Record { fields, .. } => fields.clone(),
+                                                _ => unreachable!(),
+                                            };
+                                            let row_desc = RelationDesc::from_names_and_types(
+                                                fields.into_iter().map(|(n, t)| (Some(n), t)),
+                                            );
+                                            // these must be available because the DDL parsing logic already
+                                            // checks this and bails in case the key is not correct
+                                            let key_indices =
+                                                interchange::avro::validate_key_schema(key_schema, &row_desc)
+                                                    .expect(
+                                                    "Invalid key schema, this indicates a bug in Materialize",
+                                                );
+                                            Some(key_indices)
+                                        }
+                                        _ => None,
+                                    };
+
+                                    let stream = dedupe_strategy.clone().render(
+                                        stream,
+                                        self.debug_name.to_string(),
+                                        scope.index(),
+                                        // Debezium decoding has produced two extra fields, with the dedupe information and the upstream time in millis
+                                        src.bare_desc.arity() + 2,
+                                        dbz_key_indices,
+                                    );
+
                                     (stream, Some(errors))
                                 }
                                 SourceEnvelope::Upsert => {
@@ -491,52 +543,6 @@ where
                     }
 
                     (stream, capability)
-                };
-
-                // render debezium dedupe
-                let mut collection = match &envelope {
-                    SourceEnvelope::Debezium(dedupe_strategy, _) => {
-                        let dbz_key_indices = match &src.connector {
-                            SourceConnector::External {
-                                encoding:
-                                    SourceDataEncoding::KeyValue {
-                                        key:
-                                            DataEncoding::Avro(AvroEncoding {
-                                                schema: key_schema, ..
-                                            }),
-                                        ..
-                                    },
-                                ..
-                            } => {
-                                let fields = match &src.bare_desc.typ().column_types[0].scalar_type
-                                {
-                                    ScalarType::Record { fields, .. } => fields.clone(),
-                                    _ => unreachable!(),
-                                };
-                                let row_desc = RelationDesc::from_names_and_types(
-                                    fields.into_iter().map(|(n, t)| (Some(n), t)),
-                                );
-                                // these must be available because the DDL parsing logic already
-                                // checks this and bails in case the key is not correct
-                                let key_indices =
-                                    interchange::avro::validate_key_schema(key_schema, &row_desc)
-                                        .expect(
-                                        "Invalid key schema, this indicates a bug in Materialize",
-                                    );
-                                Some(key_indices)
-                            }
-                            _ => None,
-                        };
-                        dedupe_strategy.clone().render(
-                            collection,
-                            self.debug_name.to_string(),
-                            scope.index(),
-                            // Debezium decoding has produced two extra fields, with the dedupe information and the upstream time in millis
-                            src.bare_desc.arity() + 2,
-                            dbz_key_indices,
-                        )
-                    }
-                    _ => collection,
                 };
 
                 // Force a shuffling of data in case sources are not uniformly distributed.

--- a/src/interchange/benches/avro.rs
+++ b/src/interchange/benches/avro.rs
@@ -402,7 +402,7 @@ pub fn bench_avro(c: &mut Criterion) {
     let mut bg = c.benchmark_group("avro");
     bg.throughput(Throughput::Bytes(len));
     bg.bench_function("decode", move |b| {
-        b.iter(|| black_box(block_on(decoder.decode(&mut buf.as_slice(), None, None)).unwrap()))
+        b.iter(|| black_box(block_on(decoder.decode(&mut buf.as_slice(), None)).unwrap()))
     });
     bg.finish();
 }

--- a/src/interchange/benches/protobuf.rs
+++ b/src/interchange/benches/protobuf.rs
@@ -72,7 +72,7 @@ pub fn bench_protobuf(c: &mut Criterion) {
     let mut bg = c.benchmark_group("protobuf");
     bg.throughput(Throughput::Bytes(len));
     bg.bench_function("decode", move |b| {
-        b.iter(|| black_box(decoder.decode(&buf, None, true).unwrap()))
+        b.iter(|| black_box(decoder.decode(&buf).unwrap()))
     });
     bg.finish();
 }

--- a/src/interchange/src/avro/decode.rs
+++ b/src/interchange/src/avro/decode.rs
@@ -161,7 +161,6 @@ impl Decoder {
     pub async fn decode(
         &mut self,
         bytes: &mut &[u8],
-        coord: Option<i64>,
         upstream_time_millis: Option<i64>,
     ) -> anyhow::Result<Row> {
         let (bytes2, resolved_schema) = self.csr_avro.resolve(bytes).await?;
@@ -213,13 +212,8 @@ impl Decoder {
             self.packer.finish_and_reuse()
         };
         log::trace!(
-            "[customer-data] Decoded row {:?}{} in {}",
+            "[customer-data] Decoded row {:?} in {}",
             result,
-            if let Some(coord) = coord {
-                format!(" at offset {}", coord)
-            } else {
-                format!("")
-            },
             self.debug_name
         );
         Ok(result)

--- a/src/interchange/src/avro/envelope_debezium/deduplication.rs
+++ b/src/interchange/src/avro/envelope_debezium/deduplication.rs
@@ -130,7 +130,7 @@ impl DebeziumDeduplicationStrategy {
                         &debug_name,
                         worker_index,
                         &row,
-                        // Debezium decoding always adds two extra rows to the end of the record: one with the deduplication position,
+                        // Debezium decoding always adds two extra columns to the end of the record: one with the deduplication position,
                         // and one with the upstream time in milliseconds.
                         // Since these are the last two datums in the row, they are at `arity - 2` and `arity - 1`, respectively.
                         arity - 2,

--- a/src/interchange/src/protobuf.rs
+++ b/src/interchange/src/protobuf.rs
@@ -362,7 +362,7 @@ mod tests {
 
         let mut decoder = get_decoder(".TestRecord");
         let row = decoder
-            .decode(&bytes, None, false)
+            .decode(&bytes)
             .expect("deserialize protobuf into a row")
             .unwrap();
         let datums = row.iter().collect::<Vec<_>>();
@@ -390,7 +390,7 @@ mod tests {
 
         let mut decoder = get_decoder(".TestRecord");
         let row = decoder
-            .decode(&bytes, None, false)
+            .decode(&bytes)
             .expect("deserialize protobuf into a row")
             .unwrap();
         let datums = row.iter().collect::<Vec<_>>();
@@ -417,7 +417,7 @@ mod tests {
 
         let mut decoder = get_decoder(".TestRepeatedRecord");
         let row = decoder
-            .decode(&bytes, None, false)
+            .decode(&bytes)
             .expect("deserialize protobuf into a row")
             .unwrap();
         let datums = row.iter().collect::<Vec<_>>();
@@ -455,7 +455,7 @@ mod tests {
 
         let mut decoder = get_decoder(".TestNestedRecord");
         let row = decoder
-            .decode(&bytes, None, false)
+            .decode(&bytes)
             .expect("deserialize protobuf into a row")
             .unwrap();
         let datums = row.iter().collect::<Vec<_>>();
@@ -493,7 +493,7 @@ mod tests {
             .expect("test failed to serialize to bytes");
 
         let row2 = decoder
-            .decode(&bytes, None, false)
+            .decode(&bytes)
             .expect("deserialize protobuf into a row")
             .unwrap();
         let datums = row2.iter().collect::<Vec<_>>();
@@ -546,7 +546,7 @@ mod tests {
 
         let mut decoder = get_decoder(".TestRepeatedNestedRecord");
         let row = decoder
-            .decode(&bytes, None, false)
+            .decode(&bytes)
             .expect("deserialize protobuf into a row")
             .unwrap();
         let datums = row.iter().collect::<Vec<_>>();

--- a/src/interchange/src/protobuf/decode.rs
+++ b/src/interchange/src/protobuf/decode.rs
@@ -43,12 +43,7 @@ impl Decoder {
         }
     }
 
-    pub fn decode(
-        &mut self,
-        bytes: &[u8],
-        position: Option<i64>,
-        push_metadata: bool,
-    ) -> Result<Option<Row>> {
+    pub fn decode(&mut self, bytes: &[u8]) -> Result<Option<Row>> {
         let input_stream = protobuf::CodedInputStream::from_bytes(bytes);
         let mut deserializer =
             Deserializer::for_named_message(&self.descriptors, &self.message_name, input_stream)
@@ -71,9 +66,6 @@ impl Decoder {
             &relation_type.typ().column_types,
             &mut packer,
         )?;
-        if push_metadata {
-            packer.push(Datum::from(position));
-        }
         Ok(Some(packer.finish_and_reuse()))
     }
 }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -856,14 +856,12 @@ pub fn plan_create_source(
         }
     }
 
-    // TODO(benesch): the available metadata columns should not depend
-    // on the format.
-    //
     // TODO(brennan): They should not depend on the envelope either. Figure out a way to
     // make all of this more tasteful.
-    if !matches!(encoding.value_ref(), DataEncoding::Avro { .. })
-        && !matches!(envelope, SourceEnvelope::Debezium(_, _))
-    {
+    if !matches!(
+        envelope,
+        SourceEnvelope::Debezium(_, _) | SourceEnvelope::CdcV2
+    ) {
         for (name, ty) in external_connector.metadata_columns() {
             bare_desc = bare_desc.with_named_column(name, ty);
         }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -858,10 +858,9 @@ pub fn plan_create_source(
 
     // TODO(brennan): They should not depend on the envelope either. Figure out a way to
     // make all of this more tasteful.
-    if !matches!(
-        envelope,
-        SourceEnvelope::Debezium(_, _) | SourceEnvelope::CdcV2
-    ) {
+    if !matches!(encoding.value_ref(), DataEncoding::Avro { .. })
+        && !matches!(envelope, SourceEnvelope::Debezium(_, _))
+    {
         for (name, ty) in external_connector.metadata_columns() {
             bare_desc = bare_desc.with_named_column(name, ty);
         }


### PR DESCRIPTION
### Motivation
The decoding stage is responsible for transforming a timely stream of `SourceOutput` messages into a timely stream of `DecodeResult`. Previously, depending on the `push_metadata` flag, the format decoders would push the position metadata into the decoded row. However, `DecodeResult`s have a `position` field that carries the position metadata anyway.

In this patch format decoder implementations are made oblivious of the `position`[1] and `push_metadata` information and never produce this information in the output row.

Then, the downstream envelope stage of transforming the `DecodeResult` stream into a pure `Row` stream can choose whether or not it makes sense for the envelope to append the position metadata into the output `Row`.

### Tips for reviewer

Commit by commit recommended 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).