### PR TITLE
dataflow: Avoid cloning source imports

### DIFF
--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -218,15 +218,15 @@ pub fn build_dataflow<A: Allocate>(
             );
 
             // Import declared sources into the rendering context.
-            for (src_id, (src, orig_id)) in dataflow.source_imports.clone() {
+            for (src_id, (src, orig_id)) in &dataflow.source_imports {
                 context.import_source(
                     render_state,
                     &mut tokens,
                     region,
                     materialized_logging.clone(),
-                    src_id,
-                    src,
-                    orig_id,
+                    src_id.clone(),
+                    src.clone(),
+                    orig_id.clone(),
                     now,
                     source_metrics,
                 );


### PR DESCRIPTION
It turns out that cloning BTreeMaps is slow and requires several heap
allocations. The code changed in this PR is an instance where we actually
don't need the cloned map but rather cloned elements, which is much easier
to handle.