### PR TITLE
persist: correctly handle new encoding versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3010,6 +3010,9 @@ dependencies = [
 [[package]]
 name = "persist-types"
 version = "0.0.0"
+dependencies = [
+ "serde_json",
+]
 
 [[package]]
 name = "pgrepr"

--- a/src/dataflow-types/src/errors.rs
+++ b/src/dataflow-types/src/errors.rs
@@ -42,8 +42,7 @@ impl Codec for DecodeError {
     }
 
     fn decode<'a>(buf: &'a [u8]) -> Result<Self, CodecError> {
-        let decoded = serde_json::from_slice(buf)
-            .map_err(|e| CodecError::from(format!("Decoding error: {}", e)))?;
+        let decoded = serde_json::from_slice(buf)?;
         Ok(decoded)
     }
 }

--- a/src/dataflow-types/src/errors.rs
+++ b/src/dataflow-types/src/errors.rs
@@ -10,6 +10,7 @@
 use std::fmt::Display;
 
 use expr::EvalError;
+use persist_types::error::CodecError;
 use persist_types::Codec;
 
 use serde::{Deserialize, Serialize};
@@ -40,8 +41,9 @@ impl Codec for DecodeError {
         buf.extend(encoded.iter());
     }
 
-    fn decode<'a>(buf: &'a [u8]) -> Result<Self, String> {
-        let decoded = serde_json::from_slice(buf).map_err(|e| format!("Decoding error: {}", e))?;
+    fn decode<'a>(buf: &'a [u8]) -> Result<Self, CodecError> {
+        let decoded = serde_json::from_slice(buf)
+            .map_err(|e| CodecError::from(format!("Decoding error: {}", e)))?;
         Ok(decoded)
     }
 }
@@ -132,12 +134,13 @@ impl From<SourceError> for DataflowError {
 
 #[cfg(test)]
 mod tests {
+    use persist_types::error::CodecError;
     use persist_types::Codec;
 
     use super::DecodeError;
 
     #[test]
-    fn test_decode_error_codec_roundtrip() -> Result<(), String> {
+    fn test_decode_error_codec_roundtrip() -> Result<(), CodecError> {
         let original = DecodeError::Text("ciao".to_string());
         let mut encoded = Vec::new();
         original.encode(&mut encoded);

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -411,9 +411,7 @@ impl Codec for SourceTimestamp {
         let (partition, offset_start) = match typ {
             SOURCE_TIMESTAMP_PARTITION_KAFKA => {
                 let slice = &buf[1..(1 + 4)];
-                let pid = i32::from_le_bytes(
-                    <[u8; 4]>::try_from(slice).map_err(|err| CodecError::from(err.to_string()))?,
-                );
+                let pid = i32::from_le_bytes(<[u8; 4]>::try_from(slice)?);
                 (PartitionId::Kafka(pid), 1 + 4)
             }
             SOURCE_TIMESTAMP_PARTITION_NONE => (PartitionId::None, 1),
@@ -425,9 +423,7 @@ impl Codec for SourceTimestamp {
             }
         };
         let slice = &buf[offset_start..(offset_start + 8)];
-        let offset = i64::from_le_bytes(
-            <[u8; 8]>::try_from(slice).map_err(|err| CodecError::from(err.to_string()))?,
-        );
+        let offset = i64::from_le_bytes(<[u8; 8]>::try_from(slice)?);
         let offset = MzOffset { offset };
         Ok(SourceTimestamp { partition, offset })
     }
@@ -448,9 +444,9 @@ impl Codec for AssignedTimestamp {
     }
 
     fn decode<'a>(buf: &'a [u8]) -> Result<Self, CodecError> {
-        Ok(AssignedTimestamp(u64::from_le_bytes(
-            <[u8; 8]>::try_from(buf).map_err(|err| CodecError::from(err.to_string()))?,
-        )))
+        Ok(AssignedTimestamp(u64::from_le_bytes(<[u8; 8]>::try_from(
+            buf,
+        )?)))
     }
 }
 

--- a/src/persist-types/Cargo.toml
+++ b/src/persist-types/Cargo.toml
@@ -8,3 +8,4 @@ publish = false
 # NB: This is meant to be a strong, independent abstraction boundary, please
 # don't leak in deps on other Materialize packages.
 [dependencies]
+serde_json = "1.0.68"

--- a/src/persist-types/src/codec_impls.rs
+++ b/src/persist-types/src/codec_impls.rs
@@ -50,7 +50,7 @@ impl Codec for String {
     }
 
     fn decode<'a>(buf: &'a [u8]) -> Result<Self, CodecError> {
-        String::from_utf8(buf.to_owned()).map_err(|err| CodecError::from(err.to_string()))
+        Ok(String::from_utf8(buf.to_owned())?)
     }
 }
 

--- a/src/persist-types/src/error.rs
+++ b/src/persist-types/src/error.rs
@@ -1,0 +1,59 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Codec related errors.
+
+use std::{error, fmt};
+
+/// A Codec related error.
+#[derive(Debug, Clone)]
+pub enum CodecError {
+    /// An unstructured codec related error.
+    String(String),
+    /// The encoding version is incompatible with what we can currently decode.
+    InvalidEncodingVersion(Option<usize>),
+}
+
+impl error::Error for CodecError {}
+
+impl fmt::Display for CodecError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CodecError::String(e) => f.write_str(e),
+            CodecError::InvalidEncodingVersion(v) => {
+                f.write_str(&format!("invalid encoding version: {:?}", v))
+            }
+        }
+    }
+}
+
+impl From<String> for CodecError {
+    fn from(e: String) -> Self {
+        CodecError::String(e)
+    }
+}
+
+impl<'a> From<&'a str> for CodecError {
+    fn from(e: &'a str) -> Self {
+        CodecError::String(e.into())
+    }
+}
+
+// Hack so we can debug_assert_eq against Result<(), CodecError>.
+impl PartialEq for CodecError {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (CodecError::String(a), CodecError::String(b)) => a == b,
+            (CodecError::InvalidEncodingVersion(a), CodecError::InvalidEncodingVersion(b)) => {
+                a == b
+            }
+            _ => false,
+        }
+    }
+}

--- a/src/persist-types/src/error.rs
+++ b/src/persist-types/src/error.rs
@@ -12,7 +12,7 @@
 use std::{error, fmt};
 
 /// A Codec related error.
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum CodecError {
     /// An unstructured codec related error.
     String(String),
@@ -45,15 +45,20 @@ impl<'a> From<&'a str> for CodecError {
     }
 }
 
-// Hack so we can debug_assert_eq against Result<(), CodecError>.
-impl PartialEq for CodecError {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (CodecError::String(a), CodecError::String(b)) => a == b,
-            (CodecError::InvalidEncodingVersion(a), CodecError::InvalidEncodingVersion(b)) => {
-                a == b
-            }
-            _ => false,
-        }
+impl From<serde_json::Error> for CodecError {
+    fn from(e: serde_json::Error) -> Self {
+        CodecError::String(format!("decoding error: {}", e))
+    }
+}
+
+impl From<std::array::TryFromSliceError> for CodecError {
+    fn from(e: std::array::TryFromSliceError) -> Self {
+        CodecError::String(e.to_string())
+    }
+}
+
+impl From<std::string::FromUtf8Error> for CodecError {
+    fn from(e: std::string::FromUtf8Error) -> Self {
+        CodecError::String(e.to_string())
     }
 }

--- a/src/persist-types/src/lib.rs
+++ b/src/persist-types/src/lib.rs
@@ -17,6 +17,9 @@
 )]
 
 mod codec_impls;
+pub mod error;
+
+use crate::error::CodecError;
 
 /// Encoding and decoding operations for a type usable as a persisted key or
 /// value.
@@ -51,5 +54,5 @@ pub trait Codec: Sized + 'static {
     //
     // TODO: Mechanically, this could return a ref to the original bytes
     // without any copies, see if we can make the types work out for that.
-    fn decode<'a>(buf: &'a [u8]) -> Result<Self, String>;
+    fn decode<'a>(buf: &'a [u8]) -> Result<Self, CodecError>;
 }

--- a/src/persist/src/error.rs
+++ b/src/persist/src/error.rs
@@ -13,6 +13,8 @@ use std::ops::Range;
 use std::sync::Arc;
 use std::{error, fmt, io, sync};
 
+use persist_types::error::CodecError;
+
 use crate::storage::{Log, SeqNo};
 
 /// A persistence related error.
@@ -24,6 +26,8 @@ pub enum Error {
     OutOfQuota(String),
     /// An unstructured persistence related error.
     String(String),
+    /// An error returned when encoding or decoding data
+    Codec(CodecError),
     /// An error returned when a command is sent to a persistence runtime that
     /// was previously stopped.
     RuntimeShutdown,
@@ -37,6 +41,7 @@ impl fmt::Display for Error {
             Error::IO(e) => fmt::Display::fmt(e, f),
             Error::OutOfQuota(e) => f.write_str(e),
             Error::String(e) => f.write_str(e),
+            Error::Codec(e) => fmt::Display::fmt(e, f),
             Error::RuntimeShutdown => f.write_str("runtime shutdown"),
         }
     }
@@ -67,6 +72,12 @@ impl From<io::Error> for Error {
 impl From<String> for Error {
     fn from(e: String) -> Self {
         Error::String(e)
+    }
+}
+
+impl From<CodecError> for Error {
+    fn from(e: CodecError) -> Self {
+        Error::Codec(e)
     }
 }
 

--- a/src/persist/src/file.rs
+++ b/src/persist/src/file.rs
@@ -419,6 +419,10 @@ impl Blob for FileBlob {
             if let Some(name) = file_name {
                 let name = name.to_str();
                 if let Some(name) = name {
+                    // Exclude the lockfile from the user's list of keys.
+                    if name == Self::LOCKFILE_PATH {
+                        continue;
+                    }
                     ret.push(name.to_owned());
                 }
             }

--- a/src/persist/src/operators/source.rs
+++ b/src/persist/src/operators/source.rs
@@ -12,6 +12,7 @@
 use std::sync::mpsc::{self, Receiver, TryRecvError};
 use std::time::Duration;
 
+use ore::result::ResultExt;
 use persist_types::Codec;
 use timely::dataflow::operators::generic::operator;
 use timely::dataflow::operators::{Concat, Map};
@@ -114,8 +115,8 @@ where
                             if worker_index == 0 {
                                 for record in records.drain(..) {
                                     let ((k, v), ts, diff) = record;
-                                    let k = K::decode(&k).map_err(|e| e.to_string());
-                                    let v = V::decode(&v).map_err(|e| e.to_string());
+                                    let k = K::decode(&k).map_err_to_string();
+                                    let v = V::decode(&v).map_err_to_string();
                                     session.give(((k, v), ts, diff));
                                 }
                             }

--- a/src/persist/src/operators/source.rs
+++ b/src/persist/src/operators/source.rs
@@ -114,8 +114,8 @@ where
                             if worker_index == 0 {
                                 for record in records.drain(..) {
                                     let ((k, v), ts, diff) = record;
-                                    let k = K::decode(&k);
-                                    let v = V::decode(&v);
+                                    let k = K::decode(&k).map_err(|e| e.to_string());
+                                    let v = V::decode(&v).map_err(|e| e.to_string());
                                     session.give(((k, v), ts, diff));
                                 }
                             }

--- a/src/persist/src/s3.rs
+++ b/src/persist/src/s3.rs
@@ -315,6 +315,11 @@ impl Blob for S3Blob {
                 for object in contents.iter() {
                     if let Some(key) = object.key.as_ref() {
                         if let Some(key) = key.strip_prefix(&prefix) {
+                            // Exclude the system generated lock key from the user's
+                            // list of keys.
+                            if key == Self::LOCKFILE_KEY {
+                                continue;
+                            }
                             ret.push(key.to_string());
                         } else {
                             return Err(Error::from(format!(


### PR DESCRIPTION
### Motivation

This PR teaches the persistence codebase to clear out all previously persisted data if the previously persisted data was persisted using a different version of the binary encoding than we can currently decode. We are able to use such a primitive strategy (no forwards or backwards compat) because currently we are only persisting data that we can delete at any point in time.

### Tips for reviewer

This change is broken out into three logical commits that teach the `list_keys` method to only emit keys populated by users (and not any internal keys populated by the Blob implementor), add structured errors for `Codec`, and then a third commit that adds the "delete on version-mismatch" logic + tests.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
