### PR TITLE
persist: stronger invariant checking / new invariants with `list_keys`

### DIFF
--- a/src/persist/src/indexed/cache.rs
+++ b/src/persist/src/indexed/cache.rs
@@ -346,4 +346,9 @@ impl<B: Blob> BlobCache<B> {
         };
         err
     }
+
+    /// Returns the list of keys known to the underlying [Blob].
+    pub fn list_keys(&self) -> Result<Vec<String>, Error> {
+        block_on(self.blob.lock()?.list_keys())
+    }
 }


### PR DESCRIPTION
### Motivation

This pr adds two previously desired changes:

1. It upgrades all of the `debug_assert*` macro invocations in the persist crate to `soft_assert*` so those invariants can get checked in CI with release builds
2. It uses the new `list_keys` function to verify that all keys currently referenced by an unsealed or a trace actually exist in Blob (so we're not accidentally pointing to a already deleted key).