### PR TITLE
persist,dataflow: forward persistence errors from persist/upsert operators to differential error collections

### DIFF
--- a/src/persist/src/operators/stream.rs
+++ b/src/persist/src/operators/stream.rs
@@ -47,6 +47,12 @@ pub trait Persist<G: Scope<Timestamp = u64>, K: TimelyData, V: TimelyData> {
     ///
     /// **Note:** If you need to also replay persisted data when restarting, concatenate the output
     /// of this operator with the output of `replay()`.
+    ///
+    // TODO: The goal for the persistence operators is to have one combined output stream of
+    // `Result<T, E`. However, for operators that need to pass through all input updates, this
+    // seems excessively expensive if the input updates are not already wrapped in `Result`.  We
+    // therefore return two separate output streams for now but might want to reconsider this
+    // holistically, when/if we can already wrap all updates in `Result` at the source.
     fn persist(
         &self,
         name: &str,


### PR DESCRIPTION
It is not ideal that persistence errors end up in the same differential
error collection as other errors because they are transient/indefinite
errors that we should be treating differently. We do not, however, at
the current time have to infrastructure for treating these errors
differently, so we're adding them to the same error collections.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
