### PR TITLE
Allow even passed deploy steps to be manually retried

### DIFF
--- a/ci/deploy/pipeline.yml
+++ b/ci/deploy/pipeline.yml
@@ -15,11 +15,17 @@ steps:
       queue: builder
     concurrency: 1
     concurrency_group: deploy/devsite
+    retry:
+      manual:
+        permit_on_passed: true
 
   - command: bin/ci-builder run stable bin/pyactivate --dev -m ci.deploy.linux
     timeout_in_minutes: 30
     concurrency: 1
     concurrency_group: deploy/linux
+    retry:
+      manual:
+        permit_on_passed: true
 
   - command: bin/pyactivate --dev -m ci.deploy.macos
     agents:
@@ -27,11 +33,17 @@ steps:
     timeout_in_minutes: 30
     concurrency: 1
     concurrency_group: deploy/macos
+    retry:
+      manual:
+        permit_on_passed: true
 
   - command: bin/ci-builder run stable bin/pyactivate --dev -m ci.deploy.pypi
     timeout_in_minutes: 30
     concurrency: 1
     concurrency_group: deploy/pypi
+    retry:
+      manual:
+        permit_on_passed: true
 
   - label: ":bulb: Full SQL Logic Tests"
     trigger: sql-logic-tests
@@ -42,3 +54,6 @@ steps:
       branch: "$BUILDKITE_BRANCH"
       env:
         BUILDKITE_TAG: "$BUILDKITE_TAG"
+    retry:
+      manual:
+        permit_on_passed: true


### PR DESCRIPTION
If something in the release process goes wrong -- for example, if a corrupt .deb gets uploaded -- we may need to fix it manually and then re-run the corresponding deploy step. This allows us to do that without mucking around with the raw Buildkite API.