### PR TITLE
deps: upgrade to latest rdkafka version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3630,7 +3630,7 @@ dependencies = [
 [[package]]
 name = "rdkafka"
 version = "0.27.0"
-source = "git+https://github.com/fede1024/rust-rdkafka.git#a0d40d0f3bb399abb6b7546a7ab4e8f8604a613b"
+source = "git+https://github.com/fede1024/rust-rdkafka.git#f41af6c200e074b371c707c2deda71f32485f2aa"
 dependencies = [
  "futures",
  "libc",
@@ -3645,8 +3645,8 @@ dependencies = [
 
 [[package]]
 name = "rdkafka-sys"
-version = "4.1.0+1.7.0"
-source = "git+https://github.com/fede1024/rust-rdkafka.git#a0d40d0f3bb399abb6b7546a7ab4e8f8604a613b"
+version = "4.2.0+1.8.2"
+source = "git+https://github.com/fede1024/rust-rdkafka.git#f41af6c200e074b371c707c2deda71f32485f2aa"
 dependencies = [
  "cmake",
  "libc",


### PR DESCRIPTION
This fixes a statistics parsing glitch caused by an upstream bug in
librdkafka.