### PR TITLE
persist: add microbenchmarks for blob and indexed writes

### DIFF
--- a/src/persist/src/indexed/metrics.rs
+++ b/src/persist/src/indexed/metrics.rs
@@ -116,7 +116,7 @@ pub struct Metrics {
 
 impl Metrics {
     /// Returns a new [Metrics] instance connected to the given registry.
-    pub(crate) fn register_with(registry: &MetricsRegistry) -> Self {
+    pub fn register_with(registry: &MetricsRegistry) -> Self {
         Metrics {
             stream_count: registry.register_third_party_visible(metric!(
                 name: "mz_persist_stream_count",


### PR DESCRIPTION
persist: add microbenchmarks for blob and indexed writes

These benchmarks let us get a more granular look at what's taking up time when
persist is initially writing data out to disk in unsealed batches.

The `*_blob_set` benchmarks measure the time it takes each blob implementation to
write a binary blob containing approximately 8 MB of data.

mem_blob_set            time:   [2.7226 ms 2.9412 ms 3.1982 ms]

file_blob_set           time:   [28.515 ms 28.847 ms 29.176 ms]

The `*_blob_cache_set_unsealed_batch_{sorted,unsorted}` benchmarks measure the
amount of time it takes to encode 1 MM updates with 8 byte keys and write them to blob
cache, which is the principal encoding and IO work we do within `drain_pending`.

file_blob_cache_set_unsealed_batch_unsorted
                        time:   [107.74 ms 111.34 ms 114.92 ms]

mem_blob_cache_set_unsealed_batch_unsorted
                        time:   [50.857 ms 52.208 ms 53.577 ms]

file_blob_cache_set_unsealed_batch_sorted
                        time:   [162.09 ms 166.84 ms 171.94 ms]

mem_blob_cache_set_unsealed_batch_sorted
                        time:   [58.481 ms 59.479 ms 60.432 ms]

These benchmarks show the strange, and currently unexplained result that writing
down sorted batches is somehow slower than writing down sorted batches, for
batches that are otherwise identical. It's roughly 15% slower in mem blobs, and
30% slower in file blobs.

The `*_indexed_write_drain_{sorted,unsorted}` benchmarks measure the time it
takes to call `write` and `drain_pending` with 1 MM updates with 8 byte keys.

mem_indexed_write_drain_unsorted
                        time:   [461.98 ms 468.87 ms 476.32 ms]

file_indexed_write_drain_unsorted
                        time:   [505.51 ms 515.23 ms 525.31 ms]

mem_indexed_write_drain_sorted
                        time:   [304.19 ms 310.18 ms 317.93 ms]

file_indexed_write_drain_sorted
                        time:   [497.82 ms 501.45 ms 505.20 ms]

As we can see, sorting takes a substantial portion of the time in
the in-memory index. Strangely, this is not as reflected in the difference
between sorted and unsorted for the file index. However, removing all of the
sorting and consolidation before writing to an unsealed batch does result
in substantial speedups for all 4 of these benchmaeks.

