### PR TITLE
testdrive: introduce ${kafka-ingest.iteration} runtime variable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2226,6 +2226,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4617,6 +4623,7 @@ dependencies = [
  "kafka-util",
  "krb5-src",
  "lazy_static",
+ "maplit",
  "md-5",
  "mz-avro",
  "ore",

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -22,6 +22,7 @@ itertools = "0.10.1"
 kafka-util = { path = "../kafka-util" }
 krb5-src = { version = "0.2.3", features = ["binaries"] }
 lazy_static = "1.4.0"
+maplit = "1.0.2"
 md-5 = "0.9.0"
 mz-avro = { path = "../avro", features = ["snappy"] }
 ore = { path = "../ore" }

--- a/test/testdrive/testdrive.td
+++ b/test/testdrive/testdrive.td
@@ -1,3 +1,4 @@
+
 # Copyright Materialize, Inc. and contributors. All rights reserved.
 #
 # Use of this software is governed by the Business Source License
@@ -121,13 +122,20 @@ $ kafka-ingest format=avro topic=kafka-ingest-repeat schema=${kafka-ingest-repea
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE NONE
 
-> CREATE SINK kafka_ingest_repeat_sink FROM kafka_ingest_repeat_input
-  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'kafka-ingest-repeat'
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+> SELECT * FROM kafka_ingest_repeat_input;
+fish
+fish
 
-$ kafka-verify format=avro sink=materialize.public.kafka_ingest_repeat_sink sort-messages=true
-{"before":null,"after":{"row":{"f1":"fish"}}}
-{"before":null,"after":{"row":{"f1":"fish"}}}
+# kafka-ingest repeat with ${kafka-ingest.iteration}
+
+$ kafka-ingest format=avro topic=kafka-ingest-repeat schema=${kafka-ingest-repeat} publish=true repeat=2
+{"f1": "${kafka-ingest.iteration}"}
+
+> SELECT * FROM kafka_ingest_repeat_input;
+0
+1
+fish
+fish
 
 # kafka-ingest with no explicit 'partition' argument should spread the records evenly across the partitions
 
@@ -161,7 +169,7 @@ true
   AND rx_msgs > 0;
 true
 
-# kafka-verify with regexp (the set-regexp from above is used
+# kafka-verify with regexp (the set-regexp from above is used)
 
 > CREATE VIEW kafka_verify_regexp (a) AS VALUES ('u123'), ('u234');
 


### PR DESCRIPTION
If `$ kafka-ingest repeat=N` is used, the `${kafka-ingest.iteration}`
variable will be replaced at runtime with the number of the current
iteration. This way `$ kafka-ingest repeat=N` can be made to generate
N unique records that will not be folded into one by the upsert envelope.

### Motivation

I need a way to generate a lot of kafka messages to test the limits of the product and persistence. However, the records need to be unique, as 100K identical records will be folded into one by the upsert envelope.

To have  `$ kafka-ingest` to generate unique records, I special-cased the `${kafka-ingest.iteration}` variable to be evaluated at runtime.

### Tips for reviewer

I am totally unhappy with this code :-( but I was wondering if the time has arrived to introduce runtime variables in a general way (and dozens of lines of code to track and expand them) if only one such variable is currently needed. Please do advise.

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
