### PR TITLE
persist: rename Future to PFuture

### DIFF
--- a/src/persist/src/indexed/background.rs
+++ b/src/persist/src/indexed/background.rs
@@ -18,10 +18,10 @@ use timely::PartialOrder;
 use tokio::runtime::Runtime;
 
 use crate::error::Error;
-use crate::future::Future;
 use crate::indexed::cache::BlobCache;
 use crate::indexed::encoding::{BlobTraceBatch, TraceBatchMeta};
 use crate::indexed::trace::Trace;
+use crate::pfuture::PFuture;
 use crate::storage::Blob;
 
 /// A request to merge two trace batches and write the results to blob storage.
@@ -70,11 +70,11 @@ impl<B: Blob> Maintainer<B> {
 
     /// Asynchronously runs the requested compaction on the work pool provided
     /// at construction time.
-    pub fn compact_trace(&self, req: CompactTraceReq) -> Future<CompactTraceRes> {
-        let (tx, rx) = Future::new();
+    pub fn compact_trace(&self, req: CompactTraceReq) -> PFuture<CompactTraceRes> {
+        let (tx, rx) = PFuture::new();
         let blob = self.blob.clone();
         // Ignore the spawn_blocking response since we communicate
-        // success/failure through the returned Future.
+        // success/failure through the returned future.
         //
         // TODO: Push the spawn_blocking down into the cpu-intensive bits and
         // use spawn here once the storage traits are made async.

--- a/src/persist/src/indexed/cache.rs
+++ b/src/persist/src/indexed/cache.rs
@@ -20,11 +20,11 @@ use ore::cast::CastFrom;
 use persist_types::Codec;
 
 use crate::error::Error;
-use crate::future::Future;
 use crate::indexed::encoding::{
     BlobMeta, BlobTraceBatch, BlobUnsealedBatch, TraceBatchMeta, UnsealedBatchMeta,
 };
 use crate::indexed::metrics::{metric_duration_ms, Metrics};
+use crate::pfuture::PFuture;
 use crate::storage::Blob;
 
 /// A disk-backed cache for objects in [Blob] storage.
@@ -107,8 +107,8 @@ impl<B: Blob> BlobCache<B> {
 
     /// Asynchronously returns the batch for the given key, fetching in another
     /// thread if it's not already in the cache.
-    pub fn get_unsealed_batch_async(&self, key: &str) -> Future<Arc<BlobUnsealedBatch>> {
-        let (tx, rx) = Future::new();
+    pub fn get_unsealed_batch_async(&self, key: &str) -> PFuture<Arc<BlobUnsealedBatch>> {
+        let (tx, rx) = PFuture::new();
         {
             // New scope to ensure the cache lock is dropped during the
             // (expensive) get.
@@ -214,8 +214,8 @@ impl<B: Blob> BlobCache<B> {
 
     /// Asynchronously returns the batch for the given key, fetching in another
     /// thread if it's not already in the cache.
-    pub fn get_trace_batch_async(&self, key: &str) -> Future<Arc<BlobTraceBatch>> {
-        let (tx, rx) = Future::new();
+    pub fn get_trace_batch_async(&self, key: &str) -> PFuture<Arc<BlobTraceBatch>> {
+        let (tx, rx) = PFuture::new();
         {
             // New scope to ensure the cache lock is dropped during the
             // (expensive) get.

--- a/src/persist/src/indexed/trace.rs
+++ b/src/persist/src/indexed/trace.rs
@@ -22,11 +22,11 @@ use timely::PartialOrder;
 use uuid::Uuid;
 
 use crate::error::Error;
-use crate::future::Future;
 use crate::indexed::background::{CompactTraceReq, Maintainer};
 use crate::indexed::cache::BlobCache;
 use crate::indexed::encoding::{TraceBatchMeta, TraceMeta};
 use crate::indexed::{BlobTraceBatch, Id, Snapshot};
+use crate::pfuture::PFuture;
 use crate::storage::Blob;
 
 /// A persistent, compacting data structure containing `(Key, Value, Time,
@@ -300,7 +300,7 @@ pub struct TraceSnapshot {
     /// All updates not at times greater than this frontier must be advanced
     /// to a time that is equivalent to this frontier.
     pub since: Antichain<u64>,
-    batches: Vec<Future<Arc<BlobTraceBatch>>>,
+    batches: Vec<PFuture<Arc<BlobTraceBatch>>>,
 }
 
 impl Snapshot<Vec<u8>, Vec<u8>> for TraceSnapshot {
@@ -326,7 +326,7 @@ impl Snapshot<Vec<u8>, Vec<u8>> for TraceSnapshot {
 // important.
 pub struct TraceSnapshotIter {
     current_batch: Vec<((Vec<u8>, Vec<u8>), u64, isize)>,
-    batches: VecDeque<Future<Arc<BlobTraceBatch>>>,
+    batches: VecDeque<PFuture<Arc<BlobTraceBatch>>>,
 }
 
 impl Default for TraceSnapshotIter {

--- a/src/persist/src/indexed/unsealed.rs
+++ b/src/persist/src/indexed/unsealed.rs
@@ -20,10 +20,10 @@ use timely::PartialOrder;
 use uuid::Uuid;
 
 use crate::error::Error;
-use crate::future::Future;
 use crate::indexed::cache::BlobCache;
 use crate::indexed::encoding::{UnsealedBatchMeta, UnsealedMeta};
 use crate::indexed::{BlobUnsealedBatch, Id, Snapshot};
+use crate::pfuture::PFuture;
 use crate::storage::{Blob, SeqNo};
 
 /// A persistent, compacting data structure containing `(Key, Value, Time,
@@ -314,7 +314,7 @@ pub struct UnsealedSnapshot {
     pub ts_lower: Antichain<u64>,
     /// An open upper bound on the times of the contained updates.
     pub ts_upper: Antichain<u64>,
-    batches: Vec<Future<Arc<BlobUnsealedBatch>>>,
+    batches: Vec<PFuture<Arc<BlobUnsealedBatch>>>,
 }
 
 impl Snapshot<Vec<u8>, Vec<u8>> for UnsealedSnapshot {
@@ -350,7 +350,7 @@ pub struct UnsealedSnapshotIter {
     ts_upper: Antichain<u64>,
 
     current_batch: Vec<((Vec<u8>, Vec<u8>), u64, isize)>,
-    batches: VecDeque<Future<Arc<BlobUnsealedBatch>>>,
+    batches: VecDeque<PFuture<Arc<BlobUnsealedBatch>>>,
 }
 
 impl fmt::Debug for UnsealedSnapshotIter {

--- a/src/persist/src/lib.rs
+++ b/src/persist/src/lib.rs
@@ -20,10 +20,10 @@ use std::fmt;
 
 pub mod error;
 pub mod file;
-pub mod future;
 pub mod indexed;
 pub mod mem;
 pub mod operators;
+pub mod pfuture;
 pub mod s3;
 pub mod storage;
 pub mod unreliable;

--- a/src/persist/src/nemesis/mod.rs
+++ b/src/persist/src/nemesis/mod.rs
@@ -79,9 +79,9 @@ use rand::RngCore;
 use timely::progress::Antichain;
 
 use crate::error::Error;
-use crate::future::Future;
 use crate::nemesis::generator::{Generator, GeneratorConfig};
 use crate::nemesis::validator::Validator;
+use crate::pfuture::PFuture;
 use crate::storage::SeqNo;
 
 pub mod direct;
@@ -246,9 +246,9 @@ impl FutureStep {
 
 #[derive(Debug)]
 pub enum FutureRes {
-    Write(WriteReq, Result<Future<SeqNo>, Error>),
-    Seal(SealReq, Result<Future<()>, Error>),
-    AllowCompaction(AllowCompactionReq, Result<Future<()>, Error>),
+    Write(WriteReq, Result<PFuture<SeqNo>, Error>),
+    Seal(SealReq, Result<PFuture<()>, Error>),
+    AllowCompaction(AllowCompactionReq, Result<PFuture<()>, Error>),
     Ready(Res),
 }
 

--- a/src/persist/src/operators/stream.rs
+++ b/src/persist/src/operators/stream.rs
@@ -561,12 +561,12 @@ where
     }
 }
 
-enum PendingSealFuture<F: std::future::Future<Output = Result<(), Error>>> {
+enum PendingSealFuture<F: Future<Output = Result<(), Error>>> {
     PrimarySeal(SealFuture<F>),
     ConditionSeal(SealFuture<F>),
 }
 
-struct SealFuture<F: std::future::Future<Output = Result<(), Error>>> {
+struct SealFuture<F: Future<Output = Result<(), Error>>> {
     cap: Capability<u64>,
     future: F,
 }

--- a/src/persist/src/pfuture.rs
+++ b/src/persist/src/pfuture.rs
@@ -22,14 +22,14 @@ use crate::error::Error;
 /// Unlike [std::future::Future], the computation will complete even if this is
 /// dropped.
 #[derive(Debug)]
-pub struct Future<T>(oneshot::Receiver<Result<T, Error>>);
+pub struct PFuture<T>(oneshot::Receiver<Result<T, Error>>);
 
-impl<T> Future<T> {
-    /// Create a new instance of [Future], and the corresponding [FutureHandle]
-    /// to fill it.
-    pub fn new() -> (FutureHandle<T>, Future<T>) {
+impl<T> PFuture<T> {
+    /// Create a new instance of [PFuture], and the corresponding
+    /// [PFutureHandle] to fill it.
+    pub fn new() -> (PFutureHandle<T>, PFuture<T>) {
         let (tx, rx) = oneshot::channel();
-        (FutureHandle(tx), Future(rx))
+        (PFutureHandle(tx), PFuture(rx))
     }
 
     /// Blocks and synchronously receives the result.
@@ -40,7 +40,7 @@ impl<T> Future<T> {
     }
 }
 
-impl<T> std::future::Future for Future<T> {
+impl<T> std::future::Future for PFuture<T> {
     type Output = Result<T, Error>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -55,9 +55,9 @@ impl<T> std::future::Future for Future<T> {
 
 /// A handle for filling the result of an asynchronous computation.
 #[derive(Debug)]
-pub struct FutureHandle<T>(oneshot::Sender<Result<T, Error>>);
+pub struct PFutureHandle<T>(oneshot::Sender<Result<T, Error>>);
 
-impl<T> FutureHandle<T> {
+impl<T> PFutureHandle<T> {
     pub(crate) fn fill(self, res: Result<T, Error>) {
         // Don't care if the receiver hung up.
         let _ = self.0.send(res);


### PR DESCRIPTION
Petros found the duplicate name with std::future::Future confusing.

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
