### PR TITLE
persist: don't consolidate unsealed batches

### DIFF
--- a/src/persist/src/golden_test.rs
+++ b/src/persist/src/golden_test.rs
@@ -218,7 +218,8 @@ impl PersistState {
             let (_, read) = persist.create_or_load(&name)?;
             let snap = read.snapshot()?;
             let (seal, since) = (snap.get_seal(), snap.since());
-            let snap_data = snap.into_iter().collect::<Result<Vec<_>, Error>>()?;
+            let mut snap_data = snap.into_iter().collect::<Result<Vec<_>, Error>>()?;
+            differential_dataflow::consolidation::consolidate_updates(&mut snap_data);
             streams.push(PersistStreamState {
                 name,
                 seal,


### PR DESCRIPTION
Previously, we enforced the invariants that data stored in unsealed batches was
- sorted by (time, (key, val))
- consolidated, meaning that each instance of ((key, val), time) occurred exactly
  once.
- diffs were non-zero.

These invariants are potentially valuable in making trace batch construction
more efficient (since records are sorted by time you don't need to scan the entire
unsealed batch), improving the storage space utilization, and holding the data in
a canonical format that makes it trivial to compare if two unsealed batches are
identical. However, we were not using any of these properties currently, and they
were costing us a lot of CPU time in `drain_pending` to enforce, which was directly
contributing to write latency. Also, these properties are harder to enforce in a
columnar representation where its harder to sort and remove records.

This commit removes the three invariants mentioned above, and removes the parts
of drain_pending that enforced them.

mem_indexed_write_drain_sorted
                        time:   [237.57 ms 239.31 ms 241.10 ms]
                        change: [-13.368% -12.430% -11.469%] (p = 0.00 < 0.05)
                        
mem_indexed_write_drain_unsorted
                        time:   [263.83 ms 267.23 ms 270.80 ms]
                        change: [-46.222% -45.339% -44.445%] (p = 0.00 < 0.05)
                        
file_indexed_write_drain_sorted
                        time:   [360.92 ms 362.98 ms 365.07 ms]
                        change: [-10.657% -9.8504% -9.0228%] (p = 0.00 < 0.05)
                        
file_indexed_write_drain_unsorted
                        time:   [386.79 ms 391.11 ms 395.56 ms]
                        change: [-37.397% -36.510% -35.626%] (p = 0.00 < 0.05)

Note that the performance improvement is greater for the tests that write unsorted
data which is to be expected because the stdlib sort probably has some sort of
sortedness-detection that lets it skip a bunch of work when the input is pre-sorted.