### PR TITLE
Update mzcloud cli to latest cloud SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2505,7 +2505,7 @@ dependencies = [
 [[package]]
 name = "mzcloud"
 version = "1.0.0"
-source = "git+https://github.com/MaterializeInc/cloud-sdks#3e17e134530d27a57c0c48c0746709596d8fd6af"
+source = "git+https://github.com/MaterializeInc/cloud-sdks#9fad6bb7ae19eb1e714fc888d341e6355b98fc51"
 dependencies = [
  "reqwest",
  "serde",


### PR DESCRIPTION
This will include the enable_tailscale field in the responses from https://github.com/MaterializeInc/cloud-sdks/pull/11

Resolves https://github.com/MaterializeInc/cloud/issues/1531

### Motivation

  * This PR adds a known-desirable feature. https://github.com/MaterializeInc/cloud/issues/1531
  It includes the newly persisted enable_tailscale field in the responses added to the SDK in https://github.com/MaterializeInc/cloud-sdks/pull/11

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
