### PR TITLE
doc: fix release note race condition

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -103,6 +103,9 @@ List new features before bug fixes.
 
 {{% version-header v0.9.12 %}}
 
+- Add the [`date_bin`](/sql/functions/date-bin) function, which is similar to
+  `date_trunc` but supports "truncating" to arbitrary intervals.
+
 {{% version-header v0.9.11 %}}
 
 - Disallow `UPDATE` and `DELETE` operations on tables when boot in
@@ -112,9 +115,6 @@ List new features before bug fixes.
 
 - Support `SET` in transactions, as well as `SET LOCAL`. This unblocks
 a problem with PostgreSQL JDBC 42.3.0.
-
-- Add the [`date_bin`](/sql/functions/date-bin) function, which is similar to
-  `date_trunc` but supports "truncating" to arbitrary intervals.
 
 {{% version-header v0.9.10 %}}
 


### PR DESCRIPTION
This note got merged while the release process was running. It will
actually part of 0.9.12