### PR TITLE
pgwire: allow junk data after end of copy marker

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -113,6 +113,9 @@ List new features before bug fixes.
 
 - Add the `type_oid` column to [`mz_columns`](/sql/system-catalog#mz_columns).
 
+- When using [`COPY FROM`], allow extra data after the end of copy marker
+  (`\.`), but discard it. Previously, MZ would error in this case.
+
 {{% version-header v0.9.11 %}}
 
 - Disallow `UPDATE` and `DELETE` operations on tables when boot in
@@ -351,7 +354,7 @@ a problem with PostgreSQL JDBC 42.3.0.
 
 {{% version-header v0.8.0 %}}
 
-- Add the [`COPY FROM`](/sql/copy-from) statement, which allows populating a
+- Add the [`COPY FROM`] statement, which allows populating a
   table via the PostgreSQL [`COPY` protocol][pg-copy].
 
 - Stabilize the [`ARRAY`](/sql/types/array/#construction) constructor.
@@ -1447,6 +1450,7 @@ a problem with PostgreSQL JDBC 42.3.0.
 [`array`]: /sql/types/array/
 [`bytea`]: /sql/types/bytea
 [`ALTER INDEX`]: /sql/alter-index
+[`COPY FROM`]: /sql/copy-from
 [`CREATE INDEX`]: /sql/create-index
 [`CREATE MATERIALIZED VIEW`]: /sql/create-materialized-view
 [`CREATE SOURCE`]: /sql/create-source

--- a/doc/user/content/sql/copy-from.md
+++ b/doc/user/content/sql/copy-from.md
@@ -6,7 +6,7 @@ menu:
         parent: "sql"
 ---
 
-`COPY FROM` copies data into a table using the [Postgres COPY protocol](https://www.postgresql.org/docs/current/sql-copy.html).
+`COPY FROM` copies data into a table using the [Postgres `COPY` protocol](https://www.postgresql.org/docs/current/sql-copy.html).
 
 ## Syntax
 
@@ -24,11 +24,11 @@ Name | Default value | Description
 `DELIMITER` | tab character | Specifies the character that separates columns within each row (line) of the file.
 `NULL` | `\N` (backslash-N) | Specifies the string that represents a null value.
 
-Rows are expected in `text` format, one per line, with columns separated by the `DELIMITER` character.
+Rows are expected in `text` format, one per line, with columns separated by the
+`DELIMITER` character.
 
 ## Example
 
-
 ```sql
-COPY t FROM STDIN
+COPY t FROM STDIN WITH (DELIMITER '|')
 ```

--- a/test/pgtest/copy-from-2.pt
+++ b/test/pgtest/copy-from-2.pt
@@ -297,3 +297,28 @@ DataRow {"fields":["4","NULL"]}
 DataRow {"fields":["5","NULL"]}
 CommandComplete {"tag":"SELECT 5"}
 ReadyForQuery {"status":"I"}
+
+# ignore junk data after end of copy marker
+send
+Query {"query": "COPY t FROM STDIN"}
+CopyData "\\.\n"
+CopyData "invalid data\n"
+CopyDone
+Query {"query": "SELECT * FROM t ORDER BY i"}
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+----
+CopyIn {"format":"text","column_formats":["text","text"]}
+CommandComplete {"tag":"COPY 0"}
+ReadyForQuery {"status":"I"}
+RowDescription {"fields":[{"name":"i"},{"name":"t"}]}
+DataRow {"fields":["1","blah"]}
+DataRow {"fields":["2","NULL"]}
+DataRow {"fields":["3",""]}
+DataRow {"fields":["4","NULL"]}
+DataRow {"fields":["5","NULL"]}
+CommandComplete {"tag":"SELECT 5"}
+ReadyForQuery {"status":"I"}


### PR DESCRIPTION
### Motivation
This PR fixes a previously unreported bug.

Postgres allows for junk data after the end of copy marker, whereas Materialize did not. You could detect this difference by running the amended file against a locally running PG and MZ cluster; PG would succeed and MZ would error.

### Tips for reviewer

Run this change w/ MZ locally w/:

```
cargo run --bin pgtest -- test/pgtest/copy-from-2.pt
```

" " PG locally:

```
cargo run --bin pgtest -- --addr localhost:5432 --user postgres test/pgtest/copy-from-2.pt
```

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
