### PR TITLE
persist: give each mutating request a SeqNo

### DIFF
--- a/src/persist/src/error.rs
+++ b/src/persist/src/error.rs
@@ -24,6 +24,12 @@ pub enum Error {
     OutOfQuota(String),
     /// An unstructured persistence related error.
     String(String),
+    /// The associated write request was sequenced (given a SeqNo) and applied
+    /// to the persist state machine, but that application was deterministically
+    /// made into a no-op because it was contextually invalid (a write or seal
+    /// at a sealed timestamp, an allow_compactions at an unsealed timestamp,
+    /// etc).
+    Noop(SeqNo, String),
     /// An error returned when a command is sent to a persistence runtime that
     /// was previously stopped.
     RuntimeShutdown,
@@ -37,6 +43,7 @@ impl fmt::Display for Error {
             Error::IO(e) => fmt::Display::fmt(e, f),
             Error::OutOfQuota(e) => f.write_str(e),
             Error::String(e) => f.write_str(e),
+            Error::Noop(_, e) => f.write_str(e),
             Error::RuntimeShutdown => f.write_str("runtime shutdown"),
         }
     }

--- a/src/persist/src/indexed/encoding.rs
+++ b/src/persist/src/indexed/encoding.rs
@@ -73,6 +73,8 @@ pub struct BlobMeta {
     /// Invariant: For each UnsealedMeta in `unsealeds`, this is >= the last
     /// batch's upper. If they are not equal, there is logically an empty batch
     /// between [last batch's upper, unsealeds_seqno_upper).
+    ///
+    /// TODO: Rename this to seqno.
     pub unsealeds_seqno_upper: SeqNo,
     /// Internal stream id indexed by external stream name.
     ///
@@ -460,7 +462,7 @@ impl BlobMeta {
             let unsealed_seqno_upper = unsealed.seqno_upper();
             if !unsealed_seqno_upper.less_equal(&self.unsealeds_seqno_upper) {
                 return Err(Error::from(format!(
-                    "id {:?} unsealed seqno_upper {:?} is not less than the blob's unsealed_seqno_upper {:?}",
+                    "id {:?} unsealed seqno_upper {:?} is not less or equal to the blob's unsealed_seqno_upper {:?}",
                     id, unsealed_seqno_upper, self.unsealeds_seqno_upper,
                 )));
             }
@@ -1452,7 +1454,7 @@ mod tests {
         assert_eq!(
             b.validate(),
             Err(Error::from(
-                "id Id(0) unsealed seqno_upper Antichain { elements: [SeqNo(3)] } is not less than the blob's unsealed_seqno_upper SeqNo(2)"
+                "id Id(0) unsealed seqno_upper Antichain { elements: [SeqNo(3)] } is not less or equal to the blob's unsealed_seqno_upper SeqNo(2)"
             ))
         );
 

--- a/src/persist/src/indexed/trace.rs
+++ b/src/persist/src/indexed/trace.rs
@@ -156,13 +156,13 @@ impl Trace {
 
     /// Checks whether the given seal would be valid to pass to
     /// [Trace::update_seal].
-    pub fn validate_seal(&self, ts: u64) -> Result<(), Error> {
+    pub fn validate_seal(&self, ts: u64) -> Result<(), String> {
         let prev = self.get_seal();
         if !prev.less_equal(&ts) {
-            return Err(Error::from(format!(
+            return Err(format!(
                 "invalid seal for {:?}: {:?} not at or in advance of current seal frontier {:?}",
                 self.id, ts, prev
-            )));
+            ));
         }
         Ok(())
     }
@@ -175,19 +175,19 @@ impl Trace {
 
     /// Checks whether the given since would be valid to pass to
     /// [Trace::allow_compaction].
-    pub fn validate_allow_compaction(&self, since: &Antichain<u64>) -> Result<(), Error> {
+    pub fn validate_allow_compaction(&self, since: &Antichain<u64>) -> Result<(), String> {
         if PartialOrder::less_equal(&self.seal, since) {
-            return Err(Error::from(format!(
+            return Err(format!(
                 "invalid compaction at or in advance of trace seal {:?}: {:?}",
                 self.seal, since,
-            )));
+            ));
         }
 
         if PartialOrder::less_than(since, &self.since) {
-            return Err(Error::from(format!(
+            return Err(format!(
                 "invalid compaction less than trace since {:?}: {:?}",
                 self.since, since
-            )));
+            ));
         }
 
         Ok(())
@@ -432,15 +432,15 @@ mod tests {
 
         // Regress since frontier.
         assert_eq!(t.validate_allow_compaction(&Antichain::from_elem(5)),
-            Err(Error::from("invalid compaction less than trace since Antichain { elements: [6] }: Antichain { elements: [5] }")));
+            Err("invalid compaction less than trace since Antichain { elements: [6] }: Antichain { elements: [5] }".into()));
 
         // Advance since frontier to seal
         assert_eq!(t.validate_allow_compaction(&Antichain::from_elem(10)),
-            Err(Error::from("invalid compaction at or in advance of trace seal Antichain { elements: [10] }: Antichain { elements: [10] }")));
+            Err("invalid compaction at or in advance of trace seal Antichain { elements: [10] }: Antichain { elements: [10] }".into()));
 
         // Advance since frontier beyond seal
         assert_eq!(t.validate_allow_compaction(&Antichain::from_elem(11)),
-            Err(Error::from("invalid compaction at or in advance of trace seal Antichain { elements: [10] }: Antichain { elements: [11] }")));
+            Err("invalid compaction at or in advance of trace seal Antichain { elements: [10] }: Antichain { elements: [11] }".into()));
 
         Ok(())
     }
@@ -474,7 +474,7 @@ mod tests {
 
         // Regress seal frontier.
         assert_eq!(t.validate_seal(10),
-            Err(Error::from("invalid seal for Id(0): 10 not at or in advance of current seal frontier Antichain { elements: [11] }")));
+            Err("invalid seal for Id(0): 10 not at or in advance of current seal frontier Antichain { elements: [11] }".into()));
 
         Ok(())
     }

--- a/src/persist/src/nemesis/mod.rs
+++ b/src/persist/src/nemesis/mod.rs
@@ -143,10 +143,10 @@ pub enum Req {
 #[derive(Debug)]
 pub enum Res {
     Write(WriteReq, Result<WriteRes, Error>),
-    Seal(SealReq, Result<(), Error>),
+    Seal(SealReq, Result<SeqNo, Error>),
     ReadOutput(ReadOutputReq, Result<ReadOutputRes, Error>),
-    AllowCompaction(AllowCompactionReq, Result<(), Error>),
-    TakeSnapshot(TakeSnapshotReq, Result<(), Error>),
+    AllowCompaction(AllowCompactionReq, Result<SeqNo, Error>),
+    TakeSnapshot(TakeSnapshotReq, Result<SeqNo, Error>),
     ReadSnapshot(ReadSnapshotReq, Result<ReadSnapshotRes, Error>),
     Start(Result<(), Error>),
     Stop(Result<(), Error>),
@@ -248,8 +248,8 @@ impl FutureStep {
 #[derive(Debug)]
 pub enum FutureRes {
     Write(WriteReq, Result<PFuture<SeqNo>, Error>),
-    Seal(SealReq, Result<PFuture<()>, Error>),
-    AllowCompaction(AllowCompactionReq, Result<PFuture<()>, Error>),
+    Seal(SealReq, Result<PFuture<SeqNo>, Error>),
+    AllowCompaction(AllowCompactionReq, Result<PFuture<SeqNo>, Error>),
     Ready(Res),
 }
 

--- a/src/persist/src/nemesis/validator.rs
+++ b/src/persist/src/nemesis/validator.rs
@@ -309,7 +309,7 @@ impl Validator {
         }
     }
 
-    fn step_seal(&mut self, meta: &StepMeta, req: SealReq, res: Result<(), Error>) {
+    fn step_seal(&mut self, meta: &StepMeta, req: SealReq, res: Result<SeqNo, Error>) {
         let req_ok = req.ts
             >= self
                 .seal_frontier
@@ -330,7 +330,7 @@ impl Validator {
         &mut self,
         meta: &StepMeta,
         req: AllowCompactionReq,
-        res: Result<(), Error>,
+        res: Result<SeqNo, Error>,
     ) {
         let req_ok = req.ts
             >= self
@@ -358,7 +358,7 @@ impl Validator {
         &mut self,
         meta: &StepMeta,
         req: TakeSnapshotReq,
-        res: Result<(), Error>,
+        res: Result<SeqNo, Error>,
     ) {
         let require_succeed = self.uptime.storage_available(meta.before, meta.after)
             && self.uptime.runtime_available(meta.before, meta.after);
@@ -387,7 +387,7 @@ impl Validator {
                     let mut actual = res.contents;
                     let mut expected: Vec<((String, ()), u64, isize)> = self
                         .writes_by_seqno
-                        .range((stream.clone(), SeqNo(0))..(stream, SeqNo(res.seqno)))
+                        .range((stream.clone(), SeqNo(0))..=(stream, SeqNo(res.seqno)))
                         .flat_map(|(_, v)| v)
                         .cloned()
                         .collect();


### PR DESCRIPTION
Persist can be described as a state machine, with input state changes
being sequenced into a log. As an initial step in the direction of
structuring the implementation in those terms, give each request that
mutates state a unique SeqNo corresponding to the order it was applied.

This ordering also includes requests that were sequenced and applied to
the persist state machine, but that application was deterministically
made into a no-op because it was contextually invalid (a write or seal
at a sealed timestamp, an allow_compactions at an unsealed timestamp,
etc).

Read-only requests are assigned the SeqNo of a write, indicating that
all mutating requests up to and including that one are reflected in the
read state.

The immediate motivation for this is that it allows for much easier
post-hoc reasoning about behavior in the nemesis testing, but it also
will also tee us up for upcoming incremental meta work.
