### PR TITLE
coord,dataflow: separate coordinator and dataflow startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,6 +684,7 @@ name = "coordtest"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "build-info",
  "coord",
  "datadriven",
  "dataflow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2807,6 +2807,7 @@ dependencies = [
  "ctor",
  "either",
  "futures",
+ "lazy_static",
  "openssl",
  "pin-project",
  "prometheus",

--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -860,7 +860,7 @@ impl Catalog {
                 build_info: config.build_info,
                 num_workers: config.num_workers,
                 timestamp_frequency: config.timestamp_frequency,
-                now: config.now,
+                now: config.now.clone(),
                 disable_user_indexes: config.disable_user_indexes,
             },
             persist,
@@ -2877,6 +2877,7 @@ impl sql::catalog::CatalogItem for CatalogEntry {
 mod tests {
     use tempfile::NamedTempFile;
 
+    use ore::now::NOW_ZERO;
     use sql::names::{DatabaseSpecifier, FullName, PartialName};
 
     use crate::catalog::{Catalog, Op, MZ_CATALOG_SCHEMA, PG_CATALOG_SCHEMA};
@@ -2934,7 +2935,7 @@ mod tests {
         ];
 
         let catalog_file = NamedTempFile::new()?;
-        let catalog = Catalog::open_debug(catalog_file.path(), ore::now::now_zero)?;
+        let catalog = Catalog::open_debug(catalog_file.path(), NOW_ZERO.clone())?;
         for tc in test_cases {
             assert_eq!(
                 catalog
@@ -2955,7 +2956,7 @@ mod tests {
     #[test]
     fn test_catalog_revision() {
         let catalog_file = NamedTempFile::new().unwrap();
-        let mut catalog = Catalog::open_debug(catalog_file.path(), ore::now::now_zero).unwrap();
+        let mut catalog = Catalog::open_debug(catalog_file.path(), NOW_ZERO.clone()).unwrap();
         assert_eq!(catalog.transient_revision(), 1);
         catalog
             .transact(
@@ -2969,7 +2970,7 @@ mod tests {
         assert_eq!(catalog.transient_revision(), 2);
         drop(catalog);
 
-        let catalog = Catalog::open_debug(catalog_file.path(), ore::now::now_zero).unwrap();
+        let catalog = Catalog::open_debug(catalog_file.path(), NOW_ZERO.clone()).unwrap();
         assert_eq!(catalog.transient_revision(), 1);
     }
 }

--- a/src/coord/src/coord/prometheus.rs
+++ b/src/coord/src/coord/prometheus.rs
@@ -21,7 +21,7 @@ use tokio::time::{self, Duration};
 use tokio_stream::wrappers::IntervalStream;
 
 use ore::metrics::MetricsRegistry;
-use ore::now;
+use ore::now::{self, SYSTEM_TIME};
 use repr::{Datum, Diff, Row};
 
 use crate::catalog::builtin::{
@@ -213,7 +213,7 @@ impl Scraper {
     /// Scrapes the metrics once, producing a batch of updates that should be
     /// inserted into the `mz_metrics` table.
     pub fn scrape_once(&mut self) -> Vec<TimestampedUpdate> {
-        let now = now::system_time();
+        let now = SYSTEM_TIME();
         let timestamp = now::to_datetime(now);
 
         let metric_fams = self.registry.gather();

--- a/src/coord/src/lib.rs
+++ b/src/coord/src/lib.rs
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+#![cfg_attr(nightly_doc_features, feature(doc_cfg))]
+
 //! Coordinates client requests with the dataflow layer.
 //!
 //! This crate hosts the "coordinator", an object which sits at the center of
@@ -45,7 +47,7 @@ pub mod session;
 
 pub use crate::client::{Client, ConnClient, Handle, SessionClient};
 pub use crate::command::{Cancelled, ExecuteResponse, StartupMessage, StartupResponse};
-pub use crate::coord::{serve, serve_debug, Config, LoggingConfig};
+pub use crate::coord::{serve, Config, LoggingConfig};
 pub use crate::error::CoordError;
 pub use crate::persistcfg::{
     PersistConfig, PersistFileStorage, PersistS3Storage, PersistStorage, PersisterWithConfig,

--- a/src/coord/src/timestamp.rs
+++ b/src/coord/src/timestamp.rs
@@ -13,10 +13,10 @@ use std::ops::Deref;
 use std::panic;
 use std::str;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::TryRecvError;
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
-use std::sync::mpsc::TryRecvError;
 
 use anyhow::{bail, Context};
 use itertools::Itertools;

--- a/src/coord/src/timestamp.rs
+++ b/src/coord/src/timestamp.rs
@@ -16,6 +16,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
+use std::sync::mpsc::TryRecvError;
 
 use anyhow::{bail, Context};
 use itertools::Itertools;
@@ -92,7 +93,6 @@ lazy_static! {
 pub enum TimestampMessage {
     Add(GlobalId, SourceConnector),
     Drop(GlobalId),
-    Shutdown,
 }
 
 /// Timestamp consumer: wrapper around source consumers that stores necessary information
@@ -553,9 +553,9 @@ impl Timestamper {
     fn update_sources(&mut self) -> bool {
         // First check if there are some new source that we should
         // start checking
-        while let Ok(update) = self.rx.try_recv() {
-            match update {
-                TimestampMessage::Add(source_id, sc) => {
+        loop {
+            match self.rx.try_recv() {
+                Ok(TimestampMessage::Add(source_id, sc)) => {
                     let (sc, enc, env, cons) = if let SourceConnector::External {
                         connector,
                         encoding,
@@ -604,10 +604,11 @@ impl Timestamper {
                         }
                     }
                 }
-                TimestampMessage::Drop(id) => {
+                Ok(TimestampMessage::Drop(id)) => {
                     self.drop_source(id);
                 }
-                TimestampMessage::Shutdown => {
+                Err(TryRecvError::Empty) => return false,
+                Err(TryRecvError::Disconnected) => {
                     // First, let's remove all of the threads consuming metadata
                     // from realtime Kafka sources
                     for (_, src) in self.rt_sources.iter_mut() {
@@ -619,12 +620,10 @@ impl Timestamper {
                             coordination_state.stop.store(true, Ordering::SeqCst);
                         }
                     }
-
                     return true;
                 }
             }
         }
-        false
     }
 
     fn drop_source(&mut self, id: GlobalId) {

--- a/src/coord/tests/parameters.rs
+++ b/src/coord/tests/parameters.rs
@@ -13,6 +13,7 @@ use tempfile::NamedTempFile;
 
 use coord::catalog::Catalog;
 use ore::collections::CollectionExt;
+use ore::now::NOW_ZERO;
 use pgrepr::Type;
 use sql::plan::PlanContext;
 
@@ -92,7 +93,7 @@ fn test_parameter_type_inference() -> Result<(), Box<dyn Error>> {
     ];
 
     let catalog_file = NamedTempFile::new()?;
-    let catalog = Catalog::open_debug(catalog_file.path(), ore::now::now_zero)?;
+    let catalog = Catalog::open_debug(catalog_file.path(), NOW_ZERO.clone())?;
     let catalog = catalog.for_system_session();
     for (sql, types) in test_cases {
         let stmt = sql::parse::parse(sql)?.into_element();

--- a/src/coord/tests/sql.rs
+++ b/src/coord/tests/sql.rs
@@ -18,22 +18,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{cell::RefCell, collections::BTreeMap, rc::Rc};
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::rc::Rc;
 
-use expr::GlobalId;
-use repr::{RelationDesc, RelationType};
 use tempfile::NamedTempFile;
 
-use coord::{
-    catalog::{Catalog, CatalogItem, Table},
-    session::Session,
-};
-use sql::{
-    ast::{Expr, Statement},
-    names::{DatabaseSpecifier, FullName},
-    plan::{resolve_names, PlanContext, QueryContext, QueryLifetime, StatementContext},
-};
-use sql_parser::parser::parse_statements;
+use coord::catalog::{Catalog, CatalogItem, Table};
+use coord::session::Session;
+use expr::GlobalId;
+use ore::now::NOW_ZERO;
+use repr::{RelationDesc, RelationType};
+use sql::ast::{Expr, Statement};
+use sql::names::{DatabaseSpecifier, FullName};
+use sql::plan::{resolve_names, PlanContext, QueryContext, QueryLifetime, StatementContext};
 
 // This morally tests the name resolution stuff, but we need access to a
 // catalog.
@@ -44,7 +42,7 @@ fn datadriven() {
 
     walk("tests/testdata", |f| {
         let catalog_file = NamedTempFile::new().unwrap();
-        let mut catalog = Catalog::open_debug(catalog_file.path(), ore::now::now_zero).unwrap();
+        let mut catalog = Catalog::open_debug(catalog_file.path(), NOW_ZERO.clone()).unwrap();
         let mut id: u32 = 1;
         f.run(|test_case| -> String {
             match test_case.directive.as_str() {
@@ -77,7 +75,7 @@ fn datadriven() {
                     let sess = Session::dummy();
                     let catalog = catalog.for_session(&sess);
 
-                    let parsed = parse_statements(&test_case.input).unwrap();
+                    let parsed = sql::parse::parse(&test_case.input).unwrap();
                     let pcx = &PlanContext::zero();
                     let scx = StatementContext::new(
                         Some(pcx),

--- a/src/coordtest/Cargo.toml
+++ b/src/coordtest/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.44"
+build-info = { path = "../build-info" }
 coord = { path = "../coord" }
 datadriven = "0.6.0"
 dataflow = { path = "../dataflow" }

--- a/src/coordtest/src/lib.rs
+++ b/src/coordtest/src/lib.rs
@@ -61,23 +61,23 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs::{File, OpenOptions};
 use std::future::Future;
 use std::io::Write;
+use std::mem;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use anyhow::anyhow;
 use futures::future::FutureExt;
-use ore::metrics::MetricsRegistry;
-use tempfile::{NamedTempFile, TempDir};
+use tempfile::TempDir;
 use tokio::sync::mpsc;
 
-use coord::{
-    session::{EndTransactionAction, Session},
-    Client, ExecuteResponse, SessionClient, StartupResponse,
-};
+use build_info::DUMMY_BUILD_INFO;
+use coord::session::{EndTransactionAction, Session};
+use coord::{Client, ExecuteResponse, Handle, PersistConfig, SessionClient, StartupResponse};
 use dataflow::WorkerFeedback;
 use dataflow_types::PeekResponse;
 use expr::GlobalId;
-use ore::thread::JoinOnDropHandle;
+use ore::metrics::MetricsRegistry;
+use ore::now::NowFn;
 use repr::{Datum, Timestamp};
 use timely::progress::change_batch::ChangeBatch;
 
@@ -92,39 +92,61 @@ use timely::progress::change_batch::ChangeBatch;
 // down without ever panicing.
 pub struct CoordTest {
     coord_feedback_tx: mpsc::UnboundedSender<dataflow::Response>,
-    client: Option<Client>,
-    _handle: JoinOnDropHandle<()>,
+    client: Client,
+    _handle: Handle,
     dataflow_feedback_rx: mpsc::UnboundedReceiver<dataflow::Response>,
     // Keep a queue of messages in the order received from dataflow_feedback_rx so
     // we can safely modify or inject things and maintain original message order.
     queued_feedback: Vec<dataflow::Response>,
-    _catalog_file: NamedTempFile,
+    _data_directory: TempDir,
     temp_dir: TempDir,
     uppers: HashMap<GlobalId, Timestamp>,
     timestamp: Arc<Mutex<u64>>,
-    _verbose: bool,
-    _metrics_registry: MetricsRegistry,
+    verbose: bool,
     persisted_sessions: HashMap<String, (SessionClient, StartupResponse)>,
     deferred_results: HashMap<String, Vec<ExecuteResponse>>,
 }
 
 impl CoordTest {
     pub async fn new() -> anyhow::Result<Self> {
-        let catalog_file = NamedTempFile::new()?;
-        let metrics_registry = MetricsRegistry::new();
-        let (handle, client, coord_feedback_tx, dataflow_feedback_rx, timestamp) =
-            coord::serve_debug(catalog_file.path(), metrics_registry.clone());
+        let timestamp = Arc::new(Mutex::new(0));
+        let data_directory = tempfile::tempdir()?;
+        let (mut dataflow_feedback_tx, dataflow_feedback_rx) = mpsc::unbounded_channel();
+        let (coord_feedback_tx, mut coord_feedback_rx) = mpsc::unbounded_channel();
+        let (handle, client) = coord::serve(coord::Config {
+            workers: 1,
+            timely_worker: timely::WorkerConfig::default(),
+            symbiosis_url: None,
+            data_directory: data_directory.path(),
+            logging: None,
+            logical_compaction_window: None,
+            timestamp_frequency: Duration::from_millis(1),
+            experimental_mode: false,
+            disable_user_indexes: false,
+            safe_mode: false,
+            build_info: &DUMMY_BUILD_INFO,
+            metrics_registry: MetricsRegistry::new(),
+            persist: PersistConfig::disabled(),
+            now: {
+                let timestamp = timestamp.clone();
+                NowFn::from(move || *timestamp.lock().unwrap())
+            },
+            dataflow_response_interceptor: Some(Box::new(move |tx, rx| {
+                mem::swap(tx, &mut dataflow_feedback_tx);
+                mem::swap(rx, &mut coord_feedback_rx);
+            })),
+        })
+        .await?;
         let coordtest = CoordTest {
-            _handle: handle,
-            client: Some(client),
             coord_feedback_tx,
+            _handle: handle,
+            client,
             dataflow_feedback_rx,
-            _catalog_file: catalog_file,
+            _data_directory: data_directory,
             temp_dir: tempfile::tempdir().unwrap(),
             uppers: HashMap::new(),
-            _verbose: std::env::var_os("COORDTEST_VERBOSE").is_some(),
             timestamp,
-            _metrics_registry: metrics_registry,
+            verbose: std::env::var_os("COORDTEST_VERBOSE").is_some(),
             queued_feedback: Vec::new(),
             persisted_sessions: HashMap::new(),
             deferred_results: HashMap::new(),
@@ -133,7 +155,7 @@ impl CoordTest {
     }
 
     async fn connect(&self) -> anyhow::Result<(SessionClient, StartupResponse)> {
-        let conn_client = self.client.as_ref().unwrap().new_conn()?;
+        let conn_client = self.client.new_conn()?;
         let session = Session::new(conn_client.conn_id(), "materialize".into());
         Ok(conn_client.startup(session).await?)
     }
@@ -302,7 +324,7 @@ pub async fn run_test(mut tf: datadriven::TestFile) -> datadriven::TestFile {
     let ct = std::rc::Rc::new(std::cell::RefCell::new(CoordTest::new().await.unwrap()));
     tf.run_async(|tc| {
         let mut ct = ct.borrow_mut();
-        if ct._verbose {
+        if ct.verbose {
             println!("{} {:?}: {}", tc.directive, tc.args, tc.input);
         }
         async move {

--- a/src/dataflow/src/lib.rs
+++ b/src/dataflow/src/lib.rs
@@ -25,4 +25,6 @@ pub mod logging;
 pub mod source;
 
 pub use render::plan::Plan;
-pub use server::{serve, Command, Config, Response, TimestampBindingFeedback, WorkerFeedback};
+pub use server::{
+    serve, Client, Command, Config, Response, Server, TimestampBindingFeedback, WorkerFeedback,
+};

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -227,7 +227,7 @@ pub fn build_dataflow<A: Allocate>(
                     src_id.clone(),
                     src.clone(),
                     orig_id.clone(),
-                    now,
+                    now.clone(),
                     source_metrics,
                 );
             }

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -361,7 +361,7 @@ pub fn serve(config: Config) -> Result<WorkerGuards<()>, String> {
                 reported_bindings_frontiers: HashMap::new(),
                 last_bindings_feedback: Instant::now(),
                 metrics: server_metrics.for_worker_id(worker_idx),
-                now,
+                now: now.clone(),
                 dataflow_source_metrics,
                 dataflow_sink_metrics,
             }
@@ -878,7 +878,7 @@ where
                         self.timely_worker,
                         &mut self.render_state,
                         dataflow,
-                        self.now,
+                        self.now.clone(),
                         &self.dataflow_source_metrics,
                         &self.dataflow_sink_metrics,
                     );
@@ -1034,10 +1034,10 @@ where
                     ..
                 } = connector
                 {
-                    let byo_default = TimestampBindingRc::new(None, self.now, true);
+                    let byo_default = TimestampBindingRc::new(None, self.now.clone(), true);
                     let rt_default = TimestampBindingRc::new(
                         Some(ts_frequency.as_millis().try_into().unwrap()),
-                        self.now,
+                        self.now.clone(),
                         false,
                     );
                     match (connector, consistency) {

--- a/src/dataflow/src/source/timestamp.rs
+++ b/src/dataflow/src/source/timestamp.rs
@@ -866,6 +866,7 @@ impl TimestampBindingUpdater {
 mod tests {
     use dataflow_types::MzOffset;
     use expr::PartitionId;
+    use ore::now::NOW_ZERO;
     use persist_types::Codec;
     use timely::progress::Antichain;
 
@@ -909,7 +910,7 @@ mod tests {
 
     #[test]
     fn timestamp_updater_simple_updates() {
-        let timestamp_histories = TimestampBindingRc::new(None, || 0, false);
+        let timestamp_histories = TimestampBindingRc::new(None, NOW_ZERO.clone(), false);
         let mut timestamp_binding_updater = TimestampBindingUpdater::new(Vec::new());
 
         timestamp_histories.add_partition(PartitionId::Kafka(0), None);
@@ -953,7 +954,7 @@ mod tests {
     // timestamp history.
     #[test]
     fn timestamp_updater_repeated_update() {
-        let timestamp_histories = TimestampBindingRc::new(None, || 0, false);
+        let timestamp_histories = TimestampBindingRc::new(None, NOW_ZERO.clone(), false);
         let mut timestamp_binding_updater = TimestampBindingUpdater::new(Vec::new());
 
         timestamp_histories.add_partition(PartitionId::Kafka(0), None);
@@ -985,7 +986,7 @@ mod tests {
     // emitted changes.
     #[test]
     fn timestamp_updater_compaction() {
-        let mut timestamp_histories = TimestampBindingRc::new(None, || 0, false);
+        let mut timestamp_histories = TimestampBindingRc::new(None, NOW_ZERO.clone(), false);
         let mut timestamp_binding_updater = TimestampBindingUpdater::new(Vec::new());
 
         timestamp_histories.add_partition(PartitionId::Kafka(0), None);

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -29,6 +29,7 @@ use tokio_stream::wrappers::TcpListenerStream;
 use build_info::BuildInfo;
 use coord::LoggingConfig;
 use ore::metrics::MetricsRegistry;
+use ore::now::SYSTEM_TIME;
 use pid_file::PidFile;
 
 use crate::mux::Mux;
@@ -238,6 +239,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
         build_info: &BUILD_INFO,
         metrics_registry: config.metrics_registry.clone(),
         persist: config.persist,
+        now: SYSTEM_TIME.clone(),
     })
     .await?;
 

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -224,10 +224,19 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
     let listener = TcpListener::bind(&config.listen_addr).await?;
     let local_addr = listener.local_addr()?;
 
-    // Initialize coordinator.
-    let (coord_handle, coord_client) = coord::serve(coord::Config {
+    // Initialize dataflow server.
+    let (dataflow_server, dataflow_client) = dataflow::serve(dataflow::Config {
         workers,
         timely_worker: config.timely_worker,
+        experimental_mode: config.experimental_mode,
+        now: SYSTEM_TIME.clone(),
+        metrics_registry: config.metrics_registry.clone(),
+        response_interceptor: None,
+    })?;
+
+    // Initialize coordinator.
+    let (coord_handle, coord_client) = coord::serve(coord::Config {
+        dataflow_client,
         symbiosis_url: config.symbiosis_url.as_deref(),
         logging: config.logging,
         data_directory: &config.data_directory,
@@ -240,7 +249,6 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
         metrics_registry: config.metrics_registry.clone(),
         persist: config.persist,
         now: SYSTEM_TIME.clone(),
-        dataflow_response_interceptor: None,
     })
     .await?;
 
@@ -308,6 +316,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
         _pid_file: pid_file,
         _drain_trigger: drain_trigger,
         _coord_handle: coord_handle,
+        _dataflow_server: dataflow_server,
     })
 }
 
@@ -318,6 +327,7 @@ pub struct Server {
     // Drop order matters for these fields.
     _drain_trigger: oneshot::Sender<()>,
     _coord_handle: coord::Handle,
+    _dataflow_server: dataflow::Server,
 }
 
 impl Server {

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -240,6 +240,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
         metrics_registry: config.metrics_registry.clone(),
         persist: config.persist,
         now: SYSTEM_TIME.clone(),
+        dataflow_response_interceptor: None,
     })
     .await?;
 

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -26,6 +26,7 @@ chrono = { version = "0.4.0", default-features = false, features = ["std"], opti
 ctor = { version = "0.1.21", optional = true }
 either = "1.6.1"
 futures = { version = "0.3.17", optional = true }
+lazy_static = "1.4.0"
 # This isn't directly imported by anything, but it's required at link time. The
 # vendored feature is transitively depended upon by tokio-openssl.
 openssl = { version = "0.10.38", features = ["vendored"], optional = true  }

--- a/src/ore/src/future.rs
+++ b/src/ore/src/future.rs
@@ -26,9 +26,7 @@ use std::task::{Context, Poll};
 
 use futures::future::{Either, FutureExt, MapOk, TryFuture, TryFutureExt};
 use futures::sink::Sink;
-use futures::stream::{
-    self, Fuse, FuturesUnordered, Stream, StreamExt, StreamFuture, TryStream, TryStreamExt,
-};
+use futures::stream::{self, Stream, StreamExt, TryStream, TryStreamExt};
 use futures::{io, ready};
 
 /// Extension methods for futures.
@@ -231,23 +229,6 @@ pub trait OreStreamExt: Stream {
     {
         Drain(self)
     }
-
-    /// Flattens a stream of streams into one continuous stream, but does not
-    /// exhaust each incoming stream before moving on to the next.
-    ///
-    /// In other words, this is a combination of [`futures::stream::Flatten`] and
-    /// [`futures::stream::select`]. The streams may be interleaved in any order, but
-    /// the ordering within one of the underlying streams is preserved.
-    fn select_flatten(self) -> SelectFlatten<Self>
-    where
-        Self: Stream + Sized,
-        Self::Item: Stream + Unpin,
-    {
-        SelectFlatten {
-            incoming_streams: self.fuse(),
-            active_streams: FuturesUnordered::new(),
-        }
-    }
 }
 
 impl<S: Stream> OreStreamExt for S {}
@@ -282,68 +263,6 @@ where
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
         while ready!(Pin::new(&mut self.0).poll_next(cx)).is_some() {}
         Poll::Ready(())
-    }
-}
-
-/// The stream returned by [`OreStreamExt::select_flatten`].
-#[derive(Debug)]
-pub struct SelectFlatten<S>
-where
-    S: Stream,
-{
-    /// The stream of incoming streams.
-    incoming_streams: Fuse<S>,
-    /// The set of currently active streams that have been received from
-    /// `incoming_streams`. Streams are removed from the set when they are
-    /// closed.
-    active_streams: FuturesUnordered<StreamFuture<S::Item>>,
-}
-
-impl<S> Stream for SelectFlatten<S>
-where
-    S: Stream + Unpin,
-    S::Item: Stream + Unpin,
-{
-    type Item = <S::Item as Stream>::Item;
-
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
-        // First, drain the incoming stream queue.
-        while let Poll::Ready(Some(stream)) = self.incoming_streams.poll_next_unpin(cx) {
-            // New stream available. Add it to the set of active streams.
-            self.active_streams.push(stream.into_future())
-        }
-
-        // Second, try to find an item from a ready stream.
-        loop {
-            match self.active_streams.poll_next_unpin(cx) {
-                Poll::Ready(Some((Some(item), stream))) => {
-                    // An active stream yielded an item. Arrange to receive the
-                    // next item from the stream, then propagate the received
-                    // item.
-                    self.active_streams.push(stream.into_future());
-                    return Poll::Ready(Some(item));
-                }
-                Poll::Ready(Some((None, _stream))) => {
-                    // An active stream yielded a `None`, which means it has
-                    // terminated. Drop it on the floor. Then go around the loop
-                    // to see if another stream is ready.
-                }
-                Poll::Ready(None) => {
-                    if self.incoming_streams.is_done() {
-                        // There are no remaining active streams, and our
-                        // incoming stream queue is done too. We're good and
-                        // truly finished, so propagate the termination event.
-                        return Poll::Ready(None);
-                    } else {
-                        // There are no remaining active streams, but we might
-                        // yet get another stream from the incoming stream
-                        // queue. Indicate that we're not yet ready.
-                        return Poll::Pending;
-                    }
-                }
-                Poll::Pending => return Poll::Pending,
-            }
-        }
     }
 }
 

--- a/src/ore/src/now.rs
+++ b/src/ore/src/now.rs
@@ -9,26 +9,18 @@
 
 //! Now utilities.
 
+use std::fmt;
+use std::ops::Deref;
+use std::sync::Arc;
 use std::time::SystemTime;
+
+use lazy_static::lazy_static;
 
 #[cfg(feature = "chrono")]
 use chrono::{DateTime, TimeZone, Utc};
 
 /// A type representing the number of milliseconds since the Unix epoch.
 pub type EpochMillis = u64;
-
-/// A function that returns system or mocked time.
-pub type NowFn = fn() -> EpochMillis;
-
-/// Returns the current system time.
-pub fn system_time() -> EpochMillis {
-    SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .expect("failed to get millis since epoch")
-        .as_millis()
-        .try_into()
-        .expect("current time did not fit into u64")
-}
 
 /// Converts epoch milliseconds to a DateTime.
 #[cfg(feature = "chrono")]
@@ -37,7 +29,54 @@ pub fn to_datetime(millis: EpochMillis) -> DateTime<Utc> {
     Utc.timestamp(dur.as_secs() as i64, dur.subsec_nanos())
 }
 
-/// Returns zero.
-pub const fn now_zero() -> EpochMillis {
+/// A function that returns system or mocked time.
+// This is a newtype so that it can implement `Debug`, as closures don't
+// implement `Debug` by default. It derefs to a callable so that it is
+// ergonomically equivalent to a closure.
+#[derive(Clone)]
+pub struct NowFn(Arc<dyn Fn() -> EpochMillis + Send + Sync>);
+
+impl fmt::Debug for NowFn {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("<now_fn>")
+    }
+}
+
+impl Deref for NowFn {
+    type Target = dyn Fn() -> EpochMillis;
+
+    fn deref(&self) -> &Self::Target {
+        &(*self.0)
+    }
+}
+
+impl<F> From<F> for NowFn
+where
+    F: Fn() -> EpochMillis + Send + Sync + 'static,
+{
+    fn from(f: F) -> NowFn {
+        NowFn(Arc::new(f))
+    }
+}
+
+fn system_time() -> EpochMillis {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .expect("failed to get millis since epoch")
+        .as_millis()
+        .try_into()
+        .expect("current time did not fit into u64")
+}
+fn now_zero() -> EpochMillis {
     0
+}
+
+lazy_static! {
+    /// A [`NowFn`] that returns the actual system time.
+    pub static ref SYSTEM_TIME: NowFn = NowFn::from(system_time);
+
+    /// A [`NowFn`] that always returns zero.
+    ///
+    /// For use in tests.
+    pub static ref NOW_ZERO: NowFn = NowFn::from(now_zero);
 }

--- a/src/persist/examples/kafka_upsert.rs
+++ b/src/persist/examples/kafka_upsert.rs
@@ -20,7 +20,7 @@ use persist::operators::stream::Persist;
 use serde::{Deserialize, Serialize};
 
 use ore::metrics::MetricsRegistry;
-use ore::now::{system_time, NowFn};
+use ore::now::{NowFn, SYSTEM_TIME};
 use persist::error::Error as PersistError;
 use persist::file::{FileBlob, FileLog};
 use persist::indexed::runtime::{self, RuntimeClient, RuntimeConfig, StreamReadHandle};
@@ -123,7 +123,7 @@ where
 
     let source_interval_ms = 1000;
     let timestamp_interval_ms = 5000;
-    let now_fn = system_time;
+    let now_fn = SYSTEM_TIME.clone();
 
     let start_ts = cmp::min(sealed_ts(&ts_read)?, sealed_ts(&out_read)?);
     println!("Restored start timestamp: {}", start_ts);
@@ -218,7 +218,7 @@ where
     let mut source = S::new(
         starting_offsets,
         emission_interval_ms,
-        now_fn,
+        now_fn.clone(),
         worker_index,
         num_workers,
     );

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -11,9 +11,9 @@
 
 //! Catalog abstraction layer.
 
+use std::error::Error;
 use std::fmt;
 use std::time::{Duration, Instant};
-use std::{error::Error, unimplemented};
 
 use chrono::{DateTime, Utc, MIN_DATETIME};
 use dataflow_types::SourceConnector;
@@ -21,7 +21,7 @@ use lazy_static::lazy_static;
 
 use build_info::{BuildInfo, DUMMY_BUILD_INFO};
 use expr::{DummyHumanizer, ExprHumanizer, GlobalId, MirScalarExpr};
-use ore::now::{now_zero, EpochMillis, NowFn};
+use ore::now::{EpochMillis, NowFn, NOW_ZERO};
 use repr::{RelationDesc, ScalarType};
 use sql_parser::ast::{Expr, Raw};
 use uuid::Uuid;
@@ -377,7 +377,7 @@ lazy_static! {
         build_info: &DUMMY_BUILD_INFO,
         num_workers: 0,
         timestamp_frequency: Duration::from_secs(1),
-        now: now_zero,
+        now: NOW_ZERO.clone(),
         disable_user_indexes: false,
     };
 }

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -35,6 +35,7 @@ use serde::{Deserialize, Serialize};
 
 use ::expr::{GlobalId, RowSetFinishing};
 use dataflow_types::{SinkConnectorBuilder, SinkEnvelope, SourceConnector};
+use ore::now::{self, NOW_ZERO};
 use repr::{ColumnName, Diff, RelationDesc, Row, ScalarType, Timestamp};
 
 use crate::ast::{
@@ -491,7 +492,7 @@ impl PlanContext {
     /// tests.
     pub fn zero() -> Self {
         PlanContext {
-            wall_time: ore::now::to_datetime(ore::now::now_zero()),
+            wall_time: now::to_datetime(NOW_ZERO()),
         }
     }
 }

--- a/src/testdrive/src/action/sql.rs
+++ b/src/testdrive/src/action/sql.rs
@@ -23,6 +23,7 @@ use tokio_postgres::types::{FromSql, Type};
 
 use coord::catalog::Catalog;
 use ore::collections::CollectionExt;
+use ore::now::NOW_ZERO;
 use ore::retry::Retry;
 use pgrepr::{Interval, Jsonb, Numeric};
 use sql_parser::ast::{
@@ -167,7 +168,7 @@ impl Action for SqlAction {
                 | Statement::CreateView { .. }
                 | Statement::DropDatabase { .. }
                 | Statement::DropObjects { .. } => {
-                    let disk_state = Catalog::open_debug(path, ore::now::now_zero)
+                    let disk_state = Catalog::open_debug(path, NOW_ZERO.clone())
                         .map_err_to_string()?
                         .dump();
                     let mem_state = reqwest::get(&format!(


### PR DESCRIPTION
Rather than having the coordinator launch a dataflow server, have the
coordinator take in the client to an already-launched dataflow server.
This paves the way for separate dataflow and coordinator processes.

(Plus a bunch of preparatory commits.)

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

Go commit by commit.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
