### PR TITLE
Typo

### DIFF
--- a/doc/user/content/guides/cdc-mysql.md
+++ b/doc/user/content/guides/cdc-mysql.md
@@ -38,7 +38,8 @@ Before deploying a Debezium connector, you need to ensure that the upstream data
 
 ### Deploy Debezium
 
-Debezium is deployed as a set of Kafka Connect-compatible connectors, so you first need to define a MySQL connector configuration and then start the connector by adding it to Kafka Connect.
+Debezium is deployed as a set of Kafka Connect-compatible
+connectors, so you first need to define a MySQL connector configuration and then start the connector by adding it to Kafka Connect.
 
 {{< note >}}
 Currently, Materialize only supports Avro-encoded Debezium records. If you’re interested in JSON support, please reach out in the community Slack or leave a comment on [this GitHub issue](https://github.com/MaterializeInc/materialize/issues/5231).
@@ -73,8 +74,7 @@ Currently, Materialize only supports Avro-encoded Debezium records. If you’re 
 
     ```bash
     export CURRENT_HOST='<your-host>'
-
-    curl -i -X POST -H "Accept:application/json" -H  "Content-Type:application/json" \
+    curl -i -X POST -H "Accept:application/json" -H "Content-Type:application/json"
     http://$CURRENT_HOST:8083/connectors/ -d @register-mysql.json
     ```
 


### PR DESCRIPTION
 `curl -i -X POST -H "Accept:application/json" -H  "Content-Type:application/json"` is not showing up in the final output of the MySQL-CDC Guide even though it's in the source; I suspect a problem with the MD > HTML conversion and am testing out a fix.

### Motivation



  * This PR fixes a previously unreported bug.

Missing example code.



### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
