### PR TITLE
Fix failures in the cleanup script

### DIFF
--- a/ci/cleanup/aws.py
+++ b/ci/cleanup/aws.py
@@ -51,9 +51,14 @@ def clean_up_s3() -> None:
             )
             continue
         print("Deleting bucket {} (age={})".format(desc["Name"], age))
-        bucket = boto3.resource("s3").Bucket(desc["Name"])
-        bucket.objects.all().delete()
-        bucket.delete()
+        try:
+            bucket = boto3.resource("s3").Bucket(desc["Name"])
+            bucket.objects.all().delete()
+            bucket.delete()
+        except client.exceptions.NoSuchBucket:
+            print(
+                f"Couldn't delete {desc['Name']}: NoSuchBucket. This might be a transient issue."
+            )
 
 
 def clean_up_sqs() -> None:


### PR DESCRIPTION
Phantom buckets that were previously deleted can still show up:

https://aws.amazon.com/premiumsupport/knowledge-center/s3-listing-deleted-bucket/

This should fix the errors observed here: https://buildkite.com/materialize/cleanup/builds/576#f46fbcfb-97b9-4e24-aabf-be2280b4fc9d