### PR TITLE
test: Add Kafka partitions, records and envelopes to the product limi…

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -54,4 +54,4 @@
     - ./ci/plugins/mzcompose:
         composition: limits
         run: limits
-  timeout_in_minutes: 20
+  timeout_in_minutes: 40


### PR DESCRIPTION
…ts test


### Motivation

The product limits test did not include stretching the product in any Kafka dimensions, except the number of Kafka topics.

So add Kafka topics as well as well as both the None and the Upsert envelopes to the list of dimensions tested by the product limits test.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
