### PR TITLE
sql: add information_schema._pg_expandarray

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -51,8 +51,8 @@ use transform::Optimizer;
 use uuid::Uuid;
 
 use crate::catalog::builtin::{
-    Builtin, BUILTINS, BUILTIN_ROLES, MZ_CATALOG_SCHEMA, MZ_INTERNAL_SCHEMA, MZ_TEMP_SCHEMA,
-    PG_CATALOG_SCHEMA,
+    Builtin, BUILTINS, BUILTIN_ROLES, INFORMATION_SCHEMA, MZ_CATALOG_SCHEMA, MZ_INTERNAL_SCHEMA,
+    MZ_TEMP_SCHEMA, PG_CATALOG_SCHEMA,
 };
 use crate::persistcfg::{PersistConfig, PersistDetails, PersistMultiDetails, PersisterWithConfig};
 use crate::session::{PreparedStatement, Session};
@@ -2621,6 +2621,7 @@ impl SessionCatalog for ConnCatalog<'_> {
                 .iter()
                 .filter(|s| {
                     (**s != PG_CATALOG_SCHEMA)
+                        && (**s != INFORMATION_SCHEMA)
                         && (**s != MZ_CATALOG_SCHEMA)
                         && (**s != MZ_TEMP_SCHEMA)
                         && (**s != MZ_INTERNAL_SCHEMA)

--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -35,6 +35,7 @@ pub const MZ_TEMP_SCHEMA: &str = "mz_temp";
 pub const MZ_CATALOG_SCHEMA: &str = "mz_catalog";
 pub const PG_CATALOG_SCHEMA: &str = "pg_catalog";
 pub const MZ_INTERNAL_SCHEMA: &str = "mz_internal";
+pub const INFORMATION_SCHEMA: &str = "information_schema";
 
 pub enum Builtin {
     Log(&'static BuiltinLog),
@@ -1684,6 +1685,7 @@ lazy_static! {
 
         for (schema, funcs) in &[
             (PG_CATALOG_SCHEMA, &*sql::func::PG_CATALOG_BUILTINS),
+            (INFORMATION_SCHEMA, &*sql::func::INFORMATION_SCHEMA_BUILTINS),
             (MZ_CATALOG_SCHEMA, &*sql::func::MZ_CATALOG_BUILTINS),
             (MZ_INTERNAL_SCHEMA, &*sql::func::MZ_INTERNAL_BUILTINS),
         ] {

--- a/src/coord/src/catalog/storage.rs
+++ b/src/coord/src/catalog/storage.rs
@@ -120,6 +120,11 @@ const MIGRATIONS: &[&str] = &[
         offset blob NOT NULL,
         PRIMARY KEY (sid, pid, timestamp, offset)
     );",
+    // Makes the information_schema schema literal so it can store functions.
+    //
+    // Introduced in v0.9.12.
+    "INSERT INTO schemas (database_id, name) VALUES
+        (NULL, 'information_schema');",
     // Add new migrations here.
     //
     // Migrations should be preceded with a comment of the following form:

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -456,3 +456,87 @@ EXPLAIN PLAN FOR SELECT generate_series FROM generate_series(-2::bigint, 2::bigi
 | Constant (0) (2) (-2)
 
 EOF
+
+# information_schema._pg_expandarray
+
+query error scalar position not yet supported
+SELECT information_schema._pg_expandarray()
+
+query error arguments cannot be implicitly cast
+SELECT * FROM information_schema._pg_expandarray()
+
+query error scalar position not yet supported
+SELECT information_schema._pg_expandarray(ARRAY[])
+
+query error cannot determine type of empty array
+SELECT * FROM information_schema._pg_expandarray(ARRAY[])
+
+query error arguments cannot be implicitly cast
+SELECT * FROM information_schema._pg_expandarray(NULL)
+
+query error scalar position not yet supported
+SELECT information_schema._pg_expandarray(NULL)
+
+query error scalar position not yet supported
+SELECT information_schema._pg_expandarray(ARRAY[]::int[])
+----
+_pg_expandarray
+
+query TI colnames
+SELECT * FROM information_schema._pg_expandarray(ARRAY[]::int[])
+----
+x  n
+
+query error scalar position not yet supported
+SELECT information_schema._pg_expandarray(ARRAY[100])
+
+query TI
+SELECT * FROM information_schema._pg_expandarray(ARRAY[100])
+----
+100 1
+
+query error scalar position not yet supported
+SELECT information_schema._pg_expandarray(ARRAY[2, 1]) ORDER BY 1
+
+query II
+SELECT * FROM information_schema._pg_expandarray(ARRAY[2, 1]) ORDER BY x
+----
+1 2
+2 1
+
+query error scalar position not yet supported
+SELECT information_schema._pg_expandarray(ARRAY[3, 2, 1])
+
+query II
+SELECT * FROM information_schema._pg_expandarray(ARRAY[3, 2, 1]) ORDER BY x
+----
+1 3
+2 2
+3 1
+
+query error scalar position not yet supported
+SELECT information_schema._pg_expandarray(ARRAY['a'])
+
+query TI
+SELECT * FROM information_schema._pg_expandarray(ARRAY['a'])
+----
+a 1
+
+query error scalar position not yet supported
+SELECT information_schema._pg_expandarray(ARRAY['b', 'a'])
+
+query TI
+SELECT * FROM information_schema._pg_expandarray(ARRAY['b', 'a']) ORDER BY x
+----
+a 2
+b 1
+
+query error scalar position not yet supported
+SELECT information_schema._pg_expandarray(ARRAY['c', 'b', 'a'])
+
+query TI
+SELECT * FROM information_schema._pg_expandarray(ARRAY['c', 'b', 'a']) ORDER BY x
+----
+a 3
+b 2
+c 1

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -15,6 +15,7 @@ public
 > SHOW EXTENDED SCHEMAS
 name
 -------
+information_schema
 public
 mz_catalog
 mz_internal


### PR DESCRIPTION
Add the information_schema schema, as this is its first function.

Add a new Func variant that's similar to table funcs, but directly
exposes a relation expr and scope. Add a function that can produce the
appropriate expr given a SQL statement, allowing us to implement this
function in a way similar to Postgres.

Although we have added support for _pg_expandarray, it's still not yet
enough to support PgJDBC, which needs #1546. However we can add the
FROM-side support for this function now, and separately implement 1546
which will turn this on.

### Motivation

  * This PR adds a known-desirable feature. #4506

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
