### PR TITLE
Run tests with nocapture

### DIFF
--- a/ci/test/cargo-test/image/run-tests
+++ b/ci/test/cargo-test/image/run-tests
@@ -20,7 +20,7 @@ ci_init
 
 while read -r binary cwd; do
     cd "$cwd"
-    ci_try "/tests/$binary"
+    ci_try "/tests/$binary" --nocapture
     cd "$OLDPWD"
 done < /tests/manifest
 


### PR DESCRIPTION
This should allow us to verify the hypothesis that `test_no_block` is panicking in CI.

Discussion in #engineering : https://materializeinc.slack.com/archives/CM7ATT65S/p1635964379050900