### PR TITLE
sql: fix reduction elision optimization on STRING_AGG reduction

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -127,6 +127,8 @@ List new features before bug fixes.
   [`mz_kafka_source_statistics`](/sql/system-catalog#mz_kafka_source_statistics),
   containing raw statistics from the underlying librdkafka library.
 
+- Fix a bug that caused a panic when using a query containing `STRING_AGG`
+
 {{% version-header v0.9.11 %}}
 
 - Disallow `UPDATE` and `DELETE` operations on tables when boot in

--- a/src/transform/src/reduce_elision.rs
+++ b/src/transform/src/reduce_elision.rs
@@ -26,16 +26,13 @@ impl crate::Transform for ReduceElision {
         relation: &mut MirRelationExpr,
         _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
-        relation.visit_mut(&mut |e| {
-            self.action(e);
-        });
-        Ok(())
+        relation.try_visit_mut(&mut |e| self.action(e))
     }
 }
 
 impl ReduceElision {
     /// Removes `Reduce` when the input has as unique keys the keys of the reduce.
-    pub fn action(&self, relation: &mut MirRelationExpr) {
+    pub fn action(&self, relation: &mut MirRelationExpr) -> Result<(), crate::TransformError> {
         if let MirRelationExpr::Reduce {
             input,
             group_key,
@@ -45,6 +42,7 @@ impl ReduceElision {
         } = relation
         {
             let input_type = input.typ();
+
             if input_type.keys.iter().any(|keys| {
                 keys.iter()
                     .all(|k| group_key.contains(&expr::MirScalarExpr::Column(*k)))
@@ -57,7 +55,7 @@ impl ReduceElision {
                         // Count is one if non-null, and zero if null.
                         AggregateFunc::Count => {
                             let column_type = a.typ(&input_type);
-                            a.expr
+                            Ok(a.expr
                                 .clone()
                                 .call_unary(UnaryFunc::IsNull(func::IsNull))
                                 .if_then_else(
@@ -69,30 +67,30 @@ impl ReduceElision {
                                         Datum::Int64(1),
                                         column_type.scalar_type,
                                     ),
-                                )
+                                ))
                         }
 
                         // SumInt16 takes Int16s as input, but outputs Int64s.
                         AggregateFunc::SumInt16 => {
-                            a.expr.clone().call_unary(UnaryFunc::CastInt16ToInt64)
+                            Ok(a.expr.clone().call_unary(UnaryFunc::CastInt16ToInt64))
                         }
 
                         // SumInt32 takes Int32s as input, but outputs Int64s.
                         AggregateFunc::SumInt32 => {
-                            a.expr.clone().call_unary(UnaryFunc::CastInt32ToInt64)
+                            Ok(a.expr.clone().call_unary(UnaryFunc::CastInt32ToInt64))
                         }
 
                         // SumInt64 takes Int64s as input, but outputs numerics.
-                        AggregateFunc::SumInt64 => a
+                        AggregateFunc::SumInt64 => Ok(a
                             .expr
                             .clone()
-                            .call_unary(UnaryFunc::CastInt64ToNumeric(Some(0))),
+                            .call_unary(UnaryFunc::CastInt64ToNumeric(Some(0)))),
 
                         // JsonbAgg takes _anything_ as input, but must output a Jsonb array.
-                        AggregateFunc::JsonbAgg { .. } => MirScalarExpr::CallVariadic {
+                        AggregateFunc::JsonbAgg { .. } => Ok(MirScalarExpr::CallVariadic {
                             func: VariadicFunc::JsonbBuildArray,
                             exprs: vec![a.expr.clone()],
-                        },
+                        }),
 
                         // StringAgg takes nested records of strings and outputs a string
                         AggregateFunc::StringAgg { .. } => {
@@ -106,22 +104,25 @@ impl ReduceElision {
                                     ref exprs,
                                 } = exprs[0]
                                 {
-                                    exprs[0].clone()
+                                    Ok(exprs[0].clone())
                                 } else {
-                                    panic!(
+                                    Err(crate::TransformError::Internal(format!(
                                         "need nested RecordCreate as expr for StringAgg {:?}",
                                         a.expr,
-                                    )
+                                    )))
                                 }
                             } else {
-                                panic!("need RecordCreate as expr for StringAgg {:?}", a.expr,)
+                                Err(crate::TransformError::Internal(format!(
+                                    "need RecordCreate as expr for StringAgg {:?}",
+                                    a.expr,
+                                )))
                             }
                         }
 
                         // All other variants should return the argument to the aggregation.
-                        _ => a.expr.clone(),
+                        _ => Ok(a.expr.clone()),
                     })
-                    .collect::<Vec<_>>();
+                    .collect::<Result<Vec<_>, _>>()?;
 
                 let mut result = input.take_dangerous();
 
@@ -138,5 +139,7 @@ impl ReduceElision {
                 *relation = result;
             }
         }
+
+        Ok(())
     }
 }

--- a/src/transform/src/reduce_elision.rs
+++ b/src/transform/src/reduce_elision.rs
@@ -42,7 +42,6 @@ impl ReduceElision {
         } = relation
         {
             let input_type = input.typ();
-
             if input_type.keys.iter().any(|keys| {
                 keys.iter()
                     .all(|k| group_key.contains(&expr::MirScalarExpr::Column(*k)))

--- a/src/transform/src/reduce_elision.rs
+++ b/src/transform/src/reduce_elision.rs
@@ -15,7 +15,6 @@
 
 use crate::TransformArgs;
 use expr::{func, MirRelationExpr, MirScalarExpr};
-use repr::{ColumnType, ScalarType};
 
 /// Removes `Reduce` when the input has as unique keys the keys of the reduce.
 #[derive(Debug)]

--- a/test/sqllogictest/aggregates.slt
+++ b/test/sqllogictest/aggregates.slt
@@ -398,3 +398,22 @@ FROM
     v
 ----
 {"0":"c","1":"a","2":"b"}  {"0":"c","1":"a","2":"d"}  {"0":"c","1":"a","2":"d"}  {"0":"c","1":"a","2":"b"}
+
+
+# Test Reduction elision
+
+statement ok
+CREATE TABLE a (x text)
+
+statement ok
+INSERT INTO a VALUES ('a'),('b')
+
+query T
+SELECT STRING_AGG(y, ', ') FROM (SELECT x as y FROM a);
+----
+a, b
+
+query T
+SELECT STRING_AGG(y, ', ') FROM (SELECT x as y FROM a limit 1);
+----
+a

--- a/test/sqllogictest/aggregates.slt
+++ b/test/sqllogictest/aggregates.slt
@@ -412,12 +412,12 @@ statement ok
 CREATE TABLE qs (q int not null)
 
 query T
-SELECT STRING_AGG(y, ',') FROM (SELECT x as y FROM a ORDER BY x);
+SELECT STRING_AGG(x, ',') FROM (SELECT * FROM a ORDER BY x);
 ----
 a,b
 
 query T
-SELECT STRING_AGG(y, ',') FROM (SELECT x as y FROM a ORDER BY x limit 1);
+SELECT STRING_AGG(x, ',') FROM (SELECT * FROM a ORDER BY x limit 1);
 ----
 a
 

--- a/test/sqllogictest/aggregates.slt
+++ b/test/sqllogictest/aggregates.slt
@@ -409,11 +409,11 @@ statement ok
 INSERT INTO a VALUES ('a'),('b')
 
 query T
-SELECT STRING_AGG(y, ', ') FROM (SELECT x as y FROM a);
+SELECT STRING_AGG(y, ',') FROM (SELECT x as y FROM a ORDER BY x);
 ----
-a, b
+a,b
 
 query T
-SELECT STRING_AGG(y, ', ') FROM (SELECT x as y FROM a limit 1);
+SELECT STRING_AGG(y, ',') FROM (SELECT x as y FROM a ORDER BY x limit 1);
 ----
 a

--- a/test/sqllogictest/aggregates.slt
+++ b/test/sqllogictest/aggregates.slt
@@ -408,6 +408,9 @@ CREATE TABLE a (x text)
 statement ok
 INSERT INTO a VALUES ('a'),('b')
 
+statement ok
+CREATE TABLE qs (q int not null)
+
 query T
 SELECT STRING_AGG(y, ',') FROM (SELECT x as y FROM a ORDER BY x);
 ----
@@ -417,3 +420,18 @@ query T
 SELECT STRING_AGG(y, ',') FROM (SELECT x as y FROM a ORDER BY x limit 1);
 ----
 a
+
+query T
+SELECT STRING_AGG(x, ',') FROM (SELECT * FROM (SELECT 'a' as x UNION ALL SELECT 'b' as x) ORDER BY x)
+----
+a,b
+
+query T
+SELECT STRING_AGG(x, ',') FROM (SELECT * FROM (SELECT 'a' as x UNION ALL SELECT 'b' as x) ORDER BY x limit 1)
+----
+a
+
+query T
+SELECT STRING_AGG(x, ',') from (SELECT TRUE::text as x FROM(SELECT AVG(0) FROM qs))
+----
+true


### PR DESCRIPTION
fix reduction elision optimization on STRING_AGG (introduced in #7959) reduction. Prevent the system from crashing.

<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

This is part of #8595.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
