### PR TITLE
ore: introduce a test::timeout helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2807,6 +2807,7 @@ dependencies = [
 name = "ore"
 version = "0.0.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "bytes",
  "chrono",

--- a/src/materialized/tests/server.rs
+++ b/src/materialized/tests/server.rs
@@ -125,7 +125,7 @@ fn test_experimental_mode_reboot() -> Result<(), Box<dyn Error>> {
                     .to_string()
                     .contains("Materialize previously started with --experimental")
                 {
-                    return Err(e);
+                    return Err(e.into());
                 }
             }
         }
@@ -156,7 +156,7 @@ fn test_experimental_mode_on_init_or_never() -> Result<(), Box<dyn Error>> {
                     .to_string()
                     .contains("Experimental mode is only available on new nodes")
                 {
-                    return Err(e);
+                    return Err(e.into());
                 }
             }
         }
@@ -177,7 +177,7 @@ fn test_pid_file() -> Result<(), Box<dyn Error>> {
         Ok(_) => panic!("unexpected success"),
         Err(e) => {
             if !e.to_string().contains("process already running") {
-                return Err(e);
+                return Err(e.into());
             }
         }
     }

--- a/src/materialized/tests/util.rs
+++ b/src/materialized/tests/util.rs
@@ -104,7 +104,7 @@ impl Config {
     }
 }
 
-pub fn start_server(config: Config) -> Result<Server, Box<dyn Error>> {
+pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
     let runtime = Arc::new(Runtime::new()?);
     let (data_directory, temp_dir) = match config.data_directory {
         None => {
@@ -181,7 +181,7 @@ impl Server {
         config
     }
 
-    pub fn connect<T>(&self, tls: T) -> Result<postgres::Client, Box<dyn Error>>
+    pub fn connect<T>(&self, tls: T) -> Result<postgres::Client, anyhow::Error>
     where
         T: MakeTlsConnect<Socket> + Send + 'static,
         T::TlsConnect: Send,
@@ -194,7 +194,7 @@ impl Server {
     pub async fn connect_async<T>(
         &self,
         tls: T,
-    ) -> Result<(tokio_postgres::Client, tokio::task::JoinHandle<()>), Box<dyn Error>>
+    ) -> Result<(tokio_postgres::Client, tokio::task::JoinHandle<()>), anyhow::Error>
     where
         T: MakeTlsConnect<Socket> + Send + 'static,
         T::TlsConnect: Send,

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -11,7 +11,7 @@ default = ["network", "chrono", "cli", "metrics", "test"]
 cli = ["structopt"]
 metrics = ["prometheus"]
 network = ["async-trait", "bytes", "futures", "openssl", "smallvec", "tokio-openssl", "tokio"]
-test = ["ctor", "tracing-subscriber"]
+test = ["anyhow", "ctor", "tracing-subscriber"]
 
 # NB: ore is meant to be an extension of the Rust stdlib. To keep it
 # lightweight, dependencies on external crates should be avoided if possible. If
@@ -21,6 +21,7 @@ test = ["ctor", "tracing-subscriber"]
 # dependencies and is widely considered to be basically part of the stdlib.
 [dependencies]
 async-trait = { version = "0.1.51", optional = true }
+anyhow = { version = "1.0.44", optional = true }
 bytes = { version = "1.1.0", optional = true }
 chrono = { version = "0.4.0", default-features = false, features = ["std"], optional = true }
 ctor = { version = "0.1.21", optional = true }


### PR DESCRIPTION
Introduce a test::timeout function that runs a synchronous callback with
a timeout, producing an error if the callback fails to complete within
the specified time.

Then, use this function in test_no_block. The previous approach used a
"time bomb" thread, which panicked if the test hadn't completed within
30s. The defect with this time bomb approach is that it required calling
`ore::panic::set_abort_on_panic` in order for the panic in the time bomb
thread to cause the process to crash. The Rust test runner, however,
relies on catching panics to properly handle error reporting, which
`set_abort_on_panic` interferes with.

The working theory is that `test_no_block` is timing out, but the
`set_abort_on_panic` call is interfering with the test runner's ability
to produce the correct output.

The new `test::timeout` function in ore works around the problem by
runnign the code under test on a separate thread, leaving the "time
bomb" on the main thread, where its panics will be properly noticed by
the test harness.

<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

  * This PR fixes a previously unreported bug.

    CI has been flaking on the `cargo test` job for a while.

### Tips for reviewer

View with whitespace suppressed.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
