### PR TITLE
coord: exclude non-mat sources from timedomains

### DIFF
--- a/test/testdrive/transactions-timedomain-nonmaterialized.td
+++ b/test/testdrive/transactions-timedomain-nonmaterialized.td
@@ -109,3 +109,16 @@ Transactions can only reference objects in the same timedomain
 > SELECT c.oid FROM pg_catalog.pg_class c LIMIT 0;
 > SELECT pg_catalog.format_type(a.atttypid, a.atttypmod) FROM pg_catalog.pg_attribute a LIMIT 0;
 > COMMIT
+
+# Regression for #8942
+# Ensure that non-materialized, transitive views are not included. Here,
+# unindexed should not be included in the timedomain.
+> CREATE MATERIALIZED VIEW v_materialized AS SELECT count(*) FROM unindexed
+# Wait for the view to be updated, since we can't retry in the transaction if
+# it returns a 0 timestamp error.
+> SELECT * FROM v_materialized
+3
+> BEGIN
+> SELECT * FROM v_materialized
+3
+> COMMIT


### PR DESCRIPTION
When pulling in transitive dependencies, we needed to do the same "is
this indexed?" logic as above. Implement this by dynamically mutating
a list of ids to be processed that we add to if we find transitive views.

### Motivation

  * This PR fixes a recognized bug. #8942

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
