### PR TITLE
materialized: use assert_contains in test_no_block

### DIFF
--- a/src/materialized/tests/sql.rs
+++ b/src/materialized/tests/sql.rs
@@ -28,7 +28,9 @@ use log::info;
 use postgres::Row;
 use tempfile::NamedTempFile;
 
-use util::{MzTimestamp, PostgresErrorExt, KAFKA_ADDRS};
+use ore::assert_contains;
+
+use crate::util::{MzTimestamp, PostgresErrorExt, KAFKA_ADDRS};
 
 pub mod util;
 
@@ -87,10 +89,7 @@ fn test_no_block() -> Result<(), anyhow::Error> {
         // good measure.
         info!("test_no_block: joining thread");
         let slow_res = slow_thread.join().unwrap();
-        assert!(slow_res
-            .unwrap_err()
-            .to_string()
-            .contains("server error 503"));
+        assert_contains!(slow_res.unwrap_err().to_string(), "server error 503");
 
         info!("test_no_block: returning");
         Ok(())

--- a/src/ore/src/assert.rs
+++ b/src/ore/src/assert.rs
@@ -155,12 +155,14 @@ macro_rules! soft_panic_or_log {
 #[macro_export]
 macro_rules! assert_contains {
     ($left:expr, $right:expr $(,)?) => {{
-        if !$left.contains(&$right) {
+        let left = $left;
+        let right = $right;
+        if !left.contains(&$right) {
             panic!(
                 r#"assertion failed: `left.contains(right)`:
   left: `{:?}`
  right: `{:?}`"#,
-                $left, $right
+                left, right
             );
         }
     }};


### PR DESCRIPTION
This will print the error message when the assertion fails, which should
help elucidate the cause.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
