### PR TITLE
coordd,dataflowd: add new binaries for independent dataflow/coord servers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,6 +684,7 @@ name = "coordtest"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "build-info",
  "coord",
  "datadriven",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,6 +1010,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "dataflowd"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "dataflow",
+ "futures",
+ "log",
+ "ore",
+ "structopt",
+ "timely",
+ "tokio",
+ "tokio-serde",
+ "tokio-util",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "debugid"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1157,6 +1175,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86b50932a01e7ec5c06160492ab660fb19b6bb2a7878030dd6cd68d21df9d4d"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1267,6 +1297,19 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e40a16955681d469ab3da85aaa6b42ff656b3c67b52e1d8d3dd36afe97fd462"
 dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "3.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b166c9e378360dd5a6666a9604bb4f54ae0cac39023ffbac425e917a2a04fef"
+dependencies = [
+ "num-bigint",
+ "num-traits",
  "proc-macro2",
  "quote",
  "syn",
@@ -2272,6 +2315,7 @@ dependencies = [
  "datadriven",
  "dataflow",
  "dataflow-types",
+ "dataflowd",
  "differential-dataflow",
  "fail",
  "fallible-iterator",
@@ -4887,6 +4931,21 @@ dependencies = [
  "socket2",
  "tokio",
  "tokio-util",
+]
+
+[[package]]
+name = "tokio-serde"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911a61637386b789af998ee23f50aa30d5fd7edcec8d6d3dedae5e5815205466"
+dependencies = [
+ "bincode",
+ "bytes",
+ "educe",
+ "futures-core",
+ "futures-sink",
+ "pin-project",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "src/dataflow-bin",
     "src/dataflow-types",
     "src/dataflow",
+    "src/dataflowd",
     "src/expr",
     "src/expr-test-util",
     "src/http-proxy",

--- a/misc/python/materialize/cargo.py
+++ b/misc/python/materialize/cargo.py
@@ -60,10 +60,10 @@ class Crate:
                 self.bins.append(bin["name"])
         if (path / "src" / "main.rs").exists():
             self.bins.append(self.name)
-        for path in (path / "src" / "bin").glob("*.rs"):
-            self.bins.append(path.stem)
-        for path in (path / "src" / "bin").glob("*/main.rs"):
-            self.bins.append(path.parent.stem)
+        for p in (path / "src" / "bin").glob("*.rs"):
+            self.bins.append(p.stem)
+        for p in (path / "src" / "bin").glob("*/main.rs"):
+            self.bins.append(p.parent.stem)
 
     def inputs(self) -> Set[str]:
         """Compute the files that can impact the compilation of this crate.

--- a/misc/python/materialize/cli/mzimage.py
+++ b/misc/python/materialize/cli/mzimage.py
@@ -81,13 +81,6 @@ def parse_args() -> argparse.Namespace:
 
     def add_subcommand(name: str, **kwargs: Any) -> argparse.ArgumentParser:
         subparser = subparsers.add_parser(name, **kwargs)
-        return subparser
-
-    def add_image_subcommand(name: str, **kwargs: Any) -> argparse.ArgumentParser:
-        subparser = add_subcommand(name, **kwargs)
-        subparser.add_argument(
-            "image", help="the name of an mzbuild image in this repository"
-        )
         subparser.add_argument(
             "--build-mode",
             default="release",
@@ -98,6 +91,13 @@ def parse_args() -> argparse.Namespace:
             "--coverage",
             help="whether to enable code coverage compilation flags",
             action="store_true",
+        )
+        return subparser
+
+    def add_image_subcommand(name: str, **kwargs: Any) -> argparse.ArgumentParser:
+        subparser = add_subcommand(name, **kwargs)
+        subparser.add_argument(
+            "image", help="the name of an mzbuild image in this repository"
         )
         return subparser
 

--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -23,7 +23,10 @@ pub struct DataflowBuilder<'a> {
     pub transient_id_counter: &'a mut u64,
 }
 
-impl Coordinator {
+impl<C> Coordinator<C>
+where
+    C: dataflow::Client,
+{
     /// Creates a new dataflow builder from the catalog and indexes in `self`.
     pub fn dataflow_builder<'a>(&'a mut self) -> DataflowBuilder {
         DataflowBuilder {

--- a/src/coordtest/Cargo.toml
+++ b/src/coordtest/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.44"
+async-trait = "0.1.51"
 build-info = { path = "../build-info" }
 coord = { path = "../coord" }
 datadriven = "0.6.0"

--- a/src/coordtest/src/lib.rs
+++ b/src/coordtest/src/lib.rs
@@ -61,18 +61,19 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs::{File, OpenOptions};
 use std::future::Future;
 use std::io::Write;
-use std::mem;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use anyhow::anyhow;
+use async_trait::async_trait;
 use futures::future::FutureExt;
 use tempfile::TempDir;
 use tokio::sync::mpsc;
+use tokio::sync::Mutex as TokioMutex;
 
 use build_info::DUMMY_BUILD_INFO;
 use coord::session::{EndTransactionAction, Session};
-use coord::{Client, ExecuteResponse, Handle, PersistConfig, SessionClient, StartupResponse};
+use coord::{ExecuteResponse, PersistConfig, SessionClient, StartupResponse};
 use dataflow::WorkerFeedback;
 use dataflow_types::PeekResponse;
 use expr::GlobalId;
@@ -81,21 +82,18 @@ use ore::now::NowFn;
 use repr::{Datum, Timestamp};
 use timely::progress::change_batch::ChangeBatch;
 
-/// CoordTest works by creating a Coordinator with mechanisms to control
-/// when it receives messages. The dataflow server is started with a
-/// single worker, but it's feedback channel into the Coordinator is
-/// buffered (`dataflow_feedback_rx`), and only sent to the Coordinator
-/// (`coord_feedback_tx`) when specified, allowing us to control when uppers
-/// and sinces advance.
+/// CoordTest works by creating a Coordinator with mechanisms to control when it
+/// receives messages. The dataflow server is started with a single worker, but
+/// it's feedback channel is controlled by the InterceptingDataflowClient,
+/// allowing us to control when uppers and sinces advance.
 //
 // The field order matters a lot here so the various threads/tasks are shut
 // down without ever panicing.
 pub struct CoordTest {
-    coord_feedback_tx: mpsc::UnboundedSender<dataflow::Response>,
-    client: Client,
-    _handle: Handle,
+    dataflow_client: InterceptingDataflowClient<dataflow::LocalClient>,
+    coord_client: coord::Client,
+    _coord_handle: coord::Handle,
     _dataflow_server: dataflow::Server,
-    dataflow_feedback_rx: mpsc::UnboundedReceiver<dataflow::Response>,
     // Keep a queue of messages in the order received from dataflow_feedback_rx so
     // we can safely modify or inject things and maintain original message order.
     queued_feedback: Vec<dataflow::Response>,
@@ -117,24 +115,18 @@ impl CoordTest {
             NowFn::from(move || *timestamp.lock().unwrap())
         };
         let metrics_registry = MetricsRegistry::new();
-        let (mut dataflow_feedback_tx, dataflow_feedback_rx) = mpsc::unbounded_channel();
-        let (coord_feedback_tx, mut coord_feedback_rx) = mpsc::unbounded_channel();
-
         let (dataflow_server, dataflow_client) = dataflow::serve(dataflow::Config {
             workers: 1,
             timely_worker: timely::WorkerConfig::default(),
             experimental_mode,
             now: now.clone(),
             metrics_registry: metrics_registry.clone(),
-            response_interceptor: Some(Box::new(move |tx, rx| {
-                mem::swap(tx, &mut dataflow_feedback_tx);
-                mem::swap(rx, &mut coord_feedback_rx);
-            })),
         })?;
+        let dataflow_client = InterceptingDataflowClient::new(dataflow_client);
 
         let data_directory = tempfile::tempdir()?;
-        let (handle, client) = coord::serve(coord::Config {
-            dataflow_client,
+        let (coord_handle, coord_client) = coord::serve(coord::Config {
+            dataflow_client: dataflow_client.clone(),
             symbiosis_url: None,
             data_directory: data_directory.path(),
             logging: None,
@@ -150,11 +142,10 @@ impl CoordTest {
         })
         .await?;
         let coordtest = CoordTest {
-            coord_feedback_tx,
-            _handle: handle,
-            client,
+            dataflow_client,
+            _coord_handle: coord_handle,
+            coord_client,
             _dataflow_server: dataflow_server,
-            dataflow_feedback_rx,
             _data_directory: data_directory,
             temp_dir: tempfile::tempdir().unwrap(),
             uppers: HashMap::new(),
@@ -168,7 +159,7 @@ impl CoordTest {
     }
 
     async fn connect(&self) -> anyhow::Result<(SessionClient, StartupResponse)> {
-        let conn_client = self.client.new_conn()?;
+        let conn_client = self.coord_client.new_conn()?;
         let session = Session::new(conn_client.conn_id(), "materialize".into());
         Ok(conn_client.startup(session).await?)
     }
@@ -217,7 +208,7 @@ impl CoordTest {
 
     fn drain_feedback_msgs(&mut self) {
         loop {
-            if let Some(Some(msg)) = self.dataflow_feedback_rx.recv().now_or_never() {
+            if let Some(Some(msg)) = self.dataflow_client.intercepting_recv().now_or_never() {
                 self.queued_feedback.push(msg);
             } else {
                 return;
@@ -249,7 +240,7 @@ impl CoordTest {
             to_send.push(msg);
         }
         for msg in to_send {
-            self.coord_feedback_tx.send(msg).unwrap();
+            self.dataflow_client.forward_response(msg);
         }
         self.queued_feedback = to_queue;
     }
@@ -280,7 +271,7 @@ impl CoordTest {
             }
         }
         for msg in to_send {
-            self.coord_feedback_tx.send(msg).unwrap();
+            self.dataflow_client.forward_response(msg);
         }
         self.queued_feedback = to_queue;
     }
@@ -503,12 +494,10 @@ pub async fn run_test(mut tf: datadriven::TestFile) -> datadriven::TestFile {
                         batch.update(ts, 1);
                         updates.push((id, batch));
                     }
-                    ct.coord_feedback_tx
-                        .send(dataflow::Response {
-                            worker_id: 0,
-                            message: WorkerFeedback::FrontierUppers(updates),
-                        })
-                        .unwrap();
+                    ct.dataflow_client.forward_response(dataflow::Response {
+                        worker_id: 0,
+                        message: WorkerFeedback::FrontierUppers(updates),
+                    });
                     "".into()
                 }
                 "inc-timestamp" => {
@@ -542,4 +531,72 @@ pub async fn run_test(mut tf: datadriven::TestFile) -> datadriven::TestFile {
     })
     .await;
     tf
+}
+
+/// A [`dataflow::Client`] implementation that intercepts responses from the
+/// dataflow server.
+///
+/// The implementation of the `send` method is unchanged. The implementation of
+/// `recv`, however, only presents the responses that have been explicitly
+/// forwarded via `forward_response`. To access the actual responses from
+/// the underlying dataflow client, call `intercepting_recv`.
+struct InterceptingDataflowClient<C> {
+    inner: Arc<Mutex<C>>,
+    feedback_tx: mpsc::UnboundedSender<dataflow::Response>,
+    feedback_rx: Arc<TokioMutex<mpsc::UnboundedReceiver<dataflow::Response>>>,
+}
+
+impl<C> Clone for InterceptingDataflowClient<C> {
+    fn clone(&self) -> InterceptingDataflowClient<C> {
+        InterceptingDataflowClient {
+            inner: self.inner.clone(),
+            feedback_tx: self.feedback_tx.clone(),
+            feedback_rx: self.feedback_rx.clone(),
+        }
+    }
+}
+
+#[async_trait]
+impl<C> dataflow::Client for InterceptingDataflowClient<C>
+where
+    C: dataflow::Client,
+{
+    fn num_workers(&self) -> usize {
+        self.inner.lock().unwrap().num_workers()
+    }
+
+    fn send(&self, cmd: dataflow::Command) {
+        self.inner.lock().unwrap().send(cmd)
+    }
+
+    async fn recv(&mut self) -> Option<dataflow::Response> {
+        let mut feedback_rx = self.feedback_rx.lock().await;
+        feedback_rx.recv().await
+    }
+}
+
+impl<C> InterceptingDataflowClient<C>
+where
+    C: dataflow::Client,
+{
+    /// Creates a new intercepting dataflow client that wraps the provided
+    /// dataflow client.
+    fn new(inner: C) -> InterceptingDataflowClient<C> {
+        let (feedback_tx, feedback_rx) = mpsc::unbounded_channel();
+        InterceptingDataflowClient {
+            inner: Arc::new(Mutex::new(inner)),
+            feedback_tx,
+            feedback_rx: Arc::new(TokioMutex::new(feedback_rx)),
+        }
+    }
+
+    /// Receives a response from the underlying dataflow client.
+    async fn intercepting_recv(&mut self) -> Option<dataflow::Response> {
+        self.inner.lock().unwrap().recv().await
+    }
+
+    /// Makes the specified response available via the normal `recv` method.
+    fn forward_response(&self, response: dataflow::Response) {
+        self.feedback_tx.send(response).unwrap()
+    }
 }

--- a/src/dataflow/src/lib.rs
+++ b/src/dataflow/src/lib.rs
@@ -26,5 +26,6 @@ pub mod source;
 
 pub use render::plan::Plan;
 pub use server::{
-    serve, Client, Command, Config, Response, Server, TimestampBindingFeedback, WorkerFeedback,
+    serve, Client, Command, Config, LocalClient, Response, Server, TimestampBindingFeedback,
+    WorkerFeedback,
 };

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -320,7 +320,7 @@ pub trait Client: Send {
     fn num_workers(&self) -> usize;
 
     /// Sends a command to the dataflow server.
-    fn send(&self, cmd: Command);
+    async fn send(&mut self, cmd: Command);
 
     /// Receives the next response from the dataflow server.
     ///
@@ -342,7 +342,7 @@ impl Client for LocalClient {
         self.worker_txs.len()
     }
 
-    fn send(&self, cmd: Command) {
+    async fn send(&mut self, cmd: Command) {
         trace!("Broadcasting dataflow command: {:?}", cmd);
         let num_workers = self.num_workers();
         if num_workers == 1 {

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -13,9 +13,9 @@ use std::collections::HashMap;
 use std::sync::Mutex;
 use std::thread::Thread;
 use std::time::{Duration, Instant};
-use timely::progress::reachability::logging::TrackerEvent;
 
 use anyhow::anyhow;
+use async_trait::async_trait;
 use crossbeam_channel::TryRecvError;
 use differential_dataflow::operators::arrange::arrangement::Arrange;
 use differential_dataflow::trace::cursor::Cursor;
@@ -33,6 +33,7 @@ use timely::dataflow::operators::ActivateCapability;
 use timely::logging::Logger;
 use timely::order::PartialOrder;
 use timely::progress::frontier::Antichain;
+use timely::progress::reachability::logging::TrackerEvent;
 use timely::progress::ChangeBatch;
 use timely::worker::Worker as TimelyWorker;
 use tokio::sync::mpsc;
@@ -303,16 +304,7 @@ pub struct Config {
     pub now: NowFn,
     /// Metrics registry through which dataflow metrics will be reported.
     pub metrics_registry: MetricsRegistry,
-    /// An optional callback that is presented with both halves of the dataflow
-    /// feedback channel on startup. The callback can swap the channel for
-    /// another in order to intercept messages.
-    ///
-    /// For testing purposes only.
-    pub response_interceptor: Option<ResponseInterceptor>,
 }
-
-type ResponseInterceptor =
-    Box<dyn FnOnce(&mut mpsc::UnboundedSender<Response>, &mut mpsc::UnboundedReceiver<Response>)>;
 
 /// A handle to a running dataflow server.
 ///
@@ -321,21 +313,36 @@ pub struct Server {
     _worker_guards: WorkerGuards<()>,
 }
 
-/// A client to a dataflow [`Server`].
-pub struct Client {
+/// A client to a running dataflow server.
+#[async_trait]
+pub trait Client: Send {
+    /// Reports the number of dataflow workers.
+    fn num_workers(&self) -> usize;
+
+    /// Sends a command to the dataflow server.
+    fn send(&self, cmd: Command);
+
+    /// Receives the next response from the dataflow server.
+    ///
+    /// This method blocks until the next response is available, or, if the
+    /// dataflow server has been shut down, returns `None`.
+    async fn recv(&mut self) -> Option<Response>;
+}
+
+/// A client to a dataflow server running in the current process.
+pub struct LocalClient {
     feedback_rx: mpsc::UnboundedReceiver<Response>,
     worker_txs: Vec<crossbeam_channel::Sender<Command>>,
     worker_threads: Vec<Thread>,
 }
 
-impl Client {
-    /// Reports the number of dataflow workers.
-    pub fn num_workers(&self) -> usize {
+#[async_trait]
+impl Client for LocalClient {
+    fn num_workers(&self) -> usize {
         self.worker_txs.len()
     }
 
-    /// Sends a command to the dataflow server.
-    pub fn send(&self, cmd: Command) {
+    fn send(&self, cmd: Command) {
         trace!("Broadcasting dataflow command: {:?}", cmd);
         let num_workers = self.num_workers();
         if num_workers == 1 {
@@ -355,27 +362,20 @@ impl Client {
         }
     }
 
-    /// Receives the next response from the dataflow server.
-    ///
-    /// This method blocks until the next response is available, or, if the
-    /// dataflow server has been shut down, returns `None`.
-    pub async fn recv(&mut self) -> Option<Response> {
+    async fn recv(&mut self) -> Option<Response> {
         return self.feedback_rx.recv().await;
     }
 }
 
 /// Initiates a timely dataflow computation, processing materialized commands.
-pub fn serve(config: Config) -> Result<(Server, Client), anyhow::Error> {
+pub fn serve(config: Config) -> Result<(Server, LocalClient), anyhow::Error> {
     assert!(config.workers > 0);
 
     let server_metrics = ServerMetrics::register_with(&config.metrics_registry);
     let dataflow_source_metrics = SourceBaseMetrics::register_with(&config.metrics_registry);
     let dataflow_sink_metrics = SinkBaseMetrics::register_with(&config.metrics_registry);
 
-    let (mut feedback_tx, mut feedback_rx) = mpsc::unbounded_channel();
-    if let Some(response_interceptor) = config.response_interceptor {
-        response_interceptor(&mut feedback_tx, &mut feedback_rx);
-    }
+    let (feedback_tx, feedback_rx) = mpsc::unbounded_channel();
 
     // Construct endpoints for each thread that will receive the coordinator's
     // sequenced command stream.
@@ -436,7 +436,7 @@ pub fn serve(config: Config) -> Result<(Server, Client), anyhow::Error> {
         },
     )
     .map_err(|e| anyhow!("{}", e))?;
-    let client = Client {
+    let client = LocalClient {
         feedback_rx,
         worker_txs,
         worker_threads: worker_guards

--- a/src/dataflowd/Cargo.toml
+++ b/src/dataflowd/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "dataflowd"
+description = "Independent dataflow server for Materialize."
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+anyhow = "1.0.44"
+async-trait = "0.1.51"
+dataflow = { path = "../dataflow" }
+log = "0.4.13"
+ore = { path = "../ore" }
+structopt = "0.3.25"
+timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
+tracing-subscriber = "0.3.1"
+tokio = { version = "1.13.0", features = ["macros", "rt-multi-thread"] }
+tokio-serde = { version = "0.8.0", features = ["bincode"] }
+tokio-util = { version = "0.6.9", features = ["codec"] }
+futures = "0.3.17"

--- a/src/dataflowd/src/lib.rs
+++ b/src/dataflowd/src/lib.rs
@@ -1,0 +1,103 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Independent dataflow server support.
+//!
+//! This crate provides types that facilitate communicating with a remote
+//! dataflow server.
+
+#![deny(missing_docs)]
+
+use std::net::SocketAddr;
+
+use async_trait::async_trait;
+use futures::sink::SinkExt;
+use futures::stream::TryStreamExt;
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::net::TcpStream;
+use tokio_serde::formats::Bincode;
+use tokio_util::codec::LengthDelimitedCodec;
+
+use dataflow::{Command, Response};
+
+/// A framed connection to a dataflowd server.
+pub type Framed<C, T, U> =
+    tokio_serde::Framed<tokio_util::codec::Framed<C, LengthDelimitedCodec>, T, U, Bincode<T, U>>;
+
+/// A framed connection from the server's perspective.
+pub type FramedServer<C> = Framed<C, Command, Response>;
+
+/// A framed connection from the client's perspective.
+pub type FramedClient<C> = Framed<C, Response, Command>;
+
+/// Constructs a framed connection for the server.
+pub fn framed_server<C>(conn: C) -> FramedServer<C>
+where
+    C: AsyncRead + AsyncWrite,
+{
+    tokio_serde::Framed::new(
+        tokio_util::codec::Framed::new(conn, LengthDelimitedCodec::new()),
+        Bincode::default(),
+    )
+}
+
+/// Constructs a framed connection for the client.
+pub fn framed_client<C>(conn: C) -> FramedClient<C>
+where
+    C: AsyncRead + AsyncWrite,
+{
+    tokio_serde::Framed::new(
+        tokio_util::codec::Framed::new(conn, LengthDelimitedCodec::new()),
+        Bincode::default(),
+    )
+}
+
+/// A client to a remote dataflow server.
+pub struct RemoteClient {
+    // TODO: the client could discover the number of workers from the server.
+    num_workers: usize,
+    conn: FramedClient<TcpStream>,
+}
+
+impl RemoteClient {
+    /// Connects a remote client to the specified remote dataflow server.
+    pub async fn connect(
+        num_workers: usize,
+        addr: SocketAddr,
+    ) -> Result<RemoteClient, anyhow::Error> {
+        let conn = TcpStream::connect(addr).await?;
+        Ok(RemoteClient {
+            num_workers,
+            conn: framed_client(conn),
+        })
+    }
+}
+
+#[async_trait]
+impl dataflow::Client for RemoteClient {
+    fn num_workers(&self) -> usize {
+        self.num_workers
+    }
+
+    async fn send(&mut self, cmd: dataflow::Command) {
+        // TODO: something better than panicking.
+        self.conn
+            .send(cmd)
+            .await
+            .expect("connection to dataflow server broken")
+    }
+
+    async fn recv(&mut self) -> Option<dataflow::Response> {
+        // TODO: something better than panicking.
+        self.conn
+            .try_next()
+            .await
+            .expect("connection to dataflow server broken")
+    }
+}

--- a/src/dataflowd/src/main.rs
+++ b/src/dataflowd/src/main.rs
@@ -1,0 +1,98 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::net::SocketAddr;
+use std::process;
+
+use anyhow::bail;
+use futures::sink::SinkExt;
+use futures::stream::TryStreamExt;
+use log::info;
+use structopt::StructOpt;
+use tokio::net::TcpListener;
+use tokio::select;
+use tracing_subscriber::EnvFilter;
+
+use dataflow::Client;
+use ore::metrics::MetricsRegistry;
+use ore::now::SYSTEM_TIME;
+
+/// Independent dataflow server for Materialize.
+#[derive(StructOpt)]
+struct Args {
+    /// The address on which to listen for a connection from the coordinator.
+    #[structopt(
+        long,
+        env = "DATAFLOWD_LISTEN_ADDR",
+        value_name = "HOST:PORT",
+        default_value = "0.0.0.0:6876"
+    )]
+    listen_addr: SocketAddr,
+    /// Number of dataflow worker threads.
+    #[structopt(
+        short,
+        long,
+        env = "DATAFLOWD_WORKERS",
+        value_name = "N",
+        default_value = "1"
+    )]
+    workers: usize,
+}
+
+#[tokio::main]
+async fn main() {
+    if let Err(err) = run(ore::cli::parse_args()).await {
+        eprintln!("dataflowd: {:#}", err);
+        process::exit(1);
+    }
+}
+
+async fn run(args: Args) -> Result<(), anyhow::Error> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_env("DATAFLOWD_LOG_FILTER")
+                .unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .init();
+
+    if args.workers == 0 {
+        bail!("--workers must be greater than 0");
+    }
+
+    let (_server, mut client) = dataflow::serve(dataflow::Config {
+        workers: args.workers,
+        timely_worker: timely::WorkerConfig::default(),
+        experimental_mode: false,
+        metrics_registry: MetricsRegistry::new(),
+        now: SYSTEM_TIME.clone(),
+    })?;
+
+    let listener = TcpListener::bind(args.listen_addr).await?;
+    info!(
+        "listening for coordinator connection on {}...",
+        listener.local_addr()?
+    );
+
+    let (conn, _addr) = listener.accept().await?;
+    info!("coordinator connection accepted");
+
+    let mut conn = dataflowd::framed_server(conn);
+    loop {
+        select! {
+            cmd = conn.try_next() => match cmd? {
+                None => break,
+                Some(cmd) => client.send(cmd).await,
+            },
+            Some(response) = client.recv() => conn.send(response).await?,
+        }
+    }
+
+    info!("coordinator connection gone; terminating");
+    Ok(())
+}

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -40,6 +40,7 @@ compile-time-run = "0.2.12"
 coord = { path = "../coord" }
 crossbeam-channel = "0.5.1"
 dataflow = { path = "../dataflow" }
+dataflowd = { path = "../dataflowd" }
 dataflow-types = { path = "../dataflow-types" }
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 fail = { git = "https://github.com/tikv/fail-rs", features = ["failpoints"] }

--- a/src/materialized/src/bin/coordd.rs
+++ b/src/materialized/src/bin/coordd.rs
@@ -1,0 +1,123 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::process;
+use std::sync::Arc;
+use std::time::Duration;
+
+use log::info;
+use structopt::StructOpt;
+use tokio::net::TcpListener;
+use tracing_subscriber::EnvFilter;
+
+use ore::metrics::MetricsRegistry;
+use ore::now::SYSTEM_TIME;
+
+/// Independent coordinator server for Materialize.
+#[derive(StructOpt)]
+struct Args {
+    /// The address on which to listen for SQL connections.
+    #[structopt(
+        long,
+        env = "COORDD_LISTEN_ADDR",
+        value_name = "HOST:PORT",
+        default_value = "0.0.0.0:6875"
+    )]
+    listen_addr: SocketAddr,
+    /// The address of the dataflowd server to connect to.
+    #[structopt(
+        short,
+        long,
+        env = "COORDD_DATAFLOWD_ADDR",
+        default_value = "127.0.0.1:6876"
+    )]
+    dataflowd_addr: SocketAddr,
+    /// Number of dataflow worker threads. This must match the number of
+    /// workers that the targeted dataflowd was started with.
+    #[structopt(
+        short,
+        long,
+        env = "COORDD_DATAFLOWD_WORKERS",
+        value_name = "N",
+        default_value = "1"
+    )]
+    workers: usize,
+    /// Where to store data.
+    #[structopt(
+        short = "D",
+        long,
+        env = "COORDD_DATA_DIRECTORY",
+        value_name = "PATH",
+        default_value = "mzdata"
+    )]
+    data_directory: PathBuf,
+}
+
+#[tokio::main]
+async fn main() {
+    if let Err(err) = run(ore::cli::parse_args()).await {
+        eprintln!("coordd: {:#}", err);
+        process::exit(1);
+    }
+}
+
+async fn run(args: Args) -> Result<(), anyhow::Error> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_env("COORDD_LOG_FILTER").unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .init();
+
+    info!(
+        "connecting to dataflowd server at {}...",
+        args.dataflowd_addr
+    );
+
+    let dataflow_client =
+        dataflowd::RemoteClient::connect(args.workers, args.dataflowd_addr).await?;
+    let metrics_registry = MetricsRegistry::new();
+    let (_coord_handle, coord_client) = coord::serve(coord::Config {
+        dataflow_client,
+        symbiosis_url: None,
+        logging: None,
+        data_directory: &args.data_directory,
+        timestamp_frequency: Duration::from_secs(1),
+        logical_compaction_window: Some(Duration::from_millis(1)),
+        experimental_mode: false,
+        disable_user_indexes: false,
+        safe_mode: false,
+        build_info: &materialized::BUILD_INFO,
+        metrics_registry: metrics_registry.clone(),
+        persist: coord::PersistConfig::disabled(),
+        now: SYSTEM_TIME.clone(),
+    })
+    .await?;
+
+    let listener = TcpListener::bind(&args.listen_addr).await?;
+    let pgwire_server = Arc::new(pgwire::Server::new(pgwire::Config {
+        tls: None,
+        coord_client,
+        metrics_registry: &metrics_registry,
+    }));
+
+    info!(
+        "listening for pgwire connections on {}...",
+        listener.local_addr()?
+    );
+
+    loop {
+        let (conn, _addr) = listener.accept().await?;
+        tokio::spawn({
+            let pgwire_server = pgwire_server.clone();
+            async move { pgwire_server.handle_connection(conn).await }
+        });
+    }
+}

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -231,7 +231,6 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
         experimental_mode: config.experimental_mode,
         now: SYSTEM_TIME.clone(),
         metrics_registry: config.metrics_registry.clone(),
-        response_interceptor: None,
     })?;
 
     // Initialize coordinator.


### PR DESCRIPTION
Add `dataflowd` and `coordd` binaries, which serve an independent copy
of the dataflow layer and coord layer, respectively, and communicate
with one another over the network. This is a first step towards
horizontally-scalable deployments, where one `coordd` can manage a
dataflow cluster that is sharded across multiple `dataflowd` processes.

The new binaries are simple frontends for the existing coordinator and
dataflow `serve` APIs. You can think of them as extractions of the
relevant parts of the "main" function in the `materialized` binary.
Structuring this using separate binaries means we don't need to litter
`materialized` with modal command line flags (e.g.,
`--server-mode=dataflow-only`) and complicated `if` statements.

`coordd` presently communicates with precisely one `dataflowdd` binary.
The `dataflowdd` binary must be started first. If the TCP connection
fails, panic ensues. Adding retries is left to future work, though note
that timely will also need to grow some retry loops.

The communication protocol between `coordd` and `dataflowd` is quite
simple: length-encoded bincode messages, where the messages are the
existing `dataflow::Command` and `dataflow::Response` types.

To try this out on your local machine:

```
$ cargo run --bin dataflowd
# In another terminal:
$ cargo run --bin coordd
# In another terminal:
$ psql -h localhost -p 6875 -U materialize
```

If you like, you can run coordd on another machine and pass
`--dataflowd-addr=COORDD_HOST:6876` to specify the location of the
dataflowd server.

### Motivation

  * This PR adds a feature that has not yet been specified.

    The ability to run an independent coordinator and dataflow server is part of the vision for Materialize Platform.
### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
