### PR TITLE
devsite: exclude rust-private docs from search engines

### DIFF
--- a/bin/doc
+++ b/bin/doc
@@ -26,7 +26,7 @@ cd "$(dirname "$0")/.."
 
 . misc/shlib/shlib.bash
 
-RUSTDOCFLAGS="-D warnings"
+RUSTDOCFLAGS+=" -D warnings "
 if [[ $(cargo -V) = *nightly* ]]; then
   RUSTDOCFLAGS+=" --cfg nightly_doc_features"
 fi

--- a/ci/deploy/devsite.sh
+++ b/ci/deploy/devsite.sh
@@ -18,7 +18,10 @@ aws s3 cp misc/www/index.html s3://materialize-dev-website/index.html
 bin/doc
 aws s3 sync --size-only target/doc/ s3://materialize-dev-website/api/rust
 
-bin/doc --document-private-items
+# Documenting private items causes broken links in many crates we don't control.
+# So exclude all the pages from search engine indexes to avoid harming our
+# SEO score with a number of broken links.
+RUSTDOCFLAGS="--html-in-header $PWD/ci/deploy/noindex.html" bin/doc --document-private-items
 aws s3 sync --size-only target/doc/ s3://materialize-dev-website/api/rust-private
 
 bin/pydoc

--- a/ci/deploy/noindex.html
+++ b/ci/deploy/noindex.html
@@ -1,0 +1,1 @@
+<meta name="robots" content="noindex">

--- a/src/avro/src/types.rs
+++ b/src/avro/src/types.rs
@@ -182,7 +182,7 @@ pub enum Value {
 /// Any structure implementing the [ToAvro](trait.ToAvro.html) trait will be usable
 /// from a [Writer](../writer/struct.Writer.html).
 pub trait ToAvro {
-    /// Transforms this value into an Avro-compatible [Value](enum.Value.html).
+    /// Transforms this value into an Avro-compatible [`Value`].
     fn avro(self) -> Value;
 }
 


### PR DESCRIPTION
To avoid a bunch of broken links that might harm our SEO. Also fix one
legitimately broken link in the non-private docs.
