### PR TITLE
Remove mention of unstable builds from beta banner.

### DIFF
--- a/doc/user/content/sql/create-source/postgres.md
+++ b/doc/user/content/sql/create-source/postgres.md
@@ -8,9 +8,7 @@ aliases:
   - /sql/create-source/postgresql
 ---
 
-{{< beta />}}
-
-{{< version-added v0.8.0 />}}
+{{< beta v0.8.0 />}}
 
 {{% create-source/intro %}}
 This document details how to connect Materialize to a Postgres database for Postgres versions 10 and higher. Before you create the source in Materialize, you must perform [some prerequisite steps](#postgresql-source-details) in Postgres.

--- a/doc/user/layouts/shortcodes/beta.html
+++ b/doc/user/layouts/shortcodes/beta.html
@@ -8,6 +8,5 @@
     {{if in (apply $.Site.Params.versions "index" "." "name") (.Get 0)}}
     <em>Available since {{.Get 0}}.</em>
     {{else}}
-    <em>Available only in <a href="{{"/versions/#unstable-builds"|relURL}}">unstable builds</a>.</em>
     {{end}}
 </div>


### PR DESCRIPTION
Our standard beta banner included a mention that beta features whose versions weren't listed were available only in unstable builds. That may have been true at one point, but is no longer common, especially since we added a firmer distinction between "beta" and "experimental". I'm removing the mention of unstable builds.

### Motivation
 

  * This PR fixes a previously unreported bug.
 Incorrect information in docs.

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
