### PR TITLE
docs: separate beta warning and version added messages

### DIFF
--- a/doc/user/content/guides/reuse-topic-for-kafka-sink.md
+++ b/doc/user/content/guides/reuse-topic-for-kafka-sink.md
@@ -7,7 +7,9 @@ menu:
     parent: guides
 ---
 
-{{< beta v0.9.0 />}}
+{{< beta />}}
+
+{{< version-added v0.9.0 />}}
 
 By default, Materialize creates new, distinct topics for sinks after each restart. To enable the reuse of the existing topic instead and provide exactly-once processing guarantees, Materialize must be able to do two
 things:

--- a/doc/user/content/sql/create-sink.md
+++ b/doc/user/content/sql/create-sink.md
@@ -201,7 +201,9 @@ You can find the topic name for each Kafka sink by querying `mz_kafka_sinks`.
 
 #### Enabling topic reuse after restart (exactly-once sinks)
 
-{{< beta v0.9.0 />}}
+{{< beta />}}
+
+{{< version-added v0.9.0 />}}
 
 By default, Materialize creates new, distinct topics for sinks after each restart. To enable the reuse of the existing topic instead and provide exactly-once processing guarantees, Materialize must be able to do two things:
 

--- a/doc/user/layouts/shortcodes/beta.html
+++ b/doc/user/layouts/shortcodes/beta.html
@@ -4,10 +4,4 @@
     is in beta. It may have performance or stability issues and is not subject
     to our <a href="{{ "/versions/#backwards-compatibility" | relURL }}">backwards compatibility</a>
     guarantee.
-
-    {{if in (apply $.Site.Params.versions "index" "." "name") (.Get 0)}}
-    <em>Available since {{.Get 0}}.</em>
-    {{else}}
-    <em>Available only in <a href="{{"/versions/#unstable-builds"|relURL}}">unstable builds</a>.</em>
-    {{end}}
 </div>


### PR DESCRIPTION
Most beta messages don't want to say anything about the version in which the feature was added. So instead drop that bit from the standard beta message, and add a separate version message for the few beta features that want it.

### Motivation

  * This PR fixes a previously unreported bug.

    Many beta warnings were incorrectly displaying that the beta feature had not yet been released.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
