### PR TITLE
Do not merge: Test that demand is now a no-op.

### DIFF
--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -1342,13 +1342,16 @@ pub mod plan {
 
         let (map, filter, project) = mfp.as_map_filter_project();
 
-        let map_filter_project = MapFilterProject::new(output_arity)
+        let mut map_filter_project = MapFilterProject::new(output_arity)
             .map(dummies)
             .project(demand_projection)
             .map(map)
             .filter(filter)
             .project(project);
 
+        mfp.optimize();
+        map_filter_project.optimize();
+        assert_eq!(*mfp, map_filter_project);
         *mfp = map_filter_project;
     }
 

--- a/src/expr/src/explain.rs
+++ b/src/expr/src/explain.rs
@@ -248,7 +248,7 @@ impl<'a> ViewExplanation<'a> {
             Join {
                 inputs,
                 equivalences,
-                demand,
+                demand: _,
                 implementation,
             } => {
                 write!(
@@ -278,9 +278,9 @@ impl<'a> ViewExplanation<'a> {
                 writeln!(f)?;
                 write!(f, "| | implementation = ")?;
                 self.fmt_join_implementation(f, inputs, implementation)?;
-                if let Some(demand) = demand {
+                /*if let Some(demand) = demand {
                     writeln!(f, "| | demand = {}", bracketed("(", ")", Indices(demand)))?;
-                }
+                }*/
             }
             Reduce {
                 group_key,

--- a/src/transform/src/demand.rs
+++ b/src/transform/src/demand.rs
@@ -150,7 +150,7 @@ impl Demand {
             MirRelationExpr::Join {
                 inputs,
                 equivalences,
-                demand: _,
+                demand,
                 implementation: _,
             } => {
                 let input_mapper = JoinInputMapper::new(inputs);
@@ -174,6 +174,11 @@ impl Demand {
                     }
                 }
 
+                // Capture the external demand for the join. Use the permutation to intervene
+                // when an externally demanded column will be replaced with a copy of another.
+                let mut demand_vec = columns.iter().map(|c| permutation[*c]).collect::<Vec<_>>();
+                demand_vec.sort_unstable();
+                *demand = Some(demand_vec);
                 let should_permute = columns.iter().any(|c| permutation[*c] != *c);
 
                 // Each equivalence class imposes internal demand for columns.


### PR DESCRIPTION
It turns out that the fusion of the demand work with the existing MFP is not quite a no-op. Specifically, it adds unnecessary dummies to be mapped.

Before `prepend_mfp_demand`:
```
MapFilterProject { 
  expressions: [], 
  predicates: [(1, CallBinary { func: Lt, expr1: Column(0), expr2: Literal(Ok(Row{[Int32(3)]}), ColumnType { scalar_type: Int32, nullable: false }) })], 
  projection: [0], 
  input_arity: 2 }
```

After `prepend_mfp_demand`:
```
MapFilterProject { 
  expressions: [Literal(Ok(Row{[Dummy]}), ColumnType { scalar_type: Int32, nullable: false })],
  predicates: [(1, CallBinary { func: Lt, expr1: Column(0), expr2: Literal(Ok(Row{[Int32(3)]}), ColumnType { scalar_type: Int32, nullable: false }) })], 
  projection: [0], 
  input_arity: 2 }
```

Thus, I `optimize` the "After `prepend_mfp_demand`" to get rid of the unnecessary dummies before comparing the MFPs for equality. This means the before must also be optimized because the optimize may rewrite expressions and predicates to take advantage of CSE.

`Demand` stopped filling in the `demand` field for joins as of #7864, so I put the code back in for the test.