### PR TITLE
sources and sinks: refactor protobuf descriptors

### DIFF
--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -492,8 +492,10 @@ impl DataEncoding {
                     }
                 }
             }
-            DataEncoding::Protobuf(encoding) => protobuf::decode::RawDescriptors::from(encoding)
-                .decode()?
+            DataEncoding::Protobuf(ProtobufEncoding {
+                descriptors,
+                message_name,
+            }) => protobuf::decode::DecodedDescriptors::from_bytes(descriptors, message_name.into())?
                 .validate()?
                 .into_iter()
                 .fold(key_desc, |desc, (name, ty)| {
@@ -580,12 +582,6 @@ pub struct AvroOcfEncoding {
 pub struct ProtobufEncoding {
     pub descriptors: Vec<u8>,
     pub message_name: String,
-}
-
-impl<'a> From<&'a ProtobufEncoding> for protobuf::decode::RawDescriptors<'a> {
-    fn from(pe: &'a ProtobufEncoding) -> protobuf::decode::RawDescriptors<'a> {
-        protobuf::decode::RawDescriptors::new(&pe.descriptors, pe.message_name.to_owned())
-    }
 }
 
 /// Arguments necessary to define how to decode from CSV format

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -495,12 +495,14 @@ impl DataEncoding {
             DataEncoding::Protobuf(ProtobufEncoding {
                 descriptors,
                 message_name,
-            }) => protobuf::decode::DecodedDescriptors::from_bytes(descriptors, message_name.into())?
-                .validate()?
-                .into_iter()
-                .fold(key_desc, |desc, (name, ty)| {
-                    desc.with_named_column(name.unwrap(), ty)
-                }),
+            }) => {
+                protobuf::decode::DecodedDescriptors::from_bytes(descriptors, message_name.into())?
+                    .validate()?
+                    .into_iter()
+                    .fold(key_desc, |desc, (name, ty)| {
+                        desc.with_named_column(name.unwrap(), ty)
+                    })
+            }
             DataEncoding::Regex(RegexEncoding { regex }) => regex
                 .capture_names()
                 .enumerate()

--- a/src/dataflow/src/decode/mod.rs
+++ b/src/dataflow/src/decode/mod.rs
@@ -14,7 +14,6 @@ use std::{any::Any, cell::RefCell, collections::VecDeque, rc::Rc, time::Duration
 use ::regex::Regex;
 use dataflow_types::AvroEncoding;
 use dataflow_types::AvroOcfEncoding;
-use dataflow_types::ProtobufEncoding;
 use differential_dataflow::capture::YieldingIter;
 use differential_dataflow::Hashable;
 use differential_dataflow::{AsCollection, Collection};
@@ -342,13 +341,9 @@ fn get_decoder(
                 DataEncoding::Regex(RegexEncoding { regex }) => {
                     PreDelimitedFormat::Regex(regex, Default::default())
                 }
-                DataEncoding::Protobuf(ProtobufEncoding {
-                    descriptors,
-                    message_name,
-                }) => PreDelimitedFormat::Protobuf(ProtobufDecoderState::new(
-                    &descriptors,
-                    message_name,
-                )),
+                DataEncoding::Protobuf(encoding) => {
+                    PreDelimitedFormat::Protobuf(ProtobufDecoderState::new(encoding))
+                }
                 DataEncoding::Bytes => PreDelimitedFormat::Bytes,
                 DataEncoding::Text => PreDelimitedFormat::Text,
                 _ => unreachable!(),

--- a/src/dataflow/src/decode/protobuf.rs
+++ b/src/dataflow/src/decode/protobuf.rs
@@ -7,9 +7,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use dataflow_types::{DataflowError, DecodeError};
+use dataflow_types::{DataflowError, DecodeError, ProtobufEncoding};
 use interchange::protobuf;
-use interchange::protobuf::decode::{DecodedDescriptors, Decoder};
+use interchange::protobuf::decode::Decoder;
 use repr::Row;
 
 #[derive(Debug)]
@@ -20,15 +20,12 @@ pub struct ProtobufDecoderState {
 }
 
 impl ProtobufDecoderState {
-    pub fn new(descriptors: &[u8], message_name: Option<String>) -> Self {
-        let DecodedDescriptors {
-            descriptors,
-            first_message_name,
-        } = protobuf::decode_descriptors(descriptors)
+    pub fn new(encoding: ProtobufEncoding) -> Self {
+        let descriptors = protobuf::decode::RawDescriptors::from(&encoding)
+            .decode()
             .expect("descriptors provided to protobuf source are pre-validated");
-        let message_name = message_name.as_ref().unwrap_or_else(|| &first_message_name);
         ProtobufDecoderState {
-            decoder: Decoder::new(descriptors, &message_name),
+            decoder: Decoder::new(descriptors),
             events_success: 0,
             events_error: 0,
         }

--- a/src/dataflow/src/decode/protobuf.rs
+++ b/src/dataflow/src/decode/protobuf.rs
@@ -19,10 +19,12 @@ pub struct ProtobufDecoderState {
 }
 
 impl ProtobufDecoderState {
-    pub fn new(ProtobufEncoding {
-        descriptors,
-        message_name,
-    }: ProtobufEncoding) -> Self {
+    pub fn new(
+        ProtobufEncoding {
+            descriptors,
+            message_name,
+        }: ProtobufEncoding,
+    ) -> Self {
         let descriptors = DecodedDescriptors::from_bytes(&descriptors, message_name)
             .expect("descriptors provided to protobuf source are pre-validated");
         ProtobufDecoderState {

--- a/src/dataflow/src/decode/protobuf.rs
+++ b/src/dataflow/src/decode/protobuf.rs
@@ -8,8 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use dataflow_types::{DataflowError, DecodeError, ProtobufEncoding};
-use interchange::protobuf;
-use interchange::protobuf::decode::Decoder;
+use interchange::protobuf::decode::{DecodedDescriptors, Decoder};
 use repr::Row;
 
 #[derive(Debug)]
@@ -20,9 +19,11 @@ pub struct ProtobufDecoderState {
 }
 
 impl ProtobufDecoderState {
-    pub fn new(encoding: ProtobufEncoding) -> Self {
-        let descriptors = protobuf::decode::RawDescriptors::from(&encoding)
-            .decode()
+    pub fn new(ProtobufEncoding {
+        descriptors,
+        message_name,
+    }: ProtobufEncoding) -> Self {
+        let descriptors = DecodedDescriptors::from_bytes(&descriptors, message_name)
             .expect("descriptors provided to protobuf source are pre-validated");
         ProtobufDecoderState {
             decoder: Decoder::new(descriptors),

--- a/src/interchange/benches/protobuf.rs
+++ b/src/interchange/benches/protobuf.rs
@@ -9,9 +9,8 @@
 
 use criterion::{black_box, Criterion, Throughput};
 use protobuf::Message;
-use serde_protobuf::descriptor::Descriptors;
 
-use interchange::protobuf::decode::Decoder;
+use interchange::protobuf::decode::{DecodedDescriptors, Decoder};
 
 use gen::benchmark::{Connector, Record, Value};
 
@@ -64,10 +63,10 @@ pub fn bench_protobuf(c: &mut Criterion) {
         .write_to_bytes()
         .expect("record failed to serialize to bytes");
     let len = buf.len() as u64;
-    let mut decoder = Decoder::new(
-        Descriptors::from_proto(&gen::file_descriptor_set()),
-        ".bench.Record",
-    );
+    let mut decoder = Decoder::new(DecodedDescriptors::from_fds(
+        &gen::file_descriptor_set(),
+        ".bench.Record".to_string(),
+    ));
 
     let mut bg = c.benchmark_group("protobuf");
     bg.throughput(Throughput::Bytes(len));

--- a/src/interchange/src/protobuf.rs
+++ b/src/interchange/src/protobuf.rs
@@ -226,21 +226,22 @@ mod tests {
         ));
         descriptors.add_message(m1);
 
-        let mut relation = decode::DecodedDescriptors::from_descriptors(
-            &descriptors,
-            ".test.message1".to_string(),
-        )
-        .validate()
-        .expect("Failed to parse descriptor");
+        let decoded_descriptors =
+            decode::DecodedDescriptors::from_descriptors(descriptors, ".test.message1".to_string());
+        let mut relation = decoded_descriptors
+            .validate()
+            .expect("Failed to parse descriptor");
 
         sanity_check_relation(
             &relation,
-            descriptors
+            decoded_descriptors
+                .descriptors()
                 .message_by_name(".test.message1")
                 .expect("message should be in the descriptor set"),
-            &descriptors,
+            &decoded_descriptors.descriptors(),
         )?;
 
+        let mut descriptors = decoded_descriptors.into_descriptors();
         let mut m2 = MessageDescriptor::new(".test.message2");
         m2.add_field(FieldDescriptor::new(
             "ids",
@@ -259,19 +260,19 @@ mod tests {
         ));
         descriptors.add_message(m2);
 
-        relation = decode::DecodedDescriptors::from_descriptors(
-            &descriptors,
-            ".test.message2".to_string(),
-        )
-        .validate()
-        .expect("Failed to parse descriptor");
+        let decoded_descriptors =
+            decode::DecodedDescriptors::from_descriptors(descriptors, ".test.message2".to_string());
+        relation = decoded_descriptors
+            .validate()
+            .expect("Failed to parse descriptor");
 
         sanity_check_relation(
             &relation,
-            descriptors
+            decoded_descriptors
+                .descriptors()
                 .message_by_name(".test.message2")
                 .expect("message should be in the descriptor set"),
-            &descriptors,
+            &decoded_descriptors.descriptors(),
         )?;
 
         Ok(())

--- a/src/interchange/src/protobuf.rs
+++ b/src/interchange/src/protobuf.rs
@@ -13,11 +13,10 @@ pub mod decode;
 
 use std::collections::HashSet;
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{bail, Result};
 use serde_protobuf::descriptor::{Descriptors, FieldDescriptor, FieldLabel, FieldType};
 
-use ore::str::StrExt;
-use repr::{ColumnName, ColumnType, RelationDesc, RelationType, ScalarType};
+use repr::{ColumnName, ColumnType, ScalarType};
 
 fn proto_message_name(message_name: &str) -> String {
     // Prepend a . (following the serde-protobuf naming scheme to list root paths
@@ -105,65 +104,6 @@ fn derive_scalar_type<'a>(
         FieldType::UnresolvedMessage(m) => bail!("Unresolved message {} not supported", m),
         FieldType::UnresolvedEnum(e) => bail!("Unresolved enum {} not supported", e),
     })
-}
-
-pub fn decode_descriptors(descriptors: &[u8]) -> Result<decode::DecodedDescriptors> {
-    let proto: protobuf::descriptor::FileDescriptorSet =
-        protobuf::Message::parse_from_bytes(descriptors)
-            .context("parsing encoded protobuf descriptors failed")?;
-
-    // Iterate through the FileDescriptors to get the first Message name,
-    // which might not be in the first file!
-    for file in proto.file.iter() {
-        if let Some(message) = file.get_message_type().iter().next() {
-            return Ok(decode::DecodedDescriptors {
-                descriptors: Descriptors::from_proto(&proto),
-                first_message_name: format!(".{}", message.get_name().to_owned()),
-            });
-        }
-    }
-
-    Err(anyhow!("file descriptor set must have a message"))
-}
-
-pub fn validate_descriptors(message_name: &str, descriptors: &Descriptors) -> Result<RelationDesc> {
-    let proto_name = proto_message_name(message_name);
-    let message = descriptors.message_by_name(&proto_name).ok_or_else(|| {
-        // TODO(benesch): the error message here used to include the names of
-        // all messages in the descriptor set, but that one feature required
-        // maintaining a fork of serde_protobuf. I sent the patch upstream [0],
-        // and we can add the error message improvement back if that patch is
-        // accepted.
-        // [0]: https://github.com/dflemstr/serde-protobuf/pull/9
-        anyhow!(
-            "Message {} not found in file descriptor set",
-            proto_name.quoted()
-        )
-    })?;
-    let mut seen_messages = HashSet::new();
-    seen_messages.insert(message.name());
-    let column_types = message
-        .fields()
-        .iter()
-        .map(|f| {
-            Ok(ColumnType {
-                /// All the fields have to be optional, so mark a field as
-                /// nullable if it doesn't have any defaults
-                nullable: f.default_value().is_none(),
-                scalar_type: derive_scalar_type_from_proto_field(
-                    &mut seen_messages,
-                    &f,
-                    descriptors,
-                )?,
-            })
-        })
-        .collect::<Result<Vec<_>>>()?;
-
-    let column_names = message.fields().iter().map(|f| Some(f.name().to_string()));
-    Ok(RelationDesc::new(
-        RelationType::new(column_types),
-        column_names,
-    ))
 }
 
 #[cfg(test)]
@@ -286,8 +226,12 @@ mod tests {
         ));
         descriptors.add_message(m1);
 
-        let mut relation = super::validate_descriptors(".test.message1", &descriptors)
-            .expect("Failed to parse descriptor");
+        let mut relation = decode::DecodedDescriptors::from_descriptors(
+            &descriptors,
+            ".test.message1".to_string(),
+        )
+        .validate()
+        .expect("Failed to parse descriptor");
 
         sanity_check_relation(
             &relation,
@@ -315,8 +259,12 @@ mod tests {
         ));
         descriptors.add_message(m2);
 
-        relation = super::validate_descriptors(".test.message2", &descriptors)
-            .expect("Failed to parse descriptor");
+        relation = decode::DecodedDescriptors::from_descriptors(
+            &descriptors,
+            ".test.message2".to_string(),
+        )
+        .validate()
+        .expect("Failed to parse descriptor");
 
         sanity_check_relation(
             &relation,
@@ -330,19 +278,22 @@ mod tests {
     }
 
     fn get_decoder(message_name: &str) -> decode::Decoder {
-        let descriptors = Descriptors::from_proto(&gen::file_descriptor_set());
-        let relation = super::validate_descriptors(message_name, &descriptors)
-            .expect("Failed to parse descriptor");
+        let descriptors = decode::DecodedDescriptors::from_fds(
+            &gen::file_descriptor_set(),
+            message_name.to_string(),
+        );
+        let relation = descriptors.validate().expect("Failed to parse descriptor");
 
         sanity_check_relation(
             &relation,
             descriptors
+                .descriptors()
                 .message_by_name(message_name)
                 .expect("message should be in the descriptor set"),
-            &descriptors,
+            descriptors.descriptors(),
         )
         .expect("Sanity checking descriptors failed");
-        decode::Decoder::new(descriptors, message_name)
+        decode::Decoder::new(descriptors)
     }
 
     #[test]

--- a/src/interchange/src/protobuf/decode.rs
+++ b/src/interchange/src/protobuf/decode.rs
@@ -7,79 +7,179 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::borrow::Borrow;
+use std::collections::HashSet;
+
 use anyhow::{anyhow, bail, Context, Result};
 
 use ordered_float::OrderedFloat;
+use protobuf::descriptor::FileDescriptorSet;
 use serde::de::Deserialize;
 use serde_protobuf::de::Deserializer;
 use serde_protobuf::descriptor::{Descriptors, FieldDescriptor, FieldType, MessageDescriptor};
 use serde_protobuf::value::Value as ProtoValue;
 use serde_value::Value as SerdeValue;
 
+use ore::str::StrExt;
 use repr::adt::numeric::Numeric;
-use repr::{ColumnType, Datum, DatumList, Row, ScalarType};
+use repr::{ColumnType, Datum, DatumList, RelationDesc, RelationType, Row, ScalarType};
 
-use crate::protobuf::{proto_message_name, validate_descriptors};
+use crate::protobuf::proto_message_name;
+
+/// Manages required metadata to read protobuf
+#[derive(Debug)]
+pub struct RawDescriptors<'a> {
+    bytes: &'a [u8],
+    message_name: String,
+}
+
+/// Note: Descriptors are not `Clone` so we're use generics here to be able to
+/// support the two following flows:
+///   1. RawDescriptor.decode() -> DecodedDescriptor where the Descriptor must
+///      be construced inline so we cannot hold a reference.
+///   2. Tests, where we would like to be able to construct from a pre-existing
+///      `Descriptor` a `DecodedDescriptor`.  We want to be able to keep the
+///      original `Descriptor` around so we can do some sanity checking with
+///      the result of `DecodedDescriptor.verify()`.  To do this, we want to
+///      pass a borrowed version of `Descriptor`.
+#[derive(Debug)]
+pub struct DecodedDescriptors<D: Borrow<Descriptors>> {
+    descriptors: D,
+    message_name: String,
+}
+
+impl<'a> RawDescriptors<'a> {
+    pub fn new(bytes: &'a [u8], message_name: String) -> Self {
+        Self {
+            bytes,
+            message_name,
+        }
+    }
+
+    pub fn decode(self) -> Result<DecodedDescriptors<Descriptors>> {
+        Ok(DecodedDescriptors {
+            descriptors: Descriptors::from_proto(
+                &protobuf::Message::parse_from_bytes(&self.bytes)
+                    .context("parsing encoded protobuf descriptors failed")?,
+            ),
+            message_name: self.message_name,
+        })
+    }
+}
+
+impl DecodedDescriptors<Descriptors> {
+    pub fn from_fds(fds: &FileDescriptorSet, message_name: String) -> Self {
+        Self {
+            descriptors: Descriptors::from_proto(fds),
+            message_name,
+        }
+    }
+}
+
+impl<D: Borrow<Descriptors>> DecodedDescriptors<D> {
+    pub fn from_descriptors(desc: D, message_name: String) -> Self {
+        Self {
+            descriptors: desc,
+            message_name: message_name,
+        }
+    }
+
+    pub fn descriptors(&self) -> &Descriptors {
+        self.descriptors.borrow()
+    }
+
+    pub fn validate(&self) -> Result<RelationDesc> {
+        let proto_name = proto_message_name(&self.message_name);
+        let message = self
+            .descriptors()
+            .message_by_name(&proto_name)
+            .ok_or_else(|| {
+                // TODO(benesch): the error message here used to include the names of
+                // all messages in the descriptor set, but that one feature required
+                // maintaining a fork of serde_protobuf. I sent the patch upstream [0],
+                // and we can add the error message improvement back if that patch is
+                // accepted.
+                // [0]: https://github.com/dflemstr/serde-protobuf/pull/9
+                anyhow!(
+                    "Message {} not found in file descriptor set",
+                    proto_name.quoted()
+                )
+            })?;
+        let mut seen_messages = HashSet::new();
+        seen_messages.insert(message.name());
+        let column_types = message
+            .fields()
+            .iter()
+            .map(|f| {
+                Ok(ColumnType {
+                    /// All the fields have to be optional, so mark a field as
+                    /// nullable if it doesn't have any defaults
+                    nullable: f.default_value().is_none(),
+                    scalar_type: super::derive_scalar_type_from_proto_field(
+                        &mut seen_messages,
+                        &f,
+                        self.descriptors.borrow(),
+                    )?,
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        let column_names = message.fields().iter().map(|f| Some(f.name().to_string()));
+        Ok(RelationDesc::new(
+            RelationType::new(column_types),
+            column_names,
+        ))
+    }
+}
 
 /// Manages required metadata to read protobuf
 #[derive(Debug)]
 pub struct Decoder {
-    descriptors: Descriptors,
-    message_name: String,
+    descriptors: DecodedDescriptors<Descriptors>,
     packer: Row,
 }
 
 impl Decoder {
     /// Build a decoder from a pre-validated message.
-    ///
-    /// The message `message_name` must exist in the descriptor set and be
-    /// valid.
-    pub fn new(descriptors: Descriptors, message_name: &str) -> Decoder {
+    pub fn new(descriptors: DecodedDescriptors<Descriptors>) -> Self {
         // TODO: verify that name exists
         Decoder {
-            descriptors,
-            message_name: proto_message_name(message_name),
+            descriptors: descriptors,
             packer: Row::default(),
         }
     }
 
     pub fn decode(&mut self, bytes: &[u8]) -> Result<Option<Row>> {
         let input_stream = protobuf::CodedInputStream::from_bytes(bytes);
-        let mut deserializer =
-            Deserializer::for_named_message(&self.descriptors, &self.message_name, input_stream)
-                .map_err(|e| anyhow!("Creating an input stream to parse protobuf: {}", e))?;
+        let mut deserializer = Deserializer::for_named_message(
+            &self.descriptors.descriptors,
+            &self.descriptors.message_name,
+            input_stream,
+        )
+        .map_err(|e| anyhow!("Creating an input stream to parse protobuf: {}", e))?;
         let deserialized_message =
             SerdeValue::deserialize(&mut deserializer).context("Deserializing into rust object")?;
-        let relation_type = validate_descriptors(&self.message_name, &self.descriptors)?;
+        let relation_type = self.descriptors.validate()?;
 
-        let msg_name = &self.message_name;
+        let msg_name = &self.descriptors.message_name;
         let mut packer = &mut self.packer;
         extract_row_into(
             deserialized_message,
-            &self.descriptors,
-            self.descriptors.message_by_name(&msg_name).ok_or_else(|| {
-                anyhow!(
-                    "Message should be included in the descriptor set {:?}",
-                    msg_name
-                )
-            })?,
+            &self.descriptors.descriptors,
+            self.descriptors
+                .descriptors
+                .message_by_name(msg_name)
+                .ok_or_else(|| {
+                    anyhow!(
+                        "Message should be included in the descriptor set {:?}",
+                        msg_name
+                    )
+                })?,
             &relation_type.typ().column_types,
             &mut packer,
         )?;
         Ok(Some(packer.finish_and_reuse()))
     }
-}
-
-#[derive(Debug)]
-pub struct DecodedDescriptors {
-    pub descriptors: Descriptors,
-    // Confluent Schema Registry uses the first Message defined in a .proto file
-    // if multiple Messages are present. If the user is using protobuf + CSR,
-    // we should match this behavior.
-    //
-    // Link to internal discussion:
-    // https://materializeinc.slack.com/archives/C01CFKM1QRF/p1629920709406300
-    pub first_message_name: String,
 }
 
 fn extract_row_into(

--- a/test/testdrive/protobuf.td
+++ b/test/testdrive/protobuf.td
@@ -101,6 +101,8 @@ $ kafka-create-topic topic=simple
 $ set schema
 syntax = "proto3";
 
+import 'google/protobuf/timestamp.proto';
+
 message SimpleId {
   string id = 1;
 }


### PR DESCRIPTION
Refactor handling of protobuf decoding and validation to make #8720 easier to review.  There should be no behavior changes (therefore, no new tests).  Summary of the changes:
- Refactor processing into distinct `decode` and `validate` steps
- Tie `message_name` more closely to schema with `RawDescriptors` and `DecodedDescriptors`
- Remove `Option` from `ProtobufEncoding::message` because we definitely already know what it is by the time we construct it

### Motivation
Pulled out from #8720 which addresses #8297.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
