### PR TITLE
Skeleton for QGM lowering into Mir

### DIFF
--- a/src/sql/src/query_model/dot.rs
+++ b/src/sql/src/query_model/dot.rs
@@ -9,10 +9,10 @@
 
 //! Generates a graphviz graph from a Query Graph Model.
 
-use crate::query_model::{BoxScalarExpr, BoxType, Model, Quantifier, QuantifierId, QueryBox};
+use crate::query_model::{BoxType, Model, Quantifier, QuantifierId, QueryBox};
 use itertools::Itertools;
 use std::cell::RefCell;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::BTreeMap;
 
 /// Generates a graphviz graph from a Query Graph Model, defined in the DOT language.
 /// See <https://graphviz.org/doc/info/lang.html>.
@@ -181,38 +181,21 @@ impl DotGenerator {
     /// Adds red arrows from correlated quantifiers to the sibling quantifiers they
     /// are correlated with.
     fn add_correlation_info(&mut self, model: &Model, b: &QueryBox) {
-        let mut correlation_info: BTreeMap<QuantifierId, Vec<QuantifierId>> = BTreeMap::new();
-        for q_id in b.quantifiers.iter() {
-            // collect the column references from the current context within
-            // the subgraph under the current quantifier
-            let mut column_refs = HashSet::new();
-            let mut f = |inner_box: &RefCell<QueryBox>| -> Result<(), ()> {
-                inner_box.borrow().visit_expressions(
-                    &mut |expr: &BoxScalarExpr| -> Result<(), ()> {
-                        expr.collect_column_references_from_context(
-                            &b.quantifiers,
-                            &mut column_refs,
-                        );
-                        Ok(())
-                    },
+        let correlation_info: BTreeMap<QuantifierId, Vec<QuantifierId>> = b
+            .correlation_info(model)
+            .into_iter()
+            .map(|(id, column_refs)| {
+                (
+                    id,
+                    column_refs
+                        .iter()
+                        .map(|c| c.quantifier_id)
+                        .sorted()
+                        .unique()
+                        .collect::<Vec<_>>(),
                 )
-            };
-            let q = model.get_quantifier(*q_id).borrow();
-            model
-                .visit_pre_boxes_in_subgraph(&mut f, q.input_box)
-                .unwrap();
-            // collect the unique quantifiers referenced by the subgraph
-            // under the current quantifier
-            correlation_info.insert(
-                q.id,
-                column_refs
-                    .iter()
-                    .map(|c| c.quantifier_id)
-                    .sorted()
-                    .unique()
-                    .collect::<Vec<_>>(),
-            );
-        }
+            })
+            .collect();
 
         for (correlated_q, quantifiers) in correlation_info.iter() {
             for q in quantifiers.iter() {

--- a/src/sql/src/query_model/hir.rs
+++ b/src/sql/src/query_model/hir.rs
@@ -225,6 +225,7 @@ impl FromHir {
         unreachable!("column not found")
     }
 
+    /// Executes the given action within the context of the given box.
     fn within_context<F, T>(&mut self, context_box: BoxId, f: &mut F) -> T
     where
         F: FnMut(&mut Self) -> T,

--- a/src/sql/src/query_model/hir.rs
+++ b/src/sql/src/query_model/hir.rs
@@ -11,9 +11,10 @@
 
 use itertools::Itertools;
 
-use crate::plan::HirScalarExpr;
+use crate::plan::expr::{HirScalarExpr, JoinKind};
 use crate::query_model::{
-    BoxId, BoxScalarExpr, BoxType, Column, ColumnReference, Model, QuantifierType, Values,
+    BoxId, BoxScalarExpr, BoxType, Column, ColumnReference, Model, OuterJoin, QuantifierType,
+    Select, Values,
 };
 
 use crate::plan::expr::HirRelationExpr;
@@ -26,6 +27,8 @@ impl From<&HirRelationExpr> for Model {
 
 struct FromHir {
     model: Model,
+    /// The stack of context boxes for resolving offset-based column references.
+    context_stack: Vec<BoxId>,
 }
 
 impl FromHir {
@@ -33,6 +36,7 @@ impl FromHir {
     fn generate(expr: &HirRelationExpr) -> Model {
         let mut generator = FromHir {
             model: Model::new(),
+            context_stack: Vec::new(),
         };
         generator.model.top_box = generator.generate_select(expr);
         generator.model
@@ -48,6 +52,7 @@ impl FromHir {
         box_id
     }
 
+    /// Generates a sub-graph representing the given expression.
     fn generate_internal(&mut self, expr: &HirRelationExpr) -> BoxId {
         match expr {
             // HirRelationExpr::Get { id, typ } => {
@@ -69,6 +74,22 @@ impl FromHir {
                 }
                 box_id
             }
+            HirRelationExpr::Filter { input, predicates } => {
+                let input_box = self.generate_internal(input);
+                // We could install the predicates in `input_box` if it happened
+                // to be a `Select` box. However, that would require pushing down
+                // the predicates through its projection, since the predicates are
+                // written in terms of elements in `input`'s projection.
+                // Instead, we just install a new `Select` box for holding the
+                // predicate, and let normalization tranforms simply the graph.
+                let select_id = self.wrap_within_select(input_box);
+                for predicate in predicates {
+                    let expr = self.generate_expr(predicate, select_id);
+                    self.add_predicate(select_id, expr);
+                }
+                select_id
+            }
+
             HirRelationExpr::Project { input, outputs } => {
                 let input_box_id = self.generate_internal(input);
                 let select_id = self.model.make_select_box();
@@ -87,7 +108,65 @@ impl FromHir {
                 }
                 select_id
             }
-            _ => panic!("unsupported expression type"),
+            HirRelationExpr::Join {
+                left,
+                right,
+                on,
+                kind,
+            } => {
+                let (box_type, left_q_type, right_q_type) = match kind {
+                    JoinKind::Inner { .. } => (
+                        BoxType::Select(Select::default()),
+                        QuantifierType::Foreach,
+                        QuantifierType::Foreach,
+                    ),
+                    JoinKind::LeftOuter { .. } => (
+                        BoxType::OuterJoin(OuterJoin::default()),
+                        QuantifierType::PreservedForeach,
+                        QuantifierType::Foreach,
+                    ),
+                    JoinKind::RightOuter => (
+                        BoxType::OuterJoin(OuterJoin::default()),
+                        QuantifierType::Foreach,
+                        QuantifierType::PreservedForeach,
+                    ),
+                    JoinKind::FullOuter => (
+                        BoxType::OuterJoin(OuterJoin::default()),
+                        QuantifierType::PreservedForeach,
+                        QuantifierType::PreservedForeach,
+                    ),
+                };
+                let join_box = self.model.make_box(box_type);
+
+                // Left box
+                let left_box = self.generate_internal(left);
+                self.model.make_quantifier(left_q_type, left_box, join_box);
+
+                // Right box
+                let right_box = if kind.is_lateral() {
+                    self.within_context(join_box, &mut |generator| -> BoxId {
+                        generator.generate_internal(right)
+                    })
+                } else {
+                    self.generate_internal(right)
+                };
+                self.model
+                    .make_quantifier(right_q_type, right_box, join_box);
+
+                // ON clause
+                let predicate = self.generate_expr(on, join_box);
+                self.add_predicate(join_box, predicate);
+
+                // Default projection
+                self.model
+                    .get_box(join_box)
+                    .borrow_mut()
+                    .add_all_input_columns(&self.model);
+
+                join_box
+            }
+
+            _ => panic!("unsupported expression type {:?}", expr),
         }
     }
 
@@ -102,19 +181,34 @@ impl FromHir {
         select_id
     }
 
+    /// Lowers the given expression within the context of the given box.
+    ///
+    /// Note that this method may add new quantifiers to the box for subquery
+    /// expressions.
     fn generate_expr(&mut self, expr: &HirScalarExpr, context_box: BoxId) -> BoxScalarExpr {
         match expr {
             HirScalarExpr::Literal(row, col_type) => {
                 BoxScalarExpr::Literal(row.clone(), col_type.clone())
             }
             HirScalarExpr::Column(c) => {
-                assert!(c.level == 0, "correlated columns not yet supported");
+                let context_box = match c.level {
+                    0 => context_box,
+                    _ => self.context_stack[self.context_stack.len() - c.level],
+                };
                 BoxScalarExpr::ColumnReference(self.find_column_within_box(context_box, c.column))
             }
-            _ => panic!("unsupported expression type"),
+            _ => panic!("unsupported expression type {:?}", expr),
         }
     }
 
+    /// Find the N-th column among the columns projected by the input quantifiers
+    /// of the given box. This method translates Hir's offset-based column into
+    /// quantifier-based column references.
+    ///
+    /// This method is equivalent to `expr::JoinInputMapper::map_column_to_local`, in
+    /// the sense that given all the columns projected by a join (represented by the
+    /// set of input quantifiers of the given box) it returns the input the column
+    /// belongs to and its offset within the projection of the underlying operator.
     fn find_column_within_box(&self, box_id: BoxId, mut position: usize) -> ColumnReference {
         let b = self.model.get_box(box_id).borrow();
         for q_id in b.quantifiers.iter() {
@@ -128,6 +222,29 @@ impl FromHir {
             }
             position -= ib.columns.len();
         }
-        panic!("column not found")
+        unreachable!("column not found")
+    }
+
+    fn within_context<F, T>(&mut self, context_box: BoxId, f: &mut F) -> T
+    where
+        F: FnMut(&mut Self) -> T,
+    {
+        self.context_stack.push(context_box);
+        let result = f(self);
+        self.context_stack.pop();
+        result
+    }
+
+    /// Adds the given predicate to the given box.
+    ///
+    /// The given box must support predicates, ie. it must be either a Select box
+    /// or an OuterJoin one.
+    fn add_predicate(&mut self, box_id: BoxId, predicate: BoxScalarExpr) {
+        let mut the_box = self.model.get_box(box_id).borrow_mut();
+        match &mut the_box.box_type {
+            BoxType::Select(select) => select.predicates.push(Box::new(predicate)),
+            BoxType::OuterJoin(outer_join) => outer_join.predicates.push(Box::new(predicate)),
+            _ => unreachable!(),
+        }
     }
 }

--- a/src/sql/src/query_model/lowering.rs
+++ b/src/sql/src/query_model/lowering.rs
@@ -1,0 +1,243 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::query_model::{
+    BoxId, BoxScalarExpr, BoxType, ColumnReference, DistinctOperation, Model, QuantifierSet,
+    QuantifierType,
+};
+use itertools::Itertools;
+use repr::RelationType;
+use std::collections::HashMap;
+
+/// Maps a column reference to a specific column position.
+///
+/// This is used for resolving column references when lowering expressions
+/// on top of a `MirRelationExpr`, where it maps each column reference with
+/// with a column position within the projection of that `MirRelationExpr`.
+type ColumnMap = HashMap<ColumnReference, usize>;
+
+impl Model {
+    pub fn lower(&self) -> expr::MirRelationExpr {
+        let mut lowerer = Lowerer::new(self);
+        let mut id_gen = ore::id_gen::IdGen::default();
+        expr::MirRelationExpr::constant(vec![vec![]], RelationType::new(vec![]))
+            .let_in(&mut id_gen, |_id_gen, get_outer| {
+                lowerer.apply(self.top_box, get_outer, &ColumnMap::new())
+            })
+    }
+}
+
+struct Lowerer<'a> {
+    model: &'a Model,
+}
+
+impl<'a> Lowerer<'a> {
+    fn new(model: &'a Model) -> Self {
+        Self { model }
+    }
+
+    /// Applies the given box identified by its ID to the given outer relation.
+    fn apply(
+        &mut self,
+        box_id: BoxId,
+        get_outer: expr::MirRelationExpr,
+        outer_column_map: &ColumnMap,
+    ) -> expr::MirRelationExpr {
+        use expr::MirRelationExpr as SR;
+        let the_box = self.model.get_box(box_id).borrow();
+
+        assert_eq!(
+            the_box.distinct,
+            DistinctOperation::Preserve,
+            "DISTINCT is not supported yet"
+        );
+
+        match &the_box.box_type {
+            BoxType::Values(values) => {
+                let identity = SR::constant(vec![vec![]], RelationType::new(vec![]));
+                // TODO(asenac) lower actual values
+                assert!(values.rows.len() == 1 && the_box.columns.len() == 0);
+                get_outer.product(identity)
+            }
+            BoxType::Select(select) => {
+                assert!(select.order_key.is_none(), "ORDER BY is not supported yet");
+                assert!(
+                    select.limit.is_none() && select.offset.is_none(),
+                    "LIMIT/OFFSET is not supported yet"
+                );
+                // A Select box combines three operations, join, filter and project,
+                // in that order.
+
+                // 1) Lower the join component of the Select box.
+                // TODO(asenac) We could join first all non-correlated quantifiers
+                // and then apply the correlated ones one by one in order of dependency
+                // on top the join built so far, adding the predicates as soon as their
+                // dependencies are satisfied.
+                let correlation_info = the_box.correlation_info(&self.model);
+                if !correlation_info.is_empty() {
+                    panic!("correlated joins are not supported yet");
+                }
+
+                let outer_arity = get_outer.arity();
+                let (mut input, column_map) =
+                    self.lower_join(get_outer, outer_column_map, &the_box.quantifiers);
+                let input_arity = input.arity();
+
+                // 2) Lower the filter component.
+                if !select.predicates.is_empty() {
+                    input = input.filter(
+                        select
+                            .predicates
+                            .iter()
+                            .map(|p| Self::lower_expression(p, &column_map)),
+                    );
+                }
+
+                // 3) Lower the project component.
+                if !the_box.columns.is_empty() {
+                    input = input.map(
+                        the_box
+                            .columns
+                            .iter()
+                            .map(|c| Self::lower_expression(&c.expr, &column_map))
+                            .collect_vec(),
+                    );
+                }
+
+                // Project the outer columns plus the ones in the projection of
+                // this select box
+                input.project(
+                    (0..outer_arity)
+                        .chain(input_arity..input_arity + the_box.columns.len())
+                        .collect_vec(),
+                )
+            }
+            _ => panic!(),
+        }
+    }
+
+    /// Generates a join among the result of applying the outer relation to the given
+    /// quantifiers. Returns a relation and a map of column references that can be
+    /// used to lower expressions that sit directly on top of the join.
+    ///
+    /// The quantifiers are joined on the columns of the outer relation.
+    /// TODO(asenac) Since decorrelation is not yet supported the outer relation is
+    /// currently always the join identity, so the result of this method is always
+    /// a cross-join of the given quantifiers, which makes part of this code untesteable
+    /// at the moment.
+    fn lower_join(
+        &mut self,
+        get_outer: expr::MirRelationExpr,
+        outer_column_map: &ColumnMap,
+        quantifiers: &QuantifierSet,
+    ) -> (expr::MirRelationExpr, ColumnMap) {
+        if let expr::MirRelationExpr::Get { .. } = &get_outer {
+        } else {
+            panic!(
+                "get_outer: expected a MirRelationExpr::Get, found {:?}",
+                get_outer
+            );
+        }
+
+        let outer_arity = get_outer.arity();
+
+        // TODO(asenac) Lower scalar subquery quantifiers
+        assert!(quantifiers.iter().all(|q_id| {
+            self.model.get_quantifier(*q_id).borrow().quantifier_type == QuantifierType::Foreach
+        }));
+
+        let join_inputs = quantifiers
+            .iter()
+            .map(|q_id| {
+                let input_box = self.model.get_quantifier(*q_id).borrow().input_box;
+                self.apply(input_box, get_outer.clone(), outer_column_map)
+            })
+            .collect_vec();
+
+        let join = if join_inputs.len() == 1 {
+            join_inputs.into_iter().next().unwrap()
+        } else {
+            Self::join_on_prefix(join_inputs, outer_arity)
+        };
+
+        // Generate a column map with the projection of the join plus the
+        // columns from the outer context.
+        let mut column_map = outer_column_map.clone();
+        let mut next_column = outer_arity;
+        for q_id in quantifiers.iter() {
+            let input_box = self.model.get_quantifier(*q_id).borrow().input_box;
+            let arity = self.model.get_box(input_box).borrow().columns.len();
+            for c in 0..arity {
+                column_map.insert(
+                    ColumnReference {
+                        quantifier_id: *q_id,
+                        position: c,
+                    },
+                    next_column + c,
+                );
+            }
+
+            next_column += arity;
+        }
+
+        (join, column_map)
+    }
+
+    /// Join the given inputs on a shared common prefix.
+    ///
+    /// TODO(asenac) Given the lack of support for decorrelation at the moment, this
+    /// method is always called with `prefix_length` 0, and hence, it remains untested.
+    fn join_on_prefix(
+        join_inputs: Vec<expr::MirRelationExpr>,
+        prefix_length: usize,
+    ) -> expr::MirRelationExpr {
+        let input_mapper = expr::JoinInputMapper::new(&join_inputs);
+        // Join on the outer columns
+        let equivalences = (0..prefix_length)
+            .map(|col| {
+                join_inputs
+                    .iter()
+                    .enumerate()
+                    .map(|(input, _)| {
+                        expr::MirScalarExpr::Column(input_mapper.map_column_to_global(col, input))
+                    })
+                    .collect_vec()
+            })
+            .collect_vec();
+        // Project only one copy of the outer columns
+        let projection = (0..prefix_length)
+            .chain(
+                join_inputs
+                    .iter()
+                    .enumerate()
+                    .map(|(index, input)| {
+                        (prefix_length..input.arity())
+                            .map(|c| input_mapper.map_column_to_global(c, index))
+                            .collect_vec()
+                    })
+                    .flatten(),
+            )
+            .collect_vec();
+        expr::MirRelationExpr::join_scalars(join_inputs, equivalences).project(projection)
+    }
+
+    /// Lowers a scalar expression, resolving the column references using
+    /// the supplied column map.
+    fn lower_expression(expr: &BoxScalarExpr, column_map: &ColumnMap) -> expr::MirScalarExpr {
+        match expr {
+            BoxScalarExpr::ColumnReference(c) => {
+                expr::MirScalarExpr::Column(*column_map.get(c).unwrap())
+            }
+            BoxScalarExpr::Literal(row, column_type) => {
+                expr::MirScalarExpr::Literal(Ok(row.clone()), column_type.clone())
+            }
+            _ => panic!("unsupported expression"),
+        }
+    }
+}

--- a/src/sql/src/query_model/scalar_expr.rs
+++ b/src/sql/src/query_model/scalar_expr.rs
@@ -51,6 +51,7 @@ pub struct ColumnReference {
 #[derive(Debug, PartialEq, Clone)]
 pub struct BaseColumn {
     pub position: usize,
+    pub column_type: repr::ColumnType,
 }
 
 impl fmt::Display for BoxScalarExpr {

--- a/src/sql/tests/querymodel/basic
+++ b/src/sql/tests/querymodel/basic
@@ -139,3 +139,322 @@ digraph G {
     Q1 -> boxhead1 [ lhead = cluster1 ]
     Q0 -> boxhead0 [ lhead = cluster0 ]
 }
+
+build
+select a from (select 1 as a, true as b) where b;
+----
+digraph G {
+    compound = true
+    labeljust = l
+    label="select a from (select 1 as a, true as b) where b;"
+    node [ shape = box ]
+    subgraph cluster3 {
+        label = "Box3:Select"
+        boxhead3 [ shape = record, label="{ Distinct: Preserve| 0: Q2.C0 }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q2 [ label="Q2(F)" ]
+        }
+    }
+    subgraph cluster2 {
+        label = "Box2:Select"
+        boxhead2 [ shape = record, label="{ Distinct: Preserve| 0: Q1.C0| 1: Q1.C1| Q1.C1 }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q1 [ label="Q1(F)" ]
+        }
+    }
+    subgraph cluster1 {
+        label = "Box1:Select"
+        boxhead1 [ shape = record, label="{ Distinct: Preserve| 0: 1| 1: true }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q0 [ label="Q0(F)" ]
+        }
+    }
+    subgraph cluster0 {
+        label = "Box0:Values"
+        boxhead0 [ shape = record, label="{ Distinct: Preserve| ROW 0:  }" ]
+        {
+            rank = same
+        }
+    }
+    edge [ arrowhead = none, style = dashed ]
+    Q2 -> boxhead2 [ lhead = cluster2 ]
+    Q1 -> boxhead1 [ lhead = cluster1 ]
+    Q0 -> boxhead0 [ lhead = cluster0 ]
+}
+
+build
+select x.a from (select true as a) x join (select false as b) y on x.a;
+----
+digraph G {
+    compound = true
+    labeljust = l
+    label="select x.a from (select true as a) x join (select false as b) y on x.a;"
+    node [ shape = box ]
+    subgraph cluster5 {
+        label = "Box5:Select"
+        boxhead5 [ shape = record, label="{ Distinct: Preserve| 0: Q4.C0 }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q4 [ label="Q4(F)" ]
+        }
+    }
+    subgraph cluster0 {
+        label = "Box0:Select"
+        boxhead0 [ shape = record, label="{ Distinct: Preserve| 0: Q1.C0| 1: Q3.C0| Q1.C0 }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q1 [ label="Q1(F)" ]
+            Q3 [ label="Q3(F)" ]
+        }
+    }
+    subgraph cluster2 {
+        label = "Box2:Select"
+        boxhead2 [ shape = record, label="{ Distinct: Preserve| 0: true }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q0 [ label="Q0(F)" ]
+        }
+    }
+    subgraph cluster1 {
+        label = "Box1:Values"
+        boxhead1 [ shape = record, label="{ Distinct: Preserve| ROW 0:  }" ]
+        {
+            rank = same
+        }
+    }
+    subgraph cluster4 {
+        label = "Box4:Select"
+        boxhead4 [ shape = record, label="{ Distinct: Preserve| 0: false }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q2 [ label="Q2(F)" ]
+        }
+    }
+    subgraph cluster3 {
+        label = "Box3:Values"
+        boxhead3 [ shape = record, label="{ Distinct: Preserve| ROW 0:  }" ]
+        {
+            rank = same
+        }
+    }
+    edge [ arrowhead = none, style = dashed ]
+    Q4 -> boxhead0 [ lhead = cluster0 ]
+    Q1 -> boxhead2 [ lhead = cluster2 ]
+    Q3 -> boxhead4 [ lhead = cluster4 ]
+    Q0 -> boxhead1 [ lhead = cluster1 ]
+    Q2 -> boxhead3 [ lhead = cluster3 ]
+}
+
+
+build
+select x.a from (select true as a) x join lateral(select a) y on x.a;
+----
+digraph G {
+    compound = true
+    labeljust = l
+    label="select x.a from (select true as a) x join lateral(select a) y on x.a;"
+    node [ shape = box ]
+    subgraph cluster5 {
+        label = "Box5:Select"
+        boxhead5 [ shape = record, label="{ Distinct: Preserve| 0: Q4.C0 }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q4 [ label="Q4(F)" ]
+        }
+    }
+    subgraph cluster0 {
+        label = "Box0:Select"
+        boxhead0 [ shape = record, label="{ Distinct: Preserve| 0: Q1.C0| 1: Q3.C0| Q1.C0 }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q1 [ label="Q1(F)" ]
+            Q3 [ label="Q3(F)" ]
+            Q3 -> Q1 [ label = "correlation", style = filled, color = red ]
+        }
+    }
+    subgraph cluster2 {
+        label = "Box2:Select"
+        boxhead2 [ shape = record, label="{ Distinct: Preserve| 0: true }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q0 [ label="Q0(F)" ]
+        }
+    }
+    subgraph cluster1 {
+        label = "Box1:Values"
+        boxhead1 [ shape = record, label="{ Distinct: Preserve| ROW 0:  }" ]
+        {
+            rank = same
+        }
+    }
+    subgraph cluster4 {
+        label = "Box4:Select"
+        boxhead4 [ shape = record, label="{ Distinct: Preserve| 0: Q1.C0 }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q2 [ label="Q2(F)" ]
+        }
+    }
+    subgraph cluster3 {
+        label = "Box3:Values"
+        boxhead3 [ shape = record, label="{ Distinct: Preserve| ROW 0:  }" ]
+        {
+            rank = same
+        }
+    }
+    edge [ arrowhead = none, style = dashed ]
+    Q4 -> boxhead0 [ lhead = cluster0 ]
+    Q1 -> boxhead2 [ lhead = cluster2 ]
+    Q3 -> boxhead4 [ lhead = cluster4 ]
+    Q0 -> boxhead1 [ lhead = cluster1 ]
+    Q2 -> boxhead3 [ lhead = cluster3 ]
+}
+
+build
+select x.a from (select true as a) x left join (select false as b) y on x.a;
+----
+digraph G {
+    compound = true
+    labeljust = l
+    label="select x.a from (select true as a) x left join (select false as b) y on x.a;"
+    node [ shape = box ]
+    subgraph cluster5 {
+        label = "Box5:Select"
+        boxhead5 [ shape = record, label="{ Distinct: Preserve| 0: Q4.C0 }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q4 [ label="Q4(F)" ]
+        }
+    }
+    subgraph cluster0 {
+        label = "Box0:OuterJoin"
+        boxhead0 [ shape = record, label="{ Distinct: Preserve| 0: Q1.C0| 1: Q3.C0| Q1.C0 }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q1 [ label="Q1(P)" ]
+            Q3 [ label="Q3(F)" ]
+        }
+    }
+    subgraph cluster2 {
+        label = "Box2:Select"
+        boxhead2 [ shape = record, label="{ Distinct: Preserve| 0: true }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q0 [ label="Q0(F)" ]
+        }
+    }
+    subgraph cluster1 {
+        label = "Box1:Values"
+        boxhead1 [ shape = record, label="{ Distinct: Preserve| ROW 0:  }" ]
+        {
+            rank = same
+        }
+    }
+    subgraph cluster4 {
+        label = "Box4:Select"
+        boxhead4 [ shape = record, label="{ Distinct: Preserve| 0: false }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q2 [ label="Q2(F)" ]
+        }
+    }
+    subgraph cluster3 {
+        label = "Box3:Values"
+        boxhead3 [ shape = record, label="{ Distinct: Preserve| ROW 0:  }" ]
+        {
+            rank = same
+        }
+    }
+    edge [ arrowhead = none, style = dashed ]
+    Q4 -> boxhead0 [ lhead = cluster0 ]
+    Q1 -> boxhead2 [ lhead = cluster2 ]
+    Q3 -> boxhead4 [ lhead = cluster4 ]
+    Q0 -> boxhead1 [ lhead = cluster1 ]
+    Q2 -> boxhead3 [ lhead = cluster3 ]
+}
+
+build
+select x.a from (select true as a) x left join lateral (select a as b) y on x.a;
+----
+digraph G {
+    compound = true
+    labeljust = l
+    label="select x.a from (select true as a) x left join lateral (select a as b) y on x.a;"
+    node [ shape = box ]
+    subgraph cluster5 {
+        label = "Box5:Select"
+        boxhead5 [ shape = record, label="{ Distinct: Preserve| 0: Q4.C0 }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q4 [ label="Q4(F)" ]
+        }
+    }
+    subgraph cluster0 {
+        label = "Box0:OuterJoin"
+        boxhead0 [ shape = record, label="{ Distinct: Preserve| 0: Q1.C0| 1: Q3.C0| Q1.C0 }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q1 [ label="Q1(P)" ]
+            Q3 [ label="Q3(F)" ]
+            Q3 -> Q1 [ label = "correlation", style = filled, color = red ]
+        }
+    }
+    subgraph cluster2 {
+        label = "Box2:Select"
+        boxhead2 [ shape = record, label="{ Distinct: Preserve| 0: true }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q0 [ label="Q0(F)" ]
+        }
+    }
+    subgraph cluster1 {
+        label = "Box1:Values"
+        boxhead1 [ shape = record, label="{ Distinct: Preserve| ROW 0:  }" ]
+        {
+            rank = same
+        }
+    }
+    subgraph cluster4 {
+        label = "Box4:Select"
+        boxhead4 [ shape = record, label="{ Distinct: Preserve| 0: Q1.C0 }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q2 [ label="Q2(F)" ]
+        }
+    }
+    subgraph cluster3 {
+        label = "Box3:Values"
+        boxhead3 [ shape = record, label="{ Distinct: Preserve| ROW 0:  }" ]
+        {
+            rank = same
+        }
+    }
+    edge [ arrowhead = none, style = dashed ]
+    Q4 -> boxhead0 [ lhead = cluster0 ]
+    Q1 -> boxhead2 [ lhead = cluster2 ]
+    Q3 -> boxhead4 [ lhead = cluster4 ]
+    Q0 -> boxhead1 [ lhead = cluster1 ]
+    Q2 -> boxhead3 [ lhead = cluster3 ]
+}

--- a/src/sql/tests/querymodel/lowering
+++ b/src/sql/tests/querymodel/lowering
@@ -1,0 +1,121 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+lower
+select;
+----
+----
+%0 = Let l0 =
+| Constant ()
+
+%1 =
+| Constant ()
+
+%2 =
+| Join %0 %1
+| | implementation = Unimplemented
+| Project ()
+----
+----
+
+lower
+select 1;
+----
+----
+%0 = Let l0 =
+| Constant ()
+
+%1 =
+| Constant ()
+
+%2 =
+| Join %0 %1
+| | implementation = Unimplemented
+| Map 1
+| Project (#0)
+----
+----
+
+lower
+select a, a from (select 1 as a);
+----
+----
+%0 = Let l0 =
+| Constant ()
+
+%1 =
+| Constant ()
+
+%2 =
+| Join %0 %1
+| | implementation = Unimplemented
+| Map 1
+| Project (#0)
+| Map #0, #0
+| Project (#1, #2)
+----
+----
+
+
+lower
+select a, b, a from (select 1 as a, 2 as b);
+----
+----
+%0 = Let l0 =
+| Constant ()
+
+%1 =
+| Constant ()
+
+%2 =
+| Join %0 %1
+| | implementation = Unimplemented
+| Map 1, 2
+| Project (#0, #1)
+| Map #0, #1, #0
+| Project (#2..#4)
+----
+----
+
+lower
+select x.a from (select true as a) x join (select false as b) y on x.a;
+----
+----
+%0 = Let l0 =
+| Constant ()
+
+%1 =
+| Constant ()
+
+%2 =
+| Join %0 %1
+| | implementation = Unimplemented
+| Map true
+| Project (#0)
+
+%3 =
+| Constant ()
+
+%4 =
+| Join %0 %3
+| | implementation = Unimplemented
+| Map false
+| Project (#0)
+
+%5 =
+| Join %2 %4
+| | implementation = Unimplemented
+| Project (#0, #1)
+| Filter #0
+| Map #0, #1
+| Project (#2, #3)
+| Map #0
+| Project (#2)
+----
+----


### PR DESCRIPTION
<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug. [Link to issue.]

  * This PR adds a known-desirable feature. [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

This PR adds the skeleton for the new lowering code that converts QGM into Mir. Part of #8073.

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

The first commit adds support Hir->QGM for Filter and Join (including lateral and outer ones).

The second commit adds a lowering module that supports for everything we can currently import from Hir, but correlated and outer joins.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
