### PR TITLE
repr: move `&self` `Row` methods under `RowRef` and use `Deref`

### DIFF
--- a/src/interchange/src/avro/envelope_cdc_v2.rs
+++ b/src/interchange/src/avro/envelope_cdc_v2.rs
@@ -62,7 +62,7 @@ impl Encoder {
     pub fn encode_updates(&self, updates: &[(Row, i64, i64)]) -> Value {
         let mut enc_updates = Vec::new();
         for (data, time, diff) in updates {
-            let enc_data = super::encode_datums_as_avro(data, &self.columns);
+            let enc_data = super::encode_datums_as_avro(&**data, &self.columns);
             let enc_time = Value::Long(time.clone());
             let enc_diff = Value::Long(diff.clone());
             enc_updates.push(Value::Record(vec![

--- a/src/repr/benches/row.rs
+++ b/src/repr/benches/row.rs
@@ -61,7 +61,7 @@ fn bench_sort_unpacked(rows: Vec<Vec<Datum>>, b: &mut Bencher) {
         |rows| {
             let mut unpacked = vec![];
             for row in &rows {
-                unpacked.extend(row);
+                unpacked.extend(&**row);
             }
             let mut slices = unpacked.chunks(arity).collect::<Vec<_>>();
             slices.sort();

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -134,9 +134,9 @@ impl Ord for Row {
 /// need not contain a `Row`, for example large contiguous `[u8]` allocations.
 /// It is not expected that most users will use this type, especially as its
 /// only constructor is unsafe.
-#[derive(Debug)]
-pub struct RowRef<'a> {
-    data: &'a [u8],
+#[repr(transparent)]
+pub struct RowRef {
+    data: [u8],
 }
 
 #[derive(Debug)]
@@ -792,30 +792,6 @@ impl Row {
         row
     }
 
-    /// Unpack `self` into a `Vec<Datum>` for efficient random access.
-    pub fn unpack(&self) -> Vec<Datum> {
-        // It's usually cheaper to unpack twice to figure out the right length than it is to grow the vec as we go
-        let len = self.iter().count();
-        let mut vec = Vec::with_capacity(len);
-        vec.extend(self.iter());
-        vec
-    }
-
-    /// Return the first `Datum` in `self`
-    ///
-    /// Panics if the `Row` is empty.
-    pub fn unpack_first(&self) -> Datum {
-        self.iter().next().unwrap()
-    }
-
-    /// Iterate the `Datum` elements of the `Row`.
-    pub fn iter(&self) -> DatumListIter {
-        DatumListIter {
-            data: &self.data,
-            offset: 0,
-        }
-    }
-
     /// Pushes a [`DatumList`] that is built from a closure.
     ///
     /// The supplied closure will be invoked once with a `Row` that can
@@ -1044,14 +1020,9 @@ impl Row {
         // SAFETY: iterator offsets always lie on a datum boundary.
         unsafe { self.truncate(offset) }
     }
-
-    /// For debugging only
-    pub fn data(&self) -> &[u8] {
-        &self.data
-    }
 }
 
-impl<'a> RowRef<'a> {
+impl RowRef {
     /// Construct a `RowRef` from a byte slice.
     ///
     /// # Safety
@@ -1059,8 +1030,10 @@ impl<'a> RowRef<'a> {
     /// This method is unsafe because if the byte slice is not a valid
     /// row encoding, then unpacking its contents can cause undefined
     /// behavior.
-    pub unsafe fn from_bytes_unchecked(data: &'a [u8]) -> Self {
-        Self { data }
+    pub unsafe fn from_bytes_unchecked(data: &[u8]) -> &Self {
+        // SAFETY: RowRef just wraps [u8], and data is &[u8],
+        // therefore transmuting &[u8] to &RowRef is safe.
+        std::mem::transmute(data)
     }
 
     /// Unpack `self` into a `Vec<Datum>` for efficient random access.
@@ -1086,9 +1059,23 @@ impl<'a> RowRef<'a> {
             offset: 0,
         }
     }
+
+    /// For debugging only
+    pub fn data(&self) -> &[u8] {
+        &self.data
+    }
 }
 
-impl<'a> IntoIterator for &'a Row {
+impl std::ops::Deref for Row {
+    type Target = RowRef;
+
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: self.data is a valid Row encoding since self is a Row
+        unsafe { RowRef::from_bytes_unchecked(&*self.data) }
+    }
+}
+
+impl<'a> IntoIterator for &'a RowRef {
     type Item = Datum<'a>;
     type IntoIter = DatumListIter<'a>;
     fn into_iter(self) -> DatumListIter<'a> {
@@ -1096,7 +1083,7 @@ impl<'a> IntoIterator for &'a Row {
     }
 }
 
-impl fmt::Debug for Row {
+impl fmt::Debug for RowRef {
     /// Debug representation using the internal datums
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str("Row{")?;
@@ -1105,7 +1092,14 @@ impl fmt::Debug for Row {
     }
 }
 
-impl fmt::Display for Row {
+impl fmt::Debug for Row {
+    /// Debug representation using the internal datums
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&**self, f)
+    }
+}
+
+impl fmt::Display for RowRef {
     /// Display representation using the internal datums
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str("(")?;
@@ -1116,6 +1110,13 @@ impl fmt::Display for Row {
             write!(f, "{}", datum)?;
         }
         f.write_str(")")
+    }
+}
+
+impl fmt::Display for Row {
+    /// Debug representation using the internal datums
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&**self, f)
     }
 }
 


### PR DESCRIPTION
### Motivation

   * This PR refactors existing code.

Make `RowRef` the canonical representation of a borrowed Row. All the methods on Row that had a `&self` receiver have now been moved under RowRef and are available through a `Deref<Target=RowRef>` implementation.

It is necessary to mark RowRef's representation as transparent in order to safely transmute from `&u8` to `&RowRef`. The safety argument is exactly the same as stdlib's for the equivalent cases of `PathBuf` -> `Path` and `OsString` -> `OsStr`.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
