### PR TITLE
persist: introduce ingest-side workers in nemesis

### DIFF
--- a/src/persist/src/golden_test.rs
+++ b/src/persist/src/golden_test.rs
@@ -18,9 +18,9 @@ use crate::error::{Error, ErrorLog};
 use crate::indexed::runtime::{self, RuntimeClient, RuntimeConfig};
 use crate::indexed::Snapshot;
 use crate::mem::{MemBlob, MemRegistry};
-use crate::nemesis::direct::Direct;
+use crate::nemesis::direct::{Direct, StartRuntime};
 use crate::nemesis::generator::{Generator, GeneratorConfig};
-use crate::nemesis::{Input, Runtime};
+use crate::nemesis::{Input, Runtime, RuntimeWorker};
 use crate::storage::Blob;
 use crate::unreliable::UnreliableBlob;
 
@@ -152,25 +152,35 @@ fn golden_state(blob_json: &str) -> Result<PersistState, Error> {
 }
 
 fn current_state(reqs: &[Input]) -> Result<(PersistState, String), Error> {
+    #[derive(Debug)]
+    struct GoldenStartRuntime(MemRegistry);
+
+    impl StartRuntime for GoldenStartRuntime {
+        fn start_runtime(
+            &mut self,
+            unreliable: crate::unreliable::UnreliableHandle,
+        ) -> Result<RuntimeClient, Error> {
+            let blob = self.0.blob_no_reentrance()?;
+            let blob = UnreliableBlob::from_handle(blob, unreliable);
+            runtime::start(
+                RuntimeConfig::for_tests(),
+                ErrorLog,
+                blob,
+                &MetricsRegistry::new(),
+                None,
+            )
+        }
+    }
+
     let runtime = Arc::new(tokio::runtime::Runtime::new()?);
     let reg = MemRegistry::new();
-    let runtime_reg = reg.clone();
-    let runtime_closure = Arc::clone(&runtime);
-    let mut persist = Direct::new(move |unreliable| {
-        let blob = runtime_reg.blob_no_reentrance()?;
-        let blob = UnreliableBlob::from_handle(blob, unreliable);
-        runtime::start(
-            RuntimeConfig::for_tests(),
-            ErrorLog,
-            blob,
-            &MetricsRegistry::new(),
-            Some(Arc::clone(&runtime_closure)),
-        )
-    })?;
+    let start_fn = GoldenStartRuntime(reg.clone());
+    let mut persist = Direct::new(start_fn)?;
+    let mut persist_worker = persist.add_worker();
     for req in reqs.iter() {
-        let _ = persist.run(req.clone()).recv();
+        let _ = persist_worker.run(req.clone()).recv();
     }
-    let persist_state = PersistState::slurp_from(&persist.persister)?;
+    let persist_state = PersistState::slurp_from(&persist.runtime()?)?;
     persist.finish();
 
     let mut blob = reg.blob_no_reentrance()?;

--- a/src/persist/src/nemesis/direct.rs
+++ b/src/persist/src/nemesis/direct.rs
@@ -7,8 +7,93 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+//! The primary implementation of [Runtime].
+//!
+//! As mentioned elsewhere, nemesis's goal is to exercise persist's public API,
+//! record the responses/externally observable behaviors, and post-hoc verify
+//! that none of persist's external invariants were violated. [Generator] and an
+//! implementation of [Runtime] (such as [Direct] here) are together responsible
+//! for exercising the public API in "interesting" ways and [Validator] is
+//! responsible for validating the history.
+//!
+//! For nemesis's purposes, "interesting" traffic against the persist API means
+//! that it is possible (better yet, likely) to reproduce any persist bug that
+//! we might hit in production. To explain our attempt at doing this, we first
+//! need a bit of background.
+//!
+//! Persist's place in a platform world is something like the following:
+//!
+//!     ingestd -> persist -> dataflowd
+//!
+//! Where "ingestd" represents a process that roughly corresponds to the sources
+//! part of what is currently src/dataflow (tables are similar enough that we
+//! ignore them here) and "dataflowd" represents a set of HA processes that
+//! incrementally compute things from those sources of data. Persist's main
+//! responsibilities are to make source data (1) durable and (2) [definite] as
+//! well as (3) providing a separation between compute and storage such that
+//! they can scale independently. These names are what we're using at the time
+//! this was written, but it's the early days platform, so this all could very
+//! well rot.
+//!
+//! [definite]: https://github.com/MaterializeInc/materialize/blob/v0.9.11/doc/developer/design/20210831_correctness.md
+//!
+//! The nemesis testing then internally structures its API usage in the same
+//! way. A set of persisted [collection]s are written to from an ingestd process
+//! and read from one (or many) dataflowd processes. The only communication
+//! between these two is via persist.
+//!
+//! [collection]: https://docs.rs/differential-dataflow/0.12.0/differential_dataflow/collection/struct.Collection.html
+//!
+//! The external API guarantees of persist are in terms of its
+//! [StreamReadHandle]s and [StreamWriteHandle]s. Also included is the
+//! [PersistedSource] operator which wraps a StreamReadHandle to give native
+//! differential dataflow semantics.
+//!
+//! The ingestd side uses the read and write handles (technically it currently
+//! uses some extra dataflow operators that wrap them, but ingestd will
+//! eventually get off dataflow so these are going away at some point). We model
+//! this as a set of [RuntimeWorker]s (here [DataflowWorker] is the impl of
+//! that), each concurrently issuing calls to read and write handles and
+//! recording the responses.
+//!
+//! The dataflowd side uses the PersistedSource operator. We model this with a
+//! multi-[timely::worker::Worker] dataflow per persisted collection which
+//! simply captures the output for nemesis validation. These workers are driven
+//! using exactly the [timely::execute] runtime used in production. Additionally
+//! a small bit of [DataflowProgress] tracking is added, which is used by the
+//! ingestd-side to keep traffic more "interesting" by situationally waiting
+//! until the dataflow-side has caught up.
+//!
+//! Not unexpectedly, concurrency was a source of many of persist's initial
+//! bugs, so we make a particular effort to ensure that the production
+//! concurrency is modeled. One tricky thing is that the real ingestd and
+//! dataflowd tie the lifetime of the persist runtime to the lifetime of the
+//! process. However, we want nemesis to model restarts (another likely source
+//! of bugs), which is in tension with maximal concurrency (because persist
+//! requires an exclusive-writer lock, which serializes runtime start/stop
+//! operations). As a compromise, we model the source of truth in [DirectCore]
+//! behind a Mutex, and then each ingestd-side [DataflowWorker] caches the read
+//! and write handles for each collection the first time they are used after a
+//! persist runtime restart. These caches are invalidated using lock-free
+//! atomics to avoid introducing a barrier between the ingestd workers.
+//! [DirectShared] sits in between these two layers and is mostly a helper to
+//! deal with cache invalidation.
+//!
+//! [DirectShared] is also a convenient place to house nemesis's odd split of
+//! getting a snapshot and reading it. We do this split to model a very large
+//! snapshot that takes a long time to consume, so other reads and writes
+//! continue on concurrently in the background.
+//!
+//! A missing piece in all this is that the ingestd and dataflowd processes (and
+//! thus their respective persist runtimes) can be restarted independently.
+//! Sadly, support for this is coming to persist, but it's not here quite yet.
+//! In the interim, nemesis has a single persist runtime shared between them.
+//! Once this is built, we'll split [DirectCore] into one for ingestd and one
+//! for dataflowd and allow them to be restarted independently.
+
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc::Receiver;
 use std::sync::{mpsc, Arc, Mutex};
 use std::time::Instant;
@@ -28,22 +113,33 @@ use crate::indexed::SnapshotExt;
 use crate::nemesis::progress::{DataflowProgress, DataflowProgressHandle};
 use crate::nemesis::{
     AllowCompactionReq, FutureRes, FutureStep, Input, ReadOutputEvent, ReadOutputReq,
-    ReadOutputRes, ReadSnapshotReq, ReadSnapshotRes, Req, Res, Runtime, SealReq, SnapshotId,
-    TakeSnapshotReq, WriteReq, WriteReqMulti, WriteReqSingle,
+    ReadOutputRes, ReadSnapshotReq, ReadSnapshotRes, Req, Res, Runtime, RuntimeWorker, SealReq,
+    SnapshotId, TakeSnapshotReq, WriteReq, WriteReqMulti, WriteReqSingle,
+    NUM_DATAFLOW_WORKER_THREADS,
 };
 use crate::operators::source::PersistedSource;
 use crate::pfuture::PFuture;
 use crate::storage::SeqNo;
 use crate::unreliable::UnreliableHandle;
 
-#[derive(Debug)]
-struct Dataflow {
+/// A handle to the "ingestd" (input) side of a persisted collection.
+#[derive(Debug, Clone)]
+struct Ingest {
     write: StreamWriteHandle<String, ()>,
     read: StreamReadHandle<String, ()>,
+    progress: DataflowProgress,
+}
+
+/// A handle to the "dataflowd" (output) side of a persisted collection.
+#[derive(Debug)]
+struct Dataflow {
     output: Receiver<TimelyCaptureEvent<u64, (Result<(String, ()), String>, u64, isize)>>,
     workers: TimelyWorkers,
-    progress: DataflowProgress,
-    progress_handle: DataflowProgressHandle,
+    progress_tx: DataflowProgressHandle,
+}
+
+pub trait StartRuntime: fmt::Debug + Send + 'static {
+    fn start_runtime(&mut self, unreliable: UnreliableHandle) -> Result<RuntimeClient, Error>;
 }
 
 // TODO: With the recent addition of dataflows, this is much less "direct" than
@@ -52,14 +148,95 @@ struct Dataflow {
 // without graceful shutdown) and reimplement Direct using Indexed.
 #[derive(Debug)]
 pub struct Direct {
-    start_fn: StartFn,
-    pub persister: RuntimeClient,
-    unreliable: UnreliableHandle,
-    dataflows: HashMap<String, Dataflow>,
-    snapshots: HashMap<SnapshotId, DecodedSnapshot<String, ()>>,
+    workers: usize,
+    shared: Arc<DirectShared>,
 }
 
-impl Runtime for Direct {
+#[derive(Debug)]
+struct DirectCore {
+    start_fn: Box<dyn StartRuntime>,
+    unreliable: UnreliableHandle,
+    persister: RuntimeClient,
+    dataflows: HashMap<String, (Ingest, Dataflow)>,
+}
+
+#[derive(Debug)]
+struct DirectShared {
+    unreliable: UnreliableHandle,
+    snapshots: Arc<Mutex<HashMap<SnapshotId, DecodedSnapshot<String, ()>>>>,
+
+    core: Mutex<DirectCore>,
+    /// A count incremented each time persist has been restarted.
+    ///
+    /// This is used for lock-free invalidation of the cached copy of the
+    /// persist handles that DirectWorker keeps.
+    //
+    // TODO: Once we split out a read-only version of persist, we can restart
+    // the ingestd/dataflowd halves independently.
+    generation: AtomicUsize,
+}
+
+impl DirectShared {
+    fn new(mut start_fn: Box<dyn StartRuntime>) -> Result<Self, Error> {
+        let unreliable = UnreliableHandle::default();
+        let runtime = start_fn.start_runtime(unreliable.clone())?;
+        let core = DirectCore {
+            start_fn,
+            unreliable: unreliable.clone(),
+            persister: runtime,
+            dataflows: HashMap::new(),
+        };
+        let initial_generation = 0;
+        let shared = DirectShared {
+            core: Mutex::new(core),
+            generation: AtomicUsize::new(initial_generation),
+            unreliable,
+            snapshots: Arc::new(Mutex::new(HashMap::new())),
+        };
+        Ok(shared)
+    }
+
+    fn generation(&self) -> usize {
+        self.generation.load(Ordering::SeqCst)
+    }
+}
+
+#[derive(Debug)]
+pub struct DirectWorker {
+    worker_idx: usize,
+    shared: Arc<DirectShared>,
+    unreliable: UnreliableHandle,
+
+    // The generation of the persist runtime these cached handles are from. Used
+    // for lock-free invalidation of the cached copy of the persist handles that
+    // DirectWorker keeps. When this doesn't match `shared.generation()`, we're
+    // guaranteed that the contents of `self.handles` are from a persist runtime
+    // that is shut down, so to keep things interesting we need to get new ones.
+    // This protocol is race-y with the start of a new runtime (it's possible to
+    // keep using old handles for a bit after the new runtime starts), but this
+    // is best-effort and so that's fine.
+    //
+    // NB: The motivation for avoiding the DirectCore Mutex in DirectShared is
+    // not performance, but rather avoiding the barrier of the lock in pursuit
+    // of maximal concurrency in nemesis testing.
+    handles_generation: usize,
+    handles: HashMap<String, Ingest>,
+}
+
+impl DirectWorker {
+    fn new(worker_idx: usize, shared: Arc<DirectShared>) -> Self {
+        let unreliable = shared.unreliable.clone();
+        DirectWorker {
+            worker_idx,
+            shared,
+            unreliable,
+            handles_generation: 0,
+            handles: HashMap::new(),
+        }
+    }
+}
+
+impl RuntimeWorker for DirectWorker {
     fn run(&mut self, i: Input) -> FutureStep {
         let before = Instant::now();
         let res = match i.req {
@@ -70,7 +247,7 @@ impl Runtime for Direct {
                 FutureRes::Write(WriteReq::Multi(req.clone()), self.write_multi(req))
             }
             Req::ReadOutput(req) => {
-                let res = Res::ReadOutput(req.clone(), self.read_output(req));
+                let res = Res::ReadOutput(req.clone(), self.shared.read_output(req));
                 FutureRes::Ready(res)
             }
             Req::Seal(req) => FutureRes::Seal(req.clone(), self.seal(req)),
@@ -82,15 +259,15 @@ impl Runtime for Direct {
                 FutureRes::Ready(res)
             }
             Req::ReadSnapshot(req) => {
-                let res = Res::ReadSnapshot(req.clone(), self.read_snapshot(req));
+                let res = Res::ReadSnapshot(req.clone(), self.shared.read_snapshot(req));
                 FutureRes::Ready(res)
             }
             Req::Start => {
-                let res = Res::Start(self.start());
+                let res = Res::Start(self.shared.start());
                 FutureRes::Ready(res)
             }
             Req::Stop => {
-                let res = Res::Stop(self.stop());
+                let res = Res::Stop(self.shared.stop());
                 FutureRes::Ready(res)
             }
             Req::StorageUnavailable => {
@@ -109,32 +286,43 @@ impl Runtime for Direct {
             res,
         }
     }
+}
 
-    fn finish(mut self) {
-        let _ = self.stop();
+impl Runtime for Direct {
+    type Worker = DirectWorker;
+
+    fn add_worker(&mut self) -> DirectWorker {
+        let idx = self.workers;
+        self.workers += 1;
+        DirectWorker::new(idx, self.shared.clone())
+    }
+
+    fn finish(self) {
+        let _ = self.shared.stop();
     }
 }
 
 impl Direct {
-    const DATAFLOW_WORKERS: usize = 2;
-
-    pub fn new<F: FnMut(UnreliableHandle) -> Result<RuntimeClient, Error> + 'static>(
-        mut start_fn: F,
-    ) -> Result<Self, Error> {
-        let unreliable = UnreliableHandle::default();
-        let persister = start_fn(unreliable.clone())?;
+    pub fn new<F: StartRuntime>(start_fn: F) -> Result<Self, Error> {
+        let shared = DirectShared::new(Box::new(start_fn))?;
         Ok(Direct {
-            start_fn: StartFn(Box::new(start_fn)),
-            persister,
-            unreliable,
-            dataflows: HashMap::new(),
-            snapshots: HashMap::new(),
+            workers: 0,
+            shared: Arc::new(shared),
         })
     }
 
-    fn stream(&mut self, name: &str) -> Result<&mut Dataflow, Error> {
+    pub fn runtime(&self) -> Result<RuntimeClient, Error> {
+        Ok(self.shared.core.lock()?.persister.clone())
+    }
+}
+
+impl DirectCore {
+    fn stream(&mut self, name: &str) -> Result<Ingest, Error> {
         match self.dataflows.entry(name.to_owned()) {
-            Entry::Occupied(x) => Ok(x.into_mut()),
+            Entry::Occupied(x) => {
+                let (ingest, _) = x.get();
+                Ok(ingest.clone())
+            }
             Entry::Vacant(x) => {
                 let (write, read) = self.persister.create_or_load(name)?;
                 let dataflow_read = read.clone();
@@ -144,7 +332,7 @@ impl Direct {
                 let (progress_tx, progress_rx) = DataflowProgress::new();
                 let progress_handle = progress_tx.clone();
                 let workers = timely::execute(
-                    timely::Config::process(Self::DATAFLOW_WORKERS),
+                    timely::Config::process(NUM_DATAFLOW_WORKER_THREADS),
                     move |worker| {
                         let dataflow_read = dataflow_read.clone();
                         let mut probe = ProbeHandle::new();
@@ -164,17 +352,36 @@ impl Direct {
                         progress_tx.close();
                     },
                 )?;
-                let dataflow = Dataflow {
-                    write: write,
-                    read: read,
-                    output: output_rx,
+                let input = Ingest {
+                    write,
+                    read,
                     progress: progress_rx,
-                    progress_handle,
-                    workers: TimelyWorkers(workers),
                 };
-                Ok(x.insert(dataflow))
+                let output = Dataflow {
+                    workers: TimelyWorkers(workers),
+                    output: output_rx,
+                    progress_tx: progress_handle,
+                };
+                x.insert((input.clone(), output));
+                Ok(input)
             }
         }
+    }
+}
+
+impl DirectWorker {
+    fn stream(&mut self, name: &str) -> Result<Ingest, Error> {
+        let shared_generation = self.shared.generation();
+        if self.handles_generation != shared_generation {
+            self.handles.clear();
+            self.handles_generation = shared_generation;
+        }
+        if let Some(d) = self.handles.get(name) {
+            return Ok(d.clone());
+        }
+        let handle = self.shared.core.lock()?.stream(name)?;
+        self.handles.insert(name.to_owned(), handle.clone());
+        Ok(handle)
     }
 
     fn write_single(&mut self, req: WriteReqSingle) -> Result<PFuture<SeqNo>, Error> {
@@ -195,11 +402,13 @@ impl Direct {
 
         Ok(multi.write_atomic(updates))
     }
+}
 
-    fn read_output(&mut self, req: ReadOutputReq) -> Result<ReadOutputRes, Error> {
+impl DirectShared {
+    fn read_output(&self, req: ReadOutputReq) -> Result<ReadOutputRes, Error> {
         // TODO: This should probably be run async in a thread.
         let mut contents = Vec::new();
-        if let Some(dataflow) = self.dataflows.get_mut(&req.stream) {
+        if let Some((_, dataflow)) = self.core.lock()?.dataflows.get_mut(&req.stream) {
             for e in dataflow.output.try_iter() {
                 match e {
                     TimelyCaptureEvent::Progress(x) => {
@@ -219,12 +428,14 @@ impl Direct {
         };
         Ok(ReadOutputRes { contents })
     }
+}
 
+impl DirectWorker {
     fn seal(&mut self, req: SealReq) -> Result<PFuture<SeqNo>, Error> {
         let stream = self.stream(&req.stream)?;
         let seal_ts = req.ts;
         let seal_res = stream.write.seal(seal_ts);
-        let progress = stream.progress.clone();
+        let progress = stream.progress;
         let (tx, rx) = PFuture::new();
         let _ = thread::Builder::new()
             .name("nemesis-seal".into())
@@ -255,8 +466,19 @@ impl Direct {
     fn take_snapshot(&mut self, req: TakeSnapshotReq) -> Result<SeqNo, Error> {
         let stream = self.stream(&req.stream)?;
         let snap = stream.read.snapshot()?;
+        // TODO: This should probably be run async in a thread.
+        self.shared.save_snapshot(req.snap, snap)
+    }
+}
+
+impl DirectShared {
+    fn save_snapshot(
+        &self,
+        snap_id: SnapshotId,
+        snap: DecodedSnapshot<String, ()>,
+    ) -> Result<SeqNo, Error> {
         let seqno = snap.seqno();
-        match self.snapshots.entry(req.snap) {
+        match self.snapshots.lock()?.entry(snap_id) {
             Entry::Occupied(x) => {
                 return Err(format!(
                     "internal nemesis error: duplicate snapshot id {:?}",
@@ -271,8 +493,8 @@ impl Direct {
         Ok(seqno)
     }
 
-    fn read_snapshot(&mut self, req: ReadSnapshotReq) -> Result<ReadSnapshotRes, Error> {
-        let snap = match self.snapshots.remove(&req.snap) {
+    fn read_snapshot(&self, req: ReadSnapshotReq) -> Result<ReadSnapshotRes, Error> {
+        let snap = match self.snapshots.lock()?.remove(&req.snap) {
             Some(snap) => snap,
             None => return Err(format!("unknown snap: {:?}", req.snap).into()),
         };
@@ -285,12 +507,24 @@ impl Direct {
         })
     }
 
+    pub fn start(&self) -> Result<(), Error> {
+        let res = self.core.lock()?.start();
+        let _ = self.generation.fetch_add(1, Ordering::SeqCst);
+        res
+    }
+
+    pub fn stop(&self) -> Result<(), Error> {
+        self.core.lock()?.stop()
+    }
+}
+
+impl DirectCore {
     fn start(&mut self) -> Result<(), Error> {
         let _ = self.stop()?;
         // The self.stop call clears dataflows but do it again defensively.
         self.dataflows.clear();
 
-        let persister = (self.start_fn.0)(self.unreliable.clone())?;
+        let persister = self.start_fn.start_runtime(self.unreliable.clone())?;
         self.persister = persister;
 
         Ok(())
@@ -299,9 +533,9 @@ impl Direct {
     fn stop(&mut self) -> Result<(), Error> {
         let res = self.persister.stop();
 
-        // Stopping the persister allows the dataflows to finish.
-        for (_, dataflow) in self.dataflows.drain() {
-            dataflow.progress_handle.close();
+        // Stopping the persister allows the compute dataflows to finish.
+        for (_, (_, dataflow)) in self.dataflows.drain() {
+            dataflow.progress_tx.close();
             dataflow.workers.join();
         }
         res
@@ -333,6 +567,7 @@ impl TimelyWorkers {
 #[cfg(test)]
 mod tests {
     use ore::metrics::MetricsRegistry;
+    use tempfile::TempDir;
 
     use crate::file::{FileBlob, FileLog};
     use crate::indexed::runtime::RuntimeConfig;
@@ -343,19 +578,22 @@ mod tests {
 
     use super::*;
 
-    #[test]
-    fn direct_mem() {
-        let mut registry = MemRegistry::new();
-        let direct = Direct::new(move |unreliable| registry.runtime_unreliable(unreliable))
-            .expect("initial start failed");
-        nemesis::run(100, GeneratorConfig::default(), direct)
+    impl StartRuntime for MemRegistry {
+        fn start_runtime(&mut self, unreliable: UnreliableHandle) -> Result<RuntimeClient, Error> {
+            self.runtime_unreliable(unreliable)
+        }
     }
 
     #[test]
-    fn direct_file() {
-        let temp_dir = tempfile::tempdir().expect("tempdir creation failed");
-        let direct = Direct::new(move |unreliable| {
-            let (log_dir, blob_dir) = (temp_dir.path().join("log"), temp_dir.path().join("blob"));
+    fn direct_mem() {
+        let registry = MemRegistry::new();
+        let direct = Direct::new(registry).expect("initial start failed");
+        nemesis::run(100, GeneratorConfig::default(), direct)
+    }
+
+    impl StartRuntime for TempDir {
+        fn start_runtime(&mut self, unreliable: UnreliableHandle) -> Result<RuntimeClient, Error> {
+            let (log_dir, blob_dir) = (self.path().join("log"), self.path().join("blob"));
             let log = FileLog::new(log_dir, ("reentrance0", "direct_file").into())?;
             let log = UnreliableLog::from_handle(log, unreliable.clone());
             let blob = FileBlob::new(blob_dir, ("reentrance0", "direct_file").into())?;
@@ -367,8 +605,13 @@ mod tests {
                 &MetricsRegistry::new(),
                 None,
             )
-        })
-        .expect("initial start failed");
+        }
+    }
+
+    #[test]
+    fn direct_file() {
+        let temp_dir = tempfile::tempdir().expect("tempdir creation failed");
+        let direct = Direct::new(temp_dir).expect("initial start failed");
         // TODO: At the moment, running this for 100 steps takes a bit over a
         // second, so run this one for fewer steps than the other tests. Revisit
         // once we pipeline write calls in Log.
@@ -388,9 +631,8 @@ mod tests {
             write_sealed_weight: 0,
             ..Default::default()
         };
-        let mut registry = MemRegistry::new();
-        let direct = Direct::new(move |unreliable| registry.runtime_unreliable(unreliable))
-            .expect("initial start failed");
+        let registry = MemRegistry::new();
+        let direct = Direct::new(registry).expect("initial start failed");
         nemesis::run(100, config, direct)
     }
 }


### PR DESCRIPTION
Nemesis recently got the ability to run multiple workers on the
dataflowd-side, as well as running dataflowd concurrently with
operations on the ingestd-side. Continue adding more concurrency
coverage to nemesis, by introducing the idea of a worker to the
ingestd-side too. Only one of these workers is used initially (getting
exactly the previous behavior) because the Validator changes necessary
to make sense of the increased concurrency are substantial and this lets
us split up the work into more manageable PR sizes.

### Tips for reviewer

For easy of understanding (and review) of this commit, nothing is
reordered and nothing is renamed, resulting in a very awkward set of
impl blocks. These cleanups will be done in a second commit in this
PR, added after the interesting bits are signed-off on.
