### PR TITLE
sql: fix remaining AGGREGATE functions using reduce elision optimization

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -129,7 +129,8 @@ List new features before bug fixes.
 
 - Fix a bug that caused a panic when using a query containing
   `STRING_AGG`, `JSON_AGG`, `JSON_OBJECT_AGG`, `LIST_AGG`, or `ARRAY_AGG`
-  on data sets containing exactly one record.
+  on data sets containing exactly one record
+  when that condition is known at optimization time.
 
 {{% version-header v0.9.11 %}}
 

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -127,7 +127,9 @@ List new features before bug fixes.
   [`mz_kafka_source_statistics`](/sql/system-catalog#mz_kafka_source_statistics),
   containing raw statistics from the underlying librdkafka library.
 
-- Fix a bug that caused a panic when using a query containing `STRING_AGG`
+- Fix a bug that caused a panic when using a query containing
+  `STRING_AGG`, `JSON_AGG`, `JSON_OBJECT_AGG`, `LIST_AGG`, or `ARRAY_AGG`
+  on data sets containing exactly one record.
 
 {{% version-header v0.9.11 %}}
 

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -24,7 +24,7 @@ use self::func::{AggregateFunc, TableFunc};
 use crate::explain::ViewExplanation;
 use crate::{
     func as scalar_func, DummyHumanizer, EvalError, ExprHumanizer, GlobalId, Id, LocalId,
-    MirScalarExpr, UnaryFunc,
+    MirScalarExpr, UnaryFunc, VariadicFunc,
 };
 
 pub mod canonicalize;
@@ -1540,6 +1540,94 @@ impl AggregateExpr {
             | AggregateFunc::All => self.expr.is_literal(),
             AggregateFunc::Count => self.expr.is_literal_null(),
             _ => self.expr.is_literal_err(),
+        }
+    }
+
+    /// Extracts unique input from aggregate type
+    pub fn on_unique(&self, input_type: &RelationType) -> MirScalarExpr {
+        match self.func {
+            // Count is one if non-null, and zero if null.
+            AggregateFunc::Count => {
+                let column_type = self.typ(&input_type);
+                self.expr
+                    .clone()
+                    .call_unary(UnaryFunc::IsNull(crate::func::IsNull))
+                    .if_then_else(
+                        MirScalarExpr::literal_ok(Datum::Int64(0), column_type.scalar_type.clone()),
+                        MirScalarExpr::literal_ok(Datum::Int64(1), column_type.scalar_type),
+                    )
+            }
+
+            // SumInt16 takes Int16s as input, but outputs Int64s.
+            AggregateFunc::SumInt16 => self.expr.clone().call_unary(UnaryFunc::CastInt16ToInt64),
+
+            // SumInt32 takes Int32s as input, but outputs Int64s.
+            AggregateFunc::SumInt32 => self.expr.clone().call_unary(UnaryFunc::CastInt32ToInt64),
+
+            // SumInt64 takes Int64s as input, but outputs numerics.
+            AggregateFunc::SumInt64 => self
+                .expr
+                .clone()
+                .call_unary(UnaryFunc::CastInt64ToNumeric(Some(0))),
+
+            // JsonbAgg takes _anything_ as input, but must output a Jsonb array.
+            AggregateFunc::JsonbAgg { .. } => MirScalarExpr::CallVariadic {
+                func: VariadicFunc::JsonbBuildArray,
+                exprs: vec![self.expr.clone().call_unary(UnaryFunc::RecordGet(0))],
+            },
+
+            // JsonbAgg takes _anything_ as input, but must output a Jsonb object.
+            AggregateFunc::JsonbObjectAgg { .. } => {
+                let record = self.expr.clone().call_unary(UnaryFunc::RecordGet(0));
+                MirScalarExpr::CallVariadic {
+                    func: VariadicFunc::JsonbBuildObject,
+                    exprs: (0..2)
+                        .map(|i| record.clone().call_unary(UnaryFunc::RecordGet(i)))
+                        .collect(),
+                }
+            }
+
+            // StringAgg takes nested records of strings and outputs a string
+            AggregateFunc::StringAgg { .. } => self
+                .expr
+                .clone()
+                .call_unary(UnaryFunc::RecordGet(0))
+                .call_unary(UnaryFunc::RecordGet(0)),
+
+            // ListConcat and ArrayConcat take a single level of records and output a list containing exactly 1 element
+            AggregateFunc::ListConcat { .. } | AggregateFunc::ArrayConcat { .. } => {
+                self.expr.clone().call_unary(UnaryFunc::RecordGet(0))
+            }
+
+            // All other variants should return the argument to the aggregation.
+            AggregateFunc::MaxNumeric
+            | AggregateFunc::MaxInt16
+            | AggregateFunc::MaxInt32
+            | AggregateFunc::MaxInt64
+            | AggregateFunc::MaxFloat32
+            | AggregateFunc::MaxFloat64
+            | AggregateFunc::MaxBool
+            | AggregateFunc::MaxString
+            | AggregateFunc::MaxDate
+            | AggregateFunc::MaxTimestamp
+            | AggregateFunc::MaxTimestampTz
+            | AggregateFunc::MinNumeric
+            | AggregateFunc::MinInt16
+            | AggregateFunc::MinInt32
+            | AggregateFunc::MinInt64
+            | AggregateFunc::MinFloat32
+            | AggregateFunc::MinFloat64
+            | AggregateFunc::MinBool
+            | AggregateFunc::MinString
+            | AggregateFunc::MinDate
+            | AggregateFunc::MinTimestamp
+            | AggregateFunc::MinTimestampTz
+            | AggregateFunc::SumFloat32
+            | AggregateFunc::SumFloat64
+            | AggregateFunc::SumNumeric
+            | AggregateFunc::Any
+            | AggregateFunc::All
+            | AggregateFunc::Dummy => self.expr.clone(),
         }
     }
 }

--- a/test/sqllogictest/aggregates.slt
+++ b/test/sqllogictest/aggregates.slt
@@ -435,3 +435,103 @@ query T
 SELECT STRING_AGG(x, ',') from (SELECT TRUE::text as x FROM(SELECT AVG(0) FROM qs))
 ----
 true
+
+query T
+SELECT LIST_AGG(x)::text FROM (SELECT * FROM a ORDER BY x)
+----
+{a,b}
+
+query T
+SELECT LIST_AGG(x)::text FROM (SELECT * FROM a ORDER BY x limit 1)
+----
+{a}
+
+query T
+SELECT LIST_AGG(x)::text FROM (SELECT * FROM (SELECT 'a' as x UNION ALL SELECT 'b' as x) ORDER BY x)
+----
+{a,b}
+
+query T
+SELECT LIST_AGG(x)::text FROM (SELECT * FROM (SELECT 'a' as x UNION ALL SELECT 'b' as x) ORDER BY x limit 1)
+----
+{a}
+
+query T
+SELECT LIST_AGG(x)::text from (SELECT TRUE::text as x FROM(SELECT AVG(0) FROM qs))
+----
+{true}
+
+query T
+SELECT ARRAY_AGG(x) FROM (SELECT * FROM a ORDER BY x)
+----
+{a,b}
+
+query T
+SELECT ARRAY_AGG(x) FROM (SELECT * FROM a ORDER BY x limit 1)
+----
+{a}
+
+query T
+SELECT ARRAY_AGG(x) FROM (SELECT * FROM (SELECT 'a' as x UNION ALL SELECT 'b' as x) ORDER BY x)
+----
+{a,b}
+
+query T
+SELECT ARRAY_AGG(x) FROM (SELECT * FROM (SELECT 'a' as x UNION ALL SELECT 'b' as x) ORDER BY x limit 1)
+----
+{a}
+
+query T
+SELECT ARRAY_AGG(x) from (SELECT TRUE::text as x FROM(SELECT AVG(0) FROM qs))
+----
+{true}
+
+query T
+SELECT JSONB_AGG(x) FROM (SELECT * FROM a ORDER BY x)
+----
+["a","b"]
+
+query T
+SELECT JSONB_AGG(x) FROM (SELECT * FROM a ORDER BY x limit 1)
+----
+["a"]
+
+query T
+SELECT JSONB_AGG(x) FROM (SELECT * FROM (SELECT 'a' as x UNION ALL SELECT 'b' as x) ORDER BY x)
+----
+["a","b"]
+
+query T
+SELECT JSONB_AGG(x) FROM (SELECT * FROM (SELECT 'a' as x UNION ALL SELECT 'b' as x) ORDER BY x limit 1)
+----
+["a"]
+
+query T
+SELECT JSONB_AGG(x) from (SELECT TRUE::text as x FROM(SELECT AVG(0) FROM qs))
+----
+["true"]
+
+query T
+SELECT JSONB_OBJECT_AGG(a,b) FROM (SELECT * FROM t ORDER BY a)
+----
+{"1":2,"2":3,"3":1}
+
+query T
+SELECT JSONB_OBJECT_AGG(a,b) FROM (SELECT * FROM t ORDER BY a limit 1)
+----
+{"1":1}
+
+query T
+SELECT JSONB_OBJECT_AGG(a,b) FROM (SELECT * FROM (SELECT 'a' as a,'b' as b UNION ALL SELECT 'c' as a,'d' as b) ORDER by a)
+----
+{"a":"b","c":"d"}
+
+query T
+SELECT JSONB_OBJECT_AGG(a,b) FROM (SELECT * FROM (SELECT 'a' as a,'b' as b UNION ALL SELECT 'c' as a,'d' as b) ORDER by a limit 1)
+----
+{"a":"b"}
+
+query T
+SELECT JSONB_OBJECT_AGG(a,b) from (SELECT TRUE::text as a, FALSE::text as b FROM(SELECT AVG(0) FROM qs))
+----
+{"true":"false"}


### PR DESCRIPTION
Fix:
- JSONB_AGG
- JSONB_OBJECT_AGG
- LIST_AGG
- ARRAY_AGG

Also move the `on_unique` functionality to `AggregateExpr` and replace the `match _` with an explicit listing of all aggregates as per #8595.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
