### PR TITLE
Introduce a SET option to enable/disable QGM per connection

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -2511,6 +2511,7 @@ impl From<SerializedPlanContext> for PlanContext {
     fn from(cx: SerializedPlanContext) -> PlanContext {
         PlanContext {
             wall_time: cx.wall_time.unwrap_or_else(|| Utc.timestamp(0, 0)),
+            qgm_optimizations: false,
         }
     }
 }

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -143,7 +143,7 @@ use sql::plan::{
     MutationKind, Params, PeekPlan, PeekWhen, Plan, ReadThenWritePlan, SendDiffsPlan,
     SetVariablePlan, ShowVariablePlan, Source, TailPlan,
 };
-use sql::plan::{StatementDesc, View};
+use sql::plan::{OptimizerConfig, StatementDesc, View};
 use transform::Optimizer;
 
 use self::arrangement_state::{ArrangementFrontiers, Frontiers, SinkWrites};
@@ -3377,7 +3377,9 @@ where
 
         let decorrelate = |timings: &mut Timings, raw_plan: HirRelationExpr| -> MirRelationExpr {
             let start = Instant::now();
-            let decorrelated_plan = raw_plan.lower();
+            let decorrelated_plan = raw_plan.optimize_and_lower(&OptimizerConfig {
+                qgm_optimizations: session.vars().qgm_optimizations(),
+            });
             timings.decorrelation = Some(start.elapsed());
             decorrelated_plan
         };

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -2663,6 +2663,7 @@ where
             session
                 .vars()
                 .iter()
+                .filter(|v| !v.experimental())
                 .map(|v| {
                     Row::pack_slice(&[
                         Datum::String(v.name()),

--- a/src/coord/src/session.rs
+++ b/src/coord/src/session.rs
@@ -96,7 +96,7 @@ impl Session {
         match self.transaction {
             TransactionStatus::Default | TransactionStatus::Started(_) => {
                 self.transaction = TransactionStatus::InTransaction(Transaction {
-                    pcx: PlanContext::new(wall_time),
+                    pcx: PlanContext::new(wall_time, self.vars.qgm_optimizations()),
                     ops: TransactionOps::None,
                     write_lock_guard: None,
                     access,
@@ -116,7 +116,7 @@ impl Session {
     pub fn start_transaction_implicit(mut self, wall_time: DateTime<Utc>, stmts: usize) -> Self {
         if let TransactionStatus::Default = self.transaction {
             let txn = Transaction {
-                pcx: PlanContext::new(wall_time),
+                pcx: PlanContext::new(wall_time, self.vars.qgm_optimizations()),
                 ops: TransactionOps::None,
                 write_lock_guard: None,
                 access: None,

--- a/src/sql/src/lib.rs
+++ b/src/sql/src/lib.rs
@@ -92,5 +92,4 @@ pub mod normalize;
 pub mod parse;
 pub mod plan;
 pub mod pure;
-#[cfg(test)]
 pub mod query_model;

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -483,11 +483,15 @@ impl Params {
 #[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, Copy)]
 pub struct PlanContext {
     pub wall_time: DateTime<Utc>,
+    pub qgm_optimizations: bool,
 }
 
 impl PlanContext {
-    pub fn new(wall_time: DateTime<Utc>) -> Self {
-        Self { wall_time }
+    pub fn new(wall_time: DateTime<Utc>, qgm_optimizations: bool) -> Self {
+        Self {
+            wall_time,
+            qgm_optimizations,
+        }
     }
 
     /// Return a PlanContext with zero values. This should only be used when
@@ -496,6 +500,7 @@ impl PlanContext {
     pub fn zero() -> Self {
         PlanContext {
             wall_time: now::to_datetime(NOW_ZERO()),
+            qgm_optimizations: false,
         }
     }
 }

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -48,6 +48,7 @@ pub(crate) mod error;
 pub(crate) mod explain;
 pub(crate) mod expr;
 pub(crate) mod lowering;
+pub(crate) mod optimize;
 pub(crate) mod plan_utils;
 pub(crate) mod query;
 pub(crate) mod scope;
@@ -59,6 +60,7 @@ pub(crate) mod typeconv;
 pub use self::expr::{HirRelationExpr, HirScalarExpr};
 pub use error::PlanError;
 pub use explain::Explanation;
+pub use optimize::OptimizerConfig;
 // This is used by sqllogictest to turn SQL values into `Datum`s.
 pub use query::{
     plan_default_expr, resolve_names, resolve_names_data_type, resolve_names_stmt,

--- a/src/sql/src/plan/optimize.rs
+++ b/src/sql/src/plan/optimize.rs
@@ -1,0 +1,58 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+///! This module defines the API and logic for running optimization pipelines.
+use crate::plan::expr::HirRelationExpr;
+use crate::query_model::Model;
+
+use super::StatementContext;
+
+/// Feature flags for the [`HirRelationExpr::optimize_and_lower()`] logic.
+#[derive(Debug)]
+pub struct OptimizerConfig {
+    pub qgm_optimizations: bool,
+}
+
+/// Convert a reference to a [`StatementContext`] to an [`OptimizerConfig`].
+///
+/// This picks up feature flag values such as `qgm_optimizations` from the `PlanContext` if this is present in
+/// the [`StatementContext`], otherwise uses sensible defaults.
+impl<'a> From<&StatementContext<'a>> for OptimizerConfig {
+    fn from(scx: &StatementContext) -> Self {
+        match scx.pcx() {
+            Ok(pcx) => OptimizerConfig {
+                qgm_optimizations: pcx.qgm_optimizations,
+            },
+            Err(..) => OptimizerConfig {
+                qgm_optimizations: false,
+            },
+        }
+    }
+}
+
+impl HirRelationExpr {
+    /// Perform optimizing algebraic rewrites on this [`HirRelationExpr`] and lower it to a [`expr::MirRelationExpr`].
+    ///
+    /// The optimization path is fully-determined by the values of the feature flag defined in the [`OptimizerConfig`].
+    pub fn optimize_and_lower(self, config: &OptimizerConfig) -> expr::MirRelationExpr {
+        if config.qgm_optimizations {
+            // create a query graph model from this HirRelationExpr
+            let model = Model::from(&self);
+
+            // @todo: perform optimizing algebraic rewrites on the qgm
+            // ...
+
+            // decorrelate and lower the optimized query graph model into a MirRelationExpr
+            model.lower()
+        } else {
+            // directly decorrelate and lower into a MirRelationExpr
+            self.lower()
+        }
+    }
+}

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1220,7 +1220,7 @@ pub fn plan_view(
     expr.bind_parameters(&params)?;
     //TODO: materialize#724 - persist finishing information with the view?
     expr.finish(finishing);
-    let relation_expr = expr.lower();
+    let relation_expr = expr.optimize_and_lower(&scx.into());
 
     let name = if temporary {
         scx.allocate_temporary_name(normalize::unresolved_object_name(name.to_owned())?)

--- a/src/sql/src/query_model/dot.rs
+++ b/src/sql/src/query_model/dot.rs
@@ -9,6 +9,8 @@
 
 //! Generates a graphviz graph from a Query Graph Model.
 
+#![cfg(test)]
+
 use crate::query_model::{BoxType, Model, Quantifier, QuantifierId, QueryBox};
 use itertools::Itertools;
 use std::cell::RefCell;

--- a/src/sql/src/query_model/mod.rs
+++ b/src/sql/src/query_model/mod.rs
@@ -28,7 +28,7 @@ pub type BoxId = u64;
 pub type QuantifierSet = BTreeSet<QuantifierId>;
 
 /// A Query Graph Model instance represents a SQL query.
-/// See: https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/20210707_qgm_sql_high_level_representation.md
+/// See [the design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/20210707_qgm_sql_high_level_representation.md) for details.
 ///
 /// In this representation, SQL queries are represented as a graph of operators,
 /// represented as boxes, that are connected via quantifiers. A top-level box
@@ -416,7 +416,7 @@ impl QueryBox {
 }
 
 impl BoxType {
-    fn get_box_type_str(&self) -> &'static str {
+    pub fn get_box_type_str(&self) -> &'static str {
         match self {
             BoxType::BaseTable(..) => "BaseTable",
             BoxType::Except => "Except",

--- a/src/sql/src/query_model/scalar_expr.rs
+++ b/src/sql/src/query_model/scalar_expr.rs
@@ -26,8 +26,8 @@ use crate::query_model::{QuantifierId, QuantifierSet};
 /// * BaseColumn is used to represent leaf columns, only allowed in
 ///   the projection of BaseTables and TableFunctions.
 ///
-/// Scalar expressions only make sense within the context of a [QueryBox],
-/// and hence, their name.
+/// Scalar expressions only make sense within the context of a
+/// [`crate::query_model::QueryBox`], and hence, their name.
 #[derive(Debug, PartialEq, Clone)]
 pub enum BoxScalarExpr {
     /// A reference to a column from a quantifier that either lives in


### PR DESCRIPTION
### Motivation

This PR adds a known-desirable feature (closes #8863).

Note that we have a follow-up issue (#8993) to rework the SET option as a CLI flag once we are ready to decide whether to use QGM or not on a per-instance and not per-session level.

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug. [Link to issue.]

  * This PR adds a known-desirable feature. [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

### Tips for reviewer

- The first commit introduces a new `SessionVar` named `qgm_optimizations` to mark whether QGM should be enabled or disabled for the current session.
- The second commit introduces a new `qgm_optimizations` field in `PlanContext` and adds logic to use the current `SessionVar` value when a new `PlanContext` instance is created.
- The third commit adds a `HirRelationExpr::optimize` method and an `OptimizerConfig` that can be derived from a `StatementContext`. I will implement the `optimize` method once #8801 and #8969 have landed (which is why currently this PR is still marked as a draft).
- The fourth commit replaces `HirRelationExpr::lower()` calls with `optimize(...)`.

Note that currently there is no clean and obvious way to uniformly pass parameters to the optimization process. The `HirRelationExpr::lower()` method is called in various different places and not all call sites have direct access to the enclosing `Session`. I therefore followed this procedure:

- Whenever the call site has access to the `Session`, I have replaced `lower()` calls with `optimize(config)` calls with directly constructed `config` instance.
- Whenever the call site has a `StatementContext` instead, I've used the `From<&StatementContext>` implementation for `OptimizerConfig` to pass the `qgm_optimizations` from the enclosed optional `PlanContext` whenever it is present, defaulting to `false` otherwise.
- In all other cases, I've left the `lower()` call unchanged.

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
