### PR TITLE
log errors and early termination from the stream consumer in kafka-verify

### DIFF
--- a/src/testdrive/src/action/kafka/verify.rs
+++ b/src/testdrive/src/action/kafka/verify.rs
@@ -148,15 +148,27 @@ impl Action for VerifyAction {
         // instead get an error message about the expected messages that
         // were missing.
         let mut actual_bytes = vec![];
-        while let Some(Ok(message)) = message_stream.next().await {
-            let message = message.map_err_to_string()?;
-            consumer
-                .store_offset_from_message(&message)
-                .map_err(|e| format!("storing message offset: {:#}", e))?;
-            actual_bytes.push((
-                message.key().and_then(|bytes| Some(bytes.to_owned())),
-                message.payload().and_then(|bytes| Some(bytes.to_owned())),
-            ));
+        loop {
+            match message_stream.next().await {
+                Some(Ok(message)) => {
+                    let message = message.map_err_to_string()?;
+                    consumer
+                        .store_offset_from_message(&message)
+                        .map_err(|e| format!("storing message offset: {:#}", e))?;
+                    actual_bytes.push((
+                        message.key().and_then(|bytes| Some(bytes.to_owned())),
+                        message.payload().and_then(|bytes| Some(bytes.to_owned())),
+                    ));
+                }
+                Some(Err(e)) => {
+                    println!("Received error from Kafka stream consumer: {}", e);
+                    break;
+                }
+                None => {
+                    println!("Received None from Kafka stream consumer");
+                    break;
+                }
+            }
         }
 
         match &self.format {


### PR DESCRIPTION
Adding some logging that would be helpful to sort out what's going on in CI. This is likely faster than figuring out my local xcompile woes.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
