### PR TITLE
fix failing kafka-matrix nightlies

### DIFF
--- a/src/testdrive/src/action/kafka/verify.rs
+++ b/src/testdrive/src/action/kafka/verify.rs
@@ -58,6 +58,13 @@ pub fn build_verify(mut cmd: BuiltinCommand, context: Context) -> Result<VerifyA
 
     let sort_messages = cmd.args.opt_bool("sort-messages")?.unwrap_or(false);
     let expected_messages = cmd.input;
+    if expected_messages.len() == 0 {
+        // verify with 0 messages doesn't check that no messages have been written -
+        // it 'verifies' 0 messages and trivially returns true
+        return Err(String::from(
+            "kafka-verify requires a non-empty list of expected messages",
+        ));
+    }
     cmd.args.done()?;
     Ok(VerifyAction {
         sink,

--- a/test/kafka-matrix/mzcompose.yml
+++ b/test/kafka-matrix/mzcompose.yml
@@ -121,6 +121,7 @@ services:
         --schema-registry-url=http://schema-registry:8081
         --materialized-url=postgres://materialize@materialized:6875
         --validate-catalog=/share/mzdata/catalog
+        --default-timeout=30
         $$*
       - bash
     environment:

--- a/test/restart/user-indexes-disabled.td
+++ b/test/restart/user-indexes-disabled.td
@@ -97,9 +97,6 @@ unable to automatically determine a query timestamp
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'snk_indexes_disabled'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
-# No data written to sink without indexes
-$ kafka-verify format=avro sink=materialize.public.snk_indexes_disabled sort-messages=true
-
 # 🔬🔬 Tables
 
 ! INSERT INTO t VALUES (1)

--- a/test/testdrive/kafka-avro-upsert-sinks.td
+++ b/test/testdrive/kafka-avro-upsert-sinks.td
@@ -234,8 +234,6 @@ $ kafka-verify format=avro sink=materialize.public.input_with_deletions_sink sor
 $ kafka-ingest format=avro topic=input-with-deletions schema=${schema}
 {"before": {"row": {"a": 1, "b": 1}}, "after": null}
 
-$ kafka-verify format=avro sink=materialize.public.input_with_deletions_sink sort-messages=true
-
 $ kafka-ingest format=avro topic=input-with-deletions schema=${schema}
 {"before": {"row": {"a": 1, "b": 2}}, "after": null}
 

--- a/test/testdrive/sinks.td
+++ b/test/testdrive/sinks.td
@@ -180,8 +180,6 @@ $ kafka-verify format=avro sink=materialize.public.snk8 sort-messages=true
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   WITHOUT SNAPSHOT
 
-$ kafka-verify format=avro sink=materialize.public.sink9
-
 > CREATE SINK sink10 FROM foo
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'sink10'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'


### PR DESCRIPTION
The main intent here is to fix the failing kafka-matrix nightlies. Currently they appear to be occasionally timing out on the Kafka 5.0.0 runs when there's significant resource contention.

Along the way made two other changes:
1. Enabled logging of kafka error messages (this would've made it significantly easier to tell what's going on)
2. Removed use of kafka-verify with 0 expected messages and added an error if new tests add such use. Ideally this would instead verify that no new messages have been written to Kafka, but it doesn't today and it'd be better to error out than give a false sense of test coverage.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
