### PR TITLE
dataflow: Drop all dataflows on exit

### DIFF
--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -783,6 +783,9 @@ where
             self.process_tails();
         }
         self.render_state.traces.del_all_traces();
+        for dataflow in self.timely_worker.installed_dataflows() {
+            self.timely_worker.drop_dataflow(dataflow);
+        }
         self.shutdown_logging();
     }
 


### PR DESCRIPTION
When coordd exits, the dataflowd processes drop their client, but this
doesn't stop the dataflow threads. The reason for this is that dropping
the client doesn't clean up inputs and dataflows. With this patch, the
dataflow server drops all dataflows once it ceases to run.

Signed-off-by: Moritz Hoffmann <mh@materialize.com>

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/9005)
<!-- Reviewable:end -->
