### PR TITLE
Extract `RowSetFinishing` after dataflow optimization

### DIFF
--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -1594,6 +1594,16 @@ pub struct RowSetFinishing {
 }
 
 impl RowSetFinishing {
+    /// Creates a trivial RowSetFinishing instance
+    pub fn new_trivial(arity: usize) -> Self {
+        Self {
+            order_by: vec![],
+            limit: None,
+            offset: 0,
+            project: (0..arity).collect(),
+        }
+    }
+
     /// True if the finishing does nothing to any result set.
     pub fn is_trivial(&self, arity: usize) -> bool {
         self.limit.is_none()

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -33,7 +33,7 @@ use chrono::{DateTime, Utc};
 use enum_kinds::EnumKind;
 use serde::{Deserialize, Serialize};
 
-use ::expr::{GlobalId, RowSetFinishing};
+use ::expr::GlobalId;
 use dataflow_types::{SinkConnectorBuilder, SinkEnvelope, SourceConnector};
 use ore::now::{self, NOW_ZERO};
 use repr::{ColumnName, Diff, RelationDesc, Row, ScalarType, Timestamp};
@@ -228,7 +228,6 @@ pub struct SetVariablePlan {
 pub struct PeekPlan {
     pub source: ::expr::MirRelationExpr,
     pub when: PeekWhen,
-    pub finishing: RowSetFinishing,
     pub copy_to: Option<CopyFormat>,
 }
 
@@ -258,7 +257,6 @@ pub struct CopyFromPlan {
 #[derive(Debug)]
 pub struct ExplainPlan {
     pub raw_plan: HirRelationExpr,
-    pub row_set_finishing: Option<RowSetFinishing>,
     pub stage: ExplainStage,
     pub options: ExplainOptions,
 }
@@ -280,7 +278,6 @@ pub struct InsertPlan {
 pub struct ReadThenWritePlan {
     pub id: GlobalId,
     pub selection: ::expr::MirRelationExpr,
-    pub finishing: RowSetFinishing,
     pub assignments: HashMap<usize, ::expr::MirScalarExpr>,
     pub kind: MutationKind,
 }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1258,12 +1258,9 @@ pub fn plan_view(
     let query::PlannedQuery {
         mut expr,
         mut desc,
-        finishing,
         depends_on,
     } = query::plan_root_query(scx, query.clone(), QueryLifetime::Static)?;
     expr.bind_parameters(&params)?;
-    //TODO: materialize#724 - persist finishing information with the view?
-    expr.finish(finishing);
     let relation_expr = expr.lower();
 
     let name = if temporary {

--- a/src/transform/src/fusion/mod.rs
+++ b/src/transform/src/fusion/mod.rs
@@ -15,4 +15,5 @@ pub mod map;
 pub mod negate;
 pub mod project;
 pub mod reduce;
+pub mod top_k;
 pub mod union;

--- a/src/transform/src/fusion/top_k.rs
+++ b/src/transform/src/fusion/top_k.rs
@@ -1,0 +1,73 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::TransformArgs;
+use expr::MirRelationExpr;
+
+/// Fuses a sequence of `TopK` operators in to one `TopK` operator.
+#[derive(Debug)]
+pub struct TopK;
+
+impl crate::Transform for TopK {
+    fn transform(
+        &self,
+        relation: &mut MirRelationExpr,
+        _: TransformArgs,
+    ) -> Result<(), crate::TransformError> {
+        relation.visit_mut_pre(&mut |e| {
+            self.action(e);
+        });
+        Ok(())
+    }
+}
+
+impl TopK {
+    /// Fuses a sequence of `TopK` operators in to one `TopK` operator.
+    pub fn action(&self, relation: &mut MirRelationExpr) {
+        if let MirRelationExpr::TopK {
+            input,
+            group_key,
+            order_key,
+            limit,
+            offset,
+            monotonic,
+        } = relation
+        {
+            while let MirRelationExpr::TopK {
+                input: inner_input,
+                group_key: inner_group_key,
+                order_key: inner_order_key,
+                limit: inner_limit,
+                offset: inner_offset,
+                monotonic: inner_monotonic,
+            } = &mut **input
+            {
+                if *group_key == *inner_group_key && *order_key == *inner_order_key {
+                    if let Some(inner_limit) = inner_limit {
+                        if *offset >= *inner_limit {
+                            relation.take_safely();
+                            break;
+                        }
+                        *inner_limit -= *offset;
+                        if let Some(limit) = limit {
+                            *limit = std::cmp::min(*limit, *inner_limit);
+                        } else {
+                            *limit = Some(*inner_limit);
+                        }
+                    }
+                    *offset += *inner_offset;
+                    *monotonic = *inner_monotonic;
+                    **input = inner_input.take_dangerous();
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -53,6 +53,7 @@ pub mod union_cancel;
 pub mod update_let;
 
 pub mod dataflow;
+pub use dataflow::extract_row_set_finishing;
 pub use dataflow::optimize_dataflow;
 
 /// Arguments that get threaded through all transforms.

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -207,6 +207,7 @@ impl Default for FuseAndCollapse {
                 // `MirRelationExpr::Constant` if that is the case, so that subsequent use can
                 // clearly see this.
                 Box::new(crate::reduction::FoldConstants { limit: Some(10000) }),
+                Box::new(crate::fusion::top_k::TopK),
             ],
         }
     }


### PR DESCRIPTION
<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug. [Link to issue.]

  * This PR adds a known-desirable feature. [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

This is a work in progress PR for early feedback around the desired API.

#8194 cannot be done without #8678, since otherwise the optimizer is not aware of the top-level TopK operation that the consumer of the dataflow applies.

The main issue with this patch is that `topk_elision` transform removes any TopK operator without a limit, which breaks `ORDER BY` queries. We need to somehow flag one-off queries so that this transform doesn't remove the top-level ordering  from the main view of the query.

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

The first commit moves the extraction of the `RowSetFinishing` operation from the planner to the optimizer. That information is extract via a new optimizer method called `extract_row_set_finishing`, that given a dataflow description and the Id of the view the result will be fetched from, it extracts the Topk operator on top of that view.

The second commit includes a draft of the transform needed for #8194.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
