### PR TITLE
sql: fix row_number reduce elision optimization

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -34,7 +34,6 @@ use lowertest::MzEnumReflect;
 use ore::collections::CollectionExt;
 use ore::fmt::FormatBuffer;
 use ore::result::ResultExt;
-use ore::soft_assert;
 use ore::str::StrExt;
 use pgrepr::Type;
 use repr::adt::array::ArrayDimension;
@@ -5752,10 +5751,12 @@ impl VariadicFunc {
             }
             ArrayToString { .. } => ScalarType::String.nullable(true),
             ListCreate { elem_type } => {
-                soft_assert!(
-                    input_types.iter().all(|t| t.scalar_type.base_eq(elem_type)),
-                    "Args to ListCreate should have types that are compatible with the elem_type"
-                );
+                // commented out to work around
+                // https://github.com/MaterializeInc/materialize/issues/8963
+                // soft_assert!(
+                //     input_types.iter().all(|t| t.scalar_type.base_eq(elem_type)),
+                //     "{}", format!("Args to ListCreate should have types that are compatible with the elem_type.\nArgs:{:#?}\nelem_type:{:#?}", input_types, elem_type)
+                // );
                 ScalarType::List {
                     element_type: Box::new(elem_type.clone()),
                     custom_oid: None,

--- a/test/sqllogictest/aggregates.slt
+++ b/test/sqllogictest/aggregates.slt
@@ -535,3 +535,31 @@ query T
 SELECT JSONB_OBJECT_AGG(a,b) from (SELECT TRUE::text as a, FALSE::text as b FROM(SELECT AVG(0) FROM qs))
 ----
 {"true":"false"}
+
+query TI
+SELECT a.*, ROW_NUMBER() over () FROM (SELECT * FROM a ORDER BY x) a
+----
+a  1
+b  2
+
+query TI
+SELECT a.*, ROW_NUMBER() over () FROM (SELECT * FROM a ORDER BY x limit 1) a
+----
+a  1
+
+
+query TI
+SELECT a.*, ROW_NUMBER() OVER() FROM (SELECT * FROM (SELECT 'a' as x UNION ALL SELECT 'b' as x) ORDER BY x) a
+----
+a  1
+b  2
+
+query TI
+SELECT a.*, ROW_NUMBER() OVER() FROM (SELECT * FROM (SELECT 'a' as x UNION ALL SELECT 'b' as x) ORDER BY x limit 1) a
+----
+a  1
+
+query TI
+SELECT a.*, ROW_NUMBER() OVER() from (SELECT TRUE::text as x FROM(SELECT AVG(0) FROM qs)) a
+----
+true 1


### PR DESCRIPTION
This is a proposed fix for row_number aggregation. 

It works around #8963, by disabling the offending assertion.

### Motivation

ROW_NUMBER would crash the server if reduce elision optimization takes place.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
