### PR TITLE
QGM Readme: Add Mac instructions for visualizing the graphs.

### DIFF
--- a/src/sql/src/query_model/README.md
+++ b/src/sql/src/query_model/README.md
@@ -7,11 +7,13 @@ This module contains the implementation of the Query Graph Model as specified
 
 Tests around the Query Graph Model, for both the model generation logic and the
 model transformat logic, are usually `datadriven` tests that result in multiple
-`graphviz` graphs, that need to be rendered and visually validated. The following
-shell function extracts all the `graphviz` graphs containing in one of these tests
-and renders them as PNG files. The snippet after it shows how it can be used with
-one of these tests.
+`graphviz` graphs, that need to be rendered and visually validated.
 
+### Linux
+
+The following shell function extracts all the `graphviz` graphs containing in
+one of these tests and renders them as PNG files. The snippet after it shows
+how it can be used with one of these tests.
 
 ```sh
 extract_graph() {
@@ -27,3 +29,10 @@ $ extract_graph src/sql/tests/querymodel/basic
 ...
 $ eog src/sql/tests/querymodel/basic*.png &
 ```
+
+### Mac OS
+
+Refer to [the Linux instructions](#linux), except you need to replace `csplit`
+with `gcsplit`.  The Mac OS
+`csplit` supports a far smaller subset of options. You can install `gcsplit` on
+your machine with Homebrew with the command `brew install coreutils`.


### PR DESCRIPTION
The instructions for rendering the graphs in the QGM tests did not work on my Mac laptop, so I have added instructions for Mac.
