### PR TITLE
Explain MIR: Remove unnecessary printing of let types.

### DIFF
--- a/src/expr/src/explain.rs
+++ b/src/expr/src/explain.rs
@@ -183,8 +183,16 @@ impl<'a> ViewExplanation<'a> {
     /// Attach type information into the explanation.
     pub fn explain_types(&mut self) {
         for node in &mut self.nodes {
-            // TODO(jamii) `typ` is itself recursive, so this is quadratic :(
-            node.typ = Some(node.expr.typ());
+            if let MirRelationExpr::Let { .. } = &node.expr {
+                // Skip.
+                // Since we don't print out Let nodes in the explanation,
+                // types of Let nodes should not be attached to the
+                // explanation. The type information of a Let is always the
+                // same as the the type of the body.
+            } else {
+                // TODO(jamii) `typ` is itself recursive, so this is quadratic :(
+                node.typ = Some(node.expr.typ());
+            }
         }
     }
 

--- a/src/transform/tests/testdata/keys
+++ b/src/transform/tests/testdata/keys
@@ -95,10 +95,6 @@ Applied RelationCSE:
 | Get %1 (l1)
 | | types = (Int32?, Int64?, Int32?, Int32?, Int64?, Int32?)
 | | keys = ((#0), (#1))
-| | types = (Int32?, Int64?, Int32?, Int32?, Int64?, Int32?)
-| | keys = ((#0), (#1))
-| | types = (Int32?, Int64?, Int32?, Int32?, Int64?, Int32?)
-| | keys = ((#0), (#1))
 
 ====
 Applied InlineLet { inline_mfp: false }:

--- a/src/transform/tests/testdata/typ
+++ b/src/transform/tests/testdata/typ
@@ -112,8 +112,6 @@ build format=types
 | Union %1 %0
 | | types = (Int32?, Int64?, Int32?)
 | | keys = ()
-| | types = (Int32?, Int64?, Int32?)
-| | keys = ()
 ----
 ----
 
@@ -132,8 +130,6 @@ build format=types
 
 %1 =
 | Union %0 %0
-| | types = (Int32?, Int64?, Int32?)
-| | keys = ()
 | | types = (Int32?, Int64?, Int32?)
 | | keys = ()
 ----

--- a/test/sqllogictest/explain.slt
+++ b/test/sqllogictest/explain.slt
@@ -208,14 +208,10 @@ EXPLAIN TYPED DECORRELATED PLAN FOR VIEW foo
 | Get %2 (l1)
 | | types = ()
 | | keys = (())
-| | types = ()
-| | keys = (())
 | Map 1
 | | types = (integer)
 | | keys = (())
 | Project (#0)
-| | types = (integer)
-| | keys = (())
 | | types = (integer)
 | | keys = (())
 

--- a/test/sqllogictest/scalar_subqueries_select_list.slt
+++ b/test/sqllogictest/scalar_subqueries_select_list.slt
@@ -1019,8 +1019,6 @@ EXPLAIN TYPED DECORRELATED PLAN FOR SELECT CASE (SELECT 1) WHEN 1 THEN 0 ELSE 2 
 | Get %2 (l1)
 | | types = ()
 | | keys = (())
-| | types = ()
-| | keys = (())
 
 %4 = Let l3 =
 | Constant ()
@@ -1040,8 +1038,6 @@ EXPLAIN TYPED DECORRELATED PLAN FOR SELECT CASE (SELECT 1) WHEN 1 THEN 0 ELSE 2 
 
 %7 = Let l5 =
 | Get %6 (l4)
-| | types = ()
-| | keys = (())
 | | types = ()
 | | keys = (())
 | Map 1
@@ -1071,8 +1067,6 @@ EXPLAIN TYPED DECORRELATED PLAN FOR SELECT CASE (SELECT 1) WHEN 1 THEN 0 ELSE 2 
 
 %9 = Let l6 =
 | Union %7 %8
-| | types = (integer)
-| | keys = ()
 | | types = (integer)
 | | keys = ()
 
@@ -1124,8 +1118,6 @@ EXPLAIN TYPED DECORRELATED PLAN FOR SELECT CASE (SELECT 1) WHEN 1 THEN 0 ELSE 2 
 | Union %9 %15
 | | types = (integer?)
 | | keys = ()
-| | types = (integer?)
-| | keys = ()
 
 %17 =
 | Join %3 %16
@@ -1135,10 +1127,6 @@ EXPLAIN TYPED DECORRELATED PLAN FOR SELECT CASE (SELECT 1) WHEN 1 THEN 0 ELSE 2 
 | Project (#0)
 | | types = (integer?)
 | | keys = ()
-| | types = (integer?)
-| | keys = ()
-| | types = (integer?)
-| | keys = ()
 | Map if (#0 = 1) then {0} else {2}
 | | types = (integer?, integer)
 | | keys = ()
@@ -1146,8 +1134,6 @@ EXPLAIN TYPED DECORRELATED PLAN FOR SELECT CASE (SELECT 1) WHEN 1 THEN 0 ELSE 2 
 | | types = (integer?, integer, text)
 | | keys = ()
 | Project (#1, #2)
-| | types = (integer, text)
-| | keys = ()
 | | types = (integer, text)
 | | keys = ()
 


### PR DESCRIPTION
Fixes #7437.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] ~~This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).~~
  Explain is not part of the stable API.
