### PR TITLE
transform: new topk fusion transform

### DIFF
--- a/src/transform/src/fusion/mod.rs
+++ b/src/transform/src/fusion/mod.rs
@@ -15,4 +15,5 @@ pub mod map;
 pub mod negate;
 pub mod project;
 pub mod reduce;
+pub mod top_k;
 pub mod union;

--- a/src/transform/src/fusion/top_k.rs
+++ b/src/transform/src/fusion/top_k.rs
@@ -1,0 +1,92 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuses a sequence of `TopK` operators in to one `TopK` operator
+
+use crate::TransformArgs;
+use expr::MirRelationExpr;
+
+/// Fuses a sequence of `TopK` operators in to one `TopK` operator if
+/// they happen to share the same grouping and ordering key.
+#[derive(Debug)]
+pub struct TopK;
+
+impl crate::Transform for TopK {
+    fn transform(
+        &self,
+        relation: &mut MirRelationExpr,
+        _: TransformArgs,
+    ) -> Result<(), crate::TransformError> {
+        relation.visit_mut_pre(&mut |e| {
+            self.action(e);
+        });
+        Ok(())
+    }
+}
+
+impl TopK {
+    /// Fuses a sequence of `TopK` operators in to one `TopK` operator.
+    pub fn action(&self, relation: &mut MirRelationExpr) {
+        if let MirRelationExpr::TopK {
+            input,
+            group_key,
+            order_key,
+            limit,
+            offset,
+            monotonic,
+        } = relation
+        {
+            while let MirRelationExpr::TopK {
+                input: inner_input,
+                group_key: inner_group_key,
+                order_key: inner_order_key,
+                limit: inner_limit,
+                offset: inner_offset,
+                monotonic: inner_monotonic,
+            } = &mut **input
+            {
+                // We can fuse two chained TopK operators as long as they share the
+                // same grouping and ordering key.
+                if *group_key == *inner_group_key && *order_key == *inner_order_key {
+                    // Given the following limit/offset pairs:
+                    //
+                    // inner_offset          inner_limit
+                    // |------------|xxxxxxxxxxxxxxxxxx|
+                    //              |------------|xxxxxxxxxxxx|
+                    //              outer_offset    outer_limit
+                    //
+                    // the limit/offset pair of the fused TopK operator is computed
+                    // as:
+                    //
+                    // offset = inner_offset + outer_offset
+                    // limit = min(max(inner_limit - outer_offset, 0), outer_limit)
+                    if let Some(inner_limit) = inner_limit {
+                        let inner_limit_minus_outer_offset = inner_limit.saturating_sub(*offset);
+                        if let Some(limit) = limit {
+                            *limit = std::cmp::min(*limit, inner_limit_minus_outer_offset);
+                        } else {
+                            *limit = Some(inner_limit_minus_outer_offset);
+                        }
+                    }
+
+                    if let Some(0) = limit {
+                        relation.take_safely();
+                        break;
+                    }
+
+                    *offset += *inner_offset;
+                    *monotonic = *inner_monotonic;
+                    **input = inner_input.take_dangerous();
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -183,6 +183,7 @@ impl Default for FuseAndCollapse {
                 Box::new(crate::fusion::filter::Filter),
                 Box::new(crate::fusion::project::Project),
                 Box::new(crate::fusion::join::Join),
+                Box::new(crate::fusion::top_k::TopK),
                 Box::new(crate::inline_let::InlineLet { inline_mfp: false }),
                 Box::new(crate::fusion::reduce::Reduce),
                 Box::new(crate::fusion::union::Union),

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -245,6 +245,7 @@ mod tests {
                 Ok(Box::new(transform::projection_pushdown::ProjectionPushdown))
             }
             "ReductionPushdown" => Ok(Box::new(transform::reduction_pushdown::ReductionPushdown)),
+            "TopKFusion" => Ok(Box::new(transform::fusion::top_k::TopK)),
             "UnionBranchCancellation" => {
                 Ok(Box::new(transform::union_cancel::UnionBranchCancellation))
             }

--- a/src/transform/tests/testdata/keys
+++ b/src/transform/tests/testdata/keys
@@ -65,7 +65,7 @@ steps format=types
 ====
 No change: TopKElision, NonNullRequirements
 ====
-Applied Fixpoint { transforms: [FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting, Map, Negate, Filter, Project, Join, InlineLet { inline_mfp: false }, Reduce, Union, UnionBranchCancellation, UpdateLet, RedundantJoin, FoldConstants { limit: Some(10000) }] }], limit: 100 }:
+Applied Fixpoint { transforms: [FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting, Map, Negate, Filter, Project, Join, TopK, InlineLet { inline_mfp: false }, Reduce, Union, UnionBranchCancellation, UpdateLet, RedundantJoin, FoldConstants { limit: Some(10000) }] }], limit: 100 }:
 %0 =
 | Get x (u0)
 | | types = (Int32?, Int64?, Int32?)
@@ -75,7 +75,7 @@ Applied Fixpoint { transforms: [FuseAndCollapse { transforms: [ProjectionExtract
 | | keys = ((#0), (#1))
 
 ====
-No change: Fixpoint { transforms: [PredicatePushdown, NonNullable, ColumnKnowledge, Demand, FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting, Map, Negate, Filter, Project, Join, InlineLet { inline_mfp: false }, Reduce, Union, UnionBranchCancellation, UpdateLet, RedundantJoin, FoldConstants { limit: Some(10000) }] }], limit: 100 }, Fixpoint { transforms: [ReductionPushdown, ReduceElision, LiteralLifting, RelationCSE, InlineLet { inline_mfp: false }, UpdateLet, FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting, Map, Negate, Filter, Project, Join, InlineLet { inline_mfp: false }, Reduce, Union, UnionBranchCancellation, UpdateLet, RedundantJoin, FoldConstants { limit: Some(10000) }] }], limit: 100 }, ProjectionPushdown, UpdateLet, Map, Fixpoint { transforms: [Join, RedundantJoin, Project, Union, UnionBranchCancellation, RelationCSE, InlineLet { inline_mfp: true }], limit: 100 }, Fixpoint { transforms: [JoinImplementation, ColumnKnowledge, FoldConstants { limit: Some(10000) }, Demand, LiteralLifting], limit: 100 }, ReductionPushdown, CanonicalizeMfp
+No change: Fixpoint { transforms: [PredicatePushdown, NonNullable, ColumnKnowledge, Demand, FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting, Map, Negate, Filter, Project, Join, TopK, InlineLet { inline_mfp: false }, Reduce, Union, UnionBranchCancellation, UpdateLet, RedundantJoin, FoldConstants { limit: Some(10000) }] }], limit: 100 }, Fixpoint { transforms: [ReductionPushdown, ReduceElision, LiteralLifting, RelationCSE, InlineLet { inline_mfp: false }, UpdateLet, FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting, Map, Negate, Filter, Project, Join, TopK, InlineLet { inline_mfp: false }, Reduce, Union, UnionBranchCancellation, UpdateLet, RedundantJoin, FoldConstants { limit: Some(10000) }] }], limit: 100 }, ProjectionPushdown, UpdateLet, Map, Fixpoint { transforms: [Join, RedundantJoin, Project, Union, UnionBranchCancellation, RelationCSE, InlineLet { inline_mfp: true }], limit: 100 }, Fixpoint { transforms: [JoinImplementation, ColumnKnowledge, FoldConstants { limit: Some(10000) }, Demand, LiteralLifting], limit: 100 }, ReductionPushdown, CanonicalizeMfp
 ====
 Applied RelationCSE:
 %0 = Let l0 =

--- a/src/transform/tests/testdata/steps
+++ b/src/transform/tests/testdata/steps
@@ -37,9 +37,9 @@ steps
 | Union %0 %1
 
 ====
-No change: TopKElision, NonNullRequirements, Fixpoint { transforms: [FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting, Map, Negate, Filter, Project, Join, InlineLet { inline_mfp: false }, Reduce, Union, UnionBranchCancellation, UpdateLet, RedundantJoin, FoldConstants { limit: Some(10000) }] }], limit: 100 }, Fixpoint { transforms: [PredicatePushdown, NonNullable, ColumnKnowledge, Demand, FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting, Map, Negate, Filter, Project, Join, InlineLet { inline_mfp: false }, Reduce, Union, UnionBranchCancellation, UpdateLet, RedundantJoin, FoldConstants { limit: Some(10000) }] }], limit: 100 }
+No change: TopKElision, NonNullRequirements, Fixpoint { transforms: [FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting, Map, Negate, Filter, Project, Join, TopK, InlineLet { inline_mfp: false }, Reduce, Union, UnionBranchCancellation, UpdateLet, RedundantJoin, FoldConstants { limit: Some(10000) }] }], limit: 100 }, Fixpoint { transforms: [PredicatePushdown, NonNullable, ColumnKnowledge, Demand, FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting, Map, Negate, Filter, Project, Join, TopK, InlineLet { inline_mfp: false }, Reduce, Union, UnionBranchCancellation, UpdateLet, RedundantJoin, FoldConstants { limit: Some(10000) }] }], limit: 100 }
 ====
-Applied Fixpoint { transforms: [ReductionPushdown, ReduceElision, LiteralLifting, RelationCSE, InlineLet { inline_mfp: false }, UpdateLet, FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting, Map, Negate, Filter, Project, Join, InlineLet { inline_mfp: false }, Reduce, Union, UnionBranchCancellation, UpdateLet, RedundantJoin, FoldConstants { limit: Some(10000) }] }], limit: 100 }:
+Applied Fixpoint { transforms: [ReductionPushdown, ReduceElision, LiteralLifting, RelationCSE, InlineLet { inline_mfp: false }, UpdateLet, FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting, Map, Negate, Filter, Project, Join, TopK, InlineLet { inline_mfp: false }, Reduce, Union, UnionBranchCancellation, UpdateLet, RedundantJoin, FoldConstants { limit: Some(10000) }] }], limit: 100 }:
 %0 = Let l0 =
 | Get x (u0)
 | Filter #0
@@ -123,13 +123,13 @@ steps in=json format=test
 (Filter (Join [(get u1) (get x)] [] Unimplemented) [(CallBinary Or (CallBinary And (CallUnary (IsNull ) #0) (CallUnary (IsNull ) #2)) (CallBinary Eq #0 (CallBinary AddInt64 #2 (1 Int64))))])
 
 ====
-No change: TopKElision, NonNullRequirements, Fixpoint { transforms: [FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting, Map, Negate, Filter, Project, Join, InlineLet { inline_mfp: false }, Reduce, Union, UnionBranchCancellation, UpdateLet, RedundantJoin, FoldConstants { limit: Some(10000) }] }], limit: 100 }
+No change: TopKElision, NonNullRequirements, Fixpoint { transforms: [FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting, Map, Negate, Filter, Project, Join, TopK, InlineLet { inline_mfp: false }, Reduce, Union, UnionBranchCancellation, UpdateLet, RedundantJoin, FoldConstants { limit: Some(10000) }] }], limit: 100 }
 ====
-Applied Fixpoint { transforms: [PredicatePushdown, NonNullable, ColumnKnowledge, Demand, FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting, Map, Negate, Filter, Project, Join, InlineLet { inline_mfp: false }, Reduce, Union, UnionBranchCancellation, UpdateLet, RedundantJoin, FoldConstants { limit: Some(10000) }] }], limit: 100 }:
+Applied Fixpoint { transforms: [PredicatePushdown, NonNullable, ColumnKnowledge, Demand, FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting, Map, Negate, Filter, Project, Join, TopK, InlineLet { inline_mfp: false }, Reduce, Union, UnionBranchCancellation, UpdateLet, RedundantJoin, FoldConstants { limit: Some(10000) }] }], limit: 100 }:
 (Join [(get u1) (get x)] [[#0 (CallBinary AddInt64 #2 (1 Int64))]] Unimplemented)
 
 ====
-No change: Fixpoint { transforms: [ReductionPushdown, ReduceElision, LiteralLifting, RelationCSE, InlineLet { inline_mfp: false }, UpdateLet, FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting, Map, Negate, Filter, Project, Join, InlineLet { inline_mfp: false }, Reduce, Union, UnionBranchCancellation, UpdateLet, RedundantJoin, FoldConstants { limit: Some(10000) }] }], limit: 100 }, ProjectionPushdown, UpdateLet, Map, Fixpoint { transforms: [Join, RedundantJoin, Project, Union, UnionBranchCancellation, RelationCSE, InlineLet { inline_mfp: true }], limit: 100 }
+No change: Fixpoint { transforms: [ReductionPushdown, ReduceElision, LiteralLifting, RelationCSE, InlineLet { inline_mfp: false }, UpdateLet, FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting, Map, Negate, Filter, Project, Join, TopK, InlineLet { inline_mfp: false }, Reduce, Union, UnionBranchCancellation, UpdateLet, RedundantJoin, FoldConstants { limit: Some(10000) }] }], limit: 100 }, ProjectionPushdown, UpdateLet, Map, Fixpoint { transforms: [Join, RedundantJoin, Project, Union, UnionBranchCancellation, RelationCSE, InlineLet { inline_mfp: true }], limit: 100 }
 ====
 Applied Fixpoint { transforms: [JoinImplementation, ColumnKnowledge, FoldConstants { limit: Some(10000) }, Demand, LiteralLifting], limit: 100 }:
 (Join [(ArrangeBy (get u1) [[#0]]) (get x)] [[#0 (CallBinary AddInt64 #2 (1 Int64))]] (Differential [1 null] [[0 [#0]]]))

--- a/src/transform/tests/testdata/topk_fusion
+++ b/src/transform/tests/testdata/topk_fusion
@@ -1,0 +1,237 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+cat
+(defsource x [int32 int64])
+----
+ok
+
+# both have limit and offset
+
+build apply=TopKFusion
+(top_k (top_k (get x) [] [] 3 2) [] [] 1 1)
+----
+%0 =
+| Get x (u0)
+| TopK group=() order=() limit=1 offset=3
+
+build apply=TopKFusion
+(top_k (top_k (get x) [0] [#0] 3 2) [0] [#0] 1 1)
+----
+%0 =
+| Get x (u0)
+| TopK group=(#0) order=(#0 asc) limit=1 offset=3
+
+# outer limit is greater than inner limit plus outer offset
+
+build apply=TopKFusion
+(top_k (top_k (get x) [0] [#0] 3 2) [0] [#0] 10 0)
+----
+%0 =
+| Get x (u0)
+| TopK group=(#0) order=(#0 asc) limit=3 offset=2
+
+build apply=TopKFusion
+(top_k (top_k (get x) [0] [#0] 3 2) [0] [#0] 10 1)
+----
+%0 =
+| Get x (u0)
+| TopK group=(#0) order=(#0 asc) limit=2 offset=3
+
+# outer offset is equal to inner limit
+
+build apply=TopKFusion
+(top_k (top_k (get x) [] [] 3 2) [] [] 1 3)
+----
+%0 =
+| Constant
+
+# outer offset is greater than the inner offset
+
+build apply=TopKFusion
+(top_k (top_k (get x) [] [] 3 0) [] [] null 4)
+----
+%0 =
+| Constant
+
+# inner has no limit, but both have offset
+
+build apply=TopKFusion
+(top_k (top_k (get x) [0] [#0] null 2) [0] [#0] 10 1)
+----
+%0 =
+| Get x (u0)
+| TopK group=(#0) order=(#0 asc) limit=10 offset=3
+
+# both have no limit, but offset
+
+build apply=TopKFusion
+(top_k (top_k (get x) [0] [#0] null 2) [0] [#0] null 1)
+----
+%0 =
+| Get x (u0)
+| TopK group=(#0) order=(#0 asc) offset=3
+
+# outer has no limit, but both have offset
+
+build apply=TopKFusion
+(top_k (top_k (get x) [] [#0] 3 2) [] [#0] null 1)
+----
+%0 =
+| Get x (u0)
+| TopK group=() order=(#0 asc) limit=2 offset=3
+
+# outer has no limit and no offset
+
+build apply=TopKFusion
+(top_k (top_k (get x) [] [#0] 3 2) [] [#0] null 0)
+----
+%0 =
+| Get x (u0)
+| TopK group=() order=(#0 asc) limit=3 offset=2
+
+# inner has no limit and no offset
+
+build apply=TopKFusion
+(top_k (top_k (get x) [] [#0] null 0) [] [#0] 3 2)
+----
+%0 =
+| Get x (u0)
+| TopK group=() order=(#0 asc) limit=3 offset=2
+
+# inner has no limit and no offset, and outer has only limit
+
+build apply=TopKFusion
+(top_k (top_k (get x) [] [#0] null 0) [] [#0] 3 0)
+----
+%0 =
+| Get x (u0)
+| TopK group=() order=(#0 asc) limit=3 offset=0
+
+# inner has no limit and no offset, and outer has only offset
+
+build apply=TopKFusion
+(top_k (top_k (get x) [] [#0] null 0) [] [#0] null 1)
+----
+%0 =
+| Get x (u0)
+| TopK group=() order=(#0 asc) offset=1
+
+# both have no limit and no offset
+
+build apply=TopKFusion
+(top_k (top_k (get x) [] [#0] null 0) [] [#0] null 0)
+----
+%0 =
+| Get x (u0)
+| TopK group=() order=(#0 asc) offset=0
+
+# both have limit 0 and no offset
+
+build apply=TopKFusion
+(top_k (top_k (get x) [] [#0] 0 0) [] [#0] 0 0)
+----
+%0 =
+| Constant
+
+# outer has limit 0
+
+build apply=TopKFusion
+(top_k (top_k (get x) [] [#0] null 0) [] [#0] 0 0)
+----
+%0 =
+| Constant
+
+# inner has limit 0
+
+build apply=TopKFusion
+(top_k (top_k (get x) [] [#0] 0 0) [] [#0] null 0)
+----
+%0 =
+| Constant
+
+build
+(top_k (top_k (constant [[5][4][2][3][2][1]] [int32]) [] [] 3 2) [] [] 1 1)
+----
+%0 =
+| Constant (5) (4) (2) (3) (2) (1)
+| TopK group=() order=() limit=3 offset=2
+| TopK group=() order=() limit=1 offset=1
+
+build apply=TopKFusion
+(top_k (top_k (constant [[5][4][2][3][2][1]] [int32]) [] [] 3 2) [] [] 1 1)
+----
+%0 =
+| Constant (5) (4) (2) (3) (2) (1)
+| TopK group=() order=() limit=1 offset=3
+
+opt
+(top_k (top_k (constant [[5][4][2][3][2][1]] [int32]) [] [] 3 2) [] [] 1 1)
+----
+%0 =
+| Constant (3)
+
+
+build apply=TopKFusion
+(top_k (top_k (constant [[5][4][2][3][2][1]] [int32]) [] [] 3 2) [] [] 1 3)
+----
+%0 =
+| Constant
+
+build apply=TopKFusion
+(top_k (top_k (constant [[5 4] [3 2] [1 0]] [int32 int32]) [] [#1] 3 2) [] [#0] 1 0)
+----
+%0 =
+| Constant (5, 4) (3, 2) (1, 0)
+| TopK group=() order=(#1 asc) limit=3 offset=2
+| TopK group=() order=(#0 asc) limit=1 offset=0
+
+build apply=TopKFusion
+(top_k (top_k (constant [[5 4] [3 2] [1 0]] [int32 int32]) [] [#1] 3 2) [] [#1] 1 0)
+----
+%0 =
+| Constant (5, 4) (3, 2) (1, 0)
+| TopK group=() order=(#1 asc) limit=1 offset=2
+
+build apply=TopKFusion
+(top_k (top_k (constant [[5 4] [3 2] [1 0]] [int32 int32]) [0] [#0] 3 2) [1] [#1] 1 0)
+----
+%0 =
+| Constant (5, 4) (3, 2) (1, 0)
+| TopK group=(#0) order=(#0 asc) limit=3 offset=2
+| TopK group=(#1) order=(#1 asc) limit=1 offset=0
+
+build apply=TopKFusion
+(top_k (top_k (constant [[5 4] [3 2] [1 0]] [int32 int32]) [0] [] 3 2) [0] [#1] 1 0)
+----
+%0 =
+| Constant (5, 4) (3, 2) (1, 0)
+| TopK group=(#0) order=() limit=3 offset=2
+| TopK group=(#0) order=(#1 asc) limit=1 offset=0
+
+# Fusionable TopK operators with grouping key
+
+build apply=TopKFusion
+(top_k (top_k (constant [[5 4] [3 2] [1 0] [1 1]] [int32 int32]) [0] [] 3 1) [0] [] 1 0)
+----
+%0 =
+| Constant (5, 4) (3, 2) (1, 0) (1, 1)
+| TopK group=(#0) order=() limit=1 offset=1
+
+build apply=FoldConstants
+(top_k (constant [[5 4] [3 2] [1 0] [1 1]] [int32 int32]) [0] [] 1 1)
+----
+%0 =
+| Constant (1, 1)
+
+build apply=FoldConstants
+(top_k (top_k (constant [[5 4] [3 2] [1 0] [1 1]] [int32 int32]) [0] [] 3 1) [0] [] 1 0)
+----
+%0 =
+| Constant (1, 1)

--- a/test/sqllogictest/transform/topk.slt
+++ b/test/sqllogictest/transform/topk.slt
@@ -94,3 +94,22 @@ explain typed plan for select * from (select * from with_primary_key limit 0);
 | | keys = (())
 
 EOF
+
+# Check that TopK fusion transform is wired up
+
+statement ok
+create table t1(f1 int, f2 int);
+----
+
+statement ok
+create materialized view v1 as select * from (select * from t1 order by f1 limit 10 offset 2) order by f1 limit 3 offset 1;
+----
+
+query T multiline
+explain view v1;
+----
+%0 =
+| Get materialize.public.t1 (u7)
+| TopK group=() order=(#0 asc) limit=3 offset=3
+
+EOF


### PR DESCRIPTION
<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug. [Link to issue.]

  * This PR adds a known-desirable feature. [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

This is PR adds a new optimization that fuses nested `TopK` operators. This is related to #8194, but only when the redundant TopK operators belong in a materialized view.

This commit has been extract from #9006.



### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
