### PR TITLE
Use a DatumVec in FormArrangementKey

### DIFF
--- a/src/dataflow/src/render/context.rs
+++ b/src/dataflow/src/render/context.rs
@@ -491,8 +491,10 @@ where
                 let (oks, errs) = self.as_collection();
                 let mut row_packer = Row::default();
 
+                let mut datums = DatumVec::new();
                 let (oks_keyed, errs_keyed) = oks.map_fallible("FormArrangementKey", move |row| {
-                    let datums = row.unpack();
+                    // TODO: Consider reusing the `row` allocation; probably in *next* invocation.
+                    let datums = datums.borrow_with(&row);
                     let temp_storage = RowArena::new();
                     row_packer.try_extend(key2.iter().map(|k| k.eval(&datums, &temp_storage)))?;
                     let key_row = row_packer.finish_and_reuse();


### PR DESCRIPTION
The `FormArrangementKey` operator was using `Row::unpack()` which allocates. Instead, we could use the `DatumVec` type as a reusable location into which we can unpack without allocation. This should be a strict performance improvement, in an operator @ruchirK observed as taking a fair bit of time in some benchmarks.

### Motivation

  * This PR adds a known-desirable feature. The related issue is <link once issues is filed>

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
