### PR TITLE
persist: clean up Indexed state

### DIFF
--- a/src/persist/src/indexed/runtime.rs
+++ b/src/persist/src/indexed/runtime.rs
@@ -891,7 +891,7 @@ impl<L: Log, B: Blob> RuntimeImpl<L, B> {
         // mz_metrics). Otherwise, it has no effect.
         //
         // TODO: Make step smarter and remove this hack.
-        let need_step = need_step && self.indexed.pending.has_responses();
+        let need_step = need_step && self.indexed.has_pending_responses();
 
         if need_step {
             self.prev_step = step_start;

--- a/src/persist/src/indexed/runtime.rs
+++ b/src/persist/src/indexed/runtime.rs
@@ -35,6 +35,7 @@ use crate::indexed::{Indexed, IndexedSnapshot, IndexedSnapshotIter, ListenFn, Sn
 use crate::pfuture::{PFuture, PFutureHandle};
 use crate::storage::{Blob, Log, SeqNo};
 
+#[derive(Debug)]
 enum Cmd {
     Register(String, (&'static str, &'static str), PFutureHandle<Id>),
     Destroy(String, PFutureHandle<bool>),

--- a/test/persistence/failpoints/failpoint_set_sync.td
+++ b/test/persistence/failpoints/failpoint_set_sync.td
@@ -20,14 +20,14 @@
 > INSERT INTO t1 VALUES (1);
 
 ! COMMIT
-failed to append to unsealed: FileBlob::set sync fail point reached
+FileBlob::set sync fail point reached
 
 > BEGIN
 
 > INSERT INTO t1 VALUES (1);
 
 ! COMMIT
-failed to append to unsealed: FileBlob::set sync fail point reached
+FileBlob::set sync fail point reached
 
 #
 # Remove the I/O error and recover


### PR DESCRIPTION
Requests are split into two types: _unbatched_ and _batched_. An
unbatched command is run entirely by itself (the applied state has just
been written to durable storage, then the command is run, then the
resulting state is immediately written to durable storage). A batched
command is applied to the machine state, but instead of immediately
serializing the state to storage, we buffer the command response in
Pending. Any other batched command can also be run and similarly
buffered in Pending. Then, the next time we get an unbatched command (or
`step` is called), all pending batched commands are made durable at once
(and responses filled, listeners updated, etc). This is a performance
optimization to amortize the cost of writing to durable storage across
many of those requests. The most common requests (write, seal,
allow_compaction) are all _batched_ to exploit this. All unbatched
commands are expected to be relatively infrequent (to avoid excessive
barriers in our pipelining).

Two new helpers, `apply_unbatched_cmd` and `apply_batched_cmd`,
were added that wrap `try_set_meta` and correspond to these request
types. They, along with pulling Pending out into an Option, make it much
easier to reason about invariants being kept as the code is executed. This
all also sets us up for followup work to use Pending as the source of truth
for incremental updates to META.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

An attempt was made to keep each commit individually reviewable. It mostly succeeded. :)

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
