### PR TITLE
testdrive: send all error-related output to stderr

### DIFF
--- a/src/testdrive/src/main.rs
+++ b/src/testdrive/src/main.rs
@@ -209,11 +209,11 @@ async fn main() {
     if errors.is_empty() {
         println!("testdrive completed successfully.");
     } else {
-        println!("!!! Error Report");
-        println!("{} errors were encountered during execution", errors.len());
+        eprintln!("!!! Error Report");
+        eprintln!("{} errors were encountered during execution", errors.len());
 
         if !error_files.is_empty() {
-            println!("files involved: {}", error_files.join(" "));
+            eprintln!("files involved: {}", error_files.join(" "));
         }
 
         process::exit(1);


### PR DESCRIPTION
Previously, error-related output produced by main.rs was sent
to stdout while error-related output produced by lib.rs was sent
to stderr. This caused the two sets of messages to interleave
in the combined log produced by 'docker logs', making it impossible
to parse.


### Motivation

Antithesis are having issues parsing our log files in the case where messages produced by testdrive's `lib.rs` and `main.rs` are co-mingled, like in this example:

```
[1000006541370] [338.020184] [workload] [info] rename.td:26:1: error: !!! Error Report\n
[1000006541370] [338.020194] [workload] [info] 1 errors were encountered during execution\n
[1000006541370] [338.020203] [workload] [info] files involved: rename.td\n
[1000006541370] [338.020212] [workload] [info] executing query failed: db error: ERROR: error registering kafka topic for sink: error fetching configuration from broker 0 when creating new topic snk1-u81-1633060903-6436925791828755894 for sink: Admin operation error: OperationTimedOut (Local: Timed out)\n
[1000006541370] [338.020221] [workload] [info]      |\n
[1000006541370] [338.020231] [workload] [info]   25 | \n
[1000006541370] [338.02024] [workload] [info]   26 | > CREATE SINK sink1 FROM mz_data\n
[1000006541370] [338.020249] [workload] [info]      | ^\n
```

The problem is that this output:

```
!!! Error Report\n
1 errors were encountered during execution\n
files involved: rename.td
```

from `main.rs` landed right in the middle of the text of the actual error that caused testdrive to fail. The reason is that the `!!! Error Report ...` thing was being sent to stdout whereas the error got sent to stderr. When the two streams were combined inside Antitheis's podman environment, they got interleaved badly, which breaks the regular expressions they are using to generate their reports.