### PR TITLE
dataflow: Distinct should not duplicate key in value

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -105,6 +105,9 @@ List new features before bug fixes.
 
 - Add support for `LIST(<subquery>)` constructor.
 
+- Fix a crash or incorrect results when a join consumes data from a distinct
+  operation. {{% gh 9027 %}}
+
 {{% version-header v0.9.12 %}}
 
 - **Breaking change**: Disallow ambiguous table references in queries. For

--- a/src/dataflow/src/render/reduce.rs
+++ b/src/dataflow/src/render/reduce.rs
@@ -837,8 +837,11 @@ where
     G::Timestamp: Lattice,
 {
     collection.reduce_abelian::<_, RowSpine<_, _, _, _>>("DistinctBy", {
-        |key, _input, output| {
-            output.push((key.clone(), 1));
+        |_key, _input, output| {
+            // We're pushing an empty row here because the key is implicitly added by the
+            // arrangement, and the permutation logic takes care of using the key part of the
+            // output.
+            output.push((Row::default(), 1));
         }
     })
 }


### PR DESCRIPTION
This causes unexpected row format when accessing the output of distinct
aggregations and could crash materialize or produce incorrect outputs. With
this commit, the key is not duplicated anymore as part of the value.

Fixes #9027 