### PR TITLE
dataflow: retain distinction between absent and empty while decoding

### DIFF
--- a/src/dataflow/src/source/kinesis.rs
+++ b/src/dataflow/src/source/kinesis.rs
@@ -16,7 +16,6 @@ use aws_util::kinesis::{get_shard_ids, get_shard_iterator};
 use futures::executor::block_on;
 use log::error;
 use ore::metrics::{DeleteOnDropGauge, GaugeVecExt};
-use repr::MessagePayload;
 use rusoto_core::RusotoError;
 use rusoto_kinesis::{GetRecordsError, GetRecordsInput, GetRecordsOutput, Kinesis, KinesisClient};
 use timely::scheduling::SyncActivator;
@@ -27,7 +26,7 @@ use dataflow_types::{
 use expr::{PartitionId, SourceInstanceId};
 
 use crate::logging::materialized::Logger;
-use crate::source::{NextMessage, SourceMessage, SourceReader};
+use crate::source::{MessagePayload, NextMessage, SourceMessage, SourceReader};
 
 use super::metrics::{KinesisMetrics, SourceBaseMetrics};
 use prometheus::core::AtomicI64;
@@ -223,7 +222,7 @@ impl SourceReader for KinesisSourceReader {
                             },
                             upstream_time_millis: None,
                             key: None,
-                            payload: Some(MessagePayload::Data(data)),
+                            payload: MessagePayload::Data(data),
                         };
                         self.buffered_messages.push_back(source_message);
                     }

--- a/src/dataflow/src/source/s3.rs
+++ b/src/dataflow/src/source/s3.rs
@@ -56,10 +56,9 @@ use dataflow_types::{
 use expr::{PartitionId, SourceInstanceId};
 use metrics::BucketMetrics;
 use notifications::Event;
-use repr::MessagePayload;
 
 use crate::logging::materialized::Logger;
-use crate::source::{NextMessage, SourceMessage, SourceReader};
+use crate::source::{MessagePayload, NextMessage, SourceMessage, SourceReader};
 
 use self::metrics::ScanBucketMetrics;
 use self::notifications::{EventType, TestEvent};
@@ -787,7 +786,7 @@ async fn download_object(
 
     if matches!(download_status, DownloadStatus::Ok) {
         let sent = tx.send(Ok(InternalMessage {
-            record: MessagePayload::EOF,
+            record: MessagePayload::Eof,
         }));
         if sent.await.is_err() {
             download_status = DownloadStatus::SendFailed;
@@ -951,7 +950,7 @@ impl SourceReader for S3SourceReader {
                     offset: self.offset.into(),
                     upstream_time_millis: None,
                     key: None,
-                    payload: Some(record),
+                    payload: record,
                 }))
             }
             Some(Some(Err(e))) => {

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -41,27 +41,6 @@ pub use scalar::{Datum, FromTy, ScalarBaseType, ScalarType, WithArena};
 // Concrete types used throughout Materialize for the generic parameters in Timely/Differential Dataflow.
 /// System-wide timestamp type.
 pub type Timestamp = u64;
+
 /// System-wide record count difference type.
 pub type Diff = isize;
-
-use serde::{Deserialize, Serialize};
-// This probably logically belongs in `dataflow`, but source caching looks at it,
-// so put it in `repr` instead.
-/// The payload delivered by a source connector; either bytes or an EOF marker.
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, Hash, PartialEq, Ord, PartialOrd)]
-pub enum MessagePayload {
-    /// Data from the source connector
-    Data(Vec<u8>),
-    /// Forces the decoder to consider this a delimiter.
-    ///
-    /// For example, CSV records are normally terminated by a newline,
-    /// but files might not be newline-terminated; thus we need
-    /// the decoder to emit a CSV record when the end of a file is seen.
-    EOF,
-}
-
-impl Default for MessagePayload {
-    fn default() -> Self {
-        Self::Data(vec![])
-    }
-}

--- a/src/testdrive/src/action/kafka/ingest.rs
+++ b/src/testdrive/src/action/kafka/ingest.rs
@@ -166,7 +166,11 @@ impl Transcoder {
                         row.read_to_end(&mut out).map_err_to_string()?;
                     }
                 }
-                Ok(Some(bytes::unescape(&out)?))
+                if out.is_empty() {
+                    Ok(None)
+                } else {
+                    Ok(Some(bytes::unescape(&out)?))
+                }
             }
         }
     }

--- a/src/testdrive/src/action/kafka/ingest.rs
+++ b/src/testdrive/src/action/kafka/ingest.rs
@@ -119,6 +119,9 @@ impl Transcoder {
                     protobuf::MessageType::Batch => {
                         Self::decode_json::<_, protobuf::gen::billing::Batch>(row)?.map(convert)
                     }
+                    protobuf::MessageType::Empty => {
+                        Self::decode_json::<_, protobuf::well_known_types::Empty>(row)?.map(convert)
+                    }
                     protobuf::MessageType::Measurement => {
                         Self::decode_json::<_, protobuf::gen::billing::Measurement>(row)?
                             .map(convert)

--- a/src/testdrive/src/format/protobuf.rs
+++ b/src/testdrive/src/format/protobuf.rs
@@ -13,12 +13,13 @@ use std::str::FromStr;
 
 pub mod gen;
 
-pub use protobuf::Message;
+pub use protobuf::{well_known_types, Message};
 
 #[derive(Debug, Copy, Clone)]
 pub enum MessageType {
     Batch,
     Struct,
+    Empty,
     Measurement,
     SimpleId,
     NestedOuter,
@@ -34,6 +35,7 @@ impl FromStr for MessageType {
         match s {
             "batch" => Ok(MessageType::Batch),
             "struct" => Ok(MessageType::Struct),
+            "empty" => Ok(MessageType::Empty),
             "measurement" => Ok(MessageType::Measurement),
             "simpleid" => Ok(MessageType::SimpleId),
             "nested" => Ok(MessageType::NestedOuter),

--- a/test/testdrive/protobuf.td
+++ b/test/testdrive/protobuf.td
@@ -51,14 +51,22 @@ Protobuf type "fixed64" is not supported
 
 $ kafka-create-topic topic=messages
 
-$ kafka-ingest format=protobuf topic=messages message=struct timestamp=1
+$ kafka-ingest format=protobuf topic=messages message=struct
 {"int": 1, "bad_int": 1, "bin": "ONE", "st": "my-string"}
 {"int": 2, "bad_int": 2, "bin": "ONE", "st": "something-valid"}
 
+# An empty message has the same wire format as a struct message with all
+# default fields.
+#
+# TODO(benesch): teach kafka-ingest to tolerate missing fields.
+$ kafka-ingest format=protobuf topic=messages message=empty
+{}
+
 # TODO: these should be fully json
 > SELECT * FROM pm
-1 1 ONE  my-string 1
+1 1 ONE  my-string       1
 2 2 ONE  something-valid 2
+0 0 ZERO ""              3
 
 # Test failure to deserialize protobuf messages when the value is corrupted
 > CREATE SOURCE corrupted_protomessages FROM
@@ -82,6 +90,7 @@ Decode error: Text: protobuf deserialization error: Deserializing into rust obje
 
 > SELECT * FROM protomessages3
 2 2 ONE  something-valid 2
+0 0 ZERO ""              3
 
 $ kafka-create-topic topic=messages-partitioned partitions=2
 


### PR DESCRIPTION
Whether a message payload is entirely absent or present but empty is an
important distinction for formats like protobuf, where an empty message
indicates "use the default values for all fields". The decoding pipeline
was previously treating empty messages as absent messages, resulting in
empty protobuf messages being incorrectly dropped.

This commit refactors the decoding pipeline to retain the distinction
between absent and empty message payloads. It also moves the
MessagePayload type out of repr and into dataflow: it seems whatever
constraint required locating the type in repr has evaporated.

### Motivation

  * This PR fixes a previously unreported bug.

    Empty protobuf messages were dropped on the floor, despite being valid protos.

### Tips for reviewer

The diff is much smaller if viewed with whitespace hidden.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
