### PR TITLE
dataflow: encode source delimited-ness in the type system

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -110,6 +110,8 @@ List new features before bug fixes.
 
 - Support protobuf sources that contain imported messages and enums.
 
+- Correctly handle protobuf messages where the value is omitted instead of dropping them.
+
 {{% version-header v0.9.12 %}}
 
 - **Breaking change**: Disallow ambiguous table references in queries. For

--- a/src/dataflow/src/source/file.rs
+++ b/src/dataflow/src/source/file.rs
@@ -62,6 +62,8 @@ impl From<FileOffset> for MzOffset {
 }
 
 impl SourceReader for FileSourceReader {
+    type Payload = MessagePayload;
+
     fn new(
         _name: String,
         source_id: SourceInstanceId,
@@ -163,7 +165,7 @@ impl SourceReader for FileSourceReader {
         ))
     }
 
-    fn get_next_message(&mut self) -> Result<NextMessage, anyhow::Error> {
+    fn get_next_message(&mut self) -> Result<NextMessage<Self::Payload>, anyhow::Error> {
         match self.receiver_stream.try_recv() {
             Ok(Ok(record)) => {
                 self.current_file_offset.offset += 1;
@@ -172,7 +174,7 @@ impl SourceReader for FileSourceReader {
                     offset: self.current_file_offset.into(),
                     upstream_time_millis: None,
                     key: None,
-                    payload: Some(record),
+                    payload: record,
                 };
                 Ok(NextMessage::Ready(message))
             }

--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -18,7 +18,6 @@ use rdkafka::error::KafkaError;
 use rdkafka::message::BorrowedMessage;
 use rdkafka::topic_partition_list::Offset;
 use rdkafka::{ClientConfig, ClientContext, Message, TopicPartitionList};
-use repr::MessagePayload;
 use timely::scheduling::activate::SyncActivator;
 
 use dataflow_types::{
@@ -64,6 +63,8 @@ pub struct KafkaSourceReader {
 }
 
 impl SourceReader for KafkaSourceReader {
+    type Payload = Option<Vec<u8>>;
+
     /// Create a new instance of a Kafka reader.
     fn new(
         source_name: String,
@@ -149,7 +150,7 @@ impl SourceReader for KafkaSourceReader {
     ///
     /// If a message has an offset that is smaller than the next expected offset for this consumer (and this partition)
     /// we skip this message, and seek to the appropriate offset
-    fn get_next_message(&mut self) -> Result<NextMessage, anyhow::Error> {
+    fn get_next_message(&mut self) -> Result<NextMessage<Self::Payload>, anyhow::Error> {
         // Poll the consumer once. Since we split the consumer's partitions out into separate queues and poll those individually,
         // we expect this poll to always return None - but it's necessary to drive logic that consumes from rdkafka's internal
         // event queue, such as statistics callbacks.
@@ -500,13 +501,13 @@ fn create_kafka_config(
     kafka_config
 }
 
-impl<'a> From<&BorrowedMessage<'a>> for SourceMessage {
+impl<'a> From<&BorrowedMessage<'a>> for SourceMessage<Option<Vec<u8>>> {
     fn from(msg: &BorrowedMessage<'a>) -> Self {
         let kafka_offset = KafkaOffset {
             offset: msg.offset(),
         };
         Self {
-            payload: msg.payload().map(|p| MessagePayload::Data(p.to_vec())),
+            payload: msg.payload().map(|p| p.to_vec()),
             partition: PartitionId::Kafka(msg.partition()),
             offset: kafka_offset.into(),
             upstream_time_millis: msg.timestamp().to_millis(),
@@ -533,7 +534,7 @@ impl PartitionConsumer {
     }
 
     /// Returns the next message to process for this partition (if any).
-    fn get_next_message(&mut self) -> Result<Option<SourceMessage>, KafkaError> {
+    fn get_next_message(&mut self) -> Result<Option<SourceMessage<Option<Vec<u8>>>>, KafkaError> {
         match self.partition_queue.poll(Duration::from_millis(0)) {
             Some(Ok(msg)) => {
                 let result = SourceMessage::from(&msg);

--- a/src/dataflow/src/source/s3.rs
+++ b/src/dataflow/src/source/s3.rs
@@ -855,6 +855,8 @@ where
 }
 
 impl SourceReader for S3SourceReader {
+    type Payload = MessagePayload;
+
     fn new(
         source_name: String,
         source_id: SourceInstanceId,
@@ -942,7 +944,7 @@ impl SourceReader for S3SourceReader {
         ))
     }
 
-    fn get_next_message(&mut self) -> Result<NextMessage, anyhow::Error> {
+    fn get_next_message(&mut self) -> Result<NextMessage<Self::Payload>, anyhow::Error> {
         match self.receiver_stream.recv().now_or_never() {
             Some(Some(Ok(InternalMessage { record }))) => {
                 self.offset += 1;
@@ -951,7 +953,7 @@ impl SourceReader for S3SourceReader {
                     offset: self.offset.into(),
                     upstream_time_millis: None,
                     key: None,
-                    payload: Some(record),
+                    payload: record,
                 }))
             }
             Some(Some(Err(e))) => {

--- a/src/testdrive/src/action/kafka/ingest.rs
+++ b/src/testdrive/src/action/kafka/ingest.rs
@@ -119,6 +119,9 @@ impl Transcoder {
                     protobuf::MessageType::Batch => {
                         Self::decode_json::<_, protobuf::gen::billing::Batch>(row)?.map(convert)
                     }
+                    protobuf::MessageType::Empty => {
+                        Self::decode_json::<_, protobuf::well_known_types::Empty>(row)?.map(convert)
+                    }
                     protobuf::MessageType::Measurement => {
                         Self::decode_json::<_, protobuf::gen::billing::Measurement>(row)?
                             .map(convert)
@@ -163,7 +166,11 @@ impl Transcoder {
                         row.read_to_end(&mut out).map_err_to_string()?;
                     }
                 }
-                Ok(Some(bytes::unescape(&out)?))
+                if out.is_empty() {
+                    Ok(None)
+                } else {
+                    Ok(Some(bytes::unescape(&out)?))
+                }
             }
         }
     }

--- a/src/testdrive/src/format/protobuf.rs
+++ b/src/testdrive/src/format/protobuf.rs
@@ -13,12 +13,13 @@ use std::str::FromStr;
 
 pub mod gen;
 
-pub use protobuf::Message;
+pub use protobuf::{well_known_types, Message};
 
 #[derive(Debug, Copy, Clone)]
 pub enum MessageType {
     Batch,
     Struct,
+    Empty,
     Measurement,
     SimpleId,
     NestedOuter,
@@ -34,6 +35,7 @@ impl FromStr for MessageType {
         match s {
             "batch" => Ok(MessageType::Batch),
             "struct" => Ok(MessageType::Struct),
+            "empty" => Ok(MessageType::Empty),
             "measurement" => Ok(MessageType::Measurement),
             "simpleid" => Ok(MessageType::SimpleId),
             "nested" => Ok(MessageType::NestedOuter),

--- a/test/testdrive/protobuf.td
+++ b/test/testdrive/protobuf.td
@@ -51,14 +51,22 @@ Protobuf type "fixed64" is not supported
 
 $ kafka-create-topic topic=messages
 
-$ kafka-ingest format=protobuf topic=messages message=struct timestamp=1
+$ kafka-ingest format=protobuf topic=messages message=struct
 {"int": 1, "bad_int": 1, "bin": "ONE", "st": "my-string"}
 {"int": 2, "bad_int": 2, "bin": "ONE", "st": "something-valid"}
 
+# An empty message has the same wire format as a struct message with all
+# default fields.
+#
+# TODO(benesch): teach kafka-ingest to tolerate missing fields.
+$ kafka-ingest format=protobuf topic=messages message=empty
+{}
+
 # TODO: these should be fully json
 > SELECT * FROM pm
-1 1 ONE  my-string 1
+1 1 ONE  my-string       1
 2 2 ONE  something-valid 2
+0 0 ZERO ""              3
 
 # Test failure to deserialize protobuf messages when the value is corrupted
 > CREATE SOURCE corrupted_protomessages FROM
@@ -82,6 +90,7 @@ Decode error: Text: protobuf deserialization error: Deserializing into rust obje
 
 > SELECT * FROM protomessages3
 2 2 ONE  something-valid 2
+0 0 ZERO ""              3
 
 $ kafka-create-topic topic=messages-partitioned partitions=2
 


### PR DESCRIPTION
### Motivation

This patch adds an associated type to the SourceReader trait that allows source implementations to choose what type of messages they wish to produce.

In practice, there are only two valid types depending on whether or not the source implementation is a delimited source providing a stream of messages or if it is a non-delimited source which behaves like a stream of bytes.

The message type for delimited source is an `Option<Vec<u8>>` whereas for the bytestream ones the pre-existing  MessagePayload` enum is used.


This allows the decoding pipeline for delimited sources to distinguish between a payload that is present or absent, which is an
important distinction for formats like protobuf, where an empty message indicates "use the default values for all fields". The decoding pipeline was previously treating empty messages as absent messages, resulting in empty protobuf messages being incorrectly dropped.

* This PR fixes a previously unreported bug.

    Empty protobuf messages were dropped on the floor, despite being valid protos.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).