### PR TITLE
persist: make monitoring durations more idiomatic

### DIFF
--- a/src/persist/src/indexed/cache.rs
+++ b/src/persist/src/indexed/cache.rs
@@ -22,7 +22,7 @@ use crate::error::Error;
 use crate::indexed::encoding::{
     BlobMeta, BlobTraceBatch, BlobUnsealedBatch, TraceBatchMeta, UnsealedBatchMeta,
 };
-use crate::indexed::metrics::{metric_duration_ms, Metrics};
+use crate::indexed::metrics::Metrics;
 use crate::pfuture::PFuture;
 use crate::storage::Blob;
 
@@ -164,8 +164,8 @@ impl<B: Blob> BlobCache<B> {
             .map_err(|err| self.metric_set_error(err))?;
         self.metrics
             .unsealed
-            .blob_write_ms
-            .inc_by(metric_duration_ms(write_start.elapsed()));
+            .blob_write_seconds
+            .inc_by(write_start.elapsed().as_secs_f64());
         self.metrics.unsealed.blob_write_count.inc();
         self.metrics.unsealed.blob_write_bytes.inc_by(val_len);
 
@@ -180,8 +180,8 @@ impl<B: Blob> BlobCache<B> {
         block_on(self.blob.lock()?.delete(&batch.key))?;
         self.metrics
             .unsealed
-            .blob_delete_ms
-            .inc_by(metric_duration_ms(delete_start.elapsed()));
+            .blob_delete_seconds
+            .inc_by(delete_start.elapsed().as_secs_f64());
         self.metrics.unsealed.blob_delete_count.inc();
         self.metrics
             .unsealed
@@ -262,8 +262,8 @@ impl<B: Blob> BlobCache<B> {
             .map_err(|err| self.metric_set_error(err))?;
         self.metrics
             .trace
-            .blob_write_ms
-            .inc_by(metric_duration_ms(write_start.elapsed()));
+            .blob_write_seconds
+            .inc_by(write_start.elapsed().as_secs_f64());
         self.metrics.trace.blob_write_count.inc();
         self.metrics.trace.blob_write_bytes.inc_by(val_len);
 
@@ -278,8 +278,8 @@ impl<B: Blob> BlobCache<B> {
         block_on(self.blob.lock()?.delete(&batch.key))?;
         self.metrics
             .trace
-            .blob_delete_ms
-            .inc_by(metric_duration_ms(delete_start.elapsed()));
+            .blob_delete_seconds
+            .inc_by(delete_start.elapsed().as_secs_f64());
         self.metrics.trace.blob_delete_count.inc();
         self.metrics
             .trace
@@ -317,8 +317,8 @@ impl<B: Blob> BlobCache<B> {
             .map_err(|err| self.metric_set_error(err))?;
         self.metrics
             .meta
-            .blob_write_ms
-            .inc_by(metric_duration_ms(write_start.elapsed()));
+            .blob_write_seconds
+            .inc_by(write_start.elapsed().as_secs_f64());
         self.metrics.meta.blob_write_count.inc();
         self.metrics.meta.blob_write_bytes.inc_by(val_len);
 

--- a/src/persist/src/indexed/mod.rs
+++ b/src/persist/src/indexed/mod.rs
@@ -38,7 +38,7 @@ use crate::indexed::encoding::{
     BlobMeta, BlobTraceBatch, BlobUnsealedBatch, Id, StreamRegistration, TraceBatchMeta, TraceMeta,
     UnsealedBatchMeta, UnsealedMeta,
 };
-use crate::indexed::metrics::{metric_duration_ms, Metrics};
+use crate::indexed::metrics::Metrics;
 use crate::indexed::trace::{Trace, TraceSnapshot, TraceSnapshotIter};
 use crate::indexed::unsealed::{Unsealed, UnsealedSnapshot, UnsealedSnapshotIter};
 use crate::pfuture::PFutureHandle;
@@ -669,10 +669,10 @@ impl<L: Log, B: Blob> Indexed<L, B> {
         let compaction_start = Instant::now();
         let ret = self.apply_unbatched_cmd(|state, _, maintainer| state.compact_inner(maintainer));
 
-        // Track compaction_ms even if compaction failed.
+        // Track compaction_seconds even if compaction failed.
         self.metrics
-            .compaction_ms
-            .inc_by(metric_duration_ms(compaction_start.elapsed()));
+            .compaction_seconds
+            .inc_by(compaction_start.elapsed().as_secs_f64());
 
         let (total_written_bytes, deleted_unsealed_batches, deleted_trace_batches) = ret?;
         if !deleted_unsealed_batches.is_empty() || !deleted_trace_batches.is_empty() {

--- a/src/persist/src/indexed/runtime.rs
+++ b/src/persist/src/indexed/runtime.rs
@@ -31,7 +31,7 @@ use crate::error::Error;
 use crate::indexed::background::Maintainer;
 use crate::indexed::cache::BlobCache;
 use crate::indexed::encoding::Id;
-use crate::indexed::metrics::{metric_duration_ms, Metrics};
+use crate::indexed::metrics::Metrics;
 use crate::indexed::{Indexed, IndexedSnapshot, IndexedSnapshotIter, ListenFn, Snapshot};
 use crate::pfuture::{PFuture, PFutureHandle};
 use crate::storage::{Blob, Log, SeqNo};
@@ -843,8 +843,8 @@ impl<L: Log, B: Blob> RuntimeImpl<L, B> {
         }
         let step_start = Instant::now();
         self.metrics
-            .cmd_run_ms
-            .inc_by(metric_duration_ms(step_start.duration_since(run_start)));
+            .cmd_run_seconds
+            .inc_by(step_start.duration_since(run_start).as_secs_f64());
 
         // HACK: This rate limits how much we call step in response to workloads
         // consisting entirely of write, seal, and allow_compaction (which is
@@ -901,8 +901,8 @@ impl<L: Log, B: Blob> RuntimeImpl<L, B> {
             }
 
             self.metrics
-                .cmd_step_ms
-                .inc_by(metric_duration_ms(step_start.elapsed()));
+                .cmd_step_seconds
+                .inc_by(step_start.elapsed().as_secs_f64());
         }
 
         return more_work;


### PR DESCRIPTION
Match the rest of mz, which uses f64 seconds for metrics. This is also
more idiomatic Prometheus usage:
https://prometheus.io/docs/practices/naming/#base-units
