### PR TITLE
persist: make thread names more idiomatic

### DIFF
--- a/src/persist/src/indexed/runtime.rs
+++ b/src/persist/src/indexed/runtime.rs
@@ -107,7 +107,7 @@ where
     let id = RuntimeId::new();
     let runtime_pool = pool.clone();
     let impl_handle = thread::Builder::new()
-        .name(format!("persist-runtime-{}", id.0))
+        .name("persist:runtime".into())
         .spawn(move || {
             let pool_guard = runtime_pool.enter();
             while runtime.work() {}

--- a/src/persist/src/nemesis/direct.rs
+++ b/src/persist/src/nemesis/direct.rs
@@ -499,7 +499,7 @@ impl DirectWorker {
         let progress = stream.progress_rx;
         let (tx, rx) = PFuture::new();
         let _ = thread::Builder::new()
-            .name("nemesis-seal".into())
+            .name("nemesis:seal".into())
             .spawn(move || {
                 tx.fill(|| -> Result<SeqNo, Error> {
                     // Wait for the seal to succeed or fail. Then, only if it

--- a/src/persist/src/nemesis/mod.rs
+++ b/src/persist/src/nemesis/mod.rs
@@ -304,7 +304,7 @@ impl<R: Runtime> Runner<R> {
             let rx = rx.clone();
             threads.push(
                 thread::Builder::new()
-                    .name(format!("nemesis:worker-{}", idx))
+                    .name(format!("nemesis:work-{}", idx))
                     .spawn(move || {
                         let mut outstanding =
                             VecDeque::<FutureStep>::with_capacity(Self::MAX_OUTSTANDING);


### PR DESCRIPTION
These better match tokio and timely, both of which use ":" to delineate
an initial category and a "work-[num]" suffix as the worker thread
names. Also remove the persist runtime id from the thread name, which
wasn't getting us anything any might get in the way when graphing (since
it would change on each restart).
e).
