### PR TITLE
persist: disable background test when logical_compaction_window is off

### DIFF
--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -646,7 +646,11 @@ swap: {swap_total}KB total, {swap_used}KB used{swap_limit}",
         } else {
             false
         };
-        let system_table_enabled = !args.disable_persistent_system_tables_test;
+        let mut system_table_enabled = !args.disable_persistent_system_tables_test;
+        if system_table_enabled && args.logical_compaction_window.is_none() {
+            log::warn!("--logical-compaction-window is off; disabling background persistence test to prevent unbounded disk usage");
+            system_table_enabled = false;
+        }
 
         let storage = if args.persist_storage.is_empty() {
             PersistStorage::File(PersistFileStorage {


### PR DESCRIPTION
When logical_compaction_window is off, the amount of data in the metrics
system tables being persisted as part of our background test would grow
without bound and use an unbounded amount of disk. Given that this test
is supposed to be transparent to the user, we disable the test when this
option is used.

Touches #8184

