### PR TITLE
Adds multi-region support to mzcloud cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2553,7 +2553,7 @@ dependencies = [
 [[package]]
 name = "mzcloud"
 version = "1.0.0"
-source = "git+https://github.com/MaterializeInc/cloud-sdks#9fad6bb7ae19eb1e714fc888d341e6355b98fc51"
+source = "git+https://github.com/MaterializeInc/cloud-sdks#e2817663ab4c57daecb5ba61f34c6c190defbbd9"
 dependencies = [
  "reqwest",
  "serde",


### PR DESCRIPTION
Adds multi-region support to mzcloud cli.

### Motivation

  * This PR adds a known-desirable feature. https://github.com/MaterializeInc/cloud/issues/843

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
