### PR TITLE
persist: change Blob::set allow_overwrite arg to be require_atomic

### DIFF
--- a/src/persist/benches/writer.rs
+++ b/src/persist/benches/writer.rs
@@ -35,7 +35,7 @@ use persist::indexed::metrics::Metrics;
 use persist::indexed::Indexed;
 use persist::mem::MemRegistry;
 use persist::pfuture::{PFuture, PFutureHandle};
-use persist::storage::{Blob, LockInfo, Log, SeqNo};
+use persist::storage::{Atomicity, Blob, LockInfo, Log, SeqNo};
 
 fn new_file_log(name: &str, parent: &Path) -> FileLog {
     let file_log_dir = parent.join(name);
@@ -91,7 +91,7 @@ fn bench_set<B: Blob>(writer: &mut B, data: Vec<u8>, b: &mut Bencher) {
         futures_executor::block_on(writer.set(
             &format!("{}", rng.gen::<usize>()),
             data.clone(),
-            false,
+            Atomicity::AllowNonAtomic,
         ))
         .expect("failed to write data");
     })

--- a/src/persist/src/file.rs
+++ b/src/persist/src/file.rs
@@ -21,7 +21,7 @@ use fail::fail_point;
 use ore::cast::CastFrom;
 
 use crate::error::Error;
-use crate::storage::{Blob, LockInfo, Log, SeqNo};
+use crate::storage::{Atomicity, Blob, LockInfo, Log, SeqNo};
 
 /// Inner struct handles to separate files that store the data and metadata about the
 /// most recently truncated sequence number for [FileLog].
@@ -327,47 +327,50 @@ impl Blob for FileBlob {
         Ok(Some(buf))
     }
 
-    async fn set(&mut self, key: &str, value: Vec<u8>, allow_overwrite: bool) -> Result<(), Error> {
+    async fn set(&mut self, key: &str, value: Vec<u8>, atomic: Atomicity) -> Result<(), Error> {
         let file_path = self.blob_path(key)?;
-        if allow_overwrite {
-            // allow_overwrite=true requires atomic writes, so write to a temp
-            // file and rename it into place.
-            let mut tmp_name = file_path.clone();
-            debug_assert_eq!(tmp_name.extension(), None);
-            tmp_name.set_extension("tmp");
-            // NB: Don't use create_new(true) for this so that if we have a
-            // partial one from a previous crash, it will just get overwritten
-            // (which is safe).
-            let mut file = File::create(&tmp_name)?;
-            file.write_all(&value[..])?;
+        match atomic {
+            Atomicity::RequireAtomic => {
+                // To implement require_atomic, write to a temp file and rename
+                // it into place.
+                let mut tmp_name = file_path.clone();
+                debug_assert_eq!(tmp_name.extension(), None);
+                tmp_name.set_extension("tmp");
+                // NB: Don't use create_new(true) for this so that if we have a
+                // partial one from a previous crash, it will just get
+                // overwritten (which is safe).
+                let mut file = File::create(&tmp_name)?;
+                file.write_all(&value[..])?;
 
-            fail_point!("fileblob_set_sync", |_| {
-                Err(Error::from(format!(
-                    "FileBlob::set sync allow_overwrite fail point reached for file {:?}",
-                    file_path
-                )))
-            });
+                fail_point!("fileblob_set_sync", |_| {
+                    Err(Error::from(format!(
+                        "FileBlob::set sync fail point reached for file {:?}",
+                        file_path
+                    )))
+                });
 
-            file.sync_all()?;
-            fs::rename(tmp_name, &file_path)?;
-            // TODO: We also need to fsync the directory to be truly confidant
-            // that this is permanently there. It doesn't seem like this is
-            // available in the stdlib, find a crate for it?
-        } else {
-            let mut file = OpenOptions::new()
-                .write(true)
-                .create_new(true)
-                .open(&file_path)?;
-            file.write_all(&value[..])?;
+                file.sync_all()?;
+                fs::rename(tmp_name, &file_path)?;
+                // TODO: We also need to fsync the directory to be truly
+                // confidant that this is permanently there. It doesn't seem
+                // like this is available in the stdlib, find a crate for it?
+            }
+            Atomicity::AllowNonAtomic => {
+                let mut file = OpenOptions::new()
+                    .write(true)
+                    .create(true)
+                    .open(&file_path)?;
+                file.write_all(&value[..])?;
 
-            fail_point!("fileblob_set_sync", |_| {
-                Err(Error::from(format!(
-                    "FileBlob::set sync fail point reached for file {:?}",
-                    file_path
-                )))
-            });
+                fail_point!("fileblob_set_sync", |_| {
+                    Err(Error::from(format!(
+                        "FileBlob::set sync fail point reached for file {:?}",
+                        file_path
+                    )))
+                });
 
-            file.sync_all()?;
+                file.sync_all()?;
+            }
         }
         Ok(())
     }

--- a/src/persist/src/golden_test.rs
+++ b/src/persist/src/golden_test.rs
@@ -21,7 +21,7 @@ use crate::mem::{MemBlob, MemRegistry};
 use crate::nemesis::direct::{Direct, StartRuntime};
 use crate::nemesis::generator::{Generator, GeneratorConfig};
 use crate::nemesis::{Input, Runtime, RuntimeWorker};
-use crate::storage::Blob;
+use crate::storage::{Atomicity, Blob};
 use crate::unreliable::UnreliableBlob;
 
 /// A test to catch changes in any part of the end-to-end persist encoding.
@@ -202,7 +202,8 @@ impl Blobs {
         let blobs: Blobs =
             serde_json::from_str(blob_json).map_err(|err| Error::from(err.to_string()))?;
         for (key, val) in blobs.blobs.iter() {
-            blob.set(&key, val.to_owned(), false).await?;
+            blob.set(&key, val.to_owned(), Atomicity::AllowNonAtomic)
+                .await?;
         }
         Ok(())
     }


### PR DESCRIPTION
There doesn't seem to be any way to performantly implement
allow_overwrite=false for s3. Conveniently, after the keys for batch
blobs were changed to UUIDs in #8667, we no longer need the stronger
semantics of allow_overwrite=false to guard against accidental
overwrites. We do however need the ability to opt-in to atomic writes in
FileBlob for the meta key, so keep this around in a weakened form as
require_atomic.
