### PR TITLE
Partition commands rather than clone

### DIFF
--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -1117,25 +1117,31 @@ pub mod plan {
         }
 
         /// Shards the plan across workers, partitioning responsibility for the `Constant` elements.
-        pub fn clone_for_worker(&self, index: usize, peers: usize) -> Self {
+        pub fn partition_among(self, parts: usize) -> Vec<Self> {
             match self {
                 // For constants, balance the rows across the workers.
-                Plan::Constant { rows } => Plan::Constant {
-                    rows: match rows {
-                        Ok(rows) => Ok(rows
-                            .iter()
-                            .enumerate()
-                            .filter(|(i, _)| i % peers == index)
-                            .map(|(_, rows)| rows.clone())
-                            .collect()),
-                        Err(err) => {
-                            if index == 0 {
-                                Err(err.clone())
-                            } else {
-                                Ok(Vec::new())
-                            }
+                Plan::Constant { rows } => match rows {
+                    Ok(rows) => {
+                        let mut rows_parts = vec![Vec::new(); parts];
+                        for (index, row) in rows.into_iter().enumerate() {
+                            rows_parts[index % parts].push(row);
                         }
-                    },
+                        rows_parts
+                            .into_iter()
+                            .map(|rows| Plan::Constant { rows: Ok(rows) })
+                            .collect()
+                    }
+                    Err(err) => {
+                        let mut result = vec![
+                            Plan::Constant {
+                                rows: Ok(Vec::new())
+                            };
+                            parts
+                        ];
+                        assert!(parts > 0);
+                        result[0] = Plan::Constant { rows: Err(err) };
+                        result
+                    }
                 },
 
                 // For all other variants, just replace inputs with appropriately sharded versions.
@@ -1145,82 +1151,139 @@ pub mod plan {
                     keys,
                     mfp,
                     key_val,
-                } => Plan::Get {
-                    id: *id,
-                    keys: keys.clone(),
-                    mfp: mfp.clone(),
-                    key_val: key_val.clone(),
-                },
-                Plan::Let { value, body, id } => Plan::Let {
-                    value: Box::new(value.clone_for_worker(index, peers)),
-                    body: Box::new(body.clone_for_worker(index, peers)),
-                    id: *id,
-                },
+                } => vec![
+                    Plan::Get {
+                        id,
+                        keys,
+                        mfp,
+                        key_val,
+                    };
+                    parts
+                ],
+                Plan::Let { value, body, id } => {
+                    let value_parts = value.partition_among(parts);
+                    let body_parts = body.partition_among(parts);
+                    value_parts
+                        .into_iter()
+                        .zip(body_parts)
+                        .map(|(value, body)| Plan::Let {
+                            value: Box::new(value),
+                            body: Box::new(body),
+                            id,
+                        })
+                        .collect()
+                }
                 Plan::Mfp {
                     input,
                     mfp,
                     key_val,
-                } => Plan::Mfp {
-                    input: Box::new(input.clone_for_worker(index, peers)),
-                    mfp: mfp.clone(),
-                    key_val: key_val.clone(),
-                },
+                } => input
+                    .partition_among(parts)
+                    .into_iter()
+                    .map(|input| Plan::Mfp {
+                        input: Box::new(input),
+                        mfp: mfp.clone(),
+                        key_val: key_val.clone(),
+                    })
+                    .collect(),
                 Plan::FlatMap {
                     input,
                     func,
                     exprs,
                     mfp,
-                } => Plan::FlatMap {
-                    input: Box::new(input.clone_for_worker(index, peers)),
-                    func: func.clone(),
-                    exprs: exprs.clone(),
-                    mfp: mfp.clone(),
-                },
-                Plan::Join { inputs, plan } => Plan::Join {
-                    inputs: inputs
-                        .iter()
-                        .map(|input| input.clone_for_worker(index, peers))
-                        .collect(),
-                    plan: plan.clone(),
-                },
+                } => input
+                    .partition_among(parts)
+                    .into_iter()
+                    .map(|input| Plan::FlatMap {
+                        input: Box::new(input),
+                        func: func.clone(),
+                        exprs: exprs.clone(),
+                        mfp: mfp.clone(),
+                    })
+                    .collect(),
+                Plan::Join { inputs, plan } => {
+                    let mut inputs_parts = vec![Vec::new(); parts];
+                    for input in inputs.into_iter() {
+                        for (index, input_part) in
+                            input.partition_among(parts).into_iter().enumerate()
+                        {
+                            inputs_parts[index].push(input_part);
+                        }
+                    }
+                    inputs_parts
+                        .into_iter()
+                        .map(|inputs| Plan::Join {
+                            inputs,
+                            plan: plan.clone(),
+                        })
+                        .collect()
+                }
                 Plan::Reduce {
                     input,
                     key_val_plan,
                     plan,
                     permutation,
-                } => Plan::Reduce {
-                    input: Box::new(input.clone_for_worker(index, peers)),
-                    key_val_plan: key_val_plan.clone(),
-                    plan: plan.clone(),
-                    permutation: permutation.clone(),
-                },
-                Plan::TopK { input, top_k_plan } => Plan::TopK {
-                    input: Box::new(input.clone_for_worker(index, peers)),
-                    top_k_plan: top_k_plan.clone(),
-                },
-                Plan::Negate { input } => Plan::Negate {
-                    input: Box::new(input.clone_for_worker(index, peers)),
-                },
+                } => input
+                    .partition_among(parts)
+                    .into_iter()
+                    .map(|input| Plan::Reduce {
+                        input: Box::new(input),
+                        key_val_plan: key_val_plan.clone(),
+                        plan: plan.clone(),
+                        permutation: permutation.clone(),
+                    })
+                    .collect(),
+                Plan::TopK { input, top_k_plan } => input
+                    .partition_among(parts)
+                    .into_iter()
+                    .map(|input| Plan::TopK {
+                        input: Box::new(input),
+                        top_k_plan: top_k_plan.clone(),
+                    })
+                    .collect(),
+                Plan::Negate { input } => input
+                    .partition_among(parts)
+                    .into_iter()
+                    .map(|input| Plan::Negate {
+                        input: Box::new(input),
+                    })
+                    .collect(),
                 Plan::Threshold {
                     input,
                     threshold_plan,
-                } => Plan::Threshold {
-                    input: Box::new(input.clone_for_worker(index, peers)),
-                    threshold_plan: threshold_plan.clone(),
-                },
-                Plan::Union { inputs } => Plan::Union {
-                    inputs: inputs
-                        .iter()
-                        .map(|input| input.clone_for_worker(index, peers))
-                        .collect(),
-                },
+                } => input
+                    .partition_among(parts)
+                    .into_iter()
+                    .map(|input| Plan::Threshold {
+                        input: Box::new(input),
+                        threshold_plan: threshold_plan.clone(),
+                    })
+                    .collect(),
+                Plan::Union { inputs } => {
+                    let mut inputs_parts = vec![Vec::new(); parts];
+                    for input in inputs.into_iter() {
+                        for (index, input_part) in
+                            input.partition_among(parts).into_iter().enumerate()
+                        {
+                            inputs_parts[index].push(input_part);
+                        }
+                    }
+                    inputs_parts
+                        .into_iter()
+                        .map(|inputs| Plan::Union { inputs })
+                        .collect()
+                }
                 Plan::ArrangeBy {
                     input,
                     ensure_arrangements,
-                } => Plan::ArrangeBy {
-                    input: Box::new(input.clone_for_worker(index, peers)),
-                    ensure_arrangements: ensure_arrangements.clone(),
-                },
+                } => input
+                    .partition_among(parts)
+                    .into_iter()
+                    .map(|input| Plan::ArrangeBy {
+                        input: Box::new(input),
+                        ensure_arrangements: ensure_arrangements.clone(),
+                    })
+                    .collect(),
             }
         }
     }

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -1116,7 +1116,10 @@ pub mod plan {
             })
         }
 
-        /// Shards the plan across workers, partitioning responsibility for the `Constant` elements.
+        /// Partitions the plan into `parts` many disjoint pieces.
+        ///
+        /// This is used to partition `Plan::Constant` stages so that the work
+        /// can be distributed across many workers.
         pub fn partition_among(self, parts: usize) -> Vec<Self> {
             if parts == 0 {
                 Vec::new()

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -185,7 +185,7 @@ pub enum Command {
 }
 
 impl Command {
-    /// Partitions the command among `peers` many workers.
+    /// Partitions the command into `parts` many disjoint pieces.
     ///
     /// This is used to subdivide commands that can be sharded across workers,
     /// for example the `plan::Constant` stages of dataflow plans, and the

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -185,54 +185,63 @@ pub enum Command {
 }
 
 impl Command {
-    /// Produces a copy of the command suitable for the indicated worker.
+    /// Partitions the command among `peers` many workers.
     ///
     /// This is used to subdivide commands that can be sharded across workers,
     /// for example the `plan::Constant` stages of dataflow plans, and the
     /// `Command::Insert` commands that may contain multiple updates.
-    pub fn clone_for_worker(&self, index: usize, peers: usize) -> Self {
+    pub fn partition_among(self, parts: usize) -> Vec<Self> {
         match self {
             Command::CreateDataflows(dataflows) => {
-                Command::CreateDataflows(
-                    dataflows
-                        .iter()
-                        .map(|dataflow| {
-                            // We do this here, because it is hard to have `dataflow_types::Dataflow` know about
-                            // `dataflow::Plan`.
-                            // Each dataflow we construct should shard its `Constant` collections.
-                            let objects_to_build = dataflow
-                                .objects_to_build
-                                .iter()
-                                .map(|description| dataflow_types::BuildDesc {
-                                    id: description.id,
-                                    view: description.view.clone_for_worker(index, peers),
-                                })
-                                .collect::<Vec<_>>();
-                            // Clone all fields, other than `objects_to_build` defined above.
-                            DataflowDescription {
-                                source_imports: dataflow.source_imports.clone(),
-                                index_imports: dataflow.index_imports.clone(),
-                                objects_to_build,
-                                index_exports: dataflow.index_exports.clone(),
-                                sink_exports: dataflow.sink_exports.clone(),
-                                dependent_objects: dataflow.dependent_objects.clone(),
-                                as_of: dataflow.as_of.clone(),
-                                debug_name: dataflow.debug_name.clone(),
-                            }
-                        })
-                        .collect(),
-                )
+                let mut dataflows_parts = vec![Vec::new(); parts];
+
+                for dataflow in dataflows {
+                    // A list of descriptions of objects for each part to build.
+                    let mut builds_parts = vec![Vec::new(); parts];
+                    // Partition each build description among `parts`.
+                    for build_desc in dataflow.objects_to_build {
+                        let build_part = build_desc.view.partition_among(parts);
+                        for (view, objects_to_build) in
+                            build_part.into_iter().zip(builds_parts.iter_mut())
+                        {
+                            objects_to_build.push(dataflow_types::BuildDesc {
+                                id: build_desc.id,
+                                view,
+                            });
+                        }
+                    }
+                    // Each list of build descriptions results in a dataflow description.
+                    for (dataflows_part, objects_to_build) in
+                        dataflows_parts.iter_mut().zip(builds_parts)
+                    {
+                        dataflows_part.push(DataflowDescription {
+                            source_imports: dataflow.source_imports.clone(),
+                            index_imports: dataflow.index_imports.clone(),
+                            objects_to_build,
+                            index_exports: dataflow.index_exports.clone(),
+                            sink_exports: dataflow.sink_exports.clone(),
+                            dependent_objects: dataflow.dependent_objects.clone(),
+                            as_of: dataflow.as_of.clone(),
+                            debug_name: dataflow.debug_name.clone(),
+                        });
+                    }
+                }
+                dataflows_parts
+                    .into_iter()
+                    .map(|dataflows| Command::CreateDataflows(dataflows))
+                    .collect()
             }
-            Command::Insert { id, updates } => Command::Insert {
-                id: *id,
-                updates: updates
-                    .iter()
-                    .enumerate()
-                    .filter(|(i, _)| i % peers == index)
-                    .map(|(_, update)| update.clone())
-                    .collect(),
-            },
-            command => command.clone(),
+            Command::Insert { id, updates } => {
+                let mut updates_parts = vec![Vec::new(); parts];
+                for (index, update) in updates.into_iter().enumerate() {
+                    updates_parts[index % parts].push(update);
+                }
+                updates_parts
+                    .into_iter()
+                    .map(|updates| Command::Insert { id, updates })
+                    .collect()
+            }
+            command => vec![command; parts],
         }
     }
 }
@@ -344,18 +353,10 @@ impl Client for LocalClient {
 
     async fn send(&mut self, cmd: Command) {
         trace!("Broadcasting dataflow command: {:?}", cmd);
-        let num_workers = self.num_workers();
-        if num_workers == 1 {
-            // This special case avoids a clone of the whole plan.
-            self.worker_txs[0]
-                .send(cmd)
-                .expect("worker command receiver should not drop first");
-        } else {
-            for (index, sendpoint) in self.worker_txs.iter().enumerate() {
-                sendpoint
-                    .send(cmd.clone_for_worker(index, self.num_workers()))
-                    .expect("worker command receiver should not drop first")
-            }
+        let cmd_parts = cmd.partition_among(self.num_workers());
+        for (tx, cmd_part) in self.worker_txs.iter().zip(cmd_parts) {
+            tx.send(cmd_part)
+                .expect("worker command receiver should not drop first")
         }
         for thread in &self.worker_threads {
             thread.unpark()


### PR DESCRIPTION
This PR partitions `dataflow::Command` instances among the client endpoints, rather than cloning fragments of the command. It should avoid all unnecessary cloning, and avoids scanning all of the constant updates multiple times.

It is more gross than it should be, owing to the tree-shaped structure of our expressions (it would have been simpler if they used a stack representation).

### Motivation

Which of the following best describes the motivation behind this PR?

  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
