### PR TITLE
dataflow: use `DecodeError` for all decode specific functionality

### DIFF
--- a/src/dataflow/src/decode/avro.rs
+++ b/src/dataflow/src/decode/avro.rs
@@ -9,7 +9,7 @@
 
 use futures::executor::block_on;
 
-use dataflow_types::{DataflowError, DecodeError};
+use dataflow_types::DecodeError;
 use interchange::avro::{Decoder, EnvelopeType};
 use repr::Row;
 
@@ -46,16 +46,16 @@ impl AvroDecoderState {
         &mut self,
         bytes: &mut &[u8],
         upstream_time_millis: Option<i64>,
-    ) -> Result<Option<Row>, DataflowError> {
+    ) -> Result<Option<Row>, DecodeError> {
         match block_on(self.decoder.decode(bytes, upstream_time_millis)) {
             Ok(row) => {
                 self.events_success += 1;
                 Ok(Some(row))
             }
-            Err(err) => Err(DataflowError::DecodeError(DecodeError::Text(format!(
+            Err(err) => Err(DecodeError::Text(format!(
                 "avro deserialization error: {:#}",
                 err
-            )))),
+            ))),
         }
     }
 }

--- a/src/dataflow/src/decode/csv.rs
+++ b/src/dataflow/src/decode/csv.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use dataflow_types::{CsvEncoding, DataflowError, DecodeError, LinearOperator};
+use dataflow_types::{CsvEncoding, DecodeError, LinearOperator};
 use repr::{Datum, Row};
 
 #[derive(Debug)]
@@ -68,7 +68,7 @@ impl CsvDecoderState {
         }
     }
 
-    pub fn decode(&mut self, chunk: &mut &[u8]) -> Result<Option<Row>, DataflowError> {
+    pub fn decode(&mut self, chunk: &mut &[u8]) -> Result<Option<Row>, DecodeError> {
         loop {
             let (result, n_input, n_output, n_ends) = self.csv_reader.read_record(
                 *chunk,
@@ -98,12 +98,12 @@ impl CsvDecoderState {
                         }
                         if ends_valid != self.n_cols {
                             self.events_error += 1;
-                            Err(DataflowError::DecodeError(DecodeError::Text(format!(
+                            Err(DecodeError::Text(format!(
                                 "CSV error at record number {}: expected {} columns, got {}.",
                                 self.total_events(),
                                 self.n_cols,
                                 ends_valid
-                            ))))
+                            )))
                         } else {
                             match std::str::from_utf8(&self.output[0..self.output_cursor]) {
                                 Ok(output) => {
@@ -125,11 +125,11 @@ impl CsvDecoderState {
                                 }
                                 Err(e) => {
                                     self.events_error += 1;
-                                    Err(DataflowError::DecodeError(DecodeError::Text(format!(
+                                    Err(DecodeError::Text(format!(
                                         "CSV error at record number {}: invalid UTF-8 ({})",
                                         self.total_events(),
                                         e
-                                    ))))
+                                    )))
                                 }
                             }
                         }
@@ -146,14 +146,14 @@ impl CsvDecoderState {
                                 .enumerate()
                                 .find(|(_, (actual, expected))| actual.unwrap_str() != &**expected);
                             if let Some((i, (actual, expected))) = mismatched {
-                                break Err(DataflowError::DecodeError(DecodeError::Text(format!(
+                                break Err(DecodeError::Text(format!(
                                     "source file contains incorrect columns '{:?}', \
                                      first mismatched column at index {} expected={} actual={}",
                                     row,
                                     i + 1,
                                     expected,
                                     actual
-                                ))));
+                                )));
                             }
                         }
                         if chunk.is_empty() {

--- a/src/dataflow/src/decode/protobuf.rs
+++ b/src/dataflow/src/decode/protobuf.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use dataflow_types::{DataflowError, DecodeError, ProtobufEncoding};
+use dataflow_types::{DecodeError, ProtobufEncoding};
 use interchange::protobuf::decode::{DecodedDescriptors, Decoder};
 use repr::Row;
 
@@ -33,7 +33,7 @@ impl ProtobufDecoderState {
             events_error: 0,
         }
     }
-    pub fn get_value(&mut self, bytes: &[u8]) -> Option<Result<Row, DataflowError>> {
+    pub fn get_value(&mut self, bytes: &[u8]) -> Option<Result<Row, DecodeError>> {
         match self.decoder.decode(bytes) {
             Ok(row) => {
                 if let Some(row) = row {
@@ -41,17 +41,17 @@ impl ProtobufDecoderState {
                     Some(Ok(row))
                 } else {
                     self.events_error += 1;
-                    Some(Err(DataflowError::DecodeError(DecodeError::Text(format!(
+                    Some(Err(DecodeError::Text(format!(
                         "protobuf deserialization returned None"
-                    )))))
+                    ))))
                 }
             }
             Err(err) => {
                 self.events_error += 1;
-                Some(Err(DataflowError::DecodeError(DecodeError::Text(format!(
+                Some(Err(DecodeError::Text(format!(
                     "protobuf deserialization error: {:#}",
                     err
-                )))))
+                ))))
             }
         }
     }

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -9,7 +9,7 @@
 
 //! Types related to the creation of dataflow sources.
 
-use dataflow_types::{DataflowError, SourceErrorDetails};
+use dataflow_types::{DataflowError, DecodeError, SourceErrorDetails};
 use mz_avro::types::Value;
 use persist::indexed::runtime::{StreamReadHandle, StreamWriteHandle};
 use persist::indexed::Snapshot;
@@ -159,9 +159,9 @@ pub(crate) struct SourceData {
 /// The output of the decoding operator
 pub struct DecodeResult {
     /// The decoded key
-    pub key: Option<Result<Row, DataflowError>>,
+    pub key: Option<Result<Row, DecodeError>>,
     /// The decoded value
-    pub value: Option<Result<Row, DataflowError>>,
+    pub value: Option<Result<Row, DecodeError>>,
     /// The index of the decoded value in the stream
     pub position: Option<i64>,
 }


### PR DESCRIPTION
### Motivation

All the decode functions were previously returning a more general `DataflowError` but in practice they would only ever produce a `DataflowError::DecodeError` variant.

This patch changes all these places to use the more specific error type directly and does the conversion to the more general one further up the call stack.

This also had the nice side effect of statically checking some invariants that were previously guarded with panicing code paths.

@aljoscha added you as a reviewer for the changes in the persisted upsert operator.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
