### PR TITLE
Fix window function lowering for correlated subqueries

### DIFF
--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -151,3 +151,294 @@ ORDER BY row_number, x
 Finish order_by=(#0 asc, #1 asc) limit=none offset=0 project=(#0, #1)
 
 EOF
+
+#
+# Regression test for #9077
+#
+
+statement ok
+CREATE TABLE t1 (f1 INTEGER, f2 INTEGER);
+----
+
+statement ok
+----
+INSERT INTO t1 VALUES (1, 1), (2, 2), (4, 4);
+
+statement ok
+CREATE TABLE t2 (f1 INTEGER, f2 INTEGER);
+----
+
+statement ok
+INSERT INTO t2 VALUES (1, 1), (1, 2), (2, 2);
+----
+
+query I
+SELECT f1 FROM t1
+WHERE f1 IN (SELECT ROW_NUMBER() OVER () FROM t2);
+----
+1
+2
+
+query T multiline
+EXPLAIN DECORRELATED PLAN FOR SELECT f1 FROM t1
+WHERE f1 IN (SELECT ROW_NUMBER() OVER () FROM t2);
+----
+%0 = Let l0 =
+| Constant ()
+
+%1 =
+| Get materialize.public.t1 (u1)
+
+%2 = Let l1 =
+| Join %0 %1
+| | implementation = Unimplemented
+| Filter true
+
+%3 = Let l2 =
+| Get %2 (l1)
+| Distinct group=(#0)
+
+%4 =
+| Get materialize.public.t2 (u3)
+
+%5 = Let l3 =
+| Join %3 %4
+| | implementation = Unimplemented
+
+%6 = Let l4 =
+| Get %5 (l3)
+
+%7 =
+| Get %6 (l4)
+| Reduce group=(#0)
+| | agg row_number(record_create(list_create(record_create(#0, #1, #2))))
+| FlatMap unnest_list(#1)
+| Map record_get[0](record_get[1](#2))
+| Map record_get[1](record_get[1](#2))
+| Map record_get[2](record_get[1](#2))
+| Map record_get[0](#2)
+| Project (#3..#6)
+| Map #3
+| Project (#0..#2, #4)
+| Project (#0, #3)
+| Filter ((i32toi64(#0) = #1) && true)
+| Distinct group=(#0)
+
+%8 =
+| Constant (true)
+
+%9 = Let l5 =
+| Join %7 %8
+| | implementation = Unimplemented
+
+%10 =
+| Get %9 (l5)
+| Distinct group=(#0)
+| Negate
+
+%11 =
+| Get %3 (l2)
+| Distinct group=(#0)
+
+%12 =
+| Union %10 %11
+
+%13 =
+| Join %12 %3 (= #0 #1)
+| | implementation = Unimplemented
+| Project (#0)
+
+%14 =
+| Constant (false)
+
+%15 =
+| Join %13 %14
+| | implementation = Unimplemented
+
+%16 =
+| Union %9 %15
+
+%17 =
+| Join %2 %16 (= #0 #2)
+| | implementation = Unimplemented
+| Project (#0, #1, #3)
+| Filter #2
+| Project (#0, #1)
+| Project (#0)
+
+EOF
+
+query T multiline
+EXPLAIN SELECT f1 FROM t1
+WHERE f1 IN (SELECT ROW_NUMBER() OVER () FROM t2);
+----
+%0 = Let l0 =
+| Get materialize.public.t1 (u1)
+| Project (#0)
+
+%1 =
+| Get %0 (l0)
+| Distinct group=(#0)
+| ArrangeBy ()
+
+%2 =
+| Get materialize.public.t2 (u3)
+
+%3 =
+| Join %1 %2
+| | implementation = Differential %2 %1.()
+| Reduce group=(#0)
+| | agg row_number(record_create(list_create(record_create(#0, #1, #2))))
+| Project (#1)
+| FlatMap unnest_list(#0)
+| Filter (i32toi64(record_get[0](record_get[1](#1))) = record_get[0](#1))
+| Project (#1)
+| Distinct group=(record_get[0](record_get[1](#0)))
+| ArrangeBy (#0)
+
+%4 =
+| Join %0 %3 (= #0 #1)
+| | implementation = Differential %0 %3.(#0)
+| Project (#0)
+
+EOF
+
+query IIIII
+SELECT * FROM t1, LATERAL(SELECT t2.*, ROW_NUMBER() OVER() FROM t2 WHERE t1.f1 = t2.f1) AS foo;
+----
+1  1  1  1  1
+1  1  1  2  2
+2  2  2  2  1
+
+query IIIII
+SELECT * FROM t1, LATERAL(SELECT t2.*, ROW_NUMBER() OVER() FROM t2 WHERE t1.f1 = t2.f1 AND t1.f2 = t2.f2) AS foo;
+----
+1  1  1  1  1
+2  2  2  2  1
+
+query IIIII
+SELECT * FROM t1, LATERAL(SELECT t2.*, ROW_NUMBER() OVER() FROM t2 WHERE t1.f2 = t2.f2) AS foo;
+----
+1  1  1  1  1
+2  2  1  2  1
+2  2  2  2  2
+
+query IIIII
+SELECT * FROM t2, LATERAL(SELECT t1.*, ROW_NUMBER() OVER() FROM t1 WHERE t1.f1 = t2.f1) AS foo;
+----
+1  1  1  1  1
+1  2  1  1  1
+2  2  2  2  1
+
+query IIIII
+SELECT * FROM t2, LATERAL(SELECT t1.*, ROW_NUMBER() OVER() FROM t1 WHERE t1.f1 = t2.f1 AND t1.f2 = t2.f2) AS foo;
+----
+1  1  1  1  1
+2  2  2  2  1
+
+query IIIII
+SELECT * FROM t2, LATERAL(SELECT t1.*, ROW_NUMBER() OVER() FROM t1 WHERE t1.f2 = t2.f2) AS foo;
+----
+1  1  1  1  1
+1  2  2  2  1
+2  2  2  2  1
+
+# Check that the partition key comes after the outer columns in the grouping key
+
+query T multiline
+EXPLAIN DECORRELATED PLAN FOR SELECT * FROM t2, LATERAL(SELECT t1.*, ROW_NUMBER() OVER() FROM t1 WHERE t1.f2 = t2.f2) AS foo;
+----
+%0 = Let l0 =
+| Constant ()
+
+%1 =
+| Get materialize.public.t2 (u3)
+
+%2 = Let l1 =
+| Join %0 %1
+| | implementation = Unimplemented
+
+%3 = Let l2 =
+| Get %2 (l1)
+| Distinct group=(#1)
+
+%4 =
+| Get materialize.public.t1 (u1)
+
+%5 = Let l3 =
+| Join %3 %4
+| | implementation = Unimplemented
+| Filter (#2 = #0)
+
+%6 = Let l4 =
+| Get %5 (l3)
+
+%7 =
+| Get %6 (l4)
+| Reduce group=(#0)
+| | agg row_number(record_create(list_create(record_create(#0, #1, #2))))
+| FlatMap unnest_list(#1)
+| Map record_get[0](record_get[1](#2))
+| Map record_get[1](record_get[1](#2))
+| Map record_get[2](record_get[1](#2))
+| Map record_get[0](#2)
+| Project (#3..#6)
+| Map #3
+| Project (#0..#2, #4)
+
+%8 =
+| Join %2 %7 (= #1 #2)
+| | implementation = Unimplemented
+| Project (#0, #1, #3..#5)
+| Filter true
+
+EOF
+
+query T multiline
+EXPLAIN DECORRELATED PLAN FOR SELECT * FROM t2, LATERAL(SELECT t1.*, ROW_NUMBER() OVER(PARTITION BY f1) FROM t1 WHERE t1.f2 = t2.f2) AS foo;
+----
+%0 = Let l0 =
+| Constant ()
+
+%1 =
+| Get materialize.public.t2 (u3)
+
+%2 = Let l1 =
+| Join %0 %1
+| | implementation = Unimplemented
+
+%3 = Let l2 =
+| Get %2 (l1)
+| Distinct group=(#1)
+
+%4 =
+| Get materialize.public.t1 (u1)
+
+%5 = Let l3 =
+| Join %3 %4
+| | implementation = Unimplemented
+| Filter (#2 = #0)
+
+%6 = Let l4 =
+| Get %5 (l3)
+
+%7 =
+| Get %6 (l4)
+| Reduce group=(#0, #1)
+| | agg row_number(record_create(list_create(record_create(#0, #1, #2))))
+| FlatMap unnest_list(#2)
+| Map record_get[0](record_get[1](#3))
+| Map record_get[1](record_get[1](#3))
+| Map record_get[2](record_get[1](#3))
+| Map record_get[0](#3)
+| Project (#4..#7)
+| Map #3
+| Project (#0..#2, #4)
+
+%8 =
+| Join %2 %7 (= #1 #2)
+| | implementation = Unimplemented
+| Project (#0, #1, #3..#5)
+| Filter true
+
+EOF


### PR DESCRIPTION
<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug. [Link to issue.]

  * This PR adds a known-desirable feature. [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

Fixes #9077.

The reduction that computes the window function must be keyed on the columns from the outer context.

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
