### PR TITLE
reuse_topic: Create sink without timing out waiting for message

### DIFF
--- a/src/coord/src/sink_connector.rs
+++ b/src/coord/src/sink_connector.rs
@@ -466,7 +466,7 @@ async fn build_kafka(
 
             // get latest committed timestamp from consistency topic
             let gate_ts = if builder.reuse_topic {
-                get_latest_ts(&consistency_topic, config.clone(), Duration::from_secs(5))
+                get_latest_ts(&consistency_topic, config.clone(), Duration::from_secs(10))
                     .context("error restarting from existing kafka consistency topic for sink")?
             } else {
                 None

--- a/src/coord/src/sink_connector.rs
+++ b/src/coord/src/sink_connector.rs
@@ -120,7 +120,7 @@ fn get_latest_ts(
 
     let mut latest_ts = None;
     let mut latest_offset = None;
-    while let Some((message, offset)) = get_next_message(consumer, timeout)? {
+    while let Some((message, offset)) = get_next_message(consumer, Duration::ZERO)? {
         debug_assert!(offset >= latest_offset.unwrap_or(0));
         latest_offset = Some(offset);
 

--- a/src/coord/src/sink_connector.rs
+++ b/src/coord/src/sink_connector.rs
@@ -126,7 +126,7 @@ fn get_latest_ts(
             )
         })?;
 
-    // Empty topic
+    // Empty topic.  Return early to avoid unnecesasry call to kafka below.
     if hi == 0 {
         return Ok(None);
     }
@@ -144,9 +144,10 @@ fn get_latest_ts(
         }
     }
 
-    // Topic not empty but we couldn't read any messages
+    // Topic not empty but we couldn't read any messages.  We don't expect this to happen but we
+    // have no reason to rely on kafka not inserting any internal messages at the beginning.
     if latest_offset.is_none() {
-        bail!(
+        log::debug!(
             "unable to read any messages from non-empty topic {}:{}, lo/hi: {}/{}",
             consistency_topic,
             partition,

--- a/src/coord/src/sink_connector.rs
+++ b/src/coord/src/sink_connector.rs
@@ -103,7 +103,7 @@ fn get_latest_ts(
         )
     })?;
 
-    let (hi, lo) = consumer
+    let (lo, hi) = consumer
         .fetch_watermarks(consistency_topic, 0, timeout)
         .map_err(|e| {
             anyhow!(
@@ -111,7 +111,6 @@ fn get_latest_ts(
                 e
             )
         })?;
-    let hi: u64 = hi.try_into()?;
 
     // Empty topic
     if hi == 0 {
@@ -127,11 +126,11 @@ fn get_latest_ts(
         if let Some(ts) = maybe_decode_consistency_end_record(&message, consistency_topic)? {
             debug_assert!(ts >= latest_ts.unwrap_or(0));
             latest_ts = Some(ts);
+        }
 
-            // Short circuit to avoids a delay with length `timeout`
-            if ts >= hi {
-                break;
-            }
+        // Short circuit to avoids a delay with length `timeout`
+        if offset >= hi {
+            break;
         }
     }
 


### PR DESCRIPTION
Before this change, we know we've reached the end of the topic by `get_next_message` timing out.  This means it takes a duration of at least `timeout` to create or bootstrap a reuse_topic sink.  Now we look up the offset before reading all the messages and short circuiting when seeing the `hi` watermark.

With this change, the only time we hit the timeout is when the `hi` watermark does not match a message in the kafka topic.

We can see the impact in just the `kafka-exactly-once` testdrive:
```
$ time cargo run --bin testdrive -- test/testdrive/kafka-exactly_once.td
[...]
testdrive completed successfully.

real    0m20.917s
user    0m0.613s
sys     0m0.268s
$ git checkout main
$ time cargo run --bin testdrive -- test/testdrive/kafka-exactly_once.td
[...]
testdrive completed successfully.

real    1m26.748s
user    0m0.625s
sys     0m0.319s
```

### Motivation
https://github.com/MaterializeInc/materialize/issues/8544

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
