### PR TITLE
Absorb (some) permutations into MFPs

### DIFF
--- a/src/dataflow/src/render/context.rs
+++ b/src/dataflow/src/render/context.rs
@@ -542,12 +542,8 @@ where
                 let mut row_builder = Row::default();
                 let mut datum_vec = DatumVec::new();
 
-                if let Some(Permutation {
-                    key_arity: _,
-                    permutation,
-                }) = permutation
-                {
-                    mfp_plan.permute(&permutation);
+                if let Some(permutation) = &permutation {
+                    permutation.permute_mfp_plan(&mut mfp_plan);
                 }
                 move |row_parts, time, diff| {
                     let temp_storage = RowArena::new();

--- a/src/dataflow/src/render/join/linear_join.rs
+++ b/src/dataflow/src/render/join/linear_join.rs
@@ -409,7 +409,7 @@ where
         &mut self,
         prev_keyed: J,
         next_input: Arranged<G, Tr2>,
-        closure: JoinClosure,
+        mut closure: JoinClosure,
         prev_permutation: Permutation,
         next_permutation: Permutation,
     ) -> (Collection<G, Row>, Collection<G, DataflowError>)
@@ -429,11 +429,11 @@ where
         let mut row_builder = Row::default();
         let permutation = prev_permutation.join(&next_permutation);
 
+        closure.permute(&permutation);
         let (oks, err) = prev_keyed
             .join_core(&next_input, move |key, old, new| {
                 let temp_storage = RowArena::new();
                 let mut datums_local = datums.borrow_with_many(&[key, old, new]);
-                permutation.permute_in_place(&mut datums_local);
                 closure
                     .apply(&mut datums_local, &temp_storage, &mut row_builder)
                     .map_err(DataflowError::from)

--- a/src/dataflow/src/render/join/mod.rs
+++ b/src/dataflow/src/render/join/mod.rs
@@ -40,6 +40,8 @@ use repr::{Datum, Row, RowArena};
 pub use delta_join::DeltaJoinPlan;
 pub use linear_join::LinearJoinPlan;
 
+use super::Permutation;
+
 /// A complete enumeration of possible join plans to render.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum JoinPlan {
@@ -60,6 +62,14 @@ struct JoinClosure {
 }
 
 impl JoinClosure {
+    pub fn permute(&mut self, p: &Permutation) {
+        p.permute_safe_mfp_plan(&mut self.before);
+        for key in &mut self.ready_equivalences {
+            for expr in key {
+                expr.permute(&p.permutation);
+            }
+        }
+    }
     /// Applies per-row filtering and logic.
     #[inline(always)]
     fn apply<'a>(

--- a/src/dataflow/src/render/join/mod.rs
+++ b/src/dataflow/src/render/join/mod.rs
@@ -62,6 +62,8 @@ struct JoinClosure {
 }
 
 impl JoinClosure {
+    /// Prepares this join closure to act on a permuted input,
+    /// according to the permutation `p`.
     pub fn permute(&mut self, p: &Permutation) {
         p.permute_safe_mfp_plan(&mut self.before);
         for key in &mut self.ready_equivalences {

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -116,7 +116,10 @@ use timely::progress::Antichain;
 use timely::worker::Worker as TimelyWorker;
 
 use dataflow_types::*;
-use expr::{GlobalId, Id, MapFilterProject, MfpPlan, MirScalarExpr, SafeMfpPlan};
+use expr::{
+    permutation_to_map_and_new_arity, GlobalId, Id, MapFilterProject, MfpPlan, MirScalarExpr,
+    SafeMfpPlan,
+};
 use itertools::Itertools;
 use ore::collections::CollectionExt as _;
 use ore::now::NowFn;
@@ -1517,20 +1520,8 @@ impl Permutation {
         self.permutation.len()
     }
 
-    pub fn as_map_and_new_arity(&self) -> (HashMap<usize, usize>, usize) {
-        (
-            self.permutation.iter().cloned().enumerate().collect(),
-            self.permutation
-                .iter()
-                .cloned()
-                .max()
-                .map(|x| x + 1)
-                .unwrap_or(0),
-        )
-    }
-
     pub fn permute_mfp(&self, mfp: &mut MapFilterProject) {
-        let (map, new_arity) = self.as_map_and_new_arity();
+        let (map, new_arity) = permutation_to_map_and_new_arity(&self.permutation);
         mfp.permute(map, new_arity);
     }
 
@@ -1539,7 +1530,7 @@ impl Permutation {
     }
 
     pub fn permute_safe_mfp_plan(&self, mfp: &mut SafeMfpPlan) {
-        let (map, new_arity) = self.as_map_and_new_arity();
+        let (map, new_arity) = permutation_to_map_and_new_arity(&self.permutation);
         SafeMfpPlan::permute(mfp, map, new_arity);
     }
 }

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -1535,6 +1535,6 @@ impl Permutation {
 
     pub fn permute_safe_mfp_plan(&self, mfp: &mut SafeMfpPlan) {
         let (map, new_arity) = self.as_map_and_new_arity();
-	SafeMfpPlan::permute(mfp, map, new_arity);
+        SafeMfpPlan::permute(mfp, map, new_arity);
     }
 }

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -1520,15 +1520,21 @@ impl Permutation {
         self.permutation.len()
     }
 
+    /// Prepares the MFP `mfp` to act on permuted input, according
+    /// to this permutation
     pub fn permute_mfp(&self, mfp: &mut MapFilterProject) {
         let (map, new_arity) = permutation_to_map_and_new_arity(&self.permutation);
         mfp.permute(map, new_arity);
     }
 
+    /// Prepares the MfpPlan `mfp` to act on permuted input, according
+    /// to this permutation
     pub fn permute_mfp_plan(&self, mfp: &mut MfpPlan) {
         mfp.permute(&self.permutation);
     }
 
+    /// Prepares the SafeMfpPlan `mfp` to act on permuted input, according
+    /// to this permutation
     pub fn permute_safe_mfp_plan(&self, mfp: &mut SafeMfpPlan) {
         let (map, new_arity) = permutation_to_map_and_new_arity(&self.permutation);
         SafeMfpPlan::permute(mfp, map, new_arity);

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -1520,7 +1520,12 @@ impl Permutation {
     pub fn as_map_and_new_arity(&self) -> (HashMap<usize, usize>, usize) {
         (
             self.permutation.iter().cloned().enumerate().collect(),
-            self.permutation.iter().cloned().max().unwrap_or(0) + 1,
+            self.permutation
+                .iter()
+                .cloned()
+                .max()
+                .map(|x| x + 1)
+                .unwrap_or(0),
         )
     }
 

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -116,7 +116,7 @@ use timely::progress::Antichain;
 use timely::worker::Worker as TimelyWorker;
 
 use dataflow_types::*;
-use expr::{GlobalId, Id, MirScalarExpr};
+use expr::{GlobalId, Id, MapFilterProject, MfpPlan, MirScalarExpr, SafeMfpPlan};
 use itertools::Itertools;
 use ore::collections::CollectionExt as _;
 use ore::now::NowFn;
@@ -1515,5 +1515,26 @@ impl Permutation {
     /// The arity of the permutation
     pub fn arity(&self) -> usize {
         self.permutation.len()
+    }
+
+    pub fn as_map_and_new_arity(&self) -> (HashMap<usize, usize>, usize) {
+        (
+            self.permutation.iter().cloned().enumerate().collect(),
+            self.permutation.iter().cloned().max().unwrap_or(0) + 1,
+        )
+    }
+
+    pub fn permute_mfp(&self, mfp: &mut MapFilterProject) {
+        let (map, new_arity) = self.as_map_and_new_arity();
+        mfp.permute(map, new_arity);
+    }
+
+    pub fn permute_mfp_plan(&self, mfp: &mut MfpPlan) {
+        mfp.permute(&self.permutation);
+    }
+
+    pub fn permute_safe_mfp_plan(&self, mfp: &mut SafeMfpPlan) {
+        let (map, new_arity) = self.as_map_and_new_arity();
+	SafeMfpPlan::permute(mfp, map, new_arity);
     }
 }

--- a/src/dataflow/src/render/reduce.rs
+++ b/src/dataflow/src/render/reduce.rs
@@ -61,7 +61,6 @@
 //! return the output arrangement directly and avoid the extra collation arrangement.
 
 use std::collections::BTreeMap;
-use std::collections::HashSet;
 
 use differential_dataflow::collection::AsCollection;
 use differential_dataflow::difference::Multiply;

--- a/src/dataflow/src/render/reduce.rs
+++ b/src/dataflow/src/render/reduce.rs
@@ -61,6 +61,7 @@
 //! return the output arrangement directly and avoid the extra collation arrangement.
 
 use std::collections::BTreeMap;
+use std::collections::HashSet;
 
 use differential_dataflow::collection::AsCollection;
 use differential_dataflow::difference::Multiply;
@@ -608,8 +609,6 @@ pub struct KeyValPlan {
     key_plan: expr::SafeMfpPlan,
     /// Extracts the columns used to feed the aggregations.
     val_plan: expr::SafeMfpPlan,
-    /// Steps to take over the columns of the input row.
-    skips: Vec<usize>,
 }
 
 impl KeyValPlan {
@@ -628,31 +627,14 @@ impl KeyValPlan {
             .map(aggregates.iter().map(|a| a.expr.clone()))
             .project(input_arity..(input_arity + aggregates.len()));
 
-        // Determine the columns we'll need from the row.
-        let mut demand = Vec::new();
-        demand.extend(key_mfp.demand());
-        demand.extend(val_mfp.demand());
-        demand.sort();
-        demand.dedup();
-        // remap column references to the subset we use.
-        let mut demand_map = std::collections::HashMap::new();
-        for column in demand.iter() {
-            demand_map.insert(*column, demand_map.len());
-        }
-        key_mfp.permute(demand_map.clone(), demand_map.len());
         key_mfp.optimize();
         let key_plan = key_mfp.into_plan().unwrap().into_nontemporal().unwrap();
-        let demand_map_len = demand_map.len();
-        val_mfp.permute(demand_map, demand_map_len);
         val_mfp.optimize();
         let val_plan = val_mfp.into_plan().unwrap().into_nontemporal().unwrap();
-
-        let skips = convert_indexes_to_skips(demand);
 
         Self {
             key_plan,
             val_plan,
-            skips,
         }
     }
 
@@ -678,9 +660,8 @@ where
         permutation: Permutation,
     ) -> CollectionBundle<G, Row, T> {
         let KeyValPlan {
-            key_plan,
-            val_plan,
-            skips,
+            mut key_plan,
+            mut val_plan,
         } = key_val_plan;
         let key_arity = key_plan.projection.len();
         let mut row_packer = Row::default();
@@ -691,13 +672,29 @@ where
             timely::dataflow::Stream<_, (Result<(Row, Row), DataflowError>, _, _)>,
             _,
         ) = input.flat_map(None, |permutation| {
+	    if let Some(permutation) = permutation {
+		permutation.permute_safe_mfp_plan(&mut key_plan);
+		permutation.permute_safe_mfp_plan(&mut val_plan);
+	    }
+	    // Determine the columns we'll need from the row.
+            let mut demand = Vec::new();
+            demand.extend(key_plan.demand());
+            demand.extend(val_plan.demand());
+            demand.sort();
+            demand.dedup();
+            // remap column references to the subset we use.
+            let mut demand_map = std::collections::HashMap::new();
+            for column in demand.iter() {
+		demand_map.insert(*column, demand_map.len());
+            }
+	    let demand_map_len = demand_map.len();
+            key_plan.permute(demand_map.clone(), demand_map_len);
+	    val_plan.permute(demand_map, demand_map_len);
+	    let skips = convert_indexes_to_skips(demand);
             move |row_parts, time, diff| {
                 let temp_storage = RowArena::new();
 
                 let mut row_datums = row_datums.borrow_with_many(row_parts);
-                if let Some(permutation) = &permutation {
-                    permutation.permute_in_place(&mut row_datums);
-                }
 
                 let mut row_iter = row_datums.drain(..);
                 let mut datums_local = datums.borrow();

--- a/src/dataflow/src/render/reduce.rs
+++ b/src/dataflow/src/render/reduce.rs
@@ -631,10 +631,7 @@ impl KeyValPlan {
         val_mfp.optimize();
         let val_plan = val_mfp.into_plan().unwrap().into_nontemporal().unwrap();
 
-        Self {
-            key_plan,
-            val_plan,
-        }
+        Self { key_plan, val_plan }
     }
 
     /// The arity of the key plan
@@ -671,11 +668,11 @@ where
             timely::dataflow::Stream<_, (Result<(Row, Row), DataflowError>, _, _)>,
             _,
         ) = input.flat_map(None, |permutation| {
-	    if let Some(permutation) = permutation {
-		permutation.permute_safe_mfp_plan(&mut key_plan);
-		permutation.permute_safe_mfp_plan(&mut val_plan);
-	    }
-	    // Determine the columns we'll need from the row.
+            if let Some(permutation) = permutation {
+                permutation.permute_safe_mfp_plan(&mut key_plan);
+                permutation.permute_safe_mfp_plan(&mut val_plan);
+            }
+            // Determine the columns we'll need from the row.
             let mut demand = Vec::new();
             demand.extend(key_plan.demand());
             demand.extend(val_plan.demand());
@@ -684,12 +681,12 @@ where
             // remap column references to the subset we use.
             let mut demand_map = std::collections::HashMap::new();
             for column in demand.iter() {
-		demand_map.insert(*column, demand_map.len());
+                demand_map.insert(*column, demand_map.len());
             }
-	    let demand_map_len = demand_map.len();
+            let demand_map_len = demand_map.len();
             key_plan.permute(demand_map.clone(), demand_map_len);
-	    val_plan.permute(demand_map, demand_map_len);
-	    let skips = convert_indexes_to_skips(demand);
+            val_plan.permute(demand_map, demand_map_len);
+            let skips = convert_indexes_to_skips(demand);
             move |row_parts, time, diff| {
                 let temp_storage = RowArena::new();
 

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -1017,10 +1017,11 @@ where
                 timestamp,
                 conn_id,
                 finishing,
-                map_filter_project,
+                mut map_filter_project,
             } => {
                 // Acquire a copy of the trace suitable for fulfilling the peek.
                 let mut trace_bundle = self.render_state.traces.get(&id).unwrap().clone();
+		trace_bundle.permutation().permute_safe_mfp_plan(&mut map_filter_project);
                 let timestamp_frontier = Antichain::from_elem(timestamp);
                 let empty_frontier = Antichain::new();
                 trace_bundle
@@ -1443,9 +1444,6 @@ impl PendingPeek {
                 // for the arena above (the allocation would not be allowed
                 // to outlive the arena above, from which it might borrow).
                 let mut borrow = datum_vec.borrow_with_many(&[key, row]);
-                self.trace_bundle
-                    .permutation()
-                    .permute_in_place(&mut borrow);
                 if let Some(result) = self
                     .map_filter_project
                     .evaluate_into(&mut borrow, &arena, &mut row_builder)

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -1021,7 +1021,9 @@ where
             } => {
                 // Acquire a copy of the trace suitable for fulfilling the peek.
                 let mut trace_bundle = self.render_state.traces.get(&id).unwrap().clone();
-		trace_bundle.permutation().permute_safe_mfp_plan(&mut map_filter_project);
+                trace_bundle
+                    .permutation()
+                    .permute_safe_mfp_plan(&mut map_filter_project);
                 let timestamp_frontier = Antichain::from_elem(timestamp);
                 let empty_frontier = Antichain::new();
                 trace_bundle

--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -31,6 +31,7 @@ pub use id::{GlobalId, Id, LocalId, PartitionId, SourceInstanceId};
 pub use linear::{
     memoize_expr,
     plan::{MfpPlan, SafeMfpPlan},
+    util::permutation_to_map_and_new_arity,
     MapFilterProject,
 };
 pub use relation::func::{AggregateFunc, TableFunc};

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -1279,9 +1279,9 @@ pub mod plan {
     }
 
     impl MfpPlan {
-	/// Prepares `self` to act on permuted input, according to the permutation array
-	/// `permutation` (see for example the documentation on `util::permutation_to_map_and_new_arity`
-	/// for a description of the input).
+        /// Prepares `self` to act on permuted input, according to the permutation array
+        /// `permutation` (see for example the documentation on `util::permutation_to_map_and_new_arity`
+        /// for a description of the input).
         pub fn permute(&mut self, permutation: &[usize]) {
             let (map, new_arity) = permutation_to_map_and_new_arity(permutation);
             self.mfp.mfp.permute(map, new_arity);

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -1136,7 +1136,7 @@ pub mod util {
 
     /// Takes a permutation represented as an array
     /// (where the `i`th column being `j` implies that column `i` in the original row
-    ///  corresponds to column `j` in the permuted row; see `dataflow::render::Permutation`
+    ///  corresponds to column `j` in the permuted row; see `dataflow::render::Permutation`)
     /// and converts it to a column map along with the arity of the permuted representation
     pub fn permutation_to_map_and_new_arity(
         permutation: &[usize],

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -1132,6 +1132,8 @@ pub fn memoize_expr(
 }
 
 pub mod util {
+    use std::collections::HashMap;
+
     /// Takes a permutation represented as an array
     /// (where the `i`th column being `j` implies that column `i` in the original row
     ///  corresponds to column `j` in the permuted row; see `dataflow::render::Permutation`

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -1258,7 +1258,12 @@ pub mod plan {
         pub fn permute(&mut self, permutation: &[usize]) {
             self.mfp.mfp.permute(
                 permutation.iter().cloned().enumerate().collect(),
-                permutation.iter().cloned().max().unwrap_or(0) + 1,
+                permutation
+                    .iter()
+                    .cloned()
+                    .max()
+                    .map(|x| x + 1)
+                    .unwrap_or(0),
             );
             for lb in &mut self.lower_bounds {
                 lb.permute(permutation);

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -1279,6 +1279,9 @@ pub mod plan {
     }
 
     impl MfpPlan {
+	/// Prepares `self` to act on permuted input, according to the permutation array
+	/// `permutation` (see for example the documentation on `util::permutation_to_map_and_new_arity`
+	/// for a description of the input).
         pub fn permute(&mut self, permutation: &[usize]) {
             let (map, new_arity) = permutation_to_map_and_new_arity(permutation);
             self.mfp.mfp.permute(map, new_arity);


### PR DESCRIPTION
Partially fixes https://github.com/MaterializeInc/materialize/issues/8932 by absorbing permutations into nearby MFP plans during rendering.

Necessary follow-up work: understand the remaining cases where permutations are used, especially when they don't have a nearby MFP (notably: through uses of `CollectionBundle::as_collection`

Possibly useful follow-up work: investigate moving MFP permutation into planning, to avoid having to reach into MFP internals during rendering.