### PR TITLE
sql: support table/set functions in select projections

### DIFF
--- a/src/sql/src/plan/transform_ast.rs
+++ b/src/sql/src/plan/transform_ast.rs
@@ -22,6 +22,7 @@ use sql_parser::ast::{
     TableFactor, TableWithJoins, UnresolvedObjectName, Value,
 };
 
+use crate::func::Func;
 use crate::normalize;
 use crate::plan::StatementContext;
 
@@ -48,7 +49,7 @@ where
     f(&mut func_rewriter, ast);
     func_rewriter.status?;
 
-    let mut desugarer = Desugarer::new();
+    let mut desugarer = Desugarer::new(scx);
     f(&mut desugarer, ast);
     desugarer.status
 }
@@ -295,21 +296,101 @@ impl<'ast> VisitMut<'ast, Raw> for FuncRewriter<'_> {
 ///
 /// For example, `<expr> NOT IN (<subquery>)` is rewritten to `expr <> ALL
 /// (<subquery>)`.
-struct Desugarer {
+struct Desugarer<'a> {
+    scx: &'a StatementContext<'a>,
     status: Result<(), anyhow::Error>,
 }
 
-impl<'ast> VisitMut<'ast, Raw> for Desugarer {
+impl<'ast> VisitMut<'ast, Raw> for Desugarer<'_> {
     fn visit_expr_mut(&mut self, expr: &'ast mut Expr<Raw>) {
-        if self.status.is_ok() {
-            self.status = self.visit_expr_mut_internal(expr);
-        }
+        self.visit_internal(Self::visit_expr_mut_internal, expr);
+    }
+
+    fn visit_select_mut(&mut self, node: &'ast mut Select<Raw>) {
+        self.visit_internal(Self::visit_select_mut_internal, node);
     }
 }
 
-impl Desugarer {
-    fn new() -> Desugarer {
-        Desugarer { status: Ok(()) }
+impl<'a> Desugarer<'a> {
+    fn visit_internal<F, X>(&mut self, f: F, x: X)
+    where
+        F: Fn(&mut Self, X) -> Result<(), anyhow::Error>,
+    {
+        if self.status.is_ok() {
+            // self.status could have changed from a deeper call, so don't blindly
+            // overwrite it with the result of this call.
+            let status = f(self, x);
+            if self.status.is_ok() {
+                self.status = status;
+            }
+        }
+    }
+
+    fn new(scx: &'a StatementContext<'a>) -> Desugarer {
+        Desugarer {
+            scx,
+            status: Ok(()),
+        }
+    }
+
+    fn visit_select_mut_internal(&mut self, node: &mut Select<Raw>) -> Result<(), anyhow::Error> {
+        // `SELECT .., $table_func, .. FROM x`
+        // =>
+        // `SELECT .., table_func, .. FROM x, LATERAL $table_func`
+        //
+        // We do not support LATERAL ROWS FROM, so we can only support a single select
+        // item. Additionally, we do not attempt to identify table functions wrapped by
+        // other functions.
+        //
+        // See: https://www.postgresql.org/docs/14/xfunc-sql.html#XFUNC-SQL-FUNCTIONS-RETURNING-SET
+        // See: https://www.postgresql.org/docs/14/queries-table-expressions.html#QUERIES-FROM
+        let mut rewrote_table_func = false;
+        for sel_item in node.projection.iter_mut() {
+            let (func, alias) = match sel_item {
+                SelectItem::Expr {
+                    expr: Expr::Function(func),
+                    alias,
+                } => (func, alias),
+                _ => {
+                    continue;
+                }
+            };
+            let item = match self.scx.resolve_function(func.name.clone()) {
+                Ok(item) => item,
+                Err(_) => continue,
+            };
+            if !matches!(item.func()?, Func::Set(_) | Func::Table(_)) {
+                continue;
+            }
+            if rewrote_table_func {
+                bail_unsupported!("multiple table functions in select projections");
+            }
+            let name = Ident::new(item.name().item.clone());
+            // We have a table func in a select item's position, move it to FROM.
+            node.from.push(TableWithJoins {
+                relation: TableFactor::Function {
+                    name: func.name.clone(),
+                    args: func.args.clone(),
+                    alias: Some(TableAlias {
+                        name: name.clone(),
+                        columns: vec![],
+                        strict: false,
+                    }),
+                },
+                joins: vec![],
+            });
+            *sel_item = SelectItem::Expr {
+                expr: Expr::Identifier(vec![name]),
+                alias: alias.clone(),
+            };
+
+            // We don't support LATERAL ROWS FROM (#9076), so can only support a single
+            // table function.
+            rewrote_table_func = true;
+        }
+
+        visit_mut::visit_select_mut(self, node);
+        Ok(())
     }
 
     fn visit_expr_mut_internal(&mut self, expr: &mut Expr<Raw>) -> Result<(), anyhow::Error> {

--- a/test/sqllogictest/cockroach/subquery_correlated.slt
+++ b/test/sqllogictest/cockroach/subquery_correlated.slt
@@ -367,9 +367,19 @@ WHERE EXISTS
 2  TX
 4  TX
 
-# #1546
-statement error supported
+query II rowsort
 SELECT c_id, generate_series(1, (SELECT count(*) FROM o WHERE o.c_id=c.c_id)) FROM c
+----
+1  1
+1  2
+1  3
+2  1
+2  2
+2  3
+4  1
+4  2
+6  1
+
 
 # Customers that have no orders with a NULL ship state.
 # Note: Result differs from Cockroach but matches Postgres.

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -459,13 +459,13 @@ EOF
 
 # information_schema._pg_expandarray
 
-query error scalar position not yet supported
+query error arguments cannot be implicitly cast
 SELECT information_schema._pg_expandarray()
 
 query error arguments cannot be implicitly cast
 SELECT * FROM information_schema._pg_expandarray()
 
-query error scalar position not yet supported
+query error cannot determine type of empty array
 SELECT information_schema._pg_expandarray(ARRAY[])
 
 query error cannot determine type of empty array
@@ -474,10 +474,10 @@ SELECT * FROM information_schema._pg_expandarray(ARRAY[])
 query error arguments cannot be implicitly cast
 SELECT * FROM information_schema._pg_expandarray(NULL)
 
-query error scalar position not yet supported
+query error arguments cannot be implicitly cast
 SELECT information_schema._pg_expandarray(NULL)
 
-query error scalar position not yet supported
+query T colnames
 SELECT information_schema._pg_expandarray(ARRAY[]::int[])
 ----
 _pg_expandarray
@@ -487,16 +487,22 @@ SELECT * FROM information_schema._pg_expandarray(ARRAY[]::int[])
 ----
 x  n
 
-query error scalar position not yet supported
+query T colnames
 SELECT information_schema._pg_expandarray(ARRAY[100])
+----
+ _pg_expandarray
+(100,1)
 
 query TI
 SELECT * FROM information_schema._pg_expandarray(ARRAY[100])
 ----
 100 1
 
-query error scalar position not yet supported
+query T
 SELECT information_schema._pg_expandarray(ARRAY[2, 1]) ORDER BY 1
+----
+(1,2)
+(2,1)
 
 query II
 SELECT * FROM information_schema._pg_expandarray(ARRAY[2, 1]) ORDER BY x
@@ -504,8 +510,12 @@ SELECT * FROM information_schema._pg_expandarray(ARRAY[2, 1]) ORDER BY x
 1 2
 2 1
 
-query error scalar position not yet supported
-SELECT information_schema._pg_expandarray(ARRAY[3, 2, 1])
+query T
+SELECT information_schema._pg_expandarray(ARRAY[3, 2, 1]) ORDER BY 1
+----
+(1,3)
+(2,2)
+(3,1)
 
 query II
 SELECT * FROM information_schema._pg_expandarray(ARRAY[3, 2, 1]) ORDER BY x
@@ -514,16 +524,21 @@ SELECT * FROM information_schema._pg_expandarray(ARRAY[3, 2, 1]) ORDER BY x
 2 2
 3 1
 
-query error scalar position not yet supported
+query T
 SELECT information_schema._pg_expandarray(ARRAY['a'])
+----
+(a,1)
 
 query TI
 SELECT * FROM information_schema._pg_expandarray(ARRAY['a'])
 ----
 a 1
 
-query error scalar position not yet supported
-SELECT information_schema._pg_expandarray(ARRAY['b', 'a'])
+query T
+SELECT information_schema._pg_expandarray(ARRAY['b', 'a']) ORDER BY 1
+----
+(a,2)
+(b,1)
 
 query TI
 SELECT * FROM information_schema._pg_expandarray(ARRAY['b', 'a']) ORDER BY x
@@ -531,8 +546,12 @@ SELECT * FROM information_schema._pg_expandarray(ARRAY['b', 'a']) ORDER BY x
 a 2
 b 1
 
-query error scalar position not yet supported
-SELECT information_schema._pg_expandarray(ARRAY['c', 'b', 'a'])
+query T
+SELECT information_schema._pg_expandarray(ARRAY['c', 'b', 'a']) ORDER BY 1
+----
+(a,3)
+(b,2)
+(c,1)
 
 query TI
 SELECT * FROM information_schema._pg_expandarray(ARRAY['c', 'b', 'a']) ORDER BY x
@@ -635,6 +654,12 @@ SELECT g.* FROM information_schema._pg_expandarray(ARRAY[100]) AS g
 ----
 100 1
 
+query T colnames
+SELECT information_schema._pg_expandarray(ARRAY['a']) AS x
+----
+x
+(a,1)
+
 # Test aliasing table functions and using named columns of the results.
 
 query T rowsort
@@ -650,3 +675,62 @@ SELECT js.value->>'a' FROM jsonb_array_elements('[{"a":1},{"a":2},{"a":3}]') js
 1
 2
 3
+
+# Test more table/set functions in select projections.
+
+statement ok
+CREATE TABLE t (i int)
+
+statement ok
+INSERT INTO t VALUES (1), (2)
+
+query II colnames
+SELECT t.i, g.g FROM t, LATERAL generate_series(3,4) g(g) ORDER BY i, g
+----
+i g
+1 3
+1 4
+2 3
+2 4
+
+# This should be identical to the above.
+query II colnames
+SELECT t.i, generate_series(3,4) g FROM t ORDER BY i, g
+----
+i g
+1 3
+1 4
+2 3
+2 4
+
+query T colnames
+SELECT jsonb_each('{"3":4,"1":2}'::JSONB) ORDER BY 1
+----
+jsonb_each
+(1,2)
+(3,4)
+
+query error multiple table functions in select projections not yet supported
+SELECT 1, jsonb_object_keys('{"1":2,"3":4}'::JSONB), jsonb_object_keys('{"1":2,"3":4,"5":6}'::JSONB) ORDER BY 1
+
+query error table function .* in scalar position not yet supported
+SELECT jsonb_build_object(jsonb_object_keys('{"a":2, "b":3}'), 1, 'c', 3) ORDER BY 1
+
+query error table function .* in scalar position not yet supported
+SELECT jsonb_build_object(jsonb_object_keys('{"a":2, "b":3}'), 1, 'c', 3), jsonb_build_object(jsonb_object_keys('{"a":2, "b":3}'), 1, 'c', 3) ORDER BY 1
+
+query error table function .* in scalar position not yet supported
+SELECT jsonb_build_object(jsonb_object_keys('{"a":2, "b":3}'), 1, 'c', 3), jsonb_build_object(jsonb_object_keys('{"a":2}'), 1, 'c', 3);
+
+query error multiple table functions in select projections not yet supported
+SELECT jsonb_array_elements(jsonb_array_elements('[[1,2],[3,4]]')), jsonb_array_elements(jsonb_array_elements('[[1],[3,4,5]]')) ORDER BY 1
+
+query error multiple table functions in select projections not yet supported
+SELECT jsonb_array_elements(jsonb_array_elements('[[1,2],[3,4]]')), jsonb_array_elements('[7,8,9]') ORDER BY 1
+
+# Postgres explicitly disallows this use case.
+query error table function .* in scalar position not yet supported
+SELECT i, CASE WHEN i > 0 THEN generate_series(1, 5) ELSE 0 END FROM t
+
+query error multiple table functions in select projections not yet supported
+SELECT generate_series(1,2), generate_series(1,2)


### PR DESCRIPTION
Implement as an AST transform, moving the function call into a FROM
clause. We currently support only a single, top-level call.

### Motivation

  * This PR adds a known-desirable feature. #1546

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
