### PR TITLE
Update docs navbar to match main site

### DIFF
--- a/doc/user/assets/sass/_layout.scss
+++ b/doc/user/assets/sass/_layout.scss
@@ -256,7 +256,7 @@ header {
   background: $darkest-purple-v2;
   color: $white-v2;
   font-weight: 600;
-  font-size: 12px;
+  font-size: 14px;
   height: 71px;
   line-height: 21px;
 
@@ -304,7 +304,7 @@ header {
       border-radius:4px;
       color:#fff;
       cursor:pointer;
-      font-size:12px;
+      font-size:14px;
       font-weight:700;
       padding:.8rem 2rem;
       text-align:center;

--- a/doc/user/assets/sass/_layout.scss
+++ b/doc/user/assets/sass/_layout.scss
@@ -234,7 +234,7 @@ body {
   color: $grey-dark;
   font-size: 14px;
   margin: 50px 0 10px;
-  text-align: center;
+  text-align: left;
 }
 
 header {
@@ -256,7 +256,7 @@ header {
   background: $darkest-purple-v2;
   color: $white-v2;
   font-weight: 600;
-  font-size: 14px;
+  font-size: 12px;
   height: 71px;
   line-height: 21px;
 
@@ -297,18 +297,42 @@ header {
   }
 
   .btn {
-    background: $medium-purple-v2;
-    padding: 0.625rem 1.625rem;
-    margin: 0rem;
-    font-weight: 700;
-    font-size: 14px;
-    line-height: 17px;
-    transition: background 350ms ease;
+    display:
+      inline-block;
+      position:relative;
+      overflow:hidden;
+      border-radius:4px;
+      color:#fff;
+      cursor:pointer;
+      font-size:12px;
+      font-weight:700;
+      padding:.8rem 2rem;
+      text-align:center;
+      z-index:1;
+      -webkit-user-select:none;
+      -ms-user-select:none;
+      user-select:none;
+      background:#000;
+      text-decoration:none;
+      background-image:linear-gradient(110deg, #5a34cb -.7%, #9b34cb 33.33%, #be41f9 66.66%, #7f4eff 99.48%);
+      background-position:0% 100%;
+      background-size:200% 300%;
+      transition:background-position 0.3s ease-out
+    }
 
     &:hover {
-        background: $purple-v2;
+        background-position:100% 100%;
+        text-decoration:none
+      }
+
+    &:featured {
+        background-size: 200% 200%;
+        background-image:linear-gradient(300deg, #c13aff 0%, #7e52ff 31.36%, #5c29f1 43.94%, #e37ac2 76.56%, #ff9067 85.53%);
+        transition:all 0.2s ease-out}
+
+    &:featured:hover {
+      color:#fff
     }
-  }
 
   .secondary {
     opacity: 0.5;

--- a/doc/user/content/_index.md
+++ b/doc/user/content/_index.md
@@ -51,6 +51,7 @@ accepts input data from a variety of streaming sources (like Kafka), data stores
 ## Learn more
 
 - [**Install Materialize**](./install) to try it out or try [Materialize Cloud](/cloud/) for free.
+- [**Check out the Materialize blog**](https://www.materialize.com/blog/) for neat things our developers wrote.
 - [**What is Materialize?**](./overview/what-is-materialize) to learn
 more about what Materialize does and how it works.
 - [**Architecture documentation**](./overview/architecture) for a deeper dive into the `materialized` binary's components and deployment.

--- a/doc/user/layouts/partials/header.html
+++ b/doc/user/layouts/partials/header.html
@@ -15,12 +15,12 @@
     <div class="flex_grow text_center">
       <a role="menuitem" class="active" href="https://materialize.com/docs/">Docs</a>
       <a role="menuitem" class="hoverable" href="https://materialize.com/product/">Product</a>
-      <a role="menuitem" class="hoverable" href="https://materialize.com/use-cases/">Use Cases</a>
-      <a role="menuitem" class="hoverable" href="https://materialize.com/blog/">Blog</a>
+      <a role="menuitem" class="hoverable" href="https://materialize.com/use-cases/">Solutions</a>
+      <a role="menuitem" class="hoverable" href="https://materialize.com/pricing/">Pricing</a>
       <a role="menuitem" class="hoverable" href="https://materialize.com/company/">Company</a>
     </div>
     <a class="secondary" role="menuitem" href="https://cloud.materialize.com/">Log In</a>
-    <a class="btn" role="menuitem"  href="https://materialize.com/materialize-cloud">Register for Cloud</a>
+    <a class="btn featured" role="menuitem"  href="https://materialize.com/materialize-cloud">Register for Cloud</a>
   </div>
 </nav>
 


### PR DESCRIPTION
* Replaced "Use Cases" label with "Solutions"
* Removed "Blog" from top header
* Added pricing to navbar
* Added gradient to image
* Resized font
* Added "Materialize Blog" link to docs index page
* Left-justified the footer because the center justification looked weird.

### Motivation

  * This PR fixes a previously unreported bug.

Docs navbar no longer matches main website navbar.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
