### PR TITLE
sql: disallow count(distinct *)

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -112,6 +112,9 @@ List new features before bug fixes.
 
 - Correctly handle protobuf messages where the value is omitted instead of dropping them.
 
+- Disallow calls to functions with using `DISTINCT *` as their arguments, e.g.
+  `COUNT(DISTINCT *)`.
+
 {{% version-header v0.9.12 %}}
 
 - **Breaking change**: Disallow ambiguous table references in queries. For

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -115,6 +115,9 @@ List new features before bug fixes.
 - Disallow calls to functions with using `DISTINCT *` as their arguments, e.g.
   `COUNT(DISTINCT *)`.
 
+- Disallow `DISTINCT` expressions on 0-column objects, such as tables with no
+  columns.
+
 {{% version-header v0.9.12 %}}
 
 - **Breaking change**: Disallow ambiguous table references in queries. For

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -552,6 +552,14 @@ impl<'a> Parser<'a> {
             Some(DISTINCT),
         );
         let args = self.parse_optional_args(true)?;
+
+        if distinct && matches!(args, FunctionArgs::Star) {
+            return Err(self.error(
+                self.peek_prev_pos() - 1,
+                "DISTINCT * not supported as function args".to_string(),
+            ));
+        }
+
         let filter = if self.parse_keyword(FILTER) {
             self.expect_token(&Token::LParen)?;
             self.expect_keyword(WHERE)?;

--- a/src/sql-parser/tests/testdata/select
+++ b/src/sql-parser/tests/testdata/select
@@ -1149,3 +1149,10 @@ SELECT LIST(
 SELECT LIST(WITH usps AS (SELECT 42) SELECT LIST[customer.id, LIST[customer.first_name, customer.last_name], LIST[LIST[customer.zip]]] FROM customer JOIN user ON customer.id = user.id LIMIT 12)
 =>
 Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: ListSubquery(Query { ctes: [Cte { alias: TableAlias { name: Ident("usps"), columns: [], strict: false }, id: (), query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("42")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }], body: Select(Select { distinct: None, projection: [Expr { expr: List([Identifier([Ident("customer"), Ident("id")]), List([Identifier([Ident("customer"), Ident("first_name")]), Identifier([Ident("customer"), Ident("last_name")])]), List([List([Identifier([Ident("customer"), Ident("zip")])])])]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("customer")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedObjectName([Ident("user")])), alias: None }, join_operator: Inner(On(Op { op: "=", expr1: Identifier([Ident("customer"), Ident("id")]), expr2: Some(Identifier([Ident("user"), Ident("id")])) })) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: Some(Limit { with_ties: false, quantity: Value(Number("12")) }), offset: None }), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement roundtrip
+SELECT count(DISTINCT *) FROM foo
+----
+error: DISTINCT * not supported as function args
+SELECT count(DISTINCT *) FROM foo
+                      ^

--- a/test/testdrive/tables.td
+++ b/test/testdrive/tables.td
@@ -349,6 +349,9 @@ INSERT has more expressions than target columns
 > INSERT INTO nocols SELECT UNION ALL SELECT
 > SELECT count(*) FROM nocols
 2
+! SELECT DISTINCT * FROM nocols
+SELECT DISTINCT must have at least one column
+
 
 # Test that show columns preserves the column order
 > CREATE TABLE column_order (b int, a int);

--- a/test/testdrive/tables.td
+++ b/test/testdrive/tables.td
@@ -349,8 +349,6 @@ INSERT has more expressions than target columns
 > INSERT INTO nocols SELECT UNION ALL SELECT
 > SELECT count(*) FROM nocols
 2
-> SELECT count(DISTINCT *) FROM nocols
-1
 
 # Test that show columns preserves the column order
 > CREATE TABLE column_order (b int, a int);


### PR DESCRIPTION
### Motivation

This PR fixes a recognized bug. Fixes #9150.

Also fixed a minor difference between MZ and PG where we allowed calling DISTINCT on a 0-column table.

### Reviewer notes

The first iteration of this PR bailed on planning, but this should bail in parsing because no function takes `DISTINCT *` as valid arguments.

Because I did a little cleanup in the first iteration of the PR I left it in the first commit but I think it can be mostly ignored.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
