### PR TITLE
expr: rely less on macros and more on traits to define unary functions

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -42,7 +42,7 @@ use repr::adt::interval::Interval;
 use repr::adt::jsonb::JsonbRef;
 use repr::adt::numeric::{self, Numeric};
 use repr::adt::regex::Regex;
-use repr::{strconv, ColumnName, ColumnType, Datum, Row, RowArena, ScalarType};
+use repr::{strconv, ColumnName, ColumnType, Datum, DatumType, Row, RowArena, ScalarType};
 
 use crate::scalar::func::format::DateTimeFormat;
 use crate::{like_pattern, EvalError, MirScalarExpr};
@@ -714,7 +714,7 @@ fn cast_jsonb_to_int16<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
 fn cast_jsonb_to_int32<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     match a {
         Datum::Int64(_) => cast_int64_to_int32(a),
-        Datum::Float64(f) => cast_float64_to_int32(Some(*f)).map(|f| f.into()),
+        Datum::Float64(f) => cast_float64_to_int32(*f).map(|f| f.into()),
         _ => Err(EvalError::InvalidJsonbCast {
             from: jsonb_type(a).into(),
             to: "integer".into(),
@@ -725,7 +725,7 @@ fn cast_jsonb_to_int32<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
 fn cast_jsonb_to_int64<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     match a {
         Datum::Int64(_) => Ok(a),
-        Datum::Float64(f) => cast_float64_to_int64(Some(*f)).map(|f| f.into()),
+        Datum::Float64(f) => cast_float64_to_int64(*f).map(|f| f.into()),
         _ => Err(EvalError::InvalidJsonbCast {
             from: jsonb_type(a).into(),
             to: "bigint".into(),
@@ -736,7 +736,7 @@ fn cast_jsonb_to_int64<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
 fn cast_jsonb_to_float32<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     match a {
         Datum::Int64(_) => Ok(cast_int64_to_float32(a)),
-        Datum::Float64(f) => cast_float64_to_float32(Some(*f)).map(|f| f.into()),
+        Datum::Float64(f) => cast_float64_to_float32(*f).map(|f| f.into()),
         _ => Err(EvalError::InvalidJsonbCast {
             from: jsonb_type(a).into(),
             to: "real".into(),
@@ -3521,18 +3521,95 @@ impl fmt::Display for BinaryFunc {
     }
 }
 
+/// A description of an SQL unary function that has the ability to lazy evaluate its arguments
 // This trait will eventualy be annotated with #[enum_dispatch] to autogenerate the UnaryFunc enum
-trait UnaryFuncTrait {
+trait LazyUnaryFunc {
     fn eval<'a>(
         &'a self,
         datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
         a: &'a MirScalarExpr,
     ) -> Result<Datum<'a>, EvalError>;
+
+    /// The output ColumnType of this function
     fn output_type(&self, input_type: ColumnType) -> ColumnType;
+
+    /// Whether this function will produce NULL on NULL input
     fn propagates_nulls(&self) -> bool;
+
+    /// Whether this function will produce NULL on non-NULL input
     fn introduces_nulls(&self) -> bool;
+
+    /// Whether this function preserves uniqueness
     fn preserves_uniqueness(&self) -> bool;
+}
+
+/// A description of an SQL unary function that operates on eagerly evaluated expressions
+trait EagerUnaryFunc {
+    type Input: DatumType<EvalError>;
+    type Output: DatumType<EvalError>;
+
+    fn call(&self, input: Self::Input) -> Self::Output;
+
+    /// The output ColumnType of this function
+    fn output_type(&self, input_type: ColumnType) -> ColumnType {
+        let output = Self::Output::as_column_type();
+        let nullable = output.nullable;
+        // The output is nullable if it is nullable by itself or the input is nullable and this
+        // function propagates nulls
+        output.nullable(nullable || (self.propagates_nulls() && input_type.nullable))
+    }
+
+    /// Whether this function will produce NULL on NULL input
+    fn propagates_nulls(&self) -> bool {
+        // If the input is not nullable then nulls are propagated
+        !Self::Input::as_column_type().nullable
+    }
+
+    /// Whether this function will produce NULL on non-NULL input
+    fn introduces_nulls(&self) -> bool {
+        // If the output is nullable then nulls can be introduced
+        Self::Output::as_column_type().nullable
+    }
+
+    /// Whether this function preserves uniqueness
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+
+impl<T: EagerUnaryFunc> LazyUnaryFunc for T {
+    fn eval<'a>(
+        &'a self,
+        datums: &[Datum<'a>],
+        temp_storage: &'a RowArena,
+        a: &'a MirScalarExpr,
+    ) -> Result<Datum<'a>, EvalError> {
+        match T::Input::try_from_result(a.eval(datums, temp_storage)) {
+            // If we can convert to the input type then we call the function
+            Ok(input) => self.call(input).into_result(temp_storage),
+            // If we can't and we got a non-null datum something went wrong in the planner
+            Err(Ok(datum)) if !datum.is_null() => panic!("invalid input type"),
+            // Otherwise we just propagate NULLs and errors
+            Err(res) => res,
+        }
+    }
+
+    fn output_type(&self, input_type: ColumnType) -> ColumnType {
+        self.output_type(input_type)
+    }
+
+    fn propagates_nulls(&self) -> bool {
+        self.propagates_nulls()
+    }
+
+    fn introduces_nulls(&self) -> bool {
+        self.introduces_nulls()
+    }
+
+    fn preserves_uniqueness(&self) -> bool {
+        self.preserves_uniqueness()
+    }
 }
 
 #[derive(

--- a/src/expr/src/scalar/func/impls/float32.rs
+++ b/src/expr/src/scalar/func/impls/float32.rs
@@ -54,7 +54,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "f32toi16"]
     fn cast_float32_to_int16(a: f32) -> Result<i16, EvalError> {
-        let f = round_float32(Some(a))?.unwrap();
+        let f = round_float32(a);
         if (f >= (i16::MIN as f32)) && (f < -(i16::MIN as f32)) {
             Ok(f as i16)
         } else {
@@ -66,7 +66,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "f32toi32"]
     fn cast_float32_to_int32(a: f32) -> Result<i32, EvalError> {
-        let f = round_float32(Some(a))?.unwrap();
+        let f = round_float32(a);
         // This condition is delicate because i32::MIN can be represented exactly by
         // an f32 but not i32::MAX. We follow PostgreSQL's approach here.
         //
@@ -82,7 +82,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "f32toi64"]
     fn cast_float32_to_int64(a: f32) -> Result<i64, EvalError> {
-        let f = round_float32(Some(a))?.unwrap();
+        let f = round_float32(a);
         // This condition is delicate because i64::MIN can be represented exactly by
         // an f32 but not i64::MAX. We follow PostgreSQL's approach here.
         //

--- a/src/expr/src/scalar/func/impls/float64.rs
+++ b/src/expr/src/scalar/func/impls/float64.rs
@@ -55,7 +55,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "f64toi16"]
     fn cast_float64_to_int16(a: f64) -> Result<i16, EvalError> {
-        let f = round_float64(Some(a))?.unwrap();
+        let f = round_float64(a);
         if (f >= (i16::MIN as f64)) && (f < -(i16::MIN as f64)) {
             Ok(f as i16)
         } else {
@@ -67,7 +67,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "f64toi32"]
     fn cast_float64_to_int32(a: f64) -> Result<i32, EvalError> {
-        let f = round_float64(Some(a))?.unwrap();
+        let f = round_float64(a);
         // This condition is delicate because i32::MIN can be represented exactly by
         // an f64 but not i32::MAX. We follow PostgreSQL's approach here.
         //
@@ -83,7 +83,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "f64toi64"]
     fn cast_float64_to_int64(a: f64) -> Result<i64, EvalError> {
-        let f = round_float64(Some(a))?.unwrap();
+        let f = round_float64(a);
         // This condition is delicate because i64::MIN can be represented exactly by
         // an f64 but not i64::MAX. We follow PostgreSQL's approach here.
         //

--- a/src/expr/src/scalar/func/macros.rs
+++ b/src/expr/src/scalar/func/macros.rs
@@ -7,155 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-/// This macro generates a definition of a UnaryFunc variant and automatically implements
-/// `UnaryFuncTrait` for it based on the provided function.
-///
-/// The macro can be applied to unary functions that adhere to the following constraints:
-/// * The input is eagerly evaluatated
-/// * The function doesn't preserve uniquencess
-///
-/// Functions that don't adhere to the above constraints need to have their UnaryFuncTrait
-/// implementation defined manually and have full control over their eval phase and other
-/// characteristics.
-///
-/// The macro implements a set of elision rules for automatically determining whether a given
-/// function propagates or introduces nulls. The rules are summarized in the following table:
-///
-/// Input type  | Output type  | Propagates NULL  | Introduces NULL | Preserves uniqueness
-/// ------------+--------------+------------------+-----------------+---------------------
-/// `Option<T>` | `Option<T>`  | Not elided       | Not elided      | Not elided
-/// `Option<T>` | `T`          | `false`          | `false`         | false
-/// `T`         | `Option<T>`  | `true`           | `true`          | false
-/// `T`         | `T`          | `true`           | `false`         | false
-///
-/// For the non elided case the attributes `sqlname`, `propagates_nulls`, `introduces_nulls`, and
-/// `preserves_uniqueness` must be specified:
-///
-/// ```
-/// sqlfunc!(
-///     #[sqlname = "foo"]
-///     #[propagates_nulls = false]
-///     #[introduces_nulls = true]
-///     #[preserves_uniqueness = true]
-///     fn foo(a: Option<bool>) -> Option<bool> {
-///         unimplemented!()
-///     }
-/// );
-/// ```
-///
-///
-/// ```
-/// /// This SQL function will be named "booltoi32". It propagates nulls and doesn't introduce them
-/// sqlfunc!(
-///     fn booltoi32(a: bool) -> i32 {
-///         a as i32
-///     }
-/// );
-/// ```
-///
-/// A custom name can be given as the first parameter to the macro:
-/// ```
-/// /// This SQL function will be named "isnull". It doesn't propagate nor introduce nulls
-/// sqlfunc!(
-///     #[sqlname = "isnull"]
-///     fn is_null(a: Option<i32>) -> bool {
-///         a.is_none()
-///     }
-/// );
-/// ```
 macro_rules! sqlfunc {
-    (
-        #[sqlname = $name:expr]
-        #[propagates_nulls = $propagates_nulls:literal]
-        #[introduces_nulls = $introduces_nulls:literal]
-        #[preserves_uniqueness = $preserves_uniqueness:literal]
-        fn $fn_name:ident($param_name:ident: $param_ty:ty) -> Result<Option<$ret_ty:ty>, EvalError>
-            $body:block
-    ) => {
-        paste::paste! {
-            pub fn $fn_name($param_name: $param_ty) -> Result<Option<$ret_ty>, crate::EvalError> {
-                $body
-            }
-
-            mod [<__ $fn_name _impl>] {
-                use std::fmt;
-
-                use repr::{ColumnType, Datum, FromTy, RowArena, ScalarType, WithArena};
-                use serde::{Deserialize, Serialize};
-                use lowertest::MzStructReflect;
-
-                use crate::scalar::func::UnaryFuncTrait;
-                use crate::{EvalError, MirScalarExpr};
-
-                #[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzStructReflect)]
-                pub struct [<$fn_name:camel>];
-
-                /// Utility function that converts the return type the passed function into its
-                /// runtime representation
-                fn output_type_of<T, R, E>(_: fn(T) -> Result<Option<R>, E>) -> ScalarType
-                where ScalarType: FromTy<R> {
-                    <ScalarType as FromTy<R>>::from_ty()
-                }
-
-                impl UnaryFuncTrait for [<$fn_name:camel>] {
-                    fn eval<'a>(
-                        &'a self,
-                        datums: &[Datum<'a>],
-                        temp_storage: &'a RowArena,
-                        a: &'a MirScalarExpr,
-                    ) -> Result<Datum<'a>, EvalError> {
-                        // Evaluate the argument and convert it to the concrete type that the
-                        // implementation expects. This cannot fail here because the expression is
-                        // already typechecked.
-                        let a: $param_ty = a
-                            .eval(datums, temp_storage)?
-                            .try_into()
-                            .expect("expression already typechecked");
-
-                        // Then we call the provided function that will return a Result<T, _>,
-                        // where T is some concrete, owned type
-                        let result = super::$fn_name(a);
-
-                        // Finally, we convert T into a Datum<'a> by wrapping the returned value
-                        // into a `WithArena` with the temporary storage provided to eval and
-                        // delegating to the respective `Into` implementation
-                        result.map(move |r| WithArena::new(temp_storage, r).into())
-                    }
-
-                    fn output_type(&self, input_type: ColumnType) -> ColumnType {
-                        // Use the FromTy trait to convert the Rust return type into our runtime
-                        // type representation
-                        output_type_of(super::$fn_name)
-                            .nullable($propagates_nulls && input_type.nullable || $introduces_nulls)
-                    }
-
-                    fn propagates_nulls(&self) -> bool {
-                        $propagates_nulls
-                    }
-
-                    fn introduces_nulls(&self) -> bool {
-                        $introduces_nulls
-                    }
-
-                    fn preserves_uniqueness(&self) -> bool {
-                        $preserves_uniqueness
-                    }
-                }
-
-                impl fmt::Display for [<$fn_name:camel>] {
-                    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                        f.write_str($name)
-                    }
-                }
-            }
-            pub use [<__ $fn_name _impl>]::[<$fn_name:camel>];
-        }
-    };
-
-    // Here follow 3 stages of transformations for the cases where the user didn't provide a fully
-    // specified function signature as expected by the rule above.
-
-    // Stage 0: Expand the function name into an attribute, if it was omitted
+    // Expand the function name into an attribute if it was omitted
     (
         fn $fn_name:ident $($tail:tt)*
     ) => {
@@ -165,151 +18,41 @@ macro_rules! sqlfunc {
         );
     };
 
-    // Stage 1: Convert function to fallible, if it wasn't already
-
-    // It is important that we check if the return type matches Result<Option<T>>, Result<T>,
-    // Option<T>, and T in that order because once a type is matched by a `ty` typed metavariable
-    // it can no longer be destructured syntactically. So if `$ret_ty:ty` matched
-    // `Result<Option<T>>` as a unit we would no longer be able to infer information about the
-    // structure of the type and therefore wouldn't be able to apply the elision rules.
     (
         #[sqlname = $name:expr]
-        fn $fn_name:ident $params:tt -> Result<Option<$ret_ty:ty>, EvalError>
+        fn $fn_name:ident($param_name:ident: $input_ty:ty) -> $output_ty:ty
             $body:block
     ) => {
-        sqlfunc!(
-            @stage2
-            #[sqlname = $name]
-            fn $fn_name $params -> Result<Option<$ret_ty>, EvalError> {
+        paste::paste! {
+            #[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize, Hash, lowertest::MzStructReflect)]
+            pub struct [<$fn_name:camel>];
+
+            impl crate::func::EagerUnaryFunc for [<$fn_name:camel>] {
+                type Input = $input_ty;
+                type Output = $output_ty;
+
+                fn call(&self, a: Self::Input) -> Self::Output {
+                    $fn_name(a)
+                }
+            }
+
+            impl std::fmt::Display for [<$fn_name:camel>] {
+                fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                    f.write_str($name)
+                }
+            }
+
+            pub fn $fn_name($param_name: $input_ty) -> $output_ty {
                 $body
             }
-        );
-    };
-    (
-        #[sqlname = $name:expr]
-        fn $fn_name:ident $params:tt -> Result<$ret_ty:ty, EvalError>
-            $body:block
-    ) => {
-        sqlfunc!(
-            @stage2
-            #[sqlname = $name]
-            fn $fn_name $params -> Result<$ret_ty, EvalError> {
-                $body
-            }
-        );
-    };
-    (
-        #[sqlname = $name:expr]
-        fn $fn_name:ident $params:tt -> Option<$ret_ty:ty>
-            $body:block
-    ) => {
-        sqlfunc!(
-            @stage2
-            #[sqlname = $name]
-            fn $fn_name $params -> Result<Option<$ret_ty>, EvalError> {
-                Ok($body)
-            }
-        );
-    };
-    (
-        #[sqlname = $name:expr]
-        fn $fn_name:ident $params:tt -> $ret_ty:ty
-            $body:block
-    ) => {
-        sqlfunc!(
-            @stage2
-            #[sqlname = $name]
-            fn $fn_name $params -> Result<$ret_ty, EvalError> {
-                Ok($body)
-            }
-        );
-    };
-
-
-    // Stage 2: Apply the elision rules to find out if the function propagates or introduces nulls
-
-    // We can't infer in this case, bail out with a nice error message
-    (
-        @stage2
-        #[sqlname = $name:expr]
-        fn $fn_name:ident($param_name:ident: Option<$param_ty:ty>) -> Result<Option<$ret_ty:ty>, EvalError>
-            $body:block
-    ) => {
-        compile_error!(
-            "missing `propagates_nulls` and `introduces_nulls` attributes.\n       \
-            These properties cannot be elided when both input and output are optional"
-        );
-    };
-
-    // The function takes optional arguments and returns non optional, therefore it doesn't
-    // propagate nulls
-    (
-        @stage2
-        #[sqlname = $name:expr]
-        fn $fn_name:ident($param_name:ident: Option<$param_ty:ty>) -> Result<$ret_ty:ty, EvalError>
-            $body:block
-    ) => {
-        sqlfunc!(
-            #[sqlname = $name]
-            #[propagates_nulls = false]
-            #[introduces_nulls = false]
-            #[preserves_uniqueness = false]
-            fn $fn_name($param_name: Option<$param_ty>) -> Result<Option<$ret_ty>, EvalError> {
-                ($body).map(Some)
-            }
-        );
-    };
-
-    // The function takes non-optional arguments and returns optional, therefore it propagates
-    // nulls and introduces nulls too
-    (
-        @stage2
-        #[sqlname = $name:expr]
-        fn $fn_name:ident($param_name:ident: $param_ty:ty) -> Result<Option<$ret_ty:ty>, EvalError>
-            $body:block
-    ) => {
-        sqlfunc!(
-            #[sqlname = $name]
-            #[propagates_nulls = true]
-            #[introduces_nulls = true]
-            #[preserves_uniqueness = false]
-            fn $fn_name($param_name: Option<$param_ty>) -> Result<Option<$ret_ty>, EvalError> {
-                let $param_name = match $param_name {
-                    Some(v) => v,
-                    None => return Ok(None),
-                };
-                $body
-            }
-        );
-    };
-
-    // The function takes non-optional arguments and returns non optional, therefore it propagates
-    // nulls but doesn't introduce them
-    (
-        @stage2
-        #[sqlname = $name:expr]
-        fn $fn_name:ident($param_name:ident: $param_ty:ty) -> Result<$ret_ty:ty, EvalError>
-            $body:block
-    ) => {
-        sqlfunc!(
-            #[sqlname = $name]
-            #[propagates_nulls = true]
-            #[introduces_nulls = false]
-            #[preserves_uniqueness = false]
-            fn $fn_name($param_name: Option<$param_ty>) -> Result<Option<$ret_ty>, EvalError> {
-                let $param_name = match $param_name {
-                    Some(v) => v,
-                    None => return Ok(None),
-                };
-                ($body).map(Some)
-            }
-        );
+        }
     };
 }
 
 #[cfg(test)]
 mod test {
-    use crate::scalar::func::UnaryFuncTrait;
+    use crate::scalar::func::LazyUnaryFunc;
+    use crate::EvalError;
     use repr::ScalarType;
 
     sqlfunc!(
@@ -433,24 +176,6 @@ mod test {
             ScalarType::Float32.nullable(true)
         );
     }
-
-    sqlfunc!(
-        #[sqlname = "foobar"]
-        #[propagates_nulls = false]
-        #[introduces_nulls = true]
-        #[preserves_uniqueness = true]
-        fn explicit(a: Option<f64>) -> Result<Option<f64>, EvalError> {
-            Ok(a)
-        }
-    );
-
-    #[test]
-    fn explicit_annotation() {
-        assert_eq!(format!("{}", Explicit), "foobar");
-        assert!(!Explicit.propagates_nulls());
-        assert!(Explicit.introduces_nulls());
-        assert!(Explicit.preserves_uniqueness());
-    }
 }
 
 /// Temporary macro that generates the equivalent of what enum_dispatch will do in the future. We
@@ -475,25 +200,25 @@ macro_rules! derive_unary {
 
             pub fn output_type(&self, input_type: ColumnType) -> ColumnType {
                 match self {
-                    $(Self::$name(f) => f.output_type(input_type),)*
+                    $(Self::$name(f) => LazyUnaryFunc::output_type(f, input_type),)*
                     _ => self.output_type_manual(input_type),
                 }
             }
             pub fn propagates_nulls(&self) -> bool {
                 match self {
-                    $(Self::$name(f) => f.propagates_nulls(),)*
+                    $(Self::$name(f) => LazyUnaryFunc::propagates_nulls(f),)*
                     _ => self.propagates_nulls_manual(),
                 }
             }
             pub fn introduces_nulls(&self) -> bool {
                 match self {
-                    $(Self::$name(f) => f.introduces_nulls(),)*
+                    $(Self::$name(f) => LazyUnaryFunc::introduces_nulls(f),)*
                     _ => self.introduces_nulls_manual(),
                 }
             }
             pub fn preserves_uniqueness(&self) -> bool {
                 match self {
-                    $(Self::$name(f) => f.preserves_uniqueness(),)*
+                    $(Self::$name(f) => LazyUnaryFunc::preserves_uniqueness(f),)*
                     _ => self.preserves_uniqueness_manual(),
                 }
             }

--- a/src/lowertest-derive/src/lib.rs
+++ b/src/lowertest-derive/src/lib.rs
@@ -62,7 +62,7 @@ pub fn mzenumreflect_derive(input: TokenStream) -> TokenStream {
 
     let name = &ast.ident;
     let gen = quote! {
-      impl MzEnumReflect for #name {
+      impl lowertest::MzEnumReflect for #name {
         fn mz_enum_reflect() ->
             std::collections::HashMap<
                 &'static str,
@@ -100,7 +100,7 @@ pub fn mzstructreflect_derive(input: TokenStream) -> TokenStream {
 
     let name = &ast.ident;
     let gen = quote! {
-      impl MzStructReflect for #name {
+      impl lowertest::MzStructReflect for #name {
         fn mz_struct_reflect() -> (Vec<&'static str>, Vec<&'static str>)
         {
            #method_impl

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -36,7 +36,7 @@ pub use relation::{ColumnName, ColumnType, NotNullViolation, RelationDesc, Relat
 pub use row::{
     datum_list_size, datum_size, datums_size, row_size, DatumList, DatumMap, Row, RowArena, RowRef,
 };
-pub use scalar::{Datum, FromTy, ScalarBaseType, ScalarType, WithArena};
+pub use scalar::{Datum, DatumType, ScalarBaseType, ScalarType};
 
 // Concrete types used throughout Materialize for the generic parameters in Timely/Differential Dataflow.
 /// System-wide timestamp type.

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -1048,6 +1048,23 @@ impl<E> DatumType<E> for Vec<u8> {
     }
 }
 
+impl<E> DatumType<E> for Numeric {
+    fn as_column_type() -> ColumnType {
+        ScalarType::Numeric { scale: None }.nullable(false)
+    }
+
+    fn try_from_result(res: Result<Datum, E>) -> Result<Self, Result<Datum, E>> {
+        match res {
+            Ok(Datum::Numeric(n)) => Ok(n.into_inner()),
+            _ => Err(res),
+        }
+    }
+
+    fn into_result(self, _temp_storage: &RowArena) -> Result<Datum, E> {
+        Ok(Datum::from(self))
+    }
+}
+
 impl<'a> ScalarType {
     /// Returns the contained numeric scale.
     ///

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -722,58 +722,6 @@ where
     }
 }
 
-#[derive(Debug)]
-pub struct WithArena<'a, T> {
-    arena: &'a RowArena,
-    data: T,
-}
-
-impl<'a, T> WithArena<'a, T> {
-    pub fn new(arena: &'a RowArena, data: T) -> Self {
-        WithArena { arena, data }
-    }
-}
-
-/// Blanket implementation for types that don't need access to an allocation context
-impl<'a, T> From<WithArena<'a, T>> for Datum<'a>
-where
-    Datum<'a>: From<T>,
-{
-    fn from(context: WithArena<'a, T>) -> Datum<'a> {
-        context.data.into()
-    }
-}
-
-impl<'a> From<WithArena<'a, String>> for Datum<'a> {
-    fn from(context: WithArena<'a, String>) -> Datum<'a> {
-        Datum::String(context.arena.push_string(context.data))
-    }
-}
-
-impl<'a> From<WithArena<'a, Option<String>>> for Datum<'a> {
-    fn from(context: WithArena<'a, Option<String>>) -> Datum<'a> {
-        match context.data {
-            Some(b) => Datum::String(context.arena.push_string(b)),
-            None => Datum::Null,
-        }
-    }
-}
-
-impl<'a> From<WithArena<'a, Vec<u8>>> for Datum<'a> {
-    fn from(context: WithArena<'a, Vec<u8>>) -> Datum<'a> {
-        Datum::Bytes(context.arena.push_bytes(context.data))
-    }
-}
-
-impl<'a> From<WithArena<'a, Option<Vec<u8>>>> for Datum<'a> {
-    fn from(context: WithArena<'a, Option<Vec<u8>>>) -> Datum<'a> {
-        match context.data {
-            Some(b) => Datum::Bytes(context.arena.push_bytes(b)),
-            None => Datum::Null,
-        }
-    }
-}
-
 fn write_delimited<T, TS, F>(
     f: &mut fmt::Formatter,
     delimiter: &str,
@@ -967,68 +915,136 @@ pub enum ScalarType {
     RegProc,
 }
 
-/// [FromTy] is a utility trait for [ScalarType] that defines a mapping between a Rust type T and
-/// its runtime representation as a ScalarType. Not all ScalarType variants have a 1-1 mapping to a
-/// Rust type but for those variants can simply be ignored.
-///
-/// The main usecase of FromTy is to use rustc's inference to lift type information from compile
-/// time to runtime, a primitive form of reflection. See the implementation of the `fn_unary` macro
-/// in `expr` for an example use of this trait.
-pub trait FromTy<T> {
-    fn from_ty() -> Self;
+/// A bridge between native Rust types and the SQL runtime types that are wrapped in Datums
+pub trait DatumType<E>: Sized {
+    /// The SQL column type of this Rust type
+    fn as_column_type() -> ColumnType;
+
+    /// Try to convert a Result whose Ok variant is a Datum into this native Rust type (Self). If
+    /// it fails the error variant will contain the original result.
+    fn try_from_result(res: Result<Datum, E>) -> Result<Self, Result<Datum, E>>;
+
+    /// Convert this Rust type into a Result containing a Datum, or an error
+    fn into_result(self, temp_storage: &RowArena) -> Result<Datum, E>;
 }
 
-impl FromTy<bool> for ScalarType {
-    fn from_ty() -> Self {
-        Self::Bool
+impl<E, B: DatumType<E>> DatumType<E> for Option<B> {
+    fn as_column_type() -> ColumnType {
+        B::as_column_type().nullable(true)
+    }
+    fn try_from_result(res: Result<Datum, E>) -> Result<Self, Result<Datum, E>> {
+        match res {
+            Ok(Datum::Null) => Ok(None),
+            Ok(datum) => B::try_from_result(Ok(datum)).map(Some),
+            _ => Err(res),
+        }
+    }
+    fn into_result(self, temp_storage: &RowArena) -> Result<Datum, E> {
+        match self {
+            Some(inner) => inner.into_result(temp_storage),
+            None => Ok(Datum::Null),
+        }
     }
 }
 
-impl FromTy<String> for ScalarType {
-    fn from_ty() -> Self {
-        Self::String
+impl<E, B: DatumType<E>> DatumType<E> for Result<B, E> {
+    fn as_column_type() -> ColumnType {
+        B::as_column_type()
+    }
+    fn try_from_result(res: Result<Datum, E>) -> Result<Self, Result<Datum, E>> {
+        B::try_from_result(res).map(Ok)
+    }
+    fn into_result(self, temp_storage: &RowArena) -> Result<Datum, E> {
+        self.and_then(|inner| inner.into_result(temp_storage))
     }
 }
 
-impl FromTy<Vec<u8>> for ScalarType {
-    fn from_ty() -> Self {
-        Self::Bytes
+/// Macro to derive DatumType for all Datum variants that are simple Copy types
+macro_rules! impl_datum_type_copy {
+    ($(($native:ty, $variant:ident)),+) => {
+        $(
+            impl<E> DatumType<E> for $native {
+                fn as_column_type() -> ColumnType {
+                    ScalarType::$variant.nullable(false)
+                }
+
+                fn try_from_result(res: Result<Datum, E>) -> Result<Self, Result<Datum, E>> {
+                    match res {
+                        Ok(Datum::$variant(f)) => Ok(f.into()),
+                        _ => Err(res),
+                    }
+                }
+
+                fn into_result(self, _temp_storage: &RowArena) -> Result<Datum, E> {
+                    Ok(Datum::$variant(self.into()))
+                }
+            }
+        )+
     }
 }
 
-impl FromTy<f32> for ScalarType {
-    fn from_ty() -> Self {
-        Self::Float32
+impl_datum_type_copy!(
+    (f32, Float32),
+    (f64, Float64),
+    (i16, Int16),
+    (i32, Int32),
+    (i64, Int64),
+    (DateTime<Utc>, TimestampTz)
+);
+
+impl<E> DatumType<E> for bool {
+    fn as_column_type() -> ColumnType {
+        ScalarType::Bool.nullable(false)
+    }
+
+    fn try_from_result(res: Result<Datum, E>) -> Result<Self, Result<Datum, E>> {
+        match res {
+            Ok(Datum::True) => Ok(true),
+            Ok(Datum::False) => Ok(false),
+            _ => Err(res),
+        }
+    }
+
+    fn into_result(self, _temp_storage: &RowArena) -> Result<Datum, E> {
+        if self {
+            Ok(Datum::True)
+        } else {
+            Ok(Datum::False)
+        }
     }
 }
 
-impl FromTy<f64> for ScalarType {
-    fn from_ty() -> Self {
-        Self::Float64
+impl<E> DatumType<E> for String {
+    fn as_column_type() -> ColumnType {
+        ScalarType::String.nullable(false)
+    }
+
+    fn try_from_result(res: Result<Datum, E>) -> Result<Self, Result<Datum, E>> {
+        match res {
+            Ok(Datum::String(s)) => Ok(s.to_owned()),
+            _ => Err(res),
+        }
+    }
+
+    fn into_result(self, temp_storage: &RowArena) -> Result<Datum, E> {
+        Ok(Datum::String(temp_storage.push_string(self)))
     }
 }
 
-impl FromTy<i16> for ScalarType {
-    fn from_ty() -> Self {
-        Self::Int16
+impl<E> DatumType<E> for Vec<u8> {
+    fn as_column_type() -> ColumnType {
+        ScalarType::Bytes.nullable(false)
     }
-}
 
-impl FromTy<i32> for ScalarType {
-    fn from_ty() -> Self {
-        Self::Int32
+    fn try_from_result(res: Result<Datum, E>) -> Result<Self, Result<Datum, E>> {
+        match res {
+            Ok(Datum::Bytes(b)) => Ok(b.to_owned()),
+            _ => Err(res),
+        }
     }
-}
 
-impl FromTy<i64> for ScalarType {
-    fn from_ty() -> Self {
-        Self::Int64
-    }
-}
-
-impl FromTy<DateTime<Utc>> for ScalarType {
-    fn from_ty() -> Self {
-        Self::TimestampTz
+    fn into_result(self, temp_storage: &RowArena) -> Result<Datum, E> {
+        Ok(Datum::Bytes(temp_storage.push_bytes(self)))
     }
 }
 

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -136,7 +136,7 @@ lazy_static! {
             (Int16, Float64) => Implicit: CastInt16ToFloat64,
             (Int16, Numeric) => Implicit: CastTemplate::new(|_ecx, _ccx, _from_type, to_type| {
                 let s = to_type.unwrap_numeric_scale();
-                Some(move |e: HirScalarExpr| e.call_unary(CastInt16ToNumeric(s)))
+                Some(move |e: HirScalarExpr| e.call_unary(CastInt16ToNumeric(func::CastInt16ToNumeric(s))))
             }),
             (Int16, String) => Assignment: CastInt16ToString,
 


### PR DESCRIPTION
### Motivation

This is an attempt to make the function generation macro a lot simpler by relying a lot more on traits and the type system.

The primary motivation for this change is to make implementing eager functions *without* the macro also be reasonably short and straightforward.

Implementing SQL function with the `EagerUnaryFunc` directly is needed for those UnaryFunc variants that hold data, and therefore cannot work with the generated ZST type.

As with previous refactors in this area, I have converted a single data-bearing function in this PR to demonstrate its usage while keeping it short. Once this is merged we can finally move the rest of the Unary functions and start looking at the binary ones.

### Tips for reviewer

Commit by commit recommended

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.