### PR TITLE
WIP: `RenderTimestamp` abstraction of time for `dataflow::render`

### DIFF
--- a/src/dataflow/src/bin/headless.rs
+++ b/src/dataflow/src/bin/headless.rs
@@ -1,0 +1,48 @@
+use dataflow::{Command, Response};
+
+fn main() {
+    // idk?
+    let runtime = tokio::runtime::Runtime::new().expect("creating tokio runtime failed");
+    let _enter_tokio_guard = std::mem::forget(runtime.enter());
+
+    let workers = 4;
+    let worker_config = timely::WorkerConfig::default();
+
+    // Channels to communicate commands to the dataflow.
+    let mut command_send = Vec::new();
+    let mut command_recv = Vec::new();
+    for _ in 0..workers {
+        let (send, recv) = crossbeam_channel::unbounded();
+        command_send.push(send);
+        command_recv.push(recv);
+    }
+
+    // Channels to communicate response from the dataflow.
+    let (response_send, mut response_recv) = tokio::sync::mpsc::unbounded_channel();
+
+    // Required configuration to start a dataflow instance.
+    let dataflow_config = dataflow::Config {
+        command_receivers: command_recv,
+        timely_worker: worker_config,
+        experimental_mode: true,
+        now: || 0,
+        metrics_registry: ore::metrics::MetricsRegistry::new(),
+        persist: None,
+        feedback_tx: response_send,
+    };
+
+    let _worker_guards = dataflow::serve(dataflow_config);
+
+    // Now do various things with command_send and response_recv.
+    broadcast(dataflow::Command::Shutdown, &command_send);
+
+    while let Some(response) = response_recv.blocking_recv() {
+        println!("RESPONSE: {:?}", response);
+    }
+}
+
+fn broadcast(command: dataflow::Command, sends: &[crossbeam_channel::Sender<Command>]) {
+    for channel in sends.iter() {
+        channel.send(command.clone()).unwrap();
+    }
+}

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -572,7 +572,7 @@ fn flatten_results<G>(
     timely::dataflow::Stream<G, DataflowError>,
 )
 where
-    G: Scope<Timestamp = Timestamp>,
+    G: Scope,
 {
     match key_envelope {
         KeyEnvelope::None => results

--- a/src/dataflow/src/render/top_k.rs
+++ b/src/dataflow/src/render/top_k.rs
@@ -154,13 +154,14 @@ pub struct BasicTopKPlan {
 // The implementation requires integer timestamps to be able to delay feedback for monotonic inputs.
 impl<G> Context<G, Row, repr::Timestamp>
 where
-    G: Scope<Timestamp = repr::Timestamp>,
+    G: Scope,
+    G::Timestamp: crate::render::RenderTimestamp,
 {
     pub fn render_topk(
         &mut self,
-        input: CollectionBundle<G, Row, G::Timestamp>,
+        input: CollectionBundle<G, Row, repr::Timestamp>,
         top_k_plan: TopKPlan,
-    ) -> CollectionBundle<G, Row, G::Timestamp> {
+    ) -> CollectionBundle<G, Row, repr::Timestamp> {
         let (ok_input, err_input) = input.as_collection();
 
         // We create a new region to compartmentalize the topk logic.
@@ -187,8 +188,12 @@ where
                     // stage.
                     use differential_dataflow::operators::iterate::Variable;
                     let delay = std::time::Duration::from_nanos(10_000_000_000);
-                    let retractions =
-                        Variable::new(&mut ok_input.scope(), delay.as_millis() as u64);
+                    let retractions = Variable::new(
+                        &mut ok_input.scope(),
+                        <G::Timestamp as crate::render::RenderTimestamp>::system_delay(
+                            delay.as_millis() as u64,
+                        ),
+                    );
                     let thinned = ok_input.concat(&retractions.negate());
                     let result = build_topk(thinned, group_key, order_key, 0, limit, arity);
                     retractions.set(&ok_input.concat(&result.negate()));


### PR DESCRIPTION
This is a WIP abstracting a notion of timestamp for the `render` subcomponent of dataflow. The goal is to remove instances of `repr::Timestamp` deep in `render`, and to instead use the constraint of `T: RenderTimestamp`. This would allow us to use more general timestamps, enabling for example recursive computation, or timestamps that have separate system and event times.

There are currently some conflicts with the head of `main` that I may sort out, or I may punt to whomever picks this up. There is also a `headless.rs` which is something that is probably now subsumed by `dataflowd`, and we could probably get rid of (or perhaps write another front-end for `dataflowd`).

cc: @aalexandrov

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/9160)
<!-- Reviewable:end -->
