### PR TITLE
doc: Add missing operators to EXPLAIN PLAN

### DIFF
--- a/doc/user/content/sql/explain.md
+++ b/doc/user/content/sql/explain.md
@@ -10,8 +10,8 @@ menu:
 
 {{< warning >}}
 `EXPLAIN` is not part of Materialize's stable interface and is not subject to
-our [backwards compatibility](/versions/#backwards-compatibility) guarantee.
-The syntax and output of `EXPLAIN` may change arbitrarily in future versions of
+our [backwards compatibility](/versions/#backwards-compatibility) guarantee. The
+syntax and output of `EXPLAIN` may change arbitrarily in future versions of
 Materialize.
 {{< /warning >}}
 
@@ -137,23 +137,45 @@ operator use the outputs of chains `%0`, `%1` and `%2` as its inputs.
 Many operators need to refer to columns in their input. These are displayed like
 `#3` for column number 3. (Columns are numbered starting from column 0).
 
-The possible operators are:
+If you are explaining view creation for a view or one-off query that refers to unmaterialized sources, you may see `Filter` or `Project` operators attached to the unmaterialized source. This indicates that those operators will run before the upsert operator, and the upsert operator will not maintain state corresponding to data removed by the filter and project operators.
 
-Operator | Meaning | Example
----------|---------|---------
-**Constant** | Always produces the same collection of rows | `Constant (1)`
-**Get** | Produces rows from either an existing source/view or from a previous operator in the same plan | `Get materialize.public.ordered (u2)`
-**Project** | Produces a subset of the columns in the input rows | `Project (#2, #3)`
-**Map** | Appends the results of some scalar expressions to each row in the input | `Map (((#1 * 10000000dec) / #2) * 1000dec)`
-**FlatMapUnary** | Appends the result of some table function to each row in the input | `FlatMapUnary jsonb_foreach(#3)`
-**Filter** | Remove rows of the input for which some scalar predicates return false | `Filter (#20 < #21)`
-**Join** | Returns combinations of rows from each input whenever some scalar predicates are true | `Join %1 %4 (= #0 #9)`
-**Reduce** | Groups the input rows by some scalar expressions, reduces each groups using some aggregate functions and produce rows containing the group key and aggregate outputs | `Reduce group=(#5) countall(null)`
-**TopK** | Groups the inputs rows by some scalar expressions, sorts each group using the group key, removes the top `offset` rows in each group and returns the next `limit` rows | `TopK group=() order=(#1 asc, #0 desc) limit=5 offset=0`
-**Negate** | Negates the row counts of the input. This is usually used in combination with union to remove rows from the other union input. | `Negate`
-**Threshold** | Removes any rows with negative counts. | `Threshold`
-**Union** | Sums the rows counts of both inputs | `Union %2 %3`
-**ArrangeBy** | Indicates a point that will become an arrangement in the dataflow engine | `ArrangeBy (#0) (#3)`
+Here's an example of a materialized query pulling from unmaterialized sources and the `EXPLAIN PLAN` command:
+
+```
+CREATE MATERIALIZED VIEW mv as SELECT a, c FROM data EXCEPT ALL SELECT a, c FROM data2 where d is null;
+
+EXPLAIN PLAN FOR VIEW mv;
+```
+
+First, Materialize reads from two unmaterialized sources, `u1` and `u3`. You can see the `Filter` and `Project` operators applied during this process.
+
+```
+Source materialize.public.data (u1):
+| Project (#0, #2)
+
+Source materialize.public.data2 (u3):
+| Filter isnull(#3)
+| Project (#0, #2, #3)
+```
+
+Next, Materialize runs the query on the ingested sources. Because the `FILTER` and `PROJECT` operators have already been applied during the ingestion, they don't need be run again.
+
+```
+Query:
+%0 =
+| Get materialize.public.data (u1)
+| Project (#0, #2)
+
+%1 =
+| Get materialize.public.data2 (u3)
+| Filter isnull(#3)
+| Project (#0, #2)
+| Negate
+
+%2 =
+| Union %0 %1
+| Threshold
+```
 
 Each operator can also be annotated with additional metadata. The most common
 example is the choice of implementation in the `Join` operator.
@@ -178,6 +200,27 @@ dataflow.
 ```
 Finish order_by=(#1 desc, #2 asc) limit=none offset=0 project=(#0..#3)
 ```
+
+#### Operators in decorrelated and optimized plans
+
+Operator | Meaning | Example
+---------|---------|---------
+**Constant** | Always produces the same collection of rows | `Constant (1)`
+**Get** | Produces rows from either an existing source/view or from a previous operator in the same plan | `Get materialize.public.ordered (u2)`
+**Project** | Produces a subset of the columns in the input rows | `Project (#2, #3)`
+**Map** | Appends the results of some scalar expressions to each row in the input | `Map (((#1 * 10000000dec) / #2) * 1000dec)`
+**FlatMap** | Appends the result of some table function to each row in the input | `FlatMap jsonb_foreach(#3)`
+**Filter** | Remove rows of the input for which some scalar predicates return false | `Filter (#20 < #21)`
+**Join** | Returns combinations of rows from each input whenever some scalar predicates are true | `Join %1 %4 (= #0 #9)`
+**Reduce** | Groups the input rows by some scalar expressions, reduces each groups using some aggregate functions and produce rows containing the group key and aggregate outputs | `Reduce group=(#5) countall(null)`
+**TopK** | Groups the inputs rows by some scalar expressions, sorts each group using the group key, removes the top `offset` rows in each group and returns the next `limit` rows | `TopK group=() order=(#1 asc, #0 desc) limit=5 offset=0`
+**Negate** | Negates the row counts of the input. This is usually used in combination with union to remove rows from the other union input. | `Negate`
+**Threshold** | Removes any rows with negative counts. | `Threshold`
+**Union** | Sums the rows counts of both inputs | `Union %2 %3`
+**ArrangeBy** | Indicates a point that will become an arrangement in the dataflow engine | `ArrangeBy (#0) (#3)`
+**DeclareKeys**  | Contains any manually declared primary keys.    | `DeclareKeys`
+**Let**  | Marks a branch of computation whose result is used later by other branches with `%0`. |  `%0 = Let 10 =`
+
 
 ### Reading raw plans
 
@@ -211,7 +254,7 @@ the `select` operator.
 Inside a subquery, scalar expressions can refer to columns of the outside rows
 by adding a `^` to the column number eg `#^1`.
 
-The possible operators are:
+#### Operators in raw plans
 
 Operator | Meaning | Example
 ---------|---------|---------
@@ -219,7 +262,7 @@ Operator | Meaning | Example
 **Get** | Produces rows from either an existing source/view or from a previous operator in the same plan | `Get materialize.public.ordered (u2)`
 **Project** | Produces a subset of the columns in the input rows | `Project (#2, #3)`
 **Map** | Appends the results of some scalar expressions to each row in the input | `Map (((#1 * 10000000dec) / #2) * 1000dec)`
-**FlatMapUnary** | Appends the result of some table function to each row in the input | `FlatMapUnary jsonb_foreach(#3)`
+**CallTable** | Appends the result of some table function to each row in the input | `CallTable generate_series (#3)`
 **Filter** | Remove rows of the input for which some scalar predicates return false | `Filter (#20 < #21)`
 **Join** | Perform one of INNER / LEFT / RIGHT / FULL OUTER on the two inputs, using the given predicate | `InnerJoin %0 %1 on (#1 = #2)`
 **Reduce** | Groups the input rows by some scalar expressions, reduces each group using some aggregate functions and produce rows containing the group key and aggregate outputs. In the case where the group key is empty and the input is empty, returns a single row with the aggregate functions applied to empty rows. | `Reduce group=(#5) agg countall(null)`
@@ -228,3 +271,4 @@ Operator | Meaning | Example
 **Negate** | Negates the row counts of the input. This is usually used in combination with union to remove rows from the other union input. | `Negate`
 **Threshold** | Removes any rows with negative counts. | `Threshold`
 **Union** | Sums the rows counts of both inputs | `Union %2 %3`
+**DeclareKeys**  | Contains any manually declared primary keys.    | `DeclareKeys`

--- a/doc/user/layouts/partials/create-source/envelope/upsert/details.html
+++ b/doc/user/layouts/partials/create-source/envelope/upsert/details.html
@@ -8,9 +8,9 @@ and can be useful for users who want to compact
 
 The upsert envelope format has slower data ingestion and is more memory intensive
 than other formats. To correctly handle data sources that do not publish their own
-retractions the upsert format must maintain state proportional to the number of
+retractions, in most cases the upsert format must maintain state proportional to the number of
 unique rows in the source, and it must perform extra work to generate the implied
-retractions based on that state.
+retractions based on that state. In some queries on unmaterialized sources, Materialize is able to filter out rows before the upsert occurs, resulting in a smaller amount of state to maintain.
 
 #### Inserts, updates, deletes
 


### PR DESCRIPTION
Add missing operators to EXPLAIN PLAN and correct description of upsert envelope to account for rows filtered out of unmaterialized sources.

### Motivation
 
  * This PR fixes a recognized bug. [#8636]   

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
