### PR TITLE
doc: fix link to SSO app

### DIFF
--- a/doc/developer/scratch.md
+++ b/doc/developer/scratch.md
@@ -16,7 +16,7 @@ the account; if you don't have access and believe you should, check with your on
 If you are a member of a different org but feel that access to AWS resources could
 be useful to you, ask in #eng-infra on Slack.
 
-To access scratch resources from the AWS console, use [our SSO app](materialize.awsapps.com/start/).
+To access scratch resources from the AWS console, use [our SSO app](https://materialize.awsapps.com/start/).
 
 To access scratch resources from the command line, follow the instructions [here](https://github.com/MaterializeInc/i2/blob/main/doc/aws-access.md#cli-and-api-access).
 


### PR DESCRIPTION
Add `https` to the link to SSO app to ensure it does not get treated as a local link.