### PR TITLE
cluster: Add a nightly testdrive task

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -55,3 +55,11 @@
         composition: limits
         run: limits
   timeout_in_minutes: 50
+
+- id: cluster-testdrive
+  label: "Full testdrive against Cluster"
+  plugins:
+    - ./ci/plugins/mzcompose:
+        composition: cluster
+        run: cluster-testdrive
+  timeout_in_minutes: 30

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -89,15 +89,14 @@ steps:
           composition: testdrive
           run: ci
 
-  - id: testdrive-cluster
-    label: ":racing_car: testdrive-cluster"
+  - id: cluster-smoke
+    label: "Cluster smoke test"
     depends_on: build
-    timeout_in_minutes: 30
     inputs: [test/cluster]
     plugins:
       - ./ci/plugins/mzcompose:
           composition: cluster
-          run: cluster
+          run: cluster-smoke
 
   - id: testdrive-proxy
     label: ":squid: testdrive proxy"


### PR DESCRIPTION
Add a task to the nightly CI that runs the entire testdrive test
suite against 2 dataflowd-s, 1 coordd.

Filter out tests that are sensitive to metrics or the contents of the mz_ tables. The rest of the tests are green in CI:

https://buildkite.com/materialize/nightlies/builds/491#5cde1e78-75f3-4b65-9444-5ec322a7ea1a

### Motivation

As per the notes from the last all-hands, we need to fortify coord/dataflowd against regressions introduced during development of the monolithic product. The single .td test in `test/cluster` would not be sufficient to ensure that (e.g. it does not have all possible types of sources), so add a full testdrive run in Nightly.
