### PR TITLE
sql: dispatch to a separate function when planning Expr variants

### DIFF
--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -372,7 +372,7 @@ fn sql_impl_table_func(sql: &'static str) -> Operation<(HirRelationExpr, Scope)>
 
         let query = query::resolve_names(&mut qcx, query)?;
 
-        query::plan_subquery(&mut qcx, &query)
+        query::plan_nested_query(&mut qcx, &query)
     };
 
     Operation::variadic(move |ecx, args| {


### PR DESCRIPTION
### Motivation

When building materialize in debug mode the compiler is not smart enough to re-use stack space between all mutually exclusive paths of execution that lead to each individual enum variant. This has the effect of calculating a stack size for the function that is the *sum* of all local variables.

The function in question was calculated to have a 32kB stack size in debug builds which which adds up quickly when recursing.

The changes of this patch bring this number down to ~7kB.

Related to #9121

### Tips for reviewer

* The diff is much smaller if viewed with whitespace hidden.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
