### PR TITLE
Make `MirRelationExpr::*visit*` methods and HIR ⇒ MIR lowering stack safe

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -4080,7 +4080,7 @@ where
     ) -> Result<OptimizedMirRelationExpr, CoordError> {
         if let ExprPrepStyle::Static = &style {
             let mut opt_expr = self.view_optimizer.optimize(expr)?;
-            opt_expr.0.try_visit_mut(&mut |e| {
+            opt_expr.0.try_visit_mut_post(&mut |e| {
                 // Carefully test filter expressions, which may represent temporal filters.
                 if let expr::MirRelationExpr::Filter { input, predicates } = &*e {
                     let mfp = expr::MapFilterProject::new(input.arity())

--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -140,7 +140,7 @@ impl<'a> DataflowBuilder<'a> {
                             *id,
                         );
                         let mut transformation = source.optimized_expr.clone();
-                        transformation.0.visit_mut(&mut |node| {
+                        transformation.0.visit_mut_post(&mut |node| {
                             match node {
                                 MirRelationExpr::Get { id, .. } if *id == Id::LocalBareSource => {
                                     *id = Id::Global(bare_source_id);

--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -39,7 +39,7 @@ pub use relation::func::{AnalyzedRegex, CaptureGroupDesc};
 pub use relation::join_input_mapper::JoinInputMapper;
 pub use relation::{
     compare_columns, AggregateExpr, ColumnOrder, JoinImplementation, MirRelationExpr,
-    RowSetFinishing,
+    RowSetFinishing, RECURSION_LIMIT,
 };
 pub use scalar::func::{self, BinaryFunc, NullaryFunc, UnaryFunc, VariadicFunc};
 pub use scalar::{like_pattern, EvalError, MirScalarExpr};

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -690,7 +690,7 @@ impl MirRelationExpr {
     pub fn num_inputs(&self) -> usize {
         let mut count = 0;
 
-        self.visit1(|_| count += 1);
+        self.visit_children(|_| count += 1);
 
         count
     }
@@ -983,7 +983,7 @@ impl MirRelationExpr {
         {
             out.push(*id);
         }
-        self.visit1(|expr| expr.global_uses_into(out))
+        self.visit_children(|expr| expr.global_uses_into(out))
     }
 
     /// Pretty-print this MirRelationExpr to a string.
@@ -1147,67 +1147,67 @@ impl MirRelationExpr {
     }
 
     /// Applies a fallible immutable `f` to each child of type `MirRelationExpr`.
-    pub fn try_visit1<'a, F, E>(&'a self, f: F) -> Result<(), E>
+    pub fn try_visit_children<'a, F, E>(&'a self, f: F) -> Result<(), E>
     where
         F: FnMut(&'a MirRelationExpr) -> Result<(), E>,
     {
-        MirRelationExprVisitor::new().try_visit1(self, f)
+        MirRelationExprVisitor::new().try_visit_children(self, f)
     }
 
     /// Applies a fallible mutable `f` to each child of type `MirRelationExpr`.
-    pub fn try_visit1_mut<'a, F, E>(&'a mut self, f: F) -> Result<(), E>
+    pub fn try_visit_mut_children<'a, F, E>(&'a mut self, f: F) -> Result<(), E>
     where
         F: FnMut(&'a mut MirRelationExpr) -> Result<(), E>,
     {
-        MirRelationExprVisitor::new().try_visit1_mut(self, f)
+        MirRelationExprVisitor::new().try_visit_mut_children(self, f)
     }
 
     /// Applies an infallible immutable `f` to each child of type `MirRelationExpr`.
-    pub fn visit1<'a, F>(&'a self, f: F)
+    pub fn visit_children<'a, F>(&'a self, f: F)
     where
         F: FnMut(&'a MirRelationExpr),
     {
-        MirRelationExprVisitor::new().visit1(self, f)
+        MirRelationExprVisitor::new().visit_children(self, f)
     }
 
     /// Applies an infallible mutable `f` to each child of type `MirRelationExpr`.
-    pub fn visit1_mut<'a, F>(&'a mut self, f: F)
+    pub fn visit_mut_children<'a, F>(&'a mut self, f: F)
     where
         F: FnMut(&'a mut MirRelationExpr),
     {
-        MirRelationExprVisitor::new().visit1_mut(self, f)
+        MirRelationExprVisitor::new().visit_mut_children(self, f)
     }
 
     /// Post-order immutable fallible `MirRelationExpr` visitor.
-    pub fn try_visit<'a, F, E>(&'a self, f: &mut F) -> Result<(), E>
+    pub fn try_visit_post<'a, F, E>(&'a self, f: &mut F) -> Result<(), E>
     where
         F: FnMut(&'a MirRelationExpr) -> Result<(), E>,
     {
-        MirRelationExprVisitor::new().try_visit(self, f)
+        MirRelationExprVisitor::new().try_visit_post(self, f)
     }
 
     /// Post-order mutable fallible `MirRelationExpr` visitor.
-    pub fn try_visit_mut<F, E>(&mut self, f: &mut F) -> Result<(), E>
+    pub fn try_visit_mut_post<F, E>(&mut self, f: &mut F) -> Result<(), E>
     where
         F: FnMut(&mut MirRelationExpr) -> Result<(), E>,
     {
-        MirRelationExprVisitor::new().try_visit_mut(self, f)
+        MirRelationExprVisitor::new().try_visit_mut_post(self, f)
     }
 
     /// Post-order immutable infallible `MirRelationExpr` visitor.
-    pub fn visit<'a, F>(&'a self, f: &mut F)
+    pub fn visit_post<'a, F>(&'a self, f: &mut F)
     where
         F: FnMut(&'a MirRelationExpr),
     {
-        MirRelationExprVisitor::new().visit(self, f)
+        MirRelationExprVisitor::new().visit_post(self, f)
     }
 
     /// Post-order mutable infallible `MirRelationExpr` visitor.
-    pub fn visit_mut<F>(&mut self, f: &mut F)
+    pub fn visit_mut_post<F>(&mut self, f: &mut F)
     where
         F: FnMut(&mut MirRelationExpr),
     {
-        MirRelationExprVisitor::new().visit_mut(self, f)
+        MirRelationExprVisitor::new().visit_mut_post(self, f)
     }
 
     /// Pre-order immutable fallible `MirRelationExpr` visitor.
@@ -1242,7 +1242,7 @@ impl MirRelationExpr {
         MirRelationExprVisitor::new().visit_mut_pre(self, f)
     }
 
-    /// A generalization of [`Self::visit_pre`] and [`Self::visit`].
+    /// A generalization of [`Self::visit_pre`] and [`Self::visit_post`].
     ///
     /// The function `pre` runs on a `MirRelationExpr` before it runs on any of the
     /// child `MirRelationExpr`s. The function `post` runs on child `MirRelationExpr`s
@@ -1265,7 +1265,7 @@ impl MirRelationExpr {
     where
         F: FnMut(&mut MirScalarExpr) -> Result<(), E>,
     {
-        MirRelationExprVisitor::new().try_visit_scalars_mut1(self, f)
+        MirRelationExprVisitor::new().try_visit_scalar_children_mut(self, f)
     }
 
     /// Fallible mutable visitor for the [`MirScalarExpr`]s in the [`MirRelationExpr`] subtree rooted at `self`.
@@ -1306,7 +1306,7 @@ impl MirRelationExprVisitor {
     }
 
     /// Applies a fallible immutable `f` to each `expr` child of type `MirRelationExpr`.
-    fn try_visit1<'a, F, E>(&self, expr: &'a MirRelationExpr, mut f: F) -> Result<(), E>
+    fn try_visit_children<'a, F, E>(&self, expr: &'a MirRelationExpr, mut f: F) -> Result<(), E>
     where
         F: FnMut(&'a MirRelationExpr) -> Result<(), E>,
     {
@@ -1358,7 +1358,11 @@ impl MirRelationExprVisitor {
     }
 
     /// Applies a fallible mutable `f` to each `expr` child of type `MirRelationExpr`.
-    fn try_visit1_mut<'a, F, E>(&self, expr: &'a mut MirRelationExpr, mut f: F) -> Result<(), E>
+    fn try_visit_mut_children<'a, F, E>(
+        &self,
+        expr: &'a mut MirRelationExpr,
+        mut f: F,
+    ) -> Result<(), E>
     where
         F: FnMut(&'a mut MirRelationExpr) -> Result<(), E>,
     {
@@ -1410,11 +1414,11 @@ impl MirRelationExprVisitor {
     }
 
     /// Applies an infallible immutable `f` to each `expr` child of type `MirRelationExpr`.
-    fn visit1<'a, F>(&self, expr: &'a MirRelationExpr, mut f: F)
+    fn visit_children<'a, F>(&self, expr: &'a MirRelationExpr, mut f: F)
     where
         F: FnMut(&'a MirRelationExpr),
     {
-        self.try_visit1(expr, |e| {
+        self.try_visit_children(expr, |e| {
             f(e);
             Ok::<_, ()>(())
         })
@@ -1422,11 +1426,11 @@ impl MirRelationExprVisitor {
     }
 
     /// Applies an infallible mutable `f` to each `expr` child of type `MirRelationExpr`.
-    fn visit1_mut<'a, F>(&self, expr: &'a mut MirRelationExpr, mut f: F)
+    fn visit_mut_children<'a, F>(&self, expr: &'a mut MirRelationExpr, mut f: F)
     where
         F: FnMut(&'a mut MirRelationExpr),
     {
-        self.try_visit1_mut(expr, |e| {
+        self.try_visit_mut_children(expr, |e| {
             f(e);
             Ok::<_, ()>(())
         })
@@ -1434,38 +1438,38 @@ impl MirRelationExprVisitor {
     }
 
     /// Post-order immutable fallible `MirRelationExpr` visitor for `expr`.
-    fn try_visit<'a, F, E>(&self, expr: &'a MirRelationExpr, f: &mut F) -> Result<(), E>
+    fn try_visit_post<'a, F, E>(&self, expr: &'a MirRelationExpr, f: &mut F) -> Result<(), E>
     where
         F: FnMut(&'a MirRelationExpr) -> Result<(), E>,
     {
-        self.try_visit1(expr, |e| self.try_visit(e, f))?;
+        self.try_visit_children(expr, |e| self.try_visit_post(e, f))?;
         f(expr)
     }
 
     /// Post-order mutable fallible `MirRelationExpr` visitor for `expr`.
-    fn try_visit_mut<F, E>(&self, expr: &mut MirRelationExpr, f: &mut F) -> Result<(), E>
+    fn try_visit_mut_post<F, E>(&self, expr: &mut MirRelationExpr, f: &mut F) -> Result<(), E>
     where
         F: FnMut(&mut MirRelationExpr) -> Result<(), E>,
     {
-        self.try_visit1_mut(expr, |e| self.try_visit_mut(e, f))?;
+        self.try_visit_mut_children(expr, |e| self.try_visit_mut_post(e, f))?;
         f(expr)
     }
 
     /// Post-order immutable infallible `MirRelationExpr` visitor for `expr`.
-    fn visit<'a, F>(&self, expr: &'a MirRelationExpr, f: &mut F)
+    fn visit_post<'a, F>(&self, expr: &'a MirRelationExpr, f: &mut F)
     where
         F: FnMut(&'a MirRelationExpr),
     {
-        self.visit1(expr, |e| self.visit(e, f));
+        self.visit_children(expr, |e| self.visit_post(e, f));
         f(expr)
     }
 
     /// Post-order mutable infallible `MirRelationExpr` visitor for `expr`.
-    fn visit_mut<F>(&self, expr: &mut MirRelationExpr, f: &mut F)
+    fn visit_mut_post<F>(&self, expr: &mut MirRelationExpr, f: &mut F)
     where
         F: FnMut(&mut MirRelationExpr),
     {
-        self.visit1_mut(expr, |e| self.visit_mut(e, f));
+        self.visit_mut_children(expr, |e| self.visit_mut_post(e, f));
         f(expr)
     }
 
@@ -1475,7 +1479,7 @@ impl MirRelationExprVisitor {
         F: FnMut(&MirRelationExpr) -> Result<(), E>,
     {
         f(expr)?;
-        self.try_visit1(expr, |e| self.try_visit_pre(e, f))
+        self.try_visit_children(expr, |e| self.try_visit_pre(e, f))
     }
 
     /// Pre-order mutable fallible `MirRelationExpr` visitor for `expr`.
@@ -1484,7 +1488,7 @@ impl MirRelationExprVisitor {
         F: FnMut(&mut MirRelationExpr) -> Result<(), E>,
     {
         f(expr)?;
-        self.try_visit1_mut(expr, |e| self.try_visit_mut_pre(e, f))
+        self.try_visit_mut_children(expr, |e| self.try_visit_mut_pre(e, f))
     }
 
     /// Pre-order immutable infallible `MirRelationExpr` visitor for `expr`.
@@ -1493,7 +1497,7 @@ impl MirRelationExprVisitor {
         F: FnMut(&MirRelationExpr),
     {
         f(expr);
-        self.visit1(expr, |e| self.visit_pre(e, f))
+        self.visit_children(expr, |e| self.visit_pre(e, f))
     }
 
     /// Pre-order mutable infallible `MirRelationExpr` visitor for `expr`.
@@ -1502,10 +1506,10 @@ impl MirRelationExprVisitor {
         F: FnMut(&mut MirRelationExpr),
     {
         f(expr);
-        self.visit1_mut(expr, |e| self.visit_mut_pre(e, f))
+        self.visit_mut_children(expr, |e| self.visit_mut_pre(e, f))
     }
 
-    /// A generalization of [`Self::visit_pre`] and [`Self::visit`].
+    /// A generalization of [`Self::visit_pre`] and [`Self::visit_post`].
     ///
     /// The function `pre` runs on a `MirRelationExpr` before it runs on any of the
     /// child `MirRelationExpr`s. The function `post` runs on child `MirRelationExpr`s
@@ -1523,7 +1527,7 @@ impl MirRelationExprVisitor {
                 self.visit_pre_post(e, pre, post);
             }
         } else {
-            self.visit1(expr, |e| self.visit_pre_post(e, pre, post));
+            self.visit_children(expr, |e| self.visit_pre_post(e, pre, post));
         }
         post(expr);
     }
@@ -1531,7 +1535,11 @@ impl MirRelationExprVisitor {
     /// Fallible visitor for the [`MirScalarExpr`]s directly owned by this relation expression.
     ///
     /// The `f` visitor should not recursively descend into owned [`MirRelationExpr`]s.
-    fn try_visit_scalars_mut1<F, E>(&self, expr: &mut MirRelationExpr, f: &mut F) -> Result<(), E>
+    fn try_visit_scalar_children_mut<F, E>(
+        &self,
+        expr: &mut MirRelationExpr,
+        f: &mut F,
+    ) -> Result<(), E>
     where
         F: FnMut(&mut MirScalarExpr) -> Result<(), E>,
     {
@@ -1630,7 +1638,7 @@ impl MirRelationExprVisitor {
     where
         F: FnMut(&mut MirScalarExpr) -> Result<(), E>,
     {
-        self.try_visit_mut(expr, &mut |e| self.try_visit_scalars_mut1(e, f))
+        self.try_visit_mut_post(expr, &mut |e| self.try_visit_scalar_children_mut(e, f))
     }
 
     /// Infallible mutable visitor for the [`MirScalarExpr`]s in the [`MirRelationExpr`] subtree rooted at `expr`.

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -1414,6 +1414,7 @@ impl MirRelationExprVisitor {
     }
 
     /// Applies an infallible immutable `f` to each `expr` child of type `MirRelationExpr`.
+    #[inline(always)]
     fn visit_children<'a, F>(&self, expr: &'a MirRelationExpr, mut f: F)
     where
         F: FnMut(&'a MirRelationExpr),
@@ -1426,6 +1427,7 @@ impl MirRelationExprVisitor {
     }
 
     /// Applies an infallible mutable `f` to each `expr` child of type `MirRelationExpr`.
+    #[inline(always)]
     fn visit_mut_children<'a, F>(&self, expr: &'a mut MirRelationExpr, mut f: F)
     where
         F: FnMut(&'a mut MirRelationExpr),
@@ -1438,6 +1440,7 @@ impl MirRelationExprVisitor {
     }
 
     /// Post-order immutable fallible `MirRelationExpr` visitor for `expr`.
+    #[inline(always)]
     fn try_visit_post<'a, F, E>(&self, expr: &'a MirRelationExpr, f: &mut F) -> Result<(), E>
     where
         F: FnMut(&'a MirRelationExpr) -> Result<(), E>,
@@ -1447,6 +1450,7 @@ impl MirRelationExprVisitor {
     }
 
     /// Post-order mutable fallible `MirRelationExpr` visitor for `expr`.
+    #[inline(always)]
     fn try_visit_mut_post<F, E>(&self, expr: &mut MirRelationExpr, f: &mut F) -> Result<(), E>
     where
         F: FnMut(&mut MirRelationExpr) -> Result<(), E>,
@@ -1456,6 +1460,7 @@ impl MirRelationExprVisitor {
     }
 
     /// Post-order immutable infallible `MirRelationExpr` visitor for `expr`.
+    #[inline(always)]
     fn visit_post<'a, F>(&self, expr: &'a MirRelationExpr, f: &mut F)
     where
         F: FnMut(&'a MirRelationExpr),
@@ -1465,6 +1470,7 @@ impl MirRelationExprVisitor {
     }
 
     /// Post-order mutable infallible `MirRelationExpr` visitor for `expr`.
+    #[inline(always)]
     fn visit_mut_post<F>(&self, expr: &mut MirRelationExpr, f: &mut F)
     where
         F: FnMut(&mut MirRelationExpr),
@@ -1474,6 +1480,7 @@ impl MirRelationExprVisitor {
     }
 
     /// Pre-order immutable fallible `MirRelationExpr` visitor for `expr`.
+    #[inline(always)]
     fn try_visit_pre<F, E>(&self, expr: &MirRelationExpr, f: &mut F) -> Result<(), E>
     where
         F: FnMut(&MirRelationExpr) -> Result<(), E>,
@@ -1483,6 +1490,7 @@ impl MirRelationExprVisitor {
     }
 
     /// Pre-order mutable fallible `MirRelationExpr` visitor for `expr`.
+    #[inline(always)]
     fn try_visit_mut_pre<F, E>(&self, expr: &mut MirRelationExpr, f: &mut F) -> Result<(), E>
     where
         F: FnMut(&mut MirRelationExpr) -> Result<(), E>,
@@ -1492,6 +1500,7 @@ impl MirRelationExprVisitor {
     }
 
     /// Pre-order immutable infallible `MirRelationExpr` visitor for `expr`.
+    #[inline(always)]
     fn visit_pre<F>(&self, expr: &MirRelationExpr, f: &mut F)
     where
         F: FnMut(&MirRelationExpr),
@@ -1501,6 +1510,7 @@ impl MirRelationExprVisitor {
     }
 
     /// Pre-order mutable infallible `MirRelationExpr` visitor for `expr`.
+    #[inline(always)]
     fn visit_mut_pre<F>(&self, expr: &mut MirRelationExpr, f: &mut F)
     where
         F: FnMut(&mut MirRelationExpr),
@@ -1517,6 +1527,7 @@ impl MirRelationExprVisitor {
     ///
     /// Optionally, `pre` can return which child `MirRelationExpr`s, if any, should be
     /// visited (default is to visit all children).
+    #[inline(always)]
     fn visit_pre_post<F1, F2>(&self, expr: &MirRelationExpr, pre: &mut F1, post: &mut F2)
     where
         F1: FnMut(&MirRelationExpr) -> Option<Vec<&MirRelationExpr>>,
@@ -1535,6 +1546,7 @@ impl MirRelationExprVisitor {
     /// Fallible visitor for the [`MirScalarExpr`]s directly owned by this relation expression.
     ///
     /// The `f` visitor should not recursively descend into owned [`MirRelationExpr`]s.
+    #[inline(always)]
     fn try_visit_scalar_children_mut<F, E>(
         &self,
         expr: &mut MirRelationExpr,
@@ -1634,6 +1646,7 @@ impl MirRelationExprVisitor {
     /// Fallible mutable visitor for all [`MirScalarExpr`]s in the [`MirRelationExpr`] subtree rooted at `expr`.
     ///
     /// Note that this does not recurse into [`MirRelationExpr`] subtrees wrapped in [`MirScalarExpr`] nodes.
+    #[inline(always)]
     fn try_visit_scalars_mut<F, E>(&self, expr: &mut MirRelationExpr, f: &mut F) -> Result<(), E>
     where
         F: FnMut(&mut MirScalarExpr) -> Result<(), E>,
@@ -1644,6 +1657,7 @@ impl MirRelationExprVisitor {
     /// Infallible mutable visitor for the [`MirScalarExpr`]s in the [`MirRelationExpr`] subtree rooted at `expr`.
     ///
     /// Note that this does not recurse into [`MirRelationExpr`] subtrees within [`MirScalarExpr`] nodes.
+    #[inline(always)]
     fn visit_scalars_mut<F>(&self, expr: &mut MirRelationExpr, f: &mut F)
     where
         F: FnMut(&mut MirScalarExpr),

--- a/src/ore/src/stack.rs
+++ b/src/ore/src/stack.rs
@@ -92,6 +92,7 @@ pub const STACK_SIZE: usize = {
 /// stack growth. Not all recursive code paths support returning errors,
 /// however, in which case unconditionally growing the stack with this function
 /// is still preferable to panicking.
+#[inline(always)]
 pub fn maybe_grow<F, R>(f: F) -> R
 where
     F: FnOnce() -> R,
@@ -180,6 +181,7 @@ pub trait CheckedRecursion {
     ///
     /// Calls to this function must be manually inserted at any point that
     /// mutual recursion occurs.
+    #[inline(always)]
     fn checked_recur<F, T, E>(&self, f: F) -> Result<T, E>
     where
         F: FnOnce(&Self) -> Result<T, E>,
@@ -193,6 +195,7 @@ pub trait CheckedRecursion {
 
     /// Like [`CheckedRecursion::checked_recur`], but operates on a mutable
     /// reference to `Self`.
+    #[inline(always)]
     fn checked_recur_mut<F, T, E>(&mut self, f: F) -> Result<T, E>
     where
         F: FnOnce(&mut Self) -> Result<T, E>,

--- a/src/ore/src/stack.rs
+++ b/src/ore/src/stack.rs
@@ -230,7 +230,7 @@ impl RecursionGuard {
             *depth += 1;
             Ok(())
         } else {
-            Err(RecursionLimitError)
+            Err(RecursionLimitError { limit: self.limit })
         }
     }
 
@@ -241,11 +241,13 @@ impl RecursionGuard {
 
 /// A [`RecursionGuard`]'s recursion limit was reached.
 #[derive(Clone, Debug)]
-pub struct RecursionLimitError;
+pub struct RecursionLimitError {
+    limit: usize,
+}
 
 impl fmt::Display for RecursionLimitError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("recursion limit exceeded")
+        write!(f, "exceeded recursion limit of {}", self.limit)
     }
 }
 

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -360,6 +360,7 @@ impl ErrorResponse {
             CoordError::PreparedStatementExists(_) => SqlState::DUPLICATE_PSTATEMENT,
             CoordError::ReadOnlyTransaction => SqlState::READ_ONLY_SQL_TRANSACTION,
             CoordError::ReadOnlyParameter(_) => SqlState::CANT_CHANGE_RUNTIME_PARAM,
+            CoordError::RecursionLimit(_) => SqlState::INTERNAL_ERROR,
             CoordError::RelationOutsideTimeDomain { .. } => SqlState::INVALID_TRANSACTION_STATE,
             CoordError::SafeModeViolation(_) => SqlState::INTERNAL_ERROR,
             CoordError::SqlCatalog(_) => SqlState::INTERNAL_ERROR,

--- a/src/transform/src/canonicalize_mfp.rs
+++ b/src/transform/src/canonicalize_mfp.rs
@@ -55,7 +55,7 @@ impl crate::Transform for CanonicalizeMfp {
 impl CanonicalizeMfp {
     fn action(&self, relation: &mut MirRelationExpr) {
         let mut mfp = expr::MapFilterProject::extract_non_errors_from_expr_mut(relation);
-        relation.visit1_mut(|e| self.action(e));
+        relation.visit_mut_children(|e| self.action(e));
         mfp.optimize();
         if !mfp.is_identity() {
             let (map, mut filter, project) = mfp.as_map_filter_project();

--- a/src/transform/src/cse/relation_cse.rs
+++ b/src/transform/src/cse/relation_cse.rs
@@ -88,7 +88,7 @@ impl Bindings {
 
             _ => {
                 // All other expressions just need to apply the logic recursively.
-                relation.visit1_mut(&mut |expr| {
+                relation.visit_mut_children(&mut |expr| {
                     self.intern_expression(expr);
                 })
             }

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -124,7 +124,7 @@ fn inline_views(dataflow: &mut DataflowDesc) {
             dataflow.objects_to_build[other]
                 .view
                 .as_inner_mut()
-                .visit_mut(&mut |expr| {
+                .visit_mut_post(&mut |expr| {
                     if let MirRelationExpr::Get { id, .. } = expr {
                         if id == &Id::Global(global_id) {
                             *id = Id::Local(new_local);
@@ -421,7 +421,7 @@ pub mod monotonic {
             // The default behavior.
             // TODO: check that this is the behavior we want.
             MirRelationExpr::Negate { .. } | MirRelationExpr::Constant { rows: Err(_), .. } => {
-                expr.visit1_mut(|e| {
+                expr.visit_mut_children(|e| {
                     is_monotonic(e, sources, locals);
                 });
                 false

--- a/src/transform/src/fusion/join.rs
+++ b/src/transform/src/fusion/join.rs
@@ -38,7 +38,7 @@ impl crate::Transform for Join {
         relation: &mut MirRelationExpr,
         _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
-        relation.visit_mut(&mut |e| {
+        relation.visit_mut_post(&mut |e| {
             self.action(e);
         });
         Ok(())

--- a/src/transform/src/fusion/union.rs
+++ b/src/transform/src/fusion/union.rs
@@ -28,7 +28,7 @@ impl crate::Transform for Union {
         relation: &mut MirRelationExpr,
         _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
-        relation.visit_mut(&mut |e| {
+        relation.visit_mut_post(&mut |e| {
             self.action(e);
         });
         Ok(())

--- a/src/transform/src/inline_let.rs
+++ b/src/transform/src/inline_let.rs
@@ -102,7 +102,7 @@ impl InlineLet {
             // might be another Let in the body so have to recur here
             self.action(relation, lets);
         } else {
-            relation.visit1_mut(|child| self.action(child, lets));
+            relation.visit_mut_children(|child| self.action(child, lets));
         }
     }
 }

--- a/src/transform/src/join_implementation.rs
+++ b/src/transform/src/join_implementation.rs
@@ -68,7 +68,7 @@ impl JoinImplementation {
             self.action_recursive(body, arranged);
             arranged.remove(&Id::Local(*id));
         } else {
-            relation.visit1_mut(|e| self.action_recursive(e, arranged));
+            relation.visit_mut_children(|e| self.action_recursive(e, arranged));
             self.action(relation, arranged);
         }
     }

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -127,7 +127,7 @@ impl Transform for Fixpoint {
         // stable shape.
         loop {
             let mut original_count = 0;
-            relation.visit(&mut |_| original_count += 1);
+            relation.visit_post(&mut |_| original_count += 1);
             for _ in 0..self.limit {
                 let original = relation.clone();
                 for transform in self.transforms.iter() {
@@ -144,7 +144,7 @@ impl Transform for Fixpoint {
                 }
             }
             let mut final_count = 0;
-            relation.visit(&mut |_| final_count += 1);
+            relation.visit_post(&mut |_| final_count += 1);
             if final_count >= original_count {
                 break;
             }

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -54,6 +54,7 @@ pub mod update_let;
 
 pub mod dataflow;
 pub use dataflow::optimize_dataflow;
+use ore::stack::RecursionLimitError;
 
 /// Arguments that get threaded through all transforms.
 #[derive(Debug)]
@@ -97,6 +98,12 @@ impl fmt::Display for TransformError {
 }
 
 impl Error for TransformError {}
+
+impl From<RecursionLimitError> for TransformError {
+    fn from(error: RecursionLimitError) -> Self {
+        TransformError::Internal(error.to_string())
+    }
+}
 
 /// A sequence of transformations iterated some number of times.
 #[derive(Debug)]

--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -410,7 +410,7 @@ impl PredicatePushdown {
                         self.action(relation, get_predicates);
                     }
                     x => {
-                        x.visit1_mut(|e| self.action(e, get_predicates));
+                        x.visit_mut_children(|e| self.action(e, get_predicates));
                     }
                 }
 
@@ -439,7 +439,7 @@ impl PredicatePushdown {
                 if let Some(list) = get_predicates.remove(&Id::Local(*id)) {
                     if !list.is_empty() {
                         // Remove the predicates in `list` from the body.
-                        body.visit_mut(&mut |e| {
+                        body.visit_mut_post(&mut |e| {
                             if let MirRelationExpr::Filter { input, predicates } = e {
                                 if let MirRelationExpr::Get { id: get_id, .. } = **input {
                                     if get_id == Id::Local(*id) {
@@ -694,7 +694,7 @@ impl PredicatePushdown {
             }
             x => {
                 // Recursively descend.
-                x.visit1_mut(|e| self.action(e, get_predicates));
+                x.visit_mut_children(|e| self.action(e, get_predicates));
             }
         }
     }

--- a/src/transform/src/projection_extraction.rs
+++ b/src/transform/src/projection_extraction.rs
@@ -23,7 +23,7 @@ impl crate::Transform for ProjectionExtraction {
         relation: &mut MirRelationExpr,
         _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
-        relation.visit_mut(&mut |e| {
+        relation.visit_mut_post(&mut |e| {
             self.action(e);
         });
         Ok(())

--- a/src/transform/src/reduce_elision.rs
+++ b/src/transform/src/reduce_elision.rs
@@ -27,7 +27,7 @@ impl crate::Transform for ReduceElision {
         relation: &mut MirRelationExpr,
         _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
-        relation.visit_mut(&mut |e| self.action(e));
+        relation.visit_mut_post(&mut |e| self.action(e));
         Ok(())
     }
 }

--- a/src/transform/src/reduction.rs
+++ b/src/transform/src/reduction.rs
@@ -37,7 +37,7 @@ impl crate::Transform for FoldConstants {
         _: TransformArgs,
     ) -> Result<(), TransformError> {
         let mut type_stack = Vec::new();
-        relation.try_visit_mut(&mut |e| -> Result<(), TransformError> {
+        relation.try_visit_mut_post(&mut |e| -> Result<(), TransformError> {
             let num_inputs = e.num_inputs();
             let input_types = &type_stack[type_stack.len() - num_inputs..];
             let mut relation_type = e.typ_with_input_types(input_types);

--- a/src/transform/src/reduction_pushdown.rs
+++ b/src/transform/src/reduction_pushdown.rs
@@ -24,7 +24,7 @@ impl crate::Transform for ReductionPushdown {
         relation: &mut MirRelationExpr,
         _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
-        relation.visit_mut(&mut |e| {
+        relation.visit_mut_post(&mut |e| {
             self.action(e);
         });
         Ok(())

--- a/src/transform/src/topk_elision.rs
+++ b/src/transform/src/topk_elision.rs
@@ -22,7 +22,7 @@ impl crate::Transform for TopKElision {
         relation: &mut MirRelationExpr,
         _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
-        relation.visit_mut(&mut |e| {
+        relation.visit_mut_post(&mut |e| {
             self.action(e);
         });
         Ok(())

--- a/src/transform/src/union_cancel.rs
+++ b/src/transform/src/union_cancel.rs
@@ -23,7 +23,7 @@ impl crate::Transform for UnionBranchCancellation {
         relation: &mut MirRelationExpr,
         _: TransformArgs,
     ) -> Result<(), TransformError> {
-        relation.try_visit_mut(&mut |e| self.action(e))
+        relation.try_visit_mut_post(&mut |e| self.action(e))
     }
 }
 

--- a/src/transform/src/update_let.rs
+++ b/src/transform/src/update_let.rs
@@ -68,7 +68,7 @@ impl UpdateLet {
                 }
             }
             _ => {
-                relation.visit1_mut(&mut |e| self.action(e, remap, id_gen));
+                relation.visit_mut_children(&mut |e| self.action(e, remap, id_gen));
             }
         }
     }


### PR DESCRIPTION
Implements the following towards making progress on #9000.
- Stack-safe lowering from HIR to MIR.
- Stack-safe `*visit*` method in MIR.

This fixes the following issues reported in #9000
- #8598, 
- #8600,
- #8601.

However, rather than auto-closing these, I agreed to re-assign them to @philip-stoev who will close those after adding tests that validate the fix once we have the follow-up PRs merged.

<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

See #9000.

### Tips for reviewer

The commits are structured in groups that can be reviewed independently. The suggested reviewer is noted at the end of each group. @philip-stoev will and add tests based on the fixed issues to our automation pipeline.

#### Minor improvements to `ore::stack` (@benesch)
- [ore: report exceeded limit in `RecursionLimitError`](https://github.com/MaterializeInc/materialize/pull/9188/commits/b600d0504)
- [ore: inline calls to `fn` items defined in `ore::stack`](https://github.com/MaterializeInc/materialize/pull/9188/commits/2af9bd0ef)

#### Prepare `MirRelationExpr` for the introduction of a `RecursionGuard` (@asenac)
- [coord,pgwire,transform: convert `RecursionLimitError` to other types](https://github.com/MaterializeInc/materialize/pull/9188/commits/59137fc1c)
- [expr: factor out `MirRelationExpr` visitors in a dedicated struct](https://github.com/MaterializeInc/materialize/pull/9188/commits/1399caebb)
- [expr: make `MirRelationExpr::*visit*` method names consistent](https://github.com/MaterializeInc/materialize/pull/9188/commits/9ed9bb013)
- [expr: inline most `MirRelationExprVisitor::*visit*` methods](https://github.com/MaterializeInc/materialize/pull/9188/commits/56cfec60d)

#### Make some transforms stack-safe (@asenac)
- [expr: make `try_visit_children` stack safe](https://github.com/MaterializeInc/materialize/pull/9188/commits/9028c37b2)
- [expr: make `try_visit_mut_children` stack safe](https://github.com/MaterializeInc/materialize/pull/9188/commits/e88e38367)
- [sql: make HIR to MIR lowering stack safe](https://github.com/MaterializeInc/materialize/pull/9188/commits/9f3baf974)
### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
