### PR TITLE
sql: fix an error in splice_parameters in handling nested queries.

### DIFF
--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -1314,7 +1314,11 @@ impl HirScalarExpr {
                 *e = params[*i - 1].clone();
                 // Correct any column references in the parameter expression for
                 // its new depth.
-                e.visit_columns(0, &mut |_, col| col.level += depth);
+                e.visit_columns(0, &mut |d, col| {
+                    if col.level >= d {
+                        col.level += depth
+                    }
+                });
             }
             HirScalarExpr::Exists(e) | HirScalarExpr::Select(e) => {
                 e.splice_parameters(params, depth + 1)

--- a/test/sqllogictest/types.slt
+++ b/test/sqllogictest/types.slt
@@ -429,6 +429,11 @@ SELECT a::regproc FROM text_to_regproc ORDER BY a
 750
 NULL
 
+query I
+select 'now'::regproc::oid::text::regproc
+----
+1299
+
 # 🔬🔬🔬 oid alias
 
 query T
@@ -900,3 +905,8 @@ SELECT a::regtype FROM text_to_regtype ORDER BY a
 ----
 1082
 NULL
+
+query I
+select 'date'::regtype::oid::text::regtype
+----
+1082

--- a/test/sqllogictest/types.slt
+++ b/test/sqllogictest/types.slt
@@ -429,6 +429,7 @@ SELECT a::regproc FROM text_to_regproc ORDER BY a
 750
 NULL
 
+# Regression for 9194
 query I
 select 'now'::regproc::oid::text::regproc
 ----
@@ -906,6 +907,7 @@ SELECT a::regtype FROM text_to_regtype ORDER BY a
 1082
 NULL
 
+# Regression for 9194
 query I
 select 'date'::regtype::oid::text::regtype
 ----


### PR DESCRIPTION
<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

Fix an error in `splice_parameters` in handling nested queries.

### Motivation

This change is required to support pgcli.

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

Before my fix to the depth, the following query plan was generated:
```
 | | | | | | %3 =                                                                                                                                                                             +
 | | | | | | | Get mz_catalog.mz_types (s4027)                                                                                                                                                +
 | | | | | | | Filter (#^3 = "bool")                                                                                                                                                          +
 | | | | | | | Map oidtoregtype(#^1)                                                                                                                                                          +
 | | | | | | | Project (#4)  
```

whereby the correct plan is:
```
materialize=> explain raw plan for select 'bool'::regtype::text;
                                                                                           Raw Plan                                                                                            
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 %0 =                                                                                                                                                                                         +
 | Constant ()                                                                                                                                                                                +
 | Map select(%1)                                                                                                                                                                             +
 | |                                                                                                                                                                                          +
 | | %1 =                                                                                                                                                                                     +
 | | | Get mz_catalog.mz_types (s4027)                                                                                                                                                        +
 | | | Filter (#1 = regtypetooid(select(%2)))                                                                                                                                                 +
 | | | |                                                                                                                                                                                      +
 | | | | %2 =                                                                                                                                                                                 +
 | | | | | Constant ()                                                                                                                                                                        +
 | | | | | Map if isnull("bool") then {null} els {if ("bool" ~ "^\d+$") then {i32toregtype(strtoi32("bool"))} els {error_if_null(select(%3), (("type \"" || "bool") || "\" does not exist"))}}+
 | | | | | |                                                                                                                                                                                  +
 | | | | | | %3 =                                                                                                                                                                             +
 | | | | | | | Get mz_catalog.mz_types (s4027)                                                                                                                                                +
 | | | | | | | Filter (#3 = "bool")                                                                                                                                                           +
 | | | | | | | Map oidtoregtype(#1)                                                                                                                                                           +
 | | | | | | | Project (#4)                                                                                                                                                                   +
 | | | | | |                                                                                                                                                                                  +
 | | | |                                                                                                                                                                                      +
 | | | Project (#3)                                                                                                                                                                           +
 | |         
```
