### PR TITLE
sql: fix generate_series_id oid to match PG

### DIFF
--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1988,7 +1988,7 @@ lazy_static! {
                         exprs,
                         column_names: vec![Some("generate_series".into())],
                     })
-                }), 1066;
+                }), 1068;
             },
             "jsonb_array_elements" => Table {
                 params!(Jsonb) => Operation::unary(move |_ecx, jsonb| {

--- a/test/sqllogictest/types.slt
+++ b/test/sqllogictest/types.slt
@@ -912,3 +912,8 @@ query I
 select 'date'::regtype::oid::text::regtype
 ----
 1082
+
+# Make sure that there are no functions with duplicate OIDs
+query I
+select oid from (select count(*) as cnt, oid from mz_catalog.mz_functions group by oid) where cnt>1
+----


### PR DESCRIPTION
<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

fix generate_series_id oid to match PG

This is expected state in PG:
```
martin=# select oid,typname from pg_catalog.pg_type where oid in (20, 23);
 oid | typname 
-----+---------
  20 | int8
  23 | int4
(2 rows)
martin=# select oid, proname, proargtypes from pg_catalog.pg_proc where proname like '%generate_series%' and pronargs=3;
 oid  |     proname     |  proargtypes   
------+-----------------+----------------
 1066 | generate_series | 23 23 23
 1068 | generate_series | 20 20 20
 3259 | generate_series | 1700 1700 1700
  938 | generate_series | 1114 1114 1186
  939 | generate_series | 1184 1184 1186
(5 rows)
```

this is pre-change MZ:
```
materialize=> select * from mz_catalog.mz_types where oid in (20,23);
  id   | oid | schema_id | name 
-------+-----+-----------+------
 s1002 |  20 |         2 | int8
 s1003 |  23 |         2 | int4
(2 rows)

materialize=> select * from mz_catalog.mz_functions where name like '%generate_series%';
  id   | oid  | schema_id |      name       |       arg_ids       | variadic_id 
-------+------+-----------+-----------------+---------------------+-------------
 s2040 | 1067 |         2 | generate_series | {s1003,s1003}       | 
 s2040 | 1069 |         2 | generate_series | {s1002,s1002}       | 
 s2040 | 1066 |         2 | generate_series | {s1002,s1002,s1002} | 
 s2040 | 1066 |         2 | generate_series | {s1003,s1003,s1003} | 
(4 rows)
```

post-change:
```
materialize=> select * from mz_catalog.mz_types where oid in (20,23);
  id   | oid | schema_id | name 
-------+-----+-----------+------
 s1002 |  20 |         2 | int8
 s1003 |  23 |         2 | int4
(2 rows)

materialize=> select * from mz_catalog.mz_functions where name like '%generate_series%';
  id   | oid  | schema_id |      name       |       arg_ids       | variadic_id 
-------+------+-----------+-----------------+---------------------+-------------
 s2016 | 1067 |         2 | generate_series | {s1003,s1003}       | 
 s2016 | 1069 |         2 | generate_series | {s1002,s1002}       | 
 s2016 | 1066 |         2 | generate_series | {s1003,s1003,s1003} | 
 s2016 | 1068 |         2 | generate_series | {s1002,s1002,s1002} | 
(4 rows)

```

### Motivation

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug. [Link to issue.]

  * This PR adds a known-desirable feature. [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

Duplicate records cause problems with type casting. This query has to return null:
```
materialize=> select cnt, oid from (select count(*) as cnt, oid from mz_catalog.mz_functions group by oid) where cnt>1;
 cnt | oid 
-----+-----
(0 rows)
```
