### PR TITLE
doc: Add note about Aurora Serverless to CDC guide

### DIFF
--- a/doc/user/content/guides/cdc-postgres.md
+++ b/doc/user/content/guides/cdc-postgres.md
@@ -37,7 +37,7 @@ As a _superuser_:
 
     The default value is `replica`. For CDC, you'll need to set it to `logical` in the database configuration file (`postgresql.conf`). Keep in mind that changing the `wal_level` requires a restart of the Postgres instance and can affect database performance.
 
-    **Note:** If you're using Postgres on a Cloud service like Amazon RDS, AWS Aurora, or Cloud SQL, you'll need to take some additional steps. For more information, see [Postgres in the Cloud](../postgres-cloud/).
+    **Note:** If you're using Postgres on a Cloud service like Amazon RDS, AWS Aurora, or Cloud SQL, you'll need to take some additional steps. For more information, see [Postgres in the cloud](../postgres-cloud/).
 
 1. Grant the required privileges to the replication user:
 

--- a/doc/user/content/guides/postgres-cloud.md
+++ b/doc/user/content/guides/postgres-cloud.md
@@ -1,5 +1,5 @@
 ---
-title: "Postgres CDC in the cloud"
+title: "Postgres CDC in the Cloud"
 description: "How to configure Postgres CDC for instances hosted on cloud services"
 weight:
 aliases:

--- a/doc/user/content/guides/postgres-cloud.md
+++ b/doc/user/content/guides/postgres-cloud.md
@@ -1,16 +1,13 @@
 ---
-title: "Postgres in the Cloud"
-description: "How to configure Postgres CDC hosted on Cloud services"
+title: "Postgres CDC in the cloud"
+description: "How to configure Postgres CDC for instances hosted on cloud services"
 weight:
-menu:
-  main:
-    parent: guides
 aliases:
 ---
 
 **Required:** PostgreSQL 10+
 
-It is possible to use a PostgreSQL database running on Amazon RDS, AWS Aurora, or Cloud SQL for [Change Data Capture](../cdc-postgres/) with Materialize, but it requires enabling logical replication in your PostgreSQL instances.
+To use a PostgreSQL instance running on Amazon RDS, AWS Aurora, or Cloud SQL for [Change Data Capture](../cdc-postgres/), you need to ensure that the database is configured to support logical replication.
 
 Note that enabling logical replication may affect performance.
 
@@ -49,6 +46,10 @@ As an account with the `rds_superuser` role, make these changes to the upstream 
 For more information, see the [Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts.General.FeatureSupport.LogicalReplication) documentation.
 
 ## AWS Aurora
+
+{{< note >}}
+Aurora Serverless (v1) [does **not** support](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless.html#aurora-serverless.limitations) logical replication, so it's not possible to use this configuration for Postgres CDC.
+{{</ note >}}
 
 As a superuser, make these changes to the upstream database:
 


### PR DESCRIPTION
Adding a note about Amazon Aurora serverless instances to the Postgres CDC guide (motivated by [this thread](https://materializecommunity.slack.com/archives/C015KDVS7EV/p1637391157191700)). I don't think the detail page should be listed in the Guides menu, as it can be confusing, so also suggesting we simply keep it linked from the main guide page.

@msudberg, we should also work on a page with instructions for MySQL and link it from the MySQL CDC guide.