### PR TITLE
transform: allow transforms to hold thread local state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5493,7 +5493,6 @@ dependencies = [
  "expr",
  "expr_test_util",
  "itertools",
- "lazy_static",
  "lowertest",
  "ore",
  "proc-macro2",

--- a/src/transform/Cargo.toml
+++ b/src/transform/Cargo.toml
@@ -17,7 +17,6 @@ repr = { path = "../repr" }
 anyhow = "1.0.47"
 datadriven = "0.6.0"
 expr_test_util = {path = "../expr-test-util"}
-lazy_static = "1.4.0"
 lowertest = {path = "../lowertest"}
 ore = { path = "../ore"}
 proc-macro2 = "1.0.30"

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -101,7 +101,7 @@ impl Error for TransformError {}
 /// A sequence of transformations iterated some number of times.
 #[derive(Debug)]
 pub struct Fixpoint {
-    transforms: Vec<Box<dyn crate::Transform + Send + Sync>>,
+    transforms: Vec<Box<dyn crate::Transform>>,
     limit: usize,
 }
 
@@ -162,7 +162,7 @@ impl Transform for Fixpoint {
 /// A sequence of transformations that simplify the `MirRelationExpr`
 #[derive(Debug)]
 pub struct FuseAndCollapse {
-    transforms: Vec<Box<dyn crate::Transform + Send + Sync>>,
+    transforms: Vec<Box<dyn crate::Transform>>,
 }
 
 impl Default for FuseAndCollapse {
@@ -240,13 +240,13 @@ impl Transform for FuseAndCollapse {
 #[derive(Debug)]
 pub struct Optimizer {
     /// The list of transforms to apply to an input relation.
-    pub transforms: Vec<Box<dyn crate::Transform + Send + Sync>>,
+    pub transforms: Vec<Box<dyn crate::Transform>>,
 }
 
 impl Optimizer {
     /// Builds a logical optimizer that only performs logical transformations.
     pub fn logical_optimizer() -> Self {
-        let transforms: Vec<Box<dyn crate::Transform + Send + Sync>> = vec![
+        let transforms: Vec<Box<dyn crate::Transform>> = vec![
             // 1. Structure-agnostic cleanup
             Box::new(crate::topk_elision::TopKElision),
             Box::new(crate::nonnull_requirements::NonNullRequirements),
@@ -309,7 +309,7 @@ impl Optimizer {
     /// rendering.
     pub fn physical_optimizer() -> Self {
         // Implementation transformations
-        let transforms: Vec<Box<dyn crate::Transform + Send + Sync>> = vec![
+        let transforms: Vec<Box<dyn crate::Transform>> = vec![
             Box::new(crate::Fixpoint {
                 limit: 100,
                 transforms: vec![
@@ -335,7 +335,7 @@ impl Optimizer {
     /// Contains the logical optimizations that should run after cross-view
     /// transformations run.
     pub fn logical_cleanup_pass() -> Self {
-        let transforms: Vec<Box<dyn crate::Transform + Send + Sync>> = vec![
+        let transforms: Vec<Box<dyn crate::Transform>> = vec![
             // Delete unnecessary maps.
             Box::new(crate::fusion::map::Map),
             Box::new(crate::Fixpoint {


### PR DESCRIPTION
### Motivation

The bounds seem to be been added for constructing a lazy static vector but the same can be accomplished with the thread_local macro