### PR TITLE
persist: fix s3_blob test rust dependency

### DIFF
--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -34,7 +34,7 @@ ore = { path = "../ore", default-features = false, features = ["metrics"] }
 persist-types = { path = "../persist-types" }
 serde = { version = "1.0.130", features = ["derive"] }
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
-tokio = { version = "1.13.0", default-features = false, features = ["macros", "sync", "rt"] }
+tokio = { version = "1.13.0", default-features = false, features = ["macros", "sync", "rt", "rt-multi-thread"] }
 uuid = { version = "0.8.2", features = ["v4"] }
 
 [dev-dependencies]


### PR DESCRIPTION
<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

Add missing persist dependency

### Motivation

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug. [Link to issue.]

  * This PR adds a known-desirable feature. [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

Without this change, the persist crate won't compile with the error:
```
error: The runtime flavor `multi_thread` requires the `rt-multi-thread` feature.
```

I had to delete `~/.cargo/registry` and subsequent builds would fail consistently