### PR TITLE
demo/billing: deflake

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -161,7 +161,7 @@ steps:
           run: sqllogictest-fast
 
   - id: streaming-demo
-    label: ":shower: protobuf kafka streaming-demo"
+    label: ":credit_card: billing demo"
     depends_on: build
     timeout_in_minutes: 30
     plugins:

--- a/demo/billing/src/main.rs
+++ b/demo/billing/src/main.rs
@@ -169,7 +169,7 @@ async fn create_materialized_source(config: MzConfig) -> Result<()> {
             &config.kafka_url,
             &config.kafka_topic,
             config::KAFKA_SOURCE_NAME,
-            "billing.Batch",
+            ".billing.Batch",
             config.enable_persistence,
         )
         .await?;

--- a/demo/billing/src/mz.rs
+++ b/demo/billing/src/mz.rs
@@ -165,6 +165,10 @@ pub async fn validate_sink(
                 .await?
                 .get(0);
 
+            if count_input_view == 0 {
+                bail!("source is still loading");
+            }
+
             if count_check_sink != count_input_view {
                 bail!(
                     "Expected check_sink view to have {} rows, found {}",


### PR DESCRIPTION
At some point in the past, we started requiring the message name in a
protobuf source to start with a leading dot. This broke the billing
demo, which was never updated for the new syntax. This commit corrects
the error.

Also fix the billing demo's smoke test, which runs in CI, to avoid
incorrectly succeeding in the trivial case where no data has yet been
loaded. The smoke test now waits for at least *some* data to load before
asserting that the input and output to the sink have the same number of
records. With this change in place, the test would have reliably failed
in the precense of the above bug.

Also also, rename the CI job from "protobuf kafka streaming-demo" to
"billing demo" to reflect its name elsewhere in the codebase. The name
"billing demo" seems to have won out in the vernacular.

<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
