### PR TITLE
dataflow: statically enforce that byte sources don't have keys

### DIFF
--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -397,7 +397,6 @@ where
                                 ),
                                 SourceType::ByteStream(source) => render_decode(
                                     &source,
-                                    key_encoding,
                                     value_encoding,
                                     &self.debug_name,
                                     &envelope,

--- a/src/dataflow/src/source/file.rs
+++ b/src/dataflow/src/source/file.rs
@@ -62,7 +62,8 @@ impl From<FileOffset> for MzOffset {
 }
 
 impl SourceReader for FileSourceReader {
-    type Payload = MessagePayload;
+    type Key = ();
+    type Value = MessagePayload;
 
     fn new(
         _name: String,
@@ -165,7 +166,7 @@ impl SourceReader for FileSourceReader {
         ))
     }
 
-    fn get_next_message(&mut self) -> Result<NextMessage<Self::Payload>, anyhow::Error> {
+    fn get_next_message(&mut self) -> Result<NextMessage<Self::Key, Self::Value>, anyhow::Error> {
         match self.receiver_stream.try_recv() {
             Ok(Ok(record)) => {
                 self.current_file_offset.offset += 1;
@@ -173,8 +174,8 @@ impl SourceReader for FileSourceReader {
                     partition: PartitionId::None,
                     offset: self.current_file_offset.into(),
                     upstream_time_millis: None,
-                    key: None,
-                    payload: record,
+                    key: (),
+                    value: record,
                 };
                 Ok(NextMessage::Ready(message))
             }

--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -63,7 +63,8 @@ pub struct KafkaSourceReader {
 }
 
 impl SourceReader for KafkaSourceReader {
-    type Payload = Option<Vec<u8>>;
+    type Key = Option<Vec<u8>>;
+    type Value = Option<Vec<u8>>;
 
     /// Create a new instance of a Kafka reader.
     fn new(
@@ -150,7 +151,7 @@ impl SourceReader for KafkaSourceReader {
     ///
     /// If a message has an offset that is smaller than the next expected offset for this consumer (and this partition)
     /// we skip this message, and seek to the appropriate offset
-    fn get_next_message(&mut self) -> Result<NextMessage<Self::Payload>, anyhow::Error> {
+    fn get_next_message(&mut self) -> Result<NextMessage<Self::Key, Self::Value>, anyhow::Error> {
         // Poll the consumer once. Since we split the consumer's partitions out into separate queues and poll those individually,
         // we expect this poll to always return None - but it's necessary to drive logic that consumes from rdkafka's internal
         // event queue, such as statistics callbacks.
@@ -501,17 +502,17 @@ fn create_kafka_config(
     kafka_config
 }
 
-impl<'a> From<&BorrowedMessage<'a>> for SourceMessage<Option<Vec<u8>>> {
+impl<'a> From<&BorrowedMessage<'a>> for SourceMessage<Option<Vec<u8>>, Option<Vec<u8>>> {
     fn from(msg: &BorrowedMessage<'a>) -> Self {
         let kafka_offset = KafkaOffset {
             offset: msg.offset(),
         };
         Self {
-            payload: msg.payload().map(|p| p.to_vec()),
             partition: PartitionId::Kafka(msg.partition()),
             offset: kafka_offset.into(),
             upstream_time_millis: msg.timestamp().to_millis(),
             key: msg.key().map(|k| k.to_vec()),
+            value: msg.payload().map(|p| p.to_vec()),
         }
     }
 }
@@ -534,7 +535,9 @@ impl PartitionConsumer {
     }
 
     /// Returns the next message to process for this partition (if any).
-    fn get_next_message(&mut self) -> Result<Option<SourceMessage<Option<Vec<u8>>>>, KafkaError> {
+    fn get_next_message(
+        &mut self,
+    ) -> Result<Option<SourceMessage<Option<Vec<u8>>, Option<Vec<u8>>>>, KafkaError> {
         match self.partition_queue.poll(Duration::from_millis(0)) {
             Some(Ok(msg)) => {
                 let result = SourceMessage::from(&msg);

--- a/src/dataflow/src/source/kinesis.rs
+++ b/src/dataflow/src/source/kinesis.rs
@@ -53,7 +53,7 @@ pub struct KinesisSourceReader {
     /// TODO(natacha): this should be moved to timestamper
     last_checked_shards: Instant,
     /// Storage for messages that have not yet been timestamped
-    buffered_messages: VecDeque<SourceMessage<Option<Vec<u8>>>>,
+    buffered_messages: VecDeque<SourceMessage<Option<Vec<u8>>, Option<Vec<u8>>>>,
     /// Count of processed message
     processed_message_count: i64,
     /// Metrics from which per-shard metrics get created.
@@ -112,7 +112,8 @@ impl KinesisSourceReader {
 }
 
 impl SourceReader for KinesisSourceReader {
-    type Payload = Option<Vec<u8>>;
+    type Key = Option<Vec<u8>>;
+    type Value = Option<Vec<u8>>;
 
     fn new(
         _source_name: String,
@@ -147,7 +148,7 @@ impl SourceReader for KinesisSourceReader {
             Err(e) => Err(anyhow!("{}", e)),
         }
     }
-    fn get_next_message(&mut self) -> Result<NextMessage<Self::Payload>, anyhow::Error> {
+    fn get_next_message(&mut self) -> Result<NextMessage<Self::Key, Self::Value>, anyhow::Error> {
         assert_eq!(self.shard_queue.len(), self.shard_set.len());
 
         //TODO move to timestamper
@@ -230,7 +231,7 @@ impl SourceReader for KinesisSourceReader {
                             },
                             upstream_time_millis: None,
                             key: None,
-                            payload: Some(data),
+                            value: Some(data),
                         };
                         self.buffered_messages.push_back(source_message);
                     }

--- a/src/dataflow/src/source/s3.rs
+++ b/src/dataflow/src/source/s3.rs
@@ -853,7 +853,8 @@ where
 }
 
 impl SourceReader for S3SourceReader {
-    type Payload = MessagePayload;
+    type Key = ();
+    type Value = MessagePayload;
 
     fn new(
         source_name: String,
@@ -941,7 +942,7 @@ impl SourceReader for S3SourceReader {
         ))
     }
 
-    fn get_next_message(&mut self) -> Result<NextMessage<Self::Payload>, anyhow::Error> {
+    fn get_next_message(&mut self) -> Result<NextMessage<Self::Key, Self::Value>, anyhow::Error> {
         match self.receiver_stream.recv().now_or_never() {
             Some(Some(Ok(InternalMessage { record }))) => {
                 self.offset += 1;
@@ -949,8 +950,8 @@ impl SourceReader for S3SourceReader {
                     partition: PartitionId::None,
                     offset: self.offset.into(),
                     upstream_time_millis: None,
-                    key: None,
-                    payload: record,
+                    key: (),
+                    value: record,
                 }))
             }
             Some(Some(Err(e))) => {

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -529,6 +529,9 @@ pub fn plan_create_source(
                 tail,
             });
             let encoding = get_encoding(format, envelope, with_options_original)?;
+            if matches!(encoding, SourceDataEncoding::KeyValue { .. }) {
+                bail!("File sources do not support key decoding");
+            }
             (connector, encoding)
         }
         CreateSourceConnector::S3 {
@@ -571,6 +574,9 @@ pub fn plan_create_source(
                 },
             });
             let encoding = get_encoding(format, envelope, with_options_original)?;
+            if matches!(encoding, SourceDataEncoding::KeyValue { .. }) {
+                bail!("S3 sources do not support key decoding");
+            }
             (connector, encoding)
         }
         CreateSourceConnector::Postgres {


### PR DESCRIPTION
# Motivation

This patch is one step further towards making byte source sources behave as such.

These kind of sources are providing just a raw stream of byte chunks that have no notion of delimiters and therefore there is no notion of a key.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

