### PR TITLE
docs: Cloud monitoring

### DIFF
--- a/doc/user/content/cloud/monitor-cloud.md
+++ b/doc/user/content/cloud/monitor-cloud.md
@@ -1,0 +1,48 @@
+---
+title: "Monitor Cloud"
+description: "Monitor Materialize Cloud with the same tools you use for the rest of your pipeline."
+menu:
+  main:
+    parent: "cloud"
+    weight:
+---
+
+{{< cloud-notice >}}
+
+We want to make it possible for you to monitor Materialize Cloud with the same tools you use for the rest of your pipeline. Currently Materialize Cloud only supports Prometheus, but we are working on a Datadog integration. If there are any other tools you're interested in, please [let us know](https://materialize.com/s/chat).
+
+You may also find the system catalog SQL interface helpful in debugging issues.
+
+## Connect to Materialize Cloud
+
+No matter which tool you use, you first need to download and unzip the TLS certificates in a location where they can be accessed by your monitoring tool, and then connect to Materialize Cloud.
+
+{{% cloud-connection-details %}}
+
+## Prometheus
+### Set up Prometheus
+
+Next, you need to add Materialize to the configuration file for your Prometheus installation.
+
+Add the following configuration to `prometheus.yml`:
+
+```
+scrape_configs:
+  - job_name: materialized
+  - tls: config:
+    - ca_file: ca.crt
+    - cert_file: materialize.crt
+    - key_file: materialize.key
+  static_configs:
+    -  targets:
+      - <deployment_hostname>:6875
+```
+You can find the hostname listed next to the deployment name on your Deployments page. You can also copy the complete configuration update already customized for your deployment by clicking on the deployment, going to the Prometheus tab, and clicking the copy icon in the code box.
+
+### View Prometheus metrics
+
+{{% monitoring/prometheus-details %}}
+
+{{% monitoring/grafana %}}
+
+{{% monitoring/system-catalog-sql-interface %}}

--- a/doc/user/content/ops/monitoring.md
+++ b/doc/user/content/ops/monitoring.md
@@ -8,9 +8,11 @@ menu:
     parent: operations
 ---
 
-_This page is a work in progress and will have more detail in the coming months.
-If you have specific questions, feel free to [file a GitHub
-issue](https://github.com/MaterializeInc/materialize/issues/new?labels=C-feature&template=feature.md)._
+{{< note >}}
+
+This topic describes monitoring for the installed version of Materialize. For information about monitoring Materialize Cloud, see [Monitor Cloud](../../cloud/monitor-cloud).
+
+{{< /note >}}
 
 Materialize supports integration with monitoring tools using both the
 [Prometheus](#prometheus) format and via [SQL interface](#system-catalog-sql-interface)
@@ -145,30 +147,11 @@ The Prometheus metrics are not part of Materialize's stable interface.
 Backwards-incompatible changes to the exposed metrics may be made at any time.
 {{< /warning >}}
 
-Materialize exposes [Prometheus](https://prometheus.io/) metrics at the default
-path, `<materialized host>/metrics`.
+{{% monitoring/prometheus-details %}}
 
-Materialize broadly publishes the following types of data there:
+{{% monitoring/system-catalog-sql-interface %}}
 
-- Materialize-specific data with a `mz_*` prefix. For example,
-  `rate(mz_responses_sent_total[10s])` will show you the number of responses
-  averaged over 10 second windows.
-- Standard process metrics with a `process_*` prefix. For exmple, `process_cpu`.
-
-## System catalog SQL interface
-
-The `mz_catalog` SQL interface provides a variety of ways to introspect Materialize. An
-introduction to this catalog is available as part of our [SQL
-documentation](/sql/system-catalog).
-
-A user guide for debugging a running `materialized` using the system catalog is available
-in the form of a walkthrough of useful [diagnostic queries](/ops/troubleshooting).
-
-## Grafana
-
-Materialize provides a [recommended dashboard][dashboard-json] that you can [import into
-Grafana][graf-import]. It relies on you having configured Prometheus to scrape
-Materialize.
+{{% monitoring/grafana %}}
 
 ## Datadog
 

--- a/doc/user/layouts/shortcodes/monitoring/grafana.html
+++ b/doc/user/layouts/shortcodes/monitoring/grafana.html
@@ -1,0 +1,9 @@
+## Grafana
+
+Materialize provides a [recommended dashboard][dashboard-json] that you can [import into
+Grafana][graf-import]. It relies on you having configured Prometheus to scrape
+Materialize.
+
+[dashboard-json]: https://github.com/MaterializeInc/materialize/blob/main/misc/monitoring/dashboard/conf/grafana/dashboards/overview.json
+[graf-import]: https://grafana.com/docs/grafana/latest/reference/export_import/#importing-a-dashboard
+[dc-example]: https://github.com/MaterializeInc/materialize/blob/d793b112758c840c1240eefdd56ca6f7e4f484cf/demo/billing/mzcompose.yml#L60-L70

--- a/doc/user/layouts/shortcodes/monitoring/prometheus-details.html
+++ b/doc/user/layouts/shortcodes/monitoring/prometheus-details.html
@@ -1,0 +1,9 @@
+Materialize exposes [Prometheus](https://prometheus.io/) metrics at the default
+path, `<materialized host>/metrics`.
+
+Materialize broadly publishes the following types of data there:
+
+- Materialize-specific data with a `mz_*` prefix. For example,
+  `rate(mz_responses_sent_total[10s])` will show you the number of responses
+  averaged over 10 second windows.
+- Standard process metrics with a `process_*` prefix. For example, `process_cpu`.

--- a/doc/user/layouts/shortcodes/monitoring/system-catalog-sql-interface.html
+++ b/doc/user/layouts/shortcodes/monitoring/system-catalog-sql-interface.html
@@ -1,0 +1,8 @@
+## System catalog SQL interface
+
+The `mz_catalog` SQL interface provides a variety of ways to introspect Materialize. An
+introduction to this catalog is available as part of our [SQL
+documentation](/sql/system-catalog).
+
+A user guide for debugging a running `materialized` using the system catalog is available
+in the form of a walkthrough of useful [diagnostic queries](/ops/troubleshooting).


### PR DESCRIPTION
- Added instructions on setting up Cloud monitoring with Prometheus and Grafana
- Added instructions on using system SQL catalog
- Moved content shared between ops/monitoring and cloud/monitor-cloud to shared folder (reduce duplication when updating)
- Added note to ops/monitoring that this page only applies to installed Mz.

### Motivation

  * This PR adds a known-desirable feature. [Cloud 8824](https://github.com/MaterializeInc/materialize/issues/8824)
 

### Tips for reviewer

To see the pages as they will appear to customers, instead of just the markdown, go to the PR's Conversations tab, expand the Tests section, and click the Details link next to the netlify/materializeinc/deploy-preview test.

### Open questions

In our existing [Cloud troubleshooting page](https://materialize.com/docs/cloud/troubleshoot-cloud/), we mention both logging and a Datadog integration. Based on @antifuchs's [Slack update](https://materializeinc.slack.com/archives/CL68GT3AT/p1637678300338900?thread_ts=1637676645.338400&cid=CL68GT3AT), should these be removed?

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
