### PR TITLE
sql: timestamp generate_series and overflow handling

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -105,6 +105,8 @@ List new features before bug fixes.
 
 - Support `generate_series` for [`timestamp`] data.
 
+- Prevent overflow on operations combining [`timestamp`] and [`interval`].
+
 {{% version-header v0.10.0 %}}
 
 - Allow ingesting avro schemas whose top node is not a record type.

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -103,6 +103,8 @@ List new features before bug fixes.
 
 {{% version-header v0.10.1 %}}
 
+- Support `generate_series` for [`timestamp`] data.
+
 {{% version-header v0.10.0 %}}
 
 - Allow ingesting avro schemas whose top node is not a record type.

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -501,6 +501,9 @@
   - signature: 'generate_series(start: int, stop: int, step: int) -> Col<int>'
     description: Generate all integer values between `start` and `stop`, inclusive, incrementing
       by `step` each time.
+  - signature: 'generate_series(start: timestamp, stop: timestamp, step: interval) -> Col<timestamp>'
+    description: Generate all timestamp values between `start` and `stop`, inclusive, incrementing
+      by `step` each time.
   - signature: 'regexp_extract(regex: str, haystack: str) -> Col<string>'
     description: Values of the capture groups of `regex` as matched in `haystack`
   - signature: 'unnest(a: anyarray)'

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -10,8 +10,10 @@
 #![allow(missing_docs)]
 
 use std::fmt;
+use std::fmt::Debug;
 use std::iter;
 
+use chrono::Timelike;
 use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
 use dec::OrderedDecimal;
 use num::{CheckedAdd, Integer, Signed};
@@ -22,12 +24,13 @@ use serde::{Deserialize, Serialize};
 use lowertest::MzEnumReflect;
 use ore::cast::CastFrom;
 use repr::adt::array::ArrayDimension;
+use repr::adt::interval::Interval;
 use repr::adt::numeric;
 use repr::adt::regex::Regex as ReprRegex;
 use repr::{ColumnName, ColumnType, Datum, Diff, RelationType, Row, RowArena, ScalarType};
 
 use crate::relation::{compare_columns, ColumnOrder};
-use crate::scalar::func::jsonb_stringify;
+use crate::scalar::func::{add_timestamp_months, jsonb_stringify};
 use crate::EvalError;
 
 // TODO(jamii) be careful about overflow in sum/avg
@@ -913,6 +916,60 @@ where
         .map(move |i| (Row::pack_slice(&[Datum::from(i)]), 1)))
 }
 
+/// Like
+/// [`num::range_step_inclusive`](https://github.com/rust-num/num-iter/blob/ddb14c1e796d401014c6c7a727de61d8109ad986/src/lib.rs#L279),
+/// but for our timestamp types using [`Interval`] for `step`.xwxw
+#[derive(Clone)]
+pub struct TimestampRangeStepInclusive {
+    state: NaiveDateTime,
+    stop: NaiveDateTime,
+    step: Interval,
+    rev: bool,
+    done: bool,
+}
+
+impl Iterator for TimestampRangeStepInclusive {
+    type Item = NaiveDateTime;
+
+    #[inline]
+    fn next(&mut self) -> Option<NaiveDateTime> {
+        if !self.done
+            && ((self.rev && self.state >= self.stop) || (!self.rev && self.state <= self.stop))
+        {
+            let result = self.state.clone();
+            self.state = add_timestamp_months(self.state, self.step.months);
+            self.state += self.step.duration_as_chrono();
+            Some(result)
+        } else {
+            None
+        }
+    }
+}
+
+fn generate_series_ts<'a>(
+    start: NaiveDateTime,
+    stop: NaiveDateTime,
+    step: Interval,
+    conv: fn(NaiveDateTime) -> Datum<'static>,
+) -> Result<impl Iterator<Item = (Row, Diff)>, EvalError> {
+    if step.months == 0 && step.duration == 0 {
+        return Err(EvalError::InvalidParameterValue(
+            "step size cannot equal zero".to_owned(),
+        ));
+    }
+    let rev = step.duration < 0;
+
+    let tsri = TimestampRangeStepInclusive {
+        state: start,
+        stop,
+        step,
+        rev,
+        done: false,
+    };
+
+    Ok(tsri.map(move |i| (Row::pack_slice(&[conv(i)]), 1)))
+}
+
 fn unnest_array<'a>(a: Datum<'a>) -> impl Iterator<Item = (Row, Diff)> + 'a {
     a.unwrap_array()
         .elements()
@@ -1054,7 +1111,8 @@ pub enum TableFunc {
     CsvExtract(usize),
     GenerateSeriesInt32,
     GenerateSeriesInt64,
-    // TODO(justin): should also possibly have GenerateSeriesTimestamp{,Tz}.
+    GenerateSeriesTimestamp,
+    GenerateSeriesTimestampTz,
     Repeat,
     UnnestArray {
         el_typ: ScalarType,
@@ -1114,6 +1172,30 @@ impl TableFunc {
                 )?;
                 Ok(Box::new(res))
             }
+            TableFunc::GenerateSeriesTimestamp => {
+                fn pass_through<'a>(d: NaiveDateTime) -> Datum<'a> {
+                    Datum::from(d)
+                }
+                let res = generate_series_ts(
+                    datums[0].unwrap_timestamp(),
+                    datums[1].unwrap_timestamp(),
+                    datums[2].unwrap_interval(),
+                    pass_through,
+                )?;
+                Ok(Box::new(res))
+            }
+            TableFunc::GenerateSeriesTimestampTz => {
+                fn gen_ts_tz<'a>(d: NaiveDateTime) -> Datum<'a> {
+                    Datum::from(DateTime::<Utc>::from_utc(d, Utc))
+                }
+                let res = generate_series_ts(
+                    datums[0].unwrap_timestamptz().naive_utc(),
+                    datums[1].unwrap_timestamptz().naive_utc(),
+                    datums[2].unwrap_interval(),
+                    gen_ts_tz,
+                )?;
+                Ok(Box::new(res))
+            }
             TableFunc::Repeat => Ok(Box::new(repeat(datums[0]).into_iter())),
             TableFunc::UnnestArray { .. } => Ok(Box::new(unnest_array(datums[0]))),
             TableFunc::UnnestList { .. } => Ok(Box::new(unnest_list(datums[0]))),
@@ -1151,6 +1233,8 @@ impl TableFunc {
             TableFunc::GenerateSeriesInt64 => {
                 vec![ScalarType::Int64.nullable(false)]
             }
+            TableFunc::GenerateSeriesTimestamp => vec![ScalarType::Timestamp.nullable(false)],
+            TableFunc::GenerateSeriesTimestampTz => vec![ScalarType::TimestampTz.nullable(false)],
             TableFunc::Repeat => vec![],
             TableFunc::UnnestArray { el_typ } => vec![el_typ.clone().nullable(true)],
             TableFunc::UnnestList { el_typ } => vec![el_typ.clone().nullable(true)],
@@ -1167,6 +1251,8 @@ impl TableFunc {
             TableFunc::CsvExtract(n_cols) => *n_cols,
             TableFunc::GenerateSeriesInt32 => 1,
             TableFunc::GenerateSeriesInt64 => 1,
+            TableFunc::GenerateSeriesTimestamp => 1,
+            TableFunc::GenerateSeriesTimestampTz => 1,
             TableFunc::Repeat => 0,
             TableFunc::UnnestArray { .. } => 1,
             TableFunc::UnnestList { .. } => 1,
@@ -1181,6 +1267,8 @@ impl TableFunc {
             | TableFunc::JsonbArrayElements { .. }
             | TableFunc::GenerateSeriesInt32
             | TableFunc::GenerateSeriesInt64
+            | TableFunc::GenerateSeriesTimestamp
+            | TableFunc::GenerateSeriesTimestampTz
             | TableFunc::RegexpExtract(_)
             | TableFunc::CsvExtract(_)
             | TableFunc::Repeat
@@ -1202,6 +1290,8 @@ impl TableFunc {
             TableFunc::CsvExtract(_) => true,
             TableFunc::GenerateSeriesInt32 => true,
             TableFunc::GenerateSeriesInt64 => true,
+            TableFunc::GenerateSeriesTimestamp => true,
+            TableFunc::GenerateSeriesTimestampTz => true,
             TableFunc::Repeat => false,
             TableFunc::UnnestArray { .. } => true,
             TableFunc::UnnestList { .. } => true,
@@ -1220,6 +1310,8 @@ impl fmt::Display for TableFunc {
             TableFunc::CsvExtract(n_cols) => write!(f, "csv_extract({}, _)", n_cols),
             TableFunc::GenerateSeriesInt32 => f.write_str("generate_series"),
             TableFunc::GenerateSeriesInt64 => f.write_str("generate_series"),
+            TableFunc::GenerateSeriesTimestamp => f.write_str("generate_series"),
+            TableFunc::GenerateSeriesTimestampTz => f.write_str("generate_series"),
             TableFunc::Repeat => f.write_str("repeat_row"),
             TableFunc::UnnestArray { .. } => f.write_str("unnest_array"),
             TableFunc::UnnestList { .. } => f.write_str("unnest_list"),

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -843,18 +843,24 @@ fn add_float64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     }
 }
 
-fn add_timestamp_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+fn add_timestamp_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let dt = a.unwrap_timestamp();
     let i = b.unwrap_interval();
-    let dt = add_timestamp_months(dt, i.months);
-    Datum::Timestamp(dt + i.duration_as_chrono())
+    let dt = add_timestamp_months(dt, i.months)?;
+    Ok(Datum::Timestamp(
+        dt.checked_add_signed(i.duration_as_chrono())
+            .ok_or(EvalError::TimestampOutOfRange)?,
+    ))
 }
 
-fn add_timestamptz_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+fn add_timestamptz_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let dt = a.unwrap_timestamptz().naive_utc();
     let i = b.unwrap_interval();
-    let dt = add_timestamp_months(dt, i.months);
-    Datum::TimestampTz(DateTime::<Utc>::from_utc(dt + i.duration_as_chrono(), Utc))
+    let mut dt = add_timestamp_months(dt, i.months)?;
+    dt = dt
+        .checked_add_signed(i.duration_as_chrono())
+        .ok_or(EvalError::TimestampOutOfRange)?;
+    Ok(Datum::TimestampTz(DateTime::<Utc>::from_utc(dt, Utc)))
 }
 
 fn add_date_time<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
@@ -871,13 +877,16 @@ fn add_date_time<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     )
 }
 
-fn add_date_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+fn add_date_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let date = a.unwrap_date();
     let interval = b.unwrap_interval();
 
     let dt = NaiveDate::from_ymd(date.year(), date.month(), date.day()).and_hms(0, 0, 0);
-    let dt = add_timestamp_months(dt, interval.months);
-    Datum::Timestamp(dt + interval.duration_as_chrono())
+    let dt = add_timestamp_months(dt, interval.months)?;
+    Ok(Datum::Timestamp(
+        dt.checked_add_signed(interval.duration_as_chrono())
+            .ok_or(EvalError::TimestampOutOfRange)?,
+    ))
 }
 
 fn add_time_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
@@ -1069,24 +1078,28 @@ fn encoded_bytes_char_length<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>
     }
 }
 
-fn sub_timestamp_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+fn sub_timestamp_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     add_timestamp_interval(a, Datum::Interval(-b.unwrap_interval()))
 }
 
-fn sub_timestamptz_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+fn sub_timestamptz_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     add_timestamptz_interval(a, Datum::Interval(-b.unwrap_interval()))
 }
 
-pub fn add_timestamp_months(dt: NaiveDateTime, months: i32) -> NaiveDateTime {
+pub fn add_timestamp_months(
+    dt: NaiveDateTime,
+    mut months: i32,
+) -> Result<NaiveDateTime, EvalError> {
     if months == 0 {
-        return dt;
+        return Ok(dt);
     }
-
-    let mut months = months;
 
     let (mut year, mut month, mut day) = (dt.year(), dt.month0() as i32, dt.day());
     let years = months / 12;
-    year += years;
+    year = year
+        .checked_add(years)
+        .ok_or(EvalError::TimestampOutOfRange)?;
+
     months %= 12;
     // positive modulus is easier to reason about
     if months < 0 {
@@ -1101,7 +1114,11 @@ pub fn add_timestamp_months(dt: NaiveDateTime, months: i32) -> NaiveDateTime {
     // handle going from January 31st to February by saturation
     let mut new_d = chrono::NaiveDate::from_ymd_opt(year, month as u32, day);
     while new_d.is_none() {
-        debug_assert!(day > 28, "there are no months with fewer than 28 days");
+        // If we have decremented day past 28 and are still receiving `None`,
+        // then we have generally overflowed `NaiveDate`.
+        if day < 28 {
+            return Err(EvalError::TimestampOutOfRange);
+        }
         day -= 1;
         new_d = chrono::NaiveDate::from_ymd_opt(year, month as u32, day);
     }
@@ -1111,7 +1128,7 @@ pub fn add_timestamp_months(dt: NaiveDateTime, months: i32) -> NaiveDateTime {
     //
     // Both my testing and https://dba.stackexchange.com/a/105829 support the
     // idea that we should ignore leap seconds
-    new_d.and_hms_nano(dt.hour(), dt.minute(), dt.second(), dt.nanosecond())
+    Ok(new_d.and_hms_nano(dt.hour(), dt.minute(), dt.second(), dt.nanosecond()))
 }
 
 fn add_numeric<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
@@ -1287,13 +1304,17 @@ fn sub_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> 
         .map(Datum::from)
 }
 
-fn sub_date_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+fn sub_date_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let date = a.unwrap_date();
     let interval = b.unwrap_interval();
 
     let dt = NaiveDate::from_ymd(date.year(), date.month(), date.day()).and_hms(0, 0, 0);
-    let dt = add_timestamp_months(dt, -interval.months);
-    Datum::Timestamp(dt - interval.duration_as_chrono())
+    let dt = add_timestamp_months(dt, -interval.months)?;
+
+    Ok(Datum::Timestamp(
+        dt.checked_sub_signed(interval.duration_as_chrono())
+            .ok_or(EvalError::TimestampOutOfRange)?,
+    ))
 }
 
 fn sub_time_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
@@ -2778,10 +2799,10 @@ impl BinaryFunc {
             BinaryFunc::AddInt64 => eager!(add_int64),
             BinaryFunc::AddFloat32 => eager!(add_float32),
             BinaryFunc::AddFloat64 => eager!(add_float64),
-            BinaryFunc::AddTimestampInterval => Ok(eager!(add_timestamp_interval)),
-            BinaryFunc::AddTimestampTzInterval => Ok(eager!(add_timestamptz_interval)),
+            BinaryFunc::AddTimestampInterval => eager!(add_timestamp_interval),
+            BinaryFunc::AddTimestampTzInterval => eager!(add_timestamptz_interval),
             BinaryFunc::AddDateTime => Ok(eager!(add_date_time)),
-            BinaryFunc::AddDateInterval => Ok(eager!(add_date_interval)),
+            BinaryFunc::AddDateInterval => eager!(add_date_interval),
             BinaryFunc::AddTimeInterval => Ok(eager!(add_time_interval)),
             BinaryFunc::AddNumeric => eager!(add_numeric),
             BinaryFunc::AddInterval => eager!(add_interval),
@@ -2807,11 +2828,11 @@ impl BinaryFunc {
             BinaryFunc::SubFloat64 => eager!(sub_float64),
             BinaryFunc::SubTimestamp => Ok(eager!(sub_timestamp)),
             BinaryFunc::SubTimestampTz => Ok(eager!(sub_timestamptz)),
-            BinaryFunc::SubTimestampInterval => Ok(eager!(sub_timestamp_interval)),
-            BinaryFunc::SubTimestampTzInterval => Ok(eager!(sub_timestamptz_interval)),
+            BinaryFunc::SubTimestampInterval => eager!(sub_timestamp_interval),
+            BinaryFunc::SubTimestampTzInterval => eager!(sub_timestamptz_interval),
             BinaryFunc::SubInterval => eager!(sub_interval),
             BinaryFunc::SubDate => Ok(eager!(sub_date)),
-            BinaryFunc::SubDateInterval => Ok(eager!(sub_date_interval)),
+            BinaryFunc::SubDateInterval => eager!(sub_date_interval),
             BinaryFunc::SubTime => Ok(eager!(sub_time)),
             BinaryFunc::SubTimeInterval => Ok(eager!(sub_time_interval)),
             BinaryFunc::SubNumeric => eager!(sub_numeric),
@@ -5902,32 +5923,32 @@ mod test {
     fn add_interval_months() {
         let dt = ym(2000, 1);
 
-        assert_eq!(add_timestamp_months(dt, 0), dt);
-        assert_eq!(add_timestamp_months(dt, 1), ym(2000, 2));
-        assert_eq!(add_timestamp_months(dt, 12), ym(2001, 1));
-        assert_eq!(add_timestamp_months(dt, 13), ym(2001, 2));
-        assert_eq!(add_timestamp_months(dt, 24), ym(2002, 1));
-        assert_eq!(add_timestamp_months(dt, 30), ym(2002, 7));
+        assert_eq!(add_timestamp_months(dt, 0).unwrap(), dt);
+        assert_eq!(add_timestamp_months(dt, 1).unwrap(), ym(2000, 2));
+        assert_eq!(add_timestamp_months(dt, 12).unwrap(), ym(2001, 1));
+        assert_eq!(add_timestamp_months(dt, 13).unwrap(), ym(2001, 2));
+        assert_eq!(add_timestamp_months(dt, 24).unwrap(), ym(2002, 1));
+        assert_eq!(add_timestamp_months(dt, 30).unwrap(), ym(2002, 7));
 
         // and negatives
-        assert_eq!(add_timestamp_months(dt, -1), ym(1999, 12));
-        assert_eq!(add_timestamp_months(dt, -12), ym(1999, 1));
-        assert_eq!(add_timestamp_months(dt, -13), ym(1998, 12));
-        assert_eq!(add_timestamp_months(dt, -24), ym(1998, 1));
-        assert_eq!(add_timestamp_months(dt, -30), ym(1997, 7));
+        assert_eq!(add_timestamp_months(dt, -1).unwrap(), ym(1999, 12));
+        assert_eq!(add_timestamp_months(dt, -12).unwrap(), ym(1999, 1));
+        assert_eq!(add_timestamp_months(dt, -13).unwrap(), ym(1998, 12));
+        assert_eq!(add_timestamp_months(dt, -24).unwrap(), ym(1998, 1));
+        assert_eq!(add_timestamp_months(dt, -30).unwrap(), ym(1997, 7));
 
         // and going over a year boundary by less than a year
         let dt = ym(1999, 12);
-        assert_eq!(add_timestamp_months(dt, 1), ym(2000, 1));
+        assert_eq!(add_timestamp_months(dt, 1).unwrap(), ym(2000, 1));
         let end_of_month_dt = NaiveDate::from_ymd(1999, 12, 31).and_hms(9, 9, 9);
         assert_eq!(
             // leap year
-            add_timestamp_months(end_of_month_dt, 2),
+            add_timestamp_months(end_of_month_dt, 2).unwrap(),
             NaiveDate::from_ymd(2000, 2, 29).and_hms(9, 9, 9),
         );
         assert_eq!(
             // not leap year
-            add_timestamp_months(end_of_month_dt, 14),
+            add_timestamp_months(end_of_month_dt, 14).unwrap(),
             NaiveDate::from_ymd(2001, 2, 28).and_hms(9, 9, 9),
         );
     }

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1957,15 +1957,27 @@ lazy_static! {
 
             // Table functions.
             "generate_series" => Table {
-                params!(Int32, Int32) => Operation::binary(move |_ecx, start, stop| {
-                    let row = Row::pack(&[Datum::Int32(1)]);
-                    let column_type = ColumnType { scalar_type: ScalarType::Int32, nullable: false };
+                params!(Int32, Int32, Int32) => Operation::variadic(move |_ecx, exprs| {
                     Ok(TableFuncPlan {
                         func: TableFunc::GenerateSeriesInt32,
-                        exprs: vec![start, stop, HirScalarExpr::Literal(row, column_type)],
+                        exprs,
+                        column_names: vec![Some("generate_series".into())],
+                    })
+                }), 1066;
+                params!(Int32, Int32) => Operation::binary(move |_ecx, start, stop| {
+                    Ok(TableFuncPlan {
+                        func: TableFunc::GenerateSeriesInt32,
+                        exprs: vec![start, stop, HirScalarExpr::literal(Datum::Int32(1), ScalarType::Int32)],
                         column_names: vec![Some("generate_series".into())],
                     })
                 }), 1067;
+                params!(Int64, Int64, Int64) => Operation::variadic(move |_ecx, exprs| {
+                    Ok(TableFuncPlan {
+                        func: TableFunc::GenerateSeriesInt64,
+                        exprs,
+                        column_names: vec![Some("generate_series".into())],
+                    })
+                }), 1068;
                 params!(Int64, Int64) => Operation::binary(move |_ecx, start, stop| {
                     let row = Row::pack(&[Datum::Int64(1)]);
                     let column_type = ColumnType { scalar_type: ScalarType::Int64, nullable: false };
@@ -1975,20 +1987,20 @@ lazy_static! {
                         column_names: vec![Some("generate_series".into())],
                     })
                 }), 1069;
-                params!(Int32, Int32, Int32) => Operation::variadic(|_ecx, exprs| {
+                params!(Timestamp, Timestamp, Interval) => Operation::variadic(move |_ecx, exprs| {
                     Ok(TableFuncPlan {
-                        func: TableFunc::GenerateSeriesInt32,
+                        func: TableFunc::GenerateSeriesTimestamp,
                         exprs,
                         column_names: vec![Some("generate_series".into())],
                     })
-                }), 1066;
-                params!(Int64, Int64, Int64) => Operation::variadic(|_ecx, exprs| {
+                }), 938;
+                params!(TimestampTz, TimestampTz, Interval) => Operation::variadic(move |_ecx, exprs| {
                     Ok(TableFuncPlan {
-                        func: TableFunc::GenerateSeriesInt64,
+                        func: TableFunc::GenerateSeriesTimestampTz,
                         exprs,
                         column_names: vec![Some("generate_series".into())],
                     })
-                }), 1068;
+                }), 939;
             },
             "jsonb_array_elements" => Table {
                 params!(Jsonb) => Operation::unary(move |_ecx, jsonb| {

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -107,11 +107,6 @@ x
 2
 3
 
-# TODO(justin): Don't currently support the timestamp version.
-query error arguments cannot be implicitly cast to any implementation's parameters
-SELECT * FROM generate_series(now() - '5m'::interval, now(), '5s'::interval)
-----
-
 # generate_series with lateral joins.
 
 statement ok
@@ -312,7 +307,7 @@ SELECT * FROM (values ('a')), repeat_row(-1)
 statement error constant folding encountered reduce on collection with non-positive multiplicities
 SELECT (SELECT 1 FROM repeat_row(-1))
 
-query error unable to determine which implementation to use
+query T
 SELECT generate_series FROM generate_series(null, null, null)
 ----
 
@@ -734,3 +729,190 @@ SELECT i, CASE WHEN i > 0 THEN generate_series(1, 5) ELSE 0 END FROM t
 
 query error multiple table functions in select projections not yet supported
 SELECT generate_series(1,2), generate_series(1,2)
+
+
+# timestamp-based generate series
+
+query T
+SELECT * FROM generate_series('2021-01-01 00:00:00'::TIMESTAMP, '2021-01-01 02:00:00'::TIMESTAMP, '1 hour') ORDER BY 1
+----
+2021-01-01 00:00:00
+2021-01-01 01:00:00
+2021-01-01 02:00:00
+
+query T
+SELECT * FROM generate_series('2021-01-01 03:00:00'::TIMESTAMP, '2021-01-01 00:00:00'::TIMESTAMP, '-1 hour') ORDER BY 1
+----
+2021-01-01 00:00:00
+2021-01-01 01:00:00
+2021-01-01 02:00:00
+2021-01-01 03:00:00
+
+query T
+SELECT * FROM generate_series('2021-01-01 03:00:00'::TIMESTAMP, '2021-01-03 00:00:00'::TIMESTAMP, '1 day') ORDER BY 1
+----
+2021-01-01 03:00:00
+2021-01-02 03:00:00
+
+query T
+SELECT * FROM generate_series('2021-01-03 00:00:00'::TIMESTAMP, '2021-01-01 03:00:00'::TIMESTAMP, '1 day') ORDER BY 1
+----
+
+query T
+SELECT * FROM generate_series('2021-01-01 03:00:00'::TIMESTAMP, '2021-01-03 00:00:00'::TIMESTAMP, '-1 day') ORDER BY 1
+----
+
+query T
+SELECT * FROM generate_series('2021-01-31 03:00:00'::TIMESTAMP, '2022-01-31 00:00:00'::TIMESTAMP, '1 month') ORDER BY 1
+----
+2021-01-31 03:00:00
+2021-02-28 03:00:00
+2021-03-28 03:00:00
+2021-04-28 03:00:00
+2021-05-28 03:00:00
+2021-06-28 03:00:00
+2021-07-28 03:00:00
+2021-08-28 03:00:00
+2021-09-28 03:00:00
+2021-10-28 03:00:00
+2021-11-28 03:00:00
+2021-12-28 03:00:00
+2022-01-28 03:00:00
+
+query T
+SELECT * FROM generate_series('2021-01-31 03:00:00'::TIMESTAMP, '2021-04-30 00:00:00'::TIMESTAMP, '1 month') ORDER BY 1
+----
+2021-01-31 03:00:00
+2021-02-28 03:00:00
+2021-03-28 03:00:00
+2021-04-28 03:00:00
+
+# Leap years
+query T
+SELECT * FROM generate_series('2020-01-31 03:00:00'::TIMESTAMP, '2020-04-30 00:00:00'::TIMESTAMP, '1 month') ORDER BY 1
+----
+2020-01-31 03:00:00
+2020-02-29 03:00:00
+2020-03-29 03:00:00
+2020-04-29 03:00:00
+
+query T
+SELECT * FROM generate_series('2020-01-31 03:00:00'::TIMESTAMP, '2020-11-30 00:00:00'::TIMESTAMP, '2 month') ORDER BY 1
+----
+2020-01-31 03:00:00
+2020-03-31 03:00:00
+2020-05-31 03:00:00
+2020-07-31 03:00:00
+2020-09-30 03:00:00
+
+query T
+SELECT * FROM generate_series('2020-01-01 22:00:00'::TIMESTAMP, '2021-01-01 00:00:00'::TIMESTAMP, '1 month 1 day 1 hour') ORDER BY 1
+----
+2020-01-01 22:00:00
+2020-02-02 23:00:00
+2020-03-04 00:00:00
+2020-04-05 01:00:00
+2020-05-06 02:00:00
+2020-06-07 03:00:00
+2020-07-08 04:00:00
+2020-08-09 05:00:00
+2020-09-10 06:00:00
+2020-10-11 07:00:00
+2020-11-12 08:00:00
+2020-12-13 09:00:00
+
+query error step size cannot equal zero
+SELECT * FROM generate_series('2021-01-01 03:00:00'::TIMESTAMP, '2021-01-03 00:00:00'::TIMESTAMP, '0 day');
+
+# timestamptz-based generate series
+
+query T
+SELECT * FROM generate_series('2021-01-01 00:00:00'::TIMESTAMPTZ, '2021-01-01 02:00:00'::TIMESTAMPTZ, '1 hour') ORDER BY 1
+----
+2021-01-01 00:00:00+00
+2021-01-01 01:00:00+00
+2021-01-01 02:00:00+00
+
+query T
+SELECT * FROM generate_series('2021-01-01 03:00:00'::TIMESTAMPTZ, '2021-01-01 00:00:00'::TIMESTAMPTZ, '-1 hour') ORDER BY 1
+----
+2021-01-01 00:00:00+00
+2021-01-01 01:00:00+00
+2021-01-01 02:00:00+00
+2021-01-01 03:00:00+00
+
+query T
+SELECT * FROM generate_series('2021-01-01 03:00:00'::TIMESTAMPTZ, '2021-01-03 00:00:00'::TIMESTAMPTZ, '1 day') ORDER BY 1
+----
+2021-01-01 03:00:00+00
+2021-01-02 03:00:00+00
+
+query T
+SELECT * FROM generate_series('2021-01-03 00:00:00'::TIMESTAMPTZ, '2021-01-01 03:00:00'::TIMESTAMPTZ, '1 day') ORDER BY 1
+----
+
+query T
+SELECT * FROM generate_series('2021-01-01 03:00:00'::TIMESTAMPTZ, '2021-01-03 00:00:00'::TIMESTAMPTZ, '-1 day') ORDER BY 1
+----
+
+query T
+SELECT * FROM generate_series('2021-01-31 03:00:00'::TIMESTAMPTZ, '2022-01-31 00:00:00'::TIMESTAMPTZ, '1 month') ORDER BY 1
+----
+2021-01-31 03:00:00+00
+2021-02-28 03:00:00+00
+2021-03-28 03:00:00+00
+2021-04-28 03:00:00+00
+2021-05-28 03:00:00+00
+2021-06-28 03:00:00+00
+2021-07-28 03:00:00+00
+2021-08-28 03:00:00+00
+2021-09-28 03:00:00+00
+2021-10-28 03:00:00+00
+2021-11-28 03:00:00+00
+2021-12-28 03:00:00+00
+2022-01-28 03:00:00+00
+
+query T
+SELECT * FROM generate_series('2021-01-31 03:00:00'::TIMESTAMPTZ, '2021-04-30 00:00:00'::TIMESTAMPTZ, '1 month') ORDER BY 1
+----
+2021-01-31 03:00:00+00
+2021-02-28 03:00:00+00
+2021-03-28 03:00:00+00
+2021-04-28 03:00:00+00
+
+# Leap years
+query T
+SELECT * FROM generate_series('2020-01-31 03:00:00'::TIMESTAMPTZ, '2020-04-30 00:00:00'::TIMESTAMPTZ, '1 month') ORDER BY 1
+----
+2020-01-31 03:00:00+00
+2020-02-29 03:00:00+00
+2020-03-29 03:00:00+00
+2020-04-29 03:00:00+00
+
+query T
+SELECT * FROM generate_series('2020-01-31 03:00:00'::TIMESTAMPTZ, '2020-11-30 00:00:00'::TIMESTAMPTZ, '2 month') ORDER BY 1
+----
+2020-01-31 03:00:00+00
+2020-03-31 03:00:00+00
+2020-05-31 03:00:00+00
+2020-07-31 03:00:00+00
+2020-09-30 03:00:00+00
+
+query T
+SELECT * FROM generate_series('2020-01-01 22:00:00'::TIMESTAMPTZ, '2021-01-01 00:00:00'::TIMESTAMPTZ, '1 month 1 day 1 hour') ORDER BY 1
+----
+2020-01-01 22:00:00+00
+2020-02-02 23:00:00+00
+2020-03-04 00:00:00+00
+2020-04-05 01:00:00+00
+2020-05-06 02:00:00+00
+2020-06-07 03:00:00+00
+2020-07-08 04:00:00+00
+2020-08-09 05:00:00+00
+2020-09-10 06:00:00+00
+2020-10-11 07:00:00+00
+2020-11-12 08:00:00+00
+2020-12-13 09:00:00+00
+
+query error step size cannot equal zero
+SELECT * FROM generate_series('2021-01-01 03:00:00'::TIMESTAMPTZ, '2021-01-03 00:00:00'::TIMESTAMPTZ, '0 day');

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -730,7 +730,6 @@ SELECT i, CASE WHEN i > 0 THEN generate_series(1, 5) ELSE 0 END FROM t
 query error multiple table functions in select projections not yet supported
 SELECT generate_series(1,2), generate_series(1,2)
 
-
 # timestamp-based generate series
 
 query T

--- a/test/sqllogictest/timestamp.slt
+++ b/test/sqllogictest/timestamp.slt
@@ -188,3 +188,11 @@ true
 true
 1 hour 30 minutes
 true
+
+query T
+SELECT '99999-01-01'::TIMESTAMP + '162144 y';
+----
+262143-01-01 00:00:00
+
+query error timestamp out of range
+SELECT '99999-01-01'::TIMESTAMP + '162145 y';


### PR DESCRIPTION
In sketching out some work related to #8698, I needed these features and they're generalized implementations.

### Motivation

This PR adds a feature that has not yet been specified.

- `generate_series` w/ Timestamp data
- Avoiding overflows with timestamp and interval operations

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
