### PR TITLE
doc: Add disabling user index on Cloud

### DIFF
--- a/doc/user/content/cli/_index.md
+++ b/doc/user/content/cli/_index.md
@@ -383,29 +383,7 @@ example, if you add a view that contains a cross join that causes your server to
 immediately run out of memory on boot, you can use `--disable-user-indexes` to
 boot the server and then drop the offending view.
 
-In this mode users...
-
-- Can access objects within the [system catalog][sys-cat] to help determine
-  which indexes are causing the crash.
-- Can only `SELECT` from user-created objects that do not rely on user-created
-  indexes. In essence, this means users can still `SELECT` from user-created...
-  - Tables, but they will never return any data.
-  - Views that contain only references to constant values or depend entirely on
-    system tables' indexes.
-- Cannot `INSERT` data into tables.
-- Can create new objects, but any created indexes are disabled.
-
-After troubleshooting any issues, you can [enable individual
-indexes](/sql/alter-index) or reboot Materialize _without_
-`--disable-user-indexes` to enable all indexes at once.
-
-For assistance with this mode, see:
-
-- [Architecture over: Indexes][api-indexes]
-- [System catalog][sys-cat]
-- [`SHOW INDEX`](/sql/show-index)
-- [`DROP VIEW`](/sql/drop-view)
-- [`DROP INDEX`](/sql/drop-index)
+{{% troubleshooting/disable-user-indexes %}}
 
 ## Special environment variables
 

--- a/doc/user/content/cloud/troubleshoot-cloud.md
+++ b/doc/user/content/cloud/troubleshoot-cloud.md
@@ -10,11 +10,7 @@ menu:
 {{< cloud-notice >}}
 
 
-We're working on other monitoring tools, but for now there are a few tools you can use for troubleshooting issues with Materialize Cloud:
-
-* Status check
-* Logs
-* Monitoring integrations
+We're working on other monitoring tools, but for now there are a few tools you can use for troubleshooting issues with Materialize Cloud.
 
 ## Status check
 
@@ -37,11 +33,24 @@ that must be investigated and resolved.
 
 For more information, see [Monitoring: Logging](/ops/monitoring/#logging)
 
+## Disabling user indexes
+
+{{< warning >}}
+This feature is primarily meant for advanced administrators of Materialize.
+{{< /warning >}}
+
+If your Cloud deployment unexpectedly consumes all CPU or memory, you can troubleshoot by restarting with
+[indexes][api-indexes] on user-created objects disabled.  The option appears on the Deployment Details page.
+
+{{% troubleshooting/disable-user-indexes %}}
+
 ## Third-party monitoring tools
 
-Materialize supports integrations with [Datadog](/ops/monitoring/#datadog), [Grafana](/ops/monitoring/#grafana), and [Prometheus](/ops/monitoring/#prometheus).
+Materialize supports integrations with [Grafana](/ops/monitoring/#grafana) and [Prometheus](/ops/monitoring/#prometheus). For more information, see [Monitor Cloud].
 
 ## Related topics
 
-- [Monitoring](/ops/monitoring)
+- [Monitor Cloud]
 - [System Catalog](/sql/system-catalog)
+
+[Monitor Cloud]:../../cloud/monitor-cloud

--- a/doc/user/layouts/shortcodes/troubleshooting/disable-user-indexes.html
+++ b/doc/user/layouts/shortcodes/troubleshooting/disable-user-indexes.html
@@ -1,0 +1,27 @@
+
+In this mode users...
+
+- Can access objects within the [system catalog][sys-cat] to help determine
+  which indexes are causing the crash.
+- Can only `SELECT` from user-created objects that do not rely on user-created
+  indexes. In essence, this means users can still `SELECT` from user-created...
+  - Tables, but they will never return any data.
+  - Views that contain only references to constant values or depend entirely on
+    system tables' indexes.
+- Cannot `INSERT` data into tables.
+- Can create new objects, but any created indexes are disabled.
+
+After troubleshooting any issues, you can [enable individual
+indexes](/sql/alter-index) or restart Materialize _without_
+disabling user indexes to enable all indexes at once.
+
+For assistance with this mode, see:
+
+- [API Overview: Indexes][api-indexes]
+- [System Catalog][sys-cat]
+- [`SHOW INDEX`](/sql/show-index)
+- [`DROP VIEW`](/sql/drop-view)
+- [`DROP INDEX`](/sql/drop-index)
+
+[api-indexes]: /overview/api-components#indexes
+[sys-cat]: /sql/system-catalog


### PR DESCRIPTION
- Move disabling user index instructions to shared content
- Add info on disabling user indexes in Cloud

@TonyRippy had suggested adding a mention and then linking to /docs/cli for more information, but I think that would be more confusing than just sharing selected content. There is so much available there that can't be applied to Cloud yet.

### Motivation

  * This PR adds a known-desirable feature. [#8861] 

### Tips for reviewer

This is going to fail the build and linting check until [#8824] is done, because it includes a link to a new page created for that request.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
