### PR TITLE
sql: support ROWS FROM

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -110,6 +110,8 @@ List new features before bug fixes.
 - Support explicit reference to the default collation (`<expr> COLLATE pg_catalog.default`).
   Other collations are not yet supported.
 
+- Support `ROWS FROM` in `FROM` clauses.
+
 {{% version-header v0.10.0 %}}
 
 - Allow ingesting avro schemas whose top node is not a record type.

--- a/src/coord/src/catalog/migrate.rs
+++ b/src/coord/src/catalog/migrate.rs
@@ -28,8 +28,8 @@ use sql::ast::{
     CreateSourceFormat, CreateSourceStatement, CreateTableStatement, CreateTypeStatement,
     CreateViewStatement, CsrConnectorAvro, CsrConnectorProto, CsrSeed, CsrSeedCompiled,
     CsrSeedCompiledEncoding, CsrSeedCompiledOrLegacy, CsvColumns, DataType, Format, Function,
-    Ident, ProtobufSchema, Raw, RawName, SqlOption, Statement, TableFactor, UnresolvedObjectName,
-    Value, ViewDefinition, WithOption, WithOptionValue,
+    Ident, ProtobufSchema, Raw, RawName, SqlOption, Statement, TableFactor, TableFunction,
+    UnresolvedObjectName, Value, ViewDefinition, WithOption, WithOptionValue,
 };
 use sql::plan::resolve_names_stmt;
 use uuid::Uuid;
@@ -425,7 +425,11 @@ fn ast_use_pg_catalog_0_7_1(stmt: &mut sql::ast::Statement<Raw>) -> Result<(), a
             visit_mut::visit_function_mut(self, func)
         }
         fn visit_table_factor_mut(&mut self, table_factor: &'ast mut TableFactor<Raw>) {
-            if let TableFactor::Function { ref mut name, .. } = table_factor {
+            if let TableFactor::Function {
+                function: TableFunction { ref mut name, .. },
+                ..
+            } = table_factor
+            {
                 normalize_function_name(name);
             }
             // Function args can be functions themselves, so let the visitor

--- a/src/sql-parser/tests/testdata/select
+++ b/src/sql-parser/tests/testdata/select
@@ -844,7 +844,7 @@ SELECT foo FROM LATERAL bar(1)
 ----
 SELECT foo FROM bar(1)
 =>
-Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Function { name: UnresolvedObjectName([Ident("bar")]), args: Args { args: [Value(Number("1"))], order_by: [] }, alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Function { function: TableFunction { name: UnresolvedObjectName([Ident("bar")]), args: Args { args: [Value(Number("1"))], order_by: [] } }, alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT foo FROM LATERAL bar
@@ -1045,14 +1045,21 @@ SELECT * FROM customer LEFT JOIN LATERAL generate_series(1, customer.id) ON true
 ----
 SELECT * FROM customer LEFT JOIN generate_series(1, customer.id) ON true
 =>
-Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("customer")])), alias: None }, joins: [Join { relation: Function { name: UnresolvedObjectName([Ident("generate_series")]), args: Args { args: [Value(Number("1")), Identifier([Ident("customer"), Ident("id")])], order_by: [] }, alias: None }, join_operator: LeftOuter(On(Value(Boolean(true)))) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("customer")])), alias: None }, joins: [Join { relation: Function { function: TableFunction { name: UnresolvedObjectName([Ident("generate_series")]), args: Args { args: [Value(Number("1")), Identifier([Ident("customer"), Ident("id")])], order_by: [] } }, alias: None }, join_operator: LeftOuter(On(Value(Boolean(true)))) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
-SELECT * FROM a LEFT JOIN LATERAL (b CROSS JOIN c)
+SELECT * FROM LATERAL ROWS FROM (generate_series(1, 2), generate_series(3, 5))
 ----
-error: Expected SELECT, VALUES, or a subquery in the query body, found identifier "b"
-SELECT * FROM a LEFT JOIN LATERAL (b CROSS JOIN c)
-                                   ^
+SELECT * FROM ROWS FROM(generate_series(1, 2), generate_series(3, 5))
+=>
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: RowsFrom { functions: [TableFunction { name: UnresolvedObjectName([Ident("generate_series")]), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] } }, TableFunction { name: UnresolvedObjectName([Ident("generate_series")]), args: Args { args: [Value(Number("3")), Value(Number("5"))], order_by: [] } }], alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5))
+----
+SELECT * FROM ROWS FROM(generate_series(1, 2), generate_series(3, 5))
+=>
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: RowsFrom { functions: [TableFunction { name: UnresolvedObjectName([Ident("generate_series")]), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] } }, TableFunction { name: UnresolvedObjectName([Ident("generate_series")]), args: Args { args: [Value(Number("3")), Value(Number("5"))], order_by: [] } }], alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 # Ensure parsing AS OF is case-insensitive
 parse-statement

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -25,8 +25,8 @@ use sql_parser::ast::visit_mut::{self, VisitMut};
 use sql_parser::ast::{
     AstInfo, CreateIndexStatement, CreateSinkStatement, CreateSourceStatement,
     CreateTableStatement, CreateTypeStatement, CreateViewStatement, Function, FunctionArgs, Ident,
-    IfExistsBehavior, Query, Raw, SqlOption, Statement, TableFactor, UnresolvedObjectName, Value,
-    ViewDefinition,
+    IfExistsBehavior, Query, Raw, SqlOption, Statement, TableFactor, TableFunction,
+    UnresolvedObjectName, Value, ViewDefinition,
 };
 
 use crate::names::{DatabaseSpecifier, FullName, PartialName};
@@ -199,8 +199,7 @@ pub fn create_statement(
                     }
                 }
                 TableFactor::Function {
-                    ref mut name,
-                    args,
+                    function: TableFunction { ref mut name, args },
                     alias,
                 } => {
                     if let Err(e) = normalize_function_name(self.scx, name) {

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -915,3 +915,114 @@ SELECT * FROM generate_series('2020-01-01 22:00:00'::TIMESTAMPTZ, '2021-01-01 00
 
 query error step size cannot equal zero
 SELECT * FROM generate_series('2021-01-01 03:00:00'::TIMESTAMPTZ, '2021-01-03 00:00:00'::TIMESTAMPTZ, '0 day');
+
+# Test ROWS FROM
+
+query I colnames
+SELECT * FROM LATERAL ROWS FROM (generate_series(1,1));
+----
+generate_series
+1
+
+query II colnames
+SELECT * FROM LATERAL ROWS FROM (generate_series(1, 2), generate_series(3, 6)) ORDER BY 2;
+----
+generate_series generate_series
+1 3
+2 4
+NULL 5
+NULL 6
+
+query IIII colnames
+SELECT * FROM ROWS FROM (generate_series(1, 2), information_schema._pg_expandarray(array[9]), generate_series(3, 6)) ORDER BY 4;
+----
+generate_series x n generate_series
+1  9  1  3
+2  NULL  NULL  4
+NULL  NULL  NULL  5
+NULL  NULL  NULL  6
+
+query I colnames
+SELECT generate_series FROM ROWS FROM (generate_series(1, 1))
+----
+generate_series
+1
+
+query error column name "generate_series" is ambiguous
+SELECT generate_series FROM ROWS FROM (generate_series(1, 1), generate_series(2, 2))
+
+query I colnames
+SELECT generate_series FROM ROWS FROM (generate_series(1, 1), information_schema._pg_expandarray(array[9]))
+----
+generate_series
+1
+
+query error column "_pg_expandarray" does not exist
+SELECT _pg_expandarray FROM ROWS FROM (generate_series(1, 1), information_schema._pg_expandarray(array[9]))
+
+query I colnames
+SELECT x FROM ROWS FROM (generate_series(1, 1), information_schema._pg_expandarray(array[9]))
+----
+x
+9
+
+# Convert to text because sqllogictest doesn't know how to format records.
+query T colnames
+SELECT _pg_expandarray::text FROM ROWS FROM (information_schema._pg_expandarray(array[9]))
+----
+_pg_expandarray
+(9,1)
+
+query II colnames
+SELECT _pg_expandarray.* FROM ROWS FROM (information_schema._pg_expandarray(array[9]))
+----
+x n
+9 1
+
+# ROWS FROM with aliases
+
+query error Expected right parenthesis
+SELECT * FROM LATERAL ROWS FROM (generate_series(1,1) AS g)
+
+
+query I colnames
+SELECT * FROM LATERAL ROWS FROM (generate_series(1,1)) AS g
+----
+g
+1
+
+query I colnames
+SELECT g.g FROM LATERAL ROWS FROM (generate_series(1,1)) AS g
+----
+g
+1
+
+query I colnames
+SELECT g.g FROM LATERAL ROWS FROM (generate_series(1,1)) AS g(g)
+----
+g
+1
+
+query II colnames
+SELECT * FROM LATERAL ROWS FROM (generate_series(1,1), generate_series(1,1)) AS g
+----
+generate_series generate_series
+1 1
+
+query II colnames
+SELECT g.* FROM LATERAL ROWS FROM (generate_series(1,1), generate_series(1,1)) AS g
+----
+generate_series generate_series
+1 1
+
+query III colnames
+SELECT g.* FROM LATERAL ROWS FROM (generate_series(1,1), information_schema._pg_expandarray(array[1])) AS g
+----
+generate_series x n
+1 1 1
+
+query III colnames
+SELECT * FROM LATERAL ROWS FROM (generate_series(1,1), information_schema._pg_expandarray(array[1])) AS g(a,b,c)
+----
+a b c
+1 1 1


### PR DESCRIPTION
ROWS FROM is valid as a FROM clause and accepts a list of table functions
which are concatenated together as a single table. Implement using row
number and joins based on that.

Closes #9076

### Motivation

  * This PR adds a known-desirable feature. #9076

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
