### PR TITLE
QGM: Support a bunch of BoxScalarExpr variants

### DIFF
--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -1464,10 +1464,10 @@ impl HirScalarExpr {
         }
     }
 
-    /// A generalization of `visit_mut`. The function `pre` runs on a
-    /// `MirScalarExpr` before it runs on any of the child `MirScalarExpr`s.
-    /// The function `post` runs on child `MirScalarExpr`s first before the
-    /// parent. Optionally, `pre` can return which child `MirScalarExpr`s, if
+    /// A generalization of `visit`. The function `pre` runs on a
+    /// `HirScalarExpr` before it runs on any of the child `HirScalarExpr`s.
+    /// The function `post` runs on child `HirScalarExpr`s first before the
+    /// parent. Optionally, `pre` can return which child `HirScalarExpr`s, if
     /// any, should be visited (default is to visit all children).
     pub fn visit_pre_post<F1, F2>(&self, pre: &mut F1, post: &mut F2)
     where

--- a/src/sql/src/plan/optimize.rs
+++ b/src/sql/src/plan/optimize.rs
@@ -43,7 +43,7 @@ impl HirRelationExpr {
     pub fn optimize_and_lower(self, config: &OptimizerConfig) -> expr::MirRelationExpr {
         if config.qgm_optimizations {
             // create a query graph model from this HirRelationExpr
-            let model = Model::from(&self);
+            let model = Model::from(self);
 
             // @todo: perform optimizing algebraic rewrites on the qgm
             // ...

--- a/src/sql/src/query_model/hir.rs
+++ b/src/sql/src/query_model/hir.rs
@@ -197,6 +197,28 @@ impl FromHir {
                 };
                 BoxScalarExpr::ColumnReference(self.find_column_within_box(context_box, c.column))
             }
+            HirScalarExpr::CallNullary(func) => BoxScalarExpr::CallNullary(func.clone()),
+            HirScalarExpr::CallUnary { func, expr } => BoxScalarExpr::CallUnary {
+                func: func.clone(),
+                expr: Box::new(self.generate_expr(expr, context_box)),
+            },
+            HirScalarExpr::CallBinary { func, expr1, expr2 } => BoxScalarExpr::CallBinary {
+                func: func.clone(),
+                expr1: Box::new(self.generate_expr(expr1, context_box)),
+                expr2: Box::new(self.generate_expr(expr2, context_box)),
+            },
+            HirScalarExpr::CallVariadic { func, exprs } => BoxScalarExpr::CallVariadic {
+                func: func.clone(),
+                exprs: exprs
+                    .into_iter()
+                    .map(|expr| self.generate_expr(expr, context_box))
+                    .collect::<Vec<_>>(),
+            },
+            HirScalarExpr::If { cond, then, els } => BoxScalarExpr::If {
+                cond: Box::new(self.generate_expr(cond, context_box)),
+                then: Box::new(self.generate_expr(then, context_box)),
+                els: Box::new(self.generate_expr(els, context_box)),
+            },
             _ => panic!("unsupported expression type {:?}", expr),
         }
     }

--- a/src/sql/src/query_model/test.rs
+++ b/src/sql/src/query_model/test.rs
@@ -237,7 +237,7 @@ fn test_hir_generator() {
                         Err(e) => return format!("unable to plan query: {}: {}", s.input, e),
                     };
 
-                    let model = query_model::Model::from(&planned_query.expr);
+                    let model = query_model::Model::from(planned_query.expr);
 
                     let mut output = String::new();
 

--- a/src/sql/tests/querymodel/basic
+++ b/src/sql/tests/querymodel/basic
@@ -458,3 +458,31 @@ digraph G {
     Q0 -> boxhead1 [ lhead = cluster1 ]
     Q2 -> boxhead3 [ lhead = cluster3 ]
 }
+
+build
+select mz_logical_timestamp(), case when null is null then 1 + 1 else coalesce(0, 2, 1) end
+----
+digraph G {
+    compound = true
+    labeljust = l
+    label="select mz_logical_timestamp(), case when null is null then 1 + 1 else coalesce(0, 2, 1) end"
+    node [ shape = box ]
+    subgraph cluster1 {
+        label = "Box1:Select"
+        boxhead1 [ shape = record, label="{ Distinct: Preserve| 0: mz_logical_timestamp()| 1: if isnull(null) then {(1 + 1)} else {coalesce(0, 2, 1)} }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q0 [ label="Q0(F)" ]
+        }
+    }
+    subgraph cluster0 {
+        label = "Box0:Values"
+        boxhead0 [ shape = record, label="{ Distinct: Preserve| ROW 0:  }" ]
+        {
+            rank = same
+        }
+    }
+    edge [ arrowhead = none, style = dashed ]
+    Q0 -> boxhead0 [ lhead = cluster0 ]
+}

--- a/src/sql/tests/querymodel/basic
+++ b/src/sql/tests/querymodel/basic
@@ -13,20 +13,20 @@ select;
 digraph G {
     compound = true
     labeljust = l
-    label="select;"
+    label = "select;"
     node [ shape = box ]
     subgraph cluster1 {
         label = "Box1:Select"
-        boxhead1 [ shape = record, label="{ Distinct: Preserve }" ]
+        boxhead1 [ shape = record, label = "{ Distinct: Preserve }" ]
         {
             rank = same
             node [ shape = circle ]
-            Q0 [ label="Q0(F)" ]
+            Q0 [ label = "Q0(F)" ]
         }
     }
     subgraph cluster0 {
         label = "Box0:Values"
-        boxhead0 [ shape = record, label="{ Distinct: Preserve| ROW 0:  }" ]
+        boxhead0 [ shape = record, label = "{ Distinct: Preserve| ROW:  }" ]
         {
             rank = same
         }
@@ -41,20 +41,20 @@ select 1;
 digraph G {
     compound = true
     labeljust = l
-    label="select 1;"
+    label = "select 1;"
     node [ shape = box ]
     subgraph cluster1 {
         label = "Box1:Select"
-        boxhead1 [ shape = record, label="{ Distinct: Preserve| 0: 1 }" ]
+        boxhead1 [ shape = record, label = "{ Distinct: Preserve| 0: 1 }" ]
         {
             rank = same
             node [ shape = circle ]
-            Q0 [ label="Q0(F)" ]
+            Q0 [ label = "Q0(F)" ]
         }
     }
     subgraph cluster0 {
         label = "Box0:Values"
-        boxhead0 [ shape = record, label="{ Distinct: Preserve| ROW 0:  }" ]
+        boxhead0 [ shape = record, label = "{ Distinct: Preserve| ROW:  }" ]
         {
             rank = same
         }
@@ -69,29 +69,29 @@ select a, a from (select 1 as a);
 digraph G {
     compound = true
     labeljust = l
-    label="select a, a from (select 1 as a);"
+    label = "select a, a from (select 1 as a);"
     node [ shape = box ]
     subgraph cluster2 {
         label = "Box2:Select"
-        boxhead2 [ shape = record, label="{ Distinct: Preserve| 0: Q1.C0| 1: Q1.C0 }" ]
+        boxhead2 [ shape = record, label = "{ Distinct: Preserve| 0: Q1.C0| 1: Q1.C0 }" ]
         {
             rank = same
             node [ shape = circle ]
-            Q1 [ label="Q1(F)" ]
+            Q1 [ label = "Q1(F)" ]
         }
     }
     subgraph cluster1 {
         label = "Box1:Select"
-        boxhead1 [ shape = record, label="{ Distinct: Preserve| 0: 1 }" ]
+        boxhead1 [ shape = record, label = "{ Distinct: Preserve| 0: 1 }" ]
         {
             rank = same
             node [ shape = circle ]
-            Q0 [ label="Q0(F)" ]
+            Q0 [ label = "Q0(F)" ]
         }
     }
     subgraph cluster0 {
         label = "Box0:Values"
-        boxhead0 [ shape = record, label="{ Distinct: Preserve| ROW 0:  }" ]
+        boxhead0 [ shape = record, label = "{ Distinct: Preserve| ROW:  }" ]
         {
             rank = same
         }
@@ -108,29 +108,29 @@ select a, b, a from (select 1 as a, 2 as b);
 digraph G {
     compound = true
     labeljust = l
-    label="select a, b, a from (select 1 as a, 2 as b);"
+    label = "select a, b, a from (select 1 as a, 2 as b);"
     node [ shape = box ]
     subgraph cluster2 {
         label = "Box2:Select"
-        boxhead2 [ shape = record, label="{ Distinct: Preserve| 0: Q1.C0| 1: Q1.C1| 2: Q1.C0 }" ]
+        boxhead2 [ shape = record, label = "{ Distinct: Preserve| 0: Q1.C0| 1: Q1.C1| 2: Q1.C0 }" ]
         {
             rank = same
             node [ shape = circle ]
-            Q1 [ label="Q1(F)" ]
+            Q1 [ label = "Q1(F)" ]
         }
     }
     subgraph cluster1 {
         label = "Box1:Select"
-        boxhead1 [ shape = record, label="{ Distinct: Preserve| 0: 1| 1: 2 }" ]
+        boxhead1 [ shape = record, label = "{ Distinct: Preserve| 0: 1| 1: 2 }" ]
         {
             rank = same
             node [ shape = circle ]
-            Q0 [ label="Q0(F)" ]
+            Q0 [ label = "Q0(F)" ]
         }
     }
     subgraph cluster0 {
         label = "Box0:Values"
-        boxhead0 [ shape = record, label="{ Distinct: Preserve| ROW 0:  }" ]
+        boxhead0 [ shape = record, label = "{ Distinct: Preserve| ROW:  }" ]
         {
             rank = same
         }
@@ -146,38 +146,38 @@ select a from (select 1 as a, true as b) where b;
 digraph G {
     compound = true
     labeljust = l
-    label="select a from (select 1 as a, true as b) where b;"
+    label = "select a from (select 1 as a, true as b) where b;"
     node [ shape = box ]
     subgraph cluster3 {
         label = "Box3:Select"
-        boxhead3 [ shape = record, label="{ Distinct: Preserve| 0: Q2.C0 }" ]
+        boxhead3 [ shape = record, label = "{ Distinct: Preserve| 0: Q2.C0 }" ]
         {
             rank = same
             node [ shape = circle ]
-            Q2 [ label="Q2(F)" ]
+            Q2 [ label = "Q2(F)" ]
         }
     }
     subgraph cluster2 {
         label = "Box2:Select"
-        boxhead2 [ shape = record, label="{ Distinct: Preserve| 0: Q1.C0| 1: Q1.C1| Q1.C1 }" ]
+        boxhead2 [ shape = record, label = "{ Distinct: Preserve| 0: Q1.C0| 1: Q1.C1| Q1.C1 }" ]
         {
             rank = same
             node [ shape = circle ]
-            Q1 [ label="Q1(F)" ]
+            Q1 [ label = "Q1(F)" ]
         }
     }
     subgraph cluster1 {
         label = "Box1:Select"
-        boxhead1 [ shape = record, label="{ Distinct: Preserve| 0: 1| 1: true }" ]
+        boxhead1 [ shape = record, label = "{ Distinct: Preserve| 0: 1| 1: true }" ]
         {
             rank = same
             node [ shape = circle ]
-            Q0 [ label="Q0(F)" ]
+            Q0 [ label = "Q0(F)" ]
         }
     }
     subgraph cluster0 {
         label = "Box0:Values"
-        boxhead0 [ shape = record, label="{ Distinct: Preserve| ROW 0:  }" ]
+        boxhead0 [ shape = record, label = "{ Distinct: Preserve| ROW:  }" ]
         {
             rank = same
         }
@@ -194,55 +194,55 @@ select x.a from (select true as a) x join (select false as b) y on x.a;
 digraph G {
     compound = true
     labeljust = l
-    label="select x.a from (select true as a) x join (select false as b) y on x.a;"
+    label = "select x.a from (select true as a) x join (select false as b) y on x.a;"
     node [ shape = box ]
     subgraph cluster5 {
         label = "Box5:Select"
-        boxhead5 [ shape = record, label="{ Distinct: Preserve| 0: Q4.C0 }" ]
+        boxhead5 [ shape = record, label = "{ Distinct: Preserve| 0: Q4.C0 }" ]
         {
             rank = same
             node [ shape = circle ]
-            Q4 [ label="Q4(F)" ]
+            Q4 [ label = "Q4(F)" ]
         }
     }
     subgraph cluster0 {
         label = "Box0:Select"
-        boxhead0 [ shape = record, label="{ Distinct: Preserve| 0: Q1.C0| 1: Q3.C0| Q1.C0 }" ]
+        boxhead0 [ shape = record, label = "{ Distinct: Preserve| 0: Q1.C0| 1: Q3.C0| Q1.C0 }" ]
         {
             rank = same
             node [ shape = circle ]
-            Q1 [ label="Q1(F)" ]
-            Q3 [ label="Q3(F)" ]
+            Q1 [ label = "Q1(F)" ]
+            Q3 [ label = "Q3(F)" ]
         }
     }
     subgraph cluster2 {
         label = "Box2:Select"
-        boxhead2 [ shape = record, label="{ Distinct: Preserve| 0: true }" ]
+        boxhead2 [ shape = record, label = "{ Distinct: Preserve| 0: true }" ]
         {
             rank = same
             node [ shape = circle ]
-            Q0 [ label="Q0(F)" ]
+            Q0 [ label = "Q0(F)" ]
         }
     }
     subgraph cluster1 {
         label = "Box1:Values"
-        boxhead1 [ shape = record, label="{ Distinct: Preserve| ROW 0:  }" ]
+        boxhead1 [ shape = record, label = "{ Distinct: Preserve| ROW:  }" ]
         {
             rank = same
         }
     }
     subgraph cluster4 {
         label = "Box4:Select"
-        boxhead4 [ shape = record, label="{ Distinct: Preserve| 0: false }" ]
+        boxhead4 [ shape = record, label = "{ Distinct: Preserve| 0: false }" ]
         {
             rank = same
             node [ shape = circle ]
-            Q2 [ label="Q2(F)" ]
+            Q2 [ label = "Q2(F)" ]
         }
     }
     subgraph cluster3 {
         label = "Box3:Values"
-        boxhead3 [ shape = record, label="{ Distinct: Preserve| ROW 0:  }" ]
+        boxhead3 [ shape = record, label = "{ Distinct: Preserve| ROW:  }" ]
         {
             rank = same
         }
@@ -262,56 +262,56 @@ select x.a from (select true as a) x join lateral(select a) y on x.a;
 digraph G {
     compound = true
     labeljust = l
-    label="select x.a from (select true as a) x join lateral(select a) y on x.a;"
+    label = "select x.a from (select true as a) x join lateral(select a) y on x.a;"
     node [ shape = box ]
     subgraph cluster5 {
         label = "Box5:Select"
-        boxhead5 [ shape = record, label="{ Distinct: Preserve| 0: Q4.C0 }" ]
+        boxhead5 [ shape = record, label = "{ Distinct: Preserve| 0: Q4.C0 }" ]
         {
             rank = same
             node [ shape = circle ]
-            Q4 [ label="Q4(F)" ]
+            Q4 [ label = "Q4(F)" ]
         }
     }
     subgraph cluster0 {
         label = "Box0:Select"
-        boxhead0 [ shape = record, label="{ Distinct: Preserve| 0: Q1.C0| 1: Q3.C0| Q1.C0 }" ]
+        boxhead0 [ shape = record, label = "{ Distinct: Preserve| 0: Q1.C0| 1: Q3.C0| Q1.C0 }" ]
         {
             rank = same
             node [ shape = circle ]
-            Q1 [ label="Q1(F)" ]
-            Q3 [ label="Q3(F)" ]
+            Q1 [ label = "Q1(F)" ]
+            Q3 [ label = "Q3(F)" ]
             Q3 -> Q1 [ label = "correlation", style = filled, color = red ]
         }
     }
     subgraph cluster2 {
         label = "Box2:Select"
-        boxhead2 [ shape = record, label="{ Distinct: Preserve| 0: true }" ]
+        boxhead2 [ shape = record, label = "{ Distinct: Preserve| 0: true }" ]
         {
             rank = same
             node [ shape = circle ]
-            Q0 [ label="Q0(F)" ]
+            Q0 [ label = "Q0(F)" ]
         }
     }
     subgraph cluster1 {
         label = "Box1:Values"
-        boxhead1 [ shape = record, label="{ Distinct: Preserve| ROW 0:  }" ]
+        boxhead1 [ shape = record, label = "{ Distinct: Preserve| ROW:  }" ]
         {
             rank = same
         }
     }
     subgraph cluster4 {
         label = "Box4:Select"
-        boxhead4 [ shape = record, label="{ Distinct: Preserve| 0: Q1.C0 }" ]
+        boxhead4 [ shape = record, label = "{ Distinct: Preserve| 0: Q1.C0 }" ]
         {
             rank = same
             node [ shape = circle ]
-            Q2 [ label="Q2(F)" ]
+            Q2 [ label = "Q2(F)" ]
         }
     }
     subgraph cluster3 {
         label = "Box3:Values"
-        boxhead3 [ shape = record, label="{ Distinct: Preserve| ROW 0:  }" ]
+        boxhead3 [ shape = record, label = "{ Distinct: Preserve| ROW:  }" ]
         {
             rank = same
         }
@@ -330,55 +330,55 @@ select x.a from (select true as a) x left join (select false as b) y on x.a;
 digraph G {
     compound = true
     labeljust = l
-    label="select x.a from (select true as a) x left join (select false as b) y on x.a;"
+    label = "select x.a from (select true as a) x left join (select false as b) y on x.a;"
     node [ shape = box ]
     subgraph cluster5 {
         label = "Box5:Select"
-        boxhead5 [ shape = record, label="{ Distinct: Preserve| 0: Q4.C0 }" ]
+        boxhead5 [ shape = record, label = "{ Distinct: Preserve| 0: Q4.C0 }" ]
         {
             rank = same
             node [ shape = circle ]
-            Q4 [ label="Q4(F)" ]
+            Q4 [ label = "Q4(F)" ]
         }
     }
     subgraph cluster0 {
         label = "Box0:OuterJoin"
-        boxhead0 [ shape = record, label="{ Distinct: Preserve| 0: Q1.C0| 1: Q3.C0| Q1.C0 }" ]
+        boxhead0 [ shape = record, label = "{ Distinct: Preserve| 0: Q1.C0| 1: Q3.C0| Q1.C0 }" ]
         {
             rank = same
             node [ shape = circle ]
-            Q1 [ label="Q1(P)" ]
-            Q3 [ label="Q3(F)" ]
+            Q1 [ label = "Q1(P)" ]
+            Q3 [ label = "Q3(F)" ]
         }
     }
     subgraph cluster2 {
         label = "Box2:Select"
-        boxhead2 [ shape = record, label="{ Distinct: Preserve| 0: true }" ]
+        boxhead2 [ shape = record, label = "{ Distinct: Preserve| 0: true }" ]
         {
             rank = same
             node [ shape = circle ]
-            Q0 [ label="Q0(F)" ]
+            Q0 [ label = "Q0(F)" ]
         }
     }
     subgraph cluster1 {
         label = "Box1:Values"
-        boxhead1 [ shape = record, label="{ Distinct: Preserve| ROW 0:  }" ]
+        boxhead1 [ shape = record, label = "{ Distinct: Preserve| ROW:  }" ]
         {
             rank = same
         }
     }
     subgraph cluster4 {
         label = "Box4:Select"
-        boxhead4 [ shape = record, label="{ Distinct: Preserve| 0: false }" ]
+        boxhead4 [ shape = record, label = "{ Distinct: Preserve| 0: false }" ]
         {
             rank = same
             node [ shape = circle ]
-            Q2 [ label="Q2(F)" ]
+            Q2 [ label = "Q2(F)" ]
         }
     }
     subgraph cluster3 {
         label = "Box3:Values"
-        boxhead3 [ shape = record, label="{ Distinct: Preserve| ROW 0:  }" ]
+        boxhead3 [ shape = record, label = "{ Distinct: Preserve| ROW:  }" ]
         {
             rank = same
         }
@@ -397,56 +397,56 @@ select x.a from (select true as a) x left join lateral (select a as b) y on x.a;
 digraph G {
     compound = true
     labeljust = l
-    label="select x.a from (select true as a) x left join lateral (select a as b) y on x.a;"
+    label = "select x.a from (select true as a) x left join lateral (select a as b) y on x.a;"
     node [ shape = box ]
     subgraph cluster5 {
         label = "Box5:Select"
-        boxhead5 [ shape = record, label="{ Distinct: Preserve| 0: Q4.C0 }" ]
+        boxhead5 [ shape = record, label = "{ Distinct: Preserve| 0: Q4.C0 }" ]
         {
             rank = same
             node [ shape = circle ]
-            Q4 [ label="Q4(F)" ]
+            Q4 [ label = "Q4(F)" ]
         }
     }
     subgraph cluster0 {
         label = "Box0:OuterJoin"
-        boxhead0 [ shape = record, label="{ Distinct: Preserve| 0: Q1.C0| 1: Q3.C0| Q1.C0 }" ]
+        boxhead0 [ shape = record, label = "{ Distinct: Preserve| 0: Q1.C0| 1: Q3.C0| Q1.C0 }" ]
         {
             rank = same
             node [ shape = circle ]
-            Q1 [ label="Q1(P)" ]
-            Q3 [ label="Q3(F)" ]
+            Q1 [ label = "Q1(P)" ]
+            Q3 [ label = "Q3(F)" ]
             Q3 -> Q1 [ label = "correlation", style = filled, color = red ]
         }
     }
     subgraph cluster2 {
         label = "Box2:Select"
-        boxhead2 [ shape = record, label="{ Distinct: Preserve| 0: true }" ]
+        boxhead2 [ shape = record, label = "{ Distinct: Preserve| 0: true }" ]
         {
             rank = same
             node [ shape = circle ]
-            Q0 [ label="Q0(F)" ]
+            Q0 [ label = "Q0(F)" ]
         }
     }
     subgraph cluster1 {
         label = "Box1:Values"
-        boxhead1 [ shape = record, label="{ Distinct: Preserve| ROW 0:  }" ]
+        boxhead1 [ shape = record, label = "{ Distinct: Preserve| ROW:  }" ]
         {
             rank = same
         }
     }
     subgraph cluster4 {
         label = "Box4:Select"
-        boxhead4 [ shape = record, label="{ Distinct: Preserve| 0: Q1.C0 }" ]
+        boxhead4 [ shape = record, label = "{ Distinct: Preserve| 0: Q1.C0 }" ]
         {
             rank = same
             node [ shape = circle ]
-            Q2 [ label="Q2(F)" ]
+            Q2 [ label = "Q2(F)" ]
         }
     }
     subgraph cluster3 {
         label = "Box3:Values"
-        boxhead3 [ shape = record, label="{ Distinct: Preserve| ROW 0:  }" ]
+        boxhead3 [ shape = record, label = "{ Distinct: Preserve| ROW:  }" ]
         {
             rank = same
         }
@@ -465,24 +465,74 @@ select mz_logical_timestamp(), case when null is null then 1 + 1 else coalesce(0
 digraph G {
     compound = true
     labeljust = l
-    label="select mz_logical_timestamp(), case when null is null then 1 + 1 else coalesce(0, 2, 1) end"
+    label = "select mz_logical_timestamp(), case when null is null then 1 + 1 else coalesce(0, 2, 1) end"
     node [ shape = box ]
     subgraph cluster1 {
         label = "Box1:Select"
-        boxhead1 [ shape = record, label="{ Distinct: Preserve| 0: mz_logical_timestamp()| 1: if isnull(null) then {(1 + 1)} else {coalesce(0, 2, 1)} }" ]
+        boxhead1 [ shape = record, label = "{ Distinct: Preserve| 0: mz_logical_timestamp()| 1: if isnull(null) then \{(1 + 1)\} else \{coalesce(0, 2, 1)\} }" ]
         {
             rank = same
             node [ shape = circle ]
-            Q0 [ label="Q0(F)" ]
+            Q0 [ label = "Q0(F)" ]
         }
     }
     subgraph cluster0 {
         label = "Box0:Values"
-        boxhead0 [ shape = record, label="{ Distinct: Preserve| ROW 0:  }" ]
+        boxhead0 [ shape = record, label = "{ Distinct: Preserve| ROW:  }" ]
         {
             rank = same
         }
     }
     edge [ arrowhead = none, style = dashed ]
+    Q0 -> boxhead0 [ lhead = cluster0 ]
+}
+
+build
+select case when not x.a then ltrim('e', x.b) else substr(x.c, 3, 4) end, mz_logical_timestamp()
+from (select false as a, null as b, null as c) x
+----
+digraph G {
+    compound = true
+    labeljust = l
+    label = "select case when not x.a then ltrim('e', x.b) else substr(x.c, 3, 4) end, mz_logical_timestamp()
+from (select false as a, null as b, null as c) x"
+    node [ shape = box ]
+    subgraph cluster3 {
+        label = "Box3:Select"
+        boxhead3 [ shape = record, label = "{ Distinct: Preserve| 0: Q2.C3| 1: Q2.C4 }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q2 [ label = "Q2(F)" ]
+        }
+    }
+    subgraph cluster2 {
+        label = "Box2:Select"
+        boxhead2 [ shape = record, label = "{ Distinct: Preserve| 0: Q1.C0| 1: Q1.C1| 2: Q1.C2| 3: if !(Q1.C0) then \{ltrim(\"e\", Q1.C1)\} else \{substr(Q1.C2, i32toi64(3), i32toi64(4))\}| 4: mz_logical_timestamp() }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q1 [ label = "Q1(F)" ]
+        }
+    }
+    subgraph cluster1 {
+        label = "Box1:Select"
+        boxhead1 [ shape = record, label = "{ Distinct: Preserve| 0: false| 1: null| 2: null }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q0 [ label = "Q0(F)" ]
+        }
+    }
+    subgraph cluster0 {
+        label = "Box0:Values"
+        boxhead0 [ shape = record, label = "{ Distinct: Preserve| ROW:  }" ]
+        {
+            rank = same
+        }
+    }
+    edge [ arrowhead = none, style = dashed ]
+    Q2 -> boxhead2 [ lhead = cluster2 ]
+    Q1 -> boxhead1 [ lhead = cluster1 ]
     Q0 -> boxhead0 [ lhead = cluster0 ]
 }

--- a/src/sql/tests/querymodel/dotformat
+++ b/src/sql/tests/querymodel/dotformat
@@ -1,0 +1,113 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# The following do not cause an invalid graph to be generated:
+# * Quotes in the column name.
+# * The presence of a string literal.
+build
+select case when x."a3R" is null then coalesce(x.b, x.c, 'hello') else substr(x.b, 3) end, mz_logical_timestamp()
+from (select null as "a3R", null as b, null as c) x
+----
+digraph G {
+    compound = true
+    labeljust = l
+    label = "select case when x.\"a3R\" is null then coalesce(x.b, x.c, 'hello') else substr(x.b, 3) end, mz_logical_timestamp()
+from (select null as \"a3R\", null as b, null as c) x"
+    node [ shape = box ]
+    subgraph cluster3 {
+        label = "Box3:Select"
+        boxhead3 [ shape = record, label = "{ Distinct: Preserve| 0: Q2.C3| 1: Q2.C4 }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q2 [ label = "Q2(F)" ]
+        }
+    }
+    subgraph cluster2 {
+        label = "Box2:Select"
+        boxhead2 [ shape = record, label = "{ Distinct: Preserve| 0: Q1.C0| 1: Q1.C1| 2: Q1.C2| 3: if isnull(Q1.C0) then \{coalesce(Q1.C1, Q1.C2, \"hello\")\} else \{substr(Q1.C1, i32toi64(3))\}| 4: mz_logical_timestamp() }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q1 [ label = "Q1(F)" ]
+        }
+    }
+    subgraph cluster1 {
+        label = "Box1:Select"
+        boxhead1 [ shape = record, label = "{ Distinct: Preserve| 0: null| 1: null| 2: null }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q0 [ label = "Q0(F)" ]
+        }
+    }
+    subgraph cluster0 {
+        label = "Box0:Values"
+        boxhead0 [ shape = record, label = "{ Distinct: Preserve| ROW:  }" ]
+        {
+            rank = same
+        }
+    }
+    edge [ arrowhead = none, style = dashed ]
+    Q2 -> boxhead2 [ lhead = cluster2 ]
+    Q1 -> boxhead1 [ lhead = cluster1 ]
+    Q0 -> boxhead0 [ lhead = cluster0 ]
+}
+
+# The following do not cause an invalid graph to be generated:
+# * The presence of an OR operator.
+# * Quotes in the table name.
+
+build
+select "CdX".a or false from (select true as a) "CdX"
+----
+digraph G {
+    compound = true
+    labeljust = l
+    label = "select \"CdX\".a or false from (select true as a) \"CdX\""
+    node [ shape = box ]
+    subgraph cluster3 {
+        label = "Box3:Select"
+        boxhead3 [ shape = record, label = "{ Distinct: Preserve| 0: Q2.C1 }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q2 [ label = "Q2(F)" ]
+        }
+    }
+    subgraph cluster2 {
+        label = "Box2:Select"
+        boxhead2 [ shape = record, label = "{ Distinct: Preserve| 0: Q1.C0| 1: (Q1.C0 \|\| false) }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q1 [ label = "Q1(F)" ]
+        }
+    }
+    subgraph cluster1 {
+        label = "Box1:Select"
+        boxhead1 [ shape = record, label = "{ Distinct: Preserve| 0: true }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q0 [ label = "Q0(F)" ]
+        }
+    }
+    subgraph cluster0 {
+        label = "Box0:Values"
+        boxhead0 [ shape = record, label = "{ Distinct: Preserve| ROW:  }" ]
+        {
+            rank = same
+        }
+    }
+    edge [ arrowhead = none, style = dashed ]
+    Q2 -> boxhead2 [ lhead = cluster2 ]
+    Q1 -> boxhead1 [ lhead = cluster1 ]
+    Q0 -> boxhead0 [ lhead = cluster0 ]
+}

--- a/src/sql/tests/querymodel/lowering
+++ b/src/sql/tests/querymodel/lowering
@@ -138,3 +138,26 @@ coalesce(0, 2, 1) end
 | Project (#0, #1)
 ----
 ----
+
+lower
+select case when x.a > x.b then x.c else lpad(x.d, 4, 'ab') end
+from (select 10 as a, 5 as b, 'world' as c, 'realm' as d) x
+----
+----
+%0 = Let l0 =
+| Constant ()
+
+%1 =
+| Constant ()
+
+%2 =
+| Join %0 %1
+| | implementation = Unimplemented
+| Map 10, 5, "world", "realm"
+| Project (#0..#3)
+| Map #0, #1, #2, #3, if (#0 > #1) then {#2} else {lpad(#3, i32toi64(4), "ab")}
+| Project (#4..#8)
+| Map #4
+| Project (#5)
+----
+----

--- a/src/sql/tests/querymodel/lowering
+++ b/src/sql/tests/querymodel/lowering
@@ -119,3 +119,22 @@ select x.a from (select true as a) x join (select false as b) y on x.a;
 | Project (#2)
 ----
 ----
+
+lower
+select mz_logical_timestamp(), case when true = false then -(1 + 1) else
+coalesce(0, 2, 1) end
+----
+----
+%0 = Let l0 =
+| Constant ()
+
+%1 =
+| Constant ()
+
+%2 =
+| Join %0 %1
+| | implementation = Unimplemented
+| Map mz_logical_timestamp(), if (true = false) then {-((1 + 1))} else {coalesce(0, 2, 1)}
+| Project (#0, #1)
+----
+----


### PR DESCRIPTION
First commit closes #9140. It also adds function resolution for `TestCatalog`, so we can parse all kinds of functions except for `cast` since `cast` requires the `TestCatalog` to also be able to resolve types.
Second commit closes #9131 by adding support for self-referencing maps. This allows me to test functions containing column references. While testing, I noticed that some expressions break graph rendering because their display form contains characters that the Dot language treats as control characters. Added a DotLabel object so we can standardize the generating of graph labels and escape characters.

TODO:
* @asenac says we can support `cast` by allowing `HirRelationExpr` to be specified using the lisp-like syntax, but I haven't gotten around to it. 


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
