### PR TITLE
Convert a few more unary functions

### DIFF
--- a/src/expr-test-util/src/lib.rs
+++ b/src/expr-test-util/src/lib.rs
@@ -14,7 +14,7 @@ use proc_macro2::TokenTree;
 use serde_json::Value;
 
 use expr::explain::ViewExplanation;
-use expr::func::{CastInt16ToInt32, IsNull, NegInt32, Not};
+use expr::func::{CastInt16ToInt32, CastInt32ToInt64, IsNull, NegInt32, Not};
 use expr::*;
 use lowertest::*;
 use ore::result::ResultExt;
@@ -40,6 +40,7 @@ gen_reflect_info_func!(
     [
         AggregateExpr,
         CastInt16ToInt32,
+        CastInt32ToInt64,
         ColumnOrder,
         ColumnType,
         RelationType,

--- a/src/expr-test-util/src/lib.rs
+++ b/src/expr-test-util/src/lib.rs
@@ -14,7 +14,7 @@ use proc_macro2::TokenTree;
 use serde_json::Value;
 
 use expr::explain::ViewExplanation;
-use expr::func::{IsNull, NegInt32, Not};
+use expr::func::{CastInt16ToInt32, IsNull, NegInt32, Not};
 use expr::*;
 use lowertest::*;
 use ore::result::ResultExt;
@@ -39,6 +39,7 @@ gen_reflect_info_func!(
     ],
     [
         AggregateExpr,
+        CastInt16ToInt32,
         ColumnOrder,
         ColumnType,
         RelationType,

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -1523,7 +1523,10 @@ impl AggregateExpr {
             }
 
             // SumInt16 takes Int16s as input, but outputs Int64s.
-            AggregateFunc::SumInt16 => self.expr.clone().call_unary(UnaryFunc::CastInt16ToInt64),
+            AggregateFunc::SumInt16 => self
+                .expr
+                .clone()
+                .call_unary(UnaryFunc::CastInt16ToInt64(scalar_func::CastInt16ToInt64)),
 
             // SumInt32 takes Int32s as input, but outputs Int64s.
             AggregateFunc::SumInt32 => self.expr.clone().call_unary(UnaryFunc::CastInt32ToInt64),

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -1529,7 +1529,10 @@ impl AggregateExpr {
                 .call_unary(UnaryFunc::CastInt16ToInt64(scalar_func::CastInt16ToInt64)),
 
             // SumInt32 takes Int32s as input, but outputs Int64s.
-            AggregateFunc::SumInt32 => self.expr.clone().call_unary(UnaryFunc::CastInt32ToInt64),
+            AggregateFunc::SumInt32 => self
+                .expr
+                .clone()
+                .call_unary(UnaryFunc::CastInt32ToInt64(scalar_func::CastInt32ToInt64)),
 
             // SumInt64 takes Int64s as input, but outputs numerics.
             AggregateFunc::SumInt64 => self

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -3550,13 +3550,7 @@ trait EagerUnaryFunc {
     fn call(&self, input: Self::Input) -> Self::Output;
 
     /// The output ColumnType of this function
-    fn output_type(&self, input_type: ColumnType) -> ColumnType {
-        let output = Self::Output::as_column_type();
-        let nullable = output.nullable;
-        // The output is nullable if it is nullable by itself or the input is nullable and this
-        // function propagates nulls
-        output.nullable(nullable || (self.propagates_nulls() && input_type.nullable))
-    }
+    fn output_type(&self, input_type: ColumnType) -> ColumnType;
 
     /// Whether this function will produce NULL on NULL input
     fn propagates_nulls(&self) -> bool {

--- a/src/expr/src/scalar/func/impls/int16.rs
+++ b/src/expr/src/scalar/func/impls/int16.rs
@@ -12,8 +12,8 @@ use std::fmt;
 use serde::{Deserialize, Serialize};
 
 use lowertest::MzStructReflect;
-use repr::{ColumnType, ScalarType};
 use repr::adt::numeric::{self, Numeric};
+use repr::{strconv, ColumnType, ScalarType};
 
 use crate::scalar::func::EagerUnaryFunc;
 use crate::EvalError;
@@ -36,6 +36,48 @@ sqlfunc!(
     #[sqlname = "abs"]
     fn abs_int16(a: i16) -> i16 {
         a.abs()
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "i16tof32"]
+    #[preserves_uniqueness = true]
+    fn cast_int16_to_float32(a: i16) -> f32 {
+        f32::from(a)
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "i16tof64"]
+    #[preserves_uniqueness = true]
+    fn cast_int16_to_float64(a: i16) -> f64 {
+        f64::from(a)
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "i16toi32"]
+    #[preserves_uniqueness = true]
+    fn cast_int16_to_int32(a: i16) -> i32 {
+        i32::from(a)
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "i16toi64"]
+    #[preserves_uniqueness = true]
+    fn cast_int16_to_int64(a: i16) -> i64 {
+        i64::from(a)
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "i16tostr"]
+    #[preserves_uniqueness = true]
+    fn cast_int16_to_string(a: i16) -> String {
+        let mut buf = String::new();
+        strconv::format_int16(&mut buf, a);
+        buf
     }
 );
 

--- a/src/expr/src/scalar/func/impls/int16.rs
+++ b/src/expr/src/scalar/func/impls/int16.rs
@@ -12,6 +12,7 @@ use std::fmt;
 use serde::{Deserialize, Serialize};
 
 use lowertest::MzStructReflect;
+use repr::{ColumnType, ScalarType};
 use repr::adt::numeric::{self, Numeric};
 
 use crate::scalar::func::EagerUnaryFunc;
@@ -55,6 +56,10 @@ impl EagerUnaryFunc for CastInt16ToNumeric {
             }
         }
         Ok(a)
+    }
+
+    fn output_type(&self, input: ColumnType) -> ColumnType {
+        ScalarType::Numeric { scale: self.0 }.nullable(input.nullable)
     }
 }
 

--- a/src/expr/src/scalar/func/impls/int32.rs
+++ b/src/expr/src/scalar/func/impls/int32.rs
@@ -7,6 +7,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use crate::EvalError;
+use repr::strconv;
+
 sqlfunc!(
     #[sqlname = "-"]
     fn neg_int32(a: i32) -> i32 {
@@ -25,5 +28,52 @@ sqlfunc!(
     #[sqlname = "abs"]
     fn abs_int32(a: i32) -> i32 {
         a.abs()
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "i32tobool"]
+    fn cast_int32_to_bool(a: i32) -> bool {
+        a != 0
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "i32tof32"]
+    fn cast_int32_to_float32(a: i32) -> f32 {
+        a as f32
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "i32tof64"]
+    #[preserves_uniqueness = true]
+    fn cast_int32_to_float64(a: i32) -> f64 {
+        f64::from(a)
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "i32toi16"]
+    fn cast_int32_to_int16(a: i32) -> Result<i16, EvalError> {
+        i16::try_from(a).or(Err(EvalError::Int16OutOfRange))
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "i32toi64"]
+    #[preserves_uniqueness = true]
+    fn cast_int32_to_int64(a: i32) -> i64 {
+        i64::from(a)
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "i32tostr"]
+    #[preserves_uniqueness = true]
+    fn cast_int32_to_string(a: i32) -> String {
+        let mut buf = String::new();
+        strconv::format_int32(&mut buf, a);
+        buf
     }
 );

--- a/src/expr/src/scalar/func/macros.rs
+++ b/src/expr/src/scalar/func/macros.rs
@@ -34,6 +34,16 @@ macro_rules! sqlfunc {
                 fn call(&self, a: Self::Input) -> Self::Output {
                     $fn_name(a)
                 }
+
+                fn output_type(&self, input_type: repr::ColumnType) -> repr::ColumnType {
+                    use repr::DatumType;
+                    let output = <Self::Output as DatumType<crate::EvalError>>::as_column_type();
+                    let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+                    let nullable = output.nullable;
+                    // The output is nullable if it is nullable by itself or the input is nullable
+                    // and this function propagates nulls
+                    output.nullable(nullable || (propagates_nulls && input_type.nullable))
+                }
             }
 
             impl std::fmt::Display for [<$fn_name:camel>] {

--- a/src/expr/src/scalar/func/macros.rs
+++ b/src/expr/src/scalar/func/macros.rs
@@ -18,8 +18,21 @@ macro_rules! sqlfunc {
         );
     };
 
+    // Add the uniqueness attribute if it was omitted
     (
         #[sqlname = $name:expr]
+        fn $fn_name:ident $($tail:tt)*
+    ) => {
+        sqlfunc!(
+            #[sqlname = $name]
+            #[preserves_uniqueness = false]
+            fn $fn_name $($tail)*
+        );
+    };
+
+    (
+        #[sqlname = $name:expr]
+        #[preserves_uniqueness = $preserves_uniqueness:expr]
         fn $fn_name:ident($param_name:ident: $input_ty:ty) -> $output_ty:ty
             $body:block
     ) => {
@@ -43,6 +56,10 @@ macro_rules! sqlfunc {
                     // The output is nullable if it is nullable by itself or the input is nullable
                     // and this function propagates nulls
                     output.nullable(nullable || (propagates_nulls && input_type.nullable))
+                }
+
+                fn preserves_uniqueness(&self) -> bool {
+                    $preserves_uniqueness
                 }
             }
 

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -129,15 +129,15 @@ lazy_static! {
             (Bool, String) => Assignment: CastBoolToString,
 
             //INT16
-            (Int16, Int32) => Implicit: CastInt16ToInt32,
-            (Int16, Int64) => Implicit: CastInt16ToInt64,
-            (Int16, Float32) => Implicit: CastInt16ToFloat32,
-            (Int16, Float64) => Implicit: CastInt16ToFloat64,
+            (Int16, Int32) => Implicit: CastInt16ToInt32(func::CastInt16ToInt32),
+            (Int16, Int64) => Implicit: CastInt16ToInt64(func::CastInt16ToInt64),
+            (Int16, Float32) => Implicit: CastInt16ToFloat32(func::CastInt16ToFloat32),
+            (Int16, Float64) => Implicit: CastInt16ToFloat64(func::CastInt16ToFloat64),
             (Int16, Numeric) => Implicit: CastTemplate::new(|_ecx, _ccx, _from_type, to_type| {
                 let s = to_type.unwrap_numeric_scale();
                 Some(move |e: HirScalarExpr| e.call_unary(CastInt16ToNumeric(func::CastInt16ToNumeric(s))))
             }),
-            (Int16, String) => Assignment: CastInt16ToString,
+            (Int16, String) => Assignment: CastInt16ToString(func::CastInt16ToString),
 
             //INT32
             (Int32, Bool) => Explicit: CastInt32ToBool,

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -140,19 +140,19 @@ lazy_static! {
             (Int16, String) => Assignment: CastInt16ToString(func::CastInt16ToString),
 
             //INT32
-            (Int32, Bool) => Explicit: CastInt32ToBool,
+            (Int32, Bool) => Explicit: CastInt32ToBool(func::CastInt32ToBool),
             (Int32, Oid) => Implicit: CastInt32ToOid,
             (Int32, RegProc) => Implicit: CastInt32ToRegProc,
             (Int32, RegType) => Implicit: CastInt32ToRegType,
-            (Int32, Int16) => Assignment: CastInt32ToInt16,
-            (Int32, Int64) => Implicit: CastInt32ToInt64,
-            (Int32, Float32) => Implicit: CastInt32ToFloat32,
-            (Int32, Float64) => Implicit: CastInt32ToFloat64,
+            (Int32, Int16) => Assignment: CastInt32ToInt16(func::CastInt32ToInt16),
+            (Int32, Int64) => Implicit: CastInt32ToInt64(func::CastInt32ToInt64),
+            (Int32, Float32) => Implicit: CastInt32ToFloat32(func::CastInt32ToFloat32),
+            (Int32, Float64) => Implicit: CastInt32ToFloat64(func::CastInt32ToFloat64),
             (Int32, Numeric) => Implicit: CastTemplate::new(|_ecx, _ccx, _from_type, to_type| {
                 let s = to_type.unwrap_numeric_scale();
                 Some(move |e: HirScalarExpr| e.call_unary(CastInt32ToNumeric(s)))
             }),
-            (Int32, String) => Assignment: CastInt32ToString,
+            (Int32, String) => Assignment: CastInt32ToString(func::CastInt32ToString),
 
             // INT64
             (Int64, Bool) => Explicit: CastInt64ToBool,
@@ -168,7 +168,7 @@ lazy_static! {
 
             // OID
             (Oid, Int32) => Assignment: CastOidToInt32,
-            (Oid, String) => Explicit: CastInt32ToString,
+            (Oid, String) => Explicit: CastInt32ToString(func::CastInt32ToString),
             (Oid, RegProc) => Assignment: CastOidToRegProc,
             (Oid, RegType) => Assignment: CastOidToRegType,
 


### PR DESCRIPTION
### Motivation

Continue the saga. This fixes a bug in cast_i16_to_numeric that I introduced accidentally in the previous PR where it would not produce the correct output type and made it much more difficult to accidentally re-introduce this kind of bug again.

Also while going through the transition I noticed we were previously marking cast_i32_to_i16 as preserving uniqueness which isn't correct so I fixed that too.
### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
