### PR TITLE
sql: support special case COLLATE pg_catalog.default as a noop

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -107,8 +107,8 @@ List new features before bug fixes.
 
 - Prevent overflow on operations combining [`timestamp`] and [`interval`].
 
-- Support special case `COLLATE pg_catalog.default`.
-  Other types of collations are not yet supported.
+- Support explicit reference to the default collation (`<expr> COLLATE pg_catalog.default`).
+  Other collations are not yet supported.
 
 {{% version-header v0.10.0 %}}
 

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -107,6 +107,9 @@ List new features before bug fixes.
 
 - Prevent overflow on operations combining [`timestamp`] and [`interval`].
 
+- Support special case `COLLATE pg_catalog.default`.
+  Other types of collations are not yet supported.
+
 {{% version-header v0.10.0 %}}
 
 - Allow ingesting avro schemas whose top node is not a record type.

--- a/test/sqllogictest/collate.slt
+++ b/test/sqllogictest/collate.slt
@@ -1,0 +1,48 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+query T
+SELECT '12:00:00' COLLATE pg_catalog.default
+----
+12:00:00
+
+statement OK
+CREATE TABLE test1 (a text, b text)
+
+statement OK
+INSERT INTO test1 VALUES('a', 'b')
+
+query B
+SELECT a < b FROM test1
+----
+true
+
+query B
+SELECT a < b COLLATE pg_catalog.default FROM test1
+----
+true
+
+query B
+SELECT a COLLATE pg_catalog.default < b FROM test1
+----
+true
+
+# verify that other types are not supported
+
+query error COLLATE not yet supported
+SELECT '12:00:00' COLLATE "en_US"
+
+query error COLLATE not yet supported
+SELECT '12:00:00' COLLATE "de_DE"
+
+query error COLLATE not yet supported
+SELECT '12:00:00' COLLATE pg_catalog.de_DE
+
+query error COLLATE not yet supported
+SELECT '12:00:00' COLLATE mz_catalog.default


### PR DESCRIPTION
<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

support special case COLLATE pg_catalog.default as a noop. No other types of COLLATIONs are supported.

### Motivation

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug. [Link to issue.]

  * This PR adds a known-desirable feature. [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

Required to support `\dt <pattern>`. See #9011

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
