### PR TITLE
expr: break out more unary function

### DIFF
--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -1159,7 +1159,9 @@ pub mod plan {
 
     use serde::{Deserialize, Serialize};
 
-    use crate::{BinaryFunc, EvalError, MapFilterProject, MirScalarExpr, NullaryFunc, UnaryFunc};
+    use crate::{
+        func, BinaryFunc, EvalError, MapFilterProject, MirScalarExpr, NullaryFunc, UnaryFunc,
+    };
     use repr::adt::numeric::Numeric;
     use repr::{Datum, Diff, Row, RowArena, ScalarType};
 
@@ -1372,7 +1374,7 @@ pub mod plan {
                     // of negative values intact. (Negative values are never
                     // chosen as valid bounds, so their resultant values matter
                     // little, but we do want to know they were negative.)
-                    let expr2_floor = expr2.call_unary(UnaryFunc::FloorNumeric);
+                    let expr2_floor = expr2.call_unary(UnaryFunc::FloorNumeric(func::FloorNumeric));
 
                     // MzLogicalTimestamp <OP> <EXPR2> for several supported operators.
                     match func {

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -3592,9 +3592,9 @@ pub enum UnaryFunc {
     CastInt32ToBool(CastInt32ToBool),
     CastInt32ToFloat32(CastInt32ToFloat32),
     CastInt32ToFloat64(CastInt32ToFloat64),
-    CastInt32ToOid,
-    CastInt32ToRegProc,
-    CastInt32ToRegType,
+    CastInt32ToOid(CastInt32ToOid),
+    CastInt32ToRegProc(CastInt32ToRegProc),
+    CastInt32ToRegType(CastInt32ToRegType),
     CastInt32ToInt16(CastInt32ToInt16),
     CastInt32ToInt64(CastInt32ToInt64),
     CastInt32ToString(CastInt32ToString),
@@ -3828,6 +3828,9 @@ derive_unary!(
     CastInt32ToInt16,
     CastInt32ToInt64,
     CastInt32ToString,
+    CastInt32ToOid,
+    CastInt32ToRegProc,
+    CastInt32ToRegType,
     PgColumnSize,
     MzRowSize,
     IsNull,
@@ -3924,6 +3927,9 @@ impl UnaryFunc {
             | CastInt32ToInt16(_)
             | CastInt32ToInt64(_)
             | CastInt32ToString(_)
+            | CastInt32ToOid(_)
+            | CastInt32ToRegProc(_)
+            | CastInt32ToRegType(_)
             | CastFloat32ToFloat64(_) => unreachable!(),
             NegNumeric => Ok(neg_numeric(a)),
             NegInterval => Ok(neg_interval(a)),
@@ -3933,9 +3939,6 @@ impl UnaryFunc {
             CastBoolToInt32 => Ok(cast_bool_to_int32(a)),
             CastFloat32ToNumeric(scale) => cast_float32_to_numeric(a, *scale),
             CastFloat64ToNumeric(scale) => cast_float64_to_numeric(a, *scale),
-            CastInt32ToOid => Ok(a),
-            CastInt32ToRegProc => Ok(a),
-            CastInt32ToRegType => Ok(a),
             CastInt32ToNumeric(scale) => cast_int32_to_numeric(a, *scale),
             CastOidToInt32 => Ok(a),
             CastRegProcToOid => Ok(a),
@@ -4129,6 +4132,9 @@ impl UnaryFunc {
             | CastInt32ToInt16(_)
             | CastInt32ToInt64(_)
             | CastInt32ToString(_)
+            | CastInt32ToOid(_)
+            | CastInt32ToRegProc(_)
+            | CastInt32ToRegType(_)
             | CastFloat32ToFloat64(_) => unreachable!(),
 
             Ascii | CharLength | BitLengthBytes | BitLengthString | ByteLengthBytes
@@ -4191,9 +4197,6 @@ impl UnaryFunc {
             | CastFloat64ToNumeric(scale)
             | CastJsonbToNumeric(scale) => ScalarType::Numeric { scale: *scale }.nullable(nullable),
 
-            CastInt32ToOid => ScalarType::Oid.nullable(nullable),
-            CastInt32ToRegProc => ScalarType::RegProc.nullable(nullable),
-            CastInt32ToRegType => ScalarType::RegType.nullable(nullable),
             CastOidToInt32 => ScalarType::Int32.nullable(nullable),
             CastRegProcToOid => ScalarType::Oid.nullable(nullable),
             CastOidToRegProc => ScalarType::RegProc.nullable(nullable),
@@ -4359,6 +4362,9 @@ impl UnaryFunc {
             | CastInt32ToInt16(_)
             | CastInt32ToInt64(_)
             | CastInt32ToString(_)
+            | CastInt32ToOid(_)
+            | CastInt32ToRegProc(_)
+            | CastInt32ToRegType(_)
             | CastFloat32ToFloat64(_) => unreachable!(),
             // These return null when their input is SQL null.
             CastJsonbToString | CastJsonbToInt16 | CastJsonbToInt32 | CastJsonbToInt64
@@ -4410,8 +4416,8 @@ impl UnaryFunc {
             | CastFloat32ToNumeric(_)
             | CastFloat64ToNumeric(_)
             | CastJsonbToNumeric(_) => false,
-            CastInt32ToOid | CastOidToInt32 | CastInt32ToRegProc | CastRegProcToOid
-            | CastOidToRegProc | CastInt32ToRegType | CastOidToRegType | CastRegTypeToOid => false,
+            CastOidToInt32 | CastRegProcToOid | CastOidToRegProc | CastOidToRegType
+            | CastRegTypeToOid => false,
             CastStringToDate | CastTimestampToDate | CastTimestampTzToDate => false,
             CastStringToTime | CastIntervalToTime | TimezoneTime { .. } => false,
             CastStringToTimestamp
@@ -4571,6 +4577,9 @@ impl UnaryFunc {
             | CastInt32ToInt16(_)
             | CastInt32ToInt64(_)
             | CastInt32ToString(_)
+            | CastInt32ToOid(_)
+            | CastInt32ToRegProc(_)
+            | CastInt32ToRegType(_)
             | CastFloat32ToFloat64(_) => unreachable!(),
             NegNumeric => f.write_str("-"),
             NegInterval => f.write_str("-"),
@@ -4578,9 +4587,6 @@ impl UnaryFunc {
             CastBoolToString => f.write_str("booltostr"),
             CastBoolToStringNonstandard => f.write_str("booltostrns"),
             CastBoolToInt32 => f.write_str("booltoi32"),
-            CastInt32ToOid => f.write_str("i32tooid"),
-            CastInt32ToRegProc => f.write_str("i32toregproc"),
-            CastInt32ToRegType => f.write_str("i32toregtype"),
             CastInt32ToNumeric(..) => f.write_str("i32tonumeric"),
             CastOidToInt32 => f.write_str("oidtoi32"),
             CastRegProcToOid => f.write_str("regproctooid"),

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -3598,11 +3598,11 @@ pub enum UnaryFunc {
     CastInt32ToInt16(CastInt32ToInt16),
     CastInt32ToInt64(CastInt32ToInt64),
     CastInt32ToString(CastInt32ToString),
-    CastOidToInt32,
-    CastOidToRegProc,
-    CastRegProcToOid,
-    CastOidToRegType,
-    CastRegTypeToOid,
+    CastOidToInt32(CastOidToInt32),
+    CastOidToRegProc(CastOidToRegProc),
+    CastRegProcToOid(CastRegProcToOid),
+    CastOidToRegType(CastOidToRegType),
+    CastRegTypeToOid(CastRegTypeToOid),
     CastInt64ToInt16,
     CastInt64ToInt32,
     CastInt16ToNumeric(CastInt16ToNumeric),
@@ -3831,6 +3831,11 @@ derive_unary!(
     CastInt32ToOid,
     CastInt32ToRegProc,
     CastInt32ToRegType,
+    CastOidToInt32,
+    CastOidToRegProc,
+    CastRegProcToOid,
+    CastOidToRegType,
+    CastRegTypeToOid,
     PgColumnSize,
     MzRowSize,
     IsNull,
@@ -3930,6 +3935,11 @@ impl UnaryFunc {
             | CastInt32ToOid(_)
             | CastInt32ToRegProc(_)
             | CastInt32ToRegType(_)
+            | CastOidToInt32(_)
+            | CastOidToRegProc(_)
+            | CastRegProcToOid(_)
+            | CastOidToRegType(_)
+            | CastRegTypeToOid(_)
             | CastFloat32ToFloat64(_) => unreachable!(),
             NegNumeric => Ok(neg_numeric(a)),
             NegInterval => Ok(neg_interval(a)),
@@ -3940,11 +3950,6 @@ impl UnaryFunc {
             CastFloat32ToNumeric(scale) => cast_float32_to_numeric(a, *scale),
             CastFloat64ToNumeric(scale) => cast_float64_to_numeric(a, *scale),
             CastInt32ToNumeric(scale) => cast_int32_to_numeric(a, *scale),
-            CastOidToInt32 => Ok(a),
-            CastRegProcToOid => Ok(a),
-            CastOidToRegProc => Ok(a),
-            CastRegTypeToOid => Ok(a),
-            CastOidToRegType => Ok(a),
             CastInt64ToInt16 => cast_int64_to_int16(a),
             CastInt64ToInt32 => cast_int64_to_int32(a),
             CastInt64ToBool => Ok(cast_int64_to_bool(a)),
@@ -4135,6 +4140,11 @@ impl UnaryFunc {
             | CastInt32ToOid(_)
             | CastInt32ToRegProc(_)
             | CastInt32ToRegType(_)
+            | CastOidToInt32(_)
+            | CastOidToRegProc(_)
+            | CastRegProcToOid(_)
+            | CastOidToRegType(_)
+            | CastRegTypeToOid(_)
             | CastFloat32ToFloat64(_) => unreachable!(),
 
             Ascii | CharLength | BitLengthBytes | BitLengthString | ByteLengthBytes
@@ -4196,12 +4206,6 @@ impl UnaryFunc {
             | CastFloat32ToNumeric(scale)
             | CastFloat64ToNumeric(scale)
             | CastJsonbToNumeric(scale) => ScalarType::Numeric { scale: *scale }.nullable(nullable),
-
-            CastOidToInt32 => ScalarType::Int32.nullable(nullable),
-            CastRegProcToOid => ScalarType::Oid.nullable(nullable),
-            CastOidToRegProc => ScalarType::RegProc.nullable(nullable),
-            CastRegTypeToOid => ScalarType::Oid.nullable(nullable),
-            CastOidToRegType => ScalarType::RegType.nullable(nullable),
 
             CastStringToDate | CastTimestampToDate | CastTimestampTzToDate => {
                 ScalarType::Date.nullable(nullable)
@@ -4365,6 +4369,11 @@ impl UnaryFunc {
             | CastInt32ToOid(_)
             | CastInt32ToRegProc(_)
             | CastInt32ToRegType(_)
+            | CastOidToInt32(_)
+            | CastOidToRegProc(_)
+            | CastRegProcToOid(_)
+            | CastOidToRegType(_)
+            | CastRegTypeToOid(_)
             | CastFloat32ToFloat64(_) => unreachable!(),
             // These return null when their input is SQL null.
             CastJsonbToString | CastJsonbToInt16 | CastJsonbToInt32 | CastJsonbToInt64
@@ -4416,8 +4425,6 @@ impl UnaryFunc {
             | CastFloat32ToNumeric(_)
             | CastFloat64ToNumeric(_)
             | CastJsonbToNumeric(_) => false,
-            CastOidToInt32 | CastRegProcToOid | CastOidToRegProc | CastOidToRegType
-            | CastRegTypeToOid => false,
             CastStringToDate | CastTimestampToDate | CastTimestampTzToDate => false,
             CastStringToTime | CastIntervalToTime | TimezoneTime { .. } => false,
             CastStringToTimestamp
@@ -4580,6 +4587,11 @@ impl UnaryFunc {
             | CastInt32ToOid(_)
             | CastInt32ToRegProc(_)
             | CastInt32ToRegType(_)
+            | CastOidToInt32(_)
+            | CastOidToRegProc(_)
+            | CastRegProcToOid(_)
+            | CastOidToRegType(_)
+            | CastRegTypeToOid(_)
             | CastFloat32ToFloat64(_) => unreachable!(),
             NegNumeric => f.write_str("-"),
             NegInterval => f.write_str("-"),
@@ -4588,11 +4600,6 @@ impl UnaryFunc {
             CastBoolToStringNonstandard => f.write_str("booltostrns"),
             CastBoolToInt32 => f.write_str("booltoi32"),
             CastInt32ToNumeric(..) => f.write_str("i32tonumeric"),
-            CastOidToInt32 => f.write_str("oidtoi32"),
-            CastRegProcToOid => f.write_str("regproctooid"),
-            CastOidToRegProc => f.write_str("oidtoregproc"),
-            CastRegTypeToOid => f.write_str("regtypetooid"),
-            CastOidToRegType => f.write_str("oidtoregtype"),
             CastInt64ToInt16 => f.write_str("i64toi16"),
             CastInt64ToInt32 => f.write_str("i64toi32"),
             CastInt64ToBool => f.write_str("i64tobool"),

--- a/src/expr/src/scalar/func/impls.rs
+++ b/src/expr/src/scalar/func/impls.rs
@@ -14,6 +14,7 @@ mod int16;
 mod int32;
 mod int64;
 mod not;
+mod numeric;
 mod oid;
 mod regproc;
 
@@ -24,5 +25,6 @@ pub use int16::*;
 pub use int32::*;
 pub use int64::*;
 pub use not::Not;
+pub use numeric::*;
 pub use oid::*;
 pub use regproc::*;

--- a/src/expr/src/scalar/func/impls/int32.rs
+++ b/src/expr/src/scalar/func/impls/int32.rs
@@ -8,7 +8,10 @@
 // by the Apache License, Version 2.0.
 
 use crate::EvalError;
-use repr::strconv;
+use repr::{
+    adt::system::{Oid, RegProc, RegType},
+    strconv,
+};
 
 sqlfunc!(
     #[sqlname = "-"]
@@ -75,5 +78,29 @@ sqlfunc!(
         let mut buf = String::new();
         strconv::format_int32(&mut buf, a);
         buf
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "i32tooid"]
+    #[preserves_uniqueness = true]
+    fn cast_int32_to_oid(a: i32) -> Oid {
+        Oid(a)
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "i32toregproc"]
+    #[preserves_uniqueness = true]
+    fn cast_int32_to_reg_proc(a: i32) -> RegProc {
+        RegProc(a)
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "i32toregtype"]
+    #[preserves_uniqueness = true]
+    fn cast_int32_to_reg_type(a: i32) -> RegType {
+        RegType(a)
     }
 );

--- a/src/expr/src/scalar/func/impls/int32.rs
+++ b/src/expr/src/scalar/func/impls/int32.rs
@@ -58,6 +58,7 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "i32toi16"]
+    #[preserves_uniqueness = true]
     fn cast_int32_to_int16(a: i32) -> Result<i16, EvalError> {
         i16::try_from(a).or(Err(EvalError::Int16OutOfRange))
     }

--- a/src/expr/src/scalar/func/impls/numeric.rs
+++ b/src/expr/src/scalar/func/impls/numeric.rs
@@ -15,8 +15,7 @@ use crate::EvalError;
 sqlfunc!(
     #[sqlname = "-"]
     #[preserves_uniqueness = true]
-    fn neg_numeric(a: Numeric) -> Numeric {
-        let mut a = a;
+    fn neg_numeric(mut a: Numeric) -> Numeric {
         numeric::cx_datum().neg(&mut a);
         numeric::munge_numeric(&mut a).unwrap();
         a
@@ -25,8 +24,7 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "abs"]
-    fn abs_numeric(a: Numeric) -> Numeric {
-        let mut a = a;
+    fn abs_numeric(mut a: Numeric) -> Numeric {
         numeric::cx_datum().abs(&mut a);
         a
     }
@@ -34,8 +32,7 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "ceilnumeric"]
-    fn ceil_numeric(a: Numeric) -> Numeric {
-        let mut a = a;
+    fn ceil_numeric(mut a: Numeric) -> Numeric {
         // ceil will be nop if has no fractional digits.
         if a.exponent() >= 0 {
             return a;
@@ -50,8 +47,7 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "expnumeric"]
-    fn exp_numeric(a: Numeric) -> Result<Numeric, EvalError> {
-        let mut a = a;
+    fn exp_numeric(mut a: Numeric) -> Result<Numeric, EvalError> {
         let mut cx = numeric::cx_datum();
         cx.exp(&mut a);
         let cx_status = cx.status();
@@ -68,8 +64,7 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "floornumeric"]
-    fn floor_numeric(a: Numeric) -> Numeric {
-        let mut a = a;
+    fn floor_numeric(mut a: Numeric) -> Numeric {
         // floor will be nop if has no fractional digits.
         if a.exponent() >= 0 {
             return a;
@@ -124,8 +119,7 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "roundnumeric"]
-    fn round_numeric(a: Numeric) -> Numeric {
-        let mut a = a;
+    fn round_numeric(mut a: Numeric) -> Numeric {
         // round will be nop if has no fractional digits.
         if a.exponent() >= 0 {
             return a;
@@ -137,8 +131,7 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "sqrtnumeric"]
-    fn sqrt_numeric(a: Numeric) -> Result<Numeric, EvalError> {
-        let mut a = a;
+    fn sqrt_numeric(mut a: Numeric) -> Result<Numeric, EvalError> {
         if a.is_negative() {
             return Err(EvalError::NegSqrt);
         }

--- a/src/expr/src/scalar/func/impls/numeric.rs
+++ b/src/expr/src/scalar/func/impls/numeric.rs
@@ -1,0 +1,150 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use dec::Rounding;
+use repr::adt::numeric::{self, Numeric};
+
+use crate::EvalError;
+
+sqlfunc!(
+    #[sqlname = "-"]
+    #[preserves_uniqueness = true]
+    fn neg_numeric(a: Numeric) -> Numeric {
+        let mut a = a;
+        numeric::cx_datum().neg(&mut a);
+        numeric::munge_numeric(&mut a).unwrap();
+        a
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "abs"]
+    fn abs_numeric(a: Numeric) -> Numeric {
+        let mut a = a;
+        numeric::cx_datum().abs(&mut a);
+        a
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "ceilnumeric"]
+    fn ceil_numeric(a: Numeric) -> Numeric {
+        let mut a = a;
+        // ceil will be nop if has no fractional digits.
+        if a.exponent() >= 0 {
+            return a;
+        }
+        let mut cx = numeric::cx_datum();
+        cx.set_rounding(Rounding::Ceiling);
+        cx.round(&mut a);
+        numeric::munge_numeric(&mut a).unwrap();
+        a
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "expnumeric"]
+    fn exp_numeric(a: Numeric) -> Result<Numeric, EvalError> {
+        let mut a = a;
+        let mut cx = numeric::cx_datum();
+        cx.exp(&mut a);
+        let cx_status = cx.status();
+        if cx_status.overflow() {
+            Err(EvalError::FloatOverflow)
+        } else if cx_status.subnormal() {
+            Err(EvalError::FloatUnderflow)
+        } else {
+            numeric::munge_numeric(&mut a).unwrap();
+            Ok(a)
+        }
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "floornumeric"]
+    fn floor_numeric(a: Numeric) -> Numeric {
+        let mut a = a;
+        // floor will be nop if has no fractional digits.
+        if a.exponent() >= 0 {
+            return a;
+        }
+        let mut cx = numeric::cx_datum();
+        cx.set_rounding(Rounding::Floor);
+        cx.round(&mut a);
+        numeric::munge_numeric(&mut a).unwrap();
+        a
+    }
+);
+
+fn log_guard_numeric(val: &Numeric, function_name: &str) -> Result<(), EvalError> {
+    if val.is_negative() {
+        return Err(EvalError::NegativeOutOfDomain(function_name.to_owned()));
+    }
+    if val.is_zero() {
+        return Err(EvalError::ZeroOutOfDomain(function_name.to_owned()));
+    }
+    Ok(())
+}
+
+// From the `decNumber` library's documentation:
+// > Inexact results will almost always be correctly rounded, but may be up to 1
+// > ulp (unit in last place) in error in rare cases.
+//
+// See decNumberLog10 documentation at http://speleotrove.com/decimal/dnnumb.html
+fn log_numeric<F>(mut a: Numeric, logic: F, name: &'static str) -> Result<Numeric, EvalError>
+where
+    F: Fn(&mut dec::Context<Numeric>, &mut Numeric),
+{
+    log_guard_numeric(&a, name)?;
+    let mut cx = numeric::cx_datum();
+    logic(&mut cx, &mut a);
+    numeric::munge_numeric(&mut a).unwrap();
+    Ok(a)
+}
+
+sqlfunc!(
+    #[sqlname = "lnnumeric"]
+    fn ln_numeric(a: Numeric) -> Result<Numeric, EvalError> {
+        log_numeric(a, dec::Context::ln, "ln")
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "log10numeric"]
+    fn log10_numeric(a: Numeric) -> Result<Numeric, EvalError> {
+        log_numeric(a, dec::Context::log10, "log10")
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "roundnumeric"]
+    fn round_numeric(a: Numeric) -> Numeric {
+        let mut a = a;
+        // round will be nop if has no fractional digits.
+        if a.exponent() >= 0 {
+            return a;
+        }
+        numeric::cx_datum().round(&mut a);
+        a
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "sqrtnumeric"]
+    fn sqrt_numeric(a: Numeric) -> Result<Numeric, EvalError> {
+        let mut a = a;
+        if a.is_negative() {
+            return Err(EvalError::NegSqrt);
+        }
+        let mut cx = numeric::cx_datum();
+        cx.sqrt(&mut a);
+        numeric::munge_numeric(&mut a).unwrap();
+        Ok(a)
+    }
+);

--- a/src/expr/src/scalar/func/impls/oid.rs
+++ b/src/expr/src/scalar/func/impls/oid.rs
@@ -1,0 +1,34 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use repr::adt::system::{Oid, RegProc, RegType};
+
+sqlfunc!(
+    #[sqlname = "oidtoi32"]
+    #[preserves_uniqueness = true]
+    fn cast_oid_to_int32(a: Oid) -> i32 {
+        a.0
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "oidtoregproc"]
+    #[preserves_uniqueness = true]
+    fn cast_oid_to_reg_proc(a: Oid) -> RegProc {
+        RegProc(a.0)
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "oidtoregtype"]
+    #[preserves_uniqueness = true]
+    fn cast_oid_to_reg_type(a: Oid) -> RegType {
+        RegType(a.0)
+    }
+);

--- a/src/expr/src/scalar/func/impls/regproc.rs
+++ b/src/expr/src/scalar/func/impls/regproc.rs
@@ -7,22 +7,20 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-mod datum;
-mod float32;
-mod float64;
-mod int16;
-mod int32;
-mod int64;
-mod not;
-mod oid;
-mod regproc;
+use repr::adt::system::{Oid, RegProc, RegType};
 
-pub use datum::*;
-pub use float32::*;
-pub use float64::*;
-pub use int16::*;
-pub use int32::*;
-pub use int64::*;
-pub use not::Not;
-pub use oid::*;
-pub use regproc::*;
+sqlfunc!(
+    #[sqlname = "regproctooid"]
+    #[preserves_uniqueness = true]
+    fn cast_reg_proc_to_oid(a: RegProc) -> Oid {
+        Oid(a.0)
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "regtypetooid"]
+    #[preserves_uniqueness = true]
+    fn cast_reg_type_to_oid(a: RegType) -> Oid {
+        Oid(a.0)
+    }
+);

--- a/src/expr/src/scalar/func/macros.rs
+++ b/src/expr/src/scalar/func/macros.rs
@@ -33,6 +33,22 @@ macro_rules! sqlfunc {
     (
         #[sqlname = $name:expr]
         #[preserves_uniqueness = $preserves_uniqueness:expr]
+        fn $fn_name:ident(mut $param_name:ident: $input_ty:ty) -> $output_ty:ty
+            $body:block
+    ) => {
+        sqlfunc!(
+            #[sqlname = $name]
+            #[preserves_uniqueness = $preserves_uniqueness]
+            fn $fn_name($param_name: $input_ty) -> $output_ty {
+                let mut $param_name = $param_name;
+                $body
+            }
+        );
+    };
+
+    (
+        #[sqlname = $name:expr]
+        #[preserves_uniqueness = $preserves_uniqueness:expr]
         fn $fn_name:ident($param_name:ident: $input_ty:ty) -> $output_ty:ty
             $body:block
     ) => {

--- a/src/repr/src/adt.rs
+++ b/src/repr/src/adt.rs
@@ -24,5 +24,6 @@ pub mod interval;
 pub mod jsonb;
 pub mod numeric;
 pub mod regex;
+pub mod system;
 mod util;
 pub mod varchar;

--- a/src/repr/src/adt/system.rs
+++ b/src/repr/src/adt/system.rs
@@ -1,0 +1,22 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! System data types.
+
+/// A rust type representing a PostgreSQL object identifier.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Oid(pub i32);
+
+/// A rust type representing a PostgreSQL function name
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct RegProc(pub i32);
+
+/// A rust type representing a PostgreSQL function type
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct RegType(pub i32);

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -24,6 +24,7 @@ use lowertest::MzEnumReflect;
 use crate::adt::array::Array;
 use crate::adt::interval::Interval;
 use crate::adt::numeric::Numeric;
+use crate::adt::system::{Oid, RegProc, RegType};
 use crate::{ColumnName, ColumnType, DatumList, DatumMap};
 use crate::{Row, RowArena};
 
@@ -1065,6 +1066,57 @@ impl<E> DatumType<E> for Numeric {
 
     fn into_result(self, _temp_storage: &RowArena) -> Result<Datum, E> {
         Ok(Datum::from(self))
+    }
+}
+
+impl<E> DatumType<E> for Oid {
+    fn as_column_type() -> ColumnType {
+        ScalarType::Oid.nullable(false)
+    }
+
+    fn try_from_result(res: Result<Datum, E>) -> Result<Self, Result<Datum, E>> {
+        match res {
+            Ok(Datum::Int32(a)) => Ok(Oid(a)),
+            _ => Err(res),
+        }
+    }
+
+    fn into_result(self, _temp_storage: &RowArena) -> Result<Datum, E> {
+        Ok(Datum::Int32(self.0))
+    }
+}
+
+impl<E> DatumType<E> for RegProc {
+    fn as_column_type() -> ColumnType {
+        ScalarType::RegProc.nullable(false)
+    }
+
+    fn try_from_result(res: Result<Datum, E>) -> Result<Self, Result<Datum, E>> {
+        match res {
+            Ok(Datum::Int32(a)) => Ok(RegProc(a)),
+            _ => Err(res),
+        }
+    }
+
+    fn into_result(self, _temp_storage: &RowArena) -> Result<Datum, E> {
+        Ok(Datum::Int32(self.0))
+    }
+}
+
+impl<E> DatumType<E> for RegType {
+    fn as_column_type() -> ColumnType {
+        ScalarType::RegType.nullable(false)
+    }
+
+    fn try_from_result(res: Result<Datum, E>) -> Result<Self, Result<Datum, E>> {
+        match res {
+            Ok(Datum::Int32(a)) => Ok(RegType(a)),
+            _ => Err(res),
+        }
+    }
+
+    fn into_result(self, _temp_storage: &RowArena) -> Result<Datum, E> {
+        Ok(Datum::Int32(self.0))
     }
 }
 

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1330,7 +1330,7 @@ lazy_static! {
                 params!(Int16) => UnaryFunc::AbsInt16(func::AbsInt16), 1398;
                 params!(Int32) => UnaryFunc::AbsInt32(func::AbsInt32), 1397;
                 params!(Int64) => UnaryFunc::AbsInt64(func::AbsInt64), 1396;
-                params!(Numeric) => UnaryFunc::AbsNumeric, 1705;
+                params!(Numeric) => UnaryFunc::AbsNumeric(func::AbsNumeric), 1705;
                 params!(Float32) => UnaryFunc::AbsFloat32(func::AbsFloat32), 1394;
                 params!(Float64) => UnaryFunc::AbsFloat64(func::AbsFloat64), 1395;
             },
@@ -1375,7 +1375,7 @@ lazy_static! {
             "ceil" => Scalar {
                 params!(Float32) => UnaryFunc::CeilFloat32(func::CeilFloat32), oid::FUNC_CEIL_F32_OID;
                 params!(Float64) => UnaryFunc::CeilFloat64(func::CeilFloat64), 2308;
-                params!(Numeric) => UnaryFunc::CeilNumeric, 1711;
+                params!(Numeric) => UnaryFunc::CeilNumeric(func::CeilNumeric), 1711;
             },
             "char_length" => Scalar {
                 params!(String) => UnaryFunc::CharLength, 1381;
@@ -1475,12 +1475,12 @@ lazy_static! {
             },
             "exp" => Scalar {
                 params!(Float64) => UnaryFunc::Exp(func::Exp), 1347;
-                params!(Numeric) => UnaryFunc::ExpNumeric, 1732;
+                params!(Numeric) => UnaryFunc::ExpNumeric(func::ExpNumeric), 1732;
             },
             "floor" => Scalar {
                 params!(Float32) => UnaryFunc::FloorFloat32(func::FloorFloat32), oid::FUNC_FLOOR_F32_OID;
                 params!(Float64) => UnaryFunc::FloorFloat64(func::FloorFloat64), 2309;
-                params!(Numeric) => UnaryFunc::FloorNumeric, 1712;
+                params!(Numeric) => UnaryFunc::FloorNumeric(func::FloorNumeric), 1712;
             },
             "format_type" => Scalar {
                 params!(Oid, Int32) => sql_impl_func(
@@ -1540,15 +1540,15 @@ lazy_static! {
             },
             "ln" => Scalar {
                 params!(Float64) => UnaryFunc::Ln(func::Ln), 1341;
-                params!(Numeric) => UnaryFunc::LnNumeric, 1734;
+                params!(Numeric) => UnaryFunc::LnNumeric(func::LnNumeric), 1734;
             },
             "log10" => Scalar {
                 params!(Float64) => UnaryFunc::Log10(func::Log10), 1194;
-                params!(Numeric) => UnaryFunc::Log10Numeric, 1481;
+                params!(Numeric) => UnaryFunc::Log10Numeric(func::Log10Numeric), 1481;
             },
             "log" => Scalar {
                 params!(Float64) => UnaryFunc::Log10(func::Log10), 1340;
-                params!(Numeric) => UnaryFunc::Log10Numeric, 1741;
+                params!(Numeric) => UnaryFunc::Log10Numeric(func::Log10Numeric), 1741;
                 params!(Numeric, Numeric) => BinaryFunc::LogNumeric, 1736;
             },
             "lower" => Scalar {
@@ -1683,7 +1683,7 @@ lazy_static! {
             "round" => Scalar {
                 params!(Float32) => UnaryFunc::RoundFloat32(func::RoundFloat32), oid::FUNC_ROUND_F32_OID;
                 params!(Float64) => UnaryFunc::RoundFloat64(func::RoundFloat64), 1342;
-                params!(Numeric) => UnaryFunc::RoundNumeric, 1708;
+                params!(Numeric) => UnaryFunc::RoundNumeric(func::RoundNumeric), 1708;
                 params!(Numeric, Int32) => BinaryFunc::RoundNumeric, 1707;
             },
             "rtrim" => Scalar {
@@ -1730,7 +1730,7 @@ lazy_static! {
             },
             "sqrt" => Scalar {
                 params!(Float64) => UnaryFunc::SqrtFloat64(func::SqrtFloat64), 1344;
-                params!(Numeric) => UnaryFunc::SqrtNumeric, 1730;
+                params!(Numeric) => UnaryFunc::SqrtNumeric(func::SqrtNumeric), 1730;
             },
             "tan" => Scalar {
                 params!(Float64) => UnaryFunc::Tan(func::Tan), 1606;
@@ -2418,7 +2418,7 @@ lazy_static! {
                 params!(Int64) => UnaryFunc::NegInt64(func::NegInt64), 484;
                 params!(Float32) => UnaryFunc::NegFloat32(func::NegFloat32), 584;
                 params!(Float64) => UnaryFunc::NegFloat64(func::NegFloat64), 585;
-                params!(Numeric) => UnaryFunc::NegNumeric, 17510;
+                params!(Numeric) => UnaryFunc::NegNumeric(func::NegNumeric), 17510;
                 params!(Interval) => UnaryFunc::NegInterval, 1336;
                 params!(Int32, Int32) => SubInt32, 555;
                 params!(Int64, Int64) => SubInt64, 685;

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -141,9 +141,9 @@ lazy_static! {
 
             //INT32
             (Int32, Bool) => Explicit: CastInt32ToBool(func::CastInt32ToBool),
-            (Int32, Oid) => Implicit: CastInt32ToOid,
-            (Int32, RegProc) => Implicit: CastInt32ToRegProc,
-            (Int32, RegType) => Implicit: CastInt32ToRegType,
+            (Int32, Oid) => Implicit: CastInt32ToOid(func::CastInt32ToOid),
+            (Int32, RegProc) => Implicit: CastInt32ToRegProc(func::CastInt32ToRegProc),
+            (Int32, RegType) => Implicit: CastInt32ToRegType(func::CastInt32ToRegType),
             (Int32, Int16) => Assignment: CastInt32ToInt16(func::CastInt32ToInt16),
             (Int32, Int64) => Implicit: CastInt32ToInt64(func::CastInt32ToInt64),
             (Int32, Float32) => Implicit: CastInt32ToFloat32(func::CastInt32ToFloat32),

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -167,13 +167,13 @@ lazy_static! {
             (Int64, String) => Assignment: CastInt64ToString,
 
             // OID
-            (Oid, Int32) => Assignment: CastOidToInt32,
+            (Oid, Int32) => Assignment: CastOidToInt32(func::CastOidToInt32),
             (Oid, String) => Explicit: CastInt32ToString(func::CastInt32ToString),
-            (Oid, RegProc) => Assignment: CastOidToRegProc,
-            (Oid, RegType) => Assignment: CastOidToRegType,
+            (Oid, RegProc) => Assignment: CastOidToRegProc(func::CastOidToRegProc),
+            (Oid, RegType) => Assignment: CastOidToRegType(func::CastOidToRegType),
 
             // REGPROC
-            (RegProc, Oid) => Implicit: CastRegProcToOid,
+            (RegProc, Oid) => Implicit: CastRegProcToOid(func::CastRegProcToOid),
             (RegProc, String) => Explicit: sql_impl_cast("(
                 SELECT COALESCE(t.name, v.x::pg_catalog.text)
                 FROM (
@@ -183,7 +183,7 @@ lazy_static! {
             )"),
 
             // REGTYPE
-            (RegType, Oid) => Implicit: CastRegTypeToOid,
+            (RegType, Oid) => Implicit: CastRegTypeToOid(func::CastRegTypeToOid),
             (RegType, String) => Explicit: sql_impl_cast("(
                 SELECT COALESCE(t.name, v.x::pg_catalog.text)
                 FROM (


### PR DESCRIPTION
### Motivation

Moving more unary funcs under the new way of defining them. This PR also introduces native Rust types for the Oid, RegProc and RegType ScalarType variants so that we can use the macro machinery to autogenerate function definitions

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
