### PR TITLE
test: Refactor the redpanda testdrive job

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -34,12 +34,12 @@
         composition: kafka-multi-broker
         run: kafka-multi-broker
 
-- id: testdrive-redpanda
-  label: ":racing_car: testdrive :panda_face:"
+- id: redpanda-testdrive
+  label: ":panda_face: :racing_car: testdrive"
   plugins:
     - ./ci/plugins/mzcompose:
-        composition: testdrive
-        run: testdrive-redpanda
+        composition: redpanda
+        run: redpanda-testdrive
 
 - id: upgrade
   label: "Upgrade testing"

--- a/test/redpanda/mzcompose
+++ b/test/redpanda/mzcompose
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# mzcompose — runs Docker Compose with Materialize customizations.
+
+exec "$(dirname "$0")/../../bin/mzcompose" "$@"

--- a/test/redpanda/mzworkflows.py
+++ b/test/redpanda/mzworkflows.py
@@ -1,0 +1,36 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.mzcompose import Materialized, Redpanda, Testdrive, Workflow
+
+prerequisites = [Redpanda(), Materialized()]
+
+services = [
+    *prerequisites,
+    Testdrive(shell_eval=True, volumes_extra=["../testdrive:/workdir/testdrive"]),
+]
+
+
+def workflow_redpanda_testdrive(w: Workflow):
+    w.start_and_wait_for_tcp(services=prerequisites)
+    w.wait_for_mz(service="materialized")
+
+    # Features currently not supported by Redpanda:
+    # - `kafka-time-offset.td` (https://github.com/vectorizedio/redpanda/issues/2397)
+    # - `schema-registry-publish` with `format=protobuf` (Redpanda does not support schema publication for protobuf/json)
+
+    # Due to interactions between docker-compose, entrypoint, command, and bash, it is not possible to have
+    # a more complex filtering expression in 'command' . So we basically run the entire testdrive suite here
+    # except tests that contain features known to be not supported by Redpanda. So the run includes testdrive
+    # tests that do not touch Kafka at all.
+
+    w.run_service(
+        service="testdrive-svc",
+        command="grep -L -E 'kafka_time_offset|schema-type=protobuf' testdrive/*.td",
+    )

--- a/test/testdrive/mzcompose.yml
+++ b/test/testdrive/mzcompose.yml
@@ -24,37 +24,6 @@ mzworkflows:
         service: testdrive-svc
         command: --aws-endpoint=http://localstack:4566 ${TD_TEST:-*.td esoteric/*.td}
 
-  # Runs the tests that interact with Kafka and Schema Registry against Redpanda.
-  #
-  # Specify the `TD_TEST` environment variable to select a specific test to run.
-  # Otherwise, this workflow runs against the test files in this directory that
-  # use a Kafka action but do *not* use:
-  # - `kafka-time-offset.td` (https://github.com/vectorizedio/redpanda/issues/2397)
-  # - `schema-registry-publish` with `format=protobuf` (Redpanda does not support schema publication for protobuf/json)
-  testdrive-redpanda:
-    steps:
-      - step: start-services
-        services: [redpanda, materialized]
-      - step: wait-for-tcp
-        host: redpanda
-        port: 9092
-        timeout_secs: 120
-      - step: wait-for-tcp
-        host: redpanda
-        port: 8081
-      - step: wait-for-mz
-      - step: run
-        service: testdrive-svc
-        entrypoint: /bin/bash
-        command:
-        - -c
-        - >-
-          testdrive
-          --kafka-addr=redpanda:9092
-          --schema-registry-url=http://redpanda:8081
-          --materialized-url=postgres://materialize@materialized:6875
-          ${TD_TEST:-$(grep -lF '$ kafka' $(grep -L 'kafka_time_offset' $(grep -L '$ schema-registry-publish.*schema-type=protobuf' *.td)))}
-
   # Run tests, requires AWS credentials to be present. See guide-testing for
   # details.
   ci:
@@ -155,21 +124,6 @@ services:
     - SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=PLAINTEXT://kafka:9092
     - SCHEMA_REGISTRY_HOST_NAME=localhost
     depends_on: [kafka, zookeeper]
-  redpanda:
-    image: vectorized/redpanda:v21.9.3
-    # Most of these options are simply required when using Redpanda in Docker.
-    # See: https://vectorized.io/docs/quick-start-docker/#Single-command-for-a-1-node-cluster
-    # The `enable_transactions` and `enable_idempotence` feature flags enable
-    # features Materialize requires that are present by default in Apache Kafka
-    # but not in Redpanda.
-    command: >-
-      redpanda start
-      --overprovisioned --smp=1 --memory=1G --reserve-memory=0M
-      --node-id=0 --check=false
-      --set "redpanda.enable_transactions=true"
-      --set "redpanda.enable_idempotence=true"
-      --set "redpanda.auto_create_topics_enabled=false"
-      --advertise-kafka-addr redpanda:9092
   localstack:
     # https://github.com/localstack/localstack/pull/4979
     image: benesch/localstack:0.13.0-p1


### PR DESCRIPTION
### Motivation

   * This PR refactors existing code.

The redpanda testdrive job is converted into a stand-alone python file.

### Tips for reviewer

The mzcompose.yml file had the luxury of passing stuff to testdrive via the entrypont entry. A python-based test using the default `Testdrive` python class needs to use the `command` entry, which in turn limits the types of bashisms one can use. It is not possible to use pipes or `$(...)` , so we can not filter tests as well as we could before.

Any ideas on how to hack that back would be much appreciated.