### PR TITLE
Merge pull request #9293 from aalexandrov/stacker_transform

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -103,6 +103,10 @@ List new features before bug fixes.
 
 {{% version-header v0.10.1 %}}
 
+- Queries that are too big to fit the limits of our intermediate representations
+  no longer panic and will now cause query-level failure with an internal error
+  and a message of the form "exceeded recursion limit of {X}".
+
 - Support `generate_series` for [`timestamp`] data.
 
 - Prevent overflow on operations combining [`timestamp`] and [`interval`].

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -3404,7 +3404,7 @@ where
                     &optimized_plan,
                     &mut dataflow,
                 );
-                transform::optimize_dataflow(&mut dataflow, coord.catalog.enabled_indexes());
+                transform::optimize_dataflow(&mut dataflow, coord.catalog.enabled_indexes())?;
                 timings.optimization = Some(start.elapsed());
                 Ok(dataflow)
             };
@@ -4237,7 +4237,8 @@ where
         }
 
         // Optimize the dataflow across views, and any other ways that appeal.
-        transform::optimize_dataflow(&mut dataflow, self.catalog.enabled_indexes());
+        transform::optimize_dataflow(&mut dataflow, self.catalog.enabled_indexes())
+            .expect("Dataflow planning failed; unrecoverable error"); // FIXME
         dataflow_types::Plan::finalize_dataflow(dataflow)
             .expect("Dataflow planning failed; unrecoverable error")
     }

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -43,7 +43,7 @@ pub mod join_input_mapper;
 /// - (2) `CallBinary` calls with associative functions such as `OR` and `+`
 ///
 /// Until we fix those, we need to stick with the larger recursion limit.
-pub const RECURSION_LIMIT: usize = 1024;
+pub const RECURSION_LIMIT: usize = 2048;
 
 /// An abstract syntax tree which defines a collection.
 ///

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -1436,7 +1436,7 @@ impl MirRelationExprVisitor {
             f(e);
             Ok::<_, RecursionLimitError>(())
         })
-        .unwrap()
+        .expect("Unexpected error in `visit_children` call")
     }
 
     /// Applies an infallible mutable `f` to each `expr` child of type `MirRelationExpr`.
@@ -1449,7 +1449,7 @@ impl MirRelationExprVisitor {
             f(e);
             Ok::<_, RecursionLimitError>(())
         })
-        .unwrap()
+        .expect("Unexpected error in `visit_mut_children` call")
     }
 
     /// Post-order immutable fallible `MirRelationExpr` visitor for `expr`.
@@ -1684,7 +1684,7 @@ impl MirRelationExprVisitor {
             f(s);
             Ok::<_, RecursionLimitError>(())
         })
-        .unwrap()
+        .expect("Unexpected error in `visit_scalars_mut` call")
     }
 }
 

--- a/src/transform/src/canonicalize_mfp.rs
+++ b/src/transform/src/canonicalize_mfp.rs
@@ -47,15 +47,14 @@ impl crate::Transform for CanonicalizeMfp {
         relation: &mut MirRelationExpr,
         _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
-        self.action(relation);
-        Ok(())
+        self.action(relation)
     }
 }
 
 impl CanonicalizeMfp {
-    fn action(&self, relation: &mut MirRelationExpr) {
+    fn action(&self, relation: &mut MirRelationExpr) -> Result<(), crate::TransformError> {
         let mut mfp = expr::MapFilterProject::extract_non_errors_from_expr_mut(relation);
-        relation.visit_mut_children(|e| self.action(e));
+        relation.try_visit_mut_children(|e| self.action(e))?;
         mfp.optimize();
         if !mfp.is_identity() {
             let (map, mut filter, project) = mfp.as_map_filter_project();
@@ -94,5 +93,6 @@ impl CanonicalizeMfp {
                 }
             }
         }
+        Ok(())
     }
 }

--- a/src/transform/src/canonicalize_mfp.rs
+++ b/src/transform/src/canonicalize_mfp.rs
@@ -67,7 +67,7 @@ impl CanonicalizeMfp {
                 }
                 canonicalize_predicates(&mut filter, &relation_type);
                 let all_errors = filter.iter().all(|p| p.is_literal_err());
-                let (retained, pushdown) = crate::predicate_pushdown::PredicatePushdown
+                let (retained, pushdown) = crate::predicate_pushdown::PredicatePushdown::default()
                     .push_filters_through_map(&map, &mut filter, mfp.input_arity, all_errors);
                 if !pushdown.is_empty() {
                     *relation = relation.take_dangerous().filter(pushdown);

--- a/src/transform/src/column_knowledge.rs
+++ b/src/transform/src/column_knowledge.rs
@@ -63,250 +63,261 @@ impl ColumnKnowledge {
         knowledge: &mut HashMap<expr::Id, Vec<DatumKnowledge>>,
         knowledge_stack: &mut Vec<DatumKnowledge>,
     ) -> Result<Vec<DatumKnowledge>, crate::TransformError> {
-        match expr {
-            MirRelationExpr::ArrangeBy { input, .. } => {
-                self.harvest(input, knowledge, knowledge_stack)
-            }
-            MirRelationExpr::Get { id, typ } => Ok(knowledge
-                .get(id)
-                .cloned()
-                .unwrap_or_else(|| typ.column_types.iter().map(DatumKnowledge::from).collect())),
-            MirRelationExpr::Constant { rows, typ } => {
-                if let Ok([(row, _diff)]) = rows.as_deref() {
-                    let knowledge = row
+        self.checked_recur(|_| {
+            match expr {
+                MirRelationExpr::ArrangeBy { input, .. } => {
+                    self.harvest(input, knowledge, knowledge_stack)
+                }
+                MirRelationExpr::Get { id, typ } => {
+                    Ok(knowledge.get(id).cloned().unwrap_or_else(|| {
+                        typ.column_types.iter().map(DatumKnowledge::from).collect()
+                    }))
+                }
+                MirRelationExpr::Constant { rows, typ } => {
+                    if let Ok([(row, _diff)]) = rows.as_deref() {
+                        let knowledge = row
+                            .iter()
+                            .zip(typ.column_types.iter())
+                            .map(|(datum, typ)| DatumKnowledge {
+                                value: Some((Ok(Row::pack_slice(&[datum.clone()])), typ.clone())),
+                                nullable: datum == Datum::Null,
+                            })
+                            .collect();
+                        Ok(knowledge)
+                    } else {
+                        Ok(typ.column_types.iter().map(DatumKnowledge::from).collect())
+                    }
+                }
+                MirRelationExpr::Let { id, value, body } => {
+                    let value_knowledge = self.harvest(value, knowledge, knowledge_stack)?;
+                    let prior_knowledge =
+                        knowledge.insert(expr::Id::Local(id.clone()), value_knowledge);
+                    let body_knowledge = self.harvest(body, knowledge, knowledge_stack)?;
+                    knowledge.remove(&expr::Id::Local(id.clone()));
+                    if let Some(prior_knowledge) = prior_knowledge {
+                        knowledge.insert(expr::Id::Local(id.clone()), prior_knowledge);
+                    }
+                    Ok(body_knowledge)
+                }
+                MirRelationExpr::Project { input, outputs } => {
+                    let input_knowledge = self.harvest(input, knowledge, knowledge_stack)?;
+                    Ok(outputs
                         .iter()
-                        .zip(typ.column_types.iter())
-                        .map(|(datum, typ)| DatumKnowledge {
-                            value: Some((Ok(Row::pack_slice(&[datum.clone()])), typ.clone())),
-                            nullable: datum == Datum::Null,
-                        })
-                        .collect();
-                    Ok(knowledge)
-                } else {
-                    Ok(typ.column_types.iter().map(DatumKnowledge::from).collect())
+                        .map(|i| input_knowledge[*i].clone())
+                        .collect())
                 }
-            }
-            MirRelationExpr::Let { id, value, body } => {
-                let value_knowledge = self.harvest(value, knowledge, knowledge_stack)?;
-                let prior_knowledge =
-                    knowledge.insert(expr::Id::Local(id.clone()), value_knowledge);
-                let body_knowledge = self.harvest(body, knowledge, knowledge_stack)?;
-                knowledge.remove(&expr::Id::Local(id.clone()));
-                if let Some(prior_knowledge) = prior_knowledge {
-                    knowledge.insert(expr::Id::Local(id.clone()), prior_knowledge);
+                MirRelationExpr::Map { input, scalars } => {
+                    let mut input_knowledge = self.harvest(input, knowledge, knowledge_stack)?;
+                    let input_typ = input.typ();
+                    for scalar in scalars.iter_mut() {
+                        let know =
+                            optimize(scalar, &input_typ, &input_knowledge[..], knowledge_stack);
+                        input_knowledge.push(know);
+                    }
+                    Ok(input_knowledge)
                 }
-                Ok(body_knowledge)
-            }
-            MirRelationExpr::Project { input, outputs } => {
-                let input_knowledge = self.harvest(input, knowledge, knowledge_stack)?;
-                Ok(outputs
-                    .iter()
-                    .map(|i| input_knowledge[*i].clone())
-                    .collect())
-            }
-            MirRelationExpr::Map { input, scalars } => {
-                let mut input_knowledge = self.harvest(input, knowledge, knowledge_stack)?;
-                let input_typ = input.typ();
-                for scalar in scalars.iter_mut() {
-                    let know = optimize(scalar, &input_typ, &input_knowledge[..], knowledge_stack);
-                    input_knowledge.push(know);
+                MirRelationExpr::FlatMap { input, func, exprs } => {
+                    let mut input_knowledge = self.harvest(input, knowledge, knowledge_stack)?;
+                    let input_typ = input.typ();
+                    for expr in exprs {
+                        optimize(expr, &input_typ, &input_knowledge[..], knowledge_stack);
+                    }
+                    let func_typ = func.output_type();
+                    input_knowledge.extend(func_typ.column_types.iter().map(DatumKnowledge::from));
+                    Ok(input_knowledge)
                 }
-                Ok(input_knowledge)
-            }
-            MirRelationExpr::FlatMap { input, func, exprs } => {
-                let mut input_knowledge = self.harvest(input, knowledge, knowledge_stack)?;
-                let input_typ = input.typ();
-                for expr in exprs {
-                    optimize(expr, &input_typ, &input_knowledge[..], knowledge_stack);
-                }
-                let func_typ = func.output_type();
-                input_knowledge.extend(func_typ.column_types.iter().map(DatumKnowledge::from));
-                Ok(input_knowledge)
-            }
-            MirRelationExpr::Filter { input, predicates } => {
-                let mut input_knowledge = self.harvest(input, knowledge, knowledge_stack)?;
-                let input_typ = input.typ();
-                for predicate in predicates.iter_mut() {
-                    optimize(predicate, &input_typ, &input_knowledge[..], knowledge_stack);
-                }
-                // If any predicate tests a column for equality, truth, or is_null, we learn stuff.
-                for predicate in predicates.iter() {
-                    // Equality tests allow us to unify the column knowledge of each input.
-                    if let MirScalarExpr::CallBinary { func, expr1, expr2 } = predicate {
-                        if func == &expr::BinaryFunc::Eq {
-                            // Collect knowledge about the inputs (for columns and literals).
-                            let mut knowledge = DatumKnowledge::default();
-                            if let MirScalarExpr::Column(c) = &**expr1 {
-                                knowledge.absorb(&input_knowledge[*c]);
-                            }
-                            if let MirScalarExpr::Column(c) = &**expr2 {
-                                knowledge.absorb(&input_knowledge[*c]);
-                            }
-                            // Absorb literal knowledge about columns.
-                            knowledge.absorb(&DatumKnowledge::from(&**expr1));
-                            knowledge.absorb(&DatumKnowledge::from(&**expr2));
+                MirRelationExpr::Filter { input, predicates } => {
+                    let mut input_knowledge = self.harvest(input, knowledge, knowledge_stack)?;
+                    let input_typ = input.typ();
+                    for predicate in predicates.iter_mut() {
+                        optimize(predicate, &input_typ, &input_knowledge[..], knowledge_stack);
+                    }
+                    // If any predicate tests a column for equality, truth, or is_null, we learn stuff.
+                    for predicate in predicates.iter() {
+                        // Equality tests allow us to unify the column knowledge of each input.
+                        if let MirScalarExpr::CallBinary { func, expr1, expr2 } = predicate {
+                            if func == &expr::BinaryFunc::Eq {
+                                // Collect knowledge about the inputs (for columns and literals).
+                                let mut knowledge = DatumKnowledge::default();
+                                if let MirScalarExpr::Column(c) = &**expr1 {
+                                    knowledge.absorb(&input_knowledge[*c]);
+                                }
+                                if let MirScalarExpr::Column(c) = &**expr2 {
+                                    knowledge.absorb(&input_knowledge[*c]);
+                                }
+                                // Absorb literal knowledge about columns.
+                                knowledge.absorb(&DatumKnowledge::from(&**expr1));
+                                knowledge.absorb(&DatumKnowledge::from(&**expr2));
 
-                            // Write back unified knowledge to each column.
-                            if let MirScalarExpr::Column(c) = &**expr1 {
-                                input_knowledge[*c].absorb(&knowledge);
-                            }
-                            if let MirScalarExpr::Column(c) = &**expr2 {
-                                input_knowledge[*c].absorb(&knowledge);
+                                // Write back unified knowledge to each column.
+                                if let MirScalarExpr::Column(c) = &**expr1 {
+                                    input_knowledge[*c].absorb(&knowledge);
+                                }
+                                if let MirScalarExpr::Column(c) = &**expr2 {
+                                    input_knowledge[*c].absorb(&knowledge);
+                                }
                             }
                         }
-                    }
-                    if let MirScalarExpr::CallUnary {
-                        func: UnaryFunc::Not(func::Not),
-                        expr,
-                    } = predicate
-                    {
                         if let MirScalarExpr::CallUnary {
-                            func: UnaryFunc::IsNull(func::IsNull),
+                            func: UnaryFunc::Not(func::Not),
                             expr,
-                        } = &**expr
+                        } = predicate
                         {
-                            if let MirScalarExpr::Column(c) = &**expr {
-                                input_knowledge[*c].nullable = false;
+                            if let MirScalarExpr::CallUnary {
+                                func: UnaryFunc::IsNull(func::IsNull),
+                                expr,
+                            } = &**expr
+                            {
+                                if let MirScalarExpr::Column(c) = &**expr {
+                                    input_knowledge[*c].nullable = false;
+                                }
                             }
                         }
                     }
+
+                    Ok(input_knowledge)
                 }
-
-                Ok(input_knowledge)
-            }
-            MirRelationExpr::Join {
-                inputs,
-                equivalences,
-                ..
-            } => {
-                // Aggregate column knowledge from each input into one `Vec`.
-                let mut knowledges = Vec::new();
-                for input in inputs.iter_mut() {
-                    for mut knowledge in self.harvest(input, knowledge, knowledge_stack)? {
-                        // Do not propagate error literals beyond join inputs, since that may result
-                        // in them being propagated to other inputs of the join and evaluated when
-                        // they should not.
-                        if let Some((Err(_), _)) = knowledge.value {
-                            knowledge.value = None;
-                        }
-                        knowledges.push(knowledge);
-                    }
-                }
-
-                // This only aggregates the column types of each input, not the
-                // keys of the inputs. It is unnecessary to aggregate the keys
-                // of the inputs since input keys are unnecessary for reducing
-                // `MirScalarExpr`s.
-                let folded_inputs_typ = inputs.iter().fold(RelationType::empty(), |mut typ, i| {
-                    typ.column_types.append(&mut i.typ().column_types);
-                    typ
-                });
-
-                for equivalence in equivalences.iter_mut() {
-                    let mut knowledge = DatumKnowledge::default();
-
-                    // We can produce composite knowledge for everything in the equivalence class.
-                    for expr in equivalence.iter_mut() {
-                        optimize(expr, &folded_inputs_typ, &knowledges, knowledge_stack);
-                        if let MirScalarExpr::Column(c) = expr {
-                            knowledge.absorb(&knowledges[*c]);
-                        }
-                        knowledge.absorb(&DatumKnowledge::from(&*expr));
-                    }
-                    for expr in equivalence.iter_mut() {
-                        if let MirScalarExpr::Column(c) = expr {
-                            knowledges[*c] = knowledge.clone();
+                MirRelationExpr::Join {
+                    inputs,
+                    equivalences,
+                    ..
+                } => {
+                    // Aggregate column knowledge from each input into one `Vec`.
+                    let mut knowledges = Vec::new();
+                    for input in inputs.iter_mut() {
+                        for mut knowledge in self.harvest(input, knowledge, knowledge_stack)? {
+                            // Do not propagate error literals beyond join inputs, since that may result
+                            // in them being propagated to other inputs of the join and evaluated when
+                            // they should not.
+                            if let Some((Err(_), _)) = knowledge.value {
+                                knowledge.value = None;
+                            }
+                            knowledges.push(knowledge);
                         }
                     }
-                }
 
-                Ok(knowledges)
-            }
-            MirRelationExpr::Reduce {
-                input,
-                group_key,
-                aggregates,
-                monotonic: _,
-                expected_group_size: _,
-            } => {
-                let input_knowledge = self.harvest(input, knowledge, knowledge_stack)?;
-                let input_typ = input.typ();
-                let mut output = group_key
-                    .iter_mut()
-                    .map(|k| optimize(k, &input_typ, &input_knowledge[..], knowledge_stack))
-                    .collect::<Vec<_>>();
-                for aggregate in aggregates.iter_mut() {
-                    use expr::AggregateFunc;
-                    let knowledge = optimize(
-                        &mut aggregate.expr,
-                        &input_typ,
-                        &input_knowledge[..],
-                        knowledge_stack,
-                    );
-                    // This could be improved.
-                    let knowledge = match aggregate.func {
-                        AggregateFunc::MaxInt16
-                        | AggregateFunc::MaxInt32
-                        | AggregateFunc::MaxInt64
-                        | AggregateFunc::MaxFloat32
-                        | AggregateFunc::MaxFloat64
-                        | AggregateFunc::MaxBool
-                        | AggregateFunc::MaxString
-                        | AggregateFunc::MaxDate
-                        | AggregateFunc::MaxTimestamp
-                        | AggregateFunc::MaxTimestampTz
-                        | AggregateFunc::MinInt16
-                        | AggregateFunc::MinInt32
-                        | AggregateFunc::MinInt64
-                        | AggregateFunc::MinFloat32
-                        | AggregateFunc::MinFloat64
-                        | AggregateFunc::MinBool
-                        | AggregateFunc::MinString
-                        | AggregateFunc::MinDate
-                        | AggregateFunc::MinTimestamp
-                        | AggregateFunc::MinTimestampTz
-                        | AggregateFunc::Any
-                        | AggregateFunc::All => {
-                            // These methods propagate constant values exactly.
-                            knowledge
+                    // This only aggregates the column types of each input, not the
+                    // keys of the inputs. It is unnecessary to aggregate the keys
+                    // of the inputs since input keys are unnecessary for reducing
+                    // `MirScalarExpr`s.
+                    let folded_inputs_typ =
+                        inputs.iter().fold(RelationType::empty(), |mut typ, i| {
+                            typ.column_types.append(&mut i.typ().column_types);
+                            typ
+                        });
+
+                    for equivalence in equivalences.iter_mut() {
+                        let mut knowledge = DatumKnowledge::default();
+
+                        // We can produce composite knowledge for everything in the equivalence class.
+                        for expr in equivalence.iter_mut() {
+                            optimize(expr, &folded_inputs_typ, &knowledges, knowledge_stack);
+                            if let MirScalarExpr::Column(c) = expr {
+                                knowledge.absorb(&knowledges[*c]);
+                            }
+                            knowledge.absorb(&DatumKnowledge::from(&*expr));
                         }
-                        AggregateFunc::Count => DatumKnowledge {
-                            value: None,
-                            nullable: false,
-                        },
-                        _ => {
-                            // The remaining aggregates are non-null if their inputs are non-null.
-                            DatumKnowledge {
+                        for expr in equivalence.iter_mut() {
+                            if let MirScalarExpr::Column(c) = expr {
+                                knowledges[*c] = knowledge.clone();
+                            }
+                        }
+                    }
+
+                    Ok(knowledges)
+                }
+                MirRelationExpr::Reduce {
+                    input,
+                    group_key,
+                    aggregates,
+                    monotonic: _,
+                    expected_group_size: _,
+                } => {
+                    let input_knowledge = self.harvest(input, knowledge, knowledge_stack)?;
+                    let input_typ = input.typ();
+                    let mut output = group_key
+                        .iter_mut()
+                        .map(|k| optimize(k, &input_typ, &input_knowledge[..], knowledge_stack))
+                        .collect::<Vec<_>>();
+                    for aggregate in aggregates.iter_mut() {
+                        use expr::AggregateFunc;
+                        let knowledge = optimize(
+                            &mut aggregate.expr,
+                            &input_typ,
+                            &input_knowledge[..],
+                            knowledge_stack,
+                        );
+                        // This could be improved.
+                        let knowledge = match aggregate.func {
+                            AggregateFunc::MaxInt16
+                            | AggregateFunc::MaxInt32
+                            | AggregateFunc::MaxInt64
+                            | AggregateFunc::MaxFloat32
+                            | AggregateFunc::MaxFloat64
+                            | AggregateFunc::MaxBool
+                            | AggregateFunc::MaxString
+                            | AggregateFunc::MaxDate
+                            | AggregateFunc::MaxTimestamp
+                            | AggregateFunc::MaxTimestampTz
+                            | AggregateFunc::MinInt16
+                            | AggregateFunc::MinInt32
+                            | AggregateFunc::MinInt64
+                            | AggregateFunc::MinFloat32
+                            | AggregateFunc::MinFloat64
+                            | AggregateFunc::MinBool
+                            | AggregateFunc::MinString
+                            | AggregateFunc::MinDate
+                            | AggregateFunc::MinTimestamp
+                            | AggregateFunc::MinTimestampTz
+                            | AggregateFunc::Any
+                            | AggregateFunc::All => {
+                                // These methods propagate constant values exactly.
+                                knowledge
+                            }
+                            AggregateFunc::Count => DatumKnowledge {
                                 value: None,
-                                nullable: knowledge.nullable,
+                                nullable: false,
+                            },
+                            _ => {
+                                // The remaining aggregates are non-null if their inputs are non-null.
+                                DatumKnowledge {
+                                    value: None,
+                                    nullable: knowledge.nullable,
+                                }
                             }
-                        }
-                    };
-                    output.push(knowledge);
+                        };
+                        output.push(knowledge);
+                    }
+                    Ok(output)
                 }
-                Ok(output)
-            }
-            MirRelationExpr::TopK { input, .. } => self.harvest(input, knowledge, knowledge_stack),
-            MirRelationExpr::Negate { input } => self.harvest(input, knowledge, knowledge_stack),
-            MirRelationExpr::Threshold { input } => self.harvest(input, knowledge, knowledge_stack),
-            MirRelationExpr::DeclareKeys { input, .. } => {
-                self.harvest(input, knowledge, knowledge_stack)
-            }
-            MirRelationExpr::Union { base, inputs } => {
-                let mut know = self.harvest(base, knowledge, knowledge_stack)?;
-                for input in inputs {
-                    know = know
-                        .into_iter()
-                        .zip_eq(self.harvest(input, knowledge, knowledge_stack)?)
-                        .map(|(mut k1, k2)| {
-                            k1.union(&k2);
-                            k1
-                        })
-                        .collect();
+                MirRelationExpr::TopK { input, .. } => {
+                    self.harvest(input, knowledge, knowledge_stack)
                 }
-                Ok(know)
+                MirRelationExpr::Negate { input } => {
+                    self.harvest(input, knowledge, knowledge_stack)
+                }
+                MirRelationExpr::Threshold { input } => {
+                    self.harvest(input, knowledge, knowledge_stack)
+                }
+                MirRelationExpr::DeclareKeys { input, .. } => {
+                    self.harvest(input, knowledge, knowledge_stack)
+                }
+                MirRelationExpr::Union { base, inputs } => {
+                    let mut know = self.harvest(base, knowledge, knowledge_stack)?;
+                    for input in inputs {
+                        know = know
+                            .into_iter()
+                            .zip_eq(self.harvest(input, knowledge, knowledge_stack)?)
+                            .map(|(mut k1, k2)| {
+                                k1.union(&k2);
+                                k1
+                            })
+                            .collect();
+                    }
+                    Ok(know)
+                }
             }
-        }
+        })
     }
 }
 

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -107,7 +107,7 @@ fn inline_views(dataflow: &mut DataflowDesc) {
             // identifiers for the Let's `body` and `value`, as well as a new
             // identifier for the binding itself. Following `UpdateLet`, we
             // go with the binding first, then the value, then the body.
-            let update_let = crate::update_let::UpdateLet;
+            let update_let = crate::update_let::UpdateLet::default();
             let mut id_gen = crate::IdGen::default();
             let new_local = LocalId::new(id_gen.allocate_id());
             // Use the same `id_gen` to assign new identifiers to `index`.
@@ -274,7 +274,7 @@ where
         view_refs.push(view);
     }
 
-    let typ_update = crate::update_let::UpdateLet;
+    let typ_update = crate::update_let::UpdateLet::default();
     for view in view_refs {
         // Update column references to views where projections were pushed down.
         projection_pushdown.update_projection_around_get(view, &applied_projection);

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -325,7 +325,7 @@ pub fn optimize_dataflow_filters_inner<'a, I>(
 where
     I: Iterator<Item = (Id, &'a mut MirRelationExpr)>,
 {
-    let transform = crate::predicate_pushdown::PredicatePushdown;
+    let transform = crate::predicate_pushdown::PredicatePushdown::default();
     for (id, view) in view_iter {
         if let Some(list) = predicates.get(&id).clone() {
             if !list.is_empty() {

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -52,7 +52,7 @@ pub fn optimize_dataflow(
     // Physical optimization pass
     optimize_dataflow_relations(dataflow, indexes, &Optimizer::physical_optimizer());
 
-    optimize_dataflow_monotonic(dataflow);
+    optimize_dataflow_monotonic(dataflow)?;
 
     Ok(())
 }
@@ -347,7 +347,7 @@ where
 }
 
 /// Propagates information about monotonic inputs through views.
-pub fn optimize_dataflow_monotonic(dataflow: &mut DataflowDesc) {
+pub fn optimize_dataflow_monotonic(dataflow: &mut DataflowDesc) -> Result<(), TransformError> {
     let mut monotonic = std::collections::HashSet::new();
     for (source_id, (source_desc, _)) in dataflow.source_imports.iter_mut() {
         if let SourceConnector::External {
@@ -367,6 +367,8 @@ pub fn optimize_dataflow_monotonic(dataflow: &mut DataflowDesc) {
             build_desc.view.as_inner_mut(),
             &monotonic,
             &mut HashSet::new(),
-        );
+        )?;
     }
+
+    Ok(())
 }

--- a/src/transform/src/demand.rs
+++ b/src/transform/src/demand.rs
@@ -73,221 +73,226 @@ impl Demand {
         mut columns: HashSet<usize>,
         gets: &mut HashMap<Id, HashSet<usize>>,
     ) -> Result<(), crate::TransformError> {
-        // A valid relation type is only needed for Maps, but we can't borrow
-        // the relation in the corresponding branch of the match statement, since
-        // it is already borrowed mutably.
-        let relation_type = if matches!(relation, MirRelationExpr::Map { .. }) {
-            Some(relation.typ())
-        } else {
-            None
-        };
-        match relation {
-            MirRelationExpr::Constant { .. } => {
-                // Nothing clever to do with constants, that I can think of.
-                Ok(())
-            }
-            MirRelationExpr::Get { id, .. } => {
-                gets.entry(*id).or_insert_with(HashSet::new).extend(columns);
-                Ok(())
-            }
-            MirRelationExpr::Let { id, value, body } => {
-                // Let harvests any requirements of get from its body,
-                // and pushes the union of the requirements at its value.
-                let id = Id::Local(*id);
-                let prior = gets.insert(id, HashSet::new());
-                self.action(body, columns, gets)?;
-                let needs = gets.remove(&id).unwrap();
-                if let Some(prior) = prior {
-                    gets.insert(id, prior);
+        self.checked_recur(|_| {
+            // A valid relation type is only needed for Maps, but we can't borrow
+            // the relation in the corresponding branch of the match statement, since
+            // it is already borrowed mutably.
+            let relation_type = if matches!(relation, MirRelationExpr::Map { .. }) {
+                Some(relation.typ())
+            } else {
+                None
+            };
+            match relation {
+                MirRelationExpr::Constant { .. } => {
+                    // Nothing clever to do with constants, that I can think of.
+                    Ok(())
                 }
+                MirRelationExpr::Get { id, .. } => {
+                    gets.entry(*id).or_insert_with(HashSet::new).extend(columns);
+                    Ok(())
+                }
+                MirRelationExpr::Let { id, value, body } => {
+                    // Let harvests any requirements of get from its body,
+                    // and pushes the union of the requirements at its value.
+                    let id = Id::Local(*id);
+                    let prior = gets.insert(id, HashSet::new());
+                    self.action(body, columns, gets)?;
+                    let needs = gets.remove(&id).unwrap();
+                    if let Some(prior) = prior {
+                        gets.insert(id, prior);
+                    }
 
-                self.action(value, needs, gets)
-            }
-            MirRelationExpr::Project { input, outputs } => self.action(
-                input,
-                columns.into_iter().map(|c| outputs[c]).collect(),
-                gets,
-            ),
-            MirRelationExpr::Map { input, scalars } => {
-                let relation_type = relation_type.as_ref().unwrap();
-                let arity = input.arity();
-                // contains columns whose supports have yet to be explored
-                let mut new_columns = columns.clone();
-                new_columns.retain(|c| *c >= arity);
-                while !new_columns.is_empty() {
-                    // explore supports
-                    new_columns = new_columns
-                        .iter()
-                        .flat_map(|c| scalars[*c - arity].support())
-                        .filter(|c| !columns.contains(c))
-                        .collect();
-                    // add those columns to the seen list
-                    columns.extend(new_columns.clone());
+                    self.action(value, needs, gets)
+                }
+                MirRelationExpr::Project { input, outputs } => self.action(
+                    input,
+                    columns.into_iter().map(|c| outputs[c]).collect(),
+                    gets,
+                ),
+                MirRelationExpr::Map { input, scalars } => {
+                    let relation_type = relation_type.as_ref().unwrap();
+                    let arity = input.arity();
+                    // contains columns whose supports have yet to be explored
+                    let mut new_columns = columns.clone();
                     new_columns.retain(|c| *c >= arity);
-                }
-
-                // Replace un-read expressions with literals to prevent evaluation.
-                for (index, scalar) in scalars.iter_mut().enumerate() {
-                    if !columns.contains(&(arity + index)) {
-                        // Leave literals as they are, to benefit explain.
-                        if !scalar.is_literal() {
-                            let typ = relation_type.column_types[arity + index].clone();
-                            *scalar =
-                                MirScalarExpr::Literal(Ok(Row::pack_slice(&[Datum::Dummy])), typ);
-                        }
+                    while !new_columns.is_empty() {
+                        // explore supports
+                        new_columns = new_columns
+                            .iter()
+                            .flat_map(|c| scalars[*c - arity].support())
+                            .filter(|c| !columns.contains(c))
+                            .collect();
+                        // add those columns to the seen list
+                        columns.extend(new_columns.clone());
+                        new_columns.retain(|c| *c >= arity);
                     }
-                }
 
-                columns.retain(|c| *c < arity);
-                self.action(input, columns, gets)
-            }
-            MirRelationExpr::FlatMap {
-                input,
-                func: _,
-                exprs,
-            } => {
-                // A FlatMap which returns zero rows acts like a filter
-                // so we always need to execute it
-                for expr in exprs {
-                    columns.extend(expr.support());
-                }
-                columns.retain(|c| *c < input.arity());
-                self.action(input, columns, gets)
-            }
-            MirRelationExpr::Filter { input, predicates } => {
-                for predicate in predicates {
-                    for column in predicate.support() {
-                        columns.insert(column);
-                    }
-                }
-                self.action(input, columns, gets)
-            }
-            MirRelationExpr::Join {
-                inputs,
-                equivalences,
-                implementation: _,
-            } => {
-                let input_mapper = JoinInputMapper::new(inputs);
-
-                // Each produced column that is equivalent to a prior column should be remapped
-                // so that upstream uses depend only on the first column, simplifying the demand
-                // analysis. In principle we could choose any representative, if it turns out
-                // that some other column would have been more helpful, but we don't have a great
-                // reason to do that at the moment.
-                let mut permutation: Vec<usize> = (0..input_mapper.total_columns()).collect();
-                for equivalence in equivalences.iter() {
-                    let mut first_column = None;
-                    for expr in equivalence.iter() {
-                        if let MirScalarExpr::Column(c) = expr {
-                            if let Some(prior) = &first_column {
-                                permutation[*c] = *prior;
-                            } else {
-                                first_column = Some(*c);
+                    // Replace un-read expressions with literals to prevent evaluation.
+                    for (index, scalar) in scalars.iter_mut().enumerate() {
+                        if !columns.contains(&(arity + index)) {
+                            // Leave literals as they are, to benefit explain.
+                            if !scalar.is_literal() {
+                                let typ = relation_type.column_types[arity + index].clone();
+                                *scalar = MirScalarExpr::Literal(
+                                    Ok(Row::pack_slice(&[Datum::Dummy])),
+                                    typ,
+                                );
                             }
                         }
                     }
+
+                    columns.retain(|c| *c < arity);
+                    self.action(input, columns, gets)
                 }
-
-                let should_permute = columns.iter().any(|c| permutation[*c] != *c);
-
-                // Each equivalence class imposes internal demand for columns.
-                for equivalence in equivalences.iter() {
-                    for expr in equivalence.iter() {
+                MirRelationExpr::FlatMap {
+                    input,
+                    func: _,
+                    exprs,
+                } => {
+                    // A FlatMap which returns zero rows acts like a filter
+                    // so we always need to execute it
+                    for expr in exprs {
                         columns.extend(expr.support());
                     }
+                    columns.retain(|c| *c < input.arity());
+                    self.action(input, columns, gets)
                 }
-
-                // Populate child demands from external and internal demands.
-                let new_columns = input_mapper.split_column_set_by_input(columns.iter());
-
-                // Recursively indicate the requirements.
-                for (input, columns) in inputs.iter_mut().zip(new_columns) {
-                    self.action(input, columns, gets)?;
-                }
-
-                // Install a permutation if any demanded column is not the
-                // canonical column.
-                if should_permute {
-                    *relation = relation.take_dangerous().project(permutation);
-                }
-
-                Ok(())
-            }
-            MirRelationExpr::Reduce {
-                input,
-                group_key,
-                aggregates,
-                monotonic: _,
-                expected_group_size: _,
-            } => {
-                let mut new_columns = HashSet::new();
-                // Group keys determine aggregation granularity and are
-                // each crucial in determining aggregates and even the
-                // multiplicities of other keys.
-                new_columns.extend(group_key.iter().flat_map(|e| e.support()));
-                for column in columns.iter() {
-                    // No obvious requirements on aggregate columns.
-                    // A "non-empty" requirement, I guess?
-                    if *column >= group_key.len() {
-                        new_columns.extend(aggregates[*column - group_key.len()].expr.support());
+                MirRelationExpr::Filter { input, predicates } => {
+                    for predicate in predicates {
+                        for column in predicate.support() {
+                            columns.insert(column);
+                        }
                     }
+                    self.action(input, columns, gets)
                 }
+                MirRelationExpr::Join {
+                    inputs,
+                    equivalences,
+                    implementation: _,
+                } => {
+                    let input_mapper = JoinInputMapper::new(inputs);
 
-                // Replace un-demanded aggregations with dummies.
-                let input_type = input.typ();
-                for index in (0..aggregates.len()).rev() {
-                    if !columns.contains(&(group_key.len() + index)) {
-                        let typ = aggregates[index].typ(&input_type);
-                        aggregates[index] = AggregateExpr {
-                            func: AggregateFunc::Dummy,
-                            expr: MirScalarExpr::literal_ok(Datum::Dummy, typ.scalar_type),
-                            distinct: false,
-                        };
+                    // Each produced column that is equivalent to a prior column should be remapped
+                    // so that upstream uses depend only on the first column, simplifying the demand
+                    // analysis. In principle we could choose any representative, if it turns out
+                    // that some other column would have been more helpful, but we don't have a great
+                    // reason to do that at the moment.
+                    let mut permutation: Vec<usize> = (0..input_mapper.total_columns()).collect();
+                    for equivalence in equivalences.iter() {
+                        let mut first_column = None;
+                        for expr in equivalence.iter() {
+                            if let MirScalarExpr::Column(c) = expr {
+                                if let Some(prior) = &first_column {
+                                    permutation[*c] = *prior;
+                                } else {
+                                    first_column = Some(*c);
+                                }
+                            }
+                        }
                     }
-                }
 
-                self.action(input, new_columns, gets)
-            }
-            MirRelationExpr::TopK {
-                input,
-                group_key,
-                order_key,
-                ..
-            } => {
-                // Group and order keys must be retained, as they define
-                // which rows are retained.
-                columns.extend(group_key.iter().cloned());
-                columns.extend(order_key.iter().map(|o| o.column));
-                self.action(input, columns, gets)
-            }
-            MirRelationExpr::Negate { input } => self.action(input, columns, gets),
-            MirRelationExpr::DeclareKeys { input, keys: _ } => {
-                // TODO[btv] - If and when we add a "debug mode" that asserts whether this is truly a key,
-                // we will probably need to add the key to the set of demanded columns.
-                self.action(input, columns, gets)
-            }
-            MirRelationExpr::Threshold { input } => {
-                // Threshold requires all columns, as collapsing any distinct values
-                // has the potential to change how it thresholds counts. This could
-                // be improved with reasoning about distinctness or non-negativity.
-                let arity = input.arity();
-                self.action(input, (0..arity).collect(), gets)
-            }
-            MirRelationExpr::Union { base, inputs } => {
-                self.action(base, columns.clone(), gets)?;
-                for input in inputs {
-                    self.action(input, columns.clone(), gets)?;
-                }
-                Ok(())
-            }
-            MirRelationExpr::ArrangeBy { input, keys } => {
-                for key_set in keys {
-                    for key in key_set {
-                        columns.extend(key.support());
+                    let should_permute = columns.iter().any(|c| permutation[*c] != *c);
+
+                    // Each equivalence class imposes internal demand for columns.
+                    for equivalence in equivalences.iter() {
+                        for expr in equivalence.iter() {
+                            columns.extend(expr.support());
+                        }
                     }
+
+                    // Populate child demands from external and internal demands.
+                    let new_columns = input_mapper.split_column_set_by_input(columns.iter());
+
+                    // Recursively indicate the requirements.
+                    for (input, columns) in inputs.iter_mut().zip(new_columns) {
+                        self.action(input, columns, gets)?;
+                    }
+
+                    // Install a permutation if any demanded column is not the
+                    // canonical column.
+                    if should_permute {
+                        *relation = relation.take_dangerous().project(permutation);
+                    }
+
+                    Ok(())
                 }
-                self.action(input, columns, gets)
+                MirRelationExpr::Reduce {
+                    input,
+                    group_key,
+                    aggregates,
+                    monotonic: _,
+                    expected_group_size: _,
+                } => {
+                    let mut new_columns = HashSet::new();
+                    // Group keys determine aggregation granularity and are
+                    // each crucial in determining aggregates and even the
+                    // multiplicities of other keys.
+                    new_columns.extend(group_key.iter().flat_map(|e| e.support()));
+                    for column in columns.iter() {
+                        // No obvious requirements on aggregate columns.
+                        // A "non-empty" requirement, I guess?
+                        if *column >= group_key.len() {
+                            new_columns
+                                .extend(aggregates[*column - group_key.len()].expr.support());
+                        }
+                    }
+
+                    // Replace un-demanded aggregations with dummies.
+                    let input_type = input.typ();
+                    for index in (0..aggregates.len()).rev() {
+                        if !columns.contains(&(group_key.len() + index)) {
+                            let typ = aggregates[index].typ(&input_type);
+                            aggregates[index] = AggregateExpr {
+                                func: AggregateFunc::Dummy,
+                                expr: MirScalarExpr::literal_ok(Datum::Dummy, typ.scalar_type),
+                                distinct: false,
+                            };
+                        }
+                    }
+
+                    self.action(input, new_columns, gets)
+                }
+                MirRelationExpr::TopK {
+                    input,
+                    group_key,
+                    order_key,
+                    ..
+                } => {
+                    // Group and order keys must be retained, as they define
+                    // which rows are retained.
+                    columns.extend(group_key.iter().cloned());
+                    columns.extend(order_key.iter().map(|o| o.column));
+                    self.action(input, columns, gets)
+                }
+                MirRelationExpr::Negate { input } => self.action(input, columns, gets),
+                MirRelationExpr::DeclareKeys { input, keys: _ } => {
+                    // TODO[btv] - If and when we add a "debug mode" that asserts whether this is truly a key,
+                    // we will probably need to add the key to the set of demanded columns.
+                    self.action(input, columns, gets)
+                }
+                MirRelationExpr::Threshold { input } => {
+                    // Threshold requires all columns, as collapsing any distinct values
+                    // has the potential to change how it thresholds counts. This could
+                    // be improved with reasoning about distinctness or non-negativity.
+                    let arity = input.arity();
+                    self.action(input, (0..arity).collect(), gets)
+                }
+                MirRelationExpr::Union { base, inputs } => {
+                    self.action(base, columns.clone(), gets)?;
+                    for input in inputs {
+                        self.action(input, columns.clone(), gets)?;
+                    }
+                    Ok(())
+                }
+                MirRelationExpr::ArrangeBy { input, keys } => {
+                    for key_set in keys {
+                        for key in key_set {
+                            columns.extend(key.support());
+                        }
+                    }
+                    self.action(input, columns, gets)
+                }
             }
-        }
+        })
     }
 }

--- a/src/transform/src/fusion/filter.rs
+++ b/src/transform/src/fusion/filter.rs
@@ -57,10 +57,7 @@ impl crate::Transform for Filter {
         relation: &mut MirRelationExpr,
         _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
-        relation.visit_mut_pre(&mut |e| {
-            self.action(e);
-        });
-        Ok(())
+        relation.try_visit_mut_pre(&mut |e| Ok(self.action(e)))
     }
 }
 

--- a/src/transform/src/fusion/join.rs
+++ b/src/transform/src/fusion/join.rs
@@ -38,10 +38,7 @@ impl crate::Transform for Join {
         relation: &mut MirRelationExpr,
         _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
-        relation.visit_mut_post(&mut |e| {
-            self.action(e);
-        });
-        Ok(())
+        relation.try_visit_mut_post(&mut |e| Ok(self.action(e)))
     }
 }
 

--- a/src/transform/src/fusion/map.rs
+++ b/src/transform/src/fusion/map.rs
@@ -32,15 +32,12 @@ impl crate::Transform for Map {
         relation: &mut MirRelationExpr,
         _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
-        relation.visit_mut_pre(&mut |e| {
-            self.action(e);
-        });
-        Ok(())
+        relation.try_visit_mut_pre(&mut |e| Ok(self.action(e)))
     }
 }
 
 impl Map {
-    /// Fuses a sequence of `Map` operators in to one `Map` operator.
+    /// Fuses a sequence of `Map` operators into one `Map` operator.
     /// Remove the map operator if it is empty.
     pub fn action(&self, relation: &mut MirRelationExpr) {
         if let MirRelationExpr::Map { input, scalars } = relation {

--- a/src/transform/src/fusion/negate.rs
+++ b/src/transform/src/fusion/negate.rs
@@ -22,15 +22,12 @@ impl crate::Transform for Negate {
         relation: &mut MirRelationExpr,
         _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
-        relation.visit_mut_pre(&mut |e| {
-            self.action(e);
-        });
-        Ok(())
+        relation.try_visit_mut_pre(&mut |e| Ok(self.action(e)))
     }
 }
 
 impl Negate {
-    /// Fuses a sequence of `Negate` operators in to one or zero `Negate` operators.
+    /// Fuses a sequence of `Negate` operators into one or zero `Negate` operators.
     pub fn action(&self, relation: &mut MirRelationExpr) {
         if let MirRelationExpr::Negate { input } = relation {
             let mut require_negate = true;

--- a/src/transform/src/fusion/project.rs
+++ b/src/transform/src/fusion/project.rs
@@ -24,10 +24,7 @@ impl crate::Transform for Project {
         relation: &mut MirRelationExpr,
         _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
-        relation.visit_mut_pre(&mut |e| {
-            self.action(e);
-        });
-        Ok(())
+        relation.try_visit_mut_pre(&mut |e| Ok(self.action(e)))
     }
 }
 

--- a/src/transform/src/fusion/reduce.rs
+++ b/src/transform/src/fusion/reduce.rs
@@ -21,10 +21,7 @@ impl crate::Transform for Reduce {
         relation: &mut MirRelationExpr,
         _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
-        relation.visit_mut_pre(&mut |e| {
-            self.action(e);
-        });
-        Ok(())
+        relation.try_visit_mut_pre(&mut |e| Ok(self.action(e)))
     }
 }
 

--- a/src/transform/src/fusion/top_k.rs
+++ b/src/transform/src/fusion/top_k.rs
@@ -23,10 +23,7 @@ impl crate::Transform for TopK {
         relation: &mut MirRelationExpr,
         _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
-        relation.visit_mut_pre(&mut |e| {
-            self.action(e);
-        });
-        Ok(())
+        relation.try_visit_mut_pre(&mut |e| Ok(self.action(e)))
     }
 }
 

--- a/src/transform/src/fusion/union.rs
+++ b/src/transform/src/fusion/union.rs
@@ -28,10 +28,7 @@ impl crate::Transform for Union {
         relation: &mut MirRelationExpr,
         _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
-        relation.visit_mut_post(&mut |e| {
-            self.action(e);
-        });
-        Ok(())
+        relation.try_visit_mut_post(&mut |e| Ok(self.action(e)))
     }
 }
 

--- a/src/transform/src/join_implementation.rs
+++ b/src/transform/src/join_implementation.rs
@@ -19,11 +19,32 @@
 use std::collections::HashMap;
 
 use crate::TransformArgs;
-use expr::{Id, JoinInputMapper, MapFilterProject, MirRelationExpr, MirScalarExpr};
+use expr::{
+    Id, JoinInputMapper, MapFilterProject, MirRelationExpr, MirScalarExpr, RECURSION_LIMIT,
+};
+use ore::stack::{CheckedRecursion, RecursionGuard};
 
 /// Determines the join implementation for join operators.
 #[derive(Debug)]
-pub struct JoinImplementation;
+pub struct JoinImplementation {
+    recursion_guard: RecursionGuard,
+}
+
+impl Default for JoinImplementation {
+    /// Construct a new [`JoinImplementation`] where `recursion_guard`
+    /// is initialized with [`RECURSION_LIMIT`] as limit.
+    fn default() -> JoinImplementation {
+        JoinImplementation {
+            recursion_guard: RecursionGuard::with_limit(RECURSION_LIMIT),
+        }
+    }
+}
+
+impl CheckedRecursion for JoinImplementation {
+    fn recursion_guard(&self) -> &RecursionGuard {
+        &self.recursion_guard
+    }
+}
 
 impl crate::Transform for JoinImplementation {
     fn transform(

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -279,7 +279,7 @@ impl Optimizer {
                     // redundancy between the two transforms.
                     Box::new(crate::column_knowledge::ColumnKnowledge),
                     // Lifts the information `col1 = col2`
-                    Box::new(crate::demand::Demand),
+                    Box::new(crate::demand::Demand::default()),
                     Box::new(crate::FuseAndCollapse::default()),
                 ],
             }),
@@ -323,7 +323,7 @@ impl Optimizer {
                     Box::new(crate::join_implementation::JoinImplementation),
                     Box::new(crate::column_knowledge::ColumnKnowledge),
                     Box::new(crate::reduction::FoldConstants { limit: Some(10000) }),
-                    Box::new(crate::demand::Demand),
+                    Box::new(crate::demand::Demand::default()),
                     Box::new(crate::map_lifting::LiteralLifting),
                 ],
             }),

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -277,7 +277,7 @@ impl Optimizer {
                     // TODO (#6613): this also tries to lift `!isnull(col)` but
                     // less well than the previous transform. Eliminate
                     // redundancy between the two transforms.
-                    Box::new(crate::column_knowledge::ColumnKnowledge),
+                    Box::new(crate::column_knowledge::ColumnKnowledge::default()),
                     // Lifts the information `col1 = col2`
                     Box::new(crate::demand::Demand::default()),
                     Box::new(crate::FuseAndCollapse::default()),
@@ -321,7 +321,7 @@ impl Optimizer {
                 limit: 100,
                 transforms: vec![
                     Box::new(crate::join_implementation::JoinImplementation),
-                    Box::new(crate::column_knowledge::ColumnKnowledge),
+                    Box::new(crate::column_knowledge::ColumnKnowledge::default()),
                     Box::new(crate::reduction::FoldConstants { limit: Some(10000) }),
                     Box::new(crate::demand::Demand::default()),
                     Box::new(crate::map_lifting::LiteralLifting),

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -199,7 +199,7 @@ impl Default for FuseAndCollapse {
                 Box::new(crate::union_cancel::UnionBranchCancellation),
                 // This should run before redundant join to ensure that key info
                 // is correct.
-                Box::new(crate::update_let::UpdateLet),
+                Box::new(crate::update_let::UpdateLet::default()),
                 // Removes redundant inputs from joins.
                 // Note that this eliminates one redundant input per join,
                 // so it is necessary to run this section in a loop.
@@ -300,7 +300,7 @@ impl Optimizer {
                     // Must be followed by let inlining, to keep under control.
                     Box::new(crate::cse::relation_cse::RelationCSE),
                     Box::new(crate::inline_let::InlineLet::new(false)),
-                    Box::new(crate::update_let::UpdateLet),
+                    Box::new(crate::update_let::UpdateLet::default()),
                     Box::new(crate::FuseAndCollapse::default()),
                 ],
             }),
@@ -333,7 +333,7 @@ impl Optimizer {
             // Must be followed by let inlining, to keep under control.
             Box::new(crate::cse::relation_cse::RelationCSE),
             Box::new(crate::inline_let::InlineLet::new(false)),
-            Box::new(crate::update_let::UpdateLet),
+            Box::new(crate::update_let::UpdateLet::default()),
             Box::new(crate::reduction::FoldConstants { limit: Some(10000) }),
         ];
         Self { transforms }

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -270,7 +270,7 @@ impl Optimizer {
                 limit: 100,
                 transforms: vec![
                     // Predicate pushdown sets the equivalence classes of joins.
-                    Box::new(crate::predicate_pushdown::PredicatePushdown),
+                    Box::new(crate::predicate_pushdown::PredicatePushdown::default()),
                     // Lifts the information `!isnull(col)`
                     Box::new(crate::nonnullable::NonNullable),
                     // Lifts the information `col = literal`

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -208,7 +208,7 @@ impl Default for FuseAndCollapse {
                 // redundant joins from being removed. When predicate pushdown
                 // no longer works against redundant join, check if it is still
                 // necessary to run RedundantJoin here.
-                Box::new(crate::redundant_join::RedundantJoin),
+                Box::new(crate::redundant_join::RedundantJoin::default()),
                 // As a final logical action, convert any constant expression to a constant.
                 // Some optimizations fight against this, and we want to be sure to end as a
                 // `MirRelationExpr::Constant` if that is the case, so that subsequent use can
@@ -350,7 +350,7 @@ impl Optimizer {
                 transforms: vec![
                     // Projection pushdown may unblock fusing joins and unions.
                     Box::new(crate::fusion::join::Join),
-                    Box::new(crate::redundant_join::RedundantJoin),
+                    Box::new(crate::redundant_join::RedundantJoin::default()),
                     // Redundant join produces projects that need to be fused.
                     Box::new(crate::fusion::project::Project),
                     Box::new(crate::fusion::union::Union),

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -127,7 +127,7 @@ impl Transform for Fixpoint {
         // stable shape.
         loop {
             let mut original_count = 0;
-            relation.visit_post(&mut |_| original_count += 1);
+            relation.try_visit_post::<_, TransformError>(&mut |_| Ok(original_count += 1))?;
             for _ in 0..self.limit {
                 let original = relation.clone();
                 for transform in self.transforms.iter() {
@@ -144,7 +144,7 @@ impl Transform for Fixpoint {
                 }
             }
             let mut final_count = 0;
-            relation.visit_post(&mut |_| final_count += 1);
+            relation.try_visit_post::<_, TransformError>(&mut |_| Ok(final_count += 1))?;
             if final_count >= original_count {
                 break;
             }

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -191,7 +191,7 @@ impl Default for FuseAndCollapse {
                 Box::new(crate::fusion::project::Project),
                 Box::new(crate::fusion::join::Join),
                 Box::new(crate::fusion::top_k::TopK),
-                Box::new(crate::inline_let::InlineLet { inline_mfp: false }),
+                Box::new(crate::inline_let::InlineLet::new(false)),
                 Box::new(crate::fusion::reduce::Reduce),
                 Box::new(crate::fusion::union::Union),
                 // This goes after union fusion so we can cancel out
@@ -299,7 +299,7 @@ impl Optimizer {
                     // Identifies common relation subexpressions.
                     // Must be followed by let inlining, to keep under control.
                     Box::new(crate::cse::relation_cse::RelationCSE),
-                    Box::new(crate::inline_let::InlineLet { inline_mfp: false }),
+                    Box::new(crate::inline_let::InlineLet::new(false)),
                     Box::new(crate::update_let::UpdateLet),
                     Box::new(crate::FuseAndCollapse::default()),
                 ],
@@ -332,7 +332,7 @@ impl Optimizer {
             // Identifies common relation subexpressions.
             // Must be followed by let inlining, to keep under control.
             Box::new(crate::cse::relation_cse::RelationCSE),
-            Box::new(crate::inline_let::InlineLet { inline_mfp: false }),
+            Box::new(crate::inline_let::InlineLet::new(false)),
             Box::new(crate::update_let::UpdateLet),
             Box::new(crate::reduction::FoldConstants { limit: Some(10000) }),
         ];
@@ -358,7 +358,7 @@ impl Optimizer {
                     // more branches at a time.
                     Box::new(crate::union_cancel::UnionBranchCancellation),
                     Box::new(crate::cse::relation_cse::RelationCSE),
-                    Box::new(crate::inline_let::InlineLet { inline_mfp: true }),
+                    Box::new(crate::inline_let::InlineLet::new(true)),
                 ],
             }),
         ];

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -320,7 +320,7 @@ impl Optimizer {
             Box::new(crate::Fixpoint {
                 limit: 100,
                 transforms: vec![
-                    Box::new(crate::join_implementation::JoinImplementation),
+                    Box::new(crate::join_implementation::JoinImplementation::default()),
                     Box::new(crate::column_knowledge::ColumnKnowledge::default()),
                     Box::new(crate::reduction::FoldConstants { limit: Some(10000) }),
                     Box::new(crate::demand::Demand::default()),

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -184,7 +184,7 @@ impl Default for FuseAndCollapse {
             // transforms.
             transforms: vec![
                 Box::new(crate::projection_extraction::ProjectionExtraction),
-                Box::new(crate::projection_lifting::ProjectionLifting),
+                Box::new(crate::projection_lifting::ProjectionLifting::default()),
                 Box::new(crate::fusion::map::Map),
                 Box::new(crate::fusion::negate::Negate),
                 Box::new(crate::fusion::filter::Filter),

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -256,7 +256,7 @@ impl Optimizer {
         let transforms: Vec<Box<dyn crate::Transform>> = vec![
             // 1. Structure-agnostic cleanup
             Box::new(crate::topk_elision::TopKElision),
-            Box::new(crate::nonnull_requirements::NonNullRequirements),
+            Box::new(crate::nonnull_requirements::NonNullRequirements::default()),
             // 2. Collapse constants, joins, unions, and lets as much as possible.
             // TODO: lift filters/maps to maximize ability to collapse
             // things down?

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -38,6 +38,7 @@ pub mod fusion;
 pub mod inline_let;
 pub mod join_implementation;
 pub mod map_lifting;
+pub mod monotonic;
 pub mod nonnull_requirements;
 pub mod nonnullable;
 pub mod predicate_pushdown;

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -295,7 +295,7 @@ impl Optimizer {
                     // Converts `Cross Join {Constant(Literal) + Input}` to
                     // `Map {Cross Join (Input, Constant()), Literal}`.
                     // Join fusion will clean this up to `Map{Input, Literal}`
-                    Box::new(crate::map_lifting::LiteralLifting),
+                    Box::new(crate::map_lifting::LiteralLifting::default()),
                     // Identifies common relation subexpressions.
                     // Must be followed by let inlining, to keep under control.
                     Box::new(crate::cse::relation_cse::RelationCSE),
@@ -324,7 +324,7 @@ impl Optimizer {
                     Box::new(crate::column_knowledge::ColumnKnowledge::default()),
                     Box::new(crate::reduction::FoldConstants { limit: Some(10000) }),
                     Box::new(crate::demand::Demand::default()),
-                    Box::new(crate::map_lifting::LiteralLifting),
+                    Box::new(crate::map_lifting::LiteralLifting::default()),
                 ],
             }),
             Box::new(crate::reduction_pushdown::ReductionPushdown),

--- a/src/transform/src/map_lifting.rs
+++ b/src/transform/src/map_lifting.rs
@@ -24,15 +24,31 @@ use std::collections::HashMap;
 
 use itertools::Itertools;
 
-use expr::{Id, JoinInputMapper, MirRelationExpr, MirScalarExpr};
-
+use expr::{Id, JoinInputMapper, MirRelationExpr, MirScalarExpr, RECURSION_LIMIT};
+use ore::stack::{CheckedRecursion, RecursionGuard};
 use repr::Row;
 
 use crate::TransformArgs;
 
 /// Hoist literal values from maps wherever possible.
 #[derive(Debug)]
-pub struct LiteralLifting;
+pub struct LiteralLifting {
+    recursion_guard: RecursionGuard,
+}
+
+impl Default for LiteralLifting {
+    fn default() -> LiteralLifting {
+        LiteralLifting {
+            recursion_guard: RecursionGuard::with_limit(RECURSION_LIMIT),
+        }
+    }
+}
+
+impl CheckedRecursion for LiteralLifting {
+    fn recursion_guard(&self) -> &RecursionGuard {
+        &self.recursion_guard
+    }
+}
 
 impl crate::Transform for LiteralLifting {
     fn transform(

--- a/src/transform/src/map_lifting.rs
+++ b/src/transform/src/map_lifting.rs
@@ -125,549 +125,269 @@ impl LiteralLifting {
         // Map from names to literals required for appending.
         gets: &mut HashMap<Id, Vec<MirScalarExpr>>,
     ) -> Result<Vec<MirScalarExpr>, crate::TransformError> {
-        match relation {
-            MirRelationExpr::Constant { rows, typ } => {
-                // From the back to the front, check if all values are identical.
-                let mut the_same = vec![true; typ.arity()];
-                if let Ok([(row, _cnt), rows @ ..]) = rows.as_deref_mut() {
-                    let mut data = row.unpack();
-                    assert_eq!(the_same.len(), data.len());
-                    for (row, _cnt) in rows.iter() {
-                        let other = row.unpack();
-                        assert_eq!(the_same.len(), other.len());
-                        for index in 0..the_same.len() {
-                            the_same[index] = the_same[index] && (data[index] == other[index]);
-                        }
-                    }
-                    let mut literals = Vec::new();
-                    while the_same.last() == Some(&true) {
-                        the_same.pop();
-                        let datum = data.pop().unwrap();
-                        let typum = typ.column_types.pop().unwrap();
-                        literals.push(MirScalarExpr::literal_ok(datum, typum.scalar_type));
-                    }
-                    literals.reverse();
-
-                    // Any subset of constant values can be extracted with a permute.
-                    let remaining_common_literals = the_same.iter().filter(|e| **e).count();
-                    if remaining_common_literals > 0 {
-                        let final_arity = the_same.len() - remaining_common_literals;
-                        let mut projected_literals = Vec::new();
-                        let mut projection = Vec::new();
-                        let mut new_column_types = Vec::new();
-                        for (i, sameness) in the_same.iter().enumerate() {
-                            if *sameness {
-                                projection.push(final_arity + projected_literals.len());
-                                projected_literals.push(MirScalarExpr::literal_ok(
-                                    data[i],
-                                    typ.column_types[i].scalar_type.clone(),
-                                ));
-                            } else {
-                                projection.push(new_column_types.len());
-                                new_column_types.push(typ.column_types[i].clone());
+        self.checked_recur(|_| {
+            match relation {
+                MirRelationExpr::Constant { rows, typ } => {
+                    // From the back to the front, check if all values are identical.
+                    let mut the_same = vec![true; typ.arity()];
+                    if let Ok([(row, _cnt), rows @ ..]) = rows.as_deref_mut() {
+                        let mut data = row.unpack();
+                        assert_eq!(the_same.len(), data.len());
+                        for (row, _cnt) in rows.iter() {
+                            let other = row.unpack();
+                            assert_eq!(the_same.len(), other.len());
+                            for index in 0..the_same.len() {
+                                the_same[index] = the_same[index] && (data[index] == other[index]);
                             }
                         }
-                        typ.column_types = new_column_types;
-
-                        // Tidy up the type information of `relation`.
-                        for key in typ.keys.iter_mut() {
-                            *key = key
-                                .iter()
-                                .filter(|x| !the_same.get(**x).unwrap_or(&true))
-                                .map(|x| projection[*x])
-                                .collect::<Vec<usize>>();
+                        let mut literals = Vec::new();
+                        while the_same.last() == Some(&true) {
+                            the_same.pop();
+                            let datum = data.pop().unwrap();
+                            let typum = typ.column_types.pop().unwrap();
+                            literals.push(MirScalarExpr::literal_ok(datum, typum.scalar_type));
                         }
-                        typ.keys.sort();
-                        typ.keys.dedup();
+                        literals.reverse();
 
-                        let remove_extracted_literals = |row: &mut Row| {
-                            let mut new_row = Row::default();
-                            let data = row.unpack();
-                            for i in 0..the_same.len() {
-                                if !the_same[i] {
-                                    new_row.push(data[i]);
+                        // Any subset of constant values can be extracted with a permute.
+                        let remaining_common_literals = the_same.iter().filter(|e| **e).count();
+                        if remaining_common_literals > 0 {
+                            let final_arity = the_same.len() - remaining_common_literals;
+                            let mut projected_literals = Vec::new();
+                            let mut projection = Vec::new();
+                            let mut new_column_types = Vec::new();
+                            for (i, sameness) in the_same.iter().enumerate() {
+                                if *sameness {
+                                    projection.push(final_arity + projected_literals.len());
+                                    projected_literals.push(MirScalarExpr::literal_ok(
+                                        data[i],
+                                        typ.column_types[i].scalar_type.clone(),
+                                    ));
+                                } else {
+                                    projection.push(new_column_types.len());
+                                    new_column_types.push(typ.column_types[i].clone());
                                 }
                             }
-                            *row = new_row;
-                        };
+                            typ.column_types = new_column_types;
 
-                        remove_extracted_literals(row);
-                        for (row, _cnt) in rows.iter_mut() {
+                            // Tidy up the type information of `relation`.
+                            for key in typ.keys.iter_mut() {
+                                *key = key
+                                    .iter()
+                                    .filter(|x| !the_same.get(**x).unwrap_or(&true))
+                                    .map(|x| projection[*x])
+                                    .collect::<Vec<usize>>();
+                            }
+                            typ.keys.sort();
+                            typ.keys.dedup();
+
+                            let remove_extracted_literals = |row: &mut Row| {
+                                let mut new_row = Row::default();
+                                let data = row.unpack();
+                                for i in 0..the_same.len() {
+                                    if !the_same[i] {
+                                        new_row.push(data[i]);
+                                    }
+                                }
+                                *row = new_row;
+                            };
+
                             remove_extracted_literals(row);
+                            for (row, _cnt) in rows.iter_mut() {
+                                remove_extracted_literals(row);
+                            }
+
+                            *relation = relation
+                                .take_dangerous()
+                                .map(projected_literals)
+                                .project(projection);
+                        } else if !literals.is_empty() {
+                            // Tidy up the type information of `relation`.
+                            for key in typ.keys.iter_mut() {
+                                key.retain(|k| k < &data.len());
+                            }
+                            typ.keys.sort();
+                            typ.keys.dedup();
+
+                            row.truncate_datums(typ.arity());
+                            for (row, _cnt) in rows.iter_mut() {
+                                row.truncate_datums(typ.arity());
+                            }
                         }
 
-                        *relation = relation
-                            .take_dangerous()
-                            .map(projected_literals)
-                            .project(projection);
-                    } else if !literals.is_empty() {
-                        // Tidy up the type information of `relation`.
+                        Ok(literals)
+                    } else {
+                        Ok(Vec::new())
+                    }
+                }
+                MirRelationExpr::Get { id, typ } => {
+                    // A get expression may need to have literal expressions appended to it.
+                    let literals = gets.get(id).cloned().unwrap_or_else(Vec::new);
+                    if !literals.is_empty() {
+                        // Correct the type of the `Get`, which has fewer columns,
+                        // and not the same fields in its keys. It is ok to remove
+                        // any columns from the keys, as them being literals meant
+                        // that their distinctness was not what made anything a key.
+                        for _ in 0..literals.len() {
+                            typ.column_types.pop();
+                        }
+                        let columns = typ.column_types.len();
                         for key in typ.keys.iter_mut() {
-                            key.retain(|k| k < &data.len());
+                            key.retain(|k| k < &columns);
                         }
                         typ.keys.sort();
                         typ.keys.dedup();
+                    }
+                    Ok(literals)
+                }
+                MirRelationExpr::Let { id, value, body } => {
+                    // Any literals appended to the `value` should be used
+                    // at corresponding `Get`s throughout the `body`.
+                    let literals = self.action(value, gets)?;
+                    let id = Id::Local(*id);
+                    if !literals.is_empty() {
+                        let prior = gets.insert(id, literals);
+                        assert!(!prior.is_some());
+                    }
+                    let result = self.action(body, gets);
+                    gets.remove(&id);
+                    result
+                }
+                MirRelationExpr::Project { input, outputs } => {
+                    // We do not want to lift literals around projections.
+                    // Projections are the highest lifted operator and lifting
+                    // literals around projections could cause us to fail to
+                    // reach a fixed point under the transformations.
+                    let mut literals = self.action(input, gets)?;
+                    if !literals.is_empty() {
+                        let input_arity = input.arity();
+                        // For each input literal contains a vector with the `output` positions
+                        // that references it. By putting data into a Vec and sorting, we
+                        // guarantee a reliable order.
+                        let mut used_literals = outputs
+                            .iter()
+                            .enumerate()
+                            .filter(|(_, x)| **x >= input_arity)
+                            .map(|(out_col, old_in_col)| (old_in_col - input_arity, out_col))
+                            // group them to avoid adding duplicated literals
+                            .into_group_map()
+                            .drain()
+                            .collect::<Vec<_>>();
 
-                        row.truncate_datums(typ.arity());
-                        for (row, _cnt) in rows.iter_mut() {
-                            row.truncate_datums(typ.arity());
+                        if used_literals.len() != literals.len() {
+                            used_literals.sort();
+                            // Discard literals that are not projected
+                            literals = used_literals
+                                .iter()
+                                .map(|(old_in_col, _)| literals[*old_in_col].clone())
+                                .collect::<Vec<_>>();
+                            // Update the references to the literal in `output`
+                            for (new_in_col, (_old_in_col, out_cols)) in
+                                used_literals.iter().enumerate()
+                            {
+                                for out_col in out_cols {
+                                    outputs[*out_col] = input_arity + new_in_col;
+                                }
+                            }
+                        }
+
+                        // If the literals need to be re-interleaved,
+                        // we don't have much choice but to install a
+                        // Map operator to do that under the project.
+                        // Ideally this doesn't happen much, as projects
+                        // get lifted too.
+                        if !literals.is_empty() {
+                            **input = input.take_dangerous().map(literals);
                         }
                     }
-
-                    Ok(literals)
-                } else {
+                    // Policy: Do not lift literals around projects.
                     Ok(Vec::new())
                 }
-            }
-            MirRelationExpr::Get { id, typ } => {
-                // A get expression may need to have literal expressions appended to it.
-                let literals = gets.get(id).cloned().unwrap_or_else(Vec::new);
-                if !literals.is_empty() {
-                    // Correct the type of the `Get`, which has fewer columns,
-                    // and not the same fields in its keys. It is ok to remove
-                    // any columns from the keys, as them being literals meant
-                    // that their distinctness was not what made anything a key.
-                    for _ in 0..literals.len() {
-                        typ.column_types.pop();
+                MirRelationExpr::Map { input, scalars } => {
+                    let mut literals = self.action(input, gets)?;
+
+                    // Make the map properly formed again.
+                    literals.extend(scalars.iter().cloned());
+                    *scalars = literals;
+
+                    // Strip off literals at the end of `scalars`.
+                    let mut result = Vec::new();
+                    while scalars.last().map(|e| e.is_literal()) == Some(true) {
+                        result.push(scalars.pop().unwrap());
                     }
-                    let columns = typ.column_types.len();
-                    for key in typ.keys.iter_mut() {
-                        key.retain(|k| k < &columns);
-                    }
-                    typ.keys.sort();
-                    typ.keys.dedup();
-                }
-                Ok(literals)
-            }
-            MirRelationExpr::Let { id, value, body } => {
-                // Any literals appended to the `value` should be used
-                // at corresponding `Get`s throughout the `body`.
-                let literals = self.action(value, gets)?;
-                let id = Id::Local(*id);
-                if !literals.is_empty() {
-                    let prior = gets.insert(id, literals);
-                    assert!(!prior.is_some());
-                }
-                let result = self.action(body, gets);
-                gets.remove(&id);
-                result
-            }
-            MirRelationExpr::Project { input, outputs } => {
-                // We do not want to lift literals around projections.
-                // Projections are the highest lifted operator and lifting
-                // literals around projections could cause us to fail to
-                // reach a fixed point under the transformations.
-                let mut literals = self.action(input, gets)?;
-                if !literals.is_empty() {
-                    let input_arity = input.arity();
-                    // For each input literal contains a vector with the `output` positions
-                    // that references it. By putting data into a Vec and sorting, we
-                    // guarantee a reliable order.
-                    let mut used_literals = outputs
-                        .iter()
-                        .enumerate()
-                        .filter(|(_, x)| **x >= input_arity)
-                        .map(|(out_col, old_in_col)| (old_in_col - input_arity, out_col))
-                        // group them to avoid adding duplicated literals
-                        .into_group_map()
-                        .drain()
-                        .collect::<Vec<_>>();
+                    result.reverse();
 
-                    if used_literals.len() != literals.len() {
-                        used_literals.sort();
-                        // Discard literals that are not projected
-                        literals = used_literals
-                            .iter()
-                            .map(|(old_in_col, _)| literals[*old_in_col].clone())
-                            .collect::<Vec<_>>();
-                        // Update the references to the literal in `output`
-                        for (new_in_col, (_old_in_col, out_cols)) in
-                            used_literals.iter().enumerate()
-                        {
-                            for out_col in out_cols {
-                                outputs[*out_col] = input_arity + new_in_col;
-                            }
-                        }
-                    }
-
-                    // If the literals need to be re-interleaved,
-                    // we don't have much choice but to install a
-                    // Map operator to do that under the project.
-                    // Ideally this doesn't happen much, as projects
-                    // get lifted too.
-                    if !literals.is_empty() {
-                        **input = input.take_dangerous().map(literals);
-                    }
-                }
-                // Policy: Do not lift literals around projects.
-                Ok(Vec::new())
-            }
-            MirRelationExpr::Map { input, scalars } => {
-                let mut literals = self.action(input, gets)?;
-
-                // Make the map properly formed again.
-                literals.extend(scalars.iter().cloned());
-                *scalars = literals;
-
-                // Strip off literals at the end of `scalars`.
-                let mut result = Vec::new();
-                while scalars.last().map(|e| e.is_literal()) == Some(true) {
-                    result.push(scalars.pop().unwrap());
-                }
-                result.reverse();
-
-                if scalars.is_empty() {
-                    *relation = input.take_dangerous();
-                } else {
-                    // Permute columns to put literals at end, if any, hope project lifted.
-                    let literal_count = scalars.iter().filter(|e| e.is_literal()).count();
-                    if literal_count != 0 {
-                        let input_arity = input.arity();
-                        let first_literal_id = input_arity + scalars.len() - literal_count;
-                        let mut new_scalars = Vec::new();
-                        let mut projected_literals = Vec::new();
-                        let mut projection = (0..input_arity).collect::<Vec<usize>>();
-                        for scalar in scalars.iter_mut() {
-                            if scalar.is_literal() {
-                                projection.push(first_literal_id + projected_literals.len());
-                                projected_literals.push(scalar.clone());
-                            } else {
-                                let mut cloned_scalar = scalar.clone();
-                                // Propagate literals through expressions and remap columns.
-                                cloned_scalar.visit_mut(&mut |e| {
-                                    if let MirScalarExpr::Column(old_id) = e {
-                                        let new_id = projection[*old_id];
-                                        if new_id >= first_literal_id {
-                                            *e = projected_literals[new_id - first_literal_id]
-                                                .clone();
-                                        } else {
-                                            *old_id = new_id;
-                                        }
-                                    }
-                                });
-                                projection.push(input_arity + new_scalars.len());
-                                new_scalars.push(cloned_scalar);
-                            }
-                        }
-                        new_scalars.extend(projected_literals);
-                        *relation = input.take_dangerous().map(new_scalars).project(projection);
-                    }
-                }
-
-                Ok(result)
-            }
-            MirRelationExpr::FlatMap { input, func, exprs } => {
-                let literals = self.action(input, gets)?;
-                if !literals.is_empty() {
-                    let input_arity = input.arity();
-                    for expr in exprs.iter_mut() {
-                        expr.visit_mut(&mut |e| {
-                            if let MirScalarExpr::Column(c) = e {
-                                if *c >= input_arity {
-                                    *e = literals[*c - input_arity].clone();
-                                }
-                            }
-                        });
-                    }
-                    // Permute the literals around the columns added by FlatMap
-                    let mut projection = (0..input_arity).collect::<Vec<usize>>();
-                    let func_arity = func.output_arity();
-                    projection.extend((0..literals.len()).map(|x| input_arity + func_arity + x));
-                    projection.extend((0..func_arity).map(|x| input_arity + x));
-
-                    *relation = relation.take_dangerous().map(literals).project(projection);
-                }
-                Ok(Vec::new())
-            }
-            MirRelationExpr::Filter { input, predicates } => {
-                let literals = self.action(input, gets)?;
-                if !literals.is_empty() {
-                    // We should be able to instantiate all uses of `literals`
-                    // in predicates and then lift the `map` around the filter.
-                    let input_arity = input.arity();
-                    for expr in predicates.iter_mut() {
-                        expr.visit_mut(&mut |e| {
-                            if let MirScalarExpr::Column(c) = e {
-                                if *c >= input_arity {
-                                    *e = literals[*c - input_arity].clone();
-                                }
-                            }
-                        });
-                    }
-                }
-                Ok(literals)
-            }
-            MirRelationExpr::Join {
-                inputs,
-                equivalences,
-                implementation,
-            } => {
-                // before lifting, save the original shape of the inputs
-                let old_input_mapper = JoinInputMapper::new(inputs);
-
-                // lift literals from each input
-                let mut input_literals = Vec::new();
-                for mut input in inputs.iter_mut() {
-                    let literals = self.action(input, gets)?;
-
-                    // Do not propagate error literals beyond join inputs, since that may result
-                    // in them being propagated to other inputs of the join and evaluated when
-                    // they should not.
-                    if literals.iter().any(|l| l.is_literal_err()) {
-                        // Push the literal errors beyond any arrangement since otherwise JoinImplementation
-                        // would add another arrangement on top leading to an infinite loop/stack overflow.
-                        if let MirRelationExpr::ArrangeBy { input, .. } = &mut input {
-                            **input = input.take_dangerous().map(literals);
-                        } else {
-                            *input = input.take_dangerous().map(literals);
-                        }
-                        input_literals.push(Vec::new());
+                    if scalars.is_empty() {
+                        *relation = input.take_dangerous();
                     } else {
-                        input_literals.push(literals);
+                        // Permute columns to put literals at end, if any, hope project lifted.
+                        let literal_count = scalars.iter().filter(|e| e.is_literal()).count();
+                        if literal_count != 0 {
+                            let input_arity = input.arity();
+                            let first_literal_id = input_arity + scalars.len() - literal_count;
+                            let mut new_scalars = Vec::new();
+                            let mut projected_literals = Vec::new();
+                            let mut projection = (0..input_arity).collect::<Vec<usize>>();
+                            for scalar in scalars.iter_mut() {
+                                if scalar.is_literal() {
+                                    projection.push(first_literal_id + projected_literals.len());
+                                    projected_literals.push(scalar.clone());
+                                } else {
+                                    let mut cloned_scalar = scalar.clone();
+                                    // Propagate literals through expressions and remap columns.
+                                    cloned_scalar.visit_mut(&mut |e| {
+                                        if let MirScalarExpr::Column(old_id) = e {
+                                            let new_id = projection[*old_id];
+                                            if new_id >= first_literal_id {
+                                                *e = projected_literals[new_id - first_literal_id]
+                                                    .clone();
+                                            } else {
+                                                *old_id = new_id;
+                                            }
+                                        }
+                                    });
+                                    projection.push(input_arity + new_scalars.len());
+                                    new_scalars.push(cloned_scalar);
+                                }
+                            }
+                            new_scalars.extend(projected_literals);
+                            *relation = input.take_dangerous().map(new_scalars).project(projection);
+                        }
                     }
+
+                    Ok(result)
                 }
-
-                if input_literals.iter().any(|l| !l.is_empty()) {
-                    *implementation = expr::JoinImplementation::Unimplemented;
-
-                    // We should be able to install any literals in the
-                    // equivalence relations, and then lift all literals
-                    // around the join using a project to re-order columns.
-
-                    // Visit each expression in each equivalence class to either
-                    // inline literals or update column references.
-                    let new_input_mapper = JoinInputMapper::new(inputs);
-                    for equivalence in equivalences.iter_mut() {
-                        for expr in equivalence.iter_mut() {
+                MirRelationExpr::FlatMap { input, func, exprs } => {
+                    let literals = self.action(input, gets)?;
+                    if !literals.is_empty() {
+                        let input_arity = input.arity();
+                        for expr in exprs.iter_mut() {
                             expr.visit_mut(&mut |e| {
                                 if let MirScalarExpr::Column(c) = e {
-                                    let (col, input) = old_input_mapper.map_column_to_local(*c);
-                                    if col >= new_input_mapper.input_arity(input) {
-                                        // the column refers to a literal that
-                                        // has been promoted. inline it
-                                        *e = input_literals[input]
-                                            [col - new_input_mapper.input_arity(input)]
-                                        .clone()
-                                    } else {
-                                        // localize to the new join
-                                        *c = new_input_mapper.map_column_to_global(col, input);
+                                    if *c >= input_arity {
+                                        *e = literals[*c - input_arity].clone();
                                     }
                                 }
                             });
                         }
+                        // Permute the literals around the columns added by FlatMap
+                        let mut projection = (0..input_arity).collect::<Vec<usize>>();
+                        let func_arity = func.output_arity();
+                        projection
+                            .extend((0..literals.len()).map(|x| input_arity + func_arity + x));
+                        projection.extend((0..func_arity).map(|x| input_arity + x));
+
+                        *relation = relation.take_dangerous().map(literals).project(projection);
                     }
-
-                    // We now determine a projection to shovel around all of
-                    // the columns that puts the literals last. Where this is optional
-                    // for other operators, it is mandatory here if we want to lift the
-                    // literals through the join.
-
-                    // The first literal column number starts at the last column
-                    // of the new join. Increment the column number as literals
-                    // get added.
-                    let mut literal_column_number = new_input_mapper.total_columns();
-                    let mut projection = Vec::new();
-                    for input in 0..old_input_mapper.total_inputs() {
-                        for column in old_input_mapper.local_columns(input) {
-                            if column >= new_input_mapper.input_arity(input) {
-                                projection.push(literal_column_number);
-                                literal_column_number += 1;
-                            } else {
-                                projection
-                                    .push(new_input_mapper.map_column_to_global(column, input));
-                            }
-                        }
-                    }
-
-                    let literals = input_literals.into_iter().flatten().collect::<Vec<_>>();
-                    *relation = relation.take_dangerous().map(literals).project(projection)
+                    Ok(Vec::new())
                 }
-                Ok(Vec::new())
-            }
-            MirRelationExpr::Reduce {
-                input,
-                group_key,
-                aggregates,
-                monotonic: _,
-                expected_group_size: _,
-            } => {
-                let literals = self.action(input, gets)?;
-                if !literals.is_empty() {
-                    // Reduce absorbs maps, and we should inline literals.
-                    let input_arity = input.arity();
-                    // Inline literals into group key expressions.
-                    for expr in group_key.iter_mut() {
-                        expr.visit_mut(&mut |e| {
-                            if let MirScalarExpr::Column(c) = e {
-                                if *c >= input_arity {
-                                    *e = literals[*c - input_arity].clone();
-                                }
-                            }
-                        });
-                    }
-                    // Inline literals into aggregate value selector expressions.
-                    for aggr in aggregates.iter_mut() {
-                        aggr.expr.visit_mut(&mut |e| {
-                            if let MirScalarExpr::Column(c) = e {
-                                if *c >= input_arity {
-                                    *e = literals[*c - input_arity].clone();
-                                }
-                            }
-                        });
-                    }
-                }
-
-                let eval_constant_aggr = |aggr: &expr::AggregateExpr| {
-                    let temp = repr::RowArena::new();
-                    let mut eval = aggr.expr.eval(&[], &temp);
-                    if let Ok(param) = eval {
-                        eval = Ok(aggr.func.eval(Some(param), &temp));
-                    }
-                    MirScalarExpr::literal(
-                        eval,
-                        // This type information should be available in the `a.expr` literal,
-                        // but extracting it with pattern matching seems awkward.
-                        aggr.func
-                            .output_type(aggr.expr.typ(&repr::RelationType::empty()))
-                            .scalar_type,
-                    )
-                };
-
-                // The only literals we think we can lift are those that are
-                // independent of the number of records; things like `Any`, `All`,
-                // `Min`, and `Max`.
-                let mut result = Vec::new();
-                while aggregates.last().map(|a| a.is_constant()) == Some(true) {
-                    let aggr = aggregates.pop().unwrap();
-                    result.push(eval_constant_aggr(&aggr));
-                }
-                if aggregates.is_empty() {
-                    while group_key.last().map(|k| k.is_literal()) == Some(true) {
-                        let key = group_key.pop().unwrap();
-                        result.push(key);
-                    }
-                }
-                result.reverse();
-
-                // Add a Map operator with the remaining literals so that they are lifted in
-                // the next invocation of this transform.
-                let non_literal_keys = group_key.iter().filter(|x| !x.is_literal()).count();
-                let non_constant_aggr = aggregates.iter().filter(|x| !x.is_constant()).count();
-                if non_literal_keys != group_key.len() || non_constant_aggr != aggregates.len() {
-                    let first_projected_literal: usize = non_literal_keys + non_constant_aggr;
-                    let mut projection = Vec::new();
-                    let mut projected_literals = Vec::new();
-
-                    let mut new_group_key = Vec::new();
-                    for key in group_key.drain(..) {
-                        if key.is_literal() {
-                            projection.push(first_projected_literal + projected_literals.len());
-                            projected_literals.push(key);
-                        } else {
-                            projection.push(new_group_key.len());
-                            new_group_key.push(key);
-                        }
-                    }
-                    // The new group key without literals
-                    *group_key = new_group_key;
-
-                    let mut new_aggregates = Vec::new();
-                    for aggr in aggregates.drain(..) {
-                        if aggr.is_constant() {
-                            projection.push(first_projected_literal + projected_literals.len());
-                            projected_literals.push(eval_constant_aggr(&aggr));
-                        } else {
-                            projection.push(group_key.len() + new_aggregates.len());
-                            new_aggregates.push(aggr);
-                        }
-                    }
-                    // The new aggregates without constant ones
-                    *aggregates = new_aggregates;
-
-                    *relation = relation
-                        .take_dangerous()
-                        .map(projected_literals)
-                        .project(projection);
-                }
-                Ok(result)
-            }
-            MirRelationExpr::TopK {
-                input,
-                group_key,
-                order_key,
-                limit: _,
-                offset: _,
-                monotonic: _,
-            } => {
-                let literals = self.action(input, gets)?;
-                if !literals.is_empty() {
-                    // We should be able to lift literals out, as they affect neither
-                    // grouping nor ordering. We should discard grouping and ordering
-                    // that references the columns, though.
-                    let input_arity = input.arity();
-                    group_key.retain(|c| *c < input_arity);
-                    order_key.retain(|o| o.column < input_arity);
-                }
-                Ok(literals)
-            }
-            MirRelationExpr::Negate { input } => {
-                // Literals can just be lifted out of negate.
-                self.action(input, gets)
-            }
-            MirRelationExpr::Threshold { input } => {
-                // Literals can just be lifted out of threshold.
-                self.action(input, gets)
-            }
-            MirRelationExpr::DeclareKeys { input, .. } => self.action(input, gets),
-            MirRelationExpr::Union { base, inputs } => {
-                let mut base_literals = self.action(base, gets)?;
-
-                let mut input_literals = vec![];
-                for input in inputs.iter_mut() {
-                    input_literals.push(self.action(input, gets)?)
-                }
-
-                // We need to find the longest common suffix between all the arms of the union.
-                let mut suffix = Vec::new();
-                while !base_literals.is_empty()
-                    && input_literals
-                        .iter()
-                        .all(|lits| lits.last() == base_literals.last())
-                {
-                    // Every arm agrees on the last value, so push it onto the shared suffix and
-                    // remove it from each arm.
-                    suffix.push(base_literals.last().unwrap().clone());
-                    base_literals.pop();
-                    for lits in input_literals.iter_mut() {
-                        lits.pop();
-                    }
-                }
-
-                // Because we pushed stuff onto the vector like a stack, we need to reverse it now.
-                suffix.reverse();
-
-                // Any remaining literals for each expression must be appended to that expression,
-                // while the shared suffix is returned to continue traveling upwards.
-                if !base_literals.is_empty() {
-                    **base = base.take_dangerous().map(base_literals);
-                }
-                for (input, literals) in inputs.iter_mut().zip_eq(input_literals) {
+                MirRelationExpr::Filter { input, predicates } => {
+                    let literals = self.action(input, gets)?;
                     if !literals.is_empty() {
-                        *input = input.take_dangerous().map(literals);
-                    }
-                }
-                Ok(suffix)
-            }
-            MirRelationExpr::ArrangeBy { input, keys } => {
-                // TODO(frank): Not sure if this is the right behavior,
-                // as we disrupt the set of used arrangements. Though,
-                // we are probably most likely to use arranged `Get`
-                // operators rather than those decorated with maps.
-                let literals = self.action(input, gets)?;
-                if !literals.is_empty() {
-                    let input_arity = input.arity();
-                    for key in keys.iter_mut() {
-                        for expr in key.iter_mut() {
+                        // We should be able to instantiate all uses of `literals`
+                        // in predicates and then lift the `map` around the filter.
+                        let input_arity = input.arity();
+                        for expr in predicates.iter_mut() {
                             expr.visit_mut(&mut |e| {
                                 if let MirScalarExpr::Column(c) = e {
                                     if *c >= input_arity {
@@ -677,9 +397,293 @@ impl LiteralLifting {
                             });
                         }
                     }
+                    Ok(literals)
                 }
-                Ok(literals)
+                MirRelationExpr::Join {
+                    inputs,
+                    equivalences,
+                    implementation,
+                } => {
+                    // before lifting, save the original shape of the inputs
+                    let old_input_mapper = JoinInputMapper::new(inputs);
+
+                    // lift literals from each input
+                    let mut input_literals = Vec::new();
+                    for mut input in inputs.iter_mut() {
+                        let literals = self.action(input, gets)?;
+
+                        // Do not propagate error literals beyond join inputs, since that may result
+                        // in them being propagated to other inputs of the join and evaluated when
+                        // they should not.
+                        if literals.iter().any(|l| l.is_literal_err()) {
+                            // Push the literal errors beyond any arrangement since otherwise JoinImplementation
+                            // would add another arrangement on top leading to an infinite loop/stack overflow.
+                            if let MirRelationExpr::ArrangeBy { input, .. } = &mut input {
+                                **input = input.take_dangerous().map(literals);
+                            } else {
+                                *input = input.take_dangerous().map(literals);
+                            }
+                            input_literals.push(Vec::new());
+                        } else {
+                            input_literals.push(literals);
+                        }
+                    }
+
+                    if input_literals.iter().any(|l| !l.is_empty()) {
+                        *implementation = expr::JoinImplementation::Unimplemented;
+
+                        // We should be able to install any literals in the
+                        // equivalence relations, and then lift all literals
+                        // around the join using a project to re-order columns.
+
+                        // Visit each expression in each equivalence class to either
+                        // inline literals or update column references.
+                        let new_input_mapper = JoinInputMapper::new(inputs);
+                        for equivalence in equivalences.iter_mut() {
+                            for expr in equivalence.iter_mut() {
+                                expr.visit_mut(&mut |e| {
+                                    if let MirScalarExpr::Column(c) = e {
+                                        let (col, input) = old_input_mapper.map_column_to_local(*c);
+                                        if col >= new_input_mapper.input_arity(input) {
+                                            // the column refers to a literal that
+                                            // has been promoted. inline it
+                                            *e = input_literals[input]
+                                                [col - new_input_mapper.input_arity(input)]
+                                            .clone()
+                                        } else {
+                                            // localize to the new join
+                                            *c = new_input_mapper.map_column_to_global(col, input);
+                                        }
+                                    }
+                                });
+                            }
+                        }
+
+                        // We now determine a projection to shovel around all of
+                        // the columns that puts the literals last. Where this is optional
+                        // for other operators, it is mandatory here if we want to lift the
+                        // literals through the join.
+
+                        // The first literal column number starts at the last column
+                        // of the new join. Increment the column number as literals
+                        // get added.
+                        let mut literal_column_number = new_input_mapper.total_columns();
+                        let mut projection = Vec::new();
+                        for input in 0..old_input_mapper.total_inputs() {
+                            for column in old_input_mapper.local_columns(input) {
+                                if column >= new_input_mapper.input_arity(input) {
+                                    projection.push(literal_column_number);
+                                    literal_column_number += 1;
+                                } else {
+                                    projection
+                                        .push(new_input_mapper.map_column_to_global(column, input));
+                                }
+                            }
+                        }
+
+                        let literals = input_literals.into_iter().flatten().collect::<Vec<_>>();
+                        *relation = relation.take_dangerous().map(literals).project(projection)
+                    }
+                    Ok(Vec::new())
+                }
+                MirRelationExpr::Reduce {
+                    input,
+                    group_key,
+                    aggregates,
+                    monotonic: _,
+                    expected_group_size: _,
+                } => {
+                    let literals = self.action(input, gets)?;
+                    if !literals.is_empty() {
+                        // Reduce absorbs maps, and we should inline literals.
+                        let input_arity = input.arity();
+                        // Inline literals into group key expressions.
+                        for expr in group_key.iter_mut() {
+                            expr.visit_mut(&mut |e| {
+                                if let MirScalarExpr::Column(c) = e {
+                                    if *c >= input_arity {
+                                        *e = literals[*c - input_arity].clone();
+                                    }
+                                }
+                            });
+                        }
+                        // Inline literals into aggregate value selector expressions.
+                        for aggr in aggregates.iter_mut() {
+                            aggr.expr.visit_mut(&mut |e| {
+                                if let MirScalarExpr::Column(c) = e {
+                                    if *c >= input_arity {
+                                        *e = literals[*c - input_arity].clone();
+                                    }
+                                }
+                            });
+                        }
+                    }
+
+                    let eval_constant_aggr = |aggr: &expr::AggregateExpr| {
+                        let temp = repr::RowArena::new();
+                        let mut eval = aggr.expr.eval(&[], &temp);
+                        if let Ok(param) = eval {
+                            eval = Ok(aggr.func.eval(Some(param), &temp));
+                        }
+                        MirScalarExpr::literal(
+                            eval,
+                            // This type information should be available in the `a.expr` literal,
+                            // but extracting it with pattern matching seems awkward.
+                            aggr.func
+                                .output_type(aggr.expr.typ(&repr::RelationType::empty()))
+                                .scalar_type,
+                        )
+                    };
+
+                    // The only literals we think we can lift are those that are
+                    // independent of the number of records; things like `Any`, `All`,
+                    // `Min`, and `Max`.
+                    let mut result = Vec::new();
+                    while aggregates.last().map(|a| a.is_constant()) == Some(true) {
+                        let aggr = aggregates.pop().unwrap();
+                        result.push(eval_constant_aggr(&aggr));
+                    }
+                    if aggregates.is_empty() {
+                        while group_key.last().map(|k| k.is_literal()) == Some(true) {
+                            let key = group_key.pop().unwrap();
+                            result.push(key);
+                        }
+                    }
+                    result.reverse();
+
+                    // Add a Map operator with the remaining literals so that they are lifted in
+                    // the next invocation of this transform.
+                    let non_literal_keys = group_key.iter().filter(|x| !x.is_literal()).count();
+                    let non_constant_aggr = aggregates.iter().filter(|x| !x.is_constant()).count();
+                    if non_literal_keys != group_key.len() || non_constant_aggr != aggregates.len()
+                    {
+                        let first_projected_literal: usize = non_literal_keys + non_constant_aggr;
+                        let mut projection = Vec::new();
+                        let mut projected_literals = Vec::new();
+
+                        let mut new_group_key = Vec::new();
+                        for key in group_key.drain(..) {
+                            if key.is_literal() {
+                                projection.push(first_projected_literal + projected_literals.len());
+                                projected_literals.push(key);
+                            } else {
+                                projection.push(new_group_key.len());
+                                new_group_key.push(key);
+                            }
+                        }
+                        // The new group key without literals
+                        *group_key = new_group_key;
+
+                        let mut new_aggregates = Vec::new();
+                        for aggr in aggregates.drain(..) {
+                            if aggr.is_constant() {
+                                projection.push(first_projected_literal + projected_literals.len());
+                                projected_literals.push(eval_constant_aggr(&aggr));
+                            } else {
+                                projection.push(group_key.len() + new_aggregates.len());
+                                new_aggregates.push(aggr);
+                            }
+                        }
+                        // The new aggregates without constant ones
+                        *aggregates = new_aggregates;
+
+                        *relation = relation
+                            .take_dangerous()
+                            .map(projected_literals)
+                            .project(projection);
+                    }
+                    Ok(result)
+                }
+                MirRelationExpr::TopK {
+                    input,
+                    group_key,
+                    order_key,
+                    limit: _,
+                    offset: _,
+                    monotonic: _,
+                } => {
+                    let literals = self.action(input, gets)?;
+                    if !literals.is_empty() {
+                        // We should be able to lift literals out, as they affect neither
+                        // grouping nor ordering. We should discard grouping and ordering
+                        // that references the columns, though.
+                        let input_arity = input.arity();
+                        group_key.retain(|c| *c < input_arity);
+                        order_key.retain(|o| o.column < input_arity);
+                    }
+                    Ok(literals)
+                }
+                MirRelationExpr::Negate { input } => {
+                    // Literals can just be lifted out of negate.
+                    self.action(input, gets)
+                }
+                MirRelationExpr::Threshold { input } => {
+                    // Literals can just be lifted out of threshold.
+                    self.action(input, gets)
+                }
+                MirRelationExpr::DeclareKeys { input, .. } => self.action(input, gets),
+                MirRelationExpr::Union { base, inputs } => {
+                    let mut base_literals = self.action(base, gets)?;
+
+                    let mut input_literals = vec![];
+                    for input in inputs.iter_mut() {
+                        input_literals.push(self.action(input, gets)?)
+                    }
+
+                    // We need to find the longest common suffix between all the arms of the union.
+                    let mut suffix = Vec::new();
+                    while !base_literals.is_empty()
+                        && input_literals
+                            .iter()
+                            .all(|lits| lits.last() == base_literals.last())
+                    {
+                        // Every arm agrees on the last value, so push it onto the shared suffix and
+                        // remove it from each arm.
+                        suffix.push(base_literals.last().unwrap().clone());
+                        base_literals.pop();
+                        for lits in input_literals.iter_mut() {
+                            lits.pop();
+                        }
+                    }
+
+                    // Because we pushed stuff onto the vector like a stack, we need to reverse it now.
+                    suffix.reverse();
+
+                    // Any remaining literals for each expression must be appended to that expression,
+                    // while the shared suffix is returned to continue traveling upwards.
+                    if !base_literals.is_empty() {
+                        **base = base.take_dangerous().map(base_literals);
+                    }
+                    for (input, literals) in inputs.iter_mut().zip_eq(input_literals) {
+                        if !literals.is_empty() {
+                            *input = input.take_dangerous().map(literals);
+                        }
+                    }
+                    Ok(suffix)
+                }
+                MirRelationExpr::ArrangeBy { input, keys } => {
+                    // TODO(frank): Not sure if this is the right behavior,
+                    // as we disrupt the set of used arrangements. Though,
+                    // we are probably most likely to use arranged `Get`
+                    // operators rather than those decorated with maps.
+                    let literals = self.action(input, gets)?;
+                    if !literals.is_empty() {
+                        let input_arity = input.arity();
+                        for key in keys.iter_mut() {
+                            for expr in key.iter_mut() {
+                                expr.visit_mut(&mut |e| {
+                                    if let MirScalarExpr::Column(c) = e {
+                                        if *c >= input_arity {
+                                            *e = literals[*c - input_arity].clone();
+                                        }
+                                    }
+                                });
+                            }
+                        }
+                    }
+                    Ok(literals)
+                }
             }
-        }
+        })
     }
 }

--- a/src/transform/src/monotonic.rs
+++ b/src/transform/src/monotonic.rs
@@ -1,0 +1,111 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Analysis to identify monotonic collections, especially TopK inputs.
+use expr::MirRelationExpr;
+use expr::{GlobalId, Id, LocalId};
+use std::collections::HashSet;
+
+/// A struct that holds a recursive function that determines if a
+/// relation is monotonic, and applies any optimizations along the way
+#[derive(Debug, Default)]
+pub struct MonotonicFlag;
+
+impl MonotonicFlag {
+    /// Determines if a relation is monotonic, and applies any optimizations along the way.
+    pub fn apply(
+        &self,
+        expr: &mut MirRelationExpr,
+        sources: &HashSet<GlobalId>,
+        locals: &mut HashSet<LocalId>,
+    ) -> bool {
+        match expr {
+            MirRelationExpr::Get { id, .. } => match id {
+                Id::Global(id) => sources.contains(id),
+                Id::Local(id) => locals.contains(id),
+                _ => false,
+            },
+            MirRelationExpr::Project { input, .. } => self.apply(input, sources, locals),
+            MirRelationExpr::Filter { input, predicates } => {
+                let is_monotonic = self.apply(input, sources, locals);
+                // Non-temporal predicates can introduce non-monotonicity, as they
+                // can result in the future removal of records.
+                // TODO: this could be improved to only restrict if upper bounds
+                // are present, as temporal lower bounds only delay introduction.
+                is_monotonic && !predicates.iter().any(|p| p.contains_temporal())
+            }
+            MirRelationExpr::Map { input, .. } => self.apply(input, sources, locals),
+            MirRelationExpr::TopK {
+                input, monotonic, ..
+            } => {
+                *monotonic = self.apply(input, sources, locals);
+                false
+            }
+            MirRelationExpr::Reduce {
+                input,
+                aggregates,
+                monotonic,
+                ..
+            } => {
+                *monotonic = self.apply(input, sources, locals);
+                // Reduce is monotonic iff its input is and it is a "distinct",
+                // with no aggregate values; otherwise it may need to retract.
+                *monotonic && aggregates.is_empty()
+            }
+            MirRelationExpr::Union { base, inputs } => {
+                let mut monotonic = self.apply(base, sources, locals);
+                for input in inputs.iter_mut() {
+                    let monotonic_i = self.apply(input, sources, locals);
+                    monotonic = monotonic && monotonic_i;
+                }
+                monotonic
+            }
+            MirRelationExpr::ArrangeBy { input, .. }
+            | MirRelationExpr::DeclareKeys { input, .. } => self.apply(input, sources, locals),
+            MirRelationExpr::FlatMap { input, func, .. } => {
+                let is_monotonic = self.apply(input, sources, locals);
+                is_monotonic && func.preserves_monotonicity()
+            }
+            MirRelationExpr::Join { inputs, .. } => {
+                // If all inputs to the join are monotonic then so is the join.
+                let mut monotonic = true;
+                for input in inputs.iter_mut() {
+                    let monotonic_i = self.apply(input, sources, locals);
+                    monotonic = monotonic && monotonic_i;
+                }
+                monotonic
+            }
+            MirRelationExpr::Constant { rows: Ok(rows), .. } => {
+                rows.iter().all(|(_, diff)| diff > &0)
+            }
+            MirRelationExpr::Threshold { input } => self.apply(input, sources, locals),
+            MirRelationExpr::Let { id, value, body } => {
+                let prior = locals.remove(id);
+                if self.apply(value, sources, locals) {
+                    locals.insert(*id);
+                }
+                let result = self.apply(body, sources, locals);
+                if prior {
+                    locals.insert(*id);
+                } else {
+                    locals.remove(id);
+                }
+                result
+            }
+            // The default behavior.
+            // TODO: check that this is the behavior we want.
+            MirRelationExpr::Negate { .. } | MirRelationExpr::Constant { rows: Err(_), .. } => {
+                expr.visit_mut_children(|e| {
+                    self.apply(e, sources, locals);
+                });
+                false
+            }
+        }
+    }
+}

--- a/src/transform/src/monotonic.rs
+++ b/src/transform/src/monotonic.rs
@@ -24,27 +24,27 @@ impl MonotonicFlag {
         expr: &mut MirRelationExpr,
         sources: &HashSet<GlobalId>,
         locals: &mut HashSet<LocalId>,
-    ) -> bool {
-        match expr {
+    ) -> Result<bool, crate::TransformError> {
+        let is_monotonic = match expr {
             MirRelationExpr::Get { id, .. } => match id {
                 Id::Global(id) => sources.contains(id),
                 Id::Local(id) => locals.contains(id),
                 _ => false,
             },
-            MirRelationExpr::Project { input, .. } => self.apply(input, sources, locals),
+            MirRelationExpr::Project { input, .. } => self.apply(input, sources, locals)?,
             MirRelationExpr::Filter { input, predicates } => {
-                let is_monotonic = self.apply(input, sources, locals);
+                let is_monotonic = self.apply(input, sources, locals)?;
                 // Non-temporal predicates can introduce non-monotonicity, as they
                 // can result in the future removal of records.
                 // TODO: this could be improved to only restrict if upper bounds
                 // are present, as temporal lower bounds only delay introduction.
                 is_monotonic && !predicates.iter().any(|p| p.contains_temporal())
             }
-            MirRelationExpr::Map { input, .. } => self.apply(input, sources, locals),
+            MirRelationExpr::Map { input, .. } => self.apply(input, sources, locals)?,
             MirRelationExpr::TopK {
                 input, monotonic, ..
             } => {
-                *monotonic = self.apply(input, sources, locals);
+                *monotonic = self.apply(input, sources, locals)?;
                 false
             }
             MirRelationExpr::Reduce {
@@ -53,30 +53,30 @@ impl MonotonicFlag {
                 monotonic,
                 ..
             } => {
-                *monotonic = self.apply(input, sources, locals);
+                *monotonic = self.apply(input, sources, locals)?;
                 // Reduce is monotonic iff its input is and it is a "distinct",
                 // with no aggregate values; otherwise it may need to retract.
                 *monotonic && aggregates.is_empty()
             }
             MirRelationExpr::Union { base, inputs } => {
-                let mut monotonic = self.apply(base, sources, locals);
+                let mut monotonic = self.apply(base, sources, locals)?;
                 for input in inputs.iter_mut() {
-                    let monotonic_i = self.apply(input, sources, locals);
+                    let monotonic_i = self.apply(input, sources, locals)?;
                     monotonic = monotonic && monotonic_i;
                 }
                 monotonic
             }
             MirRelationExpr::ArrangeBy { input, .. }
-            | MirRelationExpr::DeclareKeys { input, .. } => self.apply(input, sources, locals),
+            | MirRelationExpr::DeclareKeys { input, .. } => self.apply(input, sources, locals)?,
             MirRelationExpr::FlatMap { input, func, .. } => {
-                let is_monotonic = self.apply(input, sources, locals);
+                let is_monotonic = self.apply(input, sources, locals)?;
                 is_monotonic && func.preserves_monotonicity()
             }
             MirRelationExpr::Join { inputs, .. } => {
                 // If all inputs to the join are monotonic then so is the join.
                 let mut monotonic = true;
                 for input in inputs.iter_mut() {
-                    let monotonic_i = self.apply(input, sources, locals);
+                    let monotonic_i = self.apply(input, sources, locals)?;
                     monotonic = monotonic && monotonic_i;
                 }
                 monotonic
@@ -84,13 +84,13 @@ impl MonotonicFlag {
             MirRelationExpr::Constant { rows: Ok(rows), .. } => {
                 rows.iter().all(|(_, diff)| diff > &0)
             }
-            MirRelationExpr::Threshold { input } => self.apply(input, sources, locals),
+            MirRelationExpr::Threshold { input } => self.apply(input, sources, locals)?,
             MirRelationExpr::Let { id, value, body } => {
                 let prior = locals.remove(id);
-                if self.apply(value, sources, locals) {
+                if self.apply(value, sources, locals)? {
                     locals.insert(*id);
                 }
-                let result = self.apply(body, sources, locals);
+                let result = self.apply(body, sources, locals)?;
                 if prior {
                     locals.insert(*id);
                 } else {
@@ -101,11 +101,10 @@ impl MonotonicFlag {
             // The default behavior.
             // TODO: check that this is the behavior we want.
             MirRelationExpr::Negate { .. } | MirRelationExpr::Constant { rows: Err(_), .. } => {
-                expr.visit_mut_children(|e| {
-                    self.apply(e, sources, locals);
-                });
+                expr.try_visit_mut_children(|e| self.apply(e, sources, locals).map(|_| ()))?;
                 false
             }
-        }
+        };
+        Ok(is_monotonic)
     }
 }

--- a/src/transform/src/monotonic.rs
+++ b/src/transform/src/monotonic.rs
@@ -42,86 +42,90 @@ impl MonotonicFlag {
         sources: &HashSet<GlobalId>,
         locals: &mut HashSet<LocalId>,
     ) -> Result<bool, crate::TransformError> {
-        let is_monotonic = match expr {
-            MirRelationExpr::Get { id, .. } => match id {
-                Id::Global(id) => sources.contains(id),
-                Id::Local(id) => locals.contains(id),
-                _ => false,
-            },
-            MirRelationExpr::Project { input, .. } => self.apply(input, sources, locals)?,
-            MirRelationExpr::Filter { input, predicates } => {
-                let is_monotonic = self.apply(input, sources, locals)?;
-                // Non-temporal predicates can introduce non-monotonicity, as they
-                // can result in the future removal of records.
-                // TODO: this could be improved to only restrict if upper bounds
-                // are present, as temporal lower bounds only delay introduction.
-                is_monotonic && !predicates.iter().any(|p| p.contains_temporal())
-            }
-            MirRelationExpr::Map { input, .. } => self.apply(input, sources, locals)?,
-            MirRelationExpr::TopK {
-                input, monotonic, ..
-            } => {
-                *monotonic = self.apply(input, sources, locals)?;
-                false
-            }
-            MirRelationExpr::Reduce {
-                input,
-                aggregates,
-                monotonic,
-                ..
-            } => {
-                *monotonic = self.apply(input, sources, locals)?;
-                // Reduce is monotonic iff its input is and it is a "distinct",
-                // with no aggregate values; otherwise it may need to retract.
-                *monotonic && aggregates.is_empty()
-            }
-            MirRelationExpr::Union { base, inputs } => {
-                let mut monotonic = self.apply(base, sources, locals)?;
-                for input in inputs.iter_mut() {
-                    let monotonic_i = self.apply(input, sources, locals)?;
-                    monotonic = monotonic && monotonic_i;
+        self.checked_recur(|_| {
+            let is_monotonic = match expr {
+                MirRelationExpr::Get { id, .. } => match id {
+                    Id::Global(id) => sources.contains(id),
+                    Id::Local(id) => locals.contains(id),
+                    _ => false,
+                },
+                MirRelationExpr::Project { input, .. } => self.apply(input, sources, locals)?,
+                MirRelationExpr::Filter { input, predicates } => {
+                    let is_monotonic = self.apply(input, sources, locals)?;
+                    // Non-temporal predicates can introduce non-monotonicity, as they
+                    // can result in the future removal of records.
+                    // TODO: this could be improved to only restrict if upper bounds
+                    // are present, as temporal lower bounds only delay introduction.
+                    is_monotonic && !predicates.iter().any(|p| p.contains_temporal())
                 }
-                monotonic
-            }
-            MirRelationExpr::ArrangeBy { input, .. }
-            | MirRelationExpr::DeclareKeys { input, .. } => self.apply(input, sources, locals)?,
-            MirRelationExpr::FlatMap { input, func, .. } => {
-                let is_monotonic = self.apply(input, sources, locals)?;
-                is_monotonic && func.preserves_monotonicity()
-            }
-            MirRelationExpr::Join { inputs, .. } => {
-                // If all inputs to the join are monotonic then so is the join.
-                let mut monotonic = true;
-                for input in inputs.iter_mut() {
-                    let monotonic_i = self.apply(input, sources, locals)?;
-                    monotonic = monotonic && monotonic_i;
+                MirRelationExpr::Map { input, .. } => self.apply(input, sources, locals)?,
+                MirRelationExpr::TopK {
+                    input, monotonic, ..
+                } => {
+                    *monotonic = self.apply(input, sources, locals)?;
+                    false
                 }
-                monotonic
-            }
-            MirRelationExpr::Constant { rows: Ok(rows), .. } => {
-                rows.iter().all(|(_, diff)| diff > &0)
-            }
-            MirRelationExpr::Threshold { input } => self.apply(input, sources, locals)?,
-            MirRelationExpr::Let { id, value, body } => {
-                let prior = locals.remove(id);
-                if self.apply(value, sources, locals)? {
-                    locals.insert(*id);
+                MirRelationExpr::Reduce {
+                    input,
+                    aggregates,
+                    monotonic,
+                    ..
+                } => {
+                    *monotonic = self.apply(input, sources, locals)?;
+                    // Reduce is monotonic iff its input is and it is a "distinct",
+                    // with no aggregate values; otherwise it may need to retract.
+                    *monotonic && aggregates.is_empty()
                 }
-                let result = self.apply(body, sources, locals)?;
-                if prior {
-                    locals.insert(*id);
-                } else {
-                    locals.remove(id);
+                MirRelationExpr::Union { base, inputs } => {
+                    let mut monotonic = self.apply(base, sources, locals)?;
+                    for input in inputs.iter_mut() {
+                        let monotonic_i = self.apply(input, sources, locals)?;
+                        monotonic = monotonic && monotonic_i;
+                    }
+                    monotonic
                 }
-                result
-            }
-            // The default behavior.
-            // TODO: check that this is the behavior we want.
-            MirRelationExpr::Negate { .. } | MirRelationExpr::Constant { rows: Err(_), .. } => {
-                expr.try_visit_mut_children(|e| self.apply(e, sources, locals).map(|_| ()))?;
-                false
-            }
-        };
-        Ok(is_monotonic)
+                MirRelationExpr::ArrangeBy { input, .. }
+                | MirRelationExpr::DeclareKeys { input, .. } => {
+                    self.apply(input, sources, locals)?
+                }
+                MirRelationExpr::FlatMap { input, func, .. } => {
+                    let is_monotonic = self.apply(input, sources, locals)?;
+                    is_monotonic && func.preserves_monotonicity()
+                }
+                MirRelationExpr::Join { inputs, .. } => {
+                    // If all inputs to the join are monotonic then so is the join.
+                    let mut monotonic = true;
+                    for input in inputs.iter_mut() {
+                        let monotonic_i = self.apply(input, sources, locals)?;
+                        monotonic = monotonic && monotonic_i;
+                    }
+                    monotonic
+                }
+                MirRelationExpr::Constant { rows: Ok(rows), .. } => {
+                    rows.iter().all(|(_, diff)| diff > &0)
+                }
+                MirRelationExpr::Threshold { input } => self.apply(input, sources, locals)?,
+                MirRelationExpr::Let { id, value, body } => {
+                    let prior = locals.remove(id);
+                    if self.apply(value, sources, locals)? {
+                        locals.insert(*id);
+                    }
+                    let result = self.apply(body, sources, locals)?;
+                    if prior {
+                        locals.insert(*id);
+                    } else {
+                        locals.remove(id);
+                    }
+                    result
+                }
+                // The default behavior.
+                // TODO: check that this is the behavior we want.
+                MirRelationExpr::Negate { .. } | MirRelationExpr::Constant { rows: Err(_), .. } => {
+                    expr.try_visit_mut_children(|e| self.apply(e, sources, locals).map(|_| ()))?;
+                    false
+                }
+            };
+            Ok(is_monotonic)
+        })
     }
 }

--- a/src/transform/src/monotonic.rs
+++ b/src/transform/src/monotonic.rs
@@ -8,14 +8,31 @@
 // by the Apache License, Version 2.0.
 
 //! Analysis to identify monotonic collections, especially TopK inputs.
-use expr::MirRelationExpr;
 use expr::{GlobalId, Id, LocalId};
+use expr::{MirRelationExpr, RECURSION_LIMIT};
+use ore::stack::{CheckedRecursion, RecursionGuard};
 use std::collections::HashSet;
 
 /// A struct that holds a recursive function that determines if a
-/// relation is monotonic, and applies any optimizations along the way
-#[derive(Debug, Default)]
-pub struct MonotonicFlag;
+/// relation is monotonic, and applies any optimizations along the way.
+#[derive(Debug)]
+pub struct MonotonicFlag {
+    recursion_guard: RecursionGuard,
+}
+
+impl Default for MonotonicFlag {
+    fn default() -> MonotonicFlag {
+        MonotonicFlag {
+            recursion_guard: RecursionGuard::with_limit(RECURSION_LIMIT),
+        }
+    }
+}
+
+impl CheckedRecursion for MonotonicFlag {
+    fn recursion_guard(&self) -> &RecursionGuard {
+        &self.recursion_guard
+    }
+}
 
 impl MonotonicFlag {
     /// Determines if a relation is monotonic, and applies any optimizations along the way.

--- a/src/transform/src/nonnull_requirements.rs
+++ b/src/transform/src/nonnull_requirements.rs
@@ -25,12 +25,29 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::TransformArgs;
-use expr::{Id, JoinInputMapper, MirRelationExpr, MirScalarExpr};
+use expr::{Id, JoinInputMapper, MirRelationExpr, MirScalarExpr, RECURSION_LIMIT};
 use itertools::{Either, Itertools};
+use ore::stack::{CheckedRecursion, RecursionGuard};
 
 /// Push non-null requirements toward sources.
 #[derive(Debug)]
-pub struct NonNullRequirements;
+pub struct NonNullRequirements {
+    recursion_guard: RecursionGuard,
+}
+
+impl Default for NonNullRequirements {
+    fn default() -> NonNullRequirements {
+        NonNullRequirements {
+            recursion_guard: RecursionGuard::with_limit(RECURSION_LIMIT),
+        }
+    }
+}
+
+impl CheckedRecursion for NonNullRequirements {
+    fn recursion_guard(&self) -> &RecursionGuard {
+        &self.recursion_guard
+    }
+}
 
 impl crate::Transform for NonNullRequirements {
     fn transform(

--- a/src/transform/src/nonnull_requirements.rs
+++ b/src/transform/src/nonnull_requirements.rs
@@ -67,226 +67,228 @@ impl NonNullRequirements {
         mut columns: HashSet<usize>,
         gets: &mut HashMap<Id, Vec<HashSet<usize>>>,
     ) -> Result<(), crate::TransformError> {
-        match relation {
-            MirRelationExpr::Constant { rows, .. } => {
-                if let Ok(rows) = rows {
-                    let mut datum_vec = repr::DatumVec::new();
-                    rows.retain(|(row, _)| {
-                        let datums = datum_vec.borrow_with(&row);
-                        columns.iter().all(|c| datums[*c] != repr::Datum::Null)
-                    })
-                }
-                Ok(())
-            }
-            MirRelationExpr::Get { id, .. } => {
-                gets.entry(*id).or_insert_with(Vec::new).push(columns);
-                Ok(())
-            }
-            MirRelationExpr::Let { id, value, body } => {
-                // Let harvests any non-null requirements from its body,
-                // and acts on the intersection of the requirements for
-                // each corresponding Get, pushing them at its value.
-                let id = Id::Local(*id);
-                let prior = gets.insert(id, Vec::new());
-                self.action(body, columns, gets)?;
-                let mut needs = gets.remove(&id).unwrap();
-                if let Some(prior) = prior {
-                    gets.insert(id, prior);
-                }
-                if let Some(mut need) = needs.pop() {
-                    while let Some(x) = needs.pop() {
-                        need.retain(|col| x.contains(col))
+        self.checked_recur(|_| {
+            match relation {
+                MirRelationExpr::Constant { rows, .. } => {
+                    if let Ok(rows) = rows {
+                        let mut datum_vec = repr::DatumVec::new();
+                        rows.retain(|(row, _)| {
+                            let datums = datum_vec.borrow_with(&row);
+                            columns.iter().all(|c| datums[*c] != repr::Datum::Null)
+                        })
                     }
-                    self.action(value, need, gets)?;
-                }
-                Ok(())
-            }
-            MirRelationExpr::Project { input, outputs } => self.action(
-                input,
-                columns.into_iter().map(|c| outputs[c]).collect(),
-                gets,
-            ),
-            MirRelationExpr::Map { input, scalars } => {
-                let arity = input.arity();
-                if columns
-                    .iter()
-                    .any(|c| *c >= arity && scalars[*c - arity].is_literal_null())
-                {
-                    // A null value was introduced in a marked column;
-                    // the entire expression can be zeroed out.
-                    relation.take_safely();
                     Ok(())
-                } else {
-                    // For each column, if it must be non-null, extract the expression's
-                    // non-null requirements and include them too. We go in reverse order
-                    // to ensure we squeegee down all requirements even for references to
-                    // other columns produced in this operator.
-                    for column in (arity..(arity + scalars.len())).rev() {
-                        if columns.contains(&column) {
-                            scalars[column - arity].non_null_requirements(&mut columns);
+                }
+                MirRelationExpr::Get { id, .. } => {
+                    gets.entry(*id).or_insert_with(Vec::new).push(columns);
+                    Ok(())
+                }
+                MirRelationExpr::Let { id, value, body } => {
+                    // Let harvests any non-null requirements from its body,
+                    // and acts on the intersection of the requirements for
+                    // each corresponding Get, pushing them at its value.
+                    let id = Id::Local(*id);
+                    let prior = gets.insert(id, Vec::new());
+                    self.action(body, columns, gets)?;
+                    let mut needs = gets.remove(&id).unwrap();
+                    if let Some(prior) = prior {
+                        gets.insert(id, prior);
+                    }
+                    if let Some(mut need) = needs.pop() {
+                        while let Some(x) = needs.pop() {
+                            need.retain(|col| x.contains(col))
                         }
-                        columns.remove(&column);
+                        self.action(value, need, gets)?;
+                    }
+                    Ok(())
+                }
+                MirRelationExpr::Project { input, outputs } => self.action(
+                    input,
+                    columns.into_iter().map(|c| outputs[c]).collect(),
+                    gets,
+                ),
+                MirRelationExpr::Map { input, scalars } => {
+                    let arity = input.arity();
+                    if columns
+                        .iter()
+                        .any(|c| *c >= arity && scalars[*c - arity].is_literal_null())
+                    {
+                        // A null value was introduced in a marked column;
+                        // the entire expression can be zeroed out.
+                        relation.take_safely();
+                        Ok(())
+                    } else {
+                        // For each column, if it must be non-null, extract the expression's
+                        // non-null requirements and include them too. We go in reverse order
+                        // to ensure we squeegee down all requirements even for references to
+                        // other columns produced in this operator.
+                        for column in (arity..(arity + scalars.len())).rev() {
+                            if columns.contains(&column) {
+                                scalars[column - arity].non_null_requirements(&mut columns);
+                            }
+                            columns.remove(&column);
+                        }
+                        self.action(input, columns, gets)
+                    }
+                }
+                MirRelationExpr::FlatMap { input, func, exprs } => {
+                    // Columns whose number is smaller than arity refer to
+                    // columns of `input`. Columns whose number is
+                    // greater than or equal to the arity refer to columns created
+                    // by the FlatMap. The latter group of columns cannot be
+                    // propagated down.
+                    let arity = input.arity();
+                    columns.retain(|c| *c < arity);
+
+                    if func.empty_on_null_input() {
+                        // we can safely disregard rows where any of the exprs
+                        // evaluate to null
+                        for expr in exprs {
+                            expr.non_null_requirements(&mut columns);
+                        }
+                    }
+
+                    // TODO: if `!func.empty_on_null_input()` and there are members
+                    // of `columns` that refer to columns created by the FlatMap, we
+                    // may be able to propagate some non-null requirements based on
+                    // which columns created by the FlatMap cannot be null. However,
+                    // we have been too lazy to handle this so far.
+
+                    self.action(input, columns, gets)
+                }
+                MirRelationExpr::Filter { input, predicates } => {
+                    for predicate in predicates {
+                        predicate.non_null_requirements(&mut columns);
+                        // TODO: Not(IsNull) should add a constraint!
                     }
                     self.action(input, columns, gets)
                 }
-            }
-            MirRelationExpr::FlatMap { input, func, exprs } => {
-                // Columns whose number is smaller than arity refer to
-                // columns of `input`. Columns whose number is
-                // greater than or equal to the arity refer to columns created
-                // by the FlatMap. The latter group of columns cannot be
-                // propagated down.
-                let arity = input.arity();
-                columns.retain(|c| *c < arity);
+                MirRelationExpr::Join {
+                    inputs,
+                    equivalences,
+                    ..
+                } => {
+                    let input_types = inputs.iter().map(|i| i.typ()).collect::<Vec<_>>();
 
-                if func.empty_on_null_input() {
-                    // we can safely disregard rows where any of the exprs
-                    // evaluate to null
-                    for expr in exprs {
-                        expr.non_null_requirements(&mut columns);
-                    }
-                }
+                    let input_mapper = JoinInputMapper::new_from_input_types(&input_types);
 
-                // TODO: if `!func.empty_on_null_input()` and there are members
-                // of `columns` that refer to columns created by the FlatMap, we
-                // may be able to propagate some non-null requirements based on
-                // which columns created by the FlatMap cannot be null. However,
-                // we have been too lazy to handle this so far.
+                    let mut new_columns = input_mapper.split_column_set_by_input(columns.iter());
 
-                self.action(input, columns, gets)
-            }
-            MirRelationExpr::Filter { input, predicates } => {
-                for predicate in predicates {
-                    predicate.non_null_requirements(&mut columns);
-                    // TODO: Not(IsNull) should add a constraint!
-                }
-                self.action(input, columns, gets)
-            }
-            MirRelationExpr::Join {
-                inputs,
-                equivalences,
-                ..
-            } => {
-                let input_types = inputs.iter().map(|i| i.typ()).collect::<Vec<_>>();
-
-                let input_mapper = JoinInputMapper::new_from_input_types(&input_types);
-
-                let mut new_columns = input_mapper.split_column_set_by_input(columns.iter());
-
-                // `variable` smears constraints around.
-                // Also, any non-nullable columns impose constraints on their equivalence class.
-                for equivalence in equivalences {
-                    let exists_constraint = equivalence.iter().any(|expr| {
-                        if let MirScalarExpr::Column(c) = expr {
-                            let (col, rel) = input_mapper.map_column_to_local(*c);
-                            new_columns[rel].contains(&col)
-                                || !input_types[rel].column_types[col].nullable
-                        } else {
-                            false
-                        }
-                    });
-
-                    if exists_constraint {
-                        for expr in equivalence.iter() {
+                    // `variable` smears constraints around.
+                    // Also, any non-nullable columns impose constraints on their equivalence class.
+                    for equivalence in equivalences {
+                        let exists_constraint = equivalence.iter().any(|expr| {
                             if let MirScalarExpr::Column(c) = expr {
                                 let (col, rel) = input_mapper.map_column_to_local(*c);
-                                new_columns[rel].insert(col);
-                            }
-                        }
-                    }
-                }
-
-                for (input, columns) in inputs.iter_mut().zip(new_columns) {
-                    self.action(input, columns, gets)?;
-                }
-                Ok(())
-            }
-            MirRelationExpr::Reduce {
-                input,
-                group_key,
-                aggregates,
-                monotonic: _,
-                expected_group_size: _,
-            } => {
-                let mut new_columns = HashSet::new();
-                let (group_key_columns, aggr_columns): (Vec<usize>, Vec<usize>) =
-                    columns.iter().partition(|c| **c < group_key.len());
-                for column in group_key_columns {
-                    group_key[column].non_null_requirements(&mut new_columns);
-                }
-
-                if !aggr_columns.is_empty() {
-                    let (
-                        mut inferred_nonnull_constraints,
-                        mut ignored_nulls_by_remaining_aggregates,
-                    ): (Vec<HashSet<usize>>, Vec<HashSet<usize>>) =
-                        aggregates.iter().enumerate().partition_map(|(pos, aggr)| {
-                            let mut ignores_nulls_on_columns = HashSet::new();
-                            if let repr::Datum::Null = aggr.func.identity_datum() {
-                                aggr.expr
-                                    .non_null_requirements(&mut ignores_nulls_on_columns);
-                            }
-                            if aggr.func.propagates_nonnull_constraint()
-                                && aggr_columns.contains(&(group_key.len() + pos))
-                            {
-                                Either::Left(ignores_nulls_on_columns)
+                                new_columns[rel].contains(&col)
+                                    || !input_types[rel].column_types[col].nullable
                             } else {
-                                Either::Right(ignores_nulls_on_columns)
+                                false
                             }
                         });
 
-                    // Compute the intersection of all pushable non contraints inferred from
-                    // the non-null constraints on aggregate columns and the nulls ignored by
-                    // the remaining aggregates. Example:
-                    // - SUM(#0 + #2), MAX(#0 + #1), non-null requirements on both aggs => implies !isnull(#0)
-                    //  We don't want to push down a !isnull(#2) because deleting a row like (1,1, null) would
-                    //  make the MAX wrong.
-                    // - SUM(#0 + #2), MAX(#0 + #1), non-null requirements only on the MAX => implies !isnull(#0).
-                    let mut pushable_nonnull_constraints: Option<HashSet<usize>> = None;
-                    if !inferred_nonnull_constraints.is_empty() {
-                        for column_set in inferred_nonnull_constraints
-                            .drain(..)
-                            .chain(ignored_nulls_by_remaining_aggregates.drain(..))
-                        {
-                            if let Some(previous) = pushable_nonnull_constraints {
-                                pushable_nonnull_constraints =
-                                    Some(column_set.intersection(&previous).cloned().collect());
-                            } else {
-                                pushable_nonnull_constraints = Some(column_set);
+                        if exists_constraint {
+                            for expr in equivalence.iter() {
+                                if let MirScalarExpr::Column(c) = expr {
+                                    let (col, rel) = input_mapper.map_column_to_local(*c);
+                                    new_columns[rel].insert(col);
+                                }
                             }
                         }
                     }
 
-                    if let Some(pushable_nonnull_constraints) = pushable_nonnull_constraints {
-                        new_columns.extend(pushable_nonnull_constraints);
+                    for (input, columns) in inputs.iter_mut().zip(new_columns) {
+                        self.action(input, columns, gets)?;
                     }
+                    Ok(())
                 }
+                MirRelationExpr::Reduce {
+                    input,
+                    group_key,
+                    aggregates,
+                    monotonic: _,
+                    expected_group_size: _,
+                } => {
+                    let mut new_columns = HashSet::new();
+                    let (group_key_columns, aggr_columns): (Vec<usize>, Vec<usize>) =
+                        columns.iter().partition(|c| **c < group_key.len());
+                    for column in group_key_columns {
+                        group_key[column].non_null_requirements(&mut new_columns);
+                    }
 
-                self.action(input, new_columns, gets)
-            }
-            MirRelationExpr::TopK {
-                input, group_key, ..
-            } => {
-                // We can only allow rows to be discarded if their key columns are
-                // NULL, as discarding rows based on other columns can change the
-                // result set, based on how NULL is ordered.
-                columns.retain(|c| group_key.contains(c));
-                // TODO(mcsherry): bind NULL ordering and apply the tranformation
-                // to all columns if the correct ASC/DESC ordering is observed
-                // (with some care about orderings on multiple columns).
-                self.action(input, columns, gets)
-            }
-            MirRelationExpr::Negate { input } => self.action(input, columns, gets),
-            MirRelationExpr::Threshold { input } => self.action(input, columns, gets),
-            MirRelationExpr::DeclareKeys { input, .. } => self.action(input, columns, gets),
-            MirRelationExpr::Union { base, inputs } => {
-                self.action(base, columns.clone(), gets)?;
-                for input in inputs {
-                    self.action(input, columns.clone(), gets)?;
+                    if !aggr_columns.is_empty() {
+                        let (
+                            mut inferred_nonnull_constraints,
+                            mut ignored_nulls_by_remaining_aggregates,
+                        ): (Vec<HashSet<usize>>, Vec<HashSet<usize>>) =
+                            aggregates.iter().enumerate().partition_map(|(pos, aggr)| {
+                                let mut ignores_nulls_on_columns = HashSet::new();
+                                if let repr::Datum::Null = aggr.func.identity_datum() {
+                                    aggr.expr
+                                        .non_null_requirements(&mut ignores_nulls_on_columns);
+                                }
+                                if aggr.func.propagates_nonnull_constraint()
+                                    && aggr_columns.contains(&(group_key.len() + pos))
+                                {
+                                    Either::Left(ignores_nulls_on_columns)
+                                } else {
+                                    Either::Right(ignores_nulls_on_columns)
+                                }
+                            });
+
+                        // Compute the intersection of all pushable non contraints inferred from
+                        // the non-null constraints on aggregate columns and the nulls ignored by
+                        // the remaining aggregates. Example:
+                        // - SUM(#0 + #2), MAX(#0 + #1), non-null requirements on both aggs => implies !isnull(#0)
+                        //  We don't want to push down a !isnull(#2) because deleting a row like (1,1, null) would
+                        //  make the MAX wrong.
+                        // - SUM(#0 + #2), MAX(#0 + #1), non-null requirements only on the MAX => implies !isnull(#0).
+                        let mut pushable_nonnull_constraints: Option<HashSet<usize>> = None;
+                        if !inferred_nonnull_constraints.is_empty() {
+                            for column_set in inferred_nonnull_constraints
+                                .drain(..)
+                                .chain(ignored_nulls_by_remaining_aggregates.drain(..))
+                            {
+                                if let Some(previous) = pushable_nonnull_constraints {
+                                    pushable_nonnull_constraints =
+                                        Some(column_set.intersection(&previous).cloned().collect());
+                                } else {
+                                    pushable_nonnull_constraints = Some(column_set);
+                                }
+                            }
+                        }
+
+                        if let Some(pushable_nonnull_constraints) = pushable_nonnull_constraints {
+                            new_columns.extend(pushable_nonnull_constraints);
+                        }
+                    }
+
+                    self.action(input, new_columns, gets)
                 }
-                Ok(())
+                MirRelationExpr::TopK {
+                    input, group_key, ..
+                } => {
+                    // We can only allow rows to be discarded if their key columns are
+                    // NULL, as discarding rows based on other columns can change the
+                    // result set, based on how NULL is ordered.
+                    columns.retain(|c| group_key.contains(c));
+                    // TODO(mcsherry): bind NULL ordering and apply the tranformation
+                    // to all columns if the correct ASC/DESC ordering is observed
+                    // (with some care about orderings on multiple columns).
+                    self.action(input, columns, gets)
+                }
+                MirRelationExpr::Negate { input } => self.action(input, columns, gets),
+                MirRelationExpr::Threshold { input } => self.action(input, columns, gets),
+                MirRelationExpr::DeclareKeys { input, .. } => self.action(input, columns, gets),
+                MirRelationExpr::Union { base, inputs } => {
+                    self.action(base, columns.clone(), gets)?;
+                    for input in inputs {
+                        self.action(input, columns.clone(), gets)?;
+                    }
+                    Ok(())
+                }
+                MirRelationExpr::ArrangeBy { input, .. } => self.action(input, columns, gets),
             }
-            MirRelationExpr::ArrangeBy { input, .. } => self.action(input, columns, gets),
-        }
+        })
     }
 }

--- a/src/transform/src/nonnullable.rs
+++ b/src/transform/src/nonnullable.rs
@@ -28,16 +28,13 @@ impl crate::Transform for NonNullable {
         relation: &mut MirRelationExpr,
         _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
-        relation.visit_mut_pre(&mut |e| {
-            self.action(e);
-        });
-        Ok(())
+        relation.try_visit_mut_pre(&mut |e| self.action(e))
     }
 }
 
 impl NonNullable {
     /// Harvests information about non-nullability of columns from sources.
-    pub fn action(&self, relation: &mut MirRelationExpr) {
+    pub fn action(&self, relation: &mut MirRelationExpr) -> Result<(), crate::TransformError> {
         match relation {
             MirRelationExpr::Map { input, scalars } => {
                 if scalars.iter().any(|s| scalar_contains_isnull(s)) {
@@ -76,6 +73,7 @@ impl NonNullable {
             }
             _ => {}
         }
+        Ok(())
     }
 }
 

--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -130,595 +130,605 @@ impl PredicatePushdown {
         relation: &mut MirRelationExpr,
         get_predicates: &mut HashMap<Id, HashSet<MirScalarExpr>>,
     ) -> Result<(), crate::TransformError> {
-        // In the case of Filter or Get we have specific work to do;
-        // otherwise we should recursively descend.
-        match relation {
-            MirRelationExpr::Filter { input, predicates } => {
-                // Reduce the predicates to determine as best as possible
-                // whether they are literal errors before working with them.
-                let input_type = input.typ();
-                for predicate in predicates.iter_mut() {
-                    predicate.reduce(&input_type);
-                }
-
-                // It can be helpful to know if there are any non-literal errors,
-                // as this is justification for not pushing down literal errors.
-                let all_errors = predicates.iter().all(|p| p.is_literal_err());
-                // Depending on the type of `input` we have different
-                // logic to apply to consider pushing `predicates` down.
-                match &mut **input {
-                    MirRelationExpr::Let { body, .. } => {
-                        // Push all predicates to the body.
-                        **body = body
-                            .take_dangerous()
-                            .filter(std::mem::replace(predicates, Vec::new()));
-
-                        self.action(input, get_predicates)?;
+        self.checked_recur(|_| {
+            // In the case of Filter or Get we have specific work to do;
+            // otherwise we should recursively descend.
+            match relation {
+                MirRelationExpr::Filter { input, predicates } => {
+                    // Reduce the predicates to determine as best as possible
+                    // whether they are literal errors before working with them.
+                    let input_type = input.typ();
+                    for predicate in predicates.iter_mut() {
+                        predicate.reduce(&input_type);
                     }
-                    MirRelationExpr::Get { id, .. } => {
-                        // We can report the predicates upward in `get_predicates`,
-                        // but we are not yet able to delete them from the
-                        // `Filter`.
-                        get_predicates
-                            .entry(*id)
-                            .or_insert_with(|| predicates.iter().cloned().collect())
-                            .retain(|p| predicates.contains(p));
-                    }
-                    MirRelationExpr::Join {
-                        inputs,
-                        equivalences,
-                        ..
-                    } => {
-                        // We want to scan `predicates` for any that can
-                        // 1) become join variable constraints
-                        // 2) apply to individual elements of `inputs`.
-                        // Figuring out the set of predicates that belong to
-                        //    the latter group requires 1) knowing which predicates
-                        //    are in the former group and 2) that the variable
-                        //    constraints be in canonical form.
-                        // Thus, there is a first scan across `predicates` to
-                        //    populate the join variable constraints
-                        //    and a second scan across the remaining predicates
-                        //    to see which ones can become individual elements of
-                        //    `inputs`.
 
-                        let input_mapper = expr::JoinInputMapper::new(inputs);
+                    // It can be helpful to know if there are any non-literal errors,
+                    // as this is justification for not pushing down literal errors.
+                    let all_errors = predicates.iter().all(|p| p.is_literal_err());
+                    // Depending on the type of `input` we have different
+                    // logic to apply to consider pushing `predicates` down.
+                    match &mut **input {
+                        MirRelationExpr::Let { body, .. } => {
+                            // Push all predicates to the body.
+                            **body = body
+                                .take_dangerous()
+                                .filter(std::mem::replace(predicates, Vec::new()));
 
-                        // Predicates not translated into join variable
-                        // constraints. We will attempt to push them at all
-                        // inputs, and failing to
-                        let mut pred_not_translated = Vec::new();
+                            self.action(input, get_predicates)?;
+                        }
+                        MirRelationExpr::Get { id, .. } => {
+                            // We can report the predicates upward in `get_predicates`,
+                            // but we are not yet able to delete them from the
+                            // `Filter`.
+                            get_predicates
+                                .entry(*id)
+                                .or_insert_with(|| predicates.iter().cloned().collect())
+                                .retain(|p| predicates.contains(p));
+                        }
+                        MirRelationExpr::Join {
+                            inputs,
+                            equivalences,
+                            ..
+                        } => {
+                            // We want to scan `predicates` for any that can
+                            // 1) become join variable constraints
+                            // 2) apply to individual elements of `inputs`.
+                            // Figuring out the set of predicates that belong to
+                            //    the latter group requires 1) knowing which predicates
+                            //    are in the former group and 2) that the variable
+                            //    constraints be in canonical form.
+                            // Thus, there is a first scan across `predicates` to
+                            //    populate the join variable constraints
+                            //    and a second scan across the remaining predicates
+                            //    to see which ones can become individual elements of
+                            //    `inputs`.
 
-                        for mut predicate in predicates.drain(..) {
-                            use expr::BinaryFunc;
-                            use expr::UnaryFunc;
-                            if let MirScalarExpr::CallBinary {
-                                func: BinaryFunc::Eq,
-                                expr1,
-                                expr2,
-                            } = &predicate
-                            {
-                                // Translate into join variable constraints:
-                                // 1) `nonliteral1 == nonliteral2` constraints
-                                // 2) `expr == literal` where `expr` refers to more
-                                //    than one input.
-                                let input_count = input_mapper.lookup_inputs(&predicate).count();
-                                if (!expr1.is_literal() && !expr2.is_literal()) || input_count >= 2
+                            let input_mapper = expr::JoinInputMapper::new(inputs);
+
+                            // Predicates not translated into join variable
+                            // constraints. We will attempt to push them at all
+                            // inputs, and failing to
+                            let mut pred_not_translated = Vec::new();
+
+                            for mut predicate in predicates.drain(..) {
+                                use expr::BinaryFunc;
+                                use expr::UnaryFunc;
+                                if let MirScalarExpr::CallBinary {
+                                    func: BinaryFunc::Eq,
+                                    expr1,
+                                    expr2,
+                                } = &predicate
                                 {
-                                    // `col1 == col2` as a `MirScalarExpr`
-                                    // implies `!isnull(col1)` as well.
-                                    // `col1 == col2` as a join constraint does
-                                    // not have this extra implication.
-                                    // Thus, when translating the
-                                    // `MirScalarExpr` to a join constraint, we
-                                    // need to retain the `!isnull(col1)`
-                                    // information.
-                                    if expr1.typ(&input_type).nullable {
-                                        pred_not_translated.push(
-                                            expr1
-                                                .clone()
-                                                .call_unary(UnaryFunc::IsNull(func::IsNull))
-                                                .call_unary(UnaryFunc::Not(func::Not)),
-                                        );
-                                    } else if expr2.typ(&input_type).nullable {
-                                        pred_not_translated.push(
-                                            expr2
-                                                .clone()
-                                                .call_unary(UnaryFunc::IsNull(func::IsNull))
-                                                .call_unary(UnaryFunc::Not(func::Not)),
-                                        );
+                                    // Translate into join variable constraints:
+                                    // 1) `nonliteral1 == nonliteral2` constraints
+                                    // 2) `expr == literal` where `expr` refers to more
+                                    //    than one input.
+                                    let input_count =
+                                        input_mapper.lookup_inputs(&predicate).count();
+                                    if (!expr1.is_literal() && !expr2.is_literal())
+                                        || input_count >= 2
+                                    {
+                                        // `col1 == col2` as a `MirScalarExpr`
+                                        // implies `!isnull(col1)` as well.
+                                        // `col1 == col2` as a join constraint does
+                                        // not have this extra implication.
+                                        // Thus, when translating the
+                                        // `MirScalarExpr` to a join constraint, we
+                                        // need to retain the `!isnull(col1)`
+                                        // information.
+                                        if expr1.typ(&input_type).nullable {
+                                            pred_not_translated.push(
+                                                expr1
+                                                    .clone()
+                                                    .call_unary(UnaryFunc::IsNull(func::IsNull))
+                                                    .call_unary(UnaryFunc::Not(func::Not)),
+                                            );
+                                        } else if expr2.typ(&input_type).nullable {
+                                            pred_not_translated.push(
+                                                expr2
+                                                    .clone()
+                                                    .call_unary(UnaryFunc::IsNull(func::IsNull))
+                                                    .call_unary(UnaryFunc::Not(func::Not)),
+                                            );
+                                        }
+                                        equivalences
+                                            .push(vec![(**expr1).clone(), (**expr2).clone()]);
+                                        continue;
                                     }
-                                    equivalences.push(vec![(**expr1).clone(), (**expr2).clone()]);
+                                } else if let Some((expr1, expr2)) =
+                                    Self::extract_equal_or_both_null(&mut predicate, &input_type)
+                                {
+                                    // Also translate into join variable constraints:
+                                    // 3) `((nonliteral1 = nonliteral2) || (nonliteral
+                                    //    is null && nonliteral2 is null))`
+                                    equivalences.push(vec![expr1, expr2]);
                                     continue;
                                 }
-                            } else if let Some((expr1, expr2)) =
-                                Self::extract_equal_or_both_null(&mut predicate, &input_type)
-                            {
-                                // Also translate into join variable constraints:
-                                // 3) `((nonliteral1 = nonliteral2) || (nonliteral
-                                //    is null && nonliteral2 is null))`
-                                equivalences.push(vec![expr1, expr2]);
-                                continue;
-                            }
-                            pred_not_translated.push(predicate)
-                        }
-
-                        expr::canonicalize::canonicalize_equivalences(equivalences, &[input_type]);
-
-                        // // Predicates to push at each input, and to retain.
-                        let mut push_downs = vec![Vec::new(); inputs.len()];
-                        let mut retain = Vec::new();
-
-                        for predicate in pred_not_translated.drain(..) {
-                            // Track if the predicate has been pushed to at least one input.
-                            let mut pushed = false;
-                            // For each input, try and see if the join
-                            // equivalences allow the predicate to be rewritten
-                            // in terms of only columns from that input.
-                            for (index, push_down) in push_downs.iter_mut().enumerate() {
-                                if predicate.is_literal_err() {
-                                    // Do nothing. We don't push down literal errors,
-                                    // as we can't know the join will be non-empty.
-                                } else if let Some(localized) = input_mapper
-                                    .try_map_to_input_with_bound_expr(
-                                        predicate.clone(),
-                                        index,
-                                        &equivalences[..],
-                                    )
-                                {
-                                    push_down.push(localized);
-                                    pushed = true;
-                                }
+                                pred_not_translated.push(predicate)
                             }
 
-                            if !pushed {
-                                retain.push(predicate);
-                            }
-                        }
+                            expr::canonicalize::canonicalize_equivalences(
+                                equivalences,
+                                &[input_type],
+                            );
 
-                        let new_inputs = inputs
-                            .drain(..)
-                            .zip(push_downs)
-                            .enumerate()
-                            .map(|(_index, (input, push_down))| {
-                                if !push_down.is_empty() {
-                                    input.filter(push_down)
-                                } else {
-                                    input
-                                }
-                            })
-                            .collect();
-                        *inputs = new_inputs;
+                            // // Predicates to push at each input, and to retain.
+                            let mut push_downs = vec![Vec::new(); inputs.len()];
+                            let mut retain = Vec::new();
 
-                        // Recursively descend on the join
-                        self.action(input, get_predicates)?;
-
-                        // remove all predicates that were pushed down from the current Filter node
-                        std::mem::swap(&mut retain, predicates);
-                    }
-                    MirRelationExpr::Reduce {
-                        input: inner,
-                        group_key,
-                        aggregates,
-                        monotonic: _,
-                        expected_group_size: _,
-                    } => {
-                        let mut retain = Vec::new();
-                        let mut push_down = Vec::new();
-                        for predicate in predicates.drain(..) {
-                            // Do not push down literal errors unless it is only errors.
-                            if !predicate.is_literal_err() || all_errors {
-                                let mut supported = true;
-                                let mut new_predicate = predicate.clone();
-                                new_predicate.visit_mut(&mut |e| {
-                                    if let MirScalarExpr::Column(c) = e {
-                                        if *c >= group_key.len() {
-                                            supported = false;
-                                        }
+                            for predicate in pred_not_translated.drain(..) {
+                                // Track if the predicate has been pushed to at least one input.
+                                let mut pushed = false;
+                                // For each input, try and see if the join
+                                // equivalences allow the predicate to be rewritten
+                                // in terms of only columns from that input.
+                                for (index, push_down) in push_downs.iter_mut().enumerate() {
+                                    if predicate.is_literal_err() {
+                                        // Do nothing. We don't push down literal errors,
+                                        // as we can't know the join will be non-empty.
+                                    } else if let Some(localized) = input_mapper
+                                        .try_map_to_input_with_bound_expr(
+                                            predicate.clone(),
+                                            index,
+                                            &equivalences[..],
+                                        )
+                                    {
+                                        push_down.push(localized);
+                                        pushed = true;
                                     }
-                                });
-                                if supported {
+                                }
+
+                                if !pushed {
+                                    retain.push(predicate);
+                                }
+                            }
+
+                            let new_inputs = inputs
+                                .drain(..)
+                                .zip(push_downs)
+                                .enumerate()
+                                .map(|(_index, (input, push_down))| {
+                                    if !push_down.is_empty() {
+                                        input.filter(push_down)
+                                    } else {
+                                        input
+                                    }
+                                })
+                                .collect();
+                            *inputs = new_inputs;
+
+                            // Recursively descend on the join
+                            self.action(input, get_predicates)?;
+
+                            // remove all predicates that were pushed down from the current Filter node
+                            std::mem::swap(&mut retain, predicates);
+                        }
+                        MirRelationExpr::Reduce {
+                            input: inner,
+                            group_key,
+                            aggregates,
+                            monotonic: _,
+                            expected_group_size: _,
+                        } => {
+                            let mut retain = Vec::new();
+                            let mut push_down = Vec::new();
+                            for predicate in predicates.drain(..) {
+                                // Do not push down literal errors unless it is only errors.
+                                if !predicate.is_literal_err() || all_errors {
+                                    let mut supported = true;
+                                    let mut new_predicate = predicate.clone();
                                     new_predicate.visit_mut(&mut |e| {
-                                        if let MirScalarExpr::Column(i) = e {
-                                            *e = group_key[*i].clone();
+                                        if let MirScalarExpr::Column(c) = e {
+                                            if *c >= group_key.len() {
+                                                supported = false;
+                                            }
                                         }
                                     });
-                                    push_down.push(new_predicate);
-                                } else if let MirScalarExpr::Column(col) = &predicate {
-                                    if *col == group_key.len()
-                                        && aggregates.len() == 1
-                                        && aggregates[0].func == AggregateFunc::Any
-                                    {
-                                        push_down.push(aggregates[0].expr.clone());
-                                        aggregates[0].expr = MirScalarExpr::literal_ok(
-                                            Datum::True,
-                                            ScalarType::Bool,
-                                        );
+                                    if supported {
+                                        new_predicate.visit_mut(&mut |e| {
+                                            if let MirScalarExpr::Column(i) = e {
+                                                *e = group_key[*i].clone();
+                                            }
+                                        });
+                                        push_down.push(new_predicate);
+                                    } else if let MirScalarExpr::Column(col) = &predicate {
+                                        if *col == group_key.len()
+                                            && aggregates.len() == 1
+                                            && aggregates[0].func == AggregateFunc::Any
+                                        {
+                                            push_down.push(aggregates[0].expr.clone());
+                                            aggregates[0].expr = MirScalarExpr::literal_ok(
+                                                Datum::True,
+                                                ScalarType::Bool,
+                                            );
+                                        } else {
+                                            retain.push(predicate);
+                                        }
                                     } else {
                                         retain.push(predicate);
                                     }
                                 } else {
                                     retain.push(predicate);
                                 }
-                            } else {
-                                retain.push(predicate);
                             }
+
+                            if !push_down.is_empty() {
+                                *inner = Box::new(inner.take_dangerous().filter(push_down));
+                            }
+                            self.action(inner, get_predicates)?;
+
+                            // remove all predicates that were pushed down from the current Filter node
+                            std::mem::swap(&mut retain, predicates);
                         }
+                        MirRelationExpr::Project { input, outputs } => {
+                            let predicates = predicates.drain(..).map(|mut predicate| {
+                                predicate.permute(outputs);
+                                predicate
+                            });
+                            *relation = input
+                                .take_dangerous()
+                                .filter(predicates)
+                                .project(outputs.clone());
 
-                        if !push_down.is_empty() {
-                            *inner = Box::new(inner.take_dangerous().filter(push_down));
+                            self.action(relation, get_predicates)?;
                         }
-                        self.action(inner, get_predicates)?;
-
-                        // remove all predicates that were pushed down from the current Filter node
-                        std::mem::swap(&mut retain, predicates);
-                    }
-                    MirRelationExpr::Project { input, outputs } => {
-                        let predicates = predicates.drain(..).map(|mut predicate| {
-                            predicate.permute(outputs);
-                            predicate
-                        });
-                        *relation = input
-                            .take_dangerous()
-                            .filter(predicates)
-                            .project(outputs.clone());
-
-                        self.action(relation, get_predicates)?;
-                    }
-                    MirRelationExpr::Filter {
-                        input,
-                        predicates: predicates2,
-                    } => {
-                        *relation = input.take_dangerous().filter(
-                            predicates
-                                .clone()
-                                .into_iter()
-                                .chain(predicates2.clone().into_iter()),
-                        );
-                        self.action(relation, get_predicates)?;
-                    }
-                    MirRelationExpr::Map { input, scalars } => {
-                        let (retained, pushdown) = self.push_filters_through_map(
-                            scalars,
-                            predicates,
-                            input.arity(),
-                            all_errors,
-                        );
-                        let scalars = std::mem::replace(scalars, Vec::new());
-                        let mut result = input.take_dangerous();
-                        if !pushdown.is_empty() {
-                            result = result.filter(pushdown);
+                        MirRelationExpr::Filter {
+                            input,
+                            predicates: predicates2,
+                        } => {
+                            *relation = input.take_dangerous().filter(
+                                predicates
+                                    .clone()
+                                    .into_iter()
+                                    .chain(predicates2.clone().into_iter()),
+                            );
+                            self.action(relation, get_predicates)?;
                         }
-                        self.action(&mut result, get_predicates)?;
-                        result = result.map(scalars);
-                        if !retained.is_empty() {
-                            result = result.filter(retained);
+                        MirRelationExpr::Map { input, scalars } => {
+                            let (retained, pushdown) = self.push_filters_through_map(
+                                scalars,
+                                predicates,
+                                input.arity(),
+                                all_errors,
+                            );
+                            let scalars = std::mem::replace(scalars, Vec::new());
+                            let mut result = input.take_dangerous();
+                            if !pushdown.is_empty() {
+                                result = result.filter(pushdown);
+                            }
+                            self.action(&mut result, get_predicates)?;
+                            result = result.map(scalars);
+                            if !retained.is_empty() {
+                                result = result.filter(retained);
+                            }
+                            *relation = result;
                         }
-                        *relation = result;
-                    }
-                    MirRelationExpr::FlatMap { input, .. } => {
-                        let (mut retained, pushdown) =
-                            Self::push_filters_through_flat_map(predicates, input.arity());
+                        MirRelationExpr::FlatMap { input, .. } => {
+                            let (mut retained, pushdown) =
+                                Self::push_filters_through_flat_map(predicates, input.arity());
 
-                        // remove all predicates that were pushed down from the current Filter node
-                        std::mem::swap(&mut retained, predicates);
+                            // remove all predicates that were pushed down from the current Filter node
+                            std::mem::swap(&mut retained, predicates);
 
-                        if !pushdown.is_empty() {
-                            // put the filter on top of the input
-                            **input = input.take_dangerous().filter(pushdown);
-                        }
+                            if !pushdown.is_empty() {
+                                // put the filter on top of the input
+                                **input = input.take_dangerous().filter(pushdown);
+                            }
 
-                        // ... and keep pushing predicates down
-                        self.action(input, get_predicates)?;
-                    }
-                    MirRelationExpr::Union { base, inputs } => {
-                        let predicates = std::mem::replace(predicates, Vec::new());
-                        *base = Box::new(base.take_dangerous().filter(predicates.clone()));
-                        self.action(base, get_predicates)?;
-                        for input in inputs {
-                            *input = input.take_dangerous().filter(predicates.clone());
+                            // ... and keep pushing predicates down
                             self.action(input, get_predicates)?;
                         }
-                    }
-                    MirRelationExpr::Negate { input: inner } => {
-                        let predicates = std::mem::replace(predicates, Vec::new());
-                        *relation = inner.take_dangerous().filter(predicates).negate();
-                        self.action(relation, get_predicates)?;
-                    }
-                    x => {
-                        x.try_visit_mut_children(|e| self.action(e, get_predicates))?;
-                    }
-                }
-
-                // remove empty filters (junk by-product of the actual transform)
-                match relation {
-                    MirRelationExpr::Filter { predicates, input } if predicates.is_empty() => {
-                        *relation = input.take_dangerous();
-                    }
-                    _ => {}
-                }
-
-                Ok(())
-            }
-            MirRelationExpr::Get { id, .. } => {
-                // Purge all predicates associated with the id.
-                get_predicates
-                    .entry(*id)
-                    .or_insert_with(HashSet::new)
-                    .clear();
-
-                Ok(())
-            }
-            MirRelationExpr::Let { id, body, value } => {
-                // Push predicates and collect intersection at `Get`s.
-                self.action(body, get_predicates)?;
-
-                // `get_predicates` should now contain the intersection
-                // of predicates at each *use* of the binding. If it is
-                // non-empty, we can move those predicates to the value.
-                if let Some(list) = get_predicates.remove(&Id::Local(*id)) {
-                    if !list.is_empty() {
-                        // Remove the predicates in `list` from the body.
-                        body.visit_mut_post(&mut |e| {
-                            if let MirRelationExpr::Filter { input, predicates } = e {
-                                if let MirRelationExpr::Get { id: get_id, .. } = **input {
-                                    if get_id == Id::Local(*id) {
-                                        predicates.retain(|p| !list.contains(p))
-                                    }
-                                }
+                        MirRelationExpr::Union { base, inputs } => {
+                            let predicates = std::mem::replace(predicates, Vec::new());
+                            *base = Box::new(base.take_dangerous().filter(predicates.clone()));
+                            self.action(base, get_predicates)?;
+                            for input in inputs {
+                                *input = input.take_dangerous().filter(predicates.clone());
+                                self.action(input, get_predicates)?;
                             }
-                        });
-                        // Apply the predicates in `list` to value. Canonicalize
-                        // `list` so that plans are always deterministic.
-                        let mut list = list.into_iter().collect::<Vec<_>>();
-                        expr::canonicalize::canonicalize_predicates(&mut list, &value.typ());
-                        **value = value.take_dangerous().filter(list);
-                    }
-                }
-
-                // Continue recursively on the value.
-                self.action(value, get_predicates)
-            }
-            MirRelationExpr::Join {
-                inputs,
-                equivalences,
-                ..
-            } => {
-                // The goal is to push
-                //   1) equivalences of the form `expr = <runtime constant>`, where `expr`
-                //      comes from a single input.
-                //   2) equivalences of the form `expr1 = expr2`, where both
-                //      expressions come from the same single input.
-                let input_types = inputs.iter().map(|i| i.typ()).collect::<Vec<_>>();
-                expr::canonicalize::canonicalize_equivalences(equivalences, &input_types);
-
-                let input_mapper = expr::JoinInputMapper::new_from_input_types(&input_types);
-                // Predicates to push at each input, and to lift out the join.
-                let mut push_downs = vec![Vec::new(); inputs.len()];
-
-                for equivalence_pos in 0..equivalences.len() {
-                    // Case 1: there are more than one literal in the
-                    // equivalence class. Because of equivalences have been
-                    // dedupped, this means that everything in the equivalence
-                    // class must be equal to two different literals, so the
-                    // entire relation zeroes out
-                    if equivalences[equivalence_pos]
-                        .iter()
-                        .filter(|expr| expr.is_literal())
-                        .count()
-                        > 1
-                    {
-                        relation.take_safely();
-                        return Ok(());
-                    }
-
-                    let runtime_constants = equivalences[equivalence_pos]
-                        .iter()
-                        .filter(|expr| expr.support().is_empty())
-                        .cloned()
-                        .collect::<Vec<_>>();
-                    if !runtime_constants.is_empty() {
-                        // Case 2: There is at least one runtime constant the equivalence class
-                        let gen_literal_equality_preds = |expr: MirScalarExpr| {
-                            let mut equality_preds = Vec::new();
-                            for constant in runtime_constants.iter() {
-                                let pred = if constant.is_literal_null() {
-                                    MirScalarExpr::CallUnary {
-                                        func: expr::UnaryFunc::IsNull(func::IsNull),
-                                        expr: Box::new(expr.clone()),
-                                    }
-                                } else {
-                                    MirScalarExpr::CallBinary {
-                                        func: expr::BinaryFunc::Eq,
-                                        expr1: Box::new(expr.clone()),
-                                        expr2: Box::new(constant.clone()),
-                                    }
-                                };
-                                equality_preds.push(pred);
-                            }
-                            equality_preds
-                        };
-
-                        // Find all single input expressions in the equivalence
-                        // class and collect (position within the equivalence class,
-                        // input the expression belongs to, localized version of the
-                        // expression).
-                        let mut single_input_exprs = equivalences[equivalence_pos]
-                            .iter()
-                            .enumerate()
-                            .filter_map(|(pos, e)| {
-                                let mut inputs = input_mapper.lookup_inputs(e);
-                                if let Some(input) = inputs.next() {
-                                    if inputs.next().is_none() {
-                                        return Some((
-                                            pos,
-                                            input,
-                                            input_mapper.map_expr_to_local(e.clone()),
-                                        ));
-                                    }
-                                }
-                                None
-                            })
-                            .collect::<Vec<_>>();
-
-                        // For every single-input expression `expr`, we can push
-                        // down `expr = <runtime constant>` and remove `expr` from the
-                        // equivalence class.
-                        for (expr_pos, input, expr) in single_input_exprs.drain(..).rev() {
-                            push_downs[input].extend(gen_literal_equality_preds(expr));
-                            equivalences[equivalence_pos].remove(expr_pos);
                         }
+                        MirRelationExpr::Negate { input: inner } => {
+                            let predicates = std::mem::replace(predicates, Vec::new());
+                            *relation = inner.take_dangerous().filter(predicates).negate();
+                            self.action(relation, get_predicates)?;
+                        }
+                        x => {
+                            x.try_visit_mut_children(|e| self.action(e, get_predicates))?;
+                        }
+                    }
 
-                        // If none of the expressions in the equivalence depend on input
-                        // columns and equality predicates with them are pushed down,
-                        // we can safely remove them from the equivalence.
-                        // TODO: we could probably push equality predicates among the
-                        // remaining constants to all join inputs to prevent any computation
-                        // from happening until the condition is satisfied.
+                    // remove empty filters (junk by-product of the actual transform)
+                    match relation {
+                        MirRelationExpr::Filter { predicates, input } if predicates.is_empty() => {
+                            *relation = input.take_dangerous();
+                        }
+                        _ => {}
+                    }
+
+                    Ok(())
+                }
+                MirRelationExpr::Get { id, .. } => {
+                    // Purge all predicates associated with the id.
+                    get_predicates
+                        .entry(*id)
+                        .or_insert_with(HashSet::new)
+                        .clear();
+
+                    Ok(())
+                }
+                MirRelationExpr::Let { id, body, value } => {
+                    // Push predicates and collect intersection at `Get`s.
+                    self.action(body, get_predicates)?;
+
+                    // `get_predicates` should now contain the intersection
+                    // of predicates at each *use* of the binding. If it is
+                    // non-empty, we can move those predicates to the value.
+                    if let Some(list) = get_predicates.remove(&Id::Local(*id)) {
+                        if !list.is_empty() {
+                            // Remove the predicates in `list` from the body.
+                            body.try_visit_mut_post::<_, crate::TransformError>(&mut |e| {
+                                if let MirRelationExpr::Filter { input, predicates } = e {
+                                    if let MirRelationExpr::Get { id: get_id, .. } = **input {
+                                        if get_id == Id::Local(*id) {
+                                            predicates.retain(|p| !list.contains(p));
+                                        }
+                                    }
+                                }
+                                Ok(())
+                            })?;
+                            // Apply the predicates in `list` to value. Canonicalize
+                            // `list` so that plans are always deterministic.
+                            let mut list = list.into_iter().collect::<Vec<_>>();
+                            expr::canonicalize::canonicalize_predicates(&mut list, &value.typ());
+                            **value = value.take_dangerous().filter(list);
+                        }
+                    }
+
+                    // Continue recursively on the value.
+                    self.action(value, get_predicates)
+                }
+                MirRelationExpr::Join {
+                    inputs,
+                    equivalences,
+                    ..
+                } => {
+                    // The goal is to push
+                    //   1) equivalences of the form `expr = <runtime constant>`, where `expr`
+                    //      comes from a single input.
+                    //   2) equivalences of the form `expr1 = expr2`, where both
+                    //      expressions come from the same single input.
+                    let input_types = inputs.iter().map(|i| i.typ()).collect::<Vec<_>>();
+                    expr::canonicalize::canonicalize_equivalences(equivalences, &input_types);
+
+                    let input_mapper = expr::JoinInputMapper::new_from_input_types(&input_types);
+                    // Predicates to push at each input, and to lift out the join.
+                    let mut push_downs = vec![Vec::new(); inputs.len()];
+
+                    for equivalence_pos in 0..equivalences.len() {
+                        // Case 1: there are more than one literal in the
+                        // equivalence class. Because of equivalences have been
+                        // dedupped, this means that everything in the equivalence
+                        // class must be equal to two different literals, so the
+                        // entire relation zeroes out
                         if equivalences[equivalence_pos]
                             .iter()
-                            .all(|e| e.support().is_empty())
-                            && push_downs.iter().any(|p| !p.is_empty())
+                            .filter(|expr| expr.is_literal())
+                            .count()
+                            > 1
                         {
-                            equivalences[equivalence_pos].clear();
+                            relation.take_safely();
+                            return Ok(());
                         }
-                    } else {
-                        // Case 3: There are no constants in the equivalence
-                        // class. Push a predicate for every pair of expressions
-                        // in the equivalence that either belong to a single
-                        // input or can be localized to a given input through
-                        // the rest of equivalences.
-                        let mut to_remove = Vec::new();
-                        for input in 0..inputs.len() {
-                            // Vector of pairs (position within the equivalence, localized
-                            // expression). The position is None for expressions derived through
-                            // other equivalences.
-                            let localized = equivalences[equivalence_pos]
+
+                        let runtime_constants = equivalences[equivalence_pos]
+                            .iter()
+                            .filter(|expr| expr.support().is_empty())
+                            .cloned()
+                            .collect::<Vec<_>>();
+                        if !runtime_constants.is_empty() {
+                            // Case 2: There is at least one runtime constant the equivalence class
+                            let gen_literal_equality_preds = |expr: MirScalarExpr| {
+                                let mut equality_preds = Vec::new();
+                                for constant in runtime_constants.iter() {
+                                    let pred = if constant.is_literal_null() {
+                                        MirScalarExpr::CallUnary {
+                                            func: expr::UnaryFunc::IsNull(func::IsNull),
+                                            expr: Box::new(expr.clone()),
+                                        }
+                                    } else {
+                                        MirScalarExpr::CallBinary {
+                                            func: expr::BinaryFunc::Eq,
+                                            expr1: Box::new(expr.clone()),
+                                            expr2: Box::new(constant.clone()),
+                                        }
+                                    };
+                                    equality_preds.push(pred);
+                                }
+                                equality_preds
+                            };
+
+                            // Find all single input expressions in the equivalence
+                            // class and collect (position within the equivalence class,
+                            // input the expression belongs to, localized version of the
+                            // expression).
+                            let mut single_input_exprs = equivalences[equivalence_pos]
                                 .iter()
                                 .enumerate()
-                                .filter_map(|(pos, expr)| {
-                                    if let MirScalarExpr::Column(col_pos) = &expr {
-                                        let local_col = input_mapper.map_column_to_local(*col_pos);
-                                        if input == local_col.1 {
+                                .filter_map(|(pos, e)| {
+                                    let mut inputs = input_mapper.lookup_inputs(e);
+                                    if let Some(input) = inputs.next() {
+                                        if inputs.next().is_none() {
                                             return Some((
-                                                Some(pos),
-                                                MirScalarExpr::Column(local_col.0),
-                                            ));
-                                        } else {
-                                            return None;
-                                        }
-                                    }
-                                    let mut inputs = input_mapper.lookup_inputs(expr);
-                                    if let Some(single_input) = inputs.next() {
-                                        if input == single_input && inputs.next().is_none() {
-                                            return Some((
-                                                Some(pos),
-                                                input_mapper.map_expr_to_local(expr.clone()),
+                                                pos,
+                                                input,
+                                                input_mapper.map_expr_to_local(e.clone()),
                                             ));
                                         }
                                     }
-                                    // Equivalences not including the current expression
-                                    let mut other_equivalences = equivalences.clone();
-                                    other_equivalences[equivalence_pos].remove(pos);
-                                    if let Some(localized) = input_mapper
-                                        .try_map_to_input_with_bound_expr(
-                                            expr.clone(),
-                                            input,
-                                            &other_equivalences[..],
-                                        )
-                                    {
-                                        Some((None, localized))
-                                    } else {
-                                        None
-                                    }
+                                    None
                                 })
                                 .collect::<Vec<_>>();
 
-                            // If there are at least 2 expression in the equivalence that
-                            // can be localized to the same input, push all combinations
-                            // of them to the input.
-                            if localized.len() > 1 {
-                                for mut pair in
-                                    localized.iter().map(|(_, expr)| expr).combinations(2)
-                                {
-                                    let expr1 = pair.pop().unwrap();
-                                    let expr2 = pair.pop().unwrap();
+                            // For every single-input expression `expr`, we can push
+                            // down `expr = <runtime constant>` and remove `expr` from the
+                            // equivalence class.
+                            for (expr_pos, input, expr) in single_input_exprs.drain(..).rev() {
+                                push_downs[input].extend(gen_literal_equality_preds(expr));
+                                equivalences[equivalence_pos].remove(expr_pos);
+                            }
 
-                                    use expr::BinaryFunc;
-                                    use expr::UnaryFunc;
-                                    push_downs[input].push(MirScalarExpr::CallBinary {
-                                        func: BinaryFunc::Or,
-                                        expr1: Box::new(MirScalarExpr::CallBinary {
-                                            func: BinaryFunc::Eq,
-                                            expr1: Box::new(expr2.clone()),
-                                            expr2: Box::new(expr1.clone()),
-                                        }),
-                                        expr2: Box::new(MirScalarExpr::CallBinary {
-                                            func: BinaryFunc::And,
-                                            expr1: Box::new(MirScalarExpr::CallUnary {
-                                                func: UnaryFunc::IsNull(func::IsNull),
-                                                expr: Box::new(expr2.clone()),
-                                            }),
-                                            expr2: Box::new(MirScalarExpr::CallUnary {
-                                                func: UnaryFunc::IsNull(func::IsNull),
-                                                expr: Box::new(expr1.clone()),
-                                            }),
-                                        }),
-                                    });
-                                }
+                            // If none of the expressions in the equivalence depend on input
+                            // columns and equality predicates with them are pushed down,
+                            // we can safely remove them from the equivalence.
+                            // TODO: we could probably push equality predicates among the
+                            // remaining constants to all join inputs to prevent any computation
+                            // from happening until the condition is satisfied.
+                            if equivalences[equivalence_pos]
+                                .iter()
+                                .all(|e| e.support().is_empty())
+                                && push_downs.iter().any(|p| !p.is_empty())
+                            {
+                                equivalences[equivalence_pos].clear();
+                            }
+                        } else {
+                            // Case 3: There are no constants in the equivalence
+                            // class. Push a predicate for every pair of expressions
+                            // in the equivalence that either belong to a single
+                            // input or can be localized to a given input through
+                            // the rest of equivalences.
+                            let mut to_remove = Vec::new();
+                            for input in 0..inputs.len() {
+                                // Vector of pairs (position within the equivalence, localized
+                                // expression). The position is None for expressions derived through
+                                // other equivalences.
+                                let localized = equivalences[equivalence_pos]
+                                    .iter()
+                                    .enumerate()
+                                    .filter_map(|(pos, expr)| {
+                                        if let MirScalarExpr::Column(col_pos) = &expr {
+                                            let local_col =
+                                                input_mapper.map_column_to_local(*col_pos);
+                                            if input == local_col.1 {
+                                                return Some((
+                                                    Some(pos),
+                                                    MirScalarExpr::Column(local_col.0),
+                                                ));
+                                            } else {
+                                                return None;
+                                            }
+                                        }
+                                        let mut inputs = input_mapper.lookup_inputs(expr);
+                                        if let Some(single_input) = inputs.next() {
+                                            if input == single_input && inputs.next().is_none() {
+                                                return Some((
+                                                    Some(pos),
+                                                    input_mapper.map_expr_to_local(expr.clone()),
+                                                ));
+                                            }
+                                        }
+                                        // Equivalences not including the current expression
+                                        let mut other_equivalences = equivalences.clone();
+                                        other_equivalences[equivalence_pos].remove(pos);
+                                        if let Some(localized) = input_mapper
+                                            .try_map_to_input_with_bound_expr(
+                                                expr.clone(),
+                                                input,
+                                                &other_equivalences[..],
+                                            )
+                                        {
+                                            Some((None, localized))
+                                        } else {
+                                            None
+                                        }
+                                    })
+                                    .collect::<Vec<_>>();
 
-                                if localized.len() == equivalences[equivalence_pos].len() {
-                                    // The equivalence is either a single input one or fully localizable
-                                    // to a single input through other equivalences, so it can be removed
-                                    // completely without introducing any new cross join.
-                                    to_remove.extend(0..equivalences[equivalence_pos].len());
-                                } else {
-                                    // Leave an expression from this input in the equivalence to avoid
-                                    // cross joins
-                                    to_remove.extend(
-                                        localized.iter().filter_map(|(pos, _)| *pos).skip(1),
-                                    );
+                                // If there are at least 2 expression in the equivalence that
+                                // can be localized to the same input, push all combinations
+                                // of them to the input.
+                                if localized.len() > 1 {
+                                    for mut pair in
+                                        localized.iter().map(|(_, expr)| expr).combinations(2)
+                                    {
+                                        let expr1 = pair.pop().unwrap();
+                                        let expr2 = pair.pop().unwrap();
+
+                                        use expr::BinaryFunc;
+                                        use expr::UnaryFunc;
+                                        push_downs[input].push(MirScalarExpr::CallBinary {
+                                            func: BinaryFunc::Or,
+                                            expr1: Box::new(MirScalarExpr::CallBinary {
+                                                func: BinaryFunc::Eq,
+                                                expr1: Box::new(expr2.clone()),
+                                                expr2: Box::new(expr1.clone()),
+                                            }),
+                                            expr2: Box::new(MirScalarExpr::CallBinary {
+                                                func: BinaryFunc::And,
+                                                expr1: Box::new(MirScalarExpr::CallUnary {
+                                                    func: UnaryFunc::IsNull(func::IsNull),
+                                                    expr: Box::new(expr2.clone()),
+                                                }),
+                                                expr2: Box::new(MirScalarExpr::CallUnary {
+                                                    func: UnaryFunc::IsNull(func::IsNull),
+                                                    expr: Box::new(expr1.clone()),
+                                                }),
+                                            }),
+                                        });
+                                    }
+
+                                    if localized.len() == equivalences[equivalence_pos].len() {
+                                        // The equivalence is either a single input one or fully localizable
+                                        // to a single input through other equivalences, so it can be removed
+                                        // completely without introducing any new cross join.
+                                        to_remove.extend(0..equivalences[equivalence_pos].len());
+                                    } else {
+                                        // Leave an expression from this input in the equivalence to avoid
+                                        // cross joins
+                                        to_remove.extend(
+                                            localized.iter().filter_map(|(pos, _)| *pos).skip(1),
+                                        );
+                                    }
                                 }
                             }
-                        }
 
-                        // Remove expressions that were pushed down to at least one input
-                        to_remove.sort();
-                        to_remove.dedup();
-                        for pos in to_remove.iter().rev() {
-                            equivalences[equivalence_pos].remove(*pos);
-                        }
-                    };
+                            // Remove expressions that were pushed down to at least one input
+                            to_remove.sort();
+                            to_remove.dedup();
+                            for pos in to_remove.iter().rev() {
+                                equivalences[equivalence_pos].remove(*pos);
+                            }
+                        };
+                    }
+
+                    expr::canonicalize::canonicalize_equivalences(equivalences, &input_types);
+
+                    let new_inputs = inputs
+                        .drain(..)
+                        .zip(push_downs)
+                        .enumerate()
+                        .map(|(_index, (input, push_down))| {
+                            if !push_down.is_empty() {
+                                input.filter(push_down)
+                            } else {
+                                input
+                            }
+                        })
+                        .collect();
+
+                    *inputs = new_inputs;
+                    // Recursively descend on each of the inputs.
+                    for input in inputs.iter_mut() {
+                        self.action(input, get_predicates)?;
+                    }
+
+                    Ok(())
                 }
-
-                expr::canonicalize::canonicalize_equivalences(equivalences, &input_types);
-
-                let new_inputs = inputs
-                    .drain(..)
-                    .zip(push_downs)
-                    .enumerate()
-                    .map(|(_index, (input, push_down))| {
-                        if !push_down.is_empty() {
-                            input.filter(push_down)
-                        } else {
-                            input
-                        }
-                    })
-                    .collect();
-
-                *inputs = new_inputs;
-                // Recursively descend on each of the inputs.
-                for input in inputs.iter_mut() {
-                    self.action(input, get_predicates)?;
+                x => {
+                    // Recursively descend.
+                    x.try_visit_mut_children(|e| self.action(e, get_predicates))
                 }
-
-                Ok(())
             }
-            x => {
-                // Recursively descend.
-                x.try_visit_mut_children(|e| self.action(e, get_predicates))
-            }
-        }
+        })
     }
 
     /// Computes "safe" predicates to push through a Map.

--- a/src/transform/src/projection_extraction.rs
+++ b/src/transform/src/projection_extraction.rs
@@ -23,16 +23,13 @@ impl crate::Transform for ProjectionExtraction {
         relation: &mut MirRelationExpr,
         _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
-        relation.visit_mut_post(&mut |e| {
-            self.action(e);
-        });
-        Ok(())
+        relation.try_visit_mut_post(&mut |e| self.action(e))
     }
 }
 
 impl ProjectionExtraction {
     /// Transform column references in a `Map` into a `Project`.
-    pub fn action(&self, relation: &mut MirRelationExpr) {
+    pub fn action(&self, relation: &mut MirRelationExpr) -> Result<(), crate::TransformError> {
         if let MirRelationExpr::Map { input, scalars } = relation {
             if scalars
                 .iter()
@@ -104,5 +101,6 @@ impl ProjectionExtraction {
                 *relation = relation.take_dangerous().project(projection);
             }
         }
+        Ok(())
     }
 }

--- a/src/transform/src/projection_lifting.rs
+++ b/src/transform/src/projection_lifting.rs
@@ -15,11 +15,28 @@ use std::collections::HashMap;
 use std::mem;
 
 use crate::TransformArgs;
-use expr::{Id, MirRelationExpr};
+use expr::{Id, MirRelationExpr, RECURSION_LIMIT};
+use ore::stack::{CheckedRecursion, RecursionGuard};
 
 /// Hoist projections through operators.
 #[derive(Debug)]
-pub struct ProjectionLifting;
+pub struct ProjectionLifting {
+    recursion_guard: RecursionGuard,
+}
+
+impl Default for ProjectionLifting {
+    fn default() -> ProjectionLifting {
+        ProjectionLifting {
+            recursion_guard: RecursionGuard::with_limit(RECURSION_LIMIT),
+        }
+    }
+}
+
+impl CheckedRecursion for ProjectionLifting {
+    fn recursion_guard(&self) -> &RecursionGuard {
+        &self.recursion_guard
+    }
+}
 
 impl crate::Transform for ProjectionLifting {
     fn transform(

--- a/src/transform/src/projection_lifting.rs
+++ b/src/transform/src/projection_lifting.rs
@@ -56,289 +56,292 @@ impl ProjectionLifting {
         // Map from names to new get type and projection required at use.
         gets: &mut HashMap<Id, (repr::RelationType, Vec<usize>)>,
     ) -> Result<(), crate::TransformError> {
-        match relation {
-            MirRelationExpr::Constant { .. } => Ok(()),
-            MirRelationExpr::Get { id, .. } => {
-                if let Some((typ, columns)) = gets.get(id) {
-                    *relation = MirRelationExpr::Get {
-                        id: *id,
-                        typ: typ.clone(),
-                    }
-                    .project(columns.clone());
-                }
-                Ok(())
-            }
-            MirRelationExpr::Let { id, value, body } => {
-                self.action(value, gets)?;
-                let id = Id::Local(*id);
-                if let MirRelationExpr::Project { input, outputs } = &mut **value {
-                    let typ = input.typ();
-                    let prior = gets.insert(id, (typ, outputs.clone()));
-                    assert!(!prior.is_some());
-                    **value = input.take_dangerous();
-                }
-
-                self.action(body, gets)?;
-                gets.remove(&id);
-                Ok(())
-            }
-            MirRelationExpr::Project { input, outputs } => {
-                self.action(input, gets)?;
-                if let MirRelationExpr::Project {
-                    input: inner,
-                    outputs: inner_outputs,
-                } = &mut **input
-                {
-                    for output in outputs.iter_mut() {
-                        *output = inner_outputs[*output];
-                    }
-                    **input = inner.take_dangerous();
-                }
-                Ok(())
-            }
-            MirRelationExpr::Map { input, scalars } => {
-                self.action(input, gets)?;
-                if let MirRelationExpr::Project {
-                    input: inner,
-                    outputs,
-                } = &mut **input
-                {
-                    // Retain projected columns and scalar columns.
-                    let mut new_outputs = outputs.clone();
-                    let inner_arity = inner.arity();
-                    new_outputs.extend(inner_arity..(inner_arity + scalars.len()));
-
-                    // Rewrite scalar expressions using inner columns.
-                    for scalar in scalars.iter_mut() {
-                        scalar.permute(&new_outputs);
-                    }
-
-                    *relation = inner
-                        .take_dangerous()
-                        .map(scalars.clone())
-                        .project(new_outputs);
-                }
-                Ok(())
-            }
-            MirRelationExpr::FlatMap { input, func, exprs } => {
-                self.action(input, gets)?;
-                if let MirRelationExpr::Project {
-                    input: inner,
-                    outputs,
-                } = &mut **input
-                {
-                    // Retain projected columns and scalar columns.
-                    let mut new_outputs = outputs.clone();
-                    let inner_arity = inner.arity();
-                    new_outputs.extend(inner_arity..(inner_arity + func.output_arity()));
-
-                    // Rewrite scalar expression using inner columns.
-                    for expr in exprs.iter_mut() {
-                        expr.permute(&new_outputs);
-                    }
-
-                    *relation = inner
-                        .take_dangerous()
-                        .flat_map(func.clone(), exprs.clone())
-                        .project(new_outputs);
-                }
-                Ok(())
-            }
-            MirRelationExpr::Filter { input, predicates } => {
-                self.action(input, gets)?;
-                if let MirRelationExpr::Project {
-                    input: inner,
-                    outputs,
-                } = &mut **input
-                {
-                    // Rewrite scalar expressions using inner columns.
-                    for predicate in predicates.iter_mut() {
-                        predicate.permute(outputs);
-                    }
-                    *relation = inner
-                        .take_dangerous()
-                        .filter(predicates.clone())
-                        .project(outputs.clone());
-                }
-                Ok(())
-            }
-            MirRelationExpr::Join {
-                inputs,
-                equivalences,
-                implementation,
-            } => {
-                for input in inputs.iter_mut() {
-                    self.action(input, gets)?;
-                }
-
-                // Track the location of the projected columns in the un-projected join.
-                let mut projection = Vec::new();
-                let mut temp_arity = 0;
-
-                for join_input in inputs.iter_mut() {
-                    if let MirRelationExpr::Project { input, outputs } = join_input {
-                        for output in outputs.iter() {
-                            projection.push(temp_arity + *output);
+        self.checked_recur(|_| {
+            match relation {
+                MirRelationExpr::Constant { .. } => Ok(()),
+                MirRelationExpr::Get { id, .. } => {
+                    if let Some((typ, columns)) = gets.get(id) {
+                        *relation = MirRelationExpr::Get {
+                            id: *id,
+                            typ: typ.clone(),
                         }
-                        temp_arity += input.arity();
-                        *join_input = input.take_dangerous();
-                    } else {
-                        let arity = join_input.arity();
-                        projection.extend(temp_arity..(temp_arity + arity));
-                        temp_arity += arity;
+                        .project(columns.clone());
                     }
+                    Ok(())
                 }
+                MirRelationExpr::Let { id, value, body } => {
+                    self.action(value, gets)?;
+                    let id = Id::Local(*id);
+                    if let MirRelationExpr::Project { input, outputs } = &mut **value {
+                        let typ = input.typ();
+                        let prior = gets.insert(id, (typ, outputs.clone()));
+                        assert!(!prior.is_some());
+                        **value = input.take_dangerous();
+                    }
 
-                if projection.len() != temp_arity || (0..temp_arity).any(|i| projection[i] != i) {
-                    // Update equivalences and implementation.
-                    for equivalence in equivalences.iter_mut() {
-                        for expr in equivalence {
-                            expr.permute(&projection[..]);
+                    self.action(body, gets)?;
+                    gets.remove(&id);
+                    Ok(())
+                }
+                MirRelationExpr::Project { input, outputs } => {
+                    self.action(input, gets)?;
+                    if let MirRelationExpr::Project {
+                        input: inner,
+                        outputs: inner_outputs,
+                    } = &mut **input
+                    {
+                        for output in outputs.iter_mut() {
+                            *output = inner_outputs[*output];
+                        }
+                        **input = inner.take_dangerous();
+                    }
+                    Ok(())
+                }
+                MirRelationExpr::Map { input, scalars } => {
+                    self.action(input, gets)?;
+                    if let MirRelationExpr::Project {
+                        input: inner,
+                        outputs,
+                    } = &mut **input
+                    {
+                        // Retain projected columns and scalar columns.
+                        let mut new_outputs = outputs.clone();
+                        let inner_arity = inner.arity();
+                        new_outputs.extend(inner_arity..(inner_arity + scalars.len()));
+
+                        // Rewrite scalar expressions using inner columns.
+                        for scalar in scalars.iter_mut() {
+                            scalar.permute(&new_outputs);
+                        }
+
+                        *relation = inner
+                            .take_dangerous()
+                            .map(scalars.clone())
+                            .project(new_outputs);
+                    }
+                    Ok(())
+                }
+                MirRelationExpr::FlatMap { input, func, exprs } => {
+                    self.action(input, gets)?;
+                    if let MirRelationExpr::Project {
+                        input: inner,
+                        outputs,
+                    } = &mut **input
+                    {
+                        // Retain projected columns and scalar columns.
+                        let mut new_outputs = outputs.clone();
+                        let inner_arity = inner.arity();
+                        new_outputs.extend(inner_arity..(inner_arity + func.output_arity()));
+
+                        // Rewrite scalar expression using inner columns.
+                        for expr in exprs.iter_mut() {
+                            expr.permute(&new_outputs);
+                        }
+
+                        *relation = inner
+                            .take_dangerous()
+                            .flat_map(func.clone(), exprs.clone())
+                            .project(new_outputs);
+                    }
+                    Ok(())
+                }
+                MirRelationExpr::Filter { input, predicates } => {
+                    self.action(input, gets)?;
+                    if let MirRelationExpr::Project {
+                        input: inner,
+                        outputs,
+                    } = &mut **input
+                    {
+                        // Rewrite scalar expressions using inner columns.
+                        for predicate in predicates.iter_mut() {
+                            predicate.permute(outputs);
+                        }
+                        *relation = inner
+                            .take_dangerous()
+                            .filter(predicates.clone())
+                            .project(outputs.clone());
+                    }
+                    Ok(())
+                }
+                MirRelationExpr::Join {
+                    inputs,
+                    equivalences,
+                    implementation,
+                } => {
+                    for input in inputs.iter_mut() {
+                        self.action(input, gets)?;
+                    }
+
+                    // Track the location of the projected columns in the un-projected join.
+                    let mut projection = Vec::new();
+                    let mut temp_arity = 0;
+
+                    for join_input in inputs.iter_mut() {
+                        if let MirRelationExpr::Project { input, outputs } = join_input {
+                            for output in outputs.iter() {
+                                projection.push(temp_arity + *output);
+                            }
+                            temp_arity += input.arity();
+                            *join_input = input.take_dangerous();
+                        } else {
+                            let arity = join_input.arity();
+                            projection.extend(temp_arity..(temp_arity + arity));
+                            temp_arity += arity;
                         }
                     }
 
-                    *implementation = expr::JoinImplementation::Unimplemented;
-
-                    *relation = relation.take_dangerous().project(projection);
-                }
-                Ok(())
-            }
-            MirRelationExpr::Reduce {
-                input,
-                group_key,
-                aggregates,
-                monotonic: _,
-                expected_group_size: _,
-            } => {
-                // Reduce *absorbs* projections, which is amazing!
-                self.action(input, gets)?;
-                if let MirRelationExpr::Project {
-                    input: inner,
-                    outputs,
-                } = &mut **input
-                {
-                    for key in group_key.iter_mut() {
-                        key.permute(outputs);
-                    }
-                    for aggregate in aggregates.iter_mut() {
-                        aggregate.expr.permute(outputs);
-                    }
-                    **input = inner.take_dangerous();
-                }
-                Ok(())
-            }
-            MirRelationExpr::TopK {
-                input,
-                group_key,
-                order_key,
-                limit,
-                offset,
-                monotonic: _,
-            } => {
-                self.action(input, gets)?;
-                if let MirRelationExpr::Project {
-                    input: inner,
-                    outputs,
-                } = &mut **input
-                {
-                    for key in group_key.iter_mut() {
-                        *key = outputs[*key];
-                    }
-                    for key in order_key.iter_mut() {
-                        key.column = outputs[key.column];
-                    }
-                    *relation = inner
-                        .take_dangerous()
-                        .top_k(
-                            group_key.clone(),
-                            order_key.clone(),
-                            limit.clone(),
-                            offset.clone(),
-                        )
-                        .project(outputs.clone());
-                }
-                Ok(())
-            }
-            MirRelationExpr::Negate { input } => {
-                self.action(input, gets)?;
-                if let MirRelationExpr::Project {
-                    input: inner,
-                    outputs,
-                } = &mut **input
-                {
-                    *relation = inner.take_dangerous().negate().project(outputs.clone());
-                }
-                Ok(())
-            }
-            MirRelationExpr::Threshold { input } => {
-                // We cannot, in general, lift projections out of threshold.
-                // If we could reason that the input cannot be negative, we
-                // would be able to lift the projection, but otherwise our
-                // action on weights need to accumulate the restricted rows.
-                self.action(input, gets)
-            }
-            MirRelationExpr::DeclareKeys { input, .. } => self.action(input, gets),
-            MirRelationExpr::Union { base, inputs } => {
-                // We cannot, in general, lift projections out of unions.
-                self.action(base, gets)?;
-                for input in &mut *inputs {
-                    self.action(input, gets)?;
-                }
-
-                if let MirRelationExpr::Project {
-                    input: base_input,
-                    outputs: base_outputs,
-                } = &mut **base
-                {
-                    let base_typ = base_input.typ();
-
-                    let mut can_lift = true;
-                    for input in &mut *inputs {
-                        match input {
-                            MirRelationExpr::Project { input, outputs }
-                                if input.typ() == base_typ && outputs == base_outputs => {}
-                            _ => {
-                                can_lift = false;
-                                break;
+                    if projection.len() != temp_arity || (0..temp_arity).any(|i| projection[i] != i)
+                    {
+                        // Update equivalences and implementation.
+                        for equivalence in equivalences.iter_mut() {
+                            for expr in equivalence {
+                                expr.permute(&projection[..]);
                             }
                         }
-                    }
 
-                    if can_lift {
-                        let base_outputs = mem::take(base_outputs);
-                        **base = base_input.take_dangerous();
-                        for inp in inputs {
-                            match inp {
-                                MirRelationExpr::Project { input, .. } => {
-                                    *inp = input.take_dangerous();
-                                }
-                                _ => unreachable!(),
-                            }
-                        }
-                        *relation = relation.take_dangerous().project(base_outputs);
+                        *implementation = expr::JoinImplementation::Unimplemented;
+
+                        *relation = relation.take_dangerous().project(projection);
                     }
+                    Ok(())
                 }
-                Ok(())
-            }
-            MirRelationExpr::ArrangeBy { input, keys } => {
-                self.action(input, gets)?;
-                if let MirRelationExpr::Project {
-                    input: inner,
-                    outputs,
-                } = &mut **input
-                {
-                    for key_set in keys.iter_mut() {
-                        for key in key_set.iter_mut() {
+                MirRelationExpr::Reduce {
+                    input,
+                    group_key,
+                    aggregates,
+                    monotonic: _,
+                    expected_group_size: _,
+                } => {
+                    // Reduce *absorbs* projections, which is amazing!
+                    self.action(input, gets)?;
+                    if let MirRelationExpr::Project {
+                        input: inner,
+                        outputs,
+                    } = &mut **input
+                    {
+                        for key in group_key.iter_mut() {
                             key.permute(outputs);
                         }
+                        for aggregate in aggregates.iter_mut() {
+                            aggregate.expr.permute(outputs);
+                        }
+                        **input = inner.take_dangerous();
                     }
-                    *relation = inner
-                        .take_dangerous()
-                        .arrange_by(keys)
-                        .project(outputs.clone());
+                    Ok(())
                 }
-                Ok(())
+                MirRelationExpr::TopK {
+                    input,
+                    group_key,
+                    order_key,
+                    limit,
+                    offset,
+                    monotonic: _,
+                } => {
+                    self.action(input, gets)?;
+                    if let MirRelationExpr::Project {
+                        input: inner,
+                        outputs,
+                    } = &mut **input
+                    {
+                        for key in group_key.iter_mut() {
+                            *key = outputs[*key];
+                        }
+                        for key in order_key.iter_mut() {
+                            key.column = outputs[key.column];
+                        }
+                        *relation = inner
+                            .take_dangerous()
+                            .top_k(
+                                group_key.clone(),
+                                order_key.clone(),
+                                limit.clone(),
+                                offset.clone(),
+                            )
+                            .project(outputs.clone());
+                    }
+                    Ok(())
+                }
+                MirRelationExpr::Negate { input } => {
+                    self.action(input, gets)?;
+                    if let MirRelationExpr::Project {
+                        input: inner,
+                        outputs,
+                    } = &mut **input
+                    {
+                        *relation = inner.take_dangerous().negate().project(outputs.clone());
+                    }
+                    Ok(())
+                }
+                MirRelationExpr::Threshold { input } => {
+                    // We cannot, in general, lift projections out of threshold.
+                    // If we could reason that the input cannot be negative, we
+                    // would be able to lift the projection, but otherwise our
+                    // action on weights need to accumulate the restricted rows.
+                    self.action(input, gets)
+                }
+                MirRelationExpr::DeclareKeys { input, .. } => self.action(input, gets),
+                MirRelationExpr::Union { base, inputs } => {
+                    // We cannot, in general, lift projections out of unions.
+                    self.action(base, gets)?;
+                    for input in &mut *inputs {
+                        self.action(input, gets)?;
+                    }
+
+                    if let MirRelationExpr::Project {
+                        input: base_input,
+                        outputs: base_outputs,
+                    } = &mut **base
+                    {
+                        let base_typ = base_input.typ();
+
+                        let mut can_lift = true;
+                        for input in &mut *inputs {
+                            match input {
+                                MirRelationExpr::Project { input, outputs }
+                                    if input.typ() == base_typ && outputs == base_outputs => {}
+                                _ => {
+                                    can_lift = false;
+                                    break;
+                                }
+                            }
+                        }
+
+                        if can_lift {
+                            let base_outputs = mem::take(base_outputs);
+                            **base = base_input.take_dangerous();
+                            for inp in inputs {
+                                match inp {
+                                    MirRelationExpr::Project { input, .. } => {
+                                        *inp = input.take_dangerous();
+                                    }
+                                    _ => unreachable!(),
+                                }
+                            }
+                            *relation = relation.take_dangerous().project(base_outputs);
+                        }
+                    }
+                    Ok(())
+                }
+                MirRelationExpr::ArrangeBy { input, keys } => {
+                    self.action(input, gets)?;
+                    if let MirRelationExpr::Project {
+                        input: inner,
+                        outputs,
+                    } = &mut **input
+                    {
+                        for key_set in keys.iter_mut() {
+                            for key in key_set.iter_mut() {
+                                key.permute(outputs);
+                            }
+                        }
+                        *relation = inner
+                            .take_dangerous()
+                            .arrange_by(keys)
+                            .project(outputs.clone());
+                    }
+                    Ok(())
+                }
             }
-        }
+        })
     }
 }

--- a/src/transform/src/reduce_elision.rs
+++ b/src/transform/src/reduce_elision.rs
@@ -27,14 +27,13 @@ impl crate::Transform for ReduceElision {
         relation: &mut MirRelationExpr,
         _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
-        relation.visit_mut_post(&mut |e| self.action(e));
-        Ok(())
+        relation.try_visit_mut_post(&mut |e| self.action(e))
     }
 }
 
 impl ReduceElision {
     /// Removes `Reduce` when the input has as unique keys the keys of the reduce.
-    pub fn action(&self, relation: &mut MirRelationExpr) {
+    pub fn action(&self, relation: &mut MirRelationExpr) -> Result<(), crate::TransformError> {
         if let MirRelationExpr::Reduce {
             input,
             group_key,
@@ -68,5 +67,6 @@ impl ReduceElision {
                 *relation = result;
             }
         }
+        Ok(())
     }
 }

--- a/src/transform/src/reduction_pushdown.rs
+++ b/src/transform/src/reduction_pushdown.rs
@@ -24,16 +24,13 @@ impl crate::Transform for ReductionPushdown {
         relation: &mut MirRelationExpr,
         _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
-        relation.visit_mut_post(&mut |e| {
-            self.action(e);
-        });
-        Ok(())
+        relation.try_visit_mut_post(&mut |e| self.action(e))
     }
 }
 
 impl ReductionPushdown {
     /// Pushes Reduce operators toward sources.
-    pub fn action(&self, relation: &mut MirRelationExpr) {
+    pub fn action(&self, relation: &mut MirRelationExpr) -> Result<(), crate::TransformError> {
         if let MirRelationExpr::Reduce {
             input,
             group_key,
@@ -84,5 +81,6 @@ impl ReductionPushdown {
                 **input = inner.take_dangerous()
             }
         }
+        Ok(())
     }
 }

--- a/src/transform/src/redundant_join.rs
+++ b/src/transform/src/redundant_join.rs
@@ -78,268 +78,270 @@ impl RedundantJoin {
         relation: &mut MirRelationExpr,
         lets: &mut HashMap<Id, Vec<ProvInfo>>,
     ) -> Result<Vec<ProvInfo>, crate::TransformError> {
-        match relation {
-            MirRelationExpr::Let { id, value, body } => {
-                // Recursively determine provenance of the value.
-                let value_prov = self.action(value, lets)?;
-                let old = lets.insert(Id::Local(*id), value_prov);
-                let result = self.action(body, lets)?;
-                if let Some(old) = old {
-                    lets.insert(Id::Local(*id), old);
-                } else {
-                    lets.remove(&Id::Local(*id));
+        self.checked_recur(|_| {
+            match relation {
+                MirRelationExpr::Let { id, value, body } => {
+                    // Recursively determine provenance of the value.
+                    let value_prov = self.action(value, lets)?;
+                    let old = lets.insert(Id::Local(*id), value_prov);
+                    let result = self.action(body, lets)?;
+                    if let Some(old) = old {
+                        lets.insert(Id::Local(*id), old);
+                    } else {
+                        lets.remove(&Id::Local(*id));
+                    }
+                    Ok(result)
                 }
-                Ok(result)
-            }
-            MirRelationExpr::Get { id, typ } => {
-                // Extract the value provenance, or an empty list if unavailable.
-                let mut val_info = lets.get(id).cloned().unwrap_or_default();
-                // Add information about being exactly this let binding too.
-                val_info.push(ProvInfo {
-                    id: *id,
-                    binding: (0..typ.arity()).map(|c| (c, c)).collect::<Vec<_>>(),
-                    exact: true,
-                });
-                Ok(val_info)
-            }
-
-            MirRelationExpr::Join {
-                inputs,
-                equivalences,
-                implementation,
-            } => {
-                // This logic first applies what it has learned about its input provenance,
-                // and if it finds a redundant join input it removes it. In that case, it
-                // also fails to produce exciting provenance information, partly out of
-                // laziness and the challenge of ensuring it is correct. Instead, if it is
-                // unable to find a rendundant join it produces meaningful provenance information.
-
-                // Recursively apply transformation, and determine the provenance of inputs.
-                let mut input_prov = Vec::new();
-                for i in inputs.iter_mut() {
-                    input_prov.push(self.action(i, lets)?);
+                MirRelationExpr::Get { id, typ } => {
+                    // Extract the value provenance, or an empty list if unavailable.
+                    let mut val_info = lets.get(id).cloned().unwrap_or_default();
+                    // Add information about being exactly this let binding too.
+                    val_info.push(ProvInfo {
+                        id: *id,
+                        binding: (0..typ.arity()).map(|c| (c, c)).collect::<Vec<_>>(),
+                        exact: true,
+                    });
+                    Ok(val_info)
                 }
 
-                // Determine useful information about the structure of the inputs.
-                let mut input_types = inputs.iter().map(|i| i.typ()).collect::<Vec<_>>();
-                let old_input_mapper = JoinInputMapper::new_from_input_types(&input_types);
+                MirRelationExpr::Join {
+                    inputs,
+                    equivalences,
+                    implementation,
+                } => {
+                    // This logic first applies what it has learned about its input provenance,
+                    // and if it finds a redundant join input it removes it. In that case, it
+                    // also fails to produce exciting provenance information, partly out of
+                    // laziness and the challenge of ensuring it is correct. Instead, if it is
+                    // unable to find a rendundant join it produces meaningful provenance information.
 
-                // If we find an input that can be removed, we should do so!
-                // We only do this once per invocation to keep our sanity, but we could
-                // rewrite it to iterate. We can avoid looking for any relation that
-                // does not have keys, as it cannot be redundant in that case.
-                if let Some((input, bindings)) = (0..input_types.len())
-                    .rev()
-                    .filter(|i| !input_types[*i].keys.is_empty())
-                    .flat_map(|i| {
-                        find_redundancy(
-                            i,
-                            &input_types[i].keys,
-                            &old_input_mapper,
-                            equivalences,
-                            &input_prov[..],
-                        )
-                        .map(|b| (i, b))
-                    })
-                    .next()
-                {
-                    inputs.remove(input);
-                    input_types.remove(input);
+                    // Recursively apply transformation, and determine the provenance of inputs.
+                    let mut input_prov = Vec::new();
+                    for i in inputs.iter_mut() {
+                        input_prov.push(self.action(i, lets)?);
+                    }
 
-                    let new_input_mapper = JoinInputMapper::new_from_input_types(&input_types);
-                    // From `binding`, we produce the projection we will apply to the join
-                    // once `input` is removed. This is valuable also to rewrite expressions
-                    // in the join constraints.
-                    let mut projection = Vec::new();
-                    for i in 0..old_input_mapper.total_inputs() {
-                        if i != input {
-                            projection.extend(new_input_mapper.global_columns(if i < input {
-                                i
+                    // Determine useful information about the structure of the inputs.
+                    let mut input_types = inputs.iter().map(|i| i.typ()).collect::<Vec<_>>();
+                    let old_input_mapper = JoinInputMapper::new_from_input_types(&input_types);
+
+                    // If we find an input that can be removed, we should do so!
+                    // We only do this once per invocation to keep our sanity, but we could
+                    // rewrite it to iterate. We can avoid looking for any relation that
+                    // does not have keys, as it cannot be redundant in that case.
+                    if let Some((input, bindings)) = (0..input_types.len())
+                        .rev()
+                        .filter(|i| !input_types[*i].keys.is_empty())
+                        .flat_map(|i| {
+                            find_redundancy(
+                                i,
+                                &input_types[i].keys,
+                                &old_input_mapper,
+                                equivalences,
+                                &input_prov[..],
+                            )
+                            .map(|b| (i, b))
+                        })
+                        .next()
+                    {
+                        inputs.remove(input);
+                        input_types.remove(input);
+
+                        let new_input_mapper = JoinInputMapper::new_from_input_types(&input_types);
+                        // From `binding`, we produce the projection we will apply to the join
+                        // once `input` is removed. This is valuable also to rewrite expressions
+                        // in the join constraints.
+                        let mut projection = Vec::new();
+                        for i in 0..old_input_mapper.total_inputs() {
+                            if i != input {
+                                projection.extend(new_input_mapper.global_columns(if i < input {
+                                    i
+                                } else {
+                                    i - 1
+                                }));
                             } else {
-                                i - 1
-                            }));
-                        } else {
-                            // When we reach the removed relation, we should introduce
-                            // references to the columns that are meant to replace these.
-                            // This should happen only once, and `.drain(..)` would be correct.
-                            projection.extend(bindings.clone());
-                        }
-                    }
-                    // The references introduced from `bindings` need to be refreshed, now that we
-                    // know where each target column will be. This is important because they could
-                    // have been to columns *after* `input`, and our original take on where they
-                    // would be is no longer correct. References before `input` should stay as they
-                    // are, and references afterwards will likely be decreased.
-                    for c in old_input_mapper.global_columns(input) {
-                        projection[c] = projection[projection[c]];
-                    }
-
-                    // Tidy up equivalences rewriting column references with `projection` and
-                    // removing any equivalence classes that are now redundant (e.g. those that
-                    // related the columns of `input` with the relation that showed its redundancy)
-                    for equivalence in equivalences.iter_mut() {
-                        for expr in equivalence.iter_mut() {
-                            expr.permute(&projection[..]);
-                        }
-                    }
-                    expr::canonicalize::canonicalize_equivalences(equivalences, &input_types);
-
-                    // Unset implementation, as irrevocably hosed by this transformation.
-                    *implementation = expr::JoinImplementation::Unimplemented;
-
-                    *relation = relation.take_dangerous().project(projection);
-                    // The projection will gum up provenance reasoning anyhow, so don't work hard.
-                    // We will return to this expression again with the same analysis.
-                    Ok(Vec::new())
-                } else {
-                    // Provenance information should be the union of input provenance information,
-                    // with columns updated. Because rows may be dropped in the join, all `exact`
-                    // bits should be un-set.
-                    let mut results = Vec::new();
-                    for (input, input_prov) in input_prov.into_iter().enumerate() {
-                        for mut prov in input_prov {
-                            prov.exact = false;
-                            for (_src, inp) in prov.binding.iter_mut() {
-                                *inp = old_input_mapper.map_column_to_global(*inp, input);
+                                // When we reach the removed relation, we should introduce
+                                // references to the columns that are meant to replace these.
+                                // This should happen only once, and `.drain(..)` would be correct.
+                                projection.extend(bindings.clone());
                             }
-                            results.push(prov);
                         }
-                    }
-                    Ok(results)
-                }
-            }
+                        // The references introduced from `bindings` need to be refreshed, now that we
+                        // know where each target column will be. This is important because they could
+                        // have been to columns *after* `input`, and our original take on where they
+                        // would be is no longer correct. References before `input` should stay as they
+                        // are, and references afterwards will likely be decreased.
+                        for c in old_input_mapper.global_columns(input) {
+                            projection[c] = projection[projection[c]];
+                        }
 
-            MirRelationExpr::Filter { input, .. } => {
-                // Filter may drop records, and so we unset `exact`.
-                let mut result = self.action(input, lets)?;
-                for prov in result.iter_mut() {
-                    prov.exact = false;
-                }
-                Ok(result)
-            }
-
-            MirRelationExpr::Map { input, .. } => self.action(input, lets),
-            MirRelationExpr::DeclareKeys { input, .. } => self.action(input, lets),
-
-            MirRelationExpr::Union { base, inputs } => {
-                let mut prov = self.action(base, lets)?;
-                for input in inputs {
-                    let input_prov = self.action(input, lets)?;
-                    // To merge a new list of provenances, we look at the cross
-                    // produce of things we might know about each source.
-                    // TODO(mcsherry): this can be optimized to use datastructures
-                    // keyed by the source identifier.
-                    let mut new_prov = Vec::new();
-                    for l in prov {
-                        new_prov.extend(input_prov.iter().flat_map(|r| l.meet(r)))
-                    }
-                    prov = new_prov;
-                }
-                Ok(prov)
-            }
-
-            MirRelationExpr::Constant { .. } => Ok(Vec::new()),
-
-            MirRelationExpr::Reduce {
-                input, group_key, ..
-            } => {
-                // Reduce yields its first few columns as a key, and produces
-                // all key tuples that were present in its input.
-                let mut result = self.action(input, lets)?;
-                for prov in result.iter_mut() {
-                    // update the bindings. no need to update `exact`.
-                    let new_bindings = group_key
-                        .iter()
-                        .enumerate()
-                        .filter_map(|(i, e)| {
-                            if let MirScalarExpr::Column(c) = e {
-                                Some((i, c))
-                            } else {
-                                None
+                        // Tidy up equivalences rewriting column references with `projection` and
+                        // removing any equivalence classes that are now redundant (e.g. those that
+                        // related the columns of `input` with the relation that showed its redundancy)
+                        for equivalence in equivalences.iter_mut() {
+                            for expr in equivalence.iter_mut() {
+                                expr.permute(&projection[..]);
                             }
-                        })
-                        .filter_map(|(i, c)| {
-                            // output column `i` corresponds to input column `c`.
-                            prov.binding
-                                .iter()
-                                .find(|(_src, inp)| inp == c)
-                                .map(|(src, _inp)| (*src, i))
-                        })
-                        .collect::<Vec<_>>();
-                    prov.binding = new_bindings;
+                        }
+                        expr::canonicalize::canonicalize_equivalences(equivalences, &input_types);
+
+                        // Unset implementation, as irrevocably hosed by this transformation.
+                        *implementation = expr::JoinImplementation::Unimplemented;
+
+                        *relation = relation.take_dangerous().project(projection);
+                        // The projection will gum up provenance reasoning anyhow, so don't work hard.
+                        // We will return to this expression again with the same analysis.
+                        Ok(Vec::new())
+                    } else {
+                        // Provenance information should be the union of input provenance information,
+                        // with columns updated. Because rows may be dropped in the join, all `exact`
+                        // bits should be un-set.
+                        let mut results = Vec::new();
+                        for (input, input_prov) in input_prov.into_iter().enumerate() {
+                            for mut prov in input_prov {
+                                prov.exact = false;
+                                for (_src, inp) in prov.binding.iter_mut() {
+                                    *inp = old_input_mapper.map_column_to_global(*inp, input);
+                                }
+                                results.push(prov);
+                            }
+                        }
+                        Ok(results)
+                    }
                 }
-                result.retain(|p| !p.binding.is_empty());
-                // TODO: For min, max aggregates, we could preserve provenance
-                // if the expression references a column. We would need to un-set
-                // the `exact` bit in that case, and so we would want to keep both
-                // sets of provenance information.
-                Ok(result)
-            }
 
-            MirRelationExpr::Threshold { input } => {
-                // Threshold may drop records, and so we unset `exact`.
-                let mut result = self.action(input, lets)?;
-                for prov in result.iter_mut() {
-                    prov.exact = false;
+                MirRelationExpr::Filter { input, .. } => {
+                    // Filter may drop records, and so we unset `exact`.
+                    let mut result = self.action(input, lets)?;
+                    for prov in result.iter_mut() {
+                        prov.exact = false;
+                    }
+                    Ok(result)
                 }
-                Ok(result)
-            }
 
-            MirRelationExpr::TopK { input, .. } => {
-                // TopK may drop records, and so we unset `exact`.
-                let mut result = self.action(input, lets)?;
-                for prov in result.iter_mut() {
-                    prov.exact = false;
+                MirRelationExpr::Map { input, .. } => self.action(input, lets),
+                MirRelationExpr::DeclareKeys { input, .. } => self.action(input, lets),
+
+                MirRelationExpr::Union { base, inputs } => {
+                    let mut prov = self.action(base, lets)?;
+                    for input in inputs {
+                        let input_prov = self.action(input, lets)?;
+                        // To merge a new list of provenances, we look at the cross
+                        // produce of things we might know about each source.
+                        // TODO(mcsherry): this can be optimized to use datastructures
+                        // keyed by the source identifier.
+                        let mut new_prov = Vec::new();
+                        for l in prov {
+                            new_prov.extend(input_prov.iter().flat_map(|r| l.meet(r)))
+                        }
+                        prov = new_prov;
+                    }
+                    Ok(prov)
                 }
-                Ok(result)
-            }
 
-            MirRelationExpr::Project { input, outputs } => {
-                // Projections re-order, drop, and duplicate columns,
-                // but they neither drop rows nor invent values.
-                let mut result = self.action(input, lets)?;
-                for provenance in result.iter_mut() {
-                    let new_binding = outputs
-                        .iter()
-                        .enumerate()
-                        .flat_map(|(i, c)| {
-                            provenance
-                                .binding
-                                .iter()
-                                .find(|(_, l)| l == c)
-                                .map(|(s, _)| (*s, i))
-                        })
-                        .collect::<Vec<_>>();
+                MirRelationExpr::Constant { .. } => Ok(Vec::new()),
 
-                    provenance.binding = new_binding;
+                MirRelationExpr::Reduce {
+                    input, group_key, ..
+                } => {
+                    // Reduce yields its first few columns as a key, and produces
+                    // all key tuples that were present in its input.
+                    let mut result = self.action(input, lets)?;
+                    for prov in result.iter_mut() {
+                        // update the bindings. no need to update `exact`.
+                        let new_bindings = group_key
+                            .iter()
+                            .enumerate()
+                            .filter_map(|(i, e)| {
+                                if let MirScalarExpr::Column(c) = e {
+                                    Some((i, c))
+                                } else {
+                                    None
+                                }
+                            })
+                            .filter_map(|(i, c)| {
+                                // output column `i` corresponds to input column `c`.
+                                prov.binding
+                                    .iter()
+                                    .find(|(_src, inp)| inp == c)
+                                    .map(|(src, _inp)| (*src, i))
+                            })
+                            .collect::<Vec<_>>();
+                        prov.binding = new_bindings;
+                    }
+                    result.retain(|p| !p.binding.is_empty());
+                    // TODO: For min, max aggregates, we could preserve provenance
+                    // if the expression references a column. We would need to un-set
+                    // the `exact` bit in that case, and so we would want to keep both
+                    // sets of provenance information.
+                    Ok(result)
                 }
-                Ok(result)
-            }
 
-            MirRelationExpr::FlatMap { input, .. } => {
-                // FlatMap may drop records, and so we unset `exact`.
-                let mut result = self.action(input, lets)?;
-                for prov in result.iter_mut() {
-                    prov.exact = false;
+                MirRelationExpr::Threshold { input } => {
+                    // Threshold may drop records, and so we unset `exact`.
+                    let mut result = self.action(input, lets)?;
+                    for prov in result.iter_mut() {
+                        prov.exact = false;
+                    }
+                    Ok(result)
                 }
-                Ok(result)
-            }
 
-            MirRelationExpr::Negate { input } => {
-                // Negate does not guarantee that the multiplicity of
-                // each source record it at least one. This could have
-                // been a problem in `Union`, where we might report
-                // that the union of positive and negative records is
-                // "exact": cancellations would make this false.
-                let mut result = self.action(input, lets)?;
-                for prov in result.iter_mut() {
-                    prov.exact = false;
+                MirRelationExpr::TopK { input, .. } => {
+                    // TopK may drop records, and so we unset `exact`.
+                    let mut result = self.action(input, lets)?;
+                    for prov in result.iter_mut() {
+                        prov.exact = false;
+                    }
+                    Ok(result)
                 }
-                Ok(result)
-            }
 
-            MirRelationExpr::ArrangeBy { input, .. } => self.action(input, lets),
-        }
+                MirRelationExpr::Project { input, outputs } => {
+                    // Projections re-order, drop, and duplicate columns,
+                    // but they neither drop rows nor invent values.
+                    let mut result = self.action(input, lets)?;
+                    for provenance in result.iter_mut() {
+                        let new_binding = outputs
+                            .iter()
+                            .enumerate()
+                            .flat_map(|(i, c)| {
+                                provenance
+                                    .binding
+                                    .iter()
+                                    .find(|(_, l)| l == c)
+                                    .map(|(s, _)| (*s, i))
+                            })
+                            .collect::<Vec<_>>();
+
+                        provenance.binding = new_binding;
+                    }
+                    Ok(result)
+                }
+
+                MirRelationExpr::FlatMap { input, .. } => {
+                    // FlatMap may drop records, and so we unset `exact`.
+                    let mut result = self.action(input, lets)?;
+                    for prov in result.iter_mut() {
+                        prov.exact = false;
+                    }
+                    Ok(result)
+                }
+
+                MirRelationExpr::Negate { input } => {
+                    // Negate does not guarantee that the multiplicity of
+                    // each source record it at least one. This could have
+                    // been a problem in `Union`, where we might report
+                    // that the union of positive and negative records is
+                    // "exact": cancellations would make this false.
+                    let mut result = self.action(input, lets)?;
+                    for prov in result.iter_mut() {
+                        prov.exact = false;
+                    }
+                    Ok(result)
+                }
+
+                MirRelationExpr::ArrangeBy { input, .. } => self.action(input, lets),
+            }
+        })
     }
 }
 

--- a/src/transform/src/redundant_join.rs
+++ b/src/transform/src/redundant_join.rs
@@ -24,13 +24,30 @@
 
 use std::collections::HashMap;
 
-use expr::{Id, JoinInputMapper, MirRelationExpr, MirScalarExpr};
+use expr::{Id, JoinInputMapper, MirRelationExpr, MirScalarExpr, RECURSION_LIMIT};
+use ore::stack::{CheckedRecursion, RecursionGuard};
 
 use crate::TransformArgs;
 
 /// Remove redundant collections of distinct elements from joins.
 #[derive(Debug)]
-pub struct RedundantJoin;
+pub struct RedundantJoin {
+    recursion_guard: RecursionGuard,
+}
+
+impl Default for RedundantJoin {
+    fn default() -> RedundantJoin {
+        RedundantJoin {
+            recursion_guard: RecursionGuard::with_limit(RECURSION_LIMIT),
+        }
+    }
+}
+
+impl CheckedRecursion for RedundantJoin {
+    fn recursion_guard(&self) -> &RecursionGuard {
+        &self.recursion_guard
+    }
+}
 
 impl crate::Transform for RedundantJoin {
     fn transform(

--- a/src/transform/src/topk_elision.rs
+++ b/src/transform/src/topk_elision.rs
@@ -22,16 +22,13 @@ impl crate::Transform for TopKElision {
         relation: &mut MirRelationExpr,
         _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
-        relation.visit_mut_post(&mut |e| {
-            self.action(e);
-        });
-        Ok(())
+        relation.try_visit_mut_post(&mut |e| self.action(e))
     }
 }
 
 impl TopKElision {
     /// Remove TopK operators with both an offset of zero and no limit.
-    pub fn action(&self, relation: &mut MirRelationExpr) {
+    pub fn action(&self, relation: &mut MirRelationExpr) -> Result<(), crate::TransformError> {
         if let MirRelationExpr::TopK {
             input,
             group_key: _,
@@ -47,5 +44,6 @@ impl TopKElision {
                 relation.take_safely();
             }
         }
+        Ok(())
     }
 }

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -236,7 +236,7 @@ mod tests {
                 limit: None,
             })),
             "JoinFusion" => Ok(Box::new(transform::fusion::join::Join)),
-            "LiteralLifting" => Ok(Box::new(transform::map_lifting::LiteralLifting)),
+            "LiteralLifting" => Ok(Box::new(transform::map_lifting::LiteralLifting::default())),
             "NonNullRequirements" => Ok(Box::new(
                 transform::nonnull_requirements::NonNullRequirements,
             )),

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -238,7 +238,7 @@ mod tests {
             "JoinFusion" => Ok(Box::new(transform::fusion::join::Join)),
             "LiteralLifting" => Ok(Box::new(transform::map_lifting::LiteralLifting::default())),
             "NonNullRequirements" => Ok(Box::new(
-                transform::nonnull_requirements::NonNullRequirements,
+                transform::nonnull_requirements::NonNullRequirements::default(),
             )),
             "PredicatePushdown" => Ok(Box::new(transform::predicate_pushdown::PredicatePushdown)),
             "ProjectionExtraction" => Ok(Box::new(

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -366,7 +366,7 @@ mod tests {
                 let mut predicates = HashMap::new();
                 match optimize_dataflow_filters_inner(dataflow.iter_mut().map(|(id, rel)| (Id::Global(*id), rel)).rev(), &mut predicates) {
                     Ok(()) => Ok(format!("Pushed-down predicates:\n{}", log_pushed_outside_of_dataflow(predicates, cat))),
-                    Err(e) => Err(format!("{}", e)),
+                    Err(e) => Err(e.to_string()),
                 }
             }
             "project" => {
@@ -374,8 +374,10 @@ mod tests {
                 if let Some((id, rel)) = dataflow.last() {
                     demand.insert(Id::Global(*id), (0..rel.arity()).collect());
                 }
-                optimize_dataflow_demand_inner(dataflow.iter_mut().map(|(id, rel)| (Id::Global(*id), rel)).rev(), &mut demand);
-                Ok(format!("Pushed-down demand:\n{}", log_pushed_outside_of_dataflow(demand, cat)))
+                match optimize_dataflow_demand_inner(dataflow.iter_mut().map(|(id, rel)| (Id::Global(*id), rel)).rev(), &mut demand) {
+                    Ok(()) => Ok(format!("Pushed-down demand:\n{}", log_pushed_outside_of_dataflow(demand, cat))),
+                    Err(e) => Err(e.to_string()),
+                }
             }
             _ => return Err(format!(
                 "no cross-view transform named {} (you might have to add it to apply_cross_view_transform)",

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -228,7 +228,7 @@ mod tests {
         match name {
             "CanonicalizeMfp" => Ok(Box::new(transform::canonicalize_mfp::CanonicalizeMfp)),
             "ColumnKnowledge" => Ok(Box::new(transform::column_knowledge::ColumnKnowledge)),
-            "Demand" => Ok(Box::new(transform::demand::Demand)),
+            "Demand" => Ok(Box::new(transform::demand::Demand::default())),
             "FilterFusion" => Ok(Box::new(transform::fusion::filter::Filter)),
             "FoldConstants" => Ok(Box::new(transform::reduction::FoldConstants {
                 limit: None,

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -246,7 +246,9 @@ mod tests {
             "ProjectionExtraction" => Ok(Box::new(
                 transform::projection_extraction::ProjectionExtraction,
             )),
-            "ProjectionLifting" => Ok(Box::new(transform::projection_lifting::ProjectionLifting)),
+            "ProjectionLifting" => Ok(Box::new(
+                transform::projection_lifting::ProjectionLifting::default(),
+            )),
             "ProjectionPushdown" => {
                 Ok(Box::new(transform::projection_pushdown::ProjectionPushdown))
             }

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -240,7 +240,9 @@ mod tests {
             "NonNullRequirements" => Ok(Box::new(
                 transform::nonnull_requirements::NonNullRequirements::default(),
             )),
-            "PredicatePushdown" => Ok(Box::new(transform::predicate_pushdown::PredicatePushdown)),
+            "PredicatePushdown" => Ok(Box::new(
+                transform::predicate_pushdown::PredicatePushdown::default(),
+            )),
             "ProjectionExtraction" => Ok(Box::new(
                 transform::projection_extraction::ProjectionExtraction,
             )),

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -47,7 +47,7 @@ mod tests {
                         as Box<dyn Transform>,
                 ))
                 .chain(std::iter::once(
-                    Box::new(transform::update_let::UpdateLet) as Box<dyn Transform>
+                    Box::new(transform::update_let::UpdateLet::default()) as Box<dyn Transform>
                 ))
                 .chain(Optimizer::logical_cleanup_pass().transforms.into_iter())
                 .chain(Optimizer::physical_optimizer().transforms.into_iter())

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -227,7 +227,9 @@ mod tests {
         // transforms?
         match name {
             "CanonicalizeMfp" => Ok(Box::new(transform::canonicalize_mfp::CanonicalizeMfp)),
-            "ColumnKnowledge" => Ok(Box::new(transform::column_knowledge::ColumnKnowledge)),
+            "ColumnKnowledge" => Ok(Box::new(
+                transform::column_knowledge::ColumnKnowledge::default(),
+            )),
             "Demand" => Ok(Box::new(transform::demand::Demand::default())),
             "FilterFusion" => Ok(Box::new(transform::fusion::filter::Filter)),
             "FoldConstants" => Ok(Box::new(transform::reduction::FoldConstants {

--- a/src/transform/tests/testdata/keys
+++ b/src/transform/tests/testdata/keys
@@ -63,9 +63,9 @@ steps format=types
 | | keys = ((#0), (#1))
 
 ====
-No change: TopKElision, NonNullRequirements
+No change: TopKElision, NonNullRequirements { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }
 ====
-Applied Fixpoint { transforms: [FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting, Map, Negate, Filter, Project, Join, TopK, InlineLet { inline_mfp: false }, Reduce, Union, UnionBranchCancellation, UpdateLet, RedundantJoin, FoldConstants { limit: Some(10000) }] }], limit: 100 }:
+Applied Fixpoint { transforms: [FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Map, Negate, Filter, Project, Join, TopK, InlineLet { inline_mfp: false, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Reduce, Union, UnionBranchCancellation, UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, RedundantJoin { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FoldConstants { limit: Some(10000) }] }], limit: 100 }:
 %0 =
 | Get x (u0)
 | | types = (Int32?, Int64?, Int32?)
@@ -75,7 +75,7 @@ Applied Fixpoint { transforms: [FuseAndCollapse { transforms: [ProjectionExtract
 | | keys = ((#0), (#1))
 
 ====
-No change: Fixpoint { transforms: [PredicatePushdown, NonNullable, ColumnKnowledge, Demand, FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting, Map, Negate, Filter, Project, Join, TopK, InlineLet { inline_mfp: false }, Reduce, Union, UnionBranchCancellation, UpdateLet, RedundantJoin, FoldConstants { limit: Some(10000) }] }], limit: 100 }, Fixpoint { transforms: [ReductionPushdown, ReduceElision, LiteralLifting, RelationCSE, InlineLet { inline_mfp: false }, UpdateLet, FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting, Map, Negate, Filter, Project, Join, TopK, InlineLet { inline_mfp: false }, Reduce, Union, UnionBranchCancellation, UpdateLet, RedundantJoin, FoldConstants { limit: Some(10000) }] }], limit: 100 }, ProjectionPushdown, UpdateLet, Map, Fixpoint { transforms: [Join, RedundantJoin, Project, Union, UnionBranchCancellation, RelationCSE, InlineLet { inline_mfp: true }], limit: 100 }, Fixpoint { transforms: [JoinImplementation, ColumnKnowledge, FoldConstants { limit: Some(10000) }, Demand, LiteralLifting], limit: 100 }, ReductionPushdown, CanonicalizeMfp
+No change: Fixpoint { transforms: [PredicatePushdown { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, NonNullable, ColumnKnowledge { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Demand { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Map, Negate, Filter, Project, Join, TopK, InlineLet { inline_mfp: false, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Reduce, Union, UnionBranchCancellation, UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, RedundantJoin { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FoldConstants { limit: Some(10000) }] }], limit: 100 }, Fixpoint { transforms: [ReductionPushdown, ReduceElision, LiteralLifting { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, RelationCSE, InlineLet { inline_mfp: false, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Map, Negate, Filter, Project, Join, TopK, InlineLet { inline_mfp: false, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Reduce, Union, UnionBranchCancellation, UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, RedundantJoin { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FoldConstants { limit: Some(10000) }] }], limit: 100 }, ProjectionPushdown, UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Map, Fixpoint { transforms: [Join, RedundantJoin { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Project, Union, UnionBranchCancellation, RelationCSE, InlineLet { inline_mfp: true, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }], limit: 100 }, Fixpoint { transforms: [JoinImplementation { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, ColumnKnowledge { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FoldConstants { limit: Some(10000) }, Demand { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, LiteralLifting { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }], limit: 100 }, ReductionPushdown, CanonicalizeMfp
 ====
 Applied RelationCSE:
 %0 = Let l0 =
@@ -97,7 +97,7 @@ Applied RelationCSE:
 | | keys = ((#0), (#1))
 
 ====
-Applied InlineLet { inline_mfp: false }:
+Applied InlineLet { inline_mfp: false, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }:
 %0 =
 | Get x (u0)
 | | types = (Int32?, Int64?, Int32?)
@@ -107,7 +107,7 @@ Applied InlineLet { inline_mfp: false }:
 | | keys = ((#0), (#1))
 
 ====
-No change: UpdateLet, FoldConstants { limit: Some(10000) }
+No change: UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FoldConstants { limit: Some(10000) }
 ====
 Final:
 %0 =

--- a/src/transform/tests/testdata/steps
+++ b/src/transform/tests/testdata/steps
@@ -37,9 +37,9 @@ steps
 | Union %0 %1
 
 ====
-No change: TopKElision, NonNullRequirements, Fixpoint { transforms: [FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting, Map, Negate, Filter, Project, Join, TopK, InlineLet { inline_mfp: false }, Reduce, Union, UnionBranchCancellation, UpdateLet, RedundantJoin, FoldConstants { limit: Some(10000) }] }], limit: 100 }, Fixpoint { transforms: [PredicatePushdown, NonNullable, ColumnKnowledge, Demand, FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting, Map, Negate, Filter, Project, Join, TopK, InlineLet { inline_mfp: false }, Reduce, Union, UnionBranchCancellation, UpdateLet, RedundantJoin, FoldConstants { limit: Some(10000) }] }], limit: 100 }
+No change: TopKElision, NonNullRequirements { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Fixpoint { transforms: [FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Map, Negate, Filter, Project, Join, TopK, InlineLet { inline_mfp: false, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Reduce, Union, UnionBranchCancellation, UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, RedundantJoin { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FoldConstants { limit: Some(10000) }] }], limit: 100 }, Fixpoint { transforms: [PredicatePushdown { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, NonNullable, ColumnKnowledge { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Demand { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Map, Negate, Filter, Project, Join, TopK, InlineLet { inline_mfp: false, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Reduce, Union, UnionBranchCancellation, UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, RedundantJoin { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FoldConstants { limit: Some(10000) }] }], limit: 100 }
 ====
-Applied Fixpoint { transforms: [ReductionPushdown, ReduceElision, LiteralLifting, RelationCSE, InlineLet { inline_mfp: false }, UpdateLet, FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting, Map, Negate, Filter, Project, Join, TopK, InlineLet { inline_mfp: false }, Reduce, Union, UnionBranchCancellation, UpdateLet, RedundantJoin, FoldConstants { limit: Some(10000) }] }], limit: 100 }:
+Applied Fixpoint { transforms: [ReductionPushdown, ReduceElision, LiteralLifting { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, RelationCSE, InlineLet { inline_mfp: false, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Map, Negate, Filter, Project, Join, TopK, InlineLet { inline_mfp: false, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Reduce, Union, UnionBranchCancellation, UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, RedundantJoin { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FoldConstants { limit: Some(10000) }] }], limit: 100 }:
 %0 = Let l0 =
 | Get x (u0)
 | Filter #0
@@ -48,9 +48,9 @@ Applied Fixpoint { transforms: [ReductionPushdown, ReduceElision, LiteralLifting
 | Union %0 %0
 
 ====
-No change: ProjectionPushdown, UpdateLet, Map
+No change: ProjectionPushdown, UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Map
 ====
-Applied Fixpoint { transforms: [Join, RedundantJoin, Project, Union, UnionBranchCancellation, RelationCSE, InlineLet { inline_mfp: true }], limit: 100 }:
+Applied Fixpoint { transforms: [Join, RedundantJoin { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Project, Union, UnionBranchCancellation, RelationCSE, InlineLet { inline_mfp: true, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }], limit: 100 }:
 %0 =
 | Get x (u0)
 | Filter #0
@@ -63,7 +63,7 @@ Applied Fixpoint { transforms: [Join, RedundantJoin, Project, Union, UnionBranch
 | Union %0 %1
 
 ====
-No change: Fixpoint { transforms: [JoinImplementation, ColumnKnowledge, FoldConstants { limit: Some(10000) }, Demand, LiteralLifting], limit: 100 }, ReductionPushdown, CanonicalizeMfp
+No change: Fixpoint { transforms: [JoinImplementation { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, ColumnKnowledge { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FoldConstants { limit: Some(10000) }, Demand { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, LiteralLifting { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }], limit: 100 }, ReductionPushdown, CanonicalizeMfp
 ====
 Applied RelationCSE:
 %0 = Let l0 =
@@ -80,7 +80,7 @@ Applied RelationCSE:
 | Get %2 (l2)
 
 ====
-Applied InlineLet { inline_mfp: false }:
+Applied InlineLet { inline_mfp: false, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }:
 %0 = Let l1 =
 | Get x (u0)
 | Filter #0
@@ -89,7 +89,7 @@ Applied InlineLet { inline_mfp: false }:
 | Union %0 %0
 
 ====
-Applied UpdateLet:
+Applied UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }:
 %0 = Let l0 =
 | Get x (u0)
 | Filter #0
@@ -123,15 +123,15 @@ steps in=json format=test
 (Filter (Join [(get u1) (get x)] [] Unimplemented) [(CallBinary Or (CallBinary And (CallUnary (IsNull ) #0) (CallUnary (IsNull ) #2)) (CallBinary Eq #0 (CallBinary AddInt64 #2 (1 Int64))))])
 
 ====
-No change: TopKElision, NonNullRequirements, Fixpoint { transforms: [FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting, Map, Negate, Filter, Project, Join, TopK, InlineLet { inline_mfp: false }, Reduce, Union, UnionBranchCancellation, UpdateLet, RedundantJoin, FoldConstants { limit: Some(10000) }] }], limit: 100 }
+No change: TopKElision, NonNullRequirements { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Fixpoint { transforms: [FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Map, Negate, Filter, Project, Join, TopK, InlineLet { inline_mfp: false, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Reduce, Union, UnionBranchCancellation, UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, RedundantJoin { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FoldConstants { limit: Some(10000) }] }], limit: 100 }
 ====
-Applied Fixpoint { transforms: [PredicatePushdown, NonNullable, ColumnKnowledge, Demand, FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting, Map, Negate, Filter, Project, Join, TopK, InlineLet { inline_mfp: false }, Reduce, Union, UnionBranchCancellation, UpdateLet, RedundantJoin, FoldConstants { limit: Some(10000) }] }], limit: 100 }:
+Applied Fixpoint { transforms: [PredicatePushdown { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, NonNullable, ColumnKnowledge { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Demand { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Map, Negate, Filter, Project, Join, TopK, InlineLet { inline_mfp: false, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Reduce, Union, UnionBranchCancellation, UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, RedundantJoin { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FoldConstants { limit: Some(10000) }] }], limit: 100 }:
 (Join [(get u1) (get x)] [[#0 (CallBinary AddInt64 #2 (1 Int64))]] Unimplemented)
 
 ====
-No change: Fixpoint { transforms: [ReductionPushdown, ReduceElision, LiteralLifting, RelationCSE, InlineLet { inline_mfp: false }, UpdateLet, FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting, Map, Negate, Filter, Project, Join, TopK, InlineLet { inline_mfp: false }, Reduce, Union, UnionBranchCancellation, UpdateLet, RedundantJoin, FoldConstants { limit: Some(10000) }] }], limit: 100 }, ProjectionPushdown, UpdateLet, Map, Fixpoint { transforms: [Join, RedundantJoin, Project, Union, UnionBranchCancellation, RelationCSE, InlineLet { inline_mfp: true }], limit: 100 }
+No change: Fixpoint { transforms: [ReductionPushdown, ReduceElision, LiteralLifting { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, RelationCSE, InlineLet { inline_mfp: false, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Map, Negate, Filter, Project, Join, TopK, InlineLet { inline_mfp: false, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Reduce, Union, UnionBranchCancellation, UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, RedundantJoin { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FoldConstants { limit: Some(10000) }] }], limit: 100 }, ProjectionPushdown, UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Map, Fixpoint { transforms: [Join, RedundantJoin { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Project, Union, UnionBranchCancellation, RelationCSE, InlineLet { inline_mfp: true, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }], limit: 100 }
 ====
-Applied Fixpoint { transforms: [JoinImplementation, ColumnKnowledge, FoldConstants { limit: Some(10000) }, Demand, LiteralLifting], limit: 100 }:
+Applied Fixpoint { transforms: [JoinImplementation { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, ColumnKnowledge { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FoldConstants { limit: Some(10000) }, Demand { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, LiteralLifting { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }], limit: 100 }:
 (Join [(ArrangeBy (get u1) [[#0]]) (get x)] [[#0 (CallBinary AddInt64 #2 (1 Int64))]] (Differential [1 null] [[0 [#0]]]))
 
 ====
@@ -141,11 +141,11 @@ Applied RelationCSE:
 (let l0 (get u1) (let l1 (ArrangeBy (get l0) [[#0]]) (let l2 (get x) (let l3 (Join [(get l1) (get l2)] [[#0 (CallBinary AddInt64 #2 (1 Int64))]] (Differential [1 null] [[0 [#0]]])) (get l3)))))
 
 ====
-Applied InlineLet { inline_mfp: false }:
+Applied InlineLet { inline_mfp: false, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }:
 (Join [(ArrangeBy (get u1) [[#0]]) (get x)] [[#0 (CallBinary AddInt64 #2 (1 Int64))]] (Differential [1 null] [[0 [#0]]]))
 
 ====
-No change: UpdateLet, FoldConstants { limit: Some(10000) }
+No change: UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FoldConstants { limit: Some(10000) }
 ====
 Final:
 (Join [(ArrangeBy (get u1) [[#0]]) (get x)] [[#0 (CallBinary AddInt64 #2 (1 Int64))]] (Differential [1 null] [[0 [#0]]]))


### PR DESCRIPTION
This PR makes all `Transform` implementations in the `transform` crate stack safe.

<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

See #9000 (issue) and #9188 (the first PR towards fixing it) for motivation and context.

### Tips for reviewer

A the high-level, the changes in this PR can be summarized as follows.

1. For each transform `$transform` that fully delegates recursion to a `MirRelationExpr::*visit*` method:
    1. Replace uses of `visit_$suffix` method to `try_visit_$suffix` in order to ensure that `RecursionLimit` errors are properly propagated upstream. Usually, this also entails changing the return type of the function passed to `visit` from `T` to `Result<T, TransformError>`.
1. For each transform `$transform` that (even partially) drives its own recursion:
    1. Change the return type of the recursive method called by `$transform::transform` (usually called `action`) from `T` to `Result<T, TransformError>`. This might entail changing client code, most notably in `transform::dataflow`.
    1. Implement `CheckedRecursion` for `${transform}`.
    1. Make the recursive function stack safe by changing the body of the recursive function from `$body` to `self.checked_recur(|_| $body)`.

The first commit handles all transforms in (1). The rest of the commits come in adjacent groups of three. The commit messages in each group correspond to the sub-steps of (2) and have the following form:

1. prepare `$transform` for stack safety
2. implement `CheckedRecursion` for `$transform`
3. make `$transform` stack safe

Towards the end, there is a commit that  factors out `dataflow::monotonic::is_monotonic` into a nullary struct in a dedicated top-level module `monotonic::MonotonicFlag` and then applies the same three steps to that struct to make it stack safe.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
