### PR TITLE
doc/user: make version list scrollable

### DIFF
--- a/doc/user/assets/sass/_content.scss
+++ b/doc/user/assets/sass/_content.scss
@@ -594,3 +594,29 @@ pre {
     }
   }
 }
+
+.table-scrollable {
+    box-shadow: inset 0 -4px 3px -3px $medium-grey-v2;
+    margin: 1rem 0;
+    overflow: auto;
+
+    table {
+        width: 100%;
+    }
+
+    thead th {
+        background: #fff;
+        border: 0;
+        position: sticky;
+        top: 0;
+
+        &:after {
+            border-bottom: 2px $purple-v2 solid;
+            content: "";
+            bottom: -1px;
+            left: 0;
+            right: 0;
+            position: absolute;
+        }
+    }
+}

--- a/doc/user/layouts/shortcodes/version-list.html
+++ b/doc/user/layouts/shortcodes/version-list.html
@@ -1,24 +1,26 @@
-<table>
-  <thead>
-    <th>Version</th>
-    <th>Release date</th>
-    <th>Binary tarball links</th>
-    <th>Supported</th>
-  </thead>
+<div class="table-scrollable" style="height: 310px;">
+  <table>
+    <thead>
+      <th>Version</th>
+      <th>Release date</th>
+      <th>Binary tarball links</th>
+      <th>Supported</th>
+    </thead>
 
-  <tbody>
-    {{range $i, $version := .Site.Params.Versions}}
-      <tr>
-        <td>
-          <strong><a href="../release-notes/#{{$version.name}}">{{$version.name}}</a></strong>
-        </td>
-        <td>{{$version.date}}</td>
-        <td>
-          <a href="https://binaries.materialize.com/materialized-{{$version.name}}-x86_64-unknown-linux-gnu.tar.gz">Linux</a>
-          /
-          <a href="https://binaries.materialize.com/materialized-{{$version.name}}-x86_64-apple-darwin.tar.gz">macOS</a>
-        </td>
-        <td style="text-align: center"><span class="symbol">{{if lt $i 2}}✓{{end}}</span></td>
-    {{end}}
-  </tbody>
-</table>
+    <tbody>
+      {{range $i, $version := .Site.Params.Versions}}
+        <tr>
+          <td>
+            <strong><a href="../release-notes/#{{$version.name}}">{{$version.name}}</a></strong>
+          </td>
+          <td>{{$version.date}}</td>
+          <td>
+            <a href="https://binaries.materialize.com/materialized-{{$version.name}}-x86_64-unknown-linux-gnu.tar.gz">Linux</a>
+            /
+            <a href="https://binaries.materialize.com/materialized-{{$version.name}}-x86_64-apple-darwin.tar.gz">macOS</a>
+          </td>
+          <td><span class="symbol">{{if lt $i 2}}✓{{end}}</span></td>
+      {{end}}
+    </tbody>
+  </table>
+</div>


### PR DESCRIPTION
Now that we have dozens of releases, the table view has gotten unwieldy.
Make it scrollable so it doesn't dominate the page.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
