### PR TITLE
testdrive: add a new `psql-execute` action

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4655,6 +4655,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e24979f63a11545f5f2c60141afe249d4f19f84581ea2138065e400941d83d3"
+
+[[package]]
 name = "siphasher"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5101,6 +5107,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "similar",
  "sql-parser",
  "structopt",
  "tempfile",

--- a/doc/developer/testdrive.md
+++ b/doc/developer/testdrive.md
@@ -708,3 +708,10 @@ The test will fail unless the HTTP status code of the response is in the 200 ran
 #### `$ schema-registry-wait-schema schema=...`
 
 Block the test until the specified schema has been defined at the schema registry. This is used to fortify tests that expect an external party, e.g. Debezium to  upload a particular schema.
+
+## Actions with `psql`
+
+#### `$ psql-execute command=...`
+
+Executes a command against Materialize via `psql`. This is intended for testing
+`psql`-specific commands like `\dn`.

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -43,6 +43,7 @@ repr = { path = "../repr" }
 reqwest = { version = "0.11.6", features = ["native-tls-vendored"] }
 serde = "1.0.130"
 serde_json = { version = "1.0.71", features = ["raw_value"] }
+similar = "2.1.0"
 sql-parser = { path = "../sql-parser" }
 structopt = "0.3.25"
 tempfile = "3.2.0"

--- a/src/testdrive/ci/Dockerfile
+++ b/src/testdrive/ci/Dockerfile
@@ -11,6 +11,7 @@ MZFROM ubuntu-base
 
 RUN apt-get update && apt-get -qy install \
     ca-certificates \
+    postgresql-client \
     wait-for-it
 
 COPY kdestroy kinit testdrive /usr/local/bin/

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -44,6 +44,7 @@ mod kafka;
 mod kinesis;
 mod postgres;
 mod protobuf;
+mod psql;
 mod s3;
 mod schema_registry;
 mod sleep;
@@ -450,6 +451,7 @@ pub async fn build(cmds: Vec<PosCommand>, state: &State) -> Result<Vec<PosAction
                     "protobuf-compile-descriptors" => {
                         Box::new(protobuf::build_compile_descriptors(builtin).map_err(wrap_err)?)
                     }
+                    "psql-execute" => Box::new(psql::build_execute(builtin).map_err(wrap_err)?),
                     "schema-registry-publish" => {
                         Box::new(schema_registry::build_publish(builtin).map_err(wrap_err)?)
                     }

--- a/src/testdrive/src/action/psql.rs
+++ b/src/testdrive/src/action/psql.rs
@@ -1,0 +1,68 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use async_trait::async_trait;
+
+use tokio::process::Command;
+
+use ore::option::OptionExt;
+
+use crate::action::{Action, State};
+use crate::parser::BuiltinCommand;
+use crate::util::text;
+
+pub struct ExecuteAction {
+    command: String,
+    expected_output: String,
+}
+
+pub fn build_execute(mut cmd: BuiltinCommand) -> Result<ExecuteAction, String> {
+    let command = cmd.args.string("command")?;
+    Ok(ExecuteAction {
+        command,
+        expected_output: cmd.input.join("\n"),
+    })
+}
+
+#[async_trait]
+impl Action for ExecuteAction {
+    async fn undo(&self, _: &mut State) -> Result<(), String> {
+        Ok(())
+    }
+
+    async fn redo(&self, state: &mut State) -> Result<(), String> {
+        let output = Command::new("psql")
+            .args(&[
+                "--pset",
+                "footer=off",
+                "--command",
+                &self.command,
+                &format!(
+                    "postgres://{}@{}",
+                    state.materialized_user, state.materialized_addr
+                ),
+            ])
+            .output()
+            .await
+            .map_err(|e| format!("execution of `psql` failed: {}", e))?;
+        if !output.status.success() {
+            return Err(format!(
+                "psql reported failure with exit code {}: {}",
+                output.status.code().display_or("unknown"),
+                String::from_utf8_lossy(&output.stderr),
+            ));
+        }
+        let stdout = text::trim_trailing_space(&String::from_utf8_lossy(&output.stdout));
+        if self.expected_output != stdout {
+            text::print_diff(&self.expected_output, &*stdout);
+            return Err("psql returned unexpected output (diff above)".into());
+        }
+        Ok(())
+    }
+}

--- a/src/testdrive/src/util.rs
+++ b/src/testdrive/src/util.rs
@@ -8,3 +8,4 @@
 // by the Apache License, Version 2.0.
 
 pub mod postgres;
+pub mod text;

--- a/src/testdrive/src/util/text.rs
+++ b/src/testdrive/src/util/text.rs
@@ -1,0 +1,51 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use atty::Stream;
+use similar::{ChangeTag, TextDiff};
+use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
+
+/// Trims trailing whitespace from each line of `s`.
+pub fn trim_trailing_space(s: &str) -> String {
+    let mut lines: Vec<_> = s.lines().map(|line| line.trim_end()).collect();
+    while lines.last().map_or(false, |l| l.is_empty()) {
+        lines.pop();
+    }
+    lines.join("\n")
+}
+
+/// Prints a colorized line diff of `expected` and `actual`.
+pub fn print_diff(expected: &str, actual: &str) {
+    let color_choice = if atty::is(Stream::Stderr) {
+        ColorChoice::Auto
+    } else {
+        ColorChoice::Never
+    };
+    let mut stderr = StandardStream::stderr(color_choice);
+    let diff = TextDiff::from_lines(expected, actual);
+    println!("--- expected");
+    println!("+++ actual");
+    for op in diff.ops() {
+        for change in diff.iter_changes(op) {
+            let sign = match change.tag() {
+                ChangeTag::Delete => {
+                    let _ = stderr.set_color(ColorSpec::new().set_fg(Some(Color::Red)));
+                    "-"
+                }
+                ChangeTag::Insert => {
+                    let _ = stderr.set_color(ColorSpec::new().set_fg(Some(Color::Green)));
+                    "+"
+                }
+                ChangeTag::Equal => " ",
+            };
+            print!("{}{}", sign, change);
+            let _ = stderr.reset();
+        }
+    }
+}

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -20,6 +20,13 @@ public
 mz_catalog
 mz_internal
 pg_catalog
+$ psql-execute command=\dn
+\   List of schemas
+    Name     | Owner
+-------------+-------
+ mz_catalog  |
+ mz_internal |
+ public      |
 
 # What objects do we have by default?
 > SHOW OBJECTS


### PR DESCRIPTION
This command will be useful for writing integration tests for the
various backslash commands in psql. This commit adds only documentation
and one sample use of the action.

<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
