### PR TITLE
sql: fix cargo test -p sql_parser compilation issue

### DIFF
--- a/src/sql-parser/Cargo.toml
+++ b/src/sql-parser/Cargo.toml
@@ -22,7 +22,7 @@ unicode-width = "0.1.9"
 
 [build-dependencies]
 anyhow = "1.0.50"
-ore = { path = "../ore", default-features = false, features = ["stack"] }
+ore = { path = "../ore", default-features = false}
 phf = { version = "0.10.0", features = ["uncased"] }
 phf_codegen = { version = "0.10.0" }
 uncased = "0.9.6"

--- a/src/sql-parser/Cargo.toml
+++ b/src/sql-parser/Cargo.toml
@@ -12,7 +12,7 @@ hex = "0.4.3"
 itertools = "0.10.1"
 lazy_static = "1.4.0"
 log = "0.4.13"
-ore = { path = "../ore", default-features = false }
+ore = { path = "../ore", default-features = false, features = ["stack"] }
 phf = { version = "0.10.0", features = ["uncased"] }
 uncased = "0.9.6"
 
@@ -22,7 +22,7 @@ unicode-width = "0.1.9"
 
 [build-dependencies]
 anyhow = "1.0.50"
-ore = { path = "../ore", default-features = false }
+ore = { path = "../ore", default-features = false, features = ["stack"] }
 phf = { version = "0.10.0", features = ["uncased"] }
 phf_codegen = { version = "0.10.0" }
 uncased = "0.9.6"

--- a/src/sql-parser/Cargo.toml
+++ b/src/sql-parser/Cargo.toml
@@ -22,7 +22,7 @@ unicode-width = "0.1.9"
 
 [build-dependencies]
 anyhow = "1.0.50"
-ore = { path = "../ore", default-features = false}
+ore = { path = "../ore", default-features = false }
 phf = { version = "0.10.0", features = ["uncased"] }
 phf_codegen = { version = "0.10.0" }
 uncased = "0.9.6"


### PR DESCRIPTION
fix the following error during test:
```
error[E0432]: unresolved import `ore::stack`
  --> src/sql-parser/src/parser.rs:31:10
   |
31 | use ore::stack::{CheckedRecursion, RecursionGuard, RecursionLimitError};
   |          ^^^^^ could not find `stack` in `ore`

For more information about this error, try `rustc --explain E0432`.
error: could not compile `sql-parser` due to previous error
warning: build failed, waiting for other jobs to finish...
error: build failed
```