### PR TITLE
testdrive: support command="\dn <pattern>"

### DIFF
--- a/src/testdrive/src/parser.rs
+++ b/src/testdrive/src/parser.rs
@@ -483,7 +483,11 @@ impl<'a> Iterator for BuiltinReader<'a> {
                 }
             } else if c == '"' {
                 quoted = !quoted;
-                continue;
+                // remove the double quote for un-nested commands such as: command="\dt public"
+                // keep the quotes when inside of a nested schema such as: schema={ "type" : "array" }
+                if nesting.is_empty() {
+                    continue;
+                }
             }
             token.push(c);
         }

--- a/src/testdrive/src/parser.rs
+++ b/src/testdrive/src/parser.rs
@@ -121,7 +121,7 @@ fn parse_builtin(line_reader: &mut LineReader) -> Result<BuiltinCommand, InputEr
             return Err(InputError {
                 msg: format!(
                     "invalid builtin argument name '{}': \
-                     only lowercase letters, numbers, and hyphens allowed",
+                     only lowercase letters, numbers, hyphens, underscores, and stars allowed",
                     pieces[0]
                 ),
                 pos,

--- a/src/testdrive/src/parser.rs
+++ b/src/testdrive/src/parser.rs
@@ -481,13 +481,11 @@ impl<'a> Iterator for BuiltinReader<'a> {
                         ),
                     }));
                 }
-            } else if c == '"' {
-                quoted = !quoted;
+            } else if c == '"' && nesting.is_empty() {
                 // remove the double quote for un-nested commands such as: command="\dt public"
-                // keep the quotes when inside of a nested schema such as: schema={ "type" : "array" }
-                if nesting.is_empty() {
-                    continue;
-                }
+                // keep the quotes when inside of a nested object such as: schema={ "type" : "array" }
+                quoted = !quoted;
+                continue;
             }
             token.push(c);
         }

--- a/src/testdrive/src/parser.rs
+++ b/src/testdrive/src/parser.rs
@@ -115,13 +115,13 @@ fn parse_builtin(line_reader: &mut LineReader) -> Result<BuiltinCommand, InputEr
             }
         };
         lazy_static! {
-            static ref VALID_KEY_REGEX: Regex = Regex::new("^[a-z0-9_\\-\\.\\*]*$").unwrap();
+            static ref VALID_KEY_REGEX: Regex = Regex::new("^[a-z0-9\\-]*$").unwrap();
         }
         if !VALID_KEY_REGEX.is_match(pieces[0]) {
             return Err(InputError {
                 msg: format!(
                     "invalid builtin argument name '{}': \
-                     only lowercase letters, numbers, hyphens, underscores, and stars allowed",
+                     only lowercase letters, numbers, and hyphens allowed",
                     pieces[0]
                 ),
                 pos,

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -28,6 +28,20 @@ $ psql-execute command=\dn
  mz_internal |
  public      |
 
+$ psql-execute command="\dn mz_catalog"
+\  List of schemas
+    Name    | Owner
+------------+-------
+ mz_catalog |
+
+
+$ psql-execute command="\dn mz_*"
+\   List of schemas
+    Name     | Owner
+-------------+-------
+ mz_catalog  |
+ mz_internal |
+
 # What objects do we have by default?
 > SHOW OBJECTS
 name


### PR DESCRIPTION
In order to support `\dn <pattern>` the following change was required:
- the parser needs to support quoted strings and pass the command including all its arguments to psql