### PR TITLE
Fast follow-ups from #9000

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -4100,7 +4100,7 @@ where
     fn prep_scalar_expr(expr: &mut MirScalarExpr, style: ExprPrepStyle) -> Result<(), CoordError> {
         // Replace calls to `MzLogicalTimestamp` as described above.
         let mut observes_ts = false;
-        expr.visit_mut(&mut |e| {
+        expr.visit_mut_post(&mut |e| {
             if let MirScalarExpr::CallNullary(f @ NullaryFunc::MzLogicalTimestamp) = e {
                 observes_ts = true;
                 if let ExprPrepStyle::OneShot { logical_time } = style {

--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -15,6 +15,7 @@
 //! isolates that logic from the rest of the somewhat complicated coordinator.
 
 use super::*;
+use ore::stack::maybe_grow;
 
 /// Borrows of catalog and indexes sufficient to build dataflow descriptions.
 pub struct DataflowBuilder<'a> {
@@ -66,98 +67,105 @@ impl<'a> DataflowBuilder<'a> {
     /// Imports the view, source, or table with `id` into the provided
     /// dataflow description.
     fn import_into_dataflow(&mut self, id: &GlobalId, dataflow: &mut DataflowDesc) {
-        // Avoid importing the item redundantly.
-        if dataflow.is_imported(id) {
-            return;
-        }
-
-        // A valid index is any index on `id` that is known to the dataflow
-        // layer, as indicated by its presence in `self.indexes`.
-        let valid_index = self.catalog.enabled_indexes()[id]
-            .iter()
-            .find(|(id, _keys)| self.indexes.contains_key(*id));
-        if let Some((index_id, keys)) = valid_index {
-            let index_desc = IndexDesc {
-                on_id: *id,
-                keys: keys.to_vec(),
-            };
-            let desc = self
-                .catalog
-                .get_by_id(id)
-                .desc()
-                .expect("indexes can only be built on items with descs");
-            dataflow.import_index(*index_id, index_desc, desc.typ().clone(), *id);
-        } else {
-            // This is only needed in the case of a source with a transformation, but we generate it now to
-            // get around borrow checker issues.
-            let transient_id = *self.transient_id_counter;
-            *self.transient_id_counter = transient_id
-                .checked_add(1)
-                .expect("id counter overflows i64");
-            let entry = self.catalog.get_by_id(id);
-            match entry.item() {
-                CatalogItem::Table(table) => {
-                    dataflow.import_source(
-                        *id,
-                        dataflow_types::SourceDesc {
-                            name: entry.name().to_string(),
-                            connector: SourceConnector::Local {
-                                timeline: table.timeline(),
-                            },
-                            operators: None,
-                            bare_desc: table.desc.clone(),
-                            persisted_name: table.persist.as_ref().map(|p| p.stream_name.clone()),
-                        },
-                        *id,
-                    );
-                }
-                CatalogItem::Source(source) => {
-                    if source.optimized_expr.0.is_trivial_source() {
-                        dataflow.import_source(
-                            *id,
-                            dataflow_types::SourceDesc {
-                                name: entry.name().to_string(),
-                                connector: source.connector.clone(),
-                                operators: None,
-                                bare_desc: source.bare_desc.clone(),
-                                persisted_name: source.persist_name.clone(),
-                            },
-                            *id,
-                        );
-                    } else {
-                        // From the dataflow layer's perspective, the source transformation is just a view (across which it should be able to do whole-dataflow optimizations).
-                        // Install it as such (giving the source a global transient ID by which the view/transformation can refer to it)
-                        let bare_source_id = GlobalId::Transient(transient_id);
-                        dataflow.import_source(
-                            bare_source_id,
-                            dataflow_types::SourceDesc {
-                                name: entry.name().to_string(),
-                                connector: source.connector.clone(),
-                                operators: None,
-                                bare_desc: source.bare_desc.clone(),
-                                persisted_name: source.persist_name.clone(),
-                            },
-                            *id,
-                        );
-                        let mut transformation = source.optimized_expr.clone();
-                        transformation.0.visit_mut_post(&mut |node| {
-                            match node {
-                                MirRelationExpr::Get { id, .. } if *id == Id::LocalBareSource => {
-                                    *id = Id::Global(bare_source_id);
-                                }
-                                _ => {}
-                            };
-                        });
-                        self.import_view_into_dataflow(id, &transformation, dataflow);
-                    }
-                }
-                CatalogItem::View(view) => {
-                    let expr = view.optimized_expr.clone();
-                    self.import_view_into_dataflow(id, &expr, dataflow);
-                }
-                _ => unreachable!(),
+        maybe_grow(|| {
+            // Avoid importing the item redundantly.
+            if dataflow.is_imported(id) {
+                return;
             }
-        }
+
+            // A valid index is any index on `id` that is known to the dataflow
+            // layer, as indicated by its presence in `self.indexes`.
+            let valid_index = self.catalog.enabled_indexes()[id]
+                .iter()
+                .find(|(id, _keys)| self.indexes.contains_key(*id));
+            if let Some((index_id, keys)) = valid_index {
+                let index_desc = IndexDesc {
+                    on_id: *id,
+                    keys: keys.to_vec(),
+                };
+                let desc = self
+                    .catalog
+                    .get_by_id(id)
+                    .desc()
+                    .expect("indexes can only be built on items with descs");
+                dataflow.import_index(*index_id, index_desc, desc.typ().clone(), *id);
+            } else {
+                // This is only needed in the case of a source with a transformation, but we generate it now to
+                // get around borrow checker issues.
+                let transient_id = *self.transient_id_counter;
+                *self.transient_id_counter = transient_id
+                    .checked_add(1)
+                    .expect("id counter overflows i64");
+                let entry = self.catalog.get_by_id(id);
+                match entry.item() {
+                    CatalogItem::Table(table) => {
+                        dataflow.import_source(
+                            *id,
+                            dataflow_types::SourceDesc {
+                                name: entry.name().to_string(),
+                                connector: SourceConnector::Local {
+                                    timeline: table.timeline(),
+                                },
+                                operators: None,
+                                bare_desc: table.desc.clone(),
+                                persisted_name: table
+                                    .persist
+                                    .as_ref()
+                                    .map(|p| p.stream_name.clone()),
+                            },
+                            *id,
+                        );
+                    }
+                    CatalogItem::Source(source) => {
+                        if source.optimized_expr.0.is_trivial_source() {
+                            dataflow.import_source(
+                                *id,
+                                dataflow_types::SourceDesc {
+                                    name: entry.name().to_string(),
+                                    connector: source.connector.clone(),
+                                    operators: None,
+                                    bare_desc: source.bare_desc.clone(),
+                                    persisted_name: source.persist_name.clone(),
+                                },
+                                *id,
+                            );
+                        } else {
+                            // From the dataflow layer's perspective, the source transformation is just a view (across which it should be able to do whole-dataflow optimizations).
+                            // Install it as such (giving the source a global transient ID by which the view/transformation can refer to it)
+                            let bare_source_id = GlobalId::Transient(transient_id);
+                            dataflow.import_source(
+                                bare_source_id,
+                                dataflow_types::SourceDesc {
+                                    name: entry.name().to_string(),
+                                    connector: source.connector.clone(),
+                                    operators: None,
+                                    bare_desc: source.bare_desc.clone(),
+                                    persisted_name: source.persist_name.clone(),
+                                },
+                                *id,
+                            );
+                            let mut transformation = source.optimized_expr.clone();
+                            transformation.0.visit_mut_post(&mut |node| {
+                                match node {
+                                    MirRelationExpr::Get { id, .. }
+                                        if *id == Id::LocalBareSource =>
+                                    {
+                                        *id = Id::Global(bare_source_id);
+                                    }
+                                    _ => {}
+                                };
+                            });
+                            self.import_view_into_dataflow(id, &transformation, dataflow);
+                        }
+                    }
+                    CatalogItem::View(view) => {
+                        let expr = view.optimized_expr.clone();
+                        self.import_view_into_dataflow(id, &expr, dataflow);
+                    }
+                    _ => unreachable!(),
+                }
+            }
+        })
     }
 
     /// Imports the view with the specified ID and expression into the provided

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -966,7 +966,7 @@ impl MapFilterProject {
         // Inline expressions per `should_inline`.
         for index in 0..self.expressions.len() {
             let (prior, expr) = self.expressions.split_at_mut(index);
-            expr[0].visit_mut(&mut |e| {
+            expr[0].visit_mut_post(&mut |e| {
                 if let MirScalarExpr::Column(i) = e {
                     if should_inline[*i] {
                         *e = prior[*i - input_arity].clone();
@@ -976,7 +976,7 @@ impl MapFilterProject {
         }
         for (_index, pred) in self.predicates.iter_mut() {
             let expressions = &self.expressions;
-            pred.visit_mut(&mut |e| {
+            pred.visit_mut_post(&mut |e| {
                 if let MirScalarExpr::Column(i) = e {
                     if should_inline[*i] {
                         *e = expressions[*i - input_arity].clone();

--- a/src/expr/src/relation/canonicalize.rs
+++ b/src/expr/src/relation/canonicalize.rs
@@ -70,7 +70,7 @@ pub fn canonicalize_equivalences(
             // which will then replace `to_reduce[i]`.
             let mut new_equivalence = Vec::with_capacity(to_reduce[i].len());
             while let Some((_, mut popped_expr)) = to_reduce[i].pop() {
-                popped_expr.visit_mut(&mut |e: &mut MirScalarExpr| {
+                popped_expr.visit_mut_post(&mut |e: &mut MirScalarExpr| {
                     // If a simpler expression can be found that is equivalent
                     // to e,
                     if let Some(simpler_e) = to_reduce.iter().find_map(|cls| {
@@ -174,7 +174,7 @@ fn rank_complexity(expr: &MirScalarExpr) -> usize {
         return 0;
     }
     let mut non_literal_count = 1;
-    expr.visit(&mut |e| {
+    expr.visit_post(&mut |e| {
         if !e.is_literal() {
             non_literal_count += 1
         }

--- a/src/expr/src/relation/join_input_mapper.rs
+++ b/src/expr/src/relation/join_input_mapper.rs
@@ -176,7 +176,7 @@ impl JoinInputMapper {
     /// where column references have been remapped to the local context.
     /// Assumes that all columns in `expr` are from the same input.
     pub fn map_expr_to_local(&self, mut expr: MirScalarExpr) -> MirScalarExpr {
-        expr.visit_mut(&mut |e| {
+        expr.visit_mut_post(&mut |e| {
             if let MirScalarExpr::Column(c) = e {
                 *c -= self.prior_arities[self.input_relation[*c]];
             }
@@ -188,7 +188,7 @@ impl JoinInputMapper {
     /// creates a new version where column references have been remapped to the
     /// global context.
     pub fn map_expr_to_global(&self, mut expr: MirScalarExpr, index: usize) -> MirScalarExpr {
-        expr.visit_mut(&mut |e| {
+        expr.visit_mut_post(&mut |e| {
             if let MirScalarExpr::Column(c) = e {
                 *c += self.prior_arities[index];
             }

--- a/src/transform/src/fusion/join.rs
+++ b/src/transform/src/fusion/join.rs
@@ -142,7 +142,7 @@ impl JoinBuilder {
         // Update and push all of the variables.
         for mut equivalence in equivalences.drain(..) {
             for expr in equivalence.iter_mut() {
-                expr.visit_mut(&mut |e| {
+                expr.visit_mut_post(&mut |e| {
                     if let MirScalarExpr::Column(c) = e {
                         *c += self.num_columns;
                     }
@@ -153,7 +153,7 @@ impl JoinBuilder {
 
         if let Some(mut predicates) = predicates {
             for mut expr in predicates.drain(..) {
-                expr.visit_mut(&mut |e| {
+                expr.visit_mut_post(&mut |e| {
                     if let MirScalarExpr::Column(c) = e {
                         *c += self.num_columns;
                     }

--- a/src/transform/src/fusion/reduce.rs
+++ b/src/transform/src/fusion/reduce.rs
@@ -47,7 +47,7 @@ impl Reduce {
                 // Collect all columns referenced by outer
                 let mut outer_cols = vec![];
                 for expr in group_key.iter() {
-                    expr.visit(&mut |e| {
+                    expr.visit_post(&mut |e| {
                         if let MirScalarExpr::Column(i) = e {
                             outer_cols.push(*i);
                         }

--- a/src/transform/src/map_lifting.rs
+++ b/src/transform/src/map_lifting.rs
@@ -335,7 +335,7 @@ impl LiteralLifting {
                                 } else {
                                     let mut cloned_scalar = scalar.clone();
                                     // Propagate literals through expressions and remap columns.
-                                    cloned_scalar.visit_mut(&mut |e| {
+                                    cloned_scalar.visit_mut_post(&mut |e| {
                                         if let MirScalarExpr::Column(old_id) = e {
                                             let new_id = projection[*old_id];
                                             if new_id >= first_literal_id {
@@ -362,7 +362,7 @@ impl LiteralLifting {
                     if !literals.is_empty() {
                         let input_arity = input.arity();
                         for expr in exprs.iter_mut() {
-                            expr.visit_mut(&mut |e| {
+                            expr.visit_mut_post(&mut |e| {
                                 if let MirScalarExpr::Column(c) = e {
                                     if *c >= input_arity {
                                         *e = literals[*c - input_arity].clone();
@@ -388,7 +388,7 @@ impl LiteralLifting {
                         // in predicates and then lift the `map` around the filter.
                         let input_arity = input.arity();
                         for expr in predicates.iter_mut() {
-                            expr.visit_mut(&mut |e| {
+                            expr.visit_mut_post(&mut |e| {
                                 if let MirScalarExpr::Column(c) = e {
                                     if *c >= input_arity {
                                         *e = literals[*c - input_arity].clone();
@@ -441,7 +441,7 @@ impl LiteralLifting {
                         let new_input_mapper = JoinInputMapper::new(inputs);
                         for equivalence in equivalences.iter_mut() {
                             for expr in equivalence.iter_mut() {
-                                expr.visit_mut(&mut |e| {
+                                expr.visit_mut_post(&mut |e| {
                                     if let MirScalarExpr::Column(c) = e {
                                         let (col, input) = old_input_mapper.map_column_to_local(*c);
                                         if col >= new_input_mapper.input_arity(input) {
@@ -499,7 +499,7 @@ impl LiteralLifting {
                         let input_arity = input.arity();
                         // Inline literals into group key expressions.
                         for expr in group_key.iter_mut() {
-                            expr.visit_mut(&mut |e| {
+                            expr.visit_mut_post(&mut |e| {
                                 if let MirScalarExpr::Column(c) = e {
                                     if *c >= input_arity {
                                         *e = literals[*c - input_arity].clone();
@@ -509,7 +509,7 @@ impl LiteralLifting {
                         }
                         // Inline literals into aggregate value selector expressions.
                         for aggr in aggregates.iter_mut() {
-                            aggr.expr.visit_mut(&mut |e| {
+                            aggr.expr.visit_mut_post(&mut |e| {
                                 if let MirScalarExpr::Column(c) = e {
                                     if *c >= input_arity {
                                         *e = literals[*c - input_arity].clone();
@@ -671,7 +671,7 @@ impl LiteralLifting {
                         let input_arity = input.arity();
                         for key in keys.iter_mut() {
                             for expr in key.iter_mut() {
-                                expr.visit_mut(&mut |e| {
+                                expr.visit_mut_post(&mut |e| {
                                     if let MirScalarExpr::Column(c) = e {
                                         if *c >= input_arity {
                                             *e = literals[*c - input_arity].clone();

--- a/src/transform/src/nonnullable.rs
+++ b/src/transform/src/nonnullable.rs
@@ -80,7 +80,7 @@ impl NonNullable {
 /// True if the expression contains a "is null" test.
 fn scalar_contains_isnull(expr: &MirScalarExpr) -> bool {
     let mut result = false;
-    expr.visit(&mut |e| {
+    expr.visit_post(&mut |e| {
         if let MirScalarExpr::CallUnary {
             func: UnaryFunc::IsNull(func::IsNull),
             ..
@@ -95,7 +95,7 @@ fn scalar_contains_isnull(expr: &MirScalarExpr) -> bool {
 /// Transformations to scalar functions, based on nonnullability of columns.
 fn scalar_nonnullable(expr: &mut MirScalarExpr, metadata: &RelationType) {
     // Tests for null can be replaced by "false" for non-nullable columns.
-    expr.visit_mut(&mut |e| {
+    expr.visit_mut_post(&mut |e| {
         if let MirScalarExpr::CallUnary {
             func: UnaryFunc::IsNull(func::IsNull),
             expr,

--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -317,7 +317,7 @@ impl PredicatePushdown {
                                 if !predicate.is_literal_err() || all_errors {
                                     let mut supported = true;
                                     let mut new_predicate = predicate.clone();
-                                    new_predicate.visit_mut(&mut |e| {
+                                    new_predicate.visit_mut_post(&mut |e| {
                                         if let MirScalarExpr::Column(c) = e {
                                             if *c >= group_key.len() {
                                                 supported = false;
@@ -325,7 +325,7 @@ impl PredicatePushdown {
                                         }
                                     });
                                     if supported {
-                                        new_predicate.visit_mut(&mut |e| {
+                                        new_predicate.visit_mut_post(&mut |e| {
                                             if let MirScalarExpr::Column(i) = e {
                                                 *e = group_key[*i].clone();
                                             }
@@ -762,7 +762,7 @@ impl PredicatePushdown {
                         || PredicatePushdown::can_inline(&scalars[*c - input_arity], input_arity)
                 })
             {
-                predicate.visit_mut(&mut |e| {
+                predicate.visit_mut_post(&mut |e| {
                     if let MirScalarExpr::Column(c) = e {
                         // NB: this inlining would be invalid if can_inline did not
                         // verify that scalars[*c - input_arity] referenced only

--- a/src/transform/src/reduction_pushdown.rs
+++ b/src/transform/src/reduction_pushdown.rs
@@ -51,7 +51,7 @@ impl ReductionPushdown {
                 let mut scalars = scalars.clone();
                 for index in 0..scalars.len() {
                     let (lower, upper) = scalars.split_at_mut(index);
-                    upper[0].visit_mut(&mut |e| {
+                    upper[0].visit_mut_post(&mut |e| {
                         if let expr::MirScalarExpr::Column(c) = e {
                             if *c >= arity {
                                 *e = lower[*c - arity].clone();
@@ -60,7 +60,7 @@ impl ReductionPushdown {
                     });
                 }
                 for key in group_key.iter_mut() {
-                    key.visit_mut(&mut |e| {
+                    key.visit_mut_post(&mut |e| {
                         if let expr::MirScalarExpr::Column(c) = e {
                             if *c >= arity {
                                 *e = scalars[*c - arity].clone();
@@ -69,7 +69,7 @@ impl ReductionPushdown {
                     });
                 }
                 for agg in aggregates.iter_mut() {
-                    agg.expr.visit_mut(&mut |e| {
+                    agg.expr.visit_mut_post(&mut |e| {
                         if let expr::MirScalarExpr::Column(c) = e {
                             if *c >= arity {
                                 *e = scalars[*c - arity].clone();


### PR DESCRIPTION
<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

Resolve fast follow-ups after #9000.

### Motivation


- This PR refactors existing code. 
  - Resolves #9331 (see the issue description for details).
  - Resolves #9332 (see the issue description for details).
- This PR fixes a recognized bug. 
  - Fixes #8599.

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug. [Link to issue.]

  * This PR adds a known-desirable feature. [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

### Tips for reviewer

The commits are assigned to issues as follows

- Refactorings for [#9332](#9332) (reviewer @asenac)
  - [expr: make `MirScalarExpr::*visit*` method names consistent](https://github.com/MaterializeInc/materialize/pull/9341/commits/4ece5b3b6)
  - [expr: make recursive `MirScalarExpr::*visit*` methods stack safe](https://github.com/MaterializeInc/materialize/pull/9341/commits/a1958c2db)
  - [expr: align visitor logic in `MirScalarExpr*` with `MirRelationExpr`](https://github.com/MaterializeInc/materialize/pull/9341/commits/397bc0fe9)
  - [expr: remove panics from `MirRelationExprVisitor::visit_*`](https://github.com/MaterializeInc/materialize/pull/9341/commits/cb52e81d3)
- Refactorings for [#9331](#9331) (reviewer @sploiselle)
  - [coord: fix `optimize_dataflow` call in `Coordinator::finalize_dataflow`](https://github.com/MaterializeInc/materialize/pull/9341/commits/548e2c199)
- Fix for [#8599](#8599) (reviewer @asenac)
  - [coord: make `DataflowBuilder::import_into_dataflow` stack safe](https://github.com/MaterializeInc/materialize/pull/9341/commits/0ad28128e)

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
