### PR TITLE
sql: full support for `\dt <pattern>`

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -107,12 +107,17 @@ List new features before bug fixes.
 
 - Prevent overflow on operations combining [`timestamp`] and [`interval`].
 
-- Support explicit reference to the default collation (`<expr> COLLATE pg_catalog.default`).
-  Other collations are not yet supported.
-
 - Support `ROWS FROM` in `FROM` clauses.
 
-- Added support for `OPERATOR(<schema>.<op>)`. Schema can either be omitted or must be `pg_catalog`.
+- Improve PostgreSQL compatibility:
+
+  - Added support for `OPERATOR(<schema>.<op>)`. Schema can either be omitted or must be `pg_catalog`.
+
+  - Support explicit reference to the default collation (`<expr> COLLATE pg_catalog.default`).
+      Other collations are not yet supported.
+
+  Together these changes enable the `\dt <pattern>` command
+  in the [psql terminal](/connect/cli).
 
 {{% version-header v0.10.0 %}}
 

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -546,3 +546,27 @@ mz_peek_durations
 mz_perf_peek_durations_aggregates
 mz_perf_peek_durations_bucket
 mz_perf_peek_durations_core
+
+# Create a second schema with the same table name as above
+> CREATE SCHEMA tester2
+
+> CREATE TABLE tester2.test_table (a int)
+
+$ psql-execute command="\dt tester.*"
+\          List of relations
+ Schema |    Name    | Type  | Owner
+--------+------------+-------+-------
+ tester | test_table | table |
+
+$ psql-execute command="\dt tester.test_table"
+\          List of relations
+ Schema |    Name    | Type  | Owner
+--------+------------+-------+-------
+ tester | test_table | table |
+
+$ psql-execute command="\dt *.test_table"
+\          List of relations
+ Schema  |    Name    | Type  | Owner
+---------+------------+-------+-------
+ tester  | test_table | table |
+ tester2 | test_table | table |


### PR DESCRIPTION
This is the final PR in a chain of changes to support `\dt <pattern>`.
- #9255
- #9280
- #9339

Add a test to validate the command.