### PR TITLE
testdrive: Provide additional control over the retry policy

### DIFF
--- a/doc/developer/testdrive.md
+++ b/doc/developer/testdrive.md
@@ -138,7 +138,7 @@ To run a test against the actual S3/SQS service at AWS:
 ```
 export AWS_ACCESS_KEY_ID=XXX
 export AWS_SECRET_ACCESS_KEY=YYY
-target/release/testdrive --aws-region=eu-central-1 --default-timeout=600  test/testdrive/disabled/s3-sqs-notifications.td
+target/release/testdrive --aws-region=eu-central-1 --default-timeout=600s test/testdrive/disabled/s3-sqs-notifications.td
 ```
 
 # Creating tests
@@ -165,9 +165,17 @@ The `testdrive` binary accepts the following command-line options. They are usua
 
 ## Default timeout
 
-####  `--default-timeout <default-timeout>`
+#### `--default-timeout <default-timeout>`
 
-Default timeout in seconds [default: 10]. A timeout at least that long will be applied to all operations.
+Default timeout as a Duration string [default: "10s"]. A timeout at least that long will be applied to all operations.
+
+#### `--initial-backoff <initial-backoff>`
+
+Specifies the initial backoff interval that will be applied as testdrive retries queries. Default is "50ms".
+
+#### `--backoff-factor <backoff-factor>`
+
+Specifies the backoff factor that will be applied to increase the backoff interval between retries. Default is 1.5.
 
 ## Interfacing with services
 

--- a/misc/python/materialize/mzcompose.py
+++ b/misc/python/materialize/mzcompose.py
@@ -1103,7 +1103,7 @@ class Testdrive(PythonService):
         name: str = "testdrive-svc",
         mzbuild: str = "testdrive",
         no_reset: bool = False,
-        default_timeout: int = 30,
+        default_timeout: str = "30s",
         validate_catalog: bool = True,
         entrypoint: Optional[List[str]] = None,
         shell_eval: Optional[bool] = False,

--- a/src/ore/src/retry.rs
+++ b/src/ore/src/retry.rs
@@ -107,9 +107,6 @@ impl Retry {
     /// The initial backoff is the amount of time to wait if the first try
     /// fails.
     pub fn initial_backoff(mut self, initial_backoff: Duration) -> Self {
-        if initial_backoff == Duration::from_secs(0) {
-            panic!("initial backoff duration must be greater than zero");
-        }
         self.initial_backoff = initial_backoff;
         self
     }

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -86,6 +86,13 @@ pub struct Config {
     pub ci_output: bool,
     /// The default timeout to use for any operation that is retried.
     pub default_timeout: Duration,
+
+    /// Starting backoff value to use when retrying
+    pub initial_backoff: Duration,
+
+    /// Backoff factor to use when retrying
+    pub backoff_factor: f64,
+
     /// A random number to distinguish each run of a testdrive script.
     pub seed: Option<u32>,
     /// Force the use of a specific temporary directory
@@ -117,6 +124,8 @@ pub struct State {
     sqs_client: SqsClient,
     sqs_queues_created: BTreeSet<String>,
     default_timeout: Duration,
+    initial_backoff: Duration,
+    backoff_factor: f64,
     postgres_clients: HashMap<String, tokio_postgres::Client>,
     sql_server_clients:
         HashMap<String, tiberius::Client<tokio_util::compat::Compat<tokio::net::TcpStream>>>,
@@ -125,6 +134,8 @@ pub struct State {
 #[derive(Clone)]
 pub struct Context {
     timeout: Duration,
+    initial_backoff: Duration,
+    backoff_factor: f64,
     regex: Option<Regex>,
     regex_replacement: String,
 }
@@ -327,6 +338,8 @@ pub async fn build(cmds: Vec<PosCommand>, state: &State) -> Result<Vec<PosAction
 
     let mut context = Context {
         timeout: state.default_timeout,
+        initial_backoff: state.initial_backoff,
+        backoff_factor: state.backoff_factor,
         regex: None,
         regex_replacement: DEFAULT_REGEX_REPLACEMENT.to_string(),
     };
@@ -750,6 +763,8 @@ pub async fn create_state(
         sqs_client,
         sqs_queues_created: BTreeSet::new(),
         default_timeout: config.default_timeout,
+        initial_backoff: config.initial_backoff,
+        backoff_factor: config.backoff_factor,
         postgres_clients: HashMap::new(),
         sql_server_clients: HashMap::new(),
     };

--- a/src/testdrive/src/action/sql.rs
+++ b/src/testdrive/src/action/sql.rs
@@ -11,7 +11,7 @@ use std::ascii;
 use std::error::Error;
 use std::fmt::{self, Write as _};
 use std::io::{self, Write};
-use std::time::Duration;
+use std::time::SystemTime;
 
 use async_trait::async_trait;
 use md5::{Digest, Md5};
@@ -128,8 +128,8 @@ impl Action for SqlAction {
 
         match should_retry {
             true => Retry::default()
-                .initial_backoff(Duration::from_millis(50))
-                .factor(1.5)
+                .initial_backoff(self.context.initial_backoff)
+                .factor(self.context.backoff_factor)
                 .max_duration(self.context.timeout),
             false => Retry::default().max_tries(1),
         }
@@ -139,7 +139,13 @@ impl Action for SqlAction {
                     if retry_state.i != 0 {
                         println!();
                     }
-                    println!("rows match; continuing");
+                    println!(
+                        "rows match; continuing at ts {}",
+                        SystemTime::now()
+                            .duration_since(SystemTime::UNIX_EPOCH)
+                            .unwrap()
+                            .as_secs_f64()
+                    );
                     Ok(())
                 }
                 Err(e) => {
@@ -147,8 +153,10 @@ impl Action for SqlAction {
                         print!("rows didn't match; sleeping to see if dataflow catches up");
                     }
                     if let Some(backoff) = retry_state.next_backoff {
-                        print!(" {:.0?}", backoff);
-                        io::stdout().flush().unwrap();
+                        if !backoff.is_zero() {
+                            print!(" {:.0?}", backoff);
+                            io::stdout().flush().unwrap();
+                        }
                     } else {
                         println!();
                     }
@@ -354,8 +362,8 @@ impl Action for FailSqlAction {
 
         match should_retry {
             true => Retry::default()
-                .initial_backoff(Duration::from_millis(50))
-                .factor(1.5)
+                .initial_backoff(self.context.initial_backoff)
+                .factor(self.context.backoff_factor)
                 .max_duration(self.context.timeout),
             false => Retry::default().max_tries(1),
         }.retry(|retry_state| async move {

--- a/test/kafka-matrix/mzcompose.yml
+++ b/test/kafka-matrix/mzcompose.yml
@@ -121,7 +121,7 @@ services:
         --schema-registry-url=http://schema-registry:8081
         --materialized-url=postgres://materialize@materialized:6875
         --validate-catalog=/share/mzdata/catalog
-        --default-timeout=30
+        --default-timeout=30s
         $$*
       - bash
     environment:

--- a/test/kafka-multi-broker/mzcompose.yml
+++ b/test/kafka-multi-broker/mzcompose.yml
@@ -60,7 +60,7 @@ services:
         testdrive
         --seed=1
         --kafka-option acks=all
-        --default-timeout=300
+        --default-timeout=300s
         --schema-registry-url=http://schema-registry:8081
         --materialized-url=postgres://materialize@materialized:6875
         $$*

--- a/test/pg-cdc-resumption/mzcompose.yml
+++ b/test/pg-cdc-resumption/mzcompose.yml
@@ -182,7 +182,7 @@ services:
         testdrive
         --materialized-url=postgres://materialize@materialized:6875
         --max-errors=1
-        --default-timeout=60
+        --default-timeout=60s
         $$*
       - bash
     volumes:

--- a/test/s3-resumption/mzworkflows.py
+++ b/test/s3-resumption/mzworkflows.py
@@ -24,7 +24,7 @@ daemons = [
     Toxiproxy(),
 ]
 
-services = [*daemons, Testdrive(default_timeout=600)]
+services = [*daemons, Testdrive(default_timeout="600s")]
 
 #
 # Test the S3 resumption logic by first instructing Toxiproxy to drop a connection


### PR DESCRIPTION
- the new options --initial-backoff and --backoff-factor allow the caller
to control testdrive's retry policy
- the --default-timeout option now takes a Duration argument, to conform
with the other materialized and testdrive options.

### Motivation


  * This PR adds a feature that has not yet been specified.

This is needed to enable an experiment where testdrive is used to drive microbenchmarks -- by setting --initial-backoff to 0, one can have testdrive run a query repeatedly until it succeeds, without any delays.

Hopefully this will open the opportunity for performance numbers to be obtained right out of testdrive while taking advantage of the entire testdrive machinery around kafka-ingest, retrying of SELECTs and the like.