### PR TITLE
Abstract clients to present as a single worker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1327,6 +1327,7 @@ dependencies = [
  "enum-iterator",
  "enum-kinds",
  "expr",
+ "futures",
  "globset",
  "http",
  "interchange",

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -328,7 +328,7 @@ where
 
     /// A map from pending peeks to the queue into which responses are sent, and
     /// the IDs of workers who have responded.
-    pending_peeks: HashMap<u32, (mpsc::UnboundedSender<PeekResponse>, HashSet<usize>)>,
+    pending_peeks: HashMap<u32, mpsc::UnboundedSender<PeekResponse>>,
     /// A map from pending tails to the queue into which responses are sent.
     ///
     /// The responses have the form `Vec<Row>` but should perhaps become `TailResponse`.
@@ -393,10 +393,6 @@ impl<C> Coordinator<C>
 where
     C: dataflow_types::client::Client + 'static,
 {
-    fn num_workers(&self) -> usize {
-        self.dataflow_client.num_workers()
-    }
-
     /// Assign a timestamp for a read.
     fn get_read_ts(&mut self) -> Timestamp {
         let ts = self.get_ts();
@@ -453,14 +449,9 @@ where
         I: IntoIterator<Item = Timestamp>,
     {
         let since_updates = Rc::clone(&self.since_updates);
-        let (frontier, handle) = Frontiers::new(
-            self.num_workers(),
-            initial,
-            compaction_window_ms,
-            move |frontier| {
-                since_updates.borrow_mut().insert(id, frontier);
-            },
-        );
+        let (frontier, handle) = Frontiers::new(initial, compaction_window_ms, move |frontier| {
+            since_updates.borrow_mut().insert(id, frontier);
+        });
         let prev = self.since_handles.insert(id, handle);
         // Ensure we don't double-register ids.
         assert!(prev.is_none());
@@ -735,32 +726,19 @@ where
 
     async fn message_worker(
         &mut self,
-        dataflow_types::client::Response { worker_id, message }: dataflow_types::client::Response,
+        dataflow_types::client::Response {
+            worker_id: _,
+            message,
+        }: dataflow_types::client::Response,
     ) {
         match message {
             WorkerFeedback::PeekResponse(conn_id, response) => {
-                let (channel, workers_responded) = self
-                    .pending_peeks
-                    .get_mut(&conn_id)
-                    .expect("no more PeekResponses after closing peek channel");
-
-                // Each worker may respond only once to each peek.
-                assert!(
-                    workers_responded.insert(worker_id),
-                    "worker {} responded more than once on conn {}",
-                    worker_id,
-                    conn_id
-                );
-
-                channel
+                // We expect exactly one peek response, which we forward.
+                self.pending_peeks
+                    .remove(&conn_id)
+                    .expect("no more PeekResponses after closing peek channel")
                     .send(response)
                     .expect("Peek endpoint terminated prematurely");
-
-                // We've gotten responses from all workers, close peek
-                // channel to propagate response to those awaiting.
-                if workers_responded.len() == self.num_workers() {
-                    self.pending_peeks.remove(&conn_id);
-                };
             }
             WorkerFeedback::TailResponse(sink_id, response) => {
                 // We use an `if let` here because the peek could have been cancelled already.
@@ -1290,7 +1268,7 @@ where
     /// 1. The `upper` frontier for each source, index and sink does not go backwards with
     /// upper updates
     /// 2. `upper` never contains any times with negative multiplicity.
-    /// 3. `upper` never contains any times with multiplicity greater than `n_workers`
+    /// 3. `upper` never contains any times with multiplicity greater than `1`.
     /// 4. No updates increase the sum of all multiplicities in `upper`.
     ///
     /// Note that invariants 2 - 4 require single dimensional time, and a fixed number of
@@ -1302,7 +1280,6 @@ where
     fn validate_update_iter(
         upper: &mut MutableAntichain<Timestamp>,
         mut changes: ChangeBatch<Timestamp>,
-        num_workers: usize,
     ) -> Vec<(Timestamp, i64)> {
         let old_frontier = upper.frontier().to_owned();
 
@@ -1321,7 +1298,7 @@ where
         for (t, _) in changes.into_inner() {
             let count = upper.count_for(&t);
             assert!(count >= 0);
-            assert!(count as usize <= num_workers);
+            assert!(count as usize <= 1);
         }
 
         assert!(<_ as PartialOrder>::less_equal(
@@ -1334,9 +1311,8 @@ where
 
     /// Updates the upper frontier of a named view.
     fn update_upper(&mut self, name: &GlobalId, changes: ChangeBatch<Timestamp>) {
-        let num_workers = self.num_workers();
         if let Some(index_state) = self.indexes.get_mut(name) {
-            let changes = Self::validate_update_iter(&mut index_state.upper, changes, num_workers);
+            let changes = Self::validate_update_iter(&mut index_state.upper, changes);
 
             if !changes.is_empty() {
                 // Advance the compaction frontier to trail the new frontier.
@@ -1368,7 +1344,7 @@ where
                 }
             }
         } else if let Some(source_state) = self.sources.get_mut(name) {
-            let changes = Self::validate_update_iter(&mut source_state.upper, changes, num_workers);
+            let changes = Self::validate_update_iter(&mut source_state.upper, changes);
 
             if !changes.is_empty() {
                 if let Some(compaction_window_ms) = source_state.compaction_window_ms {
@@ -1385,7 +1361,7 @@ where
             }
         } else if let Some(sink_state) = self.sink_writes.get_mut(name) {
             // Only one dataflow worker should give updates for sinks
-            let changes = Self::validate_update_iter(&mut sink_state.frontier, changes, 1);
+            let changes = Self::validate_update_iter(&mut sink_state.frontier, changes);
 
             if !changes.is_empty() {
                 sink_state.advance_source_handles();
@@ -4917,8 +4893,7 @@ pub mod fast_path_peek {
 
             // The peek is ready to go for both cases, fast and non-fast.
             // Stash the response mechanism, and broadcast dataflow construction.
-            self.pending_peeks
-                .insert(conn_id, (rows_tx, std::collections::HashSet::new()));
+            self.pending_peeks.insert(conn_id, rows_tx);
             self.broadcast(peek_command).await;
 
             use dataflow_types::PeekResponse;

--- a/src/coord/src/coord/arrangement_state.rs
+++ b/src/coord/src/coord/arrangement_state.rs
@@ -124,10 +124,9 @@ pub struct Frontiers<T: Timestamp> {
 }
 
 impl<T: Timestamp + Copy> Frontiers<T> {
-    /// Creates an empty index state from a number of workers and a function to run
-    /// when the since changes. Returns the initial since handle.
+    /// Creates an empty index state from a function to run when the since changes.
+    /// Returns the initial since handle.
     pub fn new<I, F>(
-        workers: usize,
         initial: I,
         compaction_window_ms: Option<T>,
         since_action: F,
@@ -139,7 +138,7 @@ impl<T: Timestamp + Copy> Frontiers<T> {
         let mut upper = MutableAntichain::new();
         // Upper must always start at minimum ("0"), even if we initialize since to
         // something in advance of it.
-        upper.update_iter(Some((T::minimum(), workers as i64)));
+        upper.update_iter(Some((T::minimum(), 1)));
         let durability = upper.clone();
         let frontier = Self {
             upper,
@@ -222,7 +221,7 @@ mod tests {
     fn test_frontiers_action() {
         let expect = Rc::new(RefCell::new(Antichain::from_elem(0)));
         let inner = Rc::clone(&expect);
-        let (f, initial) = Frontiers::new(1, Some(0), None, move |since| {
+        let (f, initial) = Frontiers::new(Some(0), None, move |since| {
             assert_eq!(*inner.borrow(), since);
         });
         // Adding 5 should not change the since.

--- a/src/coordtest/src/lib.rs
+++ b/src/coordtest/src/lib.rs
@@ -565,10 +565,6 @@ impl<C> dataflow_types::client::Client for InterceptingDataflowClient<C>
 where
     C: dataflow_types::client::Client,
 {
-    fn num_workers(&self) -> usize {
-        1
-    }
-
     async fn send(&mut self, cmd: dataflow_types::client::Command) {
         self.inner.lock().await.send(cmd).await
     }

--- a/src/coordtest/src/lib.rs
+++ b/src/coordtest/src/lib.rs
@@ -74,7 +74,6 @@ use tokio::sync::Mutex as TokioMutex;
 use build_info::DUMMY_BUILD_INFO;
 use coord::session::{EndTransactionAction, Session};
 use coord::{ExecuteResponse, PersistConfig, SessionClient, StartupResponse};
-use dataflow_types::client::WorkerFeedback;
 use dataflow_types::PeekResponse;
 use expr::GlobalId;
 use ore::metrics::MetricsRegistry;
@@ -227,16 +226,13 @@ impl CoordTest {
         let mut to_queue = vec![];
         for mut msg in self.queued_feedback.drain(..) {
             // Filter out requested ids.
-            if let WorkerFeedback::FrontierUppers(uppers) = &mut msg.message {
+            if let dataflow_types::client::Response::FrontierUppers(uppers) = &mut msg {
                 // Requeue excluded uppers so future wait-sql directives don't always have to
                 // specify the same exclude list forever.
                 let mut requeue = uppers.clone();
                 requeue.retain(|(id, _data)| exclude_uppers.contains(id));
                 if !requeue.is_empty() {
-                    to_queue.push(dataflow_types::client::Response {
-                        worker_id: msg.worker_id,
-                        message: WorkerFeedback::FrontierUppers(requeue),
-                    });
+                    to_queue.push(dataflow_types::client::Response::FrontierUppers(requeue));
                 }
                 uppers.retain(|(id, _data)| !exclude_uppers.contains(id));
             }
@@ -267,7 +263,7 @@ impl CoordTest {
         let mut to_send = vec![];
         let mut to_queue = vec![];
         for msg in self.queued_feedback.drain(..) {
-            if let WorkerFeedback::PeekResponse(..) = msg.message {
+            if let dataflow_types::client::Response::PeekResponse(..) = msg {
                 to_send.push(msg);
             } else {
                 to_queue.push(msg);
@@ -497,11 +493,9 @@ pub async fn run_test(mut tf: datadriven::TestFile) -> datadriven::TestFile {
                         batch.update(ts, 1);
                         updates.push((id, batch));
                     }
-                    ct.dataflow_client
-                        .forward_response(dataflow_types::client::Response {
-                            worker_id: 0,
-                            message: WorkerFeedback::FrontierUppers(updates),
-                        });
+                    ct.dataflow_client.forward_response(
+                        dataflow_types::client::Response::FrontierUppers(updates),
+                    );
                     "".into()
                 }
                 "inc-timestamp" => {

--- a/src/coordtest/src/lib.rs
+++ b/src/coordtest/src/lib.rs
@@ -46,7 +46,7 @@
 //!   session contained the string `<TEMP>`, it will be replaced with a
 //!   temporary directory.
 //! - `update-upper`: Sends a batch of
-//!   [`FrontierUppers`](dataflow_types::client::WorkerFeedback::FrontierUppers) to the
+//!   [`FrontierUppers`](dataflow_types::client::Response::FrontierUppers) to the
 //!   Coordinator. Input is one update per line of the format
 //!   `database.schema.item N` where N is some numeric timestamp. No output.
 //! - `inc-timestamp`: Increments the timestamp by number in the input. No

--- a/src/dataflow-types/Cargo.toml
+++ b/src/dataflow-types/Cargo.toml
@@ -16,6 +16,7 @@ crossbeam-channel = "0.5.1"
 enum-iterator = "0.7.0"
 enum-kinds = "0.5.1"
 expr = { path = "../expr" }
+futures = "0.3.17"
 globset = { version = "0.4.8", features = ["serde1"] }
 interchange = { path = "../interchange" }
 persist-types = { path = "../persist-types" }

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -452,6 +452,7 @@ pub mod partitioned {
     #[async_trait::async_trait]
     impl<C: Client> Client for Partitioned<C> {
         async fn send(&mut self, cmd: Command) {
+            self.state.observe_command(&cmd);
             let cmd_parts = cmd.partition_among(self.shards.len());
             for (shard, cmd_part) in self.shards.iter_mut().zip(cmd_parts) {
                 shard.send(cmd_part).await;
@@ -501,7 +502,7 @@ pub mod partitioned {
         /// Observes commands that move past, and prepares state for responses.
         ///
         /// In particular, this method installs and removes upper frontier maintenance.
-        pub fn observe_command(&mut self, command: Command) {
+        pub fn observe_command(&mut self, command: &Command) {
             // Temporary storage for identifiers to add to and remove from frontier tracking.
             let mut start = Vec::new();
             let mut cease = Vec::new();

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -515,11 +515,13 @@ pub mod partitioned {
                     self.parts as i64,
                 )));
                 let previous = self.uppers.insert(id, frontier);
-                assert!(previous.is_none());
+                assert!(previous.is_none(), "Protocol error: starting frontier tracking for already present identifier {:?} due to command {:?}", id, command);
             }
             for id in cease.into_iter() {
                 let previous = self.uppers.remove(&id);
-                assert!(previous.is_some());
+                if previous.is_none() {
+                    log::debug!("Protocol error: ceasing frontier tracking for absent identifier {:?} due to command {:?}", id, command);
+                }
             }
         }
 

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -13,7 +13,6 @@
 // for each variant of the `Command` enum, each of which are documented.
 // #![warn(missing_docs)]
 
-use async_trait::async_trait;
 use enum_iterator::IntoEnumIterator;
 use enum_kinds::EnumKind;
 use num_enum::IntoPrimitive;
@@ -210,6 +209,47 @@ impl Command {
             }
         }
     }
+
+    /// Indicates which global ids should start and cease frontier tracking.
+    ///
+    /// Identifiers added to `start` will install frontier tracking, and indentifiers
+    /// added to `cease` will uninstall frontier tracking.
+    pub fn frontier_tracking(&self, start: &mut Vec<GlobalId>, cease: &mut Vec<GlobalId>) {
+        match self {
+            Command::CreateDataflows(dataflows) => {
+                for dataflow in dataflows.iter() {
+                    for (sink_id, _) in dataflow.sink_exports.iter() {
+                        start.push(*sink_id)
+                    }
+                    for (index_id, _, _) in dataflow.index_exports.iter() {
+                        start.push(*index_id);
+                    }
+                }
+            }
+            Command::DropIndexes(index_ids) => {
+                for id in index_ids.iter() {
+                    cease.push(*id);
+                }
+            }
+            Command::DropSinks(sink_ids) => {
+                for id in sink_ids.iter() {
+                    cease.push(*id);
+                }
+            }
+            Command::AddSourceTimestamping { id, .. } => {
+                start.push(*id);
+            }
+            Command::DropSourceTimestamping { id } => {
+                cease.push(*id);
+            }
+            Command::EnableLogging(logging_config) => {
+                start.extend(logging_config.log_identifiers());
+            }
+            _ => {
+                // Other commands have no known impact on frontier tracking.
+            }
+        }
+    }
 }
 
 impl CommandKind {
@@ -268,10 +308,16 @@ pub enum WorkerFeedback {
 }
 
 /// A client to a running dataflow server.
-#[async_trait]
+#[async_trait::async_trait]
 pub trait Client: Send {
     /// Reports the number of dataflow workers.
-    fn num_workers(&self) -> usize;
+    ///
+    /// By default, this is one. Clients who wrap multiple workers without performing
+    /// the work of reducing their responses down to those of a single worker should
+    /// communicate that number here.
+    fn num_workers(&self) -> usize {
+        1
+    }
 
     /// Sends a command to the dataflow server.
     async fn send(&mut self, cmd: Command);
@@ -283,57 +329,295 @@ pub trait Client: Send {
     async fn recv(&mut self) -> Option<Response>;
 }
 
-/// A client to a dataflow server running in the current process.
-pub struct LocalClient {
-    feedback_rx: tokio::sync::mpsc::UnboundedReceiver<Response>,
-    worker_txs: Vec<crossbeam_channel::Sender<Command>>,
-    worker_threads: Vec<std::thread::Thread>,
+#[async_trait::async_trait]
+impl Client for Box<dyn Client> {
+    async fn send(&mut self, cmd: Command) {
+        self.send(cmd).await
+    }
+    async fn recv(&mut self) -> Option<Response> {
+        self.recv().await
+    }
 }
 
-#[async_trait]
-impl Client for LocalClient {
-    fn num_workers(&self) -> usize {
-        self.worker_txs.len()
-    }
+/// A helper struct which allows us to interpret a `Client` as a `Stream` of `Response`.
+pub struct ClientAsStream<'a, C: Client + 'a> {
+    client: &'a mut C,
+}
 
-    async fn send(&mut self, cmd: Command) {
-        log::trace!("Broadcasting dataflow command: {:?}", cmd);
-        let cmd_parts = cmd.partition_among(self.num_workers());
-        for (tx, cmd_part) in self.worker_txs.iter().zip(cmd_parts) {
-            tx.send(cmd_part)
-                .expect("worker command receiver should not drop first")
-        }
-        for thread in &self.worker_threads {
-            thread.unpark()
-        }
+use std::pin::Pin;
+use std::task::{Context, Poll};
+impl<'a, C: Client + 'a> futures::stream::Stream for ClientAsStream<'a, C> {
+    type Item = Response;
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        use futures::Future;
+        Pin::new(&mut self.client.recv()).poll(cx)
     }
+}
 
-    async fn recv(&mut self) -> Option<Response> {
-        return self.feedback_rx.recv().await;
-    }
+/// A convenience type for compatibility.
+pub struct LocalClient {
+    client: partitioned::Partitioned<process_local::ProcessLocal>,
 }
 
 impl LocalClient {
-    /// Create a new instance of [LocalClient] from its parts.
     pub fn new(
-        feedback_rx: tokio::sync::mpsc::UnboundedReceiver<Response>,
+        feedback_rxs: Vec<tokio::sync::mpsc::UnboundedReceiver<Response>>,
         worker_txs: Vec<crossbeam_channel::Sender<Command>>,
         worker_threads: Vec<std::thread::Thread>,
     ) -> Self {
-        Self {
-            feedback_rx,
-            worker_txs,
-            worker_threads,
+        assert_eq!(feedback_rxs.len(), worker_threads.len());
+        assert_eq!(worker_txs.len(), worker_threads.len());
+        // assemble a list of process-local clients.
+        let mut locals = Vec::with_capacity(worker_txs.len());
+        for ((rx, tx), thread) in feedback_rxs.into_iter().zip(worker_txs).zip(worker_threads) {
+            locals.push(process_local::ProcessLocal::new(rx, tx, thread));
+        }
+        LocalClient {
+            client: partitioned::Partitioned::new(locals),
         }
     }
 }
 
-// We implement `Drop` so that we can wake each of the workers and have them notice the drop.
-impl Drop for LocalClient {
-    fn drop(&mut self) {
-        self.worker_txs.clear();
-        for thread in &self.worker_threads {
-            thread.unpark()
+#[async_trait::async_trait]
+impl Client for LocalClient {
+    async fn send(&mut self, cmd: Command) {
+        log::trace!("SEND dataflow command: {:?}", cmd);
+        self.client.send(cmd).await
+    }
+    async fn recv(&mut self) -> Option<Response> {
+        let response = self.client.recv().await;
+        log::trace!("RECV dataflow response: {:?}", response);
+        response
+    }
+}
+
+/// Clients whose implementation is partitioned across a set of subclients (e.g. timely workers).
+pub mod partitioned {
+
+    use std::collections::HashMap;
+
+    use expr::GlobalId;
+    use repr::Timestamp;
+
+    use super::Client;
+    use super::{ClientAsStream, Command, PeekResponse, Response, WorkerFeedback};
+
+    /// A client whose implementation is sharded across a number of other clients.
+    ///
+    /// Such a client needs to broadcast (partitioned) commands to all of its clients,
+    /// and await responses from each of the client shards before it can respond.
+    pub struct Partitioned<C: Client> {
+        shards: Vec<C>,
+        state: PartitionedClientState,
+    }
+
+    impl<C: Client> Partitioned<C> {
+        /// Create a client partitioned across multiple client shards.
+        pub fn new(shards: Vec<C>) -> Self {
+            Self {
+                state: PartitionedClientState::new(shards.len()),
+                shards,
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl<C: Client> Client for Partitioned<C> {
+        async fn send(&mut self, cmd: Command) {
+            let cmd_parts = cmd.partition_among(self.shards.len());
+            for (shard, cmd_part) in self.shards.iter_mut().zip(cmd_parts) {
+                shard.send(cmd_part).await;
+            }
+        }
+
+        async fn recv(&mut self) -> Option<Response> {
+            use futures::StreamExt;
+            let mut stream = futures::stream::select_all(
+                self.shards
+                    .iter_mut()
+                    .map(|client| ClientAsStream { client }),
+            );
+            while let Some(response) = stream.next().await {
+                let message = self.state.absorb_response(response);
+                if let Some(message) = message {
+                    return Some(Response {
+                        worker_id: 0,
+                        message,
+                    });
+                }
+            }
+            // Indicate completion of the communication.
+            None
+        }
+    }
+
+    use timely::progress::{frontier::MutableAntichain, ChangeBatch};
+
+    /// Maintained state for sharded dataflow clients.
+    ///
+    /// This helper type unifies the responses of multiple partitioned
+    /// workers in order to present as a single worker.
+    pub struct PartitionedClientState {
+        /// Upper frontiers for sources and indexes.
+        uppers: HashMap<GlobalId, MutableAntichain<Timestamp>>,
+        /// Pending responses for a peek; returnable once all are available.
+        peek_responses: HashMap<u32, HashMap<usize, PeekResponse>>,
+        /// Number of parts the state machine represents.
+        parts: usize,
+    }
+
+    impl PartitionedClientState {
+        /// Instantiates a new client state machine wrapping a number of parts.
+        pub fn new(parts: usize) -> Self {
+            Self {
+                uppers: Default::default(),
+                peek_responses: Default::default(),
+                parts,
+            }
+        }
+
+        /// Observes commands that move past, and prepares state for responses.
+        ///
+        /// In particular, this method installs and removes upper frontier maintenance.
+        pub fn observe_command(&mut self, command: Command) {
+            // Temporary storage for identifiers to add to and remove from frontier tracking.
+            let mut start = Vec::new();
+            let mut cease = Vec::new();
+            command.frontier_tracking(&mut start, &mut cease);
+            // Apply the determined effects of the command to `self.uppers`.
+            for id in start.into_iter() {
+                let mut frontier = timely::progress::frontier::MutableAntichain::new();
+                frontier.update_iter(Some((
+                    <Timestamp as timely::progress::Timestamp>::minimum(),
+                    self.parts as i64,
+                )));
+                let previous = self.uppers.insert(id, frontier);
+                assert!(previous.is_none());
+            }
+            for id in cease.into_iter() {
+                let previous = self.uppers.remove(&id);
+                assert!(previous.is_some());
+            }
+        }
+
+        /// Absorbs a response, and produces response that should be emitted.
+        pub fn absorb_response(
+            &mut self,
+            Response { worker_id, message }: Response,
+        ) -> Option<WorkerFeedback> {
+            match message {
+                WorkerFeedback::FrontierUppers(mut list) => {
+                    // Fold updates into the maintained antichain, and report
+                    // any net changes to the minimal antichain itself.
+                    let mut reactions = ChangeBatch::new();
+                    for (id, changes) in list.iter_mut() {
+                        // We may receive changes to identifiers that are no longer tracked;
+                        // do not worry about them in that case (a benign race condition).
+                        if let Some(frontier) = self.uppers.get_mut(id) {
+                            for (time, diff) in frontier.update_iter(changes.drain()) {
+                                reactions.update(time, diff);
+                            }
+                            std::mem::swap(changes, &mut reactions);
+                        } else {
+                            changes.clear();
+                        }
+                    }
+                    // TODO: The following line would be great, but is not permitted by `list.retain()`.
+                    // list.retain_mut(|(_, changes)| !changes.is_empty());
+                    if !list.is_empty() {
+                        Some(WorkerFeedback::FrontierUppers(list))
+                    } else {
+                        None
+                    }
+                }
+                WorkerFeedback::PeekResponse(connection, response) => {
+                    // Incorporate new peek responses; awaiting all responses.
+                    let entry = self
+                        .peek_responses
+                        .entry(connection)
+                        .or_insert_with(|| Default::default());
+                    let novel = entry.insert(worker_id, response);
+                    assert!(novel.is_none(), "Duplicate peek response");
+                    // We may be ready to respond.
+                    if entry.len() == self.parts {
+                        let mut response = PeekResponse::Rows(Vec::new());
+                        for (_part, r) in std::mem::take(entry).into_iter() {
+                            response = match (response, r) {
+                                (_, PeekResponse::Canceled) => PeekResponse::Canceled,
+                                (PeekResponse::Canceled, _) => PeekResponse::Canceled,
+                                (_, PeekResponse::Error(e)) => PeekResponse::Error(e),
+                                (PeekResponse::Error(e), _) => PeekResponse::Error(e),
+                                (PeekResponse::Rows(mut rows), PeekResponse::Rows(r)) => {
+                                    rows.extend(r.into_iter());
+                                    PeekResponse::Rows(rows)
+                                }
+                            };
+                        }
+                        self.peek_responses.remove(&connection);
+                        Some(WorkerFeedback::PeekResponse(connection, response))
+                    } else {
+                        None
+                    }
+                }
+                message => {
+                    // TimestampBindings and TailResponses are mirrored out,
+                    // as they do not seem to contain worker-specific information.
+                    Some(message)
+                }
+            }
+        }
+    }
+}
+
+/// A client backed by a process-local timely worker thread.
+pub mod process_local {
+
+    use super::{Client, Command, Response};
+
+    /// A client to a dataflow server running in the current process.
+    pub struct ProcessLocal {
+        feedback_rx: tokio::sync::mpsc::UnboundedReceiver<Response>,
+        worker_tx: crossbeam_channel::Sender<Command>,
+        worker_thread: std::thread::Thread,
+    }
+
+    #[async_trait::async_trait]
+    impl Client for ProcessLocal {
+        async fn send(&mut self, cmd: Command) {
+            self.worker_tx
+                .send(cmd)
+                .expect("worker command receiver should not drop first");
+            self.worker_thread.unpark();
+        }
+
+        async fn recv(&mut self) -> Option<Response> {
+            self.feedback_rx.recv().await
+        }
+    }
+
+    impl ProcessLocal {
+        /// Create a new instance of [ProcessLocal] from its parts.
+        pub fn new(
+            feedback_rx: tokio::sync::mpsc::UnboundedReceiver<Response>,
+            worker_tx: crossbeam_channel::Sender<Command>,
+            worker_thread: std::thread::Thread,
+        ) -> Self {
+            Self {
+                feedback_rx,
+                worker_tx,
+                worker_thread,
+            }
+        }
+    }
+
+    // We implement `Drop` so that we can wake each of the workers and have them notice the drop.
+    impl Drop for ProcessLocal {
+        fn drop(&mut self) {
+            // Drop the worker handle.
+            let (tx, _rx) = crossbeam_channel::unbounded();
+            self.worker_tx = tx;
+            // Unpark the thread once the handle is dropped, so that it can observe the emptiness.
+            self.worker_thread.unpark();
         }
     }
 }

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -310,15 +310,6 @@ pub enum WorkerFeedback {
 /// A client to a running dataflow server.
 #[async_trait::async_trait]
 pub trait Client: Send {
-    /// Reports the number of dataflow workers.
-    ///
-    /// By default, this is one. Clients who wrap multiple workers without performing
-    /// the work of reducing their responses down to those of a single worker should
-    /// communicate that number here.
-    fn num_workers(&self) -> usize {
-        1
-    }
-
     /// Sends a command to the dataflow server.
     async fn send(&mut self, cmd: Command);
 

--- a/src/dataflow-types/src/logging.rs
+++ b/src/dataflow-types/src/logging.rs
@@ -23,6 +23,13 @@ pub struct LoggingConfig {
     pub log_logging: bool,
 }
 
+impl LoggingConfig {
+    /// Announce the identifiers the logging config will populate.
+    pub fn log_identifiers<'a>(&'a self) -> impl Iterator<Item = GlobalId> + 'a {
+        self.active_logs.values().cloned()
+    }
+}
+
 #[derive(Hash, Eq, PartialEq, Debug, Clone, Serialize, Deserialize)]
 pub enum LogVariant {
     Timely(TimelyLog),

--- a/src/dataflowd/src/lib.rs
+++ b/src/dataflowd/src/lib.rs
@@ -14,113 +14,125 @@
 
 #![deny(missing_docs)]
 
-use async_trait::async_trait;
-use futures::sink::SinkExt;
-use futures::stream::{self, SelectAll, SplitSink, SplitStream, StreamExt};
-use log::trace;
-use tokio::io::{AsyncRead, AsyncWrite};
-use tokio::net::{TcpStream, ToSocketAddrs};
-use tokio_serde::formats::Bincode;
-use tokio_util::codec::LengthDelimitedCodec;
+use dataflow_types::client::{partitioned::Partitioned, Client, Command, Response};
 
-use dataflow_types::client::{Command, Response};
-
-/// A framed connection to a dataflowd server.
-pub type Framed<C, T, U> =
-    tokio_serde::Framed<tokio_util::codec::Framed<C, LengthDelimitedCodec>, T, U, Bincode<T, U>>;
-
-/// A framed connection from the server's perspective.
-pub type FramedServer<C> = Framed<C, Command, Response>;
-
-/// A framed connection from the client's perspective.
-pub type FramedClient<C> = Framed<C, Response, Command>;
-
-fn length_delimited_codec() -> LengthDelimitedCodec {
-    // NOTE(benesch): using an unlimited maximum frame length is problematic
-    // because Tokio never shrinks its buffer. Sending or receiving one large
-    // message of size N means the client will hold on to a buffer of size
-    // N forever. We should investigate alternative transport protocols that
-    // do not have this limitation.
-    let mut codec = LengthDelimitedCodec::new();
-    codec.set_max_frame_length(usize::MAX);
-    codec
-}
-
-/// Constructs a framed connection for the server.
-pub fn framed_server<C>(conn: C) -> FramedServer<C>
-where
-    C: AsyncRead + AsyncWrite,
-{
-    tokio_serde::Framed::new(
-        tokio_util::codec::Framed::new(conn, length_delimited_codec()),
-        Bincode::default(),
-    )
-}
-
-/// Constructs a framed connection for the client.
-pub fn framed_client<C>(conn: C) -> FramedClient<C>
-where
-    C: AsyncRead + AsyncWrite,
-{
-    tokio_serde::Framed::new(
-        tokio_util::codec::Framed::new(conn, length_delimited_codec()),
-        Bincode::default(),
-    )
-}
-
-/// A client to a remote dataflow server.
+/// A convenience type for compatibility.
 pub struct RemoteClient {
-    // TODO: the client could discover the number of workers from the server.
-    num_workers: usize,
-    stream: SelectAll<SplitStream<FramedClient<TcpStream>>>,
-    sinks: Vec<SplitSink<FramedClient<TcpStream>, Command>>,
+    client: Partitioned<tcp::TcpClient>,
 }
 
 impl RemoteClient {
-    /// Connects a remote client to the specified remote dataflow server.
-    pub async fn connect(
-        num_workers: usize,
-        addrs: &[impl ToSocketAddrs],
-    ) -> Result<RemoteClient, anyhow::Error> {
-        let mut streams = vec![];
-        let mut sinks = vec![];
-        for addr in addrs {
-            let client = framed_client(TcpStream::connect(addr).await?);
-            let (sink, stream) = client.split();
-            streams.push(stream);
-            sinks.push(sink);
+    /// Construct a client backed by multiple tcp connections
+    pub async fn connect(addrs: &[impl tokio::net::ToSocketAddrs]) -> Result<Self, anyhow::Error> {
+        let mut remotes = Vec::with_capacity(addrs.len());
+        for addr in addrs.iter() {
+            remotes.push(tcp::TcpClient::connect(addr).await?);
         }
-        Ok(RemoteClient {
-            num_workers,
-            stream: stream::select_all(streams),
-            sinks,
+        Ok(Self {
+            client: Partitioned::new(remotes),
         })
     }
 }
 
-#[async_trait]
-impl dataflow_types::client::Client for RemoteClient {
-    fn num_workers(&self) -> usize {
-        self.num_workers
+#[async_trait::async_trait]
+impl Client for RemoteClient {
+    async fn send(&mut self, cmd: Command) {
+        log::trace!("Broadcasting dataflow command: {:?}", cmd);
+        self.client.send(cmd).await
+    }
+    async fn recv(&mut self) -> Option<Response> {
+        self.client.recv().await
+    }
+}
+
+/// A client to a remote dataflow server.
+pub mod tcp {
+
+    use futures::sink::SinkExt;
+    use futures::stream::StreamExt;
+    use tokio::io::{AsyncRead, AsyncWrite};
+    use tokio::net::{TcpStream, ToSocketAddrs};
+    use tokio_serde::formats::Bincode;
+    use tokio_util::codec::LengthDelimitedCodec;
+
+    use dataflow_types::client::{Command, Response};
+
+    /// A client to a remote dataflow server.
+    pub struct TcpClient {
+        connection: FramedClient<TcpStream>,
     }
 
-    async fn send(&mut self, cmd: dataflow_types::client::Command) {
-        trace!("Broadcasting dataflow command: {:?}", cmd);
-        let num_conns = self.sinks.len();
-        for (sink, cmd_part) in self.sinks.iter_mut().zip(cmd.partition_among(num_conns)) {
-            // TODO: something better than panicking.
-            sink.send(cmd_part)
-                .await
-                .expect("worker command receiver should not drop first");
+    impl TcpClient {
+        /// Connects a remote client to the specified remote dataflow server.
+        pub async fn connect(addr: impl ToSocketAddrs) -> Result<TcpClient, anyhow::Error> {
+            let connection = framed_client(TcpStream::connect(addr).await?);
+            Ok(Self { connection })
         }
     }
 
-    async fn recv(&mut self) -> Option<dataflow_types::client::Response> {
-        // TODO: something better than panicking.
-        // Attempt to read from each of `self.conns`.
-        self.stream
-            .next()
-            .await
-            .map(|x| x.expect("connection to dataflow server broken"))
+    #[async_trait::async_trait]
+    impl dataflow_types::client::Client for TcpClient {
+        async fn send(&mut self, cmd: dataflow_types::client::Command) {
+            // TODO: something better than panicking.
+            self.connection
+                .send(cmd)
+                .await
+                .expect("worker command receiver should not drop first");
+        }
+
+        async fn recv(&mut self) -> Option<dataflow_types::client::Response> {
+            // TODO: something better than panicking.
+            self.connection
+                .next()
+                .await
+                .map(|x| x.expect("connection to dataflow server broken"))
+        }
+    }
+
+    /// A framed connection to a dataflowd server.
+    pub type Framed<C, T, U> = tokio_serde::Framed<
+        tokio_util::codec::Framed<C, LengthDelimitedCodec>,
+        T,
+        U,
+        Bincode<T, U>,
+    >;
+
+    /// A framed connection from the server's perspective.
+    pub type FramedServer<C> = Framed<C, Command, Response>;
+
+    /// A framed connection from the client's perspective.
+    pub type FramedClient<C> = Framed<C, Response, Command>;
+
+    fn length_delimited_codec() -> LengthDelimitedCodec {
+        // NOTE(benesch): using an unlimited maximum frame length is problematic
+        // because Tokio never shrinks its buffer. Sending or receiving one large
+        // message of size N means the client will hold on to a buffer of size
+        // N forever. We should investigate alternative transport protocols that
+        // do not have this limitation.
+        let mut codec = LengthDelimitedCodec::new();
+        codec.set_max_frame_length(usize::MAX);
+        codec
+    }
+
+    /// Constructs a framed connection for the server.
+    pub fn framed_server<C>(conn: C) -> FramedServer<C>
+    where
+        C: AsyncRead + AsyncWrite,
+    {
+        tokio_serde::Framed::new(
+            tokio_util::codec::Framed::new(conn, length_delimited_codec()),
+            Bincode::default(),
+        )
+    }
+
+    /// Constructs a framed connection for the client.
+    pub fn framed_client<C>(conn: C) -> FramedClient<C>
+    where
+        C: AsyncRead + AsyncWrite,
+    {
+        tokio_serde::Framed::new(
+            tokio_util::codec::Framed::new(conn, length_delimited_codec()),
+            Bincode::default(),
+        )
     }
 }

--- a/src/dataflowd/src/main.rs
+++ b/src/dataflowd/src/main.rs
@@ -140,7 +140,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
     }
     let timely_config = create_timely_config(&args)?;
 
-    info!("about to bind to args.listen_addr");
+    info!("about to bind to {:?}", args.listen_addr);
     let listener = TcpListener::bind(args.listen_addr).await?;
 
     info!(
@@ -159,7 +159,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
         now: SYSTEM_TIME.clone(),
     })?;
 
-    let mut conn = dataflowd::framed_server(conn);
+    let mut conn = dataflowd::tcp::framed_server(conn);
     loop {
         select! {
             cmd = conn.try_next() => match cmd? {

--- a/src/materialized/src/bin/coordd.rs
+++ b/src/materialized/src/bin/coordd.rs
@@ -84,8 +84,8 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
         args.dataflowd_addr
     );
 
-    let dataflow_client =
-        dataflowd::RemoteClient::connect(args.workers, &args.dataflowd_addr).await?;
+    let dataflow_client = dataflowd::RemoteClient::connect(&args.dataflowd_addr).await?;
+
     let mut metrics_registry = MetricsRegistry::new();
     let (coord_handle, coord_client) = coord::serve(coord::Config {
         dataflow_client,


### PR DESCRIPTION
This PR changes the `dataflow::Client` abstraction to primarily present as wrapping a single worker. All implementors of this trait now do so, and the number `1` is reported as their number of workers.

This is done in support of abstraction boundaries that enable things like transparent rescaling, active replication, potentially other forms of reconfiguration. It also means to remove responsibility for reasoning about implementation details from users of the `Client`, namely the coordinator.

It has the defect at the moment that `mz_workers()` is exposed by the coordinator, and backed by the number it gets from the dataflow client. That ends up being `1` always, which makes this call misleading. The corresponding information is available in the introspection sources, but anyone using `mz_workers()` would be surprised by the results. There are a few related defects with `mz_workers()` that we probably want to fix (it changes across restarts, so committed data can become corrupted) but this PR 1. doesn't do that, and 2. leaves users of `mz_workers()` probably less happy than they were previously.

We could potentially fix the above by having the value captured a different way from the coordinator, rather than from the dataflow client, which leaves the above issues unfixed, but maintains the current behavior at least. Happy to look in to that before merging anything.

There is also other clean-up work that can be done, e.g. promoting `WorkerFeedback` to `Response`, as the latter only wraps the former with a worker identifier (each of the partitioned and replicated client combinators track from which of their clients responses come; that field ends up being ignored now).

### Motivation

  * This PR adds a feature that has not yet been specified.

The `Client` abstraction isn't especially gelled at the moment, but it seems likely that dataflow clients would prefer not to have to reason about the sharding/replication present in responses coming at them, and instead have a layer handle that for them. Additionally, replication is only going to make sense for heterogenous worker counts with this abstraction (e.g. transparent rescaling of worker counts, active replication between one large instance and a sharded "scale out" instance).

### Tips for reviewer

Main questions are about the appropriateness of the decision to hide this information from the client, and whether that should be made even harder (e.g. give `coord` some number on start-up, but then remove `fn num_workers()` entirely to avoid mis-use).

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
