### PR TITLE
expr: Convert more `strto*` cast functions and `numeric` functions to `sqlfunc!`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1735,6 +1735,7 @@ dependencies = [
  "sha-1",
  "sha2",
  "uncased",
+ "uuid",
 ]
 
 [[package]]

--- a/src/expr-test-util/src/lib.rs
+++ b/src/expr-test-util/src/lib.rs
@@ -15,7 +15,8 @@ use serde_json::Value;
 
 use expr::explain::ViewExplanation;
 use expr::func::{
-    CastInt16ToInt32, CastInt32ToInt64, CastInt64ToFloat64, CastInt64ToInt32, IsNull, NegInt32, Not,
+    CastInt16ToInt32, CastInt32ToInt64, CastInt64ToFloat64, CastInt64ToInt32, CastNumericToInt64,
+    IsNull, NegInt32, Not,
 };
 use expr::*;
 use lowertest::*;
@@ -45,6 +46,7 @@ gen_reflect_info_func!(
         CastInt32ToInt64,
         CastInt64ToInt32,
         CastInt64ToFloat64,
+        CastNumericToInt64,
         ColumnOrder,
         ColumnType,
         RelationType,

--- a/src/expr-test-util/src/lib.rs
+++ b/src/expr-test-util/src/lib.rs
@@ -16,7 +16,7 @@ use serde_json::Value;
 use expr::explain::ViewExplanation;
 use expr::func::{
     CastInt16ToInt32, CastInt32ToInt64, CastInt64ToFloat64, CastInt64ToInt32, CastNumericToInt64,
-    IsNull, NegInt32, Not,
+    CastStringToBool, IsNull, NegInt32, Not,
 };
 use expr::*;
 use lowertest::*;
@@ -47,6 +47,7 @@ gen_reflect_info_func!(
         CastInt64ToInt32,
         CastInt64ToFloat64,
         CastNumericToInt64,
+        CastStringToBool,
         ColumnOrder,
         ColumnType,
         RelationType,

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -33,6 +33,7 @@ serde_json = "1.0.72"
 sha-1 = "0.9.8"
 sha2 = "0.9.8"
 uncased = "0.9.6"
+uuid = "0.8.2"
 paste = "1"
 
 [dev-dependencies]

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -670,20 +670,20 @@ impl MapFilterProject {
     /// along the optimization path.
     ///
     /// ```rust
-    /// use expr::{MapFilterProject, MirScalarExpr, UnaryFunc, BinaryFunc};
+    /// use expr::{func, MapFilterProject, MirScalarExpr, UnaryFunc, BinaryFunc};
     /// // Demonstrate extraction of common expressions (here: parsing strings).
     /// let mut map_filter_project = MapFilterProject::new(5)
     ///     .map(vec![
-    ///         MirScalarExpr::column(0).call_unary(UnaryFunc::CastStringToInt64).call_binary(MirScalarExpr::column(1).call_unary(UnaryFunc::CastStringToInt64), BinaryFunc::AddInt64),
-    ///         MirScalarExpr::column(1).call_unary(UnaryFunc::CastStringToInt64).call_binary(MirScalarExpr::column(2).call_unary(UnaryFunc::CastStringToInt64), BinaryFunc::AddInt64),
+    ///         MirScalarExpr::column(0).call_unary(UnaryFunc::CastStringToInt64(func::CastStringToInt64)).call_binary(MirScalarExpr::column(1).call_unary(UnaryFunc::CastStringToInt64(func::CastStringToInt64)), BinaryFunc::AddInt64),
+    ///         MirScalarExpr::column(1).call_unary(UnaryFunc::CastStringToInt64(func::CastStringToInt64)).call_binary(MirScalarExpr::column(2).call_unary(UnaryFunc::CastStringToInt64(func::CastStringToInt64)), BinaryFunc::AddInt64),
     ///     ])
     ///     .project(vec![3,4,5,6]);
     ///
     /// let mut expected_optimized = MapFilterProject::new(5)
     ///     .map(vec![
-    ///         MirScalarExpr::column(1).call_unary(UnaryFunc::CastStringToInt64),
-    ///         MirScalarExpr::column(0).call_unary(UnaryFunc::CastStringToInt64).call_binary(MirScalarExpr::column(5), BinaryFunc::AddInt64),
-    ///         MirScalarExpr::column(5).call_binary(MirScalarExpr::column(2).call_unary(UnaryFunc::CastStringToInt64), BinaryFunc::AddInt64),
+    ///         MirScalarExpr::column(1).call_unary(UnaryFunc::CastStringToInt64(func::CastStringToInt64)),
+    ///         MirScalarExpr::column(0).call_unary(UnaryFunc::CastStringToInt64(func::CastStringToInt64)).call_binary(MirScalarExpr::column(5), BinaryFunc::AddInt64),
+    ///         MirScalarExpr::column(5).call_binary(MirScalarExpr::column(2).call_unary(UnaryFunc::CastStringToInt64(func::CastStringToInt64)), BinaryFunc::AddInt64),
     ///     ])
     ///     .project(vec![3,4,6,7]);
     ///
@@ -731,22 +731,22 @@ impl MapFilterProject {
     /// in inliniing.
     ///
     /// ```rust
-    /// use expr::{MapFilterProject, MirScalarExpr, UnaryFunc, BinaryFunc};
+    /// use expr::{func, MapFilterProject, MirScalarExpr, UnaryFunc, BinaryFunc};
     /// // Demonstrate extraction of common expressions (here: parsing strings).
     /// let mut map_filter_project = MapFilterProject::new(5)
     ///     .map(vec![
-    ///         MirScalarExpr::column(0).call_unary(UnaryFunc::CastStringToInt64).call_binary(MirScalarExpr::column(1).call_unary(UnaryFunc::CastStringToInt64), BinaryFunc::AddInt64),
-    ///         MirScalarExpr::column(1).call_unary(UnaryFunc::CastStringToInt64).call_binary(MirScalarExpr::column(2).call_unary(UnaryFunc::CastStringToInt64), BinaryFunc::AddInt64),
+    ///         MirScalarExpr::column(0).call_unary(UnaryFunc::CastStringToInt64(func::CastStringToInt64)).call_binary(MirScalarExpr::column(1).call_unary(UnaryFunc::CastStringToInt64(func::CastStringToInt64)), BinaryFunc::AddInt64),
+    ///         MirScalarExpr::column(1).call_unary(UnaryFunc::CastStringToInt64(func::CastStringToInt64)).call_binary(MirScalarExpr::column(2).call_unary(UnaryFunc::CastStringToInt64(func::CastStringToInt64)), BinaryFunc::AddInt64),
     ///     ])
     ///     .project(vec![3,4,5,6]);
     ///
     /// let mut expected_optimized = MapFilterProject::new(5)
     ///     .map(vec![
-    ///         MirScalarExpr::column(0).call_unary(UnaryFunc::CastStringToInt64),
-    ///         MirScalarExpr::column(1).call_unary(UnaryFunc::CastStringToInt64),
+    ///         MirScalarExpr::column(0).call_unary(UnaryFunc::CastStringToInt64(func::CastStringToInt64)),
+    ///         MirScalarExpr::column(1).call_unary(UnaryFunc::CastStringToInt64(func::CastStringToInt64)),
     ///         MirScalarExpr::column(5).call_binary(MirScalarExpr::column(6), BinaryFunc::AddInt64),
     ///         MirScalarExpr::column(7),
-    ///         MirScalarExpr::column(2).call_unary(UnaryFunc::CastStringToInt64),
+    ///         MirScalarExpr::column(2).call_unary(UnaryFunc::CastStringToInt64(func::CastStringToInt64)),
     ///         MirScalarExpr::column(6).call_binary(MirScalarExpr::column(9), BinaryFunc::AddInt64),
     ///         MirScalarExpr::column(10),
     ///     ])
@@ -883,15 +883,15 @@ impl MapFilterProject {
     /// pass (the `remove_undemanded` method).
     ///
     /// ```rust
-    /// use expr::{MapFilterProject, MirScalarExpr, UnaryFunc, BinaryFunc};
+    /// use expr::{func, MapFilterProject, MirScalarExpr, UnaryFunc, BinaryFunc};
     /// // Use the output from first `memoize_expression` example.
     /// let mut map_filter_project = MapFilterProject::new(5)
     ///     .map(vec![
-    ///         MirScalarExpr::column(0).call_unary(UnaryFunc::CastStringToInt64),
-    ///         MirScalarExpr::column(1).call_unary(UnaryFunc::CastStringToInt64),
+    ///         MirScalarExpr::column(0).call_unary(UnaryFunc::CastStringToInt64(func::CastStringToInt64)),
+    ///         MirScalarExpr::column(1).call_unary(UnaryFunc::CastStringToInt64(func::CastStringToInt64)),
     ///         MirScalarExpr::column(5).call_binary(MirScalarExpr::column(6), BinaryFunc::AddInt64),
     ///         MirScalarExpr::column(7),
-    ///         MirScalarExpr::column(2).call_unary(UnaryFunc::CastStringToInt64),
+    ///         MirScalarExpr::column(2).call_unary(UnaryFunc::CastStringToInt64(func::CastStringToInt64)),
     ///         MirScalarExpr::column(6).call_binary(MirScalarExpr::column(9), BinaryFunc::AddInt64),
     ///         MirScalarExpr::column(10),
     ///     ])
@@ -899,13 +899,13 @@ impl MapFilterProject {
     ///
     /// let mut expected_optimized = MapFilterProject::new(5)
     ///     .map(vec![
-    ///         MirScalarExpr::column(0).call_unary(UnaryFunc::CastStringToInt64),
-    ///         MirScalarExpr::column(1).call_unary(UnaryFunc::CastStringToInt64),
-    ///         MirScalarExpr::column(0).call_unary(UnaryFunc::CastStringToInt64).call_binary(MirScalarExpr::column(6), BinaryFunc::AddInt64),
-    ///         MirScalarExpr::column(0).call_unary(UnaryFunc::CastStringToInt64).call_binary(MirScalarExpr::column(6), BinaryFunc::AddInt64),
-    ///         MirScalarExpr::column(2).call_unary(UnaryFunc::CastStringToInt64),
-    ///         MirScalarExpr::column(6).call_binary(MirScalarExpr::column(2).call_unary(UnaryFunc::CastStringToInt64), BinaryFunc::AddInt64),
-    ///         MirScalarExpr::column(6).call_binary(MirScalarExpr::column(2).call_unary(UnaryFunc::CastStringToInt64), BinaryFunc::AddInt64),
+    ///         MirScalarExpr::column(0).call_unary(UnaryFunc::CastStringToInt64(func::CastStringToInt64)),
+    ///         MirScalarExpr::column(1).call_unary(UnaryFunc::CastStringToInt64(func::CastStringToInt64)),
+    ///         MirScalarExpr::column(0).call_unary(UnaryFunc::CastStringToInt64(func::CastStringToInt64)).call_binary(MirScalarExpr::column(6), BinaryFunc::AddInt64),
+    ///         MirScalarExpr::column(0).call_unary(UnaryFunc::CastStringToInt64(func::CastStringToInt64)).call_binary(MirScalarExpr::column(6), BinaryFunc::AddInt64),
+    ///         MirScalarExpr::column(2).call_unary(UnaryFunc::CastStringToInt64(func::CastStringToInt64)),
+    ///         MirScalarExpr::column(6).call_binary(MirScalarExpr::column(2).call_unary(UnaryFunc::CastStringToInt64(func::CastStringToInt64)), BinaryFunc::AddInt64),
+    ///         MirScalarExpr::column(6).call_binary(MirScalarExpr::column(2).call_unary(UnaryFunc::CastStringToInt64(func::CastStringToInt64)), BinaryFunc::AddInt64),
     ///     ])
     ///     .project(vec![3,4,8,11]);
     ///
@@ -1003,25 +1003,25 @@ impl MapFilterProject {
     /// # Example
     ///
     /// ```rust
-    /// use expr::{MapFilterProject, MirScalarExpr, UnaryFunc, BinaryFunc};
+    /// use expr::{func, MapFilterProject, MirScalarExpr, UnaryFunc, BinaryFunc};
     /// // Use the output from `inline_expression` example.
     /// let mut map_filter_project = MapFilterProject::new(5)
     ///     .map(vec![
-    ///         MirScalarExpr::column(0).call_unary(UnaryFunc::CastStringToInt64),
-    ///         MirScalarExpr::column(1).call_unary(UnaryFunc::CastStringToInt64),
-    ///         MirScalarExpr::column(0).call_unary(UnaryFunc::CastStringToInt64).call_binary(MirScalarExpr::column(6), BinaryFunc::AddInt64),
-    ///         MirScalarExpr::column(0).call_unary(UnaryFunc::CastStringToInt64).call_binary(MirScalarExpr::column(6), BinaryFunc::AddInt64),
-    ///         MirScalarExpr::column(2).call_unary(UnaryFunc::CastStringToInt64),
-    ///         MirScalarExpr::column(6).call_binary(MirScalarExpr::column(2).call_unary(UnaryFunc::CastStringToInt64), BinaryFunc::AddInt64),
-    ///         MirScalarExpr::column(6).call_binary(MirScalarExpr::column(2).call_unary(UnaryFunc::CastStringToInt64), BinaryFunc::AddInt64),
+    ///         MirScalarExpr::column(0).call_unary(UnaryFunc::CastStringToInt64(func::CastStringToInt64)),
+    ///         MirScalarExpr::column(1).call_unary(UnaryFunc::CastStringToInt64(func::CastStringToInt64)),
+    ///         MirScalarExpr::column(0).call_unary(UnaryFunc::CastStringToInt64(func::CastStringToInt64)).call_binary(MirScalarExpr::column(6), BinaryFunc::AddInt64),
+    ///         MirScalarExpr::column(0).call_unary(UnaryFunc::CastStringToInt64(func::CastStringToInt64)).call_binary(MirScalarExpr::column(6), BinaryFunc::AddInt64),
+    ///         MirScalarExpr::column(2).call_unary(UnaryFunc::CastStringToInt64(func::CastStringToInt64)),
+    ///         MirScalarExpr::column(6).call_binary(MirScalarExpr::column(2).call_unary(UnaryFunc::CastStringToInt64(func::CastStringToInt64)), BinaryFunc::AddInt64),
+    ///         MirScalarExpr::column(6).call_binary(MirScalarExpr::column(2).call_unary(UnaryFunc::CastStringToInt64(func::CastStringToInt64)), BinaryFunc::AddInt64),
     ///     ])
     ///     .project(vec![3,4,8,11]);
     ///
     /// let mut expected_optimized = MapFilterProject::new(5)
     ///     .map(vec![
-    ///         MirScalarExpr::column(1).call_unary(UnaryFunc::CastStringToInt64),
-    ///         MirScalarExpr::column(0).call_unary(UnaryFunc::CastStringToInt64).call_binary(MirScalarExpr::column(5), BinaryFunc::AddInt64),
-    ///         MirScalarExpr::column(5).call_binary(MirScalarExpr::column(2).call_unary(UnaryFunc::CastStringToInt64), BinaryFunc::AddInt64),
+    ///         MirScalarExpr::column(1).call_unary(UnaryFunc::CastStringToInt64(func::CastStringToInt64)),
+    ///         MirScalarExpr::column(0).call_unary(UnaryFunc::CastStringToInt64(func::CastStringToInt64)).call_binary(MirScalarExpr::column(5), BinaryFunc::AddInt64),
+    ///         MirScalarExpr::column(5).call_binary(MirScalarExpr::column(2).call_unary(UnaryFunc::CastStringToInt64(func::CastStringToInt64)), BinaryFunc::AddInt64),
     ///     ])
     ///     .project(vec![3,4,6,7]);
     ///

--- a/src/expr/src/scalar/func/impls.rs
+++ b/src/expr/src/scalar/func/impls.rs
@@ -17,6 +17,7 @@ mod int64;
 mod numeric;
 mod oid;
 mod regproc;
+mod string;
 
 pub use boolean::*;
 pub use datum::*;
@@ -28,3 +29,4 @@ pub use int64::*;
 pub use numeric::*;
 pub use oid::*;
 pub use regproc::*;
+pub use string::*;

--- a/src/expr/src/scalar/func/impls/string.rs
+++ b/src/expr/src/scalar/func/impls/string.rs
@@ -1,0 +1,100 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use lowertest::MzStructReflect;
+use ore::result::ResultExt;
+use repr::adt::numeric::{self, Numeric};
+use repr::{strconv, ColumnType, ScalarType};
+
+use crate::scalar::func::EagerUnaryFunc;
+use crate::EvalError;
+
+sqlfunc!(
+    #[sqlname = "strtobool"]
+    fn cast_string_to_bool<'a>(a: &'a str) -> Result<bool, EvalError> {
+        strconv::parse_bool(a).err_into()
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "strtobytes"]
+    #[preserves_uniqueness = true]
+    fn cast_string_to_bytes<'a>(a: &'a str) -> Result<Vec<u8>, EvalError> {
+        strconv::parse_bytes(a).err_into()
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "strtoi16"]
+    fn cast_string_to_int16<'a>(a: &'a str) -> Result<i16, EvalError> {
+        strconv::parse_int16(a).err_into()
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "strtoi32"]
+    fn cast_string_to_int32<'a>(a: &'a str) -> Result<i32, EvalError> {
+        strconv::parse_int32(a).err_into()
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "strtoi64"]
+    fn cast_string_to_int64<'a>(a: &'a str) -> Result<i64, EvalError> {
+        strconv::parse_int64(a).err_into()
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "strtof32"]
+    fn cast_string_to_float32<'a>(a: &'a str) -> Result<f32, EvalError> {
+        strconv::parse_float32(a).err_into()
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "strtof64"]
+    fn cast_string_to_float64<'a>(a: &'a str) -> Result<f64, EvalError> {
+        strconv::parse_float64(a).err_into()
+    }
+);
+
+#[derive(
+    Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzStructReflect,
+)]
+pub struct CastStringToNumeric(pub Option<u8>);
+
+impl<'a> EagerUnaryFunc<'a> for CastStringToNumeric {
+    type Input = &'a str;
+    type Output = Result<Numeric, EvalError>;
+
+    fn call(&self, a: &'a str) -> Result<Numeric, EvalError> {
+        let mut d = strconv::parse_numeric(a)?;
+        if let Some(scale) = self.0 {
+            if numeric::rescale(&mut d.0, scale).is_err() {
+                return Err(EvalError::NumericFieldOverflow);
+            }
+        }
+        Ok(d.into_inner())
+    }
+
+    fn output_type(&self, input: ColumnType) -> ColumnType {
+        ScalarType::Numeric { scale: self.0 }.nullable(input.nullable)
+    }
+}
+
+impl fmt::Display for CastStringToNumeric {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("i64tonumeric")
+    }
+}

--- a/src/expr/src/scalar/func/impls/string.rs
+++ b/src/expr/src/scalar/func/impls/string.rs
@@ -9,10 +9,13 @@
 
 use std::fmt;
 
+use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 use lowertest::MzStructReflect;
 use ore::result::ResultExt;
+use repr::adt::interval::Interval;
 use repr::adt::numeric::{self, Numeric};
 use repr::{strconv, ColumnType, ScalarType};
 
@@ -98,3 +101,45 @@ impl fmt::Display for CastStringToNumeric {
         f.write_str("i64tonumeric")
     }
 }
+
+sqlfunc!(
+    #[sqlname = "strtodate"]
+    fn cast_string_to_date<'a>(a: &'a str) -> Result<NaiveDate, EvalError> {
+        strconv::parse_date(a).err_into()
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "strtotime"]
+    fn cast_string_to_time<'a>(a: &'a str) -> Result<NaiveTime, EvalError> {
+        strconv::parse_time(a).err_into()
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "strtots"]
+    fn cast_string_to_timestamp<'a>(a: &'a str) -> Result<NaiveDateTime, EvalError> {
+        strconv::parse_timestamp(a).err_into()
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "strtotstz"]
+    fn cast_string_to_timestamp_tz<'a>(a: &'a str) -> Result<DateTime<Utc>, EvalError> {
+        strconv::parse_timestamptz(a).err_into()
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "strtoiv"]
+    fn cast_string_to_interval<'a>(a: &'a str) -> Result<Interval, EvalError> {
+        strconv::parse_interval(a).err_into()
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "strtouuid"]
+    fn cast_string_to_uuid<'a>(a: &'a str) -> Result<Uuid, EvalError> {
+        strconv::parse_uuid(a).err_into()
+    }
+);

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -1020,7 +1020,12 @@ impl_datum_type_copy!(f64, Float64);
 impl_datum_type_copy!(i16, Int16);
 impl_datum_type_copy!(i32, Int32);
 impl_datum_type_copy!(i64, Int64);
+impl_datum_type_copy!(Interval, Interval);
+impl_datum_type_copy!(NaiveDate, Date);
+impl_datum_type_copy!(NaiveTime, Time);
+impl_datum_type_copy!(NaiveDateTime, Timestamp);
 impl_datum_type_copy!(DateTime<Utc>, TimestampTz);
+impl_datum_type_copy!(Uuid, Uuid);
 impl_datum_type_copy!('a, &'a str, String);
 impl_datum_type_copy!('a, &'a [u8], Bytes);
 

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -441,12 +441,12 @@ lazy_static! {
                     Some(scale) => e.call_unary(UnaryFunc::RescaleNumeric(scale)),
                 })
             }),
-            (Numeric, Float32) => Implicit: CastNumericToFloat32,
-            (Numeric, Float64) => Implicit: CastNumericToFloat64,
-            (Numeric, Int16) => Assignment: CastNumericToInt16,
-            (Numeric, Int32) => Assignment: CastNumericToInt32,
-            (Numeric, Int64) => Assignment: CastNumericToInt64,
-            (Numeric, String) => Assignment: CastNumericToString
+            (Numeric, Float32) => Implicit: CastNumericToFloat32(func::CastNumericToFloat32),
+            (Numeric, Float64) => Implicit: CastNumericToFloat64(func::CastNumericToFloat64),
+            (Numeric, Int16) => Assignment: CastNumericToInt16(func::CastNumericToInt16),
+            (Numeric, Int32) => Assignment: CastNumericToInt32(func::CastNumericToInt32),
+            (Numeric, Int64) => Assignment: CastNumericToInt64(func::CastNumericToInt64),
+            (Numeric, String) => Assignment: CastNumericToString(func::CastNumericToString)
         }
     };
 }

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -253,11 +253,11 @@ lazy_static! {
             (Bytes, String) => Assignment: CastBytesToString,
 
             // STRING
-            (String, Bool) => Explicit: CastStringToBool,
-            (String, Int16) => Explicit: CastStringToInt16,
-            (String, Int32) => Explicit: CastStringToInt32,
-            (String, Int64) => Explicit: CastStringToInt64,
-            (String, Oid) => Explicit: CastStringToInt32,
+            (String, Bool) => Explicit: CastStringToBool(func::CastStringToBool),
+            (String, Int16) => Explicit: CastStringToInt16(func::CastStringToInt16),
+            (String, Int32) => Explicit: CastStringToInt32(func::CastStringToInt32),
+            (String, Int64) => Explicit: CastStringToInt64(func::CastStringToInt64),
+            (String, Oid) => Explicit: CastStringToInt32(func::CastStringToInt32),
 
             // STRING to REG*
             // A reg* type represents a specific type of object by oid.
@@ -311,18 +311,18 @@ lazy_static! {
                     END
             )"),
 
-            (String, Float32) => Explicit: CastStringToFloat32,
-            (String, Float64) => Explicit: CastStringToFloat64,
+            (String, Float32) => Explicit: CastStringToFloat32(func::CastStringToFloat32),
+            (String, Float64) => Explicit: CastStringToFloat64(func::CastStringToFloat64),
             (String, Numeric) => Explicit: CastTemplate::new(|_ecx, _ccx, _from_type, to_type| {
                 let s = to_type.unwrap_numeric_scale();
-                Some(move |e: HirScalarExpr| e.call_unary(CastStringToNumeric(s)))
+                Some(move |e: HirScalarExpr| e.call_unary(CastStringToNumeric(func::CastStringToNumeric(s))))
             }),
             (String, Date) => Explicit: CastStringToDate,
             (String, Time) => Explicit: CastStringToTime,
             (String, Timestamp) => Explicit: CastStringToTimestamp,
             (String, TimestampTz) => Explicit: CastStringToTimestampTz,
             (String, Interval) => Explicit: CastStringToInterval,
-            (String, Bytes) => Explicit: CastStringToBytes,
+            (String, Bytes) => Explicit: CastStringToBytes(func::CastStringToBytes),
             (String, Jsonb) => Explicit: CastStringToJsonb,
             (String, Uuid) => Explicit: CastStringToUuid,
             (String, Array) => Explicit: CastTemplate::new(|ecx, ccx, from_type, to_type| {

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -317,14 +317,14 @@ lazy_static! {
                 let s = to_type.unwrap_numeric_scale();
                 Some(move |e: HirScalarExpr| e.call_unary(CastStringToNumeric(func::CastStringToNumeric(s))))
             }),
-            (String, Date) => Explicit: CastStringToDate,
-            (String, Time) => Explicit: CastStringToTime,
-            (String, Timestamp) => Explicit: CastStringToTimestamp,
-            (String, TimestampTz) => Explicit: CastStringToTimestampTz,
-            (String, Interval) => Explicit: CastStringToInterval,
+            (String, Date) => Explicit: CastStringToDate(func::CastStringToDate),
+            (String, Time) => Explicit: CastStringToTime(func::CastStringToTime),
+            (String, Timestamp) => Explicit: CastStringToTimestamp(func::CastStringToTimestamp),
+            (String, TimestampTz) => Explicit: CastStringToTimestampTz(func::CastStringToTimestampTz),
+            (String, Interval) => Explicit: CastStringToInterval(func::CastStringToInterval),
             (String, Bytes) => Explicit: CastStringToBytes(func::CastStringToBytes),
             (String, Jsonb) => Explicit: CastStringToJsonb,
-            (String, Uuid) => Explicit: CastStringToUuid,
+            (String, Uuid) => Explicit: CastStringToUuid(func::CastStringToUuid),
             (String, Array) => Explicit: CastTemplate::new(|ecx, ccx, from_type, to_type| {
                 let return_ty = to_type.clone();
                 let to_el_type = to_type.unwrap_array_element_type();


### PR DESCRIPTION
### Motivation

Move more functions under `sqlfunc!`


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
