### PR TITLE
sql: add support for REGCLASS

### DIFF
--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -442,18 +442,6 @@ pub const TYPE_BPCHAR_ARRAY: BuiltinType = BuiltinType {
     pgtype: &postgres_types::Type::BPCHAR_ARRAY,
 };
 
-pub const TYPE_REGCLASS: BuiltinType = BuiltinType {
-    schema: PG_CATALOG_SCHEMA,
-    id: GlobalId::System(1048),
-    pgtype: &postgres_types::Type::REGCLASS,
-};
-
-pub const TYPE_REGCLASS_ARRAY: BuiltinType = BuiltinType {
-    schema: PG_CATALOG_SCHEMA,
-    id: GlobalId::System(1049),
-    pgtype: &postgres_types::Type::REGCLASS_ARRAY,
-};
-
 pub const TYPE_REGPROC: BuiltinType = BuiltinType {
     schema: PG_CATALOG_SCHEMA,
     id: GlobalId::System(1046),
@@ -476,6 +464,18 @@ pub const TYPE_REGTYPE_ARRAY: BuiltinType = BuiltinType {
     schema: PG_CATALOG_SCHEMA,
     id: GlobalId::System(1049),
     pgtype: &postgres_types::Type::REGTYPE_ARRAY,
+};
+
+pub const TYPE_REGCLASS: BuiltinType = BuiltinType {
+    schema: PG_CATALOG_SCHEMA,
+    id: GlobalId::System(1050),
+    pgtype: &postgres_types::Type::REGCLASS,
+};
+
+pub const TYPE_REGCLASS_ARRAY: BuiltinType = BuiltinType {
+    schema: PG_CATALOG_SCHEMA,
+    id: GlobalId::System(1051),
+    pgtype: &postgres_types::Type::REGCLASS_ARRAY,
 };
 
 lazy_static! {

--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -442,6 +442,18 @@ pub const TYPE_BPCHAR_ARRAY: BuiltinType = BuiltinType {
     pgtype: &postgres_types::Type::BPCHAR_ARRAY,
 };
 
+pub const TYPE_REGCLASS: BuiltinType = BuiltinType {
+    schema: PG_CATALOG_SCHEMA,
+    id: GlobalId::System(1048),
+    pgtype: &postgres_types::Type::REGCLASS,
+};
+
+pub const TYPE_REGCLASS_ARRAY: BuiltinType = BuiltinType {
+    schema: PG_CATALOG_SCHEMA,
+    id: GlobalId::System(1049),
+    pgtype: &postgres_types::Type::REGCLASS_ARRAY,
+};
+
 pub const TYPE_REGPROC: BuiltinType = BuiltinType {
     schema: PG_CATALOG_SCHEMA,
     id: GlobalId::System(1046),
@@ -1632,6 +1644,8 @@ lazy_static! {
             Builtin::Type(&TYPE_OID_ARRAY),
             Builtin::Type(&TYPE_RECORD),
             Builtin::Type(&TYPE_RECORD_ARRAY),
+            Builtin::Type(&TYPE_REGCLASS),
+            Builtin::Type(&TYPE_REGCLASS_ARRAY),
             Builtin::Type(&TYPE_REGPROC),
             Builtin::Type(&TYPE_REGPROC_ARRAY),
             Builtin::Type(&TYPE_REGTYPE),

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -3385,12 +3385,15 @@ pub enum UnaryFunc {
     CastInt32ToFloat32(CastInt32ToFloat32),
     CastInt32ToFloat64(CastInt32ToFloat64),
     CastInt32ToOid(CastInt32ToOid),
+    CastInt32ToRegClass(CastInt32ToRegClass),
     CastInt32ToRegProc(CastInt32ToRegProc),
     CastInt32ToRegType(CastInt32ToRegType),
     CastInt32ToInt16(CastInt32ToInt16),
     CastInt32ToInt64(CastInt32ToInt64),
     CastInt32ToString(CastInt32ToString),
     CastOidToInt32(CastOidToInt32),
+    CastOidToRegClass(CastOidToRegClass),
+    CastRegClassToOid(CastRegClassToOid),
     CastOidToRegProc(CastOidToRegProc),
     CastRegProcToOid(CastRegProcToOid),
     CastOidToRegType(CastOidToRegType),
@@ -3621,6 +3624,7 @@ derive_unary!(
     CastInt32ToInt64,
     CastInt32ToString,
     CastInt32ToOid,
+    CastInt32ToRegClass,
     CastInt32ToRegProc,
     CastInt32ToRegType,
     CastInt64ToInt16,
@@ -3634,6 +3638,8 @@ derive_unary!(
     CastFloat64ToNumeric,
     CastInt32ToNumeric,
     CastOidToInt32,
+    CastOidToRegClass,
+    CastRegClassToOid,
     CastOidToRegProc,
     CastRegProcToOid,
     CastOidToRegType,
@@ -3747,9 +3753,12 @@ impl UnaryFunc {
             | CastInt32ToInt64(_)
             | CastInt32ToString(_)
             | CastInt32ToOid(_)
+            | CastInt32ToRegClass(_)
             | CastInt32ToRegProc(_)
             | CastInt32ToRegType(_)
             | CastOidToInt32(_)
+            | CastOidToRegClass(_)
+            | CastRegClassToOid(_)
             | CastOidToRegProc(_)
             | CastRegProcToOid(_)
             | CastOidToRegType(_)
@@ -3952,9 +3961,12 @@ impl UnaryFunc {
             | CastInt32ToInt64(_)
             | CastInt32ToString(_)
             | CastInt32ToOid(_)
+            | CastInt32ToRegClass(_)
             | CastInt32ToRegProc(_)
             | CastInt32ToRegType(_)
             | CastOidToInt32(_)
+            | CastOidToRegClass(_)
+            | CastRegClassToOid(_)
             | CastOidToRegProc(_)
             | CastRegProcToOid(_)
             | CastOidToRegType(_)
@@ -4182,9 +4194,12 @@ impl UnaryFunc {
             | CastInt32ToInt64(_)
             | CastInt32ToString(_)
             | CastInt32ToOid(_)
+            | CastInt32ToRegClass(_)
             | CastInt32ToRegProc(_)
             | CastInt32ToRegType(_)
             | CastOidToInt32(_)
+            | CastOidToRegClass(_)
+            | CastRegClassToOid(_)
             | CastOidToRegProc(_)
             | CastRegProcToOid(_)
             | CastOidToRegType(_)
@@ -4409,9 +4424,12 @@ impl UnaryFunc {
             | CastInt32ToInt64(_)
             | CastInt32ToString(_)
             | CastInt32ToOid(_)
+            | CastInt32ToRegClass(_)
             | CastInt32ToRegProc(_)
             | CastInt32ToRegType(_)
             | CastOidToInt32(_)
+            | CastOidToRegClass(_)
+            | CastRegClassToOid(_)
             | CastOidToRegProc(_)
             | CastRegProcToOid(_)
             | CastOidToRegType(_)
@@ -5022,7 +5040,7 @@ where
     match &ty {
         Bool => strconv::format_bool(buf, d.unwrap_bool()),
         Int16 => strconv::format_int16(buf, d.unwrap_int16()),
-        Int32 | Oid | RegProc | RegType => strconv::format_int32(buf, d.unwrap_int32()),
+        Int32 | Oid | RegClass | RegProc | RegType => strconv::format_int32(buf, d.unwrap_int32()),
         Int64 => strconv::format_int64(buf, d.unwrap_int64()),
         Float32 => strconv::format_float32(buf, d.unwrap_float32()),
         Float64 => strconv::format_float64(buf, d.unwrap_float64()),

--- a/src/expr/src/scalar/func/impls/int32.rs
+++ b/src/expr/src/scalar/func/impls/int32.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 
 use lowertest::MzStructReflect;
 use repr::adt::numeric::{self, Numeric};
-use repr::adt::system::{Oid, RegProc, RegType};
+use repr::adt::system::{Oid, RegClass, RegProc, RegType};
 use repr::{strconv, ColumnType, ScalarType};
 
 use crate::scalar::func::EagerUnaryFunc;
@@ -124,6 +124,14 @@ sqlfunc!(
     #[preserves_uniqueness = true]
     fn cast_int32_to_oid(a: i32) -> Oid {
         Oid(a)
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "i32toregclass"]
+    #[preserves_uniqueness = true]
+    fn cast_int32_to_reg_class(a: i32) -> RegClass {
+        RegClass(a)
     }
 );
 

--- a/src/expr/src/scalar/func/impls/oid.rs
+++ b/src/expr/src/scalar/func/impls/oid.rs
@@ -7,13 +7,21 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use repr::adt::system::{Oid, RegProc, RegType};
+use repr::adt::system::{Oid, RegClass, RegProc, RegType};
 
 sqlfunc!(
     #[sqlname = "oidtoi32"]
     #[preserves_uniqueness = true]
     fn cast_oid_to_int32(a: Oid) -> i32 {
         a.0
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "oidtoregclass"]
+    #[preserves_uniqueness = true]
+    fn cast_oid_to_reg_class(a: Oid) -> RegClass {
+        RegClass(a.0)
     }
 );
 

--- a/src/expr/src/scalar/func/impls/regproc.rs
+++ b/src/expr/src/scalar/func/impls/regproc.rs
@@ -7,7 +7,15 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use repr::adt::system::{Oid, RegProc, RegType};
+use repr::adt::system::{Oid, RegClass, RegProc, RegType};
+
+sqlfunc!(
+    #[sqlname = "regclasstooid"]
+    #[preserves_uniqueness = true]
+    fn cast_reg_class_to_oid(a: RegClass) -> Oid {
+        Oid(a.0)
+    }
+);
 
 sqlfunc!(
     #[sqlname = "regproctooid"]

--- a/src/interchange/src/avro/encode.rs
+++ b/src/interchange/src/avro/encode.rs
@@ -289,9 +289,11 @@ impl<'a> mz_avro::types::ToAvro for TypedDatum<'a> {
             let mut val = match &typ.scalar_type {
                 ScalarType::Bool => Value::Boolean(datum.unwrap_bool()),
                 ScalarType::Int16 => Value::Int(i32::from(datum.unwrap_int16())),
-                ScalarType::Int32 | ScalarType::Oid | ScalarType::RegProc | ScalarType::RegType => {
-                    Value::Int(datum.unwrap_int32())
-                }
+                ScalarType::Int32
+                | ScalarType::Oid
+                | ScalarType::RegClass
+                | ScalarType::RegProc
+                | ScalarType::RegType => Value::Int(datum.unwrap_int32()),
                 ScalarType::Int64 => Value::Long(datum.unwrap_int64()),
                 ScalarType::Float32 => Value::Float(datum.unwrap_float32()),
                 ScalarType::Float64 => Value::Double(datum.unwrap_float64()),

--- a/src/interchange/src/json.rs
+++ b/src/interchange/src/json.rs
@@ -132,7 +132,11 @@ impl<'a> ToJson for TypedDatum<'_> {
             match &typ.scalar_type {
                 ScalarType::Bool => json!(datum.unwrap_bool()),
                 ScalarType::Int16 => json!(datum.unwrap_int16()),
-                ScalarType::Int32 | ScalarType::Oid | ScalarType::RegProc | ScalarType::RegType => {
+                ScalarType::Int32
+                | ScalarType::Oid
+                | ScalarType::RegClass
+                | ScalarType::RegProc
+                | ScalarType::RegType => {
                     json!(datum.unwrap_int32())
                 }
                 ScalarType::Int64 => json!(datum.unwrap_int64()),
@@ -244,6 +248,7 @@ fn build_row_schema_field<F: FnMut() -> String>(
         ScalarType::Int16
         | ScalarType::Int32
         | ScalarType::Oid
+        | ScalarType::RegClass
         | ScalarType::RegProc
         | ScalarType::RegType => {
             json!("int")

--- a/src/pgrepr/src/types.rs
+++ b/src/pgrepr/src/types.rs
@@ -67,6 +67,8 @@ pub enum Type {
     RegProc,
     /// A type name.
     RegType,
+    /// A class name.
+    RegClass,
 }
 
 lazy_static! {
@@ -116,6 +118,7 @@ impl Type {
             postgres_types::Type::TIMESTAMP => Some(Type::Timestamp),
             postgres_types::Type::TIMESTAMPTZ => Some(Type::TimestampTz),
             postgres_types::Type::UUID => Some(Type::Uuid),
+            postgres_types::Type::REGCLASS => Some(Type::RegClass),
             postgres_types::Type::REGPROC => Some(Type::RegProc),
             postgres_types::Type::REGTYPE => Some(Type::RegType),
             _ => None,
@@ -148,6 +151,7 @@ impl Type {
                 Type::Timestamp => &postgres_types::Type::TIMESTAMP_ARRAY,
                 Type::TimestampTz => &postgres_types::Type::TIMESTAMPTZ_ARRAY,
                 Type::Uuid => &postgres_types::Type::UUID_ARRAY,
+                Type::RegClass => &postgres_types::Type::REGCLASS_ARRAY,
                 Type::RegProc => &postgres_types::Type::REGPROC_ARRAY,
                 Type::RegType => &postgres_types::Type::REGTYPE_ARRAY,
             },
@@ -173,6 +177,7 @@ impl Type {
             Type::Timestamp => &postgres_types::Type::TIMESTAMP,
             Type::TimestampTz => &postgres_types::Type::TIMESTAMPTZ,
             Type::Uuid => &postgres_types::Type::UUID,
+            Type::RegClass => &postgres_types::Type::REGCLASS,
             Type::RegProc => &postgres_types::Type::REGPROC,
             Type::RegType => &postgres_types::Type::REGTYPE,
         }
@@ -211,6 +216,7 @@ impl Type {
             &postgres_types::Type::INT8 => "bigint",
             &postgres_types::Type::TIMESTAMPTZ => "timestamp with time zone",
             &postgres_types::Type::VARCHAR => "character varying",
+            &postgres_types::Type::REGCLASS_ARRAY => "regclass[]",
             &postgres_types::Type::REGPROC_ARRAY => "regproc[]",
             &postgres_types::Type::REGTYPE_ARRAY => "regtype[]",
             other => other.name(),
@@ -251,6 +257,7 @@ impl Type {
             Type::Timestamp => 8,
             Type::TimestampTz => 8,
             Type::Uuid => 16,
+            Type::RegClass => 4,
             Type::RegProc => 4,
             Type::RegType => 4,
         }
@@ -296,6 +303,7 @@ impl Type {
             Type::Timestamp => ScalarType::Timestamp,
             Type::TimestampTz => ScalarType::TimestampTz,
             Type::Uuid => ScalarType::Uuid,
+            Type::RegClass => ScalarType::RegClass,
             Type::RegProc => ScalarType::RegProc,
             Type::RegType => ScalarType::RegType,
         }
@@ -337,6 +345,7 @@ impl From<&ScalarType> for Type {
             ScalarType::TimestampTz => Type::TimestampTz,
             ScalarType::Uuid => Type::Uuid,
             ScalarType::Numeric { .. } => Type::Numeric,
+            ScalarType::RegClass => Type::RegClass,
             ScalarType::RegProc => Type::RegProc,
             ScalarType::RegType => Type::RegType,
         }

--- a/src/pgrepr/src/value.rs
+++ b/src/pgrepr/src/value.rs
@@ -104,6 +104,7 @@ impl Value {
             (Datum::Int16(i), ScalarType::Int16) => Some(Value::Int2(i)),
             (Datum::Int32(i), ScalarType::Int32) => Some(Value::Int4(i)),
             (Datum::Int32(i), ScalarType::Oid) => Some(Value::Int4(i)),
+            (Datum::Int32(i), ScalarType::RegClass) => Some(Value::Int4(i)),
             (Datum::Int32(i), ScalarType::RegProc) => Some(Value::Int4(i)),
             (Datum::Int32(i), ScalarType::RegType) => Some(Value::Int4(i)),
             (Datum::Int64(i), ScalarType::Int64) => Some(Value::Int8(i)),
@@ -447,7 +448,7 @@ impl Value {
             Type::Float4 => Value::Float4(strconv::parse_float32(raw)?),
             Type::Float8 => Value::Float8(strconv::parse_float64(raw)?),
             Type::Int2 => Value::Int2(strconv::parse_int16(raw)?),
-            Type::Int4 | Type::Oid | Type::RegProc | Type::RegType => {
+            Type::Int4 | Type::Oid | Type::RegClass | Type::RegProc | Type::RegType => {
                 Value::Int4(strconv::parse_int32(raw)?)
             }
             Type::Int8 => Value::Int8(strconv::parse_int64(raw)?),
@@ -497,7 +498,7 @@ impl Value {
             Type::Float4 => f32::from_sql(ty.inner(), raw).map(Value::Float4),
             Type::Float8 => f64::from_sql(ty.inner(), raw).map(Value::Float8),
             Type::Int2 => i16::from_sql(ty.inner(), raw).map(Value::Int2),
-            Type::Int4 | Type::Oid | Type::RegProc | Type::RegType => {
+            Type::Int4 | Type::Oid | Type::RegClass | Type::RegProc | Type::RegType => {
                 i32::from_sql(ty.inner(), raw).map(Value::Int4)
             }
             Type::Int8 => i64::from_sql(ty.inner(), raw).map(Value::Int8),
@@ -605,6 +606,7 @@ pub fn null_datum(ty: &Type) -> (Datum<'static>, ScalarType) {
                 custom_oid: None,
             }
         }
+        Type::RegClass => ScalarType::RegClass,
         Type::RegProc => ScalarType::RegProc,
         Type::RegType => ScalarType::RegType,
     };

--- a/src/repr/src/adt/system.rs
+++ b/src/repr/src/adt/system.rs
@@ -13,10 +13,14 @@
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct Oid(pub i32);
 
+/// A rust type representing a PostgreSQL class type
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct RegClass(pub i32);
+
 /// A rust type representing a PostgreSQL function name
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct RegProc(pub i32);
 
-/// A rust type representing a PostgreSQL function type
+/// A rust type representing a PostgreSQL type of object
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct RegType(pub i32);

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -204,7 +204,6 @@ Raw
 Read
 Real
 References
-Regclass
 Regex
 Registry
 Rename

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -3077,8 +3077,6 @@ impl<'a> Parser<'a> {
                 BOOLEAN => other("bool"),
                 BYTES => other("bytea"),
                 JSON => other("jsonb"),
-                REGCLASS => other("oid"),
-
                 _ => {
                     self.prev_token();
                     DataType::Other {

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1118,7 +1118,7 @@ CREATE TABLE public.customer (
     active int
 )
 ----
-CREATE TABLE public.customer (customer_id int4 DEFAULT nextval('public.customer_customer_id_seq'::oid) NOT NULL, store_id int2 NOT NULL, first_name varchar(45) NOT NULL, last_name varchar(45) NOT NULL, info text, address_id int2 NOT NULL, activebool bool DEFAULT true NOT NULL, create_date date DEFAULT now()::date NOT NULL, create_date1 date DEFAULT 'now'::text::date NOT NULL, last_update timestamp DEFAULT now(), active int4)
+CREATE TABLE public.customer (customer_id int4 DEFAULT nextval('public.customer_customer_id_seq'::regclass) NOT NULL, store_id int2 NOT NULL, first_name varchar(45) NOT NULL, last_name varchar(45) NOT NULL, info text, address_id int2 NOT NULL, activebool bool DEFAULT true NOT NULL, create_date date DEFAULT now()::date NOT NULL, create_date1 date DEFAULT 'now'::text::date NOT NULL, last_update timestamp DEFAULT now(), active int4)
 
 parse-statement roundtrip
 CREATE TABLE bazaar.settings (

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -100,6 +100,7 @@ impl TypeCategory {
             | ScalarType::Int32
             | ScalarType::Int64
             | ScalarType::Oid
+            | ScalarType::RegClass
             | ScalarType::RegProc
             | ScalarType::RegType
             | ScalarType::Numeric { .. } => Self::Numeric,
@@ -884,6 +885,7 @@ impl From<ScalarBaseType> for ParamType {
             Jsonb => ScalarType::Jsonb,
             Uuid => ScalarType::Uuid,
             Oid => ScalarType::Oid,
+            RegClass => ScalarType::RegClass,
             RegProc => ScalarType::RegProc,
             RegType => ScalarType::RegType,
             Array | List | Record | Map => {

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -4072,6 +4072,7 @@ pub fn scalar_type_from_pg(ty: &pgrepr::Type) -> Result<ScalarType, anyhow::Erro
             bail!("internal error: can't convert from pg record to materialize record")
         }
         pgrepr::Type::Oid => Ok(ScalarType::Oid),
+        pgrepr::Type::RegClass => Ok(ScalarType::RegClass),
         pgrepr::Type::RegProc => Ok(ScalarType::RegProc),
         pgrepr::Type::RegType => Ok(ScalarType::RegType),
         pgrepr::Type::Map { value_type } => Ok(ScalarType::Map {

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -177,10 +177,10 @@ lazy_static! {
             // REGCLASS
             (RegClass, Oid) => Implicit: CastRegClassToOid(func::CastRegClassToOid),
             (RegClass, String) => Explicit: sql_impl_cast("(
-                SELECT COALESCE(t.name, v.x::pg_catalog.text)
+                SELECT COALESCE(t.relname, v.x::pg_catalog.text)
                 FROM (
                     VALUES ($1::pg_catalog.oid)) AS v(x)
-                    LEFT JOIN mz_catalog.mz_objects AS t
+                    LEFT JOIN pg_catalog.pg_class AS t
                     ON t.oid = v.x
             )"),
 
@@ -265,7 +265,7 @@ lazy_static! {
                     WHEN $1 ~ '^\\d+$' THEN $1::pg_catalog.oid::pg_catalog.regclass
                     ELSE (
                         mz_internal.mz_error_if_null(
-                            (SELECT oid::pg_catalog.regclass FROM mz_catalog.mz_objects WHERE name = $1),
+                            (SELECT oid::pg_catalog.regclass FROM pg_catalog.pg_class WHERE relname = $1),
                             'object \"' || $1 || '\" does not exist'
                         )
                     )

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -142,6 +142,7 @@ lazy_static! {
             //INT32
             (Int32, Bool) => Explicit: CastInt32ToBool(func::CastInt32ToBool),
             (Int32, Oid) => Implicit: CastInt32ToOid(func::CastInt32ToOid),
+            (Int32, RegClass) => Implicit: CastInt32ToRegClass(func::CastInt32ToRegClass),
             (Int32, RegProc) => Implicit: CastInt32ToRegProc(func::CastInt32ToRegProc),
             (Int32, RegType) => Implicit: CastInt32ToRegType(func::CastInt32ToRegType),
             (Int32, Int16) => Assignment: CastInt32ToInt16(func::CastInt32ToInt16),
@@ -169,8 +170,19 @@ lazy_static! {
             // OID
             (Oid, Int32) => Assignment: CastOidToInt32(func::CastOidToInt32),
             (Oid, String) => Explicit: CastInt32ToString(func::CastInt32ToString),
+            (Oid, RegClass) => Assignment: CastOidToRegClass(func::CastOidToRegClass),
             (Oid, RegProc) => Assignment: CastOidToRegProc(func::CastOidToRegProc),
             (Oid, RegType) => Assignment: CastOidToRegType(func::CastOidToRegType),
+
+            // REGCLASS
+            (RegClass, Oid) => Implicit: CastRegClassToOid(func::CastRegClassToOid),
+            (RegClass, String) => Explicit: sql_impl_cast("(
+                SELECT COALESCE(t.name, v.x::pg_catalog.text)
+                FROM (
+                    VALUES ($1::pg_catalog.oid)) AS v(x)
+                    LEFT JOIN mz_catalog.mz_objects AS t
+                    ON t.oid = v.x
+            )"),
 
             // REGPROC
             (RegProc, Oid) => Implicit: CastRegProcToOid(func::CastRegProcToOid),
@@ -246,6 +258,19 @@ lazy_static! {
             (String, Int32) => Explicit: CastStringToInt32,
             (String, Int64) => Explicit: CastStringToInt64,
             (String, Oid) => Explicit: CastStringToInt32,
+            (String, RegClass) => Explicit: sql_impl_cast("(
+                SELECT
+                    CASE
+                    WHEN $1 IS NULL THEN NULL
+                    WHEN $1 ~ '^\\d+$' THEN $1::pg_catalog.oid::pg_catalog.regclass
+                    ELSE (
+                        mz_internal.mz_error_if_null(
+                            (SELECT oid::pg_catalog.regclass FROM mz_catalog.mz_objects WHERE name = $1),
+                            'object \"' || $1 || '\" does not exist'
+                        )
+                    )
+                    END
+            )"),
             // A regproc represents a function by oid. Converting from string to regproc
             // does a lookup of the function name and expects exactly one function to
             // match it. You can also specify (in postgres) a string that's a valid

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -313,6 +313,7 @@ impl<'a> FromSql<'a> for Slt {
             PgType::JSONB => Self(Value::Jsonb(Jsonb::from_sql(ty, raw)?)),
             PgType::NUMERIC => Self(Value::Numeric(Numeric::from_sql(ty, raw)?)),
             PgType::OID => Self(Value::Int4(types::oid_from_sql(raw)? as i32)),
+            PgType::REGCLASS => Self(Value::Int4(types::oid_from_sql(raw)? as i32)),
             PgType::REGPROC => Self(Value::Int4(types::oid_from_sql(raw)? as i32)),
             PgType::REGTYPE => Self(Value::Int4(types::oid_from_sql(raw)? as i32)),
             PgType::TEXT | PgType::BPCHAR | PgType::VARCHAR => {
@@ -387,6 +388,7 @@ impl<'a> FromSql<'a> for Slt {
                 | PgType::JSONB
                 | PgType::NUMERIC
                 | PgType::OID
+                | PgType::REGCLASS
                 | PgType::REGPROC
                 | PgType::REGTYPE
                 | PgType::RECORD

--- a/test/sqllogictest/types.slt
+++ b/test/sqllogictest/types.slt
@@ -458,16 +458,6 @@ select 'now'::regproc::oid::text::regproc
 statement OK
 select oid, oid::regproc::text from (select oid from mz_catalog.mz_functions)
 
-# 🔬🔬🔬 oid alias
-
-query T
-SELECT '1'::regclass
-----
-1
-
-query error unknown catalog item 'pg_catalog.regclass'
-SELECT '1'::pg_catalog.regclass
-
 # 🔬🔬 record
 
 query error type "pg_catalog.record" does not exist
@@ -963,3 +953,95 @@ NULL
 # ensure that all existing types can be cast to their respective names
 statement OK
 select oid, oid::regtype::text from (select oid from mz_catalog.mz_types)
+
+# 🔬🔬 regclass
+
+query T
+SELECT 1::regclass
+----
+1
+
+query T
+SELECT 1::int4::regclass
+----
+1
+
+query T
+SELECT 1::oid::regclass
+----
+1
+
+query T
+SELECT 1::oid::regclass::oid
+----
+1
+
+query T
+SELECT '1'::regclass
+----
+1
+
+query T
+SELECT '1'::pg_catalog.regclass
+----
+1
+
+query T
+SELECT '1'::regclass::text
+----
+1
+
+query T
+SELECT 'mz_tables'::regclass::text
+----
+mz_tables
+
+query T
+SELECT 'mz_tables'::regclass
+----
+20162
+
+query T
+SELECT 'mz_tables'::regclass::oid
+----
+20162
+
+query error object "nonexistent" does not exist
+SELECT 'nonexistent'::regclass
+
+query B
+SELECT 20162 = 'mz_tables'::regclass
+----
+true
+
+statement ok
+CREATE TABLE text_to_regclass (a text);
+
+statement ok
+INSERT INTO text_to_regclass VALUES (NULL), ('mz_tables');
+
+query I
+SELECT a::regclass FROM text_to_regclass ORDER BY a
+----
+20162
+NULL
+
+# Regression for 9194
+query I
+select 'mz_tables'::regclass::oid::text::regclass
+----
+20162
+
+# Make sure that there are no classes with duplicate OIDs
+query I
+select oid from (select count(*) as cnt, oid from pg_catalog.pg_class group by oid) where cnt>1
+----
+
+query T
+SELECT NULL::regclass::text
+----
+NULL
+
+# ensure that all existing types can be cast to their respective names
+statement OK
+select oid, oid::regclass::text from (select oid from pg_catalog.pg_class)

--- a/test/sqllogictest/types.slt
+++ b/test/sqllogictest/types.slt
@@ -996,23 +996,18 @@ SELECT 'mz_tables'::regclass::text
 ----
 mz_tables
 
-query T
-SELECT 'mz_tables'::regclass
+query B
+SELECT 'mz_tables'::regclass = (SELECT oid FROM mz_objects WHERE name = 'mz_tables')
 ----
-20162
+true
 
-query T
-SELECT 'mz_tables'::regclass::oid
+query B
+SELECT 'mz_tables'::regclass::oid = (SELECT oid FROM mz_objects WHERE name = 'mz_tables')
 ----
-20162
+true
 
 query error object "nonexistent" does not exist
 SELECT 'nonexistent'::regclass
-
-query B
-SELECT 20162 = 'mz_tables'::regclass
-----
-true
 
 statement ok
 CREATE TABLE text_to_regclass (a text);
@@ -1020,17 +1015,17 @@ CREATE TABLE text_to_regclass (a text);
 statement ok
 INSERT INTO text_to_regclass VALUES (NULL), ('mz_tables');
 
-query I
-SELECT a::regclass FROM text_to_regclass ORDER BY a
+query T
+SELECT a::regclass::text FROM text_to_regclass ORDER BY a
 ----
-20162
+mz_tables
 NULL
 
 # Regression for 9194
-query I
-select 'mz_tables'::regclass::oid::text::regclass
+query B
+select 'mz_tables'::regclass::oid::text::regclass = (SELECT oid FROM mz_objects WHERE name = 'mz_tables')
 ----
-20162
+true
 
 # Make sure that there are no classes with duplicate OIDs
 query I
@@ -1045,3 +1040,24 @@ NULL
 # ensure that all existing types can be cast to their respective names
 statement OK
 select oid, oid::regclass::text from (select oid from pg_catalog.pg_class)
+
+# multiple tables with the same name cause a lookup collision
+statement OK
+create schema test
+
+statement OK
+create schema test2
+
+statement ok
+CREATE TABLE test.table_with_id(i int);
+
+statement ok
+CREATE TABLE test2.table_with_id(i int);
+
+# unqualified duplicate names will lead to an error
+statement error more than one record produced in subquery
+SELECT 'table_with_id'::regclass
+
+# fully qualified names are not yet supported
+statement error object "test.table_with_id" does not exist
+SELECT 'test.table_with_id'::regclass

--- a/test/testdrive/types.td
+++ b/test/testdrive/types.td
@@ -30,6 +30,7 @@ _jsonb
 _numeric
 _oid
 _record
+_regclass
 _regproc
 _regtype
 _text
@@ -59,6 +60,7 @@ map
 numeric
 oid
 record
+regclass
 regproc
 regtype
 text
@@ -86,6 +88,7 @@ _jsonb           system
 _numeric         system
 _oid             system
 _record          system
+_regclass         system
 _regproc         system
 _regtype         system
 _text            system
@@ -114,6 +117,7 @@ list             system
 map              system
 numeric          system
 oid              system
+regclass         system
 regproc          system
 regtype          system
 record           system


### PR DESCRIPTION
<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

REGLASS is a convenience type to look up `mz_catalog.mz_objects` similar to the already implemented REGTYPE and REGPROC

### Motivation

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug. [Link to issue.]

  * This PR adds a known-desirable feature. [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

This is required to fully support `pgcli`.
