### PR TITLE
Fix wrong results issue when having a false THEN clause

### DIFF
--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -621,8 +621,12 @@ impl MirScalarExpr {
                                 }
                                 (Some(Ok(Datum::False)), _) => {
                                     *e = cond
-                                        .take()
+                                        .clone()
                                         .call_unary(UnaryFunc::Not(func::Not))
+                                        .call_binary(
+                                            cond.take().call_unary(UnaryFunc::IsNull(func::IsNull)),
+                                            BinaryFunc::Or,
+                                        )
                                         .call_binary(els.take(), BinaryFunc::And);
                                 }
                                 (_, Some(Ok(Datum::True))) => {

--- a/src/expr/tests/testdata/reduce
+++ b/src/expr/tests/testdata/reduce
@@ -326,6 +326,88 @@ reduce
 ----
 #0
 
+## Case/If optimizations
+
+reduce
+(if (call_binary gt #0 #1) false true)
+[int32 int32]
+----
+((isnull(#0) || isnull(#1)) || (#0 <= #1))
+
+reduce
+(if (call_binary gt #0 #1) false (null bool))
+[int32 int32]
+----
+(null && ((isnull(#0) || isnull(#1)) || (#0 <= #1)))
+
+reduce
+(if (call_binary gt #0 #1) false false)
+[int32 int32]
+----
+false
+
+# non-literal expression in the THEN clause
+reduce
+(if (call_binary gt #0 #1) (call_binary eq #0 (1 int32)) false)
+[int32 int32]
+----
+if (#0 > #1) then {(#0 = 1)} else {false}
+
+reduce
+(if (call_binary gt #0 #1) (null bool) false)
+[int32 int32]
+----
+(null && (#0 > #1))
+
+# non-literal expression in the THEN clause
+reduce
+(if (call_binary gt #0 #1) true false)
+[int32 int32]
+----
+(#0 > #1)
+
+reduce
+(if (call_binary gt #0 #1) true (null bool))
+[int32 int32]
+----
+(null || (#0 > #1))
+
+reduce
+(if (call_binary gt #0 #1) (call_binary eq #0 (1 int32)) true)
+[int32 int32]
+----
+if (#0 > #1) then {(#0 = 1)} else {true}
+
+reduce
+(if (call_binary gt #0 #1) (null bool) true)
+[int32 int32]
+----
+(null || (#0 <= #1))
+
+reduce
+(if (call_binary gt #0 #1) true true)
+[int32 int32]
+----
+true
+
+reduce
+(if (call_binary gt #0 #1) (null bool) (null bool))
+[int32 int32]
+----
+null
+
+reduce
+(if (call_binary gt #0 #1) (null int32) (null int32))
+[int32 int32]
+----
+null
+
+reduce
+(if (call_binary gt #0 #1) (1 int32) (2 int32))
+[int32 int32]
+----
+if (#0 > #1) then {1} else {2}
+
 ## undistribute_and/or works despite multiple copies of the same expression in
 ## the intersection
 

--- a/test/sqllogictest/boolean.slt
+++ b/test/sqllogictest/boolean.slt
@@ -292,7 +292,46 @@ FROM y
 ----
 %0 =
 | Get materialize.public.y (u5)
-| Map (null && !(#1))
+| Map (null && (!(#1) || isnull(#1)))
 | Project (#2)
 
 EOF
+
+query T multiline
+EXPLAIN PLAN FOR SELECT
+  CASE WHEN b THEN false ELSE TRUE END
+FROM y
+----
+%0 =
+| Get materialize.public.y (u5)
+| Map (!(#1) || isnull(#1))
+| Project (#2)
+
+EOF
+
+statement ok
+CREATE TABLE z (a int, b int)
+
+statement ok
+insert into z values (null, null), (1, null), (null, 2), (1, 2), (2, 1)
+
+query T multiline
+EXPLAIN PLAN FOR SELECT *
+FROM z
+WHERE CASE WHEN a > b THEN FALSE ELSE TRUE END
+----
+%0 =
+| Get materialize.public.z (u7)
+| Filter ((isnull(#0) || isnull(#1)) || (#0 <= #1))
+
+EOF
+
+query II
+SELECT *
+FROM z
+WHERE CASE WHEN a > b THEN FALSE ELSE TRUE END
+----
+NULL  NULL
+NULL  2
+1  NULL
+1  2


### PR DESCRIPTION
<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug. [Link to issue.]

  * This PR adds a known-desirable feature. [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

This PR fixes a recognized bug.

Fixes #9287.

Convert a case with a FALSE then branch into `(!cond OR cond is null) and else`, since the a `null` condition must return the value of the `else` branch.

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
