### PR TITLE
persist: advance persist crate version in lockstep with materialized

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3409,7 +3409,7 @@ dependencies = [
 
 [[package]]
 name = "persist"
-version = "0.0.0"
+version = "0.10.1-dev"
 dependencies = [
  "async-trait",
  "aws-sdk-s3",

--- a/misc/python/materialize/cli/mkrelease.py
+++ b/misc/python/materialize/cli/mkrelease.py
@@ -22,6 +22,7 @@ from semver.version import Version
 from materialize import errors, git, spawn, ui
 
 BIN_CARGO_TOML = "src/materialized/Cargo.toml"
+PERSIST_CARGO_TOML = "src/persist/Cargo.toml"
 LICENSE = "LICENSE"
 USER_DOC_CONFIG = "doc/user/config.toml"
 
@@ -261,6 +262,7 @@ def release(
     confirm_on_latest_rc(affect_remote)
 
     change_line(BIN_CARGO_TOML, "version", f'version = "{version}"')
+    change_line(PERSIST_CARGO_TOML, "version", f'version = "{version}"')
     change_line(
         LICENSE,
         "Licensed Work:",

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "persist"
 description = "Abstraction for Materialize dataplane persistence."
-version = "0.0.0"
+version = "0.10.1-dev"
 edition = "2021"
 publish = false
 

--- a/src/persist/src/lib.rs
+++ b/src/persist/src/lib.rs
@@ -46,6 +46,10 @@ pub mod nemesis;
 // - Failure while draining from log into unsealed.
 // - Equality edge cases around all the various timestamp/frontier checks.
 
+/// The current version of this crate, advanced in lockstep with the
+/// materialized binary itself.
+pub const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+
 /// A type usable as a persisted key or value.
 pub trait Data: Clone + persist_types::Codec + fmt::Debug + Ord {}
 impl<T: Clone + persist_types::Codec + fmt::Debug + Ord> Data for T {}


### PR DESCRIPTION
And make it available within the crate. We'll use this to tag data
written to durable storage and use it to reason about backward and
forward compatibility windows (once we have figured out what the
policies for those will be).

### Motivation

  * This PR adds a feature that has not yet been specified.

Foundations for reasoning about backward and forward compatibility of data in storage.

### Tips for reviewer

Nikhil, is there some better way I should be thinking about this?

Context: https://github.com/MaterializeInc/materialize/pull/9365/files#diff-f97533bcb017df95341321afba62625e8edc9ff1b53c9180736d968a1ae826cbR22-R34
