### PR TITLE
ci-builder: force consistent sort order when computing hash

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -89,10 +89,12 @@ build() {
 files=$(cat \
         <(git diff --name-only -z 4b825dc642cb6eb9a060e54bf8d69288fbee4904 ci/builder) \
         <(git ls-files --others --exclude-standard -z ci/builder) \
-    | sort -z \
+    | LC_ALL=C sort -z \
     | xargs -0 sha1sum)
-files+=$rust_date
-files+=$arch_gcc
+files+="
+date:$rust_date
+arch:$arch_gcc
+"
 tag=$(echo "$files" | python3 -c '
 import base64
 import hashlib


### PR DESCRIPTION
This should fix that divergent ci-builder hashes that some folks are
seeing on their personal machines.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
