### PR TITLE
reuse_topic: Add index to timestamp bindings table

### DIFF
--- a/src/coord/src/catalog/storage.rs
+++ b/src/coord/src/catalog/storage.rs
@@ -125,6 +125,10 @@ const MIGRATIONS: &[&str] = &[
     // Introduced in v0.9.12.
     "INSERT INTO schemas (database_id, name) VALUES
         (NULL, 'information_schema');",
+    // Adds index to timestamp table to more efficiently compact timestamps.
+    //
+    // Introduced in v0.12.0.
+    "CREATE INDEX timestamps_sid_timestamp ON timestamps (sid, timestamp)",
     // Add new migrations here.
     //
     // Migrations should be preceded with a comment of the following form:


### PR DESCRIPTION
We want `compact_timestamp_bindings` to use only indexed lookups.  When a sink enters into an errored state for some reason, we keep the frontier from moving forward and therefore we have a large number of un-compacted timestamp bindings which we query often.  The query requires a full table scan.  We (Ruchir) theorized this was a cause of hangs in the coordinator since profiling spends a lot of time within sqlite.

Add a `(sid, timestamp)` index so that we can do these lookups much more quickly.