### PR TITLE
persist: convert trace batches to use ColumnarRecords

### DIFF
--- a/src/persist/benches/writer.rs
+++ b/src/persist/benches/writer.rs
@@ -300,7 +300,7 @@ pub fn bench_encode_batch(c: &mut Criterion) {
             Antichain::from_elem(1),
             Antichain::from_elem(0),
         ),
-        updates: data.records().collect::<Vec<_>>(),
+        updates: data.batches().collect::<Vec<_>>(),
     };
 
     group.bench_function(BenchmarkId::new("unsealed", data.goodput_pretty()), |b| {


### PR DESCRIPTION
<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

This commit changes the in-memory representation of trace batches to use ColumnarRecords in
the same way that unsealed batches already do. This lets us encode / decode from the on-disk
columnar format more easily, as we no longer have to clone all the key-val pairs into a new
ColumnarRecords object to encode into Parquet.

```
encode_batch/trace/50MiB
                        time:   [79.449 ms 80.585 ms 81.795 ms]
                        thrpt:  [611.28 MiB/s 620.46 MiB/s 629.33 MiB/s]
                 change:
                        time:   [-45.338% -44.432% -43.535%] (p = 0.00 < 0.05)
                        thrpt:  [+77.102% +79.960% +82.941%]
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
```

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug. [Link to issue.]

  * This PR adds a known-desirable feature. [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/9380)
<!-- Reviewable:end -->
