### PR TITLE
interchange: accept protobuf message names without a leading dot

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -103,6 +103,9 @@ List new features before bug fixes.
 
 {{% version-header v0.10.1 %}}
 
+- Accept message names in [Protobuf sources] that do not start with a leading
+  dot. This fixes a regression introduced in v0.9.12.
+
 - Queries that are too big to fit the limits of our intermediate representations
   no longer panic and will now cause query-level failure with an internal error
   and a message of the form "exceeded recursion limit of {X}".
@@ -170,6 +173,10 @@ List new features before bug fixes.
   columns.
 
 {{% version-header v0.9.12 %}}
+
+- **Known issue.** Message names in [Protobuf sources] that do not start with a
+  leading dot are erroneously rejected. As a workaround, add a leading dot to
+  the message name. This regression is corrected in v0.11.0.
 
 - **Breaking change**: Disallow ambiguous table references in queries. For
   example:
@@ -1583,3 +1590,4 @@ a problem with PostgreSQL JDBC 42.3.0.
 [pgwire-simple]: https://www.postgresql.org/docs/current/protocol-flow.html#id-1.10.5.7.4
 [pgwire-extended]: https://www.postgresql.org/docs/current/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY
 [PgJDBC]: https://jdbc.postgresql.org
+[Protobuf sources]: /sql/create-source/protobuf-kinesis/#protobuf-format-details

--- a/doc/user/layouts/partials/create-source/format/protobuf/details.html
+++ b/doc/user/layouts/partials/create-source/format/protobuf/details.html
@@ -2,7 +2,7 @@
 
 Protobuf-formatted external sources require:
 
-- `FileDescriptSet`
+- `FileDescriptorSet`
 - Top-level message name
 
 #### `FileDescriptorSet`

--- a/src/interchange/src/protobuf.rs
+++ b/src/interchange/src/protobuf.rs
@@ -33,7 +33,10 @@ impl DecodedDescriptors {
     /// Builds a `DecodedDescriptors` from an encoded [`FileDescriptorSet`]
     /// and the fully qualified name of a message inside that file descriptor
     /// set.
-    pub fn from_bytes(bytes: &[u8], message_name: String) -> Result<Self, anyhow::Error> {
+    pub fn from_bytes(bytes: &[u8], mut message_name: String) -> Result<Self, anyhow::Error> {
+        if !message_name.starts_with('.') {
+            message_name = format!(".{}", message_name);
+        }
         let fds =
             FileDescriptorSet::parse_from_bytes(bytes).context("parsing file descriptor set")?;
         let fds = FileDescriptor::new_dynamic_fds(fds.file);

--- a/test/testdrive/protobuf-name.td
+++ b/test/testdrive/protobuf-name.td
@@ -1,0 +1,54 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test the various ways to specify the path to a Protobuf message.
+
+$ file-append path=name.proto
+syntax = "proto3";
+
+package some.where;
+
+message Name {
+    int32 i = 1;
+}
+
+$ protobuf-compile-descriptors inputs=name.proto output=name.pb
+
+$ kafka-create-topic topic=name partitions=1
+
+$ kafka-ingest topic=name format=protobuf descriptor-file=name.pb message=.some.where.Name
+{"i": 42}
+
+# Ingesting with the fully-qualified absolute path should work.
+> CREATE MATERIALIZED SOURCE qualified_absolute_path FROM
+  KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-name-${testdrive.seed}'
+  FORMAT PROTOBUF MESSAGE '.some.where.Name' USING SCHEMA FILE '${testdrive.temp-dir}/name.pb'
+> SELECT i, mz_offset FROM qualified_absolute_path
+i   mz_offset
+-------------
+42  1
+
+# Ingesting with the absolute path should work without the leading dot.
+> CREATE MATERIALIZED SOURCE absolute_path FROM
+  KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-name-${testdrive.seed}'
+  FORMAT PROTOBUF MESSAGE 'some.where.Name' USING SCHEMA FILE '${testdrive.temp-dir}/name.pb'
+> SELECT i, mz_offset FROM absolute_path
+i   mz_offset
+-------------
+42  1
+
+# Ingesting without the package prefix should fail.
+! CREATE MATERIALIZED SOURCE absolute_path FROM
+  KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-name-${testdrive.seed}'
+  FORMAT PROTOBUF MESSAGE 'Name' USING SCHEMA FILE '${testdrive.temp-dir}/name.pb'
+protobuf message ".Name" not found in file descriptor set
+! CREATE MATERIALIZED SOURCE absolute_path FROM
+  KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-name-${testdrive.seed}'
+  FORMAT PROTOBUF MESSAGE '.Name' USING SCHEMA FILE '${testdrive.temp-dir}/name.pb'
+protobuf message ".Name" not found in file descriptor set


### PR DESCRIPTION
We accidentally stopped accepting message names without a leading dot in
v0.9.12. Restore that functionality, and add a test case for the
behavior.

Fix #9372.

  * This PR fixes a recognized bug.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
