### PR TITLE
coord: always include system indexes in read transactions

### DIFF
--- a/test/sqllogictest/timedomain.slt
+++ b/test/sqllogictest/timedomain.slt
@@ -1,0 +1,40 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+mode cockroach
+
+statement ok
+CREATE TABLE t (i INT);
+
+# Verify that system tables are always included in read txns, even if not
+# mentioned in the first query.
+simple
+BEGIN;
+SELECT * FROM t;
+SELECT n.nspname = ANY(current_schemas(true)), n.nspname, t.typname FROM pg_catalog.pg_type t JOIN pg_catalog.pg_namespace n ON t.typnamespace = n.oid WHERE t.oid = 2249;
+COMMIT;
+----
+COMPLETE 0
+COMPLETE 0
+t,pg_catalog,record
+COMPLETE 1
+COMPLETE 0
+
+simple
+BEGIN;
+SELECT row(1, 2);
+SELECT n.nspname = ANY(current_schemas(true)), n.nspname, t.typname FROM pg_catalog.pg_type t JOIN pg_catalog.pg_namespace n ON t.typnamespace = n.oid WHERE t.oid = 2249;
+COMMIT;
+----
+COMPLETE 0
+(1,2)
+COMPLETE 1
+t,pg_catalog,record
+COMPLETE 1
+COMPLETE 0


### PR DESCRIPTION
System views from pg_catalog and mz_catalog are sometimes used by
applications (for example Metabase if it doesn't recognize a data type)
after the first query of a transaction. This previously would cause a
timedomain error. One solution to this is to always include system indexes
in read transactions. The cost is mostly that system indexes can now be
held back from compaction more than previously. This seems ok because
they don't change quickly, so should hopefully not cause memory issues.

Fixes #9375
Fixes #9374

### Motivation

  * This PR fixes a recognized bug. #9375 #9374

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
