### PR TITLE
expr: more unary func conversion

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -7,7 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::borrow::Cow;
 use std::cmp::{self, Ordering};
 use std::convert::{TryFrom, TryInto};
 use std::fmt;
@@ -110,77 +109,6 @@ pub fn or<'a>(
             _ => unreachable!(),
         },
     }
-}
-
-fn cast_string_to_array<'a>(
-    a: Datum<'a>,
-    cast_expr: &'a MirScalarExpr,
-    temp_storage: &'a RowArena,
-) -> Result<Datum<'a>, EvalError> {
-    let datums = strconv::parse_array(
-        a.unwrap_str(),
-        || Datum::Null,
-        |elem_text| {
-            let elem_text = match elem_text {
-                Cow::Owned(s) => temp_storage.push_string(s),
-                Cow::Borrowed(s) => s,
-            };
-            cast_expr.eval(&[Datum::String(elem_text)], temp_storage)
-        },
-    )?;
-    array_create_scalar(&datums, temp_storage)
-}
-
-fn cast_string_to_list<'a>(
-    a: Datum<'a>,
-    list_typ: &ScalarType,
-    cast_expr: &'a MirScalarExpr,
-    temp_storage: &'a RowArena,
-) -> Result<Datum<'a>, EvalError> {
-    let parsed_datums = strconv::parse_list(
-        a.unwrap_str(),
-        matches!(list_typ.unwrap_list_element_type(), ScalarType::List { .. }),
-        || Datum::Null,
-        |elem_text| {
-            let elem_text = match elem_text {
-                Cow::Owned(s) => temp_storage.push_string(s),
-                Cow::Borrowed(s) => s,
-            };
-            cast_expr.eval(&[Datum::String(elem_text)], temp_storage)
-        },
-    )?;
-
-    Ok(temp_storage.make_datum(|packer| packer.push_list(parsed_datums)))
-}
-
-fn cast_string_to_map<'a>(
-    a: Datum<'a>,
-    map_typ: &ScalarType,
-    cast_expr: &'a MirScalarExpr,
-    temp_storage: &'a RowArena,
-) -> Result<Datum<'a>, EvalError> {
-    let parsed_map = strconv::parse_map(
-        a.unwrap_str(),
-        matches!(map_typ.unwrap_map_value_type(), ScalarType::Map { .. }),
-        |value_text| -> Result<Datum, EvalError> {
-            let value_text = match value_text {
-                Cow::Owned(s) => temp_storage.push_string(s),
-                Cow::Borrowed(s) => s,
-            };
-            cast_expr.eval(&[Datum::String(value_text)], temp_storage)
-        },
-    )?;
-    let mut pairs: Vec<(String, Datum)> = parsed_map.into_iter().map(|(k, v)| (k, v)).collect();
-    pairs.sort_by(|(k1, _v1), (k2, _v2)| k1.cmp(k2));
-    pairs.dedup_by(|(k1, _v1), (k2, _v2)| k1 == k2);
-    Ok(temp_storage.make_datum(|packer| {
-        packer.push_dict_with(|packer| {
-            for (k, v) in pairs {
-                packer.push(Datum::String(&k));
-                packer.push(v);
-            }
-        })
-    }))
 }
 
 fn cast_str_to_char<'a>(
@@ -3281,27 +3209,9 @@ pub enum UnaryFunc {
     CastStringToFloat32(CastStringToFloat32),
     CastStringToFloat64(CastStringToFloat64),
     CastStringToDate(CastStringToDate),
-    CastStringToArray {
-        // Target array's type.
-        return_ty: ScalarType,
-        // The expression to cast the discovered array elements to the array's
-        // element type.
-        cast_expr: Box<MirScalarExpr>,
-    },
-    CastStringToList {
-        // Target list's type
-        return_ty: ScalarType,
-        // The expression to cast the discovered list elements to the list's
-        // element type.
-        cast_expr: Box<MirScalarExpr>,
-    },
-    CastStringToMap {
-        // Target map's value type
-        return_ty: ScalarType,
-        // The expression used to cast the discovered values to the map's value
-        // type.
-        cast_expr: Box<MirScalarExpr>,
-    },
+    CastStringToArray(CastStringToArray),
+    CastStringToList(CastStringToList),
+    CastStringToMap(CastStringToMap),
     CastStringToTime(CastStringToTime),
     CastStringToTimestamp(CastStringToTimestamp),
     CastStringToTimestampTz(CastStringToTimestampTz),
@@ -3532,6 +3442,9 @@ derive_unary!(
     CastStringToTimestampTz,
     CastStringToInterval,
     CastStringToUuid,
+    CastStringToArray,
+    CastStringToList,
+    CastStringToMap,
     Cos,
     Cosh,
     Sin,
@@ -3673,17 +3586,11 @@ impl UnaryFunc {
             | CastStringToTimestampTz(_)
             | CastStringToInterval(_)
             | CastStringToUuid(_)
+            | CastStringToArray(_)
+            | CastStringToList(_)
+            | CastStringToMap(_)
             | CastFloat32ToFloat64(_) => unreachable!(),
             NegInterval => Ok(neg_interval(a)),
-            CastStringToArray { cast_expr, .. } => cast_string_to_array(a, cast_expr, temp_storage),
-            CastStringToList {
-                cast_expr,
-                return_ty,
-            } => cast_string_to_list(a, return_ty, cast_expr, temp_storage),
-            CastStringToMap {
-                cast_expr,
-                return_ty,
-            } => cast_string_to_map(a, return_ty, cast_expr, temp_storage),
             CastStringToChar {
                 length,
                 fail_on_len,
@@ -3881,6 +3788,9 @@ impl UnaryFunc {
             | CastStringToTimestampTz(_)
             | CastStringToInterval(_)
             | CastStringToUuid(_)
+            | CastStringToArray(_)
+            | CastStringToList(_)
+            | CastStringToMap(_)
             | CastFloat32ToFloat64(_) => unreachable!(),
 
             Ascii | CharLength | BitLengthBytes | BitLengthString | ByteLengthBytes
@@ -3935,11 +3845,9 @@ impl UnaryFunc {
             CastJsonbToFloat64 => ScalarType::Float64.nullable(nullable),
             CastJsonbToBool => ScalarType::Bool.nullable(nullable),
 
-            CastStringToArray { return_ty, .. }
-            | CastStringToMap { return_ty, .. }
-            | CastInPlace { return_ty } => (return_ty.clone()).nullable(nullable),
+            CastInPlace { return_ty } => (return_ty.clone()).nullable(nullable),
 
-            CastList1ToList2 { return_ty, .. } | CastStringToList { return_ty, .. } => {
+            CastList1ToList2 { return_ty, .. } => {
                 return_ty.default_embedded_value().nullable(false)
             }
 
@@ -4113,6 +4021,9 @@ impl UnaryFunc {
             | CastStringToTimestampTz(_)
             | CastStringToInterval(_)
             | CastStringToUuid(_)
+            | CastStringToArray(_)
+            | CastStringToList(_)
+            | CastStringToMap(_)
             | CastFloat32ToFloat64(_) => unreachable!(),
             // These return null when their input is SQL null.
             CastJsonbToString | CastJsonbToInt16 | CastJsonbToInt32 | CastJsonbToInt64
@@ -4152,11 +4063,7 @@ impl UnaryFunc {
             CastIntervalToTime | TimezoneTime { .. } => false,
             CastDateToTimestamp | CastTimestampTzToTimestamp | TimezoneTimestampTz(_) => false,
             CastDateToTimestampTz | CastTimestampToTimestampTz | TimezoneTimestamp(_) => false,
-            CastList1ToList2 { .. }
-            | CastStringToArray { .. }
-            | CastStringToList { .. }
-            | CastStringToMap { .. }
-            | CastInPlace { .. } => false,
+            CastList1ToList2 { .. } | CastInPlace { .. } => false,
             CastStringToChar { .. } | PadChar { .. } => false,
             CastStringToVarChar { .. } => false,
             JsonbTypeof | JsonbStripNulls | JsonbPretty | ListLength => false,
@@ -4347,11 +4254,11 @@ impl UnaryFunc {
             | CastStringToTimestampTz(_)
             | CastStringToInterval(_)
             | CastStringToUuid(_)
+            | CastStringToArray(_)
+            | CastStringToList(_)
+            | CastStringToMap(_)
             | CastFloat32ToFloat64(_) => unreachable!(),
             NegInterval => f.write_str("-"),
-            CastStringToArray { .. } => f.write_str("strtoarray"),
-            CastStringToList { .. } => f.write_str("strtolist"),
-            CastStringToMap { .. } => f.write_str("strtomap"),
             CastStringToChar { .. } => f.write_str("strtochar"),
             PadChar { .. } => f.write_str("padchar"),
             CastCharToString => f.write_str("chartostr"),

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -3178,7 +3178,7 @@ pub enum UnaryFunc {
     CastStringToChar(CastStringToChar),
     PadChar(PadChar),
     CastStringToVarChar(CastStringToVarChar),
-    CastCharToString,
+    CastCharToString(CastCharToString),
     CastVarCharToString,
     CastDateToTimestamp,
     CastDateToTimestampTz,
@@ -3394,6 +3394,7 @@ derive_unary!(
     CastStringToChar,
     PadChar,
     CastStringToVarChar,
+    CastCharToString,
     Cos,
     Cosh,
     Sin,
@@ -3541,10 +3542,9 @@ impl UnaryFunc {
             | CastStringToChar(_)
             | PadChar(_)
             | CastStringToVarChar(_)
+            | CastCharToString(_)
             | CastFloat32ToFloat64(_) => unreachable!(),
             NegInterval => Ok(neg_interval(a)),
-            // This function simply allows the expression of changing a's type from varchar to string
-            CastCharToString => Ok(a),
             CastVarCharToString => Ok(a),
             CastStringToJsonb => cast_string_to_jsonb(a, temp_storage),
             CastDateToTimestamp => Ok(cast_date_to_timestamp(a)),
@@ -3737,6 +3737,7 @@ impl UnaryFunc {
             | CastStringToChar(_)
             | PadChar(_)
             | CastStringToVarChar(_)
+            | CastCharToString(_)
             | CastFloat32ToFloat64(_) => unreachable!(),
 
             Ascii | CharLength | BitLengthBytes | BitLengthString | ByteLengthBytes
@@ -3747,8 +3748,7 @@ impl UnaryFunc {
             CastTimeToInterval => ScalarType::Interval.nullable(nullable),
             CastStringToJsonb => ScalarType::Jsonb.nullable(nullable),
 
-            CastCharToString
-            | CastVarCharToString
+            CastVarCharToString
             | CastDateToString
             | CastTimeToString
             | CastTimestampToString
@@ -3965,6 +3965,7 @@ impl UnaryFunc {
             | CastStringToChar(_)
             | PadChar(_)
             | CastStringToVarChar(_)
+            | CastCharToString(_)
             | CastFloat32ToFloat64(_) => unreachable!(),
             // These return null when their input is SQL null.
             CastJsonbToString | CastJsonbToInt16 | CastJsonbToInt32 | CastJsonbToInt64
@@ -3981,8 +3982,7 @@ impl UnaryFunc {
             | ByteLengthString => false,
             IsRegexpMatch(_) | CastJsonbOrNullToJsonb => false,
             CastTimeToInterval | CastStringToJsonb => false,
-            CastCharToString
-            | CastVarCharToString
+            CastVarCharToString
             | CastDateToString
             | CastTimeToString
             | CastTimestampToString
@@ -4066,8 +4066,7 @@ impl UnaryFunc {
             | SqrtFloat64(_)
             | CbrtFloat64(_)
             | CastFloat32ToFloat64(_) => unreachable!(),
-            CastCharToString
-            | CastVarCharToString
+            CastVarCharToString
             | CastDateToTimestamp
             | CastDateToTimestampTz
             | CastDateToString
@@ -4199,9 +4198,9 @@ impl UnaryFunc {
             | CastStringToChar(_)
             | PadChar(_)
             | CastStringToVarChar(_)
+            | CastCharToString(_)
             | CastFloat32ToFloat64(_) => unreachable!(),
             NegInterval => f.write_str("-"),
-            CastCharToString => f.write_str("chartostr"),
             CastVarCharToString => f.write_str("varchartostr"),
             CastDateToTimestamp => f.write_str("datetots"),
             CastDateToTimestampTz => f.write_str("datetotstz"),

--- a/src/expr/src/scalar/func/impls.rs
+++ b/src/expr/src/scalar/func/impls.rs
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 mod boolean;
+mod char;
 mod datum;
 mod float32;
 mod float64;
@@ -19,6 +20,7 @@ mod oid;
 mod regproc;
 mod string;
 
+pub use self::char::*;
 pub use boolean::*;
 pub use datum::*;
 pub use float32::*;

--- a/src/expr/src/scalar/func/impls/char.rs
+++ b/src/expr/src/scalar/func/impls/char.rs
@@ -48,3 +48,12 @@ impl fmt::Display for PadChar {
         f.write_str("padchar")
     }
 }
+
+// This function simply allows the expression of changing a's type from varchar to string
+sqlfunc!(
+    #[sqlname = "chartostr"]
+    #[preserves_uniqueness = true]
+    fn cast_char_to_string<'a>(a: Char<&'a str>) -> &'a str {
+        a.0
+    }
+);

--- a/src/expr/src/scalar/func/impls/char.rs
+++ b/src/expr/src/scalar/func/impls/char.rs
@@ -1,0 +1,50 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use lowertest::MzStructReflect;
+use repr::adt::char::{format_str_pad, Char};
+use repr::{ColumnType, ScalarType};
+
+use crate::scalar::func::EagerUnaryFunc;
+
+/// All Char data is stored in Datum::String with its blank padding removed
+/// (i.e. trimmed), so this function provides a means of restoring any
+/// removed padding.
+#[derive(
+    Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzStructReflect,
+)]
+pub struct PadChar {
+    pub length: Option<usize>,
+}
+
+impl<'a> EagerUnaryFunc<'a> for PadChar {
+    type Input = &'a str;
+    type Output = Char<String>;
+
+    fn call(&self, a: &'a str) -> Char<String> {
+        Char(format_str_pad(a, self.length))
+    }
+
+    fn output_type(&self, input: ColumnType) -> ColumnType {
+        ScalarType::Char {
+            length: self.length,
+        }
+        .nullable(input.nullable)
+    }
+}
+
+impl fmt::Display for PadChar {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("padchar")
+    }
+}

--- a/src/expr/src/scalar/func/impls/string.rs
+++ b/src/expr/src/scalar/func/impls/string.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::borrow::Cow;
 use std::fmt;
 
 use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
@@ -17,10 +18,10 @@ use lowertest::MzStructReflect;
 use ore::result::ResultExt;
 use repr::adt::interval::Interval;
 use repr::adt::numeric::{self, Numeric};
-use repr::{strconv, ColumnType, ScalarType};
+use repr::{strconv, ColumnType, Datum, RowArena, ScalarType};
 
-use crate::scalar::func::EagerUnaryFunc;
-use crate::EvalError;
+use crate::scalar::func::{array_create_scalar, EagerUnaryFunc, LazyUnaryFunc};
+use crate::{EvalError, MirScalarExpr};
 
 sqlfunc!(
     #[sqlname = "strtobool"]
@@ -143,3 +144,213 @@ sqlfunc!(
         strconv::parse_uuid(a).err_into()
     }
 );
+
+#[derive(
+    Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzStructReflect,
+)]
+pub struct CastStringToArray {
+    // Target array's type.
+    pub return_ty: ScalarType,
+    // The expression to cast the discovered array elements to the array's
+    // element type.
+    pub cast_expr: Box<MirScalarExpr>,
+}
+
+impl LazyUnaryFunc for CastStringToArray {
+    fn eval<'a>(
+        &'a self,
+        datums: &[Datum<'a>],
+        temp_storage: &'a RowArena,
+        a: &'a MirScalarExpr,
+    ) -> Result<Datum<'a>, EvalError> {
+        let a = a.eval(datums, temp_storage)?;
+        if a.is_null() {
+            return Ok(Datum::Null);
+        }
+        let datums = strconv::parse_array(
+            a.unwrap_str(),
+            || Datum::Null,
+            |elem_text| {
+                let elem_text = match elem_text {
+                    Cow::Owned(s) => temp_storage.push_string(s),
+                    Cow::Borrowed(s) => s,
+                };
+                self.cast_expr
+                    .eval(&[Datum::String(elem_text)], temp_storage)
+            },
+        )?;
+        array_create_scalar(&datums, temp_storage)
+    }
+
+    /// The output ColumnType of this function
+    fn output_type(&self, input_type: ColumnType) -> ColumnType {
+        self.return_ty.clone().nullable(input_type.nullable)
+    }
+
+    /// Whether this function will produce NULL on NULL input
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+
+    /// Whether this function will produce NULL on non-NULL input
+    fn introduces_nulls(&self) -> bool {
+        false
+    }
+
+    /// Whether this function preserves uniqueness
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+
+impl fmt::Display for CastStringToArray {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("strtoarray")
+    }
+}
+
+#[derive(
+    Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzStructReflect,
+)]
+pub struct CastStringToList {
+    // Target list's type
+    pub return_ty: ScalarType,
+    // The expression to cast the discovered list elements to the list's
+    // element type.
+    pub cast_expr: Box<MirScalarExpr>,
+}
+
+impl LazyUnaryFunc for CastStringToList {
+    fn eval<'a>(
+        &'a self,
+        datums: &[Datum<'a>],
+        temp_storage: &'a RowArena,
+        a: &'a MirScalarExpr,
+    ) -> Result<Datum<'a>, EvalError> {
+        let a = a.eval(datums, temp_storage)?;
+        if a.is_null() {
+            return Ok(Datum::Null);
+        }
+        let parsed_datums = strconv::parse_list(
+            a.unwrap_str(),
+            matches!(
+                self.return_ty.unwrap_list_element_type(),
+                ScalarType::List { .. }
+            ),
+            || Datum::Null,
+            |elem_text| {
+                let elem_text = match elem_text {
+                    Cow::Owned(s) => temp_storage.push_string(s),
+                    Cow::Borrowed(s) => s,
+                };
+                self.cast_expr
+                    .eval(&[Datum::String(elem_text)], temp_storage)
+            },
+        )?;
+
+        Ok(temp_storage.make_datum(|packer| packer.push_list(parsed_datums)))
+    }
+
+    /// The output ColumnType of this function
+    fn output_type(&self, _input_type: ColumnType) -> ColumnType {
+        self.return_ty.default_embedded_value().nullable(false)
+    }
+
+    /// Whether this function will produce NULL on NULL input
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+
+    /// Whether this function will produce NULL on non-NULL input
+    fn introduces_nulls(&self) -> bool {
+        false
+    }
+
+    /// Whether this function preserves uniqueness
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+
+impl fmt::Display for CastStringToList {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("strtolist")
+    }
+}
+
+#[derive(
+    Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzStructReflect,
+)]
+pub struct CastStringToMap {
+    // Target map's value type
+    pub return_ty: ScalarType,
+    // The expression used to cast the discovered values to the map's value
+    // type.
+    pub cast_expr: Box<MirScalarExpr>,
+}
+
+impl LazyUnaryFunc for CastStringToMap {
+    fn eval<'a>(
+        &'a self,
+        datums: &[Datum<'a>],
+        temp_storage: &'a RowArena,
+        a: &'a MirScalarExpr,
+    ) -> Result<Datum<'a>, EvalError> {
+        let a = a.eval(datums, temp_storage)?;
+        if a.is_null() {
+            return Ok(Datum::Null);
+        }
+        let parsed_map = strconv::parse_map(
+            a.unwrap_str(),
+            matches!(
+                self.return_ty.unwrap_map_value_type(),
+                ScalarType::Map { .. }
+            ),
+            |value_text| -> Result<Datum, EvalError> {
+                let value_text = match value_text {
+                    Cow::Owned(s) => temp_storage.push_string(s),
+                    Cow::Borrowed(s) => s,
+                };
+                self.cast_expr
+                    .eval(&[Datum::String(value_text)], temp_storage)
+            },
+        )?;
+        let mut pairs: Vec<(String, Datum)> = parsed_map.into_iter().map(|(k, v)| (k, v)).collect();
+        pairs.sort_by(|(k1, _v1), (k2, _v2)| k1.cmp(k2));
+        pairs.dedup_by(|(k1, _v1), (k2, _v2)| k1 == k2);
+        Ok(temp_storage.make_datum(|packer| {
+            packer.push_dict_with(|packer| {
+                for (k, v) in pairs {
+                    packer.push(Datum::String(&k));
+                    packer.push(v);
+                }
+            })
+        }))
+    }
+
+    /// The output ColumnType of this function
+    fn output_type(&self, input_type: ColumnType) -> ColumnType {
+        self.return_ty.clone().nullable(input_type.nullable)
+    }
+
+    /// Whether this function will produce NULL on NULL input
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+
+    /// Whether this function will produce NULL on non-NULL input
+    fn introduces_nulls(&self) -> bool {
+        false
+    }
+
+    /// Whether this function preserves uniqueness
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+
+impl fmt::Display for CastStringToMap {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("strtomap")
+    }
+}

--- a/src/repr/src/adt/char.rs
+++ b/src/repr/src/adt/char.rs
@@ -7,12 +7,25 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::ops::Deref;
+
 use anyhow::bail;
 
 use super::util;
 
 // https://github.com/postgres/postgres/blob/REL_14_0/src/include/access/htup_details.h#L577-L584
 pub const MAX_LENGTH: i32 = 10_485_760;
+
+/// A rust type representing a PostgreSQL char type
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Char<S: AsRef<str>>(pub S);
+
+impl<S: AsRef<str>> Deref for Char<S> {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref()
+    }
+}
 
 pub fn extract_typ_mod(typ_mod: &[u64]) -> Result<Option<usize>, anyhow::Error> {
     let typ_mod = util::extract_typ_mod::<usize>(

--- a/src/repr/src/adt/varchar.rs
+++ b/src/repr/src/adt/varchar.rs
@@ -7,12 +7,25 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::ops::Deref;
+
 use anyhow::bail;
 
 use super::util;
 
 // https://github.com/postgres/postgres/blob/REL_14_0/src/include/access/htup_details.h#L577-L584
 pub const MAX_LENGTH: i32 = 10_485_760;
+
+/// A rust type representing a PostgreSQL varchar type
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct VarChar<S: AsRef<str>>(pub S);
+
+impl<S: AsRef<str>> Deref for VarChar<S> {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref()
+    }
+}
 
 pub fn extract_typ_mod(typ_mod: &[u64]) -> Result<Option<usize>, anyhow::Error> {
     let typ_mod = util::extract_typ_mod::<usize>(

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -22,9 +22,11 @@ use uuid::Uuid;
 use lowertest::MzEnumReflect;
 
 use crate::adt::array::Array;
+use crate::adt::char::Char;
 use crate::adt::interval::Interval;
 use crate::adt::numeric::Numeric;
 use crate::adt::system::{Oid, RegClass, RegProc, RegType};
+use crate::adt::varchar::VarChar;
 use crate::{ColumnName, ColumnType, DatumList, DatumMap};
 use crate::{Row, RowArena};
 
@@ -1266,6 +1268,74 @@ impl<'a, E> DatumType<'a, E> for RegType {
 
     fn into_result(self, _temp_storage: &'a RowArena) -> Result<Datum<'a>, E> {
         Ok(Datum::Int32(self.0))
+    }
+}
+
+impl<'a, E> DatumType<'a, E> for Char<&'a str> {
+    fn nullable() -> bool {
+        false
+    }
+
+    fn try_from_result(res: Result<Datum<'a>, E>) -> Result<Self, Result<Datum<'a>, E>> {
+        match res {
+            Ok(Datum::String(a)) => Ok(Char(a)),
+            _ => Err(res),
+        }
+    }
+
+    fn into_result(self, _temp_storage: &'a RowArena) -> Result<Datum<'a>, E> {
+        Ok(Datum::String(self.0))
+    }
+}
+
+impl<'a, E> DatumType<'a, E> for Char<String> {
+    fn nullable() -> bool {
+        false
+    }
+
+    fn try_from_result(res: Result<Datum<'a>, E>) -> Result<Self, Result<Datum<'a>, E>> {
+        match res {
+            Ok(Datum::String(a)) => Ok(Char(a.to_owned())),
+            _ => Err(res),
+        }
+    }
+
+    fn into_result(self, temp_storage: &'a RowArena) -> Result<Datum<'a>, E> {
+        Ok(Datum::String(temp_storage.push_string(self.0)))
+    }
+}
+
+impl<'a, E> DatumType<'a, E> for VarChar<&'a str> {
+    fn nullable() -> bool {
+        false
+    }
+
+    fn try_from_result(res: Result<Datum<'a>, E>) -> Result<Self, Result<Datum<'a>, E>> {
+        match res {
+            Ok(Datum::String(a)) => Ok(VarChar(a)),
+            _ => Err(res),
+        }
+    }
+
+    fn into_result(self, _temp_storage: &'a RowArena) -> Result<Datum<'a>, E> {
+        Ok(Datum::String(self.0))
+    }
+}
+
+impl<'a, E> DatumType<'a, E> for VarChar<String> {
+    fn nullable() -> bool {
+        false
+    }
+
+    fn try_from_result(res: Result<Datum<'a>, E>) -> Result<Self, Result<Datum<'a>, E>> {
+        match res {
+            Ok(Datum::String(a)) => Ok(VarChar(a.to_owned())),
+            _ => Err(res),
+        }
+    }
+
+    fn into_result(self, temp_storage: &'a RowArena) -> Result<Datum<'a>, E> {
+        Ok(Datum::String(temp_storage.push_string(self.0)))
     }
 }
 

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1395,7 +1395,7 @@ lazy_static! {
                             // to match historical baggage in PostgreSQL.
                             ScalarType::Bool => expr.call_unary(UnaryFunc::CastBoolToStringNonstandard(func::CastBoolToStringNonstandard)),
                             // TODO(#7572): remove call to PadChar
-                            ScalarType::Char { length } => expr.call_unary(UnaryFunc::PadChar { length }),
+                            ScalarType::Char { length } => expr.call_unary(UnaryFunc::PadChar(func::PadChar { length })),
                             _ => typeconv::to_string(ecx, expr)
                         });
                     }
@@ -1581,7 +1581,7 @@ lazy_static! {
                 params!(String) => UnaryFunc::ByteLengthString, 1374;
                 params!(Char) => Operation::unary(|ecx, e| {
                     let length = ecx.scalar_type(&e).unwrap_char_varchar_length();
-                    Ok(e.call_unary(UnaryFunc::PadChar { length })
+                    Ok(e.call_unary(UnaryFunc::PadChar(func::PadChar { length }))
                         .call_unary(UnaryFunc::ByteLengthString)
                     )
                 }), 1375;
@@ -1776,7 +1776,7 @@ lazy_static! {
                 params!(Any) => Operation::unary(|ecx, e| {
                     // TODO(#7572): remove this
                     let e = match ecx.scalar_type(&e) {
-                        ScalarType::Char { length } => e.call_unary(UnaryFunc::PadChar { length }),
+                        ScalarType::Char { length } => e.call_unary(UnaryFunc::PadChar(func::PadChar { length })),
                         _ => e,
                     };
                     Ok(typeconv::to_jsonb(ecx, e))
@@ -1885,7 +1885,7 @@ lazy_static! {
                 params!(Any) => Operation::unary_ordered(|ecx, e, order_by| {
                     // TODO(#7572): remove this
                     let e = match ecx.scalar_type(&e) {
-                        ScalarType::Char { length } => e.call_unary(UnaryFunc::PadChar { length }),
+                        ScalarType::Char { length } => e.call_unary(UnaryFunc::PadChar(func::PadChar { length })),
                         _ => e,
                     };
                     // `AggregateFunc::JsonbAgg` filters out `Datum::Null` (it
@@ -1905,11 +1905,11 @@ lazy_static! {
                 params!(Any, Any) => Operation::binary_ordered(|ecx, key, val, order_by| {
                     // TODO(#7572): remove this
                     let key = match ecx.scalar_type(&key) {
-                        ScalarType::Char { length } => key.call_unary(UnaryFunc::PadChar { length }),
+                        ScalarType::Char { length } => key.call_unary(UnaryFunc::PadChar(func::PadChar { length })),
                         _ => key,
                     };
                     let val = match ecx.scalar_type(&val) {
-                        ScalarType::Char { length } => val.call_unary(UnaryFunc::PadChar { length }),
+                        ScalarType::Char { length } => val.call_unary(UnaryFunc::PadChar(func::PadChar { length })),
                         _ => val,
                     };
 
@@ -2504,7 +2504,7 @@ lazy_static! {
                 params!(String, String) => IsLikePatternMatch { case_insensitive: false }, 1209;
                 params!(Char, String) => Operation::binary(|ecx, lhs, rhs| {
                     let length = ecx.scalar_type(&lhs).unwrap_char_varchar_length();
-                    Ok(lhs.call_unary(UnaryFunc::PadChar { length })
+                    Ok(lhs.call_unary(UnaryFunc::PadChar(func::PadChar { length }))
                         .call_binary(rhs, IsLikePatternMatch { case_insensitive: false })
                     )
                 }), 1211;
@@ -2517,7 +2517,7 @@ lazy_static! {
                 }), 1210;
                 params!(Char, String) => Operation::binary(|ecx, lhs, rhs| {
                     let length = ecx.scalar_type(&lhs).unwrap_char_varchar_length();
-                    Ok(lhs.call_unary(UnaryFunc::PadChar { length })
+                    Ok(lhs.call_unary(UnaryFunc::PadChar(func::PadChar { length }))
                         .call_binary(rhs, IsLikePatternMatch { case_insensitive: false })
                         .call_unary(UnaryFunc::Not(func::Not))
                     )
@@ -2532,7 +2532,7 @@ lazy_static! {
                 params!(String, String) => IsRegexpMatch { case_insensitive: false }, 641;
                 params!(Char, String) => Operation::binary(|ecx, lhs, rhs| {
                     let length = ecx.scalar_type(&lhs).unwrap_char_varchar_length();
-                    Ok(lhs.call_unary(UnaryFunc::PadChar { length })
+                    Ok(lhs.call_unary(UnaryFunc::PadChar(func::PadChar { length }))
                         .call_binary(rhs, IsRegexpMatch { case_insensitive: false })
                     )
                 }), 1055;
@@ -2543,7 +2543,7 @@ lazy_static! {
                 }), 1228;
                 params!(Char, String) => Operation::binary(|ecx, lhs, rhs| {
                     let length = ecx.scalar_type(&lhs).unwrap_char_varchar_length();
-                    Ok(lhs.call_unary(UnaryFunc::PadChar { length })
+                    Ok(lhs.call_unary(UnaryFunc::PadChar(func::PadChar { length }))
                         .call_binary(rhs, IsRegexpMatch { case_insensitive: true })
                     )
                 }), 1234;
@@ -2556,7 +2556,7 @@ lazy_static! {
                 }), 642;
                 params!(Char, String) => Operation::binary(|ecx, lhs, rhs| {
                     let length = ecx.scalar_type(&lhs).unwrap_char_varchar_length();
-                    Ok(lhs.call_unary(UnaryFunc::PadChar { length })
+                    Ok(lhs.call_unary(UnaryFunc::PadChar(func::PadChar { length }))
                         .call_binary(rhs, IsRegexpMatch { case_insensitive: true })
                         .call_unary(UnaryFunc::Not(func::Not))
                     )
@@ -2570,7 +2570,7 @@ lazy_static! {
                 }), 1229;
                 params!(Char, String) => Operation::binary(|ecx, lhs, rhs| {
                     let length = ecx.scalar_type(&lhs).unwrap_char_varchar_length();
-                    Ok(lhs.call_unary(UnaryFunc::PadChar { length })
+                    Ok(lhs.call_unary(UnaryFunc::PadChar(func::PadChar { length }))
                         .call_binary(rhs, IsRegexpMatch { case_insensitive: true })
                         .call_unary(UnaryFunc::Not(func::Not))
                     )

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -329,28 +329,28 @@ lazy_static! {
                 let return_ty = to_type.clone();
                 let to_el_type = to_type.unwrap_array_element_type();
                 let cast_expr = plan_hypothetical_cast(ecx, ccx, from_type, to_el_type)?;
-                Some(|e: HirScalarExpr| e.call_unary(UnaryFunc::CastStringToArray {
+                Some(|e: HirScalarExpr| e.call_unary(UnaryFunc::CastStringToArray(func::CastStringToArray {
                     return_ty,
                     cast_expr: Box::new(cast_expr),
-                }))
+                })))
             }),
             (String, List) => Explicit: CastTemplate::new(|ecx, ccx, from_type, to_type| {
                 let return_ty = to_type.clone();
                 let to_el_type = to_type.unwrap_list_element_type();
                 let cast_expr = plan_hypothetical_cast(ecx, ccx, from_type, to_el_type)?;
-                Some(|e: HirScalarExpr| e.call_unary(UnaryFunc::CastStringToList {
+                Some(|e: HirScalarExpr| e.call_unary(UnaryFunc::CastStringToList(func::CastStringToList {
                     return_ty,
                     cast_expr: Box::new(cast_expr),
-                }))
+                })))
             }),
             (String, Map) => Explicit: CastTemplate::new(|ecx, ccx, from_type, to_type| {
                 let return_ty = to_type.clone();
                 let to_val_type = to_type.unwrap_map_value_type();
                 let cast_expr = plan_hypothetical_cast(ecx, ccx, from_type, to_val_type)?;
-                Some(|e: HirScalarExpr| e.call_unary(UnaryFunc::CastStringToMap {
+                Some(|e: HirScalarExpr| e.call_unary(UnaryFunc::CastStringToMap(func::CastStringToMap {
                     return_ty,
                     cast_expr: Box::new(cast_expr),
-                }))
+                })))
             }),
             (String, Char) => Assignment: CastTemplate::new(|_ecx, ccx, _from_type, to_type| {
                 let length = to_type.unwrap_char_varchar_length();

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -354,33 +354,33 @@ lazy_static! {
             }),
             (String, Char) => Assignment: CastTemplate::new(|_ecx, ccx, _from_type, to_type| {
                 let length = to_type.unwrap_char_varchar_length();
-                Some(move |e: HirScalarExpr| e.call_unary(CastStringToChar {length, fail_on_len: ccx == CastContext::Assignment}))
+                Some(move |e: HirScalarExpr| e.call_unary(CastStringToChar(func::CastStringToChar {length, fail_on_len: ccx == CastContext::Assignment})))
             }),
             (String, VarChar) => Assignment: CastTemplate::new(|_ecx, ccx, _from_type, to_type| {
                 let length = to_type.unwrap_char_varchar_length();
-                Some(move |e: HirScalarExpr| e.call_unary(CastStringToVarChar {length, fail_on_len: ccx == CastContext::Assignment}))
+                Some(move |e: HirScalarExpr| e.call_unary(CastStringToVarChar(func::CastStringToVarChar {length, fail_on_len: ccx == CastContext::Assignment})))
             }),
 
             // CHAR
             (Char, String) => Implicit: CastCharToString,
             (Char, Char) => Implicit: CastTemplate::new(|_ecx, ccx, _from_type, to_type| {
                 let length = to_type.unwrap_char_varchar_length();
-                Some(move |e: HirScalarExpr| e.call_unary(CastStringToChar {length, fail_on_len: ccx == CastContext::Assignment}))
+                Some(move |e: HirScalarExpr| e.call_unary(CastStringToChar(func::CastStringToChar {length, fail_on_len: ccx == CastContext::Assignment})))
             }),
             (Char, VarChar) => Assignment: CastTemplate::new(|_ecx, ccx, _from_type, to_type| {
                 let length = to_type.unwrap_char_varchar_length();
-                Some(move |e: HirScalarExpr| e.call_unary(CastStringToVarChar {length, fail_on_len: ccx == CastContext::Assignment}))
+                Some(move |e: HirScalarExpr| e.call_unary(CastStringToVarChar(func::CastStringToVarChar {length, fail_on_len: ccx == CastContext::Assignment})))
             }),
 
             // VARCHAR
             (VarChar, String) => Implicit: CastVarCharToString,
             (VarChar, Char) => Implicit: CastTemplate::new(|_ecx, ccx, _from_type, to_type| {
                 let length = to_type.unwrap_char_varchar_length();
-                Some(move |e: HirScalarExpr| e.call_unary(CastStringToChar {length, fail_on_len: ccx == CastContext::Assignment}))
+                Some(move |e: HirScalarExpr| e.call_unary(CastStringToChar(func::CastStringToChar {length, fail_on_len: ccx == CastContext::Assignment})))
             }),
             (VarChar, VarChar) => Implicit: CastTemplate::new(|_ecx, ccx, _from_type, to_type| {
                 let length = to_type.unwrap_char_varchar_length();
-                Some(move |e: HirScalarExpr| e.call_unary(CastStringToVarChar {length, fail_on_len: ccx == CastContext::Assignment}))
+                Some(move |e: HirScalarExpr| e.call_unary(CastStringToVarChar(func::CastStringToVarChar {length, fail_on_len: ccx == CastContext::Assignment})))
             }),
 
             // RECORD

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -362,7 +362,7 @@ lazy_static! {
             }),
 
             // CHAR
-            (Char, String) => Implicit: CastCharToString,
+            (Char, String) => Implicit: CastCharToString(func::CastCharToString),
             (Char, Char) => Implicit: CastTemplate::new(|_ecx, ccx, _from_type, to_type| {
                 let length = to_type.unwrap_char_varchar_length();
                 Some(move |e: HirScalarExpr| e.call_unary(CastStringToChar(func::CastStringToChar {length, fail_on_len: ccx == CastContext::Assignment})))


### PR DESCRIPTION
The ` strto{array,list,map}` functions are complex enough that can't take advantage of the simplified traits so the implementation is a bit verbose
