### PR TITLE
ci: fix nightly pipeline

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -36,7 +36,8 @@
 
 - id: testdrive-redpanda-aarch64
   label: ":racing_car: testdrive :panda_face: aarch64"
-  queue: aarch64
+  agents:
+    queue: aarch64
   plugins:
     - ./ci/plugins/mzcompose:
         composition: testdrive


### PR DESCRIPTION
The `queue` property must be nested under the `agents` key.
