### PR TITLE
ci/deploy: try a different tarball naming strategy

### DIFF
--- a/ci/deploy/deploy_util.py
+++ b/ci/deploy/deploy_util.py
@@ -75,7 +75,7 @@ def upload_latest_redirect(platform: str, version: str) -> None:
 
 
 def deploy_tarball(platform: str, materialized: Path) -> None:
-    tar_path = materialized.with_suffix(".tar.gz")
+    tar_path = Path("materialized-{platform}.tar.gz")
     with tarfile.open(str(tar_path), "x:gz") as f:
         f.addfile(_tardir("materialized"))
         f.addfile(_tardir("materialized/bin"))


### PR DESCRIPTION
Just appending the ".tar.gz" suffix results in a file that doesn't get
cleaned up by `git clean` for the macOS tarballs.
