### PR TITLE
Extend expression reduction around boolean operations: (null AND c) => null

### DIFF
--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -518,9 +518,15 @@ impl MirScalarExpr {
                             }
                         } else if *func == BinaryFunc::And {
                             // If we are here, not both inputs are literals.
-                            if expr1.is_literal_false() || expr2.is_literal_true() {
+                            if expr1.is_literal_false()
+                                || expr1.is_literal_null()
+                                || expr2.is_literal_true()
+                            {
                                 *e = expr1.take();
-                            } else if expr2.is_literal_false() || expr1.is_literal_true() {
+                            } else if expr2.is_literal_false()
+                                || expr2.is_literal_null()
+                                || expr1.is_literal_true()
+                            {
                                 *e = expr2.take();
                             } else if expr1 == expr2 {
                                 *e = expr1.take();

--- a/src/expr/tests/testdata/reduce
+++ b/src/expr/tests/testdata/reduce
@@ -338,7 +338,7 @@ reduce
 (if (call_binary gt #0 #1) false (null bool))
 [int32 int32]
 ----
-(null && ((isnull(#0) || isnull(#1)) || (#0 <= #1)))
+null
 
 reduce
 (if (call_binary gt #0 #1) false false)
@@ -357,7 +357,7 @@ reduce
 (if (call_binary gt #0 #1) (null bool) false)
 [int32 int32]
 ----
-(null && (#0 > #1))
+null
 
 # non-literal expression in the THEN clause
 reduce
@@ -407,6 +407,80 @@ reduce
 [int32 int32]
 ----
 if (#0 > #1) then {1} else {2}
+
+# AND/OR simplifications
+
+reduce
+(call_binary or #1 false)
+[bool]
+----
+#1
+
+reduce
+(call_binary or false #1)
+[bool]
+----
+#1
+
+reduce
+(call_binary or #1 true)
+[bool]
+----
+true
+
+reduce
+(call_binary or true #1)
+[bool]
+----
+true
+
+reduce
+(call_binary or #1 null)
+[bool]
+----
+(#1 || null)
+
+reduce
+(call_binary or null #1)
+[bool]
+----
+(#1 || null)
+
+reduce
+(call_binary and #1 false)
+[bool]
+----
+false
+
+reduce
+(call_binary and false #1)
+[bool]
+----
+false
+
+reduce
+(call_binary and #1 true)
+[bool]
+----
+#1
+
+reduce
+(call_binary and true #1)
+[bool]
+----
+#1
+
+reduce
+(call_binary and #1 null)
+[bool]
+----
+null
+
+reduce
+(call_binary and null #1)
+[bool]
+----
+null
 
 ## undistribute_and/or works despite multiple copies of the same expression in
 ## the intersection

--- a/test/sqllogictest/boolean.slt
+++ b/test/sqllogictest/boolean.slt
@@ -266,7 +266,7 @@ FROM y
 ----
 %0 =
 | Get materialize.public.y (u5)
-| Map (#1 && null)
+| Map null
 | Project (#2)
 
 EOF
@@ -292,7 +292,7 @@ FROM y
 ----
 %0 =
 | Get materialize.public.y (u5)
-| Map (null && (!(#1) || isnull(#1)))
+| Map null
 | Project (#2)
 
 EOF


### PR DESCRIPTION
<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug. [Link to issue.]

  * This PR adds a known-desirable feature. [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

This PR adds a feature that has not yet been specified.

This simplifies AND expressions with a `null` operand and adds unit tests for the reductions around AND/OR expressions.

Spotted this was missing while working on #9370.

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

Note that `(null OR c)` cannot be simplified as `c` since a `null` must be returned is `c` evaluates to `false`.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
