### PR TITLE
sql: add pg_catalog.pg_tables view

### DIFF
--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -1605,8 +1605,8 @@ pub const PG_TABLES: BuiltinView = BuiltinView {
     schema: PG_CATALOG_SCHEMA,
     sql: "CREATE VIEW pg_tables AS 
 SELECT n.nspname AS schemaname,
-  c.relname AS tablename,
-  pg_catalog.pg_get_userbyid(c.relowner) AS tableowner
+    c.relname AS tablename,
+    pg_catalog.pg_get_userbyid(c.relowner) AS tableowner
 FROM pg_catalog.pg_class c
 LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
 WHERE c.relkind = ANY (ARRAY['r','p'])",

--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -1603,7 +1603,7 @@ pub const PG_CONSTRAINT: BuiltinView = BuiltinView {
 pub const PG_TABLES: BuiltinView = BuiltinView {
     name: "pg_tables",
     schema: PG_CATALOG_SCHEMA,
-    sql: "CREATE VIEW pg_tables AS 
+    sql: "CREATE VIEW pg_tables AS
 SELECT n.nspname AS schemaname,
     c.relname AS tablename,
     pg_catalog.pg_get_userbyid(c.relowner) AS tableowner

--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -1600,7 +1600,21 @@ pub const PG_CONSTRAINT: BuiltinView = BuiltinView {
     needs_logs: false,
 };
 
-// Next id BuiltinView: 5035
+pub const PG_TABLES: BuiltinView = BuiltinView {
+    name: "pg_tables",
+    schema: PG_CATALOG_SCHEMA,
+    sql: "CREATE VIEW pg_tables AS 
+SELECT n.nspname AS schemaname,
+  c.relname AS tablename,
+  pg_catalog.pg_get_userbyid(c.relowner) AS tableowner
+FROM pg_catalog.pg_class c
+LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+WHERE c.relkind = ANY (ARRAY['r','p'])",
+    id: GlobalId::System(5035),
+    needs_logs: false,
+};
+
+// Next id BuiltinView: 5036
 
 pub const MZ_SYSTEM: BuiltinRole = BuiltinRole {
     name: "mz_system",
@@ -1741,6 +1755,7 @@ lazy_static! {
             Builtin::View(&PG_ATTRDEF),
             Builtin::View(&PG_SETTINGS),
             Builtin::View(&PG_CONSTRAINT),
+            Builtin::View(&PG_TABLES),
         ];
 
         // TODO(sploiselle): assign static global IDs to functions


### PR DESCRIPTION
<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

Add pg_catalog.pg_tables view.

The original view in PG is a bit more complicated:
```
 SELECT n.nspname AS schemaname,
    c.relname AS tablename,
    pg_get_userbyid(c.relowner) AS tableowner,
    t.spcname AS tablespace,
    c.relhasindex AS hasindexes,
    c.relhasrules AS hasrules,
    c.relhastriggers AS hastriggers,
    c.relrowsecurity AS rowsecurity
   FROM pg_class c
     LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
     LEFT JOIN pg_tablespace t ON t.oid = c.reltablespace
  WHERE c.relkind = ANY (ARRAY['r'::"char", 'p'::"char"]);
```

but we don't support many of the columns on `pg_class`. This PR adds a simplified version of that view.

There is a precedent of no tests and no release-note, so I am following it in this PR.