### PR TITLE
persist: fix error on empty writes

### DIFF
--- a/src/persist/src/operators/stream.rs
+++ b/src/persist/src/operators/stream.rs
@@ -784,19 +784,21 @@ where
                         session.give(update);
                     }
 
-                    let write_future = write.write(&to_retract);
-                    to_retract.clear();
+                    if !to_retract.is_empty() {
+                        let write_future = write.write(&to_retract);
+                        to_retract.clear();
 
-                    // We are not using the capability for the main output later, but we are
-                    // holding on to it to keep the frontier from advancing because that frontier
-                    // is used downstream to track how far we have persisted. This is used, for
-                    // example, by upsert()/persist()/seal()/conditional_seal() operators
-                    // and await_frontier().
-                    pending_futures.push_back((
-                        cap.delayed(cap.time()),
-                        cap.retain_for_output(error_output_port),
-                        write_future,
-                    ));
+                        // We are not using the capability for the main output later, but we are
+                        // holding on to it to keep the frontier from advancing because that frontier
+                        // is used downstream to track how far we have persisted. This is used, for
+                        // example, by upsert()/persist()/seal()/conditional_seal() operators
+                        // and await_frontier().
+                        pending_futures.push_back((
+                            cap.delayed(cap.time()),
+                            cap.retain_for_output(error_output_port),
+                            write_future,
+                        ));
+                    }
                 });
 
                 // Swing through all pending futures and see if they're ready. Ready futures will


### PR DESCRIPTION
<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

After we switched to a columnar encoding, persist started erroring on empty write
commands. Previously, we would correctly detect when the set of pending writes was
empty and simply refuse to write a new unsealed batch. The commit that added columnar
unsealed batches broke the emptiness check, because we replaced it with a check
that the `Vec<ColumnarRecords>` itself was empty, which is more like checking that
no writes were performed.

This commit changes the behavior to only store non-empty ColumnarRecords in `pending`,
and adds a sanity check for that invariant plus a regression test. We chose to drop
the empty records as early as possible, because we don't want to be encoding these
empty ColumnarRecords at all its a pure waste of storage space, so they would either
have to be dropped just before we encode an UnsealedBatch at the latest, and from
that, there didn't seem to be any reason to keep them around at all.

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug. [Link to issue.]

  * This PR adds a known-desirable feature. [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
