### PR TITLE
Fix bin/check: the `-A style` after denying style lints re-allowed them

### DIFF
--- a/bin/check
+++ b/bin/check
@@ -162,7 +162,12 @@ extra_lints=(
 # splitting below. It's substantially clearer than doing things "properly,"
 # and the inputs to this script are trusted.
 
+flags=""
+if [[ "$*" =~ --fix ]] ; then
+    flags=--fix
+fi
+
 # shellcheck disable=SC2046
-run cargo clippy --all-targets -- \
-    $(printf -- "-D %s " "${extra_lints[@]}") \
-    $(printf -- "-A %s " "${disabled_lints[@]}")
+run cargo clippy --all-targets $flags -- \
+    $(printf -- "-A %s " "${disabled_lints[@]}") \
+    $(printf -- "-D %s " "${extra_lints[@]}")

--- a/src/ccsr/src/client.rs
+++ b/src/ccsr/src/client.rs
@@ -38,7 +38,7 @@ impl Client {
         Ok(Client { inner, url, auth })
     }
 
-    fn make_request<'a, P>(&self, method: Method, path: P) -> reqwest::RequestBuilder
+    fn make_request<P>(&self, method: Method, path: P) -> reqwest::RequestBuilder
     where
         P: IntoIterator,
         P::Item: AsRef<str>,

--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -247,7 +247,7 @@ impl CatalogState {
     pub fn populate_enabled_indexes(&mut self, id: GlobalId, item: &CatalogItem) {
         match item {
             CatalogItem::Table(_) | CatalogItem::Source(_) | CatalogItem::View(_) => {
-                self.enabled_indexes.entry(id).or_insert_with(|| vec![]);
+                self.enabled_indexes.entry(id).or_insert_with(Vec::new);
             }
             CatalogItem::Index(index) => {
                 if index.enabled {

--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -1888,12 +1888,7 @@ mod tests {
             if let Builtin::Func(func) = builtin {
                 for imp in func.inner.func_impls() {
                     // Verify that all function OIDs are unique.
-                    assert!(
-                        oids.insert(imp.oid) == true,
-                        "{} reused oid {}",
-                        func.name,
-                        imp.oid
-                    );
+                    assert!(oids.insert(imp.oid), "{} reused oid {}", func.name, imp.oid);
 
                     if imp.oid > 16_000 {
                         // High OIDS are reserved in materialize and don't have postgres counterparts.

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -3491,7 +3491,7 @@ where
                 affected_rows += diff;
             }
 
-            if all_positive_diffs == false {
+            if !all_positive_diffs {
                 // Consolidate rows. This is useful e.g. for an UPDATE where the row
                 // doesn't change, and we need to reflect that in the number of
                 // affected rows.
@@ -3695,7 +3695,7 @@ where
         {
             Ok(resp) => resp,
             Err(e) => {
-                tx.send(Err(e.into()), session);
+                tx.send(Err(e), session);
                 return;
             }
         };

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1744,10 +1744,7 @@ where
                 tx.send(self.sequence_create_role(plan).await, session);
             }
             Plan::CreateTable(plan) => {
-                tx.send(
-                    self.sequence_create_table(&mut session, plan).await,
-                    session,
-                );
+                tx.send(self.sequence_create_table(&session, plan).await, session);
             }
             Plan::CreateSource(plan) => {
                 tx.send(
@@ -1759,7 +1756,7 @@ where
                 self.sequence_create_sink(session, plan, tx).await;
             }
             Plan::CreateView(plan) => {
-                tx.send(self.sequence_create_view(&mut session, plan).await, session);
+                tx.send(self.sequence_create_view(&session, plan).await, session);
             }
             Plan::CreateViews(plan) => {
                 tx.send(

--- a/src/coord/src/coord/prometheus.rs
+++ b/src/coord/src/coord/prometheus.rs
@@ -154,7 +154,7 @@ fn add_expiring_update(
     });
 }
 
-fn add_metadata_update<'a, I: IntoIterator<Item = Row>>(
+fn add_metadata_update<I: IntoIterator<Item = Row>>(
     updates: I,
     diff: Diff,
     retain_for: u64,

--- a/src/coord/src/error.rs
+++ b/src/coord/src/error.rs
@@ -287,8 +287,8 @@ impl fmt::Display for CoordError {
             CoordError::RelationOutsideTimeDomain { .. } => {
                 write!(
                     f,
-                    "Transactions can only reference objects in the same timedomain. See {}",
-                    "https://materialize.com/docs/sql/begin/#same-timedomain-error",
+                    "Transactions can only reference objects in the same timedomain. \
+                     See https://materialize.com/docs/sql/begin/#same-timedomain-error",
                 )
             }
             CoordError::SafeModeViolation(feature) => {

--- a/src/coord/src/sink_connector.rs
+++ b/src/coord/src/sink_connector.rs
@@ -176,7 +176,7 @@ fn maybe_decode_consistency_end_record(
         match (status, id) {
             (Some(Value::String(status)), Some(Value::String(id))) if status == "END" => {
                 if let Ok(ts) = id.parse::<u64>() {
-                    Ok(Some(Timestamp::from(ts)))
+                    Ok(Some(ts))
                 } else {
                     bail!(
                         "Malformed consistency record, failed to parse timestamp {} in topic {}",

--- a/src/coordtest/src/lib.rs
+++ b/src/coordtest/src/lib.rs
@@ -320,7 +320,7 @@ async fn sql(sc: &mut SessionClient, query: String) -> anyhow::Result<Vec<Execut
 }
 
 pub async fn walk(dir: &str) {
-    datadriven::walk_async(dir, |tf| run_test(tf)).await;
+    datadriven::walk_async(dir, run_test).await;
 }
 
 pub async fn run_test(mut tf: datadriven::TestFile) -> datadriven::TestFile {

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -192,7 +192,7 @@ impl Command {
                     }
                     dataflows_parts
                         .into_iter()
-                        .map(|dataflows| Command::CreateDataflows(dataflows))
+                        .map(Command::CreateDataflows)
                         .collect()
                 }
                 Command::Insert { id, updates } => {
@@ -557,7 +557,7 @@ pub mod partitioned {
                     let entry = self
                         .peek_responses
                         .entry(connection)
-                        .or_insert_with(|| Default::default());
+                        .or_insert_with(Default::default);
                     let novel = entry.insert(shard_id, response);
                     assert!(novel.is_none(), "Duplicate peek response");
                     // We may be ready to respond.

--- a/src/dataflow-types/src/plan/reduce.rs
+++ b/src/dataflow-types/src/plan/reduce.rs
@@ -434,11 +434,7 @@ impl ReducePlan {
         match self {
             ReducePlan::DistinctNegated => {}
             _ => {
-                keys.push(
-                    (0..key_arity)
-                        .map(|column| expr::MirScalarExpr::Column(column))
-                        .collect(),
-                );
+                keys.push((0..key_arity).map(expr::MirScalarExpr::Column).collect());
             }
         }
         keys

--- a/src/dataflow/src/decode/mod.rs
+++ b/src/dataflow/src/decode/mod.rs
@@ -56,7 +56,7 @@ pub fn rewrite_for_upsert(
         // often off by one, but is only tracked every N seconds so it will always be off
         metrics.set(keys.len() as u64);
 
-        let entry = keys.entry(key.into());
+        let entry = keys.entry(key);
 
         let mut rowiter = row.iter();
         let before = rowiter.next().expect("must have a before list");

--- a/src/dataflow/src/render/reduce.rs
+++ b/src/dataflow/src/render/reduce.rs
@@ -267,7 +267,7 @@ where
         let (ok, mut err) = key_val_input
             .as_collection()
             .consolidate_stream()
-            .flat_map_fallible("OkErrDemux", |x| Some(x));
+            .flat_map_fallible("OkErrDemux", Some);
 
         err = err.concat(&err_input);
 

--- a/src/dataflow/src/render/sinks.rs
+++ b/src/dataflow/src/render/sinks.rs
@@ -84,6 +84,7 @@ where
     }
 }
 
+#[allow(clippy::borrowed_box)]
 fn apply_sink_envelope<G>(
     sink: &SinkDesc,
     sink_render: &Box<dyn SinkRender<G>>,

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -139,13 +139,9 @@ where
                         _ => (ok_stream, err_collection),
                     };
 
-                render_state.local_inputs.insert(
-                    src_id,
-                    LocalInput {
-                        handle: handle,
-                        capability,
-                    },
-                );
+                render_state
+                    .local_inputs
+                    .insert(src_id, LocalInput { handle, capability });
                 let as_of_frontier = self.as_of_frontier.clone();
                 let ok_collection = ok_stream
                     .map_in_place(move |(_, mut time, _)| {

--- a/src/dataflow/src/render/upsert.rs
+++ b/src/dataflow/src/render/upsert.rs
@@ -96,7 +96,7 @@ where
     // when it is transmitted.
     let mut temporal = Vec::new();
     let mut predicates = Vec::new();
-    let mut position_or = (0..source_arity).map(|x| Some(x)).collect::<Vec<_>>();
+    let mut position_or = (0..source_arity).map(Some).collect::<Vec<_>>();
     if let Some(mut operators) = operators.take() {
         for predicate in operators.predicates.drain(..) {
             if predicate.contains_temporal() {

--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -412,7 +412,7 @@ impl KafkaSinkState {
         }
     }
 
-    fn send_consistency_record<'a>(
+    fn send_consistency_record(
         &self,
         transaction_id: &str,
         status: &str,
@@ -467,7 +467,7 @@ impl KafkaSinkState {
     /// *NOTE*: `END` records will only be emitted when
     /// `KafkaSinkConnector.consistency` points to a consistency topic. The
     /// write frontier will be advanced regardless.
-    fn maybe_emit_progress<'a>(
+    fn maybe_emit_progress(
         &mut self,
         input_frontier: AntichainRef<Timestamp>,
     ) -> Result<(), anyhow::Error> {

--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -182,7 +182,7 @@ impl KafkaSourceReader {
         let consumer: BaseConsumer<GlueConsumerContext> = kafka_config
             .create_with_context(GlueConsumerContext {
                 activator: consumer_activator,
-                stats_tx: stats_tx,
+                stats_tx,
             })
             .expect("Failed to create Kafka Consumer");
 

--- a/src/dataflow/src/source/kinesis.rs
+++ b/src/dataflow/src/source/kinesis.rs
@@ -221,7 +221,7 @@ impl SourceReader for KinesisSourceReader {
                         let data = record
                             .data
                             .map(|blob| blob.into_inner())
-                            .unwrap_or_else(|| vec![]);
+                            .unwrap_or_else(Vec::new);
                         self.processed_message_count += 1;
                         let source_message = SourceMessage {
                             partition: PartitionId::None,

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -453,7 +453,7 @@ struct ConsInfo {
 
 impl ConsInfo {
     fn new(timestamp: Timestamp, offset: Option<MzOffset>) -> Self {
-        let offset = offset.unwrap_or_else(|| MzOffset { offset: 0 });
+        let offset = offset.unwrap_or(MzOffset { offset: 0 });
 
         Self {
             current_ts: timestamp,
@@ -779,15 +779,14 @@ impl ConsistencyInfo {
             // we already know about.
             cons_info.update_offset(offset);
             Some(cons_info.current_ts)
+        } else if let Some((timestamp, max_offset)) =
+            timestamp_bindings.get_binding(partition, offset)
+        {
+            cons_info.update_timestamp(timestamp, max_offset);
+            cons_info.update_offset(offset);
+            Some(timestamp)
         } else {
-            if let Some((timestamp, max_offset)) = timestamp_bindings.get_binding(partition, offset)
-            {
-                cons_info.update_timestamp(timestamp, max_offset);
-                cons_info.update_offset(offset);
-                Some(timestamp)
-            } else {
-                None
-            }
+            None
         }
     }
 }

--- a/src/expr-test-util/src/lib.rs
+++ b/src/expr-test-util/src/lib.rs
@@ -710,10 +710,7 @@ impl<'a> TestDeserializeContext for MirRelationExprDeserializeContext<'a> {
                                         for _ in 0..diff {
                                             rows.push(format!(
                                                 "[{}]",
-                                                separated(
-                                                    " ",
-                                                    row.iter().map(|d| datum_to_test_spec(d))
-                                                )
+                                                separated(" ", row.iter().map(datum_to_test_spec))
                                             ))
                                         }
                                     }

--- a/src/expr-test-util/tests/test_runner.rs
+++ b/src/expr-test-util/tests/test_runner.rs
@@ -64,7 +64,7 @@ mod test {
                             &s.input,
                             "MirScalarExpr",
                             |s| build_scalar(s),
-                            || MirScalarExprDeserializeContext::default(),
+                            MirScalarExprDeserializeContext::default,
                         ) {
                             Ok(scalar) => format!("{}\n", scalar),
                             Err(err) => format!("error: {}\n", err),

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -954,7 +954,7 @@ impl Iterator for TimestampRangeStepInclusive {
     }
 }
 
-fn generate_series_ts<'a>(
+fn generate_series_ts(
     start: NaiveDateTime,
     stop: NaiveDateTime,
     step: Interval,
@@ -1159,9 +1159,7 @@ impl TableFunc {
                 *stringify,
             ))),
             TableFunc::RegexpExtract(a) => Ok(Box::new(regexp_extract(datums[0], a).into_iter())),
-            TableFunc::CsvExtract(n_cols) => {
-                Ok(Box::new(csv_extract(datums[0], *n_cols)))
-            }
+            TableFunc::CsvExtract(n_cols) => Ok(Box::new(csv_extract(datums[0], *n_cols))),
             TableFunc::GenerateSeriesInt32 => {
                 let res = generate_series(
                     datums[0].unwrap_int32(),

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -1145,10 +1145,8 @@ impl TableFunc {
         datums: &'a [Datum<'a>],
         temp_storage: &'a RowArena,
     ) -> Result<Box<dyn Iterator<Item = (Row, Diff)> + 'a>, EvalError> {
-        if self.empty_on_null_input() {
-            if datums.iter().any(|d| d.is_null()) {
-                return Ok(Box::new(vec![].into_iter()));
-            }
+        if self.empty_on_null_input() && datums.iter().any(|d| d.is_null()) {
+            return Ok(Box::new(vec![].into_iter()));
         }
         match self {
             TableFunc::JsonbEach { stringify } => {
@@ -1162,7 +1160,7 @@ impl TableFunc {
             ))),
             TableFunc::RegexpExtract(a) => Ok(Box::new(regexp_extract(datums[0], a).into_iter())),
             TableFunc::CsvExtract(n_cols) => {
-                Ok(Box::new(csv_extract(datums[0], *n_cols).into_iter()))
+                Ok(Box::new(csv_extract(datums[0], *n_cols)))
             }
             TableFunc::GenerateSeriesInt32 => {
                 let res = generate_series(

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -545,25 +545,24 @@ impl MirScalarExpr {
                                 Err(err.clone()),
                                 e.typ(&relation_type).scalar_type,
                             );
-                        } else if *func == VariadicFunc::RegexpMatch {
-                            if exprs[1].is_literal()
-                                && exprs.get(2).map_or(true, |e| e.is_literal())
-                            {
-                                let needle = exprs[1].as_literal_str().unwrap();
-                                let flags = match exprs.len() {
-                                    3 => exprs[2].as_literal_str().unwrap(),
-                                    _ => "",
-                                };
-                                *e = match func::build_regex(needle, flags) {
-                                    Ok(regex) => mem::take(exprs)
-                                        .into_first()
-                                        .call_unary(UnaryFunc::RegexpMatch(Regex(regex))),
-                                    Err(err) => MirScalarExpr::literal(
-                                        Err(err),
-                                        e.typ(&relation_type).scalar_type,
-                                    ),
-                                };
-                            }
+                        } else if *func == VariadicFunc::RegexpMatch
+                            && exprs[1].is_literal()
+                            && exprs.get(2).map_or(true, |e| e.is_literal())
+                        {
+                            let needle = exprs[1].as_literal_str().unwrap();
+                            let flags = match exprs.len() {
+                                3 => exprs[2].as_literal_str().unwrap(),
+                                _ => "",
+                            };
+                            *e = match func::build_regex(needle, flags) {
+                                Ok(regex) => mem::take(exprs)
+                                    .into_first()
+                                    .call_unary(UnaryFunc::RegexpMatch(Regex(regex))),
+                                Err(err) => MirScalarExpr::literal(
+                                    Err(err),
+                                    e.typ(&relation_type).scalar_type,
+                                ),
+                            };
                         }
                     }
                     MirScalarExpr::If { cond, then, els } => {
@@ -648,11 +647,10 @@ impl MirScalarExpr {
                     if matches!(
                         *func,
                         BinaryFunc::Eq | BinaryFunc::Or | BinaryFunc::And | BinaryFunc::NotEq
-                    ) {
-                        if expr2 < expr1 {
-                            // 4) Canonically order elements so that deduplication works better.
-                            ::std::mem::swap(expr1, expr2);
-                        }
+                    ) && expr2 < expr1
+                    {
+                        // 4) Canonically order elements so that deduplication works better.
+                        ::std::mem::swap(expr1, expr2);
                     }
                 }
             },

--- a/src/http-proxy/src/proxy.rs
+++ b/src/http-proxy/src/proxy.rs
@@ -37,7 +37,7 @@ fn load_system_config() -> ProxyConfig {
     fn get_any_env(names: &[&str]) -> Option<String> {
         let val = names
             .iter()
-            .map(|n| env::var(n))
+            .map(env::var)
             .find(|v| *v != Err(env::VarError::NotPresent));
         match val {
             Some(Ok(val)) => Some(val),

--- a/src/interchange/src/avro/decode.rs
+++ b/src/interchange/src/avro/decode.rs
@@ -192,15 +192,13 @@ impl Decoder {
             };
             self.packer.push(upstream_time_millis);
             let row = self.packer.finish_and_reuse();
-            if self.reject_non_inserts {
-                if !matches!(row.iter().next(), None | Some(Datum::Null)) {
-                    anyhow::bail!(
-                        "[customer-data] Updates and deletes are not allowed for this source! \
-                         This probably means it was started with `start_offset` \
-                         and without `UPSERT` semantics. Got row: {:?}",
-                        row
-                    )
-                }
+            if self.reject_non_inserts && !matches!(row.iter().next(), None | Some(Datum::Null)) {
+                anyhow::bail!(
+                    "[customer-data] Updates and deletes are not allowed for this source! \
+                     This probably means it was started with `start_offset` \
+                     and without `UPSERT` semantics. Got row: {:?}",
+                    row
+                )
             }
 
             row

--- a/src/interchange/src/avro/schema.rs
+++ b/src/interchange/src/avro/schema.rs
@@ -237,7 +237,7 @@ impl ConfluentAvroResolver {
         confluent_wire_format: bool,
     ) -> anyhow::Result<Self> {
         let reader_schema = parse_schema(reader_schema)?;
-        let writer_schemas = config.map(|sr| SchemaCache::new(sr)).transpose()?;
+        let writer_schemas = config.map(SchemaCache::new).transpose()?;
         Ok(Self {
             reader_schema,
             writer_schemas,

--- a/src/lowertest/src/lib.rs
+++ b/src/lowertest/src/lib.rs
@@ -514,7 +514,7 @@ where
             let result = chars
                 .next()
                 .map(|c| c.to_uppercase().chain(chars).collect::<String>())
-                .unwrap_or_else(|| String::new());
+                .unwrap_or_else(String::new);
             result
         })
         .collect::<Vec<_>>()

--- a/src/materialized/src/bin/coordd.rs
+++ b/src/materialized/src/bin/coordd.rs
@@ -120,8 +120,8 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
         });
         let http_server = http::Server::new(http::Config {
             tls: None,
-            coord_client: coord_client,
-            metrics_registry: metrics_registry,
+            coord_client,
+            metrics_registry,
             global_metrics: metrics,
             pgwire_metrics: pgwire_server.metrics(),
         });

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -548,7 +548,7 @@ fn run(args: Args) -> Result<(), anyhow::Error> {
     // When inside a cgroup with a cpu limit,
     // the logical cpus can be lower than the physical cpus.
     let ncpus_useful = usize::max(1, cmp::min(num_cpus::get(), num_cpus::get_physical()));
-    let memory_limit = detect_memory_limit().unwrap_or_else(|| MemoryLimit {
+    let memory_limit = detect_memory_limit().unwrap_or(MemoryLimit {
         max: None,
         swap_max: None,
     });

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -286,7 +286,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
         let http_server = http::Server::new(http::Config {
             tls: http_tls,
             coord_client: coord_client.clone(),
-            metrics_registry: metrics_registry,
+            metrics_registry,
             global_metrics: metrics,
             pgwire_metrics: pgwire_server.metrics(),
         });

--- a/src/materialized/src/server_metrics.rs
+++ b/src/materialized/src/server_metrics.rs
@@ -47,7 +47,7 @@ impl Metrics {
             let mut system = sysinfo::System::new();
             system.refresh_system();
 
-            let memory_limit = cgroup::detect_memory_limit().unwrap_or_else(|| MemoryLimit {
+            let memory_limit = cgroup::detect_memory_limit().unwrap_or(MemoryLimit {
                 max: None,
                 swap_max: None,
             });

--- a/src/materialized/tests/sql.rs
+++ b/src/materialized/tests/sql.rs
@@ -422,7 +422,7 @@ fn test_tail_progress_non_nullable_columns() -> Result<(), Box<dyn Error>> {
     while state != State::Done {
         let row = client_reads.query_one("FETCH 1 c2", &[])?;
 
-        if row.get::<_, bool>("mz_progressed") == false {
+        if !row.get::<_, bool>("mz_progressed") {
             assert_eq!(row.get::<_, i64>("mz_diff"), 1);
             assert_eq!(row.get::<_, String>("data"), "data");
             state = State::WaitingForProgress;

--- a/src/persist/benches/end_to_end.rs
+++ b/src/persist/benches/end_to_end.rs
@@ -22,7 +22,7 @@ use timely::dataflow::ProbeHandle;
 use timely::Config;
 
 use ore::metrics::MetricsRegistry;
-use persist;
+
 use persist::file::{FileBlob, FileLog};
 use persist::indexed::runtime::{self, RuntimeClient, RuntimeConfig, StreamWriteHandle};
 use persist::operators::source::PersistedSource;

--- a/src/persist/benches/snapshot.rs
+++ b/src/persist/benches/snapshot.rs
@@ -49,13 +49,7 @@ where
 {
     let data_len = 100_000;
     let data: Vec<((String, String), u64, isize)> = (0..data_len)
-        .map(|i| {
-            (
-                (format!("key{}", i).into(), format!("val{}", i).into()),
-                i as u64,
-                1,
-            )
-        })
+        .map(|i| ((format!("key{}", i), format!("val{}", i)), i as u64, 1))
         .collect();
 
     let mut runtime = new_fn(1).expect("creating index cannot fail");

--- a/src/persist/benches/writer.rs
+++ b/src/persist/benches/writer.rs
@@ -161,14 +161,14 @@ fn block_on_drain<T, F: FnOnce(&mut Indexed<L, B>, PFutureHandle<T>), L: Log, B:
     f: F,
 ) -> Result<T, Error> {
     let (tx, rx) = PFuture::new();
-    f(index, tx.into());
+    f(index, tx);
     index.step()?;
     rx.recv()
 }
 
 fn block_on<T, F: FnOnce(PFutureHandle<T>)>(f: F) -> Result<T, Error> {
     let (tx, rx) = PFuture::new();
-    f(tx.into());
+    f(tx);
     rx.recv()
 }
 

--- a/src/persist/src/indexed/arrangement.rs
+++ b/src/persist/src/indexed/arrangement.rs
@@ -750,7 +750,7 @@ impl Snapshot<Vec<u8>, Vec<u8>> for TraceSnapshot {
 
     fn into_iters(self, num_iters: NonZeroUsize) -> Vec<Self::Iter> {
         let mut iters = Vec::with_capacity(num_iters.get());
-        iters.resize_with(num_iters.get(), || TraceSnapshotIter::default());
+        iters.resize_with(num_iters.get(), TraceSnapshotIter::default);
         // TODO: This should probably distribute batches based on size, but for
         // now it's simpler to round-robin them.
         for (i, batch) in self.batches.into_iter().enumerate() {
@@ -966,7 +966,7 @@ mod tests {
         lo: u64,
         hi: Option<u64>,
     ) -> Result<Vec<((Vec<u8>, Vec<u8>), u64, isize)>, Error> {
-        let hi = hi.map_or_else(|| Antichain::new(), |e| Antichain::from_elem(e));
+        let hi = hi.map_or_else(Antichain::new, Antichain::from_elem);
         let snapshot = arrangement.unsealed_snapshot(Antichain::from_elem(lo), hi, &blob)?;
         let updates = snapshot.read_to_end()?;
         Ok(updates)

--- a/src/persist/src/indexed/encoding.rs
+++ b/src/persist/src/indexed/encoding.rs
@@ -889,7 +889,7 @@ mod tests {
             let (name, id) = x;
             StreamRegistration {
                 name: name.to_owned(),
-                id: id,
+                id,
                 key_codec_name: "".into(),
                 val_codec_name: "".into(),
             }

--- a/src/persist/src/indexed/mod.rs
+++ b/src/persist/src/indexed/mod.rs
@@ -577,7 +577,7 @@ impl<L: Log, B: Blob> Indexed<L, B> {
         let seals_for_listeners = pending.seals;
         let updates_for_listeners = updates_by_id.clone();
 
-        let ret = (|| {
+        let ret = {
             // TODO: The following error handling took a while to debug, see if
             // we can make this more obvious.
             if let Err(err) = self
@@ -589,7 +589,7 @@ impl<L: Log, B: Blob> Indexed<L, B> {
             } else {
                 self.try_set_meta(meta_before)
             }
-        })();
+        };
 
         let ret = match ret {
             Ok(()) => {
@@ -1138,14 +1138,14 @@ mod tests {
         f: F,
     ) -> Result<T, Error> {
         let (tx, rx) = PFuture::new();
-        f(index, tx.into());
+        f(index, tx);
         index.drain_pending()?;
         rx.recv()
     }
 
     fn block_on<T, F: FnOnce(PFutureHandle<T>)>(f: F) -> Result<T, Error> {
         let (tx, rx) = PFuture::new();
-        f(tx.into());
+        f(tx);
         rx.recv()
     }
 

--- a/src/persist/src/indexed/runtime.rs
+++ b/src/persist/src/indexed/runtime.rs
@@ -1210,8 +1210,7 @@ mod tests {
 
             let mut probe = ProbeHandle::new();
             let ok_stream = worker.dataflow(|scope| {
-                let (ok_stream, _err_stream) =
-                    scope.persisted_source(read).ok_err(|x| split_ok_err(x));
+                let (ok_stream, _err_stream) = scope.persisted_source(read).ok_err(split_ok_err);
                 ok_stream.probe_with(&mut probe).capture()
             });
 

--- a/src/persist/src/nemesis/generator.rs
+++ b/src/persist/src/nemesis/generator.rs
@@ -159,7 +159,7 @@ impl ReqGenerator {
         // This is expected to error so it doesn't matter what diff is.
         let diff = 1;
         Req::Write(WriteReq::Single(WriteReqSingle {
-            stream: stream,
+            stream,
             update: ((key, ()), ts, diff),
         }))
     }
@@ -342,9 +342,8 @@ impl Generator {
                 self.config.storage_available,
                 ReqGenerator::StorageAvailable,
             ))
-            .filter(|_| self.state.storage_available == false),
-            Some((self.config.start_weight, ReqGenerator::Start))
-                .filter(|_| self.state.running == false),
+            .filter(|_| !self.state.storage_available),
+            Some((self.config.start_weight, ReqGenerator::Start)).filter(|_| !self.state.running),
         ];
 
         // Most operations just error if the runtime is down and this is fairly

--- a/src/persist/src/operators/input.rs
+++ b/src/persist/src/operators/input.rs
@@ -63,7 +63,7 @@ where
 
         // Replay the previously persisted data, if any.
         let snapshot = read.snapshot();
-        let (ok_previous, err_previous) = self.replay(snapshot).ok_err(|x| split_ok_err(x));
+        let (ok_previous, err_previous) = self.replay(snapshot).ok_err(split_ok_err);
 
         let ok_previous = ok_previous.map(|((k, _), ts, diff)| (k, ts, diff));
 

--- a/src/persist/src/operators/source.rs
+++ b/src/persist/src/operators/source.rs
@@ -174,8 +174,7 @@ mod tests {
                 let read = p
                     .create_or_load::<String, ()>("1")
                     .map(|(_write, read)| read);
-                let (ok_stream, err_stream) =
-                    scope.persisted_source(read).ok_err(|x| split_ok_err(x));
+                let (ok_stream, err_stream) = scope.persisted_source(read).ok_err(split_ok_err);
                 (ok_stream.capture(), err_stream.capture())
             });
 
@@ -246,7 +245,7 @@ mod tests {
                 let read = p
                     .create_or_load::<String, ()>("1")
                     .map(|(_write, read)| read);
-                let (oks, _rrs) = scope.persisted_source(read).ok_err(|x| split_ok_err(x));
+                let (oks, _rrs) = scope.persisted_source(read).ok_err(split_ok_err);
 
                 oks.probe_with(&mut probe);
             });
@@ -290,7 +289,7 @@ mod tests {
         timely::execute(Config::process(2), move |worker| {
             worker.dataflow(|scope| {
                 let (write, read) = p.create_or_load("1").unwrap();
-                let (ok_stream, _) = scope.persisted_source(Ok(read)).ok_err(|x| split_ok_err(x));
+                let (ok_stream, _) = scope.persisted_source(Ok(read)).ok_err(split_ok_err);
 
                 // Write one thing from each worker again. This time at timestamp 2.
                 write
@@ -341,7 +340,7 @@ mod tests {
 
         let recv = timely::execute_directly(move |worker| {
             let recv = worker.dataflow(|scope| {
-                let (_, err_stream) = scope.persisted_source(read).ok_err(|x| split_ok_err(x));
+                let (_, err_stream) = scope.persisted_source(read).ok_err(split_ok_err);
                 err_stream.capture()
             });
             recv

--- a/src/persist/src/operators/stream.rs
+++ b/src/persist/src/operators/stream.rs
@@ -411,7 +411,7 @@ where
                 primary_data_input.for_each(|cap, data| {
                     data.swap(&mut primary_data_buffer);
 
-                    let as_result = primary_data_buffer.drain(..).map(|update| Ok(update));
+                    let as_result = primary_data_buffer.drain(..).map(Ok);
 
                     let mut session = data_output.session(&cap);
                     session.give_iterator(as_result);

--- a/src/persist/src/operators/stream.rs
+++ b/src/persist/src/operators/stream.rs
@@ -620,7 +620,7 @@ where
                     }
                 }
 
-                input_frontier.clone_from(&mut new_input_frontier);
+                input_frontier.clone_from(&new_input_frontier);
                 // We need to downgrade when the input frontier is empty. This basically releases
                 // all the capabilities so that downstream operators and eventually the worker can
                 // shut down.

--- a/src/persist/src/operators/upsert.rs
+++ b/src/persist/src/operators/upsert.rs
@@ -126,8 +126,7 @@ where
 
         let (restored_upsert_oks, _state_errs) = {
             let snapshot = persist_config.read_handle.snapshot();
-            let (restored_oks, restored_errs) =
-                self.scope().replay(snapshot).ok_err(|x| split_ok_err(x));
+            let (restored_oks, restored_errs) = self.scope().replay(snapshot).ok_err(split_ok_err);
             let (restored_upsert_oks, retract_errs) = restored_oks
                 .filter_and_retract_future_updates(
                     name,

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -987,10 +987,8 @@ pub fn decode_copy_format_csv(
     let mut record = ByteRecord::new();
 
     while rdr.read_byte_record(&mut record)? {
-        if record.len() == 1 {
-            if record.iter().next() == Some(&END_OF_COPY_MARKER) {
-                break;
-            }
+        if record.len() == 1 && record.iter().next() == Some(&END_OF_COPY_MARKER) {
+            break;
         }
 
         match record.len().cmp(&column_types.len()) {

--- a/src/pid-file/src/lib.rs
+++ b/src/pid-file/src/lib.rs
@@ -85,12 +85,15 @@ impl PidFile {
 
     /// Like [`open`](PidFile::open), but opens the file with the specified
     /// permissions rather than 0600.
+    #[allow(clippy::unnecessary_mut_passed)] // this mut is being passed as a mut pointer
     pub fn open_with<P>(path: P, permissions: Permissions) -> Result<PidFile, Error>
     where
         P: AsRef<Path>,
     {
         let path_cstring = CString::new(path.as_ref().as_os_str().as_bytes())?;
         let mut old_pid: libc::pid_t = -1;
+
+        #[allow(clippy::useless_conversion)] // the types differ on macos/linux
         let mode: libc::mode_t = permissions
             .mode()
             .try_into()

--- a/src/repr-test-util/tests/test_runner.rs
+++ b/src/repr-test-util/tests/test_runner.rs
@@ -17,11 +17,9 @@ mod tests {
     fn build_datum(s: &str) -> Result<String, String> {
         // 1) Convert test spec to the row containing the datum.
         let mut stream_iter = tokenize(s)?.into_iter();
-        let litval = extract_literal_string(
-            &stream_iter.next().ok_or_else(|| "Empty test")?,
-            &mut stream_iter,
-        )?
-        .unwrap();
+        let litval =
+            extract_literal_string(&stream_iter.next().ok_or("Empty test")?, &mut stream_iter)?
+                .unwrap();
         let scalar_type = get_scalar_type_or_default(&litval[..], &mut stream_iter)?;
         let row = test_spec_to_row(std::iter::once((&litval[..], &scalar_type)))?;
         // 2) It should be possible to unpack the row and then convert the datum
@@ -63,7 +61,7 @@ mod tests {
         let roundtrip_litvals = row
             .unpack()
             .into_iter()
-            .map(|d| datum_to_test_spec(d))
+            .map(datum_to_test_spec)
             .collect::<Vec<_>>();
         if roundtrip_litvals != litvals {
             Err(format!(

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -52,7 +52,7 @@ impl ColumnType {
         match (self.scalar_type.clone(), other.scalar_type.clone()) {
             (scalar_type, other_scalar_type) if scalar_type.base_eq(&other_scalar_type) => {
                 Ok(ColumnType {
-                    scalar_type: scalar_type,
+                    scalar_type,
                     nullable: self.nullable || other.nullable,
                 })
             }

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -1494,12 +1494,12 @@ impl Datum<'static> {
 
 // Verify that bytes for static datums with manually stuffed bytes are correct.
 #[test]
-fn verify_static_datum_bytes<'a>() {
+fn verify_static_datum_bytes() {
     let arena = crate::RowArena::new();
     {
         let empty_array_datum: Datum = arena.make_datum(|packer| {
             packer
-                .push_array::<_, Datum<'a>>(
+                .push_array::<_, Datum<'_>>(
                     &[crate::adt::array::ArrayDimension {
                         lower_bound: 1,
                         length: 0,
@@ -1518,7 +1518,7 @@ fn verify_static_datum_bytes<'a>() {
 
     {
         let empty_list_datum: Datum = arena.make_datum(|packer| {
-            packer.push_list::<_, Datum<'a>>(std::iter::empty());
+            packer.push_list::<_, Datum<'_>>(std::iter::empty());
         });
         if EMPTY_LIST_ROW.iter().next().is_none() || Datum::empty_list() != empty_list_datum {
             panic!(

--- a/src/repr/tests/rows.rs
+++ b/src/repr/tests/rows.rs
@@ -57,8 +57,7 @@ fn arb_datum() -> BoxedStrategy<PropertizedDatum> {
         any::<i64>().prop_map(PropertizedDatum::Int64),
         any::<f32>().prop_map(PropertizedDatum::Float32),
         any::<f64>().prop_map(PropertizedDatum::Float64),
-        add_arb_duration(chrono::NaiveDate::from_ymd(2000, 01, 01))
-            .prop_map(PropertizedDatum::Date),
+        add_arb_duration(chrono::NaiveDate::from_ymd(2000, 1, 1)).prop_map(PropertizedDatum::Date),
         add_arb_duration(chrono::NaiveTime::from_hms(0, 0, 0)).prop_map(PropertizedDatum::Time),
         add_arb_duration(chrono::NaiveDateTime::from_timestamp(0, 0))
             .prop_map(PropertizedDatum::Timestamp),

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1142,18 +1142,16 @@ impl<'a> Parser<'a> {
                 // 'string' FROM 'int' FOR 'int'
                 exprs.push(self.parse_expr()?);
             }
+        } else if self.parse_keyword(FOR) {
+            // 'string' FOR 'int'
+            exprs.push(Expr::Value(Value::Number(String::from("1"))));
+            exprs.push(self.parse_expr()?);
         } else {
-            if self.parse_keyword(FOR) {
-                // 'string' FOR 'int'
-                exprs.push(Expr::Value(Value::Number(String::from("1"))));
-                exprs.push(self.parse_expr()?);
-            } else {
-                // 'string', 'int'
-                // or
-                // 'string', 'int', 'int'
-                self.expect_token(&Token::Comma)?;
-                exprs.extend(self.parse_comma_separated(Parser::parse_expr)?);
-            }
+            // 'string', 'int'
+            // or
+            // 'string', 'int', 'int'
+            self.expect_token(&Token::Comma)?;
+            exprs.extend(self.parse_comma_separated(Parser::parse_expr)?);
         }
 
         self.expect_token(&Token::RParen)?;
@@ -2445,7 +2443,7 @@ impl<'a> Parser<'a> {
                 return Ok(Statement::DropDatabase(DropDatabaseStatement {
                     if_exists,
                     name,
-                    restrict: restrict,
+                    restrict,
                 }));
             }
             Some(INDEX) => ObjectType::Index,

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1448,7 +1448,6 @@ impl<'a> Parser<'a> {
     }
 
     /// Bail out if the current token is not one of the expected keywords, or consume it if it is
-    #[must_use = "must match against result to determine what keyword was parsed"]
     fn expect_one_of_keywords(&mut self, keywords: &[Keyword]) -> Result<Keyword, ParserError> {
         if let Some(keyword) = self.parse_one_of_keywords(keywords) {
             Ok(keyword)
@@ -1462,7 +1461,6 @@ impl<'a> Parser<'a> {
     }
 
     /// Bail out if the current token is not an expected keyword, or consume it if it is
-    #[must_use]
     fn expect_keyword(&mut self, expected: Keyword) -> Result<(), ParserError> {
         if self.parse_keyword(expected) {
             Ok(())

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -15,7 +15,6 @@ use std::collections::HashMap;
 use std::fmt;
 
 use anyhow::{bail, Context};
-use chrono::{DateTime, Utc};
 use itertools::Itertools;
 use lazy_static::lazy_static;
 
@@ -275,8 +274,8 @@ impl<R> Operation<R> {
 pub fn sql_impl(
     expr: &'static str,
 ) -> impl Fn(&QueryContext, Vec<ScalarType>) -> Result<HirScalarExpr, anyhow::Error> {
-    let expr = sql_parser::parser::parse_expr(expr.into())
-        .expect("static function definition failed to parse");
+    let expr =
+        sql_parser::parser::parse_expr(expr).expect("static function definition failed to parse");
     move |qcx, types| {
         // Reconstruct an expression context where the parameter types are
         // bound to the types of the expressions in `args`.
@@ -1747,7 +1746,7 @@ lazy_static! {
                 params!(String, Time) => Operation::binary(|ecx, lhs, rhs| {
                     match ecx.qcx.lifetime {
                         QueryLifetime::OneShot(pcx) => {
-                            let wall_time = DateTime::<Utc>::from(pcx.wall_time).naive_utc();
+                            let wall_time = pcx.wall_time.naive_utc();
                             Ok(lhs.call_binary(rhs, BinaryFunc::TimezoneTime{wall_time}))
                         },
                         QueryLifetime::Static => bail!("timezone cannot be used in static queries"),

--- a/src/sql/src/plan/explain.rs
+++ b/src/sql/src/plan/explain.rs
@@ -461,7 +461,7 @@ impl<'a> Explanation<'a> {
                 write!(f, " over (")?;
                 for (i, e) in expr.partition.iter().enumerate() {
                     if i > 0 {
-                        write!(f, "{}", ", ")?;
+                        write!(f, ", ")?;
                     }
                     self.fmt_scalar_expr(f, e)?;
                 }
@@ -471,7 +471,7 @@ impl<'a> Explanation<'a> {
                     write!(f, " order by (")?;
                     for (i, e) in expr.order_by.iter().enumerate() {
                         if i > 0 {
-                            write!(f, "{}", ", ")?;
+                            write!(f, ", ")?;
                         }
                         self.fmt_scalar_expr(f, e)?;
                     }

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -1024,7 +1024,7 @@ pub fn eval_as_of<'a>(
     Ok(match ex.typ(desc.typ()).scalar_type {
         ScalarType::Numeric { .. } => {
             let n = evaled.unwrap_numeric().0;
-            u64::try_from(n)?.try_into()?
+            u64::try_from(n)?
         }
         ScalarType::Int16 => evaled.unwrap_int16().try_into()?,
         ScalarType::Int32 => evaled.unwrap_int32().try_into()?,

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -3808,7 +3808,7 @@ fn plan_is_expr<'a>(
         IsExprConstruct::False => UnaryFunc::IsFalse(expr_func::IsFalse),
     };
     let expr = HirScalarExpr::CallUnary {
-        func: func,
+        func,
         expr: Box::new(expr),
     };
 

--- a/src/sql/src/query_model/hir.rs
+++ b/src/sql/src/query_model/hir.rs
@@ -128,7 +128,7 @@ impl FromHir {
                     select_box.columns.push(Column {
                         expr: BoxScalarExpr::ColumnReference(ColumnReference {
                             quantifier_id,
-                            position: position,
+                            position,
                         }),
                         alias: None,
                     });

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -352,7 +352,7 @@ pub async fn build(cmds: Vec<PosCommand>, state: &State) -> Result<Vec<PosAction
         state.temp_path.display().to_string(),
     );
     vars.insert("testdrive.aws-region".into(), state.aws_region().into());
-    vars.insert("testdrive.aws-endpoint".into(), state.aws_endpoint().into());
+    vars.insert("testdrive.aws-endpoint".into(), state.aws_endpoint());
     vars.insert("testdrive.aws-account".into(), state.aws_account.clone());
     {
         let aws_credentials = state

--- a/src/testdrive/src/action/postgres/verify_slot.rs
+++ b/src/testdrive/src/action/postgres/verify_slot.rs
@@ -79,13 +79,11 @@ impl Action for VerifySlotAction {
                             &self.slot
                         ));
                     }
-                } else {
-                    if rows.len() != 0 {
-                        return Err(format!(
-                            "expected slot {} to be inactive, is active",
-                            &self.slot
-                        ));
-                    }
+                } else if rows.len() != 0 {
+                    return Err(format!(
+                        "expected slot {} to be inactive, is active",
+                        &self.slot
+                    ));
                 }
                 Ok(())
             })

--- a/src/transform/src/join_implementation.rs
+++ b/src/transform/src/join_implementation.rs
@@ -468,10 +468,8 @@ fn install_lifted_mfp(new_join: &mut MirRelationExpr, mfp: MapFilterProject) {
                     expr.visit_mut_pre_post(
                         &mut |e| {
                             if let MirScalarExpr::Column(c) = e {
-                                if *c >= mfp.input_arity {
-                                    if *c >= mfp.input_arity {
-                                        *e = map[*c - mfp.input_arity].clone();
-                                    }
+                                if *c >= mfp.input_arity && *c >= mfp.input_arity {
+                                    *e = map[*c - mfp.input_arity].clone();
                                 }
                             }
                             None

--- a/src/transform/src/join_implementation.rs
+++ b/src/transform/src/join_implementation.rs
@@ -468,7 +468,7 @@ fn install_lifted_mfp(new_join: &mut MirRelationExpr, mfp: MapFilterProject) {
                     expr.visit_mut_pre_post(
                         &mut |e| {
                             if let MirScalarExpr::Column(c) = e {
-                                if *c >= mfp.input_arity && *c >= mfp.input_arity {
+                                if *c >= mfp.input_arity {
                                     *e = map[*c - mfp.input_arity].clone();
                                 }
                             }

--- a/test/performance/s3-datagen/src/main.rs
+++ b/test/performance/s3-datagen/src/main.rs
@@ -106,7 +106,7 @@ async fn run() -> anyhow::Result<()> {
         None | Some("us-east-1") => None,
         Some(r) => Some(
             CreateBucketConfiguration::builder()
-                .location_constraint(BucketLocationConstraint::from(r.as_ref()))
+                .location_constraint(BucketLocationConstraint::from(r))
                 .build(),
         ),
     };


### PR DESCRIPTION
This meant that, for example, [`redundant_field_names`][rf] was not getting applied even though we explicitly enabled it.

Since this was unnecessarily allowing a large number of lints I had to fix a large number of things. Most of them could be auto-fixed, so I added a `--fix` flag to `bin/check`.

Other changes I had to apply manually, most of which seemed obvious but one seems like it maybe been a latent bug which someone should look at, and is in its own commit.

[rf]: https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names

### Motivation

Apply lints that we were configured to apply, but were not.

### Checklist

This change should be a pure refactoring.