### PR TITLE
 coord,persist: teach coord about persisted streams that are involved in sources

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -2218,9 +2218,10 @@ where
             let source_id = self.catalog.allocate_id()?;
             let source_oid = self.catalog.allocate_oid()?;
 
-            let persist_name =
-                self.catalog
-                    .source_persist_name(source_id, &source.connector, &name);
+            let persist = self
+                .catalog
+                .source_persist_details(source_id, &source.connector, &name)
+                .map_err(|err| anyhow!("{}", err))?;
 
             let source = catalog::Source {
                 create_sql: source.create_sql,
@@ -2228,7 +2229,7 @@ where
                 connector: source.connector,
                 bare_desc: source.bare_desc,
                 desc: transformed_desc,
-                persist_name,
+                persist,
             };
             ops.push(catalog::Op::CreateItem {
                 id: source_id,

--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -14,6 +14,8 @@
 //! and indicate which identifiers have arrangements available. This module
 //! isolates that logic from the rest of the somewhat complicated coordinator.
 
+use dataflow_types::SourcePersistDesc;
+
 use super::*;
 use ore::stack::maybe_grow;
 
@@ -108,10 +110,9 @@ impl<'a> DataflowBuilder<'a> {
                                 },
                                 operators: None,
                                 bare_desc: table.desc.clone(),
-                                persisted_name: table
-                                    .persist
-                                    .as_ref()
-                                    .map(|p| p.stream_name.clone()),
+                                persist_desc: table.persist.as_ref().map(|p| {
+                                    SourcePersistDesc::single_stream(p.stream_name.clone())
+                                }),
                             },
                             *id,
                         );
@@ -125,7 +126,10 @@ impl<'a> DataflowBuilder<'a> {
                                     connector: source.connector.clone(),
                                     operators: None,
                                     bare_desc: source.bare_desc.clone(),
-                                    persisted_name: source.persist_name.clone(),
+                                    persist_desc: source
+                                        .persist
+                                        .as_ref()
+                                        .map(|p| SourcePersistDesc::new(p.streams.clone())),
                                 },
                                 *id,
                             );
@@ -140,7 +144,10 @@ impl<'a> DataflowBuilder<'a> {
                                     connector: source.connector.clone(),
                                     operators: None,
                                     bare_desc: source.bare_desc.clone(),
-                                    persisted_name: source.persist_name.clone(),
+                                    persist_desc: source
+                                        .persist
+                                        .as_ref()
+                                        .map(|p| SourcePersistDesc::new(p.streams.clone())),
                                 },
                                 *id,
                             );

--- a/src/coord/src/persistcfg.rs
+++ b/src/coord/src/persistcfg.rs
@@ -197,14 +197,18 @@ impl PersisterWithConfig {
         }
     }
 
-    pub fn details(&self, id: GlobalId, pretty: &str) -> Result<Option<PersistDetails>, Error> {
+    pub fn details(
+        &self,
+        id: GlobalId,
+        pretty: &str,
+    ) -> Result<Option<TablePersistDetails>, Error> {
         self.details_from_name(self.stream_name(id, pretty))
     }
 
     pub fn details_from_name(
         &self,
         stream_name: Option<String>,
-    ) -> Result<Option<PersistDetails>, Error> {
+    ) -> Result<Option<TablePersistDetails>, Error> {
         let stream_name = match stream_name {
             Some(x) => x,
             None => return Ok(None),
@@ -214,7 +218,7 @@ impl PersisterWithConfig {
             None => return Ok(None),
         };
         let (write_handle, _) = persister.create_or_load(&stream_name)?;
-        Ok(Some(PersistDetails {
+        Ok(Some(TablePersistDetails {
             stream_name,
             write_handle,
         }))
@@ -243,14 +247,14 @@ impl PersisterWithConfig {
 }
 
 #[derive(Debug, Clone, Serialize)]
-pub struct PersistDetails {
+pub struct TablePersistDetails {
     pub stream_name: String,
     #[serde(skip)]
     pub write_handle: StreamWriteHandle<Row, ()>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PersistMultiDetails {
+pub struct TablePersistMultiDetails {
     pub all_table_ids: Vec<Id>,
     pub write_handle: MultiWriteHandle<Row, ()>,
 }


### PR DESCRIPTION

Before, the coordinator would only know the "prefix" that was used to
form the names of persistent streams that are involved in, say, the
persistent Kafka source.

Now, we keep a mapping from a _logical name_ to the physical stream name
in the coordinator, for all persisted streams that are involved in a
source.

This also changes what persist information is sent to workers. Before,
we would send a single persist name. Now, we send a new
`SourcePersistDesc`, which contains the mapping of streams. In future
commits, we will add more information to this.

We need to do this to allow the coordinator to:
 - determine a common seal timestamp when restarting
 - negotiate/figure out if a requested as_of matches the compaction
   frontier/since of a persisted source
 - compact persisted streams when necessary

We will do these additional changes in follow-up commits.

### Tips for reviewer

The contentious change is how I manually serialize (and deserialize) a mapping of names to the one `persist_name` field that we store in the catalog. I'm doing this in order to not break that, but could be convinced to do a more elaborate thing.

Also, there are at least two `TODO:...`s in the changes that are questions, please take a look at them.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
