### PR TITLE
ci/deploy: add missing f-string specifier

### DIFF
--- a/ci/deploy/deploy_util.py
+++ b/ci/deploy/deploy_util.py
@@ -75,7 +75,7 @@ def upload_latest_redirect(platform: str, version: str) -> None:
 
 
 def deploy_tarball(platform: str, materialized: Path) -> None:
-    tar_path = Path("materialized-{platform}.tar.gz")
+    tar_path = Path(f"materialized-{platform}.tar.gz")
     with tarfile.open(str(tar_path), "x:gz") as f:
         f.addfile(_tardir("materialized"))
         f.addfile(_tardir("materialized/bin"))


### PR DESCRIPTION
This should (finally) fix macOS deploys.
