### PR TITLE
repr: introduce a protobuf-backed permanent storage format for Row

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1327,8 +1327,7 @@ dependencies = [
 [[package]]
 name = "dec"
 version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2bbc59a6735d2f5bc4befd3300c9b75cc6ed66165e92b741da0a58c07ea04d"
+source = "git+https://github.com/MaterializeInc/rust-dec?branch=bcd#1bcccbb8ede789c83b8f258277343846bc975ef5"
 dependencies = [
  "decnumber-sys",
  "libc",
@@ -1339,8 +1338,7 @@ dependencies = [
 [[package]]
 name = "decnumber-sys"
 version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a99b958f19724bc0a2202086d135c2e7ed098e95cdae778546e965648fa47b"
+source = "git+https://github.com/MaterializeInc/rust-dec?branch=bcd#1bcccbb8ede789c83b8f258277343846bc975ef5"
 dependencies = [
  "cc",
  "libc",
@@ -4082,12 +4080,14 @@ dependencies = [
  "itertools",
  "lazy_static",
  "lowertest",
+ "mz-protoc",
  "num-traits",
  "num_enum",
  "ordered-float",
  "ore",
  "persist-types",
  "proptest",
+ "protobuf",
  "rand",
  "regex",
  "ryu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,3 +82,5 @@ debug = 1
 headers = { git = "https://github.com/MaterializeInc/headers.git" }
 # Until https://github.com/jorgecarleitao/parquet-format-rs/pull/2 is merged and released
 parquet-format-async-temp = { git = "https://github.com/MaterializeInc/parquet-format-rs", branch = "main" }
+# Until repr::row::{push_datum,read_datum} are updated with the new {to,from}_raw_parts
+dec = { git = "https://github.com/MaterializeInc/rust-dec", branch = "bcd" }

--- a/deny.toml
+++ b/deny.toml
@@ -108,7 +108,6 @@ allow-git = [
     "https://github.com/MaterializeInc/headers.git",
 
     # Waiting on several PRs to a mostly-abandoned upstream library.
-    "https://github.com/MaterializeInc/pubnub-headers.git",
     "https://github.com/MaterializeInc/pubnub-rust.git",
 
     # Waiting on https://github.com/sfackler/rust-postgres/pull/752.
@@ -130,4 +129,6 @@ allow-git = [
     "https://github.com/fede1024/rust-rdkafka.git",
     # Until https://github.com/jorgecarleitao/parquet-format-rs/pull/2 is merged and released
     "https://github.com/MaterializeInc/parquet-format-rs.git",
+    # Until repr::row::{push_datum,read_datum} are updated with the new {to,from}_raw_parts
+    "https://github.com/MaterializeInc/rust-dec",
 ]

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -30,6 +30,7 @@ num-traits = "0.2.14"
 ordered-float = { version = "2.10.0", features = ["serde"] }
 ore = { path = "../ore", features = ["bytes", "smallvec"] }
 persist-types = { path = "../persist-types" }
+protobuf = { git = "https://github.com/MaterializeInc/rust-protobuf.git" }
 regex = "1.5.4"
 ryu = "1.0.9"
 serde = { version = "1.0.133", features = ["derive"] }
@@ -37,6 +38,9 @@ serde_json = { version = "1.0.74", features = ["arbitrary_precision"] }
 serde_regex = "1.1.0"
 smallvec = { version = "1.7.0", features = ["serde", "union"] }
 uuid = "0.8.2"
+
+[build-dependencies]
+mz-protoc = { path = "../protoc" }
 
 [dev-dependencies]
 criterion = { git = "https://github.com/MaterializeInc/criterion.rs.git" }

--- a/src/repr/build.rs
+++ b/src/repr/build.rs
@@ -1,0 +1,15 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+fn main() {
+    mz_protoc::Protoc::new()
+        .include("src")
+        .input("src/row.proto")
+        .build_script_exec()
+}

--- a/src/repr/src/gen.rs
+++ b/src/repr/src/gen.rs
@@ -1,0 +1,12 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Generated protobuf code and companion impls.
+
+include!(concat!(env!("OUT_DIR"), "/protobuf/mod.rs"));

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -23,6 +23,7 @@
 #![warn(missing_debug_implementations)]
 
 mod datum_vec;
+mod gen;
 mod relation;
 mod row;
 mod scalar;

--- a/src/repr/src/row.proto
+++ b/src/repr/src/row.proto
@@ -1,0 +1,159 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+syntax = "proto3";
+
+package gen;
+
+message ProtoRow {
+    repeated ProtoDatum datums = 1;
+}
+
+message ProtoDatum {
+    // NB: Proto oneof ids `1..=15` get encoded in 1 byte and so we should
+    // reserve them for the datum types we expect to be most popular.
+    //
+    // Null, False, and True are all likely to be frequent, but the encoded
+    // length is exactly the same if they're here or in ProtoDatumOther. In
+    // general, anything that can be encoded purely as a proto enum variant
+    // (i.e. doesn't have a payload) is better off that way. If we run out of
+    // 1-byte encodings of ProtoDatumOther, we can always add ProtoDatumOther2.
+    oneof datum_type {
+        ProtoDatumOther other = 1;
+        int32 int16 = 2;
+        int32 int32 = 3;
+        int64 int64 = 4;
+        float float32 = 5;
+        double float64 = 6;
+        bytes bytes = 7;
+        string string = 8;
+        // Don't use 9-15 without truly understanding the NB above.
+
+        // These get encoded with 2 bytes for the oneof id. It's a pretty easy
+        // and low-debt migration to "bless" one of these into having a 1-byte
+        // id (fill in the new field on write, but check if either field is set
+        // on read). However, once a 1-byte id is used, it's gone forever, so
+        // we're conservative in handing them out.
+        //
+        // Of these, I'd guess Timestamp and UUID are probably the first ones
+        // we'd bless followed by Date and Time.
+        ProtoDate date = 16;
+        ProtoTime time = 17;
+        ProtoTimestamp timestamp = 18;
+        ProtoInterval interval = 19;
+        ProtoArray array = 20;
+        ProtoRow list = 21;
+        ProtoDict dict = 22;
+        ProtoNumeric numeric = 23;
+        bytes uuid = 24;
+    }
+}
+
+enum ProtoDatumOther {
+    // It's generally good practice to make id 0 (the default if the field is
+    // unset) in proto enums be an Unknown sentinel. This allows for
+    // distinguishing between unset and any of the enum variants.
+    //
+    // This enum is initially used only in a oneof, which means we can
+    // distinguish unset without this sentinel. But stick one in here anyway,
+    // in case this enum gets used somewhere else in the future.
+    Unknown = 0;
+    Null = 1;
+    False = 2;
+    True = 3;
+    JsonNull = 4;
+    Dummy = 5;
+    NumericPosInf = 6;
+    NumericNegInf = 7;
+    NumericNaN = 8;
+}
+
+message ProtoDate {
+    // Year
+    int32 year = 1;
+    // Day-of-year (0..365)
+    uint32 ordinal = 2;
+}
+
+message ProtoTime {
+    // The number of seconds since midnight
+    uint32 secs = 1;
+    // Additional fractional seconds since midnight in nanosecond granularity.
+    // This can can exceed 1,000,000,000 in order to represent the leap second.
+    uint32 nanos = 2;
+}
+
+message ProtoTimestamp {
+    // Year
+    int32 year = 1;
+    // Day-of-year (0..365)
+    uint32 ordinal = 2;
+    // The number of seconds since midnight
+    uint32 secs = 3;
+    // Additional fractional seconds since midnight in nanosecond granularity.
+    // This can can exceed 1,000,000,000 in order to represent the leap second.
+    uint32 nanos = 4;
+    // If true, this timestamp is in UTC. If false, this timestamp is zoneless.
+    bool is_tz = 5;
+}
+
+message ProtoInterval {
+    // A possibly negative number of months.
+    int32 months = 1;
+    // A 128-bit nanosecond count, represented as a 64-bit lo and hi.
+    //
+    // TODO: Why do our in-mem intervals use this representation? I've seen
+    // month/day/nanos in the past becuase a day is not always the same number
+    // of nanos.
+    int64 duration_lo = 2;
+    int64 duration_hi = 3;
+}
+
+message ProtoArray {
+    // All array elements flattened into 1 dimension, encoded in row-major
+    // order.
+    ProtoRow elements = 1;
+    // A list of metadata for each dimension in the array. Each dimension has a
+    // lower bound (the index at which the dimension begins) and the length of
+    // the dimension (the number of elements in that dimension). For a 3x4
+    // matrix, for example, you'd have two entries in the dims array, the first
+    // with length 3 and the second with length 4. ATM the lower bound for each
+    // dimension is always 1, but Postgres technically lets you choose any lower
+    // bound you like for each dimension.
+    repeated ProtoArrayDimension dims = 2;
+}
+
+message ProtoArrayDimension {
+    uint64 lower_bound = 1;
+    uint64 length = 2;
+}
+
+message ProtoDict {
+    repeated ProtoDictElement elements = 1;
+}
+
+message ProtoDictElement {
+    string key = 1;
+    ProtoDatum val = 2;
+}
+
+// See [dec::to_packed_bcd] and http://speleotrove.com/decimal/dnpack.html for
+// more information on this format.
+//
+// NB: Special values like NaN, PosInf, and NegInf are represented as variants
+// of ProtoDatumOther.
+message ProtoNumeric {
+       // A a sequence of Binary Coded Decimal digits, most significant first (at
+       // the lowest offset into the byte array) and one per 4 bits (that is, each
+       // digit taking a value of 0–9, and two digits per byte), with optional
+       // leading zero digits.
+       bytes bcd = 1;
+       // The number of digits that follow the decimal point.
+       int32 scale = 2;
+   }


### PR DESCRIPTION
We initially intended to use the internal Row encoding for decoding
efficiency, but from a maintenance perspective, it's much easier in
proto to deal with backward and forward compatibility of changes. We can
always change our minds later (with a good bit of glue code, admittedly)
if this turns out to be too much of a bottleneck.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

I'm reasonably confident in the implementations (certainly give them a skim), but the biggest feedback I'd like is on the particulars of how each datum is being broken apart and written down. We've got a bit before we're guaranteeing backward compatibility, and thus we have some time to make changes without a migration sitting permanently in code somewhere, but it's still good to do our due diligence.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/9406)
<!-- Reviewable:end -->
