### PR TITLE
Use uname -m instead of arch

### DIFF
--- a/misc/shlib/shlib.bash
+++ b/misc/shlib/shlib.bash
@@ -171,7 +171,7 @@ mapfile_shim() {
 # Dies if the host architecture is unknown.
 arch_gcc() {
     local arch
-    arch=$(arch)
+    arch=$(uname -m)
     case "$arch" in
         x86_64|aarch64) echo "$arch" ;;
         arm64) echo aarch64 ;;


### PR DESCRIPTION
The arch command is not available on all target platforms, uname -m
seems to have better support.

This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
