### PR TITLE
coord: bump table timestamps less often

### DIFF
--- a/src/materialized/tests/sql.rs
+++ b/src/materialized/tests/sql.rs
@@ -793,6 +793,102 @@ fn test_tail_shutdown() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+#[test]
+fn test_tail_table_rw_timestamps() -> Result<(), Box<dyn Error>> {
+    ore::test::init_logging();
+
+    let config = util::Config::default().workers(3);
+    let server = util::start_server(config)?;
+    let mut client_interactive = server.connect(postgres::NoTls)?;
+    let mut client_tail = server.connect(postgres::NoTls)?;
+
+    let verify_rw_pair = move |rows: &[Row], expected_data: &str| -> bool {
+        for (i, row) in rows.iter().enumerate() {
+            match row.get::<_, Option<String>>("data") {
+                // Ensure all rows with data have the expected data, and that rows
+                // without data are only ever the last row.
+                Some(inner) => assert_eq!(inner, expected_data.to_owned()),
+                // Only verify if row without data is last row
+                None => {
+                    if i + 1 != rows.len() {
+                        return false;
+                    }
+                }
+            }
+        }
+
+        if rows.len() != 2 {
+            return false;
+        }
+
+        // First row reflects write. Written rows have not progressed, and all
+        // writes occur at the same timestamp.
+        assert_eq!(rows[0].get::<_, Option<bool>>("mz_progressed"), Some(false));
+        // Two writes with the same data have their diffs compacted
+        assert_eq!(rows[0].get::<_, Option<i64>>("mz_diff"), Some(2));
+
+        // Second row reflects closing timestamp, manufactured by the read
+        assert_eq!(rows[1].get::<_, Option<bool>>("mz_progressed"), Some(true));
+        assert_eq!(rows[1].get::<_, Option<i64>>("mz_diff"), None);
+
+        true
+    };
+
+    client_interactive.batch_execute("CREATE TABLE t1 (data text)")?;
+
+    client_tail.batch_execute(
+        "COMMIT; BEGIN;
+         DECLARE c1 CURSOR FOR TAIL t1 WITH (PROGRESS);",
+    )?;
+
+    // Keep trying until you either panic or are able to verify the expected behavior.
+    loop {
+        client_interactive.execute("INSERT INTO t1 VALUES ($1)", &[&"first".to_owned()])?;
+        client_interactive.execute("INSERT INTO t1 VALUES ($1)", &[&"first".to_owned()])?;
+        let _ = client_interactive.query("SELECT * FROM T1", &[])?;
+        client_interactive.execute("INSERT INTO t1 VALUES ($1)", &[&"second".to_owned()])?;
+        client_interactive.execute("INSERT INTO t1 VALUES ($1)", &[&"second".to_owned()])?;
+
+        let first_rows = client_tail.query("FETCH ALL c1", &[])?;
+        let first_rows_verified = verify_rw_pair(&first_rows, "first");
+
+        let _ = client_interactive.query("SELECT * FROM t1", &[])?;
+
+        let second_rows = client_tail.query("FETCH ALL c1", &[])?;
+        let second_rows_verified = verify_rw_pair(&second_rows, "second");
+
+        if first_rows_verified && second_rows_verified {
+            // Closing open write timestamp only advances time 1 unit
+            let first_write_ts = first_rows[0].get::<_, MzTimestamp>("mz_timestamp");
+            let first_closed_ts = first_rows[1].get::<_, MzTimestamp>("mz_timestamp");
+            assert_eq!(first_closed_ts.0 - first_write_ts.0, 1);
+
+            // We cannot make as strong of claims about the second set of timestamps
+            // because we let more time lapse by having an interceding `FETCH`.
+            let second_write_ts = second_rows[0].get::<_, MzTimestamp>("mz_timestamp");
+            let second_closed_ts = second_rows[1].get::<_, MzTimestamp>("mz_timestamp");
+            assert!(first_write_ts < second_write_ts);
+            assert!(second_write_ts < second_closed_ts);
+            break;
+        }
+    }
+
+    // Ensure reads don't advance timestamp.
+    loop {
+        let first_read =
+            client_interactive.query("SELECT *, mz_logical_timestamp() FROM t1", &[])?;
+        let second_read =
+            client_interactive.query("SELECT *, mz_logical_timestamp() FROM t1", &[])?;
+        if first_read[0].get::<_, MzTimestamp>("mz_logical_timestamp")
+            == second_read[0].get::<_, MzTimestamp>("mz_logical_timestamp")
+        {
+            break;
+        }
+    }
+
+    Ok(())
+}
+
 // Tests that temporary views created by one connection cannot be viewed
 // by another connection.
 #[test]

--- a/test/upgrade/check-from-any_version-avro-ocf-sink.td
+++ b/test/upgrade/check-from-any_version-avro-ocf-sink.td
@@ -9,8 +9,16 @@
 
 > INSERT INTO avro_ocf_table VALUES (3);
 
-# Make sure the OCF file has been created and populated before attempting to run $ avro-ocf-verify on it
-# As there is no way to wait precisely until that occurs, we have no option but to use mz_sleep()
+# Make sure the OCF file has been created and populated before attempting to
+# run $ avro-ocf-verify on it. As there is no way to wait precisely until that
+# occurs, we have no option but to use mz_sleep(). However, we can "expedite"
+# writing to the sink file by observing the write. This should never be
+# _necessary_, but simply lets us have a shorter sleep value, e.g. without the
+# SELECT, tests need a sleep value > 5 to ensure the file's created.
+
+> SELECT COUNT(*) > 0 FROM avro_ocf_table WHERE f1 = 3;
+true
+
 > SELECT mz_internal.mz_sleep(2);
 <null>
 


### PR DESCRIPTION
You can find details of this issue in ##9362

_note: I slightly amended this description since posting the PR, as I had
misassessed some conditions originally_

The solution proposed here is to a create a kind of finite-state machine to
express when we need to open new timestamps:

### Read state

Transitions:
- Read:
    - Returns timestamps at `last_open_time` - 1
    - Stays in this state
- Write:
    - Returns timestamps at `last_open_time`
    - Moves to **Writes state**

### Write state

Transitions:
- Read:
    - Returns timestamps at `last_open_time`
    - Increases `last_open_time` by opening new timestamp/closing over previous value
    - Advances to `last_open_time`, making `last_open_time` - 1 immediately readable.
    - Moves to **Read state**
- Write:
    - Returns timestamps at `last_open_time`
    - Stays in this state

We then also trick the Coordinator to open new timestamps on
`AdvanceLocalInputs` by acting like we want to transition from the Write to
Read, signaled by `read_at_offset_from_open_local == 0`.

### Motivation

This PR adds a known-desirable feature. Closes #9362

### Tips for reviewer

The changes to the existing tests were:
- In the case of `test_tail_continuous_progress`, informed by the [`TAIL`
  docs](https://materialize.com/docs/sql/tail/#output), namely this description
  of `mz_timestamp`:
  > `mz_timestamp` will never be less than any timestamp previously emitted by
  > the same TAIL operation.  
- In the case of `test_tail_basic`, written by @aljoscha
- For `check-from-any_version-avro-ocf-sink.td`,  I was able to get it to pass with a sleep of 10 seconds, but not consistently with a sleep of 5 seconds; however, just adding a `SELECT` gets it to pass with the existing sleep of 2 seconds.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
