### PR TITLE
persist: two small refactors to persist operators

### DIFF
--- a/src/persist/src/operators/upsert.rs
+++ b/src/persist/src/operators/upsert.rs
@@ -26,7 +26,7 @@ use crate::indexed::runtime::{StreamReadHandle, StreamWriteHandle};
 use crate::operators::replay::Replay;
 use crate::operators::split_ok_err;
 use crate::operators::stream::Persist;
-use crate::operators::stream::RetractFutureUpdates;
+use crate::operators::stream::RetractUnsealed;
 
 use persist_types::Codec;
 
@@ -127,12 +127,11 @@ where
         let (restored_upsert_oks, _state_errs) = {
             let snapshot = persist_config.read_handle.snapshot();
             let (restored_oks, restored_errs) = self.scope().replay(snapshot).ok_err(split_ok_err);
-            let (restored_upsert_oks, retract_errs) = restored_oks
-                .filter_and_retract_future_updates(
-                    name,
-                    persist_config.write_handle.clone(),
-                    persist_config.upper_seal_ts,
-                );
+            let (restored_upsert_oks, retract_errs) = restored_oks.retract_unsealed(
+                name,
+                persist_config.write_handle.clone(),
+                persist_config.upper_seal_ts,
+            );
             let combined_errs = restored_errs.concat(&retract_errs);
             (restored_upsert_oks, combined_errs)
         };

--- a/src/persist/src/operators/upsert.rs
+++ b/src/persist/src/operators/upsert.rs
@@ -144,7 +144,7 @@ where
             &restored_upsert_oks,
             Exchange::new(move |(key, _value, _ts): &(K, Option<V>, T)| key.hashed()),
             Exchange::new(move |((key, _data), _ts, _diff): &((K, _), _, _)| key.hashed()),
-            "Upsert",
+            &operator_name.clone(),
             move |_cap, _info| {
                 // This is a map of (time) -> (capability, ((key) -> (value with max offset))). This
                 // is a BTreeMap because we want to ensure that if we receive (key1, value1, time


### PR DESCRIPTION
### Motivation

* rename `filter_and_retract_future_updates` -> `retract_unsealed`
* set the name for the persisted upsert operator to the name logged out
   to trace logs
<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug. [Link to issue.]

  * This PR adds a known-desirable feature. [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
