### PR TITLE
test/redpanda: enable protobuf schema tests

### DIFF
--- a/misc/python/materialize/mzcompose.py
+++ b/misc/python/materialize/mzcompose.py
@@ -897,7 +897,7 @@ class Redpanda(PythonService):
     def __init__(
         self,
         name: str = "redpanda",
-        version: str = "v21.10.2",
+        version: str = "v21.11.1-beta1",
         image: Optional[str] = None,
         aliases: Optional[List[str]] = None,
         ports: Optional[List[int]] = None,

--- a/test/redpanda/mzworkflows.py
+++ b/test/redpanda/mzworkflows.py
@@ -23,7 +23,6 @@ def workflow_redpanda_testdrive(w: Workflow):
 
     # Features currently not supported by Redpanda:
     # - `kafka-time-offset.td` (https://github.com/vectorizedio/redpanda/issues/2397)
-    # - `schema-registry-publish` with `format=protobuf` (Redpanda does not support schema publication for protobuf/json)
 
     # Due to interactions between docker-compose, entrypoint, command, and bash, it is not possible to have
     # a more complex filtering expression in 'command' . So we basically run the entire testdrive suite here
@@ -32,5 +31,5 @@ def workflow_redpanda_testdrive(w: Workflow):
 
     w.run_service(
         service="testdrive-svc",
-        command="grep -L -E 'kafka_time_offset|schema-type=protobuf' testdrive/*.td",
+        command="grep -L -E 'kafka_time_offset' testdrive/*.td",
     )


### PR DESCRIPTION
The latest version of redpanda supports publishing protobuf schemas to the registry.

### Motivation

  * This PR adds a known-desirable feature. 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
