### PR TITLE
coord, dataflow: Move TAIL row processing to coord

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -120,6 +120,7 @@ use expr::{
     ExprHumanizer, GlobalId, Id, MirRelationExpr, MirScalarExpr, NullaryFunc,
     OptimizedMirRelationExpr, RowSetFinishing,
 };
+use ore::cast::CastFrom;
 use ore::metrics::MetricsRegistry;
 use ore::now::{to_datetime, NowFn};
 use ore::retry::Retry;
@@ -329,10 +330,8 @@ where
     /// A map from pending peeks to the queue into which responses are sent, and
     /// the IDs of workers who have responded.
     pending_peeks: HashMap<u32, mpsc::UnboundedSender<PeekResponse>>,
-    /// A map from pending tails to the queue into which responses are sent.
-    ///
-    /// The responses have the form `Vec<Row>` but should perhaps become `TailResponse`.
-    pending_tails: HashMap<GlobalId, mpsc::UnboundedSender<Vec<Row>>>,
+    /// A map from pending tails to the tail description.
+    pending_tails: HashMap<GlobalId, PendingTail>,
 
     /// Serializes accesses to write critical sections.
     write_lock: Arc<tokio::sync::Mutex<()>>,
@@ -359,6 +358,18 @@ struct ConnMeta {
 struct TxnReads {
     timedomain_ids: HashSet<GlobalId>,
     _handles: Vec<AntichainToken<Timestamp>>,
+}
+
+/// A description of a pending tail from coord's perspective
+struct PendingTail {
+    /// Channel to send responses to the client
+    ///
+    /// The responses have the form `Vec<Row>` but should perhaps become `TailResponse`.
+    channel: mpsc::UnboundedSender<Vec<Row>>,
+    /// Whether progress information should be emitted
+    emit_progress: bool,
+    /// Number of columns in the output
+    object_columns: usize,
 }
 
 /// Enforces critical section invariants for functions that perform writes to
@@ -738,9 +749,50 @@ where
                 // We use an `if let` here because the peek could have been cancelled already.
                 // We can also potentially receive multiple `Complete` responses, followed by
                 // a `Dropped` response.
-                if let Some(channel) = self.pending_tails.get_mut(&sink_id) {
+                if let Some(PendingTail {
+                    channel,
+                    emit_progress,
+                    object_columns,
+                }) = self.pending_tails.get_mut(&sink_id)
+                {
+                    let mut packer = Row::default();
                     match response {
+                        TailResponse::Progress(upper) => {
+                            packer.push(Datum::from(numeric::Numeric::from(upper)));
+                            packer.push(Datum::True);
+                            // Fill in the diff column and all table columns with NULL.
+                            for _ in 0..(*object_columns + 1) {
+                                packer.push(Datum::Null);
+                            }
+                            let row = packer.finish_and_reuse();
+
+                            let result = channel.send(vec![row]);
+                            if result.is_err() {
+                                // TODO(benesch): we should actually drop the sink if the
+                                // receiver has gone away. E.g. form a DROP SINK command?
+                            }
+                        }
                         TailResponse::Rows(rows) => {
+                            let rows = rows
+                                .into_iter()
+                                .map(|(time, diff, row)| {
+                                    packer.push(Datum::from(numeric::Numeric::from(time)));
+                                    if *emit_progress {
+                                        // When sinking with PROGRESS, the output
+                                        // includes an additional column that
+                                        // indicates whether a timestamp is
+                                        // complete. For regular "data" upates this
+                                        // is always `false`.
+                                        packer.push(Datum::False);
+                                    }
+
+                                    packer.push(Datum::Int64(i64::cast_from(diff)));
+
+                                    packer.extend_by_row(&row);
+
+                                    packer.finish_and_reuse()
+                                })
+                                .collect();
                             // TODO(benesch): the lack of backpressure here can result in
                             // unbounded memory usage.
                             let result = channel.send(rows);
@@ -3084,7 +3136,14 @@ where
         let sink_id = self.catalog.allocate_id()?;
         session.add_drop_sink(sink_id);
         let (tx, rx) = mpsc::unbounded_channel();
-        self.pending_tails.insert(sink_id, tx);
+        self.pending_tails.insert(
+            sink_id,
+            PendingTail {
+                channel: tx,
+                emit_progress,
+                object_columns,
+            },
+        );
         let sink_description = dataflow_types::SinkDesc {
             from: source_id,
             from_desc: self.catalog.get_by_id(&source_id).desc().unwrap().clone(),

--- a/src/coord/src/lib.rs
+++ b/src/coord/src/lib.rs
@@ -39,6 +39,7 @@ mod error;
 mod id_alloc;
 mod persistcfg;
 mod sink_connector;
+mod tail;
 mod timestamp;
 mod util;
 

--- a/src/coord/src/tail.rs
+++ b/src/coord/src/tail.rs
@@ -1,0 +1,112 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Implementations around supporting the TAIL protocol with the dataflow layer
+
+use dataflow_types::TailResponse;
+use ore::cast::CastFrom;
+use repr::adt::numeric;
+use repr::{Datum, Row};
+use tokio::sync::mpsc;
+
+/// A description of a pending tail from coord's perspective
+pub(crate) struct PendingTail {
+    /// Channel to send responses to the client
+    ///
+    /// The responses have the form `Vec<Row>` but should perhaps become `TailResponse`.
+    channel: mpsc::UnboundedSender<Vec<Row>>,
+    /// Whether progress information should be emitted
+    emit_progress: bool,
+    /// Number of columns in the output
+    object_columns: usize,
+}
+
+impl PendingTail {
+    /// Create a new [PendingTail].
+    /// * The `channel` receives batches of finalized rows.
+    /// * If `emit_progress` is true, the finalized rows are either data or progress updates
+    /// * `object_columns` is the arity of the sink relation.
+    pub(crate) fn new(
+        channel: mpsc::UnboundedSender<Vec<Row>>,
+        emit_progress: bool,
+        object_columns: usize,
+    ) -> Self {
+        Self {
+            channel,
+            emit_progress,
+            object_columns,
+        }
+    }
+
+    /// Process a tail response
+    ///
+    /// Returns `true` if the sink should be removed.
+    pub(crate) fn process_response(&mut self, response: TailResponse) -> bool {
+        let mut packer = Row::default();
+        match response {
+            TailResponse::Progress(upper) => {
+                if self.emit_progress {
+                    packer.push(Datum::from(numeric::Numeric::from(*&upper[0])));
+                    packer.push(Datum::True);
+                    // Fill in the diff column and all table columns with NULL.
+                    for _ in 0..(self.object_columns + 1) {
+                        packer.push(Datum::Null);
+                    }
+                    let row = packer.finish_and_reuse();
+
+                    let result = self.channel.send(vec![row]);
+                    if result.is_err() {
+                        // TODO(benesch): we should actually drop the sink if the
+                        // receiver has gone away. E.g. form a DROP SINK command?
+                    }
+                }
+                false
+            }
+            TailResponse::Rows(mut rows) => {
+                // Sort results by time. We use stable sort here because it will produce deterministic
+                // results since the cursor will always produce rows in the same order.
+                // TODO: Is sorting necessary?
+                rows.sort_by_key(|(_, time, _)| *time);
+
+                let rows = rows
+                    .into_iter()
+                    .map(|(row, time, diff)| {
+                        packer.push(Datum::from(numeric::Numeric::from(time)));
+                        if self.emit_progress {
+                            // When sinking with PROGRESS, the output
+                            // includes an additional column that
+                            // indicates whether a timestamp is
+                            // complete. For regular "data" upates this
+                            // is always `false`.
+                            packer.push(Datum::False);
+                        }
+
+                        packer.push(Datum::Int64(i64::cast_from(diff)));
+
+                        packer.extend_by_row(&row);
+
+                        packer.finish_and_reuse()
+                    })
+                    .collect();
+                // TODO(benesch): the lack of backpressure here can result in
+                // unbounded memory usage.
+                let result = self.channel.send(rows);
+                if result.is_err() {
+                    // TODO(benesch): we should actually drop the sink if the
+                    // receiver has gone away. E.g. form a DROP SINK command?
+                }
+                false
+            }
+            TailResponse::Complete | TailResponse::Dropped => {
+                // TODO: Could perhaps do this earlier, in response to DROP SINK.
+                true
+            }
+        }
+    }
+}

--- a/src/coord/src/tail.rs
+++ b/src/coord/src/tail.rs
@@ -51,7 +51,12 @@ impl PendingTail {
         let mut packer = Row::default();
         match response {
             TailResponse::Progress(upper) => {
-                if self.emit_progress {
+                if self.emit_progress && !upper.is_empty() {
+                    assert_eq!(
+                        upper.len(),
+                        1,
+                        "TAIL only supports single-dimensional timestamps"
+                    );
                     packer.push(Datum::from(numeric::Numeric::from(*&upper[0])));
                     packer.push(Datum::True);
                     // Fill in the diff column and all table columns with NULL.
@@ -66,7 +71,7 @@ impl PendingTail {
                         // receiver has gone away. E.g. form a DROP SINK command?
                     }
                 }
-                false
+                upper.is_empty()
             }
             TailResponse::Rows(mut rows) => {
                 // Sort results by time. We use stable sort here because it will produce deterministic

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -59,10 +59,11 @@ impl PeekResponse {
 /// Various responses that can be communicated about the progress of a TAIL command.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub enum TailResponse {
-    /// Progress information about the upper frontier.
-    Progress(Timestamp),
+    /// Progress information. Subsequent messages from this worker will only contain timestamps
+    /// greater or equal to an element of this frontier.
+    Progress(Antichain<Timestamp>),
     /// Rows that should be returned in order to the client.
-    Rows(Vec<(Timestamp, Diff, Row)>),
+    Rows(Vec<(Row, Timestamp, Diff)>),
     /// Sent once the stream is complete. Indicates the end.
     Complete,
     /// The TAIL dataflow was dropped before completing. Indicates the end.
@@ -1163,12 +1164,8 @@ impl SinkConnector {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct TailSinkConnector {
-    pub emit_progress: bool,
-    pub object_columns: usize,
-    pub value_desc: RelationDesc,
-}
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct TailSinkConnector {}
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum SinkConnectorBuilder {

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -61,12 +61,16 @@ impl PeekResponse {
 pub enum TailResponse {
     /// Progress information. Subsequent messages from this worker will only contain timestamps
     /// greater or equal to an element of this frontier.
+    ///
+    /// An empty antichain indicates the end.
     Progress(Antichain<Timestamp>),
     /// Rows that should be returned in order to the client.
     Rows(Vec<(Row, Timestamp, Diff)>),
     /// Sent once the stream is complete. Indicates the end.
+    /// TODO(#9479): mh@ thinks this state can be included in Progress with an emtpy antichain
     Complete,
     /// The TAIL dataflow was dropped before completing. Indicates the end.
+    /// TODO(#9479): mh@ thinks this state can be included in Progress with an emtpy antichain
     Dropped,
 }
 

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -59,8 +59,10 @@ impl PeekResponse {
 /// Various responses that can be communicated about the progress of a TAIL command.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub enum TailResponse {
+    /// Progress information about the upper frontier.
+    Progress(Timestamp),
     /// Rows that should be returned in order to the client.
-    Rows(Vec<Row>),
+    Rows(Vec<(Timestamp, Diff, Row)>),
     /// Sent once the stream is complete. Indicates the end.
     Complete,
     /// The TAIL dataflow was dropped before completing. Indicates the end.

--- a/src/dataflow/src/sink/tail.rs
+++ b/src/dataflow/src/sink/tail.rs
@@ -27,9 +27,7 @@ use timely::PartialOrder;
 
 use dataflow_types::{SinkAsOf, SinkDesc, TailResponse, TailSinkConnector};
 use expr::GlobalId;
-use ore::cast::CastFrom;
-use repr::adt::numeric::{self, Numeric};
-use repr::{Datum, Diff, Row, Timestamp};
+use repr::{Diff, Row, Timestamp};
 
 use crate::render::sinks::SinkRender;
 use crate::render::RenderState;
@@ -101,8 +99,6 @@ fn tail<G>(
         .arrange_by_key()
         .stream;
 
-    let mut packer = Row::default();
-
     // Initialize to the minimal input frontier.
     let mut input_frontier = Antichain::from_elem(<G::Timestamp as TimelyTimestamp>::minimum());
     // An encapsulation of the Tail response protocol.
@@ -133,24 +129,7 @@ fn tail<G>(
                                 as_of.frontier.less_equal(time)
                             };
                             if should_emit {
-                                packer.push(Datum::from(numeric::Numeric::from(*time)));
-                                if connector.emit_progress {
-                                    // When sinking with PROGRESS, the output
-                                    // includes an additional column that
-                                    // indicates whether a timestamp is
-                                    // complete. For regular "data" upates this
-                                    // is always `false`.
-                                    packer.push(Datum::False);
-                                }
-
-                                packer.push(Datum::Int64(i64::cast_from(diff)));
-
-                                packer.extend_by_row(&row);
-
-                                let row = packer.finish_and_reuse();
-
-                                // Add the unpacked timestamp so we can sort by them later.
-                                results.push((*time, row));
+                                results.push((*time, diff, row.clone()));
                             }
                         });
                         cursor.step_val(&batch);
@@ -159,51 +138,36 @@ fn tail<G>(
                 }
             }
 
-            // Sort results by time and convert to Vec<Row>. We use stable sort here because
-            // it will produce deterministic results since the cursor will always produce
-            // rows in the same order.
-            results.sort_by_key(|(time, _)| *time);
-            let mut results: Vec<Row> = results.into_iter().map(|(_, row)| row).collect();
-
-            if let Some(batch) = batches.last() {
-                let progress_row = update_progress(
-                    &mut input_frontier,
-                    batch.desc.upper().borrow(),
-                    &mut packer,
-                    connector.object_columns + 1,
-                );
-                if connector.emit_progress && tail_protocol.is_some() {
-                    if let Some(progress_row) = progress_row {
-                        results.push(progress_row);
-                    }
-                }
-            }
+            // Sort results by time. We use stable sort here because it will produce deterministic
+            // results since the cursor will always producerows in the same order.
+            results.sort_by_key(|(time, _, _)| *time);
 
             // Emit data if configured, otherwise it is an error to have data to send.
             if let Some(tail_protocol) = &mut tail_protocol {
-                tail_protocol.send(results);
+                tail_protocol.send_rows(results);
             } else {
                 assert!(
                     results.is_empty(),
                     "Observed data at inactive TAIL instance"
                 );
             }
+
+            if let Some(batch) = batches.last() {
+                let progress = update_progress(&mut input_frontier, batch.desc.upper().borrow());
+                if connector.emit_progress {
+                    if let (Some(tail_protocol), Some(progress)) = (&mut tail_protocol, progress) {
+                        tail_protocol.send_progress(progress);
+                    }
+                }
+            }
         });
 
-        let progress_row = update_progress(
-            &mut input_frontier,
-            input.frontier().frontier(),
-            &mut packer,
-            connector.object_columns + 1,
-        );
+        let progress = update_progress(&mut input_frontier, input.frontier().frontier());
 
         // Only emit updates if this operator/worker received actual data for emission.
-        if let Some(tail_protocol) = &mut tail_protocol {
-            if connector.emit_progress {
-                if let Some(progress_row) = progress_row {
-                    let results = vec![progress_row];
-                    tail_protocol.send(results);
-                }
+        if connector.emit_progress {
+            if let (Some(tail_protocol), Some(progress)) = (&mut tail_protocol, progress) {
+                tail_protocol.send_progress(progress);
             }
         }
 
@@ -230,10 +194,21 @@ struct TailProtocol {
 }
 
 impl TailProtocol {
+    /// Send the current upper frontier of the tail.
+    ///
+    /// Does nothing if `self.complete()` has been called.
+    fn send_progress(&mut self, upper: Timestamp) {
+        if let Some(buffer) = &mut self.tail_response_buffer {
+            buffer
+                .borrow_mut()
+                .push((self.sink_id, TailResponse::Progress(upper)));
+        }
+    }
+
     /// Send further rows as responses.
     ///
     /// Does nothing if `self.complete()` has been called.
-    fn send(&mut self, rows: Vec<Row>) {
+    fn send_rows(&mut self, rows: Vec<(Timestamp, Diff, Row)>) {
         if let Some(buffer) = &mut self.tail_response_buffer {
             buffer
                 .borrow_mut()
@@ -270,9 +245,7 @@ impl Drop for TailProtocol {
 fn update_progress(
     current_input_frontier: &mut Antichain<Timestamp>,
     new_input_frontier: AntichainRef<Timestamp>,
-    packer: &mut Row,
-    empty_columns: usize,
-) -> Option<Row> {
+) -> Option<Timestamp> {
     // Test to see if strict progress has occurred. This is true if the new
     // frontier is not less or equal to the old frontier.
     let progress = !PartialOrder::less_equal(&new_input_frontier, &current_input_frontier.borrow());
@@ -286,22 +259,11 @@ fn update_progress(
         // anymore. There might not even be progress in the first dimension.
         // We panic, so that future developers introducing multi-dimensional
         // time in Materialize will notice.
-        let upper = new_input_frontier
+        new_input_frontier
             .iter()
             .at_most_one()
             .expect("more than one element in the frontier")
-            .cloned();
-
-        // the input frontier might be empty
-        upper.map(|upper| {
-            packer.push(Datum::from(Numeric::from(upper)));
-            packer.push(Datum::True);
-            // Fill in the diff column and all table columns with NULL.
-            for _ in 0..empty_columns {
-                packer.push(Datum::Null);
-            }
-            packer.finish_and_reuse()
-        })
+            .cloned()
     } else {
         None
     }

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -242,7 +242,6 @@ pub struct TailPlan {
     pub copy_to: Option<CopyFormat>,
     pub emit_progress: bool,
     pub object_columns: usize,
-    pub desc: RelationDesc,
 }
 
 #[derive(Debug)]

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -318,7 +318,6 @@ pub fn plan_tail(
     let entry = scx.resolve_item(name)?;
     let ts = as_of.map(|e| query::eval_as_of(scx, e)).transpose()?;
     let options = TailOptions::try_from(options)?;
-    let desc = entry.desc()?.clone();
 
     match entry.item_type() {
         CatalogItemType::Table | CatalogItemType::Source | CatalogItemType::View => {
@@ -329,7 +328,6 @@ pub fn plan_tail(
                 copy_to,
                 emit_progress: options.progress.unwrap_or(false),
                 object_columns: entry.desc()?.arity(),
-                desc,
             }))
         }
         CatalogItemType::Func


### PR DESCRIPTION
Currently, the dataflow layer prepares the response to a TAIL command, in
which it creates rows encoding data and optional progress updates. This
is problematic as the coordinator needs to extract metadata from rows
instead of structured information if it wishes to do so. With this change,
the formulation of rows sent to the client is moved to the coordinator.


This PR adds a known-desirable feature: #9442 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes] https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
