### PR TITLE
mzbench-opt: add a Python package for optimizer benchmarks

### DIFF
--- a/src/transform/benches/.gitignore
+++ b/src/transform/benches/.gitignore
@@ -1,0 +1,2 @@
+*.egg-info
+build/

--- a/src/transform/benches/README.md
+++ b/src/transform/benches/README.md
@@ -1,0 +1,91 @@
+# `mzbench-opt`
+
+The `mzbench-opt` package contains optimizer benchmarking scripts.
+
+## Installation (`pyenv`)
+
+We need a Python version higher than `3.9.x`
+
+```bash
+PYTHON_VERSION=3.9.5
+```
+
+Run the following commands only once on each host:
+
+```bash
+pyenv virtualenv ${PYTHON_VERSION} mzbench-opt
+```
+
+Run the following commands whenever the contents of this folder change:
+
+```bash
+# activate mzbench-opt environment
+pyenv virtualenv-delete mzbench-opt
+pyenv virtualenv ${PYTHON_VERSION} mzbench-opt
+
+# install package
+pyenv activate mzbench-opt
+pip install -e .
+
+# install zsh shell completion
+mzbench-opt --install-completion zsh
+rm -f ~/.zcompdump; compinit
+```
+
+## Run Benchmarks
+
+To run a benchmark you need to:
+
+1. Intialize the database schema for your test scenario.
+1. Run the workload of your test scenario.
+
+These two steps are modeled by the `init` and `run` commands.
+For example, for the `tpch` scenario, type
+
+```bash
+mzbench-opt init tpch
+mzbench-opt run tpch --repository="$HOME/mzbench-opt"
+```
+
+The results of benchmark `run` are stored in the OS temp folder by default, but here we set the location to `$HOME/mzbench-opt` using the `--repository` option.
+Result files have the form `mzbench-opt-${scenario}-${mz_version}.csv`, where
+
+- `${scenario}` is the value of the `SCENARIO` argument passed to the `run` command, and
+- `${mz_version}` is a suffix derived from the `SELECT mz_version()` result of the database instance under test.
+
+For a full list of the available options, type the following:
+
+```bash
+mzbench-opt init --help
+mzbench-opt run --help
+```
+
+## Comparing Two Benchmark Runs
+
+To see the relative performance of a `diff` benchmark run against a `base` run, use the `compare` command.
+
+For example, to compare the results of runs against database instances build from commits `07c937bee` and `3ab9c59b6` as described above, we will use the following command.
+
+```bash
+mzbench-opt compare \
+  $HOME/mzbench-opt/mzbench-opt-tpch-v0.10.1-dev-07c937bee.csv \
+  $HOME/mzbench-opt/mzbench-opt-tpch-v0.10.1-dev-3ab9c59b6.csv
+```
+
+As before, for a full list of the available options, type the following:
+
+```bash
+mzbench-opt compare --help
+```
+
+## Benchmark Scenarios
+
+In the example above we used `tpch` as a benchmark scenario.
+
+To add a new scenario `${scenario}`:
+
+1. Add a file called `${scenario}.sql` in `mzbench_opt/schema`. Use `tpch.sql` as a reference.
+1. Add a file called `${scenario}.sql` in `mzbench_opt/workload`. Use `tpch.sql` as a reference.
+
+Queries in the workload file must be annotated with a comment of the form `-- name: ${name}`.
+Prefer short names such as `Q01`, `Q02`, etc. in order to keep the width of the generated reports as narrow as possible.

--- a/src/transform/benches/mzbench_opt/__init__.py
+++ b/src/transform/benches/mzbench_opt/__init__.py
@@ -1,0 +1,39 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from enum import Enum
+from pathlib import Path
+from typing import List
+
+from pkg_resources import resource_filename
+
+
+def resource_path(name: str) -> Path:
+    return Path(resource_filename(__name__, name))
+
+
+def scenarios() -> List[str]:
+    schema_files = {
+        p.stem
+        for p in resource_path("schema").iterdir()
+        if p.is_file() and p.suffix == ".sql"
+    }
+    workload_files = {
+        p.stem
+        for p in resource_path("workload").iterdir()
+        if p.is_file() and p.suffix == ".sql"
+    }
+
+    return sorted(schema_files.intersection(workload_files))
+
+
+Scenario = Enum("Scenario", {scenario: scenario for scenario in scenarios()})
+Scenario.__str__ = lambda self: self.value
+Scenario.schema_path = lambda self: resource_path(f"schema/{self}.sql")
+Scenario.workload_path = lambda self: resource_path(f"workload/{self}.sql")

--- a/src/transform/benches/mzbench_opt/cli.py
+++ b/src/transform/benches/mzbench_opt/cli.py
@@ -1,0 +1,200 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+import csv
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import typer
+
+from . import Scenario, sql, util
+
+# import logging
+# logging.basicConfig(encoding='utf-8', level=logging.DEBUG)
+
+# Typer CLI Application
+# ---------------------
+
+app = typer.Typer()
+
+
+class Arg:
+    scenario: Scenario = typer.Argument(..., help="Scenario to use.")
+
+    base: Path = typer.Argument(
+        ...,
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        writable=False,
+        readable=True,
+        resolve_path=True,
+        help="Results of the base run",
+    )
+
+    diff: Path = typer.Argument(
+        ...,
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        writable=False,
+        readable=True,
+        resolve_path=True,
+        help="Results of the diff run",
+    )
+
+
+class Opt:
+    repository: Path = typer.Option(
+        Path(tempfile.gettempdir()),
+        exists=True,
+        file_okay=False,
+        dir_okay=True,
+        writable=True,
+        readable=True,
+        resolve_path=True,
+        help="Experiment results folder.",
+    )
+
+    samples: int = typer.Option(11, help="Samples per query.")
+
+    print_results: bool = typer.Option(False, help="Print the experiment results.")
+
+    db_port: int = typer.Option(6875, help="DB connection port.")
+
+    db_host: str = typer.Option("localhost", help="DB connection host.")
+
+    db_user: str = typer.Option("materialize", help="DB connection user.")
+
+
+@app.command()
+def init(
+    scenario: Scenario = Arg.scenario,
+    db_port: int = Opt.db_port,
+    db_host: str = Opt.db_host,
+    db_user: str = Opt.db_user,
+) -> None:
+    """Initialize the DB under test for the given `scenario`."""
+
+    info(f'Initializing "{scenario}" as the DB under test')
+
+    try:
+        db = sql.Database(port=db_port, host=db_host, user=db_user)
+
+        db.drop_database(scenario)
+        db.create_database(scenario)
+
+        db.set_database(scenario)
+        db.execute_all(statements=sql.parse_from_file(scenario.schema_path()))
+    except Exception as e:
+        err(f"DB initialization failed: {e}")
+        raise typer.Exit()
+
+
+@app.command()
+def run(
+    scenario: Scenario = Arg.scenario,
+    samples: int = Opt.samples,
+    repository: Path = Opt.repository,
+    print_results: bool = Opt.print_results,
+    db_port: int = Opt.db_port,
+    db_host: str = Opt.db_host,
+    db_user: str = Opt.db_user,
+) -> None:
+    """Run benchmark in the DB under test"""
+
+    info(f'Running "{scenario}" scenario')
+
+    try:
+        db = sql.Database(port=db_port, host=db_host, user=db_user)
+        db.set_database(scenario)
+
+        df = pd.DataFrame(
+            data={
+                query.name(): np.array(
+                    [
+                        db.explain(query, timing=True).optimization_time().astype(int)
+                        for _ in range(samples)
+                    ]
+                )
+                for query in [
+                    sql.Query(query)
+                    for query in sql.parse_from_file(scenario.workload_path())
+                ]
+            }
+        )
+
+        if print_results:
+            print(df.to_string())
+
+        results_path = util.results_path(repository, scenario, db.mz_version())
+        info(f'Writing results to "{results_path}"')
+        df.to_csv(results_path, index=False, quoting=csv.QUOTE_MINIMAL)
+    except Exception as e:
+        err(f"run command failed: {e}")
+        raise typer.Exit()
+
+
+@app.command()
+def compare(
+    base: Path = Arg.base,
+    diff: Path = Arg.diff,
+) -> None:
+    """Compare the results of a base and diff benchmark runs."""
+
+    info(f'Compare experiment results between "{base}" and "{diff}"')
+
+    try:
+        base_df = pd.read_csv(base, quoting=csv.QUOTE_MINIMAL).agg(
+            [np.min, np.median, np.max]
+        )
+
+        diff_df = pd.read_csv(diff, quoting=csv.QUOTE_MINIMAL).agg(
+            [np.min, np.median, np.max]
+        )
+
+        # compute diff/base quotient for all (metric, query) pairs
+        quot_df = diff_df / base_df
+        # append average quotient across all queries for each metric
+        quot_df.insert(0, "Avg", quot_df.mean(axis=1))
+
+        # TODO: use styler to color-code the cells
+        print("base times")
+        print("----------")
+        print(base_df.to_string())
+        print("")
+        print("diff times")
+        print("----------")
+        print(diff_df.to_string())
+        print("")
+        print("diff/base ratio")
+        print("---------------")
+        print(quot_df.to_string())
+    except Exception as e:
+        err(f"compare command failed: {e}")
+        raise typer.Exit()
+
+
+# Utility methods
+# ---------------
+
+
+def print_df(df: pd.DataFrame) -> None:
+    with pd.option_context("display.max_rows", None, "display.max_columns", None):
+        print(df)
+
+
+def info(msg: str, fg: str = typer.colors.GREEN) -> None:
+    typer.secho(msg, fg=fg)
+
+
+def err(msg: str, fg: str = typer.colors.RED) -> None:
+    typer.secho(msg, fg=fg, err=True)

--- a/src/transform/benches/mzbench_opt/schema/tpch.sql
+++ b/src/transform/benches/mzbench_opt/schema/tpch.sql
@@ -1,0 +1,127 @@
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Use of this software is governed by the Business Source License
+-- included in the LICENSE file at the root of this repository.
+--
+-- As of the Change Date specified in that file, in accordance with
+-- the Business Source License, use of this software will be governed
+-- by the Apache License, Version 2.0.
+
+-- Table definitions for the schema of the `TPCH` benchmarking scenario.
+
+CREATE TABLE nation (
+    n_nationkey  integer ,
+    n_name       char(25) NOT NULL,
+    n_regionkey  integer NOT NULL,
+    n_comment    varchar(152)
+);
+
+CREATE INDEX fk_nation_regionkey ON nation (n_regionkey ASC);
+
+CREATE TABLE region  (
+    r_regionkey  integer ,
+    r_name       char(25) NOT NULL,
+    r_comment    varchar(152)
+);
+
+CREATE TABLE part (
+    p_partkey     integer ,
+    p_name        varchar(55) NOT NULL,
+    p_mfgr        char(25) NOT NULL,
+    p_brand       char(10) NOT NULL,
+    p_type        varchar(25) NOT NULL,
+    p_size        integer NOT NULL,
+    p_container   char(10) NOT NULL,
+    p_retailprice decimal(15, 2) NOT NULL,
+    p_comment     varchar(23) NOT NULL
+);
+
+CREATE TABLE supplier (
+    s_suppkey     integer ,
+    s_name        char(25) NOT NULL,
+    s_address     varchar(40) NOT NULL,
+    s_nationkey   integer NOT NULL,
+    s_phone       char(15) NOT NULL,
+    s_acctbal     decimal(15, 2) NOT NULL,
+    s_comment     varchar(101) NOT NULL
+);
+
+CREATE INDEX fk_supplier_nationkey ON supplier (s_nationkey ASC);
+
+CREATE TABLE partsupp (
+    ps_partkey     integer NOT NULL,
+    ps_suppkey     integer NOT NULL,
+    ps_availqty    integer NOT NULL,
+    ps_supplycost  decimal(15, 2) NOT NULL,
+    ps_comment     varchar(199) NOT NULL
+);
+
+CREATE INDEX fk_partsupp_partkey ON partsupp (ps_partkey ASC);
+
+CREATE INDEX fk_partsupp_suppkey ON partsupp (ps_suppkey ASC);
+
+CREATE TABLE customer (
+    c_custkey     integer ,
+    c_name        varchar(25) NOT NULL,
+    c_address     varchar(40) NOT NULL,
+    c_nationkey   integer NOT NULL,
+    c_phone       char(15) NOT NULL,
+    c_acctbal     decimal(15, 2) NOT NULL,
+    c_mktsegment  char(10) NOT NULL,
+    c_comment     varchar(117) NOT NULL
+);
+
+CREATE INDEX fk_customer_nationkey ON customer (c_nationkey ASC);
+
+CREATE TABLE orders (
+    o_orderkey       integer ,
+    o_custkey        integer NOT NULL,
+    o_orderstatus    char(1) NOT NULL,
+    o_totalprice     decimal(15, 2) NOT NULL,
+    o_orderdate      DATE NOT NULL,
+    o_orderpriority  char(15) NOT NULL,
+    o_clerk          char(15) NOT NULL,
+    o_shippriority   integer NOT NULL,
+    o_comment        varchar(79) NOT NULL
+);
+
+CREATE INDEX fk_orders_custkey ON orders (o_custkey ASC);
+
+CREATE TABLE lineitem (
+    l_orderkey       integer NOT NULL,
+    l_partkey        integer NOT NULL,
+    l_suppkey        integer NOT NULL,
+    l_linenumber     integer NOT NULL,
+    l_quantity       decimal(15, 2) NOT NULL,
+    l_extendedprice  decimal(15, 2) NOT NULL,
+    l_discount       decimal(15, 2) NOT NULL,
+    l_tax            decimal(15, 2) NOT NULL,
+    l_returnflag     char(1) NOT NULL,
+    l_linestatus     char(1) NOT NULL,
+    l_shipdate       date NOT NULL,
+    l_commitdate     date NOT NULL,
+    l_receiptdate    date NOT NULL,
+    l_shipinstruct   char(25) NOT NULL,
+    l_shipmode       char(10) NOT NULL,
+    l_comment        varchar(44) NOT NULL
+);
+
+CREATE INDEX fk_lineitem_orderkey ON lineitem (l_orderkey ASC);
+
+CREATE INDEX fk_lineitem_partkey ON lineitem (l_partkey ASC);
+
+CREATE INDEX fk_lineitem_suppkey ON lineitem (l_suppkey ASC);
+
+CREATE INDEX fk_lineitem_partsuppkey ON lineitem (l_partkey ASC, l_suppkey ASC);
+
+CREATE VIEW revenue (supplier_no, total_revenue) AS
+SELECT
+    l_suppkey,
+    sum(l_extendedprice * (1 - l_discount))
+FROM
+    lineitem
+WHERE
+    l_shipdate >= DATE '1996-01-01'
+    AND l_shipdate < DATE '1996-01-01' + INTERVAL '3' month
+GROUP BY
+    l_suppkey;

--- a/src/transform/benches/mzbench_opt/sql.py
+++ b/src/transform/benches/mzbench_opt/sql.py
@@ -1,0 +1,129 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+import logging
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import psycopg2
+import psycopg2.extensions
+import sqlparse
+from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
+
+from . import Scenario, util
+
+
+class Query:
+    """An API for manipulating workload queries."""
+
+    def __init__(self, query) -> None:
+        self.query = query
+
+    def __str__(self) -> str:
+        return self.query
+
+    def name(self) -> str:
+        """Extracts and returns the name of this query from a '-- name: {name}' comment.
+        Returns 'anonymous' if the name is not set."""
+        p = r"-- name\: (?P<name>.+)"
+        m = re.search(p, self.query, re.MULTILINE)
+        return m.group("name") if m else "anonoymous"
+
+    def explain(self, timing: bool) -> str:
+        """Prepends 'EXPLAIN (TIMING {timing}) PLAN FOR' to the query."""
+        return "\n".join([f"EXPLAIN (TIMING {bool(timing)}) PLAN FOR", self.query])
+
+
+class ExplainOutput:
+    """An API for manipulating 'EXPLAIN ... PLAN FOR' results."""
+
+    def __init__(self, output) -> None:
+        self.output = output
+
+    def __str__(self) -> str:
+        return self.output
+
+    def decorrelation_time(self) -> Optional[int]:
+        """Optionally, returns the decorrelation_time for an 'EXPLAIN (TIMING true)' output."""
+        p = r"Decorrelation time\: (?P<time>[0-9]{2}\:[0-9]{2}\:[0-9]{2}\.[0-9]+)"
+        m = re.search(p, self.output, re.MULTILINE)
+        return util.str_to_ns(m.group("time")) if m else None
+
+    def optimization_time(self) -> Optional[int]:
+        """Optionally, returns the optimization_time time for an 'EXPLAIN (TIMING true)' output."""
+        p = r"Optimization time\: (?P<time>[0-9]{2}\:[0-9]{2}\:[0-9]{2}\.[0-9]+)"
+        m = re.search(p, self.output, re.MULTILINE)
+        return util.str_to_ns(m.group("time")) if m else None
+
+
+class Database:
+    """An API to the database under test."""
+
+    def __init__(
+        self,
+        port: int,
+        host: str,
+        user: str,
+    ) -> None:
+        kwargs = dict(
+            host=host,
+            port=port,
+            user=user,
+        )
+        logging.debug(f"Initialize Database with connection={kwargs}")
+        self.conn = psycopg2.connect(**kwargs)
+        self.conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+
+    def mz_version(self) -> str:
+        result = self.query_one("SELECT mz_version()")
+        return result[0]
+
+    def drop_database(self, scenario: Scenario) -> None:
+        logging.debug(f'Drop database "{scenario}"')
+        self.execute(f"DROP DATABASE IF EXISTS {scenario}")
+
+    def create_database(self, scenario: Scenario) -> None:
+        logging.debug(f'Create database "{scenario}"')
+        self.execute(f"CREATE DATABASE {scenario}")
+
+    def set_database(self, scenario: Scenario) -> None:
+        logging.debug(f'Set default database to "{scenario}"')
+        self.execute(f"SET DATABASE = {scenario}")
+
+    def explain(self, query: Query, timing: bool) -> "ExplainOutput":
+        result = self.query_one(query.explain(timing))
+        return ExplainOutput(result[0])
+
+    def execute(self, statement: str) -> None:
+        cursor = self.conn.cursor()
+        cursor.execute(statement)
+
+    def execute_all(self, statements: List[str]) -> None:
+        for statement in statements:
+            self.execute(statement)
+
+    def query_one(self, query: str) -> Dict[Any, Any]:
+        cursor = self.conn.cursor()
+        cursor.execute(query)
+        return cursor.fetchone()
+
+    def query_all(self, query: str) -> Dict[Any, Any]:
+        cursor = self.conn.cursor()
+        cursor.execute(query)
+        return cursor.fetchall()
+
+
+# Utility functions
+# -----------------
+
+
+def parse_from_file(path: Path) -> List[Query]:
+    """Parses a *.sql file to a list of queries."""
+    return sqlparse.split(path.read_text())

--- a/src/transform/benches/mzbench_opt/util.py
+++ b/src/transform/benches/mzbench_opt/util.py
@@ -1,0 +1,33 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from pathlib import Path
+
+import numpy as np
+
+from . import Scenario
+
+
+def str_to_ns(time: str) -> np.timedelta64:
+    """Parses a time format `hh:mm:ss.up_to_9_digits` to a `np.timedelta64`."""
+    h, m, s = time.split(":")
+    s, ns = s.split(".")
+    ns = ns.ljust(9, "0")
+    ns = map(
+        lambda t, unit: np.timedelta64(t, unit), [h, m, s, ns], ["h", "m", "s", "ns"]
+    )
+    return sum(ns)
+
+
+def results_path(repository: Path, scenario: Scenario, mz_version: str) -> None:
+    mz_version = mz_version.replace(" ", "-")
+    mz_version = mz_version.replace("(", "")
+    mz_version = mz_version.replace(")", "")
+    file = f"mzbench-opt-{scenario}-{mz_version}.csv"
+    return repository / file

--- a/src/transform/benches/mzbench_opt/workload/tpch.sql
+++ b/src/transform/benches/mzbench_opt/workload/tpch.sql
@@ -1,0 +1,671 @@
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Use of this software is governed by the Business Source License
+-- included in the LICENSE file at the root of this repository.
+--
+-- As of the Change Date specified in that file, in accordance with
+-- the Business Source License, use of this software will be governed
+-- by the Apache License, Version 2.0.
+
+-- Queries for to workload of the `TPCH` benchmarking scenario.
+
+-- name: Q01
+SELECT
+	l_returnflag,
+	l_linestatus,
+	sum(l_quantity) AS sum_qty,
+	sum(l_extendedprice) AS sum_base_price,
+	sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
+	sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
+	avg(l_quantity) AS avg_qty,
+	avg(l_extendedprice) AS avg_price,
+	avg(l_discount) AS avg_disc,
+	count(*) AS count_order
+FROM
+	lineitem
+WHERE
+	l_shipdate <= DATE '1998-12-01' -- - INTERVAL '60' day (fails with an error)
+GROUP BY
+	l_returnflag,
+	l_linestatus
+ORDER BY
+	l_returnflag,
+	l_linestatus;
+
+
+-- name: Q02
+SELECT
+    s_acctbal,
+    s_name,
+    n_name,
+    p_partkey,
+    p_mfgr,
+    s_address,
+    s_phone,
+    s_comment
+FROM
+    part, supplier, partsupp, nation, region
+WHERE
+    p_partkey = ps_partkey
+    AND s_suppkey = ps_suppkey
+    AND p_size = CAST (15 AS smallint)
+    AND p_type LIKE '%BRASS'
+    AND s_nationkey = n_nationkey
+    AND n_regionkey = r_regionkey
+    AND r_name = 'EUROPE'
+    AND ps_supplycost
+        = (
+                SELECT
+                    min(ps_supplycost)
+                FROM
+                    partsupp, supplier, nation, region
+                WHERE
+                    p_partkey = ps_partkey
+                    AND s_suppkey = ps_suppkey
+                    AND s_nationkey = n_nationkey
+                    AND n_regionkey = r_regionkey
+                    AND r_name = 'EUROPE'
+            )
+ORDER BY
+    s_acctbal DESC, n_name, s_name, p_partkey;
+
+-- name: Q03
+SELECT
+    l_orderkey,
+    sum(l_extendedprice * (1 - l_discount)) AS revenue,
+    o_orderdate,
+    o_shippriority
+FROM
+    customer,
+    orders,
+    lineitem
+WHERE
+    c_mktsegment = 'BUILDING'
+    AND c_custkey = o_custkey
+    AND l_orderkey = o_orderkey
+    AND o_orderdate < DATE '1995-03-15'
+    AND l_shipdate > DATE '1995-03-15'
+GROUP BY
+    l_orderkey,
+    o_orderdate,
+    o_shippriority
+ORDER BY
+    revenue DESC,
+    o_orderdate;
+
+-- name: Q04
+SELECT
+    o_orderpriority,
+    count(*) AS order_count
+FROM
+    orders
+WHERE
+    o_orderdate >= DATE '1993-07-01'
+    AND o_orderdate < DATE '1993-07-01' + INTERVAL '3' month
+    AND EXISTS (
+        SELECT
+            *
+        FROM
+            lineitem
+        WHERE
+            l_orderkey = o_orderkey
+            AND l_commitdate < l_receiptdate
+    )
+GROUP BY
+    o_orderpriority
+ORDER BY
+    o_orderpriority;
+
+
+-- name: Q05
+SELECT
+    n_name,
+    sum(l_extendedprice * (1 - l_discount)) AS revenue
+FROM
+    customer,
+    orders,
+    lineitem,
+    supplier,
+    nation,
+    region
+WHERE
+    c_custkey = o_custkey
+    AND l_orderkey = o_orderkey
+    AND l_suppkey = s_suppkey
+    AND c_nationkey = s_nationkey
+    AND s_nationkey = n_nationkey
+    AND n_regionkey = r_regionkey
+    AND r_name = 'ASIA'
+    AND o_orderdate >= DATE '1994-01-01'
+    AND o_orderdate < DATE '1995-01-01'
+GROUP BY
+    n_name
+ORDER BY
+    revenue DESC;
+
+-- name: Q06
+SELECT
+    sum(l_extendedprice * l_discount) AS revenue
+FROM
+    lineitem
+WHERE
+    l_quantity < 24
+    AND l_shipdate >= DATE '1994-01-01'
+    AND l_shipdate < DATE '1994-01-01' + INTERVAL '1' year
+    AND l_discount BETWEEN 0.06 - 0.01 AND 0.07;
+
+-- name: Q07
+SELECT
+    supp_nation,
+    cust_nation,
+    l_year,
+    sum(volume) AS revenue
+FROM
+    (
+        SELECT
+            n1.n_name AS supp_nation,
+            n2.n_name AS cust_nation,
+            extract(year FROM l_shipdate) AS l_year,
+            l_extendedprice * (1 - l_discount) AS volume
+        FROM
+            supplier,
+            lineitem,
+            orders,
+            customer,
+            nation n1,
+            nation n2
+        WHERE
+            s_suppkey = l_suppkey
+            AND o_orderkey = l_orderkey
+            AND c_custkey = o_custkey
+            AND s_nationkey = n1.n_nationkey
+            AND c_nationkey = n2.n_nationkey
+            AND (
+                (n1.n_name = 'FRANCE' AND n2.n_name = 'GERMANY')
+                or (n1.n_name = 'GERMANY' AND n2.n_name = 'FRANCE')
+            )
+            AND l_shipdate BETWEEN DATE '1995-01-01' AND DATE '1996-12-31'
+    ) AS shipping
+GROUP BY
+    supp_nation,
+    cust_nation,
+    l_year
+ORDER BY
+    supp_nation,
+    cust_nation,
+    l_year;
+
+-- name: Q08
+SELECT
+    o_year,
+    sum(case
+        when nation = 'BRAZIL' then volume
+        else 0
+    end) / sum(volume) AS mkt_share
+FROM
+    (
+        SELECT
+            extract(year FROM o_orderdate) AS o_year,
+            l_extendedprice * (1 - l_discount) AS volume,
+            n2.n_name AS nation
+        FROM
+            part,
+            supplier,
+            lineitem,
+            orders,
+            customer,
+            nation n1,
+            nation n2,
+            region
+        WHERE
+            p_partkey = l_partkey
+            AND s_suppkey = l_suppkey
+            AND l_orderkey = o_orderkey
+            AND o_custkey = c_custkey
+            AND c_nationkey = n1.n_nationkey
+            AND n1.n_regionkey = r_regionkey
+            AND r_name = 'AMERICA'
+            AND s_nationkey = n2.n_nationkey
+            AND o_orderdate BETWEEN DATE '1995-01-01' AND DATE '1996-12-31'
+            AND p_type = 'ECONOMY ANODIZED STEEL'
+    ) AS all_nations
+GROUP BY
+    o_year
+ORDER BY
+    o_year;
+
+-- name: Q09
+SELECT
+    nation,
+    o_year,
+    sum(amount) AS sum_profit
+FROM
+    (
+        SELECT
+            n_name AS nation,
+            extract(year FROM o_orderdate) AS o_year,
+            l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity AS amount
+        FROM
+            part,
+            supplier,
+            lineitem,
+            partsupp,
+            orders,
+            nation
+        WHERE
+            s_suppkey = l_suppkey
+            AND ps_suppkey = l_suppkey
+            AND ps_partkey = l_partkey
+            AND p_partkey = l_partkey
+            AND o_orderkey = l_orderkey
+            AND s_nationkey = n_nationkey
+            AND p_name like '%green%'
+    ) AS profit
+GROUP BY
+    nation,
+    o_year
+ORDER BY
+    nation,
+    o_year DESC;
+
+-- name: Q10
+SELECT
+    c_custkey,
+    c_name,
+    sum(l_extendedprice * (1 - l_discount)) AS revenue,
+    c_acctbal,
+    n_name,
+    c_address,
+    c_phone,
+    c_comment
+FROM
+    customer,
+    orders,
+    lineitem,
+    nation
+WHERE
+    c_custkey = o_custkey
+    AND l_orderkey = o_orderkey
+    AND o_orderdate >= DATE '1993-10-01'
+    AND o_orderdate < DATE '1994-01-01'
+    AND o_orderdate < DATE '1993-10-01' + INTERVAL '3' month
+    AND l_returnflag = 'R'
+    AND c_nationkey = n_nationkey
+GROUP BY
+    c_custkey,
+    c_name,
+    c_acctbal,
+    c_phone,
+    n_name,
+    c_address,
+    c_comment
+ORDER BY
+    revenue DESC;
+
+-- name: Q11
+SELECT
+    ps_partkey,
+    sum(ps_supplycost * ps_availqty) AS value
+FROM
+    partsupp,
+    supplier,
+    nation
+WHERE
+    ps_suppkey = s_suppkey
+    AND s_nationkey = n_nationkey
+    AND n_name = 'GERMANY'
+GROUP BY
+    ps_partkey having
+        sum(ps_supplycost * ps_availqty) > (
+            SELECT
+                sum(ps_supplycost * ps_availqty) * 0.0001
+            FROM
+                partsupp,
+                supplier,
+                nation
+            WHERE
+                ps_suppkey = s_suppkey
+                AND s_nationkey = n_nationkey
+                AND n_name = 'GERMANY'
+        )
+ORDER BY
+    value DESC;
+
+-- name: Q12
+SELECT
+    l_shipmode,
+    sum(case
+        when o_orderpriority = '1-URGENT'
+            or o_orderpriority = '2-HIGH'
+            then 1
+        else 0
+    end) AS high_line_count,
+    sum(case
+        when o_orderpriority <> '1-URGENT'
+            AND o_orderpriority <> '2-HIGH'
+            then 1
+        else 0
+    end) AS low_line_count
+FROM
+    orders,
+    lineitem
+WHERE
+    o_orderkey = l_orderkey
+    AND l_shipmode IN ('MAIL', 'SHIP')
+    AND l_commitdate < l_receiptdate
+    AND l_shipdate < l_commitdate
+    AND l_receiptdate >= DATE '1994-01-01'
+    AND l_receiptdate < DATE '1994-01-01' + INTERVAL '1' year
+GROUP BY
+    l_shipmode
+ORDER BY
+    l_shipmode;
+
+-- name: Q13
+SELECT
+    c_count,
+    count(*) AS custdist
+FROM
+    (
+        SELECT
+            c_custkey,
+            count(o_orderkey) c_count -- workaround for no column aliases
+        FROM
+            customer LEFT OUTER JOIN orders ON
+                c_custkey = o_custkey
+                AND o_comment NOT LIKE '%special%requests%'
+        GROUP BY
+            c_custkey
+    ) AS c_orders -- (c_custkey, c_count) -- no column aliases yet
+GROUP BY
+    c_count
+ORDER BY
+    custdist DESC,
+    c_count DESC;
+
+-- name: Q14
+SELECT
+    100.00 * sum(case
+        when p_type like 'PROMO%'
+            then l_extendedprice * (1 - l_discount)
+        else 0
+    end) / sum(l_extendedprice * (1 - l_discount)) AS promo_revenue
+FROM
+    lineitem,
+    part
+WHERE
+    l_partkey = p_partkey
+    AND l_shipdate >= DATE '1995-09-01'
+    AND l_shipdate < DATE '1995-09-01' + INTERVAL '1' month;
+
+-- name: Q15
+SELECT
+    s_suppkey,
+    s_name,
+    s_address,
+    s_phone,
+    total_revenue
+FROM
+    supplier,
+    revenue
+WHERE
+    s_suppkey = supplier_no
+    AND total_revenue = (
+        SELECT
+            max(total_revenue)
+        FROM
+            revenue
+    )
+ORDER BY
+    s_suppkey;
+
+-- name: Q16
+SELECT
+    p_brand,
+    p_type,
+    p_size,
+    count(DISTINCT ps_suppkey) AS supplier_cnt
+FROM
+    partsupp,
+    part
+WHERE
+    p_partkey = ps_partkey
+    AND p_brand <> 'Brand#45'
+    AND p_type NOT LIKE 'MEDIUM POLISHED%'
+    AND p_size IN (49, 14, 23, 45, 19, 3, 36, 9)
+    AND ps_suppkey NOT IN (
+        SELECT
+            s_suppkey
+        FROM
+            supplier
+        WHERE
+            s_comment like '%Customer%Complaints%'
+    )
+GROUP BY
+    p_brand,
+    p_type,
+    p_size
+ORDER BY
+    supplier_cnt DESC,
+    p_brand,
+    p_type,
+    p_size;
+
+-- name: Q17
+SELECT
+  sum(l_extendedprice) / 7.0 AS avg_yearly
+FROM
+  lineitem,
+  part
+WHERE
+  p_partkey = l_partkey
+  AND p_brand = 'Brand#23'
+  AND p_container = 'MED BOX'
+  AND l_quantity < (
+    SELECT
+      0.2 * avg(l_quantity)
+    FROM
+      lineitem
+    WHERE
+      l_partkey = p_partkey
+  );
+
+-- name: Q18
+SELECT
+    c_name,
+    c_custkey,
+    o_orderkey,
+    o_orderdate,
+    o_totalprice,
+    sum(l_quantity)
+FROM
+    customer,
+    orders,
+    lineitem
+WHERE
+    o_orderkey IN (
+        SELECT
+            l_orderkey
+        FROM
+            lineitem
+        GROUP BY
+            l_orderkey having
+                sum(l_quantity) > 300
+    )
+    AND c_custkey = o_custkey
+    AND o_orderkey = l_orderkey
+GROUP BY
+    c_name,
+    c_custkey,
+    o_orderkey,
+    o_orderdate,
+    o_totalprice
+ORDER BY
+    o_totalprice DESC,
+    o_orderdate;
+
+-- name: Q19
+SELECT
+    sum(l_extendedprice* (1 - l_discount)) AS revenue
+FROM
+    lineitem,
+    part
+WHERE
+    (
+        p_partkey = l_partkey
+        AND p_brand = 'Brand#12'
+        AND p_container IN ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG')
+        AND l_quantity >= CAST (1 AS smallint) AND l_quantity <= CAST (1 + 10 AS smallint)
+        AND p_size BETWEEN CAST (1 AS smallint) AND CAST (5 AS smallint)
+        AND l_shipmode IN ('AIR', 'AIR REG')
+        AND l_shipinstruct = 'DELIVER IN PERSON'
+    )
+    or
+    (
+        p_partkey = l_partkey
+        AND p_brand = 'Brand#23'
+        AND p_container IN ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')
+        AND l_quantity >= CAST (10 AS smallint) AND l_quantity <= CAST (10 + 10 AS smallint)
+        AND p_size BETWEEN CAST (1 AS smallint) AND CAST (10 AS smallint)
+        AND l_shipmode IN ('AIR', 'AIR REG')
+        AND l_shipinstruct = 'DELIVER IN PERSON'
+    )
+    or
+    (
+        p_partkey = l_partkey
+        AND p_brand = 'Brand#34'
+        AND p_container IN ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG')
+        AND l_quantity >= CAST (20 AS smallint) AND l_quantity <= CAST (20 + 10 AS smallint)
+        AND p_size BETWEEN CAST (1 AS smallint) AND CAST (15 AS smallint)
+        AND l_shipmode IN ('AIR', 'AIR REG')
+        AND l_shipinstruct = 'DELIVER IN PERSON'
+    );
+
+-- name: Q20
+SELECT
+    s_name,
+    s_address
+FROM
+    supplier,
+    nation
+WHERE
+    s_suppkey IN (
+        SELECT
+            ps_suppkey
+        FROM
+            partsupp
+        WHERE
+            ps_partkey IN (
+                SELECT
+                    p_partkey
+                FROM
+                    part
+                WHERE
+                    p_name like 'forest%'
+            )
+            AND ps_availqty > (
+                SELECT
+                    0.5 * sum(l_quantity)
+                FROM
+                    lineitem
+                WHERE
+                    l_partkey = ps_partkey
+                    AND l_suppkey = ps_suppkey
+                    AND l_shipdate >= DATE '1995-01-01'
+                    AND l_shipdate < DATE '1995-01-01' + INTERVAL '1' year
+            )
+    )
+    AND s_nationkey = n_nationkey
+    AND n_name = 'CANADA'
+ORDER BY
+    s_name;
+
+-- name: Q21
+SELECT
+    s_name,
+    count(*) AS numwait
+FROM
+    supplier,
+    lineitem l1,
+    orders,
+    nation
+WHERE
+    s_suppkey = l1.l_suppkey
+    AND o_orderkey = l1.l_orderkey
+    AND o_orderstatus = 'F'
+    AND l1.l_receiptdate > l1.l_commitdate
+    AND EXISTS (
+        SELECT
+            *
+        FROM
+            lineitem l2
+        WHERE
+            l2.l_orderkey = l1.l_orderkey
+            AND l2.l_suppkey <> l1.l_suppkey
+    )
+    AND not EXISTS (
+        SELECT
+            *
+        FROM
+            lineitem l3
+        WHERE
+            l3.l_orderkey = l1.l_orderkey
+            AND l3.l_suppkey <> l1.l_suppkey
+            AND l3.l_receiptdate > l3.l_commitdate
+    )
+    AND s_nationkey = n_nationkey
+    AND n_name = 'SAUDI ARABIA'
+GROUP BY
+    s_name
+ORDER BY
+    numwait DESC,
+    s_name;
+
+-- name: Q22
+SELECT
+    cntrycode,
+    count(*) AS numcust,
+    sum(c_acctbal) AS totacctbal
+FROM
+    (
+        SELECT
+            substring(c_phone, 1, 2) AS cntrycode, c_acctbal
+        FROM
+            customer
+        WHERE
+            substring(c_phone, 1, 2)
+            IN ('13', '31', '23', '29', '30', '18', '17')
+            AND c_acctbal
+                > (
+                        SELECT
+                            avg(c_acctbal)
+                        FROM
+                            customer
+                        WHERE
+                            c_acctbal > 0.00
+                            AND substring(c_phone, 1, 2)
+                                IN (
+                                        '13',
+                                        '31',
+                                        '23',
+                                        '29',
+                                        '30',
+                                        '18',
+                                        '17'
+                                    )
+                    )
+            AND NOT
+                    EXISTS(
+                        SELECT
+                            *
+                        FROM
+                            orders
+                        WHERE
+                            o_custkey = c_custkey
+                    )
+    )
+        AS custsale
+GROUP BY
+    cntrycode
+ORDER BY
+    cntrycode;

--- a/src/transform/benches/setup.py
+++ b/src/transform/benches/setup.py
@@ -1,0 +1,32 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from setuptools import find_packages, setup
+
+setup(
+    name="mzbench-opt",
+    version="0.0.1",
+    description="Materialize scripts for benchmarking the transform crate",
+    packages=["mzbench_opt"],
+    package_data={
+        "mzbench_opt": ["schema/*.sql", "workload/*.sql"],
+    },
+    install_requires=[
+        "numpy==1.21.4",
+        "psycopg2==2.9.1",
+        "pandas==1.3.4",
+        "typer==0.4.0",
+        "sqlparse==0.4.2",
+    ],
+    entry_points={
+        "console_scripts": [
+            "mzbench-opt=mzbench_opt.cli:app",
+        ],
+    },
+)


### PR DESCRIPTION
Add a benchmark for tracking regressions in optimization performance. Check [`src/transform/benches/README.md`](https://github.com/aalexandrov/materialize/blob/opt-benchmark/src/transform/benches/README.md) for details.

### Motivation

* This PR adds a feature that has not yet been specified.
 
I wanted to automate the workflow that @asenac was using to catch optimizer regressions.
In a follow-up task we can create buildkite scripts to do this for us as part of the PR process.


### Tips for reviewer

- The diff adds a python package under `src/transform/benches`.
- The entry-point of the package is `src/transform/benches/mzbench_opt/cli.py`.
- Instructions how to run the package can be found in [`src/transform/benches/README.md`](https://github.com/aalexandrov/materialize/blob/opt-benchmark/src/transform/benches/README.md).

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
