### PR TITLE
coord,persist: teach coord about persisted streams that are involved in sources

### DIFF
--- a/src/coord/src/catalog/builtin_table_updates.rs
+++ b/src/coord/src/catalog/builtin_table_updates.rs
@@ -24,8 +24,8 @@ use crate::catalog::builtin::{
     MZ_ROLES, MZ_SCHEMAS, MZ_SINKS, MZ_SOURCES, MZ_TABLES, MZ_TYPES, MZ_VIEWS,
 };
 use crate::catalog::{
-    CatalogItem, CatalogState, Func, Index, Sink, SinkConnector, SinkConnectorState, Source,
-    SourceDetails, Table, Type, TypeInner, SYSTEM_CONN_ID,
+    CatalogItem, CatalogState, Func, Index, Sink, SinkConnector, SinkConnectorState, Source, Table,
+    Type, TypeInner, SYSTEM_CONN_ID,
 };
 
 /// An update to a built-in table.
@@ -183,12 +183,10 @@ impl CatalogState {
         source: &Source,
         diff: Diff,
     ) -> Vec<BuiltinTableUpdate> {
-        let persist_name = match &source.details {
-            SourceDetails::NonpersistedSource(_) => None,
-            SourceDetails::PersistedSource(_connector, persist_details) => {
-                Some(persist_details.primary_stream.as_str())
-            }
-        };
+        let persist_name = source
+            .persist
+            .as_ref()
+            .map(|persist| persist.primary_stream.as_str());
         let persisted_name_datum = Datum::from(persist_name);
         vec![BuiltinTableUpdate {
             id: MZ_SOURCES.id,
@@ -197,7 +195,7 @@ impl CatalogState {
                 Datum::Int32(oid as i32),
                 Datum::Int64(schema_id),
                 Datum::String(name),
-                Datum::String(source.connector().name()),
+                Datum::String(source.connector.name()),
                 Datum::String(self.is_volatile(id).as_str()),
                 persisted_name_datum,
             ]),

--- a/src/coord/src/catalog/migrate.rs
+++ b/src/coord/src/catalog/migrate.rs
@@ -48,6 +48,7 @@ where
             create_sql,
             eval_env,
             persist_name,
+            persist_details,
         } = serde_json::from_slice(&def)?;
         let mut stmt = sql::parse::parse(&create_sql)?.into_element();
 
@@ -57,6 +58,7 @@ where
             create_sql: stmt.to_ast_string_stable(),
             eval_env,
             persist_name,
+            persist_details,
         };
 
         let serialized_item =

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -150,8 +150,7 @@ use self::arrangement_state::{ArrangementFrontiers, Frontiers, SinkWrites};
 use self::prometheus::Scraper;
 use crate::catalog::builtin::{BUILTINS, MZ_VIEW_FOREIGN_KEYS, MZ_VIEW_KEYS};
 use crate::catalog::{
-    self, BuiltinTableUpdate, Catalog, CatalogItem, CatalogState, SinkConnectorState,
-    SourceDetails, Table,
+    self, BuiltinTableUpdate, Catalog, CatalogItem, CatalogState, SinkConnectorState, Table,
 };
 use crate::client::{Client, Handle};
 use crate::command::{
@@ -2220,19 +2219,13 @@ where
                 .source_persist_details(source_id, &source.connector, &name)
                 .map_err(|err| anyhow!("{}", err))?;
 
-            let details = match persist_details {
-                Some(persist_details) => {
-                    SourceDetails::PersistedSource(source.connector, persist_details)
-                }
-                None => SourceDetails::NonpersistedSource(source.connector),
-            };
-
             let source = catalog::Source {
                 create_sql: source.create_sql,
                 optimized_expr,
-                details,
                 bare_desc: source.bare_desc,
                 desc: transformed_desc,
+                connector: source.connector,
+                persist: persist_details,
             };
             ops.push(catalog::Op::CreateItem {
                 id: source_id,
@@ -3863,7 +3856,7 @@ where
                                     ..
                                 }),
                             ..
-                        } = source.connector()
+                        } = &source.connector
                         {
                             replication_slots_to_drop
                                 .entry(conn.clone())
@@ -4238,9 +4231,9 @@ where
             if let Some(entry) = self.catalog.try_get_by_id(source_id) {
                 if let CatalogItem::Source(s) = entry.item() {
                     self.ts_tx
-                        .send(TimestampMessage::Add(source_id, s.connector().clone()))
+                        .send(TimestampMessage::Add(source_id, s.connector.clone()))
                         .expect("Failed to send CREATE Instance notice to timestamper");
-                    let connector = s.connector().clone();
+                    let connector = s.connector.clone();
                     self.broadcast(dataflow_types::client::Command::AddSourceTimestamping {
                         id: source_id,
                         connector,
@@ -4289,7 +4282,7 @@ where
             let entry = self.catalog.get_by_id(&id);
             match entry.item() {
                 CatalogItem::Source(source) => {
-                    timelines.insert(id, source.connector().timeline());
+                    timelines.insert(id, source.connector.timeline());
                 }
                 CatalogItem::Index(index) => {
                     ids.push(index.on);

--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -112,21 +112,28 @@ impl<'a> DataflowBuilder<'a> {
                                 },
                                 operators: None,
                                 bare_desc: table.desc.clone(),
-                                persisted_name: None,
+                                persist_desc: None,
                             },
                             *id,
                         );
                     }
                     CatalogItem::Source(source) => {
+                        let persist_desc = match &source.details {
+                            SourceDetails::NonpersistedSource(_connector) => None,
+                            SourceDetails::PersistedSource(_connector, persist_details) => {
+                                Some(persist_details.clone().into())
+                            }
+                        };
+
                         if source.optimized_expr.0.is_trivial_source() {
                             dataflow.import_source(
                                 *id,
                                 dataflow_types::SourceDesc {
                                     name: entry.name().to_string(),
-                                    connector: source.connector.clone(),
+                                    connector: source.connector().clone(),
                                     operators: None,
                                     bare_desc: source.bare_desc.clone(),
-                                    persisted_name: source.persist_name.clone(),
+                                    persist_desc,
                                 },
                                 *id,
                             );
@@ -138,10 +145,10 @@ impl<'a> DataflowBuilder<'a> {
                                 bare_source_id,
                                 dataflow_types::SourceDesc {
                                     name: entry.name().to_string(),
-                                    connector: source.connector.clone(),
+                                    connector: source.connector().clone(),
                                     operators: None,
                                     bare_desc: source.bare_desc.clone(),
-                                    persisted_name: source.persist_name.clone(),
+                                    persist_desc,
                                 },
                                 *id,
                             );

--- a/src/coord/src/timestamp.rs
+++ b/src/coord/src/timestamp.rs
@@ -563,6 +563,7 @@ impl Timestamper {
                         consistency,
                         ts_frequency: _,
                         timeline: _,
+                        persist: _,
                     } = sc
                     {
                         (connector, encoding, envelope, consistency)

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -508,7 +508,32 @@ pub struct SourceDesc {
     /// to the output of the source.
     pub operators: Option<LinearOperator>,
     pub bare_desc: RelationDesc,
-    pub persisted_name: Option<String>,
+    pub persist_desc: Option<SourcePersistDesc>,
+}
+
+/// The persistence details that are needed to render a persistent Source.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SourcePersistDesc {
+    /// Name of the primary persisted stream of this source. This is what a consumer of the
+    /// persisted data would be interested in while the secondary stream(s) of the source are an
+    /// internal implementation detail.
+    pub primary_stream: String,
+
+    /// Persisted stream of timestamp bindings.
+    pub timestamp_bindings_stream: String,
+
+    /// Any additional details that we need to make the envelope logic stateful.
+    pub envelope_desc: EnvelopePersistDesc,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum EnvelopePersistDesc {
+    // TODO: We only have support for UPSERT right now, which doesn't need any state besides the
+    // primary stream (which doubles as the upsert state) and the timestamp bindings.
+    //
+    // I put this here as a placeholder and we can expand in the future, when we will also have
+    // `Debezium` and know what it needs as additional state.
+    Upsert,
 }
 
 /// A sink for updates to a relational collection.

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -11,6 +11,7 @@
 
 use std::collections::HashMap;
 use std::rc::Rc;
+use std::time::Duration;
 
 use differential_dataflow::hashable::Hashable;
 use differential_dataflow::lattice::Lattice;
@@ -79,18 +80,6 @@ where
         now: NowFn,
         base_metrics: &SourceBaseMetrics,
     ) {
-        // Extract the linear operators, as we will need to manipulate them.
-        // extracting them reduces the change we might accidentally communicate
-        // them through `src`.
-        let mut linear_operators = src.operators.take();
-
-        // Blank out trivial linear operators.
-        if let Some(operator) = &linear_operators {
-            if operator.is_trivial(src.bare_desc.arity()) {
-                linear_operators = None;
-            }
-        }
-
         // Before proceeding, we may need to remediate sources with non-trivial relational
         // expressions that post-process the bare source. If the expression is trivial, a
         // get of the bare source, we can present `src.operators` to the source directly.
@@ -102,66 +91,7 @@ where
             // Create a new local input (exposed as TABLEs to users). Data is inserted
             // via Command::Insert commands.
             SourceConnector::Local { persisted_name, .. } => {
-                let ((handle, capability), ok_stream, err_collection) = {
-                    let ((handle, capability), ok_stream) = scope.new_unordered_input();
-                    let err_collection = Collection::empty(scope);
-                    ((handle, capability), ok_stream, err_collection)
-                };
-
-                // A local "source" is either fed by a local input handle, or by reading from a
-                // `persisted_source()`.
-                //
-                // For non-persisted sources, values that are to be inserted are sent from the
-                // coordinator and pushed into the handle.
-                //
-                // For persisted sources, the coordinator only writes new values to a persistent
-                // stream. These values will then "show up" here because we read from the same
-                // persistent stream.
-                let (ok_stream, err_collection) = match (&mut render_state.persist, persisted_name)
-                {
-                    (Some(persist), Some(stream_name)) => {
-                        let (_write, read) = persist.create_or_load(&stream_name);
-                        let (persist_ok_stream, persist_err_stream) =
-                            scope.persisted_source(read).ok_err(|x| match x {
-                                (Ok(kv), ts, diff) => Ok((kv, ts, diff)),
-                                (Err(err), ts, diff) => Err((err, ts, diff)),
-                            });
-                        let (persist_ok_stream, decode_err_stream) =
-                            persist_ok_stream.ok_err(|((row, ()), ts, diff)| Ok((row, ts, diff)));
-                        let persist_err_collection = persist_err_stream
-                            .concat(&decode_err_stream)
-                            .map(move |(err, ts, diff)| {
-                                let err = SourceError::new(
-                                    stream_name.clone(),
-                                    SourceErrorDetails::Persistence(err),
-                                );
-                                (err.into(), ts, diff)
-                            })
-                            .as_collection();
-                        (
-                            ok_stream.concat(&persist_ok_stream),
-                            err_collection.concat(&persist_err_collection),
-                        )
-                    }
-                    _ => (ok_stream, err_collection),
-                };
-
-                render_state
-                    .local_inputs
-                    .insert(src_id, LocalInput { handle, capability });
-                let as_of_frontier = self.as_of_frontier.clone();
-                let ok_collection = ok_stream
-                    .map_in_place(move |(_, mut time, _)| {
-                        time.advance_by(as_of_frontier.borrow());
-                    })
-                    .as_collection();
-                self.insert_id(
-                    Id::Global(src_id),
-                    crate::render::CollectionBundle::from_collections(
-                        ok_collection,
-                        err_collection,
-                    ),
-                );
+                self.render_local_source(render_state, scope, src_id, persisted_name);
             }
 
             SourceConnector::External {
@@ -172,347 +102,463 @@ where
                 ts_frequency,
                 timeline: _,
             } => {
-                // TODO(benesch): this match arm is hard to follow. Refactor.
+                // Extract the linear operators, as we will need to manipulate them.
+                // extracting them reduces the change we might accidentally communicate
+                // them through `src`.
+                let linear_operators = src.operators.take();
 
-                // This uid must be unique across all different instantiations of a source
-                let uid = SourceInstanceId {
-                    source_id: orig_id,
-                    dataflow_id: self.dataflow_id,
-                };
-
-                // All sources should push their various error streams into this vector,
-                // whose contents will be concatenated and inserted along the collection.
-                let mut error_collections = Vec::<Collection<_, _>>::new();
-
-                let source_persist_config = match (src.persist_desc, render_state.persist.as_mut())
-                {
-                    (Some(persist_desc), Some(persist)) => {
-                        let mut persist_errs = Vec::new();
-
-                        let source_persist_config = get_persist_config(&uid, persist_desc, persist);
-
-                        if let Err(ref e) = source_persist_config {
-                            let err = SourceError::new(
-                                src.name.clone(),
-                                SourceErrorDetails::Persistence(e.to_string()),
-                            );
-                            persist_errs.push(err);
-                        }
-
-                        // Make sure to always create and push an error stream, even if there
-                        // are no errors. This ensures that the shape of the operator graph is
-                        // consistent across all timely workers.
-                        //
-                        // TODO: The error collections are not the right place for surfacing
-                        // persistence errors, since they are not deterministic/definite. We
-                        // don't have a better place right now, though.
-                        error_collections.push(
-                            persist_errs
-                                .to_stream(scope)
-                                .map(DataflowError::SourceError)
-                                .pass_through("source-persist-errors")
-                                .as_collection(),
-                        );
-
-                        source_persist_config.ok()
-                    }
-                    _ => None,
-                };
-
-                let fast_forwarded = match &connector {
-                    ExternalSourceConnector::Kafka(KafkaSourceConnector {
-                        start_offsets, ..
-                    }) => start_offsets.values().any(|&val| val > 0),
-                    _ => false,
-                };
-
-                // All workers are responsible for reading in Kafka sources. Other sources
-                // support single-threaded ingestion only. Note that in all cases we want all
-                // readers of the same source or same partition to reside on the same worker,
-                // and only load-balance responsibility across distinct sources.
-                let active_read_worker = if let ExternalSourceConnector::Kafka(_) = connector {
-                    true
-                } else {
-                    (usize::cast_from(src_id.hashed()) % scope.peers()) == scope.index()
-                };
-
-                let timestamp_histories = render_state
-                    .ts_histories
-                    .get(&orig_id)
-                    .map(|history| history.clone());
-                let source_name = format!("{}-{}", connector.name(), uid);
-                let source_config = SourceConfig {
-                    name: source_name.clone(),
-                    sql_name: src.name.clone(),
-                    upstream_name: connector.upstream_name().map(ToOwned::to_owned),
-                    id: uid,
+                self.render_external_source(
+                    render_state,
+                    tokens,
                     scope,
-                    // Distribute read responsibility among workers.
-                    active: active_read_worker,
-                    timestamp_histories,
-                    consistency,
-                    timestamp_frequency: ts_frequency,
-                    worker_id: scope.index(),
-                    worker_count: scope.peers(),
-                    logger: materialized_logging,
-                    encoding: encoding.clone(),
+                    materialized_logging,
                     now,
                     base_metrics,
+                    src.name,
+                    src_id,
+                    orig_id,
+                    connector,
+                    src.persist_desc,
+                    encoding,
+                    envelope,
+                    src.bare_desc,
+                    linear_operators,
+                    consistency,
+                    ts_frequency,
+                );
+            }
+        }
+    }
+
+    fn render_local_source(
+        &mut self,
+        render_state: &mut RenderState,
+        scope: &mut G,
+        src_id: GlobalId,
+        persisted_name: Option<String>,
+    ) {
+        let ((handle, capability), ok_stream, err_collection) = {
+            let ((handle, capability), ok_stream) = scope.new_unordered_input();
+            let err_collection = Collection::empty(scope);
+            ((handle, capability), ok_stream, err_collection)
+        };
+
+        // A local "source" is either fed by a local input handle, or by reading from a
+        // `persisted_source()`.
+        //
+        // For non-persisted sources, values that are to be inserted are sent from the
+        // coordinator and pushed into the handle.
+        //
+        // For persisted sources, the coordinator only writes new values to a persistent
+        // stream. These values will then "show up" here because we read from the same
+        // persistent stream.
+        let (ok_stream, err_collection) = match (&mut render_state.persist, persisted_name) {
+            (Some(persist), Some(stream_name)) => {
+                let (_write, read) = persist.create_or_load(&stream_name);
+                let (persist_ok_stream, persist_err_stream) =
+                    scope.persisted_source(read).ok_err(|x| match x {
+                        (Ok(kv), ts, diff) => Ok((kv, ts, diff)),
+                        (Err(err), ts, diff) => Err((err, ts, diff)),
+                    });
+                let (persist_ok_stream, decode_err_stream) =
+                    persist_ok_stream.ok_err(|((row, ()), ts, diff)| Ok((row, ts, diff)));
+                let persist_err_collection = persist_err_stream
+                    .concat(&decode_err_stream)
+                    .map(move |(err, ts, diff)| {
+                        let err = SourceError::new(
+                            stream_name.clone(),
+                            SourceErrorDetails::Persistence(err),
+                        );
+                        (err.into(), ts, diff)
+                    })
+                    .as_collection();
+                (
+                    ok_stream.concat(&persist_ok_stream),
+                    err_collection.concat(&persist_err_collection),
+                )
+            }
+            _ => (ok_stream, err_collection),
+        };
+
+        render_state
+            .local_inputs
+            .insert(src_id, LocalInput { handle, capability });
+        let as_of_frontier = self.as_of_frontier.clone();
+        let ok_collection = ok_stream
+            .map_in_place(move |(_, mut time, _)| {
+                time.advance_by(as_of_frontier.borrow());
+            })
+            .as_collection();
+        self.insert_id(
+            Id::Global(src_id),
+            crate::render::CollectionBundle::from_collections(ok_collection, err_collection),
+        );
+    }
+
+    fn render_external_source(
+        &mut self,
+        render_state: &mut RenderState,
+        tokens: &mut RelevantTokens,
+        scope: &mut G,
+        materialized_logging: Option<Logger>,
+        now: NowFn,
+        base_metrics: &SourceBaseMetrics,
+        src_name: String,
+        src_id: GlobalId,
+        orig_id: GlobalId,
+        connector: ExternalSourceConnector,
+        persist_desc: Option<SourcePersistDesc>,
+        encoding: SourceDataEncoding,
+        envelope: SourceEnvelope,
+        bare_desc: RelationDesc,
+        mut linear_operators: Option<LinearOperator>,
+        consistency: Consistency,
+        ts_frequency: Duration,
+    ) {
+        // Blank out trivial linear operators.
+        if let Some(operator) = &linear_operators {
+            if operator.is_trivial(bare_desc.arity()) {
+                linear_operators = None;
+            }
+        }
+
+        // TODO(benesch): this method is hard to follow. Refactor.
+
+        // This uid must be unique across all different instantiations of a source
+        let uid = SourceInstanceId {
+            source_id: orig_id,
+            dataflow_id: self.dataflow_id,
+        };
+
+        // All sources should push their various error streams into this vector,
+        // whose contents will be concatenated and inserted along the collection.
+        let mut error_collections = Vec::<Collection<_, _>>::new();
+
+        let source_persist_config = match (persist_desc, render_state.persist.as_mut()) {
+            (Some(persist_desc), Some(persist)) => {
+                let mut persist_errs = Vec::new();
+
+                let source_persist_config = get_persist_config(&uid, persist_desc, persist);
+
+                if let Err(ref e) = source_persist_config {
+                    let err = SourceError::new(
+                        src_name.clone(),
+                        SourceErrorDetails::Persistence(e.to_string()),
+                    );
+                    persist_errs.push(err);
+                }
+
+                // Make sure to always create and push an error stream, even if there
+                // are no errors. This ensures that the shape of the operator graph is
+                // consistent across all timely workers.
+                //
+                // TODO: The error collections are not the right place for surfacing
+                // persistence errors, since they are not deterministic/definite. We
+                // don't have a better place right now, though.
+                error_collections.push(
+                    persist_errs
+                        .to_stream(scope)
+                        .map(DataflowError::SourceError)
+                        .pass_through("source-persist-errors")
+                        .as_collection(),
+                );
+
+                source_persist_config.ok()
+            }
+            _ => None,
+        };
+
+        let fast_forwarded = match &connector {
+            ExternalSourceConnector::Kafka(KafkaSourceConnector { start_offsets, .. }) => {
+                start_offsets.values().any(|&val| val > 0)
+            }
+            _ => false,
+        };
+
+        // All workers are responsible for reading in Kafka sources. Other sources
+        // support single-threaded ingestion only. Note that in all cases we want all
+        // readers of the same source or same partition to reside on the same worker,
+        // and only load-balance responsibility across distinct sources.
+        let active_read_worker = if let ExternalSourceConnector::Kafka(_) = connector {
+            true
+        } else {
+            (usize::cast_from(src_id.hashed()) % scope.peers()) == scope.index()
+        };
+
+        let timestamp_histories = render_state
+            .ts_histories
+            .get(&orig_id)
+            .map(|history| history.clone());
+        let source_name = format!("{}-{}", connector.name(), uid);
+        let source_config = SourceConfig {
+            name: source_name.clone(),
+            sql_name: src_name.clone(),
+            upstream_name: connector.upstream_name().map(ToOwned::to_owned),
+            id: uid,
+            scope,
+            // Distribute read responsibility among workers.
+            active: active_read_worker,
+            timestamp_histories,
+            consistency,
+            timestamp_frequency: ts_frequency,
+            worker_id: scope.index(),
+            worker_count: scope.peers(),
+            logger: materialized_logging,
+            encoding: encoding.clone(),
+            now,
+            base_metrics,
+        };
+
+        let (mut collection, capability) =
+            if let ExternalSourceConnector::PubNub(pubnub_connector) = connector {
+                let source = PubNubSourceReader::new(src_name, pubnub_connector);
+                let ((ok_stream, err_stream), capability) =
+                    source::create_source_simple(source_config, source);
+
+                error_collections.push(
+                    err_stream
+                        .map(DataflowError::SourceError)
+                        .pass_through("source-errors")
+                        .as_collection(),
+                );
+
+                (ok_stream.as_collection(), capability)
+            } else if let ExternalSourceConnector::Postgres(pg_connector) = connector {
+                let source = PostgresSourceReader::new(src_name, pg_connector);
+
+                let ((ok_stream, err_stream), capability) =
+                    source::create_source_simple(source_config, source);
+
+                error_collections.push(
+                    err_stream
+                        .map(DataflowError::SourceError)
+                        .pass_through("source-errors")
+                        .as_collection(),
+                );
+
+                (ok_stream.as_collection(), capability)
+            } else {
+                let ((ok_source, ts_bindings, err_source), capability) = match connector {
+                    ExternalSourceConnector::Kafka(_) => {
+                        let ((ok, ts, err), cap) = source::create_source::<_, KafkaSourceReader>(
+                            source_config,
+                            &connector,
+                            source_persist_config
+                                .as_ref()
+                                .map(|config| config.bindings_config.clone()),
+                        );
+                        ((SourceType::Delimited(ok), ts, err), cap)
+                    }
+                    ExternalSourceConnector::Kinesis(_) => {
+                        let ((ok, ts, err), cap) = source::create_source::<_, KinesisSourceReader>(
+                            source_config,
+                            &connector,
+                            source_persist_config
+                                .as_ref()
+                                .map(|config| config.bindings_config.clone()),
+                        );
+                        ((SourceType::Delimited(ok), ts, err), cap)
+                    }
+                    ExternalSourceConnector::S3(_) => {
+                        let ((ok, ts, err), cap) = source::create_source::<_, S3SourceReader>(
+                            source_config,
+                            &connector,
+                            source_persist_config
+                                .as_ref()
+                                .map(|config| config.bindings_config.clone()),
+                        );
+                        ((SourceType::ByteStream(ok), ts, err), cap)
+                    }
+                    ExternalSourceConnector::File(_) | ExternalSourceConnector::AvroOcf(_) => {
+                        let ((ok, ts, err), cap) = source::create_source::<_, FileSourceReader>(
+                            source_config,
+                            &connector,
+                            source_persist_config
+                                .as_ref()
+                                .map(|config| config.bindings_config.clone()),
+                        );
+                        ((SourceType::ByteStream(ok), ts, err), cap)
+                    }
+                    ExternalSourceConnector::Postgres(_) => unreachable!(),
+                    ExternalSourceConnector::PubNub(_) => unreachable!(),
                 };
 
-                let (mut collection, capability) = if let ExternalSourceConnector::PubNub(
-                    pubnub_connector,
-                ) = connector
-                {
-                    let source = PubNubSourceReader::new(src.name.clone(), pubnub_connector);
-                    let ((ok_stream, err_stream), capability) =
-                        source::create_source_simple(source_config, source);
+                // Include any source errors.
+                error_collections.push(
+                    err_source
+                        .map(DataflowError::SourceError)
+                        .pass_through("source-errors")
+                        .as_collection(),
+                );
 
-                    error_collections.push(
-                        err_stream
-                            .map(DataflowError::SourceError)
-                            .pass_through("source-errors")
-                            .as_collection(),
-                    );
-
-                    (ok_stream.as_collection(), capability)
-                } else if let ExternalSourceConnector::Postgres(pg_connector) = connector {
-                    let source = PostgresSourceReader::new(src.name.clone(), pg_connector);
-
-                    let ((ok_stream, err_stream), capability) =
-                        source::create_source_simple(source_config, source);
-
-                    error_collections.push(
-                        err_stream
-                            .map(DataflowError::SourceError)
-                            .pass_through("source-errors")
-                            .as_collection(),
-                    );
-
-                    (ok_stream.as_collection(), capability)
-                } else {
-                    let ((ok_source, ts_bindings, err_source), capability) = match connector {
-                        ExternalSourceConnector::Kafka(_) => {
-                            let ((ok, ts, err), cap) = source::create_source::<_, KafkaSourceReader>(
-                                source_config,
-                                &connector,
-                                source_persist_config
-                                    .as_ref()
-                                    .map(|config| config.bindings_config.clone()),
-                            );
-                            ((SourceType::Delimited(ok), ts, err), cap)
-                        }
-                        ExternalSourceConnector::Kinesis(_) => {
-                            let ((ok, ts, err), cap) =
-                                source::create_source::<_, KinesisSourceReader>(
-                                    source_config,
-                                    &connector,
-                                    source_persist_config
-                                        .as_ref()
-                                        .map(|config| config.bindings_config.clone()),
-                                );
-                            ((SourceType::Delimited(ok), ts, err), cap)
-                        }
-                        ExternalSourceConnector::S3(_) => {
-                            let ((ok, ts, err), cap) = source::create_source::<_, S3SourceReader>(
-                                source_config,
-                                &connector,
-                                source_persist_config
-                                    .as_ref()
-                                    .map(|config| config.bindings_config.clone()),
-                            );
-                            ((SourceType::ByteStream(ok), ts, err), cap)
-                        }
-                        ExternalSourceConnector::File(_) | ExternalSourceConnector::AvroOcf(_) => {
-                            let ((ok, ts, err), cap) = source::create_source::<_, FileSourceReader>(
-                                source_config,
-                                &connector,
-                                source_persist_config
-                                    .as_ref()
-                                    .map(|config| config.bindings_config.clone()),
-                            );
-                            ((SourceType::ByteStream(ok), ts, err), cap)
-                        }
-                        ExternalSourceConnector::Postgres(_) => unreachable!(),
-                        ExternalSourceConnector::PubNub(_) => unreachable!(),
+                let (stream, errors) = {
+                    let (key_desc, _) = encoding.desc().expect("planning has verified this");
+                    let (key_encoding, value_encoding) = match encoding {
+                        SourceDataEncoding::KeyValue { key, value } => (Some(key), value),
+                        SourceDataEncoding::Single(value) => (None, value),
                     };
 
-                    // Include any source errors.
-                    error_collections.push(
-                        err_source
-                            .map(DataflowError::SourceError)
-                            .pass_through("source-errors")
-                            .as_collection(),
-                    );
+                    // TODO(petrosagg): remove this inconsistency once INCLUDE (offset)
+                    // syntax is implemented
+                    let push_metadata = !matches!(value_encoding, DataEncoding::Avro(_));
 
-                    let (stream, errors) = {
-                        let (key_desc, _) = encoding.desc().expect("planning has verified this");
-                        let (key_encoding, value_encoding) = match encoding {
-                            SourceDataEncoding::KeyValue { key, value } => (Some(key), value),
-                            SourceDataEncoding::Single(value) => (None, value),
+                    // CDCv2 can't quite be slotted in to the below code, since it determines
+                    // its own diffs/timestamps as part of decoding.
+                    if let SourceEnvelope::CdcV2 = &envelope {
+                        let AvroEncoding {
+                            schema,
+                            schema_registry_config,
+                            confluent_wire_format,
+                        } = match value_encoding {
+                            DataEncoding::Avro(enc) => enc,
+                            _ => unreachable!("Attempted to create non-Avro CDCv2 source"),
                         };
-
-                        // TODO(petrosagg): remove this inconsistency once INCLUDE (offset)
-                        // syntax is implemented
-                        let push_metadata = !matches!(value_encoding, DataEncoding::Avro(_));
-
-                        // CDCv2 can't quite be slotted in to the below code, since it determines
-                        // its own diffs/timestamps as part of decoding.
-                        if let SourceEnvelope::CdcV2 = &envelope {
-                            let AvroEncoding {
-                                schema,
-                                schema_registry_config,
-                                confluent_wire_format,
-                            } = match value_encoding {
-                                DataEncoding::Avro(enc) => enc,
-                                _ => unreachable!("Attempted to create non-Avro CDCv2 source"),
-                            };
-                            let ok_source = match ok_source {
-                                SourceType::Delimited(s) => s,
-                                _ => unreachable!("Attempted to create non-delimited CDCv2 source"),
-                            };
-                            // TODO(petrosagg): this should move to the envelope section below and
-                            // made to work with a stream of Rows instead of decoding Avro directly
-                            let (oks, token) = decode_cdcv2(
-                                &ok_source,
-                                &schema,
-                                schema_registry_config,
-                                confluent_wire_format,
-                            );
+                        let ok_source = match ok_source {
+                            SourceType::Delimited(s) => s,
+                            _ => unreachable!("Attempted to create non-delimited CDCv2 source"),
+                        };
+                        // TODO(petrosagg): this should move to the envelope section below and
+                        // made to work with a stream of Rows instead of decoding Avro directly
+                        let (oks, token) = decode_cdcv2(
+                            &ok_source,
+                            &schema,
+                            schema_registry_config,
+                            confluent_wire_format,
+                        );
+                        tokens
+                            .additional_tokens
+                            .entry(src_id)
+                            .or_insert_with(Vec::new)
+                            .push(Rc::new(token));
+                        (oks, None)
+                    } else {
+                        let (results, extra_token) = match ok_source {
+                            SourceType::Delimited(source) => render_decode_delimited(
+                                &source,
+                                key_encoding,
+                                value_encoding,
+                                &self.debug_name,
+                                &envelope,
+                                &mut linear_operators,
+                                fast_forwarded,
+                                render_state.metrics.clone(),
+                            ),
+                            SourceType::ByteStream(source) => render_decode(
+                                &source,
+                                value_encoding,
+                                &self.debug_name,
+                                &envelope,
+                                &mut linear_operators,
+                                fast_forwarded,
+                                render_state.metrics.clone(),
+                            ),
+                        };
+                        if let Some(tok) = extra_token {
                             tokens
                                 .additional_tokens
                                 .entry(src_id)
                                 .or_insert_with(Vec::new)
-                                .push(Rc::new(token));
-                            (oks, None)
-                        } else {
-                            let (results, extra_token) = match ok_source {
-                                SourceType::Delimited(source) => render_decode_delimited(
-                                    &source,
-                                    key_encoding,
-                                    value_encoding,
-                                    &self.debug_name,
-                                    &envelope,
-                                    &mut linear_operators,
-                                    fast_forwarded,
-                                    render_state.metrics.clone(),
-                                ),
-                                SourceType::ByteStream(source) => render_decode(
-                                    &source,
-                                    value_encoding,
-                                    &self.debug_name,
-                                    &envelope,
-                                    &mut linear_operators,
-                                    fast_forwarded,
-                                    render_state.metrics.clone(),
-                                ),
-                            };
-                            if let Some(tok) = extra_token {
-                                tokens
-                                    .additional_tokens
-                                    .entry(src_id)
-                                    .or_insert_with(Vec::new)
-                                    .push(Rc::new(tok));
-                            }
+                                .push(Rc::new(tok));
+                        }
 
-                            // render envelopes
-                            match &envelope {
-                                SourceEnvelope::Debezium(dedupe_strategy, mode) => {
-                                    let results = match mode {
-                                        DebeziumMode::Upsert => {
-                                            let mut trackstate = (
-                                                HashMap::new(),
-                                                render_state.metrics.debezium_upsert_count_for(
-                                                    src_id,
-                                                    self.dataflow_id,
-                                                ),
-                                            );
-                                            results.flat_map(move |result| {
-                                                let (keys, metrics) = &mut trackstate;
-                                                result.value.map(|value| match result.key {
-                                                    None => Err(DecodeError::Text(
-                                                        "All upsert keys should decode to a value."
-                                                            .into(),
-                                                    )),
-                                                    Some(Err(e)) => Err(e),
-                                                    Some(Ok(key)) => rewrite_for_upsert(
-                                                        value, keys, key, metrics,
-                                                    ),
-                                                })
-                                            })
-                                        }
-                                        DebeziumMode::Plain => {
-                                            results.flat_map(|DecodeResult { value, .. }| value)
-                                        }
-                                    };
-                                    let (stream, errors) = results.ok_err(ResultExt::err_into);
-                                    let stream = stream.pass_through("decode-ok").as_collection();
-                                    let errors =
-                                        errors.pass_through("decode-errors").as_collection();
-
-                                    let dbz_key_indices = if let Some(key_desc) = key_desc {
-                                        let fields = match &src.bare_desc.typ().column_types[0]
-                                            .scalar_type
-                                        {
-                                            ScalarType::Record { fields, .. } => fields.clone(),
-                                            _ => unreachable!(),
-                                        };
-                                        let row_desc = RelationDesc::from_names_and_types(
-                                            fields.into_iter().map(|(n, t)| (Some(n), t)),
+                        // render envelopes
+                        match &envelope {
+                            SourceEnvelope::Debezium(dedupe_strategy, mode) => {
+                                let results = match mode {
+                                    DebeziumMode::Upsert => {
+                                        let mut trackstate = (
+                                            HashMap::new(),
+                                            render_state.metrics.debezium_upsert_count_for(
+                                                src_id,
+                                                self.dataflow_id,
+                                            ),
                                         );
-                                        // these must be available because the DDL parsing logic already
-                                        // checks this and bails in case the key is not correct
-                                        Some(dataflow_types::match_key_indices(&key_desc, &row_desc).expect("Invalid key schema, this indicates a bug in Materialize"))
-                                    } else {
-                                        None
-                                    };
-
-                                    let stream = dedupe_strategy.clone().render(
-                                        stream,
-                                        self.debug_name.to_string(),
-                                        scope.index(),
-                                        // Debezium decoding has produced two extra fields, with the dedupe information and the upstream time in millis
-                                        src.bare_desc.arity() + 2,
-                                        dbz_key_indices,
-                                    );
-
-                                    (stream, Some(errors))
-                                }
-                                SourceEnvelope::Upsert(_key_envelope) => {
-                                    // TODO: use the key envelope to figure out when to add keys.
-                                    // The opeator currently does it unconditionally
-                                    let upsert_operator_name = format!("{}-upsert", source_name);
-
-                                    // append position metadata to the output row
-                                    let results = if push_metadata {
-                                        results.map(|mut d| {
-                                            if let Some(Ok(ref mut row)) = d.value {
-                                                row.push(Datum::from(d.position));
-                                            }
-                                            d
+                                        results.flat_map(move |result| {
+                                            let (keys, metrics) = &mut trackstate;
+                                            result.value.map(|value| match result.key {
+                                                None => Err(DecodeError::Text(
+                                                    "All upsert keys should decode to a value."
+                                                        .into(),
+                                                )),
+                                                Some(Err(e)) => Err(e),
+                                                Some(Ok(key)) => {
+                                                    rewrite_for_upsert(value, keys, key, metrics)
+                                                }
+                                            })
                                         })
-                                    } else {
-                                        results
-                                    };
+                                    }
+                                    DebeziumMode::Plain => {
+                                        results.flat_map(|DecodeResult { value, .. }| value)
+                                    }
+                                };
+                                let (stream, errors) = results.ok_err(ResultExt::err_into);
+                                let stream = stream.pass_through("decode-ok").as_collection();
+                                let errors = errors.pass_through("decode-errors").as_collection();
 
-                                    let (upsert_ok, upsert_err) = super::upsert::upsert(
-                                        &upsert_operator_name,
-                                        &results,
-                                        self.as_of_frontier.clone(),
-                                        &mut linear_operators,
-                                        src.bare_desc.typ().arity(),
-                                        source_persist_config
-                                            .as_ref()
-                                            .map(|config| config.upsert_config.clone()),
-                                    );
-
-                                    // When persistence is enabled we need to seal up both the
-                                    // timestamp bindings and the upsert state. Otherwise, just
-                                    // pass through.
-                                    let (upsert_ok, upsert_err) = if let Some(
-                                        source_persist_config,
-                                    ) = source_persist_config
+                                let dbz_key_indices = if let Some(key_desc) = key_desc {
+                                    let fields = match &bare_desc.typ().column_types[0].scalar_type
                                     {
+                                        ScalarType::Record { fields, .. } => fields.clone(),
+                                        _ => unreachable!(),
+                                    };
+                                    let row_desc = RelationDesc::from_names_and_types(
+                                        fields.into_iter().map(|(n, t)| (Some(n), t)),
+                                    );
+                                    // these must be available because the DDL parsing logic already
+                                    // checks this and bails in case the key is not correct
+                                    Some(
+                                    dataflow_types::match_key_indices(&key_desc, &row_desc).expect(
+                                        "Invalid key schema, this indicates a bug in Materialize",
+                                    ),
+                                )
+                                } else {
+                                    None
+                                };
+
+                                let stream = dedupe_strategy.clone().render(
+                                    stream,
+                                    self.debug_name.to_string(),
+                                    scope.index(),
+                                    // Debezium decoding has produced two extra fields, with the dedupe information and the upstream time in millis
+                                    bare_desc.arity() + 2,
+                                    dbz_key_indices,
+                                );
+
+                                (stream, Some(errors))
+                            }
+                            SourceEnvelope::Upsert(_key_envelope) => {
+                                // TODO: use the key envelope to figure out when to add keys.
+                                // The opeator currently does it unconditionally
+                                let upsert_operator_name = format!("{}-upsert", source_name);
+
+                                // append position metadata to the output row
+                                let results = if push_metadata {
+                                    results.map(|mut d| {
+                                        if let Some(Ok(ref mut row)) = d.value {
+                                            row.push(Datum::from(d.position));
+                                        }
+                                        d
+                                    })
+                                } else {
+                                    results
+                                };
+
+                                let (upsert_ok, upsert_err) = super::upsert::upsert(
+                                    &upsert_operator_name,
+                                    &results,
+                                    self.as_of_frontier.clone(),
+                                    &mut linear_operators,
+                                    bare_desc.typ().arity(),
+                                    source_persist_config
+                                        .as_ref()
+                                        .map(|config| config.upsert_config.clone()),
+                                );
+
+                                // When persistence is enabled we need to seal up both the
+                                // timestamp bindings and the upsert state. Otherwise, just
+                                // pass through.
+                                let (upsert_ok, upsert_err) =
+                                    if let Some(source_persist_config) = source_persist_config {
                                         let (sealed_upsert_ok, upsert_seal_err) = upsert_ok
                                             .conditional_seal(
                                                 &source_name,
@@ -548,120 +594,113 @@ where
                                         (upsert_ok, upsert_err)
                                     };
 
-                                    (upsert_ok.as_collection(), Some(upsert_err.as_collection()))
-                                }
-                                SourceEnvelope::None(key_envelope) => {
-                                    let (stream, errors) =
-                                        flatten_results(key_envelope, push_metadata, results)
-                                            .ok_err(ResultExt::err_into);
-                                    let stream = stream.pass_through("decode-ok").as_collection();
-                                    let errors =
-                                        errors.pass_through("decode-errors").as_collection();
-                                    (stream, Some(errors))
-                                }
-                                SourceEnvelope::CdcV2 => unreachable!(),
+                                (upsert_ok.as_collection(), Some(upsert_err.as_collection()))
                             }
+                            SourceEnvelope::None(key_envelope) => {
+                                let (stream, errors) =
+                                    flatten_results(key_envelope, push_metadata, results)
+                                        .ok_err(ResultExt::err_into);
+                                let stream = stream.pass_through("decode-ok").as_collection();
+                                let errors = errors.pass_through("decode-errors").as_collection();
+                                (stream, Some(errors))
+                            }
+                            SourceEnvelope::CdcV2 => unreachable!(),
                         }
-                    };
-
-                    if let Some(errors) = errors {
-                        error_collections.push(errors);
                     }
-
-                    (stream, capability)
                 };
 
-                // Force a shuffling of data in case sources are not uniformly distributed.
-                use timely::dataflow::operators::Exchange;
-                collection = collection.inner.exchange(|x| x.hashed()).as_collection();
-
-                // Implement source filtering and projection.
-                // At the moment this is strictly optional, but we perform it anyhow
-                // to demonstrate the intended use.
-                if let Some(operators) = linear_operators {
-                    // Apply predicates and insert dummy values into undemanded columns.
-                    let (collection2, errors) =
-                        collection
-                            .inner
-                            .flat_map_fallible("SourceLinearOperators", {
-                                // Produce an executable plan reflecting the linear operators.
-                                let source_type = src.bare_desc.typ();
-                                let linear_op_mfp =
-                                    crate::render::plan::linear_to_mfp(operators, source_type)
-                                        .into_plan()
-                                        .unwrap_or_else(|e| panic!("{}", e));
-                                // Reusable allocation for unpacking datums.
-                                let mut datum_vec = repr::DatumVec::new();
-                                let mut row_builder = Row::default();
-                                // Closure that applies the linear operators to each `input_row`.
-                                move |(input_row, time, diff)| {
-                                    let arena = repr::RowArena::new();
-                                    let mut datums_local = datum_vec.borrow_with(&input_row);
-                                    linear_op_mfp.evaluate(
-                                        &mut datums_local,
-                                        &arena,
-                                        time,
-                                        diff,
-                                        &mut row_builder,
-                                    )
-                                }
-                            });
-
-                    collection = collection2.as_collection();
-                    error_collections.push(errors.as_collection());
-                };
-
-                // Flatten the error collections.
-                let mut err_collection = match error_collections.len() {
-                    0 => Collection::empty(scope),
-                    1 => error_collections.pop().unwrap(),
-                    _ => collection::concatenate(scope, error_collections),
-                };
-
-                // Apply `as_of` to each timestamp.
-                match &envelope {
-                    SourceEnvelope::Upsert(_) => {}
-                    _ => {
-                        let as_of_frontier1 = self.as_of_frontier.clone();
-                        collection = collection
-                            .inner
-                            .map_in_place(move |(_, time, _)| {
-                                time.advance_by(as_of_frontier1.borrow())
-                            })
-                            .as_collection();
-
-                        let as_of_frontier2 = self.as_of_frontier.clone();
-                        err_collection = err_collection
-                            .inner
-                            .map_in_place(move |(_, time, _)| {
-                                time.advance_by(as_of_frontier2.borrow())
-                            })
-                            .as_collection();
-                    }
+                if let Some(errors) = errors {
+                    error_collections.push(errors);
                 }
 
-                // Consolidate the results, as there may now be cancellations.
-                use differential_dataflow::operators::consolidate::ConsolidateStream;
-                collection = collection.consolidate_stream();
+                (stream, capability)
+            };
 
-                // Introduce the stream by name, as an unarranged collection.
-                self.insert_id(
-                    Id::Global(src_id),
-                    crate::render::CollectionBundle::from_collections(collection, err_collection),
-                );
+        // Force a shuffling of data in case sources are not uniformly distributed.
+        use timely::dataflow::operators::Exchange;
+        collection = collection.inner.exchange(|x| x.hashed()).as_collection();
 
-                let token = Rc::new(capability);
-                tokens.source_tokens.insert(src_id, token.clone());
+        // Implement source filtering and projection.
+        // At the moment this is strictly optional, but we perform it anyhow
+        // to demonstrate the intended use.
+        if let Some(operators) = linear_operators {
+            // Apply predicates and insert dummy values into undemanded columns.
+            let (collection2, errors) =
+                collection
+                    .inner
+                    .flat_map_fallible("SourceLinearOperators", {
+                        // Produce an executable plan reflecting the linear operators.
+                        let source_type = bare_desc.typ();
+                        let linear_op_mfp =
+                            crate::render::plan::linear_to_mfp(operators, source_type)
+                                .into_plan()
+                                .unwrap_or_else(|e| panic!("{}", e));
+                        // Reusable allocation for unpacking datums.
+                        let mut datum_vec = repr::DatumVec::new();
+                        let mut row_builder = Row::default();
+                        // Closure that applies the linear operators to each `input_row`.
+                        move |(input_row, time, diff)| {
+                            let arena = repr::RowArena::new();
+                            let mut datums_local = datum_vec.borrow_with(&input_row);
+                            linear_op_mfp.evaluate(
+                                &mut datums_local,
+                                &arena,
+                                time,
+                                diff,
+                                &mut row_builder,
+                            )
+                        }
+                    });
 
-                // We also need to keep track of this mapping globally to activate sources
-                // on timestamp advancement queries
-                render_state
-                    .ts_source_mapping
-                    .entry(orig_id)
-                    .or_insert_with(Vec::new)
-                    .push(Rc::downgrade(&token));
+            collection = collection2.as_collection();
+            error_collections.push(errors.as_collection());
+        };
+
+        // Flatten the error collections.
+        let mut err_collection = match error_collections.len() {
+            0 => Collection::empty(scope),
+            1 => error_collections.pop().unwrap(),
+            _ => collection::concatenate(scope, error_collections),
+        };
+
+        // Apply `as_of` to each timestamp.
+        match &envelope {
+            SourceEnvelope::Upsert(_) => {}
+            _ => {
+                let as_of_frontier1 = self.as_of_frontier.clone();
+                collection = collection
+                    .inner
+                    .map_in_place(move |(_, time, _)| time.advance_by(as_of_frontier1.borrow()))
+                    .as_collection();
+
+                let as_of_frontier2 = self.as_of_frontier.clone();
+                err_collection = err_collection
+                    .inner
+                    .map_in_place(move |(_, time, _)| time.advance_by(as_of_frontier2.borrow()))
+                    .as_collection();
             }
         }
+
+        // Consolidate the results, as there may now be cancellations.
+        use differential_dataflow::operators::consolidate::ConsolidateStream;
+        collection = collection.consolidate_stream();
+
+        // Introduce the stream by name, as an unarranged collection.
+        self.insert_id(
+            Id::Global(src_id),
+            crate::render::CollectionBundle::from_collections(collection, err_collection),
+        );
+
+        let token = Rc::new(capability);
+        tokens.source_tokens.insert(src_id, token.clone());
+
+        // We also need to keep track of this mapping globally to activate sources
+        // on timestamp advancement queries
+        render_state
+            .ts_source_mapping
+            .entry(orig_id)
+            .or_insert_with(Vec::new)
+            .push(Rc::downgrade(&token));
     }
 }
 

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -93,63 +93,11 @@ where
         //
         // This has a lot of potential for improvement in the near future.
         match src.connector {
-            ConnectorDesc::NonpersistedSource(connector) => self.render_source(
-                render_state,
-                tokens,
-                scope,
-                materialized_logging,
-                now,
-                base_metrics,
-                src.name,
-                src.bare_desc,
-                linear_operators,
-                src_id,
-                orig_id,
-                connector,
-                None,
-            ),
-            ConnectorDesc::PersistedSource(connector, persist_desc) => self.render_source(
-                render_state,
-                tokens,
-                scope,
-                materialized_logging,
-                now,
-                base_metrics,
-                src.name,
-                src.bare_desc,
-                linear_operators,
-                src_id,
-                orig_id,
-                connector,
-                Some(persist_desc), // <- this is the only different to above!
-            ),
-            ConnectorDesc::Ingest(_) => unreachable!("the coordinator does not send these out"),
-        }
-    }
-
-    fn render_source(
-        &mut self,
-        render_state: &mut RenderState,
-        tokens: &mut RelevantTokens,
-        scope: &mut G,
-        materialized_logging: Option<Logger>,
-        now: NowFn,
-        base_metrics: &SourceBaseMetrics,
-        src_name: String,
-        bare_desc: RelationDesc,
-        linear_operators: Option<LinearOperator>,
-        src_id: GlobalId,
-        orig_id: GlobalId,
-        connector: SourceConnector,
-        persist_desc: Option<SourcePersistDesc>,
-    ) {
-        match connector {
             // Create a new local input (exposed as TABLEs to users). Data is inserted
             // via Command::Insert commands.
             SourceConnector::Local { persisted_name, .. } => {
                 self.render_local_source(render_state, scope, src_id, persisted_name);
             }
-
             SourceConnector::External {
                 connector,
                 encoding,
@@ -157,6 +105,7 @@ where
                 consistency,
                 ts_frequency,
                 timeline: _,
+                persist,
             } => {
                 self.render_external_source(
                     render_state,
@@ -165,14 +114,14 @@ where
                     materialized_logging,
                     now,
                     base_metrics,
-                    src_name,
+                    src.name,
                     src_id,
                     orig_id,
                     connector,
-                    persist_desc,
+                    persist,
                     encoding,
                     envelope,
-                    bare_desc,
+                    src.bare_desc,
                     linear_operators,
                     consistency,
                     ts_frequency,

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -905,6 +905,7 @@ pub fn plan_create_source(
             consistency,
             ts_frequency,
             timeline,
+            persist: None,
         },
         expr,
         bare_desc,

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -348,10 +348,10 @@ where
 pub fn optimize_dataflow_monotonic(dataflow: &mut DataflowDesc) -> Result<(), TransformError> {
     let mut monotonic = std::collections::HashSet::new();
     for (source_id, (source_desc, _)) in dataflow.source_imports.iter_mut() {
-        if let Some(SourceConnector::External {
+        if let SourceConnector::External {
             envelope: SourceEnvelope::None(_),
             ..
-        }) = source_desc.connector.connector()
+        } = source_desc.connector
         {
             monotonic.insert(source_id.clone());
         }

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -348,10 +348,10 @@ where
 pub fn optimize_dataflow_monotonic(dataflow: &mut DataflowDesc) -> Result<(), TransformError> {
     let mut monotonic = std::collections::HashSet::new();
     for (source_id, (source_desc, _)) in dataflow.source_imports.iter_mut() {
-        if let SourceConnector::External {
+        if let Some(SourceConnector::External {
             envelope: SourceEnvelope::None(_),
             ..
-        } = source_desc.connector
+        }) = source_desc.connector.connector()
         {
             monotonic.insert(source_id.clone());
         }


### PR DESCRIPTION
This is a refined take on #9403.
coord,persist: teach coord about persisted streams that are involved in sources

Before, the coordinator would only know the prefix that was used to form
the names of persistent streams that are involved in, say, the
persistent Kafka source.

Now, we keep structured information that is the same for all sources
(`primary_stream` and `timstamp_bindings_stream`) as well as
per-envelope persistence details. This way, the coordinator knows all
persisted streams that are involved in a source.

This also changes what persist information is sent to dataflow workers.
Before, we would send a single persist name. Now, we send a new
`SourcePersistDesc`, which contains the same structured persistence
details that the coordinator knows about. In future commits, we will add
more information to this.

We need to do this to allow the coordinator to:
 - determine a common seal timestamp when restarting
 - negotiate/figure out if a requested as_of matches the compaction
   frontier/since of a persisted source
 - compact persisted streams when necessary

We will do these additional changes in follow-up commits.

### Tips for reviewer

The individual commits are meaningful. The changes look bigger than they are, `dataflow,sources: factor import_source() into render_local_source() and render_external_source()` is just moving code around.

I think `catalog,persist: make SerializedSourcePersistDetails more structured` is possibly contentious: I don't know how forward/backwards compatible serializing enums and structs is. I left this as a separate commit that is easy to remove.

I also added an `IngestDesc` that does nothing and can't be used right now. Not sure we want to leave that in, but I added some description/`TODO`.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR adds a release note for any
  [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
