### PR TITLE
Make the kafka-sink-errors testdrive test os-independent

### DIFF
--- a/test/testdrive/kafka-sink-errors.td
+++ b/test/testdrive/kafka-sink-errors.td
@@ -197,10 +197,13 @@ Unsupported SASL mechanism: FOO
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 Invalid WITH option sasl_kerberos_keytab='foo': file does not exist
 
+$ file-append path=invalid-keytab
+nonsense
+
 ! CREATE SINK invalid_sasl_kerberos_keytab FROM v1
   INTO KAFKA BROKER '${testdrive.kafka-addr}'
   TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
-  WITH  (security_protocol = SASL_SSL, sasl_kerberos_keytab = '/bin/true')
+  WITH  (security_protocol = SASL_SSL, sasl_kerberos_keytab = '${testdrive.temp-dir}/invalid-keytab')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 error registering kafka topic for sink
 


### PR DESCRIPTION
`/bin/true` doesn't exist by default on MacOS, this changes the test to use a
variable that exists in both places.


### Motivation

Running all the Kafka tests fails unnecessarily for me because of this one thing.