### PR TITLE
Modernize s3.rs's error handling

### DIFF
--- a/src/dataflow/src/source/s3.rs
+++ b/src/dataflow/src/source/s3.rs
@@ -221,7 +221,7 @@ async fn download_objects_task(
                         bucket_info.keys.insert(msg.key);
                     }
                     Err(DownloadError::Failed { err }) => {
-                        if tx.send(Err(S3Error::IOError(err))).await.is_err() {
+                        if tx.send(Err(S3Error::IoError(err))).await.is_err() {
                             rx.close();
                             break;
                         };
@@ -664,7 +664,7 @@ enum S3Error {
     },
     ListObjectsFailed(SdkError<ListObjectsV2Error>),
     RetryFailed,
-    IOError(std::io::Error),
+    IoError(std::io::Error),
 }
 
 impl std::error::Error for S3Error {}
@@ -684,7 +684,7 @@ impl std::fmt::Display for S3Error {
             }
             S3Error::ListObjectsFailed(err) => err.fmt(f),
             S3Error::RetryFailed => write!(f, "Retry failed to produce result"),
-            S3Error::IOError(e) => write!(f, "IOError: {}", e),
+            S3Error::IoError(e) => write!(f, "IoError: {}", e),
         }
     }
 }
@@ -945,7 +945,7 @@ impl SourceReader for S3SourceReader {
                         Err(anyhow!("Client construction failed: {}", err))
                     }
                     S3Error::RetryFailed => Err(anyhow!("Retry failed")),
-                    S3Error::IOError(e) => Err(e.into()),
+                    S3Error::IoError(e) => Err(e.into()),
                     S3Error::GetObjectError { .. } | S3Error::ListObjectsFailed(_) => {
                         Ok(NextMessage::Pending)
                     }

--- a/src/dataflow/src/source/s3.rs
+++ b/src/dataflow/src/source/s3.rs
@@ -778,7 +778,7 @@ async fn download_object(
         download_result,
     );
 
-    if let Ok(_) = &download_result {
+    if download_result.is_ok() {
         let sent = tx.send(Ok(InternalMessage {
             record: MessagePayload::EOF,
         }));


### PR DESCRIPTION
<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

Fixes #9452 

This error handling should use the canonical rust type, Result. Cleaning this up also caused 1. better debug messages in `download_object` and 2. cleaned up a discrepancy where we error, but also bump a stat (on a partial read, right before shutdown)



### Checklist

- This PR has adequate test coverage / QA involvement has been duly considered.
