### PR TITLE
persistence: tests for persistent Kafka upsert sources

### DIFF
--- a/doc/developer/testdrive.md
+++ b/doc/developer/testdrive.md
@@ -650,7 +650,13 @@ For data provided as `format=bytes key-format=bytes`, the separator between the 
 
 ##### `repeat=N`
 
-Send the same data `N` times to Kafka. This is used to create larger Kafka topics without bloating the test
+Send the same data `N` times to Kafka. This is used to create longer Kafka topics without bloating the test.
+
+The variable `${kafka-ingest.iteration}` will hold the current iteration and can be used in the body of `$ kafka-ingest`.
+
+##### `start-iteration=N`
+
+Set the starting value of the `${kafka-ingest.iteration}` variable.
 
 #### `partition=N`
 

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -716,6 +716,7 @@ pub async fn create_state(
 
         let admin_opts = AdminOptions::new().operation_timeout(Some(config.default_timeout));
 
+        kafka_config.set("message.max.bytes", "15728640");
         let producer: FutureProducer = kafka_config.create().err_hint(
             "opening Kafka producer connection",
             &[format!("connection string: {}", config.kafka_addr)],

--- a/src/testdrive/src/action/kafka/create_topic.rs
+++ b/src/testdrive/src/action/kafka/create_topic.rs
@@ -181,6 +181,8 @@ impl Action for CreateTopicAction {
                 .set("segment.ms", "100")
                 // make sure we get compaction even with low throughput
                 .set("min.cleanable.dirty.ratio", "0.01")
+                .set("min.compaction.lag.ms", "100")
+                .set("delete.retention.ms", "100")
         } else {
             new_topic
         };

--- a/test/persistence/kafka-sources/aaaa-linearizability-after.td.gh9217
+++ b/test/persistence/kafka-sources/aaaa-linearizability-after.td.gh9217
@@ -1,0 +1,26 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Make sure that we never observe a partial view of the values
+# inserted prior to the restart.
+#
+# This test is named "aaaa-..." so that it runs immediately after
+# Mz restart, before any linearizability violations could be swept
+# under he rug by the fact that the sources have caught up fully.
+#
+
+$ set-regex match=\d{13} replacement=<TIMESTAMP>
+
+> BEGIN
+
+> DECLARE c CURSOR FOR TAIL linearizability_count;
+
+> FETCH 1 c;
+<TIMESTAMP> 1 1000000

--- a/test/persistence/kafka-sources/exactly-once-sink-after.td
+++ b/test/persistence/kafka-sources/exactly-once-sink-after.td
@@ -1,0 +1,41 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set keyschema={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "f1", "type": "long"}
+    ]
+  }
+
+$ set schema={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"f2", "type":"long"}
+        ]
+    }
+
+$ kafka-ingest format=avro topic=exactly-once key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=2 start-iteration=40
+{"f1": ${kafka-ingest.iteration}} {"f2": ${kafka-ingest.iteration}}
+
+
+> SELECT COUNT(*) = 10 FROM exactly_once;
+true
+
+# We expect just the 6 new messages, having consumed the older ones in xactly-once-sink-before.td
+$ set-regex match=\d{13} replacement=<TIMESTAMP>
+$ kafka-verify format=avro sink=materialize.public.exactly_once_sink sort-messages=true
+{"before":null,"after":{"row":{"f1":20,"f2":20}},"transaction":{"id":"<TIMESTAMP>"}}
+{"before":null,"after":{"row":{"f1":21,"f2":21}},"transaction":{"id":"<TIMESTAMP>"}}
+{"before":null,"after":{"row":{"f1":30,"f2":30}},"transaction":{"id":"<TIMESTAMP>"}}
+{"before":null,"after":{"row":{"f1":31,"f2":31}},"transaction":{"id":"<TIMESTAMP>"}}
+{"before":null,"after":{"row":{"f1":40,"f2":40}},"transaction":{"id":"<TIMESTAMP>"}}
+{"before":null,"after":{"row":{"f1":41,"f2":41}},"transaction":{"id":"<TIMESTAMP>"}}

--- a/test/persistence/kafka-sources/exactly-once-sink-before.td
+++ b/test/persistence/kafka-sources/exactly-once-sink-before.td
@@ -1,0 +1,64 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Test persistent kafka topics in the context of exactly-once sinks
+#
+
+$ set keyschema={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "f1", "type": "long"}
+    ]
+  }
+
+$ set schema={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"f2", "type":"long"}
+        ]
+    }
+
+$ kafka-create-topic topic=exactly-once
+
+$ kafka-ingest format=avro topic=exactly-once key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=2
+{"f1": ${kafka-ingest.iteration}} {"f2": ${kafka-ingest.iteration}}
+
+> CREATE MATERIALIZED SOURCE exactly_once
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-exactly-once-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE UPSERT
+
+> CREATE SINK exactly_once_sink FROM exactly_once
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-exactly-once-sink-${testdrive.seed}'
+  WITH (reuse_topic=true)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}';
+
+$ kafka-ingest format=avro topic=exactly-once key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=2 start-iteration=10
+{"f1": ${kafka-ingest.iteration}} {"f2": ${kafka-ingest.iteration}}
+
+> SELECT COUNT(*) FROM exactly_once;
+4
+
+$ kafka-ingest format=avro topic=exactly-once key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=2 start-iteration=20
+{"f1": ${kafka-ingest.iteration}} {"f2": ${kafka-ingest.iteration}}
+
+$ kafka-ingest format=avro topic=exactly-once key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=2 start-iteration=30
+{"f1": ${kafka-ingest.iteration}} {"f2": ${kafka-ingest.iteration}}
+
+# Make sure that we have produced stuff to the sink before we restart
+$ set-regex match=\d{13} replacement=<TIMESTAMP>
+
+$ kafka-verify format=avro sink=materialize.public.exactly_once_sink sort-messages=true
+{"before":null,"after":{"row":{"f1":0,"f2":0}},"transaction":{"id":"<TIMESTAMP>"}}
+{"before":null,"after":{"row":{"f1":1,"f2":1}},"transaction":{"id":"<TIMESTAMP>"}}
+{"before":null,"after":{"row":{"f1":10,"f2":10}},"transaction":{"id":"<TIMESTAMP>"}}
+{"before":null,"after":{"row":{"f1":11,"f2":11}},"transaction":{"id":"<TIMESTAMP>"}}

--- a/test/persistence/kafka-sources/failpoint-after.td
+++ b/test/persistence/kafka-sources/failpoint-after.td
@@ -7,11 +7,5 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-> DROP SOURCE IF EXISTS mz_source CASCADE;
-
-> CREATE MATERIALIZED SOURCE mz_source
-  FROM POSTGRES
-  CONNECTION 'host=toxiproxy port=5432 user=postgres password=postgres dbname=postgres'
-  PUBLICATION 'mz_source'
-
-> CREATE MATERIALIZED VIEWS FROM SOURCE mz_source;
+> SELECT COUNT(*) FROM failpoint;
+1000000

--- a/test/persistence/kafka-sources/kafka-counters-after.td
+++ b/test/persistence/kafka-sources/kafka-counters-after.td
@@ -1,0 +1,36 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set keyschema={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "f1", "type": "string"}
+    ]
+  }
+
+$ set schema={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"f2", "type":"string"}
+        ]
+    }
+
+$ kafka-ingest format=avro topic=kafka-counters key-format=avro key-schema=${keyschema} schema=${schema} publish=true
+{"f1": "-1"} {"f2": "-1"}
+
+
+> SELECT COUNT(*) = 10001 FROM kafka_counters;
+true
+
+# We expect the counter to be at 1, that is no data was re-ingested
+# from the Kafka topic post-restart.
+> SELECT SUM(CAST(statistics->'topics'->'testdrive-kafka-counters-1'->'partitions'->'0'->'msgs' AS INT)) = 1 FROM mz_kafka_source_statistics;
+true

--- a/test/persistence/kafka-sources/kafka-counters-before.td
+++ b/test/persistence/kafka-sources/kafka-counters-before.td
@@ -1,0 +1,44 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Insert 10K values prior to restart and check that we never re-ingest
+# the entire topic as observed by the librdkafka counters
+#
+
+$ set count=10000
+
+$ set keyschema={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "f1", "type": "string"}
+    ]
+  }
+
+$ set schema={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"f2", "type":"string"}
+        ]
+    }
+
+$ kafka-create-topic topic=kafka-counters
+
+$ kafka-ingest format=avro topic=kafka-counters key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=${count}
+{"f1": "a${kafka-ingest.iteration}"} {"f2": "a${kafka-ingest.iteration}"}
+
+> CREATE MATERIALIZED SOURCE kafka_counters
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-kafka-counters-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE UPSERT
+
+> SELECT COUNT(*) = ${count} FROM kafka_counters;
+true

--- a/test/persistence/kafka-sources/linearizability-before.td.gh9217
+++ b/test/persistence/kafka-sources/linearizability-before.td.gh9217
@@ -1,0 +1,72 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Insert 100K values prior to restart and then test that we never observe a partial
+# view of those values post-restart
+#
+
+$ set keyschema={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "f1", "type": "string"}
+    ]
+  }
+
+$ set schema={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"f2", "type":"string"}
+        ]
+    }
+
+# We use partitions=3 here in order to introduce some concurrency during ingestion
+$ kafka-create-topic topic=linearizability partitions=3
+
+$ kafka-ingest format=avro topic=linearizability key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=100000
+{"f1": "a${kafka-ingest.iteration}"} {"f2": "a${kafka-ingest.iteration}"}
+
+$ kafka-ingest format=avro topic=linearizability key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=100000
+{"f1": "b${kafka-ingest.iteration}"} {"f2": "b${kafka-ingest.iteration}"}
+
+$ kafka-ingest format=avro topic=linearizability key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=100000
+{"f1": "c${kafka-ingest.iteration}"} {"f2": "c${kafka-ingest.iteration}"}
+
+$ kafka-ingest format=avro topic=linearizability key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=100000
+{"f1": "d${kafka-ingest.iteration}"} {"f2": "d${kafka-ingest.iteration}"}
+
+$ kafka-ingest format=avro topic=linearizability key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=100000
+{"f1": "e${kafka-ingest.iteration}"} {"f2": "e${kafka-ingest.iteration}"}
+
+$ kafka-ingest format=avro topic=linearizability key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=100000
+{"f1": "f${kafka-ingest.iteration}"} {"f2": "f${kafka-ingest.iteration}"}
+
+$ kafka-ingest format=avro topic=linearizability key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=100000
+{"f1": "g${kafka-ingest.iteration}"} {"f2": "g${kafka-ingest.iteration}"}
+
+$ kafka-ingest format=avro topic=linearizability key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=100000
+{"f1": "h${kafka-ingest.iteration}"} {"f2": "h${kafka-ingest.iteration}"}
+
+$ kafka-ingest format=avro topic=linearizability key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=100000
+{"f1": "i${kafka-ingest.iteration}"} {"f2": "i${kafka-ingest.iteration}"}
+
+$ kafka-ingest format=avro topic=linearizability key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=100000
+{"f1": "j${kafka-ingest.iteration}"} {"f2": "j${kafka-ingest.iteration}"}
+
+> CREATE MATERIALIZED SOURCE linearizability
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-linearizability-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE UPSERT
+
+> CREATE MATERIALIZED VIEW linearizability_count AS SELECT COUNT(*) FROM linearizability;
+
+> SELECT * FROM linearizability_count;
+1000000

--- a/test/persistence/kafka-sources/multipart-key-after.td
+++ b/test/persistence/kafka-sources/multipart-key-after.td
@@ -1,0 +1,40 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set keyschema={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "f1", "type": "string"},
+        {"name": "f2", "type": "string"}
+    ]
+  }
+
+$ set schema={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"f3", "type":"string"},
+            {"name":"f4", "type":"string"}
+        ]
+    }
+
+> SELECT COUNT(*), COUNT(DISTINCT f2), COUNT(DISTINCT f4) FROM multipart_key WHERE f1 = 'KEY1';
+10000 10000 10000
+
+> SELECT COUNT(*), COUNT(DISTINCT f1), COUNT(DISTINCT f3) FROM multipart_key WHERE f2 = 'KEY2';
+10000 10000 10000
+
+# Delete all rows
+$ kafka-ingest format=avro topic=multipart-key key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=10000
+{"f1": "KEY1", "f2": "${kafka-ingest.iteration}"}
+{"f1": "${kafka-ingest.iteration}", "f2": "KEY2"}
+
+> SELECT COUNT(*) FROM multipart_key;
+0

--- a/test/persistence/kafka-sources/multipart-key-before.td
+++ b/test/persistence/kafka-sources/multipart-key-before.td
@@ -1,0 +1,45 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Ingest a topic with a multi-part key
+#
+
+$ set keyschema={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "f1", "type": "string"},
+        {"name": "f2", "type": "string"}
+    ]
+  }
+
+$ set schema={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"f3", "type":"string"},
+            {"name":"f4", "type":"string"}
+        ]
+    }
+
+$ kafka-create-topic topic=multipart-key
+
+# Ingest data where the first or the second part of the key has high cardinality
+$ kafka-ingest format=avro topic=multipart-key key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=10000
+{"f1": "KEY1", "f2": "${kafka-ingest.iteration}"} {"f3": "KEY1", "f4": "${kafka-ingest.iteration}"}
+{"f1": "${kafka-ingest.iteration}", "f2": "KEY2"} {"f3": "${kafka-ingest.iteration}", "f4": "KEY2"}
+
+> CREATE MATERIALIZED SOURCE multipart_key
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-multipart-key-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE UPSERT;
+
+> SELECT COUNT(*) = 20000 FROM multipart_key;
+true

--- a/test/persistence/kafka-sources/partition-change-after.td
+++ b/test/persistence/kafka-sources/partition-change-after.td
@@ -1,0 +1,30 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set keyschema={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "f1", "type": "long"}
+    ]
+  }
+
+$ set schema={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"f2", "type":"long"}
+        ]
+    }
+
+$ kafka-ingest format=avro topic=partition-change key-format=avro key-schema=${keyschema} schema=${schema} publish=true start-iteration=10000 repeat=10000
+{"f1": ${kafka-ingest.iteration}} {"f2": ${kafka-ingest.iteration}}
+
+> SELECT COUNT(*), MIN(f1), MAX(f1), MIN(f2), MAX(f2) FROM partition_change;
+20000 0 19999 0 19999

--- a/test/persistence/kafka-sources/partition-change-before.td
+++ b/test/persistence/kafka-sources/partition-change-before.td
@@ -1,0 +1,47 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Change the number of partitions in the topic just prior to restart
+#
+
+$ set keyschema={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "f1", "type": "long"}
+    ]
+  }
+
+$ set schema={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"f2", "type":"long"}
+        ]
+    }
+
+$ kafka-create-topic topic=partition-change partitions=5
+
+$ kafka-ingest format=avro topic=partition-change key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=10000
+{"f1": ${kafka-ingest.iteration}} {"f2": ${kafka-ingest.iteration}}
+
+> CREATE MATERIALIZED SOURCE partition_change
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-partition-change-${testdrive.seed}'
+  WITH(topic_metadata_refresh_interval_ms=100)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE UPSERT
+
+> SELECT COUNT(*) > 0 FROM partition_change;
+true
+
+$ kafka-add-partitions topic=partition-change total-partitions=10
+
+$ kafka-ingest format=avro topic=partition-change key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=1000
+{"f1": ${kafka-ingest.iteration}} {"f2": ${kafka-ingest.iteration}}

--- a/test/persistence/kafka-sources/topic-compaction-after.td
+++ b/test/persistence/kafka-sources/topic-compaction-after.td
@@ -1,0 +1,33 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set keyschema={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "f1", "type": "long"}
+    ]
+  }
+
+$ set schema={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"f2", "type":"string"}
+        ]
+    }
+
+> SELECT COUNT(*) FROM topic_compaction WHERE f2 LIKE 'C%';
+1000
+
+$ kafka-ingest format=avro topic=topic-compaction key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=1000
+{"f1": ${kafka-ingest.iteration}} {"f2": "D${kafka-ingest.iteration}"}
+
+> SELECT COUNT(*) FROM topic_compaction WHERE f2 LIKE 'D%';
+1000

--- a/test/persistence/kafka-sources/topic-compaction-before.td
+++ b/test/persistence/kafka-sources/topic-compaction-before.td
@@ -1,0 +1,39 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set keyschema={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "f1", "type": "long"}
+    ]
+  }
+
+$ set schema={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"f2", "type":"string"}
+        ]
+    }
+
+$ kafka-create-topic topic=topic-compaction compaction=true
+
+$ kafka-ingest format=avro topic=topic-compaction key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=1000
+{"f1": ${kafka-ingest.iteration}} {"f2": "A${kafka-ingest.iteration}"}
+{"f1": ${kafka-ingest.iteration}} {"f2": "B${kafka-ingest.iteration}"}
+{"f1": ${kafka-ingest.iteration}} {"f2": "C${kafka-ingest.iteration}"}
+
+> CREATE MATERIALIZED SOURCE topic_compaction
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-topic-compaction-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE UPSERT;
+
+> SELECT COUNT(*) > 0 FROM topic_compaction;
+true

--- a/test/persistence/kafka-sources/topic-compression-after.td
+++ b/test/persistence/kafka-sources/topic-compression-after.td
@@ -1,0 +1,30 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set keyschema={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "f1", "type": "long"}
+    ]
+  }
+
+$ set schema={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"f2", "type":"string"}
+        ]
+    }
+
+$ kafka-ingest format=avro topic=topic-compression key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=1000
+{"f1": ${kafka-ingest.iteration}} {"f2": "abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghij"}
+
+> SELECT COUNT(*) = 1000, COUNT(DISTINCT f2) = 1, MIN(LENGTH(f2)) = 100, MAX(LENGTH(f2)) = 100 FROM topic_compression;
+true true true true

--- a/test/persistence/kafka-sources/topic-compression-before.td
+++ b/test/persistence/kafka-sources/topic-compression-before.td
@@ -1,0 +1,37 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set keyschema={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "f1", "type": "long"}
+    ]
+  }
+
+$ set schema={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"f2", "type":"string"}
+        ]
+    }
+
+$ kafka-create-topic topic=topic-compression compression=gzip
+
+$ kafka-ingest format=avro topic=topic-compression key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=1000
+{"f1": ${kafka-ingest.iteration}} {"f2": "abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghij"}
+
+> CREATE MATERIALIZED SOURCE topic_compression
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-topic-compression-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE UPSERT;
+
+> SELECT COUNT(*) = 1000 FROM topic_compression;
+true

--- a/test/persistence/kafka-sources/upsert-deletion-after.td
+++ b/test/persistence/kafka-sources/upsert-deletion-after.td
@@ -1,0 +1,32 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set keyschema={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "f1", "type": "long"}
+    ]
+  }
+
+$ set schema={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"f2", "type":"long"}
+        ]
+    }
+
+# Delete 5K records post-restart
+
+$ kafka-ingest format=avro topic=upsert-deletion key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=5000
+{"f1": ${kafka-ingest.iteration}}
+
+> SELECT COUNT(*), MIN(f1), MAX(f1), MIN(f2) , MAX(f2) FROM upsert_deletion;
+5000 5000 9999 5000 9999

--- a/test/persistence/kafka-sources/upsert-deletion-before.td
+++ b/test/persistence/kafka-sources/upsert-deletion-before.td
@@ -1,0 +1,41 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Ingest records before restart and then delete some of them post-restart
+#
+
+$ set keyschema={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "f1", "type": "long"}
+    ]
+  }
+
+$ set schema={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"f2", "type":"long"}
+        ]
+    }
+
+$ kafka-create-topic topic=upsert-deletion
+
+$ kafka-ingest format=avro topic=upsert-deletion key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=10000
+{"f1": ${kafka-ingest.iteration}} {"f2": ${kafka-ingest.iteration}}
+
+> CREATE MATERIALIZED SOURCE upsert_deletion
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-upsert-deletion-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE UPSERT
+
+> SELECT COUNT(*) = 10000 FROM upsert_deletion;
+true

--- a/test/persistence/kafka-sources/upsert-modification-after.td
+++ b/test/persistence/kafka-sources/upsert-modification-after.td
@@ -1,0 +1,35 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set keyschema={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "f1", "type": "long"}
+    ]
+  }
+
+$ set schema={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"f2", "type":"string"}
+        ]
+    }
+
+# Update 5K records
+
+$ kafka-ingest format=avro topic=upsert-modification key-format=avro key-schema=${keyschema} schema=${schema} publish=true start-iteration=2500 repeat=5000
+{"f1": ${kafka-ingest.iteration}} {"f2": "a${kafka-ingest.iteration}"}
+
+> SELECT COUNT(*) = 10000, MIN(f1) = 0, MAX(f1) = 9999 FROM upsert_modification;
+true true true
+
+> SELECT MIN(f1), MAX(f1), COUNT(*) FROM upsert_modification WHERE f2 LIKE 'a%';
+2500 7499 5000

--- a/test/persistence/kafka-sources/upsert-modification-before.td
+++ b/test/persistence/kafka-sources/upsert-modification-before.td
@@ -1,0 +1,41 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Ingest records before restart and then upsert them to a different value post-restart
+#
+
+$ set keyschema={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "f1", "type": "long"}
+    ]
+  }
+
+$ set schema={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"f2", "type":"string"}
+        ]
+    }
+
+$ kafka-create-topic topic=upsert-modification
+
+$ kafka-ingest format=avro topic=upsert-modification key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=10000
+{"f1": ${kafka-ingest.iteration}} {"f2": "${kafka-ingest.iteration}"}
+
+> CREATE MATERIALIZED SOURCE upsert_modification
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-upsert-modification-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE UPSERT
+
+> SELECT COUNT(*) = 10000 FROM upsert_modification;
+true

--- a/test/persistence/kafka-sources/wide-data-after.td
+++ b/test/persistence/kafka-sources/wide-data-after.td
@@ -1,0 +1,33 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set keyschema={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "f1", "type": "long"}
+    ]
+  }
+
+$ set schema={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"f2", "type":"long"}
+        ]
+    }
+
+
+# Cause some more rows to be produced in the Kafka topic
+
+$ kafka-ingest format=avro topic=wide-data-ten key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=10 start-iteration=10
+{"f1": ${kafka-ingest.iteration}} {"f2": ${kafka-ingest.iteration}}
+
+> SELECT COUNT(*) = 20, MIN(LENGTH(value)) = 512 * 1024, MAX(LENGTH(value)) = 512 * 1024 FROM wide_data_source;
+true true true

--- a/test/persistence/kafka-sources/wide-data-before.td
+++ b/test/persistence/kafka-sources/wide-data-before.td
@@ -1,0 +1,63 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Ingest wide data
+#
+
+$ set keyschema={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "f1", "type": "long"}
+    ]
+  }
+
+$ set schema={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"f2", "type":"long"}
+        ]
+    }
+
+#
+# Generate the wide data via a convoluted mechanism so that we do not have to push a multi-MB file in
+# the repository.
+# 1. Create a topic + source that outputs numbers 0 to 9
+# 2. Create a materialized view that outputs 10 rows worth of wide data
+# 3. Have that view produce a new Kafka topic that has the final data we want to ingest
+#
+
+$ kafka-create-topic topic=wide-data-ten
+
+$ kafka-ingest format=avro topic=wide-data-ten key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=10
+{"f1": ${kafka-ingest.iteration}} {"f2": ${kafka-ingest.iteration}}
+
+> CREATE MATERIALIZED SOURCE wide_data_ten
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-wide-data-ten-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE NONE;
+
+> CREATE MATERIALIZED VIEW wide_data_view AS SELECT wide_data_ten.f2 AS key, REPEAT('x', 512 * 1024) AS value FROM wide_data_ten;
+
+> CREATE SINK wide_data_sink FROM wide_data_view
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-wide-data-${testdrive.seed}'
+  KEY (key) NOT ENFORCED
+  WITH (reuse_topic=true)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE UPSERT;
+
+> CREATE MATERIALIZED SOURCE wide_data_source
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-wide-data-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE UPSERT;
+
+> SELECT COUNT(*) = 10 FROM wide_data_source;
+true

--- a/test/persistence/kafka-sources/zzzz-failpoint-before.td
+++ b/test/persistence/kafka-sources/zzzz-failpoint-before.td
@@ -1,0 +1,67 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Use a failpoint to prevent persisting to disk halfway through the workload
+#
+
+$ set keyschema={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "f1", "type": "string"}
+    ]
+  }
+
+$ set schema={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"f2", "type":"string"}
+        ]
+    }
+
+$ kafka-create-topic topic=failpoint
+
+$ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=100000
+{"f1": "a${kafka-ingest.iteration}"} {"f2": "a${kafka-ingest.iteration}"}
+
+$ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=100000
+{"f1": "b${kafka-ingest.iteration}"} {"f2": "b${kafka-ingest.iteration}"}
+
+> CREATE MATERIALIZED SOURCE failpoint
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-failpoint-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE UPSERT
+
+$ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=100000
+{"f1": "c${kafka-ingest.iteration}"} {"f2": "c${kafka-ingest.iteration}"}
+
+$ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=100000
+{"f1": "d${kafka-ingest.iteration}"} {"f2": "d${kafka-ingest.iteration}"}
+
+> SET failpoints = 'fileblob_set_sync=return';
+
+$ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=100000
+{"f1": "e${kafka-ingest.iteration}"} {"f2": "e${kafka-ingest.iteration}"}
+
+$ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=100000
+{"f1": "f${kafka-ingest.iteration}"} {"f2": "f${kafka-ingest.iteration}"}
+
+$ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=100000
+{"f1": "g${kafka-ingest.iteration}"} {"f2": "g${kafka-ingest.iteration}"}
+
+$ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=100000
+{"f1": "h${kafka-ingest.iteration}"} {"f2": "h${kafka-ingest.iteration}"}
+
+$ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=100000
+{"f1": "i${kafka-ingest.iteration}"} {"f2": "i${kafka-ingest.iteration}"}
+
+$ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=100000
+{"f1": "j${kafka-ingest.iteration}"} {"f2": "j${kafka-ingest.iteration}"}


### PR DESCRIPTION
### Motivation

  * This PR adds a feature that has not yet been specified.

This PR add a full complement of tests for persistent kafka sources in the face of server restarts

### Tips for reviewer

@benesch if you could review the testdrive and mzcompose.py pieces that would be much appreciated!