### PR TITLE
persist: make create_or_load() infallible

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -417,7 +417,7 @@ impl CatalogEntryMap {
                     persist: Some(persist),
                     ..
                 }) => {
-                    all_table_ids.push(persist.write_handle.stream_id());
+                    all_table_ids.push(persist.stream_id);
                     handles.push(&persist.write_handle);
                 }
                 _ => {}

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1396,8 +1396,7 @@ where
                 }) = self.catalog.get_by_id(on).item()
                 {
                     if self.catalog.default_index_for(*on) == Some(*id) {
-                        table_since_updates
-                            .push((persist.write_handle.stream_id(), frontier.clone()));
+                        table_since_updates.push((persist.stream_id, frontier.clone()));
                     }
                 }
             }
@@ -2775,8 +2774,7 @@ where
                                         .map(|(row, diff)| ((row, ()), timestamp, diff))
                                         .collect();
                                     persist_streams.push(&persist.write_handle);
-                                    persist_updates
-                                        .push((persist.write_handle.stream_id(), updates));
+                                    persist_updates.push((persist.stream_id, updates));
                                 }
                                 _ => {
                                     let updates = rows

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -111,9 +111,7 @@ where
                 let (ok_stream, err_collection) =
                     match (&mut render_state.persist, src.persisted_name) {
                         (Some(persist), Some(stream_name)) => {
-                            let read = persist
-                                .create_or_load(&stream_name)
-                                .map(|(_write, read)| read);
+                            let (_write, read) = persist.create_or_load(&stream_name);
                             let (persist_ok_stream, persist_err_stream) =
                                 scope.persisted_source(read).ok_err(|x| match x {
                                     (Ok(kv), ts, diff) => Ok((kv, ts, diff)),
@@ -703,11 +701,11 @@ fn get_persist_config(
     let persist_bindings_name = format!("{}-timestamp-bindings", persisted_name);
     let persist_data_name = format!("{}", persisted_name);
 
-    let (bindings_write, bindings_read) = persist_client
-        .create_or_load::<SourceTimestamp, AssignedTimestamp>(&persist_bindings_name)?;
+    let (bindings_write, bindings_read) =
+        persist_client.create_or_load::<SourceTimestamp, AssignedTimestamp>(&persist_bindings_name);
 
     let (data_write, data_read) = persist_client
-        .create_or_load::<Result<Row, DecodeError>, Result<Row, DecodeError>>(&persist_data_name)?;
+        .create_or_load::<Result<Row, DecodeError>, Result<Row, DecodeError>>(&persist_data_name);
 
     use persist::indexed::runtime::sealed_ts;
     let bindings_seal_ts = sealed_ts(&bindings_read)?;

--- a/src/persist/benches/end_to_end.rs
+++ b/src/persist/benches/end_to_end.rs
@@ -64,9 +64,7 @@ fn write_and_bench_read<M: Measurement>(
     let collection_name = "4b_keys".to_string();
     let mut runtime = create_runtime(temp_dir.path(), &nonce).expect("missing runtime");
 
-    let (mut write, _read) = runtime
-        .create_or_load(&collection_name)
-        .expect("could not create persistent collection");
+    let (mut write, _read) = runtime.create_or_load(&collection_name);
 
     let expected_frontier = write_test_data(
         data_size_mb,
@@ -108,9 +106,7 @@ fn bench_read_persisted_source<M: Measurement>(
             let mut runtime =
                 create_runtime(&persistence_base_path, &nonce).expect("missing runtime");
 
-            let read = runtime
-                .create_or_load::<Vec<u8>, Vec<u8>>(&collection_id)
-                .map(|(_write, read)| read);
+            let (_write, read) = runtime.create_or_load::<Vec<u8>, Vec<u8>>(&collection_id);
 
             let mut probe = ProbeHandle::new();
 

--- a/src/persist/benches/snapshot.rs
+++ b/src/persist/benches/snapshot.rs
@@ -53,7 +53,7 @@ where
         .collect();
 
     let mut runtime = new_fn(1).expect("creating index cannot fail");
-    let (write, read) = runtime.create_or_load("0").expect("registration succeeds");
+    let (write, read) = runtime.create_or_load("0");
 
     // Write the data out to the index's unsealed.
     write

--- a/src/persist/examples/kafka_upsert.rs
+++ b/src/persist/examples/kafka_upsert.rs
@@ -108,9 +108,8 @@ where
     S: Source + 'static,
 {
     let (ts_write, ts_read) = persist
-        .create_or_load::<S::SourceTimestamp, AssignedTimestamp>(&format!("{}_ts", name_base))?;
-    let (out_write, out_read) =
-        persist.create_or_load::<S::K, S::V>(&format!("{}_out", name_base))?;
+        .create_or_load::<S::SourceTimestamp, AssignedTimestamp>(&format!("{}_ts", name_base));
+    let (out_write, out_read) = persist.create_or_load::<S::K, S::V>(&format!("{}_out", name_base));
 
     // TODO: I think we need to synchronize the sources on what they think
     // current "system time" is. Otherwise, the timestamps that we seal up to

--- a/src/persist/src/golden_test.rs
+++ b/src/persist/src/golden_test.rs
@@ -235,7 +235,7 @@ impl PersistState {
         // of a RuntimeClient, so hardcode the ones nemesis uses.
         let mut streams = Vec::new();
         for name in ('a'..='e').map(|x| x.to_string()) {
-            let (_, read) = persist.create_or_load(&name)?;
+            let (_, read) = persist.create_or_load(&name);
             let snap = read.snapshot()?;
             let (seal, since) = (snap.get_seal(), snap.since());
             let mut snap_data = snap.into_iter().collect::<Result<Vec<_>, Error>>()?;

--- a/src/persist/src/nemesis/direct.rs
+++ b/src/persist/src/nemesis/direct.rs
@@ -154,7 +154,7 @@ impl DirectCore {
                 Ok(ingest.clone())
             }
             Entry::Vacant(x) => {
-                let (write, read) = self.runtime.create_or_load(name)?;
+                let (write, read) = self.runtime.create_or_load(name);
                 let dataflow_read = read.clone();
                 let (output_tx, output_rx) = mpsc::channel();
                 let output_tx = Arc::new(Mutex::new(output_tx));
@@ -171,7 +171,7 @@ impl DirectCore {
                                 .lock()
                                 .expect("clone doesn't panic and poison lock")
                                 .clone();
-                            let data = scope.persisted_source(Ok(dataflow_read));
+                            let data = scope.persisted_source(dataflow_read);
                             data.probe_with(&mut probe).capture_into(output_tx);
                         });
                         while worker.step_or_park(None) {
@@ -483,7 +483,7 @@ impl DirectWorker {
         let mut updates = Vec::new();
         for req in req.writes {
             let stream = self.stream(&req.stream)?;
-            updates.push((stream.write.stream_id(), vec![req.update]));
+            updates.push((stream.write.stream_id()?, vec![req.update]));
             write_handles.push(stream.write.clone());
         }
         let write_handles = write_handles.iter().collect::<Vec<_>>();

--- a/src/persist/src/operators/input.rs
+++ b/src/persist/src/operators/input.rs
@@ -158,7 +158,7 @@ mod tests {
 
         timely::execute_directly(move |worker| {
             let (mut handle, cap) = worker.dataflow(|scope| {
-                let token = p.create_or_load("1").unwrap();
+                let token = p.create_or_load("1");
                 let (input, _, _) = scope.new_persistent_unordered_input(token);
                 input
             });
@@ -177,7 +177,7 @@ mod tests {
         let p = registry.runtime_no_reentrance()?;
         let recv = timely::execute_directly(move |worker| {
             let ((mut handle, cap), recv) = worker.dataflow(|scope| {
-                let token = p.create_or_load("1").unwrap();
+                let token = p.create_or_load("1");
                 let (input, ok_stream, _) = scope.new_persistent_unordered_input(token);
                 // Send the data to be captured by a channel so that we can replay
                 // its contents outside of the dataflow and verify they are correct
@@ -214,7 +214,7 @@ mod tests {
         // Write some data using 3 workers.
         timely::execute(Config::process(3), move |worker| {
             worker.dataflow(|scope| {
-                let token = p.create_or_load("multiple_workers").unwrap();
+                let token = p.create_or_load("multiple_workers");
                 let ((mut handle, cap), _, _) = scope.new_persistent_unordered_input(token);
                 // Write one thing from each worker.
                 handle
@@ -233,7 +233,7 @@ mod tests {
         let tx = Arc::new(Mutex::new(tx));
         timely::execute(Config::process(2), move |worker| {
             worker.dataflow(|scope| {
-                let token = p.create_or_load("multiple_workers").unwrap();
+                let token = p.create_or_load("multiple_workers");
                 let (_, ok_stream, _) = scope.new_persistent_unordered_input(token);
                 // Send the data to be captured by a channel so that we can replay
                 // its contents outside of the dataflow and verify they are correct
@@ -262,7 +262,7 @@ mod tests {
     #[test]
     fn error_stream() -> Result<(), Error> {
         let mut p = MemRegistry::new().runtime_no_reentrance()?;
-        let token = p.create_or_load::<(), ()>("error_stream").unwrap();
+        let token = p.create_or_load::<(), ()>("error_stream");
         p.stop()?;
 
         let recv = timely::execute_directly(move |worker| {

--- a/src/persist/src/operators/stream.rs
+++ b/src/persist/src/operators/stream.rs
@@ -876,7 +876,7 @@ mod tests {
         let p = registry.runtime_no_reentrance()?;
         timely::execute_directly(move |worker| {
             let (mut input, probe) = worker.dataflow(|scope| {
-                let (write, _read) = p.create_or_load("1").unwrap();
+                let (write, _read) = p.create_or_load("1");
                 let mut input = Handle::new();
                 let (ok_stream, _) = input.to_stream(scope).persist("test", write);
                 let probe = ok_stream.probe();
@@ -900,7 +900,7 @@ mod tests {
         ];
 
         let p = registry.runtime_no_reentrance()?;
-        let (_write, read) = p.create_or_load("1")?;
+        let (_write, read) = p.create_or_load("1");
         assert_eq!(read.snapshot()?.read_to_end()?, expected);
 
         Ok(())
@@ -909,7 +909,7 @@ mod tests {
     #[test]
     fn persist_error_stream() -> Result<(), Error> {
         let mut p = MemRegistry::new().runtime_no_reentrance()?;
-        let (write, _read) = p.create_or_load::<(), ()>("error_stream").unwrap();
+        let (write, _read) = p.create_or_load::<(), ()>("error_stream");
         p.stop()?;
 
         let recv = timely::execute_directly(move |worker| {
@@ -954,7 +954,7 @@ mod tests {
 
         timely::execute_directly(move |worker| {
             let (mut input, probe) = worker.dataflow(|scope| {
-                let (write, _read) = p.create_or_load::<(), ()>("1").unwrap();
+                let (write, _read) = p.create_or_load::<(), ()>("1");
                 let mut input = Handle::new();
                 let (ok_stream, _) = input.to_stream(scope).seal("test", write);
                 let probe = ok_stream.probe();
@@ -968,7 +968,7 @@ mod tests {
         });
 
         let p = registry.runtime_no_reentrance()?;
-        let (_write, read) = p.create_or_load::<(), ()>("1")?;
+        let (_write, read) = p.create_or_load::<(), ()>("1");
         assert_eq!(read.snapshot()?.get_seal(), Antichain::from_elem(42));
 
         Ok(())
@@ -977,7 +977,7 @@ mod tests {
     #[test]
     fn seal_error_stream() -> Result<(), Error> {
         let mut p = MemRegistry::new().runtime_no_reentrance()?;
-        let (write, _read) = p.create_or_load::<(), ()>("error_stream").unwrap();
+        let (write, _read) = p.create_or_load::<(), ()>("error_stream");
         p.stop()?;
 
         let recv = timely::execute_directly(move |worker| {
@@ -1019,8 +1019,8 @@ mod tests {
 
         // Setup listens for both collections and record seal events. Afterwards, we will verify
         // that we get the expected seals, in the right order.
-        let (_write, primary_read) = p.create_or_load::<(), ()>("primary").unwrap();
-        let (_write, condition_read) = p.create_or_load::<(), ()>("condition").unwrap();
+        let (_write, primary_read) = p.create_or_load::<(), ()>("primary");
+        let (_write, condition_read) = p.create_or_load::<(), ()>("condition");
 
         #[derive(Debug, PartialEq, Eq)]
         enum Sealed {
@@ -1056,8 +1056,8 @@ mod tests {
 
         timely::execute_directly(move |worker| {
             let (mut primary_input, mut condition_input, seal_probe) = worker.dataflow(|scope| {
-                let (primary_write, _read) = p.create_or_load::<(), ()>("primary").unwrap();
-                let (condition_write, _read) = p.create_or_load::<(), ()>("condition").unwrap();
+                let (primary_write, _read) = p.create_or_load::<(), ()>("primary");
+                let (condition_write, _read) = p.create_or_load::<(), ()>("condition");
                 let mut primary_input: Handle<u64, ((), u64, isize)> = Handle::new();
                 let mut condition_input = Handle::new();
                 let primary_stream = primary_input.to_stream(scope);
@@ -1138,8 +1138,8 @@ mod tests {
 
         timely::execute_directly(move |worker| {
             let (mut primary_input, mut condition_input, seal_probe) = worker.dataflow(|scope| {
-                let (primary_write, _read) = p.create_or_load::<(), ()>("primary").unwrap();
-                let (condition_write, _read) = p.create_or_load::<(), ()>("condition").unwrap();
+                let (primary_write, _read) = p.create_or_load::<(), ()>("primary");
+                let (condition_write, _read) = p.create_or_load::<(), ()>("condition");
                 let mut primary_input: Handle<u64, ((), u64, isize)> = Handle::new();
                 let mut condition_input = Handle::new();
                 let primary_stream = primary_input.to_stream(scope);
@@ -1201,8 +1201,8 @@ mod tests {
 
         let guards = timely::execute(Config::process(3), move |worker| {
             let (mut primary_input, mut condition_input, seal_probe) = worker.dataflow(|scope| {
-                let (primary_write, _read) = p.create_or_load::<(), ()>("primary").unwrap();
-                let (condition_write, _read) = p.create_or_load::<(), ()>("condition").unwrap();
+                let (primary_write, _read) = p.create_or_load::<(), ()>("primary");
+                let (condition_write, _read) = p.create_or_load::<(), ()>("condition");
                 let mut primary_input: Handle<u64, ((), u64, isize)> = Handle::new();
                 let mut condition_input: Handle<u64, ((), u64, isize)> = Handle::new();
                 let primary_stream = primary_input.to_stream(scope);


### PR DESCRIPTION
We now keep the error that create_or_load() would return internally in
`StreamWriteHandle`/`StreamReadHandle` and raise it when their methods
are called. This delays surfacing the error to the first time one of the
methods are called.

We need this in order to make dataflow graph construction deterministic
for Tables and persisted Sources. Currently, the graph shape differs
depending on wether this call succeeds or not, so it can happen that one
worker creates a graph shape that is different from the others, which...
big no-no for timely dataflow. With this change, we are not completely
there yet because we also need to move getting the upper seal timestamp
out of graph construction. It is a necessary first step, though.

The thing this changes on the interfaces is that `create_or_load()` is
now infallible while `stream_id()` becomes fallible because we only have
a stream id when initialization of the handle succeeds. Method
`stream_name()` is still infallible, though I could change that to be
fallible as well.

### Tips for reviewer

This mostly just simplifies things, a few `expect()`s and `?`s are removed. A required change in the coordinator is that we now get the `stream_id` on creation time of `PersistDetails` because we can't get it later. (I left a comment about this right where it happens.)

I sprinkled some `TODO`s in there with questions for reviewers.

I also left a `TODO` in there about how I'm handling the `Result<Id, Error>`. It seems a bit icky and I could do something more involved, a la

```rust
struct StreamWriteHandle {
    inner_handle: InnerStreamWriteHandle
}

enum InnerStreamWriteHandle {
    Failed(err),
    Handle(TheRealStreamWriteHandle),
}
```

And then all the methods would become roughly

```rust
fn frombulate(&mut self, the_thing: String) -> Result {
     let real_handle = self.ensure_handle()?
     real_handle.frombulate(the_thing)
}
```

or

```rust
fn frombulate(&mut self, the_thing) -> PFuture {
    let (tx, rx) = PFuture::new();

    match self.inner_handle {
        Handle(handle) => {
            handle.frombulate(tx, the_thing)  
        }
        Failed(ref e) => {
            tx.fill(Err(e.clone()));
        }
    }

    rx
}
```


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
