### PR TITLE
mzbuild: update dependency on ci/builder

### DIFF
--- a/bin/lint
+++ b/bin/lint
@@ -53,7 +53,7 @@ copyright_files=$(grep -vE \
     -e '(^|/)requirements.*\.txt$' \
     -e '\.(md|json|asc|png|jpe?g|svg|avro|avsc|pb|ico|html|so)$' \
     -e '^doc/user/.*(\.scss|\.bnf|\.toml|\.yml)$' \
-    -e '^ci/builder/(ssh_known_hosts|stable.stamp|nightly.stamp|crosstool-.+\.defconfig)$' \
+    -e '^ci/builder/(ssh_known_hosts|crosstool-.+\.defconfig)$' \
     -e '^ci/www/public/_redirects$' \
     -e 'demo/chbench/chbench' \
     -e 'src/pid-file/libbsd' \

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -193,8 +193,7 @@ class CargoPreImage(PreImage):
 
     def inputs(self) -> Set[str]:
         return {
-            "ci/builder/stable.stamp",
-            "ci/builder/nightly.stamp",
+            "ci/builder",
             "Cargo.toml",
             # TODO(benesch): we could in theory fingerprint only the subset of
             # Cargo.lock that applies to the crates at hand, but that is a


### PR DESCRIPTION
The stamp files no longer exist. Instead the contents of the ci/builder
directory are fingerprinted by bin/ci-builder to determine what version
of the ci-builder to use. This should fix a bug in the test mkpipeline
script that was causing pipeline trimming to fail.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
