### PR TITLE
test/redpanda: Update Redpanda to v21.11.1

### DIFF
--- a/misc/python/materialize/mzcompose.py
+++ b/misc/python/materialize/mzcompose.py
@@ -897,7 +897,7 @@ class Redpanda(PythonService):
     def __init__(
         self,
         name: str = "redpanda",
-        version: str = "v21.11.1-beta1",
+        version: str = "v21.11.1",
         image: Optional[str] = None,
         aliases: Optional[List[str]] = None,
         ports: Optional[List[int]] = None,


### PR DESCRIPTION
Update Redpanda from v21.11.1-beta1 to v21.11.1

### Motivation

* Redpanda [v21.11.1](https://github.com/vectorizedio/redpanda/releases/tag/v21.11.1) has been released

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
