### PR TITLE
ci/builder: auto-rebuild when python dependencies change

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -70,7 +70,6 @@ gid=$(id -g)
 [[ "$gid" -lt 500 ]] && gid=$uid
 
 build() {
-    cp misc/python/requirements{,-dev}.txt ci/builder
     docker build --pull \
         --build-arg "ARCH_GCC=$arch_gcc" \
         --build-arg "ARCH_GO=$arch_go" \

--- a/ci/builder/.gitignore
+++ b/ci/builder/.gitignore
@@ -1,4 +1,1 @@
-/requirements.txt
-/requirements-dev.txt
-/requirements-ci.txt
 /*.cidfile

--- a/ci/builder/requirements-dev.txt
+++ b/ci/builder/requirements-dev.txt
@@ -1,0 +1,1 @@
+../../misc/python/requirements-dev.txt

--- a/ci/builder/requirements.txt
+++ b/ci/builder/requirements.txt
@@ -1,0 +1,1 @@
+../../misc/python/requirements.txt


### PR DESCRIPTION
This requires using symlinks to get the requirements.txt into the
builder's Docker context, rather than copying them in.

### Motivation

  * This PR fixes a previously unreported bug, in which changing the requirements.txt files in misc/python did not cause the ci-builder to get rebuilt.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
