### PR TITLE
sql: add support for `pg_type_is_visible`

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -103,7 +103,7 @@ List new features before bug fixes.
 
 {{% version-header v0.12.0 %}}
 
-- No changes yet.
+- Added the `pg_type_is_visible` [compatibility function](/sql/functions#postgresql-compatibility-func).
 
 {{% version-header v0.11.0 %}}
 

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -586,6 +586,8 @@
     description: Returns the number of bytes used to store any individual data value.
   - signature: 'pg_table_is_visible(relation: oid) -> boolean'
     description: Reports whether the relation with the specified OID is visible in the search path.
+  - signature: 'pg_type_is_visible(relation: oid) -> boolean'
+    description: Reports whether the type with the specified OID is visible in the search path.
   - signature: 'pg_typeof(expr: any) -> text'
     description: Returns the type of its input argument as a string.
   - signature: 'pg_encoding_to_char(encoding_id: integer) -> text'

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1638,6 +1638,13 @@ lazy_static! {
                      WHERE o.oid = $1)"
                 ), 2079;
             },
+            "pg_type_is_visible" => Scalar {
+                params!(Oid) => sql_impl_func(
+                    "(SELECT s.name = ANY(current_schemas(true))
+                     FROM mz_catalog.mz_types t JOIN mz_catalog.mz_schemas s ON t.schema_id = s.id
+                     WHERE t.oid = $1)"
+                ), 2080;
+            },
             "pg_typeof" => Scalar {
                 params!(Any) => Operation::new(|ecx, spec, exprs, params, _order_by| {
                     // pg_typeof reports the type *before* coercion.

--- a/test/testdrive/types.td
+++ b/test/testdrive/types.td
@@ -284,3 +284,24 @@ other_int_map_c     user
 > CREATE TYPE jsonb_array_list_c AS LIST (element_type=_jsonb);
 > CREATE TABLE jsonb_array_list_t (a jsonb_array_list_c);
 > INSERT INTO jsonb_array_list_t VALUES (LIST[ARRAY['{"1":2}'::jsonb]]);
+
+# Test pg_table_is_visible.
+
+> SELECT PG_TYPE_IS_VISIBLE('bool'::REGTYPE::OID);
+pg_type_is_visible
+--------------------
+true
+
+> CREATE SCHEMA hidden_schema;
+> CREATE TYPE hidden_schema.my_hidden_type AS LIST (element_type = int4);
+> CREATE TYPE my_type AS LIST (element_type = int4);
+
+> SELECT PG_TYPE_IS_VISIBLE(oid::REGTYPE) FROM mz_catalog.mz_types WHERE name='my_hidden_type';
+pg_type_is_visible
+--------------------
+false
+
+> SELECT PG_TYPE_IS_VISIBLE(oid::REGTYPE) FROM mz_catalog.mz_types WHERE name='my_type';
+pg_type_is_visible
+--------------------
+true


### PR DESCRIPTION
Add support for `pg_type_is_visible` which reports whether the type with the specified OID is visible in the search path.

### Motivation
Required for BI tooling.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
