### PR TITLE
persist,table: refactor Tables and SourceDesc to make clear what the persisted_name does

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -54,7 +54,9 @@ use crate::catalog::builtin::{
     Builtin, BUILTINS, BUILTIN_ROLES, INFORMATION_SCHEMA, MZ_CATALOG_SCHEMA, MZ_INTERNAL_SCHEMA,
     MZ_TEMP_SCHEMA, PG_CATALOG_SCHEMA,
 };
-use crate::persistcfg::{PersistConfig, PersistDetails, PersistMultiDetails, PersisterWithConfig};
+use crate::persistcfg::{
+    PersistConfig, PersisterWithConfig, TablePersistDetails, TablePersistMultiDetails,
+};
 use crate::session::{PreparedStatement, Session};
 use crate::CoordError;
 
@@ -368,7 +370,7 @@ struct CatalogEntryMap {
     /// currently being persisted (i.e it matches the output of
     /// self.generate_persist_multi_details() and is updated whenever the set of
     /// persisted tables changes).
-    persist_multi_details: Option<PersistMultiDetails>,
+    persist_multi_details: Option<TablePersistMultiDetails>,
 }
 
 impl std::ops::Deref for CatalogEntryMap {
@@ -408,7 +410,7 @@ impl CatalogEntryMap {
         ret
     }
 
-    fn generate_persist_multi_details(&self) -> Option<PersistMultiDetails> {
+    fn generate_persist_multi_details(&self) -> Option<TablePersistMultiDetails> {
         let mut all_table_ids = Vec::new();
         let mut handles = Vec::new();
         for (_, entry) in self.by_id.iter() {
@@ -425,13 +427,13 @@ impl CatalogEntryMap {
         }
         MultiWriteHandle::new(&handles)
             .ok()
-            .map(|write_handle| PersistMultiDetails {
+            .map(|write_handle| TablePersistMultiDetails {
                 all_table_ids,
                 write_handle,
             })
     }
 
-    pub fn persist_multi_details(&self) -> Option<&PersistMultiDetails> {
+    pub fn persist_multi_details(&self) -> Option<&TablePersistMultiDetails> {
         // Verify the persist_multi_details invariant.
         debug_assert_eq!(
             &self.persist_multi_details,
@@ -512,7 +514,7 @@ pub struct Table {
     pub defaults: Vec<Expr<Raw>>,
     pub conn_id: Option<u32>,
     pub depends_on: Vec<GlobalId>,
-    pub persist: Option<PersistDetails>,
+    pub persist: Option<TablePersistDetails>,
 }
 
 impl Table {
@@ -2214,7 +2216,7 @@ impl Catalog {
         let plan = sql::plan::plan(pcx, &self.for_system_session(), stmt, &Params::empty())?;
         Ok(match plan {
             Plan::CreateTable(CreateTablePlan { table, .. }) => {
-                let persist = self.persist.details_from_name(persist_name)?;
+                let persist = self.persist.table_details_from_name(persist_name)?;
                 CatalogItem::Table(Table {
                     create_sql: table.create_sql,
                     desc: table.desc,
@@ -2425,11 +2427,11 @@ impl Catalog {
         &self,
         id: GlobalId,
         name: &FullName,
-    ) -> Result<Option<PersistDetails>, PersistError> {
-        self.persist.details(id, &name.to_string())
+    ) -> Result<Option<TablePersistDetails>, PersistError> {
+        self.persist.table_details(id, &name.to_string())
     }
 
-    pub fn persist_multi_details(&self) -> Option<&PersistMultiDetails> {
+    pub fn persist_multi_details(&self) -> Option<&TablePersistMultiDetails> {
         self.state.by_id.persist_multi_details()
     }
 

--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -952,6 +952,7 @@ impl Catalog {
                             optimized_expr,
                             connector: dataflow_types::SourceConnector::Local {
                                 timeline: Timeline::EpochMilliseconds,
+                                persisted_name: None,
                             },
                             bare_desc: log.variant.desc(),
                             desc: log.variant.desc(),

--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -105,13 +105,14 @@ impl<'a> DataflowBuilder<'a> {
                                 name: entry.name().to_string(),
                                 connector: SourceConnector::Local {
                                     timeline: table.timeline(),
+                                    persisted_name: table
+                                        .persist
+                                        .as_ref()
+                                        .map(|p| p.stream_name.clone()),
                                 },
                                 operators: None,
                                 bare_desc: table.desc.clone(),
-                                persisted_name: table
-                                    .persist
-                                    .as_ref()
-                                    .map(|p| p.stream_name.clone()),
+                                persisted_name: None,
                             },
                             *id,
                         );

--- a/src/coord/src/persistcfg.rs
+++ b/src/coord/src/persistcfg.rs
@@ -197,14 +197,18 @@ impl PersisterWithConfig {
         }
     }
 
-    pub fn details(&self, id: GlobalId, pretty: &str) -> Result<Option<PersistDetails>, Error> {
-        self.details_from_name(self.stream_name(id, pretty))
+    pub fn table_details(
+        &self,
+        id: GlobalId,
+        pretty: &str,
+    ) -> Result<Option<TablePersistDetails>, Error> {
+        self.table_details_from_name(self.stream_name(id, pretty))
     }
 
-    pub fn details_from_name(
+    pub fn table_details_from_name(
         &self,
         stream_name: Option<String>,
-    ) -> Result<Option<PersistDetails>, Error> {
+    ) -> Result<Option<TablePersistDetails>, Error> {
         let stream_name = match stream_name {
             Some(x) => x,
             None => return Ok(None),
@@ -214,7 +218,7 @@ impl PersisterWithConfig {
             None => return Ok(None),
         };
         let (write_handle, _) = persister.create_or_load(&stream_name);
-        Ok(Some(PersistDetails {
+        Ok(Some(TablePersistDetails {
             stream_name,
             // We need to get the stream_id now because we cannot get it later since most methods
             // in the coordinator/catalog aren't fallible.
@@ -246,7 +250,7 @@ impl PersisterWithConfig {
 }
 
 #[derive(Debug, Clone, Serialize)]
-pub struct PersistDetails {
+pub struct TablePersistDetails {
     pub stream_name: String,
     pub stream_id: PersistId,
     #[serde(skip)]
@@ -254,7 +258,7 @@ pub struct PersistDetails {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PersistMultiDetails {
+pub struct TablePersistMultiDetails {
     pub all_table_ids: Vec<PersistId>,
     pub write_handle: MultiWriteHandle<Row, ()>,
 }

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -735,8 +735,27 @@ pub enum SourceConnector {
         ts_frequency: Duration,
         timeline: Timeline,
     },
+
+    /// A local "source" is either fed by a local input handle, or by reading from a
+    /// `persisted_source()`. For non-persisted sources, values that are to be inserted
+    /// are sent from the coordinator and pushed into the handle on a worker.
+    ///
+    /// For persisted sources, the coordinator only writes new values to a persistent
+    /// stream. These values will then "show up" here because we read from the same
+    /// persistent stream.
+    // TODO: We could split this up into a `Local` source, that is only fed by a local handle and a
+    // `LocalPersistenceSource` which is fed from a `persisted_source()`. But moving the
+    // persist_name from `SourceDesc` to here is already a huge simplification/clarification. The
+    // persist description on a `SourceDesc` is now purely used to signal that a source actively
+    // persists, while a `LocalPersistenceSource` is a source that happens to read from persistence
+    // but doesn't persist itself.
+    //
+    // That additional split seems like a bigger undertaking, though, because it also needs changes
+    // to the coordinator. And I don't know if I want to invest too much time there when I don't
+    // yet know how Tables will work in a post-ingestd world.
     Local {
         timeline: Timeline,
+        persisted_name: Option<String>,
     },
 }
 

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -101,41 +101,50 @@ where
         match src.connector.clone() {
             // Create a new local input (exposed as TABLEs to users). Data is inserted
             // via Command::Insert commands.
-            SourceConnector::Local { .. } => {
+            SourceConnector::Local { persisted_name, .. } => {
                 let ((handle, capability), ok_stream, err_collection) = {
                     let ((handle, capability), ok_stream) = scope.new_unordered_input();
                     let err_collection = Collection::empty(scope);
                     ((handle, capability), ok_stream, err_collection)
                 };
 
-                let (ok_stream, err_collection) =
-                    match (&mut render_state.persist, src.persisted_name) {
-                        (Some(persist), Some(stream_name)) => {
-                            let (_write, read) = persist.create_or_load(&stream_name);
-                            let (persist_ok_stream, persist_err_stream) =
-                                scope.persisted_source(read).ok_err(|x| match x {
-                                    (Ok(kv), ts, diff) => Ok((kv, ts, diff)),
-                                    (Err(err), ts, diff) => Err((err, ts, diff)),
-                                });
-                            let (persist_ok_stream, decode_err_stream) = persist_ok_stream
-                                .ok_err(|((row, ()), ts, diff)| Ok((row, ts, diff)));
-                            let persist_err_collection = persist_err_stream
-                                .concat(&decode_err_stream)
-                                .map(move |(err, ts, diff)| {
-                                    let err = SourceError::new(
-                                        stream_name.clone(),
-                                        SourceErrorDetails::Persistence(err),
-                                    );
-                                    (err.into(), ts, diff)
-                                })
-                                .as_collection();
-                            (
-                                ok_stream.concat(&persist_ok_stream),
-                                err_collection.concat(&persist_err_collection),
-                            )
-                        }
-                        _ => (ok_stream, err_collection),
-                    };
+                // A local "source" is either fed by a local input handle, or by reading from a
+                // `persisted_source()`.
+                //
+                // For non-persisted sources, values that are to be inserted are sent from the
+                // coordinator and pushed into the handle.
+                //
+                // For persisted sources, the coordinator only writes new values to a persistent
+                // stream. These values will then "show up" here because we read from the same
+                // persistent stream.
+                let (ok_stream, err_collection) = match (&mut render_state.persist, persisted_name)
+                {
+                    (Some(persist), Some(stream_name)) => {
+                        let (_write, read) = persist.create_or_load(&stream_name);
+                        let (persist_ok_stream, persist_err_stream) =
+                            scope.persisted_source(read).ok_err(|x| match x {
+                                (Ok(kv), ts, diff) => Ok((kv, ts, diff)),
+                                (Err(err), ts, diff) => Err((err, ts, diff)),
+                            });
+                        let (persist_ok_stream, decode_err_stream) =
+                            persist_ok_stream.ok_err(|((row, ()), ts, diff)| Ok((row, ts, diff)));
+                        let persist_err_collection = persist_err_stream
+                            .concat(&decode_err_stream)
+                            .map(move |(err, ts, diff)| {
+                                let err = SourceError::new(
+                                    stream_name.clone(),
+                                    SourceErrorDetails::Persistence(err),
+                                );
+                                (err.into(), ts, diff)
+                            })
+                            .as_collection();
+                        (
+                            ok_stream.concat(&persist_ok_stream),
+                            err_collection.concat(&persist_err_collection),
+                        )
+                    }
+                    _ => (ok_stream, err_collection),
+                };
 
                 render_state
                     .local_inputs


### PR DESCRIPTION
Before, the `persist_name` on SourceDesc was serving two purposes: 1) to
signal that a source actively persists, and 2) to mark a Table as a
persistent table that gets its data by creating a `persisted_source()`
with the given `persist_name`.

Now we clearly separate the two and move the `persist_name` into
`SourceConnector::Local`. It becomes a property of the local source
instead of the descriptor around it.

This will help with future refactoring that change the shape of the
persistence information that we ship with `SourceDesc`.

### Tips for reviewer

I left notes and a potential future `TODO` in the code.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
