### PR TITLE
sql: refactor USING constraint planning

### DIFF
--- a/doc/user/content/known-limitations.md
+++ b/doc/user/content/known-limitations.md
@@ -36,6 +36,11 @@ us know on the linked-to GitHub issue.
   gh 4867 %}}
 - `WITH RECURSIVE` CTEs are not available yet. {{% gh 2516 %}}
 
+### Joins
+
+- The combining `JOIN` type must be `INNER` or `LEFT` for `LATERAL` references.
+- Nested joins do not support `LATERAL` references.
+
 ### `COPY FROM`
 
 - CSV-formatted data does not strictly adhere to Postgres' semantics.

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -123,6 +123,10 @@ for SQL statements.
 - Fix a bug that returned incorrect results when filtering on _NULL_ values from
   columns joined with `USING` constraints. {{% gh 7618 %}}
 
+- Execute comma-separated joins more like PostgreSQL by treating them as nested
+  cross joins where possible. (Nested joins are currently incompatible wih
+  `LATERAL` joins.)
+
 {{% version-header v0.11.0 %}}
 
 - **Breaking change.** Remove the `mz_workers` function {{% gh 9363 %}}.

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -120,6 +120,9 @@ for SQL statements.
 - Support `generate_subscripts` for `arrays` which will generate a series comprising
   the valid subscripts of the selected dimension of the given array.
 
+- Fix a bug that returned incorrect results when filtering on _NULL_ values from
+  columns joined with `USING` constraints. {{% gh 7618 %}}
+
 {{% version-header v0.11.0 %}}
 
 - **Breaking change.** Remove the `mz_workers` function {{% gh 9363 %}}.

--- a/test/sqllogictest/cockroach/apply_join.slt
+++ b/test/sqllogictest/cockroach/apply_join.slt
@@ -82,7 +82,7 @@ INSERT INTO table9 VALUES (
   '2020-05-26 14:23:36.157383-04'
 )
 
-query error full/right outer joins in comma join not yet supported, see https://github.com/MaterializeInc/materialize/issues/6875 for more details
+query T
 SELECT
   true
 FROM
@@ -127,6 +127,8 @@ WHERE
     )
 LIMIT
     89;
+----
+true
 
 # Regression test for #37454: untyped null produced at top level.
 

--- a/test/sqllogictest/column_knowledge.slt
+++ b/test/sqllogictest/column_knowledge.slt
@@ -453,47 +453,40 @@ EXPLAIN SELECT * FROM t4 AS a1 LEFT JOIN t4 AS a2 USING (f1, f2) WHERE a1.f1 = 1
 EOF
 
 #
-# Impossible conditions after propagation are currently not detected as such
+# Detect impossible conditions
 #
 
 query T multiline
 EXPLAIN SELECT * FROM t1 LEFT JOIN t2 USING (f1) WHERE t1.f1 = 123 AND t2.f1 = 234;
 ----
-%0 = Let l0 =
+%0 =
+| Constant
+
+EOF
+
+#
+# Not all impossible conditions after propagation are currently not detected as such
+#
+
+query T multiline
+EXPLAIN SELECT * FROM t1 FULL OUTER JOIN t2 USING (f1) WHERE t1.f1 = 123 AND t2.f1 = 234;
+----
+%0 =
 | Get materialize.public.t1 (u1)
 | Filter (#0 = 123), (#0 = 234)
-
-%1 =
-| Get %0 (l0)
+| Project (#1)
 | ArrangeBy ()
 
-%2 =
+%1 =
 | Get materialize.public.t2 (u3)
 | Filter (#0 = 123), (#0 = 234)
 | Project (#1)
 
-%3 = Let l1 =
-| Join %1 %2
-| | implementation = Differential %2 %1.()
-
-%4 =
-| Get %3 (l1)
-| Project (#1)
-| Negate
+%2 =
+| Join %0 %1
+| | implementation = Differential %1 %0.()
 | Map 123
-| Project (#1, #0)
-
-%5 =
-| Get %0 (l0)
-| Map 123
-| Project (#2, #1)
-
-%6 =
-| Union %4 %5
-| Map null
-
-%7 =
-| Union %3 %6
+| Project (#2, #0, #1)
 
 EOF
 

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -596,8 +596,7 @@ EXPLAIN RAW PLAN FOR SELECT la, l.lb, big_l.lb FROM l JOIN big_l USING (la)
 
 %2 =
 | InnerJoin %0 %1 on (true && (i32toi64(#0) = #2))
-| Map coalesce(i32toi64(#0), #2)
-| Project (#4, #1, #3)
+| Project (#0, #1, #3)
 
 EOF
 
@@ -692,3 +691,297 @@ SELECT lb, rb FROM l3 INNER JOIN r3 ON (la IS NULL AND ra IS NULL) OR la = ra
 l1  r1
 l3  r3
 l4  r5
+
+# Regression test for https://github.com/MaterializeInc/materialize/issues/7618
+
+statement ok
+CREATE TABLE t1 (f1 int, f2 int);
+
+statement ok
+CREATE TABLE t2 (f1 int, f2 int);
+
+statement ok
+CREATE TABLE t3 (f1 int, f3 int);
+
+statement ok
+CREATE TABLE t4 (f3 int, f4 int);
+
+query T
+SELECT f1 FROM t1 JOIN t2 USING (f1);
+----
+
+query error column reference "f2" is ambiguous
+SELECT f1, f2 FROM t1 JOIN t2 USING (f1);
+
+query T
+SELECT f1, t1.f2 AS f1 FROM t1 JOIN t2 USING (f1);
+----
+
+query error column reference "f1" is ambiguous
+SELECT f1, t1.f2 AS f1 FROM t1 JOIN t2 USING (f1) ORDER BY f1;
+
+query error column reference "f2" is ambiguous
+SELECT * FROM t1 LEFT JOIN t2 USING (f1) RIGHT JOIN t3 USING (f2);
+
+statement ok
+INSERT INTO t1 VALUES
+    (1, 2),
+    (3, 4);
+
+query TTT
+SELECT *
+FROM t1
+    LEFT JOIN t2 USING (f1)
+ORDER BY f1;
+----
+1  2  NULL
+3  4  NULL
+
+query TTT
+SELECT *
+FROM t1
+    LEFT JOIN t2 USING (f1)
+WHERE t2.f1 IS NOT NULL
+ORDER BY f1;
+----
+
+statement ok
+INSERT INTO t2 VALUES
+    (3, 4),
+    (5, 6);
+
+statement ok
+INSERT INTO t3 VALUES
+    (3, 4),
+    (7, 8);
+
+statement ok
+INSERT INTO t4 VALUES
+    (4, 3),
+    (9, 10);
+
+# Left
+
+query TTTTTT
+SELECT *,
+    f1 IS NULL AS f1_null,
+    t1.f1 IS NULL AS t1_f1_null,
+    t2.f1 IS NULL AS t2_f1_null
+FROM t1
+    LEFT JOIN t2 USING (f1)
+ORDER BY f1;
+----
+1  2  NULL  false  false  true
+3  4  4  false  false  false
+
+
+query TTTTTT
+SELECT *,
+    f1 IS NULL AS f1_null,
+    t1.f1 IS NULL AS t1_f1_null,
+    t2.f1 IS NULL AS t2_f1_null
+FROM t2
+    LEFT JOIN t1 USING (f1)
+ORDER BY f1;
+----
+3  4  4  false  false  false
+5  6  NULL  false  true  false
+
+query TTTT
+SELECT *
+FROM t1
+    LEFT JOIN t2 USING (f1)
+    LEFT JOIN t3 USING (f1)
+ORDER BY f1;
+----
+1  2  NULL  NULL
+3  4  4  4
+
+# Right
+
+query TTTTTT
+SELECT *,
+    f1 IS NULL AS f1_null,
+    t1.f1 IS NULL AS t1_f1_null,
+    t2.f1 IS NULL AS t2_f1_null
+FROM t1
+    RIGHT JOIN t2 USING (f1)
+ORDER BY f1;
+----
+3  4  4  false  false  false
+5  NULL  6  false  true  false
+
+query TTTTTT
+SELECT *,
+    f1 IS NULL AS f1_null,
+    t1.f1 IS NULL AS t1_f1_null,
+    t2.f1 IS NULL AS t2_f1_null
+FROM t2
+    RIGHT JOIN t1
+    USING (f1)
+ORDER BY f1;
+----
+1  NULL  2  false  false  true
+3  4  4  false  false  false
+
+query TTTT
+SELECT *
+FROM t1
+    RIGHT JOIN t2 USING (f1)
+    RIGHT JOIN t3 USING (f1)
+ORDER BY f1;
+----
+3  4  4  4
+7  NULL  NULL  8
+
+query TTTT
+SELECT *
+FROM t1
+    RIGHT JOIN t2 USING (f1)
+    LEFT JOIN t3 USING (f1)
+ORDER BY f1;
+----
+3  4  4  4
+5  NULL  6  NULL
+
+query TTTT
+SELECT *
+FROM t1
+    LEFT JOIN t2 USING (f1)
+    RIGHT JOIN t3 USING (f1)
+ORDER BY f1;
+----
+3  4  4  4
+7  NULL  NULL  8
+
+# Inner
+
+query TTTTTT
+SELECT *,
+    f1 IS NULL AS f1_null,
+    t1.f1 IS NULL AS t1_f1_null,
+    t2.f1 IS NULL AS t2_f1_null
+FROM t1
+    INNER JOIN t2
+    USING (f1)
+ORDER BY f1;
+----
+3  4  4  false  false  false
+
+
+query TTTTTT
+SELECT *,
+    f1 IS NULL AS f1_null,
+    t1.f1 IS NULL AS t1_f1_null,
+    t2.f1 IS NULL AS t2_f1_null
+FROM t2
+    INNER JOIN t1
+    USING (f1)
+ORDER BY f1;
+----
+3  4  4  false  false  false
+
+query TTTT
+SELECT *
+FROM t1
+    INNER JOIN t2 USING (f1)
+    INNER JOIN t3 USING (f1)
+ORDER BY f1;
+----
+3  4  4  4
+
+# Full
+
+query TTTTTT
+SELECT *,
+    f1 IS NULL AS f1_null,
+    t1.f1 IS NULL AS t1_f1_null,
+    t2.f1 IS NULL AS t2_f1_null
+FROM t1
+    FULL OUTER JOIN t2
+    USING (f1)
+ORDER BY f1;
+----
+1  2  NULL  false  false  true
+3  4  4  false  false  false
+5  NULL  6  false  true  false
+
+query TTTTTT
+SELECT *,
+    f1 IS NULL AS f1_null,
+    t1.f1 IS NULL AS t1_f1_null,
+    t2.f1 IS NULL AS t2_f1_null
+FROM t2
+    INNER JOIN t1
+    USING (f1)
+ORDER BY f1;
+----
+3  4  4  false  false  false
+
+query TTTT
+SELECT *
+FROM t1
+    FULL OUTER JOIN t2 USING (f1)
+    FULL OUTER JOIN t3 USING (f1)
+ORDER BY f1;
+----
+1  2  NULL  NULL
+3  4  4  4
+5  NULL  6  NULL
+7  NULL  NULL  8
+
+# Most recent joined cols are always leftmost in return select
+
+query TTTTT colnames
+SELECT *
+    FROM t1
+    JOIN t2 USING (f1)
+    JOIN t3 USING (f1)
+    JOIN t4 USING (f3);
+----
+f3 f1 f2 f2 f4
+4  3  4  4  3
+
+# https://github.com/MaterializeInc/materialize/pull/9489#issuecomment-992186563
+# Ensure priority does not persist through joins
+query error column reference "f2" is ambiguous
+SELECT *, f2 IS NULL
+     FROM t1 AS t1
+     JOIN t1 AS t2 USING (f1, f2)
+     JOIN t1 AS t3 USING (f1);
+
+query error column reference "f2" is ambiguous
+SELECT *
+    FROM t1 AS t1
+    JOIN t1 AS t2 USING (f1, f2)
+    JOIN t1 AS t3 USING (f1)
+    JOIN t1 AS t4 USING (f2);
+
+# https://github.com/MaterializeInc/materialize/pull/9489#issuecomment-992195117
+# https://github.com/MaterializeInc/materialize/pull/9489#issuecomment-992207932
+# These are permitted by PG with a different order of precedence for comma joins
+# and explicit `CROSS JOIN`s. However:
+# - We treat comma joins as if they were explicit cross joins, which prevents
+#   this from working.
+# - Users can recover this behavior by explicitly introducing precedence with
+#   parens.
+
+query error column name "f2" is ambiguous
+SELECT *
+    FROM t2,
+    t2 AS x
+    JOIN t1
+    USING (f2);
+
+# However, we support this equivalent query
+query TTTTT
+SELECT *
+    FROM t2
+    CROSS JOIN (
+    t2 AS x
+        JOIN t1
+        USING (f2)
+    );
+----
+3  4  4  3  3
+5  6  4  3  3

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -958,22 +958,18 @@ SELECT *
     JOIN t1 AS t4 USING (f2);
 
 # https://github.com/MaterializeInc/materialize/pull/9489#issuecomment-992195117
-# https://github.com/MaterializeInc/materialize/pull/9489#issuecomment-992207932
-# These are permitted by PG with a different order of precedence for comma joins
-# and explicit `CROSS JOIN`s. However:
-# - We treat comma joins as if they were explicit cross joins, which prevents
-#   this from working.
-# - Users can recover this behavior by explicitly introducing precedence with
-#   parens.
-
-query error column name "f2" is ambiguous
+# Comma-joins of adjacent tables are equivalent to nested cross joins
+query TTTTT
 SELECT *
     FROM t2,
     t2 AS x
     JOIN t1
-    USING (f2);
+    USING (f2)
+ORDER BY 1;
+----
+3  4  4  3  3
+5  6  4  3  3
 
-# However, we support this equivalent query
 query TTTTT
 SELECT *
     FROM t2
@@ -981,7 +977,40 @@ SELECT *
     t2 AS x
         JOIN t1
         USING (f2)
-    );
+    )
+ORDER BY 1;
 ----
 3  4  4  3  3
 5  6  4  3  3
+
+# https://github.com/MaterializeInc/materialize/pull/9489#issuecomment-992207932
+statement ok
+DELETE FROM t1;
+
+statement ok
+DELETE FROM t2;
+
+statement ok
+INSERT INTO t1 VALUES
+    (NULL, 0),
+    (1, 1),
+    (1, 1),
+    (2, 2);
+
+statement ok
+INSERT INTO t2 VALUES
+    (NULL, 0),
+    (NULL, 0),
+    (1, 1);
+
+query II
+SELECT a3.f1,
+       a4.f1
+  FROM t2 AS a1
+  JOIN t1 AS a2 USING (f1), t2 AS a3
+  JOIN t1 AS a4 USING (f1);
+----
+1 1
+1 1
+1 1
+1 1

--- a/test/sqllogictest/outer_join.slt
+++ b/test/sqllogictest/outer_join.slt
@@ -27,13 +27,44 @@ INSERT INTO b VALUES (2);
 statement ok
 INSERT INTO c VALUES (3);
 
-query error full/right outer joins in comma join not yet supported, see https://github.com/MaterializeInc/materialize/issues/6875
+query III
 SELECT * FROM a, b full join c on b = c;
+----
+1  NULL  3
+1  2  NULL
 
-query error full/right outer joins in comma join not yet supported, see https://github.com/MaterializeInc/materialize/issues/6875
+query III
 SELECT * FROM a, b right join c on b = c;
+----
+1  NULL  3
 
 query III
 SELECT * FROM a, b left join c on b = c;
 ----
 1  2  NULL
+
+query III
+SELECT * FROM a CROSS JOIN b JOIN LATERAL(SELECT a.a FROM c) x ON TRUE;
+----
+1 2 1
+
+query error join trees using both lateral and full/right outer joins not yet supported
+SELECT * FROM a, b FULL JOIN LATERAL(SELECT a.a FROM c) x ON TRUE;
+
+query error column "a.a" does not exist
+SELECT * FROM a CROSS JOIN (b FULL JOIN LATERAL(SELECT a.a FROM c) x ON TRUE);
+
+statement ok
+CREATE TABLE t1 (a int, b int);
+
+statement ok
+CREATE TABLE t2 (a int, c int);
+
+statement ok
+INSERT INTO t1 VALUES (1, 2), (2, 3);
+
+statement ok
+INSERT INTO t2 VALUES (2, 4), (5, 7);
+
+query error join trees using both lateral and full/right outer joins not yet supported
+SELECT * FROM generate_series(1, 2), LATERAL (SELECT * FROM t1) _ NATURAL RIGHT JOIN t2;

--- a/test/sqllogictest/relation-cse.slt
+++ b/test/sqllogictest/relation-cse.slt
@@ -105,48 +105,19 @@ EXPLAIN SELECT * FROM t1 AS a1 LEFT JOIN t1 AS a2 USING (f1) WHERE a1.f1 = 1 AND
 ----
 %0 = Let l0 =
 | Get materialize.public.t1 (u1)
-| ArrangeBy (#0)
+| Filter (#0 = 1)
 
-%1 = Let l1 =
-| Join %0 %0 (= #0 #2)
-| | implementation = DeltaQuery
-| |   delta %0 %0.(#0)
-| |   delta %0 %0.(#0)
-| Filter !(isnull(#0))
-| Project (#0, #1, #3)
+%1 =
+| Get %0 (l0)
+| ArrangeBy ()
 
 %2 =
-| Get %1 (l1)
-| Project (#0, #1, #0, #2)
+| Get %0 (l0)
+| Project (#1)
 
 %3 =
-| Get %1 (l1)
-| Project (#0, #1)
-| Distinct group=(#0, #1)
-| Negate
-
-%4 =
-| Get materialize.public.t1 (u1)
-| Distinct group=(#0, #1)
-
-%5 =
-| Union %3 %4
-
-%6 =
-| Get materialize.public.t1 (u1)
-| ArrangeBy (#0, #1)
-
-%7 =
-| Join %5 %6 (= #0 #2) (= #1 #3)
-| | implementation = Differential %5 %6.(#0, #1)
-| Map null, null
-| Project (#0, #1, #4, #5)
-
-%8 =
-| Union %2 %7
-| Map coalesce(#0, #2)
-| Filter (#4 = 1)
-| Project (#4, #1, #3)
+| Join %1 %2
+| | implementation = Differential %2 %1.()
 
 EOF
 
@@ -713,38 +684,29 @@ SELECT * FROM t1 AS a1 LEFT JOIN t1 AS a2 USING (f1)
 
 %2 =
 | Get %1 (l1)
-| Project (#0, #1, #0, #2)
-
-%3 =
-| Get %1 (l1)
 | Project (#0, #1)
 | Distinct group=(#0, #1)
 | Negate
 
-%4 =
+%3 =
 | Get materialize.public.t1 (u1)
 | Distinct group=(#0, #1)
 
-%5 =
-| Union %3 %4
+%4 =
+| Union %2 %3
 
-%6 =
+%5 =
 | Get materialize.public.t1 (u1)
 | ArrangeBy (#0, #1)
 
+%6 = Let l2 =
+| Join %4 %5 (= #0 #2) (= #1 #3)
+| | implementation = Differential %4 %5.(#0, #1)
+| Project (#0, #1)
+| Map null
+
 %7 =
-| Join %5 %6 (= #0 #2) (= #1 #3)
-| | implementation = Differential %5 %6.(#0, #1)
-| Map null, null
-| Project (#0, #1, #4, #5)
-
-%8 = Let l2 =
-| Union %2 %7
-| Map coalesce(#0, #2)
-| Project (#4, #1, #3)
-
-%9 =
-| Union %8 %8
+| Union %1 %6 %1 %6
 
 EOF
 
@@ -756,57 +718,40 @@ SELECT * FROM (SELECT a2.f1 AS f1 FROM t1 AS a1 LEFT JOIN t1 AS a2 USING (f1)) W
 ----
 %0 = Let l0 =
 | Get materialize.public.t1 (u1)
-| ArrangeBy (#0)
-
-%1 = Let l1 =
-| Join %0 %0 (= #0 #2)
-| | implementation = DeltaQuery
-| |   delta %0 %0.(#0)
-| |   delta %0 %0.(#0)
-| Filter !(isnull(#0))
-| Project (#0, #1)
-
-%2 =
-| Get %1 (l1)
-| Project (#0, #0)
-
-%3 =
-| Get %1 (l1)
-| Distinct group=(#0, #1)
-| Negate
-
-%4 =
-| Get materialize.public.t1 (u1)
-| Distinct group=(#0, #1)
-
-%5 =
-| Union %3 %4
-
-%6 =
-| Get materialize.public.t1 (u1)
-| ArrangeBy (#0, #1)
-
-%7 =
-| Join %5 %6 (= #0 #2) (= #1 #3)
-| | implementation = Differential %5 %6.(#0, #1)
-| Map null
-| Project (#0, #4)
-
-%8 = Let l2 =
-| Union %2 %7
-| Map coalesce(#0, #1)
-| Project (#2)
-
-%9 =
-| Get %8 (l2)
 | Filter (#0 = 1)
 
-%10 =
-| Get %8 (l2)
+%1 = Let l1 =
+| Get materialize.public.t1 (u1)
 | Filter (#0 = 2)
 
-%11 =
-| Union %9 %10
+%2 =
+| Get %0 (l0)
+| Project ()
+| ArrangeBy ()
+
+%3 =
+| Get %0 (l0)
+| Project (#0)
+
+%4 =
+| Join %2 %3
+| | implementation = Differential %3 %2.()
+
+%5 =
+| Get %1 (l1)
+| Project ()
+| ArrangeBy ()
+
+%6 =
+| Get %1 (l1)
+| Project (#0)
+
+%7 =
+| Join %5 %6
+| | implementation = Differential %6 %5.()
+
+%8 =
+| Union %4 %7
 
 EOF
 
@@ -819,55 +764,24 @@ WHERE s1.f1 = 1 AND s2.f1 = 1
 ----
 %0 = Let l0 =
 | Get materialize.public.t1 (u1)
-| ArrangeBy (#0)
+| Filter (#0 = 1)
 
 %1 = Let l1 =
-| Join %0 %0 (= #0 #2)
-| | implementation = DeltaQuery
-| |   delta %0 %0.(#0)
-| |   delta %0 %0.(#0)
-| Filter !(isnull(#0))
-| Project (#0, #1)
-
-%2 =
-| Get %1 (l1)
-| Project (#0, #0)
-
-%3 =
-| Get %1 (l1)
-| Distinct group=(#0, #1)
-| Negate
-
-%4 =
-| Get materialize.public.t1 (u1)
-| Distinct group=(#0, #1)
-
-%5 =
-| Union %3 %4
-
-%6 =
-| Get materialize.public.t1 (u1)
-| ArrangeBy (#0, #1)
-
-%7 =
-| Join %5 %6 (= #0 #2) (= #1 #3)
-| | implementation = Differential %5 %6.(#0, #1)
-| Map null
-| Project (#0, #4)
-
-%8 = Let l2 =
-| Union %2 %7
-| Map coalesce(#0, #1)
-| Filter (#2 = 1)
-| Project (#2)
-
-%9 =
-| Get %8 (l2)
+| Get %0 (l0)
+| Project (#0)
 | ArrangeBy ()
 
-%10 =
-| Join %9 %8
-| | implementation = Differential %8 %9.()
+%2 = Let l2 =
+| Get %0 (l0)
+| Project ()
+
+%3 =
+| Get %2 (l2)
+| ArrangeBy ()
+
+%4 =
+| Join %1 %3 %1 %2
+| | implementation = Differential %2 %1.() %3.() %1.()
 
 EOF
 
@@ -880,59 +794,34 @@ WHERE s1.f1 = 1 AND s2.f1 = 2
 ----
 %0 = Let l0 =
 | Get materialize.public.t1 (u1)
-| ArrangeBy (#0)
+| Filter (#0 = 1)
 
 %1 = Let l1 =
-| Join %0 %0 (= #0 #2)
-| | implementation = DeltaQuery
-| |   delta %0 %0.(#0)
-| |   delta %0 %0.(#0)
-| Filter !(isnull(#0))
-| Project (#0, #1)
-
-%2 =
-| Get %1 (l1)
-| Project (#0, #0)
-
-%3 =
-| Get %1 (l1)
-| Distinct group=(#0, #1)
-| Negate
-
-%4 =
 | Get materialize.public.t1 (u1)
-| Distinct group=(#0, #1)
-
-%5 =
-| Union %3 %4
-
-%6 =
-| Get materialize.public.t1 (u1)
-| ArrangeBy (#0, #1)
-
-%7 =
-| Join %5 %6 (= #0 #2) (= #1 #3)
-| | implementation = Differential %5 %6.(#0, #1)
-| Map null
-| Project (#0, #4)
-
-%8 = Let l2 =
-| Union %2 %7
-| Map coalesce(#0, #1)
-| Project (#2)
-
-%9 =
-| Get %8 (l2)
-| Filter (#0 = 1)
-| ArrangeBy ()
-
-%10 =
-| Get %8 (l2)
 | Filter (#0 = 2)
 
-%11 =
-| Join %9 %10
-| | implementation = Differential %10 %9.()
+%2 =
+| Get %0 (l0)
+| Project (#0)
+| ArrangeBy ()
+
+%3 =
+| Get %0 (l0)
+| Project ()
+| ArrangeBy ()
+
+%4 =
+| Get %1 (l1)
+| Project (#0)
+| ArrangeBy ()
+
+%5 =
+| Get %1 (l1)
+| Project ()
+
+%6 =
+| Join %2 %3 %4 %5
+| | implementation = Differential %5 %2.() %3.() %4.()
 
 EOF
 
@@ -1371,12 +1260,12 @@ SELECT * FROM (SELECT a2.f1 AS f1 FROM t1 AS a1 JOIN t1 AS a2 USING (f1)) WHERE 
 
 %2 =
 | Get %0 (l0)
-| Project (#0)
+| Project ()
 | ArrangeBy ()
 
 %3 =
 | Get %0 (l0)
-| Project ()
+| Project (#0)
 
 %4 =
 | Join %2 %3
@@ -1384,12 +1273,12 @@ SELECT * FROM (SELECT a2.f1 AS f1 FROM t1 AS a1 JOIN t1 AS a2 USING (f1)) WHERE 
 
 %5 =
 | Get %1 (l1)
-| Project (#0)
+| Project ()
 | ArrangeBy ()
 
 %6 =
 | Get %1 (l1)
-| Project ()
+| Project (#0)
 
 %7 =
 | Join %5 %6


### PR DESCRIPTION
Our previous approach to planning `USING` constraints wasn't totally sufficient because it precluded filtering _NULL_ values from the output due to its reliance on `coalesce` over the joined columns (which explicitly removes _NULL_ values in the face of other, non-_NULL_ values).

This refactor instead:
- Leaves all columns from the joined relation intact, and instead sets some column in the joined relation as the "priority" version of the column
- Modifies `SELECT *` to automatically unproject any non-priority version of priority columns

Because prioritization is/was previously influenced/dictated by the column's presence in the projection list, this shouldn't interact with the other places in the code using prioritization...even though maybe it should!

@benesch pinging you only because you implemented name prioritization in the first place, so maybe you have feedback on how this approach is subtly wrong?

### `coalesce`

The previous implementation relied on coalescing columns in all cases, and that approach would have worked here. However, by only creating new, coalesced, prioritized columns when strictly necessary (on `FullOuterJoin`), and prioritizing existing columns in other cases, we get some nice wins in the optimizer.

### Motivation

This PR fixes a recognized bug:
Fixes #7618

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
