### PR TITLE
persist: fix race condition in nemesis test caused by #9465

### DIFF
--- a/src/persist/src/nemesis/direct.rs
+++ b/src/persist/src/nemesis/direct.rs
@@ -106,6 +106,7 @@ use timely::dataflow::ProbeHandle;
 use timely::progress::Antichain;
 
 use crate::error::Error;
+use crate::indexed::encoding::Id;
 use crate::indexed::runtime::{
     self, DecodedSnapshot, MultiWriteHandle, RuntimeClient, StreamReadHandle, StreamWriteHandle,
 };
@@ -127,6 +128,7 @@ use crate::unreliable::UnreliableHandle;
 struct Ingest {
     write: StreamWriteHandle<String, ()>,
     read: StreamReadHandle<String, ()>,
+    stream_id: Id,
     progress_rx: DataflowProgress,
 }
 
@@ -155,6 +157,7 @@ impl DirectCore {
             }
             Entry::Vacant(x) => {
                 let (write, read) = self.runtime.create_or_load(name);
+                let stream_id = write.stream_id()?;
                 let dataflow_read = read.clone();
                 let (output_tx, output_rx) = mpsc::channel();
                 let output_tx = Arc::new(Mutex::new(output_tx));
@@ -185,6 +188,7 @@ impl DirectCore {
                 let input = Ingest {
                     write,
                     read,
+                    stream_id,
                     progress_rx,
                 };
                 let output = Dataflow {
@@ -483,7 +487,7 @@ impl DirectWorker {
         let mut updates = Vec::new();
         for req in req.writes {
             let stream = self.stream(&req.stream)?;
-            updates.push((stream.write.stream_id()?, vec![req.update]));
+            updates.push((stream.stream_id, vec![req.update]));
             write_handles.push(stream.write.clone());
         }
         let write_handles = write_handles.iter().collect::<Vec<_>>();


### PR DESCRIPTION
Making `create_or_load()` infallible means that we delay when the error
surfaces. This messes with the expectations of the tests.

This fix makes sure to call `stream_id()?` after `create_or_load()`, so
that we bubble up the error from the same site as before.

Caused by #9465. This fixes it, but I don't know if we want to make bigger changes to accommodate the new behaviour of `create_or_load()`.

You can use `cargo stress --lib -- nemesis::direct::tests::direct_mzlike` before and after the fix to verify that a) there is a race, and b) that this fixes it. 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
