### PR TITLE
kafka_sink: Empty write frontier with empty input frontier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4981,6 +4981,7 @@ dependencies = [
  "serde",
  "serde_json",
  "similar",
+ "sql",
  "sql-parser",
  "structopt",
  "tempfile",

--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -514,6 +514,10 @@ impl KafkaSinkState {
             assert!(write_frontier.less_equal(&min_frontier));
             write_frontier.clear();
             write_frontier.insert(min_frontier);
+        } else {
+            // If there's no longer an input frontier, we will no longer receive any data forever and, therefore, will
+            // never output more data
+            self.write_frontier.borrow_mut().clear();
         }
 
         Ok(())

--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -125,6 +125,11 @@ where
         let peers = sinked_collection.inner.scope().peers();
         let worker_index = sinked_collection.inner.scope().index();
         let active_write_worker = (usize::cast_from(sink_id.hashed()) % peers) == worker_index;
+
+        // Only the active_write_worker will ever produce data so all other workers have
+        // an empty frontier.  It's necessary to insert all of these into `render_state.
+        // sink_write_frontier` below so we properly clear out default frontiers of
+        // non-active workers.
         let shared_frontier = Rc::new(RefCell::new(if active_write_worker {
             Antichain::from_elem(0)
         } else {

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -44,6 +44,7 @@ reqwest = { version = "0.11.7", features = ["native-tls-vendored"] }
 serde = "1.0.132"
 serde_json = { version = "1.0.73", features = ["raw_value"] }
 similar = "2.1.0"
+sql = { path = "../sql" }
 sql-parser = { path = "../sql-parser" }
 structopt = "0.3.25"
 tempfile = "3.2.0"

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -50,6 +50,7 @@ mod schema_registry;
 mod sleep;
 mod sql;
 mod sql_server;
+mod verify_timestamp_compaction;
 
 const DEFAULT_REGEX_REPLACEMENT: &str = "<regex_match>";
 
@@ -530,6 +531,10 @@ pub async fn build(cmds: Vec<PosCommand>, state: &State) -> Result<Vec<PosAction
                         }
                         continue;
                     }
+                    "verify-timestamp-compaction" => Box::new(
+                        verify_timestamp_compaction::build_verify_timestamp_compaction(builtin)
+                            .map_err(wrap_err)?,
+                    ),
                     _ => {
                         return Err(InputError {
                             msg: format!("unknown built-in command {}", builtin.name),

--- a/src/testdrive/src/action/verify_timestamp_compaction.rs
+++ b/src/testdrive/src/action/verify_timestamp_compaction.rs
@@ -62,19 +62,26 @@ impl Action for VerifyTimestampsAction {
                 .load_timestamp_bindings(item_id)
                 .map_err_to_string()?;
             println!(
-                "Verifying timestamp binding compaction.  Found {:?} vs expected {:?}",
+                "Verifying timestamp binding compaction for {:?}.  Found {:?} vs expected {:?}",
+                self.source,
                 bindings.len(),
                 self.max_size
             );
-            assert!(
-                bindings.len() <= self.max_size,
-                "There are {:?} bindings compared to max size {:?}",
-                bindings.len(),
-                self.max_size
-            );
+            if bindings.len() > self.max_size {
+                Err(format!(
+                    "There are {:?} bindings compared to max size {:?}",
+                    bindings.len(),
+                    self.max_size
+                ))
+            } else {
+                Ok(())
+            }
         } else {
-            println!("Skipping timestamp binding compaction verification.");
+            println!(
+                "Skipping timestamp binding compaction verification for {:?}.",
+                self.source
+            );
+            Ok(())
         }
-        Ok(())
     }
 }

--- a/src/testdrive/src/action/verify_timestamp_compaction.rs
+++ b/src/testdrive/src/action/verify_timestamp_compaction.rs
@@ -62,7 +62,7 @@ impl Action for VerifyTimestampsAction {
                 .load_timestamp_bindings(item_id)
                 .map_err_to_string()?;
             println!(
-                "Verifying Ttmestamp binding compaction.  Found {:?} vs expected {:?}",
+                "Verifying timestamp binding compaction.  Found {:?} vs expected {:?}",
                 bindings.len(),
                 self.max_size
             );

--- a/src/testdrive/src/action/verify_timestamp_compaction.rs
+++ b/src/testdrive/src/action/verify_timestamp_compaction.rs
@@ -1,0 +1,80 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use async_trait::async_trait;
+
+use coord::catalog::Catalog;
+use coord::session::Session;
+use ore::now::NOW_ZERO;
+use ore::result::ResultExt;
+use sql::catalog::SessionCatalog;
+use sql::names::PartialName;
+
+use crate::action::{Action, State};
+use crate::parser::BuiltinCommand;
+
+pub struct VerifyTimestampsAction {
+    source: String,
+    max_size: usize,
+}
+
+pub fn build_verify_timestamp_compaction(
+    mut cmd: BuiltinCommand,
+) -> Result<VerifyTimestampsAction, String> {
+    let source = cmd.args.string("source")?;
+    let max_size = cmd
+        .args
+        .opt_string("max-size")
+        .map(|s| s.parse::<usize>().expect("unable to parse usize"))
+        .unwrap_or(3);
+    cmd.args.done()?;
+    Ok(VerifyTimestampsAction { source, max_size })
+}
+
+#[async_trait]
+impl Action for VerifyTimestampsAction {
+    async fn undo(&self, _: &mut State) -> Result<(), String> {
+        // Can't undo a verification.
+        Ok(())
+    }
+
+    async fn redo(&self, state: &mut State) -> Result<(), String> {
+        if let Some(path) = &state.materialized_catalog_path {
+            let mut catalog = Catalog::open_debug(path, NOW_ZERO.clone())
+                .await
+                .map_err_to_string()?;
+            let item_id = catalog
+                .for_session(&Session::dummy())
+                .resolve_item(&PartialName {
+                    database: None,
+                    schema: None,
+                    item: self.source.clone(),
+                })
+                .map_err_to_string()?
+                .id();
+            let bindings = catalog
+                .load_timestamp_bindings(item_id)
+                .map_err_to_string()?;
+            println!(
+                "Verifying Ttmestamp binding compaction.  Found {:?} vs expected {:?}",
+                bindings.len(),
+                self.max_size
+            );
+            assert!(
+                bindings.len() <= self.max_size,
+                "There are {:?} bindings compared to max size {:?}",
+                bindings.len(),
+                self.max_size
+            );
+        } else {
+            println!("Skipping timestamp binding compaction verification.");
+        }
+        Ok(())
+    }
+}

--- a/test/testdrive/kafka-exactly-once-sink.td
+++ b/test/testdrive/kafka-exactly-once-sink.td
@@ -361,8 +361,7 @@ $ kafka-verify format=json sink=materialize.public.json_avro_upsert_key key=true
 $ kafka-verify format=json sink=materialize.public.json_avro_upsert_key_2 key=true
 {"b": 2} {"column1": 1, "b": 2, "column3": 3, "transaction": {"id": "0"}}
 
-# Verify compaction of exactly once sinks.  Add sleep to make sure we have at least one extra binding being computed.
-$ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=1
+# Verify compaction of exactly once sinks.
 $ verify-timestamp-compaction source=input_csv max-size=3
 $ verify-timestamp-compaction source=rt_binding_consistency_test_source max-size=3
 # TODO: Enable when #9514 is fixed!

--- a/test/testdrive/kafka-exactly-once-sink.td
+++ b/test/testdrive/kafka-exactly-once-sink.td
@@ -360,3 +360,10 @@ $ kafka-verify format=json sink=materialize.public.json_avro_upsert_key key=true
 
 $ kafka-verify format=json sink=materialize.public.json_avro_upsert_key_2 key=true
 {"b": 2} {"column1": 1, "b": 2, "column3": 3, "transaction": {"id": "0"}}
+
+# Verify compaction of exactly once sinks.  Add sleep to make sure we have at least one extra binding being computed.
+$ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=1
+$ verify-timestamp-compaction source=input_csv max-size=3
+$ verify-timestamp-compaction source=rt_binding_consistency_test_source max-size=3
+# TODO: Enable when #9514 is fixed!
+#$ verify-timestamp-compaction source=input_kafka_no_byo max-size=3


### PR DESCRIPTION
When the input frontier is empty and there are no pending rows, we should clear the write frontier signaling that there will be no more writes to the sink.

Also include all dataflow workers in the `RenderState` (with an empty frontier for all non-active writers) so that frontier changes are computed correctly.

### Motivation
When using an exactly-once kafka sink that is sourced by a non-tailed File (critically: a source that moves into the `SourceState::Done`), we created an unbounded number of timestamp bindings as the sink write frontier never advances.  Because of this, we're not able to compact timestamp bindings.  This is less an issue than it used to be after #9379 but we still ought to fix it.