### PR TITLE
qgm: newtype definitions `BoxId` and `QuantifierId`

### DIFF
--- a/src/ore/src/id_gen.rs
+++ b/src/ore/src/id_gen.rs
@@ -15,17 +15,23 @@
 
 //! ID generation utilities.
 
+use std::marker::PhantomData;
+
 /// Manages the allocation of unique IDs.
 #[derive(Debug, Default)]
-pub struct IdGen {
+pub struct Gen<Id: From<u64> + Default> {
     id: u64,
+    phantom: PhantomData<Id>,
 }
 
-impl IdGen {
-    /// Allocates a new identifier and advances the generator.
-    pub fn allocate_id(&mut self) -> u64 {
+impl<Id: From<u64> + Default> Gen<Id> {
+    /// Allocates a new identifier of type `Id` and advances the generator.
+    pub fn allocate_id(&mut self) -> Id {
         let id = self.id;
         self.id += 1;
-        id
+        id.into()
     }
 }
+
+/// A generator of u64-bit IDs.
+pub type IdGen = Gen<u64>;

--- a/src/sql/src/query_model/mod.rs
+++ b/src/sql/src/query_model/mod.rs
@@ -12,7 +12,7 @@ use std::collections::BTreeSet;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt;
 
-use ore::id_gen::IdGen;
+use ore::id_gen::Gen;
 
 mod dot;
 mod hir;
@@ -23,8 +23,35 @@ mod test;
 
 pub use scalar_expr::*;
 
-pub type QuantifierId = u64;
-pub type BoxId = u64;
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct QuantifierId(u64);
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct BoxId(u64);
+
+impl std::fmt::Display for QuantifierId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl std::fmt::Display for BoxId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl From<u64> for QuantifierId {
+    fn from(value: u64) -> Self {
+        QuantifierId(value)
+    }
+}
+
+impl From<u64> for BoxId {
+    fn from(value: u64) -> Self {
+        BoxId(value)
+    }
+}
+
 pub type QuantifierSet = BTreeSet<QuantifierId>;
 
 /// A Query Graph Model instance represents a SQL query.
@@ -44,11 +71,11 @@ pub struct Model {
     /// All boxes in the query graph model.
     boxes: HashMap<BoxId, Box<RefCell<QueryBox>>>,
     /// Used for assigning unique IDs to query boxes.
-    box_id_gen: IdGen,
+    box_id_gen: Gen<BoxId>,
     /// All quantifiers in the query graph model.
     quantifiers: HashMap<QuantifierId, Box<RefCell<Quantifier>>>,
     /// Used for assigning unique IDs to quantifiers.
-    quantifier_id_gen: IdGen,
+    quantifier_id_gen: Gen<QuantifierId>,
 }
 
 /// A semantic operator within a Query Graph.
@@ -191,7 +218,7 @@ pub struct Values {
 impl Model {
     fn new() -> Self {
         Self {
-            top_box: 0,
+            top_box: BoxId(0),
             boxes: HashMap::new(),
             box_id_gen: Default::default(),
             quantifiers: HashMap::new(),


### PR DESCRIPTION
Use zero-cost [[1]] newtype definitions [[2]] for `BoxId` and `QuantifierId` instead of type aliases.

[1]: https://rust-unofficial.github.io/patterns/patterns/behavioural/newtype.html
[2]: https://doc.rust-lang.org/rust-by-example/generics/new_types.html

### Motivation

_This PR refactors existing code._

Prevents uses of `QuantifierId` values in positions that expect `BoxId` and vice versa.

### Tips for reviewer

The changes are summarized as follows:

- Abstract over the return type of `IdGen` in `Gen<T: From<u64>>`.
- Set a public alias `IdGen = Gen<u64>` in order to minimize changes in non-QGM clients.
- Replace `BoxId` and `QuantifierId` types with newtype definitions.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
