### PR TITLE
support docker-compose versions with 'v' prefixes in mzcompose

### DIFF
--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -87,9 +87,11 @@ def main(argv: List[str]) -> int:
 
     # From here on out we're definitely invoking Docker Compose, so make sure
     # it's new enough.
-    output = spawn.capture(
-        ["docker-compose", "version", "--short"], unicode=True
-    ).strip()
+    output = (
+        spawn.capture(["docker-compose", "version", "--short"], unicode=True)
+        .strip()
+        .strip("v")
+    )
 
     version = tuple(int(i) for i in output.split("."))
     if version < MIN_COMPOSE_VERSION:


### PR DESCRIPTION
### Motivation
  * This PR fixes a recognized bug: On my machine `docker-compose` prepends a `v` onto the version it spits out


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
  - I mzcompose actually starts for me now	
- [x] This PR adds a release note for any [user-facing behavior changes]
  - no user-facing changes
