### PR TITLE
persist: split out a read-only subset of the Blob trait

### DIFF
--- a/src/persist/benches/end_to_end.rs
+++ b/src/persist/benches/end_to_end.rs
@@ -26,7 +26,7 @@ use ore::metrics::MetricsRegistry;
 use persist::file::{FileBlob, FileLog};
 use persist::indexed::runtime::{self, RuntimeClient, RuntimeConfig, StreamWriteHandle};
 use persist::operators::source::PersistedSource;
-use persist::storage::LockInfo;
+use persist::storage::{Blob, LockInfo};
 
 use criterion::{criterion_group, criterion_main, Bencher, BenchmarkGroup, Criterion, Throughput};
 use rand::distributions::Alphanumeric;
@@ -150,7 +150,7 @@ fn create_runtime(base_path: &Path, nonce: &str) -> Result<RuntimeClient, Error>
     let runtime = runtime::start(
         RuntimeConfig::default(),
         FileLog::new(log_dir, lock_info.clone())?,
-        FileBlob::new(blob_dir, lock_info)?,
+        FileBlob::open_exclusive(blob_dir.into(), lock_info)?,
         build_info::DUMMY_BUILD_INFO,
         &MetricsRegistry::new(),
         None,

--- a/src/persist/benches/snapshot.rs
+++ b/src/persist/benches/snapshot.rs
@@ -17,7 +17,7 @@ use persist::file::{FileBlob, FileLog};
 use persist::indexed::runtime::{self, RuntimeClient, RuntimeConfig, StreamReadHandle};
 use persist::indexed::Snapshot;
 use persist::mem::MemRegistry;
-use persist::storage::LockInfo;
+use persist::storage::{Blob, LockInfo};
 use persist_types::Codec;
 
 fn read_full_snapshot<K: Codec + Ord, V: Codec + Ord>(
@@ -87,7 +87,7 @@ pub fn bench_file_snapshots(c: &mut Criterion) {
         runtime::start(
             RuntimeConfig::default(),
             FileLog::new(log_dir, lock_info.clone())?,
-            FileBlob::new(blob_dir, lock_info)?,
+            FileBlob::open_exclusive(blob_dir.into(), lock_info)?,
             build_info::DUMMY_BUILD_INFO,
             &MetricsRegistry::new(),
             None,

--- a/src/persist/benches/writer.rs
+++ b/src/persist/benches/writer.rs
@@ -46,8 +46,11 @@ fn new_file_log(name: &str, parent: &Path) -> FileLog {
 
 fn new_file_blob(name: &str, parent: &Path) -> FileBlob {
     let file_blob_dir = parent.join(name);
-    FileBlob::new(file_blob_dir, LockInfo::new_no_reentrance(name.to_owned()))
-        .expect("creating a FileBlob cannot fail")
+    FileBlob::open_exclusive(
+        file_blob_dir.into(),
+        LockInfo::new_no_reentrance(name.to_owned()),
+    )
+    .expect("creating a FileBlob cannot fail")
 }
 
 fn generate_updates() -> ColumnarRecords {

--- a/src/persist/examples/kafka_upsert.rs
+++ b/src/persist/examples/kafka_upsert.rs
@@ -27,7 +27,7 @@ use persist::indexed::runtime::{self, RuntimeClient, RuntimeConfig, StreamReadHa
 use persist::indexed::Snapshot;
 use persist::operators::stream::{AwaitFrontier, Seal};
 use persist::operators::upsert::{PersistentUpsert, PersistentUpsertConfig};
-use persist::storage::LockInfo;
+use persist::storage::{Blob, LockInfo};
 use persist::Data;
 use persist_types::Codec;
 
@@ -55,7 +55,7 @@ fn run(args: Vec<String>) -> Result<(), Box<dyn Error>> {
     let persist = {
         let lock_info = LockInfo::new("kafka_upsert".into(), "nonce".into())?;
         let log = FileLog::new(base_dir.join("log"), lock_info.clone())?;
-        let blob = FileBlob::new(base_dir.join("blob"), lock_info)?;
+        let blob = FileBlob::open_exclusive(base_dir.join("blob").into(), lock_info)?;
         runtime::start(
             RuntimeConfig::default(),
             log,

--- a/src/persist/src/file.rs
+++ b/src/persist/src/file.rs
@@ -21,7 +21,7 @@ use fail::fail_point;
 use ore::cast::CastFrom;
 
 use crate::error::Error;
-use crate::storage::{Atomicity, Blob, LockInfo, Log, SeqNo};
+use crate::storage::{Atomicity, Blob, BlobRead, LockInfo, Log, SeqNo};
 
 /// Inner struct handles to separate files that store the data and metadata about the
 /// most recently truncated sequence number for [FileLog].
@@ -271,24 +271,34 @@ impl Log for FileLog {
     }
 }
 
-/// Implementation of [Blob] backed by files.
+/// Configuration for opening a [FileBlob] or [FileBlobRead].
 #[derive(Debug)]
-pub struct FileBlob {
+pub struct FileBlobConfig {
+    base_dir: PathBuf,
+}
+
+impl<P: AsRef<Path>> From<P> for FileBlobConfig {
+    fn from(base_dir: P) -> Self {
+        FileBlobConfig {
+            base_dir: base_dir.as_ref().to_path_buf(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct FileBlobCore {
     base_dir: Option<PathBuf>,
 }
 
-impl FileBlob {
+impl FileBlobCore {
     fn blob_path(&self, key: &str) -> Result<PathBuf, Error> {
         self.base_dir
             .as_ref()
             .map(|base_dir| base_dir.join(key))
             .ok_or_else(|| return Error::from("FileBlob unexpectedly closed"))
     }
-}
 
-#[async_trait]
-impl Blob for FileBlob {
-    async fn get(&self, key: &str) -> Result<Option<Vec<u8>>, Error> {
+    fn get(&self, key: &str) -> Result<Option<Vec<u8>>, Error> {
         let file_path = self.blob_path(key)?;
         let mut file = match File::open(file_path) {
             Ok(file) => file,
@@ -300,7 +310,7 @@ impl Blob for FileBlob {
         Ok(Some(buf))
     }
 
-    async fn list_keys(&self) -> Result<Vec<String>, Error> {
+    fn list_keys(&self) -> Result<Vec<String>, Error> {
         let base_dir = match &self.base_dir {
             Some(base_dir) => base_dir.canonicalize()?,
             None => return Err(Error::from("FileBlob unexpectedly closed")),
@@ -340,17 +350,36 @@ impl Blob for FileBlob {
         Ok(ret)
     }
 
-    async fn close(&mut self) -> Result<bool, Error> {
-        if let Some(base_dir) = self.base_dir.as_ref() {
-            let lockfile_path = Self::lockfile_path(&base_dir);
-            fs::remove_file(lockfile_path)?;
-            self.base_dir = None;
-            Ok(true)
-        } else {
-            // Already closed. Close implementations must be idempotent.
-            Ok(false)
-        }
+    fn close(&mut self) -> Option<PathBuf> {
+        self.base_dir.take()
     }
+}
+
+/// Implementation of [BlobRead] backed by files.
+#[derive(Debug)]
+pub struct FileBlobRead {
+    core: FileBlobCore,
+}
+
+#[async_trait]
+impl BlobRead for FileBlobRead {
+    async fn get(&self, key: &str) -> Result<Option<Vec<u8>>, Error> {
+        self.core.get(key)
+    }
+
+    async fn list_keys(&self) -> Result<Vec<String>, Error> {
+        self.core.list_keys()
+    }
+
+    async fn close(&mut self) -> Result<bool, Error> {
+        Ok(self.core.close().is_some())
+    }
+}
+
+/// Implementation of [Blob] backed by files.
+#[derive(Debug)]
+pub struct FileBlob {
+    core: FileBlobCore,
 }
 
 impl FileBlob {
@@ -362,47 +391,62 @@ impl FileBlob {
 }
 
 #[async_trait]
-impl Blob for FileBlob {
-    async fn close(&mut self) -> Result<bool, Error> {
-        if let Some(base_dir) = self.base_dir.as_ref() {
-            let lockfile_path = Self::lockfile_path(&base_dir);
-            fs::remove_file(lockfile_path)?;
-            self.base_dir = None;
-            Ok(true)
-        } else {
-            // Already closed. Close implementations must be idempotent.
-            Ok(false)
-        }
+impl BlobRead for FileBlob {
+    async fn get(&self, key: &str) -> Result<Option<Vec<u8>>, Error> {
+        self.core.get(key)
     }
-}
 
-impl FileBlob {
-    /// Returns a new [FileBlob] which stores files under the given dir.
-    ///
-    /// To ensure directory-wide mutual exclusion, a LOCK file is placed in
-    /// base_dir at construction time. If this file already exists (indicating
-    /// that another FileBlob is already using the dir), an error is returned
-    /// from `new`.
-    ///
-    /// The contents of `lock_info` are stored in the LOCK file and should
-    /// include anything that would help debug an unexpected LOCK file, such as
-    /// version, ip, worker number, etc.
-    pub fn new<P: AsRef<Path>>(base_dir: P, lock_info: LockInfo) -> Result<Self, Error> {
-        let base_dir = base_dir.as_ref();
-        fs::create_dir_all(&base_dir)?;
-        {
-            let _ = file_storage_lock(&Self::lockfile_path(&base_dir), lock_info)?;
+    async fn list_keys(&self) -> Result<Vec<String>, Error> {
+        self.core.list_keys()
+    }
+
+    async fn close(&mut self) -> Result<bool, Error> {
+        match self.core.close() {
+            Some(base_dir) => {
+                let lockfile_path = Self::lockfile_path(&base_dir);
+                fs::remove_file(lockfile_path)?;
+                Ok(true)
+            }
+            None => Ok(false),
         }
-        Ok(FileBlob {
-            base_dir: Some(base_dir.to_path_buf()),
-        })
     }
 }
 
 #[async_trait]
 impl Blob for FileBlob {
+    type Config = FileBlobConfig;
+    type Read = FileBlobRead;
+
+    /// Returns a new [FileBlob] which stores files under the given dir.
+    ///
+    /// To ensure directory-wide mutual exclusion, a LOCK file is placed in
+    /// base_dir at construction time. If this file already exists (indicating
+    /// that another FileBlob is already using the dir), an error is returned.
+    ///
+    /// The contents of `lock_info` are stored in the LOCK file and should
+    /// include anything that would help debug an unexpected LOCK file, such as
+    /// version, ip, worker number, etc.
+    fn open_exclusive(config: FileBlobConfig, lock_info: LockInfo) -> Result<Self, Error> {
+        let base_dir = config.base_dir;
+        fs::create_dir_all(&base_dir)?;
+        {
+            let _ = file_storage_lock(&Self::lockfile_path(&base_dir), lock_info)?;
+        }
+        let core = FileBlobCore {
+            base_dir: Some(base_dir),
+        };
+        Ok(FileBlob { core })
+    }
+
+    fn open_read(config: FileBlobConfig) -> Result<FileBlobRead, Error> {
+        let core = FileBlobCore {
+            base_dir: Some(config.base_dir),
+        };
+        Ok(FileBlobRead { core })
+    }
+
     async fn set(&mut self, key: &str, value: Vec<u8>, atomic: Atomicity) -> Result<(), Error> {
-        let file_path = self.blob_path(key)?;
+        let file_path = self.core.blob_path(key)?;
         match atomic {
             Atomicity::RequireAtomic => {
                 // To implement require_atomic, write to a temp file and rename
@@ -450,7 +494,7 @@ impl Blob for FileBlob {
     }
 
     async fn delete(&mut self, key: &str) -> Result<(), Error> {
-        let file_path = self.blob_path(key)?;
+        let file_path = self.core.blob_path(key)?;
         // TODO: strict correctness requires that we fsync the parent directory
         // as well after file removal.
         if let Err(err) = fs::remove_file(&file_path) {
@@ -494,10 +538,17 @@ mod tests {
     #[tokio::test]
     async fn file_blob() -> Result<(), Error> {
         let temp_dir = tempfile::tempdir()?;
-        blob_impl_test(move |t| {
-            let instance_dir = temp_dir.path().join(t.path);
-            FileBlob::new(instance_dir, (t.reentrance_id, "file_blob_test").into())
-        })
+        let temp_dir_read = temp_dir.path().to_owned();
+        blob_impl_test(
+            move |t| {
+                let instance_dir = temp_dir.path().join(t.path);
+                FileBlob::open_exclusive(
+                    instance_dir.into(),
+                    (t.reentrance_id, "file_blob_test").into(),
+                )
+            },
+            move |path| FileBlob::open_read(temp_dir_read.join(path).into()),
+        )
         .await
     }
 

--- a/src/persist/src/golden_test.rs
+++ b/src/persist/src/golden_test.rs
@@ -21,7 +21,7 @@ use crate::mem::{MemBlob, MemRegistry};
 use crate::nemesis::direct::{Direct, StartRuntime};
 use crate::nemesis::generator::{Generator, GeneratorConfig};
 use crate::nemesis::{Input, Runtime, RuntimeWorker};
-use crate::storage::{Atomicity, Blob};
+use crate::storage::{Atomicity, Blob, BlobRead};
 use crate::unreliable::UnreliableBlob;
 
 /// A test to catch changes in any part of the end-to-end persist encoding.

--- a/src/persist/src/mem.rs
+++ b/src/persist/src/mem.rs
@@ -24,7 +24,7 @@ use crate::indexed::cache::BlobCache;
 use crate::indexed::metrics::Metrics;
 use crate::indexed::runtime::{self, RuntimeClient, RuntimeConfig};
 use crate::indexed::Indexed;
-use crate::storage::{Atomicity, Blob, LockInfo, Log, SeqNo};
+use crate::storage::{Atomicity, Blob, BlobRead, LockInfo, Log, SeqNo};
 use crate::unreliable::{UnreliableBlob, UnreliableHandle, UnreliableLog};
 
 #[derive(Debug)]
@@ -196,6 +196,14 @@ impl MemBlobCore {
         }
     }
 
+    #[cfg(test)]
+    fn new_read() -> Self {
+        MemBlobCore {
+            dataz: HashMap::new(),
+            lock: None,
+        }
+    }
+
     fn open(&mut self, new_lock: LockInfo) -> Result<(), Error> {
         if let Some(existing) = &self.lock {
             let _ = new_lock.check_reentrant_for(&"MemBlob", existing.to_string().as_bytes())?;
@@ -219,7 +227,6 @@ impl MemBlobCore {
     }
 
     fn get(&self, key: &str) -> Result<Option<Vec<u8>>, Error> {
-        self.ensure_open()?;
         Ok(self.dataz.get(key).cloned())
     }
 
@@ -230,7 +237,6 @@ impl MemBlobCore {
     }
 
     fn list_keys(&self) -> Result<Vec<String>, Error> {
-        self.ensure_open()?;
         Ok(self.dataz.keys().cloned().collect())
     }
 
@@ -241,17 +247,23 @@ impl MemBlobCore {
     }
 }
 
-/// An in-memory implementation of [Blob].
+/// Configuration for opening a [MemBlob] or [MemBlobRead].
 #[derive(Debug)]
-pub struct MemBlob {
+pub struct MemBlobConfig {
+    core: Arc<Mutex<MemBlobCore>>,
+}
+
+/// An in-memory implementation of [BlobRead].
+#[derive(Debug)]
+pub struct MemBlobRead {
     core: Option<Arc<Mutex<MemBlobCore>>>,
 }
 
-impl MemBlob {
-    /// Open a pre-existing MemBlob.
-    fn open(core: Arc<Mutex<MemBlobCore>>, lock_info: LockInfo) -> Result<Self, Error> {
-        core.lock()?.open(lock_info)?;
-        Ok(Self { core: Some(core) })
+impl MemBlobRead {
+    fn open(config: MemBlobConfig) -> MemBlobRead {
+        MemBlobRead {
+            core: Some(config.core),
+        }
     }
 
     fn core_lock<'c>(&'c self) -> Result<MutexGuard<'c, MemBlobCore>, Error> {
@@ -263,7 +275,7 @@ impl MemBlob {
 }
 
 #[async_trait]
-impl Blob for MemBlob {
+impl BlobRead for MemBlobRead {
     async fn get(&self, key: &str) -> Result<Option<Vec<u8>>, Error> {
         self.core_lock()?.get(key)
     }
@@ -280,12 +292,17 @@ impl Blob for MemBlob {
     }
 }
 
+/// An in-memory implementation of [Blob].
+#[derive(Debug)]
+pub struct MemBlob {
+    core: Option<Arc<Mutex<MemBlobCore>>>,
+}
+
 impl MemBlob {
     /// Constructs a new, empty MemBlob.
     pub fn new(lock_info: LockInfo) -> Self {
-        MemBlob {
-            core: Some(Arc::new(Mutex::new(MemBlobCore::new(lock_info)))),
-        }
+        let core = Some(Arc::new(Mutex::new(MemBlobCore::new(lock_info))));
+        MemBlob { core }
     }
 
     /// Constructs a new, empty MemBlob with a unique reentrance id.
@@ -295,6 +312,13 @@ impl MemBlob {
     #[cfg(test)]
     pub fn new_no_reentrance(lock_info_details: &str) -> Self {
         Self::new(LockInfo::new_no_reentrance(lock_info_details.to_owned()))
+    }
+
+    fn core_lock<'c>(&'c self) -> Result<MutexGuard<'c, MemBlobCore>, Error> {
+        match self.core.as_ref() {
+            None => return Err("MemBlob has been closed".into()),
+            Some(core) => Ok(core.lock()?),
+        }
     }
 
     #[cfg(test)]
@@ -321,12 +345,36 @@ impl Drop for MemBlob {
 }
 
 #[async_trait]
-impl Blob for MemBlob {
+impl BlobRead for MemBlob {
+    async fn get(&self, key: &str) -> Result<Option<Vec<u8>>, Error> {
+        self.core_lock()?.get(key)
+    }
+
+    async fn list_keys(&self) -> Result<Vec<String>, Error> {
+        self.core_lock()?.list_keys()
+    }
+
     async fn close(&mut self) -> Result<bool, Error> {
         match self.core.take() {
             None => Ok(false), // Someone already called close.
             Some(core) => core.lock()?.close(),
         }
+    }
+}
+
+#[async_trait]
+impl Blob for MemBlob {
+    type Config = MemBlobConfig;
+    type Read = MemBlobRead;
+
+    fn open_exclusive(config: MemBlobConfig, lock_info: LockInfo) -> Result<Self, Error> {
+        let core = config.core;
+        core.lock()?.open(lock_info)?;
+        Ok(MemBlob { core: Some(core) })
+    }
+
+    fn open_read(config: MemBlobConfig) -> Result<MemBlobRead, Error> {
+        Ok(MemBlobRead::open(config))
     }
 
     async fn set(&mut self, key: &str, value: Vec<u8>, _atomic: Atomicity) -> Result<(), Error> {
@@ -372,8 +420,10 @@ impl MemRegistry {
 
     /// Opens the [MemBlob] contained by this registry.
     pub fn blob_no_reentrance(&self) -> Result<MemBlob, Error> {
-        MemBlob::open(
-            self.blob.clone(),
+        MemBlob::open_exclusive(
+            MemBlobConfig {
+                core: self.blob.clone(),
+            },
             LockInfo::new_no_reentrance("MemRegistry".to_owned()),
         )
     }
@@ -463,7 +513,7 @@ impl MemMultiRegistry {
         }
     }
 
-    /// Opens the [MemLog] associated with `path`.
+    /// Opens a [MemLog] associated with `path`.
     pub fn log(&mut self, path: &str, lock_info: LockInfo) -> Result<MemLog, Error> {
         if let Some(log) = self.log_by_path.get(path) {
             MemLog::open(log.clone(), lock_info)
@@ -475,15 +525,26 @@ impl MemMultiRegistry {
         }
     }
 
-    /// Opens the [MemBlob] associated with `path`.
+    /// Opens a [MemBlob] associated with `path`.
     pub fn blob(&mut self, path: &str, lock_info: LockInfo) -> Result<MemBlob, Error> {
         if let Some(blob) = self.blob_by_path.get(path) {
-            MemBlob::open(blob.clone(), lock_info)
+            MemBlob::open_exclusive(MemBlobConfig { core: blob.clone() }, lock_info)
         } else {
             let blob = Arc::new(Mutex::new(MemBlobCore::new(lock_info)));
             self.blob_by_path.insert(path.to_string(), blob.clone());
             let blob = MemBlob { core: Some(blob) };
             Ok(blob)
+        }
+    }
+
+    /// Opens a [MemBlobRead] associated with `path`.
+    pub fn blob_read(&mut self, path: &str) -> MemBlobRead {
+        if let Some(blob) = self.blob_by_path.get(path) {
+            MemBlobRead::open(MemBlobConfig { core: blob.clone() })
+        } else {
+            let blob = Arc::new(Mutex::new(MemBlobCore::new_read()));
+            self.blob_by_path.insert(path.to_string(), blob.clone());
+            MemBlobRead::open(MemBlobConfig { core: blob })
         }
     }
 
@@ -518,9 +579,17 @@ mod tests {
 
     #[tokio::test]
     async fn mem_blob() -> Result<(), Error> {
-        let mut registry = MemMultiRegistry::new();
-        blob_impl_test(move |t| registry.blob(t.path, (t.reentrance_id, "blob_impl_test").into()))
-            .await
+        let registry = Arc::new(Mutex::new(MemMultiRegistry::new()));
+        let registry_read = registry.clone();
+        blob_impl_test(
+            move |t| {
+                registry
+                    .lock()?
+                    .blob(t.path, (t.reentrance_id, "blob_impl_test").into())
+            },
+            move |path| Ok(registry_read.lock()?.blob_read(path)),
+        )
+        .await
     }
 
     // This test covers a regression that was affecting the nemesis tests where

--- a/src/persist/src/nemesis/direct.rs
+++ b/src/persist/src/nemesis/direct.rs
@@ -565,6 +565,7 @@ mod tests {
     use crate::mem::MemRegistry;
     use crate::nemesis;
     use crate::nemesis::generator::GeneratorConfig;
+    use crate::storage::Blob;
     use crate::unreliable::{UnreliableBlob, UnreliableLog};
 
     use super::*;
@@ -587,7 +588,8 @@ mod tests {
             let (log_dir, blob_dir) = (self.path().join("log"), self.path().join("blob"));
             let log = FileLog::new(log_dir, ("reentrance0", "direct_file").into())?;
             let log = UnreliableLog::from_handle(log, unreliable.clone());
-            let blob = FileBlob::new(blob_dir, ("reentrance0", "direct_file").into())?;
+            let blob =
+                FileBlob::open_exclusive(blob_dir.into(), ("reentrance0", "direct_file").into())?;
             let blob = UnreliableBlob::from_handle(blob, unreliable);
             runtime::start(
                 RuntimeConfig::for_tests(),

--- a/src/persist/src/s3.rs
+++ b/src/persist/src/s3.rs
@@ -9,8 +9,6 @@
 
 //! An S3 implementation of [Blob] storage.
 
-use std::fmt;
-
 use async_trait::async_trait;
 use aws_sdk_s3::ByteStream;
 use aws_sdk_s3::Client as S3Client;
@@ -20,31 +18,21 @@ use futures_executor::block_on;
 use mz_aws_util::config::AwsConfig;
 
 use crate::error::Error;
-use crate::storage::{Atomicity, Blob, LockInfo};
+use crate::storage::{Atomicity, Blob, BlobRead, LockInfo};
 
-/// Configuration for [S3Blob].
-#[derive(Clone)]
-pub struct Config {
+/// Configuration for opening an [S3Blob] or [S3BlobRead].
+#[derive(Clone, Debug)]
+pub struct S3BlobConfig {
     client: S3Client,
     bucket: String,
     prefix: String,
 }
 
-impl fmt::Debug for Config {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Config")
-            .field("client", &"...")
-            .field("bucket", &self.bucket)
-            .field("prefix", &self.prefix)
-            .finish()
-    }
-}
-
-impl Config {
+impl S3BlobConfig {
     #[cfg(test)]
     const EXTERNAL_TESTS_S3_BUCKET: &'static str = "MZ_PERSIST_EXTERNAL_STORAGE_TEST_S3_BUCKET";
 
-    /// Returns a new [Config] for use in production.
+    /// Returns a new [S3BlobConfig] for use in production.
     ///
     /// Stores objects in the given bucket prepended with the (possibly empty)
     /// prefix. S3 credentials and region must be available in the process or
@@ -53,7 +41,7 @@ impl Config {
         let config = AwsConfig::load_from_env().await;
         let client = mz_aws_util::s3::client(&config)
             .map_err(|err| format!("connecting client: {}", err))?;
-        Ok(Config {
+        Ok(S3BlobConfig {
             client,
             bucket,
             prefix,
@@ -123,16 +111,13 @@ impl Config {
         // to worry about deleting any data that we create because the bucket is
         // set to auto-delete after 1 day.
         let prefix = Uuid::new_v4().to_string();
-        let config = Config::new(bucket, prefix).await?;
+        let config = S3BlobConfig::new(bucket, prefix).await?;
         Ok(Some(config))
     }
 }
 
-/// Implementation of [Blob] backed by S3.
-//
-// TODO: Productionize this:
-// - Resolve what to do with LOCK, this impl is race-y.
-pub struct S3Blob {
+#[derive(Debug)]
+struct S3BlobCore {
     client: Option<S3Client>,
     bucket: String,
     prefix: String,
@@ -142,17 +127,7 @@ pub struct S3Blob {
     max_keys: i32,
 }
 
-impl fmt::Debug for S3Blob {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("S3Blob")
-            .field("client", &"...")
-            .field("bucket", &self.bucket)
-            .field("prefix", &self.prefix)
-            .finish()
-    }
-}
-
-impl S3Blob {
+impl S3BlobCore {
     fn get_path(&self, key: &str) -> String {
         format!("{}/{}", self.prefix, key)
     }
@@ -162,10 +137,7 @@ impl S3Blob {
             .as_ref()
             .ok_or_else(|| Error::from("S3Blob unexpectedly closed"))
     }
-}
 
-#[async_trait]
-impl Blob for S3Blob {
     async fn get(&self, key: &str) -> Result<Option<Vec<u8>>, Error> {
         let client = self.ensure_open()?;
         let path = self.get_path(key);
@@ -240,21 +212,46 @@ impl Blob for S3Blob {
         Ok(ret)
     }
 
-    async fn close(&mut self) -> Result<bool, Error> {
-        Ok(self.client.take().is_some())
+    fn close(&mut self) -> Option<S3Client> {
+        self.client.take()
     }
+}
+
+/// Implementation of [BlobRead] backed by S3.
+#[derive(Debug)]
+pub struct S3BlobRead {
+    core: S3BlobCore,
+}
+
+#[async_trait]
+impl BlobRead for S3BlobRead {
+    async fn get(&self, key: &str) -> Result<Option<Vec<u8>>, Error> {
+        self.core.get(key).await
+    }
+
+    async fn list_keys(&self) -> Result<Vec<String>, Error> {
+        self.core.list_keys().await
+    }
+
+    async fn close(&mut self) -> Result<bool, Error> {
+        Ok(self.core.close().is_some())
+    }
+}
+
+/// Implementation of [Blob] backed by S3.
+//
+// TODO: Productionize this:
+// - Resolve what to do with LOCK, this impl is race-y.
+#[derive(Debug)]
+pub struct S3Blob {
+    core: S3BlobCore,
 }
 
 impl S3Blob {
     const LOCKFILE_KEY: &'static str = "LOCK";
 
-    #[cfg(test)]
-    fn set_max_keys(&mut self, max_keys: i32) {
-        self.max_keys = max_keys;
-    }
-
     async fn lock(&mut self, new_lock: LockInfo) -> Result<(), Error> {
-        let lockfile_path = self.get_path(Self::LOCKFILE_KEY);
+        let lockfile_path = self.core.get_path(Self::LOCKFILE_KEY);
         // TODO: This is race-y. See the productionize comment on [S3Blob].
         if let Some(existing) = self.get(Self::LOCKFILE_KEY).await? {
             let _ = new_lock.check_reentrant_for(&lockfile_path, &mut existing.as_slice())?;
@@ -267,13 +264,38 @@ impl S3Blob {
 }
 
 #[async_trait]
-impl Blob for S3Blob {
+impl BlobRead for S3Blob {
+    async fn get(&self, key: &str) -> Result<Option<Vec<u8>>, Error> {
+        self.core.get(key).await
+    }
+
+    async fn list_keys(&self) -> Result<Vec<String>, Error> {
+        self.core.list_keys().await
+    }
+
     async fn close(&mut self) -> Result<bool, Error> {
-        Ok(self.client.take().is_some())
+        match self.core.close() {
+            Some(client) => {
+                let lockfile_path = self.core.get_path(Self::LOCKFILE_KEY);
+                client
+                    .delete_object()
+                    .bucket(&self.core.bucket)
+                    .key(lockfile_path)
+                    .send()
+                    .await
+                    .map_err(|err| Error::from(err.to_string()))?;
+                Ok(true)
+            }
+            None => Ok(false),
+        }
     }
 }
 
-impl S3Blob {
+#[async_trait]
+impl Blob for S3Blob {
+    type Config = S3BlobConfig;
+    type Read = S3BlobRead;
+
     /// Returns a new [S3Blob] which stores objects under the given bucket and
     /// prefix.
     ///
@@ -282,31 +304,41 @@ impl S3Blob {
     //
     // TODO: Figure out how to make this tokio runtime guard stuff more
     // explicit.
-    pub fn new(config: Config, lock_info: LockInfo) -> Result<Self, Error> {
+    fn open_exclusive(config: S3BlobConfig, lock_info: LockInfo) -> Result<Self, Error> {
         block_on(async {
-            let mut blob = S3Blob {
+            let core = S3BlobCore {
                 client: Some(config.client),
                 bucket: config.bucket,
                 prefix: config.prefix,
                 max_keys: 1_000,
             };
+            let mut blob = S3Blob { core };
             let _ = blob.lock(lock_info).await?;
             Ok(blob)
         })
     }
-}
 
-#[async_trait]
-impl Blob for S3Blob {
+    fn open_read(config: S3BlobConfig) -> Result<S3BlobRead, Error> {
+        block_on(async {
+            let core = S3BlobCore {
+                client: Some(config.client),
+                bucket: config.bucket,
+                prefix: config.prefix,
+                max_keys: 1_000,
+            };
+            Ok(S3BlobRead { core })
+        })
+    }
+
     async fn set(&mut self, key: &str, value: Vec<u8>, _atomic: Atomicity) -> Result<(), Error> {
         // NB: S3 is always atomic, so we're free to ignore the atomic param.
-        let client = self.ensure_open()?;
-        let path = self.get_path(key);
+        let client = self.core.ensure_open()?;
+        let path = self.core.get_path(key);
 
         let body = ByteStream::from(value);
         client
             .put_object()
-            .bucket(&self.bucket)
+            .bucket(&self.core.bucket)
             .key(path)
             .body(body)
             .send()
@@ -316,11 +348,11 @@ impl Blob for S3Blob {
     }
 
     async fn delete(&mut self, key: &str) -> Result<(), Error> {
-        let client = self.ensure_open()?;
-        let path = self.get_path(key);
+        let client = self.core.ensure_open()?;
+        let path = self.core.get_path(key);
         client
             .delete_object()
-            .bucket(&self.bucket)
+            .bucket(&self.core.bucket)
             .key(path)
             .send()
             .await
@@ -339,28 +371,41 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn s3_blob() -> Result<(), Error> {
         ore::test::init_logging();
-        let config = match Config::new_for_test().await? {
+        let config = match S3BlobConfig::new_for_test().await? {
             Some(client) => client,
             None => {
                 log::info!(
                     "{} env not set: skipping test that uses external service",
-                    Config::EXTERNAL_TESTS_S3_BUCKET
+                    S3BlobConfig::EXTERNAL_TESTS_S3_BUCKET
                 );
                 return Ok(());
             }
         };
+        let config_read = config.clone();
 
-        blob_impl_test(move |t| {
-            let lock_info = (t.reentrance_id, "s3_blob_test").into();
-            let config = Config {
-                client: config.client.clone(),
-                bucket: config.bucket.clone(),
-                prefix: format!("{}/s3_blob_impl_test/{}", config.prefix, t.path),
-            };
-            let mut blob = S3Blob::new(config, lock_info)?;
-            blob.set_max_keys(2);
-            Ok(blob)
-        })
+        blob_impl_test(
+            move |t| {
+                let lock_info = (t.reentrance_id, "s3_blob_test").into();
+                let config = S3BlobConfig {
+                    client: config.client.clone(),
+                    bucket: config.bucket.clone(),
+                    prefix: format!("{}/s3_blob_impl_test/{}", config.prefix, t.path),
+                };
+                let mut blob = S3Blob::open_exclusive(config, lock_info)?;
+                blob.core.max_keys = 2;
+                Ok(blob)
+            },
+            move |path| {
+                let config = S3BlobConfig {
+                    client: config_read.client.clone(),
+                    bucket: config_read.bucket.clone(),
+                    prefix: format!("{}/s3_blob_impl_test/{}", config_read.prefix, path),
+                };
+                let mut blob = S3Blob::open_read(config)?;
+                blob.core.max_keys = 2;
+                Ok(blob)
+            },
+        )
         .await?;
         Ok(())
     }


### PR DESCRIPTION
The first of several PRs to factor out a read-only version of the
persist runtime, for use in the ingestd/dataflowd platform split.

This splits the read-only operations (get/list_keys) of Blob into a new
BlobRead trait (which Blob extends). `close` is primarily responsible
for releasing the exclusive-writer lock and so stays only on Blob.

A `Read` type is added to the Blob trait to establish a relationship
between between an implementation of Blob and its read-only companion.
This relationship isn't used in code, but seems worthwhile to have
around.

A `Config` type is added to the Blob trait and unified
`open_exclusive`/`open_read` constructors are added. These are similarly
not used in code, but seem worthwhile.

An initial version of this PR also had an `as_read` method on Blob that
returned `self` as the corresponding `BlobRead` impl, but given that
Blob extends BlobRead, it was rejected as unnecessary (and it ended up
accidentally being too opinionated about the internals of a Blob impl).

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
