### PR TITLE
ci: add python3 to macOS brew deps

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -87,7 +87,7 @@ tags="queue=mac,queue=mac-VERSION"
 name="mac-X"
 <otherwise edit to match config above>
 % brew services start buildkite-agent
-% brew install cmake postgresql [other materialize dependencies...]
+% brew install cmake postgresql python3 [other materialize dependencies...]
 % curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 % cat /usr/local/etc/buildkite-agent/hooks/environment
 export AWS_ACCESS_KEY_ID=<redacted>


### PR DESCRIPTION
Homebrew-installed Python 3 is capable of installing numpy while the
system Python is not.

### Motivation

  * This PR fixes a previously unreported bug: macOS CI agents were failing to install numpy.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
