### PR TITLE
fix x86 xcompile step of mzcompose

### DIFF
--- a/misc/python/materialize/xcompile.py
+++ b/misc/python/materialize/xcompile.py
@@ -186,5 +186,5 @@ def _bootstrap_darwin_x86_64() -> None:
         return
     spawn.runv(["brew", "install", "SergioBenitez/osxct/x86_64-unknown-linux-gnu"])
     spawn.runv(["rustup", "target", "add", "x86_64-unknown-linux-gnu"])
-    BOOTSTRAP_FILE.parent.mkdir()
+    BOOTSTRAP_FILE.parent.mkdir(exist_ok=True)
     BOOTSTRAP_FILE.write_text(BOOTSTRAP_VERSION)


### PR DESCRIPTION
When installing xcompile tools as part of `mzcompose run`, I get the following error:

```
$ brew install SergioBenitez/osxct/x86_64-unknown-linux-gnu
Warning: sergiobenitez/osxct/x86_64-unknown-linux-gnu 7.2.0 is already installed and up-to-date.
To reinstall 7.2.0, run:
  brew reinstall x86_64-unknown-linux-gnu
$ rustup target add x86_64-unknown-linux-gnu
info: component 'rust-std' for target 'x86_64-unknown-linux-gnu' is up to date
Traceback (most recent call last):
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/Users/chae/src/materialize/misc/python/materialize/cli/mzcompose.py", line 316, in <module>
    sys.exit(main(sys.argv[1:]))
  File "/Users/chae/src/materialize/misc/python/materialize/cli/mzcompose.py", line 108, in main
    deps.acquire()
  File "/Users/chae/src/materialize/misc/python/materialize/mzbuild.py", line 668, in acquire
    d.acquire()
  File "/Users/chae/src/materialize/misc/python/materialize/mzbuild.py", line 533, in acquire
    self.build()
  File "/Users/chae/src/materialize/misc/python/materialize/mzbuild.py", line 494, in build
    pre_image.run()
  File "/Users/chae/src/materialize/misc/python/materialize/mzbuild.py", line 293, in run
    self.build()
  File "/Users/chae/src/materialize/misc/python/materialize/mzbuild.py", line 240, in build
    cargo_build = [*self.rd.cargo("build", self.rustflags), "--bin", self.bin]
  File "/Users/chae/src/materialize/misc/python/materialize/mzbuild.py", line 88, in cargo
    return xcompile.cargo(self.arch, subcommand, rustflags)
  File "/Users/chae/src/materialize/misc/python/materialize/xcompile.py", line 131, in cargo
    *_enter_builder(arch),
  File "/Users/chae/src/materialize/misc/python/materialize/xcompile.py", line 167, in _enter_builder
    _bootstrap_darwin_x86_64()
  File "/Users/chae/src/materialize/misc/python/materialize/xcompile.py", line 189, in _bootstrap_darwin_x86_64
    BOOTSTRAP_FILE.parent.mkdir()
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/pathlib.py", line 1287, in mkdir
    self._accessor.mkdir(self, mode)
FileExistsError: [Errno 17] File exists: '/Users/chae/src/materialize/target/x86_64-unknown-linux-gnu'
```

Changing the `mkdir` to allow the directory to already exists fixes things.