### PR TITLE
website: Correct curl install one-liners

### DIFF
--- a/doc/user/content/install.md
+++ b/doc/user/content/install.md
@@ -46,7 +46,7 @@ brew install MaterializeInc/materialize/materialized
 ### curl
 
 ```shell
-curl -L https://binaries.materialize.com/materialized-{{< version >}}-$(arch)-apple-darwin.tar.gz \
+curl -L https://binaries.materialize.com/materialized-{{< version >}}-$(uname -m)-apple-darwin.tar.gz \
     | sudo tar -xzC /usr/local --strip-components=1
 ```
 
@@ -70,7 +70,7 @@ sudo apt install materialized
 ### curl
 
 ```shell
-curl -L https://binaries.materialize.com/materialized-{{< version >}}-$(arch)-unknown-linux-gnu.tar.gz \
+curl -L https://binaries.materialize.com/materialized-{{< version >}}-$(uname -m)-unknown-linux-gnu.tar.gz \
     | sudo tar -xzC /usr/local --strip-components=1
 ```
 

--- a/misc/www/index.html
+++ b/misc/www/index.html
@@ -43,12 +43,12 @@ by the Apache License, Version 2.0.
 
     <p>Linux one-liner:</p>
     <div class="code">
-      $ curl -L https://binaries.materialize.com/materialized-latest-$(arch)-unknown-linux-gnu.tar.gz | sudo tar -xzC /usr/local --strip-components=1
+      $ curl -L https://binaries.materialize.com/materialized-latest-$(uname -m)-unknown-linux-gnu.tar.gz | sudo tar -xzC /usr/local --strip-components=1
     </div>
 
     <p>macOS one-liner:</p>
     <div class="code">
-      $ curl -L https://binaries.materialize.com/materialized-latest-$(arch)-apple-darwin.tar.gz | sudo tar -xzC /usr/local --strip-components=1
+      $ curl -L https://binaries.materialize.com/materialized-latest-$(uname -m)-apple-darwin.tar.gz | sudo tar -xzC /usr/local --strip-components=1
     </div>
 
     <p>Resources:</p>


### PR DESCRIPTION
On my Mac the `arch` program outputs i386, apparently uname -m is more
portable:

```console
$ arch
i386
$ uname -m
x86_64
```

However, this does not fix things for ARM 64 macs, both `arch` and `uname -m`
produce `arm64`.

It looks like[1] apple decided that `arm64` is just what it's called on macos, so I
don't think it's that surprising that I can't find any programs that will just output
`aarch64`. I've added another PR that just edits the output of `uname -m` but
I'm open to other ideas.

[1]: https://news.ycombinator.com/item?id=24039010