### PR TITLE
sql: structure more errors

### DIFF
--- a/src/coord/tests/sql.rs
+++ b/src/coord/tests/sql.rs
@@ -84,7 +84,7 @@ async fn datadriven() {
                     let resolved = resolve_names(&mut qcx, q);
                     match resolved {
                         Ok(q) => format!("{}\n", q),
-                        Err(e) => format!("error: {:?}\n", e),
+                        Err(e) => format!("error: {}\n", e),
                     }
                 }
                 dir => panic!("unhandled directive {}", dir),

--- a/src/sql/src/lib.rs
+++ b/src/sql/src/lib.rs
@@ -82,6 +82,13 @@ macro_rules! bail_unsupported {
     };
 }
 
+// TODO(benesch): delete this once we use structured errors everywhere.
+macro_rules! sql_bail {
+    ($($e:expr),* $(,)?) => {
+        return Err(crate::plan::error::PlanError::Unstructured(format!($($e),*)))
+    }
+}
+
 pub mod ast;
 pub mod catalog;
 pub mod func;

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -25,6 +25,7 @@ use ore::collections::CollectionExt;
 use ore::stack;
 use repr::*;
 
+use crate::plan::error::PlanError;
 use crate::plan::query::ExprContext;
 use crate::plan::typeconv::{self, CastContext};
 use crate::plan::Params;
@@ -347,15 +348,11 @@ pub enum CoercibleScalarExpr {
 }
 
 impl CoercibleScalarExpr {
-    pub fn type_as(
-        self,
-        ecx: &ExprContext,
-        ty: &ScalarType,
-    ) -> Result<HirScalarExpr, anyhow::Error> {
+    pub fn type_as(self, ecx: &ExprContext, ty: &ScalarType) -> Result<HirScalarExpr, PlanError> {
         let expr = typeconv::plan_coerce(ecx, self, ty)?;
         let expr_ty = ecx.scalar_type(&expr);
         if ty != &expr_ty {
-            bail!(
+            sql_bail!(
                 "{} must have type {}, not type {}",
                 ecx.name,
                 ecx.humanize_scalar_type(ty),
@@ -365,7 +362,7 @@ impl CoercibleScalarExpr {
         Ok(expr)
     }
 
-    pub fn type_as_any(self, ecx: &ExprContext) -> Result<HirScalarExpr, anyhow::Error> {
+    pub fn type_as_any(self, ecx: &ExprContext) -> Result<HirScalarExpr, PlanError> {
         typeconv::plan_coerce(ecx, self, &ScalarType::String)
     }
 
@@ -375,7 +372,7 @@ impl CoercibleScalarExpr {
         ecx: &ExprContext,
         ccx: CastContext,
         ty: &ScalarType,
-    ) -> Result<HirScalarExpr, anyhow::Error> {
+    ) -> Result<HirScalarExpr, PlanError> {
         let expr = typeconv::plan_coerce(ecx, self, ty)?;
         typeconv::plan_cast(op, ecx, ccx, expr, ty)
     }

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -254,7 +254,7 @@ pub fn plan_copy_from(
     columns: Vec<usize>,
     rows: Vec<repr::Row>,
 ) -> Result<super::HirRelationExpr, anyhow::Error> {
-    query::plan_copy_from_rows(pcx, catalog, id, columns, rows)
+    Ok(query::plan_copy_from_rows(pcx, catalog, id, columns, rows)?)
 }
 
 /// Whether a SQL object type can be interpreted as matching the type of the given catalog item.


### PR DESCRIPTION
Plumb `PlanError` through more of the SQL planner. In many cases we bail
out to `PlanError::Unstructured` immediately, but this sets us up to
gradually structure individual calls to `sql_bail!` as described in #5340.

In particular, this sets us up to tackle #5314, where the SQL planner
wants to special-case UnknownColumn errors that occur while planning
SELECT lists to provide a friendlier error message.

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
