### PR TITLE
sql: implement pg_am as an empty view

### DIFF
--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -1620,11 +1620,11 @@ WHERE c.relkind = ANY (ARRAY['r','p'])",
 pub const PG_ACCESS_METHODS: BuiltinView = BuiltinView {
     name: "pg_am",
     schema: PG_CATALOG_SCHEMA,
-    sql: "CREATE VIEW pg_am AS \
-SELECT NULL::pg_catalog.oid AS oid, \
-    NULL::pg_catalog.text AS amname, \
-    NULL::pg_catalog.regproc AS amhandler, \
-    NULL::pg_catalog.char(1) AS amtype \
+    sql: "CREATE VIEW pg_am AS
+SELECT NULL::pg_catalog.oid AS oid,
+    NULL::pg_catalog.text AS amname,
+    NULL::pg_catalog.regproc AS amhandler,
+    NULL::pg_catalog.char(1) AS amtype
 WHERE false",
     id: GlobalId::System(5036),
     needs_logs: false,

--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -949,19 +949,6 @@ lazy_static! {
         // for this to be persisted.
         persistent: true,
     };
-    pub static ref MZ_ACCESS_METHODS: BuiltinTable = BuiltinTable {
-        name: "mz_ams",
-        schema: MZ_CATALOG_SCHEMA,
-        desc: RelationDesc::empty()
-                .with_named_column("oid", ScalarType::Oid.nullable(false))
-                .with_named_column("amname", ScalarType::String.nullable(false))
-                .with_named_column("amhandler", ScalarType::RegProc.nullable(false))
-                .with_named_column("amtype", ScalarType::Char{length: Some(1)}.nullable(false))
-                .with_key(vec![0]),
-        id: GlobalId::System(4049),
-        index_id: GlobalId::System(4050),
-        persistent: false,
-    };
 }
 
 pub const MZ_RELATIONS: BuiltinView = BuiltinView {
@@ -1633,8 +1620,12 @@ WHERE c.relkind = ANY (ARRAY['r','p'])",
 pub const PG_ACCESS_METHODS: BuiltinView = BuiltinView {
     name: "pg_am",
     schema: PG_CATALOG_SCHEMA,
-    sql: "CREATE VIEW pg_am AS
-SELECT * from mz_catalog.mz_ams",
+    sql: "CREATE VIEW pg_am AS \
+SELECT NULL::pg_catalog.oid AS oid, \
+    NULL::pg_catalog.text AS amname, \
+    NULL::pg_catalog.regproc AS amhandler, \
+    NULL::pg_catalog.char(1) AS amtype \
+WHERE false",
     id: GlobalId::System(5036),
     needs_logs: false,
 };
@@ -1746,7 +1737,6 @@ lazy_static! {
             Builtin::Table(&MZ_PROMETHEUS_READINGS),
             Builtin::Table(&MZ_PROMETHEUS_HISTOGRAMS),
             Builtin::Table(&MZ_PROMETHEUS_METRICS),
-            Builtin::Table(&MZ_ACCESS_METHODS),
             Builtin::View(&MZ_CATALOG_NAMES),
             Builtin::View(&MZ_ARRANGEMENT_SHARING),
             Builtin::View(&MZ_ARRANGEMENT_SIZES),

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -367,6 +367,7 @@ mz_source_info                                system true          volatile    l
 mz_worker_materialization_frontiers           system true          volatile    local
 
 > SHOW TABLES FROM mz_catalog
+mz_ams
 mz_array_types
 mz_avro_ocf_sinks
 mz_base_types
@@ -395,6 +396,7 @@ mz_views
 > SHOW FULL TABLES FROM mz_catalog
 name                  type
 ----------------------------
+mz_ams                system
 mz_array_types        system
 mz_avro_ocf_sinks     system
 mz_base_types         system
@@ -425,6 +427,7 @@ mz_views              system
 > SHOW TABLES FROM tester
 
 > SHOW EXTENDED tables FROM tester
+mz_ams
 mz_array_types
 mz_avro_ocf_sinks
 mz_base_types
@@ -456,6 +459,7 @@ mz_views
 test_table
 
 > SHOW EXTENDED tables FROM tester
+mz_ams
 mz_array_types
 mz_avro_ocf_sinks
 mz_base_types
@@ -484,11 +488,11 @@ test_table
 
 # `SHOW TABLES` and `mz_tables` should agree.
 > SELECT COUNT(*) FROM mz_tables WHERE id LIKE 's%'
-24
+25
 
 # There is one entry in mz_indexes for each field_number/expression of the index.
 > SELECT COUNT(id) FROM mz_indexes WHERE id LIKE 's%'
-43
+44
 
 > SHOW VIEWS FROM mz_catalog
 mz_arrangement_sharing

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -367,7 +367,6 @@ mz_source_info                                system true          volatile    l
 mz_worker_materialization_frontiers           system true          volatile    local
 
 > SHOW TABLES FROM mz_catalog
-mz_ams
 mz_array_types
 mz_avro_ocf_sinks
 mz_base_types
@@ -396,7 +395,6 @@ mz_views
 > SHOW FULL TABLES FROM mz_catalog
 name                  type
 ----------------------------
-mz_ams                system
 mz_array_types        system
 mz_avro_ocf_sinks     system
 mz_base_types         system
@@ -427,7 +425,6 @@ mz_views              system
 > SHOW TABLES FROM tester
 
 > SHOW EXTENDED tables FROM tester
-mz_ams
 mz_array_types
 mz_avro_ocf_sinks
 mz_base_types
@@ -459,7 +456,6 @@ mz_views
 test_table
 
 > SHOW EXTENDED tables FROM tester
-mz_ams
 mz_array_types
 mz_avro_ocf_sinks
 mz_base_types
@@ -488,11 +484,11 @@ test_table
 
 # `SHOW TABLES` and `mz_tables` should agree.
 > SELECT COUNT(*) FROM mz_tables WHERE id LIKE 's%'
-25
+24
 
 # There is one entry in mz_indexes for each field_number/expression of the index.
 > SELECT COUNT(id) FROM mz_indexes WHERE id LIKE 's%'
-44
+43
 
 > SHOW VIEWS FROM mz_catalog
 mz_arrangement_sharing

--- a/test/testdrive/pg-catalog.td
+++ b/test/testdrive/pg-catalog.td
@@ -22,6 +22,7 @@ oid          false     oid
 relname      false     text
 relnamespace false     oid
 relowner     true      oid
+relam        false     oid
 relkind      true      text
 
 > SHOW COLUMNS FROM pg_database


### PR DESCRIPTION
<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

- Add `pg_am` table. This table is empty and do not contain the expected PG values.
- add relam to `pg_catalog.pg_classes` which is always 0 to indicate that there is no specified access method.

### Motivation

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug: [Link to issue.]

  * This PR adds a known-desirable feature: [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

Required for BI tools.

I have decided not to add a RN since these tables do not contain any data.