### PR TITLE
test/kafka-exactly-once: use standard kafka version, not latest

### DIFF
--- a/test/kafka-exactly-once/mzcompose.yml
+++ b/test/kafka-exactly-once/mzcompose.yml
@@ -12,7 +12,7 @@ version: '3.7'
 mzworkflows:
   kafka-exactly-once:
     env:
-      KAFKA_VERSION: latest
+      KAFKA_VERSION: "5.5.4"
       # when testing this on your local machine update SEED
       # when running this repeatedly to ensure topics don't clash
       SEED: ${SEED:-1}


### PR DESCRIPTION
Depending on the `latest` tag makes PR builds not reproducible. The most
recent `latest` tag seems to have a bug that causes Kafka to fail to
boot.

### Motivation

  * This PR fixes a previously unreported bug: CI failing on the Kafka EOS test.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
