### PR TITLE
expr: concrete function definition for `pg_get_constraintref`

### DIFF
--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -210,6 +210,7 @@ ENV TARGET_CXX=$CXX
 ENV PATH=/opt/x-tools/$ARCH_GCC-unknown-linux-gnu/bin:$PATH
 ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=x86_64-unknown-linux-gnu-cc
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-unknown-linux-gnu-cc
+ENV CARGO_INCREMENTAL=0
 
 # Set a environment variable that tools can check to see if they're in the
 # builder or not.

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -54,6 +54,8 @@ steps:
   - id: lint-macos
     label: ":mac: clippy"
     command: bin/check
+    env:
+      - CARGO_INCREMENTAL: "0"
     inputs:
       - Cargo.lock
       - "**/Cargo.toml"

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -1749,7 +1749,10 @@ fn date_part_interval_inner(
         | DateTimeUnits::DayOfWeek
         | DateTimeUnits::DayOfYear
         | DateTimeUnits::IsoDayOfWeek
-        | DateTimeUnits::IsoDayOfYear => Err(EvalError::UnsupportedDateTimeUnits(units)),
+        | DateTimeUnits::IsoDayOfYear => Err(EvalError::Unsupported {
+            feature: format!("'{}' timestamp units", units),
+            issue_no: None,
+        }),
     }
 }
 
@@ -1789,7 +1792,10 @@ where
         DateTimeUnits::Timezone
         | DateTimeUnits::TimezoneHour
         | DateTimeUnits::TimezoneMinute
-        | DateTimeUnits::IsoDayOfYear => Err(EvalError::UnsupportedDateTimeUnits(units)),
+        | DateTimeUnits::IsoDayOfYear => Err(EvalError::Unsupported {
+            feature: format!("'{}' timestamp units", units),
+            issue_no: None,
+        }),
     }
 }
 
@@ -1798,16 +1804,16 @@ where
     T: TimestampLike,
 {
     let stride_ns = if stride.months != 0 {
-        Err(EvalError::FeatureNotSupported(
+        Err(EvalError::DateBinOutOfRange(
             "timestamps cannot be binned into intervals containing months or years".to_string(),
         ))
     } else if stride.duration <= 0 {
-        Err(EvalError::FeatureNotSupported(
+        Err(EvalError::DateBinOutOfRange(
             "stride must be greater than zero".to_string(),
         ))
     } else {
         i64::try_from(stride.duration).map_err(|_| {
-            EvalError::FeatureNotSupported("stride cannot exceed 2^63 nanoseconds".to_string())
+            EvalError::DateBinOutOfRange("stride cannot exceed 2^63 nanoseconds".to_string())
         })
     }?;
 
@@ -1817,7 +1823,7 @@ where
     let sub_stride = origin > source;
 
     let tm_diff = (source - origin.clone()).num_nanoseconds().ok_or_else(|| {
-        EvalError::FeatureNotSupported(
+        EvalError::DateBinOutOfRange(
             "source and origin must not differ more than 2^63 nanoseconds".to_string(),
         )
     })?;
@@ -1868,7 +1874,10 @@ where
         | DateTimeUnits::DayOfWeek
         | DateTimeUnits::DayOfYear
         | DateTimeUnits::IsoDayOfWeek
-        | DateTimeUnits::IsoDayOfYear => Err(EvalError::UnsupportedDateTimeUnits(units)),
+        | DateTimeUnits::IsoDayOfYear => Err(EvalError::Unsupported {
+            feature: format!("'{}' timestamp units", units),
+            issue_no: None,
+        }),
     }
 }
 

--- a/src/expr/src/scalar/func/impls/oid.rs
+++ b/src/expr/src/scalar/func/impls/oid.rs
@@ -9,6 +9,8 @@
 
 use repr::adt::system::{Oid, RegClass, RegProc, RegType};
 
+use crate::EvalError;
+
 sqlfunc!(
     #[sqlname = "oidtoi32"]
     #[preserves_uniqueness = true]
@@ -38,5 +40,14 @@ sqlfunc!(
     #[preserves_uniqueness = true]
     fn cast_oid_to_reg_type(a: Oid) -> RegType {
         RegType(a.0)
+    }
+);
+
+sqlfunc!(
+    fn pg_get_constraintdef(_oid: Option<Oid>) -> Result<String, EvalError> {
+        Err(EvalError::Unsupported {
+            feature: "pg_get_constraintdef".to_string(),
+            issue_no: Some(9483),
+        })
     }
 );

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -1282,9 +1282,6 @@ impl fmt::Display for EvalError {
             } => {
                 write!(f, "value too long for type {}({})", target_type, length)
             }
-            EvalError::NotImplemented { function_name } => {
-                write!(f, "{} is not yet implemented", function_name)
-            }
         }
     }
 }

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -1130,8 +1130,12 @@ impl CheckedRecursion for MirScalarExprVisitor {
     Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzEnumReflect,
 )]
 pub enum EvalError {
+    DateBinOutOfRange(String),
     DivisionByZero,
-    FeatureNotSupported(String),
+    Unsupported {
+        feature: String,
+        issue_no: Option<usize>,
+    },
     FloatOverflow,
     FloatUnderflow,
     NumericFieldOverflow,
@@ -1168,7 +1172,6 @@ pub enum EvalError {
     InvalidParameterValue(String),
     NegSqrt,
     UnknownUnits(String),
-    UnsupportedDateTimeUnits(DateTimeUnits),
     UnterminatedLikeEscapeSequence,
     Parse(ParseError),
     ParseHex(ParseHexError),
@@ -1184,17 +1187,19 @@ pub enum EvalError {
         target_type: String,
         length: usize,
     },
-    NotImplemented {
-        function_name: String,
-    },
 }
 
 impl fmt::Display for EvalError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
+            EvalError::DateBinOutOfRange(message) => f.write_str(message),
             EvalError::DivisionByZero => f.write_str("division by zero"),
-            EvalError::FeatureNotSupported(feature) => {
-                write!(f, "{}", feature)
+            EvalError::Unsupported { feature, issue_no } => {
+                write!(f, "{} not yet supported", feature)?;
+                if let Some(issue_no) = issue_no {
+                    write!(f, ", see https://github.com/MaterializeInc/materialize/issues/{} for more details", issue_no)?;
+                }
+                Ok(())
             }
             EvalError::FloatOverflow => f.write_str("value out of range: overflow"),
             EvalError::FloatUnderflow => f.write_str("value out of range: underflow"),
@@ -1244,9 +1249,6 @@ impl fmt::Display for EvalError {
             EvalError::InvalidRegexFlag(c) => write!(f, "invalid regular expression flag: {}", c),
             EvalError::InvalidParameterValue(s) => f.write_str(s),
             EvalError::UnknownUnits(units) => write!(f, "unknown units '{}'", units),
-            EvalError::UnsupportedDateTimeUnits(units) => {
-                write!(f, "unsupported timestamp units '{}'", units)
-            }
             EvalError::UnterminatedLikeEscapeSequence => {
                 f.write_str("unterminated escape sequence in LIKE")
             }

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1610,15 +1610,8 @@ lazy_static! {
             // view. It currently returns no information as the `pg_constraint` view is empty in
             // materialize
             "pg_get_constraintdef" => Scalar {
-                params!(Oid) => {
-                    UnaryFunc::NotImplemented{function_name:"pg_get_constraintdef".to_string()}}, 1387;
-                params!(Oid, Bool) => Operation::binary(|_ecx, e, _| {
-                    Ok(
-                        e.call_unary(
-                            UnaryFunc::NotImplemented{function_name: "pg_get_constraintdef".to_string()}
-                        )
-                    )
-                }), 2508;
+                params!(Oid) => UnaryFunc::PgGetConstraintdef(func::PgGetConstraintdef), 1387;
+                params!(Oid, Bool) => BinaryFunc::PgGetConstraintdef, 2508;
             },
             // pg_get_expr is meant to convert the textual version of
             // pg_node_tree data into parseable expressions. However, we don't

--- a/test/sqllogictest/pg_get_constraintdef.slt
+++ b/test/sqllogictest/pg_get_constraintdef.slt
@@ -18,12 +18,12 @@ query T
 SELECT pg_get_constraintdef(pg_constraint.oid) FROM pg_constraint
 ----
 
-query error pg_get_constraintdef is not yet implemented
+query error pg_get_constraintdef not yet supported
 SELECT pg_get_constraintdef(885)
 
 query T
 SELECT pg_get_constraintdef(pg_constraint.oid, true) FROM pg_constraint
 ----
 
-query error pg_get_constraintdef is not yet implemented
+query error pg_get_constraintdef not yet supported
 SELECT pg_get_constraintdef(885, true)


### PR DESCRIPTION
### Motivation

Apart from the possibility of implementing it in the future, this aligns the function with the effort of migrating all functions away from the raw enum definition style.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
