### PR TITLE
Reject multiple materializations of sources that cannot handle them

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -107,6 +107,11 @@ These changes are present in [unstable builds](/versions/#unstable-builds) and
 are slated for inclusion in the next stable release. There may be additional
 changes that have not yet been documented.
 
+- Detect and reject multiple materializations of sources that would silently
+  lose data when materialized more than once. This enables safe use of
+  unmaterialized PostgreSQL and S3 with SQS notifications sources. {{% gh 8203
+  %}}
+
 - Fix a bug in the `ILIKE` operator where matching against a [`char`] value did
   not take any trailing spaces into account {{% gh 10075 %}}. The new behavior
   matches the behavior of the `LIKE` operator.

--- a/doc/user/content/sql/create-source/postgres.md
+++ b/doc/user/content/sql/create-source/postgres.md
@@ -50,7 +50,7 @@ Before creating the source in Materialize, you must:
 
      As a heads-up, you should expect a performance hit in the database from increased CPU usage. For more information, see the [PostgreSQL documentation](https://www.postgresql.org/docs/current/logical-replication-publication.html).
 
-1. Create a Postgres [publication](https://www.postgresql.org/docs/current/logical-replication-publication.html), or replication data set, containing the tables to be streamed to Materialize. Since Postgres sources are materialized (kept in memory) in their entirety, we strongly recommend that you limit publications only to the data you need to query.
+1. Create a Postgres [publication](https://www.postgresql.org/docs/current/logical-replication-publication.html), or replication data set, containing the tables to be streamed to Materialize.
 
 Once you create a materialized source from the publication, the source will contain the raw data stream of replication updates. You can then break the stream out into views that represent the publication's original tables with [`CREATE VIEWS`](/sql/create-views/). You can treat these tables as you would any other source and create other views or materialized views from them.
 
@@ -77,6 +77,8 @@ Make sure to delete any replication slots if you stop using Materialize or if ei
 
 If you stop or delete Materialize without first dropping the Postgres source, the Postgres replication slot isn't deleted and will continue to accumulate data. In such cases, you should manually delete the Materialize replication slot to recover memory and avoid degraded performance in the upstream database. Materialize replication slot names always begin with `materialize_` for easy identification.
 
+Each Materialize replication slot can be used to source data for at most one set of materialized views. You can create multiple unmaterialized views for the same replication slot using the [`CREATE VIEWS`](/sql/create-views) statement.
+
 ### Restrictions on Postgres sources
 
 - **Schema changes:** Materialize does not support changes to schemas for existing publications. You need to drop the existing sources and then recreate them after creating new publications for the updated schemas.
@@ -84,7 +86,6 @@ If you stop or delete Materialize without first dropping the Postgres source, th
 - **Truncation:** Tables replicated into Materialize should not be truncated. If a table is truncated while replicated, the whole source becomes inaccessible and will not produce any data until it is re-created.
 - **Resource usage:**
     - During the initial table sync, **disk space** consumption may increase proportionally to the size of the upstream database before returning to a steady state. To profile disk usage, see [Troubleshooting](/ops/troubleshooting/#how-much-disk-space-is-materialize-using).
-    - Since Postgres sources are materialized by default, the replicated Postgres source tables must fit into **available memory**.
 
 ### Supported Postgres versions
 

--- a/doc/user/layouts/partials/create-source/connector/s3/details.html
+++ b/doc/user/layouts/partials/create-source/connector/s3/details.html
@@ -81,9 +81,8 @@ multiple SQS queues subscribed to it, one SQS queue per source. Note that SQS qu
 SNS topics intended for Materialize must be configured to use [raw message delivery][raw-delivery].
 
 Since Materialize treats unmaterialized sources with multiple downstream views as separate sources,
-`SQS NOTIFICATIONS` should not be used with unmaterialized sources. This behavior of unmaterialized
-sources is considered a bug ([#7423](https://github.com/MaterializeInc/materialize/issues/7423)),
-and will be improved in a future release.
+`SQS NOTIFICATIONS` can not be shared across multiple materializations of the same source. You must
+create separate SQS queues for each S3 notification source.
 
 [notification-aws]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/NotificationHowTo.html
 [notification-tutorial]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/ways-to-add-notification-config-to-bucket.html

--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -198,6 +198,26 @@ impl CatalogState {
         (indexes, unmaterialized)
     }
 
+    /// Computes the IDs of any indexes that transitively depend on this catalog
+    /// entry.
+    pub fn dependent_indexes(&self, id: GlobalId) -> Vec<GlobalId> {
+        let mut out = Vec::new();
+        self.dependent_indexes_inner(id, &mut out);
+        out
+    }
+
+    fn dependent_indexes_inner(&self, id: GlobalId, out: &mut Vec<GlobalId>) {
+        let entry = self.get_by_id(&id);
+        match entry.item() {
+            CatalogItem::Index(_) => out.push(id),
+            _ => {
+                for id in entry.used_by() {
+                    self.dependent_indexes_inner(*id, out)
+                }
+            }
+        }
+    }
+
     pub fn uses_tables(&self, id: GlobalId) -> bool {
         match self.get_by_id(&id).item() {
             CatalogItem::Table(_) => true,
@@ -770,6 +790,18 @@ impl CatalogItem {
             }
         }
     }
+
+    pub fn requires_single_materialization(&self) -> bool {
+        if let CatalogItem::Source(Source {
+            connector: SourceConnector::External { ref connector, .. },
+            ..
+        }) = self
+        {
+            connector.requires_single_materialization()
+        } else {
+            false
+        }
+    }
 }
 
 impl CatalogEntry {
@@ -781,6 +813,14 @@ impl CatalogEntry {
     /// Returns the [`sql::func::Func`] associated with this `CatalogEntry`.
     pub fn func(&self) -> Result<&'static sql::func::Func, SqlCatalogError> {
         self.item.func(&self.name)
+    }
+
+    /// Return the [`Index`] if this entry is an Index, else None.
+    pub fn index(&self) -> Option<&Index> {
+        match self.item() {
+            CatalogItem::Index(idx) => Some(idx),
+            _ => None,
+        }
     }
 
     /// Returns the [`dataflow_types::sources::SourceConnector`] associated with

--- a/src/coord/src/coord/arrangement_state.rs
+++ b/src/coord/src/coord/arrangement_state.rs
@@ -44,6 +44,11 @@ impl<T: Timestamp> ArrangementFrontiers<T> {
     pub fn contains_key(&self, id: GlobalId) -> bool {
         self.index.contains_key(&id)
     }
+    pub fn intersection(&self, ids: impl IntoIterator<Item = GlobalId>) -> Vec<GlobalId> {
+        ids.into_iter()
+            .filter(|id| self.contains_key(*id))
+            .collect()
+    }
     pub fn insert(&mut self, id: GlobalId, state: Frontiers<T>) -> Option<Frontiers<T>> {
         self.index.insert(id, state)
     }

--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -15,6 +15,7 @@
 //! isolates that logic from the rest of the somewhat complicated coordinator.
 
 use super::*;
+use crate::error::RematerializedSourceType;
 use ore::stack::maybe_grow;
 
 /// Borrows of catalog and indexes sufficient to build dataflow descriptions.
@@ -66,11 +67,15 @@ where
 impl<'a> DataflowBuilder<'a> {
     /// Imports the view, source, or table with `id` into the provided
     /// dataflow description.
-    fn import_into_dataflow(&mut self, id: &GlobalId, dataflow: &mut DataflowDesc) {
+    fn import_into_dataflow(
+        &mut self,
+        id: &GlobalId,
+        dataflow: &mut DataflowDesc,
+    ) -> Result<(), CoordError> {
         maybe_grow(|| {
             // Avoid importing the item redundantly.
             if dataflow.is_imported(id) {
-                return;
+                return Ok(());
             }
 
             // A valid index is any index on `id` that is known to the dataflow
@@ -115,6 +120,27 @@ impl<'a> DataflowBuilder<'a> {
                         );
                     }
                     CatalogItem::Source(source) => {
+                        if source.connector.requires_single_materialization() {
+                            let source_type =
+                                RematerializedSourceType::for_connector(&source.connector);
+                            let dependent_indexes = self.catalog.dependent_indexes(*id);
+                            // If this source relies on any pre-existing indexes (i.e., indexes
+                            // that we're not building as part of this `DataflowBuilder`), we're
+                            // attempting to reinstantiate a single-use source.
+                            let intersection = self.indexes.intersection(dependent_indexes);
+                            if !intersection.is_empty() {
+                                let existing_indexes = intersection
+                                    .iter()
+                                    .map(|id| self.catalog.get_by_id(id).name().item.clone())
+                                    .collect();
+                                return Err(CoordError::InvalidRematerialization {
+                                    base_source: entry.name().item.clone(),
+                                    existing_indexes,
+                                    source_type,
+                                });
+                            }
+                        }
+
                         let source_connector = dataflow_types::sources::SourceDesc {
                             name: entry.name().to_string(),
                             connector: source.connector.clone(),
@@ -140,16 +166,17 @@ impl<'a> DataflowBuilder<'a> {
                                     _ => {}
                                 };
                             });
-                            self.import_view_into_dataflow(id, &transformation, dataflow);
+                            self.import_view_into_dataflow(id, &transformation, dataflow)?;
                         }
                     }
                     CatalogItem::View(view) => {
                         let expr = view.optimized_expr.clone();
-                        self.import_view_into_dataflow(id, &expr, dataflow);
+                        self.import_view_into_dataflow(id, &expr, dataflow)?;
                     }
                     _ => unreachable!(),
                 }
             }
+            Ok(())
         })
     }
 
@@ -160,10 +187,10 @@ impl<'a> DataflowBuilder<'a> {
         view_id: &GlobalId,
         view: &OptimizedMirRelationExpr,
         dataflow: &mut DataflowDesc,
-    ) {
+    ) -> Result<(), CoordError> {
         // TODO: We only need to import Get arguments for which we cannot find arrangements.
         for get_id in view.global_uses() {
-            self.import_into_dataflow(&get_id, dataflow);
+            self.import_into_dataflow(&get_id, dataflow)?;
 
             // TODO: indexes should be imported after the optimization process, and only those
             // actually used by the optimized plan
@@ -185,6 +212,7 @@ impl<'a> DataflowBuilder<'a> {
             }
         }
         dataflow.insert_view(*view_id, view.clone());
+        Ok(())
     }
 
     /// Builds a dataflow description for the index with the specified ID.
@@ -193,13 +221,13 @@ impl<'a> DataflowBuilder<'a> {
         name: String,
         id: GlobalId,
         index_description: dataflow_types::IndexDesc,
-    ) -> DataflowDesc {
+    ) -> Result<DataflowDesc, CoordError> {
         let on_entry = self.catalog.get_by_id(&index_description.on_id);
         let on_type = on_entry.desc().unwrap().typ().clone();
         let mut dataflow = DataflowDesc::new(name);
-        self.import_into_dataflow(&index_description.on_id, &mut dataflow);
+        self.import_into_dataflow(&index_description.on_id, &mut dataflow)?;
         dataflow.export_index(id, index_description, on_type);
-        dataflow
+        Ok(dataflow)
     }
 
     /// Builds a dataflow description for the sink with the specified name,
@@ -212,11 +240,11 @@ impl<'a> DataflowBuilder<'a> {
         name: String,
         id: GlobalId,
         sink_description: dataflow_types::sinks::SinkDesc,
-    ) -> DataflowDesc {
+    ) -> Result<DataflowDesc, CoordError> {
         let mut dataflow = DataflowDesc::new(name);
         dataflow.set_as_of(sink_description.as_of.frontier.clone());
-        self.import_into_dataflow(&sink_description.from, &mut dataflow);
+        self.import_into_dataflow(&sink_description.from, &mut dataflow)?;
         dataflow.export_sink(id, sink_description);
-        dataflow
+        Ok(dataflow)
     }
 }

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -351,6 +351,7 @@ impl ErrorResponse {
             CoordError::Eval(_) => SqlState::INTERNAL_ERROR,
             CoordError::IdExhaustionError => SqlState::INTERNAL_ERROR,
             CoordError::IncompleteTimestamp(_) => SqlState::SQL_STATEMENT_NOT_YET_COMPLETE,
+            CoordError::InvalidRematerialization { .. } => SqlState::FEATURE_NOT_SUPPORTED,
             CoordError::InvalidParameterType(_) => SqlState::INVALID_PARAMETER_VALUE,
             CoordError::InvalidParameterValue { .. } => SqlState::INVALID_PARAMETER_VALUE,
             CoordError::InvalidTableMutationSelection => SqlState::INVALID_TRANSACTION_STATE,

--- a/test/pg-cdc/reject-multiple-materializations.td
+++ b/test/pg-cdc/reject-multiple-materializations.td
@@ -1,0 +1,73 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Test that any replication slot can only be materialized once
+#
+
+
+# Insert data pre-snapshot
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER USER postgres WITH replication;
+DROP SCHEMA IF EXISTS public CASCADE;
+DROP PUBLICATION IF EXISTS mz_source;
+
+CREATE SCHEMA public;
+
+CREATE TABLE t1 (id SERIAL PRIMARY KEY, f1 BOOLEAN);
+ALTER TABLE t1 REPLICA IDENTITY FULL;
+
+CREATE TABLE t2 (id SERIAL PRIMARY KEY, t1_id INT REFERENCES t1(id), name VARCHAR);
+
+INSERT INTO t1(f1) VALUES ('true'),('false');
+
+INSERT INTO t2(t1_id, name) VALUES (1, 'example');
+
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+> CREATE SOURCE mz_source
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
+  PUBLICATION 'mz_source';
+
+> CREATE VIEWS FROM SOURCE mz_source;
+
+> CREATE MATERIALIZED VIEW t1_mat AS
+  SELECT * FROM t1
+
+> SELECT id, f1 FROM t1_mat;
+1 true
+2 false
+
+! CREATE MATERIALIZED VIEW t1_mat_dupe AS
+  SELECT * FROM t1
+Cannot re-materialize source mz_source
+
+! CREATE MATERIALIZED VIEWS FROM SOURCE mz_source (t1 as t1_not_a_dupe, t2 as t2_not_a_dupe)
+Cannot re-materialize source mz_source
+
+> DROP VIEW t1_mat;
+
+> DROP SOURCE mz_source CASCADE;
+
+# verify that dropping things allows recreation
+
+> CREATE SOURCE mz_source
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
+  PUBLICATION 'mz_source';
+
+> CREATE VIEWS FROM SOURCE mz_source;
+
+> CREATE MATERIALIZED VIEW joiner AS
+  SELECT t2.id, t1.f1, t2.name
+  FROM t1
+  JOIN t2
+  ON   t1.id = t2.t1_id
+
+> SELECT * FROM joiner;
+1 true example

--- a/test/testdrive/esoteric/s3-sqs-reject-multiple-materializations.td
+++ b/test/testdrive/esoteric/s3-sqs-reject-multiple-materializations.td
@@ -1,0 +1,98 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set buk=mz-sqs-double-mat-test
+
+$ s3-create-bucket bucket=${buk}
+
+$ s3-add-notifications bucket=${buk} queue=${buk} sqs-validation-timeout=5m
+
+
+> CREATE SOURCE s3_double_mat
+  FROM S3
+  DISCOVER OBJECTS USING SQS NOTIFICATIONS 'testdrive-${buk}-${testdrive.seed}'
+    WITH (
+    region = '${testdrive.aws-region}',
+    endpoint = '${testdrive.aws-endpoint}',
+    access_key_id = '${testdrive.aws-access-key-id}',
+    secret_access_key = '${testdrive.aws-secret-access-key}',
+    token = '${testdrive.aws-token}'
+  )
+  FORMAT TEXT;
+
+> CREATE MATERIALIZED VIEW s3_double_mat_initial_view AS
+  SELECT * FROM s3_double_mat
+
+> CREATE VIEW s3_double_mat_view_reuse AS
+  SELECT text FROM s3_double_mat_initial_view
+
+! CREATE MATERIALIZED VIEW s3_double_mat_error AS
+  SELECT * FROM s3_double_mat
+Cannot re-materialize source s3_double_mat
+
+# check that going through multiple unmaterialized views doesn't allow hiding from the error
+> CREATE VIEW s3_double_mat_unmaterialized AS
+  SELECT * FROM s3_double_mat
+
+> CREATE VIEW s3_double_mat_unmaterialized_extra AS
+  SELECT * FROM s3_double_mat_unmaterialized
+
+! CREATE MATERIALIZED VIEW s3_double_mat_unmaterialized_final AS
+  SELECT * FROM s3_double_mat_unmaterialized_extra
+Cannot re-materialize source s3_double_mat
+
+# check that dropping and recreating a view succeeds
+
+> DROP VIEW s3_double_mat_initial_view CASCADE
+
+> CREATE MATERIALIZED VIEW s3_double_mat_initial_view_recreated AS
+  SELECT * FROM s3_double_mat
+
+# check that an already materialized item that goes through multiple
+# unmaterialized views doesn't sneak past the check
+
+> DROP VIEW s3_double_mat_initial_view_recreated CASCADE
+
+> CREATE VIEW s3_double_mat_unmaterialized_2 AS
+  SELECT * FROM s3_double_mat
+
+> CREATE VIEW s3_double_mat_unmaterialized_extra_2 AS
+  SELECT * FROM s3_double_mat_unmaterialized_2
+
+> CREATE MATERIALIZED VIEW s3_double_mat_final_2 AS
+  SELECT * FROM s3_double_mat_unmaterialized_extra_2
+
+> CREATE MATERIALIZED VIEW s3_double_mat_final2_reuse AS
+  SELECT text FROM s3_double_mat_final_2
+
+! CREATE MATERIALIZED VIEW s3_double_mat_error AS
+  SELECT * FROM s3_double_mat
+Cannot re-materialize source s3_double_mat
+
+> CREATE VIEW s3_double_mat_unmaterialized_3 AS
+  SELECT * FROM s3_double_mat
+
+> CREATE VIEW s3_double_mat_unmaterialized_extra_3 AS
+  SELECT * FROM s3_double_mat_unmaterialized_3
+
+! CREATE MATERIALIZED VIEW s3_double_mat_error_3 AS
+  SELECT * FROM s3_double_mat_unmaterialized_extra_3
+Cannot re-materialize source s3_double_mat
+
+! CREATE INDEX s3_double_mat_custom_idx ON s3_double_mat (text)
+Cannot re-materialize source s3_double_mat
+
+! CREATE DEFAULT INDEX ON s3_double_mat
+Cannot re-materialize source s3_double_mat
+
+! CREATE SINK invalid_double_mat_sink FROM s3_double_mat
+  INTO KAFKA BROKER '${testdrive.kafka-addr}'
+  TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+Cannot re-materialize source s3_double_mat


### PR DESCRIPTION
 Reject multiple materializations of sources which would provide invalid data

Two existing source types (Postgres and S3 with notifications) would miss
upstream updates if instantiated multiple times. For example, two
S3/notification sources using the same SQS queue will each read and discard
arbitrary subsets of notifications, meaning that arbitrary subsets of S3
objects will be read by each materialization.

### Motivation

  * This PR adds a known-desirable feature: #8203 

### Tips for reviewer

@benesch @mjibson @sploiselle I had to add the previous state of the catalog to the `catalog_transact` method in order to be able to check that the newly-created views don't interact poorly with the previous state. This work is all in the first commit, not sure if there is a better way for this to have been done.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
  - [x] @petrosagg in particular I would love for you to look through the new tests for postgres and see if you can think of any other cases that should be covered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/9576)
<!-- Reviewable:end -->
