### PR TITLE
lowertest: Recursively add to ReflectedTypeInfo

### DIFF
--- a/src/expr-test-util/src/lib.rs
+++ b/src/expr-test-util/src/lib.rs
@@ -14,52 +14,22 @@ use proc_macro2::TokenTree;
 use serde_json::Value;
 
 use expr::explain::ViewExplanation;
-use expr::func::{
-    CastDateToTimestamp, CastInt16ToInt32, CastInt32ToInt64, CastInt64ToFloat64, CastInt64ToInt32,
-    CastNumericToInt64, CastStringToBool, IsNull, NegInt32, Not,
+use expr::{
+    DummyHumanizer, EvalError, ExprHumanizer, GlobalId, Id, LocalId, MirRelationExpr, MirScalarExpr,
 };
-use expr::*;
 use lowertest::*;
 use ore::result::ResultExt;
 use ore::str::separated;
 use repr::{ColumnType, RelationType, Row, ScalarType};
 use repr_test_util::*;
 
-gen_reflect_info_func!(
-    produce_rti,
-    [
-        BinaryFunc,
-        NullaryFunc,
-        UnaryFunc,
-        VariadicFunc,
-        MirScalarExpr,
-        ScalarType,
-        TableFunc,
-        AggregateFunc,
-        MirRelationExpr,
-        JoinImplementation,
-        EvalError,
-    ],
-    [
-        AggregateExpr,
-        CastDateToTimestamp,
-        CastInt16ToInt32,
-        CastInt32ToInt64,
-        CastInt64ToInt32,
-        CastInt64ToFloat64,
-        CastNumericToInt64,
-        CastStringToBool,
-        ColumnOrder,
-        ColumnType,
-        RelationType,
-        IsNull,
-        NegInt32,
-        Not
-    ]
-);
-
 lazy_static! {
-    pub static ref RTI: ReflectedTypeInfo = produce_rti();
+    pub static ref RTI: ReflectedTypeInfo = {
+        let mut rti = ReflectedTypeInfo::default();
+        EvalError::add_to_reflected_type_info(&mut rti);
+        MirRelationExpr::add_to_reflected_type_info(&mut rti);
+        rti
+    };
 }
 
 /// Builds a `MirScalarExpr` from a string.

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -19,7 +19,7 @@ use ordered_float::OrderedFloat;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
-use lowertest::MzEnumReflect;
+use lowertest::MzReflect;
 use ore::cast::CastFrom;
 use repr::adt::array::ArrayDimension;
 use repr::adt::interval::Interval;
@@ -588,7 +588,7 @@ where
     })
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzEnumReflect)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
 pub enum AggregateFunc {
     MaxNumeric,
     MaxInt16,
@@ -1134,7 +1134,7 @@ fn wrap<'a>(datums: &'a [Datum<'a>], width: usize) -> impl Iterator<Item = (Row,
     datums.chunks(width).map(|chunk| (Row::pack(chunk), 1))
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzEnumReflect)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
 pub enum TableFunc {
     JsonbEach {
         stringify: bool,

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -1064,14 +1064,14 @@ impl fmt::Display for AggregateFunc {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
 pub struct CaptureGroupDesc {
     pub index: u32,
     pub name: Option<String>,
     pub nullable: bool,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
 pub struct AnalyzedRegex(ReprRegex, Vec<CaptureGroupDesc>);
 
 impl AnalyzedRegex {

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -16,7 +16,7 @@ use std::fmt;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
-use lowertest::{MzEnumReflect, MzStructReflect};
+use lowertest::MzReflect;
 use ore::collections::CollectionExt;
 use ore::id_gen::IdGen;
 use ore::stack::{maybe_grow, CheckedRecursion, RecursionGuard, RecursionLimitError};
@@ -49,7 +49,7 @@ pub const RECURSION_LIMIT: usize = 2048;
 ///
 /// The AST is meant reflect the capabilities of the `differential_dataflow::Collection` type,
 /// written generically enough to avoid run-time compilation work.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzEnumReflect)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
 pub enum MirRelationExpr {
     /// A constant relation containing specified rows.
     ///
@@ -1851,7 +1851,7 @@ impl CheckedRecursion for MirRelationExprVisitor {
 }
 
 /// Specification for an ordering by a column.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, MzStructReflect)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, MzReflect)]
 pub struct ColumnOrder {
     /// The column index.
     pub column: usize,
@@ -1872,7 +1872,7 @@ impl fmt::Display for ColumnOrder {
 }
 
 /// Describes an aggregation expression.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzStructReflect)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
 pub struct AggregateExpr {
     /// Names the aggregation function.
     pub func: AggregateFunc,
@@ -2060,7 +2060,7 @@ impl fmt::Display for AggregateExpr {
 }
 
 /// Describe a join implementation in dataflow.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzEnumReflect)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
 pub enum JoinImplementation {
     /// Perform a sequence of binary differential dataflow joins.
     ///

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -65,6 +65,7 @@ pub enum MirRelationExpr {
     /// The runtime memory footprint of this operator is zero.
     Get {
         /// The identifier for the collection to load.
+        #[mzreflect(ignore)]
         id: Id,
         /// Schema of the collection.
         typ: RelationType,
@@ -74,6 +75,7 @@ pub enum MirRelationExpr {
     /// The runtime memory footprint of this operator is zero.
     Let {
         /// The identifier to be used in `Get` variants to retrieve `value`.
+        #[mzreflect(ignore)]
         id: LocalId,
         /// The collection to be bound to `id`.
         value: Box<MirRelationExpr>,

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -5621,7 +5621,9 @@ mod test {
         // care about input and output nullabilities.
         let dummy_col_nullable_type = ScalarType::Bool.nullable(true);
         let dummy_col_nonnullable_type = ScalarType::Bool.nullable(false);
-        for (variant, (_, f_types)) in UnaryFunc::mz_enum_reflect() {
+        let mut rti = lowertest::ReflectedTypeInfo::default();
+        UnaryFunc::add_to_reflected_type_info(&mut rti);
+        for (variant, (_, f_types)) in rti.enum_dict["UnaryFunc"].iter() {
             if f_types.is_empty() {
                 let unary_unit_variant: UnaryFunc =
                     serde_json::from_str(&format!("\"{}\"", variant)).unwrap();

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -27,7 +27,7 @@ use serde::{Deserialize, Serialize};
 use sha1::Sha1;
 use sha2::{Sha224, Sha256, Sha384, Sha512};
 
-use lowertest::MzEnumReflect;
+use lowertest::MzReflect;
 use ore::collections::CollectionExt;
 use ore::fmt::FormatBuffer;
 use ore::str::StrExt;
@@ -51,9 +51,7 @@ mod impls;
 
 pub use impls::*;
 
-#[derive(
-    Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzEnumReflect,
-)]
+#[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
 pub enum NullaryFunc {
     MzLogicalTimestamp,
 }
@@ -2066,9 +2064,7 @@ fn jsonb_pretty<'a>(a: Datum<'a>, temp_storage: &'a RowArena) -> Datum<'a> {
     Datum::String(temp_storage.push_string(buf))
 }
 
-#[derive(
-    Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzEnumReflect,
-)]
+#[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
 pub enum BinaryFunc {
     And,
     Or,
@@ -3090,9 +3086,7 @@ impl<T: for<'a> EagerUnaryFunc<'a>> LazyUnaryFunc for T {
     }
 }
 
-#[derive(
-    Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzEnumReflect,
-)]
+#[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
 pub enum UnaryFunc {
     Not(Not),
     IsNull(IsNull),
@@ -5374,9 +5368,7 @@ fn mz_render_typemod<'a>(
     Datum::String(inner)
 }
 
-#[derive(
-    Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzEnumReflect,
-)]
+#[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
 pub enum VariadicFunc {
     Coalesce,
     Concat,

--- a/src/expr/src/scalar/func/impls/char.rs
+++ b/src/expr/src/scalar/func/impls/char.rs
@@ -11,7 +11,7 @@ use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
-use lowertest::MzStructReflect;
+use lowertest::MzReflect;
 use repr::adt::char::{format_str_pad, Char};
 use repr::{ColumnType, ScalarType};
 
@@ -20,9 +20,7 @@ use crate::scalar::func::EagerUnaryFunc;
 /// All Char data is stored in Datum::String with its blank padding removed
 /// (i.e. trimmed), so this function provides a means of restoring any
 /// removed padding.
-#[derive(
-    Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzStructReflect,
-)]
+#[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
 pub struct PadChar {
     pub length: Option<usize>,
 }

--- a/src/expr/src/scalar/func/impls/float32.rs
+++ b/src/expr/src/scalar/func/impls/float32.rs
@@ -11,7 +11,7 @@ use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
-use lowertest::MzStructReflect;
+use lowertest::MzReflect;
 use repr::adt::numeric::{self, Numeric};
 use repr::{strconv, ColumnType, ScalarType};
 
@@ -119,9 +119,7 @@ sqlfunc!(
     }
 );
 
-#[derive(
-    Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzStructReflect,
-)]
+#[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
 pub struct CastFloat32ToNumeric(pub Option<u8>);
 
 impl<'a> EagerUnaryFunc<'a> for CastFloat32ToNumeric {

--- a/src/expr/src/scalar/func/impls/float64.rs
+++ b/src/expr/src/scalar/func/impls/float64.rs
@@ -12,7 +12,7 @@ use std::fmt;
 use chrono::{DateTime, NaiveDateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use lowertest::MzStructReflect;
+use lowertest::MzReflect;
 use repr::adt::numeric::{self, Numeric};
 use repr::{strconv, ColumnType, ScalarType};
 
@@ -127,9 +127,7 @@ sqlfunc!(
     }
 );
 
-#[derive(
-    Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzStructReflect,
-)]
+#[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
 pub struct CastFloat64ToNumeric(pub Option<u8>);
 
 impl<'a> EagerUnaryFunc<'a> for CastFloat64ToNumeric {

--- a/src/expr/src/scalar/func/impls/int16.rs
+++ b/src/expr/src/scalar/func/impls/int16.rs
@@ -11,7 +11,7 @@ use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
-use lowertest::MzStructReflect;
+use lowertest::MzReflect;
 use repr::adt::numeric::{self, Numeric};
 use repr::adt::system::Oid;
 use repr::{strconv, ColumnType, ScalarType};
@@ -90,9 +90,7 @@ sqlfunc!(
     }
 );
 
-#[derive(
-    Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzStructReflect,
-)]
+#[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
 pub struct CastInt16ToNumeric(pub Option<u8>);
 
 impl<'a> EagerUnaryFunc<'a> for CastInt16ToNumeric {

--- a/src/expr/src/scalar/func/impls/int32.rs
+++ b/src/expr/src/scalar/func/impls/int32.rs
@@ -11,7 +11,7 @@ use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
-use lowertest::MzStructReflect;
+use lowertest::MzReflect;
 use repr::adt::numeric::{self, Numeric};
 use repr::adt::system::{Oid, RegClass, RegProc, RegType};
 use repr::{strconv, ColumnType, ScalarType};
@@ -88,9 +88,7 @@ sqlfunc!(
     }
 );
 
-#[derive(
-    Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzStructReflect,
-)]
+#[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
 pub struct CastInt32ToNumeric(pub Option<u8>);
 
 impl<'a> EagerUnaryFunc<'a> for CastInt32ToNumeric {

--- a/src/expr/src/scalar/func/impls/int64.rs
+++ b/src/expr/src/scalar/func/impls/int64.rs
@@ -11,7 +11,7 @@ use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
-use lowertest::MzStructReflect;
+use lowertest::MzReflect;
 use repr::adt::numeric::{self, Numeric};
 use repr::adt::system::Oid;
 use repr::{strconv, ColumnType, ScalarType};
@@ -73,9 +73,7 @@ sqlfunc!(
     }
 );
 
-#[derive(
-    Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzStructReflect,
-)]
+#[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
 pub struct CastInt64ToNumeric(pub Option<u8>);
 
 impl<'a> EagerUnaryFunc<'a> for CastInt64ToNumeric {

--- a/src/expr/src/scalar/func/impls/string.rs
+++ b/src/expr/src/scalar/func/impls/string.rs
@@ -14,7 +14,7 @@ use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use lowertest::MzStructReflect;
+use lowertest::MzReflect;
 use ore::result::ResultExt;
 use repr::adt::char::{format_str_trim, Char};
 use repr::adt::interval::Interval;
@@ -75,9 +75,7 @@ sqlfunc!(
     }
 );
 
-#[derive(
-    Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzStructReflect,
-)]
+#[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
 pub struct CastStringToNumeric(pub Option<u8>);
 
 impl<'a> EagerUnaryFunc<'a> for CastStringToNumeric {
@@ -147,9 +145,7 @@ sqlfunc!(
     }
 );
 
-#[derive(
-    Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzStructReflect,
-)]
+#[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
 pub struct CastStringToArray {
     // Target array's type.
     pub return_ty: ScalarType,
@@ -211,9 +207,7 @@ impl fmt::Display for CastStringToArray {
     }
 }
 
-#[derive(
-    Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzStructReflect,
-)]
+#[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
 pub struct CastStringToList {
     // Target list's type
     pub return_ty: ScalarType,
@@ -280,9 +274,7 @@ impl fmt::Display for CastStringToList {
     }
 }
 
-#[derive(
-    Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzStructReflect,
-)]
+#[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
 pub struct CastStringToMap {
     // Target map's value type
     pub return_ty: ScalarType,
@@ -357,9 +349,7 @@ impl fmt::Display for CastStringToMap {
     }
 }
 
-#[derive(
-    Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzStructReflect,
-)]
+#[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
 pub struct CastStringToChar {
     pub length: Option<usize>,
     pub fail_on_len: bool,
@@ -395,9 +385,7 @@ impl fmt::Display for CastStringToChar {
     }
 }
 
-#[derive(
-    Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzStructReflect,
-)]
+#[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
 pub struct CastStringToVarChar {
     pub length: Option<usize>,
     pub fail_on_len: bool,

--- a/src/expr/src/scalar/func/macros.rs
+++ b/src/expr/src/scalar/func/macros.rs
@@ -67,7 +67,7 @@ macro_rules! sqlfunc {
             $body:block
     ) => {
         paste::paste! {
-            #[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize, Hash, lowertest::MzStructReflect)]
+            #[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize, Hash, lowertest::MzReflect)]
             pub struct [<$fn_name:camel>];
 
             impl<'a> crate::func::EagerUnaryFunc<'a> for [<$fn_name:camel>] {

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -15,7 +15,7 @@ use ore::stack::CheckedRecursion;
 use ore::stack::RecursionGuard;
 use serde::{Deserialize, Serialize};
 
-use lowertest::MzEnumReflect;
+use lowertest::MzReflect;
 use ore::collections::CollectionExt;
 use ore::stack::maybe_grow;
 use ore::str::separated;
@@ -32,9 +32,7 @@ use crate::RECURSION_LIMIT;
 pub mod func;
 pub mod like_pattern;
 
-#[derive(
-    Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzEnumReflect,
-)]
+#[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
 pub enum MirScalarExpr {
     /// A column of the input row
     Column(usize),
@@ -1141,9 +1139,7 @@ impl CheckedRecursion for MirScalarExprVisitor {
     }
 }
 
-#[derive(
-    Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzEnumReflect,
-)]
+#[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
 pub enum EvalError {
     DateBinOutOfRange(String),
     DivisionByZero,

--- a/src/lowertest-derive/src/lib.rs
+++ b/src/lowertest-derive/src/lib.rs
@@ -16,28 +16,41 @@ use proc_macro2::Span;
 use quote::{quote, ToTokens};
 use syn::{parse, Data, DeriveInput, Fields};
 
-/// Macro generating an implementation for the trait MzEnumReflect
-#[proc_macro_derive(MzEnumReflect)]
-pub fn mzenumreflect_derive(input: TokenStream) -> TokenStream {
+/// Macro generating an implementation for the trait MzReflect
+#[proc_macro_derive(MzReflect)]
+pub fn mzreflect_derive(input: TokenStream) -> TokenStream {
     // The intended trait implementation is
     // ```
-    // impl MzEnumReflect for #name {
-    //    fn mz_enum_reflect() ->
-    //    std::collections::HashMap<
-    //        &'static str,
-    //        (Vec<&'static str>, Vec<&'static str>)
-    //    >
+    // impl MzReflect for #name {
+    //    /// Adds the information required to create an object of this type
+    //    /// to `enum_dict` if it is an enum and to `struct_dict` if it is a
+    //    /// struct.
+    //    fn add_to_reflected_type_info(
+    //        rti: &mut lowertest::ReflectedTypeInfo
+    //    )
     //    {
+    //       // if the object is an enum
+    //       if rti.enum_dict.contains_key(#name) { return; }
     //       use std::collections::HashMap;
     //       let mut result = HashMap::new();
     //       // repeat line below for all variants
-    //       result.add(variant_name, (<field_names>, <field_types>))
-    //       result
+    //       result.insert(variant_name, (<field_names>, <field_types>));
+    //       rti.enum_dist.insert(<enum_name>, result);
+    //
+    //       // if the object is a struct
+    //       if rti.struct_dict.contains_key(#name) { return ; }
+    //       rti.struct_dict.insert(#name, (<field_names>, <field_types>));
+    //
+    //       // for all object types, repeat line below for each field type
+    //       // that should be recursively added to the reflected type info
+    //       <field_type>::add_reflect_type_info(enum_dict, struct_dict);
     //    }
     // }
     // ```
     let ast: DeriveInput = parse(input).unwrap();
 
+    let object_name = &ast.ident;
+    let object_name_as_string = object_name.to_string();
     let method_impl = if let Data::Enum(enumdata) = &ast.data {
         let variants = enumdata
             .variants
@@ -51,57 +64,28 @@ pub fn mzenumreflect_derive(input: TokenStream) -> TokenStream {
             })
             .collect::<Vec<_>>();
         quote! {
-          use std::collections::HashMap;
-          let mut result = HashMap::new();
-          #(#variants)*
-          result
+            if rti.enum_dict.contains_key(#object_name_as_string) { return; }
+            use std::collections::HashMap;
+            let mut result = HashMap::new();
+            #(#variants)*
+            rti.enum_dict.insert(#object_name_as_string, result);
         }
-    } else {
-        unreachable!("Not an enum")
-    };
-
-    let name = &ast.ident;
-    let gen = quote! {
-      impl lowertest::MzEnumReflect for #name {
-        fn mz_enum_reflect() ->
-            std::collections::HashMap<
-                &'static str,
-                (Vec<&'static str>, Vec<&'static str>)
-            >
-        {
-           #method_impl
-        }
-      }
-    };
-    gen.into()
-}
-
-/// Macro generating an implementation for the trait MzStructReflect
-#[proc_macro_derive(MzStructReflect)]
-pub fn mzstructreflect_derive(input: TokenStream) -> TokenStream {
-    // The intended trait implementation is
-    // ```
-    // impl MzStructReflect for #name {
-    //    fn mz_struct_reflect() -> (Vec<&'static str>, Vec<&'static str>)
-    //    {
-    //       (<field_names>, <field_types>))
-    //    }
-    // }
-    // ```
-    let ast: DeriveInput = parse(input).unwrap();
-    let method_impl = if let Data::Struct(structdata) = &ast.data {
+    } else if let Data::Struct(structdata) = &ast.data {
         let (names, types) = get_field_names_types(&structdata.fields);
         quote! {
-            (vec![#(#names),*], vec![#(#types),*])
+            if rti.struct_dict.contains_key(#object_name_as_string) { return; }
+            rti.struct_dict.insert(#object_name_as_string,
+                (vec![#(#names),*], vec![#(#types),*]));
         }
     } else {
-        unreachable!("Not a struct")
+        unreachable!("Not a struct or enum")
     };
 
-    let name = &ast.ident;
     let gen = quote! {
-      impl lowertest::MzStructReflect for #name {
-        fn mz_struct_reflect() -> (Vec<&'static str>, Vec<&'static str>)
+      impl lowertest::MzReflect for #object_name {
+        fn add_to_reflected_type_info(
+            rti: &mut lowertest::ReflectedTypeInfo
+        )
         {
            #method_impl
         }
@@ -112,13 +96,10 @@ pub fn mzstructreflect_derive(input: TokenStream) -> TokenStream {
 
 /// Generates a function that generates `ReflectedTypeInfo`
 ///
-/// Accepts three comma-separated arguments:
+/// Accepts two comma-separated arguments:
 /// * first is the name of the function to generate
-/// * second is a list of enums that can be looked up in the
+/// * second is a list of enums or structs that can be looked up in the
 /// `ReflectedTypeInfo`
-/// * third is a list of enums that can be looked up in the
-/// `ReflectedTypeInfo`
-/// The latter two arguments are optional
 #[proc_macro]
 pub fn gen_reflect_info_func(input: TokenStream) -> TokenStream {
     let mut input_iter = input.into_iter();
@@ -141,7 +122,7 @@ pub fn gen_reflect_info_func(input: TokenStream) -> TokenStream {
                 if let TokenTree::Ident(ident) = tt {
                     let type_name = ident.to_string();
                     let typ = syn::Ident::new(&type_name, Span::call_site());
-                    Some(quote! { enum_dict.insert(#type_name, #typ::mz_enum_reflect()) })
+                    Some(quote! { #typ::add_to_reflected_type_info(&mut result) })
                 } else {
                     None
                 }
@@ -158,7 +139,7 @@ pub fn gen_reflect_info_func(input: TokenStream) -> TokenStream {
                 if let TokenTree::Ident(ident) = tt {
                     let type_name = ident.to_string();
                     let typ = syn::Ident::new(&type_name, Span::call_site());
-                    Some(quote! { struct_dict.insert(#type_name, #typ::mz_struct_reflect()) })
+                    Some(quote! { #typ::add_to_reflected_type_info(&mut result) })
                 } else {
                     None
                 }
@@ -171,12 +152,13 @@ pub fn gen_reflect_info_func(input: TokenStream) -> TokenStream {
         fn #func_name () -> ReflectedTypeInfo {
             let mut enum_dict = std::collections::HashMap::new();
             let mut struct_dict = std::collections::HashMap::new();
-            #(#add_enums);* ;
-            #(#add_structs);* ;
-            ReflectedTypeInfo {
+            let mut result =  ReflectedTypeInfo {
                 enum_dict,
                 struct_dict
-            }
+            };
+            #(#add_enums);* ;
+            #(#add_structs);* ;
+            result
         }
     };
     gen.into()

--- a/src/lowertest/README.md
+++ b/src/lowertest/README.md
@@ -1,5 +1,21 @@
 # Utility for testing lower layers of the Materialize stack
 
+> If you are reading this because you are encountering a compile-time error that
+> looks something like:
+> ```
+>    ::: <path_to_file>:<lineno>:1
+>    |
+> <lineno> | pub <struct or enum> <Type> {
+>    | ------------------- variant or associated item `add_to_reflected_type_info` not found here
+>    |
+>    = help: items from traits can only be used if the trait is implemented and in scope
+>    = note: the following trait defines an item `add_to_reflected_type_info`, perhaps you need to implement it:
+>            candidate #1: `MzReflect`
+> = note: this error originates in the derive macro `MzReflect` (in Nightly builds, run with -Z macro-backtrace for more info)
+>  ```
+>
+> go [here](#0-required-trait-derivations).
+
 ## Purpose
 
 If you want to run tests on something like `MirRelationExpr`, specifying it in
@@ -87,8 +103,17 @@ recommended that the object also implement `serde::Serialize`.
 In order to translate the text syntax into a correctly-deserializable JSON
 string, we need information about enums and structs being created that are not
 specified in the test syntax.
-Thus, you need to derive the trait `MzReflect` for
-each enum or struct that you will need to construct your object.
+
+Thus, you need to derive the trait `MzReflect` for each enum or struct that
+you will need to construct your object. If you cannot derive the enum or struct
+because it is from an external crate, then you should add its name to
+`EXTERNAL_TYPES` in
+[../lowertest-derive/src/lib.rs](../lowertest-derive/src/lib.rs).
+
+If you have added a new type that is relied on by a type that derives the trait
+`MzReflect` and you do not derive the trait `MzReflect` or add the name of the
+type to `EXTERNAL_TYPES`, you may encounter the compile-time error shown at the
+top of this README.
 
 Default values are supported as long as the default fields are last. Put
 `#[serde(default)]` over any fields you want to be default and make sure those
@@ -118,23 +143,41 @@ enums and structs are keyed by string.
 ### 3. Feeding in type information
 
 Enum/struct information must be passed into the converter via
-the struct `ReflectedTypeInfo`. For your convenience, there is a macro to
-generate a function will produce the right `ReflectedTypeInfo` for the object
-you are trying to create.
-```
-get_reflect_info_func!(func_name, [EnumType1, .., EnumTypeN], [StructType1, ..,StructTypeN])
-```
-Calling `func_name()` will produce the desired `ReflectedTypeInfo`.
+the struct `ReflectedTypeInfo`.
 
-For instructions on how to manually populate `ReflectedTypeInfo`, see the struct
-documentation.
+To populate the `ReflectedTypeInfo` struct, add these two lines to your code:
+```
+let mut rti = ReflectedTypeInfo::default();
+<Object_type>::add_to_reflected_type_info(&mut rti);
+```
+
+Provided your object type is a [supported type](#supported-types), the
+`add_to_reflected_type_info` function will recursively add types your object
+type depends on to `ReflectedTypoInfo`.
+
+Notably, the type `Result<<ok_type>, <error_type>>` is not yet
+supported, so you may find that you need to separately add information about the
+error type to `ReflectedTypoInfo`.
+```
+<error_type>::add_to_reflected_type_info(&mut rti)
+```
+
+If it is unnecessary to add the type of a field to `ReflectedTypeInfo` because:
+* you have [overridden the syntax](#extending-the-syntax) such that you can
+construct an instance of the field without using the DSL
+* you have marked the field with the attribute `#[serde(default)]` and always
+  want the field to be initialized with the default value.
+You can add the attribute `#[mzreflect(ignore)]` to the field. If you do so,
+`add_to_reflected_type_info` will not add the type of the field to
+`ReflectedTypeInfo`, but it will add the types of other fields of the enum
+variant or struct without the attribute.
 
 ### 4. Feeding in syntax extensions
 
 If you don't need to extend or override the syntax, give a
 `&mut GenericTestDeserializationContext::default()`.
 
-Otherwise, see [#extending-the-syntax].
+Otherwise, see ["Extending the syntax"](#extending-the-syntax).
 
 ## Extending the syntax
 
@@ -153,7 +196,7 @@ The trait has a method `override_syntax`.
   should have left the stream untouched.
 * The fourth argument is the type of the object whose specification is currently
   being translated. Note that the name of the type is only guaranteed to be
-  accurate if it is a [supported type](supported-types). Thus, if an enum
+  accurate if it is a [supported type](#supported-types). Thus, if an enum
   variant (resp. struct) you are trying to create has a field that is not a
   supported type, you should use `override_syntax` to specify how to create the
   enum variant (resp. struct).
@@ -177,7 +220,17 @@ Since a one-arg enum or struct can be specified as `(<the_arg>)` or
 you from having to implement both syntaxes in `override_syntax`.
 
 The trait has a second method `reverse_syntax_override` to convert from JSON
-to the extended syntax. See [#roundtrip] for more details.
+to the extended syntax. See [Roundtrip](#roundtrip) for more details.
+
+If you implement the ability to construct an enum variant or a struct with
+an alternate syntax and you believe:
+1. the default syntax should not be used. OR
+2. it is unnecessary for the default syntax to be supported.
+
+you can add the attribute `#[mzreflect(ignore)]` to one or more fields of the
+enum variant or struct so that their types do not have to be added to
+`ReflectedTypeInfo`. This has the side effect of disabling the ability to
+construct the enum variant or the struct using the default syntax.
 
 ### Supported types
 
@@ -197,3 +250,5 @@ To convert a Rust object back into the readable syntax:
 1) Serialize the Rust object to a [serde_json::Value] object by calling
    `let json = serde_json::to_value(obj)?;`.
 2) Feed the json into the method `from_json`.
+
+[serde_json::Value]: https://docs.serde.rs/serde_json/enum.Value.html

--- a/src/lowertest/README.md
+++ b/src/lowertest/README.md
@@ -87,8 +87,8 @@ recommended that the object also implement `serde::Serialize`.
 In order to translate the text syntax into a correctly-deserializable JSON
 string, we need information about enums and structs being created that are not
 specified in the test syntax.
-Thus, you need to derive the trait `MzEnumReflect` (resp. `MzStructReflect`) for
-each enum (resp. struct) that you will need to construct your object.
+Thus, you need to derive the trait `MzReflect` for
+each enum or struct that you will need to construct your object.
 
 Default values are supported as long as the default fields are last. Put
 `#[serde(default)]` over any fields you want to be default and make sure those

--- a/src/lowertest/src/lib.rs
+++ b/src/lowertest/src/lib.rs
@@ -39,7 +39,7 @@ pub trait MzReflect {
 ///
 /// To add information required to construct a struct or enum,
 /// call `Type::add_to_reflected_type_info(enum_dict, struct_dict)`
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct ReflectedTypeInfo {
     pub enum_dict:
         HashMap<&'static str, HashMap<&'static str, (Vec<&'static str>, Vec<&'static str>)>>,
@@ -48,7 +48,7 @@ pub struct ReflectedTypeInfo {
 
 /* #endregion */
 
-/* #region Utilities */
+/* #region Public Utilities */
 
 /// Converts `s` into a [proc_macro2::TokenStream]
 pub fn tokenize(s: &str) -> Result<TokenStream, String> {

--- a/src/lowertest/src/lib.rs
+++ b/src/lowertest/src/lib.rs
@@ -19,7 +19,7 @@ use serde_json::Value;
 
 use ore::{result::ResultExt, str::separated, str::StrExt};
 
-pub use lowertest_derive::{gen_reflect_info_func, MzReflect};
+pub use lowertest_derive::MzReflect;
 
 /* #region Parts of the public interface related to collecting information
 about the fields of structs and enums. */

--- a/src/lowertest/tests/test_runner.rs
+++ b/src/lowertest/tests/test_runner.rs
@@ -19,33 +19,33 @@ mod tests {
     use serde::{Deserialize, Serialize};
     use serde_json::Value;
 
-    #[derive(Debug, Deserialize, PartialEq, Serialize, MzStructReflect)]
+    #[derive(Debug, Deserialize, PartialEq, Serialize, MzReflect)]
     struct ZeroArg;
 
-    #[derive(Debug, Deserialize, PartialEq, Serialize, MzStructReflect)]
+    #[derive(Debug, Deserialize, PartialEq, Serialize, MzReflect)]
     struct SingleUnnamedArg(Box<f64>);
 
-    #[derive(Debug, Deserialize, PartialEq, Serialize, MzStructReflect)]
+    #[derive(Debug, Deserialize, PartialEq, Serialize, MzReflect)]
     struct OptionalArg(bool, #[serde(default)] (f64, u32));
 
-    #[derive(Debug, Deserialize, PartialEq, Serialize, MzStructReflect)]
+    #[derive(Debug, Deserialize, PartialEq, Serialize, MzReflect)]
     struct MultiUnnamedArg(Vec<(usize, Vec<(String, usize)>, usize)>, String);
 
-    #[derive(Debug, Deserialize, PartialEq, Serialize, MzStructReflect)]
+    #[derive(Debug, Deserialize, PartialEq, Serialize, MzReflect)]
     struct MultiNamedArg {
         fizz: Vec<Option<bool>>,
         #[serde(default)]
         bizz: Vec<Vec<(SingleUnnamedArg, bool)>>,
     }
 
-    #[derive(Debug, Deserialize, PartialEq, Serialize, MzStructReflect)]
+    #[derive(Debug, Deserialize, PartialEq, Serialize, MzReflect)]
     struct FirstArgEnum {
         test_enum: Box<TestEnum>,
         #[serde(default)]
         second_arg: String,
     }
 
-    #[derive(Debug, Deserialize, PartialEq, Serialize, MzEnumReflect)]
+    #[derive(Debug, Deserialize, PartialEq, Serialize, MzReflect)]
     enum TestEnum {
         SingleNamedField {
             foo: Vec<usize>,

--- a/src/lowertest/tests/test_runner.rs
+++ b/src/lowertest/tests/test_runner.rs
@@ -67,21 +67,12 @@ mod tests {
         Unit,
     }
 
-    gen_reflect_info_func!(
-        produce_rti,
-        [TestEnum],
-        [
-            ZeroArg,
-            SingleUnnamedArg,
-            OptionalArg,
-            MultiUnnamedArg,
-            MultiNamedArg,
-            FirstArgEnum
-        ]
-    );
-
     lazy_static! {
-        static ref RTI: ReflectedTypeInfo = produce_rti();
+        static ref RTI: ReflectedTypeInfo = {
+            let mut rti = ReflectedTypeInfo::default();
+            TestEnum::add_to_reflected_type_info(&mut rti);
+            rti
+        };
     }
 
     #[derive(Default)]

--- a/src/repr-test-util/src/lib.rs
+++ b/src/repr-test-util/src/lib.rs
@@ -16,18 +16,18 @@ use lazy_static::lazy_static;
 use proc_macro2::TokenTree;
 
 use lowertest::{
-    deserialize_optional, gen_reflect_info_func, GenericTestDeserializeContext, MzReflect,
-    ReflectedTypeInfo,
+    deserialize_optional, GenericTestDeserializeContext, MzReflect, ReflectedTypeInfo,
 };
 use ore::str::StrExt;
 use repr::adt::numeric::Numeric;
 use repr::{ColumnType, Datum, Row, RowArena, ScalarType};
 
-/* #region Generate information required to construct arbitrary `ScalarType`*/
-gen_reflect_info_func!(produce_rti, [ScalarType], [ColumnType]);
-
 lazy_static! {
-    pub static ref RTI: ReflectedTypeInfo = produce_rti();
+    pub static ref RTI: ReflectedTypeInfo = {
+        let mut rti = ReflectedTypeInfo::default();
+        ColumnType::add_to_reflected_type_info(&mut rti);
+        rti
+    };
 }
 
 /* #endregion */

--- a/src/repr-test-util/src/lib.rs
+++ b/src/repr-test-util/src/lib.rs
@@ -16,8 +16,8 @@ use lazy_static::lazy_static;
 use proc_macro2::TokenTree;
 
 use lowertest::{
-    deserialize_optional, gen_reflect_info_func, GenericTestDeserializeContext, MzEnumReflect,
-    MzStructReflect, ReflectedTypeInfo,
+    deserialize_optional, gen_reflect_info_func, GenericTestDeserializeContext, MzReflect,
+    ReflectedTypeInfo,
 };
 use ore::str::StrExt;
 use repr::adt::numeric::Numeric;

--- a/src/repr/src/adt/array.rs
+++ b/src/repr/src/adt/array.rs
@@ -18,6 +18,8 @@ use serde::{Deserialize, Serialize};
 use crate::row::DatumList;
 use std::cmp::Ordering;
 
+use lowertest::MzReflect;
+
 /// The maximum number of dimensions permitted in an array.
 pub const MAX_ARRAY_DIMENSIONS: u8 = 6;
 
@@ -129,7 +131,9 @@ pub struct ArrayDimension {
 }
 
 /// An error that can occur when constructing an array.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
+#[derive(
+    Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize, Deserialize, MzReflect,
+)]
 pub enum InvalidArrayError {
     /// The number of dimensions in the array exceedes [`MAX_ARRAY_DIMENSIONS]`.
     TooManyDimensions(usize),

--- a/src/repr/src/adt/datetime.rs
+++ b/src/repr/src/adt/datetime.rs
@@ -22,11 +22,15 @@ use serde::{Deserialize, Serialize};
 
 use crate::adt::interval::Interval;
 
+use lowertest::MzReflect;
+
 /// Units of measurements associated with dates and times.
 ///
 /// TODO(benesch): with enough thinking, this type could probably be merged with
 /// `DateTimeField`.
-#[derive(Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(
+    Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize, MzReflect,
+)]
 pub enum DateTimeUnits {
     Epoch,
     Millennium,
@@ -292,7 +296,7 @@ impl DateTimeFieldValue {
 }
 
 /// Parsed timezone.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, MzReflect)]
 pub enum Timezone {
     #[serde(with = "fixed_offset_serde")]
     FixedOffset(FixedOffset),

--- a/src/repr/src/adt/regex.rs
+++ b/src/repr/src/adt/regex.rs
@@ -15,6 +15,8 @@ use std::ops::Deref;
 
 use serde::{Deserialize, Serialize};
 
+use lowertest::MzReflect;
+
 /// A hashable, comparable, and serializable regular expression type.
 ///
 /// The  [`regex::Regex`] type, the de facto standard regex type in Rust, does
@@ -37,7 +39,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// This type also implements [`Serialize`] and [`Deserialize`] via the
 /// [`serde_regex`] crate.
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, MzReflect)]
 pub struct Regex(
     // TODO(benesch): watch for a more efficient binary serialization for
     // [`regex::Regex`] (https://github.com/rust-lang/regex/issues/258). The

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -14,7 +14,7 @@ use std::vec;
 use anyhow::bail;
 use serde::{Deserialize, Serialize};
 
-use lowertest::MzStructReflect;
+use lowertest::MzReflect;
 use ore::str::StrExt;
 
 use crate::{Datum, ScalarType};
@@ -26,9 +26,7 @@ use crate::{Datum, ScalarType};
 ///
 /// To construct a column type, either initialize the struct directly, or
 /// use the [`ScalarType::nullable`] method.
-#[derive(
-    Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash, MzStructReflect,
-)]
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash, MzReflect)]
 pub struct ColumnType {
     /// The underlying scalar type (e.g., Int32 or String) of this column.
     pub scalar_type: ScalarType,
@@ -116,7 +114,7 @@ impl ColumnType {
 }
 
 /// The type of a relation.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzStructReflect)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
 pub struct RelationType {
     /// The type for each column, in order.
     pub column_types: Vec<ColumnType>,

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -184,7 +184,7 @@ impl RelationType {
 }
 
 /// The name of a column in a [`RelationDesc`].
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash, MzReflect)]
 pub struct ColumnName(String);
 
 impl ColumnName {

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -19,7 +19,7 @@ use ordered_float::OrderedFloat;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use lowertest::MzEnumReflect;
+use lowertest::MzReflect;
 
 use crate::adt::array::Array;
 use crate::adt::char::Char;
@@ -828,17 +828,7 @@ impl fmt::Display for Datum<'_> {
 /// There is a direct correspondence between `Datum` variants and `ScalarType`
 /// variants.
 #[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    Serialize,
-    Deserialize,
-    Ord,
-    PartialOrd,
-    Hash,
-    EnumKind,
-    MzEnumReflect,
+    Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Ord, PartialOrd, Hash, EnumKind, MzReflect,
 )]
 #[enum_kind(ScalarBaseType, derive(Hash))]
 pub enum ScalarType {

--- a/src/repr/src/strconv.rs
+++ b/src/repr/src/strconv.rs
@@ -34,6 +34,7 @@ use chrono::{DateTime, Datelike, Duration, NaiveDate, NaiveDateTime, NaiveTime, 
 use dec::OrderedDecimal;
 use fast_float::FastFloat;
 use lazy_static::lazy_static;
+use lowertest::MzReflect;
 use num_traits::Float as NumFloat;
 use ore::display::DisplayExt;
 use ore::result::ResultExt;
@@ -1311,7 +1312,7 @@ where
 }
 
 /// An error while parsing an input as a type.
-#[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
+#[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
 pub struct ParseError {
     kind: ParseErrorKind,
     type_name: String,
@@ -1319,7 +1320,9 @@ pub struct ParseError {
     details: Option<String>,
 }
 
-#[derive(Ord, PartialOrd, Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
+#[derive(
+    Ord, PartialOrd, Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect,
+)]
 pub enum ParseErrorKind {
     OutOfRange,
     InvalidInputSyntax,
@@ -1392,7 +1395,7 @@ impl fmt::Display for ParseError {
 
 impl Error for ParseError {}
 
-#[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
+#[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
 pub enum ParseHexError {
     InvalidHexDigit(char),
     OddLength,

--- a/src/sql/src/query_model/test.rs
+++ b/src/sql/src/query_model/test.rs
@@ -24,19 +24,13 @@ use expr_test_util::generate_explanation;
 use lazy_static::lazy_static;
 use lowertest::*;
 use ore::now::{EpochMillis, NOW_ZERO};
-use repr::{ColumnType, RelationDesc, RelationType, ScalarType};
+use repr::{RelationDesc, RelationType, ScalarType};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
 use uuid::Uuid;
 
 use crate::query_model;
-
-gen_reflect_info_func!(
-    produce_rti,
-    [ScalarType, TestCatalogCommand],
-    [ColumnType, RelationType,]
-);
 
 lazy_static! {
     static ref DUMMY_CONFIG: CatalogConfig = CatalogConfig {
@@ -52,7 +46,11 @@ lazy_static! {
         now: NOW_ZERO.clone(),
         disable_user_indexes: false,
     };
-    static ref RTI: ReflectedTypeInfo = produce_rti();
+    static ref RTI: ReflectedTypeInfo = {
+        let mut rti = ReflectedTypeInfo::default();
+        TestCatalogCommand::add_to_reflected_type_info(&mut rti);
+        rti
+    };
 }
 
 /// A dummy [`CatalogItem`] implementation.

--- a/src/sql/src/query_model/test.rs
+++ b/src/sql/src/query_model/test.rs
@@ -268,7 +268,7 @@ impl ExprHumanizer for TestCatalog {
 /// Contains the arguments for a command for [TestCatalog].
 ///
 /// See [lowertest] for the command syntax.
-#[derive(Debug, Serialize, Deserialize, MzEnumReflect)]
+#[derive(Debug, Serialize, Deserialize, MzReflect)]
 pub enum TestCatalogCommand {
     /// Insert a source into the catalog.
     Defsource {


### PR DESCRIPTION
### Motivation

 * This PR adds a feature that has not yet been specified.

Specifying a test object in Rust, like `MirRelationExpr`, can be onerous when the object is a tree of nested structs and enums. In `lowertest`, we define a simpler DSL for creating the test object. We translate the DSL into a JSON string that `serde_json` can then serialize into the test object. In order to translate the DSL into a JSON string, we generally need:
* the variants of an enum, and the field names and types for each variant.
* the names and types for all fields of a struct.

The aforementioned information for all structs and enums required to build the test object is collected in a `ReflectedTypeInfo` struct and passed along to the DSL-to-JSON method, which is [`lowertest::to_json`](https://github.com/MaterializeInc/materialize/blob/56d635d4eee1dd6868b5d005741e2fa1eeff5735/src/lowertest/src/lib.rs#L149).

Previously, we had the macro `MzEnumReflect` (resp. `MzStructReflect`) generate a method that returns the information for a particular enum (resp. struct) that should be added to `ReflectedTypeInfo`. You would need to call the generated method for every enum (resp. struct) that you may possibly construct as part of your test object. For convenience, there was a macro `gen_reflect_info_func` so that you could just list every enum and struct type that you may possibly construct, and the macro would call the generated method for you.

For more information, see the original design doc for `lowertest` here: https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/20210601_build_mirrelationexpr.md

But it is no longer practical to list every enum and struct type you may possibly construct when creating your test object because we are moving towards each variant of `*Func` now having a field that holds its own kind of struct.

### Description

Thus, instead of returning information that should be added to  `ReflectedTypeInfo`, the macro instead generates a method that accepts a `ReflectedTypeInfo` mutable reference. The method adds the relevant information not only for the enum/struct itself and but also for types referenced by the enum/struct. This means that we no longer need separate macros for enums and structs. 

The one downside of this is that now you have to list every non-primitive type that does not need to derive `MzReflect` but is used by a type that does derive `MzReflect`. But
1) you only have to specify it in one place. 
2) it can considered a feature that compiling fails if you forgot to add `MzReflect` to a new struct.

### Tips for reviewer

The first commit replaces macros `MzEnumReflect` and `MzStructReflect` with a macro `MzReflect` that generates a method that adds to `ReflectedTypeInfo`.
The second commit modifies the method generated by `MzReflect`.
The third commit removes the macro `gen_reflect_info_func`.
The fourth commit updates how lowertest works.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/9578)
<!-- Reviewable:end -->
