### PR TITLE
deploy: ensure macOS rustup target exists

### DIFF
--- a/ci/deploy/macos.py
+++ b/ci/deploy/macos.py
@@ -23,7 +23,9 @@ def main() -> None:
     args = parser.parse_args()
 
     target = f"{args.arch}-apple-darwin"
-    print(f"Target: {target}")
+
+    print(f"--- Ensuring rustup target {target} exists")
+    spawn.runv(["rustup", "target", "add", target])
 
     print("--- Building materialized release binary")
     spawn.runv(


### PR DESCRIPTION
On macOS deploys, the rustup target may not be installed by default,
e.g., when cross-compiling for ARM.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
