### PR TITLE
play/nix: add postgres build dependency

### DIFF
--- a/play/nix/shell.nix
+++ b/play/nix/shell.nix
@@ -21,6 +21,7 @@ stdenv.mkDerivation rec {
       cmake
       rustup
       openssl
+      postgresql
       pkg-config
       lld_13
       python38Packages.pip


### PR DESCRIPTION
this is required to build the pip package used during releases
