### PR TITLE
misc/ssh: do not use SSH agent when identity file is specified

### DIFF
--- a/misc/python/materialize/ssh.py
+++ b/misc/python/materialize/ssh.py
@@ -26,6 +26,6 @@ def runv(
     if not check_host_key:
         initial_args += ["-o", "StrictHostKeyChecking off"]
     if identity_file:
-        initial_args += ["-i", identity_file]
+        initial_args += ["-i", identity_file, "-o", "IdentitiesOnly yes"]
     initial_args += [f"{username}@{host}"]
     return spawn.runv(initial_args + args)


### PR DESCRIPTION
When an identity key is specified we shouldn't contact the SSH agent running on the machine. On my machine that my agent has many keys loaded I'm always hitting "error: Too many authentication failures" when using `bin/scratch` because my SSH client will rotate through all the keys in my SSH agent before attempting to connect with the identity file provided.

This also avoids accidentally logging in with a different key than the one specified.