### PR TITLE
coord,persist: make source persist details more structured/detailed on coordinator

### DIFF
--- a/src/coord/src/catalog/builtin_table_updates.rs
+++ b/src/coord/src/catalog/builtin_table_updates.rs
@@ -183,7 +183,13 @@ impl CatalogState {
         source: &Source,
         diff: Diff,
     ) -> Vec<BuiltinTableUpdate> {
-        let persisted_name_datum = Datum::from(source.persist_name.as_ref().map(|s| s.as_str()));
+        let persist_name = match &source.connector {
+            dataflow_types::SourceConnector::External { persist, .. } => persist
+                .as_ref()
+                .map(|persist| persist.primary_stream.as_str()),
+            dataflow_types::SourceConnector::Local { .. } => None,
+        };
+        let persisted_name_datum = Datum::from(persist_name);
         vec![BuiltinTableUpdate {
             id: MZ_SOURCES.id,
             row: Row::pack_slice(&[

--- a/src/coord/src/catalog/migrate.rs
+++ b/src/coord/src/catalog/migrate.rs
@@ -47,7 +47,8 @@ where
         let SerializedCatalogItem::V1 {
             create_sql,
             eval_env,
-            persist_name,
+            table_persist_name,
+            source_persist_details,
         } = serde_json::from_slice(&def)?;
         let mut stmt = sql::parse::parse(&create_sql)?.into_element();
 
@@ -56,7 +57,8 @@ where
         let serialized_item = SerializedCatalogItem::V1 {
             create_sql: stmt.to_ast_string_stable(),
             eval_env,
-            persist_name,
+            table_persist_name,
+            source_persist_details,
         };
 
         let serialized_item =

--- a/src/coord/src/timestamp.rs
+++ b/src/coord/src/timestamp.rs
@@ -563,6 +563,7 @@ impl Timestamper {
                         consistency,
                         ts_frequency: _,
                         timeline: _,
+                        persist: _,
                     } = sc
                     {
                         (connector, encoding, envelope, consistency)

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -523,7 +523,6 @@ pub struct SourceDesc {
     /// to the output of the source.
     pub operators: Option<LinearOperator>,
     pub bare_desc: RelationDesc,
-    pub persisted_name: Option<String>,
 }
 
 /// A sink for updates to a relational collection.
@@ -788,6 +787,7 @@ pub enum SourceConnector {
         consistency: Consistency,
         ts_frequency: Duration,
         timeline: Timeline,
+        persist: Option<SourcePersistDesc>,
     },
 
     /// A local "source" is either fed by a local input handle, or by reading from a
@@ -811,6 +811,33 @@ pub enum SourceConnector {
         timeline: Timeline,
         persisted_name: Option<String>,
     },
+}
+
+/// The details needed to make a source that uses an external [`SourceConnector`] persistent.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SourcePersistDesc {
+    /// Name of the primary persisted stream of this source. This is what a consumer of the
+    /// persisted data would be interested in while the secondary stream(s) of the source are an
+    /// internal implementation detail.
+    pub primary_stream: String,
+
+    /// Persisted stream of timestamp bindings.
+    pub timestamp_bindings_stream: String,
+
+    /// Any additional details that we need to make the envelope logic stateful.
+    pub envelope_desc: EnvelopePersistDesc,
+}
+
+/// The persistence details we need for persisting a source envelopes data structures.
+///
+/// This is a 1:1 mapping from envelope to `EnvelopePersistDesc`, as opposed to having a `None`
+/// that covers all envelopes that don't need additional data. Mostly, to just be explicit, but
+/// also because there is already a `NONE` envelope.
+///
+/// Some envelopes will require additional streams, which should be listed in the variant.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum EnvelopePersistDesc {
+    Upsert,
 }
 
 impl SourceConnector {

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -170,6 +170,7 @@ where
                 envelope,
                 consistency,
                 ts_frequency,
+                persist,
                 timeline: _,
             } => {
                 // TODO(benesch): this match arm is hard to follow. Refactor.
@@ -184,41 +185,39 @@ where
                 // whose contents will be concatenated and inserted along the collection.
                 let mut error_collections = Vec::<Collection<_, _>>::new();
 
-                let source_persist_config =
-                    match (src.persisted_name, render_state.persist.as_mut()) {
-                        (Some(persisted_name), Some(persist)) => {
-                            let mut persist_errs = Vec::new();
+                let source_persist_config = match (persist, render_state.persist.as_mut()) {
+                    (Some(persist_desc), Some(persist)) => {
+                        let mut persist_errs = Vec::new();
 
-                            let source_persist_config =
-                                get_persist_config(&uid, persisted_name, persist);
+                        let source_persist_config = get_persist_config(&uid, persist_desc, persist);
 
-                            if let Err(ref e) = source_persist_config {
-                                let err = SourceError::new(
-                                    src.name.clone(),
-                                    SourceErrorDetails::Persistence(e.to_string()),
-                                );
-                                persist_errs.push(err);
-                            }
-
-                            // Make sure to always create and push an error stream, even if there
-                            // are no errors. This ensures that the shape of the operator graph is
-                            // consistent across all timely workers.
-                            //
-                            // TODO: The error collections are not the right place for surfacing
-                            // persistence errors, since they are not deterministic/definite. We
-                            // don't have a better place right now, though.
-                            error_collections.push(
-                                persist_errs
-                                    .to_stream(scope)
-                                    .map(DataflowError::SourceError)
-                                    .pass_through("source-persist-errors")
-                                    .as_collection(),
+                        if let Err(ref e) = source_persist_config {
+                            let err = SourceError::new(
+                                src.name.clone(),
+                                SourceErrorDetails::Persistence(e.to_string()),
                             );
-
-                            source_persist_config.ok()
+                            persist_errs.push(err);
                         }
-                        _ => None,
-                    };
+
+                        // Make sure to always create and push an error stream, even if there
+                        // are no errors. This ensures that the shape of the operator graph is
+                        // consistent across all timely workers.
+                        //
+                        // TODO: The error collections are not the right place for surfacing
+                        // persistence errors, since they are not deterministic/definite. We
+                        // don't have a better place right now, though.
+                        error_collections.push(
+                            persist_errs
+                                .to_stream(scope)
+                                .map(DataflowError::SourceError)
+                                .pass_through("source-persist-errors")
+                                .as_collection(),
+                        );
+
+                        source_persist_config.ok()
+                    }
+                    _ => None,
+                };
 
                 let fast_forwarded = match &connector {
                     ExternalSourceConnector::Kafka(KafkaSourceConnector {
@@ -704,7 +703,7 @@ impl<K: Codec, V: Codec, ST: Codec, AT: Codec> PersistentSourceConfig<K, V, ST, 
 
 fn get_persist_config(
     source_id: &SourceInstanceId,
-    persisted_name: String,
+    persist_desc: SourcePersistDesc,
     persist_client: &mut persist::indexed::runtime::RuntimeClient,
 ) -> Result<
     PersistentSourceConfig<
@@ -717,8 +716,8 @@ fn get_persist_config(
 > {
     // TODO: Ensure that we only render one materialized source when persistence is enabled. We can
     // use https://github.com/MaterializeInc/materialize/pull/8522, which has most of the plumbing.
-    let persist_bindings_name = format!("{}-timestamp-bindings", persisted_name);
-    let persist_data_name = format!("{}", persisted_name);
+    let persist_bindings_name = persist_desc.timestamp_bindings_stream;
+    let persist_data_name = persist_desc.primary_stream;
 
     let (bindings_write, bindings_read) =
         persist_client.create_or_load::<SourceTimestamp, AssignedTimestamp>(&persist_bindings_name);

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -998,6 +998,7 @@ pub fn plan_create_source(
             consistency,
             ts_frequency,
             timeline,
+            persist: None,
         },
         expr,
         bare_desc,


### PR DESCRIPTION
This is a refined take on #9449 and (transitively) #9403.

Before, the coordinator would only know the prefix that was used to form
the names of persistent streams that are involved in, say, the
persistent Kafka source.

Now, we keep structured information that is the same for all sources
(`primary_stream` and `timstamp_bindings_stream`) as well as
per-envelope persistence details. This way, the coordinator knows all
persisted streams that are involved in a source.

This also changes what persist information is sent to dataflow workers.
Before, we would send a single persist name. Now, we send the new
`SourcePersistDesc`, which contains the same structured persistence
details that the coordinator knows about. In future commits, we will add
more information to this.

We need to do this to allow the coordinator to:
 - determine a common seal timestamp when restarting
 - negotiate/figure out if a requested as_of matches the compaction
   frontier/since of a persisted source
 - compact persisted streams when necessary

We will do these additional changes in follow-up commits.

## Tips for reviewer

I left one or two `TODOs`, but they're just meant to point out things we discussed offline before.

This now has a single new `SourcePersistDesc` in `dataflow-types`, which the coordinator also uses. I don't think that's necessarily good, but we have other types that are used like this, for example `SourceConnector`.

### Checklist

- [] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
