### PR TITLE
add --ci-output back to testdrive mzworkflows

### DIFF
--- a/test/testdrive/mzworkflows.py
+++ b/test/testdrive/mzworkflows.py
@@ -43,6 +43,7 @@ tests = os.getenv("TD_TEST", "*.td esoteric/*.td")
 tests_ci = tests + " esoteric/pubnub/pubnub.td"
 aws_localstack = "--aws-endpoint http://localstack:4566"
 aws_amazon = "--aws-region=us-east-2"
+ci_output = "--ci-output" if os.getenv("BUILDKITE") else ""
 
 
 def workflow_testdrive(w: Workflow):
@@ -69,5 +70,5 @@ def workflow_persistence_testdrive(w: Workflow):
 def test_testdrive(w: Workflow, mz: Materialized, aws: str, tests: str):
     w.start_and_wait_for_tcp(services=prerequisites + [mz])
     w.wait_for_mz(service=mz.name)
-    w.run_service(service="testdrive-svc", command=f"{aws} {tests}")
+    w.run_service(service="testdrive-svc", command=f"{ci_output} {aws} {tests}")
     w.kill_services(services=[mz.name])


### PR DESCRIPTION
This causes testdrive to emit lines that buildkite understands to automatically collapse testdrive
output per-file unless there is an error.