### PR TITLE
doc/user: correct generate_subscripts for multi-dim arrays

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -117,7 +117,7 @@ for SQL statements.
 - Ensure `pg_get_constraintdef` [compatibility function] parses, though it
   remains unimplemented.
 
-- Support `generate_subscripts` for 1-dimensional `arrays`
+- Support `generate_subscripts` for [`arrays`](/sql/types/array).
 
 {{% version-header v0.11.0 %}}
 

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -1111,6 +1111,18 @@ SELECT generate_subscripts('{1,2,3,4}'::TEXT[], 1) AS s;
 3
 4
 
+query I
+SELECT generate_subscripts(ARRAY[ARRAY[1, 2], ARRAY[3, 4], ARRAY[5, 6]], 1) AS s;
+----
+1
+2
+3
+
+query I
+SELECT generate_subscripts(ARRAY[ARRAY[1, 2], ARRAY[3, 4], ARRAY[5, 6]], 2) AS s;
+----
+1
+2
 
 query I
 SELECT generate_subscripts('{1,2,3,4}'::int[], 0) AS s;


### PR DESCRIPTION
generate_subscripts works fine for multi-dimensional arrays. Add a test
case to demonstrate. (Parsing multi-dimensional arrays from text is not
supported, but constructing them from ARRAY constructors does.)

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
