### PR TITLE
persist: allow specifying optional role ARN for S3 usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3365,7 +3365,9 @@ name = "persist"
 version = "0.0.0"
 dependencies = [
  "async-trait",
+ "aws-config",
  "aws-sdk-s3",
+ "aws-types",
  "bincode",
  "build-info",
  "criterion",

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -21,14 +21,16 @@ harness = false
 # don't leak in deps on other Materialize packages.
 [dependencies]
 async-trait = "0.1"
-bincode = "1.3.3"
+aws-config = { version = "0.3.0", default-features = false, features = ["default-provider", "native-tls"] }
 aws-sdk-s3 = { version = "0.3.0", default-features = false }
+aws-types = { version = "0.3.0" }
+bincode = "1.3.3"
 build-info = { path = "../build-info" }
 crossbeam-channel = "0.5"
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 fail = { version = "0.5.0", features = ["failpoints"] }
-futures-util = "0.3.19"
 futures-executor = "0.3.16"
+futures-util = "0.3.19"
 log = "0.4.13"
 md-5 = "0.9.0"
 mz-aws-util = { path = "../aws-util", features = ["s3"] }


### PR DESCRIPTION
### Motivation

  * This PR adds a feature that has not yet been specified.

Role ARN support for cloud.

### Tips for reviewer

Verified manually by creating an s3 bucket in my personal AWS account with the following bucket policy that give access to that bucket's `foo/*` path to a role I can assume in the mz scratch AWS account.

    {
        "Version": "2012-10-17",
        "Statement": [
            {
                "Effect": "Allow",
                "Principal": {
                    "AWS": "arn:aws:iam::REDACTED:role/engineer"
                },
                "Action": "s3:*",
                "Resource": "arn:aws:s3:::REDACTED/foo/*"
            },
            {
                "Effect": "Allow",
                "Principal": {
                    "AWS": "arn:aws:iam::REDACTED:role/engineer"
                },
                "Action": "s3:ListBucket*",
                "Resource": "arn:aws:s3:::REDACTED",
                "Condition": {
                    "StringLike": {
                        "s3:prefix": "foo/*"
                    }
                }
            }
        ]
    }

Authing with the scratch account without the role doesn't allow access.

    $ cargo run -- --dev --experimental --persist-storage=s3://REDACTED/foo
    materialized: persistence error: Error { code: "AccessDenied", message: "Access Denied", request_id: "27DW57MQZKZEPHAG", s3_extended_request_id: "uEoMFoqG7p7CBwVQofjT9lMHqSXYtZ5O6/qE/NiuOVDfZTSvc6gU2gRfOZPsPs+Nz4QpY78uPBk=" }

Adding the role works!

    $ cargo run -- --dev --experimental --persist-storage=s3://REDACTED/foo?aws_role_arn=arn%3Aaws%3Aiam%3A%3AREDACTED%3Arole%2Fengineer
    =======================================================================
    Thank you for trying Materialize!
    ...

And persist data starts appearing in the bucket.

Pointing at a different path in the bucket also doesn't allow access.

    $ cargo run -- --dev --experimental --persist-storage=s3://REDACTED/foo?aws_role_arn=arn%3Aaws%3Aiam%3A%3AREDACTED%3Arole%2Fengineer
    materialized: persistence error: Error { code: "AccessDenied", message: "Access Denied", request_id: "HZF9CETHWGZB4JK5", s3_extended_request_id: "RSa09MwzDSGLd02/GY5vhi7dp9cT0tRf1R9p7Ud4k1r4JXoMy+JYrINNErMnuD3fKyPDzU0qQxU=" }

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
