### PR TITLE
Fix panic with outer columns in the ON clause

### DIFF
--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -1065,8 +1065,9 @@ impl HirRelationExpr {
                 right,
             } => {
                 left.visit_columns(depth, f);
-                let depth = if kind.is_lateral() { depth + 1 } else { depth };
-                right.visit_columns(depth, f);
+                let right_depth = if kind.is_lateral() { depth + 1 } else { depth };
+                right.visit_columns(right_depth, f);
+                // The ON clause doesn't belong in the lateral context
                 on.visit_columns(depth, f);
             }
             HirRelationExpr::Map { scalars, input } => {

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -1176,8 +1176,9 @@ impl HirRelationExpr {
                 right,
             } => {
                 left.splice_parameters(params, depth);
-                let depth = if kind.is_lateral() { depth + 1 } else { depth };
-                right.splice_parameters(params, depth);
+                let right_depth = if kind.is_lateral() { depth + 1 } else { depth };
+                right.splice_parameters(params, right_depth);
+                // The ON clause doesn't belong in the lateral context
                 on.splice_parameters(params, depth);
             }
             HirRelationExpr::Map { scalars, input } => {

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -242,6 +242,13 @@ SELECT * FROM l WHERE EXISTS (SELECT * from l as l2 LEFT JOIN r ON l.la = r.ra)
 3  l3
 
 query IT rowsort
+SELECT * FROM l WHERE EXISTS (SELECT * from l as l2 LEFT JOIN LATERAL (SELECT * FROM r) r ON l.la = r.ra);
+----
+1  l1
+2  l2
+3  l3
+
+query IT rowsort
 SELECT * FROM r WHERE EXISTS (SELECT * from l RIGHT JOIN r as r2 ON l.la = r.ra)
 ----
 4  r4


### PR DESCRIPTION
Fix panic when columns from the outer scope are referenced in the ON
clause of a LATERAL join. The ON clause doesn't belong in the lateral
context.

<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug: [Link to issue.]

  * This PR adds a known-desirable feature: [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

 This PR fixes a recognized bug. Fixes #9605.

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

The first commit fixes the crash reported.

The second commit applies a similar fix in `splice_parameters` that fixes a potential crash that would happen if we added an instantiation of `sql_impl_func` with parameters in the ON clause of a lateral JOIN. This has been tested manually as explained in the commit message.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
