### PR TITLE
deps: opt into the new feature resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,11 @@ members = [
     "test/performance/s3-datagen",
     "test/test-util",
 ]
+# Use Cargo's new feature resolver, which can handle target-specific features.
+# Explicit opt-in is required even with the 2021 edition because we use a
+# virtual workspace.
+# See: https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html#cargos-new-feature-resolver
+resolver = "2"
 
 [profile.dev.package]
 # Compile the backtrace crate and its dependencies with all optimizations, even


### PR DESCRIPTION
The new Cargo feature resolver is what allows for target-specific
dependencies, and specifically avoids linking the tikv-jemallocator
crate on macOS. I mistakenly removed this configuration in the Rust 2021
edition upgrade (#8683) because the new resolver is the default for the
2021 edition... except not for virtual workspaces.

This avoids printing the error "jemalloc: option background_thread
currently supports pthread only" when booting the binary on macOS.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
