### PR TITLE
persist: unbreak Kafka upsert sources

### DIFF
--- a/test/persistence/kafka-sources/upsert-modification-after.td
+++ b/test/persistence/kafka-sources/upsert-modification-after.td
@@ -33,3 +33,41 @@ true true true
 
 > SELECT MIN(f1), MAX(f1), COUNT(*) FROM upsert_modification WHERE f2 LIKE 'a%';
 2500 7499 5000
+
+$ kafka-ingest format=bytes topic=textbytes key-format=bytes key-terminator=:
+bírdmore:géese
+mammalmore:moose
+mammal1:
+mammal1:mouse
+
+> select * from texttext
+key0          text  kafka_partition  mz_offset
+----------------------------------------------
+fish          fish  0                1
+bírdmore      géese 0                6
+mammal1       mouse 0                9
+mammalmore    moose 0                7
+
+> select * from textbytes
+key0          data            kafka_partition  mz_offset
+-------------------------------------------------------
+fish          fish            0                1
+bírdmore      g\xc3\xa9ese    0                6
+mammal1       mouse           0                9
+mammalmore    moose           0                7
+
+> select * from bytestext
+key0            text  kafka_partition  mz_offset
+------------------------------------------------
+fish            fish  0                1
+b\xc3\xadrdmore géese 0                6
+mammal1         mouse 0                9
+mammalmore      moose 0                7
+
+> select * from bytesbytes
+key0               data            kafka_partition  mz_offset
+-------------------------------------------------------------
+fish               fish            0                1
+b\xc3\xadrdmore    g\xc3\xa9ese    0                6
+mammal1            mouse           0                9
+mammalmore         moose           0                7

--- a/test/persistence/kafka-sources/upsert-modification-before.td
+++ b/test/persistence/kafka-sources/upsert-modification-before.td
@@ -39,3 +39,68 @@ $ kafka-ingest format=avro topic=upsert-modification key-format=avro key-schema=
 
 > SELECT COUNT(*) = 10000 FROM upsert_modification;
 true
+
+$ kafka-create-topic topic=textbytes
+
+$ kafka-ingest format=bytes topic=textbytes key-format=bytes key-terminator=:
+fish:fish
+bìrd1:goose
+bírdmore:geese
+mammal1:moose
+bìrd1:
+
+> CREATE MATERIALIZED SOURCE texttext
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
+  'testdrive-textbytes-${testdrive.seed}'
+  FORMAT TEXT
+  INCLUDE PARTITION AS kafka_partition, OFFSET AS mz_offset
+  ENVELOPE UPSERT
+
+> CREATE MATERIALIZED SOURCE textbytes
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
+  'testdrive-textbytes-${testdrive.seed}'
+  FORMAT BYTES
+  INCLUDE PARTITION AS kafka_partition, OFFSET AS mz_offset
+  ENVELOPE UPSERT FORMAT TEXT
+
+> CREATE MATERIALIZED SOURCE bytesbytes
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
+  'testdrive-textbytes-${testdrive.seed}'
+  FORMAT BYTES
+  INCLUDE PARTITION AS kafka_partition, OFFSET AS mz_offset
+  ENVELOPE UPSERT
+
+> CREATE MATERIALIZED SOURCE bytestext
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
+  'testdrive-textbytes-${testdrive.seed}'
+  FORMAT TEXT
+  INCLUDE PARTITION AS kafka_partition, OFFSET AS mz_offset
+  ENVELOPE UPSERT FORMAT BYTES
+
+> select * from texttext
+key0          text  kafka_partition  mz_offset
+----------------------------------------------
+fish          fish  0                1
+bírdmore      geese 0                3
+mammal1       moose 0                4
+
+> select * from textbytes
+key0          data  kafka_partition  mz_offset
+----------------------------------------------
+fish          fish  0                1
+bírdmore      geese 0                3
+mammal1       moose 0                4
+
+> select * from bytestext
+key0            text  kafka_partition  mz_offset
+------------------------------------------------
+fish            fish  0                1
+b\xc3\xadrdmore geese 0                3
+mammal1         moose 0                4
+
+> select * from bytesbytes
+key0            data  kafka_partition  mz_offset
+------------------------------------------------
+fish            fish  0                1
+b\xc3\xadrdmore geese 0                3
+mammal1         moose 0                4


### PR DESCRIPTION
Previously, we added kafka metadata into the upsert dataflow. Unfortunately, we only did
so for the non-persisted kafka upsert dataflow, and not for the persisted kafka upsert
dataflow.

This PR aims to fix that by simply folding the metadata into the value which is what
downstream `evaluate` seems to want anyway. The existing upsert implementation likely
does not do so as a performance optimization (no need to create a bunch of new, wider
values if we suspect many of them will be discarded).

This fix is admittedly brittle. A longer term fix would be to unify more of the
code around the persisted codepath, and the nonpersisted codepath. We are leaving
that for followup work.

Fixes #9614 

<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug: [Link to issue.]

  * This PR adds a known-desirable feature: [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
