### PR TITLE
docs: Change "Observing local Materialize" to use tabs

### DIFF
--- a/doc/user/content/ops/monitoring.md
+++ b/doc/user/content/ops/monitoring.md
@@ -72,13 +72,14 @@ $ docker run -d \
 
 ### Observing local Materialize
 
-Using the dashboard to observe a Materialize instance running on the same
-machine as the dashboard is complicated by Docker. The solution depends upon
-your host platform.
+Since the dashboard runs inside a Docker container, using it to observe a Materialize
+instance running on the same machine is complicated by Docker networking isolation. The
+exact steps required to expose `materialized` to the dashboard process depends on exactly
+how you are running `materialized`.
 
 {{< tabs >}}
 
-{{< tab "Materialize inside Docker" >}}
+{{< tab "Docker" >}}
 
 Local schedulers like Docker Compose (which we use for our demos) or Kubernetes will
 typically expose running containers to each other using the container's service name as a
@@ -90,7 +91,7 @@ it. Check out the [example configuration for Docker Compose][dc-example].
 [dc-example]: https://github.com/MaterializeInc/materialize/blob/d793b112758c840c1240eefdd56ca6f7e4f484cf/demo/billing/mzcompose.yml#L60-L70
 
 {{</ tab >}}
-{{< tab "Materialize on macOS" >}}
+{{< tab "macOS" >}}
 
 When our dashboard container is running inside of Docker via Docker for Mac and
 `materialized` is running on the host macOS system the `localhost` inside of the
@@ -103,7 +104,7 @@ docker run -p 3000:3000 -e MATERIALIZED_URL=host.docker.internal:6875 materializ
 ```
 
 {{</ tab >}}
-{{< tab "Materialize on Linux" >}}
+{{< tab "Linux" >}}
 
 When our dashboard container is running inside of a Docker container on a Linux machine
 we must override one of the isolation policies that Docker creates. Docker configures

--- a/doc/user/content/ops/monitoring.md
+++ b/doc/user/content/ops/monitoring.md
@@ -76,38 +76,54 @@ Using the dashboard to observe a Materialize instance running on the same
 machine as the dashboard is complicated by Docker. The solution depends upon
 your host platform.
 
-#### Inside Docker Compose or Kubernetes
+{{< tabs >}}
+
+{{< tab "Materialize inside Docker" >}}
 
 Local schedulers like Docker Compose (which we use for our demos) or Kubernetes will
-typically expose running containers to each other using their service name as a public
-DNS hostname, but _only_ within the network that they are running in.
+typically expose running containers to each other using the container's service name as a
+public DNS hostname, but _only_ within the network that the containers are running in.
 
 The easiest way to use the dashboard inside a scheduler is to tell the scheduler to run
 it. Check out the [example configuration for Docker Compose][dc-example].
 
-#### On macOS, with Materialize running outside of Docker
+[dc-example]: https://github.com/MaterializeInc/materialize/blob/d793b112758c840c1240eefdd56ca6f7e4f484cf/demo/billing/mzcompose.yml#L60-L70
 
-The problem with this is that `localhost` inside of Docker does not, on Docker for Mac,
-refer to the macOS network. So instead you must use `host.docker.internal`:
+{{</ tab >}}
+{{< tab "Materialize on macOS" >}}
+
+When our dashboard container is running inside of Docker via Docker for Mac and
+`materialized` is running on the host macOS system the `localhost` inside of the
+container does not refer to the macOS host machine's network.
+
+You must use `host.docker.internal` to refer to the host system:
 
 ```
 docker run -p 3000:3000 -e MATERIALIZED_URL=host.docker.internal:6875 materialize/dashboard
 ```
 
-#### On Linux, with Materialize running outside of Docker
+{{</ tab >}}
+{{< tab "Materialize on Linux" >}}
 
-Docker containers use a different network than their host by default, but that is easy to
-override by using the `--network host` option. Using the host network means that ports will be
-allocated from the host, so the `-p` flag is no longer necessary:
+When our dashboard container is running inside of a Docker container on a Linux machine
+we must override one of the isolation policies that Docker creates. Docker configures
+containers to use a different network than their host by default, but that is easy to
+override by using the `--network host` option:
 
 ```
 docker run --network host -e MATERIALIZED_URL=localhost:6875 materialize/dashboard
 ```
 
+Using the host network means that ports will be allocated from the host, so the `-p` flag
+is no longer necessary, with the above command the dashboard will be available on at
+`http://localhost:3000`.
+
+{{</ tab >}}
+{{</ tabs >}}
+
 [simplemon-hub]: https://hub.docker.com/repository/docker/materialize/dashboard
 [dashboard-json]: https://github.com/MaterializeInc/materialize/blob/main/misc/monitoring/dashboard/conf/grafana/dashboards/overview.json
 [graf-import]: https://grafana.com/docs/grafana/latest/reference/export_import/#importing-a-dashboard
-[dc-example]: https://github.com/MaterializeInc/materialize/blob/d793b112758c840c1240eefdd56ca6f7e4f484cf/demo/billing/mzcompose.yml#L60-L70
 
 ## Health check
 


### PR DESCRIPTION
We did not used to support tab groups for code examples or explanations, but now we do.

I was reminded of this because @mkysel bounced off the page when he saw that the first docs 
were for Materialize inside of Docker, which is not how he was running/testing things.

The current version of this page is available [here](https://deploy-preview-9026--materializeinc.netlify.app/ops/monitoring/#observing-local-materialize).
The new version in this pr is [here](https://deploy-preview-9621--materializeinc.netlify.app/ops/monitoring/#observing-local-materialize).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/9621)
<!-- Reviewable:end -->
