### PR TITLE
Clarify .*DecoderState .expect errors

### DIFF
--- a/src/dataflow/src/decode/mod.rs
+++ b/src/dataflow/src/decode/mod.rs
@@ -320,7 +320,6 @@ fn get_decoder(
                 }
                 _ => false,
             };
-            // TODO(guswynn): get rid of this expect https://github.com/MaterializeInc/materialize/issues/9613
             let state = avro::AvroDecoderState::new(
                 &schema,
                 schema_registry_config,
@@ -329,7 +328,7 @@ fn get_decoder(
                 debug_name.to_string(),
                 confluent_wire_format,
             )
-            .expect("Failed to create avro decoder");
+            .expect("Failed to create avro decoder, even though we validated ccsr client creation in purification.");
             DataDecoder {
                 inner: DataDecoderInner::Avro(state),
                 metrics,
@@ -344,11 +343,10 @@ fn get_decoder(
                     PreDelimitedFormat::Regex(regex, Default::default())
                 }
                 DataEncoding::Protobuf(encoding) => {
-                    // TODO(guswynn): get rid of this expect https://github.com/MaterializeInc/materialize/issues/9613
-                    PreDelimitedFormat::Protobuf(
-                        ProtobufDecoderState::new(encoding)
-                            .expect("Failed to create protobuf decoder"),
-                    )
+                    PreDelimitedFormat::Protobuf(ProtobufDecoderState::new(encoding).expect(
+                        "Failed to create protobuf decoder, even though we validated ccsr \
+                                    client creation in purification.",
+                    ))
                 }
                 DataEncoding::Bytes => PreDelimitedFormat::Bytes,
                 DataEncoding::Text => PreDelimitedFormat::Text,


### PR DESCRIPTION

### Motivation


  * This PR fixes a recognized bug: #9613

@quodlibetor and I are convinced that the only real errors are creating ccsr clients (https://github.com/MaterializeInc/materialize/blob/main/src/ccsr/src/client.rs#L35, just checking the url), and that this should be checked in purification: 

proto: https://github.com/MaterializeInc/materialize/blob/main/src/sql/src/pure.rs#L553-L557
avro: https://github.com/MaterializeInc/materialize/blob/main/src/sql/src/pure.rs#L763

Note that these only are checked when the decoder is not pre-compiled, but I believe that is the only case that can cause errors in decoder creation as well

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
