### PR TITLE
sql: correct lateral scoping in the face of outer joins

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -103,6 +103,9 @@ List new features before bug fixes.
 
 {{% version-header v0.13.0 %}}
 
+- Allow join trees that mix [`LATERAL`](/sql/join#lateral-subqueries)
+  elements with `RIGHT` and `FULL` joins {{% gh 6875 %}}.
+
 {{% version-header v0.12.0 %}}
 
 - Support [`PREPARE`](/sql/prepare/), [`EXECUTE`](/sql/execute/), and [`DEALLOCATE`](/sql/deallocate/)

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -307,7 +307,7 @@ impl fmt::Display for CatalogItemType {
 }
 
 /// An error returned by the catalog.
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum CatalogError {
     /// Unknown database.
     UnknownDatabase(String),

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -22,7 +22,7 @@ use crate::catalog::CatalogError;
 use crate::names::PartialName;
 use crate::plan::scope::ScopeItem;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum PlanError {
     Unsupported {
         feature: String,
@@ -33,6 +33,10 @@ pub enum PlanError {
         column: ColumnName,
     },
     UngroupedColumn {
+        table: Option<PartialName>,
+        column: ColumnName,
+    },
+    WrongJoinTypeForLateralColumn {
         table: Option<PartialName>,
         column: ColumnName,
     },
@@ -83,6 +87,12 @@ impl fmt::Display for PlanError {
             Self::UngroupedColumn { table, column } => write!(
                 f,
                 "column {} must appear in the GROUP BY clause or be used in an aggregate function",
+                ColumnDisplay { table, column },
+            ),
+            Self::WrongJoinTypeForLateralColumn { table, column } => write!(
+                f,
+                "column {} cannot be referenced from this part of the query: \
+                the combining JOIN type must be INNER or LEFT for a LATERAL reference",
                 ColumnDisplay { table, column },
             ),
             Self::AmbiguousColumn(column) => write!(

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -20,6 +20,7 @@ use repr::ColumnName;
 
 use crate::catalog::CatalogError;
 use crate::names::PartialName;
+use crate::plan::plan_utils::JoinSide;
 use crate::plan::scope::ScopeItem;
 
 #[derive(Clone, Debug)]
@@ -41,6 +42,14 @@ pub enum PlanError {
         column: ColumnName,
     },
     AmbiguousColumn(ColumnName),
+    UnknownColumnInUsingClause {
+        column: ColumnName,
+        join_side: JoinSide,
+    },
+    AmbiguousColumnInUsingClause {
+        column: ColumnName,
+        join_side: JoinSide,
+    },
     MisqualifiedName(String),
     OverqualifiedDatabaseName(String),
     OverqualifiedSchemaName(String),
@@ -99,6 +108,18 @@ impl fmt::Display for PlanError {
                 f,
                 "column reference {} is ambiguous",
                 column.as_str().quoted()
+            ),
+            Self::UnknownColumnInUsingClause { column, join_side } => write!(
+                f,
+                "column {} specified in USING clause does not exist in {} table",
+                column.as_str().quoted(),
+                join_side,
+            ),
+            Self::AmbiguousColumnInUsingClause { column, join_side } => write!(
+                f,
+                "common column name {} appears more than once in {} table",
+                column.as_str().quoted(),
+                join_side,
             ),
             Self::MisqualifiedName(name) => write!(
                 f,

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -923,6 +923,20 @@ impl HirRelationExpr {
         HirScalarExpr::Select(Box::new(self))
     }
 
+    pub fn join(
+        self,
+        right: HirRelationExpr,
+        on: HirScalarExpr,
+        kind: JoinKind,
+    ) -> HirRelationExpr {
+        HirRelationExpr::Join {
+            left: Box::new(self),
+            right: Box::new(right),
+            on,
+            kind,
+        }
+    }
+
     pub fn take(&mut self) -> HirRelationExpr {
         mem::replace(
             self,

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -1052,7 +1052,7 @@ fn branch<F>(
     id_gen: &mut ore::id_gen::IdGen,
     outer: expr::MirRelationExpr,
     col_map: &ColumnMap,
-    mut inner: HirRelationExpr,
+    inner: HirRelationExpr,
     apply_requires_distinct_outer: bool,
     apply: F,
 ) -> expr::MirRelationExpr

--- a/src/sql/src/plan/plan_utils.rs
+++ b/src/sql/src/plan/plan_utils.rs
@@ -53,3 +53,23 @@ pub fn maybe_rename_columns(
 
     Ok(desc.with_names(new_names))
 }
+
+/// Specifies the side of a join.
+///
+/// Intended for use in error messages.
+#[derive(Debug, Clone, Copy)]
+pub enum JoinSide {
+    /// The left side.
+    Left,
+    /// The right side.
+    Right,
+}
+
+impl fmt::Display for JoinSide {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            JoinSide::Left => f.write_str("left"),
+            JoinSide::Right => f.write_str("right"),
+        }
+    }
+}

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -4384,7 +4384,7 @@ impl<'a> QueryContext<'a> {
                 let name = object.raw_name;
                 let cte = self.ctes.get(&id).unwrap();
                 let mut val = cte.val.clone();
-                val.visit_columns(0, &mut |depth, col| {
+                val.visit_columns_mut(0, &mut |depth, col| {
                     if col.level > depth {
                         col.level += cte.level_offset;
                     }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -401,7 +401,7 @@ fn plan_source_envelope(
                 })],
             }),
             on: HirScalarExpr::literal_true(),
-            kind: JoinKind::Inner { lateral: true },
+            kind: JoinKind::Inner,
         }
         .project((0..diff_col).collect());
         let expr = if let Some(post_transform_key) = post_transform_key {

--- a/src/sql/src/plan/transform_expr.rs
+++ b/src/sql/src/plan/transform_expr.rs
@@ -184,9 +184,7 @@ pub fn try_simplify_quantified_comparisons(expr: &mut HirRelationExpr) {
                     walk_scalar(scalar, &outers, false);
                 }
             }
-            HirRelationExpr::Join {
-                kind, left, right, ..
-            } if kind.is_lateral() => {
+            HirRelationExpr::Join { left, right, .. } => {
                 walk_relation(left, outers);
                 let mut outers = outers.to_vec();
                 outers.push(left.typ(&outers, &NO_PARAMS));

--- a/src/sql/src/query_model/hir.rs
+++ b/src/sql/src/query_model/hir.rs
@@ -199,14 +199,10 @@ impl FromHir {
                 self.model.make_quantifier(left_q_type, left_box, join_box);
 
                 // Right box
-                let right_box = if kind.is_lateral() {
-                    self.within_context(join_box, &mut |generator| -> BoxId {
-                        let right = right.take();
-                        generator.generate_internal(right)
-                    })
-                } else {
-                    self.generate_internal(*right)
-                };
+                let right_box = self.within_context(join_box, &mut |generator| -> BoxId {
+                    let right = right.take();
+                    generator.generate_internal(right)
+                });
                 self.model
                     .make_quantifier(right_q_type, right_box, join_box);
 

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -722,7 +722,7 @@ SELECT f1, t1.f2 AS f1 FROM t1 JOIN t2 USING (f1);
 query error column reference "f1" is ambiguous
 SELECT f1, t1.f2 AS f1 FROM t1 JOIN t2 USING (f1) ORDER BY f1;
 
-query error column reference "f2" is ambiguous
+query error  common column name "f2" appears more than once in left table
 SELECT * FROM t1 LEFT JOIN t2 USING (f1) RIGHT JOIN t3 USING (f2);
 
 statement ok
@@ -952,7 +952,7 @@ SELECT *, f2 IS NULL
      JOIN t1 AS t2 USING (f1, f2)
      JOIN t1 AS t3 USING (f1);
 
-query error column reference "f2" is ambiguous
+query error common column name "f2" appears more than once in left table
 SELECT *
     FROM t1 AS t1
     JOIN t1 AS t2 USING (f1, f2)
@@ -1016,3 +1016,19 @@ SELECT a3.f1,
 1 1
 1 1
 1 1
+
+# Simple USING column missing from the right table.
+query error column "a" specified in USING clause does not exist in right table
+SELECT * FROM (SELECT 1 a) s1 JOIN (SELECT 2 b) s2 USING (a)
+
+# Simple USING column missing from the left table.
+query error column "b" specified in USING clause does not exist in left table
+SELECT * FROM (SELECT 1 a) s1 JOIN (SELECT 2 b) s2 USING (b)
+
+# USING column missing from both tables, but existing in the outer scope.
+query error column "c" specified in USING clause does not exist in left table
+SELECT (SELECT * FROM (SELECT 1 a) s1 JOIN (SELECT 2 b) s2 USING (c)) FROM (SELECT 3 c) s3
+
+# USING column missing from the right table only but existing in the outer scope.
+query error column "a" specified in USING clause does not exist in right table
+SELECT (SELECT * FROM (SELECT 1 a) s1 JOIN (SELECT 2 b) s2 USING (a)) FROM (SELECT 3 a) s3

--- a/test/sqllogictest/outer_join.slt
+++ b/test/sqllogictest/outer_join.slt
@@ -48,11 +48,15 @@ SELECT * FROM a CROSS JOIN b JOIN LATERAL(SELECT a.a FROM c) x ON TRUE;
 ----
 1 2 1
 
-query error join trees using both lateral and full/right outer joins not yet supported
+query III
 SELECT * FROM a, b FULL JOIN LATERAL(SELECT a.a FROM c) x ON TRUE;
+----
+1 2 1
 
-query error column "a.a" does not exist
+query III
 SELECT * FROM a CROSS JOIN (b FULL JOIN LATERAL(SELECT a.a FROM c) x ON TRUE);
+----
+1 2 1
 
 statement ok
 CREATE TABLE t1 (a int, b int);
@@ -66,5 +70,10 @@ INSERT INTO t1 VALUES (1, 2), (2, 3);
 statement ok
 INSERT INTO t2 VALUES (2, 4), (5, 7);
 
-query error join trees using both lateral and full/right outer joins not yet supported
+query IIII rowsort
 SELECT * FROM generate_series(1, 2), LATERAL (SELECT * FROM t1) _ NATURAL RIGHT JOIN t2;
+----
+1 2 3    4
+2 2 3    4
+1 5 NULL 7
+2 5 NULL 7

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -81,13 +81,7 @@ query T multiline
 EXPLAIN RAW PLAN FOR SELECT generate_series FROM generate_series(-2, 2)
 ----
 %0 =
-| Constant ()
-
-%1 =
 | CallTable generate_series(-2, 2, 1)
-
-%2 =
-| InnerLateralJoin %0 %1 on true
 
 EOF
 
@@ -186,7 +180,7 @@ EXPLAIN RAW PLAN FOR SELECT * FROM x, generate_series(1, a)
 | CallTable generate_series(1, #^0, 1)
 
 %2 =
-| InnerLateralJoin %0 %1 on true
+| InnerJoin %0 %1 on true
 
 EOF
 
@@ -200,7 +194,7 @@ EXPLAIN RAW PLAN FOR SELECT * FROM x, generate_series(100::bigint, a)
 | CallTable generate_series(i32toi64(100), i32toi64(#^0), 1)
 
 %2 =
-| InnerLateralJoin %0 %1 on true
+| InnerJoin %0 %1 on true
 
 EOF
 
@@ -209,7 +203,14 @@ EXPLAIN PLAN FOR SELECT * FROM x, generate_series(1, 10)
 ----
 %0 =
 | Get materialize.public.x (u3)
-| FlatMap generate_series(1, 10, 1)
+| ArrangeBy ()
+
+%1 =
+| Constant (1) (2) (3) (4) (5) (6) (7) (8) (9) (10)
+
+%2 =
+| Join %0 %1
+| | implementation = Differential %1 %0.()
 
 EOF
 
@@ -412,13 +413,7 @@ query T multiline
 EXPLAIN RAW PLAN FOR SELECT generate_series FROM generate_series(-2, 2, 1)
 ----
 %0 =
-| Constant ()
-
-%1 =
 | CallTable generate_series(-2, 2, 1)
-
-%2 =
-| InnerLateralJoin %0 %1 on true
 
 EOF
 
@@ -426,13 +421,7 @@ query T multiline
 EXPLAIN RAW PLAN FOR SELECT generate_series FROM generate_series(-2::bigint, 2::bigint, 1::bigint)
 ----
 %0 =
-| Constant ()
-
-%1 =
 | CallTable generate_series(i32toi64(-2), i32toi64(2), i32toi64(1))
-
-%2 =
-| InnerLateralJoin %0 %1 on true
 
 EOF
 


### PR DESCRIPTION
Rework join planning so that we can handle lateral references that are
mixed with right and full outer joins. The implementation here largely
follows what @asenac laid out in @6875, except that the existing outer
scope design was found to be sufficient; that is, there is no concept of
a "sibling" scope introduced here.

The gist is that we now always plan joins with the RHS as a child scope
of the LHS. (Previously, we only created the new scope for joins if we
could eagerly notice that the RHS had a lateral element.) If the join is
a right or full join, we ban referencing any of the elements in the left
scope, as required by SQL:2008. When we encounter a non-lateral
subquery, we hide any lateral scope items entirely. Yes, it's weird that
non-lateral subqueries pretend lateral scope items don't exit, while
subqueries on the RHS of a right or full join *error* if they access a
lateral scope item, but that's what SQL demands.

~**WARNING:** The lowering code is amended to always treat inner and left joins as
correlated, even if they are not. This is correct, but it may produce
worse plans. I haven't investigated the movement of plans in much detail
yet.~

Fix #6875.

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
