### PR TITLE
Add support for IS [NOT] DISTINCT

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -2084,6 +2084,7 @@ pub enum BinaryFunc {
     RoundNumeric,
     Eq,
     NotEq,
+    ValueEq,
     Lt,
     Lte,
     Gt,
@@ -2253,6 +2254,7 @@ impl BinaryFunc {
             BinaryFunc::ModFloat32 => eager!(mod_float32),
             BinaryFunc::ModFloat64 => eager!(mod_float64),
             BinaryFunc::ModNumeric => eager!(mod_numeric),
+            BinaryFunc::ValueEq => Ok(eager!(eq)),
             BinaryFunc::Eq => Ok(eager!(eq)),
             BinaryFunc::NotEq => Ok(eager!(not_eq)),
             BinaryFunc::Lt => Ok(eager!(lt)),
@@ -2397,7 +2399,7 @@ impl BinaryFunc {
                 | ModNumeric
         );
         match self {
-            And | Or | Eq | NotEq | Lt | Lte | Gt | Gte | ArrayContains => {
+            And | Or | ValueEq | Eq | NotEq | Lt | Lte | Gt | Gte | ArrayContains => {
                 ScalarType::Bool.nullable(in_nullable)
             }
 
@@ -2547,6 +2549,7 @@ impl BinaryFunc {
                 | BinaryFunc::ListListConcat
                 | BinaryFunc::ListElementConcat
                 | BinaryFunc::ElementListConcat
+                | BinaryFunc::ValueEq
         )
     }
 
@@ -2560,6 +2563,7 @@ impl BinaryFunc {
         !matches!(
             self,
             And | Or
+                | ValueEq
                 | Eq
                 | NotEq
                 | Lt
@@ -2697,6 +2701,7 @@ impl BinaryFunc {
             | ModFloat32
             | ModFloat64
             | ModNumeric
+            | ValueEq
             | Eq
             | NotEq
             | Lt
@@ -2847,6 +2852,7 @@ impl fmt::Display for BinaryFunc {
             BinaryFunc::ModFloat32 => f.write_str("%"),
             BinaryFunc::ModFloat64 => f.write_str("%"),
             BinaryFunc::ModNumeric => f.write_str("%"),
+            BinaryFunc::ValueEq => f.write_str("=="),
             BinaryFunc::Eq => f.write_str("="),
             BinaryFunc::NotEq => f.write_str("!="),
             BinaryFunc::Lt => f.write_str("<"),

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -979,7 +979,7 @@ impl<'a> Parser<'a> {
                 IS => {
                     let negated = self.parse_keyword(NOT);
                     if let Some(construct) =
-                        self.parse_one_of_keywords(&[NULL, TRUE, FALSE, UNKNOWN])
+                        self.parse_one_of_keywords(&[NULL, TRUE, FALSE, UNKNOWN, DISTINCT])
                     {
                         Ok(Expr::IsExpr {
                             expr: Box::new(expr),
@@ -989,6 +989,10 @@ impl<'a> Parser<'a> {
                                 TRUE => IsExprConstruct::True,
                                 FALSE => IsExprConstruct::False,
                                 UNKNOWN => IsExprConstruct::Unknown,
+                                DISTINCT => {
+                                    self.expect_keyword(FROM)?;
+                                    IsExprConstruct::DistinctFrom(Box::new(self.parse_expr()?))
+                                }
                                 _ => unreachable!(),
                             },
                         })


### PR DESCRIPTION
```
materialize=> explain select f1, f2, f1 is not distinct from f2, f1 = f2 from t1;
          Optimized Plan          
----------------------------------
 %0 =                            +
 | Get materialize.public.t1 (u5)+
 | Map (#0 == #1), (#0 = #1)     +
 
(1 row)

materialize=> 
```

<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

  * This PR adds a known-desirable feature: #1050.

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).

Fixes #1050.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/9625)
<!-- Reviewable:end -->
