### PR TITLE
persist,dataflow: make source rendering deterministic on workers

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -2596,8 +2596,8 @@ pub enum SerializedEnvelopePersistDetails {
 impl From<SourcePersistDesc> for SerializedSourcePersistDetails {
     fn from(source_persist_desc: SourcePersistDesc) -> Self {
         SerializedSourcePersistDetails {
-            primary_stream: source_persist_desc.primary_stream,
-            timestamp_bindings_stream: source_persist_desc.timestamp_bindings_stream,
+            primary_stream: source_persist_desc.primary_stream.name,
+            timestamp_bindings_stream: source_persist_desc.timestamp_bindings_stream.name,
             envelope_details: source_persist_desc.envelope_desc.into(),
         }
     }

--- a/src/coord/src/catalog/builtin_table_updates.rs
+++ b/src/coord/src/catalog/builtin_table_updates.rs
@@ -186,7 +186,7 @@ impl CatalogState {
         let persist_name = match &source.connector {
             dataflow_types::SourceConnector::External { persist, .. } => persist
                 .as_ref()
-                .map(|persist| persist.primary_stream.as_str()),
+                .map(|persist| persist.primary_stream.name.as_str()),
             dataflow_types::SourceConnector::Local { .. } => None,
         };
         let persisted_name_datum = Datum::from(persist_name);

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -821,10 +821,10 @@ pub struct SourcePersistDesc {
     /// Name of the primary persisted stream of this source. This is what a consumer of the
     /// persisted data would be interested in while the secondary stream(s) of the source are an
     /// internal implementation detail.
-    pub primary_stream: String,
+    pub primary_stream: PersistStreamDesc,
 
     /// Persisted stream of timestamp bindings.
-    pub timestamp_bindings_stream: String,
+    pub timestamp_bindings_stream: PersistStreamDesc,
 
     /// Any additional details that we need to make the envelope logic stateful.
     pub envelope_desc: EnvelopePersistDesc,
@@ -840,6 +840,29 @@ pub struct SourcePersistDesc {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum EnvelopePersistDesc {
     Upsert,
+}
+
+/// Description of a single persistent stream.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PersistStreamDesc {
+    /// Name of the persistent stream.
+    pub name: String,
+    /// The _current_ upper seal timestamp of this stream.
+    ///
+    /// NOTE: This timestamp is determined when the coordinator starts up or when the source is
+    /// initially created. When a source is actively writing to this stream, the seal timestamp
+    /// will progress beyond this timestamp.
+    ///
+    /// This is okay for now because we only want to allow one source instantiation for persistent
+    /// sources, meaning the flow is usually this:
+    ///
+    ///  1. coordinator determines seal timestamp
+    ///  2. seal timestamps for a source are sent to dataflow when rendering a source
+    ///  3. coordinator (or anyone) never looks at this timestamp again.
+    ///
+    /// And when we restart, we start from step 1., at which time we are guaranteed not to have a
+    /// source running already.
+    pub upper_seal_ts: u64,
 }
 
 impl SourceConnector {

--- a/src/persist/src/error.rs
+++ b/src/persist/src/error.rs
@@ -24,6 +24,8 @@ pub enum Error {
     OutOfQuota(String),
     /// An unstructured persistence related error.
     String(String),
+    /// There is no stream registered under the given name.
+    UnknownRegistration(String),
     /// The associated write request was sequenced (given a SeqNo) and applied
     /// to the persist state machine, but that application was deterministically
     /// made into a no-op because it was contextually invalid (a write or seal
@@ -43,6 +45,7 @@ impl fmt::Display for Error {
             Error::IO(e) => fmt::Display::fmt(e, f),
             Error::OutOfQuota(e) => f.write_str(e),
             Error::String(e) => f.write_str(e),
+            Error::UnknownRegistration(id) => write!(f, "unknown registration: {}", id),
             Error::Noop(_, e) => f.write_str(e),
             Error::RuntimeShutdown => f.write_str("runtime shutdown"),
         }

--- a/src/persist/src/indexed/mod.rs
+++ b/src/persist/src/indexed/mod.rs
@@ -963,7 +963,7 @@ impl<L: Log, B: Blob> Indexed<L, B> {
                         let lower = Antichain::from_elem(u64::minimum());
                         Ok(Description::new(lower, upper, since))
                     }
-                    None => Err(Error::String(format!("Unknown registration '{}'", id_str))),
+                    None => Err(Error::UnknownRegistration(id_str.to_string())),
                 }
             })
         })());

--- a/src/persist/src/indexed/runtime.rs
+++ b/src/persist/src/indexed/runtime.rs
@@ -1014,30 +1014,6 @@ impl<L: Log, B: Blob> RuntimeImpl<L, B> {
     }
 }
 
-/// Returns the seal timestamp of the given collection.
-// TODO: There are some things we should change about this:
-//
-// 1. Getting the seal timestamp shouldn't require knowing the types of the collection. This can be
-//    achieved by adding a `get_seal(id)` method on `RuntimeClient`. Even better, the method should
-//    probably be `get_description()` and return a complete differential `Description` of the
-//    contained updates.
-//
-// 2. We need to figure out what our nomenclature should be around seal vs. upper vs. "a whole
-//    Description".
-//
-pub fn sealed_ts<K: persist_types::Codec, V: persist_types::Codec>(
-    read: &StreamReadHandle<K, V>,
-) -> Result<u64, Error> {
-    let seal_ts = read.snapshot()?.get_seal();
-
-    if let Some(sealed) = seal_ts.first() {
-        Ok(*sealed)
-    } else {
-        use timely::progress::Timestamp;
-        Ok(Timestamp::minimum())
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use timely::dataflow::operators::capture::Extract;


### PR DESCRIPTION
Before, when determining the common upper seal timestamp for involved
streams, we would make fallible calls into persistence. Based on the
result, we would either render one dataflow graph or a graph with a
different shape. This does not work with timely dataflow and leads to
unexpected results.

Now, we determine the seal timestamps of involved streams in the
coordinator and send them along in the persistence description.

### Tips for reviewer

I left NOTEs/TODOs in the code that explain some of the assumptions. This will become more interesting once we move ingest/dataflow/coord into separate processes.

This does not yet make coord look at the since of the involved streams when starting up. That's one of the next steps, before we hook up compaction.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
