### PR TITLE
test,persistence: Add an explicit test for persistence and --disable-…

### DIFF
--- a/test/persistence/disable-user-indexes/after.td
+++ b/test/persistence/disable-user-indexes/after.td
@@ -1,0 +1,41 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set keyschema={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "f1", "type": "string"}
+    ]
+  }
+
+$ set schema={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"f2", "type":"string"}
+        ]
+    }
+
+> SELECT SUM(CAST(statistics->'topics'->'testdrive-disable-user-indexes-1'->'partitions'->'0'->'msgs' AS INT)) IS NULL FROM mz_kafka_source_statistics;
+true
+
+> ALTER INDEX disable_user_indexes_primary_idx SET ENABLED;
+
+$ kafka-ingest format=avro topic=disable-user-indexes key-format=avro key-schema=${keyschema} schema=${schema} publish=true
+{"f1": "-1"} {"f2": "-1"}
+
+
+> SELECT COUNT(*) = 10001 FROM disable_user_indexes;
+true
+
+# We expect the counter to be at 1, that is no data was re-ingested
+# from the Kafka topic after the indexes were enabled
+> SELECT SUM(CAST(statistics->'topics'->'testdrive-disable-user-indexes-1'->'partitions'->'0'->'msgs' AS INT)) = 1 FROM mz_kafka_source_statistics;
+true

--- a/test/persistence/disable-user-indexes/before.td
+++ b/test/persistence/disable-user-indexes/before.td
@@ -1,0 +1,43 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Insert 10K values prior to restart
+#
+
+$ set count=10000
+
+$ set keyschema={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "f1", "type": "string"}
+    ]
+  }
+
+$ set schema={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"f2", "type":"string"}
+        ]
+    }
+
+$ kafka-create-topic topic=disable-user-indexes
+
+$ kafka-ingest format=avro topic=disable-user-indexes key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=${count}
+{"f1": "a${kafka-ingest.iteration}"} {"f2": "a${kafka-ingest.iteration}"}
+
+> CREATE MATERIALIZED SOURCE disable_user_indexes
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-disable-user-indexes-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE UPSERT
+
+> SELECT COUNT(*) = ${count} FROM disable_user_indexes;
+true


### PR DESCRIPTION
…user-indexes

Confirm that after an index is re-enabled we do not ingest the
entire Kafka topic from the start.

@aljoscha FYI