### PR TITLE
attempt to get `mzcompose run testdrive` working m1 macs

### DIFF
--- a/misc/python/materialize/mzcompose.py
+++ b/misc/python/materialize/mzcompose.py
@@ -953,6 +953,9 @@ class SchemaRegistry(PythonService):
         port: int = 8081,
         environment: List[str] = [
             "SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=PLAINTEXT://kafka:9092",
+            # NOTE(guswynn): under docker, kafka *can* be really slow, which means
+            # the default of 500ms won't work, so we give it PLENTY of time
+            "SCHEMA_REGISTRY_KAFKASTORE_TIMEOUT_MS=10000",
             "SCHEMA_REGISTRY_HOST_NAME=localhost",
         ],
         depends_on: List[str] = ["kafka", "zookeeper"],

--- a/test/testdrive/mzworkflows.py
+++ b/test/testdrive/mzworkflows.py
@@ -68,7 +68,7 @@ def workflow_persistence_testdrive(w: Workflow):
 
 
 def test_testdrive(w: Workflow, mz: Materialized, aws: str, tests: str):
-    w.start_and_wait_for_tcp(services=prerequisites + [mz])
+    w.start_and_wait_for_tcp(services=prerequisites + [mz], timeout_secs=240)
     w.wait_for_mz(service=mz.name)
     w.run_service(service="testdrive-svc", command=f"{ci_output} {aws} {tests}")
     w.kill_services(services=[mz.name])


### PR DESCRIPTION
### Motivation
  * This PR adds a known-desirable feature: mzcompose on m1 macs

This is not perfect. Sometimes, kafka DOESNT segfault, but does refuse to actually respond to tcp connections, requiring you to `mzcompose down` and retry. However, once you have a version of kafka running, it also possible for the schema-registry to succeed on requests in the default timeout (500ms), but to be safe, we give it a much longer time period. The slowdown is almost assuredly because we are running under emulation. I guess we just wait on confluentinc/common-docker/issues/ 117? or perhaps use redpanda

also, @benesch, i thought only the kakfka image was running under the wrong arch, it seems like ALL the confluent images are still not arm

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
