### PR TITLE
test/redpanda: make TD_TEST match normal testdrive's TD_TEST

### DIFF
--- a/misc/python/materialize/mzcompose.py
+++ b/misc/python/materialize/mzcompose.py
@@ -1118,6 +1118,7 @@ class Testdrive(PythonService):
         environment: Optional[List[str]] = None,
         volumes: Optional[List[str]] = None,
         volumes_extra: Optional[List[str]] = None,
+        volume_workdir: str = ".:/workdir",
     ) -> None:
         if environment is None:
             environment = [
@@ -1133,7 +1134,10 @@ class Testdrive(PythonService):
             ]
 
         if volumes is None:
-            volumes = [*DEFAULT_MZ_VOLUMES, ".:/workdir"]
+            volumes = [*DEFAULT_MZ_VOLUMES]
+        if volumes_extra:
+            volumes.extend(volumes_extra)
+        volumes.append(volume_workdir)
 
         if entrypoint is None:
             entrypoint = [
@@ -1151,16 +1155,13 @@ class Testdrive(PythonService):
 
         entrypoint.append(f"--default-timeout {default_timeout}")
 
-        if volumes_extra:
-            volumes.extend(volumes_extra)
-
         if seed:
             entrypoint.append(f"--seed {seed}")
 
         if shell_eval:
             # Evaluate the arguments as a shell command
             # This allows bashisms to be used to prepare the list of tests to run
-            entrypoint.append("`${TD_TEST:-$$*}`")
+            entrypoint.append("${TD_TEST:-`$$*`}")
         else:
             entrypoint.append("${TD_TEST:-$$*}")
 

--- a/test/redpanda/mzworkflows.py
+++ b/test/redpanda/mzworkflows.py
@@ -13,7 +13,7 @@ prerequisites = [Redpanda(), Materialized()]
 
 services = [
     *prerequisites,
-    Testdrive(shell_eval=True, volumes_extra=["../testdrive:/workdir/testdrive"]),
+    Testdrive(shell_eval=True, volume_workdir="../testdrive:/workdir"),
 ]
 
 
@@ -31,5 +31,5 @@ def workflow_redpanda_testdrive(w: Workflow):
 
     w.run_service(
         service="testdrive-svc",
-        command="grep -L -E 'kafka_time_offset' testdrive/*.td",
+        command="grep -L -E 'kafka_time_offset' *.td",
     )


### PR DESCRIPTION
This commit ensures that running this command in test/testdrive

    TD_TEST=foo.td ./mzcompose run testdrive

has the same behavior of running this command in test/redpanda:

    TD_TEST=foo.td ./mzcompose run testdrive-redpanda

There are two changes involved:

  * Mounting the testdrive files at /workdir directly in the redpanda
    service to avoid a "testdrive/" prefix.

  * Only have `shell_eval=True` apply if `TD_TEST` is not specified.
    Otherwise you have to type something like `TD_TEST=echo foo.td`,
    which is very awkward. This isn't really a limitation, since when
    using TD_TEST, it's very easy to recover shell_eval behavior by
    writing `TD_TEST=$(some_command)`.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
