### PR TITLE
doc/user: migrate to new docsearch application

### DIFF
--- a/doc/user/layouts/partials/head.html
+++ b/doc/user/layouts/partials/head.html
@@ -15,7 +15,8 @@
 <script defer>
 addEventListener("DOMContentLoaded", () => {
   docsearch({
-    apiKey: "4a00e9b5208d93ae2445d7ea064ddbac",
+    apiKey: "cf315153e0b62d66538a2f8b86bfb93f",
+    appId: "9LF5B9GMOF",
     indexName: "materialize",
     inputSelector: '#search-input',
     debug: true,


### PR DESCRIPTION
Algolia recently migrated DocSearch to first-class applications that are
managed via crawler.algolia.com, rather than a public GitHub repository
[0]. Update our DocSearch credentials accordingly.

[0]: https://github.com/algolia/docsearch-configs
