### PR TITLE
persist: tweak Codec

### DIFF
--- a/src/dataflow-types/src/errors.rs
+++ b/src/dataflow-types/src/errors.rs
@@ -22,14 +22,8 @@ pub enum DecodeError {
 // We only want to support persisting DecodeError for now, and not the full DataflowError, which is
 // a bit more complex.
 impl Codec for DecodeError {
-    fn codec_name() -> &'static str {
-        "DecodeError"
-    }
-
-    fn size_hint(&self) -> usize {
-        match self {
-            DecodeError::Text(text) => text.size_hint(),
-        }
+    fn codec_name() -> String {
+        "DecodeError".into()
     }
 
     fn encode<B: for<'a> Extend<&'a u8>>(&self, buf: &mut B) {

--- a/src/dataflow/src/source/timestamp.rs
+++ b/src/dataflow/src/source/timestamp.rs
@@ -24,7 +24,6 @@
 
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::mem::size_of;
 use std::rc::Rc;
 use std::time::Instant;
 
@@ -713,12 +712,8 @@ pub struct AssignedTimestamp(pub(crate) u64);
 const SOURCE_TIMESTAMP_PARTITION_KAFKA: u8 = 0;
 const SOURCE_TIMESTAMP_PARTITION_NONE: u8 = 1;
 impl Codec for SourceTimestamp {
-    fn codec_name() -> &'static str {
-        "SourceTimestamp"
-    }
-
-    fn size_hint(&self) -> usize {
-        size_of::<u8>() + size_of::<i32>() + size_of::<i64>() // PartitionId + MzOffset
+    fn codec_name() -> String {
+        "SourceTimestamp".into()
     }
 
     fn encode<E: for<'a> Extend<&'a u8>>(&self, buf: &mut E) {
@@ -753,12 +748,8 @@ impl Codec for SourceTimestamp {
 
 // TODO: see comment on Codec for SourceTimestamp
 impl Codec for AssignedTimestamp {
-    fn codec_name() -> &'static str {
-        "AssignedTimestamp"
-    }
-
-    fn size_hint(&self) -> usize {
-        size_of::<u64>()
+    fn codec_name() -> String {
+        "AssignedTimestamp".into()
     }
 
     fn encode<E: for<'a> Extend<&'a u8>>(&self, buf: &mut E) {

--- a/src/persist-types/src/codec_impls.rs
+++ b/src/persist-types/src/codec_impls.rs
@@ -12,12 +12,8 @@
 use crate::Codec;
 
 impl Codec for () {
-    fn codec_name() -> &'static str {
-        "()"
-    }
-
-    fn size_hint(&self) -> usize {
-        0
+    fn codec_name() -> String {
+        "()".into()
     }
 
     fn encode<E: for<'a> Extend<&'a u8>>(&self, _buf: &mut E) {
@@ -33,12 +29,8 @@ impl Codec for () {
 }
 
 impl Codec for String {
-    fn codec_name() -> &'static str {
-        "String"
-    }
-
-    fn size_hint(&self) -> usize {
-        self.as_bytes().len()
+    fn codec_name() -> String {
+        "String".into()
     }
 
     fn encode<E: for<'a> Extend<&'a u8>>(&self, buf: &mut E) {
@@ -51,12 +43,8 @@ impl Codec for String {
 }
 
 impl Codec for Vec<u8> {
-    fn codec_name() -> &'static str {
-        "Vec<u8>"
-    }
-
-    fn size_hint(&self) -> usize {
-        self.len()
+    fn codec_name() -> String {
+        "Vec<u8>".into()
     }
 
     fn encode<E: for<'a> Extend<&'a u8>>(&self, buf: &mut E) {
@@ -71,15 +59,8 @@ impl Codec for Vec<u8> {
 const RESULT_OK: u8 = 0;
 const RESULT_ERR: u8 = 1;
 impl<T: Codec, E: Codec> Codec for Result<T, E> {
-    fn codec_name() -> &'static str {
-        "Result"
-    }
-
-    fn size_hint(&self) -> usize {
-        match self {
-            Ok(r) => r.size_hint() + 1 + 8,
-            Err(err) => err.size_hint() + 1 + 8,
-        }
+    fn codec_name() -> String {
+        "Result".into()
     }
 
     fn encode<B: for<'a> Extend<&'a u8>>(&self, buf: &mut B) {

--- a/src/persist-types/src/lib.rs
+++ b/src/persist-types/src/lib.rs
@@ -25,14 +25,7 @@ pub trait Codec: Sized + 'static {
     ///
     /// This name is stored for the key and value when a stream is first created
     /// and the same key and value codec must be used for that stream afterward.
-    fn codec_name() -> &'static str;
-    /// A hint of the encoded size of self.
-    ///
-    /// No correctness guarantees are made about the return value of this
-    /// function, it's used purely to pre-size buffers.
-    //
-    // TODO: Give this the same signature and semantics as Iterator::size_hint.
-    fn size_hint(&self) -> usize;
+    fn codec_name() -> String;
     /// Encode a key or value for permanent storage.
     ///
     /// This must perfectly round-trip Self through [Codec::decode]. If the

--- a/src/persist/examples/kafka_upsert.rs
+++ b/src/persist/examples/kafka_upsert.rs
@@ -441,12 +441,8 @@ mod kafka_offset_impls {
     use crate::SourceTimestamp;
 
     impl Codec for KafkaPartition {
-        fn codec_name() -> &'static str {
-            "KafkaPartition"
-        }
-
-        fn size_hint(&self) -> usize {
-            8
+        fn codec_name() -> String {
+            "KafkaPartition".into()
         }
 
         fn encode<E: for<'a> Extend<&'a u8>>(&self, buf: &mut E) {
@@ -461,12 +457,8 @@ mod kafka_offset_impls {
     }
 
     impl Codec for KafkaOffset {
-        fn codec_name() -> &'static str {
-            "KafkaOffset"
-        }
-
-        fn size_hint(&self) -> usize {
-            8
+        fn codec_name() -> String {
+            "KafkaOffset".into()
         }
 
         fn encode<E: for<'a> Extend<&'a u8>>(&self, buf: &mut E) {
@@ -481,12 +473,8 @@ mod kafka_offset_impls {
     }
 
     impl Codec for AssignedTimestamp {
-        fn codec_name() -> &'static str {
-            "AssignedTimestamp"
-        }
-
-        fn size_hint(&self) -> usize {
-            8
+        fn codec_name() -> String {
+            "AssignedTimestamp".into()
         }
 
         fn encode<E: for<'a> Extend<&'a u8>>(&self, buf: &mut E) {
@@ -501,12 +489,8 @@ mod kafka_offset_impls {
     }
 
     impl<P: Codec, O: Codec> Codec for SourceTimestamp<P, O> {
-        fn codec_name() -> &'static str {
-            "SourceTimestamp"
-        }
-
-        fn size_hint(&self) -> usize {
-            self.0.size_hint() + self.1.size_hint() + 8 + 8
+        fn codec_name() -> String {
+            "SourceTimestamp".into()
         }
 
         fn encode<E: for<'a> Extend<&'a u8>>(&self, buf: &mut E) {

--- a/src/persist/src/gen.rs
+++ b/src/persist/src/gen.rs
@@ -16,7 +16,6 @@ include!(concat!(env!("OUT_DIR"), "/protobuf/mod.rs"));
 use std::io::Read;
 
 use md5::{Digest, Md5};
-use ore::cast::CastFrom;
 use protobuf::Message;
 
 use crate::error::Error;
@@ -72,15 +71,8 @@ impl ProtoMeta {
 }
 
 impl persist_types::Codec for ProtoMeta {
-    fn codec_name() -> &'static str {
-        "protobuf+md5[ProtoMeta]"
-    }
-
-    fn size_hint(&self) -> usize {
-        // TODO: The encode step ends up internally calling compute_size a
-        // second time, which is unfortunate. Is it worth using
-        // write_to_with_cached_sizes in encode?
-        1 + Self::CHECKSUM_LEN + usize::cast_from(self.compute_size())
+    fn codec_name() -> String {
+        "protobuf+md5[ProtoMeta]".into()
     }
 
     fn encode<E: for<'a> Extend<&'a u8>>(&self, buf: &mut E) {

--- a/src/persist/src/indexed/runtime.rs
+++ b/src/persist/src/indexed/runtime.rs
@@ -44,7 +44,7 @@ use futures_executor::block_on;
 
 #[derive(Debug)]
 enum Cmd {
-    Register(String, (&'static str, &'static str), PFutureHandle<Id>),
+    Register(String, (String, String), PFutureHandle<Id>),
     Destroy(String, PFutureHandle<bool>),
     Write(Vec<(Id, ColumnarRecords)>, PFutureHandle<SeqNo>),
     Seal(Vec<Id>, u64, PFutureHandle<SeqNo>),
@@ -914,7 +914,7 @@ impl<L: Log, B: Blob> RuntimeImpl<L, B> {
                 }
                 Cmd::Register(id, (key_codec_name, val_codec_name), res) => {
                     self.indexed
-                        .register(&id, key_codec_name, val_codec_name, res);
+                        .register(&id, &key_codec_name, &val_codec_name, res);
                 }
                 Cmd::Destroy(id, res) => {
                     self.indexed.destroy(&id, res);

--- a/src/repr/src/row/encoding.rs
+++ b/src/repr/src/row/encoding.rs
@@ -58,12 +58,8 @@ use crate::Row;
 const CURRENT_VERSION: u8 = 0u8;
 
 impl Codec for Row {
-    fn codec_name() -> &'static str {
-        "RowExperimental"
-    }
-
-    fn size_hint(&self) -> usize {
-        1 + 8 + self.data.len()
+    fn codec_name() -> String {
+        "RowExperimental".into()
     }
 
     /// Encodes a row into the permanent storage format.


### PR DESCRIPTION
- Remove the size_hint fn, which was unused and will be hard to
  implement efficiently for our production impls of Codec.
- Make the return type of codec_name a String instead of &'static str.
  This will allow for helpers that impl Codec for a class of types (e.g.
  things that Into and TryFrom a certain protobuf type).

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
