### PR TITLE
play/nix: use `mold` to link materialize

### DIFF
--- a/play/nix/shell.nix
+++ b/play/nix/shell.nix
@@ -18,6 +18,7 @@ in
 stdenv.mkDerivation rec {
   name = "materialize";
   buildInputs = with pkgs; [
+      clang_13
       cmake
       rustup
       openssl
@@ -31,7 +32,7 @@ stdenv.mkDerivation rec {
   hardeningDisable = [ "fortify" ];
 
   MZ_DEV = 1;
-  RUSTFLAGS = "-C link-arg=-fuse-ld=lld -C debuginfo=1";
+  RUSTFLAGS = "-C linker=clang -C link-arg=--ld-path=${pkgs.mold}/bin/mold -C link-arg=-Wl,--warn-unresolved-symbols -C debuginfo=1";
   shellHook = ''
     export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${lib.makeLibraryPath buildInputs}"
    '';


### PR DESCRIPTION
`mold` hit 1.0.0 a couple of days ago and on my tests when touching `src/sql/src/lib.rs` and rebuilding with `cargo build --bin materialized` I see a 10% improvement.

