### PR TITLE
add kafka config property

### DIFF
--- a/src/sql/src/kafka_util.rs
+++ b/src/sql/src/kafka_util.rs
@@ -236,6 +236,12 @@ pub fn extract_config(
             Config::string("ssl_key_password").include_env_var(),
             Config::new("transaction_timeout_ms", ValType::Number(0, i32::MAX)),
             Config::new("enable_idempotence", ValType::Boolean),
+            Config::new(
+                "fetch_message_max_bytes",
+                // The range of values comes from `fetch.message.max.bytes` in
+                // https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
+                ValType::Number(0, 1_000_000_000),
+            ),
         ],
     )
 }


### PR DESCRIPTION
This change allows for setting `fetch.message.max.bytes` from a CREATE SOURCE WITH options, such as:
```sql
CREATE SOURCE local_kafka
FROM KAFKA BROKER 'localhost:9092' TOPIC 'data'
WITH (fetch_message_max_bytes=1000)
FORMAT bytes;
```

To test I added logging at the point of rdkafka client creation and the logs for the example query confirm the parameter being passed through with the correct value:
```
2021-12-16T18:34:01.954491Z  INFO coord::catalog: create view materialize.public.json_test_source (u10)
2021-12-16T18:34:01.954574Z  INFO coord::catalog: create index materialize.public.json_test_source_primary_idx (u11)
2021-12-16T18:34:01.957067Z  INFO dataflow::source::kafka: client has config: ClientConfig { conf_map: {"statistics.interval.ms": "1000", "group.id": "materialize-47df596e-1cdd-4a6f-864d-ac629bca43e7-kafka-u9/31", "auto.offset.reset": "earliest", "isolation.level": "read_committed", "bootstrap.servers": "localhost:9092", "fetch.message.max.bytes": "1", "enable.auto.commit": "false", "topic.metadata.refresh.interval.ms": "30000"}, log_level: Info }
```
### Motivation

  * This PR adds a known-desirable feature: [#6686](https://github.com/MaterializeInc/materialize/issues/6686)


### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
