### PR TITLE
xcompile: use different toolchains on x86 and M1 OS X

### DIFF
--- a/misc/python/materialize/xcompile.py
+++ b/misc/python/materialize/xcompile.py
@@ -179,13 +179,30 @@ def _bootstrap_darwin(arch: Arch) -> None:
         return
 
     if arch == Arch.AARCH64:
-        spawn.runv(["brew", "install", f"messense/macos-cross-toolchains/{target(arch)}"])
+        spawn.runv(
+            ["brew", "install", f"messense/macos-cross-toolchains/{target(arch)}"]
+        )
     elif arch == Arch.X86_64:
         # Get rid of one we used for all arches in boostrap v2 just in case a conflict makes things tricky
-        spawn.runv(["brew", "uninstall", "-f", f"messense/macos-cross-toolchains/{target(arch)}"])
-        spawn.runv(["brew", "untap", "-f", f"messense/macos-cross-toolchains"])
+        spawn.runv(
+            [
+                "brew",
+                "uninstall",
+                "-f",
+                f"messense/macos-cross-toolchains/{target(arch)}",
+            ]
+        )
+        try:
+            spawn.runv(["brew", "untap", "-f", f"messense/macos-cross-toolchains"])
+        except Exception:
+            print(
+                "Could not untap messense/macos-cross-toolchain.  Perhaps because it's not tapped"
+            )
         spawn.runv(["brew", "install", f"SergioBenitez/osxct/{target(arch)}"])
-        #spawn.runv(["cargo", "clean", "--target", f"{target(arch)}"], cwd=os.environ["MZ_ROOT"])
+        spawn.runv(
+            ["cargo", "clean", "--target", f"{target(arch)}"],
+            cwd=Path(os.environ["MZ_ROOT"]),
+        )
     else:
         raise RuntimeError("python enums are worse than rust enums")
 


### PR DESCRIPTION
In #9575 we changed which xcompile toolchain to use so that we could have one that works for M1 macs.  However, this new one doesn't work properly for x86 macs.

Introduce a new xcompile BOOSTRAP_VERSION that does the following:
- M1: keeps the `messense/macos-cross-toolchains` xcompile toolchain
- x86: removes and untaps the `messense/macos-cross-toolchains` toolchain and install the old `SergioBenitez/osxct` xcompile toolchain.  Also run `cargo clean --target x86_64-unknown-linux-gnu` command since everything will need to be re-xcompiled.  (We should not try to link things built with different xcompile toolchains lol)