### PR TITLE
Fix AWS timeout warnings in console logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2862,6 +2862,7 @@ dependencies = [
  "aws-sdk-s3",
  "aws-sdk-sqs",
  "aws-sdk-sts",
+ "aws-smithy-async",
  "aws-smithy-client",
  "aws-smithy-http",
  "aws-types",

--- a/src/aws-util/Cargo.toml
+++ b/src/aws-util/Cargo.toml
@@ -15,6 +15,7 @@ aws-sdk-s3 = { version = "0.3.0", default-features = false, features = ["native-
 aws-sdk-sqs = { version = "0.3.0", default-features = false, features = ["native-tls"], optional = true }
 aws-sdk-sts = { version = "0.3.0", default-features = false, features = ["native-tls"], optional = true }
 aws-types = { version = "0.3.0" }
+aws-smithy-async = { version = "0.33.0", default-features = false }
 hyper = "0.14.16"
 mz-http-proxy = { path = "../http-proxy", features = ["hyper"] }
 

--- a/src/aws-util/src/s3.rs
+++ b/src/aws-util/src/s3.rs
@@ -22,6 +22,8 @@ pub fn client(config: &AwsConfig) -> Result<Client, anyhow::Error> {
     if let Some(endpoint) = config.endpoint() {
         builder = builder.endpoint_resolver(endpoint.clone());
     }
+    // TODO(#9644): maybe remove this
+    builder.set_sleep_impl(aws_smithy_async::rt::sleep::default_async_sleep());
     let conn = util::connector()?;
     Ok(Client::from_conf_conn(builder.build(), conn))
 }

--- a/src/aws-util/src/sqs.rs
+++ b/src/aws-util/src/sqs.rs
@@ -22,6 +22,8 @@ pub fn client(config: &AwsConfig) -> Result<Client, anyhow::Error> {
     if let Some(endpoint) = config.endpoint() {
         builder = builder.endpoint_resolver(endpoint.clone());
     }
+    // TODO(#9644): maybe remove this
+    builder.set_sleep_impl(aws_smithy_async::rt::sleep::default_async_sleep());
     let conn = util::connector()?;
     Ok(Client::from_conf_conn(builder.build(), conn))
 }

--- a/src/aws-util/src/sts.rs
+++ b/src/aws-util/src/sts.rs
@@ -22,6 +22,8 @@ pub fn client(config: &AwsConfig) -> Result<Client, anyhow::Error> {
     if let Some(endpoint) = config.endpoint() {
         builder = builder.endpoint_resolver(endpoint.clone());
     }
+    // TODO(#9644): maybe remove this
+    builder.set_sleep_impl(aws_smithy_async::rt::sleep::default_async_sleep());
     let conn = util::connector()?;
     Ok(Client::from_conf_conn(builder.build(), conn))
 }


### PR DESCRIPTION
Currently we get the following warning tens of times every time an AWS source
starts up, or re-does anything:

    2021-12-15T16:29:50.908164Z  WARN aws_smithy_client::timeout: One or more timeouts were set but no async_sleep fn was passed. No timeouts will occur.
    Timeouts:
    Connect (time to first byte):(unset)
    TLS negotiation:(unset)
    HTTP read:(unset)
    API requests:(unset)
    HTTP requests:(unset)

In the future (when the upstream issue[1] is fixed) it may be possible to get
the default behavior by just enabling the `tokio-rt` feature. However, right
now that doesn't work, and possibly when it is fixed we won't want to tie
ourselves to that feature.

[1]: https://github.com/awslabs/aws-sdk-rust/issues/317

### Motivation
* This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).