### PR TITLE
Fix lowering panic with LATERAL references in ROWS FROM

### DIFF
--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -1140,3 +1140,31 @@ select generate_subscripts(ARRAY[ARRAY[1,2,3], ARRAY[4,5,6]], 2);
 1
 2
 3
+
+# Regression test for #9653: LATERAL column references in ROWS FROM
+
+query III
+SELECT * FROM generate_series(1, 3) as foo(a), ROWS FROM (generate_series(foo.a, foo.a + 2), generate_series(foo.a, foo.a + 1)) order by 1, 2, 3;
+----
+1  1  1
+1  2  2
+1  3  NULL
+2  2  2
+2  3  3
+2  4  NULL
+3  3  3
+3  4  4
+3  5  NULL
+
+query IIII
+SELECT * FROM generate_series(1, 3) as foo(a), ROWS FROM (generate_series(foo.a, foo.a + 2), generate_series(foo.a, foo.a + 1), generate_series(foo.a, foo.a)) order by 1, 2, 3, 4;
+----
+1  1  1  1
+1  2  2  NULL
+1  3  NULL  NULL
+2  2  2  2
+2  3  3  NULL
+2  4  NULL  NULL
+3  3  3  3
+3  4  4  NULL
+3  5  NULL  NULL


### PR DESCRIPTION
After #9623 a new scope is always defined for the RHS of any join,
LATERAL or not. If a relation is pushed down to the RHS of a join after
name resolution has already happened we must update the column references
leaving the scope of that relation to catch up with the scope of the
join. That is what happens when creating the FULL OUTER used for
supporting ROWS FROM.

Fixes #9653 
<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

This PR fixes a recognized bug

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug: [Link to issue.]

  * This PR adds a known-desirable feature: [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
