### PR TITLE
persist: take persistence since into account when calculating source since

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -511,11 +511,25 @@ where
                 // about how it was built. If we start building multiple sinks and/or indexes
                 // using a single dataflow, we have to make sure the rebuild process re-runs
                 // the same multiple-build dataflow.
-                CatalogItem::Source(_) => {
+                CatalogItem::Source(source) => {
                     // Inform the timestamper about this source.
                     self.update_timestamper(entry.id(), true).await;
-                    let frontiers =
-                        self.new_frontiers(entry.id(), Some(0), self.logical_compaction_window_ms);
+                    let since_ts = {
+                        match &source.connector {
+                            SourceConnector::External { persist, .. } => {
+                                persist.as_ref().map(|p| p.primary_stream.since_ts)
+                            }
+                            _ => None,
+                        }
+                    };
+
+                    let since_ts = since_ts.unwrap_or(0);
+
+                    let frontiers = self.new_frontiers(
+                        entry.id(),
+                        [since_ts],
+                        self.logical_compaction_window_ms,
+                    );
                     self.sources.insert(entry.id(), frontiers);
                 }
                 CatalogItem::Table(table) => {
@@ -2167,6 +2181,20 @@ where
             coord_bail!("Unmaterialized Postgres sources are not supported yet");
         }
 
+        let since_ts = {
+            match &plan {
+                CreateSourcePlan {
+                    source:
+                        Source {
+                            connector: SourceConnector::External { persist, .. },
+                            ..
+                        },
+                    ..
+                } => persist.as_ref().map(|p| p.primary_stream.since_ts),
+                _ => None,
+            }
+        };
+
         let if_not_exists = plan.if_not_exists;
         let (metadata, ops) = self.generate_create_source_ops(session, vec![plan])?;
         match self
@@ -2194,8 +2222,13 @@ where
                 // shipping any dataflows that depend on its existence.
                 for source_id in source_ids {
                     self.update_timestamper(source_id, true).await;
-                    let frontiers =
-                        self.new_frontiers(source_id, Some(0), self.logical_compaction_window_ms);
+                    let since_ts = since_ts.unwrap_or(0);
+
+                    let frontiers = self.new_frontiers(
+                        source_id,
+                        [since_ts],
+                        self.logical_compaction_window_ms,
+                    );
                     self.sources.insert(source_id, frontiers);
                 }
                 self.ship_dataflows(dfs).await?;

--- a/src/coord/src/persistcfg.rs
+++ b/src/coord/src/persistcfg.rs
@@ -262,10 +262,10 @@ impl PersisterWithConfig {
             }
         };
 
-        // TODO: We have a mismatch here: we know that these frontiers always contains only one
-        // element, because we only allow `u64` timestamps, but the return value suggests there could
-        // be more. Also: if the frontiers are truly multi-dimensional in the future, the logic that
-        // determines a common upper seal timestamp will become a bit more complicated.
+        // TODO: We have a mismatch here: we know that these frontiers always contain only one
+        // element, because we only allow `u64` timestamps, but the return value suggests there
+        // could be more. Also: if the frontiers are truly multi-dimensional in the future, the
+        // logic that determines a common upper seal timestamp will become a bit more complicated.
         let since_ts = description.since().iter().exactly_one().map_err(|_| {
             format!("expected exactly one element in the persist compaction frontier")
         })?;
@@ -382,6 +382,7 @@ fn stream_desc_from_name(
             return Ok(PersistStreamDesc {
                 name,
                 upper_seal_ts: u64::minimum(),
+                since_ts: u64::minimum(),
             });
         }
         Err(e) => {
@@ -390,18 +391,23 @@ fn stream_desc_from_name(
         }
     };
 
-    // TODO: We have a mismatch here: we know that the upper always contains only one element,
-    // because `seal` is `seal(u64)` but the return value suggests there could be more. Also: if
-    // the upper is a true multi-dimensional frontier in the future, the logic that determines a
-    // common upper seal timestamp will become a bit more complicated.
+    // TODO: We have a mismatch here: we know that these frontiers always contain only one element,
+    // because we only allow `u64` timestamps, but the return value suggests there could be more.
+    // Also: if the frontiers are truly multi-dimensional in the future, the logic that determines
+    // a common upper seal timestamp will become a bit more complicated.
     let upper_seal_ts = description
         .upper()
         .iter()
         .exactly_one()
         .map_err(|_| format!("expected exactly one element in the persist upper frontier"))?;
+    let since_ts =
+        description.since().iter().exactly_one().map_err(|_| {
+            format!("expected exactly one element in the persist compaction frontier")
+        })?;
     Ok(PersistStreamDesc {
         name,
         upper_seal_ts: *upper_seal_ts,
+        since_ts: *since_ts,
     })
 }
 

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -844,6 +844,22 @@ pub struct PersistStreamDesc {
     /// And when we restart, we start from step 1., at which time we are guaranteed not to have a
     /// source running already.
     pub upper_seal_ts: u64,
+    /// The _current_ compaction frontier (aka _since_) of this stream.
+    ///
+    /// NOTE: This timestamp is determined when the coordinator starts up or when the source is
+    /// initially created. When a source is actively writing to this stream and allowing
+    /// compaction, this will progress beyond this timestamp.
+    ///
+    /// This is okay for now because we only want to allow one source instantiation for persistent
+    /// sources, meaning the flow is usually this:
+    ///
+    ///  1. coordinator determines since timestamp
+    ///  2. timestamps for a source are sent to dataflow when rendering a source
+    ///  3. coordinator (or anyone) never looks at this timestamp again.
+    ///
+    /// And when we restart, we start from step 1., at which time we are guaranteed not to have a
+    /// source running already.
+    pub since_ts: u64,
 }
 
 impl SourceConnector {


### PR DESCRIPTION
Before, all sources started out with a since frontier of [0] when
created, without looking at the since frontier (aka compaction
frontier) of persisted streams that are involved in a persistent
source.

Now, we look at the since of the primary stream when starting to read from a
source. We only need to look at the primary stream because this is what
carries the actual data of the source that we replay when starting up.

This was not strictly a bug, because we never compact persistent
sources. We do have to resolve this issue, though, in order to
enable compaction.

Fixes #9655 

Note: I'll have to find someone from the coordinator team to also take a look at this because I'm messing with sinces and that often has the potential to introduce incorrectness. 

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/9656)
<!-- Reviewable:end -->
