### PR TITLE
Normalize table function names in ROWS FROM

### DIFF
--- a/src/coord/src/catalog/migrate.rs
+++ b/src/coord/src/catalog/migrate.rs
@@ -28,8 +28,8 @@ use sql::ast::{
     CreateSourceFormat, CreateSourceStatement, CreateTableStatement, CreateTypeStatement,
     CreateViewStatement, CsrConnectorAvro, CsrConnectorProto, CsrSeed, CsrSeedCompiled,
     CsrSeedCompiledEncoding, CsrSeedCompiledOrLegacy, CsvColumns, DataType, Format, Function,
-    Ident, ProtobufSchema, Raw, RawName, SqlOption, Statement, TableFactor, TableFunction,
-    UnresolvedObjectName, Value, ViewDefinition, WithOption, WithOptionValue,
+    Ident, ProtobufSchema, Raw, RawName, SqlOption, Statement, TableFunction, UnresolvedObjectName,
+    Value, ViewDefinition, WithOption, WithOptionValue,
 };
 use sql::plan::resolve_names_stmt;
 use uuid::Uuid;
@@ -426,17 +426,11 @@ fn ast_use_pg_catalog_0_7_1(stmt: &mut sql::ast::Statement<Raw>) -> Result<(), a
             // find them.
             visit_mut::visit_function_mut(self, func)
         }
-        fn visit_table_factor_mut(&mut self, table_factor: &'ast mut TableFactor<Raw>) {
-            if let TableFactor::Function {
-                function: TableFunction { ref mut name, .. },
-                ..
-            } = table_factor
-            {
-                normalize_function_name(name);
-            }
+        fn visit_table_function_mut(&mut self, func: &'ast mut TableFunction<Raw>) {
+            normalize_function_name(&mut func.name);
             // Function args can be functions themselves, so let the visitor
             // find them.
-            visit_mut::visit_table_factor_mut(self, table_factor)
+            visit_mut::visit_table_function_mut(self, func)
         }
     }
 

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -1168,3 +1168,7 @@ SELECT * FROM generate_series(1, 3) as foo(a), ROWS FROM (generate_series(foo.a,
 3  3  3  3
 3  4  4  NULL
 3  5  NULL  NULL
+
+# Regression test for #9657
+statement ok
+create view bar as select * from y, rows from (generate_series(1, 2), jsonb_array_elements(y.a));


### PR DESCRIPTION
Table functions within TableFactor::RowsFrom were not visited by the
query normalizer, since it didn't implement `visit_table_function_mut`.

Fixes #9657.

<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

This PR fixes a recognized bug.
<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug: [Link to issue.]

  * This PR adds a known-desirable feature: [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
