### PR TITLE
persist: fix invalid capability downgrades when seal operator is closed

### DIFF
--- a/src/persist/src/operators/stream.rs
+++ b/src/persist/src/operators/stream.rs
@@ -649,7 +649,7 @@ mod tests {
 
     #[test]
     fn seal_frontier_advance_only_on_success() -> Result<(), Error> {
-        ore::test::init_logging_default("trace");
+        ore::test::init_logging();
         let mut registry = MemRegistry::new();
         let mut unreliable = UnreliableHandle::default();
         let p = registry.runtime_unreliable(unreliable.clone())?;
@@ -759,7 +759,7 @@ mod tests {
 
     #[test]
     fn conditional_seal() -> Result<(), Error> {
-        ore::test::init_logging_default("trace");
+        ore::test::init_logging();
         let mut registry = MemRegistry::new();
 
         let p = registry.runtime_no_reentrance()?;
@@ -878,7 +878,7 @@ mod tests {
 
     #[test]
     fn conditional_seal_frontier_advance_only_on_success() -> Result<(), Error> {
-        ore::test::init_logging_default("trace");
+        ore::test::init_logging();
         let mut registry = MemRegistry::new();
         let mut unreliable = UnreliableHandle::default();
         let p = registry.runtime_unreliable(unreliable.clone())?;
@@ -982,7 +982,7 @@ mod tests {
 
     #[test]
     fn retract_unsealed() -> Result<(), Error> {
-        ore::test::init_logging_default("trace");
+        ore::test::init_logging();
         let mut registry = MemRegistry::new();
         let p = registry.runtime_no_reentrance()?;
 


### PR DESCRIPTION
Touches #9419.

We are currently seeing crashes very infrequently around capability set downgrades,
with no clear idea how to reproduce. This commit adds more logging output so that
we can at least inspect the state of the operator when it crashes, and hopefully
use that to debug. This commit also tries to do so in a fairly minimal overhead
way.

<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug: [Link to issue.]

  * This PR adds a known-desirable feature: [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
