### PR TITLE
persist: introduce a reusable data generator for benchmarks

### DIFF
--- a/src/persist/benches/end_to_end.rs
+++ b/src/persist/benches/end_to_end.rs
@@ -11,82 +11,51 @@
 //! we can ingest it.
 
 use std::path::{Path, PathBuf};
-use std::time::Duration;
 
 use criterion::measurement::Measurement;
+use criterion::{criterion_group, criterion_main, Bencher, BenchmarkId, Criterion, Throughput};
 use differential_dataflow::operators::Count;
 use differential_dataflow::AsCollection;
-use persist::error::Error;
+use ore::cast::CastFrom;
+use ore::metrics::MetricsRegistry;
 use timely::dataflow::operators::Map;
 use timely::dataflow::ProbeHandle;
 use timely::Config;
 
-use ore::metrics::MetricsRegistry;
-
-use persist::file::{FileBlob, FileLog};
-use persist::indexed::runtime::{self, RuntimeClient, RuntimeConfig, StreamWriteHandle};
+use persist::error::{Error, ErrorLog};
+use persist::file::FileBlob;
+use persist::indexed::runtime::{self, RuntimeClient, RuntimeConfig};
 use persist::operators::source::PersistedSource;
 use persist::storage::{Blob, LockInfo};
-
-use criterion::{criterion_group, criterion_main, Bencher, BenchmarkGroup, Criterion, Throughput};
-use rand::distributions::Alphanumeric;
-use rand::Rng;
+use persist::workload::{self, DataGenerator};
 
 pub fn bench_end_to_end(c: &mut Criterion) {
-    let data_size_mb = 100;
-    let chunk_size_mb = 5;
-
     let mut group = c.benchmark_group("end_to_end");
-    group.throughput(Throughput::Bytes((data_size_mb as u64) * 1024 * 1024));
 
-    write_and_bench_read(&mut group, "4b_keys", data_size_mb, chunk_size_mb, 4, 0);
-    write_and_bench_read(
-        &mut group,
-        "4kb_keys",
-        data_size_mb,
-        chunk_size_mb,
-        4 * 1024,
-        0,
-    );
-    write_and_bench_read(&mut group, "100b_keys", data_size_mb, chunk_size_mb, 100, 0);
-}
-
-fn write_and_bench_read<M: Measurement>(
-    group: &mut BenchmarkGroup<M>,
-    variant_name: &str,
-    data_size_mb: usize,
-    chunk_size_mb: usize,
-    key_bytes: usize,
-    value_bytes: usize,
-) {
     let temp_dir = tempfile::tempdir().expect("failed to create temp directory");
-    let nonce = variant_name.to_string();
-    let collection_name = "4b_keys".to_string();
+    let nonce = "end_to_end".to_string();
+    let collection_name = "end_to_end".to_string();
     let mut runtime = create_runtime(temp_dir.path(), &nonce).expect("missing runtime");
-
-    let (mut write, _read) = runtime.create_or_load(&collection_name);
-
-    let expected_frontier = write_test_data(
-        data_size_mb,
-        chunk_size_mb,
-        key_bytes,
-        value_bytes,
-        &mut write,
-    )
-    .expect("error writing data");
-
+    let (write, _read) = runtime.create_or_load(&collection_name);
+    let data = DataGenerator::default();
+    let goodput_bytes = workload::load(&write, &data, true).expect("error writing data");
+    group.throughput(Throughput::Bytes(goodput_bytes));
+    let expected_frontier = u64::cast_from(data.record_count);
     runtime.stop().expect("runtime shut down cleanly");
 
-    group.bench_function(format!("end_to_end_{}", variant_name), move |b| {
-        bench_read_persisted_source(
-            1,
-            temp_dir.path().to_path_buf(),
-            nonce.clone(),
-            collection_name.clone(),
-            expected_frontier,
-            b,
-        )
-    });
+    group.bench_function(
+        BenchmarkId::new("end_to_end", data.goodput_pretty()),
+        move |b| {
+            bench_read_persisted_source(
+                1,
+                temp_dir.path().to_path_buf(),
+                nonce.clone(),
+                collection_name.clone(),
+                expected_frontier,
+                b,
+            )
+        },
+    );
 }
 
 fn bench_read_persisted_source<M: Measurement>(
@@ -144,12 +113,11 @@ fn bench_read_persisted_source<M: Measurement>(
 }
 
 fn create_runtime(base_path: &Path, nonce: &str) -> Result<RuntimeClient, Error> {
-    let log_dir = base_path.join(format!("log_{}", nonce));
     let blob_dir = base_path.join(format!("blob_{}", nonce));
     let lock_info = LockInfo::new(format!("reentrance_{}", nonce), "no_details".to_owned())?;
     let runtime = runtime::start(
         RuntimeConfig::default(),
-        FileLog::new(log_dir, lock_info.clone())?,
+        ErrorLog,
         FileBlob::open_exclusive(blob_dir.into(), lock_info)?,
         build_info::DUMMY_BUILD_INFO,
         &MetricsRegistry::new(),
@@ -158,65 +126,8 @@ fn create_runtime(base_path: &Path, nonce: &str) -> Result<RuntimeClient, Error>
     Ok(runtime)
 }
 
-fn write_test_data(
-    data_size_mb: usize,
-    chunk_size_mb: usize,
-    key_bytes: usize,
-    value_bytes: usize,
-    write: &mut StreamWriteHandle<Vec<u8>, Vec<u8>>,
-) -> Result<u64, Error> {
-    // +8 +8 for timestamp and diff, respectively
-    let record_size_bytes = key_bytes + value_bytes + 8 + 8;
-    let data_size_bytes = data_size_mb * 1024 * 1024;
-    let chunk_size_bytes = chunk_size_mb * 1024 * 1024;
-    let num_records = (data_size_bytes / record_size_bytes) as u64;
-
-    // write data in batches
-
-    let step_size = data_size_bytes / chunk_size_bytes;
-    let mut last_time = 0;
-
-    let mut futures = Vec::new();
-    for time in (0..num_records).step_by(step_size) {
-        let data: Vec<_> = (0..step_size)
-            .map(|_i| {
-                (
-                    (generate_bytes(key_bytes), generate_bytes(value_bytes)),
-                    time,
-                    1,
-                )
-            })
-            .collect();
-
-        let result = write.write(&data);
-        futures.push(result);
-        last_time = time;
-    }
-
-    for future in futures {
-        future.recv()?;
-    }
-
-    let seal_ts = last_time + 1;
-
-    write.seal(seal_ts).recv()?;
-
-    Ok(seal_ts)
-}
-
-/// Generates and returns bytes of length `len`.
-pub fn generate_bytes(len: usize) -> Vec<u8> {
-    // not super smart, BUT we're not benchmarking this.
-    rand::thread_rng()
-        .sample_iter(&Alphanumeric)
-        .take(len)
-        .collect()
-}
-
 criterion_group! {
-    name = benches;
-    config = Criterion::default().measurement_time(Duration::from_secs(60)).sample_size(10);
-    targets = bench_end_to_end
+    benches,
+    bench_end_to_end,
 }
-
 criterion_main!(benches);

--- a/src/persist/src/indexed/mod.rs
+++ b/src/persist/src/indexed/mod.rs
@@ -1328,8 +1328,8 @@ mod tests {
     #[test]
     fn batch_consolidation() -> Result<(), Error> {
         let updates = vec![
-            (("1".into(), "".into()), 1, 1),
-            (("1".into(), "".into()), 1, 1),
+            (("1".as_bytes(), "".as_bytes()), 1, 1),
+            (("1".as_bytes(), "".as_bytes()), 1, 1),
         ];
 
         let mut i = MemRegistry::new().indexed_no_reentrance()?;
@@ -1381,7 +1381,7 @@ mod tests {
 
     #[test]
     fn regression_empty_unsealed_batch() -> Result<(), Error> {
-        let updates = vec![];
+        let updates: Vec<((Vec<u8>, Vec<u8>), _, _)> = vec![];
 
         let mut i = MemRegistry::new().indexed_no_reentrance()?;
         let id = block_on(|res| i.register("0", "", "", res))?;
@@ -1420,7 +1420,7 @@ mod tests {
             i.write(
                 vec![(
                     s1,
-                    vec![(("".into(), "".into()), 0, 1)]
+                    vec![(("".as_bytes(), "".as_bytes()), 0, 1)]
                         .iter()
                         .collect::<ColumnarRecords>(),
                 )],
@@ -1432,7 +1432,7 @@ mod tests {
             i.write(
                 vec![(
                     s2,
-                    vec![(("".into(), "".into()), 1, 1)]
+                    vec![(("".as_bytes(), "".as_bytes()), 1, 1)]
                         .iter()
                         .collect::<ColumnarRecords>(),
                 )],
@@ -1447,7 +1447,7 @@ mod tests {
             i.write(
                 vec![(
                     s1,
-                    vec![(("".into(), "".into()), 2, 1)]
+                    vec![(("".as_bytes(), "".as_bytes()), 2, 1)]
                         .iter()
                         .collect::<ColumnarRecords>(),
                 )],
@@ -1523,8 +1523,8 @@ mod tests {
     #[test]
     fn try_set_meta_matches_storage() -> Result<(), Error> {
         let updates = vec![
-            (("1".into(), "".into()), 2, 1),
-            (("2".into(), "".into()), 1, 1),
+            (("1".as_bytes(), "".as_bytes()), 2, 1),
+            (("2".as_bytes(), "".as_bytes()), 1, 1),
         ];
 
         let mut unreliable = UnreliableHandle::default();
@@ -1556,9 +1556,9 @@ mod tests {
         // answer (at the time of the bug, compaction did the right thing, which
         // is why we didn't catch it initially).
         let updates = vec![
-            (("1".into(), "".into()), 1, 1),
-            (("1".into(), "".into()), 10, -1),
-            (("2".into(), "".into()), 2, 1),
+            (("1".as_bytes(), "".as_bytes()), 1, 1),
+            (("1".as_bytes(), "".as_bytes()), 10, -1),
+            (("2".as_bytes(), "".as_bytes()), 2, 1),
         ];
         block_on_drain(&mut i, |i, res| {
             i.write(vec![(id, updates.iter().collect::<ColumnarRecords>())], res)

--- a/src/persist/src/lib.rs
+++ b/src/persist/src/lib.rs
@@ -28,6 +28,7 @@ pub mod pfuture;
 pub mod s3;
 pub mod storage;
 pub mod unreliable;
+pub mod workload;
 
 #[cfg(test)]
 pub mod golden_test;

--- a/src/persist/src/workload.rs
+++ b/src/persist/src/workload.rs
@@ -1,0 +1,274 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! A configurable data generator for benchmarking.
+
+use std::cmp;
+use std::env::{self, VarError};
+use std::io::Write;
+use std::mem::size_of;
+
+use ore::cast::CastFrom;
+
+use crate::error::Error;
+use crate::indexed::columnar::{ColumnarRecords, ColumnarRecordsBuilder};
+use crate::indexed::runtime::StreamWriteHandle;
+
+/// A configurable data generator for benchmarking.
+#[derive(Clone, Debug)]
+pub struct DataGenerator {
+    /// The total number of records to produce.
+    pub record_count: usize,
+    /// The number of "goodput" bytes to make each record.
+    pub record_size_bytes: usize,
+    /// The maximum number of records included in a generated batch of records.
+    pub batch_max_count: usize,
+    // TODO: unique: bool,
+    key_buf: Vec<u8>,
+    val_buf: Vec<u8>,
+}
+
+const RECORD_SIZE_BYTES_KEY: &'static str = "MZ_PERSIST_RECORD_SIZE_BYTES";
+const RECORD_COUNT_KEY: &'static str = "MZ_PERSIST_RECORD_COUNT";
+const BATCH_MAX_COUNT_KEY: &'static str = "MZ_PERSIST_BATCH_MAX_COUNT";
+
+// Selected arbitrarily as representative of production record sizes.
+const DEFAULT_RECORD_SIZE_BYTES: usize = 64;
+// Selected arbitrarily to make ~8MiB batches.
+const DEFAULT_BATCH_MAX_COUNT: usize = (8 * 1024 * 1024) / DEFAULT_RECORD_SIZE_BYTES;
+// Manually tuned once to be the smallest value such that (1) we hit max
+// throughput on the end_to_end benchmark and (2) goodput_pretty produces a
+// round-ish number.
+const DEFAULT_RECORD_COUNT: usize = 819_200;
+
+const TS_DIFF_GOODPUT_SIZE: usize = size_of::<u64>() + size_of::<isize>();
+
+fn read_env_usize(key: &str, default: usize) -> usize {
+    match env::var(key) {
+        Ok(x) => x
+            .parse()
+            .map_err(|err| format!("invalid value for {}: {}", key, err))
+            .unwrap(),
+        Err(VarError::NotPresent) => default,
+        Err(err) => panic!("invalid value for {}: {}", key, err),
+    }
+}
+
+impl Default for DataGenerator {
+    fn default() -> Self {
+        let record_count = read_env_usize(RECORD_COUNT_KEY, DEFAULT_RECORD_COUNT);
+        let record_size_bytes = read_env_usize(RECORD_SIZE_BYTES_KEY, DEFAULT_RECORD_SIZE_BYTES);
+        let batch_max_count = read_env_usize(BATCH_MAX_COUNT_KEY, DEFAULT_BATCH_MAX_COUNT);
+
+        eprintln!(
+            "{}={} {}={} {}={}",
+            RECORD_COUNT_KEY,
+            record_count,
+            RECORD_SIZE_BYTES_KEY,
+            record_size_bytes,
+            BATCH_MAX_COUNT_KEY,
+            batch_max_count,
+        );
+        DataGenerator::new(record_count, record_size_bytes, batch_max_count)
+    }
+}
+
+impl DataGenerator {
+    /// Returns a new [DataGenerator].
+    pub fn new(record_count: usize, record_size_bytes: usize, batch_max_count: usize) -> Self {
+        // NB: Strict greater so we have at least one byte for key.
+        assert!(record_size_bytes > TS_DIFF_GOODPUT_SIZE);
+        assert!(batch_max_count > 0);
+        DataGenerator {
+            record_count,
+            record_size_bytes,
+            batch_max_count,
+            key_buf: Vec::new(),
+            val_buf: Vec::new(),
+        }
+    }
+
+    /// Returns the number of "goodput" bytes represented by the entire dataset
+    /// produced by this generator.
+    pub fn goodput_bytes(&self) -> u64 {
+        u64::cast_from(self.record_count * self.record_size_bytes)
+    }
+
+    /// Returns a more easily human readable version of [Self::goodput_bytes].
+    pub fn goodput_pretty(&self) -> String {
+        let goodput_bytes = self.goodput_bytes();
+        const KIB: u64 = 1024;
+        const MIB: u64 = 1024 * KIB;
+        const GIB: u64 = 1024 * MIB;
+        if goodput_bytes >= 10 * GIB {
+            format!("{}GiB", goodput_bytes / GIB)
+        } else if goodput_bytes >= 10 * MIB {
+            format!("{}MiB", goodput_bytes / MIB)
+        } else if goodput_bytes >= 10 * KIB {
+            format!("{}KiB", goodput_bytes / KIB)
+        } else {
+            format!("{}B", goodput_bytes)
+        }
+    }
+
+    /// Generates the requested batch of records.
+    pub fn gen_batch(&mut self, batch_idx: usize) -> Option<ColumnarRecords> {
+        let batch_start = self.batch_max_count * batch_idx;
+        let batch_end = cmp::min(batch_start + self.batch_max_count, self.record_count);
+        if batch_start >= batch_end {
+            return None;
+        }
+        let mut batch = ColumnarRecordsBuilder::default();
+        batch.reserve(
+            batch_end - batch_start,
+            self.record_size_bytes - TS_DIFF_GOODPUT_SIZE,
+            0,
+        );
+        for record_idx in batch_start..batch_end {
+            batch.push(self.gen_record(record_idx));
+        }
+        Some(batch.finish())
+    }
+
+    fn gen_record(&mut self, record_idx: usize) -> ((&[u8], &[u8]), u64, isize) {
+        assert!(record_idx < self.record_count);
+        assert!(self.record_size_bytes > TS_DIFF_GOODPUT_SIZE);
+
+        self.key_buf.clear();
+        let key_len = self.record_size_bytes - TS_DIFF_GOODPUT_SIZE;
+        if self.key_buf.capacity() < key_len {
+            self.key_buf.reserve(key_len);
+        }
+        // This format `record_idx` as an integer and, if necessary, left-pads
+        // it with 0s to be `key_len` chars long.
+        write!(&mut self.key_buf, "{:01$}", record_idx, key_len)
+            .expect("write to Vec is infallible");
+        self.key_buf.truncate(key_len);
+        assert_eq!(self.key_buf.len(), key_len);
+
+        self.val_buf.clear();
+
+        let ts = u64::cast_from(record_idx);
+        let diff = 1;
+        ((&self.key_buf, &self.val_buf), ts, diff)
+    }
+
+    /// Returns an [Iterator] of all records in batches.
+    pub fn batches(&self) -> DataGeneratorBatchIter {
+        DataGeneratorBatchIter {
+            config: self.clone(),
+            batch_idx: 0,
+        }
+    }
+
+    /// Returns an [Iterator] of all records.
+    pub fn records(&self) -> impl Iterator<Item = ((Vec<u8>, Vec<u8>), u64, isize)> {
+        let mut config = self.clone();
+        (0..self.record_count).map(move |record_idx| {
+            let ((k, v), t, d) = config.gen_record(record_idx);
+            ((k.to_vec(), v.to_vec()), t, d)
+        })
+    }
+}
+
+/// An implementation of [Iterator] for [DataGenerator].
+#[derive(Debug)]
+pub struct DataGeneratorBatchIter {
+    config: DataGenerator,
+    batch_idx: usize,
+}
+
+impl Iterator for DataGeneratorBatchIter {
+    type Item = ColumnarRecords;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let batch_idx = self.batch_idx;
+        self.batch_idx += 1;
+        self.config.gen_batch(batch_idx)
+    }
+}
+
+/// Load the dataset into a persist collection.
+///
+/// The data is loaded with one concurrent write call per generated data batch.
+/// If `do_seals` is true, data is sealed as it's loaded.
+///
+/// The "goodput" bytes represented by this data load are returned on success.
+pub fn load(
+    handle: &StreamWriteHandle<Vec<u8>, Vec<u8>>,
+    data: &DataGenerator,
+    do_seals: bool,
+) -> Result<u64, Error> {
+    let mut writes = Vec::new();
+    let mut seals = Vec::new();
+    for batch in data.batches() {
+        // It's unfortunate to turn this into a Vec just to turn it back into a
+        // columnar batch.
+        let batch = batch
+            .iter()
+            .map(|((k, v), t, d)| ((k.to_vec(), v.to_vec()), t, d))
+            .collect::<Vec<_>>();
+        writes.push(handle.write(&batch));
+        if let Some((_, batch_largest_ts, _)) = batch.get(batch.len() - 1) {
+            if do_seals {
+                let seal_ts = batch_largest_ts + 1;
+                seals.push(handle.seal(seal_ts));
+            }
+        }
+    }
+    for write in writes {
+        write.recv()?;
+    }
+    for seal in seals {
+        seal.recv()?;
+    }
+    Ok(data.goodput_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn size_invariants() {
+        fn testcase(c: DataGenerator) {
+            let (mut actual_len, mut actual_goodput_bytes) = (0, 0);
+            for batch in c.batches() {
+                for ((k, v), _, _) in batch.iter() {
+                    actual_len += 1;
+                    actual_goodput_bytes += k.len() + v.len() + TS_DIFF_GOODPUT_SIZE;
+                }
+            }
+            assert_eq!(actual_len, c.record_count);
+            assert_eq!(actual_goodput_bytes, usize::cast_from(c.goodput_bytes()));
+        }
+
+        testcase(DataGenerator::new(1, 32, 1));
+        testcase(DataGenerator::new(1, 32, 100));
+        testcase(DataGenerator::new(100, 32, 7));
+        testcase(DataGenerator::new(1000, 32, 100));
+    }
+
+    #[test]
+    fn goodput_pretty() {
+        fn testcase(bytes: usize) -> String {
+            DataGenerator::new(1, bytes, 1).goodput_pretty()
+        }
+
+        assert_eq!(testcase(33), "33B");
+        assert_eq!(testcase(10 * 1024 - 1), "10239B");
+        assert_eq!(testcase(10 * 1024), "10KiB");
+        assert_eq!(testcase(10 * 1024 * 1024 - 1), "10239KiB");
+        assert_eq!(testcase(10 * 1024 * 1024), "10MiB");
+        assert_eq!(testcase(10 * 1024 * 1024 * 1024 - 1), "10239MiB");
+        assert_eq!(testcase(10 * 1024 * 1024 * 1024), "10GiB");
+        assert_eq!(testcase(10 * 1024 * 1024 * 1024 * 1024 - 1), "10239GiB");
+        assert_eq!(testcase(10 * 1024 * 1024 * 1024 * 1024), "10240GiB"); // No TiB
+    }
+}


### PR DESCRIPTION
    MZ_PERSIST_RECORD_COUNT=819200 MZ_PERSIST_RECORD_SIZE_BYTES=64 MZ_PERSIST_BATCH_SIZE=131072
    end_to_end/end_to_end/50MiB
                            time:   [500.08 ms 501.70 ms 503.43 ms]
                            thrpt:  [99.319 MiB/s 99.661 MiB/s 99.984 MiB/s]
    snapshot/mem_unsealed_snapshot/50MiB
                            time:   [111.41 ms 112.01 ms 112.66 ms]
                            thrpt:  [443.81 MiB/s 446.38 MiB/s 448.80 MiB/s]
    snapshot/mem_trace_snapshot/50MiB
                            time:   [104.68 ms 106.19 ms 107.91 ms]
                            thrpt:  [463.35 MiB/s 470.87 MiB/s 477.66 MiB/s]
    snapshot/file_unsealed_snapshot/50MiB
                            time:   [119.94 ms 120.80 ms 121.82 ms]
                            thrpt:  [410.43 MiB/s 413.91 MiB/s 416.88 MiB/s]
    snapshot/file_trace_snapshot/50MiB
                            time:   [108.80 ms 110.31 ms 112.09 ms]
                            thrpt:  [446.08 MiB/s 453.28 MiB/s 459.54 MiB/s]
    mem_log_write_sync      time:   [27.831 ns 28.120 ns 28.378 ns]
    file_log_write_sync     time:   [18.075 ms 18.329 ms 18.581 ms]
    blob_set/mem/50MiB      time:   [5.8573 ms 5.9314 ms 6.0031 ms]
                            thrpt:  [8.1338 GiB/s 8.2321 GiB/s 8.3364 GiB/s]
    blob_set/file/50MiB     time:   [44.383 ms 45.318 ms 46.265 ms]
                            thrpt:  [1.0554 GiB/s 1.0775 GiB/s 1.1001 GiB/s]
    blob_cache_set_unsealed_batch/file_unsorted/50MiB
                            time:   [133.86 ms 134.15 ms 134.44 ms]
                            thrpt:  [371.91 MiB/s 372.71 MiB/s 373.52 MiB/s]
    blob_cache_set_unsealed_batch/mem_unsorted/50MiB
                            time:   [92.255 ms 92.980 ms 93.872 ms]
                            thrpt:  [532.64 MiB/s 537.75 MiB/s 541.98 MiB/s]
    indexed_write_drain/mem_sorted/50MiB
                            time:   [171.35 ms 172.24 ms 173.20 ms]
                            thrpt:  [288.68 MiB/s 290.30 MiB/s 291.80 MiB/s]
    indexed_write_drain/mem_unsorted/50MiB
                            time:   [179.89 ms 180.60 ms 181.36 ms]
                            thrpt:  [275.70 MiB/s 276.85 MiB/s 277.95 MiB/s]
    indexed_write_drain/file_sorted/50MiB
                            time:   [233.29 ms 235.74 ms 238.10 ms]
                            thrpt:  [210.00 MiB/s 212.10 MiB/s 214.32 MiB/s]
    indexed_write_drain/file_unsorted/50MiB
                            time:   [232.93 ms 234.82 ms 236.55 ms]
                            thrpt:  [211.37 MiB/s 212.93 MiB/s 214.66 MiB/s]

<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug: [Link to issue.]

  * This PR adds a known-desirable feature: [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
