### PR TITLE
add support for tokio-console behind a hidden flag and feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -893,6 +893,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "console-api"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "033fddce299c93dd44ae21d5f5a6e749baa5d103784bcdde65701c07272a9fde"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+ "tonic-build",
+ "tracing-core",
+]
+
+[[package]]
+name = "console-subscriber"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2380cc150266375aeda8f9aeadc5527395c1a8807ecf9fa97a46d1bb760ec5b"
+dependencies = [
+ "console-api",
+ "futures",
+ "hdrhistogram",
+ "humantime",
+ "serde",
+ "serde_json",
+ "thread_local",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "coord"
 version = "0.0.0"
 dependencies = [
@@ -2131,6 +2165,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hdrhistogram"
+version = "7.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6490be71f07a5f62b564bc58e36953f675833df11c7e4a0647bee7a07ca1ec5e"
+dependencies = [
+ "base64",
+ "byteorder",
+ "flate2",
+ "nom",
+ "num-traits",
+]
+
+[[package]]
 name = "headers"
 version = "0.3.5"
 source = "git+https://github.com/MaterializeInc/headers.git#b968d50f79907ea74ad42c8cc83c950314f1ca31"
@@ -2245,9 +2292,9 @@ checksum = "02296996cb8796d7c6e3bc2d9211b7802812d36999a51bb754123ead7d37d026"
 
 [[package]]
 name = "humantime"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -2307,6 +2354,18 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tower-service",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
 ]
 
 [[package]]
@@ -2696,6 +2755,7 @@ dependencies = [
  "chrono",
  "clap",
  "compile-time-run",
+ "console-subscriber",
  "coord",
  "coordtest",
  "crossbeam-channel",
@@ -3925,7 +3985,7 @@ dependencies = [
 [[package]]
 name = "prost"
 version = "0.9.0"
-source = "git+https://github.com/MaterializeInc/prost.git#28bc721d6a74b9ed4628cc8f13527a9573cf082d"
+source = "git+https://github.com/MaterializeInc/prost.git#6dd498282d0c7ade8f82f2a0163587dae259ae38"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -3934,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "prost-build"
 version = "0.9.1"
-source = "git+https://github.com/MaterializeInc/prost.git#28bc721d6a74b9ed4628cc8f13527a9573cf082d"
+source = "git+https://github.com/MaterializeInc/prost.git#6dd498282d0c7ade8f82f2a0163587dae259ae38"
 dependencies = [
  "bytes",
  "heck",
@@ -3954,7 +4014,7 @@ dependencies = [
 [[package]]
 name = "prost-derive"
 version = "0.9.0"
-source = "git+https://github.com/MaterializeInc/prost.git#28bc721d6a74b9ed4628cc8f13527a9573cf082d"
+source = "git+https://github.com/MaterializeInc/prost.git#6dd498282d0c7ade8f82f2a0163587dae259ae38"
 dependencies = [
  "anyhow",
  "itertools",
@@ -3966,7 +4026,7 @@ dependencies = [
 [[package]]
 name = "prost-types"
 version = "0.9.0"
-source = "git+https://github.com/MaterializeInc/prost.git#28bc721d6a74b9ed4628cc8f13527a9573cf082d"
+source = "git+https://github.com/MaterializeInc/prost.git#6dd498282d0c7ade8f82f2a0163587dae259ae38"
 dependencies = [
  "bytes",
  "prost",
@@ -5054,11 +5114,11 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.0.1"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
+checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
 dependencies = [
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]
@@ -5207,7 +5267,18 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "tokio-macros",
+ "tracing",
  "winapi",
+]
+
+[[package]]
+name = "tokio-io-timeout"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90c49f106be240de154571dd31fbe48acb10ba6c6dd6f6517ad603abffa42de9"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -5316,6 +5387,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff08f4649d10a70ffa3522ca559031285d8e421d727ac85c60825761818f5d0a"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "prost-derive",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9403f1bafde247186684b230dc6f38b5cd514584e8bec1dd32514be4745fa757"
+dependencies = [
+ "proc-macro2",
+ "prost-build",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5323,9 +5437,14 @@ checksum = "c00e500fff5fa1131c866b246041a6bf96da9c965f8fe4128cb1421f23e93c00"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project",
  "pin-project-lite",
+ "rand",
+ "slab",
  "tokio",
+ "tokio-stream",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -5374,6 +5493,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,3 +85,5 @@ parquet-format-async-temp = { git = "https://github.com/MaterializeInc/parquet-f
 # Waiting on https://github.com/tokio-rs/prost/pull/576.
 prost = { git = "https://github.com/MaterializeInc/prost.git" }
 prost-types = { git = "https://github.com/MaterializeInc/prost.git" }
+prost-build = { git = "https://github.com/MaterializeInc/prost.git" }
+prost-derive = { git = "https://github.com/MaterializeInc/prost.git" }

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -37,6 +37,7 @@ cfg-if = "1.0.0"
 chrono = { version = "0.4.0", default-features = false, features = ["std"] }
 clap = { version = "3.0.10", features = ["wrap_help", "env", "derive"] }
 compile-time-run = "0.2.12"
+console-subscriber = { version = "0.1.0", optional = true }
 coord = { path = "../coord" }
 crossbeam-channel = "0.5.2"
 dataflow = { path = "../dataflow" }
@@ -136,3 +137,4 @@ walkdir = "2.3.2"
 # WARNING: For development use only! When enabled, may allow unrestricted read
 # access to the file system.
 dev-web = []
+tokio-console = ["console-subscriber", "tokio/tracing"]


### PR DESCRIPTION
### Motivation

  * This PR adds a feature that has not yet been specified.

the tokio-console was release recently, in beta mode: https://tokio.rs/blog/2021-12-announcing-tokio-console, and in my experience it can be very helpful debugging problems and finding misbehaving tasks. Here is what it looks like in this commit:
![image](https://user-images.githubusercontent.com/5404303/146609091-337bf717-d834-4e90-8003-888f3ded72a6.png)

and it has already found misbehaving futures that are not yielding:
![image](https://user-images.githubusercontent.com/5404303/146609133-0b2bb6bb-ab9b-4a50-a258-9efa5251985c.png)


This pr also refactors our use of `tracing`. We give up the flexibility of `EnvFilter` to use a `Targets` per-layer filter, so that events that are not for human consumption are always passed along (to things like the console-subscriber, and our own metrics subscriber): https://docs.rs/tracing-subscriber/0.3.3/tracing_subscriber/struct.EnvFilter.html#examples has more info about this difference.

It is entirely possible that we prefer to require users of this flag to have to explicitly add the correct `trace` directive themselves with `--log-filter` or the env var.

Also, because `.with` returns different, stacked types, its hard to come up with a clean way to optionally add this, so i did the best I could

---

to run this, you must use something like this:
`RUSTFLAGS="--cfg tokio_unstable cargo run --features tokio-console -- --dev --tokio-console` . This unfortunately clashes with things like rust-analyzer, so you will often be rebuilding, but this can be added to `.cargo/config` to avoid this.

then, use `tokio-console` in another terminal to get the output. In the future, I may go into enforcing that all our tokio tasks are named, so that we can improve this. It might also be interesting to see if we could get timely to spit out the relevant info so that timely operators, which are similarly async, show up on the console

---

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/9665)
<!-- Reviewable:end -->
