### PR TITLE
doc: Restore Debezium page in "Third-party Tools"

### DIFF
--- a/doc/user/config.toml
+++ b/doc/user/config.toml
@@ -124,12 +124,6 @@ name = "Third-Party Tools"
 weight = 120
 
 [[menu.main]]
-name = "Using Debezium"
-parent = "third-party"
-url = "/guides/cdc-postgres"
-weight= 3
-
-[[menu.main]]
 identifier = "security"
 name = "Security"
 weight = 140

--- a/doc/user/content/guides/cdc-postgres.md
+++ b/doc/user/content/guides/cdc-postgres.md
@@ -5,8 +5,6 @@ weight:
 menu:
   main:
     parent: guides
-aliases:
-  - /third-party/debezium
 ---
 
 Change Data Capture (CDC) allows you to track and propagate changes in a Postgres database to downstream consumers based on its Write-Ahead Log (WAL). In this guide, we'll cover how to use Materialize to create and efficiently maintain real-time materialized views on top of CDC data.

--- a/doc/user/content/third-party/debezium.md
+++ b/doc/user/content/third-party/debezium.md
@@ -1,0 +1,28 @@
+---
+title: "Using Debezium"
+description: "Get details about using Materialize with Debezium"
+menu:
+  main:
+    parent: 'third-party'
+---
+
+You can use [Debezium](https://debezium.io/) to propagate Change Data Capture (CDC) data from a database to Materialize, for example MySQL or PostgreSQL.
+
+Debezium emits records using an envelope that contains valuable information about the change captured, like the `before` and `after` values for each record. This envelope is a powerful structure that lets Materialize perform more complex analysis to understand all CRUD-like operations happening in the upstream database. For more details on CDC support in Materialize, check the [documentation](/sql/create-source/avro-kafka/#debezium-envelope-details).
+
+
+{{< note >}}
+Currently, Materialize only supports Avro-encoded Debezium records. If you're interested in JSON support, please reach out in the community Slack or leave a comment in [this GitHub issue](https://github.com/MaterializeInc/materialize/issues/5231).
+{{</ note >}}
+
+### CDC guides
+
+For the best CDC experience, we recommend following the step-by-step guides for each upstream database:
+
+* [PostgreSQL](/guides/cdc-postgres/)
+
+* [MySQL](/guides/cdc-mysql/)
+
+### Kafka-less setup
+
+If you need to connect Materialize to a PostgreSQL database but Kafka is not part of your stack, you can use the [PostgreSQL direct source](/sql/create-source/postgres/#postgresql-source-details). This source uses PostgreSQL’s native replication protocol to continuously propagate upstream changes into Materialize, bypassing the need to deploy and maintain a Kafka instance. For more details and step-by-step instructions, check the [Change Data Capture (Postgres) guide](/guides/cdc-postgres/#direct-postgres-source).

--- a/doc/user/content/third-party/supported-tools.md
+++ b/doc/user/content/third-party/supported-tools.md
@@ -12,7 +12,7 @@ weight: 1
 | Tool | Purpose |
 |------|---------|
 | [Docker](/third-party/docker) | Easily deploy Materialize and other required infrastructure.
-| [Debezium](/guides/cdc-postgres) | Propagate change data capture (CDC) data from an upstream database to Materialize.
+| [Debezium](/third-party/debezium) | Propagate change data capture (CDC) data from an upstream database to Materialize.
 
 
 ## Beta-level support


### PR DESCRIPTION
"Using Debezium" under "Third-party Tools" currently redirects to the Postgres CDC guide. Having a dedicated overview page helps users get a better understanding of the different options and where we stand IWRT Debezium support. This PR restores the original page.