### PR TITLE
http_logs demo: Fix setup

### DIFF
--- a/demo/http_logs/mzcompose.yml
+++ b/demo/http_logs/mzcompose.yml
@@ -66,6 +66,7 @@ services:
       - materialized
     volumes:
       - .:/mounted
-    command: /mounted/setup.sh
+    entrypoint: /mounted/setup.sh
+
 volumes:
   logfile:

--- a/demo/http_logs/setup.sh
+++ b/demo/http_logs/setup.sh
@@ -9,7 +9,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-psql -h materialized -p 6875 -d materialize << EOF
+psql -U materialize -h materialized -p 6875 -d materialize << EOF
 -- Flask request logs format
 CREATE SOURCE requests
 FROM FILE '/log/requests' WITH (tail = true)


### PR DESCRIPTION
This PR fixes the `setup` service of the http_logs demo. Without this, the setup would fail to run and the user would be left to wonder why the sources and views were not created as described.

  - Since the mzcli's Dockerfile specifies an ENTRYPOINT, and we want to overwrite the container command (not just append to it), we need to specify an `entrypoint` in compose (not a `command`).
  - There is no root user in materialized, so in setup.sh, we need to specify the "materialize" user instead.

### Motivation

This PR fixes a previously unreported bug:

When running `./mzcompose up` inside `demo/http_logs`, as described in https://materialize.com/docs/demos/log-parsing/, the specified sources and views are not created in materialized.

Running `./mzcompose logs setup` yields this error:
```
psql: warning: extra command-line argument "/mounted/setup.sh" ignored
```

Furthermore, after the first error is resolved (see above), running `setup` produces a second error:
```
psql: error: FATAL:  role "root" does not exist
HINT:  Try connecting as the "materialize" user.
```