### PR TITLE
expr,sql: support casts from timestamp/tz to time

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -136,6 +136,9 @@ List new features before bug fixes.
   This bug could cause incorrect results in queries that combined `RIGHT` and
   `FULL` [joins](/sql/join) with comma-separated `FROM` items.
 
+- Support casts from [`timestamp`] and [`timestamp with time zone`] to
+  [`time`].
+
 {{% version-header v0.12.0 %}}
 
 - Optionally emit the message partition, offset, and timestamp in [Kafka
@@ -1669,6 +1672,7 @@ a problem with PostgreSQL JDBC 42.3.0.
 [`SHOW CREATE SOURCE`]: /sql/show-create-source
 [`SHOW CREATE VIEW`]: /sql/show-create-view
 [`text`]: /sql/types/text
+[`time`]: /sql/types/time
 [`timestamp`]: /sql/types/timestamp
 [`timestamp with time zone`]: /sql/types/timestamptz
 [pg-copy]: https://www.postgresql.org/docs/current/sql-copy.html

--- a/doc/user/content/sql/types/time.md
+++ b/doc/user/content/sql/types/time.md
@@ -42,6 +42,8 @@ You can [cast](../../functions/cast) from the following types to `time`:
 
 - [`interval`](../interval) (by assignment)
 - [`text`](../text) (explicitly)
+- [`timestamp`](../timestamp) (by assignment)
+- [`timestamptz`](../timestamp) (by assignment)
 
 ### Valid operations
 

--- a/doc/user/content/sql/types/timestamp.md
+++ b/doc/user/content/sql/types/timestamp.md
@@ -69,6 +69,7 @@ You can [cast](../../functions/cast) `timestamp` or `timestamptz` to:
 
 - [`date`](../date) (by assignment)
 - [`text`](../text) (by assignment)
+- [`time`](../time) (by assignment)
 
 #### To `timestamp` or `timestamptz`
 

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -3141,9 +3141,11 @@ pub enum UnaryFunc {
     CastTimestampToDate(CastTimestampToDate),
     CastTimestampToTimestampTz(CastTimestampToTimestampTz),
     CastTimestampToString(CastTimestampToString),
+    CastTimestampToTime(CastTimestampToTime),
     CastTimestampTzToDate(CastTimestampTzToDate),
     CastTimestampTzToTimestamp(CastTimestampTzToTimestamp),
     CastTimestampTzToString(CastTimestampTzToString),
+    CastTimestampTzToTime(CastTimestampTzToTime),
     CastBytesToString(CastBytesToString),
     CastStringToJsonb,
     CastJsonbToString,
@@ -3370,9 +3372,11 @@ derive_unary!(
     CastTimestampToString,
     CastTimestampTzToString,
     CastTimestampToDate,
+    CastTimestampToTime,
     CastTimestampTzToDate,
     CastTimestampToTimestampTz,
     CastTimestampTzToTimestamp,
+    CastTimestampTzToTime,
     CastDateToTimestamp,
     CastDateToTimestampTz,
     CastBytesToString,
@@ -3525,9 +3529,11 @@ impl UnaryFunc {
             | CastTimestampToString(_)
             | CastTimestampTzToString(_)
             | CastTimestampToDate(_)
+            | CastTimestampToTime(_)
             | CastTimestampTzToDate(_)
             | CastTimestampToTimestampTz(_)
             | CastTimestampTzToTimestamp(_)
+            | CastTimestampTzToTime(_)
             | CastDateToTimestamp(_)
             | CastDateToTimestampTz(_)
             | CastBytesToString(_)
@@ -3721,9 +3727,11 @@ impl UnaryFunc {
             | CastTimestampToString(_)
             | CastTimestampTzToString(_)
             | CastTimestampToDate(_)
+            | CastTimestampToTime(_)
             | CastTimestampTzToDate(_)
             | CastTimestampToTimestampTz(_)
             | CastTimestampTzToTimestamp(_)
+            | CastTimestampTzToTime(_)
             | CastDateToTimestamp(_)
             | CastDateToTimestampTz(_)
             | CastBytesToString(_)
@@ -3950,9 +3958,11 @@ impl UnaryFunc {
             | CastTimestampToString(_)
             | CastTimestampTzToString(_)
             | CastTimestampToDate(_)
+            | CastTimestampToTime(_)
             | CastTimestampTzToDate(_)
             | CastTimestampToTimestampTz(_)
             | CastTimestampTzToTimestamp(_)
+            | CastTimestampTzToTime(_)
             | CastDateToTimestamp(_)
             | CastDateToTimestampTz(_)
             | CastBytesToString(_)
@@ -4193,9 +4203,11 @@ impl UnaryFunc {
             | CastTimestampToString(_)
             | CastTimestampTzToString(_)
             | CastTimestampToDate(_)
+            | CastTimestampToTime(_)
             | CastTimestampTzToDate(_)
             | CastTimestampToTimestampTz(_)
             | CastTimestampTzToTimestamp(_)
+            | CastTimestampTzToTime(_)
             | CastDateToTimestamp(_)
             | CastDateToTimestampTz(_)
             | CastBytesToString(_)

--- a/src/expr/src/scalar/func/impls/timestamp.rs
+++ b/src/expr/src/scalar/func/impls/timestamp.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
+use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 
 use repr::strconv;
 
@@ -57,5 +57,19 @@ sqlfunc!(
     #[sqlname = "tstztots"]
     fn cast_timestamp_tz_to_timestamp(a: DateTime<Utc>) -> NaiveDateTime {
         a.naive_utc()
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "tstotime"]
+    fn cast_timestamp_to_time(a: NaiveDateTime) -> NaiveTime {
+        a.time()
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "tstztotime"]
+    fn cast_timestamp_tz_to_time(a: DateTime<Utc>) -> NaiveTime {
+        a.naive_utc().time()
     }
 );

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -238,11 +238,13 @@ lazy_static! {
             // TIMESTAMP
             (Timestamp, Date) => Assignment: CastTimestampToDate(func::CastTimestampToDate),
             (Timestamp, TimestampTz) => Implicit: CastTimestampToTimestampTz(func::CastTimestampToTimestampTz),
+            (Timestamp, Time) => Assignment: CastTimestampToTime(func::CastTimestampToTime),
             (Timestamp, String) => Assignment: CastTimestampToString(func::CastTimestampToString),
 
             // TIMESTAMPTZ
             (TimestampTz, Date) => Assignment: CastTimestampTzToDate(func::CastTimestampTzToDate),
             (TimestampTz, Timestamp) => Assignment: CastTimestampTzToTimestamp(func::CastTimestampTzToTimestamp),
+            (TimestampTz, Time) => Assignment: CastTimestampTzToTime(func::CastTimestampTzToTime),
             (TimestampTz, String) => Assignment: CastTimestampTzToString(func::CastTimestampTzToString),
 
             // INTERVAL

--- a/test/sqllogictest/type-promotion.slt
+++ b/test/sqllogictest/type-promotion.slt
@@ -1278,11 +1278,25 @@ SELECT '01:02:03'::time::time;
 ----
  01:02:03
 
-query error CAST does not support casting from timestamp to time
+query T
 SELECT '2002 03-04'::timestamp::time
+----
+00:00:00
 
-query error CAST does not support casting from timestamp with time zone to time
+query T
+SELECT '2002 03-04 05:06:07'::timestamp::time
+----
+05:06:07
+
+query T
 SELECT '2003 04-05'::timestamptz::time
+----
+00:00:00
+
+query T
+SELECT '2003 04-05 06:07:08+00'::timestamptz::time
+----
+06:07:08
 
 query error CAST does not support casting from smallint to timestamp
 SELECT 1::smallint::timestamp


### PR DESCRIPTION
These casts are supported by Postgres, but weren't supported yet by Materialize. Postgres does these casts in assignment, which surprised me a bit (checked via `\dC time`).

### Motivation

  * This PR fixes a recognized bug: #9593 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
