### PR TITLE
ci/builder: bump to Docker Compose v2.6.0

### DIFF
--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -108,7 +108,9 @@ RUN curl -fsSL https://github.com/benesch/autouseradd/releases/download/1.3.0/au
     && curl -fsSL https://github.com/koalaman/shellcheck/releases/download/v0.8.0/shellcheck-v0.8.0.linux.$ARCH_GCC.tar.xz > shellcheck.tar.xz \
     && tar -xJf shellcheck.tar.xz -C /usr/local/bin --strip-components 1 shellcheck-v0.8.0/shellcheck \
     && rm shellcheck.tar.xz \
-    && pip install docker-compose==1.29.2
+    && mkdir -p /usr/local/lib/docker/cli-plugins \
+    && curl -fsSL https://github.com/docker/compose/releases/download/v2.6.0/docker-compose-linux-$ARCH_GCC > /usr/local/lib/docker/cli-plugins/docker-compose \
+    && chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
 
 ENTRYPOINT ["autouseradd", "--user", "materialize"]
 

--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -37,7 +37,7 @@ from humanize import naturalsize
 from materialize import ROOT, ci_util, mzbuild, mzcompose, spawn, ui
 from materialize.ui import UIError
 
-MIN_COMPOSE_VERSION = (1, 24, 0)
+MIN_COMPOSE_VERSION = (2, 6, 0)
 RECOMMENDED_MIN_MEM = 8 * 1024**3  # 8GiB
 RECOMMENDED_MIN_CPUS = 2
 
@@ -51,7 +51,7 @@ mzcompose orchestrates services defined in mzcompose.yml or mzcompose.py.
 It wraps Docker Compose to add some Materialize-specific features.""",
         epilog="""
 These are only the most common options. There are additional Docker Compose
-options that are also supported. Consult `docker-compose help` for the full
+options that are also supported. Consult `docker compose help` for the full
 set.
 
 For help on a specific command, run `mzcompose COMMAND --help`.
@@ -403,9 +403,9 @@ class DockerComposeCommand(Command):
     def run(self, args: argparse.Namespace) -> None:
         if args.help:
             output = self.capture(
-                ["docker-compose", self.name, "--help"], stderr=subprocess.STDOUT
+                ["docker", "compose", self.name, "--help"], stderr=subprocess.STDOUT
             )
-            output = output.replace("docker-compose", "./mzcompose")
+            output = output.replace("docker compose", "./mzcompose")
             output += "\nThis command is a wrapper around Docker Compose."
             if self.help_epilog:
                 output += "\n"
@@ -416,7 +416,7 @@ class DockerComposeCommand(Command):
         # Make sure Docker Compose is new enough.
         output = (
             self.capture(
-                ["docker-compose", "version", "--short"], stderr=subprocess.STDOUT
+                ["docker", "compose", "version", "--short"], stderr=subprocess.STDOUT
             )
             .strip()
             .strip("v")
@@ -424,7 +424,7 @@ class DockerComposeCommand(Command):
         version = tuple(int(i) for i in output.split("."))
         if version < MIN_COMPOSE_VERSION:
             raise UIError(
-                f"unsupported docker-compose version v{output}",
+                f"unsupported docker compose version v{output}",
                 hint=f"minimum version allowed: v{'.'.join(str(p) for p in MIN_COMPOSE_VERSION)}",
             )
 
@@ -654,14 +654,14 @@ UpCommand = DockerComposeCommand(
 #
 #   * `version`, because mzcompose isn't versioned. If someone wants their
 #     Docker Compose version, it's clearer to have them run
-#     `docker-compose version` explicitly.
+#     `docker compose version` explicitly.
 
 
 # The following `ArgumentParser` subclasses attach unknown arguments as
 # `unknown_args` and `unknown_subargs` to the returned arguments object. The
 # difference between unknown arguments that occur *before* the command vs. after
 # (consider `./mzcompose --before command --after) is important when forwarding
-# arguments to `docker-compose`.
+# arguments to `docker compose`.
 #
 # `argparse.REMAINDER` seems like it'd be useful here, but it doesn't maintain
 # the above distinction, plus was deprecated in Python 3.9 due to unfixable

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -319,16 +319,16 @@ class Composition:
     def invoke(
         self, *args: str, capture: bool = False, stdin: Optional[str] = None
     ) -> subprocess.CompletedProcess:
-        """Invoke `docker-compose` on the rendered composition.
+        """Invoke `docker compose` on the rendered composition.
 
         Args:
-            args: The arguments to pass to `docker-compose`.
+            args: The arguments to pass to `docker compose`.
             capture: Whether to capture the child's stdout stream.
             input: A string to provide as stdin for the command.
         """
 
         if not self.silent:
-            print(f"$ docker-compose {' '.join(args)}", file=sys.stderr)
+            print(f"$ docker compose {' '.join(args)}", file=sys.stderr)
 
         self.file.seek(0)
 
@@ -339,7 +339,8 @@ class Composition:
         try:
             return subprocess.run(
                 [
-                    "docker-compose",
+                    "docker",
+                    "compose",
                     *(["--log-level=ERROR"] if self.silent else []),
                     f"-f/dev/fd/{self.file.fileno()}",
                     "--project-directory",
@@ -355,12 +356,12 @@ class Composition:
         except subprocess.CalledProcessError as e:
             if e.stdout:
                 print(e.stdout)
-            raise UIError(f"running docker-compose failed (exit status {e.returncode})")
+            raise UIError(f"running docker compose failed (exit status {e.returncode})")
 
     def port(self, service: str, private_port: Union[int, str]) -> int:
         """Get the public port for a service's private port.
 
-        Delegates to `docker-compose port`. See that command's help for details.
+        Delegates to `docker compose port`. See that command's help for details.
 
         Args:
             service: The name of a service in the composition.
@@ -558,9 +559,9 @@ class Composition:
     ) -> subprocess.CompletedProcess:
         """Run a one-off command in a service.
 
-        Delegates to `docker-compose run`. See that command's help for details.
+        Delegates to `docker compose run`. See that command's help for details.
         Note that unlike `docker compose run`, any services whose definitions
-        have changed are rebuilt (like `docker-compose up` would do) before the
+        have changed are rebuilt (like `docker compose up` would do) before the
         command is executed.
 
         Args:
@@ -570,7 +571,7 @@ class Composition:
             stdin: read STDIN from a string.
             env_extra: Additional environment variables to set in the container.
             rm: Remove container after run.
-            capture: Capture the stdout of the `docker-compose` invocation.
+            capture: Capture the stdout of the `docker compose` invocation.
         """
         # Restart any dependencies whose definitions have changed. The trick,
         # taken from Buildkite's Docker Compose plugin, is to run an `up`
@@ -597,7 +598,7 @@ class Composition:
     ) -> subprocess.CompletedProcess:
         """Execute a one-off command in a service's running container
 
-        Delegates to `docker-compose exec`.
+        Delegates to `docker compose exec`.
 
         Args:
             service: The service whose container will be used.
@@ -639,7 +640,7 @@ class Composition:
     def up(self, *services: str, detach: bool = True, persistent: bool = False) -> None:
         """Build, (re)create, and start the named services.
 
-        Delegates to `docker-compose up`. See that command's help for details.
+        Delegates to `docker compose up`. See that command's help for details.
 
         Args:
             services: The names of services in the composition.
@@ -664,7 +665,7 @@ class Composition:
     def down(self, destroy_volumes: bool = True, remove_orphans: bool = True) -> None:
         """Stop and remove resources.
 
-        Delegates to `docker-compose down`. See that command's help for details.
+        Delegates to `docker compose down`. See that command's help for details.
 
         Args:
             destroy_volumes: Remove named volumes and anonymous volumes attached
@@ -679,7 +680,7 @@ class Composition:
     def stop(self, *services: str) -> None:
         """Stop the docker containers for the named services.
 
-        Delegates to `docker-compose stop`. See that command's help for details.
+        Delegates to `docker compose stop`. See that command's help for details.
 
         Args:
             services: The names of services in the composition.
@@ -689,7 +690,7 @@ class Composition:
     def kill(self, *services: str, signal: str = "SIGKILL") -> None:
         """Force stop service containers.
 
-        Delegates to `docker-compose kill`. See that command's help for details.
+        Delegates to `docker compose kill`. See that command's help for details.
 
         Args:
             services: The names of services in the composition.
@@ -700,7 +701,7 @@ class Composition:
     def pause(self, *services: str) -> None:
         """Pause service containers.
 
-        Delegates to `docker-compose pause`. See that command's help for details.
+        Delegates to `docker compose pause`. See that command's help for details.
 
         Args:
             services: The names of services in the composition.
@@ -710,7 +711,7 @@ class Composition:
     def unpause(self, *services: str) -> None:
         """Unpause service containers
 
-        Delegates to `docker-compose unpause`. See that command's help for details.
+        Delegates to `docker compose unpause`. See that command's help for details.
 
         Args:
             services: The names of services in the composition.
@@ -722,7 +723,7 @@ class Composition:
     ) -> None:
         """Remove stopped service containers.
 
-        Delegates to `docker-compose rm`. See that command's help for details.
+        Delegates to `docker compose rm`. See that command's help for details.
 
         Args:
             services: The names of services in the composition.


### PR DESCRIPTION
Now that we no longer need to support end users with mzcompose, we can
mandate a single version of Docker Compose. Require v2.6.0, since the
v1.29 series is EOL'd.

Fix https://github.com/MaterializeInc/materialize/issues/10054.