### PR TITLE
doc/user: remove timestamp_frequency_ms from AWS with options

### DIFF
--- a/doc/user/layouts/partials/aws-credentials-with-options.html
+++ b/doc/user/layouts/partials/aws-credentials-with-options.html
@@ -1,7 +1,6 @@
 `access_key_id` | `text` | A valid [access key ID](https://docs.aws.amazon.com/streams/latest/dev/controlling-access.html) for the AWS resource.
 `secret_access_key` | `text` | A valid [secret access key](https://docs.aws.amazon.com/streams/latest/dev/controlling-access.html) for the AWS resource.
 `token` | `text` | The session token associated with the credentials, if the credentials are temporary
-`timestamp_frequency_ms`| `int` | Default: `1000`. Sets the timestamping frequency in `ms`. Reflects how frequently the source advances its timestamp. This measure reflects how stale data in views will be. Lower values result in more-up-to-date views but may reduce throughput.
 
 If you do not provide credentials via with options then `materialized` will examine the standard
 AWS authorization chain:


### PR DESCRIPTION
It's already documented in the correct place (the top-level S3 options).
