### PR TITLE
expr,sql: support casts from integer types to/from oid

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -107,15 +107,18 @@ These changes are present in [unstable builds](/versions/#unstable-builds) and
 are slated for inclusion in the next stable release. There may be additional
 changes that have not yet been documented.
 
+- **Breaking change.** Change the internal representation of numbers in
+  [`jsonb`](/sql/types/jsonb). Previously, JSON numbers were stored as either
+  [`int8`](/sql/types/int8) or [`float8`](/sql/types/float8) values; now they
+  are always stored as [`numeric`](/sql/types/numeric) values.
+
 - Support casts from [`timestamp`] and [`timestamp with time zone`] to
   [`time`].
 
 - Add `pg_catalog.pg_roles` as a builtin view.
 
-- **Breaking change.** Change the internal representation of numbers in
-  [`jsonb`](/sql/types/jsonb). Previously, JSON numbers were stored as either
-  [`int8`](/sql/types/int8) or [`float8`](/sql/types/float8) values; now they
-  are always stored as [`numeric`](/sql/types/numeric) values.
+- Support casts from [`smallint`] and [`bigint`] to [`oid`], as well as
+  casts from [`oid`] to [`bigint`].
 
 {{< comment >}}
 Only add new release notes above this line.
@@ -825,7 +828,7 @@ a problem with PostgreSQL JDBC 42.3.0.
   collision](/sql/identifiers#keyword-collision) documentation for details.
 
 - **Backwards-incompatible change.** Change the return type of
-  [`sum`](/sql/functions/#aggregate-func) over [`bigint`](/sql/types/integer)s
+  [`sum`](/sql/functions/#aggregate-func) over [`bigint`]s
   from `bigint` to [`numeric`](/sql/types/numeric). This avoids the possibility
   of overflow when summing many large numbers {{% gh 5218 %}}.
 
@@ -1672,6 +1675,7 @@ a problem with PostgreSQL JDBC 42.3.0.
 * [Architecture overview](/overview/architecture/)
 
 [`array`]: /sql/types/array/
+[`bigint`]: /sql/types/integer#bigint-info
 [`bytea`]: /sql/types/bytea
 [`ALTER INDEX`]: /sql/alter-index
 [`COPY FROM`]: /sql/copy-from
@@ -1687,6 +1691,7 @@ a problem with PostgreSQL JDBC 42.3.0.
 [`map`]: /sql/types/map/
 [`real`]: /sql/types/float4
 [`pgcrypto`]: https://www.postgresql.org/docs/current/pgcrypto.html
+[`smallint`]: /sql/types/integer#smallint-info
 [`SHOW CREATE SOURCE`]: /sql/show-create-source
 [`SHOW CREATE VIEW`]: /sql/show-create-view
 [`text`]: /sql/types/text

--- a/doc/user/content/sql/types/integer.md
+++ b/doc/user/content/sql/types/integer.md
@@ -69,6 +69,7 @@ To | Required context
 ---|--------
 [`boolean`](../boolean) (`integer` only) | Explicit
 [`numeric`](../numeric) | Implicit
+[`oid`](../oid) | Implicit
 [`real`/`double precision`](../float) | Implicit
 [`text`](../text) | Assignment
 
@@ -80,7 +81,7 @@ From | Required context
 ---|--------
 [`boolean`](../boolean) (`integer` only) | Explicit
 [`jsonb`](../jsonb) | Explicit
-[`oid`](../oid) (`integer` only) | Assignment
+[`oid`](../oid) (`integer` and `bigint` only) | Assignment
 [`numeric`](../numeric) | Assignment
 [`real`/`double precision`](../float) | Assignment
 [`text`](../text) | Explicit

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -3057,6 +3057,7 @@ pub enum UnaryFunc {
     CastInt16ToFloat64(CastInt16ToFloat64),
     CastInt16ToInt32(CastInt16ToInt32),
     CastInt16ToInt64(CastInt16ToInt64),
+    CastInt16ToOid(CastInt16ToOid),
     CastInt16ToString(CastInt16ToString),
     CastInt32ToBool(CastInt32ToBool),
     CastInt32ToFloat32(CastInt32ToFloat32),
@@ -3069,6 +3070,7 @@ pub enum UnaryFunc {
     CastInt32ToInt64(CastInt32ToInt64),
     CastInt32ToString(CastInt32ToString),
     CastOidToInt32(CastOidToInt32),
+    CastOidToInt64(CastOidToInt64),
     CastOidToRegClass(CastOidToRegClass),
     CastRegClassToOid(CastRegClassToOid),
     CastOidToRegProc(CastOidToRegProc),
@@ -3083,6 +3085,7 @@ pub enum UnaryFunc {
     CastInt64ToNumeric(CastInt64ToNumeric),
     CastInt64ToFloat32(CastInt64ToFloat32),
     CastInt64ToFloat64(CastInt64ToFloat64),
+    CastInt64ToOid(CastInt64ToOid),
     CastInt64ToString(CastInt64ToString),
     CastFloat32ToInt16(CastFloat32ToInt16),
     CastFloat32ToInt32(CastFloat32ToInt32),
@@ -3268,6 +3271,7 @@ derive_unary!(
     CastInt16ToFloat64,
     CastInt16ToInt32,
     CastInt16ToInt64,
+    CastInt16ToOid,
     CastInt16ToString,
     CastInt16ToNumeric,
     CastInt32ToBool,
@@ -3286,11 +3290,13 @@ derive_unary!(
     CastInt64ToNumeric,
     CastInt64ToFloat32,
     CastInt64ToFloat64,
+    CastInt64ToOid,
     CastInt64ToString,
     CastFloat32ToNumeric,
     CastFloat64ToNumeric,
     CastInt32ToNumeric,
     CastOidToInt32,
+    CastOidToInt64,
     CastOidToRegClass,
     CastRegClassToOid,
     CastOidToRegProc,
@@ -3444,6 +3450,7 @@ impl UnaryFunc {
             | CastInt16ToFloat64(_)
             | CastInt16ToInt32(_)
             | CastInt16ToInt64(_)
+            | CastInt16ToOid(_)
             | CastInt16ToString(_)
             | CastInt32ToBool(_)
             | CastInt32ToFloat32(_)
@@ -3456,6 +3463,7 @@ impl UnaryFunc {
             | CastInt32ToRegProc(_)
             | CastInt32ToRegType(_)
             | CastOidToInt32(_)
+            | CastOidToInt64(_)
             | CastOidToRegClass(_)
             | CastRegClassToOid(_)
             | CastOidToRegProc(_)
@@ -3480,6 +3488,7 @@ impl UnaryFunc {
             | CastInt64ToNumeric(_)
             | CastInt64ToFloat32(_)
             | CastInt64ToFloat64(_)
+            | CastInt64ToOid(_)
             | CastInt64ToString(_)
             | CastFloat32ToNumeric(_)
             | CastFloat64ToNumeric(_)
@@ -3642,6 +3651,7 @@ impl UnaryFunc {
             | CastInt16ToFloat64(_)
             | CastInt16ToInt32(_)
             | CastInt16ToInt64(_)
+            | CastInt16ToOid(_)
             | CastInt16ToString(_)
             | CastInt32ToBool(_)
             | CastInt32ToFloat32(_)
@@ -3654,6 +3664,7 @@ impl UnaryFunc {
             | CastInt32ToRegProc(_)
             | CastInt32ToRegType(_)
             | CastOidToInt32(_)
+            | CastOidToInt64(_)
             | CastOidToRegClass(_)
             | CastRegClassToOid(_)
             | CastOidToRegProc(_)
@@ -3678,6 +3689,7 @@ impl UnaryFunc {
             | CastInt64ToNumeric(_)
             | CastInt64ToFloat32(_)
             | CastInt64ToFloat64(_)
+            | CastInt64ToOid(_)
             | CastInt64ToString(_)
             | CastFloat32ToNumeric(_)
             | CastFloat64ToNumeric(_)
@@ -3873,6 +3885,7 @@ impl UnaryFunc {
             | CastInt16ToFloat64(_)
             | CastInt16ToInt32(_)
             | CastInt16ToInt64(_)
+            | CastInt16ToOid(_)
             | CastInt16ToString(_)
             | CastInt32ToBool(_)
             | CastInt32ToFloat32(_)
@@ -3885,6 +3898,7 @@ impl UnaryFunc {
             | CastInt32ToRegProc(_)
             | CastInt32ToRegType(_)
             | CastOidToInt32(_)
+            | CastOidToInt64(_)
             | CastOidToRegClass(_)
             | CastRegClassToOid(_)
             | CastOidToRegProc(_)
@@ -3909,6 +3923,7 @@ impl UnaryFunc {
             | CastInt64ToNumeric(_)
             | CastInt64ToFloat32(_)
             | CastInt64ToFloat64(_)
+            | CastInt64ToOid(_)
             | CastInt64ToString(_)
             | CastFloat32ToNumeric(_)
             | CastFloat64ToNumeric(_)
@@ -4118,6 +4133,7 @@ impl UnaryFunc {
             | CastInt16ToFloat64(_)
             | CastInt16ToInt32(_)
             | CastInt16ToInt64(_)
+            | CastInt16ToOid(_)
             | CastInt16ToString(_)
             | CastInt32ToBool(_)
             | CastInt32ToFloat32(_)
@@ -4130,6 +4146,7 @@ impl UnaryFunc {
             | CastInt32ToRegProc(_)
             | CastInt32ToRegType(_)
             | CastOidToInt32(_)
+            | CastOidToInt64(_)
             | CastOidToRegClass(_)
             | CastRegClassToOid(_)
             | CastOidToRegProc(_)
@@ -4154,6 +4171,7 @@ impl UnaryFunc {
             | CastInt64ToNumeric(_)
             | CastInt64ToFloat32(_)
             | CastInt64ToFloat64(_)
+            | CastInt64ToOid(_)
             | CastInt64ToString(_)
             | CastFloat32ToNumeric(_)
             | CastFloat64ToNumeric(_)

--- a/src/expr/src/scalar/func/impls/int16.rs
+++ b/src/expr/src/scalar/func/impls/int16.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 
 use lowertest::MzStructReflect;
 use repr::adt::numeric::{self, Numeric};
+use repr::adt::system::Oid;
 use repr::{strconv, ColumnType, ScalarType};
 
 use crate::scalar::func::EagerUnaryFunc;
@@ -68,6 +69,14 @@ sqlfunc!(
     #[preserves_uniqueness = true]
     fn cast_int16_to_int64(a: i16) -> i64 {
         i64::from(a)
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "i16tooid"]
+    #[preserves_uniqueness = true]
+    fn cast_int16_to_oid(a: i16) -> Oid {
+        Oid(i32::from(a))
     }
 );
 

--- a/src/expr/src/scalar/func/impls/int64.rs
+++ b/src/expr/src/scalar/func/impls/int64.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 
 use lowertest::MzStructReflect;
 use repr::adt::numeric::{self, Numeric};
+use repr::adt::system::Oid;
 use repr::{strconv, ColumnType, ScalarType};
 
 use crate::scalar::func::EagerUnaryFunc;
@@ -61,6 +62,14 @@ sqlfunc!(
     #[preserves_uniqueness = true]
     fn cast_int64_to_int32(a: i64) -> Result<i32, EvalError> {
         i32::try_from(a).or(Err(EvalError::Int32OutOfRange))
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "i64tooid"]
+    #[preserves_uniqueness = true]
+    fn cast_int64_to_oid(a: i64) -> Result<Oid, EvalError> {
+        i32::try_from(a).map(Oid).or(Err(EvalError::OidOutOfRange))
     }
 );
 

--- a/src/expr/src/scalar/func/impls/oid.rs
+++ b/src/expr/src/scalar/func/impls/oid.rs
@@ -20,6 +20,14 @@ sqlfunc!(
 );
 
 sqlfunc!(
+    #[sqlname = "oidtoi64"]
+    #[preserves_uniqueness = true]
+    fn cast_oid_to_int64(a: Oid) -> i64 {
+        i64::from(a.0)
+    }
+);
+
+sqlfunc!(
     #[sqlname = "oidtoregclass"]
     #[preserves_uniqueness = true]
     fn cast_oid_to_reg_class(a: Oid) -> RegClass {

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -1144,6 +1144,7 @@ pub enum EvalError {
     Int16OutOfRange,
     Int32OutOfRange,
     Int64OutOfRange,
+    OidOutOfRange,
     IntervalOutOfRange,
     TimestampOutOfRange,
     InvalidBase64Equals,
@@ -1209,6 +1210,7 @@ impl fmt::Display for EvalError {
             EvalError::Int16OutOfRange => f.write_str("smallint out of range"),
             EvalError::Int32OutOfRange => f.write_str("integer out of range"),
             EvalError::Int64OutOfRange => f.write_str("bigint out of range"),
+            EvalError::OidOutOfRange => f.write_str("OID out of range"),
             EvalError::IntervalOutOfRange => f.write_str("interval out of range"),
             EvalError::TimestampOutOfRange => f.write_str("timestamp out of range"),
             EvalError::InvalidBase64Equals => {

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -137,6 +137,7 @@ lazy_static! {
                 let s = to_type.unwrap_numeric_scale();
                 Some(move |e: HirScalarExpr| e.call_unary(CastInt16ToNumeric(func::CastInt16ToNumeric(s))))
             }),
+            (Int16, Oid) => Implicit: CastInt16ToOid(func::CastInt16ToOid),
             (Int16, String) => Assignment: CastInt16ToString(func::CastInt16ToString),
 
             //INT32
@@ -165,10 +166,12 @@ lazy_static! {
             }),
             (Int64, Float32) => Implicit: CastInt64ToFloat32(func::CastInt64ToFloat32),
             (Int64, Float64) => Implicit: CastInt64ToFloat64(func::CastInt64ToFloat64),
+            (Int64, Oid) => Implicit: CastInt64ToOid(func::CastInt64ToOid),
             (Int64, String) => Assignment: CastInt64ToString(func::CastInt64ToString),
 
             // OID
             (Oid, Int32) => Assignment: CastOidToInt32(func::CastOidToInt32),
+            (Oid, Int64) => Assignment: CastOidToInt32(func::CastOidToInt32),
             (Oid, String) => Explicit: CastInt32ToString(func::CastInt32ToString),
             (Oid, RegClass) => Assignment: CastOidToRegClass(func::CastOidToRegClass),
             (Oid, RegProc) => Assignment: CastOidToRegProc(func::CastOidToRegProc),

--- a/test/sqllogictest/type-promotion.slt
+++ b/test/sqllogictest/type-promotion.slt
@@ -1417,3 +1417,31 @@ query T
 SELECT '2003 04-05'::timestamptz::timestamptz;
 ----
 2003-04-05 00:00:00+00
+
+query T
+SELECT 14::smallint::oid;
+----
+14
+
+query T
+SELECT 14::bigint::oid;
+----
+14
+
+query T
+SELECT 14::oid::bigint;
+----
+14
+
+query T
+SELECT 14::oid = 14::bigint;
+----
+true
+
+query T
+SELECT 14::oid = 14::smallint;
+----
+true
+
+query error OID out of range
+SELECT 120129019392::bigint::oid;


### PR DESCRIPTION
These three casts are supported by Postgres:
- `smallint` -> `oid` (implicit)
- `bigint` -> `oid` (implicit)
- `oid` -> `bigint` (assignment)

The main motivation here is supporting bigint -> oid, as DBeaver required it.

### Motivation

  * This PR fixes a recognized bug: #9695 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
