### PR TITLE
ci: fix specification of CARGO_INCREMENTAL in macOS clippy

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -55,7 +55,7 @@ steps:
     label: ":mac: clippy"
     command: bin/check
     env:
-      - CARGO_INCREMENTAL: "0"
+      CARGO_INCREMENTAL: "0"
     inputs:
       - Cargo.lock
       - "**/Cargo.toml"


### PR DESCRIPTION
This parameter wants a map, not a list.

For what it's worth I haven't actually tested this, because I don't have the patience to wait for an extra CI cycle given the flakiness. But I'm 99% certain this will fix the issue, and I can't imagine it can make the situation any worse.