### PR TITLE
Store 1 less copy of a key in `upsert_core`

### DIFF
--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -474,11 +474,14 @@ where
                                     // The opeator currently does it unconditionally
                                     let upsert_operator_name = format!("{}-upsert", source_name);
 
+                                    let key_arity = key_desc.expect("SourceEnvelope::Upsert to require SourceDataEncoding::KeyValue").arity();
+
                                     let (upsert_ok, upsert_err) = super::upsert::upsert(
                                         &upsert_operator_name,
                                         &results,
                                         self.as_of_frontier.clone(),
                                         &mut linear_operators,
+                                        key_arity,
                                         src.bare_desc.typ().arity(),
                                         source_persist_config
                                             .as_ref()

--- a/src/dataflow/src/render/upsert.rs
+++ b/src/dataflow/src/render/upsert.rs
@@ -390,6 +390,8 @@ where
                                         Some(value) => value.and_then(|row| {
                                             let mut datums = Vec::with_capacity(source_arity);
 
+                                            // The datums we send to `evaluate` contain the keys
+                                            // and the values in order, so indexing works
                                             let key_columns = decoded_key.iter().count();
                                             datums.extend(decoded_key.iter());
 
@@ -417,8 +419,9 @@ where
                                         current_values.remove(&decoded_key)
                                     };
 
-                                    // This closure re-uses `row_packer` to re-assemble rows with
-                                    // the keys that were replaced with `Datum::Dummy`
+                                    // This closure re-uses a `Row` to 
+                                    // rebuild the full `Row` with both keys and values, before we
+                                    // send them off to sql-land
                                     let mut repack_value = |row: Row| {
                                         row_packer.clear();
 


### PR DESCRIPTION
Currently, in upsert, to track which values are new or being updated, we store a map like this:
```
key => row (packed (key, value)
```

This pr changes this so that the packed row contains `Datum::Dummy` 

There is some complexity here related to the `position_or`. When we repack the row, we totally skip keys that weren't `Dummy'-fied and repack them, and we also rely on the fact that `position_or` may `Dummy`-fy columns, but NOT reorder them (this is something i wish to express in the type system in the final version of the pr)

@antiguru, the logic around packing and unpacking rows I do here (as well as the already built `position_or` stuff) is similar to the way that `Permutation` works. Is that something that looks like it can adapted here, or would I have to alter `Permutation` to work with `Row`'s, not just plans?

(also note that this pr does not avoid all temp allocations, like those temporary vectors, I consider that to be complex enough to warrant another pr. this pr also starts with only upsert_core to reduce complexity for now)
