### PR TITLE
coord: add pg_roles builtin view

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -139,6 +139,8 @@ List new features before bug fixes.
 - Support casts from [`timestamp`] and [`timestamp with time zone`] to
   [`time`].
 
+- Add `pg_catalog.pg_roles` as a builtin view.
+
 {{% version-header v0.12.0 %}}
 
 - Optionally emit the message partition, offset, and timestamp in [Kafka

--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -1630,7 +1630,19 @@ WHERE false",
     needs_logs: false,
 };
 
-// Next id BuiltinView: 5037
+pub const PG_ROLES: BuiltinView = BuiltinView {
+    name: "pg_roles",
+    schema: PG_CATALOG_SCHEMA,
+    sql: "CREATE VIEW pg_roles AS SELECT
+    name AS rolname,
+    '********'::pg_catalog.text AS rolpassword,
+    oid AS oid
+FROM mz_catalog.mz_roles",
+    id: GlobalId::System(5037),
+    needs_logs: false,
+};
+
+// Next id BuiltinView: 5038
 
 pub const MZ_SYSTEM: BuiltinRole = BuiltinRole {
     name: "mz_system",
@@ -1773,6 +1785,7 @@ lazy_static! {
             Builtin::View(&PG_CONSTRAINT),
             Builtin::View(&PG_TABLES),
             Builtin::View(&PG_ACCESS_METHODS),
+            Builtin::View(&PG_ROLES),
         ];
 
         // TODO(sploiselle): assign static global IDs to functions

--- a/test/sqllogictest/pg_catalog.slt
+++ b/test/sqllogictest/pg_catalog.slt
@@ -103,3 +103,9 @@ SELECT atttypid, attname FROM pg_attribute WHERE attrelid = (SELECT oid FROM mz_
 2951  c__uuid
 3802  c_jsonb
 3807  c__jsonb
+
+query IT
+SELECT oid, rolname FROM pg_roles ORDER BY oid
+----
+20007  materialize
+20008  mz_system


### PR DESCRIPTION
This is a minimalistic view based on mz_roles, and just enough to make DBeaver and Postico happy.

Together with #9698, this change makes DBeaver work for most basic tasks (listing tables/views, looking at data inside tables/views) without any errors popping up.

### Motivation

  * This PR fixes a recognized bug: #9711 

### Tips for reviewer

I added the `rolpassword` column since it's also a constant in Postgres: all the other columns would require more data than what we currently have in `mz_roles`.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
