### PR TITLE
testdrive: Allow progress in verify-timestamp-compaction

### DIFF
--- a/src/testdrive/src/action/verify_timestamp_compaction.rs
+++ b/src/testdrive/src/action/verify_timestamp_compaction.rs
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -25,6 +27,7 @@ use crate::parser::BuiltinCommand;
 pub struct VerifyTimestampsAction {
     source: String,
     max_size: usize,
+    permit_progress: bool,
 }
 
 pub fn build_verify_timestamp_compaction(
@@ -36,8 +39,17 @@ pub fn build_verify_timestamp_compaction(
         .opt_string("max-size")
         .map(|s| s.parse::<usize>().expect("unable to parse usize"))
         .unwrap_or(3);
+    let permit_progress = cmd
+        .args
+        .opt_bool("permit-progress")
+        .expect("require valid bool if specified")
+        .unwrap_or(false);
     cmd.args.done()?;
-    Ok(VerifyTimestampsAction { source, max_size })
+    Ok(VerifyTimestampsAction {
+        source,
+        max_size,
+        permit_progress,
+    })
 }
 
 #[async_trait]
@@ -49,42 +61,62 @@ impl Action for VerifyTimestampsAction {
 
     async fn redo(&self, state: &mut State) -> Result<(), String> {
         if let Some(path) = &state.materialized_catalog_path {
+            let initial_highest_base = Arc::new(AtomicU64::new(u64::MAX));
             Retry::default()
                 .initial_backoff(Duration::from_secs(1))
                 .max_duration(Duration::from_secs(10))
-                .retry(|_| async move {
-                    let mut catalog = Catalog::open_debug(path, NOW_ZERO.clone())
-                        .await
-                        .map_err_to_string()?;
-                    let item_id = catalog
-                        .for_session(&Session::dummy())
-                        .resolve_item(&PartialName {
-                            database: None,
-                            schema: None,
-                            item: self.source.clone(),
-                        })
-                        .map_err_to_string()?
-                        .id();
-                    let bindings = catalog
-                        .load_timestamp_bindings(item_id)
-                        .map_err_to_string()?;
-                    println!(
-                        "Verifying timestamp binding compaction for {:?}.  Found {:?} vs expected {:?}",
-                        self.source,
-                        bindings.len(),
-                        self.max_size
-                    );
-                    if bindings.len() > self.max_size {
-                        Err(format!(
-                            "There are {:?} bindings compared to max size {:?}",
+                .retry(|retry_state| {
+                    let initial_highest = initial_highest_base.clone();
+                    async move {
+                        let mut catalog = Catalog::open_debug(path, NOW_ZERO.clone())
+                            .await
+                            .map_err_to_string()?;
+                        let item_id = catalog
+                            .for_session(&Session::dummy())
+                            .resolve_item(&PartialName {
+                                database: None,
+                                schema: None,
+                                item: self.source.clone(),
+                            })
+                            .map_err_to_string()?
+                            .id();
+                        let bindings = catalog
+                            .load_timestamp_bindings(item_id)
+                            .map_err_to_string()?;
+
+                        // We consider progress to be eventually compacting at least up to the original highest
+                        // timestamp binding.
+                        let progress = if retry_state.i == 0 {
+                            initial_highest.store(
+                                bindings.iter().map(|(_, ts, _)| ts).fold(u64::MIN, |a, &b| a.max(b)),
+                                Ordering::SeqCst,
+                            );
+                            false
+                        } else {
+                            self.permit_progress &&
+                                (bindings.iter().map(|(_, ts, _)| ts).fold(u64::MAX, |a, &b| a.min(b))
+                                    >= initial_highest.load(Ordering::SeqCst))
+                        };
+
+                        println!(
+                            "Verifying timestamp binding compaction for {:?}.  Found {:?} vs expected {:?}.  Progress: {:?}",
+                            self.source,
                             bindings.len(),
-                            self.max_size
-                        ))
-                    } else {
-                        Ok(())
+                            self.max_size,
+                            progress,
+                        );
+
+                        if bindings.len() < self.max_size || progress {
+                            Ok(())
+                        } else {
+                            Err(format!(
+                                "There are {:?} bindings compared to max size {:?}",
+                                bindings.len(),
+                                self.max_size,
+                            ))
+                        }
                     }
-                })
-                .await
+                }).await
         } else {
             println!(
                 "Skipping timestamp binding compaction verification for {:?}.",

--- a/src/testdrive/src/action/verify_timestamp_compaction.rs
+++ b/src/testdrive/src/action/verify_timestamp_compaction.rs
@@ -106,7 +106,7 @@ impl Action for VerifyTimestampsAction {
                             progress,
                         );
 
-                        if bindings.len() < self.max_size || progress {
+                        if bindings.len() <= self.max_size || progress {
                             Ok(())
                         } else {
                             Err(format!(

--- a/test/testdrive/kafka-exactly-once-sink.td
+++ b/test/testdrive/kafka-exactly-once-sink.td
@@ -362,7 +362,7 @@ $ kafka-verify format=json sink=materialize.public.json_avro_upsert_key_2 key=tr
 {"b": 2} {"column1": 1, "b": 2, "column3": 3, "transaction": {"id": "0"}}
 
 # Verify compaction of exactly once sinks.
-$ verify-timestamp-compaction source=input_csv max-size=3
-$ verify-timestamp-compaction source=rt_binding_consistency_test_source max-size=3
+$ verify-timestamp-compaction source=input_csv max-size=3 permit-progress=true
+$ verify-timestamp-compaction source=rt_binding_consistency_test_source max-size=3 permit-progress=true
 # TODO: Enable when #9514 is fixed!
 #$ verify-timestamp-compaction source=input_kafka_no_byo max-size=3


### PR DESCRIPTION
Under heavy load with multiple workers, it's possible to not compact down to just one or two timestamp bindings.  However, this doesn't mean we haven't made progress. Therefore, add a new option to the `verify-timestamp-bindings` command in testdrive to allow for compaction to have proceeded past the highest timestamp binding of the first examination of the catalog.

This showed up in the nightly build tests which run with 32 workers.  The test consistently failed even though compaction progress was in fact being made