### PR TITLE
doc/user: make it harder to add release notes to the wrong header

### DIFF
--- a/.github/ISSUE_TEMPLATE/05-release.md
+++ b/.github/ISSUE_TEMPLATE/05-release.md
@@ -45,15 +45,6 @@ production readiness.
   bin/mkrelease new-rc weekly
   ```
 
-- [ ] Update the [release notes][] to include a new "unreleased" version so that new
-  changes don't get advertised as being part of this release as folks add notes.
-
-  > **NOTE:** the next "unreleased" version should always bump the middle
-  > component.
-  >
-  > For example, if the version being released is `v0.5.9`, `<NEXT_VERSION>` should always be
-  > `0.6.0`.
-
 - [ ] Incorporate this tag into `main`'s history by preparing dev on top of it.
 
   Without checking out `main`, perform:
@@ -84,9 +75,11 @@ production readiness.
 
 ### Review Release Notes
 
-Release notes should be updated by engineers as they merge PRs. The release notes
-team is responsible for reviewing release notes and the release announcement before
-a release is published.
+Release notes should be added to the "unstable" section by engineers as they
+merge PRs. Before announcing the release, the release notes team (Nikhil)
+migrates the relevant release notes to the dedicated "v0.X.Y" section header,
+based on which commits actually made it into the release, then reviews the list
+of PRs and adds release notes for any features or bugs that were missed.
 
 - [ ] Post the following message to the `#release` channel in slack, modifying the two
   issue links, one to point to the unreviewed PRs issue you went through above, and one

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -101,7 +101,23 @@ List new features before bug fixes.
 
 {{< /comment >}}
 
-{{% version-header v0.14.0 %}}
+## Unstable
+
+These changes are present in [unstable builds](/versions/#unstable-builds) and
+are slated for inclusion in the next stable release. There may be additional
+changes that have not yet been documented.
+
+- Support casts from [`timestamp`] and [`timestamp with time zone`] to
+  [`time`].
+
+- Add `pg_catalog.pg_roles` as a builtin view.
+
+{{< comment >}}
+Only add new release notes above this line.
+
+The presence of this comment ensures that PRs that are alive across a release
+boundary don't silently merge their release notes into the wrong place.
+{{</ comment >}}
 
 {{% version-header v0.13.0 %}}
 
@@ -135,11 +151,6 @@ List new features before bug fixes.
 
   This bug could cause incorrect results in queries that combined `RIGHT` and
   `FULL` [joins](/sql/join) with comma-separated `FROM` items.
-
-- Support casts from [`timestamp`] and [`timestamp with time zone`] to
-  [`time`].
-
-- Add `pg_catalog.pg_roles` as a builtin view.
 
 {{% version-header v0.12.0 %}}
 

--- a/doc/user/layouts/shortcodes/version-header.html
+++ b/doc/user/layouts/shortcodes/version-header.html
@@ -5,4 +5,6 @@
 
 {{with $versionMeta}}
 <p class="release-date">Released on {{.date}}.</p>
+{{else}}
+<p class="release-date">Release in progress.</p>
 {{end}}


### PR DESCRIPTION
Rework the release notes page so that there is always a dedicated
"Unstable" section. Then old PRs that add release notes will either
conflict or correctly add the release notes to the unstable section.
I'll be responsible for migrating the correct set of release notes to
the dedicated version header when the release ships.


### Motivation

This PR fixes a hazard in which old PRs that add release notes might silently add those release notes to the wrong version when the PR lands.
