### PR TITLE
ci: adjust for native macOS M1 builder

### DIFF
--- a/ci/deploy/pipeline.yml
+++ b/ci/deploy/pipeline.yml
@@ -29,7 +29,7 @@ steps:
 
   - command: bin/pyactivate --dev -m ci.deploy.macos x86_64
     agents:
-      queue: mac-mojave
+      queue: mac-x86_64
     timeout_in_minutes: 30
     concurrency: 1
     concurrency_group: deploy/macos/x86_64
@@ -39,7 +39,7 @@ steps:
 
   - command: bin/pyactivate --dev -m ci.deploy.macos aarch64
     agents:
-      queue: mac-bigsur
+      queue: mac-aarch64
     timeout_in_minutes: 30
     concurrency: 1
     concurrency_group: deploy/macos/aarch64

--- a/doc/user/content/versions.md
+++ b/doc/user/content/versions.md
@@ -21,12 +21,14 @@ recommended.
 
 Binary tarballs require a recent version of their stated platform:
 
-* macOS Intel binary tarballs require macOS 10.14+ from v0.1.0 – v0.9.0 and
-  macOS 10.15+ from v0.9.1 onwards.
+* macOS Intel binary tarballs require:
+    * macOS 10.13+ from v0.1.0 – v0.9.0
+    * macOS 10.14+ from v0.9.1 – v0.13.0
+    * macOS 10.15+ from v0.14 onwards
 * macOS ARM binary tarballs require macOS 11+.
 * Linux Intel binary tarballs require a glibc-based Linux distribution with a
   kernel version of v2.6.32+ and a glibc version of 2.12.1+.
-* Linux ARM binary tarballs require a glibc-based Linux distrubtion with a
+* Linux ARM binary tarballs require a glibc-based Linux distribution with a
   kernel version of v3.10+ and a glibc version of 2.17+.
 
 ## Unstable builds


### PR DESCRIPTION
I've decided it's easier to run a dedicated macOS M1 builder. This
spares us from having to cross compile Materialize from x86_64 to arm64,
which is always at risk of breaking with every new macOS version or new
C dependency. Importantly, having a macOS M1 builder opens up the
possibility of actually running tests on M1, so we're not just blindly
shipping a binary that might not even be loadable.
