### PR TITLE
sql: Let support in Hir

### DIFF
--- a/doc/user/content/known-limitations.md
+++ b/doc/user/content/known-limitations.md
@@ -31,9 +31,6 @@ us know on the linked-to GitHub issue.
 ### Common table expressions (CTEs)
 
 - CTEs only support `SELECT` queries. {{% gh 4867 %}}
-- Materialize inlines the CTE where it's referenced, which could cause
-  unexpected performance characteristics for especially complex expressions. {{%
-  gh 4867 %}}
 - `WITH RECURSIVE` CTEs are not available yet. {{% gh 2516 %}}
 
 ### Joins

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -207,6 +207,8 @@ boundary don't silently merge their release notes into the wrong place.
   This bug could cause incorrect results in queries that combined `RIGHT` and
   `FULL` [joins](/sql/join) with comma-separated `FROM` items.
 
+- Materialize no longer inlines the CTE where it's referenced {{% gh 4867 %}}.
+
 {{% version-header v0.12.0 %}}
 
 - Optionally emit the message partition, offset, and timestamp in [Kafka

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -48,6 +48,7 @@ pub enum HirRelationExpr {
     },
     /// CTE
     Let {
+        name: String,
         /// The identifier to be used in `Get` variants to retrieve `value`.
         id: expr::LocalId,
         /// The collection to be bound to `name`.

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -37,8 +37,6 @@ use super::Explanation;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 /// Just like MirRelationExpr, except where otherwise noted below.
-///
-/// - There is no equivalent to `MirRelationExpr::Let`.
 pub enum HirRelationExpr {
     Constant {
         rows: Vec<Row>,
@@ -47,6 +45,15 @@ pub enum HirRelationExpr {
     Get {
         id: expr::Id,
         typ: RelationType,
+    },
+    /// CTE
+    Let {
+        /// The identifier to be used in `Get` variants to retrieve `value`.
+        id: expr::LocalId,
+        /// The collection to be bound to `name`.
+        value: Box<HirRelationExpr>,
+        /// The result of the `Let`, evaluated with `name` bound to `value`.
+        body: Box<HirRelationExpr>,
     },
     Project {
         input: Box<HirRelationExpr>,
@@ -689,6 +696,7 @@ impl HirRelationExpr {
         stack::maybe_grow(|| match self {
             HirRelationExpr::Constant { typ, .. } => typ.clone(),
             HirRelationExpr::Get { typ, .. } => typ.clone(),
+            HirRelationExpr::Let { body, .. } => body.typ(outers, params),
             HirRelationExpr::Project { input, outputs } => {
                 let input_typ = input.typ(outers, params);
                 RelationType::new(
@@ -774,6 +782,7 @@ impl HirRelationExpr {
         match self {
             HirRelationExpr::Constant { typ, .. } => typ.column_types.len(),
             HirRelationExpr::Get { typ, .. } => typ.column_types.len(),
+            HirRelationExpr::Let { body, .. } => body.arity(),
             HirRelationExpr::Project { outputs, .. } => outputs.len(),
             HirRelationExpr::Map { input, scalars } => input.arity() + scalars.len(),
             HirRelationExpr::CallTable { func, .. } => func.output_arity(),
@@ -985,6 +994,10 @@ impl HirRelationExpr {
             HirRelationExpr::Constant { .. }
             | HirRelationExpr::Get { .. }
             | HirRelationExpr::CallTable { .. } => (),
+            HirRelationExpr::Let { body, value, .. } => {
+                f(value);
+                f(body);
+            }
             HirRelationExpr::Project { input, .. } => {
                 f(input);
             }
@@ -1041,6 +1054,10 @@ impl HirRelationExpr {
             HirRelationExpr::Constant { .. }
             | HirRelationExpr::Get { .. }
             | HirRelationExpr::CallTable { .. } => (),
+            HirRelationExpr::Let { body, value, .. } => {
+                f(value);
+                f(body);
+            }
             HirRelationExpr::Project { input, .. } => {
                 f(input);
             }
@@ -1091,6 +1108,10 @@ impl HirRelationExpr {
         F: FnMut(usize, &ColumnRef),
     {
         match self {
+            HirRelationExpr::Let { body, value, .. } => {
+                value.visit_columns(depth, f);
+                body.visit_columns(depth, f);
+            }
             HirRelationExpr::Join {
                 on, left, right, ..
             } => {
@@ -1148,6 +1169,10 @@ impl HirRelationExpr {
         F: FnMut(usize, &mut ColumnRef),
     {
         match self {
+            HirRelationExpr::Let { body, value, .. } => {
+                value.visit_columns_mut(depth, f);
+                body.visit_columns_mut(depth, f);
+            }
             HirRelationExpr::Join {
                 on, left, right, ..
             } => {
@@ -1203,6 +1228,10 @@ impl HirRelationExpr {
     /// corresponding datum from `params`.
     pub fn bind_parameters(&mut self, params: &Params) -> Result<(), anyhow::Error> {
         match self {
+            HirRelationExpr::Let { body, value, .. } => {
+                value.bind_parameters(params)?;
+                body.bind_parameters(params)
+            }
             HirRelationExpr::Join {
                 on, left, right, ..
             } => {
@@ -1255,6 +1284,10 @@ impl HirRelationExpr {
     /// See the documentation for [`HirScalarExpr::splice_parameters`].
     pub fn splice_parameters(&mut self, params: &[HirScalarExpr], depth: usize) {
         match self {
+            HirRelationExpr::Let { body, value, .. } => {
+                value.splice_parameters(params, depth);
+                body.splice_parameters(params, depth);
+            }
             HirRelationExpr::Join {
                 on, left, right, ..
             } => {

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -254,7 +254,12 @@ impl HirRelationExpr {
                         get_outer.product(SR::Get { id, typ })
                     }
                 },
-                Let { id, value, body } => {
+                Let {
+                    name: _,
+                    id,
+                    value,
+                    body,
+                } => {
                     let value = value.applied_to(id_gen, get_outer.clone(), col_map, cte_map);
                     value.let_in(id_gen, |id_gen, get_value| {
                         let (new_id, typ) = if let expr::MirRelationExpr::Get {

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -1198,7 +1198,14 @@ fn plan_query_inner(
 
         match cte.id {
             Id::Local(id) => {
-                let old_val = qcx.ctes.insert(id, CteDesc { val, val_desc });
+                let old_val = qcx.ctes.insert(
+                    id,
+                    CteDesc {
+                        val,
+                        name: cte_name,
+                        val_desc,
+                    },
+                );
                 old_cte_values.push((id, old_val));
             }
             _ => unreachable!(),
@@ -1262,6 +1269,7 @@ fn plan_query_inner(
     for (id, old_val) in old_cte_values.into_iter().rev() {
         if let Some(cte) = qcx.ctes.remove(&id) {
             result = HirRelationExpr::Let {
+                name: cte.name,
                 id: id.clone(),
                 value: Box::new(cte.val),
                 body: Box::new(result),
@@ -4019,6 +4027,7 @@ pub enum QueryLifetime<'a> {
 pub struct CteDesc {
     /// The CTE's expression.
     val: HirRelationExpr,
+    name: String,
     val_desc: RelationDesc,
 }
 

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -1198,15 +1198,8 @@ fn plan_query_inner(
 
         match cte.id {
             Id::Local(id) => {
-                let old_val = qcx.ctes.insert(
-                    id,
-                    CteDesc {
-                        val,
-                        val_desc,
-                        level_offset: 0,
-                    },
-                );
-                old_cte_values.push((cte_name, old_val));
+                let old_val = qcx.ctes.insert(id, CteDesc { val, val_desc });
+                old_cte_values.push((id, old_val));
             }
             _ => unreachable!(),
         }
@@ -1232,7 +1225,7 @@ fn plan_query_inner(
         _ => sql_bail!("OFFSET must be an integer constant"),
     };
 
-    let result = match &q.body {
+    let (mut result, scope, finishing) = match &q.body {
         SetExpr::Select(s) => {
             let plan = plan_view_select(qcx, s, &q.order_by)?;
             let finishing = RowSetFinishing {
@@ -1241,7 +1234,7 @@ fn plan_query_inner(
                 limit,
                 offset,
             };
-            Ok((plan.expr, plan.scope, finishing))
+            Ok::<_, PlanError>((plan.expr, plan.scope, finishing))
         }
         _ => {
             let (expr, scope) = plan_set_expr(qcx, &q.body)?;
@@ -1264,9 +1257,22 @@ fn plan_query_inner(
             };
             Ok((expr.map(map_exprs), scope, finishing))
         }
-    };
+    }?;
 
-    result
+    for (id, old_val) in old_cte_values.into_iter().rev() {
+        if let Some(cte) = qcx.ctes.remove(&id) {
+            result = HirRelationExpr::Let {
+                id: id.clone(),
+                value: Box::new(cte.val),
+                body: Box::new(result),
+            };
+        }
+        if let Some(old_val) = old_val {
+            qcx.ctes.insert(id, old_val);
+        }
+    }
+
+    Ok((result, scope, finishing))
 }
 
 pub fn plan_nested_query(
@@ -4014,11 +4020,6 @@ pub struct CteDesc {
     /// The CTE's expression.
     val: HirRelationExpr,
     val_desc: RelationDesc,
-    /// We evaluate CTEs when they're defined and not when they're referred to
-    /// (i.e. it's like a pointer, not a macro). This means that we need to
-    /// adjust the level of correlated columns to retain their original
-    /// references.
-    level_offset: usize,
 }
 
 /// The state required when planning a `Query`.
@@ -4065,11 +4066,7 @@ impl<'a> QueryContext<'a> {
     /// Generate a new `QueryContext` appropriate to be used in subqueries of
     /// `self`.
     fn derived_context(&self, scope: Scope, relation_type: RelationType) -> QueryContext<'a> {
-        let mut ctes = self.ctes.clone();
-        for (_, cte) in ctes.iter_mut() {
-            cte.level_offset += 1;
-        }
-
+        let ctes = self.ctes.clone();
         let outer_scopes = iter::once(scope).chain(self.outer_scopes.clone()).collect();
         let outer_relation_types = iter::once(relation_type)
             .chain(self.outer_relation_types.clone())
@@ -4103,19 +4100,14 @@ impl<'a> QueryContext<'a> {
             Id::Local(id) => {
                 let name = object.raw_name;
                 let cte = self.ctes.get(&id).unwrap();
-                let mut val = cte.val.clone();
-                val.visit_columns_mut(0, &mut |depth, col| {
-                    if col.level > depth {
-                        col.level += cte.level_offset;
-                    }
-                });
+                let expr = HirRelationExpr::Get {
+                    id: Id::Local(id),
+                    typ: cte.val_desc.typ().clone(),
+                };
 
                 let scope = Scope::from_source(Some(name), cte.val_desc.iter_names());
 
-                // Inline `val` where its name was referenced. In an ideal
-                // world, multiple instances of this expression would be
-                // de-duplicated.
-                Ok((val, scope))
+                Ok((expr, scope))
             }
             Id::Global(id) => {
                 let item = self.scx.get_item_by_id(&id);

--- a/test/sqllogictest/cte_lowering.slt
+++ b/test/sqllogictest/cte_lowering.slt
@@ -29,7 +29,7 @@ EXPLAIN RAW PLAN FOR
 WITH t AS (SELECT * FROM y WHERE a < 3)
   SELECT * FROM t NATURAL JOIN t a;
 ----
-%0 = Let l0 =
+%0 = Let t (l0) =
 | Get materialize.public.y (u3)
 | Filter (#0 < 3)
 
@@ -45,7 +45,7 @@ EXPLAIN RAW PLAN FOR
 WITH t AS (SELECT * FROM y WHERE a < 3)
   SELECT * FROM y WHERE (select a from t) < a;
 ----
-%0 = Let l0 =
+%0 = Let t (l0) =
 | Get materialize.public.y (u3)
 | Filter (#0 < 3)
 
@@ -54,7 +54,7 @@ WITH t AS (SELECT * FROM y WHERE a < 3)
 | Filter (select(%2) < #0)
 | |
 | | %2 =
-| | | Get %0 (l0)
+| | | Get t (l0) (%0)
 | |
 
 EOF
@@ -721,5 +721,84 @@ FROM x,
 | | implementation = Unimplemented
 | Project (#0, #2, #3)
 | Filter true
+
+EOF
+
+# Check that CTEs are annotated with their names
+query T multiline
+EXPLAIN RAW PLAN FOR
+WITH a(a) AS (SELECT a FROM y),
+     b(b) AS (SELECT a FROM y),
+     x(x) AS (SELECT b FROM b)
+SELECT (WITH c(c) AS (SELECT a FROM y)
+        SELECT c FROM c where (WITH d(d) AS (SELECT c FROM c)
+                               SELECT max(d) FROM d) > 1)
+FROM (WITH e(e) AS (SELECT b FROM b)
+      SELECT e FROM e where (WITH f(f) AS (SELECT e FROM e)
+                             SELECT min(f) FROM f)
+                             < (SELECT max(x) FROM x))
+----
+%0 = Let a (l0) =
+| Get materialize.public.y (u3)
+
+%1 = Let b (l1) =
+| Get materialize.public.y (u3)
+
+%2 = Let x (l2) =
+| Get b (l1) (%1)
+
+%3 = Let e (l3) =
+| Get b (l1) (%1)
+
+%4 =
+| Get e (l3) (%3)
+| Filter (select(%6) < select(%7))
+| |
+| | %5 = Let f (l4) =
+| | | Get e (l3) (%3)
+| |
+| | %6 =
+| | | Get f (l4) (%5)
+| | | Reduce group=() min(#0)
+| |
+| |
+| | %7 =
+| | | Get x (l2) (%2)
+| | | Reduce group=() max(#0)
+| |
+| Map select(%9)
+| |
+| | %8 = Let c (l3) =
+| | | Get materialize.public.y (u3)
+| |
+| | %9 =
+| | | Get c (l3) (%8)
+| | | Filter (select(%11) > 1)
+| | | |
+| | | | %10 = Let d (l4) =
+| | | | | Get c (l3) (%8)
+| | | |
+| | | | %11 =
+| | | | | Get d (l4) (%10)
+| | | | | Reduce group=() max(#0)
+| | | |
+| |
+| Project (#1)
+
+EOF
+
+# CTEs with the same name in nested context
+query T multiline
+EXPLAIN RAW PLAN FOR
+WITH a(a) AS (SELECT a FROM y) SELECT * FROM (WITH a(a) AS (SELECT a FROM a) SELECT a FROM a);
+----
+%0 = Let a (l0) =
+| Get materialize.public.y (u3)
+
+%1 = Let a (l1) =
+| Get a (l0) (%0)
+
+%2 =
+| Get a (l1) (%1)
 
 EOF

--- a/test/sqllogictest/cte_lowering.slt
+++ b/test/sqllogictest/cte_lowering.slt
@@ -1,0 +1,725 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test that correlated CTE are lowered properly
+
+mode cockroach
+
+statement ok
+CREATE TABLE x (a int)
+
+statement ok
+INSERT INTO x VALUES (1), (2), (3)
+
+statement ok
+CREATE TABLE y (a int)
+
+statement ok
+INSERT INTO y VALUES (2), (3), (4)
+
+# Check that CTEs aren't inlined during planning
+query T multiline
+EXPLAIN RAW PLAN FOR
+WITH t AS (SELECT * FROM y WHERE a < 3)
+  SELECT * FROM t NATURAL JOIN t a;
+----
+%0 = Let l0 =
+| Get materialize.public.y (u3)
+| Filter (#0 < 3)
+
+%1 =
+| InnerJoin %0 %0 on (true && (#0 = #1))
+| Project (#0)
+
+EOF
+
+# Check that CTE defined in outer context is explained properly
+query T multiline
+EXPLAIN RAW PLAN FOR
+WITH t AS (SELECT * FROM y WHERE a < 3)
+  SELECT * FROM y WHERE (select a from t) < a;
+----
+%0 = Let l0 =
+| Get materialize.public.y (u3)
+| Filter (#0 < 3)
+
+%1 =
+| Get materialize.public.y (u3)
+| Filter (select(%2) < #0)
+| |
+| | %2 =
+| | | Get %0 (l0)
+| |
+
+EOF
+
+# Check the body of a CTE is only lowered once
+query T multiline
+EXPLAIN DECORRELATED PLAN FOR
+WITH t AS (SELECT * FROM y WHERE a < 3)
+  SELECT * FROM t NATURAL JOIN t a;
+----
+%0 = Let l0 =
+| Constant ()
+
+%1 =
+| Get materialize.public.y (u3)
+
+%2 = Let l1 =
+| Join %0 %1
+| | implementation = Unimplemented
+| Filter (#0 < 3)
+
+%3 = Let l2 =
+| Join %2 %2
+| | implementation = Unimplemented
+| Project (#0, #1)
+| Filter (true && (#0 = #1))
+
+%4 =
+| Get %3 (l2)
+| Project (#0)
+
+EOF
+
+# Correlated CTE inside a LATERAL join operand
+query T multiline
+EXPLAIN DECORRELATED PLAN FOR
+SELECT *
+FROM x,
+     LATERAL(WITH a(m) AS (SELECT max(y.a) FROM y WHERE y.a < x.a)
+             SELECT * FROM a);
+----
+%0 = Let l0 =
+| Constant ()
+
+%1 =
+| Get materialize.public.x (u1)
+
+%2 = Let l1 =
+| Join %0 %1
+| | implementation = Unimplemented
+
+%3 = Let l2 =
+| Get %2 (l1)
+| Distinct group=(#0)
+
+%4 =
+| Get materialize.public.y (u3)
+
+%5 = Let l3 =
+| Join %3 %4
+| | implementation = Unimplemented
+| Filter (#1 < #0)
+| Reduce group=(#0)
+| | agg max(#1)
+
+%6 =
+| Get %5 (l3)
+| Distinct group=(#0)
+| Negate
+
+%7 =
+| Get %3 (l2)
+| Distinct group=(#0)
+
+%8 =
+| Union %6 %7
+
+%9 =
+| Join %8 %3 (= #0 #1)
+| | implementation = Unimplemented
+| Project (#0)
+
+%10 =
+| Constant (null)
+
+%11 =
+| Join %9 %10
+| | implementation = Unimplemented
+
+%12 = Let l4 =
+| Union %5 %11
+
+%13 =
+| Get %12 (l4)
+
+%14 =
+| Join %2 %13 (= #0 #1)
+| | implementation = Unimplemented
+| Project (#0, #2)
+| Filter true
+
+EOF
+
+query II
+SELECT *
+FROM x,
+     LATERAL(WITH a(m) AS (SELECT max(y.a) FROM y WHERE y.a < x.a)
+             SELECT * FROM a);
+----
+1  NULL
+2  NULL
+3  2
+
+# Reference of a correlated CTE applied to an outer relation that has the same cardinality as
+# the one the CTE was applied to.
+# When the CTE is lowered, the outer relation is `Get x`. But then, the reference of the CTE
+# is applied to `Distinct(Join(Get x, Get y), x.*)` which has the same cardinality as `Get x`.
+query T multiline
+EXPLAIN DECORRELATED PLAN FOR
+SELECT *
+FROM x,
+     LATERAL(WITH a(m) as (SELECT max(y.a) FROM y WHERE y.a < x.a)
+             SELECT (SELECT m FROM a) FROM y) b;
+----
+%0 = Let l0 =
+| Constant ()
+
+%1 =
+| Get materialize.public.x (u1)
+
+%2 = Let l1 =
+| Join %0 %1
+| | implementation = Unimplemented
+
+%3 = Let l2 =
+| Get %2 (l1)
+| Distinct group=(#0)
+
+%4 =
+| Get materialize.public.y (u3)
+
+%5 = Let l3 =
+| Join %3 %4
+| | implementation = Unimplemented
+| Filter (#1 < #0)
+| Reduce group=(#0)
+| | agg max(#1)
+
+%6 =
+| Get %5 (l3)
+| Distinct group=(#0)
+| Negate
+
+%7 =
+| Get %3 (l2)
+| Distinct group=(#0)
+
+%8 =
+| Union %6 %7
+
+%9 =
+| Join %8 %3 (= #0 #1)
+| | implementation = Unimplemented
+| Project (#0)
+
+%10 =
+| Constant (null)
+
+%11 =
+| Join %9 %10
+| | implementation = Unimplemented
+
+%12 = Let l4 =
+| Union %5 %11
+
+%13 =
+| Get materialize.public.y (u3)
+
+%14 = Let l5 =
+| Join %3 %13
+| | implementation = Unimplemented
+
+%15 = Let l6 =
+| Get %14 (l5)
+| Distinct group=(#0, #1)
+
+%16 = Let l7 =
+| Get %15 (l6)
+| Distinct group=(#0)
+
+%17 = Let l8 =
+| Join %16 %12 (= #0 #1)
+| | implementation = Unimplemented
+| Project (#0, #2)
+
+%18 =
+| Get %17 (l8)
+| Reduce group=(#0)
+| | agg count(true)
+| Filter (#1 > 1)
+| Project (#0)
+| Map (err: more than one record produced in subquery)
+
+%19 = Let l9 =
+| Union %17 %18
+
+%20 =
+| Get %19 (l9)
+| Distinct group=(#0)
+| Negate
+
+%21 =
+| Get %16 (l7)
+| Distinct group=(#0)
+
+%22 =
+| Union %20 %21
+
+%23 =
+| Join %22 %16 (= #0 #1)
+| | implementation = Unimplemented
+| Project (#0)
+
+%24 =
+| Constant (null)
+
+%25 =
+| Join %23 %24
+| | implementation = Unimplemented
+
+%26 =
+| Union %19 %25
+
+%27 =
+| Join %15 %26 (= #0 #2)
+| | implementation = Unimplemented
+| Project (#0, #1, #3)
+
+%28 =
+| Join %14 %27 (= #0 #2) (= #1 #3)
+| | implementation = Unimplemented
+| Map #4
+| Project (#0, #1, #5)
+| Project (#0, #2)
+
+%29 =
+| Join %2 %28 (= #0 #1)
+| | implementation = Unimplemented
+| Project (#0, #2)
+| Filter true
+
+EOF
+
+# Correlated CTE used at different scope level: offset 0 and offset 1 (RHS of the join)
+# Note: the CTE is represented by %12 (l4)
+query T multiline
+EXPLAIN DECORRELATED PLAN FOR
+SELECT *
+FROM x,
+     LATERAL(WITH a(m) AS (SELECT max(y.a) FROM y WHERE y.a < x.a)
+             SELECT * FROM a INNER JOIN a b ON a.m = b.m);
+----
+%0 = Let l0 =
+| Constant ()
+
+%1 =
+| Get materialize.public.x (u1)
+
+%2 = Let l1 =
+| Join %0 %1
+| | implementation = Unimplemented
+
+%3 = Let l2 =
+| Get %2 (l1)
+| Distinct group=(#0)
+
+%4 =
+| Get materialize.public.y (u3)
+
+%5 = Let l3 =
+| Join %3 %4
+| | implementation = Unimplemented
+| Filter (#1 < #0)
+| Reduce group=(#0)
+| | agg max(#1)
+
+%6 =
+| Get %5 (l3)
+| Distinct group=(#0)
+| Negate
+
+%7 =
+| Get %3 (l2)
+| Distinct group=(#0)
+
+%8 =
+| Union %6 %7
+
+%9 =
+| Join %8 %3 (= #0 #1)
+| | implementation = Unimplemented
+| Project (#0)
+
+%10 =
+| Constant (null)
+
+%11 =
+| Join %9 %10
+| | implementation = Unimplemented
+
+%12 = Let l4 =
+| Union %5 %11
+
+%13 = Let l5 =
+| Join %12 %12 (= #0 #2)
+| | implementation = Unimplemented
+| Project (#0, #1, #3)
+| Filter (#1 = #2)
+
+%14 = Let l6 =
+| Get %13 (l5)
+| Project (#0, #1)
+| Distinct group=(#0, #1)
+
+%15 =
+| Get %13 (l5)
+
+%16 =
+| Join %2 %15 (= #0 #1)
+| | implementation = Unimplemented
+| Project (#0, #2, #3)
+| Filter true
+
+EOF
+
+query III
+SELECT *
+FROM x,
+     LATERAL(WITH a(m) AS (SELECT max(y.a) FROM y WHERE y.a < x.a)
+             SELECT * FROM a INNER JOIN a b ON a.m = b.m);
+----
+3  2  2
+
+query III
+SELECT *
+FROM x,
+     LATERAL(WITH a(m) as (SELECT max(y.a) FROM y WHERE y.a < x.a)
+             SELECT * FROM a INNER JOIN a b ON true);
+----
+1  NULL  NULL
+2  NULL  NULL
+3  2  2
+
+# Correlated CTE used at different scope level: offset 0 and offset 3 (subquery in the
+# selection list of a derived relation in the RHS of the join)
+query T multiline
+EXPLAIN DECORRELATED PLAN FOR
+SELECT *
+FROM x,
+     LATERAL(WITH a(m) as (SELECT max(y.a) FROM y WHERE y.a < x.a)
+             SELECT * FROM a INNER JOIN (SELECT (SELECT m FROM a) FROM y) b ON true);
+----
+%0 = Let l0 =
+| Constant ()
+
+%1 =
+| Get materialize.public.x (u1)
+
+%2 = Let l1 =
+| Join %0 %1
+| | implementation = Unimplemented
+
+%3 = Let l2 =
+| Get %2 (l1)
+| Distinct group=(#0)
+
+%4 =
+| Get materialize.public.y (u3)
+
+%5 = Let l3 =
+| Join %3 %4
+| | implementation = Unimplemented
+| Filter (#1 < #0)
+| Reduce group=(#0)
+| | agg max(#1)
+
+%6 =
+| Get %5 (l3)
+| Distinct group=(#0)
+| Negate
+
+%7 =
+| Get %3 (l2)
+| Distinct group=(#0)
+
+%8 =
+| Union %6 %7
+
+%9 =
+| Join %8 %3 (= #0 #1)
+| | implementation = Unimplemented
+| Project (#0)
+
+%10 =
+| Constant (null)
+
+%11 =
+| Join %9 %10
+| | implementation = Unimplemented
+
+%12 = Let l4 =
+| Union %5 %11
+
+%13 =
+| Get materialize.public.y (u3)
+
+%14 = Let l5 =
+| Join %3 %13
+| | implementation = Unimplemented
+
+%15 = Let l6 =
+| Get %14 (l5)
+| Distinct group=(#0, #1)
+
+%16 = Let l7 =
+| Get %15 (l6)
+| Distinct group=(#0)
+
+%17 = Let l8 =
+| Join %16 %12 (= #0 #1)
+| | implementation = Unimplemented
+| Project (#0, #2)
+
+%18 =
+| Get %17 (l8)
+| Reduce group=(#0)
+| | agg count(true)
+| Filter (#1 > 1)
+| Project (#0)
+| Map (err: more than one record produced in subquery)
+
+%19 = Let l9 =
+| Union %17 %18
+
+%20 =
+| Get %19 (l9)
+| Distinct group=(#0)
+| Negate
+
+%21 =
+| Get %16 (l7)
+| Distinct group=(#0)
+
+%22 =
+| Union %20 %21
+
+%23 =
+| Join %22 %16 (= #0 #1)
+| | implementation = Unimplemented
+| Project (#0)
+
+%24 =
+| Constant (null)
+
+%25 =
+| Join %23 %24
+| | implementation = Unimplemented
+
+%26 =
+| Union %19 %25
+
+%27 =
+| Join %15 %26 (= #0 #2)
+| | implementation = Unimplemented
+| Project (#0, #1, #3)
+
+%28 = Let l10 =
+| Join %14 %27 (= #0 #2) (= #1 #3)
+| | implementation = Unimplemented
+| Map #4
+| Project (#0, #1, #5)
+| Project (#0, #2)
+
+%29 = Let l11 =
+| Join %12 %28 (= #0 #2)
+| | implementation = Unimplemented
+| Project (#0, #1, #3)
+| Filter true
+
+%30 =
+| Get %29 (l11)
+
+%31 =
+| Join %2 %30 (= #0 #1)
+| | implementation = Unimplemented
+| Project (#0, #2, #3)
+| Filter true
+
+EOF
+
+query III
+SELECT *
+FROM x,
+     LATERAL(WITH a(m) AS (SELECT max(y.a) FROM y WHERE y.a < x.a)
+             SELECT * FROM a INNER JOIN (SELECT (SELECT m FROM a) FROM y) b ON true);
+----
+1  NULL  NULL
+1  NULL  NULL
+1  NULL  NULL
+2  NULL  NULL
+2  NULL  NULL
+2  NULL  NULL
+3  2  2
+3  2  2
+3  2  2
+
+# Correlated CTE used from a correlated scope
+# Note: the CTE is represented by %12 (l4)
+query T multiline
+EXPLAIN DECORRELATED PLAN FOR
+SELECT *
+FROM x,
+     LATERAL(WITH a(m) AS (SELECT max(y.a) FROM y WHERE y.a < x.a)
+             SELECT * FROM y INNER JOIN LATERAL(SELECT y.a FROM x WHERE (SELECT m FROM a) > 0) ON true);
+----
+%0 = Let l0 =
+| Constant ()
+
+%1 =
+| Get materialize.public.x (u1)
+
+%2 = Let l1 =
+| Join %0 %1
+| | implementation = Unimplemented
+
+%3 = Let l2 =
+| Get %2 (l1)
+| Distinct group=(#0)
+
+%4 =
+| Get materialize.public.y (u3)
+
+%5 = Let l3 =
+| Join %3 %4
+| | implementation = Unimplemented
+| Filter (#1 < #0)
+| Reduce group=(#0)
+| | agg max(#1)
+
+%6 =
+| Get %5 (l3)
+| Distinct group=(#0)
+| Negate
+
+%7 =
+| Get %3 (l2)
+| Distinct group=(#0)
+
+%8 =
+| Union %6 %7
+
+%9 =
+| Join %8 %3 (= #0 #1)
+| | implementation = Unimplemented
+| Project (#0)
+
+%10 =
+| Constant (null)
+
+%11 =
+| Join %9 %10
+| | implementation = Unimplemented
+
+%12 = Let l4 =
+| Union %5 %11
+
+%13 =
+| Get materialize.public.y (u3)
+
+%14 = Let l5 =
+| Join %3 %13
+| | implementation = Unimplemented
+
+%15 = Let l6 =
+| Get %14 (l5)
+| Distinct group=(#1)
+
+%16 =
+| Get materialize.public.x (u1)
+
+%17 = Let l7 =
+| Join %15 %16
+| | implementation = Unimplemented
+| Filter true
+
+%18 = Let l8 =
+| Get %17 (l7)
+| Distinct group=(#0)
+
+%19 = Let l9 =
+| Join %18 %12 (= #0 #1)
+| | implementation = Unimplemented
+| Project (#0, #2)
+
+%20 =
+| Get %19 (l9)
+| Reduce group=(#0)
+| | agg count(true)
+| Filter (#1 > 1)
+| Project (#0)
+| Map (err: more than one record produced in subquery)
+
+%21 = Let l10 =
+| Union %19 %20
+
+%22 =
+| Get %21 (l10)
+| Distinct group=(#0)
+| Negate
+
+%23 =
+| Get %18 (l8)
+| Distinct group=(#0)
+
+%24 =
+| Union %22 %23
+
+%25 =
+| Join %24 %18 (= #0 #1)
+| | implementation = Unimplemented
+| Project (#0)
+
+%26 =
+| Constant (null)
+
+%27 =
+| Join %25 %26
+| | implementation = Unimplemented
+
+%28 =
+| Union %21 %27
+
+%29 = Let l11 =
+| Join %17 %28 (= #0 #2)
+| | implementation = Unimplemented
+| Project (#0, #1, #3)
+| Filter (#2 > 0)
+| Project (#0, #1)
+
+%30 =
+| Get %29 (l11)
+| Map #0
+| Project (#0..#2)
+| Project (#0, #2)
+
+%31 =
+| Join %14 %30 (= #1 #2)
+| | implementation = Unimplemented
+| Project (#0, #1, #3)
+| Filter true
+
+%32 =
+| Join %2 %31 (= #0 #1)
+| | implementation = Unimplemented
+| Project (#0, #2, #3)
+| Filter true
+
+EOF

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -110,8 +110,11 @@ WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
 SELECT row_number() OVER (PARTITION BY x ORDER BY x), x FROM t
 ORDER BY row_number, x
 ----
-%0 =
+%0 = Let l0 =
 | CallTable wrap2("a", 1, "b", 2, "c", 1)
+
+%1 =
+| Get %0 (l0)
 | Map row_number() over (#0) order by (#0)
 | Project (#2, #0)
 
@@ -132,11 +135,8 @@ ORDER BY row_number, x
 | Get %0 (l0)
 | FlatMap wrap2("a", 1, "b", 2, "c", 1)
 
-%2 = Let l2 =
+%2 =
 | Get %1 (l1)
-
-%3 =
-| Get %2 (l2)
 | Reduce group=(#0)
 | | agg row_number(record_create(list_create(record_create(#0, #1)), #0))
 | FlatMap unnest_list(#1)

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -110,11 +110,11 @@ WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
 SELECT row_number() OVER (PARTITION BY x ORDER BY x), x FROM t
 ORDER BY row_number, x
 ----
-%0 = Let l0 =
+%0 = Let t (l0) =
 | CallTable wrap2("a", 1, "b", 2, "c", 1)
 
 %1 =
-| Get %0 (l0)
+| Get t (l0) (%0)
 | Map row_number() over (#0) order by (#0)
 | Project (#2, #0)
 


### PR DESCRIPTION
CTEs are no longer inlined.

<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug: [Link to issue.]

  * This PR adds a known-desirable feature: [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

Closes #4867.

I needed Hir support for CTEs to be able to tests QGM graphs involving CTEs.

Example:

```
explain decorrelated plan for select * from t1, lateral(with a(a) as (select t1.f1 + t2.f1 from t2) select * from a, a b where (select a from a) > 1);
```

main:

![hir-without-cte](https://user-images.githubusercontent.com/1282736/147088595-1cf7c966-12ce-4236-b028-72078064f6b1.png)

this branch:

![decorrelated-cte](https://user-images.githubusercontent.com/1282736/147088607-e200a02d-727d-46fe-8bf6-1294a07380f3.png)

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

This would benefit from intensive RQG testing.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).

