### PR TITLE
run tests for repurpose_vec and DatumVec under miri

### DIFF
--- a/ci/test/cargo-test-miri.sh
+++ b/ci/test/cargo-test-miri.sh
@@ -18,9 +18,10 @@ set -euo pipefail
 # so keep them away from the `target` directory.
 export CARGO_TARGET_DIR=miri-target
 
-# At the moment only repr has tests meant to be run under miri.
+# At the moment only ore and repr have tests meant to be run under miri.
 pkgs=(
     repr
+    ore
 )
 
 for pkg in "${pkgs[@]}"; do

--- a/src/ore/src/vec.rs
+++ b/src/ore/src/vec.rs
@@ -23,8 +23,9 @@ use smallvec::SmallVec;
 /// Create a new vector that re-uses the same allocation as an old one.
 /// The element types must have the same size and alignment.
 pub fn repurpose_allocation<T1, T2>(mut v: Vec<T1>) -> Vec<T2> {
-    assert!(size_of::<T1>() == size_of::<T2>());
-    assert!(align_of::<T1>() == align_of::<T2>());
+    assert_eq!(size_of::<T1>(), size_of::<T2>(), "same size");
+    assert_eq!(align_of::<T1>(), align_of::<T2>(), "same alignment");
+
     v.clear();
     let cap = v.capacity();
     let p = v.as_mut_ptr().cast();
@@ -73,5 +74,83 @@ where
         A::Item: Copy,
     {
         SmallVec::extend_from_slice(self, other)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn miri_test_repurpose() {
+        let v: Vec<usize> = vec![0, 1, 2];
+
+        let mut other: Vec<isize> = repurpose_allocation(v);
+
+        assert!(other.is_empty());
+        other.push(-1);
+        assert_eq!(other[0], -1);
+
+        struct Gus1 {
+            s: String,
+        }
+        impl Drop for Gus1 {
+            fn drop(&mut self) {
+                println!("happy {}", self.s);
+            }
+        }
+
+        struct Gus2 {
+            s: String,
+        }
+        impl Drop for Gus2 {
+            fn drop(&mut self) {
+                println!("happy {}", self.s);
+            }
+        }
+
+        // also exercise non-`Copy`, `Drop`-impling values as well
+        let v: Vec<Gus1> = vec![Gus1 {
+            s: "hmm".to_string(),
+        }];
+
+        let mut other: Vec<Gus2> = repurpose_allocation(v);
+
+        assert!(other.is_empty());
+        other.push(Gus2 {
+            s: "hmm2".to_string(),
+        });
+        assert_eq!(other[0].s, "hmm2");
+    }
+
+    #[test]
+    #[should_panic(expected = "same size")]
+    fn miri_test_wrong_size() {
+        let v: Vec<usize> = vec![0, 1, 2];
+        let _: Vec<()> = repurpose_allocation(v);
+    }
+
+    #[test]
+    #[should_panic(expected = "same alignment")]
+    fn miri_test_wrong_align() {
+        #[repr(align(8))]
+        #[derive(Default)]
+        struct Gus1 {
+            _i: [u8; 16],
+        }
+
+        #[repr(align(16))]
+        #[derive(Default)]
+        struct Gus2 {
+            _i: [u8; 8],
+        }
+
+        use std::mem::size_of;
+        assert_eq!(size_of::<Gus1>(), size_of::<Gus2>(), "same size in test");
+
+        // You need a value in here to have miri catch the problem, if we remove
+        // the alignment check
+        let v: Vec<Gus1> = vec![Default::default()];
+        let _: Vec<Gus2> = repurpose_allocation(v);
     }
 }

--- a/src/repr/src/datum_vec.rs
+++ b/src/repr/src/datum_vec.rs
@@ -88,3 +88,34 @@ impl<'outer> std::ops::DerefMut for DatumVecBorrow<'outer> {
         &mut self.inner
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn miri_test_datum_vec() {
+        let mut d = DatumVec::new();
+
+        assert_eq!(d.borrow().len(), 0);
+
+        let mut r = Row::with_capacity(10);
+        r.push(Datum::String("first"));
+        r.push(Datum::Dummy);
+
+        {
+            let borrow = d.borrow_with(&r);
+            assert_eq!(borrow.len(), 2);
+            assert_eq!(borrow[0], Datum::String("first"));
+        }
+
+        {
+            // different lifetime, so that rust is happy with the reference lifetimes
+            let mut r2 = Row::with_capacity(1);
+            r2.push(Datum::String("second"));
+            let borrow = d.borrow_with_many(&[&r, &r2]);
+            assert_eq!(borrow.len(), 3);
+            assert_eq!(borrow[2], Datum::String("second"));
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

   * This PR refactors existing code.

when writing https://github.com/MaterializeInc/materialize/pull/9710, I noticed I leaned heavily on the magic of `repurpose_allocation`. As I didnt want to setup miri tests for ore, I moved the scope of `repurpose_allocation` to its only callsite, in `datum_vec.rs`, and added tests for it, and for `DatumVec` itself


run with `cargo +nightly miri test miri`

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
