### PR TITLE
coord: add `pronamespace` and `proargdefaults` to `pg_proc`

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -120,6 +120,8 @@ changes that have not yet been documented.
 - Support casts from [`smallint`] and [`bigint`] to [`oid`], as well as
   casts from [`oid`] to [`bigint`].
 
+- Add `pronamespace` and `proargdefaults` columns to `pg_catalog.pg_proc`.
+
 {{< comment >}}
 Only add new release notes above this line.
 

--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -1365,9 +1365,12 @@ pub const PG_PROC: BuiltinView = BuiltinView {
     name: "pg_proc",
     schema: PG_CATALOG_SCHEMA,
     sql: "CREATE VIEW pg_proc AS SELECT
-    oid,
-    name AS proname
-FROM mz_catalog.mz_functions",
+    mz_functions.oid,
+    mz_functions.name AS proname,
+    mz_schemas.oid AS pronamespace,
+    NULL::pg_catalog.text AS proargdefaults
+FROM mz_catalog.mz_functions
+JOIN mz_catalog.mz_schemas ON mz_functions.schema_id = mz_schemas.id",
     id: GlobalId::System(5021),
     needs_logs: false,
 };

--- a/test/sqllogictest/pg_catalog.slt
+++ b/test/sqllogictest/pg_catalog.slt
@@ -109,3 +109,13 @@ SELECT oid, rolname FROM pg_roles ORDER BY oid
 ----
 20007  materialize
 20008  mz_system
+
+query TIIO colnames
+SELECT proname, pronamespace, oid, proargdefaults
+FROM pg_catalog.pg_proc
+WHERE proname='substring'
+ORDER BY oid
+----
+proname    pronamespace  oid  proargdefaults
+substring  20003         936  NULL
+substring  20003         937  NULL


### PR DESCRIPTION
Add two new columns to pg_proc. These two columns are used by psql, DataGrip and DBeaver. With these columns, the "Functions" section of DBeaver is now fully functional, and we are slightly closer to supporting `\df` on psql.

### Motivation

* This PR contributes to a known-desirable feature: #9694 #9720 #9721 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
