### PR TITLE
deps: bump to krb5-src v0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2471,9 +2471,9 @@ dependencies = [
 
 [[package]]
 name = "krb5-src"
-version = "0.2.4+1.18.2"
+version = "0.3.1+1.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01c2b7c3b70ca41646dafc8fc3b6053a8a0da9301251e8da8548fb067462d81"
+checksum = "57fe5be675c272d885d49be528b3b048e38974a0579b0e691da2fb3f3c41eaca"
 dependencies = [
  "duct",
  "openssl-sys",
@@ -4360,9 +4360,9 @@ dependencies = [
 
 [[package]]
 name = "sasl2-sys"
-version = "0.1.11"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "342a1dfdd8f3d1072fecf792ebf99070a439362984f19c3103b15a5b1e2bd197"
+checksum = "5c50936b766924ec8f5118bcd3d6e5dc7ac25263df4f2ea450fe7919281a4544"
 dependencies = [
  "cc",
  "duct",

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -50,7 +50,7 @@ hyper = { version = "0.14.16", features = ["http1", "server"] }
 hyper-openssl = "0.9.1"
 include_dir = "0.7.2"
 itertools = "0.10.3"
-krb5-src = { version = "0.2.3", features = ["binaries"] }
+krb5-src = { version = "0.3.1", features = ["binaries"] }
 lazy_static = "1.4.0"
 libc = "0.2.112"
 log = "0.4.13"

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -26,7 +26,7 @@ http = "0.2.5"
 interchange = { path = "../interchange" }
 itertools = "0.10.3"
 kafka-util = { path = "../kafka-util" }
-krb5-src = { version = "0.2.3", features = ["binaries"] }
+krb5-src = { version = "0.3.1", features = ["binaries"] }
 lazy_static = "1.4.0"
 maplit = "1.0.2"
 md-5 = "0.9.0"


### PR DESCRIPTION
This release of krb5-src includes a bug fix for cross compiling from
macOS to Linux with recent versions of binutils. See [0] for details.

[0]: https://github.com/MaterializeInc/materialize/pull/9732#issuecomment-999955640

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
