### PR TITLE
dependabot: bump pip open pull requests limit to 10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,5 +43,6 @@ updates:
     # want to rebuild more often than we need to.
     interval: monthly
     time: "22:00"
+  open-pull-requests-limit: 10
   reviewers: [MaterializeInc/dependency-czars]
   labels: [A-dependencies]


### PR DESCRIPTION
To match the configuration for the other dependency ecosystems.

<!--