### PR TITLE
sql: add pg_backend_pid

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -122,6 +122,9 @@ changes that have not yet been documented.
 
 - Add `pronamespace` and `proargdefaults` columns to `pg_catalog.pg_proc`.
 
+- Add `pg_backend_pid` as a dummy function for compatibility with pgcli and
+  Apache Superset.
+
 {{< comment >}}
 Only add new release notes above this line.
 

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -584,6 +584,8 @@
       `mz_catalog` and `pg_catalog` are included in the output.
   - signature: 'obj_description(oid: oid, catalog: text) -> text'
     description: PostgreSQL compatibility shim. Currently always returns `NULL`.
+  - signature: 'pg_backend_pid() -> int'
+    description: Returns -1. Not intended for direct use.
   - signature: 'pg_column_size(expr: any) -> int'
     description: Returns the number of bytes used to store any individual data value.
   - signature: 'pg_get_constraintdef(oid: oid [, pretty: bool]) -> text'

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1604,6 +1604,14 @@ lazy_static! {
                 // encoding id for UTF8 (6) is provided, otherwise return 'NULL'.
                 params!(Int64) => sql_impl_func("CASE WHEN $1 = 6 THEN 'UTF8' ELSE NULL END"), 1597;
             },
+            "pg_backend_pid" => Scalar {
+                params!() => Operation::nullary(|_ecx| {
+                    Ok(HirScalarExpr::literal(
+                        Datum::from(-1),
+                        ScalarType::Int32,
+                    ))
+                }), 2026;
+            },
             // pg_get_constraintdef gives more info about a constraint with in the `pg_constraint`
             // view. It currently returns no information as the `pg_constraint` view is empty in
             // materialize

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -1113,3 +1113,8 @@ query I
 SELECT mz_internal.mz_error_if_null(1, '')
 ----
 1
+
+query I
+SELECT pg_backend_pid()
+----
+-1


### PR DESCRIPTION
Add `pg_backend_pid` with a hardcoded implementation to always return -1, for compatibility with pgcli and Apache Superset.

### Motivation

  * This PR contributes a known-desirable feature: #9245 #8229

### Tips for reviewer
I am following on the footsteps of cockroachdb/cockroach#13097 here, assuming that if it worked well enough in their case for years, it is probably going to work for us.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
