### PR TITLE
doc/user: correct position of release note marker

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -125,13 +125,6 @@ changes that have not yet been documented.
 - Add `pg_backend_pid` as a dummy function for compatibility with pgcli and
   Apache Superset.
 
-{{< comment >}}
-Only add new release notes above this line.
-
-The presence of this comment ensures that PRs that are alive across a release
-boundary don't silently merge their release notes into the wrong place.
-{{</ comment >}}
-
 - Fix a bug that could cause wrong results in queries that used the `ROWS FROM`
   clause. The bug occurred if functions beyond the second function in the clause
   produced more rows than the first function in the clause.
@@ -168,6 +161,13 @@ boundary don't silently merge their release notes into the wrong place.
   with 1.
 
 - **Breaking change.** Disallow views with multiple unnamed columns.
+
+{{< comment >}}
+Only add new release notes above this line.
+
+The presence of this comment ensures that PRs that are alive across a release
+boundary don't silently merge their release notes into the wrong place.
+{{</ comment >}}
 
 {{% version-header v0.13.0 %}}
 


### PR DESCRIPTION
We'll be fighting bad merge conflict resolutions until we've cleared all
PRs that predate the new release note template. This particular glitch
was my fault with #9686.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
