### PR TITLE
ci: add instructions for spinning up CI-like infrastructure

### DIFF
--- a/misc/python/materialize/cli/scratch/create.py
+++ b/misc/python/materialize/cli/scratch/create.py
@@ -80,6 +80,7 @@ def run(args: argparse.Namespace) -> None:
             launch_script=obj.get("launch_script"),
             instance_type=obj["instance_type"],
             ami=obj["ami"],
+            ami_user=obj["ami_user"],
             tags=obj.get("tags", dict()),
             size_gb=obj["size_gb"],
             checkout=obj.get("checkout", True),

--- a/misc/python/materialize/cli/scratch/ssh.py
+++ b/misc/python/materialize/cli/scratch/ssh.py
@@ -9,12 +9,15 @@
 
 import argparse
 
+import boto3
+
 from materialize.cli.scratch import check_required_vars
 from materialize.scratch import mssh
 
 
 def configure_parser(parser: argparse.ArgumentParser) -> None:
     check_required_vars()
+
     parser.add_argument("instance", help="The ID of the instance to connect to"),
     parser.add_argument("command", nargs="*", help="The command to run via SSH, if any")
 
@@ -22,4 +25,5 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
 def run(args: argparse.Namespace) -> None:
     # SSH will join together multiple arguments with spaces, so we don't lose
     # anything by doing the same.
-    mssh(args.instance, " ".join(args.command))
+    instance = boto3.resource("ec2").Instance(args.instance)
+    mssh(instance, " ".join(args.command))

--- a/misc/python/materialize/mzcompose.py
+++ b/misc/python/materialize/mzcompose.py
@@ -17,6 +17,7 @@ documentation][user-docs].
 
 import functools
 import importlib
+import importlib.abc
 import importlib.util
 import ipaddress
 import json


### PR DESCRIPTION
For security reasons, it's hard to give all engineers access to running
CI agents. But we can do something almost as good, which is to give all
engineers the ability to spin up an EC2 instance that looks nearly
identical to an actual CI agent.

This commit adds instructions for doing that. It also makes some tweaks
to the `bin/scratch` infrastructure to support AMIs whose default name
is "ec2-user" rather than "ubuntu".


### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
