### PR TITLE
*: deoptionalize column names everywhere

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -2305,8 +2305,7 @@ impl Catalog {
             Plan::CreateView(CreateViewPlan { view, .. }) => {
                 let mut optimizer = Optimizer::logical_optimizer();
                 let optimized_expr = optimizer.optimize(view.expr)?;
-                let desc =
-                    RelationDesc::new(optimized_expr.typ(), view.column_names.iter().map(Some));
+                let desc = RelationDesc::new(optimized_expr.typ(), view.column_names);
                 CatalogItem::View(View {
                     create_sql: view.create_sql,
                     optimized_expr,

--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -650,9 +650,9 @@ lazy_static! {
         name: "mz_view_keys",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-            .with_named_column("global_id", ScalarType::String.nullable(false))
-            .with_named_column("column", ScalarType::Int64.nullable(false))
-            .with_named_column("key_group", ScalarType::Int64.nullable(false)),
+            .with_column("global_id", ScalarType::String.nullable(false))
+            .with_column("column", ScalarType::Int64.nullable(false))
+            .with_column("key_group", ScalarType::Int64.nullable(false)),
         id: GlobalId::System(4001),
         index_id: GlobalId::System(4002),
         persistent: false,
@@ -661,11 +661,11 @@ lazy_static! {
         name: "mz_view_foreign_keys",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-            .with_named_column("child_id", ScalarType::String.nullable(false))
-            .with_named_column("child_column", ScalarType::Int64.nullable(false))
-            .with_named_column("parent_id", ScalarType::String.nullable(false))
-            .with_named_column("parent_column", ScalarType::Int64.nullable(false))
-            .with_named_column("key_group", ScalarType::Int64.nullable(false))
+            .with_column("child_id", ScalarType::String.nullable(false))
+            .with_column("child_column", ScalarType::Int64.nullable(false))
+            .with_column("parent_id", ScalarType::String.nullable(false))
+            .with_column("parent_column", ScalarType::Int64.nullable(false))
+            .with_column("key_group", ScalarType::Int64.nullable(false))
             .with_key(vec![0, 1, 4]), // TODO: explain why this is a key.
         id: GlobalId::System(4003),
         index_id: GlobalId::System(4004),
@@ -675,9 +675,9 @@ lazy_static! {
         name: "mz_kafka_sinks",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-            .with_named_column("sink_id", ScalarType::String.nullable(false))
-            .with_named_column("topic", ScalarType::String.nullable(false))
-            .with_named_column("consistency_topic", ScalarType::String.nullable(true))
+            .with_column("sink_id", ScalarType::String.nullable(false))
+            .with_column("topic", ScalarType::String.nullable(false))
+            .with_column("consistency_topic", ScalarType::String.nullable(true))
             .with_key(vec![0]),
         id: GlobalId::System(4005),
         index_id: GlobalId::System(4006),
@@ -687,8 +687,8 @@ lazy_static! {
         name: "mz_avro_ocf_sinks",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-            .with_named_column("sink_id", ScalarType::String.nullable(false))
-            .with_named_column("path", ScalarType::Bytes.nullable(false))
+            .with_column("sink_id", ScalarType::String.nullable(false))
+            .with_column("path", ScalarType::Bytes.nullable(false))
             .with_key(vec![0]),
         id: GlobalId::System(4007),
         index_id: GlobalId::System(4008),
@@ -698,9 +698,9 @@ lazy_static! {
         name: "mz_databases",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-            .with_named_column("id", ScalarType::Int64.nullable(false))
-            .with_named_column("oid", ScalarType::Oid.nullable(false))
-            .with_named_column("name", ScalarType::String.nullable(false)),
+            .with_column("id", ScalarType::Int64.nullable(false))
+            .with_column("oid", ScalarType::Oid.nullable(false))
+            .with_column("name", ScalarType::String.nullable(false)),
         id: GlobalId::System(4009),
         index_id: GlobalId::System(4010),
         persistent: false,
@@ -709,10 +709,10 @@ lazy_static! {
         name: "mz_schemas",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-            .with_named_column("id", ScalarType::Int64.nullable(false))
-            .with_named_column("oid", ScalarType::Oid.nullable(false))
-            .with_named_column("database_id", ScalarType::Int64.nullable(true))
-            .with_named_column("name", ScalarType::String.nullable(false)),
+            .with_column("id", ScalarType::Int64.nullable(false))
+            .with_column("oid", ScalarType::Oid.nullable(false))
+            .with_column("database_id", ScalarType::Int64.nullable(true))
+            .with_column("name", ScalarType::String.nullable(false)),
         id: GlobalId::System(4011),
         index_id: GlobalId::System(4012),
         persistent: false,
@@ -721,13 +721,13 @@ lazy_static! {
         name: "mz_columns",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-            .with_named_column("id", ScalarType::String.nullable(false))
-            .with_named_column("name", ScalarType::String.nullable(false))
-            .with_named_column("position", ScalarType::Int64.nullable(false))
-            .with_named_column("nullable", ScalarType::Bool.nullable(false))
-            .with_named_column("type", ScalarType::String.nullable(false))
-            .with_named_column("default", ScalarType::String.nullable(true))
-            .with_named_column("type_oid", ScalarType::Oid.nullable(false)),
+            .with_column("id", ScalarType::String.nullable(false))
+            .with_column("name", ScalarType::String.nullable(false))
+            .with_column("position", ScalarType::Int64.nullable(false))
+            .with_column("nullable", ScalarType::Bool.nullable(false))
+            .with_column("type", ScalarType::String.nullable(false))
+            .with_column("default", ScalarType::String.nullable(true))
+            .with_column("type_oid", ScalarType::Oid.nullable(false)),
         id: GlobalId::System(4013),
         index_id: GlobalId::System(4014),
         persistent: false,
@@ -736,12 +736,12 @@ lazy_static! {
         name: "mz_indexes",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-            .with_named_column("id", ScalarType::String.nullable(false))
-            .with_named_column("oid", ScalarType::Oid.nullable(false))
-            .with_named_column("name", ScalarType::String.nullable(false))
-            .with_named_column("on_id", ScalarType::String.nullable(false))
-            .with_named_column("volatility", ScalarType::String.nullable(false))
-            .with_named_column("enabled", ScalarType::Bool.nullable(false)),
+            .with_column("id", ScalarType::String.nullable(false))
+            .with_column("oid", ScalarType::Oid.nullable(false))
+            .with_column("name", ScalarType::String.nullable(false))
+            .with_column("on_id", ScalarType::String.nullable(false))
+            .with_column("volatility", ScalarType::String.nullable(false))
+            .with_column("enabled", ScalarType::Bool.nullable(false)),
         id: GlobalId::System(4015),
         index_id: GlobalId::System(4016),
         persistent: false,
@@ -750,11 +750,11 @@ lazy_static! {
         name: "mz_index_columns",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-            .with_named_column("index_id", ScalarType::String.nullable(false))
-            .with_named_column("index_position", ScalarType::Int64.nullable(false))
-            .with_named_column("on_position", ScalarType::Int64.nullable(true))
-            .with_named_column("on_expression", ScalarType::String.nullable(true))
-            .with_named_column("nullable", ScalarType::Bool.nullable(false)),
+            .with_column("index_id", ScalarType::String.nullable(false))
+            .with_column("index_position", ScalarType::Int64.nullable(false))
+            .with_column("on_position", ScalarType::Int64.nullable(true))
+            .with_column("on_expression", ScalarType::String.nullable(true))
+            .with_column("nullable", ScalarType::Bool.nullable(false)),
         id: GlobalId::System(4017),
         index_id: GlobalId::System(4018),
         persistent: false,
@@ -763,11 +763,11 @@ lazy_static! {
         name: "mz_tables",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-            .with_named_column("id", ScalarType::String.nullable(false))
-            .with_named_column("oid", ScalarType::Oid.nullable(false))
-            .with_named_column("schema_id", ScalarType::Int64.nullable(false))
-            .with_named_column("name", ScalarType::String.nullable(false))
-            .with_named_column("persisted_name", ScalarType::String.nullable(true)),
+            .with_column("id", ScalarType::String.nullable(false))
+            .with_column("oid", ScalarType::Oid.nullable(false))
+            .with_column("schema_id", ScalarType::Int64.nullable(false))
+            .with_column("name", ScalarType::String.nullable(false))
+            .with_column("persisted_name", ScalarType::String.nullable(true)),
         id: GlobalId::System(4019),
         index_id: GlobalId::System(4020),
         persistent: false,
@@ -776,13 +776,13 @@ lazy_static! {
         name: "mz_sources",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-            .with_named_column("id", ScalarType::String.nullable(false))
-            .with_named_column("oid", ScalarType::Oid.nullable(false))
-            .with_named_column("schema_id", ScalarType::Int64.nullable(false))
-            .with_named_column("name", ScalarType::String.nullable(false))
-            .with_named_column("connector_type", ScalarType::String.nullable(false))
-            .with_named_column("volatility", ScalarType::String.nullable(false))
-            .with_named_column("persisted_name", ScalarType::String.nullable(true)),
+            .with_column("id", ScalarType::String.nullable(false))
+            .with_column("oid", ScalarType::Oid.nullable(false))
+            .with_column("schema_id", ScalarType::Int64.nullable(false))
+            .with_column("name", ScalarType::String.nullable(false))
+            .with_column("connector_type", ScalarType::String.nullable(false))
+            .with_column("volatility", ScalarType::String.nullable(false))
+            .with_column("persisted_name", ScalarType::String.nullable(true)),
         id: GlobalId::System(4021),
         index_id: GlobalId::System(4022),
         persistent: false,
@@ -791,12 +791,12 @@ lazy_static! {
         name: "mz_sinks",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-            .with_named_column("id", ScalarType::String.nullable(false))
-            .with_named_column("oid", ScalarType::Oid.nullable(false))
-            .with_named_column("schema_id", ScalarType::Int64.nullable(false))
-            .with_named_column("name", ScalarType::String.nullable(false))
-            .with_named_column("connector_type", ScalarType::String.nullable(false))
-            .with_named_column("volatility", ScalarType::String.nullable(false)),
+            .with_column("id", ScalarType::String.nullable(false))
+            .with_column("oid", ScalarType::Oid.nullable(false))
+            .with_column("schema_id", ScalarType::Int64.nullable(false))
+            .with_column("name", ScalarType::String.nullable(false))
+            .with_column("connector_type", ScalarType::String.nullable(false))
+            .with_column("volatility", ScalarType::String.nullable(false)),
         id: GlobalId::System(4023),
         index_id: GlobalId::System(4024),
         persistent: false,
@@ -805,11 +805,11 @@ lazy_static! {
         name: "mz_views",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-            .with_named_column("id", ScalarType::String.nullable(false))
-            .with_named_column("oid", ScalarType::Oid.nullable(false))
-            .with_named_column("schema_id", ScalarType::Int64.nullable(false))
-            .with_named_column("name", ScalarType::String.nullable(false))
-            .with_named_column("volatility", ScalarType::String.nullable(false)),
+            .with_column("id", ScalarType::String.nullable(false))
+            .with_column("oid", ScalarType::Oid.nullable(false))
+            .with_column("schema_id", ScalarType::Int64.nullable(false))
+            .with_column("name", ScalarType::String.nullable(false))
+            .with_column("volatility", ScalarType::String.nullable(false)),
         id: GlobalId::System(4025),
         index_id: GlobalId::System(4026),
         persistent: false,
@@ -818,10 +818,10 @@ lazy_static! {
         name: "mz_types",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-            .with_named_column("id", ScalarType::String.nullable(false))
-            .with_named_column("oid", ScalarType::Oid.nullable(false))
-            .with_named_column("schema_id", ScalarType::Int64.nullable(false))
-            .with_named_column("name", ScalarType::String.nullable(false)),
+            .with_column("id", ScalarType::String.nullable(false))
+            .with_column("oid", ScalarType::Oid.nullable(false))
+            .with_column("schema_id", ScalarType::Int64.nullable(false))
+            .with_column("name", ScalarType::String.nullable(false)),
         id: GlobalId::System(4027),
         index_id: GlobalId::System(4028),
         persistent: false,
@@ -830,8 +830,8 @@ lazy_static! {
         name: "mz_array_types",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-            .with_named_column("type_id", ScalarType::String.nullable(false))
-            .with_named_column("element_id", ScalarType::String.nullable(false)),
+            .with_column("type_id", ScalarType::String.nullable(false))
+            .with_column("element_id", ScalarType::String.nullable(false)),
             id: GlobalId::System(4029),
             index_id: GlobalId::System(4030),
             persistent: false,
@@ -840,7 +840,7 @@ lazy_static! {
         name: "mz_base_types",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-            .with_named_column("type_id", ScalarType::String.nullable(false)),
+            .with_column("type_id", ScalarType::String.nullable(false)),
             id: GlobalId::System(4031),
             index_id: GlobalId::System(4032),
             persistent: false,
@@ -849,8 +849,8 @@ lazy_static! {
         name: "mz_list_types",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-            .with_named_column("type_id", ScalarType::String.nullable(false))
-            .with_named_column("element_id", ScalarType::String.nullable(false)),
+            .with_column("type_id", ScalarType::String.nullable(false))
+            .with_column("element_id", ScalarType::String.nullable(false)),
             id: GlobalId::System(4033),
             index_id: GlobalId::System(4034),
             persistent: false,
@@ -859,9 +859,9 @@ lazy_static! {
         name: "mz_map_types",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-            .with_named_column("type_id", ScalarType::String.nullable(false))
-            .with_named_column("key_id", ScalarType::String.nullable(false))
-            .with_named_column("value_id", ScalarType::String.nullable(false)),
+            .with_column("type_id", ScalarType::String.nullable(false))
+            .with_column("key_id", ScalarType::String.nullable(false))
+            .with_column("value_id", ScalarType::String.nullable(false)),
             id: GlobalId::System(4035),
             index_id: GlobalId::System(4036),
             persistent: false,
@@ -870,9 +870,9 @@ lazy_static! {
         name: "mz_roles",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-            .with_named_column("id", ScalarType::Int64.nullable(false))
-            .with_named_column("oid", ScalarType::Oid.nullable(false))
-            .with_named_column("name", ScalarType::String.nullable(false)),
+            .with_column("id", ScalarType::Int64.nullable(false))
+            .with_column("oid", ScalarType::Oid.nullable(false))
+            .with_column("name", ScalarType::String.nullable(false)),
         id: GlobalId::System(4037),
         index_id: GlobalId::System(4038),
         persistent: false,
@@ -881,7 +881,7 @@ lazy_static! {
         name: "mz_pseudo_types",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-            .with_named_column("type_id", ScalarType::String.nullable(false)),
+            .with_column("type_id", ScalarType::String.nullable(false)),
         id: GlobalId::System(4039),
         index_id: GlobalId::System(4040),
         persistent: false,
@@ -890,12 +890,12 @@ lazy_static! {
         name: "mz_functions",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-            .with_named_column("id", ScalarType::String.nullable(false))
-            .with_named_column("oid", ScalarType::Oid.nullable(false))
-            .with_named_column("schema_id", ScalarType::Int64.nullable(false))
-            .with_named_column("name", ScalarType::String.nullable(false))
-            .with_named_column("arg_ids", ScalarType::Array(Box::new(ScalarType::String)).nullable(false))
-            .with_named_column("variadic_id", ScalarType::String.nullable(true)),
+            .with_column("id", ScalarType::String.nullable(false))
+            .with_column("oid", ScalarType::Oid.nullable(false))
+            .with_column("schema_id", ScalarType::Int64.nullable(false))
+            .with_column("name", ScalarType::String.nullable(false))
+            .with_column("arg_ids", ScalarType::Array(Box::new(ScalarType::String)).nullable(false))
+            .with_column("variadic_id", ScalarType::String.nullable(true)),
         id: GlobalId::System(4041),
         index_id: GlobalId::System(4042),
         persistent: false,
@@ -904,10 +904,10 @@ lazy_static! {
         name: "mz_metrics",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-                .with_named_column("metric", ScalarType::String.nullable(false))
-                .with_named_column("time", ScalarType::TimestampTz.nullable(false))
-                .with_named_column("labels", ScalarType::Jsonb.nullable(false))
-                .with_named_column("value", ScalarType::Float64.nullable(false))
+                .with_column("metric", ScalarType::String.nullable(false))
+                .with_column("time", ScalarType::TimestampTz.nullable(false))
+                .with_column("labels", ScalarType::Jsonb.nullable(false))
+                .with_column("value", ScalarType::Float64.nullable(false))
                 .with_key(vec![0, 1, 2]),
         // NB: Until the end of our persisted system tables experiment, give
         // persist team a heads up if you change this id, please!
@@ -922,9 +922,9 @@ lazy_static! {
         name: "mz_metrics_meta",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-                .with_named_column("metric", ScalarType::String.nullable(false))
-                .with_named_column("type", ScalarType::String.nullable(false))
-                .with_named_column("help", ScalarType::String.nullable(false))
+                .with_column("metric", ScalarType::String.nullable(false))
+                .with_column("type", ScalarType::String.nullable(false))
+                .with_column("help", ScalarType::String.nullable(false))
                 .with_key(vec![0]),
         id: GlobalId::System(4045),
         index_id: GlobalId::System(4046),
@@ -934,11 +934,11 @@ lazy_static! {
         name: "mz_metric_histograms",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-                .with_named_column("metric", ScalarType::String.nullable(false))
-                .with_named_column("time", ScalarType::Timestamp.nullable(false))
-                .with_named_column("labels", ScalarType::Jsonb.nullable(false))
-                .with_named_column("bound", ScalarType::Float64.nullable(false))
-                .with_named_column("count", ScalarType::Int64.nullable(false))
+                .with_column("metric", ScalarType::String.nullable(false))
+                .with_column("time", ScalarType::Timestamp.nullable(false))
+                .with_column("labels", ScalarType::Jsonb.nullable(false))
+                .with_column("bound", ScalarType::Float64.nullable(false))
+                .with_column("count", ScalarType::Int64.nullable(false))
                 .with_key(vec![0, 1, 2]),
         // NB: Until the end of our persisted system tables experiment, give
         // persist team a heads up if you change this id, please!

--- a/src/coord/src/catalog/builtin_table_updates.rs
+++ b/src/coord/src/catalog/builtin_table_updates.rs
@@ -131,11 +131,7 @@ impl CatalogState {
                     id: MZ_COLUMNS.id,
                     row: Row::pack_slice(&[
                         Datum::String(&id.to_string()),
-                        Datum::String(
-                            &column_name
-                                .map(|n| n.to_string())
-                                .unwrap_or_else(|| "?column?".to_owned()),
-                        ),
+                        Datum::String(column_name.as_str()),
                         Datum::Int64(i as i64 + 1),
                         Datum::from(column_type.nullable),
                         Datum::String(pgtype.name()),

--- a/src/coord/src/client.rs
+++ b/src/coord/src/client.rs
@@ -467,10 +467,7 @@ impl SessionClient {
             };
             let mut sql_rows: Vec<Vec<serde_json::Value>> = vec![];
             let col_names = match desc.relation_desc {
-                Some(desc) => desc
-                    .iter_names()
-                    .map(|name| name.map(|name| name.to_string()))
-                    .collect(),
+                Some(desc) => desc.iter_names().map(|name| name.to_string()).collect(),
                 None => vec![],
             };
             let mut datum_vec = repr::DatumVec::new();

--- a/src/coord/src/command.rs
+++ b/src/coord/src/command.rs
@@ -284,7 +284,7 @@ pub struct SimpleExecuteResponse {
 #[derive(Debug, Serialize)]
 pub struct SimpleResult {
     pub rows: Vec<Vec<serde_json::Value>>,
-    pub col_names: Vec<Option<String>>,
+    pub col_names: Vec<String>,
 }
 
 /// The state of a cancellation request.

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -2333,7 +2333,7 @@ where
         let view_oid = self.catalog.allocate_oid()?;
         // Optimize the expression so that we can form an accurately typed description.
         let optimized_expr = self.prep_relation_expr(view.expr, ExprPrepStyle::Static)?;
-        let desc = RelationDesc::new(optimized_expr.typ(), view.column_names.iter().map(Some));
+        let desc = RelationDesc::new(optimized_expr.typ(), view.column_names);
         let view = catalog::View {
             create_sql: view.create_sql,
             optimized_expr,

--- a/src/coord/tests/sql.rs
+++ b/src/coord/tests/sql.rs
@@ -24,7 +24,7 @@ use coord::catalog::{Catalog, CatalogItem, Table};
 use coord::session::Session;
 use expr::GlobalId;
 use ore::now::NOW_ZERO;
-use repr::{RelationDesc, RelationType};
+use repr::RelationDesc;
 use sql::ast::{Expr, Statement};
 use sql::names::{DatabaseSpecifier, FullName};
 use sql::plan::{resolve_names, PlanContext, QueryContext, QueryLifetime, StatementContext};
@@ -53,10 +53,7 @@ async fn datadriven() {
                         },
                         CatalogItem::Table(Table {
                             create_sql: "TODO".to_string(),
-                            desc: RelationDesc::new(
-                                RelationType::new(Vec::new()),
-                                Vec::<Option<String>>::new(),
-                            ),
+                            desc: RelationDesc::empty(),
                             defaults: vec![Expr::null(); 0],
                             conn_id: None,
                             depends_on: vec![],

--- a/src/dataflow-types/src/logging.rs
+++ b/src/dataflow-types/src/logging.rs
@@ -87,33 +87,33 @@ impl LogVariant {
     pub fn desc(&self) -> RelationDesc {
         match self {
             LogVariant::Timely(TimelyLog::Operates) => RelationDesc::empty()
-                .with_named_column("id", ScalarType::Int64.nullable(false))
-                .with_named_column("worker", ScalarType::Int64.nullable(false))
-                .with_named_column("name", ScalarType::String.nullable(false))
+                .with_column("id", ScalarType::Int64.nullable(false))
+                .with_column("worker", ScalarType::Int64.nullable(false))
+                .with_column("name", ScalarType::String.nullable(false))
                 .with_key(vec![0, 1]),
 
             LogVariant::Timely(TimelyLog::Channels) => RelationDesc::empty()
-                .with_named_column("id", ScalarType::Int64.nullable(false))
-                .with_named_column("worker", ScalarType::Int64.nullable(false))
-                .with_named_column("source_node", ScalarType::Int64.nullable(false))
-                .with_named_column("source_port", ScalarType::Int64.nullable(false))
-                .with_named_column("target_node", ScalarType::Int64.nullable(false))
-                .with_named_column("target_port", ScalarType::Int64.nullable(false))
+                .with_column("id", ScalarType::Int64.nullable(false))
+                .with_column("worker", ScalarType::Int64.nullable(false))
+                .with_column("source_node", ScalarType::Int64.nullable(false))
+                .with_column("source_port", ScalarType::Int64.nullable(false))
+                .with_column("target_node", ScalarType::Int64.nullable(false))
+                .with_column("target_port", ScalarType::Int64.nullable(false))
                 .with_key(vec![0, 1]),
 
             LogVariant::Timely(TimelyLog::Elapsed) => RelationDesc::empty()
-                .with_named_column("id", ScalarType::Int64.nullable(false))
-                .with_named_column("worker", ScalarType::Int64.nullable(false)),
+                .with_column("id", ScalarType::Int64.nullable(false))
+                .with_column("worker", ScalarType::Int64.nullable(false)),
 
             LogVariant::Timely(TimelyLog::Histogram) => RelationDesc::empty()
-                .with_named_column("id", ScalarType::Int64.nullable(false))
-                .with_named_column("worker", ScalarType::Int64.nullable(false))
-                .with_named_column("duration_ns", ScalarType::Int64.nullable(false)),
+                .with_column("id", ScalarType::Int64.nullable(false))
+                .with_column("worker", ScalarType::Int64.nullable(false))
+                .with_column("duration_ns", ScalarType::Int64.nullable(false)),
 
             LogVariant::Timely(TimelyLog::Addresses) => RelationDesc::empty()
-                .with_named_column("id", ScalarType::Int64.nullable(false))
-                .with_named_column("worker", ScalarType::Int64.nullable(false))
-                .with_named_column(
+                .with_column("id", ScalarType::Int64.nullable(false))
+                .with_column("worker", ScalarType::Int64.nullable(false))
+                .with_column(
                     "address",
                     ScalarType::List {
                         element_type: Box::new(ScalarType::Int64),
@@ -124,22 +124,22 @@ impl LogVariant {
                 .with_key(vec![0, 1]),
 
             LogVariant::Timely(TimelyLog::Parks) => RelationDesc::empty()
-                .with_named_column("worker", ScalarType::Int64.nullable(false))
-                .with_named_column("slept_for", ScalarType::Int64.nullable(false))
-                .with_named_column("requested", ScalarType::Int64.nullable(false)),
+                .with_column("worker", ScalarType::Int64.nullable(false))
+                .with_column("slept_for", ScalarType::Int64.nullable(false))
+                .with_column("requested", ScalarType::Int64.nullable(false)),
 
             LogVariant::Timely(TimelyLog::MessagesReceived) => RelationDesc::empty()
-                .with_named_column("channel", ScalarType::Int64.nullable(false))
-                .with_named_column("source_worker", ScalarType::Int64.nullable(false))
-                .with_named_column("target_worker", ScalarType::Int64.nullable(false)),
+                .with_column("channel", ScalarType::Int64.nullable(false))
+                .with_column("source_worker", ScalarType::Int64.nullable(false))
+                .with_column("target_worker", ScalarType::Int64.nullable(false)),
 
             LogVariant::Timely(TimelyLog::MessagesSent) => RelationDesc::empty()
-                .with_named_column("channel", ScalarType::Int64.nullable(false))
-                .with_named_column("source_worker", ScalarType::Int64.nullable(false))
-                .with_named_column("target_worker", ScalarType::Int64.nullable(false)),
+                .with_column("channel", ScalarType::Int64.nullable(false))
+                .with_column("source_worker", ScalarType::Int64.nullable(false))
+                .with_column("target_worker", ScalarType::Int64.nullable(false)),
 
             LogVariant::Timely(TimelyLog::Reachability) => RelationDesc::empty()
-                .with_named_column(
+                .with_column(
                     "address",
                     ScalarType::List {
                         element_type: Box::new(ScalarType::Int64),
@@ -147,60 +147,60 @@ impl LogVariant {
                     }
                     .nullable(false),
                 )
-                .with_named_column("port", ScalarType::Int64.nullable(false))
-                .with_named_column("worker", ScalarType::Int64.nullable(false))
-                .with_named_column("update_type", ScalarType::String.nullable(false))
-                .with_named_column("timestamp", ScalarType::Int64.nullable(true)),
+                .with_column("port", ScalarType::Int64.nullable(false))
+                .with_column("worker", ScalarType::Int64.nullable(false))
+                .with_column("update_type", ScalarType::String.nullable(false))
+                .with_column("timestamp", ScalarType::Int64.nullable(true)),
 
             LogVariant::Differential(DifferentialLog::ArrangementBatches)
             | LogVariant::Differential(DifferentialLog::ArrangementRecords)
             | LogVariant::Differential(DifferentialLog::Sharing) => RelationDesc::empty()
-                .with_named_column("operator", ScalarType::Int64.nullable(false))
-                .with_named_column("worker", ScalarType::Int64.nullable(false)),
+                .with_column("operator", ScalarType::Int64.nullable(false))
+                .with_column("worker", ScalarType::Int64.nullable(false)),
 
             LogVariant::Materialized(MaterializedLog::DataflowCurrent) => RelationDesc::empty()
-                .with_named_column("name", ScalarType::String.nullable(false))
-                .with_named_column("worker", ScalarType::Int64.nullable(false))
+                .with_column("name", ScalarType::String.nullable(false))
+                .with_column("worker", ScalarType::Int64.nullable(false))
                 .with_key(vec![0, 1]),
 
             LogVariant::Materialized(MaterializedLog::SourceInfo) => RelationDesc::empty()
-                .with_named_column("source_name", ScalarType::String.nullable(false))
-                .with_named_column("source_id", ScalarType::String.nullable(false))
-                .with_named_column("dataflow_id", ScalarType::Int64.nullable(false))
-                .with_named_column("partition_id", ScalarType::String.nullable(true))
-                .with_named_column("offset", ScalarType::Int64.nullable(false))
-                .with_named_column("timestamp", ScalarType::Int64.nullable(false))
+                .with_column("source_name", ScalarType::String.nullable(false))
+                .with_column("source_id", ScalarType::String.nullable(false))
+                .with_column("dataflow_id", ScalarType::Int64.nullable(false))
+                .with_column("partition_id", ScalarType::String.nullable(true))
+                .with_column("offset", ScalarType::Int64.nullable(false))
+                .with_column("timestamp", ScalarType::Int64.nullable(false))
                 .with_key(vec![0, 1, 2, 3]),
 
             LogVariant::Materialized(MaterializedLog::DataflowDependency) => RelationDesc::empty()
-                .with_named_column("dataflow", ScalarType::String.nullable(false))
-                .with_named_column("source", ScalarType::String.nullable(false))
-                .with_named_column("worker", ScalarType::Int64.nullable(false)),
+                .with_column("dataflow", ScalarType::String.nullable(false))
+                .with_column("source", ScalarType::String.nullable(false))
+                .with_column("worker", ScalarType::Int64.nullable(false)),
 
             LogVariant::Materialized(MaterializedLog::FrontierCurrent) => RelationDesc::empty()
-                .with_named_column("global_id", ScalarType::String.nullable(false))
-                .with_named_column("worker", ScalarType::Int64.nullable(false))
-                .with_named_column("time", ScalarType::Int64.nullable(false)),
+                .with_column("global_id", ScalarType::String.nullable(false))
+                .with_column("worker", ScalarType::Int64.nullable(false))
+                .with_column("time", ScalarType::Int64.nullable(false)),
 
             LogVariant::Materialized(MaterializedLog::KafkaSourceStatistics) => {
                 RelationDesc::empty()
-                    .with_named_column("source_id", ScalarType::String.nullable(false))
-                    .with_named_column("worker", ScalarType::Int64.nullable(false))
-                    .with_named_column("statistics", ScalarType::Jsonb.nullable(false))
+                    .with_column("source_id", ScalarType::String.nullable(false))
+                    .with_column("worker", ScalarType::Int64.nullable(false))
+                    .with_column("statistics", ScalarType::Jsonb.nullable(false))
                     .with_key(vec![0, 1])
             }
 
             LogVariant::Materialized(MaterializedLog::PeekCurrent) => RelationDesc::empty()
-                .with_named_column("uuid", ScalarType::String.nullable(false))
-                .with_named_column("worker", ScalarType::Int64.nullable(false))
-                .with_named_column("id", ScalarType::String.nullable(false))
-                .with_named_column("time", ScalarType::Int64.nullable(false))
+                .with_column("uuid", ScalarType::String.nullable(false))
+                .with_column("worker", ScalarType::Int64.nullable(false))
+                .with_column("id", ScalarType::String.nullable(false))
+                .with_column("time", ScalarType::Int64.nullable(false))
                 .with_key(vec![0, 1]),
 
             LogVariant::Materialized(MaterializedLog::PeekDuration) => RelationDesc::empty()
-                .with_named_column("worker", ScalarType::Int64.nullable(false))
-                .with_named_column("duration_ns", ScalarType::Int64.nullable(false))
-                .with_named_column("count", ScalarType::Int64.nullable(false))
+                .with_column("worker", ScalarType::Int64.nullable(false))
+                .with_column("duration_ns", ScalarType::Int64.nullable(false))
+                .with_column("count", ScalarType::Int64.nullable(false))
                 .with_key(vec![0, 1]),
         }
     }

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -449,9 +449,7 @@ where
                                             ScalarType::Record { fields, .. } => fields.clone(),
                                             _ => unreachable!(),
                                         };
-                                        let row_desc = RelationDesc::from_names_and_types(
-                                            fields.into_iter().map(|(n, t)| (Some(n), t)),
-                                        );
+                                        let row_desc = RelationDesc::from_names_and_types(fields);
                                         // these must be available because the DDL parsing logic already
                                         // checks this and bails in case the key is not correct
                                         Some(dataflow_types::match_key_indices(&key_desc, &row_desc).expect("Invalid key schema, this indicates a bug in Materialize"))

--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -78,8 +78,8 @@ mod tests {
 
         let desc = schema_to_relationdesc(parse_schema(schema)?)?;
         let expected_desc = RelationDesc::empty()
-            .with_named_column("f1", ScalarType::Int32.nullable(false))
-            .with_named_column("f2", ScalarType::String.nullable(false));
+            .with_column("f1", ScalarType::Int32.nullable(false))
+            .with_column("f2", ScalarType::String.nullable(false));
 
         assert_eq!(desc, expected_desc);
         Ok(())
@@ -162,7 +162,7 @@ mod tests {
             ),
         ];
         for (typ, datum, expected) in valid_pairings {
-            let desc = RelationDesc::empty().with_named_column("column1", typ.nullable(false));
+            let desc = RelationDesc::empty().with_column("column1", typ.nullable(false));
             let schema_generator = AvroSchemaGenerator::new(None, desc, false);
             let avro_value =
                 encode_datums_as_avro(std::iter::once(datum), schema_generator.value_columns());

--- a/src/interchange/src/avro/envelope_cdc_v2.rs
+++ b/src/interchange/src/avro/envelope_cdc_v2.rs
@@ -270,8 +270,8 @@ mod tests {
     #[test]
     fn test_roundtrip() {
         let desc = RelationDesc::empty()
-            .with_named_column("id", ScalarType::Int64.nullable(false))
-            .with_named_column("price", ScalarType::Float64.nullable(true));
+            .with_column("id", ScalarType::Int64.nullable(false))
+            .with_column("price", ScalarType::Float64.nullable(true));
 
         let encoder = Encoder::new(desc.clone());
         let row_schema =

--- a/src/interchange/src/encode.rs
+++ b/src/interchange/src/encode.rs
@@ -36,14 +36,7 @@ impl<'a> TypedDatum<'a> {
 /// Extracts deduplicated column names and types from a relation description.
 pub fn column_names_and_types(desc: RelationDesc) -> Vec<(ColumnName, ColumnType)> {
     // Invent names for columns that don't have a name.
-    let mut columns: Vec<_> = desc
-        .into_iter()
-        .enumerate()
-        .map(|(i, (name, ty))| match name {
-            None => (ColumnName::from(format!("column{}", i + 1)), ty),
-            Some(name) => (name, ty),
-        })
-        .collect();
+    let mut columns: Vec<_> = desc.into_iter().collect();
 
     // Deduplicate names.
     let mut seen = HashSet::new();

--- a/src/interchange/src/envelopes.rs
+++ b/src/interchange/src/envelopes.rs
@@ -125,7 +125,7 @@ pub fn dbz_desc(desc: RelationDesc) -> RelationDesc {
         },
     };
     let typ = RelationType::new(vec![row.clone(), row]);
-    RelationDesc::new(typ, vec![Some("before"), Some("after")])
+    RelationDesc::new(typ, ["before", "after"])
 }
 
 pub fn dbz_format(rp: &mut Row, dp: DiffPair<Row>) -> Row {

--- a/src/materialized/tests/server.rs
+++ b/src/materialized/tests/server.rs
@@ -278,7 +278,7 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
         TestCase {
             query: "select 1; select 2",
             status: StatusCode::OK,
-            body: r#"{"results":[{"rows":[[1]],"col_names":[null]},{"rows":[[2]],"col_names":[null]}]}"#,
+            body: r#"{"results":[{"rows":[[1]],"col_names":["?column?"]},{"rows":[[2]],"col_names":["?column?"]}]}"#,
         },
         // CREATEs should not work.
         TestCase {

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -1034,7 +1034,7 @@ pub fn encode_row_description(
         .map(|((name, typ), format)| {
             let pg_type = pgrepr::Type::from(&typ.scalar_type);
             FieldDescription {
-                name: name.cloned().unwrap_or_else(|| "?column?".into()),
+                name: name.clone(),
                 table_id: 0,
                 column_id: 0,
                 type_oid: pg_type.oid(),

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -238,8 +238,8 @@ impl From<&ColumnName> for ColumnName {
 /// use repr::{ColumnType, RelationDesc, ScalarType};
 ///
 /// let desc = RelationDesc::empty()
-///     .with_named_column("id", ScalarType::Int64.nullable(false))
-///     .with_named_column("price", ScalarType::Float64.nullable(true));
+///     .with_column("id", ScalarType::Int64.nullable(false))
+///     .with_column("price", ScalarType::Float64.nullable(true));
 /// ```
 ///
 /// In more complicated cases, like when constructing a `RelationDesc` in
@@ -252,17 +252,16 @@ impl From<&ColumnName> for ColumnName {
 /// # fn plan_query(_: &str) -> repr::RelationType { repr::RelationType::new(vec![]) }
 /// let relation_type = plan_query("SELECT * FROM table");
 /// let names = (0..relation_type.arity()).map(|i| match i {
-///     0 => Some("first"),
-///     1 => Some("second"),
-///     // Leave the rest of the columns unnamed.
-///     _ => None,
+///     0 => "first",
+///     1 => "second",
+///     _ => "unknown",
 /// });
 /// let desc = RelationDesc::new(relation_type, names);
 /// ```
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub struct RelationDesc {
     typ: RelationType,
-    names: Vec<Option<ColumnName>>,
+    names: Vec<ColumnName>,
 }
 
 impl RelationDesc {
@@ -284,17 +283,17 @@ impl RelationDesc {
     /// items in `names`.
     pub fn new<I, N>(typ: RelationType, names: I) -> Self
     where
-        I: IntoIterator<Item = Option<N>>,
+        I: IntoIterator<Item = N>,
         N: Into<ColumnName>,
     {
-        let names: Vec<_> = names.into_iter().map(|n| n.map(Into::into)).collect();
+        let names: Vec<_> = names.into_iter().map(|name| name.into()).collect();
         assert_eq!(typ.column_types.len(), names.len());
         RelationDesc { typ, names }
     }
 
     pub fn from_names_and_types<I, T, N>(iter: I) -> Self
     where
-        I: IntoIterator<Item = (Option<N>, T)>,
+        I: IntoIterator<Item = (N, T)>,
         T: Into<ColumnType>,
         N: Into<ColumnName>,
     {
@@ -315,22 +314,14 @@ impl RelationDesc {
         self
     }
 
-    /// Appends an optionally named column with the specified column type.
-    pub fn with_column<N>(mut self, name: Option<N>, column_type: ColumnType) -> Self
+    /// Appends a column with the specified name and type.
+    pub fn with_column<N>(mut self, name: N, column_type: ColumnType) -> Self
     where
         N: Into<ColumnName>,
     {
         self.typ.column_types.push(column_type);
-        self.names.push(name.map(|n| n.into()));
+        self.names.push(name.into());
         self
-    }
-
-    /// Appends a named column with the specified column type.
-    pub fn with_named_column<N>(self, name: N, column_type: ColumnType) -> Self
-    where
-        N: Into<ColumnName>,
-    {
-        self.with_column(Some(name), column_type)
     }
 
     /// Adds a new key for the relation.
@@ -354,7 +345,7 @@ impl RelationDesc {
     /// items in `names`.
     pub fn with_names<I, N>(self, names: I) -> Self
     where
-        I: IntoIterator<Item = Option<N>>,
+        I: IntoIterator<Item = N>,
         N: Into<ColumnName>,
     {
         Self::new(self.typ, names)
@@ -371,7 +362,7 @@ impl RelationDesc {
     }
 
     /// Returns an iterator over the columns in this relation.
-    pub fn iter(&self) -> impl Iterator<Item = (Option<&ColumnName>, &ColumnType)> {
+    pub fn iter(&self) -> impl Iterator<Item = (&ColumnName, &ColumnType)> {
         self.iter_names().zip(self.iter_types())
     }
 
@@ -381,8 +372,8 @@ impl RelationDesc {
     }
 
     /// Returns an iterator over the names of the columns in this relation.
-    pub fn iter_names(&self) -> impl Iterator<Item = Option<&ColumnName>> {
-        self.names.iter().map(|n| n.as_ref())
+    pub fn iter_names(&self) -> impl Iterator<Item = &ColumnName> {
+        self.names.iter()
     }
 
     /// Finds a column by name.
@@ -392,7 +383,7 @@ impl RelationDesc {
     /// specified name, the leftmost column is returned.
     pub fn get_by_name(&self, name: &ColumnName) -> Option<(usize, &ColumnType)> {
         self.iter_names()
-            .position(|n| n == Some(name))
+            .position(|n| n == name)
             .map(|i| (i, &self.typ.column_types[i]))
     }
 
@@ -401,8 +392,8 @@ impl RelationDesc {
     /// # Panics
     ///
     /// Panics if `i` is not a valid column index.
-    pub fn get_name(&self, i: usize) -> Option<&ColumnName> {
-        self.names[i].as_ref()
+    pub fn get_name(&self, i: usize) -> &ColumnName {
+        &self.names[i]
     }
 
     /// Gets the name of the `i`th column if that column name is unambiguous.
@@ -414,9 +405,9 @@ impl RelationDesc {
     ///
     /// Panics if `i` is not a valid column index.
     pub fn get_unambiguous_name(&self, i: usize) -> Option<&ColumnName> {
-        let name = self.names[i].as_ref();
-        if self.iter_names().filter(|n| n == &name).count() == 1 {
-            name
+        let name = &self.names[i];
+        if self.iter_names().filter(|n| *n == name).count() == 1 {
+            Some(name)
         } else {
             None
         }
@@ -427,9 +418,10 @@ impl RelationDesc {
     /// n.b. The only constraint MZ currently supports in NOT NULL, but this
     /// structure will  be simple to extend.
     pub fn constraints_met(&self, i: usize, d: &Datum) -> Result<(), NotNullViolation> {
-        let (name, typ) = (self.names[i].as_ref(), &self.typ.column_types[i]);
+        let name = &self.names[i];
+        let typ = &self.typ.column_types[i];
         if d == &Datum::Null && !typ.nullable {
-            Err(NotNullViolation(name.cloned()))
+            Err(NotNullViolation(name.clone()))
         } else {
             Ok(())
         }
@@ -437,8 +429,8 @@ impl RelationDesc {
 }
 
 impl IntoIterator for RelationDesc {
-    type Item = (Option<ColumnName>, ColumnType);
-    type IntoIter = iter::Zip<vec::IntoIter<Option<ColumnName>>, vec::IntoIter<ColumnType>>;
+    type Item = (ColumnName, ColumnType);
+    type IntoIter = iter::Zip<vec::IntoIter<ColumnName>, vec::IntoIter<ColumnType>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.names.into_iter().zip(self.typ.column_types)
@@ -447,18 +439,14 @@ impl IntoIterator for RelationDesc {
 
 /// Expression violated not-null constraint on named column
 #[derive(Debug, PartialEq, Eq)]
-pub struct NotNullViolation(pub Option<ColumnName>);
+pub struct NotNullViolation(pub ColumnName);
 
 impl fmt::Display for NotNullViolation {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
             "null value in column {} violates not-null constraint",
-            self.0
-                .as_ref()
-                .unwrap_or(&ColumnName::from("unnamed column"))
-                .as_str()
-                .quoted()
+            self.0.as_str().quoted()
         )
     }
 }

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -374,7 +374,7 @@ fn sql_impl_table_func(sql: &'static str) -> Operation<TableFuncPlan> {
         expr.splice_parameters(&args, 0);
         Ok(TableFuncPlan {
             expr,
-            column_names: scope.column_names().map(|n| n.cloned()).collect(),
+            column_names: scope.column_names().cloned().collect(),
         })
     })
 }
@@ -1269,7 +1269,7 @@ macro_rules! builtins {
 #[derive(Debug)]
 pub struct TableFuncPlan {
     pub expr: HirRelationExpr,
-    pub column_names: Vec<Option<ColumnName>>,
+    pub column_names: Vec<ColumnName>,
 }
 
 #[derive(Debug)]
@@ -1980,7 +1980,7 @@ lazy_static! {
                             func: TableFunc::GenerateSeriesInt32,
                             exprs,
                         },
-                        column_names: vec![Some("generate_series".into())],
+                        column_names: vec!["generate_series".into()],
                     })
                 }), 1066;
                 params!(Int32, Int32) => Operation::binary(move |_ecx, start, stop| {
@@ -1989,7 +1989,7 @@ lazy_static! {
                             func: TableFunc::GenerateSeriesInt32,
                             exprs: vec![start, stop, HirScalarExpr::literal(Datum::Int32(1), ScalarType::Int32)],
                         },
-                        column_names: vec![Some("generate_series".into())],
+                        column_names: vec!["generate_series".into()],
                     })
                 }), 1067;
                 params!(Int64, Int64, Int64) => Operation::variadic(move |_ecx, exprs| {
@@ -1998,7 +1998,7 @@ lazy_static! {
                             func: TableFunc::GenerateSeriesInt64,
                             exprs,
                         },
-                        column_names: vec![Some("generate_series".into())],
+                        column_names: vec!["generate_series".into()],
                     })
                 }), 1068;
                 params!(Int64, Int64) => Operation::binary(move |_ecx, start, stop| {
@@ -2009,7 +2009,7 @@ lazy_static! {
                             func: TableFunc::GenerateSeriesInt64,
                             exprs: vec![start, stop, HirScalarExpr::Literal(row, column_type)],
                         },
-                        column_names: vec![Some("generate_series".into())],
+                        column_names: vec!["generate_series".into()],
                     })
                 }), 1069;
                 params!(Timestamp, Timestamp, Interval) => Operation::variadic(move |_ecx, exprs| {
@@ -2018,7 +2018,7 @@ lazy_static! {
                             func: TableFunc::GenerateSeriesTimestamp,
                             exprs,
                         },
-                        column_names: vec![Some("generate_series".into())],
+                        column_names: vec!["generate_series".into()],
                     })
                 }), 938;
                 params!(TimestampTz, TimestampTz, Interval) => Operation::variadic(move |_ecx, exprs| {
@@ -2027,7 +2027,7 @@ lazy_static! {
                             func: TableFunc::GenerateSeriesTimestampTz,
                             exprs,
                         },
-                        column_names: vec![Some("generate_series".into())],
+                        column_names: vec!["generate_series".into()],
                     })
                 }), 939;
             },
@@ -2039,7 +2039,7 @@ lazy_static! {
                             func: TableFunc::GenerateSubscriptsArray,
                             exprs,
                         },
-                        column_names: vec![Some("generate_subscripts".into())],
+                        column_names: vec!["generate_subscripts".into()],
                     })
                 }), 1192;
             },
@@ -2051,7 +2051,7 @@ lazy_static! {
                             func: TableFunc::JsonbArrayElements { stringify: false },
                             exprs: vec![jsonb],
                         },
-                        column_names: vec![Some("value".into())],
+                        column_names: vec!["value".into()],
                     })
                 }), 3219;
             },
@@ -2062,7 +2062,7 @@ lazy_static! {
                             func: TableFunc::JsonbArrayElements { stringify: true },
                             exprs: vec![jsonb],
                         },
-                        column_names: vec![Some("value".into())],
+                        column_names: vec!["value".into()],
                     })
                 }), 3465;
             },
@@ -2073,7 +2073,7 @@ lazy_static! {
                             func: TableFunc::JsonbEach { stringify: false },
                             exprs: vec![jsonb],
                         },
-                        column_names: vec![Some("key".into()), Some("value".into())],
+                        column_names: vec!["key".into(), "value".into()],
                     })
                 }), 3208;
             },
@@ -2084,7 +2084,7 @@ lazy_static! {
                             func: TableFunc::JsonbEach { stringify: true },
                             exprs: vec![jsonb],
                         },
-                        column_names: vec![Some("key".into()), Some("value".into())],
+                        column_names: vec!["key".into(), "value".into()],
                     })
                 }), 3932;
             },
@@ -2095,7 +2095,7 @@ lazy_static! {
                             func: TableFunc::JsonbObjectKeys,
                             exprs: vec![jsonb],
                         },
-                        column_names: vec![Some("jsonb_object_keys".into())],
+                        column_names: vec!["jsonb_object_keys".into()],
                     })
                 }), 3931;
             },
@@ -2144,7 +2144,7 @@ lazy_static! {
                             func: TableFunc::CsvExtract(ncols),
                             exprs: vec![input],
                         },
-                        column_names: (1..=ncols).map(|i| Some(format!("column{}", i).into())).collect(),
+                        column_names: (1..=ncols).map(|i| format!("column{}", i).into()).collect(),
                     })
                 }), oid::FUNC_CSV_EXTRACT_OID;
             },
@@ -2218,8 +2218,7 @@ lazy_static! {
                     let column_names = regex
                         .capture_groups_iter()
                         .map(|cg| {
-                            let name = cg.name.clone().unwrap_or_else(|| format!("column{}", cg.index));
-                            Some(name.into())
+                            cg.name.clone().unwrap_or_else(|| format!("column{}", cg.index)).into()
                         })
                         .collect();
                     Ok(TableFuncPlan {
@@ -2251,7 +2250,7 @@ lazy_static! {
                             func: TableFunc::UnnestArray { el_typ },
                             exprs: vec![e],
                         },
-                        column_names: vec![Some("unnest".into())],
+                        column_names: vec!["unnest".into()],
                     })
                 }), 2331;
                 vec![ListAny] => Operation::unary(move |ecx, e| {
@@ -2261,7 +2260,7 @@ lazy_static! {
                             func: TableFunc::UnnestList { el_typ },
                             exprs: vec![e],
                         },
-                        column_names: vec![Some("unnest".into())],
+                        column_names: vec!["unnest".into()],
                     })
                 }), oid::FUNC_UNNEST_LIST_OID;
             }

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -367,7 +367,8 @@ pub struct Source {
     pub connector: SourceConnector,
     pub bare_desc: RelationDesc,
     pub expr: ::expr::MirRelationExpr,
-    pub column_names: Vec<Option<ColumnName>>, // Column names for the transformed source; i.e. the expr
+    /// Column names for the transformed source; i.e. the expr
+    pub column_names: Vec<ColumnName>,
 }
 
 #[derive(Clone, Debug)]

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -70,10 +70,7 @@ impl PlanError {
     pub(crate) fn ungrouped_column(item: &ScopeItem) -> PlanError {
         PlanError::UngroupedColumn {
             table: item.table_name.clone(),
-            column: item
-                .column_name
-                .clone()
-                .unwrap_or_else(|| ColumnName::from("?column?")),
+            column: item.column_name.clone(),
         }
     }
 }

--- a/src/sql/src/plan/plan_utils.rs
+++ b/src/sql/src/plan/plan_utils.rs
@@ -49,7 +49,7 @@ pub fn maybe_rename_columns(
 
     let new_names = column_names
         .iter()
-        .map(|n| Some(normalize::column_name(n.clone())));
+        .map(|n| normalize::column_name(n.clone()));
 
     Ok(desc.with_names(new_names))
 }

--- a/src/sql/src/plan/statement/scl.rs
+++ b/src/sql/src/plan/statement/scl.rs
@@ -61,12 +61,11 @@ pub fn describe_show_variable(
 ) -> Result<StatementDesc, anyhow::Error> {
     let desc = if variable.as_str() == UncasedStr::new("ALL") {
         RelationDesc::empty()
-            .with_named_column("name", ScalarType::String.nullable(false))
-            .with_named_column("setting", ScalarType::String.nullable(false))
-            .with_named_column("description", ScalarType::String.nullable(false))
+            .with_column("name", ScalarType::String.nullable(false))
+            .with_column("setting", ScalarType::String.nullable(false))
+            .with_column("description", ScalarType::String.nullable(false))
     } else {
-        RelationDesc::empty()
-            .with_named_column(variable.as_str(), ScalarType::String.nullable(false))
+        RelationDesc::empty().with_column(variable.as_str(), ScalarType::String.nullable(false))
     };
     Ok(StatementDesc::new(Some(desc)))
 }

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -40,8 +40,8 @@ pub fn describe_show_create_view(
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(Some(
         RelationDesc::empty()
-            .with_named_column("View", ScalarType::String.nullable(false))
-            .with_named_column("Create View", ScalarType::String.nullable(false)),
+            .with_column("View", ScalarType::String.nullable(false))
+            .with_column("Create View", ScalarType::String.nullable(false)),
     )))
 }
 
@@ -96,8 +96,8 @@ pub fn describe_show_create_table(
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(Some(
         RelationDesc::empty()
-            .with_named_column("Table", ScalarType::String.nullable(false))
-            .with_named_column("Create Table", ScalarType::String.nullable(false)),
+            .with_column("Table", ScalarType::String.nullable(false))
+            .with_column("Create Table", ScalarType::String.nullable(false)),
     )))
 }
 
@@ -124,8 +124,8 @@ pub fn describe_show_create_source(
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(Some(
         RelationDesc::empty()
-            .with_named_column("Source", ScalarType::String.nullable(false))
-            .with_named_column("Create Source", ScalarType::String.nullable(false)),
+            .with_column("Source", ScalarType::String.nullable(false))
+            .with_column("Create Source", ScalarType::String.nullable(false)),
     )))
 }
 
@@ -152,8 +152,8 @@ pub fn describe_show_create_sink(
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(Some(
         RelationDesc::empty()
-            .with_named_column("Sink", ScalarType::String.nullable(false))
-            .with_named_column("Create Sink", ScalarType::String.nullable(false)),
+            .with_column("Sink", ScalarType::String.nullable(false))
+            .with_column("Create Sink", ScalarType::String.nullable(false)),
     )))
 }
 
@@ -180,8 +180,8 @@ pub fn describe_show_create_index(
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(Some(
         RelationDesc::empty()
-            .with_named_column("Index", ScalarType::String.nullable(false))
-            .with_named_column("Create Index", ScalarType::String.nullable(false)),
+            .with_column("Index", ScalarType::String.nullable(false))
+            .with_column("Create Index", ScalarType::String.nullable(false)),
     )))
 }
 

--- a/src/sql/src/query_model/test.rs
+++ b/src/sql/src/query_model/test.rs
@@ -275,7 +275,7 @@ pub enum TestCatalogCommand {
         source_name: String,
         typ: RelationType,
         #[serde(default)]
-        column_names: Vec<Option<String>>,
+        column_names: Vec<String>,
     },
 }
 

--- a/test/testdrive/avro-decode-no-record.td
+++ b/test/testdrive/avro-decode-no-record.td
@@ -11,17 +11,20 @@
 # Decoding a schema that is not a record results in a relation with a single column
 #
 
-$ set no-record={"type": "map", "values" : "int" }
+$ set no-record
+"int"
 
 $ kafka-create-topic topic=avro-decode-no-record
 
 $ kafka-ingest format=avro topic=avro-decode-no-record schema=${no-record} timestamp=1
-{"f1":123}
+123
 
 > CREATE MATERIALIZED SOURCE avro_decode_no_record
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avro-decode-no-record-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${no-record}'
   ENVELOPE NONE
 
-> SELECT pg_typeof(data) FROM avro_decode_no_record a(data)
-map[text=>integer]
+> SHOW COLUMNS FROM avro_decode_no_record
+name       nullable  type
+----------------------------
+\?column?  false     integer


### PR DESCRIPTION
As of recently, we no longer permit sources or views to contain unnamed columns.  Instead, we generate the concrete name "?column?" at the earliest moment possible, so to the rest of the system it appears that the user has explicitly named the column "?column?".
    
So, this commit changes our codebase to use `ColumnName` rather than `Option<ColumnName>` as the type of a column. This simplifies almost all code that touches column names, and also avoids a lot of "expect" and "unwrap" calls whose correctness was hard to verify.

There should be no externally-visible behavior change whatsoever; if there is, it's a bug!

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
