### PR TITLE
scratch: handle host repository being in detached HEAD mode

### DIFF
--- a/misc/python/materialize/scratch.py
+++ b/misc/python/materialize/scratch.py
@@ -70,6 +70,10 @@ def delete_after(tags: Dict[str, str]) -> Optional[datetime.datetime]:
     return datetime.datetime.fromtimestamp(unix)
 
 
+def instance_host(instance: Instance) -> str:
+    return f"{ami_user(tags(instance))}@{instance.id}"
+
+
 def print_instances(ists: List[Instance], format: str) -> None:
     field_names = [
         "Name",
@@ -225,7 +229,14 @@ async def setup(
 def mkrepo(i: Instance, rev: str) -> None:
     mssh(i, "git init --bare materialize/.git")
     spawn.runv(
-        ["git", "push", f"{ami_user(tags(i))}@{i.instance_id}:materialize/.git"],
+        [
+            "git",
+            "push",
+            f"{instance_host(i)}:materialize/.git",
+            # Explicit refspec is required if the host repository is in detached
+            # HEAD mode.
+            "HEAD:refs/heads/scratch",
+        ],
         cwd=ROOT,
         env=dict(os.environ, GIT_SSH_COMMAND=" ".join(SSH_COMMAND)),
     )
@@ -350,7 +361,7 @@ def mssh(
     stdin: Union[None, int, IO[bytes], bytes] = None,
 ) -> None:
     """Runs a command over SSH via EC2 Instance Connect."""
-    host = f"{ami_user(tags(instance))}@{instance.id}"
+    host = instance_host(instance)
     # The actual invocation of SSH that `spawn.runv` wants to print is
     # unreadable quoted garbage, so we do our own printing here before the shell
     # quoting.


### PR DESCRIPTION
I broke this in #9714. CI uses detached head mode when spinning up the
periodic load test infrastructure.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
