### PR TITLE
scratch: use pydantic to decode JSON from stdin

### DIFF
--- a/ci/builder/requirements-dev.txt
+++ b/ci/builder/requirements-dev.txt
@@ -12,6 +12,7 @@ pdoc3==0.10.0
 prettytable==2.5.0
 psutil==5.8.0
 psycopg2==2.9.2
+pydantic==1.8.2
 pytest==6.2.5
 requests==2.26.0
 sqlparse==0.4.2

--- a/misc/python/materialize/cli/scratch/create.py
+++ b/misc/python/materialize/cli/scratch/create.py
@@ -74,19 +74,7 @@ def run(args: argparse.Namespace) -> None:
 
     extra_tags["LaunchedBy"] = whoami()
 
-    descs = [
-        MachineDesc(
-            name=obj["name"],
-            launch_script=obj.get("launch_script"),
-            instance_type=obj["instance_type"],
-            ami=obj["ami"],
-            ami_user=obj["ami_user"],
-            tags=obj.get("tags", dict()),
-            size_gb=obj["size_gb"],
-            checkout=obj.get("checkout", True),
-        )
-        for obj in multi_json(sys.stdin.read())
-    ]
+    descs = [MachineDesc.parse_obj(obj) for obj in multi_json(sys.stdin.read())]
 
     instances = launch_cluster(
         descs,

--- a/misc/python/materialize/scratch.py
+++ b/misc/python/materialize/scratch.py
@@ -15,7 +15,6 @@ import datetime
 import os
 import shlex
 import sys
-from dataclasses import dataclass
 from pathlib import Path
 from subprocess import CalledProcessError
 from typing import IO, Dict, List, NamedTuple, Optional, Union
@@ -28,6 +27,7 @@ from mypy_boto3_ec2.type_defs import (
     RunInstancesRequestRequestTypeDef,
 )
 from prettytable import PrettyTable
+from pydantic import BaseModel
 
 from materialize import git, spawn, ui, util
 
@@ -236,13 +236,12 @@ def mkrepo(i: Instance, rev: str) -> None:
     )
 
 
-@dataclass
-class MachineDesc:
+class MachineDesc(BaseModel):
     name: str
     launch_script: Optional[str]
     instance_type: str
     ami: str
-    tags: Dict[str, str]
+    tags: Dict[str, str] = {}
     size_gb: int
     checkout: bool = True
     ami_user: str = "ubuntu"


### PR DESCRIPTION
Pydantic is essentially a more powerful version of dataclasses that
supports producing an object from JSON. Using it removes some annoying
boilerplate in MachineDesc construction that is easy to forget to update
when adding a new field to MachineDesc.

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
