### PR TITLE
sql: restrict window function planning to SELECT and ORDER BY

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -164,6 +164,9 @@ changes that have not yet been documented.
 
 - Fix a problem when connecting with Npgsql 6.
 
+- **Breaking change.** Disallow window functions outside of `SELECT`
+  lists and `ORDER BY`.
+
 {{< comment >}}
 Only add new release notes above this line.
 

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -297,6 +297,7 @@ pub fn sql_impl(
             relation_type: &RelationType::empty(),
             allow_aggregates: false,
             allow_subqueries: true,
+            allow_windows: false,
         };
 
         // Plan the expression.

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -763,6 +763,7 @@ pub fn plan_hypothetical_cast(
         relation_type: &relation_type,
         allow_aggregates: false,
         allow_subqueries: true,
+        allow_windows: false,
     };
 
     let col_expr = HirScalarExpr::Column(ColumnRef {

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -442,3 +442,20 @@ EXPLAIN DECORRELATED PLAN FOR SELECT * FROM t2, LATERAL(SELECT t1.*, ROW_NUMBER(
 | Filter true
 
 EOF
+
+# Regression for #9749
+query error window functions are not allowed in ON
+WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
+SELECT * FROM t AS v JOIN t ON row_number() over () > 1;
+
+query error window functions are not allowed in WHERE
+WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
+SELECT * FROM t
+WHERE row_number() over () > 1;
+
+# When query.rs is allowed to plan window functions in DISTINCT ON, we
+# currently return incorrect output. Disable DISTINCT ON until fixed.
+query error window functions are not allowed in DISTINCT ON
+WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
+SELECT DISTINCT ON (row_number() OVER ()) *
+FROM t


### PR DESCRIPTION
Postgres docs say
> Window function calls are permitted only in the SELECT list and the ORDER BY
> clause of the query.

Restrict our planning by extending ExprContext. We cannot simply use
`allow_aggregates` because aggregates are acceptable in `HAVING`.

While allowed in `DISTINCT ON`, we incorrectly plan that, so disable
that context for now too.

See: https://www.postgresql.org/docs/14/sql-expressions.html#SYNTAX-WINDOW-FUNCTIONS

Fixes #9749

### Motivation

  * This PR fixes a recognized bug: #9749

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
