### PR TITLE
ci: ensure the deploy job waits for all tests to complete

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -381,23 +381,10 @@ steps:
           composition: python
           run: python
 
+  - wait: ~
+
   - id: deploy
     label: ":rocket: Deploy"
-    depends_on:
-      - build-aarch64
-      - lint-fast
-      - lint-slow
-      - cargo-test
-      - miri-test
-      - testdrive
-      - kafka-ssl
-      - kafka-krb5
-      - sqllogictest-fast
-      - streaming-demo
-      - chbench-demo
-      - catalog-compat
-      - lang-js
-      - metabase-demo
     trigger: deploy
     async: true
     branches: "main v*.*"


### PR DESCRIPTION
Maintaining this list by hand is onerous. Switch to a `wait` step, which
will automatically wait for all previous steps to complete.

Fix #9767.

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
