### PR TITLE
optbench: use pg8000 instead of psycopg2

### DIFF
--- a/misc/python/materialize/mzcompose.py
+++ b/misc/python/materialize/mzcompose.py
@@ -48,7 +48,7 @@ from typing import (
     cast,
 )
 
-import pg8000  # type: ignore
+import pg8000
 import pymysql
 import yaml
 

--- a/misc/python/materialize/optbench/sql.py
+++ b/misc/python/materialize/optbench/sql.py
@@ -13,10 +13,8 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, cast
 
 import numpy as np
-import psycopg2
-import psycopg2.extensions
-import sqlparse  # type: ignore
-from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
+import pg8000
+import sqlparse
 
 from . import Scenario, util
 
@@ -73,14 +71,8 @@ class Database:
         host: str,
         user: str,
     ) -> None:
-        kwargs = dict(
-            host=host,
-            port=port,
-            user=user,
-        )
-        logging.debug(f"Initialize Database with connection={kwargs}")
-        self.conn = psycopg2.connect(**kwargs)
-        self.conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)  # type: ignore
+        logging.debug(f"Initialize Database with host={host} port={port}, user={user}")
+        self.conn = pg8000.connect(host=host, port=port, user=user)
 
     def mz_version(self) -> str:
         result = self.query_one("SELECT mz_version()")
@@ -128,4 +120,4 @@ class Database:
 
 def parse_from_file(path: Path) -> List[str]:
     """Parses a *.sql file to a list of queries."""
-    return cast(List[str], sqlparse.split(path.read_text()))
+    return sqlparse.split(path.read_text())

--- a/misc/python/stubs/pg8000.pyi
+++ b/misc/python/stubs/pg8000.pyi
@@ -1,0 +1,28 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from typing import Any, ContextManager, Optional, Sequence
+
+class Connection:
+    autocommit: bool
+    def cursor(self) -> Cursor: ...
+
+class Cursor(ContextManager):
+    rowcount: int
+    def execute(self, sql: str) -> None: ...
+    def fetchall(self) -> Sequence[Sequence[Any]]: ...
+
+def connect(
+    host: str = ...,
+    port: int = ...,
+    user: str = ...,
+    database: Optional[str] = ...,
+    password: Optional[str] = ...,
+    timeout: Optional[int] = ...,
+) -> Connection: ...

--- a/misc/python/stubs/sqlparse.pyi
+++ b/misc/python/stubs/sqlparse.pyi
@@ -1,0 +1,12 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from typing import List
+
+def split(sql: str) -> List[str]: ...


### PR DESCRIPTION
Part of removing our dependency on psycopg2. See #9733.

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
