### PR TITLE
scratch: restore default instance profile

### DIFF
--- a/misc/python/materialize/cli/scratch/create.py
+++ b/misc/python/materialize/cli/scratch/create.py
@@ -15,7 +15,8 @@ from typing import Any, Dict, List
 
 from materialize.cli.scratch import check_required_vars
 from materialize.scratch import (
-    DEFAULT_SG_ID,
+    DEFAULT_INSTANCE_PROFILE_NAME,
+    DEFAULT_SECURITY_GROUP_ID,
     DEFAULT_SUBNET_ID,
     MachineDesc,
     launch_cluster,
@@ -52,9 +53,13 @@ def multi_json(s: str) -> List[Dict[Any, Any]]:
 def configure_parser(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--subnet-id", type=str, default=DEFAULT_SUBNET_ID)
     parser.add_argument("--key-name", type=str, required=False)
-    parser.add_argument("--security-group-id", type=str, default=DEFAULT_SG_ID)
+    parser.add_argument(
+        "--security-group-id", type=str, default=DEFAULT_SECURITY_GROUP_ID
+    )
     parser.add_argument("--extra-tags", type=str, required=False)
-    parser.add_argument("--instance-profile", type=str)
+    parser.add_argument(
+        "--instance-profile", type=str, default=DEFAULT_INSTANCE_PROFILE_NAME
+    )
     parser.add_argument("--output-format", choices=["table", "csv"], default="table")
     parser.add_argument("--git-rev", type=str, default="HEAD")
 

--- a/misc/python/materialize/scratch.py
+++ b/misc/python/materialize/scratch.py
@@ -33,7 +33,8 @@ from materialize import git, spawn, ui, util
 
 # Sane defaults for internal Materialize use in the scratch account
 DEFAULT_SUBNET_ID = "subnet-00bdfbd2d97eddb86"
-DEFAULT_SG_ID = "sg-06f780c8e23c0d944"
+DEFAULT_SECURITY_GROUP_ID = "sg-06f780c8e23c0d944"
+DEFAULT_INSTANCE_PROFILE_NAME = "admin-instance"
 
 SPEAKER = ui.speaker("scratch> ")
 ROOT = Path(os.environ["MZ_ROOT"])
@@ -264,8 +265,8 @@ def launch_cluster(
     nonce: Optional[str] = None,
     subnet_id: str = DEFAULT_SUBNET_ID,
     key_name: Optional[str] = None,
-    security_group_id: str = DEFAULT_SG_ID,
-    instance_profile: Optional[str] = None,
+    security_group_id: str = DEFAULT_SECURITY_GROUP_ID,
+    instance_profile: Optional[str] = DEFAULT_INSTANCE_PROFILE_NAME,
     extra_tags: Dict[str, str] = {},
     delete_after: datetime.datetime,
     git_rev: str = "HEAD",


### PR DESCRIPTION
It turns out the SSM instance profile wasn't just used for SSM; it was
also what granted administrator access to enable the Kinesis load test.
