### PR TITLE
Allow TD_TEST to be used to control the persistence test

### DIFF
--- a/src/testdrive/src/lib.rs
+++ b/src/testdrive/src/lib.rs
@@ -104,9 +104,9 @@ async fn run_line_reader(config: &Config, line_reader: &mut LineReader<'_>) -> R
             redo.await.map_err(|e| InputError { msg: e, pos: a.pos })?;
         }
 
-        let mut errors = Vec::new();
-
         if config.reset {
+            let mut errors = Vec::new();
+
             if let Err(e) = state.reset_s3().await {
                 errors.push(e);
             }
@@ -118,19 +118,19 @@ async fn run_line_reader(config: &Config, line_reader: &mut LineReader<'_>) -> R
             if let Err(e) = state.reset_kinesis().await {
                 errors.push(e);
             }
-        }
 
-        drop(state);
-        if let Err(e) = state_cleanup.await {
-            errors.push(e);
-        }
+            drop(state);
+            if let Err(e) = state_cleanup.await {
+                errors.push(e);
+            }
 
-        if !errors.is_empty() {
-            return Err(Error::General {
-                ctx: "Failed to clean up state at shut down".into(),
-                causes: errors.into_iter().map(Into::into).collect(),
-                hints: Vec::new(),
-            });
+            if !errors.is_empty() {
+                return Err(Error::General {
+                    ctx: "Failed to clean up state at shut down".into(),
+                    causes: errors.into_iter().map(Into::into).collect(),
+                    hints: Vec::new(),
+                });
+            }
         }
     }
     Ok(())


### PR DESCRIPTION
```
commit bc8ed2f7f683e69a4d8188adcd8a1499956419c6 (HEAD -> persistence-test-td-test-variable, origin/persistence-test-td-test-variable)
Author: Philip Stoev <pstoev@materialize.io>
Date:   Tue Dec 28 10:07:03 2021 +0100

    persistence,test: Allow $TD_TEST to be used to control the persistence test
    
    Allow the TD_TEST env variable to be used to control which .td test
    will be run as part of a persistence scenario:
    
    TD_TEST=wide ./mzcompose run kafka-sources

commit cbe09eceb4cc329c0be5bd9d5cde5186ca38d780
Author: Philip Stoev <pstoev@materialize.io>
Date:   Tue Dec 28 10:04:46 2021 +0100

    testdrive: do not reap errors with --no-reset
    
    If --no-reset is specified, do not reap and report any errors during
    teardown. This allows a .td test to crash Materialize via a failpoint
    without failing itself with a "connection lost" error upon termination.
```

### Motivation

  * This PR adds a feature that has not yet been specified.

Previously, running a portion of the persistence test required modifying the `mzcompose.py` file directly.

In addition, fix an issue with testdrive that could cause the test to fail if a failpoint is being used to crash Mz.