### PR TITLE
expr: make predicate canonizalization output reliable

### DIFF
--- a/src/expr/tests/test_runner.rs
+++ b/src/expr/tests/test_runner.rs
@@ -28,11 +28,30 @@ mod test {
     fn test_canonicalize_pred(s: &str) -> Result<Vec<MirScalarExpr>, String> {
         let mut input_stream = tokenize(&s)?.into_iter();
         let mut ctx = MirScalarExprDeserializeContext::default();
-        let mut predicates: Vec<MirScalarExpr> =
+        let input_predicates: Vec<MirScalarExpr> =
             deserialize(&mut input_stream, "Vec<MirScalarExpr>", &RTI, &mut ctx)?;
         let typ: RelationType = deserialize(&mut input_stream, "RelationType", &RTI, &mut ctx)?;
-        canonicalize_predicates(&mut predicates, &typ);
-        Ok(predicates)
+        // predicate canonicalization is meant to produce the same output regardless of the
+        // order of the input predicates.
+        let mut predicates1 = input_predicates.clone();
+        canonicalize_predicates(&mut predicates1, &typ);
+        let mut predicates2 = input_predicates.clone();
+        predicates2.sort();
+        canonicalize_predicates(&mut predicates2, &typ);
+        let mut predicates3 = input_predicates;
+        predicates3.sort();
+        predicates3.reverse();
+        canonicalize_predicates(&mut predicates3, &typ);
+        if predicates1 != predicates2 || predicates1 != predicates3 {
+            Err(format!(
+                "predicate canonicalization resulted in unrealiable output: [{}] vs [{}] vs [{}]",
+                separated(", ", predicates1.iter().map(|p| p.to_string())),
+                separated(", ", predicates2.iter().map(|p| p.to_string())),
+                separated(", ", predicates3.iter().map(|p| p.to_string())),
+            ))
+        } else {
+            Ok(predicates1)
+        }
     }
 
     /// Builds a [MapFilterProject] of a certain arity, then modifies it.

--- a/src/expr/tests/testdata/reduce
+++ b/src/expr/tests/testdata/reduce
@@ -738,3 +738,11 @@ canonicalize-join
 ----
 [#0 (isnull(#2) || isnull(#3))]
 [(#2 + #3) coalesce(#0, #1, false)]
+
+# impossible condition detection during predicate canonicalization produces
+# reliable output regardless of the order of the input predicates
+canonicalize
+[(call_binary eq #0 10) (call_unary is_null #0)]
+[int64]
+----
+false

--- a/src/transform/tests/testdata/canonicalize_mfp
+++ b/src/transform/tests/testdata/canonicalize_mfp
@@ -22,5 +22,5 @@ build apply=CanonicalizeMfp
 ----
 %0 =
 | Get x (u0)
-| Filter null
+| Filter false
 | Project (#1)

--- a/src/transform/tests/testdata/filter
+++ b/src/transform/tests/testdata/filter
@@ -42,7 +42,7 @@ build apply=FilterFusion
 ----
 %0 =
 | Get x (u0)
-| Filter false, (#0 = 1)
+| Filter false
 
 build apply=(FilterFusion,FoldConstants)
 (filter (filter (get x) [(call_unary is_null #0)]) [(call_binary eq #0 1)])
@@ -55,11 +55,11 @@ build apply=FilterFusion
 ----
 %0 =
 | Get x (u0)
-| Filter false, (#0 = #1)
+| Filter false
 
 build apply=FilterFusion
 (filter (filter (get x) [(call_unary is_null #0)]) [(call_unary not (call_unary is_null #0))])
 ----
 %0 =
 | Get x (u0)
-| Filter false, !(isnull(#0))
+| Filter false

--- a/test/sqllogictest/github-9782.slt
+++ b/test/sqllogictest/github-9782.slt
@@ -1,0 +1,56 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Regression test for https://github.com/MaterializeInc/materialize/issues/9782.
+
+statement ok
+CREATE TABLE table_f1 (f1 INTEGER);
+
+statement ok
+CREATE TAble table_f4 (f4 INTEGER);
+
+query T multiline
+EXPLAIN SELECT * FROM table_f1 , LATERAL ( SELECT * FROM (  table_f4 AS a1 LEFT JOIN table_f4 AS a2 ON a1.f4 = a2.f4 ) WHERE a1.f4 <= f1  ) WHERE  f1 IS  NULL;
+----
+%0 =
+| Constant
+
+EOF
+
+query T multiline
+EXPLAIN SELECT * FROM table_f1 , LATERAL ( SELECT * FROM (  table_f4 AS a1 LEFT JOIN table_f4 AS a2 ON a1.f4 = a2.f4 ) WHERE a1.f4 <= f1  ) WHERE  f1 IS  NULL;
+----
+%0 =
+| Constant
+
+EOF
+
+query T multiline
+EXPLAIN SELECT * FROM table_f1 , LATERAL ( SELECT * FROM (  table_f4 AS a1 LEFT JOIN table_f4 AS a2 ON a1.f4 = a2.f4 ) WHERE a1.f4 <= f1  ) WHERE  f1 IS  NULL;
+----
+%0 =
+| Constant
+
+EOF
+
+query T multiline
+EXPLAIN SELECT * FROM table_f1 , LATERAL ( SELECT * FROM (  table_f4 AS a1 LEFT JOIN table_f4 AS a2 ON a1.f4 = a2.f4 ) WHERE a1.f4 <= f1  ) WHERE  f1 IS  NULL;
+----
+%0 =
+| Constant
+
+EOF
+
+query T multiline
+EXPLAIN SELECT * FROM table_f1 , LATERAL ( SELECT * FROM (  table_f4 AS a1 LEFT JOIN table_f4 AS a2 ON a1.f4 = a2.f4 ) WHERE a1.f4 <= f1  ) WHERE  f1 IS  NULL;
+----
+%0 =
+| Constant
+
+EOF


### PR DESCRIPTION
... regardless of the order of the input predicates.

Extend the test framework to always check a few different orders of the
input predicates.

Fixes #9782.

<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug: [Link to issue.]

  * This PR adds a known-desirable feature: [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

This PR fixes a recognized bug

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
