### PR TITLE
sql: allow planning of DISTINCT ON with window functions

### DIFF
--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -1804,7 +1804,7 @@ fn plan_view_select(
                     relation_type: &qcx.relation_type(&relation_expr),
                     allow_aggregates: true,
                     allow_subqueries: true,
-                    allow_windows: false,
+                    allow_windows: true,
                 };
 
                 let mut distinct_exprs = vec![];

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -453,9 +453,12 @@ WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
 SELECT * FROM t
 WHERE row_number() over () > 1;
 
-# When query.rs is allowed to plan window functions in DISTINCT ON, we
-# currently return incorrect output. Disable DISTINCT ON until fixed.
-query error window functions are not allowed in DISTINCT ON
+query T
 WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
 SELECT DISTINCT ON (row_number() OVER ()) *
 FROM t
+ORDER BY row_number() OVER ()
+----
+a
+b
+c


### PR DESCRIPTION
Was disabled due to a sqllogictest being written incorrectly.

### Motivation

  * This PR fixes a recognized bug: https://github.com/MaterializeInc/materialize/pull/9768#issuecomment-1002224124

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
