### PR TITLE
add one off creation and --ssh to bin/scratch create

### DIFF
--- a/doc/developer/scratch.md
+++ b/doc/developer/scratch.md
@@ -47,6 +47,15 @@ This subcommand expects a series of JSON objects on standard input, each of whic
 }
 ```
 
+`bin/scratch create` takes in configs from stdin, or by passing a name as a positional arg, like:
+
+```
+$ bin/scratch create dev-box
+```
+It looks for the name as a json file in `misc/machines`, a good starter to just do some plain, personal testing is `dev-box`.
+
+---
+
 All of the keys are required (though `tags` can be an empty dictionary). Their meanings should largely be self-explanatory.
 
 Any number of JSON objects may be specified, one after the other. The script creates a "cluster" of machines identified by a random

--- a/misc/machines/dev-box.json
+++ b/misc/machines/dev-box.json
@@ -1,0 +1,8 @@
+{
+    "name": "one-off testing",
+    "launch_script": "true",
+    "instance_type": "t2.large",
+    "ami": "ami-0b29b6e62f2343b46",
+    "size_gb": 50,
+    "tags": {}
+}


### PR DESCRIPTION

### Motivation


  * This PR adds a feature that has not yet been specified.

I wanted our bin/scratch tool to be easier to use for one-off testing, so I added some flags that should be general enough to help others!

I didn't add `--ssh` to `bin/scratch mine` or `--mine` to `bin/scratch ssh` yet, as I haven't yet figured out a good ui for them.

Not sure a good default ami, but I got this one from the i2 docs


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
