### PR TITLE
extend startup timeout for persistence tests

### DIFF
--- a/test/persistence/mzworkflows.py
+++ b/test/persistence/mzworkflows.py
@@ -57,7 +57,7 @@ def workflow_persistence(w: Workflow):
 
 
 def workflow_kafka_sources(w: Workflow):
-    w.start_and_wait_for_tcp(services=prerequisites)
+    w.start_and_wait_for_tcp(services=prerequisites, timeout_secs=240)
 
     w.start_services(services=["materialized"])
     w.wait_for_mz(service="materialized")


### PR DESCRIPTION
### Motivation

  * This PR fixes a recognized bug: mzcompose runs are flaky on m1 macs
  this pr is similar to: https://github.com/MaterializeInc/materialize/pull/9629
  
  this pr does not make this process 100% non-flaky, but it makes it possible, (sometimes you need to run `down -v` beforehand), to cleanly run `test/persistence` mzcompose's on an m1 mac 


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
