### PR TITLE
Ensure multi-instance testdrive tests are repeatable

### DIFF
--- a/misc/python/materialize/mzcompose.py
+++ b/misc/python/materialize/mzcompose.py
@@ -1113,6 +1113,7 @@ class Testdrive(PythonService):
         no_reset: bool = False,
         default_timeout: str = "30s",
         seed: Optional[int] = None,
+        consistent_seed: bool = False,
         validate_catalog: bool = True,
         entrypoint: Optional[List[str]] = None,
         shell_eval: Optional[bool] = False,
@@ -1156,7 +1157,11 @@ class Testdrive(PythonService):
 
         entrypoint.append(f"--default-timeout {default_timeout}")
 
-        if seed:
+        if seed and consistent_seed:
+            raise RuntimeError("Can't pass `seed` and `consistent_seed` at same time")
+        elif consistent_seed:
+            entrypoint.append(f"--seed {random.getrandbits(32)}")
+        elif seed:
             entrypoint.append(f"--seed {seed}")
 
         if shell_eval:

--- a/test/persistence/disable-user-indexes/after.td
+++ b/test/persistence/disable-user-indexes/after.td
@@ -23,7 +23,7 @@ $ set schema={
         ]
     }
 
-> SELECT SUM(CAST(statistics->'topics'->'testdrive-disable-user-indexes-1'->'partitions'->'0'->'msgs' AS INT)) IS NULL FROM mz_kafka_source_statistics;
+> SELECT SUM(CAST(statistics->'topics'->'testdrive-disable-user-indexes-${testdrive.seed}'->'partitions'->'0'->'msgs' AS INT)) IS NULL FROM mz_kafka_source_statistics;
 true
 
 > ALTER INDEX disable_user_indexes_primary_idx SET ENABLED;
@@ -37,5 +37,5 @@ true
 
 # We expect the counter to be at 1, that is no data was re-ingested
 # from the Kafka topic after the indexes were enabled
-> SELECT SUM(CAST(statistics->'topics'->'testdrive-disable-user-indexes-1'->'partitions'->'0'->'msgs' AS INT)) = 1 FROM mz_kafka_source_statistics;
+> SELECT SUM(CAST(statistics->'topics'->'testdrive-disable-user-indexes-${testdrive.seed}'->'partitions'->'0'->'msgs' AS INT)) = 1 FROM mz_kafka_source_statistics;
 true

--- a/test/persistence/kafka-sources/kafka-counters-after.td
+++ b/test/persistence/kafka-sources/kafka-counters-after.td
@@ -32,5 +32,5 @@ true
 
 # We expect the counter to be at 1, that is no data was re-ingested
 # from the Kafka topic post-restart.
-> SELECT SUM(CAST(statistics->'topics'->'testdrive-kafka-counters-1'->'partitions'->'0'->'msgs' AS INT)) = 1 FROM mz_kafka_source_statistics;
+> SELECT SUM(CAST(statistics->'topics'->'testdrive-kafka-counters-${testdrive.seed}'->'partitions'->'0'->'msgs' AS INT)) = 1 FROM mz_kafka_source_statistics;
 true

--- a/test/persistence/mzworkflows.py
+++ b/test/persistence/mzworkflows.py
@@ -43,7 +43,7 @@ services = [
     materialized,
     mz_disable_user_indexes,
     mz_without_system_tables,
-    Testdrive(no_reset=True, seed=1),
+    Testdrive(no_reset=True, consistent_seed=True),
 ]
 
 td_test = os.environ.pop("TD_TEST", "*")


### PR DESCRIPTION
### Motivation

  * This PR fixes a previously unreported bug.

If you want to not `down` and `up` running containers (a true luxury in the slow world of m1 macs), `persist` test's didn't work more than once because of clashing on the kafka topics/etc because of the hardcoded seed. This adds a new flag that allows the

this can also be used to fix this same problem for `upgrade` in the future, `feature-benchmark` has its own wrapper than handles it, and `kafka-multi-broker` still uses a yml file; I can add at least `upgrade` in this pr or a different, depending on your preference


### Tips for reviewer
this was tested on top of: https://github.com/MaterializeInc/materialize/pull/9788, after it lands, the bottom commit will disappear 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
