### PR TITLE
persist: refactor Listen{Event,Fn} to always use Vec<u8>s

### DIFF
--- a/src/persist/src/operators/source.rs
+++ b/src/persist/src/operators/source.rs
@@ -76,7 +76,7 @@ fn listen_source<G, K, V>(
     // initial frontier because an empty frontier would signal that we are at "the end of time",
     // meaning that there will be no more events in the future.
     initial_frontier: Option<Antichain<u64>>,
-    listen_rx: Receiver<ListenEvent<Vec<u8>, Vec<u8>>>,
+    listen_rx: Receiver<ListenEvent>,
 ) -> Stream<G, (Result<(K, V), String>, u64, isize)>
 where
     G: Scope<Timestamp = u64>,


### PR DESCRIPTION
Previously, we allowed for Listeners that could receive arbitrary key value
types, and as it turns out, we don't need that flexibility. This commit also
paves the way to making listen() something that hands out a Receiver<_> instead
of taking an arbitrary callback.

<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug: [Link to issue.]

  * This PR adds a known-desirable feature: [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
