### PR TITLE
pgwire: retry on no complete timestamps error

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -3204,7 +3204,10 @@ where
                                         .less_equal(&0)
                                 })
                                 .collect::<Vec<_>>();
-                            return Err(CoordError::IncompleteTimestamp(unstarted));
+                            return Err(CoordError::IncompleteTimestamp {
+                                unstarted: unstarted.clone(),
+                                timeline: self.validate_timeline(unstarted)?,
+                            });
                         }
                     } else {
                         // A complete trace can be read in its final form with this time.

--- a/src/coord/src/error.rs
+++ b/src/coord/src/error.rs
@@ -10,6 +10,7 @@
 use std::error::Error;
 use std::fmt;
 
+use dataflow_types::Timeline;
 use expr::EvalError;
 use ore::stack::RecursionLimitError;
 use ore::str::StrExt;
@@ -41,7 +42,10 @@ pub enum CoordError {
     /// The ID allocator exhausted all valid IDs.
     IdExhaustionError,
     /// At least one input has no complete timestamps yet
-    IncompleteTimestamp(Vec<expr::GlobalId>),
+    IncompleteTimestamp {
+        unstarted: Vec<expr::GlobalId>,
+        timeline: Option<Timeline>,
+    },
     /// Specified index is disabled, but received non-enabling update request
     InvalidAlterOnDisabledIndex(String),
     /// The value for the specified parameter does not have the right type.
@@ -239,7 +243,7 @@ impl fmt::Display for CoordError {
             }
             CoordError::Eval(e) => e.fmt(f),
             CoordError::IdExhaustionError => f.write_str("ID allocator exhausted all valid IDs"),
-            CoordError::IncompleteTimestamp(unstarted) => write!(
+            CoordError::IncompleteTimestamp { unstarted, .. } => write!(
                 f,
                 "At least one input has no complete timestamps yet: {:?}",
                 unstarted

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -350,7 +350,7 @@ impl ErrorResponse {
             CoordError::DuplicateCursor(_) => SqlState::DUPLICATE_CURSOR,
             CoordError::Eval(_) => SqlState::INTERNAL_ERROR,
             CoordError::IdExhaustionError => SqlState::INTERNAL_ERROR,
-            CoordError::IncompleteTimestamp(_) => SqlState::SQL_STATEMENT_NOT_YET_COMPLETE,
+            CoordError::IncompleteTimestamp { .. } => SqlState::SQL_STATEMENT_NOT_YET_COMPLETE,
             CoordError::InvalidParameterType(_) => SqlState::INVALID_PARAMETER_VALUE,
             CoordError::InvalidParameterValue { .. } => SqlState::INVALID_PARAMETER_VALUE,
             CoordError::InvalidTableMutationSelection => SqlState::INVALID_TRANSACTION_STATE,

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -369,7 +369,11 @@ where
         }
 
         self.metrics.query_count.inc();
-        let result = match self.coord_client.execute(EMPTY_PORTAL.to_string()).await {
+        let result = match self
+            .coord_client
+            .execute_retry(EMPTY_PORTAL.to_string())
+            .await
+        {
             Ok(response) => {
                 self.send_execute_response(
                     response,
@@ -700,7 +704,7 @@ where
                     // Postgres).
                     self.start_transaction(Some(1)).await;
 
-                    match self.coord_client.execute(portal_name.clone()).await {
+                    match self.coord_client.execute_retry(portal_name.clone()).await {
                         Ok(response) => {
                             self.send_execute_response(
                                 response,


### PR DESCRIPTION
Implement a retry loop in the coord client used by the pgwire session
to retry incomplete timestamp errors. These errors generally occur
because users are waiting on a newly created or initialized view to
process data. We don't know the first timestamp that will be produced,
so we can't use something like `AS OF now()`. Because the session itself
is retrying, it can avoid putting itself into a failed state.

Fixes #3122
Fixes #8163

### Motivation

  * This PR adds a known-desirable feature: #3122

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/9816)
<!-- Reviewable:end -->
