### PR TITLE
expr,sql: add array_cat function + operator

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -118,6 +118,8 @@ changes that have not yet been documented.
   of `CREATE SOURCE` and `CREATE SINK` now reject unknown parameters.
   (Example: [Confluent Schema Registry options](/sql/create-source/avro-kafka#confluent-schema-registry-options)).
 
+- Add the `array_cat` function.
+
 {{< comment >}}
 Only add new release notes above this line.
 

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -521,6 +521,8 @@
 
 - type: Array
   functions:
+  - signature: 'array_cat(a1: arrayany, a2: arrayany) -> arrayany'
+    description: '[Experimental](/cli/#experimental-mode)––Concatenates `a1` and `a2`.'
   - signature: 'array_to_string(a: anyarray, sep: text [, ifnull: text]) -> text'
     description: >-
       Concatenates the elements of `array` together separated by `sep`.

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -2187,6 +2187,7 @@ pub enum BinaryFunc {
     ArrayLower,
     ArrayRemove,
     ArrayUpper,
+    ArrayArrayConcat,
     ListListConcat,
     ListElementConcat,
     ElementListConcat,
@@ -2422,6 +2423,7 @@ impl BinaryFunc {
             BinaryFunc::ArrayLower => Ok(eager!(array_lower)),
             BinaryFunc::ArrayRemove => eager!(array_remove, temp_storage),
             BinaryFunc::ArrayUpper => Ok(eager!(array_upper)),
+            BinaryFunc::ArrayArrayConcat => eager!(array_array_concat, temp_storage),
             BinaryFunc::ListListConcat => Ok(eager!(list_list_concat, temp_storage)),
             BinaryFunc::ListElementConcat => Ok(eager!(list_element_concat, temp_storage)),
             BinaryFunc::ElementListConcat => Ok(eager!(element_list_concat, temp_storage)),
@@ -2576,10 +2578,12 @@ impl BinaryFunc {
                 ScalarType::Int64.nullable(true)
             }
 
-            ArrayRemove | ListListConcat | ListElementConcat | ListRemove => input1_type
-                .scalar_type
-                .default_embedded_value()
-                .nullable(true),
+            ArrayArrayConcat | ArrayRemove | ListListConcat | ListElementConcat | ListRemove => {
+                input1_type
+                    .scalar_type
+                    .default_embedded_value()
+                    .nullable(true)
+            }
 
             ElementListConcat => input2_type
                 .scalar_type
@@ -2608,6 +2612,7 @@ impl BinaryFunc {
             self,
             BinaryFunc::And
                 | BinaryFunc::Or
+                | BinaryFunc::ArrayArrayConcat
                 | BinaryFunc::ListListConcat
                 | BinaryFunc::ListElementConcat
                 | BinaryFunc::ElementListConcat
@@ -2792,6 +2797,7 @@ impl BinaryFunc {
             | ArrayLength
             | ArrayLower
             | ArrayUpper
+            | ArrayArrayConcat
             | ListListConcat
             | ListElementConcat
             | ElementListConcat => true,
@@ -2984,6 +2990,7 @@ impl fmt::Display for BinaryFunc {
             BinaryFunc::ArrayLower => f.write_str("array_lower"),
             BinaryFunc::ArrayRemove => f.write_str("array_remove"),
             BinaryFunc::ArrayUpper => f.write_str("array_upper"),
+            BinaryFunc::ArrayArrayConcat => f.write_str("||"),
             BinaryFunc::ListListConcat => f.write_str("||"),
             BinaryFunc::ListElementConcat => f.write_str("||"),
             BinaryFunc::ElementListConcat => f.write_str("||"),
@@ -5249,6 +5256,108 @@ fn list_length_max<'a>(a: Datum<'a>, b: Datum<'a>, max_dim: usize) -> Result<Dat
 fn array_contains<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     let array = Datum::unwrap_array(&b);
     Datum::from(array.elements().iter().any(|e| e == a))
+}
+
+fn array_array_concat<'a>(
+    a: Datum<'a>,
+    b: Datum<'a>,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    if a.is_null() {
+        return Ok(b);
+    } else if b.is_null() {
+        return Ok(a);
+    }
+
+    let a_array = a.unwrap_array();
+    let b_array = b.unwrap_array();
+
+    let a_dims: Vec<ArrayDimension> = a_array.dims().into_iter().collect();
+    let b_dims: Vec<ArrayDimension> = b_array.dims().into_iter().collect();
+
+    let a_ndims = a_dims.len();
+    let b_ndims = b_dims.len();
+
+    // Per PostgreSQL, if either of the input arrays is zero dimensional,
+    // the output is the other array, no matter their dimensions.
+    if a_ndims == 0 {
+        return Ok(b);
+    } else if b_ndims == 0 {
+        return Ok(a);
+    }
+
+    // Postgres supports concatenating arrays of different dimensions,
+    // as long as one of the arrays has the same type as an element of
+    // the other array, i.e. `int[2][4] || int[4]` (or `int[4] || int[2][4]`)
+    // works, because each element of `int[2][4]` is an `int[4]`.
+    // This check is separate from the one below because Postgres gives a
+    // specific error message if the number of dimensions differs by more
+    // than one.
+    // This cast is safe since MAX_ARRAY_DIMENSIONS is 6
+    // Can be replaced by .abs_diff once it is stabilized
+    if (a_ndims as isize - b_ndims as isize).abs() > 1 {
+        return Err(EvalError::IncompatibleArrayDimensions {
+            dims: Some((a_ndims, b_ndims)),
+        });
+    }
+
+    let mut dims;
+
+    // After the checks above, we are certain that:
+    // - neither array is zero dimensional nor empty
+    // - both arrays have the same number of dimensions, or differ
+    //   at most by one.
+    match a_ndims.cmp(&b_ndims) {
+        // If both arrays have the same number of dimensions, validate
+        // that their inner dimensions are the same and concatenate the
+        // arrays.
+        Ordering::Equal => {
+            if &a_dims[1..] != &b_dims[1..] {
+                return Err(EvalError::IncompatibleArrayDimensions { dims: None });
+            }
+            dims = vec![ArrayDimension {
+                lower_bound: 1,
+                length: a_dims[0].length + b_dims[0].length,
+            }];
+            dims.extend(&a_dims[1..]);
+        }
+        // If `a` has less dimensions than `b`, this is an element-array
+        // concatenation, which requires that `a` has the same dimensions
+        // as an element of `b`.
+        Ordering::Less => {
+            if &a_dims[..] != &b_dims[1..] {
+                return Err(EvalError::IncompatibleArrayDimensions { dims: None });
+            }
+            dims = vec![ArrayDimension {
+                lower_bound: 1,
+                // Since `a` is treated as an element of `b`, the length of
+                // the first dimension of `b` is incremented by one, as `a` is
+                // non-empty.
+                length: b_dims[0].length + 1,
+            }];
+            dims.extend(a_dims);
+        }
+        // If `a` has more dimensions than `b`, this is an array-element
+        // concatenation, which requires that `b` has the same dimensions
+        // as an element of `a`.
+        Ordering::Greater => {
+            if &a_dims[1..] != &b_dims[..] {
+                return Err(EvalError::IncompatibleArrayDimensions { dims: None });
+            }
+            dims = vec![ArrayDimension {
+                lower_bound: 1,
+                // Since `b` is treated as an element of `a`, the length of
+                // the first dimension of `a` is incremented by one, as `b`
+                // is non-empty.
+                length: a_dims[0].length + 1,
+            }];
+            dims.extend(b_dims);
+        }
+    }
+
+    let elems = a_array.elements().iter().chain(b_array.elements().iter());
+
+    Ok(temp_storage.try_make_datum(|packer| packer.push_array(&dims, elems))?)
 }
 
 fn list_list_concat<'a>(a: Datum<'a>, b: Datum<'a>, temp_storage: &'a RowArena) -> Datum<'a> {

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -1201,6 +1201,9 @@ pub enum EvalError {
         length: usize,
     },
     MultidimensionalArrayRemovalNotSupported,
+    IncompatibleArrayDimensions {
+        dims: Option<(usize, usize)>,
+    },
 }
 
 impl fmt::Display for EvalError {
@@ -1300,11 +1303,14 @@ impl fmt::Display for EvalError {
             } => {
                 write!(f, "value too long for type {}({})", target_type, length)
             }
-            &EvalError::MultidimensionalArrayRemovalNotSupported => {
+            EvalError::MultidimensionalArrayRemovalNotSupported => {
                 write!(
                     f,
                     "removing elements from multidimensional arrays is not supported"
                 )
+            }
+            EvalError::IncompatibleArrayDimensions { dims: _ } => {
+                write!(f, "cannot concatenate incompatible arrays")
             }
         }
     }
@@ -1312,7 +1318,19 @@ impl fmt::Display for EvalError {
 
 impl EvalError {
     pub fn detail(&self) -> Option<String> {
-        None
+        match self {
+            EvalError::IncompatibleArrayDimensions { dims: None } => Some(
+                "Arrays with differing dimensions are not compatible for concatenation."
+                    .to_string(),
+            ),
+            EvalError::IncompatibleArrayDimensions {
+                dims: Some((a_dims, b_dims)),
+            } => Some(format!(
+                "Arrays of {} and {} dimensions are not compatible for concatenation.",
+                a_dims, b_dims
+            )),
+            _ => None,
+        }
     }
 
     pub fn hint(&self) -> Option<String> {

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1611,6 +1611,12 @@ lazy_static! {
                 params!(Float32) => UnaryFunc::AbsFloat32(func::AbsFloat32), 1394;
                 params!(Float64) => UnaryFunc::AbsFloat64(func::AbsFloat64), 1395;
             },
+            "array_cat" => Scalar {
+                params!(ArrayAny, ArrayAny) => Operation::binary(|ecx, lhs, rhs| {
+                    ecx.require_experimental_mode("array_cat")?;
+                    Ok(lhs.call_binary(rhs, BinaryFunc::ArrayArrayConcat))
+                }) => ArrayAny, 383;
+            },
             "array_in" => Scalar {
                 params!(String, Oid, Int32) =>
                     Operation::unary(|_ecx, _e| bail_unsupported!("array_in")) => ArrayAny, 750;
@@ -2995,6 +3001,7 @@ lazy_static! {
                 }) => String, 2780;
                 params!(String, String) => TextConcat, 654;
                 params!(Jsonb, Jsonb) => JsonbConcat, 3284;
+                params!(ArrayAny, ArrayAny) => ArrayArrayConcat => ArrayAny, 375;
                 params!(ListAny, ListAny) => ListListConcat => ListAny, oid::OP_CONCAT_LIST_LIST_OID;
                 params!(ListAny, ListElementAny) => ListElementConcat => ListAny, oid::OP_CONCAT_LIST_ELEMENT_OID;
                 params!(ListElementAny, ListAny) => ElementListConcat => ListAny, oid::OP_CONCAT_ELEMENY_LIST_OID;

--- a/test/sqllogictest/arrays.slt
+++ b/test/sqllogictest/arrays.slt
@@ -456,3 +456,297 @@ SELECT array_remove(ARRAY[1,1,1], 1)
 
 query error removing elements from multidimensional arrays is not supported
 SELECT array_remove(ARRAY[[1]], 1)
+
+# array_cat
+
+query T
+SELECT array_cat(ARRAY[1, 2], ARRAY[3, 4])
+----
+{1,2,3,4}
+
+query T
+SELECT array_cat(ARRAY[1, 2], ARRAY[3])
+----
+{1,2,3}
+
+query T
+SELECT array_cat(ARRAY[1], ARRAY[2, 3])
+----
+{1,2,3}
+
+query T
+SELECT array_cat(ARRAY[]::INT[], ARRAY[]::INT[])
+----
+{}
+
+query T
+SELECT array_cat(ARRAY[[]]::INT[], ARRAY[[]]::INT[])
+----
+{}
+
+query T
+SELECT array_cat(ARRAY[[]]::INT[], ARRAY[[[[]]]]::INT[])
+----
+{}
+
+query T
+SELECT array_cat(ARRAY[[[[]]]]::INT[], ARRAY[[]]::INT[])
+----
+{}
+
+query T
+SELECT array_cat(ARRAY[1, 2], ARRAY[]::INT[])
+----
+{1,2}
+
+query T
+SELECT array_cat(ARRAY[1, 2], ARRAY[[]]::INT[])
+----
+{1,2}
+
+query T
+SELECT array_cat(ARRAY[1, 2], ARRAY[[[[[]]]]]::INT[])
+----
+{1,2}
+
+query T
+SELECT array_cat(ARRAY[[1, 2]], ARRAY[]::INT[])
+----
+{{1,2}}
+
+query T
+SELECT array_cat(ARRAY[[1, 2]], ARRAY[[]]::INT[])
+----
+{{1,2}}
+
+query T
+SELECT array_cat(ARRAY[[1, 2]], ARRAY[[[[[]]]]]::INT[])
+----
+{{1,2}}
+
+query T
+SELECT array_cat(ARRAY[]::INT[], ARRAY[1,2])
+----
+{1,2}
+
+query T
+SELECT array_cat(ARRAY[[]]::INT[], ARRAY[1,2])
+----
+{1,2}
+
+query T
+SELECT array_cat(ARRAY[[[[[[]]]]]]::INT[], ARRAY[1,2])
+----
+{1,2}
+
+query T
+SELECT array_cat(ARRAY[]::INT[], ARRAY[[1,2]])
+----
+{{1,2}}
+
+query T
+SELECT array_cat(ARRAY[[]]::INT[], ARRAY[[1,2]])
+----
+{{1,2}}
+
+query T
+SELECT array_cat(ARRAY[[[[[[]]]]]]::INT[], ARRAY[[1,2]])
+----
+{{1,2}}
+
+query T
+SELECT array_cat(ARRAY[1,2], NULL::INT[])
+----
+{1,2}
+
+query T
+SELECT array_cat(NULL::INT[], ARRAY[1,2])
+----
+{1,2}
+
+query T
+SELECT array_cat(NULL::INT[], NULL::INT[])
+----
+NULL
+
+query T
+SELECT array_cat(ARRAY[[1,2],[3,4]], ARRAY[[5,6]])
+----
+{{1,2},{3,4},{5,6}}
+
+query T
+SELECT array_cat(ARRAY[[1,2]], ARRAY[[3,4],[5,6]])
+----
+{{1,2},{3,4},{5,6}}
+
+query T
+SELECT array_cat(ARRAY[[1,2],[3,4]], ARRAY[5,6])
+----
+{{1,2},{3,4},{5,6}}
+
+query T
+SELECT array_cat(ARRAY[1,2], ARRAY[[3,4],[5,6]])
+----
+{{1,2},{3,4},{5,6}}
+
+simple
+SELECT array_cat(ARRAY[[1,2]], ARRAY[[3,4,5]]);
+----
+db error: ERROR: cannot concatenate incompatible arrays
+DETAIL: Arrays with differing dimensions are not compatible for concatenation.
+
+simple
+SELECT array_cat(ARRAY[[[1,2]]], ARRAY[3,4]);
+----
+db error: ERROR: cannot concatenate incompatible arrays
+DETAIL: Arrays of 3 and 1 dimensions are not compatible for concatenation.
+
+query error
+SELECT array_cat(ARRAY[1,2], ARRAY['3'])
+
+# array concatenation operator
+
+query T
+SELECT ARRAY[1, 2] || ARRAY[3, 4]
+----
+{1,2,3,4}
+
+query T
+SELECT ARRAY[1, 2] || ARRAY[3]
+----
+{1,2,3}
+
+query T
+SELECT ARRAY[1] || ARRAY[2, 3]
+----
+{1,2,3}
+
+query T
+SELECT ARRAY[]::INT[] || ARRAY[]::INT[]
+----
+{}
+
+query T
+SELECT ARRAY[[]]::INT[] || ARRAY[[]]::INT[]
+----
+{}
+
+query T
+SELECT ARRAY[[]]::INT[] || ARRAY[[[[]]]]::INT[]
+----
+{}
+
+query T
+SELECT ARRAY[[[[]]]]::INT[] || ARRAY[[]]::INT[]
+----
+{}
+
+query T
+SELECT ARRAY[1, 2] || ARRAY[]::INT[]
+----
+{1,2}
+
+query T
+SELECT ARRAY[1, 2] || ARRAY[[]]::INT[]
+----
+{1,2}
+
+query T
+SELECT ARRAY[1, 2] || ARRAY[[[[[]]]]]::INT[]
+----
+{1,2}
+
+query T
+SELECT ARRAY[[1, 2]] || ARRAY[]::INT[]
+----
+{{1,2}}
+
+query T
+SELECT ARRAY[[1, 2]] || ARRAY[[]]::INT[]
+----
+{{1,2}}
+
+query T
+SELECT ARRAY[[1, 2]] || ARRAY[[[[[]]]]]::INT[]
+----
+{{1,2}}
+
+query T
+SELECT ARRAY[]::INT[] || ARRAY[1,2]
+----
+{1,2}
+
+query T
+SELECT ARRAY[[]]::INT[] || ARRAY[1,2]
+----
+{1,2}
+
+query T
+SELECT ARRAY[[[[[[]]]]]]::INT[] || ARRAY[1,2]
+----
+{1,2}
+
+query T
+SELECT ARRAY[]::INT[] || ARRAY[[1,2]]
+----
+{{1,2}}
+
+query T
+SELECT ARRAY[[]]::INT[] || ARRAY[[1,2]]
+----
+{{1,2}}
+
+query T
+SELECT ARRAY[[[[[[]]]]]]::INT[] || ARRAY[[1,2]]
+----
+{{1,2}}
+
+query T
+SELECT ARRAY[1,2] || NULL::INT[]
+----
+{1,2}
+
+query T
+SELECT NULL::INT[] || ARRAY[1,2]
+----
+{1,2}
+
+query T
+SELECT NULL::INT[] || NULL::INT[]
+----
+NULL
+
+query T
+SELECT ARRAY[[1,2],[3,4]] || ARRAY[[5,6]]
+----
+{{1,2},{3,4},{5,6}}
+
+query T
+SELECT ARRAY[[1,2]] || ARRAY[[3,4],[5,6]]
+----
+{{1,2},{3,4},{5,6}}
+
+query T
+SELECT ARRAY[[1,2],[3,4]] || ARRAY[5,6]
+----
+{{1,2},{3,4},{5,6}}
+
+query T
+SELECT ARRAY[1,2] || ARRAY[[3,4],[5,6]]
+----
+{{1,2},{3,4},{5,6}}
+
+simple
+SELECT ARRAY[[1,2]] || ARRAY[[3,4,5]];
+----
+db error: ERROR: cannot concatenate incompatible arrays
+DETAIL: Arrays with differing dimensions are not compatible for concatenation.
+
+simple
+SELECT ARRAY[[[1,2]]] || ARRAY[3,4];
+----
+db error: ERROR: cannot concatenate incompatible arrays
+DETAIL: Arrays of 3 and 1 dimensions are not compatible for concatenation.
+
+query error no overload for integer\[\] || text\[\]: arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+SELECT ARRAY[1,2] || ARRAY['3'])


### PR DESCRIPTION
Add array-array concatenation via `array_cat` function or the equivalent `||` operator. Array-element and element-array concatenation via `||` will be added in a follow-up PR.

### Motivation

  * This PR adds a known-desirable feature: #9801

### Tips for reviewer

I am pretty unhappy overall with how `array_array_concat` looks like, so I'd love any ideas on how to refactor it! Some of the weirdness is just trying to ensure we have the same behavior as Postgres, but the logic could probably be simplified.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/9819)
<!-- Reviewable:end -->
