### PR TITLE
nightly: remove stray upgrade job

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -100,11 +100,3 @@
     - ./ci/plugins/mzcompose:
         composition: testdrive
         run: persistence-testdrive
-
-  - id: upgrade
-    label: "Upgrade testing"
-    timeout_in_minutes: 60
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: upgrade
-          run: upgrade


### PR DESCRIPTION
It turns out the upgrade job already has a definition in the nightly pipeline.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
