### PR TITLE
doc/user: pin demos to latest stable release

### DIFF
--- a/doc/user/content/demos/business-intelligence.md
+++ b/doc/user/content/demos/business-intelligence.md
@@ -118,10 +118,10 @@ Putting this all together, our deployment looks like this:
    and 8GB memory. Running Docker for Mac with less resources may cause the demo
    to fail.
 
-1. Clone the Materialize repository:
+1. Clone the Materialize repository at the latest release:
 
     ```shell
-    git clone https://github.com/MaterializeInc/materialize.git
+    git clone --depth=1 --branch {{< version >}} https://github.com/MaterializeInc/materialize.git
     ```
 
    You can also view the demo's code on
@@ -130,7 +130,7 @@ Putting this all together, our deployment looks like this:
 1. Download and start all of the components we've listed above by running:
 
    ```shell
-   cd demo/chbench
+   cd materialize/demo/chbench
    ./mzcompose run demo
    ```
 

--- a/doc/user/content/demos/log-parsing.md
+++ b/doc/user/content/demos/log-parsing.md
@@ -245,16 +245,16 @@ In a future iteration, we'll make this demo more interactive.
     Python 3.7.5
     ```
 
-1. Clone the Materialize repo:
+1. Clone the Materialize repo at the latest release:
 
     ```shell
-    git clone https://github.com/MaterializeInc/materialize.git
+    git clone --depth=1 --branch {{< version >}} https://github.com/MaterializeInc/materialize.git
     ```
 
 1. Move to the `demo/http_logs` dir:
 
     ```shell
-    cd <path to materialize>/demo/http_logs
+    cd materialize/demo/http_logs
     ```
 
     You can also find the demo's code on
@@ -275,7 +275,7 @@ Now that our deployment is running (and looks like the diagram shown above), we
 can see that Materialize is ingesting the logs and structuring them. We'll also
 get a chance to see how Materialize can handle queries on our data.
 
-1. Launch a new terminal window and `cd <path to materialize>/demo/http_logs`.
+1. Launch a new terminal window and `cd materialize/demo/http_logs`.
 
 1. Launch the Materialize CLI (`mzcli`) by running:
 

--- a/doc/user/content/demos/microservice.md
+++ b/doc/user/content/demos/microservice.md
@@ -403,22 +403,16 @@ In a future iteration, we'll make this demo more interactive.
 1. Clone the Materialize repository:
 
     ```shell
-    git clone https://github.com/MaterializeInc/materialize.git
-    ```
-
-1. Move to the Materialize directory:
-
-    ```shell
-    cd <path to materialize>/
+    git clone --depth=1 --branch {{< version >}} https://github.com/MaterializeInc/materialize.git
     ```
 
     You can also view the demo's code on
-    [GitHub](https://github.com/MaterializeInc/materialize/tree/main/demo/billing).
+    [GitHub](https://github.com/MaterializeInc/materialize/tree/{{< version >}}/demo/billing).
 
 1. Download and start all of the components we've listed above by running:
 
     ```shell
-    cd demo/billing
+    cd materialize/demo/billing
     ./mzcompose run local
     ```
 


### PR DESCRIPTION
The current demo instructions have users run demos from the latest tip
of main. This is dangerous because those demos are running against an
unstable and possibly broken version of Materialize. Worse, the Docker
images for the latest tip of main take a few minutes to become
available; if you get unlucky, you'll accidentally wind up trying to
compile the latest tip from source, which most users running demos are
not prepared to do.

This commit updates the instructions so that users get a clone of the
demo from the latest stable release. It also adds `--depth=1` to the
`git clone` call, which makes the clone *much* faster because users
don't need to check out the repository in its entirety.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
