### PR TITLE
expr,sql: add functions to remove elements from collections (array_remove, list_remove)

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -112,6 +112,8 @@ changes that have not yet been documented.
 - **Breaking change.** Disallow window functions outside of `SELECT`
   lists, `DISTINCT ON` clauses, and `ORDER BY` clauses.
 
+- Add the `array_remove` and `list_remove` functions.
+
 {{< comment >}}
 Only add new release notes above this line.
 

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -109,6 +109,12 @@
     - signature: 'list_prepend(e: listelementany, l: listany) -> listany'
       description: Prepends `e` to `l`.
 
+    - signature: 'list_remove(l: listany, e: listelementany) -> listany'
+      description: >-
+        '[Experimental](/cli/#experimental-mode)––Returns the list `l` without
+        any elements equal to the given value `e`. Comparisons are done using
+        IS NOT DISTINCT FROM semantics, so it is possible to remove NULLs.
+
 - type: Numbers
   description: Number functions take number-like arguments, e.g. [`int`](../types/int),
     [`float`](../types/float), [`numeric`](../types/numeric), unless otherwise specified.
@@ -520,6 +526,11 @@
       Concatenates the elements of `array` together separated by `sep`.
       Null elements are omitted unless `ifnull` is non-null, in which case
       null elements are replaced with the value of `ifnull`.
+  - signature: 'array_remove(a: anyarray, e: anyelement) -> anyarray'
+    description: >-
+      Returns the array `a` without any elements equal to the given value `e`.
+      The array must be one-dimensional. Comparisons are done using IS NOT
+      DISTINCT FROM semantics, so it is possible to remove NULLs.
 
 - type: Cryptography
   functions:

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -2137,6 +2137,7 @@ pub enum BinaryFunc {
     ArrayIndex,
     ArrayLength,
     ArrayLower,
+    ArrayRemove,
     ArrayUpper,
     ListListConcat,
     ListElementConcat,
@@ -2367,6 +2368,7 @@ impl BinaryFunc {
             BinaryFunc::ArrayContains => Ok(eager!(array_contains)),
             BinaryFunc::ArrayIndex => Ok(eager!(array_index)),
             BinaryFunc::ArrayLower => Ok(eager!(array_lower)),
+            BinaryFunc::ArrayRemove => eager!(array_remove, temp_storage),
             BinaryFunc::ArrayUpper => Ok(eager!(array_upper)),
             BinaryFunc::ListListConcat => Ok(eager!(list_list_concat, temp_storage)),
             BinaryFunc::ListElementConcat => Ok(eager!(list_element_concat, temp_storage)),
@@ -2521,7 +2523,7 @@ impl BinaryFunc {
                 ScalarType::Int64.nullable(true)
             }
 
-            ListListConcat | ListElementConcat => input1_type
+            ArrayRemove | ListListConcat | ListElementConcat => input1_type
                 .scalar_type
                 .default_embedded_value()
                 .nullable(true),
@@ -2556,6 +2558,7 @@ impl BinaryFunc {
                 | BinaryFunc::ListListConcat
                 | BinaryFunc::ListElementConcat
                 | BinaryFunc::ElementListConcat
+                | BinaryFunc::ArrayRemove
         )
     }
 
@@ -2773,7 +2776,8 @@ impl BinaryFunc {
             | Power
             | PowerNumeric
             | RepeatString
-            | PgGetConstraintdef => false,
+            | PgGetConstraintdef
+            | ArrayRemove => false,
         }
     }
 
@@ -2921,6 +2925,7 @@ impl fmt::Display for BinaryFunc {
             BinaryFunc::ArrayIndex => f.write_str("array_index"),
             BinaryFunc::ArrayLength => f.write_str("array_length"),
             BinaryFunc::ArrayLower => f.write_str("array_lower"),
+            BinaryFunc::ArrayRemove => f.write_str("array_remove"),
             BinaryFunc::ArrayUpper => f.write_str("array_upper"),
             BinaryFunc::ListListConcat => f.write_str("||"),
             BinaryFunc::ListElementConcat => f.write_str("||"),
@@ -5100,6 +5105,38 @@ fn array_lower<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
         Some(_) => Datum::Int64(1),
         None => Datum::Null,
     }
+}
+
+fn array_remove<'a>(
+    a: Datum<'a>,
+    b: Datum<'a>,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    if a.is_null() {
+        return Ok(a);
+    }
+
+    let arr = a.unwrap_array();
+
+    // Zero-dimensional arrays are empty by definition
+    if arr.dims().len() == 0 {
+        return Ok(a);
+    }
+
+    // array_remove only supports one-dimensional arrays
+    if arr.dims().len() > 1 {
+        return Err(EvalError::MultidimensionalArrayRemovalNotSupported);
+    }
+
+    let elems: Vec<_> = arr.elements().iter().filter(|v| v != &b).collect();
+    let mut dims = arr.dims().into_iter().collect::<Vec<_>>();
+    // This access is safe because `dims` is guaranteed to be non-empty
+    dims[0] = ArrayDimension {
+        lower_bound: 1,
+        length: elems.len(),
+    };
+
+    Ok(temp_storage.try_make_datum(|packer| packer.push_array(&dims, elems))?)
 }
 
 fn array_upper<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -1188,6 +1188,7 @@ pub enum EvalError {
         target_type: String,
         length: usize,
     },
+    MultidimensionalArrayRemovalNotSupported,
 }
 
 impl fmt::Display for EvalError {
@@ -1283,6 +1284,12 @@ impl fmt::Display for EvalError {
                 length,
             } => {
                 write!(f, "value too long for type {}({})", target_type, length)
+            }
+            &EvalError::MultidimensionalArrayRemovalNotSupported => {
+                write!(
+                    f,
+                    "removing elements from multidimensional arrays is not supported"
+                )
             }
         }
     }

--- a/src/pgrepr/src/oid.rs
+++ b/src/pgrepr/src/oid.rs
@@ -72,4 +72,5 @@ pub const FUNC_LIST_AGG_OID: u32 = 16_444;
 pub const FUNC_MZ_ERROR_IF_NULL_OID: u32 = 16_445;
 pub const FUNC_MZ_DATE_BIN_UNIX_EPOCH_TS_OID: u32 = 16_446;
 pub const FUNC_MZ_DATE_BIN_UNIX_EPOCH_TSTZ_OID: u32 = 16_447;
-// next ID: 16_448
+pub const FUNC_LIST_REMOVE_OID: u32 = 16_448;
+// next ID: 16_449

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -117,6 +117,7 @@ impl TypeCategory {
         match param {
             ParamType::Any
             | ParamType::ArrayAny
+            | ParamType::ArrayElementAny
             | ParamType::ListAny
             | ParamType::ListElementAny
             | ParamType::NonVecAny
@@ -512,7 +513,8 @@ impl ParamList {
     ///
     /// Polymorphic type consistency constraints include:
     /// - All arguments passed to `ArrayAny` must be `ScalarType::Array`s with
-    ///   the same types of elements.
+    ///   the same types of elements. All arguments passed to `ArrayElementAny`
+    ///   must also be of these elements' type.
     /// - All arguments passed to `ListAny` must be `ScalarType::List`s with the
     ///   same types of elements. All arguments passed to `ListElementAny` must
     ///   also be of these elements' type.
@@ -544,7 +546,8 @@ impl ParamList {
     ///   Valid `ScalarType`s passed to these parameters have a `custom_oid`
     ///   field and some embedded type, which we'll refer to as its element.
     ///
-    /// - **Element parameters** which include `ListElementAny` and `NonVecAny`.
+    /// - **Element parameters** which include `ArrayElementAny`,
+    ///   `ListElementAny` and `NonVecAny`.
     ///
     /// Note that:
     /// - Custom types can be used as values for either complex or element
@@ -661,6 +664,22 @@ impl ParamList {
                         element_lock = true;
                     }
                 }
+                (ParamType::ArrayElementAny, Some(t), None) => {
+                    constrained_type = Some(ScalarType::Array(Box::new(t.clone())));
+                    element_lock = t.is_custom_type();
+                }
+                (ParamType::ArrayElementAny, Some(t), Some(constrained)) => {
+                    let constrained_element_type = constrained.unwrap_array_element_type();
+                    if (element_lock && t.is_custom_type() && t != constrained_element_type)
+                        || !complex_base_eq(t, &constrained_element_type)
+                    {
+                        return None;
+                    }
+                    if t.is_custom_type() && !element_lock {
+                        constrained_type = Some(ScalarType::Array(Box::new(t.clone())));
+                        element_lock = true;
+                    }
+                }
                 (ParamType::ListElementAny, Some(t), None) => {
                     constrained_type = Some(ScalarType::List {
                         custom_oid: None,
@@ -751,6 +770,10 @@ pub enum ParamType {
     /// A polymorphic pseudotype permitting any array type.  For more details,
     /// see `ParamList::resolve_polymorphic_types`.
     ArrayAny,
+    /// A polymorphic pseudotype permitting all types, with more constraints
+    /// than `Any`, i.e. it is subject to polymorphic constraints. For more
+    /// details, see `ParamList::resolve_polymorphic_types`.
+    ArrayElementAny,
     /// A polymorphic pseudotype permitting a `ScalarType::List` of any element
     /// type.  For more details, see `ParamList::resolve_polymorphic_types`.
     ListAny,
@@ -779,7 +802,7 @@ impl ParamType {
         match self {
             ArrayAny => matches!(t, Array(..)),
             ListAny => matches!(t, List { .. }),
-            Any | ListElementAny => true,
+            Any | ArrayElementAny | ListElementAny => true,
             NonVecAny => !t.is_vec(),
             MapAny => matches!(t, Map { .. }),
             Plain(to) => typeconv::can_cast(ecx, CastContext::Implicit, t.clone(), to.clone()),
@@ -808,7 +831,7 @@ impl ParamType {
     fn is_polymorphic(&self) -> bool {
         use ParamType::*;
         match self {
-            ArrayAny | ListAny | MapAny | ListElementAny | NonVecAny => true,
+            ArrayAny | ArrayElementAny | ListAny | MapAny | ListElementAny | NonVecAny => true,
             Any | Plain(_) => false,
         }
     }
@@ -828,6 +851,7 @@ impl ParamType {
             },
             ParamType::Any => postgres_types::Type::ANY.oid(),
             ParamType::ArrayAny => postgres_types::Type::ANYARRAY.oid(),
+            ParamType::ArrayElementAny => postgres_types::Type::ANYELEMENT.oid(),
             ParamType::ListAny => pgrepr::LIST.oid(),
             ParamType::ListElementAny => postgres_types::Type::ANYELEMENT.oid(),
             ParamType::MapAny => pgrepr::MAP.oid(),
@@ -1211,6 +1235,10 @@ fn coerce_args_to_types(
             // Polymorphic pseudotypes. Convert based on constrained type.
             ParamType::ArrayAny | ParamType::ListAny | ParamType::MapAny => {
                 do_convert(arg, &get_constrained_ty())?
+            }
+            ParamType::ArrayElementAny => {
+                let constrained_array = get_constrained_ty();
+                do_convert(arg, &constrained_array.unwrap_array_element_type())?
             }
             ParamType::ListElementAny => {
                 let constrained_list = get_constrained_ty();

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1367,6 +1367,9 @@ lazy_static! {
             "array_lower" => Scalar {
                 params!(ArrayAny, Int64) => BinaryFunc::ArrayLower, 2091;
             },
+            "array_remove" => Scalar {
+                params!(ArrayAny, ArrayElementAny) => BinaryFunc::ArrayRemove, 3167;
+            },
             "array_to_string" => Scalar {
                 params!(ArrayAny, String) => Operation::variadic(array_to_string), 395;
                 params!(ArrayAny, String, String) => Operation::variadic(array_to_string), 384;

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -2226,6 +2226,12 @@ lazy_static! {
             "list_prepend" => Scalar {
                 vec![ListElementAny, ListAny] => BinaryFunc::ElementListConcat, oid::FUNC_LIST_PREPEND_OID;
             },
+            "list_remove" => Scalar {
+                vec![ListAny, ListElementAny] => Operation::binary(|ecx, lhs, rhs| {
+                    ecx.require_experimental_mode("list_remove")?;
+                    Ok(lhs.call_binary(rhs, BinaryFunc::ListRemove))
+                }), oid::FUNC_LIST_REMOVE_OID;
+            },
             "mz_cluster_id" => Scalar {
                 params!() => Operation::nullary(mz_cluster_id), oid::FUNC_MZ_CLUSTER_ID_OID;
             },

--- a/test/sqllogictest/arrays.slt
+++ b/test/sqllogictest/arrays.slt
@@ -418,3 +418,41 @@ SELECT ARRAY[1,2,3] > ARRAY['1','2','3']
 
 query error no overload for integer\[\] >= text\[\]: arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
 SELECT ARRAY[1,2,3] >= ARRAY['1','2','3']
+
+query T
+SELECT array_remove(ARRAY[1,2,3,2], 2)
+----
+{1,3}
+
+query T
+SELECT array_remove(ARRAY[1,2,3,2], 5)
+----
+{1,2,3,2}
+
+query T
+SELECT array_remove(ARRAY[1,2,3,NULL::INT], NULL::INT)
+----
+{1,2,3}
+
+query T
+SELECT array_remove(ARRAY[1,NULL::INT,2,3,NULL::INT], NULL::INT)
+----
+{1,2,3}
+
+query T
+SELECT array_remove(NULL::INT[], NULL::INT)
+----
+NULL
+
+query T
+SELECT array_remove(NULL::INT[], 1)
+----
+NULL
+
+query T
+SELECT array_remove(ARRAY[1,1,1], 1)
+----
+{}
+
+query error removing elements from multidimensional arrays is not supported
+SELECT array_remove(ARRAY[[1]], 1)

--- a/test/sqllogictest/list.slt
+++ b/test/sqllogictest/list.slt
@@ -2485,3 +2485,50 @@ query T
 SELECT sum(a ORDER BY b) FROM t2
 ----
 4
+
+# list_remove
+
+query T
+SELECT list_remove(LIST[1,2,3,2], 2)::text
+----
+{1,3}
+
+query T
+SELECT list_remove(LIST[1,2,3,2], 5)::text
+----
+{1,2,3,2}
+
+query T
+SELECT list_remove(LIST[1,2,3,NULL::INT], NULL::INT)::text
+----
+{1,2,3}
+
+query T
+SELECT list_remove(LIST[1,NULL::INT,2,3,NULL::INT], NULL::INT)::text
+----
+{1,2,3}
+
+query T
+SELECT list_remove(NULL::integer list, NULL::INT)::text
+----
+NULL
+
+query T
+SELECT list_remove(NULL::integer list, 1)::text
+----
+NULL
+
+query T
+SELECT list_remove(LIST[1,1,1], 1)::text
+----
+{}
+
+query T
+SELECT list_remove(LIST[[1,2],[1],[1,2,3], LIST[1]], LIST[1])::text
+----
+{{1,2},{1,2,3}}
+
+query T
+SELECT list_remove(LIST[[1,2],[1],[1,2,3],LIST[1]], LIST[1,2,3])::text
+----
+{{1,2},{1},{1}}


### PR DESCRIPTION
Add two functions to remove elements from our supported collections (arrays and lists) with identical API: `array_removal` and `list_removal`. As part of the work, support for `ArrayElementAny` was also added.

### Motivation

  * This PR contributes to two known-desirable features: #8229 and #9731

### Tips for reviewer

There are four commits in this PR that could be reviewed independently:
1. Add support for `ArrayElementAny` in `sql`
2. Add `array_remove` + tests
3. Add `list_remove` + tests
4. Release notes + docs

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/9836)
<!-- Reviewable:end -->
