### PR TITLE
sql: Implement date_part for Time data type

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -112,6 +112,9 @@ changes that have not yet been documented.
 - **Breaking change.** Disallow window functions outside of `SELECT`
   lists, `DISTINCT ON` clauses, and `ORDER BY` clauses.
 
+- Return an error when trying to extract date related fields from a Time data
+  type.
+
 {{< comment >}}
 Only add new release notes above this line.
 

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -112,8 +112,11 @@ changes that have not yet been documented.
 - **Breaking change.** Disallow window functions outside of `SELECT`
   lists, `DISTINCT ON` clauses, and `ORDER BY` clauses.
 
-- Return an error when trying to extract date related fields from a Time data
-  type.
+- **Breaking change.** Return an error when [`extract`](/sql/functions/extract/)
+  is called with a [`time`] value but a date-related field (e.g., `YEAR`).
+
+  Previous versions of Materialize would incorrectly return `0` in these cases.
+  The new behavior matches PostgreSQL.
 
 {{< comment >}}
 Only add new release notes above this line.

--- a/doc/user/content/sql/functions/extract.md
+++ b/doc/user/content/sql/functions/extract.md
@@ -12,9 +12,9 @@ menu:
 
 {{< diagram "func-extract.svg" >}}
 
-Parameter | Type | Description
-----------|------|------------
-_val_ | [`date`](../../types/date), [`timestamp`](../../types/timestamp), [`timestamp with time zone`](../../types/timestamptz) | The value from which you want to extract a component.
+Parameter | Type                                                                                                                                                | Description
+----------|-----------------------------------------------------------------------------------------------------------------------------------------------------|------------
+_val_ | [`date`](../../types/date), [`time`](../../types/time), [`timestamp`](../../types/timestamp), [`timestamp with time zone`](../../types/timestamptz) | The value from which you want to extract a component.
 
 ### Arguments
 

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -1789,8 +1789,8 @@ where
         | DateTimeUnits::DayOfYear
         | DateTimeUnits::IsoDayOfWeek
         | DateTimeUnits::IsoDayOfYear => Err(EvalError::UnsupportedUnits(
-            "time".to_string(),
             format!("{}", units),
+            "time".to_string(),
         )),
         DateTimeUnits::Timezone | DateTimeUnits::TimezoneHour | DateTimeUnits::TimezoneMinute => {
             Err(EvalError::Unsupported {

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -1365,18 +1365,49 @@ fn ascii<'a>(a: Datum<'a>) -> Datum<'a> {
     }
 }
 
+/// A timestamp with only a time component.
+pub trait TimeLike: chrono::Timelike {
+    fn extract_hour(&self) -> f64 {
+        f64::from(self.hour())
+    }
+
+    fn extract_minute(&self) -> f64 {
+        f64::from(self.minute())
+    }
+
+    fn extract_second(&self) -> f64 {
+        let s = f64::from(self.second());
+        let ns = f64::from(self.nanosecond()) / 1e9;
+        s + ns
+    }
+
+    fn extract_millisecond(&self) -> f64 {
+        let s = f64::from(self.second() * 1_000);
+        let ns = f64::from(self.nanosecond()) / 1e6;
+        s + ns
+    }
+
+    fn extract_microsecond(&self) -> f64 {
+        let s = f64::from(self.second() * 1_000_000);
+        let ns = f64::from(self.nanosecond()) / 1e3;
+        s + ns
+    }
+}
+
+impl<T> TimeLike for T where T:chrono::Timelike {}
+
 /// A timestamp with both a date and a time component, but not necessarily a
 /// timezone component.
 pub trait TimestampLike:
     Clone
     + PartialOrd
     + chrono::Datelike
-    + chrono::Timelike
     + std::ops::Add<Duration, Output = Self>
     + std::ops::Sub<Duration, Output = Self>
     + std::ops::Sub<Output = Duration>
     + for<'a> Into<Datum<'a>>
     + for<'a> TryFrom<Datum<'a>, Error = ()>
+    + TimeLike
 {
     fn new(date: NaiveDate, time: NaiveTime) -> Self;
 
@@ -1418,32 +1449,6 @@ pub trait TimestampLike:
 
     fn extract_day(&self) -> f64 {
         f64::from(self.day())
-    }
-
-    fn extract_hour(&self) -> f64 {
-        f64::from(self.hour())
-    }
-
-    fn extract_minute(&self) -> f64 {
-        f64::from(self.minute())
-    }
-
-    fn extract_second(&self) -> f64 {
-        let s = f64::from(self.second());
-        let ns = f64::from(self.nanosecond()) / 1e9;
-        s + ns
-    }
-
-    fn extract_millisecond(&self) -> f64 {
-        let s = f64::from(self.second() * 1_000);
-        let ns = f64::from(self.nanosecond()) / 1e6;
-        s + ns
-    }
-
-    fn extract_microsecond(&self) -> f64 {
-        let s = f64::from(self.second() * 1_000_000);
-        let ns = f64::from(self.nanosecond()) / 1e3;
-        s + ns
     }
 
     fn extract_millennium(&self) -> f64 {
@@ -1744,6 +1749,49 @@ fn date_part_interval_inner(
         | DateTimeUnits::DayOfYear
         | DateTimeUnits::IsoDayOfWeek
         | DateTimeUnits::IsoDayOfYear => Err(EvalError::Unsupported {
+            feature: format!("'{}' timestamp units", units),
+            issue_no: None,
+        }),
+    }
+}
+
+fn date_part_time<'a, T>(a: Datum<'a>, time: T) -> Result<Datum<'a>, EvalError>
+where
+    T: TimeLike
+{
+    let units = a.unwrap_str();
+    match units.parse() {
+        Ok(units) => date_part_time_inner(units, time),
+        Err(_) => Err(EvalError::UnknownUnits(units.to_owned())),
+    }
+}
+
+fn date_part_time_inner<'a, T>(units: DateTimeUnits, time: T) -> Result<Datum<'a>, EvalError>
+where
+    T: TimeLike
+{
+    match units {
+        DateTimeUnits::Hour => Ok(time.extract_hour().into()),
+        DateTimeUnits::Minute => Ok(time.extract_minute().into()),
+        DateTimeUnits::Second => Ok(time.extract_second().into()),
+        DateTimeUnits::Milliseconds => Ok(time.extract_millisecond().into()),
+        DateTimeUnits::Microseconds => Ok(time.extract_microsecond().into()),
+        DateTimeUnits::Epoch
+        | DateTimeUnits::Year
+        | DateTimeUnits::Week
+        | DateTimeUnits::Day
+        | DateTimeUnits::Millennium
+        | DateTimeUnits::Century
+        | DateTimeUnits::Decade
+        | DateTimeUnits::Quarter
+        | DateTimeUnits::Month
+        | DateTimeUnits::DayOfWeek
+        | DateTimeUnits::DayOfYear
+        | DateTimeUnits::IsoDayOfWeek
+        | DateTimeUnits::IsoDayOfYear => Err(EvalError::UnknownUnits(format!("{}", units))),
+        DateTimeUnits::Timezone
+        | DateTimeUnits::TimezoneHour
+        | DateTimeUnits::TimezoneMinute => Err(EvalError::Unsupported {
             feature: format!("'{}' timestamp units", units),
             issue_no: None,
         }),
@@ -2097,6 +2145,7 @@ pub enum BinaryFunc {
     DateBinTimestamp,
     DateBinTimestampTz,
     DatePartInterval,
+    DatePartTime,
     DatePartTimestamp,
     DatePartTimestampTz,
     DateTruncTimestamp,
@@ -2297,6 +2346,9 @@ impl BinaryFunc {
             BinaryFunc::DatePartInterval => {
                 eager!(|a, b: Datum| date_part_interval(a, b.unwrap_interval()))
             }
+            BinaryFunc::DatePartTime => {
+                eager!(|a, b: Datum| date_part_time(a, b.unwrap_time()))
+            }
             BinaryFunc::DatePartTimestamp => {
                 eager!(|a, b: Datum| date_part_timestamp(a, b.unwrap_timestamp()))
             }
@@ -2464,7 +2516,7 @@ impl BinaryFunc {
                 ScalarType::Timestamp.nullable(in_nullable)
             }
 
-            DatePartInterval | DatePartTimestamp | DatePartTimestampTz => {
+            DatePartInterval | DatePartTime | DatePartTimestamp | DatePartTimestampTz => {
                 ScalarType::Float64.nullable(true)
             }
 
@@ -2744,6 +2796,7 @@ impl BinaryFunc {
             | DateBinTimestamp
             | DateBinTimestampTz
             | DatePartInterval
+            | DatePartTime
             | DatePartTimestamp
             | DatePartTimestampTz
             | DateTruncTimestamp
@@ -2881,6 +2934,7 @@ impl fmt::Display for BinaryFunc {
             BinaryFunc::DateBinTimestamp => f.write_str("bin_unix_epoch_timestamp"),
             BinaryFunc::DateBinTimestampTz => f.write_str("bin_unix_epoch_timestamptz"),
             BinaryFunc::DatePartInterval => f.write_str("date_partiv"),
+            BinaryFunc::DatePartTime => f.write_str("date_partt"),
             BinaryFunc::DatePartTimestamp => f.write_str("date_partts"),
             BinaryFunc::DatePartTimestampTz => f.write_str("date_parttstz"),
             BinaryFunc::DateTruncTimestamp => f.write_str("date_truncts"),
@@ -3190,6 +3244,7 @@ pub enum UnaryFunc {
     IsRegexpMatch(Regex),
     RegexpMatch(Regex),
     DatePartInterval(DateTimeUnits),
+    DatePartTime(DateTimeUnits),
     DatePartTimestamp(DateTimeUnits),
     DatePartTimestampTz(DateTimeUnits),
     DateTruncTimestamp(DateTimeUnits),
@@ -3565,6 +3620,7 @@ impl UnaryFunc {
             IsRegexpMatch(regex) => Ok(is_regexp_match_static(a, &regex)),
             RegexpMatch(regex) => regexp_match_static(a, temp_storage, &regex),
             DatePartInterval(units) => date_part_interval_inner(*units, a.unwrap_interval()),
+            DatePartTime(units) => date_part_time_inner(*units, a.unwrap_time()),
             DatePartTimestamp(units) => date_part_timestamp_inner(*units, a.unwrap_timestamp()),
             DatePartTimestampTz(units) => date_part_timestamp_inner(*units, a.unwrap_timestamptz()),
             DateTruncTimestamp(units) => date_trunc_inner(*units, a.unwrap_timestamp()),
@@ -3784,7 +3840,7 @@ impl UnaryFunc {
                 return_ty.default_embedded_value().nullable(false)
             }
 
-            DatePartInterval(_) | DatePartTimestamp(_) | DatePartTimestampTz(_) => {
+            DatePartInterval(_) | DatePartTime(_) | DatePartTimestamp(_) | DatePartTimestampTz(_) => {
                 ScalarType::Float64.nullable(nullable)
             }
 
@@ -4005,7 +4061,7 @@ impl UnaryFunc {
             TimezoneTimestamp(_) => false,
             CastList1ToList2 { .. } | CastInPlace { .. } => false,
             JsonbTypeof | JsonbStripNulls | JsonbPretty | ListLength => false,
-            DatePartInterval(_) | DatePartTimestamp(_) | DatePartTimestampTz(_) => false,
+            DatePartInterval(_) | DatePartTime(_) | DatePartTimestamp(_) | DatePartTimestampTz(_) => false,
             DateTruncTimestamp(_) | DateTruncTimestampTz(_) => false,
             RescaleNumeric(_) => false,
         }
@@ -4248,6 +4304,7 @@ impl UnaryFunc {
             IsRegexpMatch(regex) => write!(f, "{} ~", regex.as_str().quoted()),
             RegexpMatch(regex) => write!(f, "regexp_match[{}]", regex.as_str()),
             DatePartInterval(units) => write!(f, "date_part_{}_iv", units),
+            DatePartTime(units) => write!(f, "date_part_{}_t", units),
             DatePartTimestamp(units) => write!(f, "date_part_{}_ts", units),
             DatePartTimestampTz(units) => write!(f, "date_part_{}_tstz", units),
             DateTruncTimestamp(units) => write!(f, "date_trunc_{}_ts", units),

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -1366,11 +1366,7 @@ fn ascii<'a>(a: Datum<'a>) -> Datum<'a> {
 }
 
 /// A timestamp with only a time component.
-pub trait TimeLike:
-    Copy
-    + chrono::Timelike
-    + for<'a> Into<Datum<'a>>
-{
+pub trait TimeLike: Copy + chrono::Timelike + for<'a> Into<Datum<'a>> {
     fn extract_hour(&self) -> f64 {
         f64::from(self.hour())
     }
@@ -1763,7 +1759,7 @@ fn date_part_interval_inner(
 
 fn date_part_time<'a, T>(a: Datum<'a>, time: T) -> Result<Datum<'a>, EvalError>
 where
-    T: TimeLike
+    T: TimeLike,
 {
     let units = a.unwrap_str();
     match units.parse() {
@@ -1774,7 +1770,7 @@ where
 
 fn date_part_time_inner<'a, T>(units: DateTimeUnits, time: T) -> Result<Datum<'a>, EvalError>
 where
-    T: TimeLike
+    T: TimeLike,
 {
     match units {
         DateTimeUnits::Hour => Ok(time.extract_hour().into()),
@@ -1795,13 +1791,15 @@ where
         | DateTimeUnits::DayOfYear
         | DateTimeUnits::IsoDayOfWeek
         | DateTimeUnits::IsoDayOfYear => Err(EvalError::UnsupportedUnits(
-            time.into().type_name().to_string(), format!("{}", units))),
-        DateTimeUnits::Timezone
-        | DateTimeUnits::TimezoneHour
-        | DateTimeUnits::TimezoneMinute => Err(EvalError::Unsupported {
-            feature: format!("'{}' timestamp units", units),
-            issue_no: None,
-        }),
+            time.into().type_name().to_string(),
+            format!("{}", units),
+        )),
+        DateTimeUnits::Timezone | DateTimeUnits::TimezoneHour | DateTimeUnits::TimezoneMinute => {
+            Err(EvalError::Unsupported {
+                feature: format!("'{}' timestamp units", units),
+                issue_no: None,
+            })
+        }
     }
 }
 
@@ -3847,9 +3845,10 @@ impl UnaryFunc {
                 return_ty.default_embedded_value().nullable(false)
             }
 
-            DatePartInterval(_) | DatePartTime(_) | DatePartTimestamp(_) | DatePartTimestampTz(_) => {
-                ScalarType::Float64.nullable(nullable)
-            }
+            DatePartInterval(_)
+            | DatePartTime(_)
+            | DatePartTimestamp(_)
+            | DatePartTimestampTz(_) => ScalarType::Float64.nullable(nullable),
 
             DateTruncTimestamp(_) => ScalarType::Timestamp.nullable(nullable),
             DateTruncTimestampTz(_) => ScalarType::TimestampTz.nullable(nullable),
@@ -4068,7 +4067,10 @@ impl UnaryFunc {
             TimezoneTimestamp(_) => false,
             CastList1ToList2 { .. } | CastInPlace { .. } => false,
             JsonbTypeof | JsonbStripNulls | JsonbPretty | ListLength => false,
-            DatePartInterval(_) | DatePartTime(_) | DatePartTimestamp(_) | DatePartTimestampTz(_) => false,
+            DatePartInterval(_)
+            | DatePartTime(_)
+            | DatePartTimestamp(_)
+            | DatePartTimestampTz(_) => false,
             DateTruncTimestamp(_) | DateTruncTimestampTz(_) => false,
             RescaleNumeric(_) => false,
         }

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -1366,7 +1366,7 @@ fn ascii<'a>(a: Datum<'a>) -> Datum<'a> {
 }
 
 /// A timestamp with only a time component.
-pub trait TimeLike: Copy + chrono::Timelike + for<'a> Into<Datum<'a>> {
+pub trait TimeLike: chrono::Timelike {
     fn extract_hour(&self) -> f64 {
         f64::from(self.hour())
     }
@@ -1394,9 +1394,7 @@ pub trait TimeLike: Copy + chrono::Timelike + for<'a> Into<Datum<'a>> {
     }
 }
 
-impl TimeLike for chrono::NaiveTime {}
-impl TimeLike for chrono::NaiveDateTime {}
-impl TimeLike for chrono::DateTime<chrono::Utc> {}
+impl<T> TimeLike for T where T: chrono::Timelike {}
 
 /// A timestamp with both a date and a time component, but not necessarily a
 /// timezone component.
@@ -1791,7 +1789,7 @@ where
         | DateTimeUnits::DayOfYear
         | DateTimeUnits::IsoDayOfWeek
         | DateTimeUnits::IsoDayOfYear => Err(EvalError::UnsupportedUnits(
-            time.into().type_name().to_string(),
+            "time".to_string(),
             format!("{}", units),
         )),
         DateTimeUnits::Timezone | DateTimeUnits::TimezoneHour | DateTimeUnits::TimezoneMinute => {

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -386,6 +386,18 @@ impl MirScalarExpr {
                                     e.typ(&relation_type).scalar_type,
                                 ),
                             }
+                        } else if *func == BinaryFunc::DatePartTime && expr1.is_literal() {
+                            let units = expr1.as_literal_str().unwrap();
+                            *e = match units.parse::<DateTimeUnits>() {
+                                Ok(units) => MirScalarExpr::CallUnary {
+                                    func: UnaryFunc::DatePartTime(units),
+                                    expr: Box::new(expr2.take()),
+                                },
+                                Err(_) => MirScalarExpr::literal(
+                                    Err(EvalError::UnknownUnits(units.to_owned())),
+                                    e.typ(&relation_type).scalar_type,
+                                ),
+                            }
                         } else if *func == BinaryFunc::DatePartTimestamp && expr1.is_literal() {
                             let units = expr1.as_literal_str().unwrap();
                             *e = match units.parse::<DateTimeUnits>() {

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -1264,7 +1264,9 @@ impl fmt::Display for EvalError {
             EvalError::InvalidRegexFlag(c) => write!(f, "invalid regular expression flag: {}", c),
             EvalError::InvalidParameterValue(s) => f.write_str(s),
             EvalError::UnknownUnits(units) => write!(f, "unknown units '{}'", units),
-            EvalError::UnsupportedUnits(typ, units) => write!(f, "{} units '{}' not supported", typ, units),
+            EvalError::UnsupportedUnits(typ, units) => {
+                write!(f, "{} units '{}' not supported", typ, units)
+            }
             EvalError::UnterminatedLikeEscapeSequence => {
                 f.write_str("unterminated escape sequence in LIKE")
             }

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -1263,9 +1263,9 @@ impl fmt::Display for EvalError {
             EvalError::InvalidRegex(e) => write!(f, "invalid regular expression: {}", e),
             EvalError::InvalidRegexFlag(c) => write!(f, "invalid regular expression flag: {}", c),
             EvalError::InvalidParameterValue(s) => f.write_str(s),
-            EvalError::UnknownUnits(units) => write!(f, "unknown units '{}'", units),
-            EvalError::UnsupportedUnits(typ, units) => {
-                write!(f, "{} units '{}' not supported", typ, units)
+            EvalError::UnknownUnits(units) => write!(f, "unit '{}' not recognized", units),
+            EvalError::UnsupportedUnits(units, typ) => {
+                write!(f, "unit '{}' not supported for type {}", units, typ)
             }
             EvalError::UnterminatedLikeEscapeSequence => {
                 f.write_str("unterminated escape sequence in LIKE")

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -1185,6 +1185,7 @@ pub enum EvalError {
     InvalidParameterValue(String),
     NegSqrt,
     UnknownUnits(String),
+    UnsupportedUnits(String, String),
     UnterminatedLikeEscapeSequence,
     Parse(ParseError),
     ParseHex(ParseHexError),
@@ -1263,6 +1264,7 @@ impl fmt::Display for EvalError {
             EvalError::InvalidRegexFlag(c) => write!(f, "invalid regular expression flag: {}", c),
             EvalError::InvalidParameterValue(s) => f.write_str(s),
             EvalError::UnknownUnits(units) => write!(f, "unknown units '{}'", units),
+            EvalError::UnsupportedUnits(typ, units) => write!(f, "{} units '{}' not supported", typ, units),
             EvalError::UnterminatedLikeEscapeSequence => {
                 f.write_str("unterminated escape sequence in LIKE")
             }

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -606,6 +606,34 @@ impl<'a> Datum<'a> {
         }
         is_instance_of_scalar(self, &column_type.scalar_type)
     }
+
+    /// Returns the name of the type
+    pub fn type_name(&self) -> &'static str {
+        match self {
+            Datum::False
+            | Datum::True => "boolean",
+            Datum::Int16(_) => "int16",
+            Datum::Int32(_) => "int32",
+            Datum::Int64(_) => "int64",
+            Datum::Float32(_) => "float32",
+            Datum::Float64(_) => "float64",
+            Datum::Date(_) => "date",
+            Datum::Time(_) => "time",
+            Datum::Timestamp(_) => "timestamp",
+            Datum::TimestampTz(_) => "timestamptz",
+            Datum::Interval(_) => "interval",
+            Datum::Bytes(_) => "bytes",
+            Datum::String(_) => "string",
+            Datum::Array(_) => "array",
+            Datum::List(_) => "list",
+            Datum::Map(_) => "map",
+            Datum::Numeric(_) => "numeric",
+            Datum::JsonNull => "json",
+            Datum::Uuid(_) => "uuid",
+            Datum::Dummy => "dummy",
+            Datum::Null => "null"
+        }
+    }
 }
 
 impl<'a> From<bool> for Datum<'a> {

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -610,8 +610,7 @@ impl<'a> Datum<'a> {
     /// Returns the name of the type
     pub fn type_name(&self) -> &'static str {
         match self {
-            Datum::False
-            | Datum::True => "boolean",
+            Datum::False | Datum::True => "boolean",
             Datum::Int16(_) => "int16",
             Datum::Int32(_) => "int32",
             Datum::Int64(_) => "int64",
@@ -631,7 +630,7 @@ impl<'a> Datum<'a> {
             Datum::JsonNull => "json",
             Datum::Uuid(_) => "uuid",
             Datum::Dummy => "dummy",
-            Datum::Null => "null"
+            Datum::Null => "null",
         }
     }
 }

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -606,33 +606,6 @@ impl<'a> Datum<'a> {
         }
         is_instance_of_scalar(self, &column_type.scalar_type)
     }
-
-    /// Returns the name of the type
-    pub fn type_name(&self) -> &'static str {
-        match self {
-            Datum::False | Datum::True => "boolean",
-            Datum::Int16(_) => "int16",
-            Datum::Int32(_) => "int32",
-            Datum::Int64(_) => "int64",
-            Datum::Float32(_) => "float32",
-            Datum::Float64(_) => "float64",
-            Datum::Date(_) => "date",
-            Datum::Time(_) => "time",
-            Datum::Timestamp(_) => "timestamp",
-            Datum::TimestampTz(_) => "timestamptz",
-            Datum::Interval(_) => "interval",
-            Datum::Bytes(_) => "bytes",
-            Datum::String(_) => "string",
-            Datum::Array(_) => "array",
-            Datum::List(_) => "list",
-            Datum::Map(_) => "map",
-            Datum::Numeric(_) => "numeric",
-            Datum::JsonNull => "json",
-            Datum::Uuid(_) => "uuid",
-            Datum::Dummy => "dummy",
-            Datum::Null => "null",
-        }
-    }
 }
 
 impl<'a> From<bool> for Datum<'a> {

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1458,6 +1458,7 @@ lazy_static! {
             },
             "date_part" => Scalar {
                 params!(String, Interval) => BinaryFunc::DatePartInterval, 1172;
+                params!(String, Time) => BinaryFunc::DatePartTime, 1385;
                 params!(String, Timestamp) => BinaryFunc::DatePartTimestamp, 2021;
                 params!(String, TimestampTz) => BinaryFunc::DatePartTimestampTz, 1171;
             },

--- a/test/sqllogictest/dates-times.slt
+++ b/test/sqllogictest/dates-times.slt
@@ -751,6 +751,24 @@ SELECT (INTERVAL '1-3' YEAR TO MONTH)::text
 ----
 1 year 3 months
 
+query RRRRR
+SELECT EXTRACT(hour from TIME '11:12:42.666'),
+    EXTRACT(minute from TIME '11:12:42.666'),
+    EXTRACT(second from TIME '11:12:42.666'),
+    EXTRACT(milliseconds from TIME '11:12:42.666'),
+    EXTRACT(microseconds from TIME '11:12:42.666')
+----
+11 12 42.666 42666 42666000
+
+query error
+SELECT EXTRACT(year from TIME '11:12:42.666')
+
+query error
+SELECT EXTRACT(month from TIME '11:12:42.666')
+
+query error
+SELECT EXTRACT(day from TIME '11:12:42.666')
+
 query RR
 SELECT EXTRACT(dow FROM TIMESTAMP '1999-12-26 00:00:00'), EXTRACT(dow FROM TIMESTAMP '2000-01-01 00:00:00')
 ----

--- a/test/sqllogictest/dates-times.slt
+++ b/test/sqllogictest/dates-times.slt
@@ -760,13 +760,13 @@ SELECT EXTRACT(hour from TIME '11:12:42.666'),
 ----
 11 12 42.666 42666 42666000
 
-query error time units 'year' not supported
+query error unit 'year' not supported for type time
 SELECT EXTRACT(year from TIME '11:12:42.666')
 
-query error time units 'month' not supported
+query error unit 'month' not supported for type time
 SELECT EXTRACT(month from TIME '11:12:42.666')
 
-query error time units 'day' not supported
+query error unit 'day' not supported for type time
 SELECT EXTRACT(day from TIME '11:12:42.666')
 
 query RR

--- a/test/sqllogictest/dates-times.slt
+++ b/test/sqllogictest/dates-times.slt
@@ -760,13 +760,13 @@ SELECT EXTRACT(hour from TIME '11:12:42.666'),
 ----
 11 12 42.666 42666 42666000
 
-query error
+query error time units 'year' not supported
 SELECT EXTRACT(year from TIME '11:12:42.666')
 
-query error
+query error time units 'month' not supported
 SELECT EXTRACT(month from TIME '11:12:42.666')
 
-query error
+query error time units 'day' not supported
 SELECT EXTRACT(day from TIME '11:12:42.666')
 
 query RR


### PR DESCRIPTION
The date_part_* functions internally implements the EXTRACT SQL
function. The Time data type didn't have any date_part implementations,
however the Interval data type did have an implementation. This caused
the Time type to be coerced into a Interval type whenever EXTRACT was
called with Time. Date related fields (such as Year, Month, Day, etc)
are valid for Interval types, therefore they become valid for Time
types too instead of returning an error.

This commit implements a date_part function for the Time data type that
returns an error for all date related fields. Now EXTRACT doesn't
coerce Time types to Interval and instead uses the Time implementation
directly.

Fixes #5701

<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

This PR fixes a recognized bug: https://github.com/MaterializeInc/materialize/issues/5701
<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug: [Link to issue.]

  * This PR adds a known-desirable feature: [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
