### PR TITLE
doc/developer: Fix broken link in testing guide

### DIFF
--- a/doc/developer/guide-testing.md
+++ b/doc/developer/guide-testing.md
@@ -41,7 +41,7 @@ $ cargo test
 
 Some of the packages have tests that depend on ZooKeeper, Kafka, and the
 Confluent Schema Registry running locally on the default ports. See the
-[Developer guide](develop.md) for full details on setting this up, but
+[Developer guide](guide.md) for full details on setting this up, but
 the following will do the trick if you have the Confluent Platform 5.3+ CLI
 installed and configured:
 


### PR DESCRIPTION
<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->
Within guide-testing.md, the link to provide more info on installing ZooKeeper, Kafka, and the Confluent Schema Registry point to develop.md which doesn't exist. I've replaced it with guide.md which seems to include information on setting these up. 


### Motivation
This PR fixes a previously unreported bug.

There is a broken link in guide-testing.md
<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug: [Link to issue.]

  * This PR adds a known-desirable feature: [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
