### PR TITLE
Python dependency bump 2022-01-02

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,9 +39,8 @@ updates:
 - package-ecosystem: pip
   directory: /ci/builder
   schedule:
-    # These dependencies get baked into the CI builder image, which we don't
-    # want to rebuild more often than we need to.
-    interval: monthly
+    interval: weekly
+    day: sunday
     time: "22:00"
   open-pull-requests-limit: 10
   reviewers: [MaterializeInc/dependency-czars]

--- a/ci/builder/requirements-core.txt
+++ b/ci/builder/requirements-core.txt
@@ -4,4 +4,4 @@
 # add to this list without consulting with @benesch!
 
 pip==21.3.1
-setuptools==60.1.0
+setuptools==60.2.0

--- a/ci/builder/requirements-dev.txt
+++ b/ci/builder/requirements-dev.txt
@@ -13,7 +13,7 @@ ec2instanceconnectcli==1.0.2
 flake8==4.0.1
 isort==5.10.1
 mypy==0.920
-numpy==1.21.5
+numpy==1.22.0
 pandas==1.3.5
 pdoc3==0.10.0
 psutil==5.8.0

--- a/ci/builder/requirements-dev.txt
+++ b/ci/builder/requirements-dev.txt
@@ -16,7 +16,7 @@ mypy==0.920
 numpy==1.22.0
 pandas==1.3.5
 pdoc3==0.10.0
-psutil==5.8.0
+psutil==5.9.0
 # psycopg2 intentionally omitted. Use pg8000 from requirements-core.txt instead.
 pydantic==1.8.2
 pytest==6.2.5

--- a/ci/builder/requirements-dev.txt
+++ b/ci/builder/requirements-dev.txt
@@ -25,7 +25,7 @@ scipy==1.7.3
 twine==3.7.1
 types-prettytable==2.1.1
 types-psutil==5.8.17
-types-PyMYSQL==1.0.7
+types-PyMYSQL==1.0.8
 types-PyYAML==6.0.1
 types-requests==2.26.2
 types-toml==0.10.1

--- a/ci/builder/requirements-dev.txt
+++ b/ci/builder/requirements-dev.txt
@@ -24,7 +24,7 @@ requests==2.26.0
 scipy==1.7.3
 twine==3.7.1
 types-prettytable==2.1.1
-types-psutil==5.8.16
+types-psutil==5.8.17
 types-PyMYSQL==1.0.7
 types-PyYAML==6.0.1
 types-requests==2.26.2

--- a/ci/builder/requirements-dev.txt
+++ b/ci/builder/requirements-dev.txt
@@ -27,6 +27,6 @@ types-prettytable==2.1.1
 types-psutil==5.8.17
 types-PyMYSQL==1.0.8
 types-PyYAML==6.0.1
-types-requests==2.26.2
+types-requests==2.26.3
 types-toml==0.10.1
 types-pkg-resources==0.1.3

--- a/ci/builder/requirements-dev.txt
+++ b/ci/builder/requirements-dev.txt
@@ -18,7 +18,7 @@ pandas==1.3.5
 pdoc3==0.10.0
 psutil==5.9.0
 # psycopg2 intentionally omitted. Use pg8000 from requirements-core.txt instead.
-pydantic==1.8.2
+pydantic==1.9.0
 pytest==6.2.5
 requests==2.26.0
 scipy==1.7.3

--- a/misc/python/materialize/feature_benchmark/termination.py
+++ b/misc/python/materialize/feature_benchmark/termination.py
@@ -61,7 +61,7 @@ class ProbForMin(TerminationCondition):
         if len(self._data) > 5:
             mean = np.mean(self._data)
             stdev = np.std(self._data)
-            min_val = np.min(self._data)  # type: ignore
+            min_val = np.min(self._data)
             dist = stats.norm(loc=mean, scale=stdev)
             prob = dist.cdf(min_val)
             if prob < (1 - self._threshold):


### PR DESCRIPTION
Bundle this week's Python dependency bumps.

### Motivation

Amalgamates existing dependabot PRs.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
