### PR TITLE
python: fix exit code on failure

### DIFF
--- a/misc/python/materialize/ui.py
+++ b/misc/python/materialize/ui.py
@@ -194,5 +194,6 @@ def error_handler(prog: str) -> Any:
         print(f"{prog}: {fg('red')}error:{attr('reset')} {e}", file=sys.stderr)
         if e.hint:
             print(f"{attr('bold')}hint:{attr('reset')} {e.hint}")
+        sys.exit(1)
     except KeyboardInterrupt:
         sys.exit(1)


### PR DESCRIPTION
Fix a bad bug in error reporting, introduced in 1e869d6, that caused
Python to exit successfully when handling a UIError.

Fix #9850.

### Motivation

  * This PR fixes a recognized bug

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
