### PR TITLE
Remove `drop` and `complete`, which are redundant with an empty input frontier, from the tail protocol

### DIFF
--- a/src/coord/src/tail.rs
+++ b/src/coord/src/tail.rs
@@ -108,10 +108,6 @@ impl PendingTail {
                 }
                 false
             }
-            TailResponse::Complete | TailResponse::Dropped => {
-                // TODO: Could perhaps do this earlier, in response to DROP SINK.
-                true
-            }
         }
     }
 }

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -66,12 +66,6 @@ pub enum TailResponse {
     Progress(Antichain<Timestamp>),
     /// Rows that should be returned in order to the client.
     Rows(Vec<(Row, Timestamp, Diff)>),
-    /// Sent once the stream is complete. Indicates the end.
-    /// TODO(#9479): mh@ thinks this state can be included in Progress with an emtpy antichain
-    Complete,
-    /// The TAIL dataflow was dropped before completing. Indicates the end.
-    /// TODO(#9479): mh@ thinks this state can be included in Progress with an emtpy antichain
-    Dropped,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION

<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

[This comment](https://github.com/TimelyDataflow/timely-dataflow/blob/1f09f66/timely/src/progress/subgraph.rs#L353) (running after the child is scheduled) suggests that operators will not be shut down until they have been scheduled with an empty input frontier.

Thus, `drop` and `complete` are redundant for the tail protocol, as I discuss in [this comment](https://github.com/MaterializeInc/materialize/issues/9479#issuecomment-1003743830), because they will only ever be delivered after a progress message with an empty antichain is delivered, which causes the sink to be removed anyway. 

### Motivation

* This PR adds a known-desirable feature: Fixes #9479 

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug: [Link to issue.]

  * This PR adds a known-desirable feature: [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->



### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
