### PR TITLE
Revert "sql: refactor visit methods"

### DIFF
--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -174,32 +174,41 @@ pub struct WindowExpr {
 }
 
 impl WindowExpr {
-    pub fn visit_expressions<'a, F, E>(&'a self, f: &mut F) -> Result<(), E>
-    where
-        F: FnMut(&'a HirScalarExpr) -> Result<(), E>,
-    {
-        self.func.visit_expressions(f)?;
-        for expr in self.partition.iter() {
-            f(expr)?;
+    pub fn bind_parameters(&mut self, params: &Params) -> Result<(), anyhow::Error> {
+        self.func.bind_parameters(params)?;
+        for p in self.partition.iter_mut() {
+            p.bind_parameters(params)?;
         }
-        for expr in self.order_by.iter() {
-            f(expr)?;
+        for p in self.order_by.iter_mut() {
+            p.bind_parameters(params)?;
         }
         Ok(())
     }
 
-    pub fn visit_expressions_mut<'a, F, E>(&'a mut self, f: &mut F) -> Result<(), E>
+    pub fn visit_expressions<'a, F>(&'a self, f: &mut F)
     where
-        F: FnMut(&'a mut HirScalarExpr) -> Result<(), E>,
+        F: FnMut(&'a HirScalarExpr),
     {
-        self.func.visit_expressions_mut(f)?;
+        self.func.visit_expressions(f);
+        for expr in self.partition.iter() {
+            f(expr)
+        }
+        for expr in self.order_by.iter() {
+            f(expr)
+        }
+    }
+
+    pub fn visit_expressions_mut<'a, F>(&'a mut self, f: &mut F)
+    where
+        F: FnMut(&'a mut HirScalarExpr),
+    {
+        self.func.visit_expressions_mut(f);
         for expr in self.partition.iter_mut() {
-            f(expr)?;
+            f(expr)
         }
         for expr in self.order_by.iter_mut() {
-            f(expr)?;
+            f(expr)
         }
-        Ok(())
     }
 }
 
@@ -218,18 +227,24 @@ pub enum WindowExprType {
 }
 
 impl WindowExprType {
-    pub fn visit_expressions<'a, F, E>(&'a self, f: &mut F) -> Result<(), E>
+    pub fn bind_parameters(&mut self, params: &Params) -> Result<(), anyhow::Error> {
+        match self {
+            Self::Scalar(expr) => expr.bind_parameters(params),
+        }
+    }
+
+    pub fn visit_expressions<'a, F>(&'a self, f: &mut F)
     where
-        F: FnMut(&'a HirScalarExpr) -> Result<(), E>,
+        F: FnMut(&'a HirScalarExpr),
     {
         match self {
             Self::Scalar(expr) => expr.visit_expressions(f),
         }
     }
 
-    pub fn visit_expressions_mut<'a, F, E>(&'a mut self, f: &mut F) -> Result<(), E>
+    pub fn visit_expressions_mut<'a, F>(&'a mut self, f: &mut F)
     where
-        F: FnMut(&'a mut HirScalarExpr) -> Result<(), E>,
+        F: FnMut(&'a mut HirScalarExpr),
     {
         match self {
             Self::Scalar(expr) => expr.visit_expressions_mut(f),
@@ -255,24 +270,29 @@ pub struct ScalarWindowExpr {
 }
 
 impl ScalarWindowExpr {
-    pub fn visit_expressions<'a, F, E>(&'a self, _f: &mut F) -> Result<(), E>
-    where
-        F: FnMut(&'a HirScalarExpr) -> Result<(), E>,
-    {
+    pub fn bind_parameters(&mut self, _params: &Params) -> Result<(), anyhow::Error> {
         match self.func {
             ScalarWindowFunc::RowNumber => {}
         }
         Ok(())
     }
 
-    pub fn visit_expressions_mut<'a, F, E>(&'a mut self, _f: &mut F) -> Result<(), E>
+    pub fn visit_expressions<'a, F>(&'a self, _f: &mut F)
     where
-        F: FnMut(&'a mut HirScalarExpr) -> Result<(), E>,
+        F: FnMut(&'a HirScalarExpr),
     {
         match self.func {
             ScalarWindowFunc::RowNumber => {}
         }
-        Ok(())
+    }
+
+    pub fn visit_expressions_mut<'a, F>(&'a mut self, _f: &mut F)
+    where
+        F: FnMut(&'a mut HirScalarExpr),
+    {
+        match self.func {
+            ScalarWindowFunc::RowNumber => {}
+        }
     }
 
     fn typ(
@@ -956,269 +976,192 @@ impl HirRelationExpr {
         )
     }
 
-    pub fn visit<'a, F>(&'a self, depth: usize, f: &mut F)
+    // TODO(benesch): these visit methods are too duplicative. Figure out how
+    // to deduplicate.
+
+    pub fn visit<'a, F>(&'a self, f: &mut F)
     where
-        F: FnMut(&'a Self, usize),
+        F: FnMut(&'a Self),
     {
-        let _ = self.visit_fallible(depth, &mut |e: &HirRelationExpr,
-                                                 depth: usize|
-         -> Result<(), ()> {
-            f(e, depth);
-            Ok(())
-        });
+        self.visit1(|e: &HirRelationExpr| e.visit(f));
+        f(self);
     }
 
-    pub fn visit_fallible<'a, F, E>(&'a self, depth: usize, f: &mut F) -> Result<(), E>
+    pub fn visit1<'a, F>(&'a self, mut f: F)
     where
-        F: FnMut(&'a Self, usize) -> Result<(), E>,
-    {
-        self.visit1(depth, |e: &HirRelationExpr, depth: usize| {
-            e.visit_fallible(depth, f)
-        })?;
-        f(self, depth)
-    }
-
-    pub fn visit1<'a, F, E>(&'a self, depth: usize, mut f: F) -> Result<(), E>
-    where
-        F: FnMut(&'a Self, usize) -> Result<(), E>,
+        F: FnMut(&'a Self),
     {
         match self {
             HirRelationExpr::Constant { .. }
             | HirRelationExpr::Get { .. }
             | HirRelationExpr::CallTable { .. } => (),
             HirRelationExpr::Let { body, value, .. } => {
-                f(value, depth)?;
-                f(body, depth)?;
+                f(value);
+                f(body);
             }
             HirRelationExpr::Project { input, .. } => {
-                f(input, depth)?;
+                f(input);
             }
             HirRelationExpr::Map { input, .. } => {
-                f(input, depth)?;
+                f(input);
             }
             HirRelationExpr::Filter { input, .. } => {
-                f(input, depth)?;
+                f(input);
             }
             HirRelationExpr::Join { left, right, .. } => {
-                f(left, depth)?;
-                f(right, depth + 1)?;
+                f(left);
+                f(right);
             }
             HirRelationExpr::Reduce { input, .. } => {
-                f(input, depth)?;
+                f(input);
             }
             HirRelationExpr::Distinct { input } => {
-                f(input, depth)?;
+                f(input);
             }
             HirRelationExpr::TopK { input, .. } => {
-                f(input, depth)?;
+                f(input);
             }
             HirRelationExpr::Negate { input } => {
-                f(input, depth)?;
+                f(input);
             }
             HirRelationExpr::Threshold { input } => {
-                f(input, depth)?;
+                f(input);
             }
             HirRelationExpr::DeclareKeys { input, .. } => {
-                f(input, depth)?;
+                f(input);
             }
             HirRelationExpr::Union { base, inputs } => {
-                f(base, depth)?;
+                f(base);
                 for input in inputs {
-                    f(input, depth)?;
+                    f(input);
                 }
             }
         }
-        Ok(())
     }
 
-    pub fn visit_mut<F>(&mut self, depth: usize, f: &mut F)
+    pub fn visit_mut<F>(&mut self, f: &mut F)
     where
-        F: FnMut(&mut Self, usize),
+        F: FnMut(&mut Self),
     {
-        let _ = self.visit_mut_fallible(depth, &mut |e: &mut HirRelationExpr,
-                                                     depth: usize|
-         -> Result<(), ()> {
-            f(e, depth);
-            Ok(())
-        });
+        self.visit1_mut(|e: &mut HirRelationExpr| e.visit_mut(f));
+        f(self);
     }
 
-    pub fn visit_mut_fallible<F, E>(&mut self, depth: usize, f: &mut F) -> Result<(), E>
+    pub fn visit1_mut<'a, F>(&'a mut self, mut f: F)
     where
-        F: FnMut(&mut Self, usize) -> Result<(), E>,
-    {
-        self.visit1_mut(depth, |e: &mut HirRelationExpr, depth: usize| {
-            e.visit_mut_fallible(depth, f)
-        })?;
-        f(self, depth)
-    }
-
-    pub fn visit1_mut<'a, F, E>(&'a mut self, depth: usize, mut f: F) -> Result<(), E>
-    where
-        F: FnMut(&'a mut Self, usize) -> Result<(), E>,
+        F: FnMut(&'a mut Self),
     {
         match self {
             HirRelationExpr::Constant { .. }
             | HirRelationExpr::Get { .. }
             | HirRelationExpr::CallTable { .. } => (),
             HirRelationExpr::Let { body, value, .. } => {
-                f(value, depth)?;
-                f(body, depth)?;
+                f(value);
+                f(body);
             }
             HirRelationExpr::Project { input, .. } => {
-                f(input, depth)?;
+                f(input);
             }
             HirRelationExpr::Map { input, .. } => {
-                f(input, depth)?;
+                f(input);
             }
             HirRelationExpr::Filter { input, .. } => {
-                f(input, depth)?;
+                f(input);
             }
             HirRelationExpr::Join { left, right, .. } => {
-                f(left, depth)?;
-                f(right, depth + 1)?;
+                f(left);
+                f(right);
             }
             HirRelationExpr::Reduce { input, .. } => {
-                f(input, depth)?;
+                f(input);
             }
             HirRelationExpr::Distinct { input } => {
-                f(input, depth)?;
+                f(input);
             }
             HirRelationExpr::TopK { input, .. } => {
-                f(input, depth)?;
+                f(input);
             }
             HirRelationExpr::Negate { input } => {
-                f(input, depth)?;
+                f(input);
             }
             HirRelationExpr::Threshold { input } => {
-                f(input, depth)?;
+                f(input);
             }
             HirRelationExpr::DeclareKeys { input, .. } => {
-                f(input, depth)?;
+                f(input);
             }
             HirRelationExpr::Union { base, inputs } => {
-                f(base, depth)?;
+                f(base);
                 for input in inputs {
-                    f(input, depth)?;
+                    f(input);
                 }
             }
         }
-        Ok(())
-    }
-
-    /// Visits all scalar expressions within the sub-tree of the given relation.
-    ///
-    /// The `depth` argument should indicate the subquery nesting depth of the expression,
-    /// which will be incremented when entering the RHS of a join or a subquery and
-    /// presented to the supplied function `f`.
-    pub fn visit_scalar_expressions<F, E>(&self, depth: usize, f: &mut F) -> Result<(), E>
-    where
-        F: FnMut(&HirScalarExpr, usize) -> Result<(), E>,
-    {
-        self.visit_fallible(depth, &mut |e: &HirRelationExpr,
-                                         depth: usize|
-         -> Result<(), E> {
-            match e {
-                HirRelationExpr::Join { on, .. } => {
-                    f(on, depth)?;
-                }
-                HirRelationExpr::Map { scalars, .. } => {
-                    for scalar in scalars {
-                        f(scalar, depth)?;
-                    }
-                }
-                HirRelationExpr::CallTable { exprs, .. } => {
-                    for expr in exprs {
-                        f(expr, depth)?;
-                    }
-                }
-                HirRelationExpr::Filter { predicates, .. } => {
-                    for predicate in predicates {
-                        f(predicate, depth)?;
-                    }
-                }
-                HirRelationExpr::Reduce { aggregates, .. } => {
-                    for aggregate in aggregates {
-                        f(&aggregate.expr, depth)?;
-                    }
-                }
-                HirRelationExpr::Union { .. }
-                | HirRelationExpr::Let { .. }
-                | HirRelationExpr::Project { .. }
-                | HirRelationExpr::Distinct { .. }
-                | HirRelationExpr::TopK { .. }
-                | HirRelationExpr::Negate { .. }
-                | HirRelationExpr::DeclareKeys { .. }
-                | HirRelationExpr::Threshold { .. }
-                | HirRelationExpr::Constant { .. }
-                | HirRelationExpr::Get { .. } => (),
-            }
-            Ok(())
-        })
-    }
-
-    /// Like `visit_scalar_expressions`, but permits mutating the expressions.
-    pub fn visit_scalar_expressions_mut<F, E>(&mut self, depth: usize, f: &mut F) -> Result<(), E>
-    where
-        F: FnMut(&mut HirScalarExpr, usize) -> Result<(), E>,
-    {
-        self.visit_mut_fallible(depth, &mut |e: &mut HirRelationExpr,
-                                             depth: usize|
-         -> Result<(), E> {
-            match e {
-                HirRelationExpr::Join { on, .. } => {
-                    f(on, depth)?;
-                }
-                HirRelationExpr::Map { scalars, .. } => {
-                    for scalar in scalars.iter_mut() {
-                        f(scalar, depth)?;
-                    }
-                }
-                HirRelationExpr::CallTable { exprs, .. } => {
-                    for expr in exprs.iter_mut() {
-                        f(expr, depth)?;
-                    }
-                }
-                HirRelationExpr::Filter { predicates, .. } => {
-                    for predicate in predicates.iter_mut() {
-                        f(predicate, depth)?;
-                    }
-                }
-                HirRelationExpr::Reduce { aggregates, .. } => {
-                    for aggregate in aggregates.iter_mut() {
-                        f(&mut aggregate.expr, depth)?;
-                    }
-                }
-                HirRelationExpr::Union { .. }
-                | HirRelationExpr::Let { .. }
-                | HirRelationExpr::Project { .. }
-                | HirRelationExpr::Distinct { .. }
-                | HirRelationExpr::TopK { .. }
-                | HirRelationExpr::Negate { .. }
-                | HirRelationExpr::DeclareKeys { .. }
-                | HirRelationExpr::Threshold { .. }
-                | HirRelationExpr::Constant { .. }
-                | HirRelationExpr::Get { .. } => (),
-            }
-            Ok(())
-        })
     }
 
     /// Visits the column references in this relation expression.
     ///
     /// The `depth` argument should indicate the subquery nesting depth of the expression,
-    /// which will be incremented when entering the RHS of a join or a subquery and
-    /// presented to the supplied function `f`.
+    /// which will be incremented with each subquery entered and presented to the supplied
+    /// function `f`.
     pub fn visit_columns<F>(&self, depth: usize, f: &mut F)
     where
         F: FnMut(usize, &ColumnRef),
     {
-        let _ = self.visit_scalar_expressions(depth, &mut |e: &HirScalarExpr,
-                                                           depth: usize|
-         -> Result<(), ()> {
-            e.visit_columns(depth, f);
-            Ok(())
-        });
+        match self {
+            HirRelationExpr::Let { body, value, .. } => {
+                value.visit_columns(depth, f);
+                body.visit_columns(depth, f);
+            }
+            HirRelationExpr::Join {
+                on, left, right, ..
+            } => {
+                left.visit_columns(depth, f);
+                right.visit_columns(depth + 1, f);
+                // The ON clause doesn't belong in the lateral context
+                on.visit_columns(depth, f);
+            }
+            HirRelationExpr::Map { scalars, input } => {
+                for scalar in scalars {
+                    scalar.visit_columns(depth, f);
+                }
+                input.visit_columns(depth, f);
+            }
+            HirRelationExpr::CallTable { exprs, .. } => {
+                for expr in exprs {
+                    expr.visit_columns(depth, f);
+                }
+            }
+            HirRelationExpr::Filter { predicates, input } => {
+                for predicate in predicates {
+                    predicate.visit_columns(depth, f);
+                }
+                input.visit_columns(depth, f);
+            }
+            HirRelationExpr::Reduce {
+                aggregates, input, ..
+            } => {
+                for aggregate in aggregates {
+                    aggregate.visit_columns(depth, f);
+                }
+                input.visit_columns(depth, f);
+            }
+            HirRelationExpr::Union { base, inputs } => {
+                base.visit_columns(depth, f);
+                for input in inputs {
+                    input.visit_columns(depth, f);
+                }
+            }
+            HirRelationExpr::Project { input, .. }
+            | HirRelationExpr::Distinct { input }
+            | HirRelationExpr::TopK { input, .. }
+            | HirRelationExpr::Negate { input }
+            | HirRelationExpr::DeclareKeys { input, .. }
+            | HirRelationExpr::Threshold { input } => {
+                input.visit_columns(depth, f);
+            }
+            HirRelationExpr::Constant { .. } | HirRelationExpr::Get { .. } => (),
+        }
     }
 
     /// Like `visit_columns`, but permits mutating the column references.
@@ -1226,30 +1169,175 @@ impl HirRelationExpr {
     where
         F: FnMut(usize, &mut ColumnRef),
     {
-        let _ = self.visit_scalar_expressions_mut(depth, &mut |e: &mut HirScalarExpr,
-                                                               depth: usize|
-         -> Result<(), ()> {
-            e.visit_columns_mut(depth, f);
-            Ok(())
-        });
+        match self {
+            HirRelationExpr::Let { body, value, .. } => {
+                value.visit_columns_mut(depth, f);
+                body.visit_columns_mut(depth, f);
+            }
+            HirRelationExpr::Join {
+                on, left, right, ..
+            } => {
+                left.visit_columns_mut(depth, f);
+                right.visit_columns_mut(depth + 1, f);
+                // The ON clause doesn't belong in the lateral context
+                on.visit_columns_mut(depth, f);
+            }
+            HirRelationExpr::Map { scalars, input } => {
+                for scalar in scalars {
+                    scalar.visit_columns_mut(depth, f);
+                }
+                input.visit_columns_mut(depth, f);
+            }
+            HirRelationExpr::CallTable { exprs, .. } => {
+                for expr in exprs {
+                    expr.visit_columns_mut(depth, f);
+                }
+            }
+            HirRelationExpr::Filter { predicates, input } => {
+                for predicate in predicates {
+                    predicate.visit_columns_mut(depth, f);
+                }
+                input.visit_columns_mut(depth, f);
+            }
+            HirRelationExpr::Reduce {
+                aggregates, input, ..
+            } => {
+                for aggregate in aggregates {
+                    aggregate.visit_columns_mut(depth, f);
+                }
+                input.visit_columns_mut(depth, f);
+            }
+            HirRelationExpr::Union { base, inputs } => {
+                base.visit_columns_mut(depth, f);
+                for input in inputs {
+                    input.visit_columns_mut(depth, f);
+                }
+            }
+            HirRelationExpr::Project { input, .. }
+            | HirRelationExpr::Distinct { input }
+            | HirRelationExpr::TopK { input, .. }
+            | HirRelationExpr::Negate { input }
+            | HirRelationExpr::DeclareKeys { input, .. }
+            | HirRelationExpr::Threshold { input } => {
+                input.visit_columns_mut(depth, f);
+            }
+            HirRelationExpr::Constant { .. } | HirRelationExpr::Get { .. } => (),
+        }
     }
 
     /// Replaces any parameter references in the expression with the
     /// corresponding datum from `params`.
     pub fn bind_parameters(&mut self, params: &Params) -> Result<(), anyhow::Error> {
-        self.visit_scalar_expressions_mut(0, &mut |e: &mut HirScalarExpr, _: usize| {
-            e.bind_parameters(params)
-        })
+        match self {
+            HirRelationExpr::Let { body, value, .. } => {
+                value.bind_parameters(params)?;
+                body.bind_parameters(params)
+            }
+            HirRelationExpr::Join {
+                on, left, right, ..
+            } => {
+                on.bind_parameters(params)?;
+                left.bind_parameters(params)?;
+                right.bind_parameters(params)
+            }
+            HirRelationExpr::Map { scalars, input } => {
+                for scalar in scalars {
+                    scalar.bind_parameters(params)?;
+                }
+                input.bind_parameters(params)
+            }
+            HirRelationExpr::CallTable { exprs, .. } => {
+                for expr in exprs {
+                    expr.bind_parameters(params)?;
+                }
+                Ok(())
+            }
+            HirRelationExpr::Filter { predicates, input } => {
+                for predicate in predicates {
+                    predicate.bind_parameters(params)?;
+                }
+                input.bind_parameters(params)
+            }
+            HirRelationExpr::Reduce {
+                aggregates, input, ..
+            } => {
+                for aggregate in aggregates {
+                    aggregate.bind_parameters(params)?;
+                }
+                input.bind_parameters(params)
+            }
+            HirRelationExpr::Union { base, inputs } => {
+                for input in inputs {
+                    input.bind_parameters(params)?;
+                }
+                base.bind_parameters(params)
+            }
+            HirRelationExpr::Project { input, .. }
+            | HirRelationExpr::Distinct { input, .. }
+            | HirRelationExpr::TopK { input, .. }
+            | HirRelationExpr::Negate { input, .. }
+            | HirRelationExpr::DeclareKeys { input, .. }
+            | HirRelationExpr::Threshold { input, .. } => input.bind_parameters(params),
+            HirRelationExpr::Constant { .. } | HirRelationExpr::Get { .. } => Ok(()),
+        }
     }
 
     /// See the documentation for [`HirScalarExpr::splice_parameters`].
     pub fn splice_parameters(&mut self, params: &[HirScalarExpr], depth: usize) {
-        let _ = self.visit_scalar_expressions_mut(depth, &mut |e: &mut HirScalarExpr,
-                                                               depth: usize|
-         -> Result<(), ()> {
-            e.splice_parameters(params, depth);
-            Ok(())
-        });
+        match self {
+            HirRelationExpr::Let { body, value, .. } => {
+                value.splice_parameters(params, depth);
+                body.splice_parameters(params, depth);
+            }
+            HirRelationExpr::Join {
+                on, left, right, ..
+            } => {
+                left.splice_parameters(params, depth);
+                right.splice_parameters(params, depth + 1);
+                // The ON clause doesn't belong in the lateral context
+                on.splice_parameters(params, depth);
+            }
+            HirRelationExpr::Map { scalars, input } => {
+                for scalar in scalars {
+                    scalar.splice_parameters(params, depth);
+                }
+                input.splice_parameters(params, depth);
+            }
+            HirRelationExpr::CallTable { exprs, .. } => {
+                for expr in exprs {
+                    expr.splice_parameters(params, depth);
+                }
+            }
+            HirRelationExpr::Filter { predicates, input } => {
+                for predicate in predicates {
+                    predicate.splice_parameters(params, depth);
+                }
+                input.splice_parameters(params, depth);
+            }
+            HirRelationExpr::Reduce {
+                aggregates, input, ..
+            } => {
+                for aggregate in aggregates {
+                    aggregate.expr.splice_parameters(params, depth);
+                }
+                input.splice_parameters(params, depth);
+            }
+            HirRelationExpr::Union { base, inputs } => {
+                base.splice_parameters(params, depth);
+                for input in inputs {
+                    input.splice_parameters(params, depth);
+                }
+            }
+            HirRelationExpr::Project { input, .. }
+            | HirRelationExpr::Distinct { input }
+            | HirRelationExpr::TopK { input, .. }
+            | HirRelationExpr::Negate { input }
+            | HirRelationExpr::DeclareKeys { input, .. }
+            | HirRelationExpr::Threshold { input } => {
+                input.splice_parameters(params, depth);
+            }
+            HirRelationExpr::Constant { .. } | HirRelationExpr::Get { .. } => (),
+        }
     }
 
     /// Constructs a constant collection from specific rows and schema.
@@ -1287,8 +1375,11 @@ impl HirScalarExpr {
     /// Replaces any parameter references in the expression with the
     /// corresponding datum in `params`.
     pub fn bind_parameters(&mut self, params: &Params) -> Result<(), anyhow::Error> {
-        self.visit_recursively_mut(0, &mut |_: usize, e: &mut HirScalarExpr| {
-            if let HirScalarExpr::Parameter(n) = e {
+        match self {
+            HirScalarExpr::Literal(_, _)
+            | HirScalarExpr::Column(_)
+            | HirScalarExpr::CallNullary(_) => Ok(()),
+            HirScalarExpr::Parameter(n) => {
                 let datum = match params.datums.iter().nth(*n - 1) {
                     None => bail!("there is no parameter ${}", n),
                     Some(datum) => datum,
@@ -1296,10 +1387,30 @@ impl HirScalarExpr {
                 let scalar_type = &params.types[*n - 1];
                 let row = Row::pack(&[datum]);
                 let column_type = scalar_type.clone().nullable(datum.is_null());
-                *e = HirScalarExpr::Literal(row, column_type);
+                *self = HirScalarExpr::Literal(row, column_type);
+                Ok(())
             }
-            Ok(())
-        })
+            HirScalarExpr::CallUnary { expr, .. } => expr.bind_parameters(params),
+            HirScalarExpr::CallBinary { expr1, expr2, .. } => {
+                expr1.bind_parameters(params)?;
+                expr2.bind_parameters(params)
+            }
+            HirScalarExpr::CallVariadic { exprs, .. } => {
+                for expr in exprs {
+                    expr.bind_parameters(params)?;
+                }
+                Ok(())
+            }
+            HirScalarExpr::If { cond, then, els } => {
+                cond.bind_parameters(params)?;
+                then.bind_parameters(params)?;
+                els.bind_parameters(params)
+            }
+            HirScalarExpr::Exists(expr) | HirScalarExpr::Select(expr) => {
+                expr.bind_parameters(params)
+            }
+            HirScalarExpr::Windowing(expr) => expr.bind_parameters(params),
+        }
     }
 
     /// Like [`HirScalarExpr::bind_parameters`], except that parameters are
@@ -1313,21 +1424,22 @@ impl HirScalarExpr {
     /// Column references in parameters will be corrected to account for the
     /// depth at which they are spliced.
     pub fn splice_parameters(&mut self, params: &[HirScalarExpr], depth: usize) {
-        let _ = self.visit_recursively_mut(depth, &mut |_: usize,
-                                                        e: &mut HirScalarExpr|
-         -> Result<(), ()> {
-            if let HirScalarExpr::Parameter(i) = e {
+        self.visit_mut(&mut |e| match e {
+            HirScalarExpr::Parameter(i) => {
                 *e = params[*i - 1].clone();
                 // Correct any column references in the parameter expression for
                 // its new depth.
-                e.visit_columns_mut(0, &mut |d: usize, col: &mut ColumnRef| {
+                e.visit_columns_mut(0, &mut |d, col| {
                     if col.level >= d {
                         col.level += depth
                     }
                 });
             }
-            Ok(())
-        });
+            HirScalarExpr::Exists(e) | HirScalarExpr::Select(e) => {
+                e.splice_parameters(params, depth + 1)
+            }
+            _ => (),
+        })
     }
 
     /// Constructs a column reference in the current scope.
@@ -1425,10 +1537,7 @@ impl HirScalarExpr {
             }
             Exists(..) | Select(..) => (),
             Windowing(expr) => {
-                let _ = expr.visit_expressions(&mut |e| -> Result<(), ()> {
-                    f(e);
-                    Ok(())
-                });
+                expr.visit_expressions(&mut f);
             }
         }
     }
@@ -1473,10 +1582,7 @@ impl HirScalarExpr {
             }
             Exists(..) | Select(..) => (),
             Windowing(expr) => {
-                let _ = expr.visit_expressions_mut(&mut |e| -> Result<(), ()> {
-                    f(e);
-                    Ok(())
-                });
+                expr.visit_expressions_mut(&mut f);
             }
         }
     }
@@ -1511,14 +1617,35 @@ impl HirScalarExpr {
     where
         F: FnMut(usize, &ColumnRef),
     {
-        let _ = self.visit_recursively(depth, &mut |depth: usize,
-                                                    e: &HirScalarExpr|
-         -> Result<(), ()> {
-            if let HirScalarExpr::Column(col) = e {
-                f(depth, col)
+        match self {
+            HirScalarExpr::Literal(_, _)
+            | HirScalarExpr::Parameter(_)
+            | HirScalarExpr::CallNullary(_) => (),
+            HirScalarExpr::Column(col_ref) => f(depth, col_ref),
+            HirScalarExpr::CallUnary { expr, .. } => expr.visit_columns(depth, f),
+            HirScalarExpr::CallBinary { expr1, expr2, .. } => {
+                expr1.visit_columns(depth, f);
+                expr2.visit_columns(depth, f);
             }
-            Ok(())
-        });
+            HirScalarExpr::CallVariadic { exprs, .. } => {
+                for expr in exprs {
+                    expr.visit_columns(depth, f);
+                }
+            }
+            HirScalarExpr::If { cond, then, els } => {
+                cond.visit_columns(depth, f);
+                then.visit_columns(depth, f);
+                els.visit_columns(depth, f);
+            }
+            HirScalarExpr::Exists(expr) | HirScalarExpr::Select(expr) => {
+                expr.visit_columns(depth + 1, f);
+            }
+            HirScalarExpr::Windowing(expr) => {
+                expr.visit_expressions(&mut |e| {
+                    e.visit_columns(depth, f);
+                });
+            }
+        }
     }
 
     /// Like `visit_columns`, but permits mutating the column references.
@@ -1526,90 +1653,35 @@ impl HirScalarExpr {
     where
         F: FnMut(usize, &mut ColumnRef),
     {
-        let _ = self.visit_recursively_mut(depth, &mut |depth: usize,
-                                                        e: &mut HirScalarExpr|
-         -> Result<(), ()> {
-            if let HirScalarExpr::Column(col) = e {
-                f(depth, col)
-            }
-            Ok(())
-        });
-    }
-
-    /// Like `visit` but it enters the subqueries visiting the scalar expressions contained
-    /// in them. It takes the current depth of the expression and increases it when
-    /// entering a subquery.
-    pub fn visit_recursively<F, E>(&self, depth: usize, f: &mut F) -> Result<(), E>
-    where
-        F: FnMut(usize, &HirScalarExpr) -> Result<(), E>,
-    {
         match self {
             HirScalarExpr::Literal(_, _)
             | HirScalarExpr::Parameter(_)
-            | HirScalarExpr::CallNullary(_)
-            | HirScalarExpr::Column(_) => (),
-            HirScalarExpr::CallUnary { expr, .. } => expr.visit_recursively(depth, f)?,
+            | HirScalarExpr::CallNullary(_) => (),
+            HirScalarExpr::Column(col_ref) => f(depth, col_ref),
+            HirScalarExpr::CallUnary { expr, .. } => expr.visit_columns_mut(depth, f),
             HirScalarExpr::CallBinary { expr1, expr2, .. } => {
-                expr1.visit_recursively(depth, f)?;
-                expr2.visit_recursively(depth, f)?;
+                expr1.visit_columns_mut(depth, f);
+                expr2.visit_columns_mut(depth, f);
             }
             HirScalarExpr::CallVariadic { exprs, .. } => {
                 for expr in exprs {
-                    expr.visit_recursively(depth, f)?;
+                    expr.visit_columns_mut(depth, f);
                 }
             }
             HirScalarExpr::If { cond, then, els } => {
-                cond.visit_recursively(depth, f)?;
-                then.visit_recursively(depth, f)?;
-                els.visit_recursively(depth, f)?;
+                cond.visit_columns_mut(depth, f);
+                then.visit_columns_mut(depth, f);
+                els.visit_columns_mut(depth, f);
             }
             HirScalarExpr::Exists(expr) | HirScalarExpr::Select(expr) => {
-                expr.visit_scalar_expressions(depth + 1, &mut |e, depth| {
-                    e.visit_recursively(depth, f)
-                })?;
+                expr.visit_columns_mut(depth + 1, f);
             }
             HirScalarExpr::Windowing(expr) => {
-                expr.visit_expressions(&mut |e| e.visit_recursively(depth, f))?;
+                expr.visit_expressions_mut(&mut |e| {
+                    e.visit_columns_mut(depth, f);
+                });
             }
         }
-        f(depth, self)
-    }
-
-    /// Like `visit_recursively`, but permits mutating the scalar expressions.
-    pub fn visit_recursively_mut<F, E>(&mut self, depth: usize, f: &mut F) -> Result<(), E>
-    where
-        F: FnMut(usize, &mut HirScalarExpr) -> Result<(), E>,
-    {
-        match self {
-            HirScalarExpr::Literal(_, _)
-            | HirScalarExpr::Parameter(_)
-            | HirScalarExpr::CallNullary(_)
-            | HirScalarExpr::Column(_) => (),
-            HirScalarExpr::CallUnary { expr, .. } => expr.visit_recursively_mut(depth, f)?,
-            HirScalarExpr::CallBinary { expr1, expr2, .. } => {
-                expr1.visit_recursively_mut(depth, f)?;
-                expr2.visit_recursively_mut(depth, f)?;
-            }
-            HirScalarExpr::CallVariadic { exprs, .. } => {
-                for expr in exprs {
-                    expr.visit_recursively_mut(depth, f)?;
-                }
-            }
-            HirScalarExpr::If { cond, then, els } => {
-                cond.visit_recursively_mut(depth, f)?;
-                then.visit_recursively_mut(depth, f)?;
-                els.visit_recursively_mut(depth, f)?;
-            }
-            HirScalarExpr::Exists(expr) | HirScalarExpr::Select(expr) => {
-                expr.visit_scalar_expressions_mut(depth + 1, &mut |e, depth| {
-                    e.visit_recursively_mut(depth, f)
-                })?;
-            }
-            HirScalarExpr::Windowing(expr) => {
-                expr.visit_expressions_mut(&mut |e| e.visit_recursively_mut(depth, f))?;
-            }
-        }
-        f(depth, self)
     }
 
     fn simplify_to_literal(self) -> Option<Row> {
@@ -1723,5 +1795,25 @@ impl AggregateExpr {
         params: &BTreeMap<usize, ScalarType>,
     ) -> ColumnType {
         self.func.output_type(self.expr.typ(outers, inner, params))
+    }
+
+    /// Visits the column references in this aggregate expression.
+    ///
+    /// The `depth` argument should indicate the subquery nesting depth of the expression,
+    /// which will be incremented with each subquery entered and presented to the supplied
+    /// function `f`.
+    pub fn visit_columns<F>(&self, depth: usize, f: &mut F)
+    where
+        F: FnMut(usize, &ColumnRef),
+    {
+        self.expr.visit_columns(depth, f);
+    }
+
+    /// Like `visit_columns`, but permits mutating the column reference.
+    pub fn visit_columns_mut<F>(&mut self, depth: usize, f: &mut F)
+    where
+        F: FnMut(usize, &mut ColumnRef),
+    {
+        self.expr.visit_columns_mut(depth, f);
     }
 }

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -1269,7 +1269,7 @@ where
     // detecting the moment of decorrelation in the optimizer right now is too
     // hard.
     let mut is_simple = true;
-    inner.visit(0, &mut |expr, _| match expr {
+    inner.visit(&mut |expr| match expr {
         HirRelationExpr::Constant { .. }
         | HirRelationExpr::Project { .. }
         | HirRelationExpr::Map { .. }
@@ -1304,7 +1304,7 @@ where
     });
     // Collect all the outer columns referenced by any CTE referenced by
     // the inner relation.
-    inner.visit(0, &mut |e, _| match e {
+    inner.visit(&mut |e| match e {
         HirRelationExpr::Get {
             id: expr::Id::Local(id),
             ..

--- a/src/sql/src/plan/transform_expr.rs
+++ b/src/sql/src/plan/transform_expr.rs
@@ -53,7 +53,7 @@ use crate::plan::expr::{
 /// subquery, especially when the original conjunction contains join keys.
 pub fn split_subquery_predicates(expr: &mut HirRelationExpr) {
     fn walk_relation(expr: &mut HirRelationExpr) {
-        expr.visit_mut(0, &mut |expr, _| match expr {
+        expr.visit_mut(&mut |expr| match expr {
             HirRelationExpr::Map { scalars, .. } => {
                 for scalar in scalars {
                     walk_scalar(scalar);
@@ -80,7 +80,7 @@ pub fn split_subquery_predicates(expr: &mut HirRelationExpr) {
                 }
             }
             _ => (),
-        });
+        })
     }
 
     fn walk_scalar(expr: &mut HirScalarExpr) {
@@ -190,12 +190,7 @@ pub fn try_simplify_quantified_comparisons(expr: &mut HirRelationExpr) {
                 outers.insert(0, left.typ(&outers, &NO_PARAMS));
                 walk_relation(right, &outers);
             }
-            expr => {
-                let _ = expr.visit1_mut(0, &mut |expr, _| -> Result<(), ()> {
-                    walk_relation(expr, outers);
-                    Ok(())
-                });
-            }
+            expr => expr.visit1_mut(&mut |expr| walk_relation(expr, outers)),
         }
     }
 

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -125,7 +125,7 @@ SELECT date_trunc('millennium', TIMESTAMP '0001-01-01 00:00:00.000000' - INTERVA
 ----
 1000-01-01 00:00:00 BC
 
-query error unknown units 'bad'
+query error unit 'bad' not recognized
 SELECT date_trunc('bad', TIMESTAMP '2019-11-26 15:56:46.241150')
 
 query T
@@ -138,7 +138,7 @@ SELECT date_trunc('day', TIMESTAMPTZ '1999-12-31 16:16:01+02:30')
 ----
 1999-12-31 00:00:00+00
 
-query error unknown units 'bad'
+query error unit 'bad' not recognized
 SELECT date_trunc('bad', TIMESTAMPTZ '1999-12-31 16:16:01+02:30')
 
 statement ok
@@ -160,7 +160,7 @@ SELECT date_trunc(field, TIMESTAMP '2019-11-26 15:56:46.241150') FROM date_trunc
 statement ok
 INSERT INTO date_trunc_fields VALUES ('bad')
 
-query error unknown units 'bad'
+query error unit 'bad' not recognized
 SELECT date_trunc(field, TIMESTAMP '2019-11-26 15:56:46.241150') FROM date_trunc_fields
 
 mode standard

--- a/test/testdrive/date_func.td
+++ b/test/testdrive/date_func.td
@@ -13,16 +13,16 @@
 #
 
 ! SELECT EXTRACT(NULL FROM CAST('2011-11-11' AS DATE));
-unknown units 'null'
+unit 'null' not recognized
 
 ! SELECT EXTRACT(NULL FROM CAST('11:11:11' AS TIME));
-unknown units 'null'
+unit 'null' not recognized
 
 ! SELECT EXTRACT(NULL FROM CAST('2011-11-11' AS TIMESTAMP));
-unknown units 'null'
+unit 'null' not recognized
 
 ! SELECT EXTRACT(NULL FROM CAST('2011-11-11' AS TIMESTAMP WITH TIME ZONE));
-unknown units 'null'
+unit 'null' not recognized
 
 # NULL is an argument here, so the function returns NULL
 > SELECT DATE_PART(NULL, CAST('2011-11-11' AS DATE)) IS NULL;
@@ -38,55 +38,55 @@ true
 true
 
 ! SELECT EXTRACT('foo' FROM CAST('2011-11-11' AS DATE));
-unknown units 'foo'
+unit 'foo' not recognized
 
 ! SELECT EXTRACT('foo' FROM CAST('11:11:11' AS TIME));
-unknown units 'foo'
+unit 'foo' not recognized
 
 ! SELECT EXTRACT('foo' FROM CAST('2011-11-11' AS TIMESTAMP));
-unknown units 'foo'
+unit 'foo' not recognized
 
 ! SELECT EXTRACT('foo' FROM CAST('2011-11-11' AS TIMESTAMP WITH TIME ZONE));
-unknown units 'foo'
+unit 'foo' not recognized
 
 
 ! SELECT DATE_PART('foo', CAST('2011-11-11' AS DATE));
-unknown units 'foo'
+unit 'foo' not recognized
 
 ! SELECT DATE_PART('foo', CAST('11:11:11' AS TIME));
-unknown units 'foo'
+unit 'foo' not recognized
 
 ! SELECT DATE_PART('foo', CAST('2011-11-11' AS TIMESTAMP));
-unknown units 'foo'
+unit 'foo' not recognized
 
 ! SELECT DATE_PART('foo', CAST('2011-11-11' AS TIMESTAMP WITH TIME ZONE));
-unknown units 'foo'
+unit 'foo' not recognized
 
 
 ! SELECT EXTRACT('' FROM CAST('2011-11-11' AS DATE));
-unknown units ''
+unit '' not recognized
 
 ! SELECT EXTRACT('' FROM CAST('11:11:11' AS TIME));
-unknown units ''
+unit '' not recognized
 
 ! SELECT EXTRACT('' FROM CAST('2011-11-11' AS TIMESTAMP));
-unknown units ''
+unit '' not recognized
 
 ! SELECT EXTRACT('' FROM CAST('2011-11-11' AS TIMESTAMP WITH TIME ZONE));
-unknown units ''
+unit '' not recognized
 
 
 ! SELECT DATE_PART('', CAST('2011-11-11' AS DATE));
-unknown units ''
+unit '' not recognized
 
 ! SELECT DATE_PART('', CAST('11:11:11' AS TIME));
-unknown units ''
+unit '' not recognized
 
 ! SELECT DATE_PART('', CAST('2011-11-11' AS TIMESTAMP));
-unknown units ''
+unit '' not recognized
 
 ! SELECT DATE_PART('', CAST('2011-11-11' AS TIMESTAMP WITH TIME ZONE));
-unknown units ''
+unit '' not recognized
 
 
 > SELECT EXTRACT('second' FROM CAST('2011-11-11' AS DATE));


### PR DESCRIPTION
Reverts MaterializeInc/materialize#9813

It leads to a crash that wasn't spotted during integration tests on the branch. Probably due to a conflicting change.
