### PR TITLE
test,mzcompose: allow None as options to Materialized()

### DIFF
--- a/misc/python/materialize/mzcompose.py
+++ b/misc/python/materialize/mzcompose.py
@@ -726,7 +726,7 @@ class Materialized(PythonService):
         memory: Optional[str] = None,
         data_directory: str = "/share/mzdata",
         timestamp_frequency: str = "100ms",
-        options: Union[str, List[str]] = "",
+        options: Optional[Union[str, List[str]]] = "",
         environment: Optional[List[str]] = None,
         environment_extra: Optional[List[str]] = None,
         volumes: Optional[List[str]] = None,
@@ -769,10 +769,11 @@ class Materialized(PythonService):
             "--retain-prometheus-metrics 1s",
         ]
 
-        if isinstance(options, str):
-            command_list.append(options)
-        else:
-            command_list.extend(options)
+        if options:
+            if isinstance(options, str):
+                command_list.append(options)
+            else:
+                command_list.extend(options)
 
         if workers:
             command_list.append(f"--workers {workers}")


### PR DESCRIPTION
Due to the fact that the content of test/ is not type-checked, it
is possible for the options argument to Materialized to be None.

Acknowlege the reality by updating the method signature and
handling this eventuality in the code.

  * This PR fixes a previously unreported bug.

The feature benchmark will fail to boot under certain circumstances as it takes option lists out of env variables, which may be undefined.