### PR TITLE
QGM: Change Vec<Box<BoxScalarExpr>> to Vec<BoxScalarExpr>.

### DIFF
--- a/src/sql/src/query_model/hir.rs
+++ b/src/sql/src/query_model/hir.rs
@@ -180,7 +180,7 @@ impl FromHir {
                     });
                     // Add it to the grouping key and to the projection of the
                     // Grouping box
-                    key.push(Box::new(select_box_col_ref.clone()));
+                    key.push(select_box_col_ref.clone());
                     self.model.get_mut_box(group_box_id).columns.push(Column {
                         expr: select_box_col_ref,
                         alias: None,
@@ -415,8 +415,8 @@ impl FromHir {
     fn add_predicate(&mut self, box_id: BoxId, predicate: BoxScalarExpr) {
         let mut the_box = self.model.get_mut_box(box_id);
         match &mut the_box.box_type {
-            BoxType::Select(select) => select.predicates.push(Box::new(predicate)),
-            BoxType::OuterJoin(outer_join) => outer_join.predicates.push(Box::new(predicate)),
+            BoxType::Select(select) => select.predicates.push(predicate),
+            BoxType::OuterJoin(outer_join) => outer_join.predicates.push(predicate),
             _ => unreachable!(),
         }
     }

--- a/src/sql/src/query_model/lowering.rs
+++ b/src/sql/src/query_model/lowering.rs
@@ -204,7 +204,7 @@ impl<'a> Lowerer<'a> {
                         grouping
                             .key
                             .iter()
-                            .position(|k| c.expr == **k)
+                            .position(|k| c.expr == *k)
                             .expect("expression in the projection of a Grouping box not included in the grouping key")
                     }
                 }).collect_vec();

--- a/src/sql/src/query_model/mod.rs
+++ b/src/sql/src/query_model/mod.rs
@@ -187,23 +187,23 @@ pub struct Get {
 /// The content of a Grouping box.
 #[derive(Debug, Default)]
 pub struct Grouping {
-    pub key: Vec<Box<BoxScalarExpr>>,
+    pub key: Vec<BoxScalarExpr>,
 }
 
 /// The content of a OuterJoin box.
 #[derive(Debug, Default)]
 pub struct OuterJoin {
     /// The predices in the ON clause of the outer join.
-    pub predicates: Vec<Box<BoxScalarExpr>>,
+    pub predicates: Vec<BoxScalarExpr>,
 }
 
 /// The content of a Select box.
 #[derive(Debug, Default)]
 pub struct Select {
     /// The list of predicates applied by the box.
-    pub predicates: Vec<Box<BoxScalarExpr>>,
+    pub predicates: Vec<BoxScalarExpr>,
     /// An optional ORDER BY key
-    pub order_key: Option<Vec<Box<BoxScalarExpr>>>,
+    pub order_key: Option<Vec<BoxScalarExpr>>,
     /// An optional LIMIT clause
     pub limit: Option<BoxScalarExpr>,
     /// An optional OFFSET clause
@@ -212,13 +212,13 @@ pub struct Select {
 
 #[derive(Debug, Default)]
 pub struct TableFunction {
-    pub parameters: Vec<Box<BoxScalarExpr>>,
+    pub parameters: Vec<BoxScalarExpr>,
     // @todo function metadata from the catalog
 }
 
 #[derive(Debug, Default)]
 pub struct Values {
-    pub rows: Vec<Vec<Box<BoxScalarExpr>>>,
+    pub rows: Vec<Vec<BoxScalarExpr>>,
 }
 
 impl Model {


### PR DESCRIPTION
### Motivation

   * This PR refactors existing code.

Change `Vec<Box<BoxScalarExpr>>` to `Vec<BoxScalarExpr>`, which simplifies the code.

There are occasional cases when `Vec<Box<BoxScalarExpr>>` can have performance advantages, but I don't think they apply here, and also I don't think it's worthwhile to have `Vec<Box<BoxScalarExpr>>` without exploring optimizing performance in other ways. 
https://users.rust-lang.org/t/is-there-any-advantage-of-vec-box-t-over-vec-t/65160

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

It builds.
