### PR TITLE
testdrive: always enable --ci-output

### DIFF
--- a/doc/developer/testdrive.md
+++ b/doc/developer/testdrive.md
@@ -251,10 +251,6 @@ Shuffle the list of tests before running them (using the value from --seed, if a
 
 ## Other options
 
-#### `--ci-output`
-
-Emit Buildkite-specific markup
-
 #### `--validate-catalog /path/to/catalog`
 
 After executing a DDL statement, validate that the on-disk representation of the catalog is identical to the in-memory one.

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -82,8 +82,6 @@ pub struct Config {
     pub materialized_catalog_path: Option<PathBuf>,
     /// Whether to reset Materialized and AWS's state at the start of each script.
     pub reset: bool,
-    /// Emit Buildkite-specific markup.
-    pub ci_output: bool,
     /// The default timeout to use for any operation that is retried.
     pub default_timeout: Duration,
 

--- a/src/testdrive/src/error.rs
+++ b/src/testdrive/src/error.rs
@@ -82,16 +82,14 @@ impl Error {
     }
 
     /// Prints the error to `stderr`, with coloring if the terminal supports it.
-    pub fn print_stderr(&self, ci_output: bool) -> io::Result<()> {
+    pub fn print_stderr(&self) -> io::Result<()> {
         let color_choice = if atty::is(Stream::Stderr) {
             ColorChoice::Auto
         } else {
             ColorChoice::Never
         };
         let mut stderr = StandardStream::stderr(color_choice);
-        if ci_output {
-            println!("^^^ +++");
-        }
+        println!("^^^ +++");
         match self {
             Error::Input {
                 err,

--- a/src/testdrive/src/lib.rs
+++ b/src/testdrive/src/lib.rs
@@ -50,10 +50,7 @@ pub async fn run_stdin(config: &Config) -> Result<(), Error> {
 /// only as output in error messages and such. No attempt is made to read
 /// `filename`.
 pub async fn run_string(config: &Config, filename: &str, contents: &str) -> Result<(), Error> {
-    if config.ci_output {
-        print!("--- ");
-    }
-    println!("==> {}", filename);
+    println!("--- {}", filename);
 
     let mut line_reader = LineReader::new(contents);
     run_line_reader(config, &mut line_reader)

--- a/src/testdrive/src/main.rs
+++ b/src/testdrive/src/main.rs
@@ -77,10 +77,6 @@ struct Args {
     no_reset: bool,
 
     // === Testdrive options. ===
-    /// Emit Buildkite-specific markup.
-    #[clap(long)]
-    ci_output: bool,
-
     /// Default timeout in seconds.
     #[clap(long, parse(try_from_str = repr::util::parse_duration), default_value = "10s")]
     default_timeout: Duration,
@@ -194,7 +190,6 @@ async fn main() {
         materialized_pgconfig: args.materialized_url,
         materialized_catalog_path: args.validate_catalog,
         reset: !args.no_reset,
-        ci_output: args.ci_output,
         default_timeout: args.default_timeout,
         initial_backoff: args.initial_backoff,
         backoff_factor: args.backoff_factor,
@@ -221,7 +216,7 @@ async fn main() {
             "-" => testdrive::run_stdin(&config).await,
             _ => testdrive::run_file(&config, &file).await,
         } {
-            let _ = error.print_stderr(args.ci_output);
+            let _ = error.print_stderr();
             error_files.push(file.clone());
 
             errors.push(error);
@@ -231,9 +226,7 @@ async fn main() {
         }
     }
 
-    if config.ci_output {
-        print!("+++ ")
-    }
+    print!("+++ ");
     if errors.is_empty() {
         println!("testdrive completed successfully.");
     } else {

--- a/src/testdrive/tests/cli.rs
+++ b/src/testdrive/tests/cli.rs
@@ -156,18 +156,3 @@ fn test_cmd_arg_bad_nesting_intersect2() {
 "#,
         ));
 }
-
-// --ci-output tests
-
-#[test]
-fn test_ci_output_bad_file() {
-    cmd()
-        .arg("tests")
-        .arg("--ci-output")
-        .assert()
-        .failure()
-        .stderr(predicate::str::starts_with(
-            "error: reading tests: Is a directory",
-        ))
-        .stdout(predicate::str::contains("^^^ +++"));
-}

--- a/test/testdrive/mzworkflows.py
+++ b/test/testdrive/mzworkflows.py
@@ -42,7 +42,6 @@ tests = os.getenv("TD_TEST", "*.td esoteric/*.td")
 tests_ci = tests + " esoteric/pubnub/pubnub.td"
 aws_localstack = "--aws-endpoint http://localstack:4566"
 aws_amazon = "--aws-region=us-east-2"
-ci_output = "--ci-output" if os.getenv("BUILDKITE") else ""
 
 
 def workflow_testdrive(w: Workflow):
@@ -73,5 +72,5 @@ def test_testdrive(w: Workflow, mz: Materialized, aws: str, tests: str):
         services=["zookeeper", "kafka", "schema-registry", mz.name]
     )
     w.wait_for_mz(service=mz.name)
-    w.run_service(service="testdrive-svc", command=f"{ci_output} {aws} {tests}")
+    w.run_service(service="testdrive-svc", command=f"{aws} {tests}")
     w.kill_services(services=[mz.name])


### PR DESCRIPTION
We keep forgetting to enable this in the now many workflows that run
testdrive in CI. Seems simplest to just always emit CI-compatible
output.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
