### PR TITLE
 dataflow,sources: only restore timestamp bindings on workers that need them

### DIFF
--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -908,8 +908,30 @@ where
                 // Add any timestamp bindings that we were already aware of on restart.
                 if let Some(data) = source_timestamp_data {
                     for (pid, timestamp, offset) in bindings {
-                        data.add_partition(pid.clone(), None);
-                        data.add_binding(pid, timestamp, offset, false);
+                        if crate::source::responsible_for(
+                            &id,
+                            self.timely_worker.index(),
+                            self.timely_worker.peers(),
+                            &pid,
+                        ) {
+                            log::trace!(
+                                "Adding partition/binding on worker {}: ({}, {}, {})",
+                                self.timely_worker.index(),
+                                pid,
+                                timestamp,
+                                offset
+                            );
+                            data.add_partition(pid.clone(), None);
+                            data.add_binding(pid, timestamp, offset, false);
+                        } else {
+                            log::trace!(
+                                "NOT adding partition/binding on worker {}: ({}, {}, {})",
+                                self.timely_worker.index(),
+                                pid,
+                                timestamp,
+                                offset
+                            );
+                        }
                     }
 
                     let prev = self.render_state.ts_histories.insert(id, data);


### PR DESCRIPTION
Before, we would restore all existing bindings to all workers, meaning
that workers that are not responsible for a given source id/partition id
combination nevertheless had bindings stored for them. This is
problematic because these workers periodically report those bindings,
meaning they potentially send old bindings to the coordinator that have
been superseded.

This lead to the situation that the timestamp bindings we store in
SQLite have bindings for lower offsets after bindings with higher
offsets, when sorted by the time at which the binding was reported to
the coordinator. This in turn, would lead to panics when restoring
timestamp bindings, because we check that offsets don't go backwards.

The problem only surfaces when restarting materialized multiple times,
which is what some of the newer persistence tests do. Although the
problem is not related to the newly added source persistence code (which
also deals with timestamp bindings).

Fixes #9777

### Tips for reviewer

The first commit adds assertions at the point where we modify timestamp bindings, this makes the problem surface more readily. Before, we needed a cycle of killing/restarting `materialized` to make it appear. I'm still wondering though, why this isn't failing in CI...

We might want to keep that first commit, but only do the checks when running in dev mode? @philip-stoev Any ideas?

The second commit slims down the tests and adds trace logging, that one is only there so you can try and reproduce the bug locally via
```
$ cd test/persistence
$ ./mzcompose run persistence
```

@ruchirK It would be good to check my rationale above about only restoring bindings on workers that need them. I'm also slightly wondering why it worker well before and/or if some of my work might have introduced this behaviour.

@philip-stoev Could you please check that this actually fixes the problem for you?

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/9887)
<!-- Reviewable:end -->
