### PR TITLE
Shore up dataflow |-> coord tail protocol by removing the redundant `Complete` variant and changing when `Dropped` is sent.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1243,6 +1243,7 @@ dependencies = [
  "rdkafka",
  "regex",
  "repr",
+ "scopeguard",
  "serde",
  "serde_json",
  "tempfile",

--- a/src/coord/src/tail.rs
+++ b/src/coord/src/tail.rs
@@ -108,7 +108,7 @@ impl PendingTail {
                 }
                 false
             }
-            TailResponse::Complete | TailResponse::Dropped => {
+            TailResponse::Dropped => {
                 // TODO: Could perhaps do this earlier, in response to DROP SINK.
                 true
             }

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -66,11 +66,7 @@ pub enum TailResponse {
     Progress(Antichain<Timestamp>),
     /// Rows that should be returned in order to the client.
     Rows(Vec<(Row, Timestamp, Diff)>),
-    /// Sent once the stream is complete. Indicates the end.
-    /// TODO(#9479): mh@ thinks this state can be included in Progress with an emtpy antichain
-    Complete,
     /// The TAIL dataflow was dropped before completing. Indicates the end.
-    /// TODO(#9479): mh@ thinks this state can be included in Progress with an emtpy antichain
     Dropped,
 }
 

--- a/src/dataflow/Cargo.toml
+++ b/src/dataflow/Cargo.toml
@@ -47,6 +47,7 @@ rand = "0.8.4"
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "gssapi-vendored", "libz-static", "zstd"] }
 regex = "1.5.4"
 repr = { path = "../repr" }
+scopeguard = "1.1"
 serde = { version = "1.0.133", features = ["derive"] }
 serde_json = "1.0.74"
 tempfile = "3.2.0"

--- a/src/dataflow/src/sink/tail.rs
+++ b/src/dataflow/src/sink/tail.rs
@@ -9,6 +9,7 @@
 
 use std::any::Any;
 use std::cell::RefCell;
+use std::ops::DerefMut;
 use std::rc::Rc;
 
 use differential_dataflow::operators::arrange::ArrangeByKey;
@@ -60,32 +61,51 @@ where
     where
         G: Scope<Timestamp = Timestamp>,
     {
+        let scope = sinked_collection.scope();
+        use differential_dataflow::Hashable;
+        // `active_worker` indicates the index of the worker that receives all data.
+        let active_worker = (sink_id.hashed() as usize) % scope.peers() == scope.index();
+        // An encapsulation of the Tail response protocol.
+        // Used to send rows and eventually mark complete.
+        // Set to `None` for instances that should not produce output.
+        let tail_protocol_handle = Rc::new(RefCell::new(if active_worker {
+            Some(TailProtocol {
+                sink_id,
+                tail_response_buffer: Some(render_state.tail_response_buffer.clone()),
+            })
+        } else {
+            None
+        }));
+        let tail_protocol_weak = Rc::downgrade(&tail_protocol_handle);
+
         tail(
             sinked_collection,
             sink_id,
-            render_state.tail_response_buffer.clone(),
             sink.as_of.clone(),
+            tail_protocol_handle,
+            active_worker,
         );
 
-        // no sink token
-        None
+        // Inform the coordinator that we have been dropped,
+        // and destroy the tail protocol so the sink operator
+        // can't send spurious messages while shutting down.
+        Some(Box::new(scopeguard::guard((), move |_| {
+            if let Some(tail_protocol_handle) = tail_protocol_weak.upgrade() {
+                std::mem::drop(tail_protocol_handle.borrow_mut().take())
+            }
+        })))
     }
 }
 
 fn tail<G>(
     sinked_collection: Collection<G, (Option<Row>, Option<Row>), Diff>,
     sink_id: GlobalId,
-    tail_response_buffer: Rc<RefCell<Vec<(GlobalId, TailResponse)>>>,
     as_of: SinkAsOf,
+    tail_protocol_handle: Rc<RefCell<Option<TailProtocol>>>,
+    active_worker: bool,
 ) where
     G: Scope<Timestamp = Timestamp>,
 {
-    // `active_worker` indicates the index of the worker that receives all data.
-    // This should line up with the exchange just below, but we test in the implementation
-    // just to be certain.
-    let scope = sinked_collection.scope();
-    use differential_dataflow::Hashable;
-    let active_worker = (sink_id.hashed() as usize) % scope.peers() == scope.index();
     // make sure all data is routed to one worker by keying on the sink id
     let batches = sinked_collection
         .map(move |(k, v)| {
@@ -98,17 +118,6 @@ fn tail<G>(
 
     // Initialize to the minimal input frontier.
     let mut input_frontier = Antichain::from_elem(<G::Timestamp as TimelyTimestamp>::minimum());
-    // An encapsulation of the Tail response protocol.
-    // Used to send rows and eventually mark complete.
-    // Set to `None` for instances that should not produce output.
-    let mut tail_protocol = if active_worker {
-        Some(TailProtocol {
-            sink_id,
-            tail_response_buffer: Some(tail_response_buffer),
-        })
-    } else {
-        None
-    };
 
     batches.sink(Pipeline, &format!("tail-{}", sink_id), move |input| {
         input.for_each(|_, batches| {
@@ -135,9 +144,11 @@ fn tail<G>(
                 }
             }
 
-            // Emit data if configured, otherwise it is an error to have data to send.
-            if let Some(tail_protocol) = &mut tail_protocol {
-                tail_protocol.send_rows(results);
+            if active_worker {
+                // Emit data if configured, otherwise it is an error to have data to send.
+                if let Some(tail_protocol) = tail_protocol_handle.borrow_mut().deref_mut() {
+                    tail_protocol.send_rows(results);
+                }
             } else {
                 assert!(
                     results.is_empty(),
@@ -147,7 +158,9 @@ fn tail<G>(
 
             if let Some(batch) = batches.last() {
                 let progress = update_progress(&mut input_frontier, batch.desc.upper().borrow());
-                if let (Some(tail_protocol), Some(progress)) = (&mut tail_protocol, progress) {
+                if let (Some(tail_protocol), Some(progress)) =
+                    (tail_protocol_handle.borrow_mut().deref_mut(), progress)
+                {
                     tail_protocol.send_progress(progress);
                 }
             }
@@ -156,13 +169,15 @@ fn tail<G>(
         let progress = update_progress(&mut input_frontier, input.frontier().frontier());
 
         // Only emit updates if this operator/worker received actual data for emission.
-        if let (Some(tail_protocol), Some(progress)) = (&mut tail_protocol, progress) {
+        if let (Some(tail_protocol), Some(progress)) =
+            (tail_protocol_handle.borrow_mut().deref_mut(), progress)
+        {
             tail_protocol.send_progress(progress);
         }
 
         // If the frontier is empty the tailing is complete. We should say so!
         if input.frontier().frontier().is_empty() {
-            if let Some(tail_protocol) = tail_protocol.take() {
+            if let Some(tail_protocol) = tail_protocol_handle.borrow_mut().take() {
                 tail_protocol.complete();
             } else {
                 // Not an error to notice the end of the stream at non-emitters,
@@ -184,45 +199,47 @@ struct TailProtocol {
 
 impl TailProtocol {
     /// Send the current upper frontier of the tail.
-    ///
-    /// Does nothing if `self.complete()` has been called.
     fn send_progress(&mut self, upper: Antichain<Timestamp>) {
-        if let Some(buffer) = &mut self.tail_response_buffer {
-            buffer
-                .borrow_mut()
-                .push((self.sink_id, TailResponse::Progress(upper)));
-        }
+        let buffer = self
+            .tail_response_buffer
+            .as_mut()
+            .expect("The tail response buffer is only cleared on drop.");
+        buffer
+            .borrow_mut()
+            .push((self.sink_id, TailResponse::Progress(upper)));
     }
 
     /// Send further rows as responses.
-    ///
-    /// Does nothing if `self.complete()` has been called.
     fn send_rows(&mut self, rows: Vec<(Row, Timestamp, Diff)>) {
-        if let Some(buffer) = &mut self.tail_response_buffer {
-            buffer
-                .borrow_mut()
-                .push((self.sink_id, TailResponse::Rows(rows)));
-        }
+        let buffer = self
+            .tail_response_buffer
+            .as_mut()
+            .expect("The tail response buffer is only cleared on drop.");
+        buffer
+            .borrow_mut()
+            .push((self.sink_id, TailResponse::Rows(rows)));
     }
+
     /// Completes the channel, preventing further transmissions.
     fn complete(mut self) {
-        if let Some(buffer) = &mut self.tail_response_buffer {
-            buffer
-                .borrow_mut()
-                .push((self.sink_id, TailResponse::Complete));
-            // Set to `None` to avoid `TailResponse::Dropped`.
-            self.tail_response_buffer = None;
-        }
+        let buffer = self
+            .tail_response_buffer
+            .as_mut()
+            .expect("The tail response buffer is only cleared on drop.");
+        buffer
+            .borrow_mut()
+            .push((self.sink_id, TailResponse::Complete));
+        // Set to `None` to avoid `TailResponse::Dropped`.
+        self.tail_response_buffer = None;
     }
 }
 
 impl Drop for TailProtocol {
     fn drop(&mut self) {
-        if let Some(buffer) = &mut self.tail_response_buffer {
+        if let Some(buffer) = self.tail_response_buffer.take() {
             buffer
                 .borrow_mut()
                 .push((self.sink_id, TailResponse::Dropped));
-            self.tail_response_buffer = None;
         }
     }
 }


### PR DESCRIPTION
This PR is described in the commit messages, not in this PR description field.

Fixes #9479

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/9889)
<!-- Reviewable:end -->
