### PR TITLE
persist: remove inline metadata in BlobUnsealedBatch

### DIFF
--- a/src/persist/src/indexed/encoding.rs
+++ b/src/persist/src/indexed/encoding.rs
@@ -187,8 +187,6 @@ pub struct TraceBatchMeta {
 /// - The updates field is non-empty.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct BlobUnsealedBatch {
-    /// Which updates are included in this batch.
-    pub desc: Range<SeqNo>,
     /// The updates themselves.
     ///
     /// TODO: ideally, these would be a single ColumnarRecords instead of multiple.
@@ -536,12 +534,12 @@ impl TraceBatchMeta {
 impl BlobUnsealedBatch {
     /// Asserts Self's documented invariants, returning an error if any are
     /// violated.
-    pub fn validate(&self) -> Result<(), Error> {
+    pub fn validate(&self, meta: &UnsealedBatchMeta) -> Result<(), Error> {
         // TODO: It's unclear if the equal case (an empty desc) is
         // useful/harmful. Feel free to make this a less_than if empty descs end
         // up making sense.
-        if self.desc.end <= self.desc.start {
-            return Err(format!("invalid desc: {:?}", &self.desc).into());
+        if meta.desc.end <= meta.desc.start {
+            return Err(format!("invalid desc: {:?}", &meta.desc).into());
         }
         // TODO: It's unclear if this invariant is useful/harmful. Feel free to
         // remove it if it ends up not making sense.

--- a/src/persist/src/indexed/mod.rs
+++ b/src/persist/src/indexed/mod.rs
@@ -890,10 +890,9 @@ impl AppliedState {
         }
 
         let batch = BlobUnsealedBatch {
-            desc: desc.clone(),
             updates,
         };
-        self.append_unsealed(id, batch, blob)?;
+        self.append_unsealed(id, batch, desc.clone(), blob)?;
 
         Ok(())
     }
@@ -1045,13 +1044,14 @@ impl AppliedState {
         &mut self,
         id: Id,
         batch: BlobUnsealedBatch,
+        desc: Range<SeqNo>,
         blob: &mut BlobCache<B>,
     ) -> Result<(), Error> {
         let arrangement = self
             .arrangements
             .get_mut(&id)
             .ok_or_else(|| Error::from(format!("never registered: {:?}", id)))?;
-        arrangement.unsealed_append(batch, blob)
+        arrangement.unsealed_append(batch, desc, blob)
     }
 
     fn serialize_meta(&self) -> BlobMeta {


### PR DESCRIPTION
The inlined metadata (either a Range<Seqno> or a Description<u64>) for
Blob{Unsealed|Trace}Batch is only read for validations. It seems like we could
change the API around a little bit to only use the metadata from {Unsealed|Trace}BatchMeta
when validating the corresponding blobs.

Otherwise, I think there's a missing validation somewhere to verify that the
inlined metadata and the separately stored metadata are identical.

<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug: [Link to issue.]

  * This PR adds a known-desirable feature: [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
