### PR TITLE
Expr: The type of a Datum::Int64 should always be `ScalarType::Int64`.

### DIFF
--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -1924,16 +1924,14 @@ impl AggregateExpr {
     pub fn on_unique(&self, input_type: &RelationType) -> MirScalarExpr {
         match self.func {
             // Count is one if non-null, and zero if null.
-            AggregateFunc::Count => {
-                let column_type = self.typ(&input_type);
-                self.expr
-                    .clone()
-                    .call_unary(UnaryFunc::IsNull(crate::func::IsNull))
-                    .if_then_else(
-                        MirScalarExpr::literal_ok(Datum::Int64(0), column_type.scalar_type.clone()),
-                        MirScalarExpr::literal_ok(Datum::Int64(1), column_type.scalar_type),
-                    )
-            }
+            AggregateFunc::Count => self
+                .expr
+                .clone()
+                .call_unary(UnaryFunc::IsNull(crate::func::IsNull))
+                .if_then_else(
+                    MirScalarExpr::literal_ok(Datum::Int64(0), ScalarType::Int64),
+                    MirScalarExpr::literal_ok(Datum::Int64(1), ScalarType::Int64),
+                ),
 
             // SumInt16 takes Int16s as input, but outputs Int64s.
             AggregateFunc::SumInt16 => self


### PR DESCRIPTION
### Motivation

   * This PR refactors existing code.

The output type of an AggregateFunc::Count is always `Int64`. Also, it would be an error to have a literal whose value is `Datum::Int64` but give it a type that is not `ScalarType::Int64`.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
