### PR TITLE
Support NAMES and SCHEMA in `SET`

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -115,6 +115,12 @@ changes that have not yet been documented.
 
 - Add the `array_remove` and `list_remove` functions.
 
+- Allow `SET NAMES ____` special case as per: https://www.postgresql.org/docs/9.1/sql-set.html.
+  Errors if the value is not `"UTF8"`.
+
+- Correctly parse `SET SCHEMA ____` special case as per: https://www.postgresql.org/docs/9.1/sql-set.html,
+  but it remains unsettable.
+
 {{< comment >}}
 Only add new release notes above this line.
 

--- a/src/coord/src/session/vars.rs
+++ b/src/coord/src/session/vars.rs
@@ -287,7 +287,13 @@ impl Vars {
         if name == APPLICATION_NAME.name {
             self.application_name.set(value, local)
         } else if name == CLIENT_ENCODING.name {
-            Err(CoordError::ReadOnlyParameter(&CLIENT_ENCODING))
+            // Unfortunately, some orm's like Prisma set NAMES to UTF8, thats the only
+            // value we support, so we let is through
+            if UncasedStr::new(value) != CLIENT_ENCODING.value {
+                return Err(CoordError::ConstrainedParameter(&CLIENT_ENCODING));
+            } else {
+                Ok(())
+            }
         } else if name == DATABASE.name {
             self.database.set(value, local)
         } else if name == DATE_STYLE.name {

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -164,6 +164,7 @@ Minute
 Minutes
 Month
 Months
+Names
 Natural
 Next
 No

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -3623,10 +3623,19 @@ impl<'a> Parser<'a> {
         let modifier = self.parse_one_of_keywords(&[SESSION, LOCAL]);
         let mut variable = self.parse_identifier()?;
         let mut normal = self.consume_token(&Token::Eq) || self.parse_keyword(TO);
-        if !normal && variable.as_str().parse() == Ok(TIME) {
-            self.expect_keyword(ZONE)?;
-            variable = Ident::new("timezone");
-            normal = true;
+        if !normal {
+            match variable.as_str().parse() {
+                Ok(TIME) => {
+                    self.expect_keyword(ZONE)?;
+                    variable = Ident::new("timezone");
+                    normal = true;
+                }
+                Ok(NAMES) => {
+                    variable = Ident::new("client_encoding");
+                    normal = true;
+                }
+                _ => {}
+            }
         }
         if normal {
             let token = self.peek_token();

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -3634,6 +3634,10 @@ impl<'a> Parser<'a> {
                     variable = Ident::new("client_encoding");
                     normal = true;
                 }
+                Ok(SCHEMA) => {
+                    variable = Ident::new("search_path");
+                    normal = true;
+                }
                 _ => {}
             }
         }

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -274,6 +274,8 @@ unacceptable schema name 'pg_bar'
 "mz_catalog, pg_catalog, public, mz_temp"
 ! SET search_path = foo
 parameter "search_path" cannot be changed
+! SET SCHEMA foo
+parameter "search_path" cannot be changed
 
 # Creating views in non-existent databases should fail.
 ! CREATE VIEW noexist.ignored AS SELECT 1

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -32,7 +32,14 @@ UTF8
 UTF8
 
 ! SET client_encoding = UTF9
-parameter "client_encoding" cannot be changed
+parameter "client_encoding" can only be set to "UTF8"
+
+# if its utf8 we let it through
+> SET NAMES 'UTF8';
+
+# match the behavior of postgres as specified here: https://www.postgresql.org/docs/9.1/sql-set.html
+! SET NAMES = "something";
+unrecognized configuration parameter "names"
 
 > SET sql_safe_updates = on
 > SHOW sql_safe_updates


### PR DESCRIPTION
This PR implements `SET NAMES` and `SET SCHEMA`, as per https://www.postgresql.org/docs/9.1/sql-set.html, as special cases. For `NAMES`, it special cases a non-error return when passed `UTF8`, and `SCHEMA` is unsettable. Because we have `TIME ZONE`, the last case not handled is `SEED`, but we don't implement `random()` in materialize as of this pr.

  * This PR fixes a recognized bug: https://github.com/MaterializeInc/materialize/issues/9899

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/9900)
<!-- Reviewable:end -->
