### PR TITLE
sql: refactor visit methods

### DIFF
--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -1269,7 +1269,7 @@ where
     // detecting the moment of decorrelation in the optimizer right now is too
     // hard.
     let mut is_simple = true;
-    inner.visit(&mut |expr| match expr {
+    inner.visit(0, &mut |expr, _| match expr {
         HirRelationExpr::Constant { .. }
         | HirRelationExpr::Project { .. }
         | HirRelationExpr::Map { .. }
@@ -1304,7 +1304,7 @@ where
     });
     // Collect all the outer columns referenced by any CTE referenced by
     // the inner relation.
-    inner.visit(&mut |e| match e {
+    inner.visit(0, &mut |e, _| match e {
         HirRelationExpr::Get {
             id: expr::Id::Local(id),
             ..


### PR DESCRIPTION
Make HirRelationExpr's bind_parameters, splice_parameters and
visit_columns rely on a generic visit method, that is responsible
for tracking the current depth of the relation expression, through
visit_scalar_expressions.

A new visit_recursively has been added in HirScalarExpr that descends
into subqueries by using HirRelationExpr::visit_scalar_expressions,
increasing the query depth.

<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

The changes here are the same as in #9813 but with the regression in `splice_parameters` fixed with the fix in #9876. Sorry for the PR noise. I wonder why the tests didn't catch the regression in #9813. Perhaps a system view using a `sql_impl_cast`-based cast was added concurrently.

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug: [Link to issue.]

  * This PR adds a known-desirable feature: [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
