### PR TITLE
qgm: HIR->QGM: Let support 

### DIFF
--- a/src/sql/src/query_model/hir.rs
+++ b/src/sql/src/query_model/hir.rs
@@ -124,7 +124,7 @@ impl FromHir {
                     for scalar in scalars.drain(0..end_idx) {
                         let expr = self.generate_expr(scalar, box_id);
                         let mut b = self.model.get_mut_box(box_id);
-                        b.columns.push(Column { expr, alias: None });
+                        b.add_column(expr);
                     }
 
                     // 3) If there are scalars remaining, wrap the box so the
@@ -181,10 +181,9 @@ impl FromHir {
                     // Add it to the grouping key and to the projection of the
                     // Grouping box
                     key.push(select_box_col_ref.clone());
-                    self.model.get_mut_box(group_box_id).columns.push(Column {
-                        expr: select_box_col_ref,
-                        alias: None,
-                    });
+                    self.model
+                        .get_mut_box(group_box_id)
+                        .add_column(select_box_col_ref);
                 }
                 for aggregate in aggregates.into_iter() {
                     // Any computed expression passed as an argument of an aggregate
@@ -206,10 +205,7 @@ impl FromHir {
                         expr: Box::new(col_ref),
                         distinct: aggregate.distinct,
                     };
-                    self.model.get_mut_box(group_box_id).columns.push(Column {
-                        expr: aggregate,
-                        alias: None,
-                    });
+                    self.model.get_mut_box(group_box_id).add_column(aggregate);
                 }
 
                 // Update the key of the grouping box
@@ -242,13 +238,10 @@ impl FromHir {
                         .make_quantifier(QuantifierType::Foreach, input_box_id, select_id);
                 let mut select_box = self.model.get_mut_box(select_id);
                 for position in outputs {
-                    select_box.columns.push(Column {
-                        expr: BoxScalarExpr::ColumnReference(ColumnReference {
-                            quantifier_id,
-                            position,
-                        }),
-                        alias: None,
-                    });
+                    select_box.add_column(BoxScalarExpr::ColumnReference(ColumnReference {
+                        quantifier_id,
+                        position,
+                    }));
                 }
                 select_id
             }

--- a/src/sql/src/query_model/hir.rs
+++ b/src/sql/src/query_model/hir.rs
@@ -86,6 +86,23 @@ impl FromHir {
                     panic!("unsupported get id {:?}", id);
                 }
             }
+            HirRelationExpr::Let {
+                name: _,
+                id,
+                value,
+                body,
+            } => {
+                let id = expr::Id::Local(id);
+                let value_box = self.generate_internal(*value);
+                let prev_value = self.gets_seen.insert(id.clone(), value_box);
+                let body_box = self.generate_internal(*body);
+                if let Some(prev_value) = prev_value {
+                    self.gets_seen.insert(id, prev_value);
+                } else {
+                    self.gets_seen.remove(&id);
+                }
+                body_box
+            }
             HirRelationExpr::Constant { rows, typ } => {
                 assert!(typ.arity() == 0, "expressions are not yet supported",);
                 self.model.make_box(BoxType::Values(Values {

--- a/src/sql/src/query_model/mod.rs
+++ b/src/sql/src/query_model/mod.rs
@@ -379,6 +379,14 @@ impl QueryBox {
         }
     }
 
+    /// Append the given expression as a new column without an explicit alias in
+    /// the projection of the box.
+    fn add_column(&mut self, expr: BoxScalarExpr) -> usize {
+        let position = self.columns.len();
+        self.columns.push(Column { expr, alias: None });
+        position
+    }
+
     /// Append the given expression as a new column in the projection of the box
     /// if there isn't already a column with the same expression. Returns the
     /// position of the first column in the projection with the same expression.
@@ -386,9 +394,7 @@ impl QueryBox {
         if let Some(position) = self.columns.iter().position(|c| c.expr == expr) {
             position
         } else {
-            let position = self.columns.len();
-            self.columns.push(Column { expr, alias: None });
-            position
+            self.add_column(expr)
         }
     }
 

--- a/src/sql/tests/querymodel/basic
+++ b/src/sql/tests/querymodel/basic
@@ -1080,3 +1080,143 @@ digraph G {
     Q1 -> boxhead1 [ lhead = cluster1 ]
     Q0 -> boxhead0 [ lhead = cluster0 ]
 }
+
+build
+with a(a, b) as (select 1, 2) select * from a where (select max(a) from a) = 10;
+----
+digraph G {
+    compound = true
+    labeljust = l
+    label = "with a(a, b) as (select 1, 2) select * from a where (select max(a) from a) = 10;"
+    node [ shape = box ]
+    subgraph cluster2 {
+        label = "Box2:Select"
+        boxhead2 [ shape = record, label = "{ Distinct: Preserve| 0: Q1.C0| 1: Q1.C1| (Q5.C0 = 10) }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q1 [ label = "Q1(F)" ]
+            Q5 [ label = "Q5(S)" ]
+        }
+    }
+    subgraph cluster1 {
+        label = "Box1:Select"
+        boxhead1 [ shape = record, label = "{ Distinct: Preserve| 0: 1| 1: 2 }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q0 [ label = "Q0(F)" ]
+        }
+    }
+    subgraph cluster0 {
+        label = "Box0:Values"
+        boxhead0 [ shape = record, label = "{ Distinct: Preserve| ROW:  }" ]
+        {
+            rank = same
+        }
+    }
+    subgraph cluster5 {
+        label = "Box5:Select"
+        boxhead5 [ shape = record, label = "{ Distinct: Preserve| 0: Q4.C0 }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q4 [ label = "Q4(F)" ]
+        }
+    }
+    subgraph cluster4 {
+        label = "Box4:Grouping"
+        boxhead4 [ shape = record, label = "{ Distinct: Preserve| 0: max(Q3.C0) }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q3 [ label = "Q3(F)" ]
+        }
+    }
+    subgraph cluster3 {
+        label = "Box3:Select"
+        boxhead3 [ shape = record, label = "{ Distinct: Preserve| 0: Q2.C0 }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q2 [ label = "Q2(F)" ]
+        }
+    }
+    edge [ arrowhead = none, style = dashed ]
+    Q1 -> boxhead1 [ lhead = cluster1 ]
+    Q5 -> boxhead5 [ lhead = cluster5 ]
+    Q0 -> boxhead0 [ lhead = cluster0 ]
+    Q4 -> boxhead4 [ lhead = cluster4 ]
+    Q3 -> boxhead3 [ lhead = cluster3 ]
+    Q2 -> boxhead1 [ lhead = cluster1 ]
+}
+
+build
+with a(a, b) as (select 1, 2), b(c) as (select max(a) from a) select * from a where (select c from b) = 10;
+----
+digraph G {
+    compound = true
+    labeljust = l
+    label = "with a(a, b) as (select 1, 2), b(c) as (select max(a) from a) select * from a where (select c from b) = 10;"
+    node [ shape = box ]
+    subgraph cluster4 {
+        label = "Box4:Select"
+        boxhead4 [ shape = record, label = "{ Distinct: Preserve| 0: Q3.C0| 1: Q3.C1| (Q5.C0 = 10) }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q3 [ label = "Q3(F)" ]
+            Q5 [ label = "Q5(S)" ]
+        }
+    }
+    subgraph cluster1 {
+        label = "Box1:Select"
+        boxhead1 [ shape = record, label = "{ Distinct: Preserve| 0: 1| 1: 2 }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q0 [ label = "Q0(F)" ]
+        }
+    }
+    subgraph cluster0 {
+        label = "Box0:Values"
+        boxhead0 [ shape = record, label = "{ Distinct: Preserve| ROW:  }" ]
+        {
+            rank = same
+        }
+    }
+    subgraph cluster5 {
+        label = "Box5:Select"
+        boxhead5 [ shape = record, label = "{ Distinct: Preserve| 0: Q4.C0 }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q4 [ label = "Q4(F)" ]
+        }
+    }
+    subgraph cluster3 {
+        label = "Box3:Grouping"
+        boxhead3 [ shape = record, label = "{ Distinct: Preserve| 0: max(Q2.C0) }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q2 [ label = "Q2(F)" ]
+        }
+    }
+    subgraph cluster2 {
+        label = "Box2:Select"
+        boxhead2 [ shape = record, label = "{ Distinct: Preserve| 0: Q1.C0 }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q1 [ label = "Q1(F)" ]
+        }
+    }
+    edge [ arrowhead = none, style = dashed ]
+    Q3 -> boxhead1 [ lhead = cluster1 ]
+    Q5 -> boxhead5 [ lhead = cluster5 ]
+    Q0 -> boxhead0 [ lhead = cluster0 ]
+    Q4 -> boxhead3 [ lhead = cluster3 ]
+    Q2 -> boxhead2 [ lhead = cluster2 ]
+    Q1 -> boxhead1 [ lhead = cluster1 ]
+}


### PR DESCRIPTION
Miscellaneous changes extracted from #9689. The main one is the support for Hir's Let. Even though it doesn't contain the changes for making `query_model/lowering.rs` produce the corresponding `Let` operator in Mir, this is an important change in order to validate the correctness of any transformation when there are boxes that are shared from different contexts. It currently lowers the shared box as many times as it is referenced.

The queries in the test added lead to the same query graph:

![query1](https://user-images.githubusercontent.com/1282736/148180511-a7aacbb8-37b0-4b5e-9656-1131d7c20d53.png)
![query2](https://user-images.githubusercontent.com/1282736/148180515-1f151400-8646-4201-a739-1a86629ecca6.png)

### Motivation

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug: [Link to issue.]

  * This PR adds a known-desirable feature: [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).


