### PR TITLE
[kafka sink] Remove blocking tx calls from dataflow thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1247,6 +1247,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "timely",
+ "timely-util",
  "tokio",
  "tokio-postgres",
  "tokio-util",
@@ -3171,6 +3172,7 @@ dependencies = [
  "ctor",
  "either",
  "futures",
+ "futures-util",
  "lazy_static",
  "openssl",
  "pin-project",
@@ -4912,6 +4914,16 @@ dependencies = [
  "timely_bytes",
  "timely_communication",
  "timely_logging",
+]
+
+[[package]]
+name = "timely-util"
+version = "0.0.0"
+dependencies = [
+ "futures",
+ "futures-util",
+ "timely",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3172,7 +3172,6 @@ dependencies = [
  "ctor",
  "either",
  "futures",
- "futures-util",
  "lazy_static",
  "openssl",
  "pin-project",
@@ -4920,7 +4919,6 @@ dependencies = [
 name = "timely-util"
 version = "0.0.0"
 dependencies = [
- "futures",
  "futures-util",
  "timely",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ members = [
     "src/sql",
     "src/sqllogictest",
     "src/testdrive",
+    "src/timely-util",
     "src/transform",
     "src/walkabout",
     "test/correctness",

--- a/src/dataflow/Cargo.toml
+++ b/src/dataflow/Cargo.toml
@@ -51,6 +51,7 @@ serde = { version = "1.0.133", features = ["derive"] }
 serde_json = "1.0.74"
 tempfile = "3.2.0"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
+timely-util = { path = "../timely-util" }
 tokio = { version = "1.15.0", features = ["fs", "rt", "sync"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", branch = "mz-0.7.2" }
 tokio-util = { version = "0.6.9", features = ["codec", "io"] }

--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -29,7 +29,7 @@ use rdkafka::producer::{BaseRecord, DeliveryResult, ProducerContext, ThreadedPro
 use timely::dataflow::channels::pact::Exchange;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
-use timely::dataflow::operators::generic::{FrontieredInputHandle, InputHandle, OutputHandle};
+use timely::dataflow::operators::generic::{InputHandle, OutputHandle};
 use timely::dataflow::operators::{Capability, Map};
 use timely::dataflow::{Scope, Stream};
 use timely::progress::frontier::AntichainRef;
@@ -699,290 +699,284 @@ where
     // our internal state after the send loop
     let mut progress_update = None;
 
-    let mut sink_logic = move |input: &mut FrontieredInputHandle<
-        _,
-        ((Option<Vec<u8>>, Option<Vec<u8>>), Timestamp, Diff),
-        _,
-    >| {
-        if s.shutdown_flag.load(Ordering::SeqCst) {
-            debug!("shutting down sink: {}", &s.name);
-            // Indicate that the sink is closed to everyone else who
-            // might be tracking its write frontier.
-            s.write_frontier.borrow_mut().clear();
-            return false;
-        }
-
-        // Queue all pending rows waiting to be sent to kafka
-        input.for_each(|_, rows| {
-            is_active_worker = true;
-            rows.swap(&mut vector);
-            for ((key, value), time, diff) in vector.drain(..) {
-                let should_emit = if as_of.strict {
-                    as_of.frontier.less_than(&time)
-                } else {
-                    as_of.frontier.less_equal(&time)
-                };
-
-                let previously_published = match &s.consistency {
-                    Some(consistency) => match consistency.gate_ts {
-                        Some(gate_ts) => time <= gate_ts,
-                        None => false,
-                    },
-                    None => false,
-                };
-
-                if !should_emit || previously_published {
-                    // Skip stale data for already published timestamps
-                    continue;
-                }
-
-                assert!(diff >= 0, "can't sink negative multiplicities");
-                if diff == 0 {
-                    // Explicitly refuse to send no-op records
-                    continue;
-                };
-                let diff = diff as usize;
-
-                let rows = s.pending_rows.entry(time).or_default();
-                rows.push(EncodedRow {
-                    key,
-                    value,
-                    count: diff,
-                });
-                s.metrics.rows_queued.inc();
-            }
-        });
-
-        // Figure out the durablity frontier for all sources we depent on
-        let mut durability_frontier = Antichain::new();
-
-        for history in source_timestamp_histories.iter() {
-            use differential_dataflow::lattice::Lattice;
-            durability_frontier.meet_assign(&history.durability_frontier());
-        }
-        // Move any newly closed timestamps from pending to ready
-        let mut closed_ts: Vec<u64> = s
-            .pending_rows
-            .iter()
-            .filter(|(ts, _)| {
-                !input.frontier.less_equal(*ts) && !durability_frontier.less_equal(*ts)
-            })
-            .map(|(&ts, _)| ts)
-            .collect();
-        closed_ts.sort_unstable();
-        closed_ts.into_iter().for_each(|ts| {
-            let rows = s.pending_rows.remove(&ts).unwrap();
-            s.ready_rows.push_back((ts, rows));
-        });
-
-        // Send a bounded number of records to Kafka from the ready queue.
-        // This loop has explicitly been designed so that each iteration sends
-        // at most one record to Kafka
-        for _ in 0..s.fuel {
-            if let Some((ts, rows)) = s.ready_rows.front() {
-                s.send_state = match s.send_state {
-                    SendState::Init => {
-                        let result = if s.transactional {
-                            s.producer.init_transactions(s.txn_timeout)
-                        } else {
-                            Ok(())
-                        };
-
-                        match result {
-                            Ok(()) => SendState::BeginTxn,
-                            Err(e) => s.transition_on_txn_error(s.send_state, *ts, e),
-                        }
-                    }
-                    SendState::BeginTxn => {
-                        let result = if s.transactional {
-                            s.producer.begin_transaction()
-                        } else {
-                            Ok(())
-                        };
-
-                        match result {
-                            Ok(()) => SendState::Begin,
-                            Err(e) => s.transition_on_txn_error(s.send_state, *ts, e),
-                        }
-                    }
-                    SendState::Begin => {
-                        if s.consistency.is_some() {
-                            let result = s.send_consistency_record(&ts.to_string(), "BEGIN", None);
-
-                            if let Err(retry) = result {
-                                return retry;
-                            }
-                        }
-                        SendState::Draining {
-                            row_index: 0,
-                            repeat_counter: 0,
-                            total_sent: 0,
-                        }
-                    }
-                    SendState::Draining {
-                        mut row_index,
-                        mut repeat_counter,
-                        mut total_sent,
-                    } => {
-                        let encoded_row = &rows[row_index];
-                        let record = BaseRecord::to(&s.topic);
-                        let record = if encoded_row.value.is_some() {
-                            record.payload(encoded_row.value.as_ref().unwrap())
-                        } else {
-                            record
-                        };
-                        let record = if encoded_row.key.is_some() {
-                            record.key(encoded_row.key.as_ref().unwrap())
-                        } else {
-                            record
-                        };
-                        if let Err(retry) = s.send(record) {
-                            return retry;
-                        }
-
-                        // advance to the next repetition of this row, or the next row if all
-                        // reptitions are exhausted
-                        total_sent += 1;
-                        repeat_counter += 1;
-                        if repeat_counter == encoded_row.count {
-                            repeat_counter = 0;
-                            row_index += 1;
-                            s.metrics.rows_queued.dec();
-                        }
-
-                        // move to the end state if we've finished all rows in this timestamp
-                        if row_index == rows.len() {
-                            SendState::End(total_sent)
-                        } else {
-                            SendState::Draining {
-                                row_index,
-                                repeat_counter,
-                                total_sent,
-                            }
-                        }
-                    }
-                    SendState::End(total_count) => {
-                        if s.consistency.is_some() {
-                            let result = s.send_consistency_record(
-                                &ts.to_string(),
-                                "END",
-                                Some(total_count),
-                            );
-
-                            if let Err(retry) = result {
-                                return retry;
-                            }
-                        }
-                        SendState::CommitTxn
-                    }
-                    SendState::CommitTxn => {
-                        let result = if s.transactional {
-                            s.producer.commit_transaction(s.txn_timeout)
-                        } else {
-                            Ok(())
-                        };
-
-                        match result {
-                            Ok(()) => {
-                                // sanity check for the continuous updating
-                                // of the write frontier below
-
-                                s.assert_progress(ts);
-                                progress_update.replace(ts.clone());
-
-                                s.ready_rows.pop_front();
-                                SendState::BeginTxn
-                            }
-                            Err(e) => s.transition_on_txn_error(s.send_state, *ts, e),
-                        }
-                    }
-                    SendState::AbortTxn => {
-                        let result = if s.transactional {
-                            s.producer.abort_transaction(s.txn_timeout)
-                        } else {
-                            Ok(())
-                        };
-
-                        match result {
-                            Ok(()) => SendState::BeginTxn,
-                            Err(e) => s.transition_on_txn_error(s.send_state, *ts, e),
-                        }
-                    }
-                    SendState::Shutdown => {
-                        s.shutdown_flag.store(true, Ordering::SeqCst);
-                        // Indicate that the sink is closed to everyone else who
-                        // might be tracking its write frontier.
-                        info!("shutting down kafka sink: {}", &s.name);
-                        break;
-                    }
-                };
-            } else {
-                break;
-            }
-        }
-
-        // update our state based on any END records we might have sent
-        if let Some(ts) = progress_update.take() {
-            s.maybe_update_progress(&ts);
-        }
-
-        // If we don't have ready rows, our write frontier equals the minimum
-        // of the input frontier and any stashed timestamps.
-        // While we still have ready rows that we're emitting, hold the write
-        // frontier at the previous time.
-        //
-        // Only ever emit progress records if this operator/worker received
-        // updates. Only on worker receives all the updates and we don't want
-        // the other workers to also emit END records.
-        if s.ready_rows.is_empty() && is_active_worker {
-            if let Err(e) = s.maybe_emit_progress(input.frontier.frontier()) {
-                // This can happen when the producer has not been
-                // initialized yet. This also means, that we only start
-                // emitting continuous updates once some real data
-                // has been emitted.
-                debug!("Error writing out progress update: {}", e);
-            }
-        }
-
-        let in_flight = s.producer.in_flight_count();
-        s.metrics.messages_in_flight.set(in_flight as u64);
-
-        if !s.ready_rows.is_empty() {
-            // We need timely to reschedule this operator as we have pending
-            // items that we need to send to Kafka
-            s.activator.activate();
-            return true;
-        }
-
-        if !s.pending_rows.is_empty() {
-            // We have some more rows that we need to wait for frontiers to advance before we
-            // can write them out. Let's make sure to reschedule with a small delay to give the
-            // system time to advance.
-            s.activator.activate_after(Duration::from_millis(100));
-            return true;
-        }
-
-        if in_flight > 0 {
-            // We still have messages that need to be flushed out to Kafka
-            // Let's make sure to keep the sink operator around until
-            // we flush them out
-            s.activator.activate_after(Duration::from_secs(5));
-            return true;
-        }
-
-        false
-    };
-
     // We want exactly one worker to send all the data to the sink topic.
     let hashed_id = id.hashed();
     let mut input = builder.new_input(&stream, Exchange::new(move |_| hashed_id));
 
-    builder.build_reschedule(|_capabilities| {
-        move |frontiers| {
-            let mut input_handle = FrontieredInputHandle::new(&mut input, &frontiers[0]);
-            sink_logic(&mut input_handle)
-        }
-    });
+    builder.build_async(
+        stream.scope(),
+        async_op!(|_initial_capabilities, frontiers| {
+            let frontiers_refcell = frontiers.borrow();
+            let frontier = frontiers_refcell[0].borrow();
+
+            if s.shutdown_flag.load(Ordering::SeqCst) {
+                debug!("shutting down sink: {}", &s.name);
+                // Indicate that the sink is closed to everyone else who
+                // might be tracking its write frontier.
+                s.write_frontier.borrow_mut().clear();
+                return false;
+            }
+
+            // Queue all pending rows waiting to be sent to kafka
+            input.for_each(|_, rows| {
+                is_active_worker = true;
+                rows.swap(&mut vector);
+                for ((key, value), time, diff) in vector.drain(..) {
+                    let should_emit = if as_of.strict {
+                        as_of.frontier.less_than(&time)
+                    } else {
+                        as_of.frontier.less_equal(&time)
+                    };
+
+                    let previously_published = match &s.consistency {
+                        Some(consistency) => match consistency.gate_ts {
+                            Some(gate_ts) => time <= gate_ts,
+                            None => false,
+                        },
+                        None => false,
+                    };
+
+                    if !should_emit || previously_published {
+                        // Skip stale data for already published timestamps
+                        continue;
+                    }
+
+                    assert!(diff >= 0, "can't sink negative multiplicities");
+                    if diff == 0 {
+                        // Explicitly refuse to send no-op records
+                        continue;
+                    };
+                    let diff = diff as usize;
+
+                    let rows = s.pending_rows.entry(time).or_default();
+                    rows.push(EncodedRow {
+                        key,
+                        value,
+                        count: diff,
+                    });
+                    s.metrics.rows_queued.inc();
+                }
+            });
+
+            // Figure out the durablity frontier for all sources we depent on
+            let mut durability_frontier = Antichain::new();
+
+            for history in source_timestamp_histories.iter() {
+                use differential_dataflow::lattice::Lattice;
+                durability_frontier.meet_assign(&history.durability_frontier());
+            }
+            // Move any newly closed timestamps from pending to ready
+            let mut closed_ts: Vec<u64> = s
+                .pending_rows
+                .iter()
+                .filter(|(ts, _)| !frontier.less_equal(*ts) && !durability_frontier.less_equal(*ts))
+                .map(|(&ts, _)| ts)
+                .collect();
+            closed_ts.sort_unstable();
+            closed_ts.into_iter().for_each(|ts| {
+                let rows = s.pending_rows.remove(&ts).unwrap();
+                s.ready_rows.push_back((ts, rows));
+            });
+
+            // Send a bounded number of records to Kafka from the ready queue.
+            // This loop has explicitly been designed so that each iteration sends
+            // at most one record to Kafka
+            for _ in 0..s.fuel {
+                if let Some((ts, rows)) = s.ready_rows.front() {
+                    s.send_state = match s.send_state {
+                        SendState::Init => {
+                            let result = if s.transactional {
+                                s.producer.init_transactions(s.txn_timeout)
+                            } else {
+                                Ok(())
+                            };
+
+                            match result {
+                                Ok(()) => SendState::BeginTxn,
+                                Err(e) => s.transition_on_txn_error(s.send_state, *ts, e),
+                            }
+                        }
+                        SendState::BeginTxn => {
+                            let result = if s.transactional {
+                                s.producer.begin_transaction()
+                            } else {
+                                Ok(())
+                            };
+
+                            match result {
+                                Ok(()) => SendState::Begin,
+                                Err(e) => s.transition_on_txn_error(s.send_state, *ts, e),
+                            }
+                        }
+                        SendState::Begin => {
+                            if s.consistency.is_some() {
+                                let result =
+                                    s.send_consistency_record(&ts.to_string(), "BEGIN", None);
+
+                                if let Err(retry) = result {
+                                    return retry;
+                                }
+                            }
+                            SendState::Draining {
+                                row_index: 0,
+                                repeat_counter: 0,
+                                total_sent: 0,
+                            }
+                        }
+                        SendState::Draining {
+                            mut row_index,
+                            mut repeat_counter,
+                            mut total_sent,
+                        } => {
+                            let encoded_row = &rows[row_index];
+                            let record = BaseRecord::to(&s.topic);
+                            let record = if encoded_row.value.is_some() {
+                                record.payload(encoded_row.value.as_ref().unwrap())
+                            } else {
+                                record
+                            };
+                            let record = if encoded_row.key.is_some() {
+                                record.key(encoded_row.key.as_ref().unwrap())
+                            } else {
+                                record
+                            };
+                            if let Err(retry) = s.send(record) {
+                                return retry;
+                            }
+
+                            // advance to the next repetition of this row, or the next row if all
+                            // reptitions are exhausted
+                            total_sent += 1;
+                            repeat_counter += 1;
+                            if repeat_counter == encoded_row.count {
+                                repeat_counter = 0;
+                                row_index += 1;
+                                s.metrics.rows_queued.dec();
+                            }
+
+                            // move to the end state if we've finished all rows in this timestamp
+                            if row_index == rows.len() {
+                                SendState::End(total_sent)
+                            } else {
+                                SendState::Draining {
+                                    row_index,
+                                    repeat_counter,
+                                    total_sent,
+                                }
+                            }
+                        }
+                        SendState::End(total_count) => {
+                            if s.consistency.is_some() {
+                                let result = s.send_consistency_record(
+                                    &ts.to_string(),
+                                    "END",
+                                    Some(total_count),
+                                );
+
+                                if let Err(retry) = result {
+                                    return retry;
+                                }
+                            }
+                            SendState::CommitTxn
+                        }
+                        SendState::CommitTxn => {
+                            let result = if s.transactional {
+                                s.producer.commit_transaction(s.txn_timeout)
+                            } else {
+                                Ok(())
+                            };
+
+                            match result {
+                                Ok(()) => {
+                                    // sanity check for the continuous updating
+                                    // of the write frontier below
+
+                                    s.assert_progress(ts);
+                                    progress_update.replace(ts.clone());
+
+                                    s.ready_rows.pop_front();
+                                    SendState::BeginTxn
+                                }
+                                Err(e) => s.transition_on_txn_error(s.send_state, *ts, e),
+                            }
+                        }
+                        SendState::AbortTxn => {
+                            let result = if s.transactional {
+                                s.producer.abort_transaction(s.txn_timeout)
+                            } else {
+                                Ok(())
+                            };
+
+                            match result {
+                                Ok(()) => SendState::BeginTxn,
+                                Err(e) => s.transition_on_txn_error(s.send_state, *ts, e),
+                            }
+                        }
+                        SendState::Shutdown => {
+                            s.shutdown_flag.store(true, Ordering::SeqCst);
+                            // Indicate that the sink is closed to everyone else who
+                            // might be tracking its write frontier.
+                            info!("shutting down kafka sink: {}", &s.name);
+                            break;
+                        }
+                    };
+                } else {
+                    break;
+                }
+            }
+
+            // update our state based on any END records we might have sent
+            if let Some(ts) = progress_update.take() {
+                s.maybe_update_progress(&ts);
+            }
+
+            // If we don't have ready rows, our write frontier equals the minimum
+            // of the input frontier and any stashed timestamps.
+            // While we still have ready rows that we're emitting, hold the write
+            // frontier at the previous time.
+            //
+            // Only ever emit progress records if this operator/worker received
+            // updates. Only on worker receives all the updates and we don't want
+            // the other workers to also emit END records.
+            if s.ready_rows.is_empty() && is_active_worker {
+                if let Err(e) = s.maybe_emit_progress(frontier) {
+                    // This can happen when the producer has not been
+                    // initialized yet. This also means, that we only start
+                    // emitting continuous updates once some real data
+                    // has been emitted.
+                    debug!("Error writing out progress update: {}", e);
+                }
+            }
+
+            let in_flight = s.producer.in_flight_count();
+            s.metrics.messages_in_flight.set(in_flight as u64);
+
+            if !s.ready_rows.is_empty() {
+                // We need timely to reschedule this operator as we have pending
+                // items that we need to send to Kafka
+                s.activator.activate();
+                return true;
+            }
+
+            if !s.pending_rows.is_empty() {
+                // We have some more rows that we need to wait for frontiers to advance before we
+                // can write them out. Let's make sure to reschedule with a small delay to give the
+                // system time to advance.
+                s.activator.activate_after(Duration::from_millis(100));
+                return true;
+            }
+
+            if in_flight > 0 {
+                // We still have messages that need to be flushed out to Kafka
+                // Let's make sure to keep the sink operator around until
+                // we flush them out
+                s.activator.activate_after(Duration::from_secs(5));
+                return true;
+            }
+
+            false
+        }),
+    );
 
     Box::new(KafkaSinkToken { shutdown_flag })
 }

--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -20,7 +20,6 @@ use differential_dataflow::{AsCollection, Collection, Hashable};
 use interchange::json::JsonEncoder;
 use itertools::Itertools;
 use log::{debug, error, info};
-use ore::metrics::{CounterVecExt, DeleteOnDropCounter, DeleteOnDropGauge, GaugeVecExt};
 use rdkafka::client::ClientContext;
 use rdkafka::config::ClientConfig;
 use rdkafka::error::{KafkaError, RDKafkaErrorCode};
@@ -44,7 +43,10 @@ use expr::GlobalId;
 use interchange::avro::{self, AvroEncoder, AvroSchemaGenerator};
 use interchange::encode::Encode;
 use ore::cast::CastFrom;
+use ore::metrics::{CounterVecExt, DeleteOnDropCounter, DeleteOnDropGauge, GaugeVecExt};
 use repr::{Datum, Diff, RelationDesc, Row, Timestamp};
+use timely_util::async_op;
+use timely_util::operators_async_ext::OperatorBuilderExt;
 
 use super::{KafkaBaseMetrics, SinkBaseMetrics};
 use crate::render::sinks::SinkRender;

--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -809,6 +809,9 @@ where
                 s.ready_rows.push_back((ts, rows));
             });
 
+            // TODO: #9980.  Rewrite this to take advantage of the fact that we're now within an
+            //       async op and don't need to explicitly yield in order to not block timely.
+            //
             // Send a bounded number of records to Kafka from the ready queue.
             // This loop has explicitly been designed so that each iteration sends
             // at most one record to Kafka

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -29,7 +29,6 @@ clap = { version = "3.0.0", optional = true }
 ctor = { version = "0.1.21", optional = true }
 either = "1.6.1"
 futures = { version = "0.3.19", optional = true }
-futures-util = "0.3.19"
 lazy_static = "1.4.0"
 # This isn't directly imported by anything, but it's required at link time. The
 # vendored feature is transitively depended upon by tokio-openssl.

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -29,6 +29,7 @@ clap = { version = "3.0.0", optional = true }
 ctor = { version = "0.1.21", optional = true }
 either = "1.6.1"
 futures = { version = "0.3.19", optional = true }
+futures-util = "0.3.19"
 lazy_static = "1.4.0"
 # This isn't directly imported by anything, but it's required at link time. The
 # vendored feature is transitively depended upon by tokio-openssl.

--- a/src/persist/src/operators/mod.rs
+++ b/src/persist/src/operators/mod.rs
@@ -10,8 +10,6 @@
 //! Timely and Differential Dataflow operators for persisting and replaying
 //! data.
 
-#[macro_use]
-mod async_ext;
 pub mod input;
 pub mod replay;
 pub mod source;

--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "timely-util"
+description = "Utilities for working with Timely."
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+futures = { version = "0.3.19", optional = true }
+futures-util = "0.3.19"
+timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
+tokio = { version = "1.15.0", features = ["io-util", "macros", "net", "rt-multi-thread", "time"] }

--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -6,7 +6,8 @@ edition = "2021"
 publish = false
 
 [dependencies]
-futures = { version = "0.3.19", optional = true }
 futures-util = "0.3.19"
-timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
-tokio = { version = "1.15.0", features = ["io-util", "macros", "net", "rt-multi-thread", "time"] }
+timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false }
+
+[dev-dependencies]
+tokio = { version = "1.15.0", features = ["macros", "time"] }

--- a/src/timely-util/src/lib.rs
+++ b/src/timely-util/src/lib.rs
@@ -1,0 +1,21 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Internal utility libraries for Materialize.
+//! Utilities for working with Timely
+
+#![warn(missing_docs)]
+
+pub mod operators_async_ext;

--- a/src/timely-util/src/operators_async_ext.rs
+++ b/src/timely-util/src/operators_async_ext.rs
@@ -24,7 +24,6 @@ use timely::PartialOrder;
 
 /// A type that is not inhabited by any value. Should be redefined as the
 /// [never](https://doc.rust-lang.org/std/primitive.never.html) type once it stabilizes
-#[derive(Debug)]
 pub enum Never {}
 
 /// A helper type to integrate timely notifications with async futures. Its intended to be used
@@ -93,7 +92,7 @@ pub trait OperatorBuilderExt<G: Scope> {
     /// follows the following pattern:
     ///
     /// ```ignore
-    /// op.build_async(scope, move |capabilities, frontier, scheduler, reschedule_flag| async move {
+    /// op.build_async(scope, move |capabilities, frontier, scheduler| async move {
     ///     while scheduler.yield_now().await {
     ///         // async operator logic here
     ///     }
@@ -111,7 +110,7 @@ pub trait OperatorBuilderExt<G: Scope> {
             Rc<RefCell<Vec<Antichain<G::Timestamp>>>>,
             Scheduler,
         ) -> Fut,
-        Fut: Future<Output = ()> + 'static;
+        Fut: Future + 'static;
 }
 
 impl<G: Scope> OperatorBuilderExt<G> for OperatorBuilder<G> {
@@ -122,7 +121,7 @@ impl<G: Scope> OperatorBuilderExt<G> for OperatorBuilder<G> {
             Rc<RefCell<Vec<Antichain<G::Timestamp>>>>,
             Scheduler,
         ) -> Fut,
-        Fut: Future<Output = ()> + 'static,
+        Fut: Future + 'static,
     {
         let activator = scope.sync_activator_for(&self.operator_info().address[..]);
         let waker = futures_util::task::waker(Arc::new(activator));


### PR DESCRIPTION
In the Kafka Sink, move calls to `{init,begin,commit,abort}_transaction` off the dataflow worker thread onto a background threadpool managed by tokio.  This is done in two parts (reviewing independently may help -- I can also split into two separate PRs if desired):

### Build Async Scaffolding
- bce3bc360e722d690b4ce97f4326d947189ff8e9 Move the already-existing `OperatorBuilderExt` trait to the `ore` crate and modify it to work with operators that may require being rescheduled (i.e. those that use `OperatorBuilder::build_reschedule` rather than `OperatorBuilder::build`).  Modifications to `reschedule_flag` are the primary thing that changed other than the rename.
- 6a53f799fe1a5d78172ae75ef9bad9ad8e72b34a Use the `OperatorBuilder::build_async` / `async_op!` framework to make the kafka sink an async op.  This commit doesn't actually move the tx calls off the dataflow thread yet.  (This also adds a layer of indentation so likely easier to review with whitespace changes off)

### Rdkafka Changes
- 0c368e421d8ef8231288aec57159c724b0acceec actually move the tx calls off the dataflow thread
- After that, CR

### Motivation
Fixes #6035 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/9909)
<!-- Reviewable:end -->
