### PR TITLE
doc/developer: add an mzcompose.md stub pointing to mzbuild.md

### DIFF
--- a/doc/developer/mzcompose.md
+++ b/doc/developer/mzcompose.md
@@ -1,0 +1,3 @@
+# mzcompose
+
+You're probably looking for [mzbuild.md](mzbuild.md).


### PR DESCRIPTION
I spend a decent amount of time assuming that mzcompose wasn't
documented because I didn't know I really had to look in this mzbuild.md
file.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
