### PR TITLE
filter MetricsRecorderLayer with the same filter as the fmt layer

### DIFF
--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -500,7 +500,9 @@ fn run(args: Args) -> Result<(), anyhow::Error> {
                 // The user explicitly directed logs to stderr. Log only to
                 // stderr with the user-specified `filter`.
                 tracing_subscriber::registry()
-                    .with(MetricsRecorderLayer::new(log_message_counter))
+                    .with(
+                        MetricsRecorderLayer::new(log_message_counter).with_filter(filter.clone()),
+                    )
                     .with(
                         fmt::layer()
                             .with_writer(io::stderr)
@@ -517,7 +519,9 @@ fn run(args: Args) -> Result<(), anyhow::Error> {
                     None => LevelFilter::WARN,
                 };
                 tracing_subscriber::registry()
-                    .with(MetricsRecorderLayer::new(log_message_counter))
+                    .with(
+                        MetricsRecorderLayer::new(log_message_counter).with_filter(filter.clone()),
+                    )
                     .with({
                         let path = match log_file {
                             Some(log_file) => PathBuf::from(log_file),


### PR DESCRIPTION
This appears to be the source of the regression, and reverts to the original envfilter behavior, without limiting our ability to add layers like `console-subscriber`

### Motivation

  * This PR fixes a recognized bug: [[Link to issue.]](https://github.com/MaterializeInc/materialize/issues/9879)

benchmark:
```
[+] Running 19/0
...
feature-benchmark_mzdata
NAME                      |    THIS     |    OTHER    |  Regression?  | 'THIS' is:
----------------------------------------------------------------------------------------------------
KafkaUpsertUnique         |       0.850 |       1.504 |      no       | 43.5 pct   faster
```

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/9915)
<!-- Reviewable:end -->
