### PR TITLE
materialized: disable clap's handling of --version

### DIFF
--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -66,7 +66,7 @@ fn parse_optional_duration(s: &str) -> Result<OptionalDuration, anyhow::Error> {
 
 /// The streaming SQL materialized view engine.
 #[derive(Parser)]
-#[clap(global_setting = AppSettings::NextLineHelp)]
+#[clap(global_setting = AppSettings::NextLineHelp, global_setting = AppSettings::NoAutoVersion)]
 struct Args {
     // === Special modes. ===
     /// Print version information and exit.

--- a/src/materialized/tests/cli.rs
+++ b/src/materialized/tests/cli.rs
@@ -22,6 +22,19 @@ fn cmd() -> Command {
     cmd
 }
 
+/// This test seems a bit tautological, but it protects against Clap defaults
+/// changing and overwriting our custom version output.
+#[test]
+fn test_version() {
+    let expected_version = materialized::BUILD_INFO.human_version();
+    assert!(!expected_version.is_empty() && expected_version.starts_with('v'));
+    cmd()
+        .arg("--version")
+        .assert()
+        .success()
+        .stdout(format!("materialized {}\n", expected_version));
+}
+
 #[test]
 fn test_threads() {
     let assert_fail = |cmd: &mut Command| {


### PR DESCRIPTION
Clap v3 silently started adding a `--version` option that took
precedence over ours and failed to yield the actual version information.
Disable this new behavior and also add a test to protect against this in
the future.


### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
