### PR TITLE
qgm: add typ method in BoxScalarExpr

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -3377,9 +3377,13 @@ where
                 explanation.to_string()
             }
             ExplainStage::QueryGraph => {
-                // TODO add type information to the output graph
+                let catalog = self.catalog.for_session(session);
                 let model = sql::query_model::Model::from(raw_plan);
-                sql::query_model::dot::DotGenerator::new().generate(&model, "")?
+                sql::query_model::dot::DotGenerator::new(&catalog).generate(
+                    &model,
+                    "",
+                    options.typed,
+                )?
             }
             ExplainStage::DecorrelatedPlan => {
                 let decorrelated_plan = OptimizedMirRelationExpr::declare_optimized(decorrelate(

--- a/src/sql/src/query_model/test.rs
+++ b/src/sql/src/query_model/test.rs
@@ -351,8 +351,13 @@ fn test_hir_generator() {
                     let mut output = String::new();
 
                     if dot_graph {
-                        output += &match query_model::dot::DotGenerator::new()
-                            .generate(&model, &s.input)
+                        let typed = if let Some(format) = s.args.get("format") {
+                            format.contains(&"types".to_string())
+                        } else {
+                            false
+                        };
+                        output += &match query_model::dot::DotGenerator::new(&catalog)
+                            .generate(&model, &s.input, typed)
                         {
                             Ok(graph) => graph,
                             Err(e) => return format!("graph generation error: {}", e),

--- a/src/sql/tests/querymodel/types
+++ b/src/sql/tests/querymodel/types
@@ -1,0 +1,509 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+cat
+(defsource x [int32 int64 int32] [a b c])
+(defsource y [(int32 true) (int32 false)] [a b])
+----
+ok
+
+build format=types
+select * from x;
+----
+digraph G {
+    compound = true
+    labeljust = l
+    label = "select * from x;"
+    node [ shape = box ]
+    subgraph cluster1 {
+        label = "Box1:Select"
+        boxhead1 [ shape = record, label = "{ Distinct: Preserve| 0: Q0.C0 (Int32?)| 1: Q0.C1 (Int64?)| 2: Q0.C2 (Int32?) }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q0 [ label = "Q0(F)" ]
+        }
+    }
+    subgraph cluster0 {
+        label = "Box0:Get"
+        boxhead0 [ shape = record, label = "{ Distinct: Preserve| 0: C0 (Int32?)| 1: C1 (Int64?)| 2: C2 (Int32?) }" ]
+        {
+            rank = same
+        }
+    }
+    edge [ arrowhead = none, style = dashed ]
+    Q0 -> boxhead0 [ lhead = cluster0 ]
+}
+
+build format=types
+select * from y;
+----
+digraph G {
+    compound = true
+    labeljust = l
+    label = "select * from y;"
+    node [ shape = box ]
+    subgraph cluster1 {
+        label = "Box1:Select"
+        boxhead1 [ shape = record, label = "{ Distinct: Preserve| 0: Q0.C0 (Int32?)| 1: Q0.C1 (Int32) }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q0 [ label = "Q0(F)" ]
+        }
+    }
+    subgraph cluster0 {
+        label = "Box0:Get"
+        boxhead0 [ shape = record, label = "{ Distinct: Preserve| 0: C0 (Int32?)| 1: C1 (Int32) }" ]
+        {
+            rank = same
+        }
+    }
+    edge [ arrowhead = none, style = dashed ]
+    Q0 -> boxhead0 [ lhead = cluster0 ]
+}
+
+# null rejecting predicate on one column
+build format=types
+select * from x where  a > 10;
+----
+digraph G {
+    compound = true
+    labeljust = l
+    label = "select * from x where  a \> 10;"
+    node [ shape = box ]
+    subgraph cluster1 {
+        label = "Box1:Select"
+        boxhead1 [ shape = record, label = "{ Distinct: Preserve| 0: Q0.C0 (Int32)| 1: Q0.C1 (Int64?)| 2: Q0.C2 (Int32?)| (Q0.C0 \> 10) }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q0 [ label = "Q0(F)" ]
+        }
+    }
+    subgraph cluster0 {
+        label = "Box0:Get"
+        boxhead0 [ shape = record, label = "{ Distinct: Preserve| 0: C0 (Int32?)| 1: C1 (Int64?)| 2: C2 (Int32?) }" ]
+        {
+            rank = same
+        }
+    }
+    edge [ arrowhead = none, style = dashed ]
+    Q0 -> boxhead0 [ lhead = cluster0 ]
+}
+
+# null rejecting predicate on two columns
+build format=types
+select * from x where  a > c;
+----
+digraph G {
+    compound = true
+    labeljust = l
+    label = "select * from x where  a \> c;"
+    node [ shape = box ]
+    subgraph cluster1 {
+        label = "Box1:Select"
+        boxhead1 [ shape = record, label = "{ Distinct: Preserve| 0: Q0.C0 (Int32)| 1: Q0.C1 (Int64?)| 2: Q0.C2 (Int32)| (Q0.C0 \> Q0.C2) }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q0 [ label = "Q0(F)" ]
+        }
+    }
+    subgraph cluster0 {
+        label = "Box0:Get"
+        boxhead0 [ shape = record, label = "{ Distinct: Preserve| 0: C0 (Int32?)| 1: C1 (Int64?)| 2: C2 (Int32?) }" ]
+        {
+            rank = same
+        }
+    }
+    edge [ arrowhead = none, style = dashed ]
+    Q0 -> boxhead0 [ lhead = cluster0 ]
+}
+
+# two null rejecting predicates on different two columns
+build format=types
+select * from x where  a > 10 and c > 20;
+----
+digraph G {
+    compound = true
+    labeljust = l
+    label = "select * from x where  a \> 10 and c \> 20;"
+    node [ shape = box ]
+    subgraph cluster1 {
+        label = "Box1:Select"
+        boxhead1 [ shape = record, label = "{ Distinct: Preserve| 0: Q0.C0 (Int32)| 1: Q0.C1 (Int64?)| 2: Q0.C2 (Int32)| ((Q0.C0 \> 10) && (Q0.C2 \> 20)) }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q0 [ label = "Q0(F)" ]
+        }
+    }
+    subgraph cluster0 {
+        label = "Box0:Get"
+        boxhead0 [ shape = record, label = "{ Distinct: Preserve| 0: C0 (Int32?)| 1: C1 (Int64?)| 2: C2 (Int32?) }" ]
+        {
+            rank = same
+        }
+    }
+    edge [ arrowhead = none, style = dashed ]
+    Q0 -> boxhead0 [ lhead = cluster0 ]
+}
+
+# computed expression with unsatisfied non-null requirements
+build format=types
+select a + c from x where  a > 10;
+----
+digraph G {
+    compound = true
+    labeljust = l
+    label = "select a + c from x where  a \> 10;"
+    node [ shape = box ]
+    subgraph cluster3 {
+        label = "Box3:Select"
+        boxhead3 [ shape = record, label = "{ Distinct: Preserve| 0: Q2.C3 (Int32?) }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q2 [ label = "Q2(F)" ]
+        }
+    }
+    subgraph cluster2 {
+        label = "Box2:Select"
+        boxhead2 [ shape = record, label = "{ Distinct: Preserve| 0: Q1.C0 (Int32)| 1: Q1.C1 (Int64?)| 2: Q1.C2 (Int32?)| 3: (Q1.C0 + Q1.C2) (Int32?) }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q1 [ label = "Q1(F)" ]
+        }
+    }
+    subgraph cluster1 {
+        label = "Box1:Select"
+        boxhead1 [ shape = record, label = "{ Distinct: Preserve| 0: Q0.C0 (Int32)| 1: Q0.C1 (Int64?)| 2: Q0.C2 (Int32?)| (Q0.C0 \> 10) }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q0 [ label = "Q0(F)" ]
+        }
+    }
+    subgraph cluster0 {
+        label = "Box0:Get"
+        boxhead0 [ shape = record, label = "{ Distinct: Preserve| 0: C0 (Int32?)| 1: C1 (Int64?)| 2: C2 (Int32?) }" ]
+        {
+            rank = same
+        }
+    }
+    edge [ arrowhead = none, style = dashed ]
+    Q2 -> boxhead2 [ lhead = cluster2 ]
+    Q1 -> boxhead1 [ lhead = cluster1 ]
+    Q0 -> boxhead0 [ lhead = cluster0 ]
+}
+
+build format=types
+select a + b from y;
+----
+digraph G {
+    compound = true
+    labeljust = l
+    label = "select a + b from y;"
+    node [ shape = box ]
+    subgraph cluster2 {
+        label = "Box2:Select"
+        boxhead2 [ shape = record, label = "{ Distinct: Preserve| 0: Q1.C2 (Int32?) }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q1 [ label = "Q1(F)" ]
+        }
+    }
+    subgraph cluster1 {
+        label = "Box1:Select"
+        boxhead1 [ shape = record, label = "{ Distinct: Preserve| 0: Q0.C0 (Int32?)| 1: Q0.C1 (Int32)| 2: (Q0.C0 + Q0.C1) (Int32?) }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q0 [ label = "Q0(F)" ]
+        }
+    }
+    subgraph cluster0 {
+        label = "Box0:Get"
+        boxhead0 [ shape = record, label = "{ Distinct: Preserve| 0: C0 (Int32?)| 1: C1 (Int32) }" ]
+        {
+            rank = same
+        }
+    }
+    edge [ arrowhead = none, style = dashed ]
+    Q1 -> boxhead1 [ lhead = cluster1 ]
+    Q0 -> boxhead0 [ lhead = cluster0 ]
+}
+
+# computed expression becomes non-nullable due to all non-null requirements being satisfied
+build format=types
+select a + c from x where  a > c;
+----
+digraph G {
+    compound = true
+    labeljust = l
+    label = "select a + c from x where  a \> c;"
+    node [ shape = box ]
+    subgraph cluster3 {
+        label = "Box3:Select"
+        boxhead3 [ shape = record, label = "{ Distinct: Preserve| 0: Q2.C3 (Int32) }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q2 [ label = "Q2(F)" ]
+        }
+    }
+    subgraph cluster2 {
+        label = "Box2:Select"
+        boxhead2 [ shape = record, label = "{ Distinct: Preserve| 0: Q1.C0 (Int32)| 1: Q1.C1 (Int64?)| 2: Q1.C2 (Int32)| 3: (Q1.C0 + Q1.C2) (Int32) }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q1 [ label = "Q1(F)" ]
+        }
+    }
+    subgraph cluster1 {
+        label = "Box1:Select"
+        boxhead1 [ shape = record, label = "{ Distinct: Preserve| 0: Q0.C0 (Int32)| 1: Q0.C1 (Int64?)| 2: Q0.C2 (Int32)| (Q0.C0 \> Q0.C2) }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q0 [ label = "Q0(F)" ]
+        }
+    }
+    subgraph cluster0 {
+        label = "Box0:Get"
+        boxhead0 [ shape = record, label = "{ Distinct: Preserve| 0: C0 (Int32?)| 1: C1 (Int64?)| 2: C2 (Int32?) }" ]
+        {
+            rank = same
+        }
+    }
+    edge [ arrowhead = none, style = dashed ]
+    Q2 -> boxhead2 [ lhead = cluster2 ]
+    Q1 -> boxhead1 [ lhead = cluster1 ]
+    Q0 -> boxhead0 [ lhead = cluster0 ]
+}
+
+
+build format=types
+select a + c from (select a, c from x where c > 20) where  a > 10;
+----
+digraph G {
+    compound = true
+    labeljust = l
+    label = "select a + c from (select a, c from x where c \> 20) where  a \> 10;"
+    node [ shape = box ]
+    subgraph cluster5 {
+        label = "Box5:Select"
+        boxhead5 [ shape = record, label = "{ Distinct: Preserve| 0: Q4.C2 (Int32) }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q4 [ label = "Q4(F)" ]
+        }
+    }
+    subgraph cluster4 {
+        label = "Box4:Select"
+        boxhead4 [ shape = record, label = "{ Distinct: Preserve| 0: Q3.C0 (Int32)| 1: Q3.C1 (Int32)| 2: (Q3.C0 + Q3.C1) (Int32) }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q3 [ label = "Q3(F)" ]
+        }
+    }
+    subgraph cluster3 {
+        label = "Box3:Select"
+        boxhead3 [ shape = record, label = "{ Distinct: Preserve| 0: Q2.C0 (Int32)| 1: Q2.C1 (Int32)| (Q2.C0 \> 10) }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q2 [ label = "Q2(F)" ]
+        }
+    }
+    subgraph cluster2 {
+        label = "Box2:Select"
+        boxhead2 [ shape = record, label = "{ Distinct: Preserve| 0: Q1.C0 (Int32?)| 1: Q1.C2 (Int32) }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q1 [ label = "Q1(F)" ]
+        }
+    }
+    subgraph cluster1 {
+        label = "Box1:Select"
+        boxhead1 [ shape = record, label = "{ Distinct: Preserve| 0: Q0.C0 (Int32?)| 1: Q0.C1 (Int64?)| 2: Q0.C2 (Int32)| (Q0.C2 \> 20) }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q0 [ label = "Q0(F)" ]
+        }
+    }
+    subgraph cluster0 {
+        label = "Box0:Get"
+        boxhead0 [ shape = record, label = "{ Distinct: Preserve| 0: C0 (Int32?)| 1: C1 (Int64?)| 2: C2 (Int32?) }" ]
+        {
+            rank = same
+        }
+    }
+    edge [ arrowhead = none, style = dashed ]
+    Q4 -> boxhead4 [ lhead = cluster4 ]
+    Q3 -> boxhead3 [ lhead = cluster3 ]
+    Q2 -> boxhead2 [ lhead = cluster2 ]
+    Q1 -> boxhead1 [ lhead = cluster1 ]
+    Q0 -> boxhead0 [ lhead = cluster0 ]
+}
+
+build format=types
+select a + b from y where a > 10;
+----
+digraph G {
+    compound = true
+    labeljust = l
+    label = "select a + b from y where a \> 10;"
+    node [ shape = box ]
+    subgraph cluster3 {
+        label = "Box3:Select"
+        boxhead3 [ shape = record, label = "{ Distinct: Preserve| 0: Q2.C2 (Int32) }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q2 [ label = "Q2(F)" ]
+        }
+    }
+    subgraph cluster2 {
+        label = "Box2:Select"
+        boxhead2 [ shape = record, label = "{ Distinct: Preserve| 0: Q1.C0 (Int32)| 1: Q1.C1 (Int32)| 2: (Q1.C0 + Q1.C1) (Int32) }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q1 [ label = "Q1(F)" ]
+        }
+    }
+    subgraph cluster1 {
+        label = "Box1:Select"
+        boxhead1 [ shape = record, label = "{ Distinct: Preserve| 0: Q0.C0 (Int32)| 1: Q0.C1 (Int32)| (Q0.C0 \> 10) }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q0 [ label = "Q0(F)" ]
+        }
+    }
+    subgraph cluster0 {
+        label = "Box0:Get"
+        boxhead0 [ shape = record, label = "{ Distinct: Preserve| 0: C0 (Int32?)| 1: C1 (Int32) }" ]
+        {
+            rank = same
+        }
+    }
+    edge [ arrowhead = none, style = dashed ]
+    Q2 -> boxhead2 [ lhead = cluster2 ]
+    Q1 -> boxhead1 [ lhead = cluster1 ]
+    Q0 -> boxhead0 [ lhead = cluster0 ]
+}
+
+# column from subquery quantifier is always nullable
+build format=types
+select (select a from x where a > 10);
+----
+digraph G {
+    compound = true
+    labeljust = l
+    label = "select (select a from x where a \> 10);"
+    node [ shape = box ]
+    subgraph cluster1 {
+        label = "Box1:Select"
+        boxhead1 [ shape = record, label = "{ Distinct: Preserve| 0: Q3.C0 (Int32?) }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q0 [ label = "Q0(F)" ]
+            Q3 [ label = "Q3(S)" ]
+        }
+    }
+    subgraph cluster0 {
+        label = "Box0:Values"
+        boxhead0 [ shape = record, label = "{ Distinct: Preserve| ROW:  }" ]
+        {
+            rank = same
+        }
+    }
+    subgraph cluster4 {
+        label = "Box4:Select"
+        boxhead4 [ shape = record, label = "{ Distinct: Preserve| 0: Q2.C0 (Int32) }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q2 [ label = "Q2(F)" ]
+        }
+    }
+    subgraph cluster3 {
+        label = "Box3:Select"
+        boxhead3 [ shape = record, label = "{ Distinct: Preserve| 0: Q1.C0 (Int32)| 1: Q1.C1 (Int64?)| 2: Q1.C2 (Int32?)| (Q1.C0 \> 10) }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q1 [ label = "Q1(F)" ]
+        }
+    }
+    subgraph cluster2 {
+        label = "Box2:Get"
+        boxhead2 [ shape = record, label = "{ Distinct: Preserve| 0: C0 (Int32?)| 1: C1 (Int64?)| 2: C2 (Int32?) }" ]
+        {
+            rank = same
+        }
+    }
+    edge [ arrowhead = none, style = dashed ]
+    Q0 -> boxhead0 [ lhead = cluster0 ]
+    Q3 -> boxhead4 [ lhead = cluster4 ]
+    Q2 -> boxhead3 [ lhead = cluster3 ]
+    Q1 -> boxhead2 [ lhead = cluster2 ]
+}
+
+# columns from non-preserving side of an outer join
+build format=types
+select * from y left join y b on false;
+----
+digraph G {
+    compound = true
+    labeljust = l
+    label = "select * from y left join y b on false;"
+    node [ shape = box ]
+    subgraph cluster2 {
+        label = "Box2:Select"
+        boxhead2 [ shape = record, label = "{ Distinct: Preserve| 0: Q2.C0 (Int32?)| 1: Q2.C1 (Int32)| 2: Q2.C2 (Int32?)| 3: Q2.C3 (Int32?) }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q2 [ label = "Q2(F)" ]
+        }
+    }
+    subgraph cluster0 {
+        label = "Box0:OuterJoin"
+        boxhead0 [ shape = record, label = "{ Distinct: Preserve| 0: Q0.C0 (Int32?)| 1: Q0.C1 (Int32)| 2: Q1.C0 (Int32?)| 3: Q1.C1 (Int32?)| false }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q0 [ label = "Q0(P)" ]
+            Q1 [ label = "Q1(F)" ]
+        }
+    }
+    subgraph cluster1 {
+        label = "Box1:Get"
+        boxhead1 [ shape = record, label = "{ Distinct: Preserve| 0: C0 (Int32?)| 1: C1 (Int32) }" ]
+        {
+            rank = same
+        }
+    }
+    edge [ arrowhead = none, style = dashed ]
+    Q2 -> boxhead0 [ lhead = cluster0 ]
+    Q0 -> boxhead1 [ lhead = cluster1 ]
+    Q1 -> boxhead1 [ lhead = cluster1 ]
+}

--- a/test/sqllogictest/query_graph.slt
+++ b/test/sqllogictest/query_graph.slt
@@ -43,3 +43,34 @@ digraph G {
 }
 
 EOF
+
+query T multiline
+EXPLAIN TYPED QUERY GRAPH FOR
+SELECT * FROM t;
+----
+digraph G {
+    compound = true
+    labeljust = l
+    label = ""
+    node [ shape = box ]
+    subgraph cluster1 {
+        label = "Box1:Select"
+        boxhead1 [ shape = record, label = "{ Distinct: Preserve| 0: Q0.C0 (integer?)| 1: Q0.C1 (integer?) }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q0 [ label = "Q0(F)" ]
+        }
+    }
+    subgraph cluster0 {
+        label = "Box0:Get"
+        boxhead0 [ shape = record, label = "{ Distinct: Preserve| 0: C0 (integer?)| 1: C1 (integer?) }" ]
+        {
+            rank = same
+        }
+    }
+    edge [ arrowhead = none, style = dashed ]
+    Q0 -> boxhead0 [ lhead = cluster0 ]
+}
+
+EOF


### PR DESCRIPTION
<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

Closes #9601

### Motivation

This PR adds methods to compute the type of scalar expressions. ATM they are only used to annotate the graphs with type informtion, but eventually this type information will be used by the different transformations.

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug: [Link to issue.]

  * This PR adds a known-desirable feature: [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

### Tips for reviewer

Note that nullability information associated with an expression may change when that expression is projected as a column by a box, since it may become affected by the operation the box represents. An obvious example of this is the projection of a nullable input column by a Select box that contains a null rejecting predicate on that input column. The output column then will never be null.

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/9917)
<!-- Reviewable:end -->
