### PR TITLE
feature-benchmark: fortify the FastPathFilterIndex scenario

### DIFF
--- a/test/feature-benchmark/scenarios.py
+++ b/test/feature-benchmark/scenarios.py
@@ -91,22 +91,39 @@ true
 """
     )
 
+    # Since an individual query of this particular type being benchmarked takes 1ms to execute, the results are susceptible
+    # to a lot of random noise. As we can not make the query any slower by using e.g. a large dataset,
+    # we run the query 100 times in a row and measure the total execution time.
+
     BENCHMARK = Td(
         """
+> BEGIN
+
 > /* A */ SELECT 1;
 1
+"""
+        + "\n".join(
+            [
+                """
+> SELECT * FROM v1 WHERE f1 = 1;
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+"""
+                for i in range(0, 100)
+            ]
+        )
+        + """
+> /* B */ SELECT 1;
+1
 
-> /* B */ SELECT * FROM v1 WHERE f1 = 1;
-1
-1
-1
-1
-1
-1
-1
-1
-1
-1
 """
     )
 


### PR DESCRIPTION
The FastPathFilterIndex scenario executes very quickly, at around 1ms,
leading to a lot of measurement noise. As a temporary solution,
run the query being measured 100 times within the scope of the .td
file so that the measurement value being reported is larger and
hopefully more stable.

### Motivation

  * This PR fixes a previously unreported bug.

One of the scenarios of the feature benchmark was unstable because it was measuring a very short, 1-ms time interval.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/9919)
<!-- Reviewable:end -->
