### PR TITLE
test: fix kafka-matrix

### DIFF
--- a/test/kafka-matrix/mzworkflows.py
+++ b/test/kafka-matrix/mzworkflows.py
@@ -43,8 +43,9 @@ def workflow_kafka_matrix(w: Workflow):
             SchemaRegistry(tag=version),
         ]
         with w.with_services(confluent_platform_services):
-            w.start_and_wait_for_tcp(services=confluent_platform_services)
-            w.start_services(services=["materialized"])
+            w.start_and_wait_for_tcp(
+                services=["zookeeper", "kafka", "schema-registry", "materialized"]
+            )
             w.wait_for_mz()
             w.run_service(
                 service="testdrive-svc",


### PR DESCRIPTION
w.start_and_wait_for_tcp(services=...) now takes a list of service
names and not service objects.

  * This PR fixes a previously unreported bug.
 
The nightly kafka-matrix test was failing

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/9920)
<!-- Reviewable:end -->
