### PR TITLE
persist: pass around Metrics wrapped in an Arc

### DIFF
--- a/src/persist/benches/writer.rs
+++ b/src/persist/benches/writer.rs
@@ -265,7 +265,7 @@ pub fn bench_writes_indexed(c: &mut Criterion) {
     let file_log = new_file_log("indexed_write_drain_log", temp_dir.path());
     let file_blob = new_file_blob("indexed_write_drain_blob", temp_dir.path());
 
-    let metrics = Metrics::register_with(&MetricsRegistry::new());
+    let metrics = Arc::new(Metrics::register_with(&MetricsRegistry::new()));
     let blob_cache = BlobCache::new(build_info::DUMMY_BUILD_INFO, metrics.clone(), file_blob);
     let compacter = Maintainer::new(blob_cache.clone(), Arc::new(Runtime::new().unwrap()));
     let file_indexed = Indexed::new(file_log, blob_cache, compacter, metrics)
@@ -327,14 +327,14 @@ pub fn bench_writes_blob_cache(c: &mut Criterion) {
     let mem_blob = MemRegistry::new()
         .blob_no_reentrance()
         .expect("creating a MemBlob cannot fail");
-    let metrics = Metrics::register_with(&MetricsRegistry::new());
+    let metrics = Arc::new(Metrics::register_with(&MetricsRegistry::new()));
     let mut mem_blob_cache = BlobCache::new(build_info::DUMMY_BUILD_INFO, metrics, mem_blob);
 
     // Create a directory that will automatically be dropped after the test finishes.
     let temp_dir = tempfile::tempdir().expect("failed to create temp directory");
     let file_blob = new_file_blob("indexed_write_drain_blob", temp_dir.path());
 
-    let metrics = Metrics::register_with(&MetricsRegistry::new());
+    let metrics = Arc::new(Metrics::register_with(&MetricsRegistry::new()));
     let mut file_blob_cache = BlobCache::new(build_info::DUMMY_BUILD_INFO, metrics, file_blob);
 
     let data = DataGenerator::default();

--- a/src/persist/src/indexed/arrangement.rs
+++ b/src/persist/src/indexed/arrangement.rs
@@ -1006,7 +1006,7 @@ mod tests {
     fn append_trace_ts_upper_invariant() -> Result<(), Error> {
         let mut blob = BlobCache::new(
             build_info::DUMMY_BUILD_INFO,
-            Metrics::default(),
+            Arc::new(Metrics::default()),
             MemBlob::new_no_reentrance("append_trace_ts_upper_invariant"),
         );
         let mut f = Arrangement::new(ArrangementMeta {
@@ -1048,7 +1048,7 @@ mod tests {
     fn append_detect_min_max_times() {
         let mut blob = BlobCache::new(
             build_info::DUMMY_BUILD_INFO,
-            Metrics::default(),
+            Arc::new(Metrics::default()),
             MemBlob::new_no_reentrance("append_ts_lower_invariant"),
         );
         let mut f = Arrangement::new(ArrangementMeta {
@@ -1078,7 +1078,7 @@ mod tests {
     fn unsealed_evict() -> Result<(), Error> {
         let mut blob = BlobCache::new(
             build_info::DUMMY_BUILD_INFO,
-            Metrics::default(),
+            Arc::new(Metrics::default()),
             MemBlob::new_no_reentrance("unsealed_evict"),
         );
         let mut f = Arrangement::new(ArrangementMeta {
@@ -1152,7 +1152,7 @@ mod tests {
     fn unsealed_snapshot() -> Result<(), Error> {
         let mut blob = BlobCache::new(
             build_info::DUMMY_BUILD_INFO,
-            Metrics::default(),
+            Arc::new(Metrics::default()),
             MemBlob::new_no_reentrance("unsealed_snapshot"),
         );
         let mut f = Arrangement::new(ArrangementMeta {
@@ -1205,7 +1205,7 @@ mod tests {
     fn unsealed_batch_trim() -> Result<(), Error> {
         let mut blob = BlobCache::new(
             build_info::DUMMY_BUILD_INFO,
-            Metrics::default(),
+            Arc::new(Metrics::default()),
             MemBlob::new_no_reentrance("unsealed_batch_trim"),
         );
         let mut f = Arrangement::new(ArrangementMeta {
@@ -1325,7 +1325,7 @@ mod tests {
     fn trace_compact() -> Result<(), Error> {
         let mut blob = BlobCache::new(
             build_info::DUMMY_BUILD_INFO,
-            Metrics::default(),
+            Arc::new(Metrics::default()),
             MemRegistry::new().blob_no_reentrance()?,
         );
         let maintainer = Maintainer::new(blob.clone(), Arc::new(Runtime::new()?));

--- a/src/persist/src/indexed/background.rs
+++ b/src/persist/src/indexed/background.rs
@@ -194,7 +194,7 @@ mod tests {
     fn compact_trace() -> Result<(), Error> {
         let blob = BlobCache::new(
             build_info::DUMMY_BUILD_INFO,
-            Metrics::default(),
+            Arc::new(Metrics::default()),
             MemRegistry::new().blob_no_reentrance()?,
         );
         let maintainer = Maintainer::new(blob.clone(), Arc::new(Runtime::new()?));
@@ -263,7 +263,7 @@ mod tests {
     fn compact_trace_errors() -> Result<(), Error> {
         let blob = BlobCache::new(
             build_info::DUMMY_BUILD_INFO,
-            Metrics::default(),
+            Arc::new(Metrics::default()),
             MemRegistry::new().blob_no_reentrance()?,
         );
         let maintainer = Maintainer::new(blob, Arc::new(Runtime::new()?));

--- a/src/persist/src/indexed/cache.rs
+++ b/src/persist/src/indexed/cache.rs
@@ -45,7 +45,7 @@ use crate::storage::{Atomicity, Blob};
 #[derive(Debug)]
 pub struct BlobCache<B: Blob> {
     build_version: Version,
-    metrics: Metrics,
+    metrics: Arc<Metrics>,
     blob: Arc<Mutex<B>>,
     // TODO: Use a disk-backed LRU cache.
     unsealed: Arc<Mutex<HashMap<String, Arc<BlobUnsealedBatch>>>>,
@@ -70,7 +70,7 @@ impl<B: Blob> BlobCache<B> {
     const META_KEY: &'static str = "META";
 
     /// Returns a new, empty cache for the given [Blob] storage.
-    pub fn new(build: BuildInfo, metrics: Metrics, blob: B) -> Self {
+    pub fn new(build: BuildInfo, metrics: Arc<Metrics>, blob: B) -> Self {
         BlobCache {
             build_version: build.semver_version(),
             metrics,
@@ -404,7 +404,7 @@ mod tests {
     fn build_version() -> Result<(), Error> {
         let mut cache = BlobCache::new(
             build_info::DUMMY_BUILD_INFO,
-            Metrics::default(),
+            Arc::new(Metrics::default()),
             MemRegistry::new().blob_no_reentrance()?,
         );
 

--- a/src/persist/src/indexed/metrics.rs
+++ b/src/persist/src/indexed/metrics.rs
@@ -55,7 +55,10 @@ impl BlobMetricsByType {
 }
 
 /// Persistence related monitoring metrics.
-#[derive(Clone, Debug)]
+///
+/// Intentionally not Clone because we expect this to be passed around in an
+/// Arc.
+#[derive(Debug)]
 pub struct Metrics {
     pub(crate) stream_count: ThirdPartyMetric<UIntGauge>,
     // TODO: pub(crate) stream_updated: ThirdPartyMetric<UIntGauge>,

--- a/src/persist/src/indexed/mod.rs
+++ b/src/persist/src/indexed/mod.rs
@@ -23,6 +23,7 @@ use std::any::TypeId;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::num::NonZeroUsize;
 use std::ops::Range;
+use std::sync::Arc;
 use std::time::Instant;
 
 use differential_dataflow::trace::Description;
@@ -143,7 +144,7 @@ pub struct Indexed<L: Log, B: Blob> {
     blob: BlobCache<B>,
     maintainer: Maintainer<B>,
     listeners: HashMap<Id, Vec<crossbeam_channel::Sender<ListenEvent>>>,
-    metrics: Metrics,
+    metrics: Arc<Metrics>,
     state: AppliedState,
     pending: Option<Pending>,
 }
@@ -171,7 +172,7 @@ impl<L: Log, B: Blob> Indexed<L, B> {
         mut log: L,
         mut blob: BlobCache<B>,
         maintainer: Maintainer<B>,
-        metrics: Metrics,
+        metrics: Arc<Metrics>,
     ) -> Result<Self, Error> {
         let meta = blob
             .get_meta()

--- a/src/persist/src/indexed/runtime.rs
+++ b/src/persist/src/indexed/runtime.rs
@@ -92,7 +92,7 @@ where
 {
     // TODO: Is an unbounded channel the right thing to do here?
     let (tx, rx) = crossbeam_channel::unbounded();
-    let metrics = Metrics::register_with(reg);
+    let metrics = Arc::new(Metrics::register_with(reg));
 
     // Any usage of S3Blob requires a runtime context to be set. `Indexed::new`
     // use the blob impl to start the recovery process, so make sure this stays
@@ -183,7 +183,7 @@ struct RuntimeHandles {
 struct RuntimeCore {
     handles: Mutex<Option<RuntimeHandles>>,
     tx: crossbeam_channel::Sender<Cmd>,
-    metrics: Metrics,
+    metrics: Arc<Metrics>,
 }
 
 impl RuntimeCore {
@@ -815,7 +815,7 @@ impl<K: Codec, V: Codec> StreamReadHandle<K, V> {
 struct RuntimeImpl<L: Log, B: Blob> {
     indexed: Indexed<L, B>,
     rx: crossbeam_channel::Receiver<Cmd>,
-    metrics: Metrics,
+    metrics: Arc<Metrics>,
     prev_step: Instant,
     min_step_interval: Duration,
 }
@@ -857,7 +857,7 @@ impl<L: Log, B: Blob> RuntimeImpl<L, B> {
         config: RuntimeConfig,
         indexed: Indexed<L, B>,
         rx: crossbeam_channel::Receiver<Cmd>,
-        metrics: Metrics,
+        metrics: Arc<Metrics>,
     ) -> Self {
         RuntimeImpl {
             indexed,

--- a/src/persist/src/mem.rs
+++ b/src/persist/src/mem.rs
@@ -432,7 +432,7 @@ impl MemRegistry {
     /// this registry.
     pub fn indexed_no_reentrance(&mut self) -> Result<Indexed<MemLog, MemBlob>, Error> {
         let log = self.log_no_reentrance()?;
-        let metrics = Metrics::register_with(&MetricsRegistry::new());
+        let metrics = Arc::new(Metrics::register_with(&MetricsRegistry::new()));
         let blob = BlobCache::new(
             build_info::DUMMY_BUILD_INFO,
             metrics.clone(),
@@ -450,7 +450,7 @@ impl MemRegistry {
     ) -> Result<Indexed<UnreliableLog<MemLog>, UnreliableBlob<MemBlob>>, Error> {
         let log = self.log_no_reentrance()?;
         let log = UnreliableLog::from_handle(log, unreliable.clone());
-        let metrics = Metrics::register_with(&MetricsRegistry::new());
+        let metrics = Arc::new(Metrics::register_with(&MetricsRegistry::new()));
         let blob = self.blob_no_reentrance()?;
         let blob = UnreliableBlob::from_handle(blob, unreliable);
         let blob = BlobCache::new(build_info::DUMMY_BUILD_INFO, metrics.clone(), blob);


### PR DESCRIPTION
This is almost entirely forward looking. While it's safe for Metrics to
directly derive Clone and for us to clone it in the few places we do
now, it's a big struct and these Clones are expensive. This doesn't
matter now, but at some point we'll need to pass a copy into e.g. a
snapshot so if it hits a transient error, we can try the retries.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/9923)
<!-- Reviewable:end -->
