### PR TITLE
[kafka sink] Create kafka topics using kafka_util crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -910,6 +910,7 @@ dependencies = [
  "futures",
  "interchange",
  "itertools",
+ "kafka-util",
  "lazy_static",
  "log",
  "mz-avro",

--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -23,6 +23,7 @@ fail = { version = "0.5.0", features = ["failpoints"] }
 futures = "0.3.19"
 interchange = { path = "../interchange" }
 itertools = "0.10.3"
+kafka-util = { path = "../kafka-util" }
 lazy_static = "1.4.0"
 log = "0.4.13"
 mz-avro = { path = "../avro", features = ["snappy"] }

--- a/src/testdrive/src/action/kafka/create_topic.rs
+++ b/src/testdrive/src/action/kafka/create_topic.rs
@@ -187,7 +187,7 @@ impl Action for CreateTopicAction {
             new_topic
         };
 
-        kafka_util::admin::create_topic(&state.kafka_admin, &state.kafka_admin_opts, &new_topic)
+        kafka_util::admin::ensure_topic(&state.kafka_admin, &state.kafka_admin_opts, &new_topic)
             .await
             .map_err_to_string()?;
         state.kafka_topics.insert(topic_name, self.partitions);

--- a/test/test-util/src/kafka/kafka_client.rs
+++ b/test/test-util/src/kafka/kafka_client.rs
@@ -66,7 +66,7 @@ impl KafkaClient {
             topic = topic.set(key, val);
         }
 
-        kafka_util::admin::create_topic(&client, &admin_opts, &topic)
+        kafka_util::admin::ensure_topic(&client, &admin_opts, &topic)
             .await
             .context(format!("creating Kafka topic: {}", topic_name))?;
 


### PR DESCRIPTION
Simplify the places we create kafka topics to just one.  I think this might potentially fix a latent bug because the way we created sink topics (and their corresponding consistency topics) may in some cases create the topic with the wrong number of partitions (see comment in `::kafka_util::admin::create_topic` explaining automatic topic creation)

### Motivation
Seemed like a decent first step for #8378.

### Checklist
- [x] This PR has adequate test coverage / QA involvement has been duly considered.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/9925)
<!-- Reviewable:end -->
