### PR TITLE
fix passing materialized extra args in mzcloud-cli

### DIFF
--- a/src/mzcloud-cli/src/bin/mzcloud.rs
+++ b/src/mzcloud-cli/src/bin/mzcloud.rs
@@ -125,7 +125,7 @@ enum DeploymentsCommand {
     /// Create a new Materialize deployment.
     Create {
         /// Cloud provider:region pair in which to deploy Materialize. Example: `aws:us-east-1`
-        #[structopt(long, parse(try_from_str = parse_cloud_region))]
+        #[clap(long, parse(try_from_str = parse_cloud_region))]
         cloud_provider_region: SupportedCloudRegionRequest,
 
         /// Name of the deployed materialized instance. Defaults to randomly assigned.
@@ -145,7 +145,7 @@ enum DeploymentsCommand {
         disable_user_indexes: Option<bool>,
 
         /// Extra arguments to provide to materialized.
-        #[clap(long)]
+        #[clap(long, allow_hyphen_values = true, multiple_values = true)]
         materialized_extra_args: Option<Vec<String>>,
 
         /// Version of materialized to deploy. Defaults to latest available version.
@@ -182,7 +182,7 @@ enum DeploymentsCommand {
 
         /// Extra arguments to provide to materialized. Defaults to the
         /// currently set extra arguments.
-        #[clap(long)]
+        #[clap(long, allow_hyphen_values = true, multiple_values = true)]
         materialized_extra_args: Option<Vec<String>>,
 
         /// Version of materialized to upgrade to. Defaults to the current


### PR DESCRIPTION
### Motivation

  * This PR fixes a previously unreported bug.

Fixes passing materialized extra args to mzcloud-cli. Most of these args will start with `-` or `--`, and so previously were parsed as arguments to mzcloud-cli, rather than the value of the `--materialized-extra-args` parameter.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/9927)
<!-- Reviewable:end -->
