### PR TITLE
mzcompose: emit informational output to stderr

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -352,7 +352,7 @@ class Composition:
             check: Whether to raise an error if the child process exits with
                 a failing exit code.
         """
-        print(f"$ docker-compose {' '.join(args)}")
+        print(f"$ docker-compose {' '.join(args)}", file=sys.stderr)
 
         self.file.seek(0)
         if env is not None:


### PR DESCRIPTION
So it doesn't intermix with machine-readable output on stdout.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/9928)
<!-- Reviewable:end -->
