### PR TITLE
sql-parser: remove spammy logs

### DIFF
--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -24,7 +24,7 @@ use std::error::Error;
 use std::fmt;
 
 use itertools::Itertools;
-use log::{debug, warn};
+use log::warn;
 
 use ore::collections::CollectionExt;
 use ore::option::OptionExt;
@@ -296,10 +296,8 @@ impl<'a> Parser<'a> {
         mut expr: Expr<Raw>,
     ) -> Result<Expr<Raw>, ParserError> {
         self.checked_recur_mut(|parser| {
-            debug!("prefix: {:?}", expr);
             loop {
                 let next_precedence = parser.get_next_precedence();
-                debug!("next precedence: {:?}", next_precedence);
                 if precedence >= next_precedence {
                     break;
                 }
@@ -899,7 +897,6 @@ impl<'a> Parser<'a> {
         expr: Expr<Raw>,
         precedence: Precedence,
     ) -> Result<Expr<Raw>, ParserError> {
-        debug!("parsing infix");
         let tok = self.next_token().unwrap(); // safe as EOF's precedence is the lowest
 
         let regular_binary_operator = match &tok {
@@ -1248,8 +1245,6 @@ impl<'a> Parser<'a> {
     /// Get the precedence of the next token
     fn get_next_precedence(&self) -> Precedence {
         if let Some(token) = self.peek_token() {
-            debug!("get_next_precedence() {:?}", token);
-
             match &token {
                 Token::Keyword(OR) => Precedence::Or,
                 Token::Keyword(AND) => Precedence::And,


### PR DESCRIPTION
These log messages date back to the original upstream SQL parser that we
imported into our codebase. They've never actually been used for
debugging issues in Materialize, and they're unnecessarily spammy, so
just ditch them. With modules like the SQL parser, it's very easy to add
back any necessary debug logging when investigating the parsing of a
particular statement. Put another way: I can't imagine a situation in
which you need to debug the SQL parser of a running production system.


### Motivation

  * This PR fixes a previously unreported annoyance.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/9929)
<!-- Reviewable:end -->
