### PR TITLE
Avoid destroying arrangements when constant folding

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -121,6 +121,8 @@ changes that have not yet been documented.
 - Correctly parse `SET SCHEMA ____` special case as per: https://www.postgresql.org/docs/9.1/sql-set.html,
   but it remains unsettable.
 
+- Fix a crash triggered under some circumstances when rendering delta joins of constant relations.
+
 {{< comment >}}
 Only add new release notes above this line.
 

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -551,6 +551,7 @@ AND ol_quantity BETWEEN 1 AND 100000
 
 %2 =
 | Constant ()
+| ArrangeBy ()
 
 %3 =
 | Union %1 %2
@@ -1033,6 +1034,7 @@ AND ol_delivery_d < TIMESTAMP '2020-01-02 00:00:00.000000'
 
 %4 =
 | Constant ()
+| ArrangeBy ()
 
 %5 =
 | Union %3 %4
@@ -1246,6 +1248,7 @@ AND ol_quantity < t.a
 
 %5 =
 | Constant ()
+| ArrangeBy ()
 
 %6 =
 | Union %4 %5
@@ -1356,6 +1359,7 @@ WHERE (
 
 %4 =
 | Constant ()
+| ArrangeBy ()
 
 %5 =
 | Union %3 %4

--- a/test/sqllogictest/column_knowledge.slt
+++ b/test/sqllogictest/column_knowledge.slt
@@ -274,6 +274,7 @@ EXPLAIN SELECT (SELECT t1.f1 FROM t1) = t2.f1 FROM t2 WHERE t2.f1 = 123;
 
 %5 =
 | Constant ()
+| ArrangeBy ()
 
 %6 =
 | Union %4 %5

--- a/test/sqllogictest/relation-cse.slt
+++ b/test/sqllogictest/relation-cse.slt
@@ -258,6 +258,7 @@ EXPLAIN SELECT * FROM t1 WHERE f1 = (SELECT f1 FROM t1) OR f2 = (SELECT f1 FROM 
 
 %4 =
 | Constant ()
+| ArrangeBy ()
 
 %5 =
 | Union %3 %4
@@ -422,6 +423,7 @@ EXPLAIN SELECT (SELECT f1 FROM t1 WHERE f1 = 1) , (SELECT f1 FROM t1 WHERE f1 = 
 
 %6 =
 | Constant ()
+| ArrangeBy ()
 
 %7 =
 | Union %5 %6
@@ -460,20 +462,21 @@ EXPLAIN SELECT MIN((SELECT f1 FROM t1 WHERE f1 = 1)), MAX((SELECT f1 FROM t1 WHE
 %3 = Let l1 =
 | Union %1 %2
 
-%4 =
+%4 = Let l2 =
+| Constant ()
+| ArrangeBy ()
+
+%5 =
 | Get %3 (l1)
 | Project ()
 | Distinct group=()
 | Negate
 
-%5 =
-| Constant ()
-
 %6 =
-| Union %4 %5
+| Union %5 %4
 | Map null
 
-%7 = Let l2 =
+%7 = Let l3 =
 | Union %3 %6
 
 %8 =
@@ -482,10 +485,10 @@ EXPLAIN SELECT MIN((SELECT f1 FROM t1 WHERE f1 = 1)), MAX((SELECT f1 FROM t1 WHE
 | ArrangeBy ()
 
 %9 =
-| Get %7 (l2)
+| Get %7 (l3)
 | ArrangeBy ()
 
-%10 = Let l3 =
+%10 = Let l4 =
 | Join %8 %9 %7
 | | implementation = Differential %7 %8.() %9.()
 | Reduce group=()
@@ -493,19 +496,16 @@ EXPLAIN SELECT MIN((SELECT f1 FROM t1 WHERE f1 = 1)), MAX((SELECT f1 FROM t1 WHE
 | | agg max(#1)
 
 %11 =
-| Get %10 (l3)
+| Get %10 (l4)
 | Project ()
 | Negate
 
 %12 =
-| Constant ()
-
-%13 =
-| Union %11 %12
+| Union %11 %4
 | Map null, null
 
-%14 =
-| Union %10 %13
+%13 =
+| Union %10 %12
 
 EOF
 
@@ -557,6 +557,7 @@ EXPLAIN SELECT (SELECT f1 FROM t1 WHERE f1 = 1) FROM t1 WHERE EXISTS (SELECT f1 
 
 %8 =
 | Constant ()
+| ArrangeBy ()
 
 %9 =
 | Union %7 %8
@@ -609,6 +610,7 @@ SELECT f1 FROM t1 WHERE f1 = 1
 
 %6 =
 | Constant ()
+| ArrangeBy ()
 
 %7 =
 | Union %5 %6
@@ -967,6 +969,7 @@ SELECT MIN(f1) FROM t1;
 
 %2 =
 | Constant ()
+| ArrangeBy ()
 
 %3 = Let l1 =
 | Union %1 %2
@@ -1320,16 +1323,17 @@ SELECT MAX(f1) FROM t1
 | Reduce group=()
 | | agg max(#0)
 
-%3 =
+%3 = Let l3 =
+| Constant ()
+| ArrangeBy ()
+
+%4 =
 | Get %1 (l1)
 | Project ()
 | Negate
 
-%4 =
-| Constant ()
-
 %5 =
-| Union %3 %4
+| Union %4 %3
 | Map null
 
 %6 =
@@ -1338,14 +1342,11 @@ SELECT MAX(f1) FROM t1
 | Negate
 
 %7 =
-| Constant ()
-
-%8 =
-| Union %6 %7
+| Union %6 %3
 | Map null
 
-%9 =
-| Union %1 %5 %2 %8
+%8 =
+| Union %1 %5 %2 %7
 
 EOF
 
@@ -1367,16 +1368,17 @@ SELECT MIN(f2) FROM t1
 | Reduce group=()
 | | agg min(#0)
 
-%2 =
+%2 = Let l2 =
+| Constant ()
+| ArrangeBy ()
+
+%3 =
 | Get %0 (l0)
 | Project ()
 | Negate
 
-%3 =
-| Constant ()
-
 %4 =
-| Union %2 %3
+| Union %3 %2
 | Map null
 
 %5 =
@@ -1385,13 +1387,10 @@ SELECT MIN(f2) FROM t1
 | Negate
 
 %6 =
-| Constant ()
-
-%7 =
-| Union %5 %6
+| Union %5 %2
 | Map null
 
-%8 =
-| Union %0 %4 %1 %7
+%7 =
+| Union %0 %4 %1 %6
 
 EOF

--- a/test/sqllogictest/scalar_subqueries_select_list.slt
+++ b/test/sqllogictest/scalar_subqueries_select_list.slt
@@ -76,6 +76,7 @@ EXPLAIN SELECT (SELECT * FROM t1), (SELECT * FROM t1) FROM t2
 
 %5 =
 | Constant ()
+| ArrangeBy ()
 
 %6 =
 | Union %4 %5
@@ -779,6 +780,7 @@ EXPLAIN SELECT MIN((SELECT f1 FROM t1 WHERE t1.f1 = t2.f1)), MAX((SELECT f1 FROM
 
 %24 =
 | Constant ()
+| ArrangeBy ()
 
 %25 =
 | Union %23 %24

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -313,8 +313,11 @@ SELECT abs(generate_series) FROM generate_series(-1, 2), repeat_row(generate_ser
 statement error  Negative multiplicity in constant result: -1
 SELECT * FROM (values ('a')), repeat_row(-1)
 
-statement error constant folding encountered reduce on collection with non-positive multiplicities
+simple
 SELECT (SELECT 1 FROM repeat_row(-1))
+----
+db error: ERROR: Invalid data in source, saw retractions (1) for row that does not exist: [Int32(1)]
+
 
 query T
 SELECT generate_series FROM generate_series(null, null, null)

--- a/test/sqllogictest/topk.slt
+++ b/test/sqllogictest/topk.slt
@@ -104,6 +104,7 @@ EXPLAIN PLAN FOR SELECT state, COUNT(*) FROM (
 ----
 %0 =
 | Constant
+| ArrangeBy (#0)
 
 EOF
 

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -470,6 +470,7 @@ WHERE
 
 %2 =
 | Constant ()
+| ArrangeBy ()
 
 %3 =
 | Union %1 %2
@@ -1047,6 +1048,7 @@ WHERE
 
 %4 =
 | Constant ()
+| ArrangeBy ()
 
 %5 =
 | Union %3 %4
@@ -1288,6 +1290,7 @@ WHERE
 
 %7 =
 | Constant ()
+| ArrangeBy ()
 
 %8 =
 | Union %6 %7
@@ -1448,6 +1451,7 @@ WHERE
 
 %4 =
 | Constant ()
+| ArrangeBy ()
 
 %5 =
 | Union %3 %4


### PR DESCRIPTION
Avoid stripping out MIR nodes that produce arrangements during constant folding. This is necessary becasue we sometimes rely on the fact that arrangements are produced; for example, in [delta join planning](https://github.com/MaterializeInc/materialize/blob/9558857d4/src/transform/src/join_implementation.rs#L153).

Detailed discussion took place [on Slack](https://materializeinc.slack.com/archives/C01BE3RN82F/p1641501511004300).
  
### Motivation

* This PR fixes a recognized bug: Fixes #9921 

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

I'm not adding a test, because Andi is already adding it in #9926. If that PR doesn't land for any reason, we should still add the test. 

- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/9930)
<!-- Reviewable:end -->
