### PR TITLE
pg-cdc: check that the publication exists

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -107,6 +107,9 @@ These changes are present in [unstable builds](/versions/#unstable-builds) and
 are slated for inclusion in the next stable release. There may be additional
 changes that have not yet been documented.
 
+- Detect if the publication slot is missing from the upstream database and
+  report an error when using PostgreSQL sources
+
 - **Breaking change.** When inferring a column name for a cast expression, fall
   back to choosing the name of the target type.
 

--- a/src/postgres-util/src/lib.rs
+++ b/src/postgres-util/src/lib.rs
@@ -212,6 +212,15 @@ pub async fn publication_info(
     let (client, connection) = config.connect(tls).await?;
     tokio::spawn(connection);
 
+    client
+        .query(
+            "SELECT oid FROM pg_publication WHERE pubname = $1",
+            &[&publication],
+        )
+        .await?
+        .get(0)
+        .ok_or_else(|| anyhow!("publication {:?} does not exist", publication))?;
+
     let tables = client
         .query(
             "SELECT

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -107,12 +107,10 @@ db error: FATAL: password authentication failed for user "postgres"
   PUBLICATION 'mz_source';
 db error: FATAL: database "no_such_dbname" does not exist
 
-> CREATE MATERIALIZED SOURCE "no_such_publication"
+! CREATE MATERIALIZED SOURCE "no_such_publication"
   FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
   PUBLICATION 'no_such_publication';
-# TODO: This should produce an error
-
-> DROP SOURCE "no_such_publication"
+publication "no_such_publication" does not exist
 
 > CREATE MATERIALIZED SOURCE "mz_source"
   FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'


### PR DESCRIPTION
### Motivation

Using the query right after the one added in this commit could still lead to a valid result if the publication name doesn't exist. It simply appeared as a publication that has no tables attached to it.

This query checks for the existence specifically and errors out if the publication is missing.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/9933)
<!-- Reviewable:end -->
