### PR TITLE
docs: Fix JSON notation in S3 example

### DIFF
--- a/doc/user/content/sql/create-source/json-s3.md
+++ b/doc/user/content/sql/create-source/json-s3.md
@@ -63,15 +63,15 @@ To access the data as JSON we can use standard JSON [functions](/sql/functions/#
 ```sql
 > CREATE MATERIALIZED VIEW json_example AS
   SELECT
-    jsonified.data->>user_id AS user_id,
-    jsonified.data->>disks_used AS disks_used,
-    jsonified.data->>cpu_used_minutes AS cpu_used_minutes
+    jsonified.data->>'user_id' AS user_id,
+    jsonified.data->>'disks_used' AS disks_used,
+    jsonified.data->>'cpu_used_minutes' AS cpu_used_minutes
   FROM (SELECT text::JSONB AS data FROM json_source) AS jsonified;
 ```
 
 This creates a source that...
 
-- Has three *double* columns (`user_id`, `disks_used`, and `cpu_used_minutes`)
+- Has three *string* columns (`user_id`, `disks_used`, and `cpu_used_minutes`)
 - Is immediately materialized, so will be cached in memory and is immediately queryable
 
 ## Related pages


### PR DESCRIPTION

### Motivation


  * This PR fixes a previously unreported bug.
    The [JSON example on the S3-JSON page](https://materialize.com/docs/sql/create-source/json-s3/#example) has two problems: (1) The JSON notation doesn't wrap JSON keys like `user_id` in single quotes. 
![image](https://user-images.githubusercontent.com/11527560/148574798-d7b95f78-1b6f-479c-b7fb-a7fdeaf33273.png) (2) The text after the example says the column types are DOUBLE, but they are STRING.
![image](https://user-images.githubusercontent.com/11527560/148575129-b0015d6d-fd0d-4999-b960-9369e72fb561.png)



    Bug was reported in [community slack here](https://materializecommunity.slack.com/archives/C015KDVS7EV/p1641566518063000)



<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/9936)
<!-- Reviewable:end -->
