### PR TITLE
expr: correctly union types for If exprs

### DIFF
--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -918,11 +918,7 @@ impl MirScalarExpr {
             MirScalarExpr::If { cond: _, then, els } => {
                 let then_type = then.typ(relation_type);
                 let else_type = els.typ(relation_type);
-                debug_assert!(then_type.scalar_type.base_eq(&else_type.scalar_type));
-                ColumnType {
-                    nullable: then_type.nullable || else_type.nullable,
-                    scalar_type: then_type.scalar_type,
-                }
+                then_type.union(&else_type).unwrap()
             }
         }
     }

--- a/test/sqllogictest/github-9931.slt
+++ b/test/sqllogictest/github-9931.slt
@@ -1,0 +1,25 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Regression test for https://github.com/MaterializeInc/materialize/issues/9931.
+
+mode cockroach
+
+query IIIT rowsort
+SELECT
+    t.*, CASE WHEN x IS NULL THEN NULL ELSE t.* END
+FROM
+    ROWS FROM (
+        generate_series(1, 2),
+        information_schema._pg_expandarray(ARRAY[100])
+    )
+        AS t
+----
+1  100  1  (1,100,1)
+2  NULL  NULL  NULL


### PR DESCRIPTION
Previously the debug_assert would trigger if the nullability of Record fields differed.

Fixes #9931

### Motivation

  * This PR fixes a recognized bug: #9931

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/9940)
<!-- Reviewable:end -->
