### PR TITLE
sql: support jsonb subscripting

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -107,6 +107,22 @@ These changes are present in [unstable builds](/versions/#unstable-builds) and
 are slated for inclusion in the next stable release. There may be additional
 changes that have not yet been documented.
 
+- **Breaking change.** When inferring a column name for a cast expression, fall
+  back to choosing the name of the target type.
+
+  Consider the following query:
+
+  ```sql
+  SELECT 'a'::text
+  ```
+
+  This version of Materialize will infer the column name `text`, while previous
+  versions of Materialize would fall back to the default column name `?column?`.
+
+- **Breaking change.** When inferring a column name for a [`bool`] or
+  [`interval`] literal, fall back to choosing `bool` or `interval`,
+  respectively.
+
 - **Breaking change.** Return an error when [`extract`](/sql/functions/extract/)
   is called with a [`time`] value but a date-related field (e.g., `YEAR`).
 

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -132,6 +132,18 @@ changes that have not yet been documented.
 - **Breaking change.** Disallow the string `'sNaN'` (in any casing) as a valid
   [`numeric`] value.
 
+- Support [subscripting `jsonb` values](/sql/types/jsonb/#subscripting) to
+  retrieve array elements or object values, as in:
+
+  ```sql
+  SELECT ('{"a": 1, "b": 2, "c": 3}'::jsonb)['b'];
+  ```
+  ```nofmt
+   jsonb
+  -------
+   2
+  ```
+
 - Add the `array_remove` and `list_remove` functions.
 
 - Allow `SET NAMES ____` special case as per: https://www.postgresql.org/docs/9.1/sql-set.html.

--- a/doc/user/content/sql/types/jsonb.md
+++ b/doc/user/content/sql/types/jsonb.md
@@ -120,6 +120,71 @@ You can explicitly [cast](../../functions/cast) from [`text`](../text) to `jsonb
      "\"foo\""
     ```
 
+### Subscripting
+
+{{< version-added v0.16.0 />}}
+
+You can use subscript notation (`[]`) to extract an element from a `jsonb` array
+or object.
+
+The returned value is always of type `jsonb`. If the requested array element or
+object key does not exist, or if either the input value or subscript value is
+`NULL`, the subscript operation returns `NULL`.
+
+#### Arrays
+
+To extract an element from an array, supply the 0-indexed position as the
+subscript:
+
+```sql
+SELECT ('[1, 2, 3]'::jsonb)[1]
+```
+```nofmt
+ jsonb
+-------
+ 2
+```
+
+Negative indexes count backwards from the end of the array. [Slice syntax] is
+not supported. Note also that 0-indexed positions are at variance with [`list`]
+and [`array`] types, whose subscripting operation uses 1-indexed positions.
+
+#### Objects
+
+To extract a value from an object, supply the key as the subscript:
+
+```sql
+SELECT ('{"a": 1, "b": 2, "c": 3}'::jsonb)['b'];
+```
+```nofmt
+ jsonb
+-------
+ 2
+```
+
+You can chain subscript operations to retrieve deeply nested elements:
+
+```sql
+SELECT ('{"1": 2, "a": ["b", "c"]}'::jsonb)['a'][1];
+```
+```nofmt
+ jsonb
+-------
+ "c"
+```
+
+#### Remarks
+
+Because the output type of the subscript operation is always `jsonb`, when
+comparing the output of a subscript to a string, you must supply a JSON string
+to compare against:
+
+```sql
+SELECT ('["a", "b"]::jsonb)[1] = '"b"'
+```
+
+Note the extra double quotes on the right-hand side of the comparison.
+
 ## Examples
 
 ### Operators
@@ -505,3 +570,7 @@ SELECT to_jsonb('hello');
 ```
 
 Note that the output is `jsonb`.
+
+[Slice syntax]: /sql/types/list#slicing-ranges
+[`list`]: /sql/types/list
+[`array`]: /sql/types/array

--- a/src/sql-parser/src/ast/defs/expr.rs
+++ b/src/sql-parser/src/ast/defs/expr.rs
@@ -176,7 +176,7 @@ pub enum Expr<T: AstInfo> {
     List(Vec<Expr<T>>),
     ListSubquery(Box<Query<T>>),
     /// `<expr>[<expr>]`
-    SubscriptIndex {
+    SubscriptScalar {
         expr: Box<Expr<T>>,
         subscript: Box<Expr<T>>,
     },
@@ -443,7 +443,7 @@ impl<T: AstInfo> AstDisplay for Expr<T> {
                 f.write_node(&s);
                 f.write_str(")");
             }
-            Expr::SubscriptIndex { expr, subscript } => {
+            Expr::SubscriptScalar { expr, subscript } => {
                 f.write_node(&expr);
                 f.write_str("[");
                 f.write_node(subscript);

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1116,7 +1116,7 @@ impl<'a> Parser<'a> {
             assert!(
                 positions.len() == 1 && positions[0].start.is_some() && positions[0].end.is_none(),
             );
-            Expr::SubscriptIndex {
+            Expr::SubscriptScalar {
                 expr: Box::new(expr),
                 subscript: Box::new(positions.remove(0).start.unwrap()),
             }

--- a/src/sql-parser/tests/testdata/scalar
+++ b/src/sql-parser/tests/testdata/scalar
@@ -337,7 +337,7 @@ List([List([Op { op: Bare("+"), expr1: Value(Number("1")), expr2: Some(Value(Num
 parse-scalar
 LIST[1,2,3][1]
 ----
-SubscriptIndex { expr: List([Value(Number("1")), Value(Number("2")), Value(Number("3"))]), subscript: Value(Number("1")) }
+SubscriptScalar { expr: List([Value(Number("1")), Value(Number("2")), Value(Number("3"))]), subscript: Value(Number("1")) }
 
 parse-scalar
 LIST[1,2,3][1:1]
@@ -362,7 +362,7 @@ SubscriptSlice { expr: List([List([Value(Number("1"))]), List([Value(Number("2")
 parse-scalar
 LIST[[1],[2],[3]][1:1, 1:1][1]
 ----
-SubscriptIndex { expr: SubscriptSlice { expr: List([List([Value(Number("1"))]), List([Value(Number("2"))]), List([Value(Number("3"))])]), positions: [SubscriptPosition { start: Some(Value(Number("1"))), end: Some(Value(Number("1"))) }, SubscriptPosition { start: Some(Value(Number("1"))), end: Some(Value(Number("1"))) }] }, subscript: Value(Number("1")) }
+SubscriptScalar { expr: SubscriptSlice { expr: List([List([Value(Number("1"))]), List([Value(Number("2"))]), List([Value(Number("3"))])]), positions: [SubscriptPosition { start: Some(Value(Number("1"))), end: Some(Value(Number("1"))) }, SubscriptPosition { start: Some(Value(Number("1"))), end: Some(Value(Number("1"))) }] }, subscript: Value(Number("1")) }
 
 parse-scalar
 LIST[[1],[2],[3]][1:1, 1:1, 1:1]
@@ -519,7 +519,7 @@ Nested(FieldAccess { expr: Nested(FieldAccess { expr: FieldAccess { expr: Nested
 parse-scalar
 (((x).a.b)[1].c)
 ----
-Nested(FieldAccess { expr: SubscriptIndex { expr: Nested(FieldAccess { expr: FieldAccess { expr: Nested(Identifier([Ident("x")])), field: Ident("a") }, field: Ident("b") }), subscript: Value(Number("1")) }, field: Ident("c") })
+Nested(FieldAccess { expr: SubscriptScalar { expr: Nested(FieldAccess { expr: FieldAccess { expr: Nested(Identifier([Ident("x")])), field: Ident("a") }, field: Ident("b") }), subscript: Value(Number("1")) }, field: Ident("c") })
 
 parse-scalar roundtrip
 (((x).a.b)[1].c)

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -355,13 +355,12 @@ impl CoercibleScalarExpr {
 
     pub fn cast_to(
         self,
-        op: &str,
         ecx: &ExprContext,
         ccx: CastContext,
         ty: &ScalarType,
     ) -> Result<HirScalarExpr, PlanError> {
         let expr = typeconv::plan_coerce(ecx, self, ty)?;
-        typeconv::plan_cast(op, ecx, ccx, expr, ty)
+        typeconv::plan_cast(ecx, ccx, expr, ty)
     }
 }
 

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -2777,7 +2777,7 @@ fn plan_expr_inner<'a>(
         .into()),
         Expr::FieldAccess { expr, field } => plan_field_access(ecx, expr, field),
         Expr::WildcardAccess(expr) => plan_expr(ecx, expr),
-        Expr::SubscriptIndex { expr, subscript } => plan_subscript_index(ecx, expr, subscript),
+        Expr::SubscriptScalar { expr, subscript } => plan_subscript_scalar(ecx, expr, subscript),
         Expr::SubscriptSlice { expr, positions } => plan_subscript_slice(ecx, expr, positions),
 
         // Subqueries.
@@ -2922,7 +2922,7 @@ fn plan_field_access(
     }
 }
 
-fn plan_subscript_index(
+fn plan_subscript_scalar(
     ecx: &ExprContext,
     expr: &Expr<Aug>,
     subscript: &Expr<Aug>,

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -313,7 +313,7 @@ pub fn purify(
                             for (i, column) in columns.iter().enumerate() {
                                 projection.push(SelectItem::Expr {
                                     expr: Expr::Cast {
-                                        expr: Box::new(Expr::SubscriptIndex {
+                                        expr: Box::new(Expr::SubscriptScalar {
                                             expr: Box::new(Expr::Identifier(vec![Ident::new(
                                                 "row_data",
                                             )])),

--- a/test/sqllogictest/boolean.slt
+++ b/test/sqllogictest/boolean.slt
@@ -69,6 +69,18 @@ SELECT 1 AND FALSE
 query error AND argument must have type boolean, not type integer
 SELECT FALSE AND 1
 
+query B colnames
+SELECT TRUE
+----
+bool
+true
+
+query B colnames
+SELECT FALSE
+----
+bool
+false
+
 query B
 SELECT NOT TRUE
 ----

--- a/test/sqllogictest/interval.slt
+++ b/test/sqllogictest/interval.slt
@@ -9,9 +9,10 @@
 
 mode cockroach
 
-query T
+query T colnames
 SELECT INTERVAL '1';
 ----
+interval
 00:00:01
 
 ## SQL Standard

--- a/test/sqllogictest/postgres/jsonb.slt
+++ b/test/sqllogictest/postgres/jsonb.slt
@@ -1,0 +1,185 @@
+# Copyright 1994, Regents of the University of California.
+# Copyright 1996-2019 PostgreSQL Global Development Group.
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# This file is derived from the regression test suite in PostgreSQL.
+# The original file was retrieved on January 7, 2021 from:
+#
+#     https://github.com/postgres/postgres/blob/5940ffb221316ab73e6fdc780dfe9a07d4221ebb/src/test/regress/expected/join.out
+#
+# The original source code is subject to the terms of the PostgreSQL
+# license, a copy of which can be found in the LICENSE file at the
+# root of this repository.
+
+mode cockroach
+
+# At the time of writing this file contains only PostgreSQL's subscript-related
+# jsonb tests, which constitute only a small fraction of the available jsonb
+# tests upstream.
+
+query T colnames
+select ('123'::jsonb)['a']
+----
+jsonb
+NULL
+
+query T colnames
+select ('123'::jsonb)[0]
+----
+jsonb
+NULL
+
+query T colnames
+select ('123'::jsonb)[NULL]
+----
+jsonb
+NULL
+
+query T colnames
+select ('{"a": 1}'::jsonb)['a']
+----
+jsonb
+1
+
+query T colnames
+select ('{"a": 1}'::jsonb)[0]
+----
+jsonb
+NULL
+
+query T colnames
+select ('{"a": 1}'::jsonb)['not_exist']
+----
+jsonb
+NULL
+
+query T colnames
+select ('{"a": 1}'::jsonb)[NULL]
+----
+jsonb
+NULL
+
+query T colnames
+select ('[1, "2", null]'::jsonb)['a']
+----
+jsonb
+NULL
+
+query T colnames
+select ('[1, "2", null]'::jsonb)[0]
+----
+jsonb
+1
+
+query T colnames
+select ('[1, "2", null]'::jsonb)['1']
+----
+jsonb
+"2"
+
+query error jsonb subscript type must be coercible to integer or text
+select ('[1, "2", null]'::jsonb)[1.0]
+
+query T colnames
+select ('[1, "2", null]'::jsonb)[2]
+----
+jsonb
+null
+
+query T colnames
+select ('[1, "2", null]'::jsonb)[3]
+----
+jsonb
+NULL
+
+query T colnames
+select ('[1, "2", null]'::jsonb)[-2]
+----
+jsonb
+"2"
+
+query T colnames
+select ('[1, "2", null]'::jsonb)[1]['a']
+----
+jsonb
+NULL
+
+query T colnames
+select ('[1, "2", null]'::jsonb)[1][0]
+----
+jsonb
+NULL
+
+query T colnames
+select ('{"a": 1, "b": "c", "d": [1, 2, 3]}'::jsonb)['b']
+----
+jsonb
+"c"
+
+query T colnames
+select ('{"a": 1, "b": "c", "d": [1, 2, 3]}'::jsonb)['d'];
+----
+jsonb
+[1,2,3]
+
+query T colnames
+select ('{"a": 1, "b": "c", "d": [1, 2, 3]}'::jsonb)['d'][1]
+----
+jsonb
+2
+
+query T colnames
+select ('{"a": 1, "b": "c", "d": [1, 2, 3]}'::jsonb)['d']['a'];
+----
+jsonb
+NULL
+
+query T colnames
+select ('{"a": {"a1": {"a2": "aaa"}}, "b": "bbb", "c": "ccc"}'::jsonb)['a']['a1']
+----
+jsonb
+{"a2":"aaa"}
+
+query T colnames
+select ('{"a": {"a1": {"a2": "aaa"}}, "b": "bbb", "c": "ccc"}'::jsonb)['a']['a1']['a2']
+----
+jsonb
+"aaa"
+
+query T colnames
+select ('{"a": {"a1": {"a2": "aaa"}}, "b": "bbb", "c": "ccc"}'::jsonb)['a']['a1']['a2']['a3']
+----
+jsonb
+NULL
+
+query T colnames
+select ('{"a": ["a1", {"b1": ["aaa", "bbb", "ccc"]}], "b": "bb"}'::jsonb)['a'][1]['b1']
+----
+jsonb
+["aaa","bbb","ccc"]
+
+query T colnames
+select ('{"a": ["a1", {"b1": ["aaa", "bbb", "ccc"]}], "b": "bb"}'::jsonb)['a'][1]['b1'][2]
+----
+jsonb
+"ccc"
+
+# slices are not supported
+query error jsonb subscript does not support slices
+select ('{"a": 1}'::jsonb)['a':'b']
+
+query error jsonb subscript does not support slices
+select ('[1, "2", null]'::jsonb)[1:2]
+
+query error jsonb subscript does not support slices
+select ('[1, "2", null]'::jsonb)[:2]
+
+query error jsonb subscript does not support slices
+select ('[1, "2", null]'::jsonb)[1:]

--- a/test/upgrade/create-in-any_version-interval-literals.td
+++ b/test/upgrade/create-in-any_version-interval-literals.td
@@ -11,18 +11,18 @@
 # Various INTERVAL literals
 #
 
-> CREATE MATERIALIZED VIEW postgres_interval1 AS SELECT '1 year 2 months 3.4 days 5 hours 6 minutes 7.8 seconds'::interval;
+> CREATE MATERIALIZED VIEW postgres_interval1 AS SELECT '1 year 2 months 3.4 days 5 hours 6 minutes 7.8 seconds'::interval AS interval;
 
-> CREATE MATERIALIZED VIEW postgres_interval2 AS SELECT '1y 2mon 3.4d 5h 6m 7.8s'::interval;
+> CREATE MATERIALIZED VIEW postgres_interval2 AS SELECT '1y 2mon 3.4d 5h 6m 7.8s'::interval AS interval;
 
-> CREATE MATERIALIZED VIEW interval_second AS SELECT INTERVAL '123' SECOND;
+> CREATE MATERIALIZED VIEW interval_second AS SELECT INTERVAL '123' SECOND AS interval;
 
-> CREATE MATERIALIZED VIEW interval_minute AS SELECT INTERVAL '123' MINUTE;
+> CREATE MATERIALIZED VIEW interval_minute AS SELECT INTERVAL '123' MINUTE AS interval;
 
-> CREATE MATERIALIZED VIEW interval_hour AS SELECT INTERVAL '123' HOUR;
+> CREATE MATERIALIZED VIEW interval_hour AS SELECT INTERVAL '123' HOUR AS interval;
 
-> CREATE MATERIALIZED VIEW interval_day AS SELECT INTERVAL '123' DAY;
+> CREATE MATERIALIZED VIEW interval_day AS SELECT INTERVAL '123' DAY AS interval;
 
-> CREATE MATERIALIZED VIEW interval_month AS SELECT INTERVAL '123' MONTH;
+> CREATE MATERIALIZED VIEW interval_month AS SELECT INTERVAL '123' MONTH AS interval;
 
-> CREATE MATERIALIZED VIEW interval_year AS SELECT INTERVAL '123' YEAR;
+> CREATE MATERIALIZED VIEW interval_year AS SELECT INTERVAL '123' YEAR AS interval;


### PR DESCRIPTION
Since v14, PostgreSQL permits subscripting jsonb datums, as in:
    
    SELECT ('{"1": 2, "a": ["b", "c"]}'::jsonb)['a'][1];
     jsonb
    -------
     "c"
    
This is a much more familiar syntax for users. So this commit adds support for the feature to Materialize.
    
Touches #9935.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

Go commit by commit.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/9941)
<!-- Reviewable:end -->
