### PR TITLE
feature-benchmark: Add to Nightly build

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -100,3 +100,29 @@
     - ./ci/plugins/mzcompose:
         composition: testdrive
         run: persistence-testdrive
+
+- id: feature-benchmark
+  label: "Feature benchmark against latest release"
+  timeout_in_minutes: 120
+  plugins:
+    - ./ci/plugins/mzcompose:
+        composition: feature-benchmark
+        run: feature-benchmark
+        args:
+          - --other-tag
+          - latest
+
+- id: feature-benchmark-persistence
+  label: "Feature benchmark against latest release with persistence"
+  timeout_in_minutes: 120
+  plugins:
+    - ./ci/plugins/mzcompose:
+        composition: feature-benchmark
+        run: feature-benchmark
+        args:
+          - --other-tag
+          - latest
+          - --this-options
+          - "--persistent-user-tables --persistent-kafka-upsert-source"
+          - --other-options
+          - "--persistent-user-tables --persistent-kafka-upsert-source"

--- a/doc/developer/feature-benchmark.md
+++ b/doc/developer/feature-benchmark.md
@@ -15,32 +15,32 @@ bin/pyactivate --dev
 To run all benchmarks:
 ```
 cd test/feature-benchmark
-OTHER_IMAGE=materialize/materialized:unstable ./mzcompose run feature-benchmark
+./mzcompose run feature-benchmark --other-tag unstable
 ```
 
 This is going to benchmark the current source against the `materialize/materialized:unstable` container from DockerHub.
 
-To run one benchmark or a subset:
+To run one benchmark or a named subset:
 
 ```
-FB_SCENARIO=FastPath ./mzcompose run feature-benchmark
+./mzcompose run feature-benchmark --root-scenario=FastPath
 ```
 
 To use specific Mz command-line options:
 
 ```
-THIS_OPTIONS="--workers 16" OTHER_OPTIONS="--workers 1" ./mzcompose run feature-benchmark
+ ./mzcompose run feature-benchmark --this-options "--workers 16" --other-options "--workers 1"
 ```
 
 To compare specific Mz versions:
 
 ```
-THIS_IMAGE=materialize/materialized:v1.2.3 OTHER_IMAGE=materialize/materialized:v2.3.4 ./mzcompose ...
+./mzcompose run feature-benchmark --this-tag v1.2.3 --other-tag v2.3.4 ...
 ```
 
 To compare specific Mz git revisions:
 ```
-THIS_IMAGE=materialize/materialized:unstable-42ad7432657d3e5c1a3492fa76985cd6b79fcab6 OTHER_IMAGE=... ./mzcompose ...
+./mzcompose run feature-benchmark --this-tag unstable-42ad7432657d3e5c1a3492fa76985cd6b79fcab6 ...
 ```
 
 # Output
@@ -218,13 +218,9 @@ The `bisect.sh` can be something along the following lines:
 ```
 #!/bin/bash
 THIS_SHA=$(git rev-parse HEAD)
-export THIS_IMAGE="materialize/materialized:unstable-$THIS_SHA"
-
 GOOD_MZ_VERSION="vX.Y.Z"
-export OTHER_IMAGE="materialize/materialized:$GOOD_MZ_VERSION"
 
-export FB_SCENARIO=...
 pushd /path/to/test/feature-benchmark
 ./mzcompose down -v
-./mzcompose run feature-benchmark
+./mzcompose run feature-benchmark --this-tag unstable-$THIS_SHA --other-tag $GOOD_MZ_VERSION --root-scenario=...
 ```

--- a/misc/python/materialize/feature_benchmark/benchmark.py
+++ b/misc/python/materialize/feature_benchmark/benchmark.py
@@ -43,12 +43,14 @@ class Benchmark:
         if self._mz_id == 0 and shared is not None:
             print(f"Running the SHARED section for {name} ...")
             shared.run(executor=self._executor, measure=False)
+            print("SHARED done")
 
         # Run the SHARED section once for each Mz
         init = self._scenario.INIT
         if init is not None:
             print(f"Running the INIT section for {name} ...")
             init.run(executor=self._executor, measure=False)
+            print("INIT done")
 
         before = self._scenario.BEFORE(executor=self._executor)
         benchmark = self._scenario.BENCHMARK(executor=self._executor)

--- a/misc/python/materialize/feature_benchmark/executor.py
+++ b/misc/python/materialize/feature_benchmark/executor.py
@@ -13,7 +13,6 @@ from tempfile import NamedTemporaryFile
 from typing import Any, Callable
 
 from materialize.mzcompose import Composition
-from materialize.mzcompose.services import Materialized, Testdrive
 
 
 class Executor:
@@ -52,18 +51,14 @@ class Docker(Executor):
     def __init__(
         self,
         composition: Composition,
-        mz_service: Materialized,
-        td_service: Testdrive,
         seed: int,
     ) -> None:
         self._composition = composition
-        self._mz_service = mz_service
-        self._td_service = td_service
         self._seed = seed
 
     def RestartMz(self) -> Any:
-        self._composition.kill(self._mz_service.name)
-        self._composition.up(self._mz_service.name)
+        self._composition.kill("materialized")
+        self._composition.up("materialized")
         return 0.0
 
     def Td(self, input: str) -> Any:
@@ -77,7 +72,7 @@ class Docker(Executor):
             td_file.flush()
             dirname, basename = os.path.split(td_file.name)
             return self._composition.run(
-                self._td_service.name,
+                "testdrive-svc",
                 "--no-reset",
                 f"--seed={self._seed}",
                 "--initial-backoff=0ms",

--- a/test/feature-benchmark/scenarios.py
+++ b/test/feature-benchmark/scenarios.py
@@ -571,11 +571,11 @@ true
     )
 
 
-class KafkaBenchmark(Scenario):
+class KafkaScenario(Scenario):
     pass
 
 
-class KafkaRaw(KafkaBenchmark):
+class KafkaRaw(KafkaScenario):
     SHARED = Td(
         """
 $ set count=1000000
@@ -617,7 +617,7 @@ true
     )
 
 
-class KafkaUpsert(KafkaBenchmark):
+class KafkaUpsert(KafkaScenario):
     SHARED = Td(
         """
 $ set count=1000000
@@ -664,7 +664,7 @@ $ kafka-ingest format=avro topic=kafka-upsert key-format=avro key-schema=${keysc
     )
 
 
-class KafkaUpsertUnique(KafkaBenchmark):
+class KafkaUpsertUnique(KafkaScenario):
     SHARED = Td(
         """
 $ set keyschema={"type": "record", "name": "Key", "fields": [ {"name": "f1", "type": "long"} ] }
@@ -692,7 +692,7 @@ $ kafka-ingest format=avro topic=upsert-unique key-format=avro key-schema=${keys
     )
 
 
-class KafkaRecovery(KafkaBenchmark):
+class KafkaRecovery(KafkaScenario):
     SHARED = Td(
         """
 $ set keyschema={


### PR DESCRIPTION
- refactor the code to use command-line arguments instead of env options
- since the command-line arguments are not available at startup, create
  the Mz instance to be benchmarked after the command-line arguments become
  known and use composition.override() to install it into the composition
- update documentation
- add a job to the nightly CI

### Motivation

  * This PR adds a feature that has not yet been specified.

The feature benchmarks appear to be at least somewhat ready to be run in CI, so I am jumping on the opportunity to add them now.

### Tips for reviewer

@benesch I had to make it so that `override` in `mzcompose.__init__.py` re-resolves any `mzimage` directives . For the purpose, I copy-and-pasted all the resolving code in a separate function, `_resolve_mzbuild_references()`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/9979)
<!-- Reviewable:end -->
