### PR TITLE
persist,sources: allow compaction on persisted sources

### DIFF
--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -170,6 +170,8 @@ pub struct StorageState {
     pub ts_histories: HashMap<GlobalId, TimestampBindingRc>,
     /// Metrics reported by all dataflows.
     pub metrics: Metrics,
+    /// Frontier up to which each source is allowed to compact its data.
+    pub allowed_compaction_frontiers: HashMap<GlobalId, Rc<RefCell<Antichain<Timestamp>>>>,
     /// Frontier of sink writes (all subsequent writes will be at times at or
     /// equal to this frontier)
     pub sink_write_frontiers: HashMap<GlobalId, Rc<RefCell<Antichain<Timestamp>>>>,

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -9,19 +9,23 @@
 
 //! Logic related to the creation of dataflow sources.
 
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 
+use serde::{Deserialize, Serialize};
+
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::{collection, AsCollection, Collection, Hashable};
-use serde::{Deserialize, Serialize};
 use timely::dataflow::operators::generic::operator;
 use timely::dataflow::operators::{Concat, Map, OkErr, UnorderedInput};
 use timely::dataflow::{Scope, Stream};
+use timely::progress::Antichain;
+use timely::progress::Timestamp as TimelyTimestamp;
 
 use persist::client::StreamWriteHandle;
 use persist::operators::source::PersistedSource;
-use persist::operators::stream::{AwaitFrontier, Seal};
+use persist::operators::stream::{AllowPersistCompaction, AwaitFrontier, Seal};
 use persist::operators::upsert::PersistentUpsertConfig;
 use persist_types::Codec;
 
@@ -40,6 +44,7 @@ use crate::logging::materialized::Logger;
 use crate::operator::{CollectionExt, StreamExt};
 use crate::render::envelope_none;
 use crate::render::envelope_none::PersistentEnvelopeNoneConfig;
+use crate::render::StorageState;
 use crate::server::LocalInput;
 use crate::source::metrics::SourceBaseMetrics;
 use crate::source::timestamp::{AssignedTimestamp, SourceTimestamp};
@@ -539,6 +544,8 @@ where
                                         upsert_state_handle,
                                         bindings_handle,
                                         &source_name,
+                                        &orig_id,
+                                        storage_state,
                                     );
 
                                     (sealed_upsert, upsert_err)
@@ -587,6 +594,8 @@ where
                                             envelope_config.write_handle.clone(),
                                             bindings_config.write_handle.clone(),
                                             &source_name,
+                                            &orig_id,
+                                            storage_state,
                                         );
 
                                         // NOTE: Persistence errors don't go through the same
@@ -866,6 +875,8 @@ fn seal_and_await<G, D1, D2, K1, V1, K2, V2>(
     write: StreamWriteHandle<K1, V1>,
     bindings_write: StreamWriteHandle<K2, V2>,
     source_name: &str,
+    source_id: &GlobalId,
+    render_state: &mut StorageState,
 ) -> Stream<G, (D1, Timestamp, Diff)>
 where
     G: Scope<Timestamp = Timestamp>,
@@ -876,8 +887,36 @@ where
     K2: Codec + timely::Data,
     V2: Codec + timely::Data,
 {
-    let sealed_stream =
-        stream.conditional_seal(&source_name, bindings_stream, write, bindings_write);
+    let sealed_stream = stream.conditional_seal(
+        &source_name,
+        bindings_stream,
+        write.clone(),
+        bindings_write.clone(),
+    );
+
+    let allowed_compaction_frontier = Rc::new(RefCell::new(Antichain::<Timestamp>::from_elem(
+        TimelyTimestamp::minimum(),
+    )));
+
+    render_state
+        .allowed_compaction_frontiers
+        .insert(source_id.clone(), Rc::clone(&allowed_compaction_frontier));
+
+    let sealed_stream = sealed_stream.allow_compaction(
+        format!("{}", source_name).as_str(),
+        write,
+        Rc::clone(&allowed_compaction_frontier),
+    );
+
+    // NOTE: It is *very* important to compact the bindings
+    // only as far as we compact the data. Otherwise, we might
+    // end up in a situation where we don't restore bindings
+    // because they are beyond the common seal timestamp.
+    let sealed_stream = sealed_stream.allow_compaction(
+        format!("{}-timestamp-bindings", source_name).as_str(),
+        bindings_write,
+        Rc::clone(&allowed_compaction_frontier),
+    );
 
     // Don't send data forward to "dataflow" until the frontier
     // tells us that we both persisted and sealed it.

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -898,9 +898,13 @@ where
         TimelyTimestamp::minimum(),
     )));
 
-    render_state
+    let previous = render_state
         .allowed_compaction_frontiers
         .insert(source_id.clone(), Rc::clone(&allowed_compaction_frontier));
+    assert!(
+        previous.is_none(),
+        "cannot have multiple instances of a persistent source"
+    );
 
     let sealed_stream = sealed_stream.allow_compaction(
         format!("{}", source_name).as_str(),

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -1026,6 +1026,10 @@ where
 
                 self.reported_frontiers.remove(&id);
                 self.reported_bindings_frontiers.remove(&id);
+
+                // TODO: This is not the right place to do it.
+                println!("Removing allowed compaction frontier for source {}", id);
+                self.storage_state.allowed_compaction_frontiers.remove(&id);
             }
         }
     }

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -144,6 +144,7 @@ pub fn serve(config: Config) -> Result<(Server, LocalClient), anyhow::Error> {
                 local_inputs: HashMap::new(),
                 ts_source_mapping: HashMap::new(),
                 ts_histories: HashMap::default(),
+                allowed_compaction_frontiers: HashMap::default(),
                 sink_write_frontiers: HashMap::new(),
                 metrics,
                 persist: None,
@@ -797,6 +798,15 @@ where
                         .allow_compaction(id, frontier.borrow());
                     if let Some(ts_history) = self.storage_state.ts_histories.get_mut(&id) {
                         ts_history.set_compaction_frontier(frontier.borrow());
+                    }
+
+                    if let Some(allowed_compaction_frontier) =
+                        self.storage_state.allowed_compaction_frontiers.get_mut(&id)
+                    {
+                        let mut allowed_compaction_frontier =
+                            allowed_compaction_frontier.borrow_mut();
+                        allowed_compaction_frontier.clear();
+                        allowed_compaction_frontier.extend(frontier);
                     }
                 }
             }


### PR DESCRIPTION
The idea behind this is:
 - keep track of what compaction the coordinator allows in `RenderState`
 - received `AllowCompaction` commands update that compaction frontier
 - pass a `Rc<RefCell<>>>` to that frontier to an operator that also
   looks at its input frontier and allows compaction to the combination
   (aka "minimum") of those two

An alternative solution would be to invoke `allow_compaction()` upon
receipt of the `AllowCompaction` message. This would, however, require
to keep the involved persistence write handles in `RenderState`, and the
number and type of those handles will likely be different for different
combinations of physical source (think Kafka etc.) and envelopes.

With the chosen solution we only need to update the allowed frontier
centrally and the rendering code that then allows compaction can be
tailored to the rendered source.

Fixes #9508

### Tips/Notes for reviewer

I didn't yet add tests, but I wanted to get the basic idea out for review. If you agree, I'd add unit tests.

Also, merging this PR by itself would be incorrect, because we currently don't consider the since when restarting sources. This would surface when merging this PR together with https://github.com/MaterializeInc/materialize/pull/9659, which adds a check that persistence can serve the required `as_of`/`since`. The solution for this is https://github.com/MaterializeInc/materialize/pull/9656, which calculates an `as_of`/`since` when (re-)starting.

### Checklist

I would add unit tests, and trust the combination of this PR plus the aforementioned PRs that add `as_of` checks together with Philip's persistence tests to cover this change.

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/9981)
<!-- Reviewable:end -->
