### PR TITLE
[timely async operator] fuse logic future

### DIFF
--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -10,4 +10,4 @@ futures-util = "0.3.19"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false }
 
 [dev-dependencies]
-tokio = { version = "1.15.0", features = ["macros", "time"] }
+tokio = { version = "1.15.0", features = ["macros", "rt-multi-thread", "time"] }


### PR DESCRIPTION
Fix #9909 .  If the logic future completes and the async operator is invoked again, return without doing work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/9982)
<!-- Reviewable:end -->
