### PR TITLE
sql: iterate on flaky test_tail_table_rw_timestamps

### DIFF
--- a/src/materialized/tests/sql.rs
+++ b/src/materialized/tests/sql.rs
@@ -812,9 +812,12 @@ fn test_tail_table_rw_timestamps() -> Result<(), Box<dyn Error>> {
     let verify_rw_pair = move |rows: &[Row], expected_data: &str| -> bool {
         for (i, row) in rows.iter().enumerate() {
             match row.get::<_, Option<String>>("data") {
-                // Ensure all rows with data have the expected data, and that rows
-                // without data are only ever the last row.
-                Some(inner) => assert_eq!(inner, expected_data.to_owned()),
+                // Only verify if all rows have expected data
+                Some(inner) => {
+                    if &inner != expected_data {
+                        return false;
+                    }
+                }
                 // Only verify if row without data is last row
                 None => {
                     if i + 1 != rows.len() {


### PR DESCRIPTION
Previously, this test was flaky because tail might have held back
returning data until it had seen all of the inserts, which would
cause a panic when encountering the second inserted values.

Now, we simply loop until we get lucky enough to see data in the
order we expect.

### Motivation

This PR refactors existing code, a flaky test.

### Tips for reviewer

@aljoscha Could you help me figure out which sets of invariants I can/should be testing w/ `TAIL` to determine when we bump timestamps forward? Going to merge this to see if it stops flaking as intensely, but it seems that I'm very unfamiliar with `TAIL`'s potential output to get this test in a place where it's reliable.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/9989)
<!-- Reviewable:end -->
