### PR TITLE
log::macros! -> tracing::macros!

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2457,6 +2457,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
  "url",
 ]
 
@@ -4484,6 +4485,7 @@ dependencies = [
  "globset",
  "interchange",
  "itertools",
+ "kafka-util",
  "lazy_static",
  "lowertest",
  "mz-avro",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,7 +619,6 @@ dependencies = [
  "futures",
  "futures-channel",
  "hex",
- "log",
  "mz-protoc",
  "ore",
  "postgres-types",
@@ -629,6 +628,7 @@ dependencies = [
  "test-util",
  "tokio",
  "tokio-postgres",
+ "tracing",
  "uuid",
 ]
 
@@ -922,6 +922,7 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tokio-stream",
+ "tracing",
  "transform",
  "uncased",
  "url",
@@ -1244,6 +1245,7 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tokio-util",
+ "tracing",
  "url",
  "uuid",
 ]
@@ -1276,7 +1278,6 @@ dependencies = [
  "http",
  "interchange",
  "kafka-util",
- "log",
  "mz-aws-util",
  "num_enum",
  "ore",
@@ -1289,6 +1290,7 @@ dependencies = [
  "serde_regex",
  "timely",
  "tokio",
+ "tracing",
  "url",
  "uuid",
 ]
@@ -1303,12 +1305,12 @@ dependencies = [
  "dataflow",
  "dataflow-types",
  "futures",
- "log",
  "ore",
  "timely",
  "tokio",
  "tokio-serde",
  "tokio-util",
+ "tracing",
  "tracing-subscriber",
 ]
 
@@ -2354,7 +2356,6 @@ dependencies = [
  "hex",
  "itertools",
  "lazy_static",
- "log",
  "mz-avro",
  "mz-protoc",
  "num-traits",
@@ -2371,6 +2372,7 @@ dependencies = [
  "tempfile",
  "timely",
  "tokio",
+ "tracing",
  "url",
  "uuid",
 ]
@@ -2626,7 +2628,6 @@ dependencies = [
  "krb5-src",
  "lazy_static",
  "libc",
- "log",
  "mz-http-proxy",
  "mz-process-collector",
  "nix",
@@ -2747,11 +2748,11 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "itertools",
- "log",
  "metabase",
  "ore",
  "tokio",
  "tokio-postgres",
+ "tracing",
 ]
 
 [[package]]
@@ -2820,7 +2821,6 @@ dependencies = [
  "flate2",
  "itertools",
  "lazy_static",
- "log",
  "md-5",
  "rand",
  "regex",
@@ -2828,6 +2828,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "snap",
+ "tracing",
  "uuid",
 ]
 
@@ -2858,8 +2859,8 @@ dependencies = [
  "hyper-tls",
  "ipnet",
  "lazy_static",
- "log",
  "reqwest",
+ "tracing",
 ]
 
 [[package]]
@@ -3316,13 +3317,13 @@ dependencies = [
  "env_logger",
  "futures",
  "futures-channel",
- "log",
  "mz-aws-util",
  "ore",
  "rand",
  "test-util",
  "tokio",
  "tokio-postgres",
+ "tracing",
 ]
 
 [[package]]
@@ -3344,7 +3345,6 @@ dependencies = [
  "futures-executor",
  "futures-util",
  "lazy_static",
- "log",
  "md-5",
  "mz-aws-util",
  "mz-protoc",
@@ -3359,6 +3359,7 @@ dependencies = [
  "tempfile",
  "timely",
  "tokio",
+ "tracing",
  "uuid",
 ]
 
@@ -3412,7 +3413,6 @@ dependencies = [
  "futures",
  "itertools",
  "lazy_static",
- "log",
  "openssl",
  "ordered-float",
  "ore",
@@ -3424,6 +3424,7 @@ dependencies = [
  "tokio-openssl",
  "tokio-stream",
  "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -4484,7 +4485,6 @@ dependencies = [
  "interchange",
  "itertools",
  "lazy_static",
- "log",
  "lowertest",
  "mz-avro",
  "mz-aws-util",
@@ -4505,6 +4505,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-postgres",
+ "tracing",
  "uncased",
  "url",
  "uuid",
@@ -4520,10 +4521,10 @@ dependencies = [
  "hex",
  "itertools",
  "lazy_static",
- "log",
  "ore",
  "phf",
  "phf_codegen",
+ "tracing",
  "uncased",
  "unicode-width",
  "walkabout",
@@ -4739,12 +4740,12 @@ dependencies = [
  "anyhow",
  "chrono",
  "kafka-util",
- "log",
  "ore",
  "rand",
  "rdkafka",
  "tokio",
  "tokio-postgres",
+ "tracing",
 ]
 
 [[package]]

--- a/demo/billing/Cargo.toml
+++ b/demo/billing/Cargo.toml
@@ -15,7 +15,7 @@ env_logger = "0.9.0"
 futures = "0.3.19"
 futures-channel = "0.3.16"
 hex = "0.4.3"
-log = "0.4.13"
+tracing = "0.1.29"
 ore = { path = "../../src/ore" }
 postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres", branch = "mz-0.7.2" }
 protobuf = { git = "https://github.com/MaterializeInc/rust-protobuf.git" }

--- a/demo/billing/src/mz.rs
+++ b/demo/billing/src/mz.rs
@@ -45,7 +45,7 @@ pub async fn create_proto_source(
         message = message_name,
     );
 
-    log::debug!("creating source=> {}", query);
+    tracing::debug!("creating source=> {}", query);
 
     mz_client::execute(&mz_client, &query).await?;
     Ok(())
@@ -67,7 +67,7 @@ pub async fn create_kafka_sink(
              schema_registry = schema_registry_url
          );
 
-    log::debug!("creating sink=> {}", query);
+    tracing::debug!("creating sink=> {}", query);
     mz_client::execute(&mz_client, &query).await?;
 
     // Get the topic for the newly-created sink.
@@ -120,7 +120,7 @@ pub async fn create_csv_source(
         file = absolute_path.display(),
     );
 
-    log::debug!("creating csv source=> {}", query);
+    tracing::debug!("creating csv source=> {}", query);
     mz_client::execute(&mz_client, &query).await?;
     Ok(())
 }
@@ -139,7 +139,7 @@ pub async fn reingest_sink(
                     topic_name = topic_name,
                     schema_registry = schema_registry_url);
 
-    log::debug!("creating materialized source to reingest sink=> {}", query);
+    tracing::debug!("creating materialized source to reingest sink=> {}", query);
     mz_client::execute(&mz_client, &query).await?;
 
     Ok(())
@@ -182,7 +182,7 @@ pub async fn validate_sink(
         .await?;
 
     let query = format!("SELECT * FROM {}", invalid_rows_view);
-    log::debug!("validating sinks=> {}", query);
+    tracing::debug!("validating sinks=> {}", query);
     let rows = mz_client.query(&*query, &[]).await?;
 
     if rows.len() != 0 {

--- a/src/avro/Cargo.toml
+++ b/src/avro/Cargo.toml
@@ -20,7 +20,7 @@ digest = "0.10.0"
 enum-kinds = "0.5.1"
 flate2 = "1.0.22"
 itertools = "0.10.3"
-log = "0.4.13"
+tracing = "0.1.29"
 rand = "0.8.4"
 regex = "1.5.4"
 serde = { version = "1.0.133", features = ["derive"] }

--- a/src/avro/src/schema.rs
+++ b/src/avro/src/schema.rs
@@ -33,13 +33,13 @@ use std::str::FromStr;
 
 use digest::Digest;
 use itertools::Itertools;
-use log::{debug, warn};
 use regex::Regex;
 use serde::{
     ser::{SerializeMap, SerializeSeq},
     Serialize, Serializer,
 };
 use serde_json::{self, Map, Value};
+use tracing::{debug, warn};
 use types::{DecimalValue, Value as AvroValue};
 
 use crate::error::Error as AvroError;

--- a/src/ccsr/Cargo.toml
+++ b/src/ccsr/Cargo.toml
@@ -21,4 +21,4 @@ hyper = { version = "0.14.16", features = ["server"] }
 lazy_static = "1.4.0"
 serde_json = "1.0.74"
 tokio = { version = "1.15.0", features = ["macros"] }
-tracing = { version = "0.1.29", features = ["log"] }
+tracing = "0.1.29"

--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -26,6 +26,7 @@ itertools = "0.10.3"
 kafka-util = { path = "../kafka-util" }
 lazy_static = "1.4.0"
 log = "0.4.13"
+tracing = "0.1.29"
 mz-avro = { path = "../avro", features = ["snappy"] }
 mz-aws-util = { path = "../aws-util" }
 mz-protoc = { path = "../protoc" }

--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -22,7 +22,6 @@ use dataflow_types::{
 use expr::{Id, PartitionId};
 use itertools::Itertools;
 use lazy_static::lazy_static;
-use log::{info, trace};
 use ore::collections::CollectionExt;
 use ore::metrics::MetricsRegistry;
 use ore::now::{to_datetime, EpochMillis, NowFn};
@@ -30,6 +29,7 @@ use persist::indexed::runtime::MultiWriteHandle;
 use regex::Regex;
 use repr::Timestamp;
 use serde::{Deserialize, Serialize};
+use tracing::{info, trace};
 
 use build_info::DUMMY_BUILD_INFO;
 use dataflow_types::{SinkConnector, SinkConnectorBuilder, SourceConnector, Timeline};

--- a/src/coord/src/catalog/migrate.rs
+++ b/src/coord/src/catalog/migrate.rs
@@ -636,7 +636,7 @@ fn ast_rewrite_csv_column_aliases_0_9_2(
     // they match then everything will work out. If they don't match, then at least there isn't
     // a catalog corruption error.
     if let Err(e) = result {
-        log::warn!(
+        tracing::warn!(
             "Error retrieving column names from file ({}) \
                  using previously defined column aliases",
             e

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -779,7 +779,7 @@ where
                     // EDIT: On further consideration, I think it doesn't
                     // affect correctness if this fails, just availability
                     // of the table.
-                    log::error!(
+                    tracing::error!(
                         "failed to seal persisted stream to ts {}: {}",
                         advance_to,
                         err
@@ -1479,7 +1479,7 @@ where
             let persist_multi = match self.catalog.persist_multi_details() {
                 Some(multi) => multi,
                 None => {
-                    log::error!("internal error: persist_multi_details invariant violated");
+                    tracing::error!("internal error: persist_multi_details invariant violated");
                     return;
                 }
             };
@@ -1490,7 +1490,7 @@ where
             let _ = tokio::spawn(async move {
                 if let Err(err) = compaction_fut.await {
                     // TODO: Do something smarter here
-                    log::error!("failed to compact persisted tables: {}", err);
+                    tracing::error!("failed to compact persisted tables: {}", err);
                 }
             });
         }

--- a/src/coord/src/coord/antichain.rs
+++ b/src/coord/src/coord/antichain.rs
@@ -67,7 +67,7 @@ impl<T: PartialOrder + Ord + Clone + std::fmt::Debug> AntichainToken<T> {
         new_frontier.extend(frontier.into_iter());
 
         if !<_ as PartialOrder>::less_equal(&self.antichain.frontier(), &new_frontier.borrow()) {
-            log::trace!(
+            tracing::trace!(
                 "Ignoring request to 'advance' to {:?} current antichain {:?}",
                 new_frontier,
                 self.antichain

--- a/src/coord/src/sink_connector.rs
+++ b/src/coord/src/sink_connector.rs
@@ -15,10 +15,10 @@ use anyhow::{anyhow, bail, Context};
 use interchange::avro::get_debezium_transaction_schema;
 use mz_avro::types::Value;
 use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, ResourceSpecifier, TopicReplication};
-use rdkafka::client::DefaultClientContext;
 use rdkafka::config::ClientConfig;
 use rdkafka::{Message, Offset, TopicPartitionList};
 
+use ::kafka_util::client::MzClientContext;
 use dataflow_types::{
     AvroOcfSinkConnector, AvroOcfSinkConnectorBuilder, KafkaSinkConnector,
     KafkaSinkConnectorBuilder, KafkaSinkConnectorRetention, KafkaSinkConsistencyConnector,
@@ -192,7 +192,7 @@ fn maybe_decode_consistency_end_record(
 }
 
 async fn register_kafka_topic(
-    client: &AdminClient<DefaultClientContext>,
+    client: &AdminClient<MzClientContext>,
     topic: &str,
     mut partition_count: i32,
     mut replication_factor: i32,
@@ -383,8 +383,9 @@ async fn build_kafka(
             config.set(k, v);
         }
     }
-    let client = config
-        .create::<AdminClient<_>>()
+
+    let client: AdminClient<_> = config
+        .create_with_context(MzClientContext)
         .context("creating admin client failed")?;
 
     register_kafka_topic(

--- a/src/coord/src/sink_connector.rs
+++ b/src/coord/src/sink_connector.rs
@@ -146,7 +146,7 @@ fn get_latest_ts(
     // Topic not empty but we couldn't read any messages.  We don't expect this to happen but we
     // have no reason to rely on kafka not inserting any internal messages at the beginning.
     if latest_offset.is_none() {
-        log::debug!(
+        tracing::debug!(
             "unable to read any messages from non-empty topic {}:{}, lo/hi: {}/{}",
             consistency_topic,
             partition,

--- a/src/coord/src/timestamp.rs
+++ b/src/coord/src/timestamp.rs
@@ -21,7 +21,6 @@ use std::time::Duration;
 use anyhow::{bail, Context};
 use itertools::Itertools;
 use lazy_static::lazy_static;
-use log::{debug, error, info, log_enabled, warn};
 use mz_avro::schema::Schema;
 use mz_avro::types::Value;
 use ore::metric;
@@ -31,6 +30,7 @@ use rdkafka::message::BorrowedMessage;
 use rdkafka::message::Message;
 use rdkafka::ClientConfig;
 use tokio::sync::mpsc;
+use tracing::{debug, error, info, warn};
 
 use dataflow_types::{
     Consistency, DataEncoding, DebeziumMode, ExternalSourceConnector, FileSourceConnector,
@@ -568,7 +568,10 @@ impl Timestamper {
                     {
                         (connector, encoding, envelope, consistency)
                     } else {
-                        log::debug!("Local source {} cannot be timestamped. Ignoring", source_id);
+                        tracing::debug!(
+                            "Local source {} cannot be timestamped. Ignoring",
+                            source_id
+                        );
                         continue;
                     };
 
@@ -723,7 +726,7 @@ impl Timestamper {
         let mut config = ClientConfig::new();
         config.set("bootstrap.servers", &kc.addrs.to_string());
 
-        if log_enabled!(target: "librdkafka", log::Level::Debug) {
+        if log::log_enabled!(target: "librdkafka", log::Level::Debug) {
             config.set("debug", "all");
         }
 

--- a/src/coord/src/timestamp.rs
+++ b/src/coord/src/timestamp.rs
@@ -726,6 +726,7 @@ impl Timestamper {
         let mut config = ClientConfig::new();
         config.set("bootstrap.servers", &kc.addrs.to_string());
 
+        // TODO(guswynn): replace this when https://github.com/tokio-rs/tracing/pull/1821 is merged
         if log::log_enabled!(target: "librdkafka", log::Level::Debug) {
             config.set("debug", "all");
         }

--- a/src/coord/src/timestamp.rs
+++ b/src/coord/src/timestamp.rs
@@ -38,6 +38,7 @@ use dataflow_types::{
     SourceEnvelope, TimestampSourceUpdate,
 };
 use expr::{GlobalId, PartitionId};
+use kafka_util::client::MzClientContext;
 use ore::collections::CollectionExt;
 
 use crate::coord;
@@ -161,7 +162,7 @@ struct TimestampingState {
 
 /// Data consumer for Kafka source with BYO consistency
 struct ByoKafkaConnector {
-    consumer: BaseConsumer,
+    consumer: BaseConsumer<MzClientContext>,
 
     /// Offset of the last consistency record we received and processed. We use
     /// this to filter out messages that we have seen already.
@@ -174,7 +175,7 @@ struct ByoKafkaConnector {
 }
 
 impl ByoKafkaConnector {
-    fn new(consumer: BaseConsumer) -> ByoKafkaConnector {
+    fn new(consumer: BaseConsumer<MzClientContext>) -> ByoKafkaConnector {
         ByoKafkaConnector {
             consumer,
             last_offset: None,
@@ -229,7 +230,7 @@ fn byo_query_source(
 
 /// Polls a message from a Kafka Source
 fn kafka_get_next_message(
-    consumer: &mut BaseConsumer,
+    consumer: &mut BaseConsumer<MzClientContext>,
 ) -> Result<Option<BorrowedMessage>, anyhow::Error> {
     if let Some(result) = consumer.poll(Duration::from_millis(60)) {
         match result {
@@ -246,7 +247,7 @@ fn kafka_get_next_message(
 
 /// Return the list of partition ids associated with a specific topic
 fn get_kafka_partitions(
-    consumer: &BaseConsumer,
+    consumer: &BaseConsumer<MzClientContext>,
     topic: &str,
     timeout: Duration,
 ) -> Result<Vec<i32>, anyhow::Error> {
@@ -737,13 +738,14 @@ impl Timestamper {
             }
         }
 
-        let consumer = match config.create::<BaseConsumer>() {
-            Ok(consumer) => consumer,
-            Err(e) => {
-                error!("Failed to create Kafka Consumer {}", e);
-                return None;
-            }
-        };
+        let consumer =
+            match config.create_with_context::<_, BaseConsumer<MzClientContext>>(MzClientContext) {
+                Ok(consumer) => consumer,
+                Err(e) => {
+                    error!("Failed to create Kafka Consumer {}", e);
+                    return None;
+                }
+            };
 
         let connector = RtKafkaConnector {
             coordination_state: Arc::new(TimestampingState {
@@ -873,7 +875,7 @@ impl Timestamper {
             }
         }
 
-        match config.create() {
+        match config.create_with_context(MzClientContext) {
             Ok(consumer) => {
                 let consumer = ByoKafkaConnector::new(consumer);
                 consumer.consumer.subscribe(&[&timestamp_topic]).unwrap();
@@ -921,7 +923,7 @@ impl Timestamper {
 
 fn rt_kafka_metadata_fetch_loop(
     c: RtKafkaConnector,
-    consumer: BaseConsumer,
+    consumer: BaseConsumer<MzClientContext>,
     wait: Duration,
     metrics: &Metrics,
 ) {

--- a/src/coord/src/timestamp.rs
+++ b/src/coord/src/timestamp.rs
@@ -729,6 +729,7 @@ impl Timestamper {
 
         // TODO(guswynn): replace this when https://github.com/tokio-rs/tracing/pull/1821 is merged
         if log::log_enabled!(target: "librdkafka", log::Level::Debug) {
+            debug!("Enabling 'debug' for rdkafka");
             config.set("debug", "all");
         }
 

--- a/src/dataflow-types/Cargo.toml
+++ b/src/dataflow-types/Cargo.toml
@@ -22,7 +22,7 @@ interchange = { path = "../interchange" }
 persist-types = { path = "../persist-types" }
 kafka-util = { path = "../kafka-util" }
 http = "0.2.6"
-log = "0.4.13"
+tracing = "0.1.29"
 num_enum = "0.5.6"
 mz-aws-util = { path = "../aws-util" }
 ore = { path = "../ore" }

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -407,12 +407,12 @@ impl LocalClient {
 #[async_trait::async_trait]
 impl Client for LocalClient {
     async fn send(&mut self, cmd: Command) {
-        log::trace!("SEND dataflow command: {:?}", cmd);
+        tracing::trace!("SEND dataflow command: {:?}", cmd);
         self.client.send(cmd).await
     }
     async fn recv(&mut self) -> Option<Response> {
         let response = self.client.recv().await;
-        log::trace!("RECV dataflow response: {:?}", response);
+        tracing::trace!("RECV dataflow response: {:?}", response);
         response
     }
 }
@@ -520,7 +520,7 @@ pub mod partitioned {
             for id in cease.into_iter() {
                 let previous = self.uppers.remove(&id);
                 if previous.is_none() {
-                    log::debug!("Protocol error: ceasing frontier tracking for absent identifier {:?} due to command {:?}", id, command);
+                    tracing::debug!("Protocol error: ceasing frontier tracking for absent identifier {:?} due to command {:?}", id, command);
                 }
             }
         }

--- a/src/dataflow/Cargo.toml
+++ b/src/dataflow/Cargo.toml
@@ -33,6 +33,7 @@ itertools = "0.10.3"
 kafka-util = { path = "../kafka-util" }
 lazy_static = "1.4.0"
 log = "0.4.13"
+tracing = "0.1.29"
 mz-avro = { path = "../avro", features = ["snappy"] }
 mz-aws-util = { path = "../aws-util", features = ["kinesis", "s3", "sqs"] }
 ore = { path = "../ore" }

--- a/src/dataflow/src/decode/mod.rs
+++ b/src/dataflow/src/decode/mod.rs
@@ -32,9 +32,9 @@ use dataflow_types::{
     KeyEnvelope, LinearOperator, RegexEncoding, SourceEnvelope,
 };
 use interchange::avro::ConfluentAvroResolver;
-use log::error;
 use repr::Datum;
 use repr::{Diff, Row, Timestamp};
+use tracing::error;
 
 use self::avro::AvroDecoderState;
 use self::csv::CsvDecoderState;

--- a/src/dataflow/src/logging/materialized.rs
+++ b/src/dataflow/src/logging/materialized.rs
@@ -15,11 +15,11 @@ use differential_dataflow::collection::AsCollection;
 use differential_dataflow::operators::arrange::arrangement::Arrange;
 use differential_dataflow::operators::count::CountTotal;
 use differential_dataflow::operators::Count;
-use log::error;
 use timely::communication::Allocate;
 use timely::dataflow::operators::capture::EventLink;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use timely::logging::WorkerIdentifier;
+use tracing::error;
 
 use super::{LogVariant, MaterializedLog};
 use crate::activator::RcActivator;

--- a/src/dataflow/src/render/reduce.rs
+++ b/src/dataflow/src/render/reduce.rs
@@ -563,7 +563,7 @@ where
                 // XXX: This reports user data, which we perhaps should not do!
                 for (val, cnt) in source.iter() {
                     if cnt < &0 {
-                        log::error!("[customer-data] Negative accumulation in ReduceMinsMaxes: {:?} with count {:?}", val, cnt);
+                        tracing::error!("[customer-data] Negative accumulation in ReduceMinsMaxes: {:?} with count {:?}", val, cnt);
                     }
                 }
             } else {

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -695,7 +695,7 @@ fn get_persist_config(
     let bindings_seal_ts = persist_desc.timestamp_bindings_stream.upper_seal_ts;
     let data_seal_ts = persist_desc.primary_stream.upper_seal_ts;
 
-    log::debug!(
+    tracing::debug!(
             "Persistent collections for source {}: {:?} and {:?}. Upper seal timestamps: (bindings: {}, data: {}).",
             source_id,
             persist_desc.primary_stream.name,

--- a/src/dataflow/src/render/upsert.rs
+++ b/src/dataflow/src/render/upsert.rs
@@ -331,7 +331,7 @@ where
                         let mut time = cap.time().clone();
                         time.advance_by(as_of_frontier.borrow());
                         if key.is_none() {
-                            error!("Encountered empty key for value {:?}", new_value);
+                            error!(?new_value, "Encountered empty key for value");
                             continue;
                         }
 

--- a/src/dataflow/src/render/upsert.rs
+++ b/src/dataflow/src/render/upsert.rs
@@ -21,10 +21,10 @@ use timely::progress::Antichain;
 
 use dataflow_types::{DataflowError, DecodeError, LinearOperator, SourceError, SourceErrorDetails};
 use expr::{EvalError, MirScalarExpr};
-use log::error;
 use ore::result::ResultExt;
 use persist::operators::upsert::{PersistentUpsert, PersistentUpsertConfig};
 use repr::{Datum, Diff, Row, RowArena, Timestamp};
+use tracing::error;
 
 use crate::operator::StreamExt;
 use crate::source::{DecodeResult, SourceData};

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -877,28 +877,28 @@ where
                             Some(rt_default)
                         }
                         (ExternalSourceConnector::Kinesis(_), Consistency::BringYourOwn(_)) => {
-                            log::error!("BYO timestamping not supported for Kinesis sources");
+                            tracing::error!("BYO timestamping not supported for Kinesis sources");
                             None
                         }
                         (ExternalSourceConnector::S3(_), Consistency::BringYourOwn(_)) => {
-                            log::error!("BYO timestamping not supported for S3 sources");
+                            tracing::error!("BYO timestamping not supported for S3 sources");
                             None
                         }
                         (ExternalSourceConnector::Postgres(_), _) => {
-                            log::debug!(
+                            tracing::debug!(
                                 "Postgres sources do not communicate with the timestamper thread"
                             );
                             None
                         }
                         (ExternalSourceConnector::PubNub(_), _) => {
-                            log::debug!(
+                            tracing::debug!(
                                 "PubNub sources do not communicate with the timestamper thread"
                             );
                             None
                         }
                     }
                 } else {
-                    log::debug!(
+                    tracing::debug!(
                         "Timestamping not supported for local sources {}. Ignoring",
                         id
                     );
@@ -983,12 +983,12 @@ where
                 let prev = self.render_state.ts_histories.remove(&id);
 
                 if prev.is_none() {
-                    log::debug!("Attempted to drop timestamping for source {} that was not previously known", id);
+                    tracing::debug!("Attempted to drop timestamping for source {} that was not previously known", id);
                 }
 
                 let prev = self.render_state.ts_source_mapping.remove(&id);
                 if prev.is_none() {
-                    log::debug!("Attempted to drop timestamping for source {} not previously mapped to any instances", id);
+                    tracing::debug!("Attempted to drop timestamping for source {} not previously mapped to any instances", id);
                 }
 
                 self.reported_frontiers.remove(&id);

--- a/src/dataflow/src/sink/avro_ocf.rs
+++ b/src/dataflow/src/sink/avro_ocf.rs
@@ -13,10 +13,10 @@ use std::fs::OpenOptions;
 use differential_dataflow::{Collection, Hashable};
 
 use itertools::repeat_n;
-use log::error;
 use timely::dataflow::channels::pact::Exchange;
 use timely::dataflow::operators::generic::Operator;
 use timely::dataflow::Scope;
+use tracing::error;
 
 use dataflow_types::{AvroOcfSinkConnector, SinkDesc};
 use expr::GlobalId;

--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -211,7 +211,8 @@ impl SinkProducerContext {
 }
 
 impl ClientContext for SinkProducerContext {
-    // rdkafka's ClientContext is a bit weird, so we are forced to forward here awkwardly
+    // The shape of the rdkafka *Context traits require us to forward to the `MzClientContext`
+    // implementation.
     fn log(&self, level: rdkafka::config::RDKafkaLogLevel, fac: &str, log_message: &str) {
         MzClientContext.log(level, fac, log_message)
     }

--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -43,6 +43,7 @@ use dataflow_types::{
 use expr::GlobalId;
 use interchange::avro::{self, AvroEncoder, AvroSchemaGenerator};
 use interchange::encode::Encode;
+use kafka_util::client::MzClientContext;
 use ore::cast::CastFrom;
 use repr::{Datum, Diff, RelationDesc, Row, Timestamp};
 
@@ -209,7 +210,15 @@ impl SinkProducerContext {
     }
 }
 
-impl ClientContext for SinkProducerContext {}
+impl ClientContext for SinkProducerContext {
+    // rdkafka's ClientContext is a bit weird, so we are forced to forward here awkwardly
+    fn log(&self, level: rdkafka::config::RDKafkaLogLevel, fac: &str, log_message: &str) {
+        MzClientContext.log(level, fac, log_message)
+    }
+    fn error(&self, error: rdkafka::error::KafkaError, reason: &str) {
+        MzClientContext.error(error, reason)
+    }
+}
 impl ProducerContext for SinkProducerContext {
     type DeliveryOpaque = ();
 

--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -19,7 +19,6 @@ use std::time::Duration;
 use differential_dataflow::{AsCollection, Collection, Hashable};
 use interchange::json::JsonEncoder;
 use itertools::Itertools;
-use log::{debug, error, info};
 use ore::metrics::{CounterVecExt, DeleteOnDropCounter, DeleteOnDropGauge, GaugeVecExt};
 use rdkafka::client::ClientContext;
 use rdkafka::config::ClientConfig;
@@ -36,6 +35,7 @@ use timely::dataflow::{Scope, Stream};
 use timely::progress::frontier::AntichainRef;
 use timely::progress::Antichain;
 use timely::scheduling::Activator;
+use tracing::{debug, error, info};
 
 use dataflow_types::{
     KafkaSinkConnector, KafkaSinkConsistencyConnector, PublishedSchemaInfo, SinkAsOf, SinkDesc,

--- a/src/dataflow/src/source/file.rs
+++ b/src/dataflow/src/source/file.rs
@@ -17,9 +17,9 @@ use anyhow::{Context, Error};
 use flate2::read::MultiGzDecoder;
 #[cfg(target_os = "linux")]
 use inotify::{EventMask, Inotify, WatchMask};
-use log::error;
 use repr::MessagePayload;
 use timely::scheduling::SyncActivator;
+use tracing::error;
 
 use dataflow_types::{
     AvroOcfEncoding, Compression, DataEncoding, ExternalSourceConnector, MzOffset,
@@ -77,7 +77,7 @@ impl SourceReader for FileSourceReader {
     ) -> Result<(FileSourceReader, Option<PartitionId>), anyhow::Error> {
         let receiver = match connector {
             ExternalSourceConnector::File(fc) => {
-                log::debug!("creating FileSourceReader worker_id={}", worker_id);
+                tracing::debug!("creating FileSourceReader worker_id={}", worker_id);
                 let ctor = |fi| {
                     let mut br = std::io::BufReader::new(fi);
                     Ok(std::iter::from_fn(move || {
@@ -113,7 +113,7 @@ impl SourceReader for FileSourceReader {
                 rx
             }
             ExternalSourceConnector::AvroOcf(fc) => {
-                log::debug!("creating Avro FileSourceReader worker_id={}", worker_id);
+                tracing::debug!("creating Avro FileSourceReader worker_id={}", worker_id);
                 let value_encoding = match &encoding {
                     SourceDataEncoding::Single(enc) => enc,
                     SourceDataEncoding::KeyValue { .. } => {
@@ -202,7 +202,7 @@ pub fn read_file_task<Ctor, I, Err>(
     Ctor: FnOnce(Box<dyn AvroRead + Send>) -> Result<I, Err>,
     Err: Into<anyhow::Error>,
 {
-    log::trace!("reading file {}", path.display());
+    tracing::trace!("reading file {}", path.display());
     let file = match std::fs::File::open(&path).with_context(|| {
         format!(
             "file source: unable to open file at path {}",
@@ -418,5 +418,5 @@ fn send_records<I, Out, Err>(
             activator.activate().expect("activation failed");
         }
     }
-    log::trace!("sent {} records to reader", records);
+    tracing::trace!("sent {} records to reader", records);
 }

--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -25,8 +25,8 @@ use dataflow_types::{
 };
 use expr::{PartitionId, SourceInstanceId};
 use kafka_util::KafkaAddrs;
-use log::{error, info, log_enabled, warn};
 use repr::adt::jsonb::Jsonb;
+use tracing::{error, info, warn};
 use uuid::Uuid;
 
 use crate::logging::materialized::{Logger, MaterializedEvent};
@@ -534,7 +534,7 @@ fn create_kafka_config(
     // This is a very simple integration at the moment; enabling `debug`-level
     // logs for the `librdkafka` target enables the full firehouse of librdkafka
     // debug logs. We may want to investigate finer-grained control.
-    if log_enabled!(target: "librdkafka", log::Level::Debug) {
+    if log::log_enabled!(target: "librdkafka", log::Level::Debug) {
         kafka_config.set("debug", "all");
     }
 

--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -534,6 +534,7 @@ fn create_kafka_config(
     // This is a very simple integration at the moment; enabling `debug`-level
     // logs for the `librdkafka` target enables the full firehouse of librdkafka
     // debug logs. We may want to investigate finer-grained control.
+    // TODO(guswynn): replace this when https://github.com/tokio-rs/tracing/pull/1821 is merged
     if log::log_enabled!(target: "librdkafka", log::Level::Debug) {
         kafka_config.set("debug", "all");
     }

--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -24,7 +24,7 @@ use dataflow_types::{
     ExternalSourceConnector, KafkaOffset, KafkaSourceConnector, MzOffset, SourceDataEncoding,
 };
 use expr::{PartitionId, SourceInstanceId};
-use kafka_util::KafkaAddrs;
+use kafka_util::{client::MzClientContext, KafkaAddrs};
 use repr::adt::jsonb::Jsonb;
 use tracing::{error, info, warn};
 use uuid::Uuid;
@@ -620,6 +620,14 @@ impl ClientContext for GlueConsumerContext {
             }
             Err(e) => error!("failed decoding librdkafka statistics JSON: {}", e),
         };
+    }
+
+    // rdkafka's ClientContext is a bit weird, so we are forced to forward here awkwardly
+    fn log(&self, level: rdkafka::config::RDKafkaLogLevel, fac: &str, log_message: &str) {
+        MzClientContext.log(level, fac, log_message)
+    }
+    fn error(&self, error: rdkafka::error::KafkaError, reason: &str) {
+        MzClientContext.error(error, reason)
     }
 }
 

--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -26,7 +26,7 @@ use dataflow_types::{
 use expr::{PartitionId, SourceInstanceId};
 use kafka_util::{client::MzClientContext, KafkaAddrs};
 use repr::adt::jsonb::Jsonb;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 use crate::logging::materialized::{Logger, MaterializedEvent};
@@ -536,6 +536,7 @@ fn create_kafka_config(
     // debug logs. We may want to investigate finer-grained control.
     // TODO(guswynn): replace this when https://github.com/tokio-rs/tracing/pull/1821 is merged
     if log::log_enabled!(target: "librdkafka", log::Level::Debug) {
+        debug!("Enabling 'debug' for rdkafka");
         kafka_config.set("debug", "all");
     }
 

--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -622,7 +622,8 @@ impl ClientContext for GlueConsumerContext {
         };
     }
 
-    // rdkafka's ClientContext is a bit weird, so we are forced to forward here awkwardly
+    // The shape of the rdkafka *Context traits require us to forward to the `MzClientContext`
+    // implementation.
     fn log(&self, level: rdkafka::config::RDKafkaLogLevel, fac: &str, log_message: &str) {
         MzClientContext.log(level, fac, log_message)
     }

--- a/src/dataflow/src/source/kinesis.rs
+++ b/src/dataflow/src/source/kinesis.rs
@@ -16,9 +16,9 @@ use aws_sdk_kinesis::error::GetRecordsError;
 use aws_sdk_kinesis::output::GetRecordsOutput;
 use aws_sdk_kinesis::{Client as KinesisClient, SdkError};
 use futures::executor::block_on;
-use log::error;
 use prometheus::core::AtomicI64;
 use timely::scheduling::SyncActivator;
+use tracing::error;
 
 use dataflow_types::{
     ExternalSourceConnector, KinesisSourceConnector, MzOffset, SourceDataEncoding,

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -37,11 +37,11 @@ use dataflow_types::{
     Consistency, ExternalSourceConnector, MzOffset, SourceDataEncoding, SourceError,
 };
 use expr::{GlobalId, PartitionId, SourceInstanceId};
-use log::error;
 use ore::cast::CastFrom;
 use ore::metrics::{CounterVecExt, DeleteOnDropCounter, DeleteOnDropGauge, GaugeVecExt};
 use ore::now::NowFn;
 use prometheus::core::{AtomicI64, AtomicU64};
+use tracing::error;
 
 use repr::{Diff, Row, Timestamp};
 use timely::dataflow::channels::pushers::Tee;
@@ -1370,7 +1370,7 @@ where
                             false,
                         );
                     } else {
-                        log::debug!(
+                        tracing::debug!(
                             "Filtered out timestamp binding {:?} from persistence because we already have {}.",
                             (source_ts, assigned_ts),
                             current_binding
@@ -1576,7 +1576,7 @@ where
                 // wasteful but we don't expect large numbers of bindings.
                 let mut to_emit = to_emit.collect::<Vec<_>>();
 
-                log::trace!(
+                tracing::trace!(
                     "In {} (worker {}), emitting new timestamp bindings: {:?}, cap: {:?}",
                     name.clone(),
                     worker_id,
@@ -1678,13 +1678,13 @@ impl SourceReaderPersistence {
             self.config.upper_data_seal_ts,
         )?;
 
-        log::trace!(
+        tracing::trace!(
             "In {}, initial (restored) source offsets: {:?}",
             self.source_name,
             offsets,
         );
 
-        log::trace!(
+        tracing::trace!(
             "In {}, initial (restored) timestamp bindings: {:?}",
             self.source_name,
             bindings,

--- a/src/dataflow/src/source/postgres.rs
+++ b/src/dataflow/src/source/postgres.rs
@@ -413,7 +413,7 @@ impl SimpleSource for PostgresSourceReader {
                 let mut writer = tokio::io::BufWriter::new(file);
                 match self.produce_snapshot(&mut snapshot_tx, &mut writer).await {
                     Ok(_) => {
-                        log::info!(
+                        tracing::info!(
                             "replication snapshot for source {} succeeded",
                             &self.source_name
                         );
@@ -424,7 +424,7 @@ impl SimpleSource for PostgresSourceReader {
                             source_name: self.source_name.clone(),
                             error: SourceErrorDetails::Initialization(e.to_string()),
                         })?;
-                        log::warn!(
+                        tracing::warn!(
                             "replication snapshot for source {} failed, retrying: {}",
                             &self.source_name,
                             e
@@ -453,7 +453,7 @@ impl SimpleSource for PostgresSourceReader {
         loop {
             match self.produce_replication(timestamper).await {
                 Err(ReplicationError::Recoverable(e)) => {
-                    log::warn!(
+                    tracing::warn!(
                         "replication for source {} interrupted, retrying: {}",
                         &self.source_name,
                         e
@@ -470,7 +470,7 @@ impl SimpleSource for PostgresSourceReader {
 
             // TODO(petrosagg): implement exponential back-off
             tokio::time::sleep(Duration::from_secs(3)).await;
-            log::info!("resuming replication for source {}", &self.source_name);
+            tracing::info!("resuming replication for source {}", &self.source_name);
         }
     }
 }

--- a/src/dataflow/src/source/pubnub.rs
+++ b/src/dataflow/src/source/pubnub.rs
@@ -80,7 +80,7 @@ impl SimpleSource for PubNubSourceReader {
                 }
             }
 
-            log::info!(
+            tracing::info!(
                 "pubnub channel {:?} disconnected. reconnecting",
                 channel.to_string()
             );

--- a/src/dataflow/src/source/timestamp.rs
+++ b/src/dataflow/src/source/timestamp.rs
@@ -27,12 +27,12 @@ use std::collections::HashMap;
 use std::rc::Rc;
 use std::time::Instant;
 
-use log::error;
 use persist_types::{Codec, ExtendWriteAdapter};
 use protobuf::Message;
 use timely::order::PartialOrder;
 use timely::progress::frontier::{Antichain, AntichainRef, MutableAntichain};
 use timely::progress::{ChangeBatch, Timestamp as TimelyTimestamp};
+use tracing::error;
 
 use dataflow_types::MzOffset;
 use expr::PartitionId;
@@ -347,7 +347,7 @@ impl TimestampBindingBox {
             .entry(partition.clone())
             .and_modify(|existing_offset| {
                 if existing_offset.is_some() {
-                    log::debug!(
+                    tracing::debug!(
                         "Already have offset {} for partition {}, ignoring.",
                         existing_offset.expect("known to exist"),
                         partition

--- a/src/dataflowd/Cargo.toml
+++ b/src/dataflowd/Cargo.toml
@@ -11,7 +11,7 @@ async-trait = "0.1.52"
 clap = { version = "3.0.6", features = ["derive", "env"] }
 dataflow-types = { path = "../dataflow-types" }
 dataflow = { path = "../dataflow" }
-log = "0.4.13"
+tracing = "0.1.29"
 ore = { path = "../ore" }
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 tracing-subscriber = "0.3.5"

--- a/src/dataflowd/src/lib.rs
+++ b/src/dataflowd/src/lib.rs
@@ -37,7 +37,7 @@ impl RemoteClient {
 #[async_trait::async_trait]
 impl Client for RemoteClient {
     async fn send(&mut self, cmd: Command) {
-        log::trace!("Broadcasting dataflow command: {:?}", cmd);
+        tracing::trace!("Broadcasting dataflow command: {:?}", cmd);
         self.client.send(cmd).await
     }
     async fn recv(&mut self) -> Option<Response> {

--- a/src/dataflowd/src/main.rs
+++ b/src/dataflowd/src/main.rs
@@ -12,9 +12,9 @@ use std::process;
 use anyhow::bail;
 use futures::sink::SinkExt;
 use futures::stream::TryStreamExt;
-use log::info;
 use tokio::net::TcpListener;
 use tokio::select;
+use tracing::info;
 use tracing_subscriber::EnvFilter;
 
 use dataflow_types::client::Client;

--- a/src/http-proxy/Cargo.toml
+++ b/src/http-proxy/Cargo.toml
@@ -16,7 +16,7 @@ hyper-proxy = { version = "0.9.1", optional = true }
 hyper-tls = { version = "0.5.0", optional = true }
 ipnet = "2.3.1"
 lazy_static = "1.1.1"
-log = "0.4.13"
+tracing = "0.1.29"
 reqwest = { version = "0.11.8", optional = true }
 
 [features]

--- a/src/http-proxy/src/proxy.rs
+++ b/src/http-proxy/src/proxy.rs
@@ -42,7 +42,7 @@ fn load_system_config() -> ProxyConfig {
         match val {
             Some(Ok(val)) => Some(val),
             Some(Err(e)) => {
-                log::warn!("ignoring invalid configuration for {}: {}", names[0], e);
+                tracing::warn!("ignoring invalid configuration for {}: {}", names[0], e);
                 None
             }
             None => None,
@@ -53,7 +53,7 @@ fn load_system_config() -> ProxyConfig {
         match get_any_env(names)?.parse() {
             Ok(uri) => Some(uri),
             Err(e) => {
-                log::warn!("ignoring invalid configuration for {}: {}", names[0], e);
+                tracing::warn!("ignoring invalid configuration for {}: {}", names[0], e);
                 None
             }
         }

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -23,7 +23,7 @@ futures = "0.3.19"
 hex = "0.4.3"
 itertools = "0.10.3"
 lazy_static = "1.4.0"
-log = "0.4.13"
+tracing = "0.1.29"
 mz-avro = { path = "../avro", features = ["snappy"] }
 num-traits = "0.2.14"
 ordered-float = { version = "2.10.0", features = ["serde"] }

--- a/src/interchange/src/avro/decode.rs
+++ b/src/interchange/src/avro/decode.rs
@@ -179,7 +179,7 @@ impl Decoder {
             if let Err(()) = push_coords(coords, &mut self.packer) {
                 if !self.warned_on_unknown {
                     self.warned_on_unknown = true;
-                    log::warn!(
+                    tracing::warn!(
                         "Record with unrecognized source coordinates in {}. \
                          You might be using an unsupported upstream database.",
                         self.debug_name
@@ -214,7 +214,7 @@ impl Decoder {
             dsr.deserialize(bytes, dec)?;
             self.packer.finish_and_reuse()
         };
-        log::trace!(
+        tracing::trace!(
             "[customer-data] Decoded row {:?} in {}",
             result,
             self.debug_name

--- a/src/interchange/src/avro/envelope_debezium/deduplication.rs
+++ b/src/interchange/src/avro/envelope_debezium/deduplication.rs
@@ -16,12 +16,12 @@ use anyhow::bail;
 use chrono::format::{DelayedFormat, StrftimeItems};
 use chrono::NaiveDateTime;
 use differential_dataflow::Collection;
-use log::{debug, error, info, warn};
 use repr::Diff;
 use repr::Timestamp;
 use repr::{Datum, Row};
 use serde::{Deserialize, Serialize};
 use timely::dataflow::Scope;
+use tracing::{debug, error, info, warn};
 
 /// Ordered means we can trust Debezium high water marks
 ///

--- a/src/interchange/src/avro/schema.rs
+++ b/src/interchange/src/avro/schema.rs
@@ -14,7 +14,7 @@ use std::str::FromStr;
 use std::time::Duration;
 
 use anyhow::{anyhow, bail, Error};
-use log::warn;
+use tracing::warn;
 
 use mz_avro::error::Error as AvroError;
 use mz_avro::schema::{resolve_schemas, Schema, SchemaNode, SchemaPiece, SchemaPieceOrNamed};

--- a/src/kafka-util/Cargo.toml
+++ b/src/kafka-util/Cargo.toml
@@ -20,4 +20,5 @@ rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["c
 serde = { version = "1.0.133", features = ["derive"] }
 serde_json = "1.0.74"
 tokio = { version = "1.15.0", features = ["macros"] }
+tracing = "0.1.29"
 url = "2.2.2"

--- a/src/kafka-util/src/bin/kgen.rs
+++ b/src/kafka-util/src/bin/kgen.rs
@@ -23,7 +23,7 @@ use rand::distributions::{
 use rand::prelude::{Distribution, ThreadRng};
 use rand::thread_rng;
 use rdkafka::error::KafkaError;
-use rdkafka::producer::{BaseRecord, DefaultProducerContext, Producer, ThreadedProducer};
+use rdkafka::producer::{BaseRecord, Producer, ThreadedProducer};
 use rdkafka::types::RDKafkaErrorCode;
 use rdkafka::util::Timeout;
 use rdkafka::ClientConfig;
@@ -694,10 +694,11 @@ async fn main() -> anyhow::Result<()> {
             let topic = &args.topic;
             let mut key_gen = key_gen.clone();
             let mut value_gen = value_gen.clone();
-            let producer: ThreadedProducer<DefaultProducerContext> = ClientConfig::new()
-                .set("bootstrap.servers", args.bootstrap_server.to_string())
-                .create()
-                .unwrap();
+            let producer: ThreadedProducer<kafka_util::client::MzClientContext> =
+                ClientConfig::new()
+                    .set("bootstrap.servers", args.bootstrap_server.to_string())
+                    .create_with_context(kafka_util::client::MzClientContext)
+                    .unwrap();
             let mut key_buf = vec![];
             let mut value_buf = vec![];
             let mut n = args.num_records / threads;

--- a/src/kafka-util/src/client.rs
+++ b/src/kafka-util/src/client.rs
@@ -7,16 +7,17 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! Helpers for working with Kafka's API
+//! Helpers for working with Kafka's client API.
 
-use rdkafka::{
-    consumer::ConsumerContext,
-    producer::{DefaultProducerContext, DeliveryResult, ProducerContext},
-    ClientContext,
-};
+use rdkafka::consumer::ConsumerContext;
+use rdkafka::producer::{DefaultProducerContext, DeliveryResult, ProducerContext};
+use rdkafka::ClientContext;
 use tracing::{debug, error, info, warn};
 
-/// A `ClientContext` implementation that correctly uses `tracing` instead of `log` macros
+/// A `ClientContext` implementation that uses `tracing` instead of `log` macros.
+///
+/// All code in Materialize that constructs Kafka clients should use this context or
+/// a custom context that delegates the `log` and `error` methods to this implementation.
 pub struct MzClientContext;
 
 impl ClientContext for MzClientContext {
@@ -40,8 +41,9 @@ impl ClientContext for MzClientContext {
     }
 }
 
-// Default implementation's of ConsumerContext and ProducerContext that uses the above log impl for
-// the super traits
+// Implement `ConsumerContext` and `ProducerContext` for `MzClientContext`, so that it can be used
+// in place of `DefaultProducerContext` and `DefaultConsumerContext`, but use tracing for logging.
+// (These trait have a `: ClientContext` super-trait bound)
 impl ConsumerContext for MzClientContext {}
 impl ProducerContext for MzClientContext {
     type DeliveryOpaque = <DefaultProducerContext as ProducerContext>::DeliveryOpaque;

--- a/src/kafka-util/src/client.rs
+++ b/src/kafka-util/src/client.rs
@@ -1,0 +1,55 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Helpers for working with Kafka's API
+
+use rdkafka::{
+    consumer::ConsumerContext,
+    producer::{DefaultProducerContext, DeliveryResult, ProducerContext},
+    ClientContext,
+};
+use tracing::{debug, error, info, warn};
+
+/// A `ClientContext` implementation that correctly uses `tracing` instead of `log` macros
+pub struct MzClientContext;
+
+impl ClientContext for MzClientContext {
+    fn log(&self, level: rdkafka::config::RDKafkaLogLevel, fac: &str, log_message: &str) {
+        use rdkafka::config::RDKafkaLogLevel::*;
+        // Copied from https://docs.rs/rdkafka/0.28.0/src/rdkafka/client.rs.html#58-79
+        // but using `tracing`
+        match level {
+            Emerg | Alert | Critical | Error => {
+                error!(target: "librdkafka", "{} {}", fac, log_message);
+            }
+            Warning => warn!(target: "librdkafka", "{} {}", fac, log_message),
+            Notice => info!(target: "librdkafka", "{} {}", fac, log_message),
+            Info => info!(target: "librdkafka", "{} {}", fac, log_message),
+            Debug => debug!(target: "librdkafka", "{} {}", fac, log_message),
+        }
+    }
+    // Refer to the comment on the `log` callback.
+    fn error(&self, error: rdkafka::error::KafkaError, reason: &str) {
+        error!("librdkafka: {}: {}", error, reason);
+    }
+}
+
+// Default implementation's of ConsumerContext and ProducerContext that uses the above log impl for
+// the super traits
+impl ConsumerContext for MzClientContext {}
+impl ProducerContext for MzClientContext {
+    type DeliveryOpaque = <DefaultProducerContext as ProducerContext>::DeliveryOpaque;
+    fn delivery(
+        &self,
+        delivery_result: &DeliveryResult<'_>,
+        delivery_opaque: Self::DeliveryOpaque,
+    ) {
+        DefaultProducerContext.delivery(delivery_result, delivery_opaque);
+    }
+}

--- a/src/kafka-util/src/lib.rs
+++ b/src/kafka-util/src/lib.rs
@@ -14,5 +14,6 @@
 mod addr;
 
 pub mod admin;
+pub mod client;
 
 pub use addr::{KafkaAddrs, KafkaAddrsParseError};

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -53,7 +53,6 @@ itertools = "0.10.3"
 krb5-src = { version = "0.3.1", features = ["binaries"] }
 lazy_static = "1.4.0"
 libc = "0.2.112"
-log = "0.4.13"
 mz-http-proxy = { path = "../http-proxy", features = ["reqwest"] }
 mz-process-collector = { path = "../mz-process-collector" }
 nix = "0.23.1"

--- a/src/materialized/src/bin/coordd.rs
+++ b/src/materialized/src/bin/coordd.rs
@@ -12,9 +12,9 @@ use std::path::PathBuf;
 use std::process;
 use std::time::Duration;
 
-use log::info;
 use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
+use tracing::info;
 use tracing_subscriber::EnvFilter;
 
 use materialized::http;

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -34,6 +34,7 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 
+use ::tracing::info;
 use anyhow::{bail, Context};
 use backtrace::Backtrace;
 use chrono::Utc;
@@ -42,7 +43,6 @@ use coord::{PersistConfig, PersistFileStorage, PersistStorage};
 use fail::FailScenario;
 use itertools::Itertools;
 use lazy_static::lazy_static;
-use log::info;
 use ore::cgroup::{detect_memory_limit, MemoryLimit};
 use ore::metric;
 use ore::metrics::ThirdPartyMetric;
@@ -500,9 +500,7 @@ fn run(args: Args) -> Result<(), anyhow::Error> {
                 // The user explicitly directed logs to stderr. Log only to
                 // stderr with the user-specified `filter`.
                 tracing_subscriber::registry()
-                    .with(
-                        MetricsRecorderLayer::new(log_message_counter).with_filter(filter.clone()),
-                    )
+                    .with(MetricsRecorderLayer::new(log_message_counter))
                     .with(
                         fmt::layer()
                             .with_writer(io::stderr)
@@ -519,9 +517,7 @@ fn run(args: Args) -> Result<(), anyhow::Error> {
                     None => LevelFilter::WARN,
                 };
                 tracing_subscriber::registry()
-                    .with(
-                        MetricsRecorderLayer::new(log_message_counter).with_filter(filter.clone()),
-                    )
+                    .with(MetricsRecorderLayer::new(log_message_counter))
                     .with({
                         let path = match log_file {
                             Some(log_file) => PathBuf::from(log_file),
@@ -664,7 +660,7 @@ dataflow workers: {workers}",
         };
         let mut system_table_enabled = !args.disable_persistent_system_tables_test;
         if system_table_enabled && args.logical_compaction_window.is_none() {
-            log::warn!("--logical-compaction-window is off; disabling background persistence test to prevent unbounded disk usage");
+            ::tracing::warn!("--logical-compaction-window is off; disabling background persistence test to prevent unbounded disk usage");
             system_table_enabled = false;
         }
 
@@ -826,7 +822,7 @@ fn handle_panic(panic_info: &PanicInfo) {
         "<unknown>".to_string()
     };
 
-    log::error!(
+    ::tracing::error!(
         target: "panic",
         "{msg}
 thread: {thr_name}

--- a/src/materialized/src/bin/materialized/sys.rs
+++ b/src/materialized/src/bin/materialized/sys.rs
@@ -16,9 +16,9 @@ use std::ptr;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use anyhow::{bail, Context};
-use log::trace;
 use nix::errno;
 use nix::sys::signal;
+use tracing::trace;
 
 #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "ios")))]
 pub fn adjust_rlimits() {
@@ -28,8 +28,8 @@ pub fn adjust_rlimits() {
 /// Attempts to increase the soft nofile rlimit to the maximum possible value.
 #[cfg(any(target_os = "macos", target_os = "linux", target_os = "ios"))]
 pub fn adjust_rlimits() {
-    use log::warn;
     use rlimit::Resource;
+    use tracing::warn;
 
     // getrlimit/setrlimit can have surprisingly different behavior across
     // platforms, even with the rlimit wrapper crate that we use. This function

--- a/src/materialized/src/bin/materialized/tracing.rs
+++ b/src/materialized/src/bin/materialized/tracing.rs
@@ -50,10 +50,10 @@ mod test {
     use std::collections::HashMap;
 
     use super::MetricsRecorderLayer;
-    use log::{error, info, warn};
     use ore::metric;
     use ore::metrics::raw::IntCounterVec;
     use ore::metrics::{MetricsRegistry, ThirdPartyMetric};
+    use tracing::{error, info, warn};
     use tracing_subscriber::layer::SubscriberExt;
     use tracing_subscriber::util::SubscriberInitExt;
 

--- a/src/materialized/src/http.rs
+++ b/src/materialized/src/http.rs
@@ -19,12 +19,12 @@ use std::pin::Pin;
 use futures::future::TryFutureExt;
 use hyper::{service, Body, Method, Request, Response, StatusCode};
 use hyper_openssl::MaybeHttpsStream;
-use log::error;
 use openssl::nid::Nid;
 use openssl::ssl::{Ssl, SslContext};
 use ore::metrics::MetricsRegistry;
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use tokio_openssl::SslStream;
+use tracing::error;
 
 use coord::session::Session;
 use ore::future::OreFutureExt;

--- a/src/materialized/src/http/root.rs
+++ b/src/materialized/src/http/root.rs
@@ -79,7 +79,7 @@ fn get_static_file(path: &str) -> Option<Body> {
     match fs::read(dev_path).or_else(|_| fs::read(prod_path)) {
         Ok(contents) => Some(Body::from(contents)),
         Err(e) => {
-            log::debug!("dev-web failed to load static file: {}: {}", path, e);
+            tracing::debug!("dev-web failed to load static file: {}: {}", path, e);
             None
         }
     }

--- a/src/materialized/src/mux.rs
+++ b/src/materialized/src/mux.rs
@@ -11,9 +11,9 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use futures::stream::{Stream, StreamExt};
-use log::{debug, error};
 use tokio::io::{self, AsyncWriteExt};
 use tokio::net::TcpStream;
+use tracing::{debug, error};
 
 use ore::netio::{self, SniffedStream, SniffingStream};
 

--- a/src/materialized/src/telemetry.rs
+++ b/src/materialized/src/telemetry.rs
@@ -14,7 +14,7 @@
 
 use serde::Deserialize;
 use tokio::time::{self, Duration};
-use tracing::{debug, event, Level};
+use tracing::{debug, warn};
 use uuid::Uuid;
 
 use ore::retry::Retry;
@@ -59,24 +59,24 @@ pub async fn report_loop(config: Config) {
             // We assume users running development builds are sophisticated, and
             // may be intentionally not running the latest release, so downgrade
             // the message from warn to info level.
+            //
+            // TODO: avoid duplicating the message if tokio-rs/tracing#372
+            // is resolved.
             match BUILD_INFO.semver_version().pre.as_str() {
                 "dev" => {
-                    event!(
-                        Level::DEBUG,
+                    debug!(
                         "a new version of materialized is available: {}",
                         latest_version
                     );
-                    reported_version = latest_version;
                 }
                 _ => {
-                    event!(
-                        Level::WARN,
+                    warn!(
                         "a new version of materialized is available: {}",
                         latest_version
                     );
-                    reported_version = latest_version;
                 }
             };
+            reported_version = latest_version;
         }
     }
 }

--- a/src/materialized/tests/sql.rs
+++ b/src/materialized/tests/sql.rs
@@ -25,9 +25,9 @@ use std::thread::sleep;
 use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Utc};
-use log::info;
 use postgres::Row;
 use tempfile::NamedTempFile;
+use tracing::info;
 
 use ore::assert_contains;
 

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -39,6 +39,12 @@ smallvec = { version = "1.7.0", optional = true }
 stacker = { version = "0.1.14", optional = true }
 tokio = { version = "1.15.0", features = ["io-util", "net", "rt-multi-thread", "time"], optional = true }
 tokio-openssl = { version = "0.6.3", optional = true }
+# TODO(guswynn): determine, when, if ever, we can remove `tracing-log`
+# The `tracing-log` feature here is load-bearing: While our busiest-logging dependency (`rdkafka`) is now hooked-up
+# to use `tracing`, we cannot remove this feature until we guarantee no dependencies log using the `log` crate, for
+# log lines we care about.
+# Note that this feature is distinct from `tracing`'s `log` feature, which has `tracing` macros emit `log` records if
+# there is no global `tracing` subscriber.
 tracing-subscriber = { version = "0.3.5", default-features = false, features = ["env-filter", "fmt", "tracing-log"], optional = true }
 
 [dev-dependencies]

--- a/src/ore/src/assert.rs
+++ b/src/ore/src/assert.rs
@@ -91,7 +91,7 @@ macro_rules! soft_assert_or_log {
         if $crate::assert::SOFT_ASSERTIONS.load(::std::sync::atomic::Ordering::Relaxed) {
             assert!($cond, $($arg)+);
         } else if !$cond {
-            ::log::error!($($arg)+)
+            ::tracing::error!($($arg)+)
         }
     }}
 }
@@ -104,7 +104,7 @@ macro_rules! soft_panic_or_log {
         if $crate::assert::SOFT_ASSERTIONS.load(::std::sync::atomic::Ordering::Relaxed) {
             panic!($($arg)+);
         } else {
-            ::log::error!($($arg)+)
+            ::tracing::error!($($arg)+)
         }
     }}
 }

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -34,7 +34,7 @@ fail = { version = "0.5.0", features = ["failpoints"] }
 futures-executor = "0.3.16"
 futures-util = "0.3.19"
 lazy_static = "1.4.0"
-log = "0.4.13"
+tracing = "0.1.29"
 md-5 = "0.10.0"
 mz-aws-util = { path = "../aws-util", features = ["s3"] }
 ore = { path = "../ore", default-features = false, features = ["metrics"] }

--- a/src/persist/examples/kafka_upsert.rs
+++ b/src/persist/examples/kafka_upsert.rs
@@ -80,8 +80,8 @@ fn run(args: Vec<String>) -> Result<(), Box<dyn Error>> {
                 let err_stream = vec![(err.to_string(), 0, 1)].to_stream(scope);
                 (ok_stream, err_stream)
             });
-            ok_stream.inspect(|d| log::info!("ok: {:?}", d));
-            err_stream.inspect(|d| log::info!("err: {:?}", d));
+            ok_stream.inspect(|d| tracing::info!("ok: {:?}", d));
+            err_stream.inspect(|d| tracing::info!("err: {:?}", d));
         })
     })?;
 

--- a/src/persist/src/golden_test.rs
+++ b/src/persist/src/golden_test.rs
@@ -125,17 +125,17 @@ fn golden() -> Result<(), Error> {
     let (current, raw_blobs) = current_state(&reqs)?;
     let golden = golden_state(DATAZ).map_err(|e| {
         for req in reqs.iter() {
-            log::debug!("req {:?}", req);
+            tracing::debug!("req {:?}", req);
         }
-        log::info!("current impl blob state: {}", raw_blobs);
+        tracing::info!("current impl blob state: {}", raw_blobs);
         e
     })?;
 
     if golden != current {
         for req in reqs {
-            log::debug!("req {:?}", req);
+            tracing::debug!("req {:?}", req);
         }
-        log::info!("current impl blob state: {}", raw_blobs);
+        tracing::info!("current impl blob state: {}", raw_blobs);
         assert_eq!(golden, current);
     }
 
@@ -146,7 +146,7 @@ fn golden_state(blob_json: &str) -> Result<PersistState, Error> {
     let runtime = Arc::new(tokio::runtime::Runtime::new()?);
     let mut blob = MemBlob::new_no_reentrance("");
     if let Err(err) = runtime.block_on(Blobs::deserialize_to(blob_json, &mut blob)) {
-        log::error!("error deserializing golden: {}", err);
+        tracing::error!("error deserializing golden: {}", err);
     }
     let mut persist = runtime::start(
         RuntimeConfig::for_tests(),

--- a/src/persist/src/indexed/mod.rs
+++ b/src/persist/src/indexed/mod.rs
@@ -184,10 +184,10 @@ impl<L: Log, B: Blob> Indexed<L, B> {
                 //
                 // TODO: Regression test for this.
                 if let Err(err) = log.close() {
-                    log::warn!("error closing log: {}", err);
+                    tracing::warn!("error closing log: {}", err);
                 }
                 if let Err(err) = blob.close() {
-                    log::warn!("error closing blob: {}", err);
+                    tracing::warn!("error closing blob: {}", err);
                 }
                 err
             })?
@@ -519,9 +519,9 @@ impl<L: Log, B: Blob> Indexed<L, B> {
                     // This is a test and we've almost certainly used
                     // UnreliableBlob to make storage unavailable, log it at a
                     // lower level to keep test output a little less spammy.
-                    log::trace!("unable to read back persisted metadata: {:?}", e);
+                    tracing::trace!("unable to read back persisted metadata: {:?}", e);
                 } else {
-                    log::error!("unable to read back persisted metadata: {:?}", e);
+                    tracing::error!("unable to read back persisted metadata: {:?}", e);
                 }
             }
         }
@@ -557,9 +557,9 @@ impl<L: Log, B: Blob> Indexed<L, B> {
                     // This is a test and we've almost certainly used
                     // UnreliableBlob to make storage unavailable, log it at a
                     // lower level to keep test output a little less spammy.
-                    log::trace!("unable to read back persisted metadata: {:?}", e);
+                    tracing::trace!("unable to read back persisted metadata: {:?}", e);
                 } else {
-                    log::error!("unable to read back persisted metadata: {:?}", e);
+                    tracing::error!("unable to read back persisted metadata: {:?}", e);
                 }
             }
         }

--- a/src/persist/src/indexed/runtime.rs
+++ b/src/persist/src/indexed/runtime.rs
@@ -23,7 +23,6 @@ use std::time::{Duration, Instant};
 
 use build_info::BuildInfo;
 use differential_dataflow::trace::Description;
-use log;
 use ore::metrics::MetricsRegistry;
 use persist_types::Codec;
 use timely::progress::Antichain;
@@ -226,10 +225,10 @@ impl RuntimeCore {
                 // stopped, so we can return an Ok. This is surprising, though,
                 // so log a message. Unfortunately, there isn't really a way to
                 // put the panic message in this log.
-                log::error!("persist runtime thread panic'd");
+                tracing::error!("persist runtime thread panic'd");
             }
             if let Err(err) = block_on(handles.ticker_handle) {
-                log::error!("persist ticker thread error'd: {:?}", err);
+                tracing::error!("persist ticker thread error'd: {:?}", err);
             }
             // Thread a copy of the Arc<Runtime> being used to drive
             // ticker_handle to make sure the runtime doesn't shut down before
@@ -245,7 +244,7 @@ impl RuntimeCore {
 impl Drop for RuntimeCore {
     fn drop(&mut self) {
         if let Err(err) = self.stop() {
-            log::error!("error while stopping dropped persist runtime: {}", err);
+            tracing::error!("error while stopping dropped persist runtime: {}", err);
         }
     }
 }
@@ -909,7 +908,7 @@ impl<L: Log, B: Blob> RuntimeImpl<L, B> {
                     // Finish up any pending work that we can before closing.
                     if let Err(e) = self.indexed.step() {
                         self.metrics.cmd_step_error_count.inc();
-                        log::warn!("error running step: {:?}", e);
+                        tracing::warn!("error running step: {:?}", e);
                     }
                     res.fill(self.indexed.close());
                     return false;
@@ -1004,7 +1003,7 @@ impl<L: Log, B: Blob> RuntimeImpl<L, B> {
                 // TODO: revisit whether we need to move this to a different log level
                 // depending on how spammy it ends up being. Alternatively, we
                 // may want to rate-limit our logging here.
-                log::warn!("error running step: {:?}", e);
+                tracing::warn!("error running step: {:?}", e);
             }
 
             self.metrics

--- a/src/persist/src/mem.rs
+++ b/src/persist/src/mem.rs
@@ -153,7 +153,7 @@ impl Drop for MemLog {
         // MemLog should have been closed gracefully; this drop is only here
         // as a failsafe. If it actually did anything, that's surprising.
         if did_work {
-            log::warn!("MemLog dropped without close");
+            tracing::warn!("MemLog dropped without close");
         }
     }
 }
@@ -339,7 +339,7 @@ impl Drop for MemBlob {
         // MemLog should have been closed gracefully; this drop is only here
         // as a failsafe. If it actually did anything, that's surprising.
         if did_work {
-            log::warn!("MemBlob dropped without close");
+            tracing::warn!("MemBlob dropped without close");
         }
     }
 }

--- a/src/persist/src/nemesis/mod.rs
+++ b/src/persist/src/nemesis/mod.rs
@@ -229,7 +229,7 @@ impl FutureStep {
     pub fn recv(self) -> Step {
         let res = self.res.recv();
         let after = Instant::now();
-        log::debug!("{:?} res: {:?}", self.req_id, &res);
+        tracing::debug!("{:?} res: {:?}", self.req_id, &res);
         let meta = StepMeta {
             req_id: self.req_id,
             before: self.before,
@@ -341,7 +341,7 @@ impl<R: Runtime> Runner<R> {
                                 let step = step_fut.recv();
                                 steps.push(step);
                             }
-                            log::debug!("{:?} req: {:?}", input.req_id, &input.req);
+                            tracing::debug!("{:?} req: {:?}", input.req_id, &input.req);
                             outstanding.push_back(worker.run(input));
                         }
 
@@ -375,13 +375,13 @@ pub fn run<R: Runtime>(steps: usize, config: GeneratorConfig, runtime: R) {
     let seed =
         env::var("MZ_NEMESIS_SEED").map_or_else(|_| OsRng.next_u64(), |s| s.parse().unwrap());
     let steps = env::var("MZ_NEMESIS_STEPS").map_or(steps, |s| s.parse().unwrap());
-    log::info!("MZ_NEMESIS_SEED={} MZ_NEMESIS_STEPS={}", seed, steps);
+    tracing::info!("MZ_NEMESIS_SEED={} MZ_NEMESIS_STEPS={}", seed, steps);
     let generator = Generator::new(seed, config);
     let runner = Runner::new(generator, runtime);
     let history = runner.run(steps);
     if let Err(errors) = Validator::validate(history) {
         for err in errors.iter() {
-            log::warn!("invariant violation: {}", err)
+            tracing::warn!("invariant violation: {}", err)
         }
         assert!(errors.is_empty());
     }

--- a/src/persist/src/nemesis/validator.rs
+++ b/src/persist/src/nemesis/validator.rs
@@ -70,7 +70,7 @@ impl Validator {
     }
 
     fn step(&mut self, s: Step) {
-        log::info!("step: {:?}", &s);
+        tracing::info!("step: {:?}", &s);
         match s.res {
             Res::Write(WriteReq::Single(req), res) => self.step_write_single(&s.meta, req, res),
             Res::Write(WriteReq::Multi(req), res) => self.step_write_multi(&s.meta, req, res),

--- a/src/persist/src/operators/stream.rs
+++ b/src/persist/src/operators/stream.rs
@@ -130,7 +130,7 @@ where
                         std::task::Poll::Ready(result) => {
                             match result {
                                 Ok(seq_no) => {
-                                    log::trace!(
+                                    tracing::trace!(
                                         "In {}, finished writing for time: {}, seq_no: {:?}",
                                         &operator_name,
                                         cap.time(),
@@ -145,7 +145,7 @@ where
                                         error_cap.time(),
                                         e
                                     );
-                                    log::error!("{}", error);
+                                    tracing::error!("{}", error);
 
                                     // TODO: make error retractable? Probably not...
                                     session.give((error, *error_cap.time(), 1));
@@ -279,7 +279,7 @@ where
                 // This way, we are prepared for a future of multi-dimensional frontiers, though.
                 for frontier_element in new_input_frontier.iter() {
                     if input_frontier.less_than(&frontier_element) {
-                        log::trace!(
+                        tracing::trace!(
                             "In {}, sealing collection up to {}...",
                             &operator_name,
                             frontier_element,
@@ -303,7 +303,7 @@ where
                 while let Some(mut pending_future) = pending_futures.pop_front() {
                     match Pin::new(&mut pending_future.future).poll(&mut context) {
                         std::task::Poll::Ready(Ok(_)) => {
-                            log::trace!(
+                            tracing::trace!(
                                 "In {}, finished sealing collection up to {}",
                                 &operator_name,
                                 pending_future.time,
@@ -313,7 +313,7 @@ where
                             cap_set.downgrade(Some(pending_future.time));
                         }
                         std::task::Poll::Ready(Err(e)) => {
-                            log::trace!(
+                            tracing::trace!(
                                 "Error sealing {} up to {}: {}",
                                 &operator_name,
                                 pending_future.time,
@@ -335,7 +335,10 @@ where
                             };
 
                             if retry {
-                                log::trace!("Adding seal to queue again: {}", pending_future.time);
+                                tracing::trace!(
+                                    "Adding seal to queue again: {}",
+                                    pending_future.time
+                                );
 
                                 let future = write.seal(pending_future.time);
                                 pending_futures.push_front(SealFuture {

--- a/src/persist/src/operators/upsert.rs
+++ b/src/persist/src/operators/upsert.rs
@@ -170,7 +170,7 @@ where
                     state_input.for_each(|_time, data| {
                         data.swap(&mut state_input_buffer);
                         for state_update in state_input_buffer.drain(..) {
-                            log::trace!(
+                            tracing::trace!(
                                 "In {}, restored upsert: {:?}",
                                 operator_name,
                                 state_update
@@ -194,7 +194,7 @@ where
                             .finish();
                         current_values.extend(initial_state.into_iter());
 
-                        log::trace!(
+                        tracing::trace!(
                             "In {}, initial (restored) upsert state: {:?}",
                             operator_name,
                             current_values.iter().take(10).collect::<Vec<_>>()

--- a/src/persist/src/s3.rs
+++ b/src/persist/src/s3.rs
@@ -393,7 +393,7 @@ mod tests {
         let config = match S3BlobConfig::new_for_test().await? {
             Some(client) => client,
             None => {
-                log::info!(
+                tracing::info!(
                     "{} env not set: skipping test that uses external service",
                     S3BlobConfig::EXTERNAL_TESTS_S3_BUCKET
                 );

--- a/src/persist/src/storage.rs
+++ b/src/persist/src/storage.rs
@@ -40,7 +40,7 @@ pub fn check_meta_version_maybe_delete_data<B: Blob>(b: &mut B) -> Result<(), Er
         Ok(())
     } else if current_version > persisted_version {
         // Delete all the keys, as we are upgrading to a new version.
-        log::info!(
+        tracing::info!(
             "Persistence beta detected version mismatch. Deleting all previously persisted data as part of upgrade from version {} to {}.",
             persisted_version,
             current_version

--- a/src/pgwire/Cargo.toml
+++ b/src/pgwire/Cargo.toml
@@ -18,7 +18,7 @@ expr = { path = "../expr" }
 futures = "0.3.19"
 itertools = "0.10.3"
 lazy_static = "1.4.0"
-log = "0.4.13"
+tracing = "0.1.29"
 openssl = { version = "0.10.38", features = ["vendored"] }
 ordered-float = { version = "2.10.0", features = ["serde"] }
 ore = { path = "../ore" }

--- a/src/pgwire/src/codec.rs
+++ b/src/pgwire/src/codec.rs
@@ -23,9 +23,9 @@ use async_trait::async_trait;
 use byteorder::{ByteOrder, NetworkEndian};
 use bytes::{Buf, BufMut, BytesMut};
 use futures::{sink, SinkExt, TryStreamExt};
-use log::trace;
 use tokio::io::{self, AsyncRead, AsyncReadExt, AsyncWrite, Interest, Ready};
 use tokio_util::codec::{Decoder, Encoder, Framed};
+use tracing::trace;
 
 use ore::cast::CastFrom;
 use ore::future::OreSinkExt;

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -18,12 +18,12 @@ use byteorder::{ByteOrder, NetworkEndian};
 use expr::GlobalId;
 use futures::future::{BoxFuture, FutureExt};
 use itertools::izip;
-use log::debug;
 use openssl::nid::Nid;
 use postgres::error::SqlState;
 use tokio::io::{self, AsyncRead, AsyncWrite, Interest};
 use tokio::sync::mpsc::unbounded_channel;
 use tokio::time::{self, Duration, Instant};
+use tracing::debug;
 
 use coord::session::{
     EndTransactionAction, InProgressRows, Portal, PortalState, RowBatchStream, Session,

--- a/src/pgwire/src/server.rs
+++ b/src/pgwire/src/server.rs
@@ -13,10 +13,10 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use async_trait::async_trait;
-use log::trace;
 use openssl::ssl::{Ssl, SslContext};
 use tokio::io::{self, AsyncRead, AsyncWrite, AsyncWriteExt, Interest, ReadBuf, Ready};
 use tokio_openssl::SslStream;
+use tracing::trace;
 
 use ore::cast::CastFrom;
 use ore::metrics::MetricsRegistry;

--- a/src/sql-parser/Cargo.toml
+++ b/src/sql-parser/Cargo.toml
@@ -11,7 +11,7 @@ enum-kinds = "0.5.1"
 hex = "0.4.3"
 itertools = "0.10.3"
 lazy_static = "1.4.0"
-log = "0.4.13"
+tracing = "0.1.29"
 ore = { path = "../ore", default-features = false, features = ["stack"] }
 phf = { version = "0.10.1", features = ["uncased"] }
 uncased = "0.9.6"

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -24,7 +24,7 @@ use std::error::Error;
 use std::fmt;
 
 use itertools::Itertools;
-use log::warn;
+use tracing::warn;
 
 use ore::collections::CollectionExt;
 use ore::option::OptionExt;

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -32,6 +32,7 @@ postgres-util = { path = "../postgres-util" }
 protobuf = { git = "https://github.com/MaterializeInc/rust-protobuf.git" }
 mz-protoc = { path = "../../src/protoc" }
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "gssapi-vendored", "libz-static"] }
+kafka-util = { path = "../kafka-util" }
 regex = "1.5.4"
 repr = { path = "../repr" }
 reqwest = "0.11.8"

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -21,7 +21,7 @@ globset = "0.4.8"
 interchange = { path = "../interchange" }
 itertools = "0.10.3"
 lazy_static = "1.4.0"
-log = "0.4.13"
+tracing = "0.1.29"
 mz-avro = { path = "../avro", features = ["snappy"] }
 mz-aws-util = { path = "../aws-util", features = [ "sts" ] }
 ore = { path = "../ore" }

--- a/src/sql/src/kafka_util.rs
+++ b/src/sql/src/kafka_util.rs
@@ -16,7 +16,6 @@ use std::io::Read;
 use std::sync::{Arc, Mutex};
 
 use anyhow::bail;
-use log::{debug, error, info, warn};
 use ore::collections::CollectionExt;
 use rdkafka::client::ClientContext;
 use rdkafka::consumer::{BaseConsumer, Consumer, ConsumerContext};

--- a/src/sql/src/kafka_util.rs
+++ b/src/sql/src/kafka_util.rs
@@ -16,6 +16,8 @@ use std::io::Read;
 use std::sync::{Arc, Mutex};
 
 use anyhow::bail;
+
+use kafka_util::client::MzClientContext;
 use ore::collections::CollectionExt;
 use rdkafka::client::ClientContext;
 use rdkafka::consumer::{BaseConsumer, Consumer, ConsumerContext};
@@ -470,20 +472,17 @@ impl ClientContext for KafkaErrCheckContext {
                 if error.is_none() {
                     *error = Some(log_message.to_string());
                 }
-                error!(target: "librdkafka", "{} {}", fac, log_message);
             }
-            Warning => warn!(target: "librdkafka", "{} {}", fac, log_message),
-            Notice => info!(target: "librdkafka", "{} {}", fac, log_message),
-            Info => info!(target: "librdkafka", "{} {}", fac, log_message),
-            Debug => debug!(target: "librdkafka", "{} {}", fac, log_message),
+            _ => {}
         }
+        MzClientContext.log(level, fac, log_message)
     }
     // Refer to the comment on the `log` callback.
     fn error(&self, error: rdkafka::error::KafkaError, reason: &str) {
         // Allow error to overwrite value irrespective of other conditions
         // (i.e. logging).
         *self.error.lock().expect("lock poisoned") = Some(reason.to_string());
-        error!("librdkafka: {}: {}", error, reason);
+        MzClientContext.error(error, reason)
     }
 }
 

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -22,9 +22,9 @@ use aws_arn::ARN;
 use globset::GlobBuilder;
 use interchange::protobuf::NormalizedProtobufMessageName;
 use itertools::Itertools;
-use log::{debug, error};
 use regex::Regex;
 use reqwest::Url;
+use tracing::{debug, error};
 
 use dataflow_types::{
     included_column_desc, provide_default_metadata, AvroEncoding, AvroOcfEncoding,
@@ -1790,7 +1790,7 @@ pub fn plan_create_sink(
                 if key.not_enforced && envelope == SinkEnvelope::Upsert {
                     // TODO: We should report a warning notice back to the user via the pgwire
                     // protocol. See https://github.com/MaterializeInc/materialize/issues/9333.
-                    log::warn!(
+                    tracing::warn!(
                         "Verification of upsert key disabled for sink '{}' via 'NOT ENFORCED'. This is potentially dangerous and can lead to crashing materialize when the specified key is not in fact a unique key of the sinked view.",
                         name
                     );

--- a/test/metabase/smoketest/Cargo.toml
+++ b/test/metabase/smoketest/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.52"
 itertools = "0.10.3"
-log = "0.4.13"
+tracing = "0.1.29"
 metabase = { path = "../../../src/metabase" }
 ore = { path = "../../../src/ore" }
 tokio = "1.15.0"

--- a/test/metabase/smoketest/src/main.rs
+++ b/test/metabase/smoketest/src/main.rs
@@ -28,7 +28,7 @@ async fn connect_materialized() -> Result<tokio_postgres::Client, anyhow::Error>
         .retry_async(|_| async {
             let res = TcpStream::connect("materialized:6875").await;
             if let Err(e) = &res {
-                log::debug!("error connecting to materialized: {}", e);
+                tracing::debug!("error connecting to materialized: {}", e);
             }
             res
         })
@@ -55,7 +55,7 @@ async fn connect_metabase() -> Result<metabase::Client, anyhow::Error> {
         .retry_async(|_| async {
             let res = client.session_properties().await;
             if let Err(e) = &res {
-                log::debug!("error connecting to metabase: {}", e);
+                tracing::debug!("error connecting to metabase: {}", e);
             }
             res.map(|res| res.setup_token)
         })
@@ -115,7 +115,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let metabase_client = connect_metabase().await?;
 
     let databases = metabase_client.databases().await?;
-    log::debug!("Databases: {:#?}", databases);
+    tracing::debug!("Databases: {:#?}", databases);
 
     let database_names: Vec<_> = databases.iter().map(|d| &d.name).sorted().collect();
     assert_eq!(database_names, &["Materialize", "Sample Dataset"]);
@@ -164,7 +164,7 @@ async fn main() -> Result<(), anyhow::Error> {
             for t in &mut metadata.tables {
                 t.fields.sort_by(|a, b| a.name.cmp(&b.name));
             }
-            log::debug!("Materialize database metadata: {:#?}", metadata);
+            tracing::debug!("Materialize database metadata: {:#?}", metadata);
             if expected_metadata != metadata {
                 bail!(
                     "metadata did not match\nexpected:\n{:#?}\nactual:\n{:#?}",

--- a/test/perf-kinesis/Cargo.toml
+++ b/test/perf-kinesis/Cargo.toml
@@ -14,7 +14,7 @@ clap = { version = "3.0.6", features = ["derive"] }
 env_logger = "0.9.0"
 futures = "0.3.19"
 futures-channel = "0.3.16"
-log = "0.4.13"
+tracing = "0.1.29"
 mz-aws-util = { path = "../../src/aws-util", features = ["kinesis"] }
 ore = { path = "../../src/ore" }
 rand = "0.8.4"

--- a/test/perf-kinesis/src/kinesis.rs
+++ b/test/perf-kinesis/src/kinesis.rs
@@ -108,14 +108,14 @@ pub async fn generate_and_put_records(
         if elapsed < Duration::from_secs(1) {
             thread::sleep(Duration::from_secs(1) - elapsed);
         } else {
-            log::info!(
+            tracing::info!(
                 "Expected to put {} records in 1s, took {:#?}",
                 records_per_second,
                 elapsed
             );
         }
     }
-    log::info!(
+    tracing::info!(
         "Generated and put {} records in {} milliseconds.",
         put_record_count,
         timer.elapsed().as_millis()
@@ -171,7 +171,7 @@ pub async fn put_records_one_second(
                 if err.is_kms_throttling_exception()
                     || err.is_provisioned_throughput_exceeded_exception() =>
             {
-                log::info!("Hit non-fatal error, continuing: {}", err);
+                tracing::info!("Hit non-fatal error, continuing: {}", err);
             }
             Err(SdkError::ServiceError { err, .. })
                 if err
@@ -179,7 +179,7 @@ pub async fn put_records_one_second(
                     .unwrap_or("")
                     .contains("The security token included in the request is expired") =>
             {
-                log::info!(
+                tracing::info!(
                     "{:?}. Getting a new aws_sdk_kinesis::Client.",
                     err.message()
                 );
@@ -207,6 +207,6 @@ pub async fn delete_stream(
         .send()
         .await
         .context("deleting Kinesis stream")?;
-    log::info!("Deleted Kinesis stream: {}", &stream_name);
+    tracing::info!("Deleted Kinesis stream: {}", &stream_name);
     Ok(())
 }

--- a/test/perf-kinesis/src/main.rs
+++ b/test/perf-kinesis/src/main.rs
@@ -54,7 +54,7 @@ async fn run() -> Result<(), anyhow::Error> {
     let stream_name = format!("{}-{}", args.stream_prefix, seed);
 
     // todo: make queries per second configurable. (requires mz_client changes)
-    log::info!("Starting kinesis load test with mzd={}:{} \
+    tracing::info!("Starting kinesis load test with mzd={}:{} \
                stream={} shard_count={} total_records={} records_per_second={} queries_per_second={}",
     args.materialized_host, args.materialized_port, &stream_name, args.shard_count, args.total_records, args.records_per_second, 1);
 
@@ -64,7 +64,7 @@ async fn run() -> Result<(), anyhow::Error> {
 
     let stream_arn =
         kinesis::create_stream(&kinesis_client, &stream_name, args.shard_count).await?;
-    log::info!("Created Kinesis stream {}", stream_name);
+    tracing::info!("Created Kinesis stream {}", stream_name);
 
     // Push records to Kinesis.
     let kinesis_task = tokio::spawn({
@@ -90,7 +90,7 @@ async fn run() -> Result<(), anyhow::Error> {
 
     // Create Kinesis source and materialized view.
     mz::create_source_and_views(&client, stream_arn).await?;
-    log::info!("Created source and materialized views");
+    tracing::info!("Created source and materialized views");
 
     // Query materialized view for all pushed Kinesis records.
     let materialize_task = tokio::spawn({
@@ -104,7 +104,7 @@ async fn run() -> Result<(), anyhow::Error> {
 
     kinesis_result?.context("kinesis thread failed")?;
     materialize_result.context("materialize thread failed")??;
-    log::info!(
+    tracing::info!(
         "Completed load test in {} milliseconds",
         timer.elapsed().as_millis()
     );

--- a/test/perf-kinesis/src/mz.rs
+++ b/test/perf-kinesis/src/mz.rs
@@ -24,14 +24,14 @@ pub async fn create_source_and_views(
          FORMAT BYTES",
         stream_arn = stream_arn,
     );
-    log::info!("creating source=> {}", query);
+    tracing::info!("creating source=> {}", query);
     client
         .batch_execute(&query)
         .await
         .context("Creating source")?;
 
     let query = "CREATE VIEW foo_view AS SELECT CONVERT_FROM(data, 'utf8') AS data FROM foo";
-    log::info!("creating view=> {}", query);
+    tracing::info!("creating view=> {}", query);
     client
         .batch_execute(query)
         .await
@@ -39,7 +39,7 @@ pub async fn create_source_and_views(
 
     // Only materialize the count.
     let query = "CREATE MATERIALIZED VIEW foo_count AS SELECT count(*) FROM foo";
-    log::info!("creating materialized view=> {}", query);
+    tracing::info!("creating materialized view=> {}", query);
     client
         .batch_execute(query)
         .await
@@ -54,12 +54,12 @@ pub async fn query_materialized_view_until(
     expected_total_records: u64,
 ) -> Result<(), anyhow::Error> {
     let query = format!("SELECT * FROM {view_name};", view_name = view_name);
-    log::info!("querying view=> {}", query);
+    tracing::info!("querying view=> {}", query);
 
     let row = mz_client::try_query_one(&client, &*query, Duration::from_secs(1)).await?;
     let count: i64 = row.get("count");
     if count as u64 == expected_total_records {
-        log::info!(
+        tracing::info!(
             "Found all {} records, done querying.",
             expected_total_records
         );

--- a/test/test-util/Cargo.toml
+++ b/test/test-util/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 anyhow = "1.0.52"
 chrono = { version = "0.4.0", default-features = false, features = ["clock", "std"] }
 kafka-util = { path = "../../src/kafka-util" }
-log = "0.4.13"
+tracing = "0.1.29"
 ore = { path = "../../src/ore" }
 rand = "0.8.4"
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "libz-static"] }

--- a/test/test-util/src/kafka/kafka_client.rs
+++ b/test/test-util/src/kafka/kafka_client.rs
@@ -13,13 +13,14 @@ use std::time::Duration;
 
 use anyhow::Context;
 use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, TopicReplication};
-use rdkafka::client::DefaultClientContext;
 use rdkafka::config::ClientConfig;
 use rdkafka::error::KafkaError;
 use rdkafka::producer::{DeliveryFuture, FutureProducer, FutureRecord};
 
+use kafka_util::client::MzClientContext;
+
 pub struct KafkaClient {
-    producer: FutureProducer<DefaultClientContext>,
+    producer: FutureProducer<MzClientContext>,
     kafka_url: String,
 }
 
@@ -36,7 +37,7 @@ impl KafkaClient {
             config.set(*key, *val);
         }
 
-        let producer: FutureProducer = config.create()?;
+        let producer = config.create_with_context(MzClientContext)?;
 
         Ok(KafkaClient {
             producer,

--- a/test/test-util/src/mz_client.rs
+++ b/test/test-util/src/mz_client.rs
@@ -66,7 +66,7 @@ pub async fn try_query_one(mz_client: &Client, query: &str, delay: Duration) -> 
 /// instead of failing.
 fn check_error(e: Error) -> Result<()> {
     if e.code() == Some(&SqlState::SQL_STATEMENT_NOT_YET_COMPLETE) {
-        log::info!("Error querying, will try again... {}", e.to_string());
+        tracing::info!("Error querying, will try again... {}", e.to_string());
         Ok(())
     } else {
         Err(anyhow::Error::from(e))
@@ -78,7 +78,7 @@ async fn delay_for(elapsed: Duration, delay: Duration) {
     if elapsed < delay {
         time::sleep(delay - elapsed).await;
     } else {
-        log::info!(
+        tracing::info!(
             "Expected to query for records in {:#?}, took {:#?}",
             delay,
             elapsed
@@ -99,21 +99,21 @@ pub async fn show_sources(mz_client: &Client) -> Result<Vec<String>> {
 /// Delete a source and all dependent views, if the source exists
 pub async fn drop_source(mz_client: &Client, name: &str) -> Result<()> {
     let q = format!("DROP SOURCE IF EXISTS {} CASCADE", name);
-    log::debug!("deleting source=> {}", q);
+    tracing::debug!("deleting source=> {}", q);
     mz_client.execute(&*q, &[]).await?;
     Ok(())
 }
 
 /// Run PostgreSQL's `execute` function
 pub async fn execute(mz_client: &Client, query: &str) -> Result<u64> {
-    log::debug!("exec=> {}", query);
+    tracing::debug!("exec=> {}", query);
     Ok(mz_client.execute(query, &[]).await?)
 }
 
 /// Delete an index
 pub async fn drop_index(mz_client: &Client, name: &str) -> Result<()> {
     let q = format!("DROP INDEX {}", name);
-    log::debug!("deleting index=> {}", q);
+    tracing::debug!("deleting index=> {}", q);
     mz_client.execute(&*q, &[]).await?;
     Ok(())
 }


### PR DESCRIPTION
This pr changes all out `log` callsites to use native `tracing` macros instead. See #9992 for more info.

In addition, it ensure that kafka logging uses tracing as well, and also add

quick benchmark:
```
$ docker volume rm feature-benchmark_mzdata
feature-benchmark_mzdata
NAME                      |    THIS     |    OTHER    |  Regression?  | 'THIS' is:
----------------------------------------------------------------------------------------------------
KafkaUpsertUnique         |       1.510 |       1.522 |      no       | 0.8 pct   faster
```

example new log line, with the improved formatting:
<pre>
2022-01-10T21:27:24.238430Z ERROR dataflow::render::upsert: Encountered empty key for value <i>new_value</i>=Some(Ok(Row{[String("geese")]}))
</pre>


### Motivation

   * This PR refactors existing code.
See above

### Tips for reviewer

I highly recommend you look at each commit separately to understand what each one does.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
  - this pr doesn't have any user-facing changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/9990)
<!-- Reviewable:end -->
