### PR TITLE
doc/user: Polish release notes for v0.16.0

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -126,15 +126,6 @@ changes that have not yet been documented.
   [`interval`] literal, fall back to choosing `bool` or `interval`,
   respectively.
 
-- **Breaking change.** Return an error when [`extract`](/sql/functions/extract/)
-  is called with a [`time`] value but a date-related field (e.g., `YEAR`).
-
-  Previous versions of Materialize would incorrectly return `0` in these cases.
-  The new behavior matches PostgreSQL.
-
-- **Breaking change.** Disallow the string `'sNaN'` (in any casing) as a valid
-  [`numeric`] value.
-
 - Support [subscripting `jsonb` values](/sql/types/jsonb/#subscripting) to
   retrieve array elements or object values, as in:
 
@@ -147,15 +138,6 @@ changes that have not yet been documented.
    2
   ```
 
-- Add the `array_remove` and `list_remove` functions.
-
-- Allow `SET NAMES ____` special case as per: https://www.postgresql.org/docs/9.1/sql-set.html.
-  Errors if the value is not `"UTF8"`.
-
-- Correctly parse `SET SCHEMA ____` special case as per: https://www.postgresql.org/docs/9.1/sql-set.html,
-  but it remains unsettable.
-
-- Fix a crash when a condition of a `CASE` statement evaluates to an error. {{% gh 9995 %}}
 
 - Fix a bug where using a `ROWS FROM` clause with an alias in a view would cause
   Materialize to fail to reboot {{% gh 10008 %}}.
@@ -166,6 +148,32 @@ Only add new release notes above this line.
 The presence of this comment ensures that PRs that are alive across a release
 boundary don't silently merge their release notes into the wrong place.
 {{</ comment >}}
+
+{{% version-header v0.16.0 %}}
+
+- **Breaking change.** Return an error when [`extract`](/sql/functions/extract/)
+  is called with a [`time`] value but a date-related field (e.g., `YEAR`)
+  {{% gh 9839 %}}.
+
+  Previous versions of Materialize would incorrectly return `0` in these cases.
+  The new behavior matches PostgreSQL.
+
+- **Breaking change.** Disallow the string `'sNaN'` (in any casing) as a valid
+  [`numeric`] value.
+
+- Add the [`array_remove`](https://materialize.com/docs/sql/functions/#array-func)
+  and [`list_remove`](https://materialize.com/docs/sql/functions/#list-func)
+  functions.
+
+- Support the special PostgreSQL syntax
+  [`SET NAMES` and `SET SCHEMA`](https://www.postgresql.org/docs/14/sql-set.html#id-1.9.3.173.6)
+  for setting the `client_encoding` and `search_path` parameters, respectively.
+
+- Fix a crash when a condition of a `CASE` statement evaluates to an error. {{% gh 9995 %}}
+
+- Fix a crash in the optimizer when the branches of a `CASE` statement involved
+  record types whose fields had differing nullability {{% gh 9931 %}}.
+
 
 {{% version-header v0.15.0 %}}
 
@@ -207,7 +215,7 @@ boundary don't silently merge their release notes into the wrong place.
   [`jsonb`](/sql/types/jsonb) {{% gh 5919 9669 %}}. Previously, JSON numbers
   were stored as either [`int8`](/sql/types/int8) or
   [`float8`](/sql/types/float8) values; now they are always stored as
-  [`numeric`](/sql/types/numeric) values.
+  [`numeric`] values.
 
   The upshot is that the `jsonb` type has a wider range for integers but a
   smaller range for floats. We expect this to cause very little practical
@@ -218,7 +226,7 @@ boundary don't silently merge their release notes into the wrong place.
   because `t1.a` does not appear in the `GROUP BY` clause:
 
   ```sql
-  SELECT t1.a FROM t1 JOIN t2 ON t1.a = t2.a GROUP BY t2.a
+  SELECT t1.a FROM t1 JOIN t2 ON t1.a = t2.a GROUP BY t2.a;
   ```
 
   Previous versions of Materialize permitted this query by noticing that the
@@ -229,7 +237,7 @@ boundary don't silently merge their release notes into the wrong place.
   BY` clause and the `SELECT` list:
 
   ```sql
-  SELECT t1.a FROM t1 JOIN t2 ON t1.a = t2.a GROUP BY t1.a
+  SELECT t1.a FROM t1 JOIN t2 ON t1.a = t2.a GROUP BY t1.a;
   ```
 
 - **Breaking change.** When using an arbitrary expression in an `ORDER BY` or
@@ -957,7 +965,7 @@ a problem with PostgreSQL JDBC 42.3.0.
   To maintain the old behavior, explicitly set the timeout to `0s`, as in:
 
   ```sql
-  FETCH ... WITH (timeout = '0s')
+  FETCH ... WITH (timeout = '0s');
   ```
 
 - **Backwards-incompatible change.** Consider the following keywords to be fully
@@ -1359,7 +1367,7 @@ a problem with PostgreSQL JDBC 42.3.0.
   [Kafka sources](/sql/create-source/avro-kafka/), as in
 
   ```sql
-  CREATE SOURCE ... FROM KAFKA BROKER 'host1:9092,host2:9092' ...
+  CREATE SOURCE ... FROM KAFKA BROKER 'host1:9092,host2:9092' ...;
   ```
 
   is incorrectly prohibited in this version. This change was unintentional and
@@ -1410,14 +1418,14 @@ a problem with PostgreSQL JDBC 42.3.0.
     `SELECT` list that are formed from arbitrary expressions, as in:
 
     ```sql
-    SELECT a + 1, sum(b) FROM ... GROUP BY 1
+    SELECT a + 1, sum(b) FROM ... GROUP BY 1;
     ```
 
     Previously, Materialize only handled ordinal references to items that were
     simple column references, as in:
 
     ```sql
-    SELECT a, sum(b) FROM ... GROUP BY 1
+    SELECT a, sum(b) FROM ... GROUP BY 1;
     ```
 
 - Fix two PostgreSQL compatibility issues:
@@ -1548,7 +1556,7 @@ a problem with PostgreSQL JDBC 42.3.0.
   in a `SELECT` query, as in:
 
   ```sql
-  SELECT col1_alias, col2_alias FROM rel AS rel_alias (col1_alias, col2_alias)
+  SELECT col1_alias, col2_alias FROM rel AS rel_alias (col1_alias, col2_alias);
   ```
 
 - Add the [`abs`](/sql/functions/#numbers-func) function for the
@@ -1832,6 +1840,7 @@ a problem with PostgreSQL JDBC 42.3.0.
 [`interval`]: /sql/types/interval
 [`list`]: /sql/types/list/
 [`map`]: /sql/types/map/
+[`numeric`]: /sql/types/numeric
 [`oid`]: /sql/types/oid/
 [`real`]: /sql/types/float4
 [`pgcrypto`]: https://www.postgresql.org/docs/current/pgcrypto.html

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -111,7 +111,7 @@
 
     - signature: 'list_remove(l: listany, e: listelementany) -> listany'
       description: >-
-        '[Experimental](/cli/#experimental-mode)––Returns the list `l` without
+        [Experimental](/cli/#experimental-mode)––Returns the list `l` without
         any elements equal to the given value `e`. Comparisons are done using
         IS NOT DISTINCT FROM semantics, so it is possible to remove NULLs.
 


### PR DESCRIPTION
Migrating existing release notes under the appropriate release tag. Couldn't single out any other change in the list of PRs worth adding in.

Additionally:

- Added some missing semi-colons that were driving me insane;
- Corrected minor typo in the documentation of the new `list_remove` (in `doc/user/data/sql_funcs.yml`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/9993)
<!-- Reviewable:end -->
