### PR TITLE
mzcloud-cli catalog restore mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2800,7 +2800,7 @@ dependencies = [
 [[package]]
 name = "mzcloud"
 version = "1.0.0"
-source = "git+https://github.com/MaterializeInc/cloud-sdks#e2817663ab4c57daecb5ba61f34c6c190defbbd9"
+source = "git+https://github.com/MaterializeInc/cloud-sdks#b7886468ceb9e76d1c4b9e0b1b82a957ddd2b1c8"
 dependencies = [
  "reqwest",
  "serde",

--- a/src/mzcloud-cli/src/bin/mzcloud.rs
+++ b/src/mzcloud-cli/src/bin/mzcloud.rs
@@ -144,6 +144,10 @@ enum DeploymentsCommand {
         #[clap(long)]
         disable_user_indexes: Option<bool>,
 
+        /// Disable materialized entirely, for recovering from catalog backups.
+        #[clap(long, hide = true)]
+        catalog_restore_mode: Option<bool>,
+
         /// Extra arguments to provide to materialized.
         #[clap(long, allow_hyphen_values = true, multiple_values = true)]
         materialized_extra_args: Option<Vec<String>>,
@@ -179,6 +183,10 @@ enum DeploymentsCommand {
         /// Disable user-created indexes (used for debugging).
         #[clap(long)]
         disable_user_indexes: Option<bool>,
+
+        /// Disable materialized entirely, for recovering from catalog backups.
+        #[clap(long, hide = true)]
+        catalog_restore_mode: Option<bool>,
 
         /// Extra arguments to provide to materialized. Defaults to the
         /// currently set extra arguments.
@@ -304,6 +312,7 @@ async fn handle_deployment_operations(
             size,
             storage_mb,
             disable_user_indexes,
+            catalog_restore_mode,
             materialized_extra_args,
             mz_version,
             tailscale_auth_key,
@@ -316,6 +325,7 @@ async fn handle_deployment_operations(
                     size: size.map(Box::new),
                     storage_mb,
                     disable_user_indexes,
+                    catalog_restore_mode,
                     materialized_extra_args,
                     mz_version,
                     enable_tailscale: Some(tailscale_auth_key.is_some()),
@@ -334,6 +344,7 @@ async fn handle_deployment_operations(
             name,
             size,
             disable_user_indexes,
+            catalog_restore_mode,
             materialized_extra_args,
             mz_version,
             remove_tailscale,
@@ -352,6 +363,7 @@ async fn handle_deployment_operations(
                     size: size.map(Box::new),
                     storage_mb: None,
                     disable_user_indexes,
+                    catalog_restore_mode,
                     materialized_extra_args,
                     mz_version,
                     enable_tailscale,


### PR DESCRIPTION
Add new hidden option to enter catalog restore mode, which completely disables materialized for the cloud deployment, so that the pod still exists, but does not make any modifications to mzdata. This allows us to perform restores from the catalog backups.

This feature is useless and potentially confusing for end users, so it is hidden from the command line help.

### Motivation

  * This PR adds a known-desirable feature: https://github.com/MaterializeInc/cloud/issues/2056

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/9994)
<!-- Reviewable:end -->
