### PR TITLE
sql: prefer CCSR SSL options

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -110,10 +110,10 @@ changes that have not yet been documented.
 - Detect if the publication slot is missing from the upstream database and
   report an error when using PostgreSQL sources
 
-- For Kafka sources that include `FORMAT`-specific SSL `WITH` options
-  (`ssl_ca_location`, `ssl_key_location`, `ssl_certificate_location`), use said
-  options for Confluent Schema Registry connections instead of Kafka broker SSL
-  options.
+- Allow Confluent Schema Registry SSL `WITH` options
+  (`ssl_ca_location`, `ssl_key_location`, `ssl_certificate_location`),
+  which override the equivalent Kafka options in `CREATE SOURCE` statements,
+  when creating CSR clients.
 
 - **Breaking change.** When inferring a column name for a cast expression, fall
   back to choosing the name of the target type.

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -110,6 +110,11 @@ changes that have not yet been documented.
 - Detect if the publication slot is missing from the upstream database and
   report an error when using PostgreSQL sources
 
+- For Kafka sources that include `FORMAT`-specific SSL `WITH` options
+  (`ssl_ca_location`, `ssl_key_location`, `ssl_certificate_location`), use said
+  options for Confluent Schema Registry connections instead of Kafka broker SSL
+  options.
+
 - **Breaking change.** When inferring a column name for a cast expression, fall
   back to choosing the name of the target type.
 

--- a/doc/user/layouts/partials/create-source/connector/kafka/with-options.html
+++ b/doc/user/layouts/partials/create-source/connector/kafka/with-options.html
@@ -50,3 +50,13 @@ If you specify a source with an inline schemas you may still have records that a
 client that inlines a confluent schema registry ID at the beginning of each record. If
 `confluent_wire_format` is `false` then `materialized` will *not* validate that a well-formatted
 schema-id is present at the beginning of each record.
+
+#### Confluent Schema Registry Options
+
+Options for connecting to a Confluent Schema Registry. If these options are not provided, the SSL `WITH` options for the Kafka cluster (see above) are used.
+
+Field | Value | Description
+------|-------|------------
+`ssl_certificate_location` | `text` | The absolute path to your SSL certificate. Required for SSL client authentication.
+`ssl_key_location` | `text` | The absolute path to your SSL certificate's key. Required for SSL client authentication.
+`ssl_ca_location` | `text` | The absolute path to the certificate authority (CA) certificate. Used for both SSL client and server authentication.

--- a/src/sql/src/kafka_util.rs
+++ b/src/sql/src/kafka_util.rs
@@ -495,9 +495,11 @@ pub fn generate_ccsr_client_config(
 ) -> Result<ccsr::ClientConfig, anyhow::Error> {
     let mut client_config = ccsr::ClientConfig::new(csr_url);
 
+    // If provided, prefer SSL options from the schema registry configuration
     if let Some(ca_path) = match ccsr_options.get("ssl_ca_location") {
         Some(Value::String(path)) => Some(path),
-        _ => kafka_options.get("ssl.ca.location"),
+        Some(_) => { bail!("ssl_ca_location must be a string"); },
+        None => kafka_options.get("ssl.ca.location"),
     } {
         let mut ca_buf = Vec::new();
         File::open(ca_path)?.read_to_end(&mut ca_buf)?;
@@ -507,11 +509,13 @@ pub fn generate_ccsr_client_config(
 
     let key_path = match ccsr_options.get("ssl_key_location") {
         Some(Value::String(path)) => Some(path),
-        _ => kafka_options.get("ssl.key.location"),
+        Some(_) => { bail!("ssl_key_location must be a string"); },
+        None => kafka_options.get("ssl.key.location"),
     };
     let cert_path = match ccsr_options.get("ssl_certificate_location") {
         Some(Value::String(path)) => Some(path),
-        _ => kafka_options.get("ssl.certificate.location"),
+        Some(_) => { bail!("ssl_certificate_location must be a string"); },
+        None => kafka_options.get("ssl.certificate.location"),
     };
     match (key_path, cert_path) {
         (Some(key_path), Some(cert_path)) => {

--- a/src/sql/src/kafka_util.rs
+++ b/src/sql/src/kafka_util.rs
@@ -498,7 +498,9 @@ pub fn generate_ccsr_client_config(
     // If provided, prefer SSL options from the schema registry configuration
     if let Some(ca_path) = match ccsr_options.get("ssl_ca_location") {
         Some(Value::String(path)) => Some(path),
-        Some(_) => { bail!("ssl_ca_location must be a string"); },
+        Some(_) => {
+            bail!("ssl_ca_location must be a string");
+        }
         None => kafka_options.get("ssl.ca.location"),
     } {
         let mut ca_buf = Vec::new();
@@ -509,12 +511,16 @@ pub fn generate_ccsr_client_config(
 
     let key_path = match ccsr_options.get("ssl_key_location") {
         Some(Value::String(path)) => Some(path),
-        Some(_) => { bail!("ssl_key_location must be a string"); },
+        Some(_) => {
+            bail!("ssl_key_location must be a string");
+        }
         None => kafka_options.get("ssl.key.location"),
     };
     let cert_path = match ccsr_options.get("ssl_certificate_location") {
         Some(Value::String(path)) => Some(path),
-        Some(_) => { bail!("ssl_certificate_location must be a string"); },
+        Some(_) => {
+            bail!("ssl_certificate_location must be a string");
+        }
         None => kafka_options.get("ssl.certificate.location"),
     };
     match (key_path, cert_path) {

--- a/src/sql/src/kafka_util.rs
+++ b/src/sql/src/kafka_util.rs
@@ -495,15 +495,24 @@ pub fn generate_ccsr_client_config(
 ) -> Result<ccsr::ClientConfig, anyhow::Error> {
     let mut client_config = ccsr::ClientConfig::new(csr_url);
 
-    if let Some(ca_path) = kafka_options.get("ssl.ca.location") {
+    if let Some(ca_path) = match ccsr_options.get("ssl_ca_location") {
+        Some(Value::String(path)) => Some(path),
+        _ => kafka_options.get("ssl.ca.location"),
+    } {
         let mut ca_buf = Vec::new();
         File::open(ca_path)?.read_to_end(&mut ca_buf)?;
         let cert = Certificate::from_pem(&ca_buf)?;
         client_config = client_config.add_root_certificate(cert);
     }
 
-    let key_path = kafka_options.get("ssl.key.location");
-    let cert_path = kafka_options.get("ssl.certificate.location");
+    let key_path = match ccsr_options.get("ssl_key_location") {
+        Some(Value::String(path)) => Some(path),
+        _ => kafka_options.get("ssl.key.location"),
+    };
+    let cert_path = match ccsr_options.get("ssl_certificate_location") {
+        Some(Value::String(path)) => Some(path),
+        _ => kafka_options.get("ssl.certificate.location"),
+    };
     match (key_path, cert_path) {
         (Some(key_path), Some(cert_path)) => {
             // `reqwest` expects identity `pem` files to contain one key and

--- a/test/kafka-ssl/multi.td
+++ b/test/kafka-ssl/multi.td
@@ -1,0 +1,66 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set schema={
+    "type": "record",
+    "name": "envelope",
+    "fields": [
+      {
+        "name": "before",
+        "type": [
+          {
+            "name": "row",
+            "type": "record",
+            "fields": [
+              {"name": "a", "type": "long"}
+            ]
+          },
+          "null"
+        ]
+      },
+      { "name": "after", "type": ["row", "null"] }
+    ]
+  }
+
+$ kafka-create-topic topic=data
+
+$ kafka-ingest format=avro topic=data schema=${schema} publish=true timestamp=1
+{"before": null, "after": {"row": {"a": 1}}}
+
+> CREATE MATERIALIZED SOURCE data
+  FROM KAFKA BROKER 'kafka:9092' TOPIC 'testdrive-data-${testdrive.seed}'
+  WITH (
+      security_protocol = 'SSL',
+      ssl_key_location = '/share/secrets/materialized-kafka.key',
+      ssl_certificate_location = '/share/secrets/materialized-kafka.crt',
+      ssl_ca_location = '/share/secrets/ca.crt',
+      ssl_key_password = 'mzmzmz'
+  )
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  WITH (
+      security_protocol = 'SSL',
+      ssl_key_location = '/share/secrets/materialized-sr.key',
+      ssl_certificate_location = '/share/secrets/materialized-sr.crt',
+      ssl_ca_location = '/share/secrets/ca.crt'
+  )
+  ENVELOPE DEBEZIUM
+
+> SELECT * FROM data
+a
+---
+1
+
+$ kafka-ingest format=avro topic=data schema=${schema} timestamp=2
+{"before": null, "after": {"row": {"a": 2}}}
+
+> SELECT * FROM data
+a
+---
+1
+2

--- a/test/test-certs/create-certs.sh
+++ b/test/test-certs/create-certs.sh
@@ -28,7 +28,7 @@ openssl req \
     -passin pass:$SSL_SECRET \
     -passout pass:$SSL_SECRET
 
-# Create CA
+# Create an alternative CA, used for certain tests
 openssl req \
     -x509 \
     -days 36500 \
@@ -128,7 +128,7 @@ do
 
 done
 
-# Create truststore and import CA cert
+# Create truststore and import a cert using the alternative CA
 keytool \
     -keystore secrets/kafka.truststore.jks \
     -alias Selective \
@@ -136,7 +136,7 @@ keytool \
     -file secrets/materialized-kafka.crt \
     -noprompt -storepass $SSL_SECRET -keypass $SSL_SECRET
 
-# Create truststore and import CA cert
+# Create truststore and import a cert using the alternative CA
 keytool \
     -keystore secrets/schema-registry.truststore.jks \
     -alias Selective \

--- a/test/test-certs/create-certs.sh
+++ b/test/test-certs/create-certs.sh
@@ -28,8 +28,32 @@ openssl req \
     -passin pass:$SSL_SECRET \
     -passout pass:$SSL_SECRET
 
-for i in kafka kafka1 kafka2 schema-registry materialized producer postgres certuser
+# Create CA
+openssl req \
+    -x509 \
+    -days 36500 \
+    -newkey rsa:4096 \
+    -keyout secrets/ca-selective.key \
+    -out secrets/ca-selective.crt \
+    -sha256 \
+    -batch \
+    -subj "/CN=MZ RSA CA" \
+    -passin pass:$SSL_SECRET \
+    -passout pass:$SSL_SECRET
+
+
+for i in kafka kafka1 kafka2 schema-registry materialized producer postgres certuser materialized-kafka materialized-sr
 do
+
+    if [ "$i" = "materialized-kafka" ] || [ "$i" = "materialized-sr" ];
+    then
+        ca="ca-selective"
+        cn="materialized"
+    else
+        ca="ca"
+        cn="$i"
+    fi
+
     # Create key & csr
     openssl req -nodes \
         -newkey rsa:2048 \
@@ -37,14 +61,14 @@ do
         -out tmp/$i.csr \
         -sha256 \
         -batch \
-        -subj "/CN=$i" \
+        -subj "/CN=$cn" \
         -passin pass:$SSL_SECRET \
         -passout pass:$SSL_SECRET \
 
     # Sign the CSR.
     openssl x509 -req \
-        -CA secrets/ca.crt \
-        -CAkey secrets/ca.key \
+        -CA secrets/"$ca".crt \
+        -CAkey secrets/"$ca".key \
         -in tmp/$i.csr \
         -out secrets/$i.crt \
         -sha256 \
@@ -59,7 +83,7 @@ do
         -name $i \
         -inkey secrets/$i.key \
         -passin pass:$SSL_SECRET \
-        -certfile secrets/ca.crt \
+        -certfile secrets/"$ca".crt \
         -out tmp/$i.p12 \
         -passout pass:$SSL_SECRET
 
@@ -73,7 +97,7 @@ do
         -name $i \
         -inkey secrets/$i.key \
         -passin pass:$SSL_SECRET \
-        -certfile secrets/ca.crt \
+        -certfile secrets/"$ca".crt \
         -out secrets/$i.p12 \
         -passout pass:$SSL_SECRET
 
@@ -90,7 +114,7 @@ do
     keytool \
         -alias CARoot \
         -import \
-        -file secrets/ca.crt \
+        -file secrets/"$ca".crt \
         -keystore secrets/$i.keystore.jks \
         -noprompt -storepass $SSL_SECRET -keypass $SSL_SECRET
 
@@ -99,10 +123,27 @@ do
         -keystore secrets/$i.truststore.jks \
         -alias CARoot \
         -import \
-        -file secrets/ca.crt \
+        -file secrets/"$ca".crt \
         -noprompt -storepass $SSL_SECRET -keypass $SSL_SECRET
 
 done
+
+# Create truststore and import CA cert
+keytool \
+    -keystore secrets/kafka.truststore.jks \
+    -alias Selective \
+    -import \
+    -file secrets/materialized-kafka.crt \
+    -noprompt -storepass $SSL_SECRET -keypass $SSL_SECRET
+
+# Create truststore and import CA cert
+keytool \
+    -keystore secrets/schema-registry.truststore.jks \
+    -alias Selective \
+    -import \
+    -file secrets/materialized-sr.crt \
+    -noprompt -storepass $SSL_SECRET -keypass $SSL_SECRET
+
 
 echo $SSL_SECRET > secrets/cert_creds
 


### PR DESCRIPTION
When `KEY`/`VALUE` `FORMAT` options are provided (i.e., a `CREATE SOURCE...` command includes `... WITH (...` for either `KEY` or `VALUE` formats), prefer using the SSL options from those additional "with_options."

This is necessary in situations where the Kafka broker and Schema Registry have different CA certificates, private keys and/or SSL certs.

Example of previously failing `CREATE SOURCE`:
```sql
CREATE SOURCE amazon_order FROM KAFKA BROKER 'REDACTED.byoc.vectorized.cloud:31642' topic 'postgres.public.REDACTED' WITH (
  client_id = 'MaterializeTest',
  security_protocol = 'sasl_ssl',
  sasl_mechanisms = 'SCRAM-SHA-256',
  sasl_username = 'REDACTED',
  sasl_password = 'REDACTED',
  ssl_key_location = '/secrets/redpanda/proxy-api-client-private.key',
  ssl_certificate_location = '/secrets/redpanda/proxy-api-client.crt',
  ssl_ca_location = '/secrets/redpanda/api-ca.crt'
)
KEY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'https://REDACTED.byoc.vectorized.cloud:32002' WITH (
  security_protocol = 'SSL',
  ssl_key_location = '/secrets/redpanda/schema-registry-client-private.key',
  ssl_certificate_location = '/secrets/redpanda/schema-registry-client.crt',
  ssl_ca_location = '/secrets/redpanda/schema-registry-ca.crt'
)
VALUE FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'https://REDACTED.byoc.vectorized.cloud:32002' WITH (
  security_protocol = 'SSL',
  ssl_key_location = '/secrets/redpanda/schema-registry-client-private.key',
  ssl_certificate_location = '/secrets/redpanda/schema-registry-client.crt',
  ssl_ca_location = '/secrets/redpanda/schema-registry-ca.crt'
)
ENVELOPE DEBEZIUM;
```

I have yet to add tests in this patch.

### Motivation

This pull request resolves an issue that blocked the adoption of Materialize in environments where the Kafka broker and Schema Registry use different SSL options, as is the case with Redpanda BYOC[1].

### Tips for reviewer

Please provide suggestions (I'm a Rust newbie)!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).

[1] [Example](https://materializecommunity.slack.com/archives/C015KDVS7EV/p1641488620011800)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/9997)
<!-- Reviewable:end -->
