### PR TITLE
pg-cdc: Fix default argument and usage

### DIFF
--- a/test/pg-cdc/mzcompose.py
+++ b/test/pg-cdc/mzcompose.py
@@ -22,7 +22,7 @@ def workflow_pg_cdc(c: Composition, parser: WorkflowArgumentParser) -> None:
     parser.add_argument(
         "filter",
         nargs="*",
-        default="*.td",
+        default=["*.td"],
         help="limit to only the files matching filter",
     )
     args = parser.parse_args()
@@ -30,4 +30,4 @@ def workflow_pg_cdc(c: Composition, parser: WorkflowArgumentParser) -> None:
     c.up("materialized", "test-certs", "testdrive-svc", "postgres")
     c.wait_for_materialized()
     c.wait_for_postgres()
-    c.run("testdrive-svc", args.filter)
+    c.run("testdrive-svc", *args.filter)


### PR DESCRIPTION
nargs=* always creates a list of arguments with Python's ArgumentParser

### Motivation


* This PR fixes a previously unreported bug.

  Passing any arguments to mzcompose run (e.g. `./mzcompose run pg-cdc
  my-test-file.td`, instead of plain `./mzcompose run pg-cdc`) caused an
  exception.

### Checklist

- [n/a] This PR has adequate test coverage / QA involvement has been duly considered.
- [n/a] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/10002)
<!-- Reviewable:end -->
