### PR TITLE
Expr: fix crash when case has error condition

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -124,6 +124,8 @@ changes that have not yet been documented.
 - Correctly parse `SET SCHEMA ____` special case as per: https://www.postgresql.org/docs/9.1/sql-set.html,
   but it remains unsettable.
 
+- Fix a crash when a condition of a `CASE` statement evaluates to an error. {{% gh 9995 %}}
+
 {{< comment >}}
 Only add new release notes above this line.
 

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -582,7 +582,14 @@ impl MirScalarExpr {
                             match literal {
                                 Ok(Datum::True) => *e = then.take(),
                                 Ok(Datum::False) | Ok(Datum::Null) => *e = els.take(),
-                                Err(_) => *e = cond.take(),
+                                Err(err) => {
+                                    *e = MirScalarExpr::Literal(
+                                        Err(err.clone()),
+                                        then.typ(relation_type)
+                                            .union(&els.typ(relation_type))
+                                            .unwrap(),
+                                    )
+                                }
                                 _ => unreachable!(),
                             }
                         } else if then == els {

--- a/src/expr/tests/test_runner.rs
+++ b/src/expr/tests/test_runner.rs
@@ -21,7 +21,16 @@ mod test {
         let mut scalar: MirScalarExpr =
             deserialize(&mut input_stream, "MirScalarExpr", &RTI, &mut ctx)?;
         let typ: RelationType = deserialize(&mut input_stream, "RelationType", &RTI, &mut ctx)?;
+        let before = scalar.typ(&typ);
         scalar.reduce(&typ);
+        let after = scalar.typ(&typ);
+        // Verify that `reduce` did not change the type of the scalar.
+        if before.scalar_type != after.scalar_type {
+            return Err(format!(
+                "FAIL: Type of scalar has changed:\nbefore: {:?}\nafter: {:?}\n",
+                before, after
+            ));
+        }
         Ok(scalar)
     }
 

--- a/src/expr/tests/testdata/reduce
+++ b/src/expr/tests/testdata/reduce
@@ -318,7 +318,7 @@ reduce
     (call_variadic coalesce
         [
             (call_variadic (record_create ["f1" "f2"]) [#0 #1])
-            (call_variadic (record_create ["f1" "f2"]) [null null])
+            (call_variadic (record_create ["f1" "f2"]) [(null int32) (null int32)])
         ]
     )
 )
@@ -515,6 +515,25 @@ reduce
 [bool]
 ----
 #0
+
+### Regression test for #9995.
+### The inner if statement can be replaced by its `condition`, but we must
+### ensure that we keep the type of the `then` and `els` clauses.
+### The type of the error should be int32 instead of bool.
+
+reduce
+(if
+    (call_binary eq #0 1)
+    1
+    (if
+        (call_binary eq #0 (call_binary div_int64 1 0))
+        1
+        1
+    )
+)
+[int64]
+----
+if (#0 = 1) then {1} else {(err: division by zero)}
 
 ## undistribute_and/or works despite multiple copies of the same expression in
 ## the intersection


### PR DESCRIPTION
### Motivation

Closes #9995. See https://github.com/MaterializeInc/materialize/issues/9995#issuecomment-1010179834 for the explanation of the problem. 

To catch type inconsistency problems in the future, the unit test runner for `MirScalarExpr::reduce` now checks whether the expression has the same type before and after running `MirScalarExpr::reduce`.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
