### PR TITLE
sql-parser: correct roundtripping of aliased ROWS FROM clauses

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -154,6 +154,9 @@ changes that have not yet been documented.
 
 - Fix a crash when a condition of a `CASE` statement evaluates to an error. {{% gh 9995 %}}
 
+- Fix a bug where using a `ROWS FROM` clause with an alias in a view would cause
+  Materialize to fail to reboot {{% gh 10008 %}}.
+
 {{< comment >}}
 Only add new release notes above this line.
 

--- a/src/sql-parser/src/ast/defs/query.rs
+++ b/src/sql-parser/src/ast/defs/query.rs
@@ -463,11 +463,11 @@ impl<T: AstInfo> AstDisplay for TableFactor<T> {
             } => {
                 f.write_str("ROWS FROM(");
                 f.write_node(&display::comma_separated(functions));
+                f.write_str(")");
                 if let Some(alias) = alias {
                     f.write_str(" AS ");
                     f.write_node(alias);
                 }
-                f.write_str(")");
                 if *with_ordinality {
                     f.write_str(" WITH ORDINALITY");
                 }

--- a/src/sql-parser/src/ast/defs/query.rs
+++ b/src/sql-parser/src/ast/defs/query.rs
@@ -461,7 +461,7 @@ impl<T: AstInfo> AstDisplay for TableFactor<T> {
                 alias,
                 with_ordinality,
             } => {
-                f.write_str("ROWS FROM(");
+                f.write_str("ROWS FROM (");
                 f.write_node(&display::comma_separated(functions));
                 f.write_str(")");
                 if let Some(alias) = alias {

--- a/src/sql-parser/tests/testdata/select
+++ b/src/sql-parser/tests/testdata/select
@@ -1055,6 +1055,13 @@ SELECT * FROM ROWS FROM(generate_series(1, 2), generate_series(3, 5))
 Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: RowsFrom { functions: [TableFunction { name: UnresolvedObjectName([Ident("generate_series")]), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] } }, TableFunction { name: UnresolvedObjectName([Ident("generate_series")]), args: Args { args: [Value(Number("3")), Value(Number("5"))], order_by: [] } }], alias: None, with_ordinality: false }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
+SELECT * FROM LATERAL ROWS FROM (generate_series(1, 2), generate_series(3, 5)) AS alias
+----
+SELECT * FROM ROWS FROM(generate_series(1, 2), generate_series(3, 5)) AS alias
+=>
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: RowsFrom { functions: [TableFunction { name: UnresolvedObjectName([Ident("generate_series")]), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] } }, TableFunction { name: UnresolvedObjectName([Ident("generate_series")]), args: Args { args: [Value(Number("3")), Value(Number("5"))], order_by: [] } }], alias: Some(TableAlias { name: Ident("alias"), columns: [], strict: false }), with_ordinality: false }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
 SELECT * FROM generate_series(1, 2) WITH ORDINALITY
 ----
 SELECT * FROM generate_series(1, 2) WITH ORDINALITY

--- a/src/sql-parser/tests/testdata/select
+++ b/src/sql-parser/tests/testdata/select
@@ -1050,14 +1050,14 @@ Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct
 parse-statement
 SELECT * FROM LATERAL ROWS FROM (generate_series(1, 2), generate_series(3, 5))
 ----
-SELECT * FROM ROWS FROM(generate_series(1, 2), generate_series(3, 5))
+SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5))
 =>
 Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: RowsFrom { functions: [TableFunction { name: UnresolvedObjectName([Ident("generate_series")]), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] } }, TableFunction { name: UnresolvedObjectName([Ident("generate_series")]), args: Args { args: [Value(Number("3")), Value(Number("5"))], order_by: [] } }], alias: None, with_ordinality: false }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM LATERAL ROWS FROM (generate_series(1, 2), generate_series(3, 5)) AS alias
 ----
-SELECT * FROM ROWS FROM(generate_series(1, 2), generate_series(3, 5)) AS alias
+SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5)) AS alias
 =>
 Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: RowsFrom { functions: [TableFunction { name: UnresolvedObjectName([Ident("generate_series")]), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] } }, TableFunction { name: UnresolvedObjectName([Ident("generate_series")]), args: Args { args: [Value(Number("3")), Value(Number("5"))], order_by: [] } }], alias: Some(TableAlias { name: Ident("alias"), columns: [], strict: false }), with_ordinality: false }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
@@ -1078,14 +1078,14 @@ SELECT * FROM ROWS FROM (generate_series(1, 2) WITH ORDINALITY)
 parse-statement
 SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5)) WITH ORDINALITY
 ----
-SELECT * FROM ROWS FROM(generate_series(1, 2), generate_series(3, 5)) WITH ORDINALITY
+SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5)) WITH ORDINALITY
 =>
 Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: RowsFrom { functions: [TableFunction { name: UnresolvedObjectName([Ident("generate_series")]), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] } }, TableFunction { name: UnresolvedObjectName([Ident("generate_series")]), args: Args { args: [Value(Number("3")), Value(Number("5"))], order_by: [] } }], alias: None, with_ordinality: true }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5))
 ----
-SELECT * FROM ROWS FROM(generate_series(1, 2), generate_series(3, 5))
+SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5))
 =>
 Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: RowsFrom { functions: [TableFunction { name: UnresolvedObjectName([Ident("generate_series")]), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] } }, TableFunction { name: UnresolvedObjectName([Ident("generate_series")]), args: Args { args: [Value(Number("3")), Value(Number("5"))], order_by: [] } }], alias: None, with_ordinality: false }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 


### PR DESCRIPTION
The alias goes outside the parentheses.

Fix #10008.

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
