### PR TITLE
coord: move system catalog objects to their own timeline

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -157,6 +157,12 @@ changes that have not yet been documented.
 - Fix a bug where using a `ROWS FROM` clause with an alias in a view would cause
   Materialize to fail to reboot {{% gh 10008 %}}.
 
+- **Breaking change.** Change transaction and queriy properties for
+  (system catalog objects)[/sql/system-catalog]. They can no longer be
+  joined with user data. They no longer provide snapshot isolation but
+  instead always return the most recent state. They can always be used in
+  any transaction state or timeline.
+
 {{< comment >}}
 Only add new release notes above this line.
 

--- a/doc/user/content/sql/begin.md
+++ b/doc/user/content/sql/begin.md
@@ -53,3 +53,10 @@ The first `SELECT` in a transaction assumes that any object in that `SELECT` and
 If a later `SELECT` references another object, the transaction will fail.
 This can happen if the object is in a schema not referenced by the first `SELECT`.
 It can also happen if a new object (table, view, source, or index) was created after the transaction started, even if the new object is in the same schemas as the first `SELECT`.
+
+### System catalog
+
+Objects in the (system catalog)[/sql/system-catalog]:
+
+- can always be queried in any kind of transaction (read-only or write-only)
+- do not have snapshot isolation in transactions, but instead always use the most recent state

--- a/doc/user/content/sql/system-catalog.md
+++ b/doc/user/content/sql/system-catalog.md
@@ -46,6 +46,12 @@ the particulars of Materialize. For example, PostgreSQL has no notion of
 [sinks](/sql/create-sink), and therefore `pg_catalog` does not display
 information about the sinks available in a Materialize.
 
+Objects in the system catalog:
+
+- cannot be joined in a query with user objects
+- can be queried in any [transaction](/sql/begin) (including write-only)
+- do not have snapshot isolation in transactions, but instead always use the most recent state
+
 ## `mz_catalog`
 
 The following sections describe the available objects in the `mz_catalog`

--- a/doc/user/content/sql/timelines.md
+++ b/doc/user/content/sql/timelines.md
@@ -21,7 +21,8 @@ Users can specify custom timelines if they need to join sources that are by defa
 ## Default Timeline
 
 - [CDC sources][cdc-sources] default to their own individual timeline, and cannot be joined with any other source (even other CDC sources).
-- All other sources (and all tables) use the system timeline.
+- User sources user tables use the user timeline.
+- (System catalog)[/sql/system-catalog] objects use the catalog timeline.
 
 ## User Timelines
 
@@ -46,7 +47,7 @@ CREATE MATERIALIZED SOURCE source_2
 
 ## CDC Sources
 
-[CDC sources][cdc-sources] supports a `epoch_ms_timeline` `WITH` option that moves it to the system timeline, making the CDC source joinable to tables and other system timeline sources.
+[CDC sources][cdc-sources] supports a `epoch_ms_timeline` `WITH` option that moves it to the user timeline, making the CDC source joinable to tables and other user timeline sources.
 Users **must** ensure that the `time` field's units are milliseconds since the Unix epoch.
 Joining this source to other system time sources will result in query delays until the timestamps being received are close to wall-clock `now()`.
 

--- a/src/coord/tests/sql.rs
+++ b/src/coord/tests/sql.rs
@@ -58,6 +58,7 @@ async fn datadriven() {
                             conn_id: None,
                             depends_on: vec![],
                             persist: None,
+                            is_builtin: false,
                         }),
                     );
                     id += 1;

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -735,9 +735,14 @@ pub enum Compression {
 /// if we need to tell apart more kinds of sources.
 #[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub enum Timeline {
-    /// EpochMilliseconds means the timestamp is the number of milliseconds since
-    /// the Unix epoch.
-    EpochMilliseconds,
+    /// EpochMillisecondsUser means the timestamp is the number of milliseconds
+    /// since the Unix epoch, and the source was created by a user.
+    EpochMillisecondsUser,
+    /// EpochMillisecondsCatalog means the timestamp is the number of milliseconds
+    /// since the Unix epoch, and the source was created by the system. This isn't
+    /// called the System timeline to avoid complication with the term "system
+    /// time".
+    EpochMillisecondsCatalog,
     /// Counter means the timestamp starts at 1 and is incremented for each
     /// transaction. It holds the BYO source so different instantiations can be
     /// differentiated.

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -969,10 +969,10 @@ pub fn plan_create_source(
         match (&consistency, &envelope) {
             (_, SourceEnvelope::CdcV2) => match with_options.remove("epoch_ms_timeline") {
                 None => Timeline::External(name.to_string()),
-                Some(Value::Boolean(true)) => Timeline::EpochMilliseconds,
+                Some(Value::Boolean(true)) => Timeline::EpochMillisecondsUser,
                 Some(v) => bail!("unsupported epoch_ms_timeline value {}", v),
             },
-            (Consistency::RealTime, _) => Timeline::EpochMilliseconds,
+            (Consistency::RealTime, _) => Timeline::EpochMillisecondsUser,
             (Consistency::BringYourOwn(byo), _) => Timeline::Counter(byo.clone()),
         }
     };

--- a/test/sqllogictest/timedomain.slt
+++ b/test/sqllogictest/timedomain.slt
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+# Tests for timedomains and timelines.
+
 mode cockroach
 
 statement ok
@@ -16,21 +18,21 @@ CREATE TABLE t (i INT);
 simple
 BEGIN;
 SELECT row(1, 2);
-SELECT 1 FROM mz_types LIMIT 1;
+SELECT 1 FROM t LIMIT 1;
 ----
 COMPLETE 0
 (1,2)
 COMPLETE 1
-1
-COMPLETE 1
+COMPLETE 0
 
-# But we can only change timedomains once.
-query error Transactions can only reference objects in the same timedomain.
-SELECT 3 FROM pg_type LIMIT 1;
+# Even though system catalogs are in a different timeline, they can always be
+# queried.
+statement ok
+SELECT 3 FROM pg_type LIMIT 1
 
 # Referring to the timestamp prevents including sources later.
 simple
-ROLLBACK;
+COMMIT;
 BEGIN;
 SELECT mz_logical_timestamp();
 ----
@@ -40,26 +42,63 @@ COMPLETE 0
 COMPLETE 1
 
 query error Transactions can only reference objects in the same timedomain.
-SELECT 1 FROM mz_types LIMIT 1
+SELECT 1 FROM t LIMIT 1
 
 simple
 ROLLBACK;
 BEGIN;
-SELECT 1 FROM mz_types LIMIT 1;
+SELECT 1 FROM t LIMIT 1;
 -- Use a timestamp-independent statement here, which should not allow
 -- the timedomain to change because the transaction's previous statement
 -- established a timedomain.
 SELECT 2;
+COMMIT;
 ----
 COMPLETE 0
 COMPLETE 0
-1
-COMPLETE 1
+COMPLETE 0
 2
 COMPLETE 1
+COMPLETE 0
 
-query error Transactions can only reference objects in the same timedomain.
-SELECT 3 FROM pg_type LIMIT 1;
+# System tables cannot be joined with user tables.
+query error multiple timelines within one dataflow are not supported
+SELECT * FROM t, pg_type
+
+# System catalogs can be queried even in a write transaction.
+simple
+BEGIN;
+INSERT INTO t VALUES (1);
+SELECT 1 FROM pg_type LIMIT 1;
+COMMIT;
+----
+COMPLETE 0
+COMPLETE 1
+1
+COMPLETE 1
+COMPLETE 0
+
+# System catalogs don't provide snapshot isolation.
+simple conn=1
+BEGIN;
+SELECT 1 FROM t;
+SHOW TABLES;
+----
+COMPLETE 0
+1
+COMPLETE 1
+t
+COMPLETE 1
 
 statement ok
-ROLLBACK
+CREATE TABLE x (a INT)
+
+# New table is visible even though the transaction started before it existed.
+simple conn=1
+SHOW TABLES;
+COMMIT;
+----
+t
+x
+COMPLETE 2
+COMPLETE 0

--- a/test/sqllogictest/types.slt
+++ b/test/sqllogictest/types.slt
@@ -442,11 +442,10 @@ CREATE TABLE text_to_regproc (a text);
 statement ok
 INSERT INTO text_to_regproc VALUES (NULL), ('array_in');
 
-query I
+# This previously worked but we no longer allow joining catalog tables with
+# user tables. Keep this test to verify we the right thing if we revert that.
+query error multiple timelines within one dataflow are not supported
 SELECT a::regproc FROM text_to_regproc ORDER BY a
-----
-750
-NULL
 
 # Regression for 9194
 query I
@@ -918,11 +917,8 @@ CREATE TABLE text_to_regtype (a text);
 statement ok
 INSERT INTO text_to_regtype VALUES (NULL), ('date');
 
-query I
+query error multiple timelines within one dataflow are not supported
 SELECT a::regtype FROM text_to_regtype ORDER BY a
-----
-1082
-NULL
 
 # Regression for 9194
 query I
@@ -1015,11 +1011,8 @@ CREATE TABLE text_to_regclass (a text);
 statement ok
 INSERT INTO text_to_regclass VALUES (NULL), ('mz_tables');
 
-query T
+query error multiple timelines within one dataflow are not supported
 SELECT a::regclass::text FROM text_to_regclass ORDER BY a
-----
-mz_tables
-NULL
 
 # Regression for 9194
 query B

--- a/test/testdrive/tables.td
+++ b/test/testdrive/tables.td
@@ -120,7 +120,7 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
 # joining a table with a logging source selects some reasonable timestamp,
 # rather than e.g. blocking forever, or producing an error about being
 # unable to select a timestamp.
-> SELECT * FROM t CROSS JOIN mz_dataflow_operators LIMIT 0
+#> SELECT * FROM t CROSS JOIN mz_dataflow_operators LIMIT 0
 
 > DROP SOURCE data
 

--- a/test/testdrive/timelines.td
+++ b/test/testdrive/timelines.td
@@ -222,13 +222,15 @@ multiple timelines within one dataflow are not supported
 # System sources, tables, and logs should be joinable with eachother.
 > CREATE VIEW various_system (a, b, c, d, e, f, g, h, i, j, k, l, m) AS SELECT * FROM mz_catalog_names, mz_views, mz_source_info;
 
-# System things should be joinable only with system sources.
+# Catalog things should be joinable only with catalog sources.
 ! CREATE VIEW must_fail (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) AS SELECT * FROM mz_catalog_names, mz_views, mz_source_info, source_byo;
 multiple timelines within one dataflow are not supported
 ! CREATE VIEW must_fail (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) AS SELECT * FROM mz_catalog_names, mz_views, mz_source_info, source_cdcv2;
 multiple timelines within one dataflow are not supported
-> CREATE VIEW various_system_no_byo (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) AS SELECT * FROM mz_catalog_names, mz_views, mz_source_info, source_system;
-> CREATE VIEW various_system_table (a, b, c, d, e, f, g, h, i, j, k, l, m, n) AS SELECT * FROM mz_catalog_names, mz_views, mz_source_info, input_table;
+! CREATE VIEW various_system_no_byo (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) AS SELECT * FROM mz_catalog_names, mz_views, mz_source_info, source_system;
+multiple timelines within one dataflow are not supported
+! CREATE VIEW various_system_table (a, b, c, d, e, f, g, h, i, j, k, l, m, n) AS SELECT * FROM mz_catalog_names, mz_views, mz_source_info, input_table;
+multiple timelines within one dataflow are not supported
 
 # EXPLAIN should complain too.
 ! EXPLAIN SELECT * FROM source_system, source_byo;


### PR DESCRIPTION
Change the transaction guarantees for system catalog objects to remove
snapshot isolation and instead always return the latest state. This
allows them to skip all transaction machinery and always be runnable
in any transaction or timedomain. This unblocks a PGJDBC feature which
fetches type information for unknown types needed by some tools.

As a result, catalog tables are no longer joinable with user tables. We
believe this is an acceptable tradeoff because we gain the ability to
always query the catalog regardless of which timeline the transaction
is in. Even with some solution that, say, always included catalog tables
in all realtime timeline transactions, users with non-realtime timeline
data would not be able to use the catalog should their driver need that
(like PGJDBC).

### Motivation

  * This PR fixes a recognized bug: #9375, #9374

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
