### PR TITLE
Make a last-ditch effort to plan the arrangements necessary for a delta join during LIR planning

### DIFF
--- a/src/dataflow-types/src/plan/mod.rs
+++ b/src/dataflow-types/src/plan/mod.rs
@@ -406,7 +406,7 @@ impl Plan {
                     _ => return Err(()),
                 };
                 let mut required_arrangements = vec![HashSet::new(); inputs.len()];
-                // Delta joins should only be planned if a particular set of arrangements exist.
+                // Delta joins should only be planned if a particular set of arrangements exists.
                 // Empirically, we've found that there are sometimes bugs causing them to be planned
                 // anyway. If this is the case, we need to create the arrangements, so we do so here,
                 // and complain with an error message.


### PR DESCRIPTION
#9926 mitigated the specific crash described in #9921. However, it may still be the case that bugs in planning or optimization cause us to plan Delta Joins without having access to the expected set of arrangements.

In this case, we should complain loudly in the hopes that we can find out about this when it happens and fix the bugs, but at least we won't crash or produce wrong results.

### Motivation

  * This PR fixes a recognized bug: Fixes #9921 

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. @philip-stoev -- @wangandi 's change in #9926 already mitigated #9921, making it no longer reproduce, so I'm not sure what we can do to test this, if anything.

I've manually verified that this fixes the crash by running it on top of the commit just before #9926. 


- [N/A] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
