### PR TITLE
[kafka sink] Remove blocking tx calls from dataflow thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4937,7 +4937,6 @@ dependencies = [
 name = "timely-util"
 version = "0.0.0"
 dependencies = [
- "differential-dataflow",
  "futures-util",
  "timely",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1242,6 +1242,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "timely",
+ "timely-util",
  "tokio",
  "tokio-postgres",
  "tokio-util",
@@ -4930,6 +4931,15 @@ dependencies = [
  "timely_bytes",
  "timely_communication",
  "timely_logging",
+]
+
+[[package]]
+name = "timely-util"
+version = "0.0.0"
+dependencies = [
+ "futures-util",
+ "timely",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4937,6 +4937,7 @@ dependencies = [
 name = "timely-util"
 version = "0.0.0"
 dependencies = [
+ "differential-dataflow",
  "futures-util",
  "timely",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ members = [
     "src/sql",
     "src/sqllogictest",
     "src/testdrive",
+    "src/timely-util",
     "src/transform",
     "src/walkabout",
     "test/metabase/smoketest",

--- a/src/dataflow/Cargo.toml
+++ b/src/dataflow/Cargo.toml
@@ -54,6 +54,7 @@ serde = { version = "1.0.133", features = ["derive"] }
 serde_json = "1.0.74"
 tempfile = "3.2.0"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
+timely-util = { path = "../timely-util" }
 tokio = { version = "1.15.0", features = ["fs", "rt", "sync"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", branch = "mz-0.7.2" }
 tokio-util = { version = "0.6.9", features = ["codec", "io"] }

--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -746,7 +746,9 @@ where
 
     builder.build_async(
         stream.scope(),
-        async_op!(|_initial_capabilities, frontier| {
+        async_op!(|_initial_capabilities, frontiers| {
+            let frontier = frontiers[0].borrow();
+
             if s.shutdown_flag.load(Ordering::SeqCst) {
                 debug!("shutting down sink: {}", &s.name);
                 // Indicate that the sink is closed to everyone else who

--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -746,10 +746,7 @@ where
 
     builder.build_async(
         stream.scope(),
-        async_op!(|_initial_capabilities, frontiers| {
-            let frontiers_refcell = frontiers.borrow();
-            let frontier = frontiers_refcell[0].borrow();
-
+        async_op!(|_initial_capabilities, frontier| {
             if s.shutdown_flag.load(Ordering::SeqCst) {
                 debug!("shutting down sink: {}", &s.name);
                 // Indicate that the sink is closed to everyone else who

--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -19,17 +19,16 @@ use std::time::Duration;
 use differential_dataflow::{AsCollection, Collection, Hashable};
 use interchange::json::JsonEncoder;
 use itertools::Itertools;
-use ore::metrics::{CounterVecExt, DeleteOnDropCounter, DeleteOnDropGauge, GaugeVecExt};
 use rdkafka::client::ClientContext;
 use rdkafka::config::ClientConfig;
-use rdkafka::error::{KafkaError, RDKafkaErrorCode};
+use rdkafka::error::{KafkaError, KafkaResult, RDKafkaErrorCode};
 use rdkafka::message::{Message, ToBytes};
 use rdkafka::producer::Producer;
 use rdkafka::producer::{BaseRecord, DeliveryResult, ProducerContext, ThreadedProducer};
 use timely::dataflow::channels::pact::Exchange;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
-use timely::dataflow::operators::generic::{FrontieredInputHandle, InputHandle, OutputHandle};
+use timely::dataflow::operators::generic::{InputHandle, OutputHandle};
 use timely::dataflow::operators::{Capability, Map};
 use timely::dataflow::{Scope, Stream};
 use timely::progress::frontier::AntichainRef;
@@ -45,7 +44,11 @@ use interchange::avro::{self, AvroEncoder, AvroSchemaGenerator};
 use interchange::encode::Encode;
 use kafka_util::client::MzClientContext;
 use ore::cast::CastFrom;
+use ore::metrics::{CounterVecExt, DeleteOnDropCounter, DeleteOnDropGauge, GaugeVecExt};
 use repr::{Datum, Diff, RelationDesc, Row, Timestamp};
+use timely_util::async_op;
+use timely_util::operators_async_ext::OperatorBuilderExt;
+use tokio::task;
 
 use super::{KafkaBaseMetrics, SinkBaseMetrics};
 use crate::render::sinks::SinkRender;
@@ -256,7 +259,7 @@ struct KafkaSinkState {
     topic_prefix: String,
     shutdown_flag: Arc<AtomicBool>,
     metrics: Arc<SinkMetrics>,
-    producer: ThreadedProducer<SinkProducerContext>,
+    producer: Arc<ThreadedProducer<SinkProducerContext>>,
     activator: timely::scheduling::Activator,
     txn_timeout: Duration,
     transactional: bool,
@@ -301,12 +304,14 @@ impl KafkaSinkState {
             &worker_id,
         ));
 
-        let producer = config
-            .create_with_context::<_, ThreadedProducer<_>>(SinkProducerContext::new(
-                Arc::clone(&metrics),
-                Arc::clone(&shutdown_flag),
-            ))
-            .expect("creating kafka producer for Kafka sink failed");
+        let producer = Arc::new(
+            config
+                .create_with_context::<_, ThreadedProducer<_>>(SinkProducerContext::new(
+                    Arc::clone(&metrics),
+                    Arc::clone(&shutdown_flag),
+                ))
+                .expect("creating kafka producer for Kafka sink failed"),
+        );
 
         KafkaSinkState {
             name: sink_name,
@@ -402,7 +407,35 @@ impl KafkaSinkState {
         }
     }
 
-    fn send<K, P>(&self, record: BaseRecord<K, P>) -> Result<(), bool>
+    async fn init_transactions(&self, timeout: Duration) -> KafkaResult<()> {
+        let self_producer = Arc::clone(&self.producer);
+        task::spawn_blocking(move || self_producer.init_transactions(timeout))
+            .await
+            .unwrap_or(Err(KafkaError::Canceled))
+    }
+
+    async fn begin_transaction(&self) -> KafkaResult<()> {
+        let self_producer = Arc::clone(&self.producer);
+        task::spawn_blocking(move || self_producer.begin_transaction())
+            .await
+            .unwrap_or(Err(KafkaError::Canceled))
+    }
+
+    async fn commit_transaction(&self, timeout: Duration) -> KafkaResult<()> {
+        let self_producer = Arc::clone(&self.producer);
+        task::spawn_blocking(move || self_producer.commit_transaction(timeout))
+            .await
+            .unwrap_or(Err(KafkaError::Canceled))
+    }
+
+    async fn abort_transaction(&self, timeout: Duration) -> KafkaResult<()> {
+        let self_producer = Arc::clone(&self.producer);
+        task::spawn_blocking(move || self_producer.abort_transaction(timeout))
+            .await
+            .unwrap_or(Err(KafkaError::Canceled))
+    }
+
+    fn send<'a, K, P>(&self, record: BaseRecord<'a, K, P>) -> Result<(), bool>
     where
         K: ToBytes + ?Sized,
         P: ToBytes + ?Sized,
@@ -484,9 +517,9 @@ impl KafkaSinkState {
     /// *NOTE*: `END` records will only be emitted when
     /// `KafkaSinkConnector.consistency` points to a consistency topic. The
     /// write frontier will be advanced regardless.
-    fn maybe_emit_progress(
+    async fn maybe_emit_progress<'a>(
         &mut self,
-        input_frontier: AntichainRef<Timestamp>,
+        input_frontier: AntichainRef<'a, Timestamp>,
     ) -> Result<(), anyhow::Error> {
         // This only looks at the first entry of the antichain.
         // If we ever have multi-dimensional time, this is not correct
@@ -512,14 +545,14 @@ impl KafkaSinkState {
                 // record the write frontier in the consistency topic.
                 if self.consistency.is_some() {
                     if self.transactional {
-                        self.producer.begin_transaction()?
+                        self.begin_transaction().await?
                     }
 
                     self.send_consistency_record(&min_frontier.to_string(), "END", None)
                         .map_err(|_e| anyhow::anyhow!("Error sending write frontier update."))?;
 
                     if self.transactional {
-                        self.producer.commit_transaction(self.txn_timeout)?
+                        self.commit_transaction(self.txn_timeout).await?
                     }
                 }
                 self.latest_progress_ts = min_frontier;
@@ -707,290 +740,287 @@ where
     // our internal state after the send loop
     let mut progress_update = None;
 
-    let mut sink_logic = move |input: &mut FrontieredInputHandle<
-        _,
-        ((Option<Vec<u8>>, Option<Vec<u8>>), Timestamp, Diff),
-        _,
-    >| {
-        if s.shutdown_flag.load(Ordering::SeqCst) {
-            debug!("shutting down sink: {}", &s.name);
-            // Indicate that the sink is closed to everyone else who
-            // might be tracking its write frontier.
-            s.write_frontier.borrow_mut().clear();
-            return false;
-        }
-
-        // Queue all pending rows waiting to be sent to kafka
-        input.for_each(|_, rows| {
-            is_active_worker = true;
-            rows.swap(&mut vector);
-            for ((key, value), time, diff) in vector.drain(..) {
-                let should_emit = if as_of.strict {
-                    as_of.frontier.less_than(&time)
-                } else {
-                    as_of.frontier.less_equal(&time)
-                };
-
-                let previously_published = match &s.consistency {
-                    Some(consistency) => match consistency.gate_ts {
-                        Some(gate_ts) => time <= gate_ts,
-                        None => false,
-                    },
-                    None => false,
-                };
-
-                if !should_emit || previously_published {
-                    // Skip stale data for already published timestamps
-                    continue;
-                }
-
-                assert!(diff >= 0, "can't sink negative multiplicities");
-                if diff == 0 {
-                    // Explicitly refuse to send no-op records
-                    continue;
-                };
-                let diff = diff as usize;
-
-                let rows = s.pending_rows.entry(time).or_default();
-                rows.push(EncodedRow {
-                    key,
-                    value,
-                    count: diff,
-                });
-                s.metrics.rows_queued.inc();
-            }
-        });
-
-        // Figure out the durablity frontier for all sources we depent on
-        let mut durability_frontier = Antichain::new();
-
-        for history in source_timestamp_histories.iter() {
-            use differential_dataflow::lattice::Lattice;
-            durability_frontier.meet_assign(&history.durability_frontier());
-        }
-        // Move any newly closed timestamps from pending to ready
-        let mut closed_ts: Vec<u64> = s
-            .pending_rows
-            .iter()
-            .filter(|(ts, _)| {
-                !input.frontier.less_equal(*ts) && !durability_frontier.less_equal(*ts)
-            })
-            .map(|(&ts, _)| ts)
-            .collect();
-        closed_ts.sort_unstable();
-        closed_ts.into_iter().for_each(|ts| {
-            let rows = s.pending_rows.remove(&ts).unwrap();
-            s.ready_rows.push_back((ts, rows));
-        });
-
-        // Send a bounded number of records to Kafka from the ready queue.
-        // This loop has explicitly been designed so that each iteration sends
-        // at most one record to Kafka
-        for _ in 0..s.fuel {
-            if let Some((ts, rows)) = s.ready_rows.front() {
-                s.send_state = match s.send_state {
-                    SendState::Init => {
-                        let result = if s.transactional {
-                            s.producer.init_transactions(s.txn_timeout)
-                        } else {
-                            Ok(())
-                        };
-
-                        match result {
-                            Ok(()) => SendState::BeginTxn,
-                            Err(e) => s.transition_on_txn_error(s.send_state, *ts, e),
-                        }
-                    }
-                    SendState::BeginTxn => {
-                        let result = if s.transactional {
-                            s.producer.begin_transaction()
-                        } else {
-                            Ok(())
-                        };
-
-                        match result {
-                            Ok(()) => SendState::Begin,
-                            Err(e) => s.transition_on_txn_error(s.send_state, *ts, e),
-                        }
-                    }
-                    SendState::Begin => {
-                        if s.consistency.is_some() {
-                            let result = s.send_consistency_record(&ts.to_string(), "BEGIN", None);
-
-                            if let Err(retry) = result {
-                                return retry;
-                            }
-                        }
-                        SendState::Draining {
-                            row_index: 0,
-                            repeat_counter: 0,
-                            total_sent: 0,
-                        }
-                    }
-                    SendState::Draining {
-                        mut row_index,
-                        mut repeat_counter,
-                        mut total_sent,
-                    } => {
-                        let encoded_row = &rows[row_index];
-                        let record = BaseRecord::to(&s.topic);
-                        let record = if encoded_row.value.is_some() {
-                            record.payload(encoded_row.value.as_ref().unwrap())
-                        } else {
-                            record
-                        };
-                        let record = if encoded_row.key.is_some() {
-                            record.key(encoded_row.key.as_ref().unwrap())
-                        } else {
-                            record
-                        };
-                        if let Err(retry) = s.send(record) {
-                            return retry;
-                        }
-
-                        // advance to the next repetition of this row, or the next row if all
-                        // reptitions are exhausted
-                        total_sent += 1;
-                        repeat_counter += 1;
-                        if repeat_counter == encoded_row.count {
-                            repeat_counter = 0;
-                            row_index += 1;
-                            s.metrics.rows_queued.dec();
-                        }
-
-                        // move to the end state if we've finished all rows in this timestamp
-                        if row_index == rows.len() {
-                            SendState::End(total_sent)
-                        } else {
-                            SendState::Draining {
-                                row_index,
-                                repeat_counter,
-                                total_sent,
-                            }
-                        }
-                    }
-                    SendState::End(total_count) => {
-                        if s.consistency.is_some() {
-                            let result = s.send_consistency_record(
-                                &ts.to_string(),
-                                "END",
-                                Some(total_count),
-                            );
-
-                            if let Err(retry) = result {
-                                return retry;
-                            }
-                        }
-                        SendState::CommitTxn
-                    }
-                    SendState::CommitTxn => {
-                        let result = if s.transactional {
-                            s.producer.commit_transaction(s.txn_timeout)
-                        } else {
-                            Ok(())
-                        };
-
-                        match result {
-                            Ok(()) => {
-                                // sanity check for the continuous updating
-                                // of the write frontier below
-
-                                s.assert_progress(ts);
-                                progress_update.replace(ts.clone());
-
-                                s.ready_rows.pop_front();
-                                SendState::BeginTxn
-                            }
-                            Err(e) => s.transition_on_txn_error(s.send_state, *ts, e),
-                        }
-                    }
-                    SendState::AbortTxn => {
-                        let result = if s.transactional {
-                            s.producer.abort_transaction(s.txn_timeout)
-                        } else {
-                            Ok(())
-                        };
-
-                        match result {
-                            Ok(()) => SendState::BeginTxn,
-                            Err(e) => s.transition_on_txn_error(s.send_state, *ts, e),
-                        }
-                    }
-                    SendState::Shutdown => {
-                        s.shutdown_flag.store(true, Ordering::SeqCst);
-                        // Indicate that the sink is closed to everyone else who
-                        // might be tracking its write frontier.
-                        info!("shutting down kafka sink: {}", &s.name);
-                        break;
-                    }
-                };
-            } else {
-                break;
-            }
-        }
-
-        // update our state based on any END records we might have sent
-        if let Some(ts) = progress_update.take() {
-            s.maybe_update_progress(&ts);
-        }
-
-        // If we don't have ready rows, our write frontier equals the minimum
-        // of the input frontier and any stashed timestamps.
-        // While we still have ready rows that we're emitting, hold the write
-        // frontier at the previous time.
-        //
-        // Only ever emit progress records if this operator/worker received
-        // updates. Only on worker receives all the updates and we don't want
-        // the other workers to also emit END records.
-        if s.ready_rows.is_empty() && is_active_worker {
-            if let Err(e) = s.maybe_emit_progress(input.frontier.frontier()) {
-                // This can happen when the producer has not been
-                // initialized yet. This also means, that we only start
-                // emitting continuous updates once some real data
-                // has been emitted.
-                debug!("Error writing out progress update: {}", e);
-            }
-        }
-
-        let in_flight = s.producer.in_flight_count();
-        s.metrics.messages_in_flight.set(in_flight as u64);
-
-        if !s.ready_rows.is_empty() {
-            // We need timely to reschedule this operator as we have pending
-            // items that we need to send to Kafka
-            s.activator.activate();
-            return true;
-        }
-
-        if !s.pending_rows.is_empty() {
-            // We have some more rows that we need to wait for frontiers to advance before we
-            // can write them out. Let's make sure to reschedule with a small delay to give the
-            // system time to advance.
-            s.activator.activate_after(Duration::from_millis(100));
-            return true;
-        }
-
-        if in_flight > 0 {
-            // We still have messages that need to be flushed out to Kafka
-            // Let's make sure to keep the sink operator around until
-            // we flush them out
-            s.activator.activate_after(Duration::from_secs(5));
-            return true;
-        }
-
-        false
-    };
-
     // We want exactly one worker to send all the data to the sink topic.
     let hashed_id = id.hashed();
     let mut input = builder.new_input(&stream, Exchange::new(move |_| hashed_id));
 
-    builder.build_reschedule(|_capabilities| {
-        move |frontiers| {
-            let mut input_handle = FrontieredInputHandle::new(&mut input, &frontiers[0]);
-            sink_logic(&mut input_handle)
-        }
-    });
+    builder.build_async(
+        stream.scope(),
+        async_op!(|_initial_capabilities, frontiers| {
+            let frontiers_refcell = frontiers.borrow();
+            let frontier = frontiers_refcell[0].borrow();
+
+            if s.shutdown_flag.load(Ordering::SeqCst) {
+                debug!("shutting down sink: {}", &s.name);
+                // Indicate that the sink is closed to everyone else who
+                // might be tracking its write frontier.
+                s.write_frontier.borrow_mut().clear();
+                return false;
+            }
+
+            // Queue all pending rows waiting to be sent to kafka
+            input.for_each(|_, rows| {
+                is_active_worker = true;
+                rows.swap(&mut vector);
+                for ((key, value), time, diff) in vector.drain(..) {
+                    let should_emit = if as_of.strict {
+                        as_of.frontier.less_than(&time)
+                    } else {
+                        as_of.frontier.less_equal(&time)
+                    };
+
+                    let previously_published = match &s.consistency {
+                        Some(consistency) => match consistency.gate_ts {
+                            Some(gate_ts) => time <= gate_ts,
+                            None => false,
+                        },
+                        None => false,
+                    };
+
+                    if !should_emit || previously_published {
+                        // Skip stale data for already published timestamps
+                        continue;
+                    }
+
+                    assert!(diff >= 0, "can't sink negative multiplicities");
+                    if diff == 0 {
+                        // Explicitly refuse to send no-op records
+                        continue;
+                    };
+                    let diff = diff as usize;
+
+                    let rows = s.pending_rows.entry(time).or_default();
+                    rows.push(EncodedRow {
+                        key,
+                        value,
+                        count: diff,
+                    });
+                    s.metrics.rows_queued.inc();
+                }
+            });
+
+            // Figure out the durablity frontier for all sources we depent on
+            let mut durability_frontier = Antichain::new();
+
+            for history in source_timestamp_histories.iter() {
+                use differential_dataflow::lattice::Lattice;
+                durability_frontier.meet_assign(&history.durability_frontier());
+            }
+            // Move any newly closed timestamps from pending to ready
+            let mut closed_ts: Vec<u64> = s
+                .pending_rows
+                .iter()
+                .filter(|(ts, _)| !frontier.less_equal(*ts) && !durability_frontier.less_equal(*ts))
+                .map(|(&ts, _)| ts)
+                .collect();
+            closed_ts.sort_unstable();
+            closed_ts.into_iter().for_each(|ts| {
+                let rows = s.pending_rows.remove(&ts).unwrap();
+                s.ready_rows.push_back((ts, rows));
+            });
+
+            // TODO: #9980.  Rewrite this to take advantage of the fact that we're now within an
+            //       async op and don't need to explicitly yield in order to not block timely.
+            //
+            // Send a bounded number of records to Kafka from the ready queue.
+            // This loop has explicitly been designed so that each iteration sends
+            // at most one record to Kafka
+            for _ in 0..s.fuel {
+                if let Some((ts, rows)) = s.ready_rows.front() {
+                    s.send_state = match s.send_state {
+                        SendState::Init => {
+                            let result = if s.transactional {
+                                s.init_transactions(s.txn_timeout).await
+                            } else {
+                                Ok(())
+                            };
+
+                            match result {
+                                Ok(()) => SendState::BeginTxn,
+                                Err(e) => s.transition_on_txn_error(s.send_state, *ts, e),
+                            }
+                        }
+                        SendState::BeginTxn => {
+                            let result = if s.transactional {
+                                s.begin_transaction().await
+                            } else {
+                                Ok(())
+                            };
+
+                            match result {
+                                Ok(()) => SendState::Begin,
+                                Err(e) => s.transition_on_txn_error(s.send_state, *ts, e),
+                            }
+                        }
+                        SendState::Begin => {
+                            if s.consistency.is_some() {
+                                let result =
+                                    s.send_consistency_record(&ts.to_string(), "BEGIN", None);
+
+                                if let Err(retry) = result {
+                                    return retry;
+                                }
+                            }
+                            SendState::Draining {
+                                row_index: 0,
+                                repeat_counter: 0,
+                                total_sent: 0,
+                            }
+                        }
+                        SendState::Draining {
+                            mut row_index,
+                            mut repeat_counter,
+                            mut total_sent,
+                        } => {
+                            let encoded_row = &rows[row_index];
+                            let record = BaseRecord::to(&s.topic);
+                            let record = if encoded_row.value.is_some() {
+                                record.payload(encoded_row.value.as_ref().unwrap())
+                            } else {
+                                record
+                            };
+                            let record = if encoded_row.key.is_some() {
+                                record.key(encoded_row.key.as_ref().unwrap())
+                            } else {
+                                record
+                            };
+                            if let Err(retry) = s.send(record) {
+                                return retry;
+                            }
+
+                            // advance to the next repetition of this row, or the next row if all
+                            // reptitions are exhausted
+                            total_sent += 1;
+                            repeat_counter += 1;
+                            if repeat_counter == encoded_row.count {
+                                repeat_counter = 0;
+                                row_index += 1;
+                                s.metrics.rows_queued.dec();
+                            }
+
+                            // move to the end state if we've finished all rows in this timestamp
+                            if row_index == rows.len() {
+                                SendState::End(total_sent)
+                            } else {
+                                SendState::Draining {
+                                    row_index,
+                                    repeat_counter,
+                                    total_sent,
+                                }
+                            }
+                        }
+                        SendState::End(total_count) => {
+                            if s.consistency.is_some() {
+                                let result = s.send_consistency_record(
+                                    &ts.to_string(),
+                                    "END",
+                                    Some(total_count),
+                                );
+
+                                if let Err(retry) = result {
+                                    return retry;
+                                }
+                            }
+                            SendState::CommitTxn
+                        }
+                        SendState::CommitTxn => {
+                            let result = if s.transactional {
+                                s.commit_transaction(s.txn_timeout).await
+                            } else {
+                                Ok(())
+                            };
+
+                            match result {
+                                Ok(()) => {
+                                    // sanity check for the continuous updating
+                                    // of the write frontier below
+
+                                    s.assert_progress(ts);
+                                    progress_update.replace(ts.clone());
+
+                                    s.ready_rows.pop_front();
+                                    SendState::BeginTxn
+                                }
+                                Err(e) => s.transition_on_txn_error(s.send_state, *ts, e),
+                            }
+                        }
+                        SendState::AbortTxn => {
+                            let result = if s.transactional {
+                                s.abort_transaction(s.txn_timeout).await
+                            } else {
+                                Ok(())
+                            };
+
+                            match result {
+                                Ok(()) => SendState::BeginTxn,
+                                Err(e) => s.transition_on_txn_error(s.send_state, *ts, e),
+                            }
+                        }
+                        SendState::Shutdown => {
+                            s.shutdown_flag.store(true, Ordering::SeqCst);
+                            // Indicate that the sink is closed to everyone else who
+                            // might be tracking its write frontier.
+                            info!("shutting down kafka sink: {}", &s.name);
+                            break;
+                        }
+                    };
+                } else {
+                    break;
+                }
+            }
+
+            // update our state based on any END records we might have sent
+            if let Some(ts) = progress_update.take() {
+                s.maybe_update_progress(&ts);
+            }
+
+            // If we don't have ready rows, our write frontier equals the minimum
+            // of the input frontier and any stashed timestamps.
+            // While we still have ready rows that we're emitting, hold the write
+            // frontier at the previous time.
+            //
+            // Only ever emit progress records if this operator/worker received
+            // updates. Only on worker receives all the updates and we don't want
+            // the other workers to also emit END records.
+            if s.ready_rows.is_empty() && is_active_worker {
+                if let Err(e) = s.maybe_emit_progress(frontier).await {
+                    // This can happen when the producer has not been
+                    // initialized yet. This also means, that we only start
+                    // emitting continuous updates once some real data
+                    // has been emitted.
+                    debug!("Error writing out progress update: {}", e);
+                }
+            }
+
+            let in_flight = s.producer.in_flight_count();
+            s.metrics.messages_in_flight.set(in_flight as u64);
+
+            if !s.ready_rows.is_empty() {
+                // We need timely to reschedule this operator as we have pending
+                // items that we need to send to Kafka
+                s.activator.activate();
+                return true;
+            }
+
+            if !s.pending_rows.is_empty() {
+                // We have some more rows that we need to wait for frontiers to advance before we
+                // can write them out. Let's make sure to reschedule with a small delay to give the
+                // system time to advance.
+                s.activator.activate_after(Duration::from_millis(100));
+                return true;
+            }
+
+            if in_flight > 0 {
+                // We still have messages that need to be flushed out to Kafka
+                // Let's make sure to keep the sink operator around until
+                // we flush them out
+                s.activator.activate_after(Duration::from_secs(5));
+                return true;
+            }
+
+            false
+        }),
+    );
 
     Box::new(KafkaSinkToken { shutdown_flag })
 }

--- a/src/persist/src/operators/mod.rs
+++ b/src/persist/src/operators/mod.rs
@@ -10,8 +10,6 @@
 //! Timely and Differential Dataflow operators for persisting and replaying
 //! data.
 
-#[macro_use]
-mod async_ext;
 pub mod input;
 pub mod replay;
 pub mod source;

--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "timely-util"
+description = "Utilities for working with Timely."
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+futures-util = "0.3.19"
+timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false }
+
+[dev-dependencies]
+tokio = { version = "1.15.0", features = ["macros", "rt-multi-thread", "time"] }

--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
+differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 futures-util = "0.3.19"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false }
 

--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 publish = false
 
 [dependencies]
-differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 futures-util = "0.3.19"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false }
 

--- a/src/timely-util/src/lib.rs
+++ b/src/timely-util/src/lib.rs
@@ -1,0 +1,21 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Internal utility libraries for Materialize.
+//! Utilities for working with Timely
+
+#![warn(missing_docs)]
+
+pub mod operators_async_ext;

--- a/src/timely-util/src/operators_async_ext.rs
+++ b/src/timely-util/src/operators_async_ext.rs
@@ -185,41 +185,24 @@ impl<G: Scope> OperatorBuilderExt<G> for OperatorBuilder<G> {
     }
 }
 
-use differential_dataflow::lattice::Lattice;
-#[doc(hidden)]
-pub fn multi_meet<T: Lattice + Clone>(antichains: &[Antichain<T>]) -> Antichain<T> {
-    antichains
-        .iter()
-        .fold(Antichain::new(), |acc, x| acc.meet(&x))
-}
-
 /// Convenience macro used to wrap what might otherwise be the argument to `build_reschedule`.
 #[macro_export]
 macro_rules! async_op {
-    (|$capabilities:ident, $frontier:ident| $body:block) => {
+    (|$capabilities:ident, $frontiers:ident| $body:block) => {
         move |mut capabilities, frontiers, scheduler| async move {
             loop {
                 scheduler.notified().await;
 
-                // We simplify into one single Antichain because no current users of `async_op`
-                // require treating multiple input frontiers separately and this is the easiest
-                // way we can ensure that the `$body` does not hold a borrow to the frontier at
-                // all times
-                //
-                // Pull out to function so we don't require import from differential_dataflow for
-                // user of macro.
-                let __frontier = $crate::operators_async_ext::multi_meet(&frontiers.borrow());
-                let $frontier = __frontier.borrow();
                 #[allow(unused_mut)]
                 let mut $capabilities = &mut capabilities;
+                let $frontiers = (*frontiers.borrow()).clone();
 
-                if !async { $body }.await && $frontier.is_empty() {
+                if !async { $body }.await && $frontiers.iter().all(|f| f.is_empty()) {
                     break;
                 }
             }
 
-            // Make sure they can't be accidentally dropped in `$body`
-            drop(capabilities);
+            // Make sure can't be accidentally dropped in `$body`
             drop(frontiers);
         }
     };

--- a/src/timely-util/src/operators_async_ext.rs
+++ b/src/timely-util/src/operators_async_ext.rs
@@ -193,6 +193,7 @@ macro_rules! async_op {
             loop {
                 scheduler.notified().await;
 
+                // rebind to mutable references to make sure they can't be accidentally dropped
                 #[allow(unused_mut)]
                 let mut $capabilities = &mut capabilities;
                 let $frontiers = (*frontiers.borrow()).clone();
@@ -201,9 +202,6 @@ macro_rules! async_op {
                     break;
                 }
             }
-
-            // Make sure can't be accidentally dropped in `$body`
-            drop(frontiers);
         }
     };
 }

--- a/src/timely-util/src/operators_async_ext.rs
+++ b/src/timely-util/src/operators_async_ext.rs
@@ -7,19 +7,21 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::cell::Cell;
-use std::cell::RefCell;
+//! Extensions for `OperatorBuilder` to create async operators.
+
+use std::cell::{Cell, RefCell};
 use std::future::Future;
 use std::pin::Pin;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
+use futures_util::future::FusedFuture;
+use futures_util::FutureExt;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use timely::dataflow::operators::Capability;
 use timely::dataflow::Scope;
-use timely::progress::Antichain;
-use timely::progress::Timestamp;
+use timely::progress::{Antichain, Timestamp};
 use timely::PartialOrder;
 
 /// A type that is not inhabited by any value. Should be redefined as the
@@ -84,6 +86,7 @@ impl Future for Notified<'_> {
     }
 }
 
+/// Extension trait for `OperatorBuilder`.
 pub trait OperatorBuilderExt<G: Scope> {
     /// Creates an operator implementation from supplied async logic constructor.
     ///
@@ -109,7 +112,7 @@ pub trait OperatorBuilderExt<G: Scope> {
             Rc<RefCell<Vec<Antichain<G::Timestamp>>>>,
             Scheduler,
         ) -> Fut,
-        Fut: Future<Output = Never> + 'static;
+        Fut: Future + 'static;
 }
 
 impl<G: Scope> OperatorBuilderExt<G> for OperatorBuilder<G> {
@@ -120,7 +123,7 @@ impl<G: Scope> OperatorBuilderExt<G> for OperatorBuilder<G> {
             Rc<RefCell<Vec<Antichain<G::Timestamp>>>>,
             Scheduler,
         ) -> Fut,
-        Fut: Future<Output = Never> + 'static,
+        Fut: Future + 'static,
     {
         let activator = scope.sync_activator_for(&self.operator_info().address[..]);
         let waker = futures_util::task::waker(Arc::new(activator));
@@ -129,13 +132,16 @@ impl<G: Scope> OperatorBuilderExt<G> for OperatorBuilder<G> {
             self.shape().inputs()
         ]));
 
-        self.build(move |capabilities| {
+        self.build_reschedule(move |capabilities| {
             let scheduler = Scheduler::default();
-            let mut logic_fut = Box::pin(constructor(
-                capabilities,
-                Rc::clone(&shared_frontiers),
-                scheduler.clone(),
-            ));
+            let mut logic_fut = Box::pin(
+                constructor(
+                    capabilities,
+                    Rc::clone(&shared_frontiers),
+                    scheduler.clone(),
+                )
+                .fuse(),
+            );
             move |frontiers| {
                 // Attempt to update the shared frontier before polling the future.  This operation
                 // can fail if the future also borrowed the frontier and kept the borrow active
@@ -151,8 +157,14 @@ impl<G: Scope> OperatorBuilderExt<G> for OperatorBuilder<G> {
                     }
                 }
 
+                if logic_fut.is_terminated() {
+                    return false;
+                }
+
                 let had_pending_notify = scheduler.notify();
-                let _ = Pin::new(&mut logic_fut).poll(&mut Context::from_waker(&waker));
+                let operator_incomplete = Pin::new(&mut logic_fut)
+                    .poll(&mut Context::from_waker(&waker))
+                    .is_pending();
                 // Here we check that:
                 //   1. the scheduler had been notified in some previous run of the closure
                 //   2. the future just went past a `scheduler.notified().await` point
@@ -166,12 +178,15 @@ impl<G: Scope> OperatorBuilderExt<G> for OperatorBuilder<G> {
                 if had_pending_notify && !scheduler.is_notified() {
                     waker.wake_by_ref();
                 }
+
+                operator_incomplete
             }
         });
     }
 }
 
-#[allow(unused_macros)]
+/// Convenience macro used to wrap what might otherwise be the argument to `build_reschedule`.
+#[macro_export]
 macro_rules! async_op {
     (|$capabilities:ident, $frontiers:ident| $body:block) => {
         move |mut capabilities, mut frontiers, scheduler| async move {
@@ -182,7 +197,10 @@ macro_rules! async_op {
                 let mut $capabilities = &mut capabilities;
                 #[allow(unused_mut)]
                 let mut $frontiers = &mut frontiers;
-                let _: () = async { $body }.await;
+
+                if !async { $body }.await && frontiers.borrow().iter().all(|f| f.is_empty()) {
+                    break;
+                }
             }
         }
     };
@@ -224,6 +242,7 @@ mod test {
                                 session.give(item);
                             }
                         }
+                        false
                     }),
                 );
 


### PR DESCRIPTION
Take 2 of #9909 (including small fix from #9982).

The v1 implementation held a borrow to the frontiers through each invocation of sink which made it difficult for `shared_frontiers.try_borrow_mut` to obtain the borrow and advance the frontier.  Because the frontier was not easily advanced, the kafka sink never learned of any `closed_ts`s and, therefore, never wrote any records out to the sink.

Because a brief search didn't find places where ops acted on the frontier of individual inputs -- and, more importantly, the only user of `async_op!`, the kafka sink, doesn't -- I modified the interface of `async_op` to only pass a single `Antichain` to the `$body`.  (This is computed as the `meet` of the per-input `Antichain`s.).  This means that `$body` is not able to hold a borrow so the frontier can be updated much more easily.

This may be more restrictive than necessary but we can expand the capability if / when it becomes necessary or useful.

### Motivation
Fixes #6035 

### Tips for reviewer
- c95fef3f2c168f9d5784c657e5b0d4ed23068c8d is the two original PRs merged
- 2c715a497abc5d92ad67e985dbb17f18b82d5f20 is the new code.

### Checklist
- [x] This PR has adequate test coverage / QA involvement has been duly considered.
I ran `kafka-exactly-once-sink.td` many times in CI and manually checked that it does not have the performance regression of the original #9909.

Additionally, I found a minimal repro (aka a repro that didn't involve the sink kafka tx calls actually being async) and verified this change fixed it.
