### PR TITLE
sinks: offload blocking kafka tx calls to tokio threadpool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1242,6 +1242,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "timely",
+ "timely-util",
  "tokio",
  "tokio-postgres",
  "tokio-util",
@@ -4930,6 +4931,15 @@ dependencies = [
  "timely_bytes",
  "timely_communication",
  "timely_logging",
+]
+
+[[package]]
+name = "timely-util"
+version = "0.0.0"
+dependencies = [
+ "futures-util",
+ "timely",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ members = [
     "src/sql",
     "src/sqllogictest",
     "src/testdrive",
+    "src/timely-util",
     "src/transform",
     "src/walkabout",
     "test/metabase/smoketest",

--- a/src/dataflow/Cargo.toml
+++ b/src/dataflow/Cargo.toml
@@ -54,6 +54,7 @@ serde = { version = "1.0.133", features = ["derive"] }
 serde_json = "1.0.74"
 tempfile = "3.2.0"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
+timely-util = { path = "../timely-util" }
 tokio = { version = "1.15.0", features = ["fs", "rt", "sync"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", branch = "mz-0.7.2" }
 tokio-util = { version = "0.6.9", features = ["codec", "io"] }

--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -28,7 +28,7 @@ use rdkafka::producer::{BaseRecord, DeliveryResult, ProducerContext, ThreadedPro
 use timely::dataflow::channels::pact::Exchange;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
-use timely::dataflow::operators::generic::{FrontieredInputHandle, InputHandle, OutputHandle};
+use timely::dataflow::operators::generic::{InputHandle, OutputHandle};
 use timely::dataflow::operators::{Capability, Map};
 use timely::dataflow::{Scope, Stream};
 use timely::progress::frontier::AntichainRef;
@@ -46,6 +46,8 @@ use kafka_util::client::MzClientContext;
 use ore::cast::CastFrom;
 use ore::metrics::{CounterVecExt, DeleteOnDropCounter, DeleteOnDropGauge, GaugeVecExt};
 use repr::{Datum, Diff, RelationDesc, Row, Timestamp};
+use timely_util::async_op;
+use timely_util::operators_async_ext::OperatorBuilderExt;
 
 use super::{KafkaBaseMetrics, SinkBaseMetrics};
 use crate::render::sinks::SinkRender;
@@ -707,290 +709,284 @@ where
     // our internal state after the send loop
     let mut progress_update = None;
 
-    let mut sink_logic = move |input: &mut FrontieredInputHandle<
-        _,
-        ((Option<Vec<u8>>, Option<Vec<u8>>), Timestamp, Diff),
-        _,
-    >| {
-        if s.shutdown_flag.load(Ordering::SeqCst) {
-            debug!("shutting down sink: {}", &s.name);
-            // Indicate that the sink is closed to everyone else who
-            // might be tracking its write frontier.
-            s.write_frontier.borrow_mut().clear();
-            return false;
-        }
-
-        // Queue all pending rows waiting to be sent to kafka
-        input.for_each(|_, rows| {
-            is_active_worker = true;
-            rows.swap(&mut vector);
-            for ((key, value), time, diff) in vector.drain(..) {
-                let should_emit = if as_of.strict {
-                    as_of.frontier.less_than(&time)
-                } else {
-                    as_of.frontier.less_equal(&time)
-                };
-
-                let previously_published = match &s.consistency {
-                    Some(consistency) => match consistency.gate_ts {
-                        Some(gate_ts) => time <= gate_ts,
-                        None => false,
-                    },
-                    None => false,
-                };
-
-                if !should_emit || previously_published {
-                    // Skip stale data for already published timestamps
-                    continue;
-                }
-
-                assert!(diff >= 0, "can't sink negative multiplicities");
-                if diff == 0 {
-                    // Explicitly refuse to send no-op records
-                    continue;
-                };
-                let diff = diff as usize;
-
-                let rows = s.pending_rows.entry(time).or_default();
-                rows.push(EncodedRow {
-                    key,
-                    value,
-                    count: diff,
-                });
-                s.metrics.rows_queued.inc();
-            }
-        });
-
-        // Figure out the durablity frontier for all sources we depent on
-        let mut durability_frontier = Antichain::new();
-
-        for history in source_timestamp_histories.iter() {
-            use differential_dataflow::lattice::Lattice;
-            durability_frontier.meet_assign(&history.durability_frontier());
-        }
-        // Move any newly closed timestamps from pending to ready
-        let mut closed_ts: Vec<u64> = s
-            .pending_rows
-            .iter()
-            .filter(|(ts, _)| {
-                !input.frontier.less_equal(*ts) && !durability_frontier.less_equal(*ts)
-            })
-            .map(|(&ts, _)| ts)
-            .collect();
-        closed_ts.sort_unstable();
-        closed_ts.into_iter().for_each(|ts| {
-            let rows = s.pending_rows.remove(&ts).unwrap();
-            s.ready_rows.push_back((ts, rows));
-        });
-
-        // Send a bounded number of records to Kafka from the ready queue.
-        // This loop has explicitly been designed so that each iteration sends
-        // at most one record to Kafka
-        for _ in 0..s.fuel {
-            if let Some((ts, rows)) = s.ready_rows.front() {
-                s.send_state = match s.send_state {
-                    SendState::Init => {
-                        let result = if s.transactional {
-                            s.producer.init_transactions(s.txn_timeout)
-                        } else {
-                            Ok(())
-                        };
-
-                        match result {
-                            Ok(()) => SendState::BeginTxn,
-                            Err(e) => s.transition_on_txn_error(s.send_state, *ts, e),
-                        }
-                    }
-                    SendState::BeginTxn => {
-                        let result = if s.transactional {
-                            s.producer.begin_transaction()
-                        } else {
-                            Ok(())
-                        };
-
-                        match result {
-                            Ok(()) => SendState::Begin,
-                            Err(e) => s.transition_on_txn_error(s.send_state, *ts, e),
-                        }
-                    }
-                    SendState::Begin => {
-                        if s.consistency.is_some() {
-                            let result = s.send_consistency_record(&ts.to_string(), "BEGIN", None);
-
-                            if let Err(retry) = result {
-                                return retry;
-                            }
-                        }
-                        SendState::Draining {
-                            row_index: 0,
-                            repeat_counter: 0,
-                            total_sent: 0,
-                        }
-                    }
-                    SendState::Draining {
-                        mut row_index,
-                        mut repeat_counter,
-                        mut total_sent,
-                    } => {
-                        let encoded_row = &rows[row_index];
-                        let record = BaseRecord::to(&s.topic);
-                        let record = if encoded_row.value.is_some() {
-                            record.payload(encoded_row.value.as_ref().unwrap())
-                        } else {
-                            record
-                        };
-                        let record = if encoded_row.key.is_some() {
-                            record.key(encoded_row.key.as_ref().unwrap())
-                        } else {
-                            record
-                        };
-                        if let Err(retry) = s.send(record) {
-                            return retry;
-                        }
-
-                        // advance to the next repetition of this row, or the next row if all
-                        // reptitions are exhausted
-                        total_sent += 1;
-                        repeat_counter += 1;
-                        if repeat_counter == encoded_row.count {
-                            repeat_counter = 0;
-                            row_index += 1;
-                            s.metrics.rows_queued.dec();
-                        }
-
-                        // move to the end state if we've finished all rows in this timestamp
-                        if row_index == rows.len() {
-                            SendState::End(total_sent)
-                        } else {
-                            SendState::Draining {
-                                row_index,
-                                repeat_counter,
-                                total_sent,
-                            }
-                        }
-                    }
-                    SendState::End(total_count) => {
-                        if s.consistency.is_some() {
-                            let result = s.send_consistency_record(
-                                &ts.to_string(),
-                                "END",
-                                Some(total_count),
-                            );
-
-                            if let Err(retry) = result {
-                                return retry;
-                            }
-                        }
-                        SendState::CommitTxn
-                    }
-                    SendState::CommitTxn => {
-                        let result = if s.transactional {
-                            s.producer.commit_transaction(s.txn_timeout)
-                        } else {
-                            Ok(())
-                        };
-
-                        match result {
-                            Ok(()) => {
-                                // sanity check for the continuous updating
-                                // of the write frontier below
-
-                                s.assert_progress(ts);
-                                progress_update.replace(ts.clone());
-
-                                s.ready_rows.pop_front();
-                                SendState::BeginTxn
-                            }
-                            Err(e) => s.transition_on_txn_error(s.send_state, *ts, e),
-                        }
-                    }
-                    SendState::AbortTxn => {
-                        let result = if s.transactional {
-                            s.producer.abort_transaction(s.txn_timeout)
-                        } else {
-                            Ok(())
-                        };
-
-                        match result {
-                            Ok(()) => SendState::BeginTxn,
-                            Err(e) => s.transition_on_txn_error(s.send_state, *ts, e),
-                        }
-                    }
-                    SendState::Shutdown => {
-                        s.shutdown_flag.store(true, Ordering::SeqCst);
-                        // Indicate that the sink is closed to everyone else who
-                        // might be tracking its write frontier.
-                        info!("shutting down kafka sink: {}", &s.name);
-                        break;
-                    }
-                };
-            } else {
-                break;
-            }
-        }
-
-        // update our state based on any END records we might have sent
-        if let Some(ts) = progress_update.take() {
-            s.maybe_update_progress(&ts);
-        }
-
-        // If we don't have ready rows, our write frontier equals the minimum
-        // of the input frontier and any stashed timestamps.
-        // While we still have ready rows that we're emitting, hold the write
-        // frontier at the previous time.
-        //
-        // Only ever emit progress records if this operator/worker received
-        // updates. Only on worker receives all the updates and we don't want
-        // the other workers to also emit END records.
-        if s.ready_rows.is_empty() && is_active_worker {
-            if let Err(e) = s.maybe_emit_progress(input.frontier.frontier()) {
-                // This can happen when the producer has not been
-                // initialized yet. This also means, that we only start
-                // emitting continuous updates once some real data
-                // has been emitted.
-                debug!("Error writing out progress update: {}", e);
-            }
-        }
-
-        let in_flight = s.producer.in_flight_count();
-        s.metrics.messages_in_flight.set(in_flight as u64);
-
-        if !s.ready_rows.is_empty() {
-            // We need timely to reschedule this operator as we have pending
-            // items that we need to send to Kafka
-            s.activator.activate();
-            return true;
-        }
-
-        if !s.pending_rows.is_empty() {
-            // We have some more rows that we need to wait for frontiers to advance before we
-            // can write them out. Let's make sure to reschedule with a small delay to give the
-            // system time to advance.
-            s.activator.activate_after(Duration::from_millis(100));
-            return true;
-        }
-
-        if in_flight > 0 {
-            // We still have messages that need to be flushed out to Kafka
-            // Let's make sure to keep the sink operator around until
-            // we flush them out
-            s.activator.activate_after(Duration::from_secs(5));
-            return true;
-        }
-
-        false
-    };
-
     // We want exactly one worker to send all the data to the sink topic.
     let hashed_id = id.hashed();
     let mut input = builder.new_input(&stream, Exchange::new(move |_| hashed_id));
 
-    builder.build_reschedule(|_capabilities| {
-        move |frontiers| {
-            let mut input_handle = FrontieredInputHandle::new(&mut input, &frontiers[0]);
-            sink_logic(&mut input_handle)
-        }
-    });
+    builder.build_async(
+        stream.scope(),
+        async_op!(|_initial_capabilities, frontiers| {
+            let frontiers_refcell = frontiers.borrow();
+            let frontier = frontiers_refcell[0].borrow();
+
+            if s.shutdown_flag.load(Ordering::SeqCst) {
+                debug!("shutting down sink: {}", &s.name);
+                // Indicate that the sink is closed to everyone else who
+                // might be tracking its write frontier.
+                s.write_frontier.borrow_mut().clear();
+                return false;
+            }
+
+            // Queue all pending rows waiting to be sent to kafka
+            input.for_each(|_, rows| {
+                is_active_worker = true;
+                rows.swap(&mut vector);
+                for ((key, value), time, diff) in vector.drain(..) {
+                    let should_emit = if as_of.strict {
+                        as_of.frontier.less_than(&time)
+                    } else {
+                        as_of.frontier.less_equal(&time)
+                    };
+
+                    let previously_published = match &s.consistency {
+                        Some(consistency) => match consistency.gate_ts {
+                            Some(gate_ts) => time <= gate_ts,
+                            None => false,
+                        },
+                        None => false,
+                    };
+
+                    if !should_emit || previously_published {
+                        // Skip stale data for already published timestamps
+                        continue;
+                    }
+
+                    assert!(diff >= 0, "can't sink negative multiplicities");
+                    if diff == 0 {
+                        // Explicitly refuse to send no-op records
+                        continue;
+                    };
+                    let diff = diff as usize;
+
+                    let rows = s.pending_rows.entry(time).or_default();
+                    rows.push(EncodedRow {
+                        key,
+                        value,
+                        count: diff,
+                    });
+                    s.metrics.rows_queued.inc();
+                }
+            });
+
+            // Figure out the durablity frontier for all sources we depent on
+            let mut durability_frontier = Antichain::new();
+
+            for history in source_timestamp_histories.iter() {
+                use differential_dataflow::lattice::Lattice;
+                durability_frontier.meet_assign(&history.durability_frontier());
+            }
+            // Move any newly closed timestamps from pending to ready
+            let mut closed_ts: Vec<u64> = s
+                .pending_rows
+                .iter()
+                .filter(|(ts, _)| !frontier.less_equal(*ts) && !durability_frontier.less_equal(*ts))
+                .map(|(&ts, _)| ts)
+                .collect();
+            closed_ts.sort_unstable();
+            closed_ts.into_iter().for_each(|ts| {
+                let rows = s.pending_rows.remove(&ts).unwrap();
+                s.ready_rows.push_back((ts, rows));
+            });
+
+            // Send a bounded number of records to Kafka from the ready queue.
+            // This loop has explicitly been designed so that each iteration sends
+            // at most one record to Kafka
+            for _ in 0..s.fuel {
+                if let Some((ts, rows)) = s.ready_rows.front() {
+                    s.send_state = match s.send_state {
+                        SendState::Init => {
+                            let result = if s.transactional {
+                                s.producer.init_transactions(s.txn_timeout)
+                            } else {
+                                Ok(())
+                            };
+
+                            match result {
+                                Ok(()) => SendState::BeginTxn,
+                                Err(e) => s.transition_on_txn_error(s.send_state, *ts, e),
+                            }
+                        }
+                        SendState::BeginTxn => {
+                            let result = if s.transactional {
+                                s.producer.begin_transaction()
+                            } else {
+                                Ok(())
+                            };
+
+                            match result {
+                                Ok(()) => SendState::Begin,
+                                Err(e) => s.transition_on_txn_error(s.send_state, *ts, e),
+                            }
+                        }
+                        SendState::Begin => {
+                            if s.consistency.is_some() {
+                                let result =
+                                    s.send_consistency_record(&ts.to_string(), "BEGIN", None);
+
+                                if let Err(retry) = result {
+                                    return retry;
+                                }
+                            }
+                            SendState::Draining {
+                                row_index: 0,
+                                repeat_counter: 0,
+                                total_sent: 0,
+                            }
+                        }
+                        SendState::Draining {
+                            mut row_index,
+                            mut repeat_counter,
+                            mut total_sent,
+                        } => {
+                            let encoded_row = &rows[row_index];
+                            let record = BaseRecord::to(&s.topic);
+                            let record = if encoded_row.value.is_some() {
+                                record.payload(encoded_row.value.as_ref().unwrap())
+                            } else {
+                                record
+                            };
+                            let record = if encoded_row.key.is_some() {
+                                record.key(encoded_row.key.as_ref().unwrap())
+                            } else {
+                                record
+                            };
+                            if let Err(retry) = s.send(record) {
+                                return retry;
+                            }
+
+                            // advance to the next repetition of this row, or the next row if all
+                            // reptitions are exhausted
+                            total_sent += 1;
+                            repeat_counter += 1;
+                            if repeat_counter == encoded_row.count {
+                                repeat_counter = 0;
+                                row_index += 1;
+                                s.metrics.rows_queued.dec();
+                            }
+
+                            // move to the end state if we've finished all rows in this timestamp
+                            if row_index == rows.len() {
+                                SendState::End(total_sent)
+                            } else {
+                                SendState::Draining {
+                                    row_index,
+                                    repeat_counter,
+                                    total_sent,
+                                }
+                            }
+                        }
+                        SendState::End(total_count) => {
+                            if s.consistency.is_some() {
+                                let result = s.send_consistency_record(
+                                    &ts.to_string(),
+                                    "END",
+                                    Some(total_count),
+                                );
+
+                                if let Err(retry) = result {
+                                    return retry;
+                                }
+                            }
+                            SendState::CommitTxn
+                        }
+                        SendState::CommitTxn => {
+                            let result = if s.transactional {
+                                s.producer.commit_transaction(s.txn_timeout)
+                            } else {
+                                Ok(())
+                            };
+
+                            match result {
+                                Ok(()) => {
+                                    // sanity check for the continuous updating
+                                    // of the write frontier below
+
+                                    s.assert_progress(ts);
+                                    progress_update.replace(ts.clone());
+
+                                    s.ready_rows.pop_front();
+                                    SendState::BeginTxn
+                                }
+                                Err(e) => s.transition_on_txn_error(s.send_state, *ts, e),
+                            }
+                        }
+                        SendState::AbortTxn => {
+                            let result = if s.transactional {
+                                s.producer.abort_transaction(s.txn_timeout)
+                            } else {
+                                Ok(())
+                            };
+
+                            match result {
+                                Ok(()) => SendState::BeginTxn,
+                                Err(e) => s.transition_on_txn_error(s.send_state, *ts, e),
+                            }
+                        }
+                        SendState::Shutdown => {
+                            s.shutdown_flag.store(true, Ordering::SeqCst);
+                            // Indicate that the sink is closed to everyone else who
+                            // might be tracking its write frontier.
+                            info!("shutting down kafka sink: {}", &s.name);
+                            break;
+                        }
+                    };
+                } else {
+                    break;
+                }
+            }
+
+            // update our state based on any END records we might have sent
+            if let Some(ts) = progress_update.take() {
+                s.maybe_update_progress(&ts);
+            }
+
+            // If we don't have ready rows, our write frontier equals the minimum
+            // of the input frontier and any stashed timestamps.
+            // While we still have ready rows that we're emitting, hold the write
+            // frontier at the previous time.
+            //
+            // Only ever emit progress records if this operator/worker received
+            // updates. Only on worker receives all the updates and we don't want
+            // the other workers to also emit END records.
+            if s.ready_rows.is_empty() && is_active_worker {
+                if let Err(e) = s.maybe_emit_progress(frontier) {
+                    // This can happen when the producer has not been
+                    // initialized yet. This also means, that we only start
+                    // emitting continuous updates once some real data
+                    // has been emitted.
+                    debug!("Error writing out progress update: {}", e);
+                }
+            }
+
+            let in_flight = s.producer.in_flight_count();
+            s.metrics.messages_in_flight.set(in_flight as u64);
+
+            if !s.ready_rows.is_empty() {
+                // We need timely to reschedule this operator as we have pending
+                // items that we need to send to Kafka
+                s.activator.activate();
+                return true;
+            }
+
+            if !s.pending_rows.is_empty() {
+                // We have some more rows that we need to wait for frontiers to advance before we
+                // can write them out. Let's make sure to reschedule with a small delay to give the
+                // system time to advance.
+                s.activator.activate_after(Duration::from_millis(100));
+                return true;
+            }
+
+            if in_flight > 0 {
+                // We still have messages that need to be flushed out to Kafka
+                // Let's make sure to keep the sink operator around until
+                // we flush them out
+                s.activator.activate_after(Duration::from_secs(5));
+                return true;
+            }
+
+            false
+        }),
+    );
 
     Box::new(KafkaSinkToken { shutdown_flag })
 }

--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -19,7 +19,6 @@ use std::time::Duration;
 use differential_dataflow::{AsCollection, Collection, Hashable};
 use interchange::json::JsonEncoder;
 use itertools::Itertools;
-use ore::metrics::{CounterVecExt, DeleteOnDropCounter, DeleteOnDropGauge, GaugeVecExt};
 use rdkafka::client::ClientContext;
 use rdkafka::config::ClientConfig;
 use rdkafka::error::{KafkaError, RDKafkaErrorCode};
@@ -45,6 +44,7 @@ use interchange::avro::{self, AvroEncoder, AvroSchemaGenerator};
 use interchange::encode::Encode;
 use kafka_util::client::MzClientContext;
 use ore::cast::CastFrom;
+use ore::metrics::{CounterVecExt, DeleteOnDropCounter, DeleteOnDropGauge, GaugeVecExt};
 use repr::{Datum, Diff, RelationDesc, Row, Timestamp};
 
 use super::{KafkaBaseMetrics, SinkBaseMetrics};

--- a/src/persist/src/operators/mod.rs
+++ b/src/persist/src/operators/mod.rs
@@ -10,8 +10,6 @@
 //! Timely and Differential Dataflow operators for persisting and replaying
 //! data.
 
-#[macro_use]
-mod async_ext;
 pub mod input;
 pub mod replay;
 pub mod source;

--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "timely-util"
+description = "Utilities for working with Timely."
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+futures-util = "0.3.19"
+timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false }
+
+[dev-dependencies]
+tokio = { version = "1.15.0", features = ["macros", "time"] }

--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -10,4 +10,4 @@ futures-util = "0.3.19"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false }
 
 [dev-dependencies]
-tokio = { version = "1.15.0", features = ["macros", "time"] }
+tokio = { version = "1.15.0", features = ["macros", "rt-multi-thread", "time"] }

--- a/src/timely-util/src/lib.rs
+++ b/src/timely-util/src/lib.rs
@@ -1,0 +1,21 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Internal utility libraries for Materialize.
+//! Utilities for working with Timely
+
+#![warn(missing_docs)]
+
+pub mod operators_async_ext;

--- a/src/timely-util/src/operators_async_ext.rs
+++ b/src/timely-util/src/operators_async_ext.rs
@@ -7,8 +7,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::cell::Cell;
-use std::cell::RefCell;
+//! Extensions for `OperatorBuilder` to create async operators.
+
+use std::cell::{Cell, RefCell};
 use std::future::Future;
 use std::pin::Pin;
 use std::rc::Rc;
@@ -18,8 +19,7 @@ use std::task::{Context, Poll};
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use timely::dataflow::operators::Capability;
 use timely::dataflow::Scope;
-use timely::progress::Antichain;
-use timely::progress::Timestamp;
+use timely::progress::{Antichain, Timestamp};
 use timely::PartialOrder;
 
 /// A type that is not inhabited by any value. Should be redefined as the
@@ -84,6 +84,7 @@ impl Future for Notified<'_> {
     }
 }
 
+/// Extension trait for `OperatorBuilder`.
 pub trait OperatorBuilderExt<G: Scope> {
     /// Creates an operator implementation from supplied async logic constructor.
     ///
@@ -109,7 +110,7 @@ pub trait OperatorBuilderExt<G: Scope> {
             Rc<RefCell<Vec<Antichain<G::Timestamp>>>>,
             Scheduler,
         ) -> Fut,
-        Fut: Future<Output = Never> + 'static;
+        Fut: Future + 'static;
 }
 
 impl<G: Scope> OperatorBuilderExt<G> for OperatorBuilder<G> {
@@ -120,7 +121,7 @@ impl<G: Scope> OperatorBuilderExt<G> for OperatorBuilder<G> {
             Rc<RefCell<Vec<Antichain<G::Timestamp>>>>,
             Scheduler,
         ) -> Fut,
-        Fut: Future<Output = Never> + 'static,
+        Fut: Future + 'static,
     {
         let activator = scope.sync_activator_for(&self.operator_info().address[..]);
         let waker = futures_util::task::waker(Arc::new(activator));
@@ -129,7 +130,7 @@ impl<G: Scope> OperatorBuilderExt<G> for OperatorBuilder<G> {
             self.shape().inputs()
         ]));
 
-        self.build(move |capabilities| {
+        self.build_reschedule(move |capabilities| {
             let scheduler = Scheduler::default();
             let mut logic_fut = Box::pin(constructor(
                 capabilities,
@@ -152,7 +153,9 @@ impl<G: Scope> OperatorBuilderExt<G> for OperatorBuilder<G> {
                 }
 
                 let had_pending_notify = scheduler.notify();
-                let _ = Pin::new(&mut logic_fut).poll(&mut Context::from_waker(&waker));
+                let operator_incomplete = Pin::new(&mut logic_fut)
+                    .poll(&mut Context::from_waker(&waker))
+                    .is_pending();
                 // Here we check that:
                 //   1. the scheduler had been notified in some previous run of the closure
                 //   2. the future just went past a `scheduler.notified().await` point
@@ -166,12 +169,15 @@ impl<G: Scope> OperatorBuilderExt<G> for OperatorBuilder<G> {
                 if had_pending_notify && !scheduler.is_notified() {
                     waker.wake_by_ref();
                 }
+
+                operator_incomplete
             }
         });
     }
 }
 
-#[allow(unused_macros)]
+/// Convenience macro used to wrap what might otherwise be the argument to `build_reschedule`.
+#[macro_export]
 macro_rules! async_op {
     (|$capabilities:ident, $frontiers:ident| $body:block) => {
         move |mut capabilities, mut frontiers, scheduler| async move {
@@ -182,7 +188,10 @@ macro_rules! async_op {
                 let mut $capabilities = &mut capabilities;
                 #[allow(unused_mut)]
                 let mut $frontiers = &mut frontiers;
-                let _: () = async { $body }.await;
+
+                if !async { $body }.await && frontiers.borrow().iter().all(|f| f.is_empty()) {
+                    break;
+                }
             }
         }
     };
@@ -224,6 +233,7 @@ mod test {
                                 session.give(item);
                             }
                         }
+                        false
                     }),
                 );
 


### PR DESCRIPTION
### Motivation

This is the same as the original PR from @cjubb39 (#9909) but with the frontier mechanics changed such that a refcell is never held in a borrowed state across an await point.

The code was previously unconditionally borrowing the RefCell wrapping the frontiers causing the async operator be unable to update them.

The orignal type for the frontiers was `Rc<RefCell<Vec<Antichain<Timestamp>>>>` which made it difficult to split the frontiers of each input without permanently borrowing the RefCell. This inconvenience was probably one of the reasons for the previous usage pattern.

This PR changes the type of frontiers to be `Vec<Rc<RefCell<Antichain<Timestamp>>>>` so that the frontiers of each input can be picked apart easily without borrowing the individual `RefCell`s and all uses of the frontier in the async operator have their respective `.borrow()` call right at the use site.

### Tips for reviewer

Only the last commit is different than the previously accepted PR so review should focus on that one

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
