### PR TITLE
Introduce modules into `dataflow-types`

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -17,7 +17,8 @@ use std::time::{Duration, Instant};
 use anyhow::bail;
 use chrono::{DateTime, TimeZone, Utc};
 use dataflow_types::{
-    EnvelopePersistDesc, ExternalSourceConnector, MzOffset, SinkEnvelope, SourcePersistDesc,
+    sinks::SinkEnvelope, sources::persistence::EnvelopePersistDesc,
+    sources::persistence::SourcePersistDesc, sources::ExternalSourceConnector, sources::MzOffset,
 };
 use expr::{Id, PartitionId};
 use itertools::Itertools;
@@ -32,7 +33,10 @@ use serde::{Deserialize, Serialize};
 use tracing::{info, trace};
 
 use build_info::DUMMY_BUILD_INFO;
-use dataflow_types::{SinkConnector, SinkConnectorBuilder, SourceConnector, Timeline};
+use dataflow_types::{
+    sinks::{SinkConnector, SinkConnectorBuilder},
+    sources::{SourceConnector, Timeline},
+};
 use expr::{ExprHumanizer, GlobalId, MirScalarExpr, OptimizedMirRelationExpr};
 use persist::error::Error as PersistError;
 use persist::indexed::runtime::RuntimeClient as PersistClient;
@@ -955,7 +959,7 @@ impl Catalog {
                         CatalogItem::Source(Source {
                             create_sql: "TODO".to_string(),
                             optimized_expr,
-                            connector: dataflow_types::SourceConnector::Local {
+                            connector: dataflow_types::sources::SourceConnector::Local {
                                 timeline: Timeline::EpochMilliseconds,
                                 persisted_name: None,
                             },

--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -783,7 +783,7 @@ impl CatalogEntry {
         self.item.func(&self.name)
     }
 
-    /// Returns the [`dataflow_types::SourceConnector`] associated with
+    /// Returns the [`dataflow_types::sources::SourceConnector`] associated with
     /// this `CatalogEntry`.
     pub fn source_connector(&self) -> Result<&SourceConnector, SqlCatalogError> {
         self.item.source_connector(&self.name)

--- a/src/coord/src/catalog/builtin_table_updates.rs
+++ b/src/coord/src/catalog/builtin_table_updates.rs
@@ -9,7 +9,7 @@
 
 use std::os::unix::ffi::OsStringExt;
 
-use dataflow_types::{AvroOcfSinkConnector, KafkaSinkConnector};
+use dataflow_types::sinks::{AvroOcfSinkConnector, KafkaSinkConnector};
 use expr::{GlobalId, MirScalarExpr};
 use ore::collections::CollectionExt;
 use repr::adt::array::ArrayDimension;
@@ -180,10 +180,10 @@ impl CatalogState {
         diff: Diff,
     ) -> Vec<BuiltinTableUpdate> {
         let persist_name = match &source.connector {
-            dataflow_types::SourceConnector::External { persist, .. } => persist
+            dataflow_types::sources::SourceConnector::External { persist, .. } => persist
                 .as_ref()
                 .map(|persist| persist.primary_stream.name.as_str()),
-            dataflow_types::SourceConnector::Local { .. } => None,
+            dataflow_types::sources::SourceConnector::Local { .. } => None,
         };
         let persisted_name_datum = Datum::from(persist_name);
         vec![BuiltinTableUpdate {

--- a/src/coord/src/catalog/storage.rs
+++ b/src/coord/src/catalog/storage.rs
@@ -14,7 +14,7 @@ use rusqlite::types::{FromSql, FromSqlError, ToSql, ToSqlOutput, Value, ValueRef
 use rusqlite::OptionalExtension;
 use serde::{Deserialize, Serialize};
 
-use dataflow_types::MzOffset;
+use dataflow_types::sources::MzOffset;
 use expr::{GlobalId, PartitionId};
 use ore::cast::CastFrom;
 use repr::Timestamp;

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -109,12 +109,15 @@ use tokio::sync::{mpsc, oneshot, watch};
 use build_info::BuildInfo;
 use dataflow_types::client::TimestampBindingFeedback;
 use dataflow_types::logging::LoggingConfig as DataflowLoggingConfig;
+use dataflow_types::{sinks::SinkAsOf, sources::Timeline};
 use dataflow_types::{
-    DataflowDesc, DataflowDescription, ExternalSourceConnector, IndexDesc, PeekResponse,
-    PostgresSourceConnector, SinkConnector, SourceConnector, TailSinkConnector,
-    TimestampSourceUpdate, Update,
+    sinks::{SinkConnector, TailSinkConnector},
+    sources::{
+        persistence::TimestampSourceUpdate, ExternalSourceConnector, PostgresSourceConnector,
+        SourceConnector,
+    },
+    DataflowDesc, DataflowDescription, IndexDesc, PeekResponse, Update,
 };
-use dataflow_types::{SinkAsOf, Timeline};
 use expr::{
     ExprHumanizer, GlobalId, Id, MirRelationExpr, MirScalarExpr, NullaryFunc,
     OptimizedMirRelationExpr, RowSetFinishing,
@@ -1703,7 +1706,7 @@ where
         ];
         let df = self
             .catalog_transact(ops, |mut builder| {
-                let sink_description = dataflow_types::SinkDesc {
+                let sink_description = dataflow_types::sinks::SinkDesc {
                     from: sink.from,
                     from_desc: builder
                         .catalog
@@ -3163,7 +3166,7 @@ where
         let (tx, rx) = mpsc::unbounded_channel();
         self.pending_tails
             .insert(sink_id, PendingTail::new(tx, emit_progress, object_columns));
-        let sink_description = dataflow_types::SinkDesc {
+        let sink_description = dataflow_types::sinks::SinkDesc {
             from: source_id,
             from_desc: self.catalog.get_by_id(&source_id).desc().unwrap().clone(),
             connector: SinkConnector::Tail(TailSinkConnector::default()),

--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -105,7 +105,7 @@ impl<'a> DataflowBuilder<'a> {
                         };
                         dataflow.import_source(
                             *id,
-                            dataflow_types::SourceDesc {
+                            dataflow_types::sources::SourceDesc {
                                 name: entry.name().to_string(),
                                 connector,
                                 operators: None,
@@ -115,7 +115,7 @@ impl<'a> DataflowBuilder<'a> {
                         );
                     }
                     CatalogItem::Source(source) => {
-                        let source_connector = dataflow_types::SourceDesc {
+                        let source_connector = dataflow_types::sources::SourceDesc {
                             name: entry.name().to_string(),
                             connector: source.connector.clone(),
                             operators: None,
@@ -211,7 +211,7 @@ impl<'a> DataflowBuilder<'a> {
         &mut self,
         name: String,
         id: GlobalId,
-        sink_description: dataflow_types::SinkDesc,
+        sink_description: dataflow_types::sinks::SinkDesc,
     ) -> DataflowDesc {
         let mut dataflow = DataflowDesc::new(name);
         dataflow.set_as_of(sink_description.as_of.frontier.clone());

--- a/src/coord/src/persistcfg.rs
+++ b/src/coord/src/persistcfg.rs
@@ -17,9 +17,9 @@ use std::time::Duration;
 use timely::progress::Timestamp;
 
 use build_info::BuildInfo;
-use dataflow_types::{
-    EnvelopePersistDesc, ExternalSourceConnector, PersistStreamDesc, SourceConnector,
-    SourceEnvelope, SourcePersistDesc,
+use dataflow_types::sources::{
+    persistence::{EnvelopePersistDesc, PersistStreamDesc, SourcePersistDesc},
+    ExternalSourceConnector, SourceConnector, SourceEnvelope,
 };
 use itertools::Itertools;
 use ore::metrics::MetricsRegistry;

--- a/src/coord/src/sink_connector.rs
+++ b/src/coord/src/sink_connector.rs
@@ -19,7 +19,7 @@ use rdkafka::config::ClientConfig;
 use rdkafka::{Message, Offset, TopicPartitionList};
 
 use ::kafka_util::client::MzClientContext;
-use dataflow_types::{
+use dataflow_types::sinks::{
     AvroOcfSinkConnector, AvroOcfSinkConnectorBuilder, KafkaSinkConnector,
     KafkaSinkConnectorBuilder, KafkaSinkConnectorRetention, KafkaSinkConsistencyConnector,
     PublishedSchemaInfo, SinkConnector, SinkConnectorBuilder,
@@ -399,7 +399,7 @@ async fn build_kafka(
     .await
     .context("error registering kafka topic for sink")?;
     let published_schema_info = match builder.format {
-        dataflow_types::KafkaSinkFormat::Avro {
+        dataflow_types::sinks::KafkaSinkFormat::Avro {
             key_schema,
             value_schema,
             ccsr_config,
@@ -421,11 +421,11 @@ async fn build_kafka(
                 value_schema_id,
             })
         }
-        dataflow_types::KafkaSinkFormat::Json => None,
+        dataflow_types::sinks::KafkaSinkFormat::Json => None,
     };
 
     let consistency = match builder.consistency_format {
-        Some(dataflow_types::KafkaSinkFormat::Avro {
+        Some(dataflow_types::sinks::KafkaSinkFormat::Avro {
             value_schema,
             ccsr_config,
             ..

--- a/src/coord/src/timestamp.rs
+++ b/src/coord/src/timestamp.rs
@@ -32,10 +32,11 @@ use rdkafka::ClientConfig;
 use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn};
 
-use dataflow_types::{
-    Consistency, DataEncoding, DebeziumMode, ExternalSourceConnector, FileSourceConnector,
-    KafkaSourceConnector, KinesisSourceConnector, MzOffset, S3SourceConnector, SourceConnector,
-    SourceEnvelope, TimestampSourceUpdate,
+use dataflow_types::sources::{
+    encoding::DataEncoding,
+    persistence::{Consistency, TimestampSourceUpdate},
+    DebeziumMode, ExternalSourceConnector, FileSourceConnector, KafkaSourceConnector,
+    KinesisSourceConnector, MzOffset, S3SourceConnector, SourceConnector, SourceEnvelope,
 };
 use expr::{GlobalId, PartitionId};
 use kafka_util::client::MzClientContext;

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -22,8 +22,8 @@ use timely::progress::ChangeBatch;
 
 use crate::logging::LoggingConfig;
 use crate::{
-    DataflowDescription, MzOffset, PeekResponse, SourceConnector, TailResponse,
-    TimestampSourceUpdate, Update,
+    sources::MzOffset, sources::SourceConnector, DataflowDescription, PeekResponse, TailResponse,
+    Update,
 };
 use expr::{GlobalId, PartitionId, RowSetFinishing};
 use persist::indexed::runtime::RuntimeClient;
@@ -113,14 +113,14 @@ pub enum Command {
         /// The connector for the timestamped source.
         connector: SourceConnector,
         /// Previously stored timestamp bindings.
-        bindings: Vec<(PartitionId, Timestamp, MzOffset)>,
+        bindings: Vec<(PartitionId, Timestamp, crate::sources::MzOffset)>,
     },
     /// Advance worker timestamp
     AdvanceSourceTimestamp {
         /// The ID of the timestamped source
         id: GlobalId,
         /// The associated update (RT or BYO)
-        update: TimestampSourceUpdate,
+        update: crate::types::sources::persistence::TimestampSourceUpdate,
     },
     /// Drop all timestamping info for a source
     DropSourceTimestamping {

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -551,7 +551,7 @@ pub mod sources {
             pub topic: String,
         }
 
-        /// The details needed to make a source that uses an external [`SourceConnector`] persistent.
+        /// The details needed to make a source that uses an external [`super::SourceConnector`] persistent.
         #[derive(Clone, Debug, Serialize, Deserialize)]
         pub struct SourcePersistDesc {
             /// Name of the primary persisted stream of this source. This is what a consumer of the

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -13,26 +13,13 @@
 //! on the interface of the dataflow crate, and not its implementation, can
 //! avoid the dependency, as the dataflow crate is very slow to compile.
 
-use std::collections::{BTreeMap, HashMap, HashSet};
-use std::fmt;
-use std::ops::Add;
-use std::path::PathBuf;
-use std::time::Duration;
+use std::collections::{BTreeMap, HashSet};
 
-use anyhow::{anyhow, bail, Context};
-use globset::Glob;
-use http::Uri;
-use regex::Regex;
 use serde::{Deserialize, Serialize};
 use timely::progress::frontier::Antichain;
-use url::Url;
-use uuid::Uuid;
 
-use expr::{GlobalId, MirRelationExpr, MirScalarExpr, OptimizedMirRelationExpr, PartitionId};
-use interchange::avro::{self, DebeziumDeduplicationStrategy};
-use interchange::protobuf::{self, NormalizedProtobufMessageName};
-use kafka_util::KafkaAddrs;
-use repr::{ColumnType, Diff, RelationDesc, RelationType, Row, ScalarType, Timestamp};
+use expr::{GlobalId, MirRelationExpr, MirScalarExpr, OptimizedMirRelationExpr};
+use repr::{Diff, RelationType, Row, Timestamp};
 
 /// The response from a `Peek`.
 ///
@@ -92,7 +79,7 @@ pub struct BuildDesc<View> {
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct DataflowDescription<View> {
     /// Sources made available to the dataflow.
-    pub source_imports: BTreeMap<GlobalId, (SourceDesc, GlobalId)>,
+    pub source_imports: BTreeMap<GlobalId, (crate::types::sources::SourceDesc, GlobalId)>,
     /// Indexes made available to the dataflow.
     pub index_imports: BTreeMap<GlobalId, (IndexDesc, RelationType)>,
     /// Views and indexes to be built and stored in the local context.
@@ -104,7 +91,7 @@ pub struct DataflowDescription<View> {
     pub index_exports: Vec<(GlobalId, IndexDesc, RelationType)>,
     /// sinks to be created
     /// (id of new sink, description of sink)
-    pub sink_exports: Vec<(GlobalId, SinkDesc)>,
+    pub sink_exports: Vec<(GlobalId, crate::types::sinks::SinkDesc)>,
     /// Maps views to views + indexes needed to generate that view
     pub dependent_objects: BTreeMap<GlobalId, Vec<GlobalId>>,
     /// An optional frontier to which inputs should be advanced.
@@ -155,7 +142,12 @@ impl DataflowDescription<OptimizedMirRelationExpr> {
     ///
     /// The `orig_id` identifier must be set correctly, and is used to index various
     /// internal data structures. Little else is known about it.
-    pub fn import_source(&mut self, id: GlobalId, description: SourceDesc, orig_id: GlobalId) {
+    pub fn import_source(
+        &mut self,
+        id: GlobalId,
+        description: crate::types::sources::SourceDesc,
+        orig_id: GlobalId,
+    ) {
         self.source_imports.insert(id, (description, orig_id));
     }
 
@@ -188,7 +180,7 @@ impl DataflowDescription<OptimizedMirRelationExpr> {
     }
 
     /// Exports as `id` a sink described by `description`.
-    pub fn export_sink(&mut self, id: GlobalId, description: SinkDesc) {
+    pub fn export_sink(&mut self, id: GlobalId, description: crate::types::sinks::SinkDesc) {
         self.sink_exports.push((id, description));
     }
 
@@ -289,1159 +281,1229 @@ impl<View> DataflowDescription<View> {
     }
 }
 
-/// A description of how to interpret data from various sources
-///
-/// Almost all sources only present values as part of their records, but Kafka allows a key to be
-/// associated with each record, which has a possibly independent encoding.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum SourceDataEncoding {
-    Single(DataEncoding),
-    KeyValue {
-        key: DataEncoding,
-        value: DataEncoding,
-    },
-}
+/// Types and traits related to the introduction of changing collections into `dataflow`.
+pub mod sources {
 
-/// A description of how each row should be decoded, from a string of bytes to a sequence of
-/// Differential updates.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum DataEncoding {
-    Avro(AvroEncoding),
-    AvroOcf(AvroOcfEncoding),
-    Protobuf(ProtobufEncoding),
-    Csv(CsvEncoding),
-    Regex(RegexEncoding),
-    Postgres,
-    Bytes,
-    Text,
-}
+    use std::collections::{BTreeMap, HashMap};
+    use std::ops::Add;
+    use std::path::PathBuf;
+    use std::time::Duration;
 
-impl SourceDataEncoding {
-    pub fn key_ref(&self) -> Option<&DataEncoding> {
-        match self {
-            SourceDataEncoding::Single(_) => None,
-            SourceDataEncoding::KeyValue { key, .. } => Some(key),
-        }
-    }
+    use anyhow::{anyhow, bail, Context};
+    use globset::Glob;
+    use http::Uri;
+    use serde::{Deserialize, Serialize};
+    use uuid::Uuid;
 
-    /// Return either the Single encoding if this was a `SourceDataEncoding::Single`, else return the value encoding
-    pub fn value(self) -> DataEncoding {
-        match self {
-            SourceDataEncoding::Single(encoding) => encoding,
-            SourceDataEncoding::KeyValue { value, .. } => value,
-        }
-    }
+    use interchange::avro::{self, DebeziumDeduplicationStrategy};
+    use kafka_util::KafkaAddrs;
+    use repr::{ColumnType, RelationDesc, RelationType, ScalarType};
 
-    pub fn value_ref(&self) -> &DataEncoding {
-        match self {
-            SourceDataEncoding::Single(encoding) => encoding,
-            SourceDataEncoding::KeyValue { value, .. } => value,
-        }
-    }
+    // Types and traits related to the *decoding* of data for sources.
+    pub mod encoding {
 
-    pub fn desc(&self) -> Result<(Option<RelationDesc>, RelationDesc), anyhow::Error> {
-        Ok(match self {
-            SourceDataEncoding::Single(value) => (None, value.desc()?),
-            SourceDataEncoding::KeyValue { key, value } => (Some(key.desc()?), value.desc()?),
-        })
-    }
-}
+        use anyhow::Context;
+        use regex::Regex;
+        use serde::{Deserialize, Serialize};
 
-pub fn included_column_desc(included_columns: Vec<(&str, ColumnType)>) -> RelationDesc {
-    let mut desc = RelationDesc::empty();
-    for (name, ty) in included_columns {
-        desc = desc.with_column(name, ty);
-    }
-    desc
-}
+        use interchange::avro::{self};
+        use interchange::protobuf::{self, NormalizedProtobufMessageName};
+        use repr::{ColumnType, RelationDesc, ScalarType};
 
-impl DataEncoding {
-    /// Computes the [`RelationDesc`] for the relation specified by this
-    /// data encoding and envelope.
-    ///
-    /// If a key desc is provided it will be prepended to the returned desc
-    fn desc(&self) -> Result<RelationDesc, anyhow::Error> {
-        // Add columns for the data, based on the encoding format.
-        Ok(match self {
-            DataEncoding::Bytes => {
-                RelationDesc::empty().with_column("data", ScalarType::Bytes.nullable(false))
-            }
-            DataEncoding::AvroOcf(AvroOcfEncoding {
-                reader_schema: schema,
-                ..
-            })
-            | DataEncoding::Avro(AvroEncoding { schema, .. }) => {
-                let parsed_schema = avro::parse_schema(schema).context("validating avro schema")?;
-                avro::schema_to_relationdesc(parsed_schema).context("validating avro schema")?
-            }
-            DataEncoding::Protobuf(ProtobufEncoding {
-                descriptors,
-                message_name,
-                schema_registry_config: _,
-            }) => protobuf::DecodedDescriptors::from_bytes(descriptors, message_name.to_owned())?
-                .columns()
-                .iter()
-                .fold(RelationDesc::empty(), |desc, (name, ty)| {
-                    desc.with_column(name, ty.clone())
-                }),
-            DataEncoding::Regex(RegexEncoding { regex }) => regex
-                .capture_names()
-                .enumerate()
-                // The first capture is the entire matched string. This will
-                // often not be useful, so skip it. If people want it they can
-                // just surround their entire regex in an explicit capture
-                // group.
-                .skip(1)
-                .fold(RelationDesc::empty(), |desc, (i, name)| {
-                    let name = match name {
-                        None => format!("column{}", i),
-                        Some(name) => name.to_owned(),
-                    };
-                    let ty = ScalarType::String.nullable(true);
-                    desc.with_column(name, ty)
-                }),
-            DataEncoding::Csv(CsvEncoding { columns, .. }) => match columns {
-                ColumnSpec::Count(n) => {
-                    (1..=*n).into_iter().fold(RelationDesc::empty(), |desc, i| {
-                        desc.with_column(format!("column{}", i), ScalarType::String.nullable(false))
-                    })
-                }
-                ColumnSpec::Header { names } => names
-                    .iter()
-                    .map(|s| &**s)
-                    .fold(RelationDesc::empty(), |desc, name| {
-                        desc.with_column(name, ScalarType::String.nullable(false))
-                    }),
+        /// A description of how to interpret data from various sources
+        ///
+        /// Almost all sources only present values as part of their records, but Kafka allows a key to be
+        /// associated with each record, which has a possibly independent encoding.
+        #[derive(Clone, Debug, Serialize, Deserialize)]
+        pub enum SourceDataEncoding {
+            Single(DataEncoding),
+            KeyValue {
+                key: DataEncoding,
+                value: DataEncoding,
             },
-            DataEncoding::Text => {
-                RelationDesc::empty().with_column("text", ScalarType::String.nullable(false))
-            }
-            DataEncoding::Postgres => RelationDesc::empty()
-                .with_column("oid", ScalarType::Int32.nullable(false))
-                .with_column(
-                    "row_data",
-                    ScalarType::List {
-                        element_type: Box::new(ScalarType::String),
-                        custom_oid: None,
-                    }
-                    .nullable(false),
-                ),
-        })
-    }
-
-    pub fn op_name(&self) -> &'static str {
-        match self {
-            DataEncoding::Bytes => "Bytes",
-            DataEncoding::AvroOcf { .. } => "AvroOcf",
-            DataEncoding::Avro(_) => "Avro",
-            DataEncoding::Protobuf(_) => "Protobuf",
-            DataEncoding::Regex { .. } => "Regex",
-            DataEncoding::Csv(_) => "Csv",
-            DataEncoding::Text => "Text",
-            DataEncoding::Postgres => "Postgres",
         }
-    }
-}
 
-/// Encoding in Avro format.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct AvroEncoding {
-    pub schema: String,
-    pub schema_registry_config: Option<ccsr::ClientConfig>,
-    pub confluent_wire_format: bool,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct AvroOcfEncoding {
-    pub reader_schema: String,
-}
-
-/// Encoding in Protobuf format.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct ProtobufEncoding {
-    pub descriptors: Vec<u8>,
-    pub message_name: NormalizedProtobufMessageName,
-    pub schema_registry_config: Option<ccsr::ClientConfig>,
-}
-
-/// Arguments necessary to define how to decode from CSV format
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct CsvEncoding {
-    pub columns: ColumnSpec,
-    pub delimiter: u8,
-}
-
-/// Determines the RelationDesc and decoding of CSV objects
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum ColumnSpec {
-    /// The first row is not a header row, and all columns get default names like `columnN`.
-    Count(usize),
-    /// The first row is a header row and therefore does become data
-    ///
-    /// Each of the values in `names` becomes the default name of a column in the dataflow.
-    Header { names: Vec<String> },
-}
-
-impl ColumnSpec {
-    /// The number of columns described by the column spec.
-    pub fn arity(&self) -> usize {
-        match self {
-            ColumnSpec::Count(n) => *n,
-            ColumnSpec::Header { names } => names.len(),
+        /// A description of how each row should be decoded, from a string of bytes to a sequence of
+        /// Differential updates.
+        #[derive(Clone, Debug, Serialize, Deserialize)]
+        pub enum DataEncoding {
+            Avro(AvroEncoding),
+            AvroOcf(AvroOcfEncoding),
+            Protobuf(ProtobufEncoding),
+            Csv(CsvEncoding),
+            Regex(RegexEncoding),
+            Postgres,
+            Bytes,
+            Text,
         }
-    }
 
-    pub fn into_header_names(self) -> Option<Vec<String>> {
-        match self {
-            ColumnSpec::Count(_) => None,
-            ColumnSpec::Header { names } => Some(names),
-        }
-    }
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct RegexEncoding {
-    #[serde(with = "serde_regex")]
-    pub regex: Regex,
-}
-
-/// A source of updates for a relational collection.
-///
-/// A source contains enough information to instantiate a stream of changes,
-/// as well as related metadata about the columns, their types, and properties
-/// of the collection.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct SourceDesc {
-    pub name: String,
-    pub connector: SourceConnector,
-    /// Optionally, filtering and projection that may optimistically be applied
-    /// to the output of the source.
-    pub operators: Option<LinearOperator>,
-    pub bare_desc: RelationDesc,
-}
-
-/// A sink for updates to a relational collection.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct SinkDesc {
-    pub from: GlobalId,
-    pub from_desc: RelationDesc,
-    pub connector: SinkConnector,
-    pub envelope: Option<SinkEnvelope>,
-    pub as_of: SinkAsOf,
-}
-
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub enum SinkEnvelope {
-    Debezium,
-    Upsert,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct SinkAsOf {
-    pub frontier: Antichain<Timestamp>,
-    pub strict: bool,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum SourceEnvelope {
-    /// If present, include the key columns as an output column of the source with the given properties.
-    None(KeyEnvelope),
-    Debezium(DebeziumDeduplicationStrategy, DebeziumMode),
-    Upsert(KeyEnvelope),
-    CdcV2,
-}
-
-/// Computes the indices of the value's relation description that appear in the key.
-///
-/// Returns an error if it detects a common columns between the two relations that has the same
-/// name but a different type, if a key column is missing from the value, and if the key relation
-/// has a column with no name.
-pub fn match_key_indices(
-    key_desc: &RelationDesc,
-    value_desc: &RelationDesc,
-) -> anyhow::Result<Vec<usize>> {
-    let mut indices = Vec::new();
-    for (name, key_type) in key_desc.iter() {
-        let (index, value_type) = value_desc
-            .get_by_name(name)
-            .ok_or_else(|| anyhow!("Value schema missing primary key column: {}", name))?;
-
-        if key_type == value_type {
-            indices.push(index);
-        } else {
-            bail!(
-                "key and value column types do not match: key {:?} vs. value {:?}",
-                key_type,
-                value_type
-            );
-        }
-    }
-    Ok(indices)
-}
-
-impl SourceEnvelope {
-    pub fn get_avro_envelope_type(&self) -> avro::EnvelopeType {
-        match self {
-            SourceEnvelope::None(_) => avro::EnvelopeType::None,
-            SourceEnvelope::Debezium { .. } => avro::EnvelopeType::Debezium,
-            SourceEnvelope::Upsert(_) => avro::EnvelopeType::Upsert,
-            SourceEnvelope::CdcV2 => avro::EnvelopeType::CdcV2,
-        }
-    }
-    /// Computes the output relation of this envelope when applied on top of the decoded key and
-    /// value relation desc
-    pub fn desc(
-        &self,
-        key_desc: Option<RelationDesc>,
-        value_desc: RelationDesc,
-        metadata_desc: RelationDesc,
-    ) -> anyhow::Result<RelationDesc> {
-        Ok(match self {
-            SourceEnvelope::None(key_envelope) | SourceEnvelope::Upsert(key_envelope) => {
-                let key_desc = match key_desc {
-                    Some(desc) => desc,
-                    None => return Ok(value_desc.concat(metadata_desc)),
-                };
-
-                let keyed = match key_envelope {
-                    KeyEnvelope::None => value_desc,
-                    KeyEnvelope::Flattened => {
-                        // Add the key columns as a key.
-                        let key_indices = (0..key_desc.arity()).collect();
-                        let key_desc = key_desc.with_key(key_indices);
-                        key_desc.concat(value_desc)
-                    }
-                    KeyEnvelope::LegacyUpsert => {
-                        let key_indices = (0..key_desc.arity()).collect();
-                        let key_desc = key_desc.with_key(key_indices);
-                        let names = (0..key_desc.arity()).map(|i| format!("key{}", i));
-                        // Rename key columns to "keyN"
-                        key_desc.with_names(names).concat(value_desc)
-                    }
-                    KeyEnvelope::Named(key_name) => {
-                        let key_desc = {
-                            // if the key has multiple objects, nest them as a record inside of a single name
-                            if key_desc.arity() > 1 {
-                                let key_type = key_desc.typ();
-                                let key_as_record = RelationType::new(vec![ColumnType {
-                                    nullable: false,
-                                    scalar_type: ScalarType::Record {
-                                        fields: key_desc
-                                            .iter_names()
-                                            .zip(key_type.column_types.iter())
-                                            .map(|(name, ty)| (name.clone(), ty.clone()))
-                                            .collect(),
-                                        custom_oid: None,
-                                        custom_name: None,
-                                    },
-                                }]);
-
-                                RelationDesc::new(key_as_record, [key_name.to_string()])
-                            } else {
-                                key_desc.with_names([key_name.to_string()])
-                            }
-                        };
-                        // In all cases the first column is the key
-                        key_desc.with_key(vec![0]).concat(value_desc)
-                    }
-                };
-                keyed.concat(metadata_desc)
-            }
-            SourceEnvelope::Debezium(..) => {
-                // TODO [btv] - Get rid of this, when we can. Right now source processing is still
-                // not fully orthogonal, so we have some special logic in the debezium processor
-                // that only passes on the first two columns ("before" and "after"), and uses the
-                // information in the other ones itself
-                let mut diter = value_desc.into_iter();
-                let mut key = diter
-                    .next()
-                    .ok_or_else(|| anyhow::anyhow!("Spec does not contain key"))?;
-                match &mut key.1.scalar_type {
-                    ScalarType::Record { fields, .. } => {
-                        fields.extend(metadata_desc.iter().map(|(k, v)| (k.clone(), v.clone())))
-                    }
-                    ty => bail!(
-                        "Incorrect type for Debezium value, expected Record, got {:?}",
-                        ty
-                    ),
+        impl SourceDataEncoding {
+            pub fn key_ref(&self) -> Option<&DataEncoding> {
+                match self {
+                    SourceDataEncoding::Single(_) => None,
+                    SourceDataEncoding::KeyValue { key, .. } => Some(key),
                 }
-                let mut value = diter
-                    .next()
-                    .ok_or_else(|| anyhow::anyhow!("Spec does not contain value"))?;
-                match &mut value.1.scalar_type {
-                    ScalarType::Record { fields, .. } => fields.extend(metadata_desc),
-                    ty => bail!(
-                        "Incorrect type for Debezium value, expected Record, got {:?}",
-                        ty
-                    ),
-                }
-                RelationDesc::from_names_and_types([key, value].into_iter())
             }
-            SourceEnvelope::CdcV2 => {
-                // TODO: Validate that the value schema has an `updates` and `progress` column of
-                // the correct types
 
-                // CdcV2 row data are in a record in a record in a list
-                match &value_desc.typ().column_types[0].scalar_type {
-                    ScalarType::List { element_type, .. } => match &**element_type {
-                        ScalarType::Record { fields, .. } => {
-                            // TODO maybe check this by name
-                            match &fields[0].1.scalar_type {
-                                ScalarType::Record { fields, .. } => {
-                                    RelationDesc::from_names_and_types(fields.clone())
-                                }
-                                ty => bail!("Unepxected type for MATERIALIZE envelope: {:?}", ty),
-                            }
+            /// Return either the Single encoding if this was a `SourceDataEncoding::Single`, else return the value encoding
+            pub fn value(self) -> DataEncoding {
+                match self {
+                    SourceDataEncoding::Single(encoding) => encoding,
+                    SourceDataEncoding::KeyValue { value, .. } => value,
+                }
+            }
+
+            pub fn value_ref(&self) -> &DataEncoding {
+                match self {
+                    SourceDataEncoding::Single(encoding) => encoding,
+                    SourceDataEncoding::KeyValue { value, .. } => value,
+                }
+            }
+
+            pub fn desc(&self) -> Result<(Option<RelationDesc>, RelationDesc), anyhow::Error> {
+                Ok(match self {
+                    SourceDataEncoding::Single(value) => (None, value.desc()?),
+                    SourceDataEncoding::KeyValue { key, value } => {
+                        (Some(key.desc()?), value.desc()?)
+                    }
+                })
+            }
+        }
+
+        pub fn included_column_desc(included_columns: Vec<(&str, ColumnType)>) -> RelationDesc {
+            let mut desc = RelationDesc::empty();
+            for (name, ty) in included_columns {
+                desc = desc.with_column(name, ty);
+            }
+            desc
+        }
+
+        impl DataEncoding {
+            /// Computes the [`RelationDesc`] for the relation specified by this
+            /// data encoding and envelope.
+            ///
+            /// If a key desc is provided it will be prepended to the returned desc
+            fn desc(&self) -> Result<RelationDesc, anyhow::Error> {
+                // Add columns for the data, based on the encoding format.
+                Ok(match self {
+                    DataEncoding::Bytes => {
+                        RelationDesc::empty().with_column("data", ScalarType::Bytes.nullable(false))
+                    }
+                    DataEncoding::AvroOcf(AvroOcfEncoding {
+                        reader_schema: schema,
+                        ..
+                    })
+                    | DataEncoding::Avro(AvroEncoding { schema, .. }) => {
+                        let parsed_schema =
+                            avro::parse_schema(schema).context("validating avro schema")?;
+                        avro::schema_to_relationdesc(parsed_schema)
+                            .context("validating avro schema")?
+                    }
+                    DataEncoding::Protobuf(ProtobufEncoding {
+                        descriptors,
+                        message_name,
+                        schema_registry_config: _,
+                    }) => protobuf::DecodedDescriptors::from_bytes(
+                        descriptors,
+                        message_name.to_owned(),
+                    )?
+                    .columns()
+                    .iter()
+                    .fold(RelationDesc::empty(), |desc, (name, ty)| {
+                        desc.with_column(name, ty.clone())
+                    }),
+                    DataEncoding::Regex(RegexEncoding { regex }) => regex
+                        .capture_names()
+                        .enumerate()
+                        // The first capture is the entire matched string. This will
+                        // often not be useful, so skip it. If people want it they can
+                        // just surround their entire regex in an explicit capture
+                        // group.
+                        .skip(1)
+                        .fold(RelationDesc::empty(), |desc, (i, name)| {
+                            let name = match name {
+                                None => format!("column{}", i),
+                                Some(name) => name.to_owned(),
+                            };
+                            let ty = ScalarType::String.nullable(true);
+                            desc.with_column(name, ty)
+                        }),
+                    DataEncoding::Csv(CsvEncoding { columns, .. }) => match columns {
+                        ColumnSpec::Count(n) => {
+                            (1..=*n).into_iter().fold(RelationDesc::empty(), |desc, i| {
+                                desc.with_column(
+                                    format!("column{}", i),
+                                    ScalarType::String.nullable(false),
+                                )
+                            })
                         }
-                        ty => bail!("Unepxected type for MATERIALIZE envelope: {:?}", ty),
+                        ColumnSpec::Header { names } => names
+                            .iter()
+                            .map(|s| &**s)
+                            .fold(RelationDesc::empty(), |desc, name| {
+                                desc.with_column(name, ScalarType::String.nullable(false))
+                            }),
                     },
-                    ty => bail!("Unepxected type for MATERIALIZE envelope: {:?}", ty),
+                    DataEncoding::Text => RelationDesc::empty()
+                        .with_column("text", ScalarType::String.nullable(false)),
+                    DataEncoding::Postgres => RelationDesc::empty()
+                        .with_column("oid", ScalarType::Int32.nullable(false))
+                        .with_column(
+                            "row_data",
+                            ScalarType::List {
+                                element_type: Box::new(ScalarType::String),
+                                custom_oid: None,
+                            }
+                            .nullable(false),
+                        ),
+                })
+            }
+
+            pub fn op_name(&self) -> &'static str {
+                match self {
+                    DataEncoding::Bytes => "Bytes",
+                    DataEncoding::AvroOcf { .. } => "AvroOcf",
+                    DataEncoding::Avro(_) => "Avro",
+                    DataEncoding::Protobuf(_) => "Protobuf",
+                    DataEncoding::Regex { .. } => "Regex",
+                    DataEncoding::Csv(_) => "Csv",
+                    DataEncoding::Text => "Text",
+                    DataEncoding::Postgres => "Postgres",
                 }
             }
-        })
+        }
+
+        /// Encoding in Avro format.
+        #[derive(Clone, Debug, Serialize, Deserialize)]
+        pub struct AvroEncoding {
+            pub schema: String,
+            pub schema_registry_config: Option<ccsr::ClientConfig>,
+            pub confluent_wire_format: bool,
+        }
+
+        #[derive(Clone, Debug, Serialize, Deserialize)]
+        pub struct AvroOcfEncoding {
+            pub reader_schema: String,
+        }
+
+        /// Encoding in Protobuf format.
+        #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+        pub struct ProtobufEncoding {
+            pub descriptors: Vec<u8>,
+            pub message_name: NormalizedProtobufMessageName,
+            pub schema_registry_config: Option<ccsr::ClientConfig>,
+        }
+
+        /// Arguments necessary to define how to decode from CSV format
+        #[derive(Clone, Debug, Serialize, Deserialize)]
+        pub struct CsvEncoding {
+            pub columns: ColumnSpec,
+            pub delimiter: u8,
+        }
+
+        /// Determines the RelationDesc and decoding of CSV objects
+        #[derive(Clone, Debug, Serialize, Deserialize)]
+        pub enum ColumnSpec {
+            /// The first row is not a header row, and all columns get default names like `columnN`.
+            Count(usize),
+            /// The first row is a header row and therefore does become data
+            ///
+            /// Each of the values in `names` becomes the default name of a column in the dataflow.
+            Header { names: Vec<String> },
+        }
+
+        impl ColumnSpec {
+            /// The number of columns described by the column spec.
+            pub fn arity(&self) -> usize {
+                match self {
+                    ColumnSpec::Count(n) => *n,
+                    ColumnSpec::Header { names } => names.len(),
+                }
+            }
+
+            pub fn into_header_names(self) -> Option<Vec<String>> {
+                match self {
+                    ColumnSpec::Count(_) => None,
+                    ColumnSpec::Header { names } => Some(names),
+                }
+            }
+        }
+
+        #[derive(Clone, Debug, Serialize, Deserialize)]
+        pub struct RegexEncoding {
+            #[serde(with = "serde_regex")]
+            pub regex: Regex,
+        }
     }
-}
 
-/// Legacy logic included something like an offset into almost data streams
-///
-/// Eventually we will require `INCLUDE <metadata>` for everything.
-pub fn provide_default_metadata(envelope: &SourceEnvelope, encoding: &DataEncoding) -> bool {
-    let is_avro = matches!(encoding, DataEncoding::Avro(_));
-    let is_stateless_dbz = matches!(envelope, SourceEnvelope::Debezium(_, DebeziumMode::Plain));
+    pub mod persistence {
 
-    !is_avro && !is_stateless_dbz
-}
+        use serde::{Deserialize, Serialize};
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub enum DebeziumMode {
-    Plain,
-    /// Keep track of keys from upstream and discard retractions for new keys
-    Upsert,
-}
+        use expr::PartitionId;
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub enum Compression {
-    Gzip,
-    None,
-}
+        /// A struct to hold more specific information about where a BYO source
+        /// came from so we can differentiate between topics of the same name across
+        /// different brokers.
+        #[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Serialize, Deserialize, Hash)]
+        pub struct BringYourOwn {
+            pub broker: String,
+            pub topic: String,
+        }
 
-/// The meaning of the timestamp number produced by data sources. This type
-/// is not concerned with the source of the timestamp (like if the data came
-/// from a Debezium consistency topic or a CDCv2 stream), instead only what the
-/// timestamp number means.
-///
-/// Some variants here have attached data used to differentiate incomparable
-/// instantiations. These attached data types should be expanded in the future
-/// if we need to tell apart more kinds of sources.
-#[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Serialize, Deserialize, Hash)]
-pub enum Timeline {
-    /// EpochMilliseconds means the timestamp is the number of milliseconds since
-    /// the Unix epoch.
-    EpochMilliseconds,
-    /// Counter means the timestamp starts at 1 and is incremented for each
-    /// transaction. It holds the BYO source so different instantiations can be
-    /// differentiated.
-    Counter(BringYourOwn),
-    /// External means the timestamp comes from an external data source and we
-    /// don't know what the number means. The attached String is the source's name,
-    /// which will result in different sources being incomparable.
-    External(String),
-    /// User means the user has manually specified a timeline. The attached
-    /// String is specified by the user, allowing them to decide sources that are
-    /// joinable.
-    User(String),
-}
+        /// The details needed to make a source that uses an external [`SourceConnector`] persistent.
+        #[derive(Clone, Debug, Serialize, Deserialize)]
+        pub struct SourcePersistDesc {
+            /// Name of the primary persisted stream of this source. This is what a consumer of the
+            /// persisted data would be interested in while the secondary stream(s) of the source are an
+            /// internal implementation detail.
+            pub primary_stream: PersistStreamDesc,
 
-/// A struct to hold more specific information about where a BYO source
-/// came from so we can differentiate between topics of the same name across
-/// different brokers.
-#[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Serialize, Deserialize, Hash)]
-pub struct BringYourOwn {
-    pub broker: String,
-    pub topic: String,
-}
+            /// Persisted stream of timestamp bindings.
+            pub timestamp_bindings_stream: PersistStreamDesc,
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum SourceConnector {
-    External {
-        connector: ExternalSourceConnector,
-        encoding: SourceDataEncoding,
-        envelope: SourceEnvelope,
-        consistency: Consistency,
-        ts_frequency: Duration,
-        timeline: Timeline,
-        persist: Option<SourcePersistDesc>,
-    },
+            /// Any additional details that we need to make the envelope logic stateful.
+            pub envelope_desc: EnvelopePersistDesc,
+        }
 
-    /// A local "source" is either fed by a local input handle, or by reading from a
-    /// `persisted_source()`. For non-persisted sources, values that are to be inserted
-    /// are sent from the coordinator and pushed into the handle on a worker.
+        /// The persistence details we need for persisting a source envelopes data structures.
+        ///
+        /// This is a 1:1 mapping from envelope to `EnvelopePersistDesc`, as opposed to having a `None`
+        /// that covers all envelopes that don't need additional data. Mostly, to just be explicit, but
+        /// also because there is already a `NONE` envelope.
+        ///
+        /// Some envelopes will require additional streams, which should be listed in the variant.
+        #[derive(Debug, Clone, Serialize, Deserialize)]
+        pub enum EnvelopePersistDesc {
+            Upsert,
+        }
+
+        /// Description of a single persistent stream.
+        #[derive(Debug, Clone, Serialize, Deserialize)]
+        pub struct PersistStreamDesc {
+            /// Name of the persistent stream.
+            pub name: String,
+            /// The _current_ upper seal timestamp of this stream.
+            ///
+            /// NOTE: This timestamp is determined when the coordinator starts up or when the source is
+            /// initially created. When a source is actively writing to this stream, the seal timestamp
+            /// will progress beyond this timestamp.
+            ///
+            /// This is okay for now because we only want to allow one source instantiation for persistent
+            /// sources, meaning the flow is usually this:
+            ///
+            ///  1. coordinator determines seal timestamp
+            ///  2. seal timestamps for a source are sent to dataflow when rendering a source
+            ///  3. coordinator (or anyone) never looks at this timestamp again.
+            ///
+            /// And when we restart, we start from step 1., at which time we are guaranteed not to have a
+            /// source running already.
+            pub upper_seal_ts: u64,
+            /// The _current_ compaction frontier (aka _since_) of this stream.
+            ///
+            /// NOTE: This timestamp is determined when the coordinator starts up or when the source is
+            /// initially created. When a source is actively writing to this stream and allowing
+            /// compaction, this will progress beyond this timestamp.
+            ///
+            /// This is okay for now because we only want to allow one source instantiation for persistent
+            /// sources, meaning the flow is usually this:
+            ///
+            ///  1. coordinator determines since timestamp
+            ///  2. timestamps for a source are sent to dataflow when rendering a source
+            ///  3. coordinator (or anyone) never looks at this timestamp again.
+            ///
+            /// And when we restart, we start from step 1., at which time we are guaranteed not to have a
+            /// source running already.
+            pub since_ts: u64,
+        }
+
+        #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+        pub enum Consistency {
+            BringYourOwn(BringYourOwn),
+            RealTime,
+        }
+
+        /// Structure wrapping a timestamp update from a source
+        /// If RT, contains a partition count
+        /// If BYO, contains a tuple (PartitionCount, PartitionID, Timestamp, Offset),
+        /// which informs workers that messages with Offset on PartititionId will be timestamped
+        /// with Timestamp.
+        #[derive(Clone, Debug, Serialize, Deserialize)]
+        pub enum TimestampSourceUpdate {
+            /// Update for an RT source: contains a new partition to add to this source.
+            RealTime(PartitionId),
+            /// Timestamp update for a BYO source: contains a PartitionID, Timestamp,
+            /// MzOffset tuple. This tuple informs workers that messages with Offset on
+            /// PartitionId will be timestamped with Timestamp.
+            BringYourOwn(PartitionId, u64, super::MzOffset),
+        }
+    }
+
+    /// Universal language for describing message positions in Materialize, in a source independent
+    /// way. Invidual sources like Kafka or File sources should explicitly implement their own offset
+    /// type that converts to/From MzOffsets. A 0-MzOffset denotes an empty stream.
+    #[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Eq, Hash, Serialize, Deserialize)]
+    pub struct MzOffset {
+        pub offset: i64,
+    }
+
+    impl std::fmt::Display for MzOffset {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{}", self.offset)
+        }
+    }
+
+    impl Add<i64> for MzOffset {
+        type Output = MzOffset;
+
+        fn add(self, x: i64) -> MzOffset {
+            MzOffset {
+                offset: self.offset + x,
+            }
+        }
+    }
+
+    #[derive(Clone, Copy, Eq, PartialEq)]
+    pub struct KafkaOffset {
+        pub offset: i64,
+    }
+
+    /// Convert from KafkaOffset to MzOffset (1-indexed)
+    impl From<KafkaOffset> for MzOffset {
+        fn from(kafka_offset: KafkaOffset) -> Self {
+            MzOffset {
+                offset: kafka_offset.offset + 1,
+            }
+        }
+    }
+
+    /// Convert from MzOffset to Kafka::Offset as long as
+    /// the offset is not negative
+    impl Into<KafkaOffset> for MzOffset {
+        fn into(self) -> KafkaOffset {
+            KafkaOffset {
+                offset: self.offset - 1,
+            }
+        }
+    }
+
+    /// Which piece of metadata a column corresponds to
+    #[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    pub enum IncludedColumnSource {
+        /// The materialize-specific notion of "position"
+        ///
+        /// This is legacy, and should be removed when default metadata is no longer included
+        DefaultPosition,
+        Partition,
+        Offset,
+        Timestamp,
+        Topic,
+    }
+
+    /// Whether and how to include the decoded key of a stream in dataflows
+    #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    pub enum KeyEnvelope {
+        /// Never include the key in the output row
+        None,
+        /// For composite key encodings, pull the fields from the encoding into columns.
+        Flattened,
+        /// Upsert is identical to Flattened but differs for non-avro sources, for which key names are overwritten.
+        LegacyUpsert,
+        /// Always use the given name for the key.
+        ///
+        /// * For a single-field key, this means that the column will get the given name.
+        /// * For a multi-column key, the columns will get packed into a [`ScalarType::Record`], and
+        ///   that Record will get the given name.
+        Named(String),
+    }
+
+    /// A column that was created via an `INCLUDE` expression
+    #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    pub struct IncludedColumnPos {
+        pub name: String,
+        pub pos: usize,
+    }
+
+    /// The meaning of the timestamp number produced by data sources. This type
+    /// is not concerned with the source of the timestamp (like if the data came
+    /// from a Debezium consistency topic or a CDCv2 stream), instead only what the
+    /// timestamp number means.
     ///
-    /// For persisted sources, the coordinator only writes new values to a persistent
-    /// stream. These values will then "show up" here because we read from the same
-    /// persistent stream.
-    // TODO: We could split this up into a `Local` source, that is only fed by a local handle and a
-    // `LocalPersistenceSource` which is fed from a `persisted_source()`. But moving the
-    // persist_name from `SourceDesc` to here is already a huge simplification/clarification. The
-    // persist description on a `SourceDesc` is now purely used to signal that a source actively
-    // persists, while a `LocalPersistenceSource` is a source that happens to read from persistence
-    // but doesn't persist itself.
-    //
-    // That additional split seems like a bigger undertaking, though, because it also needs changes
-    // to the coordinator. And I don't know if I want to invest too much time there when I don't
-    // yet know how Tables will work in a post-ingestd world.
-    Local {
-        timeline: Timeline,
-        persisted_name: Option<String>,
-    },
-}
+    /// Some variants here have attached data used to differentiate incomparable
+    /// instantiations. These attached data types should be expanded in the future
+    /// if we need to tell apart more kinds of sources.
+    #[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Serialize, Deserialize, Hash)]
+    pub enum Timeline {
+        /// EpochMilliseconds means the timestamp is the number of milliseconds since
+        /// the Unix epoch.
+        EpochMilliseconds,
+        /// Counter means the timestamp starts at 1 and is incremented for each
+        /// transaction. It holds the BYO source so different instantiations can be
+        /// differentiated.
+        Counter(crate::types::sources::persistence::BringYourOwn),
+        /// External means the timestamp comes from an external data source and we
+        /// don't know what the number means. The attached String is the source's name,
+        /// which will result in different sources being incomparable.
+        External(String),
+        /// User means the user has manually specified a timeline. The attached
+        /// String is specified by the user, allowing them to decide sources that are
+        /// joinable.
+        User(String),
+    }
 
-/// The details needed to make a source that uses an external [`SourceConnector`] persistent.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct SourcePersistDesc {
-    /// Name of the primary persisted stream of this source. This is what a consumer of the
-    /// persisted data would be interested in while the secondary stream(s) of the source are an
-    /// internal implementation detail.
-    pub primary_stream: PersistStreamDesc,
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    pub enum SourceEnvelope {
+        /// If present, include the key columns as an output column of the source with the given properties.
+        None(KeyEnvelope),
+        Debezium(DebeziumDeduplicationStrategy, DebeziumMode),
+        Upsert(KeyEnvelope),
+        CdcV2,
+    }
 
-    /// Persisted stream of timestamp bindings.
-    pub timestamp_bindings_stream: PersistStreamDesc,
+    /// Computes the indices of the value's relation description that appear in the key.
+    ///
+    /// Returns an error if it detects a common columns between the two relations that has the same
+    /// name but a different type, if a key column is missing from the value, and if the key relation
+    /// has a column with no name.
+    pub fn match_key_indices(
+        key_desc: &RelationDesc,
+        value_desc: &RelationDesc,
+    ) -> anyhow::Result<Vec<usize>> {
+        let mut indices = Vec::new();
+        for (name, key_type) in key_desc.iter() {
+            let (index, value_type) = value_desc
+                .get_by_name(name)
+                .ok_or_else(|| anyhow!("Value schema missing primary key column: {}", name))?;
 
-    /// Any additional details that we need to make the envelope logic stateful.
-    pub envelope_desc: EnvelopePersistDesc,
-}
+            if key_type == value_type {
+                indices.push(index);
+            } else {
+                bail!(
+                    "key and value column types do not match: key {:?} vs. value {:?}",
+                    key_type,
+                    value_type
+                );
+            }
+        }
+        Ok(indices)
+    }
 
-/// The persistence details we need for persisting a source envelopes data structures.
-///
-/// This is a 1:1 mapping from envelope to `EnvelopePersistDesc`, as opposed to having a `None`
-/// that covers all envelopes that don't need additional data. Mostly, to just be explicit, but
-/// also because there is already a `NONE` envelope.
-///
-/// Some envelopes will require additional streams, which should be listed in the variant.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum EnvelopePersistDesc {
-    Upsert,
-}
+    impl SourceEnvelope {
+        pub fn get_avro_envelope_type(&self) -> avro::EnvelopeType {
+            match self {
+                SourceEnvelope::None(_) => avro::EnvelopeType::None,
+                SourceEnvelope::Debezium { .. } => avro::EnvelopeType::Debezium,
+                SourceEnvelope::Upsert(_) => avro::EnvelopeType::Upsert,
+                SourceEnvelope::CdcV2 => avro::EnvelopeType::CdcV2,
+            }
+        }
+        /// Computes the output relation of this envelope when applied on top of the decoded key and
+        /// value relation desc
+        pub fn desc(
+            &self,
+            key_desc: Option<RelationDesc>,
+            value_desc: RelationDesc,
+            metadata_desc: RelationDesc,
+        ) -> anyhow::Result<RelationDesc> {
+            Ok(match self {
+                SourceEnvelope::None(key_envelope) | SourceEnvelope::Upsert(key_envelope) => {
+                    let key_desc = match key_desc {
+                        Some(desc) => desc,
+                        None => return Ok(value_desc.concat(metadata_desc)),
+                    };
 
-/// Description of a single persistent stream.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PersistStreamDesc {
-    /// Name of the persistent stream.
-    pub name: String,
-    /// The _current_ upper seal timestamp of this stream.
-    ///
-    /// NOTE: This timestamp is determined when the coordinator starts up or when the source is
-    /// initially created. When a source is actively writing to this stream, the seal timestamp
-    /// will progress beyond this timestamp.
-    ///
-    /// This is okay for now because we only want to allow one source instantiation for persistent
-    /// sources, meaning the flow is usually this:
-    ///
-    ///  1. coordinator determines seal timestamp
-    ///  2. seal timestamps for a source are sent to dataflow when rendering a source
-    ///  3. coordinator (or anyone) never looks at this timestamp again.
-    ///
-    /// And when we restart, we start from step 1., at which time we are guaranteed not to have a
-    /// source running already.
-    pub upper_seal_ts: u64,
-    /// The _current_ compaction frontier (aka _since_) of this stream.
-    ///
-    /// NOTE: This timestamp is determined when the coordinator starts up or when the source is
-    /// initially created. When a source is actively writing to this stream and allowing
-    /// compaction, this will progress beyond this timestamp.
-    ///
-    /// This is okay for now because we only want to allow one source instantiation for persistent
-    /// sources, meaning the flow is usually this:
-    ///
-    ///  1. coordinator determines since timestamp
-    ///  2. timestamps for a source are sent to dataflow when rendering a source
-    ///  3. coordinator (or anyone) never looks at this timestamp again.
-    ///
-    /// And when we restart, we start from step 1., at which time we are guaranteed not to have a
-    /// source running already.
-    pub since_ts: u64,
-}
+                    let keyed = match key_envelope {
+                        KeyEnvelope::None => value_desc,
+                        KeyEnvelope::Flattened => {
+                            // Add the key columns as a key.
+                            let key_indices = (0..key_desc.arity()).collect();
+                            let key_desc = key_desc.with_key(key_indices);
+                            key_desc.concat(value_desc)
+                        }
+                        KeyEnvelope::LegacyUpsert => {
+                            let key_indices = (0..key_desc.arity()).collect();
+                            let key_desc = key_desc.with_key(key_indices);
+                            let names = (0..key_desc.arity()).map(|i| format!("key{}", i));
+                            // Rename key columns to "keyN"
+                            key_desc.with_names(names).concat(value_desc)
+                        }
+                        KeyEnvelope::Named(key_name) => {
+                            let key_desc = {
+                                // if the key has multiple objects, nest them as a record inside of a single name
+                                if key_desc.arity() > 1 {
+                                    let key_type = key_desc.typ();
+                                    let key_as_record = RelationType::new(vec![ColumnType {
+                                        nullable: false,
+                                        scalar_type: ScalarType::Record {
+                                            fields: key_desc
+                                                .iter_names()
+                                                .zip(key_type.column_types.iter())
+                                                .map(|(name, ty)| (name.clone(), ty.clone()))
+                                                .collect(),
+                                            custom_oid: None,
+                                            custom_name: None,
+                                        },
+                                    }]);
 
-impl SourceConnector {
-    /// Returns `true` if this connector yields input data (including
-    /// timestamps) that is stable across restarts. This is important for
-    /// exactly-once Sinks that need to ensure that the same data is written,
-    /// even when failures/restarts happen.
-    pub fn yields_stable_input(&self) -> bool {
-        if let SourceConnector::External { connector, .. } = self {
-            // Conservatively, set all Kafka (BYO or RT), File, or AvroOcf sources as having stable inputs because
-            // we know they will be read in a known, repeatable offset order (modulo compaction for some Kafka sources).
-            match connector {
-                ExternalSourceConnector::Kafka(_)
+                                    RelationDesc::new(key_as_record, [key_name.to_string()])
+                                } else {
+                                    key_desc.with_names([key_name.to_string()])
+                                }
+                            };
+                            // In all cases the first column is the key
+                            key_desc.with_key(vec![0]).concat(value_desc)
+                        }
+                    };
+                    keyed.concat(metadata_desc)
+                }
+                SourceEnvelope::Debezium(..) => {
+                    // TODO [btv] - Get rid of this, when we can. Right now source processing is still
+                    // not fully orthogonal, so we have some special logic in the debezium processor
+                    // that only passes on the first two columns ("before" and "after"), and uses the
+                    // information in the other ones itself
+                    let mut diter = value_desc.into_iter();
+                    let mut key = diter
+                        .next()
+                        .ok_or_else(|| anyhow::anyhow!("Spec does not contain key"))?;
+                    match &mut key.1.scalar_type {
+                        ScalarType::Record { fields, .. } => {
+                            fields.extend(metadata_desc.iter().map(|(k, v)| (k.clone(), v.clone())))
+                        }
+                        ty => bail!(
+                            "Incorrect type for Debezium value, expected Record, got {:?}",
+                            ty
+                        ),
+                    }
+                    let mut value = diter
+                        .next()
+                        .ok_or_else(|| anyhow::anyhow!("Spec does not contain value"))?;
+                    match &mut value.1.scalar_type {
+                        ScalarType::Record { fields, .. } => fields.extend(metadata_desc),
+                        ty => bail!(
+                            "Incorrect type for Debezium value, expected Record, got {:?}",
+                            ty
+                        ),
+                    }
+                    RelationDesc::from_names_and_types([key, value].into_iter())
+                }
+                SourceEnvelope::CdcV2 => {
+                    // TODO: Validate that the value schema has an `updates` and `progress` column of
+                    // the correct types
+
+                    // CdcV2 row data are in a record in a record in a list
+                    match &value_desc.typ().column_types[0].scalar_type {
+                        ScalarType::List { element_type, .. } => match &**element_type {
+                            ScalarType::Record { fields, .. } => {
+                                // TODO maybe check this by name
+                                match &fields[0].1.scalar_type {
+                                    ScalarType::Record { fields, .. } => {
+                                        RelationDesc::from_names_and_types(fields.clone())
+                                    }
+                                    ty => {
+                                        bail!("Unepxected type for MATERIALIZE envelope: {:?}", ty)
+                                    }
+                                }
+                            }
+                            ty => bail!("Unepxected type for MATERIALIZE envelope: {:?}", ty),
+                        },
+                        ty => bail!("Unepxected type for MATERIALIZE envelope: {:?}", ty),
+                    }
+                }
+            })
+        }
+    }
+
+    #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    pub struct KafkaSourceConnector {
+        pub addrs: KafkaAddrs,
+        pub topic: String,
+        // Represents options specified by user when creating the source, e.g.
+        // security settings.
+        pub config_options: BTreeMap<String, String>,
+        // Map from partition -> starting offset
+        pub start_offsets: HashMap<i32, i64>,
+        pub group_id_prefix: Option<String>,
+        pub cluster_id: Uuid,
+        /// If present, include the timestamp as an output column of the source with the given name
+        pub include_timestamp: Option<IncludedColumnPos>,
+        /// If present, include the partition as an output column of the source with the given name.
+        pub include_partition: Option<IncludedColumnPos>,
+        /// If present, include the topic as an output column of the source with the given name.
+        pub include_topic: Option<IncludedColumnPos>,
+        /// If present, include the offset as an output column of the source with the given name.
+        pub include_offset: Option<IncludedColumnPos>,
+    }
+
+    /// Legacy logic included something like an offset into almost data streams
+    ///
+    /// Eventually we will require `INCLUDE <metadata>` for everything.
+    pub fn provide_default_metadata(
+        envelope: &SourceEnvelope,
+        encoding: &encoding::DataEncoding,
+    ) -> bool {
+        let is_avro = matches!(encoding, encoding::DataEncoding::Avro(_));
+        let is_stateless_dbz = matches!(envelope, SourceEnvelope::Debezium(_, DebeziumMode::Plain));
+
+        !is_avro && !is_stateless_dbz
+    }
+
+    #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+    pub enum DebeziumMode {
+        Plain,
+        /// Keep track of keys from upstream and discard retractions for new keys
+        Upsert,
+    }
+
+    #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    pub enum Compression {
+        Gzip,
+        None,
+    }
+
+    /// A source of updates for a relational collection.
+    ///
+    /// A source contains enough information to instantiate a stream of changes,
+    /// as well as related metadata about the columns, their types, and properties
+    /// of the collection.
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    pub struct SourceDesc {
+        pub name: String,
+        pub connector: SourceConnector,
+        /// Optionally, filtering and projection that may optimistically be applied
+        /// to the output of the source.
+        pub operators: Option<crate::types::LinearOperator>,
+        pub bare_desc: RelationDesc,
+    }
+
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    pub enum SourceConnector {
+        External {
+            connector: ExternalSourceConnector,
+            encoding: encoding::SourceDataEncoding,
+            envelope: SourceEnvelope,
+            consistency: persistence::Consistency,
+            ts_frequency: Duration,
+            timeline: Timeline,
+            persist: Option<persistence::SourcePersistDesc>,
+        },
+
+        /// A local "source" is either fed by a local input handle, or by reading from a
+        /// `persisted_source()`. For non-persisted sources, values that are to be inserted
+        /// are sent from the coordinator and pushed into the handle on a worker.
+        ///
+        /// For persisted sources, the coordinator only writes new values to a persistent
+        /// stream. These values will then "show up" here because we read from the same
+        /// persistent stream.
+        // TODO: We could split this up into a `Local` source, that is only fed by a local handle and a
+        // `LocalPersistenceSource` which is fed from a `persisted_source()`. But moving the
+        // persist_name from `SourceDesc` to here is already a huge simplification/clarification. The
+        // persist description on a `SourceDesc` is now purely used to signal that a source actively
+        // persists, while a `LocalPersistenceSource` is a source that happens to read from persistence
+        // but doesn't persist itself.
+        //
+        // That additional split seems like a bigger undertaking, though, because it also needs changes
+        // to the coordinator. And I don't know if I want to invest too much time there when I don't
+        // yet know how Tables will work in a post-ingestd world.
+        Local {
+            timeline: Timeline,
+            persisted_name: Option<String>,
+        },
+    }
+
+    impl SourceConnector {
+        /// Returns `true` if this connector yields input data (including
+        /// timestamps) that is stable across restarts. This is important for
+        /// exactly-once Sinks that need to ensure that the same data is written,
+        /// even when failures/restarts happen.
+        pub fn yields_stable_input(&self) -> bool {
+            if let SourceConnector::External { connector, .. } = self {
+                // Conservatively, set all Kafka (BYO or RT), File, or AvroOcf sources as having stable inputs because
+                // we know they will be read in a known, repeatable offset order (modulo compaction for some Kafka sources).
+                match connector {
+                    ExternalSourceConnector::Kafka(_)
+                    | ExternalSourceConnector::File(_)
+                    | ExternalSourceConnector::AvroOcf(_) => true,
+                    // Currently, the Kinesis connector assigns "offsets" by counting the message in the order it was received
+                    // and this order is not replayable across different reads of the same Kinesis stream.
+                    ExternalSourceConnector::Kinesis(_) => false,
+                    _ => false,
+                }
+            } else {
+                false
+            }
+        }
+
+        pub fn name(&self) -> &'static str {
+            match self {
+                SourceConnector::External { connector, .. } => connector.name(),
+                SourceConnector::Local { .. } => "local",
+            }
+        }
+
+        pub fn timeline(&self) -> Timeline {
+            match self {
+                SourceConnector::External { timeline, .. } => timeline.clone(),
+                SourceConnector::Local { timeline, .. } => timeline.clone(),
+            }
+        }
+    }
+
+    #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    pub enum ExternalSourceConnector {
+        Kafka(KafkaSourceConnector),
+        Kinesis(KinesisSourceConnector),
+        File(FileSourceConnector),
+        AvroOcf(FileSourceConnector),
+        S3(S3SourceConnector),
+        Postgres(PostgresSourceConnector),
+        PubNub(PubNubSourceConnector),
+    }
+
+    impl ExternalSourceConnector {
+        /// Returns the name and type of each additional metadata column that
+        /// Materialize will automatically append to the source's inherent columns.
+        ///
+        /// Presently, each source type exposes precisely one metadata column that
+        /// corresponds to some source-specific record counter. For example, file
+        /// sources use a line number, while Kafka sources use a topic offset.
+        ///
+        /// The columns declared here must be kept in sync with the actual source
+        /// implementations that produce these columns.
+        pub fn metadata_columns(&self, include_defaults: bool) -> Vec<(&str, ColumnType)> {
+            let mut columns = Vec::new();
+            let default_col = |name| (name, ScalarType::Int64.nullable(false));
+            match self {
+                Self::Kafka(KafkaSourceConnector {
+                    include_partition: part,
+                    include_timestamp: time,
+                    include_topic: topic,
+                    include_offset: offset,
+                    ..
+                }) => {
+                    let mut items = BTreeMap::new();
+                    // put the offset at the end if necessary
+                    if include_defaults && offset.is_none() {
+                        items.insert(4, default_col("mz_offset"));
+                    }
+
+                    for (include, ty) in [
+                        (offset, ScalarType::Int64),
+                        (part, ScalarType::Int32),
+                        (time, ScalarType::Timestamp),
+                        (topic, ScalarType::String),
+                    ] {
+                        if let Some(include) = include {
+                            items.insert(include.pos + 1, (&include.name, ty.nullable(false)));
+                        }
+                    }
+
+                    items.into_values().collect()
+                }
+                Self::File(_) => {
+                    if include_defaults {
+                        columns.push(default_col("mz_line_no"));
+                    }
+                    columns
+                }
+                Self::Kinesis(_) => {
+                    if include_defaults {
+                        columns.push(default_col("mz_offset"))
+                    };
+                    columns
+                }
+                Self::AvroOcf(_) => {
+                    if include_defaults {
+                        columns.push(default_col("mz_obj_no"))
+                    };
+                    columns
+                }
+                // TODO: should we include object key and possibly object-internal offset here?
+                Self::S3(_) => {
+                    if include_defaults {
+                        columns.push(default_col("mz_record"))
+                    };
+                    columns
+                }
+                Self::Postgres(_) => vec![],
+                Self::PubNub(_) => vec![],
+            }
+        }
+
+        // TODO(bwm): get rid of this when we no longer have the notion of default metadata
+        pub fn default_metadata_column_name(&self) -> Option<&str> {
+            match self {
+                ExternalSourceConnector::Kafka(_) => Some("mz_offset"),
+                ExternalSourceConnector::Kinesis(_) => Some("mz_offset"),
+                ExternalSourceConnector::File(_) => Some("mz_line_no"),
+                ExternalSourceConnector::AvroOcf(_) => Some("mz_obj_no"),
+                ExternalSourceConnector::S3(_) => Some("mz_record"),
+                ExternalSourceConnector::Postgres(_) => None,
+                ExternalSourceConnector::PubNub(_) => None,
+            }
+        }
+
+        pub fn metadata_column_types(&self, include_defaults: bool) -> Vec<IncludedColumnSource> {
+            match self {
+                ExternalSourceConnector::Kafka(KafkaSourceConnector {
+                    include_partition: part,
+                    include_timestamp: time,
+                    include_topic: topic,
+                    include_offset: offset,
+                    ..
+                }) => {
+                    // create a sorted list of column types based on the order they were declared in sql
+                    // TODO: should key be included in the sorted list? Breaking change, and it's
+                    // already special (it commonly multiple columns embedded in it).
+                    let mut items = BTreeMap::new();
+                    if include_defaults {
+                        items.insert(4, IncludedColumnSource::DefaultPosition);
+                    }
+                    for (include, ty) in [
+                        (offset, IncludedColumnSource::Offset),
+                        (part, IncludedColumnSource::Partition),
+                        (time, IncludedColumnSource::Timestamp),
+                        (topic, IncludedColumnSource::Topic),
+                    ] {
+                        if let Some(include) = include {
+                            items.insert(include.pos, ty);
+                        }
+                    }
+
+                    items.into_values().collect()
+                }
+
+                ExternalSourceConnector::Kinesis(_)
                 | ExternalSourceConnector::File(_)
-                | ExternalSourceConnector::AvroOcf(_) => true,
-                // Currently, the Kinesis connector assigns "offsets" by counting the message in the order it was received
-                // and this order is not replayable across different reads of the same Kinesis stream.
-                ExternalSourceConnector::Kinesis(_) => false,
-                _ => false,
-            }
-        } else {
-            false
-        }
-    }
-
-    pub fn name(&self) -> &'static str {
-        match self {
-            SourceConnector::External { connector, .. } => connector.name(),
-            SourceConnector::Local { .. } => "local",
-        }
-    }
-
-    pub fn timeline(&self) -> Timeline {
-        match self {
-            SourceConnector::External { timeline, .. } => timeline.clone(),
-            SourceConnector::Local { timeline, .. } => timeline.clone(),
-        }
-    }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub enum ExternalSourceConnector {
-    Kafka(KafkaSourceConnector),
-    Kinesis(KinesisSourceConnector),
-    File(FileSourceConnector),
-    AvroOcf(FileSourceConnector),
-    S3(S3SourceConnector),
-    Postgres(PostgresSourceConnector),
-    PubNub(PubNubSourceConnector),
-}
-
-impl ExternalSourceConnector {
-    /// Returns the name and type of each additional metadata column that
-    /// Materialize will automatically append to the source's inherent columns.
-    ///
-    /// Presently, each source type exposes precisely one metadata column that
-    /// corresponds to some source-specific record counter. For example, file
-    /// sources use a line number, while Kafka sources use a topic offset.
-    ///
-    /// The columns declared here must be kept in sync with the actual source
-    /// implementations that produce these columns.
-    pub fn metadata_columns(&self, include_defaults: bool) -> Vec<(&str, ColumnType)> {
-        let mut columns = Vec::new();
-        let default_col = |name| (name, ScalarType::Int64.nullable(false));
-        match self {
-            Self::Kafka(KafkaSourceConnector {
-                include_partition: part,
-                include_timestamp: time,
-                include_topic: topic,
-                include_offset: offset,
-                ..
-            }) => {
-                let mut items = BTreeMap::new();
-                // put the offset at the end if necessary
-                if include_defaults && offset.is_none() {
-                    items.insert(4, default_col("mz_offset"));
-                }
-
-                for (include, ty) in [
-                    (offset, ScalarType::Int64),
-                    (part, ScalarType::Int32),
-                    (time, ScalarType::Timestamp),
-                    (topic, ScalarType::String),
-                ] {
-                    if let Some(include) = include {
-                        items.insert(include.pos + 1, (&include.name, ty.nullable(false)));
+                | ExternalSourceConnector::AvroOcf(_)
+                | ExternalSourceConnector::S3(_) => {
+                    if include_defaults {
+                        vec![IncludedColumnSource::DefaultPosition]
+                    } else {
+                        Vec::new()
                     }
                 }
-
-                items.into_values().collect()
-            }
-            Self::File(_) => {
-                if include_defaults {
-                    columns.push(default_col("mz_line_no"));
-                }
-                columns
-            }
-            Self::Kinesis(_) => {
-                if include_defaults {
-                    columns.push(default_col("mz_offset"))
-                };
-                columns
-            }
-            Self::AvroOcf(_) => {
-                if include_defaults {
-                    columns.push(default_col("mz_obj_no"))
-                };
-                columns
-            }
-            // TODO: should we include object key and possibly object-internal offset here?
-            Self::S3(_) => {
-                if include_defaults {
-                    columns.push(default_col("mz_record"))
-                };
-                columns
-            }
-            Self::Postgres(_) => vec![],
-            Self::PubNub(_) => vec![],
-        }
-    }
-
-    // TODO(bwm): get rid of this when we no longer have the notion of default metadata
-    pub fn default_metadata_column_name(&self) -> Option<&str> {
-        match self {
-            ExternalSourceConnector::Kafka(_) => Some("mz_offset"),
-            ExternalSourceConnector::Kinesis(_) => Some("mz_offset"),
-            ExternalSourceConnector::File(_) => Some("mz_line_no"),
-            ExternalSourceConnector::AvroOcf(_) => Some("mz_obj_no"),
-            ExternalSourceConnector::S3(_) => Some("mz_record"),
-            ExternalSourceConnector::Postgres(_) => None,
-            ExternalSourceConnector::PubNub(_) => None,
-        }
-    }
-
-    pub fn metadata_column_types(&self, include_defaults: bool) -> Vec<IncludedColumnSource> {
-        match self {
-            ExternalSourceConnector::Kafka(KafkaSourceConnector {
-                include_partition: part,
-                include_timestamp: time,
-                include_topic: topic,
-                include_offset: offset,
-                ..
-            }) => {
-                // create a sorted list of column types based on the order they were declared in sql
-                // TODO: should key be included in the sorted list? Breaking change, and it's
-                // already special (it commonly multiple columns embedded in it).
-                let mut items = BTreeMap::new();
-                if include_defaults {
-                    items.insert(4, IncludedColumnSource::DefaultPosition);
-                }
-                for (include, ty) in [
-                    (offset, IncludedColumnSource::Offset),
-                    (part, IncludedColumnSource::Partition),
-                    (time, IncludedColumnSource::Timestamp),
-                    (topic, IncludedColumnSource::Topic),
-                ] {
-                    if let Some(include) = include {
-                        items.insert(include.pos, ty);
-                    }
-                }
-
-                items.into_values().collect()
-            }
-
-            ExternalSourceConnector::Kinesis(_)
-            | ExternalSourceConnector::File(_)
-            | ExternalSourceConnector::AvroOcf(_)
-            | ExternalSourceConnector::S3(_) => {
-                if include_defaults {
-                    vec![IncludedColumnSource::DefaultPosition]
-                } else {
+                ExternalSourceConnector::Postgres(_) | ExternalSourceConnector::PubNub(_) => {
                     Vec::new()
                 }
             }
-            ExternalSourceConnector::Postgres(_) | ExternalSourceConnector::PubNub(_) => Vec::new(),
         }
-    }
 
-    /// Returns the name of the external source connector.
-    pub fn name(&self) -> &'static str {
-        match self {
-            ExternalSourceConnector::Kafka(_) => "kafka",
-            ExternalSourceConnector::Kinesis(_) => "kinesis",
-            ExternalSourceConnector::File(_) => "file",
-            ExternalSourceConnector::AvroOcf(_) => "avro-ocf",
-            ExternalSourceConnector::S3(_) => "s3",
-            ExternalSourceConnector::Postgres(_) => "postgres",
-            ExternalSourceConnector::PubNub(_) => "pubnub",
-        }
-    }
-
-    /// Optionally returns the name of the upstream resource this source corresponds to.
-    /// (Currently only implemented for Kafka and Kinesis, to match old-style behavior
-    ///  TODO: decide whether we want file paths and other upstream names to show up in metrics too.
-    pub fn upstream_name(&self) -> Option<&str> {
-        match self {
-            ExternalSourceConnector::Kafka(KafkaSourceConnector { topic, .. }) => {
-                Some(topic.as_str())
+        /// Returns the name of the external source connector.
+        pub fn name(&self) -> &'static str {
+            match self {
+                ExternalSourceConnector::Kafka(_) => "kafka",
+                ExternalSourceConnector::Kinesis(_) => "kinesis",
+                ExternalSourceConnector::File(_) => "file",
+                ExternalSourceConnector::AvroOcf(_) => "avro-ocf",
+                ExternalSourceConnector::S3(_) => "s3",
+                ExternalSourceConnector::Postgres(_) => "postgres",
+                ExternalSourceConnector::PubNub(_) => "pubnub",
             }
-            ExternalSourceConnector::Kinesis(KinesisSourceConnector { stream_name, .. }) => {
-                Some(stream_name.as_str())
+        }
+
+        /// Optionally returns the name of the upstream resource this source corresponds to.
+        /// (Currently only implemented for Kafka and Kinesis, to match old-style behavior
+        ///  TODO: decide whether we want file paths and other upstream names to show up in metrics too.
+        pub fn upstream_name(&self) -> Option<&str> {
+            match self {
+                ExternalSourceConnector::Kafka(KafkaSourceConnector { topic, .. }) => {
+                    Some(topic.as_str())
+                }
+                ExternalSourceConnector::Kinesis(KinesisSourceConnector {
+                    stream_name, ..
+                }) => Some(stream_name.as_str()),
+                ExternalSourceConnector::File(_) => None,
+                ExternalSourceConnector::AvroOcf(_) => None,
+                ExternalSourceConnector::S3(_) => None,
+                ExternalSourceConnector::Postgres(_) => None,
+                ExternalSourceConnector::PubNub(_) => None,
             }
-            ExternalSourceConnector::File(_) => None,
-            ExternalSourceConnector::AvroOcf(_) => None,
-            ExternalSourceConnector::S3(_) => None,
-            ExternalSourceConnector::Postgres(_) => None,
-            ExternalSourceConnector::PubNub(_) => None,
         }
     }
-}
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub enum Consistency {
-    BringYourOwn(BringYourOwn),
-    RealTime,
-}
-
-/// Universal language for describing message positions in Materialize, in a source independent
-/// way. Invidual sources like Kafka or File sources should explicitly implement their own offset
-/// type that converts to/From MzOffsets. A 0-MzOffset denotes an empty stream.
-#[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Eq, Hash, Serialize, Deserialize)]
-pub struct MzOffset {
-    pub offset: i64,
-}
-
-impl fmt::Display for MzOffset {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.offset)
+    #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    pub struct KinesisSourceConnector {
+        pub stream_name: String,
+        pub aws: AwsConfig,
     }
-}
 
-impl Add<i64> for MzOffset {
-    type Output = MzOffset;
-
-    fn add(self, x: i64) -> MzOffset {
-        MzOffset {
-            offset: self.offset + x,
-        }
+    #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    pub struct FileSourceConnector {
+        pub path: PathBuf,
+        pub tail: bool,
+        pub compression: Compression,
     }
-}
 
-#[derive(Clone, Copy, Eq, PartialEq)]
-pub struct KafkaOffset {
-    pub offset: i64,
-}
-
-/// Structure wrapping a timestamp update from a source
-/// If RT, contains a partition count
-/// If BYO, contains a tuple (PartitionCount, PartitionID, Timestamp, Offset),
-/// which informs workers that messages with Offset on PartititionId will be timestamped
-/// with Timestamp.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum TimestampSourceUpdate {
-    /// Update for an RT source: contains a new partition to add to this source.
-    RealTime(PartitionId),
-    /// Timestamp update for a BYO source: contains a PartitionID, Timestamp,
-    /// MzOffset tuple. This tuple informs workers that messages with Offset on
-    /// PartitionId will be timestamped with Timestamp.
-    BringYourOwn(PartitionId, u64, MzOffset),
-}
-
-/// Convert from KafkaOffset to MzOffset (1-indexed)
-impl From<KafkaOffset> for MzOffset {
-    fn from(kafka_offset: KafkaOffset) -> Self {
-        MzOffset {
-            offset: kafka_offset.offset + 1,
-        }
+    #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    pub struct PostgresSourceConnector {
+        pub conn: String,
+        pub publication: String,
+        pub slot_name: String,
     }
-}
 
-/// Convert from MzOffset to Kafka::Offset as long as
-/// the offset is not negative
-impl Into<KafkaOffset> for MzOffset {
-    fn into(self) -> KafkaOffset {
-        KafkaOffset {
-            offset: self.offset - 1,
-        }
+    #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    pub struct PubNubSourceConnector {
+        pub subscribe_key: String,
+        pub channel: String,
     }
-}
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct KafkaSourceConnector {
-    pub addrs: KafkaAddrs,
-    pub topic: String,
-    // Represents options specified by user when creating the source, e.g.
-    // security settings.
-    pub config_options: BTreeMap<String, String>,
-    // Map from partition -> starting offset
-    pub start_offsets: HashMap<i32, i64>,
-    pub group_id_prefix: Option<String>,
-    pub cluster_id: Uuid,
-    /// If present, include the timestamp as an output column of the source with the given name
-    pub include_timestamp: Option<IncludedColumnPos>,
-    /// If present, include the partition as an output column of the source with the given name.
-    pub include_partition: Option<IncludedColumnPos>,
-    /// If present, include the topic as an output column of the source with the given name.
-    pub include_topic: Option<IncludedColumnPos>,
-    /// If present, include the offset as an output column of the source with the given name.
-    pub include_offset: Option<IncludedColumnPos>,
-}
+    #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    pub struct S3SourceConnector {
+        pub key_sources: Vec<S3KeySource>,
+        pub pattern: Option<Glob>,
+        pub aws: AwsConfig,
+        pub compression: Compression,
+    }
 
-/// Which piece of metadata a column corresponds to
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub enum IncludedColumnSource {
-    /// The materialize-specific notion of "position"
+    /// A Source of Object Key names, the argument of the `DISCOVER OBJECTS` clause
+    #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+    pub enum S3KeySource {
+        /// Scan the S3 Bucket to discover keys to download
+        Scan { bucket: String },
+        /// Load object keys based on the contents of an S3 Notifications channel
+        ///
+        /// S3 notifications channels can be configured to go to SQS, which is the
+        /// only target we currently support.
+        SqsNotifications { queue: String },
+    }
+
+    /// AWS configuration overrides for a source or sink.
     ///
-    /// This is legacy, and should be removed when default metadata is no longer included
-    DefaultPosition,
-    Partition,
-    Offset,
-    Timestamp,
-    Topic,
-}
-
-/// Whether and how to include the decoded key of a stream in dataflows
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub enum KeyEnvelope {
-    /// Never include the key in the output row
-    None,
-    /// For composite key encodings, pull the fields from the encoding into columns.
-    Flattened,
-    /// Upsert is identical to Flattened but differs for non-avro sources, for which key names are overwritten.
-    LegacyUpsert,
-    /// Always use the given name for the key.
-    ///
-    /// * For a single-field key, this means that the column will get the given name.
-    /// * For a multi-column key, the columns will get packed into a [`ScalarType::Record`], and
-    ///   that Record will get the given name.
-    Named(String),
-}
-
-/// A column that was created via an `INCLUDE` expression
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct IncludedColumnPos {
-    pub name: String,
-    pub pos: usize,
-}
-
-/// AWS configuration overrides for a source or sink.
-///
-/// This is a distinct type from any of the configuration types built into the
-/// AWS SDK so that we can implement `Serialize` and `Deserialize`.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct AwsConfig {
-    /// The optional static credentials to use.
-    ///
-    /// If unset, credentials should instead be obtained from the environment.
-    pub credentials: Option<AwsCredentials>,
-    /// The AWS region to use.
-    pub region: String,
-    /// The custom AWS endpoint to use, if any.
-    pub endpoint: Option<String>,
-}
-
-/// Static AWS credentials for a source or sink.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct AwsCredentials {
-    pub access_key_id: String,
-    pub secret_access_key: String,
-    pub session_token: Option<String>,
-}
-
-impl AwsConfig {
-    /// Loads the AWS SDK configuration object from the environment, then
-    /// applies the overrides from this object.
-    pub async fn load(&self) -> Result<mz_aws_util::config::AwsConfig, anyhow::Error> {
-        use aws_smithy_http::endpoint::Endpoint;
-        use aws_types::credentials::SharedCredentialsProvider;
-        use aws_types::region::Region;
-
-        let mut loader = aws_config::from_env().region(Region::new(self.region.clone()));
-        if let Some(credentials) = &self.credentials {
-            loader = loader.credentials_provider(SharedCredentialsProvider::new(
-                aws_types::Credentials::from_keys(
-                    &credentials.access_key_id,
-                    &credentials.secret_access_key,
-                    credentials.session_token.clone(),
-                ),
-            ));
-        }
-        let mut config = mz_aws_util::config::AwsConfig::from_loader(loader).await;
-        if let Some(endpoint) = &self.endpoint {
-            let endpoint: Uri = endpoint.parse().context("parsing AWS endpoint")?;
-            config.set_endpoint(Endpoint::immutable(endpoint));
-        }
-        Ok(config)
-    }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct KinesisSourceConnector {
-    pub stream_name: String,
-    pub aws: AwsConfig,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct FileSourceConnector {
-    pub path: PathBuf,
-    pub tail: bool,
-    pub compression: Compression,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct PostgresSourceConnector {
-    pub conn: String,
-    pub publication: String,
-    pub slot_name: String,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct PubNubSourceConnector {
-    pub subscribe_key: String,
-    pub channel: String,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct S3SourceConnector {
-    pub key_sources: Vec<S3KeySource>,
-    pub pattern: Option<Glob>,
-    pub aws: AwsConfig,
-    pub compression: Compression,
-}
-
-/// A Source of Object Key names, the argument of the `DISCOVER OBJECTS` clause
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub enum S3KeySource {
-    /// Scan the S3 Bucket to discover keys to download
-    Scan { bucket: String },
-    /// Load object keys based on the contents of an S3 Notifications channel
-    ///
-    /// S3 notifications channels can be configured to go to SQS, which is the
-    /// only target we currently support.
-    SqsNotifications { queue: String },
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum SinkConnector {
-    Kafka(KafkaSinkConnector),
-    Tail(TailSinkConnector),
-    AvroOcf(AvroOcfSinkConnector),
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct KafkaSinkConsistencyConnector {
-    pub topic: String,
-    pub schema_id: i32,
-    // gate_ts is the most recent high watermark tailed from the consistency topic
-    // Exactly-once sinks use this to determine when they should start publishing again. This
-    // tells them when they have caught up to where the previous materialize instance stopped.
-    pub gate_ts: Option<Timestamp>,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct KafkaSinkConnector {
-    pub addrs: KafkaAddrs,
-    pub topic: String,
-    pub topic_prefix: String,
-    pub key_desc_and_indices: Option<(RelationDesc, Vec<usize>)>,
-    pub relation_key_indices: Option<Vec<usize>>,
-    pub value_desc: RelationDesc,
-    pub published_schema_info: Option<PublishedSchemaInfo>,
-    pub consistency: Option<KafkaSinkConsistencyConnector>,
-    pub exactly_once: bool,
-    // Source dependencies for exactly-once sinks.
-    pub transitive_source_dependencies: Vec<GlobalId>,
-    // Maximum number of records the sink will attempt to send each time it is
-    // invoked
-    pub fuel: usize,
-    pub config_options: BTreeMap<String, String>,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct AvroOcfSinkConnector {
-    pub value_desc: RelationDesc,
-    pub path: PathBuf,
-}
-
-impl SinkConnector {
-    /// Returns the name of the sink connector.
-    pub fn name(&self) -> &'static str {
-        match self {
-            SinkConnector::AvroOcf(_) => "avro-ocf",
-            SinkConnector::Kafka(_) => "kafka",
-            SinkConnector::Tail(_) => "tail",
-        }
+    /// This is a distinct type from any of the configuration types built into the
+    /// AWS SDK so that we can implement `Serialize` and `Deserialize`.
+    #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    pub struct AwsConfig {
+        /// The optional static credentials to use.
+        ///
+        /// If unset, credentials should instead be obtained from the environment.
+        pub credentials: Option<AwsCredentials>,
+        /// The AWS region to use.
+        pub region: String,
+        /// The custom AWS endpoint to use, if any.
+        pub endpoint: Option<String>,
     }
 
-    /// Returns `true` if this sink requires sources to block timestamp binding
-    /// compaction until all sinks that depend on a given source have finished
-    /// writing out that timestamp.
-    ///
-    /// To achieve that, each sink will hold a `AntichainToken` for all of
-    /// the sources it depends on, and will advance all of its source
-    /// dependencies' compaction frontiers as it completes writes.
-    ///
-    /// Sinks that do need to hold back compaction need to insert an
-    /// [`Antichain`] into `RenderState.sink_write_frontiers` that they update
-    /// in order to advance the frontier that holds back upstream compaction
-    /// of timestamp bindings.
-    ///
-    /// See also [`transitive_source_dependencies`](SinkConnector::transitive_source_dependencies).
-    pub fn requires_source_compaction_holdback(&self) -> bool {
-        match self {
-            SinkConnector::Kafka(k) => k.exactly_once,
-            SinkConnector::AvroOcf(_) => false,
-            SinkConnector::Tail(_) => false,
-        }
+    /// Static AWS credentials for a source or sink.
+    #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    pub struct AwsCredentials {
+        pub access_key_id: String,
+        pub secret_access_key: String,
+        pub session_token: Option<String>,
     }
 
-    /// Returns the [`GlobalIds`](GlobalId) of the transitive sources of this
-    /// sink.
-    pub fn transitive_source_dependencies(&self) -> &[GlobalId] {
-        match self {
-            SinkConnector::Kafka(k) => &k.transitive_source_dependencies,
-            SinkConnector::AvroOcf(_) => &[],
-            SinkConnector::Tail(_) => &[],
+    impl AwsConfig {
+        /// Loads the AWS SDK configuration object from the environment, then
+        /// applies the overrides from this object.
+        pub async fn load(&self) -> Result<mz_aws_util::config::AwsConfig, anyhow::Error> {
+            use aws_smithy_http::endpoint::Endpoint;
+            use aws_types::credentials::SharedCredentialsProvider;
+            use aws_types::region::Region;
+
+            let mut loader = aws_config::from_env().region(Region::new(self.region.clone()));
+            if let Some(credentials) = &self.credentials {
+                loader = loader.credentials_provider(SharedCredentialsProvider::new(
+                    aws_types::Credentials::from_keys(
+                        &credentials.access_key_id,
+                        &credentials.secret_access_key,
+                        credentials.session_token.clone(),
+                    ),
+                ));
+            }
+            let mut config = mz_aws_util::config::AwsConfig::from_loader(loader).await;
+            if let Some(endpoint) = &self.endpoint {
+                let endpoint: Uri = endpoint.parse().context("parsing AWS endpoint")?;
+                config.set_endpoint(Endpoint::immutable(endpoint));
+            }
+            Ok(config)
         }
     }
 }
 
-#[derive(Default, Clone, Debug, Serialize, Deserialize)]
-pub struct TailSinkConnector {}
+/// Types and traits related to reporting changing collections out of `dataflow`.
+pub mod sinks {
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub enum SinkConnectorBuilder {
-    Kafka(KafkaSinkConnectorBuilder),
-    AvroOcf(AvroOcfSinkConnectorBuilder),
-}
+    use std::collections::BTreeMap;
+    use std::path::PathBuf;
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct AvroOcfSinkConnectorBuilder {
-    pub path: PathBuf,
-    pub file_name_suffix: String,
-    pub value_desc: RelationDesc,
-}
+    use serde::{Deserialize, Serialize};
+    use timely::progress::frontier::Antichain;
+    use url::Url;
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct KafkaSinkConnectorBuilder {
-    pub broker_addrs: KafkaAddrs,
-    pub format: KafkaSinkFormat,
-    /// A natural key of the sinked relation (view or source).
-    pub relation_key_indices: Option<Vec<usize>>,
-    /// The user-specified key for the sink.
-    pub key_desc_and_indices: Option<(RelationDesc, Vec<usize>)>,
-    pub value_desc: RelationDesc,
-    pub topic_prefix: String,
-    pub consistency_topic_prefix: Option<String>,
-    pub consistency_format: Option<KafkaSinkFormat>,
-    pub topic_suffix_nonce: String,
-    pub partition_count: i32,
-    pub replication_factor: i32,
-    pub fuel: usize,
-    pub config_options: BTreeMap<String, String>,
-    // Forces the sink to always write to the same topic across restarts instead
-    // of picking a new topic each time.
-    pub reuse_topic: bool,
-    // Source dependencies for exactly-once sinks.
-    pub transitive_source_dependencies: Vec<GlobalId>,
-    pub retention: KafkaSinkConnectorRetention,
-}
+    use expr::GlobalId;
+    use kafka_util::KafkaAddrs;
+    use repr::{RelationDesc, Timestamp};
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
-pub struct KafkaSinkConnectorRetention {
-    pub retention_ms: Option<i64>,
-    pub retention_bytes: Option<i64>,
-}
+    /// A sink for updates to a relational collection.
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    pub struct SinkDesc {
+        pub from: GlobalId,
+        pub from_desc: RelationDesc,
+        pub connector: SinkConnector,
+        pub envelope: Option<SinkEnvelope>,
+        pub as_of: SinkAsOf,
+    }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub enum KafkaSinkFormat {
-    Avro {
-        schema_registry_url: Url,
-        key_schema: Option<String>,
-        value_schema: String,
-        ccsr_config: ccsr::ClientConfig,
-    },
-    Json,
-}
+    #[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    pub enum SinkEnvelope {
+        Debezium,
+        Upsert,
+    }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct PublishedSchemaInfo {
-    pub key_schema_id: Option<i32>,
-    pub value_schema_id: i32,
+    #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    pub struct SinkAsOf {
+        pub frontier: Antichain<Timestamp>,
+        pub strict: bool,
+    }
+
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    pub enum SinkConnector {
+        Kafka(KafkaSinkConnector),
+        Tail(TailSinkConnector),
+        AvroOcf(AvroOcfSinkConnector),
+    }
+
+    #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    pub struct KafkaSinkConsistencyConnector {
+        pub topic: String,
+        pub schema_id: i32,
+        // gate_ts is the most recent high watermark tailed from the consistency topic
+        // Exactly-once sinks use this to determine when they should start publishing again. This
+        // tells them when they have caught up to where the previous materialize instance stopped.
+        pub gate_ts: Option<Timestamp>,
+    }
+
+    #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    pub struct KafkaSinkConnector {
+        pub addrs: KafkaAddrs,
+        pub topic: String,
+        pub topic_prefix: String,
+        pub key_desc_and_indices: Option<(RelationDesc, Vec<usize>)>,
+        pub relation_key_indices: Option<Vec<usize>>,
+        pub value_desc: RelationDesc,
+        pub published_schema_info: Option<PublishedSchemaInfo>,
+        pub consistency: Option<KafkaSinkConsistencyConnector>,
+        pub exactly_once: bool,
+        // Source dependencies for exactly-once sinks.
+        pub transitive_source_dependencies: Vec<GlobalId>,
+        // Maximum number of records the sink will attempt to send each time it is
+        // invoked
+        pub fuel: usize,
+        pub config_options: BTreeMap<String, String>,
+    }
+
+    /// TODO(JLDLaughlin): Documentation.
+    #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    pub struct PublishedSchemaInfo {
+        pub key_schema_id: Option<i32>,
+        pub value_schema_id: i32,
+    }
+
+    #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    pub struct AvroOcfSinkConnector {
+        pub value_desc: RelationDesc,
+        pub path: PathBuf,
+    }
+
+    impl SinkConnector {
+        /// Returns the name of the sink connector.
+        pub fn name(&self) -> &'static str {
+            match self {
+                SinkConnector::AvroOcf(_) => "avro-ocf",
+                SinkConnector::Kafka(_) => "kafka",
+                SinkConnector::Tail(_) => "tail",
+            }
+        }
+
+        /// Returns `true` if this sink requires sources to block timestamp binding
+        /// compaction until all sinks that depend on a given source have finished
+        /// writing out that timestamp.
+        ///
+        /// To achieve that, each sink will hold a `AntichainToken` for all of
+        /// the sources it depends on, and will advance all of its source
+        /// dependencies' compaction frontiers as it completes writes.
+        ///
+        /// Sinks that do need to hold back compaction need to insert an
+        /// [`Antichain`] into `RenderState.sink_write_frontiers` that they update
+        /// in order to advance the frontier that holds back upstream compaction
+        /// of timestamp bindings.
+        ///
+        /// See also [`transitive_source_dependencies`](SinkConnector::transitive_source_dependencies).
+        pub fn requires_source_compaction_holdback(&self) -> bool {
+            match self {
+                SinkConnector::Kafka(k) => k.exactly_once,
+                SinkConnector::AvroOcf(_) => false,
+                SinkConnector::Tail(_) => false,
+            }
+        }
+
+        /// Returns the [`GlobalIds`](GlobalId) of the transitive sources of this
+        /// sink.
+        pub fn transitive_source_dependencies(&self) -> &[GlobalId] {
+            match self {
+                SinkConnector::Kafka(k) => &k.transitive_source_dependencies,
+                SinkConnector::AvroOcf(_) => &[],
+                SinkConnector::Tail(_) => &[],
+            }
+        }
+    }
+
+    #[derive(Default, Clone, Debug, Serialize, Deserialize)]
+    pub struct TailSinkConnector {}
+
+    #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    pub enum SinkConnectorBuilder {
+        Kafka(KafkaSinkConnectorBuilder),
+        AvroOcf(AvroOcfSinkConnectorBuilder),
+    }
+
+    #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    pub struct AvroOcfSinkConnectorBuilder {
+        pub path: PathBuf,
+        pub file_name_suffix: String,
+        pub value_desc: RelationDesc,
+    }
+
+    #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    pub struct KafkaSinkConnectorBuilder {
+        pub broker_addrs: KafkaAddrs,
+        pub format: KafkaSinkFormat,
+        /// A natural key of the sinked relation (view or source).
+        pub relation_key_indices: Option<Vec<usize>>,
+        /// The user-specified key for the sink.
+        pub key_desc_and_indices: Option<(RelationDesc, Vec<usize>)>,
+        pub value_desc: RelationDesc,
+        pub topic_prefix: String,
+        pub consistency_topic_prefix: Option<String>,
+        pub consistency_format: Option<KafkaSinkFormat>,
+        pub topic_suffix_nonce: String,
+        pub partition_count: i32,
+        pub replication_factor: i32,
+        pub fuel: usize,
+        pub config_options: BTreeMap<String, String>,
+        // Forces the sink to always write to the same topic across restarts instead
+        // of picking a new topic each time.
+        pub reuse_topic: bool,
+        // Source dependencies for exactly-once sinks.
+        pub transitive_source_dependencies: Vec<GlobalId>,
+        pub retention: KafkaSinkConnectorRetention,
+    }
+
+    #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+    pub struct KafkaSinkConnectorRetention {
+        pub retention_ms: Option<i64>,
+        pub retention_bytes: Option<i64>,
+    }
+
+    #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    pub enum KafkaSinkFormat {
+        Avro {
+            schema_registry_url: Url,
+            key_schema: Option<String>,
+            value_schema: String,
+            ccsr_config: ccsr::ClientConfig,
+        },
+        Json,
+    }
 }
 
 /// An index storing processed updates so they can be queried

--- a/src/dataflow/src/decode/csv.rs
+++ b/src/dataflow/src/decode/csv.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use dataflow_types::{CsvEncoding, DecodeError, LinearOperator};
+use dataflow_types::{sources::encoding::CsvEncoding, DecodeError, LinearOperator};
 use repr::{Datum, Row};
 
 #[derive(Debug)]

--- a/src/dataflow/src/decode/mod.rs
+++ b/src/dataflow/src/decode/mod.rs
@@ -28,8 +28,11 @@ use timely::dataflow::{Scope, Stream};
 use timely::scheduling::SyncActivator;
 
 use dataflow_types::{
-    AvroEncoding, AvroOcfEncoding, DataEncoding, DebeziumMode, DecodeError, IncludedColumnSource,
-    KeyEnvelope, LinearOperator, RegexEncoding, SourceEnvelope,
+    sources::{
+        encoding::{AvroEncoding, AvroOcfEncoding, DataEncoding, RegexEncoding},
+        DebeziumMode, IncludedColumnSource, KeyEnvelope, SourceEnvelope,
+    },
+    DecodeError, LinearOperator,
 };
 use interchange::avro::ConfluentAvroResolver;
 use repr::Datum;

--- a/src/dataflow/src/decode/protobuf.rs
+++ b/src/dataflow/src/decode/protobuf.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use dataflow_types::{DecodeError, ProtobufEncoding};
+use dataflow_types::{sources::encoding::ProtobufEncoding, DecodeError};
 use interchange::protobuf::{DecodedDescriptors, Decoder};
 use repr::Row;
 

--- a/src/dataflow/src/render/sinks.rs
+++ b/src/dataflow/src/render/sinks.rs
@@ -18,7 +18,7 @@ use differential_dataflow::operators::arrange::arrangement::ArrangeByKey;
 use differential_dataflow::{Collection, Hashable};
 use timely::dataflow::Scope;
 
-use dataflow_types::*;
+use dataflow_types::sinks::*;
 use expr::GlobalId;
 use interchange::envelopes::{combine_at_timestamp, dbz_format, upsert_format};
 use repr::{Datum, Diff, Row, Timestamp};

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -24,6 +24,7 @@ use persist::operators::source::PersistedSource;
 use persist::operators::stream::{AwaitFrontier, Seal};
 use persist::operators::upsert::PersistentUpsertConfig;
 
+use dataflow_types::sources::{encoding::*, persistence::*, *};
 use dataflow_types::*;
 use expr::{GlobalId, Id, PartitionId, SourceInstanceId};
 use ore::now::NowFn;
@@ -459,7 +460,7 @@ where
                                         let row_desc = RelationDesc::from_names_and_types(fields);
                                         // these must be available because the DDL parsing logic already
                                         // checks this and bails in case the key is not correct
-                                        Some(dataflow_types::match_key_indices(&key_desc, &row_desc).expect("Invalid key schema, this indicates a bug in Materialize"))
+                                        Some(dataflow_types::sources::match_key_indices(&key_desc, &row_desc).expect("Invalid key schema, this indicates a bug in Materialize"))
                                     } else {
                                         None
                                     };

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -34,8 +34,11 @@ use tokio::sync::mpsc;
 use dataflow_types::client::{Command, LocalClient, Response, TimestampBindingFeedback};
 use dataflow_types::logging::LoggingConfig;
 use dataflow_types::{
-    Consistency, DataflowError, ExternalSourceConnector, PeekResponse, SourceConnector,
-    TimestampSourceUpdate,
+    sources::{
+        persistence::Consistency, persistence::TimestampSourceUpdate, ExternalSourceConnector,
+        SourceConnector,
+    },
+    DataflowError, PeekResponse,
 };
 use expr::{GlobalId, PartitionId, RowSetFinishing};
 use ore::metrics::MetricsRegistry;

--- a/src/dataflow/src/sink/avro_ocf.rs
+++ b/src/dataflow/src/sink/avro_ocf.rs
@@ -18,7 +18,7 @@ use timely::dataflow::operators::generic::Operator;
 use timely::dataflow::Scope;
 use tracing::error;
 
-use dataflow_types::{AvroOcfSinkConnector, SinkDesc};
+use dataflow_types::sinks::{AvroOcfSinkConnector, SinkDesc};
 use expr::GlobalId;
 use interchange::avro::{encode_datums_as_avro, AvroSchemaGenerator};
 use repr::{Diff, RelationDesc, Row, Timestamp};

--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -37,7 +37,7 @@ use timely::progress::Antichain;
 use timely::scheduling::Activator;
 use tracing::{debug, error, info};
 
-use dataflow_types::{
+use dataflow_types::sinks::{
     KafkaSinkConnector, KafkaSinkConsistencyConnector, PublishedSchemaInfo, SinkAsOf, SinkDesc,
 };
 use expr::GlobalId;

--- a/src/dataflow/src/sink/tail.rs
+++ b/src/dataflow/src/sink/tail.rs
@@ -25,7 +25,10 @@ use timely::progress::timestamp::Timestamp as TimelyTimestamp;
 use timely::progress::Antichain;
 use timely::PartialOrder;
 
-use dataflow_types::{SinkAsOf, SinkDesc, TailResponse, TailSinkConnector};
+use dataflow_types::{
+    sinks::{SinkAsOf, SinkDesc, TailSinkConnector},
+    TailResponse,
+};
 use expr::GlobalId;
 use repr::{Diff, Row, Timestamp};
 

--- a/src/dataflow/src/source/file.rs
+++ b/src/dataflow/src/source/file.rs
@@ -21,9 +21,9 @@ use repr::MessagePayload;
 use timely::scheduling::SyncActivator;
 use tracing::error;
 
-use dataflow_types::{
-    AvroOcfEncoding, Compression, DataEncoding, ExternalSourceConnector, MzOffset,
-    SourceDataEncoding,
+use dataflow_types::sources::{
+    encoding::AvroOcfEncoding, encoding::DataEncoding, encoding::SourceDataEncoding, Compression,
+    ExternalSourceConnector, MzOffset,
 };
 use expr::{PartitionId, SourceInstanceId};
 use mz_avro::Block;

--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -20,8 +20,9 @@ use rdkafka::topic_partition_list::Offset;
 use rdkafka::{ClientConfig, ClientContext, Message, TopicPartitionList};
 use timely::scheduling::activate::SyncActivator;
 
-use dataflow_types::{
-    ExternalSourceConnector, KafkaOffset, KafkaSourceConnector, MzOffset, SourceDataEncoding,
+use dataflow_types::sources::{
+    encoding::SourceDataEncoding, ExternalSourceConnector, KafkaOffset, KafkaSourceConnector,
+    MzOffset,
 };
 use expr::{PartitionId, SourceInstanceId};
 use kafka_util::{client::MzClientContext, KafkaAddrs};

--- a/src/dataflow/src/source/kinesis.rs
+++ b/src/dataflow/src/source/kinesis.rs
@@ -20,8 +20,8 @@ use prometheus::core::AtomicI64;
 use timely::scheduling::SyncActivator;
 use tracing::error;
 
-use dataflow_types::{
-    ExternalSourceConnector, KinesisSourceConnector, MzOffset, SourceDataEncoding,
+use dataflow_types::sources::{
+    encoding::SourceDataEncoding, ExternalSourceConnector, KinesisSourceConnector, MzOffset,
 };
 use expr::{PartitionId, SourceInstanceId};
 use mz_aws_util::kinesis;

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -34,7 +34,10 @@ use timely::dataflow::{
 use anyhow::anyhow;
 use async_trait::async_trait;
 use dataflow_types::{
-    Consistency, ExternalSourceConnector, MzOffset, SourceDataEncoding, SourceError,
+    sources::{
+        encoding::SourceDataEncoding, persistence::Consistency, ExternalSourceConnector, MzOffset,
+    },
+    SourceError,
 };
 use expr::{GlobalId, PartitionId, SourceInstanceId};
 use ore::cast::CastFrom;

--- a/src/dataflow/src/source/postgres.rs
+++ b/src/dataflow/src/source/postgres.rs
@@ -27,7 +27,7 @@ use tokio_postgres::types::PgLsn;
 use tokio_postgres::SimpleQueryMessage;
 
 use crate::source::{SimpleSource, SourceError, SourceTransaction, Timestamper};
-use dataflow_types::{PostgresSourceConnector, SourceErrorDetails};
+use dataflow_types::{sources::PostgresSourceConnector, SourceErrorDetails};
 use repr::{Datum, Row};
 
 lazy_static! {

--- a/src/dataflow/src/source/pubnub.rs
+++ b/src/dataflow/src/source/pubnub.rs
@@ -15,7 +15,7 @@ use pubnub_hyper::core::data::{channel, message::Type};
 use pubnub_hyper::{Builder, DefaultRuntime, DefaultTransport};
 
 use crate::source::{SimpleSource, SourceError, Timestamper};
-use dataflow_types::{PubNubSourceConnector, SourceErrorDetails};
+use dataflow_types::{sources::PubNubSourceConnector, SourceErrorDetails};
 use repr::{Datum, Row};
 
 /// Information required to sync data from PubNub

--- a/src/dataflow/src/source/s3.rs
+++ b/src/dataflow/src/source/s3.rs
@@ -47,8 +47,9 @@ use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::time::{self, Duration};
 use tokio_util::io::{ReaderStream, StreamReader};
 
-use dataflow_types::{
-    AwsConfig, Compression, ExternalSourceConnector, MzOffset, S3KeySource, SourceDataEncoding,
+use dataflow_types::sources::{
+    encoding::SourceDataEncoding, AwsConfig, Compression, ExternalSourceConnector, MzOffset,
+    S3KeySource,
 };
 use expr::{PartitionId, SourceInstanceId};
 use ore::retry::{Retry, RetryReader};

--- a/src/dataflow/src/source/timestamp.rs
+++ b/src/dataflow/src/source/timestamp.rs
@@ -897,7 +897,7 @@ impl TimestampBindingUpdater {
 
 #[cfg(test)]
 mod tests {
-    use dataflow_types::MzOffset;
+    use dataflow_types::sources::MzOffset;
     use expr::PartitionId;
     use ore::now::NOW_ZERO;
     use persist_types::Codec;

--- a/src/dataflow/src/source/timestamp.rs
+++ b/src/dataflow/src/source/timestamp.rs
@@ -34,7 +34,7 @@ use timely::progress::frontier::{Antichain, AntichainRef, MutableAntichain};
 use timely::progress::{ChangeBatch, Timestamp as TimelyTimestamp};
 use tracing::error;
 
-use dataflow_types::MzOffset;
+use dataflow_types::sources::MzOffset;
 use expr::PartitionId;
 use ore::now::NowFn;
 use repr::Timestamp;

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -16,7 +16,7 @@ use std::fmt;
 use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Utc, MIN_DATETIME};
-use dataflow_types::SourceConnector;
+use dataflow_types::sources::SourceConnector;
 use lazy_static::lazy_static;
 
 use build_info::{BuildInfo, DUMMY_BUILD_INFO};

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -18,7 +18,7 @@ use std::collections::BTreeMap;
 
 use anyhow::{anyhow, bail};
 
-use dataflow_types::{AwsConfig, AwsCredentials};
+use dataflow_types::sources::{AwsConfig, AwsCredentials};
 use repr::ColumnName;
 use sql_parser::ast::display::AstDisplay;
 use sql_parser::ast::visit_mut::{self, VisitMut};

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -34,7 +34,7 @@ use enum_kinds::EnumKind;
 use serde::{Deserialize, Serialize};
 
 use ::expr::{GlobalId, RowSetFinishing};
-use dataflow_types::{SinkConnectorBuilder, SinkEnvelope, SourceConnector};
+use dataflow_types::{sinks::SinkConnectorBuilder, sinks::SinkEnvelope, sources::SourceConnector};
 use ore::now::{self, NOW_ZERO};
 use repr::{ColumnName, Diff, RelationDesc, Row, ScalarType, Timestamp};
 

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -26,8 +26,8 @@ use tokio::io::AsyncBufReadExt;
 use tokio::task;
 use uuid::Uuid;
 
-use dataflow_types::AwsConfig;
-use dataflow_types::{ExternalSourceConnector, PostgresSourceConnector, SourceConnector};
+use dataflow_types::sources::AwsConfig;
+use dataflow_types::sources::{ExternalSourceConnector, PostgresSourceConnector, SourceConnector};
 use interchange::protobuf::compile_proto_from_subjects;
 use repr::strconv;
 use sql_parser::parser::parse_columns;

--- a/src/sql/src/query_model/test.rs
+++ b/src/sql/src/query_model/test.rs
@@ -18,7 +18,7 @@ use crate::plan::query::QueryLifetime;
 use crate::plan::{StatementContext, StatementDesc};
 use build_info::DUMMY_BUILD_INFO;
 use chrono::MIN_DATETIME;
-use dataflow_types::SourceConnector;
+use dataflow_types::sources::SourceConnector;
 use expr::{DummyHumanizer, ExprHumanizer, GlobalId, MirScalarExpr};
 use expr_test_util::generate_explanation;
 use lazy_static::lazy_static;

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -14,7 +14,7 @@
 //! pushdown can be applied across views once we understand the context
 //! in which the views will be executed.
 
-use dataflow_types::{DataflowDesc, LinearOperator, SourceConnector, SourceEnvelope};
+use dataflow_types::{DataflowDesc, LinearOperator};
 use expr::{GlobalId, Id, LocalId, MirRelationExpr, MirScalarExpr};
 use ore::id_gen::IdGen;
 use std::collections::{BTreeSet, HashMap, HashSet};
@@ -348,8 +348,8 @@ where
 pub fn optimize_dataflow_monotonic(dataflow: &mut DataflowDesc) -> Result<(), TransformError> {
     let mut monotonic = std::collections::HashSet::new();
     for (source_id, (source_desc, _)) in dataflow.source_imports.iter_mut() {
-        if let SourceConnector::External {
-            envelope: SourceEnvelope::None(_),
+        if let dataflow_types::sources::SourceConnector::External {
+            envelope: dataflow_types::sources::SourceEnvelope::None(_),
             ..
         } = source_desc.connector
         {


### PR DESCRIPTION
The PR introduces module structure to `dataflow_types::types`. Specifically, modules for `sources` and `sinks`, as well as submodules for `encoding` and `persistence`. This is all code movement and no intended functional change.
