### PR TITLE
Functions to enable conversion of TableInfo to PgTable

### DIFF
--- a/src/postgres-util/src/lib.rs
+++ b/src/postgres-util/src/lib.rs
@@ -21,7 +21,7 @@ use tokio_postgres::{Client, Config};
 use ore::task;
 use repr::adt;
 use sql_parser::ast::display::{AstDisplay, AstFormatter};
-use sql_parser::ast::Ident;
+use sql_parser::ast::{Ident, DataType, Raw, RawName, UnresolvedObjectName};
 use sql_parser::impl_display;
 
 pub struct PgNumericMod {
@@ -104,6 +104,30 @@ impl AstDisplay for PgScalarType {
     }
 }
 impl_display!(PgScalarType);
+
+// Defining this here prevents circular dependency with the sql-parser crate
+// impl From<PgScalarType> for DataType<Raw> {
+//     fn from(val: PgScalarType) -> Self {
+//         match val {
+//             PgScalarType::Simple(inner) => {
+//                 DataType::Other{ typ_mod: vec![], name: RawName::Name(UnresolvedObjectName(vec![Ident::from(inner.name())])) }
+//             },
+//             PgScalarType::Numeric(numeric_mod) => {
+//                 match numeric_mod {
+//                     Some(mods) => {
+//                         DataType::Other{ typ_mod: }
+//                     },
+//                     None => {},
+//                 }
+//             },
+//             PgScalarType::NumericArray(numeric_mod) => todo!(),
+//             PgScalarType::BPChar { length } => todo!(),
+//             PgScalarType::BPCharArray { length } => todo!(),
+//             PgScalarType::VarChar { length } => todo!(),
+//             PgScalarType::VarCharArray { length } => todo!(),
+//         }
+//     }
+// }
 
 /// The schema of a single column
 pub struct PgColumn {

--- a/src/postgres-util/src/lib.rs
+++ b/src/postgres-util/src/lib.rs
@@ -22,7 +22,7 @@ use tokio_postgres::{Client, Config};
 use ore::task;
 use repr::adt;
 use sql_parser::ast::display::{AstDisplay, AstFormatter};
-use sql_parser::ast::{ColumnDef, DataType, Ident, PgTable, Raw, RawName, UnresolvedObjectName};
+use sql_parser::ast::{ColumnDef, Ident, PgTable, Raw, RawName, UnresolvedObjectName};
 use sql_parser::impl_display;
 
 pub struct PgNumericMod {


### PR DESCRIPTION
This PR adds implementations of TryFrom for `postgres_util::TableInfo` to `sql_parser::ast::PgTable` which requires `postgres_util::PgScalarType` to `sql_parser::ast::DataType` and  `postgres_util::PgColumn` to `sql_parser::ast::ColumnDef` to enable it.

### Motivation
This is part of addressing pg replication not halting upon alter table as documented in https://github.com/MaterializeInc/materialize/issues/6739 with the work in this PR laying the groundwork to allow for expanding the `CreateSourceConnector::Postgres` AST node to include the remote tables that were in the publication when the source was created which will in turn allow for starting the source reader with enough metadata to only halt replication when tables which might be part of materialized views see truncate or alter, and further to only halt when alters actually change the table schema.

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
