### PR TITLE
ci/deploy: copy contents of website directory, not directory itself

### DIFF
--- a/ci/deploy/website.sh
+++ b/ci/deploy/website.sh
@@ -34,7 +34,7 @@ declare -A shortlinks=(
 
 cd doc/user
 hugo --gc --baseURL /docs --destination public/docs
-cp -R ../../ci/deploy/website/ public/
+cp -R ../../ci/deploy/website/. public/
 hugo deploy
 
 # NOTE(benesch): this code does not delete old shortlinks. That's fine, because


### PR DESCRIPTION
Turns out with GNU cp you need to spell this "SOURCE/.", not "SOURCE/"
like you can with BSD cp.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
