### PR TITLE
Add test to ensure create-certs.sh doesnt regress in kafka-ssl/multi.td

### DIFF
--- a/test/kafka-ssl/multi.td
+++ b/test/kafka-ssl/multi.td
@@ -64,3 +64,18 @@ a
 ---
 1
 2
+
+# Ensure that our test infra correctly sets up certs by failing when CSR is not
+# specifically configured
+! CREATE MATERIALIZED SOURCE data
+  FROM KAFKA BROKER 'kafka:9092' TOPIC 'testdrive-data-${testdrive.seed}'
+  WITH (
+      security_protocol = 'SSL',
+      ssl_key_location = '/share/secrets/materialized-kafka.key',
+      ssl_certificate_location = '/share/secrets/materialized-kafka.crt',
+      ssl_ca_location = '/share/secrets/ca.crt',
+      ssl_key_password = 'mzmzmz'
+  )
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE DEBEZIUM
+sslv3 alert certificate unknown


### PR DESCRIPTION
### Motivation
As mentioned by @benesch in https://github.com/MaterializeInc/materialize/pull/9997/, we want to ensure that our `create-certs.sh` image doesn't regress and become too permissive, thereby invaliding the first test in this file

  * This PR fixes a recognized bug.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
