### PR TITLE
numeric: change numeric row encoding to new BCD encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1326,9 +1326,9 @@ dependencies = [
 
 [[package]]
 name = "dec"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2bbc59a6735d2f5bc4befd3300c9b75cc6ed66165e92b741da0a58c07ea04d"
+checksum = "c9d829012cb80e6836307bc86bd621e71718f6c5370c36542cb7504f14055bb9"
 dependencies = [
  "decnumber-sys",
  "libc",

--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -16,7 +16,7 @@ chrono = { version = "0.4.0", default-features = false, features = ["std"] }
 crossbeam-channel = "0.5.2"
 dataflow-types = { path = "../dataflow-types" }
 derivative = "2.2.0"
-dec = "0.4.5"
+dec = "0.4.6"
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 expr = { path = "../expr" }
 fail = { version = "0.5.0", features = ["failpoints"] }

--- a/src/dataflow/Cargo.toml
+++ b/src/dataflow/Cargo.toml
@@ -19,7 +19,7 @@ chrono = { version = "0.4.0", default-features = false, features = ["std"] }
 crossbeam-channel = "0.5.2"
 csv-core = "0.1.10"
 dataflow-types = { path = "../dataflow-types" }
-dec = { version = "0.4.5", features = ["serde"] }
+dec = { version = "0.4.6", features = ["serde"] }
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 dogsdogsdogs = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 enum-iterator = "0.7.0"

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -10,7 +10,7 @@ aho-corasick = "0.7.18"
 anyhow = "1.0.52"
 chrono = { version = "0.4.0", default-features = false, features = ["clock", "std"] }
 csv = "1.1.6"
-dec = "0.4.5"
+dec = "0.4.6"
 encoding = "0.2.0"
 enum-iterator = "0.7.0"
 hex = "0.4.3"

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -17,7 +17,7 @@ base64 = "0.13.0"
 byteorder = "1.4.3"
 ccsr = { path = "../ccsr" }
 chrono = { version = "0.4.0", default-features = false, features = ["std"] }
-dec = "0.4.5"
+dec = "0.4.6"
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 futures = "0.3.19"
 hex = "0.4.3"

--- a/src/pgrepr/Cargo.toml
+++ b/src/pgrepr/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 byteorder = "1.4.3"
 bytes = "1.1.0"
 chrono = { version = "0.4.0", default-features = false, features = ["std"] }
-dec = "0.4.5"
+dec = "0.4.6"
 lazy_static = "1.4.0"
 ore = { path = "../ore" }
 postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres", branch = "mz-0.7.2", features = ["with-chrono-0_4", "with-uuid-0_8"] }

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -18,7 +18,7 @@ anyhow = "1.0.52"
 byteorder = "1.4.3"
 chrono = { version = "0.4.0", default-features = false, features = ["serde", "std"] }
 chrono-tz = { version = "0.6.1", features = ["serde", "case-insensitive"] }
-dec = "0.4.5"
+dec = "0.4.6"
 enum-kinds = "0.5.1"
 fast-float = "0.2.0"
 hex = "0.4.3"

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -13,7 +13,7 @@ ccsr = { path = "../ccsr" }
 chrono = { version = "0.4.0", default-features = false, features = ["clock", "std"] }
 csv = "1.1.6"
 dataflow-types = { path = "../dataflow-types" }
-dec = "0.4.5"
+dec = "0.4.6"
 enum-kinds = "0.5.1"
 expr = { path = "../expr" }
 futures = "0.3.19"


### PR DESCRIPTION
In coming up with the persistence encoding, @danhhz [noted](https://github.com/MaterializeInc/materialize/pull/9406#discussion_r764939138) deficiencies with our previous row encoding, and in determining a solution, we also realized we could pack values more tightly using a BCD-encoding (rather than the 3-digits in 2 bytes encoding we used previously).

Note that this new encoding does not retain information about special statuses, so adding those tags, as well. However, maybe instead of handling statuses as tags, we should formalize statuses with a byte in each row (rather than a tag), and maybe make this byte get returned directly from the decimal library? Thoughts, @danhhz @benesch ?

### Motivation

This PR adds a known-desirable feature: https://github.com/MaterializeInc/materialize/pull/9406#discussion_r764939138

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
