### PR TITLE
Add basic counters to Postgres source

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -147,6 +147,8 @@ changes that have not yet been documented.
 - Fix a bug where using a `ROWS FROM` clause with an alias in a view would cause
   Materialize to fail to reboot {{% gh 10008 %}}.
 
+- Add basic Prometheus counters for PostgreSQL sources
+
 {{< comment >}}
 Only add new release notes above this line.
 

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -258,7 +258,7 @@ where
 
                     (ok_stream.as_collection(), capability)
                 } else if let ExternalSourceConnector::Postgres(pg_connector) = connector {
-                    let source = PostgresSourceReader::new(src.name.clone(), pg_connector, source_config.base_metrics.clone());
+                    let source = PostgresSourceReader::new(src.name.clone(), pg_connector, source_config.base_metrics);
 
                     let ((ok_stream, err_stream), capability) =
                         source::create_source_simple(source_config, source);

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -258,7 +258,11 @@ where
 
                     (ok_stream.as_collection(), capability)
                 } else if let ExternalSourceConnector::Postgres(pg_connector) = connector {
-                    let source = PostgresSourceReader::new(src.name.clone(), pg_connector, source_config.base_metrics);
+                    let source = PostgresSourceReader::new(
+                        src.name.clone(),
+                        pg_connector,
+                        source_config.base_metrics,
+                    );
 
                     let ((ok_stream, err_stream), capability) =
                         source::create_source_simple(source_config, source);

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -258,7 +258,7 @@ where
 
                     (ok_stream.as_collection(), capability)
                 } else if let ExternalSourceConnector::Postgres(pg_connector) = connector {
-                    let source = PostgresSourceReader::new(src.name.clone(), pg_connector);
+                    let source = PostgresSourceReader::new(src.name.clone(), pg_connector, source_config.base_metrics.clone());
 
                     let ((ok_stream, err_stream), capability) =
                         source::create_source_simple(source_config, source);

--- a/src/dataflow/src/source/metrics.rs
+++ b/src/dataflow/src/source/metrics.rs
@@ -158,38 +158,38 @@ impl PostgresSourceSpecificMetrics {
         Self {
             total_messages: registry.register(metric!(
                 name: "mz_postgres_per_source_messages_total",
-                help: "The total number of replication messages for this source",
-                var_labels: ["source_id", "worker_id", "table_id"],
+                help: "The total number of replication messages for this source, not expected to be the sum of the other values.",
+                var_labels: ["source_id"],
             )),
             transactions: registry.register(metric!(
                 name: "mz_postgres_per_source_transactions_total",
-                help: "The total number of committed transactions for this source",
-                var_labels: ["source_id", "worker_id", "table_id"],
+                help: "The number of committed transactions for this source",
+                var_labels: ["source_id"],
             )),
             ignored_messages: registry.register(metric!(
-                name: "mz_postgres_per_source_ignored_messages_total",
-                help: "The total number of messages ignored",
-                var_labels: ["source_id", "worker_id", "table_id"],
+                name: "mz_postgres_per_source_ignored_messages",
+                help: "The number of messages ignored",
+                var_labels: ["source_id"],
             )),
             insert_messages: registry.register(metric!(
-                name: "mz_postgres_per_source_inserts_total",
-                help: "The total number of inserts for this source",
-                var_labels: ["source_id", "worker_id", "table_id"],
+                name: "mz_postgres_per_source_inserts",
+                help: "The number of inserts for this source",
+                var_labels: ["source_id"],
             )),
             update_messages: registry.register(metric!(
-                name: "mz_postgres_per_source_updates_total",
-                help: "The total number of updates for this source",
-                var_labels: ["source_id", "worker_id", "table_id"],
+                name: "mz_postgres_per_source_updates",
+                help: "The number of updates for this source",
+                var_labels: ["source_id"],
             )),
             delete_messages: registry.register(metric!(
-                name: "mz_postgres_per_source_deletes_total",
-                help: "The total number of deletes for this source",
-                var_labels: ["source_id", "worker_id", "table_id"],
+                name: "mz_postgres_per_source_deletes",
+                help: "The number of deletes for this source",
+                var_labels: ["source_id"],
             )),
             tables_in_publication: registry.register(metric!(
-                name: "mz_postgres_per_source_tables_total",
+                name: "mz_postgres_per_source_tables_count",
                 help: "The number of upstream tables for this source",
-                var_labels: ["source_id", "worker_id"],
+                var_labels: ["source_id"],
             )),
         }
     }

--- a/src/dataflow/src/source/metrics.rs
+++ b/src/dataflow/src/source/metrics.rs
@@ -151,6 +151,7 @@ pub(super) struct PostgresSourceSpecificMetrics {
     pub(super) update_messages: UIntCounterVec,
     pub(super) delete_messages: UIntCounterVec,
     pub(super) tables_in_publication: UIntGaugeVec,
+    pub(super) wal_lsn: UIntGaugeVec,
 }
 
 impl PostgresSourceSpecificMetrics {
@@ -163,27 +164,27 @@ impl PostgresSourceSpecificMetrics {
             )),
             transactions: registry.register(metric!(
                 name: "mz_postgres_per_source_transactions_total",
-                help: "The number of committed transactions for this source",
+                help: "The number of committed transactions for all tables in this source",
                 var_labels: ["source_id"],
             )),
             ignored_messages: registry.register(metric!(
                 name: "mz_postgres_per_source_ignored_messages",
-                help: "The number of messages ignored",
+                help: "The number of messages ignored because of an irrelevant type or relation_id",
                 var_labels: ["source_id"],
             )),
             insert_messages: registry.register(metric!(
                 name: "mz_postgres_per_source_inserts",
-                help: "The number of inserts for this source",
+                help: "The number of inserts for all tables in this source",
                 var_labels: ["source_id"],
             )),
             update_messages: registry.register(metric!(
                 name: "mz_postgres_per_source_updates",
-                help: "The number of updates for this source",
+                help: "The number of updates for all tables in this source",
                 var_labels: ["source_id"],
             )),
             delete_messages: registry.register(metric!(
                 name: "mz_postgres_per_source_deletes",
-                help: "The number of deletes for this source",
+                help: "The number of deletes for all tables in this source",
                 var_labels: ["source_id"],
             )),
             tables_in_publication: registry.register(metric!(
@@ -191,6 +192,11 @@ impl PostgresSourceSpecificMetrics {
                 help: "The number of upstream tables for this source",
                 var_labels: ["source_id"],
             )),
+            wal_lsn: registry.register(metric!(
+                name: "mz_postgres_per_source_wal_lsn",
+                help: "LSN of the latest transaction committed for this source, see Postgres Replication docs for more details on LSN",
+                var_labels: ["source_id"],
+            ))
         }
     }
 }

--- a/src/dataflow/src/source/metrics.rs
+++ b/src/dataflow/src/source/metrics.rs
@@ -140,12 +140,69 @@ impl PartitionSpecificMetrics {
     }
 }
 
+
+
+#[derive(Clone, Debug)]
+pub(super) struct PostgresSourceSpecificMetrics {
+    pub(super) total_messages: UIntCounterVec,
+    pub(super) transactions: UIntCounterVec,
+    pub(super) ignored_messages: UIntCounterVec,
+    pub(super) insert_messages: UIntCounterVec,
+    pub(super) update_messages: UIntCounterVec,
+    pub(super) delete_messages: UIntCounterVec,
+    pub(super) tables_in_publication: UIntGaugeVec,
+}
+
+impl PostgresSourceSpecificMetrics {
+    fn register_with(registry: &MetricsRegistry) -> Self {
+        Self {
+            total_messages: registry.register(metric!(
+                name: "mz_postgres_per_source_messages_total",
+                help: "The total number of replication messages for this source",
+                var_labels: ["source_id", "worker_id", "table_id"],
+            )),
+            transactions: registry.register(metric!(
+                name: "mz_postgres_per_source_transactions_total",
+                help: "The total number of committed transactions for this source",
+                var_labels: ["source_id", "worker_id", "table_id"],
+            )),
+            ignored_messages: registry.register(metric!(
+                name: "mz_postgres_per_source_ignored_messages_total",
+                help: "The total number of messages ignored",
+                var_labels: ["source_id", "worker_id", "table_id"],
+            )),
+            insert_messages: registry.register(metric!(
+                name: "mz_postgres_per_source_inserts_total",
+                help: "The total number of inserts for this source",
+                var_labels: ["source_id", "worker_id", "table_id"],
+            )),
+            update_messages: registry.register(metric!(
+                name: "mz_postgres_per_source_updates_total",
+                help: "The total number of updates for this source",
+                var_labels: ["source_id", "worker_id", "table_id"],
+            )),
+            delete_messages: registry.register(metric!(
+                name: "mz_postgres_per_source_deletes_total",
+                help: "The total number of deletes for this source",
+                var_labels: ["source_id", "worker_id", "table_id"],
+            )),
+            tables_in_publication: registry.register(metric!(
+                name: "mz_postgres_per_source_tables_total",
+                help: "The number of upstream tables for this source",
+                var_labels: ["source_id", "worker_id"],
+            )),
+        }
+    }
+}
+
+
 /// A set of base metrics that hang off a central metrics registry, labeled by the source they
 /// belong to.
 #[derive(Debug, Clone)]
 pub struct SourceBaseMetrics {
     pub(super) source_specific: SourceSpecificMetrics,
     pub(super) partition_specific: PartitionSpecificMetrics,
+    pub(super) postgres_source_specific: PostgresSourceSpecificMetrics,
 
     pub(crate) s3: S3Metrics,
     pub(crate) kinesis: KinesisMetrics,
@@ -158,6 +215,7 @@ impl SourceBaseMetrics {
         Self {
             source_specific: SourceSpecificMetrics::register_with(registry),
             partition_specific: PartitionSpecificMetrics::register_with(registry),
+            postgres_source_specific: PostgresSourceSpecificMetrics::register_with(registry),
 
             s3: S3Metrics::register_with(registry),
             kinesis: KinesisMetrics::register_with(registry),

--- a/src/dataflow/src/source/metrics.rs
+++ b/src/dataflow/src/source/metrics.rs
@@ -140,8 +140,6 @@ impl PartitionSpecificMetrics {
     }
 }
 
-
-
 #[derive(Clone, Debug)]
 pub(super) struct PostgresSourceSpecificMetrics {
     pub(super) total_messages: UIntCounterVec,
@@ -200,7 +198,6 @@ impl PostgresSourceSpecificMetrics {
         }
     }
 }
-
 
 /// A set of base metrics that hang off a central metrics registry, labeled by the source they
 /// belong to.

--- a/src/dataflow/src/source/postgres.rs
+++ b/src/dataflow/src/source/postgres.rs
@@ -123,8 +123,11 @@ macro_rules! try_recoverable {
 
 impl PostgresSourceReader {
     /// Constructs a new instance
-    pub fn new(source_name: String, connector: PostgresSourceConnector, metrics: &SourceBaseMetrics) -> Self 
-    {
+    pub fn new(
+        source_name: String,
+        connector: PostgresSourceConnector,
+        metrics: &SourceBaseMetrics,
+    ) -> Self {
         Self {
             source_name: source_name.clone(),
             connector,
@@ -396,7 +399,7 @@ impl PostgresSourceReader {
                         }
                         Origin(_) | Relation(_) | Type(_) => {
                             self.metrics.ignored.inc();
-                        },
+                        }
                         Truncate(_) => return Err(Fatal(anyhow!("source table got truncated"))),
                         // The enum is marked as non_exaustive. Better to be conservative here in
                         // case a new message is relevant to the semantics of our source

--- a/src/dataflow/src/source/postgres.rs
+++ b/src/dataflow/src/source/postgres.rs
@@ -297,7 +297,6 @@ impl PostgresSourceReader {
         let mut last_keepalive = Instant::now();
         let mut inserts = vec![];
         let mut deletes = vec![];
-        
         while let Some(item) = stream.try_next().await? {
             use ReplicationMessage::*;
             // The upstream will periodically request keepalive responses by setting the reply field

--- a/src/dataflow/src/source/postgres.rs
+++ b/src/dataflow/src/source/postgres.rs
@@ -216,6 +216,7 @@ impl PostgresSourceReader {
             }
             self.metrics.tables.inc();
         }
+        self.metrics.lsn.set(self.lsn.into());
         client.simple_query("COMMIT;").await?;
         Ok(())
     }
@@ -392,6 +393,7 @@ impl PostgresSourceReader {
                             for row in inserts.drain(..) {
                                 try_fatal!(tx.insert(row).await);
                             }
+                            self.metrics.lsn.set(self.lsn.into());
                         }
                         Origin(_) | Relation(_) | Type(_) => {
                             self.metrics.ignored.inc();

--- a/src/dataflow/src/source/postgres/metrics.rs
+++ b/src/dataflow/src/source/postgres/metrics.rs
@@ -19,6 +19,7 @@ pub(super) struct PgSourceMetrics {
     pub total: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
     pub transactions: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
     pub tables: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
+    pub lsn: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
 }
 
 
@@ -35,6 +36,7 @@ impl PgSourceMetrics {
             total: pg_metrics.total_messages.get_delete_on_drop_counter(labels.to_vec()),
             transactions: pg_metrics.transactions.get_delete_on_drop_counter(labels.to_vec()),
             tables: pg_metrics.tables_in_publication.get_delete_on_drop_gauge(labels.to_vec()),
+            lsn: pg_metrics.wal_lsn.get_delete_on_drop_gauge(labels.to_vec()),
         }
     }
 }

--- a/src/dataflow/src/source/postgres/metrics.rs
+++ b/src/dataflow/src/source/postgres/metrics.rs
@@ -7,8 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::source::metrics::{SourceBaseMetrics};
-use ore::metrics::{CounterVecExt, DeleteOnDropCounter, GaugeVecExt, DeleteOnDropGauge};
+use crate::source::metrics::SourceBaseMetrics;
+use ore::metrics::{CounterVecExt, DeleteOnDropCounter, DeleteOnDropGauge, GaugeVecExt};
 use prometheus::core::AtomicU64;
 
 pub(super) struct PgSourceMetrics {
@@ -22,20 +22,32 @@ pub(super) struct PgSourceMetrics {
     pub lsn: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
 }
 
-
 impl PgSourceMetrics {
     pub(super) fn new(base_metrics: &SourceBaseMetrics, source_id: String) -> Self {
-        
-        let labels = &[source_id.to_string()];
+        let labels = &[source_id];
         let pg_metrics = &base_metrics.postgres_source_specific;
         Self {
-            inserts: pg_metrics.insert_messages.get_delete_on_drop_counter(labels.to_vec()),
-            updates: pg_metrics.update_messages.get_delete_on_drop_counter(labels.to_vec()),
-            deletes: pg_metrics.delete_messages.get_delete_on_drop_counter(labels.to_vec()),
-            ignored: pg_metrics.ignored_messages.get_delete_on_drop_counter(labels.to_vec()),
-            total: pg_metrics.total_messages.get_delete_on_drop_counter(labels.to_vec()),
-            transactions: pg_metrics.transactions.get_delete_on_drop_counter(labels.to_vec()),
-            tables: pg_metrics.tables_in_publication.get_delete_on_drop_gauge(labels.to_vec()),
+            inserts: pg_metrics
+                .insert_messages
+                .get_delete_on_drop_counter(labels.to_vec()),
+            updates: pg_metrics
+                .update_messages
+                .get_delete_on_drop_counter(labels.to_vec()),
+            deletes: pg_metrics
+                .delete_messages
+                .get_delete_on_drop_counter(labels.to_vec()),
+            ignored: pg_metrics
+                .ignored_messages
+                .get_delete_on_drop_counter(labels.to_vec()),
+            total: pg_metrics
+                .total_messages
+                .get_delete_on_drop_counter(labels.to_vec()),
+            transactions: pg_metrics
+                .transactions
+                .get_delete_on_drop_counter(labels.to_vec()),
+            tables: pg_metrics
+                .tables_in_publication
+                .get_delete_on_drop_gauge(labels.to_vec()),
             lsn: pg_metrics.wal_lsn.get_delete_on_drop_gauge(labels.to_vec()),
         }
     }

--- a/src/dataflow/src/source/postgres/metrics.rs
+++ b/src/dataflow/src/source/postgres/metrics.rs
@@ -1,0 +1,40 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::source::metrics::{SourceBaseMetrics};
+use ore::metrics::{CounterVecExt, DeleteOnDropCounter, GaugeVecExt, DeleteOnDropGauge};
+use prometheus::core::AtomicU64;
+
+pub(super) struct PgSourceMetrics {
+    pub inserts: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
+    pub updates: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
+    pub deletes: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
+    pub ignored: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
+    pub total: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
+    pub transactions: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
+    pub tables: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
+}
+
+
+impl PgSourceMetrics {
+    pub(super) fn new(base_metrics: &SourceBaseMetrics, source_id: String) -> Self {
+        
+        let labels = &[source_id.to_string()];
+        let pg_metrics = &base_metrics.postgres_source_specific;
+        Self {
+            inserts: pg_metrics.insert_messages.get_delete_on_drop_counter(labels.to_vec()),
+            updates: pg_metrics.update_messages.get_delete_on_drop_counter(labels.to_vec()),
+            deletes: pg_metrics.delete_messages.get_delete_on_drop_counter(labels.to_vec()),
+            ignored: pg_metrics.ignored_messages.get_delete_on_drop_counter(labels.to_vec()),
+            total: pg_metrics.total_messages.get_delete_on_drop_counter(labels.to_vec()),
+            transactions: pg_metrics.transactions.get_delete_on_drop_counter(labels.to_vec()),
+            tables: pg_metrics.tables_in_publication.get_delete_on_drop_gauge(labels.to_vec()),
+        }
+    }
+}


### PR DESCRIPTION
This PR adds some basic metrics to the Postgres source including:
- Counters for different replication operations (insert/update/delete)
- Counters for ignored and total messages, total transactions
- Gauge for the number of tables the source is configured for, can be used by an operator to determine if a source needs re-materialization
- LSN of the latest commit, can be used to measure replication lag in bytes

Example stats endpoint with a single source with a single table:
```
# HELP mz_postgres_per_source_deletes The number of deletes for this source
# TYPE mz_postgres_per_source_deletes counter
mz_postgres_per_source_deletes{source_id="materialize.public.mz_source"} 0
# HELP mz_postgres_per_source_ignored_messages The number of messages ignored
# TYPE mz_postgres_per_source_ignored_messages counter
mz_postgres_per_source_ignored_messages{source_id="materialize.public.mz_source"} 1
# HELP mz_postgres_per_source_inserts The number of inserts for this source
# TYPE mz_postgres_per_source_inserts counter
mz_postgres_per_source_inserts{source_id="materialize.public.mz_source"} 2
# HELP mz_postgres_per_source_messages_total The total number of replication messages for this source, not expected to be the sum of the other values.
# TYPE mz_postgres_per_source_messages_total counter
mz_postgres_per_source_messages_total{source_id="materialize.public.mz_source"} 7
# HELP mz_postgres_per_source_tables_count The number of upstream tables for this source
# TYPE mz_postgres_per_source_tables_count gauge
mz_postgres_per_source_tables_count{source_id="materialize.public.mz_source"} 1
# HELP mz_postgres_per_source_transactions_total The number of committed transactions for this source
# TYPE mz_postgres_per_source_transactions_total counter
mz_postgres_per_source_transactions_total{source_id="materialize.public.mz_source"} 2
# HELP mz_postgres_per_source_updates The number of updates for this source
# TYPE mz_postgres_per_source_updates counter
mz_postgres_per_source_updates{source_id="materialize.public.mz_source"} 0
# HELP mz_postgres_per_source_wal_lsn The LSN of the latest transaction committed for this source
# TYPE mz_postgres_per_source_wal_lsn gauge
mz_postgres_per_source_wal_lsn{source_id="materialize.public.mz_source"} 23661856
```

### Motivation

  * This PR adds a feature that has not yet been specified in the form of basic observability on the Postgres logical replication source

### Tips for reviewer

I modeled the implementation on the S3 source's `BucketMetrics`. It would be great to break this out by table but that will be easier to do after I merge the work to add table metadata to the source definition.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
