### PR TITLE
repr: upgrade to proposed dec v0.4.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1327,8 +1327,7 @@ dependencies = [
 [[package]]
 name = "dec"
 version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9d829012cb80e6836307bc86bd621e71718f6c5370c36542cb7504f14055bb9"
+source = "git+https://github.com/MaterializeInc/rust-dec.git?branch=raw-parts-refactor#c2fbec4f4d54b5b617d63965585e23288b8ee7e0"
 dependencies = [
  "decnumber-sys",
  "libc",
@@ -1339,8 +1338,7 @@ dependencies = [
 [[package]]
 name = "decnumber-sys"
 version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a99b958f19724bc0a2202086d135c2e7ed098e95cdae778546e965648fa47b"
+source = "git+https://github.com/MaterializeInc/rust-dec.git?branch=raw-parts-refactor#c2fbec4f4d54b5b617d63965585e23288b8ee7e0"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1326,8 +1326,9 @@ dependencies = [
 
 [[package]]
 name = "dec"
-version = "0.4.6"
-source = "git+https://github.com/MaterializeInc/rust-dec.git?branch=raw-parts-refactor#c2fbec4f4d54b5b617d63965585e23288b8ee7e0"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58be07317881c8d6887c3d2e1a73778bf47f4e027d834ae0d105da8bfa3715c8"
 dependencies = [
  "decnumber-sys",
  "libc",
@@ -1338,7 +1339,8 @@ dependencies = [
 [[package]]
 name = "decnumber-sys"
 version = "0.1.5"
-source = "git+https://github.com/MaterializeInc/rust-dec.git?branch=raw-parts-refactor#c2fbec4f4d54b5b617d63965585e23288b8ee7e0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a99b958f19724bc0a2202086d135c2e7ed098e95cdae778546e965648fa47b"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,4 +82,3 @@ debug = 1
 headers = { git = "https://github.com/MaterializeInc/headers.git" }
 # Until https://github.com/jorgecarleitao/parquet-format-rs/pull/2 is merged and released
 parquet-format-async-temp = { git = "https://github.com/MaterializeInc/parquet-format-rs", branch = "main" }
-dec = { git = "https://github.com/MaterializeInc/rust-dec.git", branch = "raw-parts-refactor" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,3 +82,4 @@ debug = 1
 headers = { git = "https://github.com/MaterializeInc/headers.git" }
 # Until https://github.com/jorgecarleitao/parquet-format-rs/pull/2 is merged and released
 parquet-format-async-temp = { git = "https://github.com/MaterializeInc/parquet-format-rs", branch = "main" }
+dec = { git = "https://github.com/MaterializeInc/rust-dec.git", branch = "raw-parts-refactor" }

--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -16,7 +16,7 @@ chrono = { version = "0.4.0", default-features = false, features = ["std"] }
 crossbeam-channel = "0.5.2"
 dataflow-types = { path = "../dataflow-types" }
 derivative = "2.2.0"
-dec = "0.4.6"
+dec = "0.4.7"
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 expr = { path = "../expr" }
 fail = { version = "0.5.0", features = ["failpoints"] }

--- a/src/dataflow/Cargo.toml
+++ b/src/dataflow/Cargo.toml
@@ -19,7 +19,7 @@ chrono = { version = "0.4.0", default-features = false, features = ["std"] }
 crossbeam-channel = "0.5.2"
 csv-core = "0.1.10"
 dataflow-types = { path = "../dataflow-types" }
-dec = { version = "0.4.6", features = ["serde"] }
+dec = { version = "0.4.7", features = ["serde"] }
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 dogsdogsdogs = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 enum-iterator = "0.7.0"

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -10,7 +10,7 @@ aho-corasick = "0.7.18"
 anyhow = "1.0.52"
 chrono = { version = "0.4.0", default-features = false, features = ["clock", "std"] }
 csv = "1.1.6"
-dec = "0.4.6"
+dec = "0.4.7"
 encoding = "0.2.0"
 enum-iterator = "0.7.0"
 hex = "0.4.3"

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -17,7 +17,7 @@ base64 = "0.13.0"
 byteorder = "1.4.3"
 ccsr = { path = "../ccsr" }
 chrono = { version = "0.4.0", default-features = false, features = ["std"] }
-dec = "0.4.6"
+dec = "0.4.7"
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 futures = "0.3.19"
 hex = "0.4.3"

--- a/src/pgrepr/Cargo.toml
+++ b/src/pgrepr/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 byteorder = "1.4.3"
 bytes = "1.1.0"
 chrono = { version = "0.4.0", default-features = false, features = ["std"] }
-dec = "0.4.6"
+dec = "0.4.7"
 lazy_static = "1.4.0"
 ore = { path = "../ore" }
 postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres", branch = "mz-0.7.2", features = ["with-chrono-0_4", "with-uuid-0_8"] }

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -18,7 +18,7 @@ anyhow = "1.0.52"
 byteorder = "1.4.3"
 chrono = { version = "0.4.0", default-features = false, features = ["serde", "std"] }
 chrono-tz = { version = "0.6.1", features = ["serde", "case-insensitive"] }
-dec = "0.4.6"
+dec = "0.4.7"
 enum-kinds = "0.5.1"
 fast-float = "0.2.0"
 hex = "0.4.3"

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -409,7 +409,7 @@ unsafe fn read_datum<'a>(data: &'a [u8], offset: &mut usize) -> Datum<'a> {
                 lsu[i] = u16::from_le_bytes(c.try_into().unwrap());
             }
 
-            let d = Numeric::from_raw_parts(digits, exponent.into(), bits, &lsu[..lsu_u16_len]);
+            let d = Numeric::from_raw_parts(digits, exponent.into(), bits, lsu);
             Datum::from(d)
         }
     }
@@ -576,6 +576,8 @@ where
                     as u8,
             );
             data.push(bits);
+
+            let lsu = &lsu[..Numeric::digits_to_lsu_elements_len(digits)];
 
             // Little endian machines can take the lsu directly from u16 to u8.
             if cfg!(target_endian = "little") {

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -13,7 +13,7 @@ ccsr = { path = "../ccsr" }
 chrono = { version = "0.4.0", default-features = false, features = ["clock", "std"] }
 csv = "1.1.6"
 dataflow-types = { path = "../dataflow-types" }
-dec = "0.4.6"
+dec = "0.4.7"
 enum-kinds = "0.5.1"
 expr = { path = "../expr" }
 futures = "0.3.19"


### PR DESCRIPTION
This yields a large speedup when unpacking numeric datums:

```
sort_datums_numeric     time:   [6.3856 ms 6.4083 ms 6.4315 ms]
                        change: [+0.0758% +0.7087% +1.3497%] (p = 0.03 < 0.05)
                        Change within noise threshold.

sort_row_numeric        time:   [1.8299 ms 1.8354 ms 1.8411 ms]
                        change: [-1.1238% -0.6913% -0.2565%] (p = 0.00 < 0.05)
                        Change within noise threshold.

sort_iter_numeric       time:   [8.3586 ms 8.3765 ms 8.3946 ms]
                        change: [-19.107% -18.864% -18.607%] (p = 0.00 < 0.05)
                        Performance has improved.

sort_unpack_numeric     time:   [45.604 ms 45.670 ms 45.736 ms]
                        change: [-28.679% -28.516% -28.349%] (p = 0.00 < 0.05)
                        Performance has improved.

sort_unpacked_numeric   time:   [9.5938 ms 9.6298 ms 9.6663 ms]
                        change: [-3.8787% -3.3889% -2.8981%] (p = 0.00 < 0.05)
                        Performance has improved.
```

Just a draft for now while https://github.com/MaterializeInc/rust-dec/pull/64 is outstanding.

### Motivation

  * This PR adds a feature that has not yet been specified.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
