### PR TITLE
feature-benchmark: Large-scale persistence recovery benchmark

### DIFF
--- a/misc/python/materialize/feature_benchmark/benchmark.py
+++ b/misc/python/materialize/feature_benchmark/benchmark.py
@@ -42,7 +42,9 @@ class Benchmark:
         shared = self._scenario.SHARED
         if self._mz_id == 0 and shared is not None:
             print(f"Running the SHARED section for {name} ...")
-            shared.run(executor=self._executor, measure=False)
+
+            for shared_item in shared if isinstance(shared, list) else [shared]:
+                shared_item.run(executor=self._executor, measure=False)
             print("SHARED done")
 
         # Run the SHARED section once for each Mz

--- a/misc/python/materialize/feature_benchmark/executor.py
+++ b/misc/python/materialize/feature_benchmark/executor.py
@@ -10,7 +10,7 @@
 import os
 import subprocess
 from tempfile import NamedTemporaryFile
-from typing import Any, Callable
+from typing import Any, Callable, List
 
 from materialize.mzcompose import Composition
 
@@ -80,3 +80,8 @@ class Docker(Executor):
                 f"tmp/{basename}",
                 capture=True,
             ).stdout
+
+    def Kgen(self, topic: str, args: List[str]) -> Any:
+        return self._composition.run(
+            "kgen", f"--topic=testdrive-{topic}-{self._seed}", *args
+        )

--- a/misc/python/materialize/feature_benchmark/measurement_source.py
+++ b/misc/python/materialize/feature_benchmark/measurement_source.py
@@ -80,6 +80,21 @@ class Lambda(MeasurementSource):
         return self._executor.Lambda(self._lambda)
 
 
+class Kgen(MeasurementSource):
+    def __init__(self, topic: str, args: List[str]) -> None:
+        self._topic: str = topic
+        self._args: List[str] = args
+        self._executor: Optional[Executor] = None
+
+    def run(
+        self, executor: Optional[Executor] = None, measure: bool = True
+    ) -> Optional[float]:
+        getattr((executor if executor else self._executor), "Kgen")(
+            topic=self._topic, args=self._args
+        )
+        return None
+
+
 class Td(MeasurementSource):
     """Use testdrive to run the queries under benchmark and extract the timing information
     out of the testdrive output. The output looks like this:

--- a/misc/python/materialize/feature_benchmark/scenario.py
+++ b/misc/python/materialize/feature_benchmark/scenario.py
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-from typing import Optional
+from typing import List, Optional, Union
 
 from materialize.feature_benchmark.measurement_source import (
     Assert,
@@ -16,11 +16,21 @@ from materialize.feature_benchmark.measurement_source import (
 )
 
 
-class Scenario:
+class RootScenario:
     __name__: str
 
-    SHARED: Optional[MeasurementSource] = None
+    SHARED: Optional[Union[MeasurementSource, List[MeasurementSource]]] = None
     INIT: Optional[MeasurementSource] = None
 
     BEFORE: MeasurementSource = Dummy()
     BENCHMARK: MeasurementSource = Assert()
+
+
+# Used for benchmarks that are expected to run by default, e.g. in CI
+class Scenario(RootScenario):
+    pass
+
+
+# Used for scenarios that need to be explicitly run from the command line using --root-scenario ScenarioBig
+class ScenarioBig(RootScenario):
+    pass

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -32,8 +32,9 @@ from materialize.feature_benchmark.termination import (
     TerminationCondition,
 )
 from materialize.mzcompose import Composition, WorkflowArgumentParser
+from materialize.mzcompose.services import Kafka as KafkaService
+from materialize.mzcompose.services import Kgen as KgenService
 from materialize.mzcompose.services import (
-    Kafka,
     Materialized,
     SchemaRegistry,
     Testdrive,
@@ -64,11 +65,11 @@ def make_comparator(name: str) -> Comparator:
     return RelativeThresholdComparator(name, threshold=0.10)
 
 
-default_timeout = "5m"
+default_timeout = "30m"
 
 SERVICES = [
     Zookeeper(),
-    Kafka(),
+    KafkaService(),
     SchemaRegistry(),
     # We are going to override this service definition during the actual benchmark
     # we put "latest" here so that we avoid recompiling the current source unless
@@ -78,6 +79,7 @@ SERVICES = [
         validate_catalog=False,
         default_timeout=default_timeout,
     ),
+    KgenService(),
 ]
 
 

--- a/test/feature-benchmark/scenarios.py
+++ b/test/feature-benchmark/scenarios.py
@@ -7,8 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-from materialize.feature_benchmark.measurement_source import Lambda, Td
-from materialize.feature_benchmark.scenario import Scenario
+from materialize.feature_benchmark.measurement_source import Kgen, Lambda, Td
+from materialize.feature_benchmark.scenario import Scenario, ScenarioBig
 
 
 class Sleep(Scenario):
@@ -632,11 +632,11 @@ true
     )
 
 
-class KafkaScenario(Scenario):
+class Kafka(Scenario):
     pass
 
 
-class KafkaRaw(KafkaScenario):
+class KafkaRaw(Kafka):
     SHARED = Td(
         """
 $ set count=1000000
@@ -678,7 +678,7 @@ true
     )
 
 
-class KafkaUpsert(KafkaScenario):
+class KafkaUpsert(Kafka):
     SHARED = Td(
         """
 $ set count=1000000
@@ -725,7 +725,7 @@ $ kafka-ingest format=avro topic=kafka-upsert key-format=avro key-schema=${keysc
     )
 
 
-class KafkaUpsertUnique(KafkaScenario):
+class KafkaUpsertUnique(Kafka):
     SHARED = Td(
         """
 $ set keyschema={"type": "record", "name": "Key", "fields": [ {"name": "f1", "type": "long"} ] }
@@ -753,7 +753,7 @@ $ kafka-ingest format=avro topic=upsert-unique key-format=avro key-schema=${keys
     )
 
 
-class KafkaRecovery(KafkaScenario):
+class KafkaRecovery(Kafka):
     SHARED = Td(
         """
 $ set keyschema={
@@ -800,6 +800,74 @@ true
 1
 
 > /* B */ SELECT COUNT(*) = 10000000 FROM s1;
+true
+"""
+    )
+
+
+class KafkaRecoveryBig(ScenarioBig):
+    """Benchmark the ingestion of 100M records without constructing
+    a dataflow that would keep all of them in memory. For the purpose, we
+    emit a bunch of "EOF" records after the primary ingestion is complete
+    and consider that the source has caught up when all the EOF records have
+    been seen.
+    """
+
+    SHARED = [
+        Td("$ kafka-create-topic topic=kafka-recovery-big partitions=8"),
+        # Ingest 100M records
+        Kgen(
+            topic="kafka-recovery-big",
+            args=[
+                "--keys=random",
+                f"--num-records={100_000_000}",
+                "--values=bytes",
+                "--max-message-size=32",
+                "--min-message-size=32",
+                "--key-min=256",
+                f"--key-max={256+(100_000_000**2)}",
+            ],
+        ),
+        # Add 256 EOF markers with key values <= 256.
+        # This high number is chosen as to guarantee that there will be an EOF marker
+        # in each partition, even if the number of partitions is increased in the future.
+        Kgen(
+            topic="kafka-recovery-big",
+            args=[
+                "--keys=sequential",
+                "--num-records=256",
+                "--values=bytes",
+                "--min-message-size=32",
+                "--max-message-size=32",
+            ],
+        ),
+    ]
+
+    INIT = Td(
+        """
+> CREATE SOURCE s1
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-kafka-recovery-big-${testdrive.seed}'
+  FORMAT BYTES
+  ENVELOPE UPSERT;
+
+# Confirm that all the EOF markers generated above have been processed
+> CREATE MATERIALIZED VIEW s1_is_complete AS SELECT COUNT(*) = 256 FROM s1 WHERE key0 <= '\\x00000000000000ff'
+
+> SELECT * FROM s1_is_complete;
+true
+"""
+    )
+
+    BEFORE = Lambda(lambda e: e.RestartMz())
+
+    BENCHMARK = Td(
+        """
+> SELECT 1;
+  /* A */
+1
+
+> SELECT * FROM s1_is_complete
+  /* B */
 true
 """
     )


### PR DESCRIPTION
- Allow Kgen to be used to populate kafka topics
- insert 10 M rows into a non-materialized source, followed by
  256 additional values . The source is considered up to speed
  as soon as those 256 values show up in a materialized source
  that is set up to only fish for them and discard all other data.


### Motivation

  * This PR adds a feature that has not yet been specified.
@danhhz requested a variant of the `KafkaRecovery` benchmark but on a 10-100x larger scale. Unfortunately due to #10071 this is not possible, but the purpose of this review is to show how such a benchmark scenario could play out.

### Tips for reviewer

@danhhz  , @ruchirK if you could review just the bit in `scenarios.py` that implements the new scenario that would be much appreciated. I hope you will find it useful:

https://github.com/MaterializeInc/materialize/pull/10072/files#diff-0323c9ed034f8755d0c049904d3e1dd7ffabc097c8121b4b8da9a4275fee031cR806