### PR TITLE
 dataflow,persistence: enable persistence for ENVELOPE NONE 

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -2635,6 +2635,7 @@ pub struct SerializedSourcePersistDetails {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum SerializedEnvelopePersistDetails {
     Upsert,
+    None,
 }
 
 impl From<SourcePersistDesc> for SerializedSourcePersistDetails {
@@ -2651,6 +2652,7 @@ impl From<EnvelopePersistDesc> for SerializedEnvelopePersistDetails {
     fn from(persist_desc: EnvelopePersistDesc) -> Self {
         match persist_desc {
             EnvelopePersistDesc::Upsert => SerializedEnvelopePersistDetails::Upsert,
+            EnvelopePersistDesc::None => SerializedEnvelopePersistDetails::None,
         }
     }
 }

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -575,6 +575,7 @@ pub mod sources {
         #[derive(Debug, Clone, Serialize, Deserialize)]
         pub enum EnvelopePersistDesc {
             Upsert,
+            None,
         }
 
         /// Description of a single persistent stream.

--- a/src/dataflow/src/render/envelope_none.rs
+++ b/src/dataflow/src/render/envelope_none.rs
@@ -1,0 +1,118 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use persist::client::{StreamReadHandle, StreamWriteHandle};
+use timely::dataflow::operators::{Concat, Map, OkErr};
+use timely::dataflow::{Scope, Stream};
+use timely::progress::Antichain;
+
+use dataflow_types::{DataflowError, DecodeError, SourceError, SourceErrorDetails};
+use persist::operators::replay::Replay;
+use persist::operators::stream::{Persist, RetractUnsealed};
+use persist_types::Codec;
+use repr::{Diff, Row, Timestamp};
+
+/// Persist configuration for `ENVELOPE NONE` sources.
+#[derive(Debug, Clone)]
+pub struct PersistentEnvelopeNoneConfig<V: Codec> {
+    /// The timestamp up to which which data should be read when restoring.
+    pub upper_seal_ts: u64,
+
+    /// [`StreamReadHandle`] for the collection that we should persist to.
+    pub read_handle: StreamReadHandle<V, ()>,
+
+    /// [`StreamWriteHandle`] for the collection that we should persist to.
+    pub write_handle: StreamWriteHandle<V, ()>,
+}
+
+impl<V: Codec> PersistentEnvelopeNoneConfig<V> {
+    /// Creates a new [`PersistentEnvelopeNoneConfig`] from the given parts.
+    pub fn new(
+        upper_seal_ts: u64,
+        read_handle: StreamReadHandle<V, ()>,
+        write_handle: StreamWriteHandle<V, ()>,
+    ) -> Self {
+        PersistentEnvelopeNoneConfig {
+            upper_seal_ts,
+            read_handle,
+            write_handle,
+        }
+    }
+}
+
+/// Persists the given input stream, passes through the data it carries and replays previously
+/// persisted updates when starting up.
+///
+/// This will filter out and retract replayed updates that are not beyond the `upper_seal_ts` given
+/// in `persist_config`.
+///
+pub(crate) fn persist_and_replay<G>(
+    source_name: &str,
+    stream: &Stream<G, (Result<Row, DecodeError>, Timestamp, Diff)>,
+    as_of_frontier: &Antichain<Timestamp>,
+    persist_config: PersistentEnvelopeNoneConfig<Result<Row, DecodeError>>,
+) -> (
+    Stream<G, (Result<Row, DecodeError>, Timestamp, Diff)>,
+    Stream<G, (DataflowError, Timestamp, Diff)>,
+)
+where
+    G: Scope<Timestamp = Timestamp>,
+{
+    let scope = stream.scope();
+
+    let (restored_oks, restored_errs) = {
+        let snapshot = persist_config.read_handle.snapshot();
+
+        let (restored_oks, restored_errs) =
+            scope.replay(snapshot, as_of_frontier).ok_err(split_ok_err);
+
+        let (restored_oks, retract_errs) = restored_oks.retract_unsealed(
+            source_name,
+            persist_config.write_handle.clone(),
+            persist_config.upper_seal_ts,
+        );
+
+        let combined_errs = restored_errs.concat(&retract_errs);
+
+        (restored_oks, combined_errs)
+    };
+
+    // Persist can only deal with (key, value) streams, so promote value to key.
+    let flattened_stream = stream.map(|(row, ts, diff)| ((row, ()), ts, diff));
+
+    let (flattened_stream, persist_errs) =
+        flattened_stream.persist(source_name, persist_config.write_handle);
+
+    let persist_errs = persist_errs.concat(&restored_errs);
+
+    let source_name = source_name.to_string();
+    let persist_errs = persist_errs.map(move |(err, ts, diff)| {
+        let source_error =
+            SourceError::new(source_name.clone(), SourceErrorDetails::Persistence(err));
+        (source_error.into(), ts, diff)
+    });
+
+    let combined_stream = flattened_stream.concat(&restored_oks);
+
+    // Strip away the key/value separation that we needed for persistence.
+    let combined_stream = combined_stream.map(|((k, ()), ts, diff)| (k, ts, diff));
+
+    (combined_stream, persist_errs)
+}
+
+// TODO: Maybe we should finally move this to some central place and re-use. There seem to be
+// enough instances of this by now.
+fn split_ok_err<K, V>(
+    x: (Result<(K, V), String>, u64, isize),
+) -> Result<((K, V), u64, isize), (String, u64, isize)> {
+    match x {
+        (Ok(kv), ts, diff) => Ok((kv, ts, diff)),
+        (Err(err), ts, diff) => Err((err, ts, diff)),
+    }
+}

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -133,6 +133,7 @@ use crate::source::timestamp::TimestampBindingRc;
 use crate::source::SourceToken;
 
 mod context;
+mod envelope_none;
 mod flat_map;
 mod join;
 mod reduce;

--- a/test/feature-benchmark/scenarios.py
+++ b/test/feature-benchmark/scenarios.py
@@ -678,6 +678,36 @@ true
     )
 
 
+class KafkaEnvelopeNoneBytes(Kafka):
+    SHARED = Td(
+        """
+$ set count=1000000
+
+$ kafka-create-topic topic=kafka-envelope-none-bytes
+
+$ kafka-ingest format=bytes topic=kafka-envelope-none-bytes repeat=${count}
+12345678901234567890123456789012345678901234567890
+"""
+    )
+    BENCHMARK = Td(
+        """
+$ set count=1000000
+
+> DROP SOURCE IF EXISTS s1;
+
+> CREATE MATERIALIZED SOURCE s1
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-kafka-envelope-none-bytes-${testdrive.seed}'
+  FORMAT BYTES
+  ENVELOPE NONE
+  /* A */
+
+> SELECT COUNT(*) = ${count} FROM s1
+  /* B */
+true
+"""
+    )
+
+
 class KafkaUpsert(Kafka):
     SHARED = Td(
         """

--- a/test/persistence/kafka-sources/envelope-none-after.td
+++ b/test/persistence/kafka-sources/envelope-none-after.td
@@ -1,0 +1,31 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set schema={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"f1", "type":"long"}
+        ]
+    }
+
+> SELECT COUNT(*) FROM envelope_none;
+10000
+
+> SELECT SUM(CAST(statistics->'topics'->'testdrive-envelope-none-${testdrive.seed}'->'partitions'->'0'->'msgs' AS INT)) = 0 FROM mz_kafka_source_statistics;
+true
+
+$ kafka-ingest format=avro topic=envelope-none schema=${schema} publish=true repeat=5000
+{"f1": ${kafka-ingest.iteration}}
+
+$ kafka-ingest format=avro topic=envelope-none key-format=avro key-schema=${schema} schema=${schema} publish=true repeat=5000
+{"f1": ${kafka-ingest.iteration}} {"f1": ${kafka-ingest.iteration}}
+
+> SELECT COUNT(*), COUNT(DISTINCT f1), MIN(f1), MAX(f1) FROM envelope_none;
+20000 5000 0 4999

--- a/test/persistence/kafka-sources/envelope-none-before.td
+++ b/test/persistence/kafka-sources/envelope-none-before.td
@@ -1,0 +1,37 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set schema={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"f1", "type":"long"}
+        ]
+    }
+
+$ kafka-create-topic topic=envelope-none partitions=2
+
+# Make sure that no upsert semantics kicks in -- all the 15K records we insert must be processed independently
+
+$ kafka-ingest format=avro topic=envelope-none schema=${schema} publish=true repeat=5000
+{"f1": ${kafka-ingest.iteration}}
+
+$ kafka-ingest format=avro topic=envelope-none key-format=avro key-schema=${schema} schema=${schema} publish=true repeat=5000
+{"f1": ${kafka-ingest.iteration}} {"f1": ${kafka-ingest.iteration}}
+
+> CREATE MATERIALIZED SOURCE envelope_none
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-envelope-none-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  INCLUDE PARTITION AS kafka_partition, OFFSET AS mz_offset
+  ENVELOPE NONE
+
+> SELECT COUNT(*) = 10000 FROM envelope_none
+true
+
+$ kafka-add-partitions topic=envelope-none total-partitions=4

--- a/test/persistence/kafka-sources/envelope-none-bytes-after.td
+++ b/test/persistence/kafka-sources/envelope-none-bytes-after.td
@@ -1,0 +1,34 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> SELECT COUNT(*) FROM envelope_none_text;
+10000
+
+> SELECT COUNT(*) FROM envelope_none_bytes;
+10000
+
+> SELECT SUM(CAST(statistics->'topics'->'testdrive-envelope-none-bytes-${testdrive.seed}'->'partitions'->'0'->'msgs' AS INT)) = 0 FROM mz_kafka_source_statistics;
+true
+
+> SELECT SUM(CAST(statistics->'topics'->'testdrive-envelope-none-text-${testdrive.seed}'->'partitions'->'0'->'msgs' AS INT)) = 0 FROM mz_kafka_source_statistics;
+true
+
+$ kafka-ingest topic=envelope-none-bytes format=bytes repeat=5000
+ABC
+XYZ
+
+$ kafka-ingest topic=envelope-none-text format=bytes repeat=5000
+ABC
+XYZ
+
+> SELECT COUNT(*), COUNT(DISTINCT data) FROM envelope_none_bytes;
+20000 2
+
+> SELECT COUNT(*), COUNT(DISTINCT "text") FROM envelope_none_text;
+20000 2

--- a/test/persistence/kafka-sources/envelope-none-bytes-before.td
+++ b/test/persistence/kafka-sources/envelope-none-bytes-before.td
@@ -1,0 +1,38 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ kafka-create-topic topic=envelope-none-bytes
+
+$ kafka-ingest topic=envelope-none-bytes format=bytes repeat=5000
+ABC
+XYZ
+
+> CREATE MATERIALIZED SOURCE envelope_none_bytes
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-envelope-none-bytes-${testdrive.seed}'
+  FORMAT BYTES
+  INCLUDE PARTITION AS kafka_partition, OFFSET AS mz_offset
+  ENVELOPE NONE
+
+> SELECT COUNT(*) = 10000 FROM envelope_none_bytes
+true
+
+$ kafka-create-topic topic=envelope-none-text
+
+$ kafka-ingest topic=envelope-none-text format=bytes repeat=5000
+ABC
+XYZ
+
+> CREATE MATERIALIZED SOURCE envelope_none_text
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-envelope-none-text-${testdrive.seed}'
+  FORMAT TEXT
+  INCLUDE PARTITION AS kafka_partition, OFFSET AS mz_offset
+  ENVELOPE NONE
+
+> SELECT COUNT(*) = 10000 FROM envelope_none_text
+true


### PR DESCRIPTION
### Tips for reviewer

Code has `NOTE`s and `TODO`s.

Factoring out `await_and_seal()` doesn't seem like much today, but I originally did this on top of #9981, where that shared logic gets more complicated because we're also adding compaction.

Also, the new `persist_and_replay()` is very similar to an older iteration of `persist()`, with the difference that we filter and retract based on the seal timestamp. I can move the operator to `persist` and (independently from that) add tests if we agree on the approach.

@philip-stoev We would probably want to mirror most persistence tests for this newly brought up envelope?

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
