### PR TITLE
[testdrive] Allow for missing initial items in kafka-verify

### DIFF
--- a/doc/developer/testdrive.md
+++ b/doc/developer/testdrive.md
@@ -658,9 +658,9 @@ Set the starting value of the `${kafka-ingest.iteration}` variable.
 
 Send the data to the specified partition.
 
-#### `kafka-verify format=avro sink=... [sort-messages=true] [consistency=debezium]`
+#### `kafka-verify format=avro sink=... [sort-messages=true] [consistency=debezium] [greedy-search=false]`
 
-Obtains the data from the specified `sink` and compares it to the expected data recorded in the test. The comparison algorithm is sensitive to the order in which data arrives, so `sort-messages=true` can be used along with manually pre-sorting the expected data in the test.
+Obtains the data from the specified `sink` and compares it to the expected data recorded in the test. The comparison algorithm is sensitive to the order in which data arrives, so `sort-messages=true` can be used along with manually pre-sorting the expected data in the test. If `greedy-search=true` is specified, the messages do not have to match starting at the beginning of the sink but once one record matches, the following must all match.
 
 ## Actions on Kinesis
 

--- a/test/testdrive/kafka-exactly-once-sink.td
+++ b/test/testdrive/kafka-exactly-once-sink.td
@@ -224,7 +224,7 @@ $ kafka-verify format=avro sink=materialize.public.rt_binding_consistency_test_s
 # can't verify more because there will now be a constant stream of END records
 # as real time advances.
 
-$ kafka-verify format=avro sink=materialize.public.rt_binding_consistency_test_sink consistency=debezium
+$ kafka-verify format=avro sink=materialize.public.rt_binding_consistency_test_sink consistency=debezium greedy-search=true
 {"id": "<TIMESTAMP>", "status": "BEGIN", "event_count": null, "data_collections": null}
 {"id": "<TIMESTAMP>", "status": "END", "event_count": {"long": 1}, "data_collections": {"array": [{"event_count": 1, "data_collection": "rt-binding-consistency-test-output-${testdrive.seed}"}]}}
 


### PR DESCRIPTION
Add a new `greedy-search` option for the `kafka-verify` testdrive command.  This allows us the search for a sequence of records that does not begin at the beginning of the topic.

### Motivation
Will help unblock #9514 .  There's no reason that we _need_ to start with a BEGIN record and, as shown in this issue, it can cause us some trouble.  I've pulled this out because the direct fix to that issue is in a complex PR (#10094 )

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
