### PR TITLE
[kafka exactly once sink] Fence consistency topics before determining latest ts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1411,6 +1411,7 @@ dependencies = [
  "ore",
  "persist",
  "persist-types",
+ "rdkafka",
  "regex",
  "repr",
  "serde",

--- a/src/dataflow-types/Cargo.toml
+++ b/src/dataflow-types/Cargo.toml
@@ -31,6 +31,7 @@ num_enum = "0.5.6"
 mz-aws-util = { path = "../aws-util" }
 ore = { path = "../ore" }
 persist = { path = "../persist" }
+rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "libz-static"] }
 regex = "1.5.4"
 repr = { path = "../repr" }
 serde = { version = "1.0.135", features = ["derive"] }

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -1468,10 +1468,6 @@ pub mod sinks {
     pub struct KafkaSinkConsistencyConnector {
         pub topic: String,
         pub schema_id: i32,
-        // gate_ts is the most recent high watermark tailed from the consistency topic
-        // Exactly-once sinks use this to determine when they should start publishing again. This
-        // tells them when they have caught up to where the previous materialize instance stopped.
-        pub gate_ts: Option<Timestamp>,
     }
 
     #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/test/testdrive/kafka-exactly-once-sink.td
+++ b/test/testdrive/kafka-exactly-once-sink.td
@@ -363,5 +363,4 @@ $ kafka-verify format=json sink=materialize.public.json_avro_upsert_key_2 key=tr
 # Verify compaction of exactly once sinks.
 $ verify-timestamp-compaction source=input_csv max-size=3 permit-progress=true
 $ verify-timestamp-compaction source=rt_binding_consistency_test_source max-size=3 permit-progress=true
-# TODO: Enable when #9514 is fixed!
-#$ verify-timestamp-compaction source=input_kafka_no_byo max-size=3
+$ verify-timestamp-compaction source=input_kafka_no_byo max-size=3


### PR DESCRIPTION
Now that the kafka sink has been asyncified in #10044 , it has become easier to make changes like this.  As described in #9249 and the title, we move fencing before the determination of the last ts to be successfully written to the consistency topic.  We do that by
- Creating an explicit initialization phase of the KafkaSink.  When transitioning out of it, we call `init_transactions` on the kafka producer and then afterwards, create a consumer to read in and determine the most recent timestamp.
- Moving the work for determining most recent timestamp to live within the sink itself rather than being done when creating the sink connector
- Reorganizing how sink state is tracked with a couple new enums and structs.  These are designed in a way to make it impossible to enter into some invalid states.  For example, moving from `KafkaSinkStateEnum::Init` to `KafkaSinkStateEnum::Running` _requires_ a `gate_ts` -- and that `gate_ts` cannot be read before entering the `Running` state because it's not yet saved onto the sink state.

### Motivation

Fixes #9249
Fixes #9514 
Fixes #8356

### Tips for reviewer


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
