### PR TITLE
sql: Handle SHOW TIME ZONE as an alias for SHOW TIMEZONE #9908

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -116,6 +116,10 @@ changes that have not yet been documented.
 
 - Add basic Prometheus counters for PostgreSQL sources.
 
+- Improve PostgreSQL compatibility:
+
+  - Support `SHOW TIME ZONE` as an alias for `SHOW TIMEZONE` {{% gh 9908 %}}.
+
 {{< comment >}}
 Only add new release notes above this line.
 

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -3785,6 +3785,8 @@ impl<'a> Parser<'a> {
         } else {
             let variable = if self.parse_keywords(&[TRANSACTION, ISOLATION, LEVEL]) {
                 Ident::new("transaction_isolation")
+            } else if self.parse_keywords(&[TIME, ZONE]) {
+                Ident::new("timezone")
             } else {
                 self.parse_identifier()?
             };

--- a/test/sqllogictest/timezone.slt
+++ b/test/sqllogictest/timezone.slt
@@ -25,6 +25,16 @@ statement error parameter "TimeZone" can only be set to "UTC"
 SET TIME ZONE bad
 
 query T
+SHOW TIMEZONE
+----
+UTC
+
+query T
+SHOW TIME ZONE
+----
+UTC
+
+query T
 SELECT TIMESTAMP '2020-12-21 18:53:49' AT TIME ZONE 'America/New_York'
 ----
 2020-12-21 23:53:49+00


### PR DESCRIPTION
<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

Aliases `SHOW TIME ZONE` to `SHOW TIMEZONE` for PostgreSQL compatibility. Looks like we're already correctly aliasing `TIME ZONE` for `SET`.

Prior to change, we saw:

```
materialize=> SHOW TIME ZONE;
ERROR:  Expected end of statement, found ZONE
LINE 1: SHOW TIME ZONE;
                  ^
```

After the change we see the correct result:

```
materialize=> SHOW TIME ZONE;
 timezone
----------
 UTC
(1 row)
```

### Motivation

  * This PR fixes a recognized bug: #9908  
<!--

Which of the following best describes the motivation behind this PR?



  * This PR adds a known-desirable feature: [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
