### PR TITLE
persist: chunk up ColumnarRecords construction

### DIFF
--- a/src/persist/benches/writer.rs
+++ b/src/persist/benches/writer.rs
@@ -175,11 +175,12 @@ fn bench_write<L: Log, B: Blob>(
         for updates in data {
             // We intentionally never call seal, so that the data only gets written
             // once to Unsealed, and not to Trace.
-            let mut updates = WriteReqBuilder::from_iter(updates.iter());
-            block_on_drain(index, |i, handle| {
-                i.write(vec![(id, updates.finish())], handle)
-            })
-            .unwrap();
+            let updates = WriteReqBuilder::from_iter(updates.iter())
+                .finish()
+                .into_iter()
+                .map(|x| (id, x))
+                .collect();
+            block_on_drain(index, |i, handle| i.write(updates, handle)).unwrap();
         }
         start.elapsed()
     })

--- a/src/persist/src/indexed/columnar/parquet.rs
+++ b/src/persist/src/indexed/columnar/parquet.rs
@@ -26,7 +26,7 @@ use crate::gen::persist::ProtoBatchFormat;
 use crate::indexed::columnar::arrow::{
     decode_arrow_batch_kvtd, encode_arrow_batch_kvtd, SCHEMA_ARROW_KVTD,
 };
-use crate::indexed::columnar::ColumnarRecords;
+use crate::indexed::columnar::{ColumnarRecords, ColumnarRecordsVec};
 use crate::indexed::encoding::{
     decode_trace_inline_meta, decode_unsealed_inline_meta, encode_trace_inline_meta,
     encode_unsealed_inline_meta, BlobTraceBatch, BlobUnsealedBatch,
@@ -53,11 +53,12 @@ pub fn encode_trace_parquet<W: Write>(w: &mut W, batch: &BlobTraceBatch) -> Resu
         .updates
         .iter()
         .map(|((k, v), t, d)| ((k.to_vec(), v.to_vec()), *t, *d))
-        .collect();
+        .collect::<ColumnarRecordsVec>()
+        .into_inner();
     encode_parquet_kvtd(
         w,
         encode_trace_inline_meta(batch, ProtoBatchFormat::ParquetKvtd),
-        &[updates],
+        &updates,
     )
 }
 

--- a/src/persist/src/indexed/encoding.rs
+++ b/src/persist/src/indexed/encoding.rs
@@ -902,6 +902,7 @@ pub fn decode_trace_inline_meta(
 #[cfg(test)]
 mod tests {
     use crate::error::Error;
+    use crate::indexed::columnar::ColumnarRecordsVec;
     use crate::workload::DataGenerator;
 
     use super::*;
@@ -962,7 +963,7 @@ mod tests {
     }
 
     fn columnar_records(updates: Vec<((Vec<u8>, Vec<u8>), u64, isize)>) -> Vec<ColumnarRecords> {
-        vec![updates.iter().collect::<ColumnarRecords>()]
+        updates.iter().collect::<ColumnarRecordsVec>().into_inner()
     }
 
     impl From<(&'_ str, Id)> for StreamRegistration {

--- a/src/persist/src/workload.rs
+++ b/src/persist/src/workload.rs
@@ -131,7 +131,10 @@ impl DataGenerator {
             0,
         );
         for record_idx in batch_start..batch_end {
-            batch.push(self.gen_record(record_idx));
+            assert!(
+                batch.push(self.gen_record(record_idx)),
+                "generator exceeded batch size; smaller batches needed"
+            );
         }
         Some(batch.finish())
     }


### PR DESCRIPTION
ColumnarRecords internally has some size limits (currently that the
total amount of data in keys <= i32::MAX and similarly in vals; in the
future, perhaps additional ones). These were recently introduced in the
parquet work, but we didn't add the necessary bits to prevent
constructing batches that violate these size limits, resulting in a
panic at runtime when testing persist on large data sizes. (This is not
an issue for the background system tables, which deals with data far
smaller than 2GB).

BlobUnsealedBatch already kept a Vec of ColumnarRecords and both the
arrow and parquet formats easily handle the ability to encode a series
of them. BlobTraceBatch only had a single ColumnarRecords but it was
easily fixed in this commit.

So, we simply do the straightforward thing and break up batches as
necessary within a BlobUnsealedBatch/BlobTraceBatch. This allows us to
sidestep the issue of introducing ranges of keys to the descriptions we
use for blob batches. When combined with parquet metadata, it also sets
us up in the future for the ability to fetch individual ColumnarRecords
out of a blob value so we can e.g. compact two very large trace batches
without ever holding them both in memory at once (ditto on disk even).
Though, the details of this are hand-wavey at the moment and it will
require a good bit of code.

Note that this does result in a restriction that each individual key and
value must be <= i32::MAX bytes, but this seems entirely reasonable for
the foreseeable future.

### Motivation

  * This PR fixes a recognized bug:

Closes #10071

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
