### PR TITLE
switch dev-box.json to larger machines

### DIFF
--- a/misc/scratch/dev-box.json
+++ b/misc/scratch/dev-box.json
@@ -1,7 +1,7 @@
 {
     "name": "one-off testing",
     "launch_script": "true",
-    "instance_type": "t2.large",
+    "instance_type": "t3.2xlarge",
     "ami": "ami-0b29b6e62f2343b46",
     "size_gb": 50,
     "tags": {}


### PR DESCRIPTION
### Motivation

t3's are better value, and have better networking (which matters for rust compilation), and 2xlarge's will be MUCH better at compiling materialize.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
