### PR TITLE
[testdrive] Fix search-greedy option

### DIFF
--- a/doc/developer/testdrive.md
+++ b/doc/developer/testdrive.md
@@ -658,9 +658,9 @@ Set the starting value of the `${kafka-ingest.iteration}` variable.
 
 Send the data to the specified partition.
 
-#### `kafka-verify format=avro sink=... [sort-messages=true] [consistency=debezium] [greedy-search=false]`
+#### `kafka-verify format=avro sink=... [sort-messages=true] [consistency=debezium] [partial-search=usize]`
 
-Obtains the data from the specified `sink` and compares it to the expected data recorded in the test. The comparison algorithm is sensitive to the order in which data arrives, so `sort-messages=true` can be used along with manually pre-sorting the expected data in the test. If `greedy-search=true` is specified, the messages do not have to match starting at the beginning of the sink but once one record matches, the following must all match.
+Obtains the data from the specified `sink` and compares it to the expected data recorded in the test. The comparison algorithm is sensitive to the order in which data arrives, so `sort-messages=true` can be used along with manually pre-sorting the expected data in the test. If `partial-search=usize` is specified, up to `partial-search` records will be read from the given topic and compared to the provided records. The recordsdo not have to match starting at the beginning of the sink but once one record matches, the following must all match.  There are permitted to be records remaining in the topic after the matching is complete.  Note that if the topic is not required to have `partial-search` elements in it but there will be an attempt to read up to this number with a blocking read.
 
 ## Actions on Kinesis
 

--- a/src/testdrive/src/format/avro.rs
+++ b/src/testdrive/src/format/avro.rs
@@ -316,13 +316,13 @@ where
                     actual_item = actual.next();
                 }
             }
-            (Some(e), None) => {
+            (Some(e), None) => return Err(format!("missing record {}: {:#?}", i, e)),
+            (None, Some(a)) => {
                 if !greedy_search {
-                    return Err(format!("missing record {}: {:#?}", i, e));
+                    return Err(format!("extra record {}: {:#?}", i, a));
                 }
                 break;
             }
-            (None, Some(a)) => return Err(format!("extra record {}: {:#?}", i, a)),
             (None, None) => break,
         }
     }
@@ -330,7 +330,7 @@ where
     let actual: Vec<_> = actual.map(|a| format!("{:#?}", a)).collect();
     if !expected.is_empty() {
         Err(format!("missing records:\n{}", expected.join("\n")))
-    } else if !actual.is_empty() {
+    } else if !actual.is_empty() && !greedy_search {
         Err(format!("extra records:\n{}", actual.join("\n")))
     } else {
         Ok(())

--- a/src/testdrive/src/format/avro.rs
+++ b/src/testdrive/src/format/avro.rs
@@ -236,7 +236,7 @@ where
     I: IntoIterator,
     I::Item: AsRef<str>,
 {
-    validate_sink_with_greedy_search(
+    validate_sink_with_partial_search(
         key_schema,
         value_schema,
         expected,
@@ -247,14 +247,14 @@ where
     )
 }
 
-pub fn validate_sink_with_greedy_search<I>(
+pub fn validate_sink_with_partial_search<I>(
     key_schema: Option<&Schema>,
     value_schema: &Schema,
     expected: I,
     actual: &[(Option<Value>, Option<Value>)],
     regex: &Option<Regex>,
     regex_replacement: &String,
-    greedy_search: bool,
+    partial_search: bool,
 ) -> Result<(), String>
 where
     I: IntoIterator,
@@ -287,7 +287,7 @@ where
     let mut actual = actual.iter();
     let mut index = 0..;
 
-    let mut found_beginning = !greedy_search;
+    let mut found_beginning = !partial_search;
     let mut expected_item = expected.next();
     let mut actual_item = actual.next();
     loop {
@@ -318,7 +318,7 @@ where
             }
             (Some(e), None) => return Err(format!("missing record {}: {:#?}", i, e)),
             (None, Some(a)) => {
-                if !greedy_search {
+                if !partial_search {
                     return Err(format!("extra record {}: {:#?}", i, a));
                 }
                 break;
@@ -328,9 +328,10 @@ where
     }
     let expected: Vec<_> = expected.map(|e| format!("{:#?}", e)).collect();
     let actual: Vec<_> = actual.map(|a| format!("{:#?}", a)).collect();
+
     if !expected.is_empty() {
         Err(format!("missing records:\n{}", expected.join("\n")))
-    } else if !actual.is_empty() && !greedy_search {
+    } else if !actual.is_empty() && !partial_search {
         Err(format!("extra records:\n{}", actual.join("\n")))
     } else {
         Ok(())

--- a/test/testdrive/kafka-exactly-once-sink.td
+++ b/test/testdrive/kafka-exactly-once-sink.td
@@ -220,11 +220,10 @@ $ kafka-ingest format=avro topic=rt-binding-consistency-test-input schema=${sche
 $ kafka-verify format=avro sink=materialize.public.rt_binding_consistency_test_sink
 {"before": null, "after": {"row": {"a": 1, "b": 1}}, "transaction": {"id": "<TIMESTAMP>"}}
 
-# Verify that there is at least one cycle of consistency output. After that, we
-# can't verify more because there will now be a constant stream of END records
-# as real time advances.
-
-$ kafka-verify format=avro sink=materialize.public.rt_binding_consistency_test_sink consistency=debezium greedy-search=true
+# Because the consistency topic produces a new end record every second, parital-search will wait
+# for 10 seconds before continuing rather than the per-record timeout. Be wary of copy/pasting the
+# `partial-search` arg.
+$ kafka-verify format=avro sink=materialize.public.rt_binding_consistency_test_sink consistency=debezium partial-search=10
 {"id": "<TIMESTAMP>", "status": "BEGIN", "event_count": null, "data_collections": null}
 {"id": "<TIMESTAMP>", "status": "END", "event_count": {"long": 1}, "data_collections": {"array": [{"event_count": 1, "data_collection": "rt-binding-consistency-test-output-${testdrive.seed}"}]}}
 


### PR DESCRIPTION
Fix #10093 .  The conditions on the loop were not correct / could be improved:

- If there is more expected output after reading all actual output, show a better (and more correct) error message
- Allow there to be extra output after matching all the expected output with `greedy-search` only

Also rename to `partial-search`.