### PR TITLE
deps: upgrade to latest autotools-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,8 +257,7 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 [[package]]
 name = "autotools"
 version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec8e3c65baca58d892ae26d20bbe34713d20d0b02fd0ced4254f256aebbbb80"
+source = "git+https://github.com/lu-zero/autotools-rs.git#83de473992c7618fe2607411ad71045b3dab3da5"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,8 @@ rustc-demangle = { opt-level = 3 }
 debug = 1
 
 [patch.crates-io]
+# Waiting on https://github.com/lu-zero/autotools-rs/pull/27 to make it into a release.
+autotools = { git = "https://github.com/lu-zero/autotools-rs.git" }
 # Waiting on https://github.com/hyperium/headers/pull/99.
 headers = { git = "https://github.com/MaterializeInc/headers.git" }
 # Until https://github.com/jorgecarleitao/parquet-format-rs/pull/2 is merged and released

--- a/deny.toml
+++ b/deny.toml
@@ -104,6 +104,10 @@ license-files = [
 unknown-git = "deny"
 unknown-registry = "deny"
 allow-git = [
+    # Waiting on https://github.com/lu-zero/autotools-rs/pull/27 to make it into
+    # a release.
+    "https://github.com/lu-zero/autotools-rs.git",
+
     # See the patch in Cargo.toml.
     "https://github.com/MaterializeInc/headers.git",
 
@@ -124,14 +128,13 @@ allow-git = [
     # Waiting on https://github.com/bheisler/criterion.rs/pull/543.
     "https://github.com/MaterializeInc/criterion.rs.git",
 
+    # Until https://github.com/jorgecarleitao/parquet-format-rs/pull/2 is merged and released
+    "https://github.com/MaterializeInc/parquet-format-rs.git",
+
     # Dependencies that we control upstream whose official releases we don't
     # care about.
     "https://github.com/MaterializeInc/cloud-sdks.git",
     "https://github.com/TimelyDataflow/timely-dataflow",
     "https://github.com/TimelyDataflow/differential-dataflow.git",
     "https://github.com/fede1024/rust-rdkafka.git",
-    # Until https://github.com/jorgecarleitao/parquet-format-rs/pull/2 is merged and released
-    "https://github.com/MaterializeInc/parquet-format-rs.git",
-    # Until repr::row::{push_datum,read_datum} are updated with the new {to,from}_raw_parts
-    "https://github.com/MaterializeInc/rust-dec",
 ]


### PR DESCRIPTION
Which fixes a cross-compilation bug.

### Motivation

  * This PR fixes a previously unreported bug.

    Cross-compilation via `mzimage` was broken on macOS.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
