### PR TITLE
mzcompose: exit with a high error code on UIErrors

### DIFF
--- a/misc/python/materialize/ui.py
+++ b/misc/python/materialize/ui.py
@@ -194,6 +194,14 @@ def error_handler(prog: str) -> Any:
         print(f"{prog}: {fg('red')}error:{attr('reset')} {e}", file=sys.stderr)
         if e.hint:
             print(f"{attr('bold')}hint:{attr('reset')} {e.hint}")
-        sys.exit(1)
+        # Exit with a high exit code in order to differentiate UIErrors from any
+        # other errors that may happen elsewhere while the workflow is running.
+        #
+        # This particular value was chosen to match the one expected by git bisect to
+        # signal that a particular release is not testable and must be skipped. This
+        # way a mzcompose-based test, such as the feature benchmark framework, can
+        # report directly to git bisect that a particular Git tag could not be found
+        # in the container repository and must be skipped.
+        sys.exit(125)
     except KeyboardInterrupt:
         sys.exit(1)


### PR DESCRIPTION
Exit with a high exit code in order to differentiate UIErrors from any
other errors that may happen elsewhere while the workflow is running.

This particular value was chosen to match the one expected by git bisect to
signal that a particular release is not testable and must be skipped. This
way a mzcompose-based test, such as the feature benchmark framework, can
report directly to git bisect that a particular Git tag could not be found
in the container repository and must be skipped.

### Motivation

  * This PR adds a feature that has not yet been specified.

I am doing git bisections using the feature benchmark. Sometimes, a particular Git SHA being tested can not be found in the container registry, and the feature benchmark fails. This needs to happen with exit code 125 so that git bisect considers the revision to be "skipped" and it can move on to test other adjacent revisions.