### PR TITLE
Reworking `import_source`

### DIFF
--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -1453,7 +1453,7 @@ pub mod sinks {
         /// dependencies' compaction frontiers as it completes writes.
         ///
         /// Sinks that do need to hold back compaction need to insert an
-        /// [`Antichain`] into `RenderState.sink_write_frontiers` that they update
+        /// [`Antichain`] into `ComputeState.sink_write_frontiers` that they update
         /// in order to advance the frontier that holds back upstream compaction
         /// of timestamp bindings.
         ///

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -1453,7 +1453,7 @@ pub mod sinks {
         /// dependencies' compaction frontiers as it completes writes.
         ///
         /// Sinks that do need to hold back compaction need to insert an
-        /// [`Antichain`] into `ComputeState.sink_write_frontiers` that they update
+        /// [`Antichain`] into `StorageState::sink_write_frontiers` that they update
         /// in order to advance the frontier that holds back upstream compaction
         /// of timestamp bindings.
         ///

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -219,9 +219,8 @@ pub fn build_dataflow<A: Allocate>(
 
             // Import declared sources into the rendering context.
             for (src_id, (src, orig_id)) in &dataflow.source_imports {
-                context.import_source(
+                let (source_token, additional_tokens) = context.import_source(
                     render_state,
-                    &mut tokens,
                     region,
                     materialized_logging.clone(),
                     src_id.clone(),
@@ -230,6 +229,15 @@ pub fn build_dataflow<A: Allocate>(
                     now.clone(),
                     source_metrics,
                 );
+
+                // Associate returned tokens with the source identifier.
+                let prior = tokens.source_tokens.insert(*src_id, source_token);
+                assert!(prior.is_none());
+                tokens
+                    .additional_tokens
+                    .entry(*src_id)
+                    .or_insert_with(Vec::new)
+                    .extend(additional_tokens);
             }
 
             // Import declared indexes into the rendering context.

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -227,16 +227,23 @@ pub fn build_dataflow<A: Allocate>(
 
             // Import declared sources into the rendering context.
             for (src_id, (src, orig_id)) in &dataflow.source_imports {
-                let (source_token, additional_tokens) = context.import_source(
-                    storage_state,
-                    region,
-                    materialized_logging.clone(),
-                    src_id.clone(),
-                    src.clone(),
-                    orig_id.clone(),
-                    now.clone(),
-                    source_metrics,
-                );
+                let (collection_bundle, (source_token, additional_tokens)) =
+                    crate::render::sources::import_source(
+                        &context.debug_name,
+                        context.dataflow_id,
+                        &context.as_of_frontier,
+                        storage_state,
+                        region,
+                        materialized_logging.clone(),
+                        src_id.clone(),
+                        src.clone(),
+                        orig_id.clone(),
+                        now.clone(),
+                        source_metrics,
+                    );
+
+                // Associate collection bundle with the source identifier.
+                context.insert_id(Id::Global(*src_id), collection_bundle);
 
                 // Associate returned tokens with the source identifier.
                 let prior = tokens.source_tokens.insert(*src_id, source_token);

--- a/src/dataflow/src/render/sinks.rs
+++ b/src/dataflow/src/render/sinks.rs
@@ -34,7 +34,7 @@ where
     /// Export the sink described by `sink` from the rendering context.
     pub(crate) fn export_sink(
         &mut self,
-        render_state: &mut crate::render::ComputeState,
+        compute_state: &mut crate::render::ComputeState,
         storage_state: &mut crate::render::StorageState,
         tokens: &mut RelevantTokens,
         import_ids: HashSet<GlobalId>,
@@ -68,7 +68,7 @@ where
         // if we figure out a protocol for that.
 
         let sink_token = sink_render.render_continuous_sink(
-            render_state,
+            compute_state,
             storage_state,
             sink,
             sink_id,
@@ -85,7 +85,7 @@ where
             needed_source_tokens,
             needed_additional_tokens,
         ));
-        render_state
+        compute_state
             .dataflow_tokens
             .insert(sink_id, Box::new(tokens));
     }
@@ -214,7 +214,7 @@ where
 
     fn render_continuous_sink(
         &self,
-        render_state: &mut crate::render::ComputeState,
+        compute_state: &mut crate::render::ComputeState,
         storage_state: &mut crate::render::StorageState,
         sink: &SinkDesc,
         sink_id: GlobalId,

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -26,7 +26,7 @@ use persist::operators::upsert::PersistentUpsertConfig;
 
 use dataflow_types::sources::{encoding::*, persistence::*, *};
 use dataflow_types::*;
-use expr::{GlobalId, Id, PartitionId, SourceInstanceId};
+use expr::{GlobalId, PartitionId, SourceInstanceId};
 use ore::now::NowFn;
 use ore::result::ResultExt;
 use repr::{RelationDesc, Row, ScalarType, Timestamp};
@@ -37,7 +37,6 @@ use crate::decode::render_decode_delimited;
 use crate::decode::rewrite_for_upsert;
 use crate::logging::materialized::Logger;
 use crate::operator::{CollectionExt, StreamExt};
-use crate::render::context::Context;
 use crate::server::LocalInput;
 use crate::source::metrics::SourceBaseMetrics;
 use crate::source::timestamp::{AssignedTimestamp, SourceTimestamp};
@@ -58,595 +57,581 @@ enum SourceType<Delimited, ByteStream> {
     ByteStream(ByteStream),
 }
 
-impl<G> Context<G, Row, Timestamp>
+/// Constructs a `CollectionBundle` and tokens from source arguments.
+///
+/// The first return value is the collection bundle, and the second a pair of source and additional
+/// tokens, that are used to control the demolition of the source.
+pub(crate) fn import_source<G>(
+    dataflow_debug_name: &String,
+    dataflow_id: usize,
+    as_of_frontier: &timely::progress::Antichain<repr::Timestamp>,
+    storage_state: &mut crate::render::StorageState,
+    scope: &mut G,
+    materialized_logging: Option<Logger>,
+    src_id: GlobalId,
+    mut src: SourceDesc,
+    // The original ID of the source, before it was decomposed into a bare source (which might
+    // have its own transient ID) and a relational transformation (which has the original source
+    // ID).
+    orig_id: GlobalId,
+    now: NowFn,
+    base_metrics: &SourceBaseMetrics,
+) -> (
+    crate::render::CollectionBundle<G, Row, Timestamp>,
+    (
+        Rc<Option<crate::source::SourceToken>>,
+        Vec<Rc<dyn std::any::Any>>,
+    ),
+)
 where
     G: Scope<Timestamp = Timestamp>,
 {
-    /// Import the source described by `src` into the rendering context.
-    ///
-    /// Returns a "source token" and any "additional tokens" to be associated with `src_id`.
-    pub(crate) fn import_source(
-        &mut self,
-        storage_state: &mut crate::render::StorageState,
-        scope: &mut G,
-        materialized_logging: Option<Logger>,
-        src_id: GlobalId,
-        mut src: SourceDesc,
-        // The original ID of the source, before it was decomposed into a bare source (which might
-        // have its own transient ID) and a relational transformation (which has the original source
-        // ID).
-        orig_id: GlobalId,
-        now: NowFn,
-        base_metrics: &SourceBaseMetrics,
-    ) -> (
-        Rc<Option<crate::source::SourceToken>>,
-        Vec<Rc<dyn std::any::Any>>,
-    ) {
-        // Extract the linear operators, as we will need to manipulate them.
-        // extracting them reduces the change we might accidentally communicate
-        // them through `src`.
-        let mut linear_operators = src.operators.take();
+    // Extract the linear operators, as we will need to manipulate them.
+    // extracting them reduces the change we might accidentally communicate
+    // them through `src`.
+    let mut linear_operators = src.operators.take();
 
-        // Blank out trivial linear operators.
-        if let Some(operator) = &linear_operators {
-            if operator.is_trivial(src.bare_desc.arity()) {
-                linear_operators = None;
-            }
+    // Blank out trivial linear operators.
+    if let Some(operator) = &linear_operators {
+        if operator.is_trivial(src.bare_desc.arity()) {
+            linear_operators = None;
+        }
+    }
+
+    // Tokens that we should return from the method.
+    let mut additional_tokens: Vec<Rc<dyn std::any::Any>> = Vec::new();
+
+    // Before proceeding, we may need to remediate sources with non-trivial relational
+    // expressions that post-process the bare source. If the expression is trivial, a
+    // get of the bare source, we can present `src.operators` to the source directly.
+    // Otherwise, we need to zero out `src.operators` and instead perform that logic
+    // at the end of `src.optimized_expr`.
+    //
+    // This has a lot of potential for improvement in the near future.
+    match src.connector.clone() {
+        // Create a new local input (exposed as TABLEs to users). Data is inserted
+        // via Command::Insert commands.
+        SourceConnector::Local { persisted_name, .. } => {
+            let ((handle, capability), ok_stream, err_collection) = {
+                let ((handle, capability), ok_stream) = scope.new_unordered_input();
+                let err_collection = Collection::empty(scope);
+                ((handle, capability), ok_stream, err_collection)
+            };
+
+            // A local "source" is either fed by a local input handle, or by reading from a
+            // `persisted_source()`.
+            //
+            // For non-persisted sources, values that are to be inserted are sent from the
+            // coordinator and pushed into the handle.
+            //
+            // For persisted sources, the coordinator only writes new values to a persistent
+            // stream. These values will then "show up" here because we read from the same
+            // persistent stream.
+            let (ok_stream, err_collection) = match (&mut storage_state.persist, persisted_name) {
+                (Some(persist), Some(stream_name)) => {
+                    let (_write, read) = persist.create_or_load(&stream_name);
+                    let (persist_ok_stream, persist_err_stream) = scope
+                        .persisted_source(read, &as_of_frontier)
+                        .ok_err(|x| match x {
+                            (Ok(kv), ts, diff) => Ok((kv, ts, diff)),
+                            (Err(err), ts, diff) => Err((err, ts, diff)),
+                        });
+                    let (persist_ok_stream, decode_err_stream) =
+                        persist_ok_stream.ok_err(|((row, ()), ts, diff)| Ok((row, ts, diff)));
+                    let persist_err_collection = persist_err_stream
+                        .concat(&decode_err_stream)
+                        .map(move |(err, ts, diff)| {
+                            let err = SourceError::new(
+                                stream_name.clone(),
+                                SourceErrorDetails::Persistence(err),
+                            );
+                            (err.into(), ts, diff)
+                        })
+                        .as_collection();
+                    (
+                        ok_stream.concat(&persist_ok_stream),
+                        err_collection.concat(&persist_err_collection),
+                    )
+                }
+                _ => (ok_stream, err_collection),
+            };
+
+            storage_state
+                .local_inputs
+                .insert(src_id, LocalInput { handle, capability });
+            let as_of_frontier = as_of_frontier.clone();
+            let ok_collection = ok_stream
+                .map_in_place(move |(_, mut time, _)| {
+                    time.advance_by(as_of_frontier.borrow());
+                })
+                .as_collection();
+
+            let collection_bundle =
+                crate::render::CollectionBundle::from_collections(ok_collection, err_collection);
+
+            // TODO(mcsherry): Local tables are a special non-source we should relocate.
+            (collection_bundle, (Rc::new(None), Vec::new()))
         }
 
-        // Tokens that we should return from the method.
-        let mut additional_tokens: Vec<Rc<dyn std::any::Any>> = Vec::new();
+        SourceConnector::External {
+            connector,
+            encoding,
+            envelope,
+            consistency,
+            ts_frequency,
+            persist,
+            timeline: _,
+        } => {
+            // TODO(benesch): this match arm is hard to follow. Refactor.
 
-        // Before proceeding, we may need to remediate sources with non-trivial relational
-        // expressions that post-process the bare source. If the expression is trivial, a
-        // get of the bare source, we can present `src.operators` to the source directly.
-        // Otherwise, we need to zero out `src.operators` and instead perform that logic
-        // at the end of `src.optimized_expr`.
-        //
-        // This has a lot of potential for improvement in the near future.
-        match src.connector.clone() {
-            // Create a new local input (exposed as TABLEs to users). Data is inserted
-            // via Command::Insert commands.
-            SourceConnector::Local { persisted_name, .. } => {
-                let ((handle, capability), ok_stream, err_collection) = {
-                    let ((handle, capability), ok_stream) = scope.new_unordered_input();
-                    let err_collection = Collection::empty(scope);
-                    ((handle, capability), ok_stream, err_collection)
-                };
+            // This uid must be unique across all different instantiations of a source
+            let uid = SourceInstanceId {
+                source_id: orig_id,
+                dataflow_id,
+            };
 
-                // A local "source" is either fed by a local input handle, or by reading from a
-                // `persisted_source()`.
-                //
-                // For non-persisted sources, values that are to be inserted are sent from the
-                // coordinator and pushed into the handle.
-                //
-                // For persisted sources, the coordinator only writes new values to a persistent
-                // stream. These values will then "show up" here because we read from the same
-                // persistent stream.
-                let (ok_stream, err_collection) = match (&mut storage_state.persist, persisted_name)
-                {
-                    (Some(persist), Some(stream_name)) => {
-                        let (_write, read) = persist.create_or_load(&stream_name);
-                        let (persist_ok_stream, persist_err_stream) = scope
-                            .persisted_source(read, &self.as_of_frontier)
-                            .ok_err(|x| match x {
-                                (Ok(kv), ts, diff) => Ok((kv, ts, diff)),
-                                (Err(err), ts, diff) => Err((err, ts, diff)),
-                            });
-                        let (persist_ok_stream, decode_err_stream) =
-                            persist_ok_stream.ok_err(|((row, ()), ts, diff)| Ok((row, ts, diff)));
-                        let persist_err_collection = persist_err_stream
-                            .concat(&decode_err_stream)
-                            .map(move |(err, ts, diff)| {
-                                let err = SourceError::new(
-                                    stream_name.clone(),
-                                    SourceErrorDetails::Persistence(err),
-                                );
-                                (err.into(), ts, diff)
-                            })
-                            .as_collection();
-                        (
-                            ok_stream.concat(&persist_ok_stream),
-                            err_collection.concat(&persist_err_collection),
-                        )
-                    }
-                    _ => (ok_stream, err_collection),
-                };
+            // All sources should push their various error streams into this vector,
+            // whose contents will be concatenated and inserted along the collection.
+            let mut error_collections = Vec::<Collection<_, _>>::new();
 
-                storage_state
-                    .local_inputs
-                    .insert(src_id, LocalInput { handle, capability });
-                let as_of_frontier = self.as_of_frontier.clone();
-                let ok_collection = ok_stream
-                    .map_in_place(move |(_, mut time, _)| {
-                        time.advance_by(as_of_frontier.borrow());
-                    })
-                    .as_collection();
-                self.insert_id(
-                    Id::Global(src_id),
-                    crate::render::CollectionBundle::from_collections(
-                        ok_collection,
-                        err_collection,
-                    ),
+            let source_persist_config = match (persist, storage_state.persist.as_mut()) {
+                (Some(persist_desc), Some(persist)) => {
+                    Some(get_persist_config(&uid, persist_desc, persist))
+                }
+                _ => None,
+            };
+
+            let fast_forwarded = match &connector {
+                ExternalSourceConnector::Kafka(KafkaSourceConnector { start_offsets, .. }) => {
+                    start_offsets.values().any(|&val| val > 0)
+                }
+                _ => false,
+            };
+
+            // All workers are responsible for reading in Kafka sources. Other sources
+            // support single-threaded ingestion only. Note that in all cases we want all
+            // readers of the same source or same partition to reside on the same worker,
+            // and only load-balance responsibility across distinct sources.
+            let active_read_worker = if let ExternalSourceConnector::Kafka(_) = connector {
+                true
+            } else {
+                // TODO: This feels icky, but getting rid of hardcoding this difference between
+                // Kafka and all other sources seems harder.
+                crate::source::responsible_for(
+                    &src_id,
+                    scope.index(),
+                    scope.peers(),
+                    &PartitionId::None,
+                )
+            };
+
+            let timestamp_histories = storage_state
+                .ts_histories
+                .get(&orig_id)
+                .map(|history| history.clone());
+            let source_name = format!("{}-{}", connector.name(), uid);
+            let source_config = SourceConfig {
+                name: source_name.clone(),
+                sql_name: src.name.clone(),
+                upstream_name: connector.upstream_name().map(ToOwned::to_owned),
+                id: uid,
+                scope,
+                // Distribute read responsibility among workers.
+                active: active_read_worker,
+                timestamp_histories,
+                consistency,
+                timestamp_frequency: ts_frequency,
+                worker_id: scope.index(),
+                worker_count: scope.peers(),
+                logger: materialized_logging,
+                encoding: encoding.clone(),
+                now,
+                base_metrics,
+            };
+
+            let (mut collection, capability) = if let ExternalSourceConnector::PubNub(
+                pubnub_connector,
+            ) = connector
+            {
+                let source = PubNubSourceReader::new(src.name.clone(), pubnub_connector);
+                let ((ok_stream, err_stream), capability) =
+                    source::create_source_simple(source_config, source);
+
+                error_collections.push(
+                    err_stream
+                        .map(DataflowError::SourceError)
+                        .pass_through("source-errors")
+                        .as_collection(),
                 );
 
-                // TODO(mcsherry): Local tables are a special non-source we should relocate.
-                (Rc::new(None), Vec::new())
-            }
+                (ok_stream.as_collection(), capability)
+            } else if let ExternalSourceConnector::Postgres(pg_connector) = connector {
+                let source = PostgresSourceReader::new(
+                    src.name.clone(),
+                    pg_connector,
+                    source_config.base_metrics,
+                );
 
-            SourceConnector::External {
-                connector,
-                encoding,
-                envelope,
-                consistency,
-                ts_frequency,
-                persist,
-                timeline: _,
-            } => {
-                // TODO(benesch): this match arm is hard to follow. Refactor.
+                let ((ok_stream, err_stream), capability) =
+                    source::create_source_simple(source_config, source);
 
-                // This uid must be unique across all different instantiations of a source
-                let uid = SourceInstanceId {
-                    source_id: orig_id,
-                    dataflow_id: self.dataflow_id,
-                };
+                error_collections.push(
+                    err_stream
+                        .map(DataflowError::SourceError)
+                        .pass_through("source-errors")
+                        .as_collection(),
+                );
 
-                // All sources should push their various error streams into this vector,
-                // whose contents will be concatenated and inserted along the collection.
-                let mut error_collections = Vec::<Collection<_, _>>::new();
-
-                let source_persist_config = match (persist, storage_state.persist.as_mut()) {
-                    (Some(persist_desc), Some(persist)) => {
-                        Some(get_persist_config(&uid, persist_desc, persist))
+                (ok_stream.as_collection(), capability)
+            } else {
+                let ((ok_source, ts_bindings, err_source), capability) = match connector {
+                    ExternalSourceConnector::Kafka(_) => {
+                        let ((ok, ts, err), cap) = source::create_source::<_, KafkaSourceReader>(
+                            source_config,
+                            &connector,
+                            source_persist_config
+                                .as_ref()
+                                .map(|config| config.bindings_config.clone()),
+                        );
+                        ((SourceType::Delimited(ok), ts, err), cap)
                     }
-                    _ => None,
+                    ExternalSourceConnector::Kinesis(_) => {
+                        let ((ok, ts, err), cap) = source::create_source::<_, KinesisSourceReader>(
+                            source_config,
+                            &connector,
+                            source_persist_config
+                                .as_ref()
+                                .map(|config| config.bindings_config.clone()),
+                        );
+                        ((SourceType::Delimited(ok), ts, err), cap)
+                    }
+                    ExternalSourceConnector::S3(_) => {
+                        let ((ok, ts, err), cap) = source::create_source::<_, S3SourceReader>(
+                            source_config,
+                            &connector,
+                            source_persist_config
+                                .as_ref()
+                                .map(|config| config.bindings_config.clone()),
+                        );
+                        ((SourceType::ByteStream(ok), ts, err), cap)
+                    }
+                    ExternalSourceConnector::File(_) | ExternalSourceConnector::AvroOcf(_) => {
+                        let ((ok, ts, err), cap) = source::create_source::<_, FileSourceReader>(
+                            source_config,
+                            &connector,
+                            source_persist_config
+                                .as_ref()
+                                .map(|config| config.bindings_config.clone()),
+                        );
+                        ((SourceType::ByteStream(ok), ts, err), cap)
+                    }
+                    ExternalSourceConnector::Postgres(_) => unreachable!(),
+                    ExternalSourceConnector::PubNub(_) => unreachable!(),
                 };
 
-                let fast_forwarded = match &connector {
-                    ExternalSourceConnector::Kafka(KafkaSourceConnector {
-                        start_offsets, ..
-                    }) => start_offsets.values().any(|&val| val > 0),
-                    _ => false,
-                };
+                // Include any source errors.
+                error_collections.push(
+                    err_source
+                        .map(DataflowError::SourceError)
+                        .pass_through("source-errors")
+                        .as_collection(),
+                );
 
-                // All workers are responsible for reading in Kafka sources. Other sources
-                // support single-threaded ingestion only. Note that in all cases we want all
-                // readers of the same source or same partition to reside on the same worker,
-                // and only load-balance responsibility across distinct sources.
-                let active_read_worker = if let ExternalSourceConnector::Kafka(_) = connector {
-                    true
-                } else {
-                    // TODO: This feels icky, but getting rid of hardcoding this difference between
-                    // Kafka and all other sources seems harder.
-                    crate::source::responsible_for(
-                        &src_id,
-                        scope.index(),
-                        scope.peers(),
-                        &PartitionId::None,
-                    )
-                };
-
-                let timestamp_histories = storage_state
-                    .ts_histories
-                    .get(&orig_id)
-                    .map(|history| history.clone());
-                let source_name = format!("{}-{}", connector.name(), uid);
-                let source_config = SourceConfig {
-                    name: source_name.clone(),
-                    sql_name: src.name.clone(),
-                    upstream_name: connector.upstream_name().map(ToOwned::to_owned),
-                    id: uid,
-                    scope,
-                    // Distribute read responsibility among workers.
-                    active: active_read_worker,
-                    timestamp_histories,
-                    consistency,
-                    timestamp_frequency: ts_frequency,
-                    worker_id: scope.index(),
-                    worker_count: scope.peers(),
-                    logger: materialized_logging,
-                    encoding: encoding.clone(),
-                    now,
-                    base_metrics,
-                };
-
-                let (mut collection, capability) = if let ExternalSourceConnector::PubNub(
-                    pubnub_connector,
-                ) = connector
-                {
-                    let source = PubNubSourceReader::new(src.name.clone(), pubnub_connector);
-                    let ((ok_stream, err_stream), capability) =
-                        source::create_source_simple(source_config, source);
-
-                    error_collections.push(
-                        err_stream
-                            .map(DataflowError::SourceError)
-                            .pass_through("source-errors")
-                            .as_collection(),
-                    );
-
-                    (ok_stream.as_collection(), capability)
-                } else if let ExternalSourceConnector::Postgres(pg_connector) = connector {
-                    let source = PostgresSourceReader::new(
-                        src.name.clone(),
-                        pg_connector,
-                        source_config.base_metrics,
-                    );
-
-                    let ((ok_stream, err_stream), capability) =
-                        source::create_source_simple(source_config, source);
-
-                    error_collections.push(
-                        err_stream
-                            .map(DataflowError::SourceError)
-                            .pass_through("source-errors")
-                            .as_collection(),
-                    );
-
-                    (ok_stream.as_collection(), capability)
-                } else {
-                    let ((ok_source, ts_bindings, err_source), capability) = match connector {
-                        ExternalSourceConnector::Kafka(_) => {
-                            let ((ok, ts, err), cap) = source::create_source::<_, KafkaSourceReader>(
-                                source_config,
-                                &connector,
-                                source_persist_config
-                                    .as_ref()
-                                    .map(|config| config.bindings_config.clone()),
-                            );
-                            ((SourceType::Delimited(ok), ts, err), cap)
-                        }
-                        ExternalSourceConnector::Kinesis(_) => {
-                            let ((ok, ts, err), cap) =
-                                source::create_source::<_, KinesisSourceReader>(
-                                    source_config,
-                                    &connector,
-                                    source_persist_config
-                                        .as_ref()
-                                        .map(|config| config.bindings_config.clone()),
-                                );
-                            ((SourceType::Delimited(ok), ts, err), cap)
-                        }
-                        ExternalSourceConnector::S3(_) => {
-                            let ((ok, ts, err), cap) = source::create_source::<_, S3SourceReader>(
-                                source_config,
-                                &connector,
-                                source_persist_config
-                                    .as_ref()
-                                    .map(|config| config.bindings_config.clone()),
-                            );
-                            ((SourceType::ByteStream(ok), ts, err), cap)
-                        }
-                        ExternalSourceConnector::File(_) | ExternalSourceConnector::AvroOcf(_) => {
-                            let ((ok, ts, err), cap) = source::create_source::<_, FileSourceReader>(
-                                source_config,
-                                &connector,
-                                source_persist_config
-                                    .as_ref()
-                                    .map(|config| config.bindings_config.clone()),
-                            );
-                            ((SourceType::ByteStream(ok), ts, err), cap)
-                        }
-                        ExternalSourceConnector::Postgres(_) => unreachable!(),
-                        ExternalSourceConnector::PubNub(_) => unreachable!(),
+                let (stream, errors) = {
+                    let (key_desc, _) = encoding.desc().expect("planning has verified this");
+                    let (key_encoding, value_encoding) = match encoding {
+                        SourceDataEncoding::KeyValue { key, value } => (Some(key), value),
+                        SourceDataEncoding::Single(value) => (None, value),
                     };
 
-                    // Include any source errors.
-                    error_collections.push(
-                        err_source
-                            .map(DataflowError::SourceError)
-                            .pass_through("source-errors")
-                            .as_collection(),
-                    );
+                    // TODO(petrosagg): remove this inconsistency once INCLUDE (offset)
+                    // syntax is implemented
+                    //
+                    // Default metadata is mostly configured in planning, but we need it here for upsert
+                    let default_metadata = provide_default_metadata(&envelope, &value_encoding);
 
-                    let (stream, errors) = {
-                        let (key_desc, _) = encoding.desc().expect("planning has verified this");
-                        let (key_encoding, value_encoding) = match encoding {
-                            SourceDataEncoding::KeyValue { key, value } => (Some(key), value),
-                            SourceDataEncoding::Single(value) => (None, value),
+                    let metadata_columns = connector.metadata_column_types(default_metadata);
+
+                    // CDCv2 can't quite be slotted in to the below code, since it determines
+                    // its own diffs/timestamps as part of decoding.
+                    if let SourceEnvelope::CdcV2 = &envelope {
+                        let AvroEncoding {
+                            schema,
+                            schema_registry_config,
+                            confluent_wire_format,
+                        } = match value_encoding {
+                            DataEncoding::Avro(enc) => enc,
+                            _ => unreachable!("Attempted to create non-Avro CDCv2 source"),
                         };
+                        let ok_source = match ok_source {
+                            SourceType::Delimited(s) => s,
+                            _ => unreachable!("Attempted to create non-delimited CDCv2 source"),
+                        };
+                        // TODO(petrosagg): this should move to the envelope section below and
+                        // made to work with a stream of Rows instead of decoding Avro directly
+                        let (oks, token) = decode_cdcv2(
+                            &ok_source,
+                            &schema,
+                            schema_registry_config,
+                            confluent_wire_format,
+                        );
+                        additional_tokens.push(Rc::new(token));
+                        (oks, None)
+                    } else {
+                        let (results, extra_token) = match ok_source {
+                            SourceType::Delimited(source) => render_decode_delimited(
+                                &source,
+                                key_encoding,
+                                value_encoding,
+                                dataflow_debug_name,
+                                &envelope,
+                                metadata_columns,
+                                &mut linear_operators,
+                                fast_forwarded,
+                                storage_state.metrics.clone(),
+                            ),
+                            SourceType::ByteStream(source) => render_decode(
+                                &source,
+                                value_encoding,
+                                dataflow_debug_name,
+                                &envelope,
+                                metadata_columns,
+                                &mut linear_operators,
+                                fast_forwarded,
+                                storage_state.metrics.clone(),
+                            ),
+                        };
+                        if let Some(tok) = extra_token {
+                            additional_tokens.push(Rc::new(tok));
+                        }
 
-                        // TODO(petrosagg): remove this inconsistency once INCLUDE (offset)
-                        // syntax is implemented
-                        //
-                        // Default metadata is mostly configured in planning, but we need it here for upsert
-                        let default_metadata = provide_default_metadata(&envelope, &value_encoding);
-
-                        let metadata_columns = connector.metadata_column_types(default_metadata);
-
-                        // CDCv2 can't quite be slotted in to the below code, since it determines
-                        // its own diffs/timestamps as part of decoding.
-                        if let SourceEnvelope::CdcV2 = &envelope {
-                            let AvroEncoding {
-                                schema,
-                                schema_registry_config,
-                                confluent_wire_format,
-                            } = match value_encoding {
-                                DataEncoding::Avro(enc) => enc,
-                                _ => unreachable!("Attempted to create non-Avro CDCv2 source"),
-                            };
-                            let ok_source = match ok_source {
-                                SourceType::Delimited(s) => s,
-                                _ => unreachable!("Attempted to create non-delimited CDCv2 source"),
-                            };
-                            // TODO(petrosagg): this should move to the envelope section below and
-                            // made to work with a stream of Rows instead of decoding Avro directly
-                            let (oks, token) = decode_cdcv2(
-                                &ok_source,
-                                &schema,
-                                schema_registry_config,
-                                confluent_wire_format,
-                            );
-                            additional_tokens.push(Rc::new(token));
-                            (oks, None)
-                        } else {
-                            let (results, extra_token) = match ok_source {
-                                SourceType::Delimited(source) => render_decode_delimited(
-                                    &source,
-                                    key_encoding,
-                                    value_encoding,
-                                    &self.debug_name,
-                                    &envelope,
-                                    metadata_columns,
-                                    &mut linear_operators,
-                                    fast_forwarded,
-                                    storage_state.metrics.clone(),
-                                ),
-                                SourceType::ByteStream(source) => render_decode(
-                                    &source,
-                                    value_encoding,
-                                    &self.debug_name,
-                                    &envelope,
-                                    metadata_columns,
-                                    &mut linear_operators,
-                                    fast_forwarded,
-                                    storage_state.metrics.clone(),
-                                ),
-                            };
-                            if let Some(tok) = extra_token {
-                                additional_tokens.push(Rc::new(tok));
-                            }
-
-                            // render envelopes
-                            match &envelope {
-                                SourceEnvelope::Debezium(dedupe_strategy, mode) => {
-                                    // TODO: this needs to happen separately from trackstate
-                                    let results = match mode {
-                                        DebeziumMode::Upsert => {
-                                            let mut trackstate = (
-                                                HashMap::new(),
-                                                storage_state.metrics.debezium_upsert_count_for(
-                                                    src_id,
-                                                    self.dataflow_id,
+                        // render envelopes
+                        match &envelope {
+                            SourceEnvelope::Debezium(dedupe_strategy, mode) => {
+                                // TODO: this needs to happen separately from trackstate
+                                let results = match mode {
+                                    DebeziumMode::Upsert => {
+                                        let mut trackstate = (
+                                            HashMap::new(),
+                                            storage_state
+                                                .metrics
+                                                .debezium_upsert_count_for(src_id, dataflow_id),
+                                        );
+                                        results.flat_map(move |data| {
+                                            let DecodeResult {
+                                                key,
+                                                value,
+                                                metadata,
+                                                position: _,
+                                            } = data;
+                                            let (keys, metrics) = &mut trackstate;
+                                            value.map(|value| match key {
+                                                None => Err(DecodeError::Text(
+                                                    "All upsert keys should decode to a value."
+                                                        .into(),
+                                                )),
+                                                Some(Err(e)) => Err(e),
+                                                Some(Ok(key)) => rewrite_for_upsert(
+                                                    value, metadata, keys, key, metrics,
                                                 ),
-                                            );
-                                            results.flat_map(move |data| {
-                                                let DecodeResult {
-                                                    key,
-                                                    value,
-                                                    metadata,
-                                                    position: _,
-                                                } = data;
-                                                let (keys, metrics) = &mut trackstate;
-                                                value.map(|value| match key {
-                                                    None => Err(DecodeError::Text(
-                                                        "All upsert keys should decode to a value."
-                                                            .into(),
-                                                    )),
-                                                    Some(Err(e)) => Err(e),
-                                                    Some(Ok(key)) => rewrite_for_upsert(
-                                                        value, metadata, keys, key, metrics,
-                                                    ),
-                                                })
                                             })
-                                        }
-                                        DebeziumMode::Plain => results.flat_map(|data| {
-                                            data.value.map(|res| {
-                                                res.map(|mut val| {
-                                                    val.extend(data.metadata.into_iter());
-                                                    val
-                                                })
+                                        })
+                                    }
+                                    DebeziumMode::Plain => results.flat_map(|data| {
+                                        data.value.map(|res| {
+                                            res.map(|mut val| {
+                                                val.extend(data.metadata.into_iter());
+                                                val
                                             })
-                                        }),
-                                    };
+                                        })
+                                    }),
+                                };
 
-                                    let (stream, errors) = results.ok_err(ResultExt::err_into);
-                                    let stream = stream.pass_through("decode-ok").as_collection();
-                                    let errors =
-                                        errors.pass_through("decode-errors").as_collection();
+                                let (stream, errors) = results.ok_err(ResultExt::err_into);
+                                let stream = stream.pass_through("decode-ok").as_collection();
+                                let errors = errors.pass_through("decode-errors").as_collection();
 
-                                    let dbz_key_indices = if let Some(key_desc) = key_desc {
-                                        let fields = match &src.bare_desc.typ().column_types[0]
-                                            .scalar_type
-                                        {
+                                let dbz_key_indices = if let Some(key_desc) = key_desc {
+                                    let fields =
+                                        match &src.bare_desc.typ().column_types[0].scalar_type {
                                             ScalarType::Record { fields, .. } => fields.clone(),
                                             _ => unreachable!(),
                                         };
-                                        let row_desc = RelationDesc::from_names_and_types(fields);
-                                        // these must be available because the DDL parsing logic already
-                                        // checks this and bails in case the key is not correct
-                                        Some(dataflow_types::sources::match_key_indices(&key_desc, &row_desc).expect("Invalid key schema, this indicates a bug in Materialize"))
-                                    } else {
-                                        None
-                                    };
+                                    let row_desc = RelationDesc::from_names_and_types(fields);
+                                    // these must be available because the DDL parsing logic already
+                                    // checks this and bails in case the key is not correct
+                                    Some(dataflow_types::sources::match_key_indices(&key_desc, &row_desc).expect("Invalid key schema, this indicates a bug in Materialize"))
+                                } else {
+                                    None
+                                };
 
-                                    let stream = dedupe_strategy.clone().render(
-                                        stream,
-                                        self.debug_name.to_string(),
-                                        scope.index(),
-                                        // Debezium decoding has produced two extra fields, with the
-                                        // dedupe information and the upstream time in millis
-                                        src.bare_desc.arity() + 2,
-                                        dbz_key_indices,
-                                    );
+                                let stream = dedupe_strategy.clone().render(
+                                    stream,
+                                    dataflow_debug_name.to_string(),
+                                    scope.index(),
+                                    // Debezium decoding has produced two extra fields, with the
+                                    // dedupe information and the upstream time in millis
+                                    src.bare_desc.arity() + 2,
+                                    dbz_key_indices,
+                                );
 
-                                    (stream, Some(errors))
-                                }
-                                SourceEnvelope::Upsert(_key_envelope) => {
-                                    // TODO: use the key envelope to figure out when to add keys.
-                                    // The opeator currently does it unconditionally
-                                    let upsert_operator_name = format!("{}-upsert", source_name);
-
-                                    let key_arity = key_desc.expect("SourceEnvelope::Upsert to require SourceDataEncoding::KeyValue").arity();
-
-                                    let (upsert_ok, upsert_err) = super::upsert::upsert(
-                                        &upsert_operator_name,
-                                        &results,
-                                        self.as_of_frontier.clone(),
-                                        &mut linear_operators,
-                                        key_arity,
-                                        src.bare_desc.typ().arity(),
-                                        source_persist_config
-                                            .as_ref()
-                                            .map(|config| config.upsert_config.clone()),
-                                    );
-
-                                    // When persistence is enabled we need to seal up both the
-                                    // timestamp bindings and the upsert state. Otherwise, just
-                                    // pass through.
-                                    let (upsert_ok, upsert_err) = if let Some(
-                                        source_persist_config,
-                                    ) = source_persist_config
-                                    {
-                                        let sealed_upsert = upsert_ok.conditional_seal(
-                                            &source_name,
-                                            &ts_bindings,
-                                            source_persist_config.upsert_config.write_handle,
-                                            source_persist_config.bindings_config.write_handle,
-                                        );
-
-                                        // Don't send data forward to "dataflow" until the frontier
-                                        // tells us that we both persisted and sealed it.
-                                        //
-                                        // This is the most pessimistic style of concurrency
-                                        // control, an alternatie would be to not hold data but
-                                        // only hold the frontier (which is what the persist/seal
-                                        // operators do).
-                                        let sealed_upsert =
-                                            sealed_upsert.await_frontier(&source_name);
-
-                                        (sealed_upsert, upsert_err)
-                                    } else {
-                                        (upsert_ok, upsert_err)
-                                    };
-
-                                    (upsert_ok.as_collection(), Some(upsert_err.as_collection()))
-                                }
-                                SourceEnvelope::None(key_envelope) => {
-                                    let results = append_metadata_to_value(results);
-
-                                    let (stream, errors) =
-                                        flatten_results_prepend_keys(key_envelope, results)
-                                            .ok_err(ResultExt::err_into);
-                                    let stream = stream.pass_through("decode-ok").as_collection();
-                                    let errors =
-                                        errors.pass_through("decode-errors").as_collection();
-                                    (stream, Some(errors))
-                                }
-                                SourceEnvelope::CdcV2 => unreachable!(),
+                                (stream, Some(errors))
                             }
+                            SourceEnvelope::Upsert(_key_envelope) => {
+                                // TODO: use the key envelope to figure out when to add keys.
+                                // The opeator currently does it unconditionally
+                                let upsert_operator_name = format!("{}-upsert", source_name);
+
+                                let key_arity = key_desc.expect("SourceEnvelope::Upsert to require SourceDataEncoding::KeyValue").arity();
+
+                                let (upsert_ok, upsert_err) = super::upsert::upsert(
+                                    &upsert_operator_name,
+                                    &results,
+                                    as_of_frontier.clone(),
+                                    &mut linear_operators,
+                                    key_arity,
+                                    src.bare_desc.typ().arity(),
+                                    source_persist_config
+                                        .as_ref()
+                                        .map(|config| config.upsert_config.clone()),
+                                );
+
+                                // When persistence is enabled we need to seal up both the
+                                // timestamp bindings and the upsert state. Otherwise, just
+                                // pass through.
+                                let (upsert_ok, upsert_err) = if let Some(source_persist_config) =
+                                    source_persist_config
+                                {
+                                    let sealed_upsert = upsert_ok.conditional_seal(
+                                        &source_name,
+                                        &ts_bindings,
+                                        source_persist_config.upsert_config.write_handle,
+                                        source_persist_config.bindings_config.write_handle,
+                                    );
+
+                                    // Don't send data forward to "dataflow" until the frontier
+                                    // tells us that we both persisted and sealed it.
+                                    //
+                                    // This is the most pessimistic style of concurrency
+                                    // control, an alternatie would be to not hold data but
+                                    // only hold the frontier (which is what the persist/seal
+                                    // operators do).
+                                    let sealed_upsert = sealed_upsert.await_frontier(&source_name);
+
+                                    (sealed_upsert, upsert_err)
+                                } else {
+                                    (upsert_ok, upsert_err)
+                                };
+
+                                (upsert_ok.as_collection(), Some(upsert_err.as_collection()))
+                            }
+                            SourceEnvelope::None(key_envelope) => {
+                                let results = append_metadata_to_value(results);
+
+                                let (stream, errors) =
+                                    flatten_results_prepend_keys(key_envelope, results)
+                                        .ok_err(ResultExt::err_into);
+                                let stream = stream.pass_through("decode-ok").as_collection();
+                                let errors = errors.pass_through("decode-errors").as_collection();
+                                (stream, Some(errors))
+                            }
+                            SourceEnvelope::CdcV2 => unreachable!(),
                         }
-                    };
-
-                    if let Some(errors) = errors {
-                        error_collections.push(errors);
                     }
-
-                    (stream, capability)
                 };
 
-                // Force a shuffling of data in case sources are not uniformly distributed.
-                use timely::dataflow::operators::Exchange;
-                collection = collection.inner.exchange(|x| x.hashed()).as_collection();
-
-                // Implement source filtering and projection.
-                // At the moment this is strictly optional, but we perform it anyhow
-                // to demonstrate the intended use.
-                if let Some(operators) = linear_operators {
-                    // Apply predicates and insert dummy values into undemanded columns.
-                    let (collection2, errors) =
-                        collection
-                            .inner
-                            .flat_map_fallible("SourceLinearOperators", {
-                                // Produce an executable plan reflecting the linear operators.
-                                let source_type = src.bare_desc.typ();
-                                let linear_op_mfp =
-                                    crate::render::plan::linear_to_mfp(operators, source_type)
-                                        .into_plan()
-                                        .unwrap_or_else(|e| panic!("{}", e));
-                                // Reusable allocation for unpacking datums.
-                                let mut datum_vec = repr::DatumVec::new();
-                                let mut row_builder = Row::default();
-                                // Closure that applies the linear operators to each `input_row`.
-                                move |(input_row, time, diff)| {
-                                    let arena = repr::RowArena::new();
-                                    let mut datums_local = datum_vec.borrow_with(&input_row);
-                                    linear_op_mfp.evaluate(
-                                        &mut datums_local,
-                                        &arena,
-                                        time,
-                                        diff,
-                                        &mut row_builder,
-                                    )
-                                }
-                            });
-
-                    collection = collection2.as_collection();
-                    error_collections.push(errors.as_collection());
-                };
-
-                // Flatten the error collections.
-                let mut err_collection = match error_collections.len() {
-                    0 => Collection::empty(scope),
-                    1 => error_collections.pop().unwrap(),
-                    _ => collection::concatenate(scope, error_collections),
-                };
-
-                // Apply `as_of` to each timestamp.
-                match &envelope {
-                    SourceEnvelope::Upsert(_) => {}
-                    _ => {
-                        let as_of_frontier1 = self.as_of_frontier.clone();
-                        collection = collection
-                            .inner
-                            .map_in_place(move |(_, time, _)| {
-                                time.advance_by(as_of_frontier1.borrow())
-                            })
-                            .as_collection();
-
-                        let as_of_frontier2 = self.as_of_frontier.clone();
-                        err_collection = err_collection
-                            .inner
-                            .map_in_place(move |(_, time, _)| {
-                                time.advance_by(as_of_frontier2.borrow())
-                            })
-                            .as_collection();
-                    }
+                if let Some(errors) = errors {
+                    error_collections.push(errors);
                 }
 
-                // Consolidate the results, as there may now be cancellations.
-                use differential_dataflow::operators::consolidate::ConsolidateStream;
-                collection = collection.consolidate_stream();
+                (stream, capability)
+            };
 
-                // Introduce the stream by name, as an unarranged collection.
-                self.insert_id(
-                    Id::Global(src_id),
-                    crate::render::CollectionBundle::from_collections(collection, err_collection),
-                );
+            // Force a shuffling of data in case sources are not uniformly distributed.
+            use timely::dataflow::operators::Exchange;
+            collection = collection.inner.exchange(|x| x.hashed()).as_collection();
 
-                let source_token = Rc::new(capability);
+            // Implement source filtering and projection.
+            // At the moment this is strictly optional, but we perform it anyhow
+            // to demonstrate the intended use.
+            if let Some(operators) = linear_operators {
+                // Apply predicates and insert dummy values into undemanded columns.
+                let (collection2, errors) =
+                    collection
+                        .inner
+                        .flat_map_fallible("SourceLinearOperators", {
+                            // Produce an executable plan reflecting the linear operators.
+                            let source_type = src.bare_desc.typ();
+                            let linear_op_mfp =
+                                crate::render::plan::linear_to_mfp(operators, source_type)
+                                    .into_plan()
+                                    .unwrap_or_else(|e| panic!("{}", e));
+                            // Reusable allocation for unpacking datums.
+                            let mut datum_vec = repr::DatumVec::new();
+                            let mut row_builder = Row::default();
+                            // Closure that applies the linear operators to each `input_row`.
+                            move |(input_row, time, diff)| {
+                                let arena = repr::RowArena::new();
+                                let mut datums_local = datum_vec.borrow_with(&input_row);
+                                linear_op_mfp.evaluate(
+                                    &mut datums_local,
+                                    &arena,
+                                    time,
+                                    diff,
+                                    &mut row_builder,
+                                )
+                            }
+                        });
 
-                // We also need to keep track of this mapping globally to activate sources
-                // on timestamp advancement queries
-                storage_state
-                    .ts_source_mapping
-                    .entry(orig_id)
-                    .or_insert_with(Vec::new)
-                    .push(Rc::downgrade(&source_token));
+                collection = collection2.as_collection();
+                error_collections.push(errors.as_collection());
+            };
 
-                // Return the source token for capability manipulation, and any additional tokens.
-                (source_token, additional_tokens)
+            // Flatten the error collections.
+            let mut err_collection = match error_collections.len() {
+                0 => Collection::empty(scope),
+                1 => error_collections.pop().unwrap(),
+                _ => collection::concatenate(scope, error_collections),
+            };
+
+            // Apply `as_of` to each timestamp.
+            match &envelope {
+                SourceEnvelope::Upsert(_) => {}
+                _ => {
+                    let as_of_frontier1 = as_of_frontier.clone();
+                    collection = collection
+                        .inner
+                        .map_in_place(move |(_, time, _)| time.advance_by(as_of_frontier1.borrow()))
+                        .as_collection();
+
+                    let as_of_frontier2 = as_of_frontier.clone();
+                    err_collection = err_collection
+                        .inner
+                        .map_in_place(move |(_, time, _)| time.advance_by(as_of_frontier2.borrow()))
+                        .as_collection();
+                }
             }
+
+            // Consolidate the results, as there may now be cancellations.
+            use differential_dataflow::operators::consolidate::ConsolidateStream;
+            collection = collection.consolidate_stream();
+
+            // Introduce the stream by name, as an unarranged collection.
+            let collection_bundle =
+                crate::render::CollectionBundle::from_collections(collection, err_collection);
+
+            let source_token = Rc::new(capability);
+
+            // We also need to keep track of this mapping globally to activate sources
+            // on timestamp advancement queries
+            storage_state
+                .ts_source_mapping
+                .entry(orig_id)
+                .or_insert_with(Vec::new)
+                .push(Rc::downgrade(&source_token));
+
+            // Return the source token for capability manipulation, and any additional tokens.
+            (collection_bundle, (source_token, additional_tokens))
         }
     }
 }

--- a/src/dataflow/src/sink/avro_ocf.rs
+++ b/src/dataflow/src/sink/avro_ocf.rs
@@ -45,7 +45,7 @@ where
 
     fn render_continuous_sink(
         &self,
-        _render_state: &mut crate::render::ComputeState,
+        _compute_state: &mut crate::render::ComputeState,
         _storage_state: &mut crate::render::StorageState,
         _sink: &SinkDesc,
         sink_id: GlobalId,

--- a/src/dataflow/src/sink/avro_ocf.rs
+++ b/src/dataflow/src/sink/avro_ocf.rs
@@ -24,7 +24,6 @@ use interchange::avro::{encode_datums_as_avro, AvroSchemaGenerator};
 use repr::{Diff, RelationDesc, Row, Timestamp};
 
 use crate::render::sinks::SinkRender;
-use crate::render::RenderState;
 
 use super::SinkBaseMetrics;
 
@@ -46,7 +45,8 @@ where
 
     fn render_continuous_sink(
         &self,
-        _render_state: &mut RenderState,
+        _render_state: &mut crate::render::ComputeState,
+        _storage_state: &mut crate::render::StorageState,
         _sink: &SinkDesc,
         sink_id: GlobalId,
         sinked_collection: Collection<G, (Option<Row>, Option<Row>), Diff>,

--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -75,7 +75,7 @@ where
 
     fn render_continuous_sink(
         &self,
-        _render_state: &mut crate::render::ComputeState,
+        _compute_state: &mut crate::render::ComputeState,
         storage_state: &mut crate::render::StorageState,
         sink: &SinkDesc,
         sink_id: GlobalId,

--- a/src/dataflow/src/sink/tail.rs
+++ b/src/dataflow/src/sink/tail.rs
@@ -33,7 +33,6 @@ use expr::GlobalId;
 use repr::{Diff, Row, Timestamp};
 
 use crate::render::sinks::SinkRender;
-use crate::render::RenderState;
 
 use super::SinkBaseMetrics;
 
@@ -55,7 +54,8 @@ where
 
     fn render_continuous_sink(
         &self,
-        render_state: &mut RenderState,
+        render_state: &mut crate::render::ComputeState,
+        _storage_state: &mut crate::render::StorageState,
         sink: &SinkDesc,
         sink_id: GlobalId,
         sinked_collection: Collection<G, (Option<Row>, Option<Row>), Diff>,

--- a/src/dataflow/src/sink/tail.rs
+++ b/src/dataflow/src/sink/tail.rs
@@ -54,7 +54,7 @@ where
 
     fn render_continuous_sink(
         &self,
-        render_state: &mut crate::render::ComputeState,
+        compute_state: &mut crate::render::ComputeState,
         _storage_state: &mut crate::render::StorageState,
         sink: &SinkDesc,
         sink_id: GlobalId,
@@ -75,7 +75,7 @@ where
         let tail_protocol_handle = Rc::new(RefCell::new(if active_worker {
             Some(TailProtocol {
                 sink_id,
-                tail_response_buffer: Some(render_state.tail_response_buffer.clone()),
+                tail_response_buffer: Some(compute_state.tail_response_buffer.clone()),
             })
         } else {
             None


### PR DESCRIPTION
This is a sequence of changes with the goal of making `import_source` more transparent about the arguments it requires and the results it returns. A specific goal is to remove as many `&mut` arguments as possible, with the likely exception of the timely dataflow scope that can only be directly manipulated. Instead, the method should return the changes it wants to make, to remove e.g. "the whole of `RenderState`" from the API.

The PR introduce `StorageState` meant to represent state that STORAGE would otherwise own, except that it does not have its own durable handle to state yet. `RenderState` is essentially partitioned into `ComputeState` and `StorageState`, with the goal of handing references to the latter to storage methods, and the former to compute methods.