### PR TITLE
refuse unused WITH options in CONFLUENT SCHEMA REGISTRY

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -114,6 +114,10 @@ changes that have not yet been documented.
   is an [experimental mode] function that provides a primitive to express what
   other systems refer to as "hopping windows."
 
+- **Breaking change.** `CONFLUENT SCHEMA REGISTRY` sections
+  of `CREATE SOURCE` and `CREATE SINK` now reject unknown parameters.
+  (Example: [Confluent Schema Registry options](/sql/create-source/avro-kafka#confluent-schema-registry-options)).
+
 {{< comment >}}
 Only add new release notes above this line.
 
@@ -167,10 +171,6 @@ boundary don't silently merge their release notes into the wrong place.
   `SELECT * FROM (SELECT)` {{% gh 8723 %}}.
 
 {{% version-header v0.17.0 %}}
-
-- **Breaking change.** `CONFLUENT SCHEMA REGISTRY` sections
-  of `CREATE SOURCE` and `CREATE SINK` now reject unknown parameters.
-  (Example: [Confluent Schema Registry options](/sql/create-source/avro-kafka#confluent-schema-registry-options)).
 
 - **Breaking change.** Improve consistency with PostgreSQL's column name
   inference rules:

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -168,6 +168,10 @@ boundary don't silently merge their release notes into the wrong place.
 
 {{% version-header v0.17.0 %}}
 
+- **Breaking change.** `CONFLUENT SCHEMA REGISTRY` sections
+  of `CREATE SOURCE` and `CREATE SINK` now reject unknown parameters.
+  (Example: [Confluent Schema Registry options](/sql/create-source/avro-kafka#confluent-schema-registry-options)).
+
 - **Breaking change.** Improve consistency with PostgreSQL's column name
   inference rules:
 

--- a/src/sql/src/kafka_util.rs
+++ b/src/sql/src/kafka_util.rs
@@ -519,7 +519,12 @@ pub fn generate_ccsr_client_config(
 
     let mut ccsr_options = extract(
         ccsr_options,
-        &[Config::string("username"), Config::string("password")],
+        &[
+            Config::string("username"),
+            Config::string("password"),
+            // An old migration added this field in some avro cases, so we remove it here
+            Config::new("confluent_wire_format", ValType::Boolean),
+        ],
     )?;
     if let Some(username) = ccsr_options.remove("username") {
         client_config = client_config.auth(username, ccsr_options.remove("password"));

--- a/src/sql/src/kafka_util.rs
+++ b/src/sql/src/kafka_util.rs
@@ -520,9 +520,10 @@ pub fn generate_ccsr_client_config(
     let mut ccsr_options = extract(
         ccsr_options,
         &[
-            Config::string("username"),
-            Config::string("password"),
-            // An old migration added this field in some avro cases, so we remove it here
+            // An old migration
+            // (https://github.com/MaterializeInc/materialize/blob/c402917b7078a14bc0d0d6330b9c9b177aa73e47/src/coord/src/catalog/migrate.rs#L362)
+            // adds this field to kafka-avro WITH options, though now in the CSR case,
+            // the field is unread and fixed to `true`
             Config::new("confluent_wire_format", ValType::Boolean),
         ],
     )?;

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -414,8 +414,8 @@ macro_rules! with_option_type {
 
 /// Ensures that the given set of options are empty, useful for validating that
 /// `WITH` options are all real, used options
-pub(crate) fn ensure_empty_options(
-    with_options: &BTreeMap<String, Value>,
+pub(crate) fn ensure_empty_options<V>(
+    with_options: &BTreeMap<String, V>,
     r#for: &str,
 ) -> Result<(), anyhow::Error> {
     if !with_options.is_empty() {

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -17,6 +17,7 @@
 use std::collections::BTreeMap;
 
 use anyhow::{anyhow, bail, Context};
+use itertools::Itertools;
 
 use dataflow_types::sources::{AwsConfig, AwsCredentials, SerdeUri};
 use repr::ColumnName;
@@ -409,6 +410,22 @@ macro_rules! with_option_type {
             _ => ::anyhow::bail!("expected Interval"),
         }
     };
+}
+
+/// Ensures that the given set of options are empty, useful for validating that
+/// `WITH` options are all real, used options
+pub(crate) fn ensure_empty_options(
+    with_options: &BTreeMap<String, Value>,
+    r#for: &str,
+) -> Result<(), anyhow::Error> {
+    if !with_options.is_empty() {
+        bail!(
+            "unexpected parameters for {}: {}",
+            r#for,
+            with_options.keys().join(",")
+        )
+    }
+    Ok(())
 }
 
 /// This macro accepts a struct definition and will generate it and a `try_from`

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -416,12 +416,12 @@ macro_rules! with_option_type {
 /// `WITH` options are all real, used options
 pub(crate) fn ensure_empty_options<V>(
     with_options: &BTreeMap<String, V>,
-    r#for: &str,
+    context: &str,
 ) -> Result<(), anyhow::Error> {
     if !with_options.is_empty() {
         bail!(
             "unexpected parameters for {}: {}",
-            r#for,
+            context,
             with_options.keys().join(",")
         )
     }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1002,12 +1002,7 @@ pub fn plan_create_source(
         column_names,
     };
 
-    if !with_options.is_empty() {
-        bail!(
-            "unexpected parameters for CREATE SOURCE: {}",
-            with_options.keys().join(",")
-        )
-    }
+    normalize::ensure_empty_options(&with_options, "CREATE SOURCE")?;
 
     Ok(Plan::CreateSource(CreateSourcePlan {
         name,
@@ -1900,12 +1895,7 @@ pub fn plan_create_sink(
         }
     };
 
-    if !with_options.is_empty() {
-        bail!(
-            "unexpected parameters for CREATE SINK: {}",
-            with_options.keys().join(",")
-        )
-    }
+    normalize::ensure_empty_options(&with_options, "CREATE SINK")?;
 
     Ok(Plan::CreateSink(CreateSinkPlan {
         name,
@@ -2180,12 +2170,7 @@ pub fn plan_create_type(
         ids.push(item_id);
     }
 
-    if !with_options.is_empty() {
-        bail!(
-            "unexpected parameters for CREATE TYPE: {}",
-            with_options.keys().join(",")
-        )
-    }
+    normalize::ensure_empty_options(&with_options, "CREATE TYPE")?;
 
     let name = scx.allocate_name(normalize::unresolved_object_name(name)?);
     if scx.catalog.item_exists(&name) {

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -550,7 +550,7 @@ async fn purify_csr_connector_proto(
             let ccsr_config = kafka_util::generate_ccsr_client_config(
                 url,
                 &kafka_options,
-                normalize::options(&ccsr_options),
+                &mut normalize::options(&ccsr_options),
             )?;
 
             let value =
@@ -601,7 +601,7 @@ async fn purify_csr_connector_avro(
             kafka_util::generate_ccsr_client_config(
                 url,
                 &connector_options,
-                normalize::options(ccsr_options),
+                &mut normalize::options(ccsr_options),
             )
         })?;
 

--- a/test/kafka-ssl/multi.td
+++ b/test/kafka-ssl/multi.td
@@ -44,7 +44,6 @@ $ kafka-ingest format=avro topic=data schema=${schema} publish=true timestamp=1
   )
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   WITH (
-      security_protocol = 'SSL',
       ssl_key_location = '/share/secrets/materialized-sr.key',
       ssl_certificate_location = '/share/secrets/materialized-sr.crt',
       ssl_ca_location = '/share/secrets/ca.crt'

--- a/test/testdrive/ccsr-extra-options.td
+++ b/test/testdrive/ccsr-extra-options.td
@@ -1,0 +1,49 @@
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set schema={
+    "type": "record",
+    "name": "envelope",
+    "fields": [
+    ]
+  }
+$ set key-schema={
+    "type": "record",
+    "name": "row",
+    "fields": [
+    ]
+  }
+
+$ kafka-create-topic topic=input
+
+$ kafka-ingest format=avro key-format=avro topic=input schema=${schema} key-schema=${key-schema} publish=true
+{}
+
+> CREATE MATERIALIZED SOURCE input
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE UPSERT
+
+! CREATE SINK output FROM input
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output1-view-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  WITH (
+    gus = "gus"
+  )
+unexpected parameters for CONFLUENT SCHEMA REGISTRY: gus
+
+! CREATE MATERIALIZED SOURCE input_bad
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  WITH (
+    gus = "gus"
+  )
+  ENVELOPE UPSERT
+unexpected parameters for CONFLUENT SCHEMA REGISTRY: gus

--- a/test/testdrive/ccsr-extra-options.td
+++ b/test/testdrive/ccsr-extra-options.td
@@ -37,7 +37,7 @@ $ kafka-ingest format=avro key-format=avro topic=input schema=${schema} key-sche
   WITH (
     gus = "gus"
   )
-unexpected parameters for CONFLUENT SCHEMA REGISTRY: gus
+exact:unexpected parameters for CONFLUENT SCHEMA REGISTRY: gus
 
 ! CREATE MATERIALIZED SOURCE input_bad
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-${testdrive.seed}'
@@ -46,4 +46,4 @@ unexpected parameters for CONFLUENT SCHEMA REGISTRY: gus
     gus = "gus"
   )
   ENVELOPE UPSERT
-unexpected parameters for CONFLUENT SCHEMA REGISTRY: gus
+exact:unexpected parameters for CONFLUENT SCHEMA REGISTRY: gus

--- a/test/testdrive/types.td
+++ b/test/testdrive/types.td
@@ -305,3 +305,7 @@ false
 pg_type_is_visible
 --------------------
 true
+
+# Ensure we don't allow unknown options
+! CREATE TYPE whatever AS LIST (element_type=int4, gus=int4);
+unexpected parameters for CREATE TYPE: gus

--- a/test/testdrive/types.td
+++ b/test/testdrive/types.td
@@ -308,4 +308,4 @@ true
 
 # Ensure we don't allow unknown options
 ! CREATE TYPE whatever AS LIST (element_type=int4, gus=int4);
-unexpected parameters for CREATE TYPE: gus
+exact:unexpected parameters for CREATE TYPE: gus


### PR DESCRIPTION
Currently, if a `CONFLUENT SCHEMA REGISTRY` `WITH` option is unused, nothing happens. This leads to more complex migrations, and does not match the behavior of kafka options.

This diff validates that only accepted options are accepted, and errors otherwise. It uses a similar technique as the kafka options, passing `&mut` out parameters and removing options instead of `get`'ing them

the `generate_ccsr_client_config` function is used in a couple places, but we only validate no unused options in `plan_create_source` and `plan_create_sink`, to match how kafka option validation works, which is why validation happens outside that function

I am not sure where and how `confluent_wire_format` comes from, so where to strip that is not clear to me

### Motivation

  * This PR adds a known-desirable feature: https://github.com/MaterializeInc/materialize/issues/10018

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
