### PR TITLE
Support regexes in testdrive

### DIFF
--- a/doc/developer/testdrive.md
+++ b/doc/developer/testdrive.md
@@ -328,12 +328,39 @@ The syntax is identical, however the statement will not be retried on error:
 
 ```
 ! SELECT * FROM no_such_table
-unknown catalog item
+contains:unknown catalog item
 ```
 
 The expected error string is provided after the statement and `testdrive` will retry the statement until the expected error is returned or a timeout occurs.
 
-Note that you can provide a string that is a substring of the expected error. The full error above would have been `ERROR:  unknown catalog item 'no_such_table'` but the substring `unknown catalog item` will match and the test will pass. This allows for any variable portions of the error message to be omitted from the test file.
+The full error above would have been `ERROR:  unknown catalog item 'no_such_table'` but the match specifier `contains` ensures that the substring `unknown catalog item` will match and the test will pass.
+
+There are three match specifiers: `contains`, `exact`, and `regex`.
+
+The alternatives would be written as:
+
+```
+! SELECT * FROM no_such_table
+exact: ERROR:  unknown catalog item 'no_such_table'
+```
+
+or:
+
+```
+! SELECT * FROM no_such_table
+regex: unknown catalog.*no_such_table
+```
+
+It is possible to include variables in expected errors:
+
+```
+$ set table_name=no_table
+
+$ SELECT * FROM ${table_name}
+exact:ERROR:  unknown catalog item '${table_name}'
+```
+
+And for regex matches all variables match literally, they are not treated as regular expression patterns. A variable valued `my.+name` will match the string `my.+name`, not `my friend's name`.
 
 ## Executing statements in multiple sessions
 

--- a/src/testdrive/src/action/kafka/ingest.rs
+++ b/src/testdrive/src/action/kafka/ingest.rs
@@ -355,6 +355,7 @@ impl Action for IngestAction {
                     row,
                     &hashmap! { "kafka-ingest.iteration".into() => iteration.to_string() },
                     &None,
+                    false,
                 )?;
                 let mut row = row.as_bytes();
                 let key = match &key_transcoder {

--- a/test/cluster/insert-select.td
+++ b/test/cluster/insert-select.td
@@ -43,7 +43,7 @@
 ! INSERT INTO t SELECT * FROM (
     VALUES ('11', '12', 'f')
   );
-column "i" is of type integer but expression is of type text
+contains:column "i" is of type integer but expression is of type text
 
 > BEGIN
 
@@ -52,7 +52,7 @@ column "i" is of type integer but expression is of type text
 ! INSERT INTO t SELECT * FROM (
     VALUES (13, 14, 'g')
   );
-cannot be run inside a transaction block
+contains:cannot be run inside a transaction block
 
 > COMMIT
 
@@ -68,14 +68,14 @@ cannot be run inside a transaction block
 ! INSERT INTO t SELECT * FROM (
     VALUES (11, 12, 'f')
   );
-cannot be run inside a transaction block
+contains:cannot be run inside a transaction block
 
 > COMMIT
 
 > CREATE MATERIALIZED VIEW v (a, b, c) AS SELECT 11, 12::real, 'f';
 
 ! INSERT INTO t SELECT * FROM v;
-invalid selection
+contains:invalid selection
 
 # Table check descends into select targets
 ! INSERT INTO t (i, f, t) SELECT column1, column2, column3
@@ -84,7 +84,7 @@ invalid selection
         SELECT a, b, c FROM v
     ) AS y
     ON y.a = column1
-invalid selection
+contains:invalid selection
 
 # Multiple connections
 

--- a/test/debezium-avro/03-drop-not-null-column.td
+++ b/test/debezium-avro/03-drop-not-null-column.td
@@ -33,4 +33,4 @@ INSERT INTO alter_drop_column_not_null VALUES (345);
 # An error is thrown instead of returning nulls in a NOT NULL column
 
 ! SELECT * FROM alter_drop_column_not_null;
-Reader field `col_not_null` not found in writer, and has no default
+contains:Reader field `col_not_null` not found in writer, and has no default

--- a/test/debezium-avro/11-change-date-timestamp.td
+++ b/test/debezium-avro/11-change-date-timestamp.td
@@ -34,4 +34,4 @@ UPDATE alter_change_date_timestamp SET f1 = '2012-12-12 12:12:12' WHERE f1 = '20
 DELETE FROM alter_change_date_timestamp WHERE f1 = '2011-11-11';
 
 ! SELECT * FROM alter_change_date_timestamp;
-Failed to match TimestampMicro against any variant in the reader
+contains:Failed to match TimestampMicro against any variant in the reader

--- a/test/debezium-avro/12-change-decimal.td
+++ b/test/debezium-avro/12-change-decimal.td
@@ -35,4 +35,4 @@ INSERT INTO alter_change_decimal VALUES (23.456);
 UPDATE alter_change_decimal SET f1 = 34.567 WHERE f1 = 0;
 
 ! SELECT * FROM alter_change_decimal;
-Decimal types must match in precision, scale, and fixed size
+contains:Decimal types must match in precision, scale, and fixed size

--- a/test/debezium-avro/25-types-array.td
+++ b/test/debezium-avro/25-types-array.td
@@ -19,4 +19,4 @@ INSERT INTO array_type VALUES ('{{1,2,3},{4,5,6},{7,8,9}}');
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'postgres.public.array_type'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE DEBEZIUM;
-Unsupported type in schema
+contains:Unsupported type in schema

--- a/test/debezium-avro/34-replica-identity-default.td
+++ b/test/debezium-avro/34-replica-identity-default.td
@@ -37,4 +37,4 @@ DELETE FROM replica_identity_default WHERE f1 = 3;
 UPDATE replica_identity_default SET f1 = 5 WHERE f1 = 4;
 
 ! SELECT * FROM replica_identity_default;
-Invalid data in source, saw retractions
+contains:Invalid data in source, saw retractions

--- a/test/debezium-avro/91-hstore-handling-mode.td
+++ b/test/debezium-avro/91-hstore-handling-mode.td
@@ -47,7 +47,7 @@ $ schema-registry-wait-schema schema=postgres.public.hstore_map-value
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'postgres.public.hstore_map'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE DEBEZIUM;
-Unsupported type in schema
+contains:Unsupported type in schema
 
 #
 # Restore default

--- a/test/kafka-sasl-plain/with-options-errors.td
+++ b/test/kafka-sasl-plain/with-options-errors.td
@@ -45,7 +45,7 @@ $ kafka-ingest format=avro topic=data schema=${schema} publish=true timestamp=1
   )
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE DEBEZIUM
-Invalid WITH options: cannot specify both sasl_password and sasl_password_env options at the same time
+contains:Invalid WITH options: cannot specify both sasl_password and sasl_password_env options at the same time
 
 ! CREATE MATERIALIZED SOURCE data
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
@@ -59,7 +59,7 @@ Invalid WITH options: cannot specify both sasl_password and sasl_password_env op
   )
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE DEBEZIUM
-Invalid WITH options: cannot specify both sasl_password and sasl_password_env options at the same time
+contains:Invalid WITH options: cannot specify both sasl_password and sasl_password_env options at the same time
 
 ! CREATE MATERIALIZED SOURCE data
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
@@ -72,4 +72,4 @@ Invalid WITH options: cannot specify both sasl_password and sasl_password_env op
   )
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE DEBEZIUM
-Invalid WITH option sasl_password_env='DNE': environment variable not found
+contains:Invalid WITH option sasl_password_env='DNE': environment variable not found

--- a/test/kafka-ssl/multi.td
+++ b/test/kafka-ssl/multi.td
@@ -78,4 +78,4 @@ a
   )
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE DEBEZIUM
-sslv3 alert certificate unknown
+contains:sslv3 alert certificate unknown

--- a/test/kafka-ssl/with-options-errors.td
+++ b/test/kafka-ssl/with-options-errors.td
@@ -56,7 +56,7 @@ $ kafka-ingest format=avro topic=data schema=${schema} publish=true timestamp=1
       ssl_key_password_env = 'SSL_KEY_PASSWORD'
   )
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-Invalid WITH options: cannot specify both ssl_key_password and ssl_key_password_env options at the same time
+contains:Invalid WITH options: cannot specify both ssl_key_password and ssl_key_password_env options at the same time
 
 ! CREATE SINK env_pw_snk FROM data
   INTO KAFKA BROKER 'kafka' TOPIC 'snk'
@@ -69,7 +69,7 @@ Invalid WITH options: cannot specify both ssl_key_password and ssl_key_password_
       ssl_key_password = 'mzmzmz'
   )
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-Invalid WITH options: cannot specify both ssl_key_password and ssl_key_password_env options at the same time
+contains:Invalid WITH options: cannot specify both ssl_key_password and ssl_key_password_env options at the same time
 
 ! CREATE MATERIALIZED SOURCE data
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
@@ -82,4 +82,4 @@ Invalid WITH options: cannot specify both ssl_key_password and ssl_key_password_
   )
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE DEBEZIUM
-Invalid WITH option ssl_key_password_env='DNE': environment variable not found
+contains:Invalid WITH option ssl_key_password_env='DNE': environment variable not found

--- a/test/persistence/failpoints/failpoint_set_sync.td
+++ b/test/persistence/failpoints/failpoint_set_sync.td
@@ -20,14 +20,14 @@
 > INSERT INTO t1 VALUES (1);
 
 ! COMMIT
-FileBlob::set sync fail point reached
+contains:FileBlob::set sync fail point reached
 
 > BEGIN
 
 > INSERT INTO t1 VALUES (1);
 
 ! COMMIT
-FileBlob::set sync fail point reached
+contains:FileBlob::set sync fail point reached
 
 #
 # Remove the I/O error and recover

--- a/test/persistence/user-tables/table-persistence-after-basic.td
+++ b/test/persistence/user-tables/table-persistence-after-basic.td
@@ -31,7 +31,7 @@
 #
 
 ! SELECT * FROM to_be_dropped;
-unknown catalog item 'to_be_dropped'
+contains:unknown catalog item 'to_be_dropped'
 
 #
 # Confirm that same-named tables in different schemas still has different contents

--- a/test/pg-cdc/pg-cdc-ssl.td
+++ b/test/pg-cdc/pg-cdc-ssl.td
@@ -101,7 +101,7 @@ DELETE FROM numbers WHERE number = 2;
 ! CREATE MATERIALIZED SOURCE "mz_source"
   FROM POSTGRES CONNECTION 'host=postgres port=5432 user=hostssl sslmode=disable dbname=postgres'
   PUBLICATION 'mz_source';
-db error: FATAL: no pg_hba.conf entry for host "(HOST)", user "hostssl", database "postgres", SSL off
+contains:db error: FATAL: no pg_hba.conf entry for host "(HOST)", user "hostssl", database "postgres", SSL off
 
 # server: hostssl, client: prefer => OK
 > CREATE MATERIALIZED SOURCE "mz_source"
@@ -141,7 +141,7 @@ DELETE FROM numbers WHERE number = 2;
 ! CREATE MATERIALIZED SOURCE "mz_source"
   FROM POSTGRES CONNECTION 'host=postgres port=5432 user=hostssl dbname=postgres sslmode=verify-ca'
   PUBLICATION 'mz_source';
-self signed certificate in certificate chain
+contains:self signed certificate in certificate chain
 
 # server: hostssl, client: verify-ca => OK
 > CREATE MATERIALIZED SOURCE "mz_source"
@@ -164,7 +164,7 @@ DELETE FROM numbers WHERE number = 2;
 ! CREATE MATERIALIZED SOURCE "mz_source"
   FROM POSTGRES CONNECTION 'host=postgres port=5432 user=hostssl dbname=postgres sslmode=verify-full'
   PUBLICATION 'mz_source';
-self signed certificate in certificate chain
+contains:self signed certificate in certificate chain
 
 # server: hostssl, client: verify-full => OK
 > CREATE MATERIALIZED SOURCE "mz_source"
@@ -205,25 +205,25 @@ DELETE FROM numbers WHERE number = 2;
 ! CREATE MATERIALIZED SOURCE "mz_source"
   FROM POSTGRES CONNECTION 'host=postgres port=5432 user=hostnossl sslmode=prefer dbname=postgres'
   PUBLICATION 'mz_source';
-db error: FATAL: no pg_hba.conf entry for host "(HOST)", user "hostnossl", database "postgres", SSL on
+contains:db error: FATAL: no pg_hba.conf entry for host "(HOST)", user "hostnossl", database "postgres", SSL on
 
 # server: hostnossl, client: require => ERROR
 ! CREATE MATERIALIZED SOURCE "mz_source"
   FROM POSTGRES CONNECTION 'host=postgres port=5432 user=hostnossl sslmode=require dbname=postgres'
   PUBLICATION 'mz_source';
-db error: FATAL: no pg_hba.conf entry for host "(HOST)", user "hostnossl", database "postgres", SSL on
+contains:db error: FATAL: no pg_hba.conf entry for host "(HOST)", user "hostnossl", database "postgres", SSL on
 
 # server: hostnossl, client: verify-ca => ERROR
 ! CREATE MATERIALIZED SOURCE "mz_source"
   FROM POSTGRES CONNECTION 'host=postgres port=5432 user=hostnossl sslmode=verify-ca dbname=postgres'
   PUBLICATION 'mz_source';
-self signed certificate in certificate chain
+contains:self signed certificate in certificate chain
 
 # server: hostnossl, client: verify-full => ERROR
 ! CREATE MATERIALIZED SOURCE "mz_source"
   FROM POSTGRES CONNECTION 'host=postgres port=5432 user=hostnossl sslmode=verify-full dbname=postgres'
   PUBLICATION 'mz_source';
-self signed certificate in certificate chain
+contains:self signed certificate in certificate chain
 
 # server: certuser, client: require => OK
 > CREATE MATERIALIZED SOURCE "mz_source"
@@ -246,13 +246,13 @@ DELETE FROM numbers WHERE number = 2;
 ! CREATE MATERIALIZED SOURCE "mz_source"
   FROM POSTGRES CONNECTION 'host=postgres port=5432 user=certuser dbname=postgres sslmode=verify-ca sslrootcert=/share/secrets/ca.crt'
   PUBLICATION 'mz_source'
-db error: FATAL: connection requires a valid client certificate
+contains:db error: FATAL: connection requires a valid client certificate
 
 # server: certuser, client: verify-ca (wrong cert) => ERROR
 ! CREATE MATERIALIZED SOURCE "mz_source"
   FROM POSTGRES CONNECTION 'host=postgres port=5432 user=certuser dbname=postgres sslmode=verify-ca sslcert=/share/secrets/postgres.crt sslkey=/share/secrets/postgres.key sslrootcert=/share/secrets/ca.crt'
   PUBLICATION 'mz_source'
-db error: FATAL: certificate authentication failed for user "certuser"
+contains:db error: FATAL: certificate authentication failed for user "certuser"
 
 # server: certuser, client: verify-ca => OK
 > CREATE MATERIALIZED SOURCE "mz_source"
@@ -292,27 +292,27 @@ DELETE FROM numbers WHERE number = 2;
 ! CREATE MATERIALIZED SOURCE "mz_source"
   FROM POSTGRES CONNECTION 'host=postgres port=5432 user=certuser sslmode=verify-ca sslcert=/share/secrets/missing sslkey=/share/secrets/certuser.key sslrootcert=/share/secrets/ca.crt dbname=postgres'
   PUBLICATION 'mz_source'
-invalid connection string: invalid value for option `sslcert`
+contains:invalid connection string: invalid value for option `sslcert`
 
 # missing sslkey
 ! CREATE MATERIALIZED SOURCE "mz_source"
   FROM POSTGRES CONNECTION 'host=postgres port=5432 user=certuser sslmode=verify-ca sslcert=/share/secrets/certuser.crt sslkey=/share/secrets/missing sslrootcert=/share/secrets/ca.crt dbname=postgres'
   PUBLICATION 'mz_source'
-invalid connection string: invalid value for option `sslkey`
+contains:invalid connection string: invalid value for option `sslkey`
 
 # missing sslrootcert
 ! CREATE MATERIALIZED SOURCE "mz_source"
   FROM POSTGRES CONNECTION 'host=postgres port=5432 user=certuser sslmode=verify-ca sslcert=/share/secrets/certuser.crt sslkey=/share/secrets/certuser.key sslrootcert=/share/secrets/missing dbname=postgres'
   PUBLICATION 'mz_source'
-invalid connection string: invalid value for option `sslrootcert`
+contains:invalid connection string: invalid value for option `sslrootcert`
 
 # require both sslcert and sslkey
 ! CREATE MATERIALIZED SOURCE "mz_source"
   FROM POSTGRES CONNECTION 'host=postgres port=5432 user=certuser sslmode=verify-ca sslcert=/share/secrets/certuser.crt dbname=postgres'
   PUBLICATION 'mz_source'
-must provide both sslcert and sslkey, but only provided sslcert
+contains:must provide both sslcert and sslkey, but only provided sslcert
 
 ! CREATE MATERIALIZED SOURCE "mz_source"
   FROM POSTGRES CONNECTION 'host=postgres port=5432 user=certuser sslmode=verify-ca sslkey=/share/secrets/certuser.key dbname=postgres'
   PUBLICATION 'mz_source'
-must provide both sslcert and sslkey, but only provided sslkey
+contains:must provide both sslcert and sslkey, but only provided sslkey

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -85,32 +85,32 @@ CREATE TABLE "space table" ("space column" INTEGER);
 ! CREATE MATERIALIZED SOURCE "no_such_host"
   FROM POSTGRES CONNECTION 'host=no_such_postgres.mtrlz.com port=5432 user=postgres password=postgres dbname=postgres'
   PUBLICATION 'mz_source';
-failed to lookup address information
+contains:failed to lookup address information
 
 ! CREATE MATERIALIZED SOURCE "no_such_port"
   FROM POSTGRES CONNECTION 'host=postgres port=65534 user=postgres password=postgres dbname=postgres'
   PUBLICATION 'mz_source';
-error connecting to server: Connection refused (os error 111)
+contains:error connecting to server: Connection refused (os error 111)
 
 ! CREATE MATERIALIZED SOURCE "no_such_user"
   FROM POSTGRES CONNECTION 'host=postgres port=5432 user=no_such_user password=postgres dbname=postgres'
   PUBLICATION 'mz_source';
-db error: FATAL: role "no_such_user" does not exist
+contains:db error: FATAL: role "no_such_user" does not exist
 
 ! CREATE MATERIALIZED SOURCE "no_such_password"
   FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=no_such_password dbname=postgres'
   PUBLICATION 'mz_source';
-db error: FATAL: password authentication failed for user "postgres"
+contains:db error: FATAL: password authentication failed for user "postgres"
 
 ! CREATE MATERIALIZED SOURCE "no_such_dbname"
   FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres dbname=no_such_dbname'
   PUBLICATION 'mz_source';
-db error: FATAL: database "no_such_dbname" does not exist
+contains:db error: FATAL: database "no_such_dbname" does not exist
 
 ! CREATE MATERIALIZED SOURCE "no_such_publication"
   FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
   PUBLICATION 'no_such_publication';
-publication "no_such_publication" does not exist
+contains:publication "no_such_publication" does not exist
 
 > CREATE MATERIALIZED SOURCE "mz_source"
   FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
@@ -402,10 +402,10 @@ $ postgres-execute connection=postgres://postgres:postgres@postgres
 DROP PUBLICATION mz_source;
 INSERT INTO pk_table VALUES (99999);
 
-! SELECT COUNT(*) = 0 FROM pk_table;
 # todo: we're purifying Postgres view names incorrectly, fix that and this error!
 # should be "materialize.public.pk_table"
-Source error: materialize.public.mz_source: file IO: db error: ERROR: publication "mz_source" does not exist
+! SELECT COUNT(*) = 0 FROM pk_table;
+contains:Source error: materialize.public.mz_source: file IO: db error: ERROR: publication "mz_source" does not exist
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 DROP SCHEMA conflict_schema CASCADE;

--- a/test/pg-cdc/publication-for-table.td
+++ b/test/pg-cdc/publication-for-table.td
@@ -38,4 +38,4 @@ CREATE PUBLICATION mz_source FOR TABLE t1;
 1
 
 ! CREATE VIEWS FROM SOURCE mz_source (t2);
-table t2 does not exist in upstream database
+contains:table t2 does not exist in upstream database

--- a/test/pg-cdc/publication-with-publish-option.td
+++ b/test/pg-cdc/publication-with-publish-option.td
@@ -59,7 +59,7 @@ DELETE FROM t1;
 1
 
 ! SELECT * FROM t1_update;
-Invalid data in source, saw retractions (1) for row that does not exist
+contains:Invalid data in source, saw retractions (1) for row that does not exist
 
 ! SELECT * FROM t1_delete;
-Invalid data in source, saw retractions (1) for row that does not exist
+contains:Invalid data in source, saw retractions (1) for row that does not exist

--- a/test/pg-cdc/reject-multiple-materializations.td
+++ b/test/pg-cdc/reject-multiple-materializations.td
@@ -46,10 +46,10 @@ CREATE PUBLICATION mz_source FOR ALL TABLES;
 
 ! CREATE MATERIALIZED VIEW t1_mat_dupe AS
   SELECT * FROM t1
-Cannot re-materialize source mz_source
+contains:Cannot re-materialize source mz_source
 
 ! CREATE MATERIALIZED VIEWS FROM SOURCE mz_source (t1 as t1_not_a_dupe, t2 as t2_not_a_dupe)
-Cannot re-materialize source mz_source
+contains:Cannot re-materialize source mz_source
 
 > DROP VIEW t1_mat;
 

--- a/test/pg-cdc/replica-identity-default-nothing.td
+++ b/test/pg-cdc/replica-identity-default-nothing.td
@@ -60,13 +60,13 @@ INSERT INTO identity_nothing VALUES (1, 1);
 > CREATE VIEWS FROM SOURCE mz_source;
 
 ! SELECT * FROM identity_default_key_update;
-Old row missing from replication stream for table with OID
+contains:Old row missing from replication stream for table with OID
 
 ! SELECT * FROM identity_default_nokey_update;
-Old row missing from replication stream for table with OID
+contains:Old row missing from replication stream for table with OID
 
 ! SELECT * FROM identity_default_delete;
-Old row missing from replication stream for table with OID
+contains:Old row missing from replication stream for table with OID
 
 ! SELECT * FROM identity_nothing;
-Old row missing from replication stream for table with OID
+contains:Old row missing from replication stream for table with OID

--- a/test/pg-cdc/two-source-schemas.td
+++ b/test/pg-cdc/two-source-schemas.td
@@ -44,10 +44,10 @@ INSERT INTO schema1.t1 SELECT * FROM schema1.t1;
 INSERT INTO schema2.t1 SELECT * FROM schema2.t1;
 
 ! CREATE VIEWS FROM SOURCE mz_source;
-unknown schema 'schema1'
+contains:unknown schema 'schema1'
 
 ! CREATE VIEWS FROM SOURCE mz_source (t1);
-table t1 is ambiguous, consider specifying the schema
+contains:table t1 is ambiguous, consider specifying the schema
 
 > DROP SCHEMA IF EXISTS schema1;
 

--- a/test/pg-cdc/types-temporal-with-tz.td
+++ b/test/pg-cdc/types-temporal-with-tz.td
@@ -56,4 +56,4 @@ INSERT INTO timestamp_table SELECT * FROM timestamp_table;
 
 # Mz does not support TIME WITH TIME ZOINE
 ! CREATE VIEWS FROM SOURCE mz_source (time_table);
-unknown catalog item 'timetz'
+contains:unknown catalog item 'timetz'

--- a/test/proxy/proxy-failure.td
+++ b/test/proxy/proxy-failure.td
@@ -13,7 +13,7 @@
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-doesntmatter-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE DEBEZIUM
-error trying to connect: tcp connect error: Cannot assign requested address (os error 99)
+contains:error trying to connect: tcp connect error: Cannot assign requested address (os error 99)
 
 ! CREATE MATERIALIZED SOURCE s3_all
   FROM S3 DISCOVER OBJECTS USING BUCKET SCAN 'doesnt-matter'
@@ -25,4 +25,4 @@ error trying to connect: tcp connect error: Cannot assign requested address (os 
     token = '${testdrive.aws-token}'
   )
   FORMAT TEXT;
-Cannot assign requested address (os error 99)
+contains:Cannot assign requested address (os error 99)

--- a/test/restart/user-indexes-disabled.td
+++ b/test/restart/user-indexes-disabled.td
@@ -46,7 +46,7 @@ logging_derived_mat logging_derived_mat_primary_idx 1             count       <n
 > SHOW MATERIALIZED VIEWS
 
 ! SELECT * FROM mat_view
-unable to automatically determine a query timestamp
+contains:unable to automatically determine a query timestamp
 
 > SHOW INDEXES FROM mat_view;
 on_name   key_name              seq_in_index  column_name  expression  nullable enabled
@@ -63,7 +63,7 @@ mat_view  mat_view_primary_idx  1             sum          <null>      true     
 
 # Cannot alter disabled index
 ! ALTER INDEX mat_view_primary_idx RESET (logical_compaction_window)
-invalid ALTER on disabled index "materialize.public.mat_view_primary_idx"
+contains:invalid ALTER on disabled index "materialize.public.mat_view_primary_idx"
 
 # 🔬🔬🔬🔬 Materialized sources
 
@@ -71,7 +71,7 @@ invalid ALTER on disabled index "materialize.public.mat_view_primary_idx"
 > SHOW MATERIALIZED SOURCES
 
 ! SELECT * FROM mat_data
-unable to automatically determine a query timestamp
+contains:unable to automatically determine a query timestamp
 
 > SHOW INDEXES FROM mat_data;
 on_name   key_name              seq_in_index  column_name  expression  nullable enabled
@@ -89,7 +89,7 @@ mat_data  mat_data_primary_idx  1             a            <null>      false    
 # 🔬🔬🔬🔬 Non-materialized views
 
 ! SELECT * FROM join_view
-unable to automatically determine a query timestamp
+contains:unable to automatically determine a query timestamp
 
 # 🔬🔬 Sinks
 
@@ -100,13 +100,13 @@ unable to automatically determine a query timestamp
 # 🔬🔬 Tables
 
 ! INSERT INTO t VALUES (1)
-cannot perform operation on "materialize.public.t" while its default index ("materialize.public.t_primary_idx") is disabled
+contains:cannot perform operation on "materialize.public.t" while its default index ("materialize.public.t_primary_idx") is disabled
 
 ! UPDATE t SET a = 1
-cannot perform operation on "materialize.public.t" while its default index ("materialize.public.t_primary_idx") is disabled
+contains:cannot perform operation on "materialize.public.t" while its default index ("materialize.public.t_primary_idx") is disabled
 
 ! DELETE FROM t;
-cannot perform operation on "materialize.public.t" while its default index ("materialize.public.t_primary_idx") is disabled
+contains:cannot perform operation on "materialize.public.t" while its default index ("materialize.public.t_primary_idx") is disabled
 
 # Selects work but are always empty
 > SELECT * FROM t
@@ -193,7 +193,7 @@ mat_data
 # Still cannot select from non-materialized view because some of its indexes are disabled
 
 ! SELECT * FROM join_view
-unable to automatically determine a query timestamp
+contains:unable to automatically determine a query timestamp
 
 > ALTER INDEX join_data_primary_idx SET ENABLED
 
@@ -210,7 +210,7 @@ $ kafka-verify format=avro sink=materialize.public.snk_indexes_disabled sort-mes
 
 # Tables still work with non-primary indexes enabled because all indexes are covering
 ! ALTER INDEX t_secondary_idx SET ENABLED;
-cannot perform operation on "materialize.public.t" while its default index ("materialize.public.t_primary_idx") is disabled
+contains:cannot perform operation on "materialize.public.t" while its default index ("materialize.public.t_primary_idx") is disabled
 
 > ALTER INDEX t_primary_idx SET ENABLED
 

--- a/test/s3-resumption/materialize-verify-failure.td
+++ b/test/s3-resumption/materialize-verify-failure.td
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0.
 
 ! SELECT COUNT(*) FROM s3_text;
-s3
+contains:s3
 
 ! SELECT COUNT(*) FROM s3_gzip;
-s3
+contains:s3

--- a/test/testdrive/array.td
+++ b/test/testdrive/array.td
@@ -21,18 +21,18 @@ array
 {{a,b},{NULL,d}}
 
 ! CREATE TABLE foobar (f1 int list[]);
-integer list[] not yet supported
+contains:integer list[] not yet supported
 
 ! SELECT ARRAY[LIST[1]];
-integer list[] not yet supported
+contains:integer list[] not yet supported
 
 > CREATE TYPE bigint_list AS LIST (element_type=bigint);
 ! CREATE TABLE bigint_list_arr (f1 bigint_list[]);
-bigint_list[] not yet supported
+contains:bigint_list[] not yet supported
 
 ! SELECT ARRAY['{a => 1}'::map[text=>int]];
-map[text=>integer][] not yet supported
+contains:map[text=>integer][] not yet supported
 
 > CREATE TYPE bigint_map AS MAP (key_type=text, value_type=bigint);
 ! CREATE TABLE bigint_map_map_array_table (f1 bigint_map[]);
-bigint_map[] not yet supported
+contains:bigint_map[] not yet supported

--- a/test/testdrive/avro-decode-mismatched-columns.td
+++ b/test/testdrive/avro-decode-mismatched-columns.td
@@ -31,7 +31,7 @@ $ kafka-ingest format=avro topic=decode-1to2-nodefault schema=${1column} timesta
   ENVELOPE NONE
 
 ! SELECT * FROM decode_1to2_nodefault
-avro deserialization error: IO error: UnexpectedEof
+contains:avro deserialization error: IO error: UnexpectedEof
 
 #
 # 1 column -> 2 columns with default
@@ -48,7 +48,7 @@ $ kafka-ingest format=avro topic=decode-1to2-default schema=${1column} timestamp
   ENVELOPE NONE
 
 ! SELECT * FROM decode_1to2_default
-avro deserialization error: IO error: UnexpectedEof
+contains:avro deserialization error: IO error: UnexpectedEof
 
 #
 # 2 columns -> 1 column
@@ -66,4 +66,4 @@ $ kafka-ingest format=avro topic=decode-2to1 schema=${2columns-nodefault} timest
   ENVELOPE NONE
 
 ! SELECT * FROM decode_2to1
-Unexpected bytes remaining
+contains:Unexpected bytes remaining

--- a/test/testdrive/avro-decode-mismatched-types.td
+++ b/test/testdrive/avro-decode-mismatched-types.td
@@ -39,7 +39,7 @@ $ kafka-ingest format=avro topic=avro-types-null2int schema=${null} timestamp=1
   ENVELOPE NONE
 
 ! SELECT * FROM avro_types_null2int
-avro deserialization error: IO error: UnexpectedEof
+contains:avro deserialization error: IO error: UnexpectedEof
 
 #
 # boolean -> int
@@ -93,7 +93,7 @@ $ kafka-ingest format=avro topic=avro-types-int2float schema=${int} timestamp=1
   ENVELOPE NONE
 
 ! SELECT * FROM avro_types_int2float
-avro deserialization error: IO error: UnexpectedEof
+contains:avro deserialization error: IO error: UnexpectedEof
 
 #
 # long -> float
@@ -110,7 +110,7 @@ $ kafka-ingest format=avro topic=avro-types-long2float schema=${long} timestamp=
   ENVELOPE NONE
 
 ! SELECT * FROM avro_types_long2float
-Unexpected bytes remaining
+contains:Unexpected bytes remaining
 
 #
 # long -> int
@@ -127,7 +127,7 @@ $ kafka-ingest format=avro topic=avro-types-long2int schema=${long} timestamp=1
   ENVELOPE NONE
 
 ! SELECT * FROM avro_types_long2int
-avro deserialization error: Decode error: Decoding error: Expected i32, got: 992147483647
+contains:avro deserialization error: Decode error: Decoding error: Expected i32, got: 992147483647
 
 #
 # float -> double
@@ -144,7 +144,7 @@ $ kafka-ingest format=avro topic=avro-types-float2double schema=${float} timesta
   ENVELOPE NONE
 
 ! SELECT * FROM avro_types_float2double
-avro deserialization error: IO error: UnexpectedEof
+contains:avro deserialization error: IO error: UnexpectedEof
 
 #
 # avro-typestion string -> bytes

--- a/test/testdrive/avro-decode.td
+++ b/test/testdrive/avro-decode.td
@@ -202,7 +202,7 @@ garbage
   FORMAT AVRO USING SCHEMA '${reader-schema}'
 
 ! SELECT f2 FROM avro_corrupted_values
-Decode error: Text: avro deserialization error: wrong Confluent-style avro serialization magic: expected 0, got 1
+contains:Decode error: Text: avro deserialization error: wrong Confluent-style avro serialization magic: expected 0, got 1
 
 # Test decoding of corrupted messages without magic byte
 $ kafka-create-topic topic=avro-corrupted-values2
@@ -215,4 +215,4 @@ garbage
   FORMAT AVRO USING SCHEMA '${reader-schema}' WITH (confluent_wire_format = false)
 
 ! SELECT f2 FROM avro_corrupted_values2
-Decode error: Text: avro deserialization error: Decode error: Decoding error: Expected non-negative integer, got -49
+contains:Decode error: Text: avro deserialization error: Decode error: Decoding error: Expected non-negative integer, got -49

--- a/test/testdrive/avro-ocf.td
+++ b/test/testdrive/avro-ocf.td
@@ -105,7 +105,7 @@ mz_obj_no  false     bigint
 ! CREATE MATERIALIZED SOURCE reader_schema
   FROM AVRO OCF '${testdrive.temp-dir}/data.ocf'
   WITH (reader_schema = '{"bad": "news", "bears"')
-validating avro schema:
+contains:validating avro schema:
 
 > CREATE MATERIALIZED SOURCE tailed
   FROM AVRO OCF '${testdrive.temp-dir}/data.ocf' WITH (tail = true)
@@ -287,4 +287,4 @@ a  b
   FROM AVRO OCF '${testdrive.temp-dir}/data.ocf'
   INCLUDE OFFSET
   ENVELOPE DEBEZIUM
-INCLUDE metadata with non-Kafka sources not yet supported
+contains:INCLUDE metadata with non-Kafka sources not yet supported

--- a/test/testdrive/avro-registry.td
+++ b/test/testdrive/avro-registry.td
@@ -16,7 +16,7 @@
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-noexist-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE DEBEZIUM
-fetching latest schema for subject 'testdrive-noexist-${testdrive.seed}-value' from registry: subject not found
+contains:fetching latest schema for subject 'testdrive-noexist-${testdrive.seed}-value' from registry: subject not found
 
 $ set schema-v1={
     "type": "record",

--- a/test/testdrive/avro-resolution-no-publish-reader.td
+++ b/test/testdrive/avro-resolution-no-publish-reader.td
@@ -25,4 +25,4 @@ $ kafka-ingest format=avro topic=resolution-no-publish-writer schema=${int-schem
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-resolution-no-publish-writer-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE NONE
-subject not found
+contains:subject not found

--- a/test/testdrive/avro-resolution-no-publish-writer.td
+++ b/test/testdrive/avro-resolution-no-publish-writer.td
@@ -30,4 +30,4 @@ $ kafka-ingest format=avro topic=resolution-no-publish-writer schema=${int-schem
 {"f1": 123}
 
 ! SELECT * FROM resolution_no_publish_writer;
-Attempted to resolve
+contains:Attempted to resolve

--- a/test/testdrive/avro-resolution-notnull2null.td
+++ b/test/testdrive/avro-resolution-notnull2null.td
@@ -29,4 +29,4 @@ $ kafka-ingest format=avro topic=resolution-unions schema=${null} publish=true t
 {"f1": {"int": 123 } }
 
 ! SELECT f1 FROM resolution_unions
-Decode error: Text: avro deserialization error: Schema resolution error: Failed to match Null against any variant in the reader
+contains:Decode error: Text: avro deserialization error: Schema resolution error: Failed to match Null against any variant in the reader

--- a/test/testdrive/avro-resolution-types-array.td
+++ b/test/testdrive/avro-resolution-types-array.td
@@ -28,4 +28,4 @@ $ kafka-ingest format=avro topic=resolution-arrays schema=${array-double} publis
 {"f1": [ 234.345 ] }
 
 ! SELECT f1[0] FROM resolution_arrays
-Schemas don't match: Double, Int
+contains:Schemas don't match: Double, Int

--- a/test/testdrive/avro-resolution-types-map.td
+++ b/test/testdrive/avro-resolution-types-map.td
@@ -28,4 +28,4 @@ $ kafka-ingest format=avro topic=resolution-maps schema=${map-double} publish=tr
 {"f1": { "key1": 234.345 } }
 
 ! SELECT f1 -> 'key1' FROM resolution_maps
-Schemas don't match: Double, Int
+contains:Schemas don't match: Double, Int

--- a/test/testdrive/avro-resolution-types-records.td
+++ b/test/testdrive/avro-resolution-types-records.td
@@ -29,4 +29,4 @@ $ kafka-ingest format=avro topic=resolution-records-int2double schema=${double-c
 {"f1": { "f1": 123.234 }}
 
 ! SELECT * FROM resolution_records_int2double
-Schemas don't match: Double, Int
+contains:Schemas don't match: Double, Int

--- a/test/testdrive/avro-resolution-types.td
+++ b/test/testdrive/avro-resolution-types.td
@@ -29,4 +29,4 @@ $ kafka-ingest format=avro topic=resolution-int2double schema=${double-col} publ
 {"f1": 234.456}
 
 ! SELECT * FROM resolution_int2double
-Schema resolution error: Schemas don't match: Double, Int
+contains:Schema resolution error: Schemas don't match: Double, Int

--- a/test/testdrive/avro-resolution-unions.td
+++ b/test/testdrive/avro-resolution-unions.td
@@ -30,4 +30,4 @@ $ kafka-ingest format=avro topic=resolution-unions schema=${union-int-string} pu
 {"f1": {"string": "abc" } }
 
 ! SELECT f1 FROM resolution_unions
-avro deserialization error: Schema resolution error: Failed to match String against any variant in the reader
+contains:avro deserialization error: Schema resolution error: Failed to match String against any variant in the reader

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -61,12 +61,12 @@ s
 
 # Creating a schema with a name that already exists should fail.
 ! CREATE SCHEMA s
-schema 's' already exists
+contains:schema 's' already exists
 
 # Dropping a schema with a view should only succeed with CASCADE.
 > CREATE VIEW s.v AS SELECT 1
 ! DROP SCHEMA s
-schema 'materialize.s' cannot be dropped without CASCADE while it contains objects
+contains:schema 'materialize.s' cannot be dropped without CASCADE while it contains objects
 > DROP SCHEMA s CASCADE
 
 # Dropping a schema with no objects should succeed without CASCADE.
@@ -120,11 +120,11 @@ d
 > SHOW DATABASES WHERE (name = (SELECT min(name) FROM mz_databases))
 d
 ! SHOW DATABASES WHERE 7
-WHERE clause must have type boolean, not type integer
+contains:WHERE clause must have type boolean, not type integer
 
 # Creating a database with a name that already exists should fail.
 ! CREATE DATABASE d
-database 'd' already exists
+contains:database 'd' already exists
 
 # The new database should have a default public schema.
 > SHOW SCHEMAS FROM d
@@ -198,7 +198,7 @@ foo.other.int_list
 
 > CREATE TYPE bool AS LIST (element_type=int4)
 ! SELECT '{1}'::bool
-invalid input syntax for type boolean: "{1}"
+contains:invalid input syntax for type boolean: "{1}"
 
 > SELECT pg_typeof('{1}'::public.bool);
 public.bool
@@ -209,7 +209,7 @@ public.bool
 > DROP DATABASE foo
 
 ! DROP OBJECT v1
-Expected DATABASE, INDEX, ROLE, SCHEMA, SINK, SOURCE, TABLE, TYPE, USER, VIEW after DROP, found identifier
+contains:Expected DATABASE, INDEX, ROLE, SCHEMA, SINK, SOURCE, TABLE, TYPE, USER, VIEW after DROP, found identifier
 
 > SHOW FULL OBJECTS
 name            type
@@ -221,14 +221,14 @@ v2_primary_idx  user
 
 # DROP DATABASE does not support both RESTRICT and CASCADE.
 ! DROP DATABASE d RESTRICT CASCADE
-Cannot specify both RESTRICT and CASCADE in DROP
+contains:Cannot specify both RESTRICT and CASCADE in DROP
 ! DROP DATABASE d CASCADE RESTRICT
-Cannot specify both CASCADE and RESTRICT in DROP
+contains:Cannot specify both CASCADE and RESTRICT in DROP
 ! DROP DATABASE d CASCADE CASCADE
-Expected end of statement, found CASCADE
+contains:Expected end of statement, found CASCADE
 
 ! DROP DATABASE d RESTRICT
-database 'd' cannot be dropped with RESTRICT while it contains schemas
+contains:database 'd' cannot be dropped with RESTRICT while it contains schemas
 
 # DROP DATABASE should succeed even when there are objects in the database.
 > DROP DATABASE d
@@ -249,7 +249,7 @@ id          name
 > SHOW DATABASE
 d
 ! SELECT * FROM v
-unknown catalog item 'v'
+contains:unknown catalog item 'v'
 
 # But queries that do not depend on the session database should work fine.
 > CREATE VIEW materialize.public.v AS SELECT 1
@@ -258,38 +258,38 @@ unknown catalog item 'v'
 # Dropping the public schema is okay, but dropping the catalog schemas is not.
 > DROP SCHEMA public
 ! DROP SCHEMA mz_catalog
-cannot drop schema mz_catalog because it is required by the database system
+contains:cannot drop schema mz_catalog because it is required by the database system
 ! DROP SCHEMA pg_catalog
-cannot drop schema pg_catalog because it is required by the database system
+contains:cannot drop schema pg_catalog because it is required by the database system
 
 # Schema names that start with "mz_" or "pg_" are reserved for future use by the
 # system.
 ! CREATE SCHEMA mz_foo
-unacceptable schema name 'mz_foo'
+contains:unacceptable schema name 'mz_foo'
 ! CREATE SCHEMA pg_bar
-unacceptable schema name 'pg_bar'
+contains:unacceptable schema name 'pg_bar'
 
 # The search path is currently hardcoded.
 > SHOW search_path
 "mz_catalog, pg_catalog, public, mz_temp"
 ! SET search_path = foo
-parameter "search_path" cannot be changed
+contains:parameter "search_path" cannot be changed
 ! SET SCHEMA foo
-parameter "search_path" cannot be changed
+contains:parameter "search_path" cannot be changed
 
 # Creating views in non-existent databases should fail.
 ! CREATE VIEW noexist.ignored AS SELECT 1
-unknown schema 'noexist'
+contains:unknown schema 'noexist'
 ! CREATE VIEW materialize.noexist.ignored AS SELECT 1
-unknown schema 'noexist'
+contains:unknown schema 'noexist'
 ! CREATE VIEW noexist.ignored.ignored AS SELECT 1
-unknown database 'noexist'
+contains:unknown database 'noexist'
 
 # As should showing views.
 ! SHOW VIEWS FROM noexist
-unknown schema 'noexist'
+contains:unknown schema 'noexist'
 ! SHOW VIEWS FROM noexist_db.noexist_schema
-unknown database 'noexist_db'
+contains:unknown database 'noexist_db'
 
 # Dropping database with cross-schema dependencies is ok.
 > CREATE DATABASE d1;

--- a/test/testdrive/char-varchar-distinct.td
+++ b/test/testdrive/char-varchar-distinct.td
@@ -28,13 +28,13 @@
 "a  "
 
 ! SELECT 'a '::varchar(5) UNION DISTINCT SELECT 'a '::char(5);
-UNION types character varying and character cannot be matched
+contains:UNION types character varying and character cannot be matched
 
 ! SELECT 'a '::varchar(5) UNION DISTINCT SELECT 'a '::text;
-UNION types character varying and text cannot be matched
+contains:UNION types character varying and text cannot be matched
 
 ! SELECT 'a '::char(5) UNION DISTINCT SELECT 'a '::text;
-UNION types character and text cannot be matched
+contains:UNION types character and text cannot be matched
 
 > CREATE TABLE char_table (f1 CHAR(20));
 

--- a/test/testdrive/char-varchar-multibyte.td
+++ b/test/testdrive/char-varchar-multibyte.td
@@ -39,7 +39,7 @@
 22
 
 ! INSERT INTO vt VALUES ('това е текст това е текст');
-value too long for type character varying(20)
+contains:value too long for type character varying(20)
 
 ! INSERT INTO ct VALUES ('това е текст това е текст');
-value too long for type character(20)
+contains:value too long for type character(20)

--- a/test/testdrive/consolidation.td
+++ b/test/testdrive/consolidation.td
@@ -181,9 +181,9 @@ $ kafka-ingest format=avro topic=tx schema=${tx-schema}
 # of the latest transaction (i.e., 4).
 
 ! SELECT * FROM nums AS OF 2
-Timestamp (2) is not valid for all inputs
+contains:Timestamp (2) is not valid for all inputs
 ! SELECT * FROM nums AS OF 3
-Timestamp (3) is not valid for all inputs
+contains:Timestamp (3) is not valid for all inputs
 > SELECT * FROM nums AS OF 4
 6
 
@@ -218,8 +218,8 @@ $ kafka-ingest format=avro topic=tx schema=${tx-schema}
 8
 
 ! SELECT * FROM nums_compacted AS OF 4
-Timestamp (4) is not valid for all inputs
+contains:Timestamp (4) is not valid for all inputs
 ! SELECT * FROM nums_compacted AS OF 5
-Timestamp (5) is not valid for all inputs
+contains:Timestamp (5) is not valid for all inputs
 > SELECT * FROM nums_compacted AS OF 6
 8

--- a/test/testdrive/create-views.td
+++ b/test/testdrive/create-views.td
@@ -15,16 +15,16 @@
 > INSERT INTO t VALUES (1, 2);
 
 ! CREATE VIEW t_v AS SELECT a, a FROM t;
-column "a" specified more than once
+contains:column "a" specified more than once
 
 ! CREATE VIEW t_v AS SELECT b, a, b FROM t;
-column "b" specified more than once
+contains:column "b" specified more than once
 
 ! CREATE VIEW t_v AS SELECT a, b AS a FROM t;
-column "a" specified more than once
+contains:column "a" specified more than once
 
 ! CREATE VIEW t_v AS SELECT a, b FROM t AS t(a, a);
-column reference "a" is ambiguous
+contains:column reference "a" is ambiguous
 
 > CREATE VIEW t_v AS SELECT a, b FROM t;
 > SELECT * FROM t_v;
@@ -35,16 +35,16 @@ column reference "a" is ambiguous
 2 1
 
 ! CREATE MATERIALIZED VIEW t_m_v AS SELECT a, a FROM t;
-column "a" specified more than once
+contains:column "a" specified more than once
 
 ! CREATE MATERIALIZED VIEW t_m_v AS SELECT b, a, b FROM t;
-column "b" specified more than once
+contains:column "b" specified more than once
 
 ! CREATE MATERIALIZED VIEW t_m_v AS SELECT a, b AS a FROM t;
-column "a" specified more than once
+contains:column "a" specified more than once
 
 ! CREATE MATERIALIZED VIEW t_m_v AS SELECT a, b FROM t AS t(a, a);
-column reference "a" is ambiguous
+contains:column reference "a" is ambiguous
 
 > CREATE MATERIALIZED VIEW t_m_v AS SELECT a, b FROM t;
 > SELECT * FROM t_v;
@@ -56,7 +56,7 @@ column reference "a" is ambiguous
 
 # Regression for #9376
 ! CREATE VIEW gh9376 AS SELECT 1, 2;
-column "?column?" specified more than once
+contains:column "?column?" specified more than once
 
 >CREATE VIEW gh9376 AS SELECT 1;
 > SELECT name FROM mz_columns WHERE id = (SELECT id FROM mz_views WHERE name = 'gh9376');

--- a/test/testdrive/createdrop.td
+++ b/test/testdrive/createdrop.td
@@ -58,16 +58,16 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=34
 # Test that creating objects of the same name does not work
 
 ! CREATE MATERIALIZED VIEW i AS SELECT 1.5 AS c
-catalog item 'i' already exists
+contains:catalog item 'i' already exists
 
 ! CREATE INDEX i ON s("Y")
-catalog item 'i' already exists
+contains:catalog item 'i' already exists
 
 ! CREATE INDEX j on v2(x)
-catalog item 'j' already exists
+contains:catalog item 'j' already exists
 
 ! CREATE INDEX v ON v2(x)
-catalog item 'v' already exists
+contains:catalog item 'v' already exists
 
 $ set dummy={
     "type": "record",
@@ -100,56 +100,56 @@ $ set dummy={
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${dummy}'
   ENVELOPE DEBEZIUM
-catalog item 'v2' already exists
+contains:catalog item 'v2' already exists
 
 ! CREATE SOURCE i
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${dummy}'
   ENVELOPE DEBEZIUM
-catalog item 'i' already exists
+contains:catalog item 'i' already exists
 
 ! CREATE INDEX s ON v2(x)
-catalog item 's' already exists
+contains:catalog item 's' already exists
 
 ! CREATE MATERIALIZED VIEW s AS SELECT 'bloop' AS d
-catalog item 's' already exists
+contains:catalog item 's' already exists
 
 # Test that objects do not get dropped if the drop command does not specify the correct type
 ! DROP SOURCE v
-v is not of type SOURCE
+contains:v is not of type SOURCE
 
 ! DROP SOURCE IF EXISTS v
-v is not of type SOURCE
+contains:v is not of type SOURCE
 
 ! DROP INDEX v
-v is not of type INDEX
+contains:v is not of type INDEX
 
 ! DROP INDEX IF EXISTS v
-v is not of type INDEX
+contains:v is not of type INDEX
 
 ! DROP SOURCE i
-i is not of type SOURCE
+contains:i is not of type SOURCE
 
 ! DROP SOURCE IF EXISTS i
-i is not of type SOURCE
+contains:i is not of type SOURCE
 
 ! DROP VIEW i
-i is not of type VIEW
+contains:i is not of type VIEW
 
 ! DROP VIEW IF EXISTS i
-i is not of type VIEW
+contains:i is not of type VIEW
 
 ! DROP INDEX s
-s is not of type INDEX
+contains:s is not of type INDEX
 
 ! DROP INDEX IF EXISTS s
-s is not of type INDEX
+contains:s is not of type INDEX
 
 ! DROP VIEW s
-s is not of type VIEW
+contains:s is not of type VIEW
 
 ! DROP VIEW IF EXISTS s
-s is not of type VIEW
+contains:s is not of type VIEW
 
 # Delete objects
 
@@ -190,13 +190,13 @@ s is not of type VIEW
 # Test that drop without if exists does not work if the object does not exist
 
 ! DROP INDEX nonexistent
-unknown catalog item 'nonexistent'
+contains:unknown catalog item 'nonexistent'
 
 ! DROP VIEW nonexistent
-unknown catalog item 'nonexistent'
+contains:unknown catalog item 'nonexistent'
 
 ! DROP SOURCE nonexistent
-unknown catalog item 'nonexistent'
+contains:unknown catalog item 'nonexistent'
 
 # Test CREATE VIEW IF NOT EXISTS
 > CREATE MATERIALIZED VIEW IF NOT EXISTS test1 AS SELECT 42 AS a
@@ -207,7 +207,7 @@ View                      "Create View"
 materialize.public.test1  "CREATE VIEW \"materialize\".\"public\".\"test1\" AS SELECT 42 AS \"a\""
 
 ! CREATE MATERIALIZED VIEW test1 AS SELECT 43 AS b
-catalog item 'test1' already exists
+contains:catalog item 'test1' already exists
 
 > SELECT * FROM test1
 a

--- a/test/testdrive/csv-sources.td
+++ b/test/testdrive/csv-sources.td
@@ -19,12 +19,12 @@ place""",CA,92679
   FROM FILE '${testdrive.temp-dir}/static.csv'
   WITH (badoption=true)
   FORMAT CSV WITH 3 COLUMNS
-unexpected parameters for CREATE SOURCE: badoption
+contains:unexpected parameters for CREATE SOURCE: badoption
 
 ! CREATE SOURCE mismatched_column_count
   FROM FILE '${testdrive.temp-dir}/static.csv'
   FORMAT CSV WITH 2 COLUMNS
-Specified column count (WITH 2 COLUMNS) does not match number of columns in CSV file (3)
+contains:Specified column count (WITH 2 COLUMNS) does not match number of columns in CSV file (3)
 
 > CREATE MATERIALIZED SOURCE matching_column_names
   FROM FILE '${testdrive.temp-dir}/static.csv'
@@ -47,12 +47,12 @@ Rochester NY 14618 1
 ! CREATE SOURCE mismatched_column_names
   FROM FILE '${testdrive.temp-dir}/static.csv'
   FORMAT CSV WITH HEADER (cities, country, zip)
-Header columns do not match named columns from CREATE SOURCE statement. First mismatched columns: cities != city
+contains:Header columns do not match named columns from CREATE SOURCE statement. First mismatched columns: cities != city
 
 ! CREATE SOURCE mismatched_column_names_count
   FROM FILE '${testdrive.temp-dir}/static.csv'
   FORMAT CSV WITH HEADER (cities, state)
-Named column count (2) does not match number of columns discovered (3)
+contains:Named column count (2) does not match number of columns discovered (3)
 
 # Static CSV without headers.
 > CREATE MATERIALIZED SOURCE static_csv
@@ -149,10 +149,10 @@ $ file-delete path=deleting.csv
 > CREATE INDEX i ON deleting_csv(city,state,zip)
 
 ! SELECT * FROM deleting_csv
-Source error: materialize.public.deleting_csv: file IO: file source: unable to open file at path
+contains:Source error: materialize.public.deleting_csv: file IO: file source: unable to open file at path
 
 ! CREATE SOURCE should_fail FROM FILE '/'
-/ is a directory.
+contains:/ is a directory.
 
 # Static malformed CSV
 $ file-append path=malformed.csv
@@ -167,7 +167,7 @@ badint,
   FORMAT CSV WITH HEADER
 
 ! SELECT * FROM malformed_csv
-Decode error: Text: CSV error at record number 3: expected 2 columns, got 1.
+contains:Decode error: Text: CSV error at record number 3: expected 2 columns, got 1.
 
 # Static non-utf-8 CSV
 $ file-append path=bad-text.csv
@@ -179,7 +179,7 @@ Dollars,Category
   FORMAT CSV WITH HEADER
 
 ! SELECT * FROM bad_text_csv
-Decode error: Text: CSV error at record number 2: invalid UTF-8
+contains:Decode error: Text: CSV error at record number 2: invalid UTF-8
 
 # CSV file with comma in header
 

--- a/test/testdrive/date_func.td
+++ b/test/testdrive/date_func.td
@@ -13,16 +13,16 @@
 #
 
 ! SELECT EXTRACT(NULL FROM CAST('2011-11-11' AS DATE));
-unit 'null' not recognized
+contains:unit 'null' not recognized
 
 ! SELECT EXTRACT(NULL FROM CAST('11:11:11' AS TIME));
-unit 'null' not recognized
+contains:unit 'null' not recognized
 
 ! SELECT EXTRACT(NULL FROM CAST('2011-11-11' AS TIMESTAMP));
-unit 'null' not recognized
+contains:unit 'null' not recognized
 
 ! SELECT EXTRACT(NULL FROM CAST('2011-11-11' AS TIMESTAMP WITH TIME ZONE));
-unit 'null' not recognized
+contains:unit 'null' not recognized
 
 # NULL is an argument here, so the function returns NULL
 > SELECT DATE_PART(NULL, CAST('2011-11-11' AS DATE)) IS NULL;
@@ -38,55 +38,55 @@ true
 true
 
 ! SELECT EXTRACT('foo' FROM CAST('2011-11-11' AS DATE));
-unit 'foo' not recognized
+contains:unit 'foo' not recognized
 
 ! SELECT EXTRACT('foo' FROM CAST('11:11:11' AS TIME));
-unit 'foo' not recognized
+contains:unit 'foo' not recognized
 
 ! SELECT EXTRACT('foo' FROM CAST('2011-11-11' AS TIMESTAMP));
-unit 'foo' not recognized
+contains:unit 'foo' not recognized
 
 ! SELECT EXTRACT('foo' FROM CAST('2011-11-11' AS TIMESTAMP WITH TIME ZONE));
-unit 'foo' not recognized
+contains:unit 'foo' not recognized
 
 
 ! SELECT DATE_PART('foo', CAST('2011-11-11' AS DATE));
-unit 'foo' not recognized
+contains:unit 'foo' not recognized
 
 ! SELECT DATE_PART('foo', CAST('11:11:11' AS TIME));
-unit 'foo' not recognized
+contains:unit 'foo' not recognized
 
 ! SELECT DATE_PART('foo', CAST('2011-11-11' AS TIMESTAMP));
-unit 'foo' not recognized
+contains:unit 'foo' not recognized
 
 ! SELECT DATE_PART('foo', CAST('2011-11-11' AS TIMESTAMP WITH TIME ZONE));
-unit 'foo' not recognized
+contains:unit 'foo' not recognized
 
 
 ! SELECT EXTRACT('' FROM CAST('2011-11-11' AS DATE));
-unit '' not recognized
+contains:unit '' not recognized
 
 ! SELECT EXTRACT('' FROM CAST('11:11:11' AS TIME));
-unit '' not recognized
+contains:unit '' not recognized
 
 ! SELECT EXTRACT('' FROM CAST('2011-11-11' AS TIMESTAMP));
-unit '' not recognized
+contains:unit '' not recognized
 
 ! SELECT EXTRACT('' FROM CAST('2011-11-11' AS TIMESTAMP WITH TIME ZONE));
-unit '' not recognized
+contains:unit '' not recognized
 
 
 ! SELECT DATE_PART('', CAST('2011-11-11' AS DATE));
-unit '' not recognized
+contains:unit '' not recognized
 
 ! SELECT DATE_PART('', CAST('11:11:11' AS TIME));
-unit '' not recognized
+contains:unit '' not recognized
 
 ! SELECT DATE_PART('', CAST('2011-11-11' AS TIMESTAMP));
-unit '' not recognized
+contains:unit '' not recognized
 
 ! SELECT DATE_PART('', CAST('2011-11-11' AS TIMESTAMP WITH TIME ZONE));
-unit '' not recognized
+contains:unit '' not recognized
 
 
 > SELECT EXTRACT('second' FROM CAST('2011-11-11' AS DATE));

--- a/test/testdrive/decimal-overflow.td
+++ b/test/testdrive/decimal-overflow.td
@@ -18,28 +18,28 @@
 
 # Division creates a number that is too small
 ! SELECT '0.000000000000000000000000000000000000001'::decimal / 10::decimal;
-value out of range: underflow
+contains:value out of range: underflow
 
 # Division creates a number that is too large
 ! SELECT '999999999999999999999999999999999999999'::decimal / 0.1::decimal;
-value out of range: overflow
+contains:value out of range: overflow
 
 # Multilication creates a number that is too small
 ! SELECT '0.000000000000000000000000000000000000001'::decimal * 0.1::decimal;
-value out of range: underflow
+contains:value out of range: underflow
 
 # Multiplication creates a number that is too large
 ! SELECT '999999999999999999999999999999999999999'::decimal * 10::decimal;
-value out of range: overflow
+contains:value out of range: overflow
 
 # ROUND creates a value that is too large
 ! SELECT ROUND('999999999999999999999999999999999999999'::decimal,1);
-value out of range: overflow
+contains:value out of range: overflow
 
 # POW
 ! SELECT POW(99999::decimal,9);
-value out of range: overflow
+contains:value out of range: overflow
 
 # Conversion from double
 ! SELECT 999999999999999999999999999999999999999::double::decimal;
-numeric field overflow
+contains:numeric field overflow

--- a/test/testdrive/decimal-zero.td
+++ b/test/testdrive/decimal-zero.td
@@ -34,7 +34,7 @@
 25
 
 ! SELECT 123 / '-0'::decimal;
-division by zero
+contains:division by zero
 
 > SELECT '0.000000000000000000000000000000000000001'::decimal - '0.000000000000000000000000000000000000001'::decimal = 0;
 true
@@ -49,7 +49,7 @@ true
 0
 
 ! SELECT '0.000000000000000000000000000000000000001'::decimal * '-0.000000000000000000000000000000000000001'::decimal;
-value out of range: underflow
+contains:value out of range: underflow
 
 ! SELECT '0.1'::decimal / 999999999999999999999999999999999999999::decimal;
-value out of range: underflow
+contains:value out of range: underflow

--- a/test/testdrive/delete-using.td
+++ b/test/testdrive/delete-using.td
@@ -16,11 +16,11 @@
 > CREATE TABLE t3 (f1 INTEGER);
 
 ! DELETE FROM t1 USING t1;
-table name "t1" specified more than once
+contains:table name "t1" specified more than once
 
 # Ambiguous column name
 ! DELETE FROM t1 USING t2 WHERE f1 = 1;
-column reference "f1" is ambiguous
+contains:column reference "f1" is ambiguous
 
 #
 # Self-join

--- a/test/testdrive/dependencies.td
+++ b/test/testdrive/dependencies.td
@@ -41,7 +41,7 @@ $ set schema={
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-blah-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE DEBEZIUM
-catalog item 's' already exists
+contains:catalog item 's' already exists
 
 > CREATE SOURCE IF NOT EXISTS s
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-blah-${testdrive.seed}'
@@ -57,23 +57,23 @@ catalog item 's' already exists
 > CREATE MATERIALIZED VIEW test3b AS SELECT * FROM test2;
 
 ! DROP VIEW test1;
-cannot drop materialize.public.test1: still depended upon by catalog item 'materialize.public.test2'
+contains:cannot drop materialize.public.test1: still depended upon by catalog item 'materialize.public.test2'
 
 ! DROP VIEW test2;
-cannot drop materialize.public.test2: still depended upon by catalog item 'materialize.public.test3a'
+contains:cannot drop materialize.public.test2: still depended upon by catalog item 'materialize.public.test3a'
 
 > DROP VIEW test3a;
 
 ! DROP VIEW test1;
-cannot drop materialize.public.test1: still depended upon by catalog item 'materialize.public.test2'
+contains:cannot drop materialize.public.test1: still depended upon by catalog item 'materialize.public.test2'
 
 ! DROP VIEW test2;
-cannot drop materialize.public.test2: still depended upon by catalog item 'materialize.public.test3b'
+contains:cannot drop materialize.public.test2: still depended upon by catalog item 'materialize.public.test3b'
 
 > DROP VIEW test3b;
 
 ! DROP VIEW test1;
-cannot drop materialize.public.test1: still depended upon by catalog item 'materialize.public.test2'
+contains:cannot drop materialize.public.test1: still depended upon by catalog item 'materialize.public.test2'
 
 > DROP VIEW test2;
 
@@ -93,10 +93,10 @@ cannot drop materialize.public.test1: still depended upon by catalog item 'mater
 # rather than verifying the drop by checking whether DROP VIEW fails.
 
 ! DROP VIEW test1;
-unknown catalog item 'test1'
+contains:unknown catalog item 'test1'
 
 ! DROP VIEW test2;
-unknown catalog item 'test2'
+contains:unknown catalog item 'test2'
 
 # Test that DROP VIEW IF EXISTS succeeds even if the view does not exist.
 
@@ -110,7 +110,7 @@ unknown catalog item 'test2'
 > DROP SOURCE s CASCADE;
 
 ! DROP VIEW test4;
-unknown catalog item 'test4'
+contains:unknown catalog item 'test4'
 
 > CREATE SOURCE s
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
@@ -124,7 +124,7 @@ unknown catalog item 'test4'
 ! CREATE SINK s1 FROM s
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'v'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-catalog item 's1' already exists
+contains:catalog item 's1' already exists
 
 > CREATE SINK IF NOT EXISTS s1 FROM s
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'v2'
@@ -136,7 +136,7 @@ catalog item 's1' already exists
 
 # Test that sinks cannot be depended upon.
 ! CREATE MATERIALIZED VIEW v2 AS SELECT * FROM s1;
-catalog item 'materialize.public.s1' is a sink and so cannot be depended upon
+contains:catalog item 'materialize.public.s1' is a sink and so cannot be depended upon
 
 > CREATE MATERIALIZED VIEW v2 AS SELECT X from s;
 
@@ -147,7 +147,7 @@ catalog item 'materialize.public.s1' is a sink and so cannot be depended upon
 # Test that indexes cannot be depended upon
 
 ! CREATE MATERIALIZED VIEW v3 as SELECT * FROM i1;
-catalog item 'materialize.public.i1' is an index and so cannot be depended upon
+contains:catalog item 'materialize.public.i1' is an index and so cannot be depended upon
 
 > CREATE INDEX i2 ON v2a(x*2);
 
@@ -168,7 +168,7 @@ v2       v2_primary_idx  1            x           <null>     false    true
 > DROP VIEW v2a;
 
 ! DROP VIEW v2a;
-unknown catalog item 'v2a'
+contains:unknown catalog item 'v2a'
 
 > SHOW INDEX in v2;
 on_name  key_name        seq_in_index   column_name expression nullable enabled
@@ -177,7 +177,7 @@ v2       i1              1              x           <null>     false    true
 v2       v2_primary_idx  1              x           <null>     false    true
 
 ! DROP INDEX i2;
-unknown catalog item 'i2'
+contains:unknown catalog item 'i2'
 
 > CREATE MATERIALIZED VIEW v4 AS SELECT x, y from s;
 
@@ -204,10 +204,10 @@ v4       v4_primary_idx  2             y           <null>     false     true
 > DROP VIEW v4a CASCADE;
 
 ! DROP VIEW v4a;
-unknown catalog item 'v4a'
+contains:unknown catalog item 'v4a'
 
 ! DROP INDEX i3;
-unknown catalog item 'i3'
+contains:unknown catalog item 'i3'
 
 > SHOW INDEX in v4;
 on_name  key_name        seq_in_index  column_name expression nullable  enabled
@@ -244,16 +244,16 @@ multicol  i6        2            a            <null>       false    true
 > DROP VIEW v4 CASCADE;
 
 ! DROP VIEW v4;
-unknown catalog item 'v4'
+contains:unknown catalog item 'v4'
 
 ! DROP INDEX i5;
-unknown catalog item 'i5'
+contains:unknown catalog item 'i5'
 
 ! DROP VIEW v5;
-unknown catalog item 'v5'
+contains:unknown catalog item 'v5'
 
 ! DROP INDEX i4;
-unknown catalog item 'i4'
+contains:unknown catalog item 'i4'
 
 # Test that dropping indexes even with cascade does not cause the underlying view to be dropped
 
@@ -281,10 +281,10 @@ s3       s3_primary_idx  2             y           <null>                 false 
 > DROP SOURCE s3;
 
 ! DROP SOURCE s3;
-unknown catalog item 's3'
+contains:unknown catalog item 's3'
 
 ! DROP INDEX j1;
-unknown catalog item 'j1'
+contains:unknown catalog item 'j1'
 
 # Test cascade deletes all indexes associated with cascaded sources and views
 
@@ -314,16 +314,16 @@ w        j3         1             z           <null>     false    true
 > DROP SOURCE s4 CASCADE;
 
 ! DROP VIEW w;
-unknown catalog item 'w'
+contains:unknown catalog item 'w'
 
 ! DROP INDEX j3;
-unknown catalog item 'j3'
+contains:unknown catalog item 'j3'
 
 ! DROP SOURCE s4;
-unknown catalog item 's4'
+contains:unknown catalog item 's4'
 
 ! DROP INDEX j2;
-unknown catalog item 'j2'
+contains:unknown catalog item 'j2'
 
 # Test that dropping indexes even with cascade does not cause the underlying source to be dropped
 
@@ -342,14 +342,14 @@ unknown catalog item 'j2'
 > CREATE VIEW v1 AS SELECT CAST('{2}' AS int4_list)
 
 ! DROP TYPE int4_list
-cannot drop materialize.public.int4_list: still depended upon by catalog item 'materialize.public.v1'
+contains:cannot drop materialize.public.int4_list: still depended upon by catalog item 'materialize.public.v1'
 
 > DROP VIEW v1
 
 > CREATE TABLE t1 (custom int4_list)
 
 ! DROP TYPE int4_list
-cannot drop materialize.public.int4_list: still depended upon by catalog item 'materialize.public.t1'
+contains:cannot drop materialize.public.int4_list: still depended upon by catalog item 'materialize.public.t1'
 
 > DROP TABLE t1
 
@@ -358,28 +358,28 @@ cannot drop materialize.public.int4_list: still depended upon by catalog item 'm
 > CREATE MATERIALIZED VIEW v1 AS SELECT * FROM ( SELECT CAST('{2}' AS int4_list) )
 
 ! DROP TYPE int4_list
-cannot drop materialize.public.int4_list: still depended upon by catalog item 'materialize.public.v1'
+contains:cannot drop materialize.public.int4_list: still depended upon by catalog item 'materialize.public.v1'
 
 > DROP VIEW v1
 
 > CREATE VIEW v1 AS SELECT CAST(CAST('{2}' AS int4_list) AS text)
 
 ! DROP TYPE int4_list
-cannot drop materialize.public.int4_list: still depended upon by catalog item 'materialize.public.v1'
+contains:cannot drop materialize.public.int4_list: still depended upon by catalog item 'materialize.public.v1'
 
 > DROP VIEW v1
 
 > CREATE VIEW v1 AS VALUES (CAST('{2}' AS int4_list))
 
 ! DROP TYPE int4_list
-cannot drop materialize.public.int4_list: still depended upon by catalog item 'materialize.public.v1'
+contains:cannot drop materialize.public.int4_list: still depended upon by catalog item 'materialize.public.v1'
 
 > DROP VIEW v1
 
 > CREATE VIEW v1 AS SELECT MIN(CAST(CAST('{1}' AS int4_list) AS string))
 
 ! DROP TYPE int4_list
-cannot drop materialize.public.int4_list: still depended upon by catalog item 'materialize.public.v1'
+contains:cannot drop materialize.public.int4_list: still depended upon by catalog item 'materialize.public.v1'
 
 > DROP VIEW v1
 
@@ -390,7 +390,7 @@ cannot drop materialize.public.int4_list: still depended upon by catalog item 'm
 > CREATE TEMPORARY TABLE t1 (f1 int4_list)
 
 ! DROP TYPE int4_list
-cannot drop materialize.public.int4_list: still depended upon by catalog item 'mz_temp.t1'
+contains:cannot drop materialize.public.int4_list: still depended upon by catalog item 'mz_temp.t1'
 
 > DROP TABLE t1
 
@@ -399,14 +399,14 @@ cannot drop materialize.public.int4_list: still depended upon by catalog item 'm
 > CREATE INDEX i1 ON t1 (CAST(f1 AS int4_list))
 
 ! DROP TYPE int4_list
-cannot drop materialize.public.int4_list: still depended upon by catalog item 'materialize.public.i1'
+contains:cannot drop materialize.public.int4_list: still depended upon by catalog item 'materialize.public.i1'
 
 > DROP TABLE t1
 
 > CREATE TYPE int4_list_list AS LIST (element_type=int4_list)
 
 ! DROP TYPE int4_list
-cannot drop materialize.public.int4_list: still depended upon by catalog item 'materialize.public.int4_list_list'
+contains:cannot drop materialize.public.int4_list: still depended upon by catalog item 'materialize.public.int4_list_list'
 
 > DROP TYPE int4_list_list
 
@@ -432,7 +432,7 @@ cannot drop materialize.public.int4_list: still depended upon by catalog item 'm
 2
 
 ! CREATE OR REPLACE MATERIALIZED VIEW v3 AS SELECT 3
-cannot drop materialize.public.v3: still depended upon by catalog item 'materialize.public.v4'
+contains:cannot drop materialize.public.v3: still depended upon by catalog item 'materialize.public.v4'
 
 > CREATE OR REPLACE MATERIALIZED VIEW v4 AS SELECT 3
 > SELECT * FROM v4
@@ -452,7 +452,7 @@ cannot drop materialize.public.v3: still depended upon by catalog item 'material
 > CREATE MATERIALIZED VIEW test2 AS SELECT * FROM test1;
 
 ! DROP VIEW test1;
-cannot drop materialize.public.test1: still depended upon by catalog item 'materialize.public.test2'
+contains:cannot drop materialize.public.test1: still depended upon by catalog item 'materialize.public.test2'
 
 # Succeeds even though it's dependent on.
 > CREATE MATERIALIZED VIEW IF NOT EXISTS test1 AS SELECT 2 as b;

--- a/test/testdrive/disabled/kinesis.td
+++ b/test/testdrive/disabled/kinesis.td
@@ -23,7 +23,7 @@ here's a test string
   WITH (access_key_id = 'fake_access_key',
         secret_access_key = 'fake_secret_access_key')
   FORMAT BYTES;
-If providing a custom region, an `endpoint` option must also be provided
+contains:If providing a custom region, an `endpoint` option must also be provided
 
 > CREATE SOURCE f
   FROM KINESIS ARN 'arn:aws:kinesis:${testdrive.aws-region}:${testdrive.aws-account}:stream/testdrive-test-${testdrive.seed}'

--- a/test/testdrive/drop.td
+++ b/test/testdrive/drop.td
@@ -19,6 +19,6 @@
 # https://github.com/MaterializeInc/materialize/issues/5272
 > CREATE VIEW v2 AS SELECT 1
 ! CREATE OR REPLACE VIEW v2 AS SELECT * FROM v2
-cannot replace view materialize.public.v2: depended upon by new materialize.public.v2 definition
+contains:cannot replace view materialize.public.v2: depended upon by new materialize.public.v2 definition
 ! CREATE OR REPLACE MATERIALIZED VIEW v2 AS SELECT * FROM v2
-cannot replace view materialize.public.v2: depended upon by new materialize.public.v2 definition
+contains:cannot replace view materialize.public.v2: depended upon by new materialize.public.v2 definition

--- a/test/testdrive/duplicate-table-names.td
+++ b/test/testdrive/duplicate-table-names.td
@@ -30,53 +30,53 @@ c c
 
 # joined tables collide
 ! SELECT * FROM a, a;
-table name "a" specified more than once
+contains:table name "a" specified more than once
 
 ! SELECT * FROM b, (SELECT * FROM a, a);
-table name "a" specified more than once
+contains:table name "a" specified more than once
 
 ! SELECT * FROM other.a, other.a;
-table name "a" specified more than once
+contains:table name "a" specified more than once
 
 ! SELECT * FROM a LEFT JOIN a ON TRUE;
-table name "a" specified more than once
+contains:table name "a" specified more than once
 
 ! SELECT * FROM (a NATURAL JOIN b) NATURAL JOIN a;
-table name "a" specified more than once
+contains:table name "a" specified more than once
 
 ! SELECT * FROM (a NATURAL JOIN b) NATURAL JOIN b;
-table name "b" specified more than once
+contains:table name "b" specified more than once
 
 ! DELETE FROM a USING a;
-table name "a" specified more than once
+contains:table name "a" specified more than once
 
 # alias introduces collision
 ! SELECT * FROM a, b AS a;
-table name "a" specified more than once
+contains:table name "a" specified more than once
 
 ! SELECT * FROM a, other.a AS a;
-table name "a" specified more than once
+contains:table name "a" specified more than once
 
 ! SELECT * FROM a AS z, b AS z;
-table name "z" specified more than once
+contains:table name "z" specified more than once
 
 ! SELECT * FROM a, (SELECT * FROM a) AS a;
-table name "a" specified more than once
+contains:table name "a" specified more than once
 
 # table function names
 ! SELECT * FROM generate_series, generate_series(1,2)
-table name "generate_series" specified more than once
+contains:table name "generate_series" specified more than once
 
 ! SELECT * FROM a AS generate_series, generate_series(1,2)
-table name "generate_series" specified more than once
+contains:table name "generate_series" specified more than once
 
 ! SELECT * FROM generate_series AS a, generate_series(1,2) AS a
-table name "a" specified more than once
+contains:table name "a" specified more than once
 
 ! SELECT * FROM a, generate_series(1,2) AS a
-table name "a" specified more than once
+contains:table name "a" specified more than once
 
 # CTEs
 
 ! WITH a AS (SELECT 1) SELECT * FROM a, a;
-table name "a" specified more than once
+contains:table name "a" specified more than once

--- a/test/testdrive/esoteric/kinesis.td
+++ b/test/testdrive/esoteric/kinesis.td
@@ -27,7 +27,7 @@ here is a second test string
   WITH (access_key_id = 'fake_access_key_id',
         secret_access_key = 'fake_secret_access_key')
   FORMAT BYTES;
-dns error: failed to lookup address information: Name or service not known
+contains:dns error: failed to lookup address information: Name or service not known
 
 > CREATE SOURCE f
   FROM KINESIS ARN 'arn:aws:kinesis:${testdrive.aws-region}:${testdrive.aws-account}:stream/testdrive-test-${testdrive.seed}'

--- a/test/testdrive/esoteric/s3-sqs-reject-multiple-materializations.td
+++ b/test/testdrive/esoteric/s3-sqs-reject-multiple-materializations.td
@@ -34,7 +34,7 @@ $ s3-add-notifications bucket=${buk} queue=${buk} sqs-validation-timeout=5m
 
 ! CREATE MATERIALIZED VIEW s3_double_mat_error AS
   SELECT * FROM s3_double_mat
-Cannot re-materialize source s3_double_mat
+contains:Cannot re-materialize source s3_double_mat
 
 # check that going through multiple unmaterialized views doesn't allow hiding from the error
 > CREATE VIEW s3_double_mat_unmaterialized AS
@@ -45,7 +45,7 @@ Cannot re-materialize source s3_double_mat
 
 ! CREATE MATERIALIZED VIEW s3_double_mat_unmaterialized_final AS
   SELECT * FROM s3_double_mat_unmaterialized_extra
-Cannot re-materialize source s3_double_mat
+contains:Cannot re-materialize source s3_double_mat
 
 # check that dropping and recreating a view succeeds
 
@@ -73,7 +73,7 @@ Cannot re-materialize source s3_double_mat
 
 ! CREATE MATERIALIZED VIEW s3_double_mat_error AS
   SELECT * FROM s3_double_mat
-Cannot re-materialize source s3_double_mat
+contains:Cannot re-materialize source s3_double_mat
 
 > CREATE VIEW s3_double_mat_unmaterialized_3 AS
   SELECT * FROM s3_double_mat
@@ -83,16 +83,16 @@ Cannot re-materialize source s3_double_mat
 
 ! CREATE MATERIALIZED VIEW s3_double_mat_error_3 AS
   SELECT * FROM s3_double_mat_unmaterialized_extra_3
-Cannot re-materialize source s3_double_mat
+contains:Cannot re-materialize source s3_double_mat
 
 ! CREATE INDEX s3_double_mat_custom_idx ON s3_double_mat (text)
-Cannot re-materialize source s3_double_mat
+contains:Cannot re-materialize source s3_double_mat
 
 ! CREATE DEFAULT INDEX ON s3_double_mat
-Cannot re-materialize source s3_double_mat
+contains:Cannot re-materialize source s3_double_mat
 
 ! CREATE SINK invalid_double_mat_sink FROM s3_double_mat
   INTO KAFKA BROKER '${testdrive.kafka-addr}'
   TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-Cannot re-materialize source s3_double_mat
+contains:Cannot re-materialize source s3_double_mat

--- a/test/testdrive/failpoints.td
+++ b/test/testdrive/failpoints.td
@@ -11,9 +11,9 @@
 # Basic sanity checks around the SET failpoints syntax
 
 ! SET failpoints = 'a';
-parameter "failpoints" cannot have value "a": missing failpoint action
+contains:parameter "failpoints" cannot have value "a": missing failpoint action
 
 ! SET failpoints = 'a=1';
-parameter "failpoints" cannot have value "a=1": unrecognized command "1"
+contains:parameter "failpoints" cannot have value "a=1": unrecognized command "1"
 
 > SET failpoints = 'a=off';

--- a/test/testdrive/fetch-tail-as-of.td
+++ b/test/testdrive/fetch-tail-as-of.td
@@ -22,7 +22,7 @@ $ set-regex match=\d{13} replacement=<TIMESTAMP>
 > DECLARE c CURSOR FOR TAIL t1 AS OF -1;
 
 ! FETCH 1 c;
-out of range integral type conversion attempted
+contains:out of range integral type conversion attempted
 
 > COMMIT
 
@@ -31,14 +31,14 @@ out of range integral type conversion attempted
 # (which will happen after t has been compacted) and then we should be
 # able to see the same failure with FETCH.
 ! SELECT * FROM t1 AS OF 0
-Timestamp (0) is not valid for all inputs
+contains:Timestamp (0) is not valid for all inputs
 
 > BEGIN
 
 > DECLARE c CURSOR FOR TAIL t1 AS OF 0;
 
 ! FETCH 1 c;
-Timestamp (0) is not valid for all inputs
+contains:Timestamp (0) is not valid for all inputs
 
 > COMMIT
 

--- a/test/testdrive/frontier-advance-multiple-views.td
+++ b/test/testdrive/frontier-advance-multiple-views.td
@@ -25,10 +25,10 @@
 # the frontier
 
 ! SELECT * FROM t1 AS OF NOW() - INTERVAL '1 second';
-is not valid for all inputs
+contains:is not valid for all inputs
 
 ! SELECT * FROM v1 AS OF NOW() - INTERVAL '1 second';
-is not valid for all inputs
+contains:is not valid for all inputs
 
 ! SELECT * FROM v2 AS OF NOW() - INTERVAL '1 second';
-is not valid for all inputs
+contains:is not valid for all inputs

--- a/test/testdrive/github-6950.td
+++ b/test/testdrive/github-6950.td
@@ -10,4 +10,4 @@
 # Regression test for https://github.com/MaterializeInc/materialize/issues/6950
 
 ! CREATE TEMPORARY MATERIALIZED VIEW IF NOT EXISTS some_schema.v1 AS SELECT 1;
-cannot create temporary item in non-temporary schema
+contains:cannot create temporary item in non-temporary schema

--- a/test/testdrive/github-7706.td
+++ b/test/testdrive/github-7706.td
@@ -23,10 +23,10 @@ $ set schema={
   FORMAT AVRO USING SCHEMA '${schema}'
 
 ! SELECT * FROM s AS OF 0
-Timestamp (0) is not valid for all inputs
+contains:Timestamp (0) is not valid for all inputs
 
 ! SELECT * FROM s AS OF now() - '10s'::interval
-Timestamp (<TIMESTAMP>) is not valid for all inputs
+contains:Timestamp (<TIMESTAMP>) is not valid for all inputs
 
 # Although not the original issue, also test that AS OF does work on an
 # unmaterialized source if the timestamp is queryable.

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -226,7 +226,7 @@ foo  foo_expr_idx      1  <null>  "a + b"         true  true
 #   SHOW INDEXES FROM v LIKE '%v'
 
 ! SHOW INDEX FROM nonexistent
-unknown catalog item 'nonexistent'
+contains:unknown catalog item 'nonexistent'
 
 ! SHOW INDEX FROM foo_primary_idx
-cannot show indexes on materialize.public.foo_primary_idx because it is a index
+contains:cannot show indexes on materialize.public.foo_primary_idx because it is a index

--- a/test/testdrive/insert-select.td
+++ b/test/testdrive/insert-select.td
@@ -43,7 +43,7 @@
 ! INSERT INTO t SELECT * FROM (
     VALUES ('11', '12', 'f')
   );
-column "i" is of type integer but expression is of type text
+contains:column "i" is of type integer but expression is of type text
 
 > BEGIN
 
@@ -52,7 +52,7 @@ column "i" is of type integer but expression is of type text
 ! INSERT INTO t SELECT * FROM (
     VALUES (13, 14, 'g')
   );
-cannot be run inside a transaction block
+contains:cannot be run inside a transaction block
 
 > COMMIT
 
@@ -68,14 +68,14 @@ cannot be run inside a transaction block
 ! INSERT INTO t SELECT * FROM (
     VALUES (11, 12, 'f')
   );
-cannot be run inside a transaction block
+contains:cannot be run inside a transaction block
 
 > COMMIT
 
 > CREATE MATERIALIZED VIEW v (a, b, c) AS SELECT 11, 12::real, 'f';
 
 ! INSERT INTO t SELECT * FROM v;
-invalid selection
+contains:invalid selection
 
 # Table check descends into select targets
 ! INSERT INTO t (i, f, t) SELECT column1, column2, column3
@@ -84,7 +84,7 @@ invalid selection
         SELECT a, b, c FROM v
     ) AS y
     ON y.a = column1
-invalid selection
+contains:invalid selection
 
 # Multiple connections
 

--- a/test/testdrive/joins.td
+++ b/test/testdrive/joins.td
@@ -235,7 +235,7 @@ names_num names_name mods_num mods_mod
   SELECT * FROM names FULL OUTER JOIN mods_unmat ON 1 = 0;
 
 ! SELECT * FROM test15;
-unable to automatically determine a query timestamp
+contains:unable to automatically determine a query timestamp
 
 ! SELECT * FROM names FULL OUTER JOIN mods_unmat ON 1 = 0;
-unable to automatically determine a query timestamp
+contains:unable to automatically determine a query timestamp

--- a/test/testdrive/kafka-avro-sinks.td
+++ b/test/testdrive/kafka-avro-sinks.td
@@ -128,28 +128,28 @@ $ kafka-verify format=avro sink=materialize.public.namespace_key_value_sink sort
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'input-sink' KEY (a, a)
   FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-Repeated column name in sink key: a
+contains:Repeated column name in sink key: a
 
 ! CREATE SINK bad_sink FROM input
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'input-sink'
   WITH (avro_value_fullname = 'some.neat.class.foo', avro_key_fullname = 'some.neat.class.bar')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-Cannot specify avro_key_fullname without a corresponding KEY field
+contains:Cannot specify avro_key_fullname without a corresponding KEY field
 
 ! CREATE SINK bad_sink FROM input
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'input-sink'
   WITH (avro_key_fullname = 'some.neat.class.bar')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-Cannot specify avro_key_fullname without a corresponding KEY field
+contains:Cannot specify avro_key_fullname without a corresponding KEY field
 
 ! CREATE SINK bad_sink FROM input
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'input-sink' KEY (a)
   WITH (avro_key_fullname = 'some.neat.class.bar')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-Must specify both avro_key_fullname and avro_value_fullname when specifying generated schema names
+contains:Must specify both avro_key_fullname and avro_value_fullname when specifying generated schema names
 
 ! CREATE SINK bad_sink FROM input
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'input-sink' KEY (a)
   WITH (avro_value_fullname = 'some.neat.class.bar')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-Must specify both avro_key_fullname and avro_value_fullname when specifying generated schema names
+contains:Must specify both avro_key_fullname and avro_value_fullname when specifying generated schema names

--- a/test/testdrive/kafka-avro-sources.td
+++ b/test/testdrive/kafka-avro-sources.td
@@ -118,7 +118,7 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
   )
   FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE DEBEZIUM
-unexpected parameters for CREATE SOURCE: badoption
+contains:unexpected parameters for CREATE SOURCE: badoption
 
 > SHOW SOURCES
 name
@@ -175,7 +175,7 @@ a  b  json                     c            d             e                   f
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA FILE 'data-schema.json'
   ENVELOPE DEBEZIUM
-No such file or directory
+contains:No such file or directory
 
 $ file-append path=data-schema.json
 \${schema}
@@ -233,7 +233,7 @@ a b
   FORMAT AVRO USING SCHEMA '${non-dbz-schema}'
   INCLUDE TOPIC
   ENVELOPE NONE
-INCLUDE TOPIC not yet supported
+contains:INCLUDE TOPIC not yet supported
 
 > CREATE MATERIALIZED SOURCE non_dbz_data_metadata
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-non-dbz-data-${testdrive.seed}'
@@ -537,14 +537,14 @@ $ kafka-ingest format=avro key-format=avro topic=invalid-keyed-dbz-data schema=$
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-invalid-keyed-dbz-data-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE DEBEZIUM
-Cannot use key due to error: Value schema missing primary key column: c
+contains:Cannot use key due to error: Value schema missing primary key column: c
 
 ! CREATE MATERIALIZED SOURCE invalid_keyed_dbz_with_dedup
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-invalid-keyed-dbz-data-${testdrive.seed}'
   WITH (deduplication = 'full')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE DEBEZIUM
-Cannot use key due to error: Value schema missing primary key column: c
+contains:Cannot use key due to error: Value schema missing primary key column: c
 
 ! CREATE MATERIALIZED SOURCE invalid_keyed_dbz_with_range_dedup
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-invalid-keyed-dbz-data-${testdrive.seed}'
@@ -555,7 +555,7 @@ Cannot use key due to error: Value schema missing primary key column: c
   )
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE DEBEZIUM
-Cannot use key due to error: Value schema missing primary key column: c
+contains:Cannot use key due to error: Value schema missing primary key column: c
 
 # Test that deduplication=full_in_range accepts mis-ordered debezium data in the range
 
@@ -633,7 +633,7 @@ a b
 ! CREATE SOURCE recursive
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'ignored'
   FORMAT AVRO USING SCHEMA '{"type":"record","name":"a","fields":[{"name":"f","type":["a","null"]}]}'
-validating avro schema: Recursive types are not supported: .a
+contains:validating avro schema: Recursive types are not supported: .a
 
 $ set key-schema={"type": "string"}
 $ set value-schema={"type": "record", "name": "r", "fields": [{"name": "a", "type": "string"}]}

--- a/test/testdrive/kafka-avro-upsert-sinks.td
+++ b/test/testdrive/kafka-avro-upsert-sinks.td
@@ -275,13 +275,13 @@ $ kafka-create-topic topic=non-keyed-input
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'input-sink' KEY (a)
   WITH (consistency_topic = true) FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' ENVELOPE UPSERT
-Invalid upsert key: (a), there are no valid keys
+contains:Invalid upsert key: (a), there are no valid keys
 
 ! CREATE SINK another_invalid_key FROM input_keyed
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'input-sink' KEY (b)
   WITH (consistency_topic = true) FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' ENVELOPE UPSERT
-Invalid upsert key: (b), valid keys are: (a)
+contains:Invalid upsert key: (b), valid keys are: (a)
 
 > CREATE VIEW input_keyed_ab AS SELECT a, b FROM input GROUP BY a, b
 
@@ -289,22 +289,22 @@ Invalid upsert key: (b), valid keys are: (a)
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'input-sink' KEY (a)
   WITH (consistency_topic = true) FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' ENVELOPE UPSERT
-Invalid upsert key: (a), valid keys are: (a, b)
+contains:Invalid upsert key: (a), valid keys are: (a, b)
 
 ! CREATE SINK another_invalid_sub_key FROM input_keyed_ab
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'input-sink' KEY (b)
   WITH (consistency_topic = true) FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' ENVELOPE UPSERT
-Invalid upsert key: (b), valid keys are: (a, b)
+contains:Invalid upsert key: (b), valid keys are: (a, b)
 
 ! CREATE SINK invalid_key_from_upsert_input FROM upsert_input
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'data-sink'
   KEY (key1)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' ENVELOPE UPSERT
-Invalid upsert key: (key1), valid keys are: (key1, key2)
+contains:Invalid upsert key: (key1), valid keys are: (key1, key2)
 
 ! CREATE SINK invalid_key_from_upsert_input FROM upsert_input
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'data-sink'
   KEY (key2)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' ENVELOPE UPSERT
-Invalid upsert key: (key2), valid keys are: (key1, key2)
+contains:Invalid upsert key: (key2), valid keys are: (key1, key2)

--- a/test/testdrive/kafka-exactly-once-sink.td
+++ b/test/testdrive/kafka-exactly-once-sink.td
@@ -108,7 +108,7 @@ New York,NY,10004
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output3-view-${testdrive.seed}'
   WITH (reuse_topic=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-reuse_topic requires that sink input dependencies are sources, materialize.public.input_table is not
+contains:reuse_topic requires that sink input dependencies are sources, materialize.public.input_table is not
 
 > CREATE SINK output4 FROM input_kafka_byo_mview
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output4-view-${testdrive.seed}'
@@ -134,19 +134,19 @@ reuse_topic requires that sink input dependencies are sources, materialize.publi
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output6-view-${testdrive.seed}'
   WITH (reuse_topic=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-reuse_topic requires that sink input dependencies are sources, materialize.public.input_table is not
+contains:reuse_topic requires that sink input dependencies are sources, materialize.public.input_table is not
 
 ! CREATE SINK output7 FROM input_values_view
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output7-view-${testdrive.seed}'
   WITH (reuse_topic=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-reuse_topic requires that sink input dependencies are sources, materialize.public.input_values_view is not
+contains:reuse_topic requires that sink input dependencies are sources, materialize.public.input_values_view is not
 
 ! CREATE SINK output8 FROM input_values_mview
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output8-view-${testdrive.seed}'
   WITH (reuse_topic=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-reuse_topic requires that sink input dependencies are sources, materialize.public.input_values_mview is not
+contains:reuse_topic requires that sink input dependencies are sources, materialize.public.input_values_mview is not
 
 > CREATE SINK output12 FROM input_kafka_no_byo_derived_table
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output12-view-${testdrive.seed}'
@@ -237,7 +237,7 @@ $ kafka-verify format=avro sink=materialize.public.rt_binding_consistency_test_s
   CONSISTENCY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   WITH (consistency_topic='willfail')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-Expected TOPIC, found FORMAT
+contains:Expected TOPIC, found FORMAT
 
 # Can't provide CONSISTENCY FORMAT and consistency_topic WITH option
 ! CREATE SINK double_avro FROM simple_view
@@ -245,14 +245,14 @@ Expected TOPIC, found FORMAT
     CONSISTENCY TOPIC 'topicname'
     WITH (consistency_topic='willfail')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-Cannot specify consistency_topic and CONSISTENCY options simultaneously
+contains:Cannot specify consistency_topic and CONSISTENCY options simultaneously
 
 # Can't create sinks with JSON-encoded consistency topics
 ! CREATE SINK double_avro FROM simple_view
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'double-avro'
     CONSISTENCY TOPIC 'consistency-double-avro' CONSISTENCY FORMAT JSON
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-CONSISTENCY FORMAT JSON not yet supported
+contains:CONSISTENCY FORMAT JSON not yet supported
 
 # Providing CONSISTENCY TOPIC without CONSISTENCY FORMAT will default to the sink's FORMAT
 # of the sink, if valid
@@ -266,7 +266,7 @@ CONSISTENCY FORMAT JSON not yet supported
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'default-avro'
     CONSISTENCY TOPIC 'consistency-default-avro'
   FORMAT JSON
-CONSISTENCY FORMAT JSON not yet supported
+contains:CONSISTENCY FORMAT JSON not yet supported
 
 > CREATE SINK double_avro FROM simple_view
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'double-avro'
@@ -304,7 +304,7 @@ $ kafka-verify format=json sink=materialize.public.json_avro_2 sort-messages=tru
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'json-reuse-topic'
     WITH (reuse_topic=true)
   FORMAT JSON
-For FORMAT JSON, you need to manually specify an Avro consistency topic using 'CONSISTENCY TOPIC consistency_topic CONSISTENCY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY url'. The default of using a JSON consistency topic is not supported.
+contains:For FORMAT JSON, you need to manually specify an Avro consistency topic using 'CONSISTENCY TOPIC consistency_topic CONSISTENCY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY url'. The default of using a JSON consistency topic is not supported.
 
 # This should succeed, but will incorrectly create a nonced topic.
 # See https://github.com/MaterializeInc/materialize/issues/8231.

--- a/test/testdrive/kafka-include-key-sources.td
+++ b/test/testdrive/kafka-include-key-sources.td
@@ -32,26 +32,26 @@ $ kafka-ingest format=avro key-format=avro topic=avro-data key-schema=${conflict
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avro-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
   INCLUDE KEY
-INCLUDE KEY requires specifying KEY FORMAT .. VALUE FORMAT, got bare FORMAT
+contains:INCLUDE KEY requires specifying KEY FORMAT .. VALUE FORMAT, got bare FORMAT
 
 ! CREATE SOURCE missing_key_format
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avro-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
   INCLUDE KEY AS key_col
-INCLUDE KEY requires specifying KEY FORMAT .. VALUE FORMAT, got bare FORMAT
+contains:INCLUDE KEY requires specifying KEY FORMAT .. VALUE FORMAT, got bare FORMAT
 
 
 ! CREATE SOURCE not_supported
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avro-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
   INCLUDE TOPIC
-INCLUDE TOPIC not yet supported
+contains:INCLUDE TOPIC not yet supported
 
 ! CREATE SOURCE not_supported
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avro-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
   INCLUDE TIMESTAMP as myts, TOPIC
-INCLUDE TOPIC not yet supported
+contains:INCLUDE TOPIC not yet supported
 
 > CREATE MATERIALIZED SOURCE avro_data_conflict
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avro-data-${testdrive.seed}'
@@ -60,7 +60,7 @@ INCLUDE TOPIC not yet supported
   INCLUDE KEY
 
 ! SELECT id, b FROM avro_data_conflict
-column reference "id" is ambiguous
+contains:column reference "id" is ambiguous
 
 > SELECT * FROM avro_data_conflict
 id id b
@@ -170,7 +170,7 @@ named_id named_geo a
   VALUE FORMAT AVRO USING SCHEMA '${schema}'
   INCLUDE KEY AS named
   ENVELOPE debezium
-Cannot use INCLUDE KEY with ENVELOPE DEBEZIUM: Debezium values include all keys.
+contains:Cannot use INCLUDE KEY with ENVELOPE DEBEZIUM: Debezium values include all keys.
 
 # formats: TEXT and REGEX
 $ kafka-create-topic topic=textsrc

--- a/test/testdrive/kafka-json-sinks.td
+++ b/test/testdrive/kafka-json-sinks.td
@@ -76,7 +76,7 @@ $ kafka-verify format=json sink=materialize.public.record_sink key=false
 
 # Duplicate column names
 ! CREATE VIEW duplicate_cols AS SELECT 'a1' AS a, 'a1' AS a;
-column "a" specified more than once
+contains:column "a" specified more than once
 
 # Complex types
 

--- a/test/testdrive/kafka-sink-errors.td
+++ b/test/testdrive/kafka-sink-errors.td
@@ -17,74 +17,74 @@
   INTO KAFKA BROKER '123:123:123'
   TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-invalid port: invalid digit found in string
+contains:invalid port: invalid digit found in string
 
 ! CREATE SINK invalid_broker FROM v1
   INTO KAFKA BROKER 'localhost:1234'
   TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-Meta data fetch error: BrokerTransportFailure (Local: Broker transport failure): BrokerTransportFailure (Local: Broker transport failure)
+contains:Meta data fetch error: BrokerTransportFailure (Local: Broker transport failure): BrokerTransportFailure (Local: Broker transport failure)
 
 ! CREATE SINK invalid_schema_registry FROM v1
   INTO KAFKA BROKER '${testdrive.kafka-addr}'
   TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'foo'
-relative URL without a base
+contains:relative URL without a base
 
 ! CREATE SINK invalid_schema_registry_host FROM v1
   INTO KAFKA BROKER '${testdrive.kafka-addr}'
   TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:1234'
-tcp connect error
+contains:tcp connect error
 
 ! CREATE SINK invalid_partition_count FROM v1
   INTO KAFKA BROKER '${testdrive.kafka-addr}'
   TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   WITH (partition_count = a)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-partition count for sink topics must be an integer
+contains:partition count for sink topics must be an integer
 
 ! CREATE SINK invalid_partition_count FROM v1
   INTO KAFKA BROKER '${testdrive.kafka-addr}'
   TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   WITH (partition_count = -2)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-partition count for sink topics must be a positive integer or -1 for broker default
+contains:partition count for sink topics must be a positive integer or -1 for broker default
 
 ! CREATE SINK invalid_replication_factor FROM v1
   INTO KAFKA BROKER '${testdrive.kafka-addr}'
   TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   WITH (replication_factor = a)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-replication factor for sink topics must be an integer
+contains:replication factor for sink topics must be an integer
 
 ! CREATE SINK invalid_replication_factor FROM v1
   INTO KAFKA BROKER '${testdrive.kafka-addr}'
   TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   WITH (replication_factor = -2)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-replication factor for sink topics must be a positive integer or -1 for broker default
+contains:replication factor for sink topics must be a positive integer or -1 for broker default
 
 ! CREATE SINK invalid_consistency FROM v1
   INTO KAFKA BROKER '${testdrive.kafka-addr}'
   TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   WITH (consistency_topic = -2)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-consistency_topic must be a string
+contains:consistency_topic must be a string
 
 ! CREATE SINK invalid_acks FROM v1
   INTO KAFKA BROKER '${testdrive.kafka-addr}'
   TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   WITH (acks = foo)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-Invalid value for configuration property "request.required.acks" acks foo
+contains:Invalid value for configuration property "request.required.acks" acks foo
 
 ! CREATE SINK invalid_key FROM v1
   INTO KAFKA BROKER '${testdrive.kafka-addr}'
   TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   KEY(f2)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-No such column: f2
+contains:No such column: f2
 
 #
 # Retention options
@@ -94,28 +94,28 @@ No such column: f2
   TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   WITH (retention_ms = a)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-retention ms for sink topics must be an integer
+contains:retention ms for sink topics must be an integer
 
 ! CREATE SINK invalid_retention_ms FROM v1
   INTO KAFKA BROKER '${testdrive.kafka-addr}'
   TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   WITH (retention_ms = -2)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-retention ms for sink topics must be greater than or equal to -1
+contains:retention ms for sink topics must be greater than or equal to -1
 
 ! CREATE SINK invalid_retention_bytes FROM v1
   INTO KAFKA BROKER '${testdrive.kafka-addr}'
   TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   WITH (retention_bytes = a)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-retention bytes for sink topics must be an integer
+contains:retention bytes for sink topics must be an integer
 
 ! CREATE SINK invalid_retention_bytes FROM v1
   INTO KAFKA BROKER '${testdrive.kafka-addr}'
   TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   WITH (retention_bytes = -2)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-retention bytes for sink topics must be greater than or equal to -1
+contains:retention bytes for sink topics must be greater than or equal to -1
 
 #
 # Sink dependencies
@@ -130,13 +130,13 @@ retention bytes for sink topics must be greater than or equal to -1
   INTO KAFKA BROKER '${testdrive.kafka-addr}'
   TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-catalog item 'materialize.public.s1' is a sink and so cannot be depended upon
+contains:catalog item 'materialize.public.s1' is a sink and so cannot be depended upon
 
 ! CREATE VIEW v2 AS SELECT * FROM s1
-catalog item 'materialize.public.s1' is a sink and so cannot be depended upon
+contains:catalog item 'materialize.public.s1' is a sink and so cannot be depended upon
 
 ! SELECT * FROM s1
-catalog item 'materialize.public.s1' is a sink and so cannot be depended upon
+contains:catalog item 'materialize.public.s1' is a sink and so cannot be depended upon
 
 > DROP SINK s1
 
@@ -149,35 +149,35 @@ catalog item 'materialize.public.s1' is a sink and so cannot be depended upon
   TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   WITH (security_protocol = 'FOO')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-creating admin client failed: Client config error: Invalid value "FOO" for configuration property "security.protocol" security.protocol FOO
+contains:creating admin client failed: Client config error: Invalid value "FOO" for configuration property "security.protocol" security.protocol FOO
 
 ! CREATE SINK ssl_on_non_ssl_broker FROM v1
   INTO KAFKA BROKER '${testdrive.kafka-addr}'
   TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   WITH (security_protocol = 'SSL')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-Meta data fetch error: BrokerTransportFailure (Local: Broker transport failure)
+contains:Meta data fetch error: BrokerTransportFailure (Local: Broker transport failure)
 
 ! CREATE SINK invalid_ssl_certificate_location FROM v1
   INTO KAFKA BROKER '${testdrive.kafka-addr}'
   TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   WITH (security_protocol = SSL , ssl_certificate_location = 'foo')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-Invalid WITH option ssl_certificate_location='foo': file does not exist
+contains:Invalid WITH option ssl_certificate_location='foo': file does not exist
 
 ! CREATE SINK invalid_ssl_key_location FROM v1
   INTO KAFKA BROKER '${testdrive.kafka-addr}'
   TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   WITH (security_protocol = SSL , ssl_key_location = 'foo')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-Invalid WITH option ssl_key_location='foo': file does not exist
+contains:Invalid WITH option ssl_key_location='foo': file does not exist
 
 ! CREATE SINK invalid_ssl_ca_location FROM v1
   INTO KAFKA BROKER '${testdrive.kafka-addr}'
   TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   WITH (security_protocol = SSL , ssl_ca_location = 'foo')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-Invalid WITH option ssl_ca_location='foo': file does not exist
+contains:Invalid WITH option ssl_ca_location='foo': file does not exist
 
 #
 # Kerberos options
@@ -188,14 +188,14 @@ Invalid WITH option ssl_ca_location='foo': file does not exist
   TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   WITH  (security_protocol = SASL_SSL, sasl_mechanisms = foo)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-Unsupported SASL mechanism: FOO
+contains:Unsupported SASL mechanism: FOO
 
 ! CREATE SINK invalid_sasl_kerberos_keytab FROM v1
   INTO KAFKA BROKER '${testdrive.kafka-addr}'
   TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   WITH  (security_protocol = SASL_SSL, sasl_kerberos_keytab = foo)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-Invalid WITH option sasl_kerberos_keytab='foo': file does not exist
+contains:Invalid WITH option sasl_kerberos_keytab='foo': file does not exist
 
 $ file-append path=invalid-keytab
 nonsense
@@ -205,35 +205,35 @@ nonsense
   TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   WITH  (security_protocol = SASL_SSL, sasl_kerberos_keytab = '${testdrive.temp-dir}/invalid-keytab')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-error registering kafka topic for sink
+contains:error registering kafka topic for sink
 
 ! CREATE SINK missing_required_sasl_username FROM v1
   INTO KAFKA BROKER '${testdrive.kafka-addr}'
   TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   WITH  (security_protocol = SASL_SSL, sasl_mechanisms = plain)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-creating admin client failed: Client creation error: sasl.username and sasl.password must be set
+contains:creating admin client failed: Client creation error: sasl.username and sasl.password must be set
 
 ! CREATE SINK missing_required_sasl_password FROM v1
   INTO KAFKA BROKER '${testdrive.kafka-addr}'
   TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   WITH  (security_protocol = SASL_SSL, sasl_mechanisms = plain, sasl_username = foo)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-creating admin client failed: Client creation error: sasl.username and sasl.password must be set
+contains:creating admin client failed: Client creation error: sasl.username and sasl.password must be set
 
 ! CREATE SINK missing_required_sasl_kerberos_keytab FROM v1
   INTO KAFKA BROKER '${testdrive.kafka-addr}'
   TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   WITH  (security_protocol = SASL_SSL, sasl_mechanisms = gssapi)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-creating admin client failed: Client creation error: Invalid sasl.kerberos.kinit.cmd value: Property not available: "sasl.kerberos.keytab"
+contains:creating admin client failed: Client creation error: Invalid sasl.kerberos.kinit.cmd value: Property not available: "sasl.kerberos.keytab"
 
 ! CREATE SINK invalid_sasl_kerberos_kinit_cmd FROM v1
   INTO KAFKA BROKER '${testdrive.kafka-addr}'
   TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   WITH  (security_protocol = SASL_SSL, sasl_mechanisms = gssapi, sasl_kerberos_kinit_cmd = '/bin/false')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-error registering kafka topic for sink
+contains:error registering kafka topic for sink
 
 #
 # FORMAT
@@ -241,12 +241,12 @@ error registering kafka topic for sink
 
 ! CREATE SINK invalid_format FROM v1
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
-sink without format not yet supported
+contains:sink without format not yet supported
 
 ! CREATE SINK invalid_format FROM v1
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   FORMAT NO_SUCH_FORMAT
-found identifier "no_such_format"
+contains:found identifier "no_such_format"
 
 # Expect empty output
 > SHOW SINKS

--- a/test/testdrive/kafka-time-offset.td
+++ b/test/testdrive/kafka-time-offset.td
@@ -20,25 +20,25 @@ $ kafka-create-topic topic=t0
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'missing_topic'
   WITH (kafka_time_offset=1)
   FORMAT TEXT
-topic missing_topic does not exist
+contains:topic missing_topic does not exist
 
 ! CREATE MATERIALIZED SOURCE pick_one
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-t0-${testdrive.seed}'
   WITH (kafka_time_offset=1, start_offset=1)
   FORMAT TEXT
-`start_offset` and `kafka_time_offset` cannot be set at the same time.
+contains:`start_offset` and `kafka_time_offset` cannot be set at the same time.
 
 ! CREATE MATERIALIZED SOURCE byo
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-t0-${testdrive.seed}'
   WITH (kafka_time_offset=1, consistency_topic="t0")
   FORMAT TEXT
-`start_offset` is not yet implemented for non-realtime consistency sources.
+contains:`start_offset` is not yet implemented for non-realtime consistency sources.
 
 ! CREATE MATERIALIZED SOURCE not_a_number
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-t0-${testdrive.seed}'
   WITH (kafka_time_offset="not_a_number")
   FORMAT TEXT
-`kafka_time_offset` must be a number
+contains:`kafka_time_offset` must be a number
 
 #
 # Append-Only

--- a/test/testdrive/kafka-upsert-debezium-sources.td
+++ b/test/testdrive/kafka-upsert-debezium-sources.td
@@ -62,13 +62,13 @@ $ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschem
   ENVELOPE DEBEZIUM
 
 ! SELECT * FROM start_offset_misconfigured
-Updates and deletes are not allowed for this source! This probably means it was started with `start_offset` and without `UPSERT` semantics.
+contains:Updates and deletes are not allowed for this source! This probably means it was started with `start_offset` and without `UPSERT` semantics.
 
 ! CREATE MATERIALIZED SOURCE doin_upsert
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE DEBEZIUM UPSERT
-ENVELOPE [DEBEZIUM] UPSERT requires that KEY FORMAT be specified
+contains:ENVELOPE [DEBEZIUM] UPSERT requires that KEY FORMAT be specified
 
 > CREATE MATERIALIZED SOURCE doin_upsert
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
@@ -122,7 +122,7 @@ moros
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   INCLUDE OFFSET
   ENVELOPE DEBEZIUM
-INCLUDE OFFSET with Debezium requires UPSERT semantics
+contains:INCLUDE OFFSET with Debezium requires UPSERT semantics
 
 > CREATE MATERIALIZED SOURCE doin_upsert_metadata
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
@@ -185,7 +185,7 @@ id creature
   WITH (deduplication = 'full')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE DEBEZIUM UPSERT
-Debezium deduplication does not make sense with upsert sources
+contains:Debezium deduplication does not make sense with upsert sources
 
 
 # test include metadata

--- a/test/testdrive/kafka-upsert-sources-key-decode-error.td
+++ b/test/testdrive/kafka-upsert-sources-key-decode-error.td
@@ -46,4 +46,4 @@ $ kafka-ingest format=avro topic=int2long key-format=avro key-schema=${keyschema
 {"key": 999999999999} {"nokey": "nokey1"}
 
 ! SELECT * FROM int2long
-Schemas don't match: Long, Int
+contains:Schemas don't match: Long, Int

--- a/test/testdrive/kafka-upsert-sources.td
+++ b/test/testdrive/kafka-upsert-sources.td
@@ -597,18 +597,18 @@ $ kafka-verify format=avro sink=materialize.public.input_pkne_key_sink sort-mess
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avroavro-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE UPSERT
-Key constraint (f1) conflicts with existing key (key)
+contains:Key constraint (f1) conflicts with existing key (key)
 
 ! CREATE MATERIALIZED SOURCE avroavro (PRIMARY KEY (unknown) NOT ENFORCED)
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avroavro-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE UPSERT
-No such column in source key constraint: unknown
+contains:No such column in source key constraint: unknown
 
 ! CREATE MATERIALIZED SOURCE avroavro (PRIMARY KEY (f1, f1) NOT ENFORCED)
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avroavro-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE NONE
-Repeated column name in source key constraint: f1
+contains:Repeated column name in source key constraint: f1
 
 $ set ambiguous-schema={
         "type" : "record",
@@ -623,4 +623,4 @@ $ set ambiguous-schema={
 ! CREATE MATERIALIZED SOURCE input_pkne (f1, f2, f1, PRIMARY KEY (f1) NOT ENFORCED)
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avroavro-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${ambiguous-schema}' ENVELOPE NONE
-Ambiguous column in source key constraint: f1
+contains:Ambiguous column in source key constraint: f1

--- a/test/testdrive/list.td
+++ b/test/testdrive/list.td
@@ -53,17 +53,17 @@ name
 bool
 
 ! DROP TYPE bool
-cannot drop item pg_catalog.bool because it is required by the database system
+contains:cannot drop item pg_catalog.bool because it is required by the database system
 
 ! DROP TYPE public.bool
-cannot drop materialize.public.bool: still depended upon by catalog item 'materialize.public.another_custom'
+contains:cannot drop materialize.public.bool: still depended upon by catalog item 'materialize.public.another_custom'
 
 > DROP TYPE another_custom
 
 > DROP TYPE public.bool
 
 ! CREATE TABLE f1 (a char list);
-char list not yet supported
+contains:char list not yet supported
 
 ! CREATE TYPE test_schema.bool AS LIST (element_type=char)
-char list not yet supported
+contains:char list not yet supported

--- a/test/testdrive/logging.td
+++ b/test/testdrive/logging.td
@@ -51,10 +51,10 @@
 1
 
 ! DROP SCHEMA mz_catalog
-cannot drop schema mz_catalog because it is required by the database system
+contains:cannot drop schema mz_catalog because it is required by the database system
 
 ! DROP VIEW mz_peek_durations
-cannot drop item mz_catalog.mz_peek_durations because it is required by the database system
+contains:cannot drop item mz_catalog.mz_peek_durations because it is required by the database system
 
 > SELECT mz_columns.id, mz_columns.name, position, type
   FROM mz_views JOIN mz_columns USING (id)

--- a/test/testdrive/map.td
+++ b/test/testdrive/map.td
@@ -53,10 +53,10 @@ name
 bool
 
 ! DROP TYPE bool
-cannot drop item pg_catalog.bool because it is required by the database system
+contains:cannot drop item pg_catalog.bool because it is required by the database system
 
 ! DROP TYPE public.bool
-cannot drop materialize.public.bool: still depended upon by catalog item 'materialize.public.another_custom'
+contains:cannot drop materialize.public.bool: still depended upon by catalog item 'materialize.public.another_custom'
 
 > DROP TYPE another_custom
 

--- a/test/testdrive/materializations.td
+++ b/test/testdrive/materializations.td
@@ -26,12 +26,12 @@ $ kafka-create-topic topic=data
   FORMAT AVRO USING SCHEMA '${schema}'
 
 ! SELECT * FROM data
-unable to automatically determine a query timestamp
+contains:unable to automatically determine a query timestamp
 
 > CREATE VIEW data_view as SELECT * from data
 
 ! SELECT * FROM data_view
-unable to automatically determine a query timestamp
+contains:unable to automatically determine a query timestamp
 
 > CREATE MATERIALIZED VIEW test1 AS
   SELECT b, sum(a) FROM data GROUP BY b
@@ -136,7 +136,7 @@ b  max
 
 # Cannot select from unmaterialized view.
 ! SELECT * from data_view
-unable to automatically determine a query timestamp
+contains:unable to automatically determine a query timestamp
 
 # Can create sink from unmaterialized view.
 > CREATE SINK not_mat_sink2 FROM data_view
@@ -160,7 +160,7 @@ b  c
 > CREATE INDEX idx1 ON test5(c)
 
 ! SELECT * FROM idx1
-catalog item 'materialize.public.idx1' is an index and so cannot be depended upon
+contains:catalog item 'materialize.public.idx1' is an index and so cannot be depended upon
 
 # If there exists a second primary index, dropping one primary index will not
 # unmaterialize the view.
@@ -185,7 +185,7 @@ b  c
 > DROP INDEX idx1
 
 ! SELECT * from test5
-unable to automatically determine a query timestamp
+contains:unable to automatically determine a query timestamp
 
 > SHOW FULL VIEWS LIKE 'test5'
 name        type     materialized  volatility
@@ -205,10 +205,10 @@ d
 # Dependencies have not re-materialized as a result of creating a dependent
 # materialized view.
 ! SELECT * from test5
-unable to automatically determine a query timestamp
+contains:unable to automatically determine a query timestamp
 
 ! SELECT * from data_view
-unable to automatically determine a query timestamp
+contains:unable to automatically determine a query timestamp
 
 # Rematerialize data_view creating an index on it.
 > CREATE INDEX data_view_idx on data_view(a)
@@ -366,7 +366,7 @@ c  d
 > DROP INDEX mat_data_primary_idx1
 
 ! SELECT * from mat_data
-unable to automatically determine a query timestamp
+contains:unable to automatically determine a query timestamp
 
 > SELECT * from test7
 count
@@ -374,7 +374,7 @@ count
 4
 
 ! SELECT * from test8
-unable to automatically determine a query timestamp
+contains:unable to automatically determine a query timestamp
 
 $ kafka-ingest format=avro topic=mat schema=${schema} timestamp=2
 {"a": -3, "b": 0}

--- a/test/testdrive/negative-multiplicities.td
+++ b/test/testdrive/negative-multiplicities.td
@@ -49,7 +49,7 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
 -1
 
 ! SELECT * FROM data
-Invalid data in source, saw retractions (1) for row that does not exist: [Int64(1)]
+contains:Invalid data in source, saw retractions (1) for row that does not exist: [Int64(1)]
 
 $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
 {"before": {"row": {"a": 1}}, "after": null}
@@ -58,4 +58,4 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
 -2
 
 ! SELECT * FROM data
-Invalid data in source, saw retractions (2) for row that does not exist: [Int64(1)]
+contains:Invalid data in source, saw retractions (2) for row that does not exist: [Int64(1)]

--- a/test/testdrive/numeric-sum.td
+++ b/test/testdrive/numeric-sum.td
@@ -87,7 +87,7 @@ Infinity
 
 # Side note that you cannot rescale Infinity
 ! SELECT sum_a::numeric(39,1)::text from numeric_values_sum;
-numeric field overflow
+contains:numeric field overflow
 
 # Retracting/subtracting values lets you return to a valid state
 > INSERT INTO numeric_insertions VALUES ('-9e38');
@@ -235,7 +235,7 @@ sum_a
 # only in aggregation contexts as a means of preserving commutativity and
 # associativity.
 ! SELECT sum_a::text AS sum_a FROM numeric_scaled_values_sum;
-Evaluation error: numeric field overflow
+contains:Evaluation error: numeric field overflow
 
 # Errored state is invertible by reducing aggregated value so it's expressable
 # with the provided scale.
@@ -276,7 +276,7 @@ sum_a
 # Note that this error actually occurs in numeric_scaled_inputs, so is an
 # evaluation error, rather than the aggregation returning infinity.
 ! SELECT sum_a::text AS sum_a FROM numeric_scaled_inputs_sum;
-Evaluation error: numeric field overflow
+contains:Evaluation error: numeric field overflow
 
 # However, retracting this values returns us to a good state.
 > INSERT INTO numeric_scaled_input_deletions VALUES ('1e38');

--- a/test/testdrive/pg-catalog.td
+++ b/test/testdrive/pg-catalog.td
@@ -67,7 +67,7 @@ atthasdef    false     boolean
 attidentity  false     character
 
 ! SELECT current_schemas()
-Cannot call function current_schemas(): arguments cannot be implicitly cast to any implementation's parameters;
+contains:Cannot call function current_schemas(): arguments cannot be implicitly cast to any implementation's parameters;
 
 > SELECT current_schemas(true)
 {mz_catalog,pg_catalog,public,mz_temp}

--- a/test/testdrive/protobuf-corrupted.td
+++ b/test/testdrive/protobuf-corrupted.td
@@ -32,7 +32,7 @@ garbage
   FORMAT PROTOBUF MESSAGE '.OneInt' USING SCHEMA FILE '${testdrive.temp-dir}/simple.pb'
 
 ! SELECT * FROM total_garbage
-Decode error: Text: protobuf deserialization error: failed to decode Protobuf message: invalid wire type value: 7
+contains:Decode error: Text: protobuf deserialization error: failed to decode Protobuf message: invalid wire type value: 7
 
 $ kafka-create-topic topic=wrong-message
 
@@ -44,4 +44,4 @@ $ kafka-ingest topic=wrong-message format=protobuf descriptor-file=simple.pb mes
   FORMAT PROTOBUF MESSAGE '.OneString' USING SCHEMA FILE '${testdrive.temp-dir}/simple.pb'
 
 ! SELECT * FROM wrong_message
-Decode error: Text: protobuf deserialization error: failed to decode Protobuf message: invalid wire type: Varint (expected LengthDelimited)
+contains:Decode error: Text: protobuf deserialization error: failed to decode Protobuf message: invalid wire type: Varint (expected LengthDelimited)

--- a/test/testdrive/protobuf-evolution.td
+++ b/test/testdrive/protobuf-evolution.td
@@ -125,4 +125,4 @@ $ kafka-ingest topic=evolution format=protobuf descriptor-file=evolution.pb mess
 {"wrong": "i'm not an int!"}
 
 ! SELECT * FROM evolution
-Decode error: Text: protobuf deserialization error: failed to decode Protobuf message: invalid wire type: LengthDelimited (expected Varint)
+contains:Decode error: Text: protobuf deserialization error: failed to decode Protobuf message: invalid wire type: LengthDelimited (expected Varint)

--- a/test/testdrive/protobuf-import.td
+++ b/test/testdrive/protobuf-import.td
@@ -113,4 +113,4 @@ $ kafka-ingest topic=import-csr format=protobuf descriptor-file=import.pb messag
 {"importee1": {"b": false}, "importee2": {"ts": "1970-01-01T00:20:34.000005678Z"}}
 
 ! SELECT importee1::text, importee2::text, mz_offset FROM import_csr
-Decode error: Text: protobuf deserialization error: unsupported Confluent-style protobuf message descriptor id: expected 0, but found: 123. See https://github.com/MaterializeInc/materialize/issues/9250
+contains:Decode error: Text: protobuf deserialization error: unsupported Confluent-style protobuf message descriptor id: expected 0, but found: 123. See https://github.com/MaterializeInc/materialize/issues/9250

--- a/test/testdrive/protobuf-map.td
+++ b/test/testdrive/protobuf-map.td
@@ -24,4 +24,4 @@ $ protobuf-compile-descriptors inputs=maps.proto output=maps.pb
 ! CREATE SOURCE maps FROM
   KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-maps-${testdrive.seed}'
   FORMAT PROTOBUF MESSAGE '.Maps' USING SCHEMA FILE '${testdrive.temp-dir}/maps.pb'
-Protobuf map fields are not supported
+contains:Protobuf map fields are not supported

--- a/test/testdrive/protobuf-name.td
+++ b/test/testdrive/protobuf-name.td
@@ -47,8 +47,8 @@ i   mz_offset
 ! CREATE MATERIALIZED SOURCE absolute_path FROM
   KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-name-${testdrive.seed}'
   FORMAT PROTOBUF MESSAGE 'Name' USING SCHEMA FILE '${testdrive.temp-dir}/name.pb'
-protobuf message "Name" not found in file descriptor set
+contains:protobuf message "Name" not found in file descriptor set
 ! CREATE MATERIALIZED SOURCE absolute_path FROM
   KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-name-${testdrive.seed}'
   FORMAT PROTOBUF MESSAGE '.Name' USING SCHEMA FILE '${testdrive.temp-dir}/name.pb'
-protobuf message ".Name" not found in file descriptor set
+contains:protobuf message ".Name" not found in file descriptor set

--- a/test/testdrive/protobuf-recursive.td
+++ b/test/testdrive/protobuf-recursive.td
@@ -32,8 +32,8 @@ $ protobuf-compile-descriptors inputs=recursive.proto output=recursive.pb
 
 ! CREATE SOURCE recursive FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'recursive'
   FORMAT PROTOBUF MESSAGE '.Self' USING SCHEMA FILE '${testdrive.temp-dir}/recursive.pb'
-Recursive types are not supported: Self
+contains:Recursive types are not supported: Self
 
 ! CREATE SOURCE recursive FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'recursive'
   FORMAT PROTOBUF MESSAGE '.Mutual1' USING SCHEMA FILE '${testdrive.temp-dir}/recursive.pb'
-Recursive types are not supported: Mutual1
+contains:Recursive types are not supported: Mutual1

--- a/test/testdrive/protobuf-required.td
+++ b/test/testdrive/protobuf-required.td
@@ -36,4 +36,4 @@ $ kafka-ingest topic=required format=protobuf descriptor-file=required.pb messag
 {}
 
 ! SELECT * FROM required
-protobuf message missing required field f
+contains:protobuf message missing required field f

--- a/test/testdrive/protobuf-unsigned.td
+++ b/test/testdrive/protobuf-unsigned.td
@@ -33,16 +33,16 @@ $ protobuf-compile-descriptors inputs=unsigned.proto output=unsigned.pb
 
 ! CREATE SOURCE unsigned FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'unsigned'
   FORMAT PROTOBUF MESSAGE '.UInt32' USING SCHEMA FILE '${testdrive.temp-dir}/unsigned.pb'
-Protobuf unsigned integer types are not supported
+contains:Protobuf unsigned integer types are not supported
 
 ! CREATE SOURCE unsigned FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'unsigned'
   FORMAT PROTOBUF MESSAGE '.UInt64' USING SCHEMA FILE '${testdrive.temp-dir}/unsigned.pb'
-Protobuf unsigned integer types are not supported
+contains:Protobuf unsigned integer types are not supported
 
 ! CREATE SOURCE unsigned FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'unsigned'
   FORMAT PROTOBUF MESSAGE '.Fixed32' USING SCHEMA FILE '${testdrive.temp-dir}/unsigned.pb'
-Protobuf unsigned integer types are not supported
+contains:Protobuf unsigned integer types are not supported
 
 ! CREATE SOURCE unsigned FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'unsigned'
   FORMAT PROTOBUF MESSAGE '.Fixed64' USING SCHEMA FILE '${testdrive.temp-dir}/unsigned.pb'
-Protobuf unsigned integer types are not supported
+contains:Protobuf unsigned integer types are not supported

--- a/test/testdrive/protobuf-wrong-message-count.td
+++ b/test/testdrive/protobuf-wrong-message-count.td
@@ -22,9 +22,9 @@ message Message2 {}
 ! CREATE MATERIALIZED SOURCE fail FROM
   KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-too-few-${testdrive.seed}'
   FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-Protobuf schemas with no messages not yet supported
+contains:Protobuf schemas with no messages not yet supported
 
 ! CREATE MATERIALIZED SOURCE fail FROM
   KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-too-many-${testdrive.seed}'
   FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-Protobuf schemas with multiple messages not yet supported
+contains:Protobuf schemas with multiple messages not yet supported

--- a/test/testdrive/regex-sources.td
+++ b/test/testdrive/regex-sources.td
@@ -88,4 +88,4 @@ this line has invalid UTF-8 and will be cause dataflow errors --> \x80 <--
   FORMAT REGEX '(?P<ip>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}) - - \[(?P<ts>[^]]+)\] "(?P<path>(?:GET /search/\?kw=(?P<search_kw>[^ ]*) HTTP/\d\.\d)|(?:GET /detail/(?P<product_detail_id>[a-zA-Z0-9]+) HTTP/\d\.\d)|(?:[^"]+))" (?P<code>\d{3}) -'
 
 ! SELECT * FROM bad_regex_source
-UTF-8
+contains:UTF-8

--- a/test/testdrive/rename.td
+++ b/test/testdrive/rename.td
@@ -194,24 +194,24 @@ materialize.public.oppositional_view "CREATE VIEW \"materialize\".\"public\".\"o
 
 # ❌ Identifiers used in dependent items
 ! ALTER VIEW t1 RENAME TO b;
-renaming conflict
+contains:renaming conflict
 ! ALTER VIEW t1 RENAME TO materialize;
-renaming conflict
+contains:renaming conflict
 ! ALTER VIEW t1 RENAME TO public;
-renaming conflict
+contains:renaming conflict
 
 # ❌ Identifiers used in own definition
 # `materialize.public.a` contains an unqualified reference to `materialize.public.t1.a`.
 ! ALTER VIEW a RENAME TO anything
-renaming conflict
+contains:renaming conflict
 ! ALTER VIEW v0 RENAME TO b
-renaming conflict
+contains:renaming conflict
 
 # ❌ Name used by another item in schema's catalog
 ! ALTER VIEW t1 RENAME TO a
-a is already taken by item in schema
+contains:a is already taken by item in schema
 ! ALTER VIEW t1 RENAME TO dependent_view;
-dependent_view is already taken by item in schema
+contains:dependent_view is already taken by item in schema
 
 # 🔬 Aliases
 
@@ -224,7 +224,7 @@ dependent_view is already taken by item in schema
 
 # ❌ View name used as alias
 ! ALTER VIEW t1 RENAME TO anything
-renaming conflict
+contains:renaming conflict
 
 # 🔬 Unresolvable without scope analysis
 # These are example queries whose ambiguity cannot be resolved through
@@ -246,10 +246,10 @@ renaming conflict
 
 # ❌ Item name used as column
 ! ALTER VIEW db0.scm0.z RENAME TO anything
-renaming conflict
+contains:renaming conflict
 # ❌ Item name used as schema
 ! ALTER VIEW db0.scm0 RENAME TO anything
-renaming conflict
+contains:renaming conflict
 
 > CREATE SCHEMA IF NOT EXISTS materialize.scm0;
 > CREATE VIEW materialize.scm0.z AS SELECT 1 AS a;
@@ -263,10 +263,10 @@ renaming conflict
 
 # ❌ Item name used as column
 ! ALTER VIEW scm0.z RENAME TO anything
-renaming conflict
+contains:renaming conflict
 # ❌ Item name used as schema
 ! ALTER VIEW scm0 RENAME TO anything
-renaming conflict
+contains:renaming conflict
 
 # 🔬 DB::DB
 
@@ -294,9 +294,9 @@ renaming conflict
 
 # ❌ Insufficient qualification
 ! ALTER VIEW db1.scm1.v rename to anything;
-renaming conflict
+contains:renaming conflict
 ! ALTER VIEW db2.scm1.v rename to anything;
-renaming conflict
+contains:renaming conflict
 
 > DROP VIEW db1_db2_scm1_min_qual_invalid
 
@@ -314,9 +314,9 @@ renaming conflict
 
 # ❌ Insufficient qualification
 ! ALTER VIEW db1.scm1.v rename to anything;
-renaming conflict
+contains:renaming conflict
 ! ALTER VIEW db2.scm1.v rename to anything;
-renaming conflict
+contains:renaming conflict
 
 > DROP VIEW db1_db2_scm1_mix_qual_invalid
 
@@ -357,15 +357,15 @@ materialize.public.db1_db2_scm1_valid_qual "CREATE VIEW \"materialize\".\"public
 
 # ❌ Identifiers used in dependent items
 ! ALTER VIEW db2.scm2.v2 RENAME TO db2;
-renaming conflict
+contains:renaming conflict
 ! ALTER VIEW db2.scm2.v2 RENAME TO scm2;
-renaming conflict
+contains:renaming conflict
 ! ALTER VIEW db2.scm2.v2 RENAME TO z;
-renaming conflict
+contains:renaming conflict
 ! ALTER VIEW db2.scm2.v2 RENAME TO scm2;
-renaming conflict
+contains:renaming conflict
 ! ALTER VIEW db2.scm2.v2 RENAME TO a;
-renaming conflict
+contains:renaming conflict
 
 # ✅ New idents
 > ALTER VIEW db2.scm2.v2 RENAME TO v3;
@@ -418,15 +418,15 @@ materialize.public.db_scm_qual "CREATE VIEW \"materialize\".\"public\".\"db_scm_
 
 # ❌ Identifiers used in dependent items
 ! ALTER VIEW v1 RENAME TO z;
-renaming conflict
+contains:renaming conflict
 ! ALTER VIEW v1 RENAME TO db1;
-renaming conflict
+contains:renaming conflict
 ! ALTER VIEW v1 RENAME TO scm1;
-renaming conflict
+contains:renaming conflict
 ! ALTER VIEW v1 RENAME TO v5;
-renaming conflict
+contains:renaming conflict
 ! ALTER VIEW db1.scm1.v5 RENAME TO v1;
-renaming conflict
+contains:renaming conflict
 
 # ✅ New idents
 > ALTER VIEW v1 RENAME TO v2;
@@ -463,9 +463,9 @@ materialize.public.db_v_qual "CREATE VIEW \"materialize\".\"public\".\"db_v_qual
 
 # ❌ Insufficient qualification
 ! ALTER VIEW db1.scm1.v rename to anything;
-renaming conflict
+contains:renaming conflict
 ! ALTER VIEW db1.scm2.v rename to anything;
-renaming conflict
+contains:renaming conflict
 
 > DROP VIEW db1_scm1_scm2_min_qual_invalid
 
@@ -483,9 +483,9 @@ renaming conflict
 
 # ❌ Insufficient qualification
 ! ALTER VIEW db1.scm1.v rename to anything;
-renaming conflict
+contains:renaming conflict
 ! ALTER VIEW db1.scm2.v rename to anything;
-renaming conflict
+contains:renaming conflict
 
 > DROP VIEW db1_scm1_scm2_mix_qual_invalid
 
@@ -530,17 +530,17 @@ materialize.public.db1_scm1_scm2_valid_qual "CREATE VIEW \"materialize\".\"publi
 
 # ❌ Identifiers used in dependent items
 ! ALTER VIEW scm4.v1 RENAME TO z;
-renaming conflict
+contains:renaming conflict
 ! ALTER VIEW scm4.v1 RENAME TO scm5;
-renaming conflict
+contains:renaming conflict
 ! ALTER VIEW scm4.v1 RENAME TO v2;
-renaming conflict
+contains:renaming conflict
 ! ALTER VIEW scm4.v1 RENAME TO a;
-renaming conflict
+contains:renaming conflict
 ! ALTER VIEW scm5.v2 RENAME TO a;
-renaming conflict
+contains:renaming conflict
 ! ALTER VIEW scm5.v2 RENAME TO v1;
-renaming conflict
+contains:renaming conflict
 
 # ✅ New idents
 > ALTER VIEW scm4.v1 RENAME TO v3;
@@ -568,11 +568,11 @@ materialize.public.scm_scm_qual "CREATE VIEW \"materialize\".\"public\".\"scm_sc
 
 # ❌ Identifiers used in dependent items
 ! ALTER VIEW v1 RENAME TO z;
-renaming conflict
+contains:renaming conflict
 ! ALTER VIEW v1 RENAME TO scm5;
-renaming conflict
+contains:renaming conflict
 ! ALTER VIEW v1 RENAME TO v4;
-renaming conflict
+contains:renaming conflict
 
 # ✅ New idents
 > ALTER VIEW v1 RENAME TO v3;
@@ -599,7 +599,7 @@ materialize.public.scm_v_qual "CREATE VIEW \"materialize\".\"public\".\"scm_v_qu
 
 # ❌ Identifiers used in dependent items
 ! ALTER VIEW v4 RENAME TO z;
-renaming conflict
+contains:renaming conflict
 
 # ✅ New idents
 > ALTER VIEW v4 RENAME TO v6;
@@ -638,7 +638,7 @@ materialize.public.qualified_wildcard "CREATE VIEW \"materialize\".\"public\".\"
 
 # ❌ Identifiers used in dependent items
 ! ALTER VIEW where_in_subquery RENAME TO scm5
-renaming conflict
+contains:renaming conflict
 
 # ✅ New idents
 > ALTER VIEW where_in_literal RENAME TO v8
@@ -666,9 +666,9 @@ materialize.public.v9 "CREATE VIEW \"materialize\".\"public\".\"v9\" AS SELECT \
 
 # ❌ Identifiers used in own definition
 ! ALTER VIEW space RENAME TO "has space"
-renaming conflict
+contains:renaming conflict
 ! ALTER VIEW "already has space" RENAME TO my_space
-renaming conflict
+contains:renaming conflict
 
 # ✅ New idents
 > ALTER VIEW space RENAME TO "now has space"
@@ -713,7 +713,7 @@ materialize.public.unnatural "CREATE VIEW \"materialize\".\"public\".\"unnatural
 
 # ❌ Identifiers used in dependent items
 ! ALTER VIEW func RENAME TO count
-renaming conflict
+contains:renaming conflict
 
 # ✅ Non-colliding function name
 > ALTER VIEW no_func RENAME TO count

--- a/test/testdrive/roles.td
+++ b/test/testdrive/roles.td
@@ -16,13 +16,13 @@ $ set-sql-timeout duration=1s
 
 # Verify that invalid options are rejected.
 ! CREATE ROLE foo
-non-login users not yet supported
+contains:non-login users not yet supported
 ! CREATE ROLE foo LOGIN
-non-superusers not yet supported
+contains:non-superusers not yet supported
 ! CREATE ROLE foo LOGIN LOGIN SUPERUSER
-conflicting or redundant options
+contains:conflicting or redundant options
 ! CREATE ROLE foo LOGIN NOLOGIN SUPERUSER
-conflicting or redundant options
+contains:conflicting or redundant options
 
 # Create roles using both syntaxes and verify their existence.
 > CREATE ROLE rj LOGIN SUPERUSER
@@ -36,7 +36,7 @@ conflicting or redundant options
 # Dropping multiple roles should not have any effect if one of the role names
 # is bad...
 ! DROP ROLE rj, fms, bad
-unknown role 'bad'
+contains:unknown role 'bad'
 > SELECT id, name FROM mz_roles
 -1 mz_system
  1 materialize
@@ -63,14 +63,14 @@ unknown role 'bad'
 
 # No dropping the current role.
 ! DROP ROLE ${testdrive.materialized-user}
-current user cannot be dropped
+contains:current user cannot be dropped
 
 # No creating roles that already exist.
 ! CREATE ROLE materialize LOGIN SUPERUSER
-role 'materialize' already exists
+contains:role 'materialize' already exists
 
 # No creating roles that look like system roles.
 ! CREATE ROLE mz_system LOGIN SUPERUSER
-role name "mz_system" is reserved
+contains:role name "mz_system" is reserved
 ! CREATE ROLE mz_foo LOGIN SUPERUSER
-role name "mz_foo" is reserved
+contains:role name "mz_foo" is reserved

--- a/test/testdrive/rollback.td
+++ b/test/testdrive/rollback.td
@@ -24,4 +24,4 @@
 <null>
 
 ! SELECT * FROM t1 AS OF NOW() - INTERVAL '1 second';
-is not valid for all inputs
+contains:is not valid for all inputs

--- a/test/testdrive/runtime-errors.td
+++ b/test/testdrive/runtime-errors.td
@@ -61,10 +61,10 @@ valid2  85
 bad1    0
 
 ! SELECT * FROM divide
-division by zero
+contains:division by zero
 
 ! SELECT * FROM both
-division by zero
+contains:division by zero
 
 $ kafka-ingest format=avro topic=data schema=${schema} timestamp=3
 {"before": {"row": {"id": "bad1", "a": 7, "b": 0}}, "after": null}

--- a/test/testdrive/schema-registry-network-errors.td
+++ b/test/testdrive/schema-registry-network-errors.td
@@ -20,7 +20,7 @@
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'foo'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://127.0.0.1:65535'
   ENVELOPE NONE
-connect error: Connection refused
+contains:connect error: Connection refused
 
 #
 # Point to invalid URL schema
@@ -30,7 +30,7 @@ connect error: Connection refused
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'foo'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'ftp://127.0.0.1'
   ENVELOPE NONE
-URL scheme is not allowed
+contains:URL scheme is not allowed
 
 #
 # Point to a valid HTTP/S URL that is not a registry service
@@ -40,7 +40,7 @@ URL scheme is not allowed
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'foo'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}/no-such-path'
   ENVELOPE NONE
-fetching latest schema for subject 'foo-value' from registry: subject not found
+contains:fetching latest schema for subject 'foo-value' from registry: subject not found
 
 #
 # HTTP connection to a non-HTTP port port
@@ -50,7 +50,7 @@ fetching latest schema for subject 'foo-value' from registry: subject not found
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'foo'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://${testdrive.kafka-addr}'
   ENVELOPE NONE
-error sending request for url
+contains:error sending request for url
 
 #
 # HTTPS connection to a non-HTTPS port
@@ -60,4 +60,4 @@ error sending request for url
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'foo'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'https://${testdrive.kafka-addr}'
   ENVELOPE NONE
-error sending request for url
+contains:error sending request for url

--- a/test/testdrive/self-test.td
+++ b/test/testdrive/self-test.td
@@ -1,0 +1,24 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test tricky behavior of testdrive itself that isn't currently tested by other tests
+
+# The regex 'foo[a]bar' matches the string 'fooabar' but not itself
+$ set no-self-match=foo[a]bar
+
+> CREATE TABLE example (a int)
+
+! SELECT "${no-self-match}" FROM example
+exact: column "foo[a]bar" does not exist
+
+! SELECT "${no-self-match}" FROM example
+exact: column "${no-self-match}" does not exist
+
+! SELECT "${no-self-match}" FROM example
+regex: ^column "${no-self-match}".*not exist$

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -32,14 +32,14 @@ UTF8
 UTF8
 
 ! SET client_encoding = UTF9
-parameter "client_encoding" can only be set to "UTF8"
+contains:parameter "client_encoding" can only be set to "UTF8"
 
 # if its utf8 we let it through
 > SET NAMES 'UTF8';
 
 # match the behavior of postgres as specified here: https://www.postgresql.org/docs/9.1/sql-set.html
 ! SET NAMES = "something";
-unrecognized configuration parameter "names"
+contains:unrecognized configuration parameter "names"
 
 > SET sql_safe_updates = on
 > SHOW sql_safe_updates
@@ -63,18 +63,18 @@ off
 > SET DateStyle = 'MDY'
 > SET DateStyle = 'ISO,MDY'
 ! SET DateStyle = 'ooga booga'
-parameter "DateStyle" can only be set to "ISO, MDY"
+contains:parameter "DateStyle" can only be set to "ISO, MDY"
 
 # `search_path` is tested elsewhere.
 
 ! SET server_version = "9.6.0"
-parameter "server_version" cannot be changed
+contains:parameter "server_version" cannot be changed
 
 ! SET server_version_num = "90600"
-parameter "server_version_num" cannot be changed
+contains:parameter "server_version_num" cannot be changed
 
 ! SET TimeZone = 'nope'
-parameter "TimeZone" can only be set to "UTC"
+contains:parameter "TimeZone" can only be set to "UTC"
 
 # The `transaction_isolation` variable has dedicated syntax as mandated by the
 # SQL standard.
@@ -82,7 +82,7 @@ parameter "TimeZone" can only be set to "UTC"
 serializable
 
 ! SET transaction_isolation = 'read committed'
-parameter "transaction_isolation" cannot be changed
+contains:parameter "transaction_isolation" cannot be changed
 
 ! SET integer_datetimes = false
-parameter "integer_datetimes" cannot be changed
+contains:parameter "integer_datetimes" cannot be changed

--- a/test/testdrive/sinks.td
+++ b/test/testdrive/sinks.td
@@ -35,7 +35,7 @@ goofus,gallant
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'snk1'
   WITH (badoption=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-unexpected parameters for CREATE SINK: badoption
+contains:unexpected parameters for CREATE SINK: badoption
 
 > SHOW SINKS
 name
@@ -51,13 +51,13 @@ name
 ! CREATE SINK bad_schema_registry FROM src
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'snk1'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.kafka-addr}'
-cannot construct a CCSR client with a cannot-be-a-base URL
+contains:cannot construct a CCSR client with a cannot-be-a-base URL
 
 # Invalid in that the address is not for a schema registry
 ! CREATE SINK bad_schema_registry FROM src
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'snk1'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://${testdrive.kafka-addr}'
-unable to publish value schema to registry in kafka sink
+contains:unable to publish value schema to registry in kafka sink
 
 > SHOW SINKS
 name

--- a/test/testdrive/source-compression.td
+++ b/test/testdrive/source-compression.td
@@ -53,10 +53,10 @@ Rochester      NY        14618   2
   FROM KAFKA BROKER 'foo' TOPIC 'bar'
   COMPRESSION GZIP
   FORMAT AVRO USING SCHEMA 'schema';
-Expected end of statement, found COMPRESSION
+contains:Expected end of statement, found COMPRESSION
 
 ! CREATE SOURCE f
   FROM KINESIS ARN 'foo'
   COMPRESSION GZIP
   FORMAT BYTES;
-Expected end of statement, found COMPRESSION
+contains:Expected end of statement, found COMPRESSION

--- a/test/testdrive/string.td
+++ b/test/testdrive/string.td
@@ -27,12 +27,12 @@ a
 
 > INSERT INTO c1 VALUES ('a')
 ! INSERT INTO c1 VALUES ('ab')
-value too long for type character(1)
+contains:value too long for type character(1)
 
 > INSERT INTO c2 VALUES ('a')
 > INSERT INTO c2 VALUES ('ab')
 ! INSERT INTO c2 VALUES ('abc')
-value too long for type character(2)
+contains:value too long for type character(2)
 
 #🔬🔬 char to char
 
@@ -47,7 +47,7 @@ a
 #🔬🔬🔬 Assignment
 
 ! INSERT INTO c1 VALUES ('ab'::char(2));
-value too long for type character(1)
+contains:value too long for type character(1)
 
 > INSERT INTO c1 VALUES ('a  '::char(3));
 
@@ -94,10 +94,10 @@ l
 
 > INSERT INTO v1 VALUES ('a'::char(1));
 ! INSERT INTO v1 VALUES ('ab'::char(2));
-value too long for type character varying(1)
+contains:value too long for type character varying(1)
 
 ! INSERT INTO v1 VALUES ('abc'::char(3));
-value too long for type character varying(1)
+contains:value too long for type character varying(1)
 
 > INSERT INTO v1 VALUES ('a  '::char(3));
 
@@ -110,7 +110,7 @@ l
 > INSERT INTO v2 VALUES ('a'::char(1));
 > INSERT INTO v2 VALUES ('ab'::char(2));
 ! INSERT INTO v2 VALUES ('abc'::char(3));
-value too long for type character varying(2)
+contains:value too long for type character varying(2)
 
 > INSERT INTO v2 VALUES ('a  '::char(3));
 
@@ -170,12 +170,12 @@ a
 
 > INSERT INTO v1 VALUES ('a');
 ! INSERT INTO v1 VALUES ('ab');
-value too long for type character varying(1)
+contains:value too long for type character varying(1)
 
 > INSERT INTO v2 VALUES ('a');
 > INSERT INTO v2 VALUES ('ab');
 ! INSERT INTO v2 VALUES ('abc');
-value too long for type character varying(2)
+contains:value too long for type character varying(2)
 
 > INSERT INTO v VALUES ('a'), ('ab'), ('abc');
 
@@ -192,7 +192,7 @@ a
 #🔬🔬🔬 Assignment
 
 ! INSERT INTO v1 VALUES ('ab'::varchar);
-value too long for type character varying(1)
+contains:value too long for type character varying(1)
 
 > INSERT INTO v1 VALUES ('a  '::varchar);
 
@@ -242,10 +242,10 @@ l
 
 > INSERT INTO v1 VALUES ('a'::varchar(1));
 ! INSERT INTO v1 VALUES ('ab'::varchar(2));
-value too long for type character varying(1)
+contains:value too long for type character varying(1)
 
 ! INSERT INTO v1 VALUES ('abc'::varchar(3));
-value too long for type character varying(1)
+contains:value too long for type character varying(1)
 
 > INSERT INTO v1 VALUES ('a  '::varchar(3));
 
@@ -257,7 +257,7 @@ l
 > INSERT INTO v2 VALUES ('a'::varchar(1));
 > INSERT INTO v2 VALUES ('ab'::varchar(2));
 ! INSERT INTO v2 VALUES ('abc'::varchar(3));
-value too long for type character varying(2)
+contains:value too long for type character varying(2)
 
 > INSERT INTO v2 VALUES ('ab '::char(3));
 
@@ -332,7 +332,7 @@ a
 #🔬🔬🔬 Assignment
 
 ! INSERT INTO c1 VALUES ('ab'::text);
-value too long for type character(1)
+contains:value too long for type character(1)
 
 > INSERT INTO c1 VALUES ('a  '::text);
 
@@ -379,10 +379,10 @@ l
 
 > INSERT INTO v1 VALUES ('a'::text);
 ! INSERT INTO v1 VALUES ('ab'::text);
-value too long for type character varying(1)
+contains:value too long for type character varying(1)
 
 ! INSERT INTO v1 VALUES ('abc'::text);
-value too long for type character varying(1)
+contains:value too long for type character varying(1)
 
 > INSERT INTO v1 VALUES ('a  '::text);
 
@@ -394,7 +394,7 @@ l
 > INSERT INTO v2 VALUES ('a'::text);
 > INSERT INTO v2 VALUES ('ab'::text);
 ! INSERT INTO v2 VALUES ('abc'::text);
-value too long for type character varying(2)
+contains:value too long for type character varying(2)
 
 > INSERT INTO v2 VALUES ('a  '::text);
 

--- a/test/testdrive/subquery-scalar-errors.td
+++ b/test/testdrive/subquery-scalar-errors.td
@@ -28,28 +28,28 @@ $ set-sql-timeout duration=125ms
 > INSERT INTO two_rows VALUES (1, 1), (2, 1);
 
 ! SELECT (SELECT f1 FROM two_rows);
-Evaluation error: more than one record produced in subquery
+contains:Evaluation error: more than one record produced in subquery
 
 ! SELECT (SELECT f1 FROM two_rows) FROM two_rows LIMIT 0;
-Evaluation error: more than one record produced in subquery
+contains:Evaluation error: more than one record produced in subquery
 
 ! SELECT (SELECT TRUE FROM two_rows);
-Evaluation error: more than one record produced in subquery
+contains:Evaluation error: more than one record produced in subquery
 
 ! SELECT (SELECT f1 FROM two_rows) FROM two_rows;
-Evaluation error: more than one record produced in subquery
+contains:Evaluation error: more than one record produced in subquery
 
 ! SELECT (SELECT f1 FROM two_rows) FROM empty;
-Evaluation error: more than one record produced in subquery
+contains:Evaluation error: more than one record produced in subquery
 
 ! SELECT (SELECT f1 FROM one_row UNION ALL SELECT f1 FROM one_row) FROM two_rows;
-Evaluation error: more than one record produced in subquery
+contains:Evaluation error: more than one record produced in subquery
 
 ! SELECT (SELECT f1 FROM empty UNION ALL SELECT f1 FROM two_rows) FROM two_rows;
-Evaluation error: more than one record produced in subquery
+contains:Evaluation error: more than one record produced in subquery
 
 ! SELECT (SELECT DISTINCT f1 FROM two_rows) FROM two_rows;
-Evaluation error: more than one record produced in subquery
+contains:Evaluation error: more than one record produced in subquery
 
 > SELECT (SELECT DISTINCT f2 FROM two_rows) FROM two_rows;
 1
@@ -63,56 +63,56 @@ Evaluation error: more than one record produced in subquery
 1
 
 ! SELECT (SELECT f1 FROM two_rows GROUP BY f1);
-Evaluation error: more than one record produced in subquery
+contains:Evaluation error: more than one record produced in subquery
 
 ! SELECT (SELECT MIN(f1) FROM two_rows UNION ALL SELECT MIN(f2) FROM two_rows) FROM two_rows;
-Evaluation error: more than one record produced in subquery
+contains:Evaluation error: more than one record produced in subquery
 
 > SELECT (SELECT MIN(f1) FROM two_rows UNION DISTINCT SELECT MIN(f2) FROM two_rows) FROM two_rows;
 1
 1
 
 ! SELECT MIN((SELECT f1 FROM two_rows)) FROM two_rows;
-Evaluation error: more than one record produced in subquery
+contains:Evaluation error: more than one record produced in subquery
 
 ! SELECT * FROM two_rows WHERE f1 > (SELECT f1 FROM two_rows);
-Evaluation error: more than one record produced in subquery
+contains:Evaluation error: more than one record produced in subquery
 
 ! SELECT * FROM two_rows WHERE f1 > (SELECT f1 FROM one_row) AND f1 > (SELECT f1 FROM two_rows);
-Evaluation error: more than one record produced in subquery
+contains:Evaluation error: more than one record produced in subquery
 
 ! SELECT * FROM two_rows WHERE f1 > (SELECT f1 FROM one_row) OR f1 > (SELECT f1 FROM two_rows);
-Evaluation error: more than one record produced in subquery
+contains:Evaluation error: more than one record produced in subquery
 
 ! SELECT * FROM two_rows WHERE (SELECT f1 FROM two_rows) > (SELECT f1 FROM one_row);
-Evaluation error: more than one record produced in subquery
+contains:Evaluation error: more than one record produced in subquery
 
 ! SELECT * FROM two_rows AS o WHERE (SELECT f1 FROM two_rows AS i WHERE o.f2 = i.f2) = 1 AND f1 = 2;
-Evaluation error: more than one record produced in subquery
+contains:Evaluation error: more than one record produced in subquery
 
 ! SELECT * FROM two_rows JOIN two_rows AS r ON (SELECT TRUE FROM two_rows);
-Evaluation error: more than one record produced in subquery
+contains:Evaluation error: more than one record produced in subquery
 
 ! SELECT * FROM two_rows LEFT JOIN two_rows AS r ON (SELECT f1 = 1 FROM two_rows);
-Evaluation error: more than one record produced in subquery
+contains:Evaluation error: more than one record produced in subquery
 
 ! SELECT f1, COUNT(*) as C FROM two_rows GROUP BY f1 HAVING COUNT(*) > (SELECT f1 FROM two_rows);
-Evaluation error: more than one record produced in subquery
+contains:Evaluation error: more than one record produced in subquery
 
 ! SELECT (SELECT f1 FROM two_rows), COUNT(*) FROM two_rows GROUP BY (SELECT f1 FROM two_rows);
-Evaluation error: more than one record produced in subquery
+contains:Evaluation error: more than one record produced in subquery
 
 ! SELECT COUNT(*) FROM two_rows GROUP BY (SELECT f1 FROM two_rows);
-Evaluation error: more than one record produced in subquery
+contains:Evaluation error: more than one record produced in subquery
 
 ! SELECT * FROM two_rows ORDER BY (SELECT f1 FROM two_rows);
-Evaluation error: more than one record produced in subquery
+contains:Evaluation error: more than one record produced in subquery
 
 ! INSERT INTO two_rows VALUES ((SELECT 1 UNION ALL SELECT 2));
-more than one record produced in subquery
+contains:more than one record produced in subquery
 
 ! SELECT (SELECT f1 from two_rows) + 1 FROM two_rows;
-Evaluation error: more than one record produced in subquery
+contains:Evaluation error: more than one record produced in subquery
 
 > SELECT (SELECT f1 FROM two_rows LIMIT 0) IS NULL;
 true
@@ -142,7 +142,7 @@ true
 # Two columns returned by subquery in scalar context
 
 ! SELECT (SELECT * FROM one_row) FROM one_row;
-Expected subselect to return 1 column, got 2 columns
+contains:Expected subselect to return 1 column, got 2 columns
 
 ! SELECT * FROM one_row WHERE f1 = ( SELECT * FROM one_row );
-WHERE clause error: Expected subselect to return 1 column, got 2 columns
+contains:WHERE clause error: Expected subselect to return 1 column, got 2 columns

--- a/test/testdrive/tables.td
+++ b/test/testdrive/tables.td
@@ -8,10 +8,10 @@
 # by the Apache License, Version 2.0.
 
 ! INSERT INTO t VALUES (1, 'a');
-unknown catalog item 't'
+contains:unknown catalog item 't'
 
 ! SHOW CREATE TABLE t;
-unknown catalog item 't'
+contains:unknown catalog item 't'
 
 > CREATE TABLE t (a int, b text NOT NULL)
 
@@ -33,13 +33,13 @@ materialize.public.t  "CREATE TABLE \"materialize\".\"public\".\"t\" (\"a\" \"pg
 > DROP TABLE s;
 
 ! CREATE TABLE s (a date DEFAULT 42)
-DEFAULT expression does not support casting from integer to date
+contains:DEFAULT expression does not support casting from integer to date
 
 ! CREATE TABLE s (a int, b int DEFAULT a + 3)
-column "a" does not exist
+contains:column "a" does not exist
 
 ! CREATE TABLE t (a int, b int, a int);
-column "a" specified more than once
+contains:column "a" specified more than once
 
 > SELECT * FROM t;
 
@@ -59,7 +59,7 @@ t        t_primary_idx  1             a            <null>      true     true
 t        t_primary_idx  2             b            <null>      false    true
 
 ! DROP INDEX t_primary_idx
-cannot drop 'materialize.public.t_primary_idx' as it is the default index for a table
+contains:cannot drop 'materialize.public.t_primary_idx' as it is the default index for a table
 
 > SHOW COLUMNS in t;
 name       nullable  type
@@ -145,13 +145,13 @@ a      b
 > INSERT INTO t SELECT * FROM t WHERE a IS NULL;
 
 ! INSERT INTO t VALUES (1);
-null value in column "b" violates not-null constraint
+contains:null value in column "b" violates not-null constraint
 
 ! INSERT INTO t VALUES (1, NULL);
-null value in column "b" violates not-null constraint
+contains:null value in column "b" violates not-null constraint
 
 ! INSERT INTO t VALUES ('d', 4);
-invalid input syntax for type integer: invalid digit found in string: "d"
+contains:invalid input syntax for type integer: invalid digit found in string: "d"
 
 # Test that the INSERT body can be a SELECT query.
 > INSERT INTO t SELECT 3, 'd'
@@ -161,7 +161,7 @@ invalid input syntax for type integer: invalid digit found in string: "d"
 
 # ...but not in complicated VALUES clauses, per PostgreSQL.
 ! INSERT INTO t VALUES ('5', 'f') LIMIT 0
-column "a" is of type integer but expression is of type text
+contains:column "a" is of type integer but expression is of type text
 
 # Test that assignment casts occur when possible...
 > INSERT INTO t VALUES (5.0, 'f');
@@ -169,14 +169,14 @@ column "a" is of type integer but expression is of type text
 
 # ...but not when impossible.
 ! INSERT INTO t VALUES (DATE '2020-01-01', 'bad')
-column "a" is of type integer but expression is of type date
+contains:column "a" is of type integer but expression is of type date
 
 # Attempting to insert JSON into an int column is particularly interesting.
 # While there is an "explicit" cast from `jsonb` to `int`, there is no
 # "assignment" cast, and INSERT is only allowed to use assignment/implicit
 # casts.
 ! INSERT INTO t VALUES (JSON '1', 'bad')
-column "a" is of type integer but expression is of type jsonb
+contains:column "a" is of type integer but expression is of type jsonb
 
 > SELECT * FROM t;
 a       b
@@ -193,16 +193,16 @@ a       b
 > CREATE TABLE s (a int NOT NULL);
 
 ! INSERT INTO s VALUES (1 + NULL);
-null value in column "a" violates not-null constraint
+contains:null value in column "a" violates not-null constraint
 
 > CREATE TABLE v (a timestamptz);
 > INSERT INTO v VALUES (now());
 
 ! CREATE INDEX ON v (now())
-now cannot be used in static queries
+contains:now cannot be used in static queries
 
 ! CREATE INDEX ON v (mz_logical_timestamp())
-calls to mz_logical_timestamp in in static or write queries are not supported
+contains:calls to mz_logical_timestamp in in static or write queries are not supported
 
 > DROP TABLE IF EXISTS s;
 
@@ -211,10 +211,10 @@ calls to mz_logical_timestamp in in static or write queries are not supported
 > DROP TABLE IF EXISTS t;
 
 ! SELECT * from t;
-unknown catalog item 't'
+contains:unknown catalog item 't'
 
 ! SHOW INDEXES FROM t;
-unknown catalog item 't'
+contains:unknown catalog item 't'
 
 > SHOW TABLES;
 name
@@ -237,10 +237,10 @@ name
 
 > CREATE VIEW view AS SELECT 1
 ! INSERT INTO view VALUES (1)
-cannot insert into view 'materialize.public.view'
+contains:cannot insert into view 'materialize.public.view'
 
 ! INSERT INTO mz_kafka_sinks VALUES ('bad', 'bad')
-cannot insert into system table 'mz_catalog.mz_kafka_sinks'
+contains:cannot insert into system table 'mz_catalog.mz_kafka_sinks'
 
 > CREATE TABLE j (time TIMESTAMP NOT NULL);
 
@@ -301,28 +301,28 @@ a      b    c
 <null> "c"  <null>
 
 ! INSERT INTO t (notpresent, a, c) VALUES ('str', 1, 2);
-column "notpresent" of relation "materialize.public.t" does not exist
+contains:column "notpresent" of relation "materialize.public.t" does not exist
 
 ! INSERT INTO t (a, b, c) VALUES ('str', 1, 2);
-invalid input syntax for type integer: invalid digit found in string: "str"
+contains:invalid input syntax for type integer: invalid digit found in string: "str"
 
 ! INSERT INTO t (b, a, c) VALUES (1, 'str', 2);
-invalid input syntax for type integer: invalid digit found in string: "str"
+contains:invalid input syntax for type integer: invalid digit found in string: "str"
 
 ! INSERT INTO t (d, c, b, a) VALUES (1, 1, 1, 'str');
-column "d" of relation "materialize.public.t" does not exist
+contains:column "d" of relation "materialize.public.t" does not exist
 
 ! INSERT INTO t (a) VALUES (1);
-null value in column "b" violates not-null constraint
+contains:null value in column "b" violates not-null constraint
 
 ! INSERT INTO t (a) VALUES (1, 'str');
-INSERT has more expressions than target columns
+contains:INSERT has more expressions than target columns
 
 ! INSERT INTO t (a, b, c) VALUES (1);
-INSERT has more target columns than expressions
+contains:INSERT has more target columns than expressions
 
 ! INSERT INTO t (a, a) VALUES (1, 'str')
-column "a" specified more than once
+contains:column "a" specified more than once
 
 # Test pg_table_is_visible.
 > CREATE SCHEMA non_default
@@ -340,14 +340,14 @@ v       true
 # pretty useless.
 > CREATE TABLE nocols ();
 ! INSERT INTO nocols VALUES (1)
-INSERT has more expressions than target columns
+contains:INSERT has more expressions than target columns
 > SELECT count(*) FROM nocols
 0
 > INSERT INTO nocols SELECT UNION ALL SELECT
 > SELECT count(*) FROM nocols
 2
 ! SELECT DISTINCT * FROM nocols
-SELECT DISTINCT must have at least one column
+contains:SELECT DISTINCT must have at least one column
 
 
 # Test that show columns preserves the column order

--- a/test/testdrive/temporal.td
+++ b/test/testdrive/temporal.td
@@ -257,16 +257,16 @@ ts
 #
 
 !CREATE MATERIALIZED VIEW v1 AS SELECT * FROM first_ts WHERE mz_logical_timestamp() != ts;
-Unsupported binary temporal operation: NotEq
+contains:Unsupported binary temporal operation: NotEq
 
 !CREATE MATERIALIZED VIEW v1 AS SELECT * FROM first_ts WHERE mz_logical_timestamp() + 1 = ts;
-Unsupported temporal predicate. Note: `mz_logical_timestamp()` must be directly compared to a numeric non-temporal expression; if it is compared to a non-numeric type, consider casting that type to numeric. Expression found: CallBinary { func: Eq, expr1: CallUnary { func: CastInt64ToNumeric(CastInt64ToNumeric(None)), expr: Column(0) }, expr2: CallBinary { func: AddNumeric, expr1: CallNullary(MzLogicalTimestamp), expr2: Literal(Ok(Row{[Numeric(OrderedDecimal(1))]}), ColumnType { scalar_type: Numeric { scale: None }, nullable: false }) } }
+contains:Unsupported temporal predicate. Note: `mz_logical_timestamp()` must be directly compared to a numeric non-temporal expression; if it is compared to a non-numeric type, consider casting that type to numeric. Expression found: CallBinary { func: Eq, expr1: CallUnary { func: CastInt64ToNumeric(CastInt64ToNumeric(None)), expr: Column(0) }, expr2: CallBinary { func: AddNumeric, expr1: CallNullary(MzLogicalTimestamp), expr2: Literal(Ok(Row{[Numeric(OrderedDecimal(1))]}), ColumnType { scalar_type: Numeric { scale: None }, nullable: false }) } }
 
 !CREATE MATERIALIZED VIEW v1 AS SELECT * FROM first_ts WHERE mz_logical_timestamp() > ts OR ts = 1;
-Unsupported temporal predicate. Note: `mz_logical_timestamp()` must be directly compared to a numeric non-temporal expression; if it is compared to a non-numeric type, consider casting that type to numeric. Expression found: CallBinary { func: Or, expr1: CallBinary { func: Eq, expr1: Column(0), expr2: Literal(Ok(Row{[Int64(1)]}), ColumnType { scalar_type: Int64, nullable: false }) }, expr2: CallBinary { func: Gt, expr1: CallNullary(MzLogicalTimestamp), expr2: CallUnary { func: CastInt64ToNumeric(CastInt64ToNumeric(None)), expr: Column(0) } } }
+contains:Unsupported temporal predicate. Note: `mz_logical_timestamp()` must be directly compared to a numeric non-temporal expression; if it is compared to a non-numeric type, consider casting that type to numeric. Expression found: CallBinary { func: Or, expr1: CallBinary { func: Eq, expr1: Column(0), expr2: Literal(Ok(Row{[Int64(1)]}), ColumnType { scalar_type: Int64, nullable: false }) }, expr2: CallBinary { func: Gt, expr1: CallNullary(MzLogicalTimestamp), expr2: CallUnary { func: CastInt64ToNumeric(CastInt64ToNumeric(None)), expr: Column(0) } } }
 
 !CREATE MATERIALIZED VIEW v1 AS SELECT * FROM first_ts WHERE ts BETWEEN mz_logical_timestamp() AND mz_logical_timestamp() + 1;
-Unsupported temporal predicate. Note: `mz_logical_timestamp()` must be directly compared to a numeric non-temporal expression; if it is compared to a non-numeric type, consider casting that type to numeric. Expression found: CallBinary { func: Lte, expr1: Column(1), expr2: CallBinary { func: AddNumeric, expr1: CallNullary(MzLogicalTimestamp), expr2: Literal(Ok(Row{[Numeric(OrderedDecimal(1))]}), ColumnType { scalar_type: Numeric { scale: None }, nullable: false }) } }
+contains:Unsupported temporal predicate. Note: `mz_logical_timestamp()` must be directly compared to a numeric non-temporal expression; if it is compared to a non-numeric type, consider casting that type to numeric. Expression found: CallBinary { func: Lte, expr1: Column(1), expr2: CallBinary { func: AddNumeric, expr1: CallNullary(MzLogicalTimestamp), expr2: Literal(Ok(Row{[Numeric(OrderedDecimal(1))]}), ColumnType { scalar_type: Numeric { scale: None }, nullable: false }) } }
 
 #
 # Numeric comparisons

--- a/test/testdrive/temporary.td
+++ b/test/testdrive/temporary.td
@@ -30,17 +30,17 @@
 3 "foo"
 
 ! CREATE VIEW non_temp AS SELECT * FROM temp_v
-non-temporary items cannot depend on temporary item
+contains:non-temporary items cannot depend on temporary item
 
 > CREATE TEMP VIEW double_temp_v AS SELECT * FROM temp_v
 
 ! CREATE TEMP VIEW double_temp_v AS SELECT * FROM temp_v
-catalog item 'double_temp_v' already exists
+contains:catalog item 'double_temp_v' already exists
 
 > CREATE OR REPLACE TEMP VIEW double_temp_v AS SELECT * FROM temp_v
 
 ! CREATE OR REPLACE VIEW double_temp_v AS SELECT * FROM temp_v
-non-temporary items cannot depend on temporary item
+contains:non-temporary items cannot depend on temporary item
 
 > SELECT * FROM double_temp_v
 1 "foo"
@@ -63,7 +63,7 @@ non-temporary items cannot depend on temporary item
  foo        foo_primary_idx  2             column2      <null>      false     true
 
 ! CREATE TEMP MATERIALIZED VIEW foo AS SELECT * FROM v
-catalog item 'foo' already exists
+contains:catalog item 'foo' already exists
 
 > CREATE OR REPLACE TEMPORARY MATERIALIZED VIEW foo AS SELECT * FROM v
 
@@ -88,7 +88,7 @@ catalog item 'foo' already exists
 > DROP VIEW v1;
 
 ! SELECT * FROM v1;
-unknown catalog item 'v1'
+contains:unknown catalog item 'v1'
 
 # Rename temporary view
 
@@ -97,7 +97,7 @@ unknown catalog item 'v1'
 > ALTER VIEW v1 RENAME TO v2;
 
 ! SELECT * FROM v1;
-unknown catalog item 'v1'
+contains:unknown catalog item 'v1'
 
 > SELECT * FROM v2;
  f1
@@ -112,7 +112,7 @@ unknown catalog item 'v1'
 > CREATE TEMPORARY TABLE temp_t (a int, b text NOT NULL)
 
 ! CREATE TEMP TABLE temp_t (a int, b text NOT NULL)
-catalog item 'temp_t' already exists
+contains:catalog item 'temp_t' already exists
 
 > INSERT INTO temp_t VALUES (1, 'testing')
 
@@ -162,7 +162,7 @@ catalog item 'temp_t' already exists
 > ALTER TABLE t1 RENAME TO t2;
 
 ! SELECT * FROM t1;
-unknown catalog item 't1'
+contains:unknown catalog item 't1'
 
 > SELECT * FROM t2;
  f1
@@ -176,10 +176,10 @@ unknown catalog item 't1'
 > CREATE TEMPORARY TABLE t1 (f1 INTEGER);
 
 ! CREATE VIEW non_temp AS SELECT * FROM t1;
-non-temporary items cannot depend on temporary item
+contains:non-temporary items cannot depend on temporary item
 
 ! CREATE VIEW non_temp AS SELECT (SELECT * FROM t1);
-non-temporary items cannot depend on temporary item
+contains:non-temporary items cannot depend on temporary item
 
 > DROP TABLE t1;
 
@@ -187,10 +187,10 @@ non-temporary items cannot depend on temporary item
 # Make sure the mz_temp schema is protected
 
 ! DROP SCHEMA mz_temp
-cannot drop schema mz_temp because it is required by the database system
+contains:cannot drop schema mz_temp because it is required by the database system
 
 ! CREATE TABLE mz_temp.table_in_mz_temp (f1 INTEGER)
-unknown schema 'mz_temp'
+contains:unknown schema 'mz_temp'
 
 #####################################################################
 # Test things we shouldn't be able to make temporary.
@@ -206,24 +206,24 @@ $ set schema={
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE DEBEZIUM
-Expected DATABASE, SCHEMA, ROLE, USER, TYPE, INDEX, SINK, SOURCE, TABLE or [OR REPLACE] [TEMPORARY] [MATERIALIZED] VIEW or VIEWS after CREATE, found SOURCE
+contains:Expected DATABASE, SCHEMA, ROLE, USER, TYPE, INDEX, SINK, SOURCE, TABLE or [OR REPLACE] [TEMPORARY] [MATERIALIZED] VIEW or VIEWS after CREATE, found SOURCE
 
 
 ##### Temporary sinks.
 ! CREATE TEMPORARY SINK data_sink FROM data
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'data-sink'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-Expected DATABASE, SCHEMA, ROLE, USER, TYPE, INDEX, SINK, SOURCE, TABLE or [OR REPLACE] [TEMPORARY] [MATERIALIZED] VIEW or VIEWS after CREATE, found SINK
+contains:Expected DATABASE, SCHEMA, ROLE, USER, TYPE, INDEX, SINK, SOURCE, TABLE or [OR REPLACE] [TEMPORARY] [MATERIALIZED] VIEW or VIEWS after CREATE, found SINK
 
 #####################################################################
 
 ! DROP VIEW temp_v;
-cannot drop mz_temp.temp_v: still depended upon by catalog item 'mz_temp.double_temp_v'
+contains:cannot drop mz_temp.temp_v: still depended upon by catalog item 'mz_temp.double_temp_v'
 
 > DROP VIEW double_temp_v;
 
 ! SELECT * FROM double_temp_v;
-unknown catalog item 'double_temp_v'
+contains:unknown catalog item 'double_temp_v'
 
 > DISCARD TEMP
 
@@ -232,7 +232,7 @@ unknown catalog item 'double_temp_v'
 > SELECT * FROM mz_indexes WHERE name = 'temp_t_primary_idx'
 
 ! SELECT * FROM temp_v;
-unknown catalog item 'temp_v'
+contains:unknown catalog item 'temp_v'
 
 ! CREATE TEMP VIEW mz_foo.a AS SELECT 1
-cannot create temporary item in non-temporary schema
+contains:cannot create temporary item in non-temporary schema

--- a/test/testdrive/testdrive.td
+++ b/test/testdrive/testdrive.td
@@ -58,7 +58,7 @@ $ set-regex match=u\d+ replacement=UID
 | | implementation = Differential %1 %0.()
 
 ! SELECT * FROM u1234;
-unknown catalog item 'UID'
+contains:unknown catalog item 'UID'
 
 # Exclude FETCH from the retry logic
 

--- a/test/testdrive/timelines.td
+++ b/test/testdrive/timelines.td
@@ -157,7 +157,7 @@ $ kafka-ingest format=avro topic=input-cdcv2 schema=${schema} timestamp=1
     WITH (epoch_ms_timeline=false)
   FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE MATERIALIZE
-unsupported epoch_ms_timeline value
+contains:unsupported epoch_ms_timeline value
 
 # Can't specify epoch_ms_timeline and timeline.
 ! CREATE MATERIALIZED SOURCE source_cdcv2_system
@@ -165,7 +165,7 @@ unsupported epoch_ms_timeline value
     WITH (epoch_ms_timeline=false, timeline='user')
   FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE MATERIALIZE
-unexpected parameters for CREATE SOURCE: epoch_ms_timeline
+contains:unexpected parameters for CREATE SOURCE: epoch_ms_timeline
 
 > CREATE MATERIALIZED SOURCE source_cdcv2_system
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-cdcv2-${testdrive.seed}'
@@ -186,28 +186,28 @@ unexpected parameters for CREATE SOURCE: epoch_ms_timeline
 > CREATE MATERIALIZED VIEW input_values_mview AS VALUES (1), (2), (3);
 
 ! CREATE VIEW must_fail (a, b, c, d) AS SELECT * FROM source_byo, source_system;
-multiple timelines within one dataflow are not supported
+contains:multiple timelines within one dataflow are not supported
 
 ! CREATE MATERIALIZED VIEW must_fail (a, b, c, d) AS SELECT * FROM source_system, source_byo;
-multiple timelines within one dataflow are not supported
+contains:multiple timelines within one dataflow are not supported
 
 ! CREATE MATERIALIZED VIEW must_fail (a, b, c, d) AS SELECT * FROM source_system, source_byo;
-multiple timelines within one dataflow are not supported
+contains:multiple timelines within one dataflow are not supported
 
 ! CREATE MATERIALIZED VIEW must_fail (a, b, c, d) AS SELECT * FROM source_system, source_cdcv2;
-multiple timelines within one dataflow are not supported
+contains:multiple timelines within one dataflow are not supported
 
 ! CREATE MATERIALIZED VIEW must_fail (a, b, c, d) AS SELECT * FROM source_byo, source_cdcv2;
-multiple timelines within one dataflow are not supported
+contains:multiple timelines within one dataflow are not supported
 
 ! CREATE MATERIALIZED VIEW must_fail AS SELECT (SELECT a FROM source_system LIMIT 1) FROM source_byo;
-multiple timelines within one dataflow are not supported
+contains:multiple timelines within one dataflow are not supported
 
 # Verify that user timelines don't allow things to be joinable with their non-user versions.
 ! CREATE MATERIALIZED VIEW must_fail (a, b, c, d) AS SELECT * FROM source_system, source_system_user;
-multiple timelines within one dataflow are not supported
+contains:multiple timelines within one dataflow are not supported
 ! CREATE MATERIALIZED VIEW must_fail (a, b, c, d) AS SELECT * FROM source_byo, source_byo_user;
-multiple timelines within one dataflow are not supported
+contains:multiple timelines within one dataflow are not supported
 
 # Can join static view with anything.
 > CREATE VIEW values_table_view AS SELECT * FROM input_values_view, input_table;
@@ -224,27 +224,27 @@ multiple timelines within one dataflow are not supported
 
 # System things should be joinable only with system sources.
 ! CREATE VIEW must_fail (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) AS SELECT * FROM mz_catalog_names, mz_views, mz_source_info, source_byo;
-multiple timelines within one dataflow are not supported
+contains:multiple timelines within one dataflow are not supported
 ! CREATE VIEW must_fail (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) AS SELECT * FROM mz_catalog_names, mz_views, mz_source_info, source_cdcv2;
-multiple timelines within one dataflow are not supported
+contains:multiple timelines within one dataflow are not supported
 > CREATE VIEW various_system_no_byo (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) AS SELECT * FROM mz_catalog_names, mz_views, mz_source_info, source_system;
 > CREATE VIEW various_system_table (a, b, c, d, e, f, g, h, i, j, k, l, m, n) AS SELECT * FROM mz_catalog_names, mz_views, mz_source_info, input_table;
 
 # EXPLAIN should complain too.
 ! EXPLAIN SELECT * FROM source_system, source_byo;
-multiple timelines within one dataflow are not supported
+contains:multiple timelines within one dataflow are not supported
 
 # Can join user-specified timelines.
 > CREATE MATERIALIZED VIEW source_system_byo_user (a, b, c, d, e, f) AS SELECT * FROM source_system_user, source_byo_user, source_cdcv2_user;
 
 # Unless they are from different user timelines.
 ! CREATE MATERIALIZED VIEW must_fail (a, b, c, d) AS SELECT * FROM source_byo_user, source_byo_user2;
-multiple timelines within one dataflow are not supported
+contains:multiple timelines within one dataflow are not supported
 
 # CDCv2 can only be joined with system time stuff if specified
 > CREATE MATERIALIZED VIEW source_cdcv2_table_system AS SELECT * FROM source_cdcv2_system, input_table;
 ! CREATE MATERIALIZED VIEW must_fail AS SELECT * FROM source_cdcv2, input_table;
-multiple timelines within one dataflow are not supported
+contains:multiple timelines within one dataflow are not supported
 
 # Verify that timedomains don't cross timelines. In the case that
 # source_byo is grouped in the same timedomain as epoch ms sources,
@@ -253,7 +253,7 @@ multiple timelines within one dataflow are not supported
 # complains about.
 > BEGIN;
 ! SELECT * FROM source_byo;
-At least one input has no complete timestamps yet
+contains:At least one input has no complete timestamps yet
 > ROLLBACK;
 
 # Verify that if the transaction starts on some timeline (epoch ms here),
@@ -261,5 +261,5 @@ At least one input has no complete timestamps yet
 > BEGIN;
 > SELECT * FROM input_table;
 ! SELECT * FROM source_byo;
-Transactions can only reference objects in the same timedomain
+contains:Transactions can only reference objects in the same timedomain
 > ROLLBACK;

--- a/test/testdrive/timestamps-debezium-kafka.td
+++ b/test/testdrive/timestamps-debezium-kafka.td
@@ -95,13 +95,13 @@ $ kafka-ingest format=avro topic=bar schema=${schema} timestamp=1
 > CREATE MATERIALIZED VIEW join (b, foo_sum, bar_sum) AS SELECT * FROM foo JOIN bar USING (b);
 
 ! SELECT * FROM bar;
-At least one input has no complete timestamps yet:
+contains:At least one input has no complete timestamps yet:
 
 ! SELECT * FROM foo;
-At least one input has no complete timestamps yet:
+contains:At least one input has no complete timestamps yet:
 
 ! SELECT * FROM join ;
-At least one input has no complete timestamps yet:
+contains:At least one input has no complete timestamps yet:
 
 $ kafka-ingest format=avro topic=consistency timestamp=1 schema=${trxschemakey}
 {"id": "1"}

--- a/test/testdrive/transactions-stable.td
+++ b/test/testdrive/transactions-stable.td
@@ -42,4 +42,4 @@
 # in this file). Although this error message is misleading, we don't
 # expect users to do this, so it's ok for now.
 ! INSERT INTO dec VALUES (mz_logical_timestamp())
-calls to mz_logical_timestamp in in static or write queries are not supported
+contains:calls to mz_logical_timestamp in in static or write queries are not supported

--- a/test/testdrive/transactions-timedomain-nonmaterialized.td
+++ b/test/testdrive/transactions-timedomain-nonmaterialized.td
@@ -31,10 +31,10 @@ $ file-append path=static.csv
 4
 
 ! SELECT * FROM unindexed
-unable to automatically determine a query timestamp
+contains:unable to automatically determine a query timestamp
 
 ! SELECT * FROM v_unindexed
-unable to automatically determine a query timestamp
+contains:unable to automatically determine a query timestamp
 
 > BEGIN
 
@@ -46,7 +46,7 @@ unable to automatically determine a query timestamp
 4
 
 ! SELECT c FROM unindexed ORDER BY c
-Transactions can only reference objects in the same timedomain
+contains:Transactions can only reference objects in the same timedomain
 
 > ROLLBACK
 
@@ -59,7 +59,7 @@ Transactions can only reference objects in the same timedomain
 4
 
 ! SELECT * FROM v_unindexed
-Transactions can only reference objects in the same timedomain
+contains:Transactions can only reference objects in the same timedomain
 
 > ROLLBACK
 

--- a/test/testdrive/unsupported.td
+++ b/test/testdrive/unsupported.td
@@ -11,10 +11,10 @@ $ set-sql-timeout duration=125ms
 
 # DROP MATERIALIZED <anything> is not allowed
 ! DROP MATERIALIZED VIEW foo
-DROP MATERIALIZED VIEW is not allowed, use DROP VIEW
+contains:DROP MATERIALIZED VIEW is not allowed, use DROP VIEW
 
 ! DROP MATERIALIZED SOURCE foo
-DROP MATERIALIZED SOURCE is not allowed, use DROP SOURCE
+contains:DROP MATERIALIZED SOURCE is not allowed, use DROP SOURCE
 
 ! DROP MATERIALIZED TABLE foo
-DROP MATERIALIZED TABLE is not allowed, use DROP TABLE
+contains:DROP MATERIALIZED TABLE is not allowed, use DROP TABLE

--- a/test/testdrive/update.td
+++ b/test/testdrive/update.td
@@ -38,7 +38,7 @@
 4 5 be
 
 ! UPDATE t SET i = '4'::text
-SET clause does not support casting from text to integer
+contains:SET clause does not support casting from text to integer
 
 > DELETE FROM t WHERE i < 4
 
@@ -46,7 +46,7 @@ SET clause does not support casting from text to integer
 4 5 be
 
 ! UPDATE t SET f = 'a'
-invalid input syntax for type double precision
+contains:invalid input syntax for type double precision
 
 # Ensure that we can update after an error.
 > UPDATE t SET f = 6::FLOAT
@@ -67,30 +67,30 @@ invalid input syntax for type double precision
 > CREATE MATERIALIZED VIEW v (a) AS SELECT 4;
 
 ! UPDATE t SET i = i + 1 WHERE i IN (SELECT a FROM v);
-invalid selection
+contains:invalid selection
 
 ! UPDATE v SET a = 1
-cannot mutate view
+contains:cannot mutate view
 
 ! UPDATE mz_tables SET a = 1
-cannot mutate system table
+contains:cannot mutate system table
 
 ! UPDATE t SET a = 1
-unknown column a
+contains:unknown column a
 
 ! UPDATE t SET i = 1 WHERE a = 1
-column "a" does not exist
+contains:column "a" does not exist
 
 ! UPDATE t SET i = 1 WHERE i = 'a'
-invalid input syntax for type integer
+contains:invalid input syntax for type integer
 
 ! UPDATE t SET i = 1, i = 1
-column i set twice
+contains:column i set twice
 
 > BEGIN
 
 ! UPDATE t SET i = 1
-cannot be run inside a transaction block
+contains:cannot be run inside a transaction block
 
 > ROLLBACK
 
@@ -99,14 +99,14 @@ cannot be run inside a transaction block
 
 > INSERT INTO t DEFAULT VALUES;
 ! UPDATE t SET i = 1
-cannot be run inside a transaction block
+contains:cannot be run inside a transaction block
 
 > ROLLBACK
 
 > BEGIN
 
 ! DELETE FROM t
-cannot be run inside a transaction block
+contains:cannot be run inside a transaction block
 
 > ROLLBACK
 
@@ -217,7 +217,7 @@ DELETE FROM c WHERE a < 3;
 
 # Lateral subqueries cannot access `FROM` table
 ! DELETE FROM t3 USING lateral (SELECT t3.x FROM t1) t4 WHERE true;
-column "t3.x" does not exist
+contains:column "t3.x" does not exist
 
 # ...unless it's explicitly brought into scope
 > DELETE FROM t3 USING lateral (SELECT t3.x FROM t3) t4 WHERE true;

--- a/test/upgrade/check-from-any_version-database-schema.td
+++ b/test/upgrade/check-from-any_version-database-schema.td
@@ -20,4 +20,4 @@ public
 > DROP DATABASE "some database";
 
 ! SELECT * FROM "some database"."some schema".t1;
-unknown database
+contains:unknown database

--- a/test/upgrade/check-from-any_version-table.td
+++ b/test/upgrade/check-from-any_version-table.td
@@ -34,4 +34,4 @@
 f1 false integer
 
 ! INSERT INTO not_null VALUES (null)
-null value in column "f1" violates not-null constraint
+contains:null value in column "f1" violates not-null constraint

--- a/test/upgrade/check-from-v0.17.0-persistent-user-tables-diffs.td
+++ b/test/upgrade/check-from-v0.17.0-persistent-user-tables-diffs.td
@@ -13,10 +13,10 @@
 true
 
 ! SELECT * FROM persistent_user_table_negative_diff;
-Invalid data in source, saw retractions (1) for row that does not exist: [Null]
+contains:Invalid data in source, saw retractions (1) for row that does not exist: [Null]
 
 ! SELECT * FROM persistent_user_table_large_negative_diff;
-Invalid data in source, saw retractions (8589934592) for row that does not exist: [Null]
+contains:Invalid data in source, saw retractions (8589934592) for row that does not exist: [Null]
 
 > SELECT COUNT(*) = 0 FROM persistent_user_table_cancelling_diffs;
 true

--- a/test/upgrade/check-from-v0.9.2-csv-header-alias.td
+++ b/test/upgrade/check-from-v0.9.2-csv-header-alias.td
@@ -18,7 +18,7 @@ definitely,different
   SELECT * FROM csv_upgrade_with_header_alias_missing_file
 
 ! SELECT * FROM breaker
-source file contains incorrect columns
+contains:source file contains incorrect columns
 
 $ file-append path=changer.csv
 no,body
@@ -28,4 +28,4 @@ no,body
   SELECT * FROM csv_upgrade_with_file_change
 
 ! SELECT * FROM breaker_file_change
-source file contains incorrect columns
+contains:source file contains incorrect columns

--- a/test/upgrade/create-in-v0.7.3-role.td
+++ b/test/upgrade/create-in-v0.7.3-role.td
@@ -13,7 +13,7 @@
 
 # If this begins to succeeed, this means additional tests need to be added
 ! CREATE ROLE nosuperuser_login NOSUPERUSER LOGIN;
-non-superusers not yet supported
+contains:non-superusers not yet supported
 
 ! CREATE ROLE superuser_nologin SUPERUSER NOLOGIN;
-non-login users not yet supported
+contains:non-login users not yet supported

--- a/test/upgrade/create-in-v0.7.3-special-functions.td
+++ b/test/upgrade/create-in-v0.7.3-special-functions.td
@@ -21,7 +21,7 @@
 # if they ever are allowed, add an upgrade test for them
 
 ! CREATE MATERIALIZED VIEW foo AS SELECT NOW();
-cannot be used in static queries
+contains:cannot be used in static queries
 
 ! CREATE MATERIALIZED VIEW bar AS SELECT CURRENT_TIMESTAMP();
-cannot be used in static queries
+contains:cannot be used in static queries


### PR DESCRIPTION
This converts the post-substitution error string into a regex, and checks for a match instead of just containment.

### Motivation

* This PR adds a feature that has not yet been specified.

  I have often wanted to verify that two aspects of an error message match a
  pattern exactly, while not caring what is between them. For example: `Unable
  to get S3 object <bucket_name>/<object_name>: Access Denied`. The exact object
  that we download doesn't matter -- in fact it's reasonable for multiple
  buckets to be part of the query -- but the overall pattern should be verified.

  With this change, I'll be able to expect an error message like:

  `Unable to get S3 object ${bucket_name}.*Access Denied`

   or even: `Unable to get S3 object.*Access Denied`

### Checklist

Just sending this up for review, I'd like to use it in an upcoming PR, and wanted to see whether there was any appetite for this separately.

- [ ] This PR has adequate test coverage / QA involvement has been duly
      considered.
- [n/a] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).