### PR TITLE
scratch: add persist-benchmarking shortcut for create

### DIFF
--- a/misc/scratch/persist-benchmarking.json
+++ b/misc/scratch/persist-benchmarking.json
@@ -1,0 +1,8 @@
+{
+    "name": "persist benchmarking",
+    "launch_script": "true",
+    "instance_type": "r5a.4xlarge",
+    "ami": "ami-0b29b6e62f2343b46",
+    "size_gb": 200,
+    "tags": {}
+}


### PR DESCRIPTION
I keep manually making this and then stashing the change. It's unclear
what the best instance_type for this is, but the one in dev-box.json is
definitely not powerful enough, so starting with the one used for our
release load tests. (It's also the one I've been using.)

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [N/A] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
