### PR TITLE
testdrive: invoke real protoc in protobuf-compile action

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5027,7 +5027,7 @@ dependencies = [
  "predicates",
  "prost",
  "prost-reflect",
- "protobuf",
+ "protobuf-src",
  "rand",
  "rdkafka",
  "regex",

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -39,7 +39,7 @@ pgrepr = { path = "../pgrepr" }
 postgres_array = { git = "https://github.com/MaterializeInc/rust-postgres-array", branch = "mz-0.7.2" }
 prost = "0.9.0"
 prost-reflect = { version = "0.5.3", features = ["serde"] }
-protobuf = { git = "https://github.com/MaterializeInc/rust-protobuf.git" }
+protobuf-src = "1.0.4"
 rand = "0.8.4"
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "libz-static"] }
 regex = "1.5.4"

--- a/src/testdrive/ci/.gitignore
+++ b/src/testdrive/ci/.gitignore
@@ -1,3 +1,4 @@
 /kdestroy
 /kinit
+/protobuf-install
 /testdrive

--- a/src/testdrive/ci/Dockerfile
+++ b/src/testdrive/ci/Dockerfile
@@ -16,6 +16,10 @@ RUN apt-get update && apt-get -qy install \
 
 COPY kdestroy kinit testdrive /usr/local/bin/
 
+# Install the Protobuf compiler from protobuf-src.
+COPY protobuf-install /usr/local/
+ENV PROTOC /usr/local/bin/protoc
+
 WORKDIR /workdir
 
 RUN mkdir -p /share/tmp && chmod 777 /share/tmp

--- a/src/testdrive/ci/mzbuild.yml
+++ b/src/testdrive/ci/mzbuild.yml
@@ -15,3 +15,5 @@ pre-image:
       krb5-src:
         install/bin/kinit: .
         install/bin/kdestroy: .
+      protobuf-src:
+        install: protobuf-install


### PR DESCRIPTION
Extracted from #10079. See that PR for justification on the migration of
rust-protobuf.

This commit changes testdrive to invoke the proper `protoc` binary
that's built by the protobuf-src crate. Using a real Protobuf compiler
is more representative of how our end users build descriptors.

The blocker to this historically has been that we didn't want protobuf
to become a build dependency via `brew install protobuf`, since
different developers wind up with different versions of protobuf
installed. The protobuf-src crate fixes that by vendoring a particular
version of the protobuf source code and building it from source.

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
