### PR TITLE
core,test: Allow stack traces on SIGSEGV/SIGBUS to be disabled

### DIFF
--- a/test/antithesis/driver/docker-compose.yml
+++ b/test/antithesis/driver/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       --timestamp-frequency 100ms
       --disable-telemetry
       --retain-prometheus-metrics 1s
+      --no-sigbus-sigsegv-backtraces
     image: antithesis-materialized
     volumes:
       - mzdata:/share/mzdata:rw


### PR DESCRIPTION
Attempting to dump stack traces in case of SIGSEGV/SIGBUS may
cause the core file to become garbled and contain the strack frames
of the stack dumper and not the original stack frames that lead to the
crash.

Provide an option to disable stack traces on SIGSEGV/SIGBUS and
use it to obtain core files in the Antithesis environment
in order to debug one particular issue that only happens there.


### Motivation
  * This PR adds a feature that has not yet been specified.