### PR TITLE
dataflow: demonstrate how a halfway fix leads us to reading TOO MANY records from Kafka

### DIFF
--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -1681,13 +1681,13 @@ impl SourceReaderPersistence {
             self.config.upper_data_seal_ts,
         )?;
 
-        tracing::trace!(
+        tracing::debug!(
             "In {}, initial (restored) source offsets: {:?}",
             self.source_name,
             offsets,
         );
 
-        tracing::trace!(
+        tracing::debug!(
             "In {}, initial (restored) timestamp bindings: {:?}",
             self.source_name,
             bindings,

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -1682,9 +1682,11 @@ impl SourceReaderPersistence {
         )?;
 
         tracing::debug!(
-            "In {}, initial (restored) source offsets: {:?}",
+            "In {}, initial (restored) source offsets: {:?}. upper_bindings_seal_ts = {}, upper_data_seal_ts = {}",
             self.source_name,
             offsets,
+            self.config.upper_bindings_seal_ts,
+            self.config.upper_data_seal_ts,
         );
 
         tracing::debug!(

--- a/test/persistence/kafka-sources/failpoint-after.td
+++ b/test/persistence/kafka-sources/failpoint-after.td
@@ -9,3 +9,11 @@
 
 > SELECT COUNT(*) FROM failpoint;
 1000000
+
+# We expect to read at least some of the messages from Kafka after restarting
+> SELECT SUM(CAST(statistics->'topics'->'testdrive-failpoint-${testdrive.seed}'->'partitions'->'0'->'msgs' AS INT)) > 1 FROM mz_kafka_source_statistics;
+true
+
+# We also expect, though, that some messages we're successfully read before we activated the failpoint and restarted
+> SELECT SUM(CAST(statistics->'topics'->'testdrive-failpoint-${testdrive.seed}'->'partitions'->'0'->'msgs' AS INT)) < 1000000 FROM mz_kafka_source_statistics;
+true

--- a/test/persistence/mzcompose.py
+++ b/test/persistence/mzcompose.py
@@ -19,9 +19,9 @@ from materialize.mzcompose.services import (
     Zookeeper,
 )
 
-mz_options = "--persistent-user-tables --persistent-kafka-upsert-source --disable-persistent-system-tables-test"
+mz_options = "--log-filter=dataflow::source=trace,persist::operators::stream=trace --persistent-user-tables --persistent-kafka-upsert-source --disable-persistent-system-tables-test"
 
-mz_default = Materialized(options=mz_options)
+mz_default = Materialized(timestamp_frequency="100ms", options=mz_options)
 
 mz_logical_compaction_window_off = Materialized(
     options=f"{mz_options} --logical-compaction-window=off"


### PR DESCRIPTION
This is a demonstration for some of the behaviour that is wrong before #10128. And includes a fix that we should include there.