### PR TITLE
Improve error message specificity for AWS initialization errors

### DIFF
--- a/src/aws-util/src/kinesis.rs
+++ b/src/aws-util/src/kinesis.rs
@@ -24,7 +24,7 @@ pub fn client(config: &AwsConfig) -> Result<Client, anyhow::Error> {
     if let Some(endpoint) = config.endpoint() {
         builder = builder.endpoint_resolver(endpoint.clone());
     }
-    let conn = util::connector()?;
+    let conn = util::connector("Kinesis")?;
     Ok(Client::from_conf_conn(builder.build(), conn))
 }
 

--- a/src/aws-util/src/s3.rs
+++ b/src/aws-util/src/s3.rs
@@ -21,6 +21,6 @@ pub fn client(config: &AwsConfig) -> Result<Client, anyhow::Error> {
     if let Some(endpoint) = config.endpoint() {
         builder = builder.endpoint_resolver(endpoint.clone());
     }
-    let conn = util::connector()?;
+    let conn = util::connector("S3")?;
     Ok(Client::from_conf_conn(builder.build(), conn))
 }

--- a/src/aws-util/src/sqs.rs
+++ b/src/aws-util/src/sqs.rs
@@ -21,6 +21,6 @@ pub fn client(config: &AwsConfig) -> Result<Client, anyhow::Error> {
     if let Some(endpoint) = config.endpoint() {
         builder = builder.endpoint_resolver(endpoint.clone());
     }
-    let conn = util::connector()?;
+    let conn = util::connector("SQS")?;
     Ok(Client::from_conf_conn(builder.build(), conn))
 }

--- a/src/aws-util/src/sts.rs
+++ b/src/aws-util/src/sts.rs
@@ -21,6 +21,6 @@ pub fn client(config: &AwsConfig) -> Result<Client, anyhow::Error> {
     if let Some(endpoint) = config.endpoint() {
         builder = builder.endpoint_resolver(endpoint.clone());
     }
-    let conn = util::connector()?;
+    let conn = util::connector("STS")?;
     Ok(Client::from_conf_conn(builder.build(), conn))
 }

--- a/src/aws-util/src/util.rs
+++ b/src/aws-util/src/util.rs
@@ -11,7 +11,8 @@ use anyhow::anyhow;
 use aws_smithy_client::erase::DynConnector;
 use aws_smithy_client::hyper_ext::Adapter;
 
-pub fn connector() -> Result<DynConnector, anyhow::Error> {
-    let connector = mz_http_proxy::hyper::connector().map_err(|e| anyhow!("{}", e))?;
+pub fn connector(service: &str) -> Result<DynConnector, anyhow::Error> {
+    let connector = mz_http_proxy::hyper::connector()
+        .map_err(|e| anyhow!("Unable to build AWS {} HTTP connector: {}", service, e))?;
     Ok(DynConnector::new(Adapter::builder().build(connector)))
 }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -592,7 +592,7 @@ pub fn plan_create_source(
 
             let region = arn
                 .region
-                .ok_or_else(|| anyhow!("Provided ARN does not include an AWS region"))?;
+                .ok_or_else(|| anyhow!("Provided Kinesis ARN does not include an AWS region"))?;
 
             let aws = normalize::aws_config(&mut with_options, Some(region.into()))?;
             let connector =


### PR DESCRIPTION
Previously the purification step would fail with a message that contained just
"Unable to build connector." Which doesn't explain why we're trying to build a
connector, what kind of connector it is, or provide resolution steps.

With this, we know that it's failing to validate, it will say something like
"Access Denied" if it's not possible to access STS, etc.