### PR TITLE
persist: ensure there is a tokio runtime available in BlobCache

### DIFF
--- a/src/persist/benches/writer.rs
+++ b/src/persist/benches/writer.rs
@@ -26,7 +26,7 @@ use persist_types::Codec;
 use rand::prelude::{SliceRandom, SmallRng};
 use rand::{Rng, SeedableRng};
 use timely::progress::Antichain;
-use tokio::runtime::Runtime;
+use tokio::runtime::Runtime as AsyncRuntime;
 
 use persist::client::WriteReqBuilder;
 use persist::error::Error;
@@ -265,9 +265,15 @@ pub fn bench_writes_indexed(c: &mut Criterion) {
     let file_log = new_file_log("indexed_write_drain_log", temp_dir.path());
     let file_blob = new_file_blob("indexed_write_drain_blob", temp_dir.path());
 
+    let async_runtime = Arc::new(AsyncRuntime::new().unwrap());
     let metrics = Arc::new(Metrics::register_with(&MetricsRegistry::new()));
-    let blob_cache = BlobCache::new(build_info::DUMMY_BUILD_INFO, metrics.clone(), file_blob);
-    let compacter = Maintainer::new(blob_cache.clone(), Arc::new(Runtime::new().unwrap()));
+    let blob_cache = BlobCache::new(
+        build_info::DUMMY_BUILD_INFO,
+        metrics.clone(),
+        async_runtime.clone(),
+        file_blob,
+    );
+    let compacter = Maintainer::new(blob_cache.clone(), async_runtime);
     let file_indexed = Indexed::new(file_log, blob_cache, compacter, metrics)
         .expect("failed to create file indexed");
     bench_writes_indexed_inner(file_indexed, "file", &mut group).expect("running benchmark failed");
@@ -324,18 +330,29 @@ pub fn bench_writes_blob_cache(c: &mut Criterion) {
     group.warm_up_time(Duration::from_secs(1));
     group.measurement_time(Duration::from_secs(1));
 
+    let async_runtime = Arc::new(AsyncRuntime::new().expect("failed to create runtime"));
     let mem_blob = MemRegistry::new()
         .blob_no_reentrance()
         .expect("creating a MemBlob cannot fail");
     let metrics = Arc::new(Metrics::register_with(&MetricsRegistry::new()));
-    let mut mem_blob_cache = BlobCache::new(build_info::DUMMY_BUILD_INFO, metrics, mem_blob);
+    let mut mem_blob_cache = BlobCache::new(
+        build_info::DUMMY_BUILD_INFO,
+        metrics,
+        async_runtime.clone(),
+        mem_blob,
+    );
 
     // Create a directory that will automatically be dropped after the test finishes.
     let temp_dir = tempfile::tempdir().expect("failed to create temp directory");
     let file_blob = new_file_blob("indexed_write_drain_blob", temp_dir.path());
 
     let metrics = Arc::new(Metrics::register_with(&MetricsRegistry::new()));
-    let mut file_blob_cache = BlobCache::new(build_info::DUMMY_BUILD_INFO, metrics, file_blob);
+    let mut file_blob_cache = BlobCache::new(
+        build_info::DUMMY_BUILD_INFO,
+        metrics,
+        async_runtime,
+        file_blob,
+    );
 
     let data = DataGenerator::default();
     let batches = data.batches().collect::<Vec<_>>();

--- a/src/persist/src/operators/stream.rs
+++ b/src/persist/src/operators/stream.rs
@@ -733,7 +733,7 @@ mod tests {
     use timely::dataflow::operators::probe::Probe;
     use timely::dataflow::operators::Capture;
     use timely::Config;
-    use tokio::runtime::Runtime;
+    use tokio::runtime::Runtime as AsyncRuntime;
 
     use crate::error::Error;
     use crate::indexed::{ListenEvent, SnapshotExt};
@@ -982,8 +982,8 @@ mod tests {
         condition_read.listen(condition_listen_tx)?;
         let (listen_tx, listen_rx) = crossbeam_channel::unbounded();
 
-        let runtime = Runtime::new()?;
-        let listener_handle = runtime.spawn(async move {
+        let async_runtime = AsyncRuntime::new()?;
+        let listener_handle = async_runtime.spawn(async move {
             let mut num_channels_closed = 0;
             loop {
                 crossbeam_channel::select! {


### PR DESCRIPTION
Fixes a panic when using s3 storage.

Before, we were making a tokio::runtime::Runtime available in the
thread-local context (tokio calls this "runtime context" but there's
already enough runtimes here) for the entirety of the execution of the
persist runtime. This was clunky (see the bit in start where we had to
make sure it was available for Indexed::new) and error prone (see the
bug this closes). Instead plumb one to BlobCache and internally use it
to make sure it's available in the thread-local context for any calls
into Blob implementations.

Additionally, there has previously been confusion around the "persist
runtime" vs the "async runtime" within src/persist. So, take this
opportunity to rename all imports within src/persist so they're now
tokio::runtime::{Runtime as AsyncRuntime}. This was already done in some
places, so this is just being more consistent about it. We also rename
all variable names of this type to be async_runtime.

Closes #10132

### Motivation

  * This PR fixes a recognized bug

### Tips for reviewer

I think I caught all the "runtime" -> "async_runtime" renames, but feel free to poke around for any I missed.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
