### PR TITLE
mzcompose: acquire images on service definition override

### DIFF
--- a/misc/python/materialize/benches/avro_ingest.py
+++ b/misc/python/materialize/benches/avro_ingest.py
@@ -96,8 +96,9 @@ def main() -> None:
     wait_for_confluent(args.confluent_host)
 
     images = ["kgen", "materialized"]
-    deps = repo.resolve_dependencies([repo.images[name] for name in images])
-    deps.acquire()
+    deps = repo.resolve_dependencies(
+        [repo.images[name] for name in images], acquire=True
+    )
 
     docker_client = docker.from_env()
 

--- a/misc/python/materialize/ci_util.py
+++ b/misc/python/materialize/ci_util.py
@@ -20,8 +20,7 @@ def acquire_materialized(repo: mzbuild.Repository, out: Path) -> None:
     This avoids an expensive rebuild if a Docker image is available from Docker
     Hub.
     """
-    deps = repo.resolve_dependencies([repo.images["materialized"]])
-    deps.acquire()
+    deps = repo.resolve_dependencies([repo.images["materialized"]], acquire=True)
     out.parent.mkdir(parents=True, exist_ok=True)
     with open(out, "wb") as f:
         spawn.runv(

--- a/misc/python/materialize/cli/deploy_antithesis.py
+++ b/misc/python/materialize/cli/deploy_antithesis.py
@@ -25,8 +25,9 @@ REGISTRY = "us-central1-docker.pkg.dev/molten-verve-216720/materialize-repositor
 def main() -> None:
     root = Path(os.environ["MZ_ROOT"])
     repo = mzbuild.Repository(root)
-    deps = repo.resolve_dependencies([repo.images[name] for name in IMAGES])
-    deps.acquire()
+    deps = repo.resolve_dependencies(
+        [repo.images[name] for name in IMAGES], acquire=True
+    )
     for mzimage in IMAGES:
         spawn.runv(["docker", "tag", deps[mzimage].spec(), f"{REGISTRY}/{mzimage}"])
         spawn.runv(["docker", "push", f"{REGISTRY}/{mzimage}"])

--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -342,8 +342,9 @@ class SqlCommand(Command):
         # if the service isn't running or isn't exposing a port.
         composition.default_port(args.service)
 
-        deps = composition.repo.resolve_dependencies([composition.repo.images["psql"]])
-        deps.acquire()
+        deps = composition.repo.resolve_dependencies(
+            [composition.repo.images["psql"]], acquire=True
+        )
         deps["psql"].run(
             [
                 "-h",

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -805,13 +805,17 @@ class Repository:
         """The path to the root directory for the repository."""
         return self.rd.root
 
-    def resolve_dependencies(self, targets: Iterable[Image]) -> DependencySet:
+    def resolve_dependencies(
+        self, targets: Iterable[Image], acquire: bool = False
+    ) -> DependencySet:
         """Compute the dependency set necessary to build target images.
 
         The dependencies of `targets` will be crawled recursively until the
         complete set of transitive dependencies is determined or a circular
         dependency is discovered. The returned dependency set will be sorted
         in topological order.
+
+        The dependencies will also be acquired if `acquire` is set.
 
         Raises:
            ValueError: A circular dependency was discovered in the images
@@ -835,7 +839,11 @@ class Repository:
         for target in sorted(targets, key=lambda image: image.name):
             visit(target)
 
-        return DependencySet(resolved.values())
+        deps = DependencySet(resolved.values())
+        if acquire:
+            deps.acquire()
+
+        return deps
 
     def __iter__(self) -> Iterator[Image]:
         return iter(self.images.values())


### PR DESCRIPTION
- If the `c.override(service)` construct is used, attempt to aquire
  (compile if needed) any new images that are needed
- Add a new argument "acquire" to resolve_dependencies(). The default is
  False so that e.g. ./mzcompose down -v does not perform any acquisition.

## Justification

  * This PR fixes a previously unreported bug.

The feature benchmark would fail to run if the current source has not been compiled previously. So, we need to perform image aquisition (fetching or compilation) for any overriden service definitions.