### PR TITLE
feature-benchmark: Sleep 10ms when retrying a query

### DIFF
--- a/misc/python/materialize/feature_benchmark/executor.py
+++ b/misc/python/materialize/feature_benchmark/executor.py
@@ -75,7 +75,7 @@ class Docker(Executor):
                 "testdrive-svc",
                 "--no-reset",
                 f"--seed={self._seed}",
-                "--initial-backoff=0ms",
+                "--initial-backoff=10ms",
                 "--backoff-factor=0",
                 f"tmp/{basename}",
                 capture=True,


### PR DESCRIPTION
Previously, testdrive retried each query until it succeeds, without
any delay. Introduce a 10ms delay in order to burn less CPU in
busy waiting.

The noise floor when it comes to operations that require retries,
such as waiting for a source to become fully hydrated is such that
precise measurements with resolution less than 10ms are unlikely
in practice.

  * This PR fixes a previously unreported bug.

The benchmark numbers in the Nightly CI are all over the place due to the use of EC2 instances with variable performance. See if this change will help somewhat with stabilization.