### PR TITLE
http-proxy: make hyper connector constructor infallible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,6 +1375,7 @@ dependencies = [
  "futures",
  "globset",
  "http",
+ "http-serde",
  "interchange",
  "kafka-util",
  "mz-aws-util",
@@ -2268,6 +2269,16 @@ dependencies = [
  "bytes",
  "http",
  "pin-project-lite",
+]
+
+[[package]]
+name = "http-serde"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25698ac7002625796d5a7df8f0602400571da944c2edc1d5c268a6947dd4f692"
+dependencies = [
+ "http",
+ "serde",
 ]
 
 [[package]]

--- a/src/aws-util/src/kinesis.rs
+++ b/src/aws-util/src/kinesis.rs
@@ -19,13 +19,12 @@ use crate::util;
 
 /// Constructs a new AWS Kinesis client that respects the
 /// [system proxy configuration](mz_http_proxy#system-proxy-configuration).
-pub fn client(config: &AwsConfig) -> Result<Client, anyhow::Error> {
+pub fn client(config: &AwsConfig) -> Client {
     let mut builder = aws_sdk_kinesis::config::Builder::from(config.inner());
     if let Some(endpoint) = config.endpoint() {
         builder = builder.endpoint_resolver(endpoint.clone());
     }
-    let conn = util::connector()?;
-    Ok(Client::from_conf_conn(builder.build(), conn))
+    Client::from_conf_conn(builder.build(), util::connector())
 }
 
 /// Wrapper around AWS Kinesis ListShards API.

--- a/src/aws-util/src/s3.rs
+++ b/src/aws-util/src/s3.rs
@@ -16,11 +16,10 @@ use crate::util;
 
 /// Constructs a new AWS S3 client that respects the
 /// [system proxy configuration](mz_http_proxy#system-proxy-configuration).
-pub fn client(config: &AwsConfig) -> Result<Client, anyhow::Error> {
+pub fn client(config: &AwsConfig) -> Client {
     let mut builder = aws_sdk_s3::config::Builder::from(config.inner());
     if let Some(endpoint) = config.endpoint() {
         builder = builder.endpoint_resolver(endpoint.clone());
     }
-    let conn = util::connector()?;
-    Ok(Client::from_conf_conn(builder.build(), conn))
+    Client::from_conf_conn(builder.build(), util::connector())
 }

--- a/src/aws-util/src/sqs.rs
+++ b/src/aws-util/src/sqs.rs
@@ -16,11 +16,10 @@ use crate::util;
 
 /// Constructs a new AWS SQS client that respects the
 /// [system proxy configuration](mz_http_proxy#system-proxy-configuration).
-pub fn client(config: &AwsConfig) -> Result<Client, anyhow::Error> {
+pub fn client(config: &AwsConfig) -> Client {
     let mut builder = aws_sdk_sqs::config::Builder::from(config.inner());
     if let Some(endpoint) = config.endpoint() {
         builder = builder.endpoint_resolver(endpoint.clone());
     }
-    let conn = util::connector()?;
-    Ok(Client::from_conf_conn(builder.build(), conn))
+    Client::from_conf_conn(builder.build(), util::connector())
 }

--- a/src/aws-util/src/sts.rs
+++ b/src/aws-util/src/sts.rs
@@ -16,11 +16,10 @@ use crate::util;
 
 /// Constructs a new AWS STS client that respects the
 /// [system proxy configuration](mz_http_proxy#system-proxy-configuration).
-pub fn client(config: &AwsConfig) -> Result<Client, anyhow::Error> {
+pub fn client(config: &AwsConfig) -> Client {
     let mut builder = aws_sdk_sts::config::Builder::from(config.inner());
     if let Some(endpoint) = config.endpoint() {
         builder = builder.endpoint_resolver(endpoint.clone());
     }
-    let conn = util::connector()?;
-    Ok(Client::from_conf_conn(builder.build(), conn))
+    Client::from_conf_conn(builder.build(), util::connector())
 }

--- a/src/aws-util/src/util.rs
+++ b/src/aws-util/src/util.rs
@@ -7,11 +7,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use anyhow::anyhow;
 use aws_smithy_client::erase::DynConnector;
 use aws_smithy_client::hyper_ext::Adapter;
 
-pub fn connector() -> Result<DynConnector, anyhow::Error> {
-    let connector = mz_http_proxy::hyper::connector().map_err(|e| anyhow!("{}", e))?;
-    Ok(DynConnector::new(Adapter::builder().build(connector)))
+pub fn connector() -> DynConnector {
+    DynConnector::new(Adapter::builder().build(mz_http_proxy::hyper::connector()))
 }

--- a/src/dataflow-types/Cargo.toml
+++ b/src/dataflow-types/Cargo.toml
@@ -23,6 +23,7 @@ interchange = { path = "../interchange" }
 persist-types = { path = "../persist-types" }
 kafka-util = { path = "../kafka-util" }
 http = "0.2.6"
+http-serde = "1.0.3"
 tracing = "0.1.29"
 num_enum = "0.5.6"
 mz-aws-util = { path = "../aws-util" }

--- a/src/dataflow/src/source/kinesis.rs
+++ b/src/dataflow/src/source/kinesis.rs
@@ -260,7 +260,7 @@ async fn create_state(
     ),
     anyhow::Error,
 > {
-    let config = c.aws.load().await?;
+    let config = c.aws.load().await;
     let kinesis_client = kinesis::client(&config);
 
     let shard_set = kinesis::get_shard_ids(&kinesis_client, &c.stream_name).await?;

--- a/src/dataflow/src/source/kinesis.rs
+++ b/src/dataflow/src/source/kinesis.rs
@@ -261,7 +261,7 @@ async fn create_state(
     anyhow::Error,
 > {
     let config = c.aws.load().await?;
-    let kinesis_client = kinesis::client(&config)?;
+    let kinesis_client = kinesis::client(&config);
 
     let shard_set = kinesis::get_shard_ids(&kinesis_client, &c.stream_name).await?;
     let mut shard_queue: VecDeque<(String, Option<String>)> = VecDeque::new();

--- a/src/dataflow/src/source/s3.rs
+++ b/src/dataflow/src/source/s3.rs
@@ -133,7 +133,7 @@ async fn download_objects_task(
     let client = match aws_config
         .load()
         .await
-        .and_then(|config| mz_aws_util::s3::client(&config))
+        .map(|config| mz_aws_util::s3::client(&config))
     {
         Ok(client) => client,
         Err(e) => {
@@ -261,7 +261,7 @@ async fn scan_bucket_task(
     let client = match aws_config
         .load()
         .await
-        .and_then(|config| mz_aws_util::s3::client(&config))
+        .map(|config| mz_aws_util::s3::client(&config))
     {
         Ok(client) => client,
         Err(e) => {
@@ -397,7 +397,7 @@ async fn read_sqs_task(
     let client = match aws_config
         .load()
         .await
-        .and_then(|config| mz_aws_util::sqs::client(&config))
+        .map(|config| mz_aws_util::sqs::client(&config))
     {
         Ok(client) => client,
         Err(e) => {

--- a/src/dataflow/src/source/s3.rs
+++ b/src/dataflow/src/source/s3.rs
@@ -130,21 +130,8 @@ async fn download_objects_task(
     compression: Compression,
     metrics: SourceBaseMetrics,
 ) {
-    let client = match aws_config
-        .load()
-        .await
-        .map(|config| mz_aws_util::s3::client(&config))
-    {
-        Ok(client) => client,
-        Err(e) => {
-            tx.send(Err(S3Error::ClientConstructionFailed(e)))
-                .await
-                .unwrap_or_else(|e| {
-                    tracing::debug!("unable to send error on stream creating s3 client: {}", e)
-                });
-            return;
-        }
-    };
+    let config = aws_config.load().await;
+    let client = mz_aws_util::s3::client(&config);
 
     struct BucketInfo {
         keys: HashSet<String>,
@@ -258,21 +245,8 @@ async fn scan_bucket_task(
     tx: Sender<S3Result<KeyInfo>>,
     base_metrics: SourceBaseMetrics,
 ) {
-    let client = match aws_config
-        .load()
-        .await
-        .map(|config| mz_aws_util::s3::client(&config))
-    {
-        Ok(client) => client,
-        Err(e) => {
-            tx.send(Err(S3Error::ClientConstructionFailed(e)))
-                .await
-                .unwrap_or_else(|e| {
-                    tracing::debug!("unable to send error on stream creating s3 client: {}", e)
-                });
-            return;
-        }
-    };
+    let config = aws_config.load().await;
+    let client = mz_aws_util::s3::client(&config);
 
     let glob = glob.as_ref();
     let prefix = glob.map(|g| find_prefix(g.glob().glob()));
@@ -394,25 +368,8 @@ async fn read_sqs_task(
         queue,
     );
 
-    let client = match aws_config
-        .load()
-        .await
-        .map(|config| mz_aws_util::sqs::client(&config))
-    {
-        Ok(client) => client,
-        Err(e) => {
-            tx.send(Err(S3Error::ClientConstructionFailed(e)))
-                .await
-                .unwrap_or_else(|e| {
-                    tracing::debug!(
-                        "source_id={} unable to send error on stream creating sqs client: {}",
-                        source_id,
-                        e
-                    )
-                });
-            return;
-        }
-    };
+    let config = aws_config.load().await;
+    let client = mz_aws_util::sqs::client(&config);
 
     let glob = glob.as_ref();
 
@@ -657,7 +614,6 @@ enum DownloadError {
 
 #[derive(Debug)]
 enum S3Error {
-    ClientConstructionFailed(anyhow::Error),
     GetObjectError {
         bucket: String,
         key: String,
@@ -684,9 +640,6 @@ impl From<S3Error> for std::io::Error {
 impl std::fmt::Display for S3Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            S3Error::ClientConstructionFailed(err) => {
-                write!(f, "Unable to build S3 client: {}", err)
-            }
             S3Error::GetObjectError { bucket, key, err } => {
                 write!(f, "Unable to get S3 object {}/{}: {}", bucket, key, err)
             }
@@ -954,9 +907,7 @@ impl SourceReader for S3SourceReader {
                     );
                     Ok(NextMessage::Pending)
                 }
-                e @ (S3Error::ListObjectsFailed { .. }
-                | S3Error::ClientConstructionFailed(_)
-                | S3Error::IoError { .. }) => Err(e.into()),
+                e @ (S3Error::ListObjectsFailed { .. } | S3Error::IoError { .. }) => Err(e.into()),
             },
             None => Ok(NextMessage::Pending),
             Some(None) => Ok(NextMessage::Finished),

--- a/src/persist/src/s3.rs
+++ b/src/persist/src/s3.rs
@@ -57,8 +57,7 @@ impl S3BlobConfig {
             loader = loader.credentials_provider(role_provider.build(default_provider));
         }
         let config = AwsConfig::from_loader(loader).await;
-        let client = mz_aws_util::s3::client(&config)
-            .map_err(|err| format!("connecting client: {}", err))?;
+        let client = mz_aws_util::s3::client(&config);
         Ok(S3BlobConfig {
             client,
             bucket,

--- a/src/s3-datagen/src/main.rs
+++ b/src/s3-datagen/src/main.rs
@@ -99,7 +99,7 @@ async fn run() -> anyhow::Result<()> {
         .collect::<String>();
 
     let config = AwsConfig::load_from_env().await;
-    let client = mz_aws_util::s3::client(&config)?;
+    let client = mz_aws_util::s3::client(&config);
 
     let first_object_key = format!("{}{:>05}", args.key_prefix, 0);
 

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -16,9 +16,9 @@
 
 use std::collections::BTreeMap;
 
-use anyhow::{anyhow, bail};
+use anyhow::{anyhow, bail, Context};
 
-use dataflow_types::sources::{AwsConfig, AwsCredentials};
+use dataflow_types::sources::{AwsConfig, AwsCredentials, SerdeUri};
 use repr::ColumnName;
 use sql_parser::ast::display::AstDisplay;
 use sql_parser::ast::visit_mut::{self, VisitMut};
@@ -485,7 +485,10 @@ pub fn aws_config(
         None => extract("region")?.ok_or_else(|| anyhow!("region is required"))?,
     };
 
-    let endpoint = extract("endpoint")?;
+    let endpoint = match extract("endpoint")? {
+        None => None,
+        Some(endpoint) => Some(SerdeUri(endpoint.parse().context("parsing AWS endpoint")?)),
+    };
 
     let access_key_id = extract("access_key_id")?;
     let secret_access_key = extract("secret_access_key")?;

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -828,7 +828,7 @@ async fn compile_proto(
 /// whether the specified AWS configuration is valid.
 async fn validate_aws_credentials(config: &AwsConfig) -> Result<(), anyhow::Error> {
     let config = config.load().await?;
-    let sts_client = mz_aws_util::sts::client(&config)?;
+    let sts_client = mz_aws_util::sts::client(&config);
     let _ = sts_client.get_caller_identity().send().await?;
     Ok(())
 }

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -827,7 +827,7 @@ async fn compile_proto(
 /// Makes an always-valid AWS API call to perform a basic sanity check of
 /// whether the specified AWS configuration is valid.
 async fn validate_aws_credentials(config: &AwsConfig) -> Result<(), anyhow::Error> {
-    let config = config.load().await?;
+    let config = config.load().await;
     let sts_client = mz_aws_util::sts::client(&config);
     let _ = sts_client.get_caller_identity().send().await?;
     Ok(())

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -736,10 +736,9 @@ pub async fn create_state(
         )
     };
 
-    let kinesis_client =
-        mz_aws_util::kinesis::client(&config.aws_config).err_ctx("creating Kinesis client")?;
-    let s3_client = mz_aws_util::s3::client(&config.aws_config).err_ctx("creating S3 client")?;
-    let sqs_client = mz_aws_util::sqs::client(&config.aws_config).err_ctx("creating SQS client")?;
+    let kinesis_client = mz_aws_util::kinesis::client(&config.aws_config);
+    let s3_client = mz_aws_util::s3::client(&config.aws_config);
+    let sqs_client = mz_aws_util::sqs::client(&config.aws_config);
 
     let state = State {
         seed,

--- a/src/testdrive/src/main.rs
+++ b/src/testdrive/src/main.rs
@@ -138,7 +138,7 @@ async fn main() {
             let loader = aws_config::from_env().region(Region::new(region));
             let config = AwsConfig::from_loader(loader).await;
             let account = async {
-                let sts_client = mz_aws_util::sts::client(&config)?;
+                let sts_client = mz_aws_util::sts::client(&config);
                 Ok::<_, Box<dyn Error>>(
                     sts_client
                         .get_caller_identity()

--- a/test/perf-kinesis/src/main.rs
+++ b/test/perf-kinesis/src/main.rs
@@ -60,7 +60,7 @@ async fn run() -> Result<(), anyhow::Error> {
 
     // Initialize test resources in Kinesis.
     let config = AwsConfig::load_from_env().await;
-    let kinesis_client = mz_aws_util::kinesis::client(&config)?;
+    let kinesis_client = mz_aws_util::kinesis::client(&config);
 
     let stream_arn =
         kinesis::create_stream(&kinesis_client, &stream_name, args.shard_count).await?;


### PR DESCRIPTION
I got curious about how constructing AWS clients via the SDK directly
could be a `Result`-less operation, given that constructing an AWS client
via our `aws-util` crate bubbles up a potential error from constructing
an HTTPS client. It turns out that `hyper_tls::HttpsConnector::new` will
just panic if it can't create a TLS context (e.g., if it can't
initialize OpenSSL), while `hyper_proxy::ProxyConnector::new` is a bit
more pedantic and returns the error rather than panicking. Given that
the default across the Rust ecosystem is to panic, failures while
constructing TLS contexts must essentially never occur in practice.

The `http_proxy::hyper::connector` function calls *both*
`hyper_tls::HttpsConnector::new` and `hyper_proxy::ProxyConnector::new`,
so the Result return is not buying us anything: if constructing TLS
contexts is for some reason broken, we're panicking via
`hyper_tls::HttpsConnector::new`.

So this commit drops the error return from the
`http_proxy::hyper::connector` function. The big win is that
constructing AWS clients becomes a `Result`-less operation, like it is
if you use the SDK directly.

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
