### PR TITLE
testdrive: fix redpanda nightlies

### DIFF
--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -98,7 +98,7 @@ def workflow_testdrive_redpanda_ci(c: Composition) -> None:
     """Run testdrive against files known to be supported by Redpanda."""
 
     # https://github.com/vectorizedio/redpanda/issues/2397
-    KNOWN_FAILURES = {"./kafka-time-offset.td"}
+    KNOWN_FAILURES = {"kafka-time-offset.td"}
 
     files = set(
         # NOTE(benesch): invoking the shell like this to filter testdrive files is

--- a/test/testdrive/protobuf-evolution.td
+++ b/test/testdrive/protobuf-evolution.td
@@ -101,7 +101,8 @@ i  mz_offset
 # Expect that ingesting an incompatible message will brick the topic. We have to
 # explicitly disable the schema registry's protection against this.
 
-$ http-request method=PUT url=${testdrive.schema-registry-url}config/testdrive-evolution-${testdrive.seed}-value
+$ http-request method=PUT content-type=application/json
+  url=${testdrive.schema-registry-url}config/testdrive-evolution-${testdrive.seed}-value
 {"compatibility": "NONE"}
 
 $ set schema


### PR DESCRIPTION
The Redpanda schema registry is more pedantic about content-type
headers. Also fix the exclusion of `kafka-time-offset.td` in the
workflow file.

@guswynn this is the redpanda SR thing you were asking about on Slack yesterday!

### Motivation


  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
