### PR TITLE
Cargo.lock: bump prost to pick up the latest changes in our fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3967,7 +3967,7 @@ dependencies = [
 [[package]]
 name = "prost"
 version = "0.9.0"
-source = "git+https://github.com/MaterializeInc/prost.git#6dd498282d0c7ade8f82f2a0163587dae259ae38"
+source = "git+https://github.com/MaterializeInc/prost.git#60a377c72d8025bd185f49842d1ff3dec1d4c466"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -3976,7 +3976,7 @@ dependencies = [
 [[package]]
 name = "prost-build"
 version = "0.9.1"
-source = "git+https://github.com/MaterializeInc/prost.git#6dd498282d0c7ade8f82f2a0163587dae259ae38"
+source = "git+https://github.com/MaterializeInc/prost.git#60a377c72d8025bd185f49842d1ff3dec1d4c466"
 dependencies = [
  "bytes",
  "heck",
@@ -3996,7 +3996,7 @@ dependencies = [
 [[package]]
 name = "prost-derive"
 version = "0.9.0"
-source = "git+https://github.com/MaterializeInc/prost.git#6dd498282d0c7ade8f82f2a0163587dae259ae38"
+source = "git+https://github.com/MaterializeInc/prost.git#60a377c72d8025bd185f49842d1ff3dec1d4c466"
 dependencies = [
  "anyhow",
  "itertools",
@@ -4022,7 +4022,7 @@ dependencies = [
 [[package]]
 name = "prost-types"
 version = "0.9.0"
-source = "git+https://github.com/MaterializeInc/prost.git#6dd498282d0c7ade8f82f2a0163587dae259ae38"
+source = "git+https://github.com/MaterializeInc/prost.git#60a377c72d8025bd185f49842d1ff3dec1d4c466"
 dependencies = [
  "bytes",
  "prost",


### PR DESCRIPTION
In particular, this one that seems to fix a build issue I'm having:
https://github.com/MaterializeInc/prost/commit/60a377c72d8025bd185f49842d1ff3dec1d4c466
