### PR TITLE
add spawn/spawn_blocking apis to ore to optionally name tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3804,6 +3804,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "openssl",
+ "ore",
  "postgres-openssl",
  "repr",
  "sql-parser",

--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -30,7 +30,7 @@ log = "0.4.13"
 tracing = "0.1.29"
 mz-avro = { path = "../avro", features = ["snappy"] }
 mz-aws-util = { path = "../aws-util" }
-ore = { path = "../ore" }
+ore = { path = "../ore", features = ["task"] }
 persist = { path = "../persist" }
 pgrepr = { path = "../pgrepr" }
 postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres", branch = "mz-0.7.2" }

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1553,7 +1553,8 @@ where
                 .write_handle
                 .allow_compaction(&table_since_updates);
             let _ = task::spawn(
-                || "compaction <insert some details about what we are compacting here>",
+                // TODO(guswynn): Add more relevant info here
+                || "compaction",
                 async move {
                     if let Err(err) = compaction_fut.await {
                         // TODO: Do something smarter here

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -2024,9 +2024,7 @@ where
                 match self.sequence_execute(&mut session, plan) {
                     Ok(portal_name) => {
                         let internal_cmd_tx = self.internal_cmd_tx.clone();
-                        // TODO(guswynn): see if we can avoid this formatting
-                        let task_name = format!("execute:{plan_name}");
-                        task::spawn(|| task_name, async move {
+                        task::spawn(|| format!("execute:{plan_name}"), async move {
                             internal_cmd_tx
                                 .send(Message::Command(Command::Execute {
                                     portal_name,

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -721,7 +721,7 @@ where
             // close on a regular interval. This roughly tracks the behaivor of realtime
             // sources that close off timestamps on an interval.
             let internal_cmd_tx = self.internal_cmd_tx.clone();
-            task::spawn("coordinator_serve", async move {
+            task::spawn(|| "coordinator_serve", async move {
                 let mut interval = tokio::time::interval(tokio::time::Duration::from_millis(1_000));
                 loop {
                     interval.tick().await;
@@ -806,7 +806,7 @@ where
             let seal_fut = persist_multi
                 .write_handle
                 .seal(&persist_multi.all_table_ids, advance_to);
-            let _ = task::spawn("advance_local_inputs", async move {
+            let _ = task::spawn(|| "advance_local_inputs", async move {
                 if let Err(err) = seal_fut.await {
                     // TODO: Linearizability relies on this, bubble up the
                     // error instead.
@@ -1243,7 +1243,7 @@ where
                         let internal_cmd_tx = self.internal_cmd_tx.clone();
                         let catalog = self.catalog.for_session(&session);
                         let purify_fut = sql::pure::purify(&catalog, stmt);
-                        task::spawn("purify", async move {
+                        task::spawn(|| "purify", async move {
                             let result = purify_fut.await.map_err(|e| e.into());
                             internal_cmd_tx
                                 .send(Message::StatementReady(StatementReady {
@@ -1549,7 +1549,7 @@ where
                 .write_handle
                 .allow_compaction(&table_since_updates);
             let _ = task::spawn(
-                "compaction <insert some details about what we are compacting here>",
+                || "compaction <insert some details about what we are compacting here>",
                 async move {
                     if let Err(err) = compaction_fut.await {
                         // TODO: Do something smarter here
@@ -2018,7 +2018,9 @@ where
                 match self.sequence_execute(&mut session, plan) {
                     Ok(portal_name) => {
                         let internal_cmd_tx = self.internal_cmd_tx.clone();
-                        task::spawn(&format!("execute:{portal_name}"), async move {
+                        // TODO(guswynn): see if we can avoid this formatting
+                        let task_name = format!("execute:{portal_name}");
+                        task::spawn(|| task_name, async move {
                             internal_cmd_tx
                                 .send(Message::Command(Command::Execute {
                                     portal_name,
@@ -2477,7 +2479,7 @@ where
         // main coordinator thread when the future completes.
         let connector_builder = sink.connector_builder;
         let internal_cmd_tx = self.internal_cmd_tx.clone();
-        task::spawn("sink_connector_ready", async move {
+        task::spawn(|| "sink_connector_ready", async move {
             internal_cmd_tx
                 .send(Message::SinkConnectorReady(SinkConnectorReady {
                     session,
@@ -2850,7 +2852,7 @@ where
 
         // We can now wait for responses or errors and do any session/transaction
         // finalization in a separate task.
-        task::spawn("sequence_end_transaction", async move {
+        task::spawn(|| "sequence_end_transaction", async move {
             let result = match rx {
                 // If we have more work to do, do it
                 Ok(fut) => fut.await,
@@ -3863,7 +3865,7 @@ where
         };
 
         let internal_cmd_tx = self.internal_cmd_tx.clone();
-        task::spawn("sequence_copy_rows", async move {
+        task::spawn(|| "sequence_copy_rows", async move {
             let arena = RowArena::new();
             let diffs = match peek_response {
                 ExecuteResponse::SendingRows(batch) => match batch.await {
@@ -4089,7 +4091,7 @@ where
         // did (and how the code previously worked), mz has already dropped it from our
         // catalog, and so we wouldn't be able to retry anyway.
         if !replication_slots_to_drop.is_empty() {
-            task::spawn("drop_replication_slots", async move {
+            task::spawn(|| "drop_replication_slots", async move {
                 for (conn, slot_names) in replication_slots_to_drop {
                     // Try to drop the replication slots, but give up after a while.
                     let _ = Retry::default()
@@ -4146,7 +4148,7 @@ where
                 // but only if we synchronously wait for the (fast) registration
                 // of that work to return.
                 let write_fut = persist.write_handle.write(&updates);
-                let _ = task::spawn("write_fut", write_fut);
+                let _ = task::spawn(|| "write_fut", write_fut);
             } else {
                 self.dataflow_client.table_insert(id, updates).await
             }
@@ -4505,7 +4507,7 @@ where
 
         let internal_cmd_tx = self.internal_cmd_tx.clone();
         let write_lock = Arc::clone(&self.write_lock);
-        task::spawn("defer_write", async move {
+        task::spawn(|| "defer_write", async move {
             let guard = write_lock.lock_owned().await;
             internal_cmd_tx
                 .send(Message::WriteLockGrant(guard))

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -129,6 +129,7 @@ use expr::{
 use ore::metrics::MetricsRegistry;
 use ore::now::{to_datetime, NowFn};
 use ore::retry::Retry;
+use ore::task::spawn;
 use ore::thread::{JoinHandleExt as _, JoinOnDropHandle};
 use repr::adt::numeric;
 use repr::{Datum, Diff, RelationDesc, Row, RowArena, Timestamp};
@@ -1547,12 +1548,15 @@ where
             let compaction_fut = persist_multi
                 .write_handle
                 .allow_compaction(&table_since_updates);
-            let _ = tokio::spawn(async move {
-                if let Err(err) = compaction_fut.await {
-                    // TODO: Do something smarter here
-                    tracing::error!("failed to compact persisted tables: {}", err);
-                }
-            });
+            let _ = spawn(
+                "compaction <insert some details about what we are compacting here>",
+                async move {
+                    if let Err(err) = compaction_fut.await {
+                        // TODO: Do something smarter here
+                        tracing::error!("failed to compact persisted tables: {}", err);
+                    }
+                },
+            );
         }
     }
 

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -806,21 +806,24 @@ where
             let seal_fut = persist_multi
                 .write_handle
                 .seal(&persist_multi.all_table_ids, advance_to);
-            let _ = task::spawn(|| "advance_local_inputs", async move {
-                if let Err(err) = seal_fut.await {
-                    // TODO: Linearizability relies on this, bubble up the
-                    // error instead.
-                    //
-                    // EDIT: On further consideration, I think it doesn't
-                    // affect correctness if this fails, just availability
-                    // of the table.
-                    tracing::error!(
-                        "failed to seal persisted stream to ts {}: {}",
-                        advance_to,
-                        err
-                    );
-                }
-            });
+            let _ = task::spawn(
+                || format!("advance_local_inputs:{advance_to}"),
+                async move {
+                    if let Err(err) = seal_fut.await {
+                        // TODO: Linearizability relies on this, bubble up the
+                        // error instead.
+                        //
+                        // EDIT: On further consideration, I think it doesn't
+                        // affect correctness if this fails, just availability
+                        // of the table.
+                        tracing::error!(
+                            "failed to seal persisted stream to ts {}: {}",
+                            advance_to,
+                            err
+                        );
+                    }
+                },
+            );
         }
 
         self.dataflow_client
@@ -1243,7 +1246,8 @@ where
                         let internal_cmd_tx = self.internal_cmd_tx.clone();
                         let catalog = self.catalog.for_session(&session);
                         let purify_fut = sql::pure::purify(&catalog, stmt);
-                        task::spawn(|| "purify", async move {
+                        let conn_id = session.conn_id();
+                        task::spawn(|| format!("purify:{conn_id}"), async move {
                             let result = purify_fut.await.map_err(|e| e.into());
                             internal_cmd_tx
                                 .send(Message::StatementReady(StatementReady {
@@ -2015,11 +2019,12 @@ where
                 }
             }
             Plan::Execute(plan) => {
+                let plan_name = plan.name.clone();
                 match self.sequence_execute(&mut session, plan) {
                     Ok(portal_name) => {
                         let internal_cmd_tx = self.internal_cmd_tx.clone();
                         // TODO(guswynn): see if we can avoid this formatting
-                        let task_name = format!("execute:{portal_name}");
+                        let task_name = format!("execute:{plan_name}");
                         task::spawn(|| task_name, async move {
                             internal_cmd_tx
                                 .send(Message::Command(Command::Execute {
@@ -2479,17 +2484,20 @@ where
         // main coordinator thread when the future completes.
         let connector_builder = sink.connector_builder;
         let internal_cmd_tx = self.internal_cmd_tx.clone();
-        task::spawn(|| "sink_connector_ready", async move {
-            internal_cmd_tx
-                .send(Message::SinkConnectorReady(SinkConnectorReady {
-                    session,
-                    tx,
-                    id,
-                    oid,
-                    result: sink_connector::build(connector_builder, id).await,
-                }))
-                .expect("sending to internal_cmd_tx cannot fail");
-        });
+        task::spawn(
+            || format!("sink_connector_ready:{}", sink.from),
+            async move {
+                internal_cmd_tx
+                    .send(Message::SinkConnectorReady(SinkConnectorReady {
+                        session,
+                        tx,
+                        id,
+                        oid,
+                        result: sink_connector::build(connector_builder, id).await,
+                    }))
+                    .expect("sending to internal_cmd_tx cannot fail");
+            },
+        );
     }
 
     fn generate_view_ops(
@@ -2852,23 +2860,27 @@ where
 
         // We can now wait for responses or errors and do any session/transaction
         // finalization in a separate task.
-        task::spawn(|| "sequence_end_transaction", async move {
-            let result = match rx {
-                // If we have more work to do, do it
-                Ok(fut) => fut.await,
-                Err(e) => Err(e),
-            };
+        let conn_id = session.conn_id();
+        task::spawn(
+            || format!("sequence_end_transaction:{conn_id}"),
+            async move {
+                let result = match rx {
+                    // If we have more work to do, do it
+                    Ok(fut) => fut.await,
+                    Err(e) => Err(e),
+                };
 
-            if result.is_err() {
-                action = EndTransactionAction::Rollback;
-            }
-            session.vars_mut().end_transaction(action);
+                if result.is_err() {
+                    action = EndTransactionAction::Rollback;
+                }
+                session.vars_mut().end_transaction(action);
 
-            match result {
-                Ok(()) => tx.send(Ok(response), session),
-                Err(err) => tx.send(Err(err), session),
-            }
-        });
+                match result {
+                    Ok(()) => tx.send(Ok(response), session),
+                    Err(err) => tx.send(Err(err), session),
+                }
+            },
+        );
     }
 
     async fn sequence_end_transaction_inner(
@@ -3865,7 +3877,7 @@ where
         };
 
         let internal_cmd_tx = self.internal_cmd_tx.clone();
-        task::spawn(|| "sequence_copy_rows", async move {
+        task::spawn(|| format!("sequence_read_then_write:{id}"), async move {
             let arena = RowArena::new();
             let diffs = match peek_response {
                 ExecuteResponse::SendingRows(batch) => match batch.await {
@@ -4091,6 +4103,7 @@ where
         // did (and how the code previously worked), mz has already dropped it from our
         // catalog, and so we wouldn't be able to retry anyway.
         if !replication_slots_to_drop.is_empty() {
+            // TODO(guswynn): see if there is more relevant info to add to this name
             task::spawn(|| "drop_replication_slots", async move {
                 for (conn, slot_names) in replication_slots_to_drop {
                     // Try to drop the replication slots, but give up after a while.
@@ -4148,7 +4161,7 @@ where
                 // but only if we synchronously wait for the (fast) registration
                 // of that work to return.
                 let write_fut = persist.write_handle.write(&updates);
-                let _ = task::spawn(|| "write_fut", write_fut);
+                let _ = task::spawn(|| "builtin_table_updates_write_fut:{id}", write_fut);
             } else {
                 self.dataflow_client.table_insert(id, updates).await
             }
@@ -4502,12 +4515,14 @@ where
         session: Session,
         plan: Plan,
     ) {
+        let conn_id = session.conn_id();
         let plan = DeferredPlan { tx, session, plan };
         self.write_lock_wait_group.push_back(plan);
 
         let internal_cmd_tx = self.internal_cmd_tx.clone();
         let write_lock = Arc::clone(&self.write_lock);
-        task::spawn(|| "defer_write", async move {
+        // TODO(guswynn): see if there is more relevant info to add to this name
+        task::spawn(|| format!("defer_write:{conn_id}"), async move {
             let guard = write_lock.lock_owned().await;
             internal_cmd_tx
                 .send(Message::WriteLockGrant(guard))

--- a/src/dataflow/Cargo.toml
+++ b/src/dataflow/Cargo.toml
@@ -38,7 +38,7 @@ log = "0.4.13"
 tracing = "0.1.29"
 mz-avro = { path = "../avro", features = ["snappy"] }
 mz-aws-util = { path = "../aws-util", features = ["kinesis", "s3", "sqs"] }
-ore = { path = "../ore" }
+ore = { path = "../ore", features = ["task"]  }
 pdqselect = "0.1.1"
 persist = { path = "../persist" }
 persist-types = { path = "../persist-types" }

--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -308,9 +308,10 @@ impl KafkaTxProducer {
     fn flush(&self) -> impl Future<Output = KafkaResult<()>> {
         let self_producer = Arc::clone(&self.inner);
         let self_timeout = self.timeout;
-        task::spawn_blocking(|| format!("flush:{}", self.name), move || {
-            self_producer.flush(self_timeout)
-        })
+        task::spawn_blocking(
+            || format!("flush:{}", self.name),
+            move || self_producer.flush(self_timeout),
+        )
         .unwrap_or_else(|_| Err(KafkaError::Canceled))
     }
 

--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -269,42 +269,46 @@ impl KafkaTxProducer {
     fn init_transactions(&self) -> impl Future<Output = KafkaResult<()>> {
         let self_producer = Arc::clone(&self.inner);
         let self_timeout = self.timeout;
-        task::spawn_blocking(&format!("init_transactions:{}", self.name), move || {
-            self_producer.init_transactions(self_timeout)
-        })
+        task::spawn_blocking(
+            || format!("init_transactions:{}", self.name),
+            move || self_producer.init_transactions(self_timeout),
+        )
         .unwrap_or_else(|_| Err(KafkaError::Canceled))
     }
 
     fn begin_transaction(&self) -> impl Future<Output = KafkaResult<()>> {
         let self_producer = Arc::clone(&self.inner);
-        task::spawn_blocking(&format!("begin_transaction:{}", self.name), move || {
-            self_producer.begin_transaction()
-        })
+        task::spawn_blocking(
+            || format!("begin_transaction:{}", self.name),
+            move || self_producer.begin_transaction(),
+        )
         .unwrap_or_else(|_| Err(KafkaError::Canceled))
     }
 
     fn commit_transaction(&self) -> impl Future<Output = KafkaResult<()>> {
         let self_producer = Arc::clone(&self.inner);
         let self_timeout = self.timeout;
-        task::spawn_blocking(&format!("commit_transaction:{}", self.name), move || {
-            self_producer.commit_transaction(self_timeout)
-        })
+        task::spawn_blocking(
+            || format!("commit_transaction:{}", self.name),
+            move || self_producer.commit_transaction(self_timeout),
+        )
         .unwrap_or_else(|_| Err(KafkaError::Canceled))
     }
 
     fn abort_transaction(&self) -> impl Future<Output = KafkaResult<()>> {
         let self_producer = Arc::clone(&self.inner);
         let self_timeout = self.timeout;
-        task::spawn_blocking(&format!("abort_transaction:{}", self.name), move || {
-            self_producer.abort_transaction(self_timeout)
-        })
+        task::spawn_blocking(
+            || format!("abort_transaction:{}", self.name),
+            move || self_producer.abort_transaction(self_timeout),
+        )
         .unwrap_or_else(|_| Err(KafkaError::Canceled))
     }
 
     fn flush(&self) -> impl Future<Output = KafkaResult<()>> {
         let self_producer = Arc::clone(&self.inner);
         let self_timeout = self.timeout;
-        task::spawn_blocking(&format!("flush:{}", self.name), move || {
+        task::spawn_blocking(|| format!("flush:{}", self.name), move || {
             self_producer.flush(self_timeout)
         })
         .unwrap_or_else(|_| Err(KafkaError::Canceled))

--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -50,10 +50,10 @@ use interchange::encode::Encode;
 use kafka_util::client::MzClientContext;
 use ore::cast::CastFrom;
 use ore::metrics::{CounterVecExt, DeleteOnDropCounter, DeleteOnDropGauge, GaugeVecExt};
+use ore::task;
 use repr::{Datum, Diff, RelationDesc, Row, Timestamp};
 use timely_util::async_op;
 use timely_util::operators_async_ext::OperatorBuilderExt;
-use tokio::task;
 
 use super::{KafkaBaseMetrics, SinkBaseMetrics};
 use crate::render::sinks::SinkRender;
@@ -260,6 +260,7 @@ impl Drop for KafkaSinkToken {
 
 #[derive(Clone)]
 struct KafkaTxProducer {
+    name: String,
     inner: Arc<ThreadedProducer<SinkProducerContext>>,
     timeout: Duration,
 }
@@ -268,35 +269,45 @@ impl KafkaTxProducer {
     fn init_transactions(&self) -> impl Future<Output = KafkaResult<()>> {
         let self_producer = Arc::clone(&self.inner);
         let self_timeout = self.timeout;
-        task::spawn_blocking(move || self_producer.init_transactions(self_timeout))
-            .unwrap_or_else(|_| Err(KafkaError::Canceled))
+        task::spawn_blocking(&format!("init_transactions:{}", self.name), move || {
+            self_producer.init_transactions(self_timeout)
+        })
+        .unwrap_or_else(|_| Err(KafkaError::Canceled))
     }
 
     fn begin_transaction(&self) -> impl Future<Output = KafkaResult<()>> {
         let self_producer = Arc::clone(&self.inner);
-        task::spawn_blocking(move || self_producer.begin_transaction())
-            .unwrap_or_else(|_| Err(KafkaError::Canceled))
+        task::spawn_blocking(&format!("begin_transaction:{}", self.name), move || {
+            self_producer.begin_transaction()
+        })
+        .unwrap_or_else(|_| Err(KafkaError::Canceled))
     }
 
     fn commit_transaction(&self) -> impl Future<Output = KafkaResult<()>> {
         let self_producer = Arc::clone(&self.inner);
         let self_timeout = self.timeout;
-        task::spawn_blocking(move || self_producer.commit_transaction(self_timeout))
-            .unwrap_or_else(|_| Err(KafkaError::Canceled))
+        task::spawn_blocking(&format!("commit_transaction:{}", self.name), move || {
+            self_producer.commit_transaction(self_timeout)
+        })
+        .unwrap_or_else(|_| Err(KafkaError::Canceled))
     }
 
     fn abort_transaction(&self) -> impl Future<Output = KafkaResult<()>> {
         let self_producer = Arc::clone(&self.inner);
         let self_timeout = self.timeout;
-        task::spawn_blocking(move || self_producer.abort_transaction(self_timeout))
-            .unwrap_or_else(|_| Err(KafkaError::Canceled))
+        task::spawn_blocking(&format!("abort_transaction:{}", self.name), move || {
+            self_producer.abort_transaction(self_timeout)
+        })
+        .unwrap_or_else(|_| Err(KafkaError::Canceled))
     }
 
     fn flush(&self) -> impl Future<Output = KafkaResult<()>> {
         let self_producer = Arc::clone(&self.inner);
         let self_timeout = self.timeout;
-        task::spawn_blocking(move || self_producer.flush(self_timeout))
-            .unwrap_or_else(|_| Err(KafkaError::Canceled))
+        task::spawn_blocking(&format!("flush:{}", self.name), move || {
+            self_producer.flush(self_timeout)
+        })
+        .unwrap_or_else(|_| Err(KafkaError::Canceled))
     }
 
     fn in_flight_count(&self) -> i32 {
@@ -366,6 +377,7 @@ impl KafkaSinkState {
         ));
 
         let producer = KafkaTxProducer {
+            name: sink_name.clone(),
             inner: Arc::new(
                 config
                     .create_with_context::<_, ThreadedProducer<_>>(SinkProducerContext::new(

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -43,6 +43,7 @@ use expr::{GlobalId, PartitionId, SourceInstanceId};
 use ore::cast::CastFrom;
 use ore::metrics::{CounterVecExt, DeleteOnDropCounter, DeleteOnDropGauge, GaugeVecExt};
 use ore::now::NowFn;
+use ore::task;
 use prometheus::core::{AtomicI64, AtomicU64};
 use tracing::error;
 
@@ -1178,7 +1179,7 @@ where
     let (tx, mut rx) = mpsc::channel(64);
 
     if active {
-        tokio::spawn(async move {
+        task::spawn(&format!("create_source_simple:{}", name), async move {
             let timestamper = Timestamper::new(tx, timestamp_frequency, now);
             let source = connector.start(&timestamper);
             tokio::pin!(source);

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -1179,7 +1179,7 @@ where
     let (tx, mut rx) = mpsc::channel(64);
 
     if active {
-        task::spawn(&format!("create_source_simple:{}", name), async move {
+        task::spawn(|| format!("create_source_simple:{}", name), async move {
             let timestamper = Timestamper::new(tx, timestamp_frequency, now);
             let source = connector.start(&timestamper);
             tokio::pin!(source);

--- a/src/dataflow/src/source/s3.rs
+++ b/src/dataflow/src/source/s3.rs
@@ -825,7 +825,7 @@ impl SourceReader for S3SourceReader {
             let glob = s3_conn.pattern.map(|g| g.compile_matcher());
 
             task::spawn(
-                &format!("s3_download:{}", source_id),
+                || format!("s3_download:{}", source_id),
                 download_objects_task(
                     source_id.to_string(),
                     keys_rx,
@@ -846,8 +846,10 @@ impl SourceReader for S3SourceReader {
                             bucket,
                             worker_id
                         );
+                        // TODO(guswynn): see if we can avoid this formatting
+                        let task_name = format!("s3_scan:{}:{}", source_id, bucket);
                         task::spawn(
-                            &format!("s3_scan:{}:{}", source_id, bucket),
+                            || task_name,
                             scan_bucket_task(
                                 bucket,
                                 source_id.to_string(),
@@ -866,7 +868,7 @@ impl SourceReader for S3SourceReader {
                             worker_id
                         );
                         task::spawn(
-                            &format!("s3_read_sqs:{}", source_id),
+                            || format!("s3_read_sqs:{}", source_id),
                             read_sqs_task(
                                 source_id.to_string(),
                                 glob.clone(),

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -61,7 +61,7 @@ nix = "0.23.1"
 num_cpus = "1.13.1"
 openssl = { version = "0.10.38", features = ["vendored"] }
 openssl-sys = { version = "0.9.72", features = ["vendored"] }
-ore = { path = "../ore" }
+ore = { path = "../ore", features = ["task"] }
 os_info = "3.1.0"
 pid-file = { path = "../pid-file" }
 pgwire = { path = "../pgwire" }

--- a/src/materialized/src/bin/coordd.rs
+++ b/src/materialized/src/bin/coordd.rs
@@ -22,6 +22,7 @@ use materialized::mux::Mux;
 use materialized::server_metrics::Metrics;
 use ore::metrics::MetricsRegistry;
 use ore::now::SYSTEM_TIME;
+use ore::task;
 
 /// Independent coordinator server for Materialize.
 #[derive(clap::Parser)]
@@ -105,7 +106,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
 
     let listener = TcpListener::bind(&args.listen_addr).await?;
 
-    tokio::spawn({
+    task::spawn("pgwire_server", {
         let pgwire_server = pgwire::Server::new(pgwire::Config {
             tls: None,
             coord_client: coord_client.clone(),

--- a/src/materialized/src/bin/coordd.rs
+++ b/src/materialized/src/bin/coordd.rs
@@ -106,7 +106,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
 
     let listener = TcpListener::bind(&args.listen_addr).await?;
 
-    task::spawn("pgwire_server", {
+    task::spawn(|| "pgwire_server", {
         let pgwire_server = pgwire::Server::new(pgwire::Config {
             tls: None,
             coord_client: coord_client.clone(),

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -30,6 +30,7 @@ use build_info::BuildInfo;
 use coord::LoggingConfig;
 use ore::metrics::MetricsRegistry;
 use ore::now::SYSTEM_TIME;
+use ore::task;
 use pid_file::PidFile;
 
 use crate::mux::Mux;
@@ -257,7 +258,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
 
     // Listen on the third-party metrics port if we are configured for it.
     if let Some(third_party_addr) = config.third_party_metrics_listen_addr {
-        tokio::spawn({
+        task::spawn("metrics_server", {
             let server = http::ThirdPartyServer::new(metrics_registry.clone());
             async move {
                 server.serve(third_party_addr).await;
@@ -273,7 +274,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
     // should be rejected. Once all existing user connections have gracefully
     // terminated, this task exits.
     let (drain_trigger, drain_tripwire) = oneshot::channel();
-    tokio::spawn({
+    task::spawn("pgwire_server", {
         let pgwire_server = pgwire::Server::new(pgwire::Config {
             tls: pgwire_tls,
             coord_client: coord_client.clone(),
@@ -307,7 +308,9 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
             workers,
             coord_client,
         };
-        tokio::spawn(async move { telemetry::report_loop(config).await });
+        task::spawn("telemetry_loop", async move {
+            telemetry::report_loop(config).await
+        });
     }
 
     Ok(Server {

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -258,7 +258,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
 
     // Listen on the third-party metrics port if we are configured for it.
     if let Some(third_party_addr) = config.third_party_metrics_listen_addr {
-        task::spawn("metrics_server", {
+        task::spawn(|| "metrics_server", {
             let server = http::ThirdPartyServer::new(metrics_registry.clone());
             async move {
                 server.serve(third_party_addr).await;
@@ -274,7 +274,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
     // should be rejected. Once all existing user connections have gracefully
     // terminated, this task exits.
     let (drain_trigger, drain_tripwire) = oneshot::channel();
-    task::spawn("pgwire_server", {
+    task::spawn(|| "pgwire_server", {
         let pgwire_server = pgwire::Server::new(pgwire::Config {
             tls: pgwire_tls,
             coord_client: coord_client.clone(),
@@ -308,7 +308,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
             workers,
             coord_client,
         };
-        task::spawn("telemetry_loop", async move {
+        task::spawn(|| "telemetry_loop", async move {
             telemetry::report_loop(config).await
         });
     }

--- a/src/materialized/src/mux.rs
+++ b/src/materialized/src/mux.rs
@@ -72,7 +72,7 @@ impl Mux {
             //
             // [0]: https://news.ycombinator.com/item?id=10608356
             conn.set_nodelay(true).expect("set_nodelay failed");
-            task::spawn("mux_serve", handle_connection(Arc::clone(&handlers), conn));
+            task::spawn(|| "mux_serve", handle_connection(Arc::clone(&handlers), conn));
         }
     }
 }

--- a/src/materialized/src/mux.rs
+++ b/src/materialized/src/mux.rs
@@ -72,7 +72,10 @@ impl Mux {
             //
             // [0]: https://news.ycombinator.com/item?id=10608356
             conn.set_nodelay(true).expect("set_nodelay failed");
-            task::spawn(|| "mux_serve", handle_connection(Arc::clone(&handlers), conn));
+            task::spawn(
+                || "mux_serve",
+                handle_connection(Arc::clone(&handlers), conn),
+            );
         }
     }
 }

--- a/src/materialized/src/mux.rs
+++ b/src/materialized/src/mux.rs
@@ -16,6 +16,7 @@ use tokio::net::TcpStream;
 use tracing::{debug, error};
 
 use ore::netio::{self, SniffedStream, SniffingStream};
+use ore::task;
 
 use crate::http;
 
@@ -71,7 +72,7 @@ impl Mux {
             //
             // [0]: https://news.ycombinator.com/item?id=10608356
             conn.set_nodelay(true).expect("set_nodelay failed");
-            tokio::spawn(handle_connection(Arc::clone(&handlers), conn));
+            task::spawn("mux_serve", handle_connection(Arc::clone(&handlers), conn));
         }
     }
 }

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -12,6 +12,7 @@ default = ["network", "chrono", "cli", "metrics", "stack", "test"]
 cli = ["clap"]
 metrics = ["prometheus"]
 network = ["async-trait", "bytes", "futures", "openssl", "smallvec", "tokio-openssl", "tokio"]
+task = ["tokio", "tokio/tracing"]
 stack = ["stacker"]
 test = ["anyhow", "ctor", "tracing-subscriber"]
 

--- a/src/ore/src/lib.rs
+++ b/src/ore/src/lib.rs
@@ -62,6 +62,9 @@ pub mod retry;
 pub mod stack;
 pub mod stats;
 pub mod str;
+#[cfg(feature = "task")]
+#[doc(hidden)]
+pub mod task;
 #[cfg_attr(nightly_doc_features, doc(cfg(feature = "test")))]
 #[cfg(feature = "test")]
 pub mod test;

--- a/src/ore/src/task.rs
+++ b/src/ore/src/task.rs
@@ -92,6 +92,7 @@ where
 }
 
 pub trait RuntimeExt {
+    #[track_caller]
     fn spawn_blocking<Function, Output, Name, NameClosure>(
         &self,
         nc: NameClosure,
@@ -103,6 +104,7 @@ pub trait RuntimeExt {
         Function: FnOnce() -> Output + Send + 'static,
         Output: Send + 'static;
 
+    #[track_caller]
     fn spawn<Fut, Name, NameClosure>(
         &self,
         _nc: NameClosure,

--- a/src/ore/src/task.rs
+++ b/src/ore/src/task.rs
@@ -93,7 +93,7 @@ where
 
 pub trait RuntimeExt {
     #[track_caller]
-    fn spawn_blocking<Function, Output, Name, NameClosure>(
+    fn spawn_blocking_named<Function, Output, Name, NameClosure>(
         &self,
         nc: NameClosure,
         function: Function,
@@ -105,7 +105,7 @@ pub trait RuntimeExt {
         Output: Send + 'static;
 
     #[track_caller]
-    fn spawn<Fut, Name, NameClosure>(
+    fn spawn_named<Fut, Name, NameClosure>(
         &self,
         _nc: NameClosure,
         future: Fut,
@@ -118,7 +118,7 @@ pub trait RuntimeExt {
 }
 
 impl RuntimeExt for Arc<Runtime> {
-    fn spawn_blocking<Function, Output, Name, NameClosure>(
+    fn spawn_blocking_named<Function, Output, Name, NameClosure>(
         &self,
         nc: NameClosure,
         function: Function,
@@ -133,7 +133,11 @@ impl RuntimeExt for Arc<Runtime> {
         spawn_blocking(nc, function)
     }
 
-    fn spawn<Fut, Name, NameClosure>(&self, nc: NameClosure, future: Fut) -> JoinHandle<Fut::Output>
+    fn spawn_named<Fut, Name, NameClosure>(
+        &self,
+        nc: NameClosure,
+        future: Fut,
+    ) -> JoinHandle<Fut::Output>
     where
         Name: AsRef<str>,
         NameClosure: FnOnce() -> Name,
@@ -146,7 +150,7 @@ impl RuntimeExt for Arc<Runtime> {
 }
 
 impl RuntimeExt for Handle {
-    fn spawn_blocking<Function, Output, Name, NameClosure>(
+    fn spawn_blocking_named<Function, Output, Name, NameClosure>(
         &self,
         nc: NameClosure,
         function: Function,
@@ -161,7 +165,11 @@ impl RuntimeExt for Handle {
         spawn_blocking(nc, function)
     }
 
-    fn spawn<Fut, Name, NameClosure>(&self, nc: NameClosure, future: Fut) -> JoinHandle<Fut::Output>
+    fn spawn_named<Fut, Name, NameClosure>(
+        &self,
+        nc: NameClosure,
+        future: Fut,
+    ) -> JoinHandle<Fut::Output>
     where
         Name: AsRef<str>,
         NameClosure: FnOnce() -> Name,

--- a/src/ore/src/task.rs
+++ b/src/ore/src/task.rs
@@ -1,0 +1,74 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::future::Future;
+
+use tokio::task::{self, JoinHandle};
+
+/// Spawns a task on the executor.
+///
+/// See [`spawn`](::tokio::spawn) for
+/// more details.
+#[cfg(not(all(tokio_unstable, feature = "task")))]
+#[track_caller]
+pub fn spawn<Fut>(_name: &str, future: Fut) -> JoinHandle<Fut::Output>
+where
+    Fut: Future + Send + 'static,
+    Fut::Output: Send + 'static,
+{
+    tokio::spawn(future)
+}
+
+/// Spawns a task on the executor.
+///
+/// See [`spawn`](tokio::spawn) for
+/// more details.
+#[cfg(all(tokio_unstable, feature = "task"))]
+#[track_caller]
+pub fn spawn<Fut>(name: &str, future: Fut) -> JoinHandle<Fut::Output>
+where
+    Fut: Future + Send + 'static,
+    Fut::Output: Send + 'static,
+{
+    task::Builder::new().name(name).spawn(future)
+}
+
+/// Spawns blocking code on the blocking threadpool.
+///
+/// See [`spawn_blocking`](::tokio::task::spawn_blocking)
+/// for more details.
+#[cfg(not(all(tokio_unstable, feature = "task")))]
+#[track_caller]
+pub fn spawn_blocking<Function, Output>(_name: &str, function: Function) -> JoinHandle<Output>
+where
+    Function: FnOnce() -> Output + Send + 'static,
+    Output: Send + 'static,
+{
+    task::spawn_blocking(function)
+}
+
+/// Spawns blocking code on the blocking threadpool.
+///
+/// See [`spawn_blocking`](::tokio::task::spawn_blocking)
+/// for more details.
+#[cfg(all(tokio_unstable, feature = "task"))]
+#[track_caller]
+pub fn spawn_blocking<Function, Output>(name: &str, function: Function) -> JoinHandle<Output>
+where
+    Function: FnOnce() -> Output + Send + 'static,
+    Output: Send + 'static,
+{
+    task::Builder::new().name(name).spawn_blocking(function)
+}

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -39,7 +39,7 @@ lazy_static = "1.4.0"
 tracing = "0.1.29"
 md-5 = "0.10.0"
 mz-aws-util = { path = "../aws-util", features = ["s3"] }
-ore = { path = "../ore", default-features = false, features = ["metrics"] }
+ore = { path = "../ore", default-features = false, features = ["metrics", "task"] }
 parquet2 = { version = "0.8.1", default-features = false }
 persist-types = { path = "../persist-types" }
 prost = "0.9.0"

--- a/src/persist/src/indexed/background.rs
+++ b/src/persist/src/indexed/background.rs
@@ -17,6 +17,8 @@ use timely::progress::Antichain;
 use timely::PartialOrder;
 use tokio::runtime::Runtime as AsyncRuntime;
 
+use ore::task::RuntimeExt;
+
 use crate::error::Error;
 use crate::indexed::arrangement::Arrangement;
 use crate::indexed::cache::BlobCache;
@@ -81,9 +83,11 @@ impl<B: Blob> Maintainer<B> {
         //
         // TODO: Push the spawn_blocking down into the cpu-intensive bits and
         // use spawn here once the storage traits are made async.
-        let _ = self
-            .async_runtime
-            .spawn_blocking(move || tx.fill(Self::compact_trace_blocking(blob, req)));
+        let _ = <_ as RuntimeExt>::spawn_blocking(
+            &self.async_runtime,
+            || "",
+            move || tx.fill(Self::compact_trace_blocking(blob, req)),
+        );
         rx
     }
 

--- a/src/persist/src/indexed/background.rs
+++ b/src/persist/src/indexed/background.rs
@@ -83,9 +83,9 @@ impl<B: Blob> Maintainer<B> {
         //
         // TODO: Push the spawn_blocking down into the cpu-intensive bits and
         // use spawn here once the storage traits are made async.
-        let _ = <_ as RuntimeExt>::spawn_blocking(
-            &self.async_runtime,
-            || "",
+        // TODO(guswynn): consider adding more info to the task name here
+        let _ = self.async_runtime.spawn_blocking_named(
+            || "persist_trace_compaction",
             move || tx.fill(Self::compact_trace_blocking(blob, req)),
         );
         rx

--- a/src/persist/src/runtime.rs
+++ b/src/persist/src/runtime.rs
@@ -18,6 +18,7 @@ use std::time::{Duration, Instant};
 
 use build_info::BuildInfo;
 use ore::metrics::MetricsRegistry;
+use ore::task::RuntimeExt;
 use tokio::runtime::Runtime as AsyncRuntime;
 use tokio::time;
 
@@ -102,7 +103,7 @@ where
 
     // Start up the ticker thread.
     let ticker_tx = tx.clone();
-    let ticker_handle = async_runtime.spawn(async move {
+    let ticker_handle = <_ as RuntimeExt>::spawn(&async_runtime, || "persist_ticker", async move {
         // Try to keep worst case command response times to roughly `110% of
         // min_step_interval` by ensuring there's a tick relatively shortly
         // after a step becomes eligible. We could just as easily make this

--- a/src/persist/src/runtime.rs
+++ b/src/persist/src/runtime.rs
@@ -103,7 +103,7 @@ where
 
     // Start up the ticker thread.
     let ticker_tx = tx.clone();
-    let ticker_handle = <_ as RuntimeExt>::spawn(&async_runtime, || "persist_ticker", async move {
+    let ticker_handle = async_runtime.spawn_named(|| "persist_ticker", async move {
         // Try to keep worst case command response times to roughly `110% of
         // min_step_interval` by ensuring there's a tick relatively shortly
         // after a step becomes eligible. We could just as easily make this

--- a/src/postgres-util/Cargo.toml
+++ b/src/postgres-util/Cargo.toml
@@ -12,5 +12,6 @@ openssl = { version = "0.10.38", features = ["vendored"] }
 postgres-openssl = { git = "https://github.com/MaterializeInc/rust-postgres", branch = "mz-0.7.2" }
 sql-parser = { path = "../sql-parser" }
 repr = { path = "../repr" }
+ore = { path = "../ore", features = [ "task" ] }
 tokio = { version = "1.15.0", features = ["fs"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", branch = "mz-0.7.2" }

--- a/src/postgres-util/src/lib.rs
+++ b/src/postgres-util/src/lib.rs
@@ -212,7 +212,7 @@ pub async fn publication_info(
     let tls = make_tls(&config)?;
     let (client, connection) = config.connect(tls).await?;
     task::spawn(
-        &format!("publication_info:postgres_connection{conn}"),
+        || format!("publication_info:postgres_connection{conn}"),
         connection,
     );
 
@@ -348,7 +348,7 @@ pub async fn drop_replication_slots(conn: &str, slots: &[String]) -> Result<(), 
     let tls = make_tls(&config)?;
     let (client, connection) = tokio_postgres::connect(&conn, tls).await?;
     task::spawn(
-        &format!("drop_replication_slots:postgres_connection{conn}"),
+        || format!("drop_replication_slots:postgres_connection{conn}"),
         connection,
     );
 
@@ -391,7 +391,7 @@ pub async fn connect_replication(conn: &str) -> Result<Client, anyhow::Error> {
         .connect(tls)
         .await?;
     task::spawn(
-        &format!("connect_replication:postgres_connection:{conn}"),
+        || format!("connect_replication:postgres_connection:{conn}"),
         connection,
     );
     Ok(client)

--- a/src/postgres-util/src/lib.rs
+++ b/src/postgres-util/src/lib.rs
@@ -211,10 +211,7 @@ pub async fn publication_info(
     let config = conn.parse()?;
     let tls = make_tls(&config)?;
     let (client, connection) = config.connect(tls).await?;
-    task::spawn(
-        || format!("publication_info:postgres_connection{conn}"),
-        connection,
-    );
+    task::spawn(|| format!("postgres_publication_info:{conn}"), connection);
 
     client
         .query(
@@ -348,7 +345,7 @@ pub async fn drop_replication_slots(conn: &str, slots: &[String]) -> Result<(), 
     let tls = make_tls(&config)?;
     let (client, connection) = tokio_postgres::connect(&conn, tls).await?;
     task::spawn(
-        || format!("drop_replication_slots:postgres_connection{conn}"),
+        || format!("postgres_drop_replication_slots:{conn}"),
         connection,
     );
 
@@ -391,7 +388,7 @@ pub async fn connect_replication(conn: &str) -> Result<Client, anyhow::Error> {
         .connect(tls)
         .await?;
     task::spawn(
-        || format!("connect_replication:postgres_connection:{conn}"),
+        || format!("postgres_connect_replication:{conn}"),
         connection,
     );
     Ok(client)

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -25,7 +25,7 @@ lazy_static = "1.4.0"
 tracing = "0.1.29"
 mz-avro = { path = "../avro", features = ["snappy"] }
 mz-aws-util = { path = "../aws-util", features = [ "sts" ] }
-ore = { path = "../ore" }
+ore = { path = "../ore", features = ["task"] }
 pgrepr = { path = "../pgrepr" }
 postgres-protocol = { git = "https://github.com/MaterializeInc/rust-postgres", branch = "mz-0.7.2" }
 postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres", branch = "mz-0.7.2", features = ["with-chrono-0_4", "with-uuid-0_8"] }

--- a/src/sql/src/kafka_util.rs
+++ b/src/sql/src/kafka_util.rs
@@ -366,6 +366,7 @@ pub async fn lookup_start_offsets(
 
     // Lookup offsets
     // TODO(guswynn): see if we can avoid this formatting
+    // TODO(guswynn): see if we can add broker to this name
     let task_name = format!("kafka_lookup_start_offets:{topic}");
     task::spawn_blocking(|| task_name, {
         let topic = topic.to_string();

--- a/src/sql/src/kafka_util.rs
+++ b/src/sql/src/kafka_util.rs
@@ -278,7 +278,9 @@ pub async fn create_consumer(
             // e.g. the hostname was mistyped. librdkafka doesn't expose a
             // better API for asking whether a connection succeeded or failed,
             // unfortunately.
-            task::spawn_blocking(&format!("kafka_set_metadata:{broker}:{topic}"), {
+            // TODO(guswynn): see if we can avoid this formatting
+            let task_name = format!("kafka_set_metadata:{broker}:{topic}");
+            task::spawn_blocking(|| task_name, {
                 let consumer = Arc::clone(&consumer);
                 move || {
                     let _ = consumer.fetch_metadata(Some(&topic), Duration::from_secs(1));
@@ -363,7 +365,9 @@ pub async fn lookup_start_offsets(
     };
 
     // Lookup offsets
-    task::spawn_blocking(&format!("kafka_lookup_start_offets:{topic}"), {
+    // TODO(guswynn): see if we can avoid this formatting
+    let task_name = format!("kafka_lookup_start_offets:{topic}");
+    task::spawn_blocking(|| task_name, {
         let topic = topic.to_string();
         move || {
             // There cannot be more than i32 partitions


### PR DESCRIPTION
When using `tokio-console`, the tasks are given spawn-call locations. While this is very helpful, using the unstable tokio apis (which are available whenever we use `tokio-console`, which requires `--cfg tokio_unstable`), that allow us to name the tasks. This gives us a nice quick idea about the context of the task we are looking into.

This pr adds apis that ALWAYS takes a closure to name a task. In the `tokio_unstable` world, this closure is used to name the task, and in the default world, it is unused. This pr also codemods all `tokio` `spawn`'s and `spawn_blocking`'s to use this new api (with the exception of `spawn`'s used in tests and examples which I left untouched, though I may add a simple api for those just to consolidate where we do ALL spawning)

Question for the reviewer: how should I document that people should use `ore::task::spawn*` apis over the native tokio ones.

### Motivation

  * This PR adds a feature that has not yet been specified.

	see above

### Tips for reviewer

the naming of these tasks is currently best effort: I tried to find the most relevant context and add it to the name. This may seem like adding semi-structured data to a string: thats because it is. `tokio-console` and `console-subscriber` are still in alpha stages, which is why they are heavily hidden and gated within `materialize`. In the future, we will add actual structured data to the tasks: https://github.com/tokio-rs/console/issues/7, so in the drill down state, we can see more information about the task we are investigating.

The persist changes are the most complex, as they pass around a `Runtime` instance. I ensured my changes are correct using: https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=c1f4cda46900a14b6171b5e946b120bb

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- N/A This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
