### PR TITLE
sql: fix some more edge cases in column name inference

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -127,6 +127,24 @@ changes that have not yet been documented.
 
   - Support `SHOW TIME ZONE` as an alias for `SHOW TIMEZONE` {{% gh 9908 %}}.
 
+- **Breaking change.** Further improve consistency with PostgreSQL's column name
+  inference rules:
+
+    * When inferring a column name for a nested cast expression, prefer the
+      name of the outermost cast rather than the innermost cast {{% gh 10167 %}}.
+
+      Consider the following query:
+
+      ```sql
+      SELECT 'a'::int::text;
+      ```
+
+      This version of Materialize will infer the column name `text`, while
+      previous versions of Materialize would incorrectly infer the name `int4`.
+
+    * Infer the name `case` for `CASE` expressions unless column name inference
+      on the `ELSE` expression produces a preferred name.
+
 {{< comment >}}
 Only add new release notes above this line.
 

--- a/test/sqllogictest/scoping.slt
+++ b/test/sqllogictest/scoping.slt
@@ -142,3 +142,35 @@ SELECT * FROM (SELECT 1 a) t1 CROSS JOIN ((SELECT 1 a) t1 CROSS JOIN LATERAL (SE
 
 query error table reference "t1" is ambiguous
 SELECT * FROM (SELECT 1 a) t1 CROSS JOIN ((SELECT 1 a) t1 CROSS JOIN LATERAL (SELECT t1) t2) t3;
+
+# Test column name inference corner cases.
+
+query T colnames
+SELECT 1::int
+----
+int4
+1
+
+query T colnames
+SELECT 1::text::int
+----
+int4
+1
+
+query T colnames
+SELECT CASE WHEN TRUE THEN 1 END
+----
+case
+1
+
+query T colnames
+SELECT CASE WHEN TRUE THEN 1 ELSE column1 END FROM (VALUES (1))
+----
+column1
+1
+
+query T colnames
+SELECT CASE WHEN TRUE THEN 1 ELSE 1::int END
+----
+case
+1


### PR DESCRIPTION
Nested cast expressions require more careful handling. Also infer names
for CASE expressions per PostgreSQL, which I just noticed we were
missing.

### Motivation

  * This PR fixes a recognized bug. Fixes #10167.

### Tips for reviewer

Diff is a little better with whitespace hidden.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
