### PR TITLE
Fix timestamp logic around metadata availability

### DIFF
--- a/src/coord/src/coord/prometheus.rs
+++ b/src/coord/src/coord/prometheus.rs
@@ -157,7 +157,6 @@ fn add_expiring_update(
 fn add_metadata_update<I: IntoIterator<Item = Row>>(
     updates: I,
     diff: Diff,
-    retain_for: u64,
     out: &mut Vec<TimestampedUpdate>,
 ) {
     let id = MZ_PROMETHEUS_METRICS.id;
@@ -166,7 +165,7 @@ fn add_metadata_update<I: IntoIterator<Item = Row>>(
             .into_iter()
             .map(|row| BuiltinTableUpdate { id, row, diff })
             .collect(),
-        timestamp_offset: retain_for,
+        timestamp_offset: 0,
     });
 }
 
@@ -248,7 +247,7 @@ impl Scraper {
                     .insert(metric.clone(), now + retain_for)
                     .is_none()
             });
-        add_metadata_update(missing, 1, retain_for, &mut out);
+        add_metadata_update(missing, 1, &mut out);
 
         // Expire any that can now go (I would love HashMap.drain_filter here):
         add_metadata_update(
@@ -258,7 +257,6 @@ impl Scraper {
                 .map(|(row, _)| row)
                 .cloned(),
             -1,
-            retain_for,
             &mut out,
         );
         self.metadata.retain(|_, &mut retention| retention > now);


### PR DESCRIPTION
After a refactor, this code ended up inserting metadata such that it
would turn valid only _after_ the "retain_for" had passed. This is
usually ok in the normal case, but means that for the first n scrape
intervals, there is no metrics metadata available (because it only
starts being valid after the batch for which it got inserted gets
expired).

Instead of this wrong behavior, insert the metadata update (and
expiry) to be valid as of now, and remove the confusing argument.

<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug: [Link to issue.]

  * This PR adds a known-desirable feature: [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
