### PR TITLE
mzcompose: re-fetch deps when `Composition.override` is called

### DIFF
--- a/ci/test/mkpipeline.py
+++ b/ci/test/mkpipeline.py
@@ -104,7 +104,6 @@ def trim_pipeline(pipeline: Any) -> None:
     no other untrimmed steps that depend on it.
     """
     repo = mzbuild.Repository(Path("."))
-    images = repo.resolve_dependencies(image for image in repo)
 
     steps = OrderedDict()
     for config in pipeline["steps"]:
@@ -128,8 +127,8 @@ def trim_pipeline(pipeline: Any) -> None:
                     if plugin_name == "./ci/plugins/mzcompose":
                         name = plugin_config["composition"]
                         composition = mzcompose.Composition(repo, name)
-                        for image in composition.images:
-                            step.image_dependencies.add(images[image.name])
+                        for dep in composition.dependencies:
+                            step.image_dependencies.add(dep)
                         step.extra_inputs.add(str(repo.compositions[name]))
         steps[step.id] = step
 

--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -421,9 +421,8 @@ class DockerComposeCommand(Command):
             )
 
         composition = load_composition(args)
-        ui.header("Collecting mzbuild dependencies")
-        deps = composition.repo.resolve_dependencies(composition.images)
-        for d in deps:
+        ui.header("Collecting mzbuild images")
+        for d in composition.dependencies:
             ui.say(d.spec())
 
         if self.runs_containers:
@@ -433,7 +432,7 @@ class DockerComposeCommand(Command):
                 # it as root.
                 (composition.path / "coverage").mkdir(exist_ok=True)
             self.check_docker_resource_limits()
-            deps.acquire()
+            composition.dependencies.acquire()
 
         self.handle_composition(args, composition)
 


### PR DESCRIPTION
The overridden definitions may add new mzbuild dependencies, so the
dependencies need to be refetched.

@philip-stoev this is a slightly different take on #10155. I think they are functionally identical, but I would like to keep the concept of resolving dependencies relatively separate from acquiring those dependencies, and allowing `resolve_dependencies` to optionally acquire dependencies fuzzes up those concepts a bit.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
