### PR TITLE
sql-parser: permit nested empty SELECTs

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -107,6 +107,9 @@ These changes are present in [unstable builds](/versions/#unstable-builds) and
 are slated for inclusion in the next stable release. There may be additional
 changes that have not yet been documented.
 
+- Fix parsing of nested empty `SELECT` statements, as in
+  `SELECT * FROM (SELECT)` {{% gh 8723 %}}.
+
 - Detect and reject multiple materializations of sources that would silently
   lose data when materialized more than once. This enables safe use of
   unmaterialized PostgreSQL and S3 with SQS notifications sources. {{% gh 8203

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -3564,7 +3564,7 @@ impl<'a> Parser<'a> {
             // An empty target list is permissible to match PostgreSQL, which
             // permits these for symmetry with zero column tables.
             Some(Token::Keyword(kw)) if kw.is_reserved() => vec![],
-            Some(Token::Semicolon) | None => vec![],
+            Some(Token::Semicolon) | Some(Token::RParen) | None => vec![],
             _ => self.parse_comma_separated(Parser::parse_select_item)?,
         };
 

--- a/src/sql-parser/tests/testdata/select
+++ b/src/sql-parser/tests/testdata/select
@@ -127,6 +127,20 @@ SELECT
 ----
 SELECT
 
+parse-statement
+SELECT (SELECT)
+----
+SELECT (SELECT)
+=>
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Subquery(Query { ctes: [], body: Select(Select { distinct: None, projection: [], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+SELECT )
+----
+error: Expected end of statement, found right parenthesis
+SELECT )
+       ^
+
 parse-statement roundtrip
 SELECT LIMIT 1
 ----

--- a/test/sqllogictest/subquery.slt
+++ b/test/sqllogictest/subquery.slt
@@ -175,10 +175,17 @@ query BBBBBBBBBBBBBBB
 ----
 true  false  false  true  false  false  NULL  true  NULL  NULL  NULL  NULL  NULL  NULL  NULL
 
-# TODO(benesch): this should yield a nullary result set, but presently
-# fails.
-# query error subquery has too few columns
-# SELECT 1 < ALL(SELECT * FROM nullary)
+query error subquery has 0 columns available but 1 columns specified
+SELECT 1 < ALL(SELECT * FROM nullary)
+
+query error Expected subselect to return 1 column, got 0 columns
+SELECT (SELECT);
+----
+
+query
+SELECT * FROM (SELECT);
+----
+
 
 query error subquery has 2 columns available but 1 columns specified
 SELECT 1 < ALL(SELECT 1, 2)


### PR DESCRIPTION
Admittedly an edge case, but a bug nonetheless.

Fix #8723.

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
