### PR TITLE
testdrive: switch to anyhow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,9 +65,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.52"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84450d0b4a8bd1ba4144ce8ce718fbc5d071358b1e5384bace6536b3d1f2d5b3"
+checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
 
 [[package]]
 name = "arbitrary"
@@ -5028,6 +5028,7 @@ dependencies = [
 name = "testdrive"
 version = "0.0.0"
 dependencies = [
+ "anyhow",
  "assert_cmd",
  "async-compression",
  "async-trait",

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
+anyhow = "1.0.53"
 async-compression = { version = "0.3.8", features = ["tokio", "gzip"] }
 async-trait = "0.1.52"
 aws-config = { version = "0.5.0", default-features = false, features = ["native-tls"] }

--- a/src/testdrive/src/action/avro_ocf.rs
+++ b/src/testdrive/src/action/avro_ocf.rs
@@ -13,9 +13,9 @@ use std::io::Write;
 use std::os::unix::ffi::OsStringExt;
 use std::path::{self, PathBuf};
 
+use anyhow::{bail, Context as _};
 use async_trait::async_trait;
 
-use ore::result::ResultExt;
 use ore::retry::Retry;
 
 use crate::action::{Action, Context, State, SyncAction};
@@ -29,7 +29,7 @@ pub struct WriteAction {
     codec: Option<Codec>,
 }
 
-pub fn build_write(mut cmd: BuiltinCommand) -> Result<WriteAction, String> {
+pub fn build_write(mut cmd: BuiltinCommand) -> Result<WriteAction, anyhow::Error> {
     let path = cmd.args.string("path")?;
     let schema = cmd.args.string("schema")?;
     let codec = cmd.args.opt_parse("codec")?;
@@ -38,7 +38,7 @@ pub fn build_write(mut cmd: BuiltinCommand) -> Result<WriteAction, String> {
     cmd.args.done()?;
     if path.contains(path::MAIN_SEPARATOR) {
         // The goal isn't security, but preventing mistakes.
-        return Err("separators in paths are forbidden".into());
+        bail!("separators in paths are forbidden");
     }
     Ok(WriteAction {
         path,
@@ -49,22 +49,22 @@ pub fn build_write(mut cmd: BuiltinCommand) -> Result<WriteAction, String> {
 }
 
 impl SyncAction for WriteAction {
-    fn undo(&self, _state: &mut State) -> Result<(), String> {
+    fn undo(&self, _state: &mut State) -> Result<(), anyhow::Error> {
         // Files are written to a fresh temporary directory, so no need to
         // explicitly remove the file here.
         Ok(())
     }
 
-    fn redo(&self, state: &mut State) -> Result<(), String> {
+    fn redo(&self, state: &mut State) -> Result<(), anyhow::Error> {
         let path = state.temp_path.join(&self.path);
         println!("Writing to {}", path.display());
-        let mut file = File::create(path).map_err_to_string()?;
-        let schema = avro::parse_schema(&self.schema)
-            .map_err(|e| format!("parsing avro schema: {:#}", e))?;
+        let mut file = File::create(&path)
+            .with_context(|| format!("creating Avro OCF file: {}", path.display()))?;
+        let schema = avro::parse_schema(&self.schema).context("parsing avro schema")?;
         let mut writer = Writer::with_codec_opt(schema, &mut file, self.codec);
         write_records(&mut writer, &self.records)?;
         file.sync_all()
-            .map_err(|e| format!("error syncing file: {}", e))?;
+            .with_context(|| format!("syncing Avro OCF file: {}", path.display()))?;
         Ok(())
     }
 }
@@ -74,53 +74,45 @@ pub struct AppendAction {
     records: Vec<String>,
 }
 
-pub fn build_append(mut cmd: BuiltinCommand) -> Result<AppendAction, String> {
+pub fn build_append(mut cmd: BuiltinCommand) -> Result<AppendAction, anyhow::Error> {
     let path = cmd.args.string("path")?;
     let records = cmd.input;
     cmd.args.done()?;
     if path.contains(path::MAIN_SEPARATOR) {
         // The goal isn't security, but preventing mistakes.
-        return Err("separators in paths are forbidden".into());
+        bail!("separators in paths are forbidden");
     }
     Ok(AppendAction { path, records })
 }
 
 impl SyncAction for AppendAction {
-    fn undo(&self, _state: &mut State) -> Result<(), String> {
+    fn undo(&self, _state: &mut State) -> Result<(), anyhow::Error> {
         Ok(())
     }
 
-    fn redo(&self, state: &mut State) -> Result<(), String> {
+    fn redo(&self, state: &mut State) -> Result<(), anyhow::Error> {
         let path = state.temp_path.join(&self.path);
         println!("Appending to {}", path.display());
-        let file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .open(path)
-            .map_err_to_string()?;
-        let mut writer = Writer::append_to(file).map_err_to_string()?;
+        let file = OpenOptions::new().read(true).write(true).open(path)?;
+        let mut writer = Writer::append_to(file)?;
         write_records(&mut writer, &self.records)?;
         Ok(())
     }
 }
 
-fn write_records<W>(writer: &mut Writer<W>, records: &[String]) -> Result<(), String>
+fn write_records<W>(writer: &mut Writer<W>, records: &[String]) -> Result<(), anyhow::Error>
 where
     W: Write,
 {
     let schema = writer.schema().clone();
     for record in records {
         let record = avro::from_json(
-            &serde_json::from_str(record).map_err(|e| format!("parsing avro datum: {:#}", e))?,
+            &serde_json::from_str(record).context("parsing avro datum: {:#}")?,
             schema.top_node(),
         )?;
-        writer
-            .append(record)
-            .map_err(|e| format!("writing avro record: {:#}", e))?;
+        writer.append(record).context("writing avro record")?;
     }
-    writer
-        .flush()
-        .map_err(|e| format!("flushing avro writer: {:#}", e))?;
+    writer.flush().context("flushing avro writer")?;
     Ok(())
 }
 
@@ -130,13 +122,16 @@ pub struct VerifyAction {
     context: Context,
 }
 
-pub fn build_verify(mut cmd: BuiltinCommand, context: Context) -> Result<VerifyAction, String> {
+pub fn build_verify(
+    mut cmd: BuiltinCommand,
+    context: Context,
+) -> Result<VerifyAction, anyhow::Error> {
     let sink = cmd.args.string("sink")?;
     let expected = cmd.input;
     cmd.args.done()?;
     if sink.contains(path::MAIN_SEPARATOR) {
         // The goal isn't security, but preventing mistakes.
-        return Err("separators in file sink names are forbidden".into());
+        bail!("separators in file sink names are forbidden");
     }
     Ok(VerifyAction {
         sink,
@@ -147,11 +142,11 @@ pub fn build_verify(mut cmd: BuiltinCommand, context: Context) -> Result<VerifyA
 
 #[async_trait]
 impl Action for VerifyAction {
-    async fn undo(&self, _state: &mut State) -> Result<(), String> {
+    async fn undo(&self, _state: &mut State) -> Result<(), anyhow::Error> {
         Ok(())
     }
 
-    async fn redo(&self, state: &mut State) -> Result<(), String> {
+    async fn redo(&self, state: &mut State) -> Result<(), anyhow::Error> {
         let path = Retry::default()
             .max_duration(state.default_timeout)
             .retry_async(|_| async {
@@ -164,12 +159,12 @@ impl Action for VerifyAction {
                         &[&self.sink],
                     )
                     .await
-                    .map_err(|e| format!("querying materialize: {:#}", e))?;
+                    .context("querying materialize")?;
                 let bytes: Vec<u8> = row.get("path");
-                Ok::<_, String>(PathBuf::from(OsString::from_vec(bytes)))
+                Ok::<_, anyhow::Error>(PathBuf::from(OsString::from_vec(bytes)))
             })
             .await
-            .map_err(|e| format!("retrieving path: {:?}", e))?;
+            .context("retrieving path")?;
 
         println!("Verifying results in file {}", path.display());
 
@@ -177,13 +172,13 @@ impl Action for VerifyAction {
         // we drop into synchronous code here.
         tokio::task::block_in_place(|| {
             let file = File::open(&path)
-                .map_err(|e| format!("reading sink file {}: {}", path.display(), e))?;
-            let reader = Reader::new(file).map_err(|e| format!("creating avro reader: {}", e))?;
+                .with_context(|| format!("reading sink file {}", path.display()))?;
+            let reader = Reader::new(file).context("creating avro reader")?;
             let schema = reader.writer_schema().clone();
             let actual = reader
                 .map(|res| res.map(|val| (None, Some(val))))
                 .collect::<Result<Vec<_>, _>>()
-                .map_err(|e| format!("reading avro values from file: {}", e))?;
+                .context("reading avro values from file")?;
             avro::validate_sink(
                 None,
                 &schema,

--- a/src/testdrive/src/action/file.rs
+++ b/src/testdrive/src/action/file.rs
@@ -10,9 +10,9 @@
 use std::path;
 use std::str::FromStr;
 
+use anyhow::bail;
 use async_compression::tokio::write::GzipEncoder;
 use async_trait::async_trait;
-use ore::result::ResultExt;
 use tokio::fs::OpenOptions;
 use tokio::io::{AsyncWrite, AsyncWriteExt};
 
@@ -32,35 +32,35 @@ pub enum Compression {
 }
 
 impl FromStr for Compression {
-    type Err = String;
+    type Err = anyhow::Error;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> Result<Self, anyhow::Error> {
         match s {
             "gzip" => Ok(Compression::Gzip),
             "none" => Ok(Compression::None),
-            f => Err(format!("unknown compression format: {}", f)),
+            f => bail!("unknown compression format: {}", f),
         }
     }
 }
 
-pub fn build_compression(cmd: &mut BuiltinCommand) -> Result<Compression, String> {
+pub fn build_compression(cmd: &mut BuiltinCommand) -> Result<Compression, anyhow::Error> {
     match cmd.args.opt_string("compression") {
         Some(s) => s.parse(),
         None => Ok(Compression::None),
     }
 }
 
-fn build_path(cmd: &mut BuiltinCommand) -> Result<String, String> {
+fn build_path(cmd: &mut BuiltinCommand) -> Result<String, anyhow::Error> {
     let path = cmd.args.string("path")?;
     if path.contains(path::MAIN_SEPARATOR) {
         // The goal isn't security, but preventing mistakes.
-        Err("separators in paths are forbidden".into())
+        bail!("separators in paths are forbidden")
     } else {
         Ok(path)
     }
 }
 
-pub fn build_append(mut cmd: BuiltinCommand) -> Result<AppendAction, String> {
+pub fn build_append(mut cmd: BuiltinCommand) -> Result<AppendAction, anyhow::Error> {
     let path = build_path(&mut cmd)?;
     let compression = build_compression(&mut cmd)?;
     let trailing_newline = cmd.args.opt_bool("trailing-newline")?.unwrap_or(true);
@@ -82,30 +82,29 @@ pub fn build_append(mut cmd: BuiltinCommand) -> Result<AppendAction, String> {
 
 #[async_trait]
 impl Action for AppendAction {
-    async fn undo(&self, _: &mut State) -> Result<(), String> {
+    async fn undo(&self, _: &mut State) -> Result<(), anyhow::Error> {
         // Files are written to a fresh temporary directory, so no need to
         // explicitly remove the file here.
         Ok(())
     }
 
-    async fn redo(&self, state: &mut State) -> Result<(), String> {
+    async fn redo(&self, state: &mut State) -> Result<(), anyhow::Error> {
         let path = state.temp_path.join(&self.path);
         println!("Appending to file {}", path.display());
         let file = OpenOptions::new()
             .create(true)
             .append(true)
             .open(&path)
-            .await
-            .map_err_to_string()?;
+            .await?;
 
         let mut file: Box<dyn AsyncWrite + Unpin + Send> = match self.compression {
             Compression::Gzip => Box::new(GzipEncoder::new(file)),
             Compression::None => Box::new(file),
         };
 
-        file.write_all(&self.contents).await.map_err_to_string()?;
+        file.write_all(&self.contents).await?;
 
-        file.shutdown().await.map_err_to_string()?;
+        file.shutdown().await?;
         Ok(())
     }
 }
@@ -114,7 +113,7 @@ pub struct DeleteAction {
     path: String,
 }
 
-pub fn build_delete(mut cmd: BuiltinCommand) -> Result<DeleteAction, String> {
+pub fn build_delete(mut cmd: BuiltinCommand) -> Result<DeleteAction, anyhow::Error> {
     let path = build_path(&mut cmd)?;
     cmd.args.done()?;
     Ok(DeleteAction { path })
@@ -122,13 +121,14 @@ pub fn build_delete(mut cmd: BuiltinCommand) -> Result<DeleteAction, String> {
 
 #[async_trait]
 impl Action for DeleteAction {
-    async fn undo(&self, _: &mut State) -> Result<(), String> {
+    async fn undo(&self, _: &mut State) -> Result<(), anyhow::Error> {
         Ok(())
     }
 
-    async fn redo(&self, state: &mut State) -> Result<(), String> {
+    async fn redo(&self, state: &mut State) -> Result<(), anyhow::Error> {
         let path = state.temp_path.join(&self.path);
         println!("Deleting file {}", path.display());
-        tokio::fs::remove_file(&path).await.map_err_to_string()
+        tokio::fs::remove_file(&path).await?;
+        Ok(())
     }
 }

--- a/src/testdrive/src/action/kafka/add_partitions.rs
+++ b/src/testdrive/src/action/kafka/add_partitions.rs
@@ -10,13 +10,14 @@
 use std::cmp;
 use std::time::Duration;
 
+use anyhow::{bail, Context};
 use async_trait::async_trait;
-use ore::result::ResultExt;
 use rdkafka::admin::NewPartitions;
 use rdkafka::producer::Producer;
 
 use ore::collections::CollectionExt;
 use ore::retry::Retry;
+use ore::str::StrExt;
 
 use crate::action::{Action, State};
 use crate::parser::BuiltinCommand;
@@ -26,7 +27,7 @@ pub struct AddPartitionsAction {
     partitions: usize,
 }
 
-pub fn build_add_partitions(mut cmd: BuiltinCommand) -> Result<AddPartitionsAction, String> {
+pub fn build_add_partitions(mut cmd: BuiltinCommand) -> Result<AddPartitionsAction, anyhow::Error> {
     let topic_prefix = format!("testdrive-{}", cmd.args.string("topic")?);
     let partitions = cmd.args.opt_parse("total-partitions")?.unwrap_or(1);
     cmd.args.done()?;
@@ -39,11 +40,11 @@ pub fn build_add_partitions(mut cmd: BuiltinCommand) -> Result<AddPartitionsActi
 
 #[async_trait]
 impl Action for AddPartitionsAction {
-    async fn undo(&self, _: &mut State) -> Result<(), String> {
+    async fn undo(&self, _: &mut State) -> Result<(), anyhow::Error> {
         Ok(())
     }
 
-    async fn redo(&self, state: &mut State) -> Result<(), String> {
+    async fn redo(&self, state: &mut State) -> Result<(), anyhow::Error> {
         let topic_name = format!("{}-{}", self.topic_prefix, state.seed);
         println!(
             "Raising partition count of Kafka topic {} to {}",
@@ -53,17 +54,18 @@ impl Action for AddPartitionsAction {
         match state.kafka_topics.get(&topic_name) {
             Some(partitions) => {
                 if self.partitions <= *partitions {
-                    return Err(format!(
+                    bail!(
                         "new partition count {} is not greater than current partition count {}",
-                        self.partitions, partitions
-                    ));
+                        self.partitions,
+                        partitions
+                    );
                 }
             }
             None => {
-                return Err(format!(
+                bail!(
                     "topic {} not created by kafka-create-topic",
-                    topic_name
-                ))
+                    topic_name.quoted(),
+                )
             }
         }
 
@@ -72,39 +74,35 @@ impl Action for AddPartitionsAction {
             .kafka_admin
             .create_partitions(&[partitions], &state.kafka_admin_opts)
             .await
-            .map_err_to_string()?;
+            .context("creating partitions")?;
         if res.len() != 1 {
-            return Err(format!(
+            bail!(
                 "kafka partition addition returned {} results, but exactly one result was expected",
                 res.len()
-            ));
+            );
         }
         if let Err((_topic_name, e)) = res.into_element() {
-            return Err(e.to_string());
+            return Err(e.into());
         }
 
         Retry::default()
             .max_duration(state.default_timeout)
             .retry_async(|_| async {
-                let metadata = state
-                    .kafka_producer
-                    .client()
-                    .fetch_metadata(
-                        Some(&topic_name),
-                        Some(cmp::max(state.default_timeout, Duration::from_secs(1))),
-                    )
-                    .map_err_to_string()?;
+                let metadata = state.kafka_producer.client().fetch_metadata(
+                    Some(&topic_name),
+                    Some(cmp::max(state.default_timeout, Duration::from_secs(1))),
+                )?;
                 if metadata.topics().len() != 1 {
-                    return Err("metadata fetch returned no topics".to_string());
+                    bail!("metadata fetch returned no topics");
                 }
                 let topic = metadata.topics().into_element();
                 if topic.partitions().len() != self.partitions {
-                    return Err(format!(
+                    bail!(
                         "topic {} has {} partitions when exactly {} was expected",
                         topic_name,
                         topic.partitions().len(),
                         self.partitions,
-                    ));
+                    );
                 }
                 Ok(())
             })

--- a/src/testdrive/src/action/kafka/verify.rs
+++ b/src/testdrive/src/action/kafka/verify.rs
@@ -11,9 +11,9 @@ use std::cmp;
 use std::str;
 use std::time::Duration;
 
+use anyhow::{bail, Context as _};
 use async_trait::async_trait;
 use byteorder::{BigEndian, ByteOrder};
-use ore::result::ResultExt;
 use rdkafka::consumer::{Consumer, StreamConsumer};
 use rdkafka::message::Message;
 use tokio::pin;
@@ -42,18 +42,21 @@ pub struct VerifyAction {
     partial_search: Option<usize>,
 }
 
-pub fn build_verify(mut cmd: BuiltinCommand, context: Context) -> Result<VerifyAction, String> {
+pub fn build_verify(
+    mut cmd: BuiltinCommand,
+    context: Context,
+) -> Result<VerifyAction, anyhow::Error> {
     let format = match cmd.args.string("format")?.as_str() {
         "avro" => SinkFormat::Avro,
         "json" => SinkFormat::Json {
             key: cmd.args.parse("key")?,
         },
-        f => return Err(format!("unknown format: {}", f)),
+        f => bail!("unknown format: {}", f),
     };
     let sink = cmd.args.string("sink")?;
     let consistency = match cmd.args.opt_string("consistency").as_deref() {
         Some("debezium") => Some(SinkConsistencyFormat::Debezium),
-        Some(s) => return Err(format!("unknown sink consistency format {}", s)),
+        Some(s) => bail!("unknown sink consistency format {}", s),
         None => None,
     };
 
@@ -62,9 +65,7 @@ pub fn build_verify(mut cmd: BuiltinCommand, context: Context) -> Result<VerifyA
     if expected_messages.len() == 0 {
         // verify with 0 messages doesn't check that no messages have been written -
         // it 'verifies' 0 messages and trivially returns true
-        return Err(String::from(
-            "kafka-verify requires a non-empty list of expected messages",
-        ));
+        bail!("kafka-verify requires a non-empty list of expected messages");
     }
     let partial_search = cmd.args.opt_parse("partial-search")?;
     cmd.args.done()?;
@@ -82,47 +83,50 @@ pub fn build_verify(mut cmd: BuiltinCommand, context: Context) -> Result<VerifyA
 fn avro_from_bytes(
     schema: &mz_avro::Schema,
     mut bytes: &[u8],
-) -> Result<mz_avro::types::Value, String> {
+) -> Result<mz_avro::types::Value, anyhow::Error> {
     if bytes.len() < 5 {
-        return Err(format!(
+        bail!(
             "avro datum is too few bytes: expected at least 5 bytes, got {}",
             bytes.len()
-        ));
+        );
     }
     let magic = bytes[0];
     let _schema_id = BigEndian::read_i32(&bytes[1..5]);
     bytes = &bytes[5..];
 
     if magic != 0 {
-        return Err(format!(
+        bail!(
             "wrong avro serialization magic: expected 0, got {}",
             bytes[0]
-        ));
+        );
     }
 
-    let datum = avro::from_avro_datum(schema, &mut bytes)
-        .map_err(|e| format!("from_avro_datum: {:#}", e))?;
+    let datum = avro::from_avro_datum(schema, &mut bytes).context("decoding avro datum")?;
     Ok(datum)
 }
 
-async fn get_topic(sink: &str, topic_field: &str, state: &mut State) -> Result<String, String> {
+async fn get_topic(
+    sink: &str,
+    topic_field: &str,
+    state: &mut State,
+) -> Result<String, anyhow::Error> {
     let query = format!("SELECT {} FROM mz_catalog_names JOIN mz_kafka_sinks ON global_id = sink_id WHERE name = $1", topic_field);
     let result = state
         .pgclient
         .query_one(query.as_str(), &[&sink])
         .await
-        .map_err(|e| format!("retrieving topic name: {}", e))?
+        .context("retrieving topic name")?
         .get(topic_field);
     Ok(result)
 }
 
 #[async_trait]
 impl Action for VerifyAction {
-    async fn undo(&self, _state: &mut State) -> Result<(), String> {
+    async fn undo(&self, _state: &mut State) -> Result<(), anyhow::Error> {
         Ok(())
     }
 
-    async fn redo(&self, state: &mut State) -> Result<(), String> {
+    async fn redo(&self, state: &mut State) -> Result<(), anyhow::Error> {
         let topic: String = match self.consistency {
             None => get_topic(&self.sink, "topic", state).await?,
             Some(SinkConsistencyFormat::Debezium) => {
@@ -135,12 +139,10 @@ impl Action for VerifyAction {
         let mut config = state.kafka_config.clone();
         config.set("enable.auto.offset.store", "false");
 
-        let consumer: StreamConsumer = config
-            .create()
-            .map_err(|e| format!("creating kafka consumer: {:#}", e))?;
+        let consumer: StreamConsumer = config.create().context("creating kafka consumer")?;
         consumer
             .subscribe(&[&topic])
-            .map_err(|e| format!("subscribing: {:#}", e))?;
+            .context("subscribing to kafka topic")?;
 
         let (stream_size, stream_timeout) = match self.partial_search {
             Some(size) => (size, state.default_timeout),
@@ -162,10 +164,10 @@ impl Action for VerifyAction {
         loop {
             match message_stream.next().await {
                 Some(Ok(message)) => {
-                    let message = message.map_err_to_string()?;
+                    let message = message?;
                     consumer
                         .store_offset_from_message(&message)
-                        .map_err(|e| format!("storing message offset: {:#}", e))?;
+                        .context("storing message offset")?;
                     actual_bytes.push((
                         message.key().and_then(|bytes| Some(bytes.to_owned())),
                         message.payload().and_then(|bytes| Some(bytes.to_owned())),
@@ -187,7 +189,7 @@ impl Action for VerifyAction {
                     .ccsr_client
                     .get_schema_by_subject(&format!("{}-value", topic))
                     .await
-                    .map_err(|e| format!("fetching schema: {}", e))?
+                    .context("fetching schema")?
                     .raw;
 
                 let key_schema = state
@@ -196,13 +198,12 @@ impl Action for VerifyAction {
                     .await
                     .ok()
                     .map(|key_schema| {
-                        avro::parse_schema(&key_schema.raw)
-                            .map_err(|e| format!("parsing avro schema: {}", e))
+                        avro::parse_schema(&key_schema.raw).context("parsing avro schema")
                     })
                     .transpose()?;
 
-                let value_schema = avro::parse_schema(&value_schema)
-                    .map_err(|e| format!("parsing avro schema: {}", e))?;
+                let value_schema =
+                    avro::parse_schema(&value_schema).context("parsing avro schema")?;
                 let value_schema = &value_schema;
 
                 let mut actual_messages = vec![];
@@ -212,7 +213,7 @@ impl Action for VerifyAction {
                         .map(|key_schema| {
                             let bytes = match key {
                                 Some(key) => key,
-                                None => return Err("empty message key".into()),
+                                None => bail!("empty message key"),
                             };
                             avro_from_bytes(key_schema, &bytes)
                         })
@@ -247,17 +248,15 @@ impl Action for VerifyAction {
                 for (key, value) in actual_bytes {
                     let key_datum = match key {
                         None => None,
-                        Some(bytes) => Some(
-                            serde_json::from_slice(&bytes)
-                                .map_err(|e| format!("converting bytes to JSON {}", e))?,
-                        ),
+                        Some(bytes) => {
+                            Some(serde_json::from_slice(&bytes).context("decoding json")?)
+                        }
                     };
                     let value_datum = match value {
                         None => None,
-                        Some(bytes) => Some(
-                            serde_json::from_slice(&bytes)
-                                .map_err(|e| format!("converting bytes to JSON {}", e))?,
-                        ),
+                        Some(bytes) => {
+                            Some(serde_json::from_slice(&bytes).context("decoding json")?)
+                        }
                     };
 
                     actual_messages.push((key_datum, value_datum));
@@ -286,20 +285,20 @@ pub struct VerifySchemaAction {
     expected_value_schema: String,
 }
 
-pub fn build_verify_schema(mut cmd: BuiltinCommand) -> Result<VerifySchemaAction, String> {
+pub fn build_verify_schema(mut cmd: BuiltinCommand) -> Result<VerifySchemaAction, anyhow::Error> {
     let format = match cmd.args.string("format")?.as_str() {
         "avro" => SinkFormat::Avro,
         "json" => SinkFormat::Json {
             key: cmd.args.parse("key")?,
         },
-        f => return Err(format!("unknown format: {}", f)),
+        f => bail!("unknown format: {}", f),
     };
     let sink = cmd.args.string("sink")?;
 
-    let (key, value): (Option<String>, String) = match &cmd.input[..] {
+    let (key, value) = match &cmd.input[..] {
         [value] => (None, value.clone()),
         [key, value] => (Some(key.clone()), value.clone()),
-        _ => return Err(String::from("unable to read key/value schema inputs")),
+        _ => bail!("unable to read key/value schema inputs"),
     };
 
     cmd.args.done()?;
@@ -313,11 +312,11 @@ pub fn build_verify_schema(mut cmd: BuiltinCommand) -> Result<VerifySchemaAction
 
 #[async_trait]
 impl Action for VerifySchemaAction {
-    async fn undo(&self, _state: &mut State) -> Result<(), String> {
+    async fn undo(&self, _state: &mut State) -> Result<(), anyhow::Error> {
         Ok(())
     }
 
-    async fn redo(&self, state: &mut State) -> Result<(), String> {
+    async fn redo(&self, state: &mut State) -> Result<(), anyhow::Error> {
         let topic = get_topic(&self.sink, "topic", state).await?;
 
         match &self.format {
@@ -326,7 +325,7 @@ impl Action for VerifySchemaAction {
                     .ccsr_client
                     .get_schema_by_subject(&format!("{}-value", topic))
                     .await
-                    .map_err(|e| format!("fetching schema: {}", e))?
+                    .context("fetching schema")?
                     .raw;
 
                 let generated_key_schema = state
@@ -335,44 +334,43 @@ impl Action for VerifySchemaAction {
                     .await
                     .ok()
                     .map(|key_schema| {
-                        avro::parse_schema(&key_schema.raw)
-                            .map_err(|e| format!("parsing avro schema: {}", e))
+                        avro::parse_schema(&key_schema.raw).context("parsing avro schema")
                     })
                     .transpose()?;
 
                 let generated_value_schema = avro::parse_schema(&generated_value_schema)
-                    .map_err(|e| format!("parsing generated avro schema: {}", e))?;
+                    .context("parsing generated avro schema")?;
                 let expected_value_schema = avro::parse_schema(&self.expected_value_schema)
-                    .map_err(|e| format!("parsing expected avro schema: {}", e))?;
+                    .context("parsing expected avro schema")?;
 
                 if expected_value_schema.ne(&generated_value_schema) {
-                    return Err(format!(
+                    bail!(
                         "value schema did not match\nexpected:\n{:?}\n\nactual:\n{:?}",
-                        expected_value_schema, generated_value_schema
-                    ));
+                        expected_value_schema,
+                        generated_value_schema
+                    );
                 }
 
                 if let Some(expected_key_schema) = &self.expected_key_schema {
                     let expected_key_schema = avro::parse_schema(expected_key_schema)
-                        .map_err(|e| format!("parsing expected avro schema: {}", e))?;
+                        .context("parsing expected avro schema")?;
 
                     if generated_key_schema.is_none() {
-                        return Err(String::from("empty generated key schema"));
+                        bail!("empty generated key schema");
                     }
 
                     let generated_key_schema = generated_key_schema.unwrap();
                     if expected_key_schema.ne(&generated_key_schema) {
-                        return Err(format!(
+                        bail!(
                             "key schema did not match\nexpected:\n{:?}\n\nactual:\n{:?}",
-                            expected_key_schema, generated_key_schema
-                        ));
+                            expected_key_schema,
+                            generated_key_schema
+                        );
                     }
                 }
             }
             _ => {
-                return Err(String::from(
-                    "kafka-verify-schema is only supported for Avro sinks",
-                ))
+                bail!("kafka-verify-schema is only supported for Avro sinks")
             }
         }
 

--- a/src/testdrive/src/action/postgres/connect.rs
+++ b/src/testdrive/src/action/postgres/connect.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use anyhow::bail;
 use async_trait::async_trait;
 
 use crate::action::{Action, State};
@@ -18,10 +19,10 @@ pub struct ConnectAction {
     url: String,
 }
 
-pub fn build_connect(mut cmd: BuiltinCommand) -> Result<ConnectAction, String> {
+pub fn build_connect(mut cmd: BuiltinCommand) -> Result<ConnectAction, anyhow::Error> {
     let name = cmd.args.string("name")?;
     if name.starts_with("postgres://") {
-        return Err("connection name can not be url".into());
+        bail!("connection name can not be url");
     }
 
     let url = cmd.args.string("url")?;
@@ -31,11 +32,11 @@ pub fn build_connect(mut cmd: BuiltinCommand) -> Result<ConnectAction, String> {
 
 #[async_trait]
 impl Action for ConnectAction {
-    async fn undo(&self, _: &mut State) -> Result<(), String> {
+    async fn undo(&self, _: &mut State) -> Result<(), anyhow::Error> {
         Ok(())
     }
 
-    async fn redo(&self, state: &mut State) -> Result<(), String> {
+    async fn redo(&self, state: &mut State) -> Result<(), anyhow::Error> {
         let client = postgres_client(&self.url).await?;
         state.postgres_clients.insert(self.name.clone(), client);
         Ok(())

--- a/src/testdrive/src/action/postgres/execute.rs
+++ b/src/testdrive/src/action/postgres/execute.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use anyhow::{anyhow, Context};
 use async_trait::async_trait;
 
 use crate::action::{Action, State};
@@ -18,7 +19,7 @@ pub struct ExecuteAction {
     queries: Vec<String>,
 }
 
-pub fn build_execute(mut cmd: BuiltinCommand) -> Result<ExecuteAction, String> {
+pub fn build_execute(mut cmd: BuiltinCommand) -> Result<ExecuteAction, anyhow::Error> {
     let connection = cmd.args.string("connection")?;
     cmd.args.done()?;
     Ok(ExecuteAction {
@@ -29,11 +30,11 @@ pub fn build_execute(mut cmd: BuiltinCommand) -> Result<ExecuteAction, String> {
 
 #[async_trait]
 impl Action for ExecuteAction {
-    async fn undo(&self, _: &mut State) -> Result<(), String> {
+    async fn undo(&self, _: &mut State) -> Result<(), anyhow::Error> {
         Ok(())
     }
 
-    async fn redo(&self, state: &mut State) -> Result<(), String> {
+    async fn redo(&self, state: &mut State) -> Result<(), anyhow::Error> {
         let client;
         let client = if self.connection.starts_with("postgres://") {
             client = postgres_client(&self.connection).await?;
@@ -42,7 +43,7 @@ impl Action for ExecuteAction {
             state
                 .postgres_clients
                 .get(&self.connection)
-                .ok_or(format!("connection '{}' not found", &self.connection))?
+                .ok_or_else(|| anyhow!("connection '{}' not found", &self.connection))?
         };
 
         for query in &self.queries {
@@ -50,7 +51,7 @@ impl Action for ExecuteAction {
             client
                 .batch_execute(query)
                 .await
-                .map_err(|e| format!("executing postgres query: {}", e))?;
+                .context("executing postgres query")?;
         }
 
         Ok(())

--- a/src/testdrive/src/action/postgres/verify_slot.rs
+++ b/src/testdrive/src/action/postgres/verify_slot.rs
@@ -7,9 +7,11 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use async_trait::async_trait;
 use std::cmp;
 use std::time::Duration;
+
+use anyhow::{bail, Context};
+use async_trait::async_trait;
 use tokio_postgres::NoTls;
 
 use ore::retry::Retry;
@@ -23,7 +25,7 @@ pub struct VerifySlotAction {
     active: bool,
 }
 
-pub fn build_verify_slot(mut cmd: BuiltinCommand) -> Result<VerifySlotAction, String> {
+pub fn build_verify_slot(mut cmd: BuiltinCommand) -> Result<VerifySlotAction, anyhow::Error> {
     let connection = cmd.args.string("connection")?;
     let slot = cmd.args.string("slot")?;
     let active: bool = cmd.args.parse("active")?;
@@ -37,14 +39,14 @@ pub fn build_verify_slot(mut cmd: BuiltinCommand) -> Result<VerifySlotAction, St
 
 #[async_trait]
 impl Action for VerifySlotAction {
-    async fn undo(&self, _: &mut State) -> Result<(), String> {
+    async fn undo(&self, _: &mut State) -> Result<(), anyhow::Error> {
         Ok(())
     }
 
-    async fn redo(&self, state: &mut State) -> Result<(), String> {
+    async fn redo(&self, state: &mut State) -> Result<(), anyhow::Error> {
         let (client, conn) = tokio_postgres::connect(&self.connection, NoTls)
             .await
-            .map_err(|e| format!("connecting to postgres: {}", e))?;
+            .context("connecting to postgres")?;
         println!(
             "Executing queries against PostgreSQL server at {}...",
             self.connection
@@ -62,28 +64,22 @@ impl Action for VerifySlotAction {
                         &[&self.slot],
                     )
                     .await
-                    .map_err(|e| format!("querying postgres for replication slot: {}", e))?;
+                    .context("querying postgres for replication slot")?;
 
                 if self.active {
                     if rows.len() != 1 {
-                        return Err(format!(
+                        bail!(
                             "expected entry for slot {} in pg_replication slots, found {}",
                             &self.slot,
                             rows.len()
-                        ));
+                        );
                     }
                     let active_pid: Option<i32> = rows[0].get(0);
                     if active_pid.is_none() {
-                        return Err(format!(
-                            "expected slot {} to be active, is inactive",
-                            &self.slot
-                        ));
+                        bail!("expected slot {} to be active, is inactive", &self.slot);
                     }
                 } else if rows.len() != 0 {
-                    return Err(format!(
-                        "expected slot {} to be inactive, is active",
-                        &self.slot
-                    ));
+                    bail!("expected slot {} to be inactive, is active", &self.slot);
                 }
                 Ok(())
             })
@@ -93,6 +89,6 @@ impl Action for VerifySlotAction {
         conn_handle
             .await
             .unwrap()
-            .map_err(|e| format!("postgres connection error: {}", e))
+            .context("postgres connection error")
     }
 }

--- a/src/testdrive/src/action/s3.rs
+++ b/src/testdrive/src/action/s3.rs
@@ -11,6 +11,7 @@ use std::cmp;
 use std::io::Write;
 use std::time::{Duration, Instant};
 
+use anyhow::{anyhow, bail, Context};
 use async_trait::async_trait;
 use aws_sdk_s3::error::{CreateBucketError, CreateBucketErrorKind};
 use aws_sdk_s3::model::{
@@ -22,8 +23,6 @@ use aws_sdk_sqs::model::{DeleteMessageBatchRequestEntry, QueueAttributeName};
 use flate2::write::GzEncoder;
 use flate2::Compression as Flate2Compression;
 
-use ore::result::ResultExt;
-
 use crate::action::file::{build_compression, Compression};
 use crate::action::{Action, State};
 use crate::parser::BuiltinCommand;
@@ -32,7 +31,7 @@ pub struct CreateBucketAction {
     bucket_prefix: String,
 }
 
-pub fn build_create_bucket(mut cmd: BuiltinCommand) -> Result<CreateBucketAction, String> {
+pub fn build_create_bucket(mut cmd: BuiltinCommand) -> Result<CreateBucketAction, anyhow::Error> {
     let bucket_prefix = format!("testdrive-{}", cmd.args.string("bucket")?);
     cmd.args.done()?;
     Ok(CreateBucketAction { bucket_prefix })
@@ -40,11 +39,11 @@ pub fn build_create_bucket(mut cmd: BuiltinCommand) -> Result<CreateBucketAction
 
 #[async_trait]
 impl Action for CreateBucketAction {
-    async fn undo(&self, _state: &mut State) -> Result<(), String> {
+    async fn undo(&self, _state: &mut State) -> Result<(), anyhow::Error> {
         Ok(())
     }
 
-    async fn redo(&self, state: &mut State) -> Result<(), String> {
+    async fn redo(&self, state: &mut State) -> Result<(), anyhow::Error> {
         let bucket = format!("{}-{}", self.bucket_prefix, state.seed);
         println!("Creating S3 bucket {}", bucket);
 
@@ -75,7 +74,7 @@ impl Action for CreateBucketAction {
                 state.s3_buckets_created.insert(bucket);
                 Ok(())
             }
-            Err(e) => Err(format!("creating bucket: {}", e)),
+            Err(e) => Err(e).context("creating bucket"),
         }
     }
 }
@@ -87,7 +86,7 @@ pub struct PutObjectAction {
     contents: String,
 }
 
-pub fn build_put_object(mut cmd: BuiltinCommand) -> Result<PutObjectAction, String> {
+pub fn build_put_object(mut cmd: BuiltinCommand) -> Result<PutObjectAction, anyhow::Error> {
     let bucket_prefix = format!("testdrive-{}", cmd.args.string("bucket")?);
     let key = cmd.args.string("key")?;
     let compression = build_compression(&mut cmd)?;
@@ -103,11 +102,11 @@ pub fn build_put_object(mut cmd: BuiltinCommand) -> Result<PutObjectAction, Stri
 
 #[async_trait]
 impl Action for PutObjectAction {
-    async fn undo(&self, _state: &mut State) -> Result<(), String> {
+    async fn undo(&self, _state: &mut State) -> Result<(), anyhow::Error> {
         Ok(())
     }
 
-    async fn redo(&self, state: &mut State) -> Result<(), String> {
+    async fn redo(&self, state: &mut State) -> Result<(), anyhow::Error> {
         let bucket = format!("{}-{}", self.bucket_prefix, state.seed);
         println!("Put S3 object {}/{}", bucket, self.key);
 
@@ -118,10 +117,8 @@ impl Action for PutObjectAction {
                 let mut encoder = GzEncoder::new(Vec::new(), Flate2Compression::default());
                 encoder
                     .write_all(buffer.as_ref())
-                    .map_err(|e| format!("error writing bytes to encoder: {}", e))?;
-                encoder
-                    .finish()
-                    .map_err(|e| format!("error compressing contents: {}", e))
+                    .context("writing to gzip encoder")?;
+                encoder.finish().context("writing to gzip encoder")
             }
         }?;
 
@@ -139,7 +136,7 @@ impl Action for PutObjectAction {
             .send()
             .await
             .map(|_| ())
-            .map_err(|e| format!("putting s3 object: {}", e))
+            .context("putting to S3")
     }
 }
 
@@ -148,7 +145,7 @@ pub struct DeleteObjectAction {
     keys: Vec<String>,
 }
 
-pub fn build_delete_object(mut cmd: BuiltinCommand) -> Result<DeleteObjectAction, String> {
+pub fn build_delete_object(mut cmd: BuiltinCommand) -> Result<DeleteObjectAction, anyhow::Error> {
     let bucket_prefix = format!("testdrive-{}", cmd.args.string("bucket")?);
     cmd.args.done()?;
     Ok(DeleteObjectAction {
@@ -159,14 +156,14 @@ pub fn build_delete_object(mut cmd: BuiltinCommand) -> Result<DeleteObjectAction
 
 #[async_trait]
 impl Action for DeleteObjectAction {
-    async fn undo(&self, _state: &mut State) -> Result<(), String> {
+    async fn undo(&self, _state: &mut State) -> Result<(), anyhow::Error> {
         Ok(())
     }
 
-    async fn redo(&self, state: &mut State) -> Result<(), String> {
+    async fn redo(&self, state: &mut State) -> Result<(), anyhow::Error> {
         let bucket = format!("{}-{}", self.bucket_prefix, state.seed);
         println!("Deleting S3 objects {}: {}", bucket, self.keys.join(", "));
-        let result = state
+        state
             .s3_client
             .delete_objects()
             .bucket(bucket)
@@ -183,9 +180,8 @@ impl Action for DeleteObjectAction {
             )
             .send()
             .await
-            .map(|_| ())
-            .map_err(|e| format!("deleting s3 objects: {}", e));
-        result
+            .context("deleting S3 objects")?;
+        Ok(())
     }
 }
 
@@ -196,7 +192,9 @@ pub struct AddBucketNotifications {
     sqs_validation_timeout: Option<Duration>,
 }
 
-pub fn build_add_notifications(mut cmd: BuiltinCommand) -> Result<AddBucketNotifications, String> {
+pub fn build_add_notifications(
+    mut cmd: BuiltinCommand,
+) -> Result<AddBucketNotifications, anyhow::Error> {
     let bucket_prefix = format!("testdrive-{}", cmd.args.string("bucket")?);
     let queue_prefix = format!("testdrive-{}", cmd.args.string("queue")?);
     let events = cmd
@@ -207,7 +205,7 @@ pub fn build_add_notifications(mut cmd: BuiltinCommand) -> Result<AddBucketNotif
     let sqs_validation_timeout = cmd
         .args
         .opt_string("sqs-validation-timeout")
-        .map(|t| repr::util::parse_duration(&t).map_err_to_string())
+        .map(|t| repr::util::parse_duration(&t).context("parsing duration"))
         .transpose()?;
     cmd.args.done()?;
     Ok(AddBucketNotifications {
@@ -220,11 +218,11 @@ pub fn build_add_notifications(mut cmd: BuiltinCommand) -> Result<AddBucketNotif
 
 #[async_trait]
 impl Action for AddBucketNotifications {
-    async fn undo(&self, _state: &mut State) -> Result<(), String> {
+    async fn undo(&self, _state: &mut State) -> Result<(), anyhow::Error> {
         Ok(())
     }
 
-    async fn redo(&self, state: &mut State) -> Result<(), String> {
+    async fn redo(&self, state: &mut State) -> Result<(), anyhow::Error> {
         let bucket = format!("{}-{}", self.bucket_prefix, state.seed);
         let queue = format!("{}-{}", self.queue_prefix, state.seed);
 
@@ -248,16 +246,11 @@ impl Action for AddBucketNotifications {
                     .queue_name(&queue)
                     .send()
                     .await
-                    .map_err(|e| {
-                        format!(
-                            "when trying to get sqs queue url for already-existing queue: {}",
-                            e
-                        )
-                    })?;
+                    .context("fetching SQS queue url for existing queue")?;
                 resp.queue_url
                     .expect("successfully getting the url gets the url")
             }
-            Err(e) => return Err(e.to_string()),
+            Err(e) => return Err(e.into()),
         };
 
         let queue_arn: String = state
@@ -267,11 +260,11 @@ impl Action for AddBucketNotifications {
             .attribute_names(QueueAttributeName::QueueArn)
             .send()
             .await
-            .map_err(|e| format!("getting queue {} attributes: {}", queue, e))?
+            .with_context(|| format!("getting queue {} attributes", queue))?
             .attributes
-            .ok_or_else(|| "the result should not be empty".to_string())?
+            .ok_or_else(|| anyhow!("queue attributes missing"))?
             .remove(&QueueAttributeName::QueueArn)
-            .ok_or_else(|| "QueueArn should be present in arn request".to_string())?;
+            .ok_or_else(|| anyhow!("queue ARN attribute missing"))?;
 
         // Configure the queue to allow the S3 bucket to write to this queue
         state
@@ -284,7 +277,7 @@ impl Action for AddBucketNotifications {
             )
             .send()
             .await
-            .map_err(|e| format!("setting aws queue attributes: {}", e))?;
+            .context("setting SQS queue policy")?;
 
         state.sqs_queues_created.insert(queue_url.clone());
 
@@ -295,7 +288,7 @@ impl Action for AddBucketNotifications {
             .bucket(&bucket)
             .send()
             .await
-            .map_err(|e| format!("getting bucket notification_configuration: {}", e))?;
+            .context("getting bucket notification_configuration")?;
 
         {
             let queue_configs = config.queue_configurations.get_or_insert_with(Vec::new);
@@ -321,12 +314,7 @@ impl Action for AddBucketNotifications {
             )
             .send()
             .await
-            .map_err(|e| {
-                format!(
-                    "Putting s3 bucket configuration notification {} \n{:?}",
-                    e, e
-                )
-            })?;
+            .context("putting S3 bucket configuration notification")?;
 
         let sqs_validation_timeout = self
             .sqs_validation_timeout
@@ -355,7 +343,7 @@ impl Action for AddBucketNotifications {
                 .key(format!("sqs-test/{}", attempts))
                 .send()
                 .await
-                .map_err(|e| format!("creating object to verify sqs: {}", e))?;
+                .context("creating SQS verification object")?;
             attempts += 1;
 
             let resp = state
@@ -365,7 +353,7 @@ impl Action for AddBucketNotifications {
                 .wait_time_seconds(1)
                 .send()
                 .await
-                .map_err(|e| format!("reading from sqs for verification: {}", e))?;
+                .context("receiving verification message from SQS")?;
 
             if let Some(ms) = resp.messages {
                 if !ms.is_empty() {
@@ -392,7 +380,7 @@ impl Action for AddBucketNotifications {
                         ))
                         .send()
                         .await
-                        .map_err(|e| format!("Deleting validation messages from sqs: {}", e))?;
+                        .context("deleting validation messages from SQS")?;
                 }
             }
             if success {
@@ -414,7 +402,7 @@ impl Action for AddBucketNotifications {
                 attempts + 1,
                 start.elapsed()
             );
-            Err("Never got messages on S3 bucket notification queue".to_string())
+            bail!("never received messages on S3 bucket notification queue")
         }
     }
 }

--- a/src/testdrive/src/action/sleep.rs
+++ b/src/testdrive/src/action/sleep.rs
@@ -10,7 +10,7 @@
 use std::thread;
 use std::time::Duration;
 
-use ore::result::ResultExt;
+use anyhow::Context;
 use rand::Rng;
 
 use crate::action::{State, SyncAction};
@@ -21,18 +21,18 @@ pub struct SleepAction {
     random: bool,
 }
 
-pub fn build_random_sleep(mut cmd: BuiltinCommand) -> Result<SleepAction, String> {
+pub fn build_random_sleep(mut cmd: BuiltinCommand) -> Result<SleepAction, anyhow::Error> {
     let arg = cmd.args.string("duration")?;
-    let duration = repr::util::parse_duration(&arg).map_err_to_string()?;
+    let duration = repr::util::parse_duration(&arg).context("parsing duration")?;
     Ok(SleepAction {
         duration,
         random: true,
     })
 }
 
-pub fn build_sleep(mut cmd: BuiltinCommand) -> Result<SleepAction, String> {
+pub fn build_sleep(mut cmd: BuiltinCommand) -> Result<SleepAction, anyhow::Error> {
     let arg = cmd.args.string("duration")?;
-    let duration = repr::util::parse_duration(&arg).map_err_to_string()?;
+    let duration = repr::util::parse_duration(&arg).context("parsing duration")?;
     Ok(SleepAction {
         duration,
         random: false,
@@ -40,11 +40,11 @@ pub fn build_sleep(mut cmd: BuiltinCommand) -> Result<SleepAction, String> {
 }
 
 impl SyncAction for SleepAction {
-    fn undo(&self, _: &mut State) -> Result<(), String> {
+    fn undo(&self, _: &mut State) -> Result<(), anyhow::Error> {
         Ok(())
     }
 
-    fn redo(&self, _: &mut State) -> Result<(), String> {
+    fn redo(&self, _: &mut State) -> Result<(), anyhow::Error> {
         let sleep = if self.random {
             let mut rng = rand::thread_rng();
             rng.gen_range(Duration::from_secs(0)..self.duration)

--- a/src/testdrive/src/action/sql_server/connect.rs
+++ b/src/testdrive/src/action/sql_server/connect.rs
@@ -7,8 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use anyhow::Context;
 use async_trait::async_trait;
-
 use tiberius::{Client, Config};
 use tokio::net::TcpStream;
 use tokio_util::compat::TokioAsyncWriteCompatExt;
@@ -21,38 +21,37 @@ pub struct ConnectAction {
     config: tiberius::Config,
 }
 
-pub fn build_connect(mut cmd: BuiltinCommand) -> Result<ConnectAction, String> {
+pub fn build_connect(mut cmd: BuiltinCommand) -> Result<ConnectAction, anyhow::Error> {
     let name = cmd.args.string("name")?;
     cmd.args.done()?;
 
     let ado_string = cmd.input.join("\n");
 
-    let config =
-        Config::from_ado_string(&ado_string).map_err(|e| format!("parsing ADO string: {}", e))?;
+    let config = Config::from_ado_string(&ado_string).context("parsing ADO string: {}")?;
 
     Ok(ConnectAction { name, config })
 }
 
 #[async_trait]
 impl Action for ConnectAction {
-    async fn undo(&self, _: &mut State) -> Result<(), String> {
+    async fn undo(&self, _: &mut State) -> Result<(), anyhow::Error> {
         Ok(())
     }
 
-    async fn redo(&self, state: &mut State) -> Result<(), String> {
+    async fn redo(&self, state: &mut State) -> Result<(), anyhow::Error> {
         let tcp = TcpStream::connect(self.config.get_addr())
             .await
-            .map_err(|e| format!("Connecting to SQL Server: {}", e))?;
+            .context("connecting to SQL Server: {}")?;
 
         tcp.set_nodelay(true)
-            .map_err(|e| format!("Setting NODELAY socket option: {}", e))?;
+            .context("setting nodelay socket option")?;
 
         // To be able to use Tokio's tcp, we're using the `compat_write` from
         // the `TokioAsyncWriteCompatExt` to get a stream compatible with the
         // traits from the `futures` crate.
         let client = Client::connect(self.config.clone(), tcp.compat_write())
             .await
-            .map_err(|e| format!("connecting to SQL Server: {}", e))?;
+            .context("connecting to SQL Server")?;
 
         state.sql_server_clients.insert(self.name.clone(), client);
         Ok(())

--- a/src/testdrive/src/format/bytes.rs
+++ b/src/testdrive/src/format/bytes.rs
@@ -7,19 +7,21 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use anyhow::bail;
+
 /// Unescapes a testdrive byte string.
 ///
 /// The escape character is `\` and the only interesting escape sequence is
 /// `\xNN`, where each `N` is a valid hexadecimal digit. All other characters
 /// following a backslash are taken literally.
-pub fn unescape(s: &[u8]) -> Result<Vec<u8>, String> {
+pub fn unescape(s: &[u8]) -> Result<Vec<u8>, anyhow::Error> {
     let mut out = vec![];
     let mut s = s.iter().copied().fuse();
     while let Some(b) = s.next() {
         match b {
             b'\\' if s.next() == Some(b'x') => match (next_hex(&mut s), next_hex(&mut s)) {
                 (Some(c1), Some(c0)) => out.push((c1 << 4) + c0),
-                _ => return Err("invalid hexadecimal escape".into()),
+                _ => bail!("invalid hexadecimal escape"),
             },
             b'\\' => continue,
             _ => out.push(b),

--- a/src/testdrive/src/parser.rs
+++ b/src/testdrive/src/parser.rs
@@ -7,16 +7,17 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use anyhow::{anyhow, bail, Context};
 use lazy_static::lazy_static;
 use regex::Regex;
 
 use std::borrow::ToOwned;
 use std::collections::hash_map;
 use std::collections::{BTreeMap, HashMap};
-use std::fmt;
+use std::error::Error;
 use std::str::FromStr;
 
-use super::error::{InputError, Positioner};
+use crate::error::PosError;
 
 #[derive(Debug, Clone)]
 pub struct PosCommand {
@@ -69,7 +70,7 @@ pub enum SqlErrorMatchType {
     Regex,
 }
 
-pub fn parse(line_reader: &mut LineReader) -> Result<Vec<PosCommand>, InputError> {
+pub(crate) fn parse(line_reader: &mut LineReader) -> Result<Vec<PosCommand>, PosError> {
     let mut out = Vec::new();
     while let Some((pos, line)) = line_reader.peek() {
         let pos = *pos;
@@ -84,9 +85,9 @@ pub fn parse(line_reader: &mut LineReader) -> Result<Vec<PosCommand>, InputError
                 continue;
             }
             _ => {
-                return Err(InputError {
-                    msg: "unexpected input line at beginning of file".into(),
-                    pos,
+                return Err(PosError {
+                    source: anyhow!("unexpected input line at beginning of file"),
+                    pos: Some(pos),
                 });
             }
         };
@@ -95,16 +96,16 @@ pub fn parse(line_reader: &mut LineReader) -> Result<Vec<PosCommand>, InputError
     Ok(out)
 }
 
-fn parse_builtin(line_reader: &mut LineReader) -> Result<BuiltinCommand, InputError> {
+fn parse_builtin(line_reader: &mut LineReader) -> Result<BuiltinCommand, PosError> {
     let (pos, line) = line_reader.next().unwrap();
     let mut builtin_reader = BuiltinReader::new(&line, pos);
     let name = match builtin_reader.next() {
         Some(Ok((_, s))) => s,
         Some(Err(e)) => return Err(e),
         None => {
-            return Err(InputError {
-                msg: "command line is missing command name".into(),
-                pos,
+            return Err(PosError {
+                source: anyhow!("command line is missing command name"),
+                pos: Some(pos),
             });
         }
     };
@@ -116,9 +117,9 @@ fn parse_builtin(line_reader: &mut LineReader) -> Result<BuiltinCommand, InputEr
             [key, value] => vec![*key, *value],
             [key] => vec![*key, ""],
             _ => {
-                return Err(InputError {
-                    msg: "command argument is not in required key=value format".into(),
-                    pos,
+                return Err(PosError {
+                    source: anyhow!("command argument is not in required key=value format"),
+                    pos: Some(pos),
                 });
             }
         };
@@ -126,19 +127,19 @@ fn parse_builtin(line_reader: &mut LineReader) -> Result<BuiltinCommand, InputEr
             static ref VALID_KEY_REGEX: Regex = Regex::new("^[a-z0-9\\-]*$").unwrap();
         }
         if !VALID_KEY_REGEX.is_match(pieces[0]) {
-            return Err(InputError {
-                msg: format!(
+            return Err(PosError {
+                source: anyhow!(
                     "invalid builtin argument name '{}': \
                      only lowercase letters, numbers, and hyphens allowed",
                     pieces[0]
                 ),
-                pos,
+                pos: Some(pos),
             });
         }
         if let Some(original) = args.insert(pieces[0].to_owned(), pieces[1].to_owned()) {
-            return Err(InputError {
-                msg: format!("argument '{}' specified twice", original),
-                pos,
+            return Err(PosError {
+                source: anyhow!("argument '{}' specified twice", original),
+                pos: Some(pos),
             });
         };
     }
@@ -149,7 +150,7 @@ fn parse_builtin(line_reader: &mut LineReader) -> Result<BuiltinCommand, InputEr
     })
 }
 
-fn parse_sql(line_reader: &mut LineReader) -> Result<SqlCommand, InputError> {
+fn parse_sql(line_reader: &mut LineReader) -> Result<SqlCommand, PosError> {
     let (_, line1) = line_reader.next().unwrap();
     let query = line1[1..].trim().to_owned();
     let line2 = slurp_one(line_reader);
@@ -180,9 +181,9 @@ fn parse_sql(line_reader: &mut LineReader) -> Result<SqlCommand, InputError> {
                     })
                 }
                 Err(err) => {
-                    return Err(InputError {
-                        pos: pos2,
-                        msg: format!("Error parsing number of expected rows: {}", err),
+                    return Err(PosError {
+                        source: anyhow!("Error parsing number of expected rows: {}", err),
+                        pos: Some(pos2),
                     });
                 }
             },
@@ -202,7 +203,7 @@ fn parse_sql(line_reader: &mut LineReader) -> Result<SqlCommand, InputError> {
     })
 }
 
-fn parse_explain_sql(line_reader: &mut LineReader) -> Result<SqlCommand, InputError> {
+fn parse_explain_sql(line_reader: &mut LineReader) -> Result<SqlCommand, PosError> {
     let (_, line1) = line_reader.next().unwrap();
     // This is a bit of a hack to extract the next chunk of the file with
     // blank lines intact. Ideally the `LineReader` would expose the API we
@@ -226,15 +227,15 @@ fn parse_explain_sql(line_reader: &mut LineReader) -> Result<SqlCommand, InputEr
     })
 }
 
-fn parse_fail_sql(line_reader: &mut LineReader) -> Result<FailSqlCommand, InputError> {
+fn parse_fail_sql(line_reader: &mut LineReader) -> Result<FailSqlCommand, PosError> {
     let (pos, line1) = line_reader.next().unwrap();
     let line2 = slurp_one(line_reader);
     let (err_pos, expected_error) = match line2 {
         Some((err_pos, line2)) => (err_pos, line2),
         None => {
-            return Err(InputError {
-                pos,
-                msg: "failing SQL command is missing expected error message".into(),
+            return Err(PosError {
+                pos: Some(pos),
+                source: anyhow!("failing SQL command is missing expected error message"),
             });
         }
     };
@@ -248,9 +249,9 @@ fn parse_fail_sql(line_reader: &mut LineReader) -> Result<FailSqlCommand, InputE
         } else if let Some(exp_err) = expected_error.strip_prefix("exact:") {
             (exp_err, SqlErrorMatchType::Exact)
         } else {
-            return Err(InputError {
-                pos: err_pos,
-                msg: "Query error must start with match specifier".into(),
+            return Err(PosError {
+                pos: Some(err_pos),
+                source: anyhow!("Query error must start with match specifier"),
             });
         };
     Ok(FailSqlCommand {
@@ -260,7 +261,7 @@ fn parse_fail_sql(line_reader: &mut LineReader) -> Result<FailSqlCommand, InputE
     })
 }
 
-fn split_line(pos: usize, line: &str) -> Result<Vec<String>, InputError> {
+fn split_line(pos: usize, line: &str) -> Result<Vec<String>, PosError> {
     let mut out = Vec::new();
     let mut field = String::new();
     let mut in_quotes = None;
@@ -295,9 +296,9 @@ fn split_line(pos: usize, line: &str) -> Result<Vec<String>, InputError> {
         }
     }
     if let Some(i) = in_quotes {
-        return Err(InputError {
-            msg: "unterminated quote".into(),
-            pos: pos + i,
+        return Err(PosError {
+            source: anyhow!("unterminated quote"),
+            pos: Some(pos + i),
         });
     }
     if !field.is_empty() {
@@ -345,7 +346,7 @@ pub struct LineReader<'a> {
 }
 
 impl<'a> LineReader<'a> {
-    pub fn new(inner: &str) -> LineReader {
+    pub fn new(inner: &'a str) -> LineReader<'a> {
         let mut pos_map = BTreeMap::new();
         pos_map.insert(0, (1, 1));
         LineReader {
@@ -363,10 +364,8 @@ impl<'a> LineReader<'a> {
         }
         self.next.as_ref().unwrap().as_ref()
     }
-}
 
-impl<'a> Positioner for LineReader<'a> {
-    fn line_col(&self, pos: usize) -> (usize, usize) {
+    pub fn line_col(&self, pos: usize) -> (usize, usize) {
         let (base_pos, (line, col)) = self.pos_map.range(..=pos).next_back().unwrap();
         (*line, col + (pos - base_pos))
     }
@@ -441,7 +440,7 @@ impl<'a> BuiltinReader<'a> {
 }
 
 impl<'a> Iterator for BuiltinReader<'a> {
-    type Item = Result<(usize, String), InputError>;
+    type Item = Result<(usize, String), PosError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.inner.is_empty() {
@@ -469,9 +468,9 @@ impl<'a> Iterator for BuiltinReader<'a> {
                 continue;
             } else if done {
                 if let Some(nested) = nesting.last() {
-                    return Some(Err(InputError {
-                        pos: self.pos + i,
-                        msg: format!(
+                    return Some(Err(PosError {
+                        pos: Some(self.pos + i),
+                        source: anyhow!(
                             "command argument has unterminated open {}",
                             if nested == &'{' { "brace" } else { "bracket" }
                         ),
@@ -488,18 +487,18 @@ impl<'a> Iterator for BuiltinReader<'a> {
                     if (nested == &'{' && c == '}') || (nested == &'[' && c == ']') {
                         nesting.pop();
                     } else {
-                        return Some(Err(InputError {
-                            pos: self.pos + i,
-                            msg: format!(
+                        return Some(Err(PosError {
+                            pos: Some(self.pos + i),
+                            source: anyhow!(
                                 "command argument has unterminated open {}",
                                 if nested == &'{' { "brace" } else { "bracket" }
                             ),
                         }));
                     }
                 } else {
-                    return Some(Err(InputError {
-                        pos: self.pos + i,
-                        msg: format!(
+                    return Some(Err(PosError {
+                        pos: Some(self.pos + i),
+                        source: anyhow!(
                             "command argument has unbalanced close {}",
                             if c == '}' { "brace" } else { "bracket" }
                         ),
@@ -515,9 +514,9 @@ impl<'a> Iterator for BuiltinReader<'a> {
         }
 
         if let Some(nested) = nesting.last() {
-            return Some(Err(InputError {
-                pos: self.pos + self.inner.len() - 1,
-                msg: format!(
+            return Some(Err(PosError {
+                pos: Some(self.pos + self.inner.len() - 1),
+                source: anyhow!(
                     "command argument has unterminated open {}",
                     if nested == &'{' { "brace" } else { "bracket" }
                 ),
@@ -525,9 +524,9 @@ impl<'a> Iterator for BuiltinReader<'a> {
         }
 
         if quoted {
-            return Some(Err(InputError {
-                pos: self.pos,
-                msg: format!("command argument has unterminated open double quote",),
+            return Some(Err(PosError {
+                pos: Some(self.pos),
+                source: anyhow!("command argument has unterminated open double quote",),
             }));
         }
 
@@ -552,41 +551,40 @@ impl ArgMap {
         self.0.remove(name)
     }
 
-    pub fn string(&mut self, name: &str) -> Result<String, String> {
+    pub fn string(&mut self, name: &str) -> Result<String, anyhow::Error> {
         self.opt_string(name)
-            .ok_or_else(|| format!("missing {} parameter", name))
+            .ok_or_else(|| anyhow!("missing {} parameter", name))
     }
 
-    pub fn opt_parse<T>(&mut self, name: &str) -> Result<Option<T>, String>
+    pub fn opt_parse<T>(&mut self, name: &str) -> Result<Option<T>, anyhow::Error>
     where
         T: FromStr,
-        T::Err: fmt::Display,
+        T::Err: Error + Send + Sync + 'static,
     {
         match self.opt_string(name) {
             Some(val) => {
                 let t = val
                     .parse()
-                    .map_err(|e| format!("parsing {} parameter: {}", name, e))?;
+                    .with_context(|| format!("parsing {} parameter", name))?;
                 Ok(Some(t))
             }
             None => Ok(None),
         }
     }
 
-    #[allow(dead_code)]
-    pub fn parse<T>(&mut self, name: &str) -> Result<T, String>
+    pub fn parse<T>(&mut self, name: &str) -> Result<T, anyhow::Error>
     where
         T: FromStr,
-        T::Err: fmt::Display,
+        T::Err: Error + Send + Sync + 'static,
     {
         match self.opt_parse(name) {
-            Ok(None) => Err(format!("missing {} parameter", name)),
+            Ok(None) => bail!("missing {} parameter", name),
             Ok(Some(t)) => Ok(t),
             Err(err) => Err(err),
         }
     }
 
-    pub fn opt_bool(&mut self, name: &str) -> Result<Option<bool>, String> {
+    pub fn opt_bool(&mut self, name: &str) -> Result<Option<bool>, anyhow::Error> {
         self.opt_string(name)
             .map(|val| {
                 if val == "true" {
@@ -594,15 +592,15 @@ impl ArgMap {
                 } else if val == "false" {
                     Ok(false)
                 } else {
-                    Err(format!("bad value for boolean parameter {}: {}", name, val))
+                    bail!("bad value for boolean parameter {}: {}", name, val);
                 }
             })
             .transpose()
     }
 
-    pub fn done(&self) -> Result<(), String> {
+    pub fn done(&self) -> Result<(), anyhow::Error> {
         if let Some(name) = self.0.keys().next() {
-            return Err(format!("unknown parameter {}", name));
+            bail!("unknown parameter {}", name);
         }
         Ok(())
     }

--- a/src/testdrive/src/util/postgres.rs
+++ b/src/testdrive/src/util/postgres.rs
@@ -7,40 +7,31 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use anyhow::{bail, Context};
 use tokio_postgres::config::Host;
 use tokio_postgres::{Client, Config, NoTls};
 use url::Url;
-
-use crate::error::{Error, ResultExt};
 
 /// Constructs a URL from PostgreSQL configuration parameters.
 ///
 /// Returns an error if the set of configuration parameters is not representable
 /// as a URL, e.g., if there are multiple hosts.
-pub fn config_url(config: &Config) -> Result<Url, Error> {
+pub fn config_url(config: &Config) -> Result<Url, anyhow::Error> {
     let mut url = Url::parse("postgresql://").unwrap();
 
     let host = match config.get_hosts() {
         [] => "localhost".into(),
         [Host::Tcp(host)] => host.clone(),
         [Host::Unix(path)] => path.display().to_string(),
-        _ => {
-            return Err(Error::message(
-                "materialized URL cannot contain multiple hosts",
-            ));
-        }
+        _ => bail!("materialized URL cannot contain multiple hosts"),
     };
     url.set_host(Some(&host))
-        .err_ctx("parsing materialized host")?;
+        .context("parsing materialized host")?;
 
     url.set_port(Some(match config.get_ports() {
         [] => 5432,
         [port] => *port,
-        _ => {
-            return Err(Error::message(
-                "materialized URL cannot contain multiple ports",
-            ));
-        }
+        _ => bail!("materialized URL cannot contain multiple ports"),
     }))
     .expect("known to be valid to set port");
 
@@ -52,10 +43,10 @@ pub fn config_url(config: &Config) -> Result<Url, Error> {
     Ok(url)
 }
 
-pub async fn postgres_client(url: &String) -> Result<Client, String> {
+pub async fn postgres_client(url: &String) -> Result<Client, anyhow::Error> {
     let (client, connection) = tokio_postgres::connect(url, NoTls)
         .await
-        .map_err(|e| format!("connecting to postgres: {}", e))?;
+        .context("connecting to postgres")?;
 
     println!("Connecting to PostgreSQL server at {}...", url);
     tokio::spawn(connection);


### PR DESCRIPTION
Testdrive predates anyhow, and so had its own homegrown error type that
was mostly equivalent in functionality to `anyhow::Error`. But for
historical reasons, the `testdrive::Error` type was not used throughout
the entire crate, and so much of testdrive dealt in `String` errors.
This made writing testdrive actions unnecessarily verbose; lots of calls
like:

    fallible_op().map_err(|e| format!("fallible op failed: {:#}", e)

This commit switches testdrive to use `anyhow::Error` throughout the
crate. Much of the error handling goop becomes vastly less verbose, and
even when it doesn't, it becomes much more familiar.

The only casualty is the loss of error "hints". These weren't that
helpful, and in most cases have been largely mitigated by adding a bit more
context to the error message itself.

Fix #10172.

### Motivation

This PR refactors existing code.

This gets us a little closer to the ideal set out in https://github.com/MaterializeInc/materialize/discussions/5340. `testdrive` is a perfect example of a crate that _should_ be using `anyhow::Error` but wasn't. Elsewhere in Materialize (`dataflow`, `expr`, `repr`, `coord`, `sql`), `anyhow` should be on the way out.

### Tips for reviewer

The diff is scary but it's entirely mechanical.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
