### PR TITLE
Python dependency bump 2022-01-23

### DIFF
--- a/ci/builder/requirements-dev.txt
+++ b/ci/builder/requirements-dev.txt
@@ -6,7 +6,7 @@
 # variety of platforms, including M1 Macs.
 
 black==21.12b0
-boto3-stubs[ec2,kinesis,s3,sqs,ssm,sts]==1.20.37
+boto3-stubs[ec2,kinesis,s3,sqs,ssm,sts]==1.20.41
 boto3==1.20.41
 docker==5.0.3
 ec2instanceconnectcli==1.0.2

--- a/ci/builder/requirements-dev.txt
+++ b/ci/builder/requirements-dev.txt
@@ -7,7 +7,7 @@
 
 black==21.12b0
 boto3-stubs[ec2,kinesis,s3,sqs,ssm,sts]==1.20.37
-boto3==1.20.37
+boto3==1.20.41
 docker==5.0.3
 ec2instanceconnectcli==1.0.2
 flake8==4.0.1

--- a/ci/builder/requirements-dev.txt
+++ b/ci/builder/requirements-dev.txt
@@ -14,7 +14,7 @@ flake8==4.0.1
 isort==5.10.1
 mypy==0.931
 numpy==1.22.1
-pandas==1.3.5
+pandas==1.4.0
 pdoc3==0.10.0
 psutil==5.9.0
 # psycopg2 intentionally omitted. Use pg8000 from requirements-core.txt instead.

--- a/ci/builder/requirements.txt
+++ b/ci/builder/requirements.txt
@@ -12,6 +12,6 @@ prettytable==3.0.0
 PyMySQL==1.0.2
 pyyaml==6.0
 requests==2.27.1
-semver==3.0.0-dev.2
+semver==3.0.0.dev3
 sqlparse==0.4.2
 toml==0.10.2


### PR DESCRIPTION
### Motivation

* Weekly Python dependency bump PR.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
