### PR TITLE
test/proxy: support redpanda

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -72,7 +72,8 @@
     - ./ci/plugins/scratch-aws-access: ~
     - ./ci/plugins/mzcompose:
         composition: proxy
-        run: proxy-ci
+        run: proxy
+        args: [--aws-region=us-east-2]
 
 - id: testdrive_workers_1
   label: ":racing_car: testdrive with --workers 1"


### PR DESCRIPTION
Support a `--redpanda` option in test/proxy just like in test/testdrive.
This is mostly for the convenience of folks on M1 Macs who can't easily
run Confluent Platform in Docker.

While I'm in here, use the new `c.override` feature to avoid creating
separate `Materialized` services, and imbue the workflow with the same
`--aws-region` option that test/testdrive has.

There's a bit of duplication with test/testdrive now, but I want to
avoid introducing any helpers until we've got a few more examples of
this duplication so that we can get the abstraction boundary right.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
