### PR TITLE
mzcompose: rename `env` -> `env_extra` in Composition.run

### DIFF
--- a/misc/dbt-materialize/mzcompose.py
+++ b/misc/dbt-materialize/mzcompose.py
@@ -69,5 +69,5 @@ def run_test(c: Composition, materialized: str, env: Dict[str, str]) -> None:
         "dbt-test",
         "pytest",
         "dbt-materialize/test",
-        env=env,
+        env_extra=env,
     )

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -467,7 +467,7 @@ class Composition:
         *args: str,
         detach: bool = False,
         rm: bool = False,
-        env: Dict[str, str] = {},
+        env_extra: Dict[str, str] = {},
         capture: bool = False,
     ) -> subprocess.CompletedProcess:
         """Run a one-off command in a service.
@@ -481,7 +481,7 @@ class Composition:
             service: The name of a service in the composition.
             args: Arguments to pass to the service's entrypoint.
             detach: Run the container in the background.
-            env: Additional environment variables to set in the container.
+            env_extra: Additional environment variables to set in the container.
             rm: Remove container after run.
             capture: Capture the stdout of the `docker-compose` invocation.
         """
@@ -491,7 +491,7 @@ class Composition:
         self.invoke("up", "--detach", "--scale", f"{service}=0", service)
         return self.invoke(
             "run",
-            *(f"-e{k}={v}" for k, v in env.items()),
+            *(f"-e{k}={v}" for k, v in env_extra.items()),
             *(["--detach"] if detach else []),
             *(["--rm"] if rm else []),
             service,


### PR DESCRIPTION
Per @quodlibetor, the `env` parameter implied a totality (c.f.
spawn.runv); rename it to `env_extra` to make clear that the specified
environment variables are in addition to any in the service's
specification.


### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
