### PR TITLE
sql: remove expression deduplication in GROUP BY planning #8302 

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -110,7 +110,7 @@ changes that have not yet been documented.
 - Fix parsing of nested empty `SELECT` statements, as in
   `SELECT * FROM (SELECT)` {{% gh 8723 %}}.
 
-- Fix parsing of repeat constant expressions in a `GROUP BY` clause {{% gh 8302 %}}
+- Fix planning of repeat constant expressions in a `GROUP BY` clause {{% gh 8302 %}}
 
 - Detect and reject multiple materializations of sources that would silently
   lose data when materialized more than once. This enables safe use of

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -110,6 +110,8 @@ changes that have not yet been documented.
 - Fix parsing of nested empty `SELECT` statements, as in
   `SELECT * FROM (SELECT)` {{% gh 8723 %}}.
 
+- Fix parsing of repeat constant expressions in a `GROUP BY` clause {{% gh 8302 %}}
+
 - Detect and reject multiple materializations of sources that would silently
   lose data when materialized more than once. This enables safe use of
   unmaterialized PostgreSQL and S3 with SQS notifications sources. {{% gh 8203

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -1631,6 +1631,7 @@ fn plan_view_select(
         let mut group_exprs = vec![];
         let mut group_scope = Scope::empty();
         let mut select_all_mapping = BTreeMap::new();
+
         for group_expr in &s.group_by {
             let (group_expr, expr) = plan_group_by_expr(ecx, group_expr, &projection)?;
             let new_column = group_key.len();

--- a/src/sql/src/plan/scope.rs
+++ b/src/sql/src/plan/scope.rs
@@ -62,9 +62,9 @@ pub struct ScopeItem {
     pub table_name: Option<PartialName>,
     /// The name of the column.
     pub column_name: ColumnName,
-    /// The expression from which this scope item is derived. Used by `GROUP
+    /// The expressions from which this scope item is derived. Used by `GROUP
     /// BY`.
-    pub expr: HashSet<Expr<Aug>>,
+    pub exprs: HashSet<Expr<Aug>>,
     /// Whether the column is the return value of a function that produces only
     /// a single column. This accounts for a strange PostgreSQL special case
     /// around whole-row expansion.
@@ -126,11 +126,11 @@ pub struct Scope {
 }
 
 impl ScopeItem {
-    fn empty() -> ScopeItem {
+    pub fn empty() -> ScopeItem {
         ScopeItem {
             table_name: None,
             column_name: "?column?".into(),
-            expr: HashSet::new(),
+            exprs: HashSet::new(),
             from_single_column_function: false,
             allow_unqualified_references: true,
             lateral_error_if_referenced: false,
@@ -162,7 +162,7 @@ impl ScopeItem {
     pub fn from_expr(expr: impl Into<Option<Expr<Aug>>>) -> ScopeItem {
         let mut item = ScopeItem::empty();
         if let Some(expr) = expr.into() {
-            item.expr.insert(expr);
+            item.exprs.insert(expr);
         }
         item
     }
@@ -399,7 +399,7 @@ impl Scope {
         self.items
             .iter()
             .enumerate()
-            .find(|(_, item)| item.expr.contains(expr))
+            .find(|(_, item)| item.exprs.contains(expr))
             .map(|(i, _)| ColumnRef {
                 level: 0,
                 column: i,

--- a/test/sqllogictest/aggregates.slt
+++ b/test/sqllogictest/aggregates.slt
@@ -78,6 +78,13 @@ SELECT a, sum(b) AS a FROM t GROUP BY a
 2 3
 3 1
 
+query I
+SELECT a FROM t GROUP BY t.a, t.a
+----
+1
+2
+3
+
 # Smoke test to make sure multiple accumulable and hierarchical reductions work
 query IIIII rowsort
 SELECT a, count(b), min(b), sum(b), max(b) FROM t GROUP BY a

--- a/test/sqllogictest/aggregates.slt
+++ b/test/sqllogictest/aggregates.slt
@@ -85,6 +85,13 @@ SELECT a FROM t GROUP BY t.a, t.a
 2
 3
 
+query I
+SELECT a FROM t GROUP BY t.a, public.t.a
+----
+1
+2
+3
+
 # Smoke test to make sure multiple accumulable and hierarchical reductions work
 query IIIII rowsort
 SELECT a, count(b), min(b), sum(b), max(b) FROM t GROUP BY a

--- a/test/sqllogictest/aggregates.slt
+++ b/test/sqllogictest/aggregates.slt
@@ -138,6 +138,12 @@ SELECT pg_typeof(sum(b)) FROM t_bigint
 pg_typeof
 numeric
 
+query TT colnames
+SELECT pg_typeof(a) as a_type, pg_typeof(b) as b_type FROM t_bigint GROUP BY a_type, b_type
+----
+a_type b_type
+bigint bigint
+
 # Tests to make sure reduce elision works correctly
 
 statement ok


### PR DESCRIPTION
<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

GROUP BY planning currently deduplicates expressions, but in the case of repeat constant expressions (`e.g. pg_typeof(colA) as a, pg_typeof(colB) as b`) this will later cause the query to fail. Further details are in #8302.

On the surface, removing the duplication process entirely seems to work (thanks @benesch for the double check!), and this PR adds a quick test to ensure the formerly problematic query works as intended. Definitely need to have this change run through our full set of tests though.

### Motivation

Fixes #8302. Further discussion on Slack starting with https://materializeinc.slack.com/archives/CMHDK0DK8/p1643032415071900

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug: [Link to issue.]

  * This PR adds a known-desirable feature: [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
