### PR TITLE
aws-util: depend on openssl-sys with the "vendored" feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3035,6 +3035,7 @@ dependencies = [
  "aws-smithy-http",
  "aws-types",
  "mz-http-proxy",
+ "openssl-sys",
 ]
 
 [[package]]

--- a/src/aws-util/Cargo.toml
+++ b/src/aws-util/Cargo.toml
@@ -15,6 +15,10 @@ aws-sdk-s3 = { version = "0.5.0", default-features = false, features = ["native-
 aws-sdk-sqs = { version = "0.5.0", default-features = false, features = ["native-tls"], optional = true }
 aws-sdk-sts = { version = "0.5.0", default-features = false, features = ["native-tls"], optional = true }
 aws-types = { version = "0.5.0" }
+# Make sure the "vendored" feature makes it into the transitive dep graph of
+# every aws user, so that we don't attempt to link against the system OpenSSL
+# library.
+openssl-sys = { version = "0.9.72", features = ["vendored"] }
 mz-http-proxy = { path = "../http-proxy", features = ["hyper"] }
 
 [features]


### PR DESCRIPTION
This ensures the "vendored" feature makes it into the transitive dep
graph of every aws user, so the right things are available at link time.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [N/A] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
