### PR TITLE
qgm: factor out model-dependent methods

### DIFF
--- a/src/sql/src/query_model/hir.rs
+++ b/src/sql/src/query_model/hir.rs
@@ -309,9 +309,7 @@ impl FromHir {
                 self.add_predicate(join_box, predicate);
 
                 // Default projection
-                self.model
-                    .get_mut_box(join_box)
-                    .add_all_input_columns(&self.model);
+                self.model.get_mut_box(join_box).add_all_input_columns();
 
                 join_box
             }
@@ -326,8 +324,7 @@ impl FromHir {
         let select_id = self.model.make_select_box();
         self.model
             .make_quantifier(QuantifierType::Foreach, box_id, select_id);
-        let mut select_box = self.model.get_mut_box(select_id);
-        select_box.add_all_input_columns(&self.model);
+        self.model.get_mut_box(select_id).add_all_input_columns();
         select_id
     }
 

--- a/src/sql/src/query_model/mod.rs
+++ b/src/sql/src/query_model/mod.rs
@@ -296,6 +296,16 @@ impl Model {
         self.make_box(BoxType::Select(Select::default()))
     }
 
+    /// An iterator over immutable references to the [`QueryBox`] instances in this [`Model`].
+    fn boxes_iter(&self) -> impl Iterator<Item = Ref<'_, QueryBox>> {
+        self.boxes.keys().map(|box_id| {
+            self.boxes
+                .get(&box_id)
+                .expect("a valid box identifier")
+                .borrow()
+        })
+    }
+
     /// Get an immutable reference to the box identified by `box_id`.
     fn get_box(&self, box_id: BoxId) -> Ref<'_, QueryBox> {
         self.boxes
@@ -518,7 +528,7 @@ impl QueryBox {
     fn input_quantifiers<'a>(
         &'a self,
         model: &'a Model,
-    ) -> impl Iterator<Item = BoundRef<'a, Quantifier>> {
+    ) -> impl Iterator<Item = Ref<'a, Quantifier>> {
         self.quantifiers
             .iter()
             .map(|q_id| model.get_quantifier(*q_id))
@@ -529,7 +539,7 @@ impl QueryBox {
     fn ranging_quantifiers<'a>(
         &'a self,
         model: &'a Model,
-    ) -> impl Iterator<Item = BoundRef<'a, Quantifier>> {
+    ) -> impl Iterator<Item = Ref<'a, Quantifier>> {
         self.ranging_quantifiers
             .iter()
             .map(|q_id| model.get_quantifier(*q_id))

--- a/src/sql/src/query_model/mod.rs
+++ b/src/sql/src/query_model/mod.rs
@@ -11,6 +11,7 @@ use std::cell::{Ref, RefCell, RefMut};
 use std::collections::BTreeSet;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt;
+use std::ops::{Deref, DerefMut};
 
 use ore::id_gen::Gen;
 
@@ -77,6 +78,44 @@ pub struct Model {
     quantifiers: HashMap<QuantifierId, Box<RefCell<Quantifier>>>,
     /// Used for assigning unique IDs to quantifiers.
     quantifier_id_gen: Gen<QuantifierId>,
+}
+
+/// A mutable reference to an object of type `T` (a [`QueryBox`] or a [`Quantifier`])
+/// bound to a specific [`Model`].
+#[derive(Debug)]
+pub struct BoundRef<'a, T> {
+    model: &'a Model,
+    r#ref: Ref<'a, T>,
+}
+
+impl<T> Deref for BoundRef<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        self.r#ref.deref()
+    }
+}
+
+/// A mutable reference to an object of type `T` (a [`QueryBox`] or a [`Quantifier`])
+/// bound to a specific [`Model`].
+#[derive(Debug)]
+pub struct BoundRefMut<'a, T> {
+    model: &'a mut Model,
+    r#ref: RefMut<'a, T>,
+}
+
+impl<T> Deref for BoundRefMut<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        self.r#ref.deref()
+    }
+}
+
+impl<T> DerefMut for BoundRefMut<'_, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        self.r#ref.deref_mut()
+    }
 }
 
 /// A semantic operator within a Query Graph.

--- a/src/sql/src/query_model/validator/quantifier.rs
+++ b/src/sql/src/query_model/validator/quantifier.rs
@@ -70,7 +70,7 @@ impl RangeBounds<usize> for QuantifierConstraint {
 /// - All `quantifiers` with satisfied type also satisfy the quantifier box constraints.
 fn check_constraints<'a, const N: usize>(
     constraints: &[QuantifierConstraint; N],
-    quantifiers: impl Iterator<Item = Ref<'a, Quantifier>>,
+    quantifiers: impl Iterator<Item = BoundRef<'a, Quantifier>>,
     model: &'a Model,
     mut on_failure: impl FnMut(&QuantifierConstraint) -> (),
 ) {
@@ -218,29 +218,29 @@ impl Validator for QuantifierConstraintValidator {
             match b.box_type {
                 Get(..) | TableFunction(..) | Values(..) => {
                     let constraints = [ZERO_ARBITRARY];
-                    check_constraints(&constraints, b.input_quantifiers(model), model, |c| {
+                    check_constraints(&constraints, b.input_quantifiers(), model, |c| {
                         errors.push(ValidationError::InvalidInputQuantifiers(b.id, c.clone()))
                     })
                 }
                 Union | Except | Intersect => {
                     let constraints = [ONE_OR_MORE_FOREACH, ZERO_NOT_FOREACH];
-                    check_constraints(&constraints, b.input_quantifiers(model), model, |c| {
+                    check_constraints(&constraints, b.input_quantifiers(), model, |c| {
                         errors.push(ValidationError::InvalidInputQuantifiers(b.id, c.clone()))
                     })
                 }
                 Grouping(..) => {
                     let constraints = [ONE_FOREACH_INPUT_SELECT, ZERO_NOT_FOREACH];
-                    check_constraints(&constraints, b.input_quantifiers(model), model, |c| {
+                    check_constraints(&constraints, b.input_quantifiers(), model, |c| {
                         errors.push(ValidationError::InvalidInputQuantifiers(b.id, c.clone()))
                     });
                     let constraints = [ONE_FOREACH_PARENT_SELECT, ZERO_NOT_FOREACH];
-                    check_constraints(&constraints, b.ranging_quantifiers(model), model, |c| {
+                    check_constraints(&constraints, b.ranging_quantifiers(), model, |c| {
                         errors.push(ValidationError::InvalidRangingQuantifiers(b.id, c.clone()))
                     });
                 }
                 Select(..) => {
                     let constraints = [ONE_OR_MORE_NOT_PRES_FOREACH, ZERO_PRESERVED_FOREACH];
-                    check_constraints(&constraints, b.input_quantifiers(model), model, |c| {
+                    check_constraints(&constraints, b.input_quantifiers(), model, |c| {
                         errors.push(ValidationError::InvalidInputQuantifiers(b.id, c.clone()))
                     });
                 }
@@ -251,7 +251,7 @@ impl Validator for QuantifierConstraintValidator {
                         TWO_OUTER_JOIN_INPUTS,
                         ZERO_NOT_OUTER_JOIN_INPUTS,
                     ];
-                    check_constraints(&constraints, b.input_quantifiers(model), model, |c| {
+                    check_constraints(&constraints, b.input_quantifiers(), model, |c| {
                         errors.push(ValidationError::InvalidInputQuantifiers(b.id, c.clone()))
                     });
                 }

--- a/src/sql/src/query_model/validator/quantifier.rs
+++ b/src/sql/src/query_model/validator/quantifier.rs
@@ -212,7 +212,7 @@ impl Validator for QuantifierConstraintValidator {
     fn validate(&self, model: &Model) -> ValidationResult {
         let mut errors = vec![];
 
-        for b in model.boxes.values().map(|b| b.borrow()) {
+        for b in model.boxes_iter() {
             use constants::*;
             use BoxType::*;
             match b.box_type {


### PR DESCRIPTION
See commit messages for details.

### Motivation

Which of the following best describes the motivation behind this PR?

   * This PR refactors existing code.

We want to statically enforce model immutability in client code in the obvious way (i.e., by passing `model: &Model` parameter). However, at the moment the `QueryBox::get_mut_box` and `QueryBox::get_mut_quantifier` methods are not marked as mutable (their first argument is `&self` and not `&mut self`). Consequently, clients that operate on a `model: &Model` parameter are not guaranteed to not change the `Model`.

### Tips for reviewer

The intuitive minimal fix (changing the receiver type to `&mut self`) breaks the borrow checker for statements such as

```rust
model.get_box_mut(box_id).add_all_input_columns(model)
```

where we need to pass the model as an argument to the ref.

To overcome this limitation, we do the following:

1. Introduce two new types that implement `Deref`/`DerefMut` in the `query_graph` module: `BoundRef` and `BoundRefMut`. These types model a (mutable) reference to an item (a `QueryBox` or a `Quantifier`) which is bound within the context of an enclosing QGM `Model`.
2. Factor out model-specific methods in `QueryBox` into a dedicated `impl` block.
3. Implement delegators for these methods for `BoundRef<'a, QueryBox>` and `BoundRefMut<'a, QueryBox>`.
4. Change the return types of the `Model::get_*` methods from `Ref`/`RefMut` to `BoundRef`/`BoundRefMut` and use the delegator methods from the above item in client code.

The commit messages are broken into small refactoring units for better readability.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
