### PR TITLE
mzcompose: use new --var feature instead of env vars

### DIFF
--- a/doc/developer/testdrive.md
+++ b/doc/developer/testdrive.md
@@ -561,7 +561,7 @@ Creates a named connection to SQL Server. The parameters of the connection are s
 
 ```
 $ sql-server-connect name=sql-server
-server=tcp:sql-server,1433;IntegratedSecurity=true;TrustServerCertificate=true;User ID=sa;Password=${env.SA_PASSWORD}
+server=tcp:sql-server,1433;IntegratedSecurity=true;TrustServerCertificate=true;User ID=sa;Password=${arg.sa-password}
 ```
 
 #### `$ sql-server-execute name=...`

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -39,12 +39,18 @@ class Materialized(Service):
     ) -> None:
         if environment is None:
             environment = [
-                "MZ_LOG_FILTER",
                 "MZ_SOFT_ASSERTIONS=1",
+                "MZ_METRICS_SCRAPING_INTERVAL=1s",
+                # Please think twice before forwarding additional environment
+                # variables from the host, as it's easy to write tests that are
+                # then accidentally dependent on the state of the host machine.
+                #
+                # To dynamically change the environment during a workflow run,
+                # use Composition.override.
+                "MZ_LOG_FILTER",
                 "AWS_ACCESS_KEY_ID",
                 "AWS_SECRET_ACCESS_KEY",
                 "AWS_SESSION_TOKEN",
-                "MZ_METRICS_SCRAPING_INTERVAL=1s",
             ]
 
         # Make sure MZ_DEV=1 is always present
@@ -504,13 +510,16 @@ class Testdrive(Service):
         if environment is None:
             environment = [
                 "TMPDIR=/share/tmp",
+                # Please think twice before forwarding additional environment
+                # variables from the host, as it's easy to write tests that are
+                # then accidentally dependent on the state of the host machine.
+                #
+                # To pass arguments to a testdrive script, use the `--var` CLI
+                # option rather than environment variables.
                 "MZ_LOG_FILTER",
                 "AWS_ACCESS_KEY_ID",
                 "AWS_SECRET_ACCESS_KEY",
                 "AWS_SESSION_TOKEN",
-                "SA_PASSWORD",
-                "TOXIPROXY_BYTES_ALLOWED",
-                "UPGRADE_FROM_VERSION",
             ]
 
         if volumes is None:

--- a/test/debezium-avro/mzcompose.py
+++ b/test/debezium-avro/mzcompose.py
@@ -7,10 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-import os
 import random
 import string
-from unittest.mock import patch
 
 from materialize.mzcompose import Composition
 from materialize.mzcompose.services import (
@@ -53,9 +51,8 @@ def workflow_debezium_avro(c: Composition) -> None:
     c.run("testdrive-svc", "*.td")
 
 
-@patch.dict(os.environ, {"SA_PASSWORD": sa_password})
 def workflow_debezium_sql_server(c: Composition) -> None:
     c.start_and_wait_for_tcp(services=prerequisites)
     c.start_and_wait_for_tcp(services=["sql-server"])
 
-    c.run("testdrive-svc", "sql-server/*.td")
+    c.run("testdrive-svc", f"--var=sa-password={sa_password}", "sql-server/*.td")

--- a/test/debezium-avro/sql-server/10-configure-sql-server.td
+++ b/test/debezium-avro/sql-server/10-configure-sql-server.td
@@ -20,7 +20,7 @@
 <null>
 
 $ sql-server-connect name=sql-server
-server=tcp:sql-server,1433;IntegratedSecurity=true;TrustServerCertificate=true;User ID=sa;Password=${env.SA_PASSWORD}
+server=tcp:sql-server,1433;IntegratedSecurity=true;TrustServerCertificate=true;User ID=sa;Password=${arg.sa-password}
 
 $ sql-server-execute name=sql-server
 DROP DATABASE IF EXISTS test;

--- a/test/debezium-avro/sql-server/20-populate-delete.td
+++ b/test/debezium-avro/sql-server/20-populate-delete.td
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0.
 
 $ sql-server-connect name=sql-server
-server=tcp:sql-server,1433;IntegratedSecurity=true;TrustServerCertificate=true;User ID=sa;Password=${env.SA_PASSWORD}
+server=tcp:sql-server,1433;IntegratedSecurity=true;TrustServerCertificate=true;User ID=sa;Password=${arg.sa-password}
 
 $ sql-server-execute name=sql-server
 USE test;

--- a/test/debezium-avro/sql-server/20-populate-smoke.td
+++ b/test/debezium-avro/sql-server/20-populate-smoke.td
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0.
 
 $ sql-server-connect name=sql-server
-server=tcp:sql-server,1433;IntegratedSecurity=true;TrustServerCertificate=true;User ID=sa;Password=${env.SA_PASSWORD}
+server=tcp:sql-server,1433;IntegratedSecurity=true;TrustServerCertificate=true;User ID=sa;Password=${arg.sa-password}
 
 $ sql-server-execute name=sql-server
 USE test;

--- a/test/debezium-avro/sql-server/20-populate-transactions.td
+++ b/test/debezium-avro/sql-server/20-populate-transactions.td
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0.
 
 $ sql-server-connect name=sql-server
-server=tcp:sql-server,1433;IntegratedSecurity=true;TrustServerCertificate=true;User ID=sa;Password=${env.SA_PASSWORD}
+server=tcp:sql-server,1433;IntegratedSecurity=true;TrustServerCertificate=true;User ID=sa;Password=${arg.sa-password}
 
 $ sql-server-execute name=sql-server
 USE test;

--- a/test/debezium-avro/sql-server/20-populate-types.td
+++ b/test/debezium-avro/sql-server/20-populate-types.td
@@ -12,7 +12,7 @@
 #
 
 $ sql-server-connect name=sql-server
-server=tcp:sql-server,1433;IntegratedSecurity=true;TrustServerCertificate=true;User ID=sa;Password=${env.SA_PASSWORD}
+server=tcp:sql-server,1433;IntegratedSecurity=true;TrustServerCertificate=true;User ID=sa;Password=${arg.sa-password}
 
 $ sql-server-execute name=sql-server
 USE test;

--- a/test/debezium-avro/sql-server/20-populate-update.td
+++ b/test/debezium-avro/sql-server/20-populate-update.td
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0.
 
 $ sql-server-connect name=sql-server
-server=tcp:sql-server,1433;IntegratedSecurity=true;TrustServerCertificate=true;User ID=sa;Password=${env.SA_PASSWORD}
+server=tcp:sql-server,1433;IntegratedSecurity=true;TrustServerCertificate=true;User ID=sa;Password=${arg.sa-password}
 
 $ sql-server-execute name=sql-server
 USE test;

--- a/test/debezium-avro/sql-server/30-configure-debezium.td
+++ b/test/debezium-avro/sql-server/30-configure-debezium.td
@@ -37,7 +37,7 @@ $ http-request method=POST url=http://debezium:8083/connectors content-type=appl
         "database.hostname": "sql-server",
         "database.port": "1433",
         "database.user": "sa",
-        "database.password": "${env.SA_PASSWORD}",
+        "database.password": "${arg.sa-password}",
         "database.dbname": "test",
         "database.server.name": "sql-server",
         "database.history.kafka.bootstrap.servers": "kafka:9092",

--- a/test/debezium-avro/sql-server/40-check-delete.td
+++ b/test/debezium-avro/sql-server/40-check-delete.td
@@ -22,7 +22,7 @@ $ schema-registry-wait-schema schema=sql-server.dbo.delete_table_nopk-value
   ENVELOPE DEBEZIUM;
 
 $ sql-server-connect name=sql-server
-server=tcp:sql-server,1433;IntegratedSecurity=true;TrustServerCertificate=true;User ID=sa;Password=${env.SA_PASSWORD}
+server=tcp:sql-server,1433;IntegratedSecurity=true;TrustServerCertificate=true;User ID=sa;Password=${arg.sa-password}
 
 $ sql-server-execute name=sql-server
 USE test;

--- a/test/debezium-avro/sql-server/40-check-smoke.td
+++ b/test/debezium-avro/sql-server/40-check-smoke.td
@@ -10,7 +10,7 @@
 $ schema-registry-wait-schema schema=sql-server.dbo.t1-value
 
 $ sql-server-connect name=sql-server
-server=tcp:sql-server,1433;IntegratedSecurity=true;TrustServerCertificate=true;User ID=sa;Password=${env.SA_PASSWORD}
+server=tcp:sql-server,1433;IntegratedSecurity=true;TrustServerCertificate=true;User ID=sa;Password=${arg.sa-password}
 
 $ sql-server-execute name=sql-server
 USE test;

--- a/test/debezium-avro/sql-server/40-check-transactions.td
+++ b/test/debezium-avro/sql-server/40-check-transactions.td
@@ -22,7 +22,7 @@ $ schema-registry-wait-schema schema=sql-server.dbo.transaction_table2-value
   ENVELOPE DEBEZIUM;
 
 $ sql-server-connect name=sql-server
-server=tcp:sql-server,1433;IntegratedSecurity=true;TrustServerCertificate=true;User ID=sa;Password=${env.SA_PASSWORD}
+server=tcp:sql-server,1433;IntegratedSecurity=true;TrustServerCertificate=true;User ID=sa;Password=${arg.sa-password}
 
 $ sql-server-execute name=sql-server
 USE test;

--- a/test/debezium-avro/sql-server/40-check-types.td
+++ b/test/debezium-avro/sql-server/40-check-types.td
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0.
 
 $ sql-server-connect name=sql-server
-server=tcp:sql-server,1433;IntegratedSecurity=true;TrustServerCertificate=true;User ID=sa;Password=${env.SA_PASSWORD}
+server=tcp:sql-server,1433;IntegratedSecurity=true;TrustServerCertificate=true;User ID=sa;Password=${arg.sa-password}
 
 $ sql-server-execute name=sql-server
 USE test;

--- a/test/debezium-avro/sql-server/40-check-update.td
+++ b/test/debezium-avro/sql-server/40-check-update.td
@@ -22,7 +22,7 @@ $ schema-registry-wait-schema schema=sql-server.dbo.update_table_nopk-value
   ENVELOPE DEBEZIUM;
 
 $ sql-server-connect name=sql-server
-server=tcp:sql-server,1433;IntegratedSecurity=true;TrustServerCertificate=true;User ID=sa;Password=${env.SA_PASSWORD}
+server=tcp:sql-server,1433;IntegratedSecurity=true;TrustServerCertificate=true;User ID=sa;Password=${arg.sa-password}
 
 $ sql-server-execute name=sql-server
 USE test;

--- a/test/s3-resumption/mzcompose.py
+++ b/test/s3-resumption/mzcompose.py
@@ -61,33 +61,31 @@ def workflow_s3_resumption(c: Composition) -> None:
             else ["toxiproxy-close-connection.td", "configure-materialize.td"]
         )
 
-        with patch.dict(
-            environ, {"TOXIPROXY_BYTES_ALLOWED": str(toxiproxy_bytes_allowed)}
-        ):
-            c.run(
-                "testdrive-svc",
-                "--no-reset",
-                "--max-errors=1",
-                f"--seed={toxiproxy_bytes_allowed}",
-                "--aws-endpoint=http://toxiproxy:4566",
-                "configure-toxiproxy.td",
-                "s3-create.td",
-                "s3-insert-long.td",
-                "s3-insert-long-gzip.td",
-                #
-                # Confirm that short network interruptions are tolerated
-                #
-                *toxiproxy_setup,
-                "short-sleep.td",
-                "toxiproxy-restore-connection.td",
-                "materialize-verify-success.td",
-                #
-                # Confirm that long network interruptions cause source error
-                # Disabled due to https://github.com/MaterializeInc/materialize/issues/7009
-                # "s3-insert-long.td s3-insert-long-gzip.td toxiproxy-close-connection.td materialize-verify-failure.td",
-                #
-                # Cleanup
-                #
-                "materialize-drop-source.td",
-                "toxiproxy-remove.td",
-            )
+        c.run(
+            "testdrive-svc",
+            "--no-reset",
+            "--max-errors=1",
+            f"--seed={toxiproxy_bytes_allowed}",
+            "--aws-endpoint=http://toxiproxy:4566",
+            f"--var=toxiproxy-bytes-allowed={toxiproxy_bytes_allowed}",
+            "configure-toxiproxy.td",
+            "s3-create.td",
+            "s3-insert-long.td",
+            "s3-insert-long-gzip.td",
+            #
+            # Confirm that short network interruptions are tolerated
+            #
+            *toxiproxy_setup,
+            "short-sleep.td",
+            "toxiproxy-restore-connection.td",
+            "materialize-verify-success.td",
+            #
+            # Confirm that long network interruptions cause source error
+            # Disabled due to https://github.com/MaterializeInc/materialize/issues/7009
+            # "s3-insert-long.td s3-insert-long-gzip.td toxiproxy-close-connection.td materialize-verify-failure.td",
+            #
+            # Cleanup
+            #
+            "materialize-drop-source.td",
+            "toxiproxy-remove.td",
+        )

--- a/test/s3-resumption/toxiproxy-close-connection.td
+++ b/test/s3-resumption/toxiproxy-close-connection.td
@@ -15,5 +15,5 @@ $ http-request method=POST url=http://toxiproxy:8474/proxies/localstack/toxics c
 {
   "name": "localstack",
   "type": "limit_data",
-  "attributes": { "bytes": ${env.TOXIPROXY_BYTES_ALLOWED} }
+  "attributes": { "bytes": ${arg.toxiproxy-bytes-allowed} }
 }

--- a/test/upgrade/check-from-any_version-kafka-source.td
+++ b/test/upgrade/check-from-any_version-kafka-source.td
@@ -23,7 +23,7 @@ a b
 1 2
 2 3
 
-$ kafka-ingest format=avro topic=upgrade-kafka-source-${env.UPGRADE_FROM_VERSION} schema=${schema} timestamp=1
+$ kafka-ingest format=avro topic=upgrade-kafka-source-${arg.upgrade-from-version} schema=${schema} timestamp=1
 {"a": 10, "b": 20}
 {"a": 20, "b": 30}
 

--- a/test/upgrade/check-from-v0.9.12-compile-proto-sources.td
+++ b/test/upgrade/check-from-v0.9.12-compile-proto-sources.td
@@ -13,7 +13,7 @@ id mz_offset
 c  1
 h  2
 
-$ kafka-ingest topic=upgrade-proto-source-${env.UPGRADE_FROM_VERSION} format=protobuf descriptor-file=message.pb message=Message confluent-wire-format=true
+$ kafka-ingest topic=upgrade-proto-source-${arg.upgrade-from-version} format=protobuf descriptor-file=message.pb message=Message confluent-wire-format=true
 {"id": "a"}
 {"id": "e"}
 

--- a/test/upgrade/create-in-any_version-kafka-source.td
+++ b/test/upgrade/create-in-any_version-kafka-source.td
@@ -16,14 +16,14 @@ $ set schema={
     ]
   }
 
-$ kafka-create-topic topic=upgrade-kafka-source-${env.UPGRADE_FROM_VERSION}
+$ kafka-create-topic topic=upgrade-kafka-source-${arg.upgrade-from-version}
 
-$ kafka-ingest format=avro topic=upgrade-kafka-source-${env.UPGRADE_FROM_VERSION} schema=${schema} timestamp=1
+$ kafka-ingest format=avro topic=upgrade-kafka-source-${arg.upgrade-from-version} schema=${schema} timestamp=1
 {"a": 1, "b": 2}
 {"a": 2, "b": 3}
 
 > CREATE MATERIALIZED SOURCE kafka_source
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-upgrade-kafka-source-${env.UPGRADE_FROM_VERSION}-${testdrive.seed}'
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-upgrade-kafka-source-${arg.upgrade-from-version}-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE NONE
 

--- a/test/upgrade/create-in-v0.9.12-compile-proto-sources.td
+++ b/test/upgrade/create-in-v0.9.12-compile-proto-sources.td
@@ -19,15 +19,15 @@ $ file-append path=message.proto
 
 $ protobuf-compile-descriptors inputs=message.proto output=message.pb
 
-$ kafka-create-topic topic=upgrade-proto-source-${env.UPGRADE_FROM_VERSION}
+$ kafka-create-topic topic=upgrade-proto-source-${arg.upgrade-from-version}
 
-$ schema-registry-publish subject=testdrive-upgrade-proto-source-${env.UPGRADE_FROM_VERSION}-${testdrive.seed}-value schema-type=protobuf
+$ schema-registry-publish subject=testdrive-upgrade-proto-source-${arg.upgrade-from-version}-${testdrive.seed}-value schema-type=protobuf
 \${schema}
 
-$ kafka-ingest topic=upgrade-proto-source-${env.UPGRADE_FROM_VERSION} format=protobuf descriptor-file=message.pb message=Message confluent-wire-format=true
+$ kafka-ingest topic=upgrade-proto-source-${arg.upgrade-from-version} format=protobuf descriptor-file=message.pb message=Message confluent-wire-format=true
 {"id": "c"}
 {"id": "h"}
 
 > CREATE MATERIALIZED SOURCE kafka_proto_source
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-upgrade-proto-source-${env.UPGRADE_FROM_VERSION}-${testdrive.seed}'
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-upgrade-proto-source-${arg.upgrade-from-version}-${testdrive.seed}'
   FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'

--- a/test/upgrade/mzcompose.py
+++ b/test/upgrade/mzcompose.py
@@ -112,14 +112,14 @@ def test_upgrade_from_version(
     c.wait_for_materialized("materialized")
 
     temp_dir = f"--temp-dir=/share/tmp/upgrade-from-{from_version}"
-    with patch.dict(os.environ, {"UPGRADE_FROM_VERSION": from_version}):
-        c.run(
-            "testdrive-svc",
-            "--seed=1",
-            "--no-reset",
-            temp_dir,
-            f"create-in-{version_glob}-{filter}.td",
-        )
+    c.run(
+        "testdrive-svc",
+        "--seed=1",
+        "--no-reset",
+        f"--var=upgrade-from-version={from_version}",
+        temp_dir,
+        f"create-in-{version_glob}-{filter}.td",
+    )
 
     c.kill("materialized")
     c.rm("materialized", "testdrive-svc")
@@ -127,15 +127,15 @@ def test_upgrade_from_version(
     c.up("materialized")
     c.wait_for_materialized("materialized")
 
-    with patch.dict(os.environ, {"UPGRADE_FROM_VERSION": from_version}):
-        c.run(
-            "testdrive-svc",
-            "--seed=1",
-            "--no-reset",
-            temp_dir,
-            "--validate-catalog=/share/mzdata/catalog",
-            f"check-from-{version_glob}-{filter}.td",
-        )
+    c.run(
+        "testdrive-svc",
+        "--seed=1",
+        "--no-reset",
+        f"--var=upgrade-from-version={from_version}",
+        temp_dir,
+        "--validate-catalog=/share/mzdata/catalog",
+        f"check-from-{version_glob}-{filter}.td",
+    )
 
     c.kill("materialized")
     c.rm("materialized", "testdrive-svc")


### PR DESCRIPTION
Thanks for adding this feature, @quodlibetor! I think it's so much more obvious what's going on like this.

----


Teach all mzcompose files that use environment munging via the
`patch.dict` function to instead pass the desired values as testdrive
variables using testdrive's new `--var` CLI option.

This is relatively minor, but it makes the plumbing of these values a
bit more obvious, and typos can't result in accidentally using stray
environment variables from the host machine.

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
