### PR TITLE
feature-benchmark: Allow parameterized scenarios

### DIFF
--- a/misc/python/materialize/feature_benchmark/action.py
+++ b/misc/python/materialize/feature_benchmark/action.py
@@ -1,0 +1,84 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from typing import Callable, Iterator, List, Optional
+
+from materialize.feature_benchmark.executor import Executor
+
+
+class Action:
+    def __init__(self) -> None:
+        self._executor: Optional[Executor] = None
+
+    def __iter__(self) -> Iterator[None]:
+        return self
+
+    def __next__(self) -> None:
+        return self.run()
+
+    def __call__(self, executor: Executor) -> "Action":
+        self._executor = executor
+        return self
+
+    def run(
+        self,
+        executor: Optional[Executor] = None,
+    ) -> None:
+        assert False
+
+
+class Lambda(Action):
+    def __init__(self, _lambda: Callable) -> None:
+        self._lambda = _lambda
+
+    def run(
+        self,
+        executor: Optional[Executor] = None,
+    ) -> None:
+        e = executor if executor else self._executor
+        assert e is not None
+        e.Lambda(self._lambda)
+        return None
+
+
+class Kgen(Action):
+    def __init__(self, topic: str, args: List[str]) -> None:
+        self._topic: str = topic
+        self._args: List[str] = args
+        self._executor: Optional[Executor] = None
+
+    def run(
+        self,
+        executor: Optional[Executor] = None,
+    ) -> None:
+        getattr((executor if executor else self._executor), "Kgen")(
+            topic=self._topic, args=self._args
+        )
+
+
+class TdAction(Action):
+    """Use testdrive to run some queries without measuring"""
+
+    def __init__(self, td_str: str) -> None:
+        self._td_str = td_str
+        self._executor: Optional[Executor] = None
+
+    def run(
+        self,
+        executor: Optional[Executor] = None,
+    ) -> None:
+        getattr((executor if executor else self._executor), "Td")(self._td_str)
+
+
+class DummyAction(Action):
+    def run(
+        self,
+        executor: Optional[Executor] = None,
+    ) -> None:
+        return None

--- a/misc/python/materialize/feature_benchmark/aggregation.py
+++ b/misc/python/materialize/feature_benchmark/aggregation.py
@@ -21,7 +21,7 @@ class Aggregation:
         self._data.append(measurement)
 
     def aggregate(self) -> Any:
-        return self.func()(*self._data)
+        return self.func()([*self._data])
 
     def func(self) -> Callable:
         assert False
@@ -52,3 +52,8 @@ class StdDevAggregation(Aggregation):
 class NormalDistributionAggregation(Aggregation):
     def aggregate(self) -> statistics.NormalDist:
         return statistics.NormalDist(mu=np.mean(self._data), sigma=np.std(self._data))
+
+
+class NoAggregation(Aggregation):
+    def aggregate(self) -> Any:
+        return self._data[0]

--- a/misc/python/materialize/feature_benchmark/scenario.py
+++ b/misc/python/materialize/feature_benchmark/scenario.py
@@ -7,23 +7,81 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+from math import ceil
 from typing import List, Optional, Union
 
-from materialize.feature_benchmark.measurement_source import (
-    Assert,
-    Dummy,
-    MeasurementSource,
-)
+from materialize.feature_benchmark.action import Action, DummyAction, TdAction
+from materialize.feature_benchmark.measurement_source import MeasurementSource
 
 
 class RootScenario:
-    __name__: str
+    SCALE: float = 6
 
-    SHARED: Optional[Union[MeasurementSource, List[MeasurementSource]]] = None
-    INIT: Optional[MeasurementSource] = None
+    def __init__(self, scale: float) -> None:
+        self._name = self.__class__.__name__
+        self._scale = scale
+        self._n: int = int(10 ** scale)
 
-    BEFORE: MeasurementSource = Dummy()
-    BENCHMARK: MeasurementSource = Assert()
+    def shared(self) -> Optional[Union[Action, List[Action]]]:
+        return None
+
+    def init(self) -> Optional[Union[Action, List[Action]]]:
+        return None
+
+    def before(self) -> Action:
+        return DummyAction()
+
+    def benchmark(self) -> MeasurementSource:
+        assert False
+
+    def name(self) -> str:
+        return self._name
+
+    def scale(self) -> float:
+        return self._scale
+
+    def n(self) -> int:
+        return self._n
+
+    def table_ten(self) -> TdAction:
+        """Returns a Td() object that creates the 'ten' table"""
+        return TdAction(
+            """
+> CREATE TABLE ten (f1 INTEGER);
+> INSERT INTO ten VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
+"""
+        )
+
+    def view_ten(self) -> TdAction:
+        return TdAction(
+            """
+> CREATE VIEW ten (f1) AS (VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9));
+"""
+        )
+
+    def unique_values(self) -> str:
+        """Returns a string of the form 'a1.f1 + (a2.f1 * 10) + (a2.f1 * 100) ...'"""
+        return " + ".join(
+            f"(a{i+1}.f1 * {10**i})" for i in range(0, ceil(self.scale()))
+        )
+
+    def join(self) -> str:
+        """Returns a string of the form 'ten AS a1 , ten AS a2 , ten AS a3 ...'"""
+        return ", ".join(f"ten AS a{i+1}" for i in range(0, ceil(self.scale())))
+
+    def keyschema(self) -> str:
+        return (
+            "\n"
+            + '$ set keyschema={"type": "record", "name": "Key", "fields": [ { "name": "f1", "type": "long" } ] }'
+            + "\n"
+        )
+
+    def schema(self) -> str:
+        return (
+            "\n"
+            + '$ set schema={"type" : "record", "name" : "test", "fields": [ { "name": "f2", "type": "long" } ] }'
+            + "\n"
+        )
 
 
 # Used for benchmarks that are expected to run by default, e.g. in CI

--- a/misc/python/materialize/feature_benchmark/termination.py
+++ b/misc/python/materialize/feature_benchmark/termination.py
@@ -15,7 +15,9 @@ from scipy import stats  # type: ignore
 
 
 class TerminationCondition:
-    pass
+    def __init__(self, threshold: float) -> None:
+        self._threshold = threshold
+        self._data: List[float] = []
 
     def terminate(self, measurement: float) -> bool:
         assert False
@@ -25,9 +27,8 @@ class NormalDistributionOverlap(TerminationCondition):
     """Signal termination if the overlap between the two distributions is above the threshold"""
 
     def __init__(self, threshold: float) -> None:
-        self._threshold = threshold
-        self._data: List[float] = []
         self._last_fit: Optional[statistics.NormalDist] = None
+        super().__init__(threshold=threshold)
 
     def terminate(self, measurement: float) -> bool:
         self._data.append(measurement)
@@ -51,10 +52,6 @@ class ProbForMin(TerminationCondition):
     has dropped below the threshold
     """
 
-    def __init__(self, threshold: float) -> None:
-        self._threshold = threshold
-        self._data: List[float] = []
-
     def terminate(self, measurement: float) -> bool:
         self._data.append(measurement)
 
@@ -70,3 +67,10 @@ class ProbForMin(TerminationCondition):
                 return False
         else:
             return False
+
+
+class RunAtMost(TerminationCondition):
+    def terminate(self, measurement: float) -> bool:
+        self._data.append(measurement)
+
+        return len(self._data) >= self._threshold

--- a/src/testdrive/src/action/kafka/ingest.rs
+++ b/src/testdrive/src/action/kafka/ingest.rs
@@ -274,7 +274,10 @@ impl Action for IngestAction {
 
     async fn redo(&self, state: &mut State) -> Result<(), anyhow::Error> {
         let topic_name = &format!("{}-{}", self.topic_prefix, state.seed);
-        println!("Ingesting data into Kafka topic {}", topic_name);
+        println!(
+            "Ingesting data into Kafka topic {} with repeat {}",
+            topic_name, self.repeat
+        );
 
         let ccsr_client = &state.ccsr_client;
         let temp_path = &state.temp_path;

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -11,7 +11,7 @@ import argparse
 import os
 import sys
 import time
-from typing import List
+from typing import List, Type
 
 # mzcompose may start this script from the root of the Mz repository,
 # so we need to explicitly add this directory to the Python module search path
@@ -29,6 +29,7 @@ from materialize.feature_benchmark.filter import Filter, NoFilter
 from materialize.feature_benchmark.termination import (
     NormalDistributionOverlap,
     ProbForMin,
+    RunAtMost,
     TerminationCondition,
 )
 from materialize.mzcompose import Composition, WorkflowArgumentParser
@@ -50,10 +51,11 @@ def make_filter() -> Filter:
     return NoFilter()
 
 
-def make_termination_conditions() -> List[TerminationCondition]:
+def make_termination_conditions(args: argparse.Namespace) -> List[TerminationCondition]:
     return [
         NormalDistributionOverlap(threshold=0.99),
         ProbForMin(threshold=0.95),
+        RunAtMost(threshold=args.max_runs),
     ]
 
 
@@ -84,7 +86,7 @@ SERVICES = [
 
 
 def run_one_scenario(
-    c: Composition, scenario: Scenario, args: argparse.Namespace
+    c: Composition, scenario: Type[Scenario], args: argparse.Namespace
 ) -> Comparator:
     name = scenario.__name__
     print(f"Now benchmarking {name} ...")
@@ -119,9 +121,10 @@ def run_one_scenario(
             benchmark = Benchmark(
                 mz_id=mz_id,
                 scenario=scenario,
+                scale=args.scale,
                 executor=executor,
                 filter=make_filter(),
-                termination_conditions=make_termination_conditions(),
+                termination_conditions=make_termination_conditions(args),
                 aggregation=make_aggregation(),
             )
 
@@ -172,10 +175,27 @@ def workflow_feature_benchmark(c: Composition, parser: WorkflowArgumentParser) -
 
     parser.add_argument(
         "--root-scenario",
+        "--scenario",
         metavar="SCENARIO",
         type=str,
         default="Scenario",
         help="Scenario or scenario family to benchmark. See scenarios.py for available scenarios.",
+    )
+
+    parser.add_argument(
+        "--scale",
+        metavar="+N | -N | N",
+        type=str,
+        default=None,
+        help="Absolute or relative scale to apply.",
+    )
+
+    parser.add_argument(
+        "--max-runs",
+        metavar="N",
+        type=int,
+        default=99,
+        help="Limit the number of executions to N.",
     )
 
     args = parser.parse_args()

--- a/test/feature-benchmark/scenarios.py
+++ b/test/feature-benchmark/scenarios.py
@@ -7,22 +7,11 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-from materialize.feature_benchmark.measurement_source import Kgen, Lambda, Td
+from typing import List
+
+from materialize.feature_benchmark.action import Action, Kgen, Lambda, TdAction
+from materialize.feature_benchmark.measurement_source import MeasurementSource, Td
 from materialize.feature_benchmark.scenario import Scenario, ScenarioBig
-
-
-class Sleep(Scenario):
-    """Dummy benchmark that measures the duration of mz_sleep(0.1)"""
-
-    BENCHMARK = Td(
-        """
-> /* A */ SELECT 1
-1
-
-> /* B */ SELECT mz_internal.mz_sleep(0.1);
-<null>
-"""
-    )
 
 
 class FastPath(Scenario):
@@ -34,130 +23,100 @@ class FastPath(Scenario):
 class FastPathFilterNoIndex(FastPath):
     """Measure the time it takes for the fast path to filter our all rows from a materialized view and return"""
 
-    INIT = Td(
-        """
-> CREATE TABLE ten (f1 INTEGER);
-> INSERT INTO ten VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
+    SCALE = 7
 
-> CREATE MATERIALIZED VIEW v1 (f1, f2) AS
-  SELECT
-  a1.f1 +
-  (a2.f1 * 10) +
-  (a3.f1 * 100) +
-  (a4.f1 * 1000) +
-  (a5.f1 * 10000) +
-  (a6.f1 * 100000) +
-  (a7.f1 * 1000000) AS f1,
-  1 AS f2
-  FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4, ten AS a5, ten AS a6, ten AS a7;
+    def init(self) -> List[Action]:
+        return [
+            self.table_ten(),
+            TdAction(
+                f"""
+> CREATE MATERIALIZED VIEW v1 (f1, f2) AS SELECT {self.unique_values()} AS f1, 1 AS f2 FROM {self.join()}
 
-> SELECT COUNT(*) = 10000000 FROM v1;
+> SELECT COUNT(*) = {self.n()} FROM v1;
 true
 """
-    )
+            ),
+        ]
 
-    BENCHMARK = Td(
-        """
+    def benchmark(self) -> MeasurementSource:
+        return Td(
+            """
 > /* A */ SELECT 1;
 1
-
 > /* B */ SELECT * FROM v1 WHERE f2 < 0;
-
 """
-    )
+        )
 
 
 class FastPathFilterIndex(FastPath):
     """Measure the time it takes for the fast path to filter our all rows from a materialized view using an index and return"""
 
-    INIT = Td(
-        """
-> CREATE TABLE ten (f1 INTEGER);
-> INSERT INTO ten VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
+    def init(self) -> List[Action]:
+        return [
+            self.table_ten(),
+            TdAction(
+                f"""
+> CREATE MATERIALIZED VIEW v1 AS SELECT {self.unique_values()} AS f1 FROM {self.join()}
 
-> CREATE MATERIALIZED VIEW v1 AS
-  SELECT
-  a1.f1 +
-  (a2.f1 * 10) +
-  (a3.f1 * 100) +
-  (a4.f1 * 1000) +
-  (a5.f1 * 10000) AS f1
-  FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4, ten AS a5, ten AS a6;
-
-> SELECT COUNT(*) = 1000000 FROM v1;
+> SELECT COUNT(*) = {self.n()} FROM v1;
 true
 """
-    )
+            ),
+        ]
 
     # Since an individual query of this particular type being benchmarked takes 1ms to execute, the results are susceptible
     # to a lot of random noise. As we can not make the query any slower by using e.g. a large dataset,
     # we run the query 100 times in a row and measure the total execution time.
 
-    BENCHMARK = Td(
-        """
+    def benchmark(self) -> MeasurementSource:
+        hundred_selects = "\n".join(
+            f"> SELECT * FROM v1 WHERE f1 = 1;\n1\n" for i in range(0, 100)
+        )
+
+        return Td(
+            f"""
 > BEGIN
 
-> /* A */ SELECT 1;
-1
-"""
-        + "\n".join(
-            [
-                """
-> SELECT * FROM v1 WHERE f1 = 1;
-1
-1
-1
-1
-1
-1
-1
-1
-1
-1
-"""
-                for i in range(0, 100)
-            ]
-        )
-        + """
-> /* B */ SELECT 1;
+> SELECT 1;
+  /* A */
 1
 
+{hundred_selects}
+
+> SELECT 1
+  /* B */
+1
 """
-    )
+        )
 
 
 class FastPathOrderByLimit(FastPath):
     """Benchmark the case SELECT * FROM materialized_view ORDER BY <key> LIMIT <i>"""
 
-    INIT = Td(
-        """
-> CREATE TABLE ten (f1 INTEGER);
-> INSERT INTO ten VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
+    def init(self) -> List[Action]:
+        return [
+            self.table_ten(),
+            TdAction(
+                f"""
+> CREATE MATERIALIZED VIEW v1 AS SELECT {self.unique_values()} AS f1 FROM {self.join()};
 
-> CREATE MATERIALIZED VIEW v1 AS
-  SELECT
-  a1.f1 +
-  (a2.f1 * 10) +
-  (a3.f1 * 100) +
-  (a4.f1 * 1000) +
-  (a5.f1 * 10000) +
-  (a6.f1 * 100000) AS f1
-  FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4, ten AS a5, ten AS a6;
-
-> SELECT COUNT(*) = 1000000 FROM v1;
+> SELECT COUNT(*) = {self.n()} FROM v1;
 true
 """
-    )
+            ),
+        ]
 
-    BENCHMARK = Td(
-        """
-> /* A */ SELECT 1;
+    def benchmark(self) -> MeasurementSource:
+        return Td(
+            """
+> SELECT 1;
+  /* A */
 1
-
-> /* B */ SELECT f1 FROM v1 ORDER BY f1 DESC LIMIT 1000;
+> SELECT f1 FROM v1 ORDER BY f1 DESC LIMIT 1000
+  /* B */
 """
-        + "\n".join([str(x) for x in range(999000, 1000000)])
-    )
+            + "\n".join([str(x) for x in range(self.n() - 1000, self.n())])
+        )
 
 
 class DML(Scenario):
@@ -169,58 +128,49 @@ class DML(Scenario):
 class Insert(DML):
     """Measure the time it takes for an INSERT statement to return."""
 
-    INIT = Td(
-        """
-> CREATE TABLE ten (f1 INTEGER);
-> INSERT INTO ten VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
-"""
-    )
+    def init(self) -> Action:
+        return self.table_ten()
 
-    BENCHMARK = Td(
-        """
+    def benchmark(self) -> MeasurementSource:
+        return Td(
+            f"""
 > DROP TABLE IF EXISTS t1;
 
-> /* A */ CREATE TABLE t1 (f1 INTEGER);
-> /* B */ INSERT INTO t1 SELECT
-  a1.f1 +
-  (a2.f1 * 10) +
-  (a3.f1 * 100) +
-  (a4.f1 * 1000) +
-  (a5.f1 * 10000) +
-  (a6.f1 * 100000)
-  FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4, ten AS a5, ten AS a6;
+> CREATE TABLE t1 (f1 INTEGER)
+  /* A */
+
+> INSERT INTO t1 SELECT {self.unique_values()} FROM {self.join()}
+  /* B */
 """
-    )
+        )
 
 
 class Update(DML):
     """Measure the time it takes for an UPDATE statement to return to client"""
 
-    INIT = Td(
-        """
-> CREATE TABLE ten (f1 INTEGER);
-> INSERT INTO ten VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
-
+    def init(self) -> List[Action]:
+        return [
+            self.table_ten(),
+            TdAction(
+                f"""
 > CREATE TABLE t1 (f1 BIGINT);
-> INSERT INTO t1 SELECT
-  a1.f1 +
-  (a2.f1 * 10) +
-  (a3.f1 * 100) +
-  (a4.f1 * 1000) +
-  (a5.f1 * 10000) +
-  (a6.f1 * 100000)
-  FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4, ten AS a5, ten AS a6;
-"""
-    )
 
-    BENCHMARK = Td(
-        """
-> /* A */ SELECT 1
+> INSERT INTO t1 SELECT {self.unique_values()} FROM {self.join()}
+"""
+            ),
+        ]
+
+    def benchmark(self) -> MeasurementSource:
+        return Td(
+            f"""
+> SELECT 1
+  /* A */
 1
 
-> /* B */ UPDATE t1 SET f1 = f1 + 10000000
+> UPDATE t1 SET f1 = f1 + {self.n()}
+  /* B */
 """
-    )
+        )
 
 
 class InsertAndSelect(DML):
@@ -229,32 +179,24 @@ class InsertAndSelect(DML):
     dataflow to be completely caught up.
     """
 
-    INIT = Td(
-        """
-> CREATE TABLE ten (f1 INTEGER);
-> INSERT INTO ten VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
-"""
-    )
+    def init(self) -> Action:
+        return self.table_ten()
 
-    BENCHMARK = Td(
-        """
+    def benchmark(self) -> MeasurementSource:
+        return Td(
+            f"""
 > DROP TABLE IF EXISTS t1;
 
-> /* A */ CREATE TABLE t1 (f1 INTEGER);
+> CREATE TABLE t1 (f1 INTEGER)
+  /* A */
 
-> INSERT INTO t1 SELECT
-  a1.f1 +
-  (a2.f1 * 10) +
-  (a3.f1 * 100) +
-  (a4.f1 * 1000) +
-  (a5.f1 * 10000) +
-  (a6.f1 * 100000)
-  FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4, ten AS a5, ten AS a6;
+> INSERT INTO t1 SELECT {self.unique_values()} FROM {self.join()};
 
-> /* B */ SELECT 1 FROM t1 WHERE f1 = 1;
+> SELECT 1 FROM t1 WHERE f1 = 1
+  /* B */
 1
 """
-    )
+        )
 
 
 class Dataflow(Scenario):
@@ -267,223 +209,176 @@ class OrderBy(Dataflow):
     """Benchmark ORDER BY as executed by the dataflow layer,
     in contrast with an ORDER BY executed using a Finish step in the coordinator"""
 
-    INIT = Td(
-        """
+    def init(self) -> Action:
+        # Just to spice things up a bit, we perform individual
+        # inserts here so that the rows are assigned separate timestamps
+        inserts = "\n\n".join(f"> INSERT INTO ten VALUES ({i})" for i in range(0, 10))
+
+        return TdAction(
+            f"""
 > CREATE TABLE ten (f1 INTEGER);
 
-> CREATE MATERIALIZED VIEW v1 AS
-  SELECT
-  a1.f1 +
-  (a2.f1 * 10) +
-  (a3.f1 * 100) +
-  (a4.f1 * 1000) +
-  (a5.f1 * 10000) +
-  (a6.f1 * 100000) AS f1
-  FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4, ten AS a5, ten AS a6;
+> CREATE MATERIALIZED VIEW v1 AS SELECT {self.unique_values()} AS f1 FROM {self.join()};
 
-# Just to spice things up a bit, we perform individual
-# inserts here so that the rows are assigned separate timestamps
+{inserts}
 
-> INSERT INTO ten VALUES (0);
-
-> INSERT INTO ten VALUES (1);
-
-> INSERT INTO ten VALUES (2);
-
-> INSERT INTO ten VALUES (3);
-
-> INSERT INTO ten VALUES (4);
-
-> INSERT INTO ten VALUES (5);
-
-> INSERT INTO ten VALUES (6);
-
-> INSERT INTO ten VALUES (7);
-
-> INSERT INTO ten VALUES (8);
-
-> INSERT INTO ten VALUES (9);
-
-> SELECT COUNT(*) = 1000000 FROM v1;
+> SELECT COUNT(*) = {self.n()} FROM v1;
 true
 """
-    )
+        )
 
-    BENCHMARK = Td(
-        """
+    def benchmark(self) -> MeasurementSource:
+        # Explicit LIMIT is needed for the ORDER BY to not be optimized away
+        return Td(
+            f"""
 > DROP VIEW IF EXISTS v2
   /* A */
 
-# explicit LIMIT is needed for the ORDER BY to not be optimized away
 > CREATE MATERIALIZED VIEW v2 AS SELECT * FROM v1 ORDER BY f1 LIMIT 999999999999
 
 > SELECT COUNT(*) FROM v2
   /* B */
-1000000
+{self.n()}
 """
-    )
+        )
 
 
 class CountDistinct(Dataflow):
-    INIT = Td(
-        """
-> CREATE VIEW ten (f1) AS (VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9));
-> CREATE MATERIALIZED VIEW v1 AS
-  SELECT
-  a1.f1 +
-  (a2.f1 * 10) AS f1,
-  a1.f1 +
-  (a2.f1 * 10) +
-  (a3.f1 * 100) +
-  (a4.f1 * 1000) +
-  (a5.f1 * 10000) +
-  (a6.f1 * 100000) +
-  (a7.f1 * 1000000) /* +
-  (a8.f1 * 10000000) */ AS unique
-  FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4, ten AS a5, ten AS a6, ten AS a7;
+    def init(self) -> List[Action]:
+        return [
+            self.view_ten(),
+            TdAction(
+                f"""
+> CREATE MATERIALIZED VIEW v1 AS SELECT {self.unique_values()} AS f1, {self.unique_values()} AS f2 FROM {self.join()};
 
-
-> SELECT COUNT(*) = 10000000 FROM v1;
+> SELECT COUNT(*) = {self.n()} FROM v1;
 true
 """
-    )
+            ),
+        ]
 
-    BENCHMARK = Td(
-        """
-> /* A */ SELECT 1
+    def benchmark(self) -> MeasurementSource:
+        return Td(
+            f"""
+> SELECT 1
+  /* A */
 1
 
-> /* B */ SELECT COUNT(DISTINCT f1) AS f1 FROM v1;
-100
+> SELECT COUNT(DISTINCT f1) AS f1 FROM v1
+  /* B */
+{self.n()}
 """
-    )
+        )
 
 
 class MinMax(Dataflow):
-    INIT = Td(
-        """
-> CREATE VIEW ten (f1) AS (VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9));
-> CREATE MATERIALIZED VIEW v1 AS SELECT
-  a1.f1 +
-  (a2.f1 * 10) +
-  (a3.f1 * 100) +
-  (a4.f1 * 1000) +
-  (a5.f1 * 10000) +
-  (a6.f1 * 100000) AS f1
-  FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4, ten AS a5, ten AS a6;
+    def init(self) -> List[Action]:
+        return [
+            self.view_ten(),
+            TdAction(
+                f"""
+> CREATE MATERIALIZED VIEW v1 AS SELECT {self.unique_values()} AS f1 FROM {self.join()};
 
-> SELECT COUNT(*) = 1000000 FROM v1;
+> SELECT COUNT(*) = {self.n()} FROM v1;
 true
 """
-    )
+            ),
+        ]
 
-    BENCHMARK = Td(
-        """
-> /* A */ SELECT 1
+    def benchmark(self) -> MeasurementSource:
+        return Td(
+            f"""
+> SELECT 1
+  /* A */
 1
 
-> /* B */ SELECT MIN(f1), MAX(f1) AS f1 FROM v1;
-0 999999
+> SELECT MIN(f1), MAX(f1) AS f1 FROM v1
+  /* B */
+0 {self.n()-1}
 """
-    )
+        )
 
 
 class GroupBy(Dataflow):
-    INIT = Td(
-        """
-> CREATE VIEW ten (f1) AS (VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9));
-> CREATE MATERIALIZED VIEW v1 AS SELECT
-  a1.f1 +
-  (a2.f1 * 10) +
-  (a3.f1 * 100) +
-  (a4.f1 * 1000) +
-  (a5.f1 * 10000) +
-  (a6.f1 * 100000) AS f1,
-  a1.f1 +
-  (a2.f1 * 10) +
-  (a3.f1 * 100) +
-  (a4.f1 * 1000) +
-  (a5.f1 * 10000) +
-  (a6.f1 * 100000) AS f2
-  FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4, ten AS a5, ten AS a6;
+    def init(self) -> List[Action]:
+        return [
+            self.view_ten(),
+            TdAction(
+                f"""
+> CREATE MATERIALIZED VIEW v1 AS SELECT {self.unique_values()} AS f1, {self.unique_values()} AS f2 FROM {self.join()}
 
-> SELECT COUNT(*) = 1000000 FROM v1
+> SELECT COUNT(*) = {self.n()} FROM v1
 true
 """
-    )
+            ),
+        ]
 
-    BENCHMARK = Td(
-        """
-> /* A */ SELECT 1
+    def benchmark(self) -> MeasurementSource:
+        return Td(
+            f"""
+> SELECT 1
+  /* A */
 1
 
-> /* B */ SELECT COUNT(*), MIN(f1_min), MAX(f1_max) FROM (SELECT f2, MIN(f1) AS f1_min, MAX(f1) AS f1_max FROM v1 GROUP BY f2);
-1000000 0 999999
+> SELECT COUNT(*), MIN(f1_min), MAX(f1_max) FROM (SELECT f2, MIN(f1) AS f1_min, MAX(f1) AS f1_max FROM v1 GROUP BY f2)
+  /* B */
+{self.n()} 0 {self.n()-1}
 """
-    )
+        )
 
 
 class CrossJoin(Dataflow):
+    def init(self) -> Action:
+        return self.view_ten()
 
-    INIT = Td(
-        """
-> CREATE VIEW ten (f1) AS (VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9));
-"""
-    )
-
-    BENCHMARK = Td(
-        """
+    def benchmark(self) -> MeasurementSource:
+        return Td(
+            f"""
 > DROP VIEW IF EXISTS v1;
 
-> /* A */ CREATE MATERIALIZED VIEW v1 AS
-  SELECT a1.f1 +
-  (a2.f1 * 10) +
-  (a3.f1 * 100) +
-  (a4.f1 * 1000) +
-  (a5.f1 * 10000) +
-  (a6.f1 * 100000)
-  FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4, ten AS a5, ten AS a6
+> CREATE MATERIALIZED VIEW v1 AS SELECT {self.unique_values()} FROM {self.join()}
+  /* A */
 
-> /* B */ SELECT COUNT(*) = 1000000 AS f1 FROM v1;
+> SELECT COUNT(*) = {self.n()} AS f1 FROM v1;
+  /* B */
 true
 """
-    )
+        )
 
 
 class Retraction(Dataflow):
     """Benchmark the time it takes to process a very large retraction"""
 
-    BENCHMARK = Td(
-        """
-> DROP VIEW IF EXISTS v1;
-
-> DROP TABLE IF EXISTS ten;
+    def before(self) -> Action:
+        return TdAction(
+            f"""
+> DROP TABLE IF EXISTS ten CASCADE;
 
 > CREATE TABLE ten (f1 INTEGER);
 
 > INSERT INTO ten VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
 
-> CREATE MATERIALIZED VIEW v1 AS
-  SELECT a1.f1 +
-  (a2.f1 * 10) +
-  (a3.f1 * 100) +
-  (a4.f1 * 1000) +
-  (a5.f1 * 10000) +
-  (a6.f1 * 100000)
-  FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4, ten AS a5, ten AS a6
+> CREATE MATERIALIZED VIEW v1 AS SELECT {self.unique_values()} FROM {self.join()}
 
-> SELECT COUNT(*) = 1000000 AS f1 FROM v1;
+> SELECT COUNT(*) = {self.n()} AS f1 FROM v1;
 true
+"""
+        )
 
-> /* A */ SELECT 1;
+    def benchmark(self) -> MeasurementSource:
+        return Td(
+            """
+> SELECT 1
+  /* A */
 1
 
 > DELETE FROM ten;
 
-> /* B */ SELECT COUNT(*) FROM v1;
+> SELECT COUNT(*) FROM v1
+  /* B */
 0
 """
-    )
+        )
 
 
 class CreateIndex(Dataflow):
@@ -491,104 +386,90 @@ class CreateIndex(Dataflow):
     it takes for a SELECT query that would use the index to return rows.
     """
 
-    INIT = Td(
-        """
-> CREATE TABLE ten (f1 INTEGER);
-> INSERT INTO ten VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
-
+    def init(self) -> List[Action]:
+        return [
+            self.table_ten(),
+            TdAction(
+                f"""
 > CREATE TABLE t1 (f1 INTEGER, f2 INTEGER);
-> INSERT INTO t1 (f1) SELECT a1.f1 +
-  (a2.f1 * 10) +
-  (a3.f1 * 100) +
-  (a4.f1 * 1000) +
-  (a5.f1 * 10000) +
-  (a6.f1 * 100000)
-  FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4, ten AS a5, ten AS a6;
+> INSERT INTO t1 (f1) SELECT {self.unique_values()} FROM {self.join()}
 
 # Make sure the dataflow is fully hydrated
 > SELECT 1 FROM t1 WHERE f1 = 0;
 1
 """
-    )
+            ),
+        ]
 
-    BENCHMARK = Td(
-        """
-> /* A */ DROP INDEX IF EXISTS i1;
+    def benchmark(self) -> MeasurementSource:
+        return Td(
+            """
+> DROP INDEX IF EXISTS i1;
+  /* A */
 
 > CREATE INDEX i1 ON t1(f1);
 
-> /* B */ SELECT COUNT(*)
+> SELECT COUNT(*)
   FROM t1 AS a1, t1 AS a2
   WHERE a1.f1 = a2.f1
   AND a1.f1 = 0
-  AND a2.f1 = 0;
+  AND a2.f1 = 0
+  /* B */
 1
 """
-    )
+        )
 
 
 class DeltaJoin(Dataflow):
-    INIT = Td(
-        """
-> CREATE VIEW ten (f1) AS (VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9));
-
-> CREATE MATERIALIZED VIEW v1 AS
-  SELECT a1.f1 +
-  (a2.f1 * 10) +
-  (a3.f1 * 100) +
-  (a4.f1 * 1000) +
-  (a5.f1 * 10000) +
-  (a6.f1 * 100000) AS f1
-  FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4, ten AS a5, ten AS a6;
-
+    def init(self) -> List[Action]:
+        return [
+            self.view_ten(),
+            TdAction(
+                f"""
+> CREATE MATERIALIZED VIEW v1 AS SELECT {self.unique_values()} AS f1 FROM {self.join()}
 """
-    )
+            ),
+        ]
 
-    BENCHMARK = Td(
-        """
-> /* A */ SELECT 1;
+    def benchmark(self) -> MeasurementSource:
+        return Td(
+            f"""
+> SELECT 1;
+  /* A */
 1
 
 
-> /* B */ SELECT COUNT(*) FROM v1 AS a1 JOIN v1 AS a2 USING (f1);
-1000000
+> SELECT COUNT(*) FROM v1 AS a1 JOIN v1 AS a2 USING (f1)
+  /* B */
+{self.n()}
 """
-    )
+        )
 
 
 class DifferentialJoin(Dataflow):
-    INIT = Td(
-        """
-> CREATE VIEW ten (f1) AS (VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9));
-
-> CREATE MATERIALIZED VIEW v1 AS
-  SELECT a1.f1 +
-  (a2.f1 * 10) +
-  (a3.f1 * 100) +
-  (a4.f1 * 1000) +
-  (a5.f1 * 10000) +
-  (a6.f1 * 100000) AS f1,
-  a1.f1 +
-  (a2.f1 * 10) +
-  (a3.f1 * 100) +
-  (a4.f1 * 1000) +
-  (a5.f1 * 10000) +
-  (a6.f1 * 100000) AS f2
-  FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4, ten AS a5, ten AS a6;
-
+    def init(self) -> List[Action]:
+        return [
+            self.view_ten(),
+            TdAction(
+                f"""
+> CREATE MATERIALIZED VIEW v1 AS SELECT {self.unique_values()} AS f1, {self.unique_values()} AS f2 FROM {self.join()}
 """
-    )
+            ),
+        ]
 
-    BENCHMARK = Td(
-        """
-> /* A */ SELECT 1;
+    def benchmark(self) -> MeasurementSource:
+        return Td(
+            f"""
+> SELECT 1;
+  /* A */
 1
 
 
-> /* B */ SELECT COUNT(*) FROM v1 AS a1 JOIN v1 AS a2 USING (f1);
-1000000
+> SELECT COUNT(*) FROM v1 AS a1 JOIN v1 AS a2 USING (f1)
+  /* B */
+{self.n()}
 """
-    )
+        )
 
 
 class Finish(Scenario):
@@ -598,38 +479,31 @@ class Finish(Scenario):
 class FinishOrderByLimit(Finish):
     """Benchmark ORDER BY + LIMIT without the benefit of an index"""
 
-    INIT = Td(
-        """
-> CREATE VIEW ten (f1) AS (VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9));
-> CREATE MATERIALIZED VIEW v1 AS SELECT
-  a1.f1 +
-  (a2.f1 * 10) +
-  (a3.f1 * 100) +
-  (a4.f1 * 1000) +
-  (a5.f1 * 10000) +
-  (a6.f1 * 100000) AS f1,
-  a1.f1 +
-  (a2.f1 * 10) +
-  (a3.f1 * 100) +
-  (a4.f1 * 1000) +
-  (a5.f1 * 10000) +
-  (a6.f1 * 100000) AS f2
-  FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4, ten AS a5, ten AS a6;
+    def init(self) -> List[Action]:
+        return [
+            self.view_ten(),
+            TdAction(
+                f"""
+> CREATE MATERIALIZED VIEW v1 AS SELECT {self.unique_values()} AS f1, {self.unique_values()} AS f2 FROM {self.join()}
 
-> SELECT COUNT(*) = 1000000 FROM v1;
+> SELECT COUNT(*) = {self.n()} FROM v1;
 true
 """
-    )
+            ),
+        ]
 
-    BENCHMARK = Td(
-        """
-> /* A */ SELECT 1
+    def benchmark(self) -> MeasurementSource:
+        return Td(
+            f"""
+> SELECT 1
+  /* A */
 1
 
-> /* B */ SELECT f2 FROM v1 ORDER BY 1 DESC LIMIT 1;
-999999
+> SELECT f2 FROM v1 ORDER BY 1 DESC LIMIT 1
+  /* B */
+{self.n()-1}
 """
-    )
+        )
 
 
 class Kafka(Scenario):
@@ -637,172 +511,152 @@ class Kafka(Scenario):
 
 
 class KafkaRaw(Kafka):
-    SHARED = Td(
-        """
-$ set count=1000000
-
-$ set schema={
-        "type" : "record",
-        "name" : "test",
-        "fields" : [
-            {"name":"f1", "type":"long"}
-        ]
-    }
-
+    def shared(self) -> Action:
+        return TdAction(
+            self.schema()
+            + f"""
 $ kafka-create-topic topic=kafka-raw
 
-$ kafka-ingest format=avro topic=kafka-raw schema=${schema} publish=true repeat=${count}
-{"f1": 1}
+$ kafka-ingest format=avro topic=kafka-raw schema=${{schema}} publish=true repeat={self.n()}
+{{"f2": 1}}
 """
-    )
-    BENCHMARK = Td(
-        """
-$ set count=1000000
+        )
 
+    def benchmark(self) -> MeasurementSource:
+        return Td(
+            f"""
 > DROP SOURCE IF EXISTS s1;
 
 > SELECT COUNT(*) = 0
   FROM mz_kafka_source_statistics
-  WHERE CAST(statistics->'topics'->'testdrive-kafka-raw-${testdrive.seed}'->'partitions'->'0'->'msgs' AS INT) > 0
+  WHERE CAST(statistics->'topics'->'testdrive-kafka-raw-${{testdrive.seed}}'->'partitions'->'0'->'msgs' AS INT) > 0
 true
 
-> /* A */ CREATE MATERIALIZED SOURCE s1
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-kafka-raw-${testdrive.seed}'
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+> CREATE MATERIALIZED SOURCE s1
+  FROM KAFKA BROKER '${{testdrive.kafka-addr}}' TOPIC 'testdrive-kafka-raw-${{testdrive.seed}}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${{testdrive.schema-registry-url}}'
   ENVELOPE NONE
+  /* A */
 
-> /* B */ SELECT SUM(CAST(statistics->'topics'->'testdrive-kafka-raw-${testdrive.seed}'->'partitions'->'0'->'msgs' AS INT)) = ${count}
+
+> SELECT SUM(CAST(statistics->'topics'->'testdrive-kafka-raw-${{testdrive.seed}}'->'partitions'->'0'->'msgs' AS INT)) = {self.n()}
+  /* B */
   FROM mz_kafka_source_statistics;
 true
 """
-    )
+        )
 
 
 class KafkaUpsert(Kafka):
-    SHARED = Td(
-        """
-$ set count=1000000
-
-$ set keyschema={
-    "type": "record",
-    "name": "Key",
-    "fields": [
-        {"name": "f1", "type": "long"}
-    ]
-  }
-
-$ set schema={
-        "type" : "record",
-        "name" : "test",
-        "fields" : [
-            {"name":"f2", "type":"long"}
-        ]
-    }
-
+    def shared(self) -> Action:
+        return TdAction(
+            self.keyschema()
+            + self.schema()
+            + f"""
 $ kafka-create-topic topic=kafka-upsert
 
-$ kafka-ingest format=avro topic=kafka-upsert key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=${count}
-{"f1": 1} {"f2": ${kafka-ingest.iteration}}
+$ kafka-ingest format=avro topic=kafka-upsert key-format=avro key-schema=${{keyschema}} schema=${{schema}} publish=true repeat={self.n()}
+{{"f1": 1}} {{"f2": ${{kafka-ingest.iteration}} }}
 
-$ kafka-ingest format=avro topic=kafka-upsert key-format=avro key-schema=${keyschema} schema=${schema} publish=true
-{"f1": 2} {"f2": 2}
+$ kafka-ingest format=avro topic=kafka-upsert key-format=avro key-schema=${{keyschema}} schema=${{schema}} publish=true
+{{"f1": 2}} {{"f2": 2}}
 """
-    )
-    BENCHMARK = Td(
-        """
+        )
 
+    def benchmark(self) -> MeasurementSource:
+        return Td(
+            """
 > DROP SOURCE IF EXISTS s1;
 
-> /* A */ CREATE MATERIALIZED SOURCE s1
+> CREATE MATERIALIZED SOURCE s1
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-kafka-upsert-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-  ENVELOPE UPSERT;
+  ENVELOPE UPSERT
+  /* A */
 
-> /* B */ SELECT f1 FROM s1;
+> SELECT f1 FROM s1
+  /* B */
 1
 2
 """
-    )
+        )
 
 
 class KafkaUpsertUnique(Kafka):
-    SHARED = Td(
-        """
-$ set keyschema={"type": "record", "name": "Key", "fields": [ {"name": "f1", "type": "long"} ] }
-
-$ set schema={"type" : "record", "name" : "test", "fields": [ {"name": "f2", "type": "long"} ] }
-
+    def shared(self) -> Action:
+        return TdAction(
+            self.keyschema()
+            + self.schema()
+            + f"""
 $ kafka-create-topic topic=upsert-unique partitions=16
 
-$ kafka-ingest format=avro topic=upsert-unique key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=1000000
-{"f1": ${kafka-ingest.iteration}} {"f2": ${kafka-ingest.iteration}}
+$ kafka-ingest format=avro topic=upsert-unique key-format=avro key-schema=${{keyschema}} schema=${{schema}} publish=true repeat={self.n()}
+{{"f1": ${{kafka-ingest.iteration}} }} {{"f2": ${{kafka-ingest.iteration}} }}
 """
-    )
-    BENCHMARK = Td(
-        """
+        )
+
+    def benchmark(self) -> MeasurementSource:
+        return Td(
+            f"""
 > DROP SOURCE IF EXISTS s1;
 
-> /* A */ CREATE MATERIALIZED SOURCE s1
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-upsert-unique-${testdrive.seed}'
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-  ENVELOPE UPSERT;
+> CREATE MATERIALIZED SOURCE s1
+  FROM KAFKA BROKER '${{testdrive.kafka-addr}}' TOPIC 'testdrive-upsert-unique-${{testdrive.seed}}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${{testdrive.schema-registry-url}}'
+  ENVELOPE UPSERT
+  /* A */
 
-> /* B */ SELECT COUNT(*) FROM s1;
-1000000
+> SELECT COUNT(*) FROM s1;
+  /* B */
+{self.n()}
 """
-    )
+        )
 
 
 class KafkaRecovery(Kafka):
-    SHARED = Td(
-        """
-$ set keyschema={
-    "type": "record",
-    "name": "Key",
-    "fields": [
-        {"name": "f1", "type": "long"}
-    ]
-  }
+    SCALE = 7
 
-$ set schema={
-        "type" : "record",
-        "name" : "test",
-        "fields" : [
-            {"name":"f2", "type":"long"}
-        ]
-    }
-
+    def shared(self) -> Action:
+        return TdAction(
+            self.keyschema()
+            + self.schema()
+            + f"""
 $ kafka-create-topic topic=kafka-recovery partitions=8
 
-$ kafka-ingest format=avro topic=kafka-recovery key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=10000000
-{"f1": ${kafka-ingest.iteration}} {"f2": ${kafka-ingest.iteration}}
+$ kafka-ingest format=avro topic=kafka-recovery key-format=avro key-schema=${{keyschema}} schema=${{schema}} publish=true repeat={self.n()}
+{{"f1": ${{kafka-ingest.iteration}} }} {{"f2": ${{kafka-ingest.iteration}} }}
 """
-    )
+        )
 
-    INIT = Td(
-        """
+    def init(self) -> Action:
+        return TdAction(
+            f"""
 > CREATE MATERIALIZED SOURCE s1
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-kafka-recovery-${testdrive.seed}'
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  FROM KAFKA BROKER '${{testdrive.kafka-addr}}' TOPIC 'testdrive-kafka-recovery-${{testdrive.seed}}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${{testdrive.schema-registry-url}}'
   ENVELOPE UPSERT;
 
 # Make sure we are fully caught up before continuing
-> SELECT COUNT(*) = 10000000 FROM s1;
-true
+> SELECT COUNT(*) FROM s1;
+{self.n()}
 """
-    )
+        )
 
-    BEFORE = Lambda(lambda e: e.RestartMz())
+    def before(self) -> Action:
+        return Lambda(lambda e: e.RestartMz())
 
-    BENCHMARK = Td(
-        """
-> /* A */ SELECT 1;
+    def benchmark(self) -> MeasurementSource:
+        return Td(
+            f"""
+> SELECT 1;
+  /* A */
 1
 
-> /* B */ SELECT COUNT(*) = 10000000 FROM s1;
-true
+> SELECT COUNT(*) FROM s1;
+  /* B */
+{self.n()}
 """
-    )
+        )
 
 
 class KafkaRecoveryBig(ScenarioBig):
@@ -813,38 +667,42 @@ class KafkaRecoveryBig(ScenarioBig):
     been seen.
     """
 
-    SHARED = [
-        Td("$ kafka-create-topic topic=kafka-recovery-big partitions=8"),
-        # Ingest 100M records
-        Kgen(
-            topic="kafka-recovery-big",
-            args=[
-                "--keys=random",
-                f"--num-records={100_000_000}",
-                "--values=bytes",
-                "--max-message-size=32",
-                "--min-message-size=32",
-                "--key-min=256",
-                f"--key-max={256+(100_000_000**2)}",
-            ],
-        ),
-        # Add 256 EOF markers with key values <= 256.
-        # This high number is chosen as to guarantee that there will be an EOF marker
-        # in each partition, even if the number of partitions is increased in the future.
-        Kgen(
-            topic="kafka-recovery-big",
-            args=[
-                "--keys=sequential",
-                "--num-records=256",
-                "--values=bytes",
-                "--min-message-size=32",
-                "--max-message-size=32",
-            ],
-        ),
-    ]
+    SCALE = 8
 
-    INIT = Td(
-        """
+    def shared(self) -> List[Action]:
+        return [
+            TdAction("$ kafka-create-topic topic=kafka-recovery-big partitions=8"),
+            # Ingest 10 ** SCALE records
+            Kgen(
+                topic="kafka-recovery-big",
+                args=[
+                    "--keys=random",
+                    f"--num-records={self.n()}",
+                    "--values=bytes",
+                    "--max-message-size=32",
+                    "--min-message-size=32",
+                    "--key-min=256",
+                    f"--key-max={256+(self.n()**2)}",
+                ],
+            ),
+            # Add 256 EOF markers with key values <= 256.
+            # This high number is chosen as to guarantee that there will be an EOF marker
+            # in each partition, even if the number of partitions is increased in the future.
+            Kgen(
+                topic="kafka-recovery-big",
+                args=[
+                    "--keys=sequential",
+                    "--num-records=256",
+                    "--values=bytes",
+                    "--min-message-size=32",
+                    "--max-message-size=32",
+                ],
+            ),
+        ]
+
+    def init(self) -> Action:
+        return TdAction(
+            """
 > CREATE SOURCE s1
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-kafka-recovery-big-${testdrive.seed}'
   FORMAT BYTES
@@ -856,12 +714,14 @@ class KafkaRecoveryBig(ScenarioBig):
 > SELECT * FROM s1_is_complete;
 true
 """
-    )
+        )
 
-    BEFORE = Lambda(lambda e: e.RestartMz())
+    def before(self) -> Action:
+        return Lambda(lambda e: e.RestartMz())
 
-    BENCHMARK = Td(
-        """
+    def benchmark(self) -> MeasurementSource:
+        return Td(
+            """
 > SELECT 1;
   /* A */
 1
@@ -870,7 +730,7 @@ true
   /* B */
 true
 """
-    )
+        )
 
 
 class Sink(Scenario):
@@ -883,33 +743,34 @@ class ExactlyOnce(Sink):
     the data again to determine completion.
     """
 
-    SHARED = Td(
-        """
-$ set keyschema={"type": "record", "name": "Key", "fields": [ {"name": "f1", "type": "long"} ] }
-
-$ set schema={"type" : "record", "name" : "test", "fields": [ {"name": "f2", "type": "long"} ] }
-
+    def shared(self) -> Action:
+        return TdAction(
+            self.keyschema()
+            + self.schema()
+            + f"""
 $ kafka-create-topic topic=sink-input partitions=16
 
-$ kafka-ingest format=avro topic=sink-input key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=1000000
-{"f1": ${kafka-ingest.iteration}} {"f2": ${kafka-ingest.iteration}}
+$ kafka-ingest format=avro topic=sink-input key-format=avro key-schema=${{keyschema}} schema=${{schema}} publish=true repeat={self.n()}
+{{"f1": ${{kafka-ingest.iteration}} }} {{"f2": ${{kafka-ingest.iteration}} }}
 """
-    )
+        )
 
-    INIT = Td(
-        """
+    def init(self) -> Action:
+        return TdAction(
+            f"""
 > CREATE MATERIALIZED SOURCE source1
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-sink-input-${testdrive.seed}'
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  FROM KAFKA BROKER '${{testdrive.kafka-addr}}' TOPIC 'testdrive-sink-input-${{testdrive.seed}}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${{testdrive.schema-registry-url}}'
   ENVELOPE UPSERT;
 
-> /* B */ SELECT COUNT(*) FROM source1;
-1000000
+> SELECT COUNT(*) FROM source1;
+{self.n()}
 """
-    )
+        )
 
-    BENCHMARK = Td(
-        """
+    def benchmark(self) -> MeasurementSource:
+        return Td(
+            """
 > DROP SINK IF EXISTS sink1;
 
 > DROP SOURCE IF EXISTS sink1_check CASCADE;
@@ -933,6 +794,6 @@ $ kafka-ingest format=avro topic=sink-input key-format=avro key-schema=${keysche
 
 > SELECT * FROM sink1_check_v
   /* B */
-1000000
 """
-    )
+            + str(self.n())
+        )


### PR DESCRIPTION
Allow the scenarios to be parameterized using a "scale" factor.
The scenario can use self.scale() and self.n() , which is 10^scale,
to decide how many records to process.

Rendered documentation:

https://github.com/philip-stoev/materialize/blob/feature-benchmark-methods/doc/developer/feature-benchmark.md

Taken together, those changes allow the following command line:

```
./mzcompose run feature-benchmark --scale 9 --root-scenario=KafkaRecoveryBig --max-runs 1
```

to be used to run a Kafka restart benchmark with 1B rows (will fail in reality due to an OOM)

Other changes:
- Convert all scenarios from class methods to normal methods
- Allow the scale to be controlled from the command line
- Allow the maximum number of runs to be controlled via --max-runs
- Split the non-measuring from the non-measuring parts of the code
  by putting them in different classes and using pypy to enforce
  the separation.


### Motivation

  * This PR adds a feature that has not yet been specified.

It became necessary to allow scenarios to be parameterized so that they can run with different scale factors.

This required the wholesale refactoring of `scenarios.py` from class methods to normal methods.


### Tips for reviewer

If reviewers could review the updated documentation file and check out the new format by reading a couple of scenarios from `scenarios.py` that would be much appreciated.