### PR TITLE
dataflow,coord: tweeze apart Response and AllowCompaction messages

### DIFF
--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -821,14 +821,11 @@ where
                     }
                 }
             }
-            ComputeCommand::AllowCompaction(list) => {
+            ComputeCommand::AllowIndexCompaction(list) => {
                 for (id, frontier) in list {
                     self.compute_state
                         .traces
                         .allow_compaction(id, frontier.borrow());
-                    if let Some(ts_history) = self.storage_state.ts_histories.get_mut(&id) {
-                        ts_history.set_compaction_frontier(frontier.borrow());
-                    }
                 }
             }
             ComputeCommand::EnableLogging(config) => {
@@ -1030,6 +1027,13 @@ where
                                 token.activate();
                             }
                         }
+                    }
+                }
+            }
+            StorageCommand::AllowSourceCompaction(list) => {
+                for (id, frontier) in list {
+                    if let Some(ts_history) = self.storage_state.ts_histories.get_mut(&id) {
+                        ts_history.set_compaction_frontier(frontier.borrow());
                     }
                 }
             }


### PR DESCRIPTION
### Motivation

We'll eventually need this to realize the compute/storage separation. It's a first step and seemed easy enough to do.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
