### PR TITLE
ci: remove outdated reference to nightly.stamp

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -90,7 +90,7 @@ steps:
   - id: miri-test
     label: ":face_with_monocle: miri test"
     command: bin/ci-builder run nightly ci/test/cargo-test-miri.sh
-    inputs: [src/repr, ci/builder/nightly.stamp]
+    inputs: [src/repr]
     timeout_in_minutes: 30
     agents:
       queue: builder


### PR DESCRIPTION

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
