### PR TITLE
persist: remove <K, V> bounds from MultiWriteHandle

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -451,7 +451,7 @@ impl CatalogEntryMap {
                 _ => {}
             }
         }
-        MultiWriteHandle::new(&handles)
+        MultiWriteHandle::new_from_streams(handles.into_iter())
             .ok()
             .map(|write_handle| TablePersistMultiDetails {
                 all_table_ids,

--- a/src/coord/src/persistcfg.rs
+++ b/src/coord/src/persistcfg.rs
@@ -448,5 +448,5 @@ pub struct TablePersistDetails {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TablePersistMultiDetails {
     pub all_table_ids: Vec<PersistId>,
-    pub write_handle: MultiWriteHandle<Row, ()>,
+    pub write_handle: MultiWriteHandle,
 }


### PR DESCRIPTION
They weren't structural, just a convenience. This will allow our source
persistence integration to atomically seal two persisted streams with
different <K, V> types.

A happy side-benefit of this is addressing a couple TODOs on
atomic_write which saves some `.collect::<Vec<_>>()` calls in its
current production user (coord).

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
