### PR TITLE
persist: lint for `Arc::clone(&foo)` vs `foo.clone()`

### DIFF
--- a/src/persist/src/client.rs
+++ b/src/persist/src/client.rs
@@ -100,7 +100,7 @@ impl RuntimeClient {
             stream_id,
             client: RuntimeReadClient {
                 sender: CmdReadSender::Full(self.sender.clone()),
-                stopper: self.stopper.clone(),
+                stopper: Arc::clone(&self.stopper),
             },
             _phantom: PhantomData,
         };

--- a/src/persist/src/indexed/arrangement.rs
+++ b/src/persist/src/indexed/arrangement.rs
@@ -1334,7 +1334,7 @@ mod tests {
         let mut blob = BlobCache::new(
             build_info::DUMMY_BUILD_INFO,
             Arc::new(Metrics::default()),
-            async_runtime.clone(),
+            Arc::clone(&async_runtime),
             MemRegistry::new().blob_no_reentrance()?,
         );
         let maintainer = Maintainer::new(blob.clone(), async_runtime);
@@ -1488,7 +1488,7 @@ mod tests {
         let mut blob = BlobCache::new(
             build_info::DUMMY_BUILD_INFO,
             Arc::new(Metrics::default()),
-            async_runtime.clone(),
+            Arc::clone(&async_runtime),
             MemRegistry::new().blob_no_reentrance()?,
         );
         let maintainer = Maintainer::new(blob.clone(), async_runtime);

--- a/src/persist/src/indexed/background.rs
+++ b/src/persist/src/indexed/background.rs
@@ -74,7 +74,7 @@ impl<B: Blob> Maintainer<B> {
     /// at construction time.
     pub fn compact_trace(&self, req: CompactTraceReq) -> PFuture<CompactTraceRes> {
         let (tx, rx) = PFuture::new();
-        let blob = self.blob.clone();
+        let blob = Arc::clone(&self.blob);
         // Ignore the spawn_blocking response since we communicate
         // success/failure through the returned future.
         //
@@ -200,7 +200,7 @@ mod tests {
         let blob = BlobCache::new(
             build_info::DUMMY_BUILD_INFO,
             Arc::new(Metrics::default()),
-            async_runtime.clone(),
+            Arc::clone(&async_runtime),
             MemRegistry::new().blob_no_reentrance()?,
         );
         let maintainer = Maintainer::new(blob.clone(), async_runtime);
@@ -274,7 +274,7 @@ mod tests {
         let blob = BlobCache::new(
             build_info::DUMMY_BUILD_INFO,
             Arc::new(Metrics::default()),
-            async_runtime.clone(),
+            Arc::clone(&async_runtime),
             MemRegistry::new().blob_no_reentrance()?,
         );
         let maintainer = Maintainer::new(blob, async_runtime);

--- a/src/persist/src/lib.rs
+++ b/src/persist/src/lib.rs
@@ -14,7 +14,8 @@
 #![warn(
     clippy::cast_possible_truncation,
     clippy::cast_precision_loss,
-    clippy::cast_sign_loss
+    clippy::cast_sign_loss,
+    clippy::clone_on_ref_ptr
 )]
 
 use std::fmt;

--- a/src/persist/src/nemesis/direct.rs
+++ b/src/persist/src/nemesis/direct.rs
@@ -351,7 +351,7 @@ impl Runtime for Direct {
 
     fn add_worker(&mut self) -> DirectWorker {
         self.workers += 1;
-        DirectWorker::new(self.shared.clone())
+        DirectWorker::new(Arc::clone(&self.shared))
     }
 
     fn finish(self) {

--- a/src/persist/src/nemesis/progress.rs
+++ b/src/persist/src/nemesis/progress.rs
@@ -40,7 +40,7 @@ impl DataflowProgress {
             DataflowProgressHandle {
                 core: Arc::new(Mutex::new(DataflowProgressCore {
                     rx,
-                    closed: closed.clone(),
+                    closed: Arc::clone(&closed),
                     waiters: BTreeMap::new(),
                     frontier: Antichain::from_elem(0),
                 })),

--- a/src/persist/src/runtime.rs
+++ b/src/persist/src/runtime.rs
@@ -86,10 +86,15 @@ where
     };
 
     // Start up the runtime.
-    let blob = BlobCache::new(build, metrics.clone(), async_runtime.clone(), blob);
-    let maintainer = Maintainer::new(blob.clone(), async_runtime.clone());
-    let indexed = Indexed::new(log, blob, maintainer, metrics.clone())?;
-    let mut runtime = RuntimeImpl::new(config.clone(), indexed, rx, metrics.clone());
+    let blob = BlobCache::new(
+        build,
+        Arc::clone(&metrics),
+        Arc::clone(&async_runtime),
+        blob,
+    );
+    let maintainer = Maintainer::new(blob.clone(), Arc::clone(&async_runtime));
+    let indexed = Indexed::new(log, blob, maintainer, Arc::clone(&metrics))?;
+    let mut runtime = RuntimeImpl::new(config.clone(), indexed, rx, Arc::clone(&metrics));
     let id = RuntimeId::new();
     let impl_handle = thread::Builder::new()
         .name("persist:runtime".into())
@@ -163,10 +168,15 @@ where
     };
 
     // Start up the runtime.
-    let blob = BlobCache::new(build, metrics.clone(), async_runtime.clone(), blob);
+    let blob = BlobCache::new(
+        build,
+        Arc::clone(&metrics),
+        Arc::clone(&async_runtime),
+        blob,
+    );
     let maintainer = Maintainer::new(blob.clone(), async_runtime);
-    let indexed = Indexed::new(ErrorLog, blob, maintainer, metrics.clone())?;
-    let mut runtime = RuntimeReadImpl::new(indexed, rx, metrics.clone());
+    let indexed = Indexed::new(ErrorLog, blob, maintainer, Arc::clone(&metrics))?;
+    let mut runtime = RuntimeReadImpl::new(indexed, rx, Arc::clone(&metrics));
     let id = RuntimeId::new();
     let impl_handle = thread::Builder::new()
         .name("persist:runtime-read".into())


### PR DESCRIPTION
The former makes it obvious that the clone is a cheap one on a smart
pointer.

### Tips for reviewer

One hesitation I have here now that I've typed this up is that the `warn(clippy::foo)` things are only caught by `./bin/check`, not my editor or cargo check. I assume the situation is similar for others. The few clippy warns that persist has currently (cast_possible_truncation, cast_precision_loss, cast_precision_loss) are all much less likely to make someone eat a CI cycle than this one. They also have correctness implications (this one is probably limited to perf implications).

### Checklist

- [N/A] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
