### PR TITLE
clean up the tokio-console initialization code

### DIFF
--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -528,13 +528,8 @@ fn run(args: Args) -> Result<(), anyhow::Error> {
                     );
 
                 #[cfg(feature = "tokio-console")]
-                if args.tokio_console {
-                    stack.with(console_subscriber::spawn()).init()
-                } else {
-                    stack.init()
-                }
+                let stack = stack.with(args.tokio_console.then(|| console_subscriber::spawn()));
 
-                #[cfg(not(feature = "tokio-console"))]
                 stack.init()
             }
             log_file => {
@@ -579,13 +574,8 @@ fn run(args: Args) -> Result<(), anyhow::Error> {
                     );
 
                 #[cfg(feature = "tokio-console")]
-                if args.tokio_console {
-                    stack.with(console_subscriber::spawn()).init()
-                } else {
-                    stack.init()
-                }
+                let stack = stack.with(args.tokio_console.then(|| console_subscriber::spawn()));
 
-                #[cfg(not(feature = "tokio-console"))]
                 stack.init()
             }
         }


### PR DESCRIPTION
Turns out `Option` implements layer, which REALLY cleans up how this code looks (especially when used with a cheeky `bool::then`

### Motivation

   * This PR refactors existing code.
	see above

### Checklist

- N/A This PR has adequate test coverage / QA involvement has been duly considered.
- N/A This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
