### PR TITLE
mzcompose: optionalize forwarding AWS environment variables

### DIFF
--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -33,6 +33,7 @@ class Materialized(Service):
         options: Optional[Union[str, List[str]]] = "",
         environment: Optional[List[str]] = None,
         environment_extra: Optional[List[str]] = None,
+        forward_aws_credentials: bool = True,
         volumes: Optional[List[str]] = None,
         volumes_extra: Optional[List[str]] = None,
         depends_on: Optional[List[str]] = None,
@@ -48,6 +49,10 @@ class Materialized(Service):
                 # To dynamically change the environment during a workflow run,
                 # use Composition.override.
                 "MZ_LOG_FILTER",
+            ]
+
+        if forward_aws_credentials:
+            environment += [
                 "AWS_ACCESS_KEY_ID",
                 "AWS_SECRET_ACCESS_KEY",
                 "AWS_SESSION_TOKEN",


### PR DESCRIPTION
To facilitate #9894, which wants to disable the automatic forwarding of AWS environment variables.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
