### PR TITLE
mzbuild: always perform docker pull on acquire()

### DIFF
--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -527,15 +527,16 @@ class ResolvedImage:
         Returns:
             acquired_from: How the image was acquired.
         """
-        if self.image.publish:
-            try:
-                spawn.runv(
-                    ["docker", "pull", self.spec()],
-                    stdout=sys.stderr.buffer,
-                )
-                return AcquiredFrom.REGISTRY
-            except subprocess.CalledProcessError:
-                pass
+
+        try:
+            spawn.runv(
+                ["docker", "pull", self.spec()],
+                stdout=sys.stderr.buffer,
+            )
+            return AcquiredFrom.REGISTRY
+        except subprocess.CalledProcessError:
+            pass
+
         self.build()
         return AcquiredFrom.LOCAL_BUILD
 


### PR DESCRIPTION
perform 'docker pull' when acquiring an image even if self.publish
is set to False. This way a fresh copy of images such as
'materialized:latest' will always be fetched from the Docker hub.

Prior to this fix, mzcompose would use an old image if one was
cached locally, defeating the purpose of performing tests against
'latest'.

### Motivation

  * This PR fixes a previously unreported bug.

Tests that were attempting to run against the 'latest' version of some image were not guaranteed to truly get the latest version, especially if run on a machine that had been up for a while.

### Tips for reviewer

@benesch On the reverse side, I was tempted to also remove `is_docker_image_pushed()` and simply always do `docker push` on `publish()` and let docker sort it out if a push was really necessary or not.