### PR TITLE
coord,persist: fetch latest persist frontiers when rendering source

### DIFF
--- a/src/coord/src/error.rs
+++ b/src/coord/src/error.rs
@@ -67,6 +67,8 @@ pub enum CoordError {
     OperationProhibitsTransaction(String),
     /// The named operation requires an active transaction.
     OperationRequiresTransaction(String),
+    /// A persistence-related error.
+    Persistence(persist::error::Error),
     /// The named prepared statement already exists.
     PreparedStatementExists(String),
     /// The transaction is in read-only mode.
@@ -313,6 +315,7 @@ impl fmt::Display for CoordError {
             CoordError::OperationRequiresTransaction(op) => {
                 write!(f, "{} can only be used in transaction blocks", op)
             }
+            CoordError::Persistence(error) => error.fmt(f),
             CoordError::PreparedStatementExists(name) => {
                 write!(f, "prepared statement {} already exists", name.quoted())
             }

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -358,6 +358,7 @@ impl ErrorResponse {
             CoordError::ConstraintViolation(NotNullViolation(_)) => SqlState::NOT_NULL_VIOLATION,
             CoordError::OperationProhibitsTransaction(_) => SqlState::ACTIVE_SQL_TRANSACTION,
             CoordError::OperationRequiresTransaction(_) => SqlState::NO_ACTIVE_SQL_TRANSACTION,
+            CoordError::Persistence(_) => SqlState::INTERNAL_ERROR,
             CoordError::PreparedStatementExists(_) => SqlState::DUPLICATE_PSTATEMENT,
             CoordError::ReadOnlyTransaction => SqlState::READ_ONLY_SQL_TRANSACTION,
             CoordError::ReadOnlyParameter(_) => SqlState::CANT_CHANGE_RUNTIME_PARAM,

--- a/test/persistence/kafka-sources/repeated-source-rendering-after.td
+++ b/test/persistence/kafka-sources/repeated-source-rendering-after.td
@@ -1,0 +1,39 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Run parts of repeated-source-rendering-before.td post-restart
+
+> SELECT COUNT(*) = 10 FROM a_view;
+true
+
+> SELECT SUM(CAST(statistics->'topics'->'testdrive-re-created-${testdrive.seed}'->'partitions'->'0'->'msgs' AS INT)) = 0 FROM mz_kafka_source_statistics;
+true
+
+> DROP VIEW a_view;
+
+> CREATE MATERIALIZED VIEW a_view AS SELECT * FROM re_created;
+
+> SELECT COUNT(*) = 10 FROM a_view;
+true
+
+# Re-creating the source should result in no messages being read from Kafka, because we still have the persisted data and offsets.
+> SELECT SUM(CAST(statistics->'topics'->'testdrive-re-created-${testdrive.seed}'->'partitions'->'0'->'msgs' AS INT)) = 0 FROM mz_kafka_source_statistics;
+true
+
+# Same with DROP INDEX
+
+> DROP INDEX a_view_primary_idx;
+
+> CREATE DEFAULT INDEX ON a_view;
+
+> SELECT COUNT(*) = 10 FROM a_view;
+true
+
+> SELECT SUM(CAST(statistics->'topics'->'testdrive-re-created-${testdrive.seed}'->'partitions'->'0'->'msgs' AS INT)) = 0 FROM mz_kafka_source_statistics;
+true

--- a/test/persistence/kafka-sources/repeated-source-rendering-before.td
+++ b/test/persistence/kafka-sources/repeated-source-rendering-before.td
@@ -1,0 +1,61 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set schema={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"f1", "type":"long"}
+        ]
+    }
+
+$ kafka-create-topic topic=re-created partitions=1
+
+# Make sure that we can render a source (by creating a MATERIALIZED VIEW), drop
+# it, and render it again.
+
+$ kafka-ingest format=avro topic=re-created schema=${schema} publish=true repeat=10
+{"f1": ${kafka-ingest.iteration}}
+
+> CREATE SOURCE re_created
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-re-created-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  INCLUDE PARTITION AS kafka_partition, OFFSET AS mz_offset
+  ENVELOPE NONE
+
+> CREATE MATERIALIZED VIEW a_view AS SELECT * FROM re_created;
+
+> SELECT COUNT(*) = 10 FROM a_view;
+true
+
+> SELECT SUM(CAST(statistics->'topics'->'testdrive-re-created-${testdrive.seed}'->'partitions'->'0'->'msgs' AS INT)) = 10 FROM mz_kafka_source_statistics;
+true
+
+> DROP VIEW a_view;
+
+> CREATE MATERIALIZED VIEW a_view AS SELECT * FROM re_created;
+
+> SELECT COUNT(*) = 10 FROM a_view;
+true
+
+# Re-creating the source should result in no messages being read from Kafka, because we still have the persisted data and offsets.
+> SELECT SUM(CAST(statistics->'topics'->'testdrive-re-created-${testdrive.seed}'->'partitions'->'0'->'msgs' AS INT)) = 0 FROM mz_kafka_source_statistics;
+true
+
+# Same with DROP INDEX
+
+> DROP INDEX a_view_primary_idx;
+
+> CREATE DEFAULT INDEX ON a_view;
+
+> SELECT COUNT(*) = 10 FROM a_view;
+true
+
+> SELECT SUM(CAST(statistics->'topics'->'testdrive-re-created-${testdrive.seed}'->'partitions'->'0'->'msgs' AS INT)) = 0 FROM mz_kafka_source_statistics;
+true


### PR DESCRIPTION
Before, we were fetching the latest seal/compaction frontiers when
starting up. We did this, because the dataflow rendering paths where not
fallible.

Recently, these rendering paths gained the ability to return errors, so
now we can call into persistence right when rendering the source. This
fixes a problem where previously creating a materialized view, dropping
it, and then re-creating it would result in errors because the rendering
code would still assume the frontiers as they were at the time the
coordinator had started up.

The problem would manifest as error messages in the log, and the
rendered view would be wedged with a persistence-related error message.
I added a test that verifies that we can drop and re-render a source
successfully.

This does change where we keep "persist details". Before, we were
keeping them in the `SourceConnector`, but these were "resolved"
details, that is with the frontiers as they were when the coordinator
booted up. Now we keep the serialized (or "unresolved") form of the
persist details in the catalog entry `Source` and resolve them when
rendering the source to get the latest frontiers.

### Tips for reviewers

I don't super like how we mutate the connector, but we also did it before. At least we now only do it in one place.

@philip-stoev I added a test. Is it ok to add a test in there that only has a `before` version. I mainly added it there because theses tests run with persistence enabled.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
