### PR TITLE
Ore/QGM: Add generalized nonrecursive graph depth-first traversal to ore/qgm

### DIFF
--- a/src/ore/src/graph.rs
+++ b/src/ore/src/graph.rs
@@ -1,0 +1,143 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Graph utilities.
+
+use std::collections::HashSet;
+
+/// A non-recursive implementation of depth-first traversal starting from `root`.
+///
+/// Assumes that nodes in the graph all have unique node ids.
+///
+/// `at_enter` runs when entering a node. It is expected to return an in-order
+/// list of the children of the node. You can omit children from the list
+/// returned if you want to skip the traversing subgraphs corresponding to
+/// those children. If no children are omitted, `at_enter` can be thought
+/// of as a function that processes the nodes of the graph in pre-order.
+///
+/// `at_exit` runs when exiting a node. It can be thought of as a function that
+/// processes the nodes of the graph in post-order.
+///
+/// This function only enters and exits a node at most once and thus is safe to
+/// run even if the graph contains a cycle.
+pub fn nonrecursive_dft<Graph, NodeId, AtEnter, AtExit, E>(
+    graph: &Graph,
+    root: NodeId,
+    at_enter: &mut AtEnter,
+    at_exit: &mut AtExit,
+) -> Result<(), E>
+where
+    NodeId: std::cmp::Eq + std::hash::Hash,
+    AtEnter: FnMut(&Graph, &NodeId) -> Result<Vec<NodeId>, E>,
+    AtExit: FnMut(&Graph, &NodeId) -> Result<(), E>,
+{
+    // All nodes that have been entered but not exited. Last node in the vec is
+    // the node that we most recently entered.
+    let mut entered = Vec::new();
+    // All nodes that have been exited.
+    let mut exited = HashSet::new();
+
+    // Pseudocode for the recursive version of this function would look like:
+    // ```
+    // atenter(graph, node)
+    // foreach child in children(graph, node):
+    //    recursive_call(graph, child)
+    // atexit(graph, node)
+    // ```
+    // In this non-recursive implementation, you can think of the call stack as
+    // been replaced by `entered`. Every time an object is pushed into `entered`
+    // would have been a time you would have pushed a recursive call onto the
+    // call stack. Likewise, times an object is popped from `entered` would have
+    // been times when recursive calls leave the stack.
+
+    // Enter from the root.
+    let children = at_enter(graph, &root)?;
+    entered_node(&mut entered, root, children);
+    while !entered.is_empty() {
+        if let Some(to_enter) = find_next_child_to_enter(&mut entered, &mut exited) {
+            let children = at_enter(graph, &to_enter)?;
+            entered_node(&mut entered, to_enter, children);
+        } else {
+            // If this node has no more children to descend into,
+            // exit the current node and run `at_exit`.
+            let (to_exit, _) = entered.pop().unwrap();
+            at_exit(graph, &to_exit)?;
+            exited.insert(to_exit);
+        }
+    }
+    Ok(())
+}
+
+/// Same as [nonrecursive_dft], but allows changes to be made to the graph.
+pub fn nonrecursive_dft_mut<Graph, NodeId, AtEnter, AtExit, E>(
+    graph: &mut Graph,
+    root: NodeId,
+    at_enter: &mut AtEnter,
+    at_exit: &mut AtExit,
+) -> Result<(), E>
+where
+    NodeId: std::cmp::Eq + std::hash::Hash + Clone,
+    AtEnter: FnMut(&mut Graph, &NodeId) -> Result<Vec<NodeId>, E>,
+    AtExit: FnMut(&mut Graph, &NodeId) -> Result<(), E>,
+{
+    // Code in this method is identical to the code in `nonrecursive_dft`.
+    let mut entered = Vec::new();
+    let mut exited = HashSet::new();
+
+    let children = at_enter(graph, &root)?;
+    entered_node(&mut entered, root, children);
+    while !entered.is_empty() {
+        if let Some(to_enter) = find_next_child_to_enter(&mut entered, &mut exited) {
+            let children = at_enter(graph, &to_enter)?;
+            entered_node(&mut entered, to_enter, children);
+        } else {
+            let (to_exit, _) = entered.pop().unwrap();
+            at_exit(graph, &to_exit)?;
+            exited.insert(to_exit);
+        }
+    }
+    Ok(())
+}
+
+/// Add to `entered` that we have entered `node` and `node` has `children`.
+fn entered_node<NodeId>(
+    entered: &mut Vec<(NodeId, Vec<NodeId>)>,
+    node: NodeId,
+    mut children: Vec<NodeId>,
+) where
+    NodeId: std::cmp::Eq + std::hash::Hash,
+{
+    // Reverse children because `find_next_child_to_enter` will traverse the
+    // list of children by popping them out from the back.
+    children.reverse();
+    entered.push((node, children))
+}
+
+/// Find the next child node, if any, that we have not entered.
+fn find_next_child_to_enter<NodeId>(
+    entered: &mut Vec<(NodeId, Vec<NodeId>)>,
+    exited: &mut HashSet<NodeId>,
+) -> Option<NodeId>
+where
+    NodeId: std::cmp::Eq + std::hash::Hash,
+{
+    let (_, children) = entered.last_mut().unwrap();
+    while let Some(child) = children.pop() {
+        if !exited.contains(&child) {
+            return Some(child);
+        }
+    }
+    return None;
+}

--- a/src/ore/src/lib.rs
+++ b/src/ore/src/lib.rs
@@ -38,6 +38,7 @@ pub mod fmt;
 #[cfg_attr(nightly_doc_features, doc(cfg(feature = "network")))]
 #[cfg(feature = "network")]
 pub mod future;
+pub mod graph;
 pub mod hash;
 pub mod hint;
 pub mod id_gen;

--- a/src/sql/src/query_model/dot.rs
+++ b/src/sql/src/query_model/dot.rs
@@ -69,10 +69,9 @@ impl DotGenerator {
         let mut quantifiers = Vec::new();
 
         model
-            .visit_pre_boxes_in_subgraph(
-                &mut |b| -> Result<(), ()> {
-                    let box_id = b.id;
-
+            .try_visit_pre_post_descendants(
+                &mut |m, box_id| -> Result<(), ()> {
+                    let b = m.get_box(*box_id);
                     self.new_line(&format!("subgraph cluster{} {{", box_id));
                     self.inc();
                     self.new_line(
@@ -118,6 +117,7 @@ impl DotGenerator {
 
                     Ok(())
                 },
+                &mut |_, _| Ok(()),
                 start_box,
             )
             .unwrap();

--- a/src/sql/src/query_model/mod.rs
+++ b/src/sql/src/query_model/mod.rs
@@ -434,37 +434,77 @@ impl Model {
     }
 
     /// Visit boxes in the query graph in pre-order starting from `self.top_box`.
-    fn visit_pre_boxes<'a, F, E>(&'a self, f: &mut F) -> Result<(), E>
+    pub(super) fn visit_pre_post<'a, F, G, E>(&'a self, pre: &mut F, post: &mut G) -> Result<(), E>
     where
-        F: FnMut(Ref<'a, QueryBox>) -> Result<(), E>,
+        F: FnMut(&Model, &BoxId) -> Result<(), E>,
+        G: FnMut(&Model, &BoxId) -> Result<(), E>,
     {
-        self.visit_pre_boxes_in_subgraph(f, self.top_box)
+        self.try_visit_pre_post_descendants(pre, post, self.top_box)
     }
 
     /// Visit boxes in the query graph in pre-order
-    fn visit_pre_boxes_in_subgraph<'a, F, E>(&'a self, f: &mut F, start_box: BoxId) -> Result<(), E>
+    pub(super) fn try_visit_pre_post_descendants<'a, F, G, E>(
+        &'a self,
+        pre: &mut F,
+        post: &mut G,
+        root: BoxId,
+    ) -> Result<(), E>
     where
-        F: FnMut(Ref<'a, QueryBox>) -> Result<(), E>,
+        F: FnMut(&Model, &BoxId) -> Result<(), E>,
+        G: FnMut(&Model, &BoxId) -> Result<(), E>,
     {
-        let mut visited = HashSet::new();
-        let mut stack = vec![start_box];
-        while !stack.is_empty() {
-            let box_id = stack.pop().unwrap();
-            if visited.insert(box_id) {
-                let query_box = self.boxes.get(&box_id).expect("a valid box identifier");
-                f(query_box.borrow())?;
+        ore::graph::nonrecursive_dft(
+            self,
+            root,
+            &mut |model, box_id| {
+                pre(model, box_id)?;
+                Ok(model
+                    .get_box(*box_id)
+                    .input_quantifiers()
+                    .map(|q| q.input_box)
+                    .collect())
+            },
+            post,
+        )
+    }
 
-                stack.extend(
-                    query_box
-                        .borrow()
-                        .quantifiers
-                        .iter()
-                        .rev()
-                        .map(|q| self.get_quantifier(*q).input_box),
-                );
-            }
-        }
-        Ok(())
+    /// Visit boxes in the query graph in pre-order starting from `self.top_box`.
+    pub(super) fn visit_mut_pre_post<'a, F, G, E>(
+        &'a mut self,
+        pre: &mut F,
+        post: &mut G,
+    ) -> Result<(), E>
+    where
+        F: FnMut(&mut Model, &BoxId) -> Result<(), E>,
+        G: FnMut(&mut Model, &BoxId) -> Result<(), E>,
+    {
+        self.try_visit_mut_pre_post_descendants(pre, post, self.top_box)
+    }
+
+    /// Visit boxes in the query graph in pre-order
+    pub(super) fn try_visit_mut_pre_post_descendants<'a, F, G, E>(
+        &'a mut self,
+        pre: &mut F,
+        post: &mut G,
+        root: BoxId,
+    ) -> Result<(), E>
+    where
+        F: FnMut(&mut Model, &BoxId) -> Result<(), E>,
+        G: FnMut(&mut Model, &BoxId) -> Result<(), E>,
+    {
+        ore::graph::nonrecursive_dft_mut(
+            self,
+            root,
+            &mut |model, box_id| {
+                pre(model, box_id)?;
+                Ok(model
+                    .get_box(*box_id)
+                    .input_quantifiers()
+                    .map(|q| q.input_box)
+                    .collect())
+            },
+            post,
+        )
     }
 
     /// Removes unreferenced objects from the model.
@@ -474,11 +514,15 @@ impl Model {
         let mut visited_boxes = HashSet::new();
         let mut visited_quantifiers: HashSet<QuantifierId> = HashSet::new();
 
-        let _ = self.visit_pre_boxes(&mut |b| -> Result<(), ()> {
-            visited_boxes.insert(b.id);
-            visited_quantifiers.extend(b.quantifiers.iter());
-            Ok(())
-        });
+        let _ = self.visit_pre_post(
+            &mut |m, box_id| -> Result<(), ()> {
+                visited_boxes.insert(*box_id);
+                let b = m.get_box(*box_id);
+                visited_quantifiers.extend(b.input_quantifiers().map(|q| q.id));
+                Ok(())
+            },
+            &mut |_, _| Ok(()),
+        );
         self.boxes.retain(|b, _| visited_boxes.contains(b));
         self.quantifiers
             .retain(|q, _| visited_quantifiers.contains(q));
@@ -686,7 +730,8 @@ impl QueryBox {
             // collect the column references from the current context within
             // the subgraph under the current quantifier
             let mut column_refs = HashSet::new();
-            let mut f = |inner_box: Ref<'_, QueryBox>| -> Result<(), ()> {
+            let mut f = |m: &Model, box_id: &BoxId| -> Result<(), ()> {
+                let inner_box = m.get_box(*box_id);
                 inner_box.visit_expressions(&mut |expr: &BoxScalarExpr| -> Result<(), ()> {
                     expr.collect_column_references_from_context(
                         &self.quantifiers,
@@ -697,7 +742,7 @@ impl QueryBox {
             };
             let q = model.get_quantifier(*q_id);
             model
-                .visit_pre_boxes_in_subgraph(&mut f, q.input_box)
+                .try_visit_pre_post_descendants(&mut f, &mut |_, _| Ok(()), q.input_box)
                 .unwrap();
             if !column_refs.is_empty() {
                 correlation_info.insert(*q_id, column_refs);

--- a/src/sql/src/query_model/rewrites/mod.rs
+++ b/src/sql/src/query_model/rewrites/mod.rs
@@ -10,7 +10,6 @@
 //! Apply rewrites to [`Model`] instances.
 
 use crate::query_model::{BoxId, Model};
-use std::collections::HashSet;
 
 /// Trait that all rewrite rules must implement.
 pub(crate) trait Rule {
@@ -115,68 +114,25 @@ fn apply_rule(rule: &dyn Rule, model: &mut Model, box_id: BoxId) -> bool {
 ///
 /// Returns whether any box was rewritten.
 fn apply_dft_rules(pre: &Vec<Box<dyn Rule>>, post: &Vec<Box<dyn Rule>>, model: &mut Model) -> bool {
-    let mut rewritten = false;
+    let mut rewritten_in_pre = false;
+    let mut rewritten_in_post = false;
 
-    // All nodes that have been entered but not exited. Last node in the vec is
-    // the node that we most recently entered.
-    let mut entered = Vec::new();
-    // All nodes that have been exited.
-    let mut exited = HashSet::new();
-
-    // In our current node, find the next child box, if any, that we have not entered.
-    fn find_next_child_to_enter(
-        model: &Model,
-        entered: &mut Vec<(BoxId, usize)>,
-        exited: &HashSet<BoxId>,
-    ) -> Option<BoxId> {
-        let (box_id, traversed_quantifiers) = entered.last_mut().unwrap();
-        let b = model.get_box(*box_id);
-        for q in b.input_quantifiers().skip(*traversed_quantifiers) {
-            *traversed_quantifiers += 1;
-            if !exited.contains(&q.input_box) {
-                return Some(q.input_box);
-            }
-        }
-        return None;
-    }
-
-    // Pseudocode for the recursive version of this function would look like:
-    // ```
-    // apply_preorder_rules()
-    // foreach quantifier:
-    //    recursive_call(quantifier.input_box)
-    // apply_postorder_rules()
-    // ```
-    // In this non-recursive implementation, you can think of the call stack as
-    // been replaced by `entered`. Every time an object is pushed into `entered`
-    // would have been a time you would have pushed a recursive call onto the
-    // call stack. Likewise, times an object is popped from `entered` would have
-    // been times when recursive calls leave the stack.
-
-    // Start from the top box.
-    entered.push((model.top_box, 0));
-    for rule in pre {
-        rewritten |= apply_rule(rule.as_ref(), model, model.top_box);
-    }
-    while !entered.is_empty() {
-        if let Some(to_enter) = find_next_child_to_enter(model, &mut entered, &exited) {
-            entered.push((to_enter, 0));
+    let _ = model.visit_mut_pre_post(
+        &mut |m, box_id| -> Result<(), ()> {
             for rule in pre {
-                rewritten |= apply_rule(rule.as_ref(), model, to_enter);
+                rewritten_in_pre |= apply_rule(rule.as_ref(), m, *box_id);
             }
-        } else {
-            // If this box has no more children to descend into,
-            // run PostOrder rules and exit the current box.
-            let (box_id, _) = entered.last().unwrap();
+            Ok(())
+        },
+        &mut |m, box_id| -> Result<(), ()> {
             for rule in post {
-                rewritten |= apply_rule(rule.as_ref(), model, *box_id);
+                rewritten_in_post |= apply_rule(rule.as_ref(), m, *box_id);
             }
-            exited.insert(*box_id);
-            entered.pop();
-        }
-    }
+            Ok(())
+        },
+    );
 
-    rewritten
+    rewritten_in_pre | rewritten_in_post
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Motivation

   * This PR refactors existing code.

Add a generalized version of the depth first graph traversal from the QGM rewrite engine to the crate `ore`.

It turns out that we already had a non-recursive depth first graph traversal method in `query_model::Model` called `visit_pre_boxes` that only handled functions that process nodes in pre-order. I:
* changed the method to handle pre- and post-order functions. 
* changed the implementation to call `ore::graph::nonrecursive_dft*`.
* renamed the methods to conform the new `visit` nomenclature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
