### PR TITLE
persist: use a single main for all benches

### DIFF
--- a/misc/scratch/persist-benchmarking.json
+++ b/misc/scratch/persist-benchmarking.json
@@ -1,7 +1,7 @@
 {
     "name": "persist benchmarking",
     "launch_script": "true",
-    "instance_type": "r5a.4xlarge",
+    "instance_type": "m6i.8xlarge",
     "ami": "ami-0b29b6e62f2343b46",
     "size_gb": 200,
     "tags": {}

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -5,18 +5,22 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 rust-version = "1.58.0"
+# Since we intentionally will only ever have one bench target, auto discovery of
+# benches is unnecessary. Turning it off allows us to have helper code in
+# src/benches.
+autobenches = false
 
+# We intentionally have only a single bench target because it saves on linking
+# time.
 [[bench]]
-name = "writer"
+name = "benches"
 harness = false
 
-[[bench]]
-name = "snapshot"
-harness = false
-
-[[bench]]
-name = "end_to_end"
-harness = false
+# Disable the ability to use benches in the library because the bench harness
+# isn't override-able there and the stock one prevents using criterion specific
+# flags e.g. `cargo bench -p persist -- --baseline=foo`.
+[lib]
+bench = false
 
 # NB: This is meant to be a strong, independent abstraction boundary, please
 # don't leak in deps on other Materialize packages.
@@ -53,7 +57,7 @@ uuid = { version = "0.8.2", features = ["v4"] }
 prost-build = "0.9.1"
 
 [dev-dependencies]
-criterion = { git = "https://github.com/MaterializeInc/criterion.rs.git" }
+criterion = { git = "https://github.com/MaterializeInc/criterion.rs.git", features = ["html_reports"] }
 ore = { path = "../ore", default-features = false, features = ["test"] }
 rand = { version = "0.8.4", features = [ "small_rng" ] }
 tempfile = "3.2.0"

--- a/src/persist/benches/benches.rs
+++ b/src/persist/benches/benches.rs
@@ -1,0 +1,41 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use persist::workload::DataGenerator;
+
+mod end_to_end;
+mod snapshot;
+mod writer;
+
+pub fn bench_persist(c: &mut Criterion) {
+    let data = DataGenerator::default();
+
+    end_to_end::bench_replay(&data, &mut c.benchmark_group("end_to_end/replay"));
+
+    snapshot::bench_mem(&data, &mut c.benchmark_group("snapshot/mem"));
+    snapshot::bench_file(&data, &mut c.benchmark_group("snapshot/file"));
+
+    writer::bench_log(&mut c.benchmark_group("writer/log"));
+    writer::bench_blob(&data, &mut c.benchmark_group("writer/blob"));
+    writer::bench_encode_batch(&data, &mut c.benchmark_group("writer/encode_batch"));
+    writer::bench_blob_cache_set_unsealed_batch(
+        &data,
+        &mut c.benchmark_group("writer/blob_cache_set_unsealed_batch"),
+    );
+    writer::bench_indexed_drain(&data, &mut c.benchmark_group("writer/indexed_drain"));
+}
+
+// The grouping here is an artifact of criterion's interaction with the
+// plug-able rust benchmark harness. We use criterion's groups instead.
+criterion_group! {
+    benches,
+    bench_persist,
+}
+criterion_main!(benches);

--- a/src/persist/benches/writer.rs
+++ b/src/persist/benches/writer.rs
@@ -15,9 +15,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use criterion::measurement::WallTime;
-use criterion::{
-    criterion_group, criterion_main, Bencher, BenchmarkGroup, BenchmarkId, Criterion, Throughput,
-};
+use criterion::{Bencher, BenchmarkGroup, BenchmarkId, Throughput};
 use differential_dataflow::trace::Description;
 use ore::cast::CastFrom;
 use ore::metrics::MetricsRegistry;
@@ -81,35 +79,32 @@ fn bench_set<B: Blob>(writer: &mut B, data: Vec<u8>, b: &mut Bencher) {
     })
 }
 
-pub fn bench_writes_log(c: &mut Criterion) {
+pub fn bench_log(g: &mut BenchmarkGroup<'_, WallTime>) {
     let data = "entry0".as_bytes().to_vec();
 
     let mut mem_log = MemRegistry::new()
         .log_no_reentrance()
         .expect("creating a MemLog cannot fail");
-    c.bench_function("mem_log_write_sync", |b| {
+    g.bench_function("mem_sync", |b| {
         bench_write_sync(&mut mem_log, data.clone(), b)
     });
 
     // Create a directory that will automatically be dropped after the test finishes.
     let temp_dir = tempfile::tempdir().expect("failed to create temp directory");
     let mut file_log = new_file_log("file_log_write_sync", temp_dir.path());
-    c.bench_function("file_log_write_sync", |b| {
+    g.bench_function("file_sync", |b| {
         bench_write_sync(&mut file_log, data.clone(), b)
     });
 }
 
-pub fn bench_writes_blob(c: &mut Criterion) {
-    let mut group = c.benchmark_group("blob_set");
-
+pub fn bench_blob(data: &DataGenerator, g: &mut BenchmarkGroup<'_, WallTime>) {
     // Limit the amount of time this test gets to run in order to limit the total
     // number of iterations criterion takes, and consequently, limit the peak
     // memory usage.
-    group.warm_up_time(Duration::from_secs(1));
-    group.measurement_time(Duration::from_secs(1));
+    g.warm_up_time(Duration::from_secs(1));
+    g.measurement_time(Duration::from_secs(1));
 
     let mut blob_val = vec![];
-    let data = DataGenerator::default();
     for batch in data.batches() {
         for ((k, v), t, d) in batch.iter() {
             blob_val.extend_from_slice(k);
@@ -119,12 +114,12 @@ pub fn bench_writes_blob(c: &mut Criterion) {
         }
     }
     assert_eq!(data.goodput_bytes(), u64::cast_from(blob_val.len()));
-    group.throughput(Throughput::Bytes(data.goodput_bytes()));
+    g.throughput(Throughput::Bytes(data.goodput_bytes()));
 
     let mut mem_blob = MemRegistry::new()
         .blob_no_reentrance()
         .expect("creating a MemBlob cannot fail");
-    group.bench_with_input(
+    g.bench_with_input(
         BenchmarkId::new("mem", data.goodput_pretty()),
         &blob_val,
         |b, blob_val| bench_set(&mut mem_blob, blob_val.clone(), b),
@@ -133,7 +128,7 @@ pub fn bench_writes_blob(c: &mut Criterion) {
     // Create a directory that will automatically be dropped after the test finishes.
     let temp_dir = tempfile::tempdir().expect("failed to create temp directory");
     let mut file_blob = new_file_blob("file_blob_set", temp_dir.path());
-    group.bench_with_input(
+    g.bench_with_input(
         BenchmarkId::new("file", data.goodput_pretty()),
         &blob_val,
         |b, blob_val| bench_set(&mut file_blob, blob_val.clone(), b),
@@ -221,11 +216,11 @@ fn bench_set_unsealed_batch<B: Blob>(
 }
 
 fn bench_writes_indexed_inner<B: Blob, L: Log>(
-    mut index: Indexed<L, B>,
-    name: &str,
+    data: &DataGenerator,
     g: &mut BenchmarkGroup<WallTime>,
+    name: &str,
+    mut index: Indexed<L, B>,
 ) -> Result<(), Error> {
-    let data = DataGenerator::default();
     let mut sorted_updates = data.records().collect::<Vec<_>>();
     sorted_updates.sort();
     let mut unsorted_updates = sorted_updates.clone();
@@ -255,16 +250,14 @@ fn bench_writes_indexed_inner<B: Blob, L: Log>(
     Ok(())
 }
 
-pub fn bench_writes_indexed(c: &mut Criterion) {
-    let mut group = c.benchmark_group("indexed_write_drain");
-
+pub fn bench_indexed_drain(data: &DataGenerator, g: &mut BenchmarkGroup<'_, WallTime>) {
     // Limit the sample size of this benchmark group to constrain it to a more
     // reasonable runtime.
-    group.sample_size(10);
+    g.sample_size(10);
     let mem_indexed = MemRegistry::new()
         .indexed_no_reentrance()
         .expect("failed to create mem indexed");
-    bench_writes_indexed_inner(mem_indexed, "mem", &mut group).expect("running benchmark failed");
+    bench_writes_indexed_inner(data, g, "mem", mem_indexed).expect("running benchmark failed");
 
     // Create a directory that will automatically be dropped after the test finishes.
     let temp_dir = tempfile::tempdir().expect("failed to create temp directory");
@@ -282,14 +275,11 @@ pub fn bench_writes_indexed(c: &mut Criterion) {
     let compacter = Maintainer::new(blob_cache.clone(), async_runtime);
     let file_indexed = Indexed::new(file_log, blob_cache, compacter, metrics)
         .expect("failed to create file indexed");
-    bench_writes_indexed_inner(file_indexed, "file", &mut group).expect("running benchmark failed");
+    bench_writes_indexed_inner(data, g, "file", file_indexed).expect("running benchmark failed");
 }
 
-pub fn bench_encode_batch(c: &mut Criterion) {
-    let mut group = c.benchmark_group("encode_batch");
-
-    let data = DataGenerator::default();
-    group.throughput(Throughput::Bytes(data.goodput_bytes()));
+pub fn bench_encode_batch(data: &DataGenerator, g: &mut BenchmarkGroup<'_, WallTime>) {
+    g.throughput(Throughput::Bytes(data.goodput_bytes()));
     let unsealed = BlobUnsealedBatch {
         desc: SeqNo(0)..SeqNo(1),
         updates: data.batches().collect::<Vec<_>>(),
@@ -303,7 +293,7 @@ pub fn bench_encode_batch(c: &mut Criterion) {
         updates: data.batches().collect::<Vec<_>>(),
     };
 
-    group.bench_function(BenchmarkId::new("unsealed", data.goodput_pretty()), |b| {
+    g.bench_function(BenchmarkId::new("unsealed", data.goodput_pretty()), |b| {
         b.iter(|| {
             // Intentionally alloc a new buf each iter.
             let mut buf = Vec::new();
@@ -311,7 +301,7 @@ pub fn bench_encode_batch(c: &mut Criterion) {
         })
     });
 
-    group.bench_function(BenchmarkId::new("trace", data.goodput_pretty()), |b| {
+    g.bench_function(BenchmarkId::new("trace", data.goodput_pretty()), |b| {
         b.iter(|| {
             // Intentionally alloc a new buf each iter.
             let mut buf = Vec::new();
@@ -320,9 +310,10 @@ pub fn bench_encode_batch(c: &mut Criterion) {
     });
 }
 
-pub fn bench_writes_blob_cache(c: &mut Criterion) {
-    let mut group = c.benchmark_group("blob_cache_set_unsealed_batch");
-
+pub fn bench_blob_cache_set_unsealed_batch(
+    data: &DataGenerator,
+    g: &mut BenchmarkGroup<'_, WallTime>,
+) {
     // Limit the sample size and measurement time of this benchmark group to both
     // limit the overall runtime to a reasonable length and bound the memory
     // utilization.
@@ -332,9 +323,9 @@ pub fn bench_writes_blob_cache(c: &mut Criterion) {
     // because we want to have a tight limit on the number of iterations, as each
     // incurs substantial memory usage for both file and mem blobs (because of how
     // caching is currently implemented), we have to manually specify both.
-    group.sample_size(10);
-    group.warm_up_time(Duration::from_secs(1));
-    group.measurement_time(Duration::from_secs(1));
+    g.sample_size(10);
+    g.warm_up_time(Duration::from_secs(1));
+    g.measurement_time(Duration::from_secs(1));
 
     let async_runtime = Arc::new(AsyncRuntime::new().expect("failed to create runtime"));
     let mem_blob = MemRegistry::new()
@@ -360,12 +351,11 @@ pub fn bench_writes_blob_cache(c: &mut Criterion) {
         file_blob,
     );
 
-    let data = DataGenerator::default();
     let batches = data.batches().collect::<Vec<_>>();
-    group.throughput(Throughput::Bytes(data.goodput_bytes()));
+    g.throughput(Throughput::Bytes(data.goodput_bytes()));
     let desc = SeqNo(0)..SeqNo(1);
 
-    group.bench_with_input(
+    g.bench_with_input(
         BenchmarkId::new("file_unsorted", data.goodput_pretty()),
         &(desc.clone(), batches.clone()),
         |b, (desc, batches)| {
@@ -373,7 +363,7 @@ pub fn bench_writes_blob_cache(c: &mut Criterion) {
         },
     );
 
-    group.bench_with_input(
+    g.bench_with_input(
         BenchmarkId::new("mem_unsorted", data.goodput_pretty()),
         &(desc, batches),
         |b, (desc, batches)| {
@@ -381,13 +371,3 @@ pub fn bench_writes_blob_cache(c: &mut Criterion) {
         },
     );
 }
-
-criterion_group!(
-    benches,
-    bench_writes_log,
-    bench_writes_blob,
-    bench_encode_batch,
-    bench_writes_blob_cache,
-    bench_writes_indexed
-);
-criterion_main!(benches);


### PR DESCRIPTION
There's no particular reason they need to be separate binaries and only
having one cuts down on link time. While I'm in here, also:

- Fix `cargo bench -p persist -- --baseline=foo` (broken previously
  because lib was getting the std bench harness for its non-existent
  benches and the harness errors on unknown flags).
- Standardize on passing a criterion::BenchmarkGroup instead of
  criterion::Criterion to "top-level" benchmarks.
- Skip the reasonably expensive setup work in end_to_end when it wasn't
  selected for execution.
- Use the same DataGenerator for all benchmarks.
- Silence the criterion "html_reports" warning.
- Rename the benchmarks a bit to remove redundances in the names.

New output is much cleaner

    $ cargo bench -p persist
       Compiling persist v0.0.0
        Finished bench [optimized + debuginfo] target(s) in 32.28s
         Running unittests (target/release/deps/main-0ce35e00c69ce2e6)
    Gnuplot not found, using plotters backend
    MZ_PERSIST_RECORD_COUNT=819200 MZ_PERSIST_RECORD_SIZE_BYTES=64 MZ_PERSIST_BATCH_MAX_COUNT=131072
    Benchmarking end_to_end/replay/50MiB: Warming up for 3.0000 s
    Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 41.3s, or reduce sample count to 10.
    end_to_end/replay/50MiB time:   [405.32 ms 406.61 ms 407.95 ms]
                            thrpt:  [122.56 MiB/s 122.97 MiB/s 123.36 MiB/s]
    Found 4 outliers among 100 measurements (4.00%)
      4 (4.00%) high mild

    Benchmarking snapshot/mem/unsealed/50MiB: Warming up for 3.0000 s
    Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.3s, or reduce sample count to 50.
    snapshot/mem/unsealed/50MiB
                            time:   [91.837 ms 92.120 ms 92.406 ms]
                            thrpt:  [541.09 MiB/s 542.77 MiB/s 544.44 MiB/s]
    Found 4 outliers among 100 measurements (4.00%)
      2 (2.00%) low mild
      2 (2.00%) high mild
    Benchmarking snapshot/mem/trace/50MiB: Warming up for 3.0000 s
    Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 10.0s, or reduce sample count to 50.
    snapshot/mem/trace/50MiB
                            time:   [93.718 ms 93.964 ms 94.236 ms]
                            thrpt:  [530.58 MiB/s 532.12 MiB/s 533.52 MiB/s]
    Found 4 outliers among 100 measurements (4.00%)
      3 (3.00%) high mild
      1 (1.00%) high severe

    Benchmarking snapshot/file/unsealed/50MiB: Warming up for 3.0000 s
    Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 10.3s, or reduce sample count to 40.
    snapshot/file/unsealed/50MiB
                            time:   [100.44 ms 100.85 ms 101.29 ms]
                            thrpt:  [493.64 MiB/s 495.77 MiB/s 497.80 MiB/s]
    Found 9 outliers among 100 measurements (9.00%)
      1 (1.00%) low severe
      1 (1.00%) low mild
      5 (5.00%) high mild
      2 (2.00%) high severe
    Benchmarking snapshot/file/trace/50MiB: Warming up for 3.0000 s
    Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 10.6s, or reduce sample count to 40.
    snapshot/file/trace/50MiB
                            time:   [93.832 ms 94.086 ms 94.368 ms]
                            thrpt:  [529.84 MiB/s 531.43 MiB/s 532.87 MiB/s]
    Found 7 outliers among 100 measurements (7.00%)
      5 (5.00%) high mild
      2 (2.00%) high severe

    writer/log/mem_sync     time:   [39.419 ns 40.356 ns 41.133 ns]
    Found 2 outliers among 100 measurements (2.00%)
      2 (2.00%) low mild
    writer/log/file_sync    time:   [18.324 ms 18.551 ms 18.823 ms]
    Found 6 outliers among 100 measurements (6.00%)
      6 (6.00%) high severe

    writer/log/mem/50MiB    time:   [6.5780 ms 6.6923 ms 6.8125 ms]
                            thrpt:  [7.1675 GiB/s 7.2962 GiB/s 7.4230 GiB/s]
    Found 1 outliers among 100 measurements (1.00%)
      1 (1.00%) high severe
    Benchmarking writer/log/file/50MiB: Warming up for 1.0000 s
    Warning: Unable to complete 100 samples in 1.0s. You may wish to increase target time to 4.3s, or reduce sample count to 20.
    writer/log/file/50MiB   time:   [41.201 ms 41.862 ms 42.560 ms]
                            thrpt:  [1.1473 GiB/s 1.1664 GiB/s 1.1851 GiB/s]
    Found 15 outliers among 100 measurements (15.00%)
      2 (2.00%) low severe
      2 (2.00%) low mild
      8 (8.00%) high mild
      3 (3.00%) high severe

    writer/encode_batch/unsealed/50MiB
                            time:   [19.726 ms 20.059 ms 20.402 ms]
                            thrpt:  [2.3933 GiB/s 2.4342 GiB/s 2.4753 GiB/s]
    writer/encode_batch/trace/50MiB
                            time:   [19.564 ms 19.819 ms 20.092 ms]
                            thrpt:  [2.4302 GiB/s 2.4637 GiB/s 2.4959 GiB/s]
    Found 13 outliers among 100 measurements (13.00%)
      13 (13.00%) high mild

    writer/blob_cache_set_unsealed_batch/file_unsorted/50MiB
                            time:   [63.956 ms 64.511 ms 65.203 ms]
                            thrpt:  [766.83 MiB/s 775.06 MiB/s 781.79 MiB/s]
    Found 1 outliers among 10 measurements (10.00%)
      1 (10.00%) high mild
    Benchmarking writer/blob_cache_set_unsealed_batch/mem_unsorted/50MiB: Warming up for 1.0000 s
    Warning: Unable to complete 10 samples in 1.0s. You may wish to increase target time to 1.4s or enable flat sampling.
    writer/blob_cache_set_unsealed_batch/mem_unsorted/50MiB
                            time:   [32.449 ms 32.930 ms 33.750 ms]
                            thrpt:  [1.4468 GiB/s 1.4828 GiB/s 1.5048 GiB/s]
    Found 2 outliers among 10 measurements (20.00%)
      1 (10.00%) low severe
      1 (10.00%) high mild

    Benchmarking writer/indexed_drain/mem_sorted/50MiB: Warming up for 3.0000 s
    Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 5.9s or enable flat sampling.
    writer/indexed_drain/mem_sorted/50MiB
                            time:   [91.524 ms 109.44 ms 117.71 ms]
                            thrpt:  [424.79 MiB/s 456.89 MiB/s 546.30 MiB/s]
    Benchmarking writer/indexed_drain/mem_unsorted/50MiB: Warming up for 3.0000 s
    Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 7.9s or enable flat sampling.
    writer/indexed_drain/mem_unsorted/50MiB
                            time:   [105.28 ms 115.92 ms 120.74 ms]
                            thrpt:  [414.11 MiB/s 431.34 MiB/s 474.93 MiB/s]
    Benchmarking writer/indexed_drain/file_sorted/50MiB: Warming up for 3.0000 s
    Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 8.6s or enable flat sampling.
    writer/indexed_drain/file_sorted/50MiB
                            time:   [143.87 ms 144.90 ms 146.49 ms]
                            thrpt:  [341.32 MiB/s 345.06 MiB/s 347.53 MiB/s]
    Found 3 outliers among 10 measurements (30.00%)
      1 (10.00%) low mild
      1 (10.00%) high mild
      1 (10.00%) high severe
    writer/indexed_drain/file_unsorted/50MiB
                            time:   [148.95 ms 151.90 ms 154.85 ms]
                            thrpt:  [322.89 MiB/s 329.16 MiB/s 335.67 MiB/s]

Cleaning up all the "Warning: Unable to complete 10 samples" messages is
left as a followup.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

I'm about to add s3 variants of some of our benchmarks and the organic structure was bugging me :).

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
