### PR TITLE
persist: add s3 variants of a couple key benchmarks

### DIFF
--- a/src/persist/benches/benches.rs
+++ b/src/persist/benches/benches.rs
@@ -17,6 +17,7 @@ mod writer;
 pub fn bench_persist(c: &mut Criterion) {
     let data = DataGenerator::default();
 
+    end_to_end::bench_load(&data, &mut c.benchmark_group("end_to_end/load"));
     end_to_end::bench_replay(&data, &mut c.benchmark_group("end_to_end/replay"));
 
     snapshot::bench_mem(&data, &mut c.benchmark_group("snapshot/mem"));

--- a/src/persist/benches/end_to_end.rs
+++ b/src/persist/benches/end_to_end.rs
@@ -11,6 +11,7 @@
 //! we can ingest it.
 
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use criterion::measurement::{Measurement, WallTime};
 use criterion::{Bencher, BenchmarkGroup, BenchmarkId, Throughput};
@@ -18,10 +19,12 @@ use differential_dataflow::operators::Count;
 use differential_dataflow::AsCollection;
 use ore::cast::CastFrom;
 use ore::metrics::MetricsRegistry;
+use persist::s3::{S3Blob, S3BlobConfig};
 use timely::dataflow::operators::Map;
 use timely::dataflow::ProbeHandle;
 use timely::progress::Antichain;
 use timely::Config;
+use tokio::runtime::Runtime as AsyncRuntime;
 
 use persist::client::RuntimeClient;
 use persist::error::{Error, ErrorLog};
@@ -31,30 +34,65 @@ use persist::runtime::{self, RuntimeConfig};
 use persist::storage::{Blob, LockInfo};
 use persist::workload::{self, DataGenerator};
 
+pub fn bench_load(data: &DataGenerator, g: &mut BenchmarkGroup<'_, WallTime>) {
+    let config =
+        futures_executor::block_on(S3BlobConfig::new_for_test()).expect("failed to load s3 config");
+    let config = match config {
+        Some(config) => config,
+        None => return,
+    };
+
+    g.throughput(Throughput::Bytes(data.goodput_bytes()));
+    g.bench_function(BenchmarkId::new("s3", data.goodput_pretty()), move |b| {
+        b.iter(|| bench_load_s3_one_iter(&data, &config))
+    });
+}
+
+// NB: This makes sure to start a new runtime for each iter to ensure the work
+// done in each is as equal as possible.
+fn bench_load_s3_one_iter(data: &DataGenerator, config: &S3BlobConfig) -> Result<(), Error> {
+    let async_runtime = Arc::new(AsyncRuntime::new()?);
+
+    let config = config.clone_with_new_uuid_prefix();
+    let async_guard = async_runtime.enter();
+    let s3_blob =
+        S3Blob::open_exclusive(config, LockInfo::new_no_reentrance("bench_load_s3".into()))?;
+    drop(async_guard);
+
+    let mut runtime = runtime::start(
+        RuntimeConfig::default(),
+        ErrorLog,
+        s3_blob,
+        build_info::DUMMY_BUILD_INFO,
+        &MetricsRegistry::new(),
+        None,
+    )?;
+    let (write, _read) = runtime.create_or_load("end_to_end");
+    workload::load(&write, &data, true)?;
+    runtime.stop()
+}
+
 pub fn bench_replay(data: &DataGenerator, g: &mut BenchmarkGroup<'_, WallTime>) {
     g.throughput(Throughput::Bytes(data.goodput_bytes()));
-    g.bench_function(
-        BenchmarkId::new("replay", data.goodput_pretty()),
-        move |b| {
-            let temp_dir = tempfile::tempdir().expect("failed to create temp directory");
-            let nonce = "end_to_end".to_string();
-            let collection_name = "end_to_end".to_string();
-            let mut runtime = create_runtime(temp_dir.path(), &nonce).expect("missing runtime");
-            let (write, _read) = runtime.create_or_load(&collection_name);
-            workload::load(&write, &data, true).expect("error writing data");
-            let expected_frontier = u64::cast_from(data.record_count);
-            runtime.stop().expect("runtime shut down cleanly");
+    g.bench_function(BenchmarkId::new("file", data.goodput_pretty()), move |b| {
+        let temp_dir = tempfile::tempdir().expect("failed to create temp directory");
+        let nonce = "end_to_end".to_string();
+        let collection_name = "end_to_end".to_string();
+        let mut runtime = create_runtime(temp_dir.path(), &nonce).expect("missing runtime");
+        let (write, _read) = runtime.create_or_load(&collection_name);
+        workload::load(&write, &data, true).expect("error writing data");
+        let expected_frontier = u64::cast_from(data.record_count);
+        runtime.stop().expect("runtime shut down cleanly");
 
-            bench_read_persisted_source(
-                1,
-                temp_dir.path().to_path_buf(),
-                nonce,
-                collection_name,
-                expected_frontier,
-                b,
-            )
-        },
-    );
+        bench_read_persisted_source(
+            1,
+            temp_dir.path().to_path_buf(),
+            nonce,
+            collection_name,
+            expected_frontier,
+            b,
+        )
+    });
 }
 
 fn bench_read_persisted_source<M: Measurement>(

--- a/src/persist/s3_test_env_mz.sh
+++ b/src/persist/s3_test_env_mz.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# Set up the materialize autodeleting s3 bucket env vars. External developers
+# will have to use thier own autodeleting bucket and export the same env vars.
+
+export MZ_PERSIST_EXTERNAL_STORAGE_TEST_S3_BUCKET="mtlz-test-persist-1d-lifecycle-delete"
+export AWS_DEFAULT_REGION="us-east-2"
+export AWS_PROFILE="mz-scratch-admin"

--- a/src/persist/src/indexed/cache.rs
+++ b/src/persist/src/indexed/cache.rs
@@ -96,7 +96,10 @@ impl<B: BlobRead> BlobCache<B> {
     /// This method is idempotent. Returns true if the blob had not
     /// previously been closed.
     pub fn close(&mut self) -> Result<bool, Error> {
-        block_on(self.blob.lock()?.close())
+        let async_guard = self.async_runtime.enter();
+        let ret = block_on(self.blob.lock()?.close());
+        drop(async_guard);
+        ret
     }
 
     /// Synchronously fetches the batch for the given key.
@@ -271,7 +274,10 @@ impl<B: BlobRead> BlobCache<B> {
 
     /// Returns the list of keys known to the underlying [Blob].
     pub fn list_keys(&self) -> Result<Vec<String>, Error> {
-        block_on(self.blob.lock()?.list_keys())
+        let async_guard = self.async_runtime.enter();
+        let ret = block_on(self.blob.lock()?.list_keys());
+        drop(async_guard);
+        ret
     }
 }
 


### PR DESCRIPTION
Benchmark results on an m6i.8xlarge

    MZ_PERSIST_RECORD_COUNT=819200 MZ_PERSIST_RECORD_SIZE_BYTES=64 MZ_PERSIST_BATCH_MAX_COUNT=131072
    blob_set/s3/50MiB       time:   [759.33 ms 772.32 ms 788.59 ms]
                            thrpt:  [63.405 MiB/s 64.740 MiB/s 65.848 MiB/s]
    Found 1 outliers among 10 measurements (10.00%)
      1 (10.00%) high mild

    MZ_PERSIST_RECORD_COUNT=819200 MZ_PERSIST_RECORD_SIZE_BYTES=64 MZ_PERSIST_BATCH_MAX_COUNT=131072
    end_to_end/load_s3/50MiB
                            time:   [2.6896 s 2.7933 s 2.9051 s]
                            thrpt:  [17.211 MiB/s 17.900 MiB/s 18.590 MiB/s]

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
