### PR TITLE
ci: prune unpushed images before acquisition

### DIFF
--- a/ci/test/build.py
+++ b/ci/test/build.py
@@ -28,6 +28,8 @@ def main() -> None:
     # other build agents.
     print("--- Acquiring mzbuild images")
     deps = repo.resolve_dependencies(image for image in repo if image.publish)
+    for pruned in deps.retain_only_unpushed():
+        print(f"Skipping already-existing image {pruned.name}")
     deps.acquire()
     deps.push()
 

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -431,13 +431,6 @@ class Image:
                 if match:
                     self.depends_on.append(match.group(1).decode())
 
-    def env_var_name(self) -> str:
-        """Return the image name formatted for use in an environment variable.
-
-        The name is capitalized and all hyphens are replaced with underscores.
-        """
-        return self.name.upper().replace("-", "_")
-
     def docker_name(self, tag: str) -> str:
         """Return the name of the image on Docker Hub at the given tag."""
         return f"materialize/{self.name}:{tag}"


### PR DESCRIPTION
@petrosagg sending this one your way since I know you've poked at the build job in CI before.

----

This fixes one of my longest standing gripes with CI, which is that when
all images already exist (e.g. because no code has changed), the build
job still has to download all the existing images from Docker Hub.

This commit reworks the build job so that the only images downloaded are
those that are dependencies of other images that need to be built.

Fix #2695.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
