### PR TITLE
feature-benchmark: Allow scenarios to be run at multiple scales

### DIFF
--- a/ci/builder/requirements-dev.txt
+++ b/ci/builder/requirements-dev.txt
@@ -15,6 +15,7 @@ isort==5.10.1
 mypy==0.931
 numpy==1.22.1
 pandas==1.4.0
+parameterized==0.8.1
 pdoc3==0.10.0
 psutil==5.9.0
 # psycopg2 intentionally omitted. Use pg8000 from requirements-core.txt instead.

--- a/doc/developer/feature-benchmark.md
+++ b/doc/developer/feature-benchmark.md
@@ -225,6 +225,19 @@ Available `Action`s:
 * `Lambda(lambda e: e.RestartMz())` - restarts the Mz service
 
 
+## Running the same scenario with multiple times within the same run
+
+It is possible to use the python `parameterized` module to cause the same scenario to be executed multiple times. For example, with different scale factors:
+
+```
+@parameterized_class(
+    [{"SCALE": i} for i in [5,6,7,8]], class_name_func=Scenario.name_with_scale
+)
+class ScalingScenario(ScenarioBig):
+    def benchmark(self) -> MeasurementSource:
+        ...
+```
+
 ## Caveats and considerations
 
 * Aim for the query or queries being benchmarked to take around 1 second to execute. This allows the framework to perform several iterations without blowing up

--- a/misc/python/materialize/feature_benchmark/scenario.py
+++ b/misc/python/materialize/feature_benchmark/scenario.py
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0.
 
 from math import ceil
-from typing import List, Optional, Union
+from typing import Dict, List, Optional, Type, Union
 
 from materialize.feature_benchmark.action import Action, DummyAction, TdAction
 from materialize.feature_benchmark.measurement_source import MeasurementSource
@@ -42,6 +42,14 @@ class RootScenario:
 
     def n(self) -> int:
         return self._n
+
+    @staticmethod
+    def name_with_scale(cls: Type["Scenario"], num: int, params_dict: Dict) -> str:
+        """Return the name of the Senario including the scale.
+        Used for running multiple instances of the same scenario via the
+        parameterized python module.
+        """
+        return f"{cls.__name__}_scale_{params_dict['SCALE']}"
 
     def table_ten(self) -> TdAction:
         """Returns a Td() object that creates the 'ten' table"""


### PR DESCRIPTION
- Use the 'parameterized' module to allow a scenario to be run
  multiple times within a single benchmark run -- at multiple scales
  or with some other variation.

- Add documentation and an example scenario that uses this functionality.

### Motivation

  * This PR adds a feature that has not yet been specified.

This was needed to visualize a scalability issue that was observed with materialized sources.