### PR TITLE
feature-benchmark: give time for Mz to settle in the KafkaRecovery sc…

### DIFF
--- a/test/feature-benchmark/scenarios.py
+++ b/test/feature-benchmark/scenarios.py
@@ -670,6 +670,10 @@ $ kafka-ingest format=avro topic=kafka-recovery key-format=avro key-schema=${{ke
 # Make sure we are fully caught up before continuing
 > SELECT COUNT(*) FROM s1;
 {self.n()}
+
+# Give time for any background tasks (e.g. compaction) to settle down
+> SELECT mz_internal.mz_sleep(10)
+<null>
 """
         )
 


### PR DESCRIPTION
…enario

Sleep 10 seconds after ingesting all the data before starting the
actual benchmarking sequence. Apparently killing Mz too soon after
ingestion has completed causes the measured restart times to exhibit
extreme variability.

### Motivation

  * This PR fixes a previously unreported bug.

As seen in https://github.com/MaterializeInc/materialize/pull/9602#issuecomment-1022853539 and following comments apparently killing Mz too soon after ingesting the initial data causes extreme variability in the recovery times.