### PR TITLE
 persist,sources: allow compaction on persisted sources

### DIFF
--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -171,6 +171,8 @@ pub struct StorageState {
     pub ts_histories: HashMap<GlobalId, TimestampBindingRc>,
     /// Metrics reported by all dataflows.
     pub metrics: Metrics,
+    /// Frontier up to which each source is allowed to compact its data.
+    pub allowed_compaction_frontiers: HashMap<GlobalId, Rc<RefCell<Antichain<Timestamp>>>>,
     /// Frontier of sink writes (all subsequent writes will be at times at or
     /// equal to this frontier)
     pub sink_write_frontiers: HashMap<GlobalId, Rc<RefCell<Antichain<Timestamp>>>>,

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -146,6 +146,7 @@ pub fn serve(config: Config) -> Result<(Server, LocalClient), anyhow::Error> {
                 local_inputs: HashMap::new(),
                 ts_source_mapping: HashMap::new(),
                 ts_histories: HashMap::default(),
+                allowed_compaction_frontiers: HashMap::default(),
                 sink_write_frontiers: HashMap::new(),
                 metrics,
                 persist: None,
@@ -1033,6 +1034,15 @@ where
                     if let Some(ts_history) = self.storage_state.ts_histories.get_mut(&id) {
                         ts_history.set_compaction_frontier(frontier.borrow());
                     }
+
+                    if let Some(allowed_compaction_frontier) =
+                        self.storage_state.allowed_compaction_frontiers.get_mut(&id)
+                    {
+                        let mut allowed_compaction_frontier =
+                            allowed_compaction_frontier.borrow_mut();
+                        allowed_compaction_frontier.clear();
+                        allowed_compaction_frontier.extend(frontier);
+                    }
                 }
             }
             StorageCommand::DropSourceTimestamping { id } => {
@@ -1049,6 +1059,11 @@ where
 
                 self.reported_frontiers.remove(&id);
                 self.reported_bindings_frontiers.remove(&id);
+
+                let prev = self.storage_state.allowed_compaction_frontiers.remove(&id);
+                if prev.is_none() {
+                    tracing::debug!("Attempted to drop timestamping for source {} that was not previously known", id);
+                }
             }
         }
     }


### PR DESCRIPTION
Updated version of #9981, and alternative (again) to #10258 (which was meant to be an alternative... :sweat_smile:).

The idea behind this is:
 - keep track of what compaction the coordinator allows in `StorageState`
 - received `AllowSourceCompaction` commands update that compaction frontier
 - pass a `Rc<RefCell<>>>` to that frontier to an operator that also
   looks at its input frontier and allows compaction to the combination
   (aka "minimum", or "meet") of those two

An alternative solution would be to invoke `allow_compaction()` upon
receipt of the `AllowSourceCompaction` message. This would, however,
require that we allow async in the command handling code, or to start a
new thread for doing the `allow_compaction` call. Otherwise, we would
block the dataflow worker thread.

With the chosen solution we only need to update the allowed frontier
centrally and the rendering code that then allows compaction can be
tailored to the rendered source.

Fixes #9508

### Tips/Notes for reviewer

I revived this alternative because the problem of how to send off the `allow_compaction()` message in the command handling code (as mentioned above). This version has the simple properties that
 - the coordinator allowing compaction is just updating the `Antichain`
 - the operator does compaction whenever it is scheduled (and the frontiers advanced) which seems to fit nicely with the timely nature/scheduling of the system

### Checklist

I would add unit tests, and trust the combination of this PR plus the aforementioned PRs that add `as_of` checks together with Philip's persistence tests to cover this change.

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).