### PR TITLE
mzbuild: perform inline graph traversal when acquiring deps

### DIFF
--- a/ci/test/build.py
+++ b/ci/test/build.py
@@ -23,15 +23,11 @@ def main() -> None:
     repo = mzbuild.Repository(Path("."))
     workspace = cargo.Workspace(repo.root)
 
-    # Acquire all the mzbuild images in the repository, while pushing any
-    # images that we build to Docker Hub, where they will be accessible to
-    # other build agents.
+    # Build and push any images that are not already available on Docker Hub,
+    # so they are accessible to other build agents.
     print("--- Acquiring mzbuild images")
     deps = repo.resolve_dependencies(image for image in repo if image.publish)
-    for pruned in deps.retain_only_unpushed():
-        print(f"Skipping already-existing image {pruned.name}")
-    deps.acquire()
-    deps.push()
+    deps.ensure()
 
     print("--- Staging Debian package")
     if os.environ["BUILDKITE_BRANCH"] == "main":

--- a/misc/python/materialize/cli/mzimage.py
+++ b/misc/python/materialize/cli/mzimage.py
@@ -30,9 +30,7 @@ def main() -> int:
             return 1
         deps = repo.resolve_dependencies([repo.images[args.image]])
         rimage = deps[args.image]
-        if args.command == "build":
-            deps.acquire(force_build=True)
-        elif args.command == "run":
+        if args.command == "run":
             deps.acquire()
             rimage.run(args.image_args)
         elif args.command == "acquire":
@@ -89,10 +87,6 @@ def _parse_args() -> argparse.Namespace:
         "list",
         description="List all images in this repository.",
         help="list all images",
-    )
-
-    add_image_subcommand(
-        "build", description="Unconditionally build an image.", help="build an image"
     )
 
     add_image_subcommand(


### PR DESCRIPTION
@petrosagg this is what you meant, right? If so, and if it actually works, 🙌🏽 thanks very much for the suggestion.

----

Per @petrosagg's code review on #10267, mzbuild gets much simpler if we
memoize dependency acquisition and perform a much simpler graph
traversal inline in `ResolvedImage.acquire`.

The one casualty here is the `force_build` parameter to
DependencySet.acquire. That existed only to support `mzimage build`,
which was not particularly important. We could add this back with not
too much effort, but didn't seem worth it at the moment.


### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
