### PR TITLE
docs on how to use `tokio-console`

### DIFF
--- a/doc/developer/guide-tokio-console.md
+++ b/doc/developer/guide-tokio-console.md
@@ -1,0 +1,47 @@
+# Developer guide: `tokio-console`
+
+This guide details how to run `tokio-console` with `materialized`
+
+## Overview
+
+First, install `tokio-console`:
+
+```
+cargo install tokio-console
+```
+
+Then run `materialized` with the `console-subscriber` on:
+
+```
+RUSTFLAGS="--cfg tokio_unstable" cargo run --features tokio-console -- --dev --tokio-console
+```
+
+(note that this may slow down `materialized` a lot, as it increases the amount of tracing by a lot,
+and may inadvertently turn on debug logging for `rdkafka`)
+
+The, in a different tmux pane/terminal, run:
+
+```
+tokio-console
+```
+
+This [README] has some docs on how to navigate the ui.
+
+[README]: https://github.com/tokio-rs/console/tree/main/tokio-console
+
+### Notes on compilation times:
+
+`RUSTFLAGS="--cfg tokio_unstable"` forces a recompilation of our entire dependency tree.
+Note that this also clashes with the compilation cache that `rust-analyzer` uses, and may
+cause regular recompilations. To avoid this, you can add:
+
+```
+[build]
+rustflags = ["--cfg", "tokio_unstable"]
+```
+
+to our [cargo config] temporarily, or your cargo config in `$HOME`, which can make RA and cargo use the same flags.
+Please be careful to not add it under the `x86_64-unknown-linux-gnu` target section if you
+aren't running on that target (i.e. you are using a macbook).
+
+[cargo config]: https://github.com/MaterializeInc/materialize/blob/main/.cargo/config

--- a/doc/developer/style.md
+++ b/doc/developer/style.md
@@ -106,6 +106,21 @@ macros, and type definitions) should have rustdoc examples. This is a great
 standard for libraries, but total overkill for a fast-moving startup like
 Materialize.</small>
 
+### Tokio-specific
+
+You should use the `spawn` and `spawn_blocking` functions in the [`ore::task`]
+module as opposed to the native. There is also a [`RuntimeExt`] trait that adds
+`spawn_named` and `spawn_blocking_named` to [`Arc<Runtime>`] and [`Handle`] from `tokio`.
+They are named different as to avoid clashing with inherent methods.
+
+These functions require a closure that produces a _name_ for the task, to improve the use of
+[`tokio-console`]
+
 [Clippy]: https://github.com/rust-lang/rust-clippy
 [rustfmt]: https://github.com/rust-lang/rustfmt
 [rust-api]: https://rust-lang.github.io/api-guidelines/
+[`ore::task`]: https://github.com/MaterializeInc/materialize/blob/a9f51618c950f3a1c22ce4e6096e7d1d8babe6d5/src/ore/src/task.rs
+[`RuntimeExt`]: https://github.com/MaterializeInc/materialize/blob/a9f51618c950f3a1c22ce4e6096e7d1d8babe6d5/src/ore/src/task.rs#L94
+[`Handle`]: https://docs.rs/tokio/latest/tokio/runtime/struct.Handle.html
+[`Arc<Runtime>`]: https://docs.rs/tokio/latest/tokio/runtime/struct.Runtime.html
+[`tokio-console`]: /doc/developer/guide-tokio-console.md


### PR DESCRIPTION
I realized I never committed a guide on how to use this. This is a quick and dirty one, as well as some style changes (however, I will add a clippy `disallowed_method` lint in another pr soon!

### Motivation

  * This pr adds developer docs


### Checklist

- N/A This PR has adequate test coverage / QA involvement has been duly considered.
- N/A This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
