### PR TITLE
Fix release load test for new default workflow

### DIFF
--- a/demo/chbench/mzcompose.py
+++ b/demo/chbench/mzcompose.py
@@ -85,7 +85,7 @@ def workflow_load_test(c: Composition) -> None:
     """Run CH-benCHmark with a selected amount of load against Materialize."""
     c.up("prometheus-sql-exporter")
     c.workflow(
-        "demo",
+        "default",
         "--peek-conns=1",
         "--mz-views=q01,q02,q05,q06,q08,q09,q12,q14,q17,q19",
         "--transactional-threads=2",


### PR DESCRIPTION
When updating all compositions to have a "default" workflow I missed that the chbench release test referred to the default workflow by name.

### Motivation

* This PR fixes a previously unreported bug.

### Checklist

- [n/a] This PR has adequate test coverage / QA involvement has been duly considered.
- [n/a] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).