### PR TITLE
fix basic auth for ccsr

### DIFF
--- a/src/sql/src/kafka_util.rs
+++ b/src/sql/src/kafka_util.rs
@@ -521,6 +521,8 @@ pub fn generate_ccsr_client_config(
     let mut ccsr_options = extract(
         ccsr_options,
         &[
+            Config::string("username"),
+            Config::string("password"),
             // An old migration
             // (https://github.com/MaterializeInc/materialize/blob/c402917b7078a14bc0d0d6330b9c9b177aa73e47/src/coord/src/catalog/migrate.rs#L362)
             // adds this field to kafka-avro WITH options, though now in the CSR case,


### PR DESCRIPTION
In https://github.com/MaterializeInc/materialize/pull/10129 I removed these, thinking they were unnecessary. The code continued to typecheck, but in reality, `username` and `password` will be correctly removed from `ccsr_options`, but not removed when they are actually used to build an `auth(...)` call below. 

This is untestable, as we don't have a way of testing basic auth for ccsr. I am working on that, but want to match the previous behavior for now, as we release

### Motivation

- fix a previously unreported bug