### PR TITLE
fix the ability to make a patch rc in mkrelease

### DIFF
--- a/misc/python/materialize/cli/mkrelease.py
+++ b/misc/python/materialize/cli/mkrelease.py
@@ -60,7 +60,7 @@ def cli() -> None:
 @OPT_AFFECT_REMOTE
 @click.argument(
     "level",
-    type=click.Choice(["major", "feature", "weekly", "rc"]),
+    type=click.Choice(["major", "weekly", "patch", "rc"]),
 )
 def new_rc(
     create_branch: Optional[str],


### PR DESCRIPTION
<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation


  * This PR fixes a previously unreported bug.

When we changed the names of the release types, the possible choices got out of sync; fix them.

### Checklist

- [n/a] This PR has adequate test coverage / QA involvement has been duly considered.
- [n/a] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
