### PR TITLE
deps: bump to protobuf-src v1.0.5+3.19.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4083,9 +4083,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf-src"
-version = "1.0.4+3.19.1"
+version = "1.0.5+3.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "152161ab96ab8f66c4faeda5179798cc03a6c55c653d314d0e6d2f3ae7a46f1f"
+checksum = "fe57f68bf9767f48f8cbcbceb5da21524e2b1330a821c1c2502c447d8043f078"
 dependencies = [
  "autotools",
 ]


### PR DESCRIPTION
The regenerated configury might fix a build problem on M1 Macs.


### Motivation

  * This PR fixes a previously unreported bug: build is failing on @elindsey's M1 Mac.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
