### PR TITLE
persist: make MultiWriteHandle construction infallible

### DIFF
--- a/src/coord/src/persistcfg.rs
+++ b/src/coord/src/persistcfg.rs
@@ -445,7 +445,7 @@ pub struct TablePersistDetails {
     pub write_handle: StreamWriteHandle<Row, ()>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct TablePersistMultiDetails {
     pub all_table_ids: Vec<PersistId>,
     pub write_handle: MultiWriteHandle,

--- a/src/persist/src/runtime.rs
+++ b/src/persist/src/runtime.rs
@@ -708,7 +708,7 @@ mod tests {
         // Verify that we can atomically write to streams with mismatched types.
         let (c1s3, c1s3_read) = client1.create_or_load::<String, ()>("3");
         let (c1s4, c1s4_read) = client1.create_or_load::<(), String>("4");
-        let mut multi = MultiWriteHandle::new(&c1s3)?;
+        let mut multi = MultiWriteHandle::new(&c1s3);
         multi.add_stream(&c1s4)?;
         multi
             .write_atomic(|b| {


### PR DESCRIPTION
We need to make this infallible so that we can create them during dataflow
construction, which has to be infallible/deterministic.

### Tips for reviewer

There are TODOs/remarks in the code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
