### PR TITLE
sql: support casting 1D arrays to 1D lists

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -120,6 +120,8 @@ changes that have not yet been documented.
 
 - Add the `array_cat` function.
 
+- Support casting [`array`] types to [`list`] types.
+
 {{< comment >}}
 Only add new release notes above this line.
 

--- a/doc/user/content/sql/types/array.md
+++ b/doc/user/content/sql/types/array.md
@@ -132,15 +132,31 @@ Array element | Catalog name | OID
 
 ### Valid casts
 
-You can [cast](/sql/functions/cast) all array types to
-[`text`](/sql/types/text) by assignment.
-
+You can [cast](/sql/functions/cast) all array types to:
+- [`text`](../text) (by assignment)
+- [`list`](../list) (explicit)
 
 {{< version-added v0.7.4 >}}
 You can cast `text` to any array type. The input must conform to the [textual
 format](#textual-format) described above, with the additional restriction that
 you cannot yet use a cast to construct a multidimensional array.
 {{< /version-added >}}
+
+### Array to `list` casts
+
+You can cast any type of array to a list of the same element type, as long as
+the array has only 0 or 1 dimensions, i.e. you can cast `integer[]` to `integer
+list`, as long as the array is empty or does not contain any arrays itself. Note
+that Materialize does not provide support for multi-dimensional arrays, so the
+latter condition is already impossible, but this requirement is unlikely to
+change even if Materialize does eventually support multi-dimensional arrays.
+
+```sql
+SELECT pg_typeof('{1,2,3}`::integer[]::integer list);
+```
+```
+integer list
+```
 
 ## Examples
 

--- a/doc/user/content/sql/types/list.md
+++ b/doc/user/content/sql/types/list.md
@@ -475,7 +475,8 @@ You can [cast](../../functions/cast) `list` to:
 
 You can [cast](../../functions/cast) the following types to `list`:
 
-- [`text`](../text)(explicitly). See [details](#text-to-list-casts).
+- [arrays](../array) (explicitly). See [details](../array#array-to-list-casts).
+- [`text`](../text) (explicitly). See [details](#text-to-list-casts).
 - Other `lists` as noted above.
 
 ### Known limitations

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -3237,6 +3237,7 @@ pub enum UnaryFunc {
         // The expression to cast List1's elements to List2's elements' type
         cast_expr: Box<MirScalarExpr>,
     },
+    CastArrayToListOneDim(CastArrayToListOneDim),
     CastMapToString {
         ty: ScalarType,
     },
@@ -3425,6 +3426,7 @@ derive_unary!(
     CastStringToVarChar,
     CastCharToString,
     CastUuidToString,
+    CastArrayToListOneDim,
     Cos,
     Cosh,
     Sin,
@@ -3597,6 +3599,7 @@ impl UnaryFunc {
             | CastIntervalToTime(_)
             | NegInterval(_)
             | CastUuidToString(_)
+            | CastArrayToListOneDim(_)
             | CastTimestampToString(_)
             | CastTimestampTzToString(_)
             | CastTimestampToDate(_)
@@ -3799,6 +3802,7 @@ impl UnaryFunc {
             | CastIntervalToTime(_)
             | NegInterval(_)
             | CastUuidToString(_)
+            | CastArrayToListOneDim(_)
             | CastTimestampToString(_)
             | CastTimestampTzToString(_)
             | CastTimestampToDate(_)
@@ -4034,6 +4038,7 @@ impl UnaryFunc {
             | CastIntervalToTime(_)
             | NegInterval(_)
             | CastUuidToString(_)
+            | CastArrayToListOneDim(_)
             | CastTimestampToString(_)
             | CastTimestampTzToString(_)
             | CastTimestampToDate(_)
@@ -4285,6 +4290,7 @@ impl UnaryFunc {
             | CastIntervalToTime(_)
             | NegInterval(_)
             | CastUuidToString(_)
+            | CastArrayToListOneDim(_)
             | CastTimestampToString(_)
             | CastTimestampTzToString(_)
             | CastTimestampToDate(_)
@@ -5733,6 +5739,7 @@ mod test {
         let mut rti = lowertest::ReflectedTypeInfo::default();
         UnaryFunc::add_to_reflected_type_info(&mut rti);
         for (variant, (_, f_types)) in rti.enum_dict["UnaryFunc"].iter() {
+            println!("f_types {:?}", f_types);
             if f_types.is_empty() {
                 let unary_unit_variant: UnaryFunc =
                     serde_json::from_str(&format!("\"{}\"", variant)).unwrap();

--- a/src/expr/src/scalar/func/impls.rs
+++ b/src/expr/src/scalar/func/impls.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+mod array;
 mod boolean;
 mod byte;
 mod char;
@@ -27,6 +28,7 @@ mod timestamp;
 mod uuid;
 mod varchar;
 
+pub use self::array::*;
 pub use self::char::*;
 pub use self::uuid::*;
 pub use boolean::*;

--- a/src/expr/src/scalar/func/impls/array.rs
+++ b/src/expr/src/scalar/func/impls/array.rs
@@ -1,0 +1,79 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use lowertest::MzReflect;
+use repr::{ColumnType, Datum, RowArena, ScalarType};
+
+use crate::scalar::func::LazyUnaryFunc;
+use crate::{EvalError, MirScalarExpr};
+
+#[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
+pub struct CastArrayToListOneDim;
+
+impl LazyUnaryFunc for CastArrayToListOneDim {
+    fn eval<'a>(
+        &'a self,
+        datums: &[Datum<'a>],
+        temp_storage: &'a RowArena,
+        a: &'a MirScalarExpr,
+    ) -> Result<Datum<'a>, EvalError> {
+        let a = a.eval(datums, temp_storage)?;
+        if a.is_null() {
+            return Ok(Datum::Null);
+        }
+
+        let arr = a.unwrap_array();
+        let ndims = arr.dims().ndims();
+        if ndims > 1 {
+            return Err(EvalError::Unsupported {
+                feature: format!(
+                    "casting multi-dimensional array to list; got array with {} dimensions",
+                    ndims
+                ),
+                issue_no: None,
+            });
+        }
+
+        Ok(Datum::List(arr.elements()))
+    }
+
+    /// The output ColumnType of this function
+    fn output_type(&self, input_type: ColumnType) -> ColumnType {
+        ScalarType::List {
+            element_type: Box::new(input_type.scalar_type.unwrap_array_element_type().clone()),
+            custom_oid: None,
+        }
+        .nullable(true)
+    }
+
+    /// Whether this function will produce NULL on NULL input
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+
+    /// Whether this function will produce NULL on non-NULL input
+    fn introduces_nulls(&self) -> bool {
+        false
+    }
+
+    /// Whether this function preserves uniqueness
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+
+impl fmt::Display for CastArrayToListOneDim {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("arraytolist")
+    }
+}

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -398,6 +398,7 @@ lazy_static! {
                 let ty = from_type.clone();
                 Some(|e: HirScalarExpr| e.call_unary(CastArrayToString { ty }))
             }),
+            (Array, List) => Explicit: CastArrayToListOneDim(func::CastArrayToListOneDim),
 
             // LIST
             (List, String) => Assignment: CastTemplate::new(|_ecx, _ccx, from_type, _to_type| {

--- a/test/sqllogictest/list.slt
+++ b/test/sqllogictest/list.slt
@@ -2532,3 +2532,37 @@ query T
 SELECT list_remove(LIST[[1,2],[1],[1,2,3],LIST[1]], LIST[1,2,3])::text
 ----
 {{1,2},{1},{1}}
+
+# array to list
+query T
+SELECT '{1,2,3}'::int[]::int list::text;
+----
+{1,2,3}
+
+query T
+SELECT pg_typeof('{1,2,3}'::int[]::int list);
+----
+integer list
+
+query T
+SELECT '{}'::int[]::int list::text;
+----
+{}
+
+query T
+SELECT pg_typeof('{1,2,3}'::int[]::int list);
+----
+integer list
+
+query T
+SELECT NULL::int[]::int list::text;
+----
+NULL
+
+query T
+SELECT pg_typeof(NULL::int[]::int list);
+----
+integer list
+
+query error invalid input syntax for type array: parsing multi-dimensional arrays is not supported
+SELECT '{{1},{2},{3}}'::int[]::int list::text;


### PR DESCRIPTION
Some apprehension about our lack of support for arrays has stemmed from the fact that we couldn't previously support moving from arrays to lists, so this PR adds that feature.

### Motivation

 This PR adds a known-desirable feature; not documented but discussed with @andrioni 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
