### PR TITLE
[sql] add a migration to remove extraneous confluent_wire_format WITH parameter

### DIFF
--- a/src/sql/src/kafka_util.rs
+++ b/src/sql/src/kafka_util.rs
@@ -520,16 +520,9 @@ pub fn generate_ccsr_client_config(
 
     let mut ccsr_options = extract(
         ccsr_options,
-        &[
-            Config::string("username"),
-            Config::string("password"),
-            // An old migration
-            // (https://github.com/MaterializeInc/materialize/blob/c402917b7078a14bc0d0d6330b9c9b177aa73e47/src/coord/src/catalog/migrate.rs#L362)
-            // adds this field to kafka-avro WITH options, though now in the CSR case,
-            // the field is unread and fixed to `true`
-            Config::new("confluent_wire_format", ValType::Boolean),
-        ],
+        &[Config::string("username"), Config::string("password")],
     )?;
+
     if let Some(username) = ccsr_options.remove("username") {
         client_config = client_config.auth(username, ccsr_options.remove("password"));
     }

--- a/test/upgrade/check-from-v0.7.1-schema-registry.td
+++ b/test/upgrade/check-from-v0.7.1-schema-registry.td
@@ -1,0 +1,17 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> SELECT * FROM data
+1
+
+# This next query will fail if a bug like #10234 occurs again, where a migration
+# injects a `WITH` option into the wrong spot.
+
+> SHOW CREATE SOURCE data
+"materialize.public.data" "CREATE SOURCE \"materialize\".\"public\".\"data\" FROM KAFKA BROKER 'kafka:9092' TOPIC 'testdrive-data-${testdrive.seed}' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://schema-registry:8081/' SEED VALUE SCHEMA '\"int\"'"

--- a/test/upgrade/create-in-v0.7.1-schema-registry.td
+++ b/test/upgrade/create-in-v0.7.1-schema-registry.td
@@ -1,0 +1,24 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set schema
+"int"
+
+$ kafka-create-topic topic=data
+
+$ kafka-ingest format=avro topic=data schema=${schema} publish=true
+1
+
+> CREATE MATERIALIZED SOURCE data
+  FROM KAFKA BROKER 'kafka:9092' TOPIC 'testdrive-data-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE NONE
+
+> SELECT * FROM data
+1


### PR DESCRIPTION
When I wrote https://github.com/MaterializeInc/materialize/pull/10129, the existence of https://github.com/MaterializeInc/materialize/blob/1fb88e45979d0c44cde4c51f7029febace460709/src/coord/src/catalog/migrate.rs#L362 meant that I had to `extract` `confluent_wire_format` and drop the `WITH` value.

As far as I can tell, this parameter is not longer used (I would love to have other people confirm this!), so this adds a migration to remove it from the catalog. It stacks on the old migration.

### Motivation

   * This PR fixes a recognized bug: #10234.

### Tips for reviewer

 I do not alter the `InlineSchema` change from the previous migration to minimize this change.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- N/A This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
