### PR TITLE
mzcompose: Raise an error if the same service is specified twice

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -221,7 +221,10 @@ class Composition:
                     self.workflows[name] = fn
 
             for python_service in getattr(module, "SERVICES", []):
-                compose["services"][python_service.name] = python_service.config
+                name = python_service.name
+                if name in compose["services"]:
+                    raise UIError(f"service {name!r} specified more than once")
+                compose["services"][name] = python_service.config
 
         # Add default volumes
         compose.setdefault("volumes", {}).update(


### PR DESCRIPTION
In an mzcompose.py file I was doing:

    TD = Testdrive(..no-settings..)
    TD_C = Testdrive(..complex-settings..)

    SERVICES = [TD, TD_C]

and forgot that I needed to include a `name` to separate the two, and getting
errors because the second testdrive wasn't using the settings I was specifying.

### Motivation

* This PR fixes a previously unreported bug.

### Checklist

- [n/a] This PR has adequate test coverage / QA involvement has been duly considered.
- [n/a] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).