### PR TITLE
mzcompose: Support specifying volumes in py files

### DIFF
--- a/doc/developer/mzcompose.md
+++ b/doc/developer/mzcompose.md
@@ -114,6 +114,30 @@ from materialize.mzcompose import PythonService
 SERVICES = [PythonService(image = "vendor/container")]
 ```
 
+## Dealing with volumes
+
+All compositions have a set of default volumes, but it is possible to add to these or completely replace them.
+
+Equivalently to the declaration of services via the `SERVICES` top-level constant, you may specify a `VOLUMES` variable to declare all volumes within a composition. This will overwrite the default volumes.
+
+You may instead specify `VOLUMES_EXTRA` to preserve the default volumes and add arbitrary extra volumes.
+
+The type of both `VOLUMES` and `VOLUMES` extra is a dict from name to optional volume spec, as a dict. See [the docker-compose docs][volumes-doc] for full details of possible values. Setting the value to `None` will create a named persistent volume which should be sufficient for most uses:
+
+```python
+SERVICES = [
+    Materialized(volumes=["unique-workdir:/share/mzdata"])
+]
+
+VOLUMES_EXTRA = {
+    "unique-workdir": None
+}
+```
+
+Note that you can specify at most one explicit volume declaration: either `volumes:` in `mzcompose.yml`, `VOLUMES`, or `VOLUMES_EXTRA`.
+
+[volumes-doc]: https://docs.docker.com/compose/compose-file/compose-file-v3/#volume-configuration-reference
+
 # Dealing with workflows
 
 A Python workflow is a Python function that contains the steps to execute as part of the workflow

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -223,6 +223,15 @@ class Composition:
             for python_service in getattr(module, "SERVICES", []):
                 compose["services"][python_service.name] = python_service.config
 
+            if volumes := getattr(module, "VOLUMES", None):
+                compose["volumes"] = volumes
+            if volumes_extra := getattr(module, "VOLUMES_EXTRA", None):
+                if "volumes" in compose:
+                    raise UIError(
+                        "VOLUMES_EXTRA cannot be set with other explicit volumes"
+                    )
+                compose["volumes"] = volumes_extra
+
         # Add default volumes
         compose.setdefault("volumes", {}).update(
             {


### PR DESCRIPTION
Currently if you want to specify volumes you are required to add an
mzcompose.yml file next to mzcompose.py.

With this, VOLUMES in mzcompose.py acts analogously to SERVICES, and
VOLUMES_EXTRA adds volumes in addition to the default volumes, but does not
work along with any other explicitly-set volumes.

### Motivation

* This PR adds a feature that has not yet been specified.

  Specifically, I need to be able to run materialized with two different sets of
  arguments in the same mzcompose file, which, because `up` doesn't take
  arguments for the underlying service, requires specifying a different service
  which has its own mzdata directory.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. Tested in #9894
- [n/a] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).