### PR TITLE
Make data-directory errors specify the dir that caused the error

### DIFF
--- a/src/pid-file/src/lib.rs
+++ b/src/pid-file/src/lib.rs
@@ -111,6 +111,7 @@ impl PidFile {
             if err.kind() == io::ErrorKind::AlreadyExists {
                 Err(Error::AlreadyRunning {
                     pid: (old_pid != -1).then(|| old_pid),
+                    workdir: path.as_ref().display().to_string(),
                 })
             } else {
                 Err(Error::Io(err))
@@ -151,6 +152,8 @@ pub enum Error {
     AlreadyRunning {
         /// The PID of the existing process, if it is known.
         pid: Option<i32>,
+        /// The directory that the current materialized process is trying to run in
+        workdir: String,
     },
 }
 
@@ -165,10 +168,11 @@ impl fmt::Display for Error {
         match self {
             Error::Io(e) => write!(f, "unable to open PID file: {}", e),
             Error::Nul(e) => write!(f, "PID file path contained null bytes: {}", e),
-            Error::AlreadyRunning { pid } => write!(
+            Error::AlreadyRunning { pid, workdir } => write!(
                 f,
-                "process already running (PID: {})",
-                pid.display_or("<unknown>")
+                "process already running (PID: {} data directory: {})",
+                pid.display_or("<unknown>"),
+                workdir
             ),
         }
     }

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -664,7 +664,11 @@ pub async fn create_state(
                 bail!("materialized catalog path is not a regular file");
             }
             Ok(_) => Some(path.to_path_buf()),
-            Err(e) => return Err(e).context("opening materialized catalog path"),
+            Err(e) => {
+                return Err(e).with_context(|| {
+                    format!("opening materialized catalog path '{}'", path.display())
+                })
+            }
         }
     } else {
         None


### PR DESCRIPTION
It is totally fine to run two different materialized's on the same machine if
they use different ports and data directories. If you accidentally run them in
the same directory you get a misleading error stating just that the other mz is
running, when the problem is also that it's running with the same workdir.

### Motivation

* This PR fixes a previously unreported bug.

### Checklist

- [n/a] This PR has adequate test coverage / QA involvement has been duly considered.
- [n/a] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).