### PR TITLE
[kafka eos sink] Enable disconnect and reconnect to kafka

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -265,6 +265,13 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: s3-resumption
 
+  - id: kafka-resumption
+    label: Kafka resumption tests
+    depends_on: build-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: kafka-resumption
+
   - id: kafka-exactly-once
     label: Kafka exactly-once tests
     depends_on: build-x86_64

--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -1079,7 +1079,7 @@ where
     // our internal state after the send loop
     let mut progress_update = None;
 
-    let shutdown_flush = AtomicBool::new(false);
+    let shutdown_flush = Cell::new(false);
 
     // We want exactly one worker to send all the data to the sink topic.
     let hashed_id = id.hashed();
@@ -1094,10 +1094,10 @@ where
                 debug!("shutting down sink: {}", &s.name);
 
                 // Approximately one last attempt to push anything pending to kafka before closing.
-                if !shutdown_flush.load(Ordering::Relaxed) {
+                if !shutdown_flush.get() {
                     debug!("flushing kafka producer for sink: {}", &s.name);
                     let _ = s.producer.flush().await;
-                    shutdown_flush.store(true, Ordering::Relaxed);
+                    shutdown_flush.set(true);
                 }
 
                 // Indicate that the sink is closed to everyone else who

--- a/test/kafka-multi-broker/mzcompose.py
+++ b/test/kafka-multi-broker/mzcompose.py
@@ -23,7 +23,9 @@ SERVICES = [
     Kafka(name="kafka1", broker_id=1, offsets_topic_replication_factor=2),
     Kafka(name="kafka2", broker_id=2, offsets_topic_replication_factor=2),
     Kafka(name="kafka3", broker_id=3, offsets_topic_replication_factor=2),
-    SchemaRegistry(kafka_servers=["kafka1", "kafka2", "kafka3"]),
+    SchemaRegistry(
+        kafka_servers=[("kafka1", "9092"), ("kafka2", "9092"), ("kafka3", "9092")]
+    ),
     Materialized(),
     Testdrive(
         entrypoint=[

--- a/test/kafka-resumption/cleanup.td
+++ b/test/kafka-resumption/cleanup.td
@@ -1,0 +1,14 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> DROP SINK output CASCADE;
+
+> DROP SOURCE input CASCADE;
+
+$ http-request method=DELETE url=http://toxiproxy:8474/proxies/kafka content-type=application/json

--- a/test/kafka-resumption/during.td
+++ b/test/kafka-resumption/during.td
@@ -1,0 +1,11 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ file-append path=dynamic.csv
+Brooklyn,NY,11217

--- a/test/kafka-resumption/mzcompose
+++ b/test/kafka-resumption/mzcompose
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# mzcompose — runs Docker Compose with Materialize customizations.
+
+exec "$(dirname "$0")/../../bin/mzcompose" "$@"

--- a/test/kafka-resumption/mzcompose.py
+++ b/test/kafka-resumption/mzcompose.py
@@ -36,19 +36,12 @@ SERVICES = [
 # Test the kafka sink resumption logic
 #
 def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
-    parser.add_argument(
-        "--seed",
-        help="an alternate seed to use to avoid clashing with existing topics",
-        type=int,
-        default=int(random.getrandbits(16)),
-    )
-    args = parser.parse_args()
-
     c.start_and_wait_for_tcp(
         services=["zookeeper", "kafka", "schema-registry", "materialized", "toxiproxy"]
     )
     c.wait_for_materialized()
 
+    seed = random.getrandbits(16)
     for i, failure_mode in enumerate(
         [
             "toxiproxy-close-connection.td",
@@ -59,8 +52,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             "testdrive-svc",
             "--no-reset",
             "--max-errors=1",
-            f"--seed={args.seed}{i}",
-            f"--temp-dir=/share/tmp/kafka-resumption-{args.seed}-{i}",
+            f"--seed={seed}{i}",
+            f"--temp-dir=/share/tmp/kafka-resumption-{seed}{i}",
             "setup.td",
             failure_mode,
             "during.td",

--- a/test/kafka-resumption/mzcompose.py
+++ b/test/kafka-resumption/mzcompose.py
@@ -1,0 +1,71 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+import random
+from os import environ
+from unittest.mock import patch
+
+from materialize.mzcompose import Composition, WorkflowArgumentParser
+from materialize.mzcompose.services import (
+    Kafka,
+    Materialized,
+    SchemaRegistry,
+    Testdrive,
+    Toxiproxy,
+    Zookeeper,
+)
+
+# Pick a non-default port to make sure nothing is accidentally going around the proxy
+KAFKA_SINK_PORT = 9091
+SERVICES = [
+    Zookeeper(),
+    Kafka(port=KAFKA_SINK_PORT),
+    SchemaRegistry(kafka_servers=[("kafka", f"{KAFKA_SINK_PORT}")]),
+    Materialized(),
+    Toxiproxy(),
+    Testdrive(kafka_url="toxiproxy:9093"),
+]
+
+#
+# Test the kafka sink resumption logic
+#
+def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
+    parser.add_argument(
+        "--seed",
+        help="an alternate seed to use to avoid clashing with existing topics",
+        type=int,
+        default=random.getrandbits(32),
+    )
+    args = parser.parse_args()
+
+    c.start_and_wait_for_tcp(
+        services=["zookeeper", "kafka", "schema-registry", "materialized", "toxiproxy"]
+    )
+    c.wait_for_materialized()
+
+    for i, failure_mode in enumerate(
+        [
+            "toxiproxy-close-connection.td",
+            "toxiproxy-timeout.td",
+        ]
+    ):
+        c.run(
+            "testdrive-svc",
+            "--no-reset",
+            "--max-errors=1",
+            f"--seed={args.seed}{i}",
+            f"--temp-dir=/share/tmp/kafka-resumption-{args.seed}-{i}",
+            "setup.td",
+            failure_mode,
+            "during.td",
+            "sleep.td",
+            "toxiproxy-restore-connection.td",
+            "verify-success.td",
+            "cleanup.td",
+        )

--- a/test/kafka-resumption/mzcompose.py
+++ b/test/kafka-resumption/mzcompose.py
@@ -40,7 +40,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         "--seed",
         help="an alternate seed to use to avoid clashing with existing topics",
         type=int,
-        default=random.getrandbits(32),
+        default=int(random.getrandbits(16)),
     )
     args = parser.parse_args()
 

--- a/test/kafka-resumption/setup.td
+++ b/test/kafka-resumption/setup.td
@@ -1,0 +1,33 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ http-request method=POST url=http://toxiproxy:8474/proxies content-type=application/json
+{
+  "name": "kafka",
+  "listen": "0.0.0.0:9093",
+  "upstream": "kafka:9091"
+}
+
+$ file-append path=dynamic.csv
+city,state,zip
+Rochester,NY,14618
+New York,NY,10004
+
+> CREATE SOURCE input
+  FROM FILE '${testdrive.temp-dir}/dynamic.csv'
+  WITH (tail=true)
+  FORMAT CSV WITH HEADER (city,state,zip)
+
+> CREATE SINK output FROM input
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-byo-sink-${testdrive.seed}'
+  WITH (reuse_topic=true)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+
+$ file-append path=dynamic.csv
+San Francisco,CA,94114

--- a/test/kafka-resumption/sleep.td
+++ b/test/kafka-resumption/sleep.td
@@ -1,0 +1,13 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# We need this length to be noticably longer than any internal
+# timeouts if we want this test to be informative.
+> SELECT mz_internal.mz_sleep(60);
+<null>

--- a/test/kafka-resumption/toxiproxy-close-connection.td
+++ b/test/kafka-resumption/toxiproxy-close-connection.td
@@ -1,0 +1,15 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ http-request method=POST url=http://toxiproxy:8474/proxies/kafka/toxics content-type=application/json
+{
+  "name": "kafka",
+  "type": "limit_data",
+  "attributes": { "bytes": 0 }
+}

--- a/test/kafka-resumption/toxiproxy-restore-connection.td
+++ b/test/kafka-resumption/toxiproxy-restore-connection.td
@@ -1,0 +1,10 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ http-request method=DELETE url=http://toxiproxy:8474/proxies/kafka/toxics/kafka content-type=application/json

--- a/test/kafka-resumption/toxiproxy-timeout.td
+++ b/test/kafka-resumption/toxiproxy-timeout.td
@@ -1,0 +1,15 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ http-request method=POST url=http://toxiproxy:8474/proxies/kafka/toxics content-type=application/json
+{
+  "name": "kafka",
+  "type": "timeout",
+  "attributes": { "timeout": 30000 }
+}

--- a/test/kafka-resumption/verify-success.td
+++ b/test/kafka-resumption/verify-success.td
@@ -1,0 +1,20 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ file-append path=dynamic.csv
+Hanover,PA,17331
+
+$ set-regex match=\d{13} replacement=<TIMESTAMP>
+
+$ kafka-verify format=avro sink=materialize.public.output sort-messages=true
+{"before": null, "after": {"row": {"city": "Brooklyn", "state": "NY", "zip": "11217", "mz_line_no":4}},"transaction":{"id":"<TIMESTAMP>"}}
+{"before": null, "after": {"row": {"city": "Hanover", "state": "PA", "zip": "17331", "mz_line_no":5}},"transaction":{"id":"<TIMESTAMP>"}}
+{"before": null, "after": {"row": {"city": "New York", "state": "NY", "zip": "10004", "mz_line_no":2}},"transaction":{"id":"<TIMESTAMP>"}}
+{"before": null, "after": {"row": {"city": "Rochester", "state": "NY", "zip": "14618", "mz_line_no":1}},"transaction":{"id":"<TIMESTAMP>"}}
+{"before": null, "after": {"row": {"city": "San Francisco", "state": "CA", "zip": "94114", "mz_line_no":3}},"transaction":{"id":"<TIMESTAMP>"}}


### PR DESCRIPTION
Two main changes here, both made with the goal of being able to disconnect and then reconnect to kafka:
- Don't shutdown on any send error.  This was happening via the `ProducerContext` callback.
- Retry all instances of `{begin,commit}_transaction`: we weren't doing so within `maybe_emit_progress`.  The issue I consistently ran into here is that the `commit` would not succeed because it couldn't flush messages successfully; it would return but the internal state machine would not have moved out of `BeginCommit`; the next call to `begin_commit` would cause a fatal error.

Also, update comments to solidify the approach of infinitely retrying non-fatal errors.

Minor change in only calling `flush` approximately once after moving the sink into a shutdown state as a result of a fatal error.

### Motivation
Fixes #8537 

Generally, we want to be able to tolerate transient errors when writing to kafka.  The following sequence resulted in a shutdown sink before but does work now:
- Set up ssh proxy to be able to interrupt connection to kafka without actually bringing it down
- Create EOS sink based on value in table (for ease as described in #8537)
- Run script to modify value in sink (also as described in #8537) 
- Note output of both consistency and data topics progresses as expected
- KILL SSH PROXY causing mz to not be able to connect to kafka
- Wait
- Restart ssh proxy allowing mz to again connect to kafka
- Note that the data topic produces _all_ missing outputs [Previously, at most one message would be send (if it was retrying a send when first hitting the error)]

### Testing
Adding a test that we could reasonably integrate into CI would be a lot of work at the moment since we don't have a way to interrupt connections to kafka.  This is something we could add in the future via testdrive commands / a mocked out kafka interface (where, in tests, we can deterministically make requests fail).

For now, I've run this manually test locally.  I don't anticipate any major changes to EOS kafka sinks anytime soon so I think this is an acceptable state -- even though it is potentially quite brittle.