### PR TITLE
Partition dataflow channel into compute and storage

### DIFF
--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -25,9 +25,10 @@ pub struct DataflowBuilder<'a> {
     pub transient_id_counter: &'a mut u64,
 }
 
-impl<C> Coordinator<C>
+impl<C, S> Coordinator<C, S>
 where
-    C: dataflow_types::client::Client,
+    C: dataflow_types::client::ComputeClient,
+    S: dataflow_types::client::StorageClient,
 {
     /// Creates a new dataflow builder from the catalog and indexes in `self`.
     pub fn dataflow_builder<'a>(&'a mut self) -> DataflowBuilder {

--- a/src/dataflowd/src/lib.rs
+++ b/src/dataflowd/src/lib.rs
@@ -22,7 +22,7 @@ pub struct RemoteClient {
 }
 
 impl RemoteClient {
-    /// Construct a client backed by multiple tcp connections
+    /// Constructs compute and storage clients backed by multiple tcp connections
     pub async fn connect(addrs: &[impl tokio::net::ToSocketAddrs]) -> Result<Self, anyhow::Error> {
         let mut remotes = Vec::with_capacity(addrs.len());
         for addr in addrs.iter() {

--- a/src/materialized/src/bin/coordd.rs
+++ b/src/materialized/src/bin/coordd.rs
@@ -38,6 +38,7 @@ struct Args {
     /// The address of the dataflowd servers to connect to.
     #[clap()]
     dataflowd_addr: Vec<String>,
+    /// The address of the dataflowd servers to connect to.
     /// Number of dataflow worker threads. This must match the number of
     /// workers that the targeted dataflowd was started with.
     #[clap(
@@ -74,16 +75,13 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
         )
         .init();
 
-    info!(
-        "connecting to dataflowd server at {:?}...",
-        args.dataflowd_addr
-    );
-
-    let dataflow_client = dataflowd::RemoteClient::connect(&args.dataflowd_addr).await?;
+    let compute_client = dataflowd::RemoteClient::connect(&args.dataflowd_addr).await?;
+    let storage_client = dataflowd::RemoteClient::connect(&args.dataflowd_addr).await?;
 
     let mut metrics_registry = MetricsRegistry::new();
     let (coord_handle, coord_client) = coord::serve(coord::Config {
-        dataflow_client,
+        compute_client,
+        storage_client,
         logging: None,
         data_directory: &args.data_directory,
         timestamp_frequency: Duration::from_secs(1),

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -223,7 +223,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
     let local_addr = listener.local_addr()?;
 
     // Initialize dataflow server.
-    let (dataflow_server, dataflow_client) = dataflow::serve(dataflow::Config {
+    let (dataflow_server, compute_client, storage_client) = dataflow::serve(dataflow::Config {
         workers,
         timely_config: timely::Config {
             communication: timely::CommunicationConfig::Process(workers),
@@ -236,7 +236,8 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
 
     // Initialize coordinator.
     let (coord_handle, coord_client) = coord::serve(coord::Config {
-        dataflow_client,
+        compute_client,
+        storage_client,
         logging: config.logging,
         data_directory: &config.data_directory,
         timestamp_frequency: config.timestamp_frequency,


### PR DESCRIPTION
This PR forcibly separate the one channel containing both COMPUTE and STORAGE commands into two channels, that each carry a corresponding subset of commands. The sequence of commits should progressively tidy this up, from roughly duplication of channels, to more clearly typed channels that could only carry their relevant types of commands and responses.

For the moment, this is just up for inspection.

### Motivation

This PR communicates to `coord` that there are two distinct instances for each form of communication, which is a necessary precursor to replacing them with platform-friendly implementations that do other things.

### Tips for reviewer

The main potential Gotcha I foresee is that where we used to have a total order over all commands, there are now potential interleavings of COMPUTE and STORAGE commands. That might cause hilarious problems, and if it does we have some sort of race we need to fix up. Potential examples include STORAGE actions on sources that have not been announced yet (as they are only announced in `CreateDataflow` statements). We may need to defer this work until `CreateSource` is explicitly introduced as a command.

@mjibson in the interest of expedience I commented out parts of `coord_test`, as I couldn't determine the correct modifications to make there. In particular, with the interleavings of responses from COMPUTE and STORAGE, I don't know that there are still a clear and deterministic sequence of results to expect, and the test may want to become more flexible.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
