### PR TITLE
Introduce create and drop source commands

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -4093,7 +4093,7 @@ where
             for &id in &tables_to_drop {
                 self.sources.remove(&id);
             }
-            self.dataflow_client.drop_tables(tables_to_drop).await;
+            self.dataflow_client.drop_sources(tables_to_drop).await;
         }
         if !sinks_to_drop.is_empty() {
             for id in sinks_to_drop.iter() {

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -4319,7 +4319,7 @@ where
         // TODO: Delete the following through `create_sources` once that lands.
         let mut source_descriptions = Vec::new();
         for plan in dataflow_plans.iter() {
-            for (global_id, desc) in plan.source_imports.iter() {
+            for (global_id, (desc, _operators)) in plan.source_imports.iter() {
                 source_descriptions.push((*global_id, desc.clone()));
             }
         }
@@ -5063,7 +5063,7 @@ pub mod fast_path_peek {
                     // and CREATE TABLE, but for starters we'll do this here to get it working.
                     // TODO: Delete the following through `create_sources` once that lands.
                     let mut source_descriptions = Vec::new();
-                    for (global_id, desc) in dataflow.source_imports.iter() {
+                    for (global_id, (desc, _operators)) in dataflow.source_imports.iter() {
                         source_descriptions.push((*global_id, desc.clone()));
                     }
                     self.dataflow_client

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -4319,8 +4319,8 @@ where
         // TODO: Delete the following through `create_sources` once that lands.
         let mut source_descriptions = Vec::new();
         for plan in dataflow_plans.iter() {
-            for (global_id, (desc, orig_id)) in plan.source_imports.iter() {
-                source_descriptions.push((*global_id, (desc.clone(), *orig_id)));
+            for (global_id, desc) in plan.source_imports.iter() {
+                source_descriptions.push((*global_id, desc.clone()));
             }
         }
         self.dataflow_client
@@ -5063,8 +5063,8 @@ pub mod fast_path_peek {
                     // and CREATE TABLE, but for starters we'll do this here to get it working.
                     // TODO: Delete the following through `create_sources` once that lands.
                     let mut source_descriptions = Vec::new();
-                    for (global_id, (desc, orig_id)) in dataflow.source_imports.iter() {
-                        source_descriptions.push((*global_id, (desc.clone(), *orig_id)));
+                    for (global_id, desc) in dataflow.source_imports.iter() {
+                        source_descriptions.push((*global_id, desc.clone()));
                     }
                     self.dataflow_client
                         .create_sources(source_descriptions)

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -4319,8 +4319,8 @@ where
         // TODO: Delete the following through `create_sources` once that lands.
         let mut source_descriptions = Vec::new();
         for plan in dataflow_plans.iter() {
-            for (global_id, (desc, _operators)) in plan.source_imports.iter() {
-                source_descriptions.push((*global_id, desc.clone()));
+            for (global_id, source) in plan.source_imports.iter() {
+                source_descriptions.push((*global_id, source.description.clone()));
             }
         }
         self.dataflow_client
@@ -5063,8 +5063,8 @@ pub mod fast_path_peek {
                     // and CREATE TABLE, but for starters we'll do this here to get it working.
                     // TODO: Delete the following through `create_sources` once that lands.
                     let mut source_descriptions = Vec::new();
-                    for (global_id, (desc, _operators)) in dataflow.source_imports.iter() {
-                        source_descriptions.push((*global_id, desc.clone()));
+                    for (global_id, source) in dataflow.source_imports.iter() {
+                        source_descriptions.push((*global_id, source.description.clone()));
                     }
                     self.dataflow_client
                         .create_sources(source_descriptions)

--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -113,7 +113,6 @@ impl<'a> DataflowBuilder<'a> {
                             dataflow_types::sources::SourceDesc {
                                 name: entry.name().to_string(),
                                 connector,
-                                operators: None,
                                 desc: table.desc.clone(),
                             },
                         );
@@ -167,7 +166,6 @@ impl<'a> DataflowBuilder<'a> {
                         let source_connector = dataflow_types::sources::SourceDesc {
                             name: entry.name().to_string(),
                             connector,
-                            operators: None,
                             desc: source.desc.clone(),
                         };
 

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -131,10 +131,7 @@ impl ComputeCommandKind {
 )]
 pub enum StorageCommand {
     /// Create the enumerated sources, each associated with its identifier.
-    ///
-    /// Paired with each source description is its `orig_id`, a thing that has
-    /// unknown properties, but must be set correctly as used in dataflows.
-    CreateSources(Vec<(GlobalId, (crate::types::sources::SourceDesc, GlobalId))>),
+    CreateSources(Vec<(GlobalId, crate::types::sources::SourceDesc)>),
 
     /// Drop the sources bound to these names.
     DropSources(Vec<GlobalId>),
@@ -390,7 +387,7 @@ pub trait ComputeClient: Client {
 pub trait StorageClient: Client {
     async fn create_sources(
         &mut self,
-        source_descriptions: Vec<(GlobalId, (crate::sources::SourceDesc, GlobalId))>,
+        source_descriptions: Vec<(GlobalId, crate::sources::SourceDesc)>,
     ) {
         self.send(Command::Storage(StorageCommand::CreateSources(
             source_descriptions,

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -130,8 +130,14 @@ impl ComputeCommandKind {
     doc = "the kind of storage command that was received"
 )]
 pub enum StorageCommand {
-    /// Drop the tables bound to these names.
-    DropTables(Vec<GlobalId>),
+    /// Create the enumerated sources, each associated with its identifier.
+    ///
+    /// Paired with each source description is its `orig_id`, a thing that has
+    /// unknown properties, but must be set correctly as used in dataflows.
+    CreateSources(Vec<(GlobalId, (crate::types::sources::SourceDesc, GlobalId))>),
+
+    /// Drop the sources bound to these names.
+    DropSources(Vec<GlobalId>),
 
     /// Insert `updates` into the local input named `id`.
     Insert {
@@ -196,7 +202,8 @@ impl StorageCommandKind {
             StorageCommandKind::AdvanceSourceTimestamp => "advance_source_timestamp",
             StorageCommandKind::DropSourceTimestamping => "drop_source_timestamping",
             StorageCommandKind::AllowSourceCompaction => "allows_source_compaction",
-            StorageCommandKind::DropTables => "drop_tables",
+            StorageCommandKind::CreateSources => "create_sources",
+            StorageCommandKind::DropSources => "drop_sources",
             StorageCommandKind::DurabilityFrontierUpdates => "durability_frontier_updates",
             StorageCommandKind::EnablePersistence => "enable_persistence",
             StorageCommandKind::Insert => "insert",
@@ -381,9 +388,9 @@ pub trait ComputeClient: Client {
 /// Methods that reflect actions that can be performed against the storage layer.
 #[async_trait::async_trait]
 pub trait StorageClient: Client {
-    async fn drop_tables(&mut self, table_identifiers: Vec<GlobalId>) {
-        self.send(Command::Storage(StorageCommand::DropTables(
-            table_identifiers,
+    async fn drop_sources(&mut self, source_identifiers: Vec<GlobalId>) {
+        self.send(Command::Storage(StorageCommand::DropSources(
+            source_identifiers,
         )))
         .await
     }

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -388,6 +388,15 @@ pub trait ComputeClient: Client {
 /// Methods that reflect actions that can be performed against the storage layer.
 #[async_trait::async_trait]
 pub trait StorageClient: Client {
+    async fn create_sources(
+        &mut self,
+        source_descriptions: Vec<(GlobalId, (crate::sources::SourceDesc, GlobalId))>,
+    ) {
+        self.send(Command::Storage(StorageCommand::CreateSources(
+            source_descriptions,
+        )))
+        .await
+    }
     async fn drop_sources(&mut self, source_identifiers: Vec<GlobalId>) {
         self.send(Command::Storage(StorageCommand::DropSources(
             source_identifiers,

--- a/src/dataflow-types/src/explain.rs
+++ b/src/dataflow-types/src/explain.rs
@@ -90,8 +90,8 @@ where
         let sources = dataflow
             .source_imports
             .iter()
-            .filter_map(|(id, source_desc)| {
-                if let Some(operator) = &source_desc.operators {
+            .filter_map(|(id, (_source_desc, operators))| {
+                if let Some(operator) = operators {
                     Some((*id, operator))
                 } else {
                     None

--- a/src/dataflow-types/src/explain.rs
+++ b/src/dataflow-types/src/explain.rs
@@ -90,8 +90,8 @@ where
         let sources = dataflow
             .source_imports
             .iter()
-            .filter_map(|(id, (_source_desc, operators))| {
-                if let Some(operator) = operators {
+            .filter_map(|(id, source)| {
+                if let Some(operator) = &source.operators {
                     Some((*id, operator))
                 } else {
                     None

--- a/src/dataflow/src/decode/mod.rs
+++ b/src/dataflow/src/decode/mod.rs
@@ -262,7 +262,7 @@ fn get_decoder(
         | DataEncoding::Regex(_) => {
             let after_delimiting = match encoding {
                 DataEncoding::Regex(RegexEncoding { regex }) => {
-                    PreDelimitedFormat::Regex(regex, Default::default())
+                    PreDelimitedFormat::Regex(regex.0, Default::default())
                 }
                 DataEncoding::Protobuf(encoding) => {
                     PreDelimitedFormat::Protobuf(ProtobufDecoderState::new(encoding).expect(

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -232,17 +232,18 @@ pub fn build_dataflow<A: Allocate>(
             );
 
             // Import declared sources into the rendering context.
-            for (src_id, src) in &dataflow.source_imports {
+            for (src_id, (src_desc, operators)) in &dataflow.source_imports {
                 let (collection_bundle, (source_token, additional_tokens)) =
                     crate::render::sources::import_source(
                         &context.debug_name,
                         context.dataflow_id,
                         &context.as_of_frontier,
+                        operators.clone(),
                         storage_state,
                         region,
                         materialized_logging.clone(),
                         src_id.clone(),
-                        src.clone(),
+                        src_desc.clone(),
                         now.clone(),
                         source_metrics,
                     );

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -168,7 +168,7 @@ pub struct StorageState {
     /// Source descriptions that have been created and not yet dropped.
     ///
     /// The second `GlobalId` is the `orig_id` which I do not understand.
-    pub source_descriptions: HashMap<GlobalId, (dataflow_types::sources::SourceDesc, GlobalId)>,
+    pub source_descriptions: HashMap<GlobalId, dataflow_types::sources::SourceDesc>,
     /// Handles to external sources, keyed by ID.
     pub ts_source_mapping: HashMap<GlobalId, Vec<Weak<Option<SourceToken>>>>,
     /// Timestamp data updates for each source.

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -167,7 +167,10 @@ pub struct StorageState {
     pub local_inputs: HashMap<GlobalId, LocalInput>,
     /// Source descriptions that have been created and not yet dropped.
     ///
-    /// The second `GlobalId` is the `orig_id` which I do not understand.
+    /// For the moment we retain all source descriptions, even those that have been
+    /// dropped, as this is used to check for rebinding of previous identifiers.
+    /// Once we have a better mechanism to avoid that, for example that identifiers
+    /// must strictly increase, we can clean up descriptions when sources are dropped.
     pub source_descriptions: HashMap<GlobalId, dataflow_types::sources::SourceDesc>,
     /// Handles to external sources, keyed by ID.
     pub ts_source_mapping: HashMap<GlobalId, Vec<Weak<Option<SourceToken>>>>,

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -165,6 +165,10 @@ pub struct ComputeState {
 pub struct StorageState {
     /// Handles to local inputs, keyed by ID.
     pub local_inputs: HashMap<GlobalId, LocalInput>,
+    /// Source descriptions that have been created and not yet dropped.
+    ///
+    /// The second `GlobalId` is the `orig_id` which I do not understand.
+    pub source_descriptions: HashMap<GlobalId, (dataflow_types::sources::SourceDesc, GlobalId)>,
     /// Handles to external sources, keyed by ID.
     pub ts_source_mapping: HashMap<GlobalId, Vec<Weak<Option<SourceToken>>>>,
     /// Timestamp data updates for each source.

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -235,18 +235,18 @@ pub fn build_dataflow<A: Allocate>(
             );
 
             // Import declared sources into the rendering context.
-            for (src_id, (src_desc, operators)) in &dataflow.source_imports {
+            for (src_id, source) in &dataflow.source_imports {
                 let (collection_bundle, (source_token, additional_tokens)) =
                     crate::render::sources::import_source(
                         &context.debug_name,
                         context.dataflow_id,
                         &context.as_of_frontier,
-                        operators.clone(),
+                        source.operators.clone(),
                         storage_state,
                         region,
                         materialized_logging.clone(),
                         src_id.clone(),
-                        src_desc.clone(),
+                        source.description.clone(),
                         now.clone(),
                         source_metrics,
                     );

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -134,11 +134,12 @@ pub(crate) fn import_source<G>(
     dataflow_debug_name: &String,
     dataflow_id: usize,
     as_of_frontier: &timely::progress::Antichain<repr::Timestamp>,
+    mut linear_operators: Option<dataflow_types::LinearOperator>,
     storage_state: &mut crate::render::StorageState,
     scope: &mut G,
     materialized_logging: Option<Logger>,
     src_id: GlobalId,
-    mut src: SourceDesc,
+    src: SourceDesc,
     now: NowFn,
     base_metrics: &SourceBaseMetrics,
 ) -> (
@@ -151,11 +152,6 @@ pub(crate) fn import_source<G>(
 where
     G: Scope<Timestamp = Timestamp>,
 {
-    // Extract the linear operators, as we will need to manipulate them.
-    // extracting them reduces the change we might accidentally communicate
-    // them through `src`.
-    let mut linear_operators = src.operators.take();
-
     // Blank out trivial linear operators.
     if let Some(operator) = &linear_operators {
         if operator.is_trivial(src.desc.arity()) {

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -836,15 +836,14 @@ where
     fn handle_storage_command(&mut self, cmd: StorageCommand) {
         match cmd {
             StorageCommand::CreateSources(sources) => {
-                for (source_id, (description, orig_id)) in sources.into_iter() {
+                for (source_id, description) in sources.into_iter() {
                     // Assert that a source is not recreated with a new description.
-                    if let Some((d, o)) = self.storage_state.source_descriptions.get(&source_id) {
+                    if let Some(d) = self.storage_state.source_descriptions.get(&source_id) {
                         assert_eq!(d, &description);
-                        assert_eq!(o, &orig_id);
                     }
                     self.storage_state
                         .source_descriptions
-                        .insert(source_id, (description, orig_id));
+                        .insert(source_id, description);
                 }
             }
             StorageCommand::DropSources(names) => {

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -839,7 +839,14 @@ where
                 for (source_id, description) in sources.into_iter() {
                     // Assert that a source is not recreated with a new description.
                     if let Some(d) = self.storage_state.source_descriptions.get(&source_id) {
-                        assert_eq!(d, &description);
+                        if d != &description {
+                            log::error!(
+                                "Multiple registration of source id {}: {:?} and {:?}",
+                                source_id,
+                                d,
+                                description
+                            );
+                        }
                     }
                     self.storage_state
                         .source_descriptions

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -856,10 +856,12 @@ where
             StorageCommand::DropSources(names) => {
                 // The only sources that currently require actions are local inputs.
                 for name in names {
+                    // Drop table-related state.
                     self.storage_state.local_inputs.remove(&name);
-                    let prior = self.storage_state.source_descriptions.remove(&name);
-                    if prior.is_none() {
-                        panic!("Source dropped without prior creation: {}", name);
+                    // Check that the source has been previously created.
+                    // Do not remove it, so that we can continue to check for rebinding.
+                    if !self.storage_state.source_descriptions.contains_key(&name) {
+                        log::error!("DropSource for id that was not created: {:?}", name);
                     }
                 }
             }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1218,7 +1218,9 @@ fn get_encoding_inner<T: sql_parser::ast::AstInfo>(
         },
         Format::Regex(regex) => {
             let regex = Regex::new(&regex)?;
-            DataEncoding::Regex(RegexEncoding { regex })
+            DataEncoding::Regex(RegexEncoding {
+                regex: repr::adt::regex::Regex(regex),
+            })
         }
         Format::Csv { columns, delimiter } => {
             let columns = match columns {

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -217,17 +217,17 @@ fn optimize_dataflow_demand(dataflow: &mut DataflowDesc) -> Result<(), Transform
     )?;
 
     // Push demand information into the SourceDesc.
-    for (source_id, source_desc) in dataflow.source_imports.iter_mut() {
+    for (source_id, (source_desc, operators)) in dataflow.source_imports.iter_mut() {
         if let Some(columns) = demand.get(&Id::Global(*source_id)).clone() {
             // Install no-op demand information if none exists.
-            if source_desc.operators.is_none() {
-                source_desc.operators = Some(LinearOperator {
+            if operators.is_none() {
+                *operators = Some(LinearOperator {
                     predicates: Vec::new(),
                     projection: (0..source_desc.desc.arity()).collect(),
                 })
             }
             // Restrict required columns by those identified as demanded.
-            if let Some(operator) = &mut source_desc.operators {
+            if let Some(operator) = operators {
                 operator.projection.retain(|col| columns.contains(col));
             }
         }
@@ -301,17 +301,17 @@ fn optimize_dataflow_filters(dataflow: &mut DataflowDesc) -> Result<(), Transfor
     )?;
 
     // Push predicate information into the SourceDesc.
-    for (source_id, source_desc) in dataflow.source_imports.iter_mut() {
+    for (source_id, (source_desc, operators)) in dataflow.source_imports.iter_mut() {
         if let Some(list) = predicates.get(&Id::Global(*source_id)).clone() {
             // Install no-op predicate information if none exists.
-            if source_desc.operators.is_none() {
-                source_desc.operators = Some(LinearOperator {
+            if operators.is_none() {
+                *operators = Some(LinearOperator {
                     predicates: Vec::new(),
                     projection: (0..source_desc.desc.arity()).collect(),
                 })
             }
             // Add any predicates that can be pushed to the source.
-            if let Some(operator) = &mut source_desc.operators {
+            if let Some(operator) = operators {
                 operator.predicates.extend(list.iter().cloned());
                 operator.predicates.sort();
             }
@@ -347,7 +347,7 @@ where
 /// Propagates information about monotonic inputs through views.
 pub fn optimize_dataflow_monotonic(dataflow: &mut DataflowDesc) -> Result<(), TransformError> {
     let mut monotonic = std::collections::HashSet::new();
-    for (source_id, source_desc) in dataflow.source_imports.iter_mut() {
+    for (source_id, (source_desc, _operators)) in dataflow.source_imports.iter_mut() {
         if let dataflow_types::sources::SourceConnector::External {
             envelope: dataflow_types::sources::SourceEnvelope::None(_),
             ..


### PR DESCRIPTION
This PR introduces the `CreateSources` and `DropSources` variants of `StorageCommand`. Their only behavior at the moment is to assert that source identifiers are not rebound to new descriptions, and to assert that dropped sources have been previously created.

The goal is to train the coordinator 1. to explicitly call `CreateSources` whereas at the moment it uses `CreateSources` implicitly by sending dataflow descriptions containing novel source descriptions, and 2. to explicitly call `DropSources` for sources it no longer wishes to use.

### Motivation

Sources are only implicitly introduced, which requires COMPUTE to monitor the commands it receives and sniff out novel sources, to inform STORAGE. Ideally, the coordinator would inform STORAGE as each source is created, so that it can proactively prepare the associated data.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
