### PR TITLE
stash: introduce new abstraction for persistent metadata storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1848,9 +1848,9 @@ checksum = "95765f67b4b18863968b4a1bd5bb576f732b29a4a28c7cd84c09fa3e2875f33c"
 
 [[package]]
 name = "fastrand"
-version = "1.5.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b394ed3d285a429378d3b384b9eb1285267e7df4b166df24b7a6939a04dc392e"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
 dependencies = [
  "instant",
 ]
@@ -3062,6 +3062,21 @@ dependencies = [
  "ore",
  "procfs",
  "prometheus",
+]
+
+[[package]]
+name = "mz-stash"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "build-info",
+ "differential-dataflow",
+ "ore",
+ "persist",
+ "persist-types",
+ "rusqlite",
+ "tempfile",
+ "timely",
 ]
 
 [[package]]
@@ -4281,9 +4296,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.4"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ec8ca9416c5ea37062b502703cd7fcb207736bc294f6e0cf367ac6fc234570"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
 ]
@@ -4561,9 +4576,9 @@ checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 
 [[package]]
 name = "serde"
-version = "1.0.135"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cf9235533494ea2ddcdb794665461814781c53f19d87b76e571a1c35acbad2b"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
 ]
@@ -4590,9 +4605,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.135"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dcde03d87d4c973c04be249e7d8f0b35db1c848c487bd43032808e59dd8328d"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4983,13 +4998,13 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
  "cfg-if",
+ "fastrand",
  "libc",
- "rand",
  "redox_syscall",
  "remove_dir_all",
  "winapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
     "src/repr-test-util",
     "src/repr",
     "src/s3-datagen",
+    "src/stash",
     "src/sql-parser",
     "src/sql",
     "src/sqllogictest",

--- a/src/stash/Cargo.toml
+++ b/src/stash/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "mz-stash"
+description = "A durable metadata store."
+version = "0.0.0"
+edition = "2021"
+publish = false
+rust-version = "1.58.0"
+
+[dependencies]
+build-info = { path = "../build-info" }
+differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow" }
+ore = { path = "../ore" }
+rusqlite = "0.26.3"
+persist = { path = "../persist" }
+persist-types = { path = "../persist-types" }
+timely = { git = "https://github.com/TimelyDataflow/timely-dataflow" }
+
+[dev-dependencies]
+anyhow = "1.0.53"
+tempfile = "3.3.0"

--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -1,0 +1,18 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Facilities for durably storing metadata.
+
+mod persist;
+mod sqlite;
+mod stash;
+
+pub use crate::persist::PersistStash;
+pub use crate::sqlite::SqliteStash;
+pub use crate::stash::{Stash, StashError, StashOp};

--- a/src/stash/src/persist.rs
+++ b/src/stash/src/persist.rs
@@ -1,0 +1,139 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::{hash_map, HashMap};
+use std::fmt;
+use std::hash::Hash;
+use std::vec;
+
+use ore::metrics::MetricsRegistry;
+use persist::client::{RuntimeClient, StreamWriteHandle};
+use persist::indexed::Snapshot;
+use persist::runtime::{self, RuntimeConfig};
+use persist::storage::{Blob, Log};
+use persist_types::Codec;
+use timely::progress::Antichain;
+
+use crate::{Stash, StashError, StashOp};
+
+type Error = StashError<persist::error::Error>;
+
+/// A stash backed by a [`persist`] collection.
+#[derive(Debug)]
+pub struct PersistStash<K, V> {
+    _client: RuntimeClient,
+    write_handle: StreamWriteHandle<K, V>,
+    data: HashMap<K, V>,
+    timestamp: u64,
+}
+
+impl<K, V> PersistStash<K, V>
+where
+    K: Codec + Clone + Eq + Hash + Ord + fmt::Debug,
+    V: Codec + Clone + Eq + Hash + Ord + fmt::Debug,
+{
+    /// Opens the stash specified by the provided blob and log.
+    pub fn open<B, L>(
+        blob: B,
+        log: L,
+        metrics_registry: &MetricsRegistry,
+    ) -> Result<PersistStash<K, V>, Error>
+    where
+        B: Blob + Send + 'static,
+        L: Log + Send + 'static,
+    {
+        let client = runtime::start(
+            RuntimeConfig::default(),
+            log,
+            blob,
+            build_info::DUMMY_BUILD_INFO,
+            metrics_registry,
+            None,
+        )?;
+        let (write_handle, read_handle) = client.create_or_load("stash");
+        write_handle.allow_compaction(Antichain::new());
+
+        let mut stage = vec![];
+        for entry in read_handle.snapshot()?.into_iter() {
+            let ((key, val), _ts, diff) = entry?;
+            stage.push(((key, val), diff));
+        }
+        differential_dataflow::consolidation::consolidate(&mut stage);
+
+        let mut data = HashMap::new();
+        for ((key, val), diff) in stage {
+            if diff != 1 {
+                return Err(StashError::Corruption(format!(
+                    "unexpected diff {} for key {:?}",
+                    diff, key
+                )));
+            }
+            data.insert(key, val);
+        }
+
+        Ok(PersistStash {
+            _client: client,
+            write_handle,
+            data,
+            timestamp: 0,
+        })
+    }
+}
+
+impl<K, V> Stash<K, V> for PersistStash<K, V>
+where
+    K: Codec + Clone + Eq + Hash,
+    V: Codec + Clone + Eq + Hash,
+{
+    type EngineError = persist::error::Error;
+
+    type ReplayIterator = hash_map::IntoIter<K, V>;
+
+    fn write_batch(&mut self, ops: Vec<StashOp<K, V>>) -> Result<(), Error> {
+        let timestamp = self.timestamp;
+        self.timestamp += 1;
+
+        let mut writes = vec![];
+        for op in &ops {
+            match op {
+                StashOp::Put(key, val) => {
+                    if let Some(val) = self.data.get(&key) {
+                        writes.push(((key.clone(), val.clone()), timestamp, -1));
+                    }
+                    writes.push(((key.clone(), val.clone()), timestamp, 1));
+                }
+                StashOp::Delete(key) => {
+                    if let Some(val) = self.data.get(&key) {
+                        writes.push(((key.clone(), val.clone()), timestamp, -1));
+                    }
+                }
+            }
+        }
+
+        let _ = self.write_handle.write(&writes).recv()?;
+        let _ = self.write_handle.seal(timestamp).recv()?;
+
+        for op in ops {
+            match op {
+                StashOp::Put(key, val) => {
+                    self.data.insert(key, val);
+                }
+                StashOp::Delete(key) => {
+                    self.data.remove(&key);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn replay(&self) -> Result<Self::ReplayIterator, Error> {
+        Ok(self.data.clone().into_iter())
+    }
+}

--- a/src/stash/src/sqlite.rs
+++ b/src/stash/src/sqlite.rs
@@ -1,0 +1,106 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::path::Path;
+use std::vec;
+
+use rusqlite::{params, Connection};
+
+use persist_types::Codec;
+
+use crate::{Stash, StashError, StashOp};
+
+const APPLICATION_ID: i32 = 0x0872_e898;
+
+const SCHEMA: &str = "CREATE TABLE stash (
+    key blob NOT NULL UNIQUE,
+    value blob NOT NULL
+);";
+
+type Error = StashError<rusqlite::Error>;
+
+/// A stash backed by a SQLite database.
+#[derive(Debug)]
+pub struct SqliteStash {
+    conn: Connection,
+}
+
+impl SqliteStash {
+    /// Opens the stash stored at the specified path.
+    pub fn open<P>(path: P) -> Result<SqliteStash, Error>
+    where
+        P: AsRef<Path>,
+    {
+        let mut conn = Connection::open(path)?;
+        let tx = conn.transaction()?;
+        let app_id: i32 = tx.query_row("PRAGMA application_id", params![], |row| row.get(0))?;
+        if app_id == 0 {
+            tx.execute_batch(&format!("PRAGMA application_id = {}", APPLICATION_ID))?;
+            tx.execute_batch("PRAGMA user_version = 1")?;
+            tx.execute_batch(SCHEMA)?;
+        } else if app_id != APPLICATION_ID {
+            return Err(Error::Corruption(format!(
+                "invalid application id: {}",
+                app_id
+            )));
+        }
+        tx.commit()?;
+        Ok(SqliteStash { conn })
+    }
+}
+
+impl<K, V> Stash<K, V> for SqliteStash
+where
+    K: Codec,
+    V: Codec,
+{
+    type EngineError = rusqlite::Error;
+
+    type ReplayIterator = vec::IntoIter<(K, V)>;
+
+    fn write_batch(&mut self, ops: Vec<StashOp<K, V>>) -> Result<(), Error> {
+        let tx = self.conn.transaction()?;
+        for op in ops {
+            match op {
+                StashOp::Put(key, val) => {
+                    let mut key_buf = vec![];
+                    let mut val_buf = vec![];
+                    key.encode(&mut key_buf);
+                    val.encode(&mut val_buf);
+                    tx.execute(
+                        "INSERT INTO stash (key, value) VALUES (?, ?)
+                        ON CONFLICT (key) DO UPDATE SET value = excluded.value",
+                        params![key_buf, val_buf],
+                    )?;
+                }
+                StashOp::Delete(key) => {
+                    let mut key_buf = vec![];
+                    key.encode(&mut key_buf);
+                    tx.execute("DELETE FROM stash WHERE key = ?", params![key_buf])?;
+                }
+            }
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    fn replay(&self) -> Result<Self::ReplayIterator, Error> {
+        let mut out = vec![];
+        let mut stmt = self.conn.prepare("SELECT key, value FROM stash")?;
+        let mut rows = stmt.query([])?;
+        while let Some(row) = rows.next()? {
+            let key_buf: Vec<u8> = row.get("key")?;
+            let val_buf: Vec<u8> = row.get("value")?;
+            let key = K::decode(&key_buf).map_err(|e| Error::Codec(e))?;
+            let val = V::decode(&val_buf).map_err(|e| Error::Codec(e))?;
+            out.push((key, val));
+        }
+        Ok(out.into_iter())
+    }
+}

--- a/src/stash/src/stash.rs
+++ b/src/stash/src/stash.rs
@@ -1,0 +1,124 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::error::Error;
+use std::fmt;
+
+use persist_types::Codec;
+
+/// A durable metadata store.
+///
+/// A stash stores key–value pairs. It supports atomic updates of any number of
+/// keys via the [`write_batch`](Stash::write_batch) method and provides access
+/// to the most recently written value for each key by way of the
+/// [`replay`](Stash::replay) method.
+///
+/// The minimal API ensures that a stash can, in principle, be implemented by
+/// approximately any system that can store data durably, from our `persist`
+/// crate to SQLite to Kafka.
+///
+/// It is expected that stash implementations will adhere to a reasonable but
+/// opaque compaction policy so that the on-disk size of a stash is proportional
+/// to the number of distinct keys written.
+pub trait Stash<K, V>
+where
+    K: Codec,
+    V: Codec,
+{
+    /// The error type produced by the underlying storage engine.
+    type EngineError: Error + Send + Sync + 'static;
+
+    /// The type of the iterator returned by [`replay`](Stash::replay).
+    type ReplayIterator: Iterator<Item = (K, V)>;
+
+    /// Atomically writes a batch of operations to the stash.
+    ///
+    /// The method does not return successfully unless the batch has been
+    /// committed to durable storage.
+    fn write_batch(&mut self, ops: Vec<StashOp<K, V>>)
+        -> Result<(), StashError<Self::EngineError>>;
+
+    /// Returns an iterator over the key–value pairs in the stash.
+    ///
+    /// The key–value pairs may be returned in any order.
+    fn replay(&self) -> Result<Self::ReplayIterator, StashError<Self::EngineError>>;
+
+    /// Writes a single key–value pair to the stash.
+    ///
+    /// The method does not return successfully unless the batch has been
+    /// committed to durable storage.
+    ///
+    /// If there is an existing value with the same key, it is overwritten.
+    fn put(&mut self, key: K, val: V) -> Result<(), StashError<Self::EngineError>> {
+        self.write_batch(vec![StashOp::Put(key, val)])
+    }
+
+    /// Remove the existing key–value pair with the specified key.
+    ///
+    /// The method does not return successfully unless the batch has been
+    /// committed to durable storage.
+    ///
+    /// It is not an error if there is no existing value with the specified key.
+    fn delete(&mut self, key: K) -> Result<(), StashError<Self::EngineError>> {
+        self.write_batch(vec![StashOp::Delete(key)])
+    }
+}
+
+/// A write operation on a stash.
+pub enum StashOp<K, V> {
+    /// Insert a new key–value pair.
+    ///
+    /// If there is an existing value with the same key, it is overwritten.
+    Put(K, V),
+    /// Remove the existing key–value pair with the specified key.
+    ///
+    /// It is not an error if there is no existing value with the specified key.
+    Delete(K),
+}
+
+/// An error that can occur while interacting with a [`Stash`.]
+#[derive(Debug)]
+pub enum StashError<E> {
+    /// An error from the underlying storage engine.
+    Engine(E),
+    /// An error from the codec.
+    Codec(String),
+    /// The database file is corrupted.
+    Corruption(String),
+}
+
+impl<E> fmt::Display for StashError<E>
+where
+    E: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            StashError::Engine(e) => {
+                f.write_str("stash error: engine: ")?;
+                e.fmt(f)
+            }
+            StashError::Codec(e) => {
+                f.write_str("stash error: codec: ")?;
+                e.fmt(f)
+            }
+            StashError::Corruption(e) => {
+                f.write_str("stash error: corruption: ")?;
+                e.fmt(f)
+            }
+        }
+    }
+}
+
+impl<E> Error for StashError<E> where E: fmt::Debug + fmt::Display {}
+
+impl<E> From<E> for StashError<E> {
+    fn from(e: E) -> StashError<E> {
+        StashError::Engine(e)
+    }
+}

--- a/src/stash/tests/stash.rs
+++ b/src/stash/tests/stash.rs
@@ -1,0 +1,70 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::HashSet;
+use std::error::Error;
+
+use ore::metrics::MetricsRegistry;
+use tempfile::{NamedTempFile, TempDir};
+
+use mz_stash::{PersistStash, SqliteStash, Stash, StashOp};
+use persist::file::{FileBlob, FileLog};
+use persist::storage::{Blob, LockInfo};
+
+#[test]
+fn test_sqlite() -> Result<(), anyhow::Error> {
+    let file = NamedTempFile::new()?;
+    run_tests(|| SqliteStash::open(file.path()))?;
+    Ok(())
+}
+
+#[test]
+fn test_persist() -> Result<(), anyhow::Error> {
+    let dir = TempDir::new()?;
+    run_tests(|| {
+        let lock_info = LockInfo::new("stash".into(), "nonce".into())?;
+        let log = FileLog::new(dir.path().join("log"), lock_info.clone())?;
+        let blob = FileBlob::open_exclusive(dir.path().join("blob").into(), lock_info)?;
+        PersistStash::open(blob, log, &MetricsRegistry::new())
+    })?;
+    Ok(())
+}
+
+fn run_tests<F, E, S>(open_stash: F) -> Result<(), anyhow::Error>
+where
+    F: Fn() -> Result<S, E>,
+    E: Error + Send + Sync + 'static,
+    S: Stash<String, String>,
+{
+    let expected = HashSet::from_iter([
+        ("a".into(), "2".into()),
+        ("c".into(), "5".into()),
+        ("d".into(), "4".into()),
+    ]);
+
+    let mut stash = open_stash()?;
+    stash.write_batch(vec![
+        StashOp::Put("a".into(), "1".into()),
+        StashOp::Put("b".into(), "2".into()),
+        StashOp::Put("a".into(), "2".into()),
+        StashOp::Put("c".into(), "3".into()),
+        StashOp::Put("d".into(), "4".into()),
+    ])?;
+    stash.put("c".into(), "5".into())?;
+    stash.delete("b".into())?;
+
+    let snapshot: HashSet<_> = stash.replay()?.collect();
+    assert_eq!(snapshot, expected);
+
+    let stash = open_stash()?;
+    let snapshot: HashSet<_> = stash.replay()?.collect();
+    assert_eq!(snapshot, expected);
+
+    Ok(())
+}


### PR DESCRIPTION
A `Stash` is a candidate abstraction for how layers in the platform will
store their persistent state. This PR adds two `Stash` implementations:
one that uses SQLite and one that uses the `persist` crate.

@danhhz for some reason the enclosed `test_persist` fails nondeterministically. Any ideas? Am I holding it wrong?

```
  left: `Err(String("meta BlobMeta { seqno: SeqNo(7), id_mapping: [StreamRegistration { name: \"stash\", id: Id(0), key_codec_name: \"String\", val_codec_name: \"String\" }], graveyard: [], arrangements: [ArrangementMeta { id: Id(0), seal: Antichain { elements: [2] }, since: Antichain { elements: [] }, unsealed_batches: [UnsealedBatchMeta { key: \"4e19a4d3-d1e7-4543-91ff-c1391442415a\", format: ParquetKvtd, desc: SeqNo(2)..SeqNo(4), ts_upper: 1, ts_lower: 1, size_bytes: 457 }, UnsealedBatchMeta { key: \"54192f8f-6d75-4468-b006-4561c718bcb9\", format: ParquetKvtd, desc: SeqNo(4)..SeqNo(6), ts_upper: 2, ts_lower: 2, size_bytes: 431 }], trace_batches: [TraceBatchMeta { key: \"60a4648d-35d2-477d-b056-b6b9e19f26ae\", format: ParquetKvtd, desc: Description { lower: Antichain { elements: [0] }, upper: Antichain { elements: [1] }, since: Antichain { elements: [0] } }, level: 0, size_bytes: 553 }] }] } did not match the one in storage BlobMeta { seqno: SeqNo(7), id_mapping: [StreamRegistration { name: \"stash\", id: Id(0), key_codec_name: \"String\", val_codec_name: \"String\" }], graveyard: [], arrangements: [ArrangementMeta { id: Id(0), seal: Antichain { elements: [2] }, since: Antichain { elements: [] }, unsealed_batches: [UnsealedBatchMeta { key: \"4e19a4d3-d1e7-4543-91ff-c1391442415a\", format: ParquetKvtd, desc: SeqNo(2)..SeqNo(4), ts_upper: 1, ts_lower: 1, size_bytes: 457 }, UnsealedBatchMeta { key: \"54192f8f-6d75-4468-b006-4561c718bcb9\", format: ParquetKvtd, desc: SeqNo(4)..SeqNo(6), ts_upper: 2, ts_lower: 2, size_bytes: 431 }], trace_batches: [TraceBatchMeta { key: \"60a4648d-35d2-477d-b056-b6b9e19f26ae\", format: ParquetKvtd, desc: Description { lower: Antichain { elements: [0] }, upper: Antichain { elements: [1] }, since: Antichain { elements: [0] } }, level: 0, size_bytes: 553 }, TraceBatchMeta { key: \"1ffe3d25-cc35-4985-8321-46a8b3fc7cb4\", format: ParquetKvtd, desc: Description { lower: Antichain { elements: [1] }, upper: Antichain { elements: [2] }, since: Antichain { elements: [0] } }, level: 0, size_bytes: 473 }] }] }"))`,
```

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
