### PR TITLE
ci/test: correct input globs for test/debezium-avro

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -226,7 +226,7 @@ steps:
   - id: debezium-postgres
     label: "Debezium test (Postgres)"
     depends_on: build-x86_64
-    inputs: [test/debezium-avro]
+    inputs: [test/debezium]
     plugins:
       - ./ci/plugins/mzcompose:
           composition: debezium
@@ -235,7 +235,7 @@ steps:
   - id: debezium-sql-server
     label: "Debezium test (SQL Server)"
     depends_on: build-x86_64
-    inputs: [test/debezium-avro]
+    inputs: [test/debezium]
     plugins:
       - ./ci/plugins/mzcompose:
           composition: debezium


### PR DESCRIPTION
### Motivation

  * This PR fixes a previously unreported bug. The correct input globs were broken by #10244.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
