### PR TITLE
mzcompose: the chbench load-test workflow needs to run default now

### DIFF
--- a/demo/chbench/mzcompose.py
+++ b/demo/chbench/mzcompose.py
@@ -85,7 +85,7 @@ def workflow_load_test(c: Composition) -> None:
     """Run CH-benCHmark with a selected amount of load against Materialize."""
     c.up("prometheus-sql-exporter")
     c.workflow(
-        "demo",
+        "default",
         "--peek-conns=1",
         "--mz-views=q01,q02,q05,q06,q08,q09,q12,q14,q17,q19",
         "--transactional-threads=2",


### PR DESCRIPTION
This is an extraction of the non-controversial part of #10281.

Extracting this so that it's sure to make it in before the next release.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
