### PR TITLE
materialized: improve error when another process is active

### DIFF
--- a/src/materialized/tests/server.rs
+++ b/src/materialized/tests/server.rs
@@ -176,7 +176,10 @@ fn test_pid_file() -> Result<(), Box<dyn Error>> {
     match util::start_server(config.clone()) {
         Ok(_) => panic!("unexpected success"),
         Err(e) => {
-            if !e.to_string().contains("process already running") {
+            if !e
+                .to_string()
+                .contains("running with the same data directory")
+            {
                 return Err(e.into());
             }
         }


### PR DESCRIPTION
This is an alternative to #10298 that puts the materialized-specific
details in the materialized crate rather than in the
materialized-agnostic pid-file crate.

Co-authored-by: Brandon W Maister <bwm@materialize.com>

### Motivation

* Improves an existing possibly-confusing error message.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
