### PR TITLE
remove concept of original ID from sources

### DIFF
--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -116,7 +116,6 @@ impl<'a> DataflowBuilder<'a> {
                                 operators: None,
                                 desc: table.desc.clone(),
                             },
-                            *id,
                         );
                     }
                     CatalogItem::Source(source) => {
@@ -172,7 +171,7 @@ impl<'a> DataflowBuilder<'a> {
                             desc: source.desc.clone(),
                         };
 
-                        dataflow.import_source(*id, source_connector, *id);
+                        dataflow.import_source(*id, source_connector);
                     }
                     CatalogItem::View(view) => {
                         let expr = view.optimized_expr.clone();

--- a/src/dataflow-types/src/explain.rs
+++ b/src/dataflow-types/src/explain.rs
@@ -91,7 +91,7 @@ where
             .source_imports
             .iter()
             .filter_map(|(id, source_desc)| {
-                if let Some(operator) = &source_desc.0.operators {
+                if let Some(operator) = &source_desc.operators {
                     Some((*id, operator))
                 } else {
                     None

--- a/src/dataflow-types/src/plan/mod.rs
+++ b/src/dataflow-types/src/plan/mod.rs
@@ -877,7 +877,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                 .arranged
                 .push((key, permutation, thinning));
         }
-        for (_source_desc, id) in desc.source_imports.values() {
+        for id in desc.source_imports.keys() {
             arrangements
                 .entry(Id::Global(*id))
                 .or_insert_with(AvailableCollections::new_raw);

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -79,7 +79,7 @@ pub struct BuildDesc<View> {
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct DataflowDescription<View> {
     /// Sources made available to the dataflow.
-    pub source_imports: BTreeMap<GlobalId, (crate::types::sources::SourceDesc, GlobalId)>,
+    pub source_imports: BTreeMap<GlobalId, crate::types::sources::SourceDesc>,
     /// Indexes made available to the dataflow.
     pub index_imports: BTreeMap<GlobalId, (IndexDesc, RelationType)>,
     /// Views and indexes to be built and stored in the local context.
@@ -139,16 +139,8 @@ impl DataflowDescription<OptimizedMirRelationExpr> {
     }
 
     /// Imports a source and makes it available as `id`.
-    ///
-    /// The `orig_id` identifier must be set correctly, and is used to index various
-    /// internal data structures. Little else is known about it.
-    pub fn import_source(
-        &mut self,
-        id: GlobalId,
-        description: crate::types::sources::SourceDesc,
-        orig_id: GlobalId,
-    ) {
-        self.source_imports.insert(id, (description, orig_id));
+    pub fn import_source(&mut self, id: GlobalId, description: crate::types::sources::SourceDesc) {
+        self.source_imports.insert(id, description);
     }
 
     /// Binds to `id` the relation expression `view`.
@@ -230,7 +222,7 @@ impl DataflowDescription<OptimizedMirRelationExpr> {
 
     /// The number of columns associated with an identifier in the dataflow.
     pub fn arity_of(&self, id: &GlobalId) -> usize {
-        for (source_id, (desc, _orig_id)) in self.source_imports.iter() {
+        for (source_id, desc) in self.source_imports.iter() {
             if source_id == id {
                 return desc.desc.arity();
             }

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -228,7 +228,7 @@ pub fn build_dataflow<A: Allocate>(
             );
 
             // Import declared sources into the rendering context.
-            for (src_id, (src, orig_id)) in &dataflow.source_imports {
+            for (src_id, src) in &dataflow.source_imports {
                 let (collection_bundle, (source_token, additional_tokens)) =
                     crate::render::sources::import_source(
                         &context.debug_name,
@@ -239,7 +239,6 @@ pub fn build_dataflow<A: Allocate>(
                         materialized_logging.clone(),
                         src_id.clone(),
                         src.clone(),
-                        orig_id.clone(),
                         now.clone(),
                         source_metrics,
                     );

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -139,10 +139,6 @@ pub(crate) fn import_source<G>(
     materialized_logging: Option<Logger>,
     src_id: GlobalId,
     mut src: SourceDesc,
-    // The original ID of the source, before it was decomposed into a bare source (which might
-    // have its own transient ID) and a relational transformation (which has the original source
-    // ID).
-    orig_id: GlobalId,
     now: NowFn,
     base_metrics: &SourceBaseMetrics,
 ) -> (
@@ -202,7 +198,7 @@ where
 
             // This uid must be unique across all different instantiations of a source
             let uid = SourceInstanceId {
-                source_id: orig_id,
+                source_id: src_id,
                 dataflow_id,
             };
 
@@ -236,7 +232,7 @@ where
 
             let timestamp_histories = storage_state
                 .ts_histories
-                .get(&orig_id)
+                .get(&src_id)
                 .map(|history| history.clone());
             let source_name = format!("{}-{}", connector.name(), uid);
             let source_config = SourceConfig {
@@ -640,7 +636,7 @@ where
             // on timestamp advancement queries
             storage_state
                 .ts_source_mapping
-                .entry(orig_id)
+                .entry(src_id)
                 .or_insert_with(Vec::new)
                 .push(Rc::downgrade(&source_token));
 

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -217,7 +217,7 @@ fn optimize_dataflow_demand(dataflow: &mut DataflowDesc) -> Result<(), Transform
     )?;
 
     // Push demand information into the SourceDesc.
-    for (source_id, (source_desc, _)) in dataflow.source_imports.iter_mut() {
+    for (source_id, source_desc) in dataflow.source_imports.iter_mut() {
         if let Some(columns) = demand.get(&Id::Global(*source_id)).clone() {
             // Install no-op demand information if none exists.
             if source_desc.operators.is_none() {
@@ -301,7 +301,7 @@ fn optimize_dataflow_filters(dataflow: &mut DataflowDesc) -> Result<(), Transfor
     )?;
 
     // Push predicate information into the SourceDesc.
-    for (source_id, (source_desc, _)) in dataflow.source_imports.iter_mut() {
+    for (source_id, source_desc) in dataflow.source_imports.iter_mut() {
         if let Some(list) = predicates.get(&Id::Global(*source_id)).clone() {
             // Install no-op predicate information if none exists.
             if source_desc.operators.is_none() {
@@ -347,7 +347,7 @@ where
 /// Propagates information about monotonic inputs through views.
 pub fn optimize_dataflow_monotonic(dataflow: &mut DataflowDesc) -> Result<(), TransformError> {
     let mut monotonic = std::collections::HashSet::new();
-    for (source_id, (source_desc, _)) in dataflow.source_imports.iter_mut() {
+    for (source_id, source_desc) in dataflow.source_imports.iter_mut() {
         if let dataflow_types::sources::SourceConnector::External {
             envelope: dataflow_types::sources::SourceEnvelope::None(_),
             ..


### PR DESCRIPTION
### Motivation

This is a leftover from when sources were made of two parts, a bare
source and a mini view that post processed the results of the bare
source.

Since the decoupling of debezium from decoding this is no longer the
case and sources always directly output their final collection.

`orig_id` was previously used to differenticate between the bare source
and the mini view but now the ids are always the same, so we can remove
the concepct of orignal ID altogether.

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug: [Link to issue.]

  * This PR adds a known-desirable feature: [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
