### PR TITLE
doc/platform: replace REGION with ENVIRONMENT

### DIFF
--- a/doc/developer/platform/overview.md
+++ b/doc/developer/platform/overview.md
@@ -38,16 +38,17 @@ The intended user experience drives some of the concepts that we'll want to refl
 The intended user experience in turn reflects the practical realities of the tools we have access to.
 
 The coarsest level of granularity of Materialize Platform is the ACCOUNT.
-Within an ACCOUNT there may be multiple REGIONs, which correspond roughly to availability zones.
-A REGION is the unit within which it is reasonable to transfer data, and across which that expectation doesn't exist.
+Within an ACCOUNT there may be multiple ENVIRONMENTs.
+Each ENVIRONMENT is bound to a region of a specific cloud provider, e.g. AWS us-east-1.
+An ENVIRONMENT is the unit within which it is reasonable to transfer data, and across which that expectation doesn't exist.
 
-Within each REGION there may be multiple CLUSTERs, which correspond roughly to timely dataflow instances.
+Within each ENVIRONMENT there may be multiple CLUSTERs, which correspond roughly to timely dataflow instances.
 A CLUSTER contains indexes and is the unit within which it is possible to share indexes.
 
-Within each REGION there may be multiple TIMELINEs, which correspond roughly to coordinator timelines.
+Within each ENVIRONMENT there may be multiple TIMELINEs, which correspond roughly to coordinator timelines.
 A TIMELINE contains collections, and is the unit within which it is possible to query across multiple collections
 
-The main restrictions we plan to impose on users is that their access to data is always associated with a REGION, CLUSTER, and TIMELINE, and attempts to access data across these may result in poorer performance, or explicit query rejection.
+The main restrictions we plan to impose on users is that their access to data is always associated with a ENVIRONMENT, CLUSTER, and TIMELINE, and attempts to access data across these may result in poorer performance, or explicit query rejection.
 
 There is some work to do to present these concepts to users, but prior work exists with e.g. SQL `database`s for TIMELINE and Snowflake's `USE WAREHOUSE` command to pilot CLUSTER.
 
@@ -85,7 +86,7 @@ For example, STORAGE may reasonably conclude that it cannot rely on determinism 
 
 There are any number of secondary requirements and additional commands that can be exposed (for example, to drop sources, manage timeouts of subscriptions, advance compaction of collections, set and modify rendition reconciliation policies, etc).
 
-STORAGE can be sharded into REGIONs.
+STORAGE can be sharded into ENVIRONMENTs.
 
 ### COMPUTE
 
@@ -102,7 +103,7 @@ Its primary requirements include (all from CONTROL)
 Each CLUSTER is by design stateless, and should be explicitly instructed in what is required of it.
 
 COMPUTE can be sharded into CLUSTERs.
-Each CLUSTER is bound to one REGION.
+Each CLUSTER is bound to one ENVIRONMENT.
 Views installed in one CLUSTER can be used in that same CLUSTER, but cannot be used by others without a round-trip through STORAGE.
 
 ### CONTROL

--- a/doc/developer/platform/sql-catalog.md
+++ b/doc/developer/platform/sql-catalog.md
@@ -3,9 +3,9 @@
 The following is a candidate proposal for how to map the SQL catalog to Platform
 concepts.
 
-An ACCOUNT contains REGIONS. Each REGION contains an independent SQL catalog.
-A SQL catalog contains DATABASES, which each contain SCHEMAS, which each contain
-OBJECTS. An OBJECT is a SOURCE, SINK, VIEW, TABLE, or INDEX.
+An ACCOUNT contains ENVIRONMENTs. Each ENVIRONMENT contains an independent SQL
+catalog. A SQL catalog contains DATABASEs, which each contain SCHEMAs, which
+each contain OBJECTs. An OBJECT is a SOURCE, SINK, VIEW, TABLE, or INDEX.
 
 At the moment, a DATABASE or SCHEMA is a simple namespace and confers no
 additional semantics. We plan to soon think about how DATABASES map to


### PR DESCRIPTION
To match the terminology we're already using in Materialize Cloud. The
term ENVIRONMENT has less baggage and makes it clear that it refers to a
a specific customer's workspace within a cloud provider region, rather
than the cloud provider region itself.

### Motivation

* We've been interchanging the terms REGION and ENVIRONMENT in a way that's real confusing to other folks.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
