### PR TITLE
sources: remove BYO timestamping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,7 +978,6 @@ dependencies = [
  "kafka-util",
  "lazy_static",
  "log",
- "mz-avro",
  "mz-aws-util",
  "ore",
  "persist",

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -107,6 +107,10 @@ These changes are present in [unstable builds](/versions/#unstable-builds) and
 are slated for inclusion in the next stable release. There may be additional
 changes that have not yet been documented.
 
+- **Breaking change.** Drop support for the `consistency_topic` option when
+  creating a `DEBEZIUM` source. This was an undocumented option that is no
+  longer relevant.
+
 - **Breaking change.** Fix parsing of certain `INTERVAL head_time_unit TO tail_time_unit`
   expressions involving two-component time expressions {{% gh 7918 %}}.
 

--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -28,7 +28,6 @@ kafka-util = { path = "../kafka-util" }
 lazy_static = "1.4.0"
 log = "0.4.13"
 tracing = "0.1.29"
-mz-avro = { path = "../avro", features = ["snappy"] }
 mz-aws-util = { path = "../aws-util" }
 ore = { path = "../ore", features = ["task"] }
 persist = { path = "../persist" }

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -4476,7 +4476,7 @@ where
     /// be used to prevent users from doing things that are either meaningless
     /// (joining data from timelines that have similar numbers with different
     /// meanings like two separate debezium topics) or will never complete (joining
-    /// byo and realtime data).
+    /// cdcv2 and realtime data).
     fn validate_timeline(&self, mut ids: Vec<GlobalId>) -> Result<Option<Timeline>, CoordError> {
         let mut timelines: HashMap<GlobalId, Timeline> = HashMap::new();
 

--- a/src/coord/src/timestamp.rs
+++ b/src/coord/src/timestamp.rs
@@ -9,8 +9,6 @@
 
 use std::cmp;
 use std::collections::HashMap;
-use std::ops::Deref;
-use std::panic;
 use std::str;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::TryRecvError;
@@ -18,25 +16,17 @@ use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
-use anyhow::{bail, Context};
-use itertools::Itertools;
-use lazy_static::lazy_static;
-use mz_avro::schema::Schema;
-use mz_avro::types::Value;
+use anyhow::bail;
 use ore::metric;
 use ore::metrics::{GaugeVecExt, IntGaugeVec, MetricsRegistry};
 use rdkafka::consumer::{BaseConsumer, Consumer};
-use rdkafka::message::BorrowedMessage;
-use rdkafka::message::Message;
 use rdkafka::ClientConfig;
 use tokio::sync::mpsc;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info};
 
 use dataflow_types::sources::{
-    encoding::DataEncoding,
-    persistence::{Consistency, TimestampSourceUpdate},
-    DebeziumMode, ExternalSourceConnector, FileSourceConnector, KafkaSourceConnector,
-    KinesisSourceConnector, MzOffset, S3SourceConnector, SourceConnector, SourceEnvelope,
+    persistence::TimestampSourceUpdate, ExternalSourceConnector, FileSourceConnector,
+    KafkaSourceConnector, KinesisSourceConnector, S3SourceConnector, SourceConnector,
 };
 use expr::{GlobalId, PartitionId};
 use kafka_util::client::MzClientContext;
@@ -45,51 +35,6 @@ use ore::collections::CollectionExt;
 use crate::coord;
 
 const CONF_DENYLIST: &'static [&'static str] = &["statistics.interval.ms"];
-
-lazy_static! {
-    /// Key schema for Debezium consistency sources.
-    static ref DEBEZIUM_TRX_SCHEMA_KEY: Schema = {
-        r#"{
-          "name": "io.debezium.connector.common.TransactionMetadataKey",
-          "type": "record",
-          "fields": [{"name": "id", "type": "string"}]
-        }"#.parse().unwrap()
-    };
-
-    /// Value schema for Debezium consistency sources.
-    static ref DEBEZIUM_TRX_SCHEMA_VALUE: Schema = {
-        r#"{
-          "type": "record",
-          "name": "TransactionMetadataValue",
-          "namespace": "io.debezium.connector.common",
-          "fields": [
-            {"name": "status", "type": "string"},
-            {"name": "id", "type": "string"},
-            {"name": "event_count", "type": ["null", "long"], "default": null},
-            {
-              "name": "data_collections",
-              "type": [
-                "null",
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "record",
-                    "name": "ConnectDefault",
-                    "namespace": "io.confluent.connect.Avro",
-                    "fields": [
-                      {"name": "data_collection", "type": "string"},
-                      {"name": "event_count", "type": "long"}
-                    ]
-                  }
-                }
-              ],
-              "default": null
-            }
-          ],
-          "connect.name": "io.debezium.connector.common.TransactionMetadataValue"
-        }"#.parse().unwrap()
-    };
-}
 
 #[derive(Debug)]
 pub enum TimestampMessage {
@@ -111,40 +56,6 @@ enum RtTimestampConnector {
     S3(RtS3Connector),
 }
 
-enum ByoTimestampConnector {
-    Kafka(ByoKafkaConnector),
-}
-
-// List of possible encoding types
-enum ValueEncoding {
-    Bytes(Vec<u8>),
-}
-
-/// Timestamp consumer: wrapper around source consumers that stores necessary information
-/// about topics and offset for byo consistency
-struct ByoTimestampConsumer {
-    /// Source Connector
-    connector: ByoTimestampConnector,
-    /// The name of the source with which this connector is associated
-    ///
-    /// * For kafka this is the topic
-    /// * For file types this is the file name
-    source_name: String,
-    /// The format of the connector
-    envelope: ConsistencyFormatting,
-    /// The max assigned timestamp.
-    last_ts: u64,
-    /// The max offset for which a timestamp has been assigned
-    last_offset: MzOffset,
-}
-
-/// Supported format/envelope pairs for consistency topic decoding
-enum ConsistencyFormatting {
-    /// The formatting of this consistency source follows the
-    /// Debezium Avro format
-    DebeziumAvro,
-}
-
 /// Data consumer for Kafka source with RT consistency
 #[derive(Clone)]
 struct RtKafkaConnector {
@@ -161,29 +72,6 @@ struct TimestampingState {
     coordinator_channel: mpsc::UnboundedSender<coord::Message>,
 }
 
-/// Data consumer for Kafka source with BYO consistency
-struct ByoKafkaConnector {
-    consumer: BaseConsumer<MzClientContext>,
-
-    /// Offset of the last consistency record we received and processed. We use
-    /// this to filter out messages that we have seen already.
-    ///
-    /// Session timeouts, together with consumer-group re-arrangement, combined
-    /// with the fact that we don't commit read offsets for the BYO consumer
-    /// can lead to cases where an existing consumer starts reading the
-    /// consistency topic from the beginning, after a connection outage.
-    last_offset: Option<i64>,
-}
-
-impl ByoKafkaConnector {
-    fn new(consumer: BaseConsumer<MzClientContext>) -> ByoKafkaConnector {
-        ByoKafkaConnector {
-            consumer,
-            last_offset: None,
-        }
-    }
-}
-
 /// Data consumer stub for Kinesis source with RT consistency
 struct RtKinesisConnector {}
 
@@ -192,59 +80,6 @@ struct RtFileConnector {}
 
 /// Data consumer stub for S3 source with RT consistency
 struct RtS3Connector {}
-
-fn byo_query_source(
-    consumer: &mut ByoTimestampConsumer,
-) -> Result<Vec<ValueEncoding>, anyhow::Error> {
-    let mut messages = vec![];
-    match &mut consumer.connector {
-        ByoTimestampConnector::Kafka(kafka_connector) => {
-            while let Some(message) = kafka_get_next_message(&mut kafka_connector.consumer)? {
-                if let Some(last_offset) = kafka_connector.last_offset {
-                    if message.offset() <= last_offset {
-                        // it would probably be nicer to print the decoded
-                        // message here. But we don't know the message format
-                        // and I don't necessarily want to pipe Kafka specifics
-                        // (offsets) to the decoding part.
-                        debug!(
-                            "Received BYO consistency record that we have received before: {:?}",
-                            message
-                        );
-                        continue;
-                    }
-                }
-                kafka_connector.last_offset = Some(message.offset());
-
-                match message.payload() {
-                    Some(payload) => {
-                        messages.push(ValueEncoding::Bytes(payload.to_vec()));
-                    }
-                    None => {
-                        bail!("unexpected null payload");
-                    }
-                }
-            }
-        }
-    }
-    Ok(messages)
-}
-
-/// Polls a message from a Kafka Source
-fn kafka_get_next_message(
-    consumer: &mut BaseConsumer<MzClientContext>,
-) -> Result<Option<BorrowedMessage>, anyhow::Error> {
-    if let Some(result) = consumer.poll(Duration::from_millis(60)) {
-        match result {
-            Ok(message) => Ok(Some(message)),
-
-            Err(err) => {
-                bail!("Failed to process message {}", err);
-            }
-        }
-    } else {
-        Ok(None)
-    }
-}
 
 /// Return the list of partition ids associated with a specific topic
 fn get_kafka_partitions(
@@ -272,9 +107,6 @@ fn get_kafka_partitions(
 pub struct Timestamper {
     /// Current list of up to date sources that use a real time consistency model
     rt_sources: HashMap<GlobalId, RtTimestampConsumer>,
-
-    /// Current list of up to date sources that use a BYO consistency model
-    byo_sources: HashMap<GlobalId, ByoTimestampConsumer>,
 
     /// Channel through which timestamp data updates are communicated through the coordinator
     tx: mpsc::UnboundedSender<coord::Message>,
@@ -306,214 +138,6 @@ impl Metrics {
     }
 }
 
-/// Implements the byo timestamping logic
-///
-/// If the partition count remains the same:
-/// A new timestamp should be
-/// 1) strictly greater than the last timestamp in this partition
-/// 2) greater or equal to all the timestamps that have been assigned so far across all partitions
-/// If the partition count increases:
-/// A new timestamp should be:
-/// 1) strictly greater than the last timestamp
-/// This is necessary to guarantee that this timestamp *could not have been closed yet*
-///
-/// Supports two envelopes: None and Debezium. Currentlye compatible with Debezium format 1.1
-fn update_source_timestamps(
-    id: &GlobalId,
-    tx: &mpsc::UnboundedSender<coord::Message>,
-    byo_consumer: &mut ByoTimestampConsumer,
-) -> Result<(), anyhow::Error> {
-    let messages = byo_query_source(byo_consumer)?;
-    match byo_consumer.envelope {
-        ConsistencyFormatting::DebeziumAvro => {
-            for msg in messages {
-                let ValueEncoding::Bytes(msg) = msg;
-                // The first 5 bytes are reserved for the schema id/schema registry information
-                let mut bytes = &msg[5..];
-                let res = mz_avro::from_avro_datum(&DEBEZIUM_TRX_SCHEMA_VALUE, &mut bytes);
-                match res {
-                    Err(_) => {
-                        // This was a key message, can safely ignore it
-                        // TODO (#6671): raise error on failure to parse
-                        continue;
-                    }
-                    Ok(record) => {
-                        generate_ts_updates_from_debezium(&id, tx, byo_consumer, record)?;
-                    }
-                }
-            }
-        }
-    }
-
-    Ok(())
-}
-
-/// Extracts Materialize timestamp updates from a Debezium consistency record.
-fn generate_ts_updates_from_debezium(
-    id: &GlobalId,
-    tx: &mpsc::UnboundedSender<coord::Message>,
-    byo_consumer: &mut ByoTimestampConsumer,
-    value: Value,
-) -> Result<(), anyhow::Error> {
-    if let Value::Record(record) = value {
-        let results =
-            parse_debezium(record).with_context(|| format!("Failed to parse debezium record"))?;
-
-        // Results are only returned when the record's status type is END
-        if let Some(results) = results {
-            byo_consumer.last_ts += 1;
-            for (topic, count) in results {
-                // Debezium topics are formatted as "server_name.database.topic", but
-                // entries in data_collection do not contain server_name
-                // so we discard it before doing the comparison.
-                // We check for both here
-                // TODO(): possible performance issue here?
-                let parsed_source_name = byo_consumer.source_name.split('.').skip(1).join(".");
-                if byo_consumer.source_name == topic.trim() || parsed_source_name == topic.trim() {
-                    byo_consumer.last_offset.offset += count;
-                    // Debezium consistency topic should only work for single-partition
-                    // topics
-                    tx.send(coord::Message::AdvanceSourceTimestamp(
-                        coord::AdvanceSourceTimestamp {
-                            id: *id,
-                            update: TimestampSourceUpdate::BringYourOwn(
-                                match byo_consumer.connector {
-                                    ByoTimestampConnector::Kafka(_) => PartitionId::Kafka(0),
-                                },
-                                byo_consumer.last_ts,
-                                byo_consumer.last_offset,
-                            ),
-                        },
-                    ))
-                    .expect("Failed to send update to coordinator");
-                }
-            }
-        }
-    } else {
-        bail!("Expected record type for value, got {:?}", value);
-    }
-
-    Ok(())
-}
-
-/// A debezium record contains a set of update counts for each topic that the transaction
-/// updated. This function extracts the set of (topic, update_count) as a vector if
-/// processing an END message. It returns NONE otherwise.
-fn parse_debezium(
-    record: Vec<(String, Value)>,
-) -> Result<Option<Vec<(String, i64)>>, anyhow::Error> {
-    let mut collections = vec![];
-    let mut event_count = 0;
-    for (key, value) in record {
-        match (key.as_str(), value) {
-            ("data_collections", Value::Union { inner: value, .. }) => match *value {
-                Value::Array(items) => {
-                    for v in items {
-                        match v {
-                            Value::Record(item) => {
-                                let mut collection: Option<String> = None;
-                                let mut event_count: Option<i64> = None;
-                                for (k, v) in item {
-                                    match (k.as_str(), v) {
-                                        ("data_collection", Value::String(data)) => {
-                                            collection = Some(data)
-                                        }
-                                        ("data_collection", v) => {
-                                            bail!(
-                                                "Expected string for field 'data_collection', got {:?}",
-                                                v
-                                            );
-                                        }
-                                        ("event_count", Value::Long(e)) => event_count = Some(e),
-                                        ("event_count", v) => {
-                                            bail!(
-                                                "Expected long for field 'event_count', got {:?}",
-                                                v
-                                            );
-                                        }
-                                        (_, _) => (),
-                                    }
-                                }
-                                match (collection, event_count) {
-                                    (Some(c), Some(e)) => collections.push((c, e)),
-                                    (c, w) => {
-                                        bail!(
-                                        "Missing count or collection name. Parsed collection={:?}, event_count={:?}",
-                                        c, w);
-                                    }
-                                }
-                            }
-                            _ => {
-                                bail!("Record expected, got {:?}", v);
-                            }
-                        }
-                    }
-                }
-                _ => {
-                    bail!(
-                        "Expected Array for field 'data_collections', got {:?}",
-                        value
-                    );
-                }
-            },
-            ("data_collections", v) => {
-                bail!("Expection Union for field 'data_collections', got {:?}", v);
-            }
-            ("event_count", Value::Union { inner: value, .. }) => match *value {
-                Value::Long(e) => event_count = e,
-                _ => {
-                    bail!("Expected Long for field 'event_count', got {:?}", value);
-                }
-            },
-            ("event_count", v) => {
-                bail!("Expected Union for field 'event_count', got {:?}", v);
-            }
-            ("status", Value::String(status)) => match status.as_str() {
-                "BEGIN" => return Ok(None),
-                "END" => (),
-                _ => bail!(
-                    "Expect 'BEGIN' or 'END' for field 'status', got {:?}",
-                    status
-                ),
-            },
-            ("status", v) => {
-                bail!("Expected String for field 'status', got {:?}", v);
-            }
-            (_, _) => (),
-        }
-    }
-    if event_count < 0 {
-        bail!("Expected non-negative event count, got '{}'", event_count);
-    }
-    if collections.iter().map(|(_, c)| c).sum::<i64>() != event_count {
-        bail!(
-            "Event count '{:?}' does not match parsed collections: {:?}",
-            event_count,
-            collections
-        );
-    }
-    Ok(Some(collections))
-}
-
-/// This function determines the expected format of the consistency metadata as a function
-/// of the encoding and the envelope of the source.
-/// Specifically:
-/// 1) an OCF file source with a Debezium envelope will expect an OCF Avro consistency source
-/// that follows the TRX_METADATA_SCHEMA Avro spec outlined above
-/// 2) any other file source with a Debezium envelope will expect an Avro consistency source
-/// that follows the TRX_METADATA_SCHEMA Avro spec outlined above
-fn identify_consistency_format(_enc: DataEncoding, env: SourceEnvelope) -> ConsistencyFormatting {
-    match env {
-        SourceEnvelope::Debezium(dbz_envelope) => match dbz_envelope.mode {
-            DebeziumMode::Upsert => {
-                panic!("BYO timestamping for Debezium Upsert sources not supported!")
-            }
-            _ => ConsistencyFormatting::DebeziumAvro,
-        },
-        _ => panic!("BYO timestamping for non-Debezium sources not supported!"),
-    }
-}
-
 impl Timestamper {
     pub fn new(
         frequency: Duration,
@@ -528,7 +152,6 @@ impl Timestamper {
 
         Self {
             rt_sources: HashMap::new(),
-            byo_sources: HashMap::new(),
             tx,
             rx,
             timestamp_frequency: frequency,
@@ -538,15 +161,12 @@ impl Timestamper {
 
     /// Run the update function in a loop at the specified frequency. Acquires timestamps using
     /// either the Kafka topic ground truth
-    /// TODO(ncrooks): move to thread local BYO implementation
     pub fn run(&mut self) {
         loop {
             thread::sleep(self.timestamp_frequency);
             let shutdown = self.update_sources();
             if shutdown {
                 return;
-            } else {
-                self.update_byo_timestamp();
             }
         }
     }
@@ -562,53 +182,25 @@ impl Timestamper {
         loop {
             match self.rx.try_recv() {
                 Ok(TimestampMessage::Add(source_id, sc)) => {
-                    let (sc, enc, env, cons) = if let SourceConnector::External {
-                        connector,
-                        encoding,
-                        envelope,
-                        consistency,
-                        ts_frequency: _,
-                        timeline: _,
-                    } = sc
-                    {
-                        (connector, encoding, envelope, consistency)
-                    } else {
-                        tracing::debug!(
-                            "Local source {} cannot be timestamped. Ignoring",
-                            source_id
-                        );
-                        continue;
+                    let sc = match sc {
+                        SourceConnector::External { connector, .. } => connector,
+                        _ => {
+                            tracing::debug!(
+                                "Local source {} cannot be timestamped. Ignoring",
+                                source_id
+                            );
+                            continue;
+                        }
                     };
 
-                    if !self.rt_sources.contains_key(&source_id)
-                        && !self.byo_sources.contains_key(&source_id)
-                    {
-                        // Did not know about source, must update
-                        match cons {
-                            Consistency::RealTime => {
-                                info!(
-                                    "Timestamping Source {} with Real Time Consistency.",
-                                    source_id
-                                );
-                                let consumer = self.create_rt_connector(source_id, sc);
-                                if let Some(consumer) = consumer {
-                                    self.rt_sources.insert(source_id, consumer);
-                                }
-                            }
-                            Consistency::BringYourOwn(consistency_topic) => {
-                                info!("Timestamping Source {} with BYO Consistency. Consistency Source: {:?}.",
-                                      source_id, consistency_topic);
-                                let consumer = self.create_byo_connector(
-                                    source_id,
-                                    sc,
-                                    enc.value(),
-                                    env,
-                                    consistency_topic.topic,
-                                );
-                                if let Some(consumer) = consumer {
-                                    self.byo_sources.insert(source_id, consumer);
-                                }
-                            }
+                    if !self.rt_sources.contains_key(&source_id) {
+                        info!(
+                            "Timestamping Source {} with Real Time Consistency.",
+                            source_id
+                        );
+                        let consumer = self.create_rt_connector(source_id, sc);
+                        if let Some(consumer) = consumer {
+                            self.rt_sources.insert(source_id, consumer);
                         }
                     }
                 }
@@ -645,29 +237,6 @@ impl Timestamper {
         }) = self.rt_sources.remove(&id)
         {
             coordination_state.stop.store(true, Ordering::SeqCst);
-        }
-        self.byo_sources.remove(&id);
-    }
-
-    /// Iterate over each source, updating BYO timestamps
-    ///
-    /// If an error is encountered while reading the sources, log an error message
-    /// and remove that source of BYO timestamps
-    fn update_byo_timestamp(&mut self) {
-        let mut invalid_byo_sources: Vec<GlobalId> = vec![];
-        for (id, byo_consumer) in self.byo_sources.iter_mut() {
-            // Get the next set of messages from the Consistency topic
-            if let Err(err) = update_source_timestamps(id, &self.tx, byo_consumer) {
-                error!(
-                    "Failed to correctly parse messages from source {}; {}",
-                    id, err
-                );
-                invalid_byo_sources.push(*id);
-            }
-        }
-
-        for id in invalid_byo_sources {
-            self.drop_source(id);
         }
     }
 
@@ -814,115 +383,6 @@ impl Timestamper {
         _fc: S3SourceConnector,
     ) -> Option<RtS3Connector> {
         Some(RtS3Connector {})
-    }
-
-    /// Creates a BYO connector
-    fn create_byo_connector(
-        &self,
-        id: GlobalId,
-        sc: ExternalSourceConnector,
-        enc: DataEncoding,
-        env: SourceEnvelope,
-        timestamp_topic: String,
-    ) -> Option<ByoTimestampConsumer> {
-        match sc {
-            ExternalSourceConnector::Kafka(kc) => {
-                let topic = kc.topic.clone();
-                match self.create_byo_kafka_connector(id, &kc, timestamp_topic) {
-                    Some(connector) => Some(ByoTimestampConsumer {
-                        source_name: topic,
-                        connector: ByoTimestampConnector::Kafka(connector),
-                        envelope: identify_consistency_format(enc, env),
-                        last_ts: 0,
-                        last_offset: MzOffset { offset: 0 },
-                    }),
-                    None => None,
-                }
-            }
-            ExternalSourceConnector::AvroOcf(_) => None, // BYO is not supported for OCF sources
-            ExternalSourceConnector::File(_) => None, // BYO is not supported for plain file sources
-            ExternalSourceConnector::Kinesis(_) => None, // BYO is not supported for Kinesis sources
-            ExternalSourceConnector::S3(_) => None,   // BYO is not supported for s3 sources
-            ExternalSourceConnector::Postgres(_) => None, // BYO is not supported for postgres sources
-            ExternalSourceConnector::PubNub(_) => None,   // BYO is not supported for pubnub sources
-        }
-    }
-
-    fn create_byo_kafka_connector(
-        &self,
-        id: GlobalId,
-        kc: &KafkaSourceConnector,
-        timestamp_topic: String,
-    ) -> Option<ByoKafkaConnector> {
-        let mut config = ClientConfig::new();
-        config
-            .set("enable.auto.commit", "false")
-            .set("enable.partition.eof", "false")
-            .set("auto.offset.reset", "earliest")
-            .set("session.timeout.ms", "6000")
-            .set("max.poll.interval.ms", "300000") // 5 minutes
-            .set("fetch.message.max.bytes", "134217728")
-            .set("enable.sparse.connections", "true")
-            .set("bootstrap.servers", &kc.addrs.to_string());
-
-        let group_id_prefix = kc.group_id_prefix.clone().unwrap_or_else(String::new);
-        config.set(
-            "group.id",
-            &format!(
-                "{}materialize-byo-{}-{}",
-                group_id_prefix, &timestamp_topic, id
-            ),
-        );
-
-        for (k, v) in &kc.config_options {
-            if !CONF_DENYLIST.contains(&k.as_str()) {
-                config.set(k, v);
-            }
-        }
-
-        match config.create_with_context(MzClientContext) {
-            Ok(consumer) => {
-                let consumer = ByoKafkaConnector::new(consumer);
-                consumer.consumer.subscribe(&[&timestamp_topic]).unwrap();
-
-                match get_kafka_partitions(
-                    &consumer.consumer,
-                    &timestamp_topic,
-                    Duration::from_secs(5),
-                )
-                .as_ref()
-                .map(Deref::deref)
-                {
-                    Ok([]) => {
-                        warn!(
-                            "Consistency topic {} does not exist; assuming it will exist soon",
-                            timestamp_topic
-                        );
-                        Some(consumer)
-                    }
-                    Ok([_]) => Some(consumer),
-                    Ok(partitions) => {
-                        error!(
-                            "Consistency topic should contain a single partition. Contains {}",
-                            partitions.len(),
-                        );
-                        None
-                    }
-                    Err(e) => {
-                        warn!(
-                            "Unable to fetch metadata about consistency topic {}; \
-                             assuming it exists with one partition (error: {})",
-                            timestamp_topic, e
-                        );
-                        Some(consumer)
-                    }
-                }
-            }
-            Err(e) => {
-                error!("Could not create a Kafka consumer. Error: {}", e);
-                None
-            }
-        }
     }
 }
 

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -162,7 +162,7 @@ pub enum StorageCommand {
     AdvanceSourceTimestamp {
         /// The ID of the timestamped source
         id: GlobalId,
-        /// The associated update (RT or BYO)
+        /// The associated update
         update: crate::types::sources::persistence::TimestampSourceUpdate,
     },
     /// Enable compaction in sources.

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -188,7 +188,6 @@ where
             connector,
             encoding,
             envelope,
-            consistency,
             ts_frequency,
             timeline: _,
         } => {
@@ -242,7 +241,6 @@ where
                 // Distribute read responsibility among workers.
                 active: active_read_worker,
                 timestamp_histories,
-                consistency,
                 timestamp_frequency: ts_frequency,
                 worker_id: scope.index(),
                 worker_count: scope.peers(),

--- a/test/kafka-exactly-once/after-restart.td
+++ b/test/kafka-exactly-once/after-restart.td
@@ -7,110 +7,98 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ set-regex match=\d{13} replacement=<TIMESTAMP>
-
-$ set schema={
-    "type": "record",
-    "name": "envelope",
-    "fields": [
-      {
-        "name": "before",
-        "type": [
-          {
-            "name": "row",
+$ set schema=[
+  {
+    "type": "array",
+    "items": {
+      "type": "record",
+      "name": "update",
+      "namespace": "com.materialize.cdc",
+      "fields": [
+        {
+          "name": "data",
+          "type": {
             "type": "record",
+            "name": "data",
             "fields": [
               {"name": "a", "type": "long"},
               {"name": "b", "type": "long"}
             ]
-          },
-          "null"
-        ]
+          }
+        },
+        {
+          "name": "time",
+          "type": "long"
+        },
+        {
+          "name": "diff",
+          "type": "long"
+        }
+      ]
+    }
+  },
+  {
+    "type": "record",
+    "name": "progress",
+    "namespace": "com.materialize.cdc",
+    "fields": [
+      {
+        "name": "lower",
+        "type": {
+          "type": "array",
+          "items": "long"
+        }
       },
-      { "name": "after", "type": ["row", "null"] }
+      {
+        "name": "upper",
+        "type": {
+          "type": "array",
+          "items": "long"
+        }
+      },
+      {
+        "name": "counts",
+        "type": {
+          "type": "array",
+          "items": {
+            "type": "record",
+            "name": "counts",
+            "fields": [
+              {
+                "name": "time",
+                "type": "long"
+              },
+              {
+                "name": "count",
+                "type": "long"
+              }
+            ]
+          }
+        }
+      }
     ]
   }
+  ]
 
-$ set trxschemakey={
-      "name": "io.debezium.connector.common.TransactionMetadataKey",
-      "type": "record",
-      "fields": [
-          {
-              "name": "id",
-              "type": "string"
-          }
-      ]
-  }
+$ kafka-ingest format=avro topic=input schema=${schema}
+{"array":[{"data":{"a":4,"b":1},"time":4,"diff":1}]}
+{"array":[{"data":{"a":5,"b":2},"time":4,"diff":1}]}
+{"com.materialize.cdc.progress":{"lower":[4],"upper":[5],"counts":[{"time":4,"count":2}]}}
 
-$ set trxschema={
-    "type":"record", "name":"TransactionMetadataValue", "namespace":"io.debezium.connector.common",
-    "fields":[
-    {"name":"status","type":"string"},
-    {"name":"id","type": "string"},
-    {"name": "event_count",
-    "type": ["null", "long"],
-    "default": null
-    },
-    {"name":"data_collections","type":["null",{"type":"array",
-    "items": {"type":"record",
-    "name":"ConnectDefault",
-    "namespace":"io.confluent.connect.Avro",
-    "fields": [ {
-    "name": "data_collection",
-    "type": "string"
-    },
-    {
-    "name": "event_count",
-    "type": "long" }]}}],
-    "default": null}],
-    "connect.name": "io.debezium.connector.common.TransactionMetadataValue"
-    }
-
-$ kafka-ingest format=avro topic=input-consistency timestamp=1 schema=${trxschemakey}
-{"id": "52"}
-
-$ kafka-ingest format=avro topic=input-consistency timestamp=1 schema=${trxschema}
-{"status":"BEGIN","id":"52","event_count":null,"data_collections":null}
-{"status":"END","id":"52","event_count":{"long": 2},"data_collections":{"array": [{"event_count": 2, "data_collection": "testdrive-input-${testdrive.seed}"}]}}
-
-$ kafka-ingest format=avro topic=input schema=${schema} timestamp=14
-{"before": null, "after": {"row": {"a": 4, "b": 1}}}
-{"before": null, "after": {"row": {"a": 5, "b": 2}}}
-
-$ kafka-verify format=avro sink=materialize.public.output_byo sort-messages=true
+$ kafka-verify format=avro sink=materialize.public.output sort-messages=true
 {"before": null, "after": {"row": {"a": 1, "b": 1}}, "transaction": {"id": "1"}}
 {"before": null, "after": {"row": {"a": 1, "b": 2}}, "transaction": {"id": "1"}}
 {"before": null, "after": {"row": {"a": 2, "b": 1}}, "transaction": {"id": "1"}}
 {"before": null, "after": {"row": {"a": 3, "b": 1}}, "transaction": {"id": "1"}}
 
-$ kafka-verify format=avro sink=materialize.public.output_byo sort-messages=true
+$ kafka-verify format=avro sink=materialize.public.output sort-messages=true
 {"before": null, "after": {"row": {"a": 11, "b": 11}}, "transaction": {"id": "2"}}
 {"before": null, "after": {"row": {"a": 22, "b": 11}}, "transaction": {"id": "2"}}
 
-$ kafka-verify format=avro sink=materialize.public.output_byo sort-messages=true
+$ kafka-verify format=avro sink=materialize.public.output sort-messages=true
 {"before": null, "after": {"row": {"a": 3, "b": 4}}, "transaction": {"id": "3"}}
 {"before": null, "after": {"row": {"a": 5, "b": 6}}, "transaction": {"id": "3"}}
 
-$ kafka-verify format=avro sink=materialize.public.output_byo sort-messages=true
+$ kafka-verify format=avro sink=materialize.public.output sort-messages=true
 {"before": null, "after": {"row": {"a": 4, "b": 1}}, "transaction": {"id": "4"}}
 {"before": null, "after": {"row": {"a": 5, "b": 2}}, "transaction": {"id": "4"}}
-
-# can't distinguish "transactions" with real-time timestamping
-
-# this first batch definitely comes first, though
-
-$ kafka-verify format=avro sink=materialize.public.output_rt sort-messages=true
-{"before": null, "after": {"row": {"a": 1, "b": 1}}, "transaction": {"id": "<TIMESTAMP>"}}
-{"before": null, "after": {"row": {"a": 1, "b": 2}}, "transaction": {"id": "<TIMESTAMP>"}}
-{"before": null, "after": {"row": {"a": 11, "b": 11}}, "transaction": {"id": "<TIMESTAMP>"}}
-{"before": null, "after": {"row": {"a": 2, "b": 1}}, "transaction": {"id": "<TIMESTAMP>"}}
-{"before": null, "after": {"row": {"a": 22, "b": 11}}, "transaction": {"id": "<TIMESTAMP>"}}
-{"before": null, "after": {"row": {"a": 3, "b": 1}}, "transaction": {"id": "<TIMESTAMP>"}}
-{"before": null, "after": {"row": {"a": 3, "b": 4}}, "transaction": {"id": "<TIMESTAMP>"}}
-{"before": null, "after": {"row": {"a": 5, "b": 6}}, "transaction": {"id": "<TIMESTAMP>"}}
-
-# these are the new messages
-
-$ kafka-verify format=avro sink=materialize.public.output_rt sort-messages=true
-{"before": null, "after": {"row": {"a": 4, "b": 1}}, "transaction": {"id": "<TIMESTAMP>"}}
-{"before": null, "after": {"row": {"a": 5, "b": 2}}, "transaction": {"id": "<TIMESTAMP>"}}

--- a/test/kafka-exactly-once/before-restart.td
+++ b/test/kafka-exactly-once/before-restart.td
@@ -7,140 +7,114 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ set-regex match=\d{13} replacement=<TIMESTAMP>
-
-$ set schema={
-    "type": "record",
-    "name": "envelope",
-    "fields": [
-      {
-        "name": "before",
-        "type": [
-          {
-            "name": "row",
+$ set schema=[
+  {
+    "type": "array",
+    "items": {
+      "type": "record",
+      "name": "update",
+      "namespace": "com.materialize.cdc",
+      "fields": [
+        {
+          "name": "data",
+          "type": {
             "type": "record",
+            "name": "data",
             "fields": [
               {"name": "a", "type": "long"},
               {"name": "b", "type": "long"}
             ]
-          },
-          "null"
-        ]
+          }
+        },
+        {
+          "name": "time",
+          "type": "long"
+        },
+        {
+          "name": "diff",
+          "type": "long"
+        }
+      ]
+    }
+  },
+  {
+    "type": "record",
+    "name": "progress",
+    "namespace": "com.materialize.cdc",
+    "fields": [
+      {
+        "name": "lower",
+        "type": {
+          "type": "array",
+          "items": "long"
+        }
       },
-      { "name": "after", "type": ["row", "null"] }
+      {
+        "name": "upper",
+        "type": {
+          "type": "array",
+          "items": "long"
+        }
+      },
+      {
+        "name": "counts",
+        "type": {
+          "type": "array",
+          "items": {
+            "type": "record",
+            "name": "counts",
+            "fields": [
+              {
+                "name": "time",
+                "type": "long"
+              },
+              {
+                "name": "count",
+                "type": "long"
+              }
+            ]
+          }
+        }
+      }
     ]
   }
-
-$ set trxschemakey={
-      "name": "io.debezium.connector.common.TransactionMetadataKey",
-      "type": "record",
-      "fields": [
-          {
-              "name": "id",
-              "type": "string"
-          }
-      ]
-  }
-
-$ set trxschema={
-    "type":"record", "name":"TransactionMetadataValue", "namespace":"io.debezium.connector.common",
-    "fields":[
-    {"name":"status","type":"string"},
-    {"name":"id","type": "string"},
-    {"name": "event_count",
-    "type": ["null", "long"],
-    "default": null
-    },
-    {"name":"data_collections","type":["null",{"type":"array",
-    "items": {"type":"record",
-    "name":"ConnectDefault",
-    "namespace":"io.confluent.connect.Avro",
-    "fields": [ {
-    "name": "data_collection",
-    "type": "string"
-    },
-    {
-    "name": "event_count",
-    "type": "long" }]}}],
-    "default": null}],
-    "connect.name": "io.debezium.connector.common.TransactionMetadataValue"
-    }
-
-$ kafka-create-topic topic=input-consistency
+  ]
 
 $ kafka-create-topic topic=input
 
-> CREATE MATERIALIZED SOURCE input_rt
+> CREATE MATERIALIZED SOURCE input
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-${testdrive.seed}'
-  FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
+  FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE MATERIALIZE
 
-> CREATE SINK output_rt FROM input_rt
-  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-rt-sink-${testdrive.seed}'
-  WITH (reuse_topic=true)
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-
-> CREATE MATERIALIZED SOURCE input_byo
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-${testdrive.seed}'
-    WITH (consistency_topic = 'testdrive-input-consistency-${testdrive.seed}')
-  FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
-
-> CREATE SINK output_byo FROM input_byo
+> CREATE SINK output FROM input
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-byo-sink-${testdrive.seed}'
   WITH (reuse_topic=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
-$ kafka-ingest format=avro topic=input-consistency timestamp=1 schema=${trxschemakey}
-{"id": "10"}
-{"id": "30"}
-{"id": "40"}
+$ kafka-ingest format=avro topic=input schema=${schema}
+{"array":[{"data":{"a":1,"b":1},"time":1,"diff":1}]}
+{"array":[{"data":{"a":2,"b":1},"time":1,"diff":1}]}
+{"array":[{"data":{"a":3,"b":1},"time":1,"diff":1}]}
+{"array":[{"data":{"a":1,"b":2},"time":1,"diff":1}]}
+{"array":[{"data":{"a":11,"b":11},"time":2,"diff":1}]}
+{"array":[{"data":{"a":22,"b":11},"time":2,"diff":1}]}
+{"array":[{"data":{"a":3,"b":4},"time":3,"diff":1}]}
+{"array":[{"data":{"a":5,"b":6},"time":3,"diff":1}]}
+{"com.materialize.cdc.progress":{"lower":[0],"upper":[4],"counts":[{"time":1,"count":4},{"time":2,"count":2},{"time":3,"count":2}]}}
 
-$ kafka-ingest format=avro topic=input-consistency timestamp=1 schema=${trxschema}
-{"status":"BEGIN","id":"10","event_count":null,"data_collections":null}
-{"status":"END","id":"10","event_count":{"long": 4},"data_collections":{"array": [{"event_count": 4, "data_collection": "testdrive-input-${testdrive.seed}"}]}}
-{"status":"BEGIN","id":"30","event_count":null,"data_collections":null}
-{"status":"END","id":"30","event_count":{"long": 2},"data_collections":{"array": [{"event_count": 2, "data_collection": "testdrive-input-${testdrive.seed}"}]}}
-{"status":"BEGIN","id":"40","event_count":null,"data_collections":null}
-{"status":"END","id":"40","event_count":{"long": 2},"data_collections":{"array": [{"event_count": 2, "data_collection": "testdrive-input-${testdrive.seed}"}]}}
-
-$ kafka-ingest format=avro topic=input schema=${schema} timestamp=1
-{"before": null, "after": {"row": {"a": 1, "b": 1}}}
-{"before": null, "after": {"row": {"a": 2, "b": 1}}}
-{"before": null, "after": {"row": {"a": 3, "b": 1}}}
-{"before": null, "after": {"row": {"a": 1, "b": 2}}}
-
-$ kafka-ingest format=avro topic=input schema=${schema} timestamp=3
-{"before": null, "after": {"row": {"a": 11, "b": 11}}}
-{"before": null, "after": {"row": {"a": 22, "b": 11}}}
-
-$ kafka-ingest format=avro topic=input schema=${schema} timestamp=4
-{"before": null, "after": {"row": {"a": 3, "b": 4}}}
-{"before": null, "after": {"row": {"a": 5, "b": 6}}}
-
-$ kafka-verify format=avro sink=materialize.public.output_byo sort-messages=true
+$ kafka-verify format=avro sink=materialize.public.output sort-messages=true
 {"before": null, "after": {"row": {"a": 1, "b": 1}}, "transaction": {"id": "1"}}
 {"before": null, "after": {"row": {"a": 1, "b": 2}}, "transaction": {"id": "1"}}
 {"before": null, "after": {"row": {"a": 2, "b": 1}}, "transaction": {"id": "1"}}
 {"before": null, "after": {"row": {"a": 3, "b": 1}}, "transaction": {"id": "1"}}
 
-$ kafka-verify format=avro sink=materialize.public.output_byo sort-messages=true
+$ kafka-verify format=avro sink=materialize.public.output sort-messages=true
 {"before": null, "after": {"row": {"a": 11, "b": 11}}, "transaction": {"id": "2"}}
 {"before": null, "after": {"row": {"a": 22, "b": 11}}, "transaction": {"id": "2"}}
 
-$ kafka-verify format=avro sink=materialize.public.output_byo sort-messages=true
+$ kafka-verify format=avro sink=materialize.public.output sort-messages=true
 {"before": null, "after": {"row": {"a": 3, "b": 4}}, "transaction": {"id": "3"}}
 {"before": null, "after": {"row": {"a": 5, "b": 6}}, "transaction": {"id": "3"}}
-
-# can't distinguish "transactions" with real-time timestamping
-
-$ kafka-verify format=avro sink=materialize.public.output_rt sort-messages=true
-{"before": null, "after": {"row": {"a": 1, "b": 1}}, "transaction": {"id": "<TIMESTAMP>"}}
-{"before": null, "after": {"row": {"a": 1, "b": 2}}, "transaction": {"id": "<TIMESTAMP>"}}
-{"before": null, "after": {"row": {"a": 11, "b": 11}}, "transaction": {"id": "<TIMESTAMP>"}}
-{"before": null, "after": {"row": {"a": 2, "b": 1}}, "transaction": {"id": "<TIMESTAMP>"}}
-{"before": null, "after": {"row": {"a": 22, "b": 11}}, "transaction": {"id": "<TIMESTAMP>"}}
-{"before": null, "after": {"row": {"a": 3, "b": 1}}, "transaction": {"id": "<TIMESTAMP>"}}
-{"before": null, "after": {"row": {"a": 3, "b": 4}}, "transaction": {"id": "<TIMESTAMP>"}}
-{"before": null, "after": {"row": {"a": 5, "b": 6}}, "transaction": {"id": "<TIMESTAMP>"}}
 
 # Wait a bit to allow timestamp compaction to happen. We need to ensure that we
 # get correct results even with compaction, which re-timestamps earlier data

--- a/test/testdrive/avro-cdcv2.td
+++ b/test/testdrive/avro-cdcv2.td
@@ -93,7 +93,7 @@ $ set schema=[
 
 $ kafka-create-topic topic=data
 
-$ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
+$ kafka-ingest format=avro topic=data schema=${schema}
 {"array":[{"data":{"id":5,"price":{"int":10}},"time":5,"diff":1}]}
 {"array":[{"data":{"id":5,"price":{"int":12}},"time":4,"diff":1}]}
 {"array":[{"data":{"id":5,"price":{"int":12}},"time":5,"diff":-1}]}
@@ -105,7 +105,7 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
   FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE MATERIALIZE
 
-$ kafka-ingest format=avro topic=data schema=${schema} timestamp=2
+$ kafka-ingest format=avro topic=data schema=${schema}
 {"com.materialize.cdc.progress":{"lower":[0],"upper":[3],"counts":[]}}
 {"com.materialize.cdc.progress":{"lower":[3],"upper":[10],"counts":[{"time":4,"count":1},{"time":5,"count":2}, {"time": 6, "count": 1}]}}
 
@@ -114,7 +114,7 @@ id price
 --------
 5 10
 
-$ kafka-ingest format=avro topic=data schema=${schema} timestamp=3
+$ kafka-ingest format=avro topic=data schema=${schema}
 {"array":[{"data":{"id":5,"price":{"int":10}},"time":6,"diff":-1}]}
 
 > SELECT * FROM data_schema_inline
@@ -122,19 +122,19 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=3
 # Inject "junk" with a previous timestamp, which could simulate a materialized
 # that restarted and emits previously emitted data at a compacted timestamp
 
-$ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
+$ kafka-ingest format=avro topic=data schema=${schema}
 {"array":[{"data":{"id":5,"price":{"int":10}},"time":5,"diff":1}]}
 {"array":[{"data":{"id":5,"price":{"int":12}},"time":4,"diff":1}]}
 {"array":[{"data":{"id":5,"price":{"int":12}},"time":5,"diff":-1}]}
 
-$ kafka-ingest format=avro topic=data schema=${schema} timestamp=2
+$ kafka-ingest format=avro topic=data schema=${schema}
 {"com.materialize.cdc.progress":{"lower":[3],"upper":[6],"counts":[{"time":4,"count":1},{"time":5,"count":2}]}}
 
 > SELECT * FROM data_schema_inline
 
 # and now, new data again
 
-$ kafka-ingest format=avro topic=data schema=${schema} timestamp=4
+$ kafka-ingest format=avro topic=data schema=${schema}
 {"array":[{"data":{"id":6,"price":{"int":10}},"time":10,"diff":1}]}
 
 $ kafka-ingest format=avro topic=data schema=${schema} timestamp=5

--- a/test/testdrive/consolidation.td
+++ b/test/testdrive/consolidation.td
@@ -19,68 +19,82 @@
 # transaction is assigned timestamp 1, data from the second is assigned
 # timestamp 2, and so on.
 
-$ set nums-schema={
+$ set nums-schema=[
+  {
+    "type": "array",
+    "items": {
+      "type": "record",
+      "name": "update",
+      "namespace": "com.materialize.cdc",
+      "fields": [
+        {
+          "name": "data",
+          "type": {
+            "type": "record",
+            "name": "data",
+            "fields": [{"name": "num", "type": "long"}]
+          }
+        },
+        {
+          "name": "time",
+          "type": "long"
+        },
+        {
+          "name": "diff",
+          "type": "long"
+        }
+      ]
+    }
+  },
+  {
     "type": "record",
-    "name": "envelope",
+    "name": "progress",
+    "namespace": "com.materialize.cdc",
     "fields": [
       {
-        "name": "before",
-        "type": [
-          {
-            "name": "row",
-            "type": "record",
-            "fields": [{"name": "num", "type": "long"}]
-          },
-          "null"
-        ]
+        "name": "lower",
+        "type": {
+          "type": "array",
+          "items": "long"
+        }
       },
-      { "name": "after", "type": ["row", "null"] }
+      {
+        "name": "upper",
+        "type": {
+          "type": "array",
+          "items": "long"
+        }
+      },
+      {
+        "name": "counts",
+        "type": {
+          "type": "array",
+          "items": {
+            "type": "record",
+            "name": "counts",
+            "fields": [
+              {
+                "name": "time",
+                "type": "long"
+              },
+              {
+                "name": "count",
+                "type": "long"
+              }
+            ]
+          }
+        }
+      }
     ]
   }
-
-$ set tx-schema={
-    "type": "record",
-    "name": "TransactionMetadataValue",
-    "namespace": "io.debezium.connector.common",
-    "fields": [
-      {"name": "status", "type": "string"},
-      {"name": "id", "type": "string"},
-      {
-        "name": "event_count",
-        "type": ["null", "long"],
-        "default": null
-      },
-      {
-        "name": "data_collections",
-        "type": [
-          "null",
-          {
-            "type": "array",
-            "items": {
-              "type": "record",
-              "name": "ConnectDefault",
-              "namespace": "io.confluent.connect.Avro",
-              "fields": [
-                {"name": "data_collection", "type": "string"},
-                {"name": "event_count", "type": "long"}
-              ]
-            }
-          }
-        ],
-        "default": null
-      }
-    ],
-    "connect.name": "io.debezium.connector.common.TransactionMetadataValue"
-  }
+  ]
 
 $ kafka-create-topic topic=nums
-$ kafka-create-topic topic=tx
 
 > CREATE MATERIALIZED SOURCE nums
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-nums-${testdrive.seed}'
-  WITH (consistency_topic = 'testdrive-tx-${testdrive.seed}')
   FORMAT AVRO USING SCHEMA '${nums-schema}'
-  ENVELOPE DEBEZIUM
+  ENVELOPE MATERIALIZE
 
 # Disable logical compaction, to ensure we can view historical detail.
 > ALTER INDEX materialize.public.nums_primary_idx
@@ -97,19 +111,16 @@ $ kafka-create-topic topic=tx
 # transaction, and some of them are in their own transactions.
 
 $ kafka-ingest format=avro topic=nums schema=${nums-schema}
-{"before": null, "after": {"row": {"num": 1}}}
-{"before": {"row": {"num": 1}}, "after": {"row": {"num": 2}}}
-{"before": {"row": {"num": 2}}, "after": {"row": {"num": 3}}}
-{"before": {"row": {"num": 3}}, "after": {"row": {"num": 4}}}
-{"before": {"row": {"num": 4}}, "after": {"row": {"num": 5}}}
-
-$ kafka-ingest format=avro topic=tx schema=${tx-schema}
-{"status": "BEGIN", "id": "1", "event_count": null, "data_collections": null}
-{"status": "END", "id": "1", "event_count": {"long": 3}, "data_collections": {"array": [{"event_count": 3, "data_collection": "testdrive-nums-${testdrive.seed}"}]}}
-{"status": "BEGIN", "id": "2", "event_count": null, "data_collections": null}
-{"status": "END", "id": "2", "event_count": {"long": 1}, "data_collections": {"array": [{"event_count": 1, "data_collection": "testdrive-nums-${testdrive.seed}"}]}}
-{"status": "BEGIN", "id": "3", "event_count": null, "data_collections": null}
-{"status": "END", "id": "3", "event_count": {"long": 1}, "data_collections": {"array": [{"event_count": 1, "data_collection": "testdrive-nums-${testdrive.seed}"}]}}
+{"array":[{"data":{"num":1},"time":1,"diff":1}]}
+{"array":[{"data":{"num":1},"time":1,"diff":-1}]}
+{"array":[{"data":{"num":2},"time":1,"diff":1}]}
+{"array":[{"data":{"num":2},"time":1,"diff":-1}]}
+{"array":[{"data":{"num":3},"time":1,"diff":1}]}
+{"array":[{"data":{"num":3},"time":2,"diff":-1}]}
+{"array":[{"data":{"num":4},"time":2,"diff":1}]}
+{"array":[{"data":{"num":4},"time":3,"diff":-1}]}
+{"array":[{"data":{"num":5},"time":3,"diff":1}]}
+{"com.materialize.cdc.progress":{"lower":[0],"upper":[4],"counts":[{"time":1,"count":5},{"time":2,"count":2}, {"time": 3, "count": 2}]}}
 
 # Test that by default updates that occurred at the same time are consolidated,
 # but updates that occurred at distinct times are not.
@@ -171,11 +182,9 @@ mz_timestamp  mz_diff  num
   SET (logical_compaction_window = '1ms')
 
 $ kafka-ingest format=avro topic=nums schema=${nums-schema}
-{"before": {"row": {"num": 5}}, "after": {"row": {"num": 6}}}
-
-$ kafka-ingest format=avro topic=tx schema=${tx-schema}
-{"status": "BEGIN", "id": "4", "event_count": null, "data_collections": null}
-{"status": "END", "id": "4", "event_count": {"long": 1}, "data_collections": {"array": [{"event_count": 1, "data_collection": "testdrive-nums-${testdrive.seed}"}]}}
+{"array":[{"data":{"num":5},"time":4,"diff":-1}]}
+{"array":[{"data":{"num":6},"time":4,"diff":1}]}
+{"com.materialize.cdc.progress":{"lower":[4],"upper":[5],"counts":[{"time":4,"count":2}]}}
 
 # Data from older transactions should be immediately compacted to the timestamp
 # of the latest transaction (i.e., 4).
@@ -187,25 +196,21 @@ contains:Timestamp (3) is not valid for all inputs
 > SELECT * FROM nums AS OF 4
 6
 
-# Reset the compaction window back to default (currently 60s) and advance the
-# number in transactions 5 and 6.
+# Set the compaction window back to off and advance the number in transactions 5 and 6.
 
 > ALTER INDEX materialize.public.nums_primary_idx
-  RESET (logical_compaction_window)
+  SET (logical_compaction_window = 'off')
 
 # But also create an index that compacts frequently.
 > CREATE VIEW nums_compacted AS SELECT * FROM nums
 > CREATE DEFAULT INDEX ON nums_compacted WITH (logical_compaction_window = '1ms')
 
 $ kafka-ingest format=avro topic=nums schema=${nums-schema}
-{"before": {"row": {"num": 6}}, "after": {"row": {"num": 7}}}
-{"before": {"row": {"num": 7}}, "after": {"row": {"num": 8}}}
-
-$ kafka-ingest format=avro topic=tx schema=${tx-schema}
-{"status": "BEGIN", "id": "5", "event_count": null, "data_collections": null}
-{"status": "END", "id": "5", "event_count": {"long": 1}, "data_collections": {"array": [{"event_count": 1, "data_collection": "testdrive-nums-${testdrive.seed}"}]}}
-{"status": "BEGIN", "id": "6", "event_count": null, "data_collections": null}
-{"status": "END", "id": "6", "event_count": {"long": 1}, "data_collections": {"array": [{"event_count": 1, "data_collection": "testdrive-nums-${testdrive.seed}"}]}}
+{"array":[{"data":{"num":6},"time":5,"diff":-1}]}
+{"array":[{"data":{"num":7},"time":5,"diff":1}]}
+{"array":[{"data":{"num":7},"time":6,"diff":-1}]}
+{"array":[{"data":{"num":8},"time":6,"diff":1}]}
+{"com.materialize.cdc.progress":{"lower":[5],"upper":[7],"counts":[{"time":5,"count":2},{"time":6,"count":2}]}}
 
 # Timestamps 4, 5, and 6 should all be available due to the longer compaction
 # window.

--- a/test/testdrive/kafka-avro-debezium-sinks.td
+++ b/test/testdrive/kafka-avro-debezium-sinks.td
@@ -27,64 +27,79 @@ $ kafka-verify format=avro sink=materialize.public.data_sink sort-messages=true
 # all the possible combinations of user-specified sink key and
 # natural (primary) relation key.
 
-$ set schema={
-    "type": "record",
-    "name": "envelope",
-    "fields": [
-      {
-        "name": "before",
-        "type": [
-          {
-            "name": "row",
+$ set schema=[
+  {
+    "type": "array",
+    "items": {
+      "type": "record",
+      "name": "update",
+      "namespace": "com.materialize.cdc",
+      "fields": [
+        {
+          "name": "data",
+          "type": {
             "type": "record",
+            "name": "data",
             "fields": [
               {"name": "a", "type": "long"},
               {"name": "b", "type": "long"}
             ]
-          },
-          "null"
-        ]
+          }
+        },
+        {
+          "name": "time",
+          "type": "long"
+        },
+        {
+          "name": "diff",
+          "type": "long"
+        }
+      ]
+    }
+  },
+  {
+    "type": "record",
+    "name": "progress",
+    "namespace": "com.materialize.cdc",
+    "fields": [
+      {
+        "name": "lower",
+        "type": {
+          "type": "array",
+          "items": "long"
+        }
       },
-      { "name": "after", "type": ["row", "null"] }
+      {
+        "name": "upper",
+        "type": {
+          "type": "array",
+          "items": "long"
+        }
+      },
+      {
+        "name": "counts",
+        "type": {
+          "type": "array",
+          "items": {
+            "type": "record",
+            "name": "counts",
+            "fields": [
+              {
+                "name": "time",
+                "type": "long"
+              },
+              {
+                "name": "count",
+                "type": "long"
+              }
+            ]
+          }
+        }
+      }
     ]
   }
+  ]
 
-$ set trxschemakey={
-      "name": "io.debezium.connector.common.TransactionMetadataKey",
-      "type": "record",
-      "fields": [
-          {
-              "name": "id",
-              "type": "string"
-          }
-      ]
-  }
-
-$ set trxschema={
-    "type":"record", "name":"TransactionMetadataValue", "namespace":"io.debezium.connector.common",
-    "fields":[
-    {"name":"status","type":"string"},
-    {"name":"id","type": "string"},
-    {"name": "event_count",
-    "type": ["null", "long"],
-    "default": null
-    },
-    {"name":"data_collections","type":["null",{"type":"array",
-    "items": {"type":"record",
-    "name":"ConnectDefault",
-    "namespace":"io.confluent.connect.Avro",
-    "fields": [ {
-    "name": "data_collection",
-    "type": "string"
-    },
-    {
-    "name": "event_count",
-    "type": "long" }]}}],
-    "default": null}],
-    "connect.name": "io.debezium.connector.common.TransactionMetadataValue"
-    }
-
-$ kafka-create-topic topic=consistency
 $ kafka-create-topic topic=input
 
 # first create all the sinks, then ingest data, to ensure that
@@ -92,8 +107,7 @@ $ kafka-create-topic topic=input
 
 > CREATE MATERIALIZED SOURCE input
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-${testdrive.seed}'
-    WITH (consistency_topic = 'testdrive-consistency-${testdrive.seed}')
-  FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
+  FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE MATERIALIZE
 
 > CREATE SINK non_keyed_sink FROM input
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'non-keyed-sink'
@@ -124,22 +138,13 @@ $ kafka-create-topic topic=input
   WITH (consistency_topic = 'multi-keyed-sink-consistency') FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
-$ kafka-ingest format=avro topic=input schema=${schema} timestamp=1
-{"before": null, "after": {"row": {"a": 1, "b": 1}}}
-{"before": null, "after": {"row": {"a": 2, "b": 2}}}
-
-$ kafka-ingest format=avro topic=input schema=${schema} timestamp=1
-{"before": null, "after": {"row": {"a": 3, "b": 1}}}
-{"before": null, "after": {"row": {"a": 4, "b": 2}}}
-{"before": null, "after": {"row": {"a": 1, "b": 7}}}
-
-$ kafka-ingest format=avro topic=consistency timestamp=1 schema=${trxschema}
-{"status":"BEGIN","id":"1","event_count":null,"data_collections":null}
-{"status":"END","id":"1","event_count":{"long": 2},"data_collections":{"array": [{"event_count": 2, "data_collection": "testdrive-input-${testdrive.seed}"}]}}
-{"status":"BEGIN","id":"2","event_count":null,"data_collections":null}
-{"status":"END","id":"2","event_count":{"long": 2},"data_collections":{"array": [{"event_count": 2, "data_collection": "testdrive-input-${testdrive.seed}"}]}}
-{"status":"BEGIN","id":"3","event_count":null,"data_collections":null}
-{"status":"END","id":"3","event_count":{"long": 1},"data_collections":{"array": [{"event_count": 1, "data_collection": "testdrive-input-${testdrive.seed}"}]}}
+$ kafka-ingest format=avro topic=input schema=${schema}
+{"array":[{"data":{"a":1,"b":1},"time":1,"diff":1}]}
+{"array":[{"data":{"a":2,"b":2},"time":1,"diff":1}]}
+{"array":[{"data":{"a":3,"b":1},"time":2,"diff":1}]}
+{"array":[{"data":{"a":4,"b":2},"time":2,"diff":1}]}
+{"array":[{"data":{"a":1,"b":7},"time":3,"diff":1}]}
+{"com.materialize.cdc.progress":{"lower":[0],"upper":[4],"counts":[{"time":1,"count":2},{"time":2,"count":2},{"time":3,"count":1}]}}
 
 > SELECT * FROM input;
 a  b

--- a/test/testdrive/kafka-avro-upsert-sinks.td
+++ b/test/testdrive/kafka-avro-upsert-sinks.td
@@ -7,8 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# Test Avro UPSERT sinks. Some tests that should cover both DEBEZIUM and UPSERT
-# sinks are only in kafka-avro-upsert-sinks.td
+# Test Avro UPSERT sinks.
 
 # sinking directly from an UPSERT source with multi-part key
 
@@ -58,71 +57,85 @@ $ kafka-verify format=avro sink=materialize.public.upsert_input_sink
 {"key1": "fisch", "key2": 42} {"key1": "fisch", "key2": 42, "f1": "richtig, fisch", "f2": 2000}
 
 # More complicated scenarios: super keys, consistency input/output
-
-$ set schema={
-    "type": "record",
-    "name": "envelope",
-    "fields": [
-      {
-        "name": "before",
-        "type": [
-          {
-            "name": "row",
+$ set schema=[
+  {
+    "type": "array",
+    "items": {
+      "type": "record",
+      "name": "update",
+      "namespace": "com.materialize.cdc",
+      "fields": [
+        {
+          "name": "data",
+          "type": {
             "type": "record",
+            "name": "data",
             "fields": [
               {"name": "a", "type": "long"},
               {"name": "b", "type": "long"}
             ]
-          },
-          "null"
-        ]
+          }
+        },
+        {
+          "name": "time",
+          "type": "long"
+        },
+        {
+          "name": "diff",
+          "type": "long"
+        }
+      ]
+    }
+  },
+  {
+    "type": "record",
+    "name": "progress",
+    "namespace": "com.materialize.cdc",
+    "fields": [
+      {
+        "name": "lower",
+        "type": {
+          "type": "array",
+          "items": "long"
+        }
       },
-      { "name": "after", "type": ["row", "null"] }
+      {
+        "name": "upper",
+        "type": {
+          "type": "array",
+          "items": "long"
+        }
+      },
+      {
+        "name": "counts",
+        "type": {
+          "type": "array",
+          "items": {
+            "type": "record",
+            "name": "counts",
+            "fields": [
+              {
+                "name": "time",
+                "type": "long"
+              },
+              {
+                "name": "count",
+                "type": "long"
+              }
+            ]
+          }
+        }
+      }
     ]
   }
+  ]
 
-$ set trxschemakey={
-      "name": "io.debezium.connector.common.TransactionMetadataKey",
-      "type": "record",
-      "fields": [
-          {
-              "name": "id",
-              "type": "string"
-          }
-      ]
-  }
-
-$ set trxschema={
-    "type":"record", "name":"TransactionMetadataValue", "namespace":"io.debezium.connector.common",
-    "fields":[
-    {"name":"status","type":"string"},
-    {"name":"id","type": "string"},
-    {"name": "event_count",
-    "type": ["null", "long"],
-    "default": null
-    },
-    {"name":"data_collections","type":["null",{"type":"array",
-    "items": {"type":"record",
-    "name":"ConnectDefault",
-    "namespace":"io.confluent.connect.Avro",
-    "fields": [ {
-    "name": "data_collection",
-    "type": "string"
-    },
-    {
-    "name": "event_count",
-    "type": "long" }]}}],
-    "default": null}],
-    "connect.name": "io.debezium.connector.common.TransactionMetadataValue"
-    }
-
-$ kafka-create-topic topic=consistency
 $ kafka-create-topic topic=input
 
+# (PRIMARY KEY (id) NOT ENFORCED)
 > CREATE MATERIALIZED SOURCE input
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-${testdrive.seed}'
-    WITH (consistency_topic = 'testdrive-consistency-${testdrive.seed}')
-  FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
+  FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE MATERIALIZE
 
 > CREATE VIEW input_keyed AS SELECT a, max(b) as b FROM input GROUP BY a
 
@@ -138,22 +151,13 @@ $ kafka-create-topic topic=input
   WITH (consistency_topic = 'input-sink-consistency') FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' ENVELOPE UPSERT
 
-$ kafka-ingest format=avro topic=input schema=${schema} timestamp=1
-{"before": null, "after": {"row": {"a": 1, "b": 1}}}
-{"before": null, "after": {"row": {"a": 2, "b": 2}}}
-
-$ kafka-ingest format=avro topic=input schema=${schema} timestamp=1
-{"before": null, "after": {"row": {"a": 3, "b": 1}}}
-{"before": null, "after": {"row": {"a": 4, "b": 2}}}
-{"before": null, "after": {"row": {"a": 1, "b": 7}}}
-
-$ kafka-ingest format=avro topic=consistency timestamp=1 schema=${trxschema}
-{"status":"BEGIN","id":"1","event_count":null,"data_collections":null}
-{"status":"END","id":"1","event_count":{"long": 2},"data_collections":{"array": [{"event_count": 2, "data_collection": "testdrive-input-${testdrive.seed}"}]}}
-{"status":"BEGIN","id":"2","event_count":null,"data_collections":null}
-{"status":"END","id":"2","event_count":{"long": 2},"data_collections":{"array": [{"event_count": 2, "data_collection": "testdrive-input-${testdrive.seed}"}]}}
-{"status":"BEGIN","id":"3","event_count":null,"data_collections":null}
-{"status":"END","id":"3","event_count":{"long": 1},"data_collections":{"array": [{"event_count": 1, "data_collection": "testdrive-input-${testdrive.seed}"}]}}
+$ kafka-ingest format=avro topic=input schema=${schema}
+{"array":[{"data":{"a":1,"b":1},"time":1,"diff":1}]}
+{"array":[{"data":{"a":2,"b":2},"time":1,"diff":1}]}
+{"array":[{"data":{"a":3,"b":1},"time":2,"diff":1}]}
+{"array":[{"data":{"a":4,"b":2},"time":2,"diff":1}]}
+{"array":[{"data":{"a":1,"b":7},"time":3,"diff":1}]}
+{"com.materialize.cdc.progress":{"lower":[0],"upper":[4],"counts":[{"time":1,"count":2},{"time":2,"count":2}, {"time": 3, "count": 1}]}}
 
 > SELECT * FROM input;
 a  b
@@ -209,7 +213,7 @@ $ kafka-create-topic topic=input-with-deletions
 
 > CREATE MATERIALIZED SOURCE input_with_deletions
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-with-deletions-${testdrive.seed}'
-  FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
+  FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE MATERIALIZE
 
 > CREATE VIEW input_with_deletions_keyed AS SELECT a, max(b) as b FROM input_with_deletions GROUP BY a
 
@@ -218,13 +222,15 @@ $ kafka-create-topic topic=input-with-deletions
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' ENVELOPE UPSERT
 
 $ kafka-ingest format=avro topic=input-with-deletions schema=${schema}
-{"before": null, "after": {"row": {"a": 1, "b": 1}}}
+{"array":[{"data":{"a":1,"b":1},"time":1,"diff":1}]}
+{"com.materialize.cdc.progress":{"lower":[0],"upper":[2],"counts":[{"time":1,"count":1}]}}
 
 $ kafka-verify format=avro sink=materialize.public.input_with_deletions_sink sort-messages=true
 {"a": 1} {"a": 1, "b": 1}
 
 $ kafka-ingest format=avro topic=input-with-deletions schema=${schema}
-{"before": null, "after": {"row": {"a": 1, "b": 2}}}
+{"array":[{"data":{"a":1,"b":2},"time":2,"diff":1}]}
+{"com.materialize.cdc.progress":{"lower":[2],"upper":[3],"counts":[{"time":2,"count":1}]}}
 
 $ kafka-verify format=avro sink=materialize.public.input_with_deletions_sink sort-messages=true
 {"a": 1} {"a": 1, "b": 2}
@@ -232,10 +238,12 @@ $ kafka-verify format=avro sink=materialize.public.input_with_deletions_sink sor
 # deletion of the "shadowed" input should not cause downstream updates
 
 $ kafka-ingest format=avro topic=input-with-deletions schema=${schema}
-{"before": {"row": {"a": 1, "b": 1}}, "after": null}
+{"array":[{"data":{"a":1,"b":1},"time":3,"diff":-1}]}
+{"com.materialize.cdc.progress":{"lower":[3],"upper":[4],"counts":[{"time":3,"count":1}]}}
 
 $ kafka-ingest format=avro topic=input-with-deletions schema=${schema}
-{"before": {"row": {"a": 1, "b": 2}}, "after": null}
+{"array":[{"data":{"a":1,"b":2},"time":4,"diff":-1}]}
+{"com.materialize.cdc.progress":{"lower":[4],"upper":[5],"counts":[{"time":4,"count":1}]}}
 
 # now we should see a NULL update on the key, which means a DELETE
 
@@ -243,14 +251,16 @@ $ kafka-verify format=avro sink=materialize.public.input_with_deletions_sink sor
 {"a": 1}
 
 $ kafka-ingest format=avro topic=input-with-deletions schema=${schema}
-{"before": null, "after": {"row": {"a": 1, "b": 1}}}
-{"before": null, "after": {"row": {"a": 1, "b": 2}}}
+{"array":[{"data":{"a":1,"b":1},"time":5,"diff":1}]}
+{"array":[{"data":{"a":1,"b":2},"time":5,"diff":1}]}
+{"com.materialize.cdc.progress":{"lower":[5],"upper":[6],"counts":[{"time":5,"count":2}]}}
 
 $ kafka-verify format=avro sink=materialize.public.input_with_deletions_sink sort-messages=true
 {"a": 1} {"a": 1, "b": 2}
 
 $ kafka-ingest format=avro topic=input-with-deletions schema=${schema}
-{"before": {"row": {"a": 1, "b": 2}}, "after": null}
+{"array":[{"data":{"a":1,"b":2},"time":6,"diff":-1}]}
+{"com.materialize.cdc.progress":{"lower":[6],"upper":[7],"counts":[{"time":6,"count":1}]}}
 
 # removing the occluding input should "reveal" the previous input again
 #
@@ -263,7 +273,7 @@ $ kafka-create-topic topic=non-keyed-input
 
 > CREATE MATERIALIZED SOURCE non_keyed_input
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-non-keyed-input-${testdrive.seed}'
-  FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
+  FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE MATERIALIZE
 
 > CREATE SINK not_enforced_key FROM non_keyed_input
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'not-enforced-sink' KEY (a) NOT ENFORCED

--- a/test/testdrive/kafka-exactly-once-sink.td
+++ b/test/testdrive/kafka-exactly-once-sink.td
@@ -8,7 +8,80 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ set schema={
+$ set cdcv2-schema=[
+  {
+    "type": "array",
+    "items": {
+      "type": "record",
+      "name": "update",
+      "namespace": "com.materialize.cdc",
+      "fields": [
+        {
+          "name": "data",
+          "type": {
+            "type": "record",
+            "name": "data",
+            "fields": [
+              {"name": "a", "type": "long"},
+              {"name": "b", "type": "long"}
+            ]
+          }
+        },
+        {
+          "name": "time",
+          "type": "long"
+        },
+        {
+          "name": "diff",
+          "type": "long"
+        }
+      ]
+    }
+  },
+  {
+    "type": "record",
+    "name": "progress",
+    "namespace": "com.materialize.cdc",
+    "fields": [
+      {
+        "name": "lower",
+        "type": {
+          "type": "array",
+          "items": "long"
+        }
+      },
+      {
+        "name": "upper",
+        "type": {
+          "type": "array",
+          "items": "long"
+        }
+      },
+      {
+        "name": "counts",
+        "type": {
+          "type": "array",
+          "items": {
+            "type": "record",
+            "name": "counts",
+            "fields": [
+              {
+                "name": "time",
+                "type": "long"
+              },
+              {
+                "name": "count",
+                "type": "long"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+  ]
+
+$ set dbz-schema={
     "type": "record",
     "name": "envelope",
     "fields": [
@@ -30,51 +103,26 @@ $ set schema={
     ]
   }
 
-$ set trxschema={
-    "type":"record", "name":"TransactionMetadataValue", "namespace":"io.debezium.connector.common",
-    "fields":[
-    {"name":"status","type":"string"},
-    {"name":"id","type": "string"},
-    {"name": "event_count",
-    "type": ["null", "long"],
-    "default": null
-    },
-    {"name":"data_collections","type":["null",{"type":"array",
-    "items": {"type":"record",
-    "name":"ConnectDefault",
-    "namespace":"io.confluent.connect.Avro",
-    "fields": [ {
-    "name": "data_collection",
-    "type": "string"
-    },
-    {
-    "name": "event_count",
-    "type": "long" }]}}],
-    "default": null}],
-    "connect.name": "io.debezium.connector.common.TransactionMetadataValue"
-    }
+$ kafka-create-topic topic=input_dbz
+$ kafka-create-topic topic=input_cdcv2
 
-$ kafka-create-topic topic=input-consistency
-$ kafka-create-topic topic=input
+> CREATE MATERIALIZED SOURCE input_kafka_cdcv2
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input_cdcv2-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${cdcv2-schema}' ENVELOPE MATERIALIZE
 
-> CREATE MATERIALIZED SOURCE input_kafka_byo
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-${testdrive.seed}'
-    WITH (consistency_topic = 'testdrive-input-consistency-${testdrive.seed}')
-  FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
-
-> CREATE MATERIALIZED SOURCE input_kafka_no_byo
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-${testdrive.seed}'
-  FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
+> CREATE MATERIALIZED SOURCE input_kafka_dbz
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input_dbz-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${dbz-schema}' ENVELOPE DEBEZIUM
 
 > CREATE TABLE input_table (a bigint, b bigint)
 
-> CREATE MATERIALIZED VIEW input_kafka_byo_mview AS SELECT a + 2 AS a , b + 10 AS b from input_kafka_byo;
+> CREATE MATERIALIZED VIEW input_kafka_cdcv2_mview AS SELECT a + 2 AS a , b + 10 AS b from input_kafka_cdcv2;
 
-> CREATE MATERIALIZED VIEW input_kafka_byo_mview_view AS SELECT * FROM input_kafka_byo_mview;
+> CREATE MATERIALIZED VIEW input_kafka_cdcv2_mview_view AS SELECT * FROM input_kafka_cdcv2_mview;
 
-> CREATE VIEW input_kafka_no_byo_mview AS SELECT a + 2 AS a , b + 10 AS b from input_kafka_no_byo;
+> CREATE VIEW input_kafka_dbz_mview AS SELECT a + 2 AS a , b + 10 AS b from input_kafka_dbz;
 
-> CREATE MATERIALIZED VIEW input_kafka_no_byo_mview_view AS SELECT * FROM input_kafka_no_byo_mview;
+> CREATE MATERIALIZED VIEW input_kafka_dbz_mview_view AS SELECT * FROM input_kafka_dbz_mview;
 
 > CREATE MATERIALIZED VIEW input_table_mview AS SELECT a + 2 AS a , b + 10 AS b from input_table;
 
@@ -82,7 +130,7 @@ $ kafka-create-topic topic=input
 
 > CREATE MATERIALIZED VIEW input_values_mview AS VALUES (1), (2), (3);
 
-> CREATE MATERIALIZED VIEW input_kafka_no_byo_derived_table AS SELECT * FROM ( SELECT * FROM input_kafka_no_byo ) AS a1;
+> CREATE MATERIALIZED VIEW input_kafka_dbz_derived_table AS SELECT * FROM ( SELECT * FROM input_kafka_dbz ) AS a1;
 
 $ file-append path=static.csv
 city,state,zip
@@ -94,12 +142,12 @@ New York,NY,10004
   FROM FILE '${testdrive.temp-dir}/static.csv'
   FORMAT CSV WITH 3 COLUMNS
 
-> CREATE SINK output1 FROM input_kafka_byo
+> CREATE SINK output1 FROM input_kafka_cdcv2
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output1-view-${testdrive.seed}'
   WITH (reuse_topic=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
-> CREATE SINK output2 FROM input_kafka_no_byo
+> CREATE SINK output2 FROM input_kafka_dbz
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output2-view-${testdrive.seed}'
   WITH (reuse_topic=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
@@ -110,22 +158,22 @@ New York,NY,10004
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 contains:reuse_topic requires that sink input dependencies are sources, materialize.public.input_table is not
 
-> CREATE SINK output4 FROM input_kafka_byo_mview
+> CREATE SINK output4 FROM input_kafka_cdcv2_mview
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output4-view-${testdrive.seed}'
   WITH (reuse_topic=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
-> CREATE SINK output4_view FROM input_kafka_byo_mview_view
+> CREATE SINK output4_view FROM input_kafka_cdcv2_mview_view
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output4b-view-${testdrive.seed}'
   WITH (reuse_topic=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
-> CREATE SINK output5 FROM input_kafka_no_byo_mview
+> CREATE SINK output5 FROM input_kafka_dbz_mview
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output5-view-${testdrive.seed}'
   WITH (reuse_topic=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
-> CREATE SINK output5_view FROM input_kafka_no_byo_mview_view
+> CREATE SINK output5_view FROM input_kafka_dbz_mview_view
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output5b-view-${testdrive.seed}'
   WITH (reuse_topic=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
@@ -148,7 +196,7 @@ contains:reuse_topic requires that sink input dependencies are sources, material
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 contains:reuse_topic requires that sink input dependencies are sources, materialize.public.input_values_mview is not
 
-> CREATE SINK output12 FROM input_kafka_no_byo_derived_table
+> CREATE SINK output12 FROM input_kafka_dbz_derived_table
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output12-view-${testdrive.seed}'
   WITH (reuse_topic=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
@@ -158,14 +206,13 @@ contains:reuse_topic requires that sink input dependencies are sources, material
   WITH (reuse_topic=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
-> CREATE SINK output14_custom_consistency_topic FROM input_kafka_byo
+> CREATE SINK output14_custom_consistency_topic FROM input_kafka_cdcv2
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output1-view-${testdrive.seed}'
   WITH (reuse_topic=true, consistency_topic='output14-custom-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 # ensure that the sink works with log compaction enabled on the consistency topic
 
-$ kafka-create-topic topic=compaction-test-input-consistency
 $ kafka-create-topic topic=compaction-test-input
 
 # create topic with known compaction settings, instead of letting
@@ -174,21 +221,17 @@ $ kafka-create-topic topic=compaction-test-output-consistency compaction=true
 
 > CREATE MATERIALIZED SOURCE compaction_test_input
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-compaction-test-input-${testdrive.seed}'
-    WITH (consistency_topic = 'testdrive-compaction-test-input-consistency-${testdrive.seed}')
-  FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
+  FORMAT AVRO USING SCHEMA '${cdcv2-schema}' ENVELOPE MATERIALIZE
 
 > CREATE SINK compaction_test_sink FROM compaction_test_input
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'compaction-test-output-${testdrive.seed}'
   WITH (reuse_topic=true) FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' ENVELOPE DEBEZIUM
 
-$ kafka-ingest format=avro topic=compaction-test-input schema=${schema} timestamp=1
-{"before": null, "after": {"row": {"a": 1, "b": 1}}}
-{"before": null, "after": {"row": {"a": 2, "b": 2}}}
-
-$ kafka-ingest format=avro topic=compaction-test-input-consistency timestamp=1 schema=${trxschema}
-{"status":"BEGIN","id":"1","event_count":null,"data_collections":null}
-{"status":"END","id":"1","event_count":{"long": 2},"data_collections":{"array": [{"event_count": 2, "data_collection": "testdrive-compaction-test-input-${testdrive.seed}"}]}}
+$ kafka-ingest format=avro topic=compaction-test-input schema=${cdcv2-schema}
+{"array":[{"data":{"a":1,"b":1},"time":1,"diff":1}]}
+{"array":[{"data":{"a":2,"b":2},"time":1,"diff":1}]}
+{"com.materialize.cdc.progress":{"lower":[0],"upper":[2],"counts":[{"time":1,"count":2}]}}
 
 # We cannot observe the consistency topic, because compaction is not deterministic.
 # We indirectly test this by verifying that the data output is correct. If this
@@ -207,14 +250,14 @@ $ kafka-create-topic topic=rt-binding-consistency-test-input
 
 > CREATE MATERIALIZED SOURCE rt_binding_consistency_test_source
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-rt-binding-consistency-test-input-${testdrive.seed}'
-  FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
+  FORMAT AVRO USING SCHEMA '${dbz-schema}' ENVELOPE DEBEZIUM
 
 > CREATE SINK rt_binding_consistency_test_sink FROM rt_binding_consistency_test_source
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'rt-binding-consistency-test-output-${testdrive.seed}'
   WITH (reuse_topic=true) FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' ENVELOPE DEBEZIUM
 
-$ kafka-ingest format=avro topic=rt-binding-consistency-test-input schema=${schema} timestamp=1
+$ kafka-ingest format=avro topic=rt-binding-consistency-test-input schema=${dbz-schema} timestamp=1
 {"before": null, "after": {"row": {"a": 1, "b": 1}}}
 
 $ kafka-verify format=avro sink=materialize.public.rt_binding_consistency_test_sink
@@ -363,4 +406,4 @@ $ kafka-verify format=json sink=materialize.public.json_avro_upsert_key_2 key=tr
 # Verify compaction of exactly once sinks.
 $ verify-timestamp-compaction source=input_csv max-size=3 permit-progress=true
 $ verify-timestamp-compaction source=rt_binding_consistency_test_source max-size=3 permit-progress=true
-$ verify-timestamp-compaction source=input_kafka_no_byo max-size=3
+$ verify-timestamp-compaction source=input_kafka_dbz max-size=3

--- a/test/testdrive/kafka-time-offset.td
+++ b/test/testdrive/kafka-time-offset.td
@@ -28,12 +28,6 @@ contains:topic missing_topic does not exist
   FORMAT TEXT
 contains:`start_offset` and `kafka_time_offset` cannot be set at the same time.
 
-! CREATE MATERIALIZED SOURCE byo
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-t0-${testdrive.seed}'
-  WITH (kafka_time_offset=1, consistency_topic="t0")
-  FORMAT TEXT
-contains:`start_offset` is not yet implemented for non-realtime consistency sources.
-
 ! CREATE MATERIALIZED SOURCE not_a_number
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-t0-${testdrive.seed}'
   WITH (kafka_time_offset="not_a_number")

--- a/test/testdrive/timelines.td
+++ b/test/testdrive/timelines.td
@@ -31,23 +31,7 @@ $ set schema={
     ]
   }
 
-$ kafka-create-topic topic=input-consistency
 $ kafka-create-topic topic=input-system
-
-> CREATE MATERIALIZED SOURCE source_byo
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-${testdrive.seed}'
-    WITH (consistency_topic = 'testdrive-input-consistency-${testdrive.seed}')
-  FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
-
-> CREATE MATERIALIZED SOURCE source_byo_user
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-${testdrive.seed}'
-    WITH (consistency_topic = 'testdrive-input-consistency-${testdrive.seed}', timeline = 'user')
-  FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
-
-> CREATE MATERIALIZED SOURCE source_byo_user2
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-${testdrive.seed}'
-    WITH (consistency_topic = 'testdrive-input-consistency-${testdrive.seed}', timeline = 'user2')
-  FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
 
 > CREATE MATERIALIZED SOURCE source_system
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-system-${testdrive.seed}'
@@ -142,7 +126,7 @@ $ set schema=[
 
 $ kafka-create-topic topic=input-cdcv2
 
-$ kafka-ingest format=avro topic=input-cdcv2 schema=${schema} timestamp=1
+$ kafka-ingest format=avro topic=input-cdcv2 schema=${schema}
 {"array":[{"data":{"id":5,"price":{"int":10}},"time":5,"diff":1}]}
 {"array":[{"data":{"id":5,"price":{"int":12}},"time":4,"diff":1}]}
 {"array":[{"data":{"id":5,"price":{"int":12}},"time":5,"diff":-1}]}
@@ -185,28 +169,11 @@ contains:unexpected parameters for CREATE SOURCE: epoch_ms_timeline
 
 > CREATE MATERIALIZED VIEW input_values_mview AS VALUES (1), (2), (3);
 
-! CREATE VIEW must_fail (a, b, c, d) AS SELECT * FROM source_byo, source_system;
-contains:multiple timelines within one dataflow are not supported
-
-! CREATE MATERIALIZED VIEW must_fail (a, b, c, d) AS SELECT * FROM source_system, source_byo;
-contains:multiple timelines within one dataflow are not supported
-
-! CREATE MATERIALIZED VIEW must_fail (a, b, c, d) AS SELECT * FROM source_system, source_byo;
-contains:multiple timelines within one dataflow are not supported
-
 ! CREATE MATERIALIZED VIEW must_fail (a, b, c, d) AS SELECT * FROM source_system, source_cdcv2;
-contains:multiple timelines within one dataflow are not supported
-
-! CREATE MATERIALIZED VIEW must_fail (a, b, c, d) AS SELECT * FROM source_byo, source_cdcv2;
-contains:multiple timelines within one dataflow are not supported
-
-! CREATE MATERIALIZED VIEW must_fail AS SELECT (SELECT a FROM source_system LIMIT 1) FROM source_byo;
 contains:multiple timelines within one dataflow are not supported
 
 # Verify that user timelines don't allow things to be joinable with their non-user versions.
 ! CREATE MATERIALIZED VIEW must_fail (a, b, c, d) AS SELECT * FROM source_system, source_system_user;
-contains:multiple timelines within one dataflow are not supported
-! CREATE MATERIALIZED VIEW must_fail (a, b, c, d) AS SELECT * FROM source_byo, source_byo_user;
 contains:multiple timelines within one dataflow are not supported
 
 # Can join static view with anything.
@@ -215,51 +182,33 @@ contains:multiple timelines within one dataflow are not supported
 > CREATE VIEW values_system_view AS SELECT * FROM input_values_view, source_system;
 > CREATE VIEW values_system_user_view AS SELECT * FROM input_values_view, source_system_user;
 > CREATE VIEW values_cdcv2_view AS SELECT * FROM input_values_view, source_cdcv2;
-> CREATE VIEW values_byo_view AS SELECT * FROM input_values_view, source_byo;
-> CREATE VIEW values_byo_user_view AS SELECT * FROM input_values_view, source_byo_user;
 > CREATE VIEW values_mz_catalog_view (a, b, c, d, e, f, g, h, i, j, k, l, m, n) AS SELECT * FROM input_values_view, mz_catalog_names, mz_views, mz_source_info;
 
 # System sources, tables, and logs should be joinable with eachother.
 > CREATE VIEW various_system (a, b, c, d, e, f, g, h, i, j, k, l, m) AS SELECT * FROM mz_catalog_names, mz_views, mz_source_info;
 
 # System things should be joinable only with system sources.
-! CREATE VIEW must_fail (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) AS SELECT * FROM mz_catalog_names, mz_views, mz_source_info, source_byo;
-contains:multiple timelines within one dataflow are not supported
 ! CREATE VIEW must_fail (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) AS SELECT * FROM mz_catalog_names, mz_views, mz_source_info, source_cdcv2;
 contains:multiple timelines within one dataflow are not supported
-> CREATE VIEW various_system_no_byo (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) AS SELECT * FROM mz_catalog_names, mz_views, mz_source_info, source_system;
+> CREATE VIEW various_system_no_cdcv2 (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) AS SELECT * FROM mz_catalog_names, mz_views, mz_source_info, source_system;
 > CREATE VIEW various_system_table (a, b, c, d, e, f, g, h, i, j, k, l, m, n) AS SELECT * FROM mz_catalog_names, mz_views, mz_source_info, input_table;
 
 # EXPLAIN should complain too.
-! EXPLAIN SELECT * FROM source_system, source_byo;
+! EXPLAIN SELECT * FROM source_system, source_cdcv2;
 contains:multiple timelines within one dataflow are not supported
 
 # Can join user-specified timelines.
-> CREATE MATERIALIZED VIEW source_system_byo_user (a, b, c, d, e, f) AS SELECT * FROM source_system_user, source_byo_user, source_cdcv2_user;
-
-# Unless they are from different user timelines.
-! CREATE MATERIALIZED VIEW must_fail (a, b, c, d) AS SELECT * FROM source_byo_user, source_byo_user2;
-contains:multiple timelines within one dataflow are not supported
+> CREATE MATERIALIZED VIEW source_system_cdcv2_user (a, b, c, d) AS SELECT * FROM source_system_user, source_cdcv2_user;
 
 # CDCv2 can only be joined with system time stuff if specified
 > CREATE MATERIALIZED VIEW source_cdcv2_table_system AS SELECT * FROM source_cdcv2_system, input_table;
 ! CREATE MATERIALIZED VIEW must_fail AS SELECT * FROM source_cdcv2, input_table;
 contains:multiple timelines within one dataflow are not supported
 
-# Verify that timedomains don't cross timelines. In the case that
-# source_byo is grouped in the same timedomain as epoch ms sources,
-# the SELECT will hang forever. We expect the error here since we have
-# not written any rows so its upper is still 0, which determine_timestamp
-# complains about.
-> BEGIN;
-! SELECT * FROM source_byo;
-contains:At least one input has no complete timestamps yet
-> ROLLBACK;
-
 # Verify that if the transaction starts on some timeline (epoch ms here),
 # things outside that are not there due to timedomain reasons.
 > BEGIN;
 > SELECT * FROM input_table;
-! SELECT * FROM source_byo;
+! SELECT * FROM source_cdcv2;
 contains:Transactions can only reference objects in the same timedomain
 > ROLLBACK;

--- a/test/testdrive/timestamps-debezium-kafka.td
+++ b/test/testdrive/timestamps-debezium-kafka.td
@@ -7,85 +7,99 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ set schema={
-    "type": "record",
-    "name": "envelope",
-    "fields": [
-      {
-        "name": "before",
-        "type": [
-          {
-            "name": "row",
+$ set schema=[
+  {
+    "type": "array",
+    "items": {
+      "type": "record",
+      "name": "update",
+      "namespace": "com.materialize.cdc",
+      "fields": [
+        {
+          "name": "data",
+          "type": {
             "type": "record",
+            "name": "data",
             "fields": [
               {"name": "a", "type": "long"},
               {"name": "b", "type": "long"}
             ]
-          },
-          "null"
-        ]
+          }
+        },
+        {
+          "name": "time",
+          "type": "long"
+        },
+        {
+          "name": "diff",
+          "type": "long"
+        }
+      ]
+    }
+  },
+  {
+    "type": "record",
+    "name": "progress",
+    "namespace": "com.materialize.cdc",
+    "fields": [
+      {
+        "name": "lower",
+        "type": {
+          "type": "array",
+          "items": "long"
+        }
       },
-      { "name": "after", "type": ["row", "null"] }
+      {
+        "name": "upper",
+        "type": {
+          "type": "array",
+          "items": "long"
+        }
+      },
+      {
+        "name": "counts",
+        "type": {
+          "type": "array",
+          "items": {
+            "type": "record",
+            "name": "counts",
+            "fields": [
+              {
+                "name": "time",
+                "type": "long"
+              },
+              {
+                "name": "count",
+                "type": "long"
+              }
+            ]
+          }
+        }
+      }
     ]
   }
-
-$ set trxschemakey={
-      "name": "io.debezium.connector.common.TransactionMetadataKey",
-      "type": "record",
-      "fields": [
-          {
-              "name": "id",
-              "type": "string"
-          }
-      ]
-  }
-
-$ set trxschema={
-    "type":"record", "name":"TransactionMetadataValue", "namespace":"io.debezium.connector.common",
-    "fields":[
-    {"name":"status","type":"string"},
-    {"name":"id","type": "string"},
-    {"name": "event_count",
-    "type": ["null", "long"],
-    "default": null
-    },
-    {"name":"data_collections","type":["null",{"type":"array",
-    "items": {"type":"record",
-    "name":"ConnectDefault",
-    "namespace":"io.confluent.connect.Avro",
-    "fields": [ {
-    "name": "data_collection",
-    "type": "string"
-    },
-    {
-    "name": "event_count",
-    "type": "long" }]}}],
-    "default": null}],
-    "connect.name": "io.debezium.connector.common.TransactionMetadataValue"
-    }
-
-$ kafka-create-topic topic=consistency
+  ]
 
 $ kafka-create-topic topic=foo
 
 $ kafka-create-topic topic=bar
 
-$ kafka-ingest format=avro topic=foo schema=${schema} timestamp=1
-{"before": null, "after": {"row":{"a": 1, "b": 1}}}
-{"before": null, "after": {"row":{"a": 2, "b": 2}}}
+$ kafka-ingest format=avro topic=foo schema=${schema}
+{"array":[{"data":{"a":1,"b":1},"time":1,"diff":1}]}
+{"array":[{"data":{"a":2,"b":2},"time":1,"diff":1}]}
 
-$ kafka-ingest format=avro topic=bar schema=${schema} timestamp=1
-{"before": null, "after": {"row":{"a": 10, "b": 1}}}
+$ kafka-ingest format=avro topic=bar schema=${schema}
+{"array":[{"data":{"a":10,"b":1},"time":1,"diff":1}]}
 
 > CREATE MATERIALIZED SOURCE data_foo
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-foo-${testdrive.seed}'
-    WITH (consistency_topic = 'testdrive-consistency-${testdrive.seed}')
-  FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
+    WITH (timeline='user')
+  FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE MATERIALIZE
 
 > CREATE MATERIALIZED SOURCE data_bar
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-bar-${testdrive.seed}'
-    WITH (consistency_topic = 'testdrive-consistency-${testdrive.seed}')
-  FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
+    WITH (timeline='user')
+  FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE MATERIALIZE
 
 
 > CREATE MATERIALIZED VIEW foo AS SELECT b, sum(a) FROM data_foo GROUP BY b
@@ -103,14 +117,11 @@ contains:At least one input has no complete timestamps yet:
 ! SELECT * FROM join ;
 contains:At least one input has no complete timestamps yet:
 
-$ kafka-ingest format=avro topic=consistency timestamp=1 schema=${trxschemakey}
-{"id": "1"}
+$ kafka-ingest format=avro topic=foo schema=${schema}
+{"com.materialize.cdc.progress":{"lower":[0],"upper":[2],"counts":[{"time":1,"count":2}]}}
 
-$ kafka-ingest format=avro topic=consistency timestamp=1 schema=${trxschema}
-{"status":"BEGIN","id":"1","event_count":null,"data_collections":null}
-{"status":"END","id":"1","event_count":{"long": 0},"data_collections":{"array": []}}
-{"status":"BEGIN","id":"2","event_count":null,"data_collections":null}
-{"status":"END","id":"2","event_count":{"long": 3},"data_collections":{"array": [{"event_count": 2, "data_collection": "testdrive-foo-${testdrive.seed}"},{"event_count": 1, "data_collection": "testdrive-bar-${testdrive.seed}"}]}}
+$ kafka-ingest format=avro topic=bar schema=${schema}
+{"com.materialize.cdc.progress":{"lower":[0],"upper":[2],"counts":[{"time":1,"count":1}]}}
 
 > SELECT * FROM data_foo;
 a  b
@@ -135,15 +146,13 @@ b foo_sum bar_sum
 -----------------
 1  1  10
 
-$ kafka-ingest format=avro topic=foo schema=${schema} timestamp=1
-{"before": null, "after": {"row": {"a": 3, "b": 3}}}
+$ kafka-ingest format=avro topic=foo schema=${schema}
+{"array":[{"data":{"a":3,"b":3},"time":2,"diff":1}]}
+{"com.materialize.cdc.progress":{"lower":[2],"upper":[3],"counts":[{"time":2,"count":2}]}}
 
-$ kafka-ingest format=avro topic=bar schema=${schema} timestamp=1
-{"before": null, "after": {"row": {"a": 30, "b": 3}}}
-
-$ kafka-ingest format=avro topic=consistency timestamp=1 schema=${trxschema}
-{"status":"BEGIN","id":"3","event_count":null,"data_collections":null}
-{"status":"END","id":"3","event_count":{"long": 3},"data_collections":{"array": [{"event_count": 2, "data_collection": "testdrive-foo-${testdrive.seed}"},{"event_count": 1, "data_collection": "testdrive-bar-${testdrive.seed}"}]}}
+$ kafka-ingest format=avro topic=bar schema=${schema}
+{"array":[{"data":{"a":30,"b":3},"time":2,"diff":1}]}
+{"com.materialize.cdc.progress":{"lower":[2],"upper":[3],"counts":[{"time":2,"count":1}]}}
 
 > SELECT * FROM foo;
 b  sum
@@ -162,8 +171,8 @@ b foo_sum bar_sum
 -----------------
 1  1  10
 
-$ kafka-ingest format=avro topic=foo schema=${schema} timestamp=1
-{"before": null, "after": {"row": {"a": 4, "b": 4}}}
+$ kafka-ingest format=avro topic=foo schema=${schema}
+{"array":[{"data":{"a":4,"b":4},"time":2,"diff":1}]}
 
 > SELECT * FROM foo;
 b  sum


### PR DESCRIPTION
### Motivation

BYO timestamping allowed users to provide their own mapping between
message offsets in a kafka data topic and the timestamp they get
assigned. This mechanism could be used to preserve transaction semantics
by ensuring that all relevant events of a transaction happen at the same
timestamp.

To the best of my knowledge no one is actually using this feature and it
has never been mentioned in our documentation. The mechanism is also
specific to Kafka and doesn't lend itself very well to other source
types. Its main use until now has been in our testdrive test suite where
it served as a way to very precicely control the timestamping of
ingested data.

The motivation for removal of this feature is its entangled nature with
the coordinator which currently has code to connect to kafka, decode
avro, and a hardcoded schema of the debezium transaction schema, all
part of what is known as the timestamper. As part of platform we want to
move all the timestamper logic out of the coordinator and keeping BYO
support would make this goal ten times more difficult.

For the above reasons we'll be dropping support for BYO timestamping.
All the tests that were affected by this have been rewritten to use our
`MATERIALIZE` envelope for controlling timestamps which is much easier
to work with and supports sending both data and progress events inline
in the same stream.

### Tips for reviewer

Most of the diff is just changing kafka-ingest in tests to ingest CDCv2 formatted data instead of debezium.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
