### PR TITLE
remove transient id allocation from dataflow builder

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -4067,14 +4067,9 @@ where
         }
 
         let indexes = &self.indexes;
-        let transient_id_counter = &mut self.transient_id_counter;
 
         let (builtin_table_updates, result) = self.catalog.transact(ops, |catalog| {
-            let builder = DataflowBuilder {
-                catalog,
-                indexes,
-                transient_id_counter,
-            };
+            let builder = DataflowBuilder { catalog, indexes };
             f(builder)
         })?;
         self.send_builtin_table_updates(builtin_table_updates).await;

--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -22,7 +22,6 @@ use ore::stack::maybe_grow;
 pub struct DataflowBuilder<'a> {
     pub catalog: &'a CatalogState,
     pub indexes: &'a ArrangementFrontiers<Timestamp>,
-    pub transient_id_counter: &'a mut u64,
 }
 
 impl<C> Coordinator<C>
@@ -34,7 +33,6 @@ where
         DataflowBuilder {
             catalog: self.catalog.state(),
             indexes: &self.indexes,
-            transient_id_counter: &mut self.transient_id_counter,
         }
     }
 
@@ -95,12 +93,6 @@ impl<'a> DataflowBuilder<'a> {
                     .expect("indexes can only be built on items with descs");
                 dataflow.import_index(*index_id, index_desc, desc.typ().clone(), *id);
             } else {
-                // This is only needed in the case of a source with a transformation, but we generate it now to
-                // get around borrow checker issues.
-                let transient_id = *self.transient_id_counter;
-                *self.transient_id_counter = transient_id
-                    .checked_add(1)
-                    .expect("id counter overflows i64");
                 let entry = self.catalog.get_by_id(id);
                 match entry.item() {
                     CatalogItem::Table(table) => {


### PR DESCRIPTION
This PR removes code that existed only in the case that sources were wrapped in views, which has bee removed from the code base.