### PR TITLE
Have Catalog produce a canonical SourceDesc

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -566,6 +566,15 @@ where
                         self.logical_compaction_window_ms,
                     );
                     self.sources.insert(entry.id(), frontiers);
+                    // Re-announce the source description.
+                    let source_description = self
+                        .catalog
+                        .state()
+                        .source_description_for(entry.id())
+                        .unwrap();
+                    self.dataflow_client
+                        .create_sources(vec![(entry.id(), source_description)])
+                        .await;
                 }
                 CatalogItem::Table(table) => {
                     let since_ts = {
@@ -585,6 +594,15 @@ where
                     // NOTE: Tables are not sources, but to a large part of the system they look
                     // like they are, e.g. they are rendered as a SourceConnector::Local.
                     self.sources.insert(entry.id(), frontiers);
+                    // Re-announce the source description.
+                    let source_description = self
+                        .catalog
+                        .state()
+                        .source_description_for(entry.id())
+                        .unwrap();
+                    self.dataflow_client
+                        .create_sources(vec![(entry.id(), source_description)])
+                        .await;
                 }
                 CatalogItem::Index(_) => {
                     if BUILTINS.logs().any(|log| log.index_id == entry.id()) {

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -4100,6 +4100,7 @@ where
                 self.catalog.delete_timestamp_bindings(id)?;
                 self.sources.remove(&id);
             }
+            self.dataflow_client.drop_sources(sources_to_drop).await;
         }
         if !tables_to_drop.is_empty() {
             // NOTE: When creating a persistent table we insert its compaction frontier (aka since)

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -840,11 +840,9 @@ where
                     // Assert that a source is not recreated with a new description.
                     if let Some(d) = self.storage_state.source_descriptions.get(&source_id) {
                         if d != &description {
-                            log::error!(
+                            panic!(
                                 "Multiple registration of source id {}: {:?} and {:?}",
-                                source_id,
-                                d,
-                                description
+                                source_id, d, description
                             );
                         }
                     }
@@ -861,7 +859,7 @@ where
                     // Check that the source has been previously created.
                     // Do not remove it, so that we can continue to check for rebinding.
                     if !self.storage_state.source_descriptions.contains_key(&name) {
-                        log::error!("DropSource for id that was not created: {:?}", name);
+                        panic!("DropSource for id that was not created: {:?}", name);
                     }
                 }
             }

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -859,7 +859,7 @@ where
                     // Check that the source has been previously created.
                     // Do not remove it, so that we can continue to check for rebinding.
                     if !self.storage_state.source_descriptions.contains_key(&name) {
-                        panic!("DropSource for id that was not created: {:?}", name);
+                        panic!("DropSource for id that was not created: {:?}; created source ids are: {:?}", name, self.storage_state.source_descriptions.keys());
                     }
                 }
             }


### PR DESCRIPTION
This PR extracts the definition of a `SourceDesc` from the dataflow construction process, while still providing the persistence layer the ability to manipulate the description once it is constructed.

It will be followed with a coordinator-local store of definitions, and hard checks for non-rebinding in this location, with the `dataflow` checks for the same removed (as they are confused by the persistence rewriting of source descriptions). I'm working on that now, so this is mostly to start the discussion and provide visibility.

Edit: the hard checks at not going to be coordinator-local for this PR, as there is a bunch of stuff that goes with that which ends up being more contentious than this stuff.

### Motivation

   * This PR refactors existing code.

Prior code conflated the definition of source descriptions with their instantiation, and had them defined only by the code that happened to be called, interleaved with manipulation. This made it hard to communicate about the lifetime of a source and its description.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
