### PR TITLE
coord: refactor handling of source persist details

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -848,10 +848,18 @@ impl CatalogEntry {
         self.item.func(&self.name)
     }
 
-    /// Return the [`Index`] if this entry is an Index, else None.
+    /// Returns the inner [`Index`] if this entry is an index, else `None`.
     pub fn index(&self) -> Option<&Index> {
         match self.item() {
             CatalogItem::Index(idx) => Some(idx),
+            _ => None,
+        }
+    }
+
+    /// Returns the inner [`Source`] if this entry is a source, else `None`.
+    pub fn source(&self) -> Option<&Source> {
+        match self.item() {
+            CatalogItem::Source(src) => Some(src),
             _ => None,
         }
     }
@@ -2540,17 +2548,6 @@ impl Catalog {
 
     pub fn persist_multi_details(&self) -> Option<&TablePersistMultiDetails> {
         self.state.by_id.persist_multi_details()
-    }
-
-    pub fn source_persist_desc(
-        &self,
-        id: GlobalId,
-        connector: &SourceConnector,
-        name: &FullName,
-    ) -> Result<Option<SourcePersistDesc>, PersistError> {
-        self.state
-            .persist
-            .source_persist_desc(id, connector, &name.to_string())
     }
 }
 

--- a/src/coord/src/catalog/builtin_table_updates.rs
+++ b/src/coord/src/catalog/builtin_table_updates.rs
@@ -179,13 +179,10 @@ impl CatalogState {
         source: &Source,
         diff: Diff,
     ) -> Vec<BuiltinTableUpdate> {
-        let persist_name = match &source.connector {
-            dataflow_types::sources::SourceConnector::External { persist, .. } => persist
-                .as_ref()
-                .map(|persist| persist.primary_stream.name.as_str()),
-            dataflow_types::sources::SourceConnector::Local { .. } => None,
-        };
-        let persisted_name_datum = Datum::from(persist_name);
+        let persist_name = source
+            .persist_details
+            .as_ref()
+            .map(|persist| &*persist.primary_stream);
         vec![BuiltinTableUpdate {
             id: MZ_SOURCES.id,
             row: Row::pack_slice(&[
@@ -195,7 +192,7 @@ impl CatalogState {
                 Datum::String(name),
                 Datum::String(source.connector.name()),
                 Datum::String(self.is_volatile(id).as_str()),
-                persisted_name_datum,
+                Datum::from(persist_name),
             ]),
             diff,
         }]

--- a/src/coord/src/error.rs
+++ b/src/coord/src/error.rs
@@ -41,6 +41,8 @@ pub enum CoordError {
     Eval(EvalError),
     /// The ID allocator exhausted all valid IDs.
     IdExhaustionError,
+    /// Unexpected internal state was encountered.
+    Internal(String),
     /// At least one input has no complete timestamps yet
     IncompleteTimestamp(Vec<expr::GlobalId>),
     /// Specified index is disabled, but received non-enabling update request
@@ -276,6 +278,7 @@ impl fmt::Display for CoordError {
                 "At least one input has no complete timestamps yet: {:?}",
                 unstarted
             ),
+            CoordError::Internal(e) => write!(f, "internal error: {}", e),
             CoordError::InvalidAlterOnDisabledIndex(name) => {
                 write!(f, "invalid ALTER on disabled index {}", name.quoted())
             }

--- a/src/coord/src/timestamp.rs
+++ b/src/coord/src/timestamp.rs
@@ -569,7 +569,6 @@ impl Timestamper {
                         consistency,
                         ts_frequency: _,
                         timeline: _,
-                        persist: _,
                     } = sc
                     {
                         (connector, encoding, envelope, consistency)

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -241,12 +241,11 @@ pub fn build_dataflow<A: Allocate>(
                         &context.debug_name,
                         context.dataflow_id,
                         &context.as_of_frontier,
-                        source.operators.clone(),
+                        source.clone(),
                         storage_state,
                         region,
                         materialized_logging.clone(),
                         src_id.clone(),
-                        source.description.clone(),
                         now.clone(),
                         source_metrics,
                     );

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -134,12 +134,15 @@ pub(crate) fn import_source<G>(
     dataflow_debug_name: &String,
     dataflow_id: usize,
     as_of_frontier: &timely::progress::Antichain<repr::Timestamp>,
-    mut linear_operators: Option<dataflow_types::LinearOperator>,
+    SourceInstanceDesc {
+        description: src,
+        operators: mut linear_operators,
+        persist,
+    }: SourceInstanceDesc,
     storage_state: &mut crate::render::StorageState,
     scope: &mut G,
     materialized_logging: Option<Logger>,
     src_id: GlobalId,
-    src: SourceDesc,
     now: NowFn,
     base_metrics: &SourceBaseMetrics,
 ) -> (
@@ -187,7 +190,6 @@ where
             envelope,
             consistency,
             ts_frequency,
-            persist,
             timeline: _,
         } => {
             // TODO(benesch): this match arm is hard to follow. Refactor.

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -351,6 +351,7 @@ impl ErrorResponse {
             CoordError::Eval(_) => SqlState::INTERNAL_ERROR,
             CoordError::IdExhaustionError => SqlState::INTERNAL_ERROR,
             CoordError::IncompleteTimestamp(_) => SqlState::SQL_STATEMENT_NOT_YET_COMPLETE,
+            CoordError::Internal(_) => SqlState::INTERNAL_ERROR,
             CoordError::InvalidRematerialization { .. } => SqlState::FEATURE_NOT_SUPPORTED,
             CoordError::InvalidParameterType(_) => SqlState::INVALID_PARAMETER_VALUE,
             CoordError::InvalidParameterValue { .. } => SqlState::INVALID_PARAMETER_VALUE,

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -868,7 +868,6 @@ pub fn plan_create_source(
             consistency,
             ts_frequency,
             timeline,
-            persist: None,
         },
         expr,
         desc,


### PR DESCRIPTION
coord: refactor handling of source persist details

The primary change in this PR is that `SourcePersistDesc` struct is
transmitted to the dataflow layer by way of the `SourceInstanceDesc`
struct, rather than via injection into the `SourceConnector` struct.

This clarity fixes several unreported bugs:

    * The `persist_details` field of mz_sources is correctly populated.
    * The `since_ts` of recreated sources is correctly restored.

Both of these bugs were the result of relying on the persist details in
the `SourceConnector` before those details were injected, so the details
were always `None`.

### Motivation

  * This PR fixes a previously unreported bug.
   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
