### PR TITLE
test: Allow code coverage to be dumped on SIGUSR2

### DIFF
--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -387,6 +387,7 @@ fn run(args: Args) -> Result<(), anyhow::Error> {
         sys::enable_sigbus_sigsegv_backtraces()?;
     }
 
+    sys::enable_sigusr2_coverage_dump()?;
     sys::enable_termination_signal_cleanup()?;
 
     // Initialize fail crate for failpoint support


### PR DESCRIPTION
Force code coverage to be dumped on SIGUSR2 . This is needed to
enable tooling that will collect code coverage on a per-query basis.

  * This PR adds a feature that has not yet been specified.

This is needed so that the code coverage is dumped after each randomly-generated query is executed. This will allow the code coverage contribution of each incoming query to be evaluated, which in turn will tell us which ones are worth including in an SLT test.