### PR TITLE
mzbuild,xcompile: Compile the coverage build using the nightly compiler

### DIFF
--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -72,7 +72,7 @@ class RepositoryDetails:
 
     def cargo(self, subcommand: str, rustflags: List[str]) -> List[str]:
         """Start a cargo invocation for the configured architecture."""
-        return xcompile.cargo(self.arch, subcommand, rustflags)
+        return xcompile.cargo(self.arch, self.coverage, subcommand, rustflags)
 
     def tool(self, name: str) -> List[str]:
         """Start a binutils tool invocation for the configured architecture."""
@@ -211,7 +211,6 @@ class CargoBuild(CargoPreImage):
         if rd.coverage:
             self.rustflags += [
                 "-Zinstrument-coverage",
-                "-Clink-dead-code",
                 # Nix generates some unresolved symbols that -Zinstrument-coverage
                 # somehow causes the linker to complain about, so just disable
                 # warnings about unresolved symbols and hope it all works out.
@@ -624,6 +623,7 @@ class ResolvedImage:
             self_hash.update(b"\0")
 
         self_hash.update(f"arch={self.image.rd.arch}".encode())
+        self_hash.update(f"coverage={self.image.rd.coverage}".encode())
 
         full_hash = hashlib.sha1()
         full_hash.update(self_hash.digest())

--- a/misc/python/materialize/xcompile.py
+++ b/misc/python/materialize/xcompile.py
@@ -64,7 +64,9 @@ def target(arch: Arch) -> str:
     return f"{arch}-unknown-linux-gnu"
 
 
-def cargo(arch: Arch, subcommand: str, rustflags: List[str]) -> List[str]:
+def cargo(
+    arch: Arch, coverage: bool, subcommand: str, rustflags: List[str]
+) -> List[str]:
     """Construct a Cargo invocation for cross compiling.
 
     Args:
@@ -112,7 +114,7 @@ def cargo(arch: Arch, subcommand: str, rustflags: List[str]) -> List[str]:
     }
 
     return [
-        *_enter_builder(arch),
+        *_enter_builder(arch, coverage),
         "env",
         *(f"{k}={v}" for k, v in env.items()),
         "cargo",
@@ -138,7 +140,7 @@ def tool(arch: Arch, name: str) -> List[str]:
     ]
 
 
-def _enter_builder(arch: Arch) -> List[str]:
+def _enter_builder(arch: Arch, coverage: bool = False) -> List[str]:
     assert (
         arch == Arch.host()
     ), f"target architecture {arch} does not match host architecture {Arch.host()}"
@@ -150,7 +152,8 @@ def _enter_builder(arch: Arch) -> List[str]:
         _bootstrap_darwin(arch)
         return []
     else:
-        return ["bin/ci-builder", "run", "stable"]
+        channel = "nightly" if coverage else "stable"
+        return ["bin/ci-builder", "run", channel]
 
 
 def _bootstrap_darwin(arch: Arch) -> None:


### PR DESCRIPTION
Coverage builds require the -Zinstrument-coverage rustc option, which
is only available in Nightly. So pass the desire to build a coverage
build all the way to where the bin/ci-builder command line is composed,
so that the nightly compiler is chosen.

Add the state of the coverage option to the hash that is used to decide
if an image needs to be rebuilt. Otherwise, a non-coverage image will
be used if already present in Docker.


  * This PR fixes a previously unreported bug.

The ability to perform coverage builds was lost during some refactoring of the build pipeline.

### Tips for reviewer

@benesch I am positive that you will refactor this ... prove me right