### PR TITLE
mzbuild,xcompile: Compile the coverage build using the nightly compiler

### DIFF
--- a/misc/python/materialize/cli/xcompile.py
+++ b/misc/python/materialize/cli/xcompile.py
@@ -29,6 +29,12 @@ def main() -> int:
         choices=mzbuild.Arch,
     )
 
+    parser.add_argument(
+        "--channel",
+        default=None,
+        help="Rust compiler channel to use",
+    )
+
     subparsers = parser.add_subparsers(
         dest="command", metavar="<command>", required=True
     )
@@ -42,6 +48,7 @@ def main() -> int:
         default=[],
         help="override the default flags to the Rust compiler",
     )
+
     cargo_parser.add_argument("subcommand", help="the cargo subcommand to invoke")
     cargo_parser.add_argument(
         "subargs", nargs=argparse.REMAINDER, help="the arguments to pass to cargo"
@@ -59,7 +66,12 @@ def main() -> int:
     if args.command == "cargo":
         spawn.runv(
             [
-                *xcompile.cargo(args.arch, args.subcommand, args.rustflags),
+                *xcompile.cargo(
+                    arch=args.arch,
+                    channel=args.channel,
+                    subcommand=args.subcommand,
+                    rustflags=args.rustflags,
+                ),
                 *args.subargs,
             ]
         )


### PR DESCRIPTION
Coverage builds require the -Zinstrument-coverage rustc option, which
is only available in Nightly. So pass the desire to build a coverage
build all the way to where the bin/ci-builder command line is composed,
so that the nightly compiler is chosen.

Add the state of the coverage option to the hash that is used to decide
if an image needs to be rebuilt. Otherwise, a non-coverage image will
be used if already present in Docker.

### Motivation

  * This PR fixes a previously unreported bug.

The ability to build coverage builds was lost during recent refactorings.