### PR TITLE
tests/release: add kafka-ingest-open-loop to release tests

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -569,9 +569,11 @@ class Composition:
         self,
         *,
         host: str = "localhost",
-        port: int,
+        port: Union[int, str],
         timeout_secs: int = 240,
     ) -> None:
+        if isinstance(port, str):
+            port = int(port.split(":")[0])
         ui.progress(f"waiting for {host}:{port}", "C")
         for remaining in ui.timeout_loop(timeout_secs):
             cmd = f"docker run --rm -t --network {self.name}_default ubuntu:focal-20210723".split()

--- a/misc/scratch/release.json
+++ b/misc/scratch/release.json
@@ -29,3 +29,33 @@
         "environment": "scratch"
     }
 }
+
+{
+    "name": "kafka-ingest-open-loop",
+    "launch_script": "MZ_WORKERS=4 bin/mzcompose --preserve-ports --find kafka-ingest-open-loop run default --num-seconds=86400 --records-per-second=1000",
+    "instance_type": "r5a.4xlarge",
+    "ami": "ami-0b29b6e62f2343b46",
+    "size_gb": 200,
+    "tags": {
+        "scrape_benchmark_numbers": "true",
+        "lt_name": "release-kafka-ingest-open-loop",
+        "purpose": "load_test",
+        "test": "kafka-ingest-open-loop",
+        "environment": "scratch"
+    }
+}
+
+{
+    "name": "kafka-ingest-open-loop-persist",
+    "launch_script": "MZ_WORKERS=4 bin/mzcompose --preserve-ports --find kafka-ingest-open-loop run default --num-seconds=86400 --records-per-second=1000 --enable-persistence --s3-storage=release-$(echo $RANDOM)",
+    "instance_type": "r5a.4xlarge",
+    "ami": "ami-0b29b6e62f2343b46",
+    "size_gb": 200,
+    "tags": {
+        "scrape_benchmark_numbers": "true",
+        "lt_name": "release-kafka-ingest-open-loop-persist",
+        "purpose": "load_test",
+        "test": "kafka-ingest-open-loop-persist",
+        "environment": "scratch"
+    }
+}


### PR DESCRIPTION
This commit adds two versions of the kafka-ingest-open loop test, one
with persistence to s3, and one without.

The tests are configured to run for 24 hours, with 1k inserts of 500 byte values
per second. Previously, when I ran 100k records/second for 100 seconds Materialize
used ~2.5 GB of RAM without persistence, and approximately 14 GB of RAM with
persistence. This test will send approximately 9x as much data, over a ~900x larger
time interval, for a total of ~90 million inserts (45 GB total data).

<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug: [Link to issue.]

  * This PR adds a known-desirable feature: [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
