### PR TITLE
add bin/scratch-login

### DIFF
--- a/bin/scratch-login
+++ b/bin/scratch-login
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# logs into aws locally so `bin/scratch` is usable
+aws sso login --profile mz-scratch-admin


### PR DESCRIPTION
### Motivation

I struggle to remember the login command each day

### Tips for reviewer

This can't go in `bin/scratch login` because argument parsing in `bin/scratch` requires access to aws

### Checklist

- N/A This PR has adequate test coverage / QA involvement has been duly considered.
- N/A This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
