### PR TITLE
scratch: add login subcommand

### DIFF
--- a/misc/python/materialize/cli/scratch/__main__.py
+++ b/misc/python/materialize/cli/scratch/__main__.py
@@ -9,13 +9,14 @@
 
 import argparse
 
-from materialize.cli.scratch import create, destroy, mine, push, sftp, ssh
+from materialize.cli.scratch import create, destroy, login, mine, push, sftp, ssh
 
 
 def main() -> None:
     parser = argparse.ArgumentParser("scratch")
     subparsers = parser.add_subparsers(dest="subcommand", required=True)
     for name, configure, run in [
+        ("login", login.configure_parser, login.run),
         ("create", create.configure_parser, create.run),
         ("mine", mine.configure_parser, mine.run),
         ("ssh", ssh.configure_parser, ssh.run),

--- a/misc/python/materialize/cli/scratch/login.py
+++ b/misc/python/materialize/cli/scratch/login.py
@@ -1,0 +1,21 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+import argparse
+
+from materialize import spawn
+from materialize.cli.scratch import check_required_vars
+
+
+def configure_parser(parser: argparse.ArgumentParser) -> None:
+    check_required_vars()
+
+
+def run(args: argparse.Namespace) -> None:
+    spawn.runv(["aws", "sso", "login"])

--- a/misc/python/materialize/cli/scratch/mine.py
+++ b/misc/python/materialize/cli/scratch/mine.py
@@ -23,7 +23,6 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
         "who",
         nargs="*",
         help="Whose instances to show (defaults to yourself)",
-        default=[whoami()],
     )
     parser.add_argument("--all", help="Show all instances", action="store_true")
     parser.add_argument("--output-format", choices=["table", "csv"], default="table")
@@ -32,7 +31,7 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
 def run(args: argparse.Namespace) -> None:
     filters: List[FilterTypeDef] = []
     if not args.all:
-        filters.append({"Name": "tag:LaunchedBy", "Values": args.who})
+        filters.append({"Name": "tag:LaunchedBy", "Values": args.who or [whoami()]})
     print_instances(
         list(boto3.resource("ec2").instances.filter(Filters=filters)),
         args.output_format,


### PR DESCRIPTION
@guswynn this is a reworking of #10357 that prevents argparsing on `bin/scratch` from making an AWS API call!

----

Add a `login` subcommand to `bin/scratch` that delegates to `aws sso
login` with the correct profile. This is a good bit easier to type than
`aws sso login --profile mz-scratch-admin`.

A minor refactoring was necessary to prevent argument parsing for the
`mine` subcommand from attempting to make a API call to AWS to figure
out the invoking user's email address.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
