### PR TITLE
implement skip-if in testdrive

### DIFF
--- a/doc/developer/testdrive.md
+++ b/doc/developer/testdrive.md
@@ -775,5 +775,16 @@ Block the test until the specified schema has been defined at the schema registr
 Executes a command against Materialize via `psql`. This is intended for testing
 `psql`-specific commands like `\dn`.
 
+## Conditionally skipping the rest of a `.td` file
+
+```
+$ skip-if
+SELECT true
+```
+
+`skip-if`, followed by a SQL statement will conditionally skip the rest of the `.td` file if the statement returns exactly `true`.
+If it returns anything but `true` or `false`, it will error. This can be useful to conditionally test things in different
+versions of materialize, and more!
+
 [confluent-arm]: https://github.com/confluentinc/common-docker/issues/117#issuecomment-948789717
 [aws-creds]: https://github.com/MaterializeInc/i2/blob/main/doc/aws-access.md

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -51,6 +51,7 @@ mod protobuf;
 mod psql;
 mod s3;
 mod schema_registry;
+mod skip_if;
 mod sleep;
 mod sql;
 mod sql_server;
@@ -143,6 +144,7 @@ pub struct State {
     postgres_clients: HashMap<String, tokio_postgres::Client>,
     sql_server_clients:
         HashMap<String, tiberius::Client<tokio_util::compat::Compat<tokio::net::TcpStream>>>,
+    pub(crate) skip_rest: bool,
 }
 
 #[derive(Clone)]
@@ -498,6 +500,9 @@ pub(crate) async fn build(
                     "schema-registry-wait-schema" => Box::new(
                         schema_registry::build_wait(builtin, context.clone()).map_err(wrap_err)?,
                     ),
+                    "skip-if" => Box::new(
+                        skip_if::build_publish(builtin, context.clone()).map_err(wrap_err)?,
+                    ),
                     "sql-server-connect" => {
                         Box::new(sql_server::build_connect(builtin).map_err(wrap_err)?)
                     }
@@ -799,6 +804,7 @@ pub async fn create_state(
         mysql_clients: HashMap::new(),
         postgres_clients: HashMap::new(),
         sql_server_clients: HashMap::new(),
+        skip_rest: false,
     };
     Ok((state, pgconn_task))
 }

--- a/src/testdrive/src/action/skip_if.rs
+++ b/src/testdrive/src/action/skip_if.rs
@@ -1,0 +1,64 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use anyhow::{bail, Context as _};
+use async_trait::async_trait;
+
+use crate::action::{Action, Context, State};
+use crate::parser::BuiltinCommand;
+
+pub struct SkipIfAction {
+    query: String,
+    context: Context,
+}
+
+pub fn build_publish(cmd: BuiltinCommand, context: Context) -> Result<SkipIfAction, anyhow::Error> {
+    Ok(SkipIfAction {
+        query: cmd.input.join(" "),
+        context,
+    })
+}
+
+#[async_trait]
+impl Action for SkipIfAction {
+    async fn undo(&self, _: &mut State) -> Result<(), anyhow::Error> {
+        Ok(())
+    }
+
+    async fn redo(&self, state: &mut State) -> Result<(), anyhow::Error> {
+        let stmt = state
+            .pgclient
+            .prepare(&self.query)
+            .await
+            .context("failed to prepare skip-if query")?;
+
+        let actual: Vec<_> = state
+            .pgclient
+            .query(&stmt, &[])
+            .await
+            .context("executing query failed")?
+            .into_iter()
+            .map(|row| crate::action::sql::decode_row(row, self.context.clone()))
+            .collect::<Result<_, _>>()?;
+
+        if vec![vec!["true".to_string()]] == actual {
+            println!("skip-if query returned true; skipping rest of file");
+            state.skip_rest = true;
+        } else if vec![vec!["false".to_string()]] == actual {
+            println!("skip-if query returned false; continuing");
+        } else {
+            bail!(
+                "skip-if query did not return `true` or `false`: {:?}",
+                actual
+            );
+        }
+
+        Ok(())
+    }
+}

--- a/src/testdrive/src/action/sql.rs
+++ b/src/testdrive/src/action/sql.rs
@@ -480,7 +480,7 @@ pub fn print_query(query: &str) {
     println!("> {}", query);
 }
 
-fn decode_row(row: Row, context: Context) -> Result<Vec<String>, anyhow::Error> {
+pub(crate) fn decode_row(row: Row, context: Context) -> Result<Vec<String>, anyhow::Error> {
     enum ArrayElement<T> {
         Null,
         NonNull(T),

--- a/src/testdrive/src/lib.rs
+++ b/src/testdrive/src/lib.rs
@@ -114,7 +114,10 @@ async fn run_line_reader(
 
         for a in &actions {
             let redo = a.action.redo(&mut state);
-            redo.await.map_err(|e| PosError::new(e, a.pos))?
+            redo.await.map_err(|e| PosError::new(e, a.pos))?;
+            if state.skip_rest {
+                break;
+            }
         }
 
         if config.reset {

--- a/test/testdrive/test-skip-if.td
+++ b/test/testdrive/test-skip-if.td
@@ -1,0 +1,22 @@
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ skip-if
+SELECT false;
+
+# false skip result means we run this and see the failure
+! SELECT nonsense;
+exact:column "nonsense" does not exist
+
+$ skip-if
+SELECT true;
+
+# true skip result means we don't run this erroneous statement
+> SELECT nonsense;


### PR DESCRIPTION
### Motivation

In working on https://github.com/MaterializeInc/materialize/issues/10257
I need to do some complex upgrade testing:

I need to validate that 
- a catalog from an old version (lets say `vX.X`) that has kafka-ssl options is correctly migrated, and can be `check-from'd` `vCurrentSource`
- a sql statement that cannot succeed in the new version

Upgrade tests ALWAYs run a `vCurrentSource` -> `vCurrentSource` upgrade: https://github.com/MaterializeInc/materialize/blob/main/test/upgrade/mzcompose.py#L86

this wont work here (and in fact, other issues I have had had the same issue), as we are SPECIFICALLY banning something in the new source.

This pr adds a `skip-if` action to testdrive, which allows me to add:
```
skip-if sql="SELECT mz_version() LIKE '%gus%'"
```
to the create-in's 
and
```
skip-if sql="SELECT mz_version() LIKE '%gus%' AND ${arg.upgrade-skip-if}"
```
in the `check-from`'s so that we
1. always check-from current-source
2. never run the current-source to current-source upgrade
