### PR TITLE
coord: move falliable dataflow transform to a safe error path

### DIFF
--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -175,6 +175,7 @@ impl<'a> DataflowBuilder<'a> {
             }
         }
         dataflow.insert_view(*view_id, view.clone());
+
         Ok(())
     }
 
@@ -190,6 +191,10 @@ impl<'a> DataflowBuilder<'a> {
         let mut dataflow = DataflowDesc::new(name);
         self.import_into_dataflow(&index_description.on_id, &mut dataflow)?;
         dataflow.export_index(id, index_description, on_type);
+
+        // Optimize the dataflow across views, and any other ways that appeal.
+        transform::optimize_dataflow(&mut dataflow, self.catalog.enabled_indexes())?;
+
         Ok(dataflow)
     }
 
@@ -208,6 +213,10 @@ impl<'a> DataflowBuilder<'a> {
         dataflow.set_as_of(sink_description.as_of.frontier.clone());
         self.import_into_dataflow(&sink_description.from, &mut dataflow)?;
         dataflow.export_sink(id, sink_description);
+
+        // Optimize the dataflow across views, and any other ways that appeal.
+        transform::optimize_dataflow(&mut dataflow, self.catalog.enabled_indexes())?;
+
         Ok(dataflow)
     }
 }


### PR DESCRIPTION
`ship_dataflow` is not allowed to produce an error because it is
called after `catalog_transact` which doesn't know how to undo its
operations. Move the falliable optimizer call to a common dataflow
builder location that already supports errors.

See #6786
See #9341

### Motivation

  * This PR fixes a previously unreported bug.

`ship_dataflow` failing due to this optimizer call would cause the coordinator to be in an inconsistent state, assuming that certain dataflows existed when they did not.

### Tips for reviewer

The added test attempts to prevent us from doing this again in the future. I'm not sure if it's clever or terrible.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
