### PR TITLE
test: Adjust the limits test for large expressions in Aggregates

### DIFF
--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -792,6 +792,10 @@ class Aggregates(Generator):
 
 
 class AggregateExpression(Generator):
+    # Stack exhaustion with COUNT=1000 due to unprotected path:
+    # https://github.com/MaterializeInc/materialize/issues/10348#issuecomment-1025946920
+    COUNT = min(Generator.COUNT, 500)
+
     @classmethod
     def body(cls) -> None:
         create_list = ", ".join(f"f{i} INTEGER" for i in cls.all())


### PR DESCRIPTION
The test causes stack exhaustion under COUNT=1000 due to a code path
that is not protected by a stack guard.

Run the test at COUNT=500 instead.