### PR TITLE
qgm: basic framework for derived attributes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5158,6 +5158,7 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tracing",
+ "typemap_rev",
  "uncased",
  "url",
  "uuid",
@@ -5972,6 +5973,12 @@ dependencies = [
  "rand",
  "static_assertions",
 ]
+
+[[package]]
+name = "typemap_rev"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5b74f0a24b5454580a79abb6994393b09adf0ab8070f15827cb666255de155"
 
 [[package]]
 name = "typenum"

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -43,6 +43,7 @@ sql-parser = { path = "../sql-parser" }
 tempfile = "3.2.0"
 tokio = { version = "1.16.1", features = ["fs"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", branch = "mz-0.7.2" }
+typemap_rev = { version= "0.1.5"}
 uncased = "0.9.6"
 url = "2.2.2"
 uuid = { version = "0.8.2", features = ["serde", "v4"] }

--- a/src/sql/src/query_model/attribute/core.rs
+++ b/src/sql/src/query_model/attribute/core.rs
@@ -1,0 +1,335 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Framework for modeling and computing derived attributes for QGM
+//! graphs.
+//!
+//! A derived attribute is a value that is associated with a specific
+//! QGM box and can be derived from a QGM graph and other derived
+//! attributes.
+//!
+//! To implement a new attribute, define a new type to represent that
+//! attribute and implement the [`Attribute`] and [`AttributeKey`]
+//! for that type.
+//!
+//! Note that the current implementation does not support parameterized
+//! [`Attribute`] instances, so `MyAttr` is OK, but `MyAttr(i32)` isn't.
+
+use crate::query_model::model::{BoxId, Model};
+use std::any::type_name;
+use std::collections::HashSet;
+use std::hash::Hash;
+use std::marker::PhantomData;
+use typemap_rev::{TypeMap, TypeMapKey};
+
+/// A container for derived attributes associated with a specific QGM
+/// box.
+pub struct Attributes(TypeMap);
+
+impl std::fmt::Debug for Attributes {
+    fn fmt(&self, _: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Ok(()) // FIXME
+    }
+}
+
+/// A public api for getting and setting attributes.
+impl Attributes {
+    pub(crate) fn new() -> Self {
+        Self(TypeMap::new())
+    }
+
+    /// Return a value for the attribute `A`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the attribute `A` is not set.
+    #[allow(dead_code)]
+    pub(crate) fn get<A: 'static + AttributeKey>(&self) -> &A::Value
+    where
+        A::Value: std::fmt::Debug,
+    {
+        match self.0.get::<AsKey<A>>() {
+            Some(value) => value,
+            None => panic!("attribute {} not present", type_name::<A>()),
+        }
+    }
+
+    /// Set attribute `A` to `value`.
+    #[allow(dead_code)]
+    pub(crate) fn set<A: 'static + AttributeKey>(&mut self, value: A::Value)
+    where
+        A::Value: std::fmt::Debug,
+    {
+        self.0.insert::<AsKey<A>>(value);
+    }
+}
+
+/// A trait that defines the logic for deriving an attribute.
+pub(crate) trait Attribute: std::fmt::Debug + 'static {
+    /// A globally unique identifier for this attribute type.
+    fn attr_id(&self) -> &'static str;
+
+    /// A vector of attributes that need to  be derived before
+    /// this attribute.
+    fn requires(&self) -> Vec<Box<dyn Attribute>>;
+
+    /// A function that derives at a specific [`BoxId`].
+    fn derive(&self, model: &mut Model, box_id: BoxId);
+}
+
+/// A naive [`PartialEq`] implementation for [`Attribute`] trait objects that
+/// differentiates two attributes based on their [`std::any::TypeId`].
+impl PartialEq for dyn Attribute {
+    fn eq(&self, other: &Self) -> bool {
+        self.attr_id() == other.attr_id()
+    }
+}
+
+/// An evidence that the [`PartialEq`] implementation for [`Attribute`] is an
+/// equivalence relation.
+impl Eq for dyn Attribute {}
+
+/// A naive `Hash` for attributes that delegates to the associated
+/// [`std::any::TypeId`].
+impl Hash for dyn Attribute {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.attr_id().hash(state);
+    }
+}
+
+/// A trait sets an attribute `Value` type.
+pub(crate) trait AttributeKey: Attribute {
+    type Value: Send + Sync;
+}
+
+/// Helper struct to derive a [`TypeMapKey`] from an [`Attribute`].
+struct AsKey<A: AttributeKey>(PhantomData<A>);
+
+/// Derive a [`TypeMapKey`] from an [`Attribute`].
+impl<A: AttributeKey> TypeMapKey for AsKey<A> {
+    type Value = A::Value;
+}
+
+/// derive attributes for the entire model before each transform
+pub(crate) fn derive_dft_attributes(
+    model: &mut Model,
+    attributes: &Vec<Box<dyn Attribute>>,
+    root: BoxId,
+) {
+    if !attributes.is_empty() {
+        let _ = model.try_visit_mut_pre_post_descendants(
+            &mut |_, _| -> Result<(), ()> { Ok(()) },
+            &mut |m, box_id| -> Result<(), ()> {
+                for attr in attributes.iter() {
+                    attr.derive(m, *box_id);
+                }
+                Ok(())
+            },
+            root,
+        );
+    }
+}
+
+/// Consumes a set of attributes and produces a topologically sorted
+/// version of the elements in that set based on the dependency
+/// information provided by the [`Attribute::requires`] results.
+///
+/// We use Kahn's algorithm[^1] to sort the input.
+///
+/// [^1]: <https://en.wikipedia.org/wiki/Topological_sorting#Kahn's_algorithm>
+pub(crate) fn dependency_order(attributes: HashSet<Box<dyn Attribute>>) -> Vec<Box<dyn Attribute>> {
+    let mut rest = attributes.into_iter().collect::<Vec<_>>();
+    let mut seen = HashSet::new() as HashSet<&'static str>;
+    let mut sort = vec![] as Vec<Box<dyn Attribute>>;
+
+    // TODO: remove this
+    // let mut i = 0 as usize;
+    // println!("sort[T{}] = {:?}", i, sort);
+    // println!("seen[T{}] = {:?}", i, seen);
+    // println!("rest[T{}] = {:?}", i, rest);
+
+    while !rest.is_empty() {
+        let (tail, head) = rest.into_iter().partition::<Vec<_>, _>(|attr| {
+            attr.requires()
+                .into_iter()
+                .filter(|req| !seen.contains(req.attr_id()))
+                .next()
+                .is_some()
+        });
+        rest = tail;
+        seen.extend(head.iter().map(|attr| attr.attr_id()));
+        sort.extend(head);
+
+        // TODO: remove this
+        // i += 1;
+        // println!("sort[T{}] = {:?}", i, sort);
+        // println!("seen[T{}] = {:?}", i, seen);
+        // println!("rest[T{}] = {:?}", i, rest);
+    }
+
+    sort
+}
+
+/// Compute the transitive closure of the given set of attributes.
+pub(crate) fn transitive_closure(attributes: &mut HashSet<Box<dyn Attribute>>) {
+    let mut diff = requirements(&attributes);
+
+    // iterate until no new attributes can be discovered
+    while !diff.is_empty() {
+        attributes.extend(diff);
+        diff = requirements(&attributes);
+    }
+}
+
+/// Compute the attributes required to derive the given set of `attributes` that are not
+/// already in that set.
+fn requirements(attributes: &HashSet<Box<dyn Attribute>>) -> HashSet<Box<dyn Attribute>> {
+    attributes
+        .iter()
+        .flat_map(|a| a.requires())
+        .filter(|a| !attributes.contains(a))
+        .collect::<HashSet<_>>()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    /// Shorthand macros for defining test attributes.
+    macro_rules! attr_def {
+        // attribute with dependencies
+        ($id:ident depending on $($deps:expr),*) => {
+            #[derive(Debug, PartialEq, Eq, Clone, Hash)]
+            struct $id;
+
+            impl Attribute for $id {
+                fn attr_id(&self) -> &'static str {
+                    stringify!($id)
+                }
+
+                fn requires(&self) -> Vec<Box<(dyn Attribute)>> {
+                    vec![$(Box::new($deps)),*]
+                }
+
+                fn derive(&self, _: &mut Model, _: BoxId) {}
+            }
+        };
+        // attribute without dependencies
+        ($id:ident) => {
+            #[derive(Debug, PartialEq, Eq, Clone, Hash)]
+            struct $id;
+
+            impl Attribute for $id {
+                fn attr_id(&self) -> &'static str {
+                    stringify!($id)
+                }
+
+                fn requires(&self) -> Vec<Box<(dyn Attribute)>> {
+                    vec![]
+                }
+
+                fn derive(&self, _: &mut Model, _: BoxId) {}
+            }
+        };
+    }
+
+    /// Shorthand macro for referencing test attributes.
+    macro_rules! attr_ref {
+        // attribute without dependencies
+        ($id:ident) => {
+            Box::new($id) as Box<dyn Attribute>
+        };
+    }
+
+    // Define trivial attributes for testing purposes. The dependencies
+    // ionduce the following graph (dependencies are always on the left):
+    //
+    // C1 --- B2 --- B1    E1
+    //    ╲-- A2 --- A1
+    //        D1 --╱
+    attr_def!(A1 depending on A2, D1);
+    attr_def!(A2 depending on C1);
+    attr_def!(B1 depending on B2);
+    attr_def!(B2 depending on C1);
+    attr_def!(C1);
+    attr_def!(D1);
+    attr_def!(E1);
+
+    #[test]
+    fn test_eq() {
+        assert_eq!(&attr_ref!(A1), &attr_ref!(A1));
+        assert_ne!(&attr_ref!(A1), &attr_ref!(B1));
+        assert_ne!(&attr_ref!(B1), &attr_ref!(C1));
+    }
+
+    #[test]
+    fn requirements_ok() {
+        let attrs1 = HashSet::from([attr_ref!(A1), attr_ref!(B1)]);
+        let attrs2 = HashSet::from([attr_ref!(A2), attr_ref!(B2), attr_ref!(D1)]);
+        assert_eq!(requirements(&attrs1), attrs2);
+    }
+
+    #[test]
+    fn transitive_closure_ok() {
+        let mut attrs1 = HashSet::from([attr_ref!(A1), attr_ref!(B1)]);
+        let attrs2 = HashSet::from([
+            attr_ref!(A1),
+            attr_ref!(A2),
+            attr_ref!(B1),
+            attr_ref!(B2),
+            attr_ref!(C1),
+            attr_ref!(D1),
+        ]);
+        transitive_closure(&mut attrs1);
+        assert_eq!(attrs1, attrs2);
+    }
+
+    #[test]
+    fn dependency_ordered_ok() {
+        let attrs = dependency_order(HashSet::from([
+            attr_ref!(A1),
+            attr_ref!(A2),
+            attr_ref!(B1),
+            attr_ref!(B2),
+            attr_ref!(C1),
+            attr_ref!(D1),
+            attr_ref!(E1),
+        ]));
+
+        let index = attrs
+            .iter()
+            .enumerate()
+            .map(|(i, a)| (a, i))
+            .collect::<HashMap<_, _>>();
+
+        // assert that the result is the right size and has the right elements
+        assert_eq!(attrs.len(), 7);
+        assert!(index.contains_key(&attr_ref!(A1)));
+        assert!(index.contains_key(&attr_ref!(A2)));
+        assert!(index.contains_key(&attr_ref!(B1)));
+        assert!(index.contains_key(&attr_ref!(B2)));
+        assert!(index.contains_key(&attr_ref!(C1)));
+        assert!(index.contains_key(&attr_ref!(D1)));
+        assert!(index.contains_key(&attr_ref!(E1)));
+
+        // assert that the result is topologically sorted
+        let a1 = index[&attr_ref!(A1)];
+        let a2 = index[&attr_ref!(A2)];
+        let b1 = index[&attr_ref!(B1)];
+        let b2 = index[&attr_ref!(B2)];
+        let c1 = index[&attr_ref!(C1)];
+        let d1 = index[&attr_ref!(D1)];
+        assert!(a1 > a2 && a1 > d1);
+        assert!(a2 > c1);
+        assert!(b1 > b2);
+        assert!(b2 > c1);
+    }
+}

--- a/src/sql/src/query_model/attribute/mod.rs
+++ b/src/sql/src/query_model/attribute/mod.rs
@@ -7,15 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-mod attribute;
-mod dot;
-mod hir;
-mod mir;
-mod model;
-mod rewrite;
-#[cfg(test)]
-mod test;
-mod validator;
+//! Derived attributes framework and definitions.
 
-pub use model::{BoxId, DistinctOperation, Model, QuantifierId};
-pub use validator::{ValidationError, ValidationResult};
+pub mod core;

--- a/src/sql/src/query_model/dot.rs
+++ b/src/sql/src/query_model/dot.rs
@@ -199,17 +199,20 @@ impl DotGenerator {
             rows.extend(predicates.iter().map(|p| p.to_string()));
         }
 
-        if !b.unique_keys.is_empty() {
-            rows.push(format!(
-                "UNIQUE KEY {}",
-                separated(
-                    " ",
-                    b.unique_keys.iter().map(|key_set| format!(
-                        "[{}]",
-                        separated(", ", key_set.iter().map(|k| k.to_string()))
-                    ))
-                )
-            ));
+        // TODO: print UNIQUE KEY for all nodes if the derived attribute is present
+        if let BoxType::Get(get) = &b.box_type {
+            if !get.unique_keys.is_empty() {
+                rows.push(format!(
+                    "UNIQUE KEY {}",
+                    separated(
+                        " ",
+                        get.unique_keys.iter().map(|key_set| format!(
+                            "[{}]",
+                            separated(", ", key_set.iter().map(|k| k.to_string()))
+                        ))
+                    )
+                ));
+            }
         }
 
         DotLabel::MultiRow(&rows).to_string()

--- a/src/sql/src/query_model/hir.rs
+++ b/src/sql/src/query_model/hir.rs
@@ -64,15 +64,17 @@ impl FromHir {
     /// Generates a sub-graph representing the given expression.
     fn generate_internal(&mut self, expr: HirRelationExpr) -> BoxId {
         match expr {
-            HirRelationExpr::Get { id, mut typ } => {
+            HirRelationExpr::Get { id, typ } => {
                 if let Some(box_id) = self.gets_seen.get(&id) {
                     return *box_id;
                 }
                 if let expr::Id::Global(id) = id {
-                    let result = self.model.make_box(BoxType::Get(Get { id }));
+                    let result = self.model.make_box(BoxType::Get(Get {
+                        id,
+                        unique_keys: typ.keys,
+                    }));
                     let mut b = self.model.get_mut_box(result);
                     self.gets_seen.insert(expr::Id::Global(id), result);
-                    b.unique_keys.append(&mut typ.keys);
                     b.columns
                         .extend(typ.column_types.into_iter().enumerate().map(
                             |(position, column_type)| Column {

--- a/src/sql/src/query_model/mir.rs
+++ b/src/sql/src/query_model/mir.rs
@@ -61,7 +61,7 @@ impl<'a> Lowerer<'a> {
         let the_box = self.model.get_box(box_id);
 
         let input = match &the_box.box_type {
-            BoxType::Get(Get { id }) => {
+            BoxType::Get(Get { id, unique_keys }) => {
                 let typ = RelationType::new(
                     the_box
                         .columns
@@ -77,7 +77,7 @@ impl<'a> Lowerer<'a> {
                         })
                         .collect::<Vec<_>>(),
                 )
-                .with_keys(the_box.unique_keys.clone());
+                .with_keys(unique_keys.clone());
                 get_outer.product(SR::Get {
                     id: expr::Id::Global(*id),
                     typ,

--- a/src/sql/src/query_model/model/graph.rs
+++ b/src/sql/src/query_model/model/graph.rs
@@ -17,6 +17,7 @@
 //!
 //! All other types are crate-private.
 
+use super::super::attribute::core::Attributes;
 use super::scalar::*;
 use itertools::Itertools;
 use ore::id_gen::Gen;
@@ -137,6 +138,9 @@ pub(crate) struct QueryBox {
     /// guaranteed by structure of the box or it must preserve duplicated
     /// rows from its input boxes. See [DistinctOperation].
     pub distinct: DistinctOperation,
+    /// Derived attributes
+    #[allow(dead_code)]
+    pub attributes: Attributes,
 }
 
 /// A column projected by a `QueryBox`.
@@ -325,6 +329,7 @@ impl Model {
             quantifiers: QuantifierSet::new(),
             ranging_quantifiers: QuantifierSet::new(),
             distinct: DistinctOperation::Preserve,
+            attributes: Attributes::new(),
         }));
         self.boxes.insert(id, b);
         id

--- a/src/sql/src/query_model/model/graph.rs
+++ b/src/sql/src/query_model/model/graph.rs
@@ -133,10 +133,6 @@ pub(crate) struct QueryBox {
     pub quantifiers: QuantifierSet,
     /// quantifiers ranging over this box
     pub ranging_quantifiers: QuantifierSet,
-    /// list of unique keys exposed by this box. Each unique key is made by
-    /// a list of column positions. Must be re-computed every time the box
-    /// is modified.
-    pub unique_keys: Vec<Vec<usize>>,
     /// whether this box must enforce the uniqueness of its output, it is
     /// guaranteed by structure of the box or it must preserve duplicated
     /// rows from its input boxes. See [DistinctOperation].
@@ -233,6 +229,7 @@ pub(crate) enum BoxType {
 #[derive(Debug)]
 pub(crate) struct Get {
     pub id: expr::GlobalId,
+    pub unique_keys: Vec<Vec<usize>>,
 }
 
 impl From<Get> for BoxType {
@@ -327,7 +324,6 @@ impl Model {
             columns: Vec::new(),
             quantifiers: QuantifierSet::new(),
             ranging_quantifiers: QuantifierSet::new(),
-            unique_keys: Vec::new(),
             distinct: DistinctOperation::Preserve,
         }));
         self.boxes.insert(id, b);

--- a/src/sql/src/query_model/rewrite/mod.rs
+++ b/src/sql/src/query_model/rewrite/mod.rs
@@ -253,6 +253,7 @@ mod tests {
     fn get_user_id(id: u64) -> Get {
         Get {
             id: expr::GlobalId::User(id),
+            unique_keys: vec![],
         }
     }
 

--- a/src/sql/src/query_model/validator/quantifier.rs
+++ b/src/sql/src/query_model/validator/quantifier.rs
@@ -502,6 +502,7 @@ mod tests {
     fn get_user_id(id: u64) -> Get {
         Get {
             id: expr::GlobalId::User(id),
+            unique_keys: vec![],
         }
     }
 }


### PR DESCRIPTION
This adds the feature requested in #10237. 

Requirements (3) and (4) are not part of this PR and will be addressed at a later stage as we evolve this component.

### Motivation

* This PR adds a known-desirable feature: [#10237](#10237)

Attributes are added in a new `query_graph::attribute` module.  The `core` submodule contains the core infrastructure, consisting of the following items:

- `Attributes` - a container for attributes to be associated with each `QueryBox`.
- `Attribute` - a trait that encapsulates information about attribute derivation and dependency handling.
- `AttributeKey` - a trait that enables attribute lookup in an `Attributes` instance.
- `transitive_closure	` - computes the transitive closure of a seed set of attributes.
- `dependency_order` - sorts a set of attributes topologically based on the `Attribute::requires` links.

The `query_graph::attribute::tests` module contains tests for the above.

### Tips for reviewer

1. 3843b0437 moves `unique_keys` from `QueryBox` to `Get`.
1. bbfb64cd4 inlines `apply_dft_rules` in `apply_rules_to_model` in preparation for some follow-up integration work.
1. 7380a4cdc introduces the `attributes::core` module (this is the core of this PR).
1. f1e6530c7 integrates `attributes::core` with the rest of the code as follows:
    1. installs an `Attributes` field in `QueryBox`,
    1. ensures that attributes required by rules are always derived correctly in `apply_rules_to_model`.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
