### PR TITLE
qgm: add `NonNullRequirements` derived attribute

### DIFF
--- a/src/sql/src/query_model/attribute/mod.rs
+++ b/src/sql/src/query_model/attribute/mod.rs
@@ -10,3 +10,4 @@
 //! Derived attributes framework and definitions.
 
 pub mod core;
+pub mod non_null_requirements;

--- a/src/sql/src/query_model/attribute/non_null_requirements.rs
+++ b/src/sql/src/query_model/attribute/non_null_requirements.rs
@@ -1,0 +1,158 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Defines the [`NonNullRequirements`] attribute.
+//!
+//! The attribute value is a vector of column references corresponding
+//! to the columns of the associated `QueryBox`.
+//!
+//! If any of the references is `NULL`, the corresponding column will
+//! also be `NULL`.
+
+use crate::query_model::attribute::core::{Attribute, AttributeKey};
+use crate::query_model::model::{BoxId, BoxScalarExpr, ColumnReference, Model};
+use std::collections::HashSet;
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+pub(crate) struct NonNullRequirements;
+
+impl AttributeKey for NonNullRequirements {
+    type Value = Vec<HashSet<ColumnReference>>;
+}
+
+impl Attribute for NonNullRequirements {
+    fn attr_id(&self) -> &'static str {
+        "NonNullRequirements"
+    }
+
+    fn requires(&self) -> Vec<Box<dyn Attribute>> {
+        vec![]
+    }
+
+    fn derive(&self, model: &mut Model, box_id: BoxId) {
+        let mut r#box = model.get_mut_box(box_id);
+
+        let value = r#box
+            .columns
+            .iter()
+            .map(|x| non_null_requirements(&x.expr))
+            .collect::<Vec<_>>();
+
+        // TODO: remove this
+        // println!("|box[{}].columns| = {:?}", box_id, r#box.columns.len());
+        // println!("attr[{}] = {:?}", box_id, value);
+
+        r#box.attributes.set::<NonNullRequirements>(value);
+    }
+}
+
+/// Returns all columns that *must* be non-Null for the `expr` to be non-Null.
+pub(crate) fn non_null_requirements(expr: &BoxScalarExpr) -> HashSet<ColumnReference> {
+    use BoxScalarExpr::*;
+    let mut result = HashSet::new();
+
+    expr.try_visit_pre_post(
+        &mut |expr| {
+            match expr {
+                ColumnReference(col) => {
+                    result.insert(col.clone());
+                    None
+                }
+                BaseColumn(..) | Literal(..) | CallNullary(_) => None,
+                CallUnary { func, .. } => {
+                    if func.propagates_nulls() {
+                        None
+                    } else {
+                        Some(vec![])
+                    }
+                }
+                CallBinary { func, .. } => {
+                    if func.propagates_nulls() {
+                        None
+                    } else {
+                        Some(vec![])
+                    }
+                }
+                CallVariadic { func, .. } => {
+                    if func.propagates_nulls() {
+                        None
+                    } else {
+                        Some(vec![])
+                    }
+                }
+                // The branches of an if are computed lazily, but the condition is not
+                // so we can descend into it safely
+                If { cond, .. } => Some(vec![cond]),
+                // TODO the non-null requeriments of an aggregate expression can
+                // be pused down to, for example, convert an outer join into an
+                // inner join
+                Aggregate { .. } => Some(vec![]),
+            }
+        },
+        &mut |_| (),
+    );
+
+    return result;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query_model::model::*;
+    use crate::query_model::test::util::*;
+
+    #[test]
+    fn test_derivation() {
+        let mut model = Model::new();
+        let g_id = model.make_box(qgm::get(0).into());
+        {
+            let mut b = model.get_mut_box(g_id);
+            b.add_column(exp::base(0, typ::int32(true)));
+            b.add_column(exp::base(1, typ::int32(true)));
+            b.add_column(exp::base(2, typ::int32(true)));
+            b.add_column(exp::base(3, typ::int32(true)));
+        }
+
+        let s_id = model.make_box(Select::default().into());
+        let q_id = model.make_quantifier(QuantifierType::Foreach, g_id, s_id);
+        {
+            let mut b = model.get_mut_box(s_id);
+            // C0: (#0 - #1) + (#2 - #3)
+            b.add_column(exp::add(
+                exp::sub(exp::cref(q_id, 0), exp::cref(q_id, 1)),
+                exp::sub(exp::cref(q_id, 2), exp::cref(q_id, 3)),
+            ));
+            // C1: (#0 > #1) || (#2 > #3)
+            b.add_column(exp::or(
+                exp::gt(exp::cref(q_id, 0), exp::cref(q_id, 1)),
+                exp::gt(exp::cref(q_id, 2), exp::cref(q_id, 3)),
+            ));
+            // C1: (#0 > #1) && isnull(#1)
+            b.add_column(exp::and(
+                exp::gt(exp::cref(q_id, 0), exp::cref(q_id, 1)),
+                exp::not(exp::isnull(exp::cref(q_id, 1))),
+            ));
+        }
+
+        NonNullRequirements.derive(&mut model, s_id);
+
+        {
+            let s_box = model.get_box(s_id);
+
+            let act_value = s_box.attributes.get::<NonNullRequirements>();
+            let exp_value = &vec![
+                HashSet::from([cref(q_id, 0), cref(q_id, 1), cref(q_id, 2), cref(q_id, 3)]),
+                HashSet::from([]),
+                HashSet::from([]),
+            ];
+
+            assert_eq!(act_value, exp_value);
+        }
+    }
+}

--- a/src/sql/src/query_model/rewrite/mod.rs
+++ b/src/sql/src/query_model/rewrite/mod.rs
@@ -196,11 +196,12 @@ fn apply_rules_to_model(model: &mut Model, rules: Vec<Box<dyn ApplyRule>>) {
 mod tests {
     use super::*;
     use crate::query_model::model::*;
+    use crate::query_model::test::util::*;
 
     #[test]
     fn it_applies_a_simple_rule() {
         let mut model = test_model();
-        let src_id = model.make_box(get_user_id(5).into());
+        let src_id = model.make_box(qgm::get(5).into());
 
         let rules: Vec<Box<dyn ApplyRule>> = vec![
             // create E(src_id, curr_id) quantifiers in pre-visit
@@ -260,13 +261,6 @@ mod tests {
         model.top_box = b4;
 
         model
-    }
-
-    fn get_user_id(id: u64) -> Get {
-        Get {
-            id: expr::GlobalId::User(id),
-            unique_keys: vec![],
-        }
     }
 
     /// A test [`Rule`] that creates quantifiers between `src_id`

--- a/src/sql/src/query_model/test/mod.rs
+++ b/src/sql/src/query_model/test/mod.rs
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 pub(crate) mod catalog;
+pub(crate) mod util;
 
 use crate::plan::query::QueryLifetime;
 use crate::plan::StatementContext;

--- a/src/sql/src/query_model/test/mod.rs
+++ b/src/sql/src/query_model/test/mod.rs
@@ -1,0 +1,81 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+pub(crate) mod catalog;
+
+use crate::plan::query::QueryLifetime;
+use crate::plan::StatementContext;
+use expr_test_util::generate_explanation;
+
+use crate::query_model;
+use catalog::TestCatalog;
+
+#[test]
+fn test_hir_generator() {
+    datadriven::walk("tests/querymodel", |f| {
+        let mut catalog = TestCatalog::default();
+
+        f.run(move |s| -> String {
+            let build_stmt = |stmt, dot_graph, lower| -> String {
+                let scx = &StatementContext::new(None, &catalog);
+                if let sql_parser::ast::Statement::Select(query) = stmt {
+                    let planned_query = match crate::plan::query::plan_root_query(
+                        scx,
+                        query.query,
+                        QueryLifetime::Static,
+                    ) {
+                        Ok(planned_query) => planned_query,
+                        Err(e) => return format!("unable to plan query: {}: {}", s.input, e),
+                    };
+
+                    let model = query_model::Model::from(planned_query.expr);
+
+                    let mut output = String::new();
+
+                    if dot_graph {
+                        output += &match model.as_dot(&s.input) {
+                            Ok(graph) => graph,
+                            Err(e) => return format!("graph generation error: {}", e),
+                        };
+                    }
+
+                    if lower {
+                        output +=
+                            &generate_explanation(&catalog, &model.into(), s.args.get("format"));
+                    }
+
+                    output
+                } else {
+                    format!("invalid query: {}", s.input)
+                }
+            };
+
+            let execute_command = |dot_graph, lower| -> String {
+                let stmts = match sql_parser::parser::parse_statements(&s.input) {
+                    Ok(stmts) => stmts,
+                    Err(e) => return format!("unable to parse SQL: {}: {}", s.input, e),
+                };
+
+                stmts.into_iter().fold("".to_string(), |c, stmt| {
+                    c + &build_stmt(stmt, dot_graph, lower)
+                })
+            };
+
+            match s.directive.as_str() {
+                "build" => execute_command(true, false),
+                "lower" => execute_command(false, true),
+                "cat" => match catalog.execute_commands(&s.input) {
+                    Ok(ok) => ok,
+                    Err(err) => err,
+                },
+                _ => panic!("unknown directive: {}", s.directive),
+            }
+        })
+    });
+}

--- a/src/sql/src/query_model/test/util.rs
+++ b/src/sql/src/query_model/test/util.rs
@@ -1,0 +1,112 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::query_model::model::*;
+use repr::*;
+
+pub(crate) fn cref(quantifier_id: QuantifierId, position: usize) -> ColumnReference {
+    ColumnReference {
+        quantifier_id,
+        position,
+    }
+}
+
+pub(crate) mod qgm {
+    use super::*;
+
+    pub(crate) fn get(id: u64) -> Get {
+        Get {
+            id: expr::GlobalId::User(id),
+            unique_keys: vec![],
+        }
+    }
+}
+
+pub(crate) mod exp {
+    use super::*;
+
+    pub(crate) fn cref(quantifier_id: QuantifierId, position: usize) -> BoxScalarExpr {
+        BoxScalarExpr::ColumnReference(ColumnReference {
+            quantifier_id,
+            position,
+        })
+    }
+
+    pub(crate) fn add(lhs: BoxScalarExpr, rhs: BoxScalarExpr) -> BoxScalarExpr {
+        BoxScalarExpr::CallBinary {
+            func: expr::BinaryFunc::AddInt32,
+            expr1: Box::new(lhs),
+            expr2: Box::new(rhs),
+        }
+    }
+
+    pub(crate) fn sub(lhs: BoxScalarExpr, rhs: BoxScalarExpr) -> BoxScalarExpr {
+        BoxScalarExpr::CallBinary {
+            func: expr::BinaryFunc::SubInt32,
+            expr1: Box::new(lhs),
+            expr2: Box::new(rhs),
+        }
+    }
+
+    pub(crate) fn gt(lhs: BoxScalarExpr, rhs: BoxScalarExpr) -> BoxScalarExpr {
+        BoxScalarExpr::CallBinary {
+            func: expr::BinaryFunc::Gt,
+            expr1: Box::new(lhs),
+            expr2: Box::new(rhs),
+        }
+    }
+
+    pub(crate) fn or(lhs: BoxScalarExpr, rhs: BoxScalarExpr) -> BoxScalarExpr {
+        BoxScalarExpr::CallBinary {
+            func: expr::BinaryFunc::Or,
+            expr1: Box::new(lhs),
+            expr2: Box::new(rhs),
+        }
+    }
+
+    pub(crate) fn and(lhs: BoxScalarExpr, rhs: BoxScalarExpr) -> BoxScalarExpr {
+        BoxScalarExpr::CallBinary {
+            func: expr::BinaryFunc::And,
+            expr1: Box::new(lhs),
+            expr2: Box::new(rhs),
+        }
+    }
+
+    pub(crate) fn not(expr: BoxScalarExpr) -> BoxScalarExpr {
+        BoxScalarExpr::CallUnary {
+            func: expr::UnaryFunc::Not(expr::func::Not),
+            expr: Box::new(expr),
+        }
+    }
+
+    pub(crate) fn isnull(expr: BoxScalarExpr) -> BoxScalarExpr {
+        BoxScalarExpr::CallUnary {
+            func: expr::UnaryFunc::IsNull(expr::func::IsNull),
+            expr: Box::new(expr),
+        }
+    }
+
+    pub(crate) fn base(position: usize, column_type: ColumnType) -> BoxScalarExpr {
+        BoxScalarExpr::BaseColumn(BaseColumn {
+            position,
+            column_type,
+        })
+    }
+}
+
+pub(crate) mod typ {
+    use super::*;
+
+    pub(crate) fn int32(nullable: bool) -> ColumnType {
+        ColumnType {
+            scalar_type: ScalarType::Int32,
+            nullable,
+        }
+    }
+}

--- a/src/sql/src/query_model/validator/quantifier.rs
+++ b/src/sql/src/query_model/validator/quantifier.rs
@@ -270,6 +270,7 @@ impl Validator for QuantifierConstraintValidator {
 mod tests {
     use super::constants::*;
     use super::*;
+    use crate::query_model::test::util::*;
     use std::collections::HashSet;
 
     /// Tests constraints for quantifiers incident with [`BoxType::Get`],
@@ -278,7 +279,7 @@ mod tests {
     fn test_invalid_get_table_fn_values_ok() {
         let mut model = Model::new();
 
-        let box_get = model.make_box(get_user_id(1).into());
+        let box_get = model.make_box(qgm::get(1).into());
         let box_table_fn = model.make_box(TableFunction::default().into());
         let box_values = model.make_box(Values::default().into());
         let box_tgt = model.make_box(Select::default().into());
@@ -297,8 +298,8 @@ mod tests {
     fn test_invalid_get_table_fn_values_not_ok() {
         let mut model = Model::new();
 
-        let box_src = model.make_box(get_user_id(0).into());
-        let box_get = model.make_box(get_user_id(1).into());
+        let box_src = model.make_box(qgm::get(0).into());
+        let box_get = model.make_box(qgm::get(1).into());
         let box_table_fn = model.make_box(TableFunction::default().into());
         let box_values = model.make_box(Values::default().into());
 
@@ -324,7 +325,7 @@ mod tests {
     fn test_invalid_union_except_intersect_ok() {
         let mut model = Model::new();
 
-        let box_src = model.make_box(get_user_id(0).into());
+        let box_src = model.make_box(qgm::get(0).into());
         let box_union = model.make_box(BoxType::Union);
         let box_except = model.make_box(BoxType::Except);
         let box_intersect = model.make_box(BoxType::Intersect);
@@ -346,7 +347,7 @@ mod tests {
     fn test_invalid_union_except_intersect_not_ok() {
         let mut model = Model::new();
 
-        let box_src = model.make_box(get_user_id(0).into());
+        let box_src = model.make_box(qgm::get(0).into());
         let box_union = model.make_box(BoxType::Union);
         let box_except = model.make_box(BoxType::Except);
         let box_intersect = model.make_box(BoxType::Intersect);
@@ -375,7 +376,7 @@ mod tests {
     fn test_invalid_grouping_ok() {
         let mut model = Model::new();
 
-        let box_src = model.make_box(get_user_id(0).into());
+        let box_src = model.make_box(qgm::get(0).into());
         let box_select = model.make_box(Select::default().into());
         let box_grouping = model.make_box(Grouping::default().into());
         let box_dst = model.make_box(Select::default().into());
@@ -393,7 +394,7 @@ mod tests {
     fn test_invalid_grouping_not_ok() {
         let mut model = Model::new();
 
-        let box_src = model.make_box(get_user_id(0).into());
+        let box_src = model.make_box(qgm::get(0).into());
         let box_grouping = model.make_box(Grouping::default().into());
         let box_dst = model.make_box(BoxType::Union);
 
@@ -419,7 +420,7 @@ mod tests {
     fn test_invalid_select_ok() {
         let mut model = Model::new();
 
-        let box_src = model.make_box(get_user_id(0).into());
+        let box_src = model.make_box(qgm::get(0).into());
         let box_select = model.make_box(Select::default().into());
 
         model.make_quantifier(QuantifierType::Foreach, box_src, box_select);
@@ -435,7 +436,7 @@ mod tests {
     fn test_invalid_select_not_ok() {
         let mut model = Model::new();
 
-        let box_src = model.make_box(get_user_id(0).into());
+        let box_src = model.make_box(qgm::get(0).into());
         let box_select = model.make_box(Select::default().into());
 
         model.make_quantifier(QuantifierType::PreservedForeach, box_src, box_select);
@@ -456,8 +457,8 @@ mod tests {
     fn test_outer_join_ok() {
         let mut model = Model::new();
 
-        let box_lhs = model.make_box(get_user_id(0).into());
-        let box_rhs = model.make_box(get_user_id(1).into());
+        let box_lhs = model.make_box(qgm::get(0).into());
+        let box_rhs = model.make_box(qgm::get(1).into());
         let box_outer_join_1 = model.make_box(OuterJoin::default().into());
         let box_outer_join_2 = model.make_box(OuterJoin::default().into());
 
@@ -475,8 +476,8 @@ mod tests {
     fn test_outer_join_not_ok() {
         let mut model = Model::new();
 
-        let box_lhs = model.make_box(get_user_id(0).into());
-        let box_rhs = model.make_box(get_user_id(1).into());
+        let box_lhs = model.make_box(qgm::get(0).into());
+        let box_rhs = model.make_box(qgm::get(1).into());
         let box_outer_join_1 = model.make_box(OuterJoin::default().into());
         let box_outer_join_2 = model.make_box(OuterJoin::default().into());
 
@@ -497,12 +498,5 @@ mod tests {
             ValidationError::InvalidInputQuantifiers(box_outer_join_2, ZERO_OR_ONE_FOREACH),
         ]);
         assert_eq!(errors_act, errors_exp);
-    }
-
-    fn get_user_id(id: u64) -> Get {
-        Get {
-            id: expr::GlobalId::User(id),
-            unique_keys: vec![],
-        }
     }
 }


### PR DESCRIPTION
Adds `NonNullRequirements`. 

### Motivation

* This PR adds a known-desirable feature: [#10238](10238)

### Tips for reviewer

- The first four commits are part of [#10369](10369) and should be reviewed there.
- The next two commits put existing and new test utilities in a separate module so they can be reused.
- The final commit adds the `NonNullRequirements` attribute. Note the differences between [`MirScalarExpr::non_null_requirements`](https://github.com/aalexandrov/materialize/blob/49b12450ed78a5a231a3c7ff79e4c085e7cf55ed/src/expr/src/scalar/mod.rs#L882) and the derived attribute [`non_null_requirements`](https://github.com/aalexandrov/materialize/blob/2f92fac3eb1413d8ced041eb98cd05144c203166/src/sql/src/query_model/attribute/non_null_requirements.rs#L56) function proposed here.
    - I think we can descend in the `cond` part of the `If { .. }` case.
    - The `MirScalarExpr::non_null_requirements` function is recursive. This probably should be fixed as part of [#10348](10348).

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
