### PR TITLE
Introduce compute instances to the coordinator

### DIFF
--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -53,9 +53,9 @@ pub const DEFAULT_INSTANCE_ID: usize = 0;
     doc = "The kind of compute command that was received"
 )]
 pub enum ComputeCommand {
-    /// Indicates the creation of an instance, and is the first command.
+    /// Indicates the creation of an instance, and is the first command for its compute instance.
     CreateInstance,
-    /// Indicates the termination of an instance, and is the last command.
+    /// Indicates the termination of an instance, and is the last command for its compute instance.
     DropInstance,
 
     /// Create a sequence of dataflows.

--- a/src/dataflow-types/src/client/controller.rs
+++ b/src/dataflow-types/src/client/controller.rs
@@ -83,13 +83,13 @@ impl<C: Client> Controller<C> {
                     }
                 }
             }
-            Command::Compute(ComputeCommand::EnableLogging(logging_config)) => {
+            Command::Compute(ComputeCommand::EnableLogging(logging_config), _instance) => {
                 for id in logging_config.log_identifiers() {
                     self.compute_since_uppers
                         .insert(id, (Antichain::from_elem(0), Antichain::from_elem(0)));
                 }
             }
-            Command::Compute(ComputeCommand::CreateDataflows(dataflows)) => {
+            Command::Compute(ComputeCommand::CreateDataflows(dataflows), _instance) => {
                 // Validate dataflows as having inputs whose `since` is less or equal to the dataflow's `as_of`.
                 // Start tracking frontiers for each dataflow, using its `as_of` for each index and sink.
                 for dataflow in dataflows.iter() {
@@ -134,7 +134,7 @@ impl<C: Client> Controller<C> {
                     }
                 }
             }
-            Command::Compute(ComputeCommand::AllowIndexCompaction(frontiers)) => {
+            Command::Compute(ComputeCommand::AllowIndexCompaction(frontiers), _instance) => {
                 for (id, frontier) in frontiers.iter() {
                     self.compute_since_uppers.advance_since_for(*id, frontier);
                 }

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -461,7 +461,6 @@ where
 
     /// Draws from `dataflow_command_receiver` until shutdown.
     fn run(&mut self) {
-        let mut started = false;
         let mut shutdown = false;
         while !shutdown {
             // Enable trace compaction.
@@ -485,29 +484,9 @@ where
 
             while !empty && !shutdown {
                 match self.command_rx.try_recv() {
-                    Ok(Command::Compute(ComputeCommand::CreateInstance, _)) => {
-                        if !started {
-                            started = true
-                        } else {
-                            panic!("Repeated CreateInstance command");
-                        }
-                    }
-                    Ok(Command::Compute(ComputeCommand::DropInstance, _)) => {
-                        if !started {
-                            panic!("First command was not CreateInstance");
-                        }
-                        // Cease consuming from `self.command_rx`.
-                        shutdown = true;
-                    }
-                    Ok(cmd) => {
-                        if !started {
-                            panic!("First command was not CreateInstance");
-                        }
-                        cmds.push(cmd)
-                    }
+                    Ok(cmd) => cmds.push(cmd),
                     Err(TryRecvError::Empty) => empty = true,
                     Err(TryRecvError::Disconnected) => {
-                        // Unclean termination. Not obviously wrong at this point though.
                         empty = true;
                         shutdown = true;
                     }
@@ -723,7 +702,9 @@ where
     fn handle_compute_command(&mut self, cmd: ComputeCommand) {
         match cmd {
             ComputeCommand::CreateInstance | ComputeCommand::DropInstance => {
-                panic!("CreateInstance and DropInstance commands should be filtered, not handled.");
+                // Can be ignored for the moment.
+                // Should eventually be filtered outside of this method,
+                // we are already deep in a specific instance.
             }
             ComputeCommand::CreateDataflows(dataflows) => {
                 for dataflow in dataflows.into_iter() {

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -481,8 +481,7 @@ where
             // Handle any received commands.
             let mut cmds = vec![];
             let mut empty = false;
-
-            while !empty && !shutdown {
+            while !empty {
                 match self.command_rx.try_recv() {
                     Ok(cmd) => cmds.push(cmd),
                     Err(TryRecvError::Empty) => empty = true,
@@ -704,7 +703,7 @@ where
             ComputeCommand::CreateInstance | ComputeCommand::DropInstance => {
                 // Can be ignored for the moment.
                 // Should eventually be filtered outside of this method,
-                // we are already deep in a specific instance.
+                // as we are already deep in a specific instance.
             }
             ComputeCommand::CreateDataflows(dataflows) => {
                 for dataflow in dataflows.into_iter() {


### PR DESCRIPTION
This PR decorates each `ComputeCommand` with a `ComputeInstancesId`, and adds `CreateInstance` and `DropInstance` variants to `ComputeCommand` so that instances can be started and stopped. The implementation currently ignores these arguments, and we continue to use a single timely instance to support all instances. The guarantees of an instance are only that two commands with the same instance identifier go to the same cluster, not that they are held apart. Nothing has changed about about the requirement of `GlobalId`s being unique; even though you may send commands to distinct instances, you need to use globally unique names.

### Motivation

The concept of cluster instances are important to introduce before we slot multiple cluster implementations behind the scenes. They cannot work correctly without the coordinator learning about the concept and modifying its behavior appropriately. That work is TBD, but it can at least be done concurrently with this work. If the coordinator remains otherwise unchanged, it will continue to use a single compute instance.

### Tips for reviewer

The design for instance creation and dropping is very simple and imperative: you use the same client, and issue the commands. The coordinator starts by creating a `DEFAULT_INSTANCE_ID` compute instance, and uses that throughout. A search for that identifier should clarify the coordinator moments where an instance id needs to be specified.

This relates to https://github.com/MaterializeInc/materialize/pull/10353 in that one could reasonably conclude that it is too tedious for the coordinator to track which indexes and sinks are live in which compute instances, and the proposed fat client could do that too. This seems like a good idea modulo the issues about only mirroring out the truth for information that has been committed, rather than e.g. updates halfway through a transaction. I'd be interested in any takes on that.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
