### PR TITLE
ci/test: fix git diff invocation

### DIFF
--- a/ci/test/mkpipeline.py
+++ b/ci/test/mkpipeline.py
@@ -183,7 +183,7 @@ def trim_pipeline(pipeline: Any) -> None:
 def have_paths_changed(globs: Iterable[str]) -> bool:
     """Reports whether the specified globs have diverged from origin/main."""
     diff = subprocess.run(
-        ["git", "diff", "--no-patch", "--quiet", "--", "origin/main...", *globs]
+        ["git", "diff", "--no-patch", "--quiet", "origin/main...", "--", *globs]
     )
     if diff.returncode == 0:
         return False


### PR DESCRIPTION
The "--" separator must go after any refspecs, apparently.


### Motivation

  * This PR fixes a previously unreported bug: 0f07c5cc8e89c35400c05d9bbd415d94c9e29f97 broke CI.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
