### PR TITLE
debezium: fix deduplication logic with multi-partition topics

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -107,6 +107,10 @@ These changes are present in [unstable builds](/versions/#unstable-builds) and
 are slated for inclusion in the next stable release. There may be additional
 changes that have not yet been documented.
 
+- Correctly deduplicate debezium topics that have more than one partition.
+  Previous versions of materialize would experience data loss unless
+  `deduplication=full` was used.
+
 {{< comment >}}
 Only add new release notes above this line.
 

--- a/src/dataflow/src/render/upsert.rs
+++ b/src/dataflow/src/render/upsert.rs
@@ -326,6 +326,7 @@ where
                         value: new_value,
                         position: new_position,
                         upstream_time_millis: _,
+                        partition: _,
                         metadata,
                     } in vector.drain(..)
                     {

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -160,7 +160,7 @@ pub(crate) struct SourceData {
 }
 
 /// The output of the decoding operator
-#[derive(Debug, Default, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub struct DecodeResult {
     /// The decoded key
     pub key: Option<Result<Row, DecodeError>>,
@@ -170,6 +170,8 @@ pub struct DecodeResult {
     pub position: Option<i64>,
     /// The time the record was created in the upstream systsem, as milliseconds since the epoch
     pub upstream_time_millis: Option<i64>,
+    /// The partition this record came from
+    pub partition: PartitionId,
     /// If this is a Kafka stream, the appropriate metadata
     // TODO(bwm): This should probably be statically different for different streams, or we should
     // propagate whether metadata is requested into the decoder

--- a/test/testdrive/debezium-multiple-partitions.td
+++ b/test/testdrive/debezium-multiple-partitions.td
@@ -1,0 +1,107 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test that debezium deduplication works correctly in the presence of multiple partitions
+
+$ set key-schema={"type": "record", "name": "row", "fields": [{"name": "a", "type": "long"}]}
+
+$ set schema={
+    "type": "record",
+    "name": "envelope",
+    "fields": [
+      {
+        "name": "before",
+        "type": [
+          {
+            "name": "row",
+            "type": "record",
+            "fields": [
+              {"name": "a", "type": "long"},
+              {"name": "b", "type": "long"}
+            ]
+          },
+          "null"
+        ]
+      },
+      { "name": "after", "type": ["row", "null"] },
+      {
+        "name": "source",
+        "type": {
+          "type": "record",
+          "name": "Source",
+          "namespace": "io.debezium.connector.mysql",
+          "fields": [
+            {
+              "name": "file",
+              "type": "string"
+            },
+            {
+              "name": "pos",
+              "type": "long"
+            },
+            {
+              "name": "row",
+              "type": "int"
+            },
+            {
+              "name": "snapshot",
+              "type": [
+                {
+                  "type": "boolean",
+                  "connect.default": false
+                },
+                "null"
+              ],
+              "default": false
+            }
+          ],
+          "connect.name": "io.debezium.connector.mysql.Source"
+        }
+      },
+      {
+        "name": "transaction",
+        "type": {
+          "type": "record",
+          "name": "Transaction",
+          "namespace": "whatever",
+          "fields": [
+            {
+              "name": "total_order",
+              "type": ["long", "null"]
+            }
+          ]
+        }
+      }
+    ]
+  }
+
+$ kafka-create-topic topic=data partitions=3
+
+> CREATE MATERIALIZED SOURCE multipartition
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
+  WITH (deduplication = 'ordered')
+  FORMAT AVRO USING SCHEMA '${schema}'
+  ENVELOPE DEBEZIUM
+
+# Ingest the data in the reverse order but in separate partitions
+$ kafka-ingest format=avro key-format=avro topic=data schema=${schema} key-schema=${key-schema} partition=2
+{"a":3} {"before":null,"after":{"row":{"a":3,"b":1}},"source":{"file":"binlog","pos":3,"row":0,"snapshot":{"boolean":false}},"transaction":{"total_order":null}}
+
+$ kafka-ingest format=avro key-format=avro topic=data schema=${schema} key-schema=${key-schema} partition=1
+{"a":2} {"before":null,"after":{"row":{"a":2,"b":1}},"source":{"file":"binlog","pos":2,"row":0,"snapshot":{"boolean":false}},"transaction":{"total_order":null}}
+
+$ kafka-ingest format=avro key-format=avro topic=data schema=${schema} key-schema=${key-schema} partition=0
+{"a":1} {"before":null,"after":{"row":{"a":1,"b":1}},"source":{"file":"binlog","pos":1,"row":0,"snapshot":{"boolean":false}},"transaction":{"total_order":null}}
+
+> SELECT a, b FROM multipartition
+a b
+----
+1 1
+2 1
+3 1


### PR DESCRIPTION
### Motivation

We were previously incorrectly assuming that deduplication state is
global accross all partitions of a topic. This is incorrect and can lead
to data loss.

This PR changes the deduplication logic to store state per partition.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
