### PR TITLE
kafka-ingest-open-loop: make envelope configurable

### DIFF
--- a/test/kafka-ingest-open-loop/mzcompose.py
+++ b/test/kafka-ingest-open-loop/mzcompose.py
@@ -111,6 +111,11 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         "--value-bytes", type=int, default=500, help="record payload size in bytes"
     )
     parser.add_argument(
+        "--upsert",
+        action="store_true",
+        help="whether to use envelope UPSERT (True) or NONE (False)",
+    )
+    parser.add_argument(
         "--timeout-secs", type=int, default=120, help="timeout to send records to Kafka"
     )
     parser.add_argument(
@@ -131,6 +136,10 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         help="number of dataflow workers to use in materialized",
     )
     args = parser.parse_args()
+
+    envelope = "NONE"
+    if args.upsert:
+        envelope = "UPSERT"
 
     options = []
     if args.enable_persistence:
@@ -173,6 +182,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
         c.run(
             "testdrive-svc",
+            f"--var=envelope={envelope}",
             "setup.td",
         )
 

--- a/test/kafka-ingest-open-loop/setup.td
+++ b/test/kafka-ingest-open-loop/setup.td
@@ -30,7 +30,7 @@ $ kafka-create-topic topic=load-test partitions=4
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-load-test-${testdrive.seed}'
   FORMAT BYTES
   INCLUDE PARTITION AS kafka_partition, OFFSET AS mz_offset
-  ENVELOPE UPSERT
+  ENVELOPE ${arg.envelope}
 
 # Render a dataflow that uses the source, but does a minimal amount of
 # work and keeps a minimal amount of data in memory.


### PR DESCRIPTION
Default to ENVELOPE NONE and add a new `--upsert` flag to the workflow
to use ENVELOPE UPSERT instead. (This benchmark was designed as a
worst-case for persist overhead, but we didn't yet have persist support
for ENVELOPE NONE when it was merged.)

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [N/A] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
