### PR TITLE
doc/user: mark Materialize CDC as in beta

### DIFF
--- a/doc/user/content/connect/materialize-cdc.md
+++ b/doc/user/content/connect/materialize-cdc.md
@@ -7,6 +7,8 @@ menu:
     weight: 4
 ---
 
+{{< beta />}}
+
 Change data capture (CDC) tools provide feeds that record any changes to a database. Typically, the feeds are then saved to another platform, like Kafka, for storage or processing. However, sometimes the stream can have missing or duplicate records, or records can be received out of order. For example, if a CDC tool crashes while writing a record, it may retry and write the record again, resulting in a duplicate entry.
 
 The **Materialize CDC format** has been designed to provide a downstream data consumer (like Materialize) with enough information to recognize when records are duplicated or out of order. For a technical deep dive on the subject, see our blog post on [Change Data Capture](https://materialize.com/change-data-capture-part-1/).


### PR DESCRIPTION
Even though it hasn't been marked as such, we've internally been
thinking about the format as in beta, as there are still a number of
rough edges to sand down. Make the docs reflect reality.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
