### PR TITLE
Do not panic if commands appear out of order

### DIFF
--- a/src/dataflow-types/src/client/controller.rs
+++ b/src/dataflow-types/src/client/controller.rs
@@ -234,8 +234,7 @@ struct SinceUpperMap {
 
 impl SinceUpperMap {
     fn insert(&mut self, id: GlobalId, since_upper: (Antichain<Timestamp>, Antichain<Timestamp>)) {
-        let prior = self.since_uppers.insert(id, since_upper);
-        assert!(prior.is_none());
+        self.since_uppers.insert(id, since_upper);
     }
     fn get(&self, id: &GlobalId) -> Option<(AntichainRef<Timestamp>, AntichainRef<Timestamp>)> {
         self.since_uppers


### PR DESCRIPTION
Avoid crashing in cases where one allows frontier compaction without first creating the source/index/sink.

### Motivation

This command sequence is likely out of the intended spec, but that spec isn't written down yet so in the meantime avoid being too grouchy about it.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
