### PR TITLE
persist: concurrently download parts in s3 get

### DIFF
--- a/src/persist/benches/benches.rs
+++ b/src/persist/benches/benches.rs
@@ -15,16 +15,21 @@ mod snapshot;
 mod writer;
 
 pub fn bench_persist(c: &mut Criterion) {
+    // Override the default of "info" here because the s3 library is chatty on
+    // info while initializing. It's good info to have in mz logs, but ends
+    // being as spammy in these benchmarks.
+    ore::test::init_logging_default("warn");
     let data = DataGenerator::default();
 
     end_to_end::bench_load(&data, &mut c.benchmark_group("end_to_end/load"));
     end_to_end::bench_replay(&data, &mut c.benchmark_group("end_to_end/replay"));
 
+    snapshot::bench_blob_get(&data, &mut c.benchmark_group("snapshot/blob_get"));
     snapshot::bench_mem(&data, &mut c.benchmark_group("snapshot/mem"));
     snapshot::bench_file(&data, &mut c.benchmark_group("snapshot/file"));
 
     writer::bench_log(&mut c.benchmark_group("writer/log"));
-    writer::bench_blob(&data, &mut c.benchmark_group("writer/blob"));
+    writer::bench_blob_set(&data, &mut c.benchmark_group("writer/blob_set"));
     writer::bench_encode_batch(&data, &mut c.benchmark_group("writer/encode_batch"));
     writer::bench_blob_cache_set_unsealed_batch(
         &data,

--- a/src/persist/benches/end_to_end.rs
+++ b/src/persist/benches/end_to_end.rs
@@ -44,7 +44,7 @@ pub fn bench_load(data: &DataGenerator, g: &mut BenchmarkGroup<'_, WallTime>) {
 
     g.throughput(Throughput::Bytes(data.goodput_bytes()));
     g.bench_function(BenchmarkId::new("s3", data.goodput_pretty()), move |b| {
-        b.iter(|| bench_load_s3_one_iter(&data, &config))
+        b.iter(|| bench_load_s3_one_iter(&data, &config).expect("failed to run load iter"))
     });
 }
 

--- a/src/persist/src/workload.rs
+++ b/src/persist/src/workload.rs
@@ -234,6 +234,22 @@ pub fn load(
     Ok(data.goodput_bytes())
 }
 
+/// Encodes the given data into a flat buffer that is exactly
+/// `data.goodput_bytes()` long.
+pub fn flat_blob(data: &DataGenerator) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(usize::cast_from(data.goodput_bytes()));
+    for batch in data.batches() {
+        for ((k, v), t, d) in batch.iter() {
+            buf.extend_from_slice(k);
+            buf.extend_from_slice(v);
+            buf.extend_from_slice(&t.to_le_bytes());
+            buf.extend_from_slice(&d.to_le_bytes());
+        }
+    }
+    assert_eq!(buf.len(), usize::cast_from(data.goodput_bytes()));
+    buf
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
AWS advises fetching multiple parts concurrently for large objects [1].

[1]: https://docs.aws.amazon.com/whitepapers/latest/s3-optimizing-performance-best-practices/use-byte-range-fetches.html

Results on an m6i.8xlarge

    MZ_PERSIST_RECORD_COUNT=1000000 MZ_PERSIST_RECORD_SIZE_BYTES=64 MZ_PERSIST_BATCH_MAX_COUNT=131072
    snapshot/blob_get/s3/61MiB
                            time:   [133.04 ms 135.06 ms 136.92 ms]
                            thrpt:  [445.76 MiB/s 451.93 MiB/s 458.79 MiB/s]
                     change:
                            time:   [-81.140% -80.831% -80.549%] (p = 0.00 < 0.05)
                            thrpt:  [+414.11% +421.68% +430.22%]
                            Performance has improved.

    MZ_PERSIST_RECORD_COUNT=10000000 MZ_PERSIST_RECORD_SIZE_BYTES=64 MZ_PERSIST_BATCH_MAX_COUNT=131072
    snapshot/blob_get/s3/610MiB
                            time:   [728.31 ms 755.87 ms 781.59 ms]
                            thrpt:  [780.91 MiB/s 807.48 MiB/s 838.04 MiB/s]
                     change:
                            time:   [-89.624% -89.218% -88.868%] (p = 0.00 < 0.05)
                            thrpt:  [+798.34% +827.43% +863.81%]
                            Performance has improved.

    snapshot/blob_get/s3/6103MiB
                            time:   [7.4983 s 7.7315 s 8.0957 s]
                            thrpt:  [753.92 MiB/s 789.44 MiB/s 813.98 MiB/s]
    Found 1 outliers among 10 measurements (10.00%)
      1 (10.00%) high severe

    NAME                      |    THIS     |    OTHER    |  Regression?  | 'THIS' is:
    ----------------------------------------------------------------------------------------------------
    KafkaRecovery             |      23.758 |      23.890 |      no       | 0.6 pct   faster
    KafkaRecoveryBig          |     186.796 |     340.601 |      no       | 45.2 pct   faster

    KafkaRecoveryBig THIS
    Measurement: 244.5950734615326
    Measurement: 199.1898534297943
    Measurement: 197.5417845249176
    Measurement: 186.7961528301239 (bonus)

    KafkaRecoveryBig OTHER
    Measurement: 496.861661195755
    Measurement: 531.6735861301422
    Measurement: 324.1175286769867
    Measurement: 340.6010401248932 (bonus)

KafkaRecovery is operating over 10_000_000 inputs, each of which is
logically 2 longs (plus some overhead), so roughly ~80MiB. It's possible
this isn't enough for individual batches to hit the 8MiB minimum we use
for switching to multipart.

Closes #10138

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
