### PR TITLE
ban log from as many places as possible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1407,7 +1407,6 @@ dependencies = [
  "http-serde",
  "interchange",
  "kafka-util",
- "log",
  "mz-aws-util",
  "num_enum",
  "ore",

--- a/deny.toml
+++ b/deny.toml
@@ -72,6 +72,37 @@ wrappers = [
     "zip",
 ]
 
+[[bans.deny]]
+name = "log"
+wrappers = [
+    "wasm-bindgen-backend",
+    "want",
+    "tracing-log",
+    "tracing",
+    "tokio-util",
+    "tokio-postgres",
+    "reqwest",
+    # TODO(guswynn): switch to tracing in rdkafka
+    "rdkafka",
+    "pubnub-hyper",
+    "pubnub-core",
+    "prost-build",
+    "pprof",
+    "postgres",
+    "os_info",
+    "opentls",
+    "native-tls",
+    "mio",
+    "globset",
+    "fail",
+    "env_logger",
+
+
+    # TODO(guswynn): switch to `tracing:enabled!` when its released
+    "dataflow",
+    "coord",
+]
+
 # We prefer the system's native TLS or OpenSSL to Rustls, since they are more
 # mature and more widely used.
 [[bans.deny]]

--- a/src/dataflow-types/Cargo.toml
+++ b/src/dataflow-types/Cargo.toml
@@ -28,7 +28,6 @@ kafka-util = { path = "../kafka-util" }
 http = "0.2.6"
 http-serde = "1.0.3"
 tracing = "0.1.29"
-log = "0.4.13"
 num_enum = "0.5.6"
 mz-aws-util = { path = "../aws-util" }
 ore = { path = "../ore" }

--- a/src/dataflow-types/src/client/controller.rs
+++ b/src/dataflow-types/src/client/controller.rs
@@ -77,7 +77,7 @@ impl<C: Client> Controller<C> {
             Command::Storage(StorageCommand::DropSources(identifiers)) => {
                 for id in identifiers.iter() {
                     if !self.source_descriptions.contains_key(id) {
-                        log::error!("Source id {} dropped without first being created", id);
+                        tracing::error!("Source id {} dropped without first being created", id);
                     } else {
                         self.source_descriptions.insert(*id, None);
                     }

--- a/src/dataflow/src/render/debezium.rs
+++ b/src/dataflow/src/render/debezium.rs
@@ -15,10 +15,10 @@ use chrono::format::{DelayedFormat, StrftimeItems};
 use chrono::NaiveDateTime;
 use differential_dataflow::AsCollection;
 use differential_dataflow::Collection;
-use log::{debug, error, info, warn};
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::Operator;
 use timely::dataflow::{Scope, Stream};
+use tracing::{debug, error, info, warn};
 
 use dataflow_types::{
     sources::{DebeziumDedupProjection, DebeziumEnvelope, DebeziumMode, DebeziumSourceProjection},

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -923,7 +923,7 @@ where
                             self.timely_worker.peers(),
                             &pid,
                         ) {
-                            log::trace!(
+                            tracing::trace!(
                                 "Adding partition/binding on worker {}: ({}, {}, {})",
                                 self.timely_worker.index(),
                                 pid,
@@ -933,7 +933,7 @@ where
                             data.add_partition(pid.clone(), None);
                             data.add_binding(pid, timestamp, offset, false);
                         } else {
-                            log::trace!(
+                            tracing::trace!(
                                 "NOT adding partition/binding on worker {}: ({}, {}, {})",
                                 self.timely_worker.index(),
                                 pid,


### PR DESCRIPTION
A couple callsites slipped through

unfortunately, `clippy::disallowed_methods` doesnt work with macros, so eventually we need to ban log from all our crates. Once my `tracing::enabled!` change is backported, then we can do so

### Motivation

   * This PR refactors existing code.

