### PR TITLE
persist: add counter for times step called, but compaction already in…

### DIFF
--- a/src/persist/src/indexed/metrics.rs
+++ b/src/persist/src/indexed/metrics.rs
@@ -85,6 +85,7 @@ pub struct Metrics {
     pub(crate) compaction_seconds: ThirdPartyMetric<Counter>,
     pub(crate) compaction_write_bytes: ThirdPartyMetric<UIntCounter>,
     pub(crate) trace_compaction_error_response_count: ThirdPartyMetric<UIntCounter>,
+    pub(crate) trace_compaction_skipped_count: ThirdPartyMetric<UIntCounter>,
 
     // TODO: Tag cmd_process_count with cmd type and remove this?
     pub(crate) cmd_write_count: ThirdPartyMetric<UIntCounter>,
@@ -172,6 +173,10 @@ impl Metrics {
             trace_compaction_error_response_count: registry.register_third_party_visible(metric!(
                 name: "mz_persist_trace_compaction_error_response_count",
                 help: "count of trace compaction requests where an error was returned",
+            )),
+            trace_compaction_skipped_count: registry.register_third_party_visible(metric!(
+                name: "mz_persist_trace_compaction_skipped_count",
+                help: "count of times trace compaction request generation was skipped",
             )),
             cmd_write_count: registry.register_third_party_visible(metric!(
                 name: "mz_persist_cmd_write_count",

--- a/src/persist/src/indexed/mod.rs
+++ b/src/persist/src/indexed/mod.rs
@@ -1000,6 +1000,7 @@ impl<L: Log, B: Blob> Indexed<L, B> {
             // arbitrarily long for maintenance responses and most likely institute
             // a timeout.
             if self.in_flight_trace_compactions.contains_key(&id) {
+                self.metrics.trace_compaction_skipped_count.inc();
                 continue;
             }
             if let Some(req) = arrangement.trace_next_compact_req()? {


### PR DESCRIPTION
… flight

This counter helps indicate when compactions might be falling behind calls to
drain_unsealed which mint new trace batches.

<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug: [Link to issue.]

  * This PR adds a known-desirable feature: [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
