### PR TITLE
persist: add a naive size bound to the blob cache

### DIFF
--- a/src/coord/src/persistcfg.rs
+++ b/src/coord/src/persistcfg.rs
@@ -135,6 +135,8 @@ pub struct PersistConfig {
     /// version of the creating process).
     pub lock_info: String,
     pub min_step_interval: Duration,
+    /// Maximum size of the in-memory blob storage cache, in bytes.
+    pub cache_size_limit: Option<usize>,
 }
 
 impl PersistConfig {
@@ -147,6 +149,7 @@ impl PersistConfig {
             kafka_upsert_source_enabled: false,
             lock_info: Default::default(),
             min_step_interval: Duration::default(),
+            cache_size_limit: None,
         }
     }
 
@@ -171,7 +174,7 @@ impl PersistConfig {
                     let mut blob = FileBlob::open_exclusive((&s.blob_path).into(), lock_info)?;
                     persist::storage::check_meta_version_maybe_delete_data(&mut blob)?;
                     runtime::start(
-                        RuntimeConfig::with_min_step_interval(self.min_step_interval),
+                        RuntimeConfig::new(self.min_step_interval, self.cache_size_limit),
                         log,
                         blob,
                         build,
@@ -186,7 +189,7 @@ impl PersistConfig {
                     let mut blob = S3Blob::open_exclusive(config, lock_info)?;
                     persist::storage::check_meta_version_maybe_delete_data(&mut blob)?;
                     runtime::start(
-                        RuntimeConfig::with_min_step_interval(self.min_step_interval),
+                        RuntimeConfig::new(self.min_step_interval, self.cache_size_limit),
                         log,
                         blob,
                         build,

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -155,6 +155,11 @@ struct Args {
     #[structopt(long, hide = true)]
     persistent_kafka_upsert_source: bool,
 
+    /// Maximum allowed size of the in-memory persist storage cache, in bytes. Has
+    /// to be used with --experimental.
+    #[structopt(long, hide = true)]
+    persist_cache_size_limit: Option<usize>,
+
     // === Timely worker configuration. ===
     /// Number of dataflow worker threads.
     #[clap(short, long, env = "MZ_WORKERS", value_name = "N", default_value_t)]
@@ -717,6 +722,14 @@ dataflow workers: {workers}",
                 false
             };
 
+        let cache_size_limit = {
+            if args.persist_cache_size_limit.is_some() && !args.experimental {
+                bail!("cannot specify --persist-cache-size-limit without --experimental");
+            }
+
+            args.persist_cache_size_limit
+        };
+
         let lock_info = format!(
             "materialized {mz_version}\nos: {os}\nstart time: {start_time}\nnum workers: {num_workers}\n",
             mz_version = materialized::BUILD_INFO.human_version(),
@@ -740,6 +753,7 @@ dataflow workers: {workers}",
             kafka_upsert_source_enabled,
             lock_info,
             min_step_interval,
+            cache_size_limit,
         }
     };
 

--- a/src/persist/benches/writer.rs
+++ b/src/persist/benches/writer.rs
@@ -288,6 +288,7 @@ pub fn bench_indexed_drain(data: &DataGenerator, g: &mut BenchmarkGroup<'_, Wall
         Arc::clone(&metrics),
         async_runtime,
         file_blob,
+        None,
     );
     let file_indexed =
         Indexed::new(file_log, blob_cache, metrics).expect("failed to create file indexed");
@@ -353,6 +354,7 @@ pub fn bench_blob_cache_set_unsealed_batch(
         metrics,
         Arc::clone(&async_runtime),
         mem_blob,
+        None,
     );
 
     // Create a directory that will automatically be dropped after the test finishes.
@@ -365,6 +367,7 @@ pub fn bench_blob_cache_set_unsealed_batch(
         metrics,
         async_runtime,
         file_blob,
+        None,
     );
 
     let batches = data.batches().collect::<Vec<_>>();

--- a/src/persist/src/indexed/arrangement.rs
+++ b/src/persist/src/indexed/arrangement.rs
@@ -1041,6 +1041,7 @@ mod tests {
             Arc::new(Metrics::default()),
             Arc::new(AsyncRuntime::new()?),
             MemBlob::new_no_reentrance("append_trace_ts_upper_invariant"),
+            None,
         );
         let mut f = Arrangement::new(ArrangementMeta {
             id: Id(0),
@@ -1085,6 +1086,7 @@ mod tests {
             Arc::new(Metrics::default()),
             Arc::new(AsyncRuntime::new()?),
             MemBlob::new_no_reentrance("append_ts_lower_invariant"),
+            None,
         );
         let mut f = Arrangement::new(ArrangementMeta {
             id: Id(0),
@@ -1118,6 +1120,7 @@ mod tests {
             Arc::new(Metrics::default()),
             Arc::new(AsyncRuntime::new()?),
             MemBlob::new_no_reentrance("unsealed_evict"),
+            None,
         );
         let mut f = Arrangement::new(ArrangementMeta {
             id: Id(0),
@@ -1193,6 +1196,7 @@ mod tests {
             Arc::new(Metrics::default()),
             Arc::new(AsyncRuntime::new()?),
             MemBlob::new_no_reentrance("unsealed_snapshot"),
+            None,
         );
         let mut f = Arrangement::new(ArrangementMeta {
             id: Id(0),
@@ -1247,6 +1251,7 @@ mod tests {
             Arc::new(Metrics::default()),
             Arc::new(AsyncRuntime::new()?),
             MemBlob::new_no_reentrance("unsealed_batch_trim"),
+            None,
         );
         let mut f = Arrangement::new(ArrangementMeta {
             id: Id(0),
@@ -1370,6 +1375,7 @@ mod tests {
             Arc::new(Metrics::default()),
             Arc::clone(&async_runtime),
             MemRegistry::new().blob_no_reentrance()?,
+            None,
         );
         let maintainer = Maintainer::new(blob.clone(), async_runtime, metrics);
         let mut t = Arrangement::new(ArrangementMeta::new(Id(0)));
@@ -1525,6 +1531,7 @@ mod tests {
             Arc::new(Metrics::default()),
             Arc::clone(&async_runtime),
             MemRegistry::new().blob_no_reentrance()?,
+            None,
         );
         let maintainer = Maintainer::new(blob.clone(), async_runtime, metrics);
         let mut t = Arrangement::new(ArrangementMeta::new(Id(0)));

--- a/src/persist/src/indexed/arrangement.rs
+++ b/src/persist/src/indexed/arrangement.rs
@@ -23,7 +23,7 @@ use uuid::Uuid;
 
 use crate::error::Error;
 use crate::indexed::background::{CompactTraceReq, CompactTraceRes};
-use crate::indexed::cache::BlobCache;
+use crate::indexed::cache::{BlobCache, CacheHint};
 use crate::indexed::columnar::ColumnarRecordsVec;
 use crate::indexed::encoding::{
     ArrangementMeta, BlobTraceBatch, TraceBatchMeta, UnsealedBatchMeta,
@@ -334,7 +334,7 @@ impl Arrangement {
             // - ts_lower <= hi
             // - ts_upper > lo
             if ts_lower.less_equal(&meta.ts_upper) && !ts_upper.less_equal(&meta.ts_lower) {
-                batches.push(blob.get_unsealed_batch_async(&meta.key));
+                batches.push(blob.get_unsealed_batch_async(&meta.key, CacheHint::MaybeAdd));
             }
         }
 
@@ -423,7 +423,7 @@ impl Arrangement {
         // Sanity check that batch cannot be evicted
         debug_assert!(self.trace_ts_upper().less_equal(&batch.ts_upper));
         let updates = ColumnarRecordsVec::from_iter(
-            blob.get_unsealed_batch_async(&batch.key)
+            blob.get_unsealed_batch_async(&batch.key, CacheHint::NeverAdd)
                 .recv()?
                 .updates
                 .iter()
@@ -574,7 +574,22 @@ impl Arrangement {
         let since = self.since();
         let mut batches = Vec::with_capacity(self.trace_batches.len());
         for meta in self.trace_batches.iter() {
-            batches.push(blob.get_trace_batch_async(&meta.key));
+            // We want to save these results to the cache (if possible) because
+            // currently the cache is purely in-memory and thus will be empty on
+            // restart. This policy is much more clearly worthwhile for unsealed
+            // batches, as every unsealed batch will eventually get moved into
+            // trace and therefore every unsealed batch we can populate in the
+            // saves us an external read later.
+            //
+            // The rationale for trace is more unclear. If the size of all data
+            // in trace ends up being smaller than the size of the cache then
+            // clearly populating the cache is better. Otherwise, we could get
+            // unlucky and fill the cache with one large trace batch that won't
+            // get compacted for a very long time. We chose to allow trace snapshots
+            // to populate the cache because the default cache size is small
+            // enough that in real workloads large batches won't pollute the
+            // cache.
+            batches.push(blob.get_trace_batch_async(&meta.key, CacheHint::MaybeAdd));
         }
         TraceSnapshot {
             ts_upper,

--- a/src/persist/src/indexed/background.rs
+++ b/src/persist/src/indexed/background.rs
@@ -217,6 +217,7 @@ mod tests {
             Arc::new(Metrics::default()),
             Arc::clone(&async_runtime),
             MemRegistry::new().blob_no_reentrance()?,
+            None,
         );
         let maintainer = Maintainer::new(blob.clone(), async_runtime, metrics);
 
@@ -301,6 +302,7 @@ mod tests {
             Arc::new(Metrics::default()),
             Arc::clone(&async_runtime),
             MemRegistry::new().blob_no_reentrance()?,
+            None,
         );
         let maintainer = Maintainer::new(blob, async_runtime, metrics);
 

--- a/src/persist/src/indexed/background.rs
+++ b/src/persist/src/indexed/background.rs
@@ -22,7 +22,7 @@ use ore::task::RuntimeExt;
 
 use crate::error::Error;
 use crate::indexed::arrangement::Arrangement;
-use crate::indexed::cache::BlobCache;
+use crate::indexed::cache::{BlobCache, CacheHint};
 use crate::indexed::columnar::ColumnarRecordsVec;
 use crate::indexed::encoding::{BlobTraceBatch, TraceBatchMeta};
 use crate::indexed::metrics::Metrics;
@@ -142,10 +142,14 @@ impl<B: Blob> Maintainer<B> {
 
         let mut updates = vec![];
 
-        let first_batch = blob.get_trace_batch_async(&first.key).recv()?;
+        let first_batch = blob
+            .get_trace_batch_async(&first.key, CacheHint::NeverAdd)
+            .recv()?;
         updates.extend(first_batch.updates.iter().flat_map(|u| u.iter()));
 
-        let second_batch = blob.get_trace_batch_async(&second.key).recv()?;
+        let second_batch = blob
+            .get_trace_batch_async(&second.key, CacheHint::NeverAdd)
+            .recv()?;
         updates.extend(second_batch.updates.iter().flat_map(|u| u.iter()));
 
         for ((_, _), ts, _) in updates.iter_mut() {
@@ -279,7 +283,9 @@ mod tests {
         res.merged.size_bytes = 0;
         assert_eq!(res, expected_res);
 
-        let b2 = blob.get_trace_batch_async(&merged_key).recv()?;
+        let b2 = blob
+            .get_trace_batch_async(&merged_key, CacheHint::MaybeAdd)
+            .recv()?;
         let expected_updates = vec![
             (("k".as_bytes(), "v".as_bytes()), 2, 2),
             (("k2".as_bytes(), "v2".as_bytes()), 2, 1),

--- a/src/persist/src/indexed/mod.rs
+++ b/src/persist/src/indexed/mod.rs
@@ -1516,6 +1516,7 @@ mod tests {
             Arc::clone(&metrics),
             Arc::clone(&async_runtime),
             blob,
+            None,
         );
         let maintainer = Maintainer::new(blob.clone(), async_runtime, Arc::clone(&metrics));
         let i = Indexed::new(log, blob, metrics)?;

--- a/src/persist/src/mem.rs
+++ b/src/persist/src/mem.rs
@@ -439,6 +439,7 @@ impl MemRegistry {
             Arc::clone(&metrics),
             async_runtime,
             self.blob_no_reentrance()?,
+            None,
         );
         Indexed::new(log, blob, metrics)
     }
@@ -460,6 +461,7 @@ impl MemRegistry {
             Arc::clone(&metrics),
             async_runtime,
             blob,
+            None,
         );
         Indexed::new(log, blob, metrics)
     }

--- a/src/persist/src/runtime.rs
+++ b/src/persist/src/runtime.rs
@@ -92,6 +92,7 @@ where
         Arc::clone(&metrics),
         Arc::clone(&async_runtime),
         blob,
+        config.cache_size_limit,
     );
     let maintainer = Maintainer::new(
         blob.clone(),
@@ -181,7 +182,7 @@ where
     };
 
     // Start up the runtime.
-    let blob = BlobCache::new(build, Arc::clone(&metrics), async_runtime, blob);
+    let blob = BlobCache::new(build, Arc::clone(&metrics), async_runtime, blob, None);
     let indexed = Indexed::new(ErrorLog, blob, Arc::clone(&metrics))?;
     let mut runtime = RuntimeReadImpl::new(indexed, rx, Arc::clone(&metrics));
     let id = RuntimeId::new();
@@ -292,12 +293,15 @@ struct RuntimeImpl<L: Log, B: Blob> {
 pub struct RuntimeConfig {
     /// Minimum step interval to use
     min_step_interval: Duration,
+    /// Maximum in-memory cache size, in bytes
+    cache_size_limit: Option<usize>,
 }
 
 impl Default for RuntimeConfig {
     fn default() -> Self {
         Self {
             min_step_interval: Self::DEFAULT_MIN_STEP_INTERVAL,
+            cache_size_limit: None,
         }
     }
 }
@@ -310,12 +314,16 @@ impl RuntimeConfig {
     pub(crate) fn for_tests() -> Self {
         RuntimeConfig {
             min_step_interval: Duration::from_millis(1),
+            cache_size_limit: None,
         }
     }
 
-    /// A configuration with a configurable min_step_interval
-    pub fn with_min_step_interval(min_step_interval: Duration) -> Self {
-        RuntimeConfig { min_step_interval }
+    /// A new runtime configuration.
+    pub fn new(min_step_interval: Duration, cache_size_limit: Option<usize>) -> Self {
+        RuntimeConfig {
+            min_step_interval,
+            cache_size_limit,
+        }
     }
 }
 


### PR DESCRIPTION
<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

This PR adds a bound to the blob cache size in persist. The first commit is purely a refactor, the second commit adds the limit, and the third commit adds a hint whereby we indicate that certain reads should not be cached.
<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug: [Link to issue.]

  * This PR adds a known-desirable feature: [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
