### PR TITLE
coord: lump system schemas in the same timeline

### DIFF
--- a/test/sqllogictest/timedomain.slt
+++ b/test/sqllogictest/timedomain.slt
@@ -17,16 +17,19 @@ simple
 BEGIN;
 SELECT row(1, 2);
 SELECT 1 FROM mz_types LIMIT 1;
+SELECT 3 FROM pg_type LIMIT 1; -- mz_catalog and pg_catalog should be treated as the same schema
 ----
 COMPLETE 0
 (1,2)
 COMPLETE 1
 1
 COMPLETE 1
+3
+COMPLETE 1
 
 # But we can only change timedomains once.
 query error Transactions can only reference objects in the same timedomain.
-SELECT 3 FROM pg_type LIMIT 1;
+SELECT * FROM t
 
 # Referring to the timestamp prevents including sources later.
 simple
@@ -59,7 +62,7 @@ COMPLETE 1
 COMPLETE 1
 
 query error Transactions can only reference objects in the same timedomain.
-SELECT 3 FROM pg_type LIMIT 1;
+SELECT * FROM t;
 
 statement ok
 ROLLBACK


### PR DESCRIPTION
@mjibson I actually made it so that I don't need this in dbt-materialize, but it seemed maybe worth doing anyway?

----

This allows transactions that look at mz_catalog, pg_catalog, and
information_schema in different queries. pg_catalog and
information_schema are just views over mz_catalog, so this is safe.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
