### PR TITLE
tests: use avro schema compatible with older versions

### DIFF
--- a/test/upgrade/check-from-v0.7.1-schema-registry.td
+++ b/test/upgrade/check-from-v0.7.1-schema-registry.td
@@ -14,4 +14,4 @@
 # injects a `WITH` option into the wrong spot.
 
 > SHOW CREATE SOURCE data
-"materialize.public.data" "CREATE SOURCE \"materialize\".\"public\".\"data\" FROM KAFKA BROKER 'kafka:9092' TOPIC 'testdrive-data-${testdrive.seed}' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://schema-registry:8081/' SEED VALUE SCHEMA '\"int\"'"
+"materialize.public.data" "CREATE SOURCE \"materialize\".\"public\".\"data\" FROM KAFKA BROKER 'kafka:9092' TOPIC 'testdrive-data-${testdrive.seed}' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://schema-registry:8081/' SEED VALUE SCHEMA '{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"a\",\"type\":\"int\"}]}'"

--- a/test/upgrade/create-in-v0.7.1-schema-registry.td
+++ b/test/upgrade/create-in-v0.7.1-schema-registry.td
@@ -7,13 +7,18 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ set schema
-"int"
+$ set schema={
+    "type": "record",
+    "name": "foo",
+    "fields": [
+      {"name": "a", "type": "int"}
+    ]
+  }
 
 $ kafka-create-topic topic=data
 
 $ kafka-ingest format=avro topic=data schema=${schema} publish=true
-1
+{"a": 1}
 
 > CREATE MATERIALIZED SOURCE data
   FROM KAFKA BROKER 'kafka:9092' TOPIC 'testdrive-data-${testdrive.seed}'


### PR DESCRIPTION
### Motivation

Support for bare data types (vs. records) was only added in one of the
most recent releases.

Fixes #10394

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
