### PR TITLE
test: emit correct CDCv2 data in consolidation test

### DIFF
--- a/test/testdrive/consolidation.td
+++ b/test/testdrive/consolidation.td
@@ -107,23 +107,17 @@ $ kafka-create-topic topic=nums
 
 # ==> Test consolidation.
 
-# Ingest several updates that consolidate. Some of these updates are in one
-# transaction, and some of them are in their own transactions.
+# Ingest several updates that consolidate
 
 $ kafka-ingest format=avro topic=nums schema=${nums-schema}
-{"array":[{"data":{"num":1},"time":1,"diff":1}]}
-{"array":[{"data":{"num":1},"time":1,"diff":-1}]}
-{"array":[{"data":{"num":2},"time":1,"diff":1}]}
-{"array":[{"data":{"num":2},"time":1,"diff":-1}]}
 {"array":[{"data":{"num":3},"time":1,"diff":1}]}
 {"array":[{"data":{"num":3},"time":2,"diff":-1}]}
 {"array":[{"data":{"num":4},"time":2,"diff":1}]}
 {"array":[{"data":{"num":4},"time":3,"diff":-1}]}
 {"array":[{"data":{"num":5},"time":3,"diff":1}]}
-{"com.materialize.cdc.progress":{"lower":[0],"upper":[4],"counts":[{"time":1,"count":5},{"time":2,"count":2}, {"time": 3, "count": 2}]}}
+{"com.materialize.cdc.progress":{"lower":[0],"upper":[4],"counts":[{"time":1,"count":1},{"time":2,"count":2}, {"time": 3, "count": 2}]}}
 
-# Test that by default updates that occurred at the same time are consolidated,
-# but updates that occurred at distinct times are not.
+# Test that by updates that occurred at at distinct times are not consolidated
 
 # we know that transactions (timestamps) are emitted in order, but the order
 # of emitted records with the same timestamp is not deterministic. We therefore


### PR DESCRIPTION
Using BYO sources we were able to emit multiple updates for a given
(data, time) pair and therefore test consolidation of records on the
same timestamp.

The CDCv2 protocol requires that a statement for a given (data, time)
pair is made only once and it's final, otherwise the wrong stream is
reproduced. Unfortunately this means that we can't test the case where
records consolidate within a single timestamp right after ingestion.

This isn't as bad though because the rest of the test enables compaction
which eventually does consolidate records and so we can test it through
there.

In some glorious feature we might end up with a special testdrive source
type that we simply type in the precise (Row, Timestamp, Diff) updates
verbatim instead of jumping through hoops with avro encoded CDCv2
sources.

Fixes #10397

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
