### PR TITLE
persist,test: increase timeout on failpoint test

### DIFF
--- a/test/persistence/kafka-sources/failpoint-after.td
+++ b/test/persistence/kafka-sources/failpoint-after.td
@@ -7,6 +7,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+# Reading all that data after starting up can take longer than the default timeout.
+$ set-sql-timeout duration=60s
+
 > SELECT COUNT(*) FROM failpoint;
 1000000
 


### PR DESCRIPTION
I did observe this failing when running it manually in a loop, but the
dataflow would catch up eventually, which I checked by running a
`SELECT` query by hand. This means it's not the bug that we fixed in
https://github.com/MaterializeInc/materialize/pull/10128

We've also seen it at least once in ci builds.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
