### PR TITLE
[kafka EOS] disable flaky timestamp compaction verification

### DIFF
--- a/test/testdrive/kafka-exactly-once-sink.td
+++ b/test/testdrive/kafka-exactly-once-sink.td
@@ -406,4 +406,4 @@ $ kafka-verify format=json sink=materialize.public.json_avro_upsert_key_2 key=tr
 # Verify compaction of exactly once sinks.
 $ verify-timestamp-compaction source=input_csv max-size=3 permit-progress=true
 $ verify-timestamp-compaction source=rt_binding_consistency_test_source max-size=3 permit-progress=true
-$ verify-timestamp-compaction source=input_kafka_dbz max-size=3
+#$ verify-timestamp-compaction source=input_kafka_dbz max-size=3


### PR DESCRIPTION
This assertion is flaky.  Remove it while I investigate.

Reported in #10398 
