### PR TITLE
persist: rename --persistent-kafka-upsert-source -> --persistent-kafka-source

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -117,6 +117,6 @@
           - --other-tag
           - latest
           - --this-options
-          - "--persistent-user-tables --persistent-kafka-upsert-source"
+          - "--persistent-user-tables --persistent-kafka-sources"
           - --other-options
-          - "--persistent-user-tables --persistent-kafka-upsert-source"
+          - "--persistent-user-tables --persistent-kafka-sources"

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -151,9 +151,9 @@ struct Args {
     #[structopt(long, hide = true)]
     persist_storage_enabled: bool,
 
-    /// Enable persistent Kafka UPSERT source. Has to be used with --experimental.
+    /// Enable persistent Kafka source. Has to be used with --experimental.
     #[structopt(long, hide = true)]
-    persistent_kafka_upsert_source: bool,
+    persistent_kafka_sources: bool,
 
     // === Timely worker configuration. ===
     /// Number of dataflow worker threads.
@@ -708,14 +708,14 @@ dataflow workers: {workers}",
             })
         };
 
-        let kafka_upsert_source_enabled =
-            if args.experimental && args.persistent_kafka_upsert_source {
-                true
-            } else if args.persistent_kafka_upsert_source {
-                bail!("cannot specify --persistent-kafka-upsert-source without --experimental");
-            } else {
-                false
-            };
+        let persistent_kafka_sources_enabled = if args.experimental && args.persistent_kafka_sources
+        {
+            true
+        } else if args.persistent_kafka_sources {
+            bail!("cannot specify --persistent-kafka-sources without --experimental");
+        } else {
+            false
+        };
 
         let lock_info = format!(
             "materialized {mz_version}\nos: {os}\nstart time: {start_time}\nnum workers: {num_workers}\n",
@@ -737,7 +737,7 @@ dataflow workers: {workers}",
             storage,
             user_table_enabled,
             system_table_enabled,
-            kafka_upsert_source_enabled,
+            kafka_sources_enabled: persistent_kafka_sources_enabled,
             lock_info,
             min_step_interval,
         }

--- a/test/kafka-ingest-open-loop/mzcompose.py
+++ b/test/kafka-ingest-open-loop/mzcompose.py
@@ -145,7 +145,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     if args.enable_persistence:
         options = [
             "--persistent-user-tables",
-            "--persistent-kafka-upsert-source",
+            "--persistent-kafka-sources",
             "--disable-persistent-system-tables-test",
         ]
 

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -1007,7 +1007,7 @@ SERVICES = [
     Kafka(),
     SchemaRegistry(),
     Materialized(
-        memory="8G", options="--persistent-user-tables --persistent-kafka-upsert-source"
+        memory="8G", options="--persistent-user-tables --persistent-kafka-sources"
     ),
     Testdrive(),
 ]

--- a/test/persistence/mzcompose.py
+++ b/test/persistence/mzcompose.py
@@ -19,7 +19,7 @@ from materialize.mzcompose.services import (
     Zookeeper,
 )
 
-mz_options = "--persistent-user-tables --persistent-kafka-upsert-source --disable-persistent-system-tables-test"
+mz_options = "--persistent-user-tables --persistent-kafka-sources --disable-persistent-system-tables-test"
 
 mz_default = Materialized(options=mz_options)
 


### PR DESCRIPTION
This reflects current reality: we also support ENVELOPE NONE. We now
panic! when users enable persistence but an envelope is not supported
yet.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
