### PR TITLE
Assert that EOS does not write compacted data

### DIFF
--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -301,6 +301,7 @@ pub fn build_dataflow<A: Allocate>(
             // Export declared sinks.
             for (sink_id, imports, sink) in sinks {
                 context.export_sink(
+                    dataflow.as_of.clone().unwrap(),
                     compute_state,
                     storage_state,
                     &mut tokens,

--- a/src/dataflow/src/render/sinks.rs
+++ b/src/dataflow/src/render/sinks.rs
@@ -34,6 +34,7 @@ where
     /// Export the sink described by `sink` from the rendering context.
     pub(crate) fn export_sink(
         &mut self,
+        dataflow_as_of: timely::progress::Antichain<Timestamp>,
         compute_state: &mut crate::render::ComputeState,
         storage_state: &mut crate::render::StorageState,
         tokens: &mut RelevantTokens,
@@ -68,6 +69,7 @@ where
         // if we figure out a protocol for that.
 
         let sink_token = sink_render.render_continuous_sink(
+            dataflow_as_of,
             compute_state,
             storage_state,
             sink,
@@ -214,6 +216,7 @@ where
 
     fn render_continuous_sink(
         &self,
+        dataflow_as_of: timely::progress::Antichain<Timestamp>,
         compute_state: &mut crate::render::ComputeState,
         storage_state: &mut crate::render::StorageState,
         sink: &SinkDesc,

--- a/src/dataflow/src/sink/avro_ocf.rs
+++ b/src/dataflow/src/sink/avro_ocf.rs
@@ -45,6 +45,7 @@ where
 
     fn render_continuous_sink(
         &self,
+        _dataflow_as_of: timely::progress::Antichain<Timestamp>,
         _compute_state: &mut crate::render::ComputeState,
         _storage_state: &mut crate::render::StorageState,
         _sink: &SinkDesc,

--- a/src/dataflow/src/sink/tail.rs
+++ b/src/dataflow/src/sink/tail.rs
@@ -54,6 +54,7 @@ where
 
     fn render_continuous_sink(
         &self,
+        _dataflow_as_of: Antichain<Timestamp>,
         compute_state: &mut crate::render::ComputeState,
         _storage_state: &mut crate::render::StorageState,
         sink: &SinkDesc,


### PR DESCRIPTION
This is an assert I thought should exist in EOS, but I'm not sure that its absence actually means anything is not "Exactly Once" so much as "not exactly corresponding to the input data". If the test fails, then it is possible that the EOS will write out compacted timestamps, meaning that it may record changes not at the time they happened, but at a potentially later time. This doesn't have to be a bug, but it was surprising to me that EOS could do it. Anyhow, lmk what you think about whether this is in spec or out of spec, and .. what the spec is if it is in spec (what needs to be preserved in future implementations).