### PR TITLE
[kafka exactly once sink] Reenable timestamp compaction verification

### DIFF
--- a/src/testdrive/src/action/verify_timestamp_compaction.rs
+++ b/src/testdrive/src/action/verify_timestamp_compaction.rs
@@ -76,13 +76,13 @@ impl Action for VerifyTimestampCompactionAction {
                         // timestamp binding.
                         let progress = if retry_state.i == 0 {
                             initial_highest.store(
-                                bindings.iter().map(|(_, ts, _)| ts).fold(u64::MIN, |a, &b| a.max(b)),
+                                bindings.iter().map(|(_, ts, _)| *ts).max().unwrap_or(u64::MIN),
                                 Ordering::SeqCst,
                             );
                             false
                         } else {
                             self.permit_progress &&
-                                (bindings.iter().map(|(_, ts, _)| ts).fold(u64::MAX, |a, &b| a.min(b))
+                                (bindings.iter().map(|(_, ts, _)| *ts).min().unwrap_or(u64::MAX)
                                     >= initial_highest.load(Ordering::SeqCst))
                         };
 

--- a/src/testdrive/src/action/verify_timestamp_compaction.rs
+++ b/src/testdrive/src/action/verify_timestamp_compaction.rs
@@ -56,7 +56,7 @@ impl Action for VerifyTimestampCompactionAction {
             let initial_highest_base = Arc::new(AtomicU64::new(u64::MAX));
             Retry::default()
                 .initial_backoff(Duration::from_secs(1))
-                .max_duration(Duration::from_secs(10))
+                .max_duration(Duration::from_secs(30))
                 .retry_async(|retry_state| {
                     let initial_highest = Arc::clone(&initial_highest_base);
                     async move {

--- a/src/testdrive/src/action/verify_timestamp_compaction.rs
+++ b/src/testdrive/src/action/verify_timestamp_compaction.rs
@@ -74,6 +74,7 @@ impl Action for VerifyTimestampCompactionAction {
 
                         // We consider progress to be eventually compacting at least up to the original highest
                         // timestamp binding.
+                        let lo_binding= bindings.iter().map(|(_, ts, _)| *ts).min();
                         let progress = if retry_state.i == 0 {
                             initial_highest.store(
                                 bindings.iter().map(|(_, ts, _)| *ts).max().unwrap_or(u64::MIN),
@@ -82,16 +83,16 @@ impl Action for VerifyTimestampCompactionAction {
                             false
                         } else {
                             self.permit_progress &&
-                                (bindings.iter().map(|(_, ts, _)| *ts).min().unwrap_or(u64::MAX)
-                                    >= initial_highest.load(Ordering::SeqCst))
+                                (lo_binding.unwrap_or(u64::MAX) >= initial_highest.load(Ordering::SeqCst))
                         };
 
                         println!(
-                            "Verifying timestamp binding compaction for {:?}.  Found {:?} vs expected {:?}.  Progress: {:?}",
+                            "Verifying timestamp binding compaction for {:?}.  Found {:?} vs expected {:?}.  Progress: {:?} vs {:?}",
                             self.source,
                             bindings.len(),
                             self.max_size,
-                            progress,
+                            lo_binding,
+                            initial_highest.load(Ordering::SeqCst),
                         );
 
                         if bindings.len() <= self.max_size || progress {

--- a/test/testdrive/kafka-exactly-once-sink.td
+++ b/test/testdrive/kafka-exactly-once-sink.td
@@ -406,4 +406,4 @@ $ kafka-verify format=json sink=materialize.public.json_avro_upsert_key_2 key=tr
 # Verify compaction of exactly once sinks.
 $ verify-timestamp-compaction source=input_csv max-size=3 permit-progress=true
 $ verify-timestamp-compaction source=rt_binding_consistency_test_source max-size=3 permit-progress=true
-$ verify-timestamp-compaction source=input_kafka_dbz max-size=3
+$ verify-timestamp-compaction source=input_kafka_dbz max-size=3 permit-progress=true

--- a/test/testdrive/kafka-exactly-once-sink.td
+++ b/test/testdrive/kafka-exactly-once-sink.td
@@ -406,4 +406,4 @@ $ kafka-verify format=json sink=materialize.public.json_avro_upsert_key_2 key=tr
 # Verify compaction of exactly once sinks.
 $ verify-timestamp-compaction source=input_csv max-size=3 permit-progress=true
 $ verify-timestamp-compaction source=rt_binding_consistency_test_source max-size=3 permit-progress=true
-#$ verify-timestamp-compaction source=input_kafka_dbz max-size=3
+$ verify-timestamp-compaction source=input_kafka_dbz max-size=3


### PR DESCRIPTION
Disabled in #10413 because it was flaky with a large number of workers.

Just increase the timeout and re-enable.  Flaking (as opposed to perma-failing) isn't really indicative of an issue since we just want the compaction to _eventually_ happen.  We're not trying to put strong bounds on how quickly timestamp compaction must occur after it's theoretically possible -- we just want to make sure it _does_ happen so the timestamp bindings database doesn't explode in size.  Note that we do allow _progress_ in compaction (as opposed to just looking for an absolute number) to satisfy verification.

The underlying issue was that the `permit-progress=true` flag wasn't on the failing verification because it was commented out when that flag was added

Fixes #10398 