### PR TITLE
coord: improve catalog transact error paths

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -4132,7 +4132,6 @@ impl Coordinator {
         if !sources_to_drop.is_empty() {
             for &id in &sources_to_drop {
                 self.update_timestamper(id, false).await;
-                self.catalog.delete_timestamp_bindings(id)?;
                 self.sources.remove(&id);
             }
             self.dataflow_client.drop_sources(sources_to_drop).await;


### PR DESCRIPTION
Move a falliable operation to a path that supports errors, and prevent adding error returns in a path that prohibits it.

### Motivation

  * This PR fixes a previously unreported bug.

A failure in the sqlite transaction would have left the catalog in an inconsistent state.

### Tips for reviewer

    * The diff is much smaller if viewed with whitespace hidden.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
