### PR TITLE
persist: add MultiWriteHandle::seal_all()

### DIFF
--- a/src/persist/src/client.rs
+++ b/src/persist/src/client.rs
@@ -573,6 +573,27 @@ impl MultiWriteHandle {
         rx
     }
 
+    /// Closes all contained streams at the given timestamp, migrating data strictly less than it
+    /// into the trace.
+    pub fn seal_all(&self, upper: u64) -> PFuture<SeqNo> {
+        let (tx, rx) = PFuture::new();
+
+        let client = match self.client.as_ref() {
+            Ok(client) => client,
+            Err(e) => {
+                tx.fill(Err(e.clone()));
+                return rx;
+            }
+        };
+
+        let ids = self.stream_ids.iter().map(|id| *id).collect::<Vec<_>>();
+
+        client
+            .sender
+            .send_runtime_cmd(RuntimeCmd::IndexedCmd(Cmd::Seal(ids, upper, tx)));
+        rx
+    }
+
     /// Unblocks compaction for updates for the given streams at the paired
     /// `since` timestamp.
     ///

--- a/src/persist/src/runtime.rs
+++ b/src/persist/src/runtime.rs
@@ -766,6 +766,34 @@ mod tests {
     }
 
     #[test]
+    fn multi_write_handle_allow_compaction_all() -> Result<(), Error> {
+        let mut registry = MemMultiRegistry::new();
+        let client = registry.open("1", "multi")?;
+
+        let (write1, _) = client.create_or_load::<String, ()>("1");
+        let (write2, _) = client.create_or_load::<String, ()>("2");
+
+        let mut multi = MultiWriteHandle::new(&write1);
+        multi.add_stream(&write2)?;
+
+        let _ = multi
+            .allow_compaction_all(Antichain::from_elem(42))
+            .recv()?;
+
+        assert_eq!(
+            client.get_description("1")?.since(),
+            &Antichain::from_elem(42)
+        );
+
+        assert_eq!(
+            client.get_description("2")?.since(),
+            &Antichain::from_elem(42)
+        );
+
+        Ok(())
+    }
+
+    #[test]
     fn codec_mismatch() -> Result<(), Error> {
         let client = MemRegistry::new().runtime_no_reentrance()?;
 


### PR DESCRIPTION
We will need this to atomically seal all streams/collections involved in
a persistent source.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
