### PR TITLE
tests: harden persistence failpoint test some more

### DIFF
--- a/test/persistence/kafka-sources/zzzz-failpoint-before.td
+++ b/test/persistence/kafka-sources/zzzz-failpoint-before.td
@@ -46,6 +46,10 @@ $ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschem
 $ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=100000
 {"f1": "d${kafka-ingest.iteration}"} {"f2": "d${kafka-ingest.iteration}"}
 
+# Make sure that we read (and persisted) at least one message before activating the failpoint.
+> SELECT COUNT(*) > 0 FROM failpoint;
+true
+
 > SET failpoints = 'fileblob_set_sync=return';
 
 $ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=100000


### PR DESCRIPTION
Before, we were not guaranteed that the first instantiation of
materialize actually managed to read any data. Now, we check whether we
read (and persisted) at least one message before activating the
failpoint.

Not doing this check before is a possible explanation for https://buildkite.com/materialize/tests/builds/27958#1e0ef462-d3e3-480d-bbb0-86dc5288d8d8

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
