### PR TITLE
Try harder to find a key that makes Plan::Mfp the identity.

### DIFF
--- a/src/dataflow-types/src/plan/mod.rs
+++ b/src/dataflow-types/src/plan/mod.rs
@@ -834,6 +834,15 @@ This is not expected to cause incorrect results, but could indicate a performanc
                 mfp.permute(permutation.clone(), thinning.len() + key.len());
 
                 Some((key, Some(val)))
+            } else if let Some((key, permutation, thinning)) =
+                keys.arranged.iter().find(|(key, permutation, thinning)| {
+                    let mut mfp = mfp.clone();
+                    mfp.permute(permutation.clone(), thinning.len() + key.len());
+                    mfp.is_identity()
+                })
+            {
+                mfp.permute(permutation.clone(), thinning.len() + key.len());
+                Some((key.clone(), None))
             } else if let Some((key, permutation, thinning)) = keys.arbitrary_arrangement() {
                 mfp.permute(permutation.clone(), thinning.len() + key.len());
                 Some((key.clone(), None))

--- a/src/dataflow-types/src/plan/mod.rs
+++ b/src/dataflow-types/src/plan/mod.rs
@@ -830,6 +830,12 @@ This is not expected to cause incorrect results, but could indicate a performanc
                 })
                 .max_by_key(|(key, _, _, _)| key.len());
 
+            // Input key selection strategy:
+            // (1) If we can read a key at a particular value, do so
+            // (2) Otherwise, if there is a key that causes the MFP to be the identity, and
+            // therefore allows us to avoid discarding the arrangement, use that.
+            // (3) Otherwise, if there is _some_ key, use that,
+            // (4) Otherwise just read the raw collection.
             let input_key_val = if let Some((key, permutation, thinning, val)) = key_val {
                 mfp.permute(permutation.clone(), thinning.len() + key.len());
 


### PR DESCRIPTION
An unnecessary Plan::Mfp is bad, as discards any arrangements that might have existed, which could have been useful in a following stage. Thus, try to find a key whose permutation turns it into the identity, so we don't have to apply it.

### Motivation
@philip-stoev thought there were still some small performance regressions. Maybe this fixes them. We are at present not sure if those regressions are real or bugs/noise in his tool. But, at any rate, this doesn't seem like it can hurt, so I felt we should do it regardless.
