### PR TITLE
persist,dataflow: retire conditional_seal() in favour of newly atomic seal()

### DIFF
--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -814,12 +814,12 @@ where
     K2: Codec + timely::Data,
     V2: Codec + timely::Data,
 {
-    let sealed_stream = stream.conditional_seal(
-        &source_name,
-        bindings_stream,
-        write.clone(),
-        bindings_write.clone(),
-    );
+    let mut seal_handle = MultiWriteHandle::new(&write);
+    seal_handle
+        .add_stream(&bindings_write)
+        .expect("handles known to be from same persist runtime");
+
+    let sealed_stream = stream.seal(&source_name, vec![bindings_stream.probe()], seal_handle);
 
     // The compaction since of persisted sources is upper-bounded by two frontiers: a) the
     // compaction that the coordinator allows, and b) the seal frontier of the involved persistent

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -908,7 +908,7 @@ where
 /// The returned `Stream` of persisted timestamp bindings can be used to track the persistence
 /// frontier and should be used to seal up the backing collection to that frontier. This function
 /// does not do any sealing and it is the responsibility of the caller to eventually do that, for
-/// example using [`conditional_seal`](persist::operators::stream::Seal::conditional_seal).
+/// example using [`seal`](persist::operators::stream::Seal::seal).
 pub(crate) fn create_source<G, S: 'static>(
     config: SourceConfig<G>,
     source_connector: &ExternalSourceConnector,


### PR DESCRIPTION
Before, with `conditional_seal()` the timestamp bindings stream would
always be sealed further than the data stream, which made it harder to
reason about correctness, especially for the restart/retraction code.

Now, `seal()` takes a `MultiWriteHandle` instead of a
`StreamWriteHandle` and will atomically seal all contained streams when
the frontier advances.

All call sites that used the old `seal()` before now use a
`MultiWriteHandle` that contains only a single stream. Call sites of
`conditional_seal()` have been changed to manually tie together the
involved streams (to create a frontier dependency) and use the new
atomic `seal()`. Existing tests for `conditional_seal()` where changed
to the new `seal()` as well.

There will be a follow-up PR that uses this simpler invariant to simplify the restore logic.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
