### PR TITLE
multi-worker tails

### DIFF
--- a/src/coord/src/tail.rs
+++ b/src/coord/src/tail.rs
@@ -77,11 +77,11 @@ impl PendingTail {
                 // Sort results by time. We use stable sort here because it will produce deterministic
                 // results since the cursor will always produce rows in the same order.
                 // TODO: Is sorting necessary?
-                rows.sort_by_key(|(_, time, _)| *time);
+                rows.sort_by_key(|(time, _, _)| *time);
 
                 let rows = rows
                     .into_iter()
-                    .map(|(row, time, diff)| {
+                    .map(|(time, row, diff)| {
                         packer.push(Datum::from(numeric::Numeric::from(time)));
                         if self.emit_progress {
                             // When sinking with PROGRESS, the output

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -982,7 +982,7 @@ pub mod partitioned {
                         TailResponse::Progress(frontier) => {
                             if let Some(new_frontier) = entry.record_progress(shard_id, frontier) {
                                 let data = entry.consolidate_up_to(new_frontier.clone());
-                                let progress_response = TailResponse::Progress(new_frontier.into());
+                                let progress_response = TailResponse::Progress(new_frontier);
                                 if data.is_empty() {
                                     Box::new(
                                         Some(Response::Compute(

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -737,30 +737,6 @@ pub mod partitioned {
             &mut self,
             upper: Antichain<Timestamp>,
         ) -> Vec<(Timestamp, Row, Diff)> {
-            // self.buffer
-            //     .sort_unstable_by(|(d1, t1, _r1), (d2, t2, _r2)| (t1, d1).cmp(&(t2, d2)));
-            // let mut offset = 0;
-            // let mut index = 1;
-            // while index < self.buffer.len()
-            //     && PartialOrder::less_than(&Antichain::from_elem(self.buffer[index].1), &upper)
-            // {
-            //     if self.buffer[index].0 == self.buffer[offset].0
-            //         && self.buffer[index].1 == self.buffer[offset].1
-            //     {
-            //         self.buffer[offset].2 += self.buffer[index].2;
-            //     } else {
-            //         if self.buffer[offset].2 != 0 {
-            //             offset += 1;
-            //         }
-            //         let next = std::mem::take(&mut self.buffer[index]);
-            //         self.buffer[offset] = next;
-            //     }
-            //     index += 1;
-            // }
-            // if offset < self.buffer.len() && self.buffer[offset].2 != 0 {
-            //     offset += 1;
-            // }
-            // self.buffer.drain(0..offset).collect()
             differential_dataflow::consolidation::consolidate_updates(&mut self.buffer);
             let split_point = self
                 .buffer
@@ -995,7 +971,7 @@ pub mod partitioned {
                     let entry = match maybe_entry {
                         None => {
                             // This tail has been dropped;
-                            // we should pernanently block
+                            // we should permanently block
                             // any messages from it
                             return Box::new(None.into_iter());
                         }

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -720,7 +720,7 @@ pub mod partitioned {
         /// still receieve results from worker `i`.
         frontiers: HashMap<usize, Antichain<Timestamp>>,
         /// The results (possibly unsorted) which have not yet been delivered.
-        buffer: Vec<(Row, Timestamp, Diff)>,
+        buffer: Vec<(Timestamp, Row, Diff)>,
         /// The number of unique shard IDs expected.
         parts: usize,
         /// The last progress message that has been reported to the consumer.
@@ -728,44 +728,42 @@ pub mod partitioned {
     }
 
     impl PendingTail {
-        // See [`differential_dataflow::consolidation::consolidate_updates_slice`].
-        // This function works similarly, except that we sort by timestamp first, then data.
-        //
-        // I implemented it without `unsafe`; we can revisit that if proves to be
-        // a hot path.
-        /// Return all the updates with time less than `upper` (or all times if that is `None`),
+        /// Return all the updates with time less than `upper`,
         /// in sorted and consolidated representation.
         pub fn consolidate_up_to(
             &mut self,
             upper: Antichain<Timestamp>,
-        ) -> Vec<(Row, Timestamp, Diff)> {
-            self.buffer
-                .sort_unstable_by(|(d1, t1, _r1), (d2, t2, _r2)| (t1, d1).cmp(&(t2, d2)));
-            let mut offset = 0;
-            let mut index = 1;
-            while index < self.buffer.len()
-                && PartialOrder::less_than(&Antichain::from_elem(self.buffer[index].1), &upper)
-            {
-                if self.buffer[index].0 == self.buffer[offset].0
-                    && self.buffer[index].1 == self.buffer[offset].1
-                {
-                    self.buffer[offset].2 += self.buffer[index].2;
-                } else {
-                    if self.buffer[offset].2 != 0 {
-                        offset += 1;
-                    }
-                    let next = std::mem::take(&mut self.buffer[index]);
-                    self.buffer[offset] = next;
-                }
-                index += 1;
-            }
-            if offset < self.buffer.len() && self.buffer[offset].2 != 0 {
-                offset += 1;
-            }
-            self.buffer.drain(0..offset).collect()
+        ) -> Vec<(Timestamp, Row, Diff)> {
+            // self.buffer
+            //     .sort_unstable_by(|(d1, t1, _r1), (d2, t2, _r2)| (t1, d1).cmp(&(t2, d2)));
+            // let mut offset = 0;
+            // let mut index = 1;
+            // while index < self.buffer.len()
+            //     && PartialOrder::less_than(&Antichain::from_elem(self.buffer[index].1), &upper)
+            // {
+            //     if self.buffer[index].0 == self.buffer[offset].0
+            //         && self.buffer[index].1 == self.buffer[offset].1
+            //     {
+            //         self.buffer[offset].2 += self.buffer[index].2;
+            //     } else {
+            //         if self.buffer[offset].2 != 0 {
+            //             offset += 1;
+            //         }
+            //         let next = std::mem::take(&mut self.buffer[index]);
+            //         self.buffer[offset] = next;
+            //     }
+            //     index += 1;
+            // }
+            // if offset < self.buffer.len() && self.buffer[offset].2 != 0 {
+            //     offset += 1;
+            // }
+            // self.buffer.drain(0..offset).collect()
+            differential_dataflow::consolidation::consolidate_updates(&mut self.buffer);
+            let split_point = self.buffer.partition_point(|(t, _, _)| upper.less_equal(t));
+            self.buffer.drain(0..split_point).collect()
         }
 
-        pub fn push_data<I: IntoIterator<Item = (Row, Timestamp, Diff)>>(&mut self, data: I) {
+        pub fn push_data<I: IntoIterator<Item = (Timestamp, Row, Diff)>>(&mut self, data: I) {
             self.buffer.extend(data);
         }
 

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -762,7 +762,9 @@ pub mod partitioned {
             // }
             // self.buffer.drain(0..offset).collect()
             differential_dataflow::consolidation::consolidate_updates(&mut self.buffer);
-            let split_point = self.buffer.partition_point(|(t, _, _)| !upper.less_equal(t));
+            let split_point = self
+                .buffer
+                .partition_point(|(t, _, _)| !upper.less_equal(t));
             self.buffer.drain(0..split_point).collect()
         }
 

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -762,7 +762,7 @@ pub mod partitioned {
             // }
             // self.buffer.drain(0..offset).collect()
             differential_dataflow::consolidation::consolidate_updates(&mut self.buffer);
-            let split_point = self.buffer.partition_point(|(t, _, _)| upper.less_equal(t));
+            let split_point = self.buffer.partition_point(|(t, _, _)| !upper.less_equal(t));
             self.buffer.drain(0..split_point).collect()
         }
 

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -55,7 +55,7 @@ pub enum TailResponse {
     /// An empty antichain indicates the end.
     Progress(Antichain<Timestamp>),
     /// Rows that should be returned in order to the client.
-    Rows(Vec<(Row, Timestamp, Diff)>),
+    Rows(Vec<(Timestamp, Row, Diff)>),
     /// The TAIL dataflow was dropped before completing. Indicates the end.
     Dropped,
 }

--- a/src/dataflow/src/render/sinks.rs
+++ b/src/dataflow/src/render/sinks.rs
@@ -158,7 +158,6 @@ where
     //   It then renders those as Avro.
     // * Upsert" does the same, except at the last step, it renders the diff pair in upsert format.
     //   (As part of doing so, it asserts that there are not multiple conflicting values at the same timestamp)
-    // * "Tail" writes some metadata.
     let collection = match sink.envelope {
         Some(SinkEnvelope::Debezium) => {
             let combined = combine_at_timestamp(keyed.arrange_by_key().stream);

--- a/src/dataflow/src/sink/tail.rs
+++ b/src/dataflow/src/sink/tail.rs
@@ -96,16 +96,6 @@ fn tail<G>(
 ) where
     G: Scope<Timestamp = Timestamp>,
 {
-    // // make sure all data is routed to one worker by keying on the sink id
-    // let batches = sinked_collection
-    //     .map(move |(k, v)| {
-    //         assert!(k.is_none(), "tail does not support keys");
-    //         let v = v.expect("tail must have values");
-    //         (sink_id, v)
-    //     })
-    //     .arrange_by_key()
-    //     .stream;
-
     // Initialize to the minimal input frontier.
     let mut input_frontier = Antichain::from_elem(<G::Timestamp as TimelyTimestamp>::minimum());
 

--- a/src/dataflow/src/sink/tail.rs
+++ b/src/dataflow/src/sink/tail.rs
@@ -60,14 +60,10 @@ where
         // An encapsulation of the Tail response protocol.
         // Used to send rows and progress messages,
         // and alert if the dataflow was dropped before completing.
-        let tail_protocol_handle = Rc::new(RefCell::new(if true {
-            Some(TailProtocol {
-                sink_id,
-                tail_response_buffer: Some(Rc::clone(&compute_state.tail_response_buffer)),
-            })
-        } else {
-            None
-        }));
+        let tail_protocol_handle = Rc::new(RefCell::new(Some(TailProtocol {
+            sink_id,
+            tail_response_buffer: Some(Rc::clone(&compute_state.tail_response_buffer)),
+        })));
         let tail_protocol_weak = Rc::downgrade(&tail_protocol_handle);
 
         tail(

--- a/src/dataflow/src/sink/tail.rs
+++ b/src/dataflow/src/sink/tail.rs
@@ -123,7 +123,7 @@ fn tail<G>(
                         as_of.frontier.less_equal(time)
                     };
                     if should_emit {
-                        results.push((row.clone(), *time, *diff));
+                        results.push((*time, row.clone(), *diff));
                     }
                 }
 
@@ -173,7 +173,7 @@ impl TailProtocol {
     }
 
     /// Send further rows as responses.
-    fn send_rows(&mut self, rows: Vec<(Row, Timestamp, Diff)>) {
+    fn send_rows(&mut self, rows: Vec<(Timestamp, Row, Diff)>) {
         let buffer = self
             .tail_response_buffer
             .as_mut()


### PR DESCRIPTION
This is not ready to land, as it is failing some tests and needs some cleanup, but the basic idea is:

* Remove the restriction that each tail has to run on one worker
* Remove the consolidation/arrangement as I'm not sure it serves any other purpose
* Conslidate and sort in the partitioned client
* Wait for progress messages to come in and release rows from the partitioned client only when they are part of a completed timestamp.