### PR TITLE
sql: add MD5 and SHA-2 functions

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -134,6 +134,9 @@ changes that have not yet been documented.
 - Follow PostgreSQL's type conversion rules for the relations involved in a
   `UNION`, `EXCEPT`, or `INTERSECT` operation {{% gh 3331 %}}.
 
+- Add the `md5`, `sha224`, `sha256`, `sha384`, and `sha512` [cryptography
+  functions](/sql/functions/#cryptography-func).
+
 {{< comment >}}
 Only add new release notes above this line.
 

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -580,6 +580,22 @@
       description: >-
         Computes a hashed MAC of the given bytea `data` using the specified `key` and
         `type` algorithm. The supported hash algorithms are the same as for `digest`.
+    - signature: 'md5(data: bytea) -> text'
+      description: >-
+        Computes the MD5 hash of the given bytea `data`.
+        For PostgreSQL compatibility, returns a hex-encoded value of type `text` rather than `bytea`.
+    - signature: 'sha224(data: bytea) -> bytea'
+      description: >-
+        Computes the SHA-224 hash of the given bytea `data`.
+    - signature: 'sha256(data: bytea) -> bytea'
+      description: >-
+        Computes the SHA-256 hash of the given bytea `data`.
+    - signature: 'sha384(data: bytea) -> bytea'
+      description: >-
+        Computes the SHA-384 hash of the given bytea `data`.
+    - signature: 'sha512(data: bytea) -> bytea'
+      description: >-
+        Computes the SHA-512 hash of the given bytea `data`.
 
 - type: Window
   description: Window functions compute values across sets of rows related to the current query.

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1868,6 +1868,18 @@ lazy_static! {
             "make_timestamp" => Scalar {
                 params!(Int64, Int64, Int64, Int64, Int64, Float64) => VariadicFunc::MakeTimestamp, 3461;
             },
+            "md5" => Scalar {
+                params!(String) => Operation::unary(move |_ecx, input| {
+                    let algorithm = HirScalarExpr::literal(Datum::String("md5"), ScalarType::String);
+                    let encoding = HirScalarExpr::literal(Datum::String("hex"), ScalarType::String);
+                    Ok(input.call_binary(algorithm, BinaryFunc::DigestString).call_binary(encoding, BinaryFunc::Encode))
+                }) => String, 2311;
+                params!(Bytes) => Operation::unary(move |_ecx, input| {
+                    let algorithm = HirScalarExpr::literal(Datum::String("md5"), ScalarType::String);
+                    let encoding = HirScalarExpr::literal(Datum::String("hex"), ScalarType::String);
+                    Ok(input.call_binary(algorithm, BinaryFunc::DigestBytes).call_binary(encoding, BinaryFunc::Encode))
+                }) => String, 2321;
+            },
             "mod" => Scalar {
                 params!(Numeric, Numeric) => Operation::nullary(|_ecx| catalog_name_only!("mod")) => Numeric, 1728;
                 params!(Int16, Int16) => Operation::nullary(|_ecx| catalog_name_only!("mod")) => Int16, 940;
@@ -2010,6 +2022,18 @@ lazy_static! {
             "rtrim" => Scalar {
                 params!(String) => UnaryFunc::TrimTrailingWhitespace, 882;
                 params!(String, String) => BinaryFunc::TrimTrailing, 876;
+            },
+            "sha224" => Scalar {
+                params!(Bytes) => digest("sha224") => Bytes, 3419;
+            },
+            "sha256" => Scalar {
+                params!(Bytes) => digest("sha256") => Bytes, 3420;
+            },
+            "sha384" => Scalar {
+                params!(Bytes) => digest("sha384") => Bytes, 3421;
+            },
+            "sha512" => Scalar {
+                params!(Bytes) => digest("sha512") => Bytes, 3422;
             },
             "sin" => Scalar {
                 params!(Float64) => UnaryFunc::Sin(func::Sin), 1604;
@@ -2695,6 +2719,13 @@ fn plan_current_timestamp(ecx: &ExprContext, name: &str) -> Result<HirScalarExpr
         )),
         QueryLifetime::Static => sql_bail!("{} cannot be used in static queries; see: https://materialize.com/docs/sql/functions/now_and_mz_logical_timestamp/", name),
     }
+}
+
+fn digest(algorithm: &'static str) -> Operation<HirScalarExpr> {
+    Operation::unary(move |_ecx, input| {
+        let algorithm = HirScalarExpr::literal(Datum::String(algorithm), ScalarType::String);
+        Ok(input.call_binary(algorithm, BinaryFunc::DigestBytes))
+    })
 }
 
 fn mz_cluster_id(ecx: &ExprContext) -> Result<HirScalarExpr, PlanError> {

--- a/test/sqllogictest/postgres/strings.slt
+++ b/test/sqllogictest/postgres/strings.slt
@@ -1,0 +1,99 @@
+# Copyright 1994, Regents of the University of California.
+# Copyright 1996-2022 PostgreSQL Global Development Group.
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# This file is derived from the regression test suite in PostgreSQL.
+# The original file was retrieved on February 3, 2022 from:
+#
+#     https://github.com/postgres/postgres/blob/d33a81203e95d31e62157c4ae0e00e2198841208/src/test/regress/expected/strings.out
+#
+# The original source code is subject to the terms of the PostgreSQL
+# license, a copy of which can be found in the LICENSE file at the
+# root of this repository.
+
+# At the time of writing this file contains only PostgreSQL's
+# hash-function-related string tests, which constitute only a small fraction of
+# the available string tests upstream.
+
+mode cockroach
+
+# MD5 test suite - from IETF RFC 1321
+# (see: ftp://ftp.rfc-editor.org/in-notes/rfc1321.txt)
+
+statement ok
+CREATE TABLE md5_test (t text)
+
+statement ok
+INSERT INTO md5_test VALUES
+    (''),
+    ('a'),
+    ('abc'),
+    ('message digest'),
+    ('abcdefghijklmnopqrstuvwxyz'),
+    ('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'),
+    ('12345678901234567890123456789012345678901234567890123456789012345678901234567890')
+
+query T rowsort
+SELECT md5(t) FROM md5_test ORDER BY t
+----
+d41d8cd98f00b204e9800998ecf8427e
+0cc175b9c0f1b6a831c399e269772661
+900150983cd24fb0d6963f7d28e17f72
+f96b697d7cb7938d525a2f31aaf161d0
+c3fcd3d76192e4007dfb496cca67e13b
+d174ab98d277d9f5a5611c2c9f419d9f
+57edf4a22be3c955ac49da2e2107b67a
+
+query I
+SELECT count(*) FROM md5_test WHERE md5(t) <> md5(t::bytea)
+----
+0
+
+# SHA-2
+
+query T
+SELECT sha224('')::text
+----
+\xd14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f
+
+query T
+SELECT sha224('The quick brown fox jumps over the lazy dog.')::text
+----
+\x619cba8e8e05826e9b8c519c0a5c68f4fb653e8a3d8aa04bb2c8cd4c
+
+query T
+SELECT sha256('')::text
+----
+\xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+
+query T
+SELECT sha256('The quick brown fox jumps over the lazy dog.')::text
+----
+\xef537f25c895bfa782526529a9b63d97aa631564d5d789c2b765448c8635fb6c
+
+query T
+SELECT sha384('')::text
+----
+\x38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b
+
+query T
+SELECT sha384('The quick brown fox jumps over the lazy dog.')::text
+----
+\xed892481d8272ca6df370bf706e4d7bc1b5739fa2177aae6c50e946678718fc67a7af2819a021c2fc34e91bdb63409d7
+
+query T
+SELECT sha512('')::text
+----
+\xcf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e
+
+query T
+SELECT sha512('The quick brown fox jumps over the lazy dog.')::text
+----
+\x91ea1245f20d46ae9a037a989f54f1f790f0a47607eeb8a14d12890cea77a1bbc6c7ed9cf205e67b7f2b8fd4c7dfd3a7a8617e45f3c463d481c7e586c39ac1ed


### PR DESCRIPTION
Add dedicated md5, sha224, sha256, sha384, and sha512 functions. These
complement the existing digest function, which takes its algorithm as a
parameter.

These functions are in PostgreSQL. md5 in particular is needed for
compatibility with materialize-dbt-utils.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
