### PR TITLE
add a feature benchmark for initial pg-cdc data loading

### DIFF
--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -40,6 +40,7 @@ from materialize.mzcompose.services import (
     SchemaRegistry,
     Testdrive,
     Zookeeper,
+    Postgres,
 )
 
 #
@@ -82,6 +83,7 @@ SERVICES = [
         default_timeout=default_timeout,
     ),
     KgenService(),
+    Postgres(),
 ]
 
 
@@ -229,7 +231,7 @@ root_scenario: {args.root_scenario}"""
 
     print(f"scenarios: {', '.join([scenario.__name__ for scenario in scenarios])}")
 
-    c.start_and_wait_for_tcp(services=["zookeeper", "kafka", "schema-registry"])
+    c.start_and_wait_for_tcp(services=["zookeeper", "kafka", "schema-registry", "postgres"])
 
     report = Report()
     has_regressions = False

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -37,10 +37,10 @@ from materialize.mzcompose.services import Kafka as KafkaService
 from materialize.mzcompose.services import Kgen as KgenService
 from materialize.mzcompose.services import (
     Materialized,
+    Postgres,
     SchemaRegistry,
     Testdrive,
     Zookeeper,
-    Postgres,
 )
 
 #
@@ -231,7 +231,9 @@ root_scenario: {args.root_scenario}"""
 
     print(f"scenarios: {', '.join([scenario.__name__ for scenario in scenarios])}")
 
-    c.start_and_wait_for_tcp(services=["zookeeper", "kafka", "schema-registry", "postgres"])
+    c.start_and_wait_for_tcp(
+        services=["zookeeper", "kafka", "schema-registry", "postgres"]
+    )
 
     report = Report()
     has_regressions = False

--- a/test/feature-benchmark/scenarios.py
+++ b/test/feature-benchmark/scenarios.py
@@ -892,7 +892,6 @@ class PostgresInitialLoad(PgCdc):
     when creating a materialized source"""
 
     def shared(self) -> Action:
-        rows = ",".join(f"({i}, \'{i}')" for i in range(0, self.n()))
         return TdAction(
             f"""
 $ postgres-execute connection=postgres://postgres:postgres@postgres
@@ -903,8 +902,8 @@ CREATE SCHEMA public;
 DROP PUBLICATION IF EXISTS mz_source;
 CREATE PUBLICATION mz_source FOR ALL TABLES;
 
-CREATE TABLE pk_table (pk INTEGER PRIMARY KEY, f2 TEXT);
-INSERT INTO pk_table VALUES {rows}
+CREATE TABLE pk_table (pk BIGINT PRIMARY KEY, f2 BIGINT);
+INSERT INTO pk_table SELECT x, x*2 FROM generate_series(1, {self.n()}) as x;
 ALTER TABLE pk_table REPLICA IDENTITY FULL;
 """
         )

--- a/test/feature-benchmark/scenarios.py
+++ b/test/feature-benchmark/scenarios.py
@@ -881,3 +881,51 @@ $ kafka-ingest format=avro topic=sink-input key-format=avro key-schema=${{keysch
 """
             + str(self.n())
         )
+
+
+class PgCdc(Scenario):
+    pass
+
+
+class PostgresInitialLoad(PgCdc):
+    """Measure the time it takes to read 1M existing records from Postgres
+    when creating a materialized source"""
+
+    def shared(self) -> Action:
+        rows = ",".join(f"({i}, \'{i}')" for i in range(0, self.n()))
+        return TdAction(
+            f"""
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER USER postgres WITH replication;
+DROP SCHEMA IF EXISTS public CASCADE;
+CREATE SCHEMA public;
+
+DROP PUBLICATION IF EXISTS mz_source;
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+CREATE TABLE pk_table (pk INTEGER PRIMARY KEY, f2 TEXT);
+INSERT INTO pk_table VALUES {rows}
+ALTER TABLE pk_table REPLICA IDENTITY FULL;
+"""
+        )
+
+    def before(self) -> Action:
+        return TdAction(
+            f"""
+> DROP SOURCE IF EXISTS mz_source_pgcdc;
+            """
+        )
+
+    def benchmark(self) -> MeasurementSource:
+        return Td(
+            f"""
+> CREATE MATERIALIZED SOURCE mz_source_pgcdc
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
+  PUBLICATION 'mz_source';
+  /* A */
+
+> SELECT count(*) FROM mz_source_pgcdc
+  /* B */
+{self.n()}
+            """
+        )


### PR DESCRIPTION
<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

Follow-up to https://github.com/MaterializeInc/materialize/pull/10299 which moved our initial pg-cdc data loading from `SELECT *` to `COPY TO`. It felt a little lackluster to not have a way to measure whether we've made a performance improvement, so this adds a new feature benchmark for the initial data loading of a materialized source/view.

Not sure if I did it all correctly, but I tried a local run by cherry picking this change onto the #10299 branch. I then ran:

`./bin/mzcompose --find feature-benchmark run default --root-scenario PgCdc --other-tag unstable`

And got:

```
feature-benchmark_mzdata
NAME                      |    THIS     |    OTHER    |  Regression?  | 'THIS' is:
----------------------------------------------------------------------------------------------------
PostgresInitialLoad       |       1.571 |       1.703 |      no       | 7.8 pct   faster
```

### Motivation

Benchmark for pg-cdc data loading  / follow up to https://github.com/MaterializeInc/materialize/pull/10299#issuecomment-1026806632
<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug: [Link to issue.]

  * This PR adds a known-desirable feature: [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

### Tips for reviewer

The dataset right now is very simple: just a bunch of int/text values. Do we want to make the dataset more complex?

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
