### PR TITLE
expr,coord: standardize handling of nonpure functions

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -116,6 +116,33 @@ changes that have not yet been documented.
   -59.999999 seconds' to '-2147483648 months -2147483648 days -2147483648 hours
   -59 minutes -59.999999 seconds' to match PostgreSQL's behavior {{% gh 10598 %}}.
 
+- **Breaking change.** Standardize handling of the following
+  [nonpure functions](/sql/functions/#pure-and-nonpure-functions) {{% gh 10445 %}}:
+
+  - `current_database`
+  - `current_timestamp`
+  - `current_role`
+  - `current_schema`
+  - `current_schemas`
+  - `current_user`
+  - `mz_cluster_id`
+  - `mz_logical_timestamp`
+  - `mz_uptime`
+  - `mz_version`
+  - `session_user`
+  - `pg_backend_pid`
+  - `pg_postmaster_start_time`
+  - `version`
+
+  Materialize now allows use of nonpure functions in views, but will refuse to
+  create an index that directly or indirectly depends on a nonpure function.
+  The one exception is `mz_logical_timestamp`, which can be used in limited
+  contexts in a materialized view as a [temporal filter](/guides/temporal-filters).
+
+  Previously `current_timestamp`, `mz_logical_timestamp`, and `mz_uptime` were
+  incorrectly disallowed in unmaterialized views, while the remaining nonpure
+  functions were incorrectly allowed in materialized views.
+
 - Fix a bug where too many columns were returned when both `*` and a
   table function appeared in the `SELECT` list {{% gh 10363 %}}.
 

--- a/doc/user/content/sql/functions/_index.md
+++ b/doc/user/content/sql/functions/_index.md
@@ -16,6 +16,21 @@ This page details Materialize's supported SQL [functions](#functions) and [opera
 
 {{< fnlist >}}
 
+### Pure and nonpure functions
+
+Most functions in Materialize are **pure** functions, which means their output
+is wholly determined by their inputs. Pure functions can be used in all
+contexts.
+
+Several functions in Materialize are **nonpure** functions, which means their
+output depends upon state besides their input parameters, like the value of a
+session parameter or the timestamp of the current transaction. You cannot create
+an [index](/sql/create-index) or materialized view that depends on a nonpure
+function, but you can use nonpure functions in unmaterialized views and one-off
+[`SELECT`](/sql/select) statements.
+
+Nonpure functions are marked as such in the table above.
+
 ## Operators
 
 ### Generic

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -424,8 +424,8 @@
     [`timestamp`](../types/timestamp), [`timestamp with time zone`](../types/timestamptz).
   functions:
   - signature: current_timestamp() -> timestamptz
-    description: 'The `timestamp with time zone` representing when the query was executed.<br/><br/>**NOTE**:
-      Users cannot define views with queries containing `current_timestamp()`.'
+    description: 'The `timestamp with time zone` representing when the query was executed.'
+    nonpure: true
 
   - signature: 'date_bin(stride: interval, source: timestamp, origin: timestamp) -> timestamp'
     description: Align `source` with `origin` along `stride`.
@@ -448,13 +448,18 @@
     url: date-part
 
   - signature: mz_logical_timestamp() -> numeric
-    description: 'The logical time at which a query executes. Used for temporal filters and internal debugging.'
+    description: |
+      The logical time at which a query executes. Used for temporal filters and internal debugging.
+      <br><br>
+      **Note**: This function generally behaves like a [non-pure] function, but
+      can be used in limited contexts in materialized views as a [temporal filter](/guides/temporal-filters).
     url: now_and_mz_logical_timestamp
+    nonpure: true
 
   - signature: now() -> timestamptz
-    description: 'The `timestamp with time zone` representing when the query was executed.<br/><br/>**NOTE**:
-      Users cannot define views with queries containing `now()`.'
+    description: 'The `timestamp with time zone` representing when the query was executed.'
     url: now_and_mz_logical_timestamp
+    nonpure: true
 
   - signature: timestamp AT TIME ZONE zone -> timestamptz
     description: 'Converts `timestamp` to the specified time zone, expressed as an offset from UTC. <br/><br/>**Known limitation:** You must explicitly cast the type for the time zone.'
@@ -484,6 +489,7 @@
   functions:
   - signature: mz_cluster_id() -> uuid
     description: The `uuid` uniquely identifying this Materialize cluster.
+    nonpure: true
 
 - type: JSON
   functions:
@@ -620,22 +626,28 @@
   functions:
   - signature: 'mz_uptime() -> interval'
     description: Returns the length of time that the materialized process has been running.
+    nonpure: true
   - signature: 'mz_version() -> text'
     description: Returns the server's version information as a human-readable string.
+    nonpure: true
   - signature: 'format_type(oid: int, typemod: int) -> text'
     description: Returns the canonical SQL name for the type specified by `oid` with `typemod` applied.
   - signature: 'current_database() -> text'
     description: >-
       Returns the name of the current database.
+    nonpure: true
   - signature: 'current_role() -> text'
     description: >-
       Alias for `current_user`.
+    nonpure: true
   - signature: 'current_user() -> text'
     description: >-
       Returns the name of the user who executed the containing query.
-  - signature: 'session_user -> text'
+    nonpure: true
+  - signature: 'session_user() -> text'
     description: >-
       Returns the name of the user who executed the containing query.
+    nonpure: true
   - signature: 'mz_row_size(expr: Record) -> int'
     description: Returns the number of bytes used to store a row.
 
@@ -646,15 +658,18 @@
     description: >-
       Returns the name of the first non-implicit schema on the search path, or
       `NULL` if the search path is empty.
+    nonpure: true
   - signature: 'current_schemas(include_implicit: bool) -> text[]'
     description: >-
       Returns the names of the schemas on the search path.
       The `include_implicit` parameter controls whether implicit schemas like
       `mz_catalog` and `pg_catalog` are included in the output.
+    nonpure: true
   - signature: 'obj_description(oid: oid, catalog: text) -> text'
     description: PostgreSQL compatibility shim. Currently always returns `NULL`.
   - signature: 'pg_backend_pid() -> int'
-    description: Returns -1. Not intended for direct use.
+    description: Returns the internal connection ID.
+    nonpure: true
   - signature: 'pg_column_size(expr: any) -> int'
     description: Returns the number of bytes used to store any individual data value.
   - signature: 'pg_get_constraintdef(oid: oid [, pretty: bool]) -> text'
@@ -669,5 +684,7 @@
     description: PostgreSQL compatibility shim. Not intended for direct use.
   - signature: 'pg_postmaster_start_time() -> timestamptz'
     description: Returns the time when the server started.
+    nonpure: true
   - signature: 'version() -> text'
     description: Returns a PostgreSQL-compatible version string.
+    nonpure: true

--- a/doc/user/layouts/shortcodes/fnlist.html
+++ b/doc/user/layouts/shortcodes/fnlist.html
@@ -34,8 +34,11 @@
 
       {{ .description | $.Page.RenderString }}
 
-      {{ if .url}}(<a href="{{ .url}}">docs</a>){{ end }}
+      {{ if .url }}(<a href="{{ .url }}">docs</a>){{ end }}
 
+      {{ if .nonpure }}
+        <br><br><b>Note:</b> This function is <a href="#pure-and-nonpure-functions">nonpure</a>.
+      {{ end }}
     </td>
   </tr>
   {{ end }} {{/*  {{ range .functions }} */}}

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -98,7 +98,6 @@ use differential_dataflow::lattice::Lattice;
 use futures::future::{self, FutureExt, TryFutureExt};
 use futures::stream::StreamExt;
 use itertools::Itertools;
-use mz_repr::adt::interval::Interval;
 use rand::Rng;
 use timely::order::PartialOrder;
 use timely::progress::frontier::MutableAntichain;
@@ -118,10 +117,11 @@ use mz_dataflow_types::sources::{
     AwsExternalId, ExternalSourceConnector, PostgresSourceConnector, SourceConnector, Timeline,
 };
 use mz_dataflow_types::{
-    DataflowDesc, DataflowDescription, IndexDesc, PeekResponse, PeekResponseUnary, Update,
+    BuildDesc, DataflowDesc, DataflowDescription, IndexDesc, PeekResponse, PeekResponseUnary,
+    Update,
 };
 use mz_expr::{
-    permutation_for_arrangement, GlobalId, MirRelationExpr, MirScalarExpr, NullaryFunc,
+    permutation_for_arrangement, ExprHumanizer, GlobalId, MirRelationExpr, MirScalarExpr,
     OptimizedMirRelationExpr, RowSetFinishing,
 };
 use mz_ore::metrics::MetricsRegistry;
@@ -130,8 +130,9 @@ use mz_ore::retry::Retry;
 use mz_ore::soft_assert_eq;
 use mz_ore::task;
 use mz_ore::thread::JoinHandleExt;
-use mz_repr::adt::numeric;
-use mz_repr::{Datum, Diff, RelationDesc, Row, RowArena, ScalarType, Timestamp};
+use mz_repr::adt::interval::Interval;
+use mz_repr::adt::numeric::{Numeric, NumericMaxScale};
+use mz_repr::{Datum, Diff, RelationDesc, RelationType, Row, RowArena, ScalarType, Timestamp};
 use mz_sql::ast::display::AstDisplay;
 use mz_sql::ast::{
     ConnectorType, CreateIndexStatement, CreateSinkStatement, CreateSourceStatement, ExplainStage,
@@ -154,15 +155,13 @@ use mz_transform::Optimizer;
 use self::arrangement_state::{ArrangementFrontiers, Frontiers, SinkWrites};
 use self::prometheus::Scraper;
 use crate::catalog::builtin::{BUILTINS, MZ_VIEW_FOREIGN_KEYS, MZ_VIEW_KEYS};
-use crate::catalog::{
-    self, storage, BuiltinTableUpdate, Catalog, CatalogItem, CatalogState, SinkConnectorState,
-};
+use crate::catalog::{self, storage, BuiltinTableUpdate, Catalog, CatalogItem, SinkConnectorState};
 use crate::client::{Client, Handle};
 use crate::command::{
     Canceled, Command, ExecuteResponse, Response, StartupMessage, StartupResponse,
 };
 use crate::coord::antichain::AntichainToken;
-use crate::coord::dataflow_builder::DataflowBuilder;
+use crate::coord::dataflow_builder::{DataflowBuilder, ExprPrepStyle};
 use crate::error::CoordError;
 use crate::persistcfg::PersisterWithConfig;
 use crate::session::{
@@ -2567,8 +2566,7 @@ impl Coordinator {
         }
         let view_id = self.catalog.allocate_id()?;
         let view_oid = self.catalog.allocate_oid()?;
-        // Optimize the expression so that we can form an accurately typed description.
-        let optimized_expr = self.prep_relation_expr(view.expr, ExprPrepStyle::Static)?;
+        let optimized_expr = self.view_optimizer.optimize(view.expr)?;
         let desc = RelationDesc::new(optimized_expr.typ(), view.column_names);
         let view = catalog::View {
             create_sql: view.create_sql,
@@ -2708,14 +2706,11 @@ impl Coordinator {
     ) -> Result<ExecuteResponse, CoordError> {
         let CreateIndexPlan {
             name,
-            mut index,
+            index,
             options,
             if_not_exists,
         } = plan;
 
-        for key in &mut index.keys {
-            Self::prep_scalar_expr(key, ExprPrepStyle::Static)?;
-        }
         let id = self.catalog.allocate_id()?;
         let index = catalog::Index {
             create_sql: index.create_sql,
@@ -3098,7 +3093,7 @@ impl Coordinator {
         plan: PeekPlan,
     ) -> Result<ExecuteResponse, CoordError> {
         let PeekPlan {
-            source,
+            mut source,
             when,
             finishing,
             copy_to,
@@ -3119,12 +3114,8 @@ impl Coordinator {
         // queries.
         let timestamp = if in_transaction && when == PeekWhen::Immediately {
             // Queries are independent of the logical timestamp iff there are no referenced
-            // sources or indexes and there is no reference to `mz_logical_timestamp()`
-            // which we check by using a Static prep style.
-            let timestamp_independent = source_ids.is_empty()
-                && self
-                    .prep_relation_expr(source.clone(), ExprPrepStyle::Static)
-                    .is_ok();
+            // sources or indexes and there is no reference to `mz_logical_timestamp()`.
+            let timestamp_independent = source_ids.is_empty() && !source.contains_temporal();
 
             // If all previous statements were timestamp-independent and the current one is
             // not, clear the transaction ops so it can get a new timestamp and timedomain.
@@ -3134,7 +3125,7 @@ impl Coordinator {
                 }
             }
 
-            let timestamp = session.get_transaction_timestamp(|| {
+            let timestamp = session.get_transaction_timestamp(|session| {
                 // Determine a timestamp that will be valid for anything in any schema
                 // referenced by the first query.
                 let mut timedomain_ids = self.timedomain_for(&source_ids, &timeline, conn_id)?;
@@ -3142,7 +3133,7 @@ impl Coordinator {
                 // We want to prevent compaction of the indexes consulted by
                 // determine_timestamp, not the ones listed in the query.
                 let (timestamp, timestamp_ids) =
-                    self.determine_timestamp(&timedomain_ids, PeekWhen::Immediately)?;
+                    self.determine_timestamp(session, &timedomain_ids, PeekWhen::Immediately)?;
                 // Add the used indexes to the recorded ids.
                 timedomain_ids.extend(&timestamp_ids);
                 let mut handles = vec![];
@@ -3204,15 +3195,10 @@ impl Coordinator {
 
             timestamp
         } else {
-            self.determine_timestamp(&source_ids, when)?.0
+            self.determine_timestamp(session, &source_ids, when)?.0
         };
 
-        let source = self.prep_relation_expr(
-            source,
-            ExprPrepStyle::OneShot {
-                logical_time: timestamp,
-            },
-        )?;
+        let source = self.view_optimizer.optimize(source)?;
 
         // We create a dataflow and optimize it, to determine if we can avoid building it.
         // This can happen if the result optimizes to a constant, or to a `Get` expression
@@ -3231,8 +3217,17 @@ impl Coordinator {
         // The assembled dataflow contains a view and an index of that view.
         let mut dataflow = DataflowDesc::new(format!("temp-view-{}", view_id), view_id);
         dataflow.set_as_of(Antichain::from_elem(timestamp));
-        self.dataflow_builder()
-            .import_view_into_dataflow(&view_id, &source, &mut dataflow)?;
+        let mut builder = self.dataflow_builder();
+        builder.import_view_into_dataflow(&view_id, &source, &mut dataflow)?;
+        for BuildDesc { view, .. } in &mut dataflow.objects_to_build {
+            builder.prep_relation_expr(
+                view,
+                ExprPrepStyle::OneShot {
+                    logical_time: Some(timestamp),
+                    session,
+                },
+            )?;
+        }
         dataflow.export_index(
             index_id,
             IndexDesc {
@@ -3298,7 +3293,7 @@ impl Coordinator {
             // Updates greater or equal to this frontier will be produced.
             let frontier = if let Some(ts) = ts {
                 // If a timestamp was explicitly requested, use that.
-                let ts = coord.determine_timestamp(uses, PeekWhen::AtTimestamp(ts))?;
+                let ts = coord.determine_timestamp(session, uses, PeekWhen::AtTimestamp(ts))?;
                 Antichain::from_elem(ts.0)
             } else {
                 coord.determine_frontier(uses)
@@ -3332,7 +3327,7 @@ impl Coordinator {
                 depends_on,
             } => {
                 let id = self.allocate_transient_id()?;
-                let expr = self.prep_relation_expr(expr, ExprPrepStyle::Static)?;
+                let expr = self.view_optimizer.optimize(expr)?;
                 let desc = RelationDesc::new(expr.typ(), desc.iter_names());
                 let sink_desc = make_sink_desc(self, id, desc, &depends_on)?;
                 let mut dataflow = DataflowDesc::new(format!("tail-{}", id), id);
@@ -3370,6 +3365,7 @@ impl Coordinator {
     /// used is also returned.
     fn determine_timestamp(
         &mut self,
+        session: &Session,
         uses_ids: &[GlobalId],
         when: PeekWhen,
     ) -> Result<(Timestamp, Vec<GlobalId>), CoordError> {
@@ -3400,7 +3396,37 @@ impl Coordinator {
         // timestamp, or the latest timestamp known to be immediately available.
         let timestamp = match when {
             // Explicitly requested timestamps should be respected.
-            PeekWhen::AtTimestamp(timestamp) => timestamp,
+            PeekWhen::AtTimestamp(mut timestamp) => {
+                let temp_storage = RowArena::new();
+                self.dataflow_builder().prep_scalar_expr(
+                    &mut timestamp,
+                    ExprPrepStyle::OneShot {
+                        logical_time: None,
+                        session,
+                    },
+                )?;
+                let evaled = timestamp.eval(&[], &temp_storage)?;
+                let ty = timestamp.typ(&RelationType::empty());
+                match ty.scalar_type {
+                    ScalarType::Numeric { .. } => {
+                        let n = evaled.unwrap_numeric().0;
+                        u64::try_from(n)?
+                    }
+                    ScalarType::Int16 => evaled.unwrap_int16().try_into()?,
+                    ScalarType::Int32 => evaled.unwrap_int32().try_into()?,
+                    ScalarType::Int64 => evaled.unwrap_int64().try_into()?,
+                    ScalarType::TimestampTz => {
+                        evaled.unwrap_timestamptz().timestamp_millis().try_into()?
+                    }
+                    ScalarType::Timestamp => {
+                        evaled.unwrap_timestamp().timestamp_millis().try_into()?
+                    }
+                    _ => coord_bail!(
+                        "can't use {} as a timestamp for AS OF",
+                        self.catalog.for_session(session).humanize_column_type(&ty)
+                    ),
+                }
+            }
 
             // These two strategies vary in terms of which traces drive the
             // timestamp determination process: either the trace itself or the
@@ -3609,8 +3635,7 @@ impl Coordinator {
              decorrelated_plan: MirRelationExpr|
              -> Result<DataflowDescription<OptimizedMirRelationExpr>, CoordError> {
                 let start = Instant::now();
-                let optimized_plan =
-                    coord.prep_relation_expr(decorrelated_plan, ExprPrepStyle::Explain)?;
+                let optimized_plan = coord.view_optimizer.optimize(decorrelated_plan)?;
                 let mut dataflow = DataflowDesc::new(format!("explanation"), GlobalId::Explain);
                 coord.dataflow_builder().import_view_into_dataflow(
                     // TODO: If explaining a view, pipe the actual id of the view.
@@ -3782,11 +3807,17 @@ impl Coordinator {
         mut session: Session,
         plan: InsertPlan,
     ) {
-        let optimized_mir = match self.prep_relation_expr(plan.values, ExprPrepStyle::Write) {
-            Ok(m) => m,
-            Err(e) => {
-                tx.send(Err(e), session);
-                return;
+        let optimized_mir = if let MirRelationExpr::Constant { .. } = &plan.values {
+            // We don't perform any optimizations on an expression that is already
+            // a constant for writes, as we want to maximize bulk-insert throughput.
+            OptimizedMirRelationExpr(plan.values)
+        } else {
+            match self.view_optimizer.optimize(plan.values) {
+                Ok(m) => m,
+                Err(e) => {
+                    tx.send(Err(e.into()), session);
+                    return;
+                }
             }
         };
 
@@ -3796,7 +3827,7 @@ impl Coordinator {
                 session,
             ),
             // All non-constant values must be planned as read-then-writes.
-            selection => {
+            mut selection => {
                 let desc_arity = match self.catalog.try_get_by_id(plan.id) {
                     Some(table) => table.desc().expect("desc called on table").arity(),
                     None => {
@@ -3809,6 +3840,16 @@ impl Coordinator {
                         return;
                     }
                 };
+
+                if selection.contains_temporal() {
+                    tx.send(
+                        Err(CoordError::Unsupported(
+                            "calls to mz_logical_timestamp in write statements are not supported",
+                        )),
+                        session,
+                    );
+                    return;
+                }
 
                 let finishing = RowSetFinishing {
                     order_by: vec![],
@@ -3878,13 +3919,9 @@ impl Coordinator {
     ) -> Result<ExecuteResponse, CoordError> {
         let catalog = self.catalog.for_session(session);
         let values = mz_sql::plan::plan_copy_from(&session.pcx(), &catalog, id, columns, rows)?;
-
-        let constants = self
-            .prep_relation_expr(values.lower(), ExprPrepStyle::Write)?
-            .into_inner();
-
+        let values = self.view_optimizer.optimize(values.lower())?;
         // Copied rows must always be constants.
-        self.sequence_insert_constant(session, id, constants)
+        self.sequence_insert_constant(session, id, values.into_inner())
     }
 
     // ReadThenWrite is a plan whose writes depend on the results of a
@@ -3936,6 +3973,12 @@ impl Coordinator {
         }
 
         let ts = self.get_local_read_ts();
+        let ts = MirScalarExpr::literal_ok(
+            Datum::from(Numeric::from(ts)),
+            ScalarType::Numeric {
+                max_scale: Some(NumericMaxScale::ZERO),
+            },
+        );
         let peek_response = match self
             .sequence_peek(
                 &mut session,
@@ -4089,6 +4132,8 @@ impl Coordinator {
     /// returned by this function. This allows callers to error while building
     /// [`DataflowDesc`]s. [`Coordinator::ship_dataflow`] must be called after this
     /// function successfully returns on any built `DataflowDesc`.
+    ///
+    /// [`CatalogState`]: crate::catalog::CatalogState
     async fn catalog_transact<F, T>(&mut self, ops: Vec<catalog::Op>, f: F) -> Result<T, CoordError>
     where
         F: FnOnce(DataflowBuilder) -> Result<T, CoordError>,
@@ -4329,76 +4374,6 @@ impl Coordinator {
                     index.set_compaction_window_ms(window);
                 }
             }
-        }
-        Ok(())
-    }
-
-    /// Prepares a relation expression for execution by preparing all contained
-    /// scalar expressions (see `prep_scalar_expr`), then optimizing the
-    /// relation expression.
-    fn prep_relation_expr(
-        &mut self,
-        mut expr: MirRelationExpr,
-        style: ExprPrepStyle,
-    ) -> Result<OptimizedMirRelationExpr, CoordError> {
-        if let ExprPrepStyle::Static = &style {
-            let mut opt_expr = self.view_optimizer.optimize(expr)?;
-            opt_expr.0.try_visit_mut_post(&mut |e| {
-                // Carefully test filter expressions, which may represent temporal filters.
-                if let mz_expr::MirRelationExpr::Filter { input, predicates } = &*e {
-                    let mfp = mz_expr::MapFilterProject::new(input.arity())
-                        .filter(predicates.iter().cloned());
-                    match mfp.into_plan() {
-                        Err(e) => coord_bail!("{:?}", e),
-                        Ok(_) => Ok(()),
-                    }
-                } else {
-                    e.try_visit_scalars_mut1(&mut |s| Self::prep_scalar_expr(s, style))
-                }
-            })?;
-            Ok(opt_expr)
-        } else {
-            expr.try_visit_scalars_mut(&mut |s| Self::prep_scalar_expr(s, style))?;
-
-            if let (ExprPrepStyle::Write, mz_expr::MirRelationExpr::Constant { .. }) =
-                (&style, &expr)
-            {
-                // We don't perform any optimizations on an expression that is already
-                // a constant for writes, as we want to maximize bulk-insert throughput.
-                Ok(OptimizedMirRelationExpr(expr))
-            } else {
-                // TODO (wangandi): Is there anything that optimizes to a
-                // constant expression that originally contains a global get? Is
-                // there anything not containing a global get that cannot be
-                // optimized to a constant expression?
-                Ok(self.view_optimizer.optimize(expr)?)
-            }
-        }
-    }
-
-    /// Prepares a scalar expression for execution by replacing any placeholders
-    /// with their correct values.
-    ///
-    /// Specifically, calls to the special function `MzLogicalTimestamp` are
-    /// replaced if `style` is `OneShot { logical_timestamp }`. Calls are not
-    /// replaced for the `Explain` style nor for `Static` which should not
-    /// reach this point if we have correctly validated the use of placeholders.
-    fn prep_scalar_expr(expr: &mut MirScalarExpr, style: ExprPrepStyle) -> Result<(), CoordError> {
-        // Replace calls to `MzLogicalTimestamp` as described above.
-        let mut observes_ts = false;
-        expr.visit_mut_post(&mut |e| {
-            if let MirScalarExpr::CallNullary(f @ NullaryFunc::MzLogicalTimestamp) = e {
-                observes_ts = true;
-                if let ExprPrepStyle::OneShot { logical_time } = style {
-                    let ts = numeric::Numeric::from(logical_time);
-                    *e = MirScalarExpr::literal_ok(Datum::from(ts), f.output_type().scalar_type);
-                }
-            }
-        });
-        if observes_ts && matches!(style, ExprPrepStyle::Static | ExprPrepStyle::Write) {
-            return Err(CoordError::Unsupported(
-                "calls to mz_logical_timestamp in in static or write queries",
-            ));
         }
         Ok(())
     }
@@ -4756,22 +4731,6 @@ pub async fn serve(
         }
         Err(e) => Err(e),
     }
-}
-
-/// The styles in which an expression can be prepared.
-#[derive(Clone, Copy, Debug)]
-enum ExprPrepStyle {
-    /// The expression is being prepared for output as part of an `EXPLAIN`
-    /// query.
-    Explain,
-    /// The expression is being prepared for installation in a static context,
-    /// like in a view.
-    Static,
-    /// The expression is being prepared to run once at the specified logical
-    /// time.
-    OneShot { logical_time: u64 },
-    /// The expression is being prepared to run in an INSERT or other write.
-    Write,
 }
 
 /// Constructs an [`ExecuteResponse`] that that will send some rows to the

--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -14,13 +14,23 @@
 //! and indicate which identifiers have arrangements available. This module
 //! isolates that logic from the rest of the somewhat complicated coordinator.
 
-use mz_ore::stack::maybe_grow;
-
 use mz_dataflow_types::sinks::SinkDesc;
-use mz_dataflow_types::IndexDesc;
+use mz_dataflow_types::{BuildDesc, DataflowDesc, IndexDesc};
+use mz_expr::{
+    GlobalId, MapFilterProject, MirRelationExpr, MirScalarExpr, NullaryFunc,
+    OptimizedMirRelationExpr,
+};
+use mz_ore::stack::maybe_grow;
+use mz_repr::adt::array::ArrayDimension;
+use mz_repr::adt::numeric::Numeric;
+use mz_repr::{Datum, Row, Timestamp};
 
-use super::*;
+use crate::catalog::{CatalogItem, CatalogState};
+use crate::coord::ArrangementFrontiers;
+use crate::coord::Coordinator;
 use crate::error::RematerializedSourceType;
+use crate::session::Session;
+use crate::{CoordError, PersisterWithConfig};
 
 /// Borrows of catalog and indexes sufficient to build dataflow descriptions.
 pub struct DataflowBuilder<'a> {
@@ -30,6 +40,19 @@ pub struct DataflowBuilder<'a> {
     /// A handle to the storage abstraction, which describe sources from their identifier.
     pub storage:
         &'a mz_dataflow_types::client::Controller<Box<dyn mz_dataflow_types::client::Client>>,
+}
+
+/// The styles in which an expression can be prepared for use in a dataflow.
+#[derive(Clone, Copy, Debug)]
+pub enum ExprPrepStyle<'a> {
+    /// The expression is being prepared for installation as a maintained index.
+    Index,
+    /// The expression is being prepared to run once at the specified logical
+    /// time in the specified session.
+    OneShot {
+        logical_time: Option<u64>,
+        session: &'a Session,
+    },
 }
 
 impl Coordinator {
@@ -189,12 +212,18 @@ impl<'a> DataflowBuilder<'a> {
         &mut self,
         name: String,
         id: GlobalId,
-        index_description: IndexDesc,
+        mut index_description: IndexDesc,
     ) -> Result<DataflowDesc, CoordError> {
         let on_entry = self.catalog.get_by_id(&index_description.on_id);
         let on_type = on_entry.desc().unwrap().typ().clone();
         let mut dataflow = DataflowDesc::new(name, id);
         self.import_into_dataflow(&index_description.on_id, &mut dataflow)?;
+        for BuildDesc { view, .. } in &mut dataflow.objects_to_build {
+            self.prep_relation_expr(view, ExprPrepStyle::Index)?;
+        }
+        for key in &mut index_description.key {
+            self.prep_scalar_expr(key, ExprPrepStyle::Index)?;
+        }
         dataflow.export_index(id, index_description, on_type);
 
         // Optimize the dataflow across views, and any other ways that appeal.
@@ -229,11 +258,177 @@ impl<'a> DataflowBuilder<'a> {
     ) -> Result<(), CoordError> {
         dataflow.set_as_of(sink_description.as_of.frontier.clone());
         self.import_into_dataflow(&sink_description.from, dataflow)?;
+        for BuildDesc { view, .. } in &mut dataflow.objects_to_build {
+            self.prep_relation_expr(view, ExprPrepStyle::Index)?;
+        }
         dataflow.export_sink(id, sink_description);
 
         // Optimize the dataflow across views, and any other ways that appeal.
         mz_transform::optimize_dataflow(dataflow, self.catalog.enabled_indexes())?;
 
         Ok(())
+    }
+
+    /// Prepares a relation expression for dataflow execution by preparing all
+    /// contained scalar expressions (see `prep_scalar_expr`) in the specified
+    /// style.
+    pub fn prep_relation_expr(
+        &self,
+        expr: &mut OptimizedMirRelationExpr,
+        style: ExprPrepStyle,
+    ) -> Result<(), CoordError> {
+        match style {
+            ExprPrepStyle::Index => {
+                expr.0.try_visit_mut_post(&mut |e| {
+                    // Carefully test filter expressions, which may represent temporal filters.
+                    if let MirRelationExpr::Filter { input, predicates } = &*e {
+                        let mfp =
+                            MapFilterProject::new(input.arity()).filter(predicates.iter().cloned());
+                        match mfp.into_plan() {
+                            Err(e) => coord_bail!("{:?}", e),
+                            Ok(_) => Ok(()),
+                        }
+                    } else {
+                        e.try_visit_scalars_mut1(&mut |s| self.prep_scalar_expr(s, style))
+                    }
+                })
+            }
+            ExprPrepStyle::OneShot { .. } => expr
+                .0
+                .try_visit_scalars_mut(&mut |s| self.prep_scalar_expr(s, style)),
+        }
+    }
+
+    /// Prepares a scalar expression for execution by replacing any placeholders
+    /// with their correct values.
+    ///
+    /// Specifically, calls to nullary functions replaced if `style` is
+    /// `OneShot`. If `style` is `Index`, then an error is produced if a call
+    /// to a nullary function is encountered.
+    pub fn prep_scalar_expr(
+        &self,
+        expr: &mut MirScalarExpr,
+        style: ExprPrepStyle,
+    ) -> Result<(), CoordError> {
+        match style {
+            // Evaluate each nullary function and replace the invocation with
+            // the result.
+            ExprPrepStyle::OneShot {
+                logical_time,
+                session,
+            } => {
+                let mut res = Ok(());
+                expr.visit_mut_post(&mut |e| {
+                    if let MirScalarExpr::CallNullary(f) = e {
+                        match self.eval_nullary_func(f, logical_time, session) {
+                            Ok(evaled) => *e = evaled,
+                            Err(e) => res = Err(e),
+                        }
+                    }
+                });
+                res
+            }
+
+            // Reject the query if it contains any nullary function calls.
+            ExprPrepStyle::Index => {
+                let mut last_observed_nullary_func = None;
+                expr.visit_mut_post(&mut |e| {
+                    if let MirScalarExpr::CallNullary(f) = e {
+                        last_observed_nullary_func = Some(f.clone());
+                    }
+                });
+                if let Some(f) = last_observed_nullary_func {
+                    return Err(CoordError::UnmaterializableFunction(f));
+                }
+                Ok(())
+            }
+        }
+    }
+
+    fn eval_nullary_func(
+        &self,
+        f: &NullaryFunc,
+        logical_time: Option<u64>,
+        session: &Session,
+    ) -> Result<MirScalarExpr, CoordError> {
+        let pack_1d_array = |datums: Vec<Datum>| {
+            let mut row = Row::default();
+            row.push_array(
+                &[ArrayDimension {
+                    lower_bound: 1,
+                    length: datums.len(),
+                }],
+                datums,
+            )
+            .expect("known to be a valid array");
+            Ok(MirScalarExpr::Literal(Ok(row), f.output_type()))
+        };
+        let pack = |datum| {
+            Ok(MirScalarExpr::literal_ok(
+                datum,
+                f.output_type().scalar_type,
+            ))
+        };
+
+        match f {
+            NullaryFunc::CurrentDatabase => pack(Datum::from(session.vars().database())),
+            NullaryFunc::CurrentSchemasWithSystem => pack_1d_array(
+                session
+                    .vars()
+                    .search_path()
+                    .iter()
+                    .map(|s| Datum::String(s))
+                    .collect(),
+            ),
+            NullaryFunc::CurrentSchemasWithoutSystem => {
+                use crate::catalog::builtin::{
+                    INFORMATION_SCHEMA, MZ_CATALOG_SCHEMA, MZ_INTERNAL_SCHEMA, MZ_TEMP_SCHEMA,
+                    PG_CATALOG_SCHEMA,
+                };
+                pack_1d_array(
+                    session
+                        .vars()
+                        .search_path()
+                        .iter()
+                        .filter(|s| {
+                            (**s != PG_CATALOG_SCHEMA)
+                                && (**s != INFORMATION_SCHEMA)
+                                && (**s != MZ_CATALOG_SCHEMA)
+                                && (**s != MZ_TEMP_SCHEMA)
+                                && (**s != MZ_INTERNAL_SCHEMA)
+                        })
+                        .map(|s| Datum::String(s))
+                        .collect(),
+                )
+            }
+            NullaryFunc::CurrentTimestamp => pack(Datum::from(session.pcx().wall_time)),
+            NullaryFunc::CurrentUser => pack(Datum::from(session.user())),
+            NullaryFunc::MzClusterId => pack(Datum::from(self.catalog.config().cluster_id)),
+            NullaryFunc::MzLogicalTimestamp => match logical_time {
+                None => coord_bail!("cannot call mz_logical_timestamp in this context"),
+                Some(logical_time) => pack(Datum::from(Numeric::from(logical_time))),
+            },
+            NullaryFunc::MzSessionId => pack(Datum::from(self.catalog.config().session_id)),
+            NullaryFunc::MzUptime => {
+                let uptime = self.catalog.config().start_instant.elapsed();
+                let uptime = chrono::Duration::from_std(uptime).map_or(Datum::Null, Datum::from);
+                pack(uptime)
+            }
+            NullaryFunc::MzVersion => pack(Datum::from(
+                &*self.catalog.config().build_info.human_version(),
+            )),
+            NullaryFunc::PgBackendPid => pack(Datum::Int32(session.conn_id() as i32)),
+            NullaryFunc::PgPostmasterStartTime => {
+                pack(Datum::from(self.catalog.config().start_time))
+            }
+            NullaryFunc::Version => {
+                let build_info = self.catalog.config().build_info;
+                let version = format!(
+                    "PostgreSQL 9.6 on {} (materialized {})",
+                    build_info.target_triple, build_info.version,
+                );
+                pack(Datum::from(&*version))
+            }
+        }
     }
 }

--- a/src/coord/src/session.rs
+++ b/src/coord/src/session.rs
@@ -227,7 +227,7 @@ impl Session {
     /// Assumes an active transaction. Returns its read timestamp. Errors if not
     /// a read transaction. Calls get_ts to get a timestamp if the transaction
     /// doesn't have an operation yet, converting the transaction to a read.
-    pub fn get_transaction_timestamp<F: FnMut() -> Result<Timestamp, CoordError>>(
+    pub fn get_transaction_timestamp<F: FnMut(&Session) -> Result<Timestamp, CoordError>>(
         &mut self,
         mut get_ts: F,
     ) -> Result<Timestamp, CoordError> {
@@ -242,7 +242,7 @@ impl Session {
                 write_lock_guard: _,
                 access: _,
             }) => *ts,
-            _ => get_ts()?,
+            _ => get_ts(self)?,
         };
         self.add_transaction_ops(TransactionOps::Peeks(ts))?;
         Ok(ts)

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -1394,7 +1394,7 @@ pub mod plan {
                     mut expr2,
                 } = predicate
                 {
-                    // Attempt to put `MzLogicalTimestamp` in the first argument position.
+                    // Attempt to put `LogicalTimestamp` in the first argument position.
                     if !expr1.contains_temporal()
                         && *expr2 == MirScalarExpr::CallNullary(NullaryFunc::MzLogicalTimestamp)
                     {
@@ -1437,7 +1437,7 @@ pub mod plan {
                     // little, but we do want to know they were negative.)
                     let expr2_floor = expr2.call_unary(UnaryFunc::FloorNumeric(func::FloorNumeric));
 
-                    // MzLogicalTimestamp <OP> <EXPR2> for several supported operators.
+                    // LogicalTimestamp <OP> <EXPR2> for several supported operators.
                     match func {
                         BinaryFunc::Eq => {
                             // Lower bound of expr, upper bound of expr+1

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -1206,6 +1206,13 @@ impl MirRelationExpr {
         }
     }
 
+    /// True iff the expression contains a `NullaryFunc::MzLogicalTimestamp`.
+    pub fn contains_temporal(&mut self) -> bool {
+        let mut contains = false;
+        self.visit_scalars_mut(&mut |e| contains = contains || e.contains_temporal());
+        contains
+    }
+
     /// Applies a fallible immutable `f` to each child of type `MirRelationExpr`.
     pub fn try_visit_children<'a, F, E>(&'a self, f: F) -> Result<(), E>
     where

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -57,16 +57,45 @@ pub use impls::*;
 
 #[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
 pub enum NullaryFunc {
+    CurrentDatabase,
+    CurrentSchemasWithSystem,
+    CurrentSchemasWithoutSystem,
+    CurrentTimestamp,
+    CurrentUser,
+    MzClusterId,
     MzLogicalTimestamp,
+    MzSessionId,
+    MzUptime,
+    MzVersion,
+    PgBackendPid,
+    PgPostmasterStartTime,
+    Version,
 }
 
 impl NullaryFunc {
     pub fn output_type(&self) -> ColumnType {
         match self {
+            NullaryFunc::CurrentDatabase => ScalarType::String.nullable(false),
+            // TODO: The `CurrentSchemas` functions should should return name[].
+            NullaryFunc::CurrentSchemasWithSystem => {
+                ScalarType::Array(Box::new(ScalarType::String)).nullable(false)
+            }
+            NullaryFunc::CurrentSchemasWithoutSystem => {
+                ScalarType::Array(Box::new(ScalarType::String)).nullable(false)
+            }
+            NullaryFunc::CurrentTimestamp => ScalarType::TimestampTz.nullable(false),
+            NullaryFunc::CurrentUser => ScalarType::String.nullable(false),
+            NullaryFunc::MzClusterId => ScalarType::Uuid.nullable(false),
             NullaryFunc::MzLogicalTimestamp => ScalarType::Numeric {
                 max_scale: Some(NumericMaxScale::ZERO),
             }
             .nullable(false),
+            NullaryFunc::MzSessionId => ScalarType::Uuid.nullable(false),
+            NullaryFunc::MzUptime => ScalarType::Interval.nullable(true),
+            NullaryFunc::MzVersion => ScalarType::String.nullable(false),
+            NullaryFunc::PgBackendPid => ScalarType::Int32.nullable(false),
+            NullaryFunc::PgPostmasterStartTime => ScalarType::TimestampTz.nullable(false),
+            NullaryFunc::Version => ScalarType::String.nullable(false),
         }
     }
 }
@@ -74,7 +103,19 @@ impl NullaryFunc {
 impl fmt::Display for NullaryFunc {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
+            NullaryFunc::CurrentDatabase => f.write_str("current_database"),
+            NullaryFunc::CurrentSchemasWithSystem => f.write_str("current_schemas(true)"),
+            NullaryFunc::CurrentSchemasWithoutSystem => f.write_str("current_schemas(false)"),
+            NullaryFunc::CurrentTimestamp => f.write_str("current_timestamp"),
+            NullaryFunc::CurrentUser => f.write_str("current_user"),
+            NullaryFunc::MzClusterId => f.write_str("mz_cluster_id"),
             NullaryFunc::MzLogicalTimestamp => f.write_str("mz_logical_timestamp"),
+            NullaryFunc::MzSessionId => f.write_str("mz_session_id"),
+            NullaryFunc::MzUptime => f.write_str("mz_uptime"),
+            NullaryFunc::MzVersion => f.write_str("mz_version"),
+            NullaryFunc::PgBackendPid => f.write_str("pg_backend_pid"),
+            NullaryFunc::PgPostmasterStartTime => f.write_str("pg_postmaster_start_time"),
+            NullaryFunc::Version => f.write_str("version"),
         }
     }
 }

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -1021,11 +1021,22 @@ impl MirScalarExpr {
         }
     }
 
-    /// True iff the expression contains `NullaryFunc::MzLogicalTimestamp`.
+    /// True iff the expression contains a `NullaryFunc::MzLogicalTimestamp`.
     pub fn contains_temporal(&self) -> bool {
         let mut contains = false;
         self.visit_post(&mut |e| {
             if let MirScalarExpr::CallNullary(NullaryFunc::MzLogicalTimestamp) = e {
+                contains = true;
+            }
+        });
+        contains
+    }
+
+    /// True iff the expression contains a `NullaryFunc`.
+    pub fn contains_nullary(&self) -> bool {
+        let mut contains = false;
+        self.visit_post(&mut |e| {
+            if let MirScalarExpr::CallNullary(_) = e {
                 contains = true;
             }
         });

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -384,6 +384,7 @@ impl ErrorResponse {
             CoordError::UnknownParameter(_) => SqlState::INVALID_SQL_STATEMENT_NAME,
             CoordError::UnknownPreparedStatement(_) => SqlState::UNDEFINED_PSTATEMENT,
             CoordError::UnknownLoginRole(_) => SqlState::INVALID_AUTHORIZATION_SPECIFICATION,
+            CoordError::UnmaterializableFunction(_) => SqlState::FEATURE_NOT_SUPPORTED,
             CoordError::Unsupported(..) => SqlState::FEATURE_NOT_SUPPORTED,
             CoordError::Unstructured(_) => SqlState::INTERNAL_ERROR,
             // It's not immediately clear which error code to use here because a

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -56,9 +56,6 @@ use crate::plan::statement::StatementDesc;
 /// [`get_item`]: Catalog::resolve_item
 /// [`resolve_item`]: SessionCatalog::resolve_item
 pub trait SessionCatalog: fmt::Debug + ExprHumanizer {
-    /// Returns the search path used by the catalog.
-    fn search_path(&self, include_system_schemas: bool) -> Vec<&str>;
-
     /// Returns the name of the user who is issuing the query.
     fn user(&self) -> &str;
 
@@ -434,10 +431,6 @@ lazy_static! {
 }
 
 impl SessionCatalog for DummyCatalog {
-    fn search_path(&self, _: bool) -> Vec<&str> {
-        vec!["dummy"]
-    }
-
     fn user(&self) -> &str {
         "dummy"
     }

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -36,9 +36,9 @@ use serde::{Deserialize, Serialize};
 use mz_dataflow_types::{
     sinks::SinkConnectorBuilder, sinks::SinkEnvelope, sources::SourceConnector,
 };
-use mz_expr::{GlobalId, MirRelationExpr, RowSetFinishing};
+use mz_expr::{GlobalId, MirRelationExpr, MirScalarExpr, RowSetFinishing};
 use mz_ore::now::{self, NOW_ZERO};
-use mz_repr::{ColumnName, Diff, RelationDesc, Row, ScalarType, Timestamp};
+use mz_repr::{ColumnName, Diff, RelationDesc, Row, ScalarType};
 
 use crate::ast::{
     ExplainOptions, ExplainStage, Expr, FetchDirection, ObjectType, Raw, Statement,
@@ -237,7 +237,7 @@ pub struct PeekPlan {
 pub struct TailPlan {
     pub from: TailFrom,
     pub with_snapshot: bool,
-    pub ts: Option<Timestamp>,
+    pub ts: Option<MirScalarExpr>,
     pub copy_to: Option<CopyFormat>,
     pub emit_progress: bool,
 }
@@ -416,8 +416,11 @@ pub enum PeekWhen {
     /// The peek should occur at the latest possible timestamp that allows the
     /// peek to complete immediately.
     Immediately,
-    /// The peek should occur at the specified timestamp.
-    AtTimestamp(Timestamp),
+    /// The peek should occur at the timestamp described by the specified
+    /// expression.
+    ///
+    /// The expression may have any type.
+    AtTimestamp(MirScalarExpr),
 }
 
 #[derive(Debug)]

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -152,7 +152,7 @@ pub fn plan_select(
         expr, finishing, ..
     } = plan_query(scx, query, params, QueryLifetime::OneShot(scx.pcx()?))?;
 
-    let when = match as_of.map(|e| query::eval_as_of(scx, e)).transpose()? {
+    let when = match as_of.map(|e| query::plan_as_of(scx, e)).transpose()? {
         Some(ts) => PeekWhen::AtTimestamp(ts),
         None => PeekWhen::Immediately,
     };
@@ -365,7 +365,7 @@ pub fn plan_tail(
         }
     };
 
-    let ts = as_of.map(|e| query::eval_as_of(scx, e)).transpose()?;
+    let ts = as_of.map(|e| query::plan_as_of(scx, e)).transpose()?;
     let options = TailOptions::try_from(options)?;
     Ok(Plan::Tail(TailPlan {
         from,

--- a/src/sql/src/query_model/test/catalog.rs
+++ b/src/sql/src/query_model/test/catalog.rs
@@ -176,10 +176,6 @@ impl Default for TestCatalog {
 }
 
 impl SessionCatalog for TestCatalog {
-    fn search_path(&self, _: bool) -> Vec<&str> {
-        vec!["dummy"]
-    }
-
     fn user(&self) -> &str {
         "dummy"
     }

--- a/src/transform/src/reduction.rs
+++ b/src/transform/src/reduction.rs
@@ -81,9 +81,9 @@ impl FoldConstants {
                     aggregate.expr.reduce(input_typ);
                 }
 
-                // Guard against evaluating an expression that may contain temporal expressions.
-                if group_key.iter().any(|e| e.contains_temporal())
-                    || aggregates.iter().any(|a| a.expr.contains_temporal())
+                // Guard against evaluating an expression that may contain nullary functions.
+                if group_key.iter().any(|e| e.contains_nullary())
+                    || aggregates.iter().any(|a| a.expr.contains_nullary())
                 {
                     return Ok(());
                 }
@@ -156,8 +156,8 @@ impl FoldConstants {
                     scalar.reduce(&current_type);
                 }
 
-                // Guard against evaluating expression that may contain temporal expressions.
-                if scalars.iter().any(|e| e.contains_temporal()) {
+                // Guard against evaluating expression that may contain nullary functions.
+                if scalars.iter().any(|e| e.contains_nullary()) {
                     return Ok(());
                 }
 
@@ -190,8 +190,8 @@ impl FoldConstants {
                     expr.reduce(input_typ);
                 }
 
-                // Guard against evaluating expression that may contain temporal expressions.
-                if exprs.iter().any(|e| e.contains_temporal()) {
+                // Guard against evaluating expression that may contain nullary functions.
+                if exprs.iter().any(|e| e.contains_nullary()) {
                     return Ok(());
                 }
 
@@ -224,8 +224,8 @@ impl FoldConstants {
                 }
                 predicates.retain(|p| !p.is_literal_true());
 
-                // Guard against evaluating expression that may contain temporal expressions.
-                if predicates.iter().any(|e| e.contains_temporal()) {
+                // Guard against evaluating expression that may contain nullary function calls.
+                if predicates.iter().any(|e| e.contains_nullary()) {
                     return Ok(());
                 }
 
@@ -288,10 +288,10 @@ impl FoldConstants {
                     .iter()
                     .all(|i| matches!(i, MirRelationExpr::Constant { rows: Ok(_), .. }))
                 {
-                    // Guard against evaluating expression that may contain temporal expressions.
+                    // Guard against evaluating expression that may contain nullary functions.
                     if equivalences
                         .iter()
-                        .any(|equiv| equiv.iter().any(|e| e.contains_temporal()))
+                        .any(|equiv| equiv.iter().any(|e| e.contains_nullary()))
                     {
                         return Ok(());
                     }

--- a/test/sqllogictest/as_of.slt
+++ b/test/sqllogictest/as_of.slt
@@ -54,3 +54,6 @@ SELECT * FROM data AS OF 1E38;
 
 query error decimal cannot be expressed in target primitive type
 SELECT * FROM data AS OF 1.2;
+
+query error cannot call mz_logical_timestamp in this context
+SELECT * FROM data AS OF mz_logical_timestamp();

--- a/test/sqllogictest/dates-times.slt
+++ b/test/sqllogictest/dates-times.slt
@@ -725,11 +725,23 @@ SELECT current_timestamp > TIMESTAMP '2016-06-13 00:00:00'
 ----
 true
 
-query error calls to mz_logical_timestamp in in static or write queries are not supported
-CREATE VIEW timeview AS SELECT mz_logical_timestamp()
+statement ok
+CREATE VIEW logical_timestamp_view AS SELECT mz_logical_timestamp()
 
-query error now cannot be used in static queries
-CREATE VIEW timeview AS SELECT now()
+# Equivalent to running `SELECT mz_logical_timestamp()` directly and has the
+# same somewhat confusing output when there are no dependencies on any views.
+query T
+SELECT * FROM logical_timestamp_view
+----
+18446744073709551615
+
+statement ok
+CREATE VIEW now_view AS SELECT now() AS ts
+
+query B
+SELECT ts > TIMESTAMP '2016-06-13 00:00:00' FROM now_view
+----
+true
 
 query T
 SELECT (DATE '2000-01-01')::text

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -1339,4 +1339,4 @@ SELECT mz_internal.mz_error_if_null(1, '')
 query I
 SELECT pg_backend_pid()
 ----
--1
+1

--- a/test/testdrive/tables.td
+++ b/test/testdrive/tables.td
@@ -199,10 +199,13 @@ contains:null value in column "a" violates not-null constraint
 > INSERT INTO v VALUES (now());
 
 ! CREATE INDEX ON v (now())
-contains:now cannot be used in static queries
+contains:cannot materialize call to current_timestamp
 
 ! CREATE INDEX ON v (mz_logical_timestamp())
-contains:calls to mz_logical_timestamp in in static or write queries are not supported
+contains:cannot materialize call to mz_logical_timestamp
+
+! CREATE INDEX ON v (mz_version())
+contains:cannot materialize call to mz_version
 
 > DROP TABLE IF EXISTS s;
 

--- a/test/testdrive/transactions-stable.td
+++ b/test/testdrive/transactions-stable.td
@@ -42,4 +42,4 @@
 # in this file). Although this error message is misleading, we don't
 # expect users to do this, so it's ok for now.
 ! INSERT INTO dec VALUES (mz_logical_timestamp())
-contains:calls to mz_logical_timestamp in in static or write queries are not supported
+contains:calls to mz_logical_timestamp in write statements are not supported

--- a/test/upgrade/create-in-v0.7.3-special-functions.td
+++ b/test/upgrade/create-in-v0.7.3-special-functions.td
@@ -21,7 +21,7 @@
 # if they ever are allowed, add an upgrade test for them
 
 ! CREATE MATERIALIZED VIEW foo AS SELECT NOW();
-contains:cannot be used in static queries
+regex:(cannot be used in static queries|cannot materialize call to current_timestamp)
 
 ! CREATE MATERIALIZED VIEW bar AS SELECT CURRENT_TIMESTAMP();
-contains:cannot be used in static queries
+regex:(cannot be used in static queries|cannot materialize call to current_timestamp)


### PR DESCRIPTION
Classify all functions whose output depends on values besides their
inputs as "nonpure", and give them consistent semantics: they can be
used in unmaterialized views, but cannot be materialized by an index,
either directly or indirectly.

Additional details in the linked issue and in the documentation enclosed
in the patch.

@aalexandrov there's hardly any impact on the optimizer (just a few calls of `contains_temporal()` that change to `contains_nullary()`), so I figure we can probably just discuss here on the PR?

Fix #10445.

### Motivation

  * This PR fixes a recognized bug: #10445.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
