### PR TITLE
sql: support queries in TAIL

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -144,6 +144,8 @@ changes that have not yet been documented.
 
 - Improve the performance of SQL `LIKE` expressions.
 
+- Add `SELECT` statement support to [`TAIL`](/sql/tail).
+
 {{< comment >}}
 Only add new release notes above this line.
 

--- a/doc/user/content/sql/tail.md
+++ b/doc/user/content/sql/tail.md
@@ -31,6 +31,7 @@ Clients can use `TAIL` to:
 Field | Use
 ------|-----
 _object&lowbar;name_ | The name of the source, table, or view that you want to tail.
+_select&lowbar;stmt_ | The [`SELECT` statement](../select) whose output you want to tail.
 _timestamp&lowbar;expression_ | The logical time at which the `TAIL` begins as a [`bigint`] representing milliseconds since the Unix epoch. See [`AS OF`](#as-of) below.
 
 ### `WITH` options

--- a/doc/user/layouts/partials/sql-grammar/tail-stmt.svg
+++ b/doc/user/layouts/partials/sql-grammar/tail-stmt.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="651" height="281">
+<svg xmlns="http://www.w3.org/2000/svg" width="651" height="325">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="52" height="32" rx="10"/>
@@ -9,68 +9,87 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="39" y="21">TAIL</text>
-   <rect x="103" y="3" width="104" height="32"/>
-   <rect x="101" y="1" width="104" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="111" y="21">object_name</text>
-   <rect x="65" y="145" width="58" height="32" rx="10"/>
+   <rect x="123" y="3" width="104" height="32"/>
+   <rect x="121" y="1" width="104" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="131" y="21">object_name</text>
+   <rect x="123" y="47" width="26" height="32" rx="10"/>
+   <rect x="121"
+         y="45"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="131" y="65">(</text>
+   <rect x="169" y="47" width="96" height="32"/>
+   <rect x="167" y="45" width="96" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="177" y="65">select_stmt</text>
+   <rect x="285" y="47" width="26" height="32" rx="10"/>
+   <rect x="283"
+         y="45"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="293" y="65">)</text>
+   <rect x="65" y="189" width="58" height="32" rx="10"/>
    <rect x="63"
-         y="143"
+         y="187"
          width="58"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="73" y="163">WITH</text>
-   <rect x="163" y="113" width="26" height="32" rx="10"/>
+   <text class="terminal" x="73" y="207">WITH</text>
+   <rect x="163" y="157" width="26" height="32" rx="10"/>
    <rect x="161"
-         y="111"
+         y="155"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="171" y="131">(</text>
-   <rect x="229" y="113" width="104" height="32"/>
-   <rect x="227" y="111" width="104" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="237" y="131">option_name</text>
-   <rect x="373" y="145" width="28" height="32" rx="10"/>
+   <text class="terminal" x="171" y="175">(</text>
+   <rect x="229" y="157" width="104" height="32"/>
+   <rect x="227" y="155" width="104" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="237" y="175">option_name</text>
+   <rect x="373" y="189" width="28" height="32" rx="10"/>
    <rect x="371"
-         y="143"
+         y="187"
          width="28"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="381" y="163">=</text>
-   <rect x="421" y="145" width="102" height="32"/>
-   <rect x="419" y="143" width="102" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="429" y="163">option_value</text>
-   <rect x="229" y="69" width="24" height="32" rx="10"/>
+   <text class="terminal" x="381" y="207">=</text>
+   <rect x="421" y="189" width="102" height="32"/>
+   <rect x="419" y="187" width="102" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="429" y="207">option_value</text>
+   <rect x="229" y="113" width="24" height="32" rx="10"/>
    <rect x="227"
-         y="67"
+         y="111"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="237" y="87">,</text>
-   <rect x="583" y="113" width="26" height="32" rx="10"/>
+   <text class="terminal" x="237" y="131">,</text>
+   <rect x="583" y="157" width="26" height="32" rx="10"/>
    <rect x="581"
-         y="111"
+         y="155"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="591" y="131">)</text>
-   <rect x="353" y="247" width="62" height="32" rx="10"/>
+   <text class="terminal" x="591" y="175">)</text>
+   <rect x="353" y="291" width="62" height="32" rx="10"/>
    <rect x="351"
-         y="245"
+         y="289"
          width="62"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="361" y="265">AS OF</text>
-   <rect x="435" y="247" width="168" height="32"/>
-   <rect x="433" y="245" width="168" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="443" y="265">timestamp_expression</text>
+   <text class="terminal" x="361" y="309">AS OF</text>
+   <rect x="435" y="291" width="168" height="32"/>
+   <rect x="433" y="289" width="168" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="443" y="309">timestamp_expression</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m52 0 h10 m0 0 h10 m104 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-226 110 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m0 0 h68 m-98 0 h20 m78 0 h20 m-118 0 q10 0 10 10 m98 0 q0 -10 10 -10 m-108 10 v12 m98 0 v-12 m-98 12 q0 10 10 10 m78 0 q10 0 10 -10 m-88 10 h10 m58 0 h10 m20 -32 h10 m26 0 h10 m20 0 h10 m104 0 h10 m20 0 h10 m0 0 h160 m-190 0 h20 m170 0 h20 m-210 0 q10 0 10 10 m190 0 q0 -10 10 -10 m-200 10 v12 m190 0 v-12 m-190 12 q0 10 10 10 m170 0 q10 0 10 -10 m-180 10 h10 m28 0 h10 m0 0 h10 m102 0 h10 m-334 -32 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m334 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-334 0 h10 m24 0 h10 m0 0 h290 m20 44 h10 m26 0 h10 m-604 0 h20 m584 0 h20 m-624 0 q10 0 10 10 m604 0 q0 -10 10 -10 m-614 10 v46 m604 0 v-46 m-604 46 q0 10 10 10 m584 0 q10 0 10 -10 m-594 10 h10 m0 0 h574 m22 -66 l2 0 m2 0 l2 0 m2 0 l2 0 m-340 102 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h260 m-290 0 h20 m270 0 h20 m-310 0 q10 0 10 10 m290 0 q0 -10 10 -10 m-300 10 v12 m290 0 v-12 m-290 12 q0 10 10 10 m270 0 q10 0 10 -10 m-280 10 h10 m62 0 h10 m0 0 h10 m168 0 h10 m23 -32 h-3"/>
-   <polygon points="641 229 649 225 649 233"/>
-   <polygon points="641 229 633 225 633 233"/>
+         d="m17 17 h2 m0 0 h10 m52 0 h10 m20 0 h10 m104 0 h10 m0 0 h84 m-228 0 h20 m208 0 h20 m-248 0 q10 0 10 10 m228 0 q0 -10 10 -10 m-238 10 v24 m228 0 v-24 m-228 24 q0 10 10 10 m208 0 q10 0 10 -10 m-218 10 h10 m26 0 h10 m0 0 h10 m96 0 h10 m0 0 h10 m26 0 h10 m22 -44 l2 0 m2 0 l2 0 m2 0 l2 0 m-350 154 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m0 0 h68 m-98 0 h20 m78 0 h20 m-118 0 q10 0 10 10 m98 0 q0 -10 10 -10 m-108 10 v12 m98 0 v-12 m-98 12 q0 10 10 10 m78 0 q10 0 10 -10 m-88 10 h10 m58 0 h10 m20 -32 h10 m26 0 h10 m20 0 h10 m104 0 h10 m20 0 h10 m0 0 h160 m-190 0 h20 m170 0 h20 m-210 0 q10 0 10 10 m190 0 q0 -10 10 -10 m-200 10 v12 m190 0 v-12 m-190 12 q0 10 10 10 m170 0 q10 0 10 -10 m-180 10 h10 m28 0 h10 m0 0 h10 m102 0 h10 m-334 -32 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m334 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-334 0 h10 m24 0 h10 m0 0 h290 m20 44 h10 m26 0 h10 m-604 0 h20 m584 0 h20 m-624 0 q10 0 10 10 m604 0 q0 -10 10 -10 m-614 10 v46 m604 0 v-46 m-604 46 q0 10 10 10 m584 0 q10 0 10 -10 m-594 10 h10 m0 0 h574 m22 -66 l2 0 m2 0 l2 0 m2 0 l2 0 m-340 102 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h260 m-290 0 h20 m270 0 h20 m-310 0 q10 0 10 10 m290 0 q0 -10 10 -10 m-300 10 v12 m290 0 v-12 m-290 12 q0 10 10 10 m270 0 q10 0 10 -10 m-280 10 h10 m62 0 h10 m0 0 h10 m168 0 h10 m23 -32 h-3"/>
+   <polygon points="641 273 649 269 649 277"/>
+   <polygon points="641 273 633 269 633 277"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -434,7 +434,8 @@ table_ref ::=
     | '(' join_expr ')'
   ) ('AS'? table_alias ('(' col_alias (',' col_alias)* ')'))?
 tail_stmt ::=
-    'TAIL' object_name
+    'TAIL'
+    ( object_name | '(' select_stmt ')' )
     ( 'WITH'? '(' (option_name ('=' option_value)?) ( ',' (option_name ('=' option_value)?) )* ')' )?
     ('AS OF' timestamp_expression)?
 time_unit ::=

--- a/src/coord/src/tail.rs
+++ b/src/coord/src/tail.rs
@@ -24,23 +24,23 @@ pub(crate) struct PendingTail {
     /// Whether progress information should be emitted
     emit_progress: bool,
     /// Number of columns in the output
-    object_columns: usize,
+    arity: usize,
 }
 
 impl PendingTail {
     /// Create a new [PendingTail].
     /// * The `channel` receives batches of finalized rows.
     /// * If `emit_progress` is true, the finalized rows are either data or progress updates
-    /// * `object_columns` is the arity of the sink relation.
+    /// * `arity` is the arity of the sink relation.
     pub(crate) fn new(
         channel: mpsc::UnboundedSender<Vec<Row>>,
         emit_progress: bool,
-        object_columns: usize,
+        arity: usize,
     ) -> Self {
         Self {
             channel,
             emit_progress,
-            object_columns,
+            arity,
         }
     }
 
@@ -60,7 +60,7 @@ impl PendingTail {
                     packer.push(Datum::from(numeric::Numeric::from(*&upper[0])));
                     packer.push(Datum::True);
                     // Fill in the diff column and all table columns with NULL.
-                    for _ in 0..(self.object_columns + 1) {
+                    for _ in 0..(self.arity + 1) {
                         packer.push(Datum::Null);
                     }
                     let row = packer.finish_and_reuse();

--- a/src/sql-parser/src/ast/defs/query.rs
+++ b/src/sql-parser/src/ast/defs/query.rs
@@ -150,6 +150,16 @@ impl<T: AstInfo> Query<T> {
         }
     }
 
+    pub fn query(query: Query<T>) -> Query<T> {
+        Query {
+            ctes: vec![],
+            body: SetExpr::Query(Box::new(query)),
+            order_by: vec![],
+            limit: None,
+            offset: None,
+        }
+    }
+
     pub fn take(&mut self) -> Query<T> {
         mem::replace(
             self,

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1262,7 +1262,7 @@ impl_display!(RollbackStatement);
 /// `TAIL`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TailStatement<T: AstInfo> {
-    pub name: UnresolvedObjectName,
+    pub relation: TailRelation<T>,
     pub options: Vec<WithOption>,
     pub as_of: Option<Expr<T>>,
 }
@@ -1270,7 +1270,7 @@ pub struct TailStatement<T: AstInfo> {
 impl<T: AstInfo> AstDisplay for TailStatement<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("TAIL ");
-        f.write_node(&self.name);
+        f.write_node(&self.relation);
         if !self.options.is_empty() {
             f.write_str(" WITH (");
             f.write_node(&display::comma_separated(&self.options));
@@ -1283,6 +1283,26 @@ impl<T: AstInfo> AstDisplay for TailStatement<T> {
     }
 }
 impl_display_t!(TailStatement);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum TailRelation<T: AstInfo> {
+    Name(UnresolvedObjectName),
+    Query(Query<T>),
+}
+
+impl<T: AstInfo> AstDisplay for TailRelation<T> {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        match self {
+            TailRelation::Name(name) => f.write_node(&name),
+            TailRelation::Query(query) => {
+                f.write_str("(");
+                f.write_node(query);
+                f.write_str(")");
+            }
+        }
+    }
+}
+impl_display_t!(TailRelation);
 
 /// `EXPLAIN ...`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -4267,11 +4267,17 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_tail(&mut self) -> Result<Statement<Raw>, ParserError> {
-        let name = self.parse_object_name()?;
+        let relation = if self.consume_token(&Token::LParen) {
+            let query = self.parse_query()?;
+            self.expect_token(&Token::RParen)?;
+            TailRelation::Query(query)
+        } else {
+            TailRelation::Name(self.parse_object_name()?)
+        };
         let options = self.parse_opt_with_options()?;
         let as_of = self.parse_optional_as_of()?;
         Ok(Statement::Tail(TailStatement {
-            name,
+            relation,
             options,
             as_of,
         }))

--- a/src/sql-parser/tests/testdata/cursor
+++ b/src/sql-parser/tests/testdata/cursor
@@ -25,7 +25,7 @@ DECLARE c CURSOR FOR TAIL t
 ----
 DECLARE c CURSOR FOR TAIL t
 =>
-Declare(DeclareStatement { name: Ident("c"), stmt: Tail(TailStatement { name: UnresolvedObjectName([Ident("t")]), options: [], as_of: None }) })
+Declare(DeclareStatement { name: Ident("c"), stmt: Tail(TailStatement { relation: Name(UnresolvedObjectName([Ident("t")])), options: [], as_of: None }) })
 
 parse-statement
 CLOSE c

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1047,35 +1047,35 @@ TAIL foo.bar
 ----
 TAIL foo.bar
 =>
-Tail(TailStatement { name: UnresolvedObjectName([Ident("foo"), Ident("bar")]), options: [], as_of: None })
+Tail(TailStatement { relation: Name(UnresolvedObjectName([Ident("foo"), Ident("bar")])), options: [], as_of: None })
 
 parse-statement
 TAIL foo.bar AS OF 123
 ----
 TAIL foo.bar AS OF 123
 =>
-Tail(TailStatement { name: UnresolvedObjectName([Ident("foo"), Ident("bar")]), options: [], as_of: Some(Value(Number("123"))) })
+Tail(TailStatement { relation: Name(UnresolvedObjectName([Ident("foo"), Ident("bar")])), options: [], as_of: Some(Value(Number("123"))) })
 
 parse-statement
 TAIL foo.bar AS OF now()
 ----
 TAIL foo.bar AS OF now()
 =>
-Tail(TailStatement { name: UnresolvedObjectName([Ident("foo"), Ident("bar")]), options: [], as_of: Some(Function(Function { name: UnresolvedObjectName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false })) })
+Tail(TailStatement { relation: Name(UnresolvedObjectName([Ident("foo"), Ident("bar")])), options: [], as_of: Some(Function(Function { name: UnresolvedObjectName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false })) })
 
 parse-statement
 TAIL foo.bar WITH (SNAPSHOT) AS OF now()
 ----
 TAIL foo.bar WITH (snapshot) AS OF now()
 =>
-Tail(TailStatement { name: UnresolvedObjectName([Ident("foo"), Ident("bar")]), options: [WithOption { key: Ident("snapshot"), value: None }], as_of: Some(Function(Function { name: UnresolvedObjectName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false })) })
+Tail(TailStatement { relation: Name(UnresolvedObjectName([Ident("foo"), Ident("bar")])), options: [WithOption { key: Ident("snapshot"), value: None }], as_of: Some(Function(Function { name: UnresolvedObjectName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false })) })
 
 parse-statement
 TAIL foo.bar WITH (SNAPSHOT = false, TIMESTAMPS) AS OF now()
 ----
 TAIL foo.bar WITH (snapshot = false, timestamps) AS OF now()
 =>
-Tail(TailStatement { name: UnresolvedObjectName([Ident("foo"), Ident("bar")]), options: [WithOption { key: Ident("snapshot"), value: Some(Value(Boolean(false))) }, WithOption { key: Ident("timestamps"), value: None }], as_of: Some(Function(Function { name: UnresolvedObjectName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false })) })
+Tail(TailStatement { relation: Name(UnresolvedObjectName([Ident("foo"), Ident("bar")])), options: [WithOption { key: Ident("snapshot"), value: Some(Value(Boolean(false))) }, WithOption { key: Ident("timestamps"), value: None }], as_of: Some(Function(Function { name: UnresolvedObjectName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false })) })
 
 parse-statement
 TAIL foo.bar WITH (SNAPSHOT false)
@@ -1083,6 +1083,13 @@ TAIL foo.bar WITH (SNAPSHOT false)
 error: Expected equals sign, found FALSE
 TAIL foo.bar WITH (SNAPSHOT false)
                             ^
+
+parse-statement
+TAIL (SELECT * FROM a)
+----
+TAIL (SELECT * FROM a)
+=>
+Tail(TailStatement { relation: Query(Query { ctes: [], body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("a")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }), options: [], as_of: None })
 
 parse-statement
 CREATE TABLE public.customer (

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -33,7 +33,7 @@ use chrono::{DateTime, Utc};
 use enum_kinds::EnumKind;
 use serde::{Deserialize, Serialize};
 
-use ::expr::{GlobalId, RowSetFinishing};
+use ::expr::{GlobalId, MirRelationExpr, RowSetFinishing};
 use dataflow_types::{sinks::SinkConnectorBuilder, sinks::SinkEnvelope, sources::SourceConnector};
 use ore::now::{self, NOW_ZERO};
 use repr::{ColumnName, Diff, RelationDesc, Row, ScalarType, Timestamp};
@@ -228,7 +228,7 @@ pub struct SetVariablePlan {
 
 #[derive(Debug)]
 pub struct PeekPlan {
-    pub source: ::expr::MirRelationExpr,
+    pub source: MirRelationExpr,
     pub when: PeekWhen,
     pub finishing: RowSetFinishing,
     pub copy_to: Option<CopyFormat>,
@@ -236,12 +236,21 @@ pub struct PeekPlan {
 
 #[derive(Debug)]
 pub struct TailPlan {
-    pub id: GlobalId,
+    pub from: TailFrom,
     pub with_snapshot: bool,
     pub ts: Option<Timestamp>,
     pub copy_to: Option<CopyFormat>,
     pub emit_progress: bool,
-    pub object_columns: usize,
+}
+
+#[derive(Debug)]
+pub enum TailFrom {
+    Id(GlobalId),
+    Query {
+        expr: MirRelationExpr,
+        desc: RelationDesc,
+        depends_on: Vec<GlobalId>,
+    },
 }
 
 #[derive(Debug)]

--- a/test/testdrive/fetch-tail-query.td
+++ b/test/testdrive/fetch-tail-query.td
@@ -1,0 +1,67 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test that non-views can be used in TAIL.
+
+$ set-regex match=\d{13} replacement=<TIMESTAMP>
+
+> CREATE TABLE t1 (f1 INTEGER);
+
+> INSERT INTO t1 VALUES (123);
+
+> BEGIN
+
+> DECLARE c CURSOR FOR TAIL (SELECT * FROM t1)
+
+> FETCH ALL c
+<TIMESTAMP> 1 123
+
+> COMMIT
+
+> TAIL (WITH a(x) AS (SELECT 'a') SELECT generate_series(1, 2), x FROM a)
+0 1 1 a
+0 1 2 a
+
+> CREATE MATERIALIZED VIEW v1 AS SELECT count(*) FROM t1
+
+> CREATE VIEW v2 AS SELECT 3
+
+> BEGIN
+
+> DECLARE c CURSOR FOR TAIL (SELECT * FROM v1, v2)
+
+> FETCH ALL c
+<TIMESTAMP> 1 1 3
+
+> COMMIT
+
+# Verify TAIL behavior when the query includes an ORDER BY and a LIMIT.
+
+# Check that the initial output of the TAIL is correct.
+> BEGIN
+> DECLARE c CURSOR FOR TAIL (SELECT * FROM t1 ORDER BY 1 DESC LIMIT 1)
+> FETCH ALL c
+<TIMESTAMP> 1 123
+
+# Insert a value from another connection that is not a new maximum.
+$ postgres-connect name=alt url=postgres://materialize:materialize@${testdrive.materialized-addr}
+$ postgres-execute connection=alt
+INSERT INTO t1 VALUES (100)
+
+# Verify that the TAIL does not emit any updates.
+> FETCH ALL c WITH (timeout = '100ms')
+
+# Insert a value from another connection that *is* a new maximum.
+$ postgres-execute connection=alt
+INSERT INTO t1 VALUES (124)
+
+# Verify that the TAIL emits the new maximum.
+> FETCH ALL c
+<TIMESTAMP> -1 123
+<TIMESTAMP> 1 124


### PR DESCRIPTION
Implement by creating a temporary view then TAILing that. These views
are normal temp views and so are cleaned up when the session ends,
not when the transaction ends. This will slowly pollute the catalog
if connections are pooled and sessions are long lived. However this is
already what some users are doing, so it's fine for now.

Unexplored yet if it's possible to drop the views at txn end due to how
catalog_transact works (and thus could error).

Fixes #5484

### Motivation

  * This PR adds a known-desirable feature: #5484

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
