### PR TITLE
Hold back source frontiers to durable bindings

### DIFF
--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -638,10 +638,6 @@ where
         // If that frontier is different than the durability frontier we've previously reported then we also need to
         // get the new bindings we've produced and send them to the coordinator.
         for (id, history) in self.storage_state.ts_histories.iter() {
-            if !history.requires_persistence() {
-                continue;
-            }
-
             // Read the upper frontier and compare to what we've reported.
             history.read_upper(&mut new_frontier);
             let prev_frontier = self

--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -18,7 +18,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{anyhow, bail, Context};
-use differential_dataflow::lattice::Lattice;
 use differential_dataflow::{AsCollection, Collection, Hashable};
 use futures::{StreamExt, TryFutureExt};
 use interchange::json::JsonEncoder;
@@ -61,7 +60,6 @@ use timely_util::operators_async_ext::OperatorBuilderExt;
 
 use super::{KafkaBaseMetrics, SinkBaseMetrics};
 use crate::render::sinks::SinkRender;
-use crate::source::timestamp::TimestampBindingRc;
 use prometheus::core::{AtomicI64, AtomicU64};
 
 impl<G> SinkRender<G> for KafkaSinkConnector
@@ -113,24 +111,6 @@ where
             sinked_collection
         };
 
-        // Extract handles to the relevant source timestamp histories the sink
-        // needs to hear from before it can write data out to Kafka.
-        let mut source_ts_histories = Vec::new();
-
-        for id in &self.transitive_source_dependencies {
-            if let Some(history) = storage_state.ts_histories.get(id) {
-                // As soon as we have one sink that depends on a given source,
-                // that source needs to persist timestamp bindings.
-                history.enable_persistence();
-
-                let mut history_bindings = history.clone();
-                // We don't want these to block compaction
-                // ever.
-                history_bindings.set_compaction_frontier(Antichain::new().borrow());
-                source_ts_histories.push(history_bindings);
-            }
-        }
-
         // TODO: this is a brittle way to indicate the worker that will write to the sink
         // because it relies on us continuing to hash on the sink_id, with the same hash
         // function, and for the Exchange pact to continue to distribute by modulo number
@@ -158,7 +138,6 @@ where
                 .map(|(desc, _indices)| desc),
             self.value_desc.clone(),
             sink.as_of.clone(),
-            source_ts_histories,
             Rc::clone(&shared_frontier),
             &metrics.kafka,
         );
@@ -970,7 +949,6 @@ fn kafka<G>(
     key_desc: Option<RelationDesc>,
     value_desc: RelationDesc,
     as_of: SinkAsOf,
-    source_timestamp_histories: Vec<TimestampBindingRc>,
     write_frontier: Rc<RefCell<Antichain<Timestamp>>>,
     metrics: &KafkaBaseMetrics,
 ) -> Box<dyn Any>
@@ -1025,7 +1003,6 @@ where
         connector,
         as_of,
         shared_gate_ts,
-        source_timestamp_histories,
         write_frontier,
         metrics,
     )
@@ -1049,7 +1026,6 @@ pub fn produce_to_kafka<G>(
     connector: KafkaSinkConnector,
     as_of: SinkAsOf,
     shared_gate_ts: Rc<Cell<Option<Timestamp>>>,
-    source_timestamp_histories: Vec<TimestampBindingRc>,
     write_frontier: Rc<RefCell<Antichain<Timestamp>>>,
     metrics: &KafkaBaseMetrics,
 ) -> Box<dyn Any>
@@ -1107,13 +1083,6 @@ where
             }
             // Panic if there's not exactly once element in the frontier like we expect.
             let frontier = frontiers.clone().into_element();
-
-            // Figure out the durablity frontier for all sources we depend on
-            let durability_frontier = source_timestamp_histories
-                .iter()
-                .fold(Antichain::new(), |accum, history| {
-                    accum.meet(&history.durability_frontier())
-                });
 
             // Can't use `?` when the return type is a `bool` so use a custom try operator
             macro_rules! bail_err {
@@ -1195,7 +1164,7 @@ where
             let mut closed_ts: Vec<u64> = s
                 .pending_rows
                 .iter()
-                .filter(|(ts, _)| !frontier.less_equal(*ts) && !durability_frontier.less_equal(*ts))
+                .filter(|(ts, _)| !frontier.less_equal(*ts))
                 .map(|(&ts, _)| ts)
                 .collect();
             closed_ts.sort_unstable();

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -850,12 +850,14 @@ where
 
         move |cap,
               _secondary_cap: &mut Capability<Timestamp>,
-              _durability_cap: &mut CapabilitySet<Timestamp>,
+              durability_cap: &mut CapabilitySet<Timestamp>,
               output,
               _secondary_output: &mut OutputHandle<Timestamp, (), _>| {
             if !active {
                 return SourceStatus::Done;
             }
+
+            durability_cap.downgrade(Vec::<Timestamp>::new());
 
             let waker = futures::task::waker_ref(&activator);
             let mut context = Context::from_waker(&waker);
@@ -1163,8 +1165,6 @@ where
             };
 
             // Maintain a capability set that tracks the durability frontier.
-            // This may initially *exceed* the durability frontier, so we
-            // must be careful attempting to downgrade it.
             durability_cap.downgrade(timestamp_histories.durability_frontier());
 
             // NOTE: It's **very** important that we get out any necessary

--- a/src/dataflow/src/source/timestamp.rs
+++ b/src/dataflow/src/source/timestamp.rs
@@ -267,8 +267,6 @@ pub struct TimestampBindingBox {
     durability_frontier: Antichain<Timestamp>,
     /// Generates new timestamps for RT sources
     proposer: TimestampProposer,
-    /// Whether or not these timestamp bindings need to be persisted.
-    requires_persistence: bool,
 }
 
 impl TimestampBindingBox {
@@ -279,7 +277,6 @@ impl TimestampBindingBox {
             compaction_frontier: MutableAntichain::new_bottom(TimelyTimestamp::minimum()),
             durability_frontier: Antichain::from_elem(TimelyTimestamp::minimum()),
             proposer: TimestampProposer::new(timestamp_update_interval, now),
-            requires_persistence: false,
         }
     }
 
@@ -561,16 +558,6 @@ impl TimestampBindingRc {
     /// Returns the current durability frontier
     pub fn durability_frontier(&self) -> Antichain<Timestamp> {
         self.wrapper.borrow().durability_frontier.clone()
-    }
-
-    /// Whether or not these timestamp bindings must be persisted.
-    pub fn requires_persistence(&self) -> bool {
-        self.wrapper.borrow().requires_persistence
-    }
-
-    /// Enables persistence for these bindings.
-    pub fn enable_persistence(&self) {
-        self.wrapper.borrow_mut().requires_persistence = true;
     }
 }
 

--- a/src/dataflow/src/source/timestamp.rs
+++ b/src/dataflow/src/source/timestamp.rs
@@ -267,6 +267,8 @@ pub struct TimestampBindingBox {
     durability_frontier: Antichain<Timestamp>,
     /// Generates new timestamps for RT sources
     proposer: TimestampProposer,
+    /// Source operators that should be activated on durability changes.
+    pub activators: Vec<timely::scheduling::Activator>,
 }
 
 impl TimestampBindingBox {
@@ -277,6 +279,7 @@ impl TimestampBindingBox {
             compaction_frontier: MutableAntichain::new_bottom(TimelyTimestamp::minimum()),
             durability_frontier: Antichain::from_elem(TimelyTimestamp::minimum()),
             proposer: TimestampProposer::new(timestamp_update_interval, now),
+            activators: Vec::new(),
         }
     }
 
@@ -299,6 +302,9 @@ impl TimestampBindingBox {
             new_frontier
         );
         self.durability_frontier = new_frontier.to_owned();
+        for activator in self.activators.iter() {
+            activator.activate();
+        }
     }
 
     fn compact(&mut self) {
@@ -424,7 +430,8 @@ impl TimestampBindingBox {
 /// and hold back its compaction.
 #[derive(Debug)]
 pub struct TimestampBindingRc {
-    wrapper: Rc<RefCell<TimestampBindingBox>>,
+    /// The wrapped shared state.
+    pub wrapper: Rc<RefCell<TimestampBindingBox>>,
     compaction_frontier: Antichain<Timestamp>,
 }
 

--- a/test/testdrive/shared-timestamp-bindings.td
+++ b/test/testdrive/shared-timestamp-bindings.td
@@ -50,7 +50,7 @@ $ kafka-ingest format=avro topic=data partition=3 schema=${schema}
 
 > CREATE MATERIALIZED SOURCE direct_source1
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
-  WITH (timestamp_frequency_ms = 1)
+  WITH (timestamp_frequency_ms = 90)
   FORMAT AVRO USING SCHEMA '${schema}';
 
 > CREATE MATERIALIZED SOURCE direct_source2


### PR DESCRIPTION
Re-attempt at causing sources to hold back their presented frontier to that of durable timestamp bindings. The implementation introduces a new `CapabilitySet` that tracks the durability frontier.

This does not change the capabilities used for sending messages, which advance using whatever logic they used previously. However, the additional held capabilities will prevent the downstream operators from treating times greater or equal to the durability frontier as complete.

The sequence of subsequent commits learn a bit more about what we need to do beyond this, including
1. Teach `TimestampBindingBox` to activate operators, because durability frontier changes are reasons to need to run operators that might not otherwise run again.
2. Place the new `CapabilitySet` in the `SourceToken` so that it can be forcibly dropped like the other capabilities
3. Revisit `create_simple_source` which needs to discard the capability as it receives no timestamp bindings.
4. Dial down the timestamp frequency from 1ms to .. 90ms is what I chose .. for a test that ends up CPU pegged.

In each case, things get a bit messier, but in ways that felt unavoidable (as in, the system needs to learn to do them eventually). We may be able to tidy things up, and I have some thoughts on that.

The intent here is to decouple sources and sinks, by introducing the timely frontier as the definite frontier, which allows them to agree on what they are seeing without external coordination. Going forward each can maintain this property, but can evolve their implementations as benefits them.