### PR TITLE
Unify source durability and upper frontiers

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -30,8 +30,7 @@
 //! the frontier when being added to [`txn_reads`](Coordinator::txn_reads). The
 //! compaction frontier may change when a transaction ends (if it was the oldest
 //! transaction and the since was advanced after the transaction started) or
-//! when [`update_index_upper()`](Coordinator::update_index_upper) or
-//! [`update_storage_upper`](Coordinator::update_storage_upper) is run (if there
+//! when [`update_upper()`](Coordinator::update_upper) is run (if there
 //! are no in progress transactions before the new since). When it does, it is
 //! added to [`index_since_updates`](Coordinator::index_since_updates) or
 //! [`source_since_updates`](Coordinator::source_since_updates) and will be
@@ -872,7 +871,7 @@ impl Coordinator {
             }
             DataflowResponse::Compute(ComputeResponse::FrontierUppers(updates)) => {
                 for (name, changes) in updates {
-                    self.update_index_upper(&name, changes);
+                    self.update_upper(&name, changes);
                 }
                 self.maintenance().await;
             }
@@ -1402,8 +1401,8 @@ impl Coordinator {
         frontier_changes
     }
 
-    /// Updates the upper frontier of a named view.
-    fn update_index_upper(&mut self, name: &GlobalId, changes: ChangeBatch<Timestamp>) {
+    /// Updates the upper frontier of a maintained arrangement or sink.
+    fn update_upper(&mut self, name: &GlobalId, changes: ChangeBatch<Timestamp>) {
         if let Some(index_state) = self.indexes.get_mut(name) {
             let changes = Self::validate_update_iter(&mut index_state.upper, changes);
 

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -876,12 +876,6 @@ impl Coordinator {
                 }
                 self.maintenance().await;
             }
-            DataflowResponse::Storage(StorageResponse::Frontiers(updates)) => {
-                for (name, changes) in updates {
-                    self.update_storage_upper(&name, changes);
-                }
-                self.maintenance().await;
-            }
             DataflowResponse::Storage(StorageResponse::TimestampBindings(
                 TimestampBindingFeedback { bindings, changes },
             )) => {
@@ -898,45 +892,40 @@ impl Coordinator {
                     if let Some(source_state) = self.sources.get_mut(&source_id) {
                         // Apply the updates the dataflow worker sent over, and check if there
                         // were any changes to the source's upper frontier.
-                        let changes: Vec<_> = source_state
-                            .durability
-                            .update_iter(changes.drain())
-                            .collect();
+                        let changes: Vec<_> =
+                            source_state.upper.update_iter(changes.drain()).collect();
 
                         if !changes.is_empty() {
                             // The source's durability frontier changed as a result of the updates sent over
                             // by the dataflow workers. Advance the durability frontier known to the dataflow worker
                             // to indicate that these bindings have been persisted.
                             durability_updates
-                                .push((source_id, source_state.durability.frontier().to_owned()));
+                                .push((source_id, source_state.upper.frontier().to_owned()));
+
+                            // Allow compaction to advance.
+                            if let Some(compaction_window_ms) = source_state.compaction_window_ms {
+                                if !source_state.upper.frontier().is_empty() {
+                                    self.since_handles
+                                        .get_mut(&source_id)
+                                        .unwrap()
+                                        .maybe_advance(source_state.upper.frontier().iter().map(
+                                            |time| {
+                                                compaction_window_ms
+                                                    * (time.saturating_sub(compaction_window_ms)
+                                                        / compaction_window_ms)
+                                            },
+                                        ));
+                                }
+                            }
                         }
 
                         // Let's also check to see if we can compact any of the bindings we've received.
-                        let compaction_ts = if <_ as PartialOrder>::less_equal(
-                            &source_state.since.borrow().frontier(),
-                            &source_state.durability.frontier(),
-                        ) {
-                            // In this case we have persisted ahead of the compaction frontier and can safely compact
-                            // up to it
-                            *source_state
-                                .since
-                                .borrow()
-                                .frontier()
-                                .first()
-                                .expect("known to exist")
-                        } else {
-                            // Otherwise, the compaction frontier is ahead of what we've persisted so far, but we can
-                            // still potentially compact up whatever we have persisted to this point.
-                            // Note that we have to subtract from the durability frontier because it functions as the
-                            // least upper bound of whats been persisted, and we decline to compact up to the empty
-                            // frontier.
-                            source_state
-                                .durability
-                                .frontier()
-                                .first()
-                                .unwrap_or(&0)
-                                .saturating_sub(1)
-                        };
+                        let compaction_ts = *source_state
+                            .since
+                            .borrow()
+                            .frontier()
+                            .first()
+                            .expect("known to exist");
 
                         self.catalog
                             .compact_timestamp_bindings(source_id, compaction_ts)
@@ -1449,40 +1438,9 @@ impl Coordinator {
             }
         } else if self.sources.get_mut(name).is_some() {
             panic!(
-                "expected an update for an index, instead got update for source {}",
+                "expected an update for an index or sink, instead got update for source {}",
                 name
             );
-        } else if self.sink_writes.get_mut(name).is_some() {
-            panic!(
-                "expected an update for an index, instead got update for sink {}",
-                name
-            );
-        }
-    }
-
-    /// Updates the upper frontier of a named source or sink.
-    fn update_storage_upper(&mut self, name: &GlobalId, changes: ChangeBatch<Timestamp>) {
-        if self.indexes.get_mut(name).is_some() {
-            panic!(
-                "expected an update for a source or a sink, instead got update for index {}",
-                name
-            );
-        } else if let Some(source_state) = self.sources.get_mut(name) {
-            let changes = Self::validate_update_iter(&mut source_state.upper, changes);
-
-            if !changes.is_empty() {
-                if let Some(compaction_window_ms) = source_state.compaction_window_ms {
-                    if !source_state.upper.frontier().is_empty() {
-                        self.since_handles.get_mut(name).unwrap().maybe_advance(
-                            source_state.upper.frontier().iter().map(|time| {
-                                compaction_window_ms
-                                    * (time.saturating_sub(compaction_window_ms)
-                                        / compaction_window_ms)
-                            }),
-                        );
-                    }
-                }
-            }
         } else if let Some(sink_state) = self.sink_writes.get_mut(name) {
             // Only one dataflow worker should give updates for sinks
             let changes = Self::validate_update_iter(&mut sink_state.frontier, changes);

--- a/src/coord/src/coord/arrangement_state.rs
+++ b/src/coord/src/coord/arrangement_state.rs
@@ -110,10 +110,6 @@ pub struct Frontiers<T: Timestamp> {
     /// The most recent frontier for new data.
     /// All further changes will be in advance of this bound.
     pub upper: MutableAntichain<T>,
-    /// The most recent frontier for durable data.
-    /// All data at times in advance of this frontier have not yet been
-    /// durably persisted and may not be replayable across restarts.
-    pub durability: MutableAntichain<T>,
     /// The compaction frontier.
     /// All peeks in advance of this frontier will be correct,
     /// but peeks not in advance of this frontier may not be.
@@ -144,10 +140,8 @@ impl<T: Timestamp + Copy> Frontiers<T> {
         // Upper must always start at minimum ("0"), even if we initialize since to
         // something in advance of it.
         upper.update_iter(Some((T::minimum(), 1)));
-        let durability = upper.clone();
         let frontier = Self {
             upper,
-            durability,
             since: Rc::new(RefCell::new(MutableAntichain::new())),
             compaction_window_ms,
             since_action: Rc::new(RefCell::new(since_action)),

--- a/src/dataflow-types/src/client/controller.rs
+++ b/src/dataflow-types/src/client/controller.rs
@@ -9,9 +9,7 @@
 
 //! A client that maintains summaries of the involved objects.
 
-use crate::client::{
-    Client, Command, ComputeCommand, ComputeResponse, Response, StorageCommand, StorageResponse,
-};
+use crate::client::{Client, Command, ComputeCommand, ComputeResponse, Response, StorageCommand};
 use expr::GlobalId;
 use repr::Timestamp;
 use timely::progress::{frontier::AntichainRef, Antichain, ChangeBatch};
@@ -158,11 +156,6 @@ impl<C: Client> Controller<C> {
                 Response::Compute(ComputeResponse::FrontierUppers(updates)) => {
                     for (id, changes) in updates.iter() {
                         self.compute_since_uppers.update_upper_for(*id, changes);
-                    }
-                }
-                Response::Storage(StorageResponse::Frontiers(updates)) => {
-                    for (id, changes) in updates.iter() {
-                        self.storage_since_uppers.update_upper_for(*id, changes);
                     }
                 }
                 _ => {}


### PR DESCRIPTION
This PR unifies the concepts of a durable frontier and an upper frontier for sources. Sources do not report frontiers other than their durable frontier, along with the information that should be made durable to make this the case.

Many minor changes fall out of this, with a few more cosmetic changes planned. Sinks present more like indexes (with compute frontiers, rather than storage frontiers; makes sense as compute hosts them). No storage response for frontiers any more. Special cases to handle `TimestampFeedback` were folded in what had previously managed source upper frontiers.

The only intended functional change is that source upper reports no longer occur, and source compaction is held back by their replacement, the durability frontier. As source compaction is only meant to affect sources with durable bindings, this isn't meant to have an effect other than less brisk compaction for durable sources.

### Motivation

The distinction between these two frontiers was unclear. Source compaction and durability fought in an unclear way that presented as data that might be never both durable and correct (i.e. not compacted).

While it is possible and reasonable to track both of these frontiers, especially in pursuit of optimistic concurrency control (e.g. starting DD computations on non-durable data, and holding back outputs only at the boundaries), we are working to simply assumptions at the moment, and can certainly put this back in when our ducks are more orderly.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
