### PR TITLE
stash: introduce new abstraction for persistent metadata storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1919,9 +1919,9 @@ checksum = "95765f67b4b18863968b4a1bd5bb576f732b29a4a28c7cd84c09fa3e2875f33c"
 
 [[package]]
 name = "fastrand"
-version = "1.5.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b394ed3d285a429378d3b384b9eb1285267e7df4b166df24b7a6939a04dc392e"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
 dependencies = [
  "instant",
 ]
@@ -3387,6 +3387,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "mz-stash"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "differential-dataflow",
+ "persist-types",
+ "rusqlite",
+ "tempfile",
+ "timely",
+ "timely-util",
+]
+
+[[package]]
 name = "mzcloud"
 version = "1.0.0"
 source = "git+https://github.com/MaterializeInc/cloud-sdks#b7886468ceb9e76d1c4b9e0b1b82a957ddd2b1c8"
@@ -4624,9 +4637,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.4"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ec8ca9416c5ea37062b502703cd7fcb207736bc294f6e0cf367ac6fc234570"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
 ]
@@ -5372,13 +5385,13 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
  "cfg-if",
+ "fastrand",
  "libc",
- "rand",
  "redox_syscall",
  "remove_dir_all",
  "winapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ members = [
     "src/sql-parser",
     "src/sql",
     "src/sqllogictest",
+    "src/stash",
     "src/testdrive",
     "src/timely-util",
     "src/transform",

--- a/src/stash/Cargo.toml
+++ b/src/stash/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "mz-stash"
+description = "Durable metadata storage."
+version = "0.0.0"
+edition = "2021"
+publish = false
+rust-version = "1.58.0"
+
+[dependencies]
+differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow" }
+rusqlite = { version = "0.26.3", features = ["bundled"] }
+persist-types = { path = "../persist-types" }
+timely-util = { path = "../timely-util" }
+timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false }
+
+[dev-dependencies]
+anyhow = "1.0.53"
+tempfile = "3.3.0"

--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -1,0 +1,531 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Durable metadata storage.
+
+use std::cmp;
+use std::error::Error;
+use std::fmt;
+use std::iter;
+use std::marker::PhantomData;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use rusqlite::{named_params, params, Connection, Transaction};
+use timely::PartialOrder;
+
+use persist_types::Codec;
+use timely_util::antichain_ext::Max1Antichain;
+
+const APPLICATION_ID: i32 = 0x0872_e898; // chosen randomly
+
+const SCHEMA: &str = "
+CREATE TABLE collections (
+    collection_id integer PRIMARY KEY,
+    name text NOT NULL UNIQUE
+);
+
+CREATE TABLE data (
+    collection_id integer NOT NULL REFERENCES collections (collection_id),
+    key blob NOT NULL,
+    value blob NOT NULL,
+    time integer NOT NULL,
+    diff integer NOT NULL,
+    UNIQUE (collection_id, key, value, time)
+);
+
+CREATE INDEX data_time_idx ON data (collection_id, time);
+
+CREATE TABLE sinces (
+    collection_id NOT NULL UNIQUE REFERENCES collections (collection_id),
+    since integer
+);
+
+CREATE TABLE uppers (
+    collection_id NOT NULL UNIQUE REFERENCES collections (collection_id),
+    upper integer
+);
+";
+
+/// A durable metadata store.
+///
+/// A stash manages any number of named [`StashCollection`]s.
+///
+/// Data is stored in a single file on disk. The format of this file is not
+/// specified and should not be relied upon. The only promise is stability. Any
+/// changes to the on-disk format will be accompanied by a clear migration path.
+///
+/// A stash is designed to store only a small quantity of data. Think megabytes,
+/// not gigabytes.
+///
+/// The API of a stash intentionally mimics the API of a [STORAGE] collection.
+/// You can think of stash as a stable but very low performance STORAGE
+/// collection. When the STORAGE layer is stable enough to serve as a source of
+/// truth, the intent is to swap all stashes for STORAGE collections.
+///
+/// [STORAGE]: https://github.com/MaterializeInc/materialize/blob/main/doc/developer/platform/architecture-db.md#STORAGE
+pub struct Stash {
+    conn: Arc<Mutex<Connection>>,
+}
+
+impl Stash {
+    /// Opens the stash stored at the specified path.
+    pub fn open(path: &Path) -> Result<Stash, StashError> {
+        let mut conn = Connection::open(path)?;
+        let tx = conn.transaction()?;
+        let app_id: i32 = tx.query_row("PRAGMA application_id", params![], |row| row.get(0))?;
+        if app_id == 0 {
+            tx.execute_batch(&format!(
+                "PRAGMA application_id = {APPLICATION_ID};
+                 PRAGMA user_version = 1;"
+            ))?;
+            tx.execute_batch(SCHEMA)?;
+        } else if app_id != APPLICATION_ID {
+            return Err(StashError::from(format!(
+                "invalid application id: {}",
+                app_id
+            )));
+        }
+        tx.commit()?;
+        Ok(Stash {
+            conn: Arc::new(Mutex::new(conn)),
+        })
+    }
+
+    /// Loads or creates the named collection.
+    ///
+    /// If the collection with the specified name does not yet exist, it is
+    /// created with no entries, a zero since frontier, and a zero upper
+    /// frontier. Otherwise the existing durable state is loaded.
+    ///
+    /// It is the callers responsibility to keep `K` and `V` fixed for a given
+    /// collection in a given stash for the lifetime of the stash.
+    ///
+    /// It is valid to construct multiple handles to the same named collection
+    /// and use them simultaneously.
+    pub fn collection<K, V>(&self, name: &str) -> Result<StashCollection<K, V>, StashError>
+    where
+        K: Codec + Ord,
+        V: Codec + Ord,
+    {
+        let mut conn = self.conn.lock().expect("lock poisoned");
+        let tx = conn.transaction()?;
+        tx.execute(
+            "INSERT INTO collections (name) VALUES ($name) ON CONFLICT DO NOTHING",
+            named_params! {"$name": name},
+        )?;
+        let collection_id = tx.query_row(
+            "SELECT collection_id FROM collections WHERE name = $name",
+            named_params! {"$name": name},
+            |row| row.get("collection_id"),
+        )?;
+        tx.execute(
+            "INSERT INTO sinces (collection_id, since) VALUES ($collection_id, $since)
+             ON CONFLICT DO NOTHING",
+            named_params! {"$collection_id": collection_id, "$since": 0_i64},
+        )?;
+        tx.execute(
+            "INSERT INTO uppers (collection_id, upper) VALUES ($collection_id, $upper)
+             ON CONFLICT DO NOTHING",
+            named_params! {"$collection_id": collection_id, "$upper": 0_i64},
+        )?;
+        tx.commit()?;
+        Ok(StashCollection {
+            conn: Arc::clone(&self.conn),
+            collection_id,
+            _kv: PhantomData,
+        })
+    }
+}
+
+/// `StashCollection` is like a differential dataflow [`Collection`], but the
+/// state of the collection is durable.
+///
+/// A `StashCollection` stores `(key, value, timestamp, diff)` entries. The key
+/// and value types are chosen by the caller; they must implement [`Ord`] and
+/// they must be serializable to and deserializable from bytes via the [`Codec`]
+/// trait. The timestamp and diff types are fixed to `i64`.
+///
+/// A `StashCollection` maintains a since frontier and an upper frontier, as
+/// described in the [correctness vocabulary document]. To advance the since
+/// frontier, call [`compact`]. To advance the upper frontier, call [`seal`]. To
+/// physically compact data beneath the since frontier, call [`consolidate`].
+///
+/// [`compact`]: StashCollection::compact
+/// [`consolidate`]: StashCollection::consolidate
+/// [`seal`]: StashCollection::seal
+/// [correctness vocabulary document]: https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/20210831_correctness.md
+/// [`Collection`]: differential_dataflow::collection::Collection
+pub struct StashCollection<K, V>
+where
+    K: Codec + Ord,
+    V: Codec + Ord,
+{
+    conn: Arc<Mutex<Connection>>,
+    collection_id: i64,
+    _kv: PhantomData<(K, V)>,
+}
+
+impl<K, V> StashCollection<K, V>
+where
+    K: Codec + Ord,
+    V: Codec + Ord,
+{
+    /// Iterates over all entries in the stash.
+    ///
+    /// Entries are iterated in `(key, value, time)` order and are guaranteed
+    /// to be consolidated.
+    ///
+    /// Each entry's time is guaranteed to be greater than or equal to the since
+    /// frontier. The time may also be greater than the upper frontier,
+    /// indicating data that has not yet been made definite.
+    ///
+    /// [`consolidate`]: StashCollection::consolidate
+    /// [`update`]: StashCollection::update
+    /// [`update_many`]: StashCollection::update_many
+    pub fn iter(&self) -> Result<impl Iterator<Item = ((K, V), i64, i64)>, StashError> {
+        let mut conn = self.conn.lock().expect("lock poisoned");
+        let tx = conn.transaction()?;
+        let since = match self.since_tx(&tx)? {
+            Max1Antichain::Singular(since) => since,
+            Max1Antichain::Empty => {
+                return Err(StashError::from(
+                    "cannot iterate collection with empty since frontier",
+                ));
+            }
+        };
+        let mut rows = tx
+            .prepare(
+                "SELECT key, value, time, diff FROM data
+                 WHERE collection_id = $collection_id",
+            )?
+            .query_and_then(
+                named_params! {"$collection_id": self.collection_id},
+                |row| {
+                    let key_buf: Vec<_> = row.get("key")?;
+                    let value_buf: Vec<_> = row.get("value")?;
+                    let key = K::decode(&key_buf)?;
+                    let value = V::decode(&value_buf)?;
+                    let time = row.get("time")?;
+                    let diff = row.get("diff")?;
+                    Ok::<_, StashError>(((key, value), cmp::max(time, since), diff))
+                },
+            )?
+            .collect::<Result<Vec<_>, _>>()?;
+        differential_dataflow::consolidation::consolidate_updates(&mut rows);
+        Ok(rows.into_iter())
+    }
+
+    /// Iterates over entries in the stash for the given key.
+    ///
+    /// Entries are iterated in `(value, timestamp)` order and are guaranteed
+    /// to be consolidated.
+    ///
+    /// Each entry's time is guaranteed to be greater than or equal to the since
+    /// frontier. The time may also be greater than the upper frontier,
+    /// indicating data that has not yet been made definite.
+    ///
+    /// [`consolidate`]: StashCollection::consolidate
+    /// [`update`]: StashCollection::update
+    /// [`update_many`]: StashCollection::update_many
+    pub fn iter_key(&self, key: K) -> Result<impl Iterator<Item = (V, i64, i64)>, StashError> {
+        let mut key_buf = vec![];
+        key.encode(&mut key_buf);
+        let mut conn = self.conn.lock().expect("lock poisoned");
+        let tx = conn.transaction()?;
+        let since = match self.since_tx(&tx)? {
+            Max1Antichain::Singular(since) => since,
+            Max1Antichain::Empty => {
+                return Err(StashError::from(
+                    "cannot iterate collection with empty since frontier",
+                ));
+            }
+        };
+        let mut rows = tx
+            .prepare(
+                "SELECT value, time, diff FROM data
+                 WHERE collection_id = $collection_id AND key = $key",
+            )?
+            .query_and_then(
+                named_params! {
+                    "$collection_id": self.collection_id,
+                    "$key": key_buf,
+                },
+                |row| {
+                    let value_buf: Vec<_> = row.get("value")?;
+                    let value = V::decode(&value_buf)?;
+                    let time = row.get("time")?;
+                    let diff = row.get("diff")?;
+                    Ok::<_, StashError>((value, cmp::max(time, since), diff))
+                },
+            )?
+            .collect::<Result<Vec<_>, _>>()?;
+        differential_dataflow::consolidation::consolidate_updates(&mut rows);
+        Ok(rows.into_iter())
+    }
+
+    /// Adds a single entry to the arrangement.
+    ///
+    /// The entry's time must be greater than or equal to the upper frontier.
+    ///
+    /// If this method returns `Ok`, the entry has been made durable.
+    pub fn update(&mut self, data: (K, V), time: i64, diff: i64) -> Result<(), StashError> {
+        self.update_many(iter::once((data, time, diff)))
+    }
+
+    /// Atomically adds multiple entries to the arrangement.
+    ///
+    /// Each entry's time must be greater than or equal to the upper frontier.
+    ///
+    /// If this method returns `Ok`, the entries have been made durable.
+    pub fn update_many<I>(&mut self, entries: I) -> Result<(), StashError>
+    where
+        I: IntoIterator<Item = ((K, V), i64, i64)>,
+    {
+        let mut conn = self.conn.lock().expect("lock poisoned");
+        let tx = conn.transaction()?;
+        let upper = self.upper_tx(&tx)?;
+        let mut insert_stmt = tx.prepare(
+            "INSERT INTO data (collection_id, key, value, time, diff)
+             VALUES ($collection_id, $key, $value, $time, $diff)
+             ON CONFLICT (collection_id, key, value, time) DO UPDATE SET diff = diff + excluded.diff",
+        )?;
+        let mut delete_stmt = tx.prepare(
+            "DELETE FROM data
+             WHERE collection_id = $collection_id AND key = $key AND value = $value AND time = $time AND diff = 0",
+        )?;
+        let mut key_buf = vec![];
+        let mut value_buf = vec![];
+        for ((key, value), time, diff) in entries {
+            if !upper.less_equal(&time) {
+                return Err(StashError::from(format!(
+                    "entry time {:?} is less than the current upper frontier {:?}",
+                    time, upper
+                )));
+            }
+            key_buf.clear();
+            value_buf.clear();
+            key.encode(&mut key_buf);
+            value.encode(&mut value_buf);
+            insert_stmt.execute(named_params! {
+                "$collection_id": self.collection_id,
+                "$key": key_buf,
+                "$value": value_buf,
+                "$time": time,
+                "$diff": diff,
+            })?;
+            delete_stmt.execute(named_params! {
+                "$collection_id": self.collection_id,
+                "$key": key_buf,
+                "$value": value_buf,
+                "$time": time,
+            })?;
+        }
+        drop(insert_stmt);
+        drop(delete_stmt);
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Advances the upper frontier to the specified value.
+    ///
+    /// The provided `upper` must be greater than or equal to the current upper
+    /// frontier.
+    ///
+    /// Intuitively, this method declares that all times less than `upper` are
+    /// definite.
+    pub fn seal<A>(&self, new_upper: A) -> Result<(), StashError>
+    where
+        A: Into<Max1Antichain<i64>>,
+    {
+        let mut conn = self.conn.lock().expect("lock poisoned");
+        let tx = conn.transaction()?;
+        let upper = self.upper_tx(&tx)?;
+        let new_upper = new_upper.into();
+        if PartialOrder::less_than(&new_upper, &upper) {
+            return Err(StashError::from(format!(
+                "seal request {:?} is less than the current upper frontier {:?}",
+                new_upper, upper
+            )));
+        }
+        tx.execute(
+            "UPDATE uppers SET upper = $upper WHERE collection_id = $collection_id",
+            named_params! {"$upper": new_upper.as_option(), "$collection_id": self.collection_id},
+        )?;
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Advances the since frontier to the specified value.
+    ///
+    /// The provided `since` must be greater than or equal to the current since
+    /// frontier but less than or equal to the current upper frontier.
+    ///
+    /// Intuitively, this method performs logical compaction. Existing entries
+    /// whose time is less than `since` are fast-forwarded to `since`.
+    pub fn compact<A>(&self, new_since: A) -> Result<(), StashError>
+    where
+        A: Into<Max1Antichain<i64>>,
+    {
+        let mut conn = self.conn.lock().expect("lock poisoned");
+        let tx = conn.transaction()?;
+        let since = self.since_tx(&tx)?;
+        let upper = self.upper_tx(&tx)?;
+        let new_since = new_since.into();
+        if PartialOrder::less_than(&upper, &new_since) {
+            return Err(StashError::from(format!(
+                "compact request {:?} is greater than the current upper frontier {:?}",
+                new_since, upper
+            )));
+        }
+        if PartialOrder::less_than(&new_since, &since) {
+            return Err(StashError::from(format!(
+                "compact request {:?} is less than the current since frontier {:?}",
+                new_since, upper
+            )));
+        }
+        tx.execute(
+            "UPDATE sinces SET since = $since WHERE collection_id = $collection_id",
+            named_params! {"$since": new_since.as_option(), "$collection_id": self.collection_id},
+        )?;
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Consolidates entries less than the since frontier.
+    ///
+    /// Intuitively, this method performs physical compaction. Existing
+    /// key–value pairs whose time is less than the since frontier are
+    /// consolidated together when possible.
+    pub fn consolidate(&mut self) -> Result<(), StashError> {
+        let mut conn = self.conn.lock().expect("lock poisoned");
+        let tx = conn.transaction()?;
+        let since = self.since_tx(&tx)?;
+        match since {
+            Max1Antichain::Singular(since) => {
+                tx.execute(
+                    "INSERT INTO data (collection_id, key, value, time, diff)
+                     SELECT collection_id, key, value, $since, sum(diff) FROM data
+                     WHERE collection_id = $collection_id AND time < $since
+                     GROUP BY key, value
+                     ON CONFLICT (collection_id, key, value, time) DO UPDATE SET diff = diff + excluded.diff",
+                    named_params! {
+                        "$collection_id": self.collection_id,
+                        "$since": since,
+                    },
+                )?;
+                tx.execute(
+                    "DELETE FROM data WHERE collection_id = $collection_id AND time < $since",
+                    named_params! {
+                        "$collection_id": self.collection_id,
+                        "$since": since,
+                    },
+                )?;
+            }
+            Max1Antichain::Empty => {
+                tx.execute(
+                    "DELETE FROM data WHERE collection_id = $collection_id",
+                    named_params! {
+                        "$collection_id": self.collection_id,
+                    },
+                )?;
+            }
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Reports the current since frontier.
+    pub fn since(&self) -> Result<Max1Antichain<i64>, StashError> {
+        let mut conn = self.conn.lock().expect("lock poisoned");
+        let tx = conn.transaction()?;
+        let since = self.since_tx(&tx)?;
+        tx.commit()?;
+        Ok(since)
+    }
+
+    /// Reports the current upper frontier.
+    pub fn upper(&self) -> Result<Max1Antichain<i64>, StashError> {
+        let mut conn = self.conn.lock().expect("lock poisoned");
+        let tx = conn.transaction()?;
+        let upper = self.upper_tx(&tx)?;
+        tx.commit()?;
+        Ok(upper)
+    }
+
+    fn since_tx(&self, tx: &Transaction) -> Result<Max1Antichain<i64>, StashError> {
+        let since: Option<i64> = tx.query_row(
+            "SELECT since FROM sinces WHERE collection_id = $collection_id",
+            named_params! {"$collection_id": self.collection_id},
+            |row| row.get("since"),
+        )?;
+        Ok(since.into())
+    }
+
+    fn upper_tx(&self, tx: &Transaction) -> Result<Max1Antichain<i64>, StashError> {
+        let upper: Option<i64> = tx.query_row(
+            "SELECT upper FROM uppers WHERE collection_id = $collection_id",
+            named_params! {"$collection_id": self.collection_id},
+            |row| row.get("upper"),
+        )?;
+        Ok(upper.into())
+    }
+}
+
+/// An error that can occur while interacting with a [`Stash`].
+///
+/// Stash errors are deliberately opaque. They generally indicate unrecoverable
+/// conditions, like running out of disk space.
+#[derive(Debug)]
+pub struct StashError {
+    // Internal to avoid leaking implementation details about SQLite.
+    inner: InternalStashError,
+}
+
+#[derive(Debug)]
+enum InternalStashError {
+    Sqlite(rusqlite::Error),
+    Other(String),
+}
+
+impl fmt::Display for StashError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("stash error: ")?;
+        match &self.inner {
+            InternalStashError::Sqlite(e) => e.fmt(f),
+            InternalStashError::Other(e) => f.write_str(&e),
+        }
+    }
+}
+
+impl Error for StashError {}
+
+impl From<rusqlite::Error> for StashError {
+    fn from(e: rusqlite::Error) -> StashError {
+        StashError {
+            inner: InternalStashError::Sqlite(e),
+        }
+    }
+}
+
+impl From<String> for StashError {
+    fn from(e: String) -> StashError {
+        StashError {
+            inner: InternalStashError::Other(e),
+        }
+    }
+}
+
+impl From<&str> for StashError {
+    fn from(e: &str) -> StashError {
+        StashError {
+            inner: InternalStashError::Other(e.into()),
+        }
+    }
+}

--- a/src/stash/tests/stash.rs
+++ b/src/stash/tests/stash.rs
@@ -1,0 +1,147 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use tempfile::NamedTempFile;
+
+use mz_stash::Stash;
+use timely_util::antichain_ext::Max1Antichain;
+
+#[test]
+fn test_stash() -> Result<(), anyhow::Error> {
+    let file = NamedTempFile::new()?;
+    let stash = Stash::open(file.path())?;
+
+    // Create an arrangement, write some data into it, then read it back.
+    let mut orders = stash.collection::<String, String>("orders")?;
+    orders.update(("widgets".into(), "1".into()), 1, 1)?;
+    orders.update(("wombats".into(), "2".into()), 1, 2)?;
+    assert_eq!(
+        orders.iter()?.collect::<Vec<_>>(),
+        &[
+            (("widgets".into(), "1".into()), 1, 1),
+            (("wombats".into(), "2".into()), 1, 2),
+        ]
+    );
+    assert_eq!(
+        orders.iter_key("widgets".into())?.collect::<Vec<_>>(),
+        &[("1".into(), 1, 1)]
+    );
+    assert_eq!(
+        orders.iter_key("wombats".into())?.collect::<Vec<_>>(),
+        &[("2".into(), 1, 2)]
+    );
+
+    // Write to another arrangement and ensure the data stays separate.
+    let mut other = stash.collection::<String, String>("other")?;
+    other.update(("foo".into(), "bar".into()), 1, 1)?;
+    assert_eq!(
+        other.iter()?.collect::<Vec<_>>(),
+        &[(("foo".into(), "bar".into()), 1, 1)],
+    );
+    assert_eq!(
+        orders.iter()?.collect::<Vec<_>>(),
+        &[
+            (("widgets".into(), "1".into()), 1, 1),
+            (("wombats".into(), "2".into()), 1, 2),
+        ]
+    );
+
+    // Check that consolidation happens immediately...
+    orders.update(("wombats".into(), "2".into()), 1, -1)?;
+    assert_eq!(
+        orders.iter()?.collect::<Vec<_>>(),
+        &[
+            (("widgets".into(), "1".into()), 1, 1),
+            (("wombats".into(), "2".into()), 1, 1),
+        ]
+    );
+
+    // ...even when it results in a entry's removal.
+    orders.update(("wombats".into(), "2".into()), 1, -1)?;
+    assert_eq!(
+        orders.iter()?.collect::<Vec<_>>(),
+        &[(("widgets".into(), "1".into()), 1, 1),]
+    );
+
+    // Check that logical compaction applies immediately.
+    orders.update_many([
+        (("widgets".into(), "1".into()), 2, 1),
+        (("widgets".into(), "1".into()), 3, 1),
+        (("widgets".into(), "1".into()), 4, 1),
+    ])?;
+    orders.seal(Some(3))?;
+    orders.compact(Some(3))?;
+    assert_eq!(
+        orders.iter()?.collect::<Vec<_>>(),
+        &[
+            (("widgets".into(), "1".into()), 3, 3),
+            (("widgets".into(), "1".into()), 4, 1),
+        ]
+    );
+
+    // Check that physical compaction does not change the collection's contents.
+    orders.consolidate()?;
+    assert_eq!(
+        orders.iter()?.collect::<Vec<_>>(),
+        &[
+            (("widgets".into(), "1".into()), 3, 3),
+            (("widgets".into(), "1".into()), 4, 1),
+        ]
+    );
+
+    // Test invalid seals, compactions, and updates.
+    assert_eq!(
+        orders.seal(Some(2)).unwrap_err().to_string(),
+        "stash error: seal request {2} is less than the current upper frontier {3}",
+    );
+    assert_eq!(
+        orders.compact(Some(2)).unwrap_err().to_string(),
+        "stash error: compact request {2} is less than the current since frontier {3}",
+    );
+    assert_eq!(
+        orders.compact(Some(4)).unwrap_err().to_string(),
+        "stash error: compact request {4} is greater than the current upper frontier {3}",
+    );
+    assert_eq!(
+        orders
+            .update(("wodgets".into(), "1".into()), 2, 1)
+            .unwrap_err()
+            .to_string(),
+        "stash error: entry time 2 is less than the current upper frontier {3}",
+    );
+
+    // Test advancing since and upper to the empty frontier.
+    orders.seal(None)?;
+    orders.compact(None)?;
+    assert_eq!(
+        match orders.iter() {
+            Ok(_) => panic!("call to iter unexpectedly succeeded"),
+            Err(e) => e.to_string(),
+        },
+        "stash error: cannot iterate collection with empty since frontier",
+    );
+    assert_eq!(
+        match orders.iter_key("wombats".into()) {
+            Ok(_) => panic!("call to iter_key unexpectedly succeeded"),
+            Err(e) => e.to_string(),
+        },
+        "stash error: cannot iterate collection with empty since frontier",
+    );
+    orders.consolidate()?;
+
+    // Double check that the other collection is still untouched.
+    assert_eq!(
+        other.iter()?.collect::<Vec<_>>(),
+        &[(("foo".into(), "bar".into()), 1, 1)],
+    );
+    assert_eq!(other.since()?, Max1Antichain::Singular(0),);
+    assert_eq!(other.upper()?, Max1Antichain::Singular(0),);
+
+    Ok(())
+}

--- a/src/timely-util/src/antichain_ext.rs
+++ b/src/timely-util/src/antichain_ext.rs
@@ -1,0 +1,172 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Antichain utilities.
+
+use std::fmt;
+use std::slice;
+
+use timely::PartialOrder;
+
+/// An [`Antichain`] that stores at most one element.
+///
+/// [`Antichain`]: timely::progress::frontier::Antichain
+#[derive(Clone, PartialEq, Eq)]
+pub enum Max1Antichain<T> {
+    /// An antichain with a single element.
+    Singular(T),
+    /// An antichain with no elements.
+    Empty,
+}
+
+impl<T> Max1Antichain<T>
+where
+    T: PartialOrder,
+{
+    /// Returns true if any item in the antichain is strictly less than the
+    /// argument.
+    pub fn less_than(&self, element: &T) -> bool {
+        match self {
+            Max1Antichain::Singular(s) => s.less_than(element),
+            Max1Antichain::Empty => false,
+        }
+    }
+
+    /// Returns true if any item in the antichain is less than or equal to the
+    /// argument.
+    pub fn less_equal(&self, element: &T) -> bool {
+        match self {
+            Max1Antichain::Singular(s) => s.less_equal(element),
+            Max1Antichain::Empty => false,
+        }
+    }
+
+    /// Reveals the elements in the antichain.
+    pub fn elements(&self) -> &[T] {
+        match self {
+            Max1Antichain::Singular(s) => slice::from_ref(s),
+            Max1Antichain::Empty => &[],
+        }
+    }
+
+    /// Converts the antichain to an option.
+    ///
+    /// Use with caution. The comparison semantics on the returned option do
+    /// not match the this type's [`PartialOrder`] implementation.
+    pub fn as_option(&self) -> Option<&T> {
+        match self {
+            Max1Antichain::Singular(s) => Some(s),
+            Max1Antichain::Empty => None,
+        }
+    }
+}
+
+impl<T> fmt::Debug for Max1Antichain<T>
+where
+    T: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Max1Antichain::Empty => f.write_str("{}"),
+            Max1Antichain::Singular(s) => {
+                f.write_str("{")?;
+                s.fmt(f)?;
+                f.write_str("}")
+            }
+        }
+    }
+}
+
+impl<T> PartialOrder for Max1Antichain<T>
+where
+    T: PartialOrder,
+{
+    fn less_equal(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Max1Antichain::Singular(l), Max1Antichain::Singular(r)) => l.less_equal(r),
+            (Max1Antichain::Singular(_), Max1Antichain::Empty) => true,
+            (Max1Antichain::Empty, Max1Antichain::Singular(_)) => false,
+            (Max1Antichain::Empty, Max1Antichain::Empty) => true,
+        }
+    }
+}
+
+impl<T> From<Option<T>> for Max1Antichain<T> {
+    fn from(option: Option<T>) -> Max1Antichain<T> {
+        match option {
+            Some(t) => Max1Antichain::Singular(t),
+            None => Max1Antichain::Empty,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use timely::PartialOrder;
+
+    use super::Max1Antichain;
+
+    #[test]
+    fn test_max1antichain_eq() {
+        assert_eq!(Max1Antichain::<i64>::Empty, Max1Antichain::Empty);
+        assert_eq!(Max1Antichain::Singular(1), Max1Antichain::Singular(1));
+        assert_ne!(Max1Antichain::Singular(1), Max1Antichain::Singular(2));
+        assert_ne!(Max1Antichain::Empty, Max1Antichain::Singular(2));
+    }
+
+    #[test]
+    fn test_max1antichain_partial_order() {
+        assert!(PartialOrder::less_equal(
+            &Max1Antichain::<i64>::Empty,
+            &Max1Antichain::Empty
+        ));
+        assert!(PartialOrder::less_equal(
+            &Max1Antichain::Singular(1),
+            &Max1Antichain::Empty
+        ));
+        assert!(PartialOrder::less_equal(
+            &Max1Antichain::Singular(1),
+            &Max1Antichain::Singular(1)
+        ));
+        assert!(PartialOrder::less_equal(
+            &Max1Antichain::Singular(1),
+            &Max1Antichain::Singular(2)
+        ));
+        assert!(!PartialOrder::less_equal(
+            &Max1Antichain::Singular(2),
+            &Max1Antichain::Singular(1)
+        ));
+        assert!(!PartialOrder::less_equal(
+            &Max1Antichain::Empty,
+            &Max1Antichain::Singular(1)
+        ));
+    }
+
+    #[test]
+    fn test_max1antichain_less_equal() {
+        assert!(Max1Antichain::Singular(1).less_equal(&1));
+        assert!(Max1Antichain::Singular(1).less_equal(&2));
+        assert!(!Max1Antichain::Singular(2).less_equal(&1));
+        assert!(!Max1Antichain::Empty.less_equal(&1));
+    }
+
+    #[test]
+    fn test_max1antichain_less_than() {
+        assert!(!Max1Antichain::Singular(1).less_than(&1));
+        assert!(Max1Antichain::Singular(1).less_than(&2));
+        assert!(!Max1Antichain::Singular(2).less_than(&1));
+        assert!(!Max1Antichain::Empty.less_than(&1));
+    }
+}

--- a/src/timely-util/src/lib.rs
+++ b/src/timely-util/src/lib.rs
@@ -13,9 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Internal utility libraries for Materialize.
 //! Utilities for working with Timely
 
 #![warn(missing_docs)]
 
+pub mod antichain_ext;
 pub mod operators_async_ext;


### PR DESCRIPTION
The new `stash` crate provides a durable metadata store called a
`Stash`. A stash is like a differential arrangement but its state is
durable.

The idea is that each layer of the platform will store its durable state
in a `Stash`. The API of `Stash` is intentionally very similar to the
intended API of a STORAGE collection. Once STORAGE is stable enough to
serve as a source of truth, we intend to swap all stashes for STORAGE
collections.

This supersedes #10306, which was an earlier attempt at building a `Stash`. The API in #10306 was roughly a table with upsert semantics, while the API here is roughly a differential arrangement. We believe the latter to be a superior API because it matches the intended STORAGE collection API, which will facilitate swapping `Stash`es for proper STORAGE collections down the line.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
