### PR TITLE
Move sinks to ComputeState; tidy

### DIFF
--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -160,6 +160,9 @@ pub struct ComputeState {
     /// The entries are pairs of sink identifier (to identify the tail instance)
     /// and the response itself.
     pub tail_response_buffer: Rc<RefCell<Vec<(GlobalId, TailResponse)>>>,
+    /// Frontier of sink writes (all subsequent writes will be at times at or
+    /// equal to this frontier)
+    pub sink_write_frontiers: HashMap<GlobalId, Rc<RefCell<Antichain<Timestamp>>>>,
 }
 
 /// Worker-local state related to the ingress or egress of collections of data.
@@ -183,9 +186,6 @@ pub struct StorageState {
     pub persisted_sources: PersistedSourceManager,
     /// Metrics reported by all dataflows.
     pub metrics: Metrics,
-    /// Frontier of sink writes (all subsequent writes will be at times at or
-    /// equal to this frontier)
-    pub sink_write_frontiers: HashMap<GlobalId, Rc<RefCell<Antichain<Timestamp>>>>,
     /// Handle to the persistence runtime. None if disabled.
     pub persist: Option<RuntimeClient>,
 }
@@ -307,7 +307,6 @@ pub fn build_dataflow<A: Allocate>(
             for (sink_id, imports, sink) in sinks {
                 context.export_sink(
                     compute_state,
-                    storage_state,
                     &mut tokens,
                     imports,
                     sink_id,

--- a/src/dataflow/src/render/sinks.rs
+++ b/src/dataflow/src/render/sinks.rs
@@ -35,7 +35,6 @@ where
     pub(crate) fn export_sink(
         &mut self,
         compute_state: &mut crate::render::ComputeState,
-        storage_state: &mut crate::render::StorageState,
         tokens: &mut RelevantTokens,
         import_ids: HashSet<GlobalId>,
         sink_id: GlobalId,
@@ -86,14 +85,8 @@ where
         // TODO(benesch): errors should stream out through the sink,
         // if we figure out a protocol for that.
 
-        let sink_token = sink_render.render_continuous_sink(
-            compute_state,
-            storage_state,
-            sink,
-            sink_id,
-            collection,
-            metrics,
-        );
+        let sink_token =
+            sink_render.render_continuous_sink(compute_state, sink, sink_id, collection, metrics);
 
         if let Some(sink_token) = sink_token {
             needed_sink_tokens.push(sink_token);
@@ -234,7 +227,6 @@ where
     fn render_continuous_sink(
         &self,
         compute_state: &mut crate::render::ComputeState,
-        storage_state: &mut crate::render::StorageState,
         sink: &SinkDesc,
         sink_id: GlobalId,
         sinked_collection: Collection<G, (Option<Row>, Option<Row>), Diff>,

--- a/src/dataflow/src/sink/avro_ocf.rs
+++ b/src/dataflow/src/sink/avro_ocf.rs
@@ -46,7 +46,6 @@ where
     fn render_continuous_sink(
         &self,
         _compute_state: &mut crate::render::ComputeState,
-        _storage_state: &mut crate::render::StorageState,
         _sink: &SinkDesc,
         sink_id: GlobalId,
         sinked_collection: Collection<G, (Option<Row>, Option<Row>), Diff>,

--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -82,8 +82,7 @@ where
 
     fn render_continuous_sink(
         &self,
-        _compute_state: &mut crate::render::ComputeState,
-        storage_state: &mut crate::render::StorageState,
+        compute_state: &mut crate::render::ComputeState,
         sink: &SinkDesc,
         sink_id: GlobalId,
         sinked_collection: Collection<G, (Option<Row>, Option<Row>), Diff>,
@@ -142,7 +141,7 @@ where
             &metrics.kafka,
         );
 
-        storage_state
+        compute_state
             .sink_write_frontiers
             .insert(sink_id, shared_frontier);
 

--- a/src/dataflow/src/sink/tail.rs
+++ b/src/dataflow/src/sink/tail.rs
@@ -55,7 +55,6 @@ where
     fn render_continuous_sink(
         &self,
         compute_state: &mut crate::render::ComputeState,
-        _storage_state: &mut crate::render::StorageState,
         sink: &SinkDesc,
         sink_id: GlobalId,
         sinked_collection: Collection<G, (Option<Row>, Option<Row>), Diff>,


### PR DESCRIPTION
This PR moves sink frontier information from `StorageState` to `ComputeState`, which makes sense because sinks exist in compute instances and their lifetimes are tied to them. They were previously in `StorageState` only as a first cut "because they are a storage concept". That's now fixed, and less commingling of the two flavors of state is now required.