### PR TITLE
Ensure bindings doesn't advance beyond durability frontier

### DIFF
--- a/src/dataflow/src/source/util.rs
+++ b/src/dataflow/src/source/util.rs
@@ -87,7 +87,7 @@ where
         let secondary_capability = capabilities.pop().unwrap();
         let data_capability = capabilities.pop().unwrap();
         let durability_capability1 = CapabilitySet::from_elem(data_capability.clone());
-        let durability_capability2 = CapabilitySet::from_elem(data_capability.clone());
+        let durability_capability2 = CapabilitySet::from_elem(secondary_capability.clone());
 
         let capabilities_rc = Rc::new(RefCell::new(Some((
             data_capability,


### PR DESCRIPTION
The binding output of the source operator could run ahead of the bindings that are durable in the catalog. This was (I believe) causing crashes when on recovery the persistence mechanism attempted to restore the capability to the last persisted moment, which was ahead of the last durable (a different mechanism) moment.

This change holds the bindings back until they are durable in the catalog, making it be the source of truth. We can certainly reconsider and have them fight on bindings, but this approach seems to be appropriate based on what is stable, and having a single source of truth.

Fixes #10404