### PR TITLE
test/persistence: temporarily disable flaky test

### DIFF
--- a/test/persistence/mzcompose.py
+++ b/test/persistence/mzcompose.py
@@ -45,7 +45,9 @@ td_test = os.environ.pop("TD_TEST", "*")
 
 
 def workflow_default(c: Composition) -> None:
-    for mz in [mz_default, mz_logical_compaction_window_off]:
+    # TODO: add back mz_logical_compaction_window_off in the line below.
+    # See: https://github.com/MaterializeInc/materialize/issues/10488
+    for mz in [mz_default]:
         with c.override(mz):
             workflow_kafka_sources(c)
             workflow_user_tables(c)


### PR DESCRIPTION
The persistence tests with the logical compaction window disabled are
flaky. Disable them for now.

#10488 tracks the reenablement.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
