### PR TITLE
doc/user: Update dbt guide

### DIFF
--- a/doc/user/content/guides/dbt.md
+++ b/doc/user/content/guides/dbt.md
@@ -157,7 +157,7 @@ When you use dbt with Materialize, **your models stay up-to-date** without manua
     FROM {{ ref('market_orders_raw') }}
     ```
 
-    One thing to note here is that the model depends on the source defined in the previous step. To express this dependency and track the **lineage** of your project, you can use the dbt [source()](https://docs.getdbt.com/docs/building-a-dbt-project/using-sources) and [ref()](https://docs.getdbt.com/reference/dbt-jinja-functions/ref) functions.
+    One thing to note here is that the model depends on the source defined in the previous step. To express this dependency and track the **lineage** of your project, you can use the dbt [ref()](https://docs.getdbt.com/reference/dbt-jinja-functions/ref) function {{% gh 8744 %}}.
 
     <h5>Creating a materialized view</h5>
 

--- a/doc/user/content/guides/dbt.md
+++ b/doc/user/content/guides/dbt.md
@@ -154,7 +154,7 @@ When you use dbt with Materialize, **your models stay up-to-date** without manua
         (text::jsonb)->>'symbol' AS symbol,
         (text::jsonb)->>'trade_type' AS trade_type,
         to_timestamp(((text::jsonb)->'timestamp')::bigint) AS ts
-    FROM {{ source('public','market_orders_raw') }}
+    FROM {{ ref('market_orders_raw') }}
     ```
 
     One thing to note here is that the model depends on the source defined in the previous step. To express this dependency and track the **lineage** of your project, you can use the dbt [source()](https://docs.getdbt.com/docs/building-a-dbt-project/using-sources) and [ref()](https://docs.getdbt.com/reference/dbt-jinja-functions/ref) functions.

--- a/misc/dbt-materialize/README.md
+++ b/misc/dbt-materialize/README.md
@@ -51,6 +51,8 @@ Macro | Purpose
 ------|----------
 `mz_generate_name(identifier)` | Generates a fully-qualified name (including the database and schema) given an object name.
 
+We provide a `materialize-dbt-utils` package with Materialize-specific implementations of dispatched macros from `dbt-utils`. To use this package in your dbt project, check the latest installation instructions in [dbt Hub](https://hub.getdbt.com/materializeinc/materialize_dbt_utils/latest/).
+
 ### Seeds
 
 [`dbt seed`](https://docs.getdbt.com/reference/commands/seed/) will create a


### PR DESCRIPTION
Given the current `dbt-materialize` adapter implementation, it's not possible to reference sources using `source()` (see #8744). Patching the dbt guide to reflect this.

Also adding a pointer to `materialize-dbt-utils` to the adapter `README` to make it discoverable.