### PR TITLE
doc/user: Add systemd instructions

### DIFF
--- a/doc/user/content/install.md
+++ b/doc/user/content/install.md
@@ -131,7 +131,21 @@ Detail | Info
 **Database** | `materialize`
 **Port** | `6875`
 
-### CLI Connections
+### `systemd` service
+
+If you've install Materialize via [`apt`](#apt-ubuntu-debian-or-variants), you can start it as a service by running:
+
+```shell
+systemctl start materialized.service
+```
+
+To enable the service to start up at boot, run:
+
+```shell
+systemctl enable materialized.service
+```
+
+## CLI Connections
 
 To connect to a running instance, you can use any [Materialize-compatible CLI](/connect/cli/),
 like `psql` or `mzcli`. To install the `psql` client:


### PR DESCRIPTION
As per [this discussion](https://materializecommunity.slack.com/archives/C015KDVS7EV/p1644141874138559) in the Materialize Community Slack, I'm adding instructions on how to start Materialize as a service in case it has been installed via `apt`.