### PR TITLE
sql: make multi-dimensional subscripts PG-like

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -140,6 +140,12 @@ changes that have not yet been documented.
 - Add the `md5`, `sha224`, `sha256`, `sha384`, and `sha512` [cryptography
   functions](/sql/functions/#cryptography-func).
 
+- Support sequences of subscript operations on [`array`] values when
+  indexing/accessing individual elements (as opposed to taking slices/ranges of
+  values). However, because Materialize does not currently support
+  multi-dimensional arrays, subscripting more than once always returns _NULL_
+  {{% gh 9815 %}}.
+
 {{< comment >}}
 Only add new release notes above this line.
 

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -142,9 +142,7 @@ changes that have not yet been documented.
 
 - Support sequences of subscript operations on [`array`] values when
   indexing/accessing individual elements (as opposed to taking slices/ranges of
-  values). However, because Materialize does not currently support
-  multi-dimensional arrays, subscripting more than once always returns _NULL_
-  {{% gh 9815 %}}.
+  values) {{% gh 9815 %}}.
 
 - Let users perform layered/multi-dimensional slices on [`list`] values.
 

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -146,6 +146,12 @@ changes that have not yet been documented.
   multi-dimensional arrays, subscripting more than once always returns _NULL_
   {{% gh 9815 %}}.
 
+- Let users perform layered/multi-dimensional slices on [`list`] values.
+
+  The behavior of this feature mimics PostgreSQL subscript slices, with the
+  exception that you cannot slice along more layers than the list has. For
+  example, `int list list` supports at most two layers of slices.
+
 {{< comment >}}
 Only add new release notes above this line.
 

--- a/doc/user/content/sql/types/list.md
+++ b/doc/user/content/sql/types/list.md
@@ -207,7 +207,7 @@ SELECT LIST[1,2,3,4,5][3:] AS three_to_five;
 ```
 
 If the first index exceeds the list's maximum index, the operation returns
-_NULL_:
+an empty list:
 
 ```sql
 SELECT LIST[1,2,3,4,5][10:] AS exceed_index;
@@ -215,7 +215,7 @@ SELECT LIST[1,2,3,4,5][10:] AS exceed_index;
 ```nofmt
  exceed_index
 --------------
-
+ {}
 ```
 
 If the last index exceeds the list’s maximum index, the operation returns all
@@ -232,9 +232,10 @@ SELECT LIST[1,2,3,4,5][2:10] AS two_to_end;
 
 #### Layered slices
 
-{{< experimental v0.5.1 >}}
-Layered slices
-{{< /experimental >}}
+{{< version-changed v0.20.0 >}}
+Prior versions of Materialize required
+experimental mode to perform layered slices.
+{{< /version-changed >}}
 
 To slice on layers beyond the first, indicate the range you want to slice along
 each layer, separating the ranges with square brackets:
@@ -256,6 +257,18 @@ SELECT LIST[[1,2], [3,4]][1:2][2:2][1:1] AS failed_third_dim_slice;
 ```nofmt
 ERROR:  cannot slice into 3 layers; list only has 2 layers
 ```
+
+If any subscript operation is a slice, all subscript operations are treated as
+slices. Subscripted expressions without colons (e.g. `[n]`) are rewritten to the equivalent of `[1:n]`.
+
+```sql
+SELECT LIST[[1,2], [3,4]][2][2:2] AS slice_second_lyr;
+```
+```nofmt
+ slice_second_lyr
+------------------
+ {{2},{4}}
+````
 
 ### Output format
 

--- a/doc/user/content/sql/types/list.md
+++ b/doc/user/content/sql/types/list.md
@@ -237,10 +237,10 @@ Layered slices
 {{< /experimental >}}
 
 To slice on layers beyond the first, indicate the range you want to slice along
-each layer, separating the ranges with commas:
+each layer, separating the ranges with square brackets:
 
 ```sql
-SELECT LIST[[1,2], [3,4]][1:2, 2:2] AS slice_second_lyr;
+SELECT LIST[[1,2], [3,4]][1:2][2:2] AS slice_second_lyr;
 ```
 ```nofmt
  slice_second_lyr
@@ -251,7 +251,7 @@ SELECT LIST[[1,2], [3,4]][1:2, 2:2] AS slice_second_lyr;
 You can only slice into as many layers as the list contains:
 
 ```sql
-SELECT LIST[[1,2], [3,4]][1:2, 2:2, 1:1] AS failed_third_dim_slice;
+SELECT LIST[[1,2], [3,4]][1:2][2:2][1:1] AS failed_third_dim_slice;
 ```
 ```nofmt
 ERROR:  cannot slice into 3 layers; list only has 2 layers

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -25,8 +25,8 @@ use repr::{ColumnName, ColumnType, Datum, Diff, RelationType, Row, ScalarType};
 use self::func::{AggregateFunc, TableFunc};
 use crate::explain::ViewExplanation;
 use crate::{
-    func as scalar_func, BinaryFunc, DummyHumanizer, EvalError, ExprHumanizer, GlobalId, Id,
-    LocalId, MirScalarExpr, UnaryFunc, VariadicFunc,
+    func as scalar_func, DummyHumanizer, EvalError, ExprHumanizer, GlobalId, Id, LocalId,
+    MirScalarExpr, UnaryFunc, VariadicFunc,
 };
 
 pub mod canonicalize;
@@ -1972,16 +1972,21 @@ impl AggregateExpr {
 
             // RowNumber takes a list of records and outputs a list containing exactly 1 element
             AggregateFunc::RowNumber { .. } => {
-                let record = self
+                let list = self
                     .expr
                     .clone()
                     // extract the list within the record
-                    .call_unary(UnaryFunc::RecordGet(0))
-                    // extract the expression within the list
-                    .call_binary(
+                    .call_unary(UnaryFunc::RecordGet(0));
+
+                // extract the expression within the list
+                let record = MirScalarExpr::CallVariadic {
+                    func: VariadicFunc::ListIndex,
+                    exprs: vec![
+                        list,
                         MirScalarExpr::literal_ok(Datum::Int64(1), ScalarType::Int64),
-                        BinaryFunc::ListIndex,
-                    );
+                    ],
+                };
+
                 MirScalarExpr::CallVariadic {
                     func: VariadicFunc::ListCreate {
                         elem_type: self

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -1373,6 +1373,30 @@ impl<'a> ScalarType {
         }
     }
 
+    /// Returns the [`ScalarType`] of elements in the nth dimension a
+    /// [`ScalarType::List`].
+    ///
+    /// For example, in an `int list list`, the:
+    /// - 0th dimension is `int list list`
+    /// - 1st dimension is `int list`
+    /// - 2nd dimension is `int`
+    ///
+    /// # Panics
+    ///
+    /// Panics if the nth-1 dimension is anything other than a
+    /// [`ScalarType::List`].
+    pub fn unwrap_list_nth_dimension_type(&self, dim: usize) -> &ScalarType {
+        if dim == 0 {
+            return self;
+        }
+        match self {
+            ScalarType::List { element_type, .. } => {
+                element_type.unwrap_list_nth_dimension_type(dim - 1)
+            }
+            _ => panic!("ScalarType::unwrap_list_element_type called on {:?}", self),
+        }
+    }
+
     /// Returns number of dimensions/axes (also known as "rank") on a
     /// [`ScalarType::List`].
     ///

--- a/src/sql-parser/src/ast/defs/expr.rs
+++ b/src/sql-parser/src/ast/defs/expr.rs
@@ -177,12 +177,12 @@ pub enum Expr<T: AstInfo> {
     /// `LIST[<expr>*]`
     List(Vec<Expr<T>>),
     ListSubquery(Box<Query<T>>),
-    /// `<expr>[<expr>]`
+    /// `<expr>([<expr>])+`
     SubscriptScalar {
         expr: Box<Expr<T>>,
-        subscript: Box<Expr<T>>,
+        indexes: Vec<Expr<T>>,
     },
-    /// `<expr>[<expr>:<expr>(, <expr>?:<expr>?)*]`
+    /// `<expr>([<expr>:<expr>])+`
     SubscriptSlice {
         expr: Box<Expr<T>>,
         positions: Vec<SubscriptPosition<T>>,
@@ -446,17 +446,21 @@ impl<T: AstInfo> AstDisplay for Expr<T> {
                 f.write_node(&s);
                 f.write_str(")");
             }
-            Expr::SubscriptScalar { expr, subscript } => {
+            Expr::SubscriptScalar { expr, indexes } => {
                 f.write_node(&expr);
-                f.write_str("[");
-                f.write_node(subscript);
-                f.write_str("]");
+                for i in indexes {
+                    f.write_str("[");
+                    f.write_node(i);
+                    f.write_str("]");
+                }
             }
             Expr::SubscriptSlice { expr, positions } => {
                 f.write_node(&expr);
-                f.write_str("[");
-                f.write_node(&display::comma_separated(positions));
-                f.write_str("]");
+                for p in positions {
+                    f.write_str("[");
+                    f.write_node(p);
+                    f.write_str("]");
+                }
             }
         }
     }

--- a/src/sql-parser/tests/testdata/error
+++ b/src/sql-parser/tests/testdata/error
@@ -213,34 +213,13 @@ error: Expected an expression, found right square bracket
 SELECT LIST[1][]
                ^
 
-# Multi-dimensional subscripts must all be slices
+# Previous experimental syntax for multi-dimensional subscripts
 parse-statement
-SELECT LIST[1][1:2, 1]
-----
-error: Expected colon, found right square bracket
-SELECT LIST[1][1:2, 1]
-                     ^
-
-parse-statement
-SELECT LIST[1][1, 1]
+SELECT LIST[1][1:1, 1:1]
 ----
 error: Expected right square bracket, found comma
-SELECT LIST[1][1, 1]
-                ^
-
-parse-statement
-SELECT LIST[1][1, 1:1]
-----
-error: Expected right square bracket, found comma
-SELECT LIST[1][1, 1:1]
-                ^
-
-parse-statement
-SELECT LIST[1][1:1, ]
-----
-error: Expected an expression, found right square bracket
-SELECT LIST[1][1:1, ]
-                    ^
+SELECT LIST[1][1:1, 1:1]
+                  ^
 
 parse-scalar
 ARRAY[]::int[1 + 1]

--- a/src/sql-parser/tests/testdata/literal
+++ b/src/sql-parser/tests/testdata/literal
@@ -59,7 +59,7 @@ E'lots\tof\nescapes\bin\nhere\r.\f\U0001f64a\u2048'
 ----
 'lots	of
 escapesin
-here.🙊⁈'
+here.🙊⁈'
 
 # Numbers
 
@@ -261,6 +261,63 @@ parse-scalar
 LIST[[[[1], [2]]], [[[3]]]]
 ----
 List([List([List([List([Value(Number("1"))]), List([Value(Number("2"))])])]), List([List([List([Value(Number("3"))])])])])
+
+# Lists w/ subscripts
+
+parse-scalar
+LIST[1][1]
+----
+SubscriptScalar { expr: List([Value(Number("1"))]), indexes: [Value(Number("1"))] }
+
+parse-scalar
+LIST[1][1][2]
+----
+SubscriptScalar { expr: List([Value(Number("1"))]), indexes: [Value(Number("1")), Value(Number("2"))] }
+
+parse-scalar
+LIST[1][1:2][2:2]
+----
+SubscriptSlice { expr: List([Value(Number("1"))]), positions: [SubscriptPosition { start: Some(Value(Number("1"))), end: Some(Value(Number("2"))) }, SubscriptPosition { start: Some(Value(Number("2"))), end: Some(Value(Number("2"))) }] }
+
+parse-scalar
+LIST[1][2][2:2]
+----
+SubscriptSlice { expr: List([Value(Number("1"))]), positions: [SubscriptPosition { start: None, end: Some(Value(Number("2"))) }, SubscriptPosition { start: Some(Value(Number("2"))), end: Some(Value(Number("2"))) }] }
+
+parse-scalar
+LIST[1][:2][2:2]
+----
+SubscriptSlice { expr: List([Value(Number("1"))]), positions: [SubscriptPosition { start: None, end: Some(Value(Number("2"))) }, SubscriptPosition { start: Some(Value(Number("2"))), end: Some(Value(Number("2"))) }] }
+
+parse-scalar
+LIST[1][:2][2:]
+----
+SubscriptSlice { expr: List([Value(Number("1"))]), positions: [SubscriptPosition { start: None, end: Some(Value(Number("2"))) }, SubscriptPosition { start: Some(Value(Number("2"))), end: None }] }
+
+parse-scalar
+LIST[1][:][2:]
+----
+SubscriptSlice { expr: List([Value(Number("1"))]), positions: [SubscriptPosition { start: None, end: None }, SubscriptPosition { start: Some(Value(Number("2"))), end: None }] }
+
+parse-scalar
+LIST[1][:][2]
+----
+SubscriptSlice { expr: List([Value(Number("1"))]), positions: [SubscriptPosition { start: None, end: None }, SubscriptPosition { start: None, end: Some(Value(Number("2"))) }] }
+
+parse-scalar
+LIST[1][:2][2:]
+----
+SubscriptSlice { expr: List([Value(Number("1"))]), positions: [SubscriptPosition { start: None, end: Some(Value(Number("2"))) }, SubscriptPosition { start: Some(Value(Number("2"))), end: None }] }
+
+parse-scalar
+LIST[1][:][2:]
+----
+SubscriptSlice { expr: List([Value(Number("1"))]), positions: [SubscriptPosition { start: None, end: None }, SubscriptPosition { start: Some(Value(Number("2"))), end: None }] }
+
+parse-scalar
+LIST[1][2][2:]
+----
+SubscriptSlice { expr: List([Value(Number("1"))]), positions: [SubscriptPosition { start: None, end: Some(Value(Number("2"))) }, SubscriptPosition { start: Some(Value(Number("2"))), end: None }] }
 
 # Arrays
 

--- a/src/sql-parser/tests/testdata/scalar
+++ b/src/sql-parser/tests/testdata/scalar
@@ -444,7 +444,7 @@ List([List([Op { op: Bare("+"), expr1: Value(Number("1")), expr2: Some(Value(Num
 parse-scalar
 LIST[1,2,3][1]
 ----
-SubscriptScalar { expr: List([Value(Number("1")), Value(Number("2")), Value(Number("3"))]), subscript: Value(Number("1")) }
+SubscriptScalar { expr: List([Value(Number("1")), Value(Number("2")), Value(Number("3"))]), indexes: [Value(Number("1"))] }
 
 parse-scalar
 LIST[1,2,3][1:1]
@@ -462,17 +462,17 @@ LIST[1,2,3][1:]
 SubscriptSlice { expr: List([Value(Number("1")), Value(Number("2")), Value(Number("3"))]), positions: [SubscriptPosition { start: Some(Value(Number("1"))), end: None }] }
 
 parse-scalar
-LIST[[1],[2],[3]][1:1, 1:1]
+LIST[[1],[2],[3]][1:1][1:1]
 ----
 SubscriptSlice { expr: List([List([Value(Number("1"))]), List([Value(Number("2"))]), List([Value(Number("3"))])]), positions: [SubscriptPosition { start: Some(Value(Number("1"))), end: Some(Value(Number("1"))) }, SubscriptPosition { start: Some(Value(Number("1"))), end: Some(Value(Number("1"))) }] }
 
 parse-scalar
-LIST[[1],[2],[3]][1:1, 1:1][1]
+LIST[[1],[2],[3]][1:1][1:1][1]
 ----
-SubscriptScalar { expr: SubscriptSlice { expr: List([List([Value(Number("1"))]), List([Value(Number("2"))]), List([Value(Number("3"))])]), positions: [SubscriptPosition { start: Some(Value(Number("1"))), end: Some(Value(Number("1"))) }, SubscriptPosition { start: Some(Value(Number("1"))), end: Some(Value(Number("1"))) }] }, subscript: Value(Number("1")) }
+SubscriptSlice { expr: List([List([Value(Number("1"))]), List([Value(Number("2"))]), List([Value(Number("3"))])]), positions: [SubscriptPosition { start: Some(Value(Number("1"))), end: Some(Value(Number("1"))) }, SubscriptPosition { start: Some(Value(Number("1"))), end: Some(Value(Number("1"))) }, SubscriptPosition { start: None, end: Some(Value(Number("1"))) }] }
 
 parse-scalar
-LIST[[1],[2],[3]][1:1, 1:1, 1:1]
+LIST[[1],[2],[3]][1:1][1:1][1:1]
 ----
 SubscriptSlice { expr: List([List([Value(Number("1"))]), List([Value(Number("2"))]), List([Value(Number("3"))])]), positions: [SubscriptPosition { start: Some(Value(Number("1"))), end: Some(Value(Number("1"))) }, SubscriptPosition { start: Some(Value(Number("1"))), end: Some(Value(Number("1"))) }, SubscriptPosition { start: Some(Value(Number("1"))), end: Some(Value(Number("1"))) }] }
 
@@ -626,7 +626,7 @@ Nested(FieldAccess { expr: Nested(FieldAccess { expr: FieldAccess { expr: Nested
 parse-scalar
 (((x).a.b)[1].c)
 ----
-Nested(FieldAccess { expr: SubscriptScalar { expr: Nested(FieldAccess { expr: FieldAccess { expr: Nested(Identifier([Ident("x")])), field: Ident("a") }, field: Ident("b") }), subscript: Value(Number("1")) }, field: Ident("c") })
+Nested(FieldAccess { expr: SubscriptScalar { expr: Nested(FieldAccess { expr: FieldAccess { expr: Nested(Identifier([Ident("x")])), field: Ident("a") }, field: Ident("b") }), indexes: [Value(Number("1"))] }, field: Ident("c") })
 
 parse-scalar roundtrip
 (((x).a.b)[1].c)

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -3309,9 +3309,7 @@ fn plan_subscript_slice(
         !positions.is_empty(),
         "subscript expression must contain at least one position"
     );
-    if positions.len() > 1 {
-        ecx.require_experimental_mode("layered/multidimensional slicing")?;
-    }
+
     let ecx = &ecx.with_name("subscript (slicing)");
     let expr = plan_expr(ecx, expr)?.type_as_any(ecx)?;
     let ty = ecx.scalar_type(&expr);

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -321,10 +321,10 @@ pub fn purify(
                                             expr: Box::new(Expr::Identifier(vec![Ident::new(
                                                 "row_data",
                                             )])),
-                                            subscript: Box::new(Expr::Value(Value::Number(
+                                            indexes: vec![Expr::Value(Value::Number(
                                                 // LIST is one based
                                                 (i + 1).to_string(),
-                                            ))),
+                                            ))],
                                         }),
                                         data_type: column.data_type.clone(),
                                     },

--- a/test/sqllogictest/arrays.slt
+++ b/test/sqllogictest/arrays.slt
@@ -311,6 +311,41 @@ SELECT ARRAY['a', 'b', 'c'][4][2]
 ----
 NULL
 
+query T
+SELECT ARRAY[['a'], ['b'], ['c']][2][1]
+----
+b
+
+query T
+SELECT ARRAY[['a'], ['b'], ['c']][2]
+----
+NULL
+
+statement ok
+CREATE TABLE array_t (a int[]);
+
+statement ok
+INSERT INTO array_t VALUES (ARRAY[[[1,2],[3,4]],[[5,6],[7,8]]]);
+
+query TTTTTTTT
+SELECT
+    a[1][1][1],
+	a[1][1][2],
+	a[1][2][1],
+	a[1][2][2],
+	a[2][1][1],
+	a[2][1][2],
+	a[2][2][1],
+	a[2][2][2]
+FROM array_t;
+----
+1 2 3 4 5 6 7 8
+
+query T
+SELECT ARRAY[[1,2,3], [4,5,6]][2][-1]
+----
+NULL
+
 # This differs from Cockroach, but matches Postgres.
 query T
 SELECT ARRAY['a', 'b', 'c'][3.5]

--- a/test/sqllogictest/arrays.slt
+++ b/test/sqllogictest/arrays.slt
@@ -306,9 +306,10 @@ SELECT ARRAY[1, 2, 3][1.5 + 1.5]
 ----
 3
 
-# Error different than Cockroach.
-query error cannot subscript type text
+query T
 SELECT ARRAY['a', 'b', 'c'][4][2]
+----
+NULL
 
 # This differs from Cockroach, but matches Postgres.
 query T

--- a/test/sqllogictest/list.slt
+++ b/test/sqllogictest/list.slt
@@ -108,8 +108,14 @@ SELECT LIST [1, 2, 3][100]
 ----
 NULL
 
+# negative
+query R
+SELECT LIST [1, 2, 3][-1]
+----
+NULL
+
 # exceeds maximum dimension
-query error cannot subscript type integer
+query error cannot index into
 SELECT LIST [1, 2, 3][1][1]
 
 # 🔬🔬 list slices
@@ -148,20 +154,14 @@ SELECT (LIST [1, 2, 3][:100])::text
 
 # exceeds maximum dimension
 query error cannot slice into 2 layers; list only has 1 layer
-SELECT LIST [1, 2, 3][:, :]
-
-# successive slices
-query T
-SELECT (LIST [1, 2, 3][2:3][1:1])::text
-----
-{2}
+SELECT LIST [1, 2, 3][:][:]
 
 # 🔬🔬 list slices + index
 
 query T
-SELECT (LIST [1, 2, 3][2:3][2])::text
+SELECT (LIST [[1],[2],[3]][2:3])[2]::text
 ----
-3
+{3}
 
 # 🔬 list list subscripts
 
@@ -194,7 +194,7 @@ SELECT (LIST [[1, 2, 3], [4, 5]][100][1])::text
 NULL
 
 # exceeds maximum dimension
-query error cannot subscript type integer
+query error cannot index into
 SELECT LIST [[1, 2, 3], [4, 5]][1][1][1]
 
 # 🔬🔬 list list slices
@@ -205,7 +205,7 @@ SELECT (LIST [[1, 2, 3], [4, 5]][2:2])::text
 {{4,5}}
 
 query T
-SELECT (LIST [[1, 2, 3], [4, 5]][1:2, 2:3])::text
+SELECT (LIST [[1, 2, 3], [4, 5]][1:2][2:3])::text
 ----
 {{2,3},{5}}
 
@@ -215,69 +215,98 @@ SELECT (LIST [[1, 2, 3], [4, 5]][2:])::text
 {{4,5}}
 
 query T
-SELECT (LIST [[1, 2, 3], [4, 5]][:2, 2:])::text
+SELECT (LIST [[1, 2, 3], [4, 5]][:2][2:])::text
 ----
 {{2,3},{5}}
 
 query T
-SELECT (LIST [[1, 2, 3], [4, 5]][:, 2:])::text
+SELECT (LIST [[1, 2, 3], [4, 5]][:][2:])::text
 ----
 {{2,3},{5}}
+
+query T
+SELECT (LIST [[1, 2, 3], [4, 5]][2:2][1:1])::text
+----
+{{4}}
 
 # start exceeds maximum index
 query T
-SELECT (LIST [[1, 2, 3], [4, 5]][100:, :])::text
+SELECT (LIST [[1, 2, 3], [4, 5]][100:][:])::text
 ----
 NULL
 
 query T
-SELECT (LIST [[1, 2, 3], [4, 5]][:, 100:])::text
+SELECT (LIST [[1, 2, 3], [4, 5]][:][100:])::text
 ----
 NULL
 
 # propagating NULL lists
 query T
-SELECT (LIST [[1, 2, 3], [4, 5]][:, 3:3])::text
+SELECT (LIST [[1, 2, 3], [4, 5]][:][3:3])::text
 ----
 {{3},NULL}
 
 # end exceeds maximum index
 query T
-SELECT (LIST [[1, 2, 3], [4, 5]][:100, :])::text
+SELECT (LIST [[1, 2, 3], [4, 5]][:100][:])::text
 ----
 {{1,2,3},{4,5}}
 
 query T
-SELECT (LIST [[1, 2, 3], [4, 5]][:, :100])::text
+SELECT (LIST [[1, 2, 3], [4, 5]][:][:100])::text
 ----
 {{1,2,3},{4,5}}
 
 # exceeds maximum dimension
 query error cannot slice into 3 layers; list only has 2 layers
-SELECT LIST [[1, 2, 3], [4, 5]][:, :, :]
+SELECT LIST [[1, 2, 3], [4, 5]][:][:][:]
 
-# successive slice operations
+# 🔬🔬 multi-dimensional list slices patterns
+
 query T
-SELECT (LIST [[1, 2, 3], [4, 5]][2:2][1:1])::text
+SELECT list[list[1,2], list[3,4]][1:2][2:2]::text;
 ----
-{{4,5}}
+{{2},{4}}
+
+query T
+SELECT list[list[1,2], list[3,4]][2][2:2]::text;
+----
+{{2},{4}}
+
+query T
+SELECT list[list[1,2], list[3,4]][:2][2:2]::text;
+----
+{{2},{4}}
+
+query T
+SELECT list[list[1,2], list[3,4]][:2][2:]::text;
+----
+{{2},{4}}
+
+query T
+SELECT list[list[1,2], list[3,4]][:][2:]::text;
+----
+{{2},{4}}
+
+query T
+SELECT list[[1,2], list[3,4]][2][2:]::text;
+----
+{{2},{4}}
+
+# query T
+# select list[[1], [2]][:2][2:]::text;
+# ----
+# {}
 
 # 🔬🔬 list list slices + index
 
 query T
-SELECT (LIST [[1, 2, 3], [4, 5]][1:2][2])::text
-----
-{4,5}
-
-query T
-SELECT (LIST [[1, 2, 3], [4, 5]][1:2][2][2:2])::text
-----
-{5}
-
-query T
-SELECT (LIST [[1, 2, 3], [4, 5]][1:2][2][2:2][1])::text
+SELECT (LIST [[1, 2, 3], [4, 5]][2:2])[1][2]::text
 ----
 5
+
+query error cannot slice into
+SELECT (LIST [[1, 2, 3], [4, 5]][:][:][:])::text
 
 # 🔬 list list list
 
@@ -319,8 +348,13 @@ SELECT LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][100][2][3]
 ----
 NULL
 
+query R
+SELECT LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][1][100][3]
+----
+NULL
+
 # exceeds maximum dimension
-query error cannot subscript type integer
+query error cannot index into
 SELECT LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][1][2][3][1]
 
 # 🔬🔬 list list list slices
@@ -331,12 +365,12 @@ SELECT (LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][1:2])::text
 {{{1,2},{3,4,5}},{{6}}}
 
 query T
-SELECT (LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][:, 1:1])::text
+SELECT (LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][:][1:1])::text
 ----
 {{{1,2}},{{6}},{{7,8}}}
 
 query T
-SELECT (LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][:, :, 1:1])::text
+SELECT (LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][:][:][1:1])::text
 ----
 {{{1},{3}},{{6}},{{7},{9}}}
 
@@ -347,28 +381,28 @@ SELECT (LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][100:100])::text
 NULL
 
 query T
-SELECT (LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][:, 100:100])::text
+SELECT (LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][:][100:100])::text
 ----
 NULL
 
 query T
-SELECT (LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][:, :, 100:100])::text
+SELECT (LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][:][:][100:100])::text
 ----
 NULL
 
 query T
-SELECT (LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][:, 100:100, :])::text
+SELECT (LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][:][100:100][:])::text
 ----
 NULL
 
 # propagating NULL lists
 query T
-SELECT (LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][:, 2:2])::text
+SELECT (LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][:][2:2])::text
 ----
 {{{3,4,5}},NULL,{{9}}}
 
 query T
-SELECT (LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][:, 2:2, 2:2])::text
+SELECT (LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][:][2:2][2:2])::text
 ----
 {{{4}},NULL,NULL}
 
@@ -379,40 +413,36 @@ SELECT (LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][:100])::text
 {{{1,2},{3,4,5}},{{6}},{{7,8},{9}}}
 
 query T
-SELECT (LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][:, :100])::text
+SELECT (LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][:][:100])::text
 ----
 {{{1,2},{3,4,5}},{{6}},{{7,8},{9}}}
 
 query T
-SELECT (LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][:, :, :100])::text
+SELECT (LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][:][:][:100])::text
 ----
 {{{1,2},{3,4,5}},{{6}},{{7,8},{9}}}
 
 query T
-SELECT (LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][:, :100, :100])::text
+SELECT (LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][:][:100][:100])::text
 ----
 {{{1,2},{3,4,5}},{{6}},{{7,8},{9}}}
 
 # exceeds maximum dimension
 query error cannot slice into 4 layers; list only has 3 layers
-SELECT LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][:, :, :, :]
+SELECT LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][:][:][:][:]
 
 # 🔬🔬 list list list slices + index
 
 query T
-SELECT (LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][1:2][1])::text
+SELECT (LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][2:3])[2]::text
 ----
-{{1,2},{3,4,5}}
+{{7,8},{9}}
 
-query T
+query error cannot slice
 SELECT (LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][1:2][1][2:2][1])::text
-----
-{3,4,5}
 
-query R
+query error cannot slice
 SELECT LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][1:2][1][2:3][1][2:3][2]
-----
-5
 
 # 🔬 NULL expressions
 
@@ -422,7 +452,7 @@ SELECT (LIST[[1, 2, 3], NULL, [4]]::INT LIST LIST)[2][1]
 NULL
 
 query T
-SELECT ((LIST[[1, 2, 3], NULL, [4]]::INT LIST LIST)[2:3, 2:2])::text
+SELECT ((LIST[[1, 2, 3], NULL, [4]]::INT LIST LIST)[2:3][2:2])::text
 ----
 NULL
 
@@ -474,7 +504,7 @@ SELECT ((LIST [[1, NULL, 3], NULL, [4, NULL, 6]]::INT LIST LIST)[2:])::text
 query T
 SELECT ((LIST [[1, NULL, 3], NULL, [4, NULL, 6]]::INT LIST LIST)[2:3][1])::text
 ----
-NULL
+{NULL,{4}}
 
 # 🔬🔬 Slices and NULLs
 
@@ -487,45 +517,45 @@ SELECT ((LIST[NULL]::INT LIST)[1:1])::text
 # Slicing into a NULL list produces an empty result expressed as NULL; if all
 # results are empty, reduce them all to a single NULL
 query T
-SELECT ((LIST[NULL, NULL]::INT LIST LIST)[:, 1:1])::text
+SELECT ((LIST[NULL, NULL]::INT LIST LIST)[:][1:1])::text
 ----
 NULL
 
 # Literal NULLs are NOT empty results and don't get reduced
 query T
-SELECT ((LIST[NULL, [NULL]]::INT LIST LIST)[:, 1:1])::text
+SELECT ((LIST[NULL, [NULL]]::INT LIST LIST)[:][1:1])::text
 ----
 {NULL,{NULL}}
 
 # Results can mix values and empty-results-as-NULLs
 query T
-SELECT ((LIST [[1, NULL, 3], NULL, [4, 5, 6]]::INT LIST LIST)[2:3, 2:2])::text
+SELECT ((LIST [[1, NULL, 3], NULL, [4, 5, 6]]::INT LIST LIST)[2:3][2:2])::text
 ----
 {NULL,{5}}
 
 # Results can mix NULL values and empty-results-as-NULLs
 query T
-SELECT ((LIST [[1, NULL, 3], NULL, [4, NULL, 6]]::INT LIST LIST)[2:3, 2:2])::text
+SELECT ((LIST [[1, NULL, 3], NULL, [4, NULL, 6]]::INT LIST LIST)[2:3][2:2])::text
 ----
 {NULL,{NULL}}
 
 # Empty results across dimensions are still reduced
 query T
-SELECT ((LIST [[1, NULL, 3], NULL, [4, NULL, 6]]::INT LIST LIST)[2:3, 4:4])::text
+SELECT ((LIST [[1, NULL, 3], NULL, [4, NULL, 6]]::INT LIST LIST)[2:3][4:4])::text
 ----
 NULL
 
 # Outer list's second position produces empty results, but third position
 # produces value, so cannot be totally reduced
 query T
-SELECT ((LIST [NULL, [NULL], [[NULL]]]::INT LIST LIST LIST)[:, :, :])::text
+SELECT ((LIST [NULL, [NULL], [[NULL]]]::INT LIST LIST LIST)[:][:][:])::text
 ----
 {NULL,NULL,{{NULL}}}
 
 # Third position returns empty results, along with the first and second
 # position, so all can be reduced to NULL
 query T
-SELECT ((LIST [NULL, [NULL], [[NULL]]]::INT LIST LIST LIST)[:, :, 2:2])::text
+SELECT ((LIST [NULL, [NULL], [[NULL]]]::INT LIST LIST LIST)[:][:][2:2])::text
 ----
 NULL
 
@@ -547,7 +577,7 @@ SELECT ((LIST[]::INT LIST)[1:1])::text
 NULL
 
 query T
-SELECT ((LIST[]::INT LIST LIST)[1:1, 1:1])::text
+SELECT ((LIST[]::INT LIST LIST)[1:1][1:1])::text
 ----
 NULL
 

--- a/test/sqllogictest/list.slt
+++ b/test/sqllogictest/list.slt
@@ -144,7 +144,7 @@ SELECT (LIST [1, 2, 3][:])::text
 query T
 SELECT (LIST [1, 2, 3][100:])::text
 ----
-NULL
+{}
 
 # end exceeds maximum index
 query T
@@ -233,12 +233,12 @@ SELECT (LIST [[1, 2, 3], [4, 5]][2:2][1:1])::text
 query T
 SELECT (LIST [[1, 2, 3], [4, 5]][100:][:])::text
 ----
-NULL
+{}
 
 query T
 SELECT (LIST [[1, 2, 3], [4, 5]][:][100:])::text
 ----
-NULL
+{}
 
 # propagating NULL lists
 query T
@@ -292,11 +292,6 @@ query T
 SELECT list[[1,2], list[3,4]][2][2:]::text;
 ----
 {{2},{4}}
-
-# query T
-# select list[[1], [2]][:2][2:]::text;
-# ----
-# {}
 
 # 🔬🔬 list list slices + index
 
@@ -378,22 +373,22 @@ SELECT (LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][:][:][1:1])::text
 query T
 SELECT (LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][100:100])::text
 ----
-NULL
+{}
 
 query T
 SELECT (LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][:][100:100])::text
 ----
-NULL
+{}
 
 query T
 SELECT (LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][:][:][100:100])::text
 ----
-NULL
+{}
 
 query T
 SELECT (LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][:][100:100][:])::text
 ----
-NULL
+{}
 
 # propagating NULL lists
 query T
@@ -454,7 +449,7 @@ NULL
 query T
 SELECT ((LIST[[1, 2, 3], NULL, [4]]::INT LIST LIST)[2:3][2:2])::text
 ----
-NULL
+{}
 
 query T
 SELECT (LIST[1, 2, 3][NULL])::text
@@ -519,7 +514,7 @@ SELECT ((LIST[NULL]::INT LIST)[1:1])::text
 query T
 SELECT ((LIST[NULL, NULL]::INT LIST LIST)[:][1:1])::text
 ----
-NULL
+{}
 
 # Literal NULLs are NOT empty results and don't get reduced
 query T
@@ -543,7 +538,7 @@ SELECT ((LIST [[1, NULL, 3], NULL, [4, NULL, 6]]::INT LIST LIST)[2:3][2:2])::tex
 query T
 SELECT ((LIST [[1, NULL, 3], NULL, [4, NULL, 6]]::INT LIST LIST)[2:3][4:4])::text
 ----
-NULL
+{}
 
 # Outer list's second position produces empty results, but third position
 # produces value, so cannot be totally reduced
@@ -557,7 +552,7 @@ SELECT ((LIST [NULL, [NULL], [[NULL]]]::INT LIST LIST LIST)[:][:][:])::text
 query T
 SELECT ((LIST [NULL, [NULL], [[NULL]]]::INT LIST LIST LIST)[:][:][2:2])::text
 ----
-NULL
+{}
 
 # 🔬 Empty lists expressions
 
@@ -569,17 +564,17 @@ NULL
 query T
 SELECT ((LIST[]::INT LIST)[:])::text
 ----
-NULL
+{}
 
 query T
 SELECT ((LIST[]::INT LIST)[1:1])::text
 ----
-NULL
+{}
 
 query T
 SELECT ((LIST[]::INT LIST LIST)[1:1][1:1])::text
 ----
-NULL
+{}
 
 # 🔬 Other subscript values
 
@@ -637,7 +632,7 @@ NULL
 query T
 SELECT (LIST[1][9223372036854775807::bigint:9223372036854775807::bigint])::text
 ----
-NULL
+{}
 
 query T
 SELECT (LIST[1][9223372036854775807::bigint:-9223372036854775807::bigint])::text


### PR DESCRIPTION
Our current implementation of subscripts treats each successive subscript operation as a left associative binary function, i.e. each subscript applies to the return value of the subscript operation to the left.

However, this is not how PG does it: instead, their multi-dimensional slices must be treated as variadic args to a function whose first argument is the item to subscript. This must be the case because arrays support infinitely-deep subscripts on any array type, and always return a value of the inner type:

```
sean=# SELECT pg_typeof('{1}'::_int2);
 pg_typeof
------------
 smallint[]
(1 row)

sean=# SELECT pg_typeof(('{1}'::_int2)[1][1][1][1]);
 pg_typeof
-----------
 smallint
(1 row)
```

This PR brings subscripts more inline with PG's semantics, but with the convenient property that multi-dimensional subscripts on arrays simply always returns null.

All this said, the feature this _actually_ unblocks is `int2vector[]`, which will be backed by arrays, and for which left-associative binary subscripts produces non-PG-like results, i.e. the subsequent subscripts index into the in2vector rather than the outer array.

```
sean=# SELECT pg_typeof('{1}'::_int2vector);
  pg_typeof
--------------
 int2vector[]
(1 row)

sean=# SELECT pg_typeof(('{1}'::_int2vector)[1][1]);
 pg_typeof
------------
 int2vector
(1 row)

sean=# SELECT pg_typeof((('{1}'::_int2vector)[1])[1]);
 pg_typeof
-----------
 smallint
```

@jkosh44 No need to do a thorough review because this is in the weeds, but certainly review to your heart's content

### Motivation

This PR adds a known-desirable feature: requisite for #10024

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
