### PR TITLE
limits test: Cap SelectExpression to 500 items

### DIFF
--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -655,6 +655,10 @@ class Lateral(Generator):
 
 
 class SelectExpression(Generator):
+    # Stack exhaustion with COUNT=1000 due to unprotected path:
+    # https://github.com/MaterializeInc/materialize/issues/10496
+    COUNT = min(Generator.COUNT, 500)
+
     @classmethod
     def body(cls) -> None:
         column_list = ", ".join(f"f{i} INTEGER" for i in cls.all())
@@ -663,9 +667,13 @@ class SelectExpression(Generator):
         value_list = ", ".join("1" for i in cls.all())
         print(f"> INSERT INTO t1 VALUES ({value_list});")
 
-        expression = " + ".join(f"{i}" for i in cls.all())
-        print(f"> SELECT {expression} FROM t1;")
+        const_expression = " + ".join(f"{i}" for i in cls.all())
+        print(f"> SELECT {const_expression} FROM t1;")
         print(f"{sum(cls.all())}")
+
+        expression = " + ".join(f"f{i}" for i in cls.all())
+        print(f"> SELECT {expression} FROM t1;")
+        print(f"{cls.COUNT}")
 
 
 class WhereExpression(Generator):
@@ -793,7 +801,7 @@ class Aggregates(Generator):
 
 class AggregateExpression(Generator):
     # Stack exhaustion with COUNT=1000 due to unprotected path:
-    # https://github.com/MaterializeInc/materialize/issues/10348#issuecomment-1025946920
+    # https://github.com/MaterializeInc/materialize/issues/10496
     COUNT = min(Generator.COUNT, 500)
 
     @classmethod


### PR DESCRIPTION
Due to #10496, the SelectExpression scenario can not run with
1000 items, so it needs to be capped.

Also, make sure that both constant and non-constant expressions
are being tested in the scenario.

<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug: [Link to issue.]

  * This PR adds a known-desirable feature: [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
