### PR TITLE
Revert "build(deps-dev): bump scipy from 1.7.3 to 1.8.0 in /ci/builder"

### DIFF
--- a/ci/builder/requirements-dev.txt
+++ b/ci/builder/requirements-dev.txt
@@ -21,7 +21,7 @@ psutil==5.9.0
 # psycopg2 intentionally omitted. Use pg8000 from requirements-core.txt instead.
 pydantic==1.9.0
 pytest==7.0.0
-scipy==1.8.0
+scipy==1.7.3
 sqlparse==0.4.2
 twine==3.8.0
 types-prettytable==2.1.2


### PR DESCRIPTION
This reverts commit 6b8767df51f2a42a6f505a789c409a4626fa3847.

### Motivation

* scipy 1.8.0 doesn't build on our macOS ARM agent.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
