### PR TITLE
release: Automatically trigger Nightly during release

### DIFF
--- a/.github/ISSUE_TEMPLATE/05-release.md
+++ b/.github/ISSUE_TEMPLATE/05-release.md
@@ -109,6 +109,9 @@ of PRs and adds release notes for any features or bugs that were missed.
   job][] for your release has been completed. Find it [here][slts] and link to it, don't
   check this checkmark off until it has succeeded.
 
+- [ ] [A full Nightly run][nightlies] will be automatically triggered as well. Find it
+[here][nightlies] and link to it. Make sure all failures are accounted for or ask in #eng-testing .
+
 - [ ] Wait for the [deploy job][] for the currently-releasing version tag to
   complete. Then launch the load tests using the `bin/scratch` script:
 
@@ -117,6 +120,7 @@ of PRs and adds release notes for any features or bugs that were missed.
   ```
 
 [slts]: https://buildkite.com/materialize/sql-logic-tests
+[nightlies]: https://buildkite.com/materialize/nightlies
 [deploy job]: https://buildkite.com/materialize/deploy
 [This commit]: https://github.com/MaterializeInc/infra/commit/fd7f594d6f9fb2fda3a604f21b730f8d401fe81c
 

--- a/ci/deploy/pipeline.yml
+++ b/ci/deploy/pipeline.yml
@@ -75,3 +75,13 @@ steps:
       branch: "$BUILDKITE_BRANCH"
       env:
         BUILDKITE_TAG: "$BUILDKITE_TAG"
+
+  - label: ":nightmare: Full Nightly"
+    trigger: nightlies
+    async: true
+    branches: "v*.*rc*"
+    build:
+      commit: "$BUILDKITE_COMMIT"
+      branch: "$BUILDKITE_BRANCH"
+      env:
+        BUILDKITE_TAG: "$BUILDKITE_TAG"


### PR DESCRIPTION
Automatically trigger a Nightly run during the release process
as there is no guarantee that Nightly would have run on its own
prior to cutting the release.

Add an item to the release checklist about Nightly

<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug: [Link to issue.]

  * This PR adds a known-desirable feature: [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
