### PR TITLE
persist,dataflow: simplify source restore logic by assuming atomic seal

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -2521,8 +2521,8 @@ pub enum SerializedEnvelopePersistDetails {
 impl From<SourcePersistDesc> for SerializedSourcePersistDetails {
     fn from(source_persist_desc: SourcePersistDesc) -> Self {
         SerializedSourcePersistDetails {
-            primary_stream: source_persist_desc.primary_stream.name,
-            timestamp_bindings_stream: source_persist_desc.timestamp_bindings_stream.name,
+            primary_stream: source_persist_desc.primary_stream,
+            timestamp_bindings_stream: source_persist_desc.timestamp_bindings_stream,
             envelope_details: source_persist_desc.envelope_desc.into(),
         }
     }

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -531,7 +531,7 @@ impl Coordinator {
                         .persister
                         .load_source_persist_desc(&source)
                         .map_err(CoordError::Persistence)?
-                        .map(|p| p.primary_stream.since_ts)
+                        .map(|p| p.since_ts)
                         .unwrap_or(0);
 
                     let frontiers = self.new_source_frontiers(
@@ -2283,7 +2283,7 @@ impl Coordinator {
                             .persister
                             .load_source_persist_desc(&source)
                             .map_err(CoordError::Persistence)?
-                            .map(|p| p.primary_stream.since_ts)
+                            .map(|p| p.since_ts)
                             .unwrap_or(0);
                         Ok::<_, CoordError>(since_ts)
                     })

--- a/src/coord/src/persistcfg.rs
+++ b/src/coord/src/persistcfg.rs
@@ -18,7 +18,7 @@ use timely::progress::Timestamp;
 
 use build_info::BuildInfo;
 use dataflow_types::sources::{
-    persistence::{EnvelopePersistDesc, PersistStreamDesc, SourcePersistDesc},
+    persistence::{EnvelopePersistDesc, SourcePersistDesc},
     ExternalSourceConnector, SourceConnector, SourceEnvelope,
 };
 use itertools::Itertools;
@@ -431,14 +431,27 @@ impl PersisterWithConfig {
             // TODO: We might want to add (or change) a get_description() that allows getting the
             // descriptions for a batch of IDs in one go instead of getting them all separately. It
             // shouldn't be an issue right now, though.
-            let primary_stream =
+            let (primary_stream, primary_since, primary_upper) =
                 stream_desc_from_name(serialized_details.primary_stream.clone(), runtime)?;
-            let timestamp_bindings_stream = stream_desc_from_name(
-                serialized_details.timestamp_bindings_stream.clone(),
-                runtime,
-            )?;
+            let (timestamp_bindings_stream, timestamp_bindings_since, timestamp_bindings_upper) =
+                stream_desc_from_name(
+                    serialized_details.timestamp_bindings_stream.clone(),
+                    runtime,
+                )?;
+
+            // Assert invariants!
+            assert_eq!(
+                primary_since, timestamp_bindings_since,
+                "the since of all involved streams must be the same"
+            );
+            assert_eq!(
+                primary_upper, timestamp_bindings_upper,
+                "the upper of all involved streams must be the same"
+            );
 
             Ok(SourcePersistDesc {
+                since_ts: primary_since,
+                upper_seal_ts: primary_upper,
                 primary_stream,
                 timestamp_bindings_stream,
                 envelope_desc,
@@ -452,7 +465,7 @@ impl PersisterWithConfig {
 fn stream_desc_from_name(
     name: String,
     runtime: &RuntimeClient,
-) -> Result<PersistStreamDesc, Error> {
+) -> Result<(String, u64, u64), Error> {
     let description = runtime.get_description(&name);
     let description = match description {
         Ok(description) => description,
@@ -460,11 +473,7 @@ fn stream_desc_from_name(
             // The stream has not been created yet, so return the initial seal timestamp of
             // streams.
             // TODO: We might want to codify this somewhere?
-            return Ok(PersistStreamDesc {
-                name,
-                upper_seal_ts: u64::minimum(),
-                since_ts: u64::minimum(),
-            });
+            return Ok((name, u64::minimum(), u64::minimum()));
         }
         Err(e) => {
             let error_string = format!("Reading upper seal timestamp for {}: {}", name, e);
@@ -485,11 +494,7 @@ fn stream_desc_from_name(
         description.since().iter().exactly_one().map_err(|_| {
             format!("expected exactly one element in the persist compaction frontier")
         })?;
-    Ok(PersistStreamDesc {
-        name,
-        upper_seal_ts: *upper_seal_ts,
-        since_ts: *since_ts,
-    })
+    Ok((name, *since_ts, *upper_seal_ts))
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -996,11 +996,10 @@ where
                 let starting_offsets = source_persist.get_starting_offsets(valid_bindings.iter());
 
                 tracing::debug!(
-                    "In {}, initial (restored) source offsets: {:?}. upper_bindings_seal_ts = {}, upper_data_seal_ts = {}",
+                    "In {}, initial (restored) source offsets: {:?}. upper_seal_ts = {}",
                     name,
                     starting_offsets,
-                    source_persist.config.upper_bindings_seal_ts,
-                    source_persist.config.upper_data_seal_ts,
+                    source_persist.config.upper_seal_ts,
                 );
 
                 tracing::debug!(
@@ -1059,7 +1058,7 @@ where
                     }
                 }
 
-                Ok((Some(source_persist), Some(valid_bindings), Some(retractions), persist_config.upper_bindings_seal_ts))
+                Ok((Some(source_persist), Some(valid_bindings), Some(retractions), persist_config.upper_seal_ts))
             });
 
                 match result {
@@ -1343,8 +1342,6 @@ impl SourceReaderPersistence {
         ),
         persist::error::Error,
     > {
-        assert!(self.config.upper_bindings_seal_ts >= self.config.upper_data_seal_ts);
-
         // Materialized version of bindings updates that are not beyond the common seal timestamp.
         let mut valid_bindings: HashMap<_, isize> = HashMap::new();
 
@@ -1358,7 +1355,7 @@ impl SourceReaderPersistence {
         // sealed. Thus, it represents the content of the timestamp histories at exactly that
         // point.
         for ((source_timestamp, assigned_timestamp), ts, diff) in buf.into_iter() {
-            if ts < self.config.upper_data_seal_ts {
+            if ts < self.config.upper_seal_ts {
                 *valid_bindings
                     .entry((source_timestamp.clone(), assigned_timestamp))
                     .or_default() += diff;
@@ -1461,14 +1458,8 @@ impl SourceReaderPersistence {
 /// bindings.
 #[derive(Clone)]
 pub struct PersistentTimestampBindingsConfig<ST: Codec, AT: Codec> {
-    /// The timestamp up to which which timestamp bindings have been sealed.
-    upper_bindings_seal_ts: u64,
-
-    /// The timestamp up to which which data (the updates read from the source) has been sealed.
-    ///
-    /// This can be different from `upper_bindings_seal_ts` because we seal bindings before data,
-    /// and the latter can fail after we succesfully sealed the bindings.
-    upper_data_seal_ts: u64,
+    /// The timestamp up to which all involved streams have been sealed.
+    upper_seal_ts: u64,
 
     /// [`StreamReadHandle`] for the collection that we should persist to.
     read_handle: StreamReadHandle<ST, AT>,
@@ -1480,17 +1471,12 @@ pub struct PersistentTimestampBindingsConfig<ST: Codec, AT: Codec> {
 impl<K: Codec, V: Codec> PersistentTimestampBindingsConfig<K, V> {
     /// Creates a new [`PersistentTimestampBindingsConfig`] from the given parts.
     pub fn new(
-        upper_bindings_seal_ts: u64,
-        upper_data_seal_ts: u64,
+        upper_seal_ts: u64,
         read_handle: StreamReadHandle<K, V>,
         write_handle: StreamWriteHandle<K, V>,
     ) -> Self {
-        // We always seal bindings before data.
-        assert!(upper_bindings_seal_ts >= upper_data_seal_ts);
-
         PersistentTimestampBindingsConfig {
-            upper_bindings_seal_ts,
-            upper_data_seal_ts,
+            upper_seal_ts,
             read_handle,
             write_handle,
         }


### PR DESCRIPTION
Before the recent change to use an atomic `seal()` for sealing up the
collections involved in the sink, we were working with the invariant
that the seal ts for timestamp bindings is always beyond the seal ts of
the data but that the two could be different.

Now, we use the newly introduced invariant to simplify the restore logic
which now assumes that the seal (and compaction frontier) are always the
same. We also assert that invariant.

### Tips for reviewer

@ruchirK Sorry for the barrage, but this one should be uncontroversial. :sweat_smile: 

### Checklist

- [N/A] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
