### PR TITLE
scratch: make type of default max_age a float

### DIFF
--- a/misc/python/materialize/cli/scratch/create.py
+++ b/misc/python/materialize/cli/scratch/create.py
@@ -26,7 +26,7 @@ from materialize.scratch import (
     whoami,
 )
 
-MAX_AGE = datetime.timedelta(days=1.5)
+MAX_AGE_DAYS = 1.5
 
 
 def multi_json(s: str) -> List[Dict[Any, Any]]:
@@ -81,7 +81,7 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
             "Hint: `dev-box` is a good starter!"
         ),
     )
-    parser.add_argument("--max-age-days", type=float, default=MAX_AGE)
+    parser.add_argument("--max-age-days", type=float, default=MAX_AGE_DAYS)
 
 
 def run(args: argparse.Namespace) -> None:


### PR DESCRIPTION
Previously, bin/scratch create would crash with the following:

TypeError: '<=' not supported between instances of 'datetime.timedelta' and 'int'

This commit changes the default to a float and by so doing avoids the error.

<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug: [Link to issue.]

  * This PR adds a known-desirable feature: [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
