### PR TITLE
Reenable TimestampBindingBox compaction

### DIFF
--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -1259,6 +1259,8 @@ where
             timestamp_histories.downgrade(cap, &partition_cursors);
             bindings_cap.downgrade(cap.time());
             source_metrics.capability.set(*cap.time());
+            // Downgrade compaction frontier to track the current time.
+            timestamp_histories.set_compaction_frontier(Antichain::from_elem(*cap.time()).borrow());
 
             let (source_status, processing_status) = source_state;
             // Schedule our next activation


### PR DESCRIPTION
As part of code refactoring, the call to `timestamp_bindings.set_compaction_frontier()` was lost, preventing compaction of the `TimestampBindingBox` containing timestamp bindings. The list of bindings would grow without bound, with presumably deleterious consequences.

Fixes #10513

### Motivation

This PR fixes an existing bug: #10513

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
