### PR TITLE
Partition storage and compute dataflows

### DIFF
--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -217,7 +217,7 @@ pub struct SourceBoundary {
     pub err: Rc<EventLink<repr::Timestamp, (DataflowError, repr::Timestamp, repr::Diff)>>,
     /// A token that should be dropped to terminate the source.
     pub token: Rc<Option<crate::source::SourceToken>>,
-    /// Additional tokens that should be dropped to terminate the suorce.
+    /// Additional tokens that should be dropped to terminate the source.
     pub additional_tokens: Vec<Rc<dyn std::any::Any>>,
 }
 
@@ -244,9 +244,6 @@ pub fn build_storage_dataflow<A: Allocate>(
         // so that other similar uses (e.g. with iterative scopes) do not require weird
         // alternate type signatures.
         scope.clone().region_named(&name, |region| {
-            // let mut context = Context::for_dataflow(&dataflow, scope.addr().into_element());
-            // let mut tokens = RelevantTokens::default();
-
             let as_of = dataflow.as_of.clone().unwrap();
             let dataflow_id = scope.addr().into_element();
             let debug_name = format!("{}-sources", dataflow.debug_name);
@@ -300,7 +297,7 @@ pub fn build_storage_dataflow<A: Allocate>(
     results
 }
 
-/// Assemble the "compute"  side of a datalfow, i.e. all but the sources.
+/// Assemble the "compute"  side of a dataflow, i.e. all but the sources.
 ///
 /// This method imports sources from provided assets, and then builds the remaining
 /// dataflow using "compute-local" assets like shared arrangements, and producing
@@ -314,7 +311,6 @@ pub fn build_compute_dataflow<A: Allocate>(
 ) {
     let worker_logging = timely_worker.log_register().get("timely");
     let name = format!("Dataflow: {}", &dataflow.debug_name);
-    // let materialized_logging = timely_worker.log_register().get("materialized");
 
     timely_worker.dataflow_core(&name, worker_logging, Box::new(()), |_, scope| {
         // The scope.clone() occurs to allow import in the region.

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -671,13 +671,19 @@ where
                         }
                     }
 
-                    render::build_dataflow(
+                    let sources_captured = render::build_storage_dataflow(
                         self.timely_worker,
-                        &mut self.compute_state,
                         &mut self.storage_state,
-                        dataflow,
+                        &dataflow,
                         self.now.clone(),
                         &self.dataflow_source_metrics,
+                    );
+
+                    render::build_compute_dataflow(
+                        self.timely_worker,
+                        &mut self.compute_state,
+                        sources_captured,
+                        dataflow,
                         &self.dataflow_sink_metrics,
                     );
                 }


### PR DESCRIPTION
This PR partitions source creation into its own dataflow, and uses timely's `capture` and `replay` to transport the results into the dataflow for the rest of the stuff. This intentionally breaks dataflows into "storage" and "compute", so that we can see the boundary. This change keeps the partitioned dataflows on the same workers, to avoid disrupting flow-control norms at the moment. We'll break that in the future, once we understand things clearly.

### Motivation

We aim to break apart this functionality, and want to understand what is up.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
