### PR TITLE
Clean up token use in dataflow

### DIFF
--- a/src/dataflow/src/render/sinks.rs
+++ b/src/dataflow/src/render/sinks.rs
@@ -24,7 +24,6 @@ use interchange::envelopes::{combine_at_timestamp, dbz_format, upsert_format};
 use repr::{Datum, Diff, Row, Timestamp};
 
 use crate::render::context::Context;
-use crate::render::RelevantTokens;
 use crate::sink::SinkBaseMetrics;
 
 impl<G> Context<G, Row, Timestamp>
@@ -35,7 +34,7 @@ where
     pub(crate) fn export_sink(
         &mut self,
         compute_state: &mut crate::render::ComputeState,
-        tokens: &mut RelevantTokens,
+        tokens: &mut std::collections::BTreeMap<GlobalId, Rc<dyn std::any::Any>>,
         import_ids: HashSet<GlobalId>,
         sink_id: GlobalId,
         sink: &SinkDesc,
@@ -44,15 +43,10 @@ where
         let sink_render = get_sink_render_for(&sink.connector);
 
         // put together tokens that belong to the export
-        let mut needed_source_tokens = Vec::new();
-        let mut needed_additional_tokens = Vec::new();
-        let mut needed_sink_tokens = Vec::new();
+        let mut needed_tokens = Vec::new();
         for import_id in import_ids {
-            if let Some(addls) = tokens.additional_tokens.get(&import_id) {
-                needed_additional_tokens.extend_from_slice(addls);
-            }
-            if let Some(source_token) = tokens.source_tokens.get(&import_id) {
-                needed_source_tokens.push(Rc::clone(&source_token));
+            if let Some(token) = tokens.get(&import_id) {
+                needed_tokens.push(Rc::clone(&token))
             }
         }
 
@@ -89,17 +83,12 @@ where
             sink_render.render_continuous_sink(compute_state, sink, sink_id, collection, metrics);
 
         if let Some(sink_token) = sink_token {
-            needed_sink_tokens.push(sink_token);
+            needed_tokens.push(sink_token);
         }
 
-        let tokens = Rc::new((
-            needed_sink_tokens,
-            needed_source_tokens,
-            needed_additional_tokens,
-        ));
         compute_state
             .dataflow_tokens
-            .insert(sink_id, Box::new(tokens));
+            .insert(sink_id, Box::new(needed_tokens));
     }
 }
 
@@ -231,7 +220,7 @@ where
         sink_id: GlobalId,
         sinked_collection: Collection<G, (Option<Row>, Option<Row>), Diff>,
         metrics: &SinkBaseMetrics,
-    ) -> Option<Box<dyn Any>>
+    ) -> Option<Rc<dyn Any>>
     where
         G: Scope<Timestamp = Timestamp>;
 }

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -129,8 +129,8 @@ where
 
 /// Constructs a `CollectionBundle` and tokens from source arguments.
 ///
-/// The first return value is the collection bundle, and the second a pair of source and additional
-/// tokens, that are used to control the demolition of the source.
+/// The first returned pair are the row and error collections, and the
+/// second is a token that will keep the source alive as long as it is held.
 pub(crate) fn import_source<G>(
     dataflow_debug_name: &String,
     dataflow_id: usize,
@@ -638,7 +638,7 @@ where
 
             needed_tokens.push(source_token);
 
-            // Return the source token for capability manipulation, and any additional tokens.
+            // Return the collections and any needed tokens.
             ((collection, err_collection), Rc::new(needed_tokens))
         }
     }

--- a/src/dataflow/src/sink/avro_ocf.rs
+++ b/src/dataflow/src/sink/avro_ocf.rs
@@ -9,6 +9,7 @@
 
 use std::any::Any;
 use std::fs::OpenOptions;
+use std::rc::Rc;
 
 use differential_dataflow::{Collection, Hashable};
 
@@ -50,7 +51,7 @@ where
         sink_id: GlobalId,
         sinked_collection: Collection<G, (Option<Row>, Option<Row>), Diff>,
         _metrics: &SinkBaseMetrics,
-    ) -> Option<Box<dyn Any>>
+    ) -> Option<Rc<dyn Any>>
     where
         G: Scope<Timestamp = Timestamp>,
     {

--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -87,7 +87,7 @@ where
         sink_id: GlobalId,
         sinked_collection: Collection<G, (Option<Row>, Option<Row>), Diff>,
         metrics: &SinkBaseMetrics,
-    ) -> Option<Box<dyn Any>>
+    ) -> Option<Rc<dyn Any>>
     where
         G: Scope<Timestamp = Timestamp>,
     {
@@ -950,7 +950,7 @@ fn kafka<G>(
     as_of: SinkAsOf,
     write_frontier: Rc<RefCell<Antichain<Timestamp>>>,
     metrics: &KafkaBaseMetrics,
-) -> Box<dyn Any>
+) -> Rc<dyn Any>
 where
     G: Scope<Timestamp = Timestamp>,
 {
@@ -1027,7 +1027,7 @@ pub fn produce_to_kafka<G>(
     shared_gate_ts: Rc<Cell<Option<Timestamp>>>,
     write_frontier: Rc<RefCell<Antichain<Timestamp>>>,
     metrics: &KafkaBaseMetrics,
-) -> Box<dyn Any>
+) -> Rc<dyn Any>
 where
     G: Scope<Timestamp = Timestamp>,
 {
@@ -1287,7 +1287,7 @@ where
         }),
     );
 
-    Box::new(KafkaSinkToken { shutdown_flag })
+    Rc::new(KafkaSinkToken { shutdown_flag })
 }
 
 /// Encodes a stream of `(Option<Row>, Option<Row>)` updates using the specified encoder.

--- a/src/dataflow/src/sink/tail.rs
+++ b/src/dataflow/src/sink/tail.rs
@@ -59,7 +59,7 @@ where
         sink_id: GlobalId,
         sinked_collection: Collection<G, (Option<Row>, Option<Row>), Diff>,
         _metrics: &SinkBaseMetrics,
-    ) -> Option<Box<dyn Any>>
+    ) -> Option<Rc<dyn Any>>
     where
         G: Scope<Timestamp = Timestamp>,
     {
@@ -92,7 +92,7 @@ where
         // Inform the coordinator that we have been dropped,
         // and destroy the tail protocol so the sink operator
         // can't send spurious messages while shutting down.
-        Some(Box::new(scopeguard::guard((), move |_| {
+        Some(Rc::new(scopeguard::guard((), move |_| {
             if let Some(tail_protocol_handle) = tail_protocol_weak.upgrade() {
                 std::mem::drop(tail_protocol_handle.borrow_mut().take())
             }

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -268,13 +268,6 @@ pub struct SourceToken {
     activator: Activator,
 }
 
-impl SourceToken {
-    /// Re-activates the associated timely source operator.
-    pub fn activate(&self) {
-        self.activator.activate();
-    }
-}
-
 impl Drop for SourceToken {
     fn drop(&mut self) {
         *self.capabilities.borrow_mut() = None;


### PR DESCRIPTION
The PR tries to simplify our use of "tokens" in `dataflow`: things that you hold to communicate that some precursor part of the dataflow needs to be kept active (e.g. sources, indexes, other things). We had a few flavors of these, but their distinctions didn't seem helpful, and they have all been unified as `Rc<dyn Any>`.

### Motivation

   * This PR refactors existing code.

The distinctions between the types of tokens led to unnecessary complexity in the code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
