### PR TITLE
test: Add explicit topic_metadata_refresh_interval_ms to product limi…

### DIFF
--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -187,6 +187,7 @@ class KafkaPartitions(Generator):
         print(
             """> CREATE MATERIALIZED SOURCE s1
             FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-kafka-partitions-${testdrive.seed}'
+            WITH (topic_metadata_refresh_interval_ms = 1000)
             FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
             ENVELOPE NONE;
             """


### PR DESCRIPTION
…ts test

The topic_metadata_refresh_interval_ms default has changed from 30s
to 300s. To allow the KafkaPartitions product limits test to pass within
a reasonable time frame, explicitly pass topic_metadata_refresh_interval_ms=1000

<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug: [Link to issue.]

  * This PR adds a known-desirable feature: [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
