### PR TITLE
Revert "Partition storage and compute dataflows"

### DIFF
--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -69,7 +69,7 @@ pub(crate) fn import_table<G>(
     persisted_name: Option<String>,
 ) -> (
     LocalInput,
-    (Collection<G, Row>, Collection<G, DataflowError>),
+    crate::render::CollectionBundle<G, Row, Timestamp>,
 )
 where
     G: Scope<Timestamp = Timestamp>,
@@ -124,7 +124,10 @@ where
         })
         .as_collection();
 
-    (local_input, (ok_collection, err_collection))
+    let collection_bundle =
+        crate::render::CollectionBundle::from_collections(ok_collection, err_collection);
+
+    (local_input, collection_bundle)
 }
 
 /// Constructs a `CollectionBundle` and tokens from source arguments.
@@ -147,7 +150,7 @@ pub(crate) fn import_source<G>(
     now: NowFn,
     base_metrics: &SourceBaseMetrics,
 ) -> (
-    (Collection<G, Row>, Collection<G, DataflowError>),
+    crate::render::CollectionBundle<G, Row, Timestamp>,
     (
         Rc<Option<crate::source::SourceToken>>,
         Vec<Rc<dyn std::any::Any>>,
@@ -177,12 +180,12 @@ where
         // Create a new local input (exposed as TABLEs to users). Data is inserted
         // via Command::Insert commands.
         SourceConnector::Local { persisted_name, .. } => {
-            let (local_input, (ok, err)) =
+            let (local_input, collection_bundle) =
                 import_table(as_of_frontier, storage_state, scope, persisted_name);
             storage_state.local_inputs.insert(src_id, local_input);
 
             // TODO(mcsherry): Local tables are a special non-source we should relocate.
-            ((ok, err), (Rc::new(None), Vec::new()))
+            (collection_bundle, (Rc::new(None), Vec::new()))
         }
 
         SourceConnector::External {
@@ -629,6 +632,10 @@ where
             use differential_dataflow::operators::consolidate::ConsolidateStream;
             collection = collection.consolidate_stream();
 
+            // Introduce the stream by name, as an unarranged collection.
+            let collection_bundle =
+                crate::render::CollectionBundle::from_collections(collection, err_collection);
+
             let source_token = Rc::new(capability);
 
             // We also need to keep track of this mapping globally to activate sources
@@ -640,10 +647,7 @@ where
                 .push(Rc::downgrade(&source_token));
 
             // Return the source token for capability manipulation, and any additional tokens.
-            (
-                (collection, err_collection),
-                (source_token, additional_tokens),
-            )
+            (collection_bundle, (source_token, additional_tokens))
         }
     }
 }

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -671,19 +671,13 @@ where
                         }
                     }
 
-                    let sources_captured = render::build_storage_dataflow(
-                        self.timely_worker,
-                        &mut self.storage_state,
-                        &dataflow,
-                        self.now.clone(),
-                        &self.dataflow_source_metrics,
-                    );
-
-                    render::build_compute_dataflow(
+                    render::build_dataflow(
                         self.timely_worker,
                         &mut self.compute_state,
-                        sources_captured,
+                        &mut self.storage_state,
                         dataflow,
+                        self.now.clone(),
+                        &self.dataflow_source_metrics,
                         &self.dataflow_sink_metrics,
                     );
                 }


### PR DESCRIPTION
Reverts MaterializeInc/materialize#10519

The PR causes 100% CPU utilization due to using the non-activated `replay_into` functionality.