### PR TITLE
mzcompose,feature-benchmark: Ensure --dev option is in effect when ne…

### DIFF
--- a/bin/mzcompose
+++ b/bin/mzcompose
@@ -11,4 +11,9 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")"/pyactivate -m materialize.cli.mzcompose "$@"
+if [ "$1" == "--dev" ] ; then
+   shift
+   exec "$(dirname "$0")"/pyactivate --dev -m materialize.cli.mzcompose "$@"
+else
+   exec "$(dirname "$0")"/pyactivate -m materialize.cli.mzcompose "$@"
+fi

--- a/doc/developer/feature-benchmark.md
+++ b/doc/developer/feature-benchmark.md
@@ -6,12 +6,6 @@ such as TPC-H.
 
 # Running
 
-First, make sure your python environment is up to speed:
-
-```
-bin/pyactivate --dev
-```
-
 The `--help` option can be used to show supported options:
 
 ```
@@ -22,6 +16,12 @@ To run the default benchmark scenarios:
 ```
 cd test/feature-benchmark
 ./mzcompose run default --other-tag unstable
+```
+
+Or, from the root of the repository:
+
+```
+bin/mzcompose --dev --find feature-benchmark run default --other-tag unstable
 ```
 
 This is going to benchmark the current source against the `materialize/materialized:unstable` container from DockerHub.

--- a/test/feature-benchmark/mzcompose
+++ b/test/feature-benchmark/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../bin/mzcompose" "$@"
+exec "$(dirname "$0")/../../bin/mzcompose" --dev "$@"


### PR DESCRIPTION
…eded

In order to avoid user frustration, the feature benchmark should run even
if the environment has not been primed with bin/pyactivate --dev in advance.

* Enable --dev if ./mzcompose from the feature directory is called
* Enable --dev if bin/mzcompose --dev is used
* Remove the documentation step where bin/pyactivate --dev was mentioned


### Motivation

  * This PR fixes a previously unreported bug.
The feature benchmark would only run on environments that were primed with bin/pyactivate --dev in advance. If that step was not executed, a cryptic error would occur which would lead to user frustration.