### PR TITLE
doc/user: Update Postgres source documentation page and guides

### DIFF
--- a/doc/user/content/guides/cdc-postgres.md
+++ b/doc/user/content/guides/cdc-postgres.md
@@ -17,7 +17,7 @@ There are two ways to connect Materialize to a Postgres database for CDC:
 
 ## Direct Postgres source
 
-If Kafka is not part of your stack, you can use the [Postgres source](/sql/create-source/postgres) to connect directly to Materialize (v0.8.2+). This source uses Postgres’ native replication protocol to continuously ingest changes resulting from `INSERT`, `UPDATE` and `DELETE` operations in the upstream database.
+If Kafka is not part of your stack, you can use the [Postgres source](/sql/create-source/postgres) to connect directly to Materialize (v0.8.2+). This source uses Postgres’ native replication protocol to continually ingest changes resulting from `INSERT`, `UPDATE` and `DELETE` operations in the upstream database.
 
 ### Database setup
 

--- a/doc/user/content/guides/cdc-postgres.md
+++ b/doc/user/content/guides/cdc-postgres.md
@@ -17,7 +17,7 @@ There are two ways to connect Materialize to a Postgres database for CDC:
 
 ## Direct Postgres source
 
-If Kafka is not part of your stack, you can use the [Postgres source](/sql/create-source/postgres/#postgresql-source-details) to connect directly to Materialize (v0.8.2+). This source uses Postgres’ native replication protocol to continuously ingest changes resulting from `INSERT`, `UPDATE` and `DELETE` operations in the upstream database.
+If Kafka is not part of your stack, you can use the [Postgres source](/sql/create-source/postgres) to connect directly to Materialize (v0.8.2+). This source uses Postgres’ native replication protocol to continuously ingest changes resulting from `INSERT`, `UPDATE` and `DELETE` operations in the upstream database.
 
 ### Database setup
 

--- a/doc/user/content/guides/postgres-cloud.md
+++ b/doc/user/content/guides/postgres-cloud.md
@@ -4,7 +4,7 @@ description: "How to configure Postgres CDC for instances hosted on cloud servic
 aliases:
 ---
 
-**Required:** PostgreSQL 10+
+**Minimum requirements:** Postgres 10+
 
 To use a PostgreSQL instance running on Amazon RDS, AWS Aurora, or Cloud SQL for [Change Data Capture](../cdc-postgres/), you need to ensure that the database is configured to support logical replication.
 
@@ -40,7 +40,7 @@ As an account with the `rds_superuser` role, make these changes to the upstream 
     CREATE PUBLICATION mz_source FOR ALL TABLES;
     ```
 
-    The `mz_source` publication will contain the set of change events generated from the specified tables, and will later be used to ingest the replication stream. We strongly recommend that you **limit** publications only to the tables you need.
+    The `mz_source` publication will contain the set of change events generated from the specified tables, and will later be used to ingest the replication stream.
 
 For more information, see the [Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts.General.FeatureSupport.LogicalReplication) documentation.
 
@@ -89,7 +89,7 @@ As a superuser, make these changes to the upstream database:
     CREATE PUBLICATION mz_source FOR ALL TABLES;
     ```
 
-    The `mz_source` publication will contain the set of change events generated from the specified tables, and will later be used to ingest the replication stream. We strongly recommend that you **limit** publications only to the tables you need.
+    The `mz_source` publication will contain the set of change events generated from the specified tables, and will later be used to ingest the replication stream.
 
 For more information, see the [AWS Aurora](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Replication.Logical.html#AuroraPostgreSQL.Replication.Logical.Configure) documentation.
 
@@ -119,11 +119,11 @@ As a user with the `cloudsqlsuperuser` role, make these changes to the upstream 
     CREATE PUBLICATION mz_source FOR ALL TABLES;
     ```
 
-    The `mz_source` publication will contain the set of change events generated from the specified tables, and will later be used to ingest the replication stream. We strongly recommend that you **limit** publications only to the tables you need.
+    The `mz_source` publication will contain the set of change events generated from the specified tables, and will later be used to ingest the replication stream.
 
 For more information, see the [Cloud SQL](https://cloud.google.com/sql/docs/postgres/replication/configure-logical-replication#configuring-your-postgresql-instance) documentation.
 
 ## Related pages
 
-- [Change Data Capture with PostgreSQL](../cdc-postgres/)
+- [Change Data Capture (Postgres)](../cdc-postgres/)
 - [`CREATE SOURCE FROM POSTGRES`](/sql/create-source/postgres/)

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -489,7 +489,7 @@ Improve PostgreSQL compatibility:
   error of the form "exceeded recursion limit of {X}".
 
 - Correctly autogenerate views from Postgres sources during [`CREATE
-  VIEWS`](/sql/create-source/postgres/#creating-views) when the upstream table
+  VIEWS`](/sql/create-source/postgres/#creating-replication-views) when the upstream table
   contains numeric columns with no specified scale and precision {{% gh 9268
   %}}.
 

--- a/doc/user/content/sql/create-source/postgres.md
+++ b/doc/user/content/sql/create-source/postgres.md
@@ -1,6 +1,6 @@
 ---
 title: "CREATE SOURCE: PostgreSQL"
-description: "Learn how to connect Materialize to a PostgreSQL database."
+description: "Connecting Materialize to a PostgreSQL database"
 menu:
   main:
     parent: 'create-source'
@@ -13,7 +13,7 @@ aliases:
 {{< version-added v0.8.0 />}}
 
 {{% create-source/intro %}}
-This document details how to connect Materialize to a Postgres database for Postgres versions 10 and higher. Before you create the source in Materialize, you must perform [some prerequisite steps](#postgresql-source-details) in Postgres.
+This page details how to connect Materialize to a PostgreSQL (10+) database to create and efficiently maintain real-time materialized views on top of a replication stream.
 {{% /create-source/intro %}}
 
 ## Syntax
@@ -36,132 +36,107 @@ Field | Value type | Description
 ------|------------|------------
 `timestamp_frequency_ms`  |  `int` |  Default: `1000`. Sets the timestamping frequency in `ms`. Reflects how frequently the source advances its timestamp. This measure reflects how stale data in views will be. Lower values result in more-up-to-date views but may reduce throughput.
 
-## PostgreSQL source details
+## Features
 
-Materialize makes use of PostgreSQL's native replication capabilities to create a continuously updated replica of the desired Postgres tables.
+### Change data capture
 
-Before creating the source in Materialize, you must:
+This source uses PostgreSQL's native replication protocol to continuously ingest changes resulting from `INSERT`, `UPDATE` and `DELETE` operations in the upstream database (also know as _change data capture_).
 
-1. Set up your Postgres database to allow logical replication.
+For this reason, the upstream database must be configured to support logical replication. To get logical replication set up, follow the step-by-step instructions in the [Change Data Capture (Postgres) guide](/guides/cdc-postgres/#direct-postgres-source).
 
-1. Ensure that the user for your Materialize connection has `REPLICATION` privileges.
+#### Creating a source
 
-1. Make sure replica identity is set to `FULL` for all tables you want to stream to Materialize.
-
-     As a heads-up, you should expect a performance hit in the database from increased CPU usage. For more information, see the [PostgreSQL documentation](https://www.postgresql.org/docs/current/logical-replication-publication.html).
-
-1. Create a Postgres [publication](https://www.postgresql.org/docs/current/logical-replication-publication.html), or replication data set, containing the tables to be streamed to Materialize.
-
-Once you create a materialized source from the publication, the source will contain the raw data stream of replication updates. You can then break the stream out into views that represent the publication's original tables with [`CREATE VIEWS`](/sql/create-views/). You can treat these tables as you would any other source and create other views or materialized views from them.
-
-### Postgres schemas
-
-`CREATE VIEWS` will attempt to create each upstream table in the same schema as Postgres. For example, if the publication contains tables `"public"."foo"` and `"otherschema"."foo"`, `CREATE VIEWS` is the equivalent of:
-
-```
-CREATE VIEW "public"."foo";
-CREATE VIEW "otherschema"."foo";
-```
-
-Therefore, in order for `CREATE VIEWS` to succeed, all upstream schemas included in the publication must exist in Materialize as well, or you must explicitly specify the downstream schemas and rename the resulting tables. For example:
+To avoid creating multiple replication slots upstream and minimize the required bandwidth, Materialize ingests the raw replication stream data for **all** tables included in a specific publication. This means that, when you define a source:
 
 ```sql
-CREATE VIEWS FROM "mz_source"
-("public"."foo" AS "foo", "otherschema"."foo" AS "foo2");
+CREATE SOURCE mz_source
+FROM POSTGRES
+  CONNECTION 'host=example.com port=5432 user=host dbname=postgres sslmode=require'
+  PUBLICATION 'mz_source';
 ```
-### Postgres replication slots
+
+, its schema looks like:
+
+```sql
+SHOW COLUMNS FROM mz_source;
+
+   name   | nullable |  type
+----------+----------+---------
+ oid      | f        | integer
+ row_data | f        | list
+```
+
+where each row of every upstream table is represented as a single row with two columns:
+
+| Column | Description |
+|--------|-------------|
+| `oid`  | A unique identifier for the tables included in the publication. |
+| `row_data` | A text-encoded, variable length `list`. The number of text elements in a list is always equal to the number of columns in the upstream table. |
+
+#### Creating replication views
+
+From here, you can break down the source into views that reproduce the publication's original tables based on the `oid` identifier and convert the text elements in `row_data` to the original data types:
+
+_Create views for specific tables included in the Postgres publication_
+
+```sql
+CREATE VIEWS FROM SOURCE mz_source (table1, table2);
+```
+
+_Create views for all tables_
+
+```sql
+CREATE VIEWS FROM SOURCE mz_source;
+```
+
+Under the hood, Materialize parses this statement into view definitions for each table that can be used as a base for your materialized view.
+
+##### Postgres schemas
+
+`CREATE VIEWS` will attempt to create each upstream table in the same schema as Postgres. For example, if the publication contains tables `public.foo` and `otherschema.foo`, `CREATE VIEWS` is the equivalent of:
+
+```sql
+CREATE VIEW public.foo;
+
+CREATE VIEW otherschema.foo;
+```
+
+For `CREATE VIEWS` to succeed, either all upstream schemas included in the publication must exist in Materialize as well, or you must explicitly specify the downstream schemas and rename the resulting views:
+
+```sql
+CREATE VIEWS FROM SOURCE mz_source
+(public.foo AS foo, otherschema.foo AS foo2);
+```
+
+#### Creating materialized views
+
+To produce correct results, Postgres sources can only be materialized _once_. As soon as you define a materialized view, Materialize:
+
+1. Creates a replication slot in the upstream Postgres database (see [Postgres replication slots](#postgres-replication-slots)). The name of the replication slots created by Materialize is prefixed with `materialize_` for easy identification.
+
+1. Performs an initial, snapshot-based sync of the tables in the publication before it starts ingesting change events.
+
+   **Note:** During this phase, **disk space** consumption may increase before returning to a steady state. To profile disk usage, see [Troubleshooting](/ops/troubleshooting/#how-much-disk-space-is-materialize-using).
+
+1. Incrementally updates the view as new change events stream in as a result of `INSERT`, `UPDATE` and `DELETE` operations in the upstream Postgres database.
+
+##### Postgres replication slots
+
+Each Materialize replication slot can be used to source data for a single materialized view. You can create multiple non-materialized views for the same replication slot using the [`CREATE VIEWS`](/sql/create-views) statement.
 
 {{< warning >}}
 Make sure to delete any replication slots if you stop using Materialize or if either your Materialize or Postgres instances crash.
 {{< /warning >}}
 
-If you stop or delete Materialize without first dropping the Postgres source, the Postgres replication slot isn't deleted and will continue to accumulate data. In such cases, you should manually delete the Materialize replication slot to recover memory and avoid degraded performance in the upstream database. Materialize replication slot names always begin with `materialize_` for easy identification.
+If you stop Materialize or delete the materialized view without dropping the Postgres source first, the upstream replication slot isn't deleted and will continue to accumulate data. In such cases, you should manually delete the replication slot to recover memory and avoid degraded performance in the upstream database.
 
-Each Materialize replication slot can be used to source data for at most one set of materialized views. You can create multiple unmaterialized views for the same replication slot using the [`CREATE VIEWS`](/sql/create-views) statement.
-
-### Restrictions on Postgres sources
+## Known limitations
 
 - **Schema changes:** Materialize does not support changes to schemas for existing publications. You need to drop the existing sources and then recreate them after creating new publications for the updated schemas.
 - **Supported data types:** Sources can only be created from publications that use [data types](/sql/types/) supported by Materialize. Attempts to create sources from publications which contain unsupported data types will fail with an error.
-- **Truncation:** Tables replicated into Materialize should not be truncated. If a table is truncated while replicated, the whole source becomes inaccessible and will not produce any data until it is re-created.
-- **Resource usage:**
-    - During the initial table sync, **disk space** consumption may increase proportionally to the size of the upstream database before returning to a steady state. To profile disk usage, see [Troubleshooting](/ops/troubleshooting/#how-much-disk-space-is-materialize-using).
+- **Truncation:** Tables replicated into Materialize should not be truncated. If a table is truncated while replicated, the whole source becomes inaccessible and will not produce any data until it is recreated.
 
-### Supported Postgres versions
-
-Postgres sources in Materialize require that upstream Postgres instances be [version 10](https://www.postgresql.org/about/news/postgresql-10-released-1786/) or greater.
-
-## Examples
-
-### Setting up PostgreSQL
-
-Before you create a Postgres source in Materialize, you must complete the following prerequisite steps in Postgres.
-
-1. Ensure the database configuration allows logical replication. For most configurations, it should suffice to set `wal_level = logical` in `postgresql.conf`.
-
-    **Note:** If you're using Postgres on a Cloud service like Amazon RDS, AWS Aurora, or Cloud SQL, you'll need to take some additional steps. For more information, see [Postgres CDC in the Cloud](/guides/postgres-cloud/).
-
-2. Assign the user `REPLICATION` privileges:
-    ```sql
-    ALTER ROLE "user" WITH REPLICATION;
-    ```
-3. Set replica identity to full for all the tables that you wish to replicate:
-    ```sql
-    ALTER TABLE foo
-    REPLICA IDENTITY FULL;
-    ```
-
-    This setting determines the amount of information that is written to the WAL in `UPDATE` and `DELETE` operations. Setting it to `FULL` will include the previous values of all the table’s columns in the change events.
-
-    As a heads-up, you should expect a performance hit in the database from increased CPU usage. For more information, see the [PostgreSQL documentation](https://www.postgresql.org/docs/current/logical-replication-publication.html).
-
-4. Create a publication containing all the tables you wish to query in Materialize:
-
-    *For all tables in Postgres:*
-    ```sql
-    CREATE PUBLICATION mz_source FOR ALL TABLES;
-    ```
-
-    *For specific tables:*
-    ```sql
-    CREATE PUBLICATION mz_source FOR TABLE table1, table2;
-    ```
-
-### Creating a source
-
-Once you have set up Postgres, you can create the source in Materialize.
-
-```sql
-CREATE MATERIALIZED SOURCE "mz_source" FROM POSTGRES
-CONNECTION 'host=postgres port=5432 user=host sslmode=require dbname=postgres'
-PUBLICATION 'mz_source';
-```
-
-This creates a source that...
-
-- Connects to a Postgres server
-- Contains raw data from all of the tables that went into the publication
-- Needs to broken out into more usable views that reproduce the original Postgres tables
-
-### Creating views
-
-Once you have created the Postgres source, you need to create views that represent the upstream publication's original tables.
-
-*Create views for all tables included in the Postgres publication*
-
-```sql
-CREATE VIEWS FROM SOURCE "mz_source";
-SHOW FULL VIEWS;
-```
-
-*Create views for specific upstream tables*
-
-```sql
-CREATE VIEWS FROM SOURCE "mz_source" ("a", "b");
-SHOW FULL VIEWS;
-```
 ## Related pages
 
-- [`CREATE SOURCE`](../)
+- [Change Data Capture (Postgres) guide](/guides/cdc-postgres/#direct-postgres-source)
 - [`CREATE VIEWS`](../../create-views)
-- [`SELECT`](../../select)

--- a/doc/user/content/third-party/debezium.md
+++ b/doc/user/content/third-party/debezium.md
@@ -25,4 +25,4 @@ For the best CDC experience, we recommend following the step-by-step guides for 
 
 ### Kafka-less setup
 
-If you need to connect Materialize to a PostgreSQL database but Kafka is not part of your stack, you can use the [PostgreSQL direct source](/sql/create-source/postgres/#postgresql-source-details). This source uses PostgreSQL’s native replication protocol to continuously propagate upstream changes into Materialize, bypassing the need to deploy and maintain a Kafka instance. For more details and step-by-step instructions, check the [Change Data Capture (Postgres) guide](/guides/cdc-postgres/#direct-postgres-source).
+If you need to connect Materialize to a PostgreSQL database but Kafka is not part of your stack, you can use the [PostgreSQL direct source](/sql/create-source/postgres). This source uses PostgreSQL’s native replication protocol to continuously propagate upstream changes into Materialize, bypassing the need to deploy and maintain a Kafka instance. For more details and step-by-step instructions, check the [Change Data Capture (Postgres) guide](/guides/cdc-postgres/#direct-postgres-source).


### PR DESCRIPTION
Restructures the Postgres source documentation page (#7885) to follow the common structure of the new source docs (which proposes a "Features" subsection for each source), and shuffles things around to make the page easier to parse.

Also covers the required changes to the Postgres CDC guide(s) resulting from the new single-materialization requirement. Touches #10219 (unsure if enough to close the issue) and fixes #10226.

Preview: https://preview.materialize.com/10528/sql/create-source/postgres/

<hr>

Open questions:

-  Would it be more helpful to bring all the subsections under "Change data capture" a level up (_i.e._ have "Creating a source", "Creating replication views" and "Creating materialized views" listed in the sidebar instead of just "Change data capture")? Out of all sources, this is the only case where surfacing "Features" doesn't really help with navigation.
- Can you confirm that it's no longer required to provide an example for manually defining views to cover [this issue](https://materializeinc.slack.com/archives/C01CFKM1QRF/p1637684697353100), @petrosagg? I ran the example in the thread and Materialize seems to munch through it just fine.
- Before, we could quantify the increased disk usage during the snapshotting phase as "proportional to the size of the tables upstream". Since this now depends on what is materialized, is there a better way to phrase it other than a vague "You should expect increased disk usage during this phase"?
