### PR TITLE
Partition storage and compute dataflows (reissue)

### DIFF
--- a/src/dataflow/src/activator.rs
+++ b/src/dataflow/src/activator.rs
@@ -47,7 +47,7 @@ impl RcActivator {
     }
 
     /// Register an additional [Activator] with this [RcActivator].
-    pub fn register(&mut self, activator: Activator) {
+    pub fn register(&self, activator: Activator) {
         self.inner.borrow_mut().register(activator)
     }
 
@@ -55,12 +55,12 @@ impl RcActivator {
     ///
     /// The implementation is free to ignore activations and only release them once a sufficient
     /// volume has been accumulated.
-    pub fn activate(&mut self) {
+    pub fn activate(&self) {
         self.inner.borrow_mut().activate()
     }
 
     /// Acknowledge the activation, which enables new activations to be scheduled.
-    pub fn ack(&mut self) {
+    pub fn ack(&self) {
         self.inner.borrow_mut().ack()
     }
 }

--- a/src/dataflow/src/event.rs
+++ b/src/dataflow/src/event.rs
@@ -9,42 +9,30 @@
 
 //! Traits and types for describing captured timely dataflow streams.
 //!
-//! This is roughly based on [timely::dataflow::operators::event].
+//! This is roughly based on [timely::dataflow::operators::capture::event].
 
 use crate::activator::RcActivator;
-use std::borrow::Borrow;
-use timely::dataflow::operators::capture::event::EventIteratorCore;
 use timely::dataflow::operators::capture::{EventCore, EventPusherCore};
 
-/// An event link wrapper that activates targets on push.
+/// An event pusher wrapper that activates targets on push.
 #[derive(Clone, Debug)]
-pub struct ActivatedEventLink<E> {
-    inner: E,
-    activators: RcActivator,
+pub struct ActivatedEventPusher<E> {
+    pub inner: E,
+    pub activator: RcActivator,
 }
 
-impl<E> ActivatedEventLink<E> {
+impl<E> ActivatedEventPusher<E> {
     /// Create a new activated event link wrapper.
     ///
     /// * inner: A wrapped event pusher/iterator.
-    pub fn new(inner: E, activators: RcActivator) -> Self {
-        Self { inner, activators }
-    }
-
-    pub fn activator(&self) -> &RcActivator {
-        self.activators.borrow()
+    pub fn new(inner: E, activator: RcActivator) -> Self {
+        Self { inner, activator }
     }
 }
 
-impl<T, D, E: EventPusherCore<T, D>> EventPusherCore<T, D> for ActivatedEventLink<E> {
+impl<T, D, E: EventPusherCore<T, D>> EventPusherCore<T, D> for ActivatedEventPusher<E> {
     fn push(&mut self, event: EventCore<T, D>) {
         self.inner.push(event);
-        self.activators.activate();
-    }
-}
-
-impl<T, D, E: EventIteratorCore<T, D>> EventIteratorCore<T, D> for ActivatedEventLink<E> {
-    fn next(&mut self) -> Option<&EventCore<T, D>> {
-        self.inner.next()
+        self.activator.activate();
     }
 }

--- a/src/dataflow/src/event.rs
+++ b/src/dataflow/src/event.rs
@@ -1,0 +1,50 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Traits and types for describing captured timely dataflow streams.
+//!
+//! This is roughly based on [timely::dataflow::operators::event].
+
+use crate::activator::RcActivator;
+use std::borrow::Borrow;
+use timely::dataflow::operators::capture::event::EventIteratorCore;
+use timely::dataflow::operators::capture::{EventCore, EventPusherCore};
+
+/// An event link wrapper that activates targets on push.
+#[derive(Clone, Debug)]
+pub struct ActivatedEventLink<E> {
+    inner: E,
+    activators: RcActivator,
+}
+
+impl<E> ActivatedEventLink<E> {
+    /// Create a new activated event link wrapper.
+    ///
+    /// * inner: A wrapped event pusher/iterator.
+    pub fn new(inner: E, activators: RcActivator) -> Self {
+        Self { inner, activators }
+    }
+
+    pub fn activator(&self) -> &RcActivator {
+        self.activators.borrow()
+    }
+}
+
+impl<T, D, E: EventPusherCore<T, D>> EventPusherCore<T, D> for ActivatedEventLink<E> {
+    fn push(&mut self, event: EventCore<T, D>) {
+        self.inner.push(event);
+        self.activators.activate();
+    }
+}
+
+impl<T, D, E: EventIteratorCore<T, D>> EventIteratorCore<T, D> for ActivatedEventLink<E> {
+    fn next(&mut self) -> Option<&EventCore<T, D>> {
+        self.inner.next()
+    }
+}

--- a/src/dataflow/src/lib.rs
+++ b/src/dataflow/src/lib.rs
@@ -14,6 +14,7 @@
 mod activator;
 mod arrangement;
 mod decode;
+mod event;
 mod metrics;
 mod operator;
 mod render;

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -102,15 +102,19 @@
 
 use std::any::Any;
 use std::cell::RefCell;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::rc::Rc;
 use std::rc::Weak;
 
 use differential_dataflow::AsCollection;
 use timely::communication::Allocate;
+use timely::dataflow::operators::capture::EventLink;
+use timely::dataflow::operators::capture::Replay;
 use timely::dataflow::operators::to_stream::ToStream;
+use timely::dataflow::operators::Capture;
 use timely::dataflow::scopes::Child;
 use timely::dataflow::Scope;
+
 use timely::progress::Antichain;
 use timely::worker::Worker as TimelyWorker;
 
@@ -205,19 +209,34 @@ pub struct RelevantTokens {
     pub cdc_tokens: HashMap<GlobalId, Rc<dyn Any>>,
 }
 
-/// Build a dataflow from a description.
-pub fn build_dataflow<A: Allocate>(
+/// Information about each source that must be communicated between storage and compute layers.
+pub struct SourceBoundary {
+    /// Captured `row` updates representing a differential collection.
+    pub ok: Rc<EventLink<repr::Timestamp, (Row, repr::Timestamp, repr::Diff)>>,
+    /// Captured error updates representing a differential collection.
+    pub err: Rc<EventLink<repr::Timestamp, (DataflowError, repr::Timestamp, repr::Diff)>>,
+    /// A token that should be dropped to terminate the source.
+    pub token: Rc<Option<crate::source::SourceToken>>,
+    /// Additional tokens that should be dropped to terminate the source.
+    pub additional_tokens: Vec<Rc<dyn std::any::Any>>,
+}
+
+/// Assemble the "storage" side of a dataflow, i.e. the sources.
+///
+/// This method creates a new dataflow to host the implementations of sources for the `dataflow`
+/// argument, and returns assets for each source that can import the results into a new dataflow.
+pub fn build_storage_dataflow<A: Allocate>(
     timely_worker: &mut TimelyWorker<A>,
-    compute_state: &mut ComputeState,
     storage_state: &mut StorageState,
-    dataflow: DataflowDescription<plan::Plan>,
+    dataflow: &DataflowDescription<plan::Plan>,
     now: NowFn,
     source_metrics: &SourceBaseMetrics,
-    sink_metrics: &SinkBaseMetrics,
-) {
+) -> BTreeMap<GlobalId, SourceBoundary> {
     let worker_logging = timely_worker.log_register().get("timely");
     let name = format!("Dataflow: {}", &dataflow.debug_name);
     let materialized_logging = timely_worker.log_register().get("materialized");
+
+    let mut results = BTreeMap::new();
 
     timely_worker.dataflow_core(&name, worker_logging, Box::new(()), |_, scope| {
         // The scope.clone() occurs to allow import in the region.
@@ -225,8 +244,9 @@ pub fn build_dataflow<A: Allocate>(
         // so that other similar uses (e.g. with iterative scopes) do not require weird
         // alternate type signatures.
         scope.clone().region_named(&name, |region| {
-            let mut context = Context::for_dataflow(&dataflow, scope.addr().into_element());
-            let mut tokens = RelevantTokens::default();
+            let as_of = dataflow.as_of.clone().unwrap();
+            let dataflow_id = scope.addr().into_element();
+            let debug_name = format!("{}-sources", dataflow.debug_name);
 
             assert!(
                 !dataflow
@@ -241,11 +261,11 @@ pub fn build_dataflow<A: Allocate>(
 
             // Import declared sources into the rendering context.
             for (src_id, source) in &dataflow.source_imports {
-                let (collection_bundle, (source_token, additional_tokens)) =
+                let ((ok, err), (source_token, additional_tokens)) =
                     crate::render::sources::import_source(
-                        &context.debug_name,
-                        context.dataflow_id,
-                        &context.as_of_frontier,
+                        &debug_name,
+                        dataflow_id,
+                        &as_of,
                         source.clone(),
                         storage_state,
                         region,
@@ -255,17 +275,70 @@ pub fn build_dataflow<A: Allocate>(
                         source_metrics,
                     );
 
+                let ok_handle = Rc::new(EventLink::new());
+                let err_handle = Rc::new(EventLink::new());
+
+                results.insert(
+                    *src_id,
+                    SourceBoundary {
+                        ok: Rc::<_>::clone(&ok_handle),
+                        err: Rc::<_>::clone(&err_handle),
+                        token: source_token,
+                        additional_tokens,
+                    },
+                );
+
+                ok.inner.capture_into(ok_handle);
+                err.inner.capture_into(err_handle);
+            }
+        })
+    });
+
+    results
+}
+
+/// Assemble the "compute"  side of a dataflow, i.e. all but the sources.
+///
+/// This method imports sources from provided assets, and then builds the remaining
+/// dataflow using "compute-local" assets like shared arrangements, and producing
+/// both arrangements and sinks.
+pub fn build_compute_dataflow<A: Allocate>(
+    timely_worker: &mut TimelyWorker<A>,
+    compute_state: &mut ComputeState,
+    sources: BTreeMap<GlobalId, SourceBoundary>,
+    dataflow: DataflowDescription<plan::Plan>,
+    sink_metrics: &SinkBaseMetrics,
+) {
+    let worker_logging = timely_worker.log_register().get("timely");
+    let name = format!("Dataflow: {}", &dataflow.debug_name);
+
+    timely_worker.dataflow_core(&name, worker_logging, Box::new(()), |_, scope| {
+        // The scope.clone() occurs to allow import in the region.
+        // We build a region here to establish a pattern of a scope inside the dataflow,
+        // so that other similar uses (e.g. with iterative scopes) do not require weird
+        // alternate type signatures.
+        scope.clone().region_named(&name, |region| {
+            let mut context = Context::for_dataflow(&dataflow, scope.addr().into_element());
+            let mut tokens = RelevantTokens::default();
+
+            // Import declared sources into the rendering context.
+            for (source_id, source) in sources.into_iter() {
                 // Associate collection bundle with the source identifier.
-                context.insert_id(Id::Global(*src_id), collection_bundle);
+                let ok = Some(source.ok).replay_into(region).as_collection();
+                let err = Some(source.err).replay_into(region).as_collection();
+                context.insert_id(
+                    Id::Global(source_id),
+                    CollectionBundle::from_collections(ok, err),
+                );
 
                 // Associate returned tokens with the source identifier.
-                let prior = tokens.source_tokens.insert(*src_id, source_token);
+                let prior = tokens.source_tokens.insert(source_id, source.token);
                 assert!(prior.is_none());
                 tokens
                     .additional_tokens
-                    .entry(*src_id)
+                    .entry(source_id)
                     .or_insert_with(Vec::new)
-                    .extend(additional_tokens);
+                    .extend(source.additional_tokens);
             }
 
             // Import declared indexes into the rendering context.

--- a/src/dataflow/src/replay.rs
+++ b/src/dataflow/src/replay.rs
@@ -48,7 +48,7 @@ where
         scope: &mut S,
         name: &str,
         period: Duration,
-        mut rc_activator: RcActivator,
+        rc_activator: RcActivator,
     ) -> Stream<S, D> {
         let name = format!("Replay {}", name);
         let mut builder = OperatorBuilder::new(name, scope.clone());

--- a/src/dataflow/src/replay.rs
+++ b/src/dataflow/src/replay.rs
@@ -43,6 +43,13 @@ where
     I: IntoIterator,
     <I as IntoIterator>::Item: EventIterator<T, D> + 'static,
 {
+    /// Replay a collection of [EventIterator]s into a Timely stream.
+    ///
+    /// * `scope`: The [Scope] to replay into.
+    /// * `name`: Human-readable debug name of the Timely operator.
+    /// * `period`: Reschedule the operator once the period has elapsed.
+    ///    Provide [Duration::MAX] to disable periodic scheduling.
+    /// * `rc_activator`: An activator to trigger the operator.
     fn mz_replay<S: Scope<Timestamp = T>>(
         self,
         scope: &mut S,
@@ -68,9 +75,15 @@ where
 
         builder.build(move |progress| {
             rc_activator.ack();
-            if last_active + period <= Instant::now() || !started {
+            if last_active
+                .checked_add(period)
+                .map_or(false, |next_active| next_active <= Instant::now())
+                || !started
+            {
                 last_active = Instant::now();
-                activator.activate_after(period);
+                if period < Duration::MAX {
+                    activator.activate_after(period);
+                }
             }
 
             if !started {

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -288,7 +288,7 @@ where
         }
 
         // Register each logger endpoint.
-        let mut activator = t_activator.clone();
+        let activator = t_activator.clone();
         self.timely_worker.log_register().insert_logger(
             "timely",
             Logger::new(now, unix, self.timely_worker.index(), move |time, data| {
@@ -297,7 +297,7 @@ where
             }),
         );
 
-        let mut activator = r_activator.clone();
+        let activator = r_activator.clone();
         self.timely_worker.log_register().insert_logger(
             "timely/reachability",
             Logger::new(
@@ -348,7 +348,7 @@ where
             ),
         );
 
-        let mut activator = d_activator.clone();
+        let activator = d_activator.clone();
         self.timely_worker.log_register().insert_logger(
             "differential/arrange",
             Logger::new(now, unix, self.timely_worker.index(), move |time, data| {
@@ -357,7 +357,7 @@ where
             }),
         );
 
-        let mut activator = m_activator.clone();
+        let activator = m_activator.clone();
         self.timely_worker.log_register().insert_logger(
             "materialized",
             Logger::new(now, unix, self.timely_worker.index(), move |time, data| {

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -671,13 +671,19 @@ where
                         }
                     }
 
-                    render::build_dataflow(
+                    let sources_captured = render::build_storage_dataflow(
                         self.timely_worker,
-                        &mut self.compute_state,
                         &mut self.storage_state,
-                        dataflow,
+                        &dataflow,
                         self.now.clone(),
                         &self.dataflow_source_metrics,
+                    );
+
+                    render::build_compute_dataflow(
+                        self.timely_worker,
+                        &mut self.compute_state,
+                        sources_captured,
+                        dataflow,
                         &self.dataflow_sink_metrics,
                     );
                 }


### PR DESCRIPTION
This PR is a re-issue of #10519 with better replay activation to avoid polling.

This PR partitions source creation into its own dataflow, and uses timely's `capture` and `replay` to transport the results into the dataflow for the rest of the stuff. This intentionally breaks dataflows into "storage" and "compute", so that we can see the boundary. This change keeps the partitioned dataflows on the same workers, to avoid disrupting flow-control norms at the moment. We'll break that in the future, once we understand things clearly.

### Motivation

We aim to break apart this functionality, and want to understand what is up.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).