### PR TITLE
avro: improve schema resolution errors

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -120,7 +120,7 @@ changes that have not yet been documented.
   table function appeared in the `SELECT` list {{% gh 10363 %}}.
 
 - Improve the clarity of any Avro schema resolution errors found when
-  creating materialized sources and views.
+  creating materialized sources and views. {{% gh 8415 %}}
 
 {{< comment >}}
 Only add new release notes above this line.

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -119,6 +119,9 @@ changes that have not yet been documented.
 - Fix a bug where too many columns were returned when both `*` and a
   table function appeared in the `SELECT` list {{% gh 10363 %}}.
 
+- Improve the clarity of any Avro schema resolution errors found when
+  creating materialized sources and views.
+
 {{< comment >}}
 Only add new release notes above this line.
 
@@ -196,6 +199,9 @@ boundary don't silently merge their release notes into the wrong place.
   Kafka topic has more than one partition {{% gh 10375 %}}. Previous versions of
   Materialize would lose data unless the `deduplication = 'full'` option was
   specified.
+
+{{< comment >}}
+Only add new release notes above this line.
 
 - Improve the performance of SQL `LIKE` expressions.
 

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -200,9 +200,6 @@ boundary don't silently merge their release notes into the wrong place.
   Materialize would lose data unless the `deduplication = 'full'` option was
   specified.
 
-{{< comment >}}
-Only add new release notes above this line.
-
 - Improve the performance of SQL `LIKE` expressions.
 
 {{% version-header v0.19.0 %}}

--- a/src/avro/tests/io.rs
+++ b/src/avro/tests/io.rs
@@ -1040,5 +1040,5 @@ fn test_partially_broken_union() {
     let err_read = from_avro_datum(&resolved_schema, &mut err_encoded.as_slice()).unwrap_err();
     assert!(err_read
         .to_string()
-        .contains("Reader field `a` not found in writer"));
+        .contains("Reader field `s.a` not found in writer"));
 }

--- a/src/dataflow/src/decode/mod.rs
+++ b/src/dataflow/src/decode/mod.rs
@@ -70,7 +70,7 @@ pub fn decode_cdcv2<G: Scope<Timestamp = Timestamp>>(
                             Some(value) => value,
                             None => continue,
                         };
-                        let (mut data, schema) = match block_on(resolver.resolve(&*value)) {
+                        let (mut data, schema, _) = match block_on(resolver.resolve(&*value)) {
                             Ok(ok) => ok,
                             Err(e) => {
                                 error!("Failed to get schema info for CDCv2 record: {}", e);

--- a/test/debezium/03-drop-not-null-column.td
+++ b/test/debezium/03-drop-not-null-column.td
@@ -33,4 +33,4 @@ INSERT INTO alter_drop_column_not_null VALUES (345);
 # An error is thrown instead of returning nulls in a NOT NULL column
 
 ! SELECT * FROM alter_drop_column_not_null;
-contains:Reader field `col_not_null` not found in writer, and has no default
+contains:Reader field `postgres.public.alter_drop_column_not_null.Value.col_not_null` not found in writer, and has no default

--- a/test/debezium/11-change-date-timestamp.td
+++ b/test/debezium/11-change-date-timestamp.td
@@ -34,4 +34,4 @@ UPDATE alter_change_date_timestamp SET f1 = '2012-12-12 12:12:12' WHERE f1 = '20
 DELETE FROM alter_change_date_timestamp WHERE f1 = '2011-11-11';
 
 ! SELECT * FROM alter_change_date_timestamp;
-contains:Failed to match TimestampMicro against any variant in the reader
+contains:Failed to match writer union variant `TimestampMicro` against any variant in the reader for field `postgres.public.alter_change_date_timestamp.Value.f1`

--- a/test/testdrive/avro-decode-mismatched-columns.td
+++ b/test/testdrive/avro-decode-mismatched-columns.td
@@ -31,7 +31,7 @@ $ kafka-ingest format=avro topic=decode-1to2-nodefault schema=${1column} timesta
   ENVELOPE NONE
 
 ! SELECT * FROM decode_1to2_nodefault
-contains:avro deserialization error: IO error: UnexpectedEof
+contains:avro deserialization error: unable to decode row : IO error: UnexpectedEof
 
 #
 # 1 column -> 2 columns with default
@@ -48,7 +48,7 @@ $ kafka-ingest format=avro topic=decode-1to2-default schema=${1column} timestamp
   ENVELOPE NONE
 
 ! SELECT * FROM decode_1to2_default
-contains:avro deserialization error: IO error: UnexpectedEof
+contains:Text: avro deserialization error: unable to decode row : IO error: UnexpectedEof
 
 #
 # 2 columns -> 1 column

--- a/test/testdrive/avro-decode-mismatched-types.td
+++ b/test/testdrive/avro-decode-mismatched-types.td
@@ -39,7 +39,7 @@ $ kafka-ingest format=avro topic=avro-types-null2int schema=${null} timestamp=1
   ENVELOPE NONE
 
 ! SELECT * FROM avro_types_null2int
-contains:avro deserialization error: IO error: UnexpectedEof
+contains:avro deserialization error: unable to decode row : IO error: UnexpectedEof
 
 #
 # boolean -> int
@@ -93,7 +93,7 @@ $ kafka-ingest format=avro topic=avro-types-int2float schema=${int} timestamp=1
   ENVELOPE NONE
 
 ! SELECT * FROM avro_types_int2float
-contains:avro deserialization error: IO error: UnexpectedEof
+contains:avro deserialization error: unable to decode row : IO error: UnexpectedEof
 
 #
 # long -> float
@@ -127,7 +127,7 @@ $ kafka-ingest format=avro topic=avro-types-long2int schema=${long} timestamp=1
   ENVELOPE NONE
 
 ! SELECT * FROM avro_types_long2int
-contains:avro deserialization error: Decode error: Decoding error: Expected i32, got: 992147483647
+contains:Decoding error: Expected i32, got: 992147483647
 
 #
 # float -> double
@@ -144,7 +144,7 @@ $ kafka-ingest format=avro topic=avro-types-float2double schema=${float} timesta
   ENVELOPE NONE
 
 ! SELECT * FROM avro_types_float2double
-contains:avro deserialization error: IO error: UnexpectedEof
+contains:avro deserialization error: unable to decode row : IO error: UnexpectedEof
 
 #
 # avro-typestion string -> bytes

--- a/test/testdrive/avro-decode.td
+++ b/test/testdrive/avro-decode.td
@@ -215,4 +215,4 @@ garbage
   FORMAT AVRO USING SCHEMA '${reader-schema}' WITH (confluent_wire_format = false)
 
 ! SELECT f2 FROM avro_corrupted_values2
-contains:Decode error: Text: avro deserialization error: Decode error: Decoding error: Expected non-negative integer, got -49
+contains:Decode error: Decoding error: Expected non-negative integer, got -49

--- a/test/testdrive/avro-resolution-notnull2null.td
+++ b/test/testdrive/avro-resolution-notnull2null.td
@@ -29,4 +29,7 @@ $ kafka-ingest format=avro topic=resolution-unions schema=${null} publish=true t
 {"f1": {"int": 123 } }
 
 ! SELECT f1 FROM resolution_unions
-contains:Decode error: Text: avro deserialization error: Schema resolution error: Failed to match Null against any variant in the reader
+contains:Failed to match writer union variant `Null` against any variant in the reader for field `schema_union.f1`
+
+! SELECT f1 FROM resolution_unions
+contains:unable to decode row (Avro schema id =

--- a/test/testdrive/avro-resolution-types-array.td
+++ b/test/testdrive/avro-resolution-types-array.td
@@ -28,4 +28,7 @@ $ kafka-ingest format=avro topic=resolution-arrays schema=${array-double} publis
 {"f1": [ 234.345 ] }
 
 ! SELECT f1[0] FROM resolution_arrays
-contains:Schemas don't match: Double, Int
+contains:Writer schema has type `Double`, but reader schema has type `Int` for field `schema_array.f1`
+
+! SELECT f1[0] FROM resolution_arrays
+contains:failed to resolve Avro schema (id =

--- a/test/testdrive/avro-resolution-types-map.td
+++ b/test/testdrive/avro-resolution-types-map.td
@@ -28,4 +28,7 @@ $ kafka-ingest format=avro topic=resolution-maps schema=${map-double} publish=tr
 {"f1": { "key1": 234.345 } }
 
 ! SELECT f1 -> 'key1' FROM resolution_maps
-contains:Schemas don't match: Double, Int
+contains:Writer schema has type `Double`, but reader schema has type `Int` for field `schema_map.f1`
+
+! SELECT f1 -> 'key1' FROM resolution_maps
+contains:failed to resolve Avro schema (id =

--- a/test/testdrive/avro-resolution-types-records.td
+++ b/test/testdrive/avro-resolution-types-records.td
@@ -29,4 +29,7 @@ $ kafka-ingest format=avro topic=resolution-records-int2double schema=${double-c
 {"f1": { "f1": 123.234 }}
 
 ! SELECT * FROM resolution_records_int2double
-contains:Schemas don't match: Double, Int
+contains:Writer schema has type `Double`, but reader schema has type `Int` for field `inner.f1`
+
+! SELECT * FROM resolution_records_int2double
+contains:failed to resolve Avro schema (id =

--- a/test/testdrive/avro-resolution-types.td
+++ b/test/testdrive/avro-resolution-types.td
@@ -29,4 +29,7 @@ $ kafka-ingest format=avro topic=resolution-int2double schema=${double-col} publ
 {"f1": 234.456}
 
 ! SELECT * FROM resolution_int2double
-contains:Schema resolution error: Schemas don't match: Double, Int
+contains:Writer schema has type `Double`, but reader schema has type `Int` for field `schema_int_double.f1`
+
+! SELECT * FROM resolution_int2double
+contains:failed to resolve Avro schema (id =

--- a/test/testdrive/avro-resolution-union-concrete.td
+++ b/test/testdrive/avro-resolution-union-concrete.td
@@ -1,0 +1,35 @@
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Attempt to write a concrete type with a union source without a match
+#
+
+$ set union-int={"type": "record", "name": "schema_union", "fields": [ {"name": "f1", "type": [ "int" ] } ] }
+$ set concrete-double={"type": "record", "name": "schema_union", "fields": [ {"name": "f1", "type": "double" } ] }
+
+$ kafka-create-topic topic=resolution-union-concrete
+
+$ kafka-ingest format=avro topic=resolution-union-concrete schema=${union-int} publish=true timestamp=1
+{"f1": {"int": 123 } }
+
+> CREATE MATERIALIZED SOURCE resolution_union_concrete
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-resolution-union-concrete-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE NONE
+
+$ kafka-ingest format=avro topic=resolution-union-concrete schema=${concrete-double} publish=true timestamp=2
+{"f1": 123.456 }
+
+! SELECT f1 FROM resolution_union_concrete
+contains:No matching schema in reader union for writer type `Double` for field `schema_union.f1`
+
+! SELECT f1 FROM resolution_union_concrete
+contains:failed to resolve Avro schema (id =

--- a/test/testdrive/avro-resolution-unions.td
+++ b/test/testdrive/avro-resolution-unions.td
@@ -30,4 +30,7 @@ $ kafka-ingest format=avro topic=resolution-unions schema=${union-int-string} pu
 {"f1": {"string": "abc" } }
 
 ! SELECT f1 FROM resolution_unions
-contains:avro deserialization error: Schema resolution error: Failed to match String against any variant in the reader
+contains:Failed to match writer union variant `String` against any variant in the reader for field `schema_union.f1`
+
+! SELECT f1 FROM resolution_unions
+contains:unable to decode row (Avro schema id =

--- a/test/testdrive/kafka-upsert-sources-key-decode-error.td
+++ b/test/testdrive/kafka-upsert-sources-key-decode-error.td
@@ -46,4 +46,4 @@ $ kafka-ingest format=avro topic=int2long key-format=avro key-schema=${keyschema
 {"key": 999999999999} {"nokey": "nokey1"}
 
 ! SELECT * FROM int2long
-contains:Schemas don't match: Long, Int
+contains:Writer schema has type `Long`, but reader schema has type `Int` for field `Key.key`


### PR DESCRIPTION
<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

This PR improves the error messages produced during Avro schema resolution. It adds a stack to the SchemaResolver that tracks the path to the current node/field, which is then included in any resulting error messages. When available, it additionally adds CSR schema IDs to the errors. The schema IDs required a bit of extra plumbing to work with union types (whose errors are pre-generated, and are only thrown when a row fully does not match during decoding), but the changes there are relatively contained.

An example from `testdrive/avro-resolution-types-records.td`, before:

```
> SELECT * FROM resolution_records_int2double;
ERROR:  Decode error: Text: avro deserialization error: 
Schema resolution error: Schemas don't match: Double, Int
```

And after:
```
> SELECT * FROM resolution_records_int2double;
ERROR:  Decode error: Text: avro deserialization error: failed to resolve Avro schema (id = 14): 
Schema resolution error: Writer schema has type `Double`, but reader schema has type `Int` for field `inner.f1`
```

~~Note that not every changed/existing error message is currently tested. Some schema reader/writer schema pairs are rejected by the schema registry for incompatibility, so I'm not sure what the best way to actually test them is (or if we need to cover _every_ path).~~ Edit: these got turned into unit tests!

### Motivation

Fixes https://github.com/MaterializeInc/materialize/issues/8415

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
