### PR TITLE
doc/developer: correct release timing in release.md

### DIFF
--- a/doc/developer/release.md
+++ b/doc/developer/release.md
@@ -18,8 +18,8 @@ section of our docs.
 The release process kicks off every week on Wednesday morning, where "morning"
 is determined by the timezone of that week's release manager. The release
 commit, however, is not dependent on when the release process starts: it is
-always chosen to be the *last* commit on `main` at 12:01am EST (00:01 EST) on
-Wednesday. If there were outstanding release blockers at 12:01am EST, either the
+always chosen to be the *last* commit on `main` at 05:00 UTC (midnight EST) on
+Wednesday. If there were outstanding release blockers at 05:00 UTC, either the
 fixes need to be backported on top of that commit or the release needs to be
 skipped.
 


### PR DESCRIPTION
I updated this in the issue template, but missed the longer-form
explanation.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
