### PR TITLE
coord/persist: lookup tables with the correct table id, not the prima…

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1480,7 +1480,10 @@ impl Coordinator {
             // well.
             let item = self.catalog.try_get_by_id(*id).map(|e| e.item());
             if let Some(CatalogItem::Index(catalog::Index { on, .. })) = item {
-                if let Some(persist) = self.persister.table_details.get(&id) {
+                // We only want to forward since updates to persist if they:
+                //  - are from the primary index on a table
+                //  - and that table itself is currently persisted
+                if let Some(persist) = self.persister.table_details.get(&on) {
                     if self.catalog.default_index_for(*on) == Some(*id) {
                         table_since_updates.push((persist.stream_id, frontier.clone()));
                         table_source_since_updates.push((*on, frontier.clone()));


### PR DESCRIPTION
…ry index id

Fixes #10533

We have to do a complicated dance at the moment to propagate since updates to persisted
collections for tables. We first grab the since updates for a given index, then check
whether that index is built off a table, then check if the table is meant to be
persisted, then check if the index is the table's primary index. If all of those checks
are true, we forward the since updates to the persisted table.

We recently introduced a regression where we used the wrong id to check if a table
was persisted - we used the index id instead of the table id. This lead since
updates never being forwarded to persistent tables, which lead to unbounded storage
growth even for persisted tables that only use a finite amount of data.

This commit fixes that regression by looking up "is this table persisted" using the
table id. Further testing to catch this type of compaction error will be done in a
followup commit.

<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug: [Link to issue.]

  * This PR adds a known-desirable feature: [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
