### PR TITLE
test/kafka-ingest: remove demand optimization when rendering upsert s…

### DIFF
--- a/test/kafka-ingest-open-loop/setup.td
+++ b/test/kafka-ingest-open-loop/setup.td
@@ -32,13 +32,25 @@ $ kafka-create-topic topic=load-test partitions=4
   INCLUDE PARTITION AS kafka_partition, OFFSET AS mz_offset
   ENVELOPE ${arg.envelope}
 
+# Create an intermediate view that applies meaningless filters (in the sense that
+# no data can get filtered out) which defeat the demand optimization that gets
+# pushed into non-persistent upsert.
+#
+# TODO: remove this once the optimization is pushed down into persistent upsert
+# as well.
+> CREATE VIEW intermediate AS SELECT key0, data, kafka_partition, mz_offset FROM load_test
+  WHERE key0 != '\\x0' AND
+  data != '\\x0' AND
+  kafka_partition != 10000 AND
+  mz_offset != -1
+
 # Render a dataflow that uses the source, but does a minimal amount of
 # work and keeps a minimal amount of data in memory.
 #
 # This view can be also be used to track how many records have been ingested when
 # the data is append only (ie no duplicate keys).
 > CREATE MATERIALIZED VIEW load_test_count AS SELECT
-  COUNT(*) FROM load_test;
+  COUNT(*) FROM intermediate;
 
 # Create a view so we can easily query the time that has fully been
 # closed in the load test.


### PR DESCRIPTION
…ources

Previously, upsert sources used much less memory than expected on the open loop
benchmark. For example, after sending ~20 GiB, we would expect materialize's
memory usage with upsert sources to be approximately 20 GiB, if not more. Instead,
the memory usage was more like 8 GiB. This happened because the views built on
top of the upsert source didn't actually use the data in any of the columns
so the upsert logic replaced all of the columns with placeholder empty datums.

This only becomes a problem when comparing persistent upsert sources with non
persistent upsert sources. Persistent upsert sources are not able to push
the fact that the columns are projected away all the way down into the upsert
logic, and consequently use a lot more memory than non-persistent upsert sources.
This ends up confounding the goal of measuring the memory overhead of the persist
runtime, as now we're not just comparing the effects of enabling vs disabling
persist, we're doing so across two very different dataflows.

A reasonable counterargument here might be something like: not being able to
push projections down as far into stateful logic is a direct consequence of using
persist, and thus we should be accounting for the overheads that result from
the lack of optimization. The best response to that line of thought is that
at the moment, we're more focused on the direct overheads of persist itself,
rather than the indirect costs of using persist. Furthermore, the demand optimization
only applies in the artificial case of the dataflow that throws away all of the
columns. We don't expect to see workloads like that from alpha testers, and if
we do, we can revisit pushing projections/MFPs into persistent upsert.

<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug: [Link to issue.]

  * This PR adds a known-desirable feature: [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
