### PR TITLE
Shard Controller state by compute instance

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -851,7 +851,10 @@ impl Coordinator {
 
     async fn message_worker(&mut self, message: DataflowResponse) {
         match message {
-            DataflowResponse::Compute(ComputeResponse::PeekResponse(conn_id, response)) => {
+            DataflowResponse::Compute(
+                ComputeResponse::PeekResponse(conn_id, response),
+                _instance,
+            ) => {
                 // We expect exactly one peek response, which we forward.
                 self.pending_peeks
                     .remove(&conn_id)
@@ -859,7 +862,10 @@ impl Coordinator {
                     .send(response)
                     .expect("Peek endpoint terminated prematurely");
             }
-            DataflowResponse::Compute(ComputeResponse::TailResponse(sink_id, response)) => {
+            DataflowResponse::Compute(
+                ComputeResponse::TailResponse(sink_id, response),
+                _instance,
+            ) => {
                 // We use an `if let` here because the peek could have been canceled already.
                 // We can also potentially receive multiple `Complete` responses, followed by
                 // a `Dropped` response.
@@ -870,7 +876,7 @@ impl Coordinator {
                     }
                 }
             }
-            DataflowResponse::Compute(ComputeResponse::FrontierUppers(updates)) => {
+            DataflowResponse::Compute(ComputeResponse::FrontierUppers(updates), _instance) => {
                 for (name, changes) in updates {
                     self.update_upper(&name, changes);
                 }

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -735,11 +735,6 @@ impl Coordinator {
             });
         }
 
-        // Create the default cluster so that subsequent default cluster commands succeed.
-        self.dataflow_client
-            .create_instance(DEFAULT_COMPUTE_INSTANCE_ID)
-            .await;
-
         let mut metric_scraper_stream = self.metric_scraper.tick_stream();
 
         loop {
@@ -4645,6 +4640,12 @@ pub async fn serve(
                 write_lock: Arc::new(tokio::sync::Mutex::new(())),
                 write_lock_wait_group: VecDeque::new(),
             };
+            // We must initialize the instance before we enable logging on it.
+            handle.block_on(
+                coord
+                    .dataflow_client
+                    .create_instance(DEFAULT_COMPUTE_INSTANCE_ID),
+            );
             if let Some(config) = &logging {
                 handle.block_on(
                     coord.dataflow_client.enable_logging(


### PR DESCRIPTION
This PR shards the `Controller`'s compute state by instance, so that users can easily get a restricted view of the state on a compute instance.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
