### PR TITLE
Further partition storage and compute state

### DIFF
--- a/src/dataflow/src/render/sinks.rs
+++ b/src/dataflow/src/render/sinks.rs
@@ -24,7 +24,6 @@ use mz_interchange::envelopes::{combine_at_timestamp, dbz_format, upsert_format}
 use mz_repr::{Datum, Diff, Row, Timestamp};
 
 use crate::render::context::Context;
-use crate::sink::SinkBaseMetrics;
 
 impl<G> Context<G, Row, Timestamp>
 where
@@ -38,7 +37,6 @@ where
         import_ids: HashSet<GlobalId>,
         sink_id: GlobalId,
         sink: &SinkDesc,
-        metrics: &SinkBaseMetrics,
     ) {
         let sink_render = get_sink_render_for(&sink.connector);
 
@@ -80,7 +78,7 @@ where
         // if we figure out a protocol for that.
 
         let sink_token =
-            sink_render.render_continuous_sink(compute_state, sink, sink_id, collection, metrics);
+            sink_render.render_continuous_sink(compute_state, sink, sink_id, collection);
 
         if let Some(sink_token) = sink_token {
             needed_tokens.push(sink_token);
@@ -219,7 +217,6 @@ where
         sink: &SinkDesc,
         sink_id: GlobalId,
         sinked_collection: Collection<G, (Option<Row>, Option<Row>), Diff>,
-        metrics: &SinkBaseMetrics,
     ) -> Option<Rc<dyn Any>>
     where
         G: Scope<Timestamp = Timestamp>;

--- a/src/dataflow/src/sink/avro_ocf.rs
+++ b/src/dataflow/src/sink/avro_ocf.rs
@@ -26,8 +26,6 @@ use mz_repr::{Diff, RelationDesc, Row, Timestamp};
 
 use crate::render::sinks::SinkRender;
 
-use super::SinkBaseMetrics;
-
 impl<G> SinkRender<G> for AvroOcfSinkConnector
 where
     G: Scope<Timestamp = Timestamp>,
@@ -50,7 +48,6 @@ where
         _sink: &SinkDesc,
         sink_id: GlobalId,
         sinked_collection: Collection<G, (Option<Row>, Option<Row>), Diff>,
-        _metrics: &SinkBaseMetrics,
     ) -> Option<Rc<dyn Any>>
     where
         G: Scope<Timestamp = Timestamp>,

--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -60,7 +60,7 @@ use mz_repr::{Datum, Diff, RelationDesc, Row, Timestamp};
 use mz_timely_util::async_op;
 use mz_timely_util::operators_async_ext::OperatorBuilderExt;
 
-use super::{KafkaBaseMetrics, SinkBaseMetrics};
+use super::KafkaBaseMetrics;
 use crate::render::sinks::SinkRender;
 use prometheus::core::{AtomicI64, AtomicU64};
 
@@ -88,7 +88,6 @@ where
         sink: &SinkDesc,
         sink_id: GlobalId,
         sinked_collection: Collection<G, (Option<Row>, Option<Row>), Diff>,
-        metrics: &SinkBaseMetrics,
     ) -> Option<Rc<dyn Any>>
     where
         G: Scope<Timestamp = Timestamp>,
@@ -140,7 +139,7 @@ where
             self.value_desc.clone(),
             sink.as_of.clone(),
             Rc::clone(&shared_frontier),
-            &metrics.kafka,
+            &compute_state.sink_metrics.kafka,
         );
 
         compute_state

--- a/src/dataflow/src/sink/tail.rs
+++ b/src/dataflow/src/sink/tail.rs
@@ -34,8 +34,6 @@ use mz_repr::{Diff, Row, Timestamp};
 
 use crate::render::sinks::SinkRender;
 
-use super::SinkBaseMetrics;
-
 impl<G> SinkRender<G> for TailSinkConnector
 where
     G: Scope<Timestamp = Timestamp>,
@@ -58,7 +56,6 @@ where
         sink: &SinkDesc,
         sink_id: GlobalId,
         sinked_collection: Collection<G, (Option<Row>, Option<Row>), Diff>,
-        _metrics: &SinkBaseMetrics,
     ) -> Option<Rc<dyn Any>>
     where
         G: Scope<Timestamp = Timestamp>,


### PR DESCRIPTION
This PR further partitions the state held in `Worker` into `StorageState` and `ComputeState`, with the goal of more easily hoisting the two piles of state and logic away from each other.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
