### PR TITLE
sql: if list slice is empty, return {} instead of NULL

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -124,6 +124,10 @@ changes that have not yet been documented.
 - **Breaking change.** Change the output of [`format_type`](/sql/functions/#system-information-func)
   to match Postgres for some specific types.
 
+- **Breaking change.** Return an empty list for slice operations that retrieve
+  no elements (e.g. the beginning of the slice's range exceeds the length of the
+  list); previously Materialize returned NULL.
+
 - Add `microsecond`, `month`, `decade`, `century`, `millennium` units
   to [`interval`](/sql/types/interval) parsing using the PostgreSQL verbose
   format {{% gh 10532 %}}.

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -5198,7 +5198,12 @@ fn list_slice<'a>(datums: &[Datum<'a>], temp_storage: &'a RowArena) -> Datum<'a>
     }
 
     temp_storage.make_datum(|row| {
-        slice_and_descend(datums[0], &ranges, row);
+        let empty_results = slice_and_descend(datums[0], &ranges, row);
+        // Empty results return an empty list and not NULL.
+        if empty_results {
+            row.truncate_datums(0);
+            row.push(Datum::empty_list());
+        }
     })
 }
 
@@ -5364,6 +5369,7 @@ fn list_index<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     if i < 1 {
         return Datum::Null;
     }
+
     a.unwrap_list()
         .iter()
         .nth(i as usize - 1)

--- a/test/sqllogictest/list.slt
+++ b/test/sqllogictest/list.slt
@@ -138,7 +138,7 @@ SELECT (LIST [1, 2, 3][:])::text
 query T
 SELECT (LIST [1, 2, 3][100:])::text
 ----
-NULL
+{}
 
 # end exceeds maximum index
 query T
@@ -228,12 +228,12 @@ SELECT (LIST [[1, 2, 3], [4, 5]][:, 2:])::text
 query T
 SELECT (LIST [[1, 2, 3], [4, 5]][100:, :])::text
 ----
-NULL
+{}
 
 query T
 SELECT (LIST [[1, 2, 3], [4, 5]][:, 100:])::text
 ----
-NULL
+{}
 
 # propagating NULL lists
 query T
@@ -344,22 +344,22 @@ SELECT (LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][:, :, 1:1])::text
 query T
 SELECT (LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][100:100])::text
 ----
-NULL
+{}
 
 query T
 SELECT (LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][:, 100:100])::text
 ----
-NULL
+{}
 
 query T
 SELECT (LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][:, :, 100:100])::text
 ----
-NULL
+{}
 
 query T
 SELECT (LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][:, 100:100, :])::text
 ----
-NULL
+{}
 
 # propagating NULL lists
 query T
@@ -424,7 +424,7 @@ NULL
 query T
 SELECT ((LIST[[1, 2, 3], NULL, [4]]::INT LIST LIST)[2:3, 2:2])::text
 ----
-NULL
+{}
 
 query T
 SELECT (LIST[1, 2, 3][NULL])::text
@@ -489,7 +489,7 @@ SELECT ((LIST[NULL]::INT LIST)[1:1])::text
 query T
 SELECT ((LIST[NULL, NULL]::INT LIST LIST)[:, 1:1])::text
 ----
-NULL
+{}
 
 # Literal NULLs are NOT empty results and don't get reduced
 query T
@@ -513,7 +513,7 @@ SELECT ((LIST [[1, NULL, 3], NULL, [4, NULL, 6]]::INT LIST LIST)[2:3, 2:2])::tex
 query T
 SELECT ((LIST [[1, NULL, 3], NULL, [4, NULL, 6]]::INT LIST LIST)[2:3, 4:4])::text
 ----
-NULL
+{}
 
 # Outer list's second position produces empty results, but third position
 # produces value, so cannot be totally reduced
@@ -527,7 +527,7 @@ SELECT ((LIST [NULL, [NULL], [[NULL]]]::INT LIST LIST LIST)[:, :, :])::text
 query T
 SELECT ((LIST [NULL, [NULL], [[NULL]]]::INT LIST LIST LIST)[:, :, 2:2])::text
 ----
-NULL
+{}
 
 # 🔬 Empty lists expressions
 
@@ -539,17 +539,17 @@ NULL
 query T
 SELECT ((LIST[]::INT LIST)[:])::text
 ----
-NULL
+{}
 
 query T
 SELECT ((LIST[]::INT LIST)[1:1])::text
 ----
-NULL
+{}
 
 query T
 SELECT ((LIST[]::INT LIST LIST)[1:1, 1:1])::text
 ----
-NULL
+{}
 
 # 🔬 Other subscript values
 
@@ -607,7 +607,7 @@ NULL
 query T
 SELECT (LIST[1][9223372036854775807::bigint:9223372036854775807::bigint])::text
 ----
-NULL
+{}
 
 query T
 SELECT (LIST[1][9223372036854775807::bigint:-9223372036854775807::bigint])::text


### PR DESCRIPTION
`LIST` is meant to feel more like Python lists or Rust vectors; when a slice returns no values, return an empty list, rather than _NULL_ (i.e. empty slices are not equal to `None`; their length is just 0);

This was in #10495, but breaking out to simplify that work.

### Motivation

This PR adds a feature that has not yet been specified, which is described above.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
