### PR TITLE
Improve feature benchmark experience in Buildkite

### DIFF
--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -91,7 +91,7 @@ def run_one_scenario(
     c: Composition, scenario: Type[Scenario], args: argparse.Namespace
 ) -> Comparator:
     name = scenario.__name__
-    print(f"Now benchmarking {name} ...")
+    print(f"--- Now benchmarking {name} ...")
     comparator = make_comparator(name)
     common_seed = round(time.time())
 
@@ -244,7 +244,11 @@ root_scenario: {args.root_scenario}"""
 
         if comparison.is_regression():
             has_regressions = True
-
         report.dump()
 
-    sys.exit(1 if has_regressions else 0)
+    print("+++ Benchmark Report")
+    report.dump()
+
+    if has_regressions:
+        print("ERROR: benchmarks have regressions")
+        sys.exit(1)


### PR DESCRIPTION
This makes the output less than thousands of lines in the buildkite UI.

Each scenario gets its own collapsed section, which both makes it easier to
scan the scenarios and to view the per-scenario report, since it will be at the
end of a section, with only collapsed sections afterwards.

Additionally, if the benchark completes without being OOM- or timeout-killed it
generates a default expanded section with just the report. If there are any
regressions it becomes easy to view the scenario-specific details by expanding
their specific sections.

### Motivation

* This PR adds a feature that has not yet been specified.

### Checklist

- [n/a] This PR has adequate test coverage / QA involvement has been duly considered.
- [n/a] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).