### PR TITLE
Partition worker logic into storage and compute

### DIFF
--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -100,46 +100,24 @@
 //! stream. This reduces the amount of recomputation that must be performed
 //! if/when the errors are retracted.
 
-use std::any::Any;
-use std::cell::RefCell;
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashSet};
 use std::rc::Rc;
-use std::rc::Weak;
-use std::time::{Duration, Instant};
 
 use differential_dataflow::AsCollection;
-use timely::communication::Allocate;
-use timely::dataflow::operators::capture::EventLink;
 use timely::dataflow::operators::to_stream::ToStream;
-use timely::dataflow::operators::Capture;
 use timely::dataflow::scopes::Child;
 use timely::dataflow::Scope;
 
-use timely::progress::Antichain;
-use timely::worker::Worker as TimelyWorker;
-
-use crate::activator::RcActivator;
 use mz_dataflow_types::*;
 use mz_expr::{GlobalId, Id};
-use mz_ore::collections::CollectionExt as _;
-use mz_ore::now::NowFn;
-use mz_persist::client::RuntimeClient;
 use mz_repr::{Row, Timestamp};
 
-use crate::arrangement::manager::{TraceBundle, TraceManager};
-use crate::event::ActivatedEventPusher;
-use crate::metrics::Metrics;
-use crate::render::context::CollectionBundle;
+use crate::arrangement::manager::TraceBundle;
+pub use crate::render::context::CollectionBundle;
 use crate::render::context::{ArrangementFlavor, Context};
-use crate::render::sources::PersistedSourceManager;
-use crate::replay::MzReplay;
-use crate::server::{LocalInput, PendingPeek};
-use crate::sink::SinkBaseMetrics;
-use crate::source::metrics::SourceBaseMetrics;
-use crate::source::timestamp::TimestampBindingRc;
-use crate::source::SourceToken;
+use crate::server::ComputeState;
 
-mod context;
+pub mod context;
 mod debezium;
 mod envelope_none;
 mod flat_map;
@@ -151,243 +129,11 @@ mod threshold;
 mod top_k;
 mod upsert;
 
-/// Worker-local state that is maintained across dataflows.
-///
-/// This state is restricted to the COMPUTE state, the deterministic, idempotent work
-/// done between data ingress and egress.
-pub struct ComputeState {
-    /// The traces available for sharing across dataflows.
-    pub traces: TraceManager,
-    /// Tokens that should be dropped when a dataflow is dropped to clean up
-    /// associated state.
-    pub dataflow_tokens: HashMap<GlobalId, Box<dyn Any>>,
-    /// Shared buffer with TAIL operator instances by which they can respond.
-    ///
-    /// The entries are pairs of sink identifier (to identify the tail instance)
-    /// and the response itself.
-    pub tail_response_buffer: Rc<RefCell<Vec<(GlobalId, TailResponse)>>>,
-    /// Frontier of sink writes (all subsequent writes will be at times at or
-    /// equal to this frontier)
-    pub sink_write_frontiers: HashMap<GlobalId, Rc<RefCell<Antichain<Timestamp>>>>,
-    /// Peek commands that are awaiting fulfillment.
-    pub(crate) pending_peeks: Vec<PendingPeek>,
-    /// Tracks the frontier information that has been sent over `response_tx`.
-    pub reported_frontiers: HashMap<GlobalId, Antichain<Timestamp>>,
-    /// Undocumented
-    pub sink_metrics: SinkBaseMetrics,
-}
-
-/// Worker-local state related to the ingress or egress of collections of data.
-pub struct StorageState {
-    /// Handles to local inputs, keyed by ID.
-    pub local_inputs: HashMap<GlobalId, LocalInput>,
-    /// Source descriptions that have been created and not yet dropped.
-    ///
-    /// For the moment we retain all source descriptions, even those that have been
-    /// dropped, as this is used to check for rebinding of previous identifiers.
-    /// Once we have a better mechanism to avoid that, for example that identifiers
-    /// must strictly increase, we can clean up descriptions when sources are dropped.
-    pub source_descriptions: HashMap<GlobalId, mz_dataflow_types::sources::SourceDesc>,
-    /// Handles to external sources, keyed by ID.
-    pub ts_source_mapping: HashMap<GlobalId, Vec<Weak<Option<SourceToken>>>>,
-    /// Timestamp data updates for each source.
-    pub ts_histories: HashMap<GlobalId, TimestampBindingRc>,
-    /// Handles that allow setting the compaction frontier for a persisted source. There can only
-    /// ever be one running (rendered) source of a persisted source, and if there is one, this map
-    /// will contain a handle to it.
-    pub persisted_sources: PersistedSourceManager,
-    /// Metrics reported by all dataflows.
-    pub metrics: Metrics,
-    /// Handle to the persistence runtime. None if disabled.
-    pub persist: Option<RuntimeClient>,
-    /// Tracks the timestamp binding durability information that has been sent over `response_tx`.
-    pub reported_bindings_frontiers: HashMap<GlobalId, Antichain<Timestamp>>,
-    /// Tracks the last time we sent binding durability info over `response_tx`.
-    pub last_bindings_feedback: Instant,
-    /// Undocumented
-    pub now: NowFn,
-    /// Metrics for the source-specific side of dataflows.
-    pub source_metrics: SourceBaseMetrics,
-}
-
-/// Information about each source that must be communicated between storage and compute layers.
-pub struct SourceBoundary {
-    /// Captured `row` updates representing a differential collection.
-    pub ok: ActivatedEventPusher<
-        Rc<EventLink<mz_repr::Timestamp, (Row, mz_repr::Timestamp, mz_repr::Diff)>>,
-    >,
-    /// Captured error updates representing a differential collection.
-    pub err: ActivatedEventPusher<
-        Rc<EventLink<mz_repr::Timestamp, (DataflowError, mz_repr::Timestamp, mz_repr::Diff)>>,
-    >,
-    /// A token that should be dropped to terminate the source.
-    pub token: Rc<dyn std::any::Any>,
-}
-
-/// Assemble the "storage" side of a dataflow, i.e. the sources.
-///
-/// This method creates a new dataflow to host the implementations of sources for the `dataflow`
-/// argument, and returns assets for each source that can import the results into a new dataflow.
-pub fn build_storage_dataflow<A: Allocate>(
-    timely_worker: &mut TimelyWorker<A>,
-    storage_state: &mut StorageState,
-    dataflow: &DataflowDescription<plan::Plan>,
-) -> BTreeMap<GlobalId, SourceBoundary> {
-    let worker_logging = timely_worker.log_register().get("timely");
-    let name = format!("Dataflow: {}", &dataflow.debug_name);
-    let materialized_logging = timely_worker.log_register().get("materialized");
-
-    let mut results = BTreeMap::new();
-
-    timely_worker.dataflow_core(&name, worker_logging, Box::new(()), |_, scope| {
-        // The scope.clone() occurs to allow import in the region.
-        // We build a region here to establish a pattern of a scope inside the dataflow,
-        // so that other similar uses (e.g. with iterative scopes) do not require weird
-        // alternate type signatures.
-        scope.clone().region_named(&name, |region| {
-            let as_of = dataflow.as_of.clone().unwrap();
-            let dataflow_id = scope.addr().into_element();
-            let debug_name = format!("{}-sources", dataflow.debug_name);
-
-            // Import declared sources into the rendering context.
-            for (src_id, source) in &dataflow.source_imports {
-                let ((ok, err), token) = crate::render::sources::import_source(
-                    &debug_name,
-                    dataflow_id,
-                    &as_of,
-                    source.clone(),
-                    storage_state,
-                    region,
-                    materialized_logging.clone(),
-                    src_id.clone(),
-                );
-
-                let ok_activator = RcActivator::new(format!("{debug_name}-ok"), 1);
-                let err_activator = RcActivator::new(format!("{debug_name}-err"), 1);
-
-                let ok_handle =
-                    ActivatedEventPusher::new(Rc::new(EventLink::new()), ok_activator.clone());
-                let err_handle =
-                    ActivatedEventPusher::new(Rc::new(EventLink::new()), err_activator.clone());
-
-                results.insert(
-                    *src_id,
-                    SourceBoundary {
-                        ok: ActivatedEventPusher::<_>::clone(&ok_handle),
-                        err: ActivatedEventPusher::<_>::clone(&err_handle),
-                        token,
-                    },
-                );
-
-                ok.inner.capture_into(ok_handle);
-                err.inner.capture_into(err_handle);
-            }
-        })
-    });
-
-    results
-}
-
-/// Assemble the "compute"  side of a dataflow, i.e. all but the sources.
-///
-/// This method imports sources from provided assets, and then builds the remaining
-/// dataflow using "compute-local" assets like shared arrangements, and producing
-/// both arrangements and sinks.
-pub fn build_compute_dataflow<A: Allocate>(
-    timely_worker: &mut TimelyWorker<A>,
-    compute_state: &mut ComputeState,
-    sources: BTreeMap<GlobalId, SourceBoundary>,
-    dataflow: DataflowDescription<plan::Plan>,
-) {
-    let worker_logging = timely_worker.log_register().get("timely");
-    let name = format!("Dataflow: {}", &dataflow.debug_name);
-
-    timely_worker.dataflow_core(&name, worker_logging, Box::new(()), |_, scope| {
-        // The scope.clone() occurs to allow import in the region.
-        // We build a region here to establish a pattern of a scope inside the dataflow,
-        // so that other similar uses (e.g. with iterative scopes) do not require weird
-        // alternate type signatures.
-        scope.clone().region_named(&name, |region| {
-            let mut context = Context::for_dataflow(&dataflow, scope.addr().into_element());
-            let mut tokens = BTreeMap::new();
-
-            // Import declared sources into the rendering context.
-            for (source_id, source) in sources.into_iter() {
-                // Associate collection bundle with the source identifier.
-                let ok = Some(source.ok.inner)
-                    .mz_replay(
-                        region,
-                        &format!("{name}-{source_id}"),
-                        Duration::MAX,
-                        source.ok.activator,
-                    )
-                    .as_collection();
-                let err = Some(source.err.inner)
-                    .mz_replay(
-                        region,
-                        &format!("{name}-{source_id}-err"),
-                        Duration::MAX,
-                        source.err.activator,
-                    )
-                    .as_collection();
-                context.insert_id(
-                    Id::Global(source_id),
-                    CollectionBundle::from_collections(ok, err),
-                );
-
-                // Associate returned tokens with the source identifier.
-                let prior = tokens.insert(source_id, source.token);
-                assert!(prior.is_none());
-            }
-
-            // Import declared indexes into the rendering context.
-            for (idx_id, idx) in &dataflow.index_imports {
-                context.import_index(compute_state, &mut tokens, scope, region, *idx_id, &idx.0);
-            }
-
-            // We first determine indexes and sinks to export, then build the declared object, and
-            // finally export indexes and sinks. The reason for this is that we want to avoid
-            // cloning the dataflow plan for `build_object`, which can be expensive.
-
-            // Determine indexes to export
-            let indexes = dataflow
-                .index_exports
-                .iter()
-                .cloned()
-                .map(|(idx_id, idx, _typ)| (idx_id, dataflow.get_imports(&idx.on_id), idx))
-                .collect::<Vec<_>>();
-
-            // Determine sinks to export
-            let sinks = dataflow
-                .sink_exports
-                .iter()
-                .cloned()
-                .map(|(sink_id, sink)| (sink_id, dataflow.get_imports(&sink.from), sink))
-                .collect::<Vec<_>>();
-
-            // Build declared objects.
-            for object in dataflow.objects_to_build {
-                context.build_object(region, object);
-            }
-
-            // Export declared indexes.
-            for (idx_id, imports, idx) in indexes {
-                context.export_index(compute_state, &mut tokens, imports, idx_id, &idx);
-            }
-
-            // Export declared sinks.
-            for (sink_id, imports, sink) in sinks {
-                context.export_sink(compute_state, &mut tokens, imports, sink_id, &sink);
-            }
-        });
-    })
-}
-
 impl<'g, G> Context<Child<'g, G, G::Timestamp>, Row, Timestamp>
 where
     G: Scope<Timestamp = Timestamp>,
 {
-    fn import_index(
+    pub(crate) fn import_index(
         &mut self,
         compute_state: &mut ComputeState,
         tokens: &mut BTreeMap<GlobalId, Rc<dyn std::any::Any>>,
@@ -429,7 +175,7 @@ where
         }
     }
 
-    fn build_object(
+    pub(crate) fn build_object(
         &mut self,
         scope: &mut Child<'g, G, G::Timestamp>,
         object: BuildDesc<plan::Plan>,
@@ -439,7 +185,7 @@ where
         self.insert_id(Id::Global(object.id), bundle);
     }
 
-    fn export_index(
+    pub(crate) fn export_index(
         &mut self,
         compute_state: &mut ComputeState,
         tokens: &mut BTreeMap<GlobalId, Rc<dyn std::any::Any>>,

--- a/src/dataflow/src/render/sinks.rs
+++ b/src/dataflow/src/render/sinks.rs
@@ -32,7 +32,7 @@ where
     /// Export the sink described by `sink` from the rendering context.
     pub(crate) fn export_sink(
         &mut self,
-        compute_state: &mut crate::render::ComputeState,
+        compute_state: &mut crate::server::ComputeState,
         tokens: &mut std::collections::BTreeMap<GlobalId, Rc<dyn std::any::Any>>,
         import_ids: HashSet<GlobalId>,
         sink_id: GlobalId,
@@ -213,7 +213,7 @@ where
 
     fn render_continuous_sink(
         &self,
-        compute_state: &mut crate::render::ComputeState,
+        compute_state: &mut crate::server::ComputeState,
         sink: &SinkDesc,
         sink_id: GlobalId,
         sinked_collection: Collection<G, (Option<Row>, Option<Row>), Diff>,

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -39,8 +39,8 @@ use crate::logging::materialized::Logger;
 use crate::operator::{CollectionExt, StreamExt};
 use crate::render::envelope_none;
 use crate::render::envelope_none::PersistentEnvelopeNoneConfig;
-use crate::render::StorageState;
 use crate::server::LocalInput;
+use crate::server::StorageState;
 use crate::source::timestamp::{AssignedTimestamp, SourceTimestamp};
 use crate::source::{
     self, DecodeResult, FileSourceReader, KafkaSourceReader, KinesisSourceReader,
@@ -62,7 +62,7 @@ enum SourceType<Delimited, ByteStream> {
 /// Imports a table (non-durable, local source of input).
 pub(crate) fn import_table<G>(
     as_of_frontier: &timely::progress::Antichain<mz_repr::Timestamp>,
-    storage_state: &mut crate::render::StorageState,
+    storage_state: &mut crate::server::StorageState,
     scope: &mut G,
     persisted_name: Option<String>,
 ) -> (
@@ -138,7 +138,7 @@ pub(crate) fn import_source<G>(
         operators: mut linear_operators,
         persist,
     }: SourceInstanceDesc,
-    storage_state: &mut crate::render::StorageState,
+    storage_state: &mut crate::server::StorageState,
     scope: &mut G,
     materialized_logging: Option<Logger>,
     src_id: GlobalId,

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -45,9 +45,11 @@ use crate::render::sources::PersistedSourceManager;
 use crate::sink::SinkBaseMetrics;
 use crate::source::metrics::SourceBaseMetrics;
 
+pub mod boundary;
 mod compute_state;
 mod metrics;
 mod storage_state;
+
 use compute_state::ActiveComputeState;
 pub(crate) use compute_state::ComputeState;
 use storage_state::ActiveStorageState;
@@ -285,17 +287,20 @@ where
                         }
                     }
 
-                    let sources_captured = storage_state::build_storage_dataflow(
+                    let mut boundary = boundary::EventLinkBoundary::new();
+
+                    crate::render::build_storage_dataflow(
                         self.timely_worker,
                         &mut self.storage_state,
                         &dataflow,
+                        &mut boundary,
                     );
 
-                    compute_state::build_compute_dataflow(
+                    crate::render::build_compute_dataflow(
                         self.timely_worker,
                         &mut self.compute_state,
-                        sources_captured,
                         dataflow,
+                        &mut boundary,
                     );
                 }
             }

--- a/src/dataflow/src/server/boundary.rs
+++ b/src/dataflow/src/server/boundary.rs
@@ -1,0 +1,132 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+/// Traits and types for capturing and replaying collections of data.
+use std::any::Any;
+use std::collections::BTreeMap;
+use std::rc::Rc;
+use std::time::Duration;
+
+use differential_dataflow::AsCollection;
+use differential_dataflow::Collection;
+use timely::dataflow::operators::capture::EventLink;
+use timely::dataflow::Scope;
+
+use mz_dataflow_types::DataflowError;
+use mz_expr::GlobalId;
+use mz_repr::{Diff, Row};
+
+use crate::activator::RcActivator;
+use crate::replay::MzReplay;
+use crate::server::ActivatedEventPusher;
+use crate::server::SourceBoundary;
+
+/// A type that can capture a specific source.
+pub trait StorageCapture {
+    /// Captures the source and binds to `id`.
+    fn capture<G: Scope<Timestamp = mz_repr::Timestamp>>(
+        &mut self,
+        id: GlobalId,
+        ok: Collection<G, Row, Diff>,
+        err: Collection<G, DataflowError, Diff>,
+        token: Rc<dyn Any>,
+        name: &str,
+    );
+}
+
+/// A type that can replay specific sources
+pub trait ComputeReplay {
+    /// Replays the source bound to `id`.
+    ///
+    /// `None` is returned if the source does not exist, either because
+    /// it was not there to begin, or has already been replayed. Either
+    /// case is likely an error.
+    fn replay<G: Scope<Timestamp = mz_repr::Timestamp>>(
+        &mut self,
+        id: GlobalId,
+        scope: &mut G,
+        name: &str,
+    ) -> Option<(
+        Collection<G, Row, Diff>,
+        Collection<G, DataflowError, Diff>,
+        Rc<dyn Any>,
+    )>;
+}
+
+/// A simple boundary that uses activated event linked lists.
+pub struct EventLinkBoundary {
+    sources: BTreeMap<GlobalId, crate::server::SourceBoundary>,
+}
+
+impl EventLinkBoundary {
+    pub fn new() -> Self {
+        Self {
+            sources: BTreeMap::new(),
+        }
+    }
+}
+
+impl StorageCapture for EventLinkBoundary {
+    fn capture<G: Scope<Timestamp = mz_repr::Timestamp>>(
+        &mut self,
+        id: GlobalId,
+        ok: Collection<G, Row, Diff>,
+        err: Collection<G, DataflowError, Diff>,
+        token: Rc<dyn Any>,
+        name: &str,
+    ) {
+        let ok_activator = RcActivator::new(format!("{name}-ok"), 1);
+        let err_activator = RcActivator::new(format!("{name}-err"), 1);
+
+        let ok_handle = ActivatedEventPusher::new(Rc::new(EventLink::new()), ok_activator);
+        let err_handle = ActivatedEventPusher::new(Rc::new(EventLink::new()), err_activator);
+
+        self.sources.insert(
+            id,
+            SourceBoundary {
+                ok: ActivatedEventPusher::<_>::clone(&ok_handle),
+                err: ActivatedEventPusher::<_>::clone(&err_handle),
+                token,
+            },
+        );
+
+        use timely::dataflow::operators::Capture;
+        ok.inner.capture_into(ok_handle);
+        err.inner.capture_into(err_handle);
+    }
+}
+
+impl ComputeReplay for EventLinkBoundary {
+    fn replay<G: Scope<Timestamp = mz_repr::Timestamp>>(
+        &mut self,
+        id: GlobalId,
+        scope: &mut G,
+        name: &str,
+    ) -> Option<(
+        Collection<G, Row, Diff>,
+        Collection<G, DataflowError, Diff>,
+        Rc<dyn Any>,
+    )> {
+        self.sources.remove(&id).map(|source| {
+            let ok = Some(source.ok.inner)
+                .mz_replay(
+                    scope,
+                    &format!("{name}-ok"),
+                    Duration::MAX,
+                    source.ok.activator,
+                )
+                .as_collection();
+            let err = Some(source.err.inner)
+                .mz_replay(
+                    scope,
+                    &format!("{name}-err"),
+                    Duration::MAX,
+                    source.err.activator,
+                )
+                .as_collection();
+            (ok, err, source.token)
+        })
+    }
+}

--- a/src/dataflow/src/server/compute_state.rs
+++ b/src/dataflow/src/server/compute_state.rs
@@ -1,0 +1,659 @@
+use std::any::Any;
+use std::cell::RefCell;
+use std::collections::{BTreeMap, HashMap};
+use std::rc::Rc;
+use std::time::{Duration, Instant};
+
+use differential_dataflow::operators::arrange::arrangement::Arrange;
+use differential_dataflow::trace::TraceReader;
+use differential_dataflow::{AsCollection, Collection};
+use timely::communication::Allocate;
+use timely::dataflow::Scope;
+use timely::logging::Logger;
+use timely::order::PartialOrder;
+use timely::progress::frontier::Antichain;
+use timely::progress::reachability::logging::TrackerEvent;
+use timely::progress::ChangeBatch;
+use timely::worker::Worker as TimelyWorker;
+use tokio::sync::mpsc;
+
+use mz_dataflow_types::client::{ComputeCommand, ComputeResponse, Response};
+use mz_dataflow_types::logging::LoggingConfig;
+use mz_dataflow_types::{DataflowDescription, DataflowError, PeekResponse, TailResponse};
+use mz_expr::GlobalId;
+use mz_ore::collections::CollectionExt as IteratorExt;
+use mz_repr::Timestamp;
+
+use crate::activator::RcActivator;
+use crate::arrangement::manager::{TraceBundle, TraceManager};
+use crate::logging;
+use crate::logging::materialized::MaterializedEvent;
+use crate::operator::CollectionExt;
+use crate::replay::MzReplay;
+use crate::server::{PendingPeek, SourceBoundary};
+use crate::sink::SinkBaseMetrics;
+
+/// Worker-local state that is maintained across dataflows.
+///
+/// This state is restricted to the COMPUTE state, the deterministic, idempotent work
+/// done between data ingress and egress.
+pub struct ComputeState {
+    /// The traces available for sharing across dataflows.
+    pub traces: TraceManager,
+    /// Tokens that should be dropped when a dataflow is dropped to clean up
+    /// associated state.
+    pub dataflow_tokens: HashMap<GlobalId, Box<dyn Any>>,
+    /// Shared buffer with TAIL operator instances by which they can respond.
+    ///
+    /// The entries are pairs of sink identifier (to identify the tail instance)
+    /// and the response itself.
+    pub tail_response_buffer: Rc<RefCell<Vec<(GlobalId, TailResponse)>>>,
+    /// Frontier of sink writes (all subsequent writes will be at times at or
+    /// equal to this frontier)
+    pub sink_write_frontiers: HashMap<GlobalId, Rc<RefCell<Antichain<Timestamp>>>>,
+    /// Peek commands that are awaiting fulfillment.
+    pub(crate) pending_peeks: Vec<PendingPeek>,
+    /// Tracks the frontier information that has been sent over `response_tx`.
+    pub reported_frontiers: HashMap<GlobalId, Antichain<Timestamp>>,
+    /// Undocumented
+    pub sink_metrics: SinkBaseMetrics,
+    /// The logger, from Timely's logging framework, if logs are enabled.
+    pub materialized_logger: Option<logging::materialized::Logger>,
+}
+
+/// Assemble the "compute"  side of a dataflow, i.e. all but the sources.
+///
+/// This method imports sources from provided assets, and then builds the remaining
+/// dataflow using "compute-local" assets like shared arrangements, and producing
+/// both arrangements and sinks.
+pub fn build_compute_dataflow<A: Allocate>(
+    timely_worker: &mut TimelyWorker<A>,
+    compute_state: &mut ComputeState,
+    sources: BTreeMap<GlobalId, SourceBoundary>,
+    dataflow: DataflowDescription<mz_dataflow_types::plan::Plan>,
+) {
+    let worker_logging = timely_worker.log_register().get("timely");
+    let name = format!("Dataflow: {}", &dataflow.debug_name);
+
+    timely_worker.dataflow_core(&name, worker_logging, Box::new(()), |_, scope| {
+        // The scope.clone() occurs to allow import in the region.
+        // We build a region here to establish a pattern of a scope inside the dataflow,
+        // so that other similar uses (e.g. with iterative scopes) do not require weird
+        // alternate type signatures.
+        scope.clone().region_named(&name, |region| {
+            let mut context = crate::render::context::Context::for_dataflow(
+                &dataflow,
+                scope.addr().into_element(),
+            );
+            let mut tokens = BTreeMap::new();
+
+            // Import declared sources into the rendering context.
+            for (source_id, source) in sources.into_iter() {
+                // Associate collection bundle with the source identifier.
+                let ok = Some(source.ok.inner)
+                    .mz_replay(
+                        region,
+                        &format!("{name}-{source_id}"),
+                        Duration::MAX,
+                        source.ok.activator,
+                    )
+                    .as_collection();
+                let err = Some(source.err.inner)
+                    .mz_replay(
+                        region,
+                        &format!("{name}-{source_id}-err"),
+                        Duration::MAX,
+                        source.err.activator,
+                    )
+                    .as_collection();
+                context.insert_id(
+                    mz_expr::Id::Global(source_id),
+                    crate::render::CollectionBundle::from_collections(ok, err),
+                );
+
+                // Associate returned tokens with the source identifier.
+                let prior = tokens.insert(source_id, source.token);
+                assert!(prior.is_none());
+            }
+
+            // Import declared indexes into the rendering context.
+            for (idx_id, idx) in &dataflow.index_imports {
+                context.import_index(compute_state, &mut tokens, scope, region, *idx_id, &idx.0);
+            }
+
+            // We first determine indexes and sinks to export, then build the declared object, and
+            // finally export indexes and sinks. The reason for this is that we want to avoid
+            // cloning the dataflow plan for `build_object`, which can be expensive.
+
+            // Determine indexes to export
+            let indexes = dataflow
+                .index_exports
+                .iter()
+                .cloned()
+                .map(|(idx_id, idx, _typ)| (idx_id, dataflow.get_imports(&idx.on_id), idx))
+                .collect::<Vec<_>>();
+
+            // Determine sinks to export
+            let sinks = dataflow
+                .sink_exports
+                .iter()
+                .cloned()
+                .map(|(sink_id, sink)| (sink_id, dataflow.get_imports(&sink.from), sink))
+                .collect::<Vec<_>>();
+
+            // Build declared objects.
+            for object in dataflow.objects_to_build {
+                context.build_object(region, object);
+            }
+
+            // Export declared indexes.
+            for (idx_id, imports, idx) in indexes {
+                context.export_index(compute_state, &mut tokens, imports, idx_id, &idx);
+            }
+
+            // Export declared sinks.
+            for (sink_id, imports, sink) in sinks {
+                context.export_sink(compute_state, &mut tokens, imports, sink_id, &sink);
+            }
+        });
+    })
+}
+
+pub struct ActiveComputeState<'a, A: Allocate> {
+    /// The underlying Timely worker.
+    pub timely_worker: &'a mut TimelyWorker<A>,
+    /// The compute state itself.
+    pub compute_state: &'a mut ComputeState,
+    /// The channel over which frontier information is reported.
+    pub response_tx: &'a mut mpsc::UnboundedSender<Response>,
+}
+
+impl<'a, A: Allocate> ActiveComputeState<'a, A> {
+    pub(crate) fn handle_compute_command(&mut self, cmd: ComputeCommand) {
+        match cmd {
+            ComputeCommand::CreateInstance | ComputeCommand::DropInstance => {
+                // Can be ignored for the moment.
+                // Should eventually be filtered outside of this method,
+                // as we are already deep in a specific instance.
+            }
+            ComputeCommand::CreateDataflows(_dataflows) => {
+                unreachable!("CreateDataflows should not be issued directly to compute state")
+            }
+
+            ComputeCommand::DropSinks(ids) => {
+                for id in ids {
+                    self.compute_state.reported_frontiers.remove(&id);
+                    self.compute_state.sink_write_frontiers.remove(&id);
+                    self.compute_state.dataflow_tokens.remove(&id);
+                }
+            }
+            ComputeCommand::DropIndexes(ids) => {
+                for id in ids {
+                    self.compute_state.traces.del_trace(&id);
+                    let frontier = self
+                        .compute_state
+                        .reported_frontiers
+                        .remove(&id)
+                        .expect("Dropped index with no frontier");
+                    if let Some(logger) = self.compute_state.materialized_logger.as_mut() {
+                        logger.log(MaterializedEvent::Dataflow(id, false));
+                        for time in frontier.elements().iter() {
+                            logger.log(MaterializedEvent::Frontier(id, *time, -1));
+                        }
+                    }
+                }
+            }
+
+            ComputeCommand::Peek {
+                id,
+                key,
+                timestamp,
+                conn_id,
+                finishing,
+                map_filter_project,
+            } => {
+                // Acquire a copy of the trace suitable for fulfilling the peek.
+                let mut trace_bundle = self.compute_state.traces.get(&id).unwrap().clone();
+                let timestamp_frontier = Antichain::from_elem(timestamp);
+                let empty_frontier = Antichain::new();
+                trace_bundle
+                    .oks_mut()
+                    .set_logical_compaction(timestamp_frontier.borrow());
+                trace_bundle
+                    .errs_mut()
+                    .set_logical_compaction(timestamp_frontier.borrow());
+                trace_bundle
+                    .oks_mut()
+                    .set_physical_compaction(empty_frontier.borrow());
+                trace_bundle
+                    .errs_mut()
+                    .set_physical_compaction(empty_frontier.borrow());
+                // Prepare a description of the peek work to do.
+                let mut peek = PendingPeek {
+                    id,
+                    key,
+                    conn_id,
+                    timestamp,
+                    finishing,
+                    trace_bundle,
+                    map_filter_project,
+                };
+                // Log the receipt of the peek.
+                if let Some(logger) = self.compute_state.materialized_logger.as_mut() {
+                    logger.log(MaterializedEvent::Peek(peek.as_log_event(), true));
+                }
+                // Attempt to fulfill the peek.
+                if let Some(response) = peek.seek_fulfillment(&mut Antichain::new()) {
+                    self.send_peek_response(peek, response);
+                } else {
+                    self.compute_state.pending_peeks.push(peek);
+                }
+            }
+
+            ComputeCommand::CancelPeek { conn_id } => {
+                let pending_peeks_len = self.compute_state.pending_peeks.len();
+                let mut pending_peeks = std::mem::replace(
+                    &mut self.compute_state.pending_peeks,
+                    Vec::with_capacity(pending_peeks_len),
+                );
+                for peek in pending_peeks.drain(..) {
+                    if peek.conn_id == conn_id {
+                        self.send_peek_response(peek, PeekResponse::Canceled);
+                    } else {
+                        self.compute_state.pending_peeks.push(peek);
+                    }
+                }
+            }
+            ComputeCommand::AllowIndexCompaction(list) => {
+                for (id, frontier) in list {
+                    self.compute_state
+                        .traces
+                        .allow_compaction(id, frontier.borrow());
+                }
+            }
+            ComputeCommand::EnableLogging(config) => {
+                self.initialize_logging(&config);
+            }
+        }
+    }
+
+    /// Initializes timely dataflow logging and publishes as a view.
+    pub fn initialize_logging(&mut self, logging: &LoggingConfig) {
+        if self.compute_state.materialized_logger.is_some() {
+            panic!("dataflow server has already initialized logging");
+        }
+
+        use crate::logging::BatchLogger;
+        use timely::dataflow::operators::capture::event::link::EventLink;
+
+        let granularity_ms = std::cmp::max(1, logging.granularity_ns / 1_000_000) as Timestamp;
+
+        // Track time relative to the Unix epoch, rather than when the server
+        // started, so that the logging sources can be joined with tables and
+        // other real time sources for semi-sensible results.
+        let now = Instant::now();
+        let start_offset = std::time::SystemTime::now()
+            .duration_since(std::time::SystemTime::UNIX_EPOCH)
+            .expect("Failed to get duration since Unix epoch");
+
+        // Establish loggers first, so we can either log the logging or not, as we like.
+        let t_linked = std::rc::Rc::new(EventLink::new());
+        let mut t_logger = BatchLogger::new(Rc::clone(&t_linked), granularity_ms);
+        let r_linked = std::rc::Rc::new(EventLink::new());
+        let mut r_logger = BatchLogger::new(Rc::clone(&r_linked), granularity_ms);
+        let d_linked = std::rc::Rc::new(EventLink::new());
+        let mut d_logger = BatchLogger::new(Rc::clone(&d_linked), granularity_ms);
+        let m_linked = std::rc::Rc::new(EventLink::new());
+        let mut m_logger = BatchLogger::new(Rc::clone(&m_linked), granularity_ms);
+
+        let mut t_traces = HashMap::new();
+        let mut r_traces = HashMap::new();
+        let mut d_traces = HashMap::new();
+        let mut m_traces = HashMap::new();
+
+        let activate_after = 128;
+
+        let t_activator = RcActivator::new("t_activator".into(), activate_after);
+        let r_activator = RcActivator::new("r_activator".into(), activate_after);
+        let d_activator = RcActivator::new("d_activator".into(), activate_after);
+        let m_activator = RcActivator::new("m_activator".into(), activate_after);
+
+        if !logging.log_logging {
+            // Construct logging dataflows and endpoints before registering any.
+            t_traces.extend(logging::timely::construct(
+                &mut self.timely_worker,
+                logging,
+                Rc::clone(&t_linked),
+                t_activator.clone(),
+            ));
+            r_traces.extend(logging::reachability::construct(
+                &mut self.timely_worker,
+                logging,
+                Rc::clone(&r_linked),
+                r_activator.clone(),
+            ));
+            d_traces.extend(logging::differential::construct(
+                &mut self.timely_worker,
+                logging,
+                Rc::clone(&d_linked),
+                d_activator.clone(),
+            ));
+            m_traces.extend(logging::materialized::construct(
+                &mut self.timely_worker,
+                logging,
+                Rc::clone(&m_linked),
+                m_activator.clone(),
+            ));
+        }
+
+        // Register each logger endpoint.
+        let activator = t_activator.clone();
+        self.timely_worker.log_register().insert_logger(
+            "timely",
+            Logger::new(
+                now,
+                start_offset,
+                self.timely_worker.index(),
+                move |time, data| {
+                    t_logger.publish_batch(time, data);
+                    activator.activate();
+                },
+            ),
+        );
+
+        let activator = r_activator.clone();
+        self.timely_worker.log_register().insert_logger(
+            "timely/reachability",
+            Logger::new(
+                now,
+                start_offset,
+                self.timely_worker.index(),
+                move |time, data: &mut Vec<(Duration, usize, TrackerEvent)>| {
+                    let mut converted_updates = Vec::new();
+                    for event in data.drain(..) {
+                        match event.2 {
+                            TrackerEvent::SourceUpdate(update) => {
+                                let massaged: Vec<_> = update
+                                    .updates
+                                    .iter()
+                                    .map(|u| {
+                                        let ts = u.2.as_any().downcast_ref::<Timestamp>().copied();
+                                        (*u.0, *u.1, true, ts, *u.3 as isize)
+                                    })
+                                    .collect();
+
+                                converted_updates.push((
+                                    event.0,
+                                    event.1,
+                                    (update.tracker_id, massaged),
+                                ));
+                            }
+                            TrackerEvent::TargetUpdate(update) => {
+                                let massaged: Vec<_> = update
+                                    .updates
+                                    .iter()
+                                    .map(|u| {
+                                        let ts = u.2.as_any().downcast_ref::<Timestamp>().copied();
+                                        (*u.0, *u.1, true, ts, *u.3 as isize)
+                                    })
+                                    .collect();
+
+                                converted_updates.push((
+                                    event.0,
+                                    event.1,
+                                    (update.tracker_id, massaged),
+                                ));
+                            }
+                        }
+                    }
+                    r_logger.publish_batch(time, &mut converted_updates);
+                    activator.activate();
+                },
+            ),
+        );
+
+        let activator = d_activator.clone();
+        self.timely_worker.log_register().insert_logger(
+            "differential/arrange",
+            Logger::new(
+                now,
+                start_offset,
+                self.timely_worker.index(),
+                move |time, data| {
+                    d_logger.publish_batch(time, data);
+                    activator.activate();
+                },
+            ),
+        );
+
+        let activator = m_activator.clone();
+        self.timely_worker.log_register().insert_logger(
+            "materialized",
+            Logger::new(
+                now,
+                start_offset,
+                self.timely_worker.index(),
+                move |time, data| {
+                    m_logger.publish_batch(time, data);
+                    activator.activate();
+                },
+            ),
+        );
+
+        let errs = self
+            .timely_worker
+            .dataflow_named("Dataflow: logging", |scope| {
+                Collection::<_, DataflowError, isize>::empty(scope)
+                    .arrange()
+                    .trace
+            });
+
+        let logger = self
+            .timely_worker
+            .log_register()
+            .get("materialized")
+            .unwrap();
+
+        if logging.log_logging {
+            // Create log processing dataflows after registering logging so we can log the
+            // logging.
+            t_traces.extend(logging::timely::construct(
+                &mut self.timely_worker,
+                logging,
+                t_linked,
+                t_activator,
+            ));
+            r_traces.extend(logging::reachability::construct(
+                &mut self.timely_worker,
+                logging,
+                r_linked,
+                r_activator,
+            ));
+            d_traces.extend(logging::differential::construct(
+                &mut self.timely_worker,
+                logging,
+                d_linked,
+                d_activator,
+            ));
+            m_traces.extend(logging::materialized::construct(
+                &mut self.timely_worker,
+                logging,
+                m_linked,
+                m_activator,
+            ));
+        }
+
+        // Install traces as maintained indexes
+        for (log, trace) in t_traces {
+            let id = logging.active_logs[&log];
+            self.compute_state
+                .traces
+                .set(id, TraceBundle::new(trace, errs.clone()));
+            self.compute_state
+                .reported_frontiers
+                .insert(id, Antichain::from_elem(0));
+            logger.log(MaterializedEvent::Frontier(id, 0, 1));
+        }
+        for (log, trace) in r_traces {
+            let id = logging.active_logs[&log];
+            self.compute_state
+                .traces
+                .set(id, TraceBundle::new(trace, errs.clone()));
+            self.compute_state
+                .reported_frontiers
+                .insert(id, Antichain::from_elem(0));
+            logger.log(MaterializedEvent::Frontier(id, 0, 1));
+        }
+        for (log, trace) in d_traces {
+            let id = logging.active_logs[&log];
+            self.compute_state
+                .traces
+                .set(id, TraceBundle::new(trace, errs.clone()));
+            self.compute_state
+                .reported_frontiers
+                .insert(id, Antichain::from_elem(0));
+            logger.log(MaterializedEvent::Frontier(id, 0, 1));
+        }
+        for (log, trace) in m_traces {
+            let id = logging.active_logs[&log];
+            self.compute_state
+                .traces
+                .set(id, TraceBundle::new(trace, errs.clone()));
+            self.compute_state
+                .reported_frontiers
+                .insert(id, Antichain::from_elem(0));
+            logger.log(MaterializedEvent::Frontier(id, 0, 1));
+        }
+
+        self.compute_state.materialized_logger = Some(logger);
+    }
+
+    /// Disables timely dataflow logging.
+    ///
+    /// This does not unpublish views and is only useful to terminate logging streams to ensure that
+    /// materialized can terminate cleanly.
+    pub fn shutdown_logging(&mut self) {
+        self.timely_worker.log_register().remove("timely");
+        self.timely_worker
+            .log_register()
+            .remove("timely/reachability");
+        self.timely_worker
+            .log_register()
+            .remove("differential/arrange");
+        self.timely_worker.log_register().remove("materialized");
+    }
+
+    /// Send progress information to the coordinator.
+    pub fn report_compute_frontiers(&mut self) {
+        fn add_progress(
+            id: GlobalId,
+            new_frontier: &Antichain<Timestamp>,
+            prev_frontier: &Antichain<Timestamp>,
+            progress: &mut Vec<(GlobalId, ChangeBatch<Timestamp>)>,
+        ) {
+            let mut changes = ChangeBatch::new();
+            for time in prev_frontier.elements().iter() {
+                changes.update(time.clone(), -1);
+            }
+            for time in new_frontier.elements().iter() {
+                changes.update(time.clone(), 1);
+            }
+            changes.compact();
+            if !changes.is_empty() {
+                progress.push((id, changes));
+            }
+        }
+
+        let mut new_frontier = Antichain::new();
+        let mut progress = Vec::new();
+        for (id, traces) in self.compute_state.traces.traces.iter_mut() {
+            // Read the upper frontier and compare to what we've reported.
+            traces.oks_mut().read_upper(&mut new_frontier);
+            let prev_frontier = self
+                .compute_state
+                .reported_frontiers
+                .get_mut(&id)
+                .expect("Index frontier missing!");
+            if prev_frontier != &new_frontier {
+                add_progress(*id, &new_frontier, &prev_frontier, &mut progress);
+                prev_frontier.clone_from(&new_frontier);
+            }
+        }
+
+        // Log index frontier changes
+        if let Some(logger) = self.compute_state.materialized_logger.as_mut() {
+            for (id, changes) in &mut progress {
+                for (time, diff) in changes.iter() {
+                    logger.log(MaterializedEvent::Frontier(*id, *time, *diff));
+                }
+            }
+        }
+
+        for (id, frontier) in self.compute_state.sink_write_frontiers.iter() {
+            new_frontier.clone_from(&frontier.borrow());
+            let prev_frontier = self
+                .compute_state
+                .reported_frontiers
+                .get_mut(&id)
+                .expect("Sink frontier missing!");
+            assert!(<_ as PartialOrder>::less_equal(
+                prev_frontier,
+                &new_frontier
+            ));
+            if prev_frontier != &new_frontier {
+                add_progress(*id, &new_frontier, &prev_frontier, &mut progress);
+                prev_frontier.clone_from(&new_frontier);
+            }
+        }
+
+        if !progress.is_empty() {
+            self.send_compute_response(ComputeResponse::FrontierUppers(progress));
+        }
+    }
+
+    /// Scan pending peeks and attempt to retire each.
+    pub fn process_peeks(&mut self) {
+        let mut upper = Antichain::new();
+        let pending_peeks_len = self.compute_state.pending_peeks.len();
+        let mut pending_peeks = std::mem::replace(
+            &mut self.compute_state.pending_peeks,
+            Vec::with_capacity(pending_peeks_len),
+        );
+        for mut peek in pending_peeks.drain(..) {
+            if let Some(response) = peek.seek_fulfillment(&mut upper) {
+                self.send_peek_response(peek, response);
+            } else {
+                self.compute_state.pending_peeks.push(peek);
+            }
+        }
+    }
+
+    /// Sends a response for this peek's resolution to the coordinator.
+    ///
+    /// Note that this function takes ownership of the `PendingPeek`, which is
+    /// meant to prevent multiple responses to the same peek.
+    fn send_peek_response(&mut self, peek: PendingPeek, response: PeekResponse) {
+        // Respond with the response.
+        self.send_compute_response(ComputeResponse::PeekResponse(peek.conn_id, response));
+
+        // Log responding to the peek request.
+        if let Some(logger) = self.compute_state.materialized_logger.as_mut() {
+            logger.log(MaterializedEvent::Peek(peek.as_log_event(), false));
+        }
+    }
+
+    /// Scan the shared tail response buffer, and forward results along.
+    pub fn process_tails(&mut self) {
+        let mut tail_responses = self.compute_state.tail_response_buffer.borrow_mut();
+        for (sink_id, response) in tail_responses.drain(..) {
+            self.send_compute_response(ComputeResponse::TailResponse(sink_id, response));
+        }
+    }
+
+    /// Send a response to the coordinator.
+    fn send_compute_response(&self, response: ComputeResponse) {
+        // Ignore send errors because the coordinator is free to ignore our
+        // responses. This happens during shutdown.
+        let _ = self.response_tx.send(Response::Compute(response));
+    }
+}

--- a/src/dataflow/src/server/compute_state.rs
+++ b/src/dataflow/src/server/compute_state.rs
@@ -1,3 +1,8 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
 use std::any::Any;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};

--- a/src/dataflow/src/server/storage_state.rs
+++ b/src/dataflow/src/server/storage_state.rs
@@ -1,3 +1,8 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
 use std::collections::{BTreeMap, HashMap};
 use std::rc::{Rc, Weak};
 use std::time::Instant;

--- a/src/dataflow/src/server/storage_state.rs
+++ b/src/dataflow/src/server/storage_state.rs
@@ -1,0 +1,377 @@
+use std::collections::{BTreeMap, HashMap};
+use std::rc::{Rc, Weak};
+use std::time::Instant;
+
+use timely::communication::Allocate;
+use timely::dataflow::operators::capture::EventLink;
+use timely::dataflow::Scope;
+use timely::order::PartialOrder;
+use timely::progress::frontier::Antichain;
+use timely::progress::ChangeBatch;
+use timely::worker::Worker as TimelyWorker;
+use tokio::sync::mpsc;
+
+use mz_dataflow_types::client::{
+    Response, StorageCommand, StorageResponse, TimestampBindingFeedback,
+};
+use mz_dataflow_types::sources::{ExternalSourceConnector, SourceConnector};
+use mz_dataflow_types::DataflowDescription;
+use mz_expr::{GlobalId, PartitionId};
+use mz_ore::collections::CollectionExt as IteratorExt;
+use mz_ore::now::NowFn;
+use mz_persist::client::RuntimeClient;
+use mz_repr::Timestamp;
+
+use crate::activator::RcActivator;
+use crate::event::ActivatedEventPusher;
+use crate::metrics::Metrics;
+use crate::render::sources::PersistedSourceManager;
+use crate::server::{LocalInput, SourceBoundary};
+use crate::source::metrics::SourceBaseMetrics;
+use crate::source::timestamp::TimestampBindingRc;
+use crate::source::SourceToken;
+
+/// How frequently each dataflow worker sends timestamp binding updates
+/// back to the coordinator.
+static TS_BINDING_FEEDBACK_INTERVAL_MS: u128 = 1_000;
+
+/// Worker-local state related to the ingress or egress of collections of data.
+pub struct StorageState {
+    /// Handles to local inputs, keyed by ID.
+    pub local_inputs: HashMap<GlobalId, LocalInput>,
+    /// Source descriptions that have been created and not yet dropped.
+    ///
+    /// For the moment we retain all source descriptions, even those that have been
+    /// dropped, as this is used to check for rebinding of previous identifiers.
+    /// Once we have a better mechanism to avoid that, for example that identifiers
+    /// must strictly increase, we can clean up descriptions when sources are dropped.
+    pub source_descriptions: HashMap<GlobalId, mz_dataflow_types::sources::SourceDesc>,
+    /// Handles to external sources, keyed by ID.
+    pub ts_source_mapping: HashMap<GlobalId, Vec<Weak<Option<SourceToken>>>>,
+    /// Timestamp data updates for each source.
+    pub ts_histories: HashMap<GlobalId, TimestampBindingRc>,
+    /// Handles that allow setting the compaction frontier for a persisted source. There can only
+    /// ever be one running (rendered) source of a persisted source, and if there is one, this map
+    /// will contain a handle to it.
+    pub persisted_sources: PersistedSourceManager,
+    /// Metrics reported by all dataflows.
+    pub metrics: Metrics,
+    /// Handle to the persistence runtime. None if disabled.
+    pub persist: Option<RuntimeClient>,
+    /// Tracks the timestamp binding durability information that has been sent over `response_tx`.
+    pub reported_bindings_frontiers: HashMap<GlobalId, Antichain<Timestamp>>,
+    /// Tracks the last time we sent binding durability info over `response_tx`.
+    pub last_bindings_feedback: Instant,
+    /// Undocumented
+    pub now: NowFn,
+    /// Metrics for the source-specific side of dataflows.
+    pub source_metrics: SourceBaseMetrics,
+    /// Index of the associated timely dataflow worker.
+    pub timely_worker_index: usize,
+    /// Peers in the associated timely dataflow worker.
+    pub timely_worker_peers: usize,
+}
+
+/// Assemble the "storage" side of a dataflow, i.e. the sources.
+///
+/// This method creates a new dataflow to host the implementations of sources for the `dataflow`
+/// argument, and returns assets for each source that can import the results into a new dataflow.
+pub fn build_storage_dataflow<A: Allocate>(
+    timely_worker: &mut TimelyWorker<A>,
+    storage_state: &mut StorageState,
+    dataflow: &DataflowDescription<mz_dataflow_types::plan::Plan>,
+) -> BTreeMap<GlobalId, SourceBoundary> {
+    let worker_logging = timely_worker.log_register().get("timely");
+    let name = format!("Dataflow: {}", &dataflow.debug_name);
+    let materialized_logging = timely_worker.log_register().get("materialized");
+
+    let mut results = BTreeMap::new();
+
+    timely_worker.dataflow_core(&name, worker_logging, Box::new(()), |_, scope| {
+        // The scope.clone() occurs to allow import in the region.
+        // We build a region here to establish a pattern of a scope inside the dataflow,
+        // so that other similar uses (e.g. with iterative scopes) do not require weird
+        // alternate type signatures.
+        scope.clone().region_named(&name, |region| {
+            let as_of = dataflow.as_of.clone().unwrap();
+            let dataflow_id = scope.addr().into_element();
+            let debug_name = format!("{}-sources", dataflow.debug_name);
+
+            // Import declared sources into the rendering context.
+            for (src_id, source) in &dataflow.source_imports {
+                let ((ok, err), token) = crate::render::sources::import_source(
+                    &debug_name,
+                    dataflow_id,
+                    &as_of,
+                    source.clone(),
+                    storage_state,
+                    region,
+                    materialized_logging.clone(),
+                    src_id.clone(),
+                );
+
+                let ok_activator = RcActivator::new(format!("{debug_name}-ok"), 1);
+                let err_activator = RcActivator::new(format!("{debug_name}-err"), 1);
+
+                let ok_handle =
+                    ActivatedEventPusher::new(Rc::new(EventLink::new()), ok_activator.clone());
+                let err_handle =
+                    ActivatedEventPusher::new(Rc::new(EventLink::new()), err_activator.clone());
+
+                results.insert(
+                    *src_id,
+                    SourceBoundary {
+                        ok: ActivatedEventPusher::<_>::clone(&ok_handle),
+                        err: ActivatedEventPusher::<_>::clone(&err_handle),
+                        token,
+                    },
+                );
+
+                use timely::dataflow::operators::Capture;
+
+                ok.inner.capture_into(ok_handle);
+                err.inner.capture_into(err_handle);
+            }
+        })
+    });
+
+    results
+}
+
+pub struct ActiveStorageState<'a, A: Allocate> {
+    /// The underlying Timely worker.
+    pub timely_worker: &'a mut TimelyWorker<A>,
+    /// The storage state itself.
+    pub storage_state: &'a mut StorageState,
+    /// The channel over which frontier information is reported.
+    pub response_tx: &'a mut mpsc::UnboundedSender<Response>,
+}
+
+impl<'a, A: Allocate> ActiveStorageState<'a, A> {
+    /// Send information about new timestamp bindings created by dataflow workers back to
+    /// the coordinator.
+    pub fn report_timestamp_bindings(&mut self) {
+        // Do nothing if dataflow workers can't send feedback or if not enough time has elapsed since
+        // the last time we reported timestamp bindings.
+        if self
+            .storage_state
+            .last_bindings_feedback
+            .elapsed()
+            .as_millis()
+            < TS_BINDING_FEEDBACK_INTERVAL_MS
+        {
+            return;
+        }
+
+        let mut changes = Vec::new();
+        let mut bindings = Vec::new();
+        let mut new_frontier = Antichain::new();
+
+        // Need to go through all sources that are generating timestamp bindings, and extract their upper frontiers.
+        // If that frontier is different than the durability frontier we've previously reported then we also need to
+        // get the new bindings we've produced and send them to the coordinator.
+        for (id, history) in self.storage_state.ts_histories.iter() {
+            // Read the upper frontier and compare to what we've reported.
+            history.read_upper(&mut new_frontier);
+            let prev_frontier = self
+                .storage_state
+                .reported_bindings_frontiers
+                .get_mut(&id)
+                .expect("Frontier missing!");
+            assert!(<_ as PartialOrder>::less_equal(
+                prev_frontier,
+                &new_frontier
+            ));
+            if prev_frontier != &new_frontier {
+                let mut change_batch = ChangeBatch::new();
+                for time in prev_frontier.elements().iter() {
+                    change_batch.update(time.clone(), -1);
+                }
+                for time in new_frontier.elements().iter() {
+                    change_batch.update(time.clone(), 1);
+                }
+                change_batch.compact();
+                if !change_batch.is_empty() {
+                    changes.push((*id, change_batch));
+                }
+                // Add all timestamp bindings we know about between the old and new frontier.
+                bindings.extend(
+                    history
+                        .get_bindings_in_range(prev_frontier.borrow(), new_frontier.borrow())
+                        .into_iter()
+                        .map(|(pid, ts, offset)| (*id, pid, ts, offset)),
+                );
+                prev_frontier.clone_from(&new_frontier);
+            }
+        }
+
+        if !changes.is_empty() || !bindings.is_empty() {
+            self.send_storage_response(StorageResponse::TimestampBindings(
+                TimestampBindingFeedback { changes, bindings },
+            ));
+        }
+        self.storage_state.last_bindings_feedback = Instant::now();
+    }
+    /// Instruct all real-time sources managed by the worker to close their current
+    /// timestamp and move to the next wall clock time.
+    ///
+    /// Needs to be called periodically (ideally once per "timestamp_frequency" in order
+    /// for real time sources to make progress.
+    pub fn update_rt_timestamps(&self) {
+        for (_, history) in self.storage_state.ts_histories.iter() {
+            history.update_timestamp();
+        }
+    }
+
+    pub(crate) fn handle_storage_command(&mut self, cmd: StorageCommand) {
+        match cmd {
+            StorageCommand::CreateSources(_sources) => {
+                // Nothing to do at the moment, but in the future prepare source ingestion.
+            }
+            StorageCommand::DropSources(names) => {
+                for name in names {
+                    // Drop table-related state.
+                    self.storage_state.local_inputs.remove(&name);
+
+                    // Clean up potentially left over persisted source state.
+                    self.storage_state.persisted_sources.del_source(&name);
+                }
+            }
+
+            StorageCommand::AdvanceAllLocalInputs { advance_to } => {
+                for (_, local_input) in self.storage_state.local_inputs.iter_mut() {
+                    local_input.capability.downgrade(&advance_to);
+                }
+            }
+
+            StorageCommand::Insert { id, updates } => {
+                let input = match self.storage_state.local_inputs.get_mut(&id) {
+                    Some(input) => input,
+                    None => panic!(
+                        "local input {} missing for insert at worker {}",
+                        id,
+                        self.timely_worker.index()
+                    ),
+                };
+                let mut session = input.handle.session(input.capability.clone());
+                for update in updates {
+                    assert!(update.timestamp >= *input.capability.time());
+                    session.give((update.row, update.timestamp, update.diff));
+                }
+            }
+
+            StorageCommand::DurabilityFrontierUpdates(list) => {
+                for (id, frontier) in list {
+                    if let Some(ts_history) = self.storage_state.ts_histories.get_mut(&id) {
+                        ts_history.set_durability_frontier(frontier.borrow());
+                    }
+                }
+            }
+
+            StorageCommand::AddSourceTimestamping {
+                id,
+                connector,
+                bindings,
+            } => {
+                let source_timestamp_data = if let SourceConnector::External {
+                    connector,
+                    ts_frequency,
+                    ..
+                } = connector
+                {
+                    let rt_default = TimestampBindingRc::new(
+                        ts_frequency.as_millis().try_into().unwrap(),
+                        self.storage_state.now.clone(),
+                    );
+                    match connector {
+                        ExternalSourceConnector::AvroOcf(_)
+                        | ExternalSourceConnector::File(_)
+                        | ExternalSourceConnector::Kinesis(_)
+                        | ExternalSourceConnector::S3(_) => {
+                            rt_default.add_partition(PartitionId::None, None);
+                            Some(rt_default)
+                        }
+                        ExternalSourceConnector::Kafka(_) => Some(rt_default),
+                        ExternalSourceConnector::Postgres(_)
+                        | ExternalSourceConnector::PubNub(_) => None,
+                    }
+                } else {
+                    tracing::debug!(
+                        "Timestamping not supported for local sources {}. Ignoring",
+                        id
+                    );
+                    None
+                };
+
+                // Add any timestamp bindings that we were already aware of on restart.
+                if let Some(data) = source_timestamp_data {
+                    for (pid, timestamp, offset) in bindings {
+                        if crate::source::responsible_for(
+                            &id,
+                            self.timely_worker.index(),
+                            self.timely_worker.peers(),
+                            &pid,
+                        ) {
+                            tracing::trace!(
+                                "Adding partition/binding on worker {}: ({}, {}, {})",
+                                self.timely_worker.index(),
+                                pid,
+                                timestamp,
+                                offset
+                            );
+                            data.add_partition(pid.clone(), None);
+                            data.add_binding(pid, timestamp, offset);
+                        } else {
+                            tracing::trace!(
+                                "NOT adding partition/binding on worker {}: ({}, {}, {})",
+                                self.timely_worker.index(),
+                                pid,
+                                timestamp,
+                                offset
+                            );
+                        }
+                    }
+
+                    let prev = self.storage_state.ts_histories.insert(id, data);
+                    assert!(prev.is_none());
+                    self.storage_state
+                        .reported_bindings_frontiers
+                        .insert(id, Antichain::from_elem(0));
+                } else {
+                    assert!(bindings.is_empty());
+                }
+            }
+            StorageCommand::AllowSourceCompaction(list) => {
+                for (id, frontier) in list {
+                    if let Some(ts_history) = self.storage_state.ts_histories.get_mut(&id) {
+                        ts_history.set_compaction_frontier(frontier.borrow());
+                    }
+
+                    self.storage_state
+                        .persisted_sources
+                        .allow_compaction(id, frontier);
+                }
+            }
+            StorageCommand::DropSourceTimestamping { id } => {
+                let prev = self.storage_state.ts_histories.remove(&id);
+                if prev.is_none() {
+                    tracing::debug!("Attempted to drop timestamping for source {} that was not previously known", id);
+                }
+
+                let prev = self.storage_state.ts_source_mapping.remove(&id);
+                if prev.is_none() {
+                    tracing::debug!("Attempted to drop timestamping for source {} not previously mapped to any instances", id);
+                }
+
+                self.storage_state.reported_bindings_frontiers.remove(&id);
+            }
+        }
+    }
+
+    /// Send a response to the coordinator.
+    fn send_storage_response(&self, response: StorageResponse) {
+        // Ignore send errors because the coordinator is free to ignore our
+        // responses. This happens during shutdown.
+        let _ = self.response_tx.send(Response::Storage(response));
+    }
+}

--- a/src/dataflow/src/sink/avro_ocf.rs
+++ b/src/dataflow/src/sink/avro_ocf.rs
@@ -44,7 +44,7 @@ where
 
     fn render_continuous_sink(
         &self,
-        _compute_state: &mut crate::render::ComputeState,
+        _compute_state: &mut crate::server::ComputeState,
         _sink: &SinkDesc,
         sink_id: GlobalId,
         sinked_collection: Collection<G, (Option<Row>, Option<Row>), Diff>,

--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -84,7 +84,7 @@ where
 
     fn render_continuous_sink(
         &self,
-        compute_state: &mut crate::render::ComputeState,
+        compute_state: &mut crate::server::ComputeState,
         sink: &SinkDesc,
         sink_id: GlobalId,
         sinked_collection: Collection<G, (Option<Row>, Option<Row>), Diff>,

--- a/src/dataflow/src/sink/tail.rs
+++ b/src/dataflow/src/sink/tail.rs
@@ -52,7 +52,7 @@ where
 
     fn render_continuous_sink(
         &self,
-        compute_state: &mut crate::render::ComputeState,
+        compute_state: &mut crate::server::ComputeState,
         sink: &SinkDesc,
         sink_id: GlobalId,
         sinked_collection: Collection<G, (Option<Row>, Option<Row>), Diff>,


### PR DESCRIPTION
This PR factors the logic of `dataflow::Worker` into compute and storage aspects. Each aspect is backed by the associated state, a timely worker, and the response queue. There is no other sharing that I can discern. In principle, other than a bit of ick around dataflow construction, these two entities could be dislocated and things would still work .. "great".

The design pattern is to form a subset of `Worker` for each facet, the `ActiveComputeState` and `ActiveStorageState` types, each of which wraps the subset of `Worker` they require access to. Their methods from `Worker` are instead implemented on these types.

Some rendering was extracted from `render`, which might be a mistake. Roughly, the two parts of rendering that feel the pain of having to interact (rendering the source dataflow, and rendering the rest) got pulled out and then call back in to `render` as needed. This may be an error, if we can find a good abstraction to present back at `render` and let it take control.

### Motivation

We want to prepare to actually isolate the state and logic for storage and compute, and this makes things a lot more clear (to me) without breaking anything.

The only intended functional change is that our metrics will only observe pending peeks once per scheduling quantum (time we drain the command queue) at the moment when the queue would be deepest. Previously it would also observe the pending peeks at each peek insertion, but as it only records the length it would just see a sequence of increasing numbers. Removing this meant that the `ComputeState` did not need to hold on to metric that are otherwise held by the server itself.

### Tips for Reviewers

The code movement is almost entirely the creation of the two wrapper types mentioned above, and the transportation of methods from `Worker` to them. There are many consequences mostly around `use` statements.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
