### PR TITLE
Fix full upgrade tests

### DIFF
--- a/test/upgrade/check-ssl-from-any_version-noop.td
+++ b/test/upgrade/check-ssl-from-any_version-noop.td
@@ -1,0 +1,10 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# no-op to keep the upgrade test glob simple

--- a/test/upgrade/create-ssl-in-any_version-noop.td
+++ b/test/upgrade/create-ssl-in-any_version-noop.td
@@ -1,0 +1,10 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# no-op to keep the upgrade test glob simple


### PR DESCRIPTION
They are currently failing on nightly with:

    testdrive: glob did not match any patterns: create-ssl-in-{any_version,...}*.td

### Motivation

* This PR fixes a previously unreported bug.

### Checklist

- [n/a] This PR has adequate test coverage / QA involvement has been duly considered.
- [n/a] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).