### PR TITLE
upgrade: Make --tests metavar reflect the legal choices

### DIFF
--- a/test/upgrade/mzcompose.py
+++ b/test/upgrade/mzcompose.py
@@ -88,7 +88,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     )
     parser.add_argument(
         "--tests",
-        metavar="S",
         choices=["all", "non-ssl", "ssl"],
         default="all",
         help="limit testing to certain scenarios",


### PR DESCRIPTION
I was confused what "certain scenarios" meant, the new output looks like:


    $ ./mzcompose run default --help
    ..snip..
      --tests {all,non-ssl,ssl}
                        limit testing to certain scenarios.