### PR TITLE
materialized: support Materialize Cloud authentication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2396,6 +2396,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
+name = "jsonwebtoken"
+version = "8.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "012bb02250fdd38faa5feee63235f7a459974440b9b57593822414c31f92839e"
+dependencies = [
+ "base64",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "junit-report"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2630,6 +2644,7 @@ dependencies = [
  "async-trait",
  "atty",
  "backtrace",
+ "base64",
  "bytes",
  "cc",
  "cfg-if",
@@ -2644,12 +2659,15 @@ dependencies = [
  "fallible-iterator",
  "flate2",
  "futures",
+ "headers",
  "hex",
  "hex-literal",
+ "http",
  "hyper",
  "hyper-openssl",
  "include_dir",
  "itertools",
+ "jsonwebtoken",
  "krb5-src",
  "lazy_static",
  "libc",
@@ -2659,6 +2677,7 @@ dependencies = [
  "mz-dataflow",
  "mz-dataflow-types",
  "mz-dataflowd",
+ "mz-frontegg-auth",
  "mz-http-proxy",
  "mz-kafka-util",
  "mz-ore",
@@ -3260,6 +3279,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "mz-frontegg-auth"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "base64",
+ "derivative",
+ "jsonwebtoken",
+ "reqwest",
+ "serde",
+ "uuid",
+]
+
+[[package]]
 name = "mz-fuzz"
 version = "0.0.1"
 dependencies = [
@@ -3581,6 +3613,7 @@ dependencies = [
  "mz-coord",
  "mz-dataflow-types",
  "mz-expr",
+ "mz-frontegg-auth",
  "mz-ore",
  "mz-pgcopy",
  "mz-pgrepr",
@@ -4857,6 +4890,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ac73b1112776fc109b2e61909bc46c7e1bf0d7f690ffb1676553acce16d5cda"
 
 [[package]]
+name = "quickcheck"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
+dependencies = [
+ "rand",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5374,6 +5416,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e24979f63a11545f5f2c60141afe249d4f19f84581ea2138065e400941d83d3"
 
 [[package]]
+name = "simple_asn1"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a762b1c38b9b990c694b9c2f8abe3372ce6a9ceaae6bca39cfc46e054f45745"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "time",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5721,6 +5775,7 @@ dependencies = [
  "itoa 1.0.1",
  "libc",
  "num_threads",
+ "quickcheck",
  "time-macros",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "src/dataflowd",
     "src/expr-test-util",
     "src/expr",
+    "src/frontegg-auth",
     "src/http-proxy",
     "src/interchange",
     "src/kafka-util",

--- a/deny.toml
+++ b/deny.toml
@@ -76,6 +76,7 @@ wrappers = [
     "protobuf-parse",
     "pubnub-core",
     "pubnub-hyper",
+    "simple_asn1",
     "sysctl",
     "tiberius",
     "zip",

--- a/src/coord/src/command.rs
+++ b/src/coord/src/command.rs
@@ -31,6 +31,7 @@ use crate::session::{EndTransactionAction, RowBatchStream, Session};
 pub enum Command {
     Startup {
         session: Session,
+        create_user_if_not_exists: bool,
         cancel_tx: Arc<watch::Sender<Canceled>>,
         tx: oneshot::Sender<Response<StartupResponse>>,
     },

--- a/src/coordtest/src/lib.rs
+++ b/src/coordtest/src/lib.rs
@@ -174,7 +174,7 @@ impl CoordTest {
     async fn connect(&self) -> anyhow::Result<(SessionClient, StartupResponse)> {
         let conn_client = self.coord_client.new_conn()?;
         let session = Session::new(conn_client.conn_id(), "materialize".into());
-        Ok(conn_client.startup(session).await?)
+        Ok(conn_client.startup(session, false).await?)
     }
 
     fn rewrite_query(&self, query: &str) -> String {

--- a/src/frontegg-auth/Cargo.toml
+++ b/src/frontegg-auth/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "mz-frontegg-auth"
+description = "Authentication interfaces to Frontegg."
+version = "0.0.0"
+edition = "2021"
+publish = false
+rust-version = "1.58.0"
+
+[dependencies]
+anyhow = "1.0.52"
+base64 = "0.13.0"
+derivative = "2.2.0"
+jsonwebtoken = "8.0.1"
+reqwest = "0.11.9"
+serde = { version = "1.0.135", features = ["derive"] }
+uuid = "0.8.2"

--- a/src/frontegg-auth/src/lib.rs
+++ b/src/frontegg-auth/src/lib.rs
@@ -1,0 +1,141 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use anyhow::bail;
+use derivative::Derivative;
+use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
+use uuid::Uuid;
+
+#[derive(Clone, Derivative)]
+#[derivative(Debug)]
+pub struct FronteggAuthentication {
+    pub admin_api_token_url: String,
+    #[derivative(Debug = "ignore")]
+    pub decoding_key: DecodingKey,
+    pub tenant_id: Uuid,
+}
+
+impl FronteggAuthentication {
+    /// Creates a new frontegg auth. `jwk_rsa_pem` is the RSA public key to
+    /// validate the JWTs. `tenant_id` must be parseable as a UUID.
+    pub fn new(
+        admin_api_token_url: String,
+        jwk_rsa_pem: &[u8],
+        tenant_id: Uuid,
+    ) -> Result<Self, anyhow::Error> {
+        let decoding_key = DecodingKey::from_rsa_pem(&jwk_rsa_pem)?;
+        Ok(Self {
+            admin_api_token_url,
+            decoding_key,
+            tenant_id,
+        })
+    }
+
+    /// Exchanges a password for a JWT token.
+    ///
+    /// Somewhat unusually, the password encodes both the client ID and secret
+    /// for the API key in use. Both the client ID and secret are UUIDs. The
+    /// password can have one of two formats:
+    ///
+    ///   * The URL-safe base64 encoding of the concatenated bytes of the UUIDs.
+    ///
+    ///     This format is a very compact representation (only 43 or 44 bytes)
+    ///     that is safe to use in a connection string without escaping.
+    ///
+    ///   * The concatenated hex-encoding of the UUIDs, with any number of
+    ///     special characters that are ignored.
+    ///
+    ///     This format allows for the UUIDs to be formatted with hyphens, or
+    ///     not, and for the two
+    pub async fn exchange_password_for_token(
+        &self,
+        password: &str,
+    ) -> Result<ApiTokenResponse, anyhow::Error> {
+        let (client_id, secret) = if password.len() == 43 || password.len() == 44 {
+            // If it's exactly 43 or 44 bytes, assume we have base64-encoded
+            // UUID bytes without or with padding, respectively.
+            let buf = base64::decode_config(password, base64::URL_SAFE)?;
+            let client_id = Uuid::from_slice(&buf[..16])?;
+            let secret = Uuid::from_slice(&buf[16..])?;
+            (client_id, secret)
+        } else if password.len() >= 64 {
+            // If it's more than 64 bytes, assume we have concatenated
+            // hex-encoded UUIDs, possibly with some special characters mixed
+            // in.
+            let mut chars = password.chars().filter(|c| c.is_alphanumeric());
+            let client_id = Uuid::parse_str(&chars.by_ref().take(32).collect::<String>())?;
+            let secret = Uuid::parse_str(&chars.take(32).collect::<String>())?;
+            (client_id, secret)
+        } else {
+            // Otherwise it's definitely not a password format we understand.
+            bail!("invalid password");
+        };
+        self.exchange_client_secret_for_token(client_id, secret)
+            .await
+    }
+
+    /// Exchanges a client id and secret for a jwt token.
+    pub async fn exchange_client_secret_for_token(
+        &self,
+        client_id: Uuid,
+        secret: Uuid,
+    ) -> Result<ApiTokenResponse, anyhow::Error> {
+        let resp = reqwest::Client::new()
+            .post(&self.admin_api_token_url)
+            .json(&ApiTokenArgs { client_id, secret })
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<ApiTokenResponse>()
+            .await?;
+
+        Ok(resp)
+    }
+
+    /// Validates an access token and its `tenant_id`.
+    pub fn validate_access_token(&self, token: &str) -> Result<Claims, anyhow::Error> {
+        let msg = decode::<Claims>(
+            &token,
+            &self.decoding_key,
+            &Validation::new(Algorithm::RS256),
+        )?;
+        if msg.claims.tenant_id != self.tenant_id {
+            bail!("tenant ids don't match")
+        }
+        Ok(msg.claims)
+    }
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ApiTokenArgs {
+    pub client_id: Uuid,
+    pub secret: Uuid,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ApiTokenResponse {
+    pub expires: String,
+    pub expires_in: i64,
+    pub access_token: String,
+    pub refresh_token: String,
+}
+
+// TODO: Do we care about the sub? Do we need to validate the sub or other
+// things, even if unused?
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Claims {
+    pub exp: i64,
+    pub email: String,
+    pub tenant_id: Uuid,
+    pub roles: Vec<String>,
+    pub permissions: Vec<String>,
+}

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -33,6 +33,7 @@ askama = { version = "0.11.0", default-features = false, features = ["config", "
 async-trait = "0.1.52"
 atty = "0.2.14"
 backtrace = "0.3.64"
+base64 = "0.13.0"
 cfg-if = "1.0.0"
 chrono = { version = "0.4.0", default-features = false, features = ["std"] }
 clap = { version = "3.0.14", features = ["wrap_help", "env", "derive"] }
@@ -42,7 +43,9 @@ crossbeam-channel = "0.5.2"
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 fail = { version = "0.5.0", features = ["failpoints"] }
 futures = "0.3.21"
+headers = "0.3.5"
 hex = "0.4.3"
+http = "0.2.6"
 hyper = { version = "0.14.17", features = ["http1", "server"] }
 hyper-openssl = "0.9.1"
 include_dir = "0.7.2"
@@ -55,6 +58,7 @@ mz-coord = { path = "../coord" }
 mz-dataflow = { path = "../dataflow" }
 mz-dataflow-types = { path = "../dataflow-types" }
 mz-dataflowd = { path = "../dataflowd" }
+mz-frontegg-auth = { path = "../frontegg-auth" }
 mz-http-proxy = { path = "../http-proxy", features = ["reqwest"] }
 mz-ore = { path = "../ore", features = ["task"] }
 mz-pgwire = { path = "../pgwire" }
@@ -103,6 +107,7 @@ bytes = "1.1.0"
 datadriven = "0.6.0"
 fallible-iterator = "0.2.0"
 itertools = "0.10.3"
+jsonwebtoken = "8.0.1"
 mz-coordtest = { path = "../coordtest" }
 mz-kafka-util = { path = "../kafka-util" }
 mz-pgrepr = { path = "../pgrepr" }

--- a/src/materialized/src/bin/coordd.rs
+++ b/src/materialized/src/bin/coordd.rs
@@ -137,9 +137,11 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
             tls: None,
             coord_client: coord_client.clone(),
             metrics_registry: &metrics_registry,
+            frontegg: None,
         });
         let http_server = http::Server::new(http::Config {
             tls: None,
+            frontegg: None,
             coord_client,
             metrics_registry,
             global_metrics: metrics,

--- a/src/materialized/src/http.rs
+++ b/src/materialized/src/http.rs
@@ -17,6 +17,8 @@ use std::net::SocketAddr;
 use std::pin::Pin;
 
 use futures::future::TryFutureExt;
+use headers::authorization::{Authorization, Basic, Bearer};
+use headers::HeaderMapExt;
 use hyper::{service, Body, Method, Request, Response, StatusCode};
 use hyper_openssl::MaybeHttpsStream;
 use mz_ore::metrics::MetricsRegistry;
@@ -27,6 +29,7 @@ use tokio_openssl::SslStream;
 use tracing::error;
 
 use mz_coord::session::Session;
+use mz_frontegg_auth::FronteggAuthentication;
 use mz_ore::future::OreFutureExt;
 use mz_ore::netio::SniffedStream;
 
@@ -56,6 +59,7 @@ fn sniff_tls(buf: &[u8]) -> bool {
 #[derive(Debug, Clone)]
 pub struct Config {
     pub tls: Option<TlsConfig>,
+    pub frontegg: Option<FronteggAuthentication>,
     pub coord_client: mz_coord::Client,
     pub metrics_registry: MetricsRegistry,
     pub global_metrics: Metrics,
@@ -77,6 +81,7 @@ pub enum TlsMode {
 #[derive(Debug)]
 pub struct Server {
     tls: Option<TlsConfig>,
+    frontegg: Option<FronteggAuthentication>,
     coord_client: mz_coord::Client,
     metrics_registry: MetricsRegistry,
     global_metrics: Metrics,
@@ -87,6 +92,7 @@ impl Server {
     pub fn new(config: Config) -> Server {
         Server {
             tls: config.tls,
+            frontegg: config.frontegg,
             coord_client: config.coord_client,
             metrics_registry: config.metrics_registry,
             global_metrics: config.global_metrics,
@@ -134,11 +140,11 @@ impl Server {
         //
         // The match here explicitly spells out all cases to be resilient to
         // future changes to TlsMode.
-        let user = match (self.tls_mode(), &conn) {
-            (None, MaybeHttpsStream::Http(_)) => Ok(SYSTEM_USER.into()),
+        let cert_user: Result<Option<String>, _> = match (self.tls_mode(), &conn) {
+            (None, MaybeHttpsStream::Http(_)) => Ok(None),
             (None, MaybeHttpsStream::Https(_)) => unreachable!(),
             (Some(TlsMode::Require), MaybeHttpsStream::Http(_)) => Err("HTTPS is required"),
-            (Some(TlsMode::Require), MaybeHttpsStream::Https(_)) => Ok(SYSTEM_USER.into()),
+            (Some(TlsMode::Require), MaybeHttpsStream::Https(_)) => Ok(None),
             (Some(TlsMode::AssumeUser), MaybeHttpsStream::Http(_)) => Err("HTTPS is required"),
             (Some(TlsMode::AssumeUser), MaybeHttpsStream::Https(conn)) => conn
                 .ssl()
@@ -146,17 +152,52 @@ impl Server {
                 .as_ref()
                 .and_then(|cert| cert.subject_name().entries_by_nid(Nid::COMMONNAME).next())
                 .and_then(|cn| cn.data().as_utf8().ok())
-                .map(|cn| cn.to_string())
+                .map(|cn| Some(cn.to_string()))
                 .ok_or("invalid user name in client certificate"),
         };
 
         let svc = service::service_fn(move |req| {
-            let user = user.clone();
+            let cert_user = cert_user.clone();
             let coord_client = self.coord_client.clone();
             let metrics_registry = self.metrics_registry.clone();
             let global_metrics = self.global_metrics.clone();
             let pgwire_metrics = self.pgwire_metrics.clone();
+            let frontegg = self.frontegg.clone();
             let future = async move {
+                // There are three places a username may be specified:
+                // - certificate common name
+                // - HTTP Basic authentication
+                // - JWT email address
+                // We verify that if any of these are present, they must match any other that
+                // is also present.
+
+                let user = if let Err(e) = cert_user {
+                    Err(e)
+                } else if let Some(frontegg) = &frontegg {
+                    // If we require mzcloud auth, fetch credentials from the http auth
+                    // header. Basic auth comes with a username/password, where the password
+                    // is the client+secret pair. Bearer auth is an existing JWT that must be
+                    // validated. In either case, if a username was specified in the client cert,
+                    // it must match that of the JWT.
+                    validate_http_frontegg_authentication(&req, &frontegg)
+                        .await
+                        .and_then(|email| {
+                            if let Ok(Some(cert_user)) = cert_user {
+                                if email != cert_user {
+                                    anyhow::bail!(
+                                        "JWT email does not match certificate common name"
+                                    );
+                                }
+                            }
+                            Ok(email)
+                        })
+                        .map_err(|_e| "unauthorized")
+                } else {
+                    // If there was no mzcloud auth, we can use the cert's username if present,
+                    // otherwise the system user.
+                    cert_user.map(|cert_user| cert_user.unwrap_or_else(|| SYSTEM_USER.to_string()))
+                };
+
                 let user = match user {
                     Ok(user) => user,
                     Err(e) => return Ok(util::error_response(StatusCode::UNAUTHORIZED, e)),
@@ -164,15 +205,16 @@ impl Server {
 
                 let coord_client = coord_client.new_conn()?;
                 let session = Session::new(coord_client.conn_id(), user);
-                let (mut coord_client, _) = match coord_client.startup(session).await {
-                    Ok(coord_client) => coord_client,
-                    Err(e) => {
-                        return Ok(util::error_response(
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            e.to_string(),
-                        ))
-                    }
-                };
+                let (mut coord_client, _) =
+                    match coord_client.startup(session, frontegg.is_some()).await {
+                        Ok(coord_client) => coord_client,
+                        Err(e) => {
+                            return Ok(util::error_response(
+                                StatusCode::INTERNAL_SERVER_ERROR,
+                                e.to_string(),
+                            ))
+                        }
+                    };
 
                 let res = match (req.method(), req.uri().path()) {
                     (&Method::GET, "/") => root::handle_home(req, &mut coord_client).await,
@@ -304,4 +346,33 @@ impl hyper::service::Service<Request<Body>> for ThirdPartyServer {
             }),
         }
     }
+}
+
+// Uses the HTTP Authorization header to fetch a JWT. Basic auth requires a
+// username and password that is "client,secret" that is exchanged for a JWT,
+// and whose username must match the JWT's email. Bearer auth can provide the
+// JWT directly. The JWT is validated and its email address is returned.
+async fn validate_http_frontegg_authentication(
+    req: &Request<Body>,
+    frontegg: &FronteggAuthentication,
+) -> Result<String, anyhow::Error> {
+    let (http_user, jwt) = if let Some(basic) = req.headers().typed_get::<Authorization<Basic>>() {
+        let jwt = frontegg
+            .exchange_password_for_token(basic.0.password())
+            .await?;
+        (Some(basic.0.username().to_string()), jwt.access_token)
+    } else if let Some(basic) = req.headers().typed_get::<Authorization<Bearer>>() {
+        (None, basic.0.token().to_string())
+    } else {
+        anyhow::bail!("expected authorization");
+    };
+
+    let claims = frontegg.validate_access_token(&jwt)?;
+    // If a username was specified, make sure it matches the JWT email.
+    if let Some(http_user) = http_user {
+        if http_user != claims.email {
+            anyhow::bail!("HTTP Authorization user and JWT email do not match");
+        }
+    }
+    Ok(claims.email)
 }

--- a/src/pgwire/Cargo.toml
+++ b/src/pgwire/Cargo.toml
@@ -19,6 +19,7 @@ lazy_static = "1.4.0"
 mz-coord = { path = "../coord" }
 mz-dataflow-types = { path = "../dataflow-types" }
 mz-expr = { path = "../expr" }
+mz-frontegg-auth = { path = "../frontegg-auth" }
 mz-ore = { path = "../ore" }
 mz-pgcopy = { path = "../pgcopy" }
 mz-pgrepr = { path = "../pgrepr" }

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -185,6 +185,10 @@ pub enum FrontendMessage {
     CopyDone,
 
     CopyFail(String),
+
+    Password {
+        password: String,
+    },
 }
 
 impl FrontendMessage {
@@ -204,6 +208,7 @@ impl FrontendMessage {
             FrontendMessage::CopyData(_) => "copy_data",
             FrontendMessage::CopyDone => "copy_done",
             FrontendMessage::CopyFail(_) => "copy_fail",
+            FrontendMessage::Password { .. } => "password",
         }
     }
 }
@@ -214,6 +219,7 @@ impl FrontendMessage {
 #[derive(Debug)]
 pub enum BackendMessage {
     AuthenticationOk,
+    AuthenticationCleartextPassword,
     CommandComplete {
         tag: String,
     },

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -553,6 +553,7 @@ impl Runner {
             aws_external_id: AwsExternalId::NotProvided,
             listen_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
             tls: None,
+            frontegg: None,
             experimental_mode: true,
             disable_user_indexes: false,
             safe_mode: false,


### PR DESCRIPTION
Add a new cli flag to specify a tenant and JWK causing pgwire and the
http endpoint to require a valid JWT from Materialize Cloud. We trust
the validated username, and will create it if it does not exist.

The JWT comes with expiry, refresh, and role information that we currently
ignore, but will use in the future. The cloud sdk has a function that
does some of this, but omits the expiry information, so isn't good enough
for use here.

### Motivation

  * This PR adds a feature that has not yet been specified.

Support password auth backed by the cloud site to allow users to connect without a client cert.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
