### PR TITLE
nightly,test: Replace --workers 32 with --workers 16

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -79,14 +79,14 @@
         composition: testdrive
         args: [--aws-region=us-east-2, --workers=1]
 
-- id: testdrive_workers_32
-  label: ":racing_car: testdrive with --workers 32"
-  timeout_in_minutes: 30
+- id: testdrive_workers_16
+  label: ":racing_car: testdrive with --workers 16"
+  timeout_in_minutes: 60
   plugins:
     - ./ci/plugins/scratch-aws-access: ~
     - ./ci/plugins/mzcompose:
         composition: testdrive
-        args: [--aws-region=us-east-2, --workers=32]
+        args: [--aws-region=us-east-2, --workers=16]
 
 - id: persistence_testdrive
   label: ":racing_car: testdrive with --persistent-user-tables"


### PR DESCRIPTION
Replace the --workers 32 CI build step with --workers 16. 32 workers
is too many for the number of CPU cores of the EC2 instance type
used by the CI, which makes it an unsupported configuration.

--workers 16 however seems to pass, so settle on this value instead.

Please see https://github.com/MaterializeInc/materialize/issues/10498