### PR TITLE
use `std::time::Duration` instead of `_ms` suffixed variables

### DIFF
--- a/src/coord/src/sink_connector.rs
+++ b/src/coord/src/sink_connector.rs
@@ -131,8 +131,12 @@ async fn register_kafka_topic(
         TopicReplication::Fixed(replication_factor),
     );
 
-    let retention_ms_str = retention.retention_ms.map(|s| s.to_string());
-    let retention_bytes_str = retention.retention_bytes.map(|s| s.to_string());
+    let retention_ms_str = match retention.duration {
+        Some(Some(d)) => Some(d.as_millis().to_string()),
+        Some(None) => Some("-1".to_string()),
+        None => None,
+    };
+    let retention_bytes_str = retention.bytes.map(|s| s.to_string());
     if let Some(ref retention_ms) = retention_ms_str {
         kafka_topic = kafka_topic.set("retention.ms", retention_ms);
     }

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -1485,6 +1485,7 @@ pub mod sinks {
 
     use std::collections::BTreeMap;
     use std::path::PathBuf;
+    use std::time::Duration;
 
     use serde::{Deserialize, Serialize};
     use timely::progress::frontier::Antichain;
@@ -1647,8 +1648,8 @@ pub mod sinks {
 
     #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
     pub struct KafkaSinkConnectorRetention {
-        pub retention_ms: Option<i64>,
-        pub retention_bytes: Option<i64>,
+        pub duration: Option<Option<Duration>>,
+        pub bytes: Option<i64>,
     }
 
     #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -87,7 +87,7 @@ pub use pubnub::PubNubSourceReader;
 pub use s3::S3SourceReader;
 
 // Interval after which the source operator will yield control.
-static YIELD_INTERVAL_MS: u128 = 10;
+const YIELD_INTERVAL: Duration = Duration::from_millis(10);
 
 /// Shared configuration information for all source types.
 pub struct SourceConfig<'a, G> {
@@ -1586,7 +1586,7 @@ fn handle_message<S: SourceReader>(
         }
     }
 
-    if timer.elapsed().as_millis() > YIELD_INTERVAL_MS {
+    if timer.elapsed() > YIELD_INTERVAL {
         // We didn't drain the entire queue, so indicate that we
         // should run again but yield the CPU to other operators.
         (SourceStatus::Alive, MessageProcessing::Yielded)


### PR DESCRIPTION
### Motivation

Avoid having to think about time units

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
