### PR TITLE
Fix underflow during binary encoding of Intervals

### DIFF
--- a/src/pgrepr/src/value/interval.rs
+++ b/src/pgrepr/src/value/interval.rs
@@ -46,7 +46,10 @@ impl ToSql for Interval {
         // Our intervals are guaranteed to fit within SQL's min/max intervals,
         // so this is compression is guaranteed to be lossless. For details, see
         // `repr::scalar::datetime::compute_interval`.
-        let days = std::cmp::min(self.0.days() as i128, i32::MAX as i128);
+        let days = std::cmp::max(
+            std::cmp::min(self.0.days() as i128, i32::MAX as i128),
+            i32::MIN as i128,
+        );
         let ns = self.0.duration - days * 24 * 60 * 60 * 1_000_000_000;
         out.put_i64((ns / 1000) as i64);
         out.put_i32(days as i32);

--- a/test/pgtest/binary.pt
+++ b/test/pgtest/binary.pt
@@ -1,0 +1,17 @@
+# Test binary encodings
+
+send
+Parse {"query": "SELECT INTERVAL '-2147483648 days -48 hrs';"}
+Bind {"result_formats": [1]}
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+ParseComplete
+BindComplete
+DataRow {"fields":["[255, 255, 255, 215, 196, 81, 64, 0, 128, 0, 0, 0, 0, 0, 0, 0]"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}


### PR DESCRIPTION
In Materialize Intervals internally store the number of months in the
interval and the number of nanoseconds. The pg_wire binary format for
Intervals is 8 bytes for the number of microseconds, followed 4 bytes
for the number of days, followed by 4 bytes for the number of months.
When converting an Interval to the pg_wire binary encoding, Materialize
extracts as many whole days from the nanoseconds as will fit in 4 bytes
(an i32 in Rust). During this it checks if the number of days is larger
than i32::MAX protecting from overflow. However, it never checked if
the number of days is less than i32::MIN making is susceptible to
underflow. This commit fixes that issue.

### Motivation

This PR fixes a previously unreported bug. As described above, the pg_wire binary encoding for Interval types never checked for underflow causing the binary encoding to lose precision/correctness of the underlying Interval.

The easiest way to see this is with the query `SELECT INTERVAL '-2147483648 days -48 hrs';` (Note that `i32::MIN` is -2147483648). Materialize tried to convert this to -2147483650 days and encode this in an `i32` which results in underflow. The resulting binary encoding is [0, 0, 0, 0, 0, 0, 0, 0, 127, 255, 255, 254, 0, 0, 0, 0]. As described above the pg_wire binary format for Intervals is [Microsecond (8 bytes), Days (4 bytes), Months (4 bytes)]. So the encoding that materialize comes up with is 
0 Microseconds, 0111 1111 1111 1111 1111 1111 1111 1110 days, and 0 months.  0111 1111 1111 1111 1111 1111 1111 1110 is equal to 2147483646 in decimal. So what's happening is that the -2147483650 days ends up underflowing into a positive amount of days.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
