### PR TITLE
Add Interval binary encoding test

### DIFF
--- a/test/pgtest/binary.pt
+++ b/test/pgtest/binary.pt
@@ -1,0 +1,17 @@
+# Test binary encodings
+
+send
+Parse {"query": "SELECT INTERVAL '2147483647 days 2147483647 hours 59 minutes 59.999999 seconds'"}
+Bind {"result_formats": [1]}
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+ParseComplete
+BindComplete
+DataRow {"fields":["[107, 73, 209, 255, 255, 255, 255, 255, 127, 255, 255, 255, 0, 0, 0, 0]"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}


### PR DESCRIPTION
Closes MaterializeInc/database-issues#1528.

Adds test for Interval binary encoding

### Motivation

This PR fixes a recognized bug: MaterializeInc/database-issues#1528. I was unable to re-create the bug, so I added a passing test with the scenario that the bug describes.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
