### PR TITLE
Update mkrelease for new process

### DIFF
--- a/.github/ISSUE_TEMPLATE/05-release.md
+++ b/.github/ISSUE_TEMPLATE/05-release.md
@@ -54,9 +54,18 @@ production readiness.
 - [ ] Create a new release candidate, specifying what kind of release this
   should be (see `--help` for all the release types):
 
-  ```shell
-  bin/mkrelease new-rc weekly
-  ```
+  - If there are no cherry-picks you can run the following command:
+
+    ```shell
+    bin/mkrelease new-rc weekly --checkout <commit_from_previous_step>
+    ```
+
+  - Otherwise, you need to check out the commit from the previous step, run the
+    appropriate `git cherry-pick` commands, and then run:
+
+    ```shell
+    bin/mkrelease new-rc weekly
+    ```
 
 - [ ] Incorporate this tag into `main`'s history by preparing dev on top of it.
 

--- a/misc/python/materialize/cli/mkrelease.py
+++ b/misc/python/materialize/cli/mkrelease.py
@@ -122,14 +122,14 @@ def incorporate_inner(
     new_version = tag.bump_patch().replace(prerelease="dev")
     if not create_branch and not checkout:
         if is_finish:
-            create = f"continue-{new_version}"
+            create_branch = f"continue-{new_version}"
         else:
-            create = f"prepare-{new_version}"
+            create_branch = f"prepare-{new_version}"
 
     release(
         new_version,
         checkout=checkout,
-        create_branch=create,
+        create_branch=create_branch,
         tag=False,
         affect_remote=affect_remote,
     )

--- a/misc/python/materialize/cli/mkrelease.py
+++ b/misc/python/materialize/cli/mkrelease.py
@@ -259,7 +259,8 @@ def release(
     if create_branch is not None:
         git.create_branch(create_branch)
 
-    confirm_on_latest_rc(affect_remote)
+    if not version.prerelease:
+        confirm_on_latest_rc(affect_remote)
 
     change_line(BIN_CARGO_TOML, "version", f'version = "{version}"')
     change_line(


### PR DESCRIPTION
### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).