### PR TITLE
docs: running confluent with the right JDK version

### DIFF
--- a/doc/developer/guide.md
+++ b/doc/developer/guide.md
@@ -156,7 +156,7 @@ source ~/.bashrc
 confluent local services start
 ```
 
-If you have multiple JDKs installed and your current JAVA_HOME points to an incompatible version, 
+If you have multiple JDKs installed and your current JAVA_HOME points to an incompatible version,
 you can explicitly run confluent with JDK 8 or 11:
 
 ```

--- a/doc/developer/guide.md
+++ b/doc/developer/guide.md
@@ -156,6 +156,13 @@ source ~/.bashrc
 confluent local services start
 ```
 
+If you have multiple JDKs installed and your current JAVA_HOME points to an incompatible version, 
+you can explicitly run confluent with JDK 8 or 11:
+
+```
+JAVA_HOME=$(/usr/libexec/java_home -v 1.8) confluent local services start
+```
+
 #### Linux
 
 On Debian-based Linux variants, you can use APT to install Java and the


### PR DESCRIPTION
Ran into this when setting things up. If you have multiple JDKs installed, you'll need to ensure confluent is running with 1.8 or 11
