### PR TITLE
Remove AWS External IDs from any part of source descriptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3762,6 +3762,7 @@ dependencies = [
  "materialized",
  "md-5",
  "mz-coord",
+ "mz-dataflow-types",
  "mz-expr",
  "mz-ore",
  "mz-pgrepr",

--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -34,7 +34,7 @@ use tracing::{info, trace};
 use mz_build_info::DUMMY_BUILD_INFO;
 use mz_dataflow_types::{
     sinks::{SinkConnector, SinkConnectorBuilder},
-    sources::{SourceConnector, Timeline},
+    sources::{AwsExternalId, SourceConnector, Timeline},
 };
 use mz_expr::{ExprHumanizer, GlobalId, MirScalarExpr, OptimizedMirRelationExpr};
 use mz_repr::{RelationDesc, ScalarType};
@@ -1204,7 +1204,7 @@ impl Catalog {
             experimental_mode,
             safe_mode: false,
             build_info: &DUMMY_BUILD_INFO,
-            aws_external_id: None,
+            aws_external_id: AwsExternalId::NotProvided,
             timestamp_frequency: Duration::from_secs(1),
             now,
             skip_migrations: true,

--- a/src/coord/src/catalog/config.rs
+++ b/src/coord/src/catalog/config.rs
@@ -10,6 +10,7 @@
 use std::time::Duration;
 
 use mz_build_info::BuildInfo;
+use mz_dataflow_types::sources::AwsExternalId;
 use mz_ore::metrics::MetricsRegistry;
 
 use crate::catalog::storage;
@@ -31,7 +32,7 @@ pub struct Config<'a> {
     /// An [External ID][] to use for all AWS AssumeRole operations.
     ///
     /// [External ID]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html
-    pub aws_external_id: Option<String>,
+    pub aws_external_id: AwsExternalId,
     /// Timestamp frequency to use for CREATE SOURCE
     pub timestamp_frequency: Duration,
     /// Function to generate wall clock now; can be mocked.

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -114,7 +114,7 @@ use mz_dataflow_types::client::{Response as DataflowResponse, StorageResponse};
 use mz_dataflow_types::logging::LoggingConfig as DataflowLoggingConfig;
 use mz_dataflow_types::sinks::{SinkAsOf, SinkConnector, SinkDesc, TailSinkConnector};
 use mz_dataflow_types::sources::{
-    ExternalSourceConnector, PostgresSourceConnector, SourceConnector, Timeline,
+    AwsExternalId, ExternalSourceConnector, PostgresSourceConnector, SourceConnector, Timeline,
 };
 use mz_dataflow_types::{DataflowDesc, DataflowDescription, IndexDesc, PeekResponse, Update};
 use mz_expr::{
@@ -256,7 +256,7 @@ pub struct Config {
     pub disable_user_indexes: bool,
     pub safe_mode: bool,
     pub build_info: &'static BuildInfo,
-    pub aws_external_id: Option<String>,
+    pub aws_external_id: AwsExternalId,
     pub metrics_registry: MetricsRegistry,
     pub persister: PersisterWithConfig,
     pub now: NowFn,

--- a/src/coordtest/src/lib.rs
+++ b/src/coordtest/src/lib.rs
@@ -68,6 +68,7 @@ use anyhow::anyhow;
 use async_trait::async_trait;
 use futures::future::FutureExt;
 use mz_dataflow_types::client::{ComputeResponse, Response};
+use mz_dataflow_types::sources::AwsExternalId;
 use tempfile::TempDir;
 use tokio::sync::mpsc;
 use tokio::sync::Mutex as TokioMutex;
@@ -125,6 +126,7 @@ impl CoordTest {
             now: now.clone(),
             metrics_registry: metrics_registry.clone(),
             persister: None,
+            aws_external_id: AwsExternalId::NotProvided,
         })?;
         let dataflow_client = InterceptingDataflowClient::new(dataflow_client);
 
@@ -146,7 +148,7 @@ impl CoordTest {
             disable_user_indexes: false,
             safe_mode: false,
             build_info: &DUMMY_BUILD_INFO,
-            aws_external_id: None,
+            aws_external_id: AwsExternalId::NotProvided,
             metrics_registry,
             persister,
             now,

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -1398,16 +1398,40 @@ pub mod sources {
     pub struct AwsAssumeRole {
         /// The Amazon Resource Name of the role to assume.
         pub arn: String,
-        /// The External ID for this customer Materialize provides during role assumption.
-        ///
-        /// <https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html>
-        pub external_id: Option<String>,
+    }
+
+    /// An external ID to use for all AWS AssumeRole operations.
+    ///
+    /// Note that it is critical for security that this ID can **not** be provided by users running
+    /// in Materialize Cloud, it must be provided by Materialize. Currently this guarantee is
+    /// satisfied by only making this accessible from the CLI, which users do not have access to.
+    ///
+    /// <https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html>
+    #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    pub enum AwsExternalId {
+        NotProvided,
+        ISwearThisCameFromACliArgOrEnvVariable(String),
+    }
+
+    impl Default for AwsExternalId {
+        fn default() -> Self {
+            AwsExternalId::NotProvided
+        }
+    }
+
+    impl AwsExternalId {
+        fn get(&self) -> Option<&str> {
+            match self {
+                AwsExternalId::NotProvided => None,
+                AwsExternalId::ISwearThisCameFromACliArgOrEnvVariable(v) => Some(v),
+            }
+        }
     }
 
     impl AwsConfig {
         /// Loads the AWS SDK configuration object from the environment, then
         /// applies the overrides from this object.
-        pub async fn load(&self) -> mz_aws_util::config::AwsConfig {
+        pub async fn load(&self, external_id: AwsExternalId) -> mz_aws_util::config::AwsConfig {
             use aws_config::default_provider::credentials::DefaultCredentialsChain;
             use aws_config::default_provider::region::DefaultRegionChain;
             use aws_config::sts::AssumeRoleProvider;
@@ -1455,14 +1479,14 @@ pub mod sources {
                 )),
             };
 
-            if let Some(AwsAssumeRole { arn, external_id }) = &self.role {
+            if let Some(AwsAssumeRole { arn }) = &self.role {
                 let mut role = AssumeRoleProvider::builder(arn).session_name("materialized");
                 // This affects which region to perform STS on, not where
                 // anything else happens.
                 if let Some(region) = &region {
                     role = role.region(region.clone());
                 }
-                if let Some(external_id) = &external_id {
+                if let Some(external_id) = external_id.get() {
                     role = role.external_id(external_id);
                 }
                 cred_provider = SharedCredentialsProvider::new(role.build(cred_provider));

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -104,6 +104,7 @@ use std::collections::{BTreeMap, HashSet};
 use std::rc::Rc;
 
 use differential_dataflow::AsCollection;
+use mz_dataflow_types::sources::AwsExternalId;
 use timely::communication::Allocate;
 use timely::dataflow::operators::to_stream::ToStream;
 use timely::dataflow::scopes::Child;
@@ -142,6 +143,7 @@ pub fn build_storage_dataflow<A: Allocate, B: StorageCapture>(
     storage_state: &mut StorageState,
     dataflow: &DataflowDescription<mz_dataflow_types::plan::Plan>,
     boundary: &mut B,
+    aws_external_id: AwsExternalId,
 ) {
     let worker_logging = timely_worker.log_register().get("timely");
     let name = format!("Dataflow: {}", &dataflow.debug_name);
@@ -168,6 +170,7 @@ pub fn build_storage_dataflow<A: Allocate, B: StorageCapture>(
                     region,
                     materialized_logging.clone(),
                     src_id.clone(),
+                    aws_external_id.clone(),
                 );
 
                 boundary.capture(*src_id, ok, err, token, &debug_name);

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -142,6 +142,7 @@ pub(crate) fn import_source<G>(
     scope: &mut G,
     materialized_logging: Option<Logger>,
     src_id: GlobalId,
+    aws_external_id: AwsExternalId,
 ) -> (
     (Collection<G, Row>, Collection<G, DataflowError>),
     Rc<dyn std::any::Any>,
@@ -242,6 +243,7 @@ where
                 encoding: encoding.clone(),
                 now: storage_state.now.clone(),
                 base_metrics: &storage_state.source_metrics,
+                aws_external_id: aws_external_id.clone(),
             };
 
             let (mut collection, capability) = if let ExternalSourceConnector::PubNub(
@@ -287,6 +289,7 @@ where
                             source_persist_config
                                 .as_ref()
                                 .map(|config| config.bindings_config.clone()),
+                            aws_external_id,
                         );
                         ((SourceType::Delimited(ok), ts, err), cap)
                     }
@@ -297,6 +300,7 @@ where
                             source_persist_config
                                 .as_ref()
                                 .map(|config| config.bindings_config.clone()),
+                            aws_external_id,
                         );
                         ((SourceType::Delimited(ok), ts, err), cap)
                     }
@@ -307,6 +311,7 @@ where
                             source_persist_config
                                 .as_ref()
                                 .map(|config| config.bindings_config.clone()),
+                            aws_external_id,
                         );
                         ((SourceType::ByteStream(ok), ts, err), cap)
                     }
@@ -317,6 +322,7 @@ where
                             source_persist_config
                                 .as_ref()
                                 .map(|config| config.bindings_config.clone()),
+                            aws_external_id,
                         );
                         ((SourceType::ByteStream(ok), ts, err), cap)
                     }

--- a/src/dataflow/src/source/file.rs
+++ b/src/dataflow/src/source/file.rs
@@ -17,6 +17,7 @@ use anyhow::{Context, Error};
 use flate2::read::MultiGzDecoder;
 #[cfg(target_os = "linux")]
 use inotify::{EventMask, Inotify, WatchMask};
+use mz_dataflow_types::sources::AwsExternalId;
 use mz_repr::MessagePayload;
 use timely::scheduling::SyncActivator;
 use tracing::error;
@@ -72,6 +73,7 @@ impl SourceReader for FileSourceReader {
         _worker_count: usize,
         consumer_activator: SyncActivator,
         connector: ExternalSourceConnector,
+        _: AwsExternalId,
         _restored_offsets: Vec<(PartitionId, Option<MzOffset>)>,
         encoding: SourceDataEncoding,
         _: Option<Logger>,

--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -11,6 +11,7 @@ use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use mz_dataflow_types::sources::AwsExternalId;
 use rdkafka::consumer::base_consumer::PartitionQueue;
 use rdkafka::consumer::{BaseConsumer, Consumer, ConsumerContext};
 use rdkafka::error::KafkaError;
@@ -76,6 +77,7 @@ impl SourceReader for KafkaSourceReader {
         worker_count: usize,
         consumer_activator: SyncActivator,
         connector: ExternalSourceConnector,
+        _: AwsExternalId,
         restored_offsets: Vec<(PartitionId, Option<MzOffset>)>,
         _: SourceDataEncoding,
         logger: Option<Logger>,

--- a/src/materialized/src/bin/coordd.rs
+++ b/src/materialized/src/bin/coordd.rs
@@ -12,6 +12,7 @@ use std::process;
 use std::time::Duration;
 
 use futures::StreamExt;
+use mz_dataflow_types::sources::AwsExternalId;
 use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
 use tracing::info;
@@ -59,7 +60,7 @@ struct Args {
     )]
     data_directory: PathBuf,
 
-    /// An AWS External ID to be supplied to all AssumeRole operations.
+    /// An external ID to use for all AWS AssumeRole operations.
     #[clap(long, value_name = "ID")]
     aws_external_id: Option<String>,
 }
@@ -113,7 +114,10 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
         disable_user_indexes: false,
         safe_mode: false,
         build_info: &materialized::BUILD_INFO,
-        aws_external_id: args.aws_external_id,
+        aws_external_id: args
+            .aws_external_id
+            .map(AwsExternalId::ISwearThisCameFromACliArgOrEnvVariable)
+            .unwrap_or(AwsExternalId::NotProvided),
         metrics_registry: metrics_registry.clone(),
         persister,
         now: SYSTEM_TIME.clone(),

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -43,6 +43,7 @@ use fail::FailScenario;
 use itertools::Itertools;
 use lazy_static::lazy_static;
 use mz_coord::{PersistConfig, PersistFileStorage, PersistStorage};
+use mz_dataflow_types::sources::AwsExternalId;
 use mz_ore::cgroup::{detect_memory_limit, MemoryLimit};
 use mz_ore::metric;
 use mz_ore::metrics::ThirdPartyMetric;
@@ -778,7 +779,10 @@ dataflow workers: {workers}",
         disable_user_indexes: args.disable_user_indexes,
         safe_mode: args.safe,
         telemetry,
-        aws_external_id: args.aws_external_id,
+        aws_external_id: args
+            .aws_external_id
+            .map(AwsExternalId::ISwearThisCameFromACliArgOrEnvVariable)
+            .unwrap_or(AwsExternalId::NotProvided),
         introspection_frequency: args
             .introspection_frequency
             .unwrap_or_else(|| Duration::from_secs(1)),

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -23,6 +23,7 @@ use anyhow::anyhow;
 use compile_time_run::run_command_str;
 use futures::StreamExt;
 use mz_coord::PersistConfig;
+use mz_dataflow_types::sources::AwsExternalId;
 use openssl::ssl::{SslAcceptor, SslFiletype, SslMethod, SslVerifyMode};
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
@@ -124,7 +125,7 @@ pub struct Config {
     /// An [external ID] to be supplied to all AWS AssumeRole operations.
     ///
     /// [external id]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html
-    pub aws_external_id: Option<String>,
+    pub aws_external_id: AwsExternalId,
 
     // === Mode switches. ===
     /// Whether to permit usage of experimental features.
@@ -272,6 +273,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
         now: SYSTEM_TIME.clone(),
         metrics_registry: config.metrics_registry.clone(),
         persister: persister.runtime.clone(),
+        aws_external_id: config.aws_external_id.clone(),
     })?;
 
     // Initialize coordinator.

--- a/src/materialized/tests/util.rs
+++ b/src/materialized/tests/util.rs
@@ -16,6 +16,7 @@ use std::time::Duration;
 
 use lazy_static::lazy_static;
 use mz_coord::PersistConfig;
+use mz_dataflow_types::sources::AwsExternalId;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::task;
 use postgres::error::DbError;
@@ -37,7 +38,7 @@ lazy_static! {
 #[derive(Clone)]
 pub struct Config {
     data_directory: Option<PathBuf>,
-    aws_external_id: Option<String>,
+    aws_external_id: AwsExternalId,
     logging_granularity: Option<Duration>,
     tls: Option<materialized::TlsConfig>,
     experimental_mode: bool,
@@ -50,7 +51,7 @@ impl Default for Config {
     fn default() -> Config {
         Config {
             data_directory: None,
-            aws_external_id: None,
+            aws_external_id: AwsExternalId::NotProvided,
             logging_granularity: Some(Duration::from_secs(1)),
             tls: None,
             experimental_mode: false,

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -17,7 +17,7 @@ use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Utc, MIN_DATETIME};
 use lazy_static::lazy_static;
-use mz_dataflow_types::sources::SourceConnector;
+use mz_dataflow_types::sources::{AwsExternalId, SourceConnector};
 
 use mz_build_info::{BuildInfo, DUMMY_BUILD_INFO};
 use mz_expr::{DummyHumanizer, ExprHumanizer, GlobalId, MirScalarExpr};
@@ -177,7 +177,7 @@ pub struct CatalogConfig {
     /// Information about this build of Materialize.
     pub build_info: &'static BuildInfo,
     /// An external ID to be supplied to all AWS AssumeRole operations.
-    pub aws_external_id: Option<String>,
+    pub aws_external_id: AwsExternalId,
     /// Default timestamp frequency for CREATE SOURCE
     pub timestamp_frequency: Duration,
     /// Function that returns a wall clock now time; can safely be mocked to return
@@ -375,7 +375,7 @@ lazy_static! {
         experimental_mode: true,
         safe_mode: false,
         build_info: &DUMMY_BUILD_INFO,
-        aws_external_id: None,
+        aws_external_id: AwsExternalId::NotProvided,
         timestamp_frequency: Duration::from_secs(1),
         now: NOW_ZERO.clone(),
         disable_user_indexes: false,

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -500,7 +500,6 @@ macro_rules! with_options {
 pub fn aws_config(
     options: &mut BTreeMap<String, Value>,
     region: Option<String>,
-    external_id: Option<String>,
 ) -> Result<AwsConfig, anyhow::Error> {
     let mut extract = |key| match options.remove(key) {
         Some(Value::String(key)) => {
@@ -567,7 +566,7 @@ pub fn aws_config(
         credentials,
         region,
         endpoint,
-        role: arn.map(|arn| AwsAssumeRole { arn, external_id }),
+        role: arn.map(|arn| AwsAssumeRole { arn }),
     })
 }
 

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -427,9 +427,7 @@ pub fn plan_create_source(
                 .region
                 .ok_or_else(|| anyhow!("Provided ARN does not include an AWS region"))?;
 
-            let external_id = scx.catalog.config().aws_external_id.clone();
-
-            let aws = normalize::aws_config(&mut with_options, Some(region.into()), external_id)?;
+            let aws = normalize::aws_config(&mut with_options, Some(region.into()))?;
             let connector =
                 ExternalSourceConnector::Kinesis(KinesisSourceConnector { stream_name, aws });
             let encoding = get_encoding(format, envelope, with_options_original)?;
@@ -461,9 +459,7 @@ pub fn plan_create_source(
             pattern,
             compression,
         } => {
-            let external_id = scx.catalog.config().aws_external_id.clone();
-
-            let aws = normalize::aws_config(&mut with_options, None, external_id)?;
+            let aws = normalize::aws_config(&mut with_options, None)?;
             let mut converted_sources = Vec::new();
             for ks in key_sources {
                 let dtks = match ks {

--- a/src/sql/src/query_model/test/catalog.rs
+++ b/src/sql/src/query_model/test/catalog.rs
@@ -18,7 +18,7 @@ use crate::plan::StatementDesc;
 use chrono::MIN_DATETIME;
 use lazy_static::lazy_static;
 use mz_build_info::DUMMY_BUILD_INFO;
-use mz_dataflow_types::sources::SourceConnector;
+use mz_dataflow_types::sources::{AwsExternalId, SourceConnector};
 use mz_expr::{DummyHumanizer, ExprHumanizer, GlobalId, MirScalarExpr};
 use mz_lowertest::*;
 use mz_ore::now::{EpochMillis, NOW_ZERO};
@@ -38,7 +38,7 @@ lazy_static! {
         experimental_mode: false,
         safe_mode: false,
         build_info: &DUMMY_BUILD_INFO,
-        aws_external_id: None,
+        aws_external_id: AwsExternalId::NotProvided,
         timestamp_frequency: Duration::from_secs(1),
         now: NOW_ZERO.clone(),
         disable_user_indexes: false,

--- a/src/sqllogictest/Cargo.toml
+++ b/src/sqllogictest/Cargo.toml
@@ -21,6 +21,7 @@ futures = "0.3.21"
 lazy_static = "1.0.0"
 materialized = { path = "../materialized" }
 md-5 = "0.10.0"
+mz-dataflow-types = { path = "../dataflow-types" }
 mz-ore = { path = "../ore", features = ["task"] }
 mz-pgrepr = { path = "../pgrepr" }
 postgres-protocol = { git = "https://github.com/MaterializeInc/rust-postgres", branch = "mz-0.7.2" }

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -42,6 +42,7 @@ use fallible_iterator::FallibleIterator;
 use lazy_static::lazy_static;
 use md5::{Digest, Md5};
 use mz_coord::PersistConfig;
+use mz_dataflow_types::sources::AwsExternalId;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::task;
 use postgres_protocol::types;
@@ -549,7 +550,7 @@ impl Runner {
             workers: config.workers,
             timely_worker: timely::WorkerConfig::default(),
             data_directory: temp_dir.path().to_path_buf(),
-            aws_external_id: None,
+            aws_external_id: AwsExternalId::NotProvided,
             listen_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
             tls: None,
             experimental_mode: true,


### PR DESCRIPTION
External IDs are part of the runtime environment, not part of the source, so it
makes sense to pass them into AWS clients from the environment instead of from
the DDL description.

This also uses a big scary name to try and make it obvious in future
implementations and code reviews that this data must come from
Materialize-the-operator, not the user of materialized.

Resolves #10522

### Motivation

* This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).