### PR TITLE
sql: exclude scalar table funcs from select *

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -166,6 +166,9 @@ changes that have not yet been documented.
   been migrated, however. See [Confluent Schema Registry options](/sql/create-source/avro-kafka#confluent-schema-registry-options))
   for more info.
 
+- Fix a big where too many columns were returned when both `*` and a
+  table function appeared in the `SELECT` list {{% gh 10363 %}}.
+
 {{< comment >}}
 Only add new release notes above this line.
 

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -2166,6 +2166,7 @@ fn plan_scalar_table_funcs(
                 item: id.clone(),
             });
             scope.items[i].from_single_column_function = num_cols == 1;
+            scope.items[i].allow_unqualified_references = false;
             i += 1;
         }
         // Ordinality column. This doubles as the
@@ -2177,8 +2178,11 @@ fn plan_scalar_table_funcs(
             item: id.clone(),
         });
         scope.items[i].is_exists_column_for_a_table_function_that_was_in_the_target_list = true;
+        scope.items[i].allow_unqualified_references = false;
         i += 1;
     }
+    // Coalesced ordinality column.
+    scope.items[i].allow_unqualified_references = false;
     Ok((expr, scope))
 }
 

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -1307,3 +1307,10 @@ SELECT * FROM generate_series(1, 3) as foo(a), ROWS FROM (generate_series(foo.a,
 # Regression test for #9657
 statement ok
 create view bar as select * from y, rows from (generate_series(1, 2), jsonb_array_elements(y.a));
+
+# Regression for #10363
+query IT
+WITH a(x) AS (SELECT 'a') SELECT generate_series(1, 2), * FROM a ORDER BY generate_series
+----
+1 a
+2 a


### PR DESCRIPTION
Scalar table functions plan into the FROM scope, but weren't excluding themselves from it.

Fixes #10363

### Motivation

  * This PR fixes a recognized bug: #10363

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
