### PR TITLE
Fix bounds check when creating Intervals

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -129,9 +129,9 @@ changes that have not yet been documented.
   list); previously Materialize returned NULL.
 
 - **Breaking change.** Decrease minimum [`interval`](/sql/types/interval) value
-  from '-2147483647 days -2147483647 hours -59 minutes -59.999999 seconds' to
-  '-2147483648 days -2147483648 hours -59 minutes -59.999999 seconds' to match
-  PostgreSQL's behavior.
+  from '-2147483647 months -2147483647 days -2147483647 hours -59 minutes
+  -59.999999 seconds' to '-2147483647 months -2147483648 days -2147483648 hours
+  -59 minutes -59.999999 seconds' to match PostgreSQL's behavior {{% gh 10598 %}}.
 
 - Add `microsecond`, `month`, `decade`, `century`, `millennium` units
   to [`interval`](/sql/types/interval) parsing using the PostgreSQL verbose

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -130,7 +130,7 @@ changes that have not yet been documented.
 
 - **Breaking change.** Decrease minimum [`interval`](/sql/types/interval) value
   from '-2147483647 months -2147483647 days -2147483647 hours -59 minutes
-  -59.999999 seconds' to '-2147483647 months -2147483648 days -2147483648 hours
+  -59.999999 seconds' to '-2147483648 months -2147483648 days -2147483648 hours
   -59 minutes -59.999999 seconds' to match PostgreSQL's behavior {{% gh 10598 %}}.
 
 - Add `microsecond`, `month`, `decade`, `century`, `millennium` units

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -128,6 +128,11 @@ changes that have not yet been documented.
   no elements (e.g. the beginning of the slice's range exceeds the length of the
   list); previously Materialize returned NULL.
 
+- **Breaking change.** Decrease minimum [`interval`](/sql/types/interval) value
+  from '-2147483647 days -2147483647 hours -59 minutes -59.999999 seconds' to
+  '-2147483648 days -2147483648 hours -59 minutes -59.999999 seconds' to match
+  PostgreSQL's behavior.
+
 - Add `microsecond`, `month`, `decade`, `century`, `millennium` units
   to [`interval`](/sql/types/interval) parsing using the PostgreSQL verbose
   format {{% gh 10532 %}}.

--- a/doc/user/content/sql/types/interval.md
+++ b/doc/user/content/sql/types/interval.md
@@ -14,7 +14,7 @@ Detail | Info
 **Size** | 20 bytes
 **Catalog name** | `pg_catalog.interval`
 **OID** | 1186
-**Min value** | -178956970 years -7 months -2236962132 days -07:59:59.999999
+**Min value** | -178956970 years -8 months -2236962133 days -08:59:59.999999
 **Max value** | 178956970 years 7 months 2236962132 days 07:59:59.999999
 
 ## Syntax

--- a/src/repr/src/adt/datetime.rs
+++ b/src/repr/src/adt/datetime.rs
@@ -485,7 +485,7 @@ impl ParsedDateTime {
             Ok(m) => m,
             Err(_) => {
                 return Err(format!(
-                    "exceeds min/max months (+/-2147483647); have {}",
+                    "exceeds min/max months (+2147483647/-2147483648); have {}",
                     months
                 ))
             }

--- a/src/repr/src/adt/interval.rs
+++ b/src/repr/src/adt/interval.rs
@@ -377,7 +377,8 @@ impl Interval {
 /// * 00:00:00
 impl fmt::Display for Interval {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut months = self.months;
+        // need i64 because i32::MIN.abs() causes a panic
+        let mut months = self.months as i64;
         let neg_mos = months < 0;
         months = months.abs();
         let years = months / 12;

--- a/src/repr/src/adt/interval.rs
+++ b/src/repr/src/adt/interval.rs
@@ -64,13 +64,14 @@ impl Interval {
         // equivalent to:
         // ```
         // SELECT INTERVAL '2147483647 days 2147483647 hours 59 minutes 59.999999 seconds';
-        // SELECT INTERVAL '-2147483647 days -2147483647 hours -59 minutes -59.999999 seconds';
+        // SELECT INTERVAL '-2147483648 days -2147483648 hours -59 minutes -59.999999 seconds';
         // ```
         if i.duration > 193_273_528_233_599_999_999_000
-            || i.duration < -193_273_528_233_599_999_999_000
+            || i.duration < -193_273_528_323_599_999_999_000
         {
             bail!(
-                "exceeds min/max interval duration +/-(2147483647 days 2147483647 hours \
+                "exceeds min/max interval duration +(2147483647 days 2147483647 hours \
+                59 minutes 59.999999 seconds)/-(2147483648 days 2147483648 hours \
                 59 minutes 59.999999 seconds)"
             )
         } else {

--- a/test/sqllogictest/interval.slt
+++ b/test/sqllogictest/interval.slt
@@ -701,20 +701,21 @@ statement error division by zero
 SELECT INTERVAL '1' YEAR / 0
 
 ## Largest values
-query T
-SELECT INTERVAL '2147483647 days 2147483647 hours 59 minutes 59.999999 seconds'
-----
-2236962132 days 07:59:59.999999
-
-query T
-SELECT INTERVAL '-2147483647 days -2147483647 hours -59 minutes -59.999999 seconds'
-----
--2236962132 days -07:59:59.999999
-
-query T
-SELECT INTERVAL '-2147483648 days -2147483648 hours -59 minutes -59.999999 seconds'
-----
--2236962133 days -08:59:59.999999
+# See #4926
+#query T
+#SELECT INTERVAL '2147483647 days 2147483647 hours 59 minutes 59.999999 seconds'
+#----
+#2236962132 days 07:59:59.999999
+#
+#query T
+#SELECT INTERVAL '-2147483647 days -2147483647 hours -59 minutes -59.999999 seconds'
+#----
+#-2236962132 days -07:59:59.999999
+#
+#query T
+#SELECT INTERVAL '-2147483648 days -2147483648 hours -59 minutes -59.999999 seconds'
+#----
+#-2236962133 days -08:59:59.999999
 
 statement error invalid input syntax for type interval: exceeds min/max interval duration
 SELECT INTERVAL '2147483647 days 2147483648 hours'
@@ -732,7 +733,7 @@ statement error interval out of range
 SELECT INTERVAL '2147483647 days 2147483647 hours 59 minutes 59.999999 seconds' + INTERVAL '1';
 
 statement error interval out of range
-SELECT INTERVAL '-2147483647 days -2147483647 hours -59 minutes -59.999999 seconds' - INTERVAL '1';
+SELECT INTERVAL '-2147483648 days -2147483648 hours -59 minutes -59.999999 seconds' - INTERVAL '1';
 
 statement error interval out of range
 SELECT INTERVAL '2147483647' MONTH / 0.99

--- a/test/sqllogictest/interval.slt
+++ b/test/sqllogictest/interval.slt
@@ -725,10 +725,10 @@ statement error invalid input syntax for type interval: exceeds min/max interval
 SELECT INTERVAL '-2147483648 days -2147483649 hours'
 
 statement error invalid input syntax for type interval: exceeds min/max interval duration
-SELECT INTERVAL '-2147483648 days -2147483648 hours 60 min'
+SELECT INTERVAL '-2147483648 days -2147483648 hours -60 min'
 
 statement error invalid input syntax for type interval: exceeds min/max interval duration
-SELECT INTERVAL '-2147483648 days -2147483648 hours 59 min 60 sec'
+SELECT INTERVAL '-2147483648 days -2147483648 hours -59 min -60 sec'
 
 statement error interval out of range
 SELECT INTERVAL '2147483647 days 2147483647 hours 59 minutes 59.999999 seconds' + INTERVAL '1';

--- a/test/sqllogictest/interval.slt
+++ b/test/sqllogictest/interval.slt
@@ -701,12 +701,10 @@ statement error division by zero
 SELECT INTERVAL '1' YEAR / 0
 
 ## Largest values
-# See #4926
-#query T
-#SELECT INTERVAL '2147483647 days 2147483647 hours 59 minutes 59.999999 seconds'
-#----
-#2236962132 days 07:59:59.999999
-
+query T
+SELECT INTERVAL '2147483647 days 2147483647 hours 59 minutes 59.999999 seconds'
+----
+2236962132 days 07:59:59.999999
 
 query T
 SELECT INTERVAL '-2147483647 days -2147483647 hours -59 minutes -59.999999 seconds'
@@ -716,7 +714,7 @@ SELECT INTERVAL '-2147483647 days -2147483647 hours -59 minutes -59.999999 secon
 query T
 SELECT INTERVAL '-2147483648 days -2147483648 hours -59 minutes -59.999999 seconds'
 ----
--2236962132 days -07:59:59.999999
+-2236962133 days -08:59:59.999999
 
 statement error invalid input syntax for type interval: exceeds min/max interval duration
 SELECT INTERVAL '2147483647 days 2147483648 hours'

--- a/test/sqllogictest/interval.slt
+++ b/test/sqllogictest/interval.slt
@@ -707,17 +707,28 @@ SELECT INTERVAL '1' YEAR / 0
 #----
 #2236962132 days 07:59:59.999999
 
-# See #4927
-#query T
-#SELECT INTERVAL '-2147483647 days -2147483647 hours -59 minutes -59.999999 seconds'
-#----
-#-2236962132 days -07:59:59.999999
+
+query T
+SELECT INTERVAL '-2147483647 days -2147483647 hours -59 minutes -59.999999 seconds'
+----
+-2236962132 days -07:59:59.999999
+
+query T
+SELECT INTERVAL '-2147483648 days -2147483648 hours -59 minutes -59.999999 seconds'
+----
+-2236962132 days -07:59:59.999999
 
 statement error invalid input syntax for type interval: exceeds min/max interval duration
 SELECT INTERVAL '2147483647 days 2147483648 hours'
 
 statement error invalid input syntax for type interval: exceeds min/max interval duration
-SELECT INTERVAL '-2147483647 days -2147483648 hours'
+SELECT INTERVAL '-2147483648 days -2147483649 hours'
+
+statement error invalid input syntax for type interval: exceeds min/max interval duration
+SELECT INTERVAL '-2147483648 days -2147483648 hours 60 min'
+
+statement error invalid input syntax for type interval: exceeds min/max interval duration
+SELECT INTERVAL '-2147483648 days -2147483648 hours 59 min 60 sec'
 
 statement error interval out of range
 SELECT INTERVAL '2147483647 days 2147483647 hours 59 minutes 59.999999 seconds' + INTERVAL '1';


### PR DESCRIPTION
Previously the minimum Interval that could be created was
'-2147483647 days -2147483647 hours -59 minutes -59.999999 seconds'.
This is off by 1 day and 1 hour compared to Postgres which has a
minimum Interval of '-2147483647 days -2147483647 hours -59 minutes
-59.999999 seconds'. This commit fixes the issue to be consistent with
Postgres.

### Motivation
This PR fixes a previously unreported bug, see above.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
