### PR TITLE
sqllogictest,testdrive: add junit output reports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,12 @@ checksum = "dabe5a181f83789739c194cbe5a897dde195078fac08568d09221fd6137a7ba8"
 
 [[package]]
 name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
+name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
@@ -1291,6 +1297,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-getters"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c5905670fd9c320154f3a4a01c9e609733cd7b753f3c58777ab7d5ce26686b3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2378,6 +2395,19 @@ name = "json"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
+
+[[package]]
+name = "junit-report"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b056c67be8e1fe9cb76b1649fba3f02bd238f384649878b814fdf9db40aace"
+dependencies = [
+ "derive-getters",
+ "strip-ansi-escapes",
+ "thiserror",
+ "time",
+ "xml-rs",
+]
 
 [[package]]
 name = "krb5-src"
@@ -3758,6 +3788,7 @@ dependencies = [
  "clap",
  "fallible-iterator",
  "futures",
+ "junit-report",
  "lazy_static",
  "materialized",
  "md-5",
@@ -3771,6 +3802,7 @@ dependencies = [
  "regex",
  "serde_json",
  "tempfile",
+ "time",
  "timely",
  "tokio",
  "tokio-postgres",
@@ -3830,6 +3862,7 @@ dependencies = [
  "globset",
  "http",
  "itertools",
+ "junit-report",
  "krb5-src",
  "lazy_static",
  "maplit",
@@ -3862,6 +3895,7 @@ dependencies = [
  "tempfile",
  "termcolor",
  "tiberius",
+ "time",
  "tokio",
  "tokio-postgres",
  "tokio-stream",
@@ -4087,6 +4121,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ba99ba6393e2c3734791401b66902d981cb03bf190af674ca69949b6d5fb15"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -5071,7 +5114,7 @@ version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0593ce4677e3800ddafb3de917e8397b1348e06e688128ade722d88fbe11ebf"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.2",
  "num-traits",
  "serde",
 ]
@@ -5418,6 +5461,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "011cbb39cf7c1f62871aea3cc46e5817b0937b49e9447370c93cacbe93a766d8"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5662,12 +5714,21 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41effe7cfa8af36f439fac33861b66b049edc6f9a32331e2312660529c1c24ad"
+checksum = "004cbc98f30fa233c61a38bc77e96a9106e65c88f2d3bef182ae952027e5753d"
 dependencies = [
+ "itoa 1.0.1",
  "libc",
+ "num_threads",
+ "time-macros",
 ]
+
+[[package]]
+name = "time-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25eb0ca3468fc0acc11828786797f6ef9aa1555e4a211a60d64cc8e4d1be47d6"
 
 [[package]]
 name = "timely"
@@ -6139,6 +6200,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a1f0175e03a0973cf4afd476bef05c26e228520400eb1fd473ad417b1c00ffb"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
+
+[[package]]
 name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6159,6 +6226,27 @@ name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+
+[[package]]
+name = "vte"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983"
+dependencies = [
+ "arrayvec 0.5.2",
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "wait-timeout"
@@ -6340,6 +6428,12 @@ checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
 
 [[package]]
 name = "xmlparser"

--- a/ci/builder/requirements-dev.txt
+++ b/ci/builder/requirements-dev.txt
@@ -12,6 +12,7 @@ docker==5.0.3
 ec2instanceconnectcli==1.0.2
 flake8==4.0.1
 isort==5.10.1
+junit-xml==1.9
 mypy==0.931
 numpy==1.22.2
 pandas==1.4.0

--- a/deny.toml
+++ b/deny.toml
@@ -29,6 +29,9 @@ skip = [
 
     # Waiting for tokio to upgrade to mio 0.8
     { name = "mio", version = "0.7.11" },
+
+    # Waiting for vte to upgrade to v0.7.0.
+    { name = "arrayvec", version = "0.5.2" },
 ]
 
 # Use `prost` or `protobuf-native` instead.
@@ -61,6 +64,7 @@ wrappers = [
     "aws-smithy-xml",
     "aws-sig-auth",
     "flatbuffers",
+    "junit-report",
     "mysql_async",
     "mysql_common",
     "pprof",

--- a/src/sqllogictest/Cargo.toml
+++ b/src/sqllogictest/Cargo.toml
@@ -18,6 +18,7 @@ mz-coord = { path = "../coord" }
 mz-expr = { path = "../expr" }
 fallible-iterator = "0.2.0"
 futures = "0.3.21"
+junit-report = "0.7.0"
 lazy_static = "1.0.0"
 materialized = { path = "../materialized" }
 md-5 = "0.10.0"
@@ -29,6 +30,7 @@ mz-repr = { path = "../repr" }
 serde_json = "1.0.78"
 mz-sql = { path = "../sql" }
 tempfile = "3.2.0"
+time = "0.3.7"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 tokio = "1.16.1"
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", branch = "mz-0.7.2", features = ["with-chrono-0_4", "with-uuid-0_8", "with-serde_json-1"] }

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -999,12 +999,6 @@ pub async fn run_file(config: &RunConfig<'_>, filename: &Path) -> Result<Outcome
     run_string(config, &format!("{}", filename.display()), &input).await
 }
 
-pub async fn run_stdin(config: &RunConfig<'_>) -> Result<Outcomes, anyhow::Error> {
-    let mut input = String::new();
-    std::io::stdin().lock().read_to_string(&mut input)?;
-    run_string(config, "<stdin>", &input).await
-}
-
 pub async fn rewrite_file(config: &RunConfig<'_>, filename: &Path) -> Result<(), anyhow::Error> {
     let mut file = OpenOptions::new().read(true).write(true).open(filename)?;
 

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -34,6 +34,7 @@ http = "0.2.6"
 mz-interchange = { path = "../interchange" }
 itertools = "0.10.3"
 mz-kafka-util = { path = "../kafka-util" }
+junit-report = "0.7.0"
 krb5-src = { version = "0.3.2", features = ["binaries"] }
 lazy_static = "1.4.0"
 maplit = "1.0.2"
@@ -56,6 +57,7 @@ reqwest = { version = "0.11.9", features = ["native-tls-vendored"] }
 serde = "1.0.136"
 serde_json = { version = "1.0.78", features = ["raw_value"] }
 similar = "2.1.0"
+time = "0.3.7"
 mz-sql = { path = "../sql" }
 mz-sql-parser = { path = "../sql-parser" }
 tempfile = "3.2.0"

--- a/src/testdrive/src/error.rs
+++ b/src/testdrive/src/error.rs
@@ -16,7 +16,7 @@
 //! that is not human-readable, so `PosError`s are upgraded to `Error`s before
 //! they are returned externally.
 
-use std::fmt::Write as _;
+use std::fmt::{self, Write as _};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
@@ -74,6 +74,12 @@ impl Error {
                 Ok(())
             }
         }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:#}", self.source)
     }
 }
 


### PR DESCRIPTION
Related to #10574. This stops short of actually wiring up the output
reporting to Buildkite Test Analytics so that the upload implementation
from #10574 can be reused.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
