### PR TITLE
Tidying `Command`s and `Response`s

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -735,11 +735,6 @@ impl Coordinator {
             });
         }
 
-        // Create the default cluster so that subsequent default cluster commands succeed.
-        self.dataflow_client
-            .create_instance(DEFAULT_COMPUTE_INSTANCE_ID)
-            .await;
-
         let mut metric_scraper_stream = self.metric_scraper.tick_stream();
 
         loop {
@@ -856,7 +851,11 @@ impl Coordinator {
 
     async fn message_worker(&mut self, message: DataflowResponse) {
         match message {
-            DataflowResponse::Compute(ComputeResponse::PeekResponse(conn_id, response)) => {
+            DataflowResponse::Compute(
+                ComputeResponse::PeekResponse(conn_id, response),
+                instance,
+            ) => {
+                assert_eq!(instance, DEFAULT_COMPUTE_INSTANCE_ID);
                 // We expect exactly one peek response, which we forward.
                 self.pending_peeks
                     .remove(&conn_id)
@@ -864,7 +863,11 @@ impl Coordinator {
                     .send(response)
                     .expect("Peek endpoint terminated prematurely");
             }
-            DataflowResponse::Compute(ComputeResponse::TailResponse(sink_id, response)) => {
+            DataflowResponse::Compute(
+                ComputeResponse::TailResponse(sink_id, response),
+                instance,
+            ) => {
+                assert_eq!(instance, DEFAULT_COMPUTE_INSTANCE_ID);
                 // We use an `if let` here because the peek could have been canceled already.
                 // We can also potentially receive multiple `Complete` responses, followed by
                 // a `Dropped` response.
@@ -875,7 +878,8 @@ impl Coordinator {
                     }
                 }
             }
-            DataflowResponse::Compute(ComputeResponse::FrontierUppers(updates)) => {
+            DataflowResponse::Compute(ComputeResponse::FrontierUppers(updates), instance) => {
+                assert_eq!(instance, DEFAULT_COMPUTE_INSTANCE_ID);
                 for (name, changes) in updates {
                     self.update_upper(&name, changes);
                 }
@@ -4645,6 +4649,11 @@ pub async fn serve(
                 write_lock: Arc::new(tokio::sync::Mutex::new(())),
                 write_lock_wait_group: VecDeque::new(),
             };
+            handle.block_on(
+                coord
+                    .dataflow_client
+                    .create_instance(DEFAULT_COMPUTE_INSTANCE_ID),
+            );
             if let Some(config) = &logging {
                 handle.block_on(
                     coord.dataflow_client.enable_logging(

--- a/src/coordtest/src/lib.rs
+++ b/src/coordtest/src/lib.rs
@@ -237,13 +237,16 @@ impl CoordTest {
         let mut to_queue = vec![];
         for mut msg in self.queued_feedback.drain(..) {
             // Filter out requested ids.
-            if let Response::Compute(ComputeResponse::FrontierUppers(uppers)) = &mut msg {
+            if let Response::Compute(ComputeResponse::FrontierUppers(uppers), instance) = &mut msg {
                 // Requeue excluded uppers so future wait-sql directives don't always have to
                 // specify the same exclude list forever.
                 let mut requeue = uppers.clone();
                 requeue.retain(|(id, _data)| exclude_uppers.contains(id));
                 if !requeue.is_empty() {
-                    to_queue.push(Response::Compute(ComputeResponse::FrontierUppers(requeue)));
+                    to_queue.push(Response::Compute(
+                        ComputeResponse::FrontierUppers(requeue),
+                        *instance,
+                    ));
                 }
                 uppers.retain(|(id, _data)| !exclude_uppers.contains(id));
             }
@@ -274,7 +277,7 @@ impl CoordTest {
         let mut to_send = vec![];
         let mut to_queue = vec![];
         for msg in self.queued_feedback.drain(..) {
-            if let Response::Compute(ComputeResponse::PeekResponse(..)) = msg {
+            if let Response::Compute(ComputeResponse::PeekResponse(..), _instance) = msg {
                 to_send.push(msg);
             } else {
                 to_queue.push(msg);
@@ -506,6 +509,7 @@ pub async fn run_test(mut tf: datadriven::TestFile) -> datadriven::TestFile {
                     }
                     ct.dataflow_client.forward_response(Response::Compute(
                         ComputeResponse::FrontierUppers(updates),
+                        mz_dataflow_types::client::DEFAULT_COMPUTE_INSTANCE_ID,
                     ));
                     "".into()
                 }

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -40,7 +40,7 @@ pub enum Command {
 }
 
 /// An abstraction allowing us to name difference compute instances.
-type ComputeInstanceId = usize;
+pub type ComputeInstanceId = usize;
 /// A default value whose use we can track down and remove later.
 pub const DEFAULT_COMPUTE_INSTANCE_ID: ComputeInstanceId = 0;
 
@@ -501,7 +501,7 @@ pub struct TimestampBindingFeedback {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Response {
     /// A compute response.
-    Compute(ComputeResponse),
+    Compute(ComputeResponse, ComputeInstanceId),
     /// A storage response.
     Storage(StorageResponse),
 }
@@ -755,7 +755,8 @@ pub mod partitioned {
         /// Absorbs a response, and produces response that should be emitted.
         pub fn absorb_response(&mut self, shard_id: usize, message: Response) -> Option<Response> {
             match message {
-                Response::Compute(ComputeResponse::FrontierUppers(mut list)) => {
+                Response::Compute(ComputeResponse::FrontierUppers(mut list), instance) => {
+                    assert_eq!(instance, super::DEFAULT_COMPUTE_INSTANCE_ID);
                     for (id, changes) in list.iter_mut() {
                         if let Some(frontier) = self.uppers.get_mut(id) {
                             let iter = frontier.update_iter(changes.drain());
@@ -777,7 +778,10 @@ pub mod partitioned {
                         }
                     }
 
-                    Some(Response::Compute(ComputeResponse::FrontierUppers(list)))
+                    Some(Response::Compute(
+                        ComputeResponse::FrontierUppers(list),
+                        instance,
+                    ))
                 }
                 // Avoid multiple retractions of minimum time, to present as updates from one worker.
                 Response::Storage(StorageResponse::TimestampBindings(mut feedback)) => {
@@ -793,7 +797,10 @@ pub mod partitioned {
                         feedback,
                     )))
                 }
-                Response::Compute(ComputeResponse::PeekResponse(connection, response)) => {
+                Response::Compute(
+                    ComputeResponse::PeekResponse(connection, response),
+                    instance,
+                ) => {
                     // Incorporate new peek responses; awaiting all responses.
                     let entry = self
                         .peek_responses
@@ -817,9 +824,10 @@ pub mod partitioned {
                             };
                         }
                         self.peek_responses.remove(&connection);
-                        Some(Response::Compute(ComputeResponse::PeekResponse(
-                            connection, response,
-                        )))
+                        Some(Response::Compute(
+                            ComputeResponse::PeekResponse(connection, response),
+                            instance,
+                        ))
                     } else {
                         None
                     }

--- a/src/dataflow-types/src/client/controller.rs
+++ b/src/dataflow-types/src/client/controller.rs
@@ -8,8 +8,11 @@
 // by the Apache License, Version 2.0.
 
 //! A client that maintains summaries of the involved objects.
+use std::collections::BTreeMap;
 
-use crate::client::{Client, Command, ComputeCommand, ComputeResponse, Response, StorageCommand};
+use crate::client::{
+    Client, Command, ComputeCommand, ComputeInstanceId, ComputeResponse, Response, StorageCommand,
+};
 use mz_expr::GlobalId;
 use mz_repr::Timestamp;
 use timely::progress::{frontier::AntichainRef, Antichain, ChangeBatch};
@@ -23,7 +26,7 @@ pub struct Controller<C> {
     /// A `None` variant means that the source was dropped before it was first created.
     source_descriptions: std::collections::BTreeMap<GlobalId, Option<crate::sources::SourceDesc>>,
     /// Tracks `since` and `upper` frontiers for indexes and sinks.
-    compute_since_uppers: SinceUpperMap,
+    compute_since_uppers: BTreeMap<ComputeInstanceId, SinceUpperMap>,
     /// Tracks `since` and `upper` frontiers for sources and tables.
     storage_since_uppers: SinceUpperMap,
 }
@@ -41,6 +44,13 @@ impl<C: Client> Client for Controller<C> {
 impl<C: Client> Controller<C> {
     pub async fn send(&mut self, cmd: Command) {
         match &cmd {
+            Command::Compute(ComputeCommand::CreateInstance, instance) => {
+                self.compute_since_uppers
+                    .insert(*instance, Default::default());
+            }
+            Command::Compute(ComputeCommand::DropInstance, instance) => {
+                self.compute_since_uppers.remove(instance);
+            }
             Command::Storage(StorageCommand::CreateSources(bindings)) => {
                 // Maintain the list of bindings, and complain if one attempts to either
                 // 1. create a dropped source identifier, or
@@ -81,13 +91,15 @@ impl<C: Client> Controller<C> {
                     }
                 }
             }
-            Command::Compute(ComputeCommand::EnableLogging(logging_config), _instance) => {
+            Command::Compute(ComputeCommand::EnableLogging(logging_config), instance) => {
                 for id in logging_config.log_identifiers() {
                     self.compute_since_uppers
+                        .get_mut(instance)
+                        .expect("Reference to absent instance")
                         .insert(id, (Antichain::from_elem(0), Antichain::from_elem(0)));
                 }
             }
-            Command::Compute(ComputeCommand::CreateDataflows(dataflows), _instance) => {
+            Command::Compute(ComputeCommand::CreateDataflows(dataflows), instance) => {
                 // Validate dataflows as having inputs whose `since` is less or equal to the dataflow's `as_of`.
                 // Start tracking frontiers for each dataflow, using its `as_of` for each index and sink.
                 for dataflow in dataflows.iter() {
@@ -112,7 +124,10 @@ impl<C: Client> Controller<C> {
                     // TODO(mcsherry): Instead, return an error from the constructing method.
                     for (index_id, _) in dataflow.index_imports.iter() {
                         let (since, _upper) = self
-                            .index_since_upper_for(*index_id)
+                            .compute_since_uppers
+                            .get_mut(instance)
+                            .expect("Reference to absent instance")
+                            .get(index_id)
                             .expect("Index frontiers absent in dataflow construction");
                         assert!(<_ as timely::order::PartialOrder>::less_equal(
                             &since,
@@ -123,18 +138,25 @@ impl<C: Client> Controller<C> {
                     for (sink_id, _) in dataflow.sink_exports.iter() {
                         // We start tracking `upper` at 0; correct this should that change (e.g. to `as_of`).
                         self.compute_since_uppers
+                            .get_mut(instance)
+                            .expect("Reference to absent instance")
                             .insert(*sink_id, (as_of.clone(), Antichain::from_elem(0)));
                     }
                     for (index_id, _, _) in dataflow.index_exports.iter() {
                         // We start tracking `upper` at 0; correct this should that change (e.g. to `as_of`).
                         self.compute_since_uppers
+                            .get_mut(instance)
+                            .expect("Reference to absent instance")
                             .insert(*index_id, (as_of.clone(), Antichain::from_elem(0)));
                     }
                 }
             }
-            Command::Compute(ComputeCommand::AllowIndexCompaction(frontiers), _instance) => {
+            Command::Compute(ComputeCommand::AllowIndexCompaction(frontiers), instance) => {
                 for (id, frontier) in frontiers.iter() {
-                    self.compute_since_uppers.advance_since_for(*id, frontier);
+                    self.compute_since_uppers
+                        .get_mut(instance)
+                        .expect("Reference to absent instance")
+                        .advance_since_for(*id, frontier);
                 }
             }
             Command::Storage(StorageCommand::AllowSourceCompaction(frontiers)) => {
@@ -153,9 +175,12 @@ impl<C: Client> Controller<C> {
 
         if let Some(response) = response.as_ref() {
             match response {
-                Response::Compute(ComputeResponse::FrontierUppers(updates)) => {
+                Response::Compute(ComputeResponse::FrontierUppers(updates), instance) => {
                     for (id, changes) in updates.iter() {
-                        self.compute_since_uppers.update_upper_for(*id, changes);
+                        self.compute_since_uppers
+                            .get_mut(instance)
+                            .expect("Reference to absent instance")
+                            .update_upper_for(*id, changes);
                     }
                 }
                 _ => {}
@@ -184,22 +209,6 @@ impl<C> Controller<C> {
     /// this information if we had a use for it.
     pub fn source_description_for(&self, id: GlobalId) -> Option<&crate::sources::SourceDesc> {
         self.source_descriptions.get(&id).unwrap_or(&None).as_ref()
-    }
-
-    /// Returns the pair of `since` and `upper` for a maintained index, if it exists.
-    ///
-    /// The `since` frontier indicates that the maintained data are certainly valid for times greater
-    /// or equal to the frontier, but they may not be for other times. Attempting to create a dataflow
-    /// using this `id` with an `as_of` that is not at least `since` will result in an error.
-    ///
-    /// The `upper` frontier indicates that the data are reported available for all times not greater
-    /// or equal to the frontier. Dataflows with an `as_of` greater or equal to this frontier may not
-    /// immediately produce results.
-    pub fn index_since_upper_for(
-        &self,
-        id: GlobalId,
-    ) -> Option<(AntichainRef<Timestamp>, AntichainRef<Timestamp>)> {
-        self.compute_since_uppers.get(&id)
     }
 
     /// Returns the pair of `since` and `upper` for a source, if it exists.

--- a/src/dataflow/src/server/compute_state.rs
+++ b/src/dataflow/src/server/compute_state.rs
@@ -77,11 +77,12 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
     /// Entrypoint for applying a compute command.
     pub(crate) fn handle_compute_command(&mut self, cmd: ComputeCommand) {
         match cmd {
-            ComputeCommand::CreateInstance | ComputeCommand::DropInstance => {
-                // Can be ignored for the moment.
-                // Should eventually be filtered outside of this method,
-                // as we are already deep in a specific instance.
+            ComputeCommand::CreateInstance(logging) => {
+                if let Some(logging) = logging {
+                    self.initialize_logging(&logging);
+                }
             }
+            ComputeCommand::DropInstance => {}
             ComputeCommand::CreateDataflows(_dataflows) => {
                 unreachable!("CreateDataflows should not be issued directly to compute state")
             }
@@ -176,9 +177,6 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
                         .traces
                         .allow_compaction(id, frontier.borrow());
                 }
-            }
-            ComputeCommand::EnableLogging(config) => {
-                self.initialize_logging(&config);
             }
         }
     }

--- a/src/dataflow/src/server/compute_state.rs
+++ b/src/dataflow/src/server/compute_state.rs
@@ -560,6 +560,9 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
     fn send_compute_response(&self, response: ComputeResponse) {
         // Ignore send errors because the coordinator is free to ignore our
         // responses. This happens during shutdown.
-        let _ = self.response_tx.send(Response::Compute(response));
+        let _ = self.response_tx.send(Response::Compute(
+            response,
+            mz_dataflow_types::client::DEFAULT_COMPUTE_INSTANCE_ID,
+        ));
     }
 }


### PR DESCRIPTION
This PR reorganizes `dataflow::{Command, Response}` slightly in the interest of clarity. Responses now come with a specific compute instance, and the `EnableLogging` variant is deprecated by being an argument to `CreateInstance`. This .. technically limits our ability to late-initialize logging, if that were a thing we wanted to do, but I assert that it is not.
