### PR TITLE
xcompile: use alternate target directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 # https://github.com/github/gitignore/tree/master/Global
 
 target
+target-xcompile
 miri-target
 .mtrlz.log
 **/*.rs.bk

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ target
 miri-target
 .mtrlz.log
 **/*.rs.bk
-.netlify
 mzdata
 __pycache__
 .mypy_cache

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -84,7 +84,7 @@ class RepositoryDetails:
 
     def cargo_target_dir(self) -> Path:
         """Determine the path to the target directory for Cargo."""
-        return self.root / "target" / xcompile.target(self.arch)
+        return self.root / "target-xcompile" / xcompile.target(self.arch)
 
 
 def docker_images() -> Set[str]:

--- a/misc/python/materialize/xcompile.py
+++ b/misc/python/materialize/xcompile.py
@@ -111,6 +111,7 @@ def cargo(
 
     env = {
         **extra_env,
+        "CARGO_TARGET_DIR": ROOT / "target-xcompile",
         "RUSTFLAGS": " ".join(rustflags),
         **KRB5_CONF_OVERRIDES,
     }
@@ -160,7 +161,7 @@ def _bootstrap_darwin(arch: Arch) -> None:
     # cross-compiling toolchain on the host and use that instead.
 
     BOOTSTRAP_VERSION = "4"
-    BOOTSTRAP_FILE = ROOT / "target" / target(arch) / ".xcompile-bootstrap"
+    BOOTSTRAP_FILE = ROOT / "target-xcompile" / target(arch) / ".xcompile-bootstrap"
     try:
         contents = BOOTSTRAP_FILE.read_text()
     except FileNotFoundError:

--- a/misc/python/materialize/xcompile.py
+++ b/misc/python/materialize/xcompile.py
@@ -169,7 +169,6 @@ def _bootstrap_darwin(arch: Arch) -> None:
         return
 
     spawn.runv(["brew", "install", f"materializeinc/crosstools/{target(arch)}"])
-    spawn.runv(["cargo", "clean", "--target", target(arch)], cwd=ROOT)
     spawn.runv(["rustup", "target", "add", target(arch)])
 
     BOOTSTRAP_FILE.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
This makes switching between `bin/xcompile` and `cargo build` less
painful, because they're not constantly invalidating one another's
caches.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
