### PR TITLE
Advance bindings *past* last offset

### DIFF
--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -141,12 +141,13 @@ impl KafkaSourceReader {
             .expect("Failed to create Kafka Consumer");
         let consumer = Arc::new(consumer);
 
-        let mut start_offsets: HashMap<_, _> = kc
-            .start_offsets
-            .into_iter()
-            .map(|(pid, offset)| (pid, offset - 1))
-            .collect();
+        // Start offsets is a map from pid -> next 0-indexed offset to read from,
+        // which is equivalent to 1 + the last 0-indexed offset read.
+        let mut start_offsets: HashMap<_, _> = kc.start_offsets.into_iter().collect();
 
+        // Restored offsets are 1-indexed, so convert to 0-indexed offsets by
+        // subtracting 1. The bindings in sqlite already encode 1 offset past the
+        // last read offset.
         for (pid, offset) in restored_offsets {
             let pid = match pid {
                 PartitionId::Kafka(id) => id,
@@ -227,16 +228,15 @@ impl KafkaSourceReader {
             return;
         }
 
-        // Indicate a last offset of -1 if we have not been instructed to have a specific start
-        // offset for this topic.
         let start_offset = match self.start_offsets.get(&pid) {
-            // Seek to the *next* offset (aka start_offset + 1) that we have not yet processed
-            Some(offset) => *offset + 1,
+            Some(offset) => *offset,
             None => 0,
         };
 
         self.create_partition_queue(pid, Offset::Offset(start_offset));
 
+        // Indicate a last offset of -1 if we have not been instructed to have a specific start
+        // offset for this topic.
         let prev = self.last_offsets.insert(pid, start_offset - 1);
 
         assert!(prev.is_none());
@@ -493,7 +493,7 @@ impl KafkaSourceReader {
                 offset,
                 last_offset + 1,
             );
-            // Seek to the *next* offset (aka last_offset + 1) that we have not yet processed
+            // Seek to the *next* 0 indexed offset that we have not yet processed
             self.fast_forward_consumer(partition, last_offset + 1);
             // We explicitly should not consume the message as we have already processed it
             // However, we make sure to activate the source to make sure that we get a chance

--- a/src/dataflow/src/source/timestamp.rs
+++ b/src/dataflow/src/source/timestamp.rs
@@ -79,9 +79,9 @@ impl TimestampProposer {
     /// a binding for an offset greater than `offset`. The only exception here is if
     /// `time` is 0, which is accepted to bootstrap the timestamp proposal.
     fn propose_binding(&mut self, partition: PartitionId, offset: MzOffset) -> Timestamp {
-        let current_max = self.bindings.entry(partition).or_insert(offset);
-        if offset > *current_max {
-            *current_max = offset;
+        let next_offset = self.bindings.entry(partition).or_insert(offset + 1);
+        if offset + 1 > *next_offset {
+            *next_offset = offset + 1;
         }
         self.timestamp
     }

--- a/test/persistence/kafka-sources/repeated-source-rendering-before.td
+++ b/test/persistence/kafka-sources/repeated-source-rendering-before.td
@@ -31,11 +31,11 @@ $ kafka-ingest format=avro topic=re-created schema=${schema} publish=true repeat
 
 > CREATE MATERIALIZED VIEW a_view AS SELECT * FROM re_created;
 
-> SELECT COUNT(*) = 10 FROM a_view;
-true
+> SELECT COUNT(*) FROM a_view;
+10
 
-> SELECT SUM(CAST(statistics->'topics'->'testdrive-re-created-${testdrive.seed}'->'partitions'->'0'->'msgs' AS INT)) = 10 FROM mz_kafka_source_statistics;
-true
+> SELECT SUM(CAST(statistics->'topics'->'testdrive-re-created-${testdrive.seed}'->'partitions'->'0'->'msgs' AS INT)) FROM mz_kafka_source_statistics;
+10
 
 # Verify that we cannot create multiple materializations of a persisted source.
 ! CREATE MATERIALIZED VIEW a_view_second_materialization AS SELECT * FROM re_created;
@@ -45,12 +45,12 @@ contains:Cannot re-materialize source re_created
 
 > CREATE MATERIALIZED VIEW a_view AS SELECT * FROM re_created;
 
-> SELECT COUNT(*) = 10 FROM a_view;
-true
+> SELECT COUNT(*) FROM a_view;
+10
 
 # Re-creating the source should result in no messages being read from Kafka, because we still have the persisted data and offsets.
-> SELECT SUM(CAST(statistics->'topics'->'testdrive-re-created-${testdrive.seed}'->'partitions'->'0'->'msgs' AS INT)) = 0 FROM mz_kafka_source_statistics;
-true
+> SELECT SUM(CAST(statistics->'topics'->'testdrive-re-created-${testdrive.seed}'->'partitions'->'0'->'msgs' AS INT)) FROM mz_kafka_source_statistics;
+0
 
 # Same with DROP INDEX
 
@@ -58,8 +58,8 @@ true
 
 > CREATE DEFAULT INDEX ON a_view;
 
-> SELECT COUNT(*) = 10 FROM a_view;
-true
+> SELECT COUNT(*) FROM a_view;
+10
 
-> SELECT SUM(CAST(statistics->'topics'->'testdrive-re-created-${testdrive.seed}'->'partitions'->'0'->'msgs' AS INT)) = 0 FROM mz_kafka_source_statistics;
-true
+> SELECT SUM(CAST(statistics->'topics'->'testdrive-re-created-${testdrive.seed}'->'partitions'->'0'->'msgs' AS INT)) FROM mz_kafka_source_statistics;
+0


### PR DESCRIPTION
This PR modifies the timestamp proposer to understand that it must record a binding strictly after the last offset it has seen, to ensure that we assign a timestamp to that offset.

### Motivation

  * This PR fixes a recognized bug: Number (3.) in https://github.com/MaterializeInc/materialize/issues/10587

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
