### PR TITLE
correct kafka error message during purification

### DIFF
--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -112,10 +112,7 @@ pub fn purify(
                     let consumer = kafka_util::create_consumer(&broker, &topic, &config_options)
                         .await
                         .map_err(|e| {
-                            anyhow!(
-                                "Cannot create Kafka Consumer for determining start offsets: {}",
-                                e
-                            )
+                            anyhow!("Failed to create and connect Kafka consumer: {}", e)
                         })?;
 
                     // Translate `kafka_time_offset` to `start_offset`.


### PR DESCRIPTION
During purification we create a Kafka consumer to validate that
connection params are correct and that we can reach the Kafka broker. We
potentially use this consumer for fetching things like the start offset
if specified, but that's not its primary purpose.

Today the error message is confusing because it incorrectly references
start offset fetching, even in cases where those params have not been
specified in CREATE SOURCE.

Rewriting the error message to be slightly more generic

### Motivation

Which of the following best describes the motivation behind this PR?

  * This PR fixes a previously unreported bug. - convo in slack https://materializeinc.slack.com/archives/C01CFKM1QRF/p1644494833057079

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
