### PR TITLE
Move AWS stuff to StorageState

### DIFF
--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -104,7 +104,6 @@ use std::collections::{BTreeMap, HashSet};
 use std::rc::Rc;
 
 use differential_dataflow::AsCollection;
-use mz_dataflow_types::sources::AwsExternalId;
 use timely::communication::Allocate;
 use timely::dataflow::operators::to_stream::ToStream;
 use timely::dataflow::scopes::Child;
@@ -143,7 +142,6 @@ pub fn build_storage_dataflow<A: Allocate, B: StorageCapture>(
     storage_state: &mut StorageState,
     dataflow: &DataflowDescription<mz_dataflow_types::plan::Plan>,
     boundary: &mut B,
-    aws_external_id: AwsExternalId,
 ) {
     let worker_logging = timely_worker.log_register().get("timely");
     let name = format!("Dataflow: {}", &dataflow.debug_name);
@@ -170,7 +168,6 @@ pub fn build_storage_dataflow<A: Allocate, B: StorageCapture>(
                     region,
                     materialized_logging.clone(),
                     src_id.clone(),
-                    aws_external_id.clone(),
                 );
 
                 boundary.capture(*src_id, ok, err, token, &debug_name);

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -142,7 +142,6 @@ pub(crate) fn import_source<G>(
     scope: &mut G,
     materialized_logging: Option<Logger>,
     src_id: GlobalId,
-    aws_external_id: AwsExternalId,
 ) -> (
     (Collection<G, Row>, Collection<G, DataflowError>),
     Rc<dyn std::any::Any>,
@@ -243,7 +242,7 @@ where
                 encoding: encoding.clone(),
                 now: storage_state.now.clone(),
                 base_metrics: &storage_state.source_metrics,
-                aws_external_id: aws_external_id.clone(),
+                aws_external_id: storage_state.aws_external_id.clone(),
             };
 
             let (mut collection, capability) = if let ExternalSourceConnector::PubNub(
@@ -289,7 +288,7 @@ where
                             source_persist_config
                                 .as_ref()
                                 .map(|config| config.bindings_config.clone()),
-                            aws_external_id,
+                            storage_state.aws_external_id.clone(),
                         );
                         ((SourceType::Delimited(ok), ts, err), cap)
                     }
@@ -300,7 +299,7 @@ where
                             source_persist_config
                                 .as_ref()
                                 .map(|config| config.bindings_config.clone()),
-                            aws_external_id,
+                            storage_state.aws_external_id.clone(),
                         );
                         ((SourceType::Delimited(ok), ts, err), cap)
                     }
@@ -311,7 +310,7 @@ where
                             source_persist_config
                                 .as_ref()
                                 .map(|config| config.bindings_config.clone()),
-                            aws_external_id,
+                            storage_state.aws_external_id.clone(),
                         );
                         ((SourceType::ByteStream(ok), ts, err), cap)
                     }
@@ -322,7 +321,7 @@ where
                             source_persist_config
                                 .as_ref()
                                 .map(|config| config.bindings_config.clone()),
-                            aws_external_id,
+                            storage_state.aws_external_id.clone(),
                         );
                         ((SourceType::ByteStream(ok), ts, err), cap)
                     }

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -150,13 +150,13 @@ pub fn serve(config: Config) -> Result<(Server, LocalClient), anyhow::Error> {
                 last_bindings_feedback: Instant::now(),
                 now: now.clone(),
                 source_metrics,
+                aws_external_id: aws_external_id.clone(),
                 timely_worker_index,
                 timely_worker_peers,
             },
             command_rx,
             response_tx,
             command_metrics: server_metrics.for_worker_id(worker_idx),
-            aws_external_id: aws_external_id.clone(),
         }
         .run()
     })
@@ -196,8 +196,6 @@ where
     response_tx: mpsc::UnboundedSender<Response>,
     /// Metrics bundle.
     command_metrics: WorkerMetrics,
-    /// An external ID to use for all AWS AssumeRole operations.
-    aws_external_id: AwsExternalId,
 }
 
 impl<'w, A> Worker<'w, A>
@@ -299,7 +297,6 @@ where
                         &mut self.storage_state,
                         &dataflow,
                         &mut boundary,
-                        self.aws_external_id.clone(),
                     );
 
                     crate::render::build_compute_dataflow(

--- a/src/dataflow/src/server/storage_state.rs
+++ b/src/dataflow/src/server/storage_state.rs
@@ -17,6 +17,7 @@ use tokio::sync::mpsc;
 use mz_dataflow_types::client::{
     Response, StorageCommand, StorageResponse, TimestampBindingFeedback,
 };
+use mz_dataflow_types::sources::AwsExternalId;
 use mz_dataflow_types::sources::{ExternalSourceConnector, SourceConnector};
 use mz_expr::{GlobalId, PartitionId};
 use mz_ore::now::NowFn;
@@ -65,6 +66,8 @@ pub struct StorageState {
     pub now: NowFn,
     /// Metrics for the source-specific side of dataflows.
     pub source_metrics: SourceBaseMetrics,
+    /// An external ID to use for all AWS AssumeRole operations.
+    pub aws_external_id: AwsExternalId,
     /// Index of the associated timely dataflow worker.
     pub timely_worker_index: usize,
     /// Peers in the associated timely dataflow worker.


### PR DESCRIPTION
AWS stuff was put at the root of `Worker`, when it belong instead in `StorageState`, at least as far as current usage dictates. Should it also be needed for sinks (idk why it is not) we can also add it to `ComputeState`.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
