### PR TITLE
ci/cargo-test: include package name in test name

### DIFF
--- a/ci/test/cargo-test/image/Dockerfile
+++ b/ci/test/cargo-test/image/Dockerfile
@@ -11,7 +11,7 @@ MZFROM ubuntu-base
 
 RUN apt-get update && apt-get -qy install \
     ca-certificates \
-    wait-for-it
+    jq
 
 COPY tests /tests/
 COPY run-tests /usr/local/bin

--- a/ci/test/cargo-test/image/run-tests
+++ b/ci/test/cargo-test/image/run-tests
@@ -18,8 +18,13 @@ set -euo pipefail
 
 ci_init
 
-while read -r binary cwd; do
-    (cd "$cwd" && ci_try "/tests/$binary" --nocapture -Z unstable-options --format json --report-time) | tee -a results.json
+while read -r binary package cwd; do
+    # Run tests, generating a JSON event stream. The jq in the pipeline below
+    # prefixes each event's name field, if present, with the package name, so
+    # that we can distinguish tests with the same names in different packages.
+    (cd "$cwd" && ci_try "/tests/$binary" -Z unstable-options --format json --report-time) \
+        | jq -c --arg package "$package" 'if .name then .name = "\($package)::\(.name)" else . end' \
+        | tee -a results.json
 done < /tests/manifest
 
 ci_status_report

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -366,7 +366,8 @@ class CargoTest(CargoPreImage):
                     [*self.rd.tool("strip"), self.path / "tests" / slug],
                     cwd=self.rd.root,
                 )
-                manifest.write(f"{slug} {crate_path}\n")
+                package = slug.replace(".", "::")
+                manifest.write(f"{slug} {package} {crate_path}\n")
         shutil.move(str(self.path / "materialized"), self.path / "tests")
         shutil.move(str(self.path / "testdrive"), self.path / "tests")
         shutil.copytree(self.rd.root / "misc" / "shlib", self.path / "shlib")

--- a/misc/shlib/shlib.bash
+++ b/misc/shlib/shlib.bash
@@ -114,15 +114,15 @@ ci_init() {
 }
 
 ci_collapsed_heading() {
-    echo "---" "$@"
+    echo "---" "$@" >&2
 }
 
 ci_uncollapsed_heading() {
-    echo "+++" "$@"
+    echo "+++" "$@" >&2
 }
 
 ci_uncollapse_current_section() {
-    echo "^^^ +++"
+    echo "^^^ +++" >&2
 }
 
 ci_try_passed=0


### PR DESCRIPTION
Extracted from #10604. This fixes the glitch where `cargo2junit` would sometimes fail to parse the output of `cargo test` based on the order of test execution. 

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
