### PR TITLE
sql: hoist name resolution out of plan::query module

### DIFF
--- a/src/coord/src/catalog/migrate.rs
+++ b/src/coord/src/catalog/migrate.rs
@@ -29,7 +29,7 @@ use mz_sql::ast::{
     ProtobufSchema, Raw, RawName, SqlOption, Statement, TableFunction, UnresolvedDataType,
     UnresolvedObjectName, Value, ViewDefinition, WithOption, WithOptionValue,
 };
-use mz_sql::plan::resolve_names_stmt;
+use mz_sql::names::resolve_names_stmt;
 
 use crate::catalog::storage::Transaction;
 use crate::catalog::{Catalog, ConnCatalog, SerializedCatalogItem};

--- a/src/coord/tests/sql.rs
+++ b/src/coord/tests/sql.rs
@@ -26,8 +26,8 @@ use mz_expr::GlobalId;
 use mz_ore::now::NOW_ZERO;
 use mz_repr::RelationDesc;
 use mz_sql::ast::{Expr, Statement};
-use mz_sql::names::{DatabaseSpecifier, FullName};
-use mz_sql::plan::{resolve_names, PlanContext, QueryContext, QueryLifetime, StatementContext};
+use mz_sql::names::{resolve_names, DatabaseSpecifier, FullName};
+use mz_sql::plan::{PlanContext, QueryContext, QueryLifetime, StatementContext};
 
 // This morally tests the name resolution stuff, but we need access to a
 // catalog.

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -23,7 +23,7 @@ use mz_pgrepr::oid;
 use mz_repr::{ColumnName, ColumnType, Datum, RelationType, Row, ScalarBaseType, ScalarType};
 
 use crate::ast::{SelectStatement, Statement};
-use crate::names::PartialName;
+use crate::names::{resolve_names, resolve_names_expr, PartialName};
 use crate::plan::error::PlanError;
 use crate::plan::expr::{
     AggregateFunc, BinaryFunc, CoercibleScalarExpr, ColumnOrder, HirRelationExpr, HirScalarExpr,
@@ -289,7 +289,7 @@ pub fn sql_impl(
         let mut expr = expr.clone();
         transform_ast::transform_expr(&scx, &mut expr)?;
 
-        let expr = query::resolve_names_expr(&mut qcx, expr)?;
+        let expr = resolve_names_expr(&mut qcx, expr)?;
 
         let ecx = ExprContext {
             qcx: &qcx,
@@ -368,7 +368,7 @@ fn sql_impl_table_func_inner(
         let mut query = query.clone();
         transform_ast::transform_query(&scx, &mut query)?;
 
-        let query = query::resolve_names(&mut qcx, query)?;
+        let query = resolve_names(&mut qcx, query)?;
 
         query::plan_nested_query(&mut qcx, &query)
     };

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -30,9 +30,8 @@ use mz_sql_parser::ast::{
     UnresolvedObjectName, Value, ViewDefinition,
 };
 
-use crate::names::{DatabaseSpecifier, FullName, PartialName};
+use crate::names::{resolve_names_stmt, Aug, DatabaseSpecifier, FullName, PartialName};
 use crate::plan::error::PlanError;
-use crate::plan::query::{resolve_names_stmt, Aug};
 use crate::plan::statement::StatementContext;
 
 /// Normalizes a single identifier.

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -63,7 +63,7 @@ pub use self::expr::{HirRelationExpr, HirScalarExpr};
 pub use error::PlanError;
 pub use explain::Explanation;
 pub use optimize::OptimizerConfig;
-pub use query::{resolve_names, resolve_names_stmt, QueryContext, QueryLifetime};
+pub use query::{QueryContext, QueryLifetime};
 pub use statement::{describe, plan, plan_copy_from, StatementContext, StatementDesc};
 
 /// Instructions for executing a SQL query.

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -23,38 +23,39 @@ use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::convert::{TryFrom, TryInto};
-use std::fmt;
+
 use std::iter;
 use std::mem;
 
+use itertools::Itertools;
 use uuid::Uuid;
 
-use itertools::Itertools;
-use mz_expr::{func as expr_func, LocalId};
+use mz_expr::{func as expr_func, GlobalId, Id, LocalId, RowSetFinishing};
 use mz_ore::collections::CollectionExt;
 use mz_ore::stack::{CheckedRecursion, RecursionGuard};
 use mz_ore::str::StrExt;
-use mz_sql_parser::ast::display::{AstDisplay, AstFormatter};
-use mz_sql_parser::ast::fold::Fold;
-use mz_sql_parser::ast::visit_mut::{self, VisitMut};
-use mz_sql_parser::ast::{
-    self, Assignment, AstInfo, Cte, DeleteStatement, Distinct, Expr, Function, FunctionArgs,
-    HomogenizingFunction, Ident, InsertSource, IsExprConstruct, Join, JoinConstraint, JoinOperator,
-    Limit, OrderByExpr, Query, Raw, RawName, Select, SelectItem, SetExpr, SetOperator, Statement,
-    SubscriptPosition, TableAlias, TableFactor, TableFunction, TableWithJoins, UnresolvedDataType,
-    UnresolvedObjectName, UpdateStatement, Value, Values,
-};
-
-use mz_expr::{GlobalId, Id, RowSetFinishing};
 use mz_repr::adt::numeric;
 use mz_repr::{
     strconv, ColumnName, ColumnType, Datum, RelationDesc, RelationType, Row, RowArena, ScalarType,
     Timestamp,
 };
 
+use mz_sql_parser::ast::fold::Fold;
+use mz_sql_parser::ast::visit_mut::{self, VisitMut};
+use mz_sql_parser::ast::{
+    Assignment, DeleteStatement, Distinct, Expr, Function, FunctionArgs, HomogenizingFunction,
+    Ident, InsertSource, IsExprConstruct, Join, JoinConstraint, JoinOperator, Limit, OrderByExpr,
+    Query, Raw, Select, SelectItem, SetExpr, SetOperator, SubscriptPosition, TableAlias,
+    TableFactor, TableFunction, TableWithJoins, UnresolvedObjectName, UpdateStatement, Value,
+    Values,
+};
+
 use crate::catalog::{CatalogItemType, SessionCatalog};
 use crate::func::{self, Func, FuncSpec};
-use crate::names::PartialName;
+use crate::names::{
+    resolve_names, resolve_names_expr, resolve_names_extend_qcx_ids, Aug, NameResolver,
+    PartialName, ResolvedDataType, ResolvedObjectName,
+};
 use crate::normalize;
 use crate::plan::error::PlanError;
 use crate::plan::expr::{
@@ -68,411 +69,6 @@ use crate::plan::statement::{StatementContext, StatementDesc};
 use crate::plan::typeconv::{self, CastContext};
 use crate::plan::Params;
 use crate::plan::{transform_ast, PlanContext};
-
-// Aug is the type variable assigned to an AST that has already been
-// name-resolved. An AST in this state has global IDs populated next to table
-// names, and local IDs assigned to CTE definitions and references.
-#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone, Default)]
-pub struct Aug;
-
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
-pub struct ResolvedObjectName {
-    pub id: Id,
-    pub raw_name: PartialName,
-    // Whether this object, when printed out, should use [id AS name] syntax. We
-    // want this for things like tables and sources, but not for things like
-    // types.
-    pub print_id: bool,
-}
-
-impl AstDisplay for ResolvedObjectName {
-    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
-        if self.print_id {
-            f.write_str(format!("[{} AS ", self.id));
-        }
-        let n = self.raw_name();
-        if let Some(database) = n.database {
-            f.write_node(&Ident::new(database));
-            f.write_str(".");
-        }
-        if let Some(schema) = n.schema {
-            f.write_node(&Ident::new(schema));
-            f.write_str(".");
-        }
-        f.write_node(&Ident::new(n.item));
-        if self.print_id {
-            f.write_str("]");
-        }
-    }
-}
-
-impl std::fmt::Display for ResolvedObjectName {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        f.write_str(self.to_ast_string().as_str())
-    }
-}
-
-impl ResolvedObjectName {
-    pub fn raw_name(&self) -> PartialName {
-        self.raw_name.clone()
-    }
-}
-
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
-pub enum ResolvedDataType {
-    // TODO(benesch): `AnonymousArray` should not exist because that concept
-    // does not exist in PostgreSQL. Array types exist properly in the catalog
-    // and should be resolved into `Named` types during name resolution.
-    AnonymousArray(Box<ResolvedDataType>),
-    AnonymousList(Box<ResolvedDataType>),
-    AnonymousMap {
-        key_type: Box<ResolvedDataType>,
-        value_type: Box<ResolvedDataType>,
-    },
-    Named {
-        id: GlobalId,
-        name: PartialName,
-        modifiers: Vec<u64>,
-        print_id: bool,
-    },
-}
-
-impl AstDisplay for ResolvedDataType {
-    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
-        match self {
-            ResolvedDataType::AnonymousArray(element_type) => {
-                element_type.fmt(f);
-                f.write_str("[]");
-            }
-            ResolvedDataType::AnonymousList(element_type) => {
-                element_type.fmt(f);
-                f.write_str(" list");
-            }
-            ResolvedDataType::AnonymousMap {
-                key_type,
-                value_type,
-            } => {
-                f.write_str("map[");
-                key_type.fmt(f);
-                f.write_str("=>");
-                value_type.fmt(f);
-                f.write_str("]");
-            }
-            ResolvedDataType::Named {
-                id,
-                name,
-                modifiers,
-                print_id,
-            } => {
-                if *print_id {
-                    f.write_str(format!("[{} AS ", id));
-                }
-                if let Some(database) = &name.database {
-                    f.write_node(&Ident::new(database));
-                    f.write_str(".");
-                }
-                if let Some(schema) = &name.schema {
-                    f.write_node(&Ident::new(schema));
-                    f.write_str(".");
-                }
-                f.write_node(&Ident::new(&name.item));
-                if *print_id {
-                    f.write_str("]");
-                }
-                if modifiers.len() > 0 {
-                    f.write_str("(");
-                    f.write_node(&ast::display::comma_separated(modifiers));
-                    f.write_str(")");
-                }
-            }
-        }
-    }
-}
-
-impl fmt::Display for ResolvedDataType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(self.to_ast_string().as_str())
-    }
-}
-
-impl AstInfo for Aug {
-    type ObjectName = ResolvedObjectName;
-    type DataType = ResolvedDataType;
-    type Id = Id;
-}
-
-#[derive(Debug)]
-struct NameResolver<'a> {
-    catalog: &'a dyn SessionCatalog,
-    ctes: HashMap<String, LocalId>,
-    status: Result<(), PlanError>,
-    ids: HashSet<GlobalId>,
-}
-
-impl<'a> NameResolver<'a> {
-    pub fn new(catalog: &'a dyn SessionCatalog) -> NameResolver {
-        NameResolver {
-            catalog,
-            ctes: HashMap::new(),
-            status: Ok(()),
-            ids: HashSet::new(),
-        }
-    }
-
-    fn fold_data_type_internal(
-        &mut self,
-        data_type: <Raw as AstInfo>::DataType,
-    ) -> Result<<Aug as AstInfo>::DataType, PlanError> {
-        match data_type {
-            UnresolvedDataType::Array(elem_type) => {
-                let elem_type = self.fold_data_type_internal(*elem_type)?;
-                Ok(ResolvedDataType::AnonymousArray(Box::new(elem_type)))
-            }
-            UnresolvedDataType::List(elem_type) => {
-                let elem_type = self.fold_data_type_internal(*elem_type)?;
-                Ok(ResolvedDataType::AnonymousList(Box::new(elem_type)))
-            }
-            UnresolvedDataType::Map {
-                key_type,
-                value_type,
-            } => {
-                let key_type = self.fold_data_type_internal(*key_type)?;
-                let value_type = self.fold_data_type_internal(*value_type)?;
-                Ok(ResolvedDataType::AnonymousMap {
-                    key_type: Box::new(key_type),
-                    value_type: Box::new(value_type),
-                })
-            }
-            UnresolvedDataType::Other { name, typ_mod } => {
-                let (name, item) = match name {
-                    RawName::Name(name) => {
-                        let name = normalize::unresolved_object_name(name).unwrap();
-                        let item = self.catalog.resolve_item(&name)?;
-                        (item.name().clone().into(), item)
-                    }
-                    RawName::Id(id, name) => {
-                        let name = normalize::unresolved_object_name(name).unwrap();
-                        let gid: GlobalId = id.parse()?;
-                        let item = self.catalog.get_item_by_id(&gid);
-                        (name, item)
-                    }
-                };
-                self.ids.insert(item.id());
-                Ok(ResolvedDataType::Named {
-                    id: item.id(),
-                    name,
-                    modifiers: typ_mod,
-                    print_id: true,
-                })
-            }
-        }
-    }
-}
-
-impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
-    fn fold_query(&mut self, q: Query<Raw>) -> Query<Aug> {
-        // Retain the old values of various CTE names so that we can restore them after we're done
-        // planning this SELECT.
-        let mut old_cte_values = Vec::new();
-        // A single WITH block cannot use the same name multiple times.
-        let mut used_names = HashSet::new();
-        let mut ctes = Vec::new();
-        for cte in q.ctes {
-            let cte_name = normalize::ident(cte.alias.name.clone());
-
-            if used_names.contains(&cte_name) {
-                self.status = Err(PlanError::Unstructured(format!(
-                    "WITH query name \"{}\" specified more than once",
-                    cte_name
-                )));
-            }
-            used_names.insert(cte_name.clone());
-
-            let id = LocalId::new(self.ctes.len() as u64);
-            ctes.push(Cte {
-                alias: cte.alias,
-                id: Id::Local(id),
-                query: self.fold_query(cte.query),
-            });
-            let old_val = self.ctes.insert(cte_name.clone(), id);
-            old_cte_values.push((cte_name, old_val));
-        }
-        let result = Query {
-            ctes,
-            body: self.fold_set_expr(q.body),
-            limit: q.limit.map(|l| self.fold_limit(l)),
-            offset: q.offset.map(|l| self.fold_expr(l)),
-            order_by: q
-                .order_by
-                .into_iter()
-                .map(|c| self.fold_order_by_expr(c))
-                .collect(),
-        };
-
-        // Restore the old values of the CTEs.
-        for (name, value) in old_cte_values.iter() {
-            match value {
-                Some(value) => {
-                    self.ctes.insert(name.to_string(), value.clone());
-                }
-                None => {
-                    self.ctes.remove(name);
-                }
-            };
-        }
-
-        result
-    }
-
-    fn fold_id(&mut self, _id: <Raw as AstInfo>::Id) -> <Aug as AstInfo>::Id {
-        panic!("this should have been handled when walking the CTE");
-    }
-
-    fn fold_object_name(
-        &mut self,
-        object_name: <Raw as AstInfo>::ObjectName,
-    ) -> <Aug as AstInfo>::ObjectName {
-        match object_name {
-            RawName::Name(raw_name) => {
-                // Check if unqualified name refers to a CTE.
-                if raw_name.0.len() == 1 {
-                    let norm_name = normalize::ident(raw_name.0[0].clone());
-                    if let Some(id) = self.ctes.get(&norm_name) {
-                        return ResolvedObjectName {
-                            id: Id::Local(*id),
-                            raw_name: normalize::unresolved_object_name(raw_name).unwrap(),
-                            print_id: false,
-                        };
-                    }
-                }
-
-                let name = normalize::unresolved_object_name(raw_name).unwrap();
-                match self.catalog.resolve_item(&name) {
-                    Ok(item) => {
-                        self.ids.insert(item.id());
-                        let print_id = !matches!(
-                            item.item_type(),
-                            CatalogItemType::Func | CatalogItemType::Type
-                        );
-                        ResolvedObjectName {
-                            id: Id::Global(item.id()),
-                            raw_name: item.name().clone().into(),
-                            print_id,
-                        }
-                    }
-                    Err(e) => {
-                        if self.status.is_ok() {
-                            self.status = Err(e.into());
-                        }
-                        ResolvedObjectName {
-                            id: Id::Local(LocalId::new(0)),
-                            raw_name: name,
-                            print_id: false,
-                        }
-                    }
-                }
-            }
-            RawName::Id(id, raw_name) => {
-                let gid: GlobalId = match id.parse() {
-                    Ok(id) => id,
-                    Err(e) => {
-                        self.status = Err(e.into());
-                        GlobalId::User(0)
-                    }
-                };
-                if self.status.is_ok() && self.catalog.try_get_item_by_id(&gid).is_none() {
-                    self.status = Err(PlanError::Unstructured(format!("invalid id {}", &gid)));
-                }
-                self.ids.insert(gid.clone());
-                ResolvedObjectName {
-                    id: Id::Global(gid),
-                    raw_name: normalize::unresolved_object_name(raw_name).unwrap(),
-                    print_id: true,
-                }
-            }
-        }
-    }
-
-    fn fold_data_type(
-        &mut self,
-        data_type: <Raw as AstInfo>::DataType,
-    ) -> <Aug as AstInfo>::DataType {
-        match self.fold_data_type_internal(data_type) {
-            Ok(data_type) => data_type,
-            Err(e) => {
-                if self.status.is_ok() {
-                    self.status = Err(e);
-                }
-                ResolvedDataType::Named {
-                    id: GlobalId::User(0),
-                    name: PartialName {
-                        database: None,
-                        schema: None,
-                        item: "ignored".into(),
-                    },
-                    modifiers: vec![],
-                    print_id: false,
-                }
-            }
-        }
-    }
-}
-
-pub fn resolve_names_stmt(
-    catalog: &dyn SessionCatalog,
-    stmt: Statement<Raw>,
-) -> Result<Statement<Aug>, PlanError> {
-    let mut n = NameResolver::new(catalog);
-    let result = n.fold_statement(stmt);
-    n.status?;
-    Ok(result)
-}
-
-// Attaches additional information to a `Raw` AST, resulting in an `Aug` AST, by
-// resolving names and (aspirationally) performing semantic analysis such as
-// type-checking.
-pub fn resolve_names(qcx: &mut QueryContext, query: Query<Raw>) -> Result<Query<Aug>, PlanError> {
-    let mut n = NameResolver::new(qcx.scx.catalog);
-    let result = n.fold_query(query);
-    n.status?;
-    qcx.ids.extend(n.ids.iter());
-    Ok(result)
-}
-
-pub fn resolve_names_expr(qcx: &mut QueryContext, expr: Expr<Raw>) -> Result<Expr<Aug>, PlanError> {
-    let mut n = NameResolver::new(qcx.scx.catalog);
-    let result = n.fold_expr(expr);
-    n.status?;
-    qcx.ids.extend(n.ids.iter());
-    Ok(result)
-}
-
-pub fn resolve_names_data_type(
-    scx: &StatementContext,
-    data_type: UnresolvedDataType,
-) -> Result<(ResolvedDataType, HashSet<GlobalId>), PlanError> {
-    let mut n = NameResolver::new(scx.catalog);
-    let result = n.fold_data_type(data_type);
-    n.status?;
-    Ok((result, n.ids))
-}
-
-/// A general implementation for name resolution on AST elements.
-///
-/// This implementation is appropriate Whenever:
-/// - You don't need to export the name resolution outside the `sql` crate and
-///   the extra typing isn't too onerous.
-/// - Discovered dependencies should extend `qcx.ids`.
-fn resolve_names_extend_qcx_ids<F, T>(qcx: &mut QueryContext, f: F) -> Result<T, PlanError>
-where
-    F: FnOnce(&mut NameResolver) -> T,
-{
-    let mut n = NameResolver::new(qcx.scx.catalog);
-    let result = f(&mut n);
-    n.status?;
-    qcx.ids.extend(n.ids.iter());
-    Ok(result)
-}
 
 pub struct PlannedQuery<E> {
     pub expr: E,

--- a/src/sql/src/plan/scope.rs
+++ b/src/sql/src/plan/scope.rs
@@ -50,11 +50,10 @@ use mz_ore::iter::IteratorExt;
 use mz_repr::ColumnName;
 
 use crate::ast::Expr;
-use crate::names::PartialName;
+use crate::names::{Aug, PartialName};
 use crate::plan::error::PlanError;
 use crate::plan::expr::ColumnRef;
 use crate::plan::plan_utils::JoinSide;
-use crate::plan::query::Aug;
 
 #[derive(Debug, Clone)]
 pub struct ScopeItem {

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -65,10 +65,12 @@ use crate::ast::{
 };
 use crate::catalog::{CatalogItem, CatalogItemType};
 use crate::kafka_util;
-use crate::names::{DatabaseSpecifier, FullName, SchemaName};
+use crate::names::{
+    resolve_names_data_type, DatabaseSpecifier, FullName, ResolvedDataType, SchemaName,
+};
 use crate::normalize;
 use crate::plan::error::PlanError;
-use crate::plan::query::{resolve_names_data_type, QueryLifetime, ResolvedDataType};
+use crate::plan::query::QueryLifetime;
 use crate::plan::statement::{StatementContext, StatementDesc};
 use crate::plan::{
     plan_utils, query, AlterIndexEnablePlan, AlterIndexResetOptionsPlan, AlterIndexSetOptionsPlan,


### PR DESCRIPTION
Eventually name resolution will be a pass that happens before planning.
Move it to the `names` module to start to make that clear.

This commit is pure code movement.

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
