### PR TITLE
ci: upload test analytics report on failure, too

### DIFF
--- a/ci/test/cargo-test/mzcompose.py
+++ b/ci/test/cargo-test/mzcompose.py
@@ -38,8 +38,12 @@ SERVICES = [
 
 def workflow_default(c: Composition) -> None:
     c.start_and_wait_for_tcp(["zookeeper", "kafka", "schema-registry"])
-    c.run("ci-cargo-test", "run-tests")
-    ci_util.upload_test_report(
-        "cargo-test",
-        spawn.capture(args=["cargo2junit"], stdin=(ROOT / "results.json").read_text()),
-    )
+    try:
+        c.run("ci-cargo-test", "run-tests")
+    finally:
+        ci_util.upload_test_report(
+            "cargo-test",
+            spawn.capture(
+                args=["cargo2junit"], stdin=(ROOT / "results.json").read_text()
+            ),
+        )

--- a/test/sqllogictest/mzcompose.py
+++ b/test/sqllogictest/mzcompose.py
@@ -27,5 +27,9 @@ def workflow_sqllogictest(c: Composition) -> None:
 def run_sqllogictest(c: Composition, command: str) -> None:
     c.up("postgres")
     c.wait_for_postgres(dbname="postgres")
-    c.run("sqllogictest-svc", command, "--junit-report=junit-report.xml")
-    ci_util.upload_test_report("sqllogictest", (ROOT / "junit-report.xml").read_text())
+    try:
+        c.run("sqllogictest-svc", command, "--junit-report=junit-report.xml")
+    finally:
+        ci_util.upload_test_report(
+            "sqllogictest", (ROOT / "junit-report.xml").read_text()
+        )

--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -91,10 +91,12 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     with c.override(materialized, testdrive):
         c.start_and_wait_for_tcp(services=dependencies)
         c.wait_for_materialized("materialized")
-        c.run("testdrive-svc", "--junit-report=junit-report.xml", *args.files)
-        ci_util.upload_test_report(
-            "testdrive", (Path(__file__).parent / "junit-report.xml").read_text()
-        )
+        try:
+            c.run("testdrive-svc", "--junit-report=junit-report.xml", *args.files)
+        finally:
+            ci_util.upload_test_report(
+                "testdrive", (Path(__file__).parent / "junit-report.xml").read_text()
+            )
         c.kill("materialized")
 
 


### PR DESCRIPTION
We hadn't actually seen an example of this, but it occurred to me that
the existing code would not upload the test report if the command under
test failed.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
