### PR TITLE
test/kafka-ingest: don't demand column key0

### DIFF
--- a/test/kafka-ingest-open-loop/setup.td
+++ b/test/kafka-ingest-open-loop/setup.td
@@ -38,8 +38,8 @@ $ kafka-create-topic topic=load-test partitions=4
 #
 # TODO: remove this once the optimization is pushed down into persistent upsert
 # as well.
-> CREATE VIEW intermediate AS SELECT key0, data, kafka_partition, mz_offset FROM load_test
-  WHERE key0 != '\\x0' AND
+> CREATE VIEW intermediate AS SELECT data, kafka_partition, mz_offset FROM load_test
+  WHERE
   data != '\\x0' AND
   kafka_partition != 10000 AND
   mz_offset != -1


### PR DESCRIPTION
The key0 column is only exposed for upsert sources and not for append-only sources.
Furthermore, that column doesn't need to be demanded as its used in the upsert
computation.

<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug: [Link to issue.]

  * This PR adds a known-desirable feature: [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
