### PR TITLE
mzcompose: always install dev deps when invoked from the root

### DIFF
--- a/bin/mzcompose
+++ b/bin/mzcompose
@@ -11,9 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-if [ "$1" == "--dev" ] ; then
-   shift
-   exec "$(dirname "$0")"/pyactivate --dev -m materialize.cli.mzcompose "$@"
-else
-   exec "$(dirname "$0")"/pyactivate -m materialize.cli.mzcompose "$@"
-fi
+exec "$(dirname "$0")"/pyactivate --dev -m materialize.cli.mzcompose "$@"

--- a/ci/test/cargo-test/mzcompose
+++ b/ci/test/cargo-test/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../../bin/mzcompose" "$@"
+exec "$(dirname "$0")"/../../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/demo/billing/mzcompose
+++ b/demo/billing/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../bin/mzcompose" "$@"
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/demo/chbench/mzcompose
+++ b/demo/chbench/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../bin/mzcompose" "$@"
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/demo/http_logs/mzcompose
+++ b/demo/http_logs/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../bin/mzcompose" "$@"
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/demo/simple/mzcompose
+++ b/demo/simple/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../bin/mzcompose" "$@"
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/doc/developer/feature-benchmark.md
+++ b/doc/developer/feature-benchmark.md
@@ -21,7 +21,7 @@ cd test/feature-benchmark
 Or, from the root of the repository:
 
 ```
-bin/mzcompose --dev --find feature-benchmark run default --other-tag unstable
+bin/mzcompose --find feature-benchmark run default --other-tag unstable
 ```
 
 This is going to benchmark the current source against the `materialize/materialized:unstable` container from DockerHub.

--- a/misc/dbt-materialize/mzcompose
+++ b/misc/dbt-materialize/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../bin/mzcompose" "$@"
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/misc/python/materialize/cli/mzcompose
+++ b/misc/python/materialize/cli/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")"/../../bin/pyactivate --dev -m materialize.cli.mzcompose "$@"
+exec "$(dirname "$0")"/../../../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -238,7 +238,7 @@ class GenShortcutsCommand(Command):
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/{}/bin/mzcompose" "$@"
+exec "$(dirname "$0")"/{}/bin/pyactivate -m materialize.cli.mzcompose "$@"
 """
         for path in repo.compositions.values():
             mzcompose_path = path / "mzcompose"

--- a/play/mbta/mzcompose
+++ b/play/mbta/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../bin/mzcompose" "$@"
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/play/wikirecent/mzcompose
+++ b/play/wikirecent/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../bin/mzcompose" "$@"
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/aws-config/mzcompose
+++ b/test/aws-config/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../bin/mzcompose" "$@"
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/catalog-compat/mzcompose
+++ b/test/catalog-compat/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../bin/mzcompose" "$@"
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/cluster/mzcompose
+++ b/test/cluster/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../bin/mzcompose" "$@"
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/debezium/mzcompose
+++ b/test/debezium/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../bin/mzcompose" "$@"
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/kafka-exactly-once/mzcompose
+++ b/test/kafka-exactly-once/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../bin/mzcompose" "$@"
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/kafka-ingest-open-loop/mzcompose
+++ b/test/kafka-ingest-open-loop/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../bin/mzcompose" "$@"
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/kafka-krb5/mzcompose
+++ b/test/kafka-krb5/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../bin/mzcompose" "$@"
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/kafka-matrix/mzcompose
+++ b/test/kafka-matrix/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../bin/mzcompose" "$@"
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/kafka-multi-broker/mzcompose
+++ b/test/kafka-multi-broker/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../bin/mzcompose" "$@"
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/kafka-resumption/mzcompose
+++ b/test/kafka-resumption/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../bin/mzcompose" "$@"
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/kafka-sasl-plain/mzcompose
+++ b/test/kafka-sasl-plain/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../bin/mzcompose" "$@"
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/kafka-ssl/mzcompose
+++ b/test/kafka-ssl/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../bin/mzcompose" "$@"
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/lang/csharp/mzcompose
+++ b/test/lang/csharp/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../../bin/mzcompose" "$@"
+exec "$(dirname "$0")"/../../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/lang/java/mzcompose
+++ b/test/lang/java/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../../bin/mzcompose" "$@"
+exec "$(dirname "$0")"/../../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/lang/js/mzcompose
+++ b/test/lang/js/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../../bin/mzcompose" "$@"
+exec "$(dirname "$0")"/../../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/lang/python/mzcompose
+++ b/test/lang/python/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../../bin/mzcompose" "$@"
+exec "$(dirname "$0")"/../../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/limits/mzcompose
+++ b/test/limits/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../bin/mzcompose" "$@"
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/metabase/mzcompose
+++ b/test/metabase/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../bin/mzcompose" "$@"
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/mzcompose_examples/mzcompose
+++ b/test/mzcompose_examples/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../bin/mzcompose" "$@"
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/perf-kinesis/mzcompose
+++ b/test/perf-kinesis/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../bin/mzcompose" "$@"
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/persistence/mzcompose
+++ b/test/persistence/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../bin/mzcompose" "$@"
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/pg-cdc-resumption/mzcompose
+++ b/test/pg-cdc-resumption/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../bin/mzcompose" "$@"
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/pg-cdc/mzcompose
+++ b/test/pg-cdc/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../bin/mzcompose" "$@"
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/proxy/mzcompose
+++ b/test/proxy/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../bin/mzcompose" "$@"
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/restart/mzcompose
+++ b/test/restart/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../bin/mzcompose" "$@"
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/s3-resumption/mzcompose
+++ b/test/s3-resumption/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../bin/mzcompose" "$@"
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/sqllogictest/mzcompose
+++ b/test/sqllogictest/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../bin/mzcompose" "$@"
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/testdrive/mzcompose
+++ b/test/testdrive/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../bin/mzcompose" "$@"
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/upgrade/mzcompose
+++ b/test/upgrade/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../bin/mzcompose" "$@"
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"


### PR DESCRIPTION
It turns out #10527 broke use of the `--dev` option to `mzcompose` to
mean "build in dev mode rather than release mode". Revert that part of
the commit. Instead, teach `bin/mzcompose` to always install dev deps
when invoked from the root. We don't tell users about `bin/mzcompose`,
so they'll continue to get the reduced set of deps when running
mzcompose from a directory locally.

@philip-stoev FYI. Gonna automerge to fix `--dev` builds for folks.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
