### PR TITLE
ci/test: fix test analysis from failing when no jobs

### DIFF
--- a/ci/test/mkpipeline.py
+++ b/ci/test/mkpipeline.py
@@ -72,6 +72,11 @@ def main() -> int:
         print("--- Trimming unchanged steps from pipeline")
         trim_pipeline(pipeline)
 
+    # Upload a dummy JUnit report so that the "Analyze tests" step doesn't fail
+    # if we trim away all the JUnit report-generating steps.
+    Path("junit-dummy.xml").write_text("")
+    spawn.runv(["buildkite-agent", "artifact", "upload", "junit-dummy.xml"])
+
     # Remove the Materialize-specific keys from the configuration that are
     # only used to inform how to trim the pipeline.
     for step in pipeline["steps"]:


### PR DESCRIPTION
Prevent the test analysis job from failing when no test jobs are run.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
