### PR TITLE
deps: move junit-xml to requirements.txt

### DIFF
--- a/ci/builder/requirements-dev.txt
+++ b/ci/builder/requirements-dev.txt
@@ -12,7 +12,6 @@ docker==5.0.3
 ec2instanceconnectcli==1.0.2
 flake8==4.0.1
 isort==5.10.1
-junit-xml==1.9
 mypy==0.931
 numpy==1.22.2
 pandas==1.4.1

--- a/ci/builder/requirements.txt
+++ b/ci/builder/requirements.txt
@@ -7,6 +7,7 @@
 click==8.0.3
 colored==1.4.3
 humanize==4.0.0
+junit-xml==1.9
 pg8000==1.24.0
 prettytable==3.1.0
 PyMySQL==1.0.2


### PR DESCRIPTION
It's used by mzcompose, so it needs to be part of the main
requirements.txt.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
