### PR TITLE
test,testdrive: Add a Nightly testdrive run with $ kafka-create-topic…

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -27,6 +27,7 @@ steps:
           - { value: cluster-testdrive }
           - { value: proxy }
           - { value: testdrive-workers-1 }
+          - { value: testdrive-partitions-5 }
           - { value: persistence-testdrive }
           - { value: feature-benchmark }
           - { value: feature-benchmark-persistence }
@@ -114,6 +115,15 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: testdrive
           args: [--aws-region=us-east-2, --workers=1]
+
+  - id: testdrive-partitions-5
+    label: ":racing_car: testdrive with --kafka-default-partitions 5"
+    timeout_in_minutes: 30
+    plugins:
+      - ./ci/plugins/scratch-aws-access: ~
+      - ./ci/plugins/mzcompose:
+          composition: testdrive
+          args: [--aws-region=us-east-2, --kafka-default-partitions=5]
 
   - id: persistence-testdrive
     label: ":racing_car: testdrive with --persistent-user-tables"

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -529,6 +529,7 @@ class Testdrive(Service):
         mzbuild: str = "testdrive",
         materialized_url: str = "postgres://materialize@materialized:6875",
         kafka_url: str = "kafka:9092",
+        kafka_default_partitions: Optional[int] = None,
         no_reset: bool = False,
         default_timeout: str = "30s",
         seed: Optional[int] = None,
@@ -579,6 +580,9 @@ class Testdrive(Service):
             entrypoint.append("--no-reset")
 
         entrypoint.append(f"--default-timeout={default_timeout}")
+
+        if kafka_default_partitions:
+            entrypoint.append(f"--kafka-default-partitions={kafka_default_partitions}")
 
         if forward_buildkite_shard:
             shard = os.environ.get("BUILDKITE_PARALLEL_JOB")

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -100,6 +100,8 @@ pub struct Config {
     // === Confluent options. ===
     /// The address of the Kafka broker that testdrive will interact with.
     pub kafka_addr: String,
+    /// Default number of partitions to use for topics
+    pub kafka_default_partitions: usize,
     /// Arbitrary rdkafka options for testdrive to use when connecting to the
     /// Kafka broker.
     pub kafka_opts: Vec<(String, String)>,
@@ -152,6 +154,7 @@ pub struct State {
     kafka_admin: rdkafka::admin::AdminClient<MzClientContext>,
     kafka_admin_opts: rdkafka::admin::AdminOptions,
     kafka_config: ClientConfig,
+    kafka_default_partitions: usize,
     kafka_producer: rdkafka::producer::FutureProducer<MzClientContext>,
     kafka_topics: HashMap<String, usize>,
 
@@ -787,6 +790,7 @@ pub async fn create_state(
         kafka_admin,
         kafka_admin_opts,
         kafka_config,
+        kafka_default_partitions: config.kafka_default_partitions,
         kafka_producer,
         kafka_topics,
 

--- a/src/testdrive/src/bin/testdrive.rs
+++ b/src/testdrive/src/bin/testdrive.rs
@@ -122,6 +122,9 @@ struct Args {
         default_value = "localhost:9092"
     )]
     kafka_addr: String,
+    /// Default number of partitions to create for topics
+    #[clap(long, default_value = "1", value_name = "N")]
+    kafka_default_partitions: usize,
     /// Arbitrary rdkafka options for testdrive to use when connecting to the
     /// Kafka broker.
     #[clap(long, value_name = "KEY=VAL", parse(from_str = parse_kafka_opt))]
@@ -252,6 +255,7 @@ async fn main() {
 
         // === Confluent options. ===
         kafka_addr: args.kafka_addr,
+        kafka_default_partitions: args.kafka_default_partitions,
         kafka_opts: args.kafka_option,
         schema_registry_url: args.schema_registry_url,
         cert_path: args.cert,

--- a/test/testdrive/bytes.td
+++ b/test/testdrive/bytes.td
@@ -9,7 +9,7 @@
 
 # Test ingestion of and selection from a simple bytes-formatted topic.
 
-$ kafka-create-topic topic=bytes
+$ kafka-create-topic topic=bytes partitions=1
 
 $ kafka-ingest format=bytes topic=bytes timestamp=1
 ©1

--- a/test/testdrive/kafka-avro-sources.td
+++ b/test/testdrive/kafka-avro-sources.td
@@ -113,7 +113,7 @@ $ set schema={
     ]
   }
 
-$ kafka-create-topic topic=data
+$ kafka-create-topic topic=data partitions=1
 
 $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
 {"before": null, "after": {"row": {"a": 1, "b": 1, "json": "null", "c": "True", "d": "False", "e": {"nested_data_1": {"n1_a": 42, "n1_b": {"double": 86.5}}}, "f": null}}, "source": {"file": "binlog", "pos": 0, "row": 0, "snapshot": {"boolean": false}}, "transaction": {"total_order": null}}
@@ -223,7 +223,7 @@ $ set non-dbz-schema={
     ]
   }
 
-$ kafka-create-topic topic=non-dbz-data
+$ kafka-create-topic topic=non-dbz-data partitions=1
 
 $ kafka-ingest format=avro topic=non-dbz-data schema=${non-dbz-schema} timestamp=1
 {"a": 1, "b": 2}
@@ -477,7 +477,7 @@ $ set new-dbz-schema={
     ]
   }
 
-$ kafka-create-topic topic=new-dbz-data
+$ kafka-create-topic topic=new-dbz-data partitions=1
 
 # We don't do anything sensible yet for snapshot "true" or "last", so just test that those are ingested.
 
@@ -747,7 +747,7 @@ $ set pg-dbz-schema={
     ]
   }
 
-$ kafka-create-topic topic=pg-dbz-data
+$ kafka-create-topic topic=pg-dbz-data partitions=1
 
 # The third and fourth records will be skipped, since `(lsn, total_order)` has gone backwards.
 $ kafka-ingest format=avro topic=pg-dbz-data schema=${pg-dbz-schema} timestamp=1

--- a/test/testdrive/kafka-data-formats.td
+++ b/test/testdrive/kafka-data-formats.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ kafka-create-topic topic=input_csv
+$ kafka-create-topic topic=input_csv partitions=1
 $ kafka-create-topic topic=input_csv_partitioned partitions=2
 $ kafka-create-topic topic=input_proto
 

--- a/test/testdrive/kafka-include-key-sources.td
+++ b/test/testdrive/kafka-include-key-sources.td
@@ -24,7 +24,7 @@ $ set schema={
     ]
   }
 
-$ kafka-create-topic topic=avro-data
+$ kafka-create-topic topic=avro-data partitions=1
 $ kafka-ingest format=avro key-format=avro topic=avro-data key-schema=${conflictkeyschema} schema=${schema} timestamp=1
 {"id": 1} {"id": 2, "b": 3}
 
@@ -173,7 +173,7 @@ named_id named_geo a
 contains:Cannot use INCLUDE KEY with ENVELOPE DEBEZIUM: Debezium values include all keys.
 
 # formats: TEXT and REGEX
-$ kafka-create-topic topic=textsrc
+$ kafka-create-topic topic=textsrc partitions=1
 
 $ kafka-ingest topic=textsrc format=bytes key-format=bytes key-terminator=:
 one,1:horse,apple

--- a/test/testdrive/kafka-upsert-debezium-sources.td
+++ b/test/testdrive/kafka-upsert-debezium-sources.td
@@ -46,7 +46,7 @@ $ set schema={
     ]
   }
 
-$ kafka-create-topic topic=dbzupsert
+$ kafka-create-topic topic=dbzupsert partitions=1
 
 $ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} publish=true timestamp=1
 {"id": 1} {"before": {"row": {"id": 1, "creature": "fish"}}, "after": {"row": {"id": 1, "creature": "mudskipper"}}}

--- a/test/testdrive/kafka-upsert-sources-new-syntax.td
+++ b/test/testdrive/kafka-upsert-sources-new-syntax.td
@@ -95,7 +95,7 @@ fish          fish     1000
 birdmore      geese    56
 mämmalmore    moose    42
 
-$ kafka-create-topic topic=textbytes
+$ kafka-create-topic topic=textbytes partitions=1
 
 $ kafka-ingest format=bytes topic=textbytes key-format=bytes key-terminator=:
 fish:fish
@@ -176,7 +176,7 @@ message Test {
 
 $ protobuf-compile-descriptors inputs=test.proto output=test.pb
 
-$ kafka-create-topic topic=textproto
+$ kafka-create-topic topic=textproto partitions=1
 
 > CREATE MATERIALIZED SOURCE textproto
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-textproto-${testdrive.seed}'
@@ -232,7 +232,7 @@ mämmalmore  five   7
 bìrd1       six    8
 mammalmore  seven  10
 
-$ kafka-create-topic topic=nullkey
+$ kafka-create-topic topic=nullkey partitions=1
 
 # A null key should result in an error decoding that row but not a panic
 $ kafka-ingest format=bytes topic=nullkey key-format=bytes key-terminator=:
@@ -256,7 +256,7 @@ key0          text  mz_offset
 birdmore      geese 5
 mammalmore    moose 6
 
-$ kafka-create-topic topic=realtimeavroavro
+$ kafka-create-topic topic=realtimeavroavro partitions=1
 
 # test multi-field avro key
 $ set keyschema2={

--- a/test/testdrive/kafka-upsert-sources.td
+++ b/test/testdrive/kafka-upsert-sources.td
@@ -97,7 +97,7 @@ fish          fish     1000
 birdmore      geese    56
 mämmalmore    moose    42
 
-$ kafka-create-topic topic=textbytes
+$ kafka-create-topic topic=textbytes partitions=1
 
 $ kafka-ingest format=bytes topic=textbytes key-format=bytes key-terminator=:
 fish:fish
@@ -178,7 +178,7 @@ message Test {
 
 $ protobuf-compile-descriptors inputs=test.proto output=test.pb
 
-$ kafka-create-topic topic=textproto
+$ kafka-create-topic topic=textproto partitions=1
 
 > CREATE MATERIALIZED SOURCE textproto
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
@@ -234,7 +234,7 @@ mämmalmore  five   7
 bìrd1       six    8
 mammalmore  seven  10
 
-$ kafka-create-topic topic=nullkey
+$ kafka-create-topic topic=nullkey partitions=1
 
 # A null key should result in an error decoding that row but not a panic
 $ kafka-ingest format=bytes topic=nullkey key-format=bytes key-terminator=:
@@ -257,7 +257,7 @@ key0          text  mz_offset
 birdmore      geese 5
 mammalmore    moose 6
 
-$ kafka-create-topic topic=realtimeavroavro
+$ kafka-create-topic topic=realtimeavroavro partitions=1
 
 # test multi-field avro key
 $ set keyschema2={

--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -51,6 +51,12 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         help="set the number of materialized dataflow workers",
     )
     parser.add_argument(
+        "--kafka-default-partitions",
+        type=int,
+        metavar="N",
+        help="set the default number of kafka partitions per topic",
+    )
+    parser.add_argument(
         "--persistent-user-tables",
         action="store_true",
         help="enable the --persistent-user-tables materialized option",
@@ -83,6 +89,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     testdrive = Testdrive(
         forward_buildkite_shard=True,
+        kafka_default_partitions=args.kafka_default_partitions,
         entrypoint_extra=[f"--aws-region={args.aws_region}"]
         if args.aws_region
         else ["--aws-endpoint=http://localstack:4566"],

--- a/test/testdrive/zstd-kafka-compression.td
+++ b/test/testdrive/zstd-kafka-compression.td
@@ -9,7 +9,7 @@
 
 # Test support for zstd compressed Kafka topics.
 
-$ kafka-create-topic topic=zstd compression=zstd
+$ kafka-create-topic topic=zstd compression=zstd partitions=1
 
 $ kafka-ingest format=bytes topic=zstd timestamp=1
 hello


### PR DESCRIPTION
… partitions=5

To that effect:
- add an argument to testdrive that allows the default partition count
  to be specified
- add an argument to test/testdrive/mzcompose.py that allows the default
  partition count to be specified
- add a Nightly job that uses the above functionality
- fix tests that use mz_offset and other partitioning-sensitive tests
  to explicitly use partitions=1 in $ kafka-create-topic

The number 5 was chosen to be higher than the default --workers 4 so that
the same worker will end up responsible for multiple partitions.

### Motivation

  * This PR adds a feature that has not yet been specified.

We do not have nearly as many tests over partitioning topics as we should given
the importance and complexity of handling partitioned topics correctly. Attempt to score
an easy win by running the existing tests with 5 partitions by default.