### PR TITLE
mkrelease: Set git-ref var in dashboard-links generated urls

### DIFF
--- a/misc/python/materialize/cli/mkrelease.py
+++ b/misc/python/materialize/cli/mkrelease.py
@@ -208,7 +208,7 @@ def dashboard_links(start_time: str, env: str) -> None:
     template = (
         "https://grafana.i.mtrlz.dev/d/materialize-overview/materialize-overview-load-tests?"
         + "orgId=1&from={time_from}&to={time_to}&var-test={test}&var-purpose={purpose}"
-        + "&var-env={env}"
+        + "&var-env={env}&var-git_ref={tag}"
     )
     purpose = "load_test"
 
@@ -220,7 +220,12 @@ def dashboard_links(start_time: str, env: str) -> None:
         "kafka-ingest-open-loop-persist",
     ):
         url = template.format(
-            time_from=time_from, time_to=time_to, test=test, purpose=purpose, env=env
+            time_from=time_from,
+            time_to=time_to,
+            test=test,
+            purpose=purpose,
+            env=env,
+            tag=tag,
         )
         tests.append((test, url))
 


### PR DESCRIPTION
This has two effects:

* If non-release load tests happen to be running at the same time, this should
  filter them out, making the release page cleaner.
* It also makes it clear in the UI, when comparing across versions (e.g. as
  part of the release process) which version you're looking at.

### Motivation

* This PR adds a feature that has not yet been specified.

### Checklist

- [n/a] This PR has adequate test coverage / QA involvement has been duly considered.
- [n/a] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).