### PR TITLE
Send WARNING instead of NOTICE when trying to commit with no active tx

### DIFF
--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -1095,10 +1095,10 @@ where
             }
             ExecuteResponse::TransactionExited { tag, was_implicit } => {
                 // In Postgres, if a user sends a COMMIT or ROLLBACK in an implicit
-                // transaction, a notice is sent warning them. (The transaction is still closed
+                // transaction, a warning is sent warning them. (The transaction is still closed
                 // and a new implicit transaction started, though.)
                 if was_implicit {
-                    let msg = ErrorResponse::notice(
+                    let msg = ErrorResponse::warning(
                         SqlState::NO_ACTIVE_SQL_TRANSACTION,
                         "there is no transaction in progress",
                     );

--- a/test/pgtest/transactions.pt
+++ b/test/pgtest/transactions.pt
@@ -145,7 +145,7 @@ Query {"query": "COMMIT;"}
 Query {"query": "ROLLBACK;"}
 ----
 
-until
+until err_field_typs=SCM
 ReadyForQuery
 ReadyForQuery
 ReadyForQuery
@@ -154,7 +154,7 @@ ReadyForQuery
 RowDescription {"fields":[{"name":"?column?"}]}
 DataRow {"fields":["1"]}
 CommandComplete {"tag":"SELECT 1"}
-NoticeResponse {"fields":[{"typ":"C","value":"25P01"},{"typ":"M","value":"there is no transaction in progress"}]}
+NoticeResponse {"fields":[{"typ":"S","value":"WARNING"},{"typ":"C","value":"25P01"},{"typ":"M","value":"there is no transaction in progress"}]}
 CommandComplete {"tag":"COMMIT"}
 RowDescription {"fields":[{"name":"?column?"}]}
 DataRow {"fields":["2"]}
@@ -163,16 +163,16 @@ ReadyForQuery {"status":"I"}
 RowDescription {"fields":[{"name":"?column?"}]}
 DataRow {"fields":["3"]}
 CommandComplete {"tag":"SELECT 1"}
-NoticeResponse {"fields":[{"typ":"C","value":"25P01"},{"typ":"M","value":"there is no transaction in progress"}]}
+NoticeResponse {"fields":[{"typ":"S","value":"WARNING"},{"typ":"C","value":"25P01"},{"typ":"M","value":"there is no transaction in progress"}]}
 CommandComplete {"tag":"ROLLBACK"}
 RowDescription {"fields":[{"name":"?column?"}]}
 DataRow {"fields":["4"]}
 CommandComplete {"tag":"SELECT 1"}
 ReadyForQuery {"status":"I"}
-NoticeResponse {"fields":[{"typ":"C","value":"25P01"},{"typ":"M","value":"there is no transaction in progress"}]}
+NoticeResponse {"fields":[{"typ":"S","value":"WARNING"},{"typ":"C","value":"25P01"},{"typ":"M","value":"there is no transaction in progress"}]}
 CommandComplete {"tag":"COMMIT"}
 ReadyForQuery {"status":"I"}
-NoticeResponse {"fields":[{"typ":"C","value":"25P01"},{"typ":"M","value":"there is no transaction in progress"}]}
+NoticeResponse {"fields":[{"typ":"S","value":"WARNING"},{"typ":"C","value":"25P01"},{"typ":"M","value":"there is no transaction in progress"}]}
 CommandComplete {"tag":"ROLLBACK"}
 ReadyForQuery {"status":"I"}
 


### PR DESCRIPTION
Postgres sends a WARNING in this case instead of a NOTICE.


### Motivation

  * This PR fixes a previously unreported bug wrt. different behavior from Postgres.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
