### PR TITLE
dbt-materialize: release v1.0.1.post1

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -1,6 +1,6 @@
 # dbt-materialize Changelog
 
-## Unreleased
+## 1.0.1.post1 - 2021-02-14
 
 * Disable transactions. This avoids errors of the form "CREATE ... must be
   executed outside of a transaction block" ([materialize-dbt-utils#11]).

--- a/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version = "1.0.1"
+version = "1.0.1.post1"

--- a/misc/dbt-materialize/setup.py
+++ b/misc/dbt-materialize/setup.py
@@ -26,7 +26,7 @@ setup(
     # dbt-postgres version, change version_suffix to ".post1", ".post2", etc.
     #
     # If you bump this version, bump it in __version__.py too.
-    version="1.0.1",
+    version="1.0.1.post1",
     description="The Materialize adapter plugin for dbt (data build tool).",
     long_description=(Path(__file__).parent / "README.md").open().read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Cut a new release of dbt-materialize with several bug fixes that will
allow us to enable almost all the macros in materialize-dbt-utils. See
the changelog for details.


### Motivation

* New dbt-materialize release with several bug fixes for the hack day.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
