### PR TITLE
skip ssl test for versions it can't be run for

### DIFF
--- a/test/upgrade/check-ssl-from-v0.16.0-ssl.td
+++ b/test/upgrade/check-ssl-from-v0.16.0-ssl.td
@@ -7,6 +7,11 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+# this can't be run if the version is > 19, as v20 is when the behavior changed, requiring the migration
+# this test is checking
+$ skip-if
+select split_part(ltrim('${arg.upgrade-from-version}', 'v'), '.', 1)::int = 0 and split_part(ltrim('${arg.upgrade-from-version}', 'v'), '.', 2)::int > 19;
+
 > SELECT * FROM data
 a
 ---

--- a/test/upgrade/create-ssl-in-v0.16.0-ssl.td
+++ b/test/upgrade/create-ssl-in-v0.16.0-ssl.td
@@ -7,6 +7,11 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+# this can't be run if the version is > 19, as v20 is when the behavior changed, requiring the migration
+# this test is checking
+$ skip-if
+select split_part(ltrim('${arg.upgrade-from-version}', 'v'), '.', 1)::int = 0 and split_part(ltrim('${arg.upgrade-from-version}', 'v'), '.', 2)::int > 19;
+
 $ set schema={
     "type": "record",
     "name": "envelope",


### PR DESCRIPTION
this was missed in the original pr, this code is not runnable past v19, as its specifically testing a migration for a newly changed behavior

the skip if does some nice parsing to try to be as general as possible

### Motivation

  * This PR fixes a previously unreported bug.

    test broken on main

