### PR TITLE
add bin/unused-deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2321,9 +2321,9 @@ dependencies = [
 
 [[package]]
 name = "inotify-sys"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4563555856585ab3180a5bf0b2f9f8d301a728462afffc8195b3f5394229c55"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
 ]
@@ -2934,7 +2934,6 @@ dependencies = [
  "aws-smithy-http",
  "aws-types",
  "mz-http-proxy",
- "openssl-sys",
 ]
 
 [[package]]
@@ -3166,7 +3165,6 @@ dependencies = [
  "mz-interchange",
  "mz-kafka-util",
  "mz-ore",
- "mz-persist",
  "mz-persist-types",
  "mz-repr",
  "num_enum",
@@ -3441,7 +3439,6 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
- "crossbeam-utils",
  "ctor",
  "either",
  "futures",
@@ -3742,7 +3739,6 @@ dependencies = [
  "mz-sql-parser",
  "postgres-protocol",
  "postgres-types",
- "prost-build",
  "protobuf-native",
  "rdkafka",
  "regex",
@@ -3766,7 +3762,6 @@ dependencies = [
  "anyhow",
  "datadriven",
  "enum-kinds",
- "hex",
  "itertools",
  "lazy_static",
  "mz-ore",
@@ -3882,7 +3877,6 @@ dependencies = [
  "postgres_array",
  "predicates",
  "prost",
- "prost-build",
  "prost-reflect",
  "protobuf-src",
  "rand",

--- a/bin/unused-deps
+++ b/bin/unused-deps
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# san — prints (possible) unused dependencies for all members of the workspace
+#
+# Example usages:
+#
+#     $ bin/unused-deps
+
+# Requires https://github.com/est31/cargo-udeps and a (working) nightly toolchain
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+. misc/shlib/shlib.bash
+
+export RUSTUP_TOOLCHAIN=${RUSTUP_TOOLCHAIN:=nightly}
+cargo udeps --workspace --all-targets "$@"

--- a/src/aws-util/Cargo.toml
+++ b/src/aws-util/Cargo.toml
@@ -16,7 +16,6 @@ aws-smithy-client = { version = "0.36.0", default-features = false }
 aws-smithy-http = "0.36.0"
 aws-types = "0.6.0"
 mz-http-proxy = { path = "../http-proxy", features = ["hyper"] }
-openssl-sys = { version = "0.9.72", features = ["vendored"] }
 
 [features]
 kinesis = ["aws-sdk-kinesis"]

--- a/src/dataflow-types/Cargo.toml
+++ b/src/dataflow-types/Cargo.toml
@@ -28,7 +28,6 @@ mz-expr = { path = "../expr" }
 mz-interchange = { path = "../interchange" }
 mz-kafka-util = { path = "../kafka-util" }
 mz-ore = { path = "../ore" }
-mz-persist = { path = "../persist" }
 mz-persist-types = { path = "../persist-types" }
 mz-repr = { path = "../repr" }
 num_enum = "0.5.6"

--- a/src/dataflow/Cargo.toml
+++ b/src/dataflow/Cargo.toml
@@ -66,3 +66,7 @@ uuid = { version = "0.8.2", features = ["serde", "v4"] }
 
 [build-dependencies]
 prost-build = "0.9.1"
+
+[package.metadata.cargo-udeps.ignore]
+# only used on linux
+normal = ["inotify"]

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -139,3 +139,6 @@ walkdir = "2.3.2"
 # access to the file system.
 dev-web = []
 tokio-console = ["console-subscriber", "tokio/tracing"]
+
+[package.metadata.cargo-udeps.ignore]
+normal = ["krb5-src"]

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -42,7 +42,6 @@ tokio-openssl = { version = "0.6.3", optional = true }
 tracing-subscriber = { version = "0.3.7", default-features = false, features = ["env-filter", "fmt", "tracing-log"], optional = true }
 
 [dev-dependencies]
-crossbeam-utils = "0.8.7"
 tokio = { version = "1.16.1", features = ["macros"] }
 
 [features]

--- a/src/sql-parser/Cargo.toml
+++ b/src/sql-parser/Cargo.toml
@@ -9,7 +9,6 @@ publish = false
 
 [dependencies]
 enum-kinds = "0.5.1"
-hex = "0.4.3"
 itertools = "0.10.3"
 lazy_static = "1.4.0"
 mz-ore = { path = "../ore", default-features = false, features = ["stack"] }

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -32,7 +32,6 @@ mz-repr = { path = "../repr" }
 mz-sql-parser = { path = "../sql-parser" }
 postgres-protocol = { git = "https://github.com/MaterializeInc/rust-postgres", branch = "mz-0.7.2" }
 postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres", branch = "mz-0.7.2", features = ["with-chrono-0_4", "with-uuid-0_8"] }
-prost-build = "0.9.1"
 protobuf-native = "0.2.1"
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "gssapi-vendored", "libz-static"] }
 regex = "1.5.4"

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -45,7 +45,6 @@ mz-sql = { path = "../sql" }
 mz-sql-parser = { path = "../sql-parser" }
 postgres_array = { git = "https://github.com/MaterializeInc/rust-postgres-array", branch = "mz-0.7.2" }
 prost = "0.9.0"
-prost-build = "0.9.1"
 prost-reflect = { version = "0.5.6", features = ["serde"] }
 protobuf-src = "1.0.4"
 rand = "0.8.4"
@@ -70,3 +69,6 @@ walkdir = "2.3.2"
 [dev-dependencies]
 assert_cmd = "2.0.4"
 predicates = "2.1.1"
+
+[package.metadata.cargo-udeps.ignore]
+normal = ["krb5-src"]


### PR DESCRIPTION

### Motivation

I want to be able to make new crates by copying other crates, and easily slimming down the deps to the ones I want. this helps me.


### Tips for reviewer

`cargo-udeps` is not a great ui, but it does work, uses cargo internally, and seems to be safe/trustworthy: https://github.com/est31/cargo-udeps

I would not consider it stable enough (or nightly stable enough) to add to ci, but in the future `ci-builder` will make it easy

locally, it can be instantiated as:
```
RUSTUP_TOOLCHAIN=nightly-2021-11-29 bin/unused-deps
```

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
