### PR TITLE
QGM: Lower outer join boxes

### DIFF
--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -1501,6 +1501,7 @@ impl AggregateExpr {
     }
 }
 
+// TODO: move this to the `mz_expr` crate.
 /// If the on clause of an outer join is an equijoin, figure out the join keys.
 ///
 /// `oa`, `la`, and `ra` are the arities of `outer`, the lhs, and the rhs
@@ -1512,6 +1513,10 @@ pub(crate) fn derive_equijoin_cols(
     on: Vec<mz_expr::MirScalarExpr>,
 ) -> Option<(Vec<usize>, Vec<usize>)> {
     use mz_expr::BinaryFunc;
+    // TODO: Replace this predicate deconstruction with
+    // `mz_expr::canonicalize::canonicalize_predicates`, which will also enable
+    // treating select * from lhs left join rhs on lhs.id = rhs.id and true as
+    // an equijoin.
     // Deconstruct predicates that may be ands of multiple conditions.
     let mut predicates = Vec::new();
     let mut todo = on;

--- a/src/sql/src/query_model/mir.rs
+++ b/src/sql/src/query_model/mir.rs
@@ -254,12 +254,18 @@ impl<'a> Lowerer<'a> {
 
                         // 2) Lower the predicates as a filter following the
                         //    join.
-                        inner_join = inner_join.filter(
-                            box_struct
-                                .predicates
-                                .iter()
-                                .map(|p| Self::lower_expression(p, &column_map)),
+                        let lowered_predicates = box_struct
+                            .predicates
+                            .iter()
+                            .map(|p| Self::lower_expression(p, &column_map))
+                            .collect_vec();
+                        let equijoin_keys = crate::plan::lowering::derive_equijoin_cols(
+                            oa,
+                            la,
+                            ra,
+                            lowered_predicates.clone(),
                         );
+                        inner_join = inner_join.filter(lowered_predicates.into_iter());
 
                         // 3) Calculate preserved rows
                         // This corresponds to the general join case in lowering.rs

--- a/src/sql/src/query_model/model/graph.rs
+++ b/src/sql/src/query_model/model/graph.rs
@@ -638,6 +638,18 @@ impl QueryBox {
         }
     }
 
+    /// Returns a vector of [`ColumnReference`] if all column expressions projected
+    /// by this [`QueryBox`] of that form.
+    pub fn columns_as_refs(&self) -> Option<Vec<&ColumnReference>> {
+        self.columns
+            .iter()
+            .map(|c| match &c.expr {
+                BoxScalarExpr::ColumnReference(cr) => Some(cr),
+                _ => None,
+            })
+            .collect::<Option<Vec<_>>>()
+    }
+
     /// Visit all the expressions in this query box.
     pub fn visit_expressions<F, E>(&self, f: &mut F) -> Result<(), E>
     where

--- a/src/sql/tests/querymodel/lowering
+++ b/src/sql/tests/querymodel/lowering
@@ -658,3 +658,171 @@ select * from x full join y on x.a > y.b
 | Project (#5..#9)
 ----
 ----
+
+lower
+select x.a, x.b, y.a from x right join y on x.a = y.b and x.c = y.a
+----
+----
+%0 = Let l0 =
+| Constant ()
+
+%1 =
+| Get ? (u0)
+
+%2 = Let l1 =
+| Join %0 %1
+| | implementation = Unimplemented
+
+%3 =
+| Get ? (u1)
+
+%4 = Let l2 =
+| Join %0 %3
+| | implementation = Unimplemented
+
+%5 = Let l3 =
+| Join %2 %4
+| | implementation = Unimplemented
+| Project (#0..#4)
+| Filter ((#0 = #4) && (#2 = #3))
+
+%6 = Let l4 =
+| Get %5 (l3)
+| Project (#2, #0)
+| Distinct group=(#0, #1)
+
+%7 =
+| Join %4 %6 (= #0 #2) (= #1 #3)
+| | implementation = Unimplemented
+| Project (#0, #1)
+| Negate
+
+%8 =
+| Union %7 %4
+| Map null, null, null
+| Project (#2..#4, #0, #1)
+
+%9 =
+| Union %8 %5
+| Map #0, #1, #2, #3, #4
+| Project (#5..#9)
+| Map #0, #1, #3
+| Project (#5..#7)
+----
+----
+
+lower
+select * from x left join y on x.a = y.b
+----
+----
+%0 = Let l0 =
+| Constant ()
+
+%1 =
+| Get ? (u0)
+
+%2 = Let l1 =
+| Join %0 %1
+| | implementation = Unimplemented
+
+%3 =
+| Get ? (u1)
+
+%4 = Let l2 =
+| Join %0 %3
+| | implementation = Unimplemented
+
+%5 = Let l3 =
+| Join %2 %4
+| | implementation = Unimplemented
+| Project (#0..#4)
+| Filter (#0 = #4)
+
+%6 = Let l4 =
+| Get %5 (l3)
+| Project (#0)
+| Distinct group=(#0)
+
+%7 =
+| Join %2 %6 (= #0 #3)
+| | implementation = Unimplemented
+| Project (#0..#2)
+| Negate
+
+%8 =
+| Union %7 %2
+| Map null, null
+
+%9 =
+| Union %8 %5
+| Map #0, #1, #2, #3, #4
+| Project (#5..#9)
+| Map #0, #1, #2, #3, #4
+| Project (#5..#9)
+----
+----
+
+end_to_end
+select * from x full outer join y on x.a = y.b
+----
+----
+%0 = Let l0 =
+| Constant ()
+
+%1 =
+| Get ? (u0)
+
+%2 = Let l1 =
+| Join %0 %1
+| | implementation = Unimplemented
+
+%3 =
+| Get ? (u1)
+
+%4 = Let l2 =
+| Join %0 %3
+| | implementation = Unimplemented
+
+%5 = Let l3 =
+| Join %2 %4
+| | implementation = Unimplemented
+| Project (#0..#4)
+| Filter (#0 = #4)
+
+%6 = Let l4 =
+| Get %5 (l3)
+| Project (#0)
+| Distinct group=(#0)
+
+%7 =
+| Join %4 %6 (= #1 #2)
+| | implementation = Unimplemented
+| Project (#0, #1)
+| Negate
+
+%8 =
+| Union %7 %4
+| Map null, null, null
+| Project (#2..#4, #0, #1)
+
+%9 =
+| Join %2 %6 (= #0 #3)
+| | implementation = Unimplemented
+| Project (#0..#2)
+| Negate
+
+%10 =
+| Union %9 %2
+| Map null, null
+
+%11 =
+| Union %10 %5
+
+%12 =
+| Union %8 %11
+| Map #0, #1, #2, #3, #4
+| Project (#5..#9)
+| Map #0, #1, #2, #3, #4
+| Project (#5..#9)
+----
+----

--- a/src/sql/tests/querymodel/lowering
+++ b/src/sql/tests/querymodel/lowering
@@ -164,6 +164,7 @@ from (select 10 as a, 5 as b, 'world' as c, 'realm' as d) x
 
 cat
 (defsource x ([(int32 false) int64 int32] [[0]]) [a b c])
+(defsource y ([(int32 false) int32] [[0]]) [a b])
 ----
 ok
 
@@ -444,5 +445,216 @@ select min(a), c, count(*), b, max(a) from x group by c, b;
 | Project (#0..=#4)
 | Map #2, #0, #3, #1, #4
 | Project (#5..=#9)
+----
+----
+
+lower
+select x.a, x.b, y.a from x left join y on x.a > y.b
+----
+----
+%0 = Let l0 =
+| Constant ()
+
+%1 =
+| Get ? (u0)
+
+%2 = Let l1 =
+| Join %0 %1
+| | implementation = Unimplemented
+
+%3 =
+| Get ? (u1)
+
+%4 = Let l2 =
+| Join %0 %3
+| | implementation = Unimplemented
+
+%5 = Let l3 =
+| Join %2 %4
+| | implementation = Unimplemented
+| Project (#0..#4)
+| Filter (#0 > #4)
+
+%6 =
+| Get %5 (l3)
+| Distinct group=(#0, #1, #2)
+| Negate
+
+%7 =
+| Get %2 (l1)
+| Distinct group=(#0, #1, #2)
+
+%8 =
+| Union %6 %7
+
+%9 =
+| Join %8 %2 (= #0 #3) (= #1 #4) (= #2 #5)
+| | implementation = Unimplemented
+| Project (#0..#2)
+
+%10 =
+| Constant (null, null)
+
+%11 =
+| Join %9 %10
+| | implementation = Unimplemented
+
+%12 =
+| Union %5 %11
+| Map #0, #1, #2, #3, #4
+| Project (#5..#9)
+| Map #0, #1, #3
+| Project (#5..#7)
+----
+----
+
+lower
+select * from x right join y on x.a > y.b
+----
+----
+%0 = Let l0 =
+| Constant ()
+
+%1 =
+| Get ? (u0)
+
+%2 = Let l1 =
+| Join %0 %1
+| | implementation = Unimplemented
+
+%3 =
+| Get ? (u1)
+
+%4 = Let l2 =
+| Join %0 %3
+| | implementation = Unimplemented
+
+%5 = Let l3 =
+| Join %2 %4
+| | implementation = Unimplemented
+| Project (#0..#4)
+| Filter (#0 > #4)
+
+%6 =
+| Get %5 (l3)
+| Project (#3, #4, #0..#2)
+| Distinct group=(#0, #1)
+| Negate
+
+%7 =
+| Get %4 (l2)
+| Distinct group=(#0, #1)
+
+%8 =
+| Union %6 %7
+
+%9 =
+| Join %8 %4 (= #0 #2) (= #1 #3)
+| | implementation = Unimplemented
+| Project (#0, #1)
+
+%10 =
+| Constant (null, null, null)
+
+%11 =
+| Join %9 %10
+| | implementation = Unimplemented
+| Project (#2..#4, #0, #1)
+
+%12 =
+| Union %5 %11
+| Map #0, #1, #2, #3, #4
+| Project (#5..#9)
+| Map #0, #1, #2, #3, #4
+| Project (#5..#9)
+----
+----
+
+lower
+select * from x full join y on x.a > y.b
+----
+----
+%0 = Let l0 =
+| Constant ()
+
+%1 =
+| Get ? (u0)
+
+%2 = Let l1 =
+| Join %0 %1
+| | implementation = Unimplemented
+
+%3 =
+| Get ? (u1)
+
+%4 = Let l2 =
+| Join %0 %3
+| | implementation = Unimplemented
+
+%5 = Let l3 =
+| Join %2 %4
+| | implementation = Unimplemented
+| Project (#0..#4)
+| Filter (#0 > #4)
+
+%6 =
+| Get %5 (l3)
+| Distinct group=(#0, #1, #2)
+| Negate
+
+%7 =
+| Get %2 (l1)
+| Distinct group=(#0, #1, #2)
+
+%8 =
+| Union %6 %7
+
+%9 =
+| Join %8 %2 (= #0 #3) (= #1 #4) (= #2 #5)
+| | implementation = Unimplemented
+| Project (#0..#2)
+
+%10 =
+| Constant (null, null)
+
+%11 =
+| Join %9 %10
+| | implementation = Unimplemented
+
+%12 =
+| Union %5 %11
+
+%13 =
+| Get %5 (l3)
+| Project (#3, #4, #0..#2)
+| Distinct group=(#0, #1)
+| Negate
+
+%14 =
+| Get %4 (l2)
+| Distinct group=(#0, #1)
+
+%15 =
+| Union %13 %14
+
+%16 =
+| Join %15 %4 (= #0 #2) (= #1 #3)
+| | implementation = Unimplemented
+| Project (#0, #1)
+
+%17 =
+| Constant (null, null, null)
+
+%18 =
+| Join %16 %17
+| | implementation = Unimplemented
+| Project (#2..#4, #0, #1)
+
+%19 =
+| Union %12 %18
+| Map #0, #1, #2, #3, #4
+| Project (#5..#9)
+| Map #0, #1, #2, #3, #4
+| Project (#5..#9)
 ----
 ----

--- a/src/sql/tests/querymodel/lowering
+++ b/src/sql/tests/querymodel/lowering
@@ -57,8 +57,7 @@ select a, a from (select 1 as a);
 | | implementation = Unimplemented
 | Map 1
 | Project (#0)
-| Map #0, #0
-| Project (#1, #2)
+| Project (#0, #0)
 ----
 ----
 
@@ -78,8 +77,7 @@ select a, b, a from (select 1 as a, 2 as b);
 | | implementation = Unimplemented
 | Map 1, 2
 | Project (#0, #1)
-| Map #0, #1, #0
-| Project (#2..=#4)
+| Project (#0, #1, #0)
 ----
 ----
 
@@ -113,10 +111,8 @@ select x.a from (select true as a) x join (select false as b) y on x.a;
 | | implementation = Unimplemented
 | Project (#0, #1)
 | Filter #0
-| Map #0, #1
-| Project (#2, #3)
-| Map #0
-| Project (#2)
+| Project (#0, #1)
+| Project (#0)
 ----
 ----
 
@@ -157,8 +153,7 @@ from (select 10 as a, 5 as b, 'world' as c, 'realm' as d) x
 | Project (#0..=#3)
 | Map #0, #1, #2, #3, if (#0 > #1) then {#2} else {lpad(#3, i32toi64(4), "ab")}
 | Project (#4..=#8)
-| Map #4
-| Project (#5)
+| Project (#4)
 ----
 ----
 
@@ -187,10 +182,7 @@ select * from x;
 | | implementation = Unimplemented
 | | types = (Int32, Int64?, Int32?)
 | | keys = ()
-| Map #0, #1, #2
-| | types = (Int32, Int64?, Int32?, Int32, Int64?, Int32?)
-| | keys = ()
-| Project (#3..=#5)
+| Project (#0..=#2)
 | | types = (Int32, Int64?, Int32?)
 | | keys = ()
 ----
@@ -219,16 +211,10 @@ c from x where x.b is not null) z on y.a = z.b
 | Filter (#0 = 0)
 | | types = (Int32, Int64?, Int32?)
 | | keys = ()
-| Map #0, #1, #2
-| | types = (Int32, Int64?, Int32?, Int32, Int64?, Int32?)
-| | keys = ()
-| Project (#3..=#5)
+| Project (#0..=#2)
 | | types = (Int32, Int64?, Int32?)
 | | keys = ()
-| Map #0, #2
-| | types = (Int32, Int64?, Int32?, Int32, Int32?)
-| | keys = ()
-| Project (#3, #4)
+| Project (#0, #2)
 | | types = (Int32, Int32?)
 | | keys = ()
 
@@ -245,16 +231,10 @@ c from x where x.b is not null) z on y.a = z.b
 | Filter !(isnull(#1))
 | | types = (Int32, Int64, Int32?)
 | | keys = ()
-| Map #0, #1, #2
-| | types = (Int32, Int64, Int32?, Int32, Int64, Int32?)
-| | keys = ()
-| Project (#3..=#5)
+| Project (#0..=#2)
 | | types = (Int32, Int64, Int32?)
 | | keys = ()
-| Map #1, #2
-| | types = (Int32, Int64, Int32?, Int64, Int32?)
-| | keys = ()
-| Project (#3, #4)
+| Project (#1, #2)
 | | types = (Int64, Int32?)
 | | keys = ()
 
@@ -269,16 +249,10 @@ c from x where x.b is not null) z on y.a = z.b
 | Filter (i32toi64(#0) = #2)
 | | types = (Int32, Int32?, Int64, Int32?)
 | | keys = ()
-| Map #0, #1, #2, #3
-| | types = (Int32, Int32?, Int64, Int32?, Int32, Int32?, Int64, Int32?)
-| | keys = ()
-| Project (#4..=#7)
+| Project (#0..=#3)
 | | types = (Int32, Int32?, Int64, Int32?)
 | | keys = ()
-| Map #1, #3
-| | types = (Int32, Int32?, Int64, Int32?, Int32?, Int32?)
-| | keys = ()
-| Project (#4, #5)
+| Project (#1, #3)
 | | types = (Int32?, Int32?)
 | | keys = ()
 ----
@@ -352,10 +326,8 @@ select a, b, a from (select 1 as a, 2 as b) where (select true);
 | | implementation = Unimplemented
 | Project (#0..=#2)
 | Filter #2
-| Map #0, #1
-| Project (#3, #4)
-| Map #0, #1, #0
-| Project (#2..=#4)
+| Project (#0, #1)
+| Project (#0, #1, #0)
 ----
 ----
 
@@ -372,8 +344,7 @@ select distinct c, b, a from x;
 %2 =
 | Join %0 %1
 | | implementation = Unimplemented
-| Map #2, #1, #0
-| Project (#3..=#5)
+| Project (#2, #1, #0)
 | Distinct group=(#0, #1, #2)
 ----
 ----
@@ -391,8 +362,7 @@ select distinct b from x;
 %2 =
 | Join %0 %1
 | | implementation = Unimplemented
-| Map #1
-| Project (#3)
+| Project (#1)
 | Distinct group=(#0)
 ----
 ----
@@ -410,14 +380,11 @@ select b from x group by c, b;
 %2 =
 | Join %0 %1
 | | implementation = Unimplemented
-| Map #0, #1, #2, #2, #1
-| Project (#3..=#7)
-| Map #3, #4
-| Project (#5, #6)
+| Project (#0..=#2, #2, #1)
+| Project (#3, #4)
 | Distinct group=(#0, #1)
 | Project (#0, #1)
-| Map #1
-| Project (#2)
+| Project (#1)
 ----
 ----
 
@@ -434,8 +401,7 @@ select min(a), c, count(*), b, max(a) from x group by c, b;
 %2 =
 | Join %0 %1
 | | implementation = Unimplemented
-| Map #0, #1, #2, #2, #1
-| Project (#3..=#7)
+| Project (#0..=#2, #2, #1)
 | Map #3, #4, #0, true
 | Project (#5..=#8)
 | Reduce group=(#0, #1)
@@ -443,8 +409,7 @@ select min(a), c, count(*), b, max(a) from x group by c, b;
 | | agg count(#3)
 | | agg max(#2)
 | Project (#0..=#4)
-| Map #2, #0, #3, #1, #4
-| Project (#5..=#9)
+| Project (#2, #0, #3, #1, #4)
 ----
 ----
 
@@ -472,7 +437,7 @@ select x.a, x.b, y.a from x left join y on x.a > y.b
 %5 = Let l3 =
 | Join %2 %4
 | | implementation = Unimplemented
-| Project (#0..#4)
+| Project (#0..=#4)
 | Filter (#0 > #4)
 
 %6 =
@@ -490,7 +455,7 @@ select x.a, x.b, y.a from x left join y on x.a > y.b
 %9 =
 | Join %8 %2 (= #0 #3) (= #1 #4) (= #2 #5)
 | | implementation = Unimplemented
-| Project (#0..#2)
+| Project (#0..=#2)
 
 %10 =
 | Constant (null, null)
@@ -501,10 +466,8 @@ select x.a, x.b, y.a from x left join y on x.a > y.b
 
 %12 =
 | Union %5 %11
-| Map #0, #1, #2, #3, #4
-| Project (#5..#9)
-| Map #0, #1, #3
-| Project (#5..#7)
+| Project (#0..=#4)
+| Project (#0, #1, #3)
 ----
 ----
 
@@ -532,12 +495,12 @@ select * from x right join y on x.a > y.b
 %5 = Let l3 =
 | Join %2 %4
 | | implementation = Unimplemented
-| Project (#0..#4)
+| Project (#0..=#4)
 | Filter (#0 > #4)
 
 %6 =
 | Get %5 (l3)
-| Project (#3, #4, #0..#2)
+| Project (#3, #4, #0..=#2)
 | Distinct group=(#0, #1)
 | Negate
 
@@ -559,14 +522,12 @@ select * from x right join y on x.a > y.b
 %11 =
 | Join %9 %10
 | | implementation = Unimplemented
-| Project (#2..#4, #0, #1)
+| Project (#2..=#4, #0, #1)
 
 %12 =
 | Union %5 %11
-| Map #0, #1, #2, #3, #4
-| Project (#5..#9)
-| Map #0, #1, #2, #3, #4
-| Project (#5..#9)
+| Project (#0..=#4)
+| Project (#0..=#4)
 ----
 ----
 
@@ -594,7 +555,7 @@ select * from x full join y on x.a > y.b
 %5 = Let l3 =
 | Join %2 %4
 | | implementation = Unimplemented
-| Project (#0..#4)
+| Project (#0..=#4)
 | Filter (#0 > #4)
 
 %6 =
@@ -612,7 +573,7 @@ select * from x full join y on x.a > y.b
 %9 =
 | Join %8 %2 (= #0 #3) (= #1 #4) (= #2 #5)
 | | implementation = Unimplemented
-| Project (#0..#2)
+| Project (#0..=#2)
 
 %10 =
 | Constant (null, null)
@@ -626,7 +587,7 @@ select * from x full join y on x.a > y.b
 
 %13 =
 | Get %5 (l3)
-| Project (#3, #4, #0..#2)
+| Project (#3, #4, #0..=#2)
 | Distinct group=(#0, #1)
 | Negate
 
@@ -648,14 +609,12 @@ select * from x full join y on x.a > y.b
 %18 =
 | Join %16 %17
 | | implementation = Unimplemented
-| Project (#2..#4, #0, #1)
+| Project (#2..=#4, #0, #1)
 
 %19 =
 | Union %12 %18
-| Map #0, #1, #2, #3, #4
-| Project (#5..#9)
-| Map #0, #1, #2, #3, #4
-| Project (#5..#9)
+| Project (#0..=#4)
+| Project (#0..=#4)
 ----
 ----
 
@@ -683,7 +642,7 @@ select x.a, x.b, y.a from x right join y on x.a = y.b and x.c = y.a
 %5 = Let l3 =
 | Join %2 %4
 | | implementation = Unimplemented
-| Project (#0..#4)
+| Project (#0..=#4)
 | Filter ((#0 = #4) && (#2 = #3))
 
 %6 = Let l4 =
@@ -700,14 +659,12 @@ select x.a, x.b, y.a from x right join y on x.a = y.b and x.c = y.a
 %8 =
 | Union %7 %4
 | Map null, null, null
-| Project (#2..#4, #0, #1)
+| Project (#2..=#4, #0, #1)
 
 %9 =
 | Union %8 %5
-| Map #0, #1, #2, #3, #4
-| Project (#5..#9)
-| Map #0, #1, #3
-| Project (#5..#7)
+| Project (#0..=#4)
+| Project (#0, #1, #3)
 ----
 ----
 
@@ -735,7 +692,7 @@ select * from x left join y on x.a = y.b
 %5 = Let l3 =
 | Join %2 %4
 | | implementation = Unimplemented
-| Project (#0..#4)
+| Project (#0..=#4)
 | Filter (#0 = #4)
 
 %6 = Let l4 =
@@ -746,7 +703,7 @@ select * from x left join y on x.a = y.b
 %7 =
 | Join %2 %6 (= #0 #3)
 | | implementation = Unimplemented
-| Project (#0..#2)
+| Project (#0..=#2)
 | Negate
 
 %8 =
@@ -755,10 +712,8 @@ select * from x left join y on x.a = y.b
 
 %9 =
 | Union %8 %5
-| Map #0, #1, #2, #3, #4
-| Project (#5..#9)
-| Map #0, #1, #2, #3, #4
-| Project (#5..#9)
+| Project (#0..=#4)
+| Project (#0..=#4)
 ----
 ----
 
@@ -786,7 +741,7 @@ select * from x full outer join y on x.a = y.b
 %5 = Let l3 =
 | Join %2 %4
 | | implementation = Unimplemented
-| Project (#0..#4)
+| Project (#0..=#4)
 | Filter (#0 = #4)
 
 %6 = Let l4 =
@@ -803,12 +758,12 @@ select * from x full outer join y on x.a = y.b
 %8 =
 | Union %7 %4
 | Map null, null, null
-| Project (#2..#4, #0, #1)
+| Project (#2..=#4, #0, #1)
 
 %9 =
 | Join %2 %6 (= #0 #3)
 | | implementation = Unimplemented
-| Project (#0..#2)
+| Project (#0..=#2)
 | Negate
 
 %10 =
@@ -820,9 +775,7 @@ select * from x full outer join y on x.a = y.b
 
 %12 =
 | Union %8 %11
-| Map #0, #1, #2, #3, #4
-| Project (#5..#9)
-| Map #0, #1, #2, #3, #4
-| Project (#5..#9)
+| Project (#0..=#4)
+| Project (#0..=#4)
 ----
 ----


### PR DESCRIPTION
Closes #9134.

### Tips for reviewer

The first commit is the same as #10752.
The second commit copies over general join lowering. 
The third commit separates out a common method to be shared between QGM equijoin lowering and HIR equijoin lowering.
The fourth commit 1) copies over equijoin lowering 2) attempts to refactor equijoin lowering into something more comprehensible. 

Originally, the last commit also attempted to canonicalize predicates before equijoin checking so that a predicate like `lhs.id = rhs.id and true` gets properly detected as a equijoin, but more investigation into the sqllogictest result changes is needed.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
