### PR TITLE
pgtest: error and docs improvements

### DIFF
--- a/doc/developer/guide-testing.md
+++ b/doc/developer/guide-testing.md
@@ -12,8 +12,8 @@ There are broadly three test suites:
      in the `tests/` directory within a crate.
 
   2. The data-driven **system test suite** in the top-level [test/](/test)
-     directory. These consist of text files in various DSLs (sqllogictest and
-     testdrive, at the moment) that essentially specify SQL commands to run and
+     directory. These consist of text files in various DSLs (sqllogictest,
+     testdrive, pgtest) that essentially specify SQL commands to run and
      their expected output.
 
   3. The long-running **performance and stability test suite**. This test suite
@@ -235,6 +235,16 @@ data type, like, say, `DATE`, the upstream CockroachDB sqllogictests will
 provide most of the coverage, but it's worth adding some (*very*) basic
 testdrive tests (e.g., `> SELECT DATE '1999-01-01'`) to ensure that our pgwire
 implementation is properly serializing dates.
+
+### pgtest
+
+Pgtest is DSL to specify raw pgwire messages to send and their expected
+responses. It can be used to test message sequences that are difficult
+or impossible to test with PostgreSQL drivers. Its output is generated
+against PostgreSQL and then tested against Materialize. Usage is
+documented at the [pgtest crate][pgtest-docs].
+
+[pgtest-docs]: https://dev.materialize.com/api/rust/mz_pgtest/index.html
 
 ## Long-running tests
 

--- a/src/pgcopy/src/copy.rs
+++ b/src/pgcopy/src/copy.rs
@@ -433,7 +433,7 @@ impl<'a> TryFrom<CopyParams> for CopyTextFormatParams<'a> {
         ) -> Result<(), CopyErrorNotSupportedResponse> {
             match option {
                 Some(..) => Err(CopyErrorNotSupportedResponse::new(format!(
-                    "COPY {} only available in CSV mode",
+                    "COPY {} available only in CSV mode",
                     param
                 ))),
                 None => Ok(()),
@@ -443,7 +443,7 @@ impl<'a> TryFrom<CopyParams> for CopyTextFormatParams<'a> {
         assert_eq!(format, CopyFormat::Text);
         only_available_with_csv(quote, "quote")?;
         only_available_with_csv(escape, "escape")?;
-        only_available_with_csv(header, "header")?;
+        only_available_with_csv(header, "HEADER")?;
         let null = match null {
             Some(null) => Cow::from(null),
             None => Cow::from("\\N"),

--- a/src/pgtest/src/lib.rs
+++ b/src/pgtest/src/lib.rs
@@ -119,7 +119,7 @@ impl PgTest {
             Message::AuthenticationOk => {}
             _ => bail!("expected AuthenticationOk"),
         };
-        pgtest.until(vec!["ReadyForQuery"], vec![], HashSet::new())?;
+        pgtest.until(vec!["ReadyForQuery"], vec!['C', 'S', 'M'], HashSet::new())?;
         Ok(pgtest)
     }
     pub fn send<F: Fn(&mut BytesMut)>(&mut self, f: F) -> anyhow::Result<()> {

--- a/src/pgtest/src/lib.rs
+++ b/src/pgtest/src/lib.rs
@@ -57,6 +57,31 @@
 //! CommandComplete {"tag":"SELECT 1"}
 //! ReadyForQuery {"status":"I"}
 //! ```
+//!
+//! # Usage while writing tests
+//!
+//! The expected way to use this while writing tests is to generate output from a postgres server.
+//! Use the `pgtest-mz` directory if our output differs incompatibly from postgres.
+//! Write your test, excluding any lines after the `----` of the `until` directive.
+//! For example:
+//! ```pgtest
+//! send
+//! Query {"query": "SELECT 1"}
+//! ----
+//!
+//! until
+//! ReadyForQuery
+//! ----
+//! ```
+//! Then run the pgtest binary, enabling rewrites and pointing it at postgres:
+//! ```shell
+//! REWRITE=1 cargo run --bin mz-pgtest -- test/pgtest/test.pt --addr localhost:5432 --user postgres
+//! ```
+//! This will generate the expected output for the `until` directive.
+//! Now rerun against a running materialized server:
+//! ```shell
+//! cargo run --bin mz-pgtest -- test/pgtest/test.pt
+//! ```
 
 use std::collections::HashSet;
 use std::io::{Read, Write};

--- a/src/pgtest/src/lib.rs
+++ b/src/pgtest/src/lib.rs
@@ -36,7 +36,8 @@
 //! no_error_fields`.
 //! - `err_field_typs` specifies the set of error message fields
 //! ([reference](https://www.postgresql.org/docs/current/protocol-error-fields.html)).
-//! For example: `until err_field_typs=VC` would return the severity and code
+//! The default is `CMS` (code, message, severity).
+//! For example: `until err_field_typs=SC` would return the severity and code
 //! fields in any ErrorResponse message.
 //!
 //! For example, to execute a simple prepared statement:
@@ -486,7 +487,7 @@ pub fn run_test(tf: &mut datadriven::TestFile, addr: &str, user: &str, timeout: 
                 } else {
                     match args.remove("err_field_typs") {
                         Some(typs) => typs.join("").chars().collect(),
-                        None => vec!['C', 'M'],
+                        None => vec!['C', 'S', 'M'],
                     }
                 };
                 let mut ignore = HashSet::new();

--- a/test/pgtest/copy-from-2.pt
+++ b/test/pgtest/copy-from-2.pt
@@ -333,7 +333,7 @@ until
 ErrorResponse
 ReadyForQuery
 ----
-ErrorResponse {"fields":[{"typ":"C","value":"0A000"},{"typ":"M","value":"COPY delimiter must be a single one-byte character"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"0A000"},{"typ":"M","value":"COPY delimiter must be a single one-byte character"}]}
 ReadyForQuery {"status":"I"}
 
 send
@@ -350,9 +350,9 @@ ReadyForQuery
 ErrorResponse
 ReadyForQuery
 ----
-ErrorResponse {"fields":[{"typ":"C","value":"0A000"},{"typ":"M","value":"COPY quote available only in CSV mode"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"0A000"},{"typ":"M","value":"COPY quote available only in CSV mode"}]}
 ReadyForQuery {"status":"I"}
-ErrorResponse {"fields":[{"typ":"C","value":"0A000"},{"typ":"M","value":"COPY escape available only in CSV mode"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"0A000"},{"typ":"M","value":"COPY escape available only in CSV mode"}]}
 ReadyForQuery {"status":"I"}
-ErrorResponse {"fields":[{"typ":"C","value":"0A000"},{"typ":"M","value":"COPY HEADER available only in CSV mode"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"0A000"},{"typ":"M","value":"COPY HEADER available only in CSV mode"}]}
 ReadyForQuery {"status":"I"}

--- a/test/pgtest/copy-from-2.pt
+++ b/test/pgtest/copy-from-2.pt
@@ -350,9 +350,9 @@ ReadyForQuery
 ErrorResponse
 ReadyForQuery
 ----
-ErrorResponse {"fields":[{"typ":"C","value":"0A000"},{"typ":"M","value":"COPY quote only available in CSV mode"}]}
+ErrorResponse {"fields":[{"typ":"C","value":"0A000"},{"typ":"M","value":"COPY quote available only in CSV mode"}]}
 ReadyForQuery {"status":"I"}
-ErrorResponse {"fields":[{"typ":"C","value":"0A000"},{"typ":"M","value":"COPY escape only available in CSV mode"}]}
+ErrorResponse {"fields":[{"typ":"C","value":"0A000"},{"typ":"M","value":"COPY escape available only in CSV mode"}]}
 ReadyForQuery {"status":"I"}
-ErrorResponse {"fields":[{"typ":"C","value":"0A000"},{"typ":"M","value":"COPY header only available in CSV mode"}]}
+ErrorResponse {"fields":[{"typ":"C","value":"0A000"},{"typ":"M","value":"COPY HEADER available only in CSV mode"}]}
 ReadyForQuery {"status":"I"}

--- a/test/pgtest/copy-from-fail.pt
+++ b/test/pgtest/copy-from-fail.pt
@@ -36,7 +36,7 @@ ReadyForQuery
 ReadyForQuery
 ----
 CopyIn {"format":"text","column_formats":["text","text"]}
-ErrorResponse {"fields":[{"typ":"C","value":"57014"},{"typ":"M","value":"COPY from stdin failed: frontend failure"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"57014"},{"typ":"M","value":"COPY from stdin failed: frontend failure"}]}
 ReadyForQuery {"status":"I"}
 ReadyForQuery {"status":"I"}
 

--- a/test/pgtest/copy-from.pt
+++ b/test/pgtest/copy-from.pt
@@ -61,7 +61,7 @@ CopyDone
 until
 ReadyForQuery
 ----
-ErrorResponse {"fields":[{"typ":"C","value":"22P04"},{"typ":"M","value":"extra data after last expected column"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"22P04"},{"typ":"M","value":"extra data after last expected column"}]}
 ReadyForQuery {"status":"I"}
 
 # invalid type

--- a/test/pgtest/cursors.pt
+++ b/test/pgtest/cursors.pt
@@ -35,7 +35,7 @@ CommandComplete {"tag":"FETCH 1"}
 ReadyForQuery {"status":"T"}
 CommandComplete {"tag":"CLOSE CURSOR"}
 ReadyForQuery {"status":"T"}
-ErrorResponse {"fields":[{"typ":"C","value":"34000"},{"typ":"M","value":"portal \"p\" does not exist"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"34000"},{"typ":"M","value":"portal \"p\" does not exist"}]}
 ReadyForQuery {"status":"E"}
 CommandComplete {"tag":"ROLLBACK"}
 ReadyForQuery {"status":"I"}
@@ -178,7 +178,7 @@ ReadyForQuery
 ReadyForQuery
 ReadyForQuery
 ----
-ErrorResponse {"fields":[{"typ":"C","value":"34000"},{"typ":"M","value":"portal \"c\" does not exist"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"34000"},{"typ":"M","value":"portal \"c\" does not exist"}]}
 ReadyForQuery {"status":"I"}
 CommandComplete {"tag":"BEGIN"}
 ReadyForQuery {"status":"T"}
@@ -187,7 +187,7 @@ ReadyForQuery {"status":"T"}
 RowDescription {"fields":[{"name":"column1"}]}
 CommandComplete {"tag":"COMMIT"}
 ReadyForQuery {"status":"I"}
-ErrorResponse {"fields":[{"typ":"C","value":"34000"},{"typ":"M","value":"portal \"c\" does not exist"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"34000"},{"typ":"M","value":"portal \"c\" does not exist"}]}
 ReadyForQuery {"status":"I"}
 
 # Verify that a single Query message can declare and fetch from a
@@ -213,7 +213,7 @@ RowDescription {"fields":[{"name":"column1"}]}
 DataRow {"fields":["6"]}
 CommandComplete {"tag":"FETCH 1"}
 ReadyForQuery {"status":"I"}
-ErrorResponse {"fields":[{"typ":"C","value":"34000"},{"typ":"M","value":"portal \"c\" does not exist"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"34000"},{"typ":"M","value":"portal \"c\" does not exist"}]}
 ReadyForQuery {"status":"I"}
 
 # Test cursors in extended protocol.
@@ -379,7 +379,7 @@ ReadyForQuery {"status":"T"}
 ParseComplete
 BindComplete
 CommandComplete {"tag":"DECLARE CURSOR"}
-ErrorResponse {"fields":[{"typ":"C","value":"55000"},{"typ":"M","value":"portal \"\" cannot be run"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"55000"},{"typ":"M","value":"portal \"\" cannot be run"}]}
 ReadyForQuery {"status":"E"}
 CommandComplete {"tag":"ROLLBACK"}
 ReadyForQuery {"status":"I"}
@@ -429,7 +429,7 @@ CommandComplete {"tag":"FETCH 1"}
 ParseComplete
 BindComplete
 CommandComplete {"tag":"CLOSE CURSOR"}
-ErrorResponse {"fields":[{"typ":"C","value":"55000"},{"typ":"M","value":"portal \"\" cannot be run"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"55000"},{"typ":"M","value":"portal \"\" cannot be run"}]}
 ReadyForQuery {"status":"E"}
 CommandComplete {"tag":"ROLLBACK"}
 ReadyForQuery {"status":"I"}
@@ -508,7 +508,7 @@ RowDescription {"fields":[{"name":"column1"}]}
 DataRow {"fields":["1"]}
 CommandComplete {"tag":"FETCH 1"}
 ReadyForQuery {"status":"T"}
-ErrorResponse {"fields":[{"typ":"C","value":"34000"},{"typ":"M","value":"portal \"\" does not exist"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"34000"},{"typ":"M","value":"portal \"\" does not exist"}]}
 ReadyForQuery {"status":"E"}
 CommandComplete {"tag":"ROLLBACK"}
 ReadyForQuery {"status":"I"}
@@ -549,7 +549,7 @@ Query {"query": "DECLARE c CURSOR FOR SELECT 1"}
 until
 ReadyForQuery
 ----
-ErrorResponse {"fields":[{"typ":"C","value":"25P01"},{"typ":"M","value":"DECLARE CURSOR can only be used in transaction blocks"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"25P01"},{"typ":"M","value":"DECLARE CURSOR can only be used in transaction blocks"}]}
 ReadyForQuery {"status":"I"}
 
 send
@@ -564,5 +564,5 @@ ReadyForQuery
 ----
 ParseComplete
 BindComplete
-ErrorResponse {"fields":[{"typ":"C","value":"25P01"},{"typ":"M","value":"DECLARE CURSOR can only be used in transaction blocks"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"25P01"},{"typ":"M","value":"DECLARE CURSOR can only be used in transaction blocks"}]}
 ReadyForQuery {"status":"I"}

--- a/test/pgtest/desc.pt
+++ b/test/pgtest/desc.pt
@@ -80,7 +80,7 @@ Sync
 until ignore=ParameterDescription
 ReadyForQuery
 ----
-ErrorResponse {"fields":[{"typ":"C","value":"0A000"},{"typ":"M","value":"cached plan must not change result type"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"0A000"},{"typ":"M","value":"cached plan must not change result type"}]}
 ReadyForQuery {"status":"I"}
 
 send
@@ -93,7 +93,7 @@ Query {"query": "EXECUTE q"}
 until ignore=RowDescription
 ReadyForQuery
 ----
-ErrorResponse {"fields":[{"typ":"C","value":"0A000"},{"typ":"M","value":"cached plan must not change result type"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"0A000"},{"typ":"M","value":"cached plan must not change result type"}]}
 ReadyForQuery {"status":"I"}
 
 # Changing it back fixes it.

--- a/test/pgtest/desc.pt
+++ b/test/pgtest/desc.pt
@@ -2,6 +2,16 @@
 # replaced.
 
 send
+Query {"query": "DROP TABLE IF EXISTS t"}
+----
+
+until ignore=NoticeResponse
+ReadyForQuery
+----
+CommandComplete {"tag":"DROP TABLE"}
+ReadyForQuery {"status":"I"}
+
+send
 Query {"query": "CREATE TABLE t (a INT)"}
 Parse {"name": "q", "query": "SELECT * FROM t"}
 Describe {"variant": "S", "name": "q"}

--- a/test/pgtest/portals.pt
+++ b/test/pgtest/portals.pt
@@ -70,7 +70,7 @@ Query {"query": "CLOSE c"}
 until
 ReadyForQuery
 ----
-ErrorResponse {"fields":[{"typ":"C","value":"34000"},{"typ":"M","value":"cursor \"c\" does not exist"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"34000"},{"typ":"M","value":"cursor \"c\" does not exist"}]}
 ReadyForQuery {"status":"I"}
 
 # Verify that portals (cursors) are destroyed on Sync.
@@ -107,7 +107,7 @@ ReadyForQuery
 ----
 CommandComplete {"tag":"BEGIN"}
 CommandComplete {"tag":"DECLARE CURSOR"}
-ErrorResponse {"fields":[{"typ":"C","value":"42P03"},{"typ":"M","value":"cursor \"c\" already exists"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"42P03"},{"typ":"M","value":"cursor \"c\" already exists"}]}
 ReadyForQuery {"status":"E"}
 CommandComplete {"tag":"ROLLBACK"}
 ReadyForQuery {"status":"I"}
@@ -129,7 +129,7 @@ CommandComplete {"tag":"BEGIN"}
 CommandComplete {"tag":"DECLARE CURSOR"}
 ReadyForQuery {"status":"T"}
 ParseComplete
-ErrorResponse {"fields":[{"typ":"C","value":"42P03"},{"typ":"M","value":"cursor \"c\" already exists"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"42P03"},{"typ":"M","value":"cursor \"c\" already exists"}]}
 ReadyForQuery {"status":"E"}
 CommandComplete {"tag":"ROLLBACK"}
 ReadyForQuery {"status":"I"}
@@ -154,7 +154,7 @@ ReadyForQuery {"status":"T"}
 ParseComplete
 BindComplete
 ReadyForQuery {"status":"T"}
-ErrorResponse {"fields":[{"typ":"C","value":"42P03"},{"typ":"M","value":"cursor \"c\" already exists"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"42P03"},{"typ":"M","value":"cursor \"c\" already exists"}]}
 ReadyForQuery {"status":"E"}
 CommandComplete {"tag":"ROLLBACK"}
 ReadyForQuery {"status":"I"}

--- a/test/pgtest/prepare.pt
+++ b/test/pgtest/prepare.pt
@@ -12,7 +12,7 @@ ReadyForQuery
 ----
 CommandComplete {"tag":"DEALLOCATE ALL"}
 ReadyForQuery {"status":"I"}
-ErrorResponse {"fields":[{"typ":"C","value":"26000"},{"typ":"M","value":"prepared statement \"a\" does not exist"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"26000"},{"typ":"M","value":"prepared statement \"a\" does not exist"}]}
 ReadyForQuery {"status":"I"}
 
 # TOOD(mjibson): Teach scl.rs how to return error codes.
@@ -41,7 +41,7 @@ ReadyForQuery
 ----
 CommandComplete {"tag":"PREPARE"}
 ReadyForQuery {"status":"I"}
-ErrorResponse {"fields":[{"typ":"C","value":"42P05"},{"typ":"M","value":"prepared statement \"a\" already exists"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"42P05"},{"typ":"M","value":"prepared statement \"a\" already exists"}]}
 ReadyForQuery {"status":"I"}
 RowDescription {"fields":[{"name":"?column?"}]}
 DataRow {"fields":["1"]}
@@ -64,7 +64,7 @@ ReadyForQuery {"status":"I"}
 until
 ReadyForQuery
 ----
-ErrorResponse {"fields":[{"typ":"C","value":"26000"},{"typ":"M","value":"prepared statement \"a\" does not exist"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"26000"},{"typ":"M","value":"prepared statement \"a\" does not exist"}]}
 ReadyForQuery {"status":"I"}
 
 send

--- a/test/pgtest/transactions.pt
+++ b/test/pgtest/transactions.pt
@@ -145,7 +145,7 @@ Query {"query": "COMMIT;"}
 Query {"query": "ROLLBACK;"}
 ----
 
-until err_field_typs=SCM
+until
 ReadyForQuery
 ReadyForQuery
 ReadyForQuery
@@ -187,7 +187,7 @@ ReadyForQuery
 ----
 CommandComplete {"tag":"BEGIN"}
 ReadyForQuery {"status":"T"}
-NoticeResponse {"fields":[{"typ":"C","value":"25001"},{"typ":"M","value":"there is already a transaction in progress"}]}
+NoticeResponse {"fields":[{"typ":"S","value":"WARNING"},{"typ":"C","value":"25001"},{"typ":"M","value":"there is already a transaction in progress"}]}
 CommandComplete {"tag":"BEGIN"}
 ReadyForQuery {"status":"T"}
 


### PR DESCRIPTION
Improve pgtest's documentation, error printing, and initial connection handling.

### Motivation

  * This PR adds a feature that has not yet been specified.

pgtest was previously not reporting error severity. While adding that, I noticed a few other things that needed improvement.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
