### PR TITLE
test: Adjust tests to account for #10661

### DIFF
--- a/test/testdrive/github-5668.td
+++ b/test/testdrive/github-5668.td
@@ -82,7 +82,7 @@ $ set pg-dbz-schema={
     ]
   }
 
-$ kafka-create-topic topic=pg-dbz-data
+$ kafka-create-topic topic=pg-dbz-data partitions=1
 
 $ kafka-ingest format=avro topic=pg-dbz-data schema=${pg-dbz-schema} timestamp=1
 {"before": null, "after": {"row":{"val": "foo"}}, "source": {"lsn": {"long": 3}, "sequence": {"string": "[null, \"3\"]"}, "snapshot": {"string": "false"}}, "transaction": {"total_order": null}}

--- a/test/testdrive/kafka-avro-sources.td
+++ b/test/testdrive/kafka-avro-sources.td
@@ -872,7 +872,7 @@ $ set ms-dbz-schema={
     "type": "record"
   }
 
-$ kafka-create-topic topic=ms-dbz-data
+$ kafka-create-topic topic=ms-dbz-data partitions=1
 
 # The third record will be skipped, since `lsn` has gone backwards.
 $ kafka-ingest format=avro topic=ms-dbz-data schema=${ms-dbz-schema} timestamp=1


### PR DESCRIPTION
Explicitly use partitions=1 for some tests that are affected by #10661
and can not run with multiple partitions in the Nightly CI