### PR TITLE
sources: remove unused return value from SourceReader

### DIFF
--- a/src/dataflow/src/source/file.rs
+++ b/src/dataflow/src/source/file.rs
@@ -78,7 +78,7 @@ impl SourceReader for FileSourceReader {
         encoding: SourceDataEncoding,
         _: Option<Logger>,
         _: SourceBaseMetrics,
-    ) -> Result<(FileSourceReader, Option<PartitionId>), anyhow::Error> {
+    ) -> Result<Self, anyhow::Error> {
         let receiver = match connector {
             ExternalSourceConnector::File(fc) => {
                 tracing::debug!("creating FileSourceReader worker_id={}", worker_id);
@@ -160,14 +160,11 @@ impl SourceReader for FileSourceReader {
             _ => unreachable!(),
         };
 
-        Ok((
-            FileSourceReader {
-                id: source_id,
-                receiver_stream: receiver,
-                current_file_offset: FileOffset { offset: 0 },
-            },
-            Some(PartitionId::None),
-        ))
+        Ok(FileSourceReader {
+            id: source_id,
+            receiver_stream: receiver,
+            current_file_offset: FileOffset { offset: 0 },
+        })
     }
 
     fn get_next_message(&mut self) -> Result<NextMessage<Self::Key, Self::Value>, anyhow::Error> {

--- a/src/dataflow/src/source/kinesis.rs
+++ b/src/dataflow/src/source/kinesis.rs
@@ -128,7 +128,7 @@ impl SourceReader for KinesisSourceReader {
         _encoding: SourceDataEncoding,
         _: Option<Logger>,
         base_metrics: SourceBaseMetrics,
-    ) -> Result<(Self, Option<PartitionId>), anyhow::Error> {
+    ) -> Result<Self, anyhow::Error> {
         let kc = match connector {
             ExternalSourceConnector::Kinesis(kc) => kc,
             _ => unreachable!(),
@@ -136,19 +136,16 @@ impl SourceReader for KinesisSourceReader {
 
         let state = block_on(create_state(&base_metrics.kinesis, kc, aws_external_id));
         match state {
-            Ok((kinesis_client, stream_name, shard_set, shard_queue)) => Ok((
-                KinesisSourceReader {
-                    kinesis_client,
-                    shard_queue,
-                    last_checked_shards: Instant::now(),
-                    buffered_messages: VecDeque::new(),
-                    shard_set,
-                    stream_name,
-                    processed_message_count: 0,
-                    base_metrics: base_metrics.kinesis,
-                },
-                Some(PartitionId::None),
-            )),
+            Ok((kinesis_client, stream_name, shard_set, shard_queue)) => Ok(KinesisSourceReader {
+                kinesis_client,
+                shard_queue,
+                last_checked_shards: Instant::now(),
+                buffered_messages: VecDeque::new(),
+                shard_set,
+                stream_name,
+                processed_message_count: 0,
+                base_metrics: base_metrics.kinesis,
+            }),
             Err(e) => Err(anyhow!("{}", e)),
         }
     }

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -375,7 +375,7 @@ pub(crate) trait SourceReader {
         encoding: SourceDataEncoding,
         logger: Option<Logger>,
         metrics: crate::source::metrics::SourceBaseMetrics,
-    ) -> Result<(Self, Option<PartitionId>), anyhow::Error>
+    ) -> Result<Self, anyhow::Error>
     where
         Self: Sized;
 
@@ -1129,7 +1129,7 @@ where
                 logger,
                 base_metrics.clone(),
             ) {
-                Ok((source_reader, _delete_me)) => Some(source_reader),
+                Ok(source_reader) => Some(source_reader),
                 Err(e) => {
                     error!("Failed to create source: {}", e);
                     None

--- a/src/dataflow/src/source/s3.rs
+++ b/src/dataflow/src/source/s3.rs
@@ -815,7 +815,7 @@ impl SourceReader for S3SourceReader {
         _encoding: SourceDataEncoding,
         _: Option<Logger>,
         metrics: SourceBaseMetrics,
-    ) -> Result<(S3SourceReader, Option<PartitionId>), anyhow::Error> {
+    ) -> Result<Self, anyhow::Error> {
         let s3_conn = match connector {
             ExternalSourceConnector::S3(s3_conn) => s3_conn,
             _ => {
@@ -894,16 +894,13 @@ impl SourceReader for S3SourceReader {
             (dataflow_rx, shutdowner)
         };
 
-        Ok((
-            S3SourceReader {
-                source_name,
-                id: source_id,
-                receiver_stream: receiver,
-                dataflow_status: shutdowner,
-                offset: S3Offset(0),
-            },
-            Some(PartitionId::None),
-        ))
+        Ok(S3SourceReader {
+            source_name,
+            id: source_id,
+            receiver_stream: receiver,
+            dataflow_status: shutdowner,
+            offset: S3Offset(0),
+        })
     }
 
     fn get_next_message(&mut self) -> Result<NextMessage<Self::Key, Self::Value>, anyhow::Error> {


### PR DESCRIPTION
This used to indicate the default partition but it's no longer needed
after #10436

Also in the kafka source we had the `new()` and `get_next_kafka_message()` inherents method and the SourceReader trait was dispatching to. I just made them the implementation of the trait itself

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
