### PR TITLE
doc/user: Update CDC guides

### DIFF
--- a/doc/user/content/sql/create-source/postgres.md
+++ b/doc/user/content/sql/create-source/postgres.md
@@ -28,7 +28,7 @@ _src_name_  | The name for the source.
 **CONNECTION** _connection_info_ | Postgres connection parameters. See the Postgres documentation on [supported correction parameters](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS) for details.
 **PUBLICATION** _publication_name_ | Postgres [publication](https://www.postgresql.org/docs/current/logical-replication-publication.html) (the replication data set containing the tables to be streamed to Materialize).
 
-## `WITH` options
+### `WITH` options
 
 The following option is valid within the `WITH` clause.
 


### PR DESCRIPTION
When deploying Debezium on Confluent Cloud, the connectors default to only sending the `after` value in the payload due to some `After-state only` property. Unless the default is overridden (and assuming the user doesn't necessarily need to use `ENVELOPE DEBEZIUM UPSERT`), Materialize will error with:

`ERROR: 'before' column missing from debezium input`

This was reported in [a thread](https://materializecommunity.slack.com/archives/C015KDVS7EV/p1644877830894139) in the Slack community, so it's worth adding a note to both CDC guides.

**Changelog:**

- Added warning for `After-state only` defaulting to `false`;
- Corrected the syntax of the `CREATE SOURCE` examples, which were using `KEY FORMAT...VALUE FORMAT` instead of just `FORMAT`;
- Fixed an indent in the Postgres source docs + added a note about compacted topics to the guides while I'm at it.