### PR TITLE
Support setting `standard_conforming_strings` to `on`

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -122,6 +122,9 @@ changes that have not yet been documented.
 - Improve the clarity of any Avro schema resolution errors found when
   creating materialized sources and views. {{% gh 8415 %}}
 
+- Allow setting `standard_conforming_strings` to its default value of `on`.
+  Setting it to `off` is still not supported.
+
 {{< comment >}}
 Only add new release notes above this line.
 

--- a/src/coord/src/session/vars.rs
+++ b/src/coord/src/session/vars.rs
@@ -347,7 +347,15 @@ impl Vars {
         } else if name == SQL_SAFE_UPDATES.name {
             self.sql_safe_updates.set(value, local)
         } else if name == STANDARD_CONFORMING_STRINGS.name {
-            Err(CoordError::ReadOnlyParameter(&STANDARD_CONFORMING_STRINGS))
+            match bool::parse(value) {
+                Ok(value) if value == *STANDARD_CONFORMING_STRINGS.value => Ok(()),
+                Ok(_) => Err(CoordError::ConstrainedParameter(
+                    &STANDARD_CONFORMING_STRINGS,
+                )),
+                Err(()) => Err(CoordError::InvalidParameterType(
+                    &STANDARD_CONFORMING_STRINGS,
+                )),
+            }
         } else if name == TIMEZONE.name {
             if UncasedStr::new(value) != TIMEZONE.value {
                 return Err(CoordError::ConstrainedParameter(&TIMEZONE));

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -41,6 +41,19 @@ contains:parameter "client_encoding" can only be set to "UTF8"
 ! SET NAMES = "something";
 contains:unrecognized configuration parameter "names"
 
+# standard_conforming_strings is constrained to true
+> SET standard_conforming_strings = ON;
+
+> SET standard_conforming_strings = true;
+
+> SET standard_conforming_strings TO TRUE;
+
+! SET standard_conforming_strings = OFF;
+contains:parameter "standard_conforming_strings" can only be set to "on"
+
+! SET standard_conforming_strings = typo;
+contains:parameter "standard_conforming_strings" requires a "boolean" value
+
 > SET sql_safe_updates = on
 > SHOW sql_safe_updates
 on


### PR DESCRIPTION
Similar to TIMEZONE and client_encoding, only setting it to the default
value is supported: changing it to any other value is currently not supported.

### Motivation

  * This PR fixes a previously unreported bug: setting `standard_conforming_strings` to its present value, which is required for Looker to work.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
