### PR TITLE
Convert all tracing::*! invocations to be unprefixed

### DIFF
--- a/demo/billing/src/bin/billing-demo/mz.rs
+++ b/demo/billing/src/bin/billing-demo/mz.rs
@@ -14,6 +14,7 @@ use csv::Writer;
 use mz_ore::retry::Retry;
 use rand::Rng;
 use tokio_postgres::Client;
+use tracing::debug;
 
 use mz_test_util::mz_client;
 
@@ -45,7 +46,7 @@ pub async fn create_proto_source(
         message = message_name,
     );
 
-    tracing::debug!("creating source=> {}", query);
+    debug!("creating source=> {}", query);
 
     mz_client::execute(&mz_client, &query).await?;
     Ok(())
@@ -67,7 +68,7 @@ pub async fn create_kafka_sink(
              schema_registry = schema_registry_url
          );
 
-    tracing::debug!("creating sink=> {}", query);
+    debug!("creating sink=> {}", query);
     mz_client::execute(&mz_client, &query).await?;
 
     // Get the topic for the newly-created sink.
@@ -120,7 +121,7 @@ pub async fn create_csv_source(
         file = absolute_path.display(),
     );
 
-    tracing::debug!("creating csv source=> {}", query);
+    debug!("creating csv source=> {}", query);
     mz_client::execute(&mz_client, &query).await?;
     Ok(())
 }
@@ -139,7 +140,7 @@ pub async fn reingest_sink(
                     topic_name = topic_name,
                     schema_registry = schema_registry_url);
 
-    tracing::debug!("creating materialized source to reingest sink=> {}", query);
+    debug!("creating materialized source to reingest sink=> {}", query);
     mz_client::execute(&mz_client, &query).await?;
 
     Ok(())
@@ -182,7 +183,7 @@ pub async fn validate_sink(
         .await?;
 
     let query = format!("SELECT * FROM {}", invalid_rows_view);
-    tracing::debug!("validating sinks=> {}", query);
+    debug!("validating sinks=> {}", query);
     let rows = mz_client.query(&*query, &[]).await?;
 
     if rows.len() != 0 {

--- a/src/coord/src/catalog/migrate.rs
+++ b/src/coord/src/catalog/migrate.rs
@@ -17,6 +17,7 @@ use protobuf_native::compiler::{SourceTreeDescriptorDatabase, VirtualSourceTree}
 use protobuf_native::MessageLite;
 use semver::Version;
 use tokio::fs::File;
+use tracing::warn;
 
 use mz_ore::collections::CollectionExt;
 use mz_sql::ast::display::AstDisplay;
@@ -691,7 +692,7 @@ fn ast_rewrite_csv_column_aliases_0_9_2(
     // they match then everything will work out. If they don't match, then at least there isn't
     // a catalog corruption error.
     if let Err(e) = result {
-        tracing::warn!(
+        warn!(
             "Error retrieving column names from file ({}) \
                  using previously defined column aliases",
             e

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -106,6 +106,7 @@ use timely::progress::{Antichain, ChangeBatch, Timestamp as _};
 use tokio::runtime::Handle as TokioHandle;
 use tokio::select;
 use tokio::sync::{mpsc, oneshot, watch};
+use tracing::error;
 
 use mz_build_info::BuildInfo;
 use mz_dataflow_types::client::DEFAULT_COMPUTE_INSTANCE_ID;
@@ -836,10 +837,9 @@ impl Coordinator {
                         // EDIT: On further consideration, I think it doesn't
                         // affect correctness if this fails, just availability
                         // of the table.
-                        tracing::error!(
+                        error!(
                             "failed to seal persisted stream to ts {}: {}",
-                            advance_to,
-                            err
+                            advance_to, err
                         );
                     }
                 },
@@ -1539,7 +1539,7 @@ impl Coordinator {
             let persist_multi = match &mut self.persister.table_writer {
                 Some(multi) => multi,
                 None => {
-                    tracing::error!("internal error: persist_multi_details invariant violated");
+                    error!("internal error: persist_multi_details invariant violated");
                     return;
                 }
             };
@@ -1551,7 +1551,7 @@ impl Coordinator {
                 async move {
                     if let Err(err) = compaction_fut.await {
                         // TODO: Do something smarter here
-                        tracing::error!("failed to compact persisted tables: {}", err);
+                        error!("failed to compact persisted tables: {}", err);
                     }
                 },
             );

--- a/src/coord/src/coord/antichain.rs
+++ b/src/coord/src/coord/antichain.rs
@@ -12,6 +12,7 @@
 #![allow(missing_debug_implementations)]
 
 use std::rc::Rc;
+use tracing::trace;
 
 use timely::order::PartialOrder;
 use timely::progress::change_batch::ChangeBatch;
@@ -69,7 +70,7 @@ impl<T: PartialOrder + Ord + Clone + std::fmt::Debug> AntichainToken<T> {
         new_frontier.extend(frontier.into_iter());
 
         if !<_ as PartialOrder>::less_equal(&self.antichain.frontier(), &new_frontier.borrow()) {
-            tracing::trace!(
+            trace!(
                 "Ignoring request to 'advance' to {:?} current antichain {:?}",
                 new_frontier,
                 self.antichain

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -19,6 +19,7 @@ use enum_kinds::EnumKind;
 use serde::{Deserialize, Serialize};
 use timely::progress::frontier::Antichain;
 use timely::progress::ChangeBatch;
+use tracing::trace;
 
 use crate::logging::LoggingConfig;
 use crate::{
@@ -477,12 +478,12 @@ impl LocalClient {
 #[async_trait(?Send)]
 impl Client for LocalClient {
     async fn send(&mut self, cmd: Command) {
-        tracing::trace!("SEND dataflow command: {:?}", cmd);
+        trace!("SEND dataflow command: {:?}", cmd);
         self.client.send(cmd).await
     }
     async fn recv(&mut self) -> Option<Response> {
         let response = self.client.recv().await;
-        tracing::trace!("RECV dataflow response: {:?}", response);
+        trace!("RECV dataflow response: {:?}", response);
         response
     }
 }
@@ -500,6 +501,7 @@ pub mod partitioned {
     use mz_repr::{Diff, Row, Timestamp};
     use timely::order::PartialOrder;
     use timely::progress::{Antichain, ChangeBatch};
+    use tracing::debug;
 
     use crate::TailResponse;
 
@@ -706,7 +708,7 @@ pub mod partitioned {
             for id in cease.into_iter() {
                 let previous = self.uppers.remove(&id);
                 if previous.is_none() {
-                    tracing::debug!("Protocol error: ceasing frontier tracking for absent identifier {:?} due to command {:?}", id, command);
+                    debug!("Protocol error: ceasing frontier tracking for absent identifier {:?} due to command {:?}", id, command);
                 }
             }
         }

--- a/src/dataflow-types/src/client/controller.rs
+++ b/src/dataflow-types/src/client/controller.rs
@@ -11,6 +11,7 @@
 use std::collections::BTreeMap;
 
 use timely::progress::{frontier::AntichainRef, Antichain, ChangeBatch};
+use tracing::error;
 
 use crate::client::SourceConnector;
 use crate::client::{
@@ -321,7 +322,7 @@ impl<C: Client> Controller<C> {
         for id in identifiers.iter() {
             if !self.source_descriptions.contains_key(id) {
                 // This isn't an unrecoverable error, just .. probably wrong.
-                tracing::error!("Source id {} dropped without first being created", id);
+                error!("Source id {} dropped without first being created", id);
             } else {
                 self.source_descriptions.insert(*id, None);
             }

--- a/src/dataflow-types/src/plan/mod.rs
+++ b/src/dataflow-types/src/plan/mod.rs
@@ -21,6 +21,7 @@ use mz_expr::permutation_for_arrangement;
 use reduce::{KeyValPlan, ReducePlan};
 use threshold::ThresholdPlan;
 use top_k::TopKPlan;
+use tracing::error;
 
 use serde::{Deserialize, Serialize, Serializer};
 
@@ -598,7 +599,7 @@ impl Plan {
                             // we shouldn't plan delta joins at all if not all of the required arrangements
                             // are available. Print an error message, to increase the chances that
                             // the user will tell us about this.
-                            tracing::error!("Arrangements depended on by delta join alarmingly absent: {:?}
+                            error!("Arrangements depended on by delta join alarmingly absent: {:?}
 This is not expected to cause incorrect results, but could indicate a performance issue in Materialize.", missing);
                         } else {
                             // It's fine and expected that linear joins don't have all their arrangements available up front,

--- a/src/dataflow/src/render/reduce.rs
+++ b/src/dataflow/src/render/reduce.rs
@@ -25,6 +25,7 @@ use mz_expr::MirScalarExpr;
 use serde::{Deserialize, Serialize};
 use timely::dataflow::Scope;
 use timely::progress::{timestamp::Refines, Timestamp};
+use tracing::error;
 
 use mz_dataflow_types::DataflowError;
 
@@ -557,7 +558,7 @@ where
                 // XXX: This reports user data, which we perhaps should not do!
                 for (val, cnt) in source.iter() {
                     if cnt < &0 {
-                        tracing::error!("[customer-data] Negative accumulation in ReduceMinsMaxes: {:?} with count {:?}", val, cnt);
+                        error!("[customer-data] Negative accumulation in ReduceMinsMaxes: {:?} with count {:?}", val, cnt);
                     }
                 }
             } else {

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -19,6 +19,7 @@ use serde::{Deserialize, Serialize};
 use timely::dataflow::operators::generic::operator;
 use timely::dataflow::operators::{Concat, Map, OkErr, Probe, UnorderedInput};
 use timely::dataflow::{ProbeHandle, Scope, Stream};
+use tracing::debug;
 
 use mz_persist::client::{MultiWriteHandle, StreamWriteHandle};
 use mz_persist::operators::source::PersistedSource;
@@ -728,7 +729,7 @@ fn get_persist_config(
 
             let seal_ts = persist_desc.upper_seal_ts;
 
-            tracing::debug!(
+            debug!(
                 "Persistent collections for source {}: {:?} and {:?}. Upper seal timestamp: {}.",
                 source_id,
                 persist_desc.primary_stream,
@@ -752,7 +753,7 @@ fn get_persist_config(
 
             let seal_ts = persist_desc.upper_seal_ts;
 
-            tracing::debug!(
+            debug!(
                 "Persistent collections for source {}: {:?} and {:?}. Upper seal timestamp: {}.",
                 source_id,
                 persist_desc.primary_stream,

--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -742,12 +742,9 @@ impl KafkaSinkState {
             // Topic not empty but we couldn't read any messages.  We don't expect this to happen but we
             // have no reason to rely on kafka not inserting any internal messages at the beginning.
             if latest_offset.is_none() {
-                tracing::debug!(
+                debug!(
                     "unable to read any messages from non-empty topic {}:{}, lo/hi: {}/{}",
-                    consistency_topic,
-                    partition,
-                    lo,
-                    hi
+                    consistency_topic, partition, lo, hi
                 );
             }
             Ok(latest_ts)

--- a/src/dataflow/src/source/file.rs
+++ b/src/dataflow/src/source/file.rs
@@ -20,7 +20,7 @@ use inotify::{EventMask, Inotify, WatchMask};
 use mz_dataflow_types::sources::AwsExternalId;
 use mz_repr::MessagePayload;
 use timely::scheduling::SyncActivator;
-use tracing::error;
+use tracing::{debug, error, trace};
 
 use mz_avro::Block;
 use mz_avro::BlockIter;
@@ -81,7 +81,7 @@ impl SourceReader for FileSourceReader {
     ) -> Result<Self, anyhow::Error> {
         let receiver = match connector {
             ExternalSourceConnector::File(fc) => {
-                tracing::debug!("creating FileSourceReader worker_id={}", worker_id);
+                debug!("creating FileSourceReader worker_id={}", worker_id);
                 let ctor = |fi| {
                     let mut br = std::io::BufReader::new(fi);
                     Ok(std::iter::from_fn(move || {
@@ -117,7 +117,7 @@ impl SourceReader for FileSourceReader {
                 rx
             }
             ExternalSourceConnector::AvroOcf(fc) => {
-                tracing::debug!("creating Avro FileSourceReader worker_id={}", worker_id);
+                debug!("creating Avro FileSourceReader worker_id={}", worker_id);
                 let value_encoding = match &encoding {
                     SourceDataEncoding::Single(enc) => enc,
                     SourceDataEncoding::KeyValue { .. } => {
@@ -203,7 +203,7 @@ pub fn read_file_task<Ctor, I, Err>(
     Ctor: FnOnce(Box<dyn AvroRead + Send>) -> Result<I, Err>,
     Err: Into<anyhow::Error>,
 {
-    tracing::trace!("reading file {}", path.display());
+    trace!("reading file {}", path.display());
     let file = match std::fs::File::open(&path).with_context(|| {
         format!(
             "file source: unable to open file at path {}",
@@ -419,5 +419,5 @@ fn send_records<I, Out, Err>(
             activator.activate().expect("activation failed");
         }
     }
-    tracing::trace!("sent {} records to reader", records);
+    trace!("sent {} records to reader", records);
 }

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -45,7 +45,7 @@ use mz_ore::metrics::{CounterVecExt, DeleteOnDropCounter, DeleteOnDropGauge, Gau
 use mz_ore::now::NowFn;
 use mz_ore::task;
 use prometheus::core::{AtomicI64, AtomicU64};
-use tracing::error;
+use tracing::{debug, error, trace};
 
 use mz_repr::{Diff, Row, Timestamp};
 use timely::dataflow::channels::pushers::Tee;
@@ -1000,14 +1000,14 @@ where
 
                 let starting_offsets = source_persist.get_starting_offsets(valid_bindings.iter());
 
-                tracing::debug!(
+                debug!(
                     "In {}, initial (restored) source offsets: {:?}. upper_seal_ts = {}",
                     name,
                     starting_offsets,
                     source_persist.config.upper_seal_ts,
                 );
 
-                tracing::debug!(
+                debug!(
                     "In {}, initial (restored) timestamp bindings: valid_bindings: {:?}, retractions: {:?}",
                     name,
                     valid_bindings, retractions
@@ -1054,7 +1054,7 @@ where
                             );
                         },
                         Some(existing_binding) => {
-                            tracing::debug!(
+                            debug!(
                                 "Filtered out timestamp binding {:?} from persistence because we already have {:?}.",
                                 (source_ts, assigned_ts),
                                 existing_binding
@@ -1525,7 +1525,7 @@ fn maybe_emit_timestamp_bindings(
     // wasteful but we don't expect large numbers of bindings.
     let mut to_emit = to_emit.collect::<Vec<_>>();
 
-    tracing::trace!(
+    trace!(
         "In {} (worker {}), emitting new timestamp bindings: {:?}, cap: {:?}",
         source_name,
         worker_id,

--- a/src/dataflow/src/source/pubnub.rs
+++ b/src/dataflow/src/source/pubnub.rs
@@ -13,6 +13,7 @@ use async_trait::async_trait;
 use futures::StreamExt;
 use pubnub_hyper::core::data::{channel, message::Type};
 use pubnub_hyper::{Builder, DefaultRuntime, DefaultTransport};
+use tracing::info;
 
 use crate::source::{SimpleSource, SourceError, Timestamper};
 use mz_dataflow_types::{sources::PubNubSourceConnector, SourceErrorDetails};
@@ -80,7 +81,7 @@ impl SimpleSource for PubNubSourceReader {
                 }
             }
 
-            tracing::info!(
+            info!(
                 "pubnub channel {:?} disconnected. reconnecting",
                 channel.to_string()
             );

--- a/src/dataflow/src/source/timestamp.rs
+++ b/src/dataflow/src/source/timestamp.rs
@@ -34,6 +34,7 @@ use timely::dataflow::operators::Capability;
 use timely::order::PartialOrder;
 use timely::progress::frontier::{Antichain, AntichainRef, MutableAntichain};
 use timely::progress::{ChangeBatch, Timestamp as TimelyTimestamp};
+use tracing::debug;
 
 use mz_dataflow_types::sources::MzOffset;
 use mz_expr::PartitionId;
@@ -348,7 +349,7 @@ impl TimestampBindingBox {
             .entry(partition.clone())
             .and_modify(|existing_offset| {
                 if existing_offset.is_some() {
-                    tracing::debug!(
+                    debug!(
                         "Already have offset {} for partition {}, ignoring.",
                         existing_offset.expect("known to exist"),
                         partition

--- a/src/dataflowd/src/lib.rs
+++ b/src/dataflowd/src/lib.rs
@@ -17,6 +17,7 @@
 use async_trait::async_trait;
 
 use mz_dataflow_types::client::{partitioned::Partitioned, Client, Command, Response};
+use tracing::trace;
 
 /// A convenience type for compatibility.
 pub struct RemoteClient {
@@ -39,7 +40,7 @@ impl RemoteClient {
 #[async_trait(?Send)]
 impl Client for RemoteClient {
     async fn send(&mut self, cmd: Command) {
-        tracing::trace!("Broadcasting dataflow command: {:?}", cmd);
+        trace!("Broadcasting dataflow command: {:?}", cmd);
         self.client.send(cmd).await
     }
     async fn recv(&mut self) -> Option<Response> {

--- a/src/http-proxy/src/proxy.rs
+++ b/src/http-proxy/src/proxy.rs
@@ -26,6 +26,7 @@ use std::str::FromStr;
 use http::uri::{Authority, Uri};
 use ipnet::IpNet;
 use lazy_static::lazy_static;
+use tracing::warn;
 
 use self::matchers::{DomainMatcher, IpMatcher};
 
@@ -42,7 +43,7 @@ fn load_system_config() -> ProxyConfig {
         match val {
             Some(Ok(val)) => Some(val),
             Some(Err(e)) => {
-                tracing::warn!("ignoring invalid configuration for {}: {}", names[0], e);
+                warn!("ignoring invalid configuration for {}: {}", names[0], e);
                 None
             }
             None => None,
@@ -53,7 +54,7 @@ fn load_system_config() -> ProxyConfig {
         match get_any_env(names)?.parse() {
             Ok(uri) => Some(uri),
             Err(e) => {
-                tracing::warn!("ignoring invalid configuration for {}: {}", names[0], e);
+                warn!("ignoring invalid configuration for {}: {}", names[0], e);
                 None
             }
         }

--- a/src/interchange/src/avro/decode.rs
+++ b/src/interchange/src/avro/decode.rs
@@ -14,6 +14,7 @@ use std::io::Read;
 use std::rc::Rc;
 
 use ordered_float::OrderedFloat;
+use tracing::trace;
 use uuid::Uuid;
 
 use mz_avro::error::{DecodeError, Error as AvroError};
@@ -84,7 +85,7 @@ impl Decoder {
             )
         })?;
         let result = self.packer.finish_and_reuse();
-        tracing::trace!(
+        trace!(
             "[customer-data] Decoded row {:?} in {}",
             result,
             self.debug_name

--- a/src/materialized/src/http/root.rs
+++ b/src/materialized/src/http/root.rs
@@ -14,6 +14,8 @@ use std::future::Future;
 use askama::Template;
 use futures::future;
 use hyper::{Body, Method, Request, Response, StatusCode};
+#[cfg(feature = "dev-web")]
+use tracing::debug;
 
 use crate::http::util;
 use crate::BUILD_INFO;
@@ -79,7 +81,7 @@ fn get_static_file(path: &str) -> Option<Body> {
     match fs::read(dev_path).or_else(|_| fs::read(prod_path)) {
         Ok(contents) => Some(Body::from(contents)),
         Err(e) => {
-            tracing::debug!("dev-web failed to load static file: {}: {}", path, e);
+            debug!("dev-web failed to load static file: {}: {}", path, e);
             None
         }
     }

--- a/src/persist/examples/kafka_upsert.rs
+++ b/src/persist/examples/kafka_upsert.rs
@@ -18,6 +18,7 @@ use std::{cmp, env, process};
 use differential_dataflow::Hashable;
 use mz_persist::operators::stream::Persist;
 use serde::{Deserialize, Serialize};
+use tracing::info;
 
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::{NowFn, SYSTEM_TIME};
@@ -81,8 +82,8 @@ fn run(args: Vec<String>) -> Result<(), Box<dyn Error>> {
                 let err_stream = vec![(err.to_string(), 0, 1)].to_stream(scope);
                 (ok_stream, err_stream)
             });
-            ok_stream.inspect(|d| tracing::info!("ok: {:?}", d));
-            err_stream.inspect(|d| tracing::info!("err: {:?}", d));
+            ok_stream.inspect(|d| info!("ok: {:?}", d));
+            err_stream.inspect(|d| info!("err: {:?}", d));
         })
     })?;
 

--- a/src/persist/src/client.rs
+++ b/src/persist/src/client.rs
@@ -19,6 +19,7 @@ use std::sync::{Arc, Mutex};
 use differential_dataflow::trace::Description;
 use mz_persist_types::Codec;
 use timely::progress::Antichain;
+use tracing::error;
 
 use crate::error::Error;
 use crate::indexed::arrangement::{ArrangementSnapshot, ArrangementSnapshotIter};
@@ -776,7 +777,7 @@ struct StopRuntimeOnDrop {
 impl Drop for StopRuntimeOnDrop {
     fn drop(&mut self) {
         if let Err(err) = self.stop() {
-            tracing::error!("error while stopping dropped persist runtime: {}", err);
+            error!("error while stopping dropped persist runtime: {}", err);
         }
     }
 }

--- a/src/persist/src/indexed/mod.rs
+++ b/src/persist/src/indexed/mod.rs
@@ -29,6 +29,7 @@ use differential_dataflow::trace::Description;
 use mz_ore::cast::CastFrom;
 use timely::progress::Antichain;
 use timely::progress::Timestamp as TimelyTimestamp;
+use tracing::{error, trace, warn};
 
 use crate::error::Error;
 use crate::indexed::arrangement::{Arrangement, ArrangementSnapshot};
@@ -346,10 +347,10 @@ impl<L: Log, B: BlobRead> Indexed<L, B> {
                 //
                 // TODO: Regression test for this.
                 if let Err(err) = log.close() {
-                    tracing::warn!("error closing log: {}", err);
+                    warn!("error closing log: {}", err);
                 }
                 if let Err(err) = blob.close() {
-                    tracing::warn!("error closing blob: {}", err);
+                    warn!("error closing blob: {}", err);
                 }
                 err
             })?
@@ -801,9 +802,9 @@ impl<L: Log, B: BlobRead> Indexed<L, B> {
                     // This is a test and we've almost certainly used
                     // UnreliableBlob to make storage unavailable, log it at a
                     // lower level to keep test output a little less spammy.
-                    tracing::trace!("unable to read back persisted metadata: {:?}", e);
+                    trace!("unable to read back persisted metadata: {:?}", e);
                 } else {
-                    tracing::error!("unable to read back persisted metadata: {:?}", e);
+                    error!("unable to read back persisted metadata: {:?}", e);
                 }
             }
         }
@@ -839,9 +840,9 @@ impl<L: Log, B: BlobRead> Indexed<L, B> {
                     // This is a test and we've almost certainly used
                     // UnreliableBlob to make storage unavailable, log it at a
                     // lower level to keep test output a little less spammy.
-                    tracing::trace!("unable to read back persisted metadata: {:?}", e);
+                    trace!("unable to read back persisted metadata: {:?}", e);
                 } else {
-                    tracing::error!("unable to read back persisted metadata: {:?}", e);
+                    error!("unable to read back persisted metadata: {:?}", e);
                 }
             }
         }
@@ -1100,7 +1101,7 @@ impl<L: Log, B: Blob> Indexed<L, B> {
                 // TODO: revisit whether we need to move this to a different log level
                 // depending on how spammy it ends up being. Alternatively, we
                 // may want to rate-limit our logging here.
-                tracing::warn!("error running step: {:?}", e);
+                warn!("error running step: {:?}", e);
                 vec![]
             }
             Ok(reqs) => reqs,

--- a/src/persist/src/mem.rs
+++ b/src/persist/src/mem.rs
@@ -17,6 +17,7 @@ use async_trait::async_trait;
 use mz_ore::cast::CastFrom;
 use mz_ore::metrics::MetricsRegistry;
 use tokio::runtime::Runtime as AsyncRuntime;
+use tracing::warn;
 
 use crate::client::RuntimeClient;
 use crate::error::Error;
@@ -153,7 +154,7 @@ impl Drop for MemLog {
         // MemLog should have been closed gracefully; this drop is only here
         // as a failsafe. If it actually did anything, that's surprising.
         if did_work {
-            tracing::warn!("MemLog dropped without close");
+            warn!("MemLog dropped without close");
         }
     }
 }
@@ -339,7 +340,7 @@ impl Drop for MemBlob {
         // MemLog should have been closed gracefully; this drop is only here
         // as a failsafe. If it actually did anything, that's surprising.
         if did_work {
-            tracing::warn!("MemBlob dropped without close");
+            warn!("MemBlob dropped without close");
         }
     }
 }

--- a/src/persist/src/nemesis/validator.rs
+++ b/src/persist/src/nemesis/validator.rs
@@ -10,6 +10,7 @@
 use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 use std::time::Instant;
+use tracing::info;
 
 use differential_dataflow::lattice::Lattice;
 use timely::progress::{Antichain, Timestamp};
@@ -70,7 +71,7 @@ impl Validator {
     }
 
     fn step(&mut self, s: Step) {
-        tracing::info!("step: {:?}", &s);
+        info!("step: {:?}", &s);
         match s.res {
             Res::Write(WriteReq::Single(req), res) => self.step_write_single(&s.meta, req, res),
             Res::Write(WriteReq::Multi(req), res) => self.step_write_multi(&s.meta, req, res),

--- a/src/persist/src/operators/stream.rs
+++ b/src/persist/src/operators/stream.rs
@@ -30,6 +30,7 @@ use timely::progress::Antichain;
 use timely::progress::Timestamp as TimelyTimestamp;
 use timely::Data as TimelyData;
 use timely::PartialOrder;
+use tracing::{error, trace};
 
 use crate::client::MultiWriteHandle;
 use crate::client::StreamWriteHandle;
@@ -134,7 +135,7 @@ where
                         std::task::Poll::Ready(result) => {
                             match result {
                                 Ok(seq_no) => {
-                                    tracing::trace!(
+                                    trace!(
                                         "In {}, finished writing for time: {}, seq_no: {:?}",
                                         &operator_name,
                                         cap.time(),
@@ -149,7 +150,7 @@ where
                                         error_cap.time(),
                                         e
                                     );
-                                    tracing::error!("{}", error);
+                                    error!("{}", error);
 
                                     // TODO: make error retractable? Probably not...
                                     session.give((error, *error_cap.time(), 1));
@@ -287,7 +288,7 @@ where
                 // This way, we are prepared for a future of multi-dimensional frontiers, though.
                 for frontier_element in new_input_frontier.iter() {
                     if input_frontier.less_than(&frontier_element) {
-                        tracing::trace!(
+                        trace!(
                             "In {}, sealing collection up to {}...",
                             &operator_name,
                             frontier_element,
@@ -311,7 +312,7 @@ where
                 while let Some(mut pending_future) = pending_futures.pop_front() {
                     match Pin::new(&mut pending_future.future).poll(&mut context) {
                         std::task::Poll::Ready(Ok(_)) => {
-                            tracing::trace!(
+                            trace!(
                                 "In {}, finished sealing collection up to {}",
                                 &operator_name,
                                 pending_future.time,
@@ -321,7 +322,7 @@ where
                             cap_set.downgrade(Some(pending_future.time));
                         }
                         std::task::Poll::Ready(Err(e)) => {
-                            tracing::trace!(
+                            trace!(
                                 "Error sealing {} up to {}: {}",
                                 &operator_name,
                                 pending_future.time,
@@ -343,10 +344,7 @@ where
                             };
 
                             if retry {
-                                tracing::trace!(
-                                    "Adding seal to queue again: {}",
-                                    pending_future.time
-                                );
+                                trace!("Adding seal to queue again: {}", pending_future.time);
 
                                 let future = write.seal_all(pending_future.time);
                                 pending_futures.push_front(SealFuture {

--- a/src/persist/src/operators/upsert.rs
+++ b/src/persist/src/operators/upsert.rs
@@ -21,6 +21,7 @@ use timely::dataflow::operators::{Concat, Map, OkErr};
 use timely::dataflow::operators::{Delay, Operator};
 use timely::dataflow::{Scope, Stream};
 use timely::progress::Antichain;
+use tracing::trace;
 
 use crate::client::{StreamReadHandle, StreamWriteHandle};
 use crate::operators::replay::Replay;
@@ -170,11 +171,7 @@ where
                     state_input.for_each(|_time, data| {
                         data.swap(&mut state_input_buffer);
                         for state_update in state_input_buffer.drain(..) {
-                            tracing::trace!(
-                                "In {}, restored upsert: {:?}",
-                                operator_name,
-                                state_update
-                            );
+                            trace!("In {}, restored upsert: {:?}", operator_name, state_update);
 
                             differential_state_ingester
                                 .as_mut()
@@ -194,7 +191,7 @@ where
                             .finish();
                         current_values.extend(initial_state.into_iter());
 
-                        tracing::trace!(
+                        trace!(
                             "In {}, initial (restored) upsert state: {:?}",
                             operator_name,
                             current_values.iter().take(10).collect::<Vec<_>>()

--- a/src/persist/src/runtime.rs
+++ b/src/persist/src/runtime.rs
@@ -15,6 +15,7 @@ use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
+use tracing::error;
 
 use mz_build_info::BuildInfo;
 use mz_ore::metrics::MetricsRegistry;
@@ -250,10 +251,10 @@ impl RuntimeHandle {
                     // stopped, so we can return an Ok. This is surprising,
                     // though, so log a message. Unfortunately, there isn't
                     // really a way to put the panic message in this log.
-                    tracing::error!("persist runtime thread panic'd");
+                    error!("persist runtime thread panic'd");
                 }
                 if let Err(err) = block_on(ticker_handle) {
-                    tracing::error!("persist ticker thread error'd: {:?}", err);
+                    error!("persist ticker thread error'd: {:?}", err);
                 }
                 // Thread a copy of the Arc<AsyncRuntime> being used to drive
                 // ticker_handle to make sure the runtime doesn't shut down before
@@ -269,7 +270,7 @@ impl RuntimeHandle {
                     // stopped, so we can return an Ok. This is surprising,
                     // though, so log a message. Unfortunately, there isn't
                     // really a way to put the panic message in this log.
-                    tracing::error!("persist runtime thread panic'd");
+                    error!("persist runtime thread panic'd");
                 }
             }
         }

--- a/src/persist/src/storage.rs
+++ b/src/persist/src/storage.rs
@@ -17,6 +17,7 @@ use std::str::FromStr;
 use async_trait::async_trait;
 use futures_executor::block_on;
 use serde::{Deserialize, Serialize};
+use tracing::info;
 
 use crate::error::Error;
 use crate::gen::persist::ProtoMeta;
@@ -40,7 +41,7 @@ pub fn check_meta_version_maybe_delete_data<B: Blob>(b: &mut B) -> Result<(), Er
         Ok(())
     } else if current_version > persisted_version {
         // Delete all the keys, as we are upgrading to a new version.
-        tracing::info!(
+        info!(
             "Persistence beta detected version mismatch. Deleting all previously persisted data as part of upgrade from version {} to {}.",
             persisted_version,
             current_version

--- a/src/s3-datagen/src/main.rs
+++ b/src/s3-datagen/src/main.rs
@@ -15,6 +15,7 @@ use aws_sdk_s3::model::{BucketLocationConstraint, CreateBucketConfiguration};
 use aws_sdk_s3::SdkError;
 use clap::Parser;
 use futures::stream::{self, StreamExt, TryStreamExt};
+use tracing::event;
 use tracing::{error, info, Level};
 use tracing_subscriber::filter::EnvFilter;
 use tracing_subscriber::fmt;
@@ -130,7 +131,7 @@ async fn run() -> anyhow::Result<()> {
                     },
                 ..
             } => {
-                tracing::event!(Level::INFO, bucket = %args.bucket, "reusing existing bucket");
+                event!(Level::INFO, bucket = %args.bucket, "reusing existing bucket");
                 Ok(())
             }
             _ => Err(e),

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -24,7 +24,7 @@ use globset::GlobBuilder;
 use itertools::Itertools;
 use regex::Regex;
 use reqwest::Url;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use mz_dataflow_types::{
     sinks::{
@@ -1807,7 +1807,7 @@ pub fn plan_create_sink(
                 if key.not_enforced && envelope == SinkEnvelope::Upsert {
                     // TODO: We should report a warning notice back to the user via the pgwire
                     // protocol. See https://github.com/MaterializeInc/materialize/issues/9333.
-                    tracing::warn!(
+                    warn!(
                         "Verification of upsert key disabled for sink '{}' via 'NOT ENFORCED'. This is potentially dangerous and can lead to crashing materialize when the specified key is not in fact a unique key of the sinked view.",
                         name
                     );

--- a/test/test-util/src/mz_client.rs
+++ b/test/test-util/src/mz_client.rs
@@ -10,6 +10,7 @@
 use anyhow::Result;
 use tokio::time::{self, Duration};
 use tokio_postgres::{error::SqlState, Client, Error, NoTls, Row};
+use tracing::{debug, info};
 
 use mz_ore::task;
 
@@ -68,7 +69,7 @@ pub async fn try_query_one(mz_client: &Client, query: &str, delay: Duration) -> 
 /// instead of failing.
 fn check_error(e: Error) -> Result<()> {
     if e.code() == Some(&SqlState::SQL_STATEMENT_NOT_YET_COMPLETE) {
-        tracing::info!("Error querying, will try again... {}", e.to_string());
+        info!("Error querying, will try again... {}", e.to_string());
         Ok(())
     } else {
         Err(anyhow::Error::from(e))
@@ -80,10 +81,9 @@ async fn delay_for(elapsed: Duration, delay: Duration) {
     if elapsed < delay {
         time::sleep(delay - elapsed).await;
     } else {
-        tracing::info!(
+        info!(
             "Expected to query for records in {:#?}, took {:#?}",
-            delay,
-            elapsed
+            delay, elapsed
         );
     }
 }
@@ -101,21 +101,21 @@ pub async fn show_sources(mz_client: &Client) -> Result<Vec<String>> {
 /// Delete a source and all dependent views, if the source exists
 pub async fn drop_source(mz_client: &Client, name: &str) -> Result<()> {
     let q = format!("DROP SOURCE IF EXISTS {} CASCADE", name);
-    tracing::debug!("deleting source=> {}", q);
+    debug!("deleting source=> {}", q);
     mz_client.execute(&*q, &[]).await?;
     Ok(())
 }
 
 /// Run PostgreSQL's `execute` function
 pub async fn execute(mz_client: &Client, query: &str) -> Result<u64> {
-    tracing::debug!("exec=> {}", query);
+    debug!("exec=> {}", query);
     Ok(mz_client.execute(query, &[]).await?)
 }
 
 /// Delete an index
 pub async fn drop_index(mz_client: &Client, name: &str) -> Result<()> {
     let q = format!("DROP INDEX {}", name);
-    tracing::debug!("deleting index=> {}", q);
+    debug!("deleting index=> {}", q);
     mz_client.execute(&*q, &[]).await?;
     Ok(())
 }


### PR DESCRIPTION
It was mentioned in the initial tracing PR that this would be nicer, and I was
cleaning up something I was interacting with anyway, so.


### Motivation

* This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).