### PR TITLE
allow non `Send` futures in a few coord related traits

### DIFF
--- a/src/coordtest/src/lib.rs
+++ b/src/coordtest/src/lib.rs
@@ -569,7 +569,7 @@ impl<C> Clone for InterceptingDataflowClient<C> {
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<C> mz_dataflow_types::client::Client for InterceptingDataflowClient<C>
 where
     C: mz_dataflow_types::client::Client,

--- a/src/dataflow-types/src/client/controller.rs
+++ b/src/dataflow-types/src/client/controller.rs
@@ -10,12 +10,14 @@
 //! A client that maintains summaries of the involved objects.
 use std::collections::BTreeMap;
 
+use async_trait::async_trait;
+use timely::progress::{frontier::AntichainRef, Antichain, ChangeBatch};
+
 use crate::client::{
     Client, Command, ComputeCommand, ComputeInstanceId, ComputeResponse, Response, StorageCommand,
 };
 use mz_expr::GlobalId;
 use mz_repr::Timestamp;
-use timely::progress::{frontier::AntichainRef, Antichain, ChangeBatch};
 
 /// A client that maintains soft state and validates commands, in addition to forwarding them.
 pub struct Controller<C> {
@@ -31,7 +33,7 @@ pub struct Controller<C> {
     storage_since_uppers: SinceUpperMap,
 }
 
-#[async_trait::async_trait]
+#[async_trait(?Send)]
 impl<C: Client> Client for Controller<C> {
     async fn send(&mut self, cmd: Command) {
         self.send(cmd).await

--- a/src/dataflowd/src/lib.rs
+++ b/src/dataflowd/src/lib.rs
@@ -14,6 +14,8 @@
 
 #![deny(missing_docs)]
 
+use async_trait::async_trait;
+
 use mz_dataflow_types::client::{partitioned::Partitioned, Client, Command, Response};
 
 /// A convenience type for compatibility.
@@ -34,7 +36,7 @@ impl RemoteClient {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait(?Send)]
 impl Client for RemoteClient {
     async fn send(&mut self, cmd: Command) {
         tracing::trace!("Broadcasting dataflow command: {:?}", cmd);
@@ -48,6 +50,7 @@ impl Client for RemoteClient {
 /// A client to a remote dataflow server.
 pub mod tcp {
 
+    use async_trait::async_trait;
     use futures::sink::SinkExt;
     use futures::stream::StreamExt;
     use tokio::io::{AsyncRead, AsyncWrite};
@@ -70,7 +73,7 @@ pub mod tcp {
         }
     }
 
-    #[async_trait::async_trait]
+    #[async_trait(?Send)]
     impl mz_dataflow_types::client::Client for TcpClient {
         async fn send(&mut self, cmd: mz_dataflow_types::client::Command) {
             // TODO: something better than panicking.


### PR DESCRIPTION
### Motivation

The main coord future is already running on a single thread and it does not need futures to be `Send`. `async_trait` adds a `Send` bound by default so this PR removes it where appropriate.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
