### PR TITLE
persist: add s3 coverage to nemesis

### DIFF
--- a/src/persist/src/nemesis/mod.rs
+++ b/src/persist/src/nemesis/mod.rs
@@ -61,7 +61,6 @@
 //! ```
 
 // TODO
-// - Variant with S3Blob
 // - Impl of Runtime directly using Indexed
 // - Impl of Runtime with Timely workers running in processes
 // - Storage (log/blob) with variable latency/slow requests


### PR DESCRIPTION
Given that s3 is our production Blob implementation and nemesis is an
important part of our correctness test coverage, it makes sense to have
this variant.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
