### PR TITLE
Remove `Controller` assertions and return errors instead

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -552,7 +552,8 @@ impl Coordinator {
                             entry.id(),
                             (source_description, Antichain::from_elem(since_ts)),
                         )])
-                        .await;
+                        .await
+                        .unwrap();
                 }
                 CatalogItem::Table(table) => {
                     self.persister
@@ -586,7 +587,8 @@ impl Coordinator {
                             entry.id(),
                             (source_description, Antichain::from_elem(since_ts)),
                         )])
-                        .await;
+                        .await
+                        .unwrap();
                 }
                 CatalogItem::Index(_) => {
                     if BUILTINS.logs().any(|log| log.index_id == entry.id()) {
@@ -1570,7 +1572,8 @@ impl Coordinator {
             self.persisted_table_allow_compaction(&index_since_updates);
             self.dataflow_client
                 .allow_index_compaction(DEFAULT_COMPUTE_INSTANCE_ID, index_since_updates)
-                .await;
+                .await
+                .unwrap();
         }
 
         let source_since_updates: Vec<_> = self
@@ -2220,7 +2223,8 @@ impl Coordinator {
                         table_id,
                         (source_description, Antichain::from_elem(since_ts)),
                     )])
-                    .await;
+                    .await
+                    .unwrap();
                 // Install the dataflow if so required.
                 if let Some(df) = df {
                     let frontiers = self.new_source_frontiers(
@@ -2321,7 +2325,8 @@ impl Coordinator {
 
                 self.dataflow_client
                     .create_sources(source_descriptions)
-                    .await;
+                    .await
+                    .unwrap();
                 self.ship_dataflows(dfs).await;
                 Ok(ExecuteResponse::CreatedSource { existed: false })
             }
@@ -4354,7 +4359,8 @@ impl Coordinator {
         }
         self.dataflow_client
             .create_dataflows(DEFAULT_COMPUTE_INSTANCE_ID, dataflow_plans)
-            .await;
+            .await
+            .unwrap();
     }
 
     /// Finalizes a dataflow.
@@ -4660,11 +4666,13 @@ pub async fn serve(
                     .collect(),
                 log_logging: config.log_logging,
             });
-            handle.block_on(
-                coord
-                    .dataflow_client
-                    .create_instance(DEFAULT_COMPUTE_INSTANCE_ID, logging),
-            );
+            handle
+                .block_on(
+                    coord
+                        .dataflow_client
+                        .create_instance(DEFAULT_COMPUTE_INSTANCE_ID, logging),
+                )
+                .unwrap();
             let bootstrap = handle.block_on(coord.bootstrap(builtin_table_updates));
             let ok = bootstrap.is_ok();
             bootstrap_tx.send(bootstrap).unwrap();
@@ -5053,7 +5061,8 @@ pub mod fast_path_peek {
                     // Very important: actually create the dataflow (here, so we can destructure).
                     self.dataflow_client
                         .create_dataflows(DEFAULT_COMPUTE_INSTANCE_ID, vec![dataflow])
-                        .await;
+                        .await
+                        .unwrap();
                     // Create an identity MFP operator.
                     let mut map_filter_project = mz_expr::MapFilterProject::new(source_arity);
                     map_filter_project

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -5110,7 +5110,8 @@ pub mod fast_path_peek {
                     finishing.clone(),
                     map_filter_project,
                 )
-                .await;
+                .await
+                .unwrap();
 
             use futures::FutureExt;
             use futures::StreamExt;


### PR DESCRIPTION
This PR changes the return type of `Controller` methods to present errors in cases the controller would panic due to dynamically verified constraints (e.g. all identifiers present, `since` frontiers are valid, etc).

All previous uses of these methods simply `unwrap()` their results, panicking just as they would before. However, there is now the possibility of some remediation whereas there would not be otherwise. The methods validate the transition before they take them, so that if an error is returned the command had no effect.

These validation steps could likely be broken out to independent methods to allow users (@mjibson, @sploiselle) to validate commands before launching them. We can do that in follow up work if it would be useful, but didn't want to overdo it here.

### Motivation

   * This PR refactors existing code.

The coordinator was at the mercy of the `Controller` to determine what commands would work and which would not. Ideally this gets us closer to clearer communication and less guessing.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
