### PR TITLE
ci: increase the priority of longer-running jobs

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -44,6 +44,30 @@ steps:
   - wait: ~
     if: build.source == "ui"
 
+  - id: feature-benchmark
+    label: "Feature benchmark against latest release"
+    timeout_in_minutes: 120
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: feature-benchmark
+          args:
+            - --other-tag
+            - latest
+
+  - id: feature-benchmark-persistence
+    label: "Feature benchmark against latest release with persistence"
+    timeout_in_minutes: 120
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: feature-benchmark
+          args:
+            - --other-tag
+            - latest
+            - --this-options
+            - "--persistent-user-tables --persistent-kafka-sources"
+            - --other-options
+            - "--persistent-user-tables --persistent-kafka-sources"
+
   - id: coverage
     label: Code coverage
     timeout_in_minutes: 240
@@ -133,30 +157,6 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: testdrive
           args: [--aws-region=us-east-2, --persistent-user-tables]
-
-  - id: feature-benchmark
-    label: "Feature benchmark against latest release"
-    timeout_in_minutes: 120
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: feature-benchmark
-          args:
-            - --other-tag
-            - latest
-
-  - id: feature-benchmark-persistence
-    label: "Feature benchmark against latest release with persistence"
-    timeout_in_minutes: 120
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: feature-benchmark
-          args:
-            - --other-tag
-            - latest
-            - --this-options
-            - "--persistent-user-tables --persistent-kafka-sources"
-            - --other-options
-            - "--persistent-user-tables --persistent-kafka-sources"
 
   - id: aws-config
     label: "AWS credentials and role assumption"

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -98,6 +98,14 @@ steps:
     agents:
       queue: builder
 
+  - id: persistence
+    label: Persistence tests
+    depends_on: build-x86_64
+    artifact_paths: junit_mzcompose_*.xml
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: persistence
+
   - id: testdrive
     label: Testdrive %n
     depends_on: build-x86_64
@@ -309,14 +317,6 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: kafka-exactly-once
-
-  - id: persistence
-    label: Persistence tests
-    depends_on: build-x86_64
-    artifact_paths: junit_mzcompose_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: persistence
 
   - id: lang-csharp
     label: ":csharp: tests"


### PR DESCRIPTION
Buildkite schedules jobs based on the order of their appearance
in the .yml file. This causes some longer-running jobs to wait
for an available agent for a while, which increases the total
execution time of the entire pipeline.

So, tag certain longer-running jobs with "priority: 1", which will
cause them to be scheduled before all others.