### PR TITLE
mzcompose,feature-benchmark: Usability improvements

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -184,11 +184,16 @@ class Composition:
         error: Optional[str]
 
     def __init__(
-        self, repo: mzbuild.Repository, name: str, preserve_ports: bool = False
+        self,
+        repo: mzbuild.Repository,
+        name: str,
+        preserve_ports: bool = False,
+        silent: bool = False,
     ):
         self.name = name
         self.repo = repo
         self.preserve_ports = preserve_ports
+        self.silent = silent
         self.workflows: Dict[str, Callable[..., None]] = {}
         self.test_results: OrderedDict[str, Composition.TestResult] = OrderedDict()
 
@@ -333,7 +338,9 @@ class Composition:
             args: The arguments to pass to `docker-compose`.
             capture: Whether to capture the child's stdout stream.
         """
-        print(f"$ docker-compose {' '.join(args)}", file=sys.stderr)
+
+        if not self.silent:
+            print(f"$ docker-compose {' '.join(args)}", file=sys.stderr)
 
         self.file.seek(0)
 
@@ -345,6 +352,7 @@ class Composition:
             return subprocess.run(
                 [
                     "docker-compose",
+                    *(["--log-level=ERROR"] if self.silent else []),
                     f"-f/dev/fd/{self.file.fileno()}",
                     "--project-directory",
                     self.path,

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -116,6 +116,9 @@ def run_one_scenario(
 
     for mz_id, instance in enumerate(["this", "other"]):
         with c.override(mzs[instance]):
+            print(f"The version of the '{instance.upper()}' Mz instance is:")
+            c.run("materialized", "--version")
+
             c.start_and_wait_for_tcp(services=["materialized"])
             c.wait_for_materialized()
 
@@ -146,6 +149,8 @@ def run_one_scenario(
 
 def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     """Feature benchmark framework."""
+
+    c.silent = True
 
     parser.add_argument(
         "--this-tag",


### PR DESCRIPTION
- reduce the amount of docker-compose stuff printed to STDOUT
  Note that docker-compose may continue to emit unsilencable
  messages (see docker/compose#6026), so until they get their
  verbosity story straight we are making the bare minimum amount
  of changes on our side to get the currently-available benefit.

- make sure we dump the version of the Mz binary under test to
  stdout. This is to resolve any ambiguity as to what Mz version
  is being benchmarked. Ideally in the future this should
  be printed as part of the final result table.
### Motivation

  * This PR fixes a previously unreported bug.

The output of the feature benchmark contained a bunch of docker-compose cruft. Turns out that some messages can be silenced while the others are hard-coded to always be printed regardless of the logging level. Still, take advantage of what is currently available.

Also, in CI scenarios where `--other-tag latest` is used, it was difficult to figure out which git SHAs / Mz version the feature benchmark has locked onto for the `OTHER` measurements.