### PR TITLE
persist: chunk up a trace batch into multiple keys

### DIFF
--- a/src/persist/benches/benches.rs
+++ b/src/persist/benches/benches.rs
@@ -36,6 +36,7 @@ pub fn bench_persist(c: &mut Criterion) {
         &mut c.benchmark_group("writer/blob_cache_set_unsealed_batch"),
     );
     writer::bench_indexed_drain(&data, &mut c.benchmark_group("writer/indexed_drain"));
+    writer::bench_compact_trace(&data, &mut c.benchmark_group("writer/compact_trace"));
 }
 
 // The grouping here is an artifact of criterion's interaction with the

--- a/src/persist/src/indexed/background.rs
+++ b/src/persist/src/indexed/background.rs
@@ -18,13 +18,14 @@ use timely::progress::Antichain;
 use timely::PartialOrder;
 use tokio::runtime::Runtime as AsyncRuntime;
 
+use mz_ore::cast::CastFrom;
 use mz_ore::task::RuntimeExt;
 
 use crate::error::Error;
 use crate::gen::persist::ProtoBatchFormat;
 use crate::indexed::arrangement::Arrangement;
 use crate::indexed::cache::{BlobCache, CacheHint};
-use crate::indexed::columnar::ColumnarRecordsVec;
+use crate::indexed::columnar::{ColumnarRecords, ColumnarRecordsVecBuilder};
 use crate::indexed::encoding::{BlobTraceBatchPart, TraceBatchMeta, UnsealedSnapshotMeta};
 use crate::indexed::metrics::Metrics;
 use crate::pfuture::PFuture;
@@ -83,6 +84,8 @@ pub struct Maintainer<B> {
     blob: Arc<BlobCache<B>>,
     async_runtime: Arc<AsyncRuntime>,
     metrics: Arc<Metrics>,
+    // Bound the maximum size of any [ColumnarRecordsVec], only used in testing.
+    key_val_data_max_len: Option<usize>,
 }
 
 impl<B: BlobRead> Maintainer<B> {
@@ -96,6 +99,23 @@ impl<B: BlobRead> Maintainer<B> {
             blob: Arc::new(blob),
             async_runtime,
             metrics,
+            key_val_data_max_len: None,
+        }
+    }
+
+    /// Returns a new [Maintainer].
+    #[cfg(test)]
+    fn new_for_testing(
+        blob: BlobCache<B>,
+        async_runtime: Arc<AsyncRuntime>,
+        metrics: Arc<Metrics>,
+        key_val_data_max_len: usize,
+    ) -> Self {
+        Maintainer {
+            blob: Arc::new(blob),
+            async_runtime,
+            metrics,
+            key_val_data_max_len: Some(key_val_data_max_len),
         }
     }
 }
@@ -107,6 +127,7 @@ impl<B: Blob> Maintainer<B> {
         let (tx, rx) = PFuture::new();
         let blob = Arc::clone(&self.blob);
         let metrics = Arc::clone(&self.metrics);
+        let key_val_data_max_len = self.key_val_data_max_len.clone();
         // Ignore the spawn_blocking response since we communicate
         // success/failure through the returned future.
         //
@@ -116,15 +137,52 @@ impl<B: Blob> Maintainer<B> {
         // TODO(guswynn): consider adding more info to the task name here
         let _ = self.async_runtime.spawn_blocking_named(
             || "persist_trace_compaction",
-            move || tx.fill(Self::compact_trace_blocking(blob, metrics, req)),
+            move || {
+                tx.fill(Self::compact_trace_blocking(
+                    blob,
+                    metrics,
+                    req,
+                    key_val_data_max_len,
+                ))
+            },
         );
         rx
     }
 
+    /// Physically and logically compact two trace batches together
+    ///
+    /// This function performs trace compaction with bounded memory usage by:
+    ///
+    /// 1. Only ever keeping one BlobTraceBatchPart in memory from each of
+    ///    the two batches being compacted at a time.
+    /// 2. Only keeping one ColumnarRecords worth of merged data in memory at
+    ///    a time.
+    /// 3. Performing roughly a linear merge on the two trace batch parts and
+    ///    as we read data from each trace batch, figuring out the upper bound
+    ///    on data that can be compacted, consolidating and merging that, and
+    ///    then placing that in a ColumnarRecords to await being written out as
+    ///    an output BlobTraceBatchPart.
+    ///
+    /// (3). is best explained with an example. If we are compacting two trace
+    /// batches, A which has two parts, one with keys [0, 10) and one with keys
+    /// [10, 20) and B has three parts, with keys [0, 15), [15, 30) and [30, 45)
+    /// respectively then while compacting when we observe the first batches from
+    /// A and B which have keys [0, 10) and [0, 15) respectively, we cannot merge
+    /// all of both batches together.
+    ///
+    /// We can only merge the subset of keys in [0, 10), as its possible that
+    /// subsequent parts in A have relevant keys in [10, 15).
+    ///
+    /// TODO(rkhaitan): We don't do the real linear merge as compaction requires
+    /// us to both forward times and consolidate multiple updates at the
+    /// forwarded times. I believe that doing so is possible in linear time, but
+    /// doing so in a single pass was complicated enough that it is left for
+    /// future work.
     fn compact_trace_blocking(
         blob: Arc<BlobCache<B>>,
         metrics: Arc<Metrics>,
         req: CompactTraceReq,
+        key_val_data_max_len: Option<usize>,
     ) -> Result<CompactTraceRes, Error> {
         let start = Instant::now();
         let (first, second) = (&req.b0, &req.b1);
@@ -162,67 +220,141 @@ impl<B: Blob> Maintainer<B> {
             second.desc.upper().clone(),
             req.since.clone(),
         );
-        let format = ProtoBatchFormat::ParquetKvtd;
 
-        let mut updates = vec![];
-        let mut batches = vec![];
+        // Iterators over all of the keys in the first and second batch, respectively.
+        let mut first_batch_iter = first.keys.iter();
+        let mut second_batch_iter = second.keys.iter();
 
-        for key in first.keys.iter() {
-            batches.push(
-                blob.get_trace_batch_async(key, CacheHint::NeverAdd)
-                    .recv()?,
-            );
-        }
+        // Buffer for data from the first and second batch, respectively.
+        let mut first_updates = vec![];
+        let mut second_updates = vec![];
 
-        for key in second.keys.iter() {
-            batches.push(
-                blob.get_trace_batch_async(key, CacheHint::NeverAdd)
-                    .recv()?,
-            );
-        }
+        // Buffer for data that needs to be advanced to since, and consolidated before
+        // being sent to a ColumnarRecordsVecBuilder.
+        let mut consolidation_buffer = vec![];
 
-        for batch in batches.iter() {
-            updates.extend(batch.updates.iter().flat_map(|u| u.iter()));
-        }
+        // Buffer for consolidated data that is ready to be moved into storage.
+        let mut builder = match key_val_data_max_len {
+            None => ColumnarRecordsVecBuilder::default(),
+            Some(key_val_data_max_len) => {
+                ColumnarRecordsVecBuilder::new_with_len(key_val_data_max_len)
+            }
+        };
 
-        for ((_, _), ts, _) in updates.iter_mut() {
-            ts.advance_by(desc.since().borrow());
-        }
+        let mut new_size_bytes = 0;
+        let mut keys = vec![];
 
-        differential_dataflow::consolidation::consolidate_updates(&mut updates);
+        loop {
+            // Loop invariant: we don't have any data that needs consolidation across iterations.
+            debug_assert!(consolidation_buffer.is_empty());
 
-        let (keys, level, size_bytes) = if !updates.is_empty() {
-            let updates = updates.iter().collect::<ColumnarRecordsVec>().into_inner();
-            let new_batch = BlobTraceBatchPart {
-                desc: desc.clone(),
-                index: 0,
-                updates,
+            // Pull more data if either of the holding pens from first or second are empty
+            //
+            // TODO: we can simplify this logic once empty trace batch parts are disallowed.
+            while first_updates.is_empty() {
+                match first_batch_iter.next() {
+                    Some(key) => Self::load_trace_batch_part(&blob, key, &mut first_updates)?,
+                    None => break,
+                }
+            }
+
+            while second_updates.is_empty() {
+                match second_batch_iter.next() {
+                    Some(key) => Self::load_trace_batch_part(&blob, key, &mut second_updates)?,
+                    None => break,
+                }
+            }
+
+            // Figure out the stopping point for records we can safely consolidate.
+            // This is the min max value across the two batches we have seen so far.
+            //
+            // If both input buffers are empty we can exit the compaction loop.
+            let threshold_key_val = match (first_updates.last(), second_updates.last()) {
+                (Some((f, _, _)), Some((s, _, _))) => {
+                    if f < s {
+                        f.clone()
+                    } else {
+                        s.clone()
+                    }
+                }
+                (Some((f, _, _)), None) => f.clone(),
+                (None, Some((s, _, _))) => s.clone(),
+                (None, None) => break,
             };
 
-            let merged_key = Arrangement::new_blob_key();
-            let size_bytes = blob.set_trace_batch(merged_key.clone(), new_batch, format)?;
+            // Move all of the records <= threshold out of the various holding
+            // pens into a common buffer so that they can be consolidated.
+            first_updates = Self::drain_leq_threshold(
+                first_updates,
+                &mut consolidation_buffer,
+                &threshold_key_val,
+            );
+            second_updates = Self::drain_leq_threshold(
+                second_updates,
+                &mut consolidation_buffer,
+                &threshold_key_val,
+            );
 
-            // Only upgrade the compaction level if we know this new batch represents
-            // an increase in data over both of its parents so that we know we need
-            // even more additional batches to amortize the cost of compacting it in
-            // the future.
-            let merged_level = if size_bytes > first.size_bytes && size_bytes > second.size_bytes {
+            // Advance timestamps and consolidate records.
+            for ((_, _), ts, _) in consolidation_buffer.iter_mut() {
+                ts.advance_by(desc.since().borrow());
+            }
+            differential_dataflow::consolidation::consolidate_updates(&mut consolidation_buffer);
+
+            for ((key, val), time, diff) in consolidation_buffer.iter() {
+                builder.push(((key, val), *time, *diff));
+
+                // Move data from builder into storage as we fill up ColumnarRecords.
+                if let Some(filled) = builder.take_filled() {
+                    for part in filled {
+                        debug_assert!(part.len() > 0);
+                        let (key, part_size_bytes) = Self::write_trace_batch_part(
+                            &blob,
+                            desc.clone(),
+                            part,
+                            u64::cast_from(keys.len()),
+                        )?;
+                        keys.push(key);
+                        new_size_bytes += part_size_bytes;
+                    }
+                }
+            }
+
+            consolidation_buffer.clear();
+        }
+
+        // Grab the last ColumnarRecords if nonempty ones remain.
+        let finished = builder.finish();
+        for part in finished {
+            if part.len() > 0 {
+                let (key, part_size_bytes) = Self::write_trace_batch_part(
+                    &blob,
+                    desc.clone(),
+                    part,
+                    u64::cast_from(keys.len()),
+                )?;
+                keys.push(key);
+                new_size_bytes += part_size_bytes;
+            }
+        }
+
+        // Only upgrade the compaction level if we know this new batch represents
+        // an increase in data over both of its parents so that we know we need
+        // even more additional batches to amortize the cost of compacting it in
+        // the future.
+        let merged_level =
+            if new_size_bytes > first.size_bytes && new_size_bytes > second.size_bytes {
                 first.level + 1
             } else {
                 first.level
             };
 
-            (vec![merged_key], merged_level, size_bytes)
-        } else {
-            (vec![], first.level, 0)
-        };
-
         let merged = TraceBatchMeta {
             keys,
-            format,
+            format: ProtoBatchFormat::ParquetKvtd,
             desc,
-            level,
-            size_bytes,
+            level: merged_level,
+            size_bytes: new_size_bytes,
         };
 
         debug_assert_eq!(merged.validate_data(&blob), Ok(()));
@@ -230,6 +362,71 @@ impl<B: Blob> Maintainer<B> {
             .compaction_seconds
             .inc_by(start.elapsed().as_secs_f64());
         Ok(CompactTraceRes { req, merged })
+    }
+
+    /// Read the data from the trace batch part at `key` into `updates`.
+    fn load_trace_batch_part(
+        blob: &BlobCache<B>,
+        key: &str,
+        updates: &mut Vec<((Vec<u8>, Vec<u8>), u64, i64)>,
+    ) -> Result<(), Error> {
+        let batch_part = blob
+            .get_trace_batch_async(key, CacheHint::NeverAdd)
+            .recv()?;
+        updates.extend(batch_part.updates.iter().flat_map(|u| {
+            u.iter()
+                .map(|((k, v), t, d)| ((k.to_vec(), v.to_vec()), t, d))
+        }));
+
+        Ok(())
+    }
+
+    /// Drain all records from `updates` with a (key, val) <= `threshold` into
+    /// `buffer`.
+    ///
+    /// TODO: this could be replaced with a drain_filter if that wasn't
+    /// experimental.
+    fn drain_leq_threshold(
+        mut updates: Vec<((Vec<u8>, Vec<u8>), u64, i64)>,
+        buffer: &mut Vec<((Vec<u8>, Vec<u8>), u64, i64)>,
+        threshold: &(Vec<u8>, Vec<u8>),
+    ) -> Vec<((Vec<u8>, Vec<u8>), u64, i64)> {
+        let mut i = 0;
+        while i < updates.len() {
+            if &updates[i].0 <= threshold {
+                i += 1;
+            } else {
+                break;
+            }
+        }
+
+        if i > 0 {
+            let updates_new = updates.split_off(i);
+            buffer.extend(updates.into_iter());
+            updates_new
+        } else {
+            updates
+        }
+    }
+
+    /// Write a [BlobTraceBatchPart] containing `updates` into [Blob].
+    ///
+    /// Returns the key and size in bytes for the trace batch part.
+    fn write_trace_batch_part(
+        blob: &BlobCache<B>,
+        desc: Description<u64>,
+        updates: ColumnarRecords,
+        index: u64,
+    ) -> Result<(String, u64), Error> {
+        let batch_part = BlobTraceBatchPart {
+            desc,
+            updates: vec![updates],
+            index,
+        };
+        let key = Arrangement::new_blob_key();
+        let size_bytes =
+            blob.set_trace_batch(key.clone(), batch_part, ProtoBatchFormat::ParquetKvtd)?;
+        Ok((key, size_bytes))
     }
 }
 
@@ -253,104 +450,14 @@ mod tests {
         )
     }
 
-    #[test]
-    fn compact_trace() -> Result<(), Error> {
-        let async_runtime = Arc::new(AsyncRuntime::new()?);
-        let metrics = Arc::new(Metrics::default());
-        let blob = BlobCache::new(
-            mz_build_info::DUMMY_BUILD_INFO,
-            Arc::new(Metrics::default()),
-            Arc::clone(&async_runtime),
-            MemRegistry::new().blob_no_reentrance()?,
-            None,
-        );
-        let maintainer = Maintainer::new(blob.clone(), async_runtime, metrics);
-
-        let b0 = BlobTraceBatchPart {
-            desc: desc_from(0, 1, 0),
-            index: 0,
-            updates: vec![
-                (("k".as_bytes(), "v".as_bytes()), 0, 1),
-                (("k2".as_bytes(), "v2".as_bytes()), 0, 1),
-            ]
-            .into_iter()
-            .collect::<ColumnarRecordsVec>()
-            .into_inner(),
-        };
-        let format = ProtoBatchFormat::ParquetKvtd;
-        let b0_size_bytes = blob.set_trace_batch("b0".into(), b0.clone(), format)?;
-
-        let b1 = BlobTraceBatchPart {
-            desc: desc_from(1, 3, 0),
-            index: 0,
-            updates: vec![
-                (("k".as_bytes(), "v".as_bytes()), 2, 1),
-                (("k3".as_bytes(), "v3".as_bytes()), 2, 1),
-            ]
-            .into_iter()
-            .collect::<ColumnarRecordsVec>()
-            .into_inner(),
-        };
-        let b1_size_bytes = blob.set_trace_batch("b1".into(), b1.clone(), format)?;
-
-        let req = CompactTraceReq {
-            b0: TraceBatchMeta {
-                keys: vec!["b0".into()],
-                format,
-                desc: b0.desc,
-                level: 0,
-                size_bytes: b0_size_bytes,
-            },
-            b1: TraceBatchMeta {
-                keys: vec!["b1".into()],
-                format,
-                desc: b1.desc,
-                level: 0,
-                size_bytes: b1_size_bytes,
-            },
-            since: Antichain::from_elem(2),
-        };
-
-        let expected_res = CompactTraceRes {
-            req: req.clone(),
-            merged: TraceBatchMeta {
-                keys: vec!["MERGED_KEY".into()],
-                format: ProtoBatchFormat::ParquetKvtd,
-                desc: desc_from(0, 3, 2),
-                level: 1,
-                size_bytes: 0,
-            },
-        };
-        let mut res = maintainer.compact_trace(req).recv()?;
-
-        // Grab the list of newly created trace batch keys so we can check the
-        // contents of the merged batch.
-        let merged_keys = res.merged.keys.clone();
-        // Replace the list of keys with a known set of keys so that we can assert
-        // on the trace batch metadata.
-        res.merged.keys = vec!["MERGED_KEY".into()];
-        res.merged.size_bytes = 0;
-        assert_eq!(res, expected_res);
-
-        let mut updates = vec![];
-        for key in merged_keys {
-            let batch_part = blob
-                .get_trace_batch_async(&key, CacheHint::MaybeAdd)
-                .recv()?;
-            assert_eq!(&batch_part.desc, &expected_res.merged.desc);
-            updates.extend(batch_part.updates.iter().flat_map(|u| {
-                u.iter()
-                    .map(|((k, v), t, d)| ((k.to_vec(), v.to_vec()), t, d))
-            }));
-        }
-
-        let expected_updates = vec![
-            (("k".as_bytes().to_vec(), "v".as_bytes().to_vec()), 2, 2),
-            (("k2".as_bytes().to_vec(), "v2".as_bytes().to_vec()), 2, 1),
-            (("k3".as_bytes().to_vec(), "v3".as_bytes().to_vec()), 2, 1),
-        ];
-        assert_eq!(updates, expected_updates);
-        Ok(())
+    struct CompactionTestCase<'a> {
+        b0: Vec<Vec<((&'a [u8], &'a [u8]), u64, i64)>>,
+        b1: Vec<Vec<((&'a [u8], &'a [u8]), u64, i64)>>,
+        b0_desc: Description<u64>,
+        b1_desc: Description<u64>,
+        since: u64,
+        merged: TraceBatchMeta,
+        expected_updates: Vec<((&'a [u8], &'a [u8]), u64, i64)>,
     }
 
     #[test]
@@ -445,6 +552,309 @@ mod tests {
             since: Antichain::from_elem(0),
         };
         assert_eq!(maintainer.compact_trace(req).recv(), Err(Error::from("output since Antichain { elements: [0] } must be at or in advance of input since Antichain { elements: [1] }")));
+
+        Ok(())
+    }
+
+    fn compact_trace_test_case<
+        'a,
+        B: Blob,
+        F: FnMut() -> Result<(Maintainer<B>, BlobCache<B>), Error>,
+    >(
+        test: &CompactionTestCase<'a>,
+        mut new_fn: F,
+    ) -> Result<(), Error> {
+        let (maintainer, blob) = new_fn()?;
+        let format = ProtoBatchFormat::ParquetKvtd;
+        let mut b0_keys = vec![];
+        let mut b0_size_bytes = 0;
+
+        for (idx, update) in test.b0.iter().enumerate() {
+            let b = BlobTraceBatchPart {
+                desc: test.b0_desc.clone(),
+                index: u64::cast_from(idx),
+                updates: update
+                    .clone()
+                    .into_iter()
+                    .collect::<ColumnarRecordsVec>()
+                    .into_inner(),
+            };
+            let key = format!("b0-{}", idx);
+            b0_size_bytes += blob.set_trace_batch(key.clone(), b.clone(), format)?;
+            b0_keys.push(key)
+        }
+
+        let mut b1_keys = vec![];
+        let mut b1_size_bytes = 0;
+
+        for (idx, update) in test.b1.iter().enumerate() {
+            let b = BlobTraceBatchPart {
+                desc: test.b1_desc.clone(),
+                index: u64::cast_from(idx),
+                updates: update
+                    .clone()
+                    .into_iter()
+                    .collect::<ColumnarRecordsVec>()
+                    .into_inner(),
+            };
+            let key = format!("b1-{}", idx);
+            b1_size_bytes += blob.set_trace_batch(key.clone(), b.clone(), format)?;
+            b1_keys.push(key)
+        }
+
+        let req = CompactTraceReq {
+            b0: TraceBatchMeta {
+                keys: b0_keys,
+                format,
+                desc: test.b0_desc.clone(),
+                level: 0,
+                size_bytes: b0_size_bytes,
+            },
+            b1: TraceBatchMeta {
+                keys: b1_keys,
+                format,
+                desc: test.b1_desc.clone(),
+                level: 0,
+                size_bytes: b1_size_bytes,
+            },
+            since: Antichain::from_elem(test.since),
+        };
+
+        let expected_res = CompactTraceRes {
+            req: req.clone(),
+            merged: test.merged.clone(),
+        };
+        let mut res = maintainer.compact_trace(req).recv()?;
+
+        // Grab the list of newly created trace batch keys so we can check the
+        // contents of the merged batch.
+        let merged_keys = res.merged.keys.clone();
+        // Replace the list of keys with a known set of keys so that we can assert
+        // on the trace batch metadata.
+        res.merged.keys = merged_keys
+            .iter()
+            .enumerate()
+            .map(|(idx, _)| format!("MERGED-KEY-{}", idx))
+            .collect();
+        res.merged.size_bytes = 0;
+        assert_eq!(res, expected_res);
+
+        let mut updates = vec![];
+        let mut batch_parts = vec![];
+        for key in merged_keys {
+            let batch_part = blob
+                .get_trace_batch_async(&key, CacheHint::MaybeAdd)
+                .recv()?;
+            assert_eq!(&batch_part.desc, &expected_res.merged.desc);
+            batch_parts.push(batch_part);
+        }
+
+        for batch_part in batch_parts.iter() {
+            updates.extend(batch_part.updates.iter().flat_map(|u| u.iter()));
+        }
+
+        assert_eq!(updates, test.expected_updates);
+        Ok(())
+    }
+
+    #[test]
+    fn compact_trace() -> Result<(), Error> {
+        let new_fn = || {
+            let async_runtime = Arc::new(AsyncRuntime::new()?);
+            let metrics = Arc::new(Metrics::default());
+            let blob = BlobCache::new(
+                mz_build_info::DUMMY_BUILD_INFO,
+                Arc::new(Metrics::default()),
+                Arc::clone(&async_runtime),
+                MemRegistry::new().blob_no_reentrance()?,
+                None,
+            );
+            let maintainer = Maintainer::new(blob.clone(), async_runtime, metrics);
+            Ok((maintainer, blob))
+        };
+
+        let mut test_cases = vec![
+            CompactionTestCase {
+                b0: vec![vec![
+                    (("k".as_bytes(), "v".as_bytes()), 0, 1),
+                    (("k2".as_bytes(), "v2".as_bytes()), 0, 1),
+                ]],
+                b0_desc: desc_from(0, 1, 0),
+                b1: vec![vec![
+                    (("k".as_bytes(), "v".as_bytes()), 2, 1),
+                    (("k3".as_bytes(), "v3".as_bytes()), 2, 1),
+                ]],
+                b1_desc: desc_from(1, 3, 0),
+                since: 2,
+                merged: TraceBatchMeta {
+                    keys: vec!["MERGED-KEY-0".into()],
+                    format: ProtoBatchFormat::ParquetKvtd,
+                    desc: desc_from(0, 3, 2),
+                    level: 1,
+                    size_bytes: 0,
+                },
+                expected_updates: vec![
+                    (("k".as_bytes(), "v".as_bytes()), 2, 2),
+                    (("k2".as_bytes(), "v2".as_bytes()), 2, 1),
+                    (("k3".as_bytes(), "v3".as_bytes()), 2, 1),
+                ],
+            },
+            CompactionTestCase {
+                b0: vec![
+                    vec![(("k".as_bytes(), "v".as_bytes()), 0, 1)],
+                    vec![(("k2".as_bytes(), "v2".as_bytes()), 0, 1)],
+                ],
+                b0_desc: desc_from(0, 1, 0),
+                b1: vec![vec![
+                    (("k".as_bytes(), "v".as_bytes()), 2, 1),
+                    (("k3".as_bytes(), "v3".as_bytes()), 2, 1),
+                ]],
+                b1_desc: desc_from(1, 3, 0),
+                since: 2,
+                merged: TraceBatchMeta {
+                    keys: vec!["MERGED-KEY-0".into()],
+                    format: ProtoBatchFormat::ParquetKvtd,
+                    desc: desc_from(0, 3, 2),
+                    level: 0,
+                    size_bytes: 0,
+                },
+                expected_updates: vec![
+                    (("k".as_bytes(), "v".as_bytes()), 2, 2),
+                    (("k2".as_bytes(), "v2".as_bytes()), 2, 1),
+                    (("k3".as_bytes(), "v3".as_bytes()), 2, 1),
+                ],
+            },
+            CompactionTestCase {
+                b0: vec![
+                    vec![(("k".as_bytes(), "v".as_bytes()), 0, 1)],
+                    vec![(("k2".as_bytes(), "v2".as_bytes()), 0, 1)],
+                ],
+                b0_desc: desc_from(0, 1, 0),
+                b1: vec![
+                    vec![(("k".as_bytes(), "v".as_bytes()), 2, 1)],
+                    vec![(("k3".as_bytes(), "v3".as_bytes()), 2, 1)],
+                ],
+                b1_desc: desc_from(1, 3, 0),
+                since: 2,
+                merged: TraceBatchMeta {
+                    keys: vec!["MERGED-KEY-0".into()],
+                    format: ProtoBatchFormat::ParquetKvtd,
+                    desc: desc_from(0, 3, 2),
+                    level: 0,
+                    size_bytes: 0,
+                },
+                expected_updates: vec![
+                    (("k".as_bytes(), "v".as_bytes()), 2, 2),
+                    (("k2".as_bytes(), "v2".as_bytes()), 2, 1),
+                    (("k3".as_bytes(), "v3".as_bytes()), 2, 1),
+                ],
+            },
+            CompactionTestCase {
+                b0: vec![
+                    vec![],
+                    vec![(("k".as_bytes(), "v".as_bytes()), 0, 1)],
+                    vec![],
+                    vec![(("k2".as_bytes(), "v2".as_bytes()), 0, 1)],
+                    vec![],
+                ],
+                b0_desc: desc_from(0, 1, 0),
+                b1: vec![
+                    vec![(("k".as_bytes(), "v".as_bytes()), 2, 1)],
+                    vec![(("k3".as_bytes(), "v3".as_bytes()), 2, 1)],
+                ],
+                b1_desc: desc_from(1, 3, 0),
+                since: 2,
+                merged: TraceBatchMeta {
+                    keys: vec!["MERGED-KEY-0".into()],
+                    format: ProtoBatchFormat::ParquetKvtd,
+                    desc: desc_from(0, 3, 2),
+                    level: 0,
+                    size_bytes: 0,
+                },
+                expected_updates: vec![
+                    (("k".as_bytes(), "v".as_bytes()), 2, 2),
+                    (("k2".as_bytes(), "v2".as_bytes()), 2, 1),
+                    (("k3".as_bytes(), "v3".as_bytes()), 2, 1),
+                ],
+            },
+            CompactionTestCase {
+                b0: vec![vec![], vec![], vec![]],
+                b0_desc: desc_from(0, 1, 0),
+                b1: vec![vec![
+                    (("k".as_bytes(), "v".as_bytes()), 2, 2),
+                    (("k2".as_bytes(), "v2".as_bytes()), 2, 1),
+                    (("k3".as_bytes(), "v3".as_bytes()), 2, 1),
+                ]],
+                b1_desc: desc_from(1, 3, 0),
+                since: 2,
+                merged: TraceBatchMeta {
+                    keys: vec!["MERGED-KEY-0".into()],
+                    format: ProtoBatchFormat::ParquetKvtd,
+                    desc: desc_from(0, 3, 2),
+                    level: 0,
+                    size_bytes: 0,
+                },
+                expected_updates: vec![
+                    (("k".as_bytes(), "v".as_bytes()), 2, 2),
+                    (("k2".as_bytes(), "v2".as_bytes()), 2, 1),
+                    (("k3".as_bytes(), "v3".as_bytes()), 2, 1),
+                ],
+            },
+            CompactionTestCase {
+                b0: vec![],
+                b0_desc: desc_from(0, 1, 0),
+                b1: vec![vec![
+                    (("k".as_bytes(), "v".as_bytes()), 2, 2),
+                    (("k2".as_bytes(), "v2".as_bytes()), 2, 1),
+                    (("k3".as_bytes(), "v3".as_bytes()), 2, 1),
+                ]],
+                b1_desc: desc_from(1, 3, 0),
+                since: 2,
+                merged: TraceBatchMeta {
+                    keys: vec!["MERGED-KEY-0".into()],
+                    format: ProtoBatchFormat::ParquetKvtd,
+                    desc: desc_from(0, 3, 2),
+                    level: 0,
+                    size_bytes: 0,
+                },
+                expected_updates: vec![
+                    (("k".as_bytes(), "v".as_bytes()), 2, 2),
+                    (("k2".as_bytes(), "v2".as_bytes()), 2, 1),
+                    (("k3".as_bytes(), "v3".as_bytes()), 2, 1),
+                ],
+            },
+        ];
+
+        for test_case in test_cases.iter() {
+            compact_trace_test_case(test_case, new_fn.clone())?;
+        }
+
+        let new_fn = || {
+            let async_runtime = Arc::new(AsyncRuntime::new()?);
+            let metrics = Arc::new(Metrics::default());
+            let blob = BlobCache::new(
+                mz_build_info::DUMMY_BUILD_INFO,
+                Arc::new(Metrics::default()),
+                Arc::clone(&async_runtime),
+                MemRegistry::new().blob_no_reentrance()?,
+                None,
+            );
+            let maintainer = Maintainer::new_for_testing(blob.clone(), async_runtime, metrics, 10);
+            Ok((maintainer, blob))
+        };
+
+        for test_case in test_cases.iter_mut() {
+            test_case.merged.keys = vec![
+                "MERGED-KEY-0".into(),
+                "MERGED-KEY-1".into(),
+                "MERGED-KEY-2".into(),
+            ];
+            test_case.merged.level = 1;
+        }
+
+        for test_case in test_cases.iter() {
+            compact_trace_test_case(test_case, new_fn.clone())?;
+        }
 
         Ok(())
     }

--- a/src/persist/src/indexed/columnar.rs
+++ b/src/persist/src/indexed/columnar.rs
@@ -511,8 +511,10 @@ impl Default for ColumnarRecordsVecBuilder {
 }
 
 impl ColumnarRecordsVecBuilder {
-    #[cfg(test)]
-    fn new_with_len(key_val_data_max_len: usize) -> Self {
+    /// Create a new ColumnarRecordsVecBuilder with a specified max size.
+    ///
+    /// Only used for testing.
+    pub(crate) fn new_with_len(key_val_data_max_len: usize) -> Self {
         assert!(key_val_data_max_len <= KEY_VAL_DATA_MAX_LEN);
         ColumnarRecordsVecBuilder {
             current: ColumnarRecordsBuilder::default(),
@@ -572,6 +574,15 @@ impl ColumnarRecordsVecBuilder {
             ret.push(self.current.finish());
         }
         ret
+    }
+
+    /// Returns the list of filled [ColumnarRecords].
+    pub fn take_filled(&mut self) -> Option<Vec<ColumnarRecords>> {
+        if self.filled.len() > 0 {
+            Some(std::mem::take(&mut self.filled))
+        } else {
+            None
+        }
     }
 }
 


### PR DESCRIPTION
<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

This commit teaches persist to perform trace compaction with bounded memory usage
by:

1. Only ever keeping one BlobTraceBatchPart in memory from each of the two
   batches being compacted at a time.
2. Only keeping one ColumnarRecords worth of merged data in memory at a time.
3. Performing roughly a linear merge on the two trace batch parts and as we read
   data from each trace batch, figuring out the upper bound on data that can be
   compacted, consolidating and merging that, and then placing that in a
   ColumnarRecords to await being written out as an output BlobTraceBatchPart.

(3). is best explained with an example. If we are compacting two trace batches,
A which has two parts, one with keys [0, 10) and one with keys [10, 20) and B has
three parts, with keys [0, 15), [15, 30) and [30, 45) respectively then while
compacting when we observe the first batches from A and B which have keys
[0, 10) and [0, 15) respectively, we cannot merge all of both batches together.

We can only merge the subset of keys in [0, 10), as its possible that subsequent
parts in A have relevant keys in [10, 15).

We don't do the real linear merge as compaction requires us to both forward times
and consolidate multiple updates at the forwarded times. I believe that doing so
is possible in linear time, but doing so in a single pass was complicated enough
that I am leaving it for future work.

```
MZ_PERSIST_RECORD_COUNT=819200 MZ_PERSIST_RECORD_SIZE_BYTES=64 MZ_PERSIST_BATCH_MAX_COUNT=131072
writer/compact_trace/mem/50MiB
                        time:   [215.58 ms 216.61 ms 217.71 ms]
                        thrpt:  [229.66 MiB/s 230.83 MiB/s 231.93 MiB/s]
writer/compact_trace/file/50MiB
                        time:   [450.89 ms 451.40 ms 451.94 ms]
                        thrpt:  [110.64 MiB/s 110.77 MiB/s 110.89 MiB/s]
writer/compact_trace/s3/50MiB
                        time:   [554.41 ms 584.38 ms 621.09 ms]
                        thrpt:  [80.504 MiB/s 85.560 MiB/s 90.186 MiB/s]
```

At the default settings this commit is ~33% slower on the trace compaction benchmark
and roughly identical for file and s3 blob (the s3 blob implementation has really high
variance, and can be anywhere from 800 - 500 ms).

Being slower on mem blobs makes sense, as the new implementation does extra allocations and
deallocations when reading trace batch parts, and has to do more copies into a buffer where
the finalized data sits before it is written out. In absolute terms, we observe a 50ms slowdown
in mem blob which feels significant enough to also present in the file and s3 blob benchmarks.
It's unclear why that doesn't happen.

```
MZ_PERSIST_RECORD_COUNT=819200 MZ_PERSIST_RECORD_SIZE_BYTES=64 MZ_PERSIST_BATCH_MAX_COUNT=409600
writer/compact_trace/mem/50MiB
                        time:   [220.03 ms 225.41 ms 230.34 ms]
                        thrpt:  [217.07 MiB/s 221.82 MiB/s 227.24 MiB/s]
writer/compact_trace/file/50MiB
                        time:   [450.84 ms 451.22 ms 451.69 ms]
                        thrpt:  [110.69 MiB/s 110.81 MiB/s 110.90 MiB/s]
writer/compact_trace/s3/50MiB
                        time:   [564.77 ms 588.75 ms 614.72 ms]
                        thrpt:  [81.337 MiB/s 84.925 MiB/s 88.531 MiB/s]
```

This setting simulates the case where all for a given batch lives in one part. There's
no significant difference in performance between this and the default benchmark settings
which suggests that the overhead of reading and managing state for multiple batches is
reasonable.

```
MZ_PERSIST_RECORD_COUNT=8192000 MZ_PERSIST_RECORD_SIZE_BYTES=64 MZ_PERSIST_BATCH_MAX_COUNT=1310720
writer/compact_trace/mem/500MiB
                        time:   [2.2916 s 2.2986 s 2.3064 s]
                        thrpt:  [216.79 MiB/s 217.52 MiB/s 218.19 MiB/s]
writer/compact_trace/file/500MiB
                        time:   [6.0161 s 6.0258 s 6.0346 s]
                        thrpt:  [82.856 MiB/s 82.976 MiB/s 83.110 MiB/s]
writer/compact_trace/s3/500MiB
                        time:   [3.2980 s 3.5561 s 3.8442 s]
                        thrpt:  [130.07 MiB/s 140.60 MiB/s 151.61 MiB/s]
```

This final benchmark run is the same as the default settings, but with 10x as
much data placed in 10x larger batches, Mem blob exhibits almost perfectly
linear scaling, file blob shows slighly worse than linear scaling, and s3 blobs
actually show a performance improvement in this regime, achieving slightly less
than double the throughput. My unsubstantiated hypothesis is that perhaps at
the smaller sizes s3 blobs are not able to take advantage of splitting a BlobTraceBatchPart
into evenly sized chunks for the s3 uploads (or perhaps there's one large chunk and one tiny
chunk at the end?).

### Tips for reviewer

The first commit has the new compact trace benchmark + a detailed analysis of how they look currently in three different size + num batch configurations, the second commit has the new/modified invariants for trace batches and the third commit actually handles compacting part-by-part with bounded overhead (now without quadratic work :)), and new tests + an evaluation of the compaction microbenchmarks.

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
