### PR TITLE
properly propagate csr server errors when fetching key schemas

### DIFF
--- a/test/proxy/csr-failure.td
+++ b/test/proxy/csr-failure.td
@@ -1,0 +1,55 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set keyschema={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "key", "type": "string"}
+    ]
+  }
+
+$ set schema={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"f1", "type":"string"}
+        ]
+    }
+
+$ kafka-create-topic topic=denykey
+
+$ kafka-ingest format=avro topic=denykey key-format=avro key-schema=${keyschema} schema=${schema} publish=true
+{"key": "fish"} {"f1": "fishval"}
+
+# the specific error here doesn't matter, we just want to make sure we hit the error code path,
+# not the key = None codepath
+! CREATE MATERIALIZED SOURCE denykey
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
+  'testdrive-denykey-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE UPSERT
+exact:server error 403: unable to decode error details
+
+$ kafka-create-topic topic=allowkey
+
+# also test the key = None codepath
+$ kafka-ingest format=avro topic=allowkey schema=${schema} publish=true
+{"f1": "fishval"}
+
+> CREATE MATERIALIZED SOURCE allowkey
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
+  'testdrive-allowkey-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE NONE
+
+> SELECT * from allowkey
+f1
+-------
+fishval

--- a/test/proxy/mzcompose.py
+++ b/test/proxy/mzcompose.py
@@ -60,6 +60,12 @@ test_cases = [
         ],
         files=["testdrive/avro-registry.td", "testdrive/esoteric/s3.td"],
     ),
+    # Another test that needs a working proxy to test
+    TestCase(
+        name="csr-failure",
+        env=["ALL_PROXY=http://squid:3128"],
+        files=["csr-failure.td"],
+    ),
 ]
 
 

--- a/test/proxy/squid.conf
+++ b/test/proxy/squid.conf
@@ -13,6 +13,11 @@
 acl all src all
 acl all_dest dst all
 
+# ban a specific string used in csr-failure.td
+acl bad urlpath_regex .*denykey.*-key.*
+
+# deny needs to come first
+http_access deny bad
 http_access allow all
 http_access allow all_dest
 


### PR DESCRIPTION
As part of https://github.com/MaterializeInc/materialize/issues/10699, I want to make it so that `INCLUDE KEY AS` works with `FORMAT ... USING CONFLUENT SCHEMA REGISTRY` without needing a specific `KEY` format and `VALUE` format.

To do this, sql purification needs to know, precisely when the key schema exists or doesn't, which determines the shape of the format.

Previously, ANY error from CSR caused us to think the the key schema doesnt exist. This pr makes it so we ONLY conclude this if we are explicitly told this by the CSR error code.


### Motivation

  * This PR fixes a previously unreported bug.

	see above


### Tips for reviewer

I have no idea how to test this. How can I make the CSR fail for the key fetch and not the value fetch? 
I could inject a bad version here, other than "latest", https://docs.confluent.io/platform/current/schema-registry/develop/api.html#get--subjects-(string-%20subject)-versions-(versionId-%20version), but that would require heavily changing and instrumenting the `mz-sql` and `mz-ccsr` code. Any suggestions?

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
