### PR TITLE
mzbuild: always `docker pull` each image at least once

### DIFF
--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -87,15 +87,6 @@ class RepositoryDetails:
         return self.root / "target-xcompile" / xcompile.target(self.arch)
 
 
-def docker_images() -> Set[str]:
-    """List the Docker images available on the local machine."""
-    return set(
-        spawn.capture(["docker", "images", "--format", "{{.Repository}}:{{.Tag}}"])
-        .strip()
-        .split("\n")
-    )
-
-
 def is_docker_image_pushed(name: str) -> bool:
     """Check whether the named image is pushed to Docker Hub.
 
@@ -661,14 +652,11 @@ class DependencySet:
         The provided `dependencies` must be topologically sorted.
         """
         self._dependencies: Dict[str, ResolvedImage] = {}
-        known_images = docker_images()
         for d in dependencies:
-            image = ResolvedImage(
+            self._dependencies[d.name] = ResolvedImage(
                 image=d,
                 dependencies=(self._dependencies[d0] for d0 in d.depends_on),
             )
-            image.acquired = image.spec() in known_images
-            self._dependencies[d.name] = image
 
     def acquire(self) -> None:
         """Download or build all of the images in the dependency set that do not


### PR DESCRIPTION
@philip-stoev I didn't actually test this, but I think it should work!

----

This ensures that mzbuild checks for newer versions of each image used
in a composition at least once during execution of that composition.
This is particularly useful when using tags like `latest` which change
frequently.

Fix #10713.

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
