### PR TITLE
dbt-materialize: fix custom materialization types

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -1,6 +1,11 @@
 # dbt-materialize Changelog
 
-## 1.0.2.post2 - 2021-02-14
+## 1.0.1.post3 - 2021-02-17
+
+* Fix a bug introduced in v1.0.1.post1 that prevented use of the custom
+  materialization types (`sink`, `source`, `index`, and `materializedview`).
+
+## 1.0.1.post2 - 2021-02-14
 
 * Execute hooks that specify `transaction: true` ([#7675]). In particular, this
   includes hooks that are configured as a simple string.

--- a/misc/dbt-materialize/dbt/adapters/materialize/impl.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/impl.py
@@ -15,11 +15,13 @@
 # limitations under the License.
 
 from dbt.adapters.materialize import MaterializeConnectionManager
+from dbt.adapters.materialize.relation import MaterializeRelation
 from dbt.adapters.postgres import PostgresAdapter
 
 
 class MaterializeAdapter(PostgresAdapter):
     ConnectionManager = MaterializeConnectionManager
+    Relation = MaterializeRelation
 
     def _link_cached_relations(self, manifest):
         # NOTE(benesch): this *should* reimplement the parent class's method

--- a/misc/dbt-materialize/dbt/adapters/materialize/relation.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/relation.py
@@ -14,4 +14,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version = "1.0.1.post3"
+from dataclasses import dataclass
+from typing import Optional
+
+from dbt.adapters.postgres import PostgresRelation
+from dbt.dataclass_schema import StrEnum
+
+
+class MaterializeRelationType(StrEnum):
+    # Built-in materialization types.
+    Table = "table"
+    View = "view"
+    CTE = "cte"
+    External = "external"
+
+    # Materialize-specific materialization types.
+    Source = "source"
+    MaterializedView = "materializedview"
+    Index = "index"
+    Sink = "sink"
+
+
+@dataclass(frozen=True, eq=False, repr=False)
+class MaterializeRelation(PostgresRelation):
+    type: Optional[MaterializeRelationType] = None

--- a/misc/dbt-materialize/mzcompose.py
+++ b/misc/dbt-materialize/mzcompose.py
@@ -21,7 +21,13 @@ SERVICES = [
         {
             "mzbuild": "dbt-materialize",
             "depends_on": ["test-certs"],
-            "volumes": ["secrets:/secrets"],
+            "environment": [
+                "TMPDIR=/share/tmp",
+            ],
+            "volumes": [
+                "secrets:/secrets",
+                "tmp:/share/tmp",
+            ],
         },
     ),
 ]
@@ -83,11 +89,12 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                 options=test_case.materialized_options,
                 image=test_case.materialized_image,
                 depends_on=["test-certs"],
-                volumes=["secrets:/secrets"],
+                volumes_extra=["secrets:/secrets"],
             )
 
             with c.test_case(test_case.name):
                 with c.override(materialized):
+                    c.down()
                     c.up("materialized")
                     c.wait_for_tcp(host="materialized", port=6875)
                     c.run(

--- a/misc/dbt-materialize/setup.py
+++ b/misc/dbt-materialize/setup.py
@@ -26,7 +26,7 @@ setup(
     # dbt-postgres version, change version_suffix to ".post1", ".post2", etc.
     #
     # If you bump this version, bump it in __version__.py too.
-    version="1.0.1.post2",
+    version="1.0.1.post3",
     description="The Materialize adapter plugin for dbt (data build tool).",
     long_description=(Path(__file__).parent / "README.md").open().read(),
     long_description_content_type="text/markdown",

--- a/misc/dbt-materialize/test/materialize.dbtspec
+++ b/misc/dbt-materialize/test/materialize.dbtspec
@@ -69,6 +69,18 @@ sequences:
   test_dbt_schema_test: schema_test
   test_dbt_ephemeral: ephemeral
   test_dbt_ephemeral_data_tests: data_test_ephemeral_models
+  test_dbt_custom_materializations:
+    project: custom_materializations
+    sequence:
+      - type: dbt
+        cmd: run
+      - type: relations_equal
+        relations: [test_materialized_view, test_source]
+      # TODO(benesch): figure out how to test that the sink emits the correct
+      # data. Ideally we'd just ingest the sink back into Materialize with a
+      # source and then use a `relations_equal` step, but that's hard to do
+      # presently because Avro OCF sinks do not have a stable output filename
+      # and Avro OCF sources do not support glob patterns.
   # dbt-materialize does not support incremental models or snapshots
   # test_dbt_incremental: incremental
   # test_dbt_snapshot_strategy_timestamp: snapshot_strategy_timestamp
@@ -88,3 +100,35 @@ projects:
         view_model: view
         table_model: view
         swappable: view
+  - name: custom_materializations
+    paths:
+        testdata/test_csv.csv: |
+            a,b
+            chicken,pig
+            cow,horse
+
+        models/test_materialized_view.sql: |
+            {{ config(materialized='materializedview') }}
+
+            SELECT * FROM (VALUES ('chicken', 'pig'), ('cow', 'horse')) _ (a, b)
+
+        models/test_source.sql: |
+            {{ config(materialized='source') }}
+
+            CREATE SOURCE {{ mz_generate_name('test_source') }}
+            -- TODO(benesch): is there a better way to get the CWD in a test?
+            FROM FILE '{{ flags.os.getcwd() }}/testdata/test_csv.csv'
+            FORMAT CSV WITH HEADER
+
+        models/test_index.sql: |
+            {{ config(materialized='index') }}
+
+            CREATE DEFAULT INDEX test_index
+            ON {{ ref('test_source') }}
+
+        models/test_sink.sql: |
+            {{ config(materialized='sink') }}
+
+            CREATE SINK {{ mz_generate_name('test_sink') }}
+            FROM {{ ref('test_source') }}
+            INTO AVRO OCF 'test_sink.ocf'

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -571,8 +571,21 @@ class Composition:
         """
         self.invoke("up", *(["--detach"] if detach else []), *services)
 
+    def down(self, destroy_volumes: bool = True) -> None:
+        """Stop and remove resources.
+
+        Delegates to `docker-compose down`. See that command's help for details.
+
+        Args:
+            destroy_volumes: Remove named volumes and anonymous volumes attached
+                to containers.
+        """
+        self.invoke("down", *(["--volumes"] if destroy_volumes else []))
+
     def stop(self, *services: str) -> None:
         """Stop the docker containers for the named services.
+
+        Delegates to `docker-compose stop`. See that command's help for details.
 
         Args:
             services: The names of services in the composition.


### PR DESCRIPTION
It turns out a8a1676 was entirely in error; the
`MaterializationRelationType` enum was load bearing, and removing it
prevented access to the custom materialization types in the adapter.

Add it back, with some test coverage to prevent against future mistakes
of the same sort.

### Motivation

  * This PR fixes a bug without a tracking issue.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
