### PR TITLE
Decorrelation: Do not attempt outer join if the join kind is inner.

### DIFF
--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -508,15 +508,17 @@ impl HirRelationExpr {
                             // more efficiently rendered than in general. This can return `None` if
                             // such a plan is not possible, for example if `on` does not describe an
                             // equijoin between columns of `left` and `right`.
-                            if let Some(joined) = attempt_outer_join(
-                                get_left.clone(),
-                                get_right.clone(),
-                                on.clone(),
-                                kind.clone(),
-                                oa,
-                                id_gen,
-                            ) {
-                                return joined;
+                            if kind != JoinKind::Inner {
+                                if let Some(joined) = attempt_outer_join(
+                                    get_left.clone(),
+                                    get_right.clone(),
+                                    on.clone(),
+                                    kind.clone(),
+                                    oa,
+                                    id_gen,
+                                ) {
+                                    return joined;
+                                }
                             }
 
                             // Otherwise, perform a more general join.

--- a/test/sqllogictest/cte_lowering.slt
+++ b/test/sqllogictest/cte_lowering.slt
@@ -374,16 +374,11 @@ FROM x,
 | Project (#0, #1, #3)
 | Filter (#1 = #2)
 
-%14 = Let l6 =
+%14 =
 | Get %13 (l5)
-| Project (#0, #1)
-| Distinct group=(#0, #1)
 
 %15 =
-| Get %13 (l5)
-
-%16 =
-| Join %2 %15 (= #0 #1)
+| Join %2 %14 (= #0 #1)
 | | implementation = Unimplemented
 | Project (#0, #2, #3)
 | Filter true


### PR DESCRIPTION
### Motivation

  * This PR fixes a previously unreported bug.

Discovered while I was trying to figure out why my draft PR #10679 broke fast sqllogictest.

It turns out that in the raw plan, for a NATURAL INNER JOIN or an INNER JOIN with a USING clause, the `on` is always of the form `(true && (<whatever was originally in the USING clause>))` 
https://github.com/MaterializeInc/materialize/blob/30ed8d0372af037ce2c03d2d8ef799cf415fac58/src/sql/src/plan/query.rs#L2753

This `(true && <stuff>)` form comes from this very old commit: https://github.com/MaterializeInc/materialize/commit/68fc4150f9375f1310dba6ea4c0c3104da415b32. My best guess for the reason is that it is convenient to not have to pop off the first element of the joins_expr vector before folding.

In my other PR, I noticed that we currently do not use the equijoin lowering path for a query like `select * from lhs left join rhs on lhs.id = rhs.id and true`, so I canonicalized the `true` away.

It turns out that the presence of the extraneous `true` in the on clause of inner joins has been what keeps the outer equijoin path from firing on an inner equjioin, so eliminating the extraneous `true` resulted in unnecessary `let`s showing up in the decorrelated plan. 

In this PR, I ensure that the outer equijoin path does not fire on an inner equijoin by checking the join kind.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
