### PR TITLE
Prevent paninc on Interval negation

### DIFF
--- a/src/expr/src/scalar/func/impls/interval.rs
+++ b/src/expr/src/scalar/func/impls/interval.rs
@@ -8,7 +8,9 @@
 // by the Apache License, Version 2.0.
 
 use chrono::NaiveTime;
+use num::traits::CheckedNeg;
 
+use crate::EvalError;
 use mz_repr::adt::interval::Interval;
 use mz_repr::strconv;
 
@@ -48,7 +50,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "-"]
     #[preserves_uniqueness = true]
-    fn neg_interval(i: Interval) -> Interval {
-        -i
+    fn neg_interval(i: Interval) -> Result<Interval, EvalError> {
+        i.checked_neg().ok_or(EvalError::IntervalOutOfRange)
     }
 );

--- a/src/repr/src/adt/interval.rs
+++ b/src/repr/src/adt/interval.rs
@@ -41,12 +41,14 @@ impl Default for Interval {
     }
 }
 
-impl std::ops::Neg for Interval {
-    type Output = Self;
-    fn neg(self) -> Self {
-        Self {
-            months: -self.months,
-            duration: -self.duration,
+impl num_traits::ops::checked::CheckedNeg for Interval {
+    fn checked_neg(&self) -> Option<Self> {
+        if let (Some(months), Some(duration)) =
+            (self.months.checked_neg(), self.duration.checked_neg())
+        {
+            Some(Self { months, duration })
+        } else {
+            None
         }
     }
 }

--- a/src/repr/src/adt/interval.rs
+++ b/src/repr/src/adt/interval.rs
@@ -46,7 +46,7 @@ impl num_traits::ops::checked::CheckedNeg for Interval {
         if let (Some(months), Some(duration)) =
             (self.months.checked_neg(), self.duration.checked_neg())
         {
-            Some(Self { months, duration })
+            Self::new(months, 0, duration).ok()
         } else {
             None
         }

--- a/test/sqllogictest/dates-times.slt
+++ b/test/sqllogictest/dates-times.slt
@@ -1245,6 +1245,9 @@ select ('0001-01-01'::date - interval '1 DAY')::date
 ----
 0001-12-31 BC
 
+query error interval out of range
+select '0001-02-24'::date - interval '-2147483648 MONTHS'
+
 query T
 select '0001-02-24 03:04:05'::timestamp - interval '1 YEAR'
 ----
@@ -1259,3 +1262,9 @@ query T
 select '0001-02-24 03:04:05.6789 +00:00'::timestamptz - interval '1 YEAR'
 ----
 0001-02-24 03:04:05.6789+00 BC
+
+query error interval out of range
+select '0001-02-24 03:04:05.6789'::timestamp - interval '-2147483648 MONTHS'
+
+query error interval out of range
+select '0001-02-24 03:04:05.6789 +00:00'::timestamptz - interval '-2147483648 MONTHS'

--- a/test/sqllogictest/interval.slt
+++ b/test/sqllogictest/interval.slt
@@ -889,3 +889,9 @@ query T
 SELECT INTERVAL '1 millenniums 2 centuries 3 decades 4 years'
 ----
 1234 years
+
+query error interval out of range
+SELECT -INTERVAL '-2147483648 months';
+
+query error interval out of range
+SELECT INTERVAL '-1 months' - INTERVAL '-2147483648 months';

--- a/test/sqllogictest/interval.slt
+++ b/test/sqllogictest/interval.slt
@@ -895,3 +895,6 @@ SELECT -INTERVAL '-2147483648 months';
 
 query error interval out of range
 SELECT INTERVAL '-1 months' - INTERVAL '-2147483648 months';
+
+query error interval out of range
+SELECT -INTERVAL '-2147483648 days -2147483648 hours -59 minutes -59.999999 seconds';


### PR DESCRIPTION
Fixes #10729

Negating interval fields was not being checked for overflow, this
commit adds a check and throws an appropriate error.

### Motivation
This PR fixes a recognized bug: #10729

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
