### PR TITLE
test,persistence: Split the failpoints test in a separate Buildkite step

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -108,14 +108,6 @@ steps:
     agents:
       queue: builder
 
-  - id: persistence
-    label: Persistence tests
-    depends_on: build-x86_64
-    artifact_paths: junit_mzcompose_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: persistence
-
   - id: testdrive
     label: Testdrive %n
     depends_on: build-x86_64
@@ -128,6 +120,23 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: testdrive
           args: [--aws-region=us-east-2]
+
+  - id: persistence
+    label: Persistence tests
+    depends_on: build-x86_64
+    artifact_paths: junit_mzcompose_*.xml
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: persistence
+
+  - id: persistence-failpoints
+    label: Persistence failpoints
+    depends_on: build-x86_64
+    artifact_paths: junit_mzcompose_*.xml
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: persistence
+          run: failpoints
 
   - id: cluster-smoke
     label: Cluster smoke test

--- a/test/persistence/mzcompose.py
+++ b/test/persistence/mzcompose.py
@@ -30,13 +30,9 @@ mz_logical_compaction_window_off = Materialized(
     options=f"{mz_options} --logical-compaction-window=off",
 )
 
-mz_disable_user_indexes = Materialized(
-    options=f"{mz_options} --disable-user-indexes",
-)
-
-mz_fast_metrics = Materialized(
-    options=f"{mz_options} --metrics-scraping-interval=1s",
-)
+# TODO: add back mz_logical_compaction_window_off in the line below.
+# See: https://github.com/MaterializeInc/materialize/issues/10488
+mz_configurations = [mz_default]
 
 prerequisites = ["zookeeper", "kafka", "schema-registry"]
 
@@ -52,13 +48,10 @@ td_test = os.environ.pop("TD_TEST", "*")
 
 
 def workflow_default(c: Composition) -> None:
-    # TODO: add back mz_logical_compaction_window_off in the line below.
-    # See: https://github.com/MaterializeInc/materialize/issues/10488
-    for mz in [mz_default]:
+    for mz in mz_configurations:
         with c.override(mz):
             workflow_kafka_sources(c)
             workflow_user_tables(c)
-            workflow_failpoints(c)
 
     workflow_disable_user_indexes(c)
     workflow_compaction(c)
@@ -124,41 +117,46 @@ def workflow_user_tables(c: Composition) -> None:
 def workflow_failpoints(c: Composition) -> None:
     c.start_and_wait_for_tcp(services=prerequisites)
 
-    for failpoint in [
-        "fileblob_set_sync",
-        "fileblob_delete_before",
-        "fileblob_delete_after",
-        "insert_timestamp_bindings_before",
-        "insert_timestamp_bindings_after",
-    ]:
-        for action in ["return", "panic", "sleep(1000)"]:
-            print(
-                f">>> Running failpoint test for failpoint {failpoint} with action {action}"
-            )
-            seed = round(time.time())
+    for mz in mz_configurations:
+        with c.override(mz):
+            for failpoint in [
+                "fileblob_set_sync",
+                "fileblob_delete_before",
+                "fileblob_delete_after",
+                "insert_timestamp_bindings_before",
+                "insert_timestamp_bindings_after",
+            ]:
+                for action in ["return", "panic", "sleep(1000)"]:
+                    run_one_failpoint(c, failpoint, action)
 
-            c.up("materialized")
-            c.wait_for_materialized()
 
-            c.run(
-                "testdrive-svc",
-                f"--seed={seed}",
-                f"--var=failpoint={failpoint}",
-                f"--var=action={action}",
-                "failpoints/before.td",
-            )
+def run_one_failpoint(c: Composition, failpoint: str, action: str) -> None:
+    print(f">>> Running failpoint test for failpoint {failpoint} with action {action}")
 
-            time.sleep(2)
-            # kill Mz if the failpoint has not killed it
-            c.kill("materialized")
-            c.up("materialized")
-            c.wait_for_materialized()
+    seed = round(time.time())
 
-            c.run("testdrive-svc", f"--seed={seed}", "failpoints/after.td")
+    c.up("materialized")
+    c.wait_for_materialized()
 
-            c.kill("materialized")
-            c.rm("materialized", "testdrive-svc", destroy_volumes=True)
-            c.rm_volumes("mzdata")
+    c.run(
+        "testdrive-svc",
+        f"--seed={seed}",
+        f"--var=failpoint={failpoint}",
+        f"--var=action={action}",
+        "failpoints/before.td",
+    )
+
+    time.sleep(2)
+    # kill Mz if the failpoint has not killed it
+    c.kill("materialized")
+    c.up("materialized")
+    c.wait_for_materialized()
+
+    c.run("testdrive-svc", f"--seed={seed}", "failpoints/after.td")
+
+    c.kill("materialized")
+    c.rm("materialized", "testdrive-svc", destroy_volumes=True)
+    c.rm_volumes("mzdata")
 
 
 def workflow_disable_user_indexes(c: Composition) -> None:
@@ -173,7 +171,11 @@ def workflow_disable_user_indexes(c: Composition) -> None:
 
     c.kill("materialized")
 
-    with c.override(mz_disable_user_indexes):
+    with c.override(
+        Materialized(
+            options=f"{mz_options} --disable-user-indexes",
+        )
+    ):
         c.up("materialized")
         c.wait_for_materialized()
 
@@ -187,7 +189,11 @@ def workflow_disable_user_indexes(c: Composition) -> None:
 
 
 def workflow_compaction(c: Composition) -> None:
-    with c.override(mz_fast_metrics):
+    with c.override(
+        Materialized(
+            options=f"{mz_options} --metrics-scraping-interval=1s",
+        )
+    ):
         c.up("materialized")
         c.wait_for_materialized()
 


### PR DESCRIPTION
Run the persistence failpoints test as a separate Buildkite step so that:
 - it can run in parallel with the other jobs
 - a fresh Confluent stack is used, as hundreds of Kafka topics are being
   created and used by this test.

### Motivation

   * This PR refactors existing code.

- The "Persistence" CI job is the longest one in the build, so it frequently caps the minium time the CI needs to run.

- I am getting random Kafka-related failures that I suspect may be due to the fact that the entire "persistence" test was using a single instance of the Confluent stack. Splitting the test in two will allow for more observations on that problem.

@ruchirK FYI . I am afraid this PR may make merging of our S3+persistence tests PR more painful. Please let me know if you would like me to do the rebase/merge myself.