### PR TITLE
aws-util: depend on openssl-sys with the "vendored" feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2953,6 +2953,7 @@ dependencies = [
  "aws-smithy-http",
  "aws-types",
  "mz-http-proxy",
+ "openssl-sys",
 ]
 
 [[package]]

--- a/src/aws-util/Cargo.toml
+++ b/src/aws-util/Cargo.toml
@@ -16,9 +16,16 @@ aws-smithy-client = { version = "0.36.0", default-features = false }
 aws-smithy-http = "0.36.0"
 aws-types = "0.6.0"
 mz-http-proxy = { path = "../http-proxy", features = ["hyper"] }
+openssl-sys = { version = "0.9.72", features = ["vendored"] }
 
 [features]
 kinesis = ["aws-sdk-kinesis"]
 sqs = ["aws-sdk-sqs"]
 s3 = ["aws-sdk-s3"]
 sts = ["aws-sdk-sts"]
+
+[package.metadata.cargo-udeps.ignore]
+# Make sure the "vendored" feature makes it into the transitive dep graph of
+# every aws user, so that we don't attempt to link against the system OpenSSL
+# library.
+normal = ["openssl-sys"]


### PR DESCRIPTION
This enures the "vendored" feature makes it into the transitive dep
graph of every aws user, so that we don't attempt to link against the
system OpenSSL library.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
