### PR TITLE
persist: push decode down into snapshot iteration to save allocs

### DIFF
--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -13,7 +13,7 @@ use mz_avro::types::Value;
 use mz_dataflow_types::sources::AwsExternalId;
 use mz_dataflow_types::{DecodeError, SourceErrorDetails};
 use mz_persist::client::{StreamReadHandle, StreamWriteHandle};
-use mz_persist::indexed::Snapshot;
+use mz_persist::indexed::snapshot::Snapshot;
 use mz_persist::operators::stream::Persist;
 use mz_persist_types::Codec;
 use mz_repr::MessagePayload;

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -13,7 +13,6 @@ use mz_avro::types::Value;
 use mz_dataflow_types::sources::AwsExternalId;
 use mz_dataflow_types::{DecodeError, SourceErrorDetails};
 use mz_persist::client::{StreamReadHandle, StreamWriteHandle};
-use mz_persist::indexed::snapshot::Snapshot;
 use mz_persist::operators::stream::Persist;
 use mz_persist_types::Codec;
 use mz_repr::MessagePayload;

--- a/src/persist/benches/snapshot.rs
+++ b/src/persist/benches/snapshot.rs
@@ -20,7 +20,6 @@ use mz_ore::metrics::MetricsRegistry;
 use mz_persist::client::{RuntimeClient, StreamReadHandle};
 use mz_persist::error::{Error, ErrorLog};
 use mz_persist::file::FileBlob;
-use mz_persist::indexed::snapshot::Snapshot;
 use mz_persist::mem::MemRegistry;
 use mz_persist::runtime::{self, RuntimeConfig};
 use mz_persist::s3::{S3Blob, S3BlobConfig};

--- a/src/persist/benches/snapshot.rs
+++ b/src/persist/benches/snapshot.rs
@@ -20,7 +20,7 @@ use mz_ore::metrics::MetricsRegistry;
 use mz_persist::client::{RuntimeClient, StreamReadHandle};
 use mz_persist::error::{Error, ErrorLog};
 use mz_persist::file::FileBlob;
-use mz_persist::indexed::Snapshot;
+use mz_persist::indexed::snapshot::Snapshot;
 use mz_persist::mem::MemRegistry;
 use mz_persist::runtime::{self, RuntimeConfig};
 use mz_persist::s3::{S3Blob, S3BlobConfig};

--- a/src/persist/examples/kafka_upsert.rs
+++ b/src/persist/examples/kafka_upsert.rs
@@ -25,7 +25,7 @@ use mz_ore::now::{NowFn, SYSTEM_TIME};
 use mz_persist::client::{MultiWriteHandle, RuntimeClient, StreamReadHandle};
 use mz_persist::error::Error as PersistError;
 use mz_persist::file::{FileBlob, FileLog};
-use mz_persist::indexed::Snapshot;
+use mz_persist::indexed::snapshot::Snapshot;
 use mz_persist::operators::stream::{AwaitFrontier, Seal};
 use mz_persist::operators::upsert::{PersistentUpsert, PersistentUpsertConfig};
 use mz_persist::runtime::{self, RuntimeConfig};

--- a/src/persist/examples/kafka_upsert.rs
+++ b/src/persist/examples/kafka_upsert.rs
@@ -25,7 +25,6 @@ use mz_ore::now::{NowFn, SYSTEM_TIME};
 use mz_persist::client::{MultiWriteHandle, RuntimeClient, StreamReadHandle};
 use mz_persist::error::Error as PersistError;
 use mz_persist::file::{FileBlob, FileLog};
-use mz_persist::indexed::snapshot::Snapshot;
 use mz_persist::operators::stream::{AwaitFrontier, Seal};
 use mz_persist::operators::upsert::{PersistentUpsert, PersistentUpsertConfig};
 use mz_persist::runtime::{self, RuntimeConfig};

--- a/src/persist/src/client.rs
+++ b/src/persist/src/client.rs
@@ -21,11 +21,11 @@ use timely::progress::Antichain;
 use tracing::error;
 
 use crate::error::Error;
-use crate::indexed::arrangement::{ArrangementSnapshot, ArrangementSnapshotIter};
 use crate::indexed::columnar::{ColumnarRecords, ColumnarRecordsVecBuilder};
 use crate::indexed::encoding::Id;
 use crate::indexed::metrics::Metrics;
-use crate::indexed::{Cmd, CmdRead, ListenEvent, Snapshot, StreamDesc};
+use crate::indexed::snapshot::{ArrangementSnapshot, ArrangementSnapshotIter, Snapshot};
+use crate::indexed::{Cmd, CmdRead, ListenEvent, StreamDesc};
 use crate::pfuture::PFuture;
 use crate::runtime::{RuntimeCmd, RuntimeHandle, RuntimeId};
 use crate::storage::SeqNo;

--- a/src/persist/src/client.rs
+++ b/src/persist/src/client.rs
@@ -724,28 +724,41 @@ impl<K: Codec, V: Codec> DecodedSnapshot<K, V> {
     pub fn get_seal(&self) -> Antichain<u64> {
         self.snap.get_seal()
     }
-}
 
-impl<K: Codec, V: Codec> Snapshot<K, V> for DecodedSnapshot<K, V> {
-    type Iter = DecodedSnapshotIter<K, V>;
-
-    fn into_iters(self, num_iters: NonZeroUsize) -> Vec<Self::Iter> {
+    /// Returns a set of `num_iters` [Iterator]s that each output roughly
+    /// `1/num_iters` of the data represented by this snapshot.
+    pub fn into_iters(self, num_iters: NonZeroUsize) -> Vec<DecodedSnapshotIter<K, V>> {
         self.snap
             .into_iters(num_iters)
             .into_iter()
-            .map(|iter| DecodedSnapshotIter {
-                iter,
-                _phantom: PhantomData,
-            })
+            .map(|iter| DecodedSnapshotIter { iter })
             .collect()
+    }
+
+    /// Returns a single [Iterator] that outputs the data represented by this
+    /// snapshot.
+    pub fn into_iter(self) -> DecodedSnapshotIter<K, V> {
+        let mut iters = self.into_iters(NonZeroUsize::new(1).unwrap());
+        assert_eq!(iters.len(), 1);
+        iters.remove(0)
+    }
+}
+
+#[cfg(test)]
+impl<K: Codec + Ord, V: Codec + Ord> DecodedSnapshot<K, V> {
+    /// A full read of the data in the snapshot.
+    pub fn read_to_end(self) -> Result<Vec<((K, V), u64, i64)>, Error> {
+        let iter = self.into_iter();
+        let mut buf = iter.collect::<Result<Vec<_>, Error>>()?;
+        buf.sort();
+        Ok(buf)
     }
 }
 
 /// An [Iterator] representing one part of the data in a [DecodedSnapshot].
 #[derive(Debug)]
 pub struct DecodedSnapshotIter<K, V> {
-    iter: ArrangementSnapshotIter,
-    _phantom: PhantomData<(K, V)>,
+    iter: ArrangementSnapshotIter<Result<K, String>, Result<V, String>>,
 }
 
 impl<K: Codec, V: Codec> Iterator for DecodedSnapshotIter<K, V> {
@@ -754,8 +767,8 @@ impl<K: Codec, V: Codec> Iterator for DecodedSnapshotIter<K, V> {
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(|x| {
             let ((k, v), ts, diff) = x?;
-            let k = K::decode(&k)?;
-            let v = V::decode(&v)?;
+            let k = k?;
+            let v = v?;
             Ok(((k, v), ts, diff))
         })
     }

--- a/src/persist/src/golden_test.rs
+++ b/src/persist/src/golden_test.rs
@@ -18,7 +18,6 @@ use tracing::{debug, error, info};
 
 use crate::client::RuntimeClient;
 use crate::error::{Error, ErrorLog};
-use crate::indexed::snapshot::Snapshot;
 use crate::mem::{MemBlob, MemRegistry};
 use crate::nemesis::direct::{Direct, StartRuntime};
 use crate::nemesis::generator::{Generator, GeneratorConfig};

--- a/src/persist/src/golden_test.rs
+++ b/src/persist/src/golden_test.rs
@@ -18,7 +18,7 @@ use tracing::{debug, error, info};
 
 use crate::client::RuntimeClient;
 use crate::error::{Error, ErrorLog};
-use crate::indexed::Snapshot;
+use crate::indexed::snapshot::Snapshot;
 use crate::mem::{MemBlob, MemRegistry};
 use crate::nemesis::direct::{Direct, StartRuntime};
 use crate::nemesis::generator::{Generator, GeneratorConfig};

--- a/src/persist/src/indexed/arrangement.rs
+++ b/src/persist/src/indexed/arrangement.rs
@@ -10,12 +10,8 @@
 //! A persistent, compacting data structure containing indexed `(Key, Value,
 //! Time, i64)` entries.
 
-use std::collections::VecDeque;
-use std::num::NonZeroUsize;
-use std::sync::Arc;
-use std::{fmt, mem};
+use std::mem;
 
-use differential_dataflow::lattice::Lattice;
 use differential_dataflow::trace::Description;
 use timely::progress::{Antichain, Timestamp};
 use timely::PartialOrder;
@@ -31,8 +27,8 @@ use crate::indexed::columnar::ColumnarRecordsVec;
 use crate::indexed::encoding::{
     ArrangementMeta, BlobTraceBatchPart, TraceBatchMeta, UnsealedBatchMeta, UnsealedSnapshotMeta,
 };
-use crate::indexed::{BlobUnsealedBatch, Id, Snapshot};
-use crate::pfuture::PFuture;
+use crate::indexed::snapshot::{ArrangementSnapshot, Snapshot, TraceSnapshot};
+use crate::indexed::{BlobUnsealedBatch, Id};
 use crate::storage::{Blob, BlobRead, SeqNo};
 
 /// A persistent, compacting data structure containing indexed `(Key, Value,
@@ -687,280 +683,10 @@ impl Arrangement {
     }
 }
 
-/// A consistent snapshot of the data that is currently _physically_ in the
-/// unsealed bucket of a persistent [Arrangement].
-#[derive(Debug)]
-pub struct UnsealedSnapshot {
-    /// A closed lower bound on the times of contained updates.
-    pub ts_lower: Antichain<u64>,
-    /// An open upper bound on the times of the contained updates.
-    pub ts_upper: Antichain<u64>,
-    pub(crate) batches: Vec<PFuture<Arc<BlobUnsealedBatch>>>,
-}
-
-impl Snapshot<Vec<u8>, Vec<u8>> for UnsealedSnapshot {
-    type Iter = UnsealedSnapshotIter;
-
-    fn into_iters(self, num_iters: NonZeroUsize) -> Vec<Self::Iter> {
-        let mut iters = Vec::with_capacity(num_iters.get());
-        iters.resize_with(num_iters.get(), || UnsealedSnapshotIter {
-            ts_lower: self.ts_lower.clone(),
-            ts_upper: self.ts_upper.clone(),
-            current_batch: Vec::new(),
-            batches: VecDeque::new(),
-        });
-        // TODO: This should probably distribute batches based on size, but for
-        // now it's simpler to round-robin them.
-        for (i, batch) in self.batches.into_iter().enumerate() {
-            let iter_idx = i % num_iters;
-            iters[iter_idx].batches.push_back(batch);
-        }
-        iters
-    }
-}
-
-/// An [Iterator] representing one part of the data in a [UnsealedSnapshot].
-//
-// This intentionally stores the batches as a VecDeque so we can return the data
-// in roughly increasing timestamp order, but it's unclear if this is in any way
-// important.
-pub struct UnsealedSnapshotIter {
-    /// A closed lower bound on the times of contained updates.
-    ts_lower: Antichain<u64>,
-    /// An open upper bound on the times of the contained updates.
-    ts_upper: Antichain<u64>,
-
-    current_batch: Vec<((Vec<u8>, Vec<u8>), u64, i64)>,
-    batches: VecDeque<PFuture<Arc<BlobUnsealedBatch>>>,
-}
-
-impl fmt::Debug for UnsealedSnapshotIter {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("UnsealedSnapshotIter")
-            .field("ts_lower", &self.ts_lower)
-            .field("ts_upper", &self.ts_upper)
-            .field("current_batch(len)", &self.current_batch.len())
-            .field("batches", &self.batches)
-            .finish()
-    }
-}
-
-impl Iterator for UnsealedSnapshotIter {
-    type Item = Result<((Vec<u8>, Vec<u8>), u64, i64), Error>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            if !self.current_batch.is_empty() {
-                let update = self.current_batch.pop().unwrap();
-                return Some(Ok(update));
-            } else {
-                // current_batch is empty, find a new one.
-                let b = match self.batches.pop_front() {
-                    None => return None,
-                    Some(b) => b,
-                };
-                match b.recv() {
-                    Ok(b) => {
-                        // Reverse the updates so we can pop them off the back
-                        // in roughly increasing time order. At the same time,
-                        // enforce our filter before we clone them. Note that we
-                        // don't reverse the updates within each ColumnarRecords,
-                        // because those are not guaranteed to be in any order.
-                        let ts_lower = self.ts_lower.borrow();
-                        let ts_upper = self.ts_upper.borrow();
-                        self.current_batch.extend(
-                            b.updates
-                                .iter()
-                                .rev()
-                                .flat_map(|u| u.iter())
-                                .filter(|(_, ts, _)| {
-                                    ts_lower.less_equal(&ts) && !ts_upper.less_equal(&ts)
-                                })
-                                .map(|((k, v), t, d)| ((k.to_vec(), v.to_vec()), t, d)),
-                        );
-                        continue;
-                    }
-                    Err(err) => return Some(Err(err)),
-                }
-            }
-        }
-    }
-}
-
-/// A consistent snapshot of the data that is currently _physically_ in the
-/// trace bucket of a persistent [Arrangement].
-#[derive(Debug)]
-pub struct TraceSnapshot {
-    /// An open upper bound on the times of contained updates.
-    pub ts_upper: Antichain<u64>,
-    /// Since frontier of the given updates.
-    ///
-    /// All updates not at times greater than this frontier must be advanced
-    /// to a time that is equivalent to this frontier.
-    pub since: Antichain<u64>,
-    batches: Vec<PFuture<Arc<BlobTraceBatchPart>>>,
-}
-
-impl Snapshot<Vec<u8>, Vec<u8>> for TraceSnapshot {
-    type Iter = TraceSnapshotIter;
-
-    fn into_iters(self, num_iters: NonZeroUsize) -> Vec<Self::Iter> {
-        let mut iters = Vec::with_capacity(num_iters.get());
-        iters.resize_with(num_iters.get(), TraceSnapshotIter::default);
-        // TODO: This should probably distribute batches based on size, but for
-        // now it's simpler to round-robin them.
-        for (i, batch) in self.batches.into_iter().enumerate() {
-            let iter_idx = i % num_iters;
-            iters[iter_idx].batches.push_back(batch);
-        }
-        iters
-    }
-}
-
-/// An [Iterator] representing one part of the data in a [TraceSnapshot].
-//
-// This intentionally stores the batches as a VecDeque so we can return the data
-// in roughly increasing timestamp order, but it's unclear if this is in any way
-// important.
-pub struct TraceSnapshotIter {
-    current_batch: Vec<((Vec<u8>, Vec<u8>), u64, i64)>,
-    batches: VecDeque<PFuture<Arc<BlobTraceBatchPart>>>,
-}
-
-impl Default for TraceSnapshotIter {
-    fn default() -> Self {
-        TraceSnapshotIter {
-            current_batch: Vec::new(),
-            batches: VecDeque::new(),
-        }
-    }
-}
-
-impl fmt::Debug for TraceSnapshotIter {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("TraceSnapshotIter")
-            .field("current_batch(len)", &self.current_batch.len())
-            .field("batches", &self.batches)
-            .finish()
-    }
-}
-
-impl Iterator for TraceSnapshotIter {
-    type Item = Result<((Vec<u8>, Vec<u8>), u64, i64), Error>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            if !self.current_batch.is_empty() {
-                let update = self.current_batch.pop().unwrap();
-                return Some(Ok(update));
-            } else {
-                // current_batch is empty, find a new one.
-                let b = match self.batches.pop_front() {
-                    None => return None,
-                    Some(b) => b,
-                };
-                match b.recv() {
-                    Ok(b) => {
-                        self.current_batch
-                            .extend(b.updates.iter().flat_map(|u| u.iter()).map(
-                                |((key, val), time, diff)| {
-                                    ((key.to_vec(), val.to_vec()), time, diff)
-                                },
-                            ));
-                        continue;
-                    }
-                    Err(err) => return Some(Err(err)),
-                }
-            }
-        }
-    }
-}
-
-/// A consistent snapshot of all data currently stored for an id.
-#[derive(Debug)]
-pub struct ArrangementSnapshot(
-    pub(crate) UnsealedSnapshot,
-    pub(crate) TraceSnapshot,
-    pub(crate) SeqNo,
-    pub(crate) Antichain<u64>,
-);
-
-impl ArrangementSnapshot {
-    /// Returns the SeqNo at which this snapshot was run.
-    ///
-    /// All writes assigned a seqno < this are included.
-    pub fn seqno(&self) -> SeqNo {
-        self.2
-    }
-
-    /// Returns the since frontier of this snapshot.
-    ///
-    /// All updates at times less than this frontier must be forwarded
-    /// to some time in this frontier.
-    pub fn since(&self) -> Antichain<u64> {
-        self.1.since.clone()
-    }
-
-    /// A logical upper bound on the times that had been added to the collection
-    /// when this snapshot was taken
-    pub(crate) fn get_seal(&self) -> Antichain<u64> {
-        self.3.clone()
-    }
-}
-
-impl Snapshot<Vec<u8>, Vec<u8>> for ArrangementSnapshot {
-    type Iter = ArrangementSnapshotIter;
-
-    fn into_iters(self, num_iters: NonZeroUsize) -> Vec<ArrangementSnapshotIter> {
-        let since = self.since();
-        let ArrangementSnapshot(unsealed, trace, _, _) = self;
-        let unsealed_iters = unsealed.into_iters(num_iters);
-        let trace_iters = trace.into_iters(num_iters);
-        // I don't love the non-debug asserts, but it doesn't seem worth it to
-        // plumb an error around here.
-        assert_eq!(unsealed_iters.len(), num_iters.get());
-        assert_eq!(trace_iters.len(), num_iters.get());
-        unsealed_iters
-            .into_iter()
-            .zip(trace_iters.into_iter())
-            .map(|(unsealed_iter, trace_iter)| ArrangementSnapshotIter {
-                since: since.clone(),
-                iter: trace_iter.chain(unsealed_iter),
-            })
-            .collect()
-    }
-}
-
-/// An [Iterator] representing one part of the data in an [ArrangementSnapshot].
-//
-// This intentionally chains trace before unsealed so we get the data in roughly
-// increasing timestamp order, but it's unclear if this is in any way important.
-#[derive(Debug)]
-pub struct ArrangementSnapshotIter {
-    since: Antichain<u64>,
-    iter: std::iter::Chain<TraceSnapshotIter, UnsealedSnapshotIter>,
-}
-
-impl Iterator for ArrangementSnapshotIter {
-    type Item = Result<((Vec<u8>, Vec<u8>), u64, i64), Error>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next().map(|x| {
-            x.map(|(kv, mut ts, diff)| {
-                // When reading a snapshot, the contract of since is that all
-                // update timestamps will be advanced to it. We do this
-                // physically during compaction, but don't have hard guarantees
-                // about how long that takes, so we have to account for
-                // un-advanced batches on reads.
-                ts.advance_by(self.since.borrow());
-                (kv, ts, diff)
-            })
-        })
-    }
-}
-
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use differential_dataflow::trace::Description;
     use tokio::runtime::Runtime as AsyncRuntime;
 
@@ -968,8 +694,8 @@ mod tests {
     use crate::indexed::columnar::ColumnarRecords;
     use crate::indexed::encoding::Id;
     use crate::indexed::metrics::Metrics;
+    use crate::indexed::snapshot::SnapshotExt;
     use crate::indexed::Maintainer;
-    use crate::indexed::SnapshotExt;
     use crate::mem::{MemBlob, MemRegistry};
 
     use super::*;

--- a/src/persist/src/indexed/arrangement.rs
+++ b/src/persist/src/indexed/arrangement.rs
@@ -391,8 +391,7 @@ impl Arrangement {
         req: DrainUnsealedReq,
     ) -> Result<DrainUnsealedRes, Error> {
         let snap = req.snap.clone().fetch(&blob);
-        let mut updates = snap
-            .into_iter()
+        let mut updates = Snapshot::<Vec<u8>, Vec<u8>>::into_iter(snap)
             .collect::<Result<Vec<_>, Error>>()
             .map_err(|err| format!("failed to fetch snapshot: {}", err))?;
 

--- a/src/persist/src/indexed/columnar.rs
+++ b/src/persist/src/indexed/columnar.rs
@@ -88,6 +88,13 @@ impl ColumnarRecords {
         self.len
     }
 
+    /// Read the record at `idx`, if there is one.
+    ///
+    /// Returns None if `idx >= self.len()`.
+    pub fn get<'a>(&'a self, idx: usize) -> Option<((&'a [u8], &'a [u8]), u64, i64)> {
+        self.borrow().get(idx)
+    }
+
     /// Borrow Self as a [ColumnarRecordsRef].
     fn borrow<'a>(&'a self) -> ColumnarRecordsRef<'a> {
         ColumnarRecordsRef {

--- a/src/persist/src/indexed/encoding.rs
+++ b/src/persist/src/indexed/encoding.rs
@@ -35,12 +35,12 @@ use crate::gen::persist::{
     ProtoStreamRegistration, ProtoTraceBatchMeta, ProtoTraceBatchPartInline, ProtoU64Antichain,
     ProtoU64Description, ProtoUnsealedBatchInline, ProtoUnsealedBatchMeta,
 };
-use crate::indexed::arrangement::UnsealedSnapshot;
 use crate::indexed::cache::{BlobCache, CacheHint};
 use crate::indexed::columnar::parquet::{
     decode_trace_parquet, decode_unsealed_parquet, encode_trace_parquet, encode_unsealed_parquet,
 };
 use crate::indexed::columnar::ColumnarRecords;
+use crate::indexed::snapshot::UnsealedSnapshot;
 use crate::storage::{BlobRead, SeqNo};
 
 /// An internally unique id for a persisted stream. External users identify

--- a/src/persist/src/indexed/snapshot.rs
+++ b/src/persist/src/indexed/snapshot.rs
@@ -1,0 +1,334 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Isolated, consistent reads of previously written (Key, Value, Time, Diff)
+//! updates.
+
+use std::collections::VecDeque;
+use std::fmt;
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+
+use differential_dataflow::lattice::Lattice;
+use timely::progress::Antichain;
+
+use crate::error::Error;
+use crate::indexed::encoding::BlobTraceBatchPart;
+use crate::indexed::BlobUnsealedBatch;
+use crate::pfuture::PFuture;
+use crate::storage::SeqNo;
+
+/// An isolated, consistent read of previously written (Key, Value, Time, Diff)
+/// updates.
+//
+// TODO: This <K, V> allows Snapshot to be generic over both IndexedSnapshot
+// (and friends) and DecodedSnapshot, but does that get us anything?
+pub trait Snapshot<K, V>: Sized {
+    /// The kind of iterator we are turning this into.
+    type Iter: Iterator<Item = Result<((K, V), u64, i64), Error>>;
+
+    /// Returns a set of `num_iters` [Iterator]s that each output roughly
+    /// `1/num_iters` of the data represented by this snapshot.
+    fn into_iters(self, num_iters: NonZeroUsize) -> Vec<Self::Iter>;
+
+    /// Returns a single [Iterator] that outputs the data represented by this
+    /// snapshot.
+    fn into_iter(self) -> Self::Iter {
+        let mut iters = self.into_iters(NonZeroUsize::new(1).unwrap());
+        assert_eq!(iters.len(), 1);
+        iters.remove(0)
+    }
+}
+
+/// Extension methods on `Snapshot<K, V>` for use in tests.
+#[cfg(test)]
+pub trait SnapshotExt<K: Ord, V: Ord>: Snapshot<K, V> + Sized {
+    /// A full read of the data in the snapshot.
+    fn read_to_end(self) -> Result<Vec<((K, V), u64, i64)>, Error> {
+        let iter = self.into_iter();
+        let mut buf = iter.collect::<Result<Vec<_>, Error>>()?;
+        buf.sort();
+        Ok(buf)
+    }
+}
+
+#[cfg(test)]
+impl<K: Ord, V: Ord, S: Snapshot<K, V> + Sized> SnapshotExt<K, V> for S {}
+
+/// A consistent snapshot of the data that is currently _physically_ in the
+/// unsealed bucket of a persistent [crate::indexed::arrangement::Arrangement].
+#[derive(Debug)]
+pub struct UnsealedSnapshot {
+    /// A closed lower bound on the times of contained updates.
+    pub ts_lower: Antichain<u64>,
+    /// An open upper bound on the times of the contained updates.
+    pub ts_upper: Antichain<u64>,
+    pub(crate) batches: Vec<PFuture<Arc<BlobUnsealedBatch>>>,
+}
+
+impl Snapshot<Vec<u8>, Vec<u8>> for UnsealedSnapshot {
+    type Iter = UnsealedSnapshotIter;
+
+    fn into_iters(self, num_iters: NonZeroUsize) -> Vec<Self::Iter> {
+        let mut iters = Vec::with_capacity(num_iters.get());
+        iters.resize_with(num_iters.get(), || UnsealedSnapshotIter {
+            ts_lower: self.ts_lower.clone(),
+            ts_upper: self.ts_upper.clone(),
+            current_batch: Vec::new(),
+            batches: VecDeque::new(),
+        });
+        // TODO: This should probably distribute batches based on size, but for
+        // now it's simpler to round-robin them.
+        for (i, batch) in self.batches.into_iter().enumerate() {
+            let iter_idx = i % num_iters;
+            iters[iter_idx].batches.push_back(batch);
+        }
+        iters
+    }
+}
+
+/// An [Iterator] representing one part of the data in a [UnsealedSnapshot].
+//
+// This intentionally stores the batches as a VecDeque so we can return the data
+// in roughly increasing timestamp order, but it's unclear if this is in any way
+// important.
+pub struct UnsealedSnapshotIter {
+    /// A closed lower bound on the times of contained updates.
+    ts_lower: Antichain<u64>,
+    /// An open upper bound on the times of the contained updates.
+    ts_upper: Antichain<u64>,
+
+    current_batch: Vec<((Vec<u8>, Vec<u8>), u64, i64)>,
+    batches: VecDeque<PFuture<Arc<BlobUnsealedBatch>>>,
+}
+
+impl fmt::Debug for UnsealedSnapshotIter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UnsealedSnapshotIter")
+            .field("ts_lower", &self.ts_lower)
+            .field("ts_upper", &self.ts_upper)
+            .field("current_batch(len)", &self.current_batch.len())
+            .field("batches", &self.batches)
+            .finish()
+    }
+}
+
+impl Iterator for UnsealedSnapshotIter {
+    type Item = Result<((Vec<u8>, Vec<u8>), u64, i64), Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if !self.current_batch.is_empty() {
+                let update = self.current_batch.pop().unwrap();
+                return Some(Ok(update));
+            } else {
+                // current_batch is empty, find a new one.
+                let b = match self.batches.pop_front() {
+                    None => return None,
+                    Some(b) => b,
+                };
+                match b.recv() {
+                    Ok(b) => {
+                        // Reverse the updates so we can pop them off the back
+                        // in roughly increasing time order. At the same time,
+                        // enforce our filter before we clone them. Note that we
+                        // don't reverse the updates within each ColumnarRecords,
+                        // because those are not guaranteed to be in any order.
+                        let ts_lower = self.ts_lower.borrow();
+                        let ts_upper = self.ts_upper.borrow();
+                        self.current_batch.extend(
+                            b.updates
+                                .iter()
+                                .rev()
+                                .flat_map(|u| u.iter())
+                                .filter(|(_, ts, _)| {
+                                    ts_lower.less_equal(&ts) && !ts_upper.less_equal(&ts)
+                                })
+                                .map(|((k, v), t, d)| ((k.to_vec(), v.to_vec()), t, d)),
+                        );
+                        continue;
+                    }
+                    Err(err) => return Some(Err(err)),
+                }
+            }
+        }
+    }
+}
+
+/// A consistent snapshot of the data that is currently _physically_ in the
+/// trace bucket of a persistent [crate::indexed::arrangement::Arrangement].
+#[derive(Debug)]
+pub struct TraceSnapshot {
+    /// An open upper bound on the times of contained updates.
+    pub ts_upper: Antichain<u64>,
+    /// Since frontier of the given updates.
+    ///
+    /// All updates not at times greater than this frontier must be advanced
+    /// to a time that is equivalent to this frontier.
+    pub since: Antichain<u64>,
+    pub(crate) batches: Vec<PFuture<Arc<BlobTraceBatchPart>>>,
+}
+
+impl Snapshot<Vec<u8>, Vec<u8>> for TraceSnapshot {
+    type Iter = TraceSnapshotIter;
+
+    fn into_iters(self, num_iters: NonZeroUsize) -> Vec<Self::Iter> {
+        let mut iters = Vec::with_capacity(num_iters.get());
+        iters.resize_with(num_iters.get(), TraceSnapshotIter::default);
+        // TODO: This should probably distribute batches based on size, but for
+        // now it's simpler to round-robin them.
+        for (i, batch) in self.batches.into_iter().enumerate() {
+            let iter_idx = i % num_iters;
+            iters[iter_idx].batches.push_back(batch);
+        }
+        iters
+    }
+}
+
+/// An [Iterator] representing one part of the data in a [TraceSnapshot].
+//
+// This intentionally stores the batches as a VecDeque so we can return the data
+// in roughly increasing timestamp order, but it's unclear if this is in any way
+// important.
+pub struct TraceSnapshotIter {
+    current_batch: Vec<((Vec<u8>, Vec<u8>), u64, i64)>,
+    batches: VecDeque<PFuture<Arc<BlobTraceBatchPart>>>,
+}
+
+impl Default for TraceSnapshotIter {
+    fn default() -> Self {
+        TraceSnapshotIter {
+            current_batch: Vec::new(),
+            batches: VecDeque::new(),
+        }
+    }
+}
+
+impl fmt::Debug for TraceSnapshotIter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TraceSnapshotIter")
+            .field("current_batch(len)", &self.current_batch.len())
+            .field("batches", &self.batches)
+            .finish()
+    }
+}
+
+impl Iterator for TraceSnapshotIter {
+    type Item = Result<((Vec<u8>, Vec<u8>), u64, i64), Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if !self.current_batch.is_empty() {
+                let update = self.current_batch.pop().unwrap();
+                return Some(Ok(update));
+            } else {
+                // current_batch is empty, find a new one.
+                let b = match self.batches.pop_front() {
+                    None => return None,
+                    Some(b) => b,
+                };
+                match b.recv() {
+                    Ok(b) => {
+                        self.current_batch
+                            .extend(b.updates.iter().flat_map(|u| u.iter()).map(
+                                |((key, val), time, diff)| {
+                                    ((key.to_vec(), val.to_vec()), time, diff)
+                                },
+                            ));
+                        continue;
+                    }
+                    Err(err) => return Some(Err(err)),
+                }
+            }
+        }
+    }
+}
+
+/// A consistent snapshot of all data currently stored for an id.
+#[derive(Debug)]
+pub struct ArrangementSnapshot(
+    pub(crate) UnsealedSnapshot,
+    pub(crate) TraceSnapshot,
+    pub(crate) SeqNo,
+    pub(crate) Antichain<u64>,
+);
+
+impl ArrangementSnapshot {
+    /// Returns the SeqNo at which this snapshot was run.
+    ///
+    /// All writes assigned a seqno < this are included.
+    pub fn seqno(&self) -> SeqNo {
+        self.2
+    }
+
+    /// Returns the since frontier of this snapshot.
+    ///
+    /// All updates at times less than this frontier must be forwarded
+    /// to some time in this frontier.
+    pub fn since(&self) -> Antichain<u64> {
+        self.1.since.clone()
+    }
+
+    /// A logical upper bound on the times that had been added to the collection
+    /// when this snapshot was taken
+    pub(crate) fn get_seal(&self) -> Antichain<u64> {
+        self.3.clone()
+    }
+}
+
+impl Snapshot<Vec<u8>, Vec<u8>> for ArrangementSnapshot {
+    type Iter = ArrangementSnapshotIter;
+
+    fn into_iters(self, num_iters: NonZeroUsize) -> Vec<ArrangementSnapshotIter> {
+        let since = self.since();
+        let ArrangementSnapshot(unsealed, trace, _, _) = self;
+        let unsealed_iters = unsealed.into_iters(num_iters);
+        let trace_iters = trace.into_iters(num_iters);
+        // I don't love the non-debug asserts, but it doesn't seem worth it to
+        // plumb an error around here.
+        assert_eq!(unsealed_iters.len(), num_iters.get());
+        assert_eq!(trace_iters.len(), num_iters.get());
+        unsealed_iters
+            .into_iter()
+            .zip(trace_iters.into_iter())
+            .map(|(unsealed_iter, trace_iter)| ArrangementSnapshotIter {
+                since: since.clone(),
+                iter: trace_iter.chain(unsealed_iter),
+            })
+            .collect()
+    }
+}
+
+/// An [Iterator] representing one part of the data in an [ArrangementSnapshot].
+//
+// This intentionally chains trace before unsealed so we get the data in roughly
+// increasing timestamp order, but it's unclear if this is in any way important.
+#[derive(Debug)]
+pub struct ArrangementSnapshotIter {
+    since: Antichain<u64>,
+    iter: std::iter::Chain<TraceSnapshotIter, UnsealedSnapshotIter>,
+}
+
+impl Iterator for ArrangementSnapshotIter {
+    type Item = Result<((Vec<u8>, Vec<u8>), u64, i64), Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next().map(|x| {
+            x.map(|(kv, mut ts, diff)| {
+                // When reading a snapshot, the contract of since is that all
+                // update timestamps will be advanced to it. We do this
+                // physically during compaction, but don't have hard guarantees
+                // about how long that takes, so we have to account for
+                // un-advanced batches on reads.
+                ts.advance_by(self.since.borrow());
+                (kv, ts, diff)
+            })
+        })
+    }
+}

--- a/src/persist/src/nemesis/direct.rs
+++ b/src/persist/src/nemesis/direct.rs
@@ -109,7 +109,7 @@ use crate::client::{
     DecodedSnapshot, MultiWriteHandle, RuntimeClient, StreamReadHandle, StreamWriteHandle,
 };
 use crate::error::Error;
-use crate::indexed::SnapshotExt;
+use crate::indexed::snapshot::SnapshotExt;
 use crate::nemesis::progress::{DataflowProgress, DataflowProgressHandle};
 use crate::nemesis::{
     AllowCompactionReq, FutureRes, FutureStep, Input, ReadOutputEvent, ReadOutputReq,

--- a/src/persist/src/nemesis/direct.rs
+++ b/src/persist/src/nemesis/direct.rs
@@ -109,7 +109,6 @@ use crate::client::{
     DecodedSnapshot, MultiWriteHandle, RuntimeClient, StreamReadHandle, StreamWriteHandle,
 };
 use crate::error::Error;
-use crate::indexed::snapshot::SnapshotExt;
 use crate::nemesis::progress::{DataflowProgress, DataflowProgressHandle};
 use crate::nemesis::{
     AllowCompactionReq, FutureRes, FutureStep, Input, ReadOutputEvent, ReadOutputReq,

--- a/src/persist/src/operators/replay.rs
+++ b/src/persist/src/operators/replay.rs
@@ -18,7 +18,7 @@ use timely::{Data as TimelyData, PartialOrder};
 
 use crate::client::DecodedSnapshot;
 use crate::error::Error;
-use crate::indexed::Snapshot;
+use crate::indexed::snapshot::Snapshot;
 use crate::operators::DEFAULT_OUTPUTS_PER_YIELD;
 
 /// Extension trait for [`Stream`].

--- a/src/persist/src/operators/replay.rs
+++ b/src/persist/src/operators/replay.rs
@@ -18,7 +18,6 @@ use timely::{Data as TimelyData, PartialOrder};
 
 use crate::client::DecodedSnapshot;
 use crate::error::Error;
-use crate::indexed::snapshot::Snapshot;
 use crate::operators::DEFAULT_OUTPUTS_PER_YIELD;
 
 /// Extension trait for [`Stream`].

--- a/src/persist/src/operators/stream.rs
+++ b/src/persist/src/operators/stream.rs
@@ -510,7 +510,8 @@ mod tests {
     use tokio::runtime::Runtime as AsyncRuntime;
 
     use crate::error::Error;
-    use crate::indexed::{ListenEvent, SnapshotExt};
+    use crate::indexed::snapshot::SnapshotExt;
+    use crate::indexed::ListenEvent;
     use crate::mem::MemRegistry;
     use crate::unreliable::UnreliableHandle;
 

--- a/src/persist/src/operators/stream.rs
+++ b/src/persist/src/operators/stream.rs
@@ -510,7 +510,6 @@ mod tests {
     use tokio::runtime::Runtime as AsyncRuntime;
 
     use crate::error::Error;
-    use crate::indexed::snapshot::SnapshotExt;
     use crate::indexed::ListenEvent;
     use crate::mem::MemRegistry;
     use crate::unreliable::UnreliableHandle;

--- a/src/persist/src/runtime.rs
+++ b/src/persist/src/runtime.rs
@@ -531,7 +531,8 @@ mod tests {
     use timely::progress::Antichain;
 
     use crate::client::{MultiWriteHandle, StreamWriteHandle};
-    use crate::indexed::{SnapshotExt, StreamDesc};
+    use crate::indexed::snapshot::SnapshotExt;
+    use crate::indexed::StreamDesc;
     use crate::mem::{MemMultiRegistry, MemRegistry};
     use crate::operators::source::PersistedSource;
     use crate::operators::split_ok_err;

--- a/src/persist/src/runtime.rs
+++ b/src/persist/src/runtime.rs
@@ -531,7 +531,6 @@ mod tests {
     use timely::progress::Antichain;
 
     use crate::client::{MultiWriteHandle, StreamWriteHandle};
-    use crate::indexed::snapshot::SnapshotExt;
     use crate::indexed::StreamDesc;
     use crate::mem::{MemMultiRegistry, MemRegistry};
     use crate::operators::source::PersistedSource;


### PR DESCRIPTION
Summary: This speeds up raw snapshot iteration by ~30-75% and end-to-end replay by ~10%.

As part of this, DecodedSnapshot no longer implements the Snapshot
interface. As evidenced by the TODO about exactly this, this was always
suspect.

Instead Snapshot now takes K and V parameters, which allows us to push
decoding down to be called directly on the `&[u8]` K and V types exposed
by ColumnarRecords. This removes the final remaining per-record heap
alloc in the replay hot path.

It would be natural for Snapshot to bound these new K and V parameters
with Codec. However, we use Snapshot internally in unsealed draining and
trace compaction. Those currently operate directly on the encoded K and
V bytes and so decoding them is inappropriate. (Arguably, they should be
operating on the decoded K and V because we likely want the trace
batches to be sorted by the decoded values instead of the encoded bytes,
but that change is out of scope of this PR.)

Relevant micro-benchmarks on a persist-benchmarking machine:

    MZ_PERSIST_RECORD_COUNT=819200 MZ_PERSIST_RECORD_SIZE_BYTES=64 MZ_PERSIST_BATCH_MAX_COUNT=131072
    end_to_end/replay/file/50MiB
                            time:   [500.63 ms 501.94 ms 503.18 ms]
                            thrpt:  [99.367 MiB/s 99.613 MiB/s 99.874 MiB/s]
                     change:
                            time:   [-10.719% -10.406% -10.089%] (p = 0.00 < 0.05)
                            thrpt:  [+11.221% +11.615% +12.006%]
                            Performance has improved.
    snapshot/mem/unsealed/50MiB
                            time:   [89.449 ms 89.705 ms 89.984 ms]
                            thrpt:  [555.65 MiB/s 557.38 MiB/s 558.98 MiB/s]
                     change:
                            time:   [-32.575% -32.391% -32.168%] (p = 0.00 < 0.05)
                            thrpt:  [+47.424% +47.910% +48.312%]
                            Performance has improved.
    snapshot/mem/trace/50MiB
                            time:   [106.08 ms 106.17 ms 106.26 ms]
                            thrpt:  [470.54 MiB/s 470.95 MiB/s 471.34 MiB/s]
                     change:
                            time:   [-31.101% -31.044% -30.982%] (p = 0.00 < 0.05)
                            thrpt:  [+44.890% +45.020% +45.140%]
                            Performance has improved.
    snapshot/file/unsealed/50MiB
                            time:   [86.222 ms 86.351 ms 86.479 ms]
                            thrpt:  [578.18 MiB/s 579.03 MiB/s 579.90 MiB/s]
                     change:
                            time:   [-43.314% -43.140% -42.977%] (p = 0.00 < 0.05)
                            thrpt:  [+75.369% +75.870% +76.409%]
                            Performance has improved.
    snapshot/file/trace/50MiB
                            time:   [105.24 ms 105.32 ms 105.41 ms]
                            thrpt:  [474.35 MiB/s 474.73 MiB/s 475.11 MiB/s]
                     change:
                            time:   [-24.566% -24.504% -24.435%] (p = 0.00 < 0.05)
                            thrpt:  [+32.337% +32.457% +32.567%]
                            Performance has improved.

Relevant feature benchmarks:

    NAME                      |    THIS     |    OTHER    |  Regression?  | 'THIS' is:
    ----------------------------------------------------------------------------------------------------
    KafkaRecovery             |       9.953 |      11.045 |      no       | 9.9 pct   faster
    KafkaRecoveryBig          |     141.764 |     153.021 |      no       | 7.4 pct   faster

    THIS KafkaRecoveryBig
    Measurement: 141.76439762115479
    Measurement: 152.79166722297668
    Measurement: 155.00989389419556
    Measurement: 153.37186098098755
    Measurement: 154.11874389648438
    Measurement: 153.76633858680725
    OTHER KafkaRecoveryBig
    Measurement: 153.02117681503296
    Measurement: 172.94333672523499
    Measurement: 168.51269340515137
    Measurement: 164.90104389190674
    Measurement: 169.29966592788696
    Measurement: 166.35536575317383

### Reviewer Notes

Pay particular attention to the correctness of the second commit, please. The first and third are more refactor-y.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
