### PR TITLE
coord: improve timestamp determination to avoid no complete timestamps

### DIFF
--- a/demo/simple/README.md
+++ b/demo/simple/README.md
@@ -118,11 +118,6 @@ available to Docker Engine.
     Go ahead and do that a few times; you should see the `region_sum` continue
     to increase for all `region_id`s.
 
-    The first time you run the command, you may see a message stating "At least
-    one input has no complete timestamps yet." This indicates that Materialize
-    is still reading the initial batch of data from Kafka, and is usually
-    resolved by trying again in a few moments.
-
 1. Close out of the Materialize CLI (<kbd>Ctrl</kbd> + <kbd>D</kbd>).
 
 1. Watch the report change using the `watch-sql` container, which continually

--- a/src/coord/src/error.rs
+++ b/src/coord/src/error.rs
@@ -53,8 +53,6 @@ pub enum CoordError {
     IdExhaustionError,
     /// Unexpected internal state was encountered.
     Internal(String),
-    /// At least one input has no complete timestamps yet
-    IncompleteTimestamp(Vec<mz_expr::GlobalId>),
     /// Specified index is disabled, but received non-enabling update request
     InvalidAlterOnDisabledIndex(String),
     /// Attempted to build a materialization on a source that does not allow multiple materializations
@@ -307,11 +305,6 @@ impl fmt::Display for CoordError {
                 p.value().quoted()
             ),
             CoordError::IdExhaustionError => f.write_str("ID allocator exhausted all valid IDs"),
-            CoordError::IncompleteTimestamp(unstarted) => write!(
-                f,
-                "At least one input has no complete timestamps yet: {:?}",
-                unstarted
-            ),
             CoordError::Internal(e) => write!(f, "internal error: {}", e),
             CoordError::InvalidAlterOnDisabledIndex(name) => {
                 write!(f, "invalid ALTER on disabled index {}", name.quoted())

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -381,7 +381,6 @@ impl ErrorResponse {
             CoordError::Eval(_) => SqlState::INTERNAL_ERROR,
             CoordError::FixedValueParameter(_) => SqlState::INVALID_PARAMETER_VALUE,
             CoordError::IdExhaustionError => SqlState::INTERNAL_ERROR,
-            CoordError::IncompleteTimestamp(_) => SqlState::SQL_STATEMENT_NOT_YET_COMPLETE,
             CoordError::Internal(_) => SqlState::INTERNAL_ERROR,
             CoordError::InvalidRematerialization { .. } => SqlState::FEATURE_NOT_SUPPORTED,
             CoordError::InvalidParameterType(_) => SqlState::INVALID_PARAMETER_VALUE,

--- a/test/testdrive/timestamps-debezium-kafka.td
+++ b/test/testdrive/timestamps-debezium-kafka.td
@@ -108,14 +108,33 @@ $ kafka-ingest format=avro topic=bar schema=${schema}
 
 > CREATE MATERIALIZED VIEW join (b, foo_sum, bar_sum) AS SELECT * FROM foo JOIN bar USING (b);
 
-! SELECT * FROM bar;
-contains:At least one input has no complete timestamps yet:
+# Verify that we don't see any data yet. We can't use `set-sql-timeout` here
+# because the SELECT is blocked in the coordinator. For the same reason we
+# can't use `DECLARE c CURSOR FOR SELECT ...` (see #10763).
 
-! SELECT * FROM foo;
-contains:At least one input has no complete timestamps yet:
+> BEGIN
 
-! SELECT * FROM join ;
-contains:At least one input has no complete timestamps yet:
+> DECLARE c CURSOR FOR TAIL (SELECT * FROM bar)
+
+> FETCH ALL c WITH (timeout = '2s');
+
+> ROLLBACK
+
+> BEGIN
+
+> DECLARE c CURSOR FOR TAIL (SELECT * FROM foo)
+
+> FETCH ALL c WITH (timeout = '2s');
+
+> ROLLBACK
+
+> BEGIN
+
+> DECLARE c CURSOR FOR TAIL (SELECT * FROM join)
+
+> FETCH ALL c WITH (timeout = '2s');
+
+> ROLLBACK
 
 $ kafka-ingest format=avro topic=foo schema=${schema}
 {"com.materialize.cdc.progress":{"lower":[0],"upper":[2],"counts":[{"time":1,"count":2}]}}


### PR DESCRIPTION
Previously we would require a valid upper to be available and error with
"no complete timestamps" if it was not available. Instead, change the
order in which we determine timestamps:

1. Initialize to the timestamp minimum.
2. Advance to the since.
3. Advance to the upper.

Each "advance" step can possibly do nothing if the current canditate
timestamp is already in advance of the argument.

As a result, we no longer produce the no complete timestamps error. The
previous case where it occurred, when the upper was 0, will leave the
candidate timestamp at the since. If the since is also 0, that is fine,
because we assume the source is correctly declaring 0 to be the first
time at which it will produce results.

Closes #8163
Fixes #3122

### Motivation

Which of the following best describes the motivation behind this PR?

  * This PR adds a known-desirable feature: #3122
  * I no longer wish to be mocked by this error message.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Remove the "no complete timestamps" error. Queries will now wait for initial data instead of erroring and requiring users to run their query in a loop until it succeeds.