### PR TITLE
make INCLUDE KEY AS compatible with 'bare' format USING CSR

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -145,6 +145,9 @@ changes that have not yet been documented.
 - Add [`chr`](/sql/functions#string-func) function to convert a Unicode codepoint
   into a string.
 
+- Support bare `FORMAT` with `INCLUDE KEY AS` when using the confluent schema
+  registry {{% gh 10766 %}}.
+
 {{< comment >}}
 Only add new release notes above this line.
 

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -42,9 +42,8 @@ use crate::ast::{
     CreateViewsDefinitions, CreateViewsSourceTarget, CreateViewsStatement, CsrConnectorAvro,
     CsrConnectorProto, CsrSeed, CsrSeedCompiled, CsrSeedCompiledEncoding, CsrSeedCompiledOrLegacy,
     CsvColumns, DbzMode, Envelope, Expr, Format, Ident, Op, ProtobufSchema, Query, Raw, RawName,
-    Select, SelectItem, SetExpr, SourceIncludeMetadata, SourceIncludeMetadataType, SqlOption,
-    Statement, SubscriptPosition, TableFactor, TableWithJoins, UnresolvedObjectName, Value,
-    ViewDefinition, WithOption, WithOptionValue,
+    Select, SelectItem, SetExpr, SqlOption, Statement, SubscriptPosition, TableFactor,
+    TableWithJoins, UnresolvedObjectName, Value, ViewDefinition, WithOption, WithOptionValue,
 };
 use crate::catalog::SessionCatalog;
 use crate::kafka_util;
@@ -92,7 +91,7 @@ pub fn purify(
             format,
             envelope,
             with_options,
-            include_metadata,
+            include_metadata: _,
             ..
         }) = &mut stmt
         {
@@ -215,21 +214,6 @@ pub fn purify(
                 with_options,
             )
             .await?;
-
-            if include_metadata.iter().any(|i| {
-                matches!(
-                    i,
-                    SourceIncludeMetadata {
-                        ty: SourceIncludeMetadataType::Key,
-                        ..
-                    }
-                )
-            }) && !matches!(format, CreateSourceFormat::KeyValue { .. })
-            {
-                bail!(
-                    "INCLUDE KEY requires specifying KEY FORMAT .. VALUE FORMAT, got bare FORMAT"
-                );
-            }
         }
 
         if let Statement::CreateViews(CreateViewsStatement { definitions, .. }) = &mut stmt {

--- a/test/testdrive/kafka-include-key-sources.td
+++ b/test/testdrive/kafka-include-key-sources.td
@@ -25,7 +25,7 @@ $ set schema={
   }
 
 $ kafka-create-topic topic=avro-data partitions=1
-$ kafka-ingest format=avro key-format=avro topic=avro-data key-schema=${conflictkeyschema} schema=${schema} timestamp=1
+$ kafka-ingest format=avro key-format=avro topic=avro-data key-schema=${conflictkeyschema} schema=${schema} timestamp=1 publish=true
 {"id": 1} {"id": 2, "b": 3}
 
 ! CREATE SOURCE missing_key_format
@@ -40,6 +40,18 @@ contains:INCLUDE KEY requires specifying KEY FORMAT .. VALUE FORMAT, got bare FO
   INCLUDE KEY AS key_col
 contains:INCLUDE KEY requires specifying KEY FORMAT .. VALUE FORMAT, got bare FORMAT
 
+# "Bare" format works when the key format is in a registry
+> CREATE MATERIALIZED SOURCE bareformatconfluent
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
+  'testdrive-avro-data-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  INCLUDE KEY AS named
+  ENVELOPE UPSERT
+
+> SELECT * from bareformatconfluent
+named         id       b
+------------------------
+1             2        3
 
 ! CREATE SOURCE not_supported
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avro-data-${testdrive.seed}'


### PR DESCRIPTION
As called out in https://github.com/MaterializeInc/materialize/issues/10699 and in slack, `FORMAT` doesn't work when there IS actually a `KEY FORMAT` from the CSR, this cleans up that discrepancy.

### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer

This pr removes a check in `pure.rs`, and refactors a match in planning, after purification, so that an existing check is actually hit. Please read carefully, its possible I misunderstood the exact codepaths of different formats/encoding

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
