### PR TITLE
truncate datums

### DIFF
--- a/src/interchange/src/avro/decode.rs
+++ b/src/interchange/src/avro/decode.rs
@@ -39,6 +39,34 @@ pub struct Decoder {
     packer: Row,
 }
 
+#[cfg(test)]
+mod tests {
+    use futures::executor::block_on;
+
+    use crate::avro::Decoder;
+    use mz_repr::{Datum, Row};
+
+    #[test]
+    fn test_error_followed_by_success() {
+        let schema = r#"{
+"type": "record",
+"name": "test",
+"fields": [{"name": "f1", "type": "int"}, {"name": "f2", "type": "int"}]
+}"#;
+        let mut decoder = Decoder::new(&schema, None, "Test".to_string(), false).unwrap();
+        // This is not a valid Avro blob for the given schema
+        let mut bad_bytes: &[u8] = &[0];
+        assert!(block_on(decoder.decode(&mut bad_bytes)).is_err());
+        // This is the blob that will make both ints in the value zero.
+        let mut good_bytes: &[u8] = &[0, 0];
+        // The decode should succeed with the correct value.
+        assert_eq!(
+            block_on(decoder.decode(&mut good_bytes)).unwrap(),
+            Row::pack([Datum::Int32(0), Datum::Int32(0)])
+        );
+    }
+}
+
 impl Decoder {
     /// Creates a new `Decoder`
     ///
@@ -65,6 +93,10 @@ impl Decoder {
 
     /// Decodes Avro-encoded `bytes` into a `Row`.
     pub async fn decode(&mut self, bytes: &mut &[u8]) -> anyhow::Result<Row> {
+        // Clear out any bytes that might be left over from
+        // an earlier run. This can happen if the
+        // `dsr.deserialize` call returns an error,
+        // causing us to return early.
         self.packer.truncate_datums(0);
         let (bytes2, resolved_schema, csr_schema_id) = self.csr_avro.resolve(bytes).await?;
         *bytes = bytes2;

--- a/src/interchange/src/avro/decode.rs
+++ b/src/interchange/src/avro/decode.rs
@@ -65,6 +65,7 @@ impl Decoder {
 
     /// Decodes Avro-encoded `bytes` into a `Row`.
     pub async fn decode(&mut self, bytes: &mut &[u8]) -> anyhow::Result<Row> {
+        self.packer.truncate_datums(0);
         let (bytes2, resolved_schema, csr_schema_id) = self.csr_avro.resolve(bytes).await?;
         *bytes = bytes2;
         let dec = AvroFlatDecoder {

--- a/src/interchange/src/avro/decode.rs
+++ b/src/interchange/src/avro/decode.rs
@@ -97,7 +97,7 @@ impl Decoder {
         // an earlier run. This can happen if the
         // `dsr.deserialize` call returns an error,
         // causing us to return early.
-        self.packer.truncate_datums(0);
+        self.packer.clear();
         let (bytes2, resolved_schema, csr_schema_id) = self.csr_avro.resolve(bytes).await?;
         *bytes = bytes2;
         let dec = AvroFlatDecoder {


### PR DESCRIPTION
See comment in the code.

The Avro decoding client in `interchange` keeps around a `Row` packer, so that it can right-size allocations. This is just an optimization; semantically, we should use a new packer at the beginning of each call to `decode`. Normally things worked fine because the call to `finish_and_reuse` clears out the `Row`. However, in the error case, we return early without calling that function, and so there could be partial state left over, causing the _next_ returned row to be invalid.