### PR TITLE
*: refer to Timestamps more generally in a few places

### DIFF
--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -500,7 +500,7 @@ pub mod partitioned {
     use mz_expr::GlobalId;
     use mz_repr::{Diff, Row, Timestamp};
     use timely::order::PartialOrder;
-    use timely::progress::{Antichain, ChangeBatch};
+    use timely::progress::{Antichain, ChangeBatch, Timestamp as _};
     use tracing::debug;
 
     use crate::TailResponse;
@@ -813,7 +813,7 @@ pub mod partitioned {
                             change_batch: Default::default(),
                             buffer: Vec::new(),
                             parts: self.parts,
-                            reported_frontier: Antichain::from_elem(0),
+                            reported_frontier: Antichain::from_elem(Timestamp::minimum()),
                         })
                     });
 

--- a/src/dataflow/src/render/context.rs
+++ b/src/dataflow/src/render/context.rs
@@ -88,7 +88,7 @@ where
         let as_of_frontier = dataflow
             .as_of
             .clone()
-            .unwrap_or_else(|| Antichain::from_elem(0));
+            .unwrap_or_else(|| Antichain::from_elem(Timestamp::minimum()));
 
         Self {
             debug_name: dataflow.debug_name.clone(),

--- a/src/dataflow/src/source/timestamp.rs
+++ b/src/dataflow/src/source/timestamp.rs
@@ -830,7 +830,7 @@ impl TimestampBindingUpdater {
         bindings_change.extend(inverted_current_bindings);
 
         // TODO: This seems wasteful. We could just add a get_bindings() which returns all bindings.
-        let lowest_frontier = Antichain::from_elem(u64::MIN);
+        let lowest_frontier = Antichain::from_elem(Timestamp::minimum());
         let new_bindings = timestamp_histories
             .get_bindings_in_range(
                 lowest_frontier.borrow(),


### PR DESCRIPTION
This is the start to work to abstract inner details of the Timestamp type.

### Motivation

   * This PR refactors existing code.

Our `Timestamp` type can be used generally instead of as a `u64` in some places, in preparation for it not being a type alias.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
