### PR TITLE
repr: (re)introduce RowPacker

### DIFF
--- a/src/coord/src/catalog/builtin_table_updates.rs
+++ b/src/coord/src/catalog/builtin_table_updates.rs
@@ -404,14 +404,15 @@ impl CatalogState {
                 .map(|oid| self.get_by_oid(oid).id().to_string())
                 .collect::<Vec<_>>();
             let mut row = Row::default();
-            row.push_array(
-                &[ArrayDimension {
-                    lower_bound: 1,
-                    length: arg_ids.len(),
-                }],
-                arg_ids.iter().map(|id| Datum::String(&id)),
-            )
-            .unwrap();
+            row.packer()
+                .push_array(
+                    &[ArrayDimension {
+                        lower_bound: 1,
+                        length: arg_ids.len(),
+                    }],
+                    arg_ids.iter().map(|id| Datum::String(&id)),
+                )
+                .unwrap();
             let arg_ids = row.unpack_first();
 
             let variadic_id = func_impl_details

--- a/src/dataflow/src/logging/differential.rs
+++ b/src/dataflow/src/logging/differential.rs
@@ -183,14 +183,15 @@ pub fn construct<A: Allocate>(
                 );
                 let trace = collection
                     .map({
-                        let mut row_packer = Row::default();
+                        let mut row_buf = Row::default();
                         let mut datums = DatumVec::new();
                         move |row| {
                             let datums = datums.borrow_with(&row);
-                            row_packer.extend(key.iter().map(|k| datums[*k]));
-                            let row_key = row_packer.finish_and_reuse();
-                            row_packer.extend(value.iter().map(|c| datums[*c]));
-                            (row_key, row_packer.finish_and_reuse())
+                            row_buf.packer().extend(key.iter().map(|k| datums[*k]));
+                            let row_key = row_buf.clone();
+                            row_buf.packer().extend(value.iter().map(|c| datums[*c]));
+                            let row_val = row_buf.clone();
+                            (row_key, row_val)
                         }
                     })
                     .arrange_named::<RowSpine<_, _, _, _>>(&format!("ArrangeByKey {:?}", variant))

--- a/src/dataflow/src/render/top_k.rs
+++ b/src/dataflow/src/render/top_k.rs
@@ -108,7 +108,7 @@ where
                         let iterator = group_key.iter().map(|i| datums[*i]);
                         let total_size = mz_repr::datums_size(iterator.clone());
                         let mut group_row = Row::with_capacity(total_size);
-                        group_row.extend(iterator);
+                        group_row.packer().extend(iterator);
                         group_row
                     };
                     ((group_row, row_hash), row)
@@ -263,7 +263,7 @@ where
                         let iterator = group_key.iter().map(|i| datums[*i]);
                         let total_size = mz_repr::datums_size(iterator.clone());
                         let mut group_key = Row::with_capacity(total_size);
-                        group_key.extend(iterator);
+                        group_key.packer().extend(iterator);
                         group_key
                     };
                     (group_key, row)

--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -56,7 +56,7 @@ use mz_ore::collections::CollectionExt;
 use mz_ore::metrics::{CounterVecExt, DeleteOnDropCounter, DeleteOnDropGauge, GaugeVecExt};
 use mz_ore::retry::Retry;
 use mz_ore::task;
-use mz_repr::{Datum, Diff, RelationDesc, Row, Timestamp};
+use mz_repr::{Datum, Diff, RelationDesc, Row, RowPacker, Timestamp};
 use mz_timely_util::async_op;
 use mz_timely_util::operators_async_ext::OperatorBuilderExt;
 
@@ -99,7 +99,7 @@ where
                 .map(|((k, v), t, diff)| {
                     let v = v.map(|mut v| {
                         let t = t.to_string();
-                        v.push_list_with(|rp| {
+                        RowPacker::for_existing_row(&mut v).push_list_with(|rp| {
                             rp.push(Datum::String(&t));
                         });
                         v

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -1115,8 +1115,8 @@ pub fn csv_extract(a: Datum, n_cols: usize) -> impl Iterator<Item = (Row, Diff)>
         .from_reader(bytes);
     csv_reader.into_records().filter_map(move |res| match res {
         Ok(sr) if sr.len() == n_cols => {
-            row.extend(sr.iter().map(Datum::String));
-            Some((row.finish_and_reuse(), 1))
+            row.packer().extend(sr.iter().map(Datum::String));
+            Some((row.clone(), 1))
         }
         _ => None,
     })

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -2188,7 +2188,7 @@ impl RowSetFinishing {
 
         let mut ret = Vec::with_capacity(return_size);
         let mut remaining = limit;
-        let mut row_packer = Row::default();
+        let mut row_buf = Row::default();
         let mut datum_vec = mz_repr::DatumVec::new();
         for (row, count) in &rows[offset_nth_row..] {
             if remaining == 0 {
@@ -2198,8 +2198,10 @@ impl RowSetFinishing {
             for _ in 0..count {
                 let new_row = {
                     let datums = datum_vec.borrow_with(&row);
-                    row_packer.extend(self.project.iter().map(|i| &datums[*i]));
-                    row_packer.finish_and_reuse()
+                    row_buf
+                        .packer()
+                        .extend(self.project.iter().map(|i| &datums[*i]));
+                    row_buf.clone()
                 };
                 ret.push(new_row);
             }

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -42,7 +42,9 @@ use mz_repr::adt::interval::Interval;
 use mz_repr::adt::jsonb::JsonbRef;
 use mz_repr::adt::numeric::{self, DecimalLike, Numeric, NumericMaxScale};
 use mz_repr::adt::regex::Regex;
-use mz_repr::{strconv, ColumnName, ColumnType, Datum, DatumType, Row, RowArena, ScalarType};
+use mz_repr::{
+    strconv, ColumnName, ColumnType, Datum, DatumType, Row, RowArena, RowPacker, ScalarType,
+};
 
 use crate::scalar::func::format::DateTimeFormat;
 use crate::{like_pattern, EvalError, MirScalarExpr};
@@ -2120,7 +2122,7 @@ fn jsonb_typeof<'a>(a: Datum<'a>) -> Datum<'a> {
 }
 
 fn jsonb_strip_nulls<'a>(a: Datum<'a>, temp_storage: &'a RowArena) -> Datum<'a> {
-    fn strip_nulls(a: Datum, row: &mut Row) {
+    fn strip_nulls(a: Datum, row: &mut RowPacker) {
         match a {
             Datum::Map(dict) => row.push_dict_with(|row| {
                 for (k, v) in dict.iter() {
@@ -4829,14 +4831,15 @@ fn regexp_match_static<'a>(
     needle: &regex::Regex,
 ) -> Result<Datum<'a>, EvalError> {
     let mut row = Row::default();
+    let mut packer = row.packer();
     if needle.captures_len() > 1 {
         // The regex contains capture groups, so return an array containing the
         // matched text in each capture group, unless the entire match fails.
         // Individual capture groups may also be null if that group did not
         // participate in the match.
         match needle.captures(haystack.unwrap_str()) {
-            None => row.push(Datum::Null),
-            Some(captures) => row.push_array(
+            None => packer.push(Datum::Null),
+            Some(captures) => packer.push_array(
                 &[ArrayDimension {
                     lower_bound: 1,
                     length: captures.len() - 1,
@@ -4852,8 +4855,8 @@ fn regexp_match_static<'a>(
         // The regex contains no capture groups, so return a one-element array
         // containing the match, or null if there is no match.
         match needle.find(haystack.unwrap_str()) {
-            None => row.push(Datum::Null),
-            Some(mtch) => row.push_array(
+            None => packer.push(Datum::Null),
+            Some(mtch) => packer.push_array(
                 &[ArrayDimension {
                     lower_bound: 1,
                     length: 1,

--- a/src/interchange/src/envelopes.rs
+++ b/src/interchange/src/envelopes.rs
@@ -20,7 +20,7 @@ use differential_dataflow::{
 use differential_dataflow::{AsCollection, Collection};
 use itertools::Itertools;
 use mz_ore::collections::CollectionExt;
-use mz_repr::{ColumnType, Datum, Diff, RelationDesc, RelationType, Row, ScalarType};
+use mz_repr::{ColumnType, Datum, Diff, RelationDesc, RelationType, Row, RowPacker, ScalarType};
 use timely::dataflow::{channels::pact::Pipeline, operators::Operator, Scope, Stream};
 
 /// Given a stream of batches, produce a stream of (vectors of) DiffPairs, in timestamp order.
@@ -128,7 +128,7 @@ pub fn dbz_desc(desc: RelationDesc) -> RelationDesc {
     RelationDesc::new(typ, ["before", "after"])
 }
 
-pub fn dbz_format(rp: &mut Row, dp: DiffPair<Row>) -> Row {
+pub fn dbz_format(rp: &mut RowPacker, dp: DiffPair<Row>) {
     if let Some(before) = dp.before {
         rp.push_list_with(|rp| rp.extend_by_row(&before));
     } else {
@@ -139,7 +139,6 @@ pub fn dbz_format(rp: &mut Row, dp: DiffPair<Row>) -> Row {
     } else {
         rp.push(Datum::Null);
     }
-    rp.finish_and_reuse()
 }
 
 pub fn upsert_format(dps: Vec<DiffPair<Row>>) -> Option<Row> {

--- a/src/pgrepr/src/value.rs
+++ b/src/pgrepr/src/value.rs
@@ -198,29 +198,29 @@ impl Value {
                     Type::List(t) => &*t,
                     _ => panic!("Value::List should have type Type::List. Found {:?}", typ),
                 };
-                let mut row = Row::default();
-                row.push_list(elems.into_iter().map(|elem| match elem {
-                    Some(elem) => elem.into_datum(buf, &elem_pg_type),
-                    None => Datum::Null,
-                }));
-                buf.push_unary_row(row)
+                buf.make_datum(|packer| {
+                    packer.push_list(elems.into_iter().map(|elem| match elem {
+                        Some(elem) => elem.into_datum(buf, &elem_pg_type),
+                        None => Datum::Null,
+                    }));
+                })
             }
             Value::Map(map) => {
                 let elem_pg_type = match typ {
                     Type::Map { value_type } => &*value_type,
                     _ => panic!("Value::Map should have type Type::Map. Found {:?}", typ),
                 };
-                let mut row = Row::default();
-                row.push_dict_with(|row| {
-                    for (k, v) in map {
-                        row.push(Datum::String(&k));
-                        row.push(match v {
-                            Some(elem) => elem.into_datum(buf, &elem_pg_type),
-                            None => Datum::Null,
-                        });
-                    }
-                });
-                buf.push_unary_row(row)
+                buf.make_datum(|packer| {
+                    packer.push_dict_with(|row| {
+                        for (k, v) in map {
+                            row.push(Datum::String(&k));
+                            row.push(match v {
+                                Some(elem) => elem.into_datum(buf, &elem_pg_type),
+                                None => Datum::Null,
+                            });
+                        }
+                    });
+                })
             }
             Value::Record(_) => {
                 // This situation is handled gracefully by Value::decode; if we

--- a/src/repr/src/datum_vec.rs
+++ b/src/repr/src/datum_vec.rs
@@ -99,9 +99,7 @@ mod test {
 
         assert_eq!(d.borrow().len(), 0);
 
-        let mut r = Row::with_capacity(10);
-        r.push(Datum::String("first"));
-        r.push(Datum::Dummy);
+        let r = Row::pack_slice(&[Datum::String("first"), Datum::Dummy]);
 
         {
             let borrow = d.borrow_with(&r);
@@ -111,8 +109,7 @@ mod test {
 
         {
             // different lifetime, so that rust is happy with the reference lifetimes
-            let mut r2 = Row::with_capacity(1);
-            r2.push(Datum::String("second"));
+            let r2 = Row::pack_slice(&[Datum::String("second")]);
             let borrow = d.borrow_with_many(&[&r, &r2]);
             assert_eq!(borrow.len(), 3);
             assert_eq!(borrow[2], Datum::String("second"));

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -35,7 +35,8 @@ pub mod util;
 pub use datum_vec::{DatumVec, DatumVecBorrow};
 pub use relation::{ColumnName, ColumnType, NotNullViolation, RelationDesc, RelationType};
 pub use row::{
-    datum_list_size, datum_size, datums_size, row_size, DatumList, DatumMap, Row, RowArena, RowRef,
+    datum_list_size, datum_size, datums_size, row_size, DatumList, DatumMap, Row, RowArena,
+    RowPacker, RowRef,
 };
 pub use scalar::{AsColumnType, Datum, DatumType, ScalarBaseType, ScalarType};
 

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -58,10 +58,10 @@ mod encoding;
 ///
 /// A `Row` can be built from a collection of `Datum`s using `Row::pack`, but it
 /// is more efficient to use `Row::pack_slice` so that a right-sized allocation
-/// can be created. If that is not possible, consider using the "packer"
-/// pattern: allocate one row, pack into it, and then call
-/// [`Row::finish_and_reuse`] to receive a copy of that row, leaving behind the
-/// original allocation to pack future rows.
+/// can be created. If that is not possible, consider using the row buffer
+/// pattern: allocate one row, pack into it, and then call [`Row::clone`] to
+/// receive a copy of that row, leaving behind the original allocation to pack
+/// future rows.
 ///
 /// Creating a row via [`Row::pack_slice`]:
 ///
@@ -131,6 +131,18 @@ impl Ord for Row {
             std::cmp::Ordering::Equal => self.data.cmp(&other.data),
         }
     }
+}
+
+/// Packs datums into a [`Row`].
+///
+/// Creating a `RowPacker` via [`Row::packer`] starts a packing operation on the
+/// row. A packing operation always starts from scratch: the existing contents
+/// of the underlying row are cleared.
+///
+/// To complete a packing operation, drop the `RowPacker`.
+#[derive(Debug)]
+pub struct RowPacker<'a> {
+    row: &'a mut Row,
 }
 
 /// A wrapper around a byte slice that guarantees the data are row-formatted.
@@ -688,7 +700,7 @@ pub fn datum_size(datum: &Datum) -> usize {
 /// Number of bytes required by a sequence of datums.
 ///
 /// This method can be used to right-size the allocation for a `Row`
-/// before calling [`Row::extend`].
+/// before calling [`RowPacker::extend`].
 pub fn datums_size<'a, I, D>(iter: I) -> usize
 where
     I: IntoIterator<Item = D>,
@@ -731,12 +743,22 @@ impl Row {
         Row { data: data.into() }
     }
 
+    /// Constructs a [`RowPacker`] that will pack datums into this row's
+    /// allocation.
+    ///
+    /// This method clears the existing contents of the row, but retains the
+    /// allocation.
+    pub fn packer(&mut self) -> RowPacker<'_> {
+        self.data.clear();
+        RowPacker { row: self }
+    }
+
     /// Take some `Datum`s and pack them into a `Row`.
     ///
     /// This method builds a `Row` by repeatedly increasing the backing
     /// allocation. If the contents of the iterator are known ahead of
     /// time, consider [`Row::with_capacity`] to right-size the allocation
-    /// first, and then [`Row::extend`] to populate it with `Datum`s.
+    /// first, and then [`RowPacker::extend`] to populate it with `Datum`s.
     /// This avoids the repeated allocation resizing and copying.
     pub fn pack<'a, I, D>(iter: I) -> Row
     where
@@ -744,7 +766,7 @@ impl Row {
         D: Borrow<Datum<'a>>,
     {
         let mut row = Row::default();
-        row.extend(iter);
+        row.packer().extend(iter);
         row
     }
 
@@ -757,7 +779,7 @@ impl Row {
         D: Borrow<Datum<'a>>,
     {
         let mut row = Row::default();
-        row.try_extend(iter)?;
+        row.packer().try_extend(iter)?;
         Ok(row)
     }
 
@@ -769,10 +791,21 @@ impl Row {
     pub fn pack_slice<'a>(slice: &[Datum<'a>]) -> Row {
         // Pre-allocate the needed number of bytes.
         let mut row = Row::with_capacity(datums_size(slice.iter()));
-        row.extend(slice.iter());
+        row.packer().extend(slice.iter());
         row
     }
+}
 
+impl RowPacker<'_> {
+    /// Constructs a row packer that will pack additional datums into the
+    /// provided row.
+    ///
+    /// This function is intentionally somewhat inconvenient to call. You
+    /// usually want to call [`Row::packer`] instead to start packing from
+    /// scratch.
+    pub fn for_existing_row(row: &mut Row) -> RowPacker {
+        RowPacker { row }
+    }
 
     /// Extend an existing `Row` with a `Datum`.
     #[inline]
@@ -780,7 +813,7 @@ impl Row {
     where
         D: Borrow<Datum<'a>>,
     {
-        push_datum(&mut self.data, *datum.borrow())
+        push_datum(&mut self.row.data, *datum.borrow())
     }
 
     /// Extend an existing `Row` with additional `Datum`s.
@@ -791,7 +824,7 @@ impl Row {
         D: Borrow<Datum<'a>>,
     {
         for datum in iter {
-            push_datum(&mut self.data, *datum.borrow())
+            push_datum(&mut self.row.data, *datum.borrow())
         }
     }
 
@@ -814,21 +847,22 @@ impl Row {
 
     /// Appends the datums of an entire `Row`.
     pub fn extend_by_row(&mut self, row: &Row) {
-        self.data.extend(row.data.iter().copied());
+        self.row.data.extend(row.data.iter().copied());
     }
 
     /// Pushes a [`DatumList`] that is built from a closure.
     ///
-    /// The supplied closure will be invoked once with a `Row` that can
-    /// be used to populate the list. It is valid to call any method on the
-    /// [`Row`] except for [`Row::finish_and_reuse`] or [`Row::truncate`].
+    /// The supplied closure will be invoked once with a `Row` that can be used
+    /// to populate the list. It is valid to call any method on the
+    /// [`RowPacker`] except for [`RowPacker::clear`], [`RowPacker::truncate`],
+    /// or [`RowPacker::truncate_datums`].
     ///
     /// Returns the value returned by the closure, if any.
     ///
     /// ```
     /// # use mz_repr::{Row, Datum};
     /// let mut row = Row::default();
-    /// row.push_list_with(|row| {
+    /// row.packer().push_list_with(|row| {
     ///     row.push(Datum::String("age"));
     ///     row.push(Datum::Int64(42));
     /// });
@@ -840,26 +874,26 @@ impl Row {
     #[inline]
     pub fn push_list_with<F, R>(&mut self, f: F) -> R
     where
-        F: FnOnce(&mut Row) -> R,
+        F: FnOnce(&mut RowPacker) -> R,
     {
-        self.data.push(Tag::List as u8);
-        let start = self.data.len();
+        self.row.data.push(Tag::List as u8);
+        let start = self.row.data.len();
         // write a dummy len, will fix it up later
-        self.data.extend_from_slice(&[0; size_of::<u64>()]);
+        self.row.data.extend_from_slice(&[0; size_of::<u64>()]);
 
         let out = f(self);
 
-        let len = u64::cast_from(self.data.len() - start - size_of::<u64>());
+        let len = u64::cast_from(self.row.data.len() - start - size_of::<u64>());
         // fix up the len
-        self.data[start..start + size_of::<u64>()].copy_from_slice(&len.to_le_bytes());
+        self.row.data[start..start + size_of::<u64>()].copy_from_slice(&len.to_le_bytes());
 
         out
     }
 
     /// Pushes a [`DatumMap`] that is built from a closure.
     ///
-    /// The supplied closure will be invoked once with a `Row` that can be
-    /// used to populate the dict.
+    /// The supplied closure will be invoked once with a `Row` that can be used
+    /// to populate the dict.
     ///
     /// The closure **must** alternate pushing string keys and arbitary values,
     /// otherwise reading the dict will cause a panic.
@@ -868,14 +902,15 @@ impl Row {
     /// checks on the resulting `Row` may be wrong and reading the dict IN DEBUG
     /// MODE will cause a panic.
     ///
-    /// The closure **must not** call [`Row::finish_and_reuse`].
+    /// The closure **must not** call [`RowPacker::clear`],
+    /// [`RowPacker::truncate`], or [`RowPacker::truncate_datums`].
     ///
     /// # Example
     ///
     /// ```
     /// # use mz_repr::{Row, Datum};
     /// let mut row = Row::default();
-    /// row.push_dict_with(|row| {
+    /// row.packer().push_dict_with(|row| {
     ///
     ///     // key
     ///     row.push(Datum::String("age"));
@@ -894,18 +929,18 @@ impl Row {
     /// ```
     pub fn push_dict_with<F, R>(&mut self, f: F) -> R
     where
-        F: FnOnce(&mut Row) -> R,
+        F: FnOnce(&mut RowPacker) -> R,
     {
-        self.data.push(Tag::Dict as u8);
-        let start = self.data.len();
+        self.row.data.push(Tag::Dict as u8);
+        let start = self.row.data.len();
         // write a dummy len, will fix it up later
-        self.data.extend_from_slice(&[0; size_of::<u64>()]);
+        self.row.data.extend_from_slice(&[0; size_of::<u64>()]);
 
         let res = f(self);
 
-        let len = u64::cast_from(self.data.len() - start - size_of::<u64>());
+        let len = u64::cast_from(self.row.data.len() - start - size_of::<u64>());
         // fix up the len
-        self.data[start..start + size_of::<u64>()].copy_from_slice(&len.to_le_bytes());
+        self.row.data[start..start + size_of::<u64>()].copy_from_slice(&len.to_le_bytes());
 
         res
     }
@@ -940,29 +975,32 @@ impl Row {
             return Err(InvalidArrayError::TooManyDimensions(dims.len()));
         }
 
-        let start = self.data.len();
-        self.data.push(Tag::Array as u8);
+        let start = self.row.data.len();
+        self.row.data.push(Tag::Array as u8);
 
         // Write dimension information.
-        self.data
+        self.row
+            .data
             .push(dims.len().try_into().expect("ndims verified to fit in u8"));
         for dim in dims {
-            self.data
+            self.row
+                .data
                 .extend_from_slice(&u64::cast_from(dim.lower_bound).to_le_bytes());
-            self.data
+            self.row
+                .data
                 .extend_from_slice(&u64::cast_from(dim.length).to_le_bytes());
         }
 
         // Write elements.
-        let off = self.data.len();
-        self.data.extend_from_slice(&[0; size_of::<u64>()]);
+        let off = self.row.data.len();
+        self.row.data.extend_from_slice(&[0; size_of::<u64>()]);
         let mut nelements = 0;
         for datum in iter {
             self.push(*datum.borrow());
             nelements += 1;
         }
-        let len = u64::cast_from(self.data.len() - off - size_of::<u64>());
-        self.data[off..off + size_of::<u64>()].copy_from_slice(&len.to_le_bytes());
+        let len = u64::cast_from(self.row.data.len() - off - size_of::<u64>());
+        self.row.data[off..off + size_of::<u64>()].copy_from_slice(&len.to_le_bytes());
 
         // Check that the number of elements written matches the dimension
         // information.
@@ -971,7 +1009,7 @@ impl Row {
             dims => dims.iter().map(|d| d.length).product(),
         };
         if nelements != cardinality {
-            self.data.truncate(start);
+            self.row.data.truncate(start);
             return Err(InvalidArrayError::WrongCardinality {
                 actual: nelements,
                 expected: cardinality,
@@ -983,7 +1021,7 @@ impl Row {
 
     /// Convenience function to push a `DatumList` from an iter of `Datum`s
     ///
-    /// See [`Row::push_dict_with`] if you need to be able to handle errors
+    /// See [`RowPacker::push_dict_with`] if you need to be able to handle errors
     pub fn push_list<'a, I, D>(&mut self, iter: I)
     where
         I: IntoIterator<Item = D>,
@@ -1010,9 +1048,9 @@ impl Row {
         })
     }
 
-    /// Clears the contents of the row without de-allocating its backing memory.
+    /// Clears the contents of the packer without de-allocating its backing memory.
     pub fn clear(&mut self) {
-        self.data.clear();
+        self.row.data.clear();
     }
 
     /// Truncates the underlying storage to the specified byte position.
@@ -1028,27 +1066,16 @@ impl Row {
     /// byte length by calling `packer.data().len()` after pushing the desired
     /// number of datums onto the packer.
     pub unsafe fn truncate(&mut self, pos: usize) {
-        self.data.truncate(pos)
+        self.row.data.truncate(pos)
     }
 
-    /// Truncates the row to contain at most the first `n` datums.
+    /// Truncates the underlying row to contain at most the first `n` datums.
     pub fn truncate_datums(&mut self, n: usize) {
-        let mut iter = self.iter();
+        let mut iter = self.row.iter();
         for _ in iter.by_ref().take(n) {}
         let offset = iter.offset;
         // SAFETY: iterator offsets always lie on a datum boundary.
         unsafe { self.truncate(offset) }
-    }
-
-    /// Returns a copy of this `Row`, clearing the data but not the allocation
-    /// in `self`.
-    ///
-    /// The intent is that `self`'s allocation can be used to pack additional
-    /// rows, to reduce the amount of interaction with the allocator.
-    pub fn finish_and_reuse(&mut self) -> Row {
-        let data = SmallVec::from_slice(&self.data[..]);
-        self.data.clear();
-        Row { data }
     }
 }
 
@@ -1334,20 +1361,20 @@ impl RowArena {
     /// ```
     pub fn make_datum<'a, F>(&'a self, f: F) -> Datum<'a>
     where
-        F: FnOnce(&mut Row),
+        F: FnOnce(&mut RowPacker),
     {
         let mut row = Row::default();
-        f(&mut row);
+        f(&mut row.packer());
         self.push_unary_row(row)
     }
 
     /// Like [`RowArena::make_datum`], but the provided closure can return an error.
     pub fn try_make_datum<'a, F, E>(&'a self, f: F) -> Result<Datum<'a>, E>
     where
-        F: FnOnce(&mut Row) -> Result<(), E>,
+        F: FnOnce(&mut RowPacker) -> Result<(), E>,
     {
         let mut row = Row::default();
-        f(&mut row)?;
+        f(&mut row.packer())?;
         Ok(self.push_unary_row(row))
     }
 }
@@ -1386,7 +1413,8 @@ mod tests {
         assert_eq!(arena.push_bytes(vec![0, 2, 1, 255]), &[0, 2, 1, 255]);
 
         let mut row = Row::default();
-        row.push_dict_with(|row| {
+        let mut packer = row.packer();
+        packer.push_dict_with(|row| {
             row.push(Datum::String("a"));
             row.push_list_with(|row| {
                 row.push(Datum::String("one"));
@@ -1454,7 +1482,9 @@ mod tests {
             length: 2,
         };
         let mut row = Row::default();
-        row.push_array(&[DIM], vec![Datum::Int32(1), Datum::Int32(2)])
+        let mut packer = row.packer();
+        packer
+            .push_array(&[DIM], vec![Datum::Int32(1), Datum::Int32(2)])
             .unwrap();
         let arr1 = row.unpack_first().unwrap_array();
         assert_eq!(arr1.dims().into_iter().collect::<Vec<_>>(), vec![DIM]);
@@ -1484,24 +1514,26 @@ mod tests {
         ];
 
         let mut row = Row::default();
-        row.push_array(
-            &[
-                ArrayDimension {
-                    lower_bound: 1,
-                    length: 1,
-                },
-                ArrayDimension {
-                    lower_bound: 1,
-                    length: 4,
-                },
-                ArrayDimension {
-                    lower_bound: 1,
-                    length: 2,
-                },
-            ],
-            &datums,
-        )
-        .unwrap();
+        let mut packer = row.packer();
+        packer
+            .push_array(
+                &[
+                    ArrayDimension {
+                        lower_bound: 1,
+                        length: 1,
+                    },
+                    ArrayDimension {
+                        lower_bound: 1,
+                        length: 4,
+                    },
+                    ArrayDimension {
+                        lower_bound: 1,
+                        length: 2,
+                    },
+                ],
+                &datums,
+            )
+            .unwrap();
         let array = row.unpack_first().unwrap_array();
         assert_eq!(array.elements().into_iter().collect::<Vec<_>>(), datums);
     }
@@ -1512,7 +1544,7 @@ mod tests {
         let max_dims = usize::from(MAX_ARRAY_DIMENSIONS);
 
         // An array with one too many dimensions should be rejected.
-        let res = row.push_array(
+        let res = row.packer().push_array(
             &vec![
                 ArrayDimension {
                     lower_bound: 1,
@@ -1527,23 +1559,24 @@ mod tests {
 
         // An array with exactly the maximum allowable dimensions should be
         // accepted.
-        row.push_array(
-            &vec![
-                ArrayDimension {
-                    lower_bound: 1,
-                    length: 1
-                };
-                max_dims
-            ],
-            vec![Datum::Int32(4)],
-        )
-        .unwrap();
+        row.packer()
+            .push_array(
+                &vec![
+                    ArrayDimension {
+                        lower_bound: 1,
+                        length: 1
+                    };
+                    max_dims
+                ],
+                vec![Datum::Int32(4)],
+            )
+            .unwrap();
     }
 
     #[test]
     fn test_array_wrong_cardinality() {
         let mut row = Row::default();
-        let res = row.push_array(
+        let res = row.packer().push_array(
             &[
                 ArrayDimension {
                     lower_bound: 1,
@@ -1569,7 +1602,7 @@ mod tests {
     #[test]
     fn test_nesting() {
         let mut row = Row::default();
-        row.push_dict_with(|row| {
+        row.packer().push_dict_with(|row| {
             row.push(Datum::String("favourites"));
             row.push_list_with(|row| {
                 row.push(Datum::String("ice cream"));
@@ -1602,7 +1635,7 @@ mod tests {
     fn test_dict_errors() -> Result<(), Box<dyn std::error::Error>> {
         let pack = |ok| {
             let mut row = Row::default();
-            row.push_dict_with(|row| {
+            row.packer().push_dict_with(|row| {
                 if ok {
                     row.push(Datum::String("key"));
                     row.push(Datum::Int32(42));

--- a/src/repr/src/row/encoding.rs
+++ b/src/repr/src/row/encoding.rs
@@ -27,7 +27,7 @@ use crate::gen::row::{
     ProtoArray, ProtoArrayDimension, ProtoDate, ProtoDatum, ProtoDatumOther, ProtoDict,
     ProtoDictElement, ProtoInterval, ProtoNumeric, ProtoRow, ProtoTime, ProtoTimestamp,
 };
-use crate::{Datum, Row};
+use crate::{Datum, Row, RowPacker};
 
 impl Codec for Row {
     fn codec_name() -> String {
@@ -172,7 +172,7 @@ impl From<&Row> for ProtoRow {
     }
 }
 
-impl Row {
+impl RowPacker<'_> {
     fn try_push_proto(&mut self, x: &ProtoDatum) -> Result<(), String> {
         match &x.datum_type {
             Some(DatumType::Other(o)) => match ProtoDatumOther::from_i32(*o) {
@@ -289,8 +289,9 @@ impl TryFrom<&ProtoRow> for Row {
     fn try_from(x: &ProtoRow) -> Result<Self, Self::Error> {
         // TODO: Try to pre-size this.
         let mut row = Row::default();
+        let mut packer = row.packer();
         for d in x.datums.iter() {
-            row.try_push_proto(d)?;
+            packer.try_push_proto(d)?;
         }
         Ok(row)
     }
@@ -312,7 +313,9 @@ mod tests {
 
     #[test]
     fn roundtrip() {
-        let mut row = Row::pack(vec![
+        let mut row = Row::default();
+        let mut packer = row.packer();
+        packer.extend([
             Datum::False,
             Datum::True,
             Datum::Int16(1),
@@ -344,24 +347,25 @@ mod tests {
             Datum::Dummy,
             Datum::Null,
         ]);
-        row.push_array(
-            &[ArrayDimension {
-                lower_bound: 2,
-                length: 2,
-            }],
-            vec![Datum::Int32(31), Datum::Int32(32)],
-        )
-        .expect("valid array");
-        row.push_list_with(|row| {
-            row.push(Datum::String("33"));
-            row.push_list_with(|row| {
-                row.push(Datum::String("34"));
-                row.push(Datum::String("35"));
+        packer
+            .push_array(
+                &[ArrayDimension {
+                    lower_bound: 2,
+                    length: 2,
+                }],
+                vec![Datum::Int32(31), Datum::Int32(32)],
+            )
+            .expect("valid array");
+        packer.push_list_with(|packer| {
+            packer.push(Datum::String("33"));
+            packer.push_list_with(|packer| {
+                packer.push(Datum::String("34"));
+                packer.push(Datum::String("35"));
             });
-            row.push(Datum::String("36"));
-            row.push(Datum::String("37"));
+            packer.push(Datum::String("36"));
+            packer.push(Datum::String("37"));
         });
-        row.push_dict_with(|row| {
+        packer.push_dict_with(|row| {
             // Add a bunch of data to the hash to ensure we don't get a
             // HashMap's random iteration anywhere in the encode/decode path.
             let mut i = 38;

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -1373,7 +1373,7 @@ impl HirScalarExpr {
         };
 
         let mut row = Row::default();
-        row.push_array(
+        row.packer().push_array(
             &[ArrayDimension {
                 lower_bound: 1,
                 length: datums.len(),

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -814,7 +814,8 @@ pub fn plan_params<'a>(
     let scope = Scope::empty();
     let rel_type = RelationType::empty();
 
-    let mut datums = Row::with_capacity(desc.param_types.len());
+    let mut datums = Row::default();
+    let mut packer = datums.packer();
     let mut types = Vec::new();
     let temp_storage = &RowArena::new();
     for (mut param, ty) in params.into_iter().zip(&desc.param_types) {
@@ -841,7 +842,7 @@ pub fn plan_params<'a>(
         }
         let ex = ex.lower_uncorrelated()?;
         let evaled = ex.eval(&[], temp_storage)?;
-        datums.push(evaled);
+        packer.push(evaled);
         types.push(st);
     }
     Ok(Params { datums, types })


### PR DESCRIPTION
This is an more opinionated take of what Gus started working on in #10769 that moves all mutating methods into the re-introduced `RowPacker` type. There's a bunch of typing to do to get this to actually build, and some gnarly lifetime issues to sort out in the Avro decoder, but the bones are here, I think.

----

When using a `Row` in the "row packer" pattern, it was easy to forget to
call `.clear()` in every code path that started a new packing operation.
See, for example, https://github.com/MaterializeInc/materialize/pull/10767.

To avoid this footgun, force all mutation of `Row` to happen via a new
type called `RowPacker`. Constructing a `RowPacker` *always* clears the
data in the underlying `Row`. Because it is not otherwise possible to
mutate a `Row`, it is no longer possible to forget to call `clear`
before starting a packing operation.

The `RowPacker` type is a reintroduction of a type that used to exist.
However, its new design does not require two allocations to produce a
single row in the worst case. See https://github.com/MaterializeInc/materialize/pull/5472 and https://github.com/MaterializeInc/materialize/pull/6276 for some historical
context.

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
