### PR TITLE
Refactor `Controller` into `Compute` and `Storage` facets

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -549,6 +549,7 @@ impl Coordinator {
                         .source_description_for(entry.id())
                         .unwrap();
                     self.dataflow_client
+                        .storage()
                         .create_sources(vec![(
                             entry.id(),
                             (source_description, Antichain::from_elem(since_ts)),
@@ -584,6 +585,7 @@ impl Coordinator {
                         .source_description_for(entry.id())
                         .unwrap();
                     self.dataflow_client
+                        .storage()
                         .create_sources(vec![(
                             entry.id(),
                             (source_description, Antichain::from_elem(since_ts)),
@@ -847,6 +849,7 @@ impl Coordinator {
         }
 
         self.dataflow_client
+            .storage()
             .advance_all_table_timestamps(advance_to)
             .await;
     }
@@ -947,6 +950,7 @@ impl Coordinator {
                 // Announce the new frontiers that have been durably persisted.
                 if !durability_updates.is_empty() {
                     self.dataflow_client
+                        .storage()
                         .update_durability_frontiers(durability_updates)
                         .await;
                 }
@@ -1589,7 +1593,9 @@ impl Coordinator {
             // See #10300 for context.
             self.persisted_table_allow_compaction(&index_since_updates);
             self.dataflow_client
-                .allow_index_compaction(DEFAULT_COMPUTE_INSTANCE_ID, index_since_updates)
+                .compute(DEFAULT_COMPUTE_INSTANCE_ID)
+                .unwrap()
+                .allow_index_compaction(index_since_updates)
                 .await
                 .unwrap();
         }
@@ -1604,6 +1610,7 @@ impl Coordinator {
         if !source_since_updates.is_empty() {
             self.persisted_table_allow_compaction(&source_since_updates);
             self.dataflow_client
+                .storage()
                 .allow_source_compaction(source_since_updates)
                 .await;
         }
@@ -1725,7 +1732,9 @@ impl Coordinator {
 
             // Allow dataflow to cancel any pending peeks.
             self.dataflow_client
-                .cancel_peek(DEFAULT_COMPUTE_INSTANCE_ID, conn_id)
+                .compute(DEFAULT_COMPUTE_INSTANCE_ID)
+                .unwrap()
+                .cancel_peek(conn_id)
                 .await;
         }
     }
@@ -2237,6 +2246,7 @@ impl Coordinator {
                     .source_description_for(table_id)
                     .unwrap();
                 self.dataflow_client
+                    .storage()
                     .create_sources(vec![(
                         table_id,
                         (source_description, Antichain::from_elem(since_ts)),
@@ -2342,6 +2352,7 @@ impl Coordinator {
                 }
 
                 self.dataflow_client
+                    .storage()
                     .create_sources(source_descriptions)
                     .await
                     .unwrap();
@@ -3011,7 +3022,10 @@ impl Coordinator {
                             );
                         } else {
                             for (id, updates) in volatile_updates {
-                                self.dataflow_client.table_insert(id, updates).await;
+                                self.dataflow_client
+                                    .storage()
+                                    .table_insert(id, updates)
+                                    .await;
                             }
                         }
                     }
@@ -4143,7 +4157,10 @@ impl Coordinator {
                     self.update_timestamper(id, false).await;
                     self.sources.remove(&id);
                 }
-                self.dataflow_client.drop_sources(sources_to_drop).await;
+                self.dataflow_client
+                    .storage()
+                    .drop_sources(sources_to_drop)
+                    .await;
             }
             if !tables_to_drop.is_empty() {
                 // NOTE: When creating a persistent table we insert its compaction frontier (aka since)
@@ -4153,14 +4170,19 @@ impl Coordinator {
                     self.sources.remove(&id);
                     self.persister.remove_table(id);
                 }
-                self.dataflow_client.drop_sources(tables_to_drop).await;
+                self.dataflow_client
+                    .storage()
+                    .drop_sources(tables_to_drop)
+                    .await;
             }
             if !sinks_to_drop.is_empty() {
                 for id in sinks_to_drop.iter() {
                     self.sink_writes.remove(id);
                 }
                 self.dataflow_client
-                    .drop_sinks(DEFAULT_COMPUTE_INSTANCE_ID, sinks_to_drop)
+                    .compute(DEFAULT_COMPUTE_INSTANCE_ID)
+                    .unwrap()
+                    .drop_sinks(sinks_to_drop)
                     .await;
             }
             if !indexes_to_drop.is_empty() {
@@ -4230,7 +4252,10 @@ impl Coordinator {
                 let write_fut = persist.write_handle.write(&updates);
                 let _ = task::spawn(|| "builtin_table_updates_write_fut:{id}", write_fut);
             } else {
-                self.dataflow_client.table_insert(id, updates).await
+                self.dataflow_client
+                    .storage()
+                    .table_insert(id, updates)
+                    .await
             }
         }
     }
@@ -4247,7 +4272,9 @@ impl Coordinator {
     async fn drop_sinks(&mut self, dataflow_names: Vec<GlobalId>) {
         if !dataflow_names.is_empty() {
             self.dataflow_client
-                .drop_sinks(DEFAULT_COMPUTE_INSTANCE_ID, dataflow_names)
+                .compute(DEFAULT_COMPUTE_INSTANCE_ID)
+                .unwrap()
+                .drop_sinks(dataflow_names)
                 .await;
         }
     }
@@ -4261,7 +4288,9 @@ impl Coordinator {
         }
         if !trace_keys.is_empty() {
             self.dataflow_client
-                .drop_indexes(DEFAULT_COMPUTE_INSTANCE_ID, trace_keys)
+                .compute(DEFAULT_COMPUTE_INSTANCE_ID)
+                .unwrap()
+                .drop_indexes(trace_keys)
                 .await
         }
     }
@@ -4378,7 +4407,9 @@ impl Coordinator {
             dataflow_plans.push(self.finalize_dataflow(dataflow));
         }
         self.dataflow_client
-            .create_dataflows(DEFAULT_COMPUTE_INSTANCE_ID, dataflow_plans)
+            .compute(DEFAULT_COMPUTE_INSTANCE_ID)
+            .unwrap()
+            .create_dataflows(dataflow_plans)
             .await
             .unwrap();
     }
@@ -4478,12 +4509,14 @@ impl Coordinator {
             if let Some(entry) = self.catalog.try_get_by_id(source_id) {
                 if let CatalogItem::Source(s) = entry.item() {
                     self.dataflow_client
+                        .storage()
                         .add_source_timestamping(source_id, s.connector.clone(), bindings)
                         .await;
                 }
             }
         } else {
             self.dataflow_client
+                .storage()
                 .drop_source_timestamping(source_id)
                 .await;
         }
@@ -4688,13 +4721,11 @@ pub async fn serve(
                     .collect(),
                 log_logging: config.log_logging,
             });
-            handle
-                .block_on(
-                    coord
-                        .dataflow_client
-                        .create_instance(DEFAULT_COMPUTE_INSTANCE_ID, logging),
-                )
-                .unwrap();
+            handle.block_on(
+                coord
+                    .dataflow_client
+                    .create_instance(DEFAULT_COMPUTE_INSTANCE_ID, logging),
+            );
             let bootstrap = handle.block_on(coord.bootstrap(builtin_table_updates));
             let ok = bootstrap.is_ok();
             bootstrap_tx.send(bootstrap).unwrap();
@@ -5082,7 +5113,9 @@ pub mod fast_path_peek {
                 }) => {
                     // Very important: actually create the dataflow (here, so we can destructure).
                     self.dataflow_client
-                        .create_dataflows(DEFAULT_COMPUTE_INSTANCE_ID, vec![dataflow])
+                        .compute(DEFAULT_COMPUTE_INSTANCE_ID)
+                        .unwrap()
+                        .create_dataflows(vec![dataflow])
                         .await
                         .unwrap();
                     // Create an identity MFP operator.
@@ -5123,8 +5156,9 @@ pub mod fast_path_peek {
             self.pending_peeks.insert(conn_id, rows_tx);
             let (id, key, conn_id, timestamp, _finishing, map_filter_project) = peek_command;
             self.dataflow_client
+                .compute(DEFAULT_COMPUTE_INSTANCE_ID)
+                .unwrap()
                 .peek(
-                    DEFAULT_COMPUTE_INSTANCE_ID,
                     id,
                     key,
                     conn_id,

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -366,15 +366,15 @@ pub enum StorageResponse<T = mz_repr::Timestamp> {
 
 /// A client to a running dataflow server.
 #[async_trait(?Send)]
-pub trait Client {
+pub trait Client<T = mz_repr::Timestamp> {
     /// Sends a command to the dataflow server.
-    async fn send(&mut self, cmd: Command);
+    async fn send(&mut self, cmd: Command<T>);
 
     /// Receives the next response from the dataflow server.
     ///
     /// This method blocks until the next response is available, or, if the
     /// dataflow server has been shut down, returns `None`.
-    async fn recv(&mut self) -> Option<Response>;
+    async fn recv(&mut self) -> Option<Response<T>>;
 }
 
 #[async_trait(?Send)]

--- a/src/dataflow-types/src/client/controller.rs
+++ b/src/dataflow-types/src/client/controller.rs
@@ -10,407 +10,98 @@
 //! A client that maintains summaries of the involved objects.
 use std::collections::BTreeMap;
 
-use timely::progress::{frontier::AntichainRef, Antichain, ChangeBatch};
-use tracing::error;
+use differential_dataflow::lattice::Lattice;
+use timely::progress::Timestamp;
 
-use crate::client::SourceConnector;
 use crate::client::{
-    Client, Command, ComputeCommand, ComputeInstanceId, ComputeResponse, Response, StorageCommand,
+    Client, Command, ComputeCommand, ComputeInstanceId, ComputeResponse, Response,
 };
 use crate::logging::LoggingConfig;
-use crate::DataflowDescription;
-use crate::Update;
-use mz_expr::GlobalId;
-use mz_expr::PartitionId;
-use mz_expr::RowSetFinishing;
-use mz_repr::{Row, Timestamp};
+
+mod since_upper;
+pub use since_upper::SinceUpperMap;
+pub use storage::StorageController;
+pub use storage::StorageControllerState;
+mod storage;
+pub use compute::ComputeController;
+mod compute;
 
 /// A client that maintains soft state and validates commands, in addition to forwarding them.
-pub struct Controller<C> {
+pub struct Controller<C, T = mz_repr::Timestamp> {
     /// The underlying client,
     client: C,
-    /// Sources that have been created.
-    ///
-    /// A `None` variant means that the source was dropped before it was first created.
-    source_descriptions: std::collections::BTreeMap<
-        GlobalId,
-        Option<(crate::sources::SourceDesc, Antichain<mz_repr::Timestamp>)>,
-    >,
-    /// Tracks `since` and `upper` frontiers for indexes and sinks.
-    compute_since_uppers: BTreeMap<ComputeInstanceId, SinceUpperMap>,
-    /// Tracks `since` and `upper` frontiers for sources and tables.
-    storage_since_uppers: SinceUpperMap,
+    storage: StorageControllerState<T>,
+    compute: BTreeMap<ComputeInstanceId, compute::ComputeControllerState<T>>,
 }
 
-/// Controller errors, either from compute or storage commands.
-#[derive(Debug)]
-pub enum ControllerError {
-    /// Errors arising from compute commands.
-    Compute(ComputeError),
-    /// Errors arising from storage commands.
-    Storage(StorageError),
-}
-
-impl From<ComputeError> for ControllerError {
-    fn from(err: ComputeError) -> ControllerError {
-        ControllerError::Compute(err)
-    }
-}
-impl From<StorageError> for ControllerError {
-    fn from(err: StorageError) -> ControllerError {
-        ControllerError::Storage(err)
-    }
-}
-
-/// Errors arising from compute commands.
-#[derive(Debug)]
-pub enum ComputeError {
-    /// Command referenced an instance that was not present.
-    InstanceMissing(ComputeInstanceId),
-    /// Command referenced an identifier that was not present.
-    IdentifierMissing(GlobalId),
-    /// Dataflow was malformed (e.g. missing `as_of`).
-    DataflowMalformed,
-    /// The dataflow `as_of` was not greater than the `since` of the identifier.
-    DataflowSinceViolation(GlobalId),
-    /// The peek `timestamp` was not greater than the `since` of the identifier.
-    PeekSinceViolation(GlobalId),
-}
-
-#[derive(Debug)]
-pub enum StorageError {
-    /// The source identifier was re-created after having been dropped,
-    /// or installed with a different description.
-    SourceIdReused(GlobalId),
-}
-
-// Implementation of COMPUTE commands.
-impl<C: Client> Controller<C> {
+impl<C: Client, T> Controller<C, T>
+where
+    T: Timestamp + Lattice,
+{
     pub async fn create_instance(
         &mut self,
         instance: ComputeInstanceId,
         logging: Option<LoggingConfig>,
-    ) -> Result<(), ControllerError> {
-        self.compute_since_uppers
-            .insert(instance, Default::default());
-
-        if let Some(logging_config) = logging.as_ref() {
-            for id in logging_config.log_identifiers() {
-                // This cannot fail, as we inserted just above.
-                self.compute_since_uppers
-                    .get_mut(&instance)
-                    .ok_or(ComputeError::InstanceMissing(instance))?
-                    .insert(id, (Antichain::from_elem(0), Antichain::from_elem(0)));
-            }
-        }
-
+    ) {
+        self.compute
+            .insert(instance, compute::ComputeControllerState::new(&logging));
         self.client
             .send(Command::Compute(
                 ComputeCommand::CreateInstance(logging),
                 instance,
             ))
             .await;
-
-        Ok(())
     }
     pub async fn drop_instance(&mut self, instance: ComputeInstanceId) {
-        self.compute_since_uppers.remove(&instance);
-
+        self.compute.remove(&instance);
         self.client
             .send(Command::Compute(ComputeCommand::DropInstance, instance))
             .await;
     }
-    pub async fn create_dataflows(
-        &mut self,
-        instance: ComputeInstanceId,
-        dataflows: Vec<DataflowDescription<crate::plan::Plan>>,
-    ) -> Result<(), ControllerError> {
-        let compute_since_uppers = self
-            .compute_since_uppers
-            .get_mut(&instance)
-            .ok_or(ComputeError::InstanceMissing(instance))?;
+}
 
-        // Validate dataflows as having inputs whose `since` is less or equal to the dataflow's `as_of`.
-        // Start tracking frontiers for each dataflow, using its `as_of` for each index and sink.
-        for dataflow in dataflows.iter() {
-            let as_of = dataflow
-                .as_of
-                .as_ref()
-                .ok_or(ComputeError::DataflowMalformed)?;
-
-            // Validate sources have `since.less_equal(as_of)`.
-            for (source_id, _) in dataflow.source_imports.iter() {
-                let (since, _upper) = self
-                    .storage_since_uppers
-                    .get(source_id)
-                    .ok_or(ComputeError::IdentifierMissing(*source_id))?;
-                if !(<_ as timely::order::PartialOrder>::less_equal(&since, &as_of.borrow())) {
-                    Err(ComputeError::DataflowSinceViolation(*source_id))?;
-                }
-            }
-
-            // Validate indexes have `since.less_equal(as_of)`.
-            // TODO(mcsherry): Instead, return an error from the constructing method.
-            for (index_id, _) in dataflow.index_imports.iter() {
-                let (since, _upper) = compute_since_uppers
-                    .get(index_id)
-                    .ok_or(ComputeError::IdentifierMissing(*index_id))?;
-                if !(<_ as timely::order::PartialOrder>::less_equal(&since, &as_of.borrow())) {
-                    Err(ComputeError::DataflowSinceViolation(*index_id))?;
-                }
-            }
-
-            for (sink_id, _) in dataflow.sink_exports.iter() {
-                // We start tracking `upper` at 0; correct this should that change (e.g. to `as_of`).
-                compute_since_uppers.insert(*sink_id, (as_of.clone(), Antichain::from_elem(0)));
-            }
-            for (index_id, _, _) in dataflow.index_exports.iter() {
-                // We start tracking `upper` at 0; correct this should that change (e.g. to `as_of`).
-                compute_since_uppers.insert(*index_id, (as_of.clone(), Antichain::from_elem(0)));
-            }
+impl<C: Client<T>, T> Controller<C, T> {
+    /// Acquires a handle to a controller for the storage instance.
+    #[inline]
+    pub fn storage(&mut self) -> StorageController<C, T> {
+        StorageController {
+            storage: &mut self.storage,
+            client: &mut self.client,
         }
-
-        self.client
-            .send(Command::Compute(
-                ComputeCommand::CreateDataflows(dataflows),
-                instance,
-            ))
-            .await;
-
-        Ok(())
     }
-    pub async fn drop_sinks(
-        &mut self,
-        instance: ComputeInstanceId,
-        sink_identifiers: Vec<GlobalId>,
-    ) {
-        self.client
-            .send(Command::Compute(
-                ComputeCommand::DropSinks(sink_identifiers),
-                instance,
-            ))
-            .await;
-    }
-    pub async fn drop_indexes(
-        &mut self,
-        instance: ComputeInstanceId,
-        index_identifiers: Vec<GlobalId>,
-    ) {
-        self.client
-            .send(Command::Compute(
-                ComputeCommand::DropIndexes(index_identifiers),
-                instance,
-            ))
-            .await;
-    }
-    pub async fn peek(
-        &mut self,
-        instance: ComputeInstanceId,
-        id: GlobalId,
-        key: Option<Row>,
-        conn_id: u32,
-        timestamp: Timestamp,
-        finishing: RowSetFinishing,
-        map_filter_project: mz_expr::SafeMfpPlan,
-    ) -> Result<(), ControllerError> {
-        let (since, _upper) = self
-            .compute_since_uppers
-            .get(&instance)
-            .ok_or(ComputeError::InstanceMissing(instance))?
-            .get(&id)
-            .ok_or(ComputeError::IdentifierMissing(id))?;
-
-        if !since.less_equal(&timestamp) {
-            Err(ComputeError::PeekSinceViolation(id))?;
-        }
-
-        self.client
-            .send(Command::Compute(
-                ComputeCommand::Peek {
-                    id,
-                    key,
-                    conn_id,
-                    timestamp,
-                    finishing,
-                    map_filter_project,
-                },
-                instance,
-            ))
-            .await;
-
-        Ok(())
-    }
-    pub async fn cancel_peek(&mut self, instance: ComputeInstanceId, conn_id: u32) {
-        self.client
-            .send(Command::Compute(
-                ComputeCommand::CancelPeek { conn_id },
-                instance,
-            ))
-            .await;
-    }
-    pub async fn allow_index_compaction(
-        &mut self,
-        instance: ComputeInstanceId,
-        frontiers: Vec<(GlobalId, Antichain<Timestamp>)>,
-    ) -> Result<(), ControllerError> {
-        let compute_since_uppers = self
-            .compute_since_uppers
-            .get_mut(&instance)
-            .ok_or(ComputeError::InstanceMissing(instance))?;
-
-        for (id, frontier) in frontiers.iter() {
-            compute_since_uppers.advance_since_for(*id, frontier);
-        }
-
-        self.client
-            .send(Command::Compute(
-                ComputeCommand::AllowIndexCompaction(frontiers),
-                instance,
-            ))
-            .await;
-
-        Ok(())
+    /// Acquires a handle to a controller for the indicated compute instance, if it exists.
+    #[inline]
+    pub fn compute(&mut self, instance: ComputeInstanceId) -> Option<ComputeController<C, T>> {
+        let compute = self.compute.get_mut(&instance)?;
+        // A compute instance containts `self.storage` so that it can form a `StorageController` if it needs.
+        Some(ComputeController {
+            instance,
+            compute,
+            storage: &mut self.storage,
+            client: &mut self.client,
+        })
     }
 }
 
-// Implementation of STORAGE commands.
-impl<C: Client> Controller<C> {
-    pub async fn create_sources(
-        &mut self,
-        mut bindings: Vec<(GlobalId, (crate::sources::SourceDesc, Antichain<Timestamp>))>,
-    ) -> Result<(), ControllerError> {
-        // Validate first, to avoid corrupting state.
-        // 1. create a dropped source identifier, or
-        // 2. create an existing source identifier with a new description.
-        // Make sure to check for errors within `bindings` as well.
-        bindings.sort_by_key(|b| b.0);
-        bindings.dedup();
-        for pos in 1..bindings.len() {
-            if bindings[pos - 1].0 == bindings[pos].0 {
-                Err(StorageError::SourceIdReused(bindings[pos].0))?;
-            }
-        }
-        for (id, description_since) in bindings.iter() {
-            match self.source_descriptions.get(&id) {
-                Some(None) => Err(StorageError::SourceIdReused(*id))?,
-                Some(Some(prior_description)) => {
-                    if prior_description != description_since {
-                        Err(StorageError::SourceIdReused(*id))?
-                    }
-                }
-                None => {
-                    // All is well; no reason to panic.
-                }
-            }
-        }
-
-        for (id, (description, since)) in bindings.iter() {
-            self.source_descriptions
-                .insert(*id, Some((description.clone(), since.clone())));
-            // We start tracking `upper` at 0; correct this should that change (e.g. to `as_of`).
-            self.storage_since_uppers
-                .insert(*id, (since.clone(), Antichain::from_elem(0)));
-        }
-
-        self.client
-            .send(Command::Storage(StorageCommand::CreateSources(bindings)))
-            .await;
-
-        Ok(())
-    }
-    pub async fn drop_sources(&mut self, identifiers: Vec<GlobalId>) {
-        for id in identifiers.iter() {
-            if !self.source_descriptions.contains_key(id) {
-                // This isn't an unrecoverable error, just .. probably wrong.
-                error!("Source id {} dropped without first being created", id);
-            } else {
-                self.source_descriptions.insert(*id, None);
-            }
-        }
-
-        self.client
-            .send(Command::Storage(StorageCommand::DropSources(identifiers)))
-            .await
-    }
-    pub async fn table_insert(&mut self, id: GlobalId, updates: Vec<Update>) {
-        self.client
-            .send(Command::Storage(StorageCommand::Insert { id, updates }))
-            .await
-    }
-    pub async fn update_durability_frontiers(
-        &mut self,
-        updates: Vec<(GlobalId, Antichain<Timestamp>)>,
-    ) {
-        self.client
-            .send(Command::Storage(StorageCommand::DurabilityFrontierUpdates(
-                updates,
-            )))
-            .await
-    }
-    pub async fn add_source_timestamping(
-        &mut self,
-        id: GlobalId,
-        connector: SourceConnector,
-        bindings: Vec<(PartitionId, Timestamp, crate::sources::MzOffset)>,
-    ) {
-        self.client
-            .send(Command::Storage(StorageCommand::AddSourceTimestamping {
-                id,
-                connector,
-                bindings,
-            }))
-            .await
-    }
-    pub async fn allow_source_compaction(
-        &mut self,
-        frontiers: Vec<(GlobalId, Antichain<Timestamp>)>,
-    ) {
-        for (id, frontier) in frontiers.iter() {
-            self.storage_since_uppers.advance_since_for(*id, frontier);
-        }
-
-        self.client
-            .send(Command::Storage(StorageCommand::AllowSourceCompaction(
-                frontiers,
-            )))
-            .await
-    }
-    pub async fn drop_source_timestamping(&mut self, id: GlobalId) {
-        self.client
-            .send(Command::Storage(StorageCommand::DropSourceTimestamping {
-                id,
-            }))
-            .await
-    }
-    pub async fn advance_all_table_timestamps(&mut self, advance_to: Timestamp) {
-        self.client
-            .send(Command::Storage(StorageCommand::AdvanceAllLocalInputs {
-                advance_to,
-            }))
-            .await
-    }
-}
-
-impl<C: Client> Controller<C> {
-    pub async fn recv(&mut self) -> Option<Response> {
+impl<C: Client<T>, T: Timestamp + Lattice> Controller<C, T> {
+    pub async fn recv(&mut self) -> Option<Response<T>> {
         let response = self.client.recv().await;
-
         if let Some(response) = response.as_ref() {
             match response {
                 Response::Compute(ComputeResponse::FrontierUppers(updates), instance) => {
                     for (id, changes) in updates.iter() {
-                        self.compute_since_uppers
-                            .get_mut(instance)
+                        self.compute(*instance)
                             // TODO: determine if this is an error, or perhaps just a late
                             // response about a terminated instance.
                             .expect("Reference to absent instance")
+                            .compute
+                            .since_uppers
                             .update_upper_for(*id, changes);
                     }
                 }
                 _ => {}
             }
         }
-
         response
     }
 }
@@ -420,83 +111,8 @@ impl<C> Controller<C> {
     pub fn new(client: C) -> Self {
         Self {
             client,
-            source_descriptions: Default::default(),
-            compute_since_uppers: Default::default(),
-            storage_since_uppers: Default::default(),
-        }
-    }
-    /// Returns the source description for a given identifier.
-    ///
-    /// The response does not distinguish between an as yet uncreated source description,
-    /// and one that has been created and then dropped (or dropped without creation).
-    /// There is a distinction and the client is aware of it, and could plausibly return
-    /// this information if we had a use for it.
-    pub fn source_description_for(
-        &self,
-        id: GlobalId,
-    ) -> Option<&(crate::sources::SourceDesc, Antichain<mz_repr::Timestamp>)> {
-        self.source_descriptions.get(&id).unwrap_or(&None).as_ref()
-    }
-
-    /// Returns the pair of `since` and `upper` for a source, if it exists.
-    ///
-    /// The `since` frontier indicates that the maintained data are certainly valid for times greater
-    /// or equal to the frontier, but they may not be for other times. Attempting to create a dataflow
-    /// using this `id` with an `as_of` that is not at least `since` will result in an error.
-    ///
-    /// The `upper` frontier indicates that the data are reported available for all times not greater
-    /// or equal to the frontier. Dataflows with an `as_of` greater or equal to this frontier may not
-    /// immediately produce results.
-    pub fn source_since_upper_for(
-        &self,
-        id: GlobalId,
-    ) -> Option<(AntichainRef<Timestamp>, AntichainRef<Timestamp>)> {
-        self.storage_since_uppers.get(&id)
-    }
-}
-
-#[derive(Default)]
-struct SinceUpperMap {
-    since_uppers:
-        std::collections::BTreeMap<GlobalId, (Antichain<Timestamp>, Antichain<Timestamp>)>,
-}
-
-impl SinceUpperMap {
-    fn insert(&mut self, id: GlobalId, since_upper: (Antichain<Timestamp>, Antichain<Timestamp>)) {
-        self.since_uppers.insert(id, since_upper);
-    }
-    fn get(&self, id: &GlobalId) -> Option<(AntichainRef<Timestamp>, AntichainRef<Timestamp>)> {
-        self.since_uppers
-            .get(id)
-            .map(|(since, upper)| (since.borrow(), upper.borrow()))
-    }
-    fn advance_since_for(&mut self, id: GlobalId, frontier: &Antichain<Timestamp>) {
-        if let Some((since, _upper)) = self.since_uppers.get_mut(&id) {
-            use differential_dataflow::lattice::Lattice;
-            since.join_assign(frontier);
-        } else {
-            // If we allow compaction before the item is created, pre-restrict the valid range.
-            // We start tracking `upper` at 0; correct this should that change (e.g. to `as_of`).
-            self.since_uppers
-                .insert(id, (frontier.clone(), Antichain::from_elem(0)));
-        }
-    }
-    fn update_upper_for(&mut self, id: GlobalId, changes: &ChangeBatch<Timestamp>) {
-        if let Some((_since, upper)) = self.since_uppers.get_mut(&id) {
-            // Apply `changes` to `upper`.
-            let mut changes = changes.clone();
-            for time in upper.elements().iter() {
-                changes.update(time.clone(), 1);
-            }
-            upper.clear();
-            for (time, count) in changes.drain() {
-                assert_eq!(count, 1);
-                upper.insert(time);
-            }
-        } else {
-            // No panic, as we could have recently dropped this.
-            // If we can tell these are updates to an id that could still be constructed,
-            // something is weird and we should error.
+            storage: StorageControllerState::new(),
+            compute: BTreeMap::default(),
         }
     }
 }

--- a/src/dataflow-types/src/client/controller/compute.rs
+++ b/src/dataflow-types/src/client/controller/compute.rs
@@ -1,0 +1,205 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use differential_dataflow::lattice::Lattice;
+use timely::progress::{Antichain, Timestamp};
+
+use super::SinceUpperMap;
+use crate::client::{Client, Command, ComputeCommand, ComputeInstanceId};
+use crate::logging::LoggingConfig;
+use crate::DataflowDescription;
+use mz_expr::GlobalId;
+use mz_expr::RowSetFinishing;
+use mz_repr::Row;
+
+/// Controller state maintained for each compute instance.
+pub(super) struct ComputeControllerState<T> {
+    /// Tracks expressed `since` and received `upper` frontiers for indexes and sinks.
+    pub(super) since_uppers: SinceUpperMap<T>,
+}
+
+/// A controller for a compute instance.
+pub struct ComputeController<'a, C, T> {
+    pub(super) instance: ComputeInstanceId,
+    pub(super) compute: &'a mut ComputeControllerState<T>,
+    pub(super) storage: &'a mut super::StorageControllerState<T>,
+    pub(super) client: &'a mut C,
+}
+
+/// Errors arising from compute commands.
+#[derive(Debug)]
+pub enum ComputeError {
+    /// Command referenced an instance that was not present.
+    InstanceMissing(ComputeInstanceId),
+    /// Command referenced an identifier that was not present.
+    IdentifierMissing(GlobalId),
+    /// Dataflow was malformed (e.g. missing `as_of`).
+    DataflowMalformed,
+    /// The dataflow `as_of` was not greater than the `since` of the identifier.
+    DataflowSinceViolation(GlobalId),
+    /// The peek `timestamp` was not greater than the `since` of the identifier.
+    PeekSinceViolation(GlobalId),
+}
+
+impl<T: Timestamp + Lattice> ComputeControllerState<T> {
+    pub(super) fn new(logging: &Option<LoggingConfig>) -> Self {
+        let mut since_uppers = SinceUpperMap::default();
+        if let Some(logging_config) = logging.as_ref() {
+            for id in logging_config.log_identifiers() {
+                since_uppers.insert(
+                    id,
+                    (
+                        Antichain::from_elem(T::minimum()),
+                        Antichain::from_elem(T::minimum()),
+                    ),
+                );
+            }
+        }
+        Self { since_uppers }
+    }
+}
+
+impl<'a, C: Client<T>, T: Timestamp + Lattice> ComputeController<'a, C, T> {
+    pub async fn create_dataflows(
+        &mut self,
+        dataflows: Vec<DataflowDescription<crate::plan::Plan, T>>,
+    ) -> Result<(), ComputeError> {
+        // Validate dataflows as having inputs whose `since` is less or equal to the dataflow's `as_of`.
+        // Start tracking frontiers for each dataflow, using its `as_of` for each index and sink.
+        for dataflow in dataflows.iter() {
+            let as_of = dataflow
+                .as_of
+                .as_ref()
+                .ok_or(ComputeError::DataflowMalformed)?;
+
+            // Validate sources have `since.less_equal(as_of)`.
+            for (source_id, _) in dataflow.source_imports.iter() {
+                let (since, _upper) = self
+                    .storage
+                    .since_uppers
+                    .get(source_id)
+                    .ok_or(ComputeError::IdentifierMissing(*source_id))?;
+                if !(<_ as timely::order::PartialOrder>::less_equal(&since, &as_of.borrow())) {
+                    Err(ComputeError::DataflowSinceViolation(*source_id))?;
+                }
+            }
+
+            // Validate indexes have `since.less_equal(as_of)`.
+            // TODO(mcsherry): Instead, return an error from the constructing method.
+            for (index_id, _) in dataflow.index_imports.iter() {
+                let (since, _upper) = self
+                    .compute
+                    .since_uppers
+                    .get(index_id)
+                    .ok_or(ComputeError::IdentifierMissing(*index_id))?;
+                if !(<_ as timely::order::PartialOrder>::less_equal(&since, &as_of.borrow())) {
+                    Err(ComputeError::DataflowSinceViolation(*index_id))?;
+                }
+            }
+
+            for (sink_id, _) in dataflow.sink_exports.iter() {
+                self.compute.since_uppers.insert(
+                    *sink_id,
+                    (as_of.clone(), Antichain::from_elem(Timestamp::minimum())),
+                );
+            }
+            for (index_id, _, _) in dataflow.index_exports.iter() {
+                self.compute.since_uppers.insert(
+                    *index_id,
+                    (as_of.clone(), Antichain::from_elem(Timestamp::minimum())),
+                );
+            }
+        }
+
+        self.client
+            .send(Command::Compute(
+                ComputeCommand::CreateDataflows(dataflows),
+                self.instance,
+            ))
+            .await;
+
+        Ok(())
+    }
+    pub async fn drop_sinks(&mut self, sink_identifiers: Vec<GlobalId>) {
+        self.client
+            .send(Command::Compute(
+                ComputeCommand::DropSinks(sink_identifiers),
+                self.instance,
+            ))
+            .await;
+    }
+    pub async fn drop_indexes(&mut self, index_identifiers: Vec<GlobalId>) {
+        self.client
+            .send(Command::Compute(
+                ComputeCommand::DropIndexes(index_identifiers),
+                self.instance,
+            ))
+            .await;
+    }
+    pub async fn peek(
+        &mut self,
+        id: GlobalId,
+        key: Option<Row>,
+        conn_id: u32,
+        timestamp: T,
+        finishing: RowSetFinishing,
+        map_filter_project: mz_expr::SafeMfpPlan,
+    ) -> Result<(), ComputeError> {
+        let (since, _upper) = self
+            .compute
+            .since_uppers
+            .get(&id)
+            .ok_or(ComputeError::IdentifierMissing(id))?;
+
+        if !since.less_equal(&timestamp) {
+            Err(ComputeError::PeekSinceViolation(id))?;
+        }
+
+        self.client
+            .send(Command::Compute(
+                ComputeCommand::Peek {
+                    id,
+                    key,
+                    conn_id,
+                    timestamp,
+                    finishing,
+                    map_filter_project,
+                },
+                self.instance,
+            ))
+            .await;
+
+        Ok(())
+    }
+    pub async fn cancel_peek(&mut self, conn_id: u32) {
+        self.client
+            .send(Command::Compute(
+                ComputeCommand::CancelPeek { conn_id },
+                self.instance,
+            ))
+            .await;
+    }
+    pub async fn allow_index_compaction(
+        &mut self,
+        frontiers: Vec<(GlobalId, Antichain<T>)>,
+    ) -> Result<(), ComputeError> {
+        for (id, frontier) in frontiers.iter() {
+            self.compute.since_uppers.advance_since_for(*id, frontier);
+        }
+
+        self.client
+            .send(Command::Compute(
+                ComputeCommand::AllowIndexCompaction(frontiers),
+                self.instance,
+            ))
+            .await;
+
+        Ok(())
+    }
+}

--- a/src/dataflow-types/src/client/controller/since_upper.rs
+++ b/src/dataflow-types/src/client/controller/since_upper.rs
@@ -1,0 +1,68 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::BTreeMap;
+
+use differential_dataflow::lattice::Lattice;
+use timely::progress::{frontier::AntichainRef, Antichain, ChangeBatch, Timestamp};
+
+use mz_expr::GlobalId;
+
+pub struct SinceUpperMap<T> {
+    since_uppers: BTreeMap<GlobalId, (Antichain<T>, Antichain<T>)>,
+}
+
+impl<T> Default for SinceUpperMap<T> {
+    fn default() -> Self {
+        Self {
+            since_uppers: Default::default(),
+        }
+    }
+}
+
+impl<T> SinceUpperMap<T>
+where
+    T: Timestamp + Lattice,
+{
+    pub fn insert(&mut self, id: GlobalId, since_upper: (Antichain<T>, Antichain<T>)) {
+        self.since_uppers.insert(id, since_upper);
+    }
+    pub fn get(&self, id: &GlobalId) -> Option<(AntichainRef<T>, AntichainRef<T>)> {
+        self.since_uppers
+            .get(id)
+            .map(|(since, upper)| (since.borrow(), upper.borrow()))
+    }
+    pub fn advance_since_for(&mut self, id: GlobalId, frontier: &Antichain<T>) {
+        if let Some((since, _upper)) = self.since_uppers.get_mut(&id) {
+            since.join_assign(frontier);
+        } else {
+            // If we allow compaction before the item is created, pre-restrict the valid range.
+            self.since_uppers
+                .insert(id, (frontier.clone(), Antichain::from_elem(T::minimum())));
+        }
+    }
+    pub fn update_upper_for(&mut self, id: GlobalId, changes: &ChangeBatch<T>) {
+        if let Some((_since, upper)) = self.since_uppers.get_mut(&id) {
+            // Apply `changes` to `upper`.
+            let mut changes = changes.clone();
+            for time in upper.elements().iter() {
+                changes.update(time.clone(), 1);
+            }
+            upper.clear();
+            for (time, count) in changes.drain() {
+                assert_eq!(count, 1);
+                upper.insert(time);
+            }
+        } else {
+            // No panic, as we could have recently dropped this.
+            // If we can tell these are updates to an id that could still be constructed,
+            // something is weird and we should error.
+        }
+    }
+}

--- a/src/dataflow-types/src/client/controller/storage.rs
+++ b/src/dataflow-types/src/client/controller/storage.rs
@@ -1,0 +1,166 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::BTreeMap;
+
+use differential_dataflow::lattice::Lattice;
+use timely::progress::{Antichain, Timestamp};
+use tracing::error;
+
+use super::SinceUpperMap;
+use crate::client::SourceConnector;
+use crate::client::{Client, Command, StorageCommand};
+use crate::Update;
+use mz_expr::GlobalId;
+use mz_expr::PartitionId;
+
+/// Controller state maintained for each storage instance.
+pub struct StorageControllerState<T> {
+    /// Sources that have been created.
+    ///
+    /// A `None` variant means that the source was dropped before it was first created.
+    source_descriptions: BTreeMap<GlobalId, Option<(crate::sources::SourceDesc, Antichain<T>)>>,
+    /// Tracks expressed `since` and received `upper` frontiers for sources and tables.
+    pub(super) since_uppers: SinceUpperMap<T>,
+}
+
+/// A controller for a storage instance.
+pub struct StorageController<'a, C, T> {
+    pub(super) storage: &'a mut StorageControllerState<T>,
+    pub(super) client: &'a mut C,
+}
+
+#[derive(Debug)]
+pub enum StorageError {
+    /// The source identifier was re-created after having been dropped,
+    /// or installed with a different description.
+    SourceIdReused(GlobalId),
+}
+
+impl<T> StorageControllerState<T> {
+    pub(super) fn new() -> Self {
+        Self {
+            source_descriptions: BTreeMap::default(),
+            since_uppers: SinceUpperMap::default(),
+        }
+    }
+}
+
+impl<'a, C: Client<T>, T: Timestamp + Lattice> StorageController<'a, C, T> {
+    pub async fn create_sources(
+        &mut self,
+        mut bindings: Vec<(GlobalId, (crate::sources::SourceDesc, Antichain<T>))>,
+    ) -> Result<(), StorageError> {
+        // Validate first, to avoid corrupting state.
+        // 1. create a dropped source identifier, or
+        // 2. create an existing source identifier with a new description.
+        // Make sure to check for errors within `bindings` as well.
+        bindings.sort_by_key(|b| b.0);
+        bindings.dedup();
+        for pos in 1..bindings.len() {
+            if bindings[pos - 1].0 == bindings[pos].0 {
+                Err(StorageError::SourceIdReused(bindings[pos].0))?;
+            }
+        }
+        for (id, description_since) in bindings.iter() {
+            match self.storage.source_descriptions.get(&id) {
+                Some(None) => Err(StorageError::SourceIdReused(*id))?,
+                Some(Some(prior_description)) => {
+                    if prior_description != description_since {
+                        Err(StorageError::SourceIdReused(*id))?
+                    }
+                }
+                None => {
+                    // All is well; no reason to panic.
+                }
+            }
+        }
+
+        for (id, (description, since)) in bindings.iter() {
+            self.storage
+                .source_descriptions
+                .insert(*id, Some((description.clone(), since.clone())));
+            self.storage.since_uppers.insert(
+                *id,
+                (since.clone(), Antichain::from_elem(Timestamp::minimum())),
+            );
+        }
+
+        self.client
+            .send(Command::Storage(StorageCommand::CreateSources(bindings)))
+            .await;
+
+        Ok(())
+    }
+    pub async fn drop_sources(&mut self, identifiers: Vec<GlobalId>) {
+        for id in identifiers.iter() {
+            if !self.storage.source_descriptions.contains_key(id) {
+                // This isn't an unrecoverable error, just .. probably wrong.
+                error!("Source id {} dropped without first being created", id);
+            } else {
+                self.storage.source_descriptions.insert(*id, None);
+            }
+        }
+
+        self.client
+            .send(Command::Storage(StorageCommand::DropSources(identifiers)))
+            .await
+    }
+    pub async fn table_insert(&mut self, id: GlobalId, updates: Vec<Update<T>>) {
+        self.client
+            .send(Command::Storage(StorageCommand::Insert { id, updates }))
+            .await
+    }
+    pub async fn update_durability_frontiers(&mut self, updates: Vec<(GlobalId, Antichain<T>)>) {
+        self.client
+            .send(Command::Storage(StorageCommand::DurabilityFrontierUpdates(
+                updates,
+            )))
+            .await
+    }
+    pub async fn add_source_timestamping(
+        &mut self,
+        id: GlobalId,
+        connector: SourceConnector,
+        bindings: Vec<(PartitionId, T, crate::sources::MzOffset)>,
+    ) {
+        self.client
+            .send(Command::Storage(StorageCommand::AddSourceTimestamping {
+                id,
+                connector,
+                bindings,
+            }))
+            .await
+    }
+    pub async fn allow_source_compaction(&mut self, frontiers: Vec<(GlobalId, Antichain<T>)>) {
+        for (id, frontier) in frontiers.iter() {
+            self.storage.since_uppers.advance_since_for(*id, frontier);
+        }
+
+        self.client
+            .send(Command::Storage(StorageCommand::AllowSourceCompaction(
+                frontiers,
+            )))
+            .await
+    }
+    pub async fn drop_source_timestamping(&mut self, id: GlobalId) {
+        self.client
+            .send(Command::Storage(StorageCommand::DropSourceTimestamping {
+                id,
+            }))
+            .await
+    }
+    pub async fn advance_all_table_timestamps(&mut self, advance_to: T) {
+        self.client
+            .send(Command::Storage(StorageCommand::AdvanceAllLocalInputs {
+                advance_to,
+            }))
+            .await
+    }
+}


### PR DESCRIPTION
This PR breaks the state of `Controller` into `Compute` and `Storage` components, and implements methods on these respective components (each augmented with a `&mut Client` handle, and in the case of compute stuff a handle to storage).

### Motivation

The monolithic `Controller` was leaking bits of abstraction around, which made it hard to stitch up other abstractions around permitting and holding back compaction (probably other abstractions too, once they arrive). I think this is a fair bit clearer, and presents to `coord.rs` more clearly as well (as storage and compute facets, with appropriately typed errors surfaced earlier in some cases).

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
