### PR TITLE
Make commands and responses generic in `Timestamp`

### DIFF
--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -48,23 +48,23 @@ impl PeekResponse {
 
 /// Various responses that can be communicated about the progress of a TAIL command.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub enum TailResponse {
+pub enum TailResponse<T = mz_repr::Timestamp> {
     /// Progress information. Subsequent messages from this worker will only contain timestamps
     /// greater or equal to an element of this frontier.
     ///
     /// An empty antichain indicates the end.
-    Progress(Antichain<Timestamp>),
+    Progress(Antichain<T>),
     /// Rows that should be returned in order to the client.
-    Rows(Vec<(Timestamp, Row, Diff)>),
+    Rows(Vec<(T, Row, Diff)>),
     /// The TAIL dataflow was dropped before completing. Indicates the end.
     Dropped,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 /// A batch of updates to be fed to a local input
-pub struct Update {
+pub struct Update<T = mz_repr::Timestamp> {
     pub row: Row,
-    pub timestamp: u64,
+    pub timestamp: T,
     pub diff: Diff,
 }
 
@@ -106,7 +106,7 @@ pub struct SourceInstanceKey {
 
 /// A description of a dataflow to construct and results to surface.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
-pub struct DataflowDescription<View> {
+pub struct DataflowDescription<View, T = mz_repr::Timestamp> {
     /// Sources instantiations made available to the dataflow.
     pub source_imports: BTreeMap<GlobalId, SourceInstanceDesc>,
     /// Indexes made available to the dataflow.
@@ -128,7 +128,7 @@ pub struct DataflowDescription<View> {
     /// If this is set, it should override the default setting determined by
     /// the upper bound of `since` frontiers contributing to the dataflow.
     /// It is an error for this to be set to a frontier not beyond that default.
-    pub as_of: Option<Antichain<Timestamp>>,
+    pub as_of: Option<Antichain<T>>,
     /// Human readable name
     pub debug_name: String,
 }


### PR DESCRIPTION
This PR is a start on making us communicate more clearly about timestamp types, rather than using a typedef throughout the code. It generalizes `dataflow::{Command, Response}` and a few types that they use. Each generalization has a default type parameter of `mz_repr::Timestamp` so others shouldn't notice friction.

Next steps would be to make `Controller` similarly generic, and `Worker` and things below it. I tried the latter and became foiled by our metrics macros not working against enums with generic arguments. At least, that was as close as I got.

@mjibson this is the sort of approach I was thinking of when I blathered in https://github.com/MaterializeInc/materialize/pull/10771

### Motivation

MZ currently uses the "convention" that our timestamps are `mz_repr::Timestamp` though this is not enforced, and we have various places in the code where we rely on this too heavily (e.g. by using `0` and `+1` and stuff like that). The more of this we can remove, the more components have a clearer contract enforced by the compiler.

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
