### PR TITLE
repr: switch Diff type from isize -> i64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3531,6 +3531,7 @@ dependencies = [
  "mz-build-info",
  "mz-ore",
  "mz-persist-types",
+ "mz-repr",
  "parquet2",
  "prost",
  "prost-build",

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -3731,7 +3731,7 @@ impl Coordinator {
         }
 
         let affected_rows = {
-            let mut affected_rows = 0isize;
+            let mut affected_rows = Diff::from(0);
             let mut all_positive_diffs = true;
             // If all diffs are positive, the number of affected rows is just the
             // sum of all unconsolidated diffs.

--- a/src/coord/src/tail.rs
+++ b/src/coord/src/tail.rs
@@ -10,7 +10,6 @@
 //! Implementations around supporting the TAIL protocol with the dataflow layer
 
 use mz_dataflow_types::TailResponse;
-use mz_ore::cast::CastFrom;
 use mz_repr::adt::numeric;
 use mz_repr::{Datum, Row};
 use tokio::sync::mpsc;
@@ -92,7 +91,7 @@ impl PendingTail {
                             packer.push(Datum::False);
                         }
 
-                        packer.push(Datum::Int64(i64::cast_from(diff)));
+                        packer.push(Datum::Int64(diff));
 
                         packer.extend_by_row(&row);
 

--- a/src/dataflow/src/logging/reachability.rs
+++ b/src/dataflow/src/logging/reachability.rs
@@ -26,7 +26,7 @@ use crate::logging::ConsolidateBuffer;
 use crate::replay::MzReplay;
 use mz_dataflow_types::logging::LoggingConfig;
 use mz_ore::iter::IteratorExt;
-use mz_repr::{Datum, Row, RowArena, Timestamp};
+use mz_repr::{Datum, Diff, Row, RowArena, Timestamp};
 
 /// Constructs the logging dataflow for reachability logs.
 ///
@@ -49,7 +49,7 @@ pub fn construct<A: Allocate>(
                 WorkerIdentifier,
                 (
                     Vec<usize>,
-                    Vec<(usize, usize, bool, Option<Timestamp>, isize)>,
+                    Vec<(usize, usize, bool, Option<Timestamp>, Diff)>,
                 ),
             ),
         >,

--- a/src/dataflow/src/render/envelope_none.rs
+++ b/src/dataflow/src/render/envelope_none.rs
@@ -109,8 +109,8 @@ where
 // TODO: Maybe we should finally move this to some central place and re-use. There seem to be
 // enough instances of this by now.
 fn split_ok_err<K, V>(
-    x: (Result<(K, V), String>, u64, isize),
-) -> Result<((K, V), u64, isize), (String, u64, isize)> {
+    x: (Result<(K, V), String>, u64, Diff),
+) -> Result<((K, V), u64, Diff), (String, u64, Diff)> {
     match x {
         (Ok(kv), ts, diff) => Ok((kv, ts, diff)),
         (Err(err), ts, diff) => Err((err, ts, diff)),

--- a/src/dataflow/src/render/join/delta_join.rs
+++ b/src/dataflow/src/render/join/delta_join.rs
@@ -308,15 +308,15 @@ use differential_dataflow::Collection;
 /// the time of the update. This is crucial for correctness, as the total order on times of updates is used
 /// to ensure that any two updates are matched at most once.
 fn build_halfjoin<G, Tr, CF>(
-    updates: Collection<G, (Row, G::Timestamp)>,
+    updates: Collection<G, (Row, G::Timestamp), Diff>,
     trace: Arranged<G, Tr>,
     prev_key: Vec<MirScalarExpr>,
     prev_thinning: Vec<usize>,
     comparison: CF,
     closure: JoinClosure,
 ) -> (
-    Collection<G, (Row, G::Timestamp)>,
-    Collection<G, DataflowError>,
+    Collection<G, (Row, G::Timestamp), Diff>,
+    Collection<G, DataflowError, Diff>,
 )
 where
     G: Scope<Timestamp = mz_repr::Timestamp>,
@@ -395,7 +395,7 @@ fn build_update_stream<G, Tr>(
     as_of: Antichain<G::Timestamp>,
     source_relation: usize,
     initial_closure: JoinClosure,
-) -> (Collection<G, Row>, Collection<G, DataflowError>)
+) -> (Collection<G, Row, Diff>, Collection<G, DataflowError, Diff>)
 where
     G: Scope<Timestamp = mz_repr::Timestamp>,
     Tr: TraceReader<Time = G::Timestamp, Key = Row, Val = Row, R = Diff> + Clone + 'static,

--- a/src/dataflow/src/render/join/linear_join.rs
+++ b/src/dataflow/src/render/join/linear_join.rs
@@ -177,8 +177,8 @@ where
             closure,
             lookup_relation: _,
         }: LinearStagePlan,
-        errors: &mut Vec<Collection<G, DataflowError>>,
-    ) -> Collection<G, Row> {
+        errors: &mut Vec<Collection<G, DataflowError, Diff>>,
+    ) -> Collection<G, Row, Diff> {
         // If we have only a streamed collection, we must first form an arrangement.
         if let JoinedFlavor::Collection(stream) = joined {
             let mut row_packer = Row::default();
@@ -253,7 +253,7 @@ where
         prev_keyed: J,
         next_input: Arranged<G, Tr2>,
         closure: JoinClosure,
-    ) -> (Collection<G, Row>, Collection<G, DataflowError>)
+    ) -> (Collection<G, Row, Diff>, Collection<G, DataflowError, Diff>)
     where
         J: JoinCore<G, Row, Row, mz_repr::Diff>,
         Tr2: TraceReader<Key = Row, Val = Row, Time = G::Timestamp, R = mz_repr::Diff>

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -68,7 +68,7 @@ pub(crate) fn import_table<G>(
     persisted_name: Option<String>,
 ) -> (
     LocalInput,
-    (Collection<G, Row>, Collection<G, DataflowError>),
+    (Collection<G, Row, Diff>, Collection<G, DataflowError, Diff>),
 )
 where
     G: Scope<Timestamp = Timestamp>,
@@ -144,7 +144,7 @@ pub(crate) fn import_source<G>(
     materialized_logging: Option<Logger>,
     src_id: GlobalId,
 ) -> (
-    (Collection<G, Row>, Collection<G, DataflowError>),
+    (Collection<G, Row, Diff>, Collection<G, DataflowError, Diff>),
     Rc<dyn std::any::Any>,
 )
 where
@@ -197,7 +197,7 @@ where
 
             // All sources should push their various error streams into this vector,
             // whose contents will be concatenated and inserted along the collection.
-            let mut error_collections = Vec::<Collection<_, _>>::new();
+            let mut error_collections = Vec::<Collection<_, _, Diff>>::new();
 
             let source_persist_config = match (persist, storage_state.persist.as_mut()) {
                 (Some(persist_desc), Some(persist)) => {
@@ -541,8 +541,8 @@ where
                                 // place and re-use. There seem to be enough instances of this
                                 // by now.
                                 fn split_ok_err(
-                                    x: (Result<Row, DecodeError>, u64, isize),
-                                ) -> Result<(Row, u64, isize), (DataflowError, u64, isize)>
+                                    x: (Result<Row, DecodeError>, u64, Diff),
+                                ) -> Result<(Row, u64, Diff), (DataflowError, u64, Diff)>
                                 {
                                     match x {
                                         (Ok(row), ts, diff) => Ok((row, ts, diff)),

--- a/src/dataflow/src/render/upsert.rs
+++ b/src/dataflow/src/render/upsert.rs
@@ -298,7 +298,7 @@ fn upsert_core<G>(
     as_of_frontier: Antichain<Timestamp>,
     source_arity: usize,
     upsert_envelope: UpsertEnvelope,
-) -> Stream<G, (Result<Row, DataflowError>, u64, isize)>
+) -> Stream<G, (Result<Row, DataflowError>, u64, Diff)>
 where
     G: Scope<Timestamp = Timestamp>,
 {

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -424,7 +424,7 @@ impl PendingPeek {
                     // the DD representation uses a binary count and may not exhaust our
                     // memory in situtations where this copying might.
                     if let Some(limit) = max_results {
-                        let limit = std::convert::TryInto::<isize>::try_into(limit);
+                        let limit = std::convert::TryInto::<Diff>::try_into(limit);
                         if let Ok(limit) = limit {
                             copies = std::cmp::min(copies, limit);
                         }

--- a/src/dataflow/src/server/compute_state.rs
+++ b/src/dataflow/src/server/compute_state.rs
@@ -25,7 +25,7 @@ use mz_dataflow_types::client::{ComputeCommand, ComputeResponse, Response};
 use mz_dataflow_types::logging::LoggingConfig;
 use mz_dataflow_types::{DataflowError, PeekResponse, TailResponse};
 use mz_expr::GlobalId;
-use mz_repr::Timestamp;
+use mz_repr::{Diff, Timestamp};
 
 use crate::activator::RcActivator;
 use crate::arrangement::manager::{TraceBundle, TraceManager};
@@ -313,7 +313,7 @@ impl<'a, A: Allocate, B: ComputeReplay> ActiveComputeState<'a, A, B> {
                                     .iter()
                                     .map(|u| {
                                         let ts = u.2.as_any().downcast_ref::<Timestamp>().copied();
-                                        (*u.0, *u.1, true, ts, *u.3 as isize)
+                                        (*u.0, *u.1, true, ts, *u.3)
                                     })
                                     .collect();
 
@@ -329,7 +329,7 @@ impl<'a, A: Allocate, B: ComputeReplay> ActiveComputeState<'a, A, B> {
                                     .iter()
                                     .map(|u| {
                                         let ts = u.2.as_any().downcast_ref::<Timestamp>().copied();
-                                        (*u.0, *u.1, true, ts, *u.3 as isize)
+                                        (*u.0, *u.1, true, ts, *u.3)
                                     })
                                     .collect();
 
@@ -378,7 +378,7 @@ impl<'a, A: Allocate, B: ComputeReplay> ActiveComputeState<'a, A, B> {
         let errs = self
             .timely_worker
             .dataflow_named("Dataflow: logging", |scope| {
-                Collection::<_, DataflowError, isize>::empty(scope)
+                Collection::<_, DataflowError, Diff>::empty(scope)
                     .arrange()
                     .trace
             });

--- a/src/dataflow/src/sink/avro_ocf.rs
+++ b/src/dataflow/src/sink/avro_ocf.rs
@@ -65,7 +65,7 @@ where
 }
 
 fn avro_ocf<G>(
-    collection: Collection<G, (Option<Row>, Option<Row>)>,
+    collection: Collection<G, (Option<Row>, Option<Row>), Diff>,
     id: GlobalId,
     connector: AvroOcfSinkConnector,
     desc: RelationDesc,

--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -943,7 +943,7 @@ struct EncodedRow {
 
 // TODO@jldlaughlin: What guarantees does this sink support? #1728
 fn kafka<G>(
-    collection: Collection<G, (Option<Row>, Option<Row>)>,
+    collection: Collection<G, (Option<Row>, Option<Row>), Diff>,
     id: GlobalId,
     connector: KafkaSinkConnector,
     key_desc: Option<RelationDesc>,

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -1349,9 +1349,9 @@ impl SourceReaderPersistence {
         mz_persist::error::Error,
     > {
         // Materialized version of bindings updates that are not beyond the common seal timestamp.
-        let mut valid_bindings: HashMap<_, isize> = HashMap::new();
+        let mut valid_bindings: HashMap<_, Diff> = HashMap::new();
 
-        let mut retractions: HashMap<_, isize> = HashMap::new();
+        let mut retractions: HashMap<_, Diff> = HashMap::new();
 
         let snapshot = self.config.read_handle.snapshot()?;
         let buf = snapshot.into_iter().collect::<Result<Vec<_>, _>>()?;
@@ -1503,8 +1503,8 @@ fn maybe_emit_timestamp_bindings(
     bindings_cap: &Capability<u64>,
     bindings_output: &mut OutputHandle<
         u64,
-        ((SourceTimestamp, AssignedTimestamp), u64, isize),
-        Tee<u64, ((SourceTimestamp, AssignedTimestamp), u64, isize)>,
+        ((SourceTimestamp, AssignedTimestamp), u64, Diff),
+        Tee<u64, ((SourceTimestamp, AssignedTimestamp), u64, Diff)>,
     >,
 ) {
     let timestamp_bindings_updater = match timestamp_bindings_updater.as_mut() {
@@ -1519,7 +1519,7 @@ fn maybe_emit_timestamp_bindings(
     // Emit required changes downstream.
     let to_emit = changes
         .into_iter()
-        .map(|(binding, diff)| (binding, bindings_cap.time().clone(), isize::cast_from(diff)));
+        .map(|(binding, diff)| (binding, bindings_cap.time().clone(), diff));
 
     // We're collecting into a Vec because we want to log and emit. This is a bit
     // wasteful but we don't expect large numbers of bindings.

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -20,7 +20,6 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 
 use mz_lowertest::MzReflect;
-use mz_ore::cast::CastFrom;
 use mz_repr::adt::array::ArrayDimension;
 use mz_repr::adt::interval::Interval;
 use mz_repr::adt::numeric::{self, NumericMaxScale};
@@ -1124,7 +1123,7 @@ pub fn csv_extract(a: Datum, n_cols: usize) -> impl Iterator<Item = (Row, Diff)>
 }
 
 pub fn repeat(a: Datum) -> Option<(Row, Diff)> {
-    let n = Diff::cast_from(a.unwrap_int64());
+    let n = a.unwrap_int64();
     if n != 0 {
         Some((Row::default(), n))
     } else {

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -44,6 +44,7 @@ mz-aws-util = { path = "../aws-util", features = ["s3"] }
 mz-build-info = { path = "../build-info" }
 mz-ore = { path = "../ore", default-features = false, features = ["metrics", "task"] }
 mz-persist-types = { path = "../persist-types" }
+mz-repr = { path = "../repr" }
 parquet2 = { version = "0.8.1", default-features = false }
 prost = "0.9.0"
 semver = "1.0.5"

--- a/src/persist/README.md
+++ b/src/persist/README.md
@@ -94,7 +94,7 @@ correspondence to part of the following dataflow:
 
     timely::execute(Config::thread(), |worker| {
         worker.dataflow(|scope| {
-            let (input, stream) = scope.new_input::<((String, String), u64, isize)>();
+            let (input, stream) = scope.new_input::<((String, String), u64, i64)>();
             let arranged = stream.as_collection().arrange_by_key();
         });
     });
@@ -174,9 +174,9 @@ downgrade on the operator output.
 # Codec
 
 Persist allows for arbitrary key and value types in persisted collections
-(timestamp and diff are hardcoded to `u64` and `isize`, but this can change
-if/when necessary). Internally, it translates these to `&[u8]` via a user
-supplied implementation of the [Codec] trait.
+(timestamp and diff are hardcoded to `u64` and `isize`, but this can
+change if/when necessary). Internally, it translates these to `&[u8]` via a
+user supplied implementation of the [Codec] trait.
 
 [Codec]: mz_persist_types::Codec
 

--- a/src/persist/benches/snapshot.rs
+++ b/src/persist/benches/snapshot.rs
@@ -84,7 +84,7 @@ fn bench_blob_get_one_iter<B: BlobRead>(blob: &B, key: &str) -> Result<Vec<u8>, 
 fn read_full_snapshot<K: Codec + Ord, V: Codec + Ord>(
     read: &StreamReadHandle<K, V>,
     expected_len: usize,
-) -> Vec<((K, V), u64, isize)> {
+) -> Vec<((K, V), u64, i64)> {
     let buf = read
         .snapshot()
         .expect("reading snapshot cannot fail")

--- a/src/persist/benches/writer.rs
+++ b/src/persist/benches/writer.rs
@@ -164,7 +164,7 @@ fn block_on<T, F: FnOnce(PFutureHandle<T>)>(f: F) -> Result<T, Error> {
 fn bench_write<L: Log, B: Blob>(
     index: &mut Indexed<L, B>,
     id: Id,
-    updates: Vec<((Vec<u8>, Vec<u8>), u64, isize)>,
+    updates: Vec<((Vec<u8>, Vec<u8>), u64, i64)>,
     b: &mut Bencher,
 ) {
     b.iter_custom(|iters| {

--- a/src/persist/examples/kafka_upsert.rs
+++ b/src/persist/examples/kafka_upsert.rs
@@ -101,8 +101,8 @@ fn construct_persistent_upsert_source<G, S>(
     name_base: &str,
 ) -> Result<
     (
-        Stream<G, ((S::K, S::V), u64, isize)>,
-        Stream<G, (String, u64, isize)>,
+        Stream<G, ((S::K, S::V), u64, i64)>,
+        Stream<G, (String, u64, i64)>,
     ),
     Box<dyn Error>,
 >
@@ -196,8 +196,8 @@ fn read_source<G, S>(
     bindings_read: StreamReadHandle<S::SourceTimestamp, AssignedTimestamp>,
 ) -> Result<
     (
-        Stream<G, ((S::K, S::V), S::SourceTimestamp, u64, isize)>,
-        Stream<G, ((S::SourceTimestamp, AssignedTimestamp), u64, isize)>,
+        Stream<G, ((S::K, S::V), S::SourceTimestamp, u64, i64)>,
+        Stream<G, ((S::SourceTimestamp, AssignedTimestamp), u64, i64)>,
     ),
     Box<dyn Error>,
 >

--- a/src/persist/src/client.rs
+++ b/src/persist/src/client.rs
@@ -220,7 +220,7 @@ impl RuntimeReadClient {
     }
 }
 
-/// A handle that allows writes of ((Key, Value), Time, Diff) updates into an
+/// A handle that allows writes of ((Key, Value), Time, i64) updates into an
 /// [crate::indexed::Indexed] via a [RuntimeClient].
 #[derive(Debug)]
 pub struct StreamWriteHandle<K, V> {
@@ -252,10 +252,10 @@ impl<K: Codec, V: Codec> StreamWriteHandle<K, V> {
         self.stream_id.clone()
     }
 
-    /// Asynchronously persists `(Key, Value, Time, Diff)` updates.
+    /// Asynchronously persists `(Key, Value, Time, i64)` updates.
     pub fn write<'a, I>(&self, updates: I) -> PFuture<SeqNo>
     where
-        I: IntoIterator<Item = &'a ((K, V), u64, isize)>,
+        I: IntoIterator<Item = &'a ((K, V), u64, i64)>,
     {
         let (tx, rx) = PFuture::new();
 
@@ -352,7 +352,7 @@ impl<K: Codec, V: Codec> WriteReqBuilder<K, V> {
     }
 }
 
-impl<'a, K: Codec, V: Codec, T: Borrow<((K, V), u64, isize)>> FromIterator<T>
+impl<'a, K: Codec, V: Codec, T: Borrow<((K, V), u64, i64)>> FromIterator<T>
     for WriteReqBuilder<K, V>
 {
     fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
@@ -671,7 +671,7 @@ impl AtomicWriteBuilder<'_> {
     where
         K: Codec,
         V: Codec,
-        T: Borrow<((K, V), u64, isize)>,
+        T: Borrow<((K, V), u64, i64)>,
         I: IntoIterator<Item = T>,
     {
         let stream_id = handle.stream_id()?;
@@ -749,7 +749,7 @@ pub struct DecodedSnapshotIter<K, V> {
 }
 
 impl<K: Codec, V: Codec> Iterator for DecodedSnapshotIter<K, V> {
-    type Item = Result<((K, V), u64, isize), Error>;
+    type Item = Result<((K, V), u64, i64), Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(|x| {
@@ -794,7 +794,7 @@ impl StopRuntimeOnDrop {
     }
 }
 
-/// A handle for a persisted stream of ((Key, Value), Time, Diff) updates backed
+/// A handle for a persisted stream of ((Key, Value), Time, i64) updates backed
 /// by an [crate::indexed::Indexed] via a [RuntimeClient].
 #[derive(Debug)]
 pub struct StreamReadHandle<K, V> {

--- a/src/persist/src/golden_test.rs
+++ b/src/persist/src/golden_test.rs
@@ -261,7 +261,7 @@ struct PersistStreamState {
     name: String,
     seal: Antichain<u64>,
     since: Antichain<u64>,
-    snap: Vec<((String, ()), u64, isize)>,
+    snap: Vec<((String, ()), u64, i64)>,
 }
 
 const DATAZ: &'static str = include_str!("golden_test.json");

--- a/src/persist/src/indexed/arrangement.rs
+++ b/src/persist/src/indexed/arrangement.rs
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 //! A persistent, compacting data structure containing indexed `(Key, Value,
-//! Time, Diff)` entries.
+//! Time, i64)` entries.
 
 use std::collections::VecDeque;
 use std::num::NonZeroUsize;
@@ -35,7 +35,7 @@ use crate::pfuture::PFuture;
 use crate::storage::{Blob, BlobRead, SeqNo};
 
 /// A persistent, compacting data structure containing indexed `(Key, Value,
-/// Time, Diff)` entries.
+/// Time, i64)` entries.
 ///
 ///
 /// The data is logically and physically separated into two "buckets":
@@ -724,7 +724,7 @@ pub struct UnsealedSnapshotIter {
     /// An open upper bound on the times of the contained updates.
     ts_upper: Antichain<u64>,
 
-    current_batch: Vec<((Vec<u8>, Vec<u8>), u64, isize)>,
+    current_batch: Vec<((Vec<u8>, Vec<u8>), u64, i64)>,
     batches: VecDeque<PFuture<Arc<BlobUnsealedBatch>>>,
 }
 
@@ -740,7 +740,7 @@ impl fmt::Debug for UnsealedSnapshotIter {
 }
 
 impl Iterator for UnsealedSnapshotIter {
-    type Item = Result<((Vec<u8>, Vec<u8>), u64, isize), Error>;
+    type Item = Result<((Vec<u8>, Vec<u8>), u64, i64), Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
@@ -817,7 +817,7 @@ impl Snapshot<Vec<u8>, Vec<u8>> for TraceSnapshot {
 // in roughly increasing timestamp order, but it's unclear if this is in any way
 // important.
 pub struct TraceSnapshotIter {
-    current_batch: Vec<((Vec<u8>, Vec<u8>), u64, isize)>,
+    current_batch: Vec<((Vec<u8>, Vec<u8>), u64, i64)>,
     batches: VecDeque<PFuture<Arc<BlobTraceBatch>>>,
 }
 
@@ -840,7 +840,7 @@ impl fmt::Debug for TraceSnapshotIter {
 }
 
 impl Iterator for TraceSnapshotIter {
-    type Item = Result<((Vec<u8>, Vec<u8>), u64, isize), Error>;
+    type Item = Result<((Vec<u8>, Vec<u8>), u64, i64), Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
@@ -936,7 +936,7 @@ pub struct ArrangementSnapshotIter {
 }
 
 impl Iterator for ArrangementSnapshotIter {
-    type Item = Result<((Vec<u8>, Vec<u8>), u64, isize), Error>;
+    type Item = Result<((Vec<u8>, Vec<u8>), u64, i64), Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(|x| {
@@ -1000,7 +1000,7 @@ mod tests {
     }
 
     // Generate a list of ((k, v), t, 1) updates at all of the specified times.
-    fn unsealed_updates(update_times: Vec<u64>) -> Vec<((Vec<u8>, Vec<u8>), u64, isize)> {
+    fn unsealed_updates(update_times: Vec<u64>) -> Vec<((Vec<u8>, Vec<u8>), u64, i64)> {
         update_times
             .into_iter()
             .map(|t| (("k".into(), "v".into()), t, 1))
@@ -1008,7 +1008,7 @@ mod tests {
     }
 
     // Generate a ColumnarRecords containing the provided updates
-    fn columnar_records(updates: Vec<((Vec<u8>, Vec<u8>), u64, isize)>) -> Vec<ColumnarRecords> {
+    fn columnar_records(updates: Vec<((Vec<u8>, Vec<u8>), u64, i64)>) -> Vec<ColumnarRecords> {
         updates.iter().collect::<ColumnarRecordsVec>().into_inner()
     }
 
@@ -1045,7 +1045,7 @@ mod tests {
         blob: &BlobCache<L>,
         lo: u64,
         hi: Option<u64>,
-    ) -> Result<Vec<((Vec<u8>, Vec<u8>), u64, isize)>, Error> {
+    ) -> Result<Vec<((Vec<u8>, Vec<u8>), u64, i64)>, Error> {
         let hi = hi.map_or_else(Antichain::new, Antichain::from_elem);
         let snapshot = arrangement
             .unsealed_snapshot(Antichain::from_elem(lo), hi)?

--- a/src/persist/src/indexed/encoding.rs
+++ b/src/persist/src/indexed/encoding.rs
@@ -59,7 +59,7 @@ pub struct LogEntry {
     //
     // We could require that each Id is included at most once, but at the
     // moment, there's no particular reason we'd need to.
-    pub updates: Vec<(Id, Vec<((Vec<u8>, Vec<u8>), u64, isize)>)>,
+    pub updates: Vec<(Id, Vec<((Vec<u8>, Vec<u8>), u64, i64)>)>,
 }
 
 /// The structure serialized and stored as a value in [crate::storage::Blob]
@@ -675,7 +675,7 @@ impl fmt::Debug for PrettyBytes<'_> {
     }
 }
 
-struct PrettyRecord<'a>(((&'a [u8], &'a [u8]), u64, isize));
+struct PrettyRecord<'a>(((&'a [u8], &'a [u8]), u64, i64));
 
 impl fmt::Debug for PrettyRecord<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -931,11 +931,11 @@ mod tests {
 
     use super::*;
 
-    fn update_with_ts(ts: u64) -> ((Vec<u8>, Vec<u8>), u64, isize) {
+    fn update_with_ts(ts: u64) -> ((Vec<u8>, Vec<u8>), u64, i64) {
         (("".into(), "".into()), ts, 1)
     }
 
-    fn update_with_key(ts: u64, key: &'static str) -> ((Vec<u8>, Vec<u8>), u64, isize) {
+    fn update_with_key(ts: u64, key: &'static str) -> ((Vec<u8>, Vec<u8>), u64, i64) {
         ((key.into(), "".into()), ts, 1)
     }
 
@@ -986,7 +986,7 @@ mod tests {
         }
     }
 
-    fn columnar_records(updates: Vec<((Vec<u8>, Vec<u8>), u64, isize)>) -> Vec<ColumnarRecords> {
+    fn columnar_records(updates: Vec<((Vec<u8>, Vec<u8>), u64, i64)>) -> Vec<ColumnarRecords> {
         updates.iter().collect::<ColumnarRecordsVec>().into_inner()
     }
 

--- a/src/persist/src/nemesis/direct.rs
+++ b/src/persist/src/nemesis/direct.rs
@@ -133,7 +133,7 @@ struct Ingest {
 /// A handle to the "dataflowd" (output) side of a persisted collection.
 #[derive(Debug)]
 struct Dataflow {
-    output: Receiver<TimelyCaptureEvent<u64, (Result<(String, ()), String>, u64, isize)>>,
+    output: Receiver<TimelyCaptureEvent<u64, (Result<(String, ()), String>, u64, i64)>>,
     workers: TimelyWorkers,
     progress_tx: DataflowProgressHandle,
 }

--- a/src/persist/src/nemesis/mod.rs
+++ b/src/persist/src/nemesis/mod.rs
@@ -156,7 +156,7 @@ pub enum Res {
 #[derive(Clone, Debug)]
 pub struct WriteReqSingle {
     stream: String,
-    update: ((String, ()), u64, isize),
+    update: ((String, ()), u64, i64),
 }
 
 #[derive(Clone, Debug)]
@@ -185,7 +185,7 @@ pub enum ReadOutputEvent<D> {
 
 #[derive(Clone, Debug)]
 pub struct ReadOutputRes {
-    contents: Vec<ReadOutputEvent<(Result<(String, ()), String>, u64, isize)>>,
+    contents: Vec<ReadOutputEvent<(Result<(String, ()), String>, u64, i64)>>,
 }
 
 #[derive(Clone, Debug)]
@@ -215,7 +215,7 @@ pub struct ReadSnapshotReq {
 pub struct ReadSnapshotRes {
     seqno: u64,
     since: Antichain<u64>,
-    contents: Vec<((String, ()), u64, isize)>,
+    contents: Vec<((String, ()), u64, i64)>,
 }
 
 #[derive(Debug)]

--- a/src/persist/src/nemesis/validator.rs
+++ b/src/persist/src/nemesis/validator.rs
@@ -28,9 +28,9 @@ use crate::storage::SeqNo;
 pub struct Validator {
     seal_frontier: HashMap<String, u64>,
     since_frontier: HashMap<String, u64>,
-    writes_by_seqno: BTreeMap<(String, SeqNo), Vec<((String, ()), u64, isize)>>,
+    writes_by_seqno: BTreeMap<(String, SeqNo), Vec<((String, ()), u64, i64)>>,
     output_by_stream:
-        HashMap<String, Vec<ReadOutputEvent<(Result<(String, ()), String>, u64, isize)>>>,
+        HashMap<String, Vec<ReadOutputEvent<(Result<(String, ()), String>, u64, i64)>>>,
     available_snapshots: HashMap<SnapshotId, (String, Instant)>,
     errors: Vec<String>,
     uptime: Uptime,
@@ -297,7 +297,7 @@ impl Validator {
                     (kv, ts, diff)
                 })
                 .collect();
-            let mut expected: Vec<((String, ()), u64, isize)> = self
+            let mut expected: Vec<((String, ()), u64, i64)> = self
                 .writes_by_seqno
                 .range((req.stream.clone(), SeqNo(0))..(req.stream, SeqNo(u64::MAX)))
                 .flat_map(|(_, v)| v)
@@ -383,7 +383,7 @@ impl Validator {
                 self.check_success(meta, &res, require_succeed);
                 if let Ok(res) = res {
                     let mut actual = res.contents;
-                    let mut expected: Vec<((String, ()), u64, isize)> = self
+                    let mut expected: Vec<((String, ()), u64, i64)> = self
                         .writes_by_seqno
                         .range((stream.clone(), SeqNo(0))..=(stream, SeqNo(res.seqno)))
                         .flat_map(|(_, v)| v)
@@ -422,8 +422,8 @@ impl Validator {
 }
 
 fn updates_eq(
-    actual: &mut Vec<((String, ()), u64, isize)>,
-    expected: &mut Vec<((String, ()), u64, isize)>,
+    actual: &mut Vec<((String, ()), u64, i64)>,
+    expected: &mut Vec<((String, ()), u64, i64)>,
     since: Antichain<u64>,
 ) -> bool {
     // TODO: This is also used by the implementation. Write a slower but more

--- a/src/persist/src/operators/mod.rs
+++ b/src/persist/src/operators/mod.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! Timely and Differential Dataflow operators for persisting and replaying
+//! Timely and i64erential Dataflow operators for persisting and replaying
 //! data.
 
 pub mod replay;
@@ -20,11 +20,9 @@ pub mod upsert;
 // https://docs.rs/differential-dataflow/0.12.0/src/differential_dataflow/operators/join.rs.html#487-488
 const DEFAULT_OUTPUTS_PER_YIELD: usize = 1_000_000;
 
-pub(crate) fn split_ok_err<K, V>(
-    x: (Result<(K, V), String>, u64, isize),
-) -> Result<((K, V), u64, isize), (String, u64, isize)> {
+pub(crate) fn split_ok_err<O, E, T, R>(x: (Result<O, E>, T, R)) -> Result<(O, T, R), (E, T, R)> {
     match x {
-        (Ok(kv), ts, diff) => Ok((kv, ts, diff)),
+        (Ok(ok), ts, diff) => Ok((ok, ts, diff)),
         (Err(err), ts, diff) => Err((err, ts, diff)),
     }
 }

--- a/src/persist/src/operators/replay.rs
+++ b/src/persist/src/operators/replay.rs
@@ -28,7 +28,7 @@ pub trait Replay<G: Scope<Timestamp = u64>, K: TimelyData, V: TimelyData> {
         &self,
         snapshot: Result<DecodedSnapshot<K, V>, Error>,
         as_of_frontier: &Antichain<u64>,
-    ) -> Stream<G, (Result<(K, V), String>, u64, isize)> {
+    ) -> Stream<G, (Result<(K, V), String>, u64, i64)> {
         self.replay_yield(snapshot, as_of_frontier, DEFAULT_OUTPUTS_PER_YIELD)
     }
 
@@ -41,7 +41,7 @@ pub trait Replay<G: Scope<Timestamp = u64>, K: TimelyData, V: TimelyData> {
         snapshot: Result<DecodedSnapshot<K, V>, Error>,
         as_of_frontier: &Antichain<u64>,
         outputs_per_yield: usize,
-    ) -> Stream<G, (Result<(K, V), String>, u64, isize)>;
+    ) -> Stream<G, (Result<(K, V), String>, u64, i64)>;
 }
 
 impl<G, K, V> Replay<G, K, V> for G
@@ -55,7 +55,7 @@ where
         snapshot: Result<DecodedSnapshot<K, V>, Error>,
         as_of_frontier: &Antichain<u64>,
         outputs_per_yield: usize,
-    ) -> Stream<G, (Result<(K, V), String>, u64, isize)> {
+    ) -> Stream<G, (Result<(K, V), String>, u64, i64)> {
         // TODO: This currently works by only emitting the persisted
         // data on worker 0 because that was the simplest thing to do
         // initially. Instead, we should shard up the responsibility
@@ -64,7 +64,7 @@ where
 
         let as_of_frontier = as_of_frontier.clone();
 
-        let result_stream: Stream<G, Result<((K, V), u64, isize), Error>> = operator::source(
+        let result_stream: Stream<G, Result<((K, V), u64, i64), Error>> = operator::source(
             self,
             "Replay",
             move |cap, info| {

--- a/src/persist/src/operators/source.rs
+++ b/src/persist/src/operators/source.rs
@@ -31,7 +31,7 @@ pub trait PersistedSource<G: Scope<Timestamp = u64>, K: TimelyData, V: TimelyDat
         &mut self,
         read: StreamReadHandle<K, V>,
         as_of_frontier: &Antichain<u64>,
-    ) -> Stream<G, (Result<(K, V), String>, u64, isize)> {
+    ) -> Stream<G, (Result<(K, V), String>, u64, i64)> {
         self.persisted_source_yield(read, as_of_frontier, DEFAULT_OUTPUTS_PER_YIELD)
     }
 
@@ -46,7 +46,7 @@ pub trait PersistedSource<G: Scope<Timestamp = u64>, K: TimelyData, V: TimelyDat
         read: StreamReadHandle<K, V>,
         as_of_frontier: &Antichain<u64>,
         outputs_per_yield: usize,
-    ) -> Stream<G, (Result<(K, V), String>, u64, isize)>;
+    ) -> Stream<G, (Result<(K, V), String>, u64, i64)>;
 }
 
 impl<G, K, V> PersistedSource<G, K, V> for G
@@ -60,7 +60,7 @@ where
         read: StreamReadHandle<K, V>,
         as_of_frontier: &Antichain<u64>,
         outputs_per_yield: usize,
-    ) -> Stream<G, (Result<(K, V), String>, u64, isize)> {
+    ) -> Stream<G, (Result<(K, V), String>, u64, i64)> {
         let (listen_tx, listen_rx) = crossbeam_channel::unbounded();
         let snapshot = read.listen(listen_tx);
 
@@ -90,7 +90,7 @@ fn listen_source<G, K, V>(
     initial_frontier: Option<Antichain<u64>>,
     listen_rx: crossbeam_channel::Receiver<ListenEvent>,
     _outputs_per_yield: usize,
-) -> Stream<G, (Result<(K, V), String>, u64, isize)>
+) -> Stream<G, (Result<(K, V), String>, u64, i64)>
 where
     G: Scope<Timestamp = u64>,
     K: TimelyData + Codec + Send,

--- a/src/persist/src/runtime.rs
+++ b/src/persist/src/runtime.rs
@@ -797,7 +797,7 @@ mod tests {
         // Normal case: registration uses same key and value codec.
         let _ = client.create_or_load::<(), String>("stream");
 
-        // Different key codec
+        // i64erent key codec
         assert_eq!(
             client
                 .create_or_load::<Vec<u8>, String>("stream")
@@ -808,7 +808,7 @@ mod tests {
             ))
         );
 
-        // Different val codec
+        // i64erent val codec
         assert_eq!(
             client.create_or_load::<(), Vec<u8>>("stream").0.stream_id(),
             Err(Error::from(
@@ -886,7 +886,7 @@ mod tests {
             ok_stream
         });
 
-        let diff_sum: isize = ok
+        let diff_sum: i64 = ok
             .extract()
             .into_iter()
             .flat_map(|(_, xs)| xs.into_iter().map(|(_, _, diff)| diff))

--- a/src/persist/src/workload.rs
+++ b/src/persist/src/workload.rs
@@ -47,7 +47,7 @@ const DEFAULT_BATCH_MAX_COUNT: usize = (8 * 1024 * 1024) / DEFAULT_RECORD_SIZE_B
 // round-ish number.
 const DEFAULT_RECORD_COUNT: usize = 819_200;
 
-const TS_DIFF_GOODPUT_SIZE: usize = size_of::<u64>() + size_of::<isize>();
+const TS_DIFF_GOODPUT_SIZE: usize = size_of::<u64>() + size_of::<i64>();
 
 fn read_env_usize(key: &str, default: usize) -> usize {
     match env::var(key) {
@@ -139,7 +139,7 @@ impl DataGenerator {
         Some(batch.finish())
     }
 
-    fn gen_record(&mut self, record_idx: usize) -> ((&[u8], &[u8]), u64, isize) {
+    fn gen_record(&mut self, record_idx: usize) -> ((&[u8], &[u8]), u64, i64) {
         assert!(record_idx < self.record_count);
         assert!(self.record_size_bytes > TS_DIFF_GOODPUT_SIZE);
 
@@ -171,7 +171,7 @@ impl DataGenerator {
     }
 
     /// Returns an [Iterator] of all records.
-    pub fn records(&self) -> impl Iterator<Item = ((Vec<u8>, Vec<u8>), u64, isize)> {
+    pub fn records(&self) -> impl Iterator<Item = ((Vec<u8>, Vec<u8>), u64, i64)> {
         let mut config = self.clone();
         (0..self.record_count).map(move |record_idx| {
             let ((k, v), t, d) = config.gen_record(record_idx);

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -43,7 +43,7 @@ pub use scalar::{AsColumnType, Datum, DatumType, ScalarBaseType, ScalarType};
 /// System-wide timestamp type.
 pub type Timestamp = u64;
 /// System-wide record count difference type.
-pub type Diff = isize;
+pub type Diff = i64;
 
 use serde::{Deserialize, Serialize};
 // This probably logically belongs in `dataflow`, but source caching looks at it,

--- a/src/transform/src/reduction.rs
+++ b/src/transform/src/reduction.rs
@@ -542,8 +542,8 @@ impl FoldConstants {
         let mut cursor = 0;
         while cursor < rows.len() {
             // first, reset the remaining limit and offset for the current group
-            let mut offset_rem: isize = offset.clone().try_into().unwrap();
-            let mut limit_rem: Option<isize> = limit.clone().map(|x| x.try_into().unwrap());
+            let mut offset_rem: Diff = offset.clone().try_into().unwrap();
+            let mut limit_rem: Option<Diff> = limit.clone().map(|x| x.try_into().unwrap());
 
             let mut finger = cursor;
             while finger < rows.len() && same_group_key(&rows[cursor], &rows[finger]) {


### PR DESCRIPTION
### Motivation

Even though we currently only run materialized in 64bit machines it's
good to have a platform independent type, especially since we persist it.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
