### PR TITLE
Const fold create list

### DIFF
--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -643,8 +643,7 @@ impl MirScalarExpr {
                                     exprs: list_exprs,
                                 } = &mut exprs[0]
                                 {
-                                    if matches!(func, VariadicFunc::ListCreate { .. })
-                                        && list_exprs.len() > index_literal
+                                    if matches!(func, VariadicFunc::ListCreate { .. }) && index_literal < list_exprs.len()
                                     {
                                         *e = list_exprs.swap_remove(index_literal);
                                     }
@@ -1575,6 +1574,64 @@ mod tests {
                 },
                 output: err(EvalError::DivisionByZero),
             },
+            TestCase{
+                input: MirScalarExpr::CallVariadic{
+                    func: VariadicFunc::ListIndex,
+                    exprs: vec![
+                        MirScalarExpr::CallVariadic{
+                            func: VariadicFunc::ListCreate{elem_type: ScalarType::Int64},
+                            exprs: vec![col(0), col(1), col(2)]
+                        },
+                        lit(1)
+                    ]
+                },
+                output: col(0)
+            },
+            TestCase{
+                input: MirScalarExpr::CallVariadic{
+                    func: VariadicFunc::ListIndex,
+                    exprs: vec![
+                        MirScalarExpr::CallVariadic{
+                            func: VariadicFunc::ListCreate{elem_type: ScalarType::Int64},
+                            exprs: vec![col(0), col(1), col(2)]
+                        },
+                        lit(-1)
+                    ]
+                },
+                output: MirScalarExpr::CallVariadic{
+                    func: VariadicFunc::ListIndex,
+                    exprs: vec![
+                        MirScalarExpr::CallVariadic{
+                            func: VariadicFunc::ListCreate{elem_type: ScalarType::Int64},
+                            exprs: vec![col(0), col(1), col(2)]
+                        },
+                        lit(-1)
+                    ]
+                }
+            },
+            TestCase{
+                input: MirScalarExpr::CallVariadic{
+                    func: VariadicFunc::ListIndex,
+                    exprs: vec![
+                        MirScalarExpr::CallVariadic{
+                            func: VariadicFunc::ListCreate{elem_type: ScalarType::Int64},
+                            exprs: vec![col(0), col(1), col(2)]
+                        },
+                        lit(10)
+                    ]
+                },
+                output: MirScalarExpr::CallVariadic{
+                    func: VariadicFunc::ListIndex,
+                    exprs: vec![
+                        MirScalarExpr::CallVariadic{
+                            func: VariadicFunc::ListCreate{elem_type: ScalarType::Int64},
+                            exprs: vec![col(0), col(1), col(2)]
+                        },
+                        lit(10)
+                    ]
+                }
+            }
+
         ];
 
         for tc in test_cases {


### PR DESCRIPTION
<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->
Adds optimization for `list_index(list_create, literal)` to MirScalarExpr::reduce. The optimization inlines the list_index function when the index is a literal integer. If the integer is an invalid index for the list the expression is unchanged.

### Motivation

* This PR adds a known-desirable feature: #9020


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).