### PR TITLE
redpanda: Update CI to use v21.11.8

### DIFF
--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -281,7 +281,7 @@ class Redpanda(Service):
     def __init__(
         self,
         name: str = "redpanda",
-        version: str = "v21.11.1",
+        version: str = "v21.11.8",
         image: Optional[str] = None,
         aliases: Optional[List[str]] = None,
         ports: Optional[List[int]] = None,

--- a/test/testdrive/avro-resolution-no-publish-writer.td
+++ b/test/testdrive/avro-resolution-no-publish-writer.td
@@ -30,4 +30,4 @@ $ kafka-ingest format=avro topic=resolution-no-publish-writer schema=${int-schem
 {"f1": 123}
 
 ! SELECT * FROM resolution_no_publish_writer;
-contains:Attempted to resolve
+contains:to resolve


### PR DESCRIPTION
Our CI was observing a crash in Redpanda, which was
redpanda#3559 / redpanda#3867 . v21.11.8 contains a fix.