### PR TITLE
mzcompose: pull "latest" images on override()

### DIFF
--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -435,6 +435,9 @@ class DockerComposeCommand(Command):
             self.check_docker_resource_limits()
             composition.dependencies.acquire()
 
+            if "services" in composition.compose:
+                composition.pull_if_variable(composition.compose["services"].keys())
+
         self.handle_composition(args, composition)
 
     def handle_composition(

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -81,7 +81,7 @@ SERVICES = [
     # We are going to override this service definition during the actual benchmark
     # we put "latest" here so that we avoid recompiling the current source unless
     # we will actually be benchmarking it.
-    Materialized(image="latest"),
+    Materialized(image="materialize/materialized:latest"),
     Testdrive(
         validate_catalog=False,
         default_timeout=default_timeout,


### PR DESCRIPTION
Ensure that any images with the "latest" tag are pulled explicitly on
override(). This ensures that the most up-to-date image is used
during feature benchmark runs with --other-tag=latest .

### Motivation

  * This PR fixes a recognized bug: #10713 

### Tips for reviewer

This fixes the feature benchmark while keeping the code inside mzcompose and avoiding making the workflow responsible for any image management. This localized fix does not cover other eventualities, e.g. if "latest" is used outside of `override()`, etc.