### PR TITLE
testdrive: support env logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3884,6 +3884,7 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
+ "env_logger",
  "flate2",
  "futures",
  "globset",

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -25,6 +25,7 @@ flate2 = "1.0.22"
 futures = "0.3.21"
 globset = "0.4.8"
 http = "0.2.6"
+env_logger = "0.9.0"
 itertools = "0.10.3"
 junit-report = "0.7.0"
 krb5-src = { version = "0.3.2", features = ["binaries"] }

--- a/src/testdrive/src/bin/testdrive.rs
+++ b/src/testdrive/src/bin/testdrive.rs
@@ -164,6 +164,7 @@ struct Args {
 
 #[tokio::main]
 async fn main() {
+    env_logger::init();
     let args: Args = mz_ore::cli::parse_args();
 
     let (aws_config, aws_account) = match args.aws_region {


### PR DESCRIPTION
### Motivation

Enable `env_logger` for testdrive to permit the use of the `RUST_LOG` environment symbol.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
