### PR TITLE
Dataflow ID

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -3227,7 +3227,7 @@ impl Coordinator {
         let view_id = self.allocate_transient_id()?;
         let index_id = self.allocate_transient_id()?;
         // The assembled dataflow contains a view and an index of that view.
-        let mut dataflow = DataflowDesc::new(format!("temp-view-{}", view_id));
+        let mut dataflow = DataflowDesc::new(format!("temp-view-{}", view_id), view_id);
         dataflow.set_as_of(Antichain::from_elem(timestamp));
         self.dataflow_builder()
             .import_view_into_dataflow(&view_id, &source, &mut dataflow)?;
@@ -3333,7 +3333,7 @@ impl Coordinator {
                 let expr = self.prep_relation_expr(expr, ExprPrepStyle::Static)?;
                 let desc = RelationDesc::new(expr.typ(), desc.iter_names());
                 let sink_desc = make_sink_desc(self, id, desc, &depends_on)?;
-                let mut dataflow = DataflowDesc::new(format!("tail-{}", id));
+                let mut dataflow = DataflowDesc::new(format!("tail-{}", id), id);
                 let mut dataflow_builder = self.dataflow_builder();
                 dataflow_builder.import_view_into_dataflow(&id, &expr, &mut dataflow)?;
                 dataflow_builder.build_sink_dataflow_into(&mut dataflow, id, sink_desc)?;
@@ -3609,7 +3609,7 @@ impl Coordinator {
                 let start = Instant::now();
                 let optimized_plan =
                     coord.prep_relation_expr(decorrelated_plan, ExprPrepStyle::Explain)?;
-                let mut dataflow = DataflowDesc::new(format!("explanation"));
+                let mut dataflow = DataflowDesc::new(format!("explanation"), GlobalId::Explain);
                 coord.dataflow_builder().import_view_into_dataflow(
                     // TODO: If explaining a view, pipe the actual id of the view.
                     &GlobalId::Explain,
@@ -5221,7 +5221,7 @@ impl Coordinator {
         // prevent us from incorrectly teaching those functions how to return errors
         // (which has happened twice and is the motivation for this test).
 
-        let df = DataflowDesc::new("".into());
+        let df = DataflowDesc::new("".into(), GlobalId::Explain);
         let _: () = self.ship_dataflow(df.clone()).await;
         let _: () = self.ship_dataflows(vec![df.clone()]).await;
         let _: DataflowDescription<mz_dataflow_types::plan::Plan> = self.finalize_dataflow(df);

--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -193,7 +193,7 @@ impl<'a> DataflowBuilder<'a> {
     ) -> Result<DataflowDesc, CoordError> {
         let on_entry = self.catalog.get_by_id(&index_description.on_id);
         let on_type = on_entry.desc().unwrap().typ().clone();
-        let mut dataflow = DataflowDesc::new(name);
+        let mut dataflow = DataflowDesc::new(name, id);
         self.import_into_dataflow(&index_description.on_id, &mut dataflow)?;
         dataflow.export_index(id, index_description, on_type);
 
@@ -214,7 +214,7 @@ impl<'a> DataflowBuilder<'a> {
         id: GlobalId,
         sink_description: SinkDesc,
     ) -> Result<DataflowDesc, CoordError> {
-        let mut dataflow = DataflowDesc::new(name);
+        let mut dataflow = DataflowDesc::new(name, id);
         self.build_sink_dataflow_into(&mut dataflow, id, sink_description)?;
         Ok(dataflow)
     }

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -154,9 +154,10 @@ pub enum StorageCommand<T = mz_repr::Timestamp> {
     /// of sources to import.
     RenderSources(
         Vec<(
-            String,
-            Option<Antichain<T>>,
-            BTreeMap<GlobalId, SourceInstanceDesc>,
+            /* debug_name */ String,
+            /* dataflow_id */ GlobalId,
+            /* as_of */ Option<Antichain<T>>,
+            /* source_imports*/ BTreeMap<GlobalId, SourceInstanceDesc>,
         )>,
     ),
     /// Drop the sources bound to these names.
@@ -264,6 +265,7 @@ impl<T: timely::progress::Timestamp> Command<T> {
                                 dependent_objects: dataflow.dependent_objects.clone(),
                                 as_of: dataflow.as_of.clone(),
                                 debug_name: dataflow.debug_name.clone(),
+                                id: dataflow.id,
                             });
                         }
                     }

--- a/src/dataflow-types/src/client/controller/compute.rs
+++ b/src/dataflow-types/src/client/controller/compute.rs
@@ -124,6 +124,7 @@ impl<'a, C: Client<T>, T: Timestamp + Lattice> ComputeController<'a, C, T> {
             .map(|dataflow| {
                 (
                     dataflow.debug_name.clone(),
+                    dataflow.id,
                     dataflow.as_of.clone(),
                     dataflow.source_imports.clone(),
                 )

--- a/src/dataflow-types/src/plan/mod.rs
+++ b/src/dataflow-types/src/plan/mod.rs
@@ -951,6 +951,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
             dependent_objects: desc.dependent_objects,
             as_of: desc.as_of,
             debug_name: desc.debug_name,
+            id: desc.id,
         })
     }
 

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -105,7 +105,7 @@ pub struct SourceInstanceKey {
 }
 
 /// A description of a dataflow to construct and results to surface.
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct DataflowDescription<View, T = mz_repr::Timestamp> {
     /// Sources instantiations made available to the dataflow.
     pub source_imports: BTreeMap<GlobalId, SourceInstanceDesc>,
@@ -131,11 +131,13 @@ pub struct DataflowDescription<View, T = mz_repr::Timestamp> {
     pub as_of: Option<Antichain<T>>,
     /// Human readable name
     pub debug_name: String,
+    /// Unique ID of the dataflow
+    pub id: GlobalId,
 }
 
 impl DataflowDescription<OptimizedMirRelationExpr> {
     /// Creates a new dataflow description with a human-readable name.
-    pub fn new(name: String) -> Self {
+    pub fn new(name: String, id: GlobalId) -> Self {
         Self {
             source_imports: Default::default(),
             index_imports: Default::default(),
@@ -145,6 +147,7 @@ impl DataflowDescription<OptimizedMirRelationExpr> {
             dependent_objects: Default::default(),
             as_of: Default::default(),
             debug_name: name,
+            id,
         }
     }
 

--- a/src/dataflow/src/server/boundary.rs
+++ b/src/dataflow/src/server/boundary.rs
@@ -12,6 +12,7 @@ use timely::dataflow::Scope;
 
 use mz_dataflow_types::DataflowError;
 use mz_dataflow_types::SourceInstanceKey;
+use mz_expr::GlobalId;
 use mz_repr::{Diff, Row};
 
 /// A type that can capture a specific source.
@@ -24,6 +25,7 @@ pub trait StorageCapture {
         err: Collection<G, DataflowError, Diff>,
         token: Rc<dyn Any>,
         name: &str,
+        dataflow_id: GlobalId,
     );
 }
 
@@ -39,6 +41,7 @@ pub trait ComputeReplay {
         id: SourceInstanceKey,
         scope: &mut G,
         name: &str,
+        dataflow_id: GlobalId,
     ) -> (
         Collection<G, Row, Diff>,
         Collection<G, DataflowError, Diff>,
@@ -47,6 +50,7 @@ pub trait ComputeReplay {
 }
 
 pub use event_link::EventLinkBoundary;
+
 /// A simple boundary that uses activated event linked lists.
 mod event_link {
 
@@ -62,6 +66,7 @@ mod event_link {
 
     use mz_dataflow_types::DataflowError;
     use mz_dataflow_types::SourceInstanceKey;
+    use mz_expr::GlobalId;
     use mz_repr::{Diff, Row};
 
     use crate::activator::RcActivator;
@@ -93,6 +98,7 @@ mod event_link {
             err: Collection<G, DataflowError, Diff>,
             token: Rc<dyn Any>,
             name: &str,
+            _dataflow_id: GlobalId,
         ) {
             let boundary = SourceBoundary::new(name, token);
 
@@ -119,6 +125,7 @@ mod event_link {
             id: SourceInstanceKey,
             scope: &mut G,
             name: &str,
+            _dataflow_id: GlobalId,
         ) -> (
             Collection<G, Row, Diff>,
             Collection<G, DataflowError, Diff>,

--- a/src/dataflow/src/server/storage_state.rs
+++ b/src/dataflow/src/server/storage_state.rs
@@ -246,11 +246,12 @@ impl<'a, A: Allocate, B: StorageCapture> ActiveStorageState<'a, A, B> {
         &mut self,
         dataflows: Vec<(
             String,
+            GlobalId,
             Option<Antichain<Timestamp>>,
             BTreeMap<GlobalId, SourceInstanceDesc>,
         )>,
     ) {
-        for (debug_name, as_of, source_imports) in dataflows {
+        for (debug_name, dataflow_id, as_of, source_imports) in dataflows {
             for (source_id, instance) in source_imports.iter() {
                 assert_eq!(
                     self.storage_state.source_descriptions[source_id],
@@ -263,6 +264,7 @@ impl<'a, A: Allocate, B: StorageCapture> ActiveStorageState<'a, A, B> {
                 &debug_name,
                 as_of,
                 source_imports,
+                dataflow_id,
                 self.boundary,
             );
         }


### PR DESCRIPTION
Currently, dataflows are implicitly named by the output they produce. This
assumes that each dataflow produces a single output, and leaves the
information in different places.

With this PR, dataflows have an identifier, which is unique among other
dataflows, but could be reused with the object the dataflow outputs.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
