### PR TITLE
pgwire: only push RowDescription message for successful queries

### DIFF
--- a/test/pgtest/github-10814.pt
+++ b/test/pgtest/github-10814.pt
@@ -1,0 +1,20 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Regression test for https://github.com/MaterializeInc/materialize/issues/10814
+
+send
+Query {"query": "SELECT sqrt(-1)"}
+----
+
+until
+ReadyForQuery
+----
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"XX000"},{"typ":"M","value":"cannot take square root of a negative number"}]}
+ReadyForQuery {"status":"I"}


### PR DESCRIPTION
Closes #10814 by only sending the `RowDescription` message after checking if the query finished successfully.

### Motivation

  * This PR fixes a recognized bug: #10814

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
