### PR TITLE
dataflow: switch `position` from an `Option<i64>` to an `i64` across the whole codebase

### DIFF
--- a/src/dataflow/src/decode/mod.rs
+++ b/src/dataflow/src/decode/mod.rs
@@ -531,9 +531,6 @@ where
                         &value_buf
                     };
 
-                    // At this point, `value` is non-empty, as it came from a
-                    // `MessagePayload::Data`
-
                     let value_bytes_remaining = &mut value.as_slice();
                     // The intent is that the below loop runs as long as there are more bytes to decode.
                     //

--- a/src/dataflow/src/render/debezium.rs
+++ b/src/dataflow/src/render/debezium.rs
@@ -76,7 +76,7 @@ where
                                     let res = s.should_use_record(
                                         key,
                                         &value,
-                                        Some(result.position),
+                                        result.position,
                                         result.upstream_time_millis,
                                         &debug_name,
                                     );
@@ -131,7 +131,7 @@ struct DebeziumDeduplicationState {
     ///
     /// [`DebeziumEnvelope`] determines whether messages that are not ahead
     /// of the last recorded position will be skipped.
-    last_position_and_offset: Option<(RowCoordinates, Option<i64>)>,
+    last_position_and_offset: Option<(RowCoordinates, i64)>,
     /// Whether or not to track every message we've ever seen
     full: Option<TrackFull>,
     messages_processed: u64,
@@ -428,7 +428,7 @@ impl DebeziumDeduplicationState {
         &mut self,
         key: Option<Row>,
         value: &Row,
-        connector_offset: Option<i64>,
+        connector_offset: i64,
         upstream_time_millis: Option<i64>,
         debug_name: &str,
     ) -> Result<bool, DataflowError> {
@@ -583,13 +583,13 @@ impl DebeziumDeduplicationState {
 /// Helper to track information for logging on deduplication
 struct SkipInfo {
     old_position: RowCoordinates,
-    old_offset: Option<i64>,
+    old_offset: i64,
 }
 
 #[allow(clippy::too_many_arguments)]
 fn log_duplication_info(
     position: RowCoordinates,
-    connector_offset: Option<i64>,
+    connector_offset: i64,
     upstream_time_millis: Option<i64>,
     debug_name: &str,
     is_new: bool,
@@ -613,7 +613,7 @@ fn log_duplication_info(
                  message_time={} max_seen_time={}",
                 debug_name,
                 position,
-                connector_offset.unwrap_or(-1),
+                connector_offset,
                 skipinfo.old_position,
                 fmt_timestamp(upstream_time_millis),
                 fmt_timestamp(*max_seen_time),
@@ -628,7 +628,7 @@ fn log_duplication_info(
                 debug_name,
                 position,
                 skipinfo.old_position,
-                skipinfo.old_offset.unwrap_or(-1),
+                skipinfo.old_offset,
                 fmt_timestamp(upstream_time_millis),
                 fmt_timestamp(*original_time),
                 fmt_timestamp(*max_seen_time),
@@ -644,7 +644,7 @@ fn log_duplication_info(
                     is beyond the highest record we've ever seen. {:?} connector offset={} \
                     message_time={} message_first_seen={} max_seen_time={}",
                 position,
-                connector_offset.unwrap_or(-1),
+                connector_offset,
                 fmt_timestamp(upstream_time_millis),
                 fmt_timestamp(*original_time),
                 fmt_timestamp(*max_seen_time),

--- a/src/dataflow/src/render/debezium.rs
+++ b/src/dataflow/src/render/debezium.rs
@@ -76,7 +76,7 @@ where
                                     let res = s.should_use_record(
                                         key,
                                         &value,
-                                        result.position,
+                                        Some(result.position),
                                         result.upstream_time_millis,
                                         &debug_name,
                                     );

--- a/src/dataflow/src/render/upsert.rs
+++ b/src/dataflow/src/render/upsert.rs
@@ -37,15 +37,10 @@ struct UpsertSourceData {
     /// The actual value
     value: Option<Result<Row, DataflowError>>,
     /// The source's reported position for this record
-    ///
-    /// e.g. kafka offset or file location
     position: i64,
-
     /// The time that the upstream source believes that the message was created
-    ///
     /// Currently only applies to Kafka
     upstream_time_millis: Option<i64>,
-
     /// Metadata for this row
     metadata: Row,
 }

--- a/src/dataflow/src/render/upsert.rs
+++ b/src/dataflow/src/render/upsert.rs
@@ -30,11 +30,23 @@ use mz_repr::{Datum, Diff, Row, RowArena, Timestamp};
 use tracing::error;
 
 use crate::operator::StreamExt;
-use crate::source::{DecodeResult, SourceData};
+use crate::source::DecodeResult;
 
 #[derive(Debug, Default, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 struct UpsertSourceData {
-    raw_data: SourceData,
+    /// The actual value
+    value: Option<Result<Row, DataflowError>>,
+    /// The source's reported position for this record
+    ///
+    /// e.g. kafka offset or file location
+    position: i64,
+
+    /// The time that the upstream source believes that the message was created
+    ///
+    /// Currently only applies to Kafka
+    upstream_time_millis: Option<i64>,
+
+    /// Metadata for this row
     metadata: Row,
 }
 
@@ -347,13 +359,11 @@ where
                             .entry(key);
 
                         let new_entry = UpsertSourceData {
-                            raw_data: SourceData {
-                                value: new_value.map(ResultExt::err_into),
-                                position: new_position,
-                                // upsert sources don't have a column for this, so setting it to
-                                // `None` is fine.
-                                upstream_time_millis: None,
-                            },
+                            value: new_value.map(ResultExt::err_into),
+                            position: new_position,
+                            // upsert sources don't have a column for this, so setting it to
+                            // `None` is fine.
+                            upstream_time_millis: None,
                             metadata,
                         };
 
@@ -361,7 +371,7 @@ where
                             std::collections::hash_map::Entry::Occupied(mut e) => {
                                 // If the time is equal, toss out the row with the
                                 // lower offset
-                                if e.get().raw_data.position < new_position {
+                                if e.get().position < new_position {
                                     e.insert(new_entry);
                                 }
                             }
@@ -386,7 +396,7 @@ where
                             // we could produce and then remove the error from the output).
                             match key {
                                 Some(Ok(decoded_key)) => {
-                                    let decoded_value = match data.raw_data.value {
+                                    let decoded_value = match data.value {
                                         None => Ok(None),
                                         Some(value) => match value {
                                             Ok(row) => {

--- a/src/dataflow/src/source/file.rs
+++ b/src/dataflow/src/source/file.rs
@@ -91,7 +91,6 @@ impl SourceReader for FileSourceReader {
                         };
                         br.consume(chunk.len());
                         if chunk.len() > 0 {
-                            // `chunk` is always non-empty
                             Some(Ok(MessagePayload::Data(chunk)))
                         } else {
                             None

--- a/src/dataflow/src/source/file.rs
+++ b/src/dataflow/src/source/file.rs
@@ -91,6 +91,7 @@ impl SourceReader for FileSourceReader {
                         };
                         br.consume(chunk.len());
                         if chunk.len() > 0 {
+                            // `chunk` is always non-empty
                             Some(Ok(MessagePayload::Data(chunk)))
                         } else {
                             None

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -140,7 +140,7 @@ where
     /// The record's value
     pub value: V,
     /// The position in the source, if such a concept exists (e.g., Kafka offset, file line number)
-    pub position: Option<i64>,
+    pub position: i64,
     /// The time the record was created in the upstream systsem, as milliseconds since the epoch
     pub upstream_time_millis: Option<i64>,
     /// The partition of this message, present iff the partition comes from Kafka
@@ -155,7 +155,7 @@ pub(crate) struct SourceData {
     /// The source's reported position for this record
     ///
     /// e.g. kafka offset or file location
-    pub(crate) position: Option<i64>,
+    pub(crate) position: i64,
 
     /// The time that the upstream source believes that the message was created
     ///
@@ -171,7 +171,7 @@ pub struct DecodeResult {
     /// The decoded value
     pub value: Option<Result<Row, DecodeError>>,
     /// The index of the decoded value in the stream
-    pub position: Option<i64>,
+    pub position: i64,
     /// The time the record was created in the upstream systsem, as milliseconds since the epoch
     pub upstream_time_millis: Option<i64>,
     /// The partition this record came from
@@ -202,7 +202,7 @@ where
     pub fn new(
         key: K,
         value: V,
-        position: Option<i64>,
+        position: i64,
         upstream_time_millis: Option<i64>,
         partition: PartitionId,
     ) -> SourceOutput<K, V> {
@@ -245,13 +245,7 @@ where
     where
         V: Hashable<Output = u64>,
     {
-        Exchange::new(|x: &Self| {
-            if let Some(position) = x.position {
-                position.hashed()
-            } else {
-                x.value.hashed()
-            }
-        })
+        Exchange::new(|x: &Self| x.position.hashed())
     }
 }
 
@@ -1578,7 +1572,7 @@ fn handle_message<S: SourceReader>(
     output.session(&ts_cap).give(Ok(SourceOutput::new(
         key,
         out,
-        Some(offset.offset),
+        offset.offset,
         message.upstream_time_millis,
         message.partition,
     )));

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -11,7 +11,7 @@
 
 use mz_avro::types::Value;
 use mz_dataflow_types::sources::AwsExternalId;
-use mz_dataflow_types::{DataflowError, DecodeError, SourceErrorDetails};
+use mz_dataflow_types::{DecodeError, SourceErrorDetails};
 use mz_persist::client::{StreamReadHandle, StreamWriteHandle};
 use mz_persist::indexed::Snapshot;
 use mz_persist::operators::stream::Persist;
@@ -145,22 +145,6 @@ where
     pub upstream_time_millis: Option<i64>,
     /// The partition of this message, present iff the partition comes from Kafka
     pub partition: PartitionId,
-}
-
-/// The data that we send from Upsert to the decode process
-#[derive(Debug, Default, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
-pub(crate) struct SourceData {
-    /// The actual value
-    pub(crate) value: Option<Result<Row, DataflowError>>,
-    /// The source's reported position for this record
-    ///
-    /// e.g. kafka offset or file location
-    pub(crate) position: i64,
-
-    /// The time that the upstream source believes that the message was created
-    ///
-    /// Currently only applies to Kafka
-    pub(crate) upstream_time_millis: Option<i64>,
 }
 
 /// The output of the decoding operator

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -139,7 +139,8 @@ where
     pub key: K,
     /// The record's value
     pub value: V,
-    /// The position in the source, if such a concept exists (e.g., Kafka offset, file line number)
+    /// The position in the source (e.g., Kafka offset, file line number, monotonic increasing
+    /// number, etc.)
     pub position: i64,
     /// The time the record was created in the upstream systsem, as milliseconds since the epoch
     pub upstream_time_millis: Option<i64>,

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -139,7 +139,8 @@ where
     pub key: K,
     /// The record's value
     pub value: V,
-    /// The position in the source (e.g., Kafka offset, file line number, monotonic increasing
+    /// The position in the partition described by the `partition` in the source
+    /// (e.g., Kafka offset, file line number, monotonic increasing
     /// number, etc.)
     pub position: i64,
     /// The time the record was created in the upstream systsem, as milliseconds since the epoch

--- a/src/dataflow/src/source/s3.rs
+++ b/src/dataflow/src/source/s3.rs
@@ -756,6 +756,9 @@ where
                 chunks += 1;
                 if tx
                     .send(Ok(InternalMessage {
+                        // ReaderStream return's `None` if the underlying `AsyncRead`
+                        // gives out 0 bytes, so the chunk is always !empty.
+                        // See https://github.com/tokio-rs/tokio/blob/e8f19e771f501408427f7f9ee6ba4f54b2d4094c/tokio-util/src/io/reader_stream.rs#L102-L108
                         record: MessagePayload::Data(chunk.to_vec()),
                     }))
                     .await

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -52,7 +52,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, Hash, PartialEq, Ord, PartialOrd)]
 pub enum MessagePayload {
     /// Data from the source connector.
-    /// The `Vec` should be non-empty.
+    // TODO(guswynn): Determine if `Vec` needs to be non-empty.
     Data(Vec<u8>),
     /// Forces the decoder to consider this a delimiter.
     ///

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -51,7 +51,8 @@ use serde::{Deserialize, Serialize};
 /// The payload delivered by a source connector; either bytes or an EOF marker.
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, Hash, PartialEq, Ord, PartialOrd)]
 pub enum MessagePayload {
-    /// Data from the source connector
+    /// Data from the source connector.
+    /// The `Vec` should be non-empty.
     Data(Vec<u8>),
     /// Forces the decoder to consider this a delimiter.
     ///
@@ -59,10 +60,4 @@ pub enum MessagePayload {
     /// but files might not be newline-terminated; thus we need
     /// the decoder to emit a CSV record when the end of a file is seen.
     EOF,
-}
-
-impl Default for MessagePayload {
-    fn default() -> Self {
-        Self::Data(vec![])
-    }
 }


### PR DESCRIPTION
In upsert, our handling of `position` in the `to_send` map is very weird: we have `SourceData`, which has a `Default` impl, with `position: Option<i64>`, and we rely on the fact that when we are dealing with sources like kafka, we always have a `Some(i64)` in our `DecodeResult`, to figure out if there is already something in the `to_send` map, or if we hit the `or_insert_with_default` case. I found this confusing, and realized that I could actually make `DecodeResult`, `SourceData`, and `SourceOutput` ALWAYS have a non-`None` `position`

One exception was here: https://github.com/MaterializeInc/materialize/blob/2f87f22ab196cb38ccd897bbf5bf9a36ead91295/src/dataflow/src/decode/mod.rs#L549. This callsite is weird, as its not clear this codepath is EVER hit. `to_metadata_row` above: https://github.com/MaterializeInc/materialize/blob/2f87f22ab196cb38ccd897bbf5bf9a36ead91295/src/dataflow/src/decode/mod.rs#L540 would probably ALWAYS panic: https://github.com/MaterializeInc/materialize/blob/2f87f22ab196cb38ccd897bbf5bf9a36ead91295/src/dataflow/src/decode/mod.rs#L670-L673

After some examination, I saw that (and please confirm this) `value` is never empty, as nothing ever contructs a non-empty `MessagePayload::Data`, so I went ahead and made that a constraint


### Motivation

   * This PR refactors existing code.

see above

### Tips for reviewer

bottom pr is the meat of the refactor, and can be reviewed separately if you want!

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
