### PR TITLE
dataflow-types: make more types generic over `Timestamp`

### DIFF
--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -151,7 +151,7 @@ pub enum StorageCommand<T = mz_repr::Timestamp> {
             /* debug_name */ String,
             /* dataflow_id */ GlobalId,
             /* as_of */ Option<Antichain<T>>,
-            /* source_imports*/ BTreeMap<GlobalId, SourceInstanceDesc>,
+            /* source_imports*/ BTreeMap<GlobalId, SourceInstanceDesc<T>>,
         )>,
     ),
     /// Enable compaction in storage-managed collections.


### PR DESCRIPTION
Make a few more types generic over Timestamp. These were discovered when trying to make coordinator generic, but that's larger than I can fix now.

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
