### PR TITLE
Fix typo in JOIN doc

### DIFF
--- a/doc/user/content/sql/join.md
+++ b/doc/user/content/sql/join.md
@@ -6,7 +6,7 @@ menu:
     parent: 'sql'
 ---
 
-`JOIN` lets you combine two more more table expressions into a single table
+`JOIN` lets you combine two or more table expressions into a single table
 expression.
 
 ## Conceptual framework


### PR DESCRIPTION
This PR fixes a typo in the JOIN doc intro.

