### PR TITLE
Add RAISE WARNING (NOTICE, INFO, etc) statement

### DIFF
--- a/src/coord/src/command.rs
+++ b/src/coord/src/command.rs
@@ -20,7 +20,7 @@ use mz_dataflow_types::PeekResponseUnary;
 use mz_expr::GlobalId;
 use mz_ore::str::StrExt;
 use mz_repr::{Row, ScalarType};
-use mz_sql::ast::{FetchDirection, ObjectType, Raw, Statement};
+use mz_sql::ast::{FetchDirection, NoticeSeverity, ObjectType, Raw, Statement};
 use mz_sql::plan::ExecuteTimeout;
 use tokio::sync::watch;
 
@@ -274,6 +274,10 @@ pub enum ExecuteResponse {
     },
     /// The specified number of rows were updated in the requested table.
     Updated(usize),
+    /// Raise a warning.
+    Raise {
+        severity: NoticeSeverity,
+    },
 }
 
 /// The response to [`SessionClient::simple_execute`](crate::SessionClient::simple_execute).

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -146,7 +146,7 @@ use mz_sql::plan::{
     CreateSinkPlan, CreateSourcePlan, CreateTablePlan, CreateTypePlan, CreateViewPlan,
     CreateViewsPlan, DropDatabasePlan, DropItemsPlan, DropRolesPlan, DropSchemaPlan, ExecutePlan,
     ExplainPlan, FetchPlan, HirRelationExpr, IndexOption, IndexOptionName, InsertPlan,
-    MutationKind, Params, PeekPlan, PeekWhen, Plan, ReadThenWritePlan, SendDiffsPlan,
+    MutationKind, Params, PeekPlan, PeekWhen, Plan, RaisePlan, ReadThenWritePlan, SendDiffsPlan,
     SetVariablePlan, ShowVariablePlan, TailFrom, TailPlan,
 };
 use mz_sql::plan::{OptimizerConfig, StatementDesc, View};
@@ -1219,7 +1219,8 @@ impl Coordinator {
                                 | Statement::ShowVariable(_)
                                 | Statement::SetVariable(_)
                                 | Statement::StartTransaction(_)
-                                | Statement::Tail(_) => {
+                                | Statement::Tail(_)
+                                | Statement::Raise(_) => {
                                     // Always safe.
                                 }
 
@@ -2071,6 +2072,9 @@ impl Coordinator {
                     tx.send(Ok(ExecuteResponse::Deallocate { all: true }), session);
                 }
             },
+            Plan::Raise(RaisePlan { severity }) => {
+                tx.send(Ok(ExecuteResponse::Raise { severity }), session);
+            }
         }
     }
 

--- a/src/materialized/tests/pgwire.rs
+++ b/src/materialized/tests/pgwire.rs
@@ -427,7 +427,7 @@ fn test_record_types() -> Result<(), Box<dyn Error>> {
 fn pg_test_inner(dir: PathBuf) -> Result<(), Box<dyn Error>> {
     // We want a new server per file, so we can't use pgtest::walk.
     datadriven::walk(dir.to_str().unwrap(), |tf| {
-        let server = util::start_server(util::Config::default()).unwrap();
+        let server = util::start_server(util::Config::default().experimental_mode()).unwrap();
         let config = server.pg_config();
         let addr = match &config.get_hosts()[0] {
             tokio_postgres::config::Host::Tcp(host) => {

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -322,6 +322,27 @@ impl ErrorResponse {
         ErrorResponse::new(Severity::Warning, code, message)
     }
 
+    pub fn info<S>(code: SqlState, message: S) -> ErrorResponse
+    where
+        S: Into<String>,
+    {
+        ErrorResponse::new(Severity::Info, code, message)
+    }
+
+    pub fn log<S>(code: SqlState, message: S) -> ErrorResponse
+    where
+        S: Into<String>,
+    {
+        ErrorResponse::new(Severity::Log, code, message)
+    }
+
+    pub fn debug<S>(code: SqlState, message: S) -> ErrorResponse
+    where
+        S: Into<String>,
+    {
+        ErrorResponse::new(Severity::Debug, code, message)
+    }
+
     fn new<S>(severity: Severity, code: SqlState, message: S) -> ErrorResponse
     where
         S: Into<String>,

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -74,6 +74,7 @@ pub enum Statement<T: AstInfo> {
     Prepare(PrepareStatement<T>),
     Execute(ExecuteStatement<T>),
     Deallocate(DeallocateStatement),
+    Raise(RaiseStatement),
 }
 
 impl<T: AstInfo> AstDisplay for Statement<T> {
@@ -122,6 +123,7 @@ impl<T: AstInfo> AstDisplay for Statement<T> {
             Statement::Prepare(stmt) => f.write_node(stmt),
             Statement::Execute(stmt) => f.write_node(stmt),
             Statement::Deallocate(stmt) => f.write_node(stmt),
+            Statement::Raise(stmt) => f.write_node(stmt),
         }
     }
 }
@@ -1760,3 +1762,39 @@ impl AstDisplay for DeallocateStatement {
     }
 }
 impl_display!(DeallocateStatement);
+
+/// `RAISE ...`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RaiseStatement {
+    pub severity: NoticeSeverity,
+}
+
+impl AstDisplay for RaiseStatement {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        f.write_str("RAISE ");
+        f.write_node(&self.severity);
+    }
+}
+impl_display!(RaiseStatement);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum NoticeSeverity {
+    Debug,
+    Info,
+    Log,
+    Notice,
+    Warning,
+}
+
+impl AstDisplay for NoticeSeverity {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        f.write_str(match self {
+            NoticeSeverity::Debug => "DEBUG",
+            NoticeSeverity::Info => "INFO",
+            NoticeSeverity::Log => "LOG",
+            NoticeSeverity::Notice => "NOTICE",
+            NoticeSeverity::Warning => "WARNING",
+        })
+    }
+}
+impl_display!(NoticeSeverity);

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -76,6 +76,7 @@ Day
 Days
 Deallocate
 Debezium
+Debug
 Dec
 Decimal
 Declare
@@ -132,6 +133,7 @@ In
 Include
 Index
 Indexes
+Info
 Inner
 Insert
 Int
@@ -157,6 +159,7 @@ Like
 Limit
 List
 Local
+Log
 Login
 Map
 Matching
@@ -175,6 +178,7 @@ Nologin
 None
 Nosuperuser
 Not
+Notice
 Notifications
 Null
 Nullif
@@ -206,6 +210,7 @@ Protobuf
 Publication
 Pubnub
 Query
+Raise
 Range
 Raw
 Read
@@ -289,6 +294,7 @@ Varchar
 Varying
 View
 Views
+Warning
 When
 Where
 With

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -41,7 +41,7 @@ use mz_ore::now::{self, NOW_ZERO};
 use mz_repr::{ColumnName, Diff, RelationDesc, Row, ScalarType};
 
 use crate::ast::{
-    ExplainOptions, ExplainStage, Expr, FetchDirection, ObjectType, Raw, Statement,
+    ExplainOptions, ExplainStage, Expr, FetchDirection, NoticeSeverity, ObjectType, Raw, Statement,
     TransactionAccessMode,
 };
 use crate::catalog::CatalogType;
@@ -112,6 +112,7 @@ pub enum Plan {
     Prepare(PreparePlan),
     Execute(ExecutePlan),
     Deallocate(DeallocatePlan),
+    Raise(RaisePlan),
 }
 
 #[derive(Debug)]
@@ -358,6 +359,11 @@ pub struct ExecutePlan {
 #[derive(Debug)]
 pub struct DeallocatePlan {
     pub name: Option<String>,
+}
+
+#[derive(Debug)]
+pub struct RaisePlan {
+    pub severity: NoticeSeverity,
 }
 
 #[derive(Clone, Debug)]

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -32,6 +32,7 @@ use crate::plan::{Params, Plan, PlanContext};
 
 mod ddl;
 mod dml;
+mod raise;
 mod scl;
 mod show;
 mod tcl;
@@ -152,6 +153,9 @@ pub fn describe(
         Statement::SetTransaction(stmt) => tcl::describe_set_transaction(&scx, stmt)?,
         Statement::Rollback(stmt) => tcl::describe_rollback(&scx, stmt)?,
         Statement::Commit(stmt) => tcl::describe_commit(&scx, stmt)?,
+
+        // RAISE statements.
+        Statement::Raise(stmt) => raise::describe_raise(&scx, stmt)?,
     };
 
     let desc = desc.with_params(scx.finalize_param_types()?);
@@ -239,6 +243,9 @@ pub fn plan(
         Statement::SetTransaction(stmt) => tcl::plan_set_transaction(scx, stmt),
         Statement::Rollback(stmt) => tcl::plan_rollback(scx, stmt),
         Statement::Commit(stmt) => tcl::plan_commit(scx, stmt),
+
+        // RAISE statements.
+        Statement::Raise(stmt) => raise::plan_raise(scx, stmt),
     }
 }
 

--- a/src/sql/src/plan/statement/raise.rs
+++ b/src/sql/src/plan/statement/raise.rs
@@ -1,0 +1,31 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Queries that send notices/errors to the client
+//!
+//! This module houses the handlers for the `RAISE` suite of statements, like
+//! `RAISE WARNING` and `RAISE INFO`.
+
+use crate::ast::RaiseStatement;
+use crate::plan::statement::{StatementContext, StatementDesc};
+use crate::plan::{Plan, RaisePlan};
+
+pub fn describe_raise(
+    _: &StatementContext,
+    _: RaiseStatement,
+) -> Result<StatementDesc, anyhow::Error> {
+    Ok(StatementDesc::new(None))
+}
+
+pub fn plan_raise(scx: &StatementContext, r: RaiseStatement) -> Result<Plan, anyhow::Error> {
+    scx.require_experimental_mode("RAISE statement")?;
+    Ok(Plan::Raise(RaisePlan {
+        severity: r.severity,
+    }))
+}

--- a/test/pgtest-mz/raise.pt
+++ b/test/pgtest-mz/raise.pt
@@ -1,0 +1,69 @@
+# Test that the RAISE statement sends messages with the correct severity.
+
+# Ensure all severity levels are actually sent to the client
+send
+Query {"query": "SET client_min_messages TO DEBUG"}
+----
+
+until
+ReadyForQuery
+----
+CommandComplete {"tag":"SET"}
+ReadyForQuery {"status":"I"}
+
+
+send
+Query {"query": "RAISE DEBUG"}
+----
+
+until err_field_typs=S
+CommandComplete
+ReadyForQuery
+----
+NoticeResponse {"fields":[{"typ":"S","value":"DEBUG"}]}
+CommandComplete {"tag":"RAISE"}
+ReadyForQuery {"status":"I"}
+
+send
+Query {"query": "RAISE INFO"}
+----
+
+until err_field_typs=S
+ReadyForQuery
+----
+NoticeResponse {"fields":[{"typ":"S","value":"INFO"}]}
+CommandComplete {"tag":"RAISE"}
+ReadyForQuery {"status":"I"}
+
+send
+Query {"query": "RAISE LOG"}
+----
+
+until err_field_typs=S
+ReadyForQuery
+----
+NoticeResponse {"fields":[{"typ":"S","value":"LOG"}]}
+CommandComplete {"tag":"RAISE"}
+ReadyForQuery {"status":"I"}
+
+send
+Query {"query": "RAISE NOTICE"}
+----
+
+until err_field_typs=S
+ReadyForQuery
+----
+NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"}]}
+CommandComplete {"tag":"RAISE"}
+ReadyForQuery {"status":"I"}
+
+send
+Query {"query": "RAISE WARNING"}
+----
+
+until err_field_typs=S
+ReadyForQuery
+----
+NoticeResponse {"fields":[{"typ":"S","value":"WARNING"}]}
+CommandComplete {"tag":"RAISE"}
+ReadyForQuery {"status":"I"}


### PR DESCRIPTION
This is a quick proposal for adding a new kind of statement, `RAISE WARNING[|NOTICE|INFO|LOG|DEBUG]`, inspired by the [PL/pgSQL RAISE statement](https://www.postgresql.org/docs/current/plpgsql-errors-and-messages.html), that is able to send informational messages to the client.

I'm not intending for this to be publicly documented, but to be used internally as an easy way to send WARNING/NOTICE/LOG/INFO/DEBUG messages to clients to do #10839. This statement is only available under experimental mode, with no plans to remove that restriction.

This PR is now in its final state, with all intended features implemented.

### Motivation

  * This PR helps with getting #10839 done.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
