### PR TITLE
Unify 'drop' and 'compact to empty frontier'

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1612,7 +1612,7 @@ impl Coordinator {
             self.persisted_table_allow_compaction(&source_since_updates);
             self.dataflow_client
                 .storage()
-                .allow_source_compaction(source_since_updates)
+                .allow_compaction(source_since_updates)
                 .await
                 .unwrap();
         }
@@ -4162,7 +4162,8 @@ impl Coordinator {
                 self.dataflow_client
                     .storage()
                     .drop_sources(sources_to_drop)
-                    .await;
+                    .await
+                    .unwrap();
             }
             if !tables_to_drop.is_empty() {
                 // NOTE: When creating a persistent table we insert its compaction frontier (aka since)
@@ -4175,7 +4176,8 @@ impl Coordinator {
                 self.dataflow_client
                     .storage()
                     .drop_sources(tables_to_drop)
-                    .await;
+                    .await
+                    .unwrap();
             }
             if !sinks_to_drop.is_empty() {
                 for id in sinks_to_drop.iter() {

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -61,6 +61,7 @@ pub enum ComputeCommand<T = mz_repr::Timestamp> {
     CreateInstance(Option<LoggingConfig>),
     /// Indicates the termination of an instance, and is the last command for its compute instance.
     DropInstance,
+
     /// Create a sequence of dataflows.
     ///
     /// Each of the dataflows must contain `as_of` members that are valid
@@ -70,10 +71,12 @@ pub enum ComputeCommand<T = mz_repr::Timestamp> {
     /// the dataflow runners are responsible for ensuring that they can
     /// correctly maintain the dataflows.
     CreateDataflows(Vec<DataflowDescription<crate::plan::Plan, T>>),
-    /// Drop the sinks bound to these names.
-    DropSinks(Vec<GlobalId>),
-    /// Drop the indexes bound to these namees.
-    DropIndexes(Vec<GlobalId>),
+    /// Enable compaction in compute-managed collections.
+    ///
+    /// Each entry in the vector names a collection and provides a frontier after which
+    /// accumulations must be correct. The workers gain the liberty of compacting
+    /// the corresponding maintained traces up through that frontier.
+    AllowCompaction(Vec<(GlobalId, Antichain<T>)>),
 
     /// Peek at an arrangement.
     ///
@@ -108,13 +111,6 @@ pub enum ComputeCommand<T = mz_repr::Timestamp> {
         /// The identifier of the peek request to cancel.
         conn_id: u32,
     },
-    /// Enable compaction in views.
-    ///
-    /// Each entry in the vector names a view and provides a frontier after which
-    /// accumulations must be correct. The workers gain the liberty of compacting
-    /// the corresponding maintained traces up through that frontier.
-    // TODO: Could be called `AllowTraceCompaction` or `AllowArrangementCompaction`?
-    AllowIndexCompaction(Vec<(GlobalId, Antichain<T>)>),
 }
 
 impl ComputeCommandKind {
@@ -126,11 +122,9 @@ impl ComputeCommandKind {
             // TODO: This breaks metrics. Not sure that's a problem.
             ComputeCommandKind::CreateInstance => "create_instance",
             ComputeCommandKind::DropInstance => "drop_instance",
-            ComputeCommandKind::AllowIndexCompaction => "allow_index_compaction",
+            ComputeCommandKind::AllowCompaction => "allow_compute_compaction",
             ComputeCommandKind::CancelPeek => "cancel_peek",
             ComputeCommandKind::CreateDataflows => "create_dataflows",
-            ComputeCommandKind::DropIndexes => "drop_indexes",
-            ComputeCommandKind::DropSinks => "drop_sinks",
             ComputeCommandKind::Peek => "peek",
         }
     }
@@ -159,8 +153,11 @@ pub enum StorageCommand<T = mz_repr::Timestamp> {
             BTreeMap<GlobalId, SourceInstanceDesc>,
         )>,
     ),
-    /// Drop the sources bound to these names.
-    DropSources(Vec<GlobalId>),
+    /// Enable compaction in storage-managed collections.
+    ///
+    /// Each entry in the vector names a collection and provides a frontier after which
+    /// accumulations must be correct.
+    AllowCompaction(Vec<(GlobalId, Antichain<T>)>),
 
     /// Insert `updates` into the local input named `id`.
     Insert {
@@ -184,11 +181,6 @@ pub enum StorageCommand<T = mz_repr::Timestamp> {
         /// Previously stored timestamp bindings.
         bindings: Vec<(PartitionId, T, crate::sources::MzOffset)>,
     },
-    /// Enable compaction in sources.
-    ///
-    /// Each entry in the vector names a source and provides a frontier after which
-    /// accumulations must be correct.
-    AllowSourceCompaction(Vec<(GlobalId, Antichain<T>)>),
     /// Drop all timestamping info for a source
     DropSourceTimestamping {
         /// The ID id of the formerly timestamped source.
@@ -210,9 +202,8 @@ impl StorageCommandKind {
             StorageCommandKind::AddSourceTimestamping => "add_source_timestamping",
             StorageCommandKind::AdvanceAllLocalInputs => "advance_all_local_inputs",
             StorageCommandKind::DropSourceTimestamping => "drop_source_timestamping",
-            StorageCommandKind::AllowSourceCompaction => "allows_source_compaction",
+            StorageCommandKind::AllowCompaction => "allows_storage_compaction",
             StorageCommandKind::CreateSources => "create_sources",
-            StorageCommandKind::DropSources => "drop_sources",
             StorageCommandKind::DurabilityFrontierUpdates => "durability_frontier_updates",
             StorageCommandKind::Insert => "insert",
             StorageCommandKind::RenderSources => "render_sources",
@@ -303,14 +294,11 @@ impl<T: timely::progress::Timestamp> Command<T> {
                     }
                 }
             }
-            Command::Compute(ComputeCommand::DropIndexes(index_ids), _instance) => {
-                for id in index_ids.iter() {
-                    cease.push(*id);
-                }
-            }
-            Command::Compute(ComputeCommand::DropSinks(sink_ids), _instance) => {
-                for id in sink_ids.iter() {
-                    cease.push(*id);
+            Command::Compute(ComputeCommand::AllowCompaction(frontiers), _instance) => {
+                for (id, frontier) in frontiers.iter() {
+                    if frontier.is_empty() {
+                        cease.push(*id);
+                    }
                 }
             }
             Command::Storage(StorageCommand::AddSourceTimestamping { id, .. }) => {

--- a/src/dataflow-types/src/client/controller/compute.rs
+++ b/src/dataflow-types/src/client/controller/compute.rs
@@ -142,51 +142,26 @@ impl<'a, C: Client<T>, T: Timestamp + Lattice> ComputeController<'a, C, T> {
 
         Ok(())
     }
-    pub async fn drop_sinks(
-        &mut self,
-        sink_identifiers: Vec<GlobalId>,
-    ) -> Result<(), ComputeError> {
+    pub async fn drop_sinks(&mut self, identifiers: Vec<GlobalId>) -> Result<(), ComputeError> {
         // Validate that the ids exist.
-        self.validate_ids(sink_identifiers.iter().cloned())?;
+        self.validate_ids(identifiers.iter().cloned())?;
 
-        for id in sink_identifiers.iter() {
-            // Apply the updates but ignore the results for now.
-            // TODO(mcsherry): observe the results and allow compaction.
-            let _ = self
-                .collection_mut(*id)?
-                .capability_downgrade(Antichain::new());
-        }
-        self.client
-            .send(Command::Compute(
-                ComputeCommand::DropSinks(sink_identifiers),
-                self.instance,
-            ))
-            .await;
-
+        let compaction_commands = identifiers
+            .into_iter()
+            .map(|id| (id, Antichain::new()))
+            .collect();
+        self.allow_index_compaction(compaction_commands).await;
         Ok(())
     }
-    pub async fn drop_indexes(
-        &mut self,
-        index_identifiers: Vec<GlobalId>,
-    ) -> Result<(), ComputeError> {
+    pub async fn drop_indexes(&mut self, identifiers: Vec<GlobalId>) -> Result<(), ComputeError> {
         // Validate that the ids exist.
-        self.validate_ids(index_identifiers.iter().cloned())?;
+        self.validate_ids(identifiers.iter().cloned())?;
 
-        for id in index_identifiers.iter() {
-            // Apply the updates but ignore the results for now.
-            // TODO(mcsherry): observe the results and allow compaction.
-            let _ = self
-                .collection_mut(*id)?
-                .capability_downgrade(Antichain::new());
-        }
-
-        self.client
-            .send(Command::Compute(
-                ComputeCommand::DropIndexes(index_identifiers),
-                self.instance,
-            ))
-            .await;
-
+        let compaction_commands = identifiers
+            .into_iter()
+            .map(|id| (id, Antichain::new()))
+            .collect();
+        self.allow_index_compaction(compaction_commands).await;
         Ok(())
     }
     pub async fn peek(
@@ -248,7 +223,7 @@ impl<'a, C: Client<T>, T: Timestamp + Lattice> ComputeController<'a, C, T> {
 
         self.client
             .send(Command::Compute(
-                ComputeCommand::AllowIndexCompaction(frontiers),
+                ComputeCommand::AllowCompaction(frontiers),
                 self.instance,
             ))
             .await;


### PR DESCRIPTION
This PR unifies the behavior of "dropping" a collection and "allowing compaction to the empty frontier". These were two concepts before, the latter never used, but logically being the same (when a collection is compacted to the empty frontier it cannot be read at any times, and .. is fit for dropping).

Externally, the methods `drop_sources`, `drop_indexes`, and `drop_sinks` still exist, but internally they have the effect of advancing the compaction frontier to the empty set, which has the effect of invoking the drop logic. The only intended observable difference is that advancing a compaction frontier to the empty set will now result in an observable retraction of the the associated dataflow identifier from introspection, whereas previously it would linger until drop was subsequently called. 

The change is primarily to make abstractions narrower and clearer, though there is at least one behavioral change: on drops sinks now remove their frontier time from the logging infrastructure, just as indexes do. I .. think they also insert it when they are created, and this should be a "fix", but I need to find a better way to confirm this (just doing CI now to see if it upsets any tests).

### Motivation

   * This PR refactors existing code.

Distinguishing between "dropped" and "present, but unreadable" appears to be unhelpful, and complicates state machine logic elsewhere if we need to work hard to maintain the distinction.

### Tips for reviewer

I'd like to find a sink expert (@cjubb39 ?) to comment on whether the frontier tracking changes checks out, and whether sinks log their upper frontiers out to the logging infra in the same way that indexes do (I couldn't find any way they distinguished themselves, and concluded that it must be the same, but I'm happy to be wrong).

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
