### PR TITLE
update `rr` image to latest version with multi-arch support + fix rm paths

### DIFF
--- a/doc/user/sql-grammar/generate.sh
+++ b/doc/user/sql-grammar/generate.sh
@@ -22,14 +22,14 @@ rm -rf scratch
 
 # Run the railroad diagram generator, using a pinned version from our custom
 # fork.
-docker run --rm -i materialize/rr:0.0.4 -nostyles -svg -noinline -width:600 - < sql-grammar.bnf > diagrams.zip
+docker run --rm -i materialize/rr:v0.0.5 -nostyles -svg -noinline -width:600 - < sql-grammar.bnf > diagrams.zip
 
 # Extract the SVGs we care about and move them into place.
 mkdir scratch
 (
     cd scratch
     unzip -j ../diagrams.zip
-    rm ./diagrams.zip rr-1.62.svg index.html
+    rm ../diagrams.zip Railroad-Diagram-Generator.svg index.html
     for f in *; do
         # Rewrite any underscores in filenames to hyphens, for consistency with
         # other Hugo partials.


### PR DESCRIPTION
Generating railroad diagrams was hanging/crashing on an M1, so this bumps the version to a new tag that has both amd64 and arm64 images.

Also updated a teensy bit of the extraction logic. TBH I'm not entirely sure how it was working before.

@benesch @morsapaes 