### PR TITLE
 docs: update CREATE TYPE with named composite types

### DIFF
--- a/doc/user/content/sql/create-type.md
+++ b/doc/user/content/sql/create-type.md
@@ -49,7 +49,7 @@ Field | Use
 
 ### `map` properties
 
-Name | Use
+Field | Use
 -----|-----
 `key_type` | Creates a custom [`map`](../types/map) whose keys are of `key_type`. `key_type` must resolve to [`text`](../types/text).
 `value_type` | Creates a custom [`map`](../types/map) whose values are of `value_type`.

--- a/doc/user/content/sql/create-type.md
+++ b/doc/user/content/sql/create-type.md
@@ -43,7 +43,7 @@ _field_type_        | The data type of a field indicated by _field_name_.
 
 ### `list` properties
 
-Name | Use
+Field | Use
 -----|-----
 `element_type` | Creates a custom [`list`](../types/list) whose elements are of `element_type`.
 

--- a/doc/user/content/sql/create-type.md
+++ b/doc/user/content/sql/create-type.md
@@ -28,10 +28,14 @@ encoding and decoding][binary] for these types, as well.
 
 {{< diagram "create-type.svg" >}}
 
-Field | Use
-------|-----
-_type&lowbar;name_ | A name for the type.
-_field_ **=** _val_ | A property of the new type. Note that type properties can only refer to data types within the catalog, i.e. they cannot refer to anonymous `list` or `map` types.
+ Field               | Use
+---------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ _type&lowbar;name_  | A name for the type.
+ **MAP / LIST**      | The data type. If not specified, a row type is assumed.
+ _field_ **=** _val_ | A property of the new type. This is required when specifying a `LIST` or `MAP` type. Note that type properties can only refer to data types within the catalog, i.e. they cannot refer to anonymous `list` or `map` types.
+ _field_name_        | The name of a field in a row type.
+ _field_type_        | The data type of a field indicated by _field_name_.
+
 
 ### `list` properties
 
@@ -112,6 +116,18 @@ SELECT '{a=>{a=>1}}'::int4_map_map::text AS custom_nested_map;
  custom_nested_map
 -------------------
 {a=>{a=>1}}
+```
+
+### Custom `row` type
+```sql
+CREATE TYPE row_type AS (a int, b text);
+SELECT ROW(1, 'a')::row_type;
+```
+
+### Nested `row` type
+```sql
+CREATE TYPE nested_row_type AS (a row_type, b float8);
+SELECT ROW(ROW(1, 'a'), 2.3)::nested_row_type;
 ```
 
 ## Related pages

--- a/doc/user/content/sql/create-type.md
+++ b/doc/user/content/sql/create-type.md
@@ -32,23 +32,27 @@ encoding and decoding][binary] for these types, as well.
 ---------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------
  _type&lowbar;name_  | A name for the type.
  **MAP / LIST**      | The data type. If not specified, a row type is assumed.
- _field_ **=** _val_ | A property of the new type. This is required when specifying a `LIST` or `MAP` type. Note that type properties can only refer to data types within the catalog, i.e. they cannot refer to anonymous `list` or `map` types.
- _field_name_        | The name of a field in a row type.
- _field_type_        | The data type of a field indicated by _field_name_.
+ _property_ **=** _val_ | A property of the new type. This is required when specifying a `LIST` or `MAP` type. Note that type properties can only refer to data types within the catalog, i.e. they cannot refer to anonymous `list` or `map` types.
 
+### `row` properties
+
+Field               | Use
+--------------------|----------------------------------------------------
+_field_name_        | The name of a field in a row type.
+_field_type_        | The data type of a field indicated by _field_name_.
 
 ### `list` properties
 
 Name | Use
 -----|-----
-`element_type` | Creates a custom [`list`](../types/list) whose elements are are of `element_type`.
+`element_type` | Creates a custom [`list`](../types/list) whose elements are of `element_type`.
 
 ### `map` properties
 
 Name | Use
 -----|-----
-`key_type` | Creates a custom [`map`](../types/map) whose keys are are of `key_type`. `key_type` must resolve to [`text`](../types/text).
-`value_type` | Creates a custom [`map`](../types/map) whose values are are of `value_type`.
+`key_type` | Creates a custom [`map`](../types/map) whose keys are of `key_type`. `key_type` must resolve to [`text`](../types/text).
+`value_type` | Creates a custom [`map`](../types/map) whose values are of `value_type`.
 
 ## Details
 
@@ -121,13 +125,23 @@ SELECT '{a=>{a=>1}}'::int4_map_map::text AS custom_nested_map;
 ### Custom `row` type
 ```sql
 CREATE TYPE row_type AS (a int, b text);
-SELECT ROW(1, 'a')::row_type;
+SELECT ROW(1, 'a')::row_type as custom_row_type;
+```
+```
+custom_row_type
+-----------------
+(1,a)
 ```
 
 ### Nested `row` type
 ```sql
 CREATE TYPE nested_row_type AS (a row_type, b float8);
-SELECT ROW(ROW(1, 'a'), 2.3)::nested_row_type;
+SELECT ROW(ROW(1, 'a'), 2.3)::nested_row_type AS custom_nested_row_type;
+```
+```
+custom_nested_row_type
+------------------------
+("(1,a)",2.3)
 ```
 
 ## Related pages

--- a/doc/user/layouts/partials/sql-grammar/create-type.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-type.svg
@@ -1,89 +1,111 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="535" height="191">
-   <polygon points="9 17 1 13 1 21"/>
-   <polygon points="17 17 9 13 9 21"/>
-   <rect x="31" y="3" width="76" height="32" rx="10"/>
-   <rect x="29"
+<svg xmlns="http://www.w3.org/2000/svg" width="491" height="279">
+   <polygon points="11 17 3 13 3 21"/>
+   <polygon points="19 17 11 13 11 21"/>
+   <rect x="33" y="3" width="76" height="32" rx="10"/>
+   <rect x="31"
          y="1"
          width="76"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="39" y="21">CREATE</text>
-   <rect x="127" y="3" width="56" height="32" rx="10"/>
-   <rect x="125"
+   <text class="terminal" x="41" y="21">CREATE</text>
+   <rect x="129" y="3" width="56" height="32" rx="10"/>
+   <rect x="127"
          y="1"
          width="56"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="135" y="21">TYPE</text>
-   <rect x="203" y="3" width="92" height="32"/>
-   <rect x="201" y="1" width="92" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="211" y="21">type_name</text>
-   <rect x="315" y="3" width="40" height="32" rx="10"/>
-   <rect x="313"
+   <text class="terminal" x="137" y="21">TYPE</text>
+   <rect x="205" y="3" width="92" height="32"/>
+   <rect x="203" y="1" width="92" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="213" y="21">type_name</text>
+   <rect x="317" y="3" width="40" height="32" rx="10"/>
+   <rect x="315"
          y="1"
          width="40"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="323" y="21">AS</text>
-   <rect x="395" y="3" width="50" height="32" rx="10"/>
-   <rect x="393"
-         y="1"
+   <text class="terminal" x="325" y="21">AS</text>
+   <rect x="65" y="113" width="50" height="32" rx="10"/>
+   <rect x="63"
+         y="111"
          width="50"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="403" y="21">LIST</text>
-   <rect x="395" y="47" width="52" height="32" rx="10"/>
-   <rect x="393"
-         y="45"
+   <text class="terminal" x="73" y="131">LIST</text>
+   <rect x="65" y="157" width="52" height="32" rx="10"/>
+   <rect x="63"
+         y="155"
          width="52"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="403" y="65">MAP</text>
-   <rect x="487" y="3" width="26" height="32" rx="10"/>
-   <rect x="485"
-         y="1"
+   <text class="terminal" x="73" y="175">MAP</text>
+   <rect x="157" y="113" width="26" height="32" rx="10"/>
+   <rect x="155"
+         y="111"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="495" y="21">(</text>
-   <rect x="287" y="157" width="48" height="32"/>
-   <rect x="285" y="155" width="48" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="295" y="175">field</text>
-   <rect x="355" y="157" width="28" height="32" rx="10"/>
-   <rect x="353"
-         y="155"
+   <text class="terminal" x="165" y="131">(</text>
+   <rect x="223" y="113" width="48" height="32"/>
+   <rect x="221" y="111" width="48" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="231" y="131">field</text>
+   <rect x="291" y="113" width="28" height="32" rx="10"/>
+   <rect x="289"
+         y="111"
          width="28"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="363" y="175">=</text>
-   <rect x="403" y="157" width="38" height="32"/>
-   <rect x="401" y="155" width="38" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="411" y="175">val</text>
-   <rect x="287" y="113" width="24" height="32" rx="10"/>
-   <rect x="285"
-         y="111"
+   <text class="terminal" x="299" y="131">=</text>
+   <rect x="339" y="113" width="38" height="32"/>
+   <rect x="337" y="111" width="38" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="347" y="131">val</text>
+   <rect x="223" y="69" width="24" height="32" rx="10"/>
+   <rect x="221"
+         y="67"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="295" y="131">,</text>
-   <rect x="481" y="157" width="26" height="32" rx="10"/>
-   <rect x="479"
-         y="155"
+   <text class="terminal" x="231" y="87">,</text>
+   <rect x="45" y="245" width="26" height="32" rx="10"/>
+   <rect x="43"
+         y="243"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="489" y="175">)</text>
+   <text class="terminal" x="53" y="263">(</text>
+   <rect x="111" y="245" width="90" height="32"/>
+   <rect x="109" y="243" width="90" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="119" y="263">field_name</text>
+   <rect x="221" y="245" width="84" height="32"/>
+   <rect x="219" y="243" width="84" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="229" y="263">field_type</text>
+   <rect x="111" y="201" width="24" height="32" rx="10"/>
+   <rect x="109"
+         y="199"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="119" y="219">,</text>
+   <rect x="437" y="113" width="26" height="32" rx="10"/>
+   <rect x="435"
+         y="111"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="445" y="131">)</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m76 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m92 0 h10 m0 0 h10 m40 0 h10 m20 0 h10 m50 0 h10 m0 0 h2 m-92 0 h20 m72 0 h20 m-112 0 q10 0 10 10 m92 0 q0 -10 10 -10 m-102 10 v24 m92 0 v-24 m-92 24 q0 10 10 10 m72 0 q10 0 10 -10 m-82 10 h10 m52 0 h10 m20 -44 h10 m26 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-290 154 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m48 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m38 0 h10 m-194 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m174 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-174 0 h10 m24 0 h10 m0 0 h130 m20 44 h10 m26 0 h10 m3 0 h-3"/>
-   <polygon points="525 171 533 167 533 175"/>
-   <polygon points="525 171 517 167 517 175"/>
+         d="m19 17 h2 m0 0 h10 m76 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m92 0 h10 m0 0 h10 m40 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-376 110 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m50 0 h10 m0 0 h2 m-92 0 h20 m72 0 h20 m-112 0 q10 0 10 10 m92 0 q0 -10 10 -10 m-102 10 v24 m92 0 v-24 m-92 24 q0 10 10 10 m72 0 q10 0 10 -10 m-82 10 h10 m52 0 h10 m20 -44 h10 m26 0 h10 m20 0 h10 m48 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m38 0 h10 m-194 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m174 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-174 0 h10 m24 0 h10 m0 0 h130 m-372 44 h20 m372 0 h20 m-412 0 q10 0 10 10 m392 0 q0 -10 10 -10 m-402 10 v112 m392 0 v-112 m-392 112 q0 10 10 10 m372 0 q10 0 10 -10 m-382 10 h10 m26 0 h10 m20 0 h10 m90 0 h10 m0 0 h10 m84 0 h10 m-234 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m214 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-214 0 h10 m24 0 h10 m0 0 h170 m20 44 h72 m20 -132 h10 m26 0 h10 m3 0 h-3"/>
+   <polygon points="481 127 489 123 489 131"/>
+   <polygon points="481 127 473 123 473 131"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/create-type.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-type.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="491" height="279">
+<svg xmlns="http://www.w3.org/2000/svg" width="519" height="279">
    <polygon points="11 17 3 13 3 21"/>
    <polygon points="19 17 11 13 11 21"/>
    <rect x="33" y="3" width="76" height="32" rx="10"/>
@@ -28,84 +28,84 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="325" y="21">AS</text>
-   <rect x="65" y="113" width="50" height="32" rx="10"/>
-   <rect x="63"
-         y="111"
-         width="50"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="73" y="131">LIST</text>
-   <rect x="65" y="157" width="52" height="32" rx="10"/>
-   <rect x="63"
-         y="155"
-         width="52"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="73" y="175">MAP</text>
-   <rect x="157" y="113" width="26" height="32" rx="10"/>
-   <rect x="155"
+   <rect x="45" y="113" width="26" height="32" rx="10"/>
+   <rect x="43"
          y="111"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="165" y="131">(</text>
-   <rect x="223" y="113" width="48" height="32"/>
-   <rect x="221" y="111" width="48" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="231" y="131">field</text>
-   <rect x="291" y="113" width="28" height="32" rx="10"/>
-   <rect x="289"
-         y="111"
-         width="28"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="299" y="131">=</text>
-   <rect x="339" y="113" width="38" height="32"/>
-   <rect x="337" y="111" width="38" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="347" y="131">val</text>
-   <rect x="223" y="69" width="24" height="32" rx="10"/>
-   <rect x="221"
+   <text class="terminal" x="53" y="131">(</text>
+   <rect x="111" y="113" width="90" height="32"/>
+   <rect x="109" y="111" width="90" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="119" y="131">field_name</text>
+   <rect x="221" y="113" width="84" height="32"/>
+   <rect x="219" y="111" width="84" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="229" y="131">field_type</text>
+   <rect x="111" y="69" width="24" height="32" rx="10"/>
+   <rect x="109"
          y="67"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="231" y="87">,</text>
-   <rect x="45" y="245" width="26" height="32" rx="10"/>
-   <rect x="43"
+   <text class="terminal" x="119" y="87">,</text>
+   <rect x="65" y="201" width="50" height="32" rx="10"/>
+   <rect x="63"
+         y="199"
+         width="50"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="73" y="219">LIST</text>
+   <rect x="65" y="245" width="52" height="32" rx="10"/>
+   <rect x="63"
          y="243"
+         width="52"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="73" y="263">MAP</text>
+   <rect x="157" y="201" width="26" height="32" rx="10"/>
+   <rect x="155"
+         y="199"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="53" y="263">(</text>
-   <rect x="111" y="245" width="90" height="32"/>
-   <rect x="109" y="243" width="90" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="119" y="263">field_name</text>
-   <rect x="221" y="245" width="84" height="32"/>
-   <rect x="219" y="243" width="84" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="229" y="263">field_type</text>
-   <rect x="111" y="201" width="24" height="32" rx="10"/>
-   <rect x="109"
+   <text class="terminal" x="165" y="219">(</text>
+   <rect x="223" y="201" width="76" height="32"/>
+   <rect x="221" y="199" width="76" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="231" y="219">property</text>
+   <rect x="319" y="201" width="28" height="32" rx="10"/>
+   <rect x="317"
          y="199"
+         width="28"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="327" y="219">=</text>
+   <rect x="367" y="201" width="38" height="32"/>
+   <rect x="365" y="199" width="38" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="375" y="219">val</text>
+   <rect x="223" y="157" width="24" height="32" rx="10"/>
+   <rect x="221"
+         y="155"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="119" y="219">,</text>
-   <rect x="437" y="113" width="26" height="32" rx="10"/>
-   <rect x="435"
+   <text class="terminal" x="231" y="175">,</text>
+   <rect x="465" y="113" width="26" height="32" rx="10"/>
+   <rect x="463"
          y="111"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="445" y="131">)</text>
+   <text class="terminal" x="473" y="131">)</text>
    <path class="line"
-         d="m19 17 h2 m0 0 h10 m76 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m92 0 h10 m0 0 h10 m40 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-376 110 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m50 0 h10 m0 0 h2 m-92 0 h20 m72 0 h20 m-112 0 q10 0 10 10 m92 0 q0 -10 10 -10 m-102 10 v24 m92 0 v-24 m-92 24 q0 10 10 10 m72 0 q10 0 10 -10 m-82 10 h10 m52 0 h10 m20 -44 h10 m26 0 h10 m20 0 h10 m48 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m38 0 h10 m-194 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m174 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-174 0 h10 m24 0 h10 m0 0 h130 m-372 44 h20 m372 0 h20 m-412 0 q10 0 10 10 m392 0 q0 -10 10 -10 m-402 10 v112 m392 0 v-112 m-392 112 q0 10 10 10 m372 0 q10 0 10 -10 m-382 10 h10 m26 0 h10 m20 0 h10 m90 0 h10 m0 0 h10 m84 0 h10 m-234 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m214 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-214 0 h10 m24 0 h10 m0 0 h170 m20 44 h72 m20 -132 h10 m26 0 h10 m3 0 h-3"/>
-   <polygon points="481 127 489 123 489 131"/>
-   <polygon points="481 127 473 123 473 131"/>
+         d="m19 17 h2 m0 0 h10 m76 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m92 0 h10 m0 0 h10 m40 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-376 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m26 0 h10 m20 0 h10 m90 0 h10 m0 0 h10 m84 0 h10 m-234 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m214 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-214 0 h10 m24 0 h10 m0 0 h170 m20 44 h100 m-420 0 h20 m400 0 h20 m-440 0 q10 0 10 10 m420 0 q0 -10 10 -10 m-430 10 v68 m420 0 v-68 m-420 68 q0 10 10 10 m400 0 q10 0 10 -10 m-390 10 h10 m50 0 h10 m0 0 h2 m-92 0 h20 m72 0 h20 m-112 0 q10 0 10 10 m92 0 q0 -10 10 -10 m-102 10 v24 m92 0 v-24 m-92 24 q0 10 10 10 m72 0 q10 0 10 -10 m-82 10 h10 m52 0 h10 m20 -44 h10 m26 0 h10 m20 0 h10 m76 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m38 0 h10 m-222 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m202 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-202 0 h10 m24 0 h10 m0 0 h158 m40 -44 h10 m26 0 h10 m3 0 h-3"/>
+   <polygon points="509 127 517 123 517 131"/>
+   <polygon points="509 127 501 123 501 131"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -187,7 +187,8 @@ create_source_text_kinesis ::=
   'FORMAT' ('BYTES' | 'TEXT')
   ('ENVELOPE' 'NONE')?
 create_type ::=
-    'CREATE' 'TYPE' type_name 'AS' ( 'LIST' | 'MAP' ) '(' ( field '=' val ) ( ( ',' field '=' val ) )* ')'
+    'CREATE' 'TYPE' type_name 'AS' ( 'LIST' | 'MAP' ) '(' ( field '=' val ) ( ( ',' field '=' val ) )* ')' |
+    'CREATE' 'TYPE' type_name 'AS' '(' ((field_name field_type) (',' field_name field_type)*) ')'
 create_user ::=
     'CREATE' 'USER' user_name ('LOGIN' | 'NOLOGIN' | 'SUPERUSER' | 'NOSUPERUSER')*
 create_view ::=

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -187,8 +187,8 @@ create_source_text_kinesis ::=
   'FORMAT' ('BYTES' | 'TEXT')
   ('ENVELOPE' 'NONE')?
 create_type ::=
-    'CREATE' 'TYPE' type_name 'AS' ( 'LIST' | 'MAP' ) '(' ( field '=' val ) ( ( ',' field '=' val ) )* ')' |
-    'CREATE' 'TYPE' type_name 'AS' '(' ((field_name field_type) (',' field_name field_type)*) ')'
+    'CREATE' 'TYPE' type_name 'AS' '(' ((field_name field_type) (',' field_name field_type)*) ')' |
+    'CREATE' 'TYPE' type_name 'AS' ( 'LIST' | 'MAP' ) '(' ( property '=' val ) ( ( ',' property '=' val ) )* ')'
 create_user ::=
     'CREATE' 'USER' user_name ('LOGIN' | 'NOLOGIN' | 'SUPERUSER' | 'NOSUPERUSER')*
 create_view ::=


### PR DESCRIPTION
Companion docs PR to https://github.com/MaterializeInc/materialize/pull/10734

The grammar for creating a LIST/MAP type is subtly different from creating a composite/row type... wondering if we should split those into separate railroad diagrams / sections to more clearly distinguish them. Row types definitions look more like table definitions... currently the diagram looks like:

<img width="844" alt="Screen Shot 2022-02-23 at 1 39 12 PM" src="https://user-images.githubusercontent.com/785446/155385545-e2907bcc-fd19-41a3-8ae4-08942c9a2cca.png">