### PR TITLE
dataflow/timestamp: reallow duplicate times in add_binding

### DIFF
--- a/src/dataflow/src/source/timestamp.rs
+++ b/src/dataflow/src/source/timestamp.rs
@@ -184,6 +184,15 @@ impl PartitionTimestamps {
 
     fn add_binding(&mut self, timestamp: Timestamp, offset: MzOffset) {
         if let Some((last_ts, last_offset)) = self.bindings.last() {
+            // TODO(rkhaitan): remove this error log and change the assertion
+            // below to be strictly greater than once we fix 10742.
+            if timestamp == *last_ts {
+                log::error!(
+                    "newly added timestamps should go forwards but {} == {}. Continuing",
+                    timestamp,
+                    last_ts
+                );
+            }
             assert!(
                 offset >= *last_offset,
                 "offset should not go backwards, but {} < {}",
@@ -191,8 +200,8 @@ impl PartitionTimestamps {
                 last_offset
             );
             assert!(
-                timestamp > *last_ts,
-                "timestamp must go forwards but {} <= {}",
+                timestamp >= *last_ts,
+                "timestamp should not go backwards, but {} < {}",
                 timestamp,
                 last_ts
             );


### PR DESCRIPTION
Touches #10742

This commit lets us temporarily allow adding bindings for times that already
have timestamp bindings. This occurs when a timestamp history is compacted beyond
the frontier of timestamps that have been finalized. Concretely:

1. We have a binding at t1 and a proposed binding at t2.
2. We compact up to t2. Now the binding previously at t1 is forwarded to t2.
3. At some later time, we attempt to finalize the proposed binding at t2 and
   when we do so, we observe that a binding at t2 already exists.

There's a number of potential fixes here:

1. Always flush pending bindings before doing any compaction
2. Compact up to pending_time - 1

are the two main candidates. It's not clear at the moment which is best or
if there's a third candidate that we haven't considered.

<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug: [Link to issue.]

  * This PR adds a known-desirable feature: [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
