### PR TITLE
qgm: Handle QGM ⇒ MIR lowering of global aggregates

### DIFF
--- a/src/sql/tests/querymodel/lowering
+++ b/src/sql/tests/querymodel/lowering
@@ -414,6 +414,56 @@ select min(a), c, count(*), b, max(a) from x group by c, b;
 ----
 
 lower
+select min(a), count(*), max(a) from x;
+----
+----
+%0 = Let l0 =
+| Constant ()
+
+%1 =
+| Get ? (u0)
+
+%2 = Let l1 =
+| Join %0 %1
+| | implementation = Unimplemented
+| Map #0, true
+| Project (#3, #4)
+| Reduce group=()
+| | agg min(#0)
+| | agg count(#1)
+| | agg max(#0)
+
+%3 =
+| Get %2 (l1)
+| Distinct group=()
+| Negate
+
+%4 =
+| Get %0 (l0)
+| Distinct group=()
+
+%5 =
+| Union %3 %4
+
+%6 =
+| Join %5 %0
+| | implementation = Unimplemented
+| Project ()
+
+%7 =
+| Constant (null, 0, null)
+
+%8 =
+| Join %6 %7
+| | implementation = Unimplemented
+
+%9 =
+| Union %2 %8
+| Project (#0..=#2)
+----
+----
+
+lower
 select x.a, x.b, y.a from x left join y on x.a > y.b
 ----
 ----


### PR DESCRIPTION
qgm: Handle QGM ⇒ MIR lowering of global aggregates
    
Handle both GROUP BY and global aggregate when lowering a `Grouping` box type.

Fixes #10800.

### Motivation

* This PR fixes a recognized bug: [#10800](10800)

### Tips for reviewer

* This is based on the changes in PR [#10679](10679). Only the last commit needs to be reviewed.
* The original PR [#9715](9715) came without migrating the case from [in `lowering.rs`](https://github.com/MaterializeInc/materialize/blob/main/src/sql/src/plan/lowering.rs#L614-L632) that handles default values for global aggregates (as required by the SQL standard).
* This PR migrates this part of the logic and adds a corresponding test.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
