### PR TITLE
persist: refactor set_{trace|unsealed}_batch to explicitly take a for…

### DIFF
--- a/src/persist/benches/writer.rs
+++ b/src/persist/benches/writer.rs
@@ -29,6 +29,7 @@ use tokio::runtime::Runtime as AsyncRuntime;
 use mz_persist::client::WriteReqBuilder;
 use mz_persist::error::Error;
 use mz_persist::file::{FileBlob, FileLog};
+use mz_persist::gen::persist::ProtoBatchFormat;
 use mz_persist::indexed::cache::BlobCache;
 use mz_persist::indexed::encoding::{BlobTraceBatch, BlobUnsealedBatch, Id};
 use mz_persist::indexed::metrics::Metrics;
@@ -217,7 +218,11 @@ fn bench_set_unsealed_batch<B: Blob>(
                 updates,
             };
             cache
-                .set_unsealed_batch(format!("{}", rng.gen::<usize>()), batch)
+                .set_unsealed_batch(
+                    format!("{}", rng.gen::<usize>()),
+                    batch,
+                    ProtoBatchFormat::ParquetKvtd,
+                )
                 .expect("writing to blobcache failed");
         }
         start.elapsed()

--- a/src/persist/src/indexed/arrangement.rs
+++ b/src/persist/src/indexed/arrangement.rs
@@ -22,6 +22,7 @@ use timely::PartialOrder;
 use uuid::Uuid;
 
 use crate::error::Error;
+use crate::gen::persist::ProtoBatchFormat;
 use crate::indexed::background::{
     CompactTraceReq, CompactTraceRes, DrainUnsealedReq, DrainUnsealedRes,
 };
@@ -251,7 +252,8 @@ impl Arrangement {
         };
 
         debug_assert!(ts_upper >= ts_lower);
-        let (format, size_bytes) = blob.set_unsealed_batch(key.clone(), batch)?;
+        let format = ProtoBatchFormat::ParquetKvtd;
+        let size_bytes = blob.set_unsealed_batch(key.clone(), batch, format)?;
         Ok(UnsealedBatchMeta {
             key,
             format,
@@ -417,7 +419,8 @@ impl Arrangement {
 
         let desc = batch.desc.clone();
         let key = Self::new_blob_key();
-        let (format, size_bytes) = blob.set_trace_batch(key.clone(), batch)?;
+        let format = ProtoBatchFormat::ParquetKvtd;
+        let size_bytes = blob.set_trace_batch(key.clone(), batch, format)?;
         // Batches are inserted into the trace with compaction level set to 0.
         let drained = TraceBatchMeta {
             key,


### PR DESCRIPTION
…mat arg

Previously, these methods returned the format they encoded the batch in. Now, we
require callers to affirmitively state what format they would like, and fail if that
format is not supported.

<!--

Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.

-->

### Motivation

<!--

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug: [Link to issue.]

  * This PR adds a known-desirable feature: [Link to issue.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]

-->

### Tips for reviewer

<!--

Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.

-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
