### PR TITLE
Expr/relation: Minor interface changes

### DIFF
--- a/src/expr/src/relation/join_input_mapper.rs
+++ b/src/expr/src/relation/join_input_mapper.rs
@@ -44,25 +44,24 @@ impl JoinInputMapper {
     /// Creates a new `JoinInputMapper` and calculates the mapping of global context
     /// columns to local context columns.
     pub fn new(inputs: &[MirRelationExpr]) -> Self {
-        Self::new_from_input_arities(inputs.iter().map(|i| i.arity()).collect::<Vec<_>>())
+        Self::new_from_input_arities(inputs.iter().map(|i| i.arity()))
     }
 
     /// Creates a new `JoinInputMapper` and calculates the mapping of global context
     /// columns to local context columns. Using this method saves is more
     /// efficient if input types have been pre-calculated
     pub fn new_from_input_types(types: &[RelationType]) -> Self {
-        let arities = types
-            .iter()
-            .map(|t| t.column_types.len())
-            .collect::<Vec<_>>();
-
-        Self::new_from_input_arities(arities)
+        Self::new_from_input_arities(types.iter().map(|t| t.column_types.len()))
     }
 
     /// Creates a new `JoinInputMapper` and calculates the mapping of global context
     /// columns to local context columns. Using this method saves is more
     /// efficient if input arities have been pre-calculated
-    pub fn new_from_input_arities(arities: Vec<usize>) -> Self {
+    pub fn new_from_input_arities<I>(arities: I) -> Self
+    where
+        I: Iterator<Item = usize>,
+    {
+        let arities = arities.collect::<Vec<usize>>();
         let mut offset = 0;
         let mut prior_arities = Vec::new();
         for input in 0..arities.len() {

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -817,6 +817,14 @@ impl MirRelationExpr {
         }
     }
 
+    /// Append to each row a single `scalar`.
+    pub fn map_one(self, scalar: MirScalarExpr) -> Self {
+        MirRelationExpr::Map {
+            input: Box::new(self),
+            scalars: vec![scalar],
+        }
+    }
+
     /// Like `map`, but yields zero-or-more output rows per input row
     pub fn flat_map(self, func: TableFunc, exprs: Vec<MirScalarExpr>) -> Self {
         MirRelationExpr::FlatMap {

--- a/src/sql/src/query_model/mir.rs
+++ b/src/sql/src/query_model/mir.rs
@@ -550,10 +550,10 @@ impl<'a> Lowerer<'a> {
                                 mz_expr::BinaryFunc::Gt,
                             )])
                         .project((0..outer_arity).collect::<Vec<_>>())
-                        .map(vec![mz_expr::MirScalarExpr::literal(
+                        .map_one(mz_expr::MirScalarExpr::literal(
                             Err(mz_expr::EvalError::MultipleRowsFromSubquery),
                             col_type.clone().scalar_type,
-                        )]);
+                        ));
                     // Return `get_select` and any errors added in.
                     get_select.union(errors)
                 });

--- a/src/sql/src/query_model/mir.rs
+++ b/src/sql/src/query_model/mir.rs
@@ -483,10 +483,9 @@ impl<'a> Lowerer<'a> {
         let (quantifiers, join_inputs): (Vec<_>, Vec<_>) = inputs.into_iter().unzip();
         let (join, input_mapper) = if join_inputs.len() == 1 {
             let only_input = join_inputs.into_iter().next().unwrap();
-            let input_mapper = mz_expr::JoinInputMapper::new_from_input_arities(vec![
-                outer_arity,
-                only_input.arity() - outer_arity,
-            ]);
+            let input_mapper = mz_expr::JoinInputMapper::new_from_input_arities(
+                [outer_arity, only_input.arity() - outer_arity].into_iter(),
+            );
             (only_input, input_mapper)
         } else {
             Self::join_on_prefix(join_inputs, outer_arity)
@@ -644,13 +643,11 @@ impl<'a> Lowerer<'a> {
         (
             mz_expr::MirRelationExpr::join_scalars(join_inputs, equivalences).project(projection),
             mz_expr::JoinInputMapper::new_from_input_arities(
-                std::iter::once(prefix_length)
-                    .chain(
-                        (0..input_mapper.total_inputs())
-                            .into_iter()
-                            .map(|i| input_mapper.input_arity(i) - prefix_length),
-                    )
-                    .collect_vec(),
+                std::iter::once(prefix_length).chain(
+                    (0..input_mapper.total_inputs())
+                        .into_iter()
+                        .map(|i| input_mapper.input_arity(i) - prefix_length),
+                ),
             ),
         )
     }

--- a/src/sql/src/query_model/mir.rs
+++ b/src/sql/src/query_model/mir.rs
@@ -175,12 +175,7 @@ impl<'a> Lowerer<'a> {
                     let input_type = input.typ();
                     let default = aggregates
                         .iter()
-                        .map(|agg| {
-                            (
-                                agg.func.default(),
-                                agg.typ(&input_type).nullable(agg.func.default().is_null()),
-                            )
-                        })
+                        .map(|agg| (agg.func.default(), agg.typ(&input_type).scalar_type))
                         .collect_vec();
 
                     input = SR::Reduce {
@@ -382,7 +377,7 @@ impl<'a> Lowerer<'a> {
                                         id_gen,
                                         get_join.clone(),
                                         rt.into_iter()
-                                            .map(|typ| (Datum::Null, typ.nullable(true)))
+                                            .map(|typ| (Datum::Null, typ.scalar_type))
                                             .collect(),
                                     );
                                     result = result.union(left_outer);
@@ -402,7 +397,7 @@ impl<'a> Lowerer<'a> {
                                                         .collect(),
                                                 ),
                                             lt.into_iter()
-                                                .map(|typ| (Datum::Null, typ.nullable(true)))
+                                                .map(|typ| (Datum::Null, typ.scalar_type))
                                                 .collect(),
                                         )
                                         // swap left and right back again
@@ -563,7 +558,7 @@ impl<'a> Lowerer<'a> {
                     get_select.union(errors)
                 });
                 // append Null to anything that didn't return any rows
-                let default = vec![(Datum::Null, col_type.nullable(true))];
+                let default = vec![(Datum::Null, col_type.scalar_type)];
                 input = get_outer.lookup(id_gen, guarded, default);
             }
             _ => panic!("Unsupported quantifier type"),

--- a/src/transform/src/reduction_pushdown.rs
+++ b/src/transform/src/reduction_pushdown.rs
@@ -304,9 +304,8 @@ fn try_push_reduce_through_join(
     }
 
     // 4) Construct the new `MirRelationExpr`.
-    let new_join_mapper = JoinInputMapper::new_from_input_arities(
-        new_reduces.iter().map(|builder| builder.arity()).collect(),
-    );
+    let new_join_mapper =
+        JoinInputMapper::new_from_input_arities(new_reduces.iter().map(|builder| builder.arity()));
 
     let new_inputs = new_reduces
         .into_iter()


### PR DESCRIPTION
### Motivation

   * This PR refactors existing code.

During the last skunkworks I played around with simplifying the decorrelation/lowering code, and this is what I got that may be worth merging.

### Tips for reviewer

First commit changes the input argument for `JoinInputMapper::new_from_arities` from a `Vec` to an `Iterator` to save having to collect arities into a `Vec`.
Second commit changes the argument `default` for `MirRelationExpr::lookup` from `Vec<Datum, ColumnType>` to `Vec<Datum, ScalarType>` because I think we are less likely to get errors if only `lookup` calculates the nullability of the `Datum` instead of every caller of `lookup`.
Third commit adds a method `MirRelationExpr::map_one` for when you only want to add a single column. This commit can be removed from the PR if not deemed useful. This was part of my playing around in order to try to figure out why `MirRelationExpr::filter` accepts an iterator as an argument
https://github.com/MaterializeInc/materialize/blob/64c7fae43e60121cd287a4cdc462546148127c61/src/expr/src/relation/mod.rs#L830
but `MirRelationExpr::map` requires the argument to be a `Vec`.
https://github.com/MaterializeInc/materialize/blob/64c7fae43e60121cd287a4cdc462546148127c61/src/expr/src/relation/mod.rs#L813

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
