### PR TITLE
materialized: allow specifying the same flag multiple times

### DIFF
--- a/doc/user/content/cli/_index.md
+++ b/doc/user/content/cli/_index.md
@@ -47,8 +47,8 @@ follows:
 For example, the `--data-directory` command line flag corresponds to the
 `MZ_DATA_DIRECTORY` environment variable.
 
-Note that command line flags that do not take arguments, like `--experimental`
-and `--disable-telemetry`, do not yet have corresponding environment variables.
+If the same command line flag is specified multiple times, the last
+specification takes precedence.
 
 ### Data directory
 

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -69,7 +69,7 @@ fn parse_optional_duration(s: &str) -> Result<OptionalDuration, anyhow::Error> {
 
 /// The streaming SQL materialized view engine.
 #[derive(Parser)]
-#[clap(next_line_help = true, global_setting = AppSettings::NoAutoVersion)]
+#[clap(next_line_help = true, args_override_self = true, global_setting = AppSettings::NoAutoVersion)]
 struct Args {
     // === Special modes. ===
     /// Print version information and exit.

--- a/src/ore/src/cli.rs
+++ b/src/ore/src/cli.rs
@@ -34,6 +34,7 @@ where
 {
     let clap = O::command()
         .disable_version_flag(true)
+        .args_override_self(true)
         .help_template(NO_VERSION_HELP_TEMPLATE);
     O::from_arg_matches(&clap.get_matches()).unwrap()
 }


### PR DESCRIPTION
The last specification wins. This matches the behavior of many standard
Unix tools. It's particularly useful for folks using materialized via
Docker, who may want to override the default `--log-file=stderr` flag
that's baked into the image entrypoint.

### Motivation

* Described above.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes
- Allow specifying [command line flags](/cli/) multiple times. The last
  specification takes precedence.
