### PR TITLE
*: replace all usage of env_logger with tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1573,19 +1573,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "error-iter"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2955,7 +2942,6 @@ dependencies = [
  "chrono",
  "clap",
  "csv",
- "env_logger",
  "futures",
  "futures-channel",
  "hex",
@@ -2970,6 +2956,7 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 
@@ -3484,7 +3471,6 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
- "env_logger",
  "futures",
  "futures-channel",
  "mz-aws-util",
@@ -3494,6 +3480,7 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3874,7 +3861,6 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
- "env_logger",
  "flate2",
  "futures",
  "globset",
@@ -3917,6 +3903,7 @@ dependencies = [
  "tokio-postgres",
  "tokio-stream",
  "tokio-util",
+ "tracing-subscriber",
  "url",
  "uuid",
  "walkdir",

--- a/demo/billing/Cargo.toml
+++ b/demo/billing/Cargo.toml
@@ -12,7 +12,6 @@ bytes = "1.1.0"
 chrono = { version = "0.4.0", default-features = false, features = ["clock", "std"] }
 clap = { version = "3.1.1", features = ["derive"] }
 csv = "1.1.6"
-env_logger = "0.9.0"
 futures = "0.3.21"
 futures-channel = "0.3.16"
 hex = "0.4.3"
@@ -26,6 +25,7 @@ rand_distr = "0.4.3"
 tokio = "1.17.0"
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", branch = "mz-0.7.2" }
 tracing = "0.1.31"
+tracing-subscriber = { version = "0.3.9", features = ["env-filter"] }
 uuid = { version = "0.8.2", features = ["v4"] }
 
 [build-dependencies]

--- a/demo/billing/mzcompose.yml
+++ b/demo/billing/mzcompose.yml
@@ -44,8 +44,6 @@ services:
     mzbuild: billing-demo
     volumes:
     - db-data:/share/billing-demo/data
-    environment:
-    - RUST_LOG=billing-demo=debug,info
     depends_on: [kafka, schema-registry, materialized]
 
 volumes:

--- a/demo/billing/src/bin/billing-demo/config.rs
+++ b/demo/billing/src/bin/billing-demo/config.rs
@@ -10,6 +10,7 @@
 use chrono::format::ParseResult;
 use chrono::prelude::*;
 use chrono::DateTime;
+use tracing_subscriber::filter::EnvFilter;
 
 pub static KAFKA_SOURCE_NAME: &str = "billing_source";
 pub static CSV_SOURCE_NAME: &str = "price_source";
@@ -28,7 +29,7 @@ fn parse_seed(s: &str) -> u64 {
     s.parse().unwrap_or_else(|_| rand::random())
 }
 
-#[derive(Clone, Debug, clap::Parser)]
+#[derive(Debug, clap::Parser)]
 pub struct Args {
     /// The materialized host
     #[clap(long, default_value = "localhost")]
@@ -102,6 +103,12 @@ pub struct Args {
     // Whether or not to enable persistence for input Kafka sources
     #[clap(long)]
     enable_persistence: bool,
+
+    /// Which log messages to emit.
+    ///
+    /// See materialized's `--log-filter` option for details.
+    #[clap(long, value_name = "FILTER", default_value = "billing-demo=debug,info")]
+    pub log_filter: EnvFilter,
 }
 
 impl Args {

--- a/demo/billing/src/bin/billing-demo/main.rs
+++ b/demo/billing/src/bin/billing-demo/main.rs
@@ -18,6 +18,7 @@
 
 #![warn(missing_debug_implementations, missing_docs)]
 
+use std::io;
 use std::process;
 use std::sync::Arc;
 
@@ -47,17 +48,22 @@ async fn main() {
 
 async fn run() -> Result<()> {
     let config: Args = mz_ore::cli::parse_args();
-    env_logger::init();
 
     let k_config = config.kafka_config();
     let mz_config = config.mz_config();
 
+    tracing_subscriber::fmt()
+        .with_env_filter(config.log_filter)
+        .with_writer(io::stderr)
+        .init();
+
     info!(
-        "starting up message_count={} mzd={}:{} kafka={} preserve_source={} start_time={} seed={} enable_persistence={}",
+        "starting up message_count={} mzd={}:{} kafka={}:{} preserve_source={} start_time={} seed={} enable_persistence={}",
         config.message_count,
         config.materialized_host,
         config.materialized_port,
-        config.kafka_url(),
+        config.kafka_host,
+        config.kafka_port,
         config.preserve_source,
         k_config.start_time.to_rfc3339(),
         k_config.seed,

--- a/deny.toml
+++ b/deny.toml
@@ -35,6 +35,10 @@ skip = [
     { name = "arrayvec", version = "0.5.2" },
 ]
 
+# Use `tracing` instead.
+[[bans.deny]]
+name = "env_logger"
+
 # Use `prost` or `protobuf-native` instead.
 [[bans.deny]]
 name = "protobuf"

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -25,7 +25,6 @@ flate2 = "1.0.22"
 futures = "0.3.21"
 globset = "0.4.8"
 http = "0.2.6"
-env_logger = "0.9.0"
 itertools = "0.10.3"
 junit-report = "0.7.0"
 krb5-src = { version = "0.3.2", features = ["binaries"] }
@@ -59,6 +58,7 @@ tempfile = "3.2.0"
 termcolor = "1.1.2"
 tiberius = { version = "0.7.1", default-features = false }
 time = "0.3.7"
+tracing-subscriber = { version = "0.3.9", features = ["env-filter"] }
 tokio = { version = "1.17.0", features = ["process"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", branch = "mz-0.7.2", features = ["with-chrono-0_4", "with-serde_json-1"] }
 tokio-stream = "0.1.8"

--- a/test/perf-kinesis/Cargo.toml
+++ b/test/perf-kinesis/Cargo.toml
@@ -12,7 +12,6 @@ aws-sdk-kinesis = { version = "0.7.0", default-features = false }
 bytes = "1.1.0"
 chrono = { version = "0.4.0", default-features = false, features = ["std"] }
 clap = { version = "3.1.1", features = ["derive"] }
-env_logger = "0.9.0"
 futures = "0.3.21"
 futures-channel = "0.3.16"
 mz-aws-util = { path = "../../src/aws-util", features = ["kinesis"] }
@@ -22,3 +21,4 @@ rand = "0.8.5"
 tokio = "1.17.0"
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", branch = "mz-0.7.2" }
 tracing = "0.1.31"
+tracing-subscriber = { version = "0.3.9", features = ["env-filter"] }

--- a/test/perf-kinesis/mzcompose.py
+++ b/test/perf-kinesis/mzcompose.py
@@ -20,7 +20,6 @@ SERVICES = [
         config={
             "mzbuild": "perf-kinesis",
             "environment": [
-                "RUST_LOG=perf-kinesis=debug,info",
                 "AWS_ACCESS_KEY_ID",
                 "AWS_DEFAULT_REGION=us-east-2",
                 "AWS_SECRET_ACCESS_KEY",


### PR DESCRIPTION
Continue transitioning our codebase to the `tracing` ecosystem by
replacing all usage of the `env_logger` crate with the equivalent
`tracing_subscriber` invocation.

This results in a slight change in interface: filters are configured via
a `--log-filter` command-line flag rather than the `RUST_LOG` or
`MZ_LOG_FILTER` environment variable. If we need to restore the
`MZ_LOG_FILTER` environment variable, it's trivial to do so with clap
via an `env = "MZ_LOG_FILTER"` annotation on the `log_filter` fields,
but best to avoid environment variables for as long as possible to avoid
spooky action at a distance.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - No user-facing behavior changes.
