### PR TITLE
sql: make literal records coercible into scalar records

### DIFF
--- a/src/materialized/tests/pgwire.rs
+++ b/src/materialized/tests/pgwire.rs
@@ -396,6 +396,16 @@ fn test_arrays() -> Result<(), Box<dyn Error>> {
         _ => panic!("unexpected simple query message"),
     }
 
+    let message = client
+        .simple_query("SELECT ARRAY[ROW(1,2), ROW(3,4), ROW(5,6)]")?
+        .into_first();
+    match message {
+        SimpleQueryMessage::Row(row) => {
+            assert_eq!(row.get(0).unwrap(), r#"{"(1,2)","(3,4)","(5,6)"}"#);
+        }
+        _ => panic!("unexpected simple query message"),
+    }
+
     Ok(())
 }
 

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -17,7 +17,7 @@ use std::fmt;
 use std::mem;
 
 use anyhow::bail;
-use itertools::Itertools;
+use itertools::{enumerate, Itertools};
 use mz_expr::DummyHumanizer;
 
 use mz_ore::collections::CollectionExt;
@@ -397,6 +397,23 @@ impl AbstractExpr for CoercibleScalarExpr {
     ) -> Self::Type {
         match self {
             CoercibleScalarExpr::Coerced(expr) => Some(expr.typ(outers, inner, params)),
+            CoercibleScalarExpr::LiteralRecord(scalars) => {
+                let mut fields = vec![];
+                for (i, scalar) in enumerate(scalars) {
+                    fields.push((
+                        format!("f{}", i + 1).into(),
+                        scalar.typ(outers, inner, params)?,
+                    ));
+                }
+                Some(ColumnType {
+                    scalar_type: ScalarType::Record {
+                        fields,
+                        custom_oid: None,
+                        custom_name: None,
+                    },
+                    nullable: false,
+                })
+            }
             _ => None,
         }
     }

--- a/test/sqllogictest/arrays.slt
+++ b/test/sqllogictest/arrays.slt
@@ -837,9 +837,3 @@ SELECT ARRAY[ARRAY[customer.first_name], ARRAY[customer.zip], ARRAY[customer.id:
 ----
 {{alice},{10003},{1}}
 {{charlie},{11217},{3}}
-
-# Create arrays of anonymous records
-query T
-SELECT ARRAY[(1,2), (2,3)]
-----
-{"(1,2)","(3,4)","(5,6)"}

--- a/test/sqllogictest/arrays.slt
+++ b/test/sqllogictest/arrays.slt
@@ -837,3 +837,9 @@ SELECT ARRAY[ARRAY[customer.first_name], ARRAY[customer.zip], ARRAY[customer.id:
 ----
 {{alice},{10003},{1}}
 {{charlie},{11217},{3}}
+
+# Create arrays of anonymous records
+query T
+SELECT ARRAY[(1,2), (2,3)]
+----
+{"(1,2)","(3,4)","(5,6)"}

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -365,6 +365,16 @@ SELECT coalesce('hello', 'world', NULL)
 ----
 hello
 
+query T
+SELECT coalesce(row(5), row(10))
+----
+(5)
+
+query T
+SELECT coalesce(row(4, 3), row(2, 1))
+----
+(4,3)
+
 statement ok
 CREATE VIEW v AS SELECT 1 AS a
 
@@ -400,6 +410,32 @@ SELECT greatest(1, NULL, -1)
 ----
 1
 
+query T
+SELECT greatest((3), (0), (-1));
+----
+3
+
+query T
+SELECT greatest(row(4, 3), row(4, 2), row(4, 4));
+----
+(4,4)
+
+query T
+SELECT greatest(row(2, 3), row(1, 4), row(5, 0));
+----
+(5,0)
+
+query T
+SELECT greatest(row(row(2, 4), 5), row(row(0, 10), 10), row(row(4, 3), 4));
+----
+("(4,3)",4)
+
+query error greatest cannot be cast to uniform type
+SELECT greatest(row(1, 2), row(3), row(4, 5));
+
+query error greatest does not support casting from text to record
+SELECT greatest(row(1, 2), 'hello');
+
 query error greatest cannot be cast to uniform type: text vs integer
 SELECT greatest(1::int, 2::text)
 
@@ -428,6 +464,32 @@ query I
 SELECT least(1, NULL, -1)
 ----
 -1
+
+query T
+SELECT least((3), (0), (-1));
+----
+-1
+
+query T
+SELECT least(row(4, 3), row(4, 2), row(4, 4));
+----
+(4,2)
+
+query T
+SELECT least(row(2, 3), row(1, 4), row(5, 0));
+----
+(1,4)
+
+query T
+SELECT least(row(row(2, 4), 5), row(row(0, 10), 10), row(row(4, 3), 4));
+----
+("(0,10)",10)
+
+query error least cannot be cast to uniform type
+SELECT least(row(1, 2), row(3), row(4, 5));
+
+query error least does not support casting from text to record
+SELECT least(row(1, 2), 'hello');
 
 query error least cannot be cast to uniform type: text vs integer
 SELECT least(1::int, 2::text)

--- a/test/sqllogictest/postgres/union.slt
+++ b/test/sqllogictest/postgres/union.slt
@@ -491,48 +491,45 @@ select x from (values (array[1, 2]), (array[1, 3])) _(x) except select x from (v
 x
 {1,3}
 
-# `VALUES (ROW(...))` doesn't work at th emoment.
-# See: https://github.com/MaterializeInc/materialize/issues/10422
+query T colnames
+select x from (values (row(1, 2)), (row(1, 3))) _(x) union select x from (values (row(1, 2)), (row(1, 4))) _(x)
+----
+x
+(1,2)
+(1,3)
+(1,4)
 
-# query T colnamess
-# select x from (values (row(1, 2)), (row(1, 3))) _(x) union select x from (values (row(1, 2)), (row(1, 4))) _(x)
-# ----
-# x
-# (1,2)
-# (1,3)
-# (1,4)
+query T colnames
+select x from (values (row(1, 2)), (row(1, 3))) _(x) intersect select x from (values (row(1, 2)), (row(1, 4))) _(x)
+----
+x
+(1,2)
 
-# query T colnames
-# select x from (values (row(1, 2)), (row(1, 3))) _(x) intersect select x from (values (row(1, 2)), (row(1, 4))) _(x)
-# ----
-# x
-# (1,2)
+query T colnames
+select x from (values (row(1, 2)), (row(1, 3))) _(x) except select x from (values (row(1, 2)), (row(1, 4))) _(x)
+----
+x
+(1,3)
 
-# query T colnames
-# select x from (values (row(1, 2)), (row(1, 3))) _(x) except select x from (values (row(1, 2)), (row(1, 4))) _(x)
-# ----
-# x
-# (1,3)
+query T colnames
+select x from (values (row(1, 2)), (row(1, 3))) _(x) union select x from (values (row(1, 2)), (row(1, 4))) _(x)
+----
+x
+(1,2)
+(1,3)
+(1,4)
 
-# query T colnames
-# select x from (values (row(1, 2)), (row(1, 3))) _(x) union select x from (values (row(1, 2)), (row(1, 4))) _(x)
-# ----
-# x
-# (1,2)
-# (1,3)
-# (1,4)
+query T colnames
+select x from (values (row(1, 2)), (row(1, 3))) _(x) intersect select x from (values (row(1, 2)), (row(1, 4))) _(x)
+----
+x
+(1,2)
 
-# query T colnames
-# select x from (values (row(1, 2)), (row(1, 3))) _(x) intersect select x from (values (row(1, 2)), (row(1, 4))) _(x)
-# ----
-# x
-# (1,2)
-
-# query T
-# select x from (values (row(1, 2)), (row(1, 3))) _(x) except select x from (values (row(1, 2)), (row(1, 4))) _(x)
-# ----
-# x
-# (1,3)
+query T colnames
+select x from (values (row(1, 2)), (row(1, 3))) _(x) except select x from (values (row(1, 2)), (row(1, 4))) _(x)
+----
+x
+(1,3)
 
 # Mixed types
 

--- a/test/sqllogictest/record.slt
+++ b/test/sqllogictest/record.slt
@@ -42,3 +42,8 @@ EXPLAIN SELECT (COALESCE(record, ROW(NULL, NULL))).f2 FROM (SELECT ROW(a, a) AS 
 | Project (#2)
 
 EOF
+
+query T
+SELECT abc FROM (VALUES (1, 2, (3,4), ROW(5, 6, 7))) as abc;
+----
+(1,2,"(3,4)","(5,6,7)")


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Got sidetracked by the interesting error of `ERROR:  VALUES cannot be cast to uniform type: record(f1: integer) vs text` resulting from a `select least(row(1))` statement and got curious where `text` was coming from. We now have an answer!

When coercing a `LiteralRecord` into a scalar type, we produced a `None` column type. Homogenizing functions like `least` try to guess the most appropriate return type, and defaults to `text` if there are no type hints.

This PR adds in coercion of `LiteralRecords` into scalar `Record` types and adds in several tests.

### Motivation

Fixes https://github.com/MaterializeInc/materialize/issues/10422
Fixes https://github.com/MaterializeInc/materialize/issues/8597

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Fixes `ROW` incompatibility in functions and `VALUES` clauses {{% gh 8597 %}} {{% gh 10422 %}}