### PR TITLE
feat: support date/time unit aliases

### DIFF
--- a/src/repr/src/adt/datetime.rs
+++ b/src/repr/src/adt/datetime.rs
@@ -168,12 +168,12 @@ impl FromStr for DateTimeField {
             "MILLENNIUM" | "MILLENNIUMS" | "MILLENNIA" | "MIL" | "MILS" => Ok(Self::Millennium),
             "CENTURY" | "CENTURIES" | "CENT" | "C" => Ok(Self::Century),
             "DECADE" | "DECADES" | "DEC" | "DECS" => Ok(Self::Decade),
-            "YEAR" | "YEARS" | "Y" => Ok(Self::Year),
+            "YEAR" | "YEARS" | "YR" | "YRS" | "Y" => Ok(Self::Year),
             "MONTH" | "MONTHS" | "MON" | "MONS" => Ok(Self::Month),
             "DAY" | "DAYS" | "D" => Ok(Self::Day),
-            "HOUR" | "HOURS" | "H" => Ok(Self::Hour),
-            "MINUTE" | "MINUTES" | "M" => Ok(Self::Minute),
-            "SECOND" | "SECONDS" | "S" => Ok(Self::Second),
+            "HOUR" | "HOURS" | "HR" | "HRS" | "H" => Ok(Self::Hour),
+            "MINUTE" | "MINUTES" | "MIN" | "MINS" | "M" => Ok(Self::Minute),
+            "SECOND" | "SECONDS" | "SEC" | "SECS" | "S" => Ok(Self::Second),
             "MILLISECOND" | "MILLISECONDS" | "MILLISECON" | "MILLISECONS" | "MSECOND"
             | "MSECONDS" | "MSEC" | "MSECS" | "MS" => Ok(Self::Milliseconds),
             "MICROSECOND" | "MICROSECONDS" | "MICROSECON" | "MICROSECONS" | "USECOND"

--- a/src/sql-parser/src/ast/defs/value.rs
+++ b/src/sql-parser/src/ast/defs/value.rs
@@ -176,12 +176,12 @@ impl FromStr for DateTimeField {
             "MILLENNIUM" | "MILLENNIA" | "MIL" | "MILS" => Ok(Self::Millennium),
             "CENTURY" | "CENTURIES" | "CENT" | "C" => Ok(Self::Century),
             "DECADE" | "DECADES" | "DEC" | "DECS" => Ok(Self::Decade),
-            "YEAR" | "YEARS" | "Y" => Ok(Self::Year),
+            "YEAR" | "YEARS" | "YR" | "YRS" | "Y" => Ok(Self::Year),
             "MONTH" | "MONTHS" | "MON" | "MONS" => Ok(Self::Month),
             "DAY" | "DAYS" | "D" => Ok(Self::Day),
-            "HOUR" | "HOURS" | "H" => Ok(Self::Hour),
-            "MINUTE" | "MINUTES" | "M" => Ok(Self::Minute),
-            "SECOND" | "SECONDS" | "S" => Ok(Self::Second),
+            "HOUR" | "HOURS" | "HR" | "HRS" | "H" => Ok(Self::Hour),
+            "MINUTE" | "MINUTES" | "MIN" | "MINS" | "M" => Ok(Self::Minute),
+            "SECOND" | "SECONDS" | "SEC" | "SECS" | "S" => Ok(Self::Second),
             "MILLISECOND" | "MILLISECONDS" | "MILLISECON" | "MILLISECONS" | "MSECOND"
             | "MSECONDS" | "MSEC" | "MSECS" | "MS" => Ok(Self::Milliseconds),
             "MICROSECOND" | "MICROSECONDS" | "MICROSECON" | "MICROSECONS" | "USECOND"

--- a/test/sqllogictest/dates-times.slt
+++ b/test/sqllogictest/dates-times.slt
@@ -82,6 +82,26 @@ SELECT INTERVAL '1' MINUTE
 ----
 00:01:00
 
+query T
+SELECT INTERVAL '1 MIN'
+----
+00:01:00
+
+query T
+SELECT INTERVAL '1 MINS'
+----
+00:01:00
+
+query T
+SELECT INTERVAL '1 SECS'
+----
+00:00:01
+
+query T
+SELECT INTERVAL '1 SEC'
+----
+00:00:01
+
 statement ok
 CREATE TABLE iv_ish (
     b interval
@@ -265,12 +285,27 @@ SELECT INTERVAL '7' DAY + DATE '2000-01-01'
 2000-01-08 00:00:00
 
 query T
+SELECT INTERVAL '2 YRS 5 DAYS'
+----
+2 years 5 days
+
+query T
+SELECT INTERVAL '2 YR 5 DAYS'
+----
+2 years 5 days
+
+query T
 SELECT DATE '2000-01-01' + INTERVAL '7 5:4:3.2' DAY TO SECOND
 ----
 2000-01-08 05:04:03.2
 
 query T
 SELECT DATE '2000-01-01' + INTERVAL '4' HOUR
+----
+2000-01-01 04:00:00
+
+query T
+SELECT DATE '2000-01-01' + INTERVAL '4 HR'
 ----
 2000-01-01 04:00:00
 


### PR DESCRIPTION
this PR  adds support for date/time unit aliases  #10536 

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Add the aliases the following aliases to Interval parsing: yr, yrs, hr, hrs, min, mins, sec, secs
