### PR TITLE
unreachable! requires a string literal

### DIFF
--- a/src/repr/src/adt/interval.rs
+++ b/src/repr/src/adt/interval.rs
@@ -287,7 +287,7 @@ impl Interval {
             | DateTimeField::Decade
             | DateTimeField::Milliseconds
             | DateTimeField::Microseconds => {
-                unreachable!(format!("Cannot truncate interval by {}", f))
+                unreachable!("Cannot truncate interval by {f}");
             }
         }
     }
@@ -363,7 +363,7 @@ impl Interval {
                 self.duration -= self.duration % f.nanos_multiplier() as i128;
             }
             Millennium | Century | Decade | Milliseconds | Microseconds => {
-                unreachable!(format!("Cannot truncate interval by {}", f))
+                unreachable!("Cannot truncate interval by {f}");
             }
         }
         Ok(())


### PR DESCRIPTION
This restores compatibility with Rust 1.59.0

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - No user-facing changes.
