### PR TITLE
frontegg-auth: expiry checking and refresh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3285,6 +3285,7 @@ dependencies = [
  "base64",
  "derivative",
  "jsonwebtoken",
+ "mz-ore",
  "reqwest",
  "serde",
  "uuid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3288,6 +3288,7 @@ dependencies = [
  "mz-ore",
  "reqwest",
  "serde",
+ "tokio",
  "uuid",
 ]
 

--- a/src/coord/src/client.rs
+++ b/src/coord/src/client.rs
@@ -499,6 +499,15 @@ impl SessionClient {
             .expect("coordinator unexpectedly gone");
     }
 
+    // Like `terminate`, but permits the session to not be present, assuming it was
+    // terminated by the coordinator.
+    pub async fn terminate_allow_no_session(self) {
+        if self.session.is_none() {
+            return;
+        }
+        self.terminate().await
+    }
+
     /// Returns a mutable reference to the session bound to this client.
     pub fn session(&mut self) -> &mut Session {
         self.session.as_mut().unwrap()

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1139,7 +1139,7 @@ impl Coordinator {
                     },
                 );
 
-                ClientTransmitter::new(tx).send(
+                ClientTransmitter::new(tx, self.internal_cmd_tx.clone()).send(
                     Ok(StartupResponse {
                         messages,
                         secret_key,
@@ -1300,7 +1300,7 @@ impl Coordinator {
                             internal_cmd_tx
                                 .send(Message::StatementReady(StatementReady {
                                     session,
-                                    tx: ClientTransmitter::new(tx),
+                                    tx: ClientTransmitter::new(tx, internal_cmd_tx.clone()),
                                     result,
                                     params,
                                 }))
@@ -1391,7 +1391,7 @@ impl Coordinator {
                 session,
                 tx,
             } => {
-                let tx = ClientTransmitter::new(tx);
+                let tx = ClientTransmitter::new(tx, self.internal_cmd_tx.clone());
                 self.sequence_end_transaction(tx, session, action).await;
             }
 

--- a/src/coord/src/util.rs
+++ b/src/coord/src/util.rs
@@ -7,30 +7,44 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::oneshot;
 
-use crate::command::Response;
+use crate::command::{Command, Response};
+use crate::coord::Message;
 use crate::error::CoordError;
 use crate::session::Session;
 
 /// Handles responding to clients.
 pub struct ClientTransmitter<T> {
     tx: Option<oneshot::Sender<Response<T>>>,
+    internal_cmd_tx: UnboundedSender<Message>,
 }
 
 impl<T> ClientTransmitter<T> {
     /// Creates a new client transmitter.
-    pub fn new(tx: oneshot::Sender<Response<T>>) -> ClientTransmitter<T> {
-        ClientTransmitter { tx: Some(tx) }
+    pub fn new(
+        tx: oneshot::Sender<Response<T>>,
+        internal_cmd_tx: UnboundedSender<Message>,
+    ) -> ClientTransmitter<T> {
+        ClientTransmitter {
+            tx: Some(tx),
+            internal_cmd_tx,
+        }
     }
 
     /// Transmits `result` to the client, returning ownership of the session
     /// `session` as well.
     pub fn send(mut self, result: Result<T, CoordError>, session: Session) {
-        // We can safely ignore failure to send the message, as that simply
-        // indicates that the client has disconnected and is no longer
-        // interested in the response.
-        let _ = self.tx.take().unwrap().send(Response { result, session });
+        // If we were not able to send a message, we must clean up the session
+        // ourselves. Return it to the caller for disposal.
+        if let Err(res) = self.tx.take().unwrap().send(Response { result, session }) {
+            self.internal_cmd_tx
+                .send(Message::Command(Command::Terminate {
+                    session: res.session,
+                }))
+                .expect("coordinator unexpectedly gone");
+        }
     }
 
     pub fn take(mut self) -> oneshot::Sender<Response<T>> {

--- a/src/frontegg-auth/Cargo.toml
+++ b/src/frontegg-auth/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = "1.0.55"
 base64 = "0.13.0"
 derivative = "2.2.0"
 jsonwebtoken = "8.0.1"
+mz-ore = { path = "../ore" }
 reqwest = "0.11.9"
 serde = { version = "1.0.135", features = ["derive"] }
 uuid = "0.8.2"

--- a/src/frontegg-auth/Cargo.toml
+++ b/src/frontegg-auth/Cargo.toml
@@ -14,4 +14,5 @@ jsonwebtoken = "8.0.1"
 mz-ore = { path = "../ore" }
 reqwest = "0.11.9"
 serde = { version = "1.0.135", features = ["derive"] }
+tokio = "1.16.1"
 uuid = "0.8.2"

--- a/src/frontegg-auth/src/lib.rs
+++ b/src/frontegg-auth/src/lib.rs
@@ -7,12 +7,28 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::future::Future;
+use std::time::Duration;
+
 use anyhow::bail;
 use derivative::Derivative;
 use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
 use uuid::Uuid;
 
 use mz_ore::now::NowFn;
+
+pub struct FronteggConfig<'a> {
+    /// URL for the token endpoint, including full path.
+    pub admin_api_token_url: String,
+    /// JWK used to validate JWTs.
+    pub jwk_rsa_pem: &'a [u8],
+    /// Tenant id used to validate JWTs.
+    pub tenant_id: Uuid,
+    /// Function to provide system time to validate exp (expires at) field of JWTs.
+    pub now: NowFn,
+    /// Number of seconds before which to attempt to renew an expiring token.
+    pub refresh_before_secs: i64,
+}
 
 #[derive(Clone, Derivative)]
 #[derivative(Debug)]
@@ -23,27 +39,26 @@ pub struct FronteggAuthentication {
     tenant_id: Uuid,
     now: NowFn,
     validation: Validation,
+    refresh_before_secs: i64,
 }
+
+pub const REFRESH_SUFFIX: &str = "/token/refresh";
 
 impl FronteggAuthentication {
     /// Creates a new frontegg auth. `jwk_rsa_pem` is the RSA public key to
     /// validate the JWTs. `tenant_id` must be parseable as a UUID.
-    pub fn new(
-        admin_api_token_url: String,
-        jwk_rsa_pem: &[u8],
-        tenant_id: Uuid,
-        now: NowFn,
-    ) -> Result<Self, anyhow::Error> {
-        let decoding_key = DecodingKey::from_rsa_pem(&jwk_rsa_pem)?;
+    pub fn new(config: FronteggConfig) -> Result<Self, anyhow::Error> {
+        let decoding_key = DecodingKey::from_rsa_pem(&config.jwk_rsa_pem)?;
         let mut validation = Validation::new(Algorithm::RS256);
         // We validate with our own now function.
         validation.validate_exp = false;
         Ok(Self {
-            admin_api_token_url,
+            admin_api_token_url: config.admin_api_token_url,
             decoding_key,
-            tenant_id,
-            now,
+            tenant_id: config.tenant_id,
+            now: config.now,
             validation,
+            refresh_before_secs: config.refresh_before_secs,
         })
     }
 
@@ -109,7 +124,11 @@ impl FronteggAuthentication {
     }
 
     /// Validates an access token and its `tenant_id`.
-    pub fn validate_access_token(&self, token: &str) -> Result<Claims, anyhow::Error> {
+    pub fn validate_access_token(
+        &self,
+        token: &str,
+        expected_email: Option<&str>,
+    ) -> Result<Claims, anyhow::Error> {
         let msg = decode::<Claims>(&token, &self.decoding_key, &self.validation)?;
         if msg.claims.exp < self.now.as_secs() {
             bail!("token expired")
@@ -117,7 +136,78 @@ impl FronteggAuthentication {
         if msg.claims.tenant_id != self.tenant_id {
             bail!("tenant ids don't match")
         }
+        if let Some(expected_email) = expected_email {
+            if msg.claims.email != expected_email {
+                bail!("unexpected email")
+            }
+        }
         Ok(msg.claims)
+    }
+
+    /// Returns a future that resolves if the token has expired.
+    pub fn check_expiry(
+        &self,
+        mut token: ApiTokenResponse,
+        expected_email: String,
+    ) -> Result<impl Future<Output = ()>, anyhow::Error> {
+        // Do an initial full validity check of the token.
+        let mut claims = self.validate_access_token(&token.access_token, Some(&expected_email))?;
+        let frontegg = self.clone();
+
+        // This future resolves once the token expiry time has been reached. It will
+        // repeatedly attempt to refresh the token before it expires.
+        Ok(async move {
+            let refresh_url = format!("{}{}", frontegg.admin_api_token_url, REFRESH_SUFFIX);
+            loop {
+                let expire_in = claims.exp - frontegg.now.as_secs();
+                // Using max(0, X) here ensures we don't have a negative, and thus have a
+                // lossless conversion to u64.
+                let check_in = std::cmp::max(0, expire_in - frontegg.refresh_before_secs) as u64;
+                tokio::time::sleep(Duration::from_secs(check_in)).await;
+
+                let refresh_request = async {
+                    let refresh = RefreshToken {
+                        refresh_token: token.refresh_token,
+                    };
+                    loop {
+                        let resp = async {
+                            let token = reqwest::Client::new()
+                                .post(&refresh_url)
+                                .json(&refresh)
+                                .send()
+                                .await?
+                                .error_for_status()?
+                                .json::<ApiTokenResponse>()
+                                .await?;
+                            let claims = frontegg.validate_access_token(
+                                &token.access_token,
+                                Some(&expected_email),
+                            )?;
+                            Ok::<(ApiTokenResponse, Claims), anyhow::Error>((token, claims))
+                        };
+                        match resp.await {
+                            Ok((token, claims)) => {
+                                return (token, claims);
+                            }
+                            Err(_) => {
+                                // Some error occurred, retry again later. 5 seconds chosen arbitrarily.
+                                tokio::time::sleep(Duration::from_secs(5)).await;
+                            }
+                        }
+                    }
+                };
+                let expire_in = std::cmp::max(0, claims.exp - frontegg.now.as_secs()) as u64;
+                let expire_in = tokio::time::sleep(Duration::from_secs(expire_in));
+
+                tokio::select! {
+                    _ = expire_in => return (),
+                    (refresh_token, refresh_claims) = refresh_request => {
+                        token = refresh_token;
+                        claims = refresh_claims;
+                    },
+                };
+            }
+        })
     }
 }
 
@@ -126,6 +216,12 @@ impl FronteggAuthentication {
 pub struct ApiTokenArgs {
     pub client_id: Uuid,
     pub secret: Uuid,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RefreshToken {
+    pub refresh_token: String,
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -44,7 +44,7 @@ use itertools::Itertools;
 use lazy_static::lazy_static;
 use mz_coord::{PersistConfig, PersistFileStorage, PersistStorage};
 use mz_dataflow_types::sources::AwsExternalId;
-use mz_frontegg_auth::FronteggAuthentication;
+use mz_frontegg_auth::{FronteggAuthentication, FronteggConfig};
 use mz_ore::cgroup::{detect_memory_limit, MemoryLimit};
 use mz_ore::metric;
 use mz_ore::metrics::ThirdPartyMetric;
@@ -509,12 +509,13 @@ fn run(args: Args) -> Result<(), anyhow::Error> {
     let frontegg = args
         .frontegg_tenant
         .map(|tenant_id| {
-            FronteggAuthentication::new(
-                args.frontegg_api_token_url.unwrap(),
-                args.frontegg_jwk.unwrap().as_bytes(),
+            FronteggAuthentication::new(FronteggConfig {
+                admin_api_token_url: args.frontegg_api_token_url.unwrap(),
+                jwk_rsa_pem: args.frontegg_jwk.unwrap().as_bytes(),
                 tenant_id,
-                mz_ore::now::SYSTEM_TIME.clone(),
-            )
+                now: mz_ore::now::SYSTEM_TIME.clone(),
+                refresh_before_secs: 60,
+            })
         })
         .transpose()?;
 

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -513,6 +513,7 @@ fn run(args: Args) -> Result<(), anyhow::Error> {
                 args.frontegg_api_token_url.unwrap(),
                 args.frontegg_jwk.unwrap().as_bytes(),
                 tenant_id,
+                mz_ore::now::SYSTEM_TIME.clone(),
             )
         })
         .transpose()?;

--- a/src/materialized/src/http.rs
+++ b/src/materialized/src/http.rs
@@ -367,12 +367,6 @@ async fn validate_http_frontegg_authentication(
         anyhow::bail!("expected authorization");
     };
 
-    let claims = frontegg.validate_access_token(&jwt)?;
-    // If a username was specified, make sure it matches the JWT email.
-    if let Some(http_user) = http_user {
-        if http_user != claims.email {
-            anyhow::bail!("HTTP Authorization user and JWT email do not match");
-        }
-    }
+    let claims = frontegg.validate_access_token(&jwt, http_user.as_deref())?;
     Ok(claims.email)
 }

--- a/src/ore/src/now.rs
+++ b/src/ore/src/now.rs
@@ -36,6 +36,13 @@ pub fn to_datetime(millis: EpochMillis) -> DateTime<Utc> {
 #[derive(Clone)]
 pub struct NowFn(Arc<dyn Fn() -> EpochMillis + Send + Sync>);
 
+impl NowFn {
+    /// Returns now in seconds.
+    pub fn as_secs(&self) -> i64 {
+        ((self)() / 1_000) as i64
+    }
+}
+
 impl fmt::Debug for NowFn {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str("<now_fn>")

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -15,7 +15,7 @@ use std::iter;
 use std::mem;
 
 use byteorder::{ByteOrder, NetworkEndian};
-use futures::future::{BoxFuture, FutureExt};
+use futures::future::{pending, BoxFuture, FutureExt};
 use itertools::izip;
 use mz_expr::GlobalId;
 use openssl::nid::Nid;
@@ -159,28 +159,12 @@ where
         }
     }
 
-    if let Some(frontegg) = frontegg {
+    let is_expired = if let Some(frontegg) = frontegg {
         conn.send(BackendMessage::AuthenticationCleartextPassword)
             .await?;
         conn.flush().await?;
-        match conn.recv().await? {
-            Some(FrontendMessage::Password { password }) => {
-                let res = frontegg
-                    .exchange_password_for_token(&password)
-                    .await
-                    .and_then(|res| frontegg.validate_access_token(&res.access_token));
-                match res {
-                    Ok(claims) if claims.email == user => {}
-                    _ => {
-                        return conn
-                            .send(ErrorResponse::fatal(
-                                SqlState::INVALID_PASSWORD,
-                                "invalid password",
-                            ))
-                            .await;
-                    }
-                }
-            }
+        let password = match conn.recv().await? {
+            Some(FrontendMessage::Password { password }) => password,
             _ => {
                 return conn
                     .send(ErrorResponse::fatal(
@@ -189,8 +173,26 @@ where
                     ))
                     .await
             }
+        };
+        match frontegg
+            .exchange_password_for_token(&password)
+            .await
+            .and_then(|token| frontegg.check_expiry(token, user.clone()))
+        {
+            Ok(check) => check.left_future(),
+            _ => {
+                return conn
+                    .send(ErrorResponse::fatal(
+                        SqlState::INVALID_PASSWORD,
+                        "invalid password",
+                    ))
+                    .await;
+            }
         }
-    }
+    } else {
+        // No frontegg check, so is_expired never resolves.
+        pending().right_future()
+    };
 
     // Construct session.
     let mut session = Session::new(conn.id(), user);
@@ -212,6 +214,7 @@ where
 
     // From this point forward we must not fail without calling `coord_client.terminate`!
 
+    let mut allow_no_session = false;
     let res = async {
         let session = coord_client.session();
         let mut buf = vec![BackendMessage::AuthenticationOk];
@@ -234,10 +237,24 @@ where
             conn,
             coord_client: &mut coord_client,
         };
-        machine.run().await
+
+        tokio::select! {
+            r = machine.run() => r,
+            _ = is_expired => {
+                // If the login has expired, we immediately stop running the state machine,
+                // meaning the session could still be owned by the coordinator, so we allow no
+                // session to be present.
+                allow_no_session = true;
+                Err(io::ErrorKind::ConnectionAborted.into())
+            }
+        }
     }
     .await;
-    coord_client.terminate().await;
+    if allow_no_session {
+        coord_client.terminate_allow_no_session().await;
+    } else {
+        coord_client.terminate().await;
+    }
     res
 }
 


### PR DESCRIPTION
The frontegg tokens come with an expiry time. Previously we were
validating that once at the start but then not rechecking during
further use. Teach pgwire to care about the token expiring.

This is done by creating a new Future that resolves if the token has
expired, and can happen at a time when the session client is interacting
with the coordinator, which means the coordinator could still own the
session. Teach both sides to handle this and always gracefully terminate
a session. The Future has an internal loop to refresh the token, but still
a respects the expiry time while attempting that.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Materialize Cloud SQL sessions now respect login token expiry and attempt to refresh it in the background.