### PR TITLE
make newline linter catch multiple files

### DIFF
--- a/misc/lint/trailing-newline.sh
+++ b/misc/lint/trailing-newline.sh
@@ -20,6 +20,7 @@ if [[ $# -lt 1 ]]; then
     echo "usage: $0 <file>" >&2
     exit 1
 fi
+errors=0
 
 for file in "$@"; do
     if [[ ! -f "$file" ]]; then
@@ -30,6 +31,9 @@ for file in "$@"; do
     last_byte=$(tail -c1 "$file")
     if [[ "$last_byte" != $'\n' && "$last_byte" != "" ]] &> /dev/null; then
         echo "lint: $(red error:) trailing-newline: $file is missing a trailing newline" >&2
+        errors++
+    fi
+    if [[ $errors -gt 0 ]]; then
         exit 1
     fi
 done

--- a/misc/lint/trailing-newline.sh
+++ b/misc/lint/trailing-newline.sh
@@ -31,9 +31,10 @@ for file in "$@"; do
     last_byte=$(tail -c1 "$file")
     if [[ "$last_byte" != $'\n' && "$last_byte" != "" ]] &> /dev/null; then
         echo "lint: $(red error:) trailing-newline: $file is missing a trailing newline" >&2
-        errors++
-    fi
-    if [[ $errors -gt 0 ]]; then
-        exit 1
+        ((errors++))
     fi
 done
+
+if [[ $errors -gt 0 ]]; then
+        exit 1
+fi


### PR DESCRIPTION
The existing implementation would bail at a single file missing the trailing newline, which is fine in CI but makes it frustrating to use locally. This change simply accumulates an error count and returns non-zero if the counter is non-zero.


  * This PR adds a feature that has not yet been specified.
    - Only having to run `bin/lint` once to detect all problems that would fail in CI is a handy
    

### Testing

- [X] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

No user facing changes.