### PR TITLE
test/kafka-matrix: restore full suite of kafka matrix tests

### DIFF
--- a/test/kafka-matrix/mzcompose.py
+++ b/test/kafka-matrix/mzcompose.py
@@ -27,7 +27,7 @@ CONFLUENT_PLATFORM_VERSIONS = [
 
 SERVICES = [
     Materialized(),
-    Testdrive(),
+    Testdrive(volumes_extra=["../testdrive:/workdir/testdrive"]),
     Zookeeper(),
     Kafka(),
     SchemaRegistry(),
@@ -47,7 +47,7 @@ def workflow_default(c: Composition) -> None:
                 services=["zookeeper", "kafka", "schema-registry", "materialized"]
             )
             c.wait_for_materialized()
-            c.run("testdrive-svc", "kafka-matrix.td")
+            c.run("testdrive-svc", "kafka-matrix.td", "testdrive/kafka-*.td")
             c.rm(
                 "zookeeper",
                 "kafka",


### PR DESCRIPTION
I broke this in 528e110 when I ported the test to Python.

Fix #10880.

### Motivation

  * This PR fixes a recognized bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - No user-facing behavior changes.
