### PR TITLE
coord,dataflow: remove special cases for table indexes

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -138,7 +138,7 @@ use mz_sql::plan::{OptimizerConfig, StatementDesc, View};
 use mz_transform::Optimizer;
 
 use self::prometheus::Scraper;
-use crate::catalog::builtin::{BUILTINS, MZ_VIEW_FOREIGN_KEYS, MZ_VIEW_KEYS};
+use crate::catalog::builtin::{self, BUILTINS, MZ_VIEW_FOREIGN_KEYS, MZ_VIEW_KEYS};
 use crate::catalog::{self, storage, BuiltinTableUpdate, Catalog, CatalogItem, SinkConnectorState};
 use crate::client::{Client, Handle};
 use crate::command::{
@@ -250,18 +250,6 @@ struct PendingPeek {
     conn_id: u32,
 }
 
-/// The return value of [`Coordinator::determine_timestamp`].
-struct DeterminedTimestamp {
-    /// The determined timestamp.
-    timestamp: mz_repr::Timestamp,
-    /// The identifiers of sources that were involved in timestamp
-    /// determination.
-    storage_ids: Vec<GlobalId>,
-    /// The identifiers of indexes that were involved in timestamp
-    /// determination.
-    compute_ids: Vec<GlobalId>,
-}
-
 /// Glues the external world to the Timely workers.
 pub struct Coordinator {
     /// A client to a running dataflow cluster.
@@ -353,7 +341,6 @@ struct TxnReads {
     // happens if both 1) there are no referenced sources or indexes and 2)
     // `mz_logical_timestamp()` is not present.
     timestamp_independent: bool,
-    timedomain_ids: HashSet<GlobalId>,
     read_holds: crate::coord::read_holds::ReadHolds<mz_repr::Timestamp>,
 }
 
@@ -1611,6 +1598,15 @@ impl Coordinator {
             frontier: self.determine_frontier(&[sink.from]),
             strict: !sink.with_snapshot,
         };
+        // If the sink depends on tables, the `determine_frontier` call above
+        // will have called `get_local_read_ts` to determine the `as_of` for the
+        // sink. The below call to `catalog_transact` will call
+        // `get_local_write_ts` to emit an update to the system catalog. This
+        // interleaving of reads and writes is only guaranteed to succeed if we
+        // advance local inputs now.
+        //
+        // TODO(benesch): this is brittle. Can we make it less brittle?
+        self.advance_local_inputs().await;
         let ops = vec![
             catalog::Op::DropItem(id),
             catalog::Op::CreateItem {
@@ -2861,34 +2857,70 @@ impl Coordinator {
     /// schemas with the same timeline as whatever the first query is".
     fn timedomain_for(
         &self,
-        source_ids: &[GlobalId],
-        source_timeline: &Option<Timeline>,
+        uses_ids: &[GlobalId],
+        timeline: &Option<Timeline>,
         conn_id: u32,
-    ) -> Result<Vec<GlobalId>, CoordError> {
-        let mut timedomain_ids = self
-            .catalog
-            .schema_adjacent_indexed_relations(&source_ids, conn_id);
+    ) -> Result<(Vec<GlobalId>, Vec<GlobalId>), CoordError> {
+        // Gather all the used schemas.
+        let mut schemas = HashSet::new();
+        for id in uses_ids {
+            let entry = self.catalog.get_by_id(&id);
+            let name = entry.name();
+            schemas.insert((&name.database, &*name.schema));
+        }
 
-        // Filter out ids from different timelines. The timeline code only verifies
-        // that the SELECT doesn't cross timelines. The schema-adjacent code looks
-        // for other ids in the same database schema.
-        timedomain_ids.retain(|&id| {
-            let id_timeline = self
-                .validate_timeline(vec![id])
-                .expect("single id should never fail");
-            match (&id_timeline, &source_timeline) {
-                // If this id doesn't have a timeline, we can keep it.
-                (None, _) => true,
-                // If there's no source timeline, we have the option to opt into a timeline,
-                // so optimistically choose epoch ms. This is useful when the first query in a
-                // transaction is on a static view.
-                (Some(id_timeline), None) => id_timeline == &Timeline::EpochMilliseconds,
-                // Otherwise check if timelines are the same.
-                (Some(id_timeline), Some(source_timeline)) => id_timeline == source_timeline,
-            }
-        });
+        // If any of the system schemas is specified, add the rest of the
+        // system schemas.
+        let system_schemas = &[
+            (&DatabaseSpecifier::Ambient, builtin::MZ_CATALOG_SCHEMA),
+            (&DatabaseSpecifier::Ambient, builtin::PG_CATALOG_SCHEMA),
+            (&DatabaseSpecifier::Ambient, builtin::INFORMATION_SCHEMA),
+        ];
+        if system_schemas.iter().any(|s| schemas.contains(s)) {
+            schemas.extend(system_schemas);
+        }
 
-        Ok(timedomain_ids)
+        // Gather the IDs of all items in all used schemas.
+        let mut item_ids: HashSet<GlobalId> = HashSet::new();
+        for (db, schema) in schemas {
+            let schema = self
+                .catalog
+                .get_schema(db, schema, conn_id)
+                .expect("known to exist");
+            item_ids.extend(schema.items.values());
+        }
+
+        // Gather the indexes and unmaterialized sources used by those items.
+        let mut storage_ids = vec![];
+        let mut compute_ids = vec![];
+        for id in item_ids {
+            let (indexes, sources) = self.catalog.nearest_indexes(&[id]);
+            storage_ids.extend(sources);
+            compute_ids.extend(indexes);
+        }
+
+        // Filter out ids from different timelines.
+        for ids in [&mut storage_ids, &mut compute_ids] {
+            ids.sort();
+            ids.dedup();
+            ids.retain(|&id| {
+                let id_timeline = self
+                    .validate_timeline(vec![id])
+                    .expect("single id should never fail");
+                match (&id_timeline, &timeline) {
+                    // If this id doesn't have a timeline, we can keep it.
+                    (None, _) => true,
+                    // If there's no source timeline, we have the option to opt into a timeline,
+                    // so optimistically choose epoch ms. This is useful when the first query in a
+                    // transaction is on a static view.
+                    (Some(id_timeline), None) => id_timeline == &Timeline::EpochMilliseconds,
+                    // Otherwise check if timelines are the same.
+                    (Some(id_timeline), Some(source_timeline)) => id_timeline == source_timeline,
+                }
+            });
+        }
+
+        Ok((storage_ids, compute_ids))
     }
 
     /// Sequence a peek, determining a timestamp and the most efficient dataflow interaction.
@@ -2940,65 +2972,67 @@ impl Coordinator {
                 _ => {
                     // Determine a timestamp that will be valid for anything in any schema
                     // referenced by the first query.
-                    let mut timedomain_ids =
+                    let (storage_ids, compute_ids) =
                         self.timedomain_for(&source_ids, &timeline, conn_id)?;
 
                     // We want to prevent compaction of the indexes consulted by
                     // determine_timestamp, not the ones listed in the query.
-                    let determined =
-                        self.determine_timestamp(session, &timedomain_ids, PeekWhen::Immediately)?;
-                    // Add the used sources and indexes to the recorded ids.
-                    timedomain_ids.extend(&determined.storage_ids);
-                    timedomain_ids.extend(&determined.compute_ids);
+                    let timestamp = self.determine_timestamp(
+                        session,
+                        &storage_ids,
+                        &compute_ids,
+                        PeekWhen::Immediately,
+                    )?;
                     let read_holds = read_holds::ReadHolds {
-                        time: determined.timestamp,
-                        storage_ids: determined.storage_ids,
-                        compute_ids: determined.compute_ids,
+                        time: timestamp,
+                        storage_ids,
+                        compute_ids,
                         compute_instance: DEFAULT_COMPUTE_INSTANCE_ID,
                     };
                     self.acquire_read_holds(&read_holds).await;
                     let txn_reads = TxnReads {
                         timestamp_independent,
-                        timedomain_ids: timedomain_ids.into_iter().collect(),
                         read_holds,
                     };
                     self.txn_reads.insert(conn_id, txn_reads);
-
-                    determined.timestamp
+                    timestamp
                 }
             };
             session.add_transaction_ops(TransactionOps::Peeks(timestamp))?;
 
-            // Verify that the references and indexes for this query are in the current
-            // read transaction.
-            let mut stmt_ids = HashSet::new();
-            stmt_ids.extend(source_ids.iter().collect::<HashSet<_>>());
-            // Using nearest_indexes here is a hack until #8318 is fixed. It's used because
-            // that's what determine_timestamp uses.
-            stmt_ids.extend(
-                self.catalog
-                    .nearest_indexes(&source_ids)
-                    .0
-                    .into_iter()
-                    .collect::<HashSet<_>>(),
-            );
+            // Verify that the references and indexes for this query are in the
+            // current read transaction.
+            //
+            // Using nearest_indexes here is a hack until #8318 is fixed. It's
+            // used because that's what determine_timestamp uses.
+            let (compute_ids, storage_ids) = self.catalog.nearest_indexes(&source_ids);
+            let storage_ids = BTreeSet::from_iter(storage_ids);
+            let compute_ids = BTreeSet::from_iter(compute_ids);
+
             let read_txn = self.txn_reads.get(&conn_id).unwrap();
+            let allowed_storage_ids =
+                BTreeSet::from_iter(read_txn.read_holds.storage_ids.iter().copied());
+            let allowed_compute_ids =
+                BTreeSet::from_iter(read_txn.read_holds.compute_ids.iter().copied());
+
             // Find the first reference or index (if any) that is not in the transaction. A
             // reference could be caused by a user specifying an object in a different
             // schema than the first query. An index could be caused by a CREATE INDEX
             // after the transaction started.
-            let outside: Vec<_> = stmt_ids.difference(&read_txn.timedomain_ids).collect();
-            if !outside.is_empty() {
-                let mut names: Vec<_> = read_txn
-                    .timedomain_ids
-                    .iter()
+            let outside_storage = &storage_ids - &allowed_storage_ids;
+            let outside_compute = &compute_ids - &allowed_compute_ids;
+            if !outside_storage.is_empty() || !outside_compute.is_empty() {
+                let mut names: Vec<_> = allowed_storage_ids
+                    .into_iter()
+                    .chain(allowed_compute_ids)
                     // This could filter out a view that has been replaced in another transaction.
-                    .filter_map(|id| self.catalog.try_get_by_id(*id))
+                    .filter_map(|id| self.catalog.try_get_by_id(id))
                     .map(|item| item.name().to_string())
                     .collect();
-                let mut outside: Vec<_> = outside
+                let mut outside: Vec<_> = outside_storage
                     .into_iter()
-                    .filter_map(|id| self.catalog.try_get_by_id(*id))
+                    .chain(outside_compute)
+                    .filter_map(|id| self.catalog.try_get_by_id(id))
                     .map(|item| item.name().to_string())
                     .collect();
                 // Sort so error messages are deterministic.
@@ -3012,8 +3046,8 @@ impl Coordinator {
 
             timestamp
         } else {
-            self.determine_timestamp(session, &source_ids, when)?
-                .timestamp
+            let (compute_ids, storage_ids) = self.catalog.nearest_indexes(&source_ids);
+            self.determine_timestamp(session, &storage_ids, &compute_ids, when)?
         };
 
         let source = self.view_optimizer.optimize(source)?;
@@ -3111,9 +3145,14 @@ impl Coordinator {
             // Updates greater or equal to this frontier will be produced.
             let frontier = if let Some(ts) = ts {
                 // If a timestamp was explicitly requested, use that.
-                let determined =
-                    coord.determine_timestamp(session, uses, PeekWhen::AtTimestamp(ts))?;
-                Antichain::from_elem(determined.timestamp)
+                let (compute_ids, storage_ids) = coord.catalog.nearest_indexes(uses);
+                let ts = coord.determine_timestamp(
+                    session,
+                    &storage_ids,
+                    &compute_ids,
+                    PeekWhen::AtTimestamp(ts),
+                )?;
+                Antichain::from_elem(ts)
             } else {
                 coord.determine_frontier(uses)
             };
@@ -3251,9 +3290,10 @@ impl Coordinator {
     fn determine_timestamp(
         &mut self,
         session: &Session,
-        uses_ids: &[GlobalId],
+        unmaterialized_source_ids: &[GlobalId],
+        index_ids: &[GlobalId],
         when: PeekWhen,
-    ) -> Result<DeterminedTimestamp, CoordError> {
+    ) -> Result<Timestamp, CoordError> {
         // Each involved trace has a validity interval `[since, upper)`.
         // The contents of a trace are only guaranteed to be correct when
         // accumulated at a time greater or equal to `since`, and they
@@ -3265,7 +3305,6 @@ impl Coordinator {
         // the compacted arrangements we have at hand. It remains unresolved
         // what to do if it cannot be satisfied (perhaps the query should use
         // a larger timestamp and block, perhaps the user should intervene).
-        let (index_ids, unmaterialized_source_ids) = self.catalog.nearest_indexes(uses_ids);
 
         let since = self.least_valid_read(
             &unmaterialized_source_ids,
@@ -3320,49 +3359,52 @@ impl Coordinator {
 
                 // Compute a timestamp to which we should advance the candidate (if it is in
                 // advance).
-                let advance_to: Timestamp =
-                    if uses_ids.iter().any(|id| self.catalog.uses_tables(*id)) {
-                        // If the view depends on any tables, we enforce linearizability by choosing
-                        // the latest input time.  If the candidate is already advanced past read_ts
-                        // due to the since work above (if joined with some other view), a peek will
-                        // be put into pending until something closes the table timestamp. That
-                        // occurs if a user does certain table operations, or otherwise by the
-                        // advance_local_inputs_loop task (and so the pending peek could wait up to 1
-                        // second before the table timestamp is closed). We do not need to worry about
-                        // telling the table linearizability stuff about this future timestamp because
-                        // by the time the read is served the table linearizability time will have
-                        // advanced already.
-                        self.get_local_read_ts()
-                    } else {
-                        let upper = self.least_valid_write(
-                            &unmaterialized_source_ids,
-                            &index_ids,
-                            DEFAULT_COMPUTE_INSTANCE_ID,
-                        );
+                let advance_to: Timestamp = if unmaterialized_source_ids
+                    .iter()
+                    .any(|id| self.catalog.uses_tables(*id))
+                    || index_ids.iter().any(|id| self.catalog.uses_tables(*id))
+                {
+                    // If the view depends on any tables, we enforce linearizability by choosing
+                    // the latest input time.  If the candidate is already advanced past read_ts
+                    // due to the since work above (if joined with some other view), a peek will
+                    // be put into pending until something closes the table timestamp. That
+                    // occurs if a user does certain table operations, or otherwise by the
+                    // advance_local_inputs_loop task (and so the pending peek could wait up to 1
+                    // second before the table timestamp is closed). We do not need to worry about
+                    // telling the table linearizability stuff about this future timestamp because
+                    // by the time the read is served the table linearizability time will have
+                    // advanced already.
+                    self.get_local_read_ts()
+                } else {
+                    let upper = self.least_valid_write(
+                        &unmaterialized_source_ids,
+                        &index_ids,
+                        DEFAULT_COMPUTE_INSTANCE_ID,
+                    );
 
-                        // We peek at the largest element not in advance of `upper`, which
-                        // involves a subtraction. If `upper` contains a zero timestamp there
-                        // is no "prior" answer, and we do not want to peek at it as it risks
-                        // hanging awaiting the response to data that may never arrive.
-                        //
-                        // The .get(0) here breaks the antichain abstraction by assuming this antichain
-                        // has 0 or 1 elements in it. It happens to work because we use a timestamp
-                        // type that meets that assumption, but would break if we used a more general
-                        // timestamp.
-                        if let Some(candidate) = upper.elements().get(0) {
-                            if *candidate > Timestamp::minimum() {
-                                candidate.saturating_sub(1)
-                            } else {
-                                Timestamp::minimum()
-                            }
+                    // We peek at the largest element not in advance of `upper`, which
+                    // involves a subtraction. If `upper` contains a zero timestamp there
+                    // is no "prior" answer, and we do not want to peek at it as it risks
+                    // hanging awaiting the response to data that may never arrive.
+                    //
+                    // The .get(0) here breaks the antichain abstraction by assuming this antichain
+                    // has 0 or 1 elements in it. It happens to work because we use a timestamp
+                    // type that meets that assumption, but would break if we used a more general
+                    // timestamp.
+                    if let Some(candidate) = upper.elements().get(0) {
+                        if *candidate > Timestamp::minimum() {
+                            candidate.saturating_sub(1)
                         } else {
-                            // A complete trace can be read in its final form with this time.
-                            //
-                            // This should only happen for literals that have no sources or sources that
-                            // are known to have completed (non-tailed files for example).
-                            Timestamp::MAX
+                            Timestamp::minimum()
                         }
-                    };
+                    } else {
+                        // A complete trace can be read in its final form with this time.
+                        //
+                        // This should only happen for literals that have no sources or sources that
+                        // are known to have completed (non-tailed files for example).
+                        Timestamp::MAX
+                    }
+                };
                 candidate.join_assign(&advance_to);
                 candidate
             }
@@ -3371,11 +3413,7 @@ impl Coordinator {
         // If the timestamp is greater or equal to some element in `since` we are
         // assured that the answer will be correct.
         if since.less_equal(&timestamp) {
-            Ok(DeterminedTimestamp {
-                timestamp,
-                compute_ids: index_ids,
-                storage_ids: unmaterialized_source_ids,
-            })
+            Ok(timestamp)
         } else {
             let invalid_indexes = index_ids
                 .iter()
@@ -3448,7 +3486,11 @@ impl Coordinator {
             DEFAULT_COMPUTE_INSTANCE_ID,
         );
 
-        let mut candidate = if index_ids.iter().any(|id| self.catalog.uses_tables(*id)) {
+        let mut candidate = if unmaterialized_source_ids
+            .iter()
+            .any(|id| self.catalog.uses_tables(*id))
+            || index_ids.iter().any(|id| self.catalog.uses_tables(*id))
+        {
             // If the sink depends on any tables, we enforce linearizability by choosing
             // the latest input time.
             self.get_local_read_ts()

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -164,7 +164,7 @@ pub fn serve_boundary<
             timely_worker,
             compute_state: BTreeMap::default(),
             storage_state: StorageState {
-                local_inputs: HashMap::new(),
+                table_state: HashMap::new(),
                 source_descriptions: HashMap::new(),
                 source_uppers: HashMap::new(),
                 ts_source_mapping: HashMap::new(),

--- a/src/materialized/tests/sql.rs
+++ b/src/materialized/tests/sql.rs
@@ -235,6 +235,7 @@ fn test_tail_basic() -> Result<(), Box<dyn Error>> {
     let mut client_reads = server.connect(postgres::NoTls)?;
 
     client_writes.batch_execute("CREATE TABLE t (data text)")?;
+    client_writes.batch_execute("CREATE DEFAULT INDEX t_primary_idx ON t")?;
     client_reads.batch_execute(
         "BEGIN;
          DECLARE c CURSOR FOR TAIL t;",

--- a/test/coordtest/github-6687.ct
+++ b/test/coordtest/github-6687.ct
@@ -16,6 +16,13 @@ CreatedTable {
 }
 
 sql
+CREATE DEFAULT INDEX t_primary_idx ON t
+----
+CreatedIndex {
+    existed: false,
+}
+
+sql
 ALTER INDEX t_primary_idx SET (logical_compaction_window = '1ms')
 ----
 AlteredObject(

--- a/test/restart/user-indexes-disabled.td
+++ b/test/restart/user-indexes-disabled.td
@@ -101,22 +101,15 @@ mat_data  mat_data_primary_idx  1             a            <null>      false    
 
 # 🔬🔬 Tables
 
-! INSERT INTO t VALUES (1)
-contains:cannot perform operation on "materialize.public.t" while its default index ("materialize.public.t_primary_idx") is disabled
+> INSERT INTO t VALUES (1)
 
-! UPDATE t SET a = 1
-contains:cannot perform operation on "materialize.public.t" while its default index ("materialize.public.t_primary_idx") is disabled
-
-! DELETE FROM t;
-contains:cannot perform operation on "materialize.public.t" while its default index ("materialize.public.t_primary_idx") is disabled
-
-# Selects work but are always empty
+# Selects work.
 > SELECT * FROM t
+1
 
 > SHOW INDEXES FROM t;
 on_name   key_name      seq_in_index  column_name  expression  nullable enabled
 -----------------------------------------------------------------------------
-t         t_primary_idx 1             a            <null>      true     false
 t         t_drop_idx    1             a            <null>      true     false
 
 # 🔬🔬 Indexes
@@ -127,7 +120,6 @@ t         t_drop_idx    1             a            <null>      true     false
 > SHOW INDEXES FROM t;
 on_name   key_name        seq_in_index  column_name  expression  nullable enabled
 -----------------------------------------------------------------------------
-t         t_primary_idx   1             a            <null>      true     false
 t         t_drop_idx      1             a            <null>      true     false
 t         t_secondary_idx 1             <null>       "a + a"     true     false
 
@@ -136,7 +128,6 @@ t         t_secondary_idx 1             <null>       "a + a"     true     false
 > SHOW INDEXES FROM t;
 on_name   key_name        seq_in_index  column_name  expression  nullable enabled
 -----------------------------------------------------------------------------
-t         t_primary_idx   1             a            <null>      true     false
 t         t_secondary_idx 1             <null>       "a + a"     true     false
 
 # 🔬 Enabling indexes
@@ -211,27 +202,23 @@ $ kafka-verify format=avro sink=materialize.public.snk_indexes_disabled sort-mes
 # 🔬🔬 Tables
 
 # Tables still work with non-primary indexes enabled because all indexes are covering
-! ALTER INDEX t_secondary_idx SET ENABLED;
-contains:cannot perform operation on "materialize.public.t" while its default index ("materialize.public.t_primary_idx") is disabled
-
-> ALTER INDEX t_primary_idx SET ENABLED
-
 > SHOW INDEXES FROM t;
 on_name   key_name        seq_in_index  column_name  expression  nullable enabled
 -----------------------------------------------------------------------------
-t         t_primary_idx   1             a            <null>      true     true
 t         t_secondary_idx 1             <null>       "a + a"     true     false
-
-> INSERT INTO t VALUES (1)
-
-> SELECT * FROM t
-1
-
-# Check idempotency
-> ALTER INDEX t_primary_idx SET ENABLED
 
 > INSERT INTO t VALUES (2)
 
 > SELECT * FROM t
 1
 2
+
+# Check idempotency
+> ALTER INDEX t_secondary_idx SET ENABLED
+
+> INSERT INTO t VALUES (3)
+
+> SELECT * FROM t
+1
+2
+3

--- a/test/sqllogictest/aggregates.slt
+++ b/test/sqllogictest/aggregates.slt
@@ -176,8 +176,12 @@ SELECT a, sum(b) from agg_pk group by a order by a
 query T multiline
 EXPLAIN PLAN FOR SELECT a, sum(b) from agg_pk group by a
 ----
+Source materialize.public.agg_pk (u3):
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.agg_pk (u5)
+| Get materialize.public.agg_pk (u3)
 | Map i32toi64(#1)
 | Project (#0, #3)
 
@@ -193,8 +197,12 @@ SELECT a, sum(c) from agg_pk group by a order by a
 query T multiline
 EXPLAIN PLAN FOR SELECT a, sum(c) from agg_pk group by a
 ----
+Source materialize.public.agg_pk (u3):
+| Project (#0, #2)
+
+Query:
 %0 =
-| Get materialize.public.agg_pk (u5)
+| Get materialize.public.agg_pk (u3)
 | Map i64tonumeric(#2)
 | Project (#0, #3)
 

--- a/test/sqllogictest/arithmetic.slt
+++ b/test/sqllogictest/arithmetic.slt
@@ -878,8 +878,12 @@ EXPLAIN SELECT
   y1 << y2 >> y3 as r2
 FROM nums
 ----
+Source materialize.public.nums (u3):
+| Project (#0..=#5)
+
+Query:
 %0 =
-| Get materialize.public.nums (u5)
+| Get materialize.public.nums (u3)
 | Map ((#0 >> i16toi32(#1)) << i16toi32(#2)), ((#3 << #4) >> #5)
 | Project (#9, #10)
 
@@ -909,8 +913,12 @@ EXPLAIN SELECT
   y1 << y2 & y3 as r2
 FROM nums
 ----
+Source materialize.public.nums (u3):
+| Project (#0..=#5)
+
+Query:
 %0 =
-| Get materialize.public.nums (u5)
+| Get materialize.public.nums (u3)
 | Map ((#0 >> i16toi32(#1)) & #2), ((#3 << #4) & #5)
 | Project (#9, #10)
 
@@ -942,8 +950,12 @@ EXPLAIN SELECT
   x1 & y2 | z3 as r4
 FROM nums
 ----
+Source materialize.public.nums (u3):
+| Project (#0..=#8)
+
+Query:
 %0 =
-| Get materialize.public.nums (u5)
+| Get materialize.public.nums (u3)
 | Map ((#0 & #1) | #2), ((#3 & #4) | #5), ((#6 & #7) | #8), (i32toi64((i16toi32(#0) & #4)) | #8)
 | Project (#9..=#12)
 
@@ -975,8 +987,12 @@ EXPLAIN SELECT
   x1 # y2 & z3 as r4
 FROM nums
 ----
+Source materialize.public.nums (u3):
+| Project (#0..=#8)
+
+Query:
 %0 =
-| Get materialize.public.nums (u5)
+| Get materialize.public.nums (u3)
 | Map ((#0 # #1) & #2), ((#3 # #4) & #5), ((#6 # #7) & #8), (i32toi64((i16toi32(#0) # #4)) & #8)
 | Project (#9..=#12)
 
@@ -1008,8 +1024,12 @@ EXPLAIN SELECT
   x1 # y2 | z3 as r4
 FROM nums
 ----
+Source materialize.public.nums (u3):
+| Project (#0..=#8)
+
+Query:
 %0 =
-| Get materialize.public.nums (u5)
+| Get materialize.public.nums (u3)
 | Map ((#0 # #1) | #2), ((#3 # #4) | #5), ((#6 # #7) | #8), (i32toi64((i16toi32(#0) # #4)) | #8)
 | Project (#9..=#12)
 

--- a/test/sqllogictest/autogenerated/all_parts_essential.slt
+++ b/test/sqllogictest/autogenerated/all_parts_essential.slt
@@ -193,11 +193,11 @@ WHERE l_quantity = 24
   AND l_quantity BETWEEN 3 AND 2 + 2
 ----
 %0 =
-| Get materialize.public.lineitem (u9)
+| Get materialize.public.lineitem (u7)
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.orders (u5)
+| Get materialize.public.orders (u4)
 | ArrangeBy (#0)
 
 %2 =
@@ -239,11 +239,11 @@ WHERE c_acctbal >= o_totalprice
   AND l_shipDATE >= o_orderdate
 ----
 %0 =
-| Get materialize.public.lineitem (u9)
+| Get materialize.public.lineitem (u7)
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.orders (u5)
+| Get materialize.public.orders (u4)
 | ArrangeBy (#0) (#1)
 
 %2 =
@@ -298,11 +298,11 @@ GROUP BY 1,
          2
 ----
 %0 =
-| Get materialize.public.lineitem (u9)
+| Get materialize.public.lineitem (u7)
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.orders (u5)
+| Get materialize.public.orders (u4)
 | ArrangeBy (#0) (#1)
 
 %2 =
@@ -362,13 +362,13 @@ GROUP BY 1,
          2
 ----
 %0 =
-| Get materialize.public.lineitem (u9)
+| Get materialize.public.lineitem (u7)
 | Filter (#3 != 1), (#3 != 2), (#3 != 6)
 | Project (#2..=#5, #12)
 | ArrangeBy (#4)
 
 %1 =
-| Get materialize.public.orders (u5)
+| Get materialize.public.orders (u4)
 | ArrangeBy (#1)
 
 %2 =
@@ -409,12 +409,12 @@ WHERE l_commitDATE >= '1998-03-22'
   OR l_receiptDATE = o_orderdate
 ----
 %0 =
-| Get materialize.public.lineitem (u9)
+| Get materialize.public.lineitem (u7)
 | Project (#0, #4, #11, #12)
 | ArrangeBy (#2)
 
 %1 =
-| Get materialize.public.orders (u5)
+| Get materialize.public.orders (u4)
 | Project (#0, #4)
 
 %2 = Let l0 =
@@ -423,7 +423,7 @@ WHERE l_commitDATE >= '1998-03-22'
 | Project (#0..=#4)
 
 %3 = Let l1 =
-| Get materialize.public.lineitem (u9)
+| Get materialize.public.lineitem (u7)
 | Filter (null || (((#0 <= 100) && (#0 >= 59)) && (#11 >= 1998-03-22)))
 
 %4 =
@@ -488,12 +488,12 @@ WHERE l_quantity = 17
                     33)
 ----
 %0 =
-| Get materialize.public.lineitem (u9)
+| Get materialize.public.lineitem (u7)
 | Project (#0, #4)
 | ArrangeBy ()
 
 %1 =
-| Get materialize.public.orders (u5)
+| Get materialize.public.orders (u4)
 | ArrangeBy (#0)
 
 %2 =
@@ -537,11 +537,11 @@ WHERE l_receiptDATE BETWEEN '1992-06-21' AND '1992-11-22'
 GROUP BY 1
 ----
 %0 =
-| Get materialize.public.lineitem (u9)
+| Get materialize.public.lineitem (u7)
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.orders (u5)
+| Get materialize.public.orders (u4)
 | ArrangeBy (#0) (#1)
 
 %2 =
@@ -595,13 +595,13 @@ GROUP BY 1,
          2
 ----
 %0 =
-| Get materialize.public.lineitem (u9)
+| Get materialize.public.lineitem (u7)
 | Filter (#3 != 4)
 | Project (#5, #10)
 | ArrangeBy ()
 
 %1 =
-| Get materialize.public.orders (u5)
+| Get materialize.public.orders (u4)
 | ArrangeBy (#1)
 
 %2 =
@@ -649,11 +649,11 @@ WHERE o_orderkey BETWEEN 117 AND 165 + 124
 GROUP BY 1
 ----
 %0 =
-| Get materialize.public.lineitem (u9)
+| Get materialize.public.lineitem (u7)
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.orders (u5)
+| Get materialize.public.orders (u4)
 | ArrangeBy (#0) (#1)
 
 %2 =
@@ -703,13 +703,13 @@ WHERE l_extendedprice < o_totalprice
 GROUP BY 1
 ----
 %0 =
-| Get materialize.public.lineitem (u9)
+| Get materialize.public.lineitem (u7)
 | Filter (#10 <= 1994-03-17), (#0 >= 53)
 | Project (#0, #5)
 | ArrangeBy ()
 
 %1 =
-| Get materialize.public.orders (u5)
+| Get materialize.public.orders (u4)
 | ArrangeBy (#0)
 
 %2 =

--- a/test/sqllogictest/boolean.slt
+++ b/test/sqllogictest/boolean.slt
@@ -234,8 +234,12 @@ EXPLAIN PLAN FOR SELECT
   NOT(j @> '{}'::JSONB)
 FROM x
 ----
+Source materialize.public.x (u2):
+| Project (#0..=#3)
+
+Query:
 %0 =
-| Get materialize.public.x (u3)
+| Get materialize.public.x (u2)
 | Map (#0 != #1), (#0 = #1), (#0 >= #1), (#0 <= #1), (#0 < #1), (#0 > #1), !((#2 @> {}))
 | Project (#4..=#9, #3, #10)
 
@@ -250,8 +254,12 @@ EXPLAIN PLAN FOR SELECT
   CASE WHEN b THEN a ELSE a END
 FROM y
 ----
+Source materialize.public.y (u3):
+| Project (#0)
+
+Query:
 %0 =
-| Get materialize.public.y (u5)
+| Get materialize.public.y (u3)
 | Project (#0)
 
 EOF
@@ -262,8 +270,12 @@ EXPLAIN PLAN FOR SELECT
   CASE WHEN b THEN NULL ELSE true END
 FROM y
 ----
+Source materialize.public.y (u3):
+| Project (#1)
+
+Query:
 %0 =
-| Get materialize.public.y (u5)
+| Get materialize.public.y (u3)
 | Map (null || (!(#1) || isnull(#1)))
 | Project (#2)
 
@@ -276,8 +288,12 @@ EXPLAIN PLAN FOR SELECT
   CASE WHEN b THEN NULL ELSE false END
 FROM y
 ----
+Source materialize.public.y (u3):
+| Project (#1)
+
+Query:
 %0 =
-| Get materialize.public.y (u5)
+| Get materialize.public.y (u3)
 | Map (null && (#1 && !(isnull(#1))))
 | Project (#2)
 
@@ -289,8 +305,12 @@ EXPLAIN PLAN FOR SELECT
   CASE WHEN b THEN true ELSE NULL END
 FROM y
 ----
+Source materialize.public.y (u3):
+| Project (#1)
+
+Query:
 %0 =
-| Get materialize.public.y (u5)
+| Get materialize.public.y (u3)
 | Map (null || (#1 && !(isnull(#1))))
 | Project (#2)
 
@@ -302,8 +322,12 @@ EXPLAIN PLAN FOR SELECT
   CASE WHEN b THEN false ELSE NULL END
 FROM y
 ----
+Source materialize.public.y (u3):
+| Project (#1)
+
+Query:
 %0 =
-| Get materialize.public.y (u5)
+| Get materialize.public.y (u3)
 | Map (null && (!(#1) || isnull(#1)))
 | Project (#2)
 
@@ -314,8 +338,12 @@ EXPLAIN PLAN FOR SELECT
   CASE WHEN b THEN false ELSE TRUE END
 FROM y
 ----
+Source materialize.public.y (u3):
+| Project (#1)
+
+Query:
 %0 =
-| Get materialize.public.y (u5)
+| Get materialize.public.y (u3)
 | Map (!(#1) || isnull(#1))
 | Project (#2)
 
@@ -332,8 +360,13 @@ EXPLAIN PLAN FOR SELECT *
 FROM z
 WHERE CASE WHEN a > b THEN FALSE ELSE TRUE END
 ----
+Source materialize.public.z (u4):
+| Filter ((isnull(#0) || isnull(#1)) || (#0 <= #1))
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.z (u7)
+| Get materialize.public.z (u4)
 | Filter ((isnull(#0) || isnull(#1)) || (#0 <= #1))
 
 EOF

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -258,7 +258,7 @@ GROUP BY ol_number
 ORDER BY ol_number
 ----
 %0 =
-| Get materialize.public.orderline (u19)
+| Get materialize.public.orderline (u13)
 | Filter (datetots(#6) > 2007-01-02 00:00:00)
 | Project (#3, #7, #8)
 | Reduce group=(#0)
@@ -301,47 +301,59 @@ AND i_id = m_i_id
 AND s_quantity = m_s_quantity
 ORDER BY n_name, su_name, i_id
 ----
+Source materialize.public.item (u17):
+| Filter "%b" ~~(padchar(#4))
+| Project (#0, #2, #4)
+
+Source materialize.public.region (u26):
+| Filter "EUROP%" ~~(padchar(#1))
+| Project (#0, #1)
+
+Query:
 %0 = Let l0 =
-| Get materialize.public.region (u37)
+| Get materialize.public.region (u26)
+| Filter "EUROP%" ~~(padchar(#1))
+| Project (#0)
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.item (u24)
+| Get materialize.public.item (u17)
+| Filter "%b" ~~(padchar(#4))
+| Project (#0, #2)
 | ArrangeBy (#0)
 
 %2 =
-| Get materialize.public.supplier (u34)
+| Get materialize.public.supplier (u24)
+| Project (#0..=#4, #6)
 | ArrangeBy (#0)
 
 %3 =
-| Get materialize.public.stock (u26)
+| Get materialize.public.stock (u18)
 | Filter !(isnull(#2))
 | Project (#0, #2, #17)
 
 %4 =
-| Get materialize.public.nation (u31)
+| Get materialize.public.nation (u22)
+| Project (#0..=#2)
 | ArrangeBy (#0)
 
 %5 =
-| Get materialize.public.stock (u26)
+| Get materialize.public.stock (u18)
 | ArrangeBy (#17)
 
 %6 =
-| Get materialize.public.supplier (u34)
-| ArrangeBy (#0) (#3)
+| Get materialize.public.supplier (u24)
+| Project (#0, #3)
+| ArrangeBy (#0)
 
 %7 =
-| Get materialize.public.nation (u31)
-| ArrangeBy (#0) (#2)
+| Get materialize.public.nation (u22)
+| Project (#0, #2)
+| ArrangeBy (#0)
 
 %8 =
-| Join %5 %6 %7 %0 (= #17 #18) (= #21 #25) (= #27 #29)
-| | implementation = DeltaQuery
-| |   delta %5 %6.(#0) %7.(#0) %0.(#0)
-| |   delta %6 %7.(#0) %0.(#0) %5.(#17)
-| |   delta %7 %0.(#0) %6.(#3) %5.(#17)
-| |   delta %0 %7.(#2) %6.(#3) %5.(#17)
-| Filter "EUROP%" ~~(padchar(#30))
+| Join %5 %6 %7 %0 (= #17 #18) (= #19 #20) (= #21 #22)
+| | implementation = Differential %5.(#17) %6.(#0) %7.(#0) %0.(#0)
 | Project (#0, #2)
 | Reduce group=(#0)
 | | agg min(#1)
@@ -349,10 +361,9 @@ ORDER BY n_name, su_name, i_id
 | ArrangeBy (#0, #1)
 
 %9 =
-| Join %1 %2 %3 %4 %0 %8 (= #0 #12 #22) (= #5 #14) (= #8 #15) (= #13 #23) (= #17 #19)
+| Join %1 %2 %3 %4 %0 %8 (= #0 #8 #15) (= #2 #10) (= #5 #11) (= #9 #16) (= #13 #14)
 | | implementation = Differential %3 %8.(#0, #1) %1.(#0) %2.(#0) %4.(#0) %0.(#0)
-| Filter "%b" ~~(padchar(#4)), "EUROP%" ~~(padchar(#20))
-| Project (#5, #6, #16, #0, #2, #7, #9, #11)
+| Project (#2, #3, #12, #0, #1, #4, #6, #7)
 
 Finish order_by=(#2 asc, #1 asc, #3 asc) limit=none offset=0 project=(#0..=#7)
 
@@ -377,31 +388,34 @@ AND o_entry_d > TIMESTAMP '2007-01-02 00:00:00.000000'
 GROUP BY ol_o_id, ol_w_id, ol_d_id, o_entry_d
 ORDER BY revenue DESC, o_entry_d
 ----
+Source materialize.public.neworder (u10):
+| Project (#0..=#2)
+
+Query:
 %0 =
-| Get materialize.public.customer (u6)
+| Get materialize.public.customer (u4)
+| Filter "A%" ~~(padchar(#9))
+| Project (#0..=#2)
 | ArrangeBy (#0, #1, #2)
 
 %1 =
-| Get materialize.public.neworder (u14)
+| Get materialize.public.neworder (u10)
 | ArrangeBy (#0, #1, #2)
 
 %2 =
-| Get materialize.public.order (u16)
-| ArrangeBy (#0, #1, #2) (#2, #1, #3)
+| Get materialize.public.order (u11)
+| Filter !(isnull(#3)), (datetots(#4) > 2007-01-02 00:00:00)
+| Project (#0..=#4)
+| ArrangeBy (#0, #1, #2)
 
 %3 =
-| Get materialize.public.orderline (u19)
-| ArrangeBy (#2, #1, #0)
+| Get materialize.public.orderline (u13)
+| Project (#0..=#2, #8)
 
 %4 =
-| Join %0 %1 %2 %3 (= #0 #28) (= #1 #23 #26 #34) (= #2 #24 #27 #35) (= #22 #25 #33)
-| | implementation = DeltaQuery
-| |   delta %0 %2.(#2, #1, #3) %1.(#0, #1, #2) %3.(#2, #1, #0)
-| |   delta %1 %2.(#0, #1, #2) %0.(#0, #1, #2) %3.(#2, #1, #0)
-| |   delta %2 %0.(#0, #1, #2) %1.(#0, #1, #2) %3.(#2, #1, #0)
-| |   delta %3 %1.(#0, #1, #2) %2.(#0, #1, #2) %0.(#0, #1, #2)
-| Filter "A%" ~~(padchar(#9)), (datetots(#29) > 2007-01-02 00:00:00)
-| Project (#1, #2, #22, #29, #41)
+| Join %0 %1 %2 %3 (= #0 #9) (= #1 #4 #7 #12) (= #2 #5 #8 #13) (= #3 #6 #11)
+| | implementation = Differential %3 %1.(#0, #1, #2) %2.(#0, #1, #2) %0.(#0, #1, #2)
+| Project (#1..=#3, #10, #14)
 | Reduce group=(#2, #1, #0, #3)
 | | agg sum(#4)
 | Project (#0..=#2, #4, #3)
@@ -428,32 +442,36 @@ AND EXISTS (
 GROUP BY o_ol_cnt
 ORDER BY o_ol_cnt
 ----
-%0 =
-| Get materialize.public.order (u16)
+%0 = Let l0 =
+| Get materialize.public.order (u11)
 | Filter (datetots(#4) < 2012-01-02 00:00:00), (datetots(#4) >= 2007-01-02 00:00:00)
-| Project (#0..=#2, #4, #6)
 
 %1 =
-| Get materialize.public.order (u16)
-| ArrangeBy (#0, #1, #2)
+| Get %0 (l0)
+| Project (#0..=#2, #4, #6)
 
 %2 =
-| Get materialize.public.orderline (u19)
-| ArrangeBy (#2, #1, #0)
+| Get %0 (l0)
+| Project (#0..=#2, #4)
+| ArrangeBy (#0, #1, #2)
 
 %3 =
-| Join %1 %2 (= #0 #8) (= #1 #9) (= #2 #10)
+| Get materialize.public.orderline (u13)
+| ArrangeBy (#2, #1, #0)
+
+%4 =
+| Join %2 %3 (= #0 #4) (= #1 #5) (= #2 #6)
 | | implementation = DeltaQuery
-| |   delta %1 %2.(#2, #1, #0)
-| |   delta %2 %1.(#0, #1, #2)
-| Filter (datetots(#4) < 2012-01-02 00:00:00), (#14 >= #4), (datetots(#4) >= 2007-01-02 00:00:00)
-| Project (#0..=#2, #4)
+| |   delta %2 %3.(#2, #1, #0)
+| |   delta %3 %2.(#0, #1, #2)
+| Filter (#10 >= #3)
+| Project (#0..=#3)
 | Distinct group=(#0, #1, #2, #3)
 | ArrangeBy (#0, #1, #2, #3)
 
-%4 =
-| Join %0 %3 (= #0 #5) (= #1 #6) (= #2 #7) (= #3 #8)
-| | implementation = Differential %0 %3.(#0, #1, #2, #3)
+%5 =
+| Join %1 %4 (= #0 #5) (= #1 #6) (= #2 #7) (= #3 #8)
+| | implementation = Differential %1 %4.(#0, #1, #2, #3)
 | Project (#4)
 | Reduce group=(#0)
 | | agg count(true)
@@ -486,41 +504,53 @@ AND o_entry_d >= TIMESTAMP '2007-01-02 00:00:00.000000'
 GROUP BY n_name
 ORDER BY revenue DESC
 ----
+Source materialize.public.region (u26):
+| Filter (#1 = "EUROPE")
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.customer (u6)
+| Get materialize.public.customer (u4)
+| Filter !(isnull(#21))
+| Project (#0..=#2, #21)
 | ArrangeBy (#0, #1, #2)
 
 %1 =
-| Get materialize.public.order (u16)
+| Get materialize.public.order (u11)
+| Filter !(isnull(#3)), (datetots(#4) >= 2007-01-02 00:00:00)
+| Project (#0..=#3)
 | ArrangeBy (#0, #1, #2)
 
 %2 =
-| Get materialize.public.orderline (u19)
+| Get materialize.public.orderline (u13)
 | Filter !(isnull(#4))
 | Project (#0..=#2, #4, #8)
 
 %3 =
-| Get materialize.public.stock (u26)
+| Get materialize.public.stock (u18)
+| Project (#0, #1, #17)
 | ArrangeBy (#0, #1)
 
 %4 =
-| Get materialize.public.supplier (u34)
+| Get materialize.public.supplier (u24)
 | Project (#0, #3)
 | ArrangeBy (#0, #1)
 
 %5 =
-| Get materialize.public.nation (u31)
+| Get materialize.public.nation (u22)
+| Project (#0..=#2)
 | ArrangeBy (#0)
 
 %6 =
-| Get materialize.public.region (u37)
+| Get materialize.public.region (u26)
+| Filter (#1 = "EUROPE")
+| Project (#0)
 | ArrangeBy (#0)
 
 %7 =
-| Join %0 %1 %2 %3 %4 %5 %6 (= #0 #25) (= #1 #23 #31) (= #2 #24 #32 #36) (= #21 #54 #55) (= #22 #30) (= #33 #35) (= #52 #53) (= #57 #59)
+| Join %0 %1 %2 %3 %4 %5 %6 (= #0 #7) (= #1 #5 #9) (= #2 #6 #10 #14) (= #3 #17 #18) (= #4 #8) (= #11 #13) (= #15 #16) (= #20 #21)
 | | implementation = Differential %2 %1.(#0, #1, #2) %0.(#0, #1, #2) %3.(#0, #1) %4.(#0, #1) %5.(#0) %6.(#0)
-| Filter (#60 = "EUROPE"), (datetots(#26) >= 2007-01-02 00:00:00)
-| Project (#34, #56)
+| Project (#12, #19)
 | Reduce group=(#1)
 | | agg sum(#0)
 
@@ -538,7 +568,7 @@ AND ol_delivery_d < TIMESTAMP '2020-01-01 00:00:00.000000'
 AND ol_quantity BETWEEN 1 AND 100000
 ----
 %0 = Let l0 =
-| Get materialize.public.orderline (u19)
+| Get materialize.public.orderline (u13)
 | Filter (#7 <= 100000), (#7 >= 1), (datetots(#6) < 2020-01-01 00:00:00), (datetots(#6) >= 1999-01-01 00:00:00)
 | Project (#8)
 | Reduce group=()
@@ -591,41 +621,42 @@ GROUP BY su_nationkey, substr(c_state, 1, 1), EXTRACT(year FROM o_entry_d)
 ORDER BY su_nationkey, cust_nation, l_year
 ----
 %0 = Let l0 =
-| Get materialize.public.nation (u31)
+| Get materialize.public.nation (u22)
+| Project (#0, #1)
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.supplier (u34)
-| ArrangeBy (#0) (#3)
+| Get materialize.public.supplier (u24)
+| Project (#0, #3)
+| ArrangeBy (#0)
 
 %2 =
-| Get materialize.public.stock (u26)
-| ArrangeBy (#0, #1) (#17)
+| Get materialize.public.stock (u18)
+| Project (#0, #1, #17)
+| ArrangeBy (#0, #1)
 
 %3 =
-| Get materialize.public.orderline (u19)
-| ArrangeBy (#2, #1, #0) (#5, #4)
+| Get materialize.public.orderline (u13)
+| Filter !(isnull(#4)), !(isnull(#5)), (datetots(#6) <= 2012-01-02 00:00:00), (datetots(#6) >= 2007-01-02 00:00:00)
+| Project (#0..=#2, #4, #5, #8)
 
 %4 =
-| Get materialize.public.order (u16)
-| ArrangeBy (#0, #1, #2) (#2, #1, #3)
+| Get materialize.public.order (u11)
+| Filter !(isnull(#3))
+| Project (#0..=#4)
+| ArrangeBy (#0, #1, #2)
 
 %5 =
-| Get materialize.public.customer (u6)
-| ArrangeBy (#0, #1, #2) (#21)
+| Get materialize.public.customer (u4)
+| Filter !(isnull(#21))
+| Project (#0..=#2, #9, #21)
+| ArrangeBy (#0, #1, #2)
 
 %6 =
-| Join %1 %2 %3 %4 %5 %0 %0 (= #0 #24) (= #3 #65) (= #7 #29) (= #8 #30) (= #25 #35) (= #26 #36 #44) (= #27 #37 #45) (= #38 #43) (= #64 #69)
-| | implementation = DeltaQuery
-| |   delta %1 %0.(#0) %2.(#17) %3.(#5, #4) %4.(#0, #1, #2) %5.(#0, #1, #2) %0.(#0)
-| |   delta %2 %1.(#0) %0.(#0) %3.(#5, #4) %4.(#0, #1, #2) %5.(#0, #1, #2) %0.(#0)
-| |   delta %3 %4.(#0, #1, #2) %5.(#0, #1, #2) %2.(#0, #1) %1.(#0) %0.(#0) %0.(#0)
-| |   delta %4 %5.(#0, #1, #2) %0.(#0) %3.(#2, #1, #0) %2.(#0, #1) %1.(#0) %0.(#0)
-| |   delta %5 %0.(#0) %4.(#2, #1, #3) %3.(#2, #1, #0) %2.(#0, #1) %1.(#0) %0.(#0)
-| |   delta %0 %1.(#3) %2.(#17) %3.(#5, #4) %4.(#0, #1, #2) %5.(#0, #1, #2) %0.(#0)
-| |   delta %0 %5.(#21) %4.(#2, #1, #3) %3.(#2, #1, #0) %2.(#0, #1) %1.(#0) %0.(#0)
-| Filter (datetots(#31) <= 2012-01-02 00:00:00), (datetots(#31) >= 2007-01-02 00:00:00), (((#66 = "GERMANY") && (#70 = "CAMBODIA")) || ((#66 = "CAMBODIA") && (#70 = "GERMANY")))
-| Project (#3, #33, #39, #52)
+| Join %1 %2 %3 %4 %5 %0 %0 (= #0 #4) (= #1 #21) (= #2 #8) (= #3 #9) (= #5 #11) (= #6 #12 #17) (= #7 #13 #18) (= #14 #16) (= #20 #23)
+| | implementation = Differential %3 %4.(#0, #1, #2) %5.(#0, #1, #2) %2.(#0, #1) %1.(#0) %0.(#0) %0.(#0)
+| Filter (((#22 = "GERMANY") && (#24 = "CAMBODIA")) || ((#22 = "CAMBODIA") && (#24 = "GERMANY")))
+| Project (#1, #10, #15, #19)
 | Reduce group=(#0, substr(chartostr(#3), 1, 1), extract_year_d(#2))
 | | agg sum(#1)
 
@@ -661,56 +692,69 @@ AND i_id = ol_i_id
 GROUP BY EXTRACT(year FROM o_entry_d)
 ORDER BY l_year
 ----
+Source materialize.public.item (u17):
+| Filter "%b" ~~(padchar(#4)), (#0 < 1000)
+| Project (#0, #4)
+
+Source materialize.public.region (u26):
+| Filter (#1 = "EUROPE")
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.item (u24)
+| Get materialize.public.item (u17)
+| Filter (#0 < 1000), "%b" ~~(padchar(#4))
+| Project (#0)
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.supplier (u34)
-| ArrangeBy (#0) (#3)
+| Get materialize.public.supplier (u24)
+| Project (#0, #3)
+| ArrangeBy (#0)
 
 %2 =
-| Get materialize.public.stock (u26)
-| ArrangeBy (#0) (#0, #1) (#17)
+| Get materialize.public.stock (u18)
+| Filter (#0 < 1000)
+| Project (#0, #1, #17)
+| ArrangeBy (#0, #1)
 
 %3 =
-| Get materialize.public.orderline (u19)
-| ArrangeBy (#2, #1, #0) (#5, #4)
+| Get materialize.public.orderline (u13)
+| Filter (#4 < 1000), !(isnull(#5))
+| Project (#0..=#2, #4, #5, #8)
 
 %4 =
-| Get materialize.public.order (u16)
-| ArrangeBy (#0, #1, #2) (#2, #1, #3)
+| Get materialize.public.order (u11)
+| Filter !(isnull(#3)), (datetots(#4) <= 2012-01-02 00:00:00), (datetots(#4) >= 2007-01-02 00:00:00)
+| Project (#0..=#4)
+| ArrangeBy (#0, #1, #2)
 
 %5 =
-| Get materialize.public.customer (u6)
-| ArrangeBy (#0, #1, #2) (#21)
+| Get materialize.public.customer (u4)
+| Filter !(isnull(#21))
+| Project (#0..=#2, #21)
+| ArrangeBy (#0, #1, #2)
 
 %6 =
-| Get materialize.public.nation (u31)
-| ArrangeBy (#0) (#2)
+| Get materialize.public.nation (u22)
+| Project (#0, #2)
+| ArrangeBy (#0)
 
 %7 =
-| Get materialize.public.nation (u31)
+| Get materialize.public.nation (u22)
+| Project (#0, #1)
 | ArrangeBy (#0)
 
 %8 =
-| Get materialize.public.region (u37)
+| Get materialize.public.region (u26)
+| Filter (#1 = "EUROPE")
+| Project (#0)
 | ArrangeBy (#0)
 
 %9 =
-| Join %0 %1 %2 %3 %4 %5 %6 %7 %8 (= #0 #12 #34) (= #5 #29) (= #8 #74) (= #13 #35) (= #30 #40) (= #31 #41 #49) (= #32 #42 #50) (= #43 #48) (= #69 #70) (= #72 #78)
-| | implementation = DeltaQuery
-| |   delta %0 %2.(#0) %1.(#0) %7.(#0) %3.(#5, #4) %4.(#0, #1, #2) %5.(#0, #1, #2) %6.(#0) %8.(#0)
-| |   delta %1 %7.(#0) %2.(#17) %0.(#0) %3.(#5, #4) %4.(#0, #1, #2) %5.(#0, #1, #2) %6.(#0) %8.(#0)
-| |   delta %2 %0.(#0) %1.(#0) %7.(#0) %3.(#5, #4) %4.(#0, #1, #2) %5.(#0, #1, #2) %6.(#0) %8.(#0)
-| |   delta %3 %4.(#0, #1, #2) %5.(#0, #1, #2) %2.(#0, #1) %0.(#0) %1.(#0) %6.(#0) %7.(#0) %8.(#0)
-| |   delta %4 %5.(#0, #1, #2) %6.(#0) %8.(#0) %3.(#2, #1, #0) %2.(#0, #1) %0.(#0) %1.(#0) %7.(#0)
-| |   delta %5 %6.(#0) %8.(#0) %4.(#2, #1, #3) %3.(#2, #1, #0) %2.(#0, #1) %0.(#0) %1.(#0) %7.(#0)
-| |   delta %6 %8.(#0) %5.(#21) %4.(#2, #1, #3) %3.(#2, #1, #0) %2.(#0, #1) %0.(#0) %1.(#0) %7.(#0)
-| |   delta %7 %1.(#3) %2.(#17) %0.(#0) %3.(#5, #4) %4.(#0, #1, #2) %5.(#0, #1, #2) %6.(#0) %8.(#0)
-| |   delta %8 %6.(#2) %5.(#21) %4.(#2, #1, #3) %3.(#2, #1, #0) %2.(#0, #1) %0.(#0) %1.(#0) %7.(#0)
-| Filter (#79 = "EUROPE"), (#0 < 1000), "%b" ~~(padchar(#4)), (datetots(#44) <= 2012-01-02 00:00:00), (datetots(#44) >= 2007-01-02 00:00:00)
-| Project (#38, #44, #75)
+| Join %0 %1 %2 %3 %4 %5 %6 %7 %8 (= #0 #3 #9) (= #1 #5) (= #2 #23) (= #4 #10) (= #6 #12) (= #7 #13 #18) (= #8 #14 #19) (= #15 #17) (= #20 #21) (= #22 #25)
+| | implementation = Differential %3 %4.(#0, #1, #2) %5.(#0, #1, #2) %2.(#0, #1) %0.(#0) %1.(#0) %6.(#0) %7.(#0) %8.(#0)
+| Project (#11, #16, #24)
 | Reduce group=(extract_year_d(#1))
 | | agg sum(if (#2 = "GERMANY") then {#0} else {0})
 | | agg sum(#0)
@@ -740,41 +784,46 @@ AND i_data like '%BB'
 GROUP BY n_name, EXTRACT(year FROM o_entry_d)
 ORDER BY n_name, l_year DESC
 ----
+Source materialize.public.item (u17):
+| Filter "%BB" ~~(padchar(#4))
+| Project (#0, #4)
+
+Query:
 %0 =
-| Get materialize.public.item (u24)
+| Get materialize.public.item (u17)
+| Filter "%BB" ~~(padchar(#4))
+| Project (#0)
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.stock (u26)
-| ArrangeBy (#0) (#0, #1) (#17)
+| Get materialize.public.stock (u18)
+| Project (#0, #1, #17)
+| ArrangeBy (#0, #1)
 
 %2 =
-| Get materialize.public.supplier (u34)
-| ArrangeBy (#0) (#3)
+| Get materialize.public.supplier (u24)
+| Project (#0, #3)
+| ArrangeBy (#0)
 
 %3 =
-| Get materialize.public.orderline (u19)
-| ArrangeBy (#2, #1, #0) (#5, #4)
+| Get materialize.public.orderline (u13)
+| Filter !(isnull(#4)), !(isnull(#5))
+| Project (#0..=#2, #4, #5, #8)
 
 %4 =
-| Get materialize.public.order (u16)
+| Get materialize.public.order (u11)
+| Project (#0..=#2, #4)
 | ArrangeBy (#0, #1, #2)
 
 %5 =
-| Get materialize.public.nation (u31)
+| Get materialize.public.nation (u22)
+| Project (#0, #1)
 | ArrangeBy (#0)
 
 %6 =
-| Join %0 %1 %2 %3 %4 %5 (= #0 #5 #34) (= #6 #35) (= #22 #23) (= #26 #48) (= #30 #40) (= #31 #41) (= #32 #42)
-| | implementation = DeltaQuery
-| |   delta %0 %1.(#0) %2.(#0) %5.(#0) %3.(#5, #4) %4.(#0, #1, #2)
-| |   delta %1 %0.(#0) %2.(#0) %5.(#0) %3.(#5, #4) %4.(#0, #1, #2)
-| |   delta %2 %5.(#0) %1.(#17) %0.(#0) %3.(#5, #4) %4.(#0, #1, #2)
-| |   delta %3 %4.(#0, #1, #2) %1.(#0, #1) %0.(#0) %2.(#0) %5.(#0)
-| |   delta %4 %3.(#2, #1, #0) %1.(#0, #1) %0.(#0) %2.(#0) %5.(#0)
-| |   delta %5 %2.(#3) %1.(#17) %0.(#0) %3.(#5, #4) %4.(#0, #1, #2)
-| Filter "%BB" ~~(padchar(#4))
-| Project (#38, #44, #49)
+| Join %0 %1 %2 %3 %4 %5 (= #0 #1 #9) (= #2 #10) (= #3 #4) (= #5 #16) (= #6 #12) (= #7 #13) (= #8 #14)
+| | implementation = Differential %3 %4.(#0, #1, #2) %1.(#0, #1) %0.(#0) %2.(#0) %5.(#0)
+| Project (#11, #15, #17)
 | Reduce group=(#2, extract_year_d(#1))
 | | agg sum(#0)
 
@@ -801,30 +850,31 @@ GROUP BY c_id, c_last, c_city, c_phone, n_name
 ORDER BY revenue DESC
 ----
 %0 =
-| Get materialize.public.customer (u6)
-| ArrangeBy (#0, #1, #2) (#21)
+| Get materialize.public.customer (u4)
+| Filter !(isnull(#21))
+| Project (#0..=#2, #5, #8, #11, #21)
+| ArrangeBy (#0, #1, #2)
 
 %1 =
-| Get materialize.public.order (u16)
-| ArrangeBy (#0, #1, #2) (#2, #1, #3)
+| Get materialize.public.order (u11)
+| Filter !(isnull(#3)), (datetots(#4) >= 2007-01-02 00:00:00)
+| Project (#0..=#4)
+| ArrangeBy (#0, #1, #2)
 
 %2 =
-| Get materialize.public.orderline (u19)
-| ArrangeBy (#2, #1, #0)
+| Get materialize.public.orderline (u13)
+| Project (#0..=#2, #6, #8)
 
 %3 =
-| Get materialize.public.nation (u31)
+| Get materialize.public.nation (u22)
+| Project (#0, #1)
 | ArrangeBy (#0)
 
 %4 =
-| Join %0 %1 %2 %3 (= #0 #25) (= #1 #23 #31) (= #2 #24 #32) (= #21 #40) (= #22 #30)
-| | implementation = DeltaQuery
-| |   delta %0 %3.(#0) %1.(#2, #1, #3) %2.(#2, #1, #0)
-| |   delta %1 %0.(#0, #1, #2) %3.(#0) %2.(#2, #1, #0)
-| |   delta %2 %1.(#0, #1, #2) %0.(#0, #1, #2) %3.(#0)
-| |   delta %3 %0.(#21) %1.(#2, #1, #3) %2.(#2, #1, #0)
-| Filter (#26 <= #36), (datetots(#26) >= 2007-01-02 00:00:00)
-| Project (#0, #5, #8, #11, #38, #41)
+| Join %0 %1 %2 %3 (= #0 #10) (= #1 #8 #13) (= #2 #9 #14) (= #6 #17) (= #7 #12)
+| | implementation = Differential %2 %1.(#0, #1, #2) %0.(#0, #1, #2) %3.(#0)
+| Filter (#11 <= #15)
+| Project (#0, #3..=#5, #16, #18)
 | Reduce group=(#0, #1, #2, #3, #5)
 | | agg sum(#4)
 | Project (#0, #1, #5, #2..=#4)
@@ -852,24 +902,23 @@ HAVING sum(s_order_cnt) > (
 ORDER BY ordercount DESC
 ----
 %0 =
-| Get materialize.public.stock (u26)
+| Get materialize.public.stock (u18)
 | ArrangeBy (#17)
 
 %1 =
-| Get materialize.public.supplier (u34)
-| ArrangeBy (#0) (#3)
+| Get materialize.public.supplier (u24)
+| Project (#0, #3)
+| ArrangeBy (#0)
 
 %2 =
-| Get materialize.public.nation (u31)
+| Get materialize.public.nation (u22)
+| Filter (#1 = "GERMANY")
+| Project (#0)
 | ArrangeBy (#0)
 
 %3 = Let l0 =
-| Join %0 %1 %2 (= #17 #18) (= #21 #25)
-| | implementation = DeltaQuery
-| |   delta %0 %1.(#0) %2.(#0)
-| |   delta %1 %2.(#0) %0.(#17)
-| |   delta %2 %1.(#3) %0.(#17)
-| Filter (#26 = "GERMANY")
+| Join %0 %1 %2 (= #17 #18) (= #19 #20)
+| | implementation = Differential %0.(#17) %1.(#0) %2.(#0)
 | Project (#0, #14)
 
 %4 =
@@ -912,20 +961,21 @@ GROUP BY o_ol_cnt
 ORDER BY o_ol_cnt
 ----
 %0 =
-| Get materialize.public.order (u16)
+| Get materialize.public.order (u11)
+| Project (#0..=#2, #4..=#6)
 | ArrangeBy (#0, #1, #2)
 
 %1 =
-| Get materialize.public.orderline (u19)
+| Get materialize.public.orderline (u13)
 | ArrangeBy (#2, #1, #0)
 
 %2 =
-| Join %0 %1 (= #0 #8) (= #1 #9) (= #2 #10)
+| Join %0 %1 (= #0 #6) (= #1 #7) (= #2 #8)
 | | implementation = DeltaQuery
 | |   delta %0 %1.(#2, #1, #0)
 | |   delta %1 %0.(#0, #1, #2)
-| Filter (datetots(#14) < 2020-01-01 00:00:00), (#4 <= #14)
-| Project (#5, #6)
+| Filter (datetots(#12) < 2020-01-01 00:00:00), (#3 <= #12)
+| Project (#4, #5)
 | Reduce group=(#1)
 | | agg sum(if ((#0 = 1) || (#0 = 2)) then {1} else {0})
 | | agg sum(if ((#0 != 1) && (#0 != 2)) then {1} else {0})
@@ -951,11 +1001,11 @@ GROUP BY c_count
 ORDER BY custdist DESC, c_count DESC
 ----
 %0 =
-| Get materialize.public.customer (u6)
+| Get materialize.public.customer (u4)
 | ArrangeBy (#0, #1, #2)
 
 %1 =
-| Get materialize.public.order (u16)
+| Get materialize.public.order (u11)
 | ArrangeBy (#2, #1, #3)
 
 %2 = Let l0 =
@@ -978,7 +1028,7 @@ ORDER BY custdist DESC, c_count DESC
 | Negate
 
 %5 =
-| Get materialize.public.customer (u6)
+| Get materialize.public.customer (u4)
 | Project (#0)
 
 %6 =
@@ -1007,12 +1057,17 @@ WHERE ol_i_id = i_id
 AND ol_delivery_d >= TIMESTAMP '2007-01-02 00:00:00.000000'
 AND ol_delivery_d < TIMESTAMP '2020-01-02 00:00:00.000000'
 ----
+Source materialize.public.item (u17):
+| Project (#0, #4)
+
+Query:
 %0 =
-| Get materialize.public.orderline (u19)
+| Get materialize.public.orderline (u13)
 | ArrangeBy (#4)
 
 %1 =
-| Get materialize.public.item (u24)
+| Get materialize.public.item (u17)
+| Project (#0, #4)
 | ArrangeBy (#0)
 
 %2 = Let l0 =
@@ -1021,7 +1076,7 @@ AND ol_delivery_d < TIMESTAMP '2020-01-02 00:00:00.000000'
 | |   delta %0 %1.(#0)
 | |   delta %1 %0.(#4)
 | Filter (datetots(#6) < 2020-01-02 00:00:00), (datetots(#6) >= 2007-01-02 00:00:00)
-| Project (#8, #14)
+| Project (#8, #11)
 | Reduce group=()
 | | agg sum(if "PR%" ~~(padchar(#1)) then {#0} else {0})
 | | agg sum(#0)
@@ -1078,11 +1133,12 @@ AND total_revenue = (
 ORDER BY su_suppkey
 ----
 %0 =
-| Get materialize.public.orderline (u19)
+| Get materialize.public.orderline (u13)
 | ArrangeBy (#5, #4)
 
 %1 =
-| Get materialize.public.stock (u26)
+| Get materialize.public.stock (u18)
+| Project (#0, #1, #17)
 | ArrangeBy (#0, #1)
 
 %2 = Let l0 =
@@ -1091,13 +1147,13 @@ ORDER BY su_suppkey
 | |   delta %0 %1.(#0, #1)
 | |   delta %1 %0.(#5, #4)
 | Filter (datetots(#6) >= 2007-01-02 00:00:00)
-| Project (#8, #27)
+| Project (#8, #12)
 | Reduce group=(#1)
 | | agg sum(#0)
 
 %3 =
-| Get materialize.public.supplier (u34)
-| ArrangeBy (#0)
+| Get materialize.public.supplier (u24)
+| Project (#0..=#2, #4)
 
 %4 =
 | Get %2 (l0)
@@ -1112,9 +1168,9 @@ ORDER BY su_suppkey
 | ArrangeBy (#0)
 
 %6 =
-| Join %3 %4 %5 (= #0 #7) (= #8 #9)
-| | implementation = Differential %3.(#0) %4.(#0) %5.(#0)
-| Project (#0..=#2, #4, #8)
+| Join %3 %4 %5 (= #0 #4) (= #5 #6)
+| | implementation = Differential %3 %4.(#0) %5.(#0)
+| Project (#0..=#3, #5)
 
 Finish order_by=(#0 asc) limit=none offset=0 project=(#0..=#4)
 
@@ -1137,12 +1193,19 @@ AND (
 GROUP BY i_name, substr(i_data, 1, 3), i_price
 ORDER BY supplier_cnt DESC
 ----
+Source materialize.public.item (u17):
+| Filter !("zz%" ~~(padchar(#4)))
+| Project (#0, #2..=#4)
+
+Query:
 %0 =
-| Get materialize.public.stock (u26)
+| Get materialize.public.stock (u18)
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.item (u24)
+| Get materialize.public.item (u17)
+| Filter !("zz%" ~~(padchar(#4)))
+| Project (#0, #2..=#4)
 | ArrangeBy (#0)
 
 %2 = Let l0 =
@@ -1150,8 +1213,7 @@ ORDER BY supplier_cnt DESC
 | | implementation = DeltaQuery
 | |   delta %0 %1.(#0)
 | |   delta %1 %0.(#0)
-| Filter !("zz%" ~~(padchar(#22)))
-| Project (#17, #20..=#22)
+| Project (#17, #19..=#21)
 
 %3 = Let l1 =
 | Get %2 (l0)
@@ -1167,15 +1229,13 @@ ORDER BY supplier_cnt DESC
 | ArrangeBy (#0)
 
 %6 =
-| Get materialize.public.supplier (u34)
-| ArrangeBy (#0)
+| Get materialize.public.supplier (u24)
+| Filter "%bad%" ~~(padchar(#6))
+| Project (#0)
 
 %7 =
 | Join %5 %6 (= #0 #1)
-| | implementation = DeltaQuery
-| |   delta %5 %6.(#0)
-| |   delta %6 %5.(#0)
-| Filter "%bad%" ~~(padchar(#7))
+| | implementation = Differential %6 %5.(#0)
 | Project (#0)
 | Negate
 
@@ -1209,21 +1269,27 @@ FROM
 WHERE ol_i_id = t.i_id
 AND ol_quantity < t.a
 ----
+Source materialize.public.item (u17):
+| Filter "%b" ~~(padchar(#4))
+| Project (#0, #4)
+
+Query:
 %0 = Let l0 =
-| Get materialize.public.orderline (u19)
+| Get materialize.public.orderline (u13)
 | ArrangeBy (#4)
 
 %1 =
-| Get materialize.public.item (u24)
+| Get materialize.public.item (u17)
+| Filter "%b" ~~(padchar(#4))
+| Project (#0)
 | ArrangeBy (#0)
 
 %2 =
-| Join %1 %0 (= #0 #9)
+| Join %1 %0 (= #0 #5)
 | | implementation = DeltaQuery
 | |   delta %1 %0.(#4)
 | |   delta %0 %1.(#0)
-| Filter "%b" ~~(padchar(#4))
-| Project (#0, #12)
+| Project (#0, #8)
 | Reduce group=(#0)
 | | agg sum(#1)
 | | agg count(#1)
@@ -1274,24 +1340,24 @@ HAVING sum(ol_amount) > 200
 ORDER BY sum(ol_amount) DESC, o_entry_d
 ----
 %0 =
-| Get materialize.public.customer (u6)
+| Get materialize.public.customer (u4)
+| Project (#0..=#2, #5)
 | ArrangeBy (#0, #1, #2)
 
 %1 =
-| Get materialize.public.order (u16)
-| ArrangeBy (#0, #1, #2) (#2, #1, #3)
+| Get materialize.public.order (u11)
+| Filter !(isnull(#3))
+| Project (#0..=#4, #6)
+| ArrangeBy (#0, #1, #2)
 
 %2 =
-| Get materialize.public.orderline (u19)
-| ArrangeBy (#2, #1, #0)
+| Get materialize.public.orderline (u13)
+| Project (#0..=#2, #8)
 
 %3 =
-| Join %0 %1 %2 (= #0 #25) (= #1 #23 #31) (= #2 #24 #32) (= #22 #30)
-| | implementation = DeltaQuery
-| |   delta %0 %1.(#2, #1, #3) %2.(#2, #1, #0)
-| |   delta %1 %0.(#0, #1, #2) %2.(#2, #1, #0)
-| |   delta %2 %1.(#0, #1, #2) %0.(#0, #1, #2)
-| Project (#0..=#2, #5, #22, #26, #28, #38)
+| Join %0 %1 %2 (= #0 #7) (= #1 #5 #11) (= #2 #6 #12) (= #4 #10)
+| | implementation = Differential %2 %1.(#0, #1, #2) %0.(#0, #1, #2)
+| Project (#0..=#4, #8, #9, #13)
 | Reduce group=(#4, #2, #1, #0, #3, #5, #6)
 | | agg sum(#7)
 | Filter (#7 > 200)
@@ -1329,12 +1395,19 @@ WHERE (
     AND ol_w_id in (1, 5, 3)
 )
 ----
+Source materialize.public.item (u17):
+| Filter (#3 <= 400000), (#3 >= 1)
+| Project (#0, #3, #4)
+
+Query:
 %0 =
-| Get materialize.public.orderline (u19)
+| Get materialize.public.orderline (u13)
 | ArrangeBy (#4)
 
 %1 =
-| Get materialize.public.item (u24)
+| Get materialize.public.item (u17)
+| Filter (#3 <= 400000), (#3 >= 1)
+| Project (#0, #4)
 | ArrangeBy (#0)
 
 %2 = Let l0 =
@@ -1342,9 +1415,9 @@ WHERE (
 | | implementation = DeltaQuery
 | |   delta %0 %1.(#0)
 | |   delta %1 %0.(#4)
-| Filter (#7 <= 10), (#13 <= 400000), (#7 >= 1), (#13 >= 1)
-| Map padchar(#14), (#2 = 1), (#2 = 3), (#16 || (#2 = 2))
-| Filter (("%c" ~~(#15) && (#17 || (#16 || (#2 = 5)))) || (("%a" ~~(#15) && (#17 || #18)) || ("%b" ~~(#15) && (#18 || (#2 = 4)))))
+| Filter (#7 <= 10), (#7 >= 1)
+| Map padchar(#11), (#2 = 1), (#2 = 3), (#13 || (#2 = 2))
+| Filter (("%c" ~~(#12) && (#14 || (#13 || (#2 = 5)))) || (("%a" ~~(#12) && (#14 || #15)) || ("%b" ~~(#12) && (#15 || (#2 = 4)))))
 | Project (#8)
 | Reduce group=()
 | | agg sum(#0)
@@ -1385,12 +1458,19 @@ AND su_nationkey = n_nationkey
 AND n_name = 'GERMANY'
 ORDER BY su_name
 ----
+Source materialize.public.item (u17):
+| Filter "co%" ~~(padchar(#4))
+| Project (#0, #4)
+
+Query:
 %0 =
-| Get materialize.public.supplier (u34)
+| Get materialize.public.supplier (u24)
 | ArrangeBy (#3)
 
 %1 =
-| Get materialize.public.nation (u31)
+| Get materialize.public.nation (u22)
+| Filter (#1 = "GERMANY")
+| Project (#0)
 | ArrangeBy (#0)
 
 %2 = Let l0 =
@@ -1398,7 +1478,6 @@ ORDER BY su_name
 | | implementation = DeltaQuery
 | |   delta %0 %1.(#0)
 | |   delta %1 %0.(#3)
-| Filter (#8 = "GERMANY")
 | Project (#0..=#2)
 
 %3 =
@@ -1407,21 +1486,23 @@ ORDER BY su_name
 | ArrangeBy ()
 
 %4 =
-| Get materialize.public.stock (u26)
+| Get materialize.public.stock (u18)
 | ArrangeBy (#0)
 
 %5 =
-| Get materialize.public.orderline (u19)
+| Get materialize.public.orderline (u13)
 | ArrangeBy (#4)
 
 %6 =
-| Get materialize.public.item (u24)
+| Get materialize.public.item (u17)
+| Filter "co%" ~~(padchar(#4))
+| Project (#0)
 | ArrangeBy (#0)
 
 %7 =
 | Join %3 %4 %5 %6 (= #1 #23 #29)
 | | implementation = Differential %4.(#0) %6.(#0) %5.(#4) %3.()
-| Filter "co%" ~~(padchar(#33)), (datetots(#25) > 2010-05-23 12:00:00)
+| Filter (datetots(#25) > 2010-05-23 12:00:00)
 | Project (#0..=#3, #26)
 | Reduce group=(#0, #1, #2, #3)
 | | agg sum(#4)
@@ -1467,31 +1548,36 @@ GROUP BY su_name
 ORDER BY numwait DESC, su_name
 ----
 %0 =
-| Get materialize.public.supplier (u34)
+| Get materialize.public.supplier (u24)
+| Project (#0, #1, #3)
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.orderline (u19)
+| Get materialize.public.orderline (u13)
 | Filter !(isnull(#4))
 | Project (#0..=#2, #4, #6)
 
 %2 =
-| Get materialize.public.order (u16)
+| Get materialize.public.order (u11)
+| Project (#0..=#2, #4)
 | ArrangeBy (#0, #1, #2)
 
 %3 =
-| Get materialize.public.stock (u26)
+| Get materialize.public.stock (u18)
+| Project (#0, #1, #17)
 | ArrangeBy (#0, #1)
 
 %4 =
-| Get materialize.public.nation (u31)
+| Get materialize.public.nation (u22)
+| Filter (#1 = "GERMANY")
+| Project (#0)
 | ArrangeBy (#0)
 
 %5 = Let l0 =
-| Join %0 %1 %2 %3 %4 (= #0 #37) (= #3 #38) (= #7 #12) (= #8 #13) (= #9 #14 #21) (= #10 #20)
+| Join %0 %1 %2 %3 %4 (= #0 #14) (= #2 #15) (= #3 #8) (= #4 #9) (= #5 #10 #13) (= #6 #12)
 | | implementation = Differential %1 %2.(#0, #1, #2) %3.(#0, #1) %0.(#0) %4.(#0)
-| Filter (#39 = "GERMANY"), (#11 > #16)
-| Project (#1, #7..=#9, #11)
+| Filter (#7 > #11)
+| Project (#1, #3..=#5, #7)
 
 %6 = Let l1 =
 | Get %5 (l0)
@@ -1503,7 +1589,7 @@ ORDER BY numwait DESC, su_name
 | ArrangeBy (#1, #2, #3, #4)
 
 %8 =
-| Get materialize.public.orderline (u19)
+| Get materialize.public.orderline (u13)
 | ArrangeBy (#2, #1, #0)
 
 %9 =
@@ -1552,13 +1638,13 @@ GROUP BY substr(c_state, 1, 1)
 ORDER BY substr(c_state, 1, 1)
 ----
 %0 =
-| Get materialize.public.customer (u6)
+| Get materialize.public.customer (u4)
 | Map substr(chartostr(#11), 1, 1)
 | Filter (((((((#22 = "1") || (#22 = "2")) || (#22 = "3")) || (#22 = "4")) || (#22 = "5")) || (#22 = "6")) || (#22 = "7"))
 | Project (#0..=#2, #9, #16)
 
 %1 =
-| Get materialize.public.customer (u6)
+| Get materialize.public.customer (u4)
 | Filter (#16 > 0)
 | Map substr(chartostr(#11), 1, 1)
 | Filter (((((((#22 = "1") || (#22 = "2")) || (#22 = "3")) || (#22 = "4")) || (#22 = "5")) || (#22 = "6")) || (#22 = "7"))
@@ -1583,7 +1669,7 @@ ORDER BY substr(c_state, 1, 1)
 | ArrangeBy (#0, #1, #2)
 
 %5 =
-| Get materialize.public.order (u16)
+| Get materialize.public.order (u11)
 | Filter !(isnull(#3))
 | Project (#1..=#3)
 | Distinct group=(#2, #0, #1)

--- a/test/sqllogictest/column_knowledge.slt
+++ b/test/sqllogictest/column_knowledge.slt
@@ -27,6 +27,11 @@ CREATE TABLE t3 (f1 INTEGER PRIMARY KEY, f2 INTEGER);
 query T multiline
 EXPLAIN SELECT * FROM t1 WHERE t1.f1 = 123 AND t1.f1 = t1.f2
 ----
+Source materialize.public.t1 (u1):
+| Filter (#0 = #1), (#0 = 123)
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 | Filter (#0 = 123), (#0 = #1)
@@ -38,13 +43,22 @@ EOF
 query T multiline
 EXPLAIN SELECT * FROM t1 , t2 WHERE t1.f1 = 123 AND t1.f1 = t2.f1
 ----
+Source materialize.public.t1 (u1):
+| Filter (#0 = 123)
+| Project (#0, #1)
+
+Source materialize.public.t2 (u2):
+| Filter (#0 = 123)
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 | Filter (#0 = 123)
 | ArrangeBy ()
 
 %1 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Filter (#0 = 123)
 
 %2 =
@@ -60,6 +74,15 @@ EOF
 query T multiline
 EXPLAIN SELECT * FROM t1 LEFT JOIN t2 ON (t1.f1 = t2.f1) WHERE t1.f1 = 123;
 ----
+Source materialize.public.t1 (u1):
+| Filter (#0 = 123)
+| Project (#0, #1)
+
+Source materialize.public.t2 (u2):
+| Filter (#0 = 123)
+| Project (#0, #1)
+
+Query:
 %0 = Let l0 =
 | Get materialize.public.t1 (u1)
 | Filter (#0 = 123)
@@ -69,7 +92,7 @@ EXPLAIN SELECT * FROM t1 LEFT JOIN t2 ON (t1.f1 = t2.f1) WHERE t1.f1 = 123;
 | ArrangeBy ()
 
 %2 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Filter (#0 = 123)
 
 %3 = Let l1 =
@@ -93,6 +116,15 @@ EOF
 query T multiline
 EXPLAIN SELECT * FROM t1 LEFT JOIN t2 USING (f1) WHERE t1.f1 = 123;
 ----
+Source materialize.public.t1 (u1):
+| Filter (#0 = 123)
+| Project (#0, #1)
+
+Source materialize.public.t2 (u2):
+| Filter (#0 = 123)
+| Project (#0, #1)
+
+Query:
 %0 = Let l0 =
 | Get materialize.public.t1 (u1)
 | Filter (#0 = 123)
@@ -102,7 +134,7 @@ EXPLAIN SELECT * FROM t1 LEFT JOIN t2 USING (f1) WHERE t1.f1 = 123;
 | ArrangeBy ()
 
 %2 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Filter (#0 = 123)
 | Project (#1)
 
@@ -134,13 +166,22 @@ EOF
 query T multiline
 EXPLAIN SELECT * FROM t1 LEFT JOIN t2 ON (TRUE) WHERE t1.f1 = t2.f1 AND t1.f1 = 123;
 ----
+Source materialize.public.t1 (u1):
+| Filter (#0 = 123)
+| Project (#0, #1)
+
+Source materialize.public.t2 (u2):
+| Filter (#0 = 123)
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 | Filter (#0 = 123)
 | ArrangeBy ()
 
 %1 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Filter (#0 = 123)
 
 %2 =
@@ -154,18 +195,31 @@ EOF
 query T multiline
 EXPLAIN SELECT * FROM t1, t2, t3 WHERE t1.f1 = 123 AND t1.f1 = t2.f1 AND t2.f1 = t3.f1;
 ----
+Source materialize.public.t1 (u1):
+| Filter (#0 = 123)
+| Project (#0, #1)
+
+Source materialize.public.t2 (u2):
+| Filter (#0 = 123)
+| Project (#0, #1)
+
+Source materialize.public.t3 (u3):
+| Filter (#0 = 123)
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 | Filter (#0 = 123)
 | ArrangeBy ()
 
 %1 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Filter (#0 = 123)
 | ArrangeBy ()
 
 %2 =
-| Get materialize.public.t3 (u5)
+| Get materialize.public.t3 (u3)
 | Filter (#0 = 123)
 
 %3 =
@@ -179,6 +233,15 @@ EOF
 query T multiline
 EXPLAIN SELECT t1.f1 FROM t1, t2 WHERE t1.f1 = t2.f1 GROUP BY t1.f1 HAVING t1.f1 = 123;
 ----
+Source materialize.public.t1 (u1):
+| Filter (#0 = 123)
+| Project (#0)
+
+Source materialize.public.t2 (u2):
+| Filter (#0 = 123)
+| Project (#0)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 | Filter (#0 = 123)
@@ -186,7 +249,7 @@ EXPLAIN SELECT t1.f1 FROM t1, t2 WHERE t1.f1 = t2.f1 GROUP BY t1.f1 HAVING t1.f1
 | ArrangeBy ()
 
 %1 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Filter (#0 = 123)
 | Project ()
 
@@ -204,8 +267,17 @@ EOF
 query T multiline
 EXPLAIN SELECT (SELECT t1.f1 FROM t1 WHERE t1.f1 = t2.f1) FROM t2 WHERE t2.f1 = 123;
 ----
+Source materialize.public.t1 (u1):
+| Filter (#0 = 123)
+| Project (#0)
+
+Source materialize.public.t2 (u2):
+| Filter (#0 = 123)
+| Project (#0)
+
+Query:
 %0 = Let l0 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Filter (#0 = 123)
 | Project ()
 
@@ -244,6 +316,14 @@ EOF
 query T multiline
 EXPLAIN SELECT (SELECT t1.f1 FROM t1) = t2.f1 FROM t2 WHERE t2.f1 = 123;
 ----
+Source materialize.public.t1 (u1):
+| Project (#0)
+
+Source materialize.public.t2 (u2):
+| Filter (#0 = 123)
+| Project (#0)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 | Project (#0)
@@ -261,7 +341,7 @@ EXPLAIN SELECT (SELECT t1.f1 FROM t1) = t2.f1 FROM t2 WHERE t2.f1 = 123;
 | Union %0 %1
 
 %3 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Filter (#0 = 123)
 | Project ()
 | ArrangeBy ()
@@ -293,13 +373,22 @@ EOF
 query T multiline
 EXPLAIN SELECT * FROM t1 WHERE t1.f1 = 123 AND EXISTS (SELECT * FROM t2 WHERE t2.f1 = t1.f1);
 ----
+Source materialize.public.t1 (u1):
+| Filter (#0 = 123)
+| Project (#0, #1)
+
+Source materialize.public.t2 (u2):
+| Filter (#0 = 123)
+| Project (#0)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 | Filter (#0 = 123)
 | ArrangeBy ()
 
 %1 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Filter (#0 = 123)
 | Project ()
 
@@ -312,19 +401,32 @@ EOF
 query T multiline
 EXPLAIN SELECT * FROM t1 WHERE t1.f1 = 123 AND EXISTS (SELECT * FROM t2 WHERE t2.f1 = t1.f1) AND EXISTS (SELECT * FROM t3 WHERE t3.f1 = t1.f1);
 ----
+Source materialize.public.t1 (u1):
+| Filter (#0 = 123)
+| Project (#0, #1)
+
+Source materialize.public.t2 (u2):
+| Filter (#0 = 123)
+| Project (#0)
+
+Source materialize.public.t3 (u3):
+| Filter (#0 = 123)
+| Project (#0)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 | Filter (#0 = 123)
 | ArrangeBy ()
 
 %1 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Filter (#0 = 123)
 | Project ()
 | ArrangeBy ()
 
 %2 =
-| Get materialize.public.t3 (u5)
+| Get materialize.public.t3 (u3)
 | Filter (#0 = 123)
 | Project ()
 
@@ -337,13 +439,22 @@ EOF
 query T multiline
 EXPLAIN SELECT * FROM t1, (SELECT t2.f1 FROM t2) AS dt1 WHERE dt1.f1 = t1.f1 AND t1.f1 = 123;
 ----
+Source materialize.public.t1 (u1):
+| Filter (#0 = 123)
+| Project (#0, #1)
+
+Source materialize.public.t2 (u2):
+| Filter (#0 = 123)
+| Project (#0)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 | Filter (#0 = 123)
 | ArrangeBy ()
 
 %1 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Filter (#0 = 123)
 | Project (#0)
 
@@ -356,17 +467,24 @@ EOF
 query T multiline
 EXPLAIN SELECT * FROM t1 WHERE 123 = (SELECT t2.f1 FROM t2);
 ----
+Source materialize.public.t1 (u1):
+| Project (#0, #1)
+
+Source materialize.public.t2 (u2):
+| Project (#0)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 | ArrangeBy ()
 
 %1 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Filter (#0 = 123)
 | Project ()
 
 %2 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Project ()
 | Reduce group=()
 | | agg count(true)
@@ -385,18 +503,26 @@ EOF
 query T multiline
 EXPLAIN SELECT * FROM t1 WHERE t1.f1 = 123 AND t1.f1 = (SELECT t2.f1 FROM t2);
 ----
+Source materialize.public.t1 (u1):
+| Filter (#0 = 123)
+| Project (#0, #1)
+
+Source materialize.public.t2 (u2):
+| Project (#0)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 | Filter (#0 = 123)
 | ArrangeBy ()
 
 %1 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Filter (#0 = 123)
 | Project ()
 
 %2 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Project ()
 | Reduce group=()
 | | agg count(true)
@@ -423,8 +549,13 @@ CREATE TABLE t4 (f1 INTEGER, f2 INTEGER, PRIMARY KEY (f1, f2));
 query T multiline
 EXPLAIN SELECT * FROM t4 AS a1, t4 AS a2 WHERE a1.f1 = 123 AND a1.f2 = 234 AND a1.f1 = a2.f1 AND a1.f2 = a2.f2;
 ----
+Source materialize.public.t4 (u4):
+| Filter (#0 = 123), (#1 = 234)
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.t4 (u7)
+| Get materialize.public.t4 (u4)
 | Filter (#0 = 123), (#1 = 234)
 | Project (#0, #1, #0, #1)
 
@@ -433,8 +564,13 @@ EOF
 query T multiline
 EXPLAIN SELECT * FROM t4 AS a1 LEFT JOIN t4 AS a2 USING (f1, f2) WHERE a1.f1 = 123 AND a1.f2 = 234;
 ----
+Source materialize.public.t4 (u4):
+| Filter (#0 = 123), (#1 = 234)
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.t4 (u7)
+| Get materialize.public.t4 (u4)
 | Filter (#0 = 123), (#1 = 234)
 
 EOF
@@ -446,8 +582,13 @@ EOF
 query T multiline
 EXPLAIN SELECT * FROM t4 AS a1 LEFT JOIN t4 AS a2 USING (f1, f2) WHERE a1.f1 = 123 AND a2.f2 = 234;
 ----
+Source materialize.public.t4 (u4):
+| Filter (#0 = 123), (#1 = 234)
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.t4 (u7)
+| Get materialize.public.t4 (u4)
 | Filter (#0 = 123), (#1 = 234)
 
 EOF
@@ -471,6 +612,15 @@ EOF
 query T multiline
 EXPLAIN SELECT * FROM t1 FULL OUTER JOIN t2 USING (f1) WHERE t1.f1 = 123 AND t2.f1 = 234;
 ----
+Source materialize.public.t1 (u1):
+| Filter (#0 = 123), (#0 = 234)
+| Project (#0, #1)
+
+Source materialize.public.t2 (u2):
+| Filter (#0 = 123), (#0 = 234)
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 | Filter (#0 = 123), (#0 = 234)
@@ -478,7 +628,7 @@ EXPLAIN SELECT * FROM t1 FULL OUTER JOIN t2 USING (f1) WHERE t1.f1 = 123 AND t2.
 | ArrangeBy ()
 
 %1 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Filter (#0 = 123), (#0 = 234)
 | Project (#1)
 
@@ -495,13 +645,22 @@ EOF
 query T multiline
 EXPLAIN SELECT * FROM t1, t2 WHERE t1.f1 = 123 AND t1.f1 > t2.f1;
 ----
+Source materialize.public.t1 (u1):
+| Filter (#0 = 123)
+| Project (#0, #1)
+
+Source materialize.public.t2 (u2):
+| Filter (123 > #0)
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 | Filter (#0 = 123)
 | ArrangeBy ()
 
 %1 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Filter (123 > #0)
 
 %2 =
@@ -521,16 +680,24 @@ create table int_table(int_col integer NOT NULL);
 query T multiline
 explain select * from int_table, double_table where int_table.int_col = double_table.double_col;
 ----
+Source materialize.public.double_table (u5):
+| Filter !(isnull(#0))
+| Project (#0)
+
+Source materialize.public.int_table (u6):
+| Project (#0)
+
+Query:
 %0 =
-| Get materialize.public.int_table (u11)
+| Get materialize.public.int_table (u6)
+| ArrangeBy (i32tof64(#0))
 
 %1 =
-| Get materialize.public.double_table (u9)
-| ArrangeBy (#0)
+| Get materialize.public.double_table (u5)
+| Filter !(isnull(#0))
 
 %2 =
 | Join %0 %1 (= #1 i32tof64(#0))
-| | implementation = Differential %0 %1.(#0)
-| Filter !(isnull(#1))
+| | implementation = Differential %1 %0.(i32tof64(#0))
 
 EOF

--- a/test/sqllogictest/cte_lowering.slt
+++ b/test/sqllogictest/cte_lowering.slt
@@ -30,7 +30,7 @@ WITH t AS (SELECT * FROM y WHERE a < 3)
   SELECT * FROM t NATURAL JOIN t a;
 ----
 %0 = Let t (l0) =
-| Get materialize.public.y (u3)
+| Get materialize.public.y (u2)
 | Filter (#0 < 3)
 
 %1 =
@@ -46,11 +46,11 @@ WITH t AS (SELECT * FROM y WHERE a < 3)
   SELECT * FROM y WHERE (select a from t) < a;
 ----
 %0 = Let t (l0) =
-| Get materialize.public.y (u3)
+| Get materialize.public.y (u2)
 | Filter (#0 < 3)
 
 %1 =
-| Get materialize.public.y (u3)
+| Get materialize.public.y (u2)
 | Filter (select(%2) < #0)
 | |
 | | %2 =
@@ -69,7 +69,7 @@ WITH t AS (SELECT * FROM y WHERE a < 3)
 | Constant ()
 
 %1 =
-| Get materialize.public.y (u3)
+| Get materialize.public.y (u2)
 
 %2 = Let l1 =
 | Join %0 %1
@@ -111,7 +111,7 @@ FROM x,
 | Distinct group=(#0)
 
 %4 =
-| Get materialize.public.y (u3)
+| Get materialize.public.y (u2)
 
 %5 = Let l3 =
 | Join %3 %4
@@ -194,7 +194,7 @@ FROM x,
 | Distinct group=(#0)
 
 %4 =
-| Get materialize.public.y (u3)
+| Get materialize.public.y (u2)
 
 %5 = Let l3 =
 | Join %3 %4
@@ -231,7 +231,7 @@ FROM x,
 | Union %5 %11
 
 %13 =
-| Get materialize.public.y (u3)
+| Get materialize.public.y (u2)
 
 %14 = Let l5 =
 | Join %3 %13
@@ -332,7 +332,7 @@ FROM x,
 | Distinct group=(#0)
 
 %4 =
-| Get materialize.public.y (u3)
+| Get materialize.public.y (u2)
 
 %5 = Let l3 =
 | Join %3 %4
@@ -427,7 +427,7 @@ FROM x,
 | Distinct group=(#0)
 
 %4 =
-| Get materialize.public.y (u3)
+| Get materialize.public.y (u2)
 
 %5 = Let l3 =
 | Join %3 %4
@@ -464,7 +464,7 @@ FROM x,
 | Union %5 %11
 
 %13 =
-| Get materialize.public.y (u3)
+| Get materialize.public.y (u2)
 
 %14 = Let l5 =
 | Join %3 %13
@@ -590,7 +590,7 @@ FROM x,
 | Distinct group=(#0)
 
 %4 =
-| Get materialize.public.y (u3)
+| Get materialize.public.y (u2)
 
 %5 = Let l3 =
 | Join %3 %4
@@ -627,7 +627,7 @@ FROM x,
 | Union %5 %11
 
 %13 =
-| Get materialize.public.y (u3)
+| Get materialize.public.y (u2)
 
 %14 = Let l5 =
 | Join %3 %13
@@ -734,10 +734,10 @@ FROM (WITH e(e) AS (SELECT b FROM b)
                              < (SELECT max(x) FROM x))
 ----
 %0 = Let a (l0) =
-| Get materialize.public.y (u3)
+| Get materialize.public.y (u2)
 
 %1 = Let b (l1) =
-| Get materialize.public.y (u3)
+| Get materialize.public.y (u2)
 
 %2 = Let x (l2) =
 | Get b (l1) (%1)
@@ -764,7 +764,7 @@ FROM (WITH e(e) AS (SELECT b FROM b)
 | Map select(%9)
 | |
 | | %8 = Let c (l3) =
-| | | Get materialize.public.y (u3)
+| | | Get materialize.public.y (u2)
 | |
 | | %9 =
 | | | Get c (l3) (%8)
@@ -788,7 +788,7 @@ EXPLAIN RAW PLAN FOR
 WITH a(a) AS (SELECT a FROM y) SELECT * FROM (WITH a(a) AS (SELECT a FROM a) SELECT a FROM a);
 ----
 %0 = Let a (l0) =
-| Get materialize.public.y (u3)
+| Get materialize.public.y (u2)
 
 %1 = Let a (l1) =
 | Get a (l0) (%0)

--- a/test/sqllogictest/distinct_on.slt
+++ b/test/sqllogictest/distinct_on.slt
@@ -39,6 +39,10 @@ CREATE TABLE abc (
 query T multiline
 EXPLAIN SELECT DISTINCT ON (c) a FROM abc
 ----
+Source materialize.public.abc (u1):
+| Project (#0, #2)
+
+Query:
 %0 =
 | Get materialize.public.abc (u1)
 | Project (#0, #2)
@@ -50,6 +54,10 @@ EOF
 query T multiline
 EXPLAIN SELECT DISTINCT ON (c) a FROM abc ORDER BY c, b
 ----
+Source materialize.public.abc (u1):
+| Project (#0..=#2)
+
+Query:
 %0 =
 | Get materialize.public.abc (u1)
 | TopK group=(#2) order=(#1 asc) limit=1 offset=0

--- a/test/sqllogictest/explain.slt
+++ b/test/sqllogictest/explain.slt
@@ -272,6 +272,10 @@ EOF
 query T multiline
 EXPLAIN TYPED OPTIMIZED PLAN FOR SELECT * FROM ordered ORDER BY y asc, x desc LIMIT 5
 ----
+Source materialize.public.ordered (u2):
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.ordered (u2)
 | | types = (integer?, text?)
@@ -287,6 +291,10 @@ CREATE VIEW ordered_view AS SELECT * FROM ordered ORDER BY y asc, x desc LIMIT 5
 query T multiline
 EXPLAIN TYPED OPTIMIZED PLAN FOR VIEW ordered_view
 ----
+Source materialize.public.ordered (u2):
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.ordered (u2)
 | | types = (integer?, text?)
@@ -311,6 +319,16 @@ EOF
 query T multiline
 EXPLAIN PHYSICAL PLAN FOR SELECT * FROM ordered
 ----
+Source materialize.public.ordered (u2):
+{
+  "predicates": [],
+  "projection": [
+    0,
+    1
+  ]
+}
+
+Query:
 {
   "Get": {
     "id": {
@@ -319,24 +337,8 @@ EXPLAIN PHYSICAL PLAN FOR SELECT * FROM ordered
       }
     },
     "keys": {
-      "raw": false,
-      "arranged": [
-        [
-          [
-            {
-              "Column": 0
-            },
-            {
-              "Column": 1
-            }
-          ],
-          {
-            "0": 0,
-            "1": 1
-          },
-          []
-        ]
-      ]
+      "raw": true,
+      "arranged": []
     },
     "mfp": {
       "expressions": [],
@@ -347,17 +349,7 @@ EXPLAIN PHYSICAL PLAN FOR SELECT * FROM ordered
       ],
       "input_arity": 2
     },
-    "key_val": [
-      [
-        {
-          "Column": 0
-        },
-        {
-          "Column": 1
-        }
-      ],
-      null
-    ]
+    "key_val": null
   }
 }
 
@@ -366,6 +358,16 @@ EOF
 query T multiline
 EXPLAIN TYPED PHYSICAL PLAN FOR SELECT * FROM ordered
 ----
+Source materialize.public.ordered (u2):
+{
+  "predicates": [],
+  "projection": [
+    0,
+    1
+  ]
+}
+
+Query:
 {
   "Get": {
     "id": {
@@ -374,24 +376,8 @@ EXPLAIN TYPED PHYSICAL PLAN FOR SELECT * FROM ordered
       }
     },
     "keys": {
-      "raw": false,
-      "arranged": [
-        [
-          [
-            {
-              "Column": 0
-            },
-            {
-              "Column": 1
-            }
-          ],
-          {
-            "0": 0,
-            "1": 1
-          },
-          []
-        ]
-      ]
+      "raw": true,
+      "arranged": []
     },
     "mfp": {
       "expressions": [],
@@ -402,17 +388,7 @@ EXPLAIN TYPED PHYSICAL PLAN FOR SELECT * FROM ordered
       ],
       "input_arity": 2
     },
-    "key_val": [
-      [
-        {
-          "Column": 0
-        },
-        {
-          "Column": 1
-        }
-      ],
-      null
-    ]
+    "key_val": null
   }
 }
 
@@ -421,72 +397,30 @@ EOF
 query T multiline
 EXPLAIN PHYSICAL PLAN FOR VIEW ordered_view
 ----
+Source materialize.public.ordered (u2):
+{
+  "predicates": [],
+  "projection": [
+    0,
+    1
+  ]
+}
+
+Query:
 {
   "TopK": {
     "input": {
-      "ArrangeBy": {
-        "input": {
-          "Get": {
-            "id": {
-              "Global": {
-                "User": 2
-              }
-            },
-            "keys": {
-              "raw": false,
-              "arranged": [
-                [
-                  [
-                    {
-                      "Column": 0
-                    },
-                    {
-                      "Column": 1
-                    }
-                  ],
-                  {
-                    "0": 0,
-                    "1": 1
-                  },
-                  []
-                ]
-              ]
-            },
-            "mfp": {
-              "expressions": [],
-              "predicates": [],
-              "projection": [
-                0,
-                1
-              ],
-              "input_arity": 2
-            },
-            "key_val": [
-              [
-                {
-                  "Column": 0
-                },
-                {
-                  "Column": 1
-                }
-              ],
-              null
-            ]
+      "Get": {
+        "id": {
+          "Global": {
+            "User": 2
           }
         },
-        "forms": {
+        "keys": {
           "raw": true,
           "arranged": []
         },
-        "input_key": [
-          {
-            "Column": 0
-          },
-          {
-            "Column": 1
-          }
-        ],
-        "input_mfp": {
+        "mfp": {
           "expressions": [],
           "predicates": [],
           "projection": [
@@ -494,7 +428,8 @@ EXPLAIN PHYSICAL PLAN FOR VIEW ordered_view
             1
           ],
           "input_arity": 2
-        }
+        },
+        "key_val": null
       }
     },
     "top_k_plan": {
@@ -523,72 +458,30 @@ EOF
 query T multiline
 EXPLAIN TYPED PHYSICAL PLAN FOR VIEW ordered_view
 ----
+Source materialize.public.ordered (u2):
+{
+  "predicates": [],
+  "projection": [
+    0,
+    1
+  ]
+}
+
+Query:
 {
   "TopK": {
     "input": {
-      "ArrangeBy": {
-        "input": {
-          "Get": {
-            "id": {
-              "Global": {
-                "User": 2
-              }
-            },
-            "keys": {
-              "raw": false,
-              "arranged": [
-                [
-                  [
-                    {
-                      "Column": 0
-                    },
-                    {
-                      "Column": 1
-                    }
-                  ],
-                  {
-                    "0": 0,
-                    "1": 1
-                  },
-                  []
-                ]
-              ]
-            },
-            "mfp": {
-              "expressions": [],
-              "predicates": [],
-              "projection": [
-                0,
-                1
-              ],
-              "input_arity": 2
-            },
-            "key_val": [
-              [
-                {
-                  "Column": 0
-                },
-                {
-                  "Column": 1
-                }
-              ],
-              null
-            ]
+      "Get": {
+        "id": {
+          "Global": {
+            "User": 2
           }
         },
-        "forms": {
+        "keys": {
           "raw": true,
           "arranged": []
         },
-        "input_key": [
-          {
-            "Column": 0
-          },
-          {
-            "Column": 1
-          }
-        ],
-        "input_mfp": {
+        "mfp": {
           "expressions": [],
           "predicates": [],
           "projection": [
@@ -596,7 +489,8 @@ EXPLAIN TYPED PHYSICAL PLAN FOR VIEW ordered_view
             1
           ],
           "input_arity": 2
-        }
+        },
+        "key_val": null
       }
     },
     "top_k_plan": {
@@ -625,6 +519,16 @@ EOF
 query T multiline
 EXPLAIN PHYSICAL PLAN FOR SELECT * FROM ordered ORDER BY y asc, x desc LIMIT 5
 ----
+Source materialize.public.ordered (u2):
+{
+  "predicates": [],
+  "projection": [
+    0,
+    1
+  ]
+}
+
+Query:
 {
   "Get": {
     "id": {
@@ -633,24 +537,8 @@ EXPLAIN PHYSICAL PLAN FOR SELECT * FROM ordered ORDER BY y asc, x desc LIMIT 5
       }
     },
     "keys": {
-      "raw": false,
-      "arranged": [
-        [
-          [
-            {
-              "Column": 0
-            },
-            {
-              "Column": 1
-            }
-          ],
-          {
-            "0": 0,
-            "1": 1
-          },
-          []
-        ]
-      ]
+      "raw": true,
+      "arranged": []
     },
     "mfp": {
       "expressions": [],
@@ -661,17 +549,7 @@ EXPLAIN PHYSICAL PLAN FOR SELECT * FROM ordered ORDER BY y asc, x desc LIMIT 5
       ],
       "input_arity": 2
     },
-    "key_val": [
-      [
-        {
-          "Column": 0
-        },
-        {
-          "Column": 1
-        }
-      ],
-      null
-    ]
+    "key_val": null
   }
 }
 
@@ -682,6 +560,16 @@ EOF
 query T multiline
 EXPLAIN TYPED PHYSICAL PLAN FOR SELECT * FROM ordered ORDER BY y asc, x desc LIMIT 5
 ----
+Source materialize.public.ordered (u2):
+{
+  "predicates": [],
+  "projection": [
+    0,
+    1
+  ]
+}
+
+Query:
 {
   "Get": {
     "id": {
@@ -690,24 +578,8 @@ EXPLAIN TYPED PHYSICAL PLAN FOR SELECT * FROM ordered ORDER BY y asc, x desc LIM
       }
     },
     "keys": {
-      "raw": false,
-      "arranged": [
-        [
-          [
-            {
-              "Column": 0
-            },
-            {
-              "Column": 1
-            }
-          ],
-          {
-            "0": 0,
-            "1": 1
-          },
-          []
-        ]
-      ]
+      "raw": true,
+      "arranged": []
     },
     "mfp": {
       "expressions": [],
@@ -718,17 +590,7 @@ EXPLAIN TYPED PHYSICAL PLAN FOR SELECT * FROM ordered ORDER BY y asc, x desc LIM
       ],
       "input_arity": 2
     },
-    "key_val": [
-      [
-        {
-          "Column": 0
-        },
-        {
-          "Column": 1
-        }
-      ],
-      null
-    ]
+    "key_val": null
   }
 }
 

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -173,8 +173,12 @@ CREATE TABLE date_trunc_timestamps (
 query T multiline
 EXPLAIN PLAN FOR SELECT date_trunc('day', ts) FROM date_trunc_timestamps
 ----
+Source materialize.public.date_trunc_timestamps (u2):
+| Project (#0)
+
+Query:
 %0 =
-| Get materialize.public.date_trunc_timestamps (u3)
+| Get materialize.public.date_trunc_timestamps (u2)
 | Map date_trunc_day_ts(#0)
 | Project (#1)
 
@@ -183,12 +187,19 @@ EOF
 query T multiline
 EXPLAIN PLAN FOR SELECT date_trunc(field, ts) FROM date_trunc_fields, date_trunc_timestamps
 ----
+Source materialize.public.date_trunc_fields (u1):
+| Project (#0)
+
+Source materialize.public.date_trunc_timestamps (u2):
+| Project (#0)
+
+Query:
 %0 =
 | Get materialize.public.date_trunc_fields (u1)
 | ArrangeBy ()
 
 %1 =
-| Get materialize.public.date_trunc_timestamps (u3)
+| Get materialize.public.date_trunc_timestamps (u2)
 
 %2 =
 | Join %0 %1
@@ -522,8 +533,12 @@ CREATE TABLE t (
 query T multiline
 EXPLAIN PLAN FOR SELECT a IS NULL FROM t
 ----
+Source materialize.public.t (u6):
+| Project (#0)
+
+Query:
 %0 =
-| Get materialize.public.t (u9)
+| Get materialize.public.t (u6)
 | Map isnull(#0)
 | Project (#2)
 
@@ -532,8 +547,12 @@ EOF
 query T multiline
 EXPLAIN PLAN FOR SELECT a + a + a + a + a IS NULL FROM t
 ----
+Source materialize.public.t (u6):
+| Project (#0)
+
+Query:
 %0 =
-| Get materialize.public.t (u9)
+| Get materialize.public.t (u6)
 | Map isnull(#0)
 | Project (#2)
 
@@ -542,8 +561,12 @@ EOF
 query T multiline
 EXPLAIN PLAN FOR SELECT a + b IS NULL FROM t
 ----
+Source materialize.public.t (u6):
+| Project (#0)
+
+Query:
 %0 =
-| Get materialize.public.t (u9)
+| Get materialize.public.t (u6)
 | Map isnull(#0)
 | Project (#2)
 
@@ -556,8 +579,12 @@ EOF
 query T multiline
 EXPLAIN PLAN FOR SELECT (a::bool AND b::bool) IS NULL FROM t
 ----
+Source materialize.public.t (u6):
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.t (u9)
+| Get materialize.public.t (u6)
 | Map isnull((i32tobool(#0) && i32tobool(#1)))
 | Project (#2)
 

--- a/test/sqllogictest/github-8241.slt
+++ b/test/sqllogictest/github-8241.slt
@@ -39,4 +39,3 @@ DETAIL: The following relations in the query are outside the transaction's time 
 "materialize.public.i2"
 Only the following relations are available:
 "materialize.public.i1"
-"materialize.public.t1_primary_idx"

--- a/test/sqllogictest/github-8241.slt
+++ b/test/sqllogictest/github-8241.slt
@@ -39,6 +39,4 @@ DETAIL: The following relations in the query are outside the transaction's time 
 "materialize.public.i2"
 Only the following relations are available:
 "materialize.public.i1"
-"materialize.public.t1"
 "materialize.public.t1_primary_idx"
-"materialize.public.v1"

--- a/test/sqllogictest/github-9027.slt
+++ b/test/sqllogictest/github-9027.slt
@@ -59,6 +59,26 @@ WHERE
  OR l_commitdate = o_orderdate - ' 7 DAY '
  );
 ----
+Source materialize.public.orders (u1):
+{
+  "predicates": [],
+  "projection": [
+    0,
+    4
+  ]
+}
+
+Source materialize.public.lineitem (u2):
+{
+  "predicates": [],
+  "projection": [
+    0,
+    11,
+    12
+  ]
+}
+
+Query:
 {
   "Let": {
     "id": 0,
@@ -71,84 +91,12 @@ WHERE
                 "Get": {
                   "id": {
                     "Global": {
-                      "User": 3
+                      "User": 2
                     }
                   },
                   "keys": {
-                    "raw": false,
-                    "arranged": [
-                      [
-                        [
-                          {
-                            "Column": 0
-                          },
-                          {
-                            "Column": 1
-                          },
-                          {
-                            "Column": 2
-                          },
-                          {
-                            "Column": 3
-                          },
-                          {
-                            "Column": 4
-                          },
-                          {
-                            "Column": 5
-                          },
-                          {
-                            "Column": 6
-                          },
-                          {
-                            "Column": 7
-                          },
-                          {
-                            "Column": 8
-                          },
-                          {
-                            "Column": 9
-                          },
-                          {
-                            "Column": 10
-                          },
-                          {
-                            "Column": 11
-                          },
-                          {
-                            "Column": 12
-                          },
-                          {
-                            "Column": 13
-                          },
-                          {
-                            "Column": 14
-                          },
-                          {
-                            "Column": 15
-                          }
-                        ],
-                        {
-                          "0": 0,
-                          "1": 1,
-                          "2": 2,
-                          "3": 3,
-                          "4": 4,
-                          "5": 5,
-                          "6": 6,
-                          "7": 7,
-                          "8": 8,
-                          "9": 9,
-                          "10": 10,
-                          "11": 11,
-                          "12": 12,
-                          "13": 13,
-                          "14": 14,
-                          "15": 15
-                        },
-                        []
-                      ]
-                    ]
+                    "raw": true,
+                    "arranged": []
                   },
                   "mfp": {
                     "expressions": [],
@@ -158,59 +106,7 @@ WHERE
                     ],
                     "input_arity": 16
                   },
-                  "key_val": [
-                    [
-                      {
-                        "Column": 0
-                      },
-                      {
-                        "Column": 1
-                      },
-                      {
-                        "Column": 2
-                      },
-                      {
-                        "Column": 3
-                      },
-                      {
-                        "Column": 4
-                      },
-                      {
-                        "Column": 5
-                      },
-                      {
-                        "Column": 6
-                      },
-                      {
-                        "Column": 7
-                      },
-                      {
-                        "Column": 8
-                      },
-                      {
-                        "Column": 9
-                      },
-                      {
-                        "Column": 10
-                      },
-                      {
-                        "Column": 11
-                      },
-                      {
-                        "Column": 12
-                      },
-                      {
-                        "Column": 13
-                      },
-                      {
-                        "Column": 14
-                      },
-                      {
-                        "Column": 15
-                      }
-                    ],
-                    null
-                  ]
+                  "key_val": null
                 }
               },
               "forms": {
@@ -246,52 +142,8 @@ WHERE
                 }
               },
               "keys": {
-                "raw": false,
-                "arranged": [
-                  [
-                    [
-                      {
-                        "Column": 0
-                      },
-                      {
-                        "Column": 1
-                      },
-                      {
-                        "Column": 2
-                      },
-                      {
-                        "Column": 3
-                      },
-                      {
-                        "Column": 4
-                      },
-                      {
-                        "Column": 5
-                      },
-                      {
-                        "Column": 6
-                      },
-                      {
-                        "Column": 7
-                      },
-                      {
-                        "Column": 8
-                      }
-                    ],
-                    {
-                      "0": 0,
-                      "1": 1,
-                      "2": 2,
-                      "3": 3,
-                      "4": 4,
-                      "5": 5,
-                      "6": 6,
-                      "7": 7,
-                      "8": 8
-                    },
-                    []
-                  ]
-                ]
+                "raw": true,
+                "arranged": []
               },
               "mfp": {
                 "expressions": [],
@@ -299,38 +151,7 @@ WHERE
                 "projection": [],
                 "input_arity": 9
               },
-              "key_val": [
-                [
-                  {
-                    "Column": 0
-                  },
-                  {
-                    "Column": 1
-                  },
-                  {
-                    "Column": 2
-                  },
-                  {
-                    "Column": 3
-                  },
-                  {
-                    "Column": 4
-                  },
-                  {
-                    "Column": 5
-                  },
-                  {
-                    "Column": 6
-                  },
-                  {
-                    "Column": 7
-                  },
-                  {
-                    "Column": 8
-                  }
-                ],
-                null
-              ]
+              "key_val": null
             }
           }
         ],
@@ -401,84 +222,12 @@ WHERE
                               "Get": {
                                 "id": {
                                   "Global": {
-                                    "User": 3
+                                    "User": 2
                                   }
                                 },
                                 "keys": {
-                                  "raw": false,
-                                  "arranged": [
-                                    [
-                                      [
-                                        {
-                                          "Column": 0
-                                        },
-                                        {
-                                          "Column": 1
-                                        },
-                                        {
-                                          "Column": 2
-                                        },
-                                        {
-                                          "Column": 3
-                                        },
-                                        {
-                                          "Column": 4
-                                        },
-                                        {
-                                          "Column": 5
-                                        },
-                                        {
-                                          "Column": 6
-                                        },
-                                        {
-                                          "Column": 7
-                                        },
-                                        {
-                                          "Column": 8
-                                        },
-                                        {
-                                          "Column": 9
-                                        },
-                                        {
-                                          "Column": 10
-                                        },
-                                        {
-                                          "Column": 11
-                                        },
-                                        {
-                                          "Column": 12
-                                        },
-                                        {
-                                          "Column": 13
-                                        },
-                                        {
-                                          "Column": 14
-                                        },
-                                        {
-                                          "Column": 15
-                                        }
-                                      ],
-                                      {
-                                        "0": 0,
-                                        "1": 1,
-                                        "2": 2,
-                                        "3": 3,
-                                        "4": 4,
-                                        "5": 5,
-                                        "6": 6,
-                                        "7": 7,
-                                        "8": 8,
-                                        "9": 9,
-                                        "10": 10,
-                                        "11": 11,
-                                        "12": 12,
-                                        "13": 13,
-                                        "14": 14,
-                                        "15": 15
-                                      },
-                                      []
-                                    ]
-                                  ]
+                                  "raw": true,
+                                  "arranged": []
                                 },
                                 "mfp": {
                                   "expressions": [],
@@ -489,59 +238,7 @@ WHERE
                                   ],
                                   "input_arity": 16
                                 },
-                                "key_val": [
-                                  [
-                                    {
-                                      "Column": 0
-                                    },
-                                    {
-                                      "Column": 1
-                                    },
-                                    {
-                                      "Column": 2
-                                    },
-                                    {
-                                      "Column": 3
-                                    },
-                                    {
-                                      "Column": 4
-                                    },
-                                    {
-                                      "Column": 5
-                                    },
-                                    {
-                                      "Column": 6
-                                    },
-                                    {
-                                      "Column": 7
-                                    },
-                                    {
-                                      "Column": 8
-                                    },
-                                    {
-                                      "Column": 9
-                                    },
-                                    {
-                                      "Column": 10
-                                    },
-                                    {
-                                      "Column": 11
-                                    },
-                                    {
-                                      "Column": 12
-                                    },
-                                    {
-                                      "Column": 13
-                                    },
-                                    {
-                                      "Column": 14
-                                    },
-                                    {
-                                      "Column": 15
-                                    }
-                                  ],
-                                  null
-                                ]
+                                "key_val": null
                               }
                             },
                             "forms": {
@@ -661,52 +358,8 @@ WHERE
                                   }
                                 },
                                 "keys": {
-                                  "raw": false,
-                                  "arranged": [
-                                    [
-                                      [
-                                        {
-                                          "Column": 0
-                                        },
-                                        {
-                                          "Column": 1
-                                        },
-                                        {
-                                          "Column": 2
-                                        },
-                                        {
-                                          "Column": 3
-                                        },
-                                        {
-                                          "Column": 4
-                                        },
-                                        {
-                                          "Column": 5
-                                        },
-                                        {
-                                          "Column": 6
-                                        },
-                                        {
-                                          "Column": 7
-                                        },
-                                        {
-                                          "Column": 8
-                                        }
-                                      ],
-                                      {
-                                        "0": 0,
-                                        "1": 1,
-                                        "2": 2,
-                                        "3": 3,
-                                        "4": 4,
-                                        "5": 5,
-                                        "6": 6,
-                                        "7": 7,
-                                        "8": 8
-                                      },
-                                      []
-                                    ]
-                                  ]
+                                  "raw": true,
+                                  "arranged": []
                                 },
                                 "mfp": {
                                   "expressions": [],
@@ -738,38 +391,7 @@ WHERE
                                   ],
                                   "input_arity": 9
                                 },
-                                "key_val": [
-                                  [
-                                    {
-                                      "Column": 0
-                                    },
-                                    {
-                                      "Column": 1
-                                    },
-                                    {
-                                      "Column": 2
-                                    },
-                                    {
-                                      "Column": 3
-                                    },
-                                    {
-                                      "Column": 4
-                                    },
-                                    {
-                                      "Column": 5
-                                    },
-                                    {
-                                      "Column": 6
-                                    },
-                                    {
-                                      "Column": 7
-                                    },
-                                    {
-                                      "Column": 8
-                                    }
-                                  ],
-                                  null
-                                ]
+                                "key_val": null
                               }
                             },
                             "forms": {

--- a/test/sqllogictest/github-9782.slt
+++ b/test/sqllogictest/github-9782.slt
@@ -64,8 +64,20 @@ CREATE TAble table_f5_f6 (f5 INTEGER, f6 INTEGER);
 query T multiline
 EXPLAIN  SELECT *  FROM table_f1 , ( table_f4_f5_f6 AS a2 LEFT JOIN table_f5_f6 AS a3 USING ( f5 , f6  ) ) WHERE f5 = f6 AND  f4 = f6;
 ----
+Source materialize.public.table_f1 (u1):
+| Project (#0)
+
+Source materialize.public.table_f4_f5_f6 (u3):
+| Filter (#0 = #1), (#0 = #2), (#1 = #2)
+| Project (#0..=#2)
+
+Source materialize.public.table_f5_f6 (u4):
+| Filter (#0 = #1)
+| Project (#0, #1)
+
+Query:
 %0 = Let l0 =
-| Get materialize.public.table_f4_f5_f6 (u5)
+| Get materialize.public.table_f4_f5_f6 (u3)
 | Filter (#0 = #1), (#0 = #2), (#1 = #2)
 
 %1 =
@@ -73,7 +85,7 @@ EXPLAIN  SELECT *  FROM table_f1 , ( table_f4_f5_f6 AS a2 LEFT JOIN table_f5_f6 
 | ArrangeBy (#0)
 
 %2 =
-| Get materialize.public.table_f5_f6 (u7)
+| Get materialize.public.table_f5_f6 (u4)
 | Filter (#0 = #1)
 | Project (#0)
 

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -110,6 +110,11 @@ SELECT l1.la, l2.lb, l3.lb
 FROM l as l1, l as l2, l as l3
 WHERE l1.la + 1 = l2.la AND l3.la = l1.la + l2.la
 ----
+Source materialize.public.l (u1):
+| Filter !(isnull(#0))
+| Project (#0, #1)
+
+Query:
 %0 = Let l0 =
 | Get materialize.public.l (u1)
 | Filter !(isnull(#0))
@@ -148,6 +153,10 @@ WHERE l1.la IN (
     )
 )
 ----
+Source materialize.public.l (u1):
+| Project (#0, #1)
+
+Query:
 %0 = Let l0 =
 | Get materialize.public.l (u1)
 | Project (#0)
@@ -313,13 +322,21 @@ query T multiline
 EXPLAIN PLAN FOR
 SELECT * FROM l LEFT JOIN r ON l.la = r.ra
 ----
+Source materialize.public.l (u1):
+| Project (#0, #1)
+
+Source materialize.public.r (u2):
+| Filter !(isnull(#0))
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.l (u1)
 | Filter !(isnull(#0))
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.r (u3)
+| Get materialize.public.r (u2)
 | Filter !(isnull(#0))
 
 %2 = Let l0 =
@@ -362,13 +379,21 @@ query T multiline
 EXPLAIN PLAN FOR
 SELECT * FROM l RIGHT JOIN r ON l.la = r.ra
 ----
+Source materialize.public.l (u1):
+| Filter !(isnull(#0))
+| Project (#0, #1)
+
+Source materialize.public.r (u2):
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.l (u1)
 | Filter !(isnull(#0))
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.r (u3)
+| Get materialize.public.r (u2)
 | Filter !(isnull(#0))
 
 %2 = Let l0 =
@@ -377,7 +402,7 @@ SELECT * FROM l RIGHT JOIN r ON l.la = r.ra
 | Project (#0, #1, #3)
 
 %3 =
-| Get materialize.public.r (u3)
+| Get materialize.public.r (u2)
 
 %4 =
 | Get %2 (l0)
@@ -392,7 +417,7 @@ SELECT * FROM l RIGHT JOIN r ON l.la = r.ra
 | Negate
 
 %6 =
-| Get materialize.public.r (u3)
+| Get materialize.public.r (u2)
 
 %7 =
 | Union %5 %6
@@ -412,13 +437,20 @@ query T multiline
 EXPLAIN PLAN FOR
 SELECT * FROM l FULL JOIN r ON l.la = r.ra
 ----
+Source materialize.public.l (u1):
+| Project (#0, #1)
+
+Source materialize.public.r (u2):
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.l (u1)
 | Filter !(isnull(#0))
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.r (u3)
+| Get materialize.public.r (u2)
 | Filter !(isnull(#0))
 
 %2 = Let l0 =
@@ -433,7 +465,7 @@ SELECT * FROM l FULL JOIN r ON l.la = r.ra
 | ArrangeBy (#0)
 
 %4 =
-| Get materialize.public.r (u3)
+| Get materialize.public.r (u2)
 
 %5 =
 | Join %4 %3 (= #0 #2)
@@ -442,7 +474,7 @@ SELECT * FROM l FULL JOIN r ON l.la = r.ra
 | Negate
 
 %6 =
-| Get materialize.public.r (u3)
+| Get materialize.public.r (u2)
 
 %7 =
 | Union %5 %6
@@ -488,13 +520,22 @@ SELECT * FROM l INNER JOIN r ON mod(l.la, 2) = mod(r.ra, 2)
 query T multiline
 EXPLAIN PLAN FOR SELECT * FROM l INNER JOIN r ON mod(l.la, 2) = mod(r.ra, 2)
 ----
+Source materialize.public.l (u1):
+| Filter !(isnull(#0))
+| Project (#0, #1)
+
+Source materialize.public.r (u2):
+| Filter !(isnull(#0))
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.l (u1)
 | Filter !(isnull(#0))
 | ArrangeBy ((#0 % 2))
 
 %1 =
-| Get materialize.public.r (u3)
+| Get materialize.public.r (u2)
 | Filter !(isnull(#0))
 
 %2 =
@@ -541,12 +582,16 @@ mode standard
 query T multiline
 EXPLAIN SELECT name, id FROM v4362 WHERE name = (SELECT name FROM v4362 WHERE id = 1)
 ----
+Source materialize.public.t4362 (u6):
+| Project (#0, #1)
+
+Query:
 %0 = Let l0 =
-| Get materialize.public.t4362 (u10)
+| Get materialize.public.t4362 (u6)
 | Filter (#1 = 1)
 
 %1 =
-| Get materialize.public.t4362 (u10)
+| Get materialize.public.t4362 (u6)
 | ArrangeBy (#0)
 
 %2 =
@@ -594,7 +639,7 @@ EXPLAIN RAW PLAN FOR SELECT la, l.lb, big_l.lb FROM l JOIN big_l USING (la)
 | Get materialize.public.l (u1)
 
 %1 =
-| Get materialize.public.big_l (u13)
+| Get materialize.public.big_l (u8)
 
 %2 =
 | InnerJoin %0 %1 on (true && (i32toi64(#0) = #2))
@@ -624,13 +669,22 @@ INSERT INTO r3 VALUES (1, 'r1'), (3, 'r3'), (4, 'r4'), (NULL, 'r5')
 query T multiline
 EXPLAIN SELECT lb, rb FROM l3 INNER JOIN r3 ON la = ra
 ----
+Source materialize.public.l3 (u10):
+| Filter !(isnull(#0))
+| Project (#0, #1)
+
+Source materialize.public.r3 (u11):
+| Filter !(isnull(#0))
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.l3 (u17)
+| Get materialize.public.l3 (u10)
 | Filter !(isnull(#0))
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.r3 (u19)
+| Get materialize.public.r3 (u11)
 | Filter !(isnull(#0))
 
 %2 =
@@ -649,12 +703,19 @@ l3  r3
 query T multiline
 EXPLAIN SELECT lb, rb FROM l3 INNER JOIN r3 ON la = ra OR (ra IS NULL AND la IS NULL)
 ----
+Source materialize.public.l3 (u10):
+| Project (#0, #1)
+
+Source materialize.public.r3 (u11):
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.l3 (u17)
+| Get materialize.public.l3 (u10)
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.r3 (u19)
+| Get materialize.public.r3 (u11)
 
 %2 =
 | Join %0 %1 (= #0 #2)
@@ -673,12 +734,19 @@ l4  r5
 query T multiline
 EXPLAIN SELECT lb, rb FROM l3 INNER JOIN r3 ON (la IS NULL AND ra IS NULL) OR la = ra
 ----
+Source materialize.public.l3 (u10):
+| Project (#0, #1)
+
+Source materialize.public.r3 (u11):
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.l3 (u17)
+| Get materialize.public.l3 (u10)
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.r3 (u19)
+| Get materialize.public.r3 (u11)
 
 %2 =
 | Join %0 %1 (= #0 #2)

--- a/test/sqllogictest/not-null-propagation.slt
+++ b/test/sqllogictest/not-null-propagation.slt
@@ -81,6 +81,10 @@ EOF
 query T multiline
 EXPLAIN TYPED PLAN FOR SELECT CAST(col_null AS BIGINT), CAST(col_not_null AS BIGINT) FROM int_table;
 ----
+Source materialize.public.int_table (u1):
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.int_table (u1)
 | | types = (integer?, integer)
@@ -101,6 +105,10 @@ EOF
 query T multiline
 EXPLAIN TYPED PLAN FOR SELECT col_null IS NULL, col_null IS NOT NULL FROM int_table;
 ----
+Source materialize.public.int_table (u1):
+| Project (#0)
+
+Query:
 %0 =
 | Get materialize.public.int_table (u1)
 | | types = (integer?, integer)
@@ -117,8 +125,12 @@ EOF
 query T multiline
 EXPLAIN TYPED PLAN FOR SELECT col_null IS TRUE, col_null IS NOT TRUE FROM bool_table;
 ----
+Source materialize.public.bool_table (u2):
+| Project (#0)
+
+Query:
 %0 =
-| Get materialize.public.bool_table (u3)
+| Get materialize.public.bool_table (u2)
 | | types = (boolean?, boolean)
 | | keys = ()
 | Map istrue(#0), !(#2)
@@ -133,8 +145,12 @@ EOF
 query T multiline
 EXPLAIN TYPED PLAN FOR SELECT col_null IS UNKNOWN, col_null IS NOT UNKNOWN FROM bool_table;
 ----
+Source materialize.public.bool_table (u2):
+| Project (#0)
+
+Query:
 %0 =
-| Get materialize.public.bool_table (u3)
+| Get materialize.public.bool_table (u2)
 | | types = (boolean?, boolean)
 | | keys = ()
 | Map isnull(#0), !(#2)
@@ -153,6 +169,10 @@ EOF
 query T multiline
 EXPLAIN TYPED PLAN FOR SELECT col_not_null + col_not_null , col_not_null + 1 , col_not_null % col_not_null , col_not_null % 2 FROM int_table;
 ----
+Source materialize.public.int_table (u1):
+| Project (#1)
+
+Query:
 %0 =
 | Get materialize.public.int_table (u1)
 | | types = (integer?, integer)
@@ -174,6 +194,10 @@ EOF
 query T multiline
 EXPLAIN TYPED PLAN FOR SELECT GREATEST(col_not_null), GREATEST(col_not_null, col_not_null), GREATEST(col_not_null, col_null), GREATEST(col_null, col_null) FROM int_table;
 ----
+Source materialize.public.int_table (u1):
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.int_table (u1)
 | | types = (integer?, integer)
@@ -190,6 +214,10 @@ EOF
 query T multiline
 EXPLAIN TYPED PLAN FOR SELECT LEAST(col_not_null), LEAST(col_not_null, col_not_null), LEAST(col_not_null, col_null), LEAST(col_null, col_null) FROM int_table;
 ----
+Source materialize.public.int_table (u1):
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.int_table (u1)
 | | types = (integer?, integer)
@@ -206,6 +234,10 @@ EOF
 query T multiline
 EXPLAIN TYPED PLAN FOR SELECT COALESCE(col_not_null), COALESCE(col_not_null, col_not_null), COALESCE(col_not_null, col_null), COALESCE(col_null, col_null) FROM int_table;
 ----
+Source materialize.public.int_table (u1):
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.int_table (u1)
 | | types = (integer?, integer)
@@ -224,6 +256,10 @@ EOF
 query T multiline
 EXPLAIN TYPED PLAN FOR SELECT NULLIF(col_not_null, 'a') , NULLIF(col_not_null, NULL), NULLIF(col_null, NULL) , NULLIF(col_null, col_not_null) FROM int_table;
 ----
+Source materialize.public.int_table (u1):
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.int_table (u1)
 | | types = (integer?, integer)
@@ -247,6 +283,10 @@ EOF
 query T multiline
 EXPLAIN TYPED PLAN FOR SELECT col_not_null = 1 FROM int_table;
 ----
+Source materialize.public.int_table (u1):
+| Project (#1)
+
+Query:
 %0 =
 | Get materialize.public.int_table (u1)
 | | types = (integer?, integer)
@@ -263,8 +303,12 @@ EOF
 query T multiline
 EXPLAIN TYPED PLAN FOR SELECT col_not_null AND col_not_null , col_not_null OR col_not_null FROM bool_table;
 ----
+Source materialize.public.bool_table (u2):
+| Project (#1)
+
+Query:
 %0 =
-| Get materialize.public.bool_table (u3)
+| Get materialize.public.bool_table (u2)
 | | types = (boolean?, boolean)
 | | keys = ()
 | Project (#1, #1)
@@ -276,8 +320,12 @@ EOF
 query T multiline
 EXPLAIN TYPED PLAN FOR SELECT col_null AND col_not_null , col_null OR col_not_null FROM bool_table;
 ----
+Source materialize.public.bool_table (u2):
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.bool_table (u3)
+| Get materialize.public.bool_table (u2)
 | | types = (boolean?, boolean)
 | | keys = ()
 | Map (#0 && #1), (#0 || #1)
@@ -292,8 +340,12 @@ EOF
 query T multiline
 EXPLAIN TYPED PLAN FOR SELECT NOT col_null , NOT col_not_null FROM bool_table;
 ----
+Source materialize.public.bool_table (u2):
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.bool_table (u3)
+| Get materialize.public.bool_table (u2)
 | | types = (boolean?, boolean)
 | | keys = ()
 | Map !(#0), !(#1)
@@ -312,6 +364,10 @@ EOF
 query T multiline
 EXPLAIN TYPED PLAN FOR SELECT ABS(col_not_null), LOG(col_not_null), ROUND(col_not_null), COS(col_not_null), col_not_null << col_not_null FROM int_table;
 ----
+Source materialize.public.int_table (u1):
+| Project (#1)
+
+Query:
 %0 =
 | Get materialize.public.int_table (u1)
 | | types = (integer?, integer)
@@ -332,6 +388,10 @@ EOF
 query T multiline
 EXPLAIN TYPED PLAN FOR SELECT MIN(col_not_null), MAX(col_not_null), AVG(col_not_null), STDDEV(col_not_null), LIST_AGG(col_not_null) FROM int_table;
 ----
+Source materialize.public.int_table (u1):
+| Project (#1)
+
+Query:
 %0 = Let l0 =
 | Get materialize.public.int_table (u1)
 | | types = (integer?, integer)
@@ -395,6 +455,10 @@ EOF
 query T multiline
 EXPLAIN TYPED PLAN FOR SELECT COUNT(col_not_null), COUNT(DISTINCT col_not_null) FROM int_table;
 ----
+Source materialize.public.int_table (u1):
+| Project (#1)
+
+Query:
 %0 = Let l0 =
 | Get materialize.public.int_table (u1)
 | | types = (integer?, integer)
@@ -446,8 +510,12 @@ EOF
 query T multiline
 EXPLAIN TYPED PLAN FOR SELECT col_not_null LIKE col_not_null, col_null LIKE col_not_null, col_not_null LIKE col_null FROM str_table;
 ----
+Source materialize.public.str_table (u3):
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.str_table (u5)
+| Get materialize.public.str_table (u3)
 | | types = (text?, text)
 | | keys = ()
 | Map (#1 like #1), (#0 like #1), (#1 like #0)
@@ -466,8 +534,12 @@ EOF
 query T multiline
 EXPLAIN TYPED PLAN FOR SELECT REGEXP_MATCH(col_not_null, 'aaa'), REGEXP_MATCH('aaa', col_not_null) FROM str_table;
 ----
+Source materialize.public.str_table (u3):
+| Project (#1)
+
+Query:
 %0 =
-| Get materialize.public.str_table (u5)
+| Get materialize.public.str_table (u3)
 | | types = (text?, text)
 | | keys = ()
 | Map regexp_match[aaa](#1), regexp_match("aaa", #1)
@@ -486,8 +558,12 @@ EOF
 query T multiline
 EXPLAIN TYPED PLAN FOR SELECT SPLIT_PART(col_not_null, 'a', 100), SPLIT_PART('a', col_not_null, 100), SPLIT_PART('a', 'a', col_not_null::int) FROM str_table;
 ----
+Source materialize.public.str_table (u3):
+| Project (#1)
+
+Query:
 %0 =
-| Get materialize.public.str_table (u5)
+| Get materialize.public.str_table (u3)
 | | types = (text?, text)
 | | keys = ()
 | Map split_string(#1, "a", 100), split_string("a", #1, 100), split_string("a", "a", i32toi64(strtoi32(#1)))
@@ -506,6 +582,10 @@ EOF
 query T multiline
 EXPLAIN TYPED PLAN FOR SELECT col_not_null IN (1), 1 IN (col_not_null), 1 IN (1, col_null) , 1 IN (NULL), NULL IN (1), NULL IN (col_not_null) FROM int_table;
 ----
+Source materialize.public.int_table (u1):
+| Project (#1)
+
+Query:
 %0 =
 | Get materialize.public.int_table (u1)
 | | types = (integer?, integer)
@@ -522,6 +602,10 @@ EOF
 query T multiline
 EXPLAIN TYPED PLAN FOR SELECT col_not_null NOT IN (1), 1 not IN (col_not_null), 1 NOT IN (1, col_null) , 1 NOT IN (NULL), NULL NOT IN (1), NULL NOT IN (col_not_null) FROM int_table;
 ----
+Source materialize.public.int_table (u1):
+| Project (#1)
+
+Query:
 %0 =
 | Get materialize.public.int_table (u1)
 | | types = (integer?, integer)
@@ -542,6 +626,10 @@ EOF
 query T multiline
 EXPLAIN TYPED PLAN FOR SELECT 1 = SOME (VALUES(col_null)), 1 = SOME (VALUES(col_not_null)), col_null = SOME (VALUES(NULL::int)), col_not_null = SOME (VALUES(NULL::int)) , col_null = SOME (VALUES(col_not_null)) , col_not_null = SOME (VALUES(col_null)) FROM int_table;
 ----
+Source materialize.public.int_table (u1):
+| Project (#0, #1)
+
+Query:
 %0 = Let l0 =
 | Get materialize.public.int_table (u1)
 | | types = (integer?, integer)
@@ -958,6 +1046,10 @@ EOF
 query T multiline
 EXPLAIN TYPED PLAN FOR SELECT 1 > ANY (VALUES(col_null)), 1 > ANY (VALUES(col_not_null)), col_null > ANY (VALUES(NULL::int)), col_not_null > ANY (VALUES(NULL::int)) , col_null > ANY (VALUES(col_not_null)) , col_not_null > ANY (VALUES(col_null)) FROM int_table;
 ----
+Source materialize.public.int_table (u1):
+| Project (#0, #1)
+
+Query:
 %0 = Let l0 =
 | Get materialize.public.int_table (u1)
 | | types = (integer?, integer)
@@ -1373,6 +1465,10 @@ EOF
 query T multiline
 EXPLAIN TYPED PLAN FOR SELECT 1 < ALL (VALUES(col_null)), 1 < ALL (VALUES(col_not_null)), col_null < ALL (VALUES(NULL::int)), col_not_null < ALL (VALUES(NULL::int)) , col_null < ALL (VALUES(col_not_null)) , col_not_null < ALL (VALUES(col_null)) FROM int_table;
 ----
+Source materialize.public.int_table (u1):
+| Project (#0, #1)
+
+Query:
 %0 = Let l0 =
 | Get materialize.public.int_table (u1)
 | | types = (integer?, integer)
@@ -1811,6 +1907,10 @@ EOF
 query T multiline
 EXPLAIN TYPED PLAN FOR SELECT 1 = SOME(VALUES(col_not_null), (NULL::int)), 1 = ALL (VALUES(col_not_null), (NULL::int)) , 1 = ANY (VALUES(col_not_null), (NULL::int)) FROM int_table;
 ----
+Source materialize.public.int_table (u1):
+| Project (#1)
+
+Query:
 %0 = Let l0 =
 | Get materialize.public.int_table (u1)
 | | types = (integer?, integer)
@@ -1978,6 +2078,10 @@ EOF
 query T multiline
 EXPLAIN TYPED PLAN FOR SELECT (SELECT col_not_null FROM int_table) FROM int_table;
 ----
+Source materialize.public.int_table (u1):
+| Project (#1)
+
+Query:
 %0 = Let l0 =
 | Get materialize.public.int_table (u1)
 | | types = (integer?, integer)
@@ -2072,6 +2176,10 @@ EOF
 query T multiline
 EXPLAIN TYPED PLAN FOR SELECT 1 IN (SELECT col_not_null FROM int_table), 1 NOT IN (SELECT col_not_null FROM int_table) FROM int_table;
 ----
+Source materialize.public.int_table (u1):
+| Project (#1)
+
+Query:
 %0 = Let l0 =
 | Get materialize.public.int_table (u1)
 | | types = (integer?, integer)
@@ -2145,6 +2253,10 @@ EOF
 query T multiline
 EXPLAIN TYPED PLAN FOR SELECT EXISTS (SELECT col_not_null FROM int_table), NOT EXISTS (SELECT col_not_null FROM int_table) FROM int_table;
 ----
+Source materialize.public.int_table (u1):
+| Project ()
+
+Query:
 %0 = Let l0 =
 | Get materialize.public.int_table (u1)
 | | types = (integer?, integer)
@@ -2217,6 +2329,10 @@ EOF
 query T multiline
 EXPLAIN TYPED PLAN FOR SELECT 1 = SOME (SELECT col_not_null FROM int_table), col_not_null = SOME (SELECT 1), col_null = SOME ( SELECT col_not_null FROM int_table ) FROM int_table;
 ----
+Source materialize.public.int_table (u1):
+| Project (#0, #1)
+
+Query:
 %0 = Let l0 =
 | Get materialize.public.int_table (u1)
 | | types = (integer?, integer)
@@ -2435,8 +2551,12 @@ EOF
 query T multiline
 EXPLAIN TYPED PLAN FOR SELECT col_null - INTERVAL '1 second' , col_not_null - INTERVAL '1 second' FROM ts_table;
 ----
+Source materialize.public.ts_table (u4):
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.ts_table (u7)
+| Get materialize.public.ts_table (u4)
 | | types = (timestamp?, timestamp)
 | | keys = ()
 | Map (#0 - 00:00:01), (#1 - 00:00:01)
@@ -2451,8 +2571,12 @@ EOF
 query T multiline
 EXPLAIN TYPED PLAN FOR SELECT col_null - col_not_null, col_not_null - col_null FROM ts_table;
 ----
+Source materialize.public.ts_table (u4):
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.ts_table (u7)
+| Get materialize.public.ts_table (u4)
 | | types = (timestamp?, timestamp)
 | | keys = ()
 | Map (#0 - #1), (#1 - #0)
@@ -2472,6 +2596,10 @@ EOF
 query T multiline
 EXPLAIN TYPED PLAN FOR SELECT a1.col_not_null, a2.col_not_null FROM int_table AS a1 INNER JOIN int_table AS a2 ON TRUE;
 ----
+Source materialize.public.int_table (u1):
+| Project (#1)
+
+Query:
 %0 = Let l0 =
 | Get materialize.public.int_table (u1)
 | | types = (integer?, integer)
@@ -2503,6 +2631,10 @@ EOF
 query T multiline
 EXPLAIN TYPED PLAN FOR SELECT a1.col_not_null, a2.col_not_null FROM int_table AS a1 LEFT JOIN int_table AS a2 ON TRUE;
 ----
+Source materialize.public.int_table (u1):
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.int_table (u1)
 | | types = (integer?, integer)
@@ -2559,18 +2691,18 @@ EXPLAIN TYPED PLAN FOR SELECT a1.col_not_null, a2.col_not_null FROM int_table AS
 | Union %4 %5
 | | types = (integer?, integer)
 | | keys = ()
+| ArrangeBy (#0, #1)
+| | types = (integer?, integer)
+| | keys = ()
 
 %7 =
 | Get materialize.public.int_table (u1)
 | | types = (integer?, integer)
 | | keys = ()
-| ArrangeBy (#0, #1)
-| | types = (integer?, integer)
-| | keys = ()
 
 %8 =
 | Join %6 %7 (= #0 #2) (= #1 #3)
-| | implementation = Differential %6 %7.(#0, #1)
+| | implementation = Differential %7 %6.(#0, #1)
 | | types = (integer?, integer, integer?, integer)
 | | keys = ()
 | Map null
@@ -2590,6 +2722,10 @@ EOF
 query T multiline
 EXPLAIN TYPED PLAN FOR SELECT a1.col_not_null, a2.col_not_null FROM int_table AS a1 FULL OUTER JOIN int_table AS a2 ON TRUE;
 ----
+Source materialize.public.int_table (u1):
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.int_table (u1)
 | | types = (integer?, integer)
@@ -2617,15 +2753,7 @@ EXPLAIN TYPED PLAN FOR SELECT a1.col_not_null, a2.col_not_null FROM int_table AS
 | | types = (integer?, integer)
 | | keys = ((#0, #1))
 
-%4 = Let l2 =
-| Get materialize.public.int_table (u1)
-| | types = (integer?, integer)
-| | keys = ()
-| ArrangeBy (#0, #1)
-| | types = (integer?, integer)
-| | keys = ()
-
-%5 =
+%4 =
 | Get %2 (l0)
 | | types = (integer?, integer, integer?, integer)
 | | keys = ()
@@ -2633,7 +2761,7 @@ EXPLAIN TYPED PLAN FOR SELECT a1.col_not_null, a2.col_not_null FROM int_table AS
 | | types = (integer, integer)
 | | keys = ()
 
-%6 =
+%5 =
 | Get %2 (l0)
 | | types = (integer?, integer, integer?, integer)
 | | keys = ()
@@ -2647,14 +2775,22 @@ EXPLAIN TYPED PLAN FOR SELECT a1.col_not_null, a2.col_not_null FROM int_table AS
 | | types = (integer?, integer)
 | | keys = ()
 
+%6 =
+| Union %5 %3
+| | types = (integer?, integer)
+| | keys = ()
+| ArrangeBy (#0, #1)
+| | types = (integer?, integer)
+| | keys = ()
+
 %7 =
-| Union %6 %3
+| Get materialize.public.int_table (u1)
 | | types = (integer?, integer)
 | | keys = ()
 
 %8 =
-| Join %7 %4 (= #0 #2) (= #1 #3)
-| | implementation = Differential %7 %4.(#0, #1)
+| Join %6 %7 (= #0 #2) (= #1 #3)
+| | implementation = Differential %7 %6.(#0, #1)
 | | types = (integer?, integer, integer?, integer)
 | | keys = ()
 | Map null
@@ -2682,10 +2818,18 @@ EXPLAIN TYPED PLAN FOR SELECT a1.col_not_null, a2.col_not_null FROM int_table AS
 | Union %9 %3
 | | types = (integer?, integer)
 | | keys = ()
+| ArrangeBy (#0, #1)
+| | types = (integer?, integer)
+| | keys = ()
 
 %11 =
-| Join %10 %4 (= #0 #2) (= #1 #3)
-| | implementation = Differential %10 %4.(#0, #1)
+| Get materialize.public.int_table (u1)
+| | types = (integer?, integer)
+| | keys = ()
+
+%12 =
+| Join %10 %11 (= #0 #2) (= #1 #3)
+| | implementation = Differential %11 %10.(#0, #1)
 | | types = (integer?, integer, integer?, integer)
 | | keys = ()
 | Map null
@@ -2695,8 +2839,8 @@ EXPLAIN TYPED PLAN FOR SELECT a1.col_not_null, a2.col_not_null FROM int_table AS
 | | types = (integer?, integer)
 | | keys = ()
 
-%12 =
-| Union %5 %8 %11
+%13 =
+| Union %4 %8 %12
 | | types = (integer?, integer?)
 | | keys = ()
 
@@ -2710,6 +2854,10 @@ EOF
 query T multiline
 EXPLAIN TYPED PLAN FOR SELECT col_not_null FROM int_table UNION ALL SELECT col_not_null FROM int_table;
 ----
+Source materialize.public.int_table (u1):
+| Project (#1)
+
+Query:
 %0 = Let l0 =
 | Get materialize.public.int_table (u1)
 | | types = (integer?, integer)
@@ -2728,6 +2876,10 @@ EOF
 query T multiline
 EXPLAIN TYPED PLAN FOR SELECT col_not_null FROM int_table UNION ALL SELECT col_null FROM int_table;
 ----
+Source materialize.public.int_table (u1):
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.int_table (u1)
 | | types = (integer?, integer)
@@ -2758,6 +2910,10 @@ EOF
 query T multiline
 EXPLAIN TYPED PLAN FOR SELECT f1 + 1 FROM (SELECT col_not_null + 1 AS f1 FROM int_table);
 ----
+Source materialize.public.int_table (u1):
+| Project (#1)
+
+Query:
 %0 =
 | Get materialize.public.int_table (u1)
 | | types = (integer?, integer)

--- a/test/sqllogictest/record.slt
+++ b/test/sqllogictest/record.slt
@@ -16,6 +16,10 @@ INSERT INTO t1 values (1, 2)
 query T multiline
 EXPLAIN SELECT (record).f2 FROM (SELECT ROW(a, a) AS record FROM t1);
 ----
+Source materialize.public.t1 (u1):
+| Project (#0)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 | Map #0
@@ -26,6 +30,10 @@ EOF
 query T multiline
 EXPLAIN SELECT record, (record).f2 FROM (SELECT ROW(a, a) AS record FROM t1);
 ----
+Source materialize.public.t1 (u1):
+| Project (#0)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 | Map record_create(#0, #0), record_get[1](#2)
@@ -36,6 +44,10 @@ EOF
 query T multiline
 EXPLAIN SELECT (COALESCE(record, ROW(NULL, NULL))).f2 FROM (SELECT ROW(a, a) AS record FROM t1)
 ----
+Source materialize.public.t1 (u1):
+| Project (#0)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 | Map #0

--- a/test/sqllogictest/recursive_type_unioning.slt
+++ b/test/sqllogictest/recursive_type_unioning.slt
@@ -22,13 +22,20 @@ INSERT INTO t2 values (null, null)
 query T multiline
 EXPLAIN SELECT row(a,b) as record from t1 union select row(a,b) as record from t2
 ----
+Source materialize.public.t1 (u1):
+| Project (#0, #1)
+
+Source materialize.public.t2 (u2):
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 | Map record_create(#0, #1)
 | Project (#2)
 
 %1 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Map record_create(#0, #1)
 | Project (#2)
 

--- a/test/sqllogictest/regex.slt
+++ b/test/sqllogictest/regex.slt
@@ -54,6 +54,10 @@ mode standard
 query T multiline
 EXPLAIN PLAN FOR SELECT input ~ 'foo?' FROM data
 ----
+Source materialize.public.data (u1):
+| Project (#0)
+
+Query:
 %0 =
 | Get materialize.public.data (u1)
 | Map "foo?" ~(#0)
@@ -65,6 +69,10 @@ EOF
 query T multiline
 EXPLAIN PLAN FOR SELECT input ~ input FROM data
 ----
+Source materialize.public.data (u1):
+| Project (#0)
+
+Query:
 %0 =
 | Get materialize.public.data (u1)
 | Map (#0 ~ #0)

--- a/test/sqllogictest/relation-cse.slt
+++ b/test/sqllogictest/relation-cse.slt
@@ -686,14 +686,14 @@ SELECT * FROM t1 AS a1 LEFT JOIN t1 AS a2 USING (f1)
 
 %4 =
 | Union %2 %3
+| ArrangeBy (#0, #1)
 
 %5 =
 | Get materialize.public.t1 (u1)
-| ArrangeBy (#0, #1)
 
 %6 = Let l2 =
 | Join %4 %5 (= #0 #2) (= #1 #3)
-| | implementation = Differential %4 %5.(#0, #1)
+| | implementation = Differential %5 %4.(#0, #1)
 | Project (#0, #1)
 | Map null
 
@@ -1132,6 +1132,10 @@ EXPLAIN
 UNION ALL
 (SELECT * FROM t2 WHERE EXISTS (SELECT * FROM t1 WHERE f1 = 1))
 ----
+Source materialize.public.t2 (u3):
+| Project (#0, #1)
+
+Query:
 %0 = Let l0 =
 | Get materialize.public.t1 (u1)
 | Filter (#0 = 1)
@@ -1147,7 +1151,7 @@ UNION ALL
 | | implementation = Differential %1 %0.()
 
 %3 =
-| Get materialize.public.t2 (u4)
+| Get materialize.public.t2 (u3)
 
 %4 =
 | Join %3 %0
@@ -1163,13 +1167,17 @@ EXPLAIN SELECT * FROM
 (SELECT f1 FROM t2 UNION ALL SELECT f1 FROM t1 WHERE f1 = 1) ,
 (SELECT f2 FROM t2 UNION ALL SELECT f1 FROM t1 WHERE f1 = 1)
 ----
+Source materialize.public.t2 (u3):
+| Project (#0, #1)
+
+Query:
 %0 = Let l0 =
 | Get materialize.public.t1 (u1)
 | Filter (#0 = 1)
 | Project (#0)
 
 %1 =
-| Get materialize.public.t2 (u4)
+| Get materialize.public.t2 (u3)
 | Project (#0)
 
 %2 =
@@ -1177,7 +1185,7 @@ EXPLAIN SELECT * FROM
 | ArrangeBy ()
 
 %3 =
-| Get materialize.public.t2 (u4)
+| Get materialize.public.t2 (u3)
 | Project (#1)
 
 %4 =

--- a/test/sqllogictest/scalar_subqueries_select_list.slt
+++ b/test/sqllogictest/scalar_subqueries_select_list.slt
@@ -48,6 +48,13 @@ INSERT INTO t3 VALUES (1), (2), (3)
 query T multiline
 EXPLAIN SELECT (SELECT * FROM t1), (SELECT * FROM t1) FROM t2
 ----
+Source materialize.public.t1 (u1):
+| Project (#0)
+
+Source materialize.public.t2 (u2):
+| Project ()
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 
@@ -64,7 +71,7 @@ EXPLAIN SELECT (SELECT * FROM t1), (SELECT * FROM t1) FROM t2
 | Union %0 %1
 
 %3 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Project ()
 | ArrangeBy ()
 
@@ -98,8 +105,16 @@ EOF
 query T multiline
 EXPLAIN SELECT (SELECT * FROM t1 WHERE t1.f1 = t2.f1) , (SELECT * FROM t1 WHERE t1.f1 = t2.f1) FROM t2
 ----
+Source materialize.public.t1 (u1):
+| Filter !(isnull(#0))
+| Project (#0)
+
+Source materialize.public.t2 (u2):
+| Project (#0)
+
+Query:
 %0 = Let l0 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Distinct group=(#0)
 
 %1 =
@@ -108,14 +123,11 @@ EXPLAIN SELECT (SELECT * FROM t1 WHERE t1.f1 = t2.f1) , (SELECT * FROM t1 WHERE 
 
 %2 =
 | Get materialize.public.t1 (u1)
-| ArrangeBy (#0)
+| Filter !(isnull(#0))
 
 %3 = Let l1 =
 | Join %1 %2 (= #0 #1)
-| | implementation = DeltaQuery
-| |   delta %1 %2.(#0)
-| |   delta %2 %1.(#0)
-| Filter !(isnull(#0))
+| | implementation = Differential %2 %1.(#0)
 | Project (#0)
 
 %4 =
@@ -134,7 +146,7 @@ EXPLAIN SELECT (SELECT * FROM t1 WHERE t1.f1 = t2.f1) , (SELECT * FROM t1 WHERE 
 | Union %4 %5
 
 %7 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | ArrangeBy (#0)
 
 %8 =
@@ -172,8 +184,16 @@ SELECT COUNT(*) FROM (SELECT (SELECT * FROM t1 WHERE t1.f1 = t2.f1) , (SELECT * 
 query T multiline
 EXPLAIN SELECT (SELECT * FROM t1 WHERE t1.f1 = t2.f1 + 1 UNION ALL SELECT * FROM t1 WHERE t1.f1 = t2.f1 + 2) , (SELECT * FROM t1 WHERE t1.f1 = t2.f1 + 1 UNION ALL SELECT * FROM t1 WHERE t1.f1 = t2.f1 + 2) FROM t2
 ----
+Source materialize.public.t1 (u1):
+| Filter !(isnull(#0))
+| Project (#0)
+
+Source materialize.public.t2 (u2):
+| Project (#0)
+
+Query:
 %0 = Let l0 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Distinct group=(#0)
 
 %1 = Let l1 =
@@ -182,23 +202,29 @@ EXPLAIN SELECT (SELECT * FROM t1 WHERE t1.f1 = t2.f1 + 1 UNION ALL SELECT * FROM
 
 %2 = Let l2 =
 | Get materialize.public.t1 (u1)
-| ArrangeBy (#0)
+| Filter !(isnull(#0))
 
 %3 =
-| Join %1 %2 (= #1 (#0 + 1))
-| | implementation = Differential %1 %2.(#0)
-| Filter !(isnull(#1))
+| Get %1 (l1)
+| ArrangeBy ((#0 + 1))
 
 %4 =
-| Join %1 %2 (= #1 (#0 + 2))
-| | implementation = Differential %1 %2.(#0)
-| Filter !(isnull(#1))
+| Join %3 %2 (= #1 (#0 + 1))
+| | implementation = Differential %2 %3.((#0 + 1))
 
-%5 = Let l3 =
-| Union %3 %4
+%5 =
+| Get %1 (l1)
+| ArrangeBy ((#0 + 2))
 
 %6 =
-| Get %5 (l3)
+| Join %5 %2 (= #1 (#0 + 2))
+| | implementation = Differential %2 %5.((#0 + 2))
+
+%7 = Let l3 =
+| Union %4 %6
+
+%8 =
+| Get %7 (l3)
 | Project (#0)
 | Reduce group=(#0)
 | | agg count(true)
@@ -206,29 +232,29 @@ EXPLAIN SELECT (SELECT * FROM t1 WHERE t1.f1 = t2.f1 + 1 UNION ALL SELECT * FROM
 | Project (#0)
 | Map (err: more than one record produced in subquery)
 
-%7 = Let l4 =
-| Union %5 %6
+%9 = Let l4 =
+| Union %7 %8
 
-%8 =
-| Get materialize.public.t2 (u3)
+%10 =
+| Get materialize.public.t2 (u2)
 | ArrangeBy (#0)
 
-%9 =
-| Get %7 (l4)
+%11 =
+| Get %9 (l4)
 | Project (#0)
 | Distinct group=(#0)
 | Negate
 
-%10 =
-| Union %9 %0
+%12 =
+| Union %11 %0
 | Map null
 
-%11 =
-| Union %7 %10
+%13 =
+| Union %9 %12
 
-%12 =
-| Join %8 %11 (= #0 #1)
-| | implementation = Differential %11 %8.(#0)
+%14 =
+| Join %10 %13 (= #0 #1)
+| | implementation = Differential %13 %10.(#0)
 | Project (#2, #2)
 
 EOF
@@ -240,8 +266,16 @@ EOF
 query T multiline
 EXPLAIN SELECT (SELECT * FROM t1 WHERE t1.f1 = t2.f1 + 1) , (SELECT * FROM t1 WHERE t1.f1 = t2.f1 + 2) FROM t2
 ----
+Source materialize.public.t1 (u1):
+| Filter !(isnull(#0))
+| Project (#0)
+
+Source materialize.public.t2 (u2):
+| Project (#0)
+
+Query:
 %0 = Let l0 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Distinct group=(#0)
 
 %1 = Let l1 =
@@ -250,15 +284,18 @@ EXPLAIN SELECT (SELECT * FROM t1 WHERE t1.f1 = t2.f1 + 1) , (SELECT * FROM t1 WH
 
 %2 = Let l2 =
 | Get materialize.public.t1 (u1)
-| ArrangeBy (#0)
+| Filter !(isnull(#0))
 
-%3 = Let l3 =
-| Join %1 %2 (= #1 (#0 + 1))
-| | implementation = Differential %1 %2.(#0)
-| Filter !(isnull(#1))
+%3 =
+| Get %1 (l1)
+| ArrangeBy ((#0 + 1))
 
-%4 =
-| Get %3 (l3)
+%4 = Let l3 =
+| Join %3 %2 (= #1 (#0 + 1))
+| | implementation = Differential %2 %3.((#0 + 1))
+
+%5 =
+| Get %4 (l3)
 | Project (#0)
 | Reduce group=(#0)
 | | agg count(true)
@@ -266,16 +303,19 @@ EXPLAIN SELECT (SELECT * FROM t1 WHERE t1.f1 = t2.f1 + 1) , (SELECT * FROM t1 WH
 | Project (#0)
 | Map (err: more than one record produced in subquery)
 
-%5 = Let l4 =
-| Union %3 %4
-
-%6 = Let l5 =
-| Join %1 %2 (= #1 (#0 + 2))
-| | implementation = Differential %1 %2.(#0)
-| Filter !(isnull(#1))
+%6 = Let l4 =
+| Union %4 %5
 
 %7 =
-| Get %6 (l5)
+| Get %1 (l1)
+| ArrangeBy ((#0 + 2))
+
+%8 = Let l5 =
+| Join %7 %2 (= #1 (#0 + 2))
+| | implementation = Differential %2 %7.((#0 + 2))
+
+%9 =
+| Get %8 (l5)
 | Project (#0)
 | Reduce group=(#0)
 | | agg count(true)
@@ -283,43 +323,43 @@ EXPLAIN SELECT (SELECT * FROM t1 WHERE t1.f1 = t2.f1 + 1) , (SELECT * FROM t1 WH
 | Project (#0)
 | Map (err: more than one record produced in subquery)
 
-%8 = Let l6 =
-| Union %6 %7
-
-%9 =
-| Get materialize.public.t2 (u3)
-| ArrangeBy (#0)
-
-%10 =
-| Get %5 (l4)
-| Project (#0)
-| Distinct group=(#0)
-| Negate
+%10 = Let l6 =
+| Union %8 %9
 
 %11 =
-| Union %10 %0
-| Map null
-
-%12 =
-| Union %5 %11
+| Get materialize.public.t2 (u2)
 | ArrangeBy (#0)
 
-%13 =
-| Get %8 (l6)
+%12 =
+| Get %6 (l4)
 | Project (#0)
 | Distinct group=(#0)
 | Negate
 
-%14 =
-| Union %13 %0
+%13 =
+| Union %12 %0
 | Map null
 
+%14 =
+| Union %6 %13
+| ArrangeBy (#0)
+
 %15 =
-| Union %8 %14
+| Get %10 (l6)
+| Project (#0)
+| Distinct group=(#0)
+| Negate
 
 %16 =
-| Join %9 %12 %15 (= #0 #1 #3)
-| | implementation = Differential %15 %9.(#0) %12.(#0)
+| Union %15 %0
+| Map null
+
+%17 =
+| Union %10 %16
+
+%18 =
+| Join %11 %14 %17 (= #0 #1 #3)
+| | implementation = Differential %17 %11.(#0) %14.(#0)
 | Project (#2, #4)
 
 EOF
@@ -338,8 +378,16 @@ NULL NULL
 query T multiline
 EXPLAIN SELECT (SELECT f1 + 1 FROM t1 WHERE t1.f1 = t2.f1) , (SELECT f1 + 2 FROM t1 WHERE t1.f1 = t2.f1) FROM t2
 ----
+Source materialize.public.t1 (u1):
+| Filter !(isnull(#0))
+| Project (#0)
+
+Source materialize.public.t2 (u2):
+| Project (#0)
+
+Query:
 %0 = Let l0 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Distinct group=(#0)
 
 %1 =
@@ -348,14 +396,11 @@ EXPLAIN SELECT (SELECT f1 + 1 FROM t1 WHERE t1.f1 = t2.f1) , (SELECT f1 + 2 FROM
 
 %2 =
 | Get materialize.public.t1 (u1)
-| ArrangeBy (#0)
+| Filter !(isnull(#0))
 
 %3 = Let l1 =
 | Join %1 %2 (= #0 #1)
-| | implementation = DeltaQuery
-| |   delta %1 %2.(#0)
-| |   delta %2 %1.(#0)
-| Filter !(isnull(#0))
+| | implementation = Differential %2 %1.(#0)
 | Project (#0)
 
 %4 = Let l2 =
@@ -381,7 +426,7 @@ EXPLAIN SELECT (SELECT f1 + 1 FROM t1 WHERE t1.f1 = t2.f1) , (SELECT f1 + 2 FROM
 | Union %7 %4
 
 %9 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | ArrangeBy (#0)
 
 %10 =
@@ -428,8 +473,16 @@ SELECT (SELECT f1 + 1 FROM t1 WHERE t1.f1 = t2.f1) , (SELECT f1 + 2 FROM t1 WHER
 query T multiline
 EXPLAIN SELECT (SELECT MIN(f1) FROM t1 WHERE t1.f1 = t2.f1) , (SELECT MAX(f1) FROM t1 WHERE t1.f1 = t2.f1) FROM t2
 ----
+Source materialize.public.t1 (u1):
+| Filter !(isnull(#0))
+| Project (#0)
+
+Source materialize.public.t2 (u2):
+| Project (#0)
+
+Query:
 %0 = Let l0 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Distinct group=(#0)
 
 %1 =
@@ -438,14 +491,11 @@ EXPLAIN SELECT (SELECT MIN(f1) FROM t1 WHERE t1.f1 = t2.f1) , (SELECT MAX(f1) FR
 
 %2 =
 | Get materialize.public.t1 (u1)
-| ArrangeBy (#0)
+| Filter !(isnull(#0))
 
 %3 = Let l1 =
 | Join %1 %2 (= #0 #1)
-| | implementation = DeltaQuery
-| |   delta %1 %2.(#0)
-| |   delta %2 %1.(#0)
-| Filter !(isnull(#0))
+| | implementation = Differential %2 %1.(#0)
 | Project (#0)
 
 %4 = Let l2 =
@@ -483,7 +533,7 @@ EXPLAIN SELECT (SELECT MIN(f1) FROM t1 WHERE t1.f1 = t2.f1) , (SELECT MAX(f1) FR
 | Union %8 %10
 
 %12 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | ArrangeBy (#0)
 
 %13 =
@@ -532,8 +582,20 @@ SELECT (SELECT MIN(f1) FROM t1 WHERE t1.f1 = t2.f1) , (SELECT MAX(f1) FROM t1 WH
 query T multiline
 EXPLAIN SELECT (SELECT (SELECT * FROM t1 WHERE t1.f1 = t2.f1) FROM t2 WHERE t2.f1 = t3.f1) FROM t3
 ----
+Source materialize.public.t1 (u1):
+| Filter !(isnull(#0))
+| Project (#0)
+
+Source materialize.public.t2 (u2):
+| Filter !(isnull(#0))
+| Project (#0)
+
+Source materialize.public.t3 (u3):
+| Project (#0)
+
+Query:
 %0 = Let l0 =
-| Get materialize.public.t3 (u5)
+| Get materialize.public.t3 (u3)
 | Distinct group=(#0)
 
 %1 =
@@ -541,15 +603,12 @@ EXPLAIN SELECT (SELECT (SELECT * FROM t1 WHERE t1.f1 = t2.f1) FROM t2 WHERE t2.f
 | ArrangeBy (#0)
 
 %2 =
-| Get materialize.public.t2 (u3)
-| ArrangeBy (#0)
+| Get materialize.public.t2 (u2)
+| Filter !(isnull(#0))
 
 %3 = Let l1 =
 | Join %1 %2 (= #0 #1)
-| | implementation = DeltaQuery
-| |   delta %1 %2.(#0)
-| |   delta %2 %1.(#0)
-| Filter !(isnull(#0))
+| | implementation = Differential %2 %1.(#0)
 | Project (#0)
 
 %4 = Let l2 =
@@ -562,13 +621,11 @@ EXPLAIN SELECT (SELECT (SELECT * FROM t1 WHERE t1.f1 = t2.f1) FROM t2 WHERE t2.f
 
 %6 =
 | Get materialize.public.t1 (u1)
-| ArrangeBy (#0)
+| Filter !(isnull(#0))
 
 %7 = Let l3 =
 | Join %5 %6 (= #0 #1)
-| | implementation = DeltaQuery
-| |   delta %5 %6.(#0)
-| |   delta %6 %5.(#0)
+| | implementation = Differential %6 %5.(#0)
 | Project (#0)
 
 %8 =
@@ -621,7 +678,7 @@ EXPLAIN SELECT (SELECT (SELECT * FROM t1 WHERE t1.f1 = t2.f1) FROM t2 WHERE t2.f
 | Union %15 %16
 
 %18 =
-| Get materialize.public.t3 (u5)
+| Get materialize.public.t3 (u3)
 | ArrangeBy (#0)
 
 %19 =
@@ -658,13 +715,21 @@ SELECT (SELECT (SELECT * FROM t1 WHERE t1.f1 = t2.f1) FROM t2 WHERE t2.f1 = t3.f
 query T multiline
 EXPLAIN SELECT MIN((SELECT f1 FROM t1 WHERE t1.f1 = t2.f1)), MAX((SELECT f1 FROM t1 WHERE t1.f1 = t2.f1)) FROM t2;
 ----
+Source materialize.public.t1 (u1):
+| Filter !(isnull(#0))
+| Project (#0)
+
+Source materialize.public.t2 (u2):
+| Project (#0)
+
+Query:
 %0 = Let l0 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Distinct group=(#0)
 
 %1 = Let l1 =
 | Get materialize.public.t1 (u1)
-| ArrangeBy (#0)
+| Filter !(isnull(#0))
 
 %2 =
 | Get %0 (l0)
@@ -672,10 +737,7 @@ EXPLAIN SELECT MIN((SELECT f1 FROM t1 WHERE t1.f1 = t2.f1)), MAX((SELECT f1 FROM
 
 %3 = Let l2 =
 | Join %2 %1 (= #0 #1)
-| | implementation = DeltaQuery
-| |   delta %2 %1.(#0)
-| |   delta %1 %2.(#0)
-| Filter !(isnull(#0))
+| | implementation = Differential %1 %2.(#0)
 | Project (#0)
 
 %4 =
@@ -694,7 +756,7 @@ EXPLAIN SELECT MIN((SELECT f1 FROM t1 WHERE t1.f1 = t2.f1)), MAX((SELECT f1 FROM
 | Union %4 %5
 
 %7 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | ArrangeBy (#0)
 
 %8 =
@@ -726,10 +788,7 @@ EXPLAIN SELECT MIN((SELECT f1 FROM t1 WHERE t1.f1 = t2.f1)), MAX((SELECT f1 FROM
 
 %14 = Let l6 =
 | Join %13 %1 (= #0 #1)
-| | implementation = DeltaQuery
-| |   delta %13 %1.(#0)
-| |   delta %1 %13.(#0)
-| Filter !(isnull(#0))
+| | implementation = Differential %1 %13.(#0)
 | Project (#0)
 
 %15 =
@@ -805,8 +864,20 @@ EXPLAIN SELECT
 	(SELECT t1.f1 FROM t1, t2 WHERE t1.f1 = t3.f1 AND t2.f1 = t3.f1)
 FROM t3
 ----
+Source materialize.public.t1 (u1):
+| Filter !(isnull(#0))
+| Project (#0)
+
+Source materialize.public.t2 (u2):
+| Filter !(isnull(#0))
+| Project (#0)
+
+Source materialize.public.t3 (u3):
+| Project (#0)
+
+Query:
 %0 = Let l0 =
-| Get materialize.public.t3 (u5)
+| Get materialize.public.t3 (u3)
 | Distinct group=(#0)
 
 %1 =
@@ -815,19 +886,16 @@ FROM t3
 
 %2 =
 | Get materialize.public.t1 (u1)
+| Filter !(isnull(#0))
 | ArrangeBy (#0)
 
 %3 =
-| Get materialize.public.t2 (u3)
-| ArrangeBy (#0)
+| Get materialize.public.t2 (u2)
+| Filter !(isnull(#0))
 
 %4 = Let l1 =
 | Join %1 %2 %3 (= #0 #1 #2)
-| | implementation = DeltaQuery
-| |   delta %1 %2.(#0) %3.(#0)
-| |   delta %2 %1.(#0) %3.(#0)
-| |   delta %3 %1.(#0) %2.(#0)
-| Filter !(isnull(#0))
+| | implementation = Differential %3 %1.(#0) %2.(#0)
 | Project (#0)
 
 %5 =
@@ -846,7 +914,7 @@ FROM t3
 | Union %5 %6
 
 %8 =
-| Get materialize.public.t3 (u5)
+| Get materialize.public.t3 (u3)
 | ArrangeBy (#0)
 
 %9 =
@@ -890,12 +958,23 @@ EXPLAIN SELECT
 	(SELECT * FROM t1 WHERE t1.f1 = t2.f1 AND t1.f1 = t3.f1)
 FROM t2, t3
 ----
+Source materialize.public.t1 (u1):
+| Filter !(isnull(#0))
+| Project (#0)
+
+Source materialize.public.t2 (u2):
+| Project (#0)
+
+Source materialize.public.t3 (u3):
+| Project (#0)
+
+Query:
 %0 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | ArrangeBy ()
 
 %1 =
-| Get materialize.public.t3 (u5)
+| Get materialize.public.t3 (u3)
 
 %2 = Let l0 =
 | Join %0 %1
@@ -912,14 +991,11 @@ FROM t2, t3
 
 %5 =
 | Get materialize.public.t1 (u1)
-| ArrangeBy (#0)
+| Filter !(isnull(#0))
 
 %6 = Let l2 =
 | Join %4 %5 (= #0 #2)
-| | implementation = DeltaQuery
-| |   delta %4 %5.(#0)
-| |   delta %5 %4.(#0)
-| Filter !(isnull(#0))
+| | implementation = Differential %5 %4.(#0)
 | Project (#0, #1)
 
 %7 =

--- a/test/sqllogictest/subquery.slt
+++ b/test/sqllogictest/subquery.slt
@@ -246,11 +246,18 @@ mode standard
 query T multiline
 EXPLAIN PLAN FOR SELECT * FROM t1 WHERE EXISTS (SELECT * FROM t2)
 ----
+Source materialize.public.t1 (u9):
+| Project (#0)
+
+Source materialize.public.t2 (u10):
+| Project ()
+
+Query:
 %0 =
-| Get materialize.public.t1 (u17)
+| Get materialize.public.t1 (u9)
 
 %1 =
-| Get materialize.public.t2 (u19)
+| Get materialize.public.t2 (u10)
 | Project ()
 | Distinct group=()
 | ArrangeBy ()
@@ -264,15 +271,25 @@ EOF
 query T multiline
 EXPLAIN PLAN FOR SELECT *  FROM t1, t3 WHERE t1.a = t3.a AND EXISTS (SELECT * FROM t2)
 ----
+Source materialize.public.t1 (u9):
+| Project (#0)
+
+Source materialize.public.t2 (u10):
+| Project ()
+
+Source materialize.public.t3 (u11):
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.t1 (u17)
+| Get materialize.public.t1 (u9)
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.t3 (u21)
+| Get materialize.public.t3 (u11)
 
 %2 =
-| Get materialize.public.t2 (u19)
+| Get materialize.public.t2 (u10)
 | Project ()
 | Distinct group=()
 | ArrangeBy ()
@@ -287,15 +304,25 @@ EOF
 query T multiline
 EXPLAIN PLAN FOR SELECT *  FROM t1, t3 WHERE t1.a = t3.a AND EXISTS (SELECT * FROM t2 WHERE t3.b = t2.b)
 ----
+Source materialize.public.t1 (u9):
+| Project (#0)
+
+Source materialize.public.t2 (u10):
+| Project (#0)
+
+Source materialize.public.t3 (u11):
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.t1 (u17)
+| Get materialize.public.t1 (u9)
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.t3 (u21)
+| Get materialize.public.t3 (u11)
 
 %2 =
-| Get materialize.public.t2 (u19)
+| Get materialize.public.t2 (u10)
 | Distinct group=(#0)
 | ArrangeBy (#0)
 
@@ -322,13 +349,22 @@ SELECT age, ascii_num * 2 as result FROM (
   )
 )
 ----
+Source materialize.public.likes (u3):
+| Filter !(isnull(#0))
+| Project (#0, #1)
+
+Source materialize.public.age (u5):
+| Filter !(isnull(#0))
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.likes (u5)
+| Get materialize.public.likes (u3)
 | Filter !(isnull(#0))
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.age (u9)
+| Get materialize.public.age (u5)
 | Filter !(isnull(#0))
 
 %2 =
@@ -442,8 +478,15 @@ true
 query T multiline
 EXPLAIN PLAN FOR SELECT b IN (SELECT a FROM x) FROM y
 ----
+Source materialize.public.x (u13):
+| Project (#0)
+
+Source materialize.public.y (u14):
+| Project (#0)
+
+Query:
 %0 = Let l0 =
-| Get materialize.public.y (u27)
+| Get materialize.public.y (u14)
 | Distinct group=(#0)
 
 %1 =
@@ -451,7 +494,7 @@ EXPLAIN PLAN FOR SELECT b IN (SELECT a FROM x) FROM y
 | ArrangeBy (#0)
 
 %2 =
-| Get materialize.public.x (u25)
+| Get materialize.public.x (u13)
 | Distinct group=(#0)
 | ArrangeBy (#0)
 
@@ -463,7 +506,7 @@ EXPLAIN PLAN FOR SELECT b IN (SELECT a FROM x) FROM y
 | Project (#0)
 
 %4 =
-| Get materialize.public.y (u27)
+| Get materialize.public.y (u14)
 | ArrangeBy (#0)
 
 %5 =
@@ -491,8 +534,15 @@ EOF
 query T multiline
 EXPLAIN PLAN FOR SELECT b != ALL(SELECT a FROM x) FROM y
 ----
+Source materialize.public.x (u13):
+| Project (#0)
+
+Source materialize.public.y (u14):
+| Project (#0)
+
+Query:
 %0 = Let l0 =
-| Get materialize.public.y (u27)
+| Get materialize.public.y (u14)
 | Distinct group=(#0)
 
 %1 =
@@ -500,7 +550,7 @@ EXPLAIN PLAN FOR SELECT b != ALL(SELECT a FROM x) FROM y
 | ArrangeBy (#0)
 
 %2 =
-| Get materialize.public.x (u25)
+| Get materialize.public.x (u13)
 | Distinct group=(#0)
 | ArrangeBy (#0)
 
@@ -512,7 +562,7 @@ EXPLAIN PLAN FOR SELECT b != ALL(SELECT a FROM x) FROM y
 | Project (#0)
 
 %4 =
-| Get materialize.public.y (u27)
+| Get materialize.public.y (u14)
 | ArrangeBy (#0)
 
 %5 =
@@ -542,8 +592,15 @@ EOF
 query T multiline
 EXPLAIN PLAN FOR SELECT b > ALL(SELECT a FROM x) FROM y
 ----
+Source materialize.public.x (u13):
+| Project (#0)
+
+Source materialize.public.y (u14):
+| Project (#0)
+
+Query:
 %0 = Let l0 =
-| Get materialize.public.y (u27)
+| Get materialize.public.y (u14)
 | Distinct group=(#0)
 
 %1 =
@@ -551,7 +608,7 @@ EXPLAIN PLAN FOR SELECT b > ALL(SELECT a FROM x) FROM y
 | ArrangeBy ()
 
 %2 =
-| Get materialize.public.x (u25)
+| Get materialize.public.x (u13)
 
 %3 = Let l1 =
 | Join %1 %2
@@ -561,7 +618,7 @@ EXPLAIN PLAN FOR SELECT b > ALL(SELECT a FROM x) FROM y
 | Distinct group=(#0)
 
 %4 =
-| Get materialize.public.y (u27)
+| Get materialize.public.y (u14)
 | ArrangeBy (#0)
 
 %5 =
@@ -683,8 +740,15 @@ WHERE a IN (9, 0)
   )
   GROUP BY TRUE;
 ----
+Source materialize.public.x (u13):
+| Project ()
+
+Source materialize.public.y (u14):
+| Project ()
+
+Query:
 %0 =
-| Get materialize.public.y (u27)
+| Get materialize.public.y (u14)
 | Project ()
 | Distinct group=()
 | Map 1

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -182,7 +182,7 @@ query T multiline
 EXPLAIN RAW PLAN FOR SELECT * FROM x, generate_series(1, a)
 ----
 %0 =
-| Get materialize.public.x (u3)
+| Get materialize.public.x (u2)
 
 %1 =
 | CallTable generate_series(1, #^0, 1)
@@ -196,7 +196,7 @@ query T multiline
 EXPLAIN RAW PLAN FOR SELECT * FROM x, generate_series(100::bigint, a)
 ----
 %0 =
-| Get materialize.public.x (u3)
+| Get materialize.public.x (u2)
 
 %1 =
 | CallTable generate_series(i32toi64(100), i32toi64(#^0), 1)
@@ -209,8 +209,12 @@ EOF
 query T multiline
 EXPLAIN PLAN FOR SELECT * FROM x, generate_series(1, 10)
 ----
+Source materialize.public.x (u2):
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.x (u3)
+| Get materialize.public.x (u2)
 | ArrangeBy ()
 
 %1 =
@@ -225,8 +229,12 @@ EOF
 query T multiline
 EXPLAIN PLAN FOR SELECT * FROM x, generate_series(1, a)
 ----
+Source materialize.public.x (u2):
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.x (u3)
+| Get materialize.public.x (u2)
 | FlatMap generate_series(1, #0, 1)
 
 EOF
@@ -234,8 +242,13 @@ EOF
 query T multiline
 EXPLAIN PLAN FOR SELECT * FROM x x1, x x2, generate_series(x1.a, x2.a) WHERE x1.b = x2.b
 ----
+Source materialize.public.x (u2):
+| Filter !(isnull(#1))
+| Project (#0, #1)
+
+Query:
 %0 = Let l0 =
-| Get materialize.public.x (u3)
+| Get materialize.public.x (u2)
 | Filter !(isnull(#1))
 
 %1 =
@@ -254,8 +267,13 @@ EOF
 query T multiline
 EXPLAIN PLAN FOR SELECT * FROM x x1, x x2, generate_series(x1.a, x2.a) WHERE x1.b = x2.b
 ----
+Source materialize.public.x (u2):
+| Filter !(isnull(#1))
+| Project (#0, #1)
+
+Query:
 %0 = Let l0 =
-| Get materialize.public.x (u3)
+| Get materialize.public.x (u2)
 | Filter !(isnull(#1))
 
 %1 =
@@ -276,8 +294,13 @@ EOF
 query T multiline
 EXPLAIN PLAN FOR SELECT * FROM x x1, x x2, generate_series(x1.a, x2.b) AS x3(b) WHERE x1.b = x2.b AND x1.a = x3.b
 ----
+Source materialize.public.x (u2):
+| Filter !(isnull(#1))
+| Project (#0, #1)
+
+Query:
 %0 = Let l0 =
-| Get materialize.public.x (u3)
+| Get materialize.public.x (u2)
 | Filter !(isnull(#1))
 
 %1 =

--- a/test/sqllogictest/topk.slt
+++ b/test/sqllogictest/topk.slt
@@ -52,6 +52,10 @@ EXPLAIN PLAN FOR SELECT state, name FROM
     (SELECT DISTINCT state FROM cities) grp,
     LATERAL (SELECT name, pop FROM cities WHERE state = grp.state ORDER BY pop DESC LIMIT 3)
 ----
+Source materialize.public.cities (u1):
+| Project (#0..=#2)
+
+Query:
 %0 =
 | Get materialize.public.cities (u1)
 | TopK group=(#1) order=(#2 desc) limit=3 offset=0
@@ -64,6 +68,10 @@ EXPLAIN PLAN FOR SELECT state, name FROM
     (SELECT DISTINCT state FROM cities) grp
     LEFT JOIN LATERAL (SELECT name, pop FROM cities  where cities.state = grp.state ORDER BY pop DESC LIMIT 3) ON true
 ----
+Source materialize.public.cities (u1):
+| Project (#0..=#2)
+
+Query:
 %0 = Let l0 =
 | Get materialize.public.cities (u1)
 | TopK group=(#1) order=(#2 desc) limit=3 offset=0
@@ -117,6 +125,10 @@ EXPLAIN PLAN FOR SELECT state, COUNT(*) FROM (
     )
     GROUP BY state
 ----
+Source materialize.public.cities (u1):
+| Project (#1, #2)
+
+Query:
 %0 =
 | Get materialize.public.cities (u1)
 | Project (#1, #2)

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -159,7 +159,7 @@ ORDER BY
 	l_linestatus
 ----
 %0 =
-| Get materialize.public.lineitem (u21)
+| Get materialize.public.lineitem (u14)
 | Filter (#10 <= 1998-12-01)
 | Project (#4..=#9)
 | Reduce group=(#4, #5)
@@ -214,60 +214,72 @@ WHERE
 ORDER BY
     s_acctbal DESC, n_name, s_name, p_partkey
 ----
+Source materialize.public.region (u3):
+| Filter (#1 = "EUROPE")
+| Project (#0, #1)
+
+Source materialize.public.part (u4):
+| Filter "%BRASS" ~~(varchartostr(#4)), (#5 = 15)
+| Project (#0, #2, #4, #5)
+
+Query:
 %0 = Let l0 =
-| Get materialize.public.supplier (u8)
-| ArrangeBy (#0) (#3)
+| Get materialize.public.partsupp (u7)
+| ArrangeBy (#0)
 
 %1 = Let l1 =
-| Get materialize.public.partsupp (u11)
-| ArrangeBy (#0) (#1)
+| Get materialize.public.region (u3)
+| Filter (#1 = "EUROPE")
+| Project (#0)
+| ArrangeBy (#0)
 
-%2 = Let l2 =
-| Get materialize.public.nation (u1)
-| ArrangeBy (#0) (#2)
+%2 =
+| Get materialize.public.part (u4)
+| Filter (#5 = 15), "%BRASS" ~~(varchartostr(#4))
+| Project (#0, #2)
+| ArrangeBy (#0)
 
-%3 = Let l3 =
-| Get materialize.public.region (u4)
+%3 =
+| Get materialize.public.supplier (u5)
 | ArrangeBy (#0)
 
 %4 =
-| Get materialize.public.part (u6)
+| Get materialize.public.nation (u1)
+| Project (#0..=#2)
 | ArrangeBy (#0)
 
-%5 = Let l4 =
-| Join %4 %0 %1 %2 %3 (= #0 #16) (= #9 #17) (= #12 #21) (= #23 #25)
-| | implementation = DeltaQuery
-| |   delta %4 %1.(#0) %0.(#0) %2.(#0) %3.(#0)
-| |   delta %0 %2.(#0) %3.(#0) %1.(#1) %4.(#0)
-| |   delta %1 %4.(#0) %0.(#0) %2.(#0) %3.(#0)
-| |   delta %2 %3.(#0) %0.(#3) %1.(#1) %4.(#0)
-| |   delta %3 %2.(#2) %0.(#3) %1.(#1) %4.(#0)
-| Filter (#5 = 15), (#26 = "EUROPE"), "%BRASS" ~~(varchartostr(#4))
-| Project (#0, #2, #10, #11, #13..=#15, #19, #22)
+%5 = Let l2 =
+| Join %2 %3 %0 %4 %1 (= #0 #9) (= #2 #10) (= #5 #14) (= #16 #17)
+| | implementation = Differential %0.(#0) %2.(#0) %3.(#0) %4.(#0) %1.(#0)
+| Project (#0, #1, #3, #4, #6..=#8, #12, #15)
 
 %6 =
-| Get %5 (l4)
+| Get %5 (l2)
 | Project (#0)
 | Distinct group=(#0)
 | ArrangeBy (#0)
 
 %7 =
-| Join %6 %1 %0 %2 %3 (= #0 #1) (= #2 #6) (= #9 #13) (= #15 #17)
-| | implementation = DeltaQuery
-| |   delta %6 %1.(#0) %0.(#0) %2.(#0) %3.(#0)
-| |   delta %1 %6.(#0) %0.(#0) %2.(#0) %3.(#0)
-| |   delta %0 %2.(#0) %3.(#0) %1.(#1) %6.(#0)
-| |   delta %2 %3.(#0) %0.(#3) %1.(#1) %6.(#0)
-| |   delta %3 %2.(#2) %0.(#3) %1.(#1) %6.(#0)
-| Filter (#18 = "EUROPE")
+| Get materialize.public.supplier (u5)
+| Project (#0, #3)
+| ArrangeBy (#0)
+
+%8 =
+| Get materialize.public.nation (u1)
+| Project (#0, #2)
+| ArrangeBy (#0)
+
+%9 =
+| Join %6 %0 %7 %8 %1 (= #0 #1) (= #2 #6) (= #7 #8) (= #9 #10)
+| | implementation = Differential %0.(#0) %6.(#0) %7.(#0) %8.(#0) %1.(#0)
 | Project (#0, #4)
 | Reduce group=(#0)
 | | agg min(#1)
 | ArrangeBy (#0, #1)
 
-%8 =
-| Join %5 %7 (= #0 #9) (= #7 #10)
-| | implementation = Differential %5 %7.(#0, #1)
+%10 =
+| Join %5 %9 (= #0 #9) (= #7 #10)
+| | implementation = Differential %5 %9.(#0, #1)
 | Project (#5, #2, #8, #0, #1, #3, #4, #6)
 
 Finish order_by=(#0 desc, #2 asc, #1 asc, #3 asc) limit=none offset=0 project=(#0..=#7)
@@ -301,25 +313,26 @@ ORDER BY
     o_orderdate
 ----
 %0 =
-| Get materialize.public.customer (u15)
+| Get materialize.public.customer (u10)
+| Filter (#6 = "BUILDING")
+| Project (#0)
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.orders (u18)
-| ArrangeBy (#0) (#1)
+| Get materialize.public.orders (u12)
+| Filter (#4 < 1995-03-15)
+| Project (#0, #1, #4, #7)
+| ArrangeBy (#0)
 
 %2 =
-| Get materialize.public.lineitem (u21)
+| Get materialize.public.lineitem (u14)
 | ArrangeBy (#0)
 
 %3 =
-| Join %0 %1 %2 (= #0 #9) (= #8 #17)
-| | implementation = DeltaQuery
-| |   delta %0 %1.(#1) %2.(#0)
-| |   delta %1 %0.(#0) %2.(#0)
-| |   delta %2 %1.(#0) %0.(#0)
-| Filter (#6 = "BUILDING"), (#12 < 1995-03-15), (#27 > 1995-03-15)
-| Project (#8, #12, #15, #22, #23)
+| Join %0 %1 %2 (= #0 #2) (= #1 #5)
+| | implementation = Differential %2.(#0) %1.(#0) %0.(#0)
+| Filter (#15 > 1995-03-15)
+| Project (#1, #3, #4, #10, #11)
 | Reduce group=(#0, #1, #2)
 | | agg sum((#3 * (1 - #4)))
 | Project (#0, #3, #1, #2)
@@ -354,23 +367,21 @@ ORDER BY
     o_orderpriority
 ----
 %0 =
-| Get materialize.public.orders (u18)
-| ArrangeBy (#0)
+| Get materialize.public.orders (u12)
+| Filter (#4 >= 1993-07-01), (datetots(#4) < 1993-10-01 00:00:00)
+| Project (#0, #5)
 
 %1 =
-| Get materialize.public.lineitem (u21)
+| Get materialize.public.lineitem (u14)
 | Filter (#11 < #12)
 | Project (#0)
 | Distinct group=(#0)
 | ArrangeBy (#0)
 
 %2 =
-| Join %0 %1 (= #0 #9)
-| | implementation = DeltaQuery
-| |   delta %0 %1.(#0)
-| |   delta %1 %0.(#0)
-| Filter (#4 >= 1993-07-01), (datetots(#4) < 1993-10-01 00:00:00)
-| Project (#5)
+| Join %0 %1 (= #0 #2)
+| | implementation = Differential %0 %1.(#0)
+| Project (#1)
 | Reduce group=(#0)
 | | agg count(true)
 
@@ -406,36 +417,46 @@ GROUP BY
 ORDER BY
     revenue DESC
 ----
+Source materialize.public.region (u3):
+| Filter (#1 = "ASIA")
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.customer (u15)
+| Get materialize.public.customer (u10)
+| Project (#0, #3)
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.orders (u18)
+| Get materialize.public.orders (u12)
+| Filter (#4 < 1995-01-01), (#4 >= 1994-01-01)
+| Project (#0, #1)
 | ArrangeBy (#0)
 
 %2 =
-| Get materialize.public.lineitem (u21)
+| Get materialize.public.lineitem (u14)
 | ArrangeBy (#0)
 
 %3 =
-| Get materialize.public.supplier (u8)
+| Get materialize.public.supplier (u5)
 | Project (#0, #3)
 | ArrangeBy (#0, #1)
 
 %4 =
 | Get materialize.public.nation (u1)
+| Project (#0..=#2)
 | ArrangeBy (#0)
 
 %5 =
-| Get materialize.public.region (u4)
+| Get materialize.public.region (u3)
+| Filter (#1 = "ASIA")
+| Project (#0)
 | ArrangeBy (#0)
 
 %6 =
-| Join %0 %1 %2 %3 %4 %5 (= #0 #9) (= #3 #34 #35) (= #8 #17) (= #19 #33) (= #37 #39)
+| Join %0 %1 %2 %3 %4 %5 (= #0 #3) (= #1 #21 #22) (= #2 #4) (= #6 #20) (= #24 #25)
 | | implementation = Differential %2.(#0) %1.(#0) %0.(#0) %3.(#0, #1) %4.(#0) %5.(#0)
-| Filter (#40 = "ASIA"), (#12 < 1995-01-01), (#12 >= 1994-01-01)
-| Project (#22, #23, #36)
+| Project (#9, #10, #23)
 | Reduce group=(#2)
 | | agg sum((#0 * (1 - #1)))
 
@@ -457,7 +478,7 @@ WHERE
     AND l_discount BETWEEN 0.06 - 0.01 AND 0.07
 ----
 %0 = Let l0 =
-| Get materialize.public.lineitem (u21)
+| Get materialize.public.lineitem (u14)
 | Filter (#4 < 24), (#6 <= 0.07), (#6 >= 0.05), (#10 >= 1994-01-01), (datetots(#10) < 1995-01-01 00:00:00)
 | Project (#5, #6)
 | Reduce group=()
@@ -525,35 +546,33 @@ ORDER BY
 ----
 %0 = Let l0 =
 | Get materialize.public.nation (u1)
+| Project (#0, #1)
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.supplier (u8)
-| ArrangeBy (#0) (#3)
+| Get materialize.public.supplier (u5)
+| Project (#0, #3)
+| ArrangeBy (#0)
 
 %2 =
-| Get materialize.public.lineitem (u21)
-| ArrangeBy (#0) (#2)
+| Get materialize.public.lineitem (u14)
+| ArrangeBy (#2)
 
 %3 =
-| Get materialize.public.orders (u18)
-| ArrangeBy (#0) (#1)
+| Get materialize.public.orders (u12)
+| Project (#0, #1)
+| ArrangeBy (#0)
 
 %4 =
-| Get materialize.public.customer (u15)
-| ArrangeBy (#0) (#3)
+| Get materialize.public.customer (u10)
+| Project (#0, #3)
+| ArrangeBy (#0)
 
 %5 =
-| Join %1 %2 %3 %4 %0 %0 (= #0 #9) (= #3 #40) (= #7 #23) (= #24 #32) (= #35 #44)
-| | implementation = DeltaQuery
-| |   delta %1 %0.(#0) %2.(#2) %3.(#0) %4.(#0) %0.(#0)
-| |   delta %2 %1.(#0) %3.(#0) %4.(#0) %0.(#0) %0.(#0)
-| |   delta %3 %4.(#0) %0.(#0) %2.(#0) %1.(#0) %0.(#0)
-| |   delta %4 %0.(#0) %3.(#1) %2.(#0) %1.(#0) %0.(#0)
-| |   delta %0 %1.(#3) %2.(#2) %3.(#0) %4.(#0) %0.(#0)
-| |   delta %0 %4.(#3) %3.(#1) %2.(#0) %1.(#0) %0.(#0)
-| Filter (#17 <= 1996-12-31), (#17 >= 1995-01-01), (((#41 = "FRANCE") && (#45 = "GERMANY")) || ((#41 = "GERMANY") && (#45 = "FRANCE")))
-| Project (#12, #13, #17, #41, #45)
+| Join %1 %2 %3 %4 %0 %0 (= #0 #4) (= #1 #22) (= #2 #18) (= #19 #20) (= #21 #24)
+| | implementation = Differential %2.(#2) %1.(#0) %3.(#0) %4.(#0) %0.(#0) %0.(#0)
+| Filter (#12 <= 1996-12-31), (#12 >= 1995-01-01), (((#23 = "FRANCE") && (#25 = "GERMANY")) || ((#23 = "GERMANY") && (#25 = "FRANCE")))
+| Project (#7, #8, #12, #23, #25)
 | Reduce group=(#3, #4, extract_year_d(#2))
 | | agg sum((#0 * (1 - #1)))
 
@@ -602,51 +621,61 @@ GROUP BY
 ORDER BY
     o_year
 ----
+Source materialize.public.region (u3):
+| Filter (#1 = "AMERICA")
+| Project (#0, #1)
+
+Source materialize.public.part (u4):
+| Filter ("ECONOMY ANODIZED STEEL" = varchartostr(#4))
+| Project (#0, #4)
+
+Query:
 %0 =
-| Get materialize.public.part (u6)
+| Get materialize.public.part (u4)
+| Filter ("ECONOMY ANODIZED STEEL" = varchartostr(#4))
+| Project (#0)
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.supplier (u8)
-| ArrangeBy (#0) (#3)
+| Get materialize.public.supplier (u5)
+| Project (#0, #3)
+| ArrangeBy (#0)
 
 %2 =
-| Get materialize.public.lineitem (u21)
-| ArrangeBy (#0) (#1) (#2)
+| Get materialize.public.lineitem (u14)
+| ArrangeBy (#1)
 
 %3 =
-| Get materialize.public.orders (u18)
-| ArrangeBy (#0) (#1)
+| Get materialize.public.orders (u12)
+| Filter (#4 <= 1996-12-31), (#4 >= 1995-01-01)
+| Project (#0, #1, #4)
+| ArrangeBy (#0)
 
 %4 =
-| Get materialize.public.customer (u15)
-| ArrangeBy (#0) (#3)
+| Get materialize.public.customer (u10)
+| Project (#0, #3)
+| ArrangeBy (#0)
 
 %5 =
 | Get materialize.public.nation (u1)
-| ArrangeBy (#0) (#2)
+| Project (#0, #2)
+| ArrangeBy (#0)
 
 %6 =
 | Get materialize.public.nation (u1)
+| Project (#0, #1)
 | ArrangeBy (#0)
 
 %7 =
-| Get materialize.public.region (u4)
+| Get materialize.public.region (u3)
+| Filter (#1 = "AMERICA")
+| Project (#0)
 | ArrangeBy (#0)
 
 %8 =
-| Join %0 %1 %2 %3 %4 %5 %6 %7 (= #0 #17) (= #9 #18) (= #12 #53) (= #16 #32) (= #33 #41) (= #44 #49) (= #51 #57)
-| | implementation = DeltaQuery
-| |   delta %0 %2.(#1) %1.(#0) %3.(#0) %4.(#0) %5.(#0) %6.(#0) %7.(#0)
-| |   delta %1 %6.(#0) %2.(#2) %0.(#0) %3.(#0) %4.(#0) %5.(#0) %7.(#0)
-| |   delta %2 %0.(#0) %1.(#0) %3.(#0) %4.(#0) %5.(#0) %6.(#0) %7.(#0)
-| |   delta %3 %4.(#0) %5.(#0) %7.(#0) %2.(#0) %0.(#0) %1.(#0) %6.(#0)
-| |   delta %4 %5.(#0) %7.(#0) %3.(#1) %2.(#0) %0.(#0) %1.(#0) %6.(#0)
-| |   delta %5 %7.(#0) %4.(#3) %3.(#1) %2.(#0) %0.(#0) %1.(#0) %6.(#0)
-| |   delta %6 %1.(#3) %2.(#2) %0.(#0) %3.(#0) %4.(#0) %5.(#0) %7.(#0)
-| |   delta %7 %5.(#2) %4.(#3) %3.(#1) %2.(#0) %0.(#0) %1.(#0) %6.(#0)
-| Filter (#58 = "AMERICA"), (#36 <= 1996-12-31), (#36 >= 1995-01-01), ("ECONOMY ANODIZED STEEL" = varchartostr(#4))
-| Project (#21, #22, #36, #54)
+| Join %0 %1 %2 %3 %4 %5 %6 %7 (= #0 #4) (= #1 #5) (= #2 #26) (= #3 #19) (= #20 #22) (= #23 #24) (= #25 #28)
+| | implementation = Differential %2.(#1) %0.(#0) %1.(#0) %3.(#0) %4.(#0) %5.(#0) %6.(#0) %7.(#0)
+| Project (#8, #9, #21, #27)
 | Reduce group=(extract_year_d(#2))
 | | agg sum(if (#3 = "BRAZIL") then {(#0 * (1 - #1))} else {0})
 | | agg sum((#0 * (1 - #1)))
@@ -693,41 +722,45 @@ ORDER BY
     nation,
     o_year DESC
 ----
+Source materialize.public.part (u4):
+| Filter "%green%" ~~(varchartostr(#1))
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.part (u6)
+| Get materialize.public.part (u4)
+| Filter "%green%" ~~(varchartostr(#1))
+| Project (#0)
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.supplier (u8)
-| ArrangeBy (#0) (#3)
+| Get materialize.public.supplier (u5)
+| Project (#0, #3)
+| ArrangeBy (#0)
 
 %2 =
-| Get materialize.public.lineitem (u21)
-| ArrangeBy (#0) (#1) (#1, #2) (#2)
+| Get materialize.public.lineitem (u14)
+| ArrangeBy (#1, #2)
 
 %3 =
-| Get materialize.public.partsupp (u11)
+| Get materialize.public.partsupp (u7)
+| Project (#0, #1, #3)
 | ArrangeBy (#0, #1)
 
 %4 =
-| Get materialize.public.orders (u18)
+| Get materialize.public.orders (u12)
+| Project (#0, #4)
 | ArrangeBy (#0)
 
 %5 =
 | Get materialize.public.nation (u1)
+| Project (#0, #1)
 | ArrangeBy (#0)
 
 %6 =
-| Join %0 %1 %2 %3 %4 %5 (= #0 #17 #32) (= #9 #18 #33) (= #12 #46) (= #16 #37)
-| | implementation = DeltaQuery
-| |   delta %0 %2.(#1) %3.(#0, #1) %1.(#0) %4.(#0) %5.(#0)
-| |   delta %1 %5.(#0) %2.(#2) %3.(#0, #1) %0.(#0) %4.(#0)
-| |   delta %2 %3.(#0, #1) %0.(#0) %1.(#0) %4.(#0) %5.(#0)
-| |   delta %3 %0.(#0) %1.(#0) %5.(#0) %2.(#1, #2) %4.(#0)
-| |   delta %4 %2.(#0) %3.(#0, #1) %0.(#0) %1.(#0) %5.(#0)
-| |   delta %5 %1.(#3) %2.(#2) %3.(#0, #1) %0.(#0) %4.(#0)
-| Filter "%green%" ~~(varchartostr(#1))
-| Project (#20..=#22, #35, #41, #47)
+| Join %0 %1 %2 %3 %4 %5 (= #0 #4 #19) (= #1 #5 #20) (= #2 #24) (= #3 #22)
+| | implementation = Differential %2.(#1, #2) %3.(#0, #1) %0.(#0) %1.(#0) %4.(#0) %5.(#0)
+| Project (#7..=#9, #21, #23, #25)
 | Reduce group=(#5, extract_year_d(#4))
 | | agg sum(((#1 * (1 - #2)) - (#3 * #0)))
 
@@ -772,30 +805,30 @@ ORDER BY
     revenue DESC
 ----
 %0 =
-| Get materialize.public.customer (u15)
-| ArrangeBy (#0) (#3)
+| Get materialize.public.customer (u10)
+| Project (#0..=#5, #7)
+| ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.orders (u18)
-| ArrangeBy (#0) (#1)
+| Get materialize.public.orders (u12)
+| Filter (#4 < 1994-01-01), (#4 >= 1993-10-01), (datetots(#4) < 1994-01-01 00:00:00)
+| Project (#0, #1)
+| ArrangeBy (#0)
 
 %2 =
-| Get materialize.public.lineitem (u21)
+| Get materialize.public.lineitem (u14)
 | ArrangeBy (#0)
 
 %3 =
 | Get materialize.public.nation (u1)
+| Project (#0, #1)
 | ArrangeBy (#0)
 
 %4 =
-| Join %0 %1 %2 %3 (= #0 #9) (= #3 #33) (= #8 #17)
-| | implementation = DeltaQuery
-| |   delta %0 %3.(#0) %1.(#1) %2.(#0)
-| |   delta %1 %0.(#0) %3.(#0) %2.(#0)
-| |   delta %2 %1.(#0) %0.(#0) %3.(#0)
-| |   delta %3 %0.(#3) %1.(#1) %2.(#0)
-| Filter (#25 = "R"), (#12 < 1994-01-01), (#12 >= 1993-10-01), (datetots(#12) < 1994-01-01 00:00:00)
-| Project (#0..=#2, #4, #5, #7, #22, #23, #34)
+| Join %0 %1 %2 %3 (= #0 #8) (= #3 #25) (= #7 #9)
+| | implementation = Differential %2.(#0) %1.(#0) %0.(#0) %3.(#0)
+| Filter (#17 = "R")
+| Project (#0..=#2, #4..=#6, #14, #15, #26)
 | Reduce group=(#0, #1, #4, #3, #8, #2, #5)
 | | agg sum((#6 * (1 - #7)))
 | Project (#0, #1, #7, #2, #4, #5, #3, #6)
@@ -836,24 +869,23 @@ ORDER BY
     value DESC
 ----
 %0 =
-| Get materialize.public.partsupp (u11)
+| Get materialize.public.partsupp (u7)
 | ArrangeBy (#1)
 
 %1 =
-| Get materialize.public.supplier (u8)
-| ArrangeBy (#0) (#3)
+| Get materialize.public.supplier (u5)
+| Project (#0, #3)
+| ArrangeBy (#0)
 
 %2 =
 | Get materialize.public.nation (u1)
+| Filter (#1 = "GERMANY")
+| Project (#0)
 | ArrangeBy (#0)
 
 %3 = Let l0 =
-| Join %0 %1 %2 (= #1 #5) (= #8 #12)
-| | implementation = DeltaQuery
-| |   delta %0 %1.(#0) %2.(#0)
-| |   delta %1 %2.(#0) %0.(#1)
-| |   delta %2 %1.(#3) %0.(#1)
-| Filter (#13 = "GERMANY")
+| Join %0 %1 %2 (= #1 #5) (= #6 #7)
+| | implementation = Differential %0.(#1) %1.(#0) %2.(#0)
 | Project (#0, #2, #3)
 
 %4 =
@@ -911,20 +943,21 @@ ORDER BY
     l_shipmode
 ----
 %0 =
-| Get materialize.public.orders (u18)
+| Get materialize.public.orders (u12)
+| Project (#0, #5)
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.lineitem (u21)
+| Get materialize.public.lineitem (u14)
 | ArrangeBy (#0)
 
 %2 =
-| Join %0 %1 (= #0 #9)
+| Join %0 %1 (= #0 #2)
 | | implementation = DeltaQuery
 | |   delta %0 %1.(#0)
 | |   delta %1 %0.(#0)
-| Filter (#21 >= 1994-01-01), (#19 < #20), (#20 < #21), (datetots(#21) < 1995-01-01 00:00:00), ((#23 = "MAIL") || (#23 = "SHIP"))
-| Project (#5, #23)
+| Filter (#14 >= 1994-01-01), (#12 < #13), (#13 < #14), (datetots(#14) < 1995-01-01 00:00:00), ((#16 = "MAIL") || (#16 = "SHIP"))
+| Project (#1, #16)
 | Reduce group=(#1)
 | | agg sum(if ((#0 = "2-HIGH") || (#0 = "1-URGENT")) then {1} else {0})
 | | agg sum(if ((#0 != "2-HIGH") && (#0 != "1-URGENT")) then {1} else {0})
@@ -958,11 +991,11 @@ ORDER BY
     c_count DESC
 ----
 %0 =
-| Get materialize.public.customer (u15)
+| Get materialize.public.customer (u10)
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.orders (u18)
+| Get materialize.public.orders (u12)
 | ArrangeBy (#1)
 
 %2 = Let l0 =
@@ -985,7 +1018,7 @@ ORDER BY
 | Negate
 
 %5 =
-| Get materialize.public.customer (u15)
+| Get materialize.public.customer (u10)
 | Project (#0)
 
 %6 =
@@ -1021,12 +1054,17 @@ WHERE
     AND l_shipdate >= DATE '1995-09-01'
     AND l_shipdate < DATE '1995-09-01' + INTERVAL '1' month
 ----
+Source materialize.public.part (u4):
+| Project (#0, #4)
+
+Query:
 %0 =
-| Get materialize.public.lineitem (u21)
+| Get materialize.public.lineitem (u14)
 | ArrangeBy (#1)
 
 %1 =
-| Get materialize.public.part (u6)
+| Get materialize.public.part (u4)
+| Project (#0, #4)
 | ArrangeBy (#0)
 
 %2 = Let l0 =
@@ -1035,7 +1073,7 @@ WHERE
 | |   delta %0 %1.(#0)
 | |   delta %1 %0.(#1)
 | Filter (#10 >= 1995-09-01), (datetots(#10) < 1995-10-01 00:00:00)
-| Project (#5, #6, #20)
+| Project (#5, #6, #17)
 | Reduce group=()
 | | agg sum(if "PROMO%" ~~(varchartostr(#2)) then {(#0 * (1 - #1))} else {0})
 | | agg sum((#0 * (1 - #1)))
@@ -1096,15 +1134,15 @@ ORDER BY
     s_suppkey
 ----
 %0 = Let l0 =
-| Get materialize.public.lineitem (u21)
+| Get materialize.public.lineitem (u14)
 | Filter (#10 >= 1996-01-01), (datetots(#10) < 1996-04-01 00:00:00)
 | Project (#2, #5, #6)
 | Reduce group=(#0)
 | | agg sum((#1 * (1 - #2)))
 
 %1 =
-| Get materialize.public.supplier (u8)
-| ArrangeBy (#0)
+| Get materialize.public.supplier (u5)
+| Project (#0..=#2, #4)
 
 %2 =
 | Get %0 (l0)
@@ -1118,9 +1156,9 @@ ORDER BY
 | ArrangeBy (#0)
 
 %4 =
-| Join %1 %2 %3 (= #0 #7) (= #8 #9)
-| | implementation = Differential %1.(#0) %2.(#0) %3.(#0)
-| Project (#0..=#2, #4, #8)
+| Join %1 %2 %3 (= #0 #4) (= #5 #6)
+| | implementation = Differential %1 %2.(#0) %3.(#0)
+| Project (#0..=#3, #5)
 
 Finish order_by=(#0 asc) limit=none offset=0 project=(#0..=#4)
 
@@ -1163,12 +1201,19 @@ ORDER BY
     p_type,
     p_size
 ----
+Source materialize.public.part (u4):
+| Filter !("MEDIUM POLISHED%" ~~(varchartostr(#4))), ((((((((#5 = 14) || (#5 = 49)) || (#5 = 23)) || (#5 = 45)) || (#5 = 19)) || (#5 = 3)) || (#5 = 36)) || (#5 = 9)), (#3 != "Brand#45")
+| Project (#0, #3..=#5)
+
+Query:
 %0 =
-| Get materialize.public.partsupp (u11)
+| Get materialize.public.partsupp (u7)
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.part (u6)
+| Get materialize.public.part (u4)
+| Filter (#3 != "Brand#45"), !("MEDIUM POLISHED%" ~~(varchartostr(#4))), ((((((((#5 = 14) || (#5 = 49)) || (#5 = 23)) || (#5 = 45)) || (#5 = 19)) || (#5 = 3)) || (#5 = 36)) || (#5 = 9))
+| Project (#0, #3..=#5)
 | ArrangeBy (#0)
 
 %2 = Let l0 =
@@ -1176,8 +1221,7 @@ ORDER BY
 | | implementation = DeltaQuery
 | |   delta %0 %1.(#0)
 | |   delta %1 %0.(#0)
-| Filter (#8 != "Brand#45"), !("MEDIUM POLISHED%" ~~(varchartostr(#9))), ((((((((#10 = 14) || (#10 = 49)) || (#10 = 23)) || (#10 = 45)) || (#10 = 19)) || (#10 = 3)) || (#10 = 36)) || (#10 = 9))
-| Project (#1, #8..=#10)
+| Project (#1, #6..=#8)
 
 %3 = Let l1 =
 | Get %2 (l0)
@@ -1193,15 +1237,13 @@ ORDER BY
 | ArrangeBy (#0)
 
 %6 =
-| Get materialize.public.supplier (u8)
-| ArrangeBy (#0)
+| Get materialize.public.supplier (u5)
+| Filter "%Customer%Complaints%" ~~(varchartostr(#6))
+| Project (#0)
 
 %7 =
 | Join %5 %6 (= #0 #1)
-| | implementation = DeltaQuery
-| |   delta %5 %6.(#0)
-| |   delta %6 %5.(#0)
-| Filter "%Customer%Complaints%" ~~(varchartostr(#7))
+| | implementation = Differential %6 %5.(#0)
 | Project (#0)
 | Negate
 
@@ -1240,12 +1282,19 @@ WHERE
       l_partkey = p_partkey
   )
 ----
+Source materialize.public.part (u4):
+| Filter (#3 = "Brand#23"), (#6 = "MED BOX")
+| Project (#0, #3, #6)
+
+Query:
 %0 = Let l0 =
-| Get materialize.public.lineitem (u21)
+| Get materialize.public.lineitem (u14)
 | ArrangeBy (#1)
 
 %1 =
-| Get materialize.public.part (u6)
+| Get materialize.public.part (u4)
+| Filter (#3 = "Brand#23"), (#6 = "MED BOX")
+| Project (#0)
 | ArrangeBy (#0)
 
 %2 = Let l1 =
@@ -1253,7 +1302,6 @@ WHERE
 | | implementation = DeltaQuery
 | |   delta %0 %1.(#0)
 | |   delta %1 %0.(#1)
-| Filter (#19 = "Brand#23"), (#22 = "MED BOX")
 | Project (#1, #4, #5)
 
 %3 =
@@ -1337,24 +1385,23 @@ ORDER BY
     o_orderdate
 ----
 %0 = Let l0 =
-| Get materialize.public.lineitem (u21)
+| Get materialize.public.lineitem (u14)
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.customer (u15)
+| Get materialize.public.customer (u10)
+| Project (#0, #1)
 | ArrangeBy (#0)
 
 %2 =
-| Get materialize.public.orders (u18)
-| ArrangeBy (#0) (#1)
+| Get materialize.public.orders (u12)
+| Project (#0, #1, #3, #4)
+| ArrangeBy (#0)
 
 %3 = Let l1 =
-| Join %1 %2 %0 (= #0 #9) (= #8 #17)
-| | implementation = DeltaQuery
-| |   delta %1 %2.(#1) %0.(#0)
-| |   delta %2 %1.(#0) %0.(#0)
-| |   delta %0 %2.(#0) %1.(#0)
-| Project (#0, #1, #8, #11, #12, #21)
+| Join %1 %2 %0 (= #0 #3) (= #2 #6)
+| | implementation = Differential %0.(#0) %2.(#0) %1.(#0)
+| Project (#0..=#2, #4, #5, #10)
 
 %4 =
 | Get %3 (l1)
@@ -1423,12 +1470,19 @@ WHERE
         AND l_shipinstruct = 'DELIVER IN PERSON'
     )
 ----
+Source materialize.public.part (u4):
+| Filter (#5 >= 1)
+| Project (#0, #3, #5, #6)
+
+Query:
 %0 =
-| Get materialize.public.lineitem (u21)
+| Get materialize.public.lineitem (u14)
 | ArrangeBy (#1)
 
 %1 =
-| Get materialize.public.part (u6)
+| Get materialize.public.part (u4)
+| Filter (#5 >= 1)
+| Project (#0, #3, #5, #6)
 | ArrangeBy (#0)
 
 %2 = Let l0 =
@@ -1436,7 +1490,7 @@ WHERE
 | | implementation = DeltaQuery
 | |   delta %0 %1.(#0)
 | |   delta %1 %0.(#1)
-| Filter (#13 = "DELIVER IN PERSON"), (#21 >= 1), ((#14 = "AIR") || (#14 = "AIR REG")), (((((((((#22 = "LG BOX") || (#22 = "LG CASE")) || (#22 = "LG PACK")) || (#22 = "LG PKG")) && (#19 = "Brand#34")) && (#4 >= 20)) && (#4 <= 30)) && (#21 <= 15)) || (((((((((#22 = "SM BOX") || (#22 = "SM CASE")) || (#22 = "SM PACK")) || (#22 = "SM PKG")) && (#19 = "Brand#12")) && (#4 >= 1)) && (#4 <= 11)) && (#21 <= 5)) || ((((((((#22 = "MED BAG") || (#22 = "MED BOX")) || (#22 = "MED PKG")) || (#22 = "MED PACK")) && (#19 = "Brand#23")) && (#4 >= 10)) && (#4 <= 20)) && (#21 <= 10))))
+| Filter (#13 = "DELIVER IN PERSON"), ((#14 = "AIR") || (#14 = "AIR REG")), (((((((((#19 = "LG BOX") || (#19 = "LG CASE")) || (#19 = "LG PACK")) || (#19 = "LG PKG")) && (#17 = "Brand#34")) && (#4 >= 20)) && (#4 <= 30)) && (#18 <= 15)) || (((((((((#19 = "SM BOX") || (#19 = "SM CASE")) || (#19 = "SM PACK")) || (#19 = "SM PKG")) && (#17 = "Brand#12")) && (#4 >= 1)) && (#4 <= 11)) && (#18 <= 5)) || ((((((((#19 = "MED BAG") || (#19 = "MED BOX")) || (#19 = "MED PKG")) || (#19 = "MED PACK")) && (#17 = "Brand#23")) && (#4 >= 10)) && (#4 <= 20)) && (#18 <= 10))))
 | Project (#5, #6)
 | Reduce group=()
 | | agg sum((#0 * (1 - #1)))
@@ -1499,12 +1553,19 @@ WHERE
 ORDER BY
     s_name
 ----
+Source materialize.public.part (u4):
+| Filter "forest%" ~~(varchartostr(#1))
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.supplier (u8)
+| Get materialize.public.supplier (u5)
 | ArrangeBy (#3)
 
 %1 =
 | Get materialize.public.nation (u1)
+| Filter (#1 = "CANADA")
+| Project (#0)
 | ArrangeBy (#0)
 
 %2 = Let l0 =
@@ -1512,7 +1573,6 @@ ORDER BY
 | | implementation = DeltaQuery
 | |   delta %0 %1.(#0)
 | |   delta %1 %0.(#3)
-| Filter (#8 = "CANADA")
 | Project (#0..=#2)
 
 %3 =
@@ -1521,17 +1581,18 @@ ORDER BY
 | ArrangeBy ()
 
 %4 =
-| Get materialize.public.partsupp (u11)
+| Get materialize.public.partsupp (u7)
 | ArrangeBy (#0)
 
 %5 =
-| Get materialize.public.part (u6)
+| Get materialize.public.part (u4)
+| Filter "forest%" ~~(varchartostr(#1))
+| Project (#0)
 | ArrangeBy (#0)
 
 %6 = Let l1 =
 | Join %3 %4 %5 (= #1 #6)
 | | implementation = Differential %4.(#0) %5.(#0) %3.()
-| Filter "forest%" ~~(varchartostr(#7))
 | Project (#0..=#3)
 
 %7 =
@@ -1546,7 +1607,7 @@ ORDER BY
 | ArrangeBy (#0, #1)
 
 %9 =
-| Get materialize.public.lineitem (u21)
+| Get materialize.public.lineitem (u14)
 | ArrangeBy (#1, #2)
 
 %10 =
@@ -1621,33 +1682,34 @@ ORDER BY
     s_name
 ----
 %0 =
-| Get materialize.public.supplier (u8)
-| ArrangeBy (#0) (#3)
+| Get materialize.public.supplier (u5)
+| Project (#0, #1, #3)
+| ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.lineitem (u21)
-| ArrangeBy (#0) (#2)
+| Get materialize.public.lineitem (u14)
+| ArrangeBy (#2)
 
 %2 =
-| Get materialize.public.orders (u18)
+| Get materialize.public.orders (u12)
+| Filter (#2 = "F")
+| Project (#0)
 | ArrangeBy (#0)
 
 %3 =
 | Get materialize.public.nation (u1)
+| Filter (#1 = "SAUDI ARABIA")
+| Project (#0)
 | ArrangeBy (#0)
 
 %4 = Let l0 =
-| Join %0 %1 %2 %3 (= #0 #9) (= #3 #32) (= #7 #23)
-| | implementation = DeltaQuery
-| |   delta %0 %3.(#0) %1.(#2) %2.(#0)
-| |   delta %1 %0.(#0) %2.(#0) %3.(#0)
-| |   delta %2 %1.(#0) %0.(#0) %3.(#0)
-| |   delta %3 %0.(#3) %1.(#2) %2.(#0)
-| Filter (#25 = "F"), (#33 = "SAUDI ARABIA"), (#19 > #18)
-| Project (#0, #1, #7)
+| Join %0 %1 %2 %3 (= #0 #5) (= #2 #20) (= #3 #19)
+| | implementation = Differential %1.(#2) %0.(#0) %2.(#0) %3.(#0)
+| Filter (#15 > #14)
+| Project (#0, #1, #3)
 
 %5 = Let l1 =
-| Get materialize.public.lineitem (u21)
+| Get materialize.public.lineitem (u14)
 | ArrangeBy (#0)
 
 %6 =
@@ -1751,13 +1813,13 @@ ORDER BY
     cntrycode
 ----
 %0 =
-| Get materialize.public.customer (u15)
+| Get materialize.public.customer (u10)
 | Map substr(chartostr(#4), 1, 2)
 | Filter (((((((#8 = "13") || (#8 = "31")) || (#8 = "23")) || (#8 = "29")) || (#8 = "30")) || (#8 = "18")) || (#8 = "17"))
 | Project (#0, #4, #5)
 
 %1 =
-| Get materialize.public.customer (u15)
+| Get materialize.public.customer (u10)
 | Filter (#5 > 0)
 | Map substr(chartostr(#4), 1, 2)
 | Filter (((((((#8 = "13") || (#8 = "31")) || (#8 = "23")) || (#8 = "29")) || (#8 = "30")) || (#8 = "18")) || (#8 = "17"))
@@ -1782,7 +1844,7 @@ ORDER BY
 | ArrangeBy (#0)
 
 %5 =
-| Get materialize.public.orders (u18)
+| Get materialize.public.orders (u12)
 | Project (#1)
 | Distinct group=(#0)
 | ArrangeBy (#0)
@@ -1853,7 +1915,7 @@ ORDER BY
     s_name
 ----
 %0 =
-| Get materialize.public.supplier (u8)
+| Get materialize.public.supplier (u5)
 
 %1 =
 | Get materialize.public.nation (u1)
@@ -1863,18 +1925,18 @@ ORDER BY
 | Filter ((select(%3) && (#3 = #7)) && (#8 = strtochar("CANADA")))
 | |
 | | %3 =
-| | | Get materialize.public.partsupp (u11)
+| | | Get materialize.public.partsupp (u7)
 | | | Filter (select(%4) && (i32tonumeric(#2) > select(%5)))
 | | | |
 | | | | %4 =
-| | | | | Get materialize.public.part (u6)
+| | | | | Get materialize.public.part (u4)
 | | | | | Filter (varchartostr(#1) like "forest%")
 | | | | | Project (#0)
 | | | | | Reduce group=() any(((#^0 = #0) && true))
 | | | |
 | | | |
 | | | | %5 =
-| | | | | Get materialize.public.lineitem (u21)
+| | | | | Get materialize.public.lineitem (u14)
 | | | | | Filter ((((#1 = #^0) && (#2 = #^1)) && (#10 >= strtodate("1995-01-01"))) && (datetots(#10) < (strtodate("1995-01-01") + 1 year)))
 | | | | | Reduce group=() sum(#4)
 | | | | | Map (0.5 * #0)

--- a/test/sqllogictest/transactions.slt
+++ b/test/sqllogictest/transactions.slt
@@ -290,10 +290,10 @@ SELECT * FROM other.t;
 ----
 db error: ERROR: Transactions can only reference objects in the same timedomain. See https://materialize.com/docs/sql/begin/#same-timedomain-error
 DETAIL: The following relations in the query are outside the transaction's time domain:
-"materialize.other.t_primary_idx"
+"materialize.other.t"
 Only the following relations are available:
-"materialize.public.t5727_primary_idx"
-"materialize.public.t_primary_idx"
+"materialize.public.t"
+"materialize.public.t5727"
 
 # Verify that changed tables and views don't change during a transaction.
 
@@ -400,7 +400,7 @@ COMPLETE 0
 simple conn=t1
 COMMIT;
 ----
-db error: ERROR: unknown catalog item 'u21'
+db error: ERROR: unknown catalog item 'u17'
 
 # Test transaction syntax that we don't support.
 

--- a/test/sqllogictest/transactions.slt
+++ b/test/sqllogictest/transactions.slt
@@ -290,11 +290,8 @@ SELECT * FROM other.t;
 ----
 db error: ERROR: Transactions can only reference objects in the same timedomain. See https://materialize.com/docs/sql/begin/#same-timedomain-error
 DETAIL: The following relations in the query are outside the transaction's time domain:
-"materialize.other.t"
 "materialize.other.t_primary_idx"
 Only the following relations are available:
-"materialize.public.t"
-"materialize.public.t5727"
 "materialize.public.t5727_primary_idx"
 "materialize.public.t_primary_idx"
 
@@ -340,7 +337,7 @@ COMPLETE 1
 COMPLETE 1
 COMPLETE 0
 
-# Verify that replacing a non-materialized view in a different transaction isn't seen.
+# Test replacing a non-materialized view in a different transaction.
 
 statement ok
 CREATE VIEW v1 AS SELECT 1
@@ -364,22 +361,16 @@ SELECT * FROM v1;
 2
 COMPLETE 1
 
-# Here we expect an error because, since our catalog doesn't respect
-# SQL transactions, the original v1 doesn't exist.
+# Our catalog doesn't respect SQL transactions, so we see the new v1.
+# Unmaterialized views with no dependencies exist outside of any particular
+# timedomain.
 simple conn=t1
 SELECT * FROM v1;
 COMMIT;
 ----
-db error: ERROR: Transactions can only reference objects in the same timedomain. See https://materialize.com/docs/sql/begin/#same-timedomain-error
-DETAIL: The following relations in the query are outside the transaction's time domain:
-"materialize.public.v1"
-Only the following relations are available:
-"materialize.public.t"
-"materialize.public.t5727"
-"materialize.public.t5727_primary_idx"
-"materialize.public.t_primary_idx"
-"materialize.public.v"
-"materialize.public.v_primary_idx"
+2
+COMPLETE 1
+COMPLETE 0
 
 simple conn=t1
 ROLLBACK;

--- a/test/sqllogictest/transform/aggregation_nullability.slt
+++ b/test/sqllogictest/transform/aggregation_nullability.slt
@@ -22,6 +22,14 @@ INSERT INTO t1 VALUES (1, 2)
 query T multiline
 EXPLAIN select t1.f1, count(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having count(t2.f1) >= 0;
 ----
+Source materialize.public.t1 (u1):
+| Project (#0)
+
+Source materialize.public.t2 (u2):
+| Filter !(isnull(#0))
+| Project (#0)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 | Filter !(isnull(#0))
@@ -29,7 +37,7 @@ EXPLAIN select t1.f1, count(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group b
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Filter !(isnull(#0))
 | Project (#0)
 
@@ -79,6 +87,15 @@ select t1.f1, count(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 
 query T multiline
 EXPLAIN select t1.f1, sum(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having sum(t2.f1) >= 0;
 ----
+Source materialize.public.t1 (u1):
+| Filter !(isnull(#0))
+| Project (#0)
+
+Source materialize.public.t2 (u2):
+| Filter !(isnull(#0))
+| Project (#0)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 | Filter !(isnull(#0))
@@ -86,7 +103,7 @@ EXPLAIN select t1.f1, sum(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by 
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Filter !(isnull(#0))
 | Project (#0)
 
@@ -108,13 +125,21 @@ select t1.f1, sum(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 ha
 query T multiline
 EXPLAIN select t1.f1, count(t2.f1), sum(t2.f1), max(t2.f1), min(t2.f1), count(t1.f2), sum(t1.f2), min(t1.f2), max(t1.f2) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1;
 ----
+Source materialize.public.t1 (u1):
+| Project (#0, #1)
+
+Source materialize.public.t2 (u2):
+| Filter !(isnull(#0))
+| Project (#0)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 | Filter !(isnull(#0))
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Filter !(isnull(#0))
 | Project (#0)
 
@@ -166,13 +191,21 @@ EOF
 query T multiline
 EXPLAIN select t1.f1, count(t2.f1), sum(t2.f1), max(t2.f1), min(t2.f1), count(t1.f2), sum(t1.f2), min(t1.f2), max(t1.f2) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having sum(t1.f2) >= 0;
 ----
+Source materialize.public.t1 (u1):
+| Project (#0, #1)
+
+Source materialize.public.t2 (u2):
+| Filter !(isnull(#0))
+| Project (#0)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 | Filter !(isnull(#0))
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Filter !(isnull(#0))
 | Project (#0)
 
@@ -225,13 +258,21 @@ EOF
 query T multiline
 EXPLAIN select t1.f1, count(t2.f1), sum(t2.f1), max(t2.f1), min(t2.f1), count(t1.f2), sum(t1.f2), min(t1.f2), max(t1.f2) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having sum(t2.f1) >= 0;
 ----
+Source materialize.public.t1 (u1):
+| Project (#0, #1)
+
+Source materialize.public.t2 (u2):
+| Filter !(isnull(#0))
+| Project (#0)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 | Filter !(isnull(#0))
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Filter !(isnull(#0))
 | Project (#0)
 
@@ -285,6 +326,10 @@ EOF
 query T multiline
 EXPLAIN select t1.f1, count(t1.f2) from t1 group by t1.f1 having count(t1.f2) is not null;
 ----
+Source materialize.public.t1 (u1):
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 | Reduce group=(#0)
@@ -295,6 +340,10 @@ EOF
 query T multiline
 EXPLAIN select t1.f1, sum(t1.f2) from t1 group by t1.f1 having sum(t1.f2) is not null;
 ----
+Source materialize.public.t1 (u1):
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 | Reduce group=(#0)
@@ -307,6 +356,15 @@ EOF
 query T multiline
 EXPLAIN select t1.f1, sum(t2.f1), max(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having max(t2.f1) >= 0;
 ----
+Source materialize.public.t1 (u1):
+| Filter !(isnull(#0))
+| Project (#0)
+
+Source materialize.public.t2 (u2):
+| Filter !(isnull(#0))
+| Project (#0)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 | Filter !(isnull(#0))
@@ -314,7 +372,7 @@ EXPLAIN select t1.f1, sum(t2.f1), max(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Filter !(isnull(#0))
 | Project (#0)
 
@@ -333,6 +391,15 @@ EOF
 query T multiline
 EXPLAIN select t1.f1, sum(t2.f1), max(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having max(t2.f1) >= 0 and sum(t2.f1) >= 0;
 ----
+Source materialize.public.t1 (u1):
+| Filter !(isnull(#0))
+| Project (#0)
+
+Source materialize.public.t2 (u2):
+| Filter !(isnull(#0))
+| Project (#0)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 | Filter !(isnull(#0))
@@ -340,7 +407,7 @@ EXPLAIN select t1.f1, sum(t2.f1), max(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Filter !(isnull(#0))
 | Project (#0)
 
@@ -359,6 +426,14 @@ EOF
 query T multiline
 EXPLAIN select t1.f1, sum(t2.f2), max(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having max(t2.f1) >= 0;
 ----
+Source materialize.public.t1 (u1):
+| Project (#0)
+
+Source materialize.public.t2 (u2):
+| Filter !(isnull(#0))
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 | Filter !(isnull(#0))
@@ -366,7 +441,7 @@ EXPLAIN select t1.f1, sum(t2.f2), max(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Filter !(isnull(#0))
 
 %2 = Let l0 =
@@ -411,6 +486,15 @@ EOF
 query T multiline
 EXPLAIN select t1.f1, sum(t2.f1 + t2.f2), max(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having max(t2.f1) >= 0;
 ----
+Source materialize.public.t1 (u1):
+| Filter !(isnull(#0))
+| Project (#0)
+
+Source materialize.public.t2 (u2):
+| Filter !(isnull(#0))
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 | Filter !(isnull(#0))
@@ -418,7 +502,7 @@ EXPLAIN select t1.f1, sum(t2.f1 + t2.f2), max(t2.f1) from t1 LEFT JOIN t2 ON t1.
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Filter !(isnull(#0))
 
 %2 =
@@ -436,6 +520,15 @@ EOF
 query T multiline
 EXPLAIN select t1.f1, sum(t1.f1 + t2.f1), max(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having max(t2.f1) >= 0;
 ----
+Source materialize.public.t1 (u1):
+| Filter !(isnull(#0))
+| Project (#0)
+
+Source materialize.public.t2 (u2):
+| Filter !(isnull(#0))
+| Project (#0)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 | Filter !(isnull(#0))
@@ -443,7 +536,7 @@ EXPLAIN select t1.f1, sum(t1.f1 + t2.f1), max(t2.f1) from t1 LEFT JOIN t2 ON t1.
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Filter !(isnull(#0))
 | Project (#0)
 
@@ -462,6 +555,14 @@ EOF
 query T multiline
 EXPLAIN select t1.f1, sum(t1.f1), max(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having max(t2.f1) >= 0;
 ----
+Source materialize.public.t1 (u1):
+| Project (#0)
+
+Source materialize.public.t2 (u2):
+| Filter !(isnull(#0))
+| Project (#0)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 | Filter !(isnull(#0))
@@ -469,7 +570,7 @@ EXPLAIN select t1.f1, sum(t1.f1), max(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Filter !(isnull(#0))
 | Project (#0)
 
@@ -514,6 +615,14 @@ EOF
 query T multiline
 EXPLAIN select t1.f1, count(t2.f2) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1;
 ----
+Source materialize.public.t1 (u1):
+| Project (#0)
+
+Source materialize.public.t2 (u2):
+| Filter !(isnull(#0))
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 | Filter !(isnull(#0))
@@ -521,7 +630,7 @@ EXPLAIN select t1.f1, count(t2.f2) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group b
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Filter !(isnull(#0))
 
 %2 = Let l0 =
@@ -560,6 +669,14 @@ EOF
 query T multiline
 EXPLAIN select t1.f1, count(t2.f2), max(t2.f2) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1;
 ----
+Source materialize.public.t1 (u1):
+| Project (#0)
+
+Source materialize.public.t2 (u2):
+| Filter !(isnull(#0))
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 | Filter !(isnull(#0))
@@ -567,7 +684,7 @@ EXPLAIN select t1.f1, count(t2.f2), max(t2.f2) from t1 LEFT JOIN t2 ON t1.f1 = t
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Filter !(isnull(#0))
 
 %2 = Let l0 =
@@ -607,6 +724,15 @@ EOF
 query T multiline
 EXPLAIN select t1.f1, count(t2.f2), max(t2.f2) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having max(t2.f2) > 0;
 ----
+Source materialize.public.t1 (u1):
+| Filter !(isnull(#0))
+| Project (#0)
+
+Source materialize.public.t2 (u2):
+| Filter !(isnull(#0))
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 | Filter !(isnull(#0))
@@ -614,7 +740,7 @@ EXPLAIN select t1.f1, count(t2.f2), max(t2.f2) from t1 LEFT JOIN t2 ON t1.f1 = t
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Filter !(isnull(#0))
 
 %2 =
@@ -632,13 +758,22 @@ EOF
 query T multiline
 EXPLAIN select t1.f1, max(t1.f1 + t2.f2), sum(t1.f2 + t2.f2) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having max(t1.f1 + t2.f2) > 0;
 ----
+Source materialize.public.t1 (u1):
+| Filter !(isnull(#0))
+| Project (#0, #1)
+
+Source materialize.public.t2 (u2):
+| Filter !(isnull(#0))
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 | Filter !(isnull(#0))
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Filter !(isnull(#0))
 
 %2 =
@@ -684,13 +819,21 @@ select t1.f1, count(t1.f2), max(t2.f2) from t1 left join t2 on t1.f2 = t2.f1 gro
 query T multiline
 explain select t1.f1, count(t1.f2), max(t2.f2) from t1 left join t2 on t1.f2 = t2.f1 group by t1.f1
 ----
+Source materialize.public.t1 (u3):
+| Project (#0, #1)
+
+Source materialize.public.t2 (u4):
+| Filter !(isnull(#0))
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.t1 (u5)
+| Get materialize.public.t1 (u3)
 | Filter !(isnull(#1))
 | ArrangeBy (#1)
 
 %1 =
-| Get materialize.public.t2 (u7)
+| Get materialize.public.t2 (u4)
 | Filter !(isnull(#0))
 
 %2 = Let l0 =
@@ -699,7 +842,7 @@ explain select t1.f1, count(t1.f2), max(t2.f2) from t1 left join t2 on t1.f2 = t
 | Project (#0, #1, #3)
 
 %3 =
-| Get materialize.public.t1 (u5)
+| Get materialize.public.t1 (u3)
 
 %4 =
 | Get %2 (l0)
@@ -714,7 +857,7 @@ explain select t1.f1, count(t1.f2), max(t2.f2) from t1 left join t2 on t1.f2 = t
 | Negate
 
 %6 =
-| Get materialize.public.t1 (u5)
+| Get materialize.public.t1 (u3)
 
 %7 =
 | Union %5 %6
@@ -731,13 +874,21 @@ EOF
 query T multiline
 explain select t1.f1, count(t1.f2), max(t2.f2) from t1 left join t2 on t1.f2 = t2.f1 group by t1.f1 having max(t2.f2) > 0
 ----
+Source materialize.public.t1 (u3):
+| Project (#0, #1)
+
+Source materialize.public.t2 (u4):
+| Filter !(isnull(#0))
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.t1 (u5)
+| Get materialize.public.t1 (u3)
 | Filter !(isnull(#1))
 | ArrangeBy (#1)
 
 %1 =
-| Get materialize.public.t2 (u7)
+| Get materialize.public.t2 (u4)
 | Filter !(isnull(#0))
 
 %2 = Let l0 =
@@ -746,7 +897,7 @@ explain select t1.f1, count(t1.f2), max(t2.f2) from t1 left join t2 on t1.f2 = t
 | Project (#0, #1, #3)
 
 %3 =
-| Get materialize.public.t1 (u5)
+| Get materialize.public.t1 (u3)
 
 %4 =
 | Get %2 (l0)
@@ -761,7 +912,7 @@ explain select t1.f1, count(t1.f2), max(t2.f2) from t1 left join t2 on t1.f2 = t
 | Negate
 
 %6 =
-| Get materialize.public.t1 (u5)
+| Get materialize.public.t1 (u3)
 
 %7 =
 | Union %5 %6
@@ -780,13 +931,22 @@ EOF
 query T multiline
 explain select t1.f1, max(t2.f2) from t1 left join t2 on t1.f2 = t2.f1 group by t1.f1 having max(t2.f2) > 0
 ----
+Source materialize.public.t1 (u3):
+| Filter !(isnull(#1))
+| Project (#0, #1)
+
+Source materialize.public.t2 (u4):
+| Filter !(isnull(#0))
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.t1 (u5)
+| Get materialize.public.t1 (u3)
 | Filter !(isnull(#1))
 | ArrangeBy (#1)
 
 %1 =
-| Get materialize.public.t2 (u7)
+| Get materialize.public.t2 (u4)
 | Filter !(isnull(#0))
 
 %2 =
@@ -812,8 +972,13 @@ insert into t1 values (0), (1)
 query T multiline
 EXPLAIN SELECT * FROM (SELECT 123, COUNT(right_table.f1) AS aggregate FROM t1 AS left_table LEFT JOIN t1 AS right_table ON FALSE GROUP BY 1) AS subquery, t1 AS outer_table WHERE outer_table.f1 = subquery.aggregate;
 ----
+Source materialize.public.t1 (u5):
+| Filter (0 = i32toi64(#0))
+| Project (#0)
+
+Query:
 %0 =
-| Get materialize.public.t1 (u9)
+| Get materialize.public.t1 (u5)
 | Filter (0 = i32toi64(#0))
 | Map 123, 0
 | Project (#1, #2, #0)
@@ -873,13 +1038,23 @@ JOIN (
 ) AS derived ON TRUE
 WHERE t1.f2 = derived.agg2;
 ----
+Source materialize.public.t1 (u6):
+| Project (#1)
+
+Source materialize.public.t2 (u7):
+| Project (#1)
+
+Source materialize.public.t3 (u8):
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.t2 (u13)
+| Get materialize.public.t2 (u7)
 | Project (#1)
 | ArrangeBy ()
 
 %1 =
-| Get materialize.public.t3 (u15)
+| Get materialize.public.t3 (u8)
 | Filter (#1 = 6)
 | Project (#0)
 
@@ -888,7 +1063,7 @@ WHERE t1.f2 = derived.agg2;
 | | implementation = Differential %1 %0.()
 
 %3 =
-| Get materialize.public.t1 (u11)
+| Get materialize.public.t1 (u6)
 | Project (#1)
 
 %4 =
@@ -903,19 +1078,19 @@ WHERE t1.f2 = derived.agg2;
 | Map 6
 
 %6 =
-| Get materialize.public.t3 (u15)
+| Get materialize.public.t3 (u8)
 | Distinct group=(#0, #1)
 
 %7 =
 | Union %5 %6
+| ArrangeBy (#0, #1)
 
 %8 =
-| Get materialize.public.t3 (u15)
-| ArrangeBy (#0, #1)
+| Get materialize.public.t3 (u8)
 
 %9 =
 | Join %7 %8 (= #0 #2) (= #1 #3)
-| | implementation = Differential %7 %8.(#0, #1)
+| | implementation = Differential %8 %7.(#0, #1)
 | Map null
 | Project (#4)
 
@@ -963,12 +1138,19 @@ LEFT JOIN t1
 ON t1.f1 < t2.f1
 HAVING SUM(t1.f1 + t2.f1) > 0;
 ----
+Source materialize.public.t1 (u9):
+| Project (#0)
+
+Source materialize.public.t2 (u10):
+| Project (#0)
+
+Query:
 %0 =
-| Get materialize.public.t2 (u19)
+| Get materialize.public.t2 (u10)
 | ArrangeBy ()
 
 %1 =
-| Get materialize.public.t1 (u17)
+| Get materialize.public.t1 (u9)
 
 %2 = Let l0 =
 | Join %0 %1
@@ -982,19 +1164,19 @@ HAVING SUM(t1.f1 + t2.f1) > 0;
 | Negate
 
 %4 =
-| Get materialize.public.t2 (u19)
+| Get materialize.public.t2 (u10)
 | Distinct group=(#0)
 
 %5 =
 | Union %3 %4
+| ArrangeBy (#0)
 
 %6 =
-| Get materialize.public.t2 (u19)
-| ArrangeBy (#0)
+| Get materialize.public.t2 (u10)
 
 %7 =
 | Join %5 %6 (= #0 #1)
-| | implementation = Differential %5 %6.(#0)
+| | implementation = Differential %6 %5.(#0)
 | Map null
 | Project (#0, #2)
 

--- a/test/sqllogictest/transform/dataflow.slt
+++ b/test/sqllogictest/transform/dataflow.slt
@@ -24,6 +24,11 @@ CREATE VIEW foo3 as select b from foo2 where b = 6;
 query T multiline
 EXPLAIN PLAN FOR SELECT * from foo3
 ----
+Source materialize.public.foo (u1):
+| Filter (#0 = 5), (#1 = 6)
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.foo (u1)
 | Filter (#0 = 5), (#1 = 6)
@@ -34,6 +39,11 @@ EOF
 query T multiline
 EXPLAIN PLAN FOR VIEW foo3
 ----
+Source materialize.public.foo (u1):
+| Filter (#0 = 5), (#1 = 6)
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.foo (u1)
 | Filter (#0 = 5), (#1 = 6)
@@ -48,7 +58,7 @@ query T multiline
 EXPLAIN PLAN FOR VIEW foo3
 ----
 %0 =
-| Get materialize.public.foo2 (u3)
+| Get materialize.public.foo2 (u2)
 | Filter (#0 = 6)
 
 EOF
@@ -57,7 +67,7 @@ query T multiline
 EXPLAIN PLAN FOR SELECT * from foo3
 ----
 %0 =
-| Get materialize.public.foo2 (u3)
+| Get materialize.public.foo2 (u2)
 | Filter (#0 = 6)
 
 EOF

--- a/test/sqllogictest/transform/filter_index.slt
+++ b/test/sqllogictest/transform/filter_index.slt
@@ -30,6 +30,11 @@ INSERT INTO bar (a, d, e) VALUES (-45, 'our', 3.14), (5, 'still', -0.0), (-3, 'i
 query T multiline
 explain plan for select b, c from foo where a = 5
 ----
+Source materialize.public.foo (u1):
+| Filter (#0 = 5)
+| Project (#0..=#2)
+
+Query:
 %0 =
 | Get materialize.public.foo (u1)
 | Filter (#0 = 5)
@@ -48,6 +53,11 @@ this
 query T multiline
 explain plan for select b, c from foo, (select 5 as a) const where foo.a = const.a
 ----
+Source materialize.public.foo (u1):
+| Filter (#0 = 5)
+| Project (#0..=#2)
+
+Query:
 %0 =
 | Get materialize.public.foo (u1)
 | Filter (#0 = 5)
@@ -66,13 +76,22 @@ this
 query T multiline
 explain plan for select * from foo, bar where foo.a = abs(bar.a) and foo.a = 3
 ----
+Source materialize.public.foo (u1):
+| Filter (#0 = 3)
+| Project (#0..=#2)
+
+Source materialize.public.bar (u2):
+| Filter (3 = abs(#0))
+| Project (#0..=#2)
+
+Query:
 %0 =
 | Get materialize.public.foo (u1)
 | Filter (#0 = 3)
 | ArrangeBy ()
 
 %1 =
-| Get materialize.public.bar (u3)
+| Get materialize.public.bar (u2)
 | Filter (3 = abs(#0))
 
 %2 =

--- a/test/sqllogictest/transform/is_null_propagation.slt
+++ b/test/sqllogictest/transform/is_null_propagation.slt
@@ -27,13 +27,21 @@ EOF
 query T multiline
 EXPLAIN SELECT FROM t1, t2 WHERE t1.f2 + t2.f1 = t1.f1 AND t2.f1 IS NOT NULL
 ----
+Source materialize.public.t1 (u1):
+| Filter !(isnull(#0))
+| Project (#0, #1)
+
+Source materialize.public.t2 (u2):
+| Project (#0)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 | Filter !(isnull(#0))
 | ArrangeBy ()
 
 %1 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Project (#0)
 
 %2 =
@@ -46,6 +54,13 @@ EOF
 query T multiline
 EXPLAIN SELECT FROM t1 WHERE f2 IN ( SELECT agg1 FROM ( SELECT COUNT ( TRUE ) agg1 FROM t2 a1 JOIN ( SELECT a2.f2 FROM t1 LEFT JOIN t1 a2 ON TRUE ) a2 ON TRUE WHERE  a2.f2 IS NOT NULL AND a2.f2 > a1.f2 ) )
 ----
+Source materialize.public.t1 (u1):
+| Project (#1)
+
+Source materialize.public.t2 (u2):
+| Project (#1)
+
+Query:
 %0 = Let l0 =
 | Get materialize.public.t1 (u1)
 | Project (#1)
@@ -55,7 +70,7 @@ EXPLAIN SELECT FROM t1 WHERE f2 IN ( SELECT agg1 FROM ( SELECT COUNT ( TRUE ) ag
 | Distinct group=(#0)
 
 %2 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Project (#1)
 | ArrangeBy ()
 

--- a/test/sqllogictest/transform/join_fusion.slt
+++ b/test/sqllogictest/transform/join_fusion.slt
@@ -30,18 +30,31 @@ INSERT INTO t3 VALUES (2, 3), (5, 5);
 query T multiline
 EXPLAIN SELECT * FROM t1 INNER JOIN t2 ON t2.f2 = t1.f2 INNER JOIN t3 ON t1.f1 = t3.f1 WHERE t1.f1 <= t2.f1 AND t3.f1 > 0;
 ----
+Source materialize.public.t1 (u1):
+| Filter !(isnull(#1)), (#0 > 0)
+| Project (#0, #1)
+
+Source materialize.public.t2 (u2):
+| Filter !(isnull(#1))
+| Project (#0, #1)
+
+Source materialize.public.t3 (u3):
+| Filter (#0 > 0)
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 | Filter (#0 > 0), !(isnull(#1))
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Filter !(isnull(#1))
 | ArrangeBy (#1)
 
 %2 =
-| Get materialize.public.t3 (u5)
+| Get materialize.public.t3 (u3)
 | Filter (#0 > 0)
 
 %3 =
@@ -109,16 +122,16 @@ EXPLAIN SELECT * FROM lineitem
   AND o_orderdate = l_shipDATE - INTERVAL ' 9 MONTHS ';
 ----
 %0 =
-| Get materialize.public.lineitem (u15)
+| Get materialize.public.lineitem (u10)
 | ArrangeBy ()
 
 %1 =
-| Get materialize.public.orders (u11)
+| Get materialize.public.orders (u7)
 | Filter !(isnull(#0))
 | ArrangeBy (#0, datetots(#3))
 
 %2 =
-| Get materialize.public.customer (u7)
+| Get materialize.public.customer (u4)
 
 %3 =
 | Join %0 %1 %2 (= #0 #8) (= datetots(#11) (#5 - 9 months))
@@ -137,17 +150,17 @@ EXPLAIN SELECT  MIN( o_orderkey  )
   AND o_orderkey  = (  SELECT l_orderkey  FROM lineitem  WHERE l_orderkey  =  38  )
 ----
 %0 = Let l0 =
-| Get materialize.public.lineitem (u15)
+| Get materialize.public.lineitem (u10)
 | Filter (#0 = 38)
 
 %1 =
-| Get materialize.public.lineitem (u15)
+| Get materialize.public.lineitem (u10)
 | Filter (#6 = 1997-01-25)
 | Project (#4)
 | ArrangeBy (#0)
 
 %2 =
-| Get materialize.public.orders (u11)
+| Get materialize.public.orders (u7)
 | ArrangeBy (#0)
 
 %3 =
@@ -200,19 +213,19 @@ EXPLAIN SELECT l_partkey AS col24843 , l_orderkey AS col24844 , l_partkey AS col
   AND l_extendedprice = MOD (o_totalprice , 5 ) ;
 ----
 %0 =
-| Get materialize.public.lineitem (u15)
+| Get materialize.public.lineitem (u10)
 | Filter (#4 = (#4 % 5))
 | Project (#0, #1, #4, #6)
 | ArrangeBy ()
 
 %1 =
-| Get materialize.public.orders (u11)
+| Get materialize.public.orders (u7)
 | Filter (#1 = 134), (#2 = (#2 % 5))
 | Project (#2, #3)
 | ArrangeBy (#0, #1)
 
 %2 =
-| Get materialize.public.customer (u7)
+| Get materialize.public.customer (u4)
 | Filter (#0 = 134)
 | Project ()
 
@@ -232,17 +245,17 @@ EXPLAIN SELECT *
   AND l_shipDATE = o_orderdate;
 ----
 %0 =
-| Get materialize.public.lineitem (u15)
+| Get materialize.public.lineitem (u10)
 | Filter (datetots(#7) = (#5 + 6 days))
 | ArrangeBy ()
 
 %1 =
-| Get materialize.public.orders (u11)
+| Get materialize.public.orders (u7)
 | Filter (#1 = 229)
 | ArrangeBy (#2, #3)
 
 %2 =
-| Get materialize.public.customer (u7)
+| Get materialize.public.customer (u4)
 | Filter (#0 = 229)
 
 %3 =

--- a/test/sqllogictest/transform/join_index.slt
+++ b/test/sqllogictest/transform/join_index.slt
@@ -29,13 +29,22 @@ INSERT INTO bar VALUES (1, 3), (-1, null), (null, 5)
 query T multiline
 EXPLAIN PLAN FOR select * from foo inner join bar on foo.a = bar.a where foo.a = 1
 ----
+Source materialize.public.foo (u1):
+| Filter (#0 = 1)
+| Project (#0, #1)
+
+Source materialize.public.bar (u2):
+| Filter (#0 = 1)
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.foo (u1)
 | Filter (#0 = 1)
 | ArrangeBy ()
 
 %1 =
-| Get materialize.public.bar (u3)
+| Get materialize.public.bar (u2)
 | Filter (#0 = 1)
 
 %2 =
@@ -56,13 +65,22 @@ select * from foo inner join bar on foo.a = bar.a where foo.a = 1
 query T multiline
 EXPLAIN PLAN FOR select * from foo inner join bar on foo.a = abs(bar.a) where mod(foo.a, 2) = 1
 ----
+Source materialize.public.foo (u1):
+| Filter (1 = (#0 % 2))
+| Project (#0, #1)
+
+Source materialize.public.bar (u2):
+| Filter (1 = (abs(#0) % 2))
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.foo (u1)
 | Filter (1 = (#0 % 2))
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.bar (u3)
+| Get materialize.public.bar (u2)
 | Filter (1 = (abs(#0) % 2))
 
 %2 =
@@ -88,13 +106,22 @@ NULL
 query T multiline
 EXPLAIN PLAN FOR select * from (select * from foo where a = 1) filtered_foo, bar where filtered_foo.a = bar.a
 ----
+Source materialize.public.foo (u1):
+| Filter (#0 = 1)
+| Project (#0, #1)
+
+Source materialize.public.bar (u2):
+| Filter (#0 = 1)
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.foo (u1)
 | Filter (#0 = 1)
 | ArrangeBy ()
 
 %1 =
-| Get materialize.public.bar (u3)
+| Get materialize.public.bar (u2)
 | Filter (#0 = 1)
 
 %2 =
@@ -131,16 +158,20 @@ from foo, bar, baz
 where foo.a = bar.a
   and baz.a = bar.b
 ----
+Source materialize.public.baz (u5):
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.foo (u1)
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.bar (u3)
+| Get materialize.public.bar (u2)
 | Filter !(isnull(#0)), !(isnull(#1))
 
 %2 =
-| Get materialize.public.baz (u7)
+| Get materialize.public.baz (u5)
 | ArrangeBy (#0)
 
 %3 =
@@ -184,11 +215,11 @@ where foo.a = bar.a
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.bar (u3)
+| Get materialize.public.bar (u2)
 | ArrangeBy (#0)
 
 %2 =
-| Get materialize.public.baz (u9)
+| Get materialize.public.baz (u6)
 | ArrangeBy (#0)
 
 %3 =
@@ -227,7 +258,7 @@ where nullif(foo.a, 0) = -bar.a
 | ArrangeBy (if (#0 = 0) then {null} else {#0})
 
 %1 =
-| Get materialize.public.bar (u3)
+| Get materialize.public.bar (u2)
 | ArrangeBy (-(#0))
 
 %2 =
@@ -267,7 +298,7 @@ where foo.a = bar.a
   and bar.a + 4 = baz.a
 ----
 %0 =
-| Get materialize.public.bar (u3)
+| Get materialize.public.bar (u2)
 | ArrangeBy ((#0 + 4))
 
 %1 =
@@ -275,7 +306,7 @@ where foo.a = bar.a
 | ArrangeBy (#0)
 
 %2 =
-| Get materialize.public.baz (u9)
+| Get materialize.public.baz (u6)
 | ArrangeBy (#0)
 
 %3 =
@@ -309,7 +340,7 @@ explain plan for select foo.b, bar.b from foo, bar, (select 1 as a) const where 
 | ArrangeBy ()
 
 %1 =
-| Get materialize.public.bar (u3)
+| Get materialize.public.bar (u2)
 
 %2 =
 | Join %0 %1 (= 1 (#0 / #2))
@@ -338,7 +369,7 @@ and bar.b - foo.b = foo.a / bar.a
 | ArrangeBy ()
 
 %1 =
-| Get materialize.public.bar (u3)
+| Get materialize.public.bar (u2)
 
 %2 =
 | Join %0 %1 (= -1 (#3 - #1) (#0 / #2))
@@ -369,18 +400,23 @@ FROM foo, bar, baz
 where foo.a = bar.a
   and foo.a + 4 = baz.a
 ----
+Source materialize.public.baz (u6):
+| Filter !(isnull(#0))
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.foo (u1)
 | Filter !(isnull(#0))
 | ArrangeBy ((#0 + 4))
 
 %1 =
-| Get materialize.public.bar (u3)
+| Get materialize.public.bar (u2)
 | Filter !(isnull(#0))
 | ArrangeBy (#0)
 
 %2 =
-| Get materialize.public.baz (u9)
+| Get materialize.public.baz (u6)
 | Filter !(isnull(#0))
 
 %3 =

--- a/test/sqllogictest/transform/lifting.slt
+++ b/test/sqllogictest/transform/lifting.slt
@@ -21,6 +21,10 @@ union all
 union all
 (select a, b, 2 from t)
 ----
+Source materialize.public.t (u1):
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.t (u1)
 
@@ -44,6 +48,10 @@ union all
 union all
 (select a, b, 2, 3 from t)
 ----
+Source materialize.public.t (u1):
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.t (u1)
 
@@ -67,6 +75,10 @@ union all
 union all
 (select a, b, 3 from t)
 ----
+Source materialize.public.t (u1):
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.t (u1)
 | Map 2
@@ -88,6 +100,11 @@ query T multiline
 explain
 select a, b from t where a = 1 group by a, b
 ----
+Source materialize.public.t (u1):
+| Filter (#0 = 1)
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.t (u1)
 | Filter (#0 = 1)
@@ -102,6 +119,11 @@ query T multiline
 explain
 select a, b from t where b = 1 group by a, b
 ----
+Source materialize.public.t (u1):
+| Filter (#1 = 1)
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.t (u1)
 | Filter (#1 = 1)
@@ -117,6 +139,10 @@ query T multiline
 explain
 select * from (select 1, a+1 from t), t;
 ----
+Source materialize.public.t (u1):
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.t (u1)
 | Map (#0 + 1)
@@ -138,6 +164,10 @@ query T multiline
 explain
 select * from (select b+1, 2, 1, a+1 from t), t;
 ----
+Source materialize.public.t (u1):
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.t (u1)
 | Map (#1 + 1), (#0 + 1)
@@ -159,6 +189,10 @@ query T multiline
 explain
 select * from (select 3, b+1, 2, a+2, 1, a+1 from t), t;
 ----
+Source materialize.public.t (u1):
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.t (u1)
 | Map (#1 + 1), (#0 + 2), (#0 + 1)
@@ -180,6 +214,10 @@ query T multiline
 explain
 select a+1 from (select 1 as a, b from t);
 ----
+Source materialize.public.t (u1):
+| Project ()
+
+Query:
 %0 =
 | Get materialize.public.t (u1)
 | Map 2
@@ -191,6 +229,10 @@ query T multiline
 explain
 select z+1 from (select 2 as y, a, 1 as z, b from t);
 ----
+Source materialize.public.t (u1):
+| Project ()
+
+Query:
 %0 =
 | Get materialize.public.t (u1)
 | Map 2
@@ -203,6 +245,10 @@ query T multiline
 explain
 select c1, c1 + a from (select 1 as c1, x as c2, 3 as c3 from generate_series(1, 3) as x union all select 1, x, 3 from generate_series(5, 8) as x), t;
 ----
+Source materialize.public.t (u1):
+| Project (#0)
+
+Query:
 %0 =
 | Constant () () () () () () ()
 
@@ -232,6 +278,10 @@ query T multiline
 explain typed plan for
 select c.* from (select f1, f2 from (select f2, f1 from (select 1 as f1), generate_series(2, 4) as f2) group by f2, f1) as c, t;
 ----
+Source materialize.public.t (u1):
+| Project ()
+
+Query:
 %0 =
 | Constant (2) (3) (4)
 | | types = (integer)
@@ -263,6 +313,10 @@ query T multiline
 explain typed plan for
 select c.* from (select f2, f1, f3 from (select f3, f2, f1 from generate_series(2, 4) as f2, generate_series(3, 5) as f3, (select 1 as f1)) group by f2, f3, f1) as c, t;
 ----
+Source materialize.public.t (u1):
+| Project ()
+
+Query:
 %0 =
 | Constant (2, 3) (2, 4) (2, 5) (3, 3) (3, 4) (3, 5) (4, 3) (4, 4) (4, 5)
 | | types = (integer, integer)
@@ -294,6 +348,10 @@ EOF
 query T multiline
 explain select * from (select 1 as a from t), generate_series(a+1, 4);
 ----
+Source materialize.public.t (u1):
+| Project ()
+
+Query:
 %0 =
 | Get materialize.public.t (u1)
 | Project ()
@@ -311,6 +369,10 @@ EOF
 query T multiline
 explain select 123 from (select 234 from t);
 ----
+Source materialize.public.t (u1):
+| Project ()
+
+Query:
 %0 =
 | Get materialize.public.t (u1)
 | Map 123
@@ -321,6 +383,10 @@ EOF
 query T multiline
 explain select 123 from (select distinct 234 from t);
 ----
+Source materialize.public.t (u1):
+| Project ()
+
+Query:
 %0 =
 | Get materialize.public.t (u1)
 | Project ()
@@ -332,6 +398,10 @@ EOF
 query T multiline
 explain select distinct 123 from (select 234 from t);
 ----
+Source materialize.public.t (u1):
+| Project ()
+
+Query:
 %0 =
 | Get materialize.public.t (u1)
 | Project ()
@@ -343,6 +413,10 @@ EOF
 query T multiline
 explain select distinct 123 from (select distinct 234 from t);
 ----
+Source materialize.public.t (u1):
+| Project ()
+
+Query:
 %0 =
 | Get materialize.public.t (u1)
 | Project ()
@@ -356,6 +430,10 @@ EOF
 query T multiline
 explain select * from (select distinct 123 from t);
 ----
+Source materialize.public.t (u1):
+| Project ()
+
+Query:
 %0 =
 | Get materialize.public.t (u1)
 | Project ()
@@ -367,6 +445,10 @@ EOF
 query T multiline
 explain select distinct * from (select 123 from t);
 ----
+Source materialize.public.t (u1):
+| Project ()
+
+Query:
 %0 =
 | Get materialize.public.t (u1)
 | Project ()
@@ -380,6 +462,10 @@ EOF
 query T multiline
 explain select 123 from (select a from t);
 ----
+Source materialize.public.t (u1):
+| Project ()
+
+Query:
 %0 =
 | Get materialize.public.t (u1)
 | Map 123
@@ -390,6 +476,10 @@ EOF
 query T multiline
 explain select 123 from (select distinct a from t);
 ----
+Source materialize.public.t (u1):
+| Project (#0)
+
+Query:
 %0 =
 | Get materialize.public.t (u1)
 | Project (#0)
@@ -402,6 +492,10 @@ EOF
 query T multiline
 explain select distinct 123 from (select a from t);
 ----
+Source materialize.public.t (u1):
+| Project ()
+
+Query:
 %0 =
 | Get materialize.public.t (u1)
 | Project ()
@@ -413,6 +507,10 @@ EOF
 query T multiline
 explain select distinct 123 from (select distinct a from t);
 ----
+Source materialize.public.t (u1):
+| Project ()
+
+Query:
 %0 =
 | Get materialize.public.t (u1)
 | Project ()
@@ -426,6 +524,10 @@ EOF
 query T multiline
 explain select distinct a1.a, a1.literal from (select a, 123 as literal from t) as a1;
 ----
+Source materialize.public.t (u1):
+| Project (#0)
+
+Query:
 %0 =
 | Get materialize.public.t (u1)
 | Project (#0)
@@ -437,6 +539,10 @@ EOF
 query T multiline
 explain select a1.a, a1.literal from (select distinct a, 123 as literal from t) as a1;
 ----
+Source materialize.public.t (u1):
+| Project (#0)
+
+Query:
 %0 =
 | Get materialize.public.t (u1)
 | Project (#0)
@@ -448,6 +554,10 @@ EOF
 query T multiline
 explain select a1.a, a1.literal from (select distinct a, 123 as literal from t) as a1;
 ----
+Source materialize.public.t (u1):
+| Project (#0)
+
+Query:
 %0 =
 | Get materialize.public.t (u1)
 | Project (#0)
@@ -459,6 +569,10 @@ EOF
 query T multiline
 explain select distinct a1.a, a1.literal from (select distinct a, 123 as literal from t) as a1;
 ----
+Source materialize.public.t (u1):
+| Project (#0)
+
+Query:
 %0 =
 | Get materialize.public.t (u1)
 | Project (#0)
@@ -472,6 +586,10 @@ EOF
 query T multiline
 explain select distinct a1.a, 123 from (select a from t) as a1;
 ----
+Source materialize.public.t (u1):
+| Project (#0)
+
+Query:
 %0 =
 | Get materialize.public.t (u1)
 | Project (#0)
@@ -483,6 +601,10 @@ EOF
 query T multiline
 explain select distinct a1.a, 123 from (select distinct a from t) as a1;
 ----
+Source materialize.public.t (u1):
+| Project (#0)
+
+Query:
 %0 =
 | Get materialize.public.t (u1)
 | Project (#0)
@@ -495,6 +617,10 @@ EOF
 query T multiline
 explain select distinct a1.a+2 from (select distinct a+1 as a, 123 as literal from t) as a1;
 ----
+Source materialize.public.t (u1):
+| Project (#0)
+
+Query:
 %0 =
 | Get materialize.public.t (u1)
 | Project (#0)
@@ -505,6 +631,10 @@ EOF
 query T multiline
 explain select distinct a1.a, 123 from (select distinct a+1 as a, 234 as literal from t) as a1;
 ----
+Source materialize.public.t (u1):
+| Project (#0)
+
+Query:
 %0 =
 | Get materialize.public.t (u1)
 | Project (#0)
@@ -516,6 +646,10 @@ EOF
 query T multiline
 explain select distinct a1.a+2, a1.literal from (select distinct a+1 as a, 123 as literal from t) as a1;
 ----
+Source materialize.public.t (u1):
+| Project (#0)
+
+Query:
 %0 =
 | Get materialize.public.t (u1)
 | Project (#0)
@@ -528,6 +662,10 @@ EOF
 query T multiline
 explain select distinct a1.a, a1.literal + 1 from (select distinct a, 123 as literal from t) as a1;
 ----
+Source materialize.public.t (u1):
+| Project (#0)
+
+Query:
 %0 =
 | Get materialize.public.t (u1)
 | Project (#0)
@@ -547,8 +685,12 @@ create table t_pk (
 query T multiline
 explain select a1.*, 123 from t_pk as a1, t_pk as a2 WHERE a1.a = a2.a;
 ----
+Source materialize.public.t_pk (u2):
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.t_pk (u3)
+| Get materialize.public.t_pk (u2)
 | Map 123
 
 EOF
@@ -556,8 +698,12 @@ EOF
 query T multiline
 explain select distinct a1.*, 123 from t_pk as a1, t_pk as a2 WHERE a1.a = a2.a;
 ----
+Source materialize.public.t_pk (u2):
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.t_pk (u3)
+| Get materialize.public.t_pk (u2)
 | Map 123
 
 EOF
@@ -567,6 +713,11 @@ query T multiline
 explain
 select a, b, max(2), count(*) from t where b = 1 group by a, b;
 ----
+Source materialize.public.t (u1):
+| Filter (#1 = 1)
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.t (u1)
 | Filter (#1 = 1)
@@ -582,6 +733,11 @@ query T multiline
 explain
 select a, b, count(*), max(2) from t where b = 1 group by a, b;
 ----
+Source materialize.public.t (u1):
+| Filter (#1 = 1)
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.t (u1)
 | Filter (#1 = 1)
@@ -597,6 +753,11 @@ query T multiline
 explain
 select a, b, min(2), max(3) from t where b = 1 group by a, b;
 ----
+Source materialize.public.t (u1):
+| Filter (#1 = 1)
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.t (u1)
 | Filter (#1 = 1)
@@ -610,6 +771,10 @@ EOF
 query T multiline
 explain select min(1/x) from (select a as y, 0 as x from t);
 ----
+Source materialize.public.t (u1):
+| Project ()
+
+Query:
 %0 = Let l0 =
 | Get materialize.public.t (u1)
 | Project ()
@@ -638,6 +803,10 @@ EOF
 query T multiline
 explain select sum(1/x) from (select a as y, 0 as x from t);
 ----
+Source materialize.public.t (u1):
+| Project ()
+
+Query:
 %0 = Let l0 =
 | Get materialize.public.t (u1)
 | Project ()
@@ -666,12 +835,23 @@ EOF
 query T multiline
 explain select min(a) from t_pk where a between 38 and 195 and a = (select a from t where a = 1308);
 ----
+Source materialize.public.t (u1):
+| Filter (#0 = 1308)
+| Project (#0)
+
+Source materialize.public.t_pk (u2):
+| Filter (#0 <= 195), (#0 >= 38)
+| Project (#0)
+
+Query:
 %0 = Let l0 =
 | Get materialize.public.t (u1)
 | Filter (#0 = 1308)
 
 %1 =
-| Get materialize.public.t_pk (u3)
+| Get materialize.public.t_pk (u2)
+| Filter (#0 <= 195), (#0 >= 38)
+| Project (#0)
 | ArrangeBy (#0)
 
 %2 =
@@ -691,9 +871,8 @@ explain select min(a) from t_pk where a between 38 and 195 and a = (select a fro
 | Union %2 %3
 
 %5 = Let l1 =
-| Join %1 %4 (= #0 #2)
+| Join %1 %4 (= #0 #1)
 | | implementation = Differential %4 %1.(#0)
-| Filter (#0 <= 195), (#0 >= 38)
 | Project (#0)
 | Reduce group=()
 | | agg min(#0)
@@ -718,6 +897,10 @@ EOF
 query T multiline
 explain select min(a) from t where a between 38 and 195 and a = (select a from t where a = 1308);
 ----
+Source materialize.public.t (u1):
+| Project (#0)
+
+Query:
 %0 = Let l0 =
 | Get materialize.public.t (u1)
 | Filter (#0 = 1308)
@@ -807,16 +990,20 @@ create table t1 (f1 double precision, f2 double precision not null);
 query T multiline
 explain select * from t1 as a1 join t1 as a2 on (a2.f2 = (select 6 from t1)) where a2.f2 = 9;
 ----
+Source materialize.public.t1 (u3):
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.t1 (u5)
+| Get materialize.public.t1 (u3)
 | ArrangeBy ()
 
 %1 =
-| Get materialize.public.t1 (u5)
+| Get materialize.public.t1 (u3)
 | Filter (#1 = 9)
 
 %2 =
-| Get materialize.public.t1 (u5)
+| Get materialize.public.t1 (u3)
 | Project ()
 | Reduce group=()
 | | agg count(true)

--- a/test/sqllogictest/transform/predicate_pushdown.slt
+++ b/test/sqllogictest/transform/predicate_pushdown.slt
@@ -18,6 +18,11 @@ CREATE TABLE y (a int not null)
 query T multiline
 EXPLAIN PLAN FOR SELECT b FROM (SELECT b, not(b) as neg FROM x) WHERE NOT(neg)
 ----
+Source materialize.public.x (u1):
+| Filter #2
+| Project (#2)
+
+Query:
 %0 =
 | Get materialize.public.x (u1)
 | Filter #2
@@ -28,6 +33,11 @@ EOF
 query T multiline
 EXPLAIN PLAN FOR SELECT b FROM (SELECT b, b = false as neg FROM x) WHERE NOT(neg)
 ----
+Source materialize.public.x (u1):
+| Filter (#2 != false)
+| Project (#2)
+
+Query:
 %0 =
 | Get materialize.public.x (u1)
 | Filter (#2 != false)
@@ -41,6 +51,11 @@ query T multiline
 EXPLAIN PLAN FOR
   SELECT a FROM (SELECT a, a = 3 AS cond, u != 2 as cond2 FROM x) WHERE NOT(cond) AND NOT(cond2)
 ----
+Source materialize.public.x (u1):
+| Filter (#1 = 2), (#0 != 3)
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.x (u1)
 | Filter (#1 = 2), (#0 != 3)
@@ -54,6 +69,10 @@ query T multiline
 EXPLAIN PLAN FOR
   SELECT a FROM (SELECT a, (a + 1) = (u + 3) AS cond FROM x) WHERE NOT(cond)
 ----
+Source materialize.public.x (u1):
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.x (u1)
 | Filter ((#0 + 1) != (#1 + 3))
@@ -71,8 +90,13 @@ EXPLAIN PLAN FOR
       (SELECT a, a+1 as b FROM y))
 WHERE b = 3 AND c = 3
 ----
+Source materialize.public.y (u2):
+| Filter (3 = (#0 + 1))
+| Project (#0)
+
+Query:
 %0 =
-| Get materialize.public.y (u3)
+| Get materialize.public.y (u2)
 | Filter (3 = (#0 + 1))
 | Map (#0 + 1), (#1 + 1)
 | Filter (#2 = 3)
@@ -104,7 +128,7 @@ SELECT a FROM (SELECT DISTINCT a FROM x UNION ALL SELECT a FROM y) WHERE a = 3
 | Project (#1)
 
 %4 =
-| Get materialize.public.y (u3)
+| Get materialize.public.y (u2)
 
 %5 = Let l2 =
 | Join %0 %4
@@ -126,6 +150,15 @@ query T multiline
 EXPLAIN PLAN FOR
 SELECT a FROM (SELECT DISTINCT a FROM x UNION ALL SELECT a FROM y) WHERE a = 3
 ----
+Source materialize.public.x (u1):
+| Filter (#0 = 3)
+| Project (#0)
+
+Source materialize.public.y (u2):
+| Filter (#0 = 3)
+| Project (#0)
+
+Query:
 %0 =
 | Get materialize.public.x (u1)
 | Filter (#0 = 3)
@@ -134,7 +167,7 @@ SELECT a FROM (SELECT DISTINCT a FROM x UNION ALL SELECT a FROM y) WHERE a = 3
 | Map 3
 
 %1 =
-| Get materialize.public.y (u3)
+| Get materialize.public.y (u2)
 | Filter (#0 = 3)
 
 %2 =
@@ -153,20 +186,27 @@ query T multiline
 EXPLAIN
 SELECT * FROM t1, t2 WHERE t1.f1 = t2.f1 AND t1.f2 = t2.f2 AND t1.f1 + t2.f2 = t2.f1 + t1.f2;
 ----
+Source materialize.public.t1 (u3):
+| Filter !(isnull(#0)), !(isnull(#1))
+| Project (#0, #1)
+
+Source materialize.public.t2 (u4):
+| Filter !(isnull(#0)), !(isnull(#1))
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.t1 (u5)
+| Get materialize.public.t1 (u3)
+| Filter !(isnull(#0)), !(isnull(#1))
 | ArrangeBy (#0, #1)
 
 %1 =
-| Get materialize.public.t2 (u7)
-| ArrangeBy (#0, #1)
+| Get materialize.public.t2 (u4)
+| Filter !(isnull(#0)), !(isnull(#1))
 
 %2 =
 | Join %0 %1 (= #0 #2) (= #1 #3)
-| | implementation = DeltaQuery
-| |   delta %0 %1.(#0, #1)
-| |   delta %1 %0.(#0, #1)
-| Filter !(isnull(#0)), !(isnull(#1))
+| | implementation = Differential %1 %0.(#0, #1)
 | Project (#0, #1, #0, #1)
 
 EOF
@@ -176,12 +216,19 @@ query T multiline
 EXPLAIN
 select * from t1, t2 where t1.f1 = t2.f1 + 1 or (t1.f1 is null and t2.f1 is null);
 ----
+Source materialize.public.t1 (u3):
+| Project (#0, #1)
+
+Source materialize.public.t2 (u4):
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.t1 (u5)
+| Get materialize.public.t1 (u3)
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.t2 (u7)
+| Get materialize.public.t2 (u4)
 
 %2 =
 | Join %0 %1 (= #0 (#2 + 1))
@@ -193,12 +240,19 @@ query T multiline
 EXPLAIN
 select * from t1, t2 where t1.f1 = t2.f1 + 1 or (t1.f1 is null and (t2.f1 + 1) is null);
 ----
+Source materialize.public.t1 (u3):
+| Project (#0, #1)
+
+Source materialize.public.t2 (u4):
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.t1 (u5)
+| Get materialize.public.t1 (u3)
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.t2 (u7)
+| Get materialize.public.t2 (u4)
 
 %2 =
 | Join %0 %1 (= #0 (#2 + 1))
@@ -210,12 +264,19 @@ query T multiline
 EXPLAIN
 select * from t1, t2 where t2.f1 = t1.f1 + 1 or (t1.f1 is null and (t2.f1 + 1) is null);
 ----
+Source materialize.public.t1 (u3):
+| Project (#0, #1)
+
+Source materialize.public.t2 (u4):
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.t1 (u5)
+| Get materialize.public.t1 (u3)
 | ArrangeBy ((#0 + 1))
 
 %1 =
-| Get materialize.public.t2 (u7)
+| Get materialize.public.t2 (u4)
 
 %2 =
 | Join %0 %1 (= #2 (#0 + 1))
@@ -227,12 +288,19 @@ query T multiline
 EXPLAIN
 select * from t1, t2 where t2.f1 = t1.f1 + 1 or (t1.f1 is null and ((t2.f1 + 1) is null and t1.f1 is null));
 ----
+Source materialize.public.t1 (u3):
+| Project (#0, #1)
+
+Source materialize.public.t2 (u4):
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.t1 (u5)
+| Get materialize.public.t1 (u3)
 | ArrangeBy ((#0 + 1))
 
 %1 =
-| Get materialize.public.t2 (u7)
+| Get materialize.public.t2 (u4)
 
 %2 =
 | Join %0 %1 (= #2 (#0 + 1))

--- a/test/sqllogictest/transform/predicate_reduction.slt
+++ b/test/sqllogictest/transform/predicate_reduction.slt
@@ -25,6 +25,11 @@ NULL
 query T multiline
 EXPLAIN SELECT * FROM t1 WHERE f1 = 0 and (f1 = 0 or f1 = 1)
 ----
+Source materialize.public.t1 (u1):
+| Filter (#0 = 0)
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 | Filter (#0 = 0)
@@ -34,6 +39,11 @@ EOF
 query T multiline
 EXPLAIN SELECT * FROM t1 WHERE f1 is null and (f1 is null or f1 = 1)
 ----
+Source materialize.public.t1 (u1):
+| Filter isnull(#0)
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 | Filter isnull(#0)
@@ -54,6 +64,11 @@ NULL
 query T multiline
 EXPLAIN SELECT * FROM t1 WHERE f1 is not null and (f1 is null or f1 = 1)
 ----
+Source materialize.public.t1 (u1):
+| Filter (#0 = 1)
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 | Filter (#0 = 1)
@@ -106,8 +121,13 @@ INSERT INTO t2 VALUES (0, -1), (1, 5), (1, -2)
 query T multiline
 EXPLAIN SELECT * FROM t2 WHERE f1 + f2 > 0 and case when f1 + f2 > 0 then 1/f1 > 0 else false end;
 ----
+Source materialize.public.t2 (u2):
+| Filter ((#0 + #1) > 0), if ((#0 + #1) > 0) then {((1 / #0) > 0)} else {false}
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Map ((#0 + #1) > 0)
 | Filter #2, if #2 then {((1 / #0) > 0)} else {false}
 | Project (#0, #1)
@@ -117,8 +137,13 @@ EOF
 query T multiline
 EXPLAIN SELECT * FROM t2 WHERE case when f1 + f2 > 0 then 1/f1 > 0 else false end and f1 + f2 > 0;
 ----
+Source materialize.public.t2 (u2):
+| Filter ((#0 + #1) > 0), if ((#0 + #1) > 0) then {((1 / #0) > 0)} else {false}
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Map ((#0 + #1) > 0)
 | Filter #2, if #2 then {((1 / #0) > 0)} else {false}
 | Project (#0, #1)

--- a/test/sqllogictest/transform/reduce_fusion.slt
+++ b/test/sqllogictest/transform/reduce_fusion.slt
@@ -13,6 +13,10 @@ CREATE TABLE t (f0 int, f1 int, f2 int)
 query T multiline
 EXPLAIN SELECT DISTINCT * FROM t GROUP BY f1, f2, f0
 ----
+Source materialize.public.t (u1):
+| Project (#0..=#2)
+
+Query:
 %0 =
 | Get materialize.public.t (u1)
 | Distinct group=(#0, #1, #2)
@@ -22,6 +26,10 @@ EOF
 query T multiline
 EXPLAIN SELECT DISTINCT r0 FROM (SELECT DISTINCT f1 + 1 as r0, f0 FROM t)
 ----
+Source materialize.public.t (u1):
+| Project (#1)
+
+Query:
 %0 =
 | Get materialize.public.t (u1)
 | Project (#1)
@@ -32,6 +40,10 @@ EOF
 query T multiline
 EXPLAIN SELECT DISTINCT f1 FROM (SELECT DISTINCT f0, f1 FROM t)
 ----
+Source materialize.public.t (u1):
+| Project (#1)
+
+Query:
 %0 =
 | Get materialize.public.t (u1)
 | Project (#1)
@@ -42,6 +54,10 @@ EOF
 query T multiline
 EXPLAIN SELECT DISTINCT FROM (SELECT DISTINCT f0, f1 FROM t)
 ----
+Source materialize.public.t (u1):
+| Project ()
+
+Query:
 %0 =
 | Get materialize.public.t (u1)
 | Project ()
@@ -52,6 +68,10 @@ EOF
 query T multiline
 EXPLAIN SELECT DISTINCT FROM (SELECT DISTINCT f0 FROM (SELECT DISTINCT f0, f1 FROM t));
 ----
+Source materialize.public.t (u1):
+| Project ()
+
+Query:
 %0 =
 | Get materialize.public.t (u1)
 | Project ()
@@ -62,6 +82,10 @@ EOF
 query T multiline
 EXPLAIN SELECT f0 FROM (SELECT f0 FROM t GROUP BY f1 / 10, f0) GROUP BY f0;
 ----
+Source materialize.public.t (u1):
+| Project (#0)
+
+Query:
 %0 =
 | Get materialize.public.t (u1)
 | Project (#0)
@@ -72,6 +96,10 @@ EOF
 query T multiline
 EXPLAIN SELECT f0 / 20 FROM (SELECT f0 / 10 AS f0 FROM t GROUP BY f0 / 10) GROUP BY f0 / 20;
 ----
+Source materialize.public.t (u1):
+| Project (#0)
+
+Query:
 %0 =
 | Get materialize.public.t (u1)
 | Project (#0)

--- a/test/sqllogictest/transform/redundant_join.slt
+++ b/test/sqllogictest/transform/redundant_join.slt
@@ -17,6 +17,11 @@ query T multiline
 EXPLAIN
 SELECT * FROM t1, (SELECT DISTINCT f1 % 2 AS F FROM t1) T WHERE t1.f1 % 2 = t.f;
 ----
+Source materialize.public.t1 (u1):
+| Filter !(isnull(#0))
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 | Filter !(isnull(#0))
@@ -29,7 +34,7 @@ EXPLAIN
 SELECT * FROM v1, (SELECT DISTINCT (v1.t1).f1 as f1 FROM v1) Y WHERE (v1.t1).f1 = y.f1;
 ----
 %0 =
-| Get materialize.public.v1 (u3)
+| Get materialize.public.v1 (u2)
 | Filter !(isnull(record_get[0](#0)))
 | Map record_get[0](#0)
 

--- a/test/sqllogictest/transform/scalar_cse.slt
+++ b/test/sqllogictest/transform/scalar_cse.slt
@@ -15,6 +15,10 @@ CREATE TABLE x (a string, b int not null)
 query T multiline
 EXPLAIN PLAN FOR SELECT b*b*b, b*b FROM x
 ----
+Source materialize.public.x (u1):
+| Project (#1)
+
+Query:
 %0 =
 | Get materialize.public.x (u1)
 | Map (#1 * #1), (#2 * #1)
@@ -25,6 +29,10 @@ EOF
 query T multiline
 EXPLAIN PLAN FOR SELECT b*b*b, b*b+1 FROM x
 ----
+Source materialize.public.x (u1):
+| Project (#1)
+
+Query:
 %0 =
 | Get materialize.public.x (u1)
 | Map (#1 * #1), (#2 * #1), (#2 + 1)
@@ -39,6 +47,10 @@ EXPLAIN PLAN FOR SELECT
     a::json->'Field3'
 FROM x
 ----
+Source materialize.public.x (u1):
+| Project (#0)
+
+Query:
 %0 =
 | Get materialize.public.x (u1)
 | Map strtojsonb(#0), (#2 -> "Field1"), (#2 -> "Field2"), (#2 -> "Field3")
@@ -54,6 +66,10 @@ EXPLAIN PLAN FOR SELECT
     a::json->'Field2'->'Quux'->'Zorb'
 FROM x
 ----
+Source materialize.public.x (u1):
+| Project (#0)
+
+Query:
 %0 =
 | Get materialize.public.x (u1)
 | Map strtojsonb(#0), (#2 -> "Field1"), (#3 -> "Foo"), (#3 -> "Bar"), (#2 -> "Field2"), (#6 -> "Baz"), ((#6 -> "Quux") -> "Zorb")
@@ -69,6 +85,10 @@ EXPLAIN PLAN FOR SELECT
     CASE WHEN b != 0 THEN 1/b ELSE 0 END
 FROM x
 ----
+Source materialize.public.x (u1):
+| Project (#1)
+
+Query:
 %0 =
 | Get materialize.public.x (u1)
 | Map if (#1 = 0) then {0} else {(1 / #1)}, if (#1 != 0) then {(1 / #1)} else {0}
@@ -87,6 +107,10 @@ FROM
     (SELECT b/2 as b FROM x)
 
 ----
+Source materialize.public.x (u1):
+| Project (#1)
+
+Query:
 %0 =
 | Get materialize.public.x (u1)
 | Map (#1 / 2), if (#2 = 0) then {0} else {(1 / #2)}, if (#2 != 0) then {(1 / #2)} else {0}

--- a/test/sqllogictest/transform/topk.slt
+++ b/test/sqllogictest/transform/topk.slt
@@ -25,6 +25,10 @@ ORDER BY d LIMIT 4
 )
 GROUP BY sumc, sumd
 ----
+Source materialize.public.test1 (u1):
+| Project (#0..=#3)
+
+Query:
 %0 =
 | Get materialize.public.test1 (u1)
 | Map (#0 + #1), (#4 + #2), (#4 + #3)
@@ -52,6 +56,10 @@ ORDER BY sumc
 query T multiline
 EXPLAIN PLAN FOR VIEW plan_test1
 ----
+Source materialize.public.test1 (u1):
+| Project (#0..=#3)
+
+Query:
 %0 =
 | Get materialize.public.test1 (u1)
 | Reduce group=(((#0 + #1) + #2), ((#0 + #1) + #3))
@@ -66,6 +74,10 @@ EOF
 query T multiline
 EXPLAIN PLAN FOR SELECT * FROM test1 UNION ALL SELECT * FROM test1 UNION ALL SELECT * FROM test1
 ----
+Source materialize.public.test1 (u1):
+| Project (#0..=#3)
+
+Query:
 %0 =
 | Get materialize.public.test1 (u1)
 
@@ -108,8 +120,12 @@ create materialized view v1 as select * from (select * from t1 order by f1 limit
 query T multiline
 explain view v1;
 ----
+Source materialize.public.t1 (u5):
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.t1 (u7)
+| Get materialize.public.t1 (u5)
 | TopK group=() order=(#0 asc) limit=3 offset=3
 
 EOF

--- a/test/sqllogictest/transform/union.slt
+++ b/test/sqllogictest/transform/union.slt
@@ -31,6 +31,13 @@ INSERT INTO t3 VALUES (2, 3), (5, 5), (5, 5), (6, 1)
 query T multiline
 EXPLAIN (SELECT * FROM t1 UNION ALL SELECT * FROM t1) UNION ALL (SELECT * FROM t2 UNION ALL SELECT * FROM t2);
 ----
+Source materialize.public.t1 (u1):
+| Project (#0, #1)
+
+Source materialize.public.t2 (u2):
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 
@@ -38,10 +45,10 @@ EXPLAIN (SELECT * FROM t1 UNION ALL SELECT * FROM t1) UNION ALL (SELECT * FROM t
 | Get materialize.public.t1 (u1)
 
 %2 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 
 %3 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 
 %4 =
 | Union %0 %1 %2 %3
@@ -66,8 +73,15 @@ query II
 query T multiline
 EXPLAIN (SELECT * FROM t1 UNION ALL SELECT * FROM t1) EXCEPT ALL (SELECT * FROM t2 UNION ALL SELECT * FROM t2);
 ----
+Source materialize.public.t1 (u1):
+| Project (#0, #1)
+
+Source materialize.public.t2 (u2):
+| Project (#0, #1)
+
+Query:
 %0 = Let l0 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Negate
 
 %1 =
@@ -93,8 +107,18 @@ query II
 query T multiline
 EXPLAIN PLAN FOR SELECT * FROM t2  EXCEPT ALL SELECT * FROM t1 INTERSECT ALL SELECT * FROM t3;
 ----
+Source materialize.public.t1 (u1):
+| Project (#0, #1)
+
+Source materialize.public.t2 (u2):
+| Project (#0, #1)
+
+Source materialize.public.t3 (u3):
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 
 %1 =
 | Get materialize.public.t1 (u1)
@@ -104,7 +128,7 @@ EXPLAIN PLAN FOR SELECT * FROM t2  EXCEPT ALL SELECT * FROM t1 INTERSECT ALL SEL
 | Get materialize.public.t1 (u1)
 
 %3 =
-| Get materialize.public.t3 (u5)
+| Get materialize.public.t3 (u3)
 | Negate
 
 %4 =
@@ -125,8 +149,18 @@ SELECT * FROM t2  EXCEPT ALL SELECT * FROM t1 INTERSECT ALL SELECT * FROM t3;
 query T multiline
 EXPLAIN PLAN FOR SELECT * FROM t2 EXCEPT ALL (SELECT * FROM t1 INTERSECT ALL SELECT f1, null::int FROM t3);
 ----
+Source materialize.public.t1 (u1):
+| Project (#0, #1)
+
+Source materialize.public.t2 (u2):
+| Project (#0, #1)
+
+Source materialize.public.t3 (u3):
+| Project (#0)
+
+Query:
 %0 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 
 %1 =
 | Get materialize.public.t1 (u1)
@@ -136,7 +170,7 @@ EXPLAIN PLAN FOR SELECT * FROM t2 EXCEPT ALL (SELECT * FROM t1 INTERSECT ALL SEL
 | Get materialize.public.t1 (u1)
 
 %3 =
-| Get materialize.public.t3 (u5)
+| Get materialize.public.t3 (u3)
 | Project (#0)
 | Negate
 | Map null
@@ -160,13 +194,21 @@ SELECT * FROM t2 EXCEPT ALL (SELECT * FROM t1 INTERSECT ALL SELECT f1, null::int
 query T multiline
 EXPLAIN SELECT a1.* FROM t3 AS a1 LEFT JOIN t2 AS a2 ON (a1.f1 = a2.nokey);
 ----
+Source materialize.public.t2 (u2):
+| Filter !(isnull(#1))
+| Project (#1)
+
+Source materialize.public.t3 (u3):
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.t3 (u5)
+| Get materialize.public.t3 (u3)
 | Filter !(isnull(#0))
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Filter !(isnull(#1))
 | Project (#1)
 
@@ -176,7 +218,7 @@ EXPLAIN SELECT a1.* FROM t3 AS a1 LEFT JOIN t2 AS a2 ON (a1.f1 = a2.nokey);
 | Project (#0, #1)
 
 %3 =
-| Get materialize.public.t3 (u5)
+| Get materialize.public.t3 (u3)
 
 %4 =
 | Get %2 (l0)
@@ -191,7 +233,7 @@ EXPLAIN SELECT a1.* FROM t3 AS a1 LEFT JOIN t2 AS a2 ON (a1.f1 = a2.nokey);
 | Negate
 
 %6 =
-| Get materialize.public.t3 (u5)
+| Get materialize.public.t3 (u3)
 
 %7 =
 | Union %5 %6 %2

--- a/test/sqllogictest/transform/union_cancel.slt
+++ b/test/sqllogictest/transform/union_cancel.slt
@@ -30,6 +30,10 @@ INSERT INTO t3 VALUES (4, 5), (5, 5), (5, 5), (null, null)
 query T multiline
 EXPLAIN SELECT * FROM t1
 ----
+Source materialize.public.t1 (u1):
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 
@@ -45,6 +49,10 @@ SELECT * FROM t1
 query T multiline
 EXPLAIN SELECT a1.* FROM t1 AS a1 LEFT JOIN t1 AS a2 ON (a1.key = a2.key)
 ----
+Source materialize.public.t1 (u1):
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 
@@ -60,6 +68,11 @@ SELECT a1.* FROM t1 AS a1 LEFT JOIN t1 AS a2 ON (a1.key = a2.key)
 query T multiline
 EXPLAIN SELECT * FROM t1 AS a1 LEFT JOIN t1 AS a2 ON (a1.key = a2.key) WHERE a1.nokey = 1
 ----
+Source materialize.public.t1 (u1):
+| Filter (#1 = 1)
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 | Filter (#1 = 1)
@@ -88,6 +101,10 @@ SELECT * FROM t1 EXCEPT ALL SELECT * FROM t1
 query T multiline
 EXPLAIN SELECT * FROM t1 UNION ALL SELECT * FROM t1 EXCEPT ALL SELECT * FROM t1
 ----
+Source materialize.public.t1 (u1):
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 | Threshold
@@ -104,6 +121,10 @@ SELECT * FROM t1 UNION ALL SELECT * FROM t1 EXCEPT ALL SELECT * FROM t1
 query T multiline
 EXPLAIN SELECT * FROM t1 EXCEPT ALL SELECT * FROM t1 UNION ALL SELECT * FROM t1
 ----
+Source materialize.public.t1 (u1):
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.t1 (u1)
 
@@ -119,8 +140,12 @@ SELECT * FROM t1 EXCEPT ALL SELECT * FROM t1 UNION ALL SELECT * FROM t1
 query T multiline
 EXPLAIN SELECT * FROM t1 UNION ALL SELECT * FROM t2 EXCEPT ALL SELECT * FROM t1
 ----
+Source materialize.public.t2 (u2):
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Threshold
 
 EOF
@@ -134,8 +159,12 @@ SELECT * FROM t1 UNION ALL SELECT * FROM t2 EXCEPT ALL SELECT * FROM t1
 query T multiline
 EXPLAIN SELECT * FROM t2 UNION ALL SELECT * FROM t1 EXCEPT ALL SELECT * FROM t1
 ----
+Source materialize.public.t2 (u2):
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 | Threshold
 
 EOF
@@ -149,8 +178,15 @@ SELECT * FROM t2 UNION ALL SELECT * FROM t1 EXCEPT ALL SELECT * FROM t1
 query T multiline
 EXPLAIN SELECT * FROM t2 EXCEPT ALL SELECT * FROM t1 UNION ALL SELECT * FROM t1
 ----
+Source materialize.public.t1 (u1):
+| Project (#0, #1)
+
+Source materialize.public.t2 (u2):
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 
 %1 =
 | Get materialize.public.t1 (u1)
@@ -181,8 +217,12 @@ EXPLAIN
 WITH t3_with_key AS (select f1 as key, sum(f2) as nokey from t3 group by f1)
 SELECT a1.* FROM t3_with_key AS a1 LEFT JOIN t3_with_key AS a2 ON (a1.key = a2.key)
 ----
+Source materialize.public.t3 (u3):
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.t3 (u5)
+| Get materialize.public.t3 (u3)
 | Reduce group=(#0)
 | | agg sum(#1)
 
@@ -201,12 +241,16 @@ EXPLAIN
 WITH t3_with_key AS (select f1 as key, sum(f2) as nokey from t3 group by f1)
 SELECT a1.* FROM t3 AS a1 LEFT JOIN t3_with_key AS a2 ON (a1.f1 = a2.key);
 ----
+Source materialize.public.t3 (u3):
+| Project (#0, #1)
+
+Query:
 %0 = Let l0 =
-| Get materialize.public.t3 (u5)
+| Get materialize.public.t3 (u3)
 | Filter !(isnull(#0))
 
 %1 =
-| Get materialize.public.t3 (u5)
+| Get materialize.public.t3 (u3)
 
 %2 =
 | Get %0 (l0)
@@ -221,7 +265,7 @@ SELECT a1.* FROM t3 AS a1 LEFT JOIN t3_with_key AS a2 ON (a1.f1 = a2.key);
 | Negate
 
 %4 =
-| Get materialize.public.t3 (u5)
+| Get materialize.public.t3 (u3)
 
 %5 =
 | Union %3 %4 %0
@@ -242,8 +286,12 @@ EXPLAIN
 WITH t3_with_key AS (select f1 as key, sum(f2) as nokey from t3 group by f1)
 SELECT a1.* FROM t3 AS a1 LEFT JOIN t3_with_key AS a2 ON (a1.f1 = a2.key or (a1.f1 is null and a2.key is null));
 ----
+Source materialize.public.t3 (u3):
+| Project (#0, #1)
+
+Query:
 %0 =
-| Get materialize.public.t3 (u5)
+| Get materialize.public.t3 (u3)
 
 EOF
 

--- a/test/sqllogictest/uniqueness_propagation_filter.slt
+++ b/test/sqllogictest/uniqueness_propagation_filter.slt
@@ -26,7 +26,7 @@ query T multiline
 EXPLAIN SELECT DISTINCT f1, f2 FROM v1 WHERE f1 = f3;
 ----
 %0 =
-| Get materialize.public.v1 (u3)
+| Get materialize.public.v1 (u2)
 | Filter (#0 = #2)
 | Project (#0, #1)
 
@@ -36,7 +36,7 @@ query T multiline
 EXPLAIN SELECT f1, f2 FROM v1 WHERE f1 = f3 GROUP BY f1, f2;
 ----
 %0 =
-| Get materialize.public.v1 (u3)
+| Get materialize.public.v1 (u2)
 | Filter (#0 = #2)
 | Project (#0, #1)
 
@@ -46,7 +46,7 @@ query T multiline
 EXPLAIN SELECT DISTINCT f1, f3 FROM v1 WHERE f1 = f2;
 ----
 %0 =
-| Get materialize.public.v1 (u3)
+| Get materialize.public.v1 (u2)
 | Filter (#0 = #1)
 | Project (#0, #2)
 
@@ -56,7 +56,7 @@ query T multiline
 EXPLAIN SELECT DISTINCT f2, f3 FROM v1 WHERE f1 = f2;
 ----
 %0 =
-| Get materialize.public.v1 (u3)
+| Get materialize.public.v1 (u2)
 | Filter (#0 = #1)
 | Project (#1, #2)
 
@@ -66,7 +66,7 @@ query T multiline
 EXPLAIN SELECT DISTINCT f1 FROM v1 WHERE f1 = f2 AND f1 = f3;
 ----
 %0 =
-| Get materialize.public.v1 (u3)
+| Get materialize.public.v1 (u2)
 | Filter (#0 = #1), (#0 = #2)
 | Project (#0)
 
@@ -76,7 +76,7 @@ query T multiline
 EXPLAIN SELECT DISTINCT f1, f3 FROM v1 WHERE f1 = f2 AND f1 = f3;
 ----
 %0 =
-| Get materialize.public.v1 (u3)
+| Get materialize.public.v1 (u2)
 | Filter (#0 = #1), (#0 = #2)
 | Project (#0, #2)
 
@@ -86,7 +86,7 @@ query T multiline
 EXPLAIN SELECT DISTINCT f2, f3 FROM v1 WHERE f1 = f2 AND f1 = f3;
 ----
 %0 =
-| Get materialize.public.v1 (u3)
+| Get materialize.public.v1 (u2)
 | Filter (#0 = #1), (#0 = #2)
 | Project (#1, #2)
 
@@ -96,7 +96,7 @@ query T multiline
 EXPLAIN SELECT DISTINCT f2, f3 FROM v1 WHERE f1 = f2 AND f2 = f3;
 ----
 %0 =
-| Get materialize.public.v1 (u3)
+| Get materialize.public.v1 (u2)
 | Filter (#0 = #1), (#1 = #2)
 | Project (#1, #2)
 
@@ -110,7 +110,7 @@ query T multiline
 EXPLAIN SELECT DISTINCT f1 FROM v1 WHERE f1 = f3;
 ----
 %0 =
-| Get materialize.public.v1 (u3)
+| Get materialize.public.v1 (u2)
 | Filter (#0 = #2)
 | Project (#0)
 | Distinct group=(#0)
@@ -121,7 +121,7 @@ query T multiline
 EXPLAIN SELECT DISTINCT f1, f2 FROM v1 WHERE f1 + 1 = f3;
 ----
 %0 =
-| Get materialize.public.v1 (u3)
+| Get materialize.public.v1 (u2)
 | Filter (#2 = (#0 + 1))
 | Project (#0, #1)
 | Distinct group=(#0, #1)
@@ -132,7 +132,7 @@ query T multiline
 EXPLAIN SELECT DISTINCT f1, f2 FROM v1 WHERE f1 > f3;
 ----
 %0 =
-| Get materialize.public.v1 (u3)
+| Get materialize.public.v1 (u2)
 | Filter (#0 > #2)
 | Project (#0, #1)
 | Distinct group=(#0, #1)
@@ -143,7 +143,7 @@ query T multiline
 EXPLAIN SELECT DISTINCT f1 + 1, f2 FROM v1 WHERE f1 = f3;
 ----
 %0 =
-| Get materialize.public.v1 (u3)
+| Get materialize.public.v1 (u2)
 | Filter (#0 = #2)
 | Project (#0, #1)
 | Distinct group=((#0 + 1), #1)
@@ -154,7 +154,7 @@ query T multiline
 EXPLAIN SELECT DISTINCT f2, f3 FROM v1 WHERE f1 = f2 OR f1 = f3;
 ----
 %0 =
-| Get materialize.public.v1 (u3)
+| Get materialize.public.v1 (u2)
 | Filter ((#0 = #1) || (#0 = #2))
 | Project (#1, #2)
 | Distinct group=(#0, #1)
@@ -165,7 +165,7 @@ query T multiline
 EXPLAIN SELECT DISTINCT f1 + 1 , f2 FROM v1 WHERE f1 + 1 = f3;
 ----
 %0 =
-| Get materialize.public.v1 (u3)
+| Get materialize.public.v1 (u2)
 | Filter (#2 = (#0 + 1))
 | Project (#0, #1)
 | Distinct group=((#0 + 1), #1)
@@ -176,7 +176,7 @@ query T multiline
 EXPLAIN SELECT DISTINCT f1 FROM v1 WHERE f1 = f3;
 ----
 %0 =
-| Get materialize.public.v1 (u3)
+| Get materialize.public.v1 (u2)
 | Filter (#0 = #2)
 | Project (#0)
 | Distinct group=(#0)
@@ -193,8 +193,13 @@ CREATE TABLE t2 (f1 INTEGER, f2 INTEGER, f3 INTEGER, f4 INTEGER, PRIMARY KEY (f1
 query T multiline
 EXPLAIN SELECT DISTINCT f1, f3 FROM t2 WHERE f2 = f3;
 ----
+Source materialize.public.t2 (u4):
+| Filter (#1 = #2)
+| Project (#0..=#2)
+
+Query:
 %0 =
-| Get materialize.public.t2 (u5)
+| Get materialize.public.t2 (u4)
 | Filter (#1 = #2)
 | Project (#0, #2)
 
@@ -203,8 +208,13 @@ EOF
 query T multiline
 EXPLAIN SELECT DISTINCT f3 FROM t2 WHERE f1 = f2 AND f2 = f3;
 ----
+Source materialize.public.t2 (u4):
+| Filter (#0 = #1), (#1 = #2)
+| Project (#0..=#2)
+
+Query:
 %0 =
-| Get materialize.public.t2 (u5)
+| Get materialize.public.t2 (u4)
 | Filter (#0 = #1), (#1 = #2)
 | Project (#2)
 
@@ -213,8 +223,13 @@ EOF
 query T multiline
 EXPLAIN SELECT DISTINCT f2 FROM t2 WHERE f1 = f3 AND f3 = f2;
 ----
+Source materialize.public.t2 (u4):
+| Filter (#0 = #2), (#1 = #2)
+| Project (#0..=#2)
+
+Query:
 %0 =
-| Get materialize.public.t2 (u5)
+| Get materialize.public.t2 (u4)
 | Filter (#0 = #2), (#1 = #2)
 | Project (#1)
 
@@ -223,8 +238,13 @@ EOF
 query T multiline
 EXPLAIN SELECT DISTINCT f1, f2, f3, f4 FROM t2 WHERE f1 = f3 AND f2 = f4;
 ----
+Source materialize.public.t2 (u4):
+| Filter (#0 = #2), (#1 = #3)
+| Project (#0..=#3)
+
+Query:
 %0 =
-| Get materialize.public.t2 (u5)
+| Get materialize.public.t2 (u4)
 | Filter (#0 = #2), (#1 = #3)
 
 EOF
@@ -233,8 +253,13 @@ EOF
 query T multiline
 EXPLAIN SELECT DISTINCT f3, f4 FROM t2 WHERE f1 = f3 AND f2 = f4;
 ----
+Source materialize.public.t2 (u4):
+| Filter (#0 = #2), (#1 = #3)
+| Project (#0..=#3)
+
+Query:
 %0 =
-| Get materialize.public.t2 (u5)
+| Get materialize.public.t2 (u4)
 | Filter (#0 = #2), (#1 = #3)
 | Project (#2, #3)
 
@@ -247,8 +272,13 @@ EOF
 query T multiline
 EXPLAIN SELECT DISTINCT f2, f3 FROM t2 WHERE f3 = f4;
 ----
+Source materialize.public.t2 (u4):
+| Filter (#2 = #3)
+| Project (#1..=#3)
+
+Query:
 %0 =
-| Get materialize.public.t2 (u5)
+| Get materialize.public.t2 (u4)
 | Filter (#2 = #3)
 | Project (#1, #2)
 | Distinct group=(#0, #1)
@@ -258,8 +288,13 @@ EOF
 query T multiline
 EXPLAIN SELECT DISTINCT f2 FROM t2 WHERE f1 = f3;
 ----
+Source materialize.public.t2 (u4):
+| Filter (#0 = #2)
+| Project (#0..=#2)
+
+Query:
 %0 =
-| Get materialize.public.t2 (u5)
+| Get materialize.public.t2 (u4)
 | Filter (#0 = #2)
 | Project (#1)
 | Distinct group=(#0)
@@ -269,8 +304,13 @@ EOF
 query T multiline
 EXPLAIN SELECT DISTINCT f3, f4 FROM t2 WHERE f1 = f3;
 ----
+Source materialize.public.t2 (u4):
+| Filter (#0 = #2)
+| Project (#0, #2, #3)
+
+Query:
 %0 =
-| Get materialize.public.t2 (u5)
+| Get materialize.public.t2 (u4)
 | Filter (#0 = #2)
 | Project (#2, #3)
 | Distinct group=(#0, #1)
@@ -280,8 +320,13 @@ EOF
 query T multiline
 EXPLAIN SELECT DISTINCT f3 FROM t2 WHERE f1 = f2;
 ----
+Source materialize.public.t2 (u4):
+| Filter (#0 = #1)
+| Project (#0..=#2)
+
+Query:
 %0 =
-| Get materialize.public.t2 (u5)
+| Get materialize.public.t2 (u4)
 | Filter (#0 = #1)
 | Project (#2)
 | Distinct group=(#0)

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -199,7 +199,7 @@ WHERE f1 IN (SELECT ROW_NUMBER() OVER () FROM t2);
 | Distinct group=(#0)
 
 %4 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 
 %5 = Let l3 =
 | Join %3 %4
@@ -272,6 +272,13 @@ query T multiline
 EXPLAIN SELECT f1 FROM t1
 WHERE f1 IN (SELECT ROW_NUMBER() OVER () FROM t2);
 ----
+Source materialize.public.t1 (u1):
+| Project (#0)
+
+Source materialize.public.t2 (u2):
+| Project (#0, #1)
+
+Query:
 %0 = Let l0 =
 | Get materialize.public.t1 (u1)
 | Project (#0)
@@ -282,7 +289,7 @@ WHERE f1 IN (SELECT ROW_NUMBER() OVER () FROM t2);
 | ArrangeBy ()
 
 %2 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 
 %3 =
 | Join %1 %2
@@ -352,7 +359,7 @@ EXPLAIN DECORRELATED PLAN FOR SELECT * FROM t2, LATERAL(SELECT t1.*, ROW_NUMBER(
 | Constant ()
 
 %1 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 
 %2 = Let l1 =
 | Join %0 %1
@@ -401,7 +408,7 @@ EXPLAIN DECORRELATED PLAN FOR SELECT * FROM t2, LATERAL(SELECT t1.*, ROW_NUMBER(
 | Constant ()
 
 %1 =
-| Get materialize.public.t2 (u3)
+| Get materialize.public.t2 (u2)
 
 %2 = Let l1 =
 | Join %0 %1

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -490,7 +490,7 @@ test_table
 
 # There is one entry in mz_indexes for each field_number/expression of the index.
 > SELECT COUNT(id) FROM mz_indexes WHERE id LIKE 's%'
-43
+19
 
 > SHOW VIEWS FROM mz_catalog
 mz_arrangement_sharing

--- a/test/testdrive/char-varchar-orderby.td
+++ b/test/testdrive/char-varchar-orderby.td
@@ -72,6 +72,10 @@
 $ set-regex match=u\d+ replacement=UID
 
 ? EXPLAIN SELECT * FROM (SELECT * FROM char_table ORDER BY f1 LIMIT 1 OFFSET 0)
+Source materialize.public.char_table (UID):
+| Project (#0, #1)
+
+Query:
 %0 =
 | Get materialize.public.char_table (UID)
 | TopK group=() order=(#0 asc) limit=1 offset=0

--- a/test/testdrive/explain-timers.td
+++ b/test/testdrive/explain-timers.td
@@ -12,6 +12,7 @@ $ set-sql-timeout duration=125ms
 $ set-regex match=(\s\(u\d+\)|materialize\.public\.|\s\d\d:\d\d:\d\d\.\d\d\d\d\d\d) replacement=
 
 > CREATE TABLE t1 (col_null INTEGER, col_not_null INTEGER NOT NULL);
+> CREATE DEFAULT INDEX on t1
 
 ? EXPLAIN (TIMING true) SELECT * FROM t1;
 %0 =

--- a/test/testdrive/fetch-tail-as-of.td
+++ b/test/testdrive/fetch-tail-as-of.td
@@ -14,6 +14,7 @@
 $ set-regex match=\d{13} replacement=<TIMESTAMP>
 
 > CREATE TABLE t1 (f1 INTEGER);
+> CREATE DEFAULT INDEX ON t1
 
 > INSERT INTO t1 VALUES (123);
 

--- a/test/testdrive/frontier-advance-multiple-views.td
+++ b/test/testdrive/frontier-advance-multiple-views.td
@@ -11,6 +11,7 @@
 # materialized views on some source.
 
 > CREATE TABLE t1 (f1 INTEGER, f2 INTEGER);
+> CREATE DEFAULT INDEX on t1
 
 > CREATE MATERIALIZED VIEW v1 AS SELECT * FROM t1;
 

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -209,6 +209,7 @@ materialize.public.data_view_primary_idx "CREATE INDEX \"data_view_primary_idx\"
     b decimal(13, 1),
     z text
   )
+> CREATE DEFAULT INDEX ON foo
 > CREATE INDEX ON foo (a + b)
 > CREATE INDEX ON foo (substr(z, 3))
 > SHOW INDEXES FROM foo

--- a/test/testdrive/rollback.td
+++ b/test/testdrive/rollback.td
@@ -13,6 +13,7 @@
 # (incorrectly) available.
 
 > CREATE TABLE t1 (f1 INTEGER);
+> CREATE DEFAULT INDEX ON t1
 
 > BEGIN
 

--- a/test/testdrive/subexpression-replacement.td
+++ b/test/testdrive/subexpression-replacement.td
@@ -18,6 +18,7 @@ $ set-sql-timeout duration=125ms
 $ set-regex match=(\s\(u\d+\)|\n|materialize\.public\.) replacement=
 
 > CREATE TABLE t1 (col_null INTEGER, col_not_null INTEGER NOT NULL);
+> CREATE DEFAULT INDEX on t1
 
 > INSERT INTO t1 VALUES (1, 1);
 

--- a/test/testdrive/tables.td
+++ b/test/testdrive/tables.td
@@ -53,13 +53,16 @@ name
 ----
 
 > SHOW INDEXES FROM t;
+
+> CREATE DEFAULT INDEX on t
+
+> SHOW INDEXES FROM t
 on_name  key_name       seq_in_index  column_name  expression  nullable enabled
 -------------------------------------------------------------------------------
 t        t_primary_idx  1             a            <null>      true     true
 t        t_primary_idx  2             b            <null>      false    true
 
-! DROP INDEX t_primary_idx
-contains:cannot drop 'materialize.public.t_primary_idx' as it is the default index for a table
+> DROP INDEX t_primary_idx
 
 > SHOW COLUMNS in t;
 name       nullable  type

--- a/test/testdrive/temporary.td
+++ b/test/testdrive/temporary.td
@@ -117,10 +117,16 @@ contains:catalog item 'temp_t' already exists
 > INSERT INTO temp_t VALUES (1, 'testing')
 
 > SHOW INDEXES FROM temp_t
- on_name    key_name            seq_in_index  column_name  expression  nullable enabled
----------------------------------------------------------------------------------------
- temp_t     temp_t_primary_idx  1             a            <null>      true     true
- temp_t     temp_t_primary_idx  2             b            <null>      false    true
+
+# Blocked on https://github.com/MaterializeInc/materialize/issues/3105.
+#
+# > CREATE TEMPORARY DEFAULT INDEX ON temp_t
+#
+# > SHOW INDEXES FROM temp_t
+#  on_name    key_name            seq_in_index  column_name  expression  nullable enabled
+# ---------------------------------------------------------------------------------------
+#  temp_t     temp_t_primary_idx  1             a            <null>      true     true
+#  temp_t     temp_t_primary_idx  2             b            <null>      false    true
 
 > DROP TABLE temp_t
 

--- a/test/testdrive/testdrive.td
+++ b/test/testdrive/testdrive.td
@@ -45,6 +45,10 @@ row 2
 $ set-regex match=u\d+ replacement=UID
 
 ? EXPLAIN SELECT * FROM t1 AS a1, t1 AS a2 WHERE a1.f1 IS NOT NULL;
+Source materialize.public.t1 (UID):
+| Project (#0..=#2)
+
+Query:
 %0 =
 | Get materialize.public.t1 (UID)
 | Filter !(isnull(#0))

--- a/test/testdrive/transactions-timedomain-nonmaterialized.td
+++ b/test/testdrive/transactions-timedomain-nonmaterialized.td
@@ -47,10 +47,12 @@ $ file-append path=static.csv
 2
 4
 
-! SELECT c FROM unindexed ORDER BY c
-contains:Transactions can only reference objects in the same timedomain
+> SELECT c FROM unindexed
+1
+2
+4
 
-> ROLLBACK
+> COMMIT
 
 # The unindexed view should be the same.
 > BEGIN
@@ -60,10 +62,10 @@ contains:Transactions can only reference objects in the same timedomain
 2
 4
 
-! SELECT * FROM v_unindexed
-contains:Transactions can only reference objects in the same timedomain
+> SELECT * FROM v_unindexed
+3
 
-> ROLLBACK
+> COMMIT
 
 # Ensure that other optionally indexed things (views) are correctly
 # included in the timedomain.


### PR DESCRIPTION
For reasons that elude me at this time of night, this doesn't quite work. Attempting to `SELECT` from a table after `INSERT`ing into it fails. But if you create an index _before_ you `INSERT` any data into the table, it all works out just fine.

----

Remove the special cases for table indexes. Rather than mandating that
each table have a primary index, store the data in a `Vec` outside of
any index. This allows tables to be imported multiple times into various
dataflows, just like other sources.

In the future, the table data will be stored in a persistent location
rather than a `Vec`.

Fix #10720.

### Motivation

  * This PR fixes a recognized bug.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - TODO.
