### PR TITLE
Implement justify interval methods

### DIFF
--- a/doc/user/content/sql/functions/justify-days.md
+++ b/doc/user/content/sql/functions/justify-days.md
@@ -1,0 +1,34 @@
+---
+title: "justify_days Function"
+description: "Adjust interval so 30-day time periods are represented as months"
+menu:
+  main:
+    parent: 'sql-functions'
+---
+
+`justify_days` returns a new [`interval`](../../types/interval) such that 30-day time periods are
+converted to months.
+
+## Signatures
+
+{{< diagram "func-justify-days.svg" >}}
+
+Parameter | Type                                                                                                                                                                                            | Description
+----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------
+_interval_ | [`interval`](../../types/interval) | The interval value to justify.
+
+
+### Return value
+
+`justify_days` returns an [`interval`](../../types/interval) value.
+
+## Example
+
+```sql
+SELECT justify_days(interval '35 days');
+```
+```nofmt
+  justify_days  
+----------------
+ 1 month 5 days
+```

--- a/doc/user/content/sql/functions/justify-days.md
+++ b/doc/user/content/sql/functions/justify-days.md
@@ -28,7 +28,7 @@ _interval_ | [`interval`](../../types/interval) | The interval value to justify.
 SELECT justify_days(interval '35 days');
 ```
 ```nofmt
-  justify_days  
+  justify_days
 ----------------
  1 month 5 days
 ```

--- a/doc/user/content/sql/functions/justify-hours.md
+++ b/doc/user/content/sql/functions/justify-hours.md
@@ -28,7 +28,7 @@ _interval_ | [`interval`](../../types/interval) | The interval value to justify.
 SELECT justify_hours(interval '27 hours');
 ```
 ```nofmt
- justify_hours  
+ justify_hours
 ----------------
  1 day 03:00:00
 ```

--- a/doc/user/content/sql/functions/justify-hours.md
+++ b/doc/user/content/sql/functions/justify-hours.md
@@ -1,0 +1,34 @@
+---
+title: "justify_hours Function"
+description: "Adjust interval so 24-hour time periods are represented as days"
+menu:
+  main:
+    parent: 'sql-functions'
+---
+
+`justify_hours` returns a new [`interval`](../../types/interval) such that 24-hour time periods are
+converted to days.
+
+## Signatures
+
+{{< diagram "func-justify-hours.svg" >}}
+
+Parameter | Type                                                                                                                                                                                            | Description
+----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------
+_interval_ | [`interval`](../../types/interval) | The interval value to justify.
+
+
+### Return value
+
+`justify_hours` returns an [`interval`](../../types/interval) value.
+
+## Example
+
+```sql
+SELECT justify_hours(interval '27 hours');
+```
+```nofmt
+ justify_hours  
+----------------
+ 1 day 03:00:00
+```

--- a/doc/user/content/sql/functions/justify-interval.md
+++ b/doc/user/content/sql/functions/justify-interval.md
@@ -8,7 +8,7 @@ menu:
 
 `justify_interval` returns a new [`interval`](../../types/interval) such that 30-day time periods are
 converted to months, 24-hour time periods are represented as days, and all fields have the same sign. It is a
-combination of ['justify_days'](../justify_days) and ['justify_hours'](../justify_hours) with additional sign
+combination of ['justify_days'](../justify-days) and ['justify_hours'](../justify-hours) with additional sign
 adjustment.
 
 ## Signatures

--- a/doc/user/content/sql/functions/justify-interval.md
+++ b/doc/user/content/sql/functions/justify-interval.md
@@ -1,0 +1,36 @@
+---
+title: "justify_interval Function"
+description: "Adjust interval using justify_days and justify_hours, with additional sign adjustments"
+menu:
+  main:
+    parent: 'sql-functions'
+---
+
+`justify_interval` returns a new [`interval`](../../types/interval) such that 30-day time periods are
+converted to months, 24-hour time periods are represented as days, and all fields have the same sign. It is a
+combination of ['justify_days'](../justify_days) and ['justify_hours'](../justify_hours) with additional sign
+adjustment.
+
+## Signatures
+
+{{< diagram "func-justify-interval.svg" >}}
+
+Parameter | Type                                                                                                                                                                                            | Description
+----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------
+_interval_ | [`interval`](../../types/interval) | The interval value to justify.
+
+
+### Return value
+
+`justify_interval` returns an [`interval`](../../types/interval) value.
+
+## Example
+
+```sql
+SELECT justify_interval(interval '1 mon -1 hour');
+```
+```nofmt
+ justify_interval 
+------------------
+ 29 days 23:00:00
+```

--- a/doc/user/content/sql/functions/justify-interval.md
+++ b/doc/user/content/sql/functions/justify-interval.md
@@ -30,7 +30,7 @@ _interval_ | [`interval`](../../types/interval) | The interval value to justify.
 SELECT justify_interval(interval '1 mon -1 hour');
 ```
 ```nofmt
- justify_interval 
+ justify_interval
 ------------------
  29 days 23:00:00
 ```

--- a/doc/user/content/sql/types/interval.md
+++ b/doc/user/content/sql/types/interval.md
@@ -8,6 +8,11 @@ menu:
 
 `interval` data expresses a duration of time.
 
+`interval` data keeps months, days, and microseconds completely separate and will not try to convert between any of
+those fields when comparing `interval`s. This may lead to some unexpected behavior. For example `1 month` is considered
+greater than `100 days`. See ['justify_days'](../justify_days), ['justify_hours'](../justify_hours), and
+['justify_interval'](../justify_interval) to explicitly convert between these fields.
+
 Detail | Info
 -------|-----
 **Quick Syntax** | `INTERVAL '1' MINUTE` <br/> `INTERVAL '1-2 3 4:5:6.7'` <br/>`INTERVAL '1 year 2.3 days 4.5 seconds'`

--- a/doc/user/content/sql/types/interval.md
+++ b/doc/user/content/sql/types/interval.md
@@ -10,8 +10,8 @@ menu:
 
 `interval` data keeps months, days, and microseconds completely separate and will not try to convert between any of
 those fields when comparing `interval`s. This may lead to some unexpected behavior. For example `1 month` is considered
-greater than `100 days`. See ['justify_days'](../justify_days), ['justify_hours'](../justify_hours), and
-['justify_interval'](../justify_interval) to explicitly convert between these fields.
+greater than `100 days`. See ['justify_days'](../../functions/justify-days), ['justify_hours'](../../functions/justify-hours), and
+['justify_interval'](../../functions/justify-interval) to explicitly convert between these fields.
 
 Detail | Info
 -------|-----

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -485,6 +485,18 @@
     description: Converts a timestamp into a string using the specified format.
     url: to_char
 
+  - signature: 'justify_days(val: interval) -> interval'
+    description: Adjust interval so 30-day time periods are represented as months.
+    url: justify-days
+
+  - signature: 'justify_hours(val: interval) -> interval'
+    description: Adjust interval so 24-hour time periods are represented as days.
+    url: justify-hours
+
+  - signature: 'justify_interval(val: interval) -> interval'
+    description: Adjust interval using justify_days and justify_hours, with additional sign adjustments.
+    url: justify-interval
+
 - type: UUID
   functions:
   - signature: mz_cluster_id() -> uuid

--- a/doc/user/layouts/partials/sql-grammar/func-justify-days.svg
+++ b/doc/user/layouts/partials/sql-grammar/func-justify-days.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="341" height="37">
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="102" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="102"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">justify_days</text>
+   <rect x="153" y="3" width="26" height="32" rx="10"/>
+   <rect x="151"
+         y="1"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="161" y="21">(</text>
+   <rect x="199" y="3" width="68" height="32"/>
+   <rect x="197" y="1" width="68" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="207" y="21">interval</text>
+   <rect x="287" y="3" width="26" height="32" rx="10"/>
+   <rect x="285"
+         y="1"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="295" y="21">)</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m102 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m68 0 h10 m0 0 h10 m26 0 h10 m3 0 h-3"/>
+   <polygon points="331 17 339 13 339 21"/>
+   <polygon points="331 17 323 13 323 21"/>
+</svg>

--- a/doc/user/layouts/partials/sql-grammar/func-justify-hours.svg
+++ b/doc/user/layouts/partials/sql-grammar/func-justify-hours.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="349" height="37">
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="110" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="110"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">justify_hours</text>
+   <rect x="161" y="3" width="26" height="32" rx="10"/>
+   <rect x="159"
+         y="1"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="169" y="21">(</text>
+   <rect x="207" y="3" width="68" height="32"/>
+   <rect x="205" y="1" width="68" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="215" y="21">interval</text>
+   <rect x="295" y="3" width="26" height="32" rx="10"/>
+   <rect x="293"
+         y="1"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="303" y="21">)</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m110 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m68 0 h10 m0 0 h10 m26 0 h10 m3 0 h-3"/>
+   <polygon points="339 17 347 13 347 21"/>
+   <polygon points="339 17 331 13 331 21"/>
+</svg>

--- a/doc/user/layouts/partials/sql-grammar/func-justify-interval.svg
+++ b/doc/user/layouts/partials/sql-grammar/func-justify-interval.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="361" height="37">
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="122" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="122"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">justify_interval</text>
+   <rect x="173" y="3" width="26" height="32" rx="10"/>
+   <rect x="171"
+         y="1"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="181" y="21">(</text>
+   <rect x="219" y="3" width="68" height="32"/>
+   <rect x="217" y="1" width="68" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="227" y="21">interval</text>
+   <rect x="307" y="3" width="26" height="32" rx="10"/>
+   <rect x="305"
+         y="1"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="315" y="21">)</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m122 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m68 0 h10 m0 0 h10 m26 0 h10 m3 0 h-3"/>
+   <polygon points="351 17 359 13 359 21"/>
+   <polygon points="351 17 343 13 343 21"/>
+</svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -298,6 +298,12 @@ func_substring ::=
   'substring' '(' str ',' start_pos (',' len)? ')'
 func_timezone ::=
     'TIMEZONE' '(' zone'::'type ',' ( 'timestamp' | 'timestamptz' ) ')'
+func_justify_days ::=
+  'justify_days' '(' interval ')'
+func_justify_hours ::=
+  'justify_hours' '(' interval ')'
+func_justify_interval ::=
+  'justify_interval' '(' interval ')'
 join_expr ::=
     select_pred ('CROSS' | 'NATURAL' join_type?) 'JOIN' table_ref select_post
 	| select_pred join_type 'JOIN' table_ref ( 'USING' '(' ( ( col_ref ) ( ( ',' col_ref ) )* ) ')' | 'ON' expression ) select_post

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -2144,27 +2144,6 @@ fn timezone_interval_timestamptz(a: Datum<'_>, b: Datum<'_>) -> Result<Datum<'st
     }
 }
 
-fn justify_days(a: Datum) -> Result<Datum, EvalError> {
-    a.unwrap_interval()
-        .justify_days()
-        .map(Datum::from)
-        .map_err(|_| EvalError::IntervalOutOfRange)
-}
-
-fn justify_hours(a: Datum) -> Result<Datum, EvalError> {
-    a.unwrap_interval()
-        .justify_hours()
-        .map(Datum::from)
-        .map_err(|_| EvalError::IntervalOutOfRange)
-}
-
-fn justify_interval(a: Datum) -> Result<Datum, EvalError> {
-    a.unwrap_interval()
-        .justify_interval()
-        .map(Datum::from)
-        .map_err(|_| EvalError::IntervalOutOfRange)
-}
-
 fn jsonb_array_length<'a>(a: Datum<'a>) -> Datum<'a> {
     match a {
         Datum::List(list) => Datum::Int64(list.iter().count() as i64),
@@ -3445,9 +3424,9 @@ pub enum UnaryFunc {
         wall_time: NaiveDateTime,
     },
     ToTimestamp(ToTimestamp),
-    JustifyDays,
-    JustifyHours,
-    JustifyInterval,
+    JustifyDays(JustifyDays),
+    JustifyHours(JustifyHours),
+    JustifyInterval(JustifyInterval),
     JsonbArrayLength,
     JsonbTypeof,
     JsonbStripNulls,
@@ -3581,6 +3560,9 @@ derive_unary!(
     CastBoolToStringNonstandard,
     CastBoolToInt32,
     ToTimestamp,
+    JustifyDays,
+    JustifyHours,
+    JustifyInterval,
     CastFloat64ToString,
     CastNumericToFloat32,
     CastNumericToFloat64,
@@ -3807,6 +3789,9 @@ impl UnaryFunc {
             | CastIntervalToString(_)
             | CastIntervalToTime(_)
             | NegInterval(_)
+            | JustifyDays(_)
+            | JustifyHours(_)
+            | JustifyInterval(_)
             | CastUuidToString(_)
             | CastArrayToListOneDim(_)
             | CastTimestampToString(_)
@@ -3874,9 +3859,6 @@ impl UnaryFunc {
             TimezoneTimestamp(tz) => timezone_timestamp(*tz, a.unwrap_timestamp()),
             TimezoneTimestampTz(tz) => Ok(timezone_timestamptz(*tz, a.unwrap_timestamptz())),
             TimezoneTime { tz, wall_time } => Ok(timezone_time(*tz, a.unwrap_time(), wall_time)),
-            JustifyDays => justify_days(a),
-            JustifyHours => justify_hours(a),
-            JustifyInterval => justify_interval(a),
             JsonbArrayLength => Ok(jsonb_array_length(a)),
             JsonbTypeof => Ok(jsonb_typeof(a)),
             JsonbStripNulls => Ok(jsonb_strip_nulls(a, temp_storage)),
@@ -4044,6 +4026,9 @@ impl UnaryFunc {
             | CastIntervalToString(_)
             | CastIntervalToTime(_)
             | NegInterval(_)
+            | JustifyDays(_)
+            | JustifyHours(_)
+            | JustifyInterval(_)
             | CastUuidToString(_)
             | CastArrayToListOneDim(_)
             | CastTimestampToString(_)
@@ -4118,8 +4103,6 @@ impl UnaryFunc {
 
             DateTruncTimestamp(_) => ScalarType::Timestamp.nullable(nullable),
             DateTruncTimestampTz(_) => ScalarType::TimestampTz.nullable(nullable),
-
-            JustifyDays | JustifyHours | JustifyInterval => ScalarType::Interval.nullable(nullable),
 
             JsonbArrayLength => ScalarType::Int64.nullable(nullable),
             JsonbTypeof => ScalarType::String.nullable(nullable),
@@ -4303,6 +4286,9 @@ impl UnaryFunc {
             | CastIntervalToString(_)
             | CastIntervalToTime(_)
             | NegInterval(_)
+            | JustifyDays(_)
+            | JustifyHours(_)
+            | JustifyInterval(_)
             | CastUuidToString(_)
             | CastArrayToListOneDim(_)
             | CastTimestampToString(_)
@@ -4359,7 +4345,6 @@ impl UnaryFunc {
             | DatePartTimestamp(_)
             | DatePartTimestampTz(_) => false,
             DateTruncTimestamp(_) | DateTruncTimestampTz(_) => false,
-            JustifyDays | JustifyHours | JustifyInterval => false,
             RescaleNumeric(_) => false,
         }
     }
@@ -4431,6 +4416,9 @@ impl UnaryFunc {
             | CastIntervalToString(_)
             | CastIntervalToTime(_)
             | NegInterval(_)
+            | JustifyDays(_)
+            | JustifyHours(_)
+            | JustifyInterval(_)
             | CastVarCharToString(_) => unreachable!(),
             _ => false,
         }
@@ -4581,6 +4569,9 @@ impl UnaryFunc {
             | CastIntervalToString(_)
             | CastIntervalToTime(_)
             | NegInterval(_)
+            | JustifyDays(_)
+            | JustifyHours(_)
+            | JustifyInterval(_)
             | CastUuidToString(_)
             | CastArrayToListOneDim(_)
             | CastTimestampToString(_)
@@ -4636,9 +4627,6 @@ impl UnaryFunc {
             TimezoneTimestamp(tz) => write!(f, "timezone_{}_ts", tz),
             TimezoneTimestampTz(tz) => write!(f, "timezone_{}_tstz", tz),
             TimezoneTime { tz, .. } => write!(f, "timezone_{}_t", tz),
-            JustifyDays => write!(f, "justify_days"),
-            JustifyHours => write!(f, "justify_hours"),
-            JustifyInterval => write!(f, "justify_interval"),
             JsonbArrayLength => f.write_str("jsonb_array_length"),
             JsonbTypeof => f.write_str("jsonb_typeof"),
             JsonbStripNulls => f.write_str("jsonb_strip_nulls"),

--- a/src/expr/src/scalar/func/impls/interval.rs
+++ b/src/expr/src/scalar/func/impls/interval.rs
@@ -51,3 +51,25 @@ sqlfunc!(
         i.checked_neg().ok_or(EvalError::IntervalOutOfRange)
     }
 );
+
+sqlfunc!(
+    #[sqlname = "justify_days"]
+    fn justify_days(i: Interval) -> Result<Interval, EvalError> {
+        i.justify_days().map_err(|_| EvalError::IntervalOutOfRange)
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "justify_hours"]
+    fn justify_hours(i: Interval) -> Result<Interval, EvalError> {
+        i.justify_hours().map_err(|_| EvalError::IntervalOutOfRange)
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "justify_interval"]
+    fn justify_interval(i: Interval) -> Result<Interval, EvalError> {
+        i.justify_interval()
+            .map_err(|_| EvalError::IntervalOutOfRange)
+    }
+);

--- a/src/repr/src/adt/interval.rs
+++ b/src/repr/src/adt/interval.rs
@@ -365,7 +365,6 @@ impl Interval {
     }
 
     /// Converts this `Interval`'s duration into `chrono::Duration`.
-    // TODO: would be best to remove usage of chrono::Duration and replace with native functions
     pub fn duration_as_chrono(&self) -> chrono::Duration {
         use chrono::Duration;
         Duration::days(self.days.into()) + Duration::microseconds(self.micros)

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1836,6 +1836,15 @@ lazy_static! {
             "jsonb_typeof" => Scalar {
                 params!(Jsonb) => UnaryFunc::JsonbTypeof, 3210;
             },
+            "justify_days" => Scalar {
+                params!(Interval) => UnaryFunc::JustifyDays, 1295;
+            },
+            "justify_hours" => Scalar {
+                params!(Interval) => UnaryFunc::JustifyHours, 1175;
+            },
+            "justify_interval" => Scalar {
+                params!(Interval) => UnaryFunc::JustifyInterval, 2711;
+            },
             "left" => Scalar {
                 params!(String, Int32) => BinaryFunc::Left, 3060;
             },

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1837,13 +1837,13 @@ lazy_static! {
                 params!(Jsonb) => UnaryFunc::JsonbTypeof, 3210;
             },
             "justify_days" => Scalar {
-                params!(Interval) => UnaryFunc::JustifyDays, 1295;
+                params!(Interval) => UnaryFunc::JustifyDays(func::JustifyDays), 1295;
             },
             "justify_hours" => Scalar {
-                params!(Interval) => UnaryFunc::JustifyHours, 1175;
+                params!(Interval) => UnaryFunc::JustifyHours(func::JustifyHours), 1175;
             },
             "justify_interval" => Scalar {
-                params!(Interval) => UnaryFunc::JustifyInterval, 2711;
+                params!(Interval) => UnaryFunc::JustifyInterval(func::JustifyInterval), 2711;
             },
             "left" => Scalar {
                 params!(String, Int32) => BinaryFunc::Left, 3060;

--- a/test/sqllogictest/interval.slt
+++ b/test/sqllogictest/interval.slt
@@ -1071,24 +1071,19 @@ SELECT justify_hours(interval '6 months 3 days 52 hours 3 minutes 2 seconds');
 6 months 5 days 04:03:02
 
 query T
-SELECT justify_days(interval '6 months 36 days 5 hours 4 minutes 3 seconds');
+SELECT justify_hours(interval '27 hours');
 ----
-7 months 6 days 05:04:03
-
-query T
-SELECT justify_interval(interval '1 month -1 hour');
-----
-29 days 23:00:00
-
-query T
-SELECT justify_hours(interval '6 months 3 days 52 hours 3 minutes 2 seconds');
-----
-6 months 5 days 04:03:02
+1 day 03:00:00
 
 query T
 SELECT justify_days(interval '6 months 36 days 5 hours 4 minutes 3 seconds');
 ----
 7 months 6 days 05:04:03
+
+query T
+SELECT justify_days(interval '35 days');
+----
+1 month 5 days
 
 query T
 SELECT justify_interval(interval '1 month -1 hour');

--- a/test/sqllogictest/interval.slt
+++ b/test/sqllogictest/interval.slt
@@ -1063,3 +1063,72 @@ query T
 SELECT INTERVAL '-1 day' < INTERVAL '-9999999 hours';
 ----
 true
+
+# Justify tests
+query T
+SELECT justify_hours(interval '6 months 3 days 52 hours 3 minutes 2 seconds');
+----
+6 months 5 days 04:03:02
+
+query T
+SELECT justify_days(interval '6 months 36 days 5 hours 4 minutes 3 seconds');
+----
+7 months 6 days 05:04:03
+
+query T
+SELECT justify_interval(interval '1 month -1 hour');
+----
+29 days 23:00:00
+
+query T
+SELECT justify_hours(interval '6 months 3 days 52 hours 3 minutes 2 seconds');
+----
+6 months 5 days 04:03:02
+
+query T
+SELECT justify_days(interval '6 months 36 days 5 hours 4 minutes 3 seconds');
+----
+7 months 6 days 05:04:03
+
+query T
+SELECT justify_interval(interval '1 month -1 hour');
+----
+29 days 23:00:00
+
+query error interval out of range
+SELECT justify_hours(interval '2147483647 days 24 hrs');
+
+query error interval out of range
+SELECT justify_days(interval '2147483647 months 30 days');
+
+query T
+SELECT justify_interval(interval '2147483647 days 24 hrs');
+----
+5965232 years 4 months 8 days
+
+query T
+SELECT justify_interval(interval '-2147483648 days -24 hrs');
+----
+-5965232 years -4 months -9 days
+
+query error interval out of range
+SELECT justify_interval(interval '2147483647 months 30 days');
+
+query error interval out of range
+SELECT justify_interval(interval '-2147483648 months -30 days');
+
+query T
+SELECT justify_interval(interval '2147483647 months 30 days -24 hrs');
+----
+178956970 years 7 months 29 days
+
+query T
+SELECT justify_interval(interval '-2147483648 months -30 days 24 hrs');
+----
+-178956970 years -8 months -29 days
+
+query error interval out of range
+SELECT justify_interval(interval '2147483647 months -30 days 1440 hrs');
+
+query error interval out of range
+SELECT justify_interval(interval '-2147483648 months 30 days -1440 hrs');


### PR DESCRIPTION
Postgres defines the justify_days, justify_hours, and justify_interval
functions, which explicitly convert between months, days, and
microseconds within an Interval. This commit adds these functions.

### Motivation
This PR adds a feature that has not yet been specified. Due to a limitation in Materialize, we diverge from PostgreSQL when comparing Intervals using equality and ordering. Specifically we do not combine months, days, and microseconds like PostgreSQL does. These functions will allow users to explicitly opt into this functionality by using the justify methods.

### Testing

- [X] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Add the \[\`justify_days\`\](/sql/functions/justify-days), \[\`justify_hours\`\](/sql/functions/justify-hours), and \[\`justify_interval\`\](/sql/functions/justify-interval) functions.
