### PR TITLE
fix bug causing results buffer to be sorted repeatedly

### DIFF
--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -370,8 +370,6 @@ impl PendingPeek {
         let (mut cursor, storage) = self.trace_bundle.oks_mut().cursor();
         // Accumulated `Vec<(row, count)>` results that we are likely to return.
         let mut results = Vec::new();
-        // Σ_{(row, count) ∈ results} count
-        let mut total_count = 0;
 
         // When set, a bound on the number of records we need to return.
         // The requirements on the records are driven by the finishing's
@@ -426,7 +424,6 @@ impl PendingPeek {
                     // if copies > 0 ... otherwise skip
                     if let Some(copies) = NonZeroUsize::new(copies) {
                         results.push((result, copies));
-                        total_count += copies.get();
                     }
 
                     // If we hold many more than `max_results` records, we can thin down
@@ -435,7 +432,7 @@ impl PendingPeek {
                         // We use a threshold twice what we intend, to amortize the work
                         // across all of the insertions. We could tighten this, but it
                         // works for the moment.
-                        if total_count >= 2 * max_results {
+                        if results.len() >= 2 * max_results {
                             if self.finishing.order_by.is_empty() {
                                 results.truncate(max_results);
                                 return Ok(results);


### PR DESCRIPTION
`total_count` was not being updated after pruning the rows, so we kept doing it over and over on each new insertion.

It's fine to use `results.len()` here anyway, as this code block is an optimization that doesn't need to be precise. We might keep around extra rows in the case that some have multiplicity > 1, but that's fine.

Another option would be to scan the buffer after every prune to keep `total_count` up to date, but I suspect the benefit of doing that is marginal, and not worth the extra work in the common case when all the multiplicities are 1, but let me know if anyone disagrees and we can discuss.

### Motivation

Fixes #10884 

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered. (Philip is tagged as a reviewer)

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

No release notes -- this fixes a performance bug that went unreleased.
