### PR TITLE
[kafka resumption] More emphatically kill toxiproxy between failure modes

### DIFF
--- a/test/kafka-resumption/mzcompose.py
+++ b/test/kafka-resumption/mzcompose.py
@@ -50,6 +50,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             "toxiproxy-timeout-hold.td",
         ]
     ):
+        c.start_and_wait_for_tcp(["toxiproxy"])
         c.run(
             "testdrive-svc",
             "--no-reset",
@@ -64,3 +65,4 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             "verify-success.td",
             "cleanup.td",
         )
+        c.kill("toxiproxy")


### PR DESCRIPTION
I maybe hit this issue on one (out of very many) runs of the kafka resumption test suite.  This should make it a little more rock solid that toxiproxy is in a good state for each type of possible failure