### PR TITLE
[kafka eos] [testdrive] verify-timestamp-compaction requires existence of timestamps

### DIFF
--- a/src/testdrive/src/action/verify_timestamp_compaction.rs
+++ b/src/testdrive/src/action/verify_timestamp_compaction.rs
@@ -74,7 +74,7 @@ impl Action for VerifyTimestampCompactionAction {
 
                         // We consider progress to be eventually compacting at least up to the original highest
                         // timestamp binding.
-                        let lo_binding= bindings.iter().map(|(_, ts, _)| *ts).min();
+                        let lo_binding = bindings.iter().map(|(_, ts, _)| *ts).min();
                         let progress = if retry_state.i == 0 {
                             initial_highest.store(
                                 bindings.iter().map(|(_, ts, _)| *ts).max().unwrap_or(u64::MIN),
@@ -95,7 +95,9 @@ impl Action for VerifyTimestampCompactionAction {
                             initial_highest.load(Ordering::SeqCst),
                         );
 
-                        if bindings.len() <= self.max_size || progress {
+                        if bindings.is_empty() {
+                            bail!("There are unexpectedly no bindings")
+                        } else if bindings.len() <= self.max_size || progress {
                             Ok(())
                         } else {
                             bail!(

--- a/test/kafka-exactly-once/before-restart.td
+++ b/test/kafka-exactly-once/before-restart.td
@@ -87,7 +87,7 @@ $ kafka-create-topic topic=input
   FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE MATERIALIZE
 
 > CREATE SINK output FROM input
-  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-byo-sink-${testdrive.seed}'
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-${testdrive.seed}'
   WITH (reuse_topic=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
@@ -120,5 +120,9 @@ $ kafka-verify format=avro sink=materialize.public.output sort-messages=true
 # get correct results even with compaction, which re-timestamps earlier data
 # at later timestamps upon restarting.
 
-> SELECT mz_internal.mz_sleep(2);
+> SELECT mz_internal.mz_sleep(5);
 <null>
+
+# TODO: enable when possible
+# max-size=0 requires that we compact past the max timestamp when this is first invoked
+# $ verify-timestamp-compaction source=input max-size=0 permit-progress=true

--- a/test/testdrive/kafka-exactly-once-sink.td
+++ b/test/testdrive/kafka-exactly-once-sink.td
@@ -207,9 +207,17 @@ contains:reuse_topic requires that sink input dependencies are sources, material
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 > CREATE SINK output14_custom_consistency_topic FROM input_kafka_cdcv2
-  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output1-view-${testdrive.seed}'
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output14-view-${testdrive.seed}'
   WITH (reuse_topic=true, consistency_topic='output14-custom-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+
+# We need some data -- any data -- to start creating timestamp bindings
+$ kafka-ingest format=avro topic=input_cdcv2 schema=${cdcv2-schema}
+{"array":[{"data":{"a":1,"b":1},"time":1,"diff":1}]}
+{"com.materialize.cdc.progress":{"lower":[0],"upper":[1],"counts":[{"time":1,"count":1}]}}
+
+$ kafka-ingest format=avro topic=input_dbz schema=${dbz-schema} timestamp=1
+{"before": null, "after": {"row": {"a": 1, "b": 1}}}
 
 # ensure that the sink works with log compaction enabled on the consistency topic
 
@@ -407,3 +415,5 @@ $ kafka-verify format=json sink=materialize.public.json_avro_upsert_key_2 key=tr
 $ verify-timestamp-compaction source=input_csv max-size=3 permit-progress=true
 $ verify-timestamp-compaction source=rt_binding_consistency_test_source max-size=3 permit-progress=true
 $ verify-timestamp-compaction source=input_kafka_dbz max-size=3 permit-progress=true
+# TODO: enable when possible
+# $ verify-timestamp-compaction source=input_kafka_cdcv2 max-size=3 permit-progress=true


### PR DESCRIPTION
Pull out of #10878 what passes now to prevent regressions:
- If we call `verify-timestamp-compaction`, we ought to make sure that we have a non-zero number of timestamps so the test isn't trivial
- Add TODOs in the tests (that I'll soon follow up on) for enabling checks that do not currently pass today