### PR TITLE
[kafka sink] Retry message send failures

### DIFF
--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -539,7 +539,7 @@ impl KafkaSinkState {
                     // clone is a cheap: Option<Arc<..>> internally
                     last_error = KafkaError::Transaction(e.clone());
                     if e.txn_requires_abort() {
-                        info!("Error requiring abort in kafka sink: {:?}", e);
+                        info!("Error requiring tx abort in kafka sink: {:?}", e);
                         let self_self_producer = self_producer.clone();
                         // Only actually used for retriable errors.
                         let should_shutdown = Retry::default()

--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -258,7 +258,6 @@ impl ProducerContext for SinkProducerContext {
             Ok(_) => self.retry_manager.lock().unwrap().record_success(),
             Err((_e, msg)) => {
                 self.metrics.message_delivery_errors_counter.inc();
-                // Should be bounded by the size of the kafka buffer
                 self.retry_manager
                     .lock()
                     .unwrap()

--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -258,6 +258,9 @@ impl ProducerContext for SinkProducerContext {
             Ok(_) => self.retry_manager.lock().unwrap().record_success(),
             Err((_e, msg)) => {
                 self.metrics.message_delivery_errors_counter.inc();
+                // TODO: figure out a good way to back these retries off.  Should be okay without
+                // because we seem to very rarely end up in a constant state where rdkafka::send
+                // works but everything is immediately rejected and hits this branch.
                 self.retry_manager
                     .lock()
                     .unwrap()

--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -13,8 +13,8 @@ use std::cmp;
 use std::collections::{HashMap, VecDeque};
 use std::future::Future;
 use std::rc::Rc;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use anyhow::{anyhow, bail, Context};
@@ -26,7 +26,7 @@ use rdkafka::client::ClientContext;
 use rdkafka::config::ClientConfig;
 use rdkafka::consumer::{BaseConsumer, Consumer};
 use rdkafka::error::{KafkaError, KafkaResult, RDKafkaErrorCode};
-use rdkafka::message::{Message, ToBytes};
+use rdkafka::message::{Message, OwnedMessage, ToBytes};
 use rdkafka::producer::Producer;
 use rdkafka::producer::{BaseRecord, DeliveryResult, ProducerContext, ThreadedProducer};
 use rdkafka::{Offset, TopicPartitionList};
@@ -62,7 +62,7 @@ use mz_timely_util::operators_async_ext::OperatorBuilderExt;
 
 use super::KafkaBaseMetrics;
 use crate::render::sinks::SinkRender;
-use prometheus::core::{AtomicI64, AtomicU64};
+use prometheus::core::{AtomicI64 as PrometheusAtomicI64, AtomicU64 as PrometheusAtomicU64};
 
 impl<G> SinkRender<G> for KafkaSinkConnector
 where
@@ -152,10 +152,10 @@ where
 
 /// Per-Kafka sink metrics.
 pub struct SinkMetrics {
-    messages_sent_counter: DeleteOnDropCounter<'static, AtomicI64, Vec<String>>,
-    message_send_errors_counter: DeleteOnDropCounter<'static, AtomicI64, Vec<String>>,
-    message_delivery_errors_counter: DeleteOnDropCounter<'static, AtomicI64, Vec<String>>,
-    rows_queued: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
+    messages_sent_counter: DeleteOnDropCounter<'static, PrometheusAtomicI64, Vec<String>>,
+    message_send_errors_counter: DeleteOnDropCounter<'static, PrometheusAtomicI64, Vec<String>>,
+    message_delivery_errors_counter: DeleteOnDropCounter<'static, PrometheusAtomicI64, Vec<String>>,
+    rows_queued: DeleteOnDropGauge<'static, PrometheusAtomicU64, Vec<String>>,
 }
 
 impl SinkMetrics {
@@ -187,11 +187,21 @@ impl SinkMetrics {
 
 pub struct SinkProducerContext {
     metrics: Arc<SinkMetrics>,
+    retry_queue: Arc<Mutex<VecDeque<OwnedMessage>>>,
+    outstanding_send_count: Arc<AtomicU64>,
 }
 
 impl SinkProducerContext {
-    pub fn new(metrics: Arc<SinkMetrics>) -> Self {
-        SinkProducerContext { metrics }
+    pub fn new(
+        metrics: Arc<SinkMetrics>,
+        retry_queue: Arc<Mutex<VecDeque<OwnedMessage>>>,
+        outstanding_send_count: Arc<AtomicU64>,
+    ) -> Self {
+        SinkProducerContext {
+            metrics,
+            retry_queue,
+            outstanding_send_count,
+        }
     }
 }
 
@@ -211,15 +221,13 @@ impl ProducerContext for SinkProducerContext {
     fn delivery(&self, result: &DeliveryResult, _: Self::DeliveryOpaque) {
         match result {
             Ok(_) => (),
-            Err((e, msg)) => {
+            Err((_e, msg)) => {
                 self.metrics.message_delivery_errors_counter.inc();
-                error!(
-                    "received error while writing to kafka sink topic {}: {}",
-                    msg.topic(),
-                    e
-                );
+                // Should be bounded by the size of the kafka buffer
+                self.retry_queue.lock().unwrap().push_back(msg.detach());
             }
         }
+        self.outstanding_send_count.fetch_sub(1, Ordering::SeqCst);
     }
 }
 
@@ -363,6 +371,8 @@ struct KafkaSinkState {
     transactional: bool,
     pending_rows: HashMap<Timestamp, Vec<EncodedRow>>,
     ready_rows: VecDeque<(Timestamp, Vec<EncodedRow>)>,
+    retry_queue: Arc<Mutex<VecDeque<OwnedMessage>>>,
+    outstanding_send_count: Arc<AtomicU64>,
     sink_state: KafkaSinkStateEnum,
 
     /// Timestamp of the latest `END` record that was written out to Kafka.
@@ -400,12 +410,17 @@ impl KafkaSinkState {
             &worker_id,
         ));
 
+        let outstanding_send_count = Arc::new(AtomicU64::new(0));
+        let retry_queue = Arc::new(Mutex::new(VecDeque::new()));
+
         let producer = KafkaTxProducer {
             name: sink_name.clone(),
             inner: Arc::new(
                 config
                     .create_with_context::<_, ThreadedProducer<_>>(SinkProducerContext::new(
                         Arc::clone(&metrics),
+                        Arc::clone(&retry_queue),
+                        Arc::clone(&outstanding_send_count),
                     ))
                     .expect("creating kafka producer for Kafka sink failed"),
             ),
@@ -431,6 +446,8 @@ impl KafkaSinkState {
             transactional: connector.exactly_once,
             pending_rows: HashMap::new(),
             ready_rows: VecDeque::new(),
+            outstanding_send_count,
+            retry_queue,
             sink_state,
             latest_progress_ts: Timestamp::minimum(),
             write_frontier,
@@ -597,6 +614,7 @@ impl KafkaSinkState {
             match self.producer.send(record) {
                 Ok(_) => {
                     self.metrics.messages_sent_counter.inc();
+                    self.outstanding_send_count.fetch_add(1, Ordering::SeqCst);
                     return Ok(());
                 }
                 Err((e, rec)) => {
@@ -626,6 +644,30 @@ impl KafkaSinkState {
     }
 
     async fn flush(&self) -> KafkaResult<()> {
+        loop {
+            self.flush_inner().await?;
+            if self.outstanding_send_count.load(Ordering::SeqCst) == 0
+                && self.retry_queue.lock().unwrap().len() == 0
+            {
+                break;
+            }
+            while let Some(msg) = { self.retry_queue.lock().unwrap().pop_front() } {
+                let mut transformed_msg = BaseRecord::to(msg.topic());
+                transformed_msg = match msg.key() {
+                    Some(k) => transformed_msg.key(k),
+                    None => transformed_msg,
+                };
+                transformed_msg = match msg.payload() {
+                    Some(p) => transformed_msg.payload(p),
+                    None => transformed_msg,
+                };
+                self.send(transformed_msg).await?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn flush_inner(&self) -> KafkaResult<()> {
         let self_producer = self.producer.clone();
         // Only actually used for retriable errors.
         Retry::default()
@@ -1217,6 +1259,10 @@ where
                     }
                 }
 
+                // Flush to make sure that errored messages have been properly retried before
+                // sending consistency records and commit transactions.
+                bail_err!(s.flush().await);
+
                 if let Some(ref consistency_state) = s.sink_state.unwrap_running() {
                     bail_err!(
                         s.send_consistency_record(
@@ -1275,6 +1321,7 @@ where
             }
 
             debug_assert_eq!(s.producer.inner.in_flight_count(), 0);
+            debug_assert_eq!(s.retry_queue.lock().unwrap().len(), 0);
 
             if !s.pending_rows.is_empty() {
                 // We have some more rows that we need to wait for frontiers to advance before we

--- a/test/kafka-resumption/mzcompose.py
+++ b/test/kafka-resumption/mzcompose.py
@@ -45,7 +45,9 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     for i, failure_mode in enumerate(
         [
             "toxiproxy-close-connection.td",
+            "toxiproxy-limit-connection.td",
             "toxiproxy-timeout.td",
+            "toxiproxy-timeout-hold.td",
         ]
     ):
         c.run(

--- a/test/kafka-resumption/mzcompose.py
+++ b/test/kafka-resumption/mzcompose.py
@@ -50,6 +50,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             "toxiproxy-timeout-hold.td",
         ]
     ):
+        c.start_and_wait_for_tcp(["toxiproxy"])
         c.run(
             "testdrive-svc",
             "--no-reset",
@@ -64,3 +65,4 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             "verify-success.td",
             "cleanup.td",
         )
+        c.kill("toxiproxy")

--- a/test/kafka-resumption/mzcompose.py
+++ b/test/kafka-resumption/mzcompose.py
@@ -47,7 +47,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             "toxiproxy-close-connection.td",
             "toxiproxy-limit-connection.td",
             "toxiproxy-timeout.td",
-            "toxiproxy-timeout-hold.td",
+            # TODO: Enable https://github.com/MaterializeInc/materialize/issues/11085
+            # "toxiproxy-timeout-hold.td",
         ]
     ):
         c.start_and_wait_for_tcp(["toxiproxy"])

--- a/test/kafka-resumption/setup.td
+++ b/test/kafka-resumption/setup.td
@@ -17,7 +17,6 @@ $ http-request method=POST url=http://toxiproxy:8474/proxies content-type=applic
 $ file-append path=dynamic.csv
 city,state,zip
 Rochester,NY,14618
-New York,NY,10004
 
 > CREATE SOURCE input
   FROM FILE '${testdrive.temp-dir}/dynamic.csv'
@@ -30,4 +29,4 @@ New York,NY,10004
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 $ file-append path=dynamic.csv
-San Francisco,CA,94114
+New York,NY,10004

--- a/test/kafka-resumption/toxiproxy-limit-connection.td
+++ b/test/kafka-resumption/toxiproxy-limit-connection.td
@@ -7,6 +7,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ file-append path=dynamic.csv
-San Francisco,CA,94114
-Brooklyn,NY,11217
+$ http-request method=POST url=http://toxiproxy:8474/proxies/kafka/toxics content-type=application/json
+{
+  "name": "kafka",
+  "type": "limit_data",
+  "attributes": { "bytes": 16 }
+}

--- a/test/kafka-resumption/toxiproxy-timeout-hold.td
+++ b/test/kafka-resumption/toxiproxy-timeout-hold.td
@@ -7,6 +7,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ file-append path=dynamic.csv
-San Francisco,CA,94114
-Brooklyn,NY,11217
+$ http-request method=POST url=http://toxiproxy:8474/proxies/kafka/toxics content-type=application/json
+{
+  "name": "kafka",
+  "type": "timeout",
+  "attributes": { "timeout": 0 }
+}


### PR DESCRIPTION
Attempt 2 to replace #10853 

There are two types of failures we can see when sending a message to rdkafka:
1. The `send` call itself.  This enqueues the message on a buffer to be sent later
2. The actual sending itself (which happens on a background thread)

We were handling (1) but not (2).  My current approach is to expand the responsibility of `KafkaSinkState::flush` to make sure that all messages are successfully sent.  This involves two new structures:
1. Retry queue: where the messages to be resent go after they are rejected
2. Tracking of outstanding message sends
We need both of these because the `ProducerContext::delivery` callback is made asynchronously after the message is successfully or unsuccessfully sent.  We need to be able to know when it's no longer possible to get more errors.

### Motivation
Fixes #10755 which alerted me to the fact that we didn't properly handle errors during the actual sending of a message.

### Checklist
- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
