### PR TITLE
QGM: Add support for QGM error in QGM -> MIR lowering

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -3415,14 +3415,12 @@ impl Coordinator {
             }
             ExplainStage::QueryGraph => {
                 // TODO add type information to the output graph
-                type Model = Result<mz_sql::query_model::Model, mz_sql::query_model::QGMError>;
-                let model = Model::from(raw_plan)?;
+                let model = mz_sql::query_model::Model::try_from(raw_plan)?;
                 model.as_dot("")?
             }
             ExplainStage::OptimizedQueryGraph => {
                 // TODO add type information to the output graph
-                type Model = Result<mz_sql::query_model::Model, mz_sql::query_model::QGMError>;
-                let mut model = Model::from(raw_plan)?;
+                let mut model = mz_sql::query_model::Model::try_from(raw_plan)?;
                 model.optimize();
                 model.as_dot("")?
             }

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -18,6 +18,8 @@ use std::mem;
 
 use anyhow::bail;
 use itertools::Itertools;
+use serde::{Deserialize, Serialize};
+
 use mz_expr::DummyHumanizer;
 
 use mz_ore::collections::CollectionExt;
@@ -38,7 +40,7 @@ pub use mz_expr::{
 
 use super::Explanation;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 /// Just like MirRelationExpr, except where otherwise noted below.
 pub enum HirRelationExpr {
     Constant {
@@ -124,7 +126,7 @@ pub enum HirRelationExpr {
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 /// Just like mz_expr::MirScalarExpr, except where otherwise noted below.
 pub enum HirScalarExpr {
     /// Unlike mz_expr::MirScalarExpr, we can nest HirRelationExprs via eg Exists. This means that a
@@ -167,7 +169,7 @@ pub enum HirScalarExpr {
     Windowing(WindowExpr),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 /// Represents the invocation of a window function over a partition with an optional
 /// order.
 pub struct WindowExpr {
@@ -206,7 +208,7 @@ impl WindowExpr {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 /// A window function with its parameters.
 ///
 /// There are two types of window functions: scalar window functions, that
@@ -251,7 +253,7 @@ impl WindowExprType {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ScalarWindowExpr {
     pub func: ScalarWindowFunc,
     pub order_by: Vec<ColumnOrder>,
@@ -296,7 +298,7 @@ impl ScalarWindowExpr {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 /// Scalar Window functions
 pub enum ScalarWindowFunc {
     RowNumber,
@@ -452,7 +454,7 @@ impl From<HirScalarExpr> for CoercibleScalarExpr {
 /// from the reference, using `column` as a unique identifier in that subquery level.
 /// A `level` of zero corresponds to the current scope, and levels increase to
 /// indicate subqueries further "outwards".
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
 pub struct ColumnRef {
     // scope level, where 0 is the current scope and 1+ are outer scopes.
     pub level: usize,
@@ -460,7 +462,7 @@ pub struct ColumnRef {
     pub column: usize,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum JoinKind {
     Inner,
     LeftOuter,
@@ -492,7 +494,7 @@ impl JoinKind {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct AggregateExpr {
     pub func: AggregateFunc,
     pub expr: Box<HirScalarExpr>,
@@ -506,7 +508,7 @@ pub struct AggregateExpr {
 /// here than in `expr`, as these aggregates may be applied over empty
 /// result sets and should be null in those cases, whereas `expr` variants
 /// only return null values when supplied nulls as input.
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub enum AggregateFunc {
     MaxNumeric,
     MaxInt16,

--- a/src/sql/src/plan/optimize.rs
+++ b/src/sql/src/plan/optimize.rs
@@ -40,16 +40,16 @@ impl HirRelationExpr {
     /// Perform optimizing algebraic rewrites on this [`HirRelationExpr`] and lower it to a [`mz_expr::MirRelationExpr`].
     ///
     /// The optimization path is fully-determined by the values of the feature flag defined in the [`OptimizerConfig`].
-    pub fn optimize_and_lower(self, config: &OptimizerConfig) -> mz_expr::MirRelationExpr {
+    pub fn optimize_and_lower(
+        self,
+        config: &OptimizerConfig,
+    ) -> Result<mz_expr::MirRelationExpr, QGMError> {
         if config.qgm_optimizations {
             // try to go through the QGM path
-            self.clone().try_qgm_path().unwrap_or_else(|e| {
-                println!("Falling back to direct HIR ⇒ MIR due to QGM error: {}", e);
-                self.lower()
-            })
+            self.try_qgm_path()
         } else {
             // directly decorrelate and lower into a MirRelationExpr
-            self.lower()
+            Ok(self.lower())
         }
     }
 

--- a/src/sql/src/plan/optimize.rs
+++ b/src/sql/src/plan/optimize.rs
@@ -58,12 +58,12 @@ impl HirRelationExpr {
     /// Return `Result::Err` if the path is not possible.
     fn try_qgm_path(self) -> Result<mz_expr::MirRelationExpr, QGMError> {
         // create a query graph model from this HirRelationExpr
-        let mut model = Result::<Model, QGMError>::from(self)?;
+        let mut model = Model::try_from(self)?;
 
         // perform optimizing algebraic rewrites on the qgm
         model.optimize();
 
         // decorrelate and lower the optimized query graph model into a MirRelationExpr
-        model.into()
+        model.try_into()
     }
 }

--- a/src/sql/src/plan/optimize.rs
+++ b/src/sql/src/plan/optimize.rs
@@ -64,6 +64,6 @@ impl HirRelationExpr {
         model.optimize();
 
         // decorrelate and lower the optimized query graph model into a MirRelationExpr
-        Ok(model.into())
+        model.into()
     }
 }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1312,7 +1312,7 @@ pub fn plan_view(
     expr.bind_parameters(&params)?;
     //TODO: materialize#724 - persist finishing information with the view?
     expr.finish(finishing);
-    let relation_expr = expr.optimize_and_lower(&scx.into());
+    let relation_expr = expr.optimize_and_lower(&scx.into())?;
 
     let name = if temporary {
         scx.allocate_temporary_name(normalize::unresolved_object_name(name.to_owned())?)

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -65,7 +65,7 @@ pub fn plan_insert(
 ) -> Result<Plan, anyhow::Error> {
     let (id, mut expr) = query::plan_insert_query(scx, table_name, columns, source)?;
     expr.bind_parameters(&params)?;
-    let expr = expr.optimize_and_lower(&scx.into());
+    let expr = expr.optimize_and_lower(&scx.into())?;
 
     Ok(Plan::Insert(InsertPlan { id, values: expr }))
 }
@@ -116,7 +116,7 @@ pub fn plan_read_then_write(
     }: query::ReadThenWritePlan,
 ) -> Result<Plan, anyhow::Error> {
     selection.bind_parameters(&params)?;
-    let selection = selection.optimize_and_lower(&scx.into());
+    let selection = selection.optimize_and_lower(&scx.into())?;
     let mut assignments_outer = HashMap::new();
     for (idx, mut set) in assignments {
         set.bind_parameters(&params)?;
@@ -263,7 +263,7 @@ pub fn plan_query(
     } = query::plan_root_query(scx, query, lifetime)?;
     expr.bind_parameters(&params)?;
     Ok(query::PlannedQuery {
-        expr: expr.optimize_and_lower(&scx.into()),
+        expr: expr.optimize_and_lower(&scx.into())?,
         desc,
         finishing,
         depends_on,

--- a/src/sql/src/query_model/error.rs
+++ b/src/sql/src/query_model/error.rs
@@ -15,16 +15,93 @@
 use std::fmt;
 
 use crate::plan::{HirRelationExpr, HirScalarExpr};
+use crate::query_model::model::{BoxScalarExpr, BoxType, QuantifierType};
 
 /// Errors that can occur while handling a QGM model.
 #[derive(Debug, Clone)]
 pub enum QGMError {
     /// Indicates HIR ⇒ QGM conversion failure due to unsupported [`HirRelationExpr`].
     UnsupportedHirRelationExpr { expr: HirRelationExpr, msg: String },
-    /// Indicates HIR ⇒ QGM conversion failure due to unsupported [`HirRelationExpr`].
+    /// Indicates HIR ⇒ QGM conversion failure due to unsupported [`HirScalarExpr`].
     UnsupportedHirScalarExpr { expr: HirScalarExpr, msg: String },
+    /// Indicates QGM ⇒ MIR conversion failure due to unsupported box type.
+    UnsupportedBoxType(UnsupportedBoxType),
+    /// Indicates QGM ⇒ MIR conversion failure due to unsupported scalar expression.
+    UnsupportedBoxScalarExpr(UnsupportedBoxScalarExpr),
+    /// Indicates QGM ⇒ MIR conversion failure due to unsupported quantifier type.
+    UnsupportedQuantifierType(UnsupportedQuantifierType),
+    /// Indicates QGM ⇒ MIR conversion failure due to lack of support for decorrelation.
+    UnsupportedDecorrelation { msg: String },
     /// An unstructured error.
     Internal { msg: String },
+}
+
+#[derive(Debug, Clone)]
+pub struct UnsupportedBoxType {
+    pub(crate) box_type: BoxType,
+    pub(crate) explanation: Option<String>,
+}
+
+impl From<UnsupportedBoxType> for QGMError {
+    fn from(inner: UnsupportedBoxType) -> Self {
+        QGMError::UnsupportedBoxType(inner)
+    }
+}
+
+impl fmt::Display for UnsupportedBoxType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "Unsupported box type in MIR conversion: {:?}.",
+            self.box_type
+        )?;
+        if let Some(explanation) = &self.explanation {
+            write!(f, " Explanation: {}", explanation)?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct UnsupportedQuantifierType {
+    pub(crate) quantifier_type: QuantifierType,
+}
+
+impl From<UnsupportedQuantifierType> for QGMError {
+    fn from(inner: UnsupportedQuantifierType) -> Self {
+        QGMError::UnsupportedQuantifierType(inner)
+    }
+}
+
+impl fmt::Display for UnsupportedQuantifierType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "Unsupported quantifier type in MIR conversion: {}.",
+            self.quantifier_type
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct UnsupportedBoxScalarExpr {
+    pub(crate) scalar: BoxScalarExpr,
+}
+
+impl From<UnsupportedBoxScalarExpr> for QGMError {
+    fn from(inner: UnsupportedBoxScalarExpr) -> Self {
+        QGMError::UnsupportedBoxScalarExpr(inner)
+    }
+}
+
+impl fmt::Display for UnsupportedBoxScalarExpr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "Unsupported QGM scalar expression in MIR conversion: {}.",
+            self.scalar
+        )
+    }
 }
 
 impl fmt::Display for QGMError {
@@ -32,6 +109,10 @@ impl fmt::Display for QGMError {
         match self {
             QGMError::UnsupportedHirRelationExpr { msg, .. } => f.write_str(msg),
             QGMError::UnsupportedHirScalarExpr { msg, .. } => f.write_str(msg),
+            QGMError::UnsupportedBoxType(s) => write!(f, "{}", s),
+            QGMError::UnsupportedDecorrelation { msg } => f.write_str(msg),
+            QGMError::UnsupportedBoxScalarExpr(s) => write!(f, "{}", s),
+            QGMError::UnsupportedQuantifierType(s) => write!(f, "{}", s),
             QGMError::Internal { msg } => f.write_str(msg),
         }
     }

--- a/src/sql/src/query_model/error.rs
+++ b/src/sql/src/query_model/error.rs
@@ -12,12 +12,17 @@
 //! The public interface consists of the [`QGMError`] method and the
 //! implemented traits.
 
+use std::error::Error;
 use std::fmt;
 
 use crate::plan::{HirRelationExpr, HirScalarExpr};
 use crate::query_model::model::{BoxScalarExpr, BoxType, QuantifierType};
 
 /// Errors that can occur while handling a QGM model.
+///
+/// A bunch of the error types exist because our support for HIR ⇒ QGM
+/// conversion and QGM ⇒ MIR conversion is currently incomplete. They will be
+/// removed once these limitations are addressed.
 #[derive(Debug, Clone)]
 pub enum QGMError {
     /// Indicates HIR ⇒ QGM conversion failure due to unsupported [`HirRelationExpr`].
@@ -35,6 +40,8 @@ pub enum QGMError {
     /// An unstructured error.
     Internal { msg: String },
 }
+
+impl Error for QGMError {}
 
 #[derive(Debug, Clone)]
 pub struct UnsupportedBoxType {

--- a/src/sql/src/query_model/hir.rs
+++ b/src/sql/src/query_model/hir.rs
@@ -23,8 +23,9 @@ use crate::query_model::model::{
     Grouping, Model, OuterJoin, QuantifierType, Select, Values,
 };
 
-impl From<HirRelationExpr> for Result<Model, QGMError> {
-    fn from(expr: HirRelationExpr) -> Self {
+impl TryFrom<HirRelationExpr> for Model {
+    type Error = QGMError;
+    fn try_from(expr: HirRelationExpr) -> Result<Self, Self::Error> {
         FromHir::generate(expr)
     }
 }

--- a/src/sql/src/query_model/hir.rs
+++ b/src/sql/src/query_model/hir.rs
@@ -88,7 +88,7 @@ impl FromHir {
                     Ok(result)
                 } else {
                     // Other id variants should not be present in the HirRelationExpr.
-                    // Tn theory, this should be `unreachable!(...)`, but we return an
+                    // In theory, this should be `unreachable!(...)`, but we return an
                     // Error just to be safe here.
                     let expr = HirRelationExpr::Get { id, typ };
                     let msg = String::from("Unexpected Id variant in Get");

--- a/src/sql/src/query_model/mir.rs
+++ b/src/sql/src/query_model/mir.rs
@@ -13,7 +13,8 @@
 //! [`Into<mz_expr::MirRelationExpr>`] for [`Model`].
 
 use crate::query_model::error::{
-    QGMError, UnsupportedBoxScalarExpr, UnsupportedBoxType, UnsupportedQuantifierType,
+    QGMError, UnsupportedBoxScalarExpr, UnsupportedBoxType, UnsupportedDecorrelation,
+    UnsupportedQuantifierType,
 };
 use crate::query_model::model::{
     BaseColumn, BoundRef, BoxId, BoxScalarExpr, BoxType, ColumnReference, DistinctOperation, Get,
@@ -182,7 +183,7 @@ impl<'a> Lowerer<'a> {
                 let correlation_info = the_box.correlation_info();
                 if !correlation_info.is_empty() {
                     let msg = String::from("correlated joins are not supported yet");
-                    return Err(QGMError::UnsupportedDecorrelation { msg });
+                    return Err(QGMError::from(UnsupportedDecorrelation { msg }));
                 }
 
                 let outer_arity = get_outer.arity();
@@ -309,7 +310,7 @@ impl<'a> Lowerer<'a> {
                 let correlation_info = the_box.correlation_info();
                 if !correlation_info.is_empty() {
                     let msg = String::from("correlated joins are not supported yet");
-                    return Err(QGMError::UnsupportedDecorrelation { msg });
+                    return Err(QGMError::from(UnsupportedDecorrelation { msg }));
                 }
 
                 let ot = get_outer.typ();
@@ -525,7 +526,7 @@ impl<'a> Lowerer<'a> {
                 "get_outer: expected a MirRelationExpr::Get, found {:?}",
                 get_outer
             );
-            return Err(QGMError::UnsupportedDecorrelation { msg });
+            return Err(QGMError::from(UnsupportedDecorrelation { msg }));
         }
 
         let outer_arity = get_outer.arity();

--- a/src/sql/src/query_model/mir.rs
+++ b/src/sql/src/query_model/mir.rs
@@ -26,8 +26,9 @@ use mz_ore::id_gen::IdGen;
 use mz_repr::{Datum, RelationType, ScalarType};
 use std::collections::HashMap;
 
-impl From<Model> for Result<mz_expr::MirRelationExpr, QGMError> {
-    fn from(model: Model) -> Result<mz_expr::MirRelationExpr, QGMError> {
+impl TryFrom<Model> for mz_expr::MirRelationExpr {
+    type Error = QGMError;
+    fn try_from(model: Model) -> Result<Self, Self::Error> {
         Lowerer::new(&model).lower()
     }
 }

--- a/src/sql/src/query_model/model/graph.rs
+++ b/src/sql/src/query_model/model/graph.rs
@@ -201,7 +201,7 @@ pub(crate) const ARBITRARY_QUANTIFIER: usize = 0b00000000
     | (QuantifierType::PreservedForeach as usize)
     | (QuantifierType::Scalar as usize);
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) enum BoxType {
     /// A table from the catalog.
     Get(Get),
@@ -230,7 +230,7 @@ pub(crate) enum BoxType {
     Values(Values),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct Get {
     pub id: mz_expr::GlobalId,
     pub unique_keys: Vec<Vec<usize>>,
@@ -243,7 +243,7 @@ impl From<Get> for BoxType {
 }
 
 /// The content of a Grouping box.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub(crate) struct Grouping {
     pub key: Vec<BoxScalarExpr>,
 }
@@ -255,7 +255,7 @@ impl From<Grouping> for BoxType {
 }
 
 /// The content of a OuterJoin box.
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default)]
 pub(crate) struct OuterJoin {
     /// The predices in the ON clause of the outer join.
     pub predicates: Vec<BoxScalarExpr>,
@@ -268,7 +268,7 @@ impl From<OuterJoin> for BoxType {
 }
 
 /// The content of a Select box.
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default)]
 pub(crate) struct Select {
     /// The list of predicates applied by the box.
     pub predicates: Vec<BoxScalarExpr>,
@@ -297,7 +297,7 @@ impl Select {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default)]
 pub(crate) struct TableFunction {
     pub parameters: Vec<BoxScalarExpr>,
     // @todo function metadata from the catalog
@@ -309,7 +309,7 @@ impl From<TableFunction> for BoxType {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default)]
 pub(crate) struct Values {
     pub rows: Vec<Vec<BoxScalarExpr>>,
 }

--- a/src/sql/src/query_model/test/mod.rs
+++ b/src/sql/src/query_model/test/mod.rs
@@ -106,11 +106,10 @@ fn run_command(
 
     // TODO: allow printing multiple stages of the transformation of the query.
     if matches!(directive, Directive::Lower | Directive::EndToEnd) {
-        Ok(generate_explanation(
-            catalog,
-            &model.into(),
-            args.get("format"),
-        ))
+        match model.into() {
+            Ok(mir) => Ok(generate_explanation(catalog, &mir, args.get("format"))),
+            Err(err) => Err(err.to_string()),
+        }
     } else {
         match model.as_dot(input) {
             Ok(graph) => Ok(graph),

--- a/src/sql/src/query_model/test/mod.rs
+++ b/src/sql/src/query_model/test/mod.rs
@@ -15,7 +15,7 @@ use crate::plan::StatementContext;
 use mz_expr_test_util::generate_explanation;
 use mz_lowertest::*;
 
-use crate::query_model::{Model, QGMError};
+use crate::query_model::Model;
 use catalog::TestCatalog;
 
 use lazy_static::lazy_static;
@@ -72,7 +72,7 @@ fn convert_input_to_model(input: &str, catalog: &TestCatalog) -> Result<Model, S
                     Ok(planned_query) => planned_query,
                     Err(e) => return Err(format!("unable to plan query: {}: {}", input, e)),
                 };
-                Result::<Model, QGMError>::from(planned_query.expr).map_err(|e| e.into())
+                Model::try_from(planned_query.expr).map_err(|e| e.into())
             } else {
                 Err(format!("invalid query: {}", input))
             }
@@ -106,7 +106,7 @@ fn run_command(
 
     // TODO: allow printing multiple stages of the transformation of the query.
     if matches!(directive, Directive::Lower | Directive::EndToEnd) {
-        match model.into() {
+        match model.try_into() {
             Ok(mir) => Ok(generate_explanation(catalog, &mir, args.get("format"))),
             Err(err) => Err(err.to_string()),
         }

--- a/src/sql/tests/querymodel/lowering
+++ b/src/sql/tests/querymodel/lowering
@@ -203,9 +203,14 @@ c from x where x.b is not null) z on y.a = z.b
 | | types = (Int32, Int64?, Int32?)
 | | keys = ((#0))
 
-%2 =
+%2 = Let l1 =
 | Join %0 %1
 | | implementation = Unimplemented
+| | types = (Int32, Int64?, Int32?)
+| | keys = ()
+
+%3 =
+| Get %2 (l1)
 | | types = (Int32, Int64?, Int32?)
 | | keys = ()
 | Filter (#0 = 0)
@@ -218,14 +223,8 @@ c from x where x.b is not null) z on y.a = z.b
 | | types = (Int32, Int32?)
 | | keys = ()
 
-%3 =
-| Get ? (u0)
-| | types = (Int32, Int64?, Int32?)
-| | keys = ((#0))
-
 %4 =
-| Join %0 %3
-| | implementation = Unimplemented
+| Get %2 (l1)
 | | types = (Int32, Int64?, Int32?)
 | | keys = ()
 | Filter !(isnull(#1))
@@ -239,7 +238,7 @@ c from x where x.b is not null) z on y.a = z.b
 | | keys = ()
 
 %5 =
-| Join %2 %4
+| Join %3 %4
 | | implementation = Unimplemented
 | | types = (Int32, Int32?, Int64, Int32?)
 | | keys = ()
@@ -827,5 +826,75 @@ select * from x full outer join y on x.a = y.b
 | Union %8 %11
 | Project (#0..=#4)
 | Project (#0..=#4)
+----
+----
+
+lower
+WITH w(f1, f2, f3, f4, f5) as (select * from x full outer join y on x.a = y.a)
+select * from w w1 inner join w w2 on w1.f1 = w1.f5
+----
+----
+%0 = Let l0 =
+| Constant ()
+
+%1 =
+| Get ? (u0)
+
+%2 = Let l1 =
+| Join %0 %1
+| | implementation = Unimplemented
+
+%3 =
+| Get ? (u1)
+
+%4 = Let l2 =
+| Join %0 %3
+| | implementation = Unimplemented
+
+%5 = Let l3 =
+| Join %2 %4
+| | implementation = Unimplemented
+| Project (#0..=#4)
+| Filter (#0 = #3)
+
+%6 = Let l4 =
+| Get %5 (l3)
+| Project (#0)
+| Distinct group=(#0)
+
+%7 =
+| Join %4 %6 (= #0 #2)
+| | implementation = Unimplemented
+| Project (#0, #1)
+| Negate
+
+%8 =
+| Union %7 %4
+| Map null, null, null
+| Project (#2..=#4, #0, #1)
+
+%9 =
+| Join %2 %6 (= #0 #3)
+| | implementation = Unimplemented
+| Project (#0..=#2)
+| Negate
+
+%10 =
+| Union %9 %2
+| Map null, null
+
+%11 =
+| Union %10 %5
+
+%12 = Let l5 =
+| Union %8 %11
+| Project (#0..=#4)
+
+%13 =
+| Join %12 %12
+| | implementation = Unimplemented
+| Project (#0..=#9)
+| Filter (#0 = #4)
+| Project (#0..=#9)
 ----
 ----


### PR DESCRIPTION
### Motivation

  * This PR adds a known-desirable feature.

Follow-up for #9128. Have the QGM -> MIR code throw errors instead of panicking if lowering fails due to unsupported features.

### Tips for reviewer

Hiding whitespace changes will make life much easier.

The first commit deals with the problem that `MirRelationExpr::let_in` only takes an infallible function. I considered creating a new version of `let_in` that takes a fallible function, but I realized that `MirRelationExpr::let_in` is not suited for lowering QGM common expressions anyway because QGM boxes can have more than one parent. So I've taken out `MirRelationExpr::let_in` from mir.rs and replaced it with:
1) A stack that tracks `Let`s that have been created.
2) A map of (box with more than one parent) -> (the `MirRelationExpr` corresponding to the subtree whose root is the box).

If you run the test in the first commit against main, you will see the result on main 26 nodes instead of the 14 that the result on this branch has.

The second commit has the QGM -> MIR code throw errors if lowering fails due to unsupported features. I left one panic in mir.rs because I believe that a validation error instead of a QGMError should be thrown for that. Since enums cannot have crate-private fields, I made errors like UnsupportedBoxType have its own public struct. The fields of the struct are crate-private.

The third commit is just a typo fix.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

No user-facing behavior changes.