### PR TITLE
Correct massive error in timestamp management

### DIFF
--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -118,7 +118,7 @@ where
     let local_input = LocalInput { handle, capability };
     let as_of_frontier = as_of_frontier.clone();
     let ok_collection = ok_stream
-        .map_in_place(move |(_, mut time, _)| {
+        .map_in_place(move |(_, time, _)| {
             time.advance_by(as_of_frontier.borrow());
         })
         .as_collection();


### PR DESCRIPTION
Deconstructing a `&mut (Row, Timestamp, Diff)` as `(row, mut time, diff)` creates a copy of `time` rather than a `&mut Timestamp`, such that subsequent calls to `time.advance_by(frontier)` acted on the copy, not the reference. I couldn't believe it either.

The fix is to remove the `mut` modifier. 

Tables have not been advanced to `dataflow.as_of` since .. pretty much forever. They only worked because they were loaded directly into arrangements, which was fine because they were then compacted. This manifests as a crash only in a @benesch branch where live table data can interact with other properly advanced collections, causing errors.

@mjibson shout out: this would have been noticed if timestamps were an opaque type that didn't implement `Copy`.

### Motivation

  * This PR fixes a Rust footgun.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
