### PR TITLE
Teach `Worker` to support multiple compute instances

### DIFF
--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -380,7 +380,7 @@ where
                                 &envelope,
                                 metadata_columns,
                                 &mut linear_operators,
-                                storage_state.metrics.clone(),
+                                storage_state.unspecified_metrics.clone(),
                             ),
                             SourceType::ByteStream(source) => render_decode(
                                 &source,
@@ -388,7 +388,7 @@ where
                                 dataflow_debug_name,
                                 metadata_columns,
                                 &mut linear_operators,
-                                storage_state.metrics.clone(),
+                                storage_state.unspecified_metrics.clone(),
                             ),
                         };
                         if let Some(tok) = extra_token {

--- a/src/dataflow/src/server/storage_state.rs
+++ b/src/dataflow/src/server/storage_state.rs
@@ -58,7 +58,7 @@ pub struct StorageState {
     /// will contain a handle to it.
     pub persisted_sources: PersistedSourceManager,
     /// Metrics reported by all dataflows.
-    pub metrics: Metrics,
+    pub unspecified_metrics: Metrics,
     /// Handle to the persistence runtime. None if disabled.
     pub persist: Option<RuntimeClient>,
     /// Tracks the timestamp binding durability information that has been sent over `response_tx`.


### PR DESCRIPTION
This PR teaches `Worker` to support multiple "virtual" compute instances. These instances are just independent `ComputeState` instances, rather than new processes or deployments, but they exercise our ability to speak about multiple instances and to see if we function correctly when asked to create and use various instances.

This does not teach the coordinator to use instances yet, though the `Controller` does maintain read capabilities and write frontiers partitioned by storage and compute instance, so it could potentially rely more on it for this state.

cc: @sploiselle 

### Motivation

Previously, attempts to create an instance other than `DEFAULT_COMPUTE_INSTANCE_ID` would .. likely eventually panic. The argument was ignored, and if logging was on in multiple instances their frontiers would clash when returning back through `PartitionedClient`.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
