### PR TITLE
dataflow: remove SQL name from SourceDesc

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -137,7 +137,6 @@ impl CatalogState {
                     persisted_name: table.persist_name.clone(),
                 };
                 Some(mz_dataflow_types::sources::SourceDesc {
-                    name: entry.name().to_string(),
                     connector,
                     desc: table.desc.clone(),
                 })
@@ -145,7 +144,6 @@ impl CatalogState {
             CatalogItem::Source(source) => {
                 let connector = source.connector.clone();
                 Some(mz_dataflow_types::sources::SourceDesc {
-                    name: entry.name().to_string(),
                     connector,
                     desc: source.desc.clone(),
                 })

--- a/src/dataflow-types/src/errors.rs
+++ b/src/dataflow-types/src/errors.rs
@@ -10,7 +10,7 @@
 use std::fmt::Display;
 
 use bytes::BufMut;
-use mz_expr::EvalError;
+use mz_expr::{EvalError, SourceInstanceId};
 use mz_persist_types::Codec;
 
 use serde::{Deserialize, Serialize};
@@ -53,19 +53,19 @@ impl Display for DecodeError {
 
 #[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub struct SourceError {
-    pub source_name: String,
+    pub source_id: SourceInstanceId,
     pub error: SourceErrorDetails,
 }
 
 impl SourceError {
-    pub fn new(source_name: String, error: SourceErrorDetails) -> SourceError {
-        SourceError { source_name, error }
+    pub fn new(source_id: SourceInstanceId, error: SourceErrorDetails) -> SourceError {
+        SourceError { source_id, error }
     }
 }
 
 impl Display for SourceError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}: ", self.source_name)?;
+        write!(f, "{}: ", self.source_id)?;
         self.error.fmt(f)
     }
 }

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -1123,7 +1123,6 @@ pub mod sources {
     /// of the collection.
     #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
     pub struct SourceDesc {
-        pub name: String,
         pub connector: SourceConnector,
         pub desc: RelationDesc,
     }

--- a/src/dataflow/src/source/postgres/metrics.rs
+++ b/src/dataflow/src/source/postgres/metrics.rs
@@ -7,9 +7,12 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::source::metrics::SourceBaseMetrics;
-use mz_ore::metrics::{CounterVecExt, DeleteOnDropCounter, DeleteOnDropGauge, GaugeVecExt};
 use prometheus::core::AtomicU64;
+
+use mz_expr::SourceInstanceId;
+use mz_ore::metrics::{CounterVecExt, DeleteOnDropCounter, DeleteOnDropGauge, GaugeVecExt};
+
+use crate::source::metrics::SourceBaseMetrics;
 
 pub(super) struct PgSourceMetrics {
     pub inserts: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
@@ -23,8 +26,8 @@ pub(super) struct PgSourceMetrics {
 }
 
 impl PgSourceMetrics {
-    pub(super) fn new(base_metrics: &SourceBaseMetrics, source_id: String) -> Self {
-        let labels = &[source_id];
+    pub(super) fn new(base_metrics: &SourceBaseMetrics, source_id: SourceInstanceId) -> Self {
+        let labels = &[source_id.to_string()];
         let pg_metrics = &base_metrics.postgres_source_specific;
         Self {
             inserts: pg_metrics

--- a/src/dataflow/src/source/pubnub.rs
+++ b/src/dataflow/src/source/pubnub.rs
@@ -15,22 +15,23 @@ use pubnub_hyper::core::data::{channel, message::Type};
 use pubnub_hyper::{Builder, DefaultRuntime, DefaultTransport};
 use tracing::info;
 
-use crate::source::{SimpleSource, SourceError, Timestamper};
 use mz_dataflow_types::{sources::PubNubSourceConnector, SourceErrorDetails};
+use mz_expr::SourceInstanceId;
 use mz_repr::{Datum, Row};
+
+use crate::source::{SimpleSource, SourceError, Timestamper};
 
 /// Information required to sync data from PubNub
 pub struct PubNubSourceReader {
-    /// Used to produce useful error messages
-    source_name: String,
+    source_id: SourceInstanceId,
     connector: PubNubSourceConnector,
 }
 
 impl PubNubSourceReader {
     /// Constructs a new instance
-    pub fn new(source_name: String, connector: PubNubSourceConnector) -> Self {
+    pub fn new(source_id: SourceInstanceId, connector: PubNubSourceConnector) -> Self {
         Self {
-            source_name,
+            source_id,
             connector,
         }
     }
@@ -45,7 +46,7 @@ impl SimpleSource for PubNubSourceReader {
             .subscribe_key(&self.connector.subscribe_key)
             .build()
             .map_err(|e| SourceError {
-                source_name: self.source_name.clone(),
+                source_id: self.source_id,
                 error: SourceErrorDetails::FileIO(e.to_string()),
             })?;
 
@@ -55,15 +56,13 @@ impl SimpleSource for PubNubSourceReader {
             .build();
 
         let channel = self.connector.channel;
-        let source_name = self.source_name.clone();
         let channel: channel::Name = channel.parse().or_else(|_| {
             Err(SourceError {
-                source_name,
+                source_id: self.source_id,
                 error: SourceErrorDetails::FileIO(format!("invalid pubnub channel: {}", channel)),
             })
         })?;
 
-        let source_name = self.source_name.clone();
         loop {
             let stream = pubnub.subscribe(channel.clone()).await;
             tokio::pin!(stream);
@@ -75,7 +74,7 @@ impl SimpleSource for PubNubSourceReader {
                     let row = Row::pack_slice(&[Datum::String(&s)]);
 
                     timestamper.insert(row).await.map_err(|e| SourceError {
-                        source_name: source_name.clone(),
+                        source_id: self.source_id,
                         error: SourceErrorDetails::FileIO(e.to_string()),
                     })?;
                 }

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -419,7 +419,7 @@ INSERT INTO pk_table VALUES (99999);
 # todo: we're purifying Postgres view names incorrectly, fix that and this error!
 # should be "materialize.public.pk_table"
 ! SELECT COUNT(*) = 0 FROM pk_table;
-contains:Source error: materialize.public.mz_source: file IO: db error: ERROR: publication "mz_source" does not exist
+regex:Source error: .*: file IO: db error: ERROR: publication "mz_source" does not exist
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 DROP SCHEMA conflict_schema CASCADE;

--- a/test/testdrive/csv-sources.td
+++ b/test/testdrive/csv-sources.td
@@ -149,7 +149,7 @@ $ file-delete path=deleting.csv
 > CREATE INDEX i ON deleting_csv(city,state,zip)
 
 ! SELECT * FROM deleting_csv
-contains:Source error: materialize.public.deleting_csv: file IO: file source: unable to open file at path
+regex:Source error: .*: file IO: file source: unable to open file at path
 
 ! CREATE SOURCE should_fail FROM FILE '/'
 contains:/ is a directory.

--- a/test/testdrive/rename.td
+++ b/test/testdrive/rename.td
@@ -55,6 +55,12 @@ name
 materialize.public.mz_data
 materialize.public.mz_data_primary_idx
 
+# Test that data can be selected from the source before renaming.
+> SELECT * FROM mz_data
+a  b    mz_obj_no
+-----------------
+1  dog  1
+
 > ALTER SOURCE mz_data RENAME TO renamed_mz_data;
 
 > SELECT name FROM mz_catalog_names WHERE name LIKE '%materialize.public.mz_data%';
@@ -66,6 +72,23 @@ materialize.public.mz_data_primary_idx
 name
 -----
 materialize.public.renamed_mz_data
+
+# Test that data can be selected from the source after renaming.
+> SELECT * FROM renamed_mz_data
+a  b    mz_obj_no
+-----------------
+1  dog  1
+
+# Test that data can be selected from the source if it is rematerialized with
+# the new name. This previously tripped an assertion that asserted that a source
+# descriptor never changed; it is in fact okay for the name of a source to
+# change.
+> DROP INDEX mz_data_primary_idx
+> CREATE DEFAULT INDEX ON renamed_mz_data
+> SELECT * FROM renamed_mz_data
+a  b    mz_obj_no
+-----------------
+1  dog  1
 
 > SELECT name FROM mz_catalog_names WHERE name LIKE '%materialize.public.mz_view%';
 name


### PR DESCRIPTION
The name of a source is a SQL concept; the dataflow layer should be
entirely oblivious to this name. But abea8395c1 started embedding the
SQL name of the source in dataflow's `SourceDesc` to improve error
messages. This has two defects:

  * The error message includes the wrong name if the source is ever
    renamed.

  * Changing the name of the source causes the source description to
    change from dataflow's perspective, which trips an assertion.

This commit removes the SQL name from the `SourceDesc`. Instead, source
errors report the source instance ID rather than the name, since this
ID is stable even if the name changes.

This will have a negative impact on error messages, because now the user
needs to translate the source instance ID into a name. We can restore
the original behavior by teaching the coordinator to perform this
translation before it sends the error message to the client, but that's
not addressed in this commit.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Fix a panic when materializing a source that has been renamed since it was last materialized.
