### PR TITLE
Clarify source timestamping

### DIFF
--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -174,6 +174,30 @@ pub fn build_storage_dataflow<A: Allocate, B: StorageCapture>(
                     src_id.clone(),
                 );
 
+                // Capture the frontier of `ok` to present as the "source upper".
+                // TODO: remove this code when storage has a better holistic take on source progress.
+                // This shared frontier is set up in `CreateSource`, and must be present by the time we render as source.
+                let shared_frontier = Rc::clone(&storage_state.source_uppers[src_id]);
+                use timely::dataflow::operators::Operator;
+                ok.inner.sink(
+                    timely::dataflow::channels::pact::Pipeline,
+                    "frontier monitor",
+                    move |input| {
+                        // Drain the input; we don't need it.
+                        input.for_each(|_, _| {});
+                        // Read the input frontier, and join with the shared frontier.
+                        let mut joined_frontier = Antichain::new();
+                        let mut borrow = shared_frontier.borrow_mut();
+                        for time1 in borrow.iter() {
+                            for time2 in &input.frontier.frontier() {
+                                use differential_dataflow::lattice::Lattice;
+                                joined_frontier.insert(time1.join(time2));
+                            }
+                        }
+                        *borrow = joined_frontier;
+                    },
+                );
+
                 let source_key = source.with_id(*src_id);
                 boundary.capture(source_key, ok, err, token, &debug_name, dataflow_id);
             }

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -178,6 +178,7 @@ pub fn build_storage_dataflow<A: Allocate, B: StorageCapture>(
                 // TODO: remove this code when storage has a better holistic take on source progress.
                 // This shared frontier is set up in `CreateSource`, and must be present by the time we render as source.
                 let shared_frontier = Rc::clone(&storage_state.source_uppers[src_id]);
+                let weak_token = Rc::downgrade(&token);
                 use timely::dataflow::operators::Operator;
                 ok.inner.sink(
                     timely::dataflow::channels::pact::Pipeline,
@@ -185,16 +186,21 @@ pub fn build_storage_dataflow<A: Allocate, B: StorageCapture>(
                     move |input| {
                         // Drain the input; we don't need it.
                         input.for_each(|_, _| {});
-                        // Read the input frontier, and join with the shared frontier.
-                        let mut joined_frontier = Antichain::new();
-                        let mut borrow = shared_frontier.borrow_mut();
-                        for time1 in borrow.iter() {
-                            for time2 in &input.frontier.frontier() {
-                                use differential_dataflow::lattice::Lattice;
-                                joined_frontier.insert(time1.join(time2));
+
+                        // Only attempt the frontier update if the source is still live.
+                        // If it is shutting down, we shouldn't treat the frontier as correct.
+                        if let Some(_) = weak_token.upgrade() {
+                            // Read the input frontier, and join with the shared frontier.
+                            let mut joined_frontier = Antichain::new();
+                            let mut borrow = shared_frontier.borrow_mut();
+                            for time1 in borrow.iter() {
+                                for time2 in &input.frontier.frontier() {
+                                    use differential_dataflow::lattice::Lattice;
+                                    joined_frontier.insert(time1.join(time2));
+                                }
                             }
+                            *borrow = joined_frontier;
                         }
-                        *borrow = joined_frontier;
                     },
                 );
 

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -141,12 +141,13 @@ pub fn serve(config: Config) -> Result<(Server, LocalClient), anyhow::Error> {
             storage_state: StorageState {
                 local_inputs: HashMap::new(),
                 source_descriptions: HashMap::new(),
+                source_uppers: HashMap::new(),
                 ts_source_mapping: HashMap::new(),
                 ts_histories: HashMap::default(),
                 persisted_sources: PersistedSourceManager::new(),
                 unspecified_metrics,
                 persist: config.persister.clone(),
-                reported_bindings_frontiers: HashMap::new(),
+                reported_frontiers: HashMap::new(),
                 last_bindings_feedback: Instant::now(),
                 now: now.clone(),
                 source_metrics,
@@ -240,7 +241,8 @@ where
                     .report_compute_frontiers();
             }
             self.activate_storage().update_rt_timestamps();
-            self.activate_storage().report_timestamp_bindings();
+            self.activate_storage()
+                .report_conditional_frontier_progress();
 
             // Handle any received commands.
             let mut cmds = vec![];

--- a/src/dataflow/src/server/storage_state.rs
+++ b/src/dataflow/src/server/storage_state.rs
@@ -3,8 +3,9 @@
 // Use of this software is governed by the Business Source License
 // included in the LICENSE file.
 
+use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};
-use std::rc::Weak;
+use std::rc::{Rc, Weak};
 use std::time::{Duration, Instant};
 
 use timely::communication::Allocate;
@@ -49,6 +50,13 @@ pub struct StorageState {
     /// Once we have a better mechanism to avoid that, for example that identifiers
     /// must strictly increase, we can clean up descriptions when sources are dropped.
     pub source_descriptions: HashMap<GlobalId, mz_dataflow_types::sources::SourceDesc>,
+    /// The highest observed upper frontier for collection.
+    ///
+    /// This is shared among all source instances, so that they can jointly advance the
+    /// frontier even as other instances are created and dropped. Ideally, the Storage
+    /// module would eventually provide one source of truth on this rather than multiple,
+    /// and we should aim for that but are not there yet.
+    pub source_uppers: HashMap<GlobalId, Rc<RefCell<Antichain<mz_repr::Timestamp>>>>,
     /// Handles to external sources, keyed by ID.
     pub ts_source_mapping: HashMap<GlobalId, Vec<Weak<Option<SourceToken>>>>,
     /// Timestamp data updates for each source.
@@ -61,8 +69,8 @@ pub struct StorageState {
     pub unspecified_metrics: Metrics,
     /// Handle to the persistence runtime. None if disabled.
     pub persist: Option<RuntimeClient>,
-    /// Tracks the timestamp binding durability information that has been sent over `response_tx`.
-    pub reported_bindings_frontiers: HashMap<GlobalId, Antichain<Timestamp>>,
+    /// Tracks the conditional write frontiers we have reported.
+    pub reported_frontiers: HashMap<GlobalId, Antichain<Timestamp>>,
     /// Tracks the last time we sent binding durability info over `response_tx`.
     pub last_bindings_feedback: Instant,
     /// Undocumented
@@ -99,6 +107,19 @@ impl<'a, A: Allocate, B: StorageCapture> ActiveStorageState<'a, A, B> {
                     self.storage_state
                         .source_descriptions
                         .insert(id, description);
+
+                    // Initialize shared frontier tracking.
+                    use timely::progress::Timestamp;
+                    self.storage_state.source_uppers.insert(
+                        id,
+                        Rc::new(RefCell::new(Antichain::from_elem(
+                            mz_repr::Timestamp::minimum(),
+                        ))),
+                    );
+
+                    self.storage_state
+                        .reported_frontiers
+                        .insert(id, Antichain::from_elem(mz_repr::Timestamp::minimum()));
                 }
             }
             StorageCommand::RenderSources(sources) => self.build_storage_dataflow(sources),
@@ -111,6 +132,10 @@ impl<'a, A: Allocate, B: StorageCapture> ActiveStorageState<'a, A, B> {
                         self.storage_state.local_inputs.remove(&id);
                         // Clean up potentially left over persisted source state.
                         self.storage_state.persisted_sources.del_source(&id);
+                        // Clean up per-source state.
+                        self.storage_state.source_descriptions.remove(&id);
+                        self.storage_state.source_uppers.remove(&id);
+                        self.storage_state.reported_frontiers.remove(&id);
                     } else {
                         if let Some(ts_history) = self.storage_state.ts_histories.get_mut(&id) {
                             ts_history.set_compaction_frontier(frontier.borrow());
@@ -219,9 +244,6 @@ impl<'a, A: Allocate, B: StorageCapture> ActiveStorageState<'a, A, B> {
 
                     let prev = self.storage_state.ts_histories.insert(id, data);
                     assert!(prev.is_none());
-                    self.storage_state
-                        .reported_bindings_frontiers
-                        .insert(id, Antichain::from_elem(0));
                 } else {
                     assert!(bindings.is_empty());
                 }
@@ -236,8 +258,6 @@ impl<'a, A: Allocate, B: StorageCapture> ActiveStorageState<'a, A, B> {
                 if prev.is_none() {
                     debug!("Attempted to drop timestamping for source {} not previously mapped to any instances", id);
                 }
-
-                self.storage_state.reported_bindings_frontiers.remove(&id);
             }
         }
     }
@@ -269,15 +289,22 @@ impl<'a, A: Allocate, B: StorageCapture> ActiveStorageState<'a, A, B> {
             );
         }
     }
-    /// Send information about new timestamp bindings created by dataflow workers back to
-    /// the coordinator.
-    pub fn report_timestamp_bindings(&mut self) {
+    /// Emit information about write frontier progress, along with information that should
+    /// be made durable for this to be the case.
+    ///
+    /// The write frontier progress is "conditional" in that it is not until the information is made
+    /// durable that the data are emitted to downstream workers, and indeed they should not rely on
+    /// the completeness of what they hear until the information is made durable.
+    ///
+    /// Specifically, this sends information about new timestamp bindings created by dataflow workers,
+    /// with the understanding if that if made durable (and ack'd back to the workers) the source will
+    /// in fact progress with this write frontier.
+    pub fn report_conditional_frontier_progress(&mut self) {
         // Do nothing if dataflow workers can't send feedback or if not enough time has elapsed since
         // the last time we reported timestamp bindings.
         if self.storage_state.last_bindings_feedback.elapsed() < TS_BINDING_FEEDBACK_INTERVAL {
             return;
         }
-
         let mut changes = Vec::new();
         let mut bindings = Vec::new();
         let mut new_frontier = Antichain::new();
@@ -290,7 +317,7 @@ impl<'a, A: Allocate, B: StorageCapture> ActiveStorageState<'a, A, B> {
             history.read_upper(&mut new_frontier);
             let prev_frontier = self
                 .storage_state
-                .reported_bindings_frontiers
+                .reported_frontiers
                 .get_mut(&id)
                 .expect("Frontier missing!");
             assert!(<_ as PartialOrder>::less_equal(
@@ -317,6 +344,35 @@ impl<'a, A: Allocate, B: StorageCapture> ActiveStorageState<'a, A, B> {
                         .map(|(pid, ts, offset)| (*id, pid, ts, offset)),
                 );
                 prev_frontier.clone_from(&new_frontier);
+            }
+        }
+
+        // Check if any observed frontier should advance the reported frontiers.
+        // We don't expect to see this for sources with timestamp histories, as their durability requests should run
+        // ahead of stream progress. However, for other sources we may see something here.
+        for (id, frontier) in self.storage_state.source_uppers.iter() {
+            let reported_frontier = self
+                .storage_state
+                .reported_frontiers
+                .get_mut(&id)
+                .expect("Reported frontier missing!");
+
+            let observed_frontier = frontier.borrow();
+
+            // Only do a thing if it *advances* the frontier, not just *changes* the frontier.
+            // This is protection against `frontier` lagging behind what we have conditionally reported.
+            if <_ as PartialOrder>::less_than(reported_frontier, &observed_frontier) {
+                let mut change_batch = ChangeBatch::new();
+                for time in reported_frontier.elements().iter() {
+                    change_batch.update(time.clone(), -1);
+                }
+                for time in observed_frontier.elements().iter() {
+                    change_batch.update(time.clone(), 1);
+                }
+                if !change_batch.is_empty() {
+                    changes.push((*id, change_batch));
+                }
+                reported_frontier.clone_from(&observed_frontier);
             }
         }
 

--- a/src/dataflow/src/server/storage_state.rs
+++ b/src/dataflow/src/server/storage_state.rs
@@ -320,11 +320,10 @@ impl<'a, A: Allocate, B: StorageCapture> ActiveStorageState<'a, A, B> {
                 .reported_frontiers
                 .get_mut(&id)
                 .expect("Frontier missing!");
-            assert!(<_ as PartialOrder>::less_equal(
-                prev_frontier,
-                &new_frontier
-            ));
-            if prev_frontier != &new_frontier {
+
+            // This is not an error in the case that the input has advanced without producing bindings, as in the
+            // case of a non-TAIL file, which will close its output and report itself as complete.
+            if <_ as PartialOrder>::less_than(prev_frontier, &new_frontier) {
                 let mut change_batch = ChangeBatch::new();
                 for time in prev_frontier.elements().iter() {
                     change_batch.update(time.clone(), -1);


### PR DESCRIPTION
This PR has all sources report forward progress, rather than just those that produce timestamp bindings. It then asks persistent sources to use this progress information for compaction, rather than the surrogate progress of its default index.

The idea is that `StorageResponse::TimestampBindings` is ret-conned to mean "conditional frontier update": it contains things that if made durable would mean that the reported upper frontiers would come into effect. This means that the bindings can be empty for some sources, and that is fine. Their frontiers advance even without making anything durable.

I opted not to change the names and docs around there due to an in-flight PR of @petrosagg attempting to excavate all of this out of the coordinator. I'll need some help to sort out if this screws up persistence compaction. I only sort of understand the logic that goes on there.

### Motivation

This PR removes an assumption that each table has an associated index. This assumption is problematic in a world where there may be multiple compute instances, and the table exists in STORAGE and is visible across all of COMPUTE, rather than just one instance. This is meant to unblock https://github.com/MaterializeInc/materialize/pull/10883 which is bonking its head against persistence compaction not happening when default indexes do not exist.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
