### PR TITLE
sql: make guess_best_common_type exactly match PostgreSQL

### DIFF
--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -85,7 +85,7 @@ impl TypeCategory {
     /// GROUP BY typcategory
     /// ORDER BY typcategory;
     /// ```
-    fn from_type(typ: &ScalarType) -> Self {
+    pub fn from_type(typ: &ScalarType) -> Self {
         match typ {
             ScalarType::Array(..) | ScalarType::Int2Vector => Self::Array,
             ScalarType::Bool => Self::Bool,
@@ -114,7 +114,7 @@ impl TypeCategory {
         }
     }
 
-    fn from_param(param: &ParamType) -> Self {
+    pub fn from_param(param: &ParamType) -> Self {
         match param {
             ParamType::Any
             | ParamType::ArrayAny
@@ -135,7 +135,7 @@ impl TypeCategory {
     /// WHERE typispreferred = true
     /// ORDER BY typcategory;
     /// ```
-    fn preferred_type(&self) -> Option<ScalarType> {
+    pub fn preferred_type(&self) -> Option<ScalarType> {
         match self {
             Self::Array | Self::List | Self::Pseudo | Self::UserDefined => None,
             Self::Bool => Some(ScalarType::Bool),

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -882,7 +882,7 @@ impl ParamType {
             Any | ArrayElementAny | ListElementAny => true,
             NonVecAny => !t.is_vec(),
             MapAny => matches!(t, Map { .. }),
-            Plain(to) => typeconv::can_cast(ecx, CastContext::Implicit, t.clone(), to.clone()),
+            Plain(to) => typeconv::can_cast(ecx, CastContext::Implicit, t, to),
             RecordAny => matches!(t, Record { .. }),
         }
     }

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -953,17 +953,17 @@ pub fn plan_cast(
 pub fn can_cast(
     ecx: &ExprContext,
     ccx: CastContext,
-    cast_from: ScalarType,
-    cast_to: ScalarType,
+    cast_from: &ScalarType,
+    cast_to: &ScalarType,
 ) -> bool {
     // All char values are cast to strings during casts, so this transformation
     // is equivalent.
     let cast_from = match cast_from {
-        ScalarType::Char { .. } | ScalarType::VarChar { .. } => ScalarType::String,
+        ScalarType::Char { .. } | ScalarType::VarChar { .. } => &ScalarType::String,
         from => from,
     };
     let cast_to = match cast_to {
-        ScalarType::Char { .. } | ScalarType::VarChar { .. } => ScalarType::String,
+        ScalarType::Char { .. } | ScalarType::VarChar { .. } => &ScalarType::String,
         to => to,
     };
     get_cast(ecx, ccx, &cast_from, &cast_to).is_some()

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -21,6 +21,8 @@ use mz_expr::func;
 use mz_expr::VariadicFunc;
 use mz_repr::{ColumnName, ColumnType, Datum, RelationType, ScalarBaseType, ScalarType};
 
+use crate::func::TypeCategory;
+
 use super::error::PlanError;
 use super::expr::{CoercibleScalarExpr, ColumnRef, HirScalarExpr, UnaryFunc};
 use super::query::{ExprContext, QueryContext};
@@ -724,63 +726,49 @@ pub fn to_jsonb(ecx: &ExprContext, expr: HirScalarExpr) -> HirScalarExpr {
 /// Postgres' ["`UNION`, `CASE`, and Related Constructs"][union-type-conv] type
 /// conversion.
 ///
-/// ## Type hints
-/// Some types contain embedded values, e.g. [`ScalarType::Numeric`] contains
-/// the values' scales. When choosing a common type, and the `type_hint` is of
-/// the type chosen, you should guess _it_ because the given type hint can
-/// contain a distinct embedded value necessary to retain type invariants.
-///
-/// [union-type-conv]:
-/// https://www.postgresql.org/docs/12/typeconv-union-case.html
+/// [union-type-conv]: https://www.postgresql.org/docs/12/typeconv-union-case.html
 pub fn guess_best_common_type(
+    ecx: &ExprContext,
     types: &[Option<ScalarType>],
-    type_hint: Option<&ScalarType>,
-) -> Option<ScalarType> {
-    // Remove unknown types and chain type_hint
-    let known_types: Vec<_> = types
-        .into_iter()
-        .filter_map(|v| match v {
-            None => type_hint.cloned(),
-            v => v.clone(),
-        })
-        .collect();
+) -> Result<ScalarType, PlanError> {
+    // This function is a direct translation of `select_common_type` in
+    // PostgreSQL.
+    // https://github.com/postgres/postgres/blob/d1b307eef/src/backend/parser/parse_coerce.c#L1288-L1308
 
-    if known_types.is_empty() {
-        return Some(ScalarType::String);
+    // Remove unknown types.
+    let types: Vec<_> = types.into_iter().filter_map(|v| v.as_ref()).collect();
+
+    // If no known types, fall back to `String`.
+    if types.is_empty() {
+        return Ok(ScalarType::String);
     }
 
-    // Tracks order of preferences for implicit casts for each [`TypeCategory`] that
-    // contains multiple types, but does so irrespective of [`TypeCategory`].
-    //
-    // We could make this deterministic, but it offers no real benefit because the
-    // information it provides is used in fallible functions anyway, so a bad guess
-    // just gets caught elsewhere.
-    let r = known_types
-        .iter()
-        .max_by_key(|scalar_type| match scalar_type {
-            // TypeCategory::String
-            ScalarType::String => 0,
-            ScalarType::Char { .. } => 1,
-            ScalarType::VarChar { .. } => 2,
-            // TypeCategory::Numeric
-            ScalarType::Int16 => 3,
-            ScalarType::Int32 => 4,
-            ScalarType::Int64 => 5,
-            ScalarType::Numeric { .. } => 6,
-            ScalarType::Float32 => 7,
-            ScalarType::Float64 => 8,
-            // TypeCategory::DateTime
-            ScalarType::Date => 9,
-            ScalarType::Timestamp => 10,
-            ScalarType::TimestampTz => 11,
-            _ => 12,
-        })
-        .unwrap();
+    let mut types = types.into_iter();
 
-    match type_hint {
-        Some(th) if r.base_eq(th) => type_hint.cloned(),
-        _ => Some(r.default_embedded_value()),
+    // Start by guessing the first type, then look at each following type in
+    // turn.
+    let mut candidate = types.next().unwrap();
+    for typ in types {
+        if TypeCategory::from_type(candidate) != TypeCategory::from_type(typ) {
+            // The next type is in a different category; give up.
+            sql_bail!(
+                "{} types {} and {} cannot be matched",
+                ecx.name,
+                ecx.humanize_scalar_type(&candidate),
+                ecx.humanize_scalar_type(&typ),
+            );
+        } else if TypeCategory::from_type(candidate).preferred_type().as_ref() != Some(candidate)
+            && can_cast(ecx, CastContext::Implicit, &candidate, &typ)
+            && !can_cast(ecx, CastContext::Implicit, &typ, &candidate)
+        {
+            // The current candidate is not the preferred type for its category
+            // and the next type is implicitly convertible to the current
+            // candidate, but not vice-versa, so take the next type as the new
+            // candidate.
+            candidate = typ;
+        }
     }
+    Ok(candidate.default_embedded_value())
 }
 
 pub fn plan_coerce<'a>(

--- a/test/sqllogictest/arrays.slt
+++ b/test/sqllogictest/arrays.slt
@@ -38,7 +38,7 @@ SELECT '{{1}, {2}}'::int[]
 
 # Test coercion behavior of multidimensional arrays.
 
-query error ARRAY expression cannot be cast to uniform type: integer\[\] vs text\[\]
+query error ARRAY could not convert type text\[\] to integer\[\]
 SELECT ARRAY[ARRAY[1, 2], ARRAY['3', '4']]
 
 query T
@@ -105,7 +105,7 @@ SELECT 'hi'::text = ANY(ARRAY[]::text[])
 ----
 false
 
-query error ARRAY expression cannot be cast to uniform type: integer vs boolean
+query error ARRAY types integer and boolean cannot be matched
 SELECT 123.4 = ANY(ARRAY[1, true, 'hi'::text])
 
 query B
@@ -829,7 +829,7 @@ INSERT INTO users VALUES (1, 10), (2, 5), (3, 8);
 statement ok
 INSERT INTO customer VALUES (1, 'alice', 'lasta', '10003'::text), (2, 'bob', 'lastb', '10013'::text), (3, 'charlie', 'lastc', '11217'::text);
 
-query error ARRAY expression cannot be cast to uniform type: text\[\] vs integer\[\]
+query error ARRAY could not convert type integer\[\] to text\[\]
 SELECT ARRAY[ARRAY[customer.first_name, customer.last_name], ARRAY[customer.zip], ARRAY[customer.id]]::text FROM customer JOIN users ON customer.id = users.id ORDER BY users.other_field DESC LIMIT 2
 
 query T

--- a/test/sqllogictest/cockroach/order_by.slt
+++ b/test/sqllogictest/cockroach/order_by.slt
@@ -189,7 +189,7 @@ query I
 query error pgcode 42601 multiple ORDER BY clauses not allowed
 ((SELECT a FROM t ORDER BY a)) ORDER BY a
 
-query error CASE cannot be cast to uniform type: integer vs boolean
+query error CASE types integer and boolean cannot be matched
 SELECT CASE a WHEN 1 THEN b ELSE c END as val FROM t ORDER BY val
 
 query error pgcode 42P10 column reference 0 in ORDER BY clause is out of range \(1 - 3\)

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -400,7 +400,7 @@ SELECT greatest(1, NULL, -1)
 ----
 1
 
-query error greatest cannot be cast to uniform type: text vs integer
+query error greatest types integer and text cannot be matched
 SELECT greatest(1::int, 2::text)
 
 # Test least.
@@ -429,7 +429,7 @@ SELECT least(1, NULL, -1)
 ----
 -1
 
-query error least cannot be cast to uniform type: text vs integer
+query error least types integer and text cannot be matched
 SELECT least(1::int, 2::text)
 
 # Tests issue #2355, that type information for Maps are correctly constructed

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -605,7 +605,7 @@ EOF
 statement ok
 CREATE TABLE join_fail (la date);
 
-query error NATURAL/USING join column "la" cannot be cast to uniform type: integer vs date
+query error NATURAL/USING join column "la" types integer and date cannot be matched
 SELECT la FROM l JOIN join_fail USING (la)
 
 # test that joins properly handle null keys

--- a/test/sqllogictest/list.slt
+++ b/test/sqllogictest/list.slt
@@ -22,7 +22,7 @@ SELECT (LIST[1,2,3])::text
 ----
 {1,2,3}
 
-query error LIST expression cannot be cast to uniform type: integer vs integer list
+query error LIST types integer and integer list cannot be matched
 SELECT LIST[1,LIST[2,3]]
 
 query T
@@ -65,7 +65,7 @@ SELECT (LIST[[[[1], [2]]], [[[3]]]])::text
 {{{{1},{2}}},{{{3}}}}
 
 # List(Int) cannot be cast to List(List(Int))
-query error LIST expression cannot be cast to uniform type: integer vs integer list
+query error LIST could not convert type integer to integer list
 SELECT LIST[1, null] :: INT LIST LIST
 
 query T
@@ -1133,7 +1133,7 @@ NULL
 query error invalid input syntax for type integer: invalid digit found in string: "dog"
 SELECT (LIST['1', 'dog']::int list)::text
 
-query error CAST does not support casting from date list to integer list
+query error LIST could not convert type date to integer
 SELECT LIST[DATE '2008-02-01']::int list
 
 # 🔬🔬🔬 Layered and jagged lists
@@ -1571,10 +1571,13 @@ query error invalid input syntax for type list: malformed literal; missing eleme
 SELECT ('{  ,a}'::text list)::text
 
 # 🔬🔬🔬🔬 homogeneous text lists
-query T
+query error char list not yet supported
 SELECT (LIST['ab'::char, 'cd'::varchar, 'ef'::text])::text
+
+query T
+SELECT (LIST['cd'::varchar, 'ef'::text])::text
 ----
-{a,cd,ef}
+{cd,ef}
 
 # 🔬🔬 char lists
 # ensures that the list type does not pick up an elements' typmod
@@ -2469,7 +2472,7 @@ INSERT INTO users VALUES (1, 10), (2, 5), (3, 8);
 statement ok
 INSERT INTO customer VALUES (1, 'alice', 'lasta', '10003'::text), (2, 'bob', 'lastb', '10013'::text), (3, 'charlie', 'lastc', '11217'::text);
 
-query error LIST expression cannot be cast to uniform type: text list vs integer list
+query error LIST could not convert type integer list to text list
 SELECT LIST[LIST[customer.first_name, customer.last_name], LIST[customer.zip], LIST[customer.id]]::text FROM customer JOIN users ON customer.id = users.id ORDER BY users.other_field DESC LIMIT 2
 
 query T

--- a/test/sqllogictest/type-promotion.slt
+++ b/test/sqllogictest/type-promotion.slt
@@ -324,7 +324,7 @@ EXPLAIN RAW PLAN FOR
 ----
 %0 =
 | Constant ()
-| Map coalesce(strtovarchar(strtochar("a")), strtovarchar("a"), strtovarchar("a"))
+| Map coalesce(strtochar("a"), strtochar(strtovarchar("a")), strtochar("a"))
 
 EOF
 

--- a/test/testdrive/tables.td
+++ b/test/testdrive/tables.td
@@ -170,6 +170,8 @@ contains:column "a" is of type integer but expression is of type text
 # ...but not when impossible.
 ! INSERT INTO t VALUES (DATE '2020-01-01', 'bad')
 contains:column "a" is of type integer but expression is of type date
+! INSERT INTO t (b, a) VALUES ('bad', DATE '2020-01-01')
+contains:column "a" is of type integer but expression is of type date
 
 # Attempting to insert JSON into an int column is particularly interesting.
 # While there is an "explicit" cast from `jsonb` to `int`, there is no


### PR DESCRIPTION
Change the `guest_best_common_type` function to more exactly match
PostgreSQL's implementation. This should tee us up to solve the glitches
observed in literal record coercion in https://github.com/MaterializeInc/materialize/pull/10868.

The big insight here is that `guess_best_common_type` should not be
dealing in type hints. Instead, `coerce_homogeneous_exprs` should use
the type "hint" as a precise specification of what to cast to *instead*
of invoking `guess_best_common_type`.

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - No known behavior change right now. We'll see what the tests think.
