### PR TITLE
testdrive: temporarily disable EOS sink test

### DIFF
--- a/test/testdrive/kafka-exactly-once-sink.td
+++ b/test/testdrive/kafka-exactly-once-sink.td
@@ -8,6 +8,11 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+# Temporarily disabled due to flakiness.
+# See: https://github.com/MaterializeInc/materialize/issues/10927
+$ skip-if
+SELECT true
+
 $ set cdcv2-schema=[
   {
     "type": "array",


### PR DESCRIPTION
Due to flakiness. See #10927, which is marked as a release blocker.


### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
