### PR TITLE
platform: Text about the Adapter layer

### DIFF
--- a/doc/developer/platform/formalism.md
+++ b/doc/developer/platform/formalism.md
@@ -244,7 +244,7 @@ Concurrent events (at the same timestamp) first modify collections and then read
 All writes at a timestamp are visible to all reads at the same timestamp.
 
 SELECT statements observe all data mutations up through and including their timestamp.
-For this reason, we strictly advance the timestamp for each write that occurs after a read, to ensure that it the write is not visible to the read.
+For this reason, we strictly advance the timestamp for each write that occurs after a read, to ensure that the write is not visible to the read.
 ADAPTER uses `UpdateAndDowngrade` in response to the first read after a write, to ensure that prior writes are readable and to strictly advance the write frontier.
 
 Some DML operations, like UPDATE and DELETE, require a read-write transaction which prevents other writes from intervening.


### PR DESCRIPTION
Further text written sketching the role and properties of the SQL facet of the adapter layer.

### Motivation

Little is currently written about the role and responsibilities of the conversion from SQL commands to Storage and Compute commands. This leads to some confusion about the foundation of Materialize, and how it might possibly present as a SQL-like system.

### Tips for reviewer

If there are clearly missing sections, or incorrect takes on various concepts, I wouldn't be the least bit surprised and you should say so. The likely short term outcome of this PR is that it lingers as we determine what to say here, rather than landing as the absolute truth.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
