### PR TITLE
repr,expr,sql: rename ScalarType::{default_embedded_value => without_modifiers}

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -2730,16 +2730,10 @@ impl BinaryFunc {
             }
 
             ArrayArrayConcat | ArrayRemove | ListListConcat | ListElementConcat | ListRemove => {
-                input1_type
-                    .scalar_type
-                    .default_embedded_value()
-                    .nullable(true)
+                input1_type.scalar_type.without_modifiers().nullable(true)
             }
 
-            ElementListConcat => input2_type
-                .scalar_type
-                .default_embedded_value()
-                .nullable(true),
+            ElementListConcat => input2_type.scalar_type.without_modifiers().nullable(true),
 
             DigestString | DigestBytes => ScalarType::Bytes.nullable(true),
             Position => ScalarType::Int32.nullable(in_nullable),
@@ -4090,12 +4084,10 @@ impl UnaryFunc {
             CastInPlace { return_ty } => (return_ty.clone()).nullable(nullable),
 
             CastRecord1ToRecord2 { return_ty, .. } => {
-                return_ty.default_embedded_value().nullable(nullable)
+                return_ty.without_modifiers().nullable(nullable)
             }
 
-            CastList1ToList2 { return_ty, .. } => {
-                return_ty.default_embedded_value().nullable(false)
-            }
+            CastList1ToList2 { return_ty, .. } => return_ty.without_modifiers().nullable(false),
 
             ExtractInterval(_)
             | ExtractTime(_)

--- a/src/expr/src/scalar/func/impls/string.rs
+++ b/src/expr/src/scalar/func/impls/string.rs
@@ -259,7 +259,7 @@ impl LazyUnaryFunc for CastStringToList {
 
     /// The output ColumnType of this function
     fn output_type(&self, _input_type: ColumnType) -> ColumnType {
-        self.return_ty.default_embedded_value().nullable(false)
+        self.return_ty.without_modifiers().nullable(false)
     }
 
     /// Whether this function will produce NULL on NULL input

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -1457,24 +1457,24 @@ impl<'a> ScalarType {
         layers
     }
 
-    /// Returns `self` with any embedded values set to a value appropriate for a
-    /// collection of the type. Namely, this should set optional scales or
-    /// limits to `None`.
-    pub fn default_embedded_value(&self) -> ScalarType {
+    /// Returns `self` with any type modifiers removed.
+    ///
+    /// Namely, this should set optional scales or limits to `None`.
+    pub fn without_modifiers(&self) -> ScalarType {
         use ScalarType::*;
         match self {
             List {
                 element_type,
                 custom_oid: None,
             } => List {
-                element_type: Box::new(element_type.default_embedded_value()),
+                element_type: Box::new(element_type.without_modifiers()),
                 custom_oid: None,
             },
             Map {
                 value_type,
                 custom_oid: None,
             } => Map {
-                value_type: Box::new(value_type.default_embedded_value()),
+                value_type: Box::new(value_type.without_modifiers()),
                 custom_oid: None,
             },
             Record {
@@ -1482,25 +1482,25 @@ impl<'a> ScalarType {
                 custom_oid: None,
                 custom_name: None,
             } => {
-                let default_embedded_field_values = fields
+                let fields = fields
                     .iter()
                     .map(|(column_name, column_type)| {
                         (
                             column_name.clone(),
                             ColumnType {
-                                scalar_type: column_type.scalar_type.default_embedded_value(),
+                                scalar_type: column_type.scalar_type.without_modifiers(),
                                 nullable: column_type.nullable,
                             },
                         )
                     })
                     .collect_vec();
                 Record {
-                    fields: default_embedded_field_values,
+                    fields,
                     custom_name: None,
                     custom_oid: None,
                 }
             }
-            Array(a) => Array(Box::new(a.default_embedded_value())),
+            Array(a) => Array(Box::new(a.without_modifiers())),
             Numeric { .. } => Numeric { max_scale: None },
             // Char's default length should not be `Some(1)`, but instead `None`
             // to support Char values of different lengths in e.g. lists.

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -3612,7 +3612,7 @@ fn plan_list(
 ) -> Result<CoercibleScalarExpr, PlanError> {
     let (elem_type, exprs) = if exprs.is_empty() {
         if let Some(ScalarType::List { element_type, .. }) = type_hint {
-            (element_type.default_embedded_value(), vec![])
+            (element_type.without_modifiers(), vec![])
         } else {
             sql_bail!("cannot determine type of empty list");
         }
@@ -3632,7 +3632,7 @@ fn plan_list(
             });
         }
         let out = coerce_homogeneous_exprs(&ecx.with_name("LIST"), out, type_hint)?;
-        (ecx.scalar_type(&out[0]).default_embedded_value(), out)
+        (ecx.scalar_type(&out[0]).without_modifiers(), out)
     };
 
     if matches!(elem_type, ScalarType::Char { .. }) {

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -768,7 +768,7 @@ pub fn guess_best_common_type(
             candidate = typ;
         }
     }
-    Ok(candidate.default_embedded_value())
+    Ok(candidate.without_modifiers())
 }
 
 pub fn plan_coerce<'a>(


### PR DESCRIPTION
We've mostly standardized on referring to a char's length, a var char's
max length, and a numeric's scale as type "modifiers". So rename
`ScalarType::default_embedded_value` to `ScalarType::without_modifiers`
to match the new vernacular.

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
