### PR TITLE
[testdrive] Reenable non-flaky parts of kafka EOS

### DIFF
--- a/test/testdrive/kafka-exactly-once-sink.td
+++ b/test/testdrive/kafka-exactly-once-sink.td
@@ -8,11 +8,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# Temporarily disabled due to flakiness.
-# See: https://github.com/MaterializeInc/materialize/issues/10927
-$ skip-if
-SELECT true
-
 $ set cdcv2-schema=[
   {
     "type": "array",
@@ -416,9 +411,12 @@ $ kafka-verify format=json sink=materialize.public.json_avro_upsert_key key=true
 $ kafka-verify format=json sink=materialize.public.json_avro_upsert_key_2 key=true
 {"b": 2} {"a": 1, "b": 2, "c": 3, "transaction": {"id": "0"}}
 
+# Temporarily disabled due to flakiness.
+# See: https://github.com/MaterializeInc/materialize/issues/10927
 # Verify compaction of exactly once sinks.
-$ verify-timestamp-compaction source=input_csv max-size=3 permit-progress=true
-$ verify-timestamp-compaction source=rt_binding_consistency_test_source max-size=3 permit-progress=true
-$ verify-timestamp-compaction source=input_kafka_dbz max-size=3 permit-progress=true
+# $ verify-timestamp-compaction source=input_csv max-size=3 permit-progress=true
+# $ verify-timestamp-compaction source=rt_binding_consistency_test_source max-size=3 permit-progress=true
+# $ verify-timestamp-compaction source=input_kafka_dbz max-size=3 permit-progress=true
+
 # TODO: enable when possible
 # $ verify-timestamp-compaction source=input_kafka_cdcv2 max-size=3 permit-progress=true


### PR DESCRIPTION
I want to be more targeted about what tests we're disabling -- especially as we're making some big changes for platform.

Test was disabled in #10928.  #10927 tracks un-flaking the tests