### PR TITLE
ci: enable all Kafka tests in Redpanda nightly

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -92,7 +92,8 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: testdrive
-          run: testdrive-redpanda-ci
+          run: default
+          args: [--redpanda, "*.td"]
 
   - id: redpanda-testdrive-aarch64
     label: ":panda_face: :racing_car: testdrive aarch64"
@@ -101,7 +102,8 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: testdrive
-          run: testdrive-redpanda-ci
+          run: default
+          args: [--redpanda, "*.td"]
 
   - id: upgrade
     label: "Upgrade testing"

--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -106,20 +106,3 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                 "testdrive", Path(__file__).parent / junit_report
             )
         c.kill("materialized")
-
-
-def workflow_testdrive_redpanda_ci(c: Composition) -> None:
-    """Run testdrive against files known to be supported by Redpanda."""
-
-    # https://github.com/vectorizedio/redpanda/issues/2397
-    KNOWN_FAILURES = {"kafka-time-offset.td"}
-
-    files = set(
-        # NOTE(benesch): invoking the shell like this to filter testdrive files is
-        # pretty gross. Let's not get into the habit of using this construction.
-        spawn.capture(
-            ["sh", "-c", "grep -lr '\$.*kafka-ingest' *.td"], cwd=Path(__file__).parent
-        ).split()
-    )
-    files -= KNOWN_FAILURES
-    c.workflow("default", "--redpanda", *files)


### PR DESCRIPTION
@ruf-io reports that the issue might be fixed.

### Motivation

Which of the following best describes the motivation behind this PR?

  * This PR accounts for a fix to a recognized bug: redpanda-data/redpanda#2397

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
