### PR TITLE
Docs: `kafka_time_offset` is broken in Redpanda, not `start_offset`

### DIFF
--- a/doc/user/content/third-party/redpanda.md
+++ b/doc/user/content/third-party/redpanda.md
@@ -14,7 +14,7 @@ The Redpanda integration has [beta-level](../supported-tools#beta-level-support)
 
 You can use most of the Kafka source options for Redpanda as a Kafka broker, with an exception:
 
-- The `start_offset` option may not work properly ([Redpanda #2397](https://github.com/vectorizedio/redpanda/issues/2397)).
+- The `kafka_time_offset` option may not work properly ([Redpanda #2397](https://github.com/vectorizedio/redpanda/issues/2397)).
 
 ## Configuration
 

--- a/doc/user/content/third-party/redpanda.md
+++ b/doc/user/content/third-party/redpanda.md
@@ -14,7 +14,7 @@ The Redpanda integration has [beta-level](../supported-tools#beta-level-support)
 
 You can use most of the Kafka source options for Redpanda as a Kafka broker, with an exception:
 
-- The `kafka_time_offset` option may not work properly ([Redpanda #2397](https://github.com/vectorizedio/redpanda/issues/2397)).
+- [Setting start offsets](https://materialize.com/docs/sql/create-source/kafka/#setting-start-offsets) based on Kafka timestamps (`kafka_time_offset`) isn't supported yet ([Redpanda #2397](https://github.com/vectorizedio/redpanda/issues/2397)).
 
 ## Configuration
 


### PR DESCRIPTION
Minor fix, we incorrectly say that `start_offset` is not working with Redpanda, when in reality it is `kafka_time_offset` that is not working.