### PR TITLE
doc/user: Move metabase to "beta", remove forked driver reference

### DIFF
--- a/doc/user/content/third-party/supported-tools.md
+++ b/doc/user/content/third-party/supported-tools.md
@@ -23,11 +23,13 @@ Beta-level support means that there may be small performance issues and minor mi
 | ----------------------- | -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
 | [dbt](/third-party/dbt) | Create views and materialized views in your Materialize instance using dbt | Full `dbt-materialize` adapter support is a [work in progress](https://github.com/MaterializeInc/materialize/issues/5462). |
 | [Redpanda](/third-party/redpanda) | Set up Redpanda as a data source. | Kafka offsets are ignored.
+| [Metabase](/third-party/metabase) | Create business intelligence dashboards on top of your Materialize data | Connect Metabase to Materialize using the **PostgreSQL** database type. See [using Metabase](/third-party/metabase) page for more details.
 
+<!--
 ## Alpha-level support
 
 Alpha-level support means that some of our community members have made this integration work, but we haven't tested it ourselves and can't guarantee its stability.
 
 | Tool | Purpose | What's missing? |
 |------|---------|---------|
-| [Metabase](/third-party/metabase) | Create business intelligence dashboards on top of your Materialize data | Running Metabase cleanly, without our forked changes, requires further [pgjdbc support](https://github.com/MaterializeInc/materialize/issues/3727).
+-->


### PR DESCRIPTION
I'm doing a full edit of this page, but in the meantime I wanted to remove incorrect information that Metabase still requires a forked driver.

@andrioni Are you okay classifying Metabase as "Beta" support? I chose to move it up because the integration has materially  improved and feels on par with dbt or Redpanda.

**Before:**
![image](https://user-images.githubusercontent.com/11527560/156046709-e729baf0-885c-4c0e-be20-0726c961ef68.png)


**After:**
![image](https://user-images.githubusercontent.com/11527560/156046676-630069e8-713d-48b7-8e66-3a4d7f882722.png)

