### PR TITLE
coord: make `version()` match `server_version` session var

### DIFF
--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -425,7 +425,7 @@ impl<'a> DataflowBuilder<'a> {
             NullaryFunc::Version => {
                 let build_info = self.catalog.config().build_info;
                 let version = format!(
-                    "PostgreSQL 9.6 on {} (materialized {})",
+                    "PostgreSQL 9.5 on {} (materialized {})",
                     build_info.target_triple, build_info.version,
                 );
                 pack(Datum::from(&*version))


### PR DESCRIPTION
Fix #10958.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Change the claimed PostgreSQL version returned by the `version()` function to 9.5 to match the values of the `server_version` and `server_version_num` session parameters.
