### PR TITLE
expr: fix (modulo) division type inference

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -2604,21 +2604,6 @@ impl BinaryFunc {
     pub fn output_type(&self, input1_type: ColumnType, input2_type: ColumnType) -> ColumnType {
         use BinaryFunc::*;
         let in_nullable = input1_type.nullable || input2_type.nullable;
-        let is_div_mod = matches!(
-            self,
-            DivInt16
-                | ModInt16
-                | DivInt32
-                | ModInt32
-                | DivInt64
-                | ModInt64
-                | DivFloat32
-                | ModFloat32
-                | DivFloat64
-                | ModFloat64
-                | DivNumeric
-                | ModNumeric
-        );
         match self {
             And | Or | Eq | NotEq | Lt | Lte | Gt | Gte | ArrayContains => {
                 ScalarType::Bool.nullable(in_nullable)
@@ -2634,7 +2619,7 @@ impl BinaryFunc {
 
             AddInt16 | SubInt16 | MulInt16 | DivInt16 | ModInt16 | BitAndInt16 | BitOrInt16
             | BitXorInt16 | BitShiftLeftInt16 | BitShiftRightInt16 => {
-                ScalarType::Int16.nullable(in_nullable || is_div_mod)
+                ScalarType::Int16.nullable(in_nullable)
             }
 
             AddInt32
@@ -2648,19 +2633,19 @@ impl BinaryFunc {
             | BitShiftLeftInt32
             | BitShiftRightInt32
             | EncodedBytesCharLength
-            | SubDate => ScalarType::Int32.nullable(in_nullable || is_div_mod),
+            | SubDate => ScalarType::Int32.nullable(in_nullable),
 
             AddInt64 | SubInt64 | MulInt64 | DivInt64 | ModInt64 | BitAndInt64 | BitOrInt64
             | BitXorInt64 | BitShiftLeftInt64 | BitShiftRightInt64 => {
-                ScalarType::Int64.nullable(in_nullable || is_div_mod)
+                ScalarType::Int64.nullable(in_nullable)
             }
 
             AddFloat32 | SubFloat32 | MulFloat32 | DivFloat32 | ModFloat32 => {
-                ScalarType::Float32.nullable(in_nullable || is_div_mod)
+                ScalarType::Float32.nullable(in_nullable)
             }
 
             AddFloat64 | SubFloat64 | MulFloat64 | DivFloat64 | ModFloat64 => {
-                ScalarType::Float64.nullable(in_nullable || is_div_mod)
+                ScalarType::Float64.nullable(in_nullable)
             }
 
             AddInterval | SubInterval | SubTimestamp | SubTimestampTz | MulInterval


### PR DESCRIPTION
Division and modulo division operations no longer introduce nulls (as in sqlite) and now respond with the Postgres-compatible "division by zero" errors, so this part of the type inference can be removed.

### Motivation

* This PR refactors existing code (see summary above for details).

### Tips for reviewer

The only commit just removes an obsolete code path.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

- The output type of numeric division and modulo operations is now more precisely inferred as `NOT NULL` when the input arguments are `NOT NULL`.