### PR TITLE
coord: share PostgreSQL version number constants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,6 +978,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_format"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22bc6cd49b0ec407b680c3e380182b6ac63b73991cb7602de350352fc309b614"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef196d5d972878a48da7decb7686eded338b4858fbabeed513d63a7c98b2b82d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2998,6 +3018,7 @@ dependencies = [
  "bincode",
  "byteorder",
  "chrono",
+ "const_format",
  "crossbeam-channel",
  "datadriven",
  "dec",

--- a/deny.toml
+++ b/deny.toml
@@ -139,6 +139,7 @@ allow = [
     "ICU",
     "ISC",
     "MIT",
+    "Zlib",
 ]
 copyleft = "deny"
 private = { ignore = true }

--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -12,6 +12,7 @@ backtrace = "0.3.64"
 bincode = { version = "1.3.3", optional = true }
 byteorder = "1.4.3"
 chrono = { version = "0.4.0", default-features = false, features = ["std"] }
+const_format = "0.2.22"
 crossbeam-channel = "0.5.2"
 dec = "0.4.8"
 derivative = "2.2.0"

--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -29,7 +29,7 @@ use crate::catalog::{CatalogItem, CatalogState};
 use crate::coord::ArrangementFrontiers;
 use crate::coord::Coordinator;
 use crate::error::RematerializedSourceType;
-use crate::session::Session;
+use crate::session::{Session, SERVER_MAJOR_VERSION, SERVER_MINOR_VERSION};
 use crate::{CoordError, PersisterWithConfig};
 
 /// Borrows of catalog and indexes sufficient to build dataflow descriptions.
@@ -425,8 +425,11 @@ impl<'a> DataflowBuilder<'a> {
             NullaryFunc::Version => {
                 let build_info = self.catalog.config().build_info;
                 let version = format!(
-                    "PostgreSQL 9.5 on {} (materialized {})",
-                    build_info.target_triple, build_info.version,
+                    "PostgreSQL {}.{} on {} (materialized {})",
+                    SERVER_MAJOR_VERSION,
+                    SERVER_MINOR_VERSION,
+                    build_info.target_triple,
+                    build_info.version,
                 );
                 pack(Datum::from(&*version))
             }

--- a/src/coord/src/session.rs
+++ b/src/coord/src/session.rs
@@ -30,7 +30,9 @@ use crate::error::CoordError;
 
 mod vars;
 
-pub use self::vars::{ClientSeverity, Var, Vars};
+pub use self::vars::{
+    ClientSeverity, Var, Vars, SERVER_MAJOR_VERSION, SERVER_MINOR_VERSION, SERVER_PATCH_VERSION,
+};
 
 const DUMMY_CONNECTION_ID: u32 = 0;
 


### PR DESCRIPTION
Per prod from @jkosh44.


### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A.