### PR TITLE
persist: skeleton of new multi-writer persist interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,9 @@ name = "anyhow"
 version = "1.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "159bb86af3a200e19a068f4224eae4c8bb2d0fa054c7e5d1cacd5cef95e684cd"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "arbitrary"
@@ -3561,6 +3564,22 @@ dependencies = [
  "timely",
  "tokio",
  "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "mz-persist-client"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "bytes",
+ "crossbeam-channel",
+ "differential-dataflow",
+ "futures-util",
+ "mz-persist-types",
+ "serde",
+ "timely",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "src/process-collector",
     "src/mzcloud-cli",
     "src/ore",
+    "src/persist-client",
     "src/persist-types",
     "src/persist",
     "src/pgcopy",

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "mz-persist-client"
+description = "Client for Materialize pTVC durability system"
+version = "0.0.0"
+edition = "2021"
+rust-version = "1.59.0"
+publish = false
+
+[dependencies]
+anyhow = { version = "1.0.55", features = ["backtrace"] }
+bincode = "1.3.3"
+bytes = "1.1.0"
+crossbeam-channel = "0.5.0"
+differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
+futures-util = "0.3.19"
+mz-persist-types = { path = "../persist-types" }
+serde = { version = "1.0.136", features = ["derive"] }
+timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
+uuid = { version = "0.8.2", features = ["v4"] }

--- a/src/persist-client/src/error.rs
+++ b/src/persist-client/src/error.rs
@@ -1,0 +1,37 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Errors for the crate
+
+/// An error coming from an underlying durability system (e.g. s3) or from
+/// invalid data received from one.
+#[derive(Debug)]
+pub struct LocationError {
+    inner: anyhow::Error,
+}
+
+impl std::fmt::Display for LocationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "timeout: {}", self.inner)
+    }
+}
+
+impl std::error::Error for LocationError {}
+
+/// An error resulting from invalid usage of the API.
+#[derive(Debug)]
+pub struct InvalidUsage(pub anyhow::Error);
+
+impl std::fmt::Display for InvalidUsage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "invalid usage: {}", self.0)
+    }
+}
+
+impl std::error::Error for InvalidUsage {}

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -1,0 +1,122 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+#![warn(missing_docs)]
+#![warn(
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss
+)]
+// TODO: Remove this once we've got at least a placeholder implementation.
+#![allow(clippy::todo)]
+
+//! An abstraction presenting as a durable time-varying collection (aka shard)
+
+use std::fmt::Debug;
+use std::marker::PhantomData;
+use std::time::Duration;
+
+use differential_dataflow::difference::Semigroup;
+use differential_dataflow::lattice::Lattice;
+use mz_persist_types::{Codec, Codec64};
+use serde::{Deserialize, Serialize};
+use timely::progress::Timestamp;
+use uuid::Uuid;
+
+use crate::error::LocationError;
+use crate::read::ReadHandle;
+use crate::write::WriteHandle;
+
+pub mod error;
+pub mod read;
+pub mod write;
+
+// Notes
+// - Pretend that everything marked with Serialize and Deserialize instead has
+//   some sort of encode/decode API that uses byte slices, Buf+BufMut, or proto,
+//   depending on what we decide.
+
+// TODOs
+// - Decide if the inner and outer error of the two-level errors should be
+//   swapped.
+
+/// A location in s3, other cloud storage, or otherwise "durable storage" used
+/// by persist. This location can contain any number of persist shards.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Location {
+    bucket: String,
+    prefix: String,
+}
+
+/// An opaque identifier for a persist durable TVC (aka shard).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize)]
+pub struct Id([u8; 16]);
+
+impl std::fmt::Display for Id {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&Uuid::from_bytes(self.0), f)
+    }
+}
+
+impl Id {
+    /// Returns a random [Id] that is reasonably likely to have never been
+    /// generated before.
+    pub fn new() -> Self {
+        Id(Uuid::new_v4().as_bytes().to_owned())
+    }
+}
+
+/// A handle for interacting with the set of persist shard made durable at a
+/// single [Location].
+pub struct Client {
+    _phantom: PhantomData<()>,
+}
+
+impl Client {
+    /// Returns a new client for interfacing with persist shards made durable to
+    /// the given `location`.
+    ///
+    /// The same `location` may be used concurrently from multiple processes.
+    /// Concurrent usage is subject to the constraints documented on individual
+    /// methods (mostly [WriteHandle::write_batch]).
+    pub async fn new(
+        timeout: Duration,
+        location: Location,
+        role_arn: Option<String>,
+    ) -> Result<Self, LocationError> {
+        todo!("{:?}{:?}{:?}", timeout, location, role_arn)
+    }
+
+    /// Provides capabilities for the durable TVC identified by `id` at its
+    /// current since and upper frontiers.
+    ///
+    /// This method is a best-effort attempt to regain control of the frontiers
+    /// of a shard. Its most common uses are to recover capabilities that have
+    /// expired (leases) or to attempt to read a TVC that one did not create (or
+    /// otherwise receive capabilities for). If the frontiers have been fully
+    /// released by all other parties, this call may result in capabilities with
+    /// empty frontiers (which are useless).
+    ///
+    /// If `id` has never been used before, initializes a new shard and returns
+    /// handles with `since` and `upper` frontiers set to initial values of
+    /// `Antichain::from_elem(T::minimum())`.
+    pub async fn open<K, V, T, D>(
+        &self,
+        timeout: Duration,
+        id: Id,
+    ) -> Result<(WriteHandle<K, V, T, D>, ReadHandle<K, V, T, D>), LocationError>
+    where
+        K: Debug + Codec,
+        V: Debug + Codec,
+        T: Timestamp + Lattice + Codec64,
+        D: Semigroup + Codec64,
+    {
+        todo!("{:?}{:?}", timeout, id)
+    }
+}

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -1,0 +1,224 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Read capabilities and handles
+
+use std::fmt::Debug;
+use std::marker::PhantomData;
+use std::num::NonZeroUsize;
+use std::time::Duration;
+
+use differential_dataflow::difference::Semigroup;
+use differential_dataflow::lattice::Lattice;
+use mz_persist_types::{Codec, Codec64};
+use serde::{Deserialize, Serialize};
+use timely::progress::{Antichain, Timestamp};
+use uuid::Uuid;
+
+use crate::error::{InvalidUsage, LocationError};
+
+/// An opaque identifier for a reader of a persist durable TVC (aka shard).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ReaderId(pub(crate) [u8; 16]);
+
+impl std::fmt::Display for ReaderId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&Uuid::from_bytes(self.0), f)
+    }
+}
+
+/// A token representing one split of a "snapshot" (the contents of a shard as
+/// of some frontier).
+///
+/// This may be exchanged (including over the network). It is tradeable via
+/// [ReadHandle::snapshot_iter] for a [SnapshotIter], which can be used to
+/// receive the relevant data.
+///
+/// See [ReadHandle::snapshot] for details.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SnapshotSplit(PhantomData<()>);
+
+/// An iterator over one split of a "snapshot" (the contents of a shard as of
+/// some frontier).
+///
+/// See [ReadHandle::snapshot] for details.
+pub struct SnapshotIter<K, V, T, D>(PhantomData<(K, V, T, D)>);
+
+impl<K, V, T, D> SnapshotIter<K, V, T, D>
+where
+    K: Debug + Codec,
+    V: Debug + Codec,
+    T: Timestamp + Lattice + Codec64,
+    D: Semigroup + Codec64,
+{
+    /// The frontier at which we're outputting the contents of the shard.
+    pub fn as_of(&self) -> &Antichain<T> {
+        todo!()
+    }
+
+    /// Attempt to pull out the next values of this iterator.
+    ///
+    /// An empty vector is returned if this iterator is exhausted.
+    pub async fn poll_next(
+        &mut self,
+        timeout: Duration,
+    ) -> Result<Vec<((Result<K, String>, Result<V, String>), T, D)>, LocationError> {
+        todo!("{:?}", timeout)
+    }
+}
+
+/// Data and progress events of a shard subscription.
+///
+/// TODO: Unify this with [timely::dataflow::operators::to_stream::Event] or
+/// [timely::dataflow::operators::capture::event::Event].
+pub enum ListenEvent<K, V, T, D> {
+    /// Progress of the shard.
+    Progress(Antichain<T>),
+    /// Data of the shard.
+    Updates(Vec<((Result<K, String>, Result<V, String>), T, D)>),
+}
+
+/// An ongoing subscription of updates to a shard.
+pub struct Listen<K, V, T, D>(PhantomData<(K, V, T, D)>);
+
+impl<K, V, T, D> Listen<K, V, T, D>
+where
+    K: Debug + Codec,
+    V: Debug + Codec,
+    T: Timestamp + Lattice + Codec64,
+    D: Semigroup + Codec64,
+{
+    /// Attempt to pull out the next values of this subscription.
+    pub async fn poll_next(
+        &mut self,
+        timeout: Duration,
+    ) -> Result<ListenEvent<K, V, T, D>, LocationError> {
+        todo!("{:?}", timeout)
+    }
+}
+
+/// A "capability" granting the ability to read the state of some shard at times
+/// greater or equal to `self.since()`.
+pub struct ReadHandle<K, V, T, D>
+where
+    T: Timestamp + Lattice + Codec64,
+{
+    _phantom: PhantomData<(K, V, T, D)>,
+}
+
+impl<K, V, T, D> ReadHandle<K, V, T, D>
+where
+    K: Debug + Codec,
+    V: Debug + Codec,
+    T: Timestamp + Lattice + Codec64,
+    D: Semigroup + Codec64,
+{
+    /// This handle's `since` frontier.
+    ///
+    /// This will always be greater or equal to the shard-global `since`.
+    pub fn since(&self) -> &Antichain<T> {
+        todo!()
+    }
+
+    /// Forwards the since frontier of this handle, giving up the ability to
+    /// read at times not greater or equal to `new_since`.
+    ///
+    /// This may trigger (asynchronous) compaction and consolidation in the
+    /// system. A `new_since` of the empty antichain "finishes" this shard,
+    /// promising that no more data will ever be read by this handle.
+    ///
+    /// The clunky two-level Result is to enable more obvious error handling in
+    /// the caller. See <http://sled.rs/errors.html> for details.
+    pub async fn downgrade_since(
+        &mut self,
+        timeout: Duration,
+        new_since: Antichain<T>,
+    ) -> Result<Result<(), InvalidUsage>, LocationError> {
+        todo!("{:?}{:?}", timeout, new_since)
+    }
+
+    /// Returns an ongoing subscription of updates to a shard.
+    ///
+    /// The stream includes all data at times greater than `as_of`. Combined
+    /// with [Self::snapshot] it will produce exactly correct results: the
+    /// snapshot is the TVCs contents at `as_of` and all subsequent updates
+    /// occur at exactly their indicated time. The recipient should only
+    /// downgrade their read capability when they are certain they have all data
+    /// through the frontier they would downgrade to.
+    ///
+    /// The clunky two-level Result is to enable more obvious error handling in
+    /// the caller. See <http://sled.rs/errors.html> for details.
+    ///
+    /// TODO: If/when persist learns about the structure of the keys and values
+    /// being stored, this is an opportunity to push down projection and key
+    /// filter information.
+    pub async fn listen(
+        &self,
+        timeout: Duration,
+        as_of: Antichain<T>,
+    ) -> Result<Result<Listen<K, V, T, D>, InvalidUsage>, LocationError> {
+        todo!("{:?}{:?}", timeout, as_of);
+    }
+
+    /// Returns a snapshot of the contents of the shard TVC at `as_of`.
+    ///
+    /// This command returns the contents of this shard as of `as_of` once they
+    /// are known. This may "block" (in an async-friendly way) if `as_of` is
+    /// greater or equal to the current `upper` of the shard. The recipient
+    /// should only downgrade their read capability when they are certain they
+    /// have all data through the frontier they would downgrade to.
+    ///
+    /// This snapshot may be split into a number of splits, each of which may be
+    /// exchanged (including over the network) to load balance the processing of
+    /// this snapshot. These splits are usable by anyone with access to the
+    /// shard's [crate::Location]. The `len()` of the returned `Vec` is
+    /// `num_splits`. If a 1:1 mapping between splits and (e.g. dataflow
+    /// workers) is used, then the work of replaying the snapshot will be
+    /// roughly balanced.
+    ///
+    /// The clunky two-level Result is to enable more obvious error handling in
+    /// the caller. See <http://sled.rs/errors.html> for details.
+    ///
+    /// TODO: If/when persist learns about the structure of the keys and values
+    /// being stored, this is an opportunity to push down projection and key
+    /// filter information.
+    pub async fn snapshot(
+        &self,
+        timeout: Duration,
+        as_of: Antichain<T>,
+        num_splits: NonZeroUsize,
+    ) -> Result<Result<Vec<SnapshotSplit>, InvalidUsage>, LocationError> {
+        todo!("{:?}{:?}{:?}", timeout, as_of, num_splits);
+    }
+
+    /// Trade in an exchange-able [SnapshotSplit] for an iterator over the data
+    /// it represents.
+    pub async fn snapshot_iter(
+        &self,
+        timeout: Duration,
+        split: SnapshotSplit,
+    ) -> Result<SnapshotIter<K, V, T, D>, LocationError> {
+        todo!("{:?}{:?}", timeout, split);
+    }
+
+    /// Returns an independent [ReadHandle] with a new [ReaderId] but the same
+    /// `since`.
+    pub async fn clone(&self, timeout: Duration) -> Result<Self, LocationError> {
+        todo!("{:?}", timeout);
+    }
+}
+
+impl<K, V, T, D> Drop for ReadHandle<K, V, T, D>
+where
+    T: Timestamp + Lattice + Codec64,
+{
+    fn drop(&mut self) {
+        todo!()
+    }
+}

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -1,0 +1,114 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Write capabilities and handles
+
+use std::fmt::Debug;
+use std::marker::PhantomData;
+use std::time::Duration;
+
+use differential_dataflow::difference::Semigroup;
+use differential_dataflow::lattice::Lattice;
+use mz_persist_types::{Codec, Codec64};
+use serde::{Deserialize, Serialize};
+use timely::progress::{Antichain, Timestamp};
+use uuid::Uuid;
+
+use crate::error::{InvalidUsage, LocationError};
+
+/// An opaque identifier for a writer of a persist durable TVC (aka shard).
+///
+/// Unlike [crate::read::ReaderId], this is intentionally not Serialize and
+/// Deserialize. It's difficult to reason about the behavior if multiple writers
+/// accidentally end up concurrently using the same [WriterId] and we haven't
+/// (yet) found a need for it.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct WriterId(pub(crate) [u8; 16]);
+
+impl std::fmt::Display for WriterId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&Uuid::from_bytes(self.0), f)
+    }
+}
+
+/// A "capability" granting the ability to apply updates to some shard at times
+/// greater or equal to `self.upper()`.
+pub struct WriteHandle<K, V, T, D>
+where
+    T: Timestamp + Lattice + Codec64,
+{
+    _phantom: PhantomData<(K, V, T, D)>,
+}
+
+impl<K, V, T, D> WriteHandle<K, V, T, D>
+where
+    K: Debug + Codec,
+    V: Debug + Codec,
+    T: Timestamp + Lattice + Codec64,
+    D: Semigroup + Codec64,
+{
+    /// This handle's `upper` frontier.
+    ///
+    /// This will always be greater or equal to the shard-global `upper`.
+    pub fn upper(&self) -> &Antichain<T> {
+        todo!()
+    }
+
+    /// Applies `updates` to this shard and downgrades this handle's upper to
+    /// `new_upper`.
+    ///
+    /// All times in `updates` must be greater or equal to `self.upper()` and
+    /// not greater or equal to `new_upper`. A `new_upper` of the empty
+    /// antichain "finishes" this shard, promising that no more data is ever
+    /// incoming.
+    ///
+    /// `updates` may be empty, which allows for downgrading `upper` to
+    /// communicate progress. It is unexpected to call this with `new_upper`
+    /// equal to `self.upper()`, as it would mean `updates` must be empty
+    /// (making the entire call a no-op).
+    ///
+    /// Multiple [WriteHandle]s (with different [WriterId]s) may be used
+    /// concurrently to write to the same shard, but in this case, the data
+    /// being written must be identical (in the sense of "definite"-ness).
+    ///
+    /// This uses a bounded amount of memory, even when `updates` is very large.
+    /// Individual records, however, should be small enough that we can
+    /// reasonably chunk them up: O(KB) is definitely fine, O(MB) come talk to
+    /// us.
+    ///
+    /// The clunky two-level Result is to enable more obvious error handling in
+    /// the caller. See <http://sled.rs/errors.html> for details.
+    ///
+    /// TODO: Introduce an AsyncIterator (futures::Stream) variant of this. Or,
+    /// given that the AsyncIterator version would be strictly more general,
+    /// alter this one if it turns out that the compiler can optimize out the
+    /// overhead.
+    pub async fn write_batch<'a, I: IntoIterator<Item = ((&'a K, &'a V), &'a T, &'a D)>>(
+        &mut self,
+        timeout: Duration,
+        updates: I,
+        new_upper: Antichain<T>,
+    ) -> Result<Result<(), InvalidUsage>, LocationError> {
+        todo!(
+            "{:?}{:?}{:?}",
+            timeout,
+            updates.into_iter().size_hint(),
+            new_upper
+        );
+    }
+}
+
+impl<K, V, T, D> Drop for WriteHandle<K, V, T, D>
+where
+    T: Timestamp + Lattice + Codec64,
+{
+    fn drop(&mut self) {
+        todo!()
+    }
+}

--- a/src/persist-types/src/codec_impls.rs
+++ b/src/persist-types/src/codec_impls.rs
@@ -11,7 +11,7 @@
 
 use bytes::BufMut;
 
-use crate::Codec;
+use crate::{Codec, Codec64};
 
 impl Codec for () {
     fn codec_name() -> String {
@@ -104,6 +104,34 @@ impl<T: Codec, E: Codec> Codec for Result<T, E> {
             typ => return Err(format!("Unexpected Result variant: {}.", typ)),
         };
         Ok(result)
+    }
+}
+
+impl Codec64 for i64 {
+    fn codec_name() -> String {
+        "i64".to_owned()
+    }
+
+    fn encode(&self) -> [u8; 8] {
+        self.to_le_bytes()
+    }
+
+    fn decode(buf: [u8; 8]) -> Self {
+        i64::from_le_bytes(buf)
+    }
+}
+
+impl Codec64 for u64 {
+    fn codec_name() -> String {
+        "u64".to_owned()
+    }
+
+    fn encode(&self) -> [u8; 8] {
+        self.to_le_bytes()
+    }
+
+    fn decode(buf: [u8; 8]) -> Self {
+        u64::from_le_bytes(buf)
     }
 }
 

--- a/src/persist-types/src/lib.rs
+++ b/src/persist-types/src/lib.rs
@@ -50,3 +50,29 @@ pub trait Codec: Sized + 'static {
     // without any copies, see if we can make the types work out for that.
     fn decode<'a>(buf: &'a [u8]) -> Result<Self, String>;
 }
+
+/// Encoding and decoding operations for a type usable as a persisted timestamp
+/// or diff.
+pub trait Codec64: Sized + 'static {
+    /// Name of the codec.
+    ///
+    /// This name is stored for the timestamp and diff when a stream is first
+    /// created and the same timestamp and diff codec must be used for that
+    /// stream afterward.
+    fn codec_name() -> String;
+
+    /// Encode a timestamp or diff for permanent storage.
+    ///
+    /// This must perfectly round-trip Self through [Codec64::decode]. If the
+    /// encode function for this codec ever changes, decode must be able to
+    /// handle bytes output by all previous versions of encode.
+    fn encode(&self) -> [u8; 8];
+
+    /// Decode a timestamp or diff previous encoded with this codec's
+    /// [Codec64::encode].
+    ///
+    /// This must perfectly round-trip Self through [Codec64::encode]. If the
+    /// encode function for this codec ever changes, decode must be able to
+    /// handle bytes output by all previous versions of encode.
+    fn decode(buf: [u8; 8]) -> Self;
+}


### PR DESCRIPTION
This is an attempt to redesign the persist API to balance all of the
following factors:
- Usage within STORAGE
- Operational simplicity
- Maintainability of implementation
- Performance
- Cost

Additionally, we're also taking this shift in product priorities (as
well as some assumptions that have changed since persist started) to lay
out a plan to incrementally ship this thing to production. Shipping
persist incrementally is something everyone wants, is much less risky,
and is an earlier timeline. This is something we've tried hard to do
historically, but have been unable to tease apart into a workable plan
(given the constraints of our initial goal of fast restarts for kafka
source persistence). Without over-promising, this interface rethink
seems at the moment like it may unlock incremental delivery.

That's the good news. The bonus good news is that persist's internal
implementation is pretty clean and contains lots of great building
blocks. Even if we entirely throw out the current API and switch to this
one, it should be a pretty fast process. This is in no way a rewrite.

Here's my rough short-to-medium-term plan:
- Figure out the balance of persist priorities (support platform vs the
  kafka source fast restart alpha) with product. Adjust the following
  steps accordingly. Timeline: ASAP
- Get persist and storage to agree on this API boundary between them,
  including performance and cost expectations. Then, get sign-off from
  Cloud on the operational implications. Merge it. Timeline: ASAP
- Write and merge a prototype-quality implementation of this API to
  prove the concept and unblock storage prototyping. Timeline: ASAP
- Write and merge a design doc for the production-quality implementation
  of this API and its incremental rollout. Timeline: ASAP
- Write a bare-bones production-quality implementation of this API. This
  will happen in parallel with the initial production-quality
  implementation of STORAGE. Adjust the API as necessary in light of the
  inevitable discovery of unforeseen issues+requirements as persist and
  STORAGE are implemented. Timeline: Platform launch.
- Continue to incrementally ship persist features as decided by product
  prioritization.

### Motivation

  * This PR adds a known-desirable feature.
