### PR TITLE
Allow dataflow `Client` to error on `send`

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -852,7 +852,8 @@ impl Coordinator {
         self.dataflow_client
             .storage()
             .advance_all_table_timestamps(advance_to)
-            .await;
+            .await
+            .unwrap();
     }
 
     async fn message_worker(&mut self, message: DataflowResponse) {
@@ -956,7 +957,8 @@ impl Coordinator {
                     self.dataflow_client
                         .storage()
                         .update_durability_frontiers(durability_updates)
-                        .await;
+                        .await
+                        .unwrap();
                 }
             }
         }
@@ -1712,7 +1714,8 @@ impl Coordinator {
                 .compute(DEFAULT_COMPUTE_INSTANCE_ID)
                 .unwrap()
                 .cancel_peek(conn_id)
-                .await;
+                .await
+                .unwrap();
         }
     }
 
@@ -3001,7 +3004,8 @@ impl Coordinator {
                                 self.dataflow_client
                                     .storage()
                                     .table_insert(id, updates)
-                                    .await;
+                                    .await
+                                    .unwrap();
                             }
                         }
                     }
@@ -4290,6 +4294,7 @@ impl Coordinator {
                     .storage()
                     .table_insert(id, updates)
                     .await
+                    .unwrap();
             }
         }
     }
@@ -4478,14 +4483,16 @@ impl Coordinator {
                     self.dataflow_client
                         .storage()
                         .add_source_timestamping(source_id, s.connector.clone(), bindings)
-                        .await;
+                        .await
+                        .unwrap();
                 }
             }
         } else {
             self.dataflow_client
                 .storage()
                 .drop_source_timestamping(source_id)
-                .await;
+                .await
+                .unwrap();
         }
     }
 
@@ -4688,11 +4695,13 @@ pub async fn serve(
                     .collect(),
                 log_logging: config.log_logging,
             });
-            handle.block_on(
-                coord
-                    .dataflow_client
-                    .create_instance(DEFAULT_COMPUTE_INSTANCE_ID, logging),
-            );
+            handle
+                .block_on(
+                    coord
+                        .dataflow_client
+                        .create_instance(DEFAULT_COMPUTE_INSTANCE_ID, logging),
+                )
+                .unwrap();
             let bootstrap = handle.block_on(coord.bootstrap(builtin_table_updates));
             let ok = bootstrap.is_ok();
             bootstrap_tx.send(bootstrap).unwrap();

--- a/src/coordtest/src/lib.rs
+++ b/src/coordtest/src/lib.rs
@@ -574,7 +574,7 @@ impl<C> mz_dataflow_types::client::Client for InterceptingDataflowClient<C>
 where
     C: mz_dataflow_types::client::Client,
 {
-    async fn send(&mut self, cmd: mz_dataflow_types::client::Command) {
+    async fn send(&mut self, cmd: mz_dataflow_types::client::Command) -> Result<(), anyhow::Error> {
         self.inner.lock().await.send(cmd).await
     }
 

--- a/src/dataflow-types/src/client/controller.rs
+++ b/src/dataflow-types/src/client/controller.rs
@@ -53,7 +53,7 @@ where
         &mut self,
         instance: ComputeInstanceId,
         logging: Option<LoggingConfig>,
-    ) {
+    ) -> Result<(), anyhow::Error> {
         self.compute
             .insert(instance, compute::ComputeControllerState::new(&logging));
         self.client
@@ -61,13 +61,16 @@ where
                 ComputeCommand::CreateInstance(logging),
                 instance,
             ))
-            .await;
+            .await
     }
-    pub async fn drop_instance(&mut self, instance: ComputeInstanceId) {
+    pub async fn drop_instance(
+        &mut self,
+        instance: ComputeInstanceId,
+    ) -> Result<(), anyhow::Error> {
         self.compute.remove(&instance);
         self.client
             .send(Command::Compute(ComputeCommand::DropInstance, instance))
-            .await;
+            .await
     }
 }
 

--- a/src/dataflow-types/src/client/controller/compute.rs
+++ b/src/dataflow-types/src/client/controller/compute.rs
@@ -62,6 +62,14 @@ pub enum ComputeError {
     DataflowSinceViolation(GlobalId),
     /// The peek `timestamp` was not greater than the `since` of the identifier.
     PeekSinceViolation(GlobalId),
+    /// An error from the underlying client.
+    ClientError(anyhow::Error),
+}
+
+impl From<anyhow::Error> for ComputeError {
+    fn from(error: anyhow::Error) -> Self {
+        Self::ClientError(error)
+    }
 }
 
 impl<T: Timestamp + Lattice> ComputeControllerState<T> {
@@ -217,13 +225,15 @@ impl<'a, C: Client<T>, T: Timestamp + Lattice> ComputeController<'a, C, T> {
 
         self.client
             .send(Command::Storage(StorageCommand::RenderSources(sources)))
-            .await;
+            .await
+            .expect("Storage command failed; unrecoverable");
         self.client
             .send(Command::Compute(
                 ComputeCommand::CreateDataflows(dataflows),
                 self.instance,
             ))
-            .await;
+            .await
+            .expect("Compute command failed; unrecoverable");
 
         Ok(())
     }
@@ -279,18 +289,18 @@ impl<'a, C: Client<T>, T: Timestamp + Lattice> ComputeController<'a, C, T> {
                 },
                 self.instance,
             ))
-            .await;
-
-        Ok(())
+            .await
+            .map_err(ComputeError::from)
     }
     /// Cancels an existing peek request.
-    pub async fn cancel_peek(&mut self, conn_id: u32) {
+    pub async fn cancel_peek(&mut self, conn_id: u32) -> Result<(), ComputeError> {
         self.client
             .send(Command::Compute(
                 ComputeCommand::CancelPeek { conn_id },
                 self.instance,
             ))
-            .await;
+            .await
+            .map_err(ComputeError::from)
     }
 
     /// Downgrade the read capabilities of specific identifiers to specific frontiers.
@@ -406,7 +416,8 @@ impl<'a, C: Client<T>, T: Timestamp + Lattice> ComputeController<'a, C, T> {
                     ComputeCommand::AllowCompaction(compaction_commands),
                     self.instance,
                 ))
-                .await;
+                .await
+                .expect("Compute instance command failed; unrecoverable");
         }
 
         // We may have storage consequences to process.

--- a/src/dataflowd/src/bin/dataflowd.rs
+++ b/src/dataflowd/src/bin/dataflowd.rs
@@ -242,7 +242,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
         select! {
             cmd = conn.try_next() => match cmd? {
                 None => break,
-                Some(cmd) => client.send(cmd).await,
+                Some(cmd) => client.send(cmd).await.unwrap(),
             },
             Some(response) = client.recv() => conn.send(response).await?,
         }


### PR DESCRIPTION
This PR modifies the return type of `dataflow::Client::send` to be `Result<(), anyhow::Error>`.

Internally, uses of client `send` either return the error upwards, or panic if it leaves the `Controller` in an unrecoverable state. For example, updating internal state and then failing to send it through the client leaves the instance in an inconsistent state from which it should not continue (at least, not without more code). I also imagine that such errors are probably fatal for the instance ("we tried sending the command, but eventually gave up").

### Motivation

Sending data to clients has been assumed to never fail, in part because of the in-memory links. They can now fail, and even though it isn't clear we should do anything with that information other than wind down the instance, at least we are clearer.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
