### PR TITLE
pg-cdc: fix logic bug with COPY iterator

### DIFF
--- a/src/dataflow/src/source/postgres.rs
+++ b/src/dataflow/src/source/postgres.rs
@@ -220,8 +220,10 @@ impl PostgresSourceReader {
                 let mut raw_values = parser.iter_raw(info.schema.len() as i32);
                 try_fatal!(packer.push_list_with(|rp| -> Result<(), anyhow::Error> {
                     while let Some(raw_value) = raw_values.next() {
-                        let value = std::str::from_utf8(raw_value?)?;
-                        rp.push(Datum::String(value));
+                        match raw_value? {
+                            Some(value) => rp.push(Datum::String(std::str::from_utf8(value)?)),
+                            None => rp.push(Datum::Null),
+                        }
                     }
                     Ok(())
                 }));

--- a/src/pgcopy/src/copy.rs
+++ b/src/pgcopy/src/copy.rs
@@ -348,15 +348,17 @@ pub struct RawIterator<'a> {
 }
 
 impl<'a> RawIterator<'a> {
-    pub fn next(&mut self) -> Option<Result<&[u8], io::Error>> {
+    pub fn next(&mut self) -> Option<Result<Option<&[u8]>, io::Error>> {
+        if self.current_column > self.num_columns {
+            return None;
+        }
+
         if self.current_column == self.num_columns {
             if let Some(err) = self.parser.expect_end_of_line().err() {
                 return Some(Err(err));
+            } else {
+                return None;
             }
-        }
-
-        if self.parser.is_eof() || self.parser.is_end_of_line() {
-            return None;
         }
 
         if self.current_column > 0 {
@@ -366,7 +368,7 @@ impl<'a> RawIterator<'a> {
         }
 
         self.current_column += 1;
-        self.parser.consume_raw_value().transpose()
+        Some(self.parser.consume_raw_value())
     }
 }
 

--- a/test/pg-cdc/gh-10981.td
+++ b/test/pg-cdc/gh-10981.td
@@ -1,0 +1,34 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Test for issue #10981
+#
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER USER postgres WITH replication;
+DROP SCHEMA IF EXISTS public CASCADE;
+DROP PUBLICATION IF EXISTS mz_source;
+
+CREATE SCHEMA public;
+
+CREATE TABLE t1 (id int, name text, id2 int);
+ALTER TABLE t1 REPLICA IDENTITY FULL;
+INSERT INTO t1 VALUES (1, NULL, 1);
+CREATE PUBLICATION mz_source FOR TABLE t1;
+
+
+> CREATE MATERIALIZED SOURCE mz_source
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
+  PUBLICATION 'mz_source';
+
+> CREATE VIEWS FROM SOURCE mz_source (t1);
+
+> SELECT * FROM t1;
+1 <null> 1


### PR DESCRIPTION
The implementation of `RawIterator` relied on the implementation of the
protocol parser which when asked to parse a column from the input buffer
returns a `Result<Option<&[u8]>, Error>` where the Option in the Ok case
is used to signal whether the current column contains some bytes or is
null.

The previous implementation of `RawIterator` transposed that result into
an `Option<Result<&[u8], Error>>` changing the semantics in a subtle but
imporant way, because now a `None` value signaled the end of the
iterator.

This resulted with the ingestion pipeline early returning when consuming
the COPY data and omitting all column data after encountering one with a
NULL.

This PR fixes the problem by making the iterator return
`Option<Result<Option<&[u8], Error>>` where the outer option signals the
end of the Iterator and the inner option singal the presence or not of a
NULL in the column.

Fixes #10981

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

Fix data loss bug of direct postgres replication sources introduced in version 0.20.0. Github issue #10981

