### PR TITLE
coord: introduce notion of cluster to coordinator

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -1470,7 +1470,7 @@ impl Catalog {
             .state
             .compute_instance_names
             .get(name)
-            .ok_or(SqlCatalogError::UnknownComputeInstance(name.to_string()))?;
+            .ok_or_else(|| SqlCatalogError::UnknownComputeInstance(name.to_string()))?;
         Ok(&self.state.compute_instances_by_id[id])
     }
 

--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -548,6 +548,7 @@ pub struct Index {
     pub conn_id: Option<u32>,
     pub depends_on: Vec<GlobalId>,
     pub enabled: bool,
+    pub compute_instance_id: usize,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -976,6 +977,7 @@ impl Catalog {
                             conn_id: None,
                             depends_on: vec![log.id],
                             enabled: catalog.index_enabled_by_default(&log.index_id),
+                            compute_instance_id: 0,
                         }),
                     );
                 }
@@ -1029,6 +1031,7 @@ impl Catalog {
                             conn_id: None,
                             depends_on: vec![table.id],
                             enabled: catalog.index_enabled_by_default(&table.index_id),
+                            compute_instance_id: 0,
                         }),
                     );
                 }
@@ -2271,6 +2274,7 @@ impl Catalog {
                 conn_id: None,
                 depends_on: index.depends_on,
                 enabled: self.index_enabled_by_default(&id),
+                compute_instance_id: 0,
             }),
             Plan::CreateSink(CreateSinkPlan {
                 sink,

--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -1070,7 +1070,8 @@ lazy_static! {
             .with_column("name", ScalarType::String.nullable(false))
             .with_column("on_id", ScalarType::String.nullable(false))
             .with_column("volatility", ScalarType::String.nullable(false))
-            .with_column("enabled", ScalarType::Bool.nullable(false)),
+            .with_column("enabled", ScalarType::Bool.nullable(false))
+            .with_column("cluster_id", ScalarType::Int64.nullable(false)),
         id: GlobalId::System(4015),
         index_id: GlobalId::System(4016),
         persistent: false,

--- a/src/coord/src/catalog/builtin_table_updates.rs
+++ b/src/coord/src/catalog/builtin_table_updates.rs
@@ -307,7 +307,12 @@ impl CatalogState {
                 Datum::String(&index.on.to_string()),
                 Datum::String(self.is_volatile(id).as_str()),
                 Datum::from(index.enabled),
-                Datum::Int64(index.compute_instance_id.try_into().expect("not more than i64::MAX clusters"))
+                Datum::Int64(
+                    index
+                        .compute_instance_id
+                        .try_into()
+                        .expect("not more than i64::MAX clusters"),
+                ),
             ]),
             diff,
         });

--- a/src/coord/src/catalog/builtin_table_updates.rs
+++ b/src/coord/src/catalog/builtin_table_updates.rs
@@ -307,6 +307,7 @@ impl CatalogState {
                 Datum::String(&index.on.to_string()),
                 Datum::String(self.is_volatile(id).as_str()),
                 Datum::from(index.enabled),
+                Datum::Int64(index.compute_instance_id.try_into().expect("not more than i64::MAX clusters"))
             ]),
             diff,
         });

--- a/src/coord/src/catalog/storage.rs
+++ b/src/coord/src/catalog/storage.rs
@@ -140,6 +140,10 @@ const MIGRATIONS: &[&str] = &[
         name text NOT NULL UNIQUE
     );
     INSERT INTO compute_instances VALUES (0, 'default');",
+    // Adds default_compute_instance setting as server configuration parameter.
+    //
+    // Introduced in v0.22.0.
+    "INSERT INTO settings VALUES ('default_compute_instance', 'default');",
     // Add new migrations here.
     //
     // Migrations should be preceded with a comment of the following form:
@@ -327,6 +331,15 @@ impl Connection {
         )?;
         tx.commit()?;
         Ok(())
+    }
+
+    pub fn get_default_compute_instance(&mut self) -> Result<String, Error> {
+        let tx = self.inner.transaction()?;
+        Ok(tx.query_row(
+            "SELECT value FROM settings WHERE name = 'default_compute_instance';",
+            params![],
+            |row| row.get(0),
+        )?)
     }
 
     pub fn load_databases(&self) -> Result<Vec<(i64, String)>, Error> {

--- a/src/coord/src/catalog/storage.rs
+++ b/src/coord/src/catalog/storage.rs
@@ -132,6 +132,14 @@ const MIGRATIONS: &[&str] = &[
     //
     // Introduced in v0.12.0.
     "CREATE INDEX timestamps_sid_timestamp ON timestamps (sid, timestamp)",
+    // Adds table to track users' compute instances.
+    //
+    // Introduced in v0.22.0.
+    "CREATE TABLE compute_instances (
+        id   integer PRIMARY KEY,
+        name text NOT NULL UNIQUE
+    );
+    INSERT INTO compute_instances VALUES (0, 'default');",
     // Add new migrations here.
     //
     // Migrations should be preceded with a comment of the following form:
@@ -351,6 +359,17 @@ impl Connection {
     pub fn load_roles(&self) -> Result<Vec<(i64, String)>, Error> {
         self.inner
             .prepare("SELECT id, name FROM roles")?
+            .query_and_then(params![], |row| -> Result<_, Error> {
+                let id: i64 = row.get(0)?;
+                let name: String = row.get(1)?;
+                Ok((id, name))
+            })?
+            .collect()
+    }
+
+    pub fn load_compute_instances(&self) -> Result<Vec<(i64, String)>, Error> {
+        self.inner
+            .prepare("SELECT id, name FROM compute_instances")?
             .query_and_then(params![], |row| -> Result<_, Error> {
                 let id: i64 = row.get(0)?;
                 let name: String = row.get(1)?;

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1585,7 +1585,7 @@ impl Coordinator {
             // Aggregate compute instance ID.
             compute_instance_update_map
                 .entry(instance_id)
-                .or_insert(vec![])
+                .or_insert_with(Vec::new)
                 .push(isu);
         }
 
@@ -4411,7 +4411,7 @@ impl Coordinator {
                 // Aggregate them by instance ID.
                 instance_key_map
                     .entry(instance_id)
-                    .or_insert(vec![])
+                    .or_insert_with(Vec::new)
                     .push(id);
             }
             self.since_handles.remove(&id);
@@ -4471,7 +4471,7 @@ impl Coordinator {
         for dataflow in dataflows {
             compute_instance_dataflow_map
                 .entry(dataflow.compute_instance_id)
-                .or_insert(vec![])
+                .or_insert_with(Vec::new)
                 .push(self.finalize_dataflow(dataflow));
         }
 

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -594,7 +594,7 @@ impl Coordinator {
                         .await
                         .unwrap();
                 }
-                CatalogItem::Index(_) => {
+                CatalogItem::Index(index) => {
                     if BUILTINS.logs().any(|log| log.index_id == entry.id()) {
                         // Indexes on logging views are special, as they are
                         // already installed in the dataflow plane via
@@ -607,6 +607,7 @@ impl Coordinator {
                         // that everything else uses?
                         let frontiers = self.new_index_frontiers(entry.id(), Some(0), Some(1_000));
                         self.indexes.insert(entry.id(), frontiers);
+                        self.catalog.add_index_to_instance(index.compute_instance_id, entry.id());
                     } else {
                         let index_id = entry.id();
                         if let Some((name, description)) =

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -2699,6 +2699,7 @@ impl Coordinator {
             conn_id: None,
             depends_on: index.depends_on,
             enabled: self.catalog.index_enabled_by_default(&id),
+            compute_instance_id: 0,
         };
         let oid = self.catalog.allocate_oid()?;
         let op = catalog::Op::CreateItem {
@@ -4752,6 +4753,7 @@ fn auto_generate_primary_idx(
         conn_id,
         depends_on,
         enabled,
+        compute_instance_id: 0,
     }
 }
 

--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -86,6 +86,7 @@ impl Coordinator {
                 mz_dataflow_types::IndexDesc {
                     on_id: index.on,
                     key: index.keys.clone(),
+                    compute_instance_id: index.compute_instance_id,
                 },
             ))
         }
@@ -112,9 +113,11 @@ impl<'a> DataflowBuilder<'a> {
                 .iter()
                 .find(|(id, _keys)| self.indexes.contains_key(*id));
             if let Some((index_id, keys)) = valid_index {
+                let compute_instance_id = self.catalog.find_index_among_instances(index_id);
                 let index_desc = IndexDesc {
                     on_id: *id,
                     key: keys.to_vec(),
+                    compute_instance_id,
                 };
                 let desc = self
                     .catalog
@@ -192,11 +195,14 @@ impl<'a> DataflowBuilder<'a> {
                     if !self.indexes.contains_key(*id) {
                         continue;
                     }
+
                     let on_entry = self.catalog.get_by_id(&get_id);
                     let on_type = on_entry.desc().unwrap().typ().clone();
+                    let compute_instance_id = self.catalog.find_index_among_instances(id);
                     let index_desc = IndexDesc {
                         on_id: get_id,
                         key: keys.clone(),
+                        compute_instance_id,
                     };
                     dataflow.import_index(*id, index_desc, on_type, *view_id);
                 }

--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -216,7 +216,7 @@ impl<'a> DataflowBuilder<'a> {
     ) -> Result<DataflowDesc, CoordError> {
         let on_entry = self.catalog.get_by_id(&index_description.on_id);
         let on_type = on_entry.desc().unwrap().typ().clone();
-        let mut dataflow = DataflowDesc::new(name, id);
+        let mut dataflow = DataflowDesc::new(name, id, 0);
         self.import_into_dataflow(&index_description.on_id, &mut dataflow)?;
         for BuildDesc { view, .. } in &mut dataflow.objects_to_build {
             self.prep_relation_expr(view, ExprPrepStyle::Index)?;
@@ -243,7 +243,7 @@ impl<'a> DataflowBuilder<'a> {
         id: GlobalId,
         sink_description: SinkDesc,
     ) -> Result<DataflowDesc, CoordError> {
-        let mut dataflow = DataflowDesc::new(name, id);
+        let mut dataflow = DataflowDesc::new(name, id, 0);
         self.build_sink_dataflow_into(&mut dataflow, id, sink_description)?;
         Ok(dataflow)
     }

--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -249,6 +249,7 @@ impl<'a> DataflowBuilder<'a> {
         id: GlobalId,
         sink_description: SinkDesc,
     ) -> Result<DataflowDesc, CoordError> {
+        // TODO: get instance ID from sink description
         let mut dataflow = DataflowDesc::new(name, id, 0);
         self.build_sink_dataflow_into(&mut dataflow, id, sink_description)?;
         Ok(dataflow)

--- a/src/coord/src/session.rs
+++ b/src/coord/src/session.rs
@@ -145,6 +145,7 @@ impl Session {
     pub fn clear_transaction(&mut self) -> (Vec<GlobalId>, TransactionStatus) {
         self.portals.clear();
         self.pcx = None;
+        // TODO: get instance ID of sinks to drop and propagate to return.
         let drop_sinks = mem::take(&mut self.drop_sinks);
         let txn = mem::take(&mut self.transaction);
         (drop_sinks, txn)
@@ -215,6 +216,7 @@ impl Session {
     /// Adds a sink that will need to be dropped when the current transaction is
     /// cleared.
     pub fn add_drop_sink(&mut self, name: GlobalId) {
+        // TODO: include instance ID from sink
         self.drop_sinks.push(name);
     }
 

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -257,6 +257,7 @@ impl<T: timely::progress::Timestamp> Command<T> {
                                 as_of: dataflow.as_of.clone(),
                                 debug_name: dataflow.debug_name.clone(),
                                 id: dataflow.id,
+                                compute_instance_id: dataflow.compute_instance_id,
                             });
                         }
                     }

--- a/src/dataflow-types/src/plan/mod.rs
+++ b/src/dataflow-types/src/plan/mod.rs
@@ -951,6 +951,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
             as_of: desc.as_of,
             debug_name: desc.debug_name,
             id: desc.id,
+            compute_instance_id: desc.compute_instance_id,
         })
     }
 

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -1789,6 +1789,7 @@ pub struct IndexDesc {
     pub on_id: GlobalId,
     /// Expressions to be arranged, in order of decreasing primacy.
     pub key: Vec<MirScalarExpr>,
+    pub compute_instance_id: usize,
 }
 
 // TODO: change contract to ensure that the operator is always applied to

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -145,11 +145,13 @@ pub struct DataflowDescription<View, T = mz_repr::Timestamp> {
     pub debug_name: String,
     /// Unique ID of the dataflow
     pub id: GlobalId,
+    /// The target compute instance for this dataflow.
+    pub compute_instance_id: usize,
 }
 
 impl<T> DataflowDescription<OptimizedMirRelationExpr, T> {
     /// Creates a new dataflow description with a human-readable name.
-    pub fn new(name: String, id: GlobalId) -> Self {
+    pub fn new(name: String, id: GlobalId, compute_instance_id: usize) -> Self {
         Self {
             source_imports: Default::default(),
             index_imports: Default::default(),
@@ -160,6 +162,7 @@ impl<T> DataflowDescription<OptimizedMirRelationExpr, T> {
             as_of: Default::default(),
             debug_name: name,
             id,
+            compute_instance_id,
         }
     }
 

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -181,6 +181,10 @@ impl<T> DataflowDescription<OptimizedMirRelationExpr, T> {
         typ: RelationType,
         requesting_view: GlobalId,
     ) {
+        assert_eq!(
+            self.compute_instance_id, description.compute_instance_id,
+            "can currently only import indexes on the same instance"
+        );
         self.index_imports.insert(id, (description, typ));
         self.record_depends_on(requesting_view, id);
     }
@@ -217,6 +221,11 @@ impl<T> DataflowDescription<OptimizedMirRelationExpr, T> {
     /// Future uses of `import_index` in other dataflow descriptions may use `id`,
     /// as long as this dataflow has not been terminated in the meantime.
     pub fn export_index(&mut self, id: GlobalId, description: IndexDesc, on_type: RelationType) {
+        assert_eq!(
+            self.compute_instance_id, description.compute_instance_id,
+            "can only export indexes from the same instance"
+        );
+
         // We first create a "view" named `id` that ensures that the
         // data are correctly arranged and available for export.
         self.insert_view(

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -106,6 +106,10 @@ pub trait SessionCatalog: fmt::Debug + ExprHumanizer {
     /// functions within the catalog.
     fn resolve_function(&self, item_name: &PartialName) -> Result<&dyn CatalogItem, CatalogError>;
 
+    /// Performs the same operation as [`SessionCatalog::resolve_item`] but for
+    /// compute instances within the catalog.
+    fn resolve_compute_instance(&self, item_name: &PartialName) -> Result<String, CatalogError>;
+
     /// Gets an item by its ID.
     fn try_get_item_by_id(&self, id: &GlobalId) -> Option<&dyn CatalogItem>;
 
@@ -374,6 +378,8 @@ pub enum CatalogError {
     UnknownFunction(String),
     /// Unknown source.
     UnknownSource(String),
+    /// Unknown compute instance.
+    UnknownComputeInstance(String),
     /// Invalid attempt to depend on a non-dependable item.
     InvalidDependency {
         /// The invalid item's name.
@@ -392,6 +398,8 @@ impl fmt::Display for CatalogError {
             Self::UnknownSchema(name) => write!(f, "unknown schema '{}'", name),
             Self::UnknownRole(name) => write!(f, "unknown role '{}'", name),
             Self::UnknownItem(name) => write!(f, "unknown catalog item '{}'", name),
+            // n.b. compute instances are referred to as clusters to users
+            Self::UnknownComputeInstance(name) => write!(f, "unknown cluster '{}'", name),
             Self::InvalidDependency { name, typ } => write!(
                 f,
                 "catalog item '{}' is {} {} and so cannot be depended upon",
@@ -467,6 +475,10 @@ impl SessionCatalog for DummyCatalog {
     }
 
     fn resolve_function(&self, _: &PartialName) -> Result<&dyn CatalogItem, CatalogError> {
+        unimplemented!();
+    }
+
+    fn resolve_compute_instance(&self, _: &PartialName) -> Result<String, CatalogError> {
         unimplemented!();
     }
 

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -407,6 +407,7 @@ pub struct Index {
     pub on: GlobalId,
     pub keys: Vec<mz_expr::MirScalarExpr>,
     pub depends_on: Vec<GlobalId>,
+    pub in_instance: String,
 }
 
 #[derive(Clone, Debug)]

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -383,6 +383,14 @@ impl<'a> StatementContext<'a> {
         Ok(self.catalog.resolve_function(&name)?)
     }
 
+    pub fn resolve_compute_instance(
+        &self,
+        name: UnresolvedObjectName,
+    ) -> Result<String, PlanError> {
+        let name = normalize::unresolved_object_name(name)?;
+        Ok(self.catalog.resolve_compute_instance(&name)?)
+    }
+
     pub fn get_item_by_id(&self, id: &GlobalId) -> &dyn CatalogItem {
         self.catalog.get_item_by_id(id)
     }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2077,6 +2077,14 @@ pub fn plan_create_index(
             on: on.id(),
             keys,
             depends_on,
+            // TODO(CLUSTER): take this argument in from the AST.
+            in_instance: scx
+                .catalog
+                .resolve_compute_instance(&crate::names::PartialName {
+                    database: None,
+                    schema: None,
+                    item: "default".to_string(),
+                })?,
         },
         options,
         if_not_exists,

--- a/src/sql/src/query_model/test/catalog.rs
+++ b/src/sql/src/query_model/test/catalog.rs
@@ -221,6 +221,10 @@ impl SessionCatalog for TestCatalog {
         Err(CatalogError::UnknownFunction(partial_name.item.clone()))
     }
 
+    fn resolve_compute_instance(&self, _item_name: &PartialName) -> Result<String, CatalogError> {
+        Ok("default".to_owned())
+    }
+
     fn get_item_by_id(&self, id: &GlobalId) -> &dyn CatalogItem {
         &self.tables[&self.id_to_name[id]]
     }


### PR DESCRIPTION
Adds the notion of what clusters are to the coordinator.

Note that this code is submitted in a less-than-ideal state, and there is a substantial simplification to the code to implement in a few more hours, namely:
- cluster->index mappings don't belong on the catalog, it can be put directly on the coordinator
- we have the compute instance defined in a few too many places.

There's also some work to teach coord about sinks' compute instances, which I've marked as todos, in addition to the more obvious front end work of supporting specifying clusters on indexes, etc.

### Motivation

This PR adds a known-desirable feature. #10680

### Tips for reviewer

Submitting this so the dataflow team can see what the interface looks like. There is still, obviously, more work to be done.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - there are no user-facing behavior changes
