### PR TITLE
pgrepr: add typmod handling for date/time types

### DIFF
--- a/src/expr/src/scalar/func/impls/oid.rs
+++ b/src/expr/src/scalar/func/impls/oid.rs
@@ -80,7 +80,7 @@ sqlfunc!(
 
 sqlfunc!(
     fn mz_type_name<'a>(oid: Oid) -> Option<String> {
-        if let Some(t) = Type::from_oid(oid.0) {
+        if let Ok(t) = Type::from_oid(oid.0) {
             Some(t.name().to_string())
         } else {
             None

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -11,14 +11,14 @@ use std::collections::HashSet;
 use std::fmt;
 use std::mem;
 
-use mz_ore::stack::CheckedRecursion;
-use mz_ore::stack::RecursionGuard;
 use serde::{Deserialize, Serialize};
 
 use mz_lowertest::MzReflect;
 use mz_ore::collections::CollectionExt;
 use mz_ore::stack::maybe_grow;
+use mz_ore::stack::{CheckedRecursion, RecursionGuard};
 use mz_ore::str::separated;
+use mz_pgrepr::TypeFromOidError;
 use mz_repr::adt::array::InvalidArrayError;
 use mz_repr::adt::datetime::DateTimeUnits;
 use mz_repr::adt::regex::Regex;
@@ -1286,6 +1286,7 @@ pub enum EvalError {
     IncompatibleArrayDimensions {
         dims: Option<(usize, usize)>,
     },
+    TypeFromOid(String),
 }
 
 impl fmt::Display for EvalError {
@@ -1423,6 +1424,7 @@ impl fmt::Display for EvalError {
             EvalError::IncompatibleArrayDimensions { dims: _ } => {
                 write!(f, "cannot concatenate incompatible arrays")
             }
+            EvalError::TypeFromOid(msg) => write!(f, "{msg}"),
         }
     }
 }
@@ -1480,6 +1482,12 @@ impl From<InvalidArrayError> for EvalError {
 impl From<regex::Error> for EvalError {
     fn from(e: regex::Error) -> EvalError {
         EvalError::InvalidRegex(e.to_string())
+    }
+}
+
+impl From<TypeFromOidError> for EvalError {
+    fn from(e: TypeFromOidError) -> EvalError {
+        EvalError::TypeFromOid(e.to_string())
     }
 }
 

--- a/src/pgrepr/src/lib.rs
+++ b/src/pgrepr/src/lib.rs
@@ -26,7 +26,7 @@ mod value;
 pub mod oid;
 
 pub use format::Format;
-pub use types::{Type, TypeConversionError, LIST, MAP};
+pub use types::{Type, TypeConversionError, TypeFromOidError, LIST, MAP};
 pub use value::interval::Interval;
 pub use value::jsonb::Jsonb;
 pub use value::numeric::Numeric;

--- a/src/pgrepr/src/types.rs
+++ b/src/pgrepr/src/types.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::error::Error;
 use std::fmt;
 
 use lazy_static::lazy_static;
@@ -24,6 +25,21 @@ use crate::oid;
 ///
 /// [`VARHDRSZ`]: https://github.com/postgres/postgres/blob/REL_14_0/src/include/c.h#L627
 const VARHDRSZ: i32 = 4;
+
+/// Mirror of PostgreSQL's [`MAX_INTERVAL_PRECISION`] constant.
+///
+/// See: <https://github.com/postgres/postgres/blob/27b77ecf9/src/include/datatype/timestamp.h#L54>
+const MAX_INTERVAL_PRECISION: i32 = 6;
+
+/// Mirror of PostgreSQL's [`MAX_TIMESTAMP_PRECISION`] constant.
+///
+/// See: <https://github.com/postgres/postgres/blob/27b77ecf9/src/include/datatype/timestamp.h#L53>
+const MAX_TIMESTAMP_PRECISION: i32 = 6;
+
+/// Mirror of PostgreSQL's [`MAX_TIME_PRECISION`] constant.
+///
+/// See: <https://github.com/postgres/postgres/blob/27b77ecf9/src/include/utils/date.h#L51>
+const MAX_TIME_PRECISION: i32 = 6;
 
 /// The type of a [`Value`](crate::Value).
 ///
@@ -50,7 +66,10 @@ pub enum Type {
     /// An 8-byte signed integer.
     Int8,
     /// A time interval.
-    Interval,
+    Interval {
+        /// Optional constraints on the type.
+        constraints: Option<IntervalConstraints>,
+    },
     /// A textual JSON blob.
     Json,
     /// A binary JSON blob.
@@ -86,13 +105,25 @@ pub enum Type {
         max_length: Option<CharLength>,
     },
     /// A time of day without a day.
-    Time,
+    Time {
+        /// An optional precision for the fractional digits in the second field.
+        precision: Option<TimePrecision>,
+    },
     /// A time with a time zone.
-    TimeTz,
+    TimeTz {
+        /// An optional precision for the fractional digits in the second field.
+        precision: Option<TimePrecision>,
+    },
     /// A date and time, without a timezone.
-    Timestamp,
+    Timestamp {
+        /// An optional precision for the fractional digits in the second field.
+        precision: Option<TimestampPrecision>,
+    },
     /// A date and time, with a timezone.
-    TimestampTz,
+    TimestampTz {
+        /// An optional precision for the fractional digits in the second field.
+        precision: Option<TimestampPrecision>,
+    },
     /// A universally unique identifier.
     Uuid,
     /// A function name.
@@ -108,7 +139,7 @@ pub enum Type {
 /// An unpacked [`typmod`](Type::typmod) for a [`Type`].
 pub trait TypeConstraint: fmt::Display {
     /// Unpacks the type constraint from a typmod value.
-    fn from_typmod(typmod: i32) -> Option<Self>
+    fn from_typmod(typmod: i32) -> Result<Option<Self>, String>
     where
         Self: Sized;
 
@@ -121,12 +152,12 @@ pub trait TypeConstraint: fmt::Display {
 pub struct CharLength(i32);
 
 impl TypeConstraint for CharLength {
-    fn from_typmod(typmod: i32) -> Option<CharLength> {
+    fn from_typmod(typmod: i32) -> Result<Option<CharLength>, String> {
         // https://github.com/postgres/postgres/blob/52377bb81/src/backend/utils/adt/varchar.c#L139
         if typmod >= VARHDRSZ {
-            Some(CharLength(typmod - VARHDRSZ))
+            Ok(Some(CharLength(typmod - VARHDRSZ)))
         } else {
-            None
+            Ok(None)
         }
     }
 
@@ -166,6 +197,103 @@ impl fmt::Display for CharLength {
     }
 }
 
+/// Constraints associated with [`Type::Interval`]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct IntervalConstraints {
+    /// The range of the interval.
+    range: i32,
+    /// The precision of the interval.
+    precision: i32,
+}
+
+impl TypeConstraint for IntervalConstraints {
+    fn from_typmod(typmod: i32) -> Result<Option<IntervalConstraints>, String> {
+        if typmod < 0 {
+            Ok(None)
+        } else {
+            // https://github.com/postgres/postgres/blob/27b77ecf9/src/include/utils/timestamp.h#L53-L54
+            let range = typmod >> 16 & 0x7fff;
+            let precision = typmod & 0xffff;
+            if precision > MAX_INTERVAL_PRECISION {
+                return Err(format!(
+                    "exceeds maximum interval precision {MAX_INTERVAL_PRECISION}"
+                ));
+            }
+            Ok(Some(IntervalConstraints { range, precision }))
+        }
+    }
+
+    fn into_typmod(&self) -> i32 {
+        (self.range << 16) | self.precision
+    }
+}
+
+impl fmt::Display for IntervalConstraints {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // https://github.com/postgres/postgres/blob/27b77ecf9/src/include/utils/timestamp.h#L52
+        // TODO: handle output of range.
+        write!(f, "({})", self.precision)
+    }
+}
+
+/// A precision associated with [`Type::Time`] and [`Type::TimeTz`].
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct TimePrecision(i32);
+
+impl TypeConstraint for TimePrecision {
+    fn from_typmod(typmod: i32) -> Result<Option<TimePrecision>, String> {
+        if typmod > MAX_TIME_PRECISION {
+            Err(format!(
+                "exceeds maximum time precision {MAX_TIME_PRECISION}"
+            ))
+        } else if typmod >= 0 {
+            Ok(Some(TimePrecision(typmod)))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn into_typmod(&self) -> i32 {
+        self.0
+    }
+}
+
+impl fmt::Display for TimePrecision {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // https://github.com/postgres/postgres/blob/27b77ecf9/src/backend/utils/adt/date.c#L97
+        write!(f, "({})", self.0)
+    }
+}
+
+/// A precision associated with [`Type::Timestamp`] and [`Type::TimestampTz`].
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct TimestampPrecision(i32);
+
+impl TypeConstraint for TimestampPrecision {
+    fn from_typmod(typmod: i32) -> Result<Option<TimestampPrecision>, String> {
+        if typmod > MAX_TIMESTAMP_PRECISION {
+            Err(format!(
+                "exceeds maximum timestamp precision {MAX_TIMESTAMP_PRECISION}"
+            ))
+        } else if typmod >= 0 {
+            Ok(Some(TimestampPrecision(typmod)))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn into_typmod(&self) -> i32 {
+        self.0
+    }
+}
+
+impl fmt::Display for TimestampPrecision {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // https://github.com/postgres/postgres/blob/54bd1e43c/src/backend/utils/adt/timestamp.c#L131
+        write!(f, "({})", self.0)
+    }
+}
+
 /// Constraints on [`Type::Numeric`].
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct NumericConstraints {
@@ -176,15 +304,15 @@ pub struct NumericConstraints {
 }
 
 impl TypeConstraint for NumericConstraints {
-    fn from_typmod(typmod: i32) -> Option<NumericConstraints> {
+    fn from_typmod(typmod: i32) -> Result<Option<NumericConstraints>, String> {
         // https://github.com/postgres/postgres/blob/52377bb81/src/backend/utils/adt/numeric.c#L829-L862
         if typmod >= VARHDRSZ {
-            Some(NumericConstraints {
+            Ok(Some(NumericConstraints {
                 max_precision: ((typmod - VARHDRSZ) >> 16) & 0xffff,
                 max_scale: (((typmod - VARHDRSZ) & 0x7ff) ^ 1024) - 1024,
-            })
+            }))
         } else {
-            None
+            Ok(None)
         }
     }
 
@@ -226,8 +354,8 @@ lazy_static! {
 
 impl Type {
     /// Returns the type corresponding to the provided OID, if the OID is known.
-    pub fn from_oid(oid: u32) -> Option<Type> {
-        Type::from_oid_and_typmod(oid, 0)
+    pub fn from_oid(oid: u32) -> Result<Type, TypeFromOidError> {
+        Type::from_oid_and_typmod(oid, -1)
     }
 
     /// Returns the `Type` corresponding to the provided OID and packed type
@@ -239,76 +367,120 @@ impl Type {
     ///
     /// Returns an error if the OID is unknown or if the typmod is invalid for
     /// the type.
-    pub fn from_oid_and_typmod(oid: u32, typmod: i32) -> Option<Type> {
-        let ty = postgres_types::Type::from_oid(oid)?;
-        match ty {
-            postgres_types::Type::BOOL => Some(Type::Bool),
-            postgres_types::Type::BYTEA => Some(Type::Bytea),
-            postgres_types::Type::DATE => Some(Type::Date),
-            postgres_types::Type::FLOAT4 => Some(Type::Float4),
-            postgres_types::Type::FLOAT8 => Some(Type::Float8),
-            postgres_types::Type::INT2 => Some(Type::Int2),
-            postgres_types::Type::INT4 => Some(Type::Int4),
-            postgres_types::Type::INT8 => Some(Type::Int8),
-            postgres_types::Type::INTERVAL => Some(Type::Interval),
-            postgres_types::Type::JSON => Some(Type::Json),
-            postgres_types::Type::JSONB => Some(Type::Jsonb),
-            postgres_types::Type::NUMERIC => Some(Type::Numeric {
-                constraints: NumericConstraints::from_typmod(typmod),
-            }),
-            postgres_types::Type::OID => Some(Type::Oid),
-            postgres_types::Type::TEXT => Some(Type::Text),
-            postgres_types::Type::BPCHAR | postgres_types::Type::CHAR => Some(Type::Char {
-                length: CharLength::from_typmod(typmod),
-            }),
-            postgres_types::Type::VARCHAR => Some(Type::VarChar {
-                max_length: CharLength::from_typmod(typmod),
-            }),
-            postgres_types::Type::TIME => Some(Type::Time),
-            postgres_types::Type::TIMETZ => Some(Type::TimeTz),
-            postgres_types::Type::TIMESTAMP => Some(Type::Timestamp),
-            postgres_types::Type::TIMESTAMPTZ => Some(Type::TimestampTz),
-            postgres_types::Type::UUID => Some(Type::Uuid),
-            postgres_types::Type::REGCLASS => Some(Type::RegClass),
-            postgres_types::Type::REGPROC => Some(Type::RegProc),
-            postgres_types::Type::REGTYPE => Some(Type::RegType),
-            postgres_types::Type::BOOL_ARRAY => Some(Type::Array(Box::new(Type::Bool))),
-            postgres_types::Type::BYTEA_ARRAY => Some(Type::Array(Box::new(Type::Bytea))),
-            postgres_types::Type::BPCHAR_ARRAY => Some(Type::Array(Box::new(Type::Char {
-                length: CharLength::from_typmod(typmod),
-            }))),
-            postgres_types::Type::DATE_ARRAY => Some(Type::Array(Box::new(Type::Date))),
-            postgres_types::Type::FLOAT4_ARRAY => Some(Type::Array(Box::new(Type::Float4))),
-            postgres_types::Type::FLOAT8_ARRAY => Some(Type::Array(Box::new(Type::Float8))),
-            postgres_types::Type::INT2_ARRAY => Some(Type::Array(Box::new(Type::Int2))),
-            postgres_types::Type::INT4_ARRAY => Some(Type::Array(Box::new(Type::Int4))),
-            postgres_types::Type::INT8_ARRAY => Some(Type::Array(Box::new(Type::Int8))),
-            postgres_types::Type::INTERVAL_ARRAY => Some(Type::Array(Box::new(Type::Interval))),
-            postgres_types::Type::JSON_ARRAY => Some(Type::Array(Box::new(Type::Json))),
-            postgres_types::Type::JSONB_ARRAY => Some(Type::Array(Box::new(Type::Jsonb))),
-            postgres_types::Type::NUMERIC_ARRAY => Some(Type::Array(Box::new(Type::Numeric {
-                constraints: NumericConstraints::from_typmod(typmod),
-            }))),
-            postgres_types::Type::OID_ARRAY => Some(Type::Array(Box::new(Type::Oid))),
-            postgres_types::Type::TEXT_ARRAY => Some(Type::Array(Box::new(Type::Text))),
-            postgres_types::Type::TIME_ARRAY => Some(Type::Array(Box::new(Type::Time))),
-            postgres_types::Type::TIMETZ_ARRAY => Some(Type::Array(Box::new(Type::TimeTz))),
-            postgres_types::Type::TIMESTAMP_ARRAY => Some(Type::Array(Box::new(Type::Timestamp))),
+    pub fn from_oid_and_typmod(oid: u32, typmod: i32) -> Result<Type, TypeFromOidError> {
+        let typ = postgres_types::Type::from_oid(oid).ok_or(TypeFromOidError::UnknownOid(oid))?;
+        let mut typ = match typ {
+            postgres_types::Type::BOOL => Type::Bool,
+            postgres_types::Type::BYTEA => Type::Bytea,
+            postgres_types::Type::DATE => Type::Date,
+            postgres_types::Type::FLOAT4 => Type::Float4,
+            postgres_types::Type::FLOAT8 => Type::Float8,
+            postgres_types::Type::INT2 => Type::Int2,
+            postgres_types::Type::INT4 => Type::Int4,
+            postgres_types::Type::INT8 => Type::Int8,
+            postgres_types::Type::INTERVAL => Type::Interval { constraints: None },
+            postgres_types::Type::JSON => Type::Json,
+            postgres_types::Type::JSONB => Type::Jsonb,
+            postgres_types::Type::NUMERIC => Type::Numeric { constraints: None },
+            postgres_types::Type::OID => Type::Oid,
+            postgres_types::Type::TEXT => Type::Text,
+            postgres_types::Type::BPCHAR | postgres_types::Type::CHAR => {
+                Type::Char { length: None }
+            }
+            postgres_types::Type::VARCHAR => Type::VarChar { max_length: None },
+            postgres_types::Type::TIME => Type::Time { precision: None },
+            postgres_types::Type::TIMETZ => Type::TimeTz { precision: None },
+            postgres_types::Type::TIMESTAMP => Type::Timestamp { precision: None },
+            postgres_types::Type::TIMESTAMPTZ => Type::TimestampTz { precision: None },
+            postgres_types::Type::UUID => Type::Uuid,
+            postgres_types::Type::REGCLASS => Type::RegClass,
+            postgres_types::Type::REGPROC => Type::RegProc,
+            postgres_types::Type::REGTYPE => Type::RegType,
+            postgres_types::Type::BOOL_ARRAY => Type::Array(Box::new(Type::Bool)),
+            postgres_types::Type::BYTEA_ARRAY => Type::Array(Box::new(Type::Bytea)),
+            postgres_types::Type::BPCHAR_ARRAY => {
+                Type::Array(Box::new(Type::Char { length: None }))
+            }
+            postgres_types::Type::DATE_ARRAY => Type::Array(Box::new(Type::Date)),
+            postgres_types::Type::FLOAT4_ARRAY => Type::Array(Box::new(Type::Float4)),
+            postgres_types::Type::FLOAT8_ARRAY => Type::Array(Box::new(Type::Float8)),
+            postgres_types::Type::INT2_ARRAY => Type::Array(Box::new(Type::Int2)),
+            postgres_types::Type::INT4_ARRAY => Type::Array(Box::new(Type::Int4)),
+            postgres_types::Type::INT8_ARRAY => Type::Array(Box::new(Type::Int8)),
+            postgres_types::Type::INTERVAL_ARRAY => {
+                Type::Array(Box::new(Type::Interval { constraints: None }))
+            }
+            postgres_types::Type::JSON_ARRAY => Type::Array(Box::new(Type::Json)),
+            postgres_types::Type::JSONB_ARRAY => Type::Array(Box::new(Type::Jsonb)),
+            postgres_types::Type::NUMERIC_ARRAY => {
+                Type::Array(Box::new(Type::Numeric { constraints: None }))
+            }
+            postgres_types::Type::OID_ARRAY => Type::Array(Box::new(Type::Oid)),
+            postgres_types::Type::TEXT_ARRAY => Type::Array(Box::new(Type::Text)),
+            postgres_types::Type::TIME_ARRAY => {
+                Type::Array(Box::new(Type::Time { precision: None }))
+            }
+            postgres_types::Type::TIMETZ_ARRAY => {
+                Type::Array(Box::new(Type::TimeTz { precision: None }))
+            }
+            postgres_types::Type::TIMESTAMP_ARRAY => {
+                Type::Array(Box::new(Type::Timestamp { precision: None }))
+            }
             postgres_types::Type::TIMESTAMPTZ_ARRAY => {
-                Some(Type::Array(Box::new(Type::TimestampTz)))
+                Type::Array(Box::new(Type::TimestampTz { precision: None }))
             }
-            postgres_types::Type::UUID_ARRAY => Some(Type::Array(Box::new(Type::Uuid))),
-            postgres_types::Type::VARCHAR_ARRAY => Some(Type::Array(Box::new(Type::VarChar {
-                max_length: CharLength::from_typmod(typmod),
-            }))),
-            postgres_types::Type::REGCLASS_ARRAY => Some(Type::Array(Box::new(Type::RegClass))),
-            postgres_types::Type::REGPROC_ARRAY => Some(Type::Array(Box::new(Type::RegProc))),
-            postgres_types::Type::REGTYPE_ARRAY => Some(Type::Array(Box::new(Type::RegType))),
-            postgres_types::Type::INT2_VECTOR => Some(Type::Int2Vector),
-            postgres_types::Type::INT2_VECTOR_ARRAY => {
-                Some(Type::Array(Box::new(Type::Int2Vector)))
+            postgres_types::Type::UUID_ARRAY => Type::Array(Box::new(Type::Uuid)),
+            postgres_types::Type::VARCHAR_ARRAY => {
+                Type::Array(Box::new(Type::VarChar { max_length: None }))
             }
-            _ => None,
+            postgres_types::Type::REGCLASS_ARRAY => Type::Array(Box::new(Type::RegClass)),
+            postgres_types::Type::REGPROC_ARRAY => Type::Array(Box::new(Type::RegProc)),
+            postgres_types::Type::REGTYPE_ARRAY => Type::Array(Box::new(Type::RegType)),
+            postgres_types::Type::INT2_VECTOR => Type::Int2Vector,
+            postgres_types::Type::INT2_VECTOR_ARRAY => Type::Array(Box::new(Type::Int2Vector)),
+            _ => return Err(TypeFromOidError::UnknownOid(oid)),
+        };
+
+        // Apply the typmod. For arrays, the typmod applies to the element type.
+        // We use a funny-looking immediately-invoked closure to share the
+        // construction of the invalid typmod error across all error paths.
+        let res = ({
+            let typ = &mut typ;
+            || {
+                let elem_typ = match typ {
+                    Type::Array(typ) => &mut **typ,
+                    typ => typ,
+                };
+                match elem_typ {
+                    Type::Char { length } => *length = CharLength::from_typmod(typmod)?,
+                    Type::Numeric { constraints } => {
+                        *constraints = NumericConstraints::from_typmod(typmod)?
+                    }
+                    Type::Interval { constraints } => {
+                        *constraints = IntervalConstraints::from_typmod(typmod)?
+                    }
+                    Type::Time { precision } => *precision = TimePrecision::from_typmod(typmod)?,
+                    Type::TimeTz { precision } => *precision = TimePrecision::from_typmod(typmod)?,
+                    Type::Timestamp { precision } => {
+                        *precision = TimestampPrecision::from_typmod(typmod)?
+                    }
+                    Type::TimestampTz { precision } => {
+                        *precision = TimestampPrecision::from_typmod(typmod)?
+                    }
+                    Type::VarChar { max_length } => *max_length = CharLength::from_typmod(typmod)?,
+                    _ if typmod != -1 => return Err("type does not support type modifiers".into()),
+                    _ => (),
+                }
+                Ok(())
+            }
+        })();
+        match res {
+            Ok(()) => Ok(typ),
+            Err(detail) => Err(TypeFromOidError::InvalidTypmod {
+                typ,
+                typmod,
+                detail,
+            }),
         }
     }
 
@@ -324,7 +496,7 @@ impl Type {
                 Type::Int2 => &postgres_types::Type::INT2_ARRAY,
                 Type::Int4 => &postgres_types::Type::INT4_ARRAY,
                 Type::Int8 => &postgres_types::Type::INT8_ARRAY,
-                Type::Interval => &postgres_types::Type::INTERVAL_ARRAY,
+                Type::Interval { .. } => &postgres_types::Type::INTERVAL_ARRAY,
                 Type::Json => &postgres_types::Type::JSON_ARRAY,
                 Type::Jsonb => &postgres_types::Type::JSONB_ARRAY,
                 Type::List(_) => unreachable!(),
@@ -335,10 +507,10 @@ impl Type {
                 Type::Text => &postgres_types::Type::TEXT_ARRAY,
                 Type::Char { .. } => &postgres_types::Type::BPCHAR_ARRAY,
                 Type::VarChar { .. } => &postgres_types::Type::VARCHAR_ARRAY,
-                Type::Time => &postgres_types::Type::TIME_ARRAY,
-                Type::TimeTz => &postgres_types::Type::TIMETZ_ARRAY,
-                Type::Timestamp => &postgres_types::Type::TIMESTAMP_ARRAY,
-                Type::TimestampTz => &postgres_types::Type::TIMESTAMPTZ_ARRAY,
+                Type::Time { .. } => &postgres_types::Type::TIME_ARRAY,
+                Type::TimeTz { .. } => &postgres_types::Type::TIMETZ_ARRAY,
+                Type::Timestamp { .. } => &postgres_types::Type::TIMESTAMP_ARRAY,
+                Type::TimestampTz { .. } => &postgres_types::Type::TIMESTAMPTZ_ARRAY,
                 Type::Uuid => &postgres_types::Type::UUID_ARRAY,
                 Type::RegClass => &postgres_types::Type::REGCLASS_ARRAY,
                 Type::RegProc => &postgres_types::Type::REGPROC_ARRAY,
@@ -353,7 +525,7 @@ impl Type {
             Type::Int2 => &postgres_types::Type::INT2,
             Type::Int4 => &postgres_types::Type::INT4,
             Type::Int8 => &postgres_types::Type::INT8,
-            Type::Interval => &postgres_types::Type::INTERVAL,
+            Type::Interval { .. } => &postgres_types::Type::INTERVAL,
             Type::Json => &postgres_types::Type::JSON,
             Type::Jsonb => &postgres_types::Type::JSONB,
             Type::List(_) => &LIST,
@@ -364,10 +536,10 @@ impl Type {
             Type::Text => &postgres_types::Type::TEXT,
             Type::Char { .. } => &postgres_types::Type::BPCHAR,
             Type::VarChar { .. } => &postgres_types::Type::VARCHAR,
-            Type::Time => &postgres_types::Type::TIME,
-            Type::TimeTz => &postgres_types::Type::TIMETZ,
-            Type::Timestamp => &postgres_types::Type::TIMESTAMP,
-            Type::TimestampTz => &postgres_types::Type::TIMESTAMPTZ,
+            Type::Time { .. } => &postgres_types::Type::TIME,
+            Type::TimeTz { .. } => &postgres_types::Type::TIMETZ,
+            Type::Timestamp { .. } => &postgres_types::Type::TIMESTAMP,
+            Type::TimestampTz { .. } => &postgres_types::Type::TIMESTAMPTZ,
             Type::Uuid => &postgres_types::Type::UUID,
             Type::RegClass => &postgres_types::Type::REGCLASS,
             Type::RegProc => &postgres_types::Type::REGPROC,
@@ -437,6 +609,21 @@ impl Type {
             Type::Numeric {
                 constraints: Some(constraints),
             } => Some(constraints),
+            Type::Interval {
+                constraints: Some(constraints),
+            } => Some(constraints),
+            Type::Time {
+                precision: Some(precision),
+            } => Some(precision),
+            Type::TimeTz {
+                precision: Some(precision),
+            } => Some(precision),
+            Type::Timestamp {
+                precision: Some(precision),
+            } => Some(precision),
+            Type::TimestampTz {
+                precision: Some(precision),
+            } => Some(precision),
             Type::Array(_)
             | Type::Bool
             | Type::Bytea
@@ -447,7 +634,7 @@ impl Type {
             | Type::Int2
             | Type::Int4
             | Type::Int8
-            | Type::Interval
+            | Type::Interval { constraints: None }
             | Type::Json
             | Type::Jsonb
             | Type::List(_)
@@ -460,10 +647,10 @@ impl Type {
             | Type::RegProc
             | Type::RegType
             | Type::Text
-            | Type::Time
-            | Type::TimeTz
-            | Type::Timestamp
-            | Type::TimestampTz
+            | Type::Time { precision: None }
+            | Type::TimeTz { precision: None }
+            | Type::Timestamp { precision: None }
+            | Type::TimestampTz { precision: None }
             | Type::Uuid
             | Type::VarChar { max_length: None } => None,
         }
@@ -482,7 +669,7 @@ impl Type {
             Type::Int2 => 2,
             Type::Int4 => 4,
             Type::Int8 => 8,
-            Type::Interval => 16,
+            Type::Interval { .. } => 16,
             Type::Json => -1,
             Type::Jsonb => -1,
             Type::List(_) => -1,
@@ -493,10 +680,10 @@ impl Type {
             Type::Text => -1,
             Type::Char { .. } => -1,
             Type::VarChar { .. } => -1,
-            Type::Time => 4,
-            Type::TimeTz => 4,
-            Type::Timestamp => 8,
-            Type::TimestampTz => 8,
+            Type::Time { .. } => 4,
+            Type::TimeTz { .. } => 4,
+            Type::Timestamp { .. } => 8,
+            Type::TimestampTz { .. } => 8,
             Type::Uuid => 16,
             Type::RegClass => 4,
             Type::RegProc => 4,
@@ -545,7 +732,7 @@ impl TryFrom<&Type> for ScalarType {
             Type::Int2 => Ok(ScalarType::Int16),
             Type::Int4 => Ok(ScalarType::Int32),
             Type::Int8 => Ok(ScalarType::Int64),
-            Type::Interval => Ok(ScalarType::Interval),
+            Type::Interval { .. } => Ok(ScalarType::Interval),
             Type::Json => Err(TypeConversionError::UnsupportedType(Type::Json)),
             Type::Jsonb => Ok(ScalarType::Jsonb),
             Type::List(t) => Ok(ScalarType::List {
@@ -584,8 +771,11 @@ impl TryFrom<&Type> for ScalarType {
                 custom_name: None,
             }),
             Type::Text => Ok(ScalarType::String),
-            Type::Time => Ok(ScalarType::Time),
-            Type::TimeTz => Err(TypeConversionError::UnsupportedType(Type::TimeTz)),
+            Type::Time { precision: None } => Ok(ScalarType::Time),
+            Type::Time { precision: Some(_) } => {
+                Err(TypeConversionError::UnsupportedType(typ.clone()))
+            }
+            Type::TimeTz { .. } => Err(TypeConversionError::UnsupportedType(typ.clone())),
             Type::Char { length } => Ok(ScalarType::Char {
                 length: match length {
                     Some(length) => Some(AdtCharLength::try_from(i64::from(length.into_i32()))?),
@@ -600,8 +790,14 @@ impl TryFrom<&Type> for ScalarType {
                     None => None,
                 },
             }),
-            Type::Timestamp => Ok(ScalarType::Timestamp),
-            Type::TimestampTz => Ok(ScalarType::TimestampTz),
+            Type::Timestamp { precision: None } => Ok(ScalarType::Timestamp),
+            Type::Timestamp { precision: Some(_) } => {
+                Err(TypeConversionError::UnsupportedType(typ.clone()))
+            }
+            Type::TimestampTz { precision: None } => Ok(ScalarType::TimestampTz),
+            Type::TimestampTz { precision: Some(_) } => {
+                Err(TypeConversionError::UnsupportedType(typ.clone()))
+            }
             Type::Uuid => Ok(ScalarType::Uuid),
             Type::RegClass => Ok(ScalarType::RegClass),
             Type::RegProc => Ok(ScalarType::RegProc),
@@ -610,6 +806,43 @@ impl TryFrom<&Type> for ScalarType {
         }
     }
 }
+
+/// An error that can occur when constructing a [`Type`] from an OID.
+#[derive(Debug, Clone)]
+pub enum TypeFromOidError {
+    /// The OID does not specify a known type.
+    UnknownOid(u32),
+    /// The specified typmod is invalid for the type.
+    InvalidTypmod {
+        /// The type.
+        typ: Type,
+        /// The type modifier.
+        typmod: i32,
+        /// Details about the nature of the invalidity.
+        detail: String,
+    },
+}
+
+impl fmt::Display for TypeFromOidError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            TypeFromOidError::UnknownOid(oid) => write!(f, "type with OID {oid} is unknown"),
+            TypeFromOidError::InvalidTypmod {
+                typ,
+                typmod,
+                detail,
+            } => {
+                write!(
+                    f,
+                    "typmod {typmod} is invalid for type {}: {detail}",
+                    typ.name()
+                )
+            }
+        }
+    }
+}
+
+impl Error for TypeFromOidError {}
 
 /// An error that can occur when converting a [`Type`] to a [`ScalarType`].
 #[derive(Debug, Clone)]
@@ -642,6 +875,8 @@ impl fmt::Display for TypeConversionError {
     }
 }
 
+impl Error for TypeConversionError {}
+
 impl From<InvalidNumericMaxScaleError> for TypeConversionError {
     fn from(e: InvalidNumericMaxScaleError) -> TypeConversionError {
         TypeConversionError::InvalidNumericMaxScale(e)
@@ -672,7 +907,7 @@ impl From<&ScalarType> for Type {
             ScalarType::Int16 => Type::Int2,
             ScalarType::Int32 => Type::Int4,
             ScalarType::Int64 => Type::Int8,
-            ScalarType::Interval => Type::Interval,
+            ScalarType::Interval => Type::Interval { constraints: None },
             ScalarType::Jsonb => Type::Jsonb,
             ScalarType::List { element_type, .. } => {
                 Type::List(Box::new(From::from(&**element_type)))
@@ -694,9 +929,9 @@ impl From<&ScalarType> for Type {
             ScalarType::VarChar { max_length } => Type::VarChar {
                 max_length: (*max_length).map(CharLength::from),
             },
-            ScalarType::Time => Type::Time,
-            ScalarType::Timestamp => Type::Timestamp,
-            ScalarType::TimestampTz => Type::TimestampTz,
+            ScalarType::Time => Type::Time { precision: None },
+            ScalarType::Timestamp => Type::Timestamp { precision: None },
+            ScalarType::TimestampTz => Type::TimestampTz { precision: None },
             ScalarType::Uuid => Type::Uuid,
             ScalarType::Numeric { max_scale } => Type::Numeric {
                 constraints: Some(NumericConstraints {

--- a/src/pgrepr/src/value.rs
+++ b/src/pgrepr/src/value.rs
@@ -441,7 +441,7 @@ impl Value {
             Type::Int2 => Value::Int2(strconv::parse_int16(raw)?),
             Type::Int4 => Value::Int4(strconv::parse_int32(raw)?),
             Type::Int8 => Value::Int8(strconv::parse_int64(raw)?),
-            Type::Interval => Value::Interval(Interval(strconv::parse_interval(raw)?)),
+            Type::Interval { .. } => Value::Interval(Interval(strconv::parse_interval(raw)?)),
             Type::Json => return Err("input of json types is not implemented".into()),
             Type::Jsonb => Value::Jsonb(Jsonb(strconv::parse_jsonb(raw)?)),
             Type::List(elem_type) => Value::List(strconv::parse_list(
@@ -465,10 +465,10 @@ impl Value {
             Type::Text => Value::Text(raw.to_owned()),
             Type::Char { .. } => Value::Char(raw.to_owned()),
             Type::VarChar { .. } => Value::VarChar(raw.to_owned()),
-            Type::Time => Value::Time(strconv::parse_time(raw)?),
-            Type::TimeTz => return Err("input of timetz types is not implemented".into()),
-            Type::Timestamp => Value::Timestamp(strconv::parse_timestamp(raw)?),
-            Type::TimestampTz => Value::TimestampTz(strconv::parse_timestamptz(raw)?),
+            Type::Time { .. } => Value::Time(strconv::parse_time(raw)?),
+            Type::TimeTz { .. } => return Err("input of timetz types is not implemented".into()),
+            Type::Timestamp { .. } => Value::Timestamp(strconv::parse_timestamp(raw)?),
+            Type::TimestampTz { .. } => Value::TimestampTz(strconv::parse_timestamptz(raw)?),
             Type::Uuid => Value::Uuid(Uuid::parse_str(raw)?),
         })
     }
@@ -487,7 +487,7 @@ impl Value {
             Type::Int2 => i16::from_sql(ty.inner(), raw).map(Value::Int2),
             Type::Int4 => i32::from_sql(ty.inner(), raw).map(Value::Int4),
             Type::Int8 => i64::from_sql(ty.inner(), raw).map(Value::Int8),
-            Type::Interval => Interval::from_sql(ty.inner(), raw).map(Value::Interval),
+            Type::Interval { .. } => Interval::from_sql(ty.inner(), raw).map(Value::Interval),
             Type::Json => return Err("input of json types is not implemented".into()),
             Type::Jsonb => Jsonb::from_sql(ty.inner(), raw).map(Value::Jsonb),
             Type::List(_) => Err("binary decoding of list types is not implemented".into()),
@@ -500,10 +500,14 @@ impl Value {
             Type::Text => String::from_sql(ty.inner(), raw).map(Value::Text),
             Type::Char { .. } => String::from_sql(ty.inner(), raw).map(Value::Char),
             Type::VarChar { .. } => String::from_sql(ty.inner(), raw).map(Value::VarChar),
-            Type::Time => NaiveTime::from_sql(ty.inner(), raw).map(Value::Time),
-            Type::TimeTz => return Err("input of timetz types is not implemented".into()),
-            Type::Timestamp => NaiveDateTime::from_sql(ty.inner(), raw).map(Value::Timestamp),
-            Type::TimestampTz => DateTime::<Utc>::from_sql(ty.inner(), raw).map(Value::TimestampTz),
+            Type::Time { .. } => NaiveTime::from_sql(ty.inner(), raw).map(Value::Time),
+            Type::TimeTz { .. } => return Err("input of timetz types is not implemented".into()),
+            Type::Timestamp { .. } => {
+                NaiveDateTime::from_sql(ty.inner(), raw).map(Value::Timestamp)
+            }
+            Type::TimestampTz { .. } => {
+                DateTime::<Utc>::from_sql(ty.inner(), raw).map(Value::TimestampTz)
+            }
             Type::Uuid => Uuid::from_sql(ty.inner(), raw).map(Value::Uuid),
         }
     }

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -502,7 +502,7 @@ where
         let mut param_types = vec![];
         for oid in param_oids {
             match mz_pgrepr::Type::from_oid(oid) {
-                Some(ty) => match ScalarType::try_from(&ty) {
+                Ok(ty) => match ScalarType::try_from(&ty) {
                     Ok(ty) => param_types.push(Some(ty)),
                     Err(err) => {
                         return self
@@ -513,12 +513,12 @@ where
                             .await
                     }
                 },
-                None if oid == 0 => param_types.push(None),
-                None => {
+                Err(_) if oid == 0 => param_types.push(None),
+                Err(e) => {
                     return self
                         .error(ErrorResponse::error(
                             SqlState::PROTOCOL_VIOLATION,
-                            format!("unable to decode parameter whose type OID is {}", oid),
+                            e.to_string(),
                         ))
                         .await;
                 }

--- a/src/postgres-util/src/lib.rs
+++ b/src/postgres-util/src/lib.rs
@@ -162,10 +162,7 @@ pub async fn publication_info(
                 let name: String = row.get("name");
                 let oid = row.get("oid");
                 let typmod: i32 = row.get("typmod");
-                let ty = match PgType::from_oid_and_typmod(oid, typmod) {
-                    Some(ty) => ty,
-                    None => bail!("unknown type with OID {}", oid),
-                };
+                let ty = PgType::from_oid_and_typmod(oid, typmod)?;
                 let not_null: bool = row.get("not_null");
                 let primary_key = row.get("primary_key");
                 Ok(PgColumn {

--- a/test/sqllogictest/types.slt
+++ b/test/sqllogictest/types.slt
@@ -868,7 +868,7 @@ numeric
 query T
 SELECT format_type(26, 1);
 ----
-oid
+oid(1)
 
 query T
 SELECT format_type(26, -1);


### PR DESCRIPTION
The date/time types in PostgreSQL all support precision constraints, so
our pgrepr package should as well. This commit also restructures
`pgrepr::Type::from_oid_and_typmod` so that supplying an OID to a type
that does not support it is a hard error.

To preserve the existing behavior of `CREATE VIEWS FROM SOURCE`, we
explicitly ignore the precision modifier on date/time types.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
