### PR TITLE
coordtest: ignore tests for now

### DIFF
--- a/src/coordtest/src/lib.rs
+++ b/src/coordtest/src/lib.rs
@@ -7,6 +7,12 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+//! ### NOTICE
+//!
+//! coordtest is currently ignored in our testing suite. If any other
+//! API change would force annoying refactoring of this file, it is ok to
+//! completely remove the coordtest directory.
+//!
 //! coordtest attempts to be a deterministic Coordinator tester using datadriven
 //! test files. Many parts of dataflow run in their own tokio task and we aren't
 //! able to observe their output until we bump a timestamp and see if new data

--- a/src/materialized/tests/pgwire.rs
+++ b/src/materialized/tests/pgwire.rs
@@ -480,7 +480,12 @@ fn test_pgtest_mz() -> Result<(), Box<dyn Error>> {
     pg_test_inner(dir)
 }
 
+// Ignore this test for now because many things have changed and will change
+// about how the coordinator works and communicates with dataflow. We are going
+// to, at the least, wait for that work to stabilize before deciding if/how to
+// test it, which may or may not involve coordtest or a similar thing.
 #[tokio::test]
+#[ignore]
 async fn test_coordtest() -> Result<(), Box<dyn Error>> {
     mz_ore::test::init_logging();
 


### PR DESCRIPTION
Ignore coordtest due to upcoming API changes that may destabilize coordtests. We will reasses in the future how to test these components.

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - No user-facing changes.
