### PR TITLE
Complete timestamps

### DIFF
--- a/demo/simple/README.md
+++ b/demo/simple/README.md
@@ -118,11 +118,6 @@ available to Docker Engine.
     Go ahead and do that a few times; you should see the `region_sum` continue
     to increase for all `region_id`s.
 
-    The first time you run the command, you may see a message stating "At least
-    one input has no complete timestamps yet." This indicates that Materialize
-    is still reading the initial batch of data from Kafka, and is usually
-    resolved by trying again in a few moments.
-
 1. Close out of the Materialize CLI (<kbd>Ctrl</kbd> + <kbd>D</kbd>).
 
 1. Watch the report change using the `watch-sql` container, which continually

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -3375,7 +3375,7 @@ impl Coordinator {
 
         // First determine the candidate timestamp, which is either the explicitly requested
         // timestamp, or the latest timestamp known to be immediately available.
-        let timestamp = match when {
+        let timestamp: Timestamp = match when {
             // Explicitly requested timestamps should be respected.
             PeekWhen::AtTimestamp(mut timestamp) => {
                 let temp_storage = RowArena::new();
@@ -3442,50 +3442,51 @@ impl Coordinator {
                     });
                 }
 
-                let mut candidate = if uses_ids.iter().any(|id| self.catalog.uses_tables(*id)) {
-                    // If the view depends on any tables, we enforce
-                    // linearizability by choosing the latest input time.
-                    self.get_local_read_ts()
-                } else {
-                    let upper = self.indexes.greatest_open_upper(index_ids.iter().copied());
-                    // We peek at the largest element not in advance of `upper`, which
-                    // involves a subtraction. If `upper` contains a zero timestamp there
-                    // is no "prior" answer, and we do not want to peek at it as it risks
-                    // hanging awaiting the response to data that may never arrive.
-                    //
-                    // The .get(0) here breaks the antichain abstraction by assuming this antichain
-                    // has 0 or 1 elements in it. It happens to work because we use a timestamp
-                    // type that meets that assumption, but would break if we used a more general
-                    // timestamp.
-                    if let Some(candidate) = upper.elements().get(0) {
-                        if *candidate > 0 {
-                            candidate.saturating_sub(1)
-                        } else {
-                            let unstarted = index_ids
-                                .into_iter()
-                                .filter(|id| {
-                                    self.indexes
-                                        .upper_of(id)
-                                        .expect("id not found")
-                                        .less_equal(&0)
-                                })
-                                .collect::<Vec<_>>();
-                            return Err(CoordError::IncompleteTimestamp(unstarted));
-                        }
+                // Initialize candidate to the minimum correct time.
+                let mut candidate = Timestamp::minimum();
+                candidate.advance_by(since.borrow());
+
+                // Compute a timestamp to which we should advance the candidate (if it is in
+                // advance).
+                let advance_to: Timestamp =
+                    if uses_ids.iter().any(|id| self.catalog.uses_tables(*id)) {
+                        // If the view depends on any tables, we enforce linearizability by choosing
+                        // the latest input time.  If the candidate is already advanced past read_ts
+                        // due to the since work above (if joined with some other view), a peek will
+                        // be put into pending until something closes the table timestamp. That
+                        // occurs if a user does certain table operations, or otherwise by the
+                        // advance_local_inputs_loop task (and so the pending peek could wait up to 1
+                        // second before the table timestamp is closed). We do not need to worry about
+                        // telling the table linearizability stuff about this future timestamp because
+                        // by the time the read is served the table linearizability time will have
+                        // advanced already.
+                        self.get_local_read_ts()
                     } else {
-                        // A complete trace can be read in its final form with this time.
+                        let upper = self.indexes.greatest_open_upper(index_ids.iter().copied());
+                        // We peek at the largest element not in advance of `upper`, which
+                        // involves a subtraction. If `upper` contains a zero timestamp there
+                        // is no "prior" answer, and we do not want to peek at it as it risks
+                        // hanging awaiting the response to data that may never arrive.
                         //
-                        // This should only happen for literals that have no sources
-                        Timestamp::max_value()
-                    }
-                };
-                // If the candidate is not beyond the valid `since` frontier,
-                // force it to become so as best as we can. If `since` is empty
-                // this will be a no-op, as there is no valid time, but that should
-                // then be caught below.
-                if !since.less_equal(&candidate) {
-                    candidate.advance_by(since.borrow());
-                }
+                        // The .get(0) here breaks the antichain abstraction by assuming this antichain
+                        // has 0 or 1 elements in it. It happens to work because we use a timestamp
+                        // type that meets that assumption, but would break if we used a more general
+                        // timestamp.
+                        if let Some(candidate) = upper.elements().get(0) {
+                            if *candidate > Timestamp::minimum() {
+                                candidate.saturating_sub(1)
+                            } else {
+                                Timestamp::minimum()
+                            }
+                        } else {
+                            // A complete trace can be read in its final form with this time.
+                            //
+                            // This should only happen for literals that have no sources or sources that
+                            // are known to have completed (non-tailed files for example).
+                            Timestamp::MAX
+                        }
+                    };
+                candidate.join_assign(&advance_to);
                 candidate
             }
         };

--- a/src/coord/src/error.rs
+++ b/src/coord/src/error.rs
@@ -53,8 +53,6 @@ pub enum CoordError {
     IdExhaustionError,
     /// Unexpected internal state was encountered.
     Internal(String),
-    /// At least one input has no complete timestamps yet
-    IncompleteTimestamp(Vec<mz_expr::GlobalId>),
     /// Specified index is disabled, but received non-enabling update request
     InvalidAlterOnDisabledIndex(String),
     /// Attempted to build a materialization on a source that does not allow multiple materializations
@@ -307,11 +305,6 @@ impl fmt::Display for CoordError {
                 p.value().quoted()
             ),
             CoordError::IdExhaustionError => f.write_str("ID allocator exhausted all valid IDs"),
-            CoordError::IncompleteTimestamp(unstarted) => write!(
-                f,
-                "At least one input has no complete timestamps yet: {:?}",
-                unstarted
-            ),
             CoordError::Internal(e) => write!(f, "internal error: {}", e),
             CoordError::InvalidAlterOnDisabledIndex(name) => {
                 write!(f, "invalid ALTER on disabled index {}", name.quoted())

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -381,7 +381,6 @@ impl ErrorResponse {
             CoordError::Eval(_) => SqlState::INTERNAL_ERROR,
             CoordError::FixedValueParameter(_) => SqlState::INVALID_PARAMETER_VALUE,
             CoordError::IdExhaustionError => SqlState::INTERNAL_ERROR,
-            CoordError::IncompleteTimestamp(_) => SqlState::SQL_STATEMENT_NOT_YET_COMPLETE,
             CoordError::Internal(_) => SqlState::INTERNAL_ERROR,
             CoordError::InvalidRematerialization { .. } => SqlState::FEATURE_NOT_SUPPORTED,
             CoordError::InvalidParameterType(_) => SqlState::INVALID_PARAMETER_VALUE,

--- a/test/testdrive/timestamps-debezium-kafka.td
+++ b/test/testdrive/timestamps-debezium-kafka.td
@@ -108,14 +108,33 @@ $ kafka-ingest format=avro topic=bar schema=${schema}
 
 > CREATE MATERIALIZED VIEW join (b, foo_sum, bar_sum) AS SELECT * FROM foo JOIN bar USING (b);
 
-! SELECT * FROM bar;
-contains:At least one input has no complete timestamps yet:
+# Verify that we don't see any data yet. We can't use `set-sql-timeout` here
+# because the SELECT is blocked in the coordinator. For the same reason we
+# can't use `DECLARE c CURSOR FOR SELECT ...` (see #10763).
 
-! SELECT * FROM foo;
-contains:At least one input has no complete timestamps yet:
+> BEGIN
 
-! SELECT * FROM join ;
-contains:At least one input has no complete timestamps yet:
+> DECLARE c CURSOR FOR TAIL (SELECT * FROM bar)
+
+> FETCH ALL c WITH (timeout = '2s');
+
+> ROLLBACK
+
+> BEGIN
+
+> DECLARE c CURSOR FOR TAIL (SELECT * FROM foo)
+
+> FETCH ALL c WITH (timeout = '2s');
+
+> ROLLBACK
+
+> BEGIN
+
+> DECLARE c CURSOR FOR TAIL (SELECT * FROM join)
+
+> FETCH ALL c WITH (timeout = '2s');
+
+> ROLLBACK
 
 $ kafka-ingest format=avro topic=foo schema=${schema}
 {"com.materialize.cdc.progress":{"lower":[0],"upper":[2],"counts":[{"time":1,"count":2}]}}


### PR DESCRIPTION
Resubmitting #10764 but after disabling coordtest in #10996.

Previously we would require a valid upper to be available and error with
"no complete timestamps" if it was not available. Instead, change the
order in which we determine timestamps:

1. Initialize to the timestamp minimum.
2. Advance to the since.
3. Advance to the upper.

Each "advance" step can possibly do nothing if the current canditate
timestamp is already in advance of the argument.

As a result, we no longer produce the no complete timestamps error. The
previous case where it occurred, when the upper was 0, will leave the
candidate timestamp at the since. If the since is also 0, that is fine,
because we assume the source is correctly declaring 0 to be the first
time at which it will produce results.

Closes #8163
Fixes #3122

### Motivation

Which of the following best describes the motivation behind this PR?

  * This PR adds a known-desirable feature: #3122
  * I no longer wish to be mocked by this error message.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Remove the "no complete timestamps" error. Queries will now wait for initial data instead of erroring and requiring users to run their query in a loop until it succeeds.