### PR TITLE
quick fix to handle arrays in composite types

### DIFF
--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2148,8 +2148,8 @@ pub fn plan_create_type(
         Ok(())
     }
 
-    let mut ids = vec![];
-    let mut record_field_names = vec![];
+    let mut depends_on = vec![];
+    let mut record_fields = vec![];
     match &as_type {
         CreateTypeAs::List { with_options } | CreateTypeAs::Map { with_options } => {
             let mut with_options = normalize::option_objects(&with_options);
@@ -2164,7 +2164,7 @@ pub fn plan_create_type(
                     Some(SqlOption::DataType { data_type, .. }) => {
                         let (data_type, dt_ids) = resolve_names_data_type(scx, data_type)?;
                         ensure_valid_data_type(scx, &data_type, &as_type, key)?;
-                        ids.extend(dt_ids);
+                        depends_on.extend(dt_ids);
                     }
                     Some(_) => bail!("{} must be a data type", key),
                     None => bail!("{} parameter required", key),
@@ -2176,14 +2176,15 @@ pub fn plan_create_type(
         CreateTypeAs::Record { ref column_defs } => {
             for column_def in column_defs {
                 let key = ident(column_def.name.clone());
-                let (data_type, _) = resolve_names_data_type(scx, column_def.data_type.clone())?;
+                let (data_type, dt_ids) =
+                    resolve_names_data_type(scx, column_def.data_type.clone())?;
                 ensure_valid_data_type(scx, &data_type, &as_type, &key)?;
+                depends_on.extend(dt_ids);
                 if let ResolvedDataType::Named { id, .. } = data_type {
-                    ids.push(id);
+                    record_fields.push((ColumnName::from(key.clone()), id));
                 } else {
                     bail!("field {} must be a named type", key)
                 }
-                record_field_names.push(ColumnName::from(key.clone()));
             }
         }
     };
@@ -2195,10 +2196,10 @@ pub fn plan_create_type(
 
     let inner = match as_type {
         CreateTypeAs::List { .. } => CatalogType::List {
-            element_id: *ids.get(0).expect("custom type to have element id"),
+            element_id: *depends_on.get(0).expect("custom type to have element id"),
         },
         CreateTypeAs::Map { .. } => {
-            let key_id = *ids.get(0).expect("key");
+            let key_id = *depends_on.get(0).expect("key");
             let entry = scx.catalog.get_item_by_id(&key_id);
             match entry.type_details() {
                 Some(CatalogTypeDetails {
@@ -2211,14 +2212,11 @@ pub fn plan_create_type(
 
             CatalogType::Map {
                 key_id,
-                value_id: *ids.get(1).expect("value"),
+                value_id: *depends_on.get(1).expect("value"),
             }
         }
         CreateTypeAs::Record { .. } => CatalogType::Record {
-            fields: record_field_names
-                .into_iter()
-                .zip_eq(ids.iter().cloned())
-                .collect_vec(),
+            fields: record_fields,
         },
     };
 
@@ -2227,7 +2225,7 @@ pub fn plan_create_type(
         typ: Type {
             create_sql,
             inner,
-            depends_on: ids,
+            depends_on,
         },
     }))
 }

--- a/test/sqllogictest/postgres/rowtypes.slt
+++ b/test/sqllogictest/postgres/rowtypes.slt
@@ -36,6 +36,16 @@ create type complex as (r float8, i float8);
 statement ok
 create type quad as (c1 complex, c2 complex);
 
+# and with various container types as fields
+statement ok
+CREATE TYPE int4_list AS LIST (element_type = int4);
+
+statement ok
+CREATE TYPE int4_map AS MAP (key_type = text, value_type = int4);
+
+statement ok
+CREATE TYPE melange AS (a int[][], b text[], c int4_list, d int4_map);
+
 # Some simple tests of conversions and row construction
 query T
 select (1.1, 2.2)::complex
@@ -61,6 +71,11 @@ query T
 select ROW((1.1, 2.2), ROW(3.3, 4.4)::complex)::quad
 ----
  ("(1.1,2.2)","(3.3,4.4)")
+
+query T
+select ROW(ARRAY[[1, 2], [3, 4]], ARRAY['abc', 'def'], LIST[5, 6, 7], '{g=>8, h=>9}')::melange::text;
+----
+({{1,2},{3,4}},{abc,def},{5,6,7},{g=>8,h=>9})
 
 # implicit casting of nested records to a named composite type
 


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

While working on JSON sources I noticed a gap in our composite type handling. We were using the wrong type ID to store as field information, causing an array type to becomes its element's type instead. This pulls the type id from the root `data_type` after resolution instead.

### Motivation

Fixes https://github.com/MaterializeInc/materialize/issues/10975

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Fixes handling of array type fields when creating named composite types {{% gh 10975 %}}
