### PR TITLE
Fix timeout on FETCH 0, fixes #6305

### DIFF
--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -1345,6 +1345,8 @@ where
                 FetchResult::Canceled
             } else if rows.current.is_some() {
                 FetchResult::Rows(rows.current.take())
+            } else if want_rows == 0 {
+                FetchResult::Rows(None)
             } else {
                 tokio::select! {
                     _ = time::sleep_until(deadline.unwrap_or_else(time::Instant::now)), if deadline.is_some() => FetchResult::Rows(None),

--- a/test/testdrive/github-6305.td
+++ b/test/testdrive/github-6305.td
@@ -9,18 +9,14 @@
 
 # Regression test for https://github.com/MaterializeInc/materialize/issues/6305
 
-$ set int={"type": "record", "name": "field_int", "fields": [ {"name": "f1", "type": "int"} ] }
-
-$ kafka-create-topic topic=tail-fetch-count-zero
-
-> CREATE MATERIALIZED SOURCE fetch_count_zero
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-tail-fetch-count-zero-${testdrive.seed}'
-  WITH( timestamp_frequency_ms = 100 )
-  FORMAT AVRO USING SCHEMA '${int}'
-  ENVELOPE NONE
+> CREATE TABLE t1 (i1 INT8);
 
 > BEGIN
 
-> DECLARE c CURSOR FOR TAIL fetch_count_zero AS OF NOW();
+> DECLARE c CURSOR FOR TAIL (SELECT * FROM t1) AS OF now() + '1hr'
 
-> FETCH 0 c WITH (timeout='1h');
+> FETCH 0 c
+
+> FETCH 0 c WITH (timeout='1h')
+
+> COMMIT

--- a/test/testdrive/github-6305.td
+++ b/test/testdrive/github-6305.td
@@ -1,0 +1,26 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Regression test for https://github.com/MaterializeInc/materialize/issues/6305
+
+$ set int={"type": "record", "name": "field_int", "fields": [ {"name": "f1", "type": "int"} ] }
+
+$ kafka-create-topic topic=tail-fetch-count-zero
+
+> CREATE MATERIALIZED SOURCE fetch_count_zero
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-tail-fetch-count-zero-${testdrive.seed}'
+  WITH( timestamp_frequency_ms = 100 )
+  FORMAT AVRO USING SCHEMA '${int}'
+  ENVELOPE NONE
+
+> BEGIN
+
+> DECLARE c CURSOR FOR TAIL fetch_count_zero AS OF NOW();
+
+> FETCH 0 c WITH (timeout='1h');


### PR DESCRIPTION
Fix timeout on FETCH 0, fixes #6305

### Motivation

This PR fixes a recognized bug.: #6305 

### Tips for reviewer

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Change `FETCH 0` to always return immediately.