### PR TITLE
dataflow: InstanceConfig to distinguish local/remote

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -91,10 +91,10 @@ use uuid::Uuid;
 
 use mz_build_info::BuildInfo;
 use mz_dataflow_types::client::controller::ReadPolicy;
-use mz_dataflow_types::client::{ComputeInstanceId, DEFAULT_COMPUTE_INSTANCE_ID};
-use mz_dataflow_types::client::{ComputeResponse, TimestampBindingFeedback};
 use mz_dataflow_types::client::{
-    CreateSourceCommand, Response as DataflowResponse, StorageResponse,
+    ComputeInstanceId, ComputeResponse, CreateSourceCommand, InstanceConfig,
+    Response as DataflowResponse, StorageResponse, TimestampBindingFeedback,
+    DEFAULT_COMPUTE_INSTANCE_ID,
 };
 use mz_dataflow_types::logging::LoggingConfig as DataflowLoggingConfig;
 use mz_dataflow_types::sinks::{SinkAsOf, SinkConnector, SinkDesc, TailSinkConnector};
@@ -236,6 +236,7 @@ pub struct LoggingConfig {
 /// Configures a coordinator.
 pub struct Config {
     pub dataflow_client: Box<dyn mz_dataflow_types::client::Client + Send>,
+    pub dataflow_instance: InstanceConfig,
     pub logging: Option<LoggingConfig>,
     pub storage: storage::Connection,
     pub timestamp_frequency: Duration,
@@ -4385,6 +4386,7 @@ impl Coordinator {
 pub async fn serve(
     Config {
         dataflow_client,
+        dataflow_instance,
         logging,
         storage,
         timestamp_frequency,
@@ -4472,11 +4474,11 @@ pub async fn serve(
                 log_logging: config.log_logging,
             });
             handle
-                .block_on(
-                    coord
-                        .dataflow_client
-                        .create_instance(DEFAULT_COMPUTE_INSTANCE_ID, logging),
-                )
+                .block_on(coord.dataflow_client.create_instance(
+                    DEFAULT_COMPUTE_INSTANCE_ID,
+                    dataflow_instance,
+                    logging,
+                ))
                 .unwrap();
             let bootstrap = handle.block_on(coord.bootstrap(builtin_table_updates));
             let ok = bootstrap.is_ok();

--- a/src/coordtest/src/lib.rs
+++ b/src/coordtest/src/lib.rs
@@ -73,7 +73,7 @@ use std::time::{Duration, Instant};
 use anyhow::anyhow;
 use async_trait::async_trait;
 use futures::future::FutureExt;
-use mz_dataflow_types::client::{ComputeResponse, Response};
+use mz_dataflow_types::client::{ComputeResponse, InstanceConfig, Response};
 use mz_dataflow_types::sources::AwsExternalId;
 use tempfile::TempDir;
 use tokio::sync::mpsc;
@@ -146,6 +146,7 @@ impl CoordTest {
             .await?;
         let (coord_handle, coord_client) = mz_coord::serve(mz_coord::Config {
             dataflow_client: Box::new(dataflow_client.clone()),
+            dataflow_instance: InstanceConfig::Virtual,
             storage,
             logging: None,
             logical_compaction_window: None,

--- a/src/dataflow-types/src/client/controller.rs
+++ b/src/dataflow-types/src/client/controller.rs
@@ -29,7 +29,8 @@ use timely::progress::frontier::{Antichain, AntichainRef};
 use timely::progress::Timestamp;
 
 use crate::client::{
-    Client, Command, ComputeCommand, ComputeInstanceId, ComputeResponse, Response, StorageResponse,
+    Client, Command, ComputeCommand, ComputeInstanceId, ComputeResponse, InstanceConfig, Response,
+    StorageResponse,
 };
 use crate::logging::LoggingConfig;
 
@@ -53,13 +54,14 @@ where
     pub async fn create_instance(
         &mut self,
         instance: ComputeInstanceId,
+        config: InstanceConfig,
         logging: Option<LoggingConfig>,
     ) -> Result<(), anyhow::Error> {
         self.compute
             .insert(instance, compute::ComputeControllerState::new(&logging));
         self.client
             .send(Command::Compute(
-                ComputeCommand::CreateInstance(logging),
+                ComputeCommand::CreateInstance(config, logging),
                 instance,
             ))
             .await

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -291,8 +291,10 @@ where
             for cmd in cmds {
                 self.metrics_bundle.0.observe_command(&cmd);
 
-                if let Command::Compute(ComputeCommand::CreateInstance(_logging), instance_id) =
-                    &cmd
+                if let Command::Compute(
+                    ComputeCommand::CreateInstance(_config, _logging),
+                    instance_id,
+                ) = &cmd
                 {
                     let compute_instance = ComputeState {
                         traces: TraceManager::new(

--- a/src/dataflow/src/server/compute_state.rs
+++ b/src/dataflow/src/server/compute_state.rs
@@ -82,7 +82,7 @@ impl<'a, A: Allocate, B: ComputeReplay> ActiveComputeState<'a, A, B> {
     /// Entrypoint for applying a compute command.
     pub(crate) fn handle_compute_command(&mut self, cmd: ComputeCommand) {
         match cmd {
-            ComputeCommand::CreateInstance(logging) => {
+            ComputeCommand::CreateInstance(_config, logging) => {
                 if let Some(logging) = logging {
                     self.initialize_logging(&logging);
                 }

--- a/src/materialized/src/bin/coordd.rs
+++ b/src/materialized/src/bin/coordd.rs
@@ -23,8 +23,8 @@ use materialized::http;
 use materialized::mux::Mux;
 use materialized::server_metrics::Metrics;
 use mz_coord::LoggingConfig;
-use mz_dataflow_types::client::Client;
-use mz_dataflowd::SplitClient;
+use mz_dataflow_types::client::{Client, InstanceConfig};
+use mz_dataflowd::{RemoteClient, SplitClient};
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
 use mz_ore::task;
@@ -76,21 +76,24 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
         )
         .init();
 
-    let dataflow_client: Box<dyn Client + Send + 'static> = if args.storaged_addr.is_empty() {
-        info!(
-            "connecting to dataflowd server at {:?}...",
-            args.dataflowd_addr
-        );
-        Box::new(mz_dataflowd::RemoteClient::connect(&args.dataflowd_addr).await?)
-    } else {
-        info!(
-            "connecting to dataflowd server at {:?} and storaged server at {:?}...",
-            args.dataflowd_addr, args.storaged_addr
-        );
-        let compute_client = mz_dataflowd::RemoteClient::connect(&args.dataflowd_addr).await?;
-        let storage_client = mz_dataflowd::RemoteClient::connect(&args.storaged_addr).await?;
-        Box::new(SplitClient::new(storage_client, compute_client))
-    };
+    let (dataflow_client, dataflow_instance): (Box<dyn Client + Send + 'static>, _) =
+        if args.storaged_addr.is_empty() {
+            info!(
+                "connecting to dataflowd server at {:?}...",
+                args.dataflowd_addr
+            );
+            let client = RemoteClient::connect(&args.dataflowd_addr).await?;
+            (Box::new(client), InstanceConfig::Virtual)
+        } else {
+            info!(
+                "connecting to dataflowd server at {:?} and storaged server at {:?}...",
+                args.dataflowd_addr, args.storaged_addr
+            );
+            let storage_client = RemoteClient::connect(&args.storaged_addr).await?;
+            let client = SplitClient::new(storage_client);
+            let config = InstanceConfig::Remote(args.dataflowd_addr);
+            (Box::new(client), config)
+        };
 
     let experimental_mode = false;
     let mut metrics_registry = MetricsRegistry::new();
@@ -113,6 +116,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
     let granularity = Duration::from_secs(1);
     let (coord_handle, coord_client) = mz_coord::serve(mz_coord::Config {
         dataflow_client,
+        dataflow_instance,
         logging: Some(LoggingConfig {
             log_logging: false,
             granularity,

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -32,6 +32,7 @@ use tokio_stream::wrappers::TcpListenerStream;
 
 use mz_build_info::BuildInfo;
 use mz_coord::LoggingConfig;
+use mz_dataflow_types::client::InstanceConfig;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
 use mz_ore::option::OptionExt;
@@ -282,6 +283,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
     // Initialize coordinator.
     let (coord_handle, coord_client) = mz_coord::serve(mz_coord::Config {
         dataflow_client: Box::new(dataflow_client),
+        dataflow_instance: InstanceConfig::Virtual,
         logging: config.logging,
         storage: coord_storage,
         timestamp_frequency: config.timestamp_frequency,


### PR DESCRIPTION
Introduce an `InstanceConfig` type that allows us to distinguish virtual and remote COMPUTE clusters.

### Motivation

This PR adds a feature that has not yet been specified.

At the moment, Materialize creates a default instance that runs within the same process as the rest of the system. For `coordd`, this is not desirable and instead we want to only connect to remote instances. The current behavior is to unconditionally initialize the `DEFAULT_COMPUTE_INSTANCE_ID` during startup, assuming that it either exists as a virtual instance or that we already established a connection to it.

With this PR, we have to indicate whether the new instance is a virtual instance (as used by `materialized`) or a remote instance, used by `coordd`. The local client handle intercepts the `CreateInstance` command, and establishes a connection to the remote if needed.

As a side-effect, the `SplitClient` makes it explicit that it cannot handle virtual instances, as such an instance does not exist in the current setup. We could add a virtual instance to `coordd` if we wanted to, though.


### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - 
