### PR TITLE
add support for intervals in date_trunc. fix #9871

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -2062,7 +2062,7 @@ fn date_trunc_interval<'a>(a: Datum, int: Interval) -> Result<Datum<'a>, EvalErr
             })
         .and_then(|dtf| {
             let mut int2 = int.clone();
-            int2.truncate_low_fields(dtf, None)
+            int2.truncate_low_fields(dtf, Some(0))
                 // truncate_low_fields should never return an error in our case
                 .map_err(|e| EvalError::Internal(e.to_string()))
                 .map(|_| int2.into())

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -2039,27 +2039,29 @@ where
     }
 }
 
-fn date_trunc_interval<'a>(a: Datum, int: Interval) -> Result<Datum<'a>, EvalError>
-{
+fn date_trunc_interval<'a>(a: Datum, int: Interval) -> Result<Datum<'a>, EvalError> {
     use mz_repr::adt::datetime::DateTimeField;
     let units = a.unwrap_str();
-    units.parse()
+    units
+        .parse()
         .map_err(|_| EvalError::UnknownUnits(units.to_owned()))
-        .and_then(|dtu|
-            match dtu {
-                DateTimeUnits::Millennium => Ok(DateTimeField::Millennium),
-                DateTimeUnits::Century => Ok(DateTimeField::Century),
-                DateTimeUnits::Decade => Ok(DateTimeField::Decade),
-                DateTimeUnits::Year => Ok(DateTimeField::Year),
-                DateTimeUnits::Month => Ok(DateTimeField::Month),
-                DateTimeUnits::Day => Ok(DateTimeField::Day),
-                DateTimeUnits::Hour => Ok(DateTimeField::Hour),
-                DateTimeUnits::Minute => Ok(DateTimeField::Minute),
-                DateTimeUnits::Second => Ok(DateTimeField::Second),
-                DateTimeUnits::Milliseconds => Ok(DateTimeField::Milliseconds),
-                DateTimeUnits::Microseconds => Ok(DateTimeField::Microseconds),
-                other => Err(EvalError::Undefined(format!("truncate interval by \"{}\"", other)))
-            })
+        .and_then(|dtu| match dtu {
+            DateTimeUnits::Millennium => Ok(DateTimeField::Millennium),
+            DateTimeUnits::Century => Ok(DateTimeField::Century),
+            DateTimeUnits::Decade => Ok(DateTimeField::Decade),
+            DateTimeUnits::Year => Ok(DateTimeField::Year),
+            DateTimeUnits::Month => Ok(DateTimeField::Month),
+            DateTimeUnits::Day => Ok(DateTimeField::Day),
+            DateTimeUnits::Hour => Ok(DateTimeField::Hour),
+            DateTimeUnits::Minute => Ok(DateTimeField::Minute),
+            DateTimeUnits::Second => Ok(DateTimeField::Second),
+            DateTimeUnits::Milliseconds => Ok(DateTimeField::Milliseconds),
+            DateTimeUnits::Microseconds => Ok(DateTimeField::Microseconds),
+            other => Err(EvalError::Undefined(format!(
+                "truncate interval by \"{}\"",
+                other
+            ))),
+        })
         .and_then(|dtf| {
             let mut int2 = int.clone();
             int2.truncate_low_fields(dtf, Some(0))

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -2041,42 +2041,32 @@ where
 
 fn date_trunc_interval<'a>(a: Datum, int: Interval) -> Result<Datum<'a>, EvalError>
 {
-    let units = a.unwrap_str();
-    match units.parse() {
-        Ok(units) => date_trunc_interval_inner(units, int),
-        Err(_) => Err(EvalError::UnknownUnits(units.to_owned())),
-    }
-}
-
-fn date_trunc_interval_inner<'a>(units: DateTimeUnits, int : Interval) -> Result<Datum<'a>, EvalError>
-{
     use mz_repr::adt::datetime::DateTimeField;
-    let mut int2 = int.clone();
-
-    fn to_eval_err<'a>(e : anyhow::Error) -> EvalError {
-        // truncate_low_fields returns only errors when fsec_max_precision is set
-        EvalError::Internal(e.to_string())
-    }
-
-    let res = match units {
-        DateTimeUnits::Millennium => int2.truncate_low_fields(DateTimeField::Millennium, None).map_err(to_eval_err),
-        DateTimeUnits::Century => int2.truncate_low_fields(DateTimeField::Century, None).map_err(to_eval_err),
-        DateTimeUnits::Decade => int2.truncate_low_fields(DateTimeField::Decade, None).map_err(to_eval_err),
-        DateTimeUnits::Year => int2.truncate_low_fields(DateTimeField::Year, None).map_err(to_eval_err),
-        DateTimeUnits::Month => int2.truncate_low_fields(DateTimeField::Month, None).map_err(to_eval_err),
-        DateTimeUnits::Day => int2.truncate_low_fields(DateTimeField::Day, None).map_err(to_eval_err),
-        DateTimeUnits::Hour => int2.truncate_low_fields(DateTimeField::Hour, None).map_err(to_eval_err),
-        DateTimeUnits::Minute => int2.truncate_low_fields(DateTimeField::Minute, None).map_err(to_eval_err),
-        DateTimeUnits::Second => int2.truncate_low_fields(DateTimeField::Second, None).map_err(to_eval_err),
-        DateTimeUnits::Milliseconds => int2.truncate_low_fields(DateTimeField::Milliseconds, None).map_err(to_eval_err),
-        DateTimeUnits::Microseconds => int2.truncate_low_fields(DateTimeField::Microseconds, None).map_err(to_eval_err),
-
-        // Since months have fractional weeks, truncating by week does not make sense.
-        // Postgres reports an error too in this case.
-        dtu => Err(EvalError::Undefined(format!("truncate interval by \"{}\"", dtu)))
-    };
-
-    res.map(|_| int2.into())
+    let units = a.unwrap_str();
+    units.parse()
+        .map_err(|_| EvalError::UnknownUnits(units.to_owned()))
+        .and_then(|dtu|
+            match dtu {
+                DateTimeUnits::Millennium => Ok(DateTimeField::Millennium),
+                DateTimeUnits::Century => Ok(DateTimeField::Century),
+                DateTimeUnits::Decade => Ok(DateTimeField::Decade),
+                DateTimeUnits::Year => Ok(DateTimeField::Year),
+                DateTimeUnits::Month => Ok(DateTimeField::Month),
+                DateTimeUnits::Day => Ok(DateTimeField::Day),
+                DateTimeUnits::Hour => Ok(DateTimeField::Hour),
+                DateTimeUnits::Minute => Ok(DateTimeField::Minute),
+                DateTimeUnits::Second => Ok(DateTimeField::Second),
+                DateTimeUnits::Milliseconds => Ok(DateTimeField::Milliseconds),
+                DateTimeUnits::Microseconds => Ok(DateTimeField::Microseconds),
+                other => Err(EvalError::Undefined(format!("truncate interval by \"{}\"", other)))
+            })
+        .and_then(|dtf| {
+            let mut int2 = int.clone();
+            int2.truncate_low_fields(dtf, None)
+                // truncate_low_fields should never return an error in our case
+                .map_err(|e| EvalError::Internal(e.to_string()))
+                .map(|_| int2.into())
+        })
 }
 
 fn date_trunc_inner<'a, T>(units: DateTimeUnits, ts: T) -> Result<Datum<'a>, EvalError>

--- a/src/repr/src/adt/interval.rs
+++ b/src/repr/src/adt/interval.rs
@@ -417,6 +417,21 @@ impl Interval {
     ) -> Result<(), anyhow::Error> {
         use DateTimeField::*;
         match f {
+            Millennium => {
+                self.months -= self.months % (12*1000);
+                self.days = 0;
+                self.micros = 0;
+            }
+            Century => {
+                self.months -= self.months % (12*100);
+                self.days = 0;
+                self.micros = 0;
+            }
+            Decade => {
+                self.months -= self.months % (12*10);
+                self.days = 0;
+                self.micros = 0;
+            }
             Year => {
                 self.months -= self.months % 12;
                 self.days = 0;
@@ -460,11 +475,8 @@ impl Interval {
             Day => {
                 self.micros = 0;
             }
-            Hour | Minute => {
+            Hour | Minute | Milliseconds | Microseconds => {
                 self.micros -= self.micros % f.micros_multiplier();
-            }
-            Millennium | Century | Decade | Milliseconds | Microseconds => {
-                unreachable!("Cannot truncate interval by {f}");
             }
         }
         Ok(())

--- a/src/repr/src/adt/interval.rs
+++ b/src/repr/src/adt/interval.rs
@@ -418,17 +418,17 @@ impl Interval {
         use DateTimeField::*;
         match f {
             Millennium => {
-                self.months -= self.months % (12*1000);
+                self.months -= self.months % (12 * 1000);
                 self.days = 0;
                 self.micros = 0;
             }
             Century => {
-                self.months -= self.months % (12*100);
+                self.months -= self.months % (12 * 100);
                 self.days = 0;
                 self.micros = 0;
             }
             Decade => {
-                self.months -= self.months % (12*10);
+                self.months -= self.months % (12 * 10);
                 self.days = 0;
                 self.micros = 0;
             }

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1789,7 +1789,7 @@ lazy_static! {
             "date_trunc" => Scalar {
                 params!(String, Timestamp) => BinaryFunc::DateTruncTimestamp, 2020;
                 params!(String, TimestampTz) => BinaryFunc::DateTruncTimestampTz, 1217;
-                params!(String, Interval) => BinaryFunc::DateTruncInterval, 1172;
+                params!(String, Interval) => BinaryFunc::DateTruncInterval, 1218;
             },
             "degrees" => Scalar {
                 params!(Float64) => UnaryFunc::Degrees(func::Degrees), 1608;

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1789,6 +1789,7 @@ lazy_static! {
             "date_trunc" => Scalar {
                 params!(String, Timestamp) => BinaryFunc::DateTruncTimestamp, 2020;
                 params!(String, TimestampTz) => BinaryFunc::DateTruncTimestampTz, 1217;
+                params!(String, Interval) => BinaryFunc::DateTruncInterval, 1172;
             },
             "degrees" => Scalar {
                 params!(Float64) => UnaryFunc::Degrees(func::Degrees), 1608;

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -199,7 +199,7 @@ SELECT date_trunc('days',  INTERVAL '1234 years 11 months 23 days 23:59:12.12345
 ----
 1234 years 11 months 23 days
 
-query error truncate interval by "week" is undefined
+query error unit 'weeks' not recognized
 SELECT date_trunc('weeks',  INTERVAL '1234 years 11 months 23 days 23:59:12.123456789') AS t;
 
 query T
@@ -221,8 +221,6 @@ query T
 SELECT date_trunc('millennium',  INTERVAL '1234 years 11 months 23 days 23:59:12.123456789') AS t;
 ----
 1000 years
-
-
 
 mode standard
 

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -163,6 +163,67 @@ INSERT INTO date_trunc_fields VALUES ('bad')
 query error unit 'bad' not recognized
 SELECT date_trunc(field, TIMESTAMP '2019-11-26 15:56:46.241150') FROM date_trunc_fields
 
+# date_trunc with interval
+query T
+SELECT date_trunc('microseconds',  INTERVAL '1234 years 11 months 23 days 23:59:12.123456789') AS t;
+----
+1234 years 11 months 23 days 23:59:12.123457
+
+query T
+SELECT date_trunc('milliseconds',  INTERVAL '1234 years 11 months 23 days 23:59:12.123456789') AS t;
+----
+1234 years 11 months 23 days 23:59:12.123
+
+query T
+SELECT date_trunc('milliseconds',  INTERVAL '1234 years 11 months 23 days 23:59:12.123456789') AS t;
+----
+1234 years 11 months 23 days 23:59:12.123
+
+query T
+SELECT date_trunc('seconds',  INTERVAL '1234 years 11 months 23 days 23:59:12.123456789') AS t;
+----
+1234 years 11 months 23 days 23:59:12
+
+query T
+SELECT date_trunc('minutes',  INTERVAL '1234 years 11 months 23 days 23:59:12.123456789') AS t;
+----
+1234 years 11 months 23 days 23:59:00
+
+query T
+SELECT date_trunc('hours',  INTERVAL '1234 years 11 months 23 days 23:59:12.123456789') AS t;
+----
+1234 years 11 months 23 days 23:00:00
+
+query T
+SELECT date_trunc('days',  INTERVAL '1234 years 11 months 23 days 23:59:12.123456789') AS t;
+----
+1234 years 11 months 23 days
+
+query error truncate interval by "week" is undefined
+SELECT date_trunc('weeks',  INTERVAL '1234 years 11 months 23 days 23:59:12.123456789') AS t;
+
+query T
+SELECT date_trunc('months',  INTERVAL '1234 years 11 months 23 days 23:59:12.123456789') AS t;
+----
+1234 years 11 months
+
+query T
+SELECT date_trunc('years',  INTERVAL '1234 years 11 months 23 days 23:59:12.123456789') AS t;
+----
+1234 years
+
+query T
+SELECT date_trunc('decade',  INTERVAL '1234 years 11 months 23 days 23:59:12.123456789') AS t;
+----
+1230 years
+
+query T
+SELECT date_trunc('millennium',  INTERVAL '1234 years 11 months 23 days 23:59:12.123456789') AS t;
+----
+1000 years
+
+
+
 mode standard
 
 statement ok


### PR DESCRIPTION
Support intervals in `date_trunc` function.
Fix #9871

### Motivation
* This PR adds a known-desirable feature. #9871 

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - `DATE_TRUNC` also supports `INTERVAL` type
