### PR TITLE
Implement INCLUDE HEADERS for kafka sources

### DIFF
--- a/doc/developer/testdrive.md
+++ b/doc/developer/testdrive.md
@@ -730,6 +730,11 @@ Send the data to the specified partition.
 
 Obtains the data from the specified `sink` and compares it to the expected data recorded in the test. The comparison algorithm is sensitive to the order in which data arrives, so `sort-messages=true` can be used along with manually pre-sorting the expected data in the test. If `partial-search=usize` is specified, up to `partial-search` records will be read from the given topic and compared to the provided records. The recordsdo not have to match starting at the beginning of the sink but once one record matches, the following must all match.  There are permitted to be records remaining in the topic after the matching is complete.  Note that if the topic is not required to have `partial-search` elements in it but there will be an attempt to read up to this number with a blocking read.
 
+#### `headers=<list or object>`
+
+`headers` is a parameter that takes a json map (or list of maps) with string key-value pairs
+sent as headers for every message for the given action.
+
 ## Actions on Kinesis
 
 #### `$ kinesis-create-stream`

--- a/src/dataflow/src/decode/mod.rs
+++ b/src/dataflow/src/decode/mod.rs
@@ -654,11 +654,15 @@ fn to_metadata_row(
                             // upheld
                             if let Some(headers) = headers {
                                 for (k, v) in headers {
-                                    if let MessagePayload::Data(v) = v {
-                                        r.push_list_with(|record_row| {
+                                    match v {
+                                        MessagePayload::Data(v) => r.push_list_with(|record_row| {
                                             record_row.push(Datum::String(&k));
                                             record_row.push(Datum::Bytes(&v));
-                                        })
+                                        }),
+                                        MessagePayload::EOF => r.push_list_with(|record_row| {
+                                            record_row.push(Datum::String(&k));
+                                            record_row.push(Datum::Null);
+                                        }),
                                     }
                                 }
                             }

--- a/src/dataflow/src/decode/mod.rs
+++ b/src/dataflow/src/decode/mod.rs
@@ -619,7 +619,7 @@ fn to_metadata_row(
     partition: PartitionId,
     position: i64,
     upstream_time_millis: Option<i64>,
-    headers: Option<&[(String, MessagePayload)]>,
+    headers: Option<&[(String, Option<Vec<u8>>)]>,
 ) -> Row {
     let mut row = Row::default();
     let mut packer = row.packer();
@@ -655,11 +655,11 @@ fn to_metadata_row(
                             if let Some(headers) = headers {
                                 for (k, v) in headers {
                                     match v {
-                                        MessagePayload::Data(v) => r.push_list_with(|record_row| {
+                                        Some(v) => r.push_list_with(|record_row| {
                                             record_row.push(Datum::String(&k));
                                             record_row.push(Datum::Bytes(&v));
                                         }),
-                                        MessagePayload::EOF => r.push_list_with(|record_row| {
+                                        None => r.push_list_with(|record_row| {
                                             record_row.push(Datum::String(&k));
                                             record_row.push(Datum::Null);
                                         }),

--- a/src/dataflow/src/source/file.rs
+++ b/src/dataflow/src/source/file.rs
@@ -177,6 +177,7 @@ impl SourceReader for FileSourceReader {
                     upstream_time_millis: None,
                     key: (),
                     value: record,
+                    headers: None,
                 };
                 Ok(NextMessage::Ready(message))
             }

--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -623,7 +623,11 @@ fn construct_headers(
             let header = headers.get(idx);
 
             let k = header.key.to_string();
-            let v = MessagePayload::Data(header.value.unwrap().to_vec());
+            let v = if let Some(value) = header.value {
+                MessagePayload::Data(value.to_vec())
+            } else {
+                MessagePayload::EOF
+            };
             out.push((k, v));
         }
     }

--- a/src/dataflow/src/source/kinesis.rs
+++ b/src/dataflow/src/source/kinesis.rs
@@ -234,6 +234,7 @@ impl SourceReader for KinesisSourceReader {
                             upstream_time_millis: None,
                             key: None,
                             value: Some(data),
+                            headers: None,
                         };
                         self.buffered_messages.push_back(source_message);
                     }

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -146,7 +146,7 @@ where
     pub partition: PartitionId,
     /// Headers, if the source is configured to pass them along. If it is, but there are none, it
     /// passes `Some([])`
-    pub headers: Option<Vec<(String, MessagePayload)>>,
+    pub headers: Option<Vec<(String, Option<Vec<u8>>)>>,
 }
 
 /// The output of the decoding operator
@@ -191,7 +191,7 @@ where
         position: i64,
         upstream_time_millis: Option<i64>,
         partition: PartitionId,
-        headers: Option<Vec<(String, MessagePayload)>>,
+        headers: Option<Vec<(String, Option<Vec<u8>>)>>,
     ) -> SourceOutput<K, V> {
         SourceOutput {
             key,
@@ -392,7 +392,7 @@ pub struct SourceMessage<Key, Value> {
     pub value: Value,
     /// Headers, if the source is configured to pass them along. If it is, but there are none, it
     /// passes `Some([])`
-    pub headers: Option<Vec<(String, MessagePayload)>>,
+    pub headers: Option<Vec<(String, Option<Vec<u8>>)>>,
 }
 
 impl fmt::Debug for SourceMessage<(), MessagePayload> {

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -144,6 +144,9 @@ where
     pub upstream_time_millis: Option<i64>,
     /// The partition of this message, present iff the partition comes from Kafka
     pub partition: PartitionId,
+    /// Headers, if the source is configured to pass them along. If it is, but there are none, it
+    /// passes `Some([])`
+    pub headers: Option<Vec<(String, MessagePayload)>>,
 }
 
 /// The output of the decoding operator
@@ -188,6 +191,7 @@ where
         position: i64,
         upstream_time_millis: Option<i64>,
         partition: PartitionId,
+        headers: Option<Vec<(String, MessagePayload)>>,
     ) -> SourceOutput<K, V> {
         SourceOutput {
             key,
@@ -195,6 +199,7 @@ where
             position,
             upstream_time_millis,
             partition,
+            headers,
         }
     }
 }
@@ -385,6 +390,9 @@ pub struct SourceMessage<Key, Value> {
     pub key: Key,
     /// The message value
     pub value: Value,
+    /// Headers, if the source is configured to pass them along. If it is, but there are none, it
+    /// passes `Some([])`
+    pub headers: Option<Vec<(String, MessagePayload)>>,
 }
 
 impl fmt::Debug for SourceMessage<(), MessagePayload> {
@@ -1556,6 +1564,7 @@ fn handle_message<S: SourceReader>(
         offset.offset,
         message.upstream_time_millis,
         message.partition,
+        message.headers,
     )));
 
     match metric_updates.entry(partition) {

--- a/src/dataflow/src/source/s3.rs
+++ b/src/dataflow/src/source/s3.rs
@@ -894,6 +894,7 @@ impl SourceReader for S3SourceReader {
                     upstream_time_millis: None,
                     key: (),
                     value: record,
+                    headers: None,
                 }))
             }
             Some(Some(Err(e))) => match e {

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -60,5 +60,16 @@ pub enum MessagePayload {
     /// For example, CSV records are normally terminated by a newline,
     /// but files might not be newline-terminated; thus we need
     /// the decoder to emit a CSV record when the end of a file is seen.
+    ///
+    // Note that the ordering here matters for the PartialOrd impl
     EOF,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    fn test_message_payload_ordering() {
+        assert!(MessagePayload::Data(vec![]) < MessagePayload::EOF);
+    }
 }

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -324,6 +324,7 @@ pub enum SourceIncludeMetadataType {
     Partition,
     Topic,
     Offset,
+    Headers,
 }
 
 impl AstDisplay for SourceIncludeMetadataType {
@@ -334,6 +335,7 @@ impl AstDisplay for SourceIncludeMetadataType {
             SourceIncludeMetadataType::Partition => f.write_str("PARTITION"),
             SourceIncludeMetadataType::Topic => f.write_str("TOPIC"),
             SourceIncludeMetadataType::Offset => f.write_str("OFFSET"),
+            SourceIncludeMetadataType::Headers => f.write_str("HEADERS"),
         }
     }
 }

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2529,13 +2529,14 @@ impl<'a> Parser<'a> {
         if self.parse_keyword(INCLUDE) {
             self.parse_comma_separated(|parser| {
                 let ty = match parser
-                    .expect_one_of_keywords(&[KEY, TIMESTAMP, PARTITION, TOPIC, OFFSET])?
+                    .expect_one_of_keywords(&[KEY, TIMESTAMP, PARTITION, TOPIC, OFFSET, HEADERS])?
                 {
                     KEY => SourceIncludeMetadataType::Key,
                     TIMESTAMP => SourceIncludeMetadataType::Timestamp,
                     PARTITION => SourceIncludeMetadataType::Partition,
                     TOPIC => SourceIncludeMetadataType::Topic,
                     OFFSET => SourceIncludeMetadataType::Offset,
+                    HEADERS => SourceIncludeMetadataType::Headers,
                     _ => unreachable!("only explicitly allowed items can be parsed"),
                 };
                 let alias = parser

--- a/src/testdrive/src/action/kafka/ingest.rs
+++ b/src/testdrive/src/action/kafka/ingest.rs
@@ -18,6 +18,7 @@ use futures::stream::{FuturesUnordered, StreamExt};
 use maplit::hashmap;
 use prost::Message;
 use prost_reflect::{DynamicMessage, FileDescriptor, MessageDescriptor};
+use rdkafka::message::{Header, OwnedHeaders};
 use rdkafka::producer::FutureRecord;
 use serde::de::DeserializeOwned;
 use tokio::fs;
@@ -39,6 +40,7 @@ pub struct IngestAction {
     rows: Vec<String>,
     start_iteration: isize,
     repeat: isize,
+    headers: Vec<(String, String)>,
 }
 
 #[derive(Clone)]
@@ -222,7 +224,39 @@ pub fn build_ingest(mut cmd: BuiltinCommand) -> Result<IngestAction, anyhow::Err
         Some(f) => bail!("unknown key format: {}", f),
         None => None,
     };
+
     let timestamp = cmd.args.opt_parse("timestamp")?;
+
+    use serde_json::Value;
+    let mut headers = Vec::new();
+    if let Some(headers_val) = cmd.args.opt_parse::<serde_json::Value>("headers")? {
+        let headers_maps = match headers_val {
+            Value::Array(values) => {
+                let mut headers_map = Vec::new();
+                for value in values {
+                    if let Value::Object(m) = value {
+                        headers_map.push(m)
+                    } else {
+                        bail!("lalala")
+                    }
+                }
+                headers_map
+            }
+            Value::Object(v) => vec![v],
+            _ => bail!("lalala"),
+        };
+
+        for headers_map in headers_maps {
+            for (k, v) in headers_map.iter() {
+                if let Value::String(val) = v {
+                    headers.push((k.clone(), val.clone()));
+                } else {
+                    bail!("lalala")
+                }
+            }
+        }
+    }
+
     cmd.args.done()?;
 
     if publish
@@ -242,6 +276,7 @@ pub fn build_ingest(mut cmd: BuiltinCommand) -> Result<IngestAction, anyhow::Err
         rows: cmd.input,
         start_iteration,
         repeat,
+        headers,
     })
 }
 
@@ -352,7 +387,9 @@ impl Action for IngestAction {
         let mut futs = FuturesUnordered::new();
 
         for iteration in self.start_iteration..(self.start_iteration + self.repeat) {
-            for row in &self.rows {
+            let iter = &mut self.rows.iter().peekable();
+
+            for row in iter {
                 let row = action::substitute_vars(
                     row,
                     &hashmap! { "kafka-ingest.iteration".into() => iteration.to_string() },
@@ -369,6 +406,7 @@ impl Action for IngestAction {
                     .with_context(|| format!("parsing row: {}", String::from_utf8_lossy(row)))?;
                 let producer = &state.kafka_producer;
                 let timeout = cmp::max(state.default_timeout, Duration::from_secs(1));
+                let headers = self.headers.clone();
                 futs.push(async move {
                     let mut record: FutureRecord<_, _> = FutureRecord::to(topic_name);
 
@@ -383,6 +421,16 @@ impl Action for IngestAction {
                     }
                     if let Some(timestamp) = self.timestamp {
                         record = record.timestamp(timestamp);
+                    }
+                    if !headers.is_empty() {
+                        let mut rd_meta = OwnedHeaders::new();
+                        for (k, v) in &headers {
+                            rd_meta = rd_meta.insert(Header {
+                                key: k,
+                                value: Some(v),
+                            });
+                        }
+                        record = record.headers(rd_meta);
                     }
                     producer.send(record, timeout).await
                 });

--- a/src/testdrive/src/action/kafka/ingest.rs
+++ b/src/testdrive/src/action/kafka/ingest.rs
@@ -40,7 +40,7 @@ pub struct IngestAction {
     rows: Vec<String>,
     start_iteration: isize,
     repeat: isize,
-    headers: Vec<(String, String)>,
+    headers: Vec<(String, Option<String>)>,
 }
 
 #[derive(Clone)]
@@ -249,7 +249,9 @@ pub fn build_ingest(mut cmd: BuiltinCommand) -> Result<IngestAction, anyhow::Err
         for headers_map in headers_maps {
             for (k, v) in headers_map.iter() {
                 if let Value::String(val) = v {
-                    headers.push((k.clone(), val.clone()));
+                    headers.push((k.clone(), Some(val.clone())));
+                } else if let Value::Null = v {
+                    headers.push((k.clone(), None));
                 } else {
                     bail!("lalala")
                 }
@@ -427,7 +429,7 @@ impl Action for IngestAction {
                         for (k, v) in &headers {
                             rd_meta = rd_meta.insert(Header {
                                 key: k,
-                                value: Some(v),
+                                value: v.as_deref(),
                             });
                         }
                         record = record.headers(rd_meta);

--- a/test/testdrive/kafka-headers-errors.td
+++ b/test/testdrive/kafka-headers-errors.td
@@ -1,0 +1,59 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Note these are nonsense schemas, as this error happens before schema verification of any form
+$ set keyschema={}
+
+$ set schema={}
+
+$ kafka-create-topic topic=headers_src
+
+! CREATE MATERIALIZED SOURCE headers_src
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
+  'testdrive-headers_src-${testdrive.seed}'
+  KEY FORMAT AVRO USING SCHEMA '${keyschema}'
+  VALUE FORMAT AVRO USING SCHEMA '${schema}'
+  INCLUDE HEADERS
+  ENVELOPE DEBEZIUM
+exact:INCLUDE HEADERS requires ENVELOPE UPSERT or no ENVELOPE
+
+! CREATE MATERIALIZED SOURCE headers_src
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
+  'testdrive-headers_src-${testdrive.seed}'
+  KEY FORMAT AVRO USING SCHEMA '${keyschema}'
+  VALUE FORMAT AVRO USING SCHEMA '${schema}'
+  INCLUDE HEADERS
+  ENVELOPE DEBEZIUM UPSERT
+exact:INCLUDE HEADERS requires ENVELOPE UPSERT or no ENVELOPE
+
+! CREATE MATERIALIZED SOURCE headers_src
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
+  'testdrive-headers_src-${testdrive.seed}'
+  KEY FORMAT AVRO USING SCHEMA '${keyschema}'
+  VALUE FORMAT AVRO USING SCHEMA '${schema}'
+  INCLUDE HEADERS
+  ENVELOPE MATERIALIZE
+exact:INCLUDE HEADERS requires ENVELOPE UPSERT or no ENVELOPE
+
+! CREATE MATERIALIZED SOURCE headers_src
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
+  'testdrive-headers_src-${testdrive.seed}'
+  KEY FORMAT AVRO USING SCHEMA '${keyschema}'
+  VALUE FORMAT AVRO USING SCHEMA '${schema}'
+  INCLUDE HEADERS
+  ENVELOPE MATERIALIZE
+exact:INCLUDE HEADERS requires ENVELOPE UPSERT or no ENVELOPE
+
+# even the csv header validation doesn't happen before this error
+$ file-append path=static.csv
+
+! CREATE SOURCE headers_src
+  FROM FILE '${testdrive.temp-dir}/static.csv'
+  FORMAT CSV WITH HEADER (city, state, zip)
+  INCLUDE HEADERS
+exact:INCLUDE HEADERS with non-Kafka sources not supported

--- a/test/testdrive/kafka-headers.td
+++ b/test/testdrive/kafka-headers.td
@@ -1,0 +1,167 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set keyschema={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "key", "type": "string"}
+    ]
+  }
+
+$ set schema={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"f1", "type":"string"},
+            {"name":"f2", "type":"long"}
+        ]
+    }
+
+$ kafka-create-topic topic=headers_src
+
+$ kafka-ingest format=avro topic=headers_src key-format=avro key-schema=${keyschema} schema=${schema} headers={"gus": "gusfive", "gus2": "gus3"}
+{"key": "fish"} {"f1": "fishval", "f2": 1000}
+
+$ kafka-ingest format=avro topic=headers_src key-format=avro key-schema=${keyschema} schema=${schema}
+{"key": "fish2"} {"f1": "fishval", "f2": 1000}
+
+
+> CREATE MATERIALIZED SOURCE headers_src
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
+  'testdrive-headers_src-${testdrive.seed}'
+  KEY FORMAT AVRO USING SCHEMA '${keyschema}'
+  VALUE FORMAT AVRO USING SCHEMA '${schema}'
+  INCLUDE HEADERS
+  ENVELOPE UPSERT
+
+# empty case + has headers case
+> SELECT key, f1, f2, list_length(headers) from headers_src
+key     f1       f2     list_length
+-------------------------------------------
+fish    fishval  1000   2
+fish2   fishval  1000   0
+
+# unpacking works
+> SELECT key, f1, f2, headers[1].value as gus from headers_src
+key     f1       f2     gus
+-------------------------------------------
+fish    fishval  1000   gusfive
+fish2   fishval  1000   <null>
+
+# selecting by key works
+> SELECT key, f1, f2, thekey, value FROM (SELECT i.key, i.f1, i.f2, unnest(headers).key as thekey, unnest(headers).value as value from headers_src as I) i WHERE thekey = 'gus'
+key     f1       f2     thekey  value
+-------------------------------------------
+fish    fishval  1000   gus     gusfive
+
+
+# The headers dict is entirely overwritten, even if the value AND the remaining header hasn't changed
+$ kafka-ingest format=avro topic=headers_src key-format=avro key-schema=${keyschema} schema=${schema} headers={"gus":"gusfive"}
+{"key": "fish"} {"f1": "fishval", "f2": 1000}
+
+# empty case + has headers case
+> SELECT key, f1, f2, list_length(headers) from headers_src
+key     f1       f2     list_length
+-------------------------------------------
+fish    fishval  1000   1
+fish2   fishval  1000   0
+
+# Headers with the same key are both preserved
+$ kafka-ingest format=avro topic=headers_src key-format=avro key-schema=${keyschema} schema=${schema} headers=[{"gus": "a"}, {"gus": "b"}]
+{"key": "fish"} {"f1": "fishval", "f2": 1000}
+
+> SELECT key, f1, f2, headers[1].value as gus1, headers[2].value as gus2 from headers_src
+key     f1       f2     gus1     gus2
+-------------------------------------------
+fish    fishval  1000   a        b
+fish2   fishval  1000   <null>   <null>
+
+
+# Works with other includes
+$ kafka-create-topic topic=headers_also
+
+$ kafka-ingest format=avro topic=headers_also key-format=avro key-schema=${keyschema} schema=${schema} headers={"gus":"gusfive"}
+{"key": "fish"} {"f1": "fishval", "f2": 1000}
+
+> CREATE MATERIALIZED SOURCE headers_also
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
+  'testdrive-headers_also-${testdrive.seed}'
+  KEY FORMAT AVRO USING SCHEMA '${keyschema}'
+  VALUE FORMAT AVRO USING SCHEMA '${schema}'
+  INCLUDE HEADERS, PARTITION
+  ENVELOPE UPSERT
+
+> SELECT key, f1, f2, list_length(headers), partition from headers_also
+key     f1       f2     list_length    partition
+-----------------------------------------------
+fish    fishval  1000   1             0
+
+# esoteric ingestions
+$ kafka-ingest format=avro topic=headers_also key-format=avro key-schema=${keyschema} schema=${schema} headers={"gus": "gus=five"}
+{"key": "fish"} {"f1": "fishval", "f2": 1000}
+
+> SELECT key, f1, f2, headers[1].value as gus, partition from headers_also
+key     f1       f2     gus           partition
+-----------------------------------------------
+fish    fishval  1000   gus=five      0
+
+# conflicting naming
+$ set schemaheaders={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"headers", "type":"string"}
+        ]
+    }
+
+$ kafka-create-topic topic=headers_conflict
+
+> CREATE MATERIALIZED SOURCE headers_conflict
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
+  'testdrive-headers_conflict-${testdrive.seed}'
+  KEY FORMAT AVRO USING SCHEMA '${keyschema}'
+  VALUE FORMAT AVRO USING SCHEMA '${schemaheaders}'
+  INCLUDE HEADERS
+  ENVELOPE UPSERT
+
+# conflict!!
+! SELECT headers from headers_conflict
+contains:column reference "headers" is ambiguous
+
+# both columns exist
+> SHOW COLUMNS from headers_conflict
+name       nullable  type
+-------------------------
+headers    false     list
+headers    false     text
+key        false     text
+
+# No meaningful way to get data out in td because its a list
+# TODO(guswynn): actually check against this error message
+# when https://github.com/MaterializeInc/materialize/pull/11003
+# lands
+# ! SELECT * from headers_conflict
+# contains:???
+
+$ kafka-ingest format=avro topic=headers_conflict key-format=avro key-schema=${keyschema} schema=${schemaheaders} headers={"gus": "gusfive"}
+{"key": "fish"} {"headers": "value"}
+
+# using AS to resolve it!
+> CREATE MATERIALIZED SOURCE headers_conflict2
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
+  'testdrive-headers_conflict-${testdrive.seed}'
+  KEY FORMAT AVRO USING SCHEMA '${keyschema}'
+  VALUE FORMAT AVRO USING SCHEMA '${schemaheaders}'
+  INCLUDE HEADERS AS kafka_headers
+  ENVELOPE UPSERT
+
+> SELECT key, headers, kafka_headers[1].value as gus from headers_conflict2
+key     headers  gus
+------------------------
+fish    value    gusfive

--- a/test/testdrive/kafka-headers.td
+++ b/test/testdrive/kafka-headers.td
@@ -41,11 +41,11 @@ $ kafka-ingest format=avro topic=headers_src key-format=avro key-schema=${keysch
   ENVELOPE UPSERT
 
 # empty case + has headers case
-> SELECT key, f1, f2, list_length(headers) from headers_src
-key     f1       f2     list_length
--------------------------------------------
-fish    fishval  1000   2
-fish2   fishval  1000   0
+> SELECT key, f1, f2, list_length(headers), headers::text from headers_src
+key     f1       f2     list_length    headers
+----------------------------------------------
+fish    fishval  1000   2              "{\"(gus,\\\\x67757366697665)\",\"(gus2,\\\\x67757333)\"}"
+fish2   fishval  1000   0              "{}"
 
 # unpacking works
 > SELECT key, f1, f2, headers[1].value as gus from headers_src
@@ -151,12 +151,18 @@ headers    false     list
 headers    false     text
 key        false     text
 
-# No meaningful way to get data out in td because its a list
-# TODO(guswynn): actually check against this error message
-# when https://github.com/MaterializeInc/materialize/pull/11003
-# lands
-# ! SELECT * from headers_conflict
-# contains:???
+$ kafka-ingest format=avro topic=headers_conflict key-format=avro key-schema=${keyschema} schema=${schemaheaders} headers={"gus": "hmm"}
+{"key": "fish"} {"headers": "value"}
+
+> SELECT count(*) from headers_conflict
+count
+-----
+1
+
+# No meaningful way to get data out in td because of the ambiguous name
+# + weird type
+# > SELECT * from headers_conflict
+
 
 $ kafka-ingest format=avro topic=headers_conflict key-format=avro key-schema=${keyschema} schema=${schemaheaders} headers={"gus": "gusfive"}
 {"key": "fish"} {"headers": "value"}

--- a/test/testdrive/kafka-headers.td
+++ b/test/testdrive/kafka-headers.td
@@ -111,6 +111,15 @@ key     f1       f2     gus           partition
 -----------------------------------------------
 fish    fishval  1000   gus=five      0
 
+# null header
+$ kafka-ingest format=avro topic=headers_also key-format=avro key-schema=${keyschema} schema=${schema} headers={"gus": null}
+{"key": "fish"} {"f1": "fishval", "f2": 1000}
+
+> SELECT key, f1, f2, headers[1].value as gus, partition from headers_also
+key     f1       f2     gus           partition
+-----------------------------------------------
+fish    fishval  1000   <null>        0
+
 # conflicting naming
 $ set schemaheaders={
         "type" : "record",


### PR DESCRIPTION
Implements the proposal outlined in https://github.com/MaterializeInc/materialize/pull/10951

As part of implementing this, I learned that _kafka allows multiple headers with the same key_. This PR implements "keep the topologically smaller of the values", but we could change it to support `map[test=>list[bytea]]` or something similar. Discussion can happen on the design document.

This PR implements `headers` as *metadata*, using the framework setup by @quodlibetor. This is 1. to reduce complexity of the implementation and 2. because the semantics of `headers` we want matches the semantics of metadata: We only record header changes if the value decodes properly, and an empty value means we ignore headers (I think, please check my work). We hop onto the existing `to_metadata_row` calls. (Question: do we ever de-duplicated equal values in `UPSERT`? I don't think we do). We also skip doing anything with headers if the source is not configured as such.

Additionally, this pr does the number of `to_vec/to_string/clone`'s necessary to keep the code simpler. Its possible some could be avoided. 

### Motivation

  * This PR adds a known-desirable feature.
https://github.com/MaterializeInc/materialize/issues/8446


### Tips for reviewer
- bottom pr adds `map_length`, which helps with testing later on
- second add header support to `testdrive`
- third is core implementation
- rest are various changes/tests

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

- Adds `INCLUDE HEADERS (as <column name>)` to Kafka sources to populate headers as list of `(k, v)` pairs in a column
- ~Adds a `map_length` function to count the number of entries in a `map`~
- ~Adds an experimental `headerstomap` to transform the headers list/multimap into a "smallest-value-wins" map~
