### PR TITLE
Add release track support to mzcloud cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3975,7 +3975,7 @@ dependencies = [
 [[package]]
 name = "mzcloud"
 version = "1.0.0"
-source = "git+https://github.com/MaterializeInc/cloud-sdks#b7886468ceb9e76d1c4b9e0b1b82a957ddd2b1c8"
+source = "git+https://github.com/MaterializeInc/cloud-sdks#824ee6e294e92a73184eb7eb7d6b072e7352f097"
 dependencies = [
  "reqwest",
  "serde",

--- a/src/mzcloud-cli/src/bin/mzcloud.rs
+++ b/src/mzcloud-cli/src/bin/mzcloud.rs
@@ -34,6 +34,7 @@ use mzcloud::models::deployment_request::DeploymentRequest;
 use mzcloud::models::deployment_size_enum::DeploymentSizeEnum;
 use mzcloud::models::patched_deployment_update_request::PatchedDeploymentUpdateRequest;
 use mzcloud::models::provider_enum::ProviderEnum;
+use mzcloud::models::release_track_enum::ReleaseTrackEnum;
 use mzcloud::models::supported_cloud_region_request::SupportedCloudRegionRequest;
 
 const VERSION: &'static str = env!("CARGO_PKG_VERSION");
@@ -156,6 +157,10 @@ enum DeploymentsCommand {
         #[clap(short = 'v', long)]
         mz_version: Option<String>,
 
+        /// Release track of materialized to deploy. Defaults to stable.
+        #[clap(long, parse(try_from_str = parse_release_track))]
+        release_track: Option<ReleaseTrackEnum>,
+
         /// Enable Tailscale by setting the Tailscale Auth Key.
         #[clap(long)]
         tailscale_auth_key: Option<String>,
@@ -197,6 +202,10 @@ enum DeploymentsCommand {
         /// version.
         #[clap(short = 'v', long)]
         mz_version: Option<String>,
+
+        /// Release track of materialized to deploy. Defaults to the current track.
+        #[clap(long, parse(try_from_str = parse_release_track))]
+        release_track: Option<ReleaseTrackEnum>,
 
         /// If Tailscale is configured, disable it and delete stored keys.
         #[clap(long)]
@@ -274,6 +283,10 @@ fn parse_cloud_region(s: &str) -> Result<SupportedCloudRegionRequest, String> {
             provider: ProviderEnum::AWS,
             region: "eu-west-1".to_owned(),
         }),
+        ("local", "minikube") => Ok(SupportedCloudRegionRequest {
+            provider: ProviderEnum::Local,
+            region: "minikube".to_owned(),
+        }),
         _ => Err("Unsupported cloud provider/region pair.".to_owned()),
     }
 }
@@ -286,6 +299,14 @@ fn parse_size(s: &str) -> Result<DeploymentSizeEnum, String> {
         "L" => Ok(DeploymentSizeEnum::L),
         "XL" => Ok(DeploymentSizeEnum::XL),
         _ => Err("Invalid size.".to_owned()),
+    }
+}
+
+fn parse_release_track(s: &str) -> Result<ReleaseTrackEnum, String> {
+    match s.to_lowercase().as_str() {
+        "stable" => Ok(ReleaseTrackEnum::Stable),
+        "canary" => Ok(ReleaseTrackEnum::Canary),
+        _ => Err("Invalid release track.".to_owned()),
     }
 }
 
@@ -315,6 +336,7 @@ async fn handle_deployment_operations(
             catalog_restore_mode,
             materialized_extra_args,
             mz_version,
+            release_track,
             tailscale_auth_key,
         } => {
             let deployment = deployments_create(
@@ -328,6 +350,7 @@ async fn handle_deployment_operations(
                     catalog_restore_mode,
                     materialized_extra_args,
                     mz_version,
+                    release_track: release_track.map(Box::new),
                     enable_tailscale: Some(tailscale_auth_key.is_some()),
                     tailscale_auth_key,
                 },
@@ -347,6 +370,7 @@ async fn handle_deployment_operations(
             catalog_restore_mode,
             materialized_extra_args,
             mz_version,
+            release_track,
             remove_tailscale,
             tailscale_auth_key,
         } => {
@@ -366,6 +390,7 @@ async fn handle_deployment_operations(
                     catalog_restore_mode,
                     materialized_extra_args,
                     mz_version,
+                    release_track: release_track.map(Box::new),
                     enable_tailscale,
                     tailscale_auth_key,
                 }),


### PR DESCRIPTION
Adds support for the release track deployments API to the mzcloud cli.

Also adds the local:minikube "cloud provider" for easier local testing.

### Motivation

  * This PR adds a known-desirable feature.

https://github.com/MaterializeInc/cloud/issues/2316

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

We are not currently providing release notes for mzcloud cli.
