### PR TITLE
Refactor peeks to have unique identifiers

### DIFF
--- a/doc/user/content/sql/system-catalog.md
+++ b/doc/user/content/sql/system-catalog.md
@@ -381,12 +381,12 @@ Field       | Type       | Meaning
 The `mz_peek_active` source describes all read queries ("peeks") that are
 pending in the dataflow layer.
 
-Field    | Type       | Meaning
----------|------------|--------
-`uuid`   | [`text`]   | The ID of the connection that requested the peek. `uuid` is a misnomer; connection IDs are 32-bit unsigned integers.
-`worker` | [`bigint`] | The ID of the worker thread servicing the peek.
-`id`     | [`text`]   | The ID of the index the peek is targeting.
-`time`   | [`bigint`] | The timestamp the peek has requested.
+Field      | Type       | Meaning
+-----------|------------|--------
+`id`       | [`text`]   | The ID of the peek request.
+`worker`   | [`bigint`] | The ID of the worker thread servicing the peek.
+`index_id` | [`text`]   | The ID of the index the peek is targeting.
+`time`     | [`bigint`] | The timestamp the peek has requested.
 
 ### `mz_peek_durations`
 

--- a/doc/user/content/sql/system-catalog.md
+++ b/doc/user/content/sql/system-catalog.md
@@ -383,7 +383,7 @@ pending in the dataflow layer.
 
 Field      | Type       | Meaning
 -----------|------------|--------
-`id`       | [`text`]   | The ID of the peek request.
+`id`       | [`uuid`]   | The ID of the peek request.
 `worker`   | [`bigint`] | The ID of the worker thread servicing the peek.
 `index_id` | [`text`]   | The ID of the index the peek is targeting.
 `time`     | [`bigint`] | The timestamp the peek has requested.
@@ -679,6 +679,7 @@ Materialize should use the documented [`mz_catalog`](#mz_catalog) API instead.
 [`text`]: /sql/types/text
 [`timestamp`]: /sql/types/timestamp
 [`timestamp with time zone`]: /sql/types/timestamp
+[`uuid`]: /sql/types/uuid
 [gh-issue]: https://github.com/MaterializeInc/materialize/issues/new?labels=C-feature&template=feature.md
 [oid]: /sql/types/oid
 [`text array`]: /sql/types/array

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -863,7 +863,8 @@ impl Coordinator {
         match message {
             DataflowResponse::Compute(ComputeResponse::PeekResponse(uuid, response), instance) => {
                 assert_eq!(instance, DEFAULT_COMPUTE_INSTANCE_ID);
-                // We expect exactly one peek response, which we forward.
+                // We expect exactly one peek response, which we forward. Then we clean up the
+                // peek's state in the coordinator.
                 let (rows_tx, conn_id) = self
                     .pending_peeks
                     .remove(&uuid)
@@ -874,7 +875,7 @@ impl Coordinator {
                 let uuids = self
                     .client_pending_peeks
                     .get_mut(&conn_id)
-                    .expect("TODO think of good message");
+                    .expect(format!("no client state for connection {conn_id}").as_str());
                 uuids.remove(&uuid);
                 if uuids.is_empty() {
                     self.client_pending_peeks.remove(&conn_id);

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -5130,7 +5130,7 @@ pub mod fast_path_peek {
             self.pending_peeks.insert(uuid, (rows_tx, conn_id));
             self.client_pending_peeks
                 .entry(conn_id)
-                .or_insert_with(HashSet::new())
+                .or_insert_with(HashSet::new)
                 .insert(uuid);
             let (id, key, timestamp, _finishing, map_filter_project) = peek_command;
             self.dataflow_client

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -5130,7 +5130,7 @@ pub mod fast_path_peek {
             self.pending_peeks.insert(uuid, (rows_tx, conn_id));
             self.client_pending_peeks
                 .entry(conn_id)
-                .or_insert(HashSet::new())
+                .or_insert_with(HashSet::new())
                 .insert(uuid);
             let (id, key, timestamp, _finishing, map_filter_project) = peek_command;
             self.dataflow_client

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -84,7 +84,7 @@
 //!
 
 use std::cell::RefCell;
-use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use std::future::Future;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -337,7 +337,7 @@ pub struct Coordinator {
     /// the connection id of the client that initiated the peek.
     pending_peeks: HashMap<Uuid, PendingPeek>,
     /// A map from client connection ids to a set of all pending peeks for that client
-    client_pending_peeks: HashMap<u32, HashSet<Uuid>>,
+    client_pending_peeks: HashMap<u32, BTreeSet<Uuid>>,
     /// A map from pending tails to the tail description.
     pending_tails: HashMap<GlobalId, PendingTail>,
 
@@ -4920,7 +4920,7 @@ pub mod fast_path_peek {
 
     use mz_dataflow_types::client::DEFAULT_COMPUTE_INSTANCE_ID;
     use mz_dataflow_types::PeekResponseUnary;
-    use std::collections::HashSet;
+    use std::collections::BTreeSet;
     use std::{collections::HashMap, num::NonZeroUsize};
     use uuid::Uuid;
 
@@ -5146,7 +5146,7 @@ pub mod fast_path_peek {
             );
             self.client_pending_peeks
                 .entry(conn_id)
-                .or_insert_with(HashSet::new)
+                .or_insert_with(BTreeSet::new)
                 .insert(uuid);
             let (id, key, timestamp, _finishing, map_filter_project) = peek_command;
             self.dataflow_client

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -875,7 +875,7 @@ impl Coordinator {
                 let uuids = self
                     .client_pending_peeks
                     .get_mut(&conn_id)
-                    .expect(format!("no client state for connection {conn_id}").as_str());
+                    .unwrap_or_else(|| panic!("no client state for connection {conn_id}"));
                 uuids.remove(&uuid);
                 if uuids.is_empty() {
                     self.client_pending_peeks.remove(&conn_id);

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -5119,8 +5119,8 @@ pub mod fast_path_peek {
             // Endpoints for sending and receiving peek responses.
             let (rows_tx, rows_rx) = tokio::sync::mpsc::unbounded_channel();
 
-            // Generate unique UUID. Guaranteed to be unique to all pending peeks, there's a very
-            // small but unlikely change that it's not unique to completed peeks.
+            // Generate unique UUID. Guaranteed to be unique to all pending peeks, there's an very
+            // small but unlikely chance that it's not unique to completed peeks.
             let mut uuid = Uuid::new_v4();
             while self.pending_peeks.contains_key(&uuid) {
                 uuid = Uuid::new_v4();

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -17,7 +17,7 @@ use async_trait::async_trait;
 use enum_iterator::IntoEnumIterator;
 use enum_kinds::EnumKind;
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 use timely::progress::frontier::Antichain;
 use timely::progress::ChangeBatch;
 use tracing::trace;
@@ -108,8 +108,8 @@ pub enum ComputeCommand<T = mz_repr::Timestamp> {
     },
     /// Cancel the peeks associated with the given `uuids`.
     CancelPeeks {
-        /// The identifier of the peek request to cancel.
-        uuids: HashSet<Uuid>,
+        /// The identifiers of the peek requests to cancel.
+        uuids: BTreeSet<Uuid>,
     },
 }
 

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -97,7 +97,7 @@ pub enum ComputeCommand<T = mz_repr::Timestamp> {
         key: Option<Row>,
         /// The identifier of this peek request.
         ///
-        /// Used in responses and cancelation requests.
+        /// Used in responses and cancellation requests.
         uuid: Uuid,
         /// The logical timestamp at which the arrangement is queried.
         timestamp: T,

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -17,7 +17,7 @@ use async_trait::async_trait;
 use enum_iterator::IntoEnumIterator;
 use enum_kinds::EnumKind;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use timely::progress::frontier::Antichain;
 use timely::progress::ChangeBatch;
 use tracing::trace;
@@ -98,7 +98,7 @@ pub enum ComputeCommand<T = mz_repr::Timestamp> {
         /// The identifier of this peek request.
         ///
         /// Used in responses and cancelation requests.
-        conn_id: u32,
+        uuid: Uuid,
         /// The logical timestamp at which the arrangement is queried.
         timestamp: T,
         /// Actions to apply to the result set before returning them.
@@ -106,10 +106,10 @@ pub enum ComputeCommand<T = mz_repr::Timestamp> {
         /// Linear operation to apply in-line on each result.
         map_filter_project: mz_expr::SafeMfpPlan,
     },
-    /// Cancel the peek associated with the given `conn_id`.
-    CancelPeek {
+    /// Cancel the peeks associated with the given `uuids`.
+    CancelPeeks {
         /// The identifier of the peek request to cancel.
-        conn_id: u32,
+        uuids: HashSet<Uuid>,
     },
 }
 
@@ -123,7 +123,7 @@ impl ComputeCommandKind {
             ComputeCommandKind::CreateInstance => "create_instance",
             ComputeCommandKind::DropInstance => "drop_instance",
             ComputeCommandKind::AllowCompaction => "allow_compute_compaction",
-            ComputeCommandKind::CancelPeek => "cancel_peek",
+            ComputeCommandKind::CancelPeeks => "cancel_peeks",
             ComputeCommandKind::CreateDataflows => "create_dataflows",
             ComputeCommandKind::Peek => "peek",
         }
@@ -353,7 +353,7 @@ pub enum ComputeResponse<T = mz_repr::Timestamp> {
     /// A list of identifiers of traces, with prior and new upper frontiers.
     FrontierUppers(Vec<(GlobalId, ChangeBatch<T>)>),
     /// The worker's response to a specified (by connection id) peek.
-    PeekResponse(u32, PeekResponse),
+    PeekResponse(Uuid, PeekResponse),
     /// The worker's next response to a specified tail.
     TailResponse(GlobalId, TailResponse<T>),
 }
@@ -398,6 +398,8 @@ pub struct ClientAsStream<'a, C: Client + 'a> {
 
 use std::pin::Pin;
 use std::task::{Context, Poll};
+use uuid::Uuid;
+
 impl<'a, C: Client + 'a> futures::stream::Stream for ClientAsStream<'a, C> {
     type Item = Response;
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
@@ -561,6 +563,7 @@ pub mod partitioned {
     }
 
     use timely::progress::frontier::MutableAntichain;
+    use uuid::Uuid;
 
     /// Buffer for partial results for a `TAIL`.
     /// This exists so we can consolidate rows and
@@ -660,7 +663,7 @@ pub mod partitioned {
         /// The `Option<ComputeInstanceId>` uses `None` to represent Storage.
         uppers: HashMap<(GlobalId, Option<ComputeInstanceId>), MutableAntichain<T>>,
         /// Pending responses for a peek; returnable once all are available.
-        peek_responses: HashMap<u32, HashMap<usize, PeekResponse>>,
+        peek_responses: HashMap<Uuid, HashMap<usize, PeekResponse>>,
         /// Number of parts the state machine represents.
         parts: usize,
         /// Tracks in-progress `TAIL`s, and the stashed rows we are holding
@@ -786,14 +789,11 @@ pub mod partitioned {
                         .into_iter(),
                     )
                 }
-                Response::Compute(
-                    ComputeResponse::PeekResponse(connection, response),
-                    instance,
-                ) => {
+                Response::Compute(ComputeResponse::PeekResponse(uuid, response), instance) => {
                     // Incorporate new peek responses; awaiting all responses.
                     let entry = self
                         .peek_responses
-                        .entry(connection)
+                        .entry(uuid)
                         .or_insert_with(Default::default);
                     let novel = entry.insert(shard_id, response);
                     assert!(novel.is_none(), "Duplicate peek response");
@@ -812,10 +812,10 @@ pub mod partitioned {
                                 }
                             };
                         }
-                        self.peek_responses.remove(&connection);
+                        self.peek_responses.remove(&uuid);
                         Box::new(
                             Some(Response::Compute(
-                                ComputeResponse::PeekResponse(connection, response),
+                                ComputeResponse::PeekResponse(uuid, response),
                                 instance,
                             ))
                             .into_iter(),

--- a/src/dataflow-types/src/client/controller/compute.rs
+++ b/src/dataflow-types/src/client/controller/compute.rs
@@ -22,7 +22,7 @@
 //! compaction of each of its outputs, ensuring that we can recover each dataflow to its current state in case of
 //! failure or other reconfiguration.
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 
 use differential_dataflow::lattice::Lattice;
 use timely::progress::frontier::MutableAntichain;
@@ -294,7 +294,7 @@ impl<'a, C: Client<T>, T: Timestamp + Lattice> ComputeController<'a, C, T> {
             .map_err(ComputeError::from)
     }
     /// Cancels existing peek requests.
-    pub async fn cancel_peeks(&mut self, uuids: &HashSet<Uuid>) -> Result<(), ComputeError> {
+    pub async fn cancel_peeks(&mut self, uuids: &BTreeSet<Uuid>) -> Result<(), ComputeError> {
         let uuids = uuids.clone();
         self.client
             .send(Command::Compute(

--- a/src/dataflow-types/src/logging.rs
+++ b/src/dataflow-types/src/logging.rs
@@ -191,9 +191,9 @@ impl LogVariant {
             }
 
             LogVariant::Materialized(MaterializedLog::PeekCurrent) => RelationDesc::empty()
-                .with_column("uuid", ScalarType::String.nullable(false))
-                .with_column("worker", ScalarType::Int64.nullable(false))
                 .with_column("id", ScalarType::String.nullable(false))
+                .with_column("worker", ScalarType::Int64.nullable(false))
+                .with_column("index_id", ScalarType::String.nullable(false))
                 .with_column("time", ScalarType::Int64.nullable(false))
                 .with_key(vec![0, 1]),
 

--- a/src/dataflow-types/src/logging.rs
+++ b/src/dataflow-types/src/logging.rs
@@ -191,7 +191,7 @@ impl LogVariant {
             }
 
             LogVariant::Materialized(MaterializedLog::PeekCurrent) => RelationDesc::empty()
-                .with_column("id", ScalarType::String.nullable(false))
+                .with_column("id", ScalarType::Uuid.nullable(false))
                 .with_column("worker", ScalarType::Int64.nullable(false))
                 .with_column("index_id", ScalarType::String.nullable(false))
                 .with_column("time", ScalarType::Int64.nullable(false))

--- a/src/dataflow/src/logging/materialized.rs
+++ b/src/dataflow/src/logging/materialized.rs
@@ -21,6 +21,7 @@ use timely::dataflow::operators::capture::EventLink;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use timely::logging::WorkerIdentifier;
 use tracing::error;
+use uuid::Uuid;
 
 use super::{LogVariant, MaterializedLog};
 use crate::activator::RcActivator;
@@ -83,14 +84,15 @@ pub struct Peek {
     id: GlobalId,
     /// The logical timestamp requested.
     time: Timestamp,
-    /// The connection ID of the peek.
-    conn_id: u32,
+    /// The ID of the peek.
+    uuid: Uuid,
+    // TODO might be nice for logging purposes to have the connection id here too
 }
 
 impl Peek {
     /// Create a new peek from its arguments.
-    pub fn new(id: GlobalId, time: Timestamp, conn_id: u32) -> Self {
-        Self { id, time, conn_id }
+    pub fn new(id: GlobalId, time: Timestamp, uuid: Uuid) -> Self {
+        Self { id, time, uuid }
     }
 }
 
@@ -240,13 +242,13 @@ pub fn construct<A: Allocate>(
                                 }
                             }
                             MaterializedEvent::Peek(peek, is_install) => {
-                                let key = (worker, peek.conn_id);
+                                let key = (worker, peek.uuid);
                                 if is_install {
                                     peek_session.give(((peek, worker), time_ms, 1));
                                     if peek_stash.contains_key(&key) {
                                         error!(
                                             "peek already registered: \
-                                             worker={}, connection_id: {}",
+                                             worker={}, uuid: {}",
                                             worker, key.1,
                                         );
                                     }
@@ -263,7 +265,7 @@ pub fn construct<A: Allocate>(
                                     } else {
                                         error!(
                                             "peek not yet registered: \
-                                             worker={}, connection_id: {}",
+                                             worker={}, uuid: {}",
                                             worker, key.1,
                                         );
                                     }
@@ -323,7 +325,7 @@ pub fn construct<A: Allocate>(
         let peek_current = peek.as_collection().map({
             move |(peek, worker)| {
                 Row::pack_slice(&[
-                    Datum::String(&format!("{}", peek.conn_id)),
+                    Datum::String(&format!("{}", peek.uuid)),
                     Datum::Int64(worker as i64),
                     Datum::String(&peek.id.to_string()),
                     Datum::Int64(peek.time as i64),

--- a/src/dataflow/src/logging/materialized.rs
+++ b/src/dataflow/src/logging/materialized.rs
@@ -86,7 +86,6 @@ pub struct Peek {
     time: Timestamp,
     /// The ID of the peek.
     uuid: Uuid,
-    // TODO might be nice for logging purposes to have the connection id here too
 }
 
 impl Peek {

--- a/src/dataflow/src/logging/materialized.rs
+++ b/src/dataflow/src/logging/materialized.rs
@@ -324,7 +324,7 @@ pub fn construct<A: Allocate>(
         let peek_current = peek.as_collection().map({
             move |(peek, worker)| {
                 Row::pack_slice(&[
-                    Datum::String(&format!("{}", peek.uuid)),
+                    Datum::Uuid(peek.uuid),
                     Datum::Int64(worker as i64),
                     Datum::String(&peek.id.to_string()),
                     Datum::Int64(peek.time as i64),

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -28,6 +28,7 @@ use timely::order::PartialOrder;
 use timely::progress::frontier::Antichain;
 use timely::worker::Worker as TimelyWorker;
 use tokio::sync::mpsc;
+use uuid::Uuid;
 
 use mz_dataflow_types::client::ComputeInstanceId;
 use mz_dataflow_types::client::{Command, ComputeCommand, LocalClient, Response};
@@ -374,8 +375,8 @@ pub(crate) struct PendingPeek {
     id: GlobalId,
     /// An optional key to use for the arrangement.
     key: Option<Row>,
-    /// The ID of the connection that submitted the peek. For logging only.
-    conn_id: u32,
+    /// The ID of the peek.
+    uuid: Uuid,
     /// Time at which the collection should be materialized.
     timestamp: Timestamp,
     /// Finishing operations to perform on the peek, like an ordering and a
@@ -390,7 +391,7 @@ pub(crate) struct PendingPeek {
 impl PendingPeek {
     /// Produces a corresponding log event.
     pub fn as_log_event(&self) -> crate::logging::materialized::Peek {
-        crate::logging::materialized::Peek::new(self.id, self.timestamp, self.conn_id)
+        crate::logging::materialized::Peek::new(self.id, self.timestamp, self.uuid)
     }
 
     /// Attempts to fulfill the peek and reports success.

--- a/src/dataflow/src/server/compute_state.rs
+++ b/src/dataflow/src/server/compute_state.rs
@@ -155,7 +155,7 @@ impl<'a, A: Allocate, B: ComputeReplay> ActiveComputeState<'a, A, B> {
                 id,
                 key,
                 timestamp,
-                conn_id,
+                uuid,
                 finishing,
                 map_filter_project,
             } => {
@@ -179,7 +179,7 @@ impl<'a, A: Allocate, B: ComputeReplay> ActiveComputeState<'a, A, B> {
                 let mut peek = PendingPeek {
                     id,
                     key,
-                    conn_id,
+                    uuid,
                     timestamp,
                     finishing,
                     trace_bundle,
@@ -196,14 +196,14 @@ impl<'a, A: Allocate, B: ComputeReplay> ActiveComputeState<'a, A, B> {
                     self.compute_state.pending_peeks.push(peek);
                 }
             }
-            ComputeCommand::CancelPeek { conn_id } => {
+            ComputeCommand::CancelPeeks { uuids } => {
                 let pending_peeks_len = self.compute_state.pending_peeks.len();
                 let mut pending_peeks = std::mem::replace(
                     &mut self.compute_state.pending_peeks,
                     Vec::with_capacity(pending_peeks_len),
                 );
                 for peek in pending_peeks.drain(..) {
-                    if peek.conn_id == conn_id {
+                    if uuids.contains(&peek.uuid) {
                         self.send_peek_response(peek, PeekResponse::Canceled);
                     } else {
                         self.compute_state.pending_peeks.push(peek);
@@ -570,7 +570,7 @@ impl<'a, A: Allocate, B: ComputeReplay> ActiveComputeState<'a, A, B> {
     /// meant to prevent multiple responses to the same peek.
     fn send_peek_response(&mut self, peek: PendingPeek, response: PeekResponse) {
         // Respond with the response.
-        self.send_compute_response(ComputeResponse::PeekResponse(peek.conn_id, response));
+        self.send_compute_response(ComputeResponse::PeekResponse(peek.uuid, response));
 
         // Log responding to the peek request.
         if let Some(logger) = self.compute_state.materialized_logger.as_mut() {


### PR DESCRIPTION
Previously peeks were identified by the connection id of the connection
that initiated the peek. This can be a problem for multiple reasons:
    * Connection ids are re-used which can lead to subtle race
    conditions.
    * If a connection ever has multiple in-flight peeks, it's
    impossible to disambiguate the peeks.

This commit refactors peeks so that they are uniquely identified by a
UUID instead of the connection ID.

Fixes #9521

### Motivation
This PR refactors existing code.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - No user facing behavior
