### PR TITLE
feature-benchmar: Fortify FastPathFilterIndex

### DIFF
--- a/test/feature-benchmark/scenarios.py
+++ b/test/feature-benchmark/scenarios.py
@@ -72,7 +72,7 @@ true
 
     def benchmark(self) -> MeasurementSource:
         hundred_selects = "\n".join(
-            f"> SELECT * FROM v1 WHERE f1 = 1;\n1\n" for i in range(0, 100)
+            f"> SELECT * FROM v1 WHERE f1 = 1;\n1\n" for i in range(0, 1000)
         )
 
         return Td(


### PR DESCRIPTION
The individual queries in the FastPathFilterIndex scenario execute
very quickly, so even if batching them up in groups of 100 there is
enough residual variability to cause sporadic false positives.

Increase the batch size to 1000 in order to get more stable measurements.

### Motivation


  * This PR fixes a previously unreported bug.

Sporadic failure in Nightly CI: https://buildkite.com/materialize/nightlies/builds/706#4f662fc9-b8ac-4853-8f5b-e5ee26e7060c