### PR TITLE
materialized: present entire TLS certificate chain when possible

### DIFF
--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -206,7 +206,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
                     builder.set_ca_file(ca)?;
                     builder.set_verify(SslVerifyMode::PEER | SslVerifyMode::FAIL_IF_NO_PEER_CERT);
                 }
-                builder.set_certificate_file(&tls_config.cert, SslFiletype::PEM)?;
+                builder.set_certificate_chain_file(&tls_config.cert)?;
                 builder.set_private_key_file(&tls_config.key, SslFiletype::PEM)?;
                 builder.build().into_context()
             };


### PR DESCRIPTION
When given a TLS certificate file that contains multiple certificates
(i.e., an intermediate certificate chain), slurp them all up so that the
entire chain can be presented to clients who connect to the server.

We noticed this because `psql` was unable to connect to Materialize
Cloud deployments whose server certificates were provided by Let's
Encrypt. Let's Encrypt certificates are signed by an intermediary "R3",
whose certificates are not present in the default CA bundle. The
intermediary's certificate *is* present in the certificate returned by
Let's Encrypt, however, so we just need to teach `materialized` to
forward it along to clients.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - When the certificate provided in the `--tls-cert` option contains a certificate chain, load the entire chain so that it can be presented to clients during TLS negotiation. Previously, only the first certificate in the chain was loaded.
