### PR TITLE
mzcompose: teach list-compositions to output descriptions

### DIFF
--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -264,12 +264,19 @@ class LintCommand(Command):
 
 class ListCompositionsCommand(Command):
     name = "list-compositions"
-    help = "list the directories that contain compositions"
+    help = "list the directories that contain compositions and their summaries"
 
     def run(cls, args: argparse.Namespace) -> None:
         repo = mzbuild.Repository.from_arguments(ROOT, args)
-        for name in sorted(repo.compositions):
-            print(name)
+        for name, path in sorted(repo.compositions.items(), key=lambda item: item[1]):
+            print(os.path.relpath(path, repo.root))
+            composition = mzcompose.Composition(repo, name, munge_services=False)
+            if composition.description:
+                # Emit the first paragraph of the description.
+                for line in composition.description.split("\n"):
+                    if line.strip() == "":
+                        break
+                    print(f"  {line}")
 
 
 class ListWorkflowsCommand(Command):

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -724,9 +724,19 @@ class Repository:
         self.images: Dict[str, Image] = {}
         self.compositions: Dict[str, Path] = {}
         for (path, dirs, files) in os.walk(self.root, topdown=True):
+            if path == str(root / "misc"):
+                dirs.remove("python")
             # Filter out some particularly massive ignored directories to keep
             # things snappy. Not required for correctness.
-            dirs[:] = set(dirs) - {".git", "target", "mzdata", "node_modules"}
+            dirs[:] = set(dirs) - {
+                ".git",
+                "target",
+                "target-ra",
+                "target-xcompile",
+                "mzdata",
+                "node_modules",
+                "venv",
+            }
             if "mzbuild.yml" in files:
                 image = Image(self.rd, Path(path))
                 if not image.name:

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -189,8 +189,10 @@ class Composition:
         name: str,
         preserve_ports: bool = False,
         silent: bool = False,
+        munge_services: bool = True,
     ):
         self.name = name
+        self.description = None
         self.repo = repo
         self.preserve_ports = preserve_ports
         self.silent = silent
@@ -226,6 +228,7 @@ class Composition:
             module = importlib.util.module_from_spec(spec)
             assert isinstance(spec.loader, importlib.abc.Loader)
             spec.loader.exec_module(module)
+            self.description = inspect.getdoc(module)
             for name, fn in getmembers(module, isfunction):
                 if name.startswith("workflow_"):
                     # The name of the workflow is the name of the function
@@ -250,7 +253,8 @@ class Composition:
         )
 
         # The CLI driver will handle acquiring these dependencies.
-        self.dependencies = self._munge_services(compose["services"].items())
+        if munge_services:
+            self.dependencies = self._munge_services(compose["services"].items())
 
         # Emit the munged configuration to a temporary file so that we can later
         # pass it to Docker Compose.

--- a/test/aws-config/mzcompose.py
+++ b/test/aws-config/mzcompose.py
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""Test loading AWS credentials from various credential sources."""
+
 import json
 import random
 import time

--- a/test/proxy/mzcompose.py
+++ b/test/proxy/mzcompose.py
@@ -7,6 +7,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""Various tests that mediate Materialize's connections to sources and sinks
+via a Squid proxy."""
+
 from dataclasses import dataclass
 from typing import Dict, List
 

--- a/test/upgrade/mzcompose.py
+++ b/test/upgrade/mzcompose.py
@@ -7,6 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""Verifies that objects created in previous versions of Materialize are still
+operational after an upgrade.
+"""
+
 import random
 from typing import List, Tuple
 


### PR DESCRIPTION
The description of each composition is sourced from the module
docstring. I've added a few examples, but filling in the rest is left to
future work.

Fix https://github.com/MaterializeInc/materialize/issues/11030.

### Motivation

  * This PR adds a known-desirable feature.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
