### PR TITLE
coord: allow SELECTing from unmaterialized sources

### DIFF
--- a/src/coord/src/error.rs
+++ b/src/coord/src/error.rs
@@ -27,12 +27,6 @@ use crate::session::Var;
 /// Errors that can occur in the coordinator.
 #[derive(Debug)]
 pub enum CoordError {
-    /// Query needs AS OF <time> or indexes to succeed.
-    // Embeded object is meant to be of structure Vec<(Objectname, Vec<Index names w/ enabled stats>)>.
-    AutomaticTimestampFailure {
-        unmaterialized: Vec<String>,
-        disabled_indexes: Vec<(String, Vec<String>)>,
-    },
     /// An error occurred in a catalog operation.
     Catalog(catalog::Error),
     /// The cached plan or descriptor changed.
@@ -126,41 +120,6 @@ impl CoordError {
     /// Reports additional details about the error, if any are available.
     pub fn detail(&self) -> Option<String> {
         match self {
-            CoordError::AutomaticTimestampFailure {
-                unmaterialized,
-                disabled_indexes,
-            } => {
-                let unmaterialized_err = if unmaterialized.is_empty() {
-                    "".into()
-                } else {
-                    format!(
-                        "\nUnmaterialized sources:\n\t{}",
-                        itertools::join(unmaterialized, "\n\t")
-                    )
-                };
-
-                let disabled_indexes_err = if disabled_indexes.is_empty() {
-                    "".into()
-                } else {
-                    let d = disabled_indexes.iter().fold(
-                        String::default(),
-                        |acc, (object_name, disabled_indexes)| {
-                            format!(
-                                "{}\n\n\t{}\n\tDisabled indexes:\n\t\t{}",
-                                acc,
-                                object_name,
-                                itertools::join(disabled_indexes, "\n\t\t")
-                            )
-                        },
-                    );
-                    format!("\nSources w/ disabled indexes:{}", d)
-                };
-
-                Some(format!(
-                    "The query transitively depends on the following:{}{}",
-                    unmaterialized_err, disabled_indexes_err
-                ))
-            }
             CoordError::Catalog(c) => c.detail(),
             CoordError::Eval(e) => e.detail(),
             CoordError::RelationOutsideTimeDomain { relations, names } => Some(format!(
@@ -208,33 +167,6 @@ impl CoordError {
     /// Reports a hint for the user about how the error could be fixed.
     pub fn hint(&self) -> Option<String> {
         match self {
-            CoordError::AutomaticTimestampFailure {
-                unmaterialized,
-                disabled_indexes,
-            } => {
-                let unmaterialized_hint = if unmaterialized.is_empty() {
-                    ""
-                } else {
-                    "\n- Use `SELECT ... AS OF` to manually choose a timestamp for your query.
-- Create indexes on the listed unmaterialized sources or on the views derived from those sources"
-                };
-                let disabled_indexes_hint = if disabled_indexes.is_empty() {
-                    ""
-                } else {
-                    "ALTER INDEX ... SET ENABLED to enable indexes"
-                };
-
-                Some(format!(
-                    "{}{}{}",
-                    unmaterialized_hint,
-                    if !unmaterialized_hint.is_empty() {
-                        "\n-"
-                    } else {
-                        ""
-                    },
-                    disabled_indexes_hint
-                ))
-            }
             CoordError::Catalog(c) => c.hint(),
             CoordError::ConstrainedParameter {
                 valid_values: Some(valid_values),
@@ -281,9 +213,6 @@ impl CoordError {
 impl fmt::Display for CoordError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            CoordError::AutomaticTimestampFailure { .. } => {
-                f.write_str("unable to automatically determine a query timestamp")
-            }
             CoordError::ChangedPlan => f.write_str("cached plan must not change result type"),
             CoordError::Catalog(e) => e.fmt(f),
             CoordError::ConstrainedParameter {

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -367,7 +367,6 @@ impl ErrorResponse {
             CoordError::Catalog(_) => SqlState::INTERNAL_ERROR,
             CoordError::ChangedPlan => SqlState::FEATURE_NOT_SUPPORTED,
             CoordError::ConstrainedParameter { .. } => SqlState::INVALID_PARAMETER_VALUE,
-            CoordError::AutomaticTimestampFailure { .. } => SqlState::INTERNAL_ERROR,
             CoordError::DuplicateCursor(_) => SqlState::DUPLICATE_CURSOR,
             CoordError::Eval(EvalError::CharacterNotValidForEncoding(_)) => {
                 SqlState::PROGRAM_LIMIT_EXCEEDED

--- a/test/restart/user-indexes-disabled.td
+++ b/test/restart/user-indexes-disabled.td
@@ -45,8 +45,9 @@ logging_derived_mat logging_derived_mat_primary_idx 1             count       <n
 # mat_view is not considered materialized
 > SHOW MATERIALIZED VIEWS
 
-! SELECT * FROM mat_view
-contains:unable to automatically determine a query timestamp
+# But it is still selectable.
+> SELECT * FROM mat_view
+1
 
 > SHOW INDEXES FROM mat_view;
 on_name   key_name              seq_in_index  column_name  expression  nullable enabled
@@ -70,8 +71,9 @@ contains:invalid ALTER on disabled index "materialize.public.mat_view_primary_id
 # mat_data is not considered materialized
 > SHOW MATERIALIZED SOURCES
 
-! SELECT * FROM mat_data
-contains:unable to automatically determine a query timestamp
+# But it is still selectable.
+> SELECT * FROM mat_data
+1
 
 > SHOW INDEXES FROM mat_data;
 on_name   key_name              seq_in_index  column_name  expression  nullable enabled
@@ -88,8 +90,8 @@ mat_data  mat_data_primary_idx  1             a            <null>      false    
 
 # 🔬🔬🔬🔬 Non-materialized views
 
-! SELECT * FROM join_view
-contains:unable to automatically determine a query timestamp
+> SELECT * FROM join_view
+1 a
 
 # 🔬🔬 Sinks
 
@@ -190,10 +192,10 @@ mat_data
 
 # 🔬🔬🔬 Non-materialized views
 
-# Still cannot select from non-materialized view because some of its indexes are disabled
+# Can seleect from `join_view` both with and without indexes enabled.
 
-! SELECT * FROM join_view
-contains:unable to automatically determine a query timestamp
+> SELECT * FROM join_view
+1 a
 
 > ALTER INDEX join_data_primary_idx SET ENABLED
 

--- a/test/testdrive/joins.td
+++ b/test/testdrive/joins.td
@@ -234,8 +234,20 @@ names_num names_name mods_num mods_mod
 > CREATE VIEW test15 (names_num, names_name, mods_num, mods_mod) AS
   SELECT * FROM names FULL OUTER JOIN mods_unmat ON 1 = 0;
 
-! SELECT * FROM test15;
-contains:unable to automatically determine a query timestamp
+> SELECT * FROM test15;
+names_num names_name mods_num mods_mod
+--------------------------------------
+1 one <null> <null>
+2 two <null> <null>
+3 three <null> <null>
+<null> <null> 0 even
+<null> <null> 1 odd
+<null> <null> 2 even
 
-! SELECT * FROM names FULL OUTER JOIN mods_unmat ON 1 = 0;
-contains:unable to automatically determine a query timestamp
+> SELECT * FROM names FULL OUTER JOIN mods_unmat ON 1 = 0;
+1 one <null> <null>
+2 two <null> <null>
+3 three <null> <null>
+<null> <null> 0 even
+<null> <null> 1 odd
+<null> <null> 2 even

--- a/test/testdrive/materializations.td
+++ b/test/testdrive/materializations.td
@@ -25,13 +25,11 @@ $ kafka-create-topic topic=data
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
 
-! SELECT * FROM data
-contains:unable to automatically determine a query timestamp
+> SELECT * FROM data
 
 > CREATE VIEW data_view as SELECT * from data
 
-! SELECT * FROM data_view
-contains:unable to automatically determine a query timestamp
+> SELECT * FROM data_view
 
 > CREATE MATERIALIZED VIEW test1 AS
   SELECT b, sum(a) FROM data GROUP BY b
@@ -134,9 +132,13 @@ b  max
 ------
 2  1
 
-# Cannot select from unmaterialized view.
-! SELECT * from data_view
-contains:unable to automatically determine a query timestamp
+> SELECT * from data_view
+a  b
+----
+1  1
+2  1
+3  1
+1  2
 
 # Can create sink from unmaterialized view.
 > CREATE SINK not_mat_sink2 FROM data_view
@@ -184,8 +186,12 @@ b  c
 # Unmaterialize test5.
 > DROP INDEX idx1
 
-! SELECT * from test5
-contains:unable to automatically determine a query timestamp
+# Still works.
+> SELECT * from test5
+b  c
+------
+1  3
+2  1
 
 > SHOW FULL VIEWS LIKE 'test5'
 name        type     materialized  volatility
@@ -202,13 +208,21 @@ d
 -1
 3
 
-# Dependencies have not re-materialized as a result of creating a dependent
+# Dependencies are still queryable after creating a dependent
 # materialized view.
-! SELECT * from test5
-contains:unable to automatically determine a query timestamp
+> SELECT * from test5
+b  c
+------
+1  3
+2  1
 
-! SELECT * from data_view
-contains:unable to automatically determine a query timestamp
+> SELECT * from data_view
+a  b
+----
+1  1
+2  1
+3  1
+1  2
 
 # Rematerialize data_view creating an index on it.
 > CREATE INDEX data_view_idx on data_view(a)
@@ -365,16 +379,27 @@ c  d
 # Unmaterialize source.
 > DROP INDEX mat_data_primary_idx1
 
-! SELECT * from mat_data
-contains:unable to automatically determine a query timestamp
+# Still works.
+> SELECT * from mat_data
+a  b
+----
+-1 0
+-1 1
+3  4
+1  2
 
 > SELECT * from test7
 count
 -----
 4
 
-! SELECT * from test8
-contains:unable to automatically determine a query timestamp
+> SELECT * from test8
+c  d
+-----
+0  1
+-1 1
+-4 -3
+-2 -1
 
 $ kafka-ingest format=avro topic=mat schema=${schema} timestamp=2
 {"a": -3, "b": 0}

--- a/test/testdrive/transactions-timedomain-nonmaterialized.td
+++ b/test/testdrive/transactions-timedomain-nonmaterialized.td
@@ -30,11 +30,13 @@ $ file-append path=static.csv
 2
 4
 
-! SELECT * FROM unindexed
-contains:unable to automatically determine a query timestamp
+> SELECT c FROM unindexed
+1
+2
+4
 
-! SELECT * FROM v_unindexed
-contains:unable to automatically determine a query timestamp
+> SELECT * FROM v_unindexed
+3
 
 > BEGIN
 


### PR DESCRIPTION
This commit allows `SELECT` queries to depend, directly or indirectly,
on unmaterialized sources. This was previously disallowed because we
didn't track the `since` frontier of unmaterialized sources; now we do.

Users will no longer see errors like

    unable to automatically determine a query timestamp

which is a huge upgrade in the user experience, in my opinion. The
downside is that users are not careful, a one-off query may result in
e.g. re-reading an entire Kafka source from the upstream broker. If it
becomes a problem, we can consider introducing a "safe mode" (maybe via
a session variable) that disallows queries that would re-instantiate a
source.

This new behavior facilitates making tables unmaterialized by default
(#10883). That change goes down more easily if you can `SELECT` from an
unmaterialized table.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

* Explained above.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - `SELECT` queries may now depend, directly or indirectly, on unmaterialized sources. Previously this resulted in a "unable to automatically determine a query timestamp" error.
