### PR TITLE
coord: refactor transaction timedomains

### DIFF
--- a/test/testdrive/transactions-timedomain-nonmaterialized.td
+++ b/test/testdrive/transactions-timedomain-nonmaterialized.td
@@ -47,10 +47,12 @@ $ file-append path=static.csv
 2
 4
 
-! SELECT c FROM unindexed ORDER BY c
-contains:Transactions can only reference objects in the same timedomain
+> SELECT c FROM unindexed
+1
+2
+4
 
-> ROLLBACK
+> COMMIT
 
 # The unindexed view should be the same.
 > BEGIN
@@ -60,10 +62,10 @@ contains:Transactions can only reference objects in the same timedomain
 2
 4
 
-! SELECT * FROM v_unindexed
-contains:Transactions can only reference objects in the same timedomain
+> SELECT * FROM v_unindexed
+3
 
-> ROLLBACK
+> COMMIT
 
 # Ensure that other optionally indexed things (views) are correctly
 # included in the timedomain.


### PR DESCRIPTION
Refactor the coordinator's handling of transaction timedomains. The
previous implementation had confusing flow between `timedomain_for`,
`determine_timestamp`, and `schema_adjacent_indexes` that I did not
quite follow. I believe the new code, described below, captures the
intent of the original code and has an implementation that is easier to
follow.

A transaction's "time domain" is simply the set of objects upon which it
acquires a read hold. The read holds are acquired at the time the
transaction's timestamp is determined, which occurs when the first query
arrives in the transaction. The current heuristic is to acquire a read
hold on every index and unmaterialized source needed to fulfill reads on
any object that shares a schema with an object directly referenced by
this first query. This logic lives in `timedomain_for`.

The timestamp of a transaction is determined entirely as a function of
the objects on which the transaction has required a read hold. This
logic lives in `determine_timestamp`.

The `TxnReads::timedomain_ids` field is no more, as the time domain IDs
of a transaction are now exactly equivalent to the storage and compute
IDs on which the transaction has a read hold.

The `schema_adjacent_indexes` method has been folded into
`timedomain_for`. This avoids needing to write a docstring like "this
method provides the exact semantics that `timedomain_for` wants"; and
indeed I believe it makes sense for the time domain determination logic
to live above the catalog.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code and possibly unblocks #10883.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
