### PR TITLE
Use Timeline struct to ensure write and read order

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1548,15 +1548,6 @@ impl Coordinator {
             frontier: self.determine_frontier(&[sink.from], compute_instance),
             strict: !sink.with_snapshot,
         };
-        // If the sink depends on tables, the `determine_frontier` call above
-        // will have called `get_local_read_ts` to determine the `as_of` for the
-        // sink. The below call to `catalog_transact` will call
-        // `get_local_write_ts` to emit an update to the system catalog. This
-        // interleaving of reads and writes is only guaranteed to succeed if we
-        // advance local inputs now.
-        //
-        // TODO(benesch): this is brittle. Can we make it less brittle?
-        self.advance_local_inputs().await;
         let ops = vec![
             catalog::Op::DropItem(id),
             catalog::Op::CreateItem {
@@ -5197,7 +5188,7 @@ impl Coordinator {
     }
 }
 
-/// A mechanism for ensuring that a sequence of writes and reads procede correctly through timestamps.
+/// A mechanism to ensure that a sequence of writes and reads proceed correctly through timestamps.
 mod timeline {
 
     /// A timeline is either currently writing or currently reading.

--- a/test/sqllogictest/postgres/subselect.slt
+++ b/test/sqllogictest/postgres/subselect.slt
@@ -18,6 +18,10 @@
 # license, a copy of which can be found in the LICENSE file at the
 # root of this repository.
 
+# RT File sources don't work with SLT, as we cannot guarantee that they have been
+# fully ingested at any time other than Timestamp::MAX.
+halt
+
 mode cockroach
 
 statement ok


### PR DESCRIPTION
This PR introduces a new `struct Timeline` that hands out write and read timestamps as requested, and ensures that all reads reflect exactly the set of preceding writes. Invoking the `write_ts()` and `read_ts()` methods will forcibly advance the internal timestamps (on read-to-write transitions) to ensure these requirements are met.

The type also allows `fast_forward(time)` to electively advance the time, and `should_advance_to()` which informs the bearer whether the write time has advanced since last polled (so that write capabilities can be downgraded).

### Motivation

Our existing timestamp issuing code had somewhat tangled logic that could result in panics if one was not careful to pilot it correctly. This removes the potential to incorrectly pilot things.

### Tips for reviewer

I'm not certain that the encapsulation here is entirely wanted, as we move from a very "introspectable" implementation to one that is more opaque. It didn't seem to be an issue when updating the code, but it could be that mischievous users might have subtle plans that are now thwarted.

cc: @benesch this has implications for your recent sink shenanigans wrt advancing the local timestamps. I'm curious to know if it automatically solves your problems by advancing the time for you.

The name `Timeline` is already taken in our codebase to mean "enum of interpretations of the `mz_repr::Timestamp` type", and I much prefer this one. I believe the existing use is closer to "timedomain hint". It is worth shaking this out at some point, as we have I think some "collection-oriented" consistency mechanisms and some "session-oriented" consistency mechanisms. This new offering is of the latter type. It is possible there should just be "timelines", and we then use policy to bind sessions and collections to them. Anyhow, thoughts are welcomed!

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
