### PR TITLE
testdrive: sleep a different way in fetch-select-during-ingest.td

### DIFF
--- a/test/testdrive/fetch-select-during-ingest.td
+++ b/test/testdrive/fetch-select-during-ingest.td
@@ -42,8 +42,11 @@ $ kafka-ingest format=avro topic=tail-fetch-during-ingest schema=${int} timestam
 # Sleep here to make sure the entire machinery has run. Since we are in a transaction,
 # we have no way of knowing that the source has progressed to '234' outside of the transaction
 
-> SELECT mz_internal.mz_sleep(2);
-<null>
+# NOTE(benesch): grumble. This is not a particularly robust way to write this
+# test. It is, however, better than what was previously here, which used
+# `SELECT mz_internal.mz_sleep(2)`, which had the extremely suboptimal property
+# of wedging up the coordinator for 2s, instead of just pausing the test for 2s.
+$ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=2s
 
 # This will return an empty result - nothing else available for fetching in the current transaction
 > FETCH 1 c WITH (timeout='2s');

--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -105,7 +105,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             ci_util.upload_junit_report(
                 "testdrive", Path(__file__).parent / junit_report
             )
-        c.kill("materialized")
 
 
 def workflow_testdrive_redpanda_ci(c: Composition) -> None:


### PR DESCRIPTION
The old code just wedged up materialized for 2s, which was not what the
test intended. It wanted to pause the test for 2s while letting
materialized continue to ingest data.

This is still timing dependent, but hopefully not in a way that will be
obserable any longer.

### Motivation

  * This PR fixes a failure in the nightly tests.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
