### PR TITLE
Allow table inputs to be dropped

### DIFF
--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -363,7 +363,8 @@ where
 
 pub struct LocalInput {
     pub handle: UnorderedHandle<Timestamp, (Row, Timestamp, Diff)>,
-    pub capability: ActivateCapability<Timestamp>,
+    /// A weak reference to the capability, in case all uses are dropped.
+    pub capability: std::rc::Weak<RefCell<ActivateCapability<Timestamp>>>,
 }
 
 /// An in-progress peek, and data to eventually fulfill it.


### PR DESCRIPTION
Table inputs would never be dropped, previously. This was not a problem, as they were indexed and we only used the indexes. Now, we are able to select directly from tables, but doing so creates dataflows that linger forever.

The change is to have the `LocalInput` capability be a weak reference, so that when bearers of the strong reference token drop it, it ceases to be and the input can close out.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
