### PR TITLE
dataflow-types: automatically derive depends_on for dataflow exports

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -164,7 +164,10 @@ impl CatalogState {
     /// Returns the identifiers of all discovered indexes, and the identifiers of
     /// the discovered unmaterialized sources required to satisfy ids. The returned list
     /// of indexes is incomplete iff `ids` depends on at least one unmaterialized source.
-    pub fn nearest_indexes(&self, ids: &[GlobalId]) -> CollectionIdBundle {
+    pub fn nearest_indexes<'a, I>(&self, ids: I) -> CollectionIdBundle
+    where
+        I: IntoIterator<Item = &'a GlobalId>,
+    {
         fn has_indexes(catalog: &CatalogState, id: GlobalId) -> bool {
             matches!(
                 catalog.get_by_id(&id).item(),
@@ -2253,7 +2256,10 @@ impl Catalog {
         self.get_indexes_on(id).iter().min().cloned()
     }
 
-    pub fn nearest_indexes(&self, ids: &[GlobalId]) -> CollectionIdBundle {
+    pub fn nearest_indexes<'a, I>(&self, ids: I) -> CollectionIdBundle
+    where
+        I: IntoIterator<Item = &'a GlobalId>,
+    {
         self.state.nearest_indexes(ids)
     }
 

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -3048,9 +3048,9 @@ impl Coordinator {
         dataflow.set_as_of(Antichain::from_elem(timestamp));
         let mut builder = self.dataflow_builder(compute_instance);
         builder.import_view_into_dataflow(&view_id, &source, &mut dataflow)?;
-        for BuildDesc { view, .. } in &mut dataflow.objects_to_build {
+        for BuildDesc { plan, .. } in &mut dataflow.objects_to_build {
             builder.prep_relation_expr(
-                view,
+                plan,
                 ExprPrepStyle::OneShot {
                     logical_time: Some(timestamp),
                     session,
@@ -4865,7 +4865,7 @@ pub mod fast_path_peek {
         if dataflow_plan.objects_to_build.len() >= 1
             && dataflow_plan.objects_to_build[0].id == view_id
         {
-            match &dataflow_plan.objects_to_build[0].view {
+            match &dataflow_plan.objects_to_build[0].plan {
                 // In the case of a constant, we can return the result now.
                 mz_dataflow_types::Plan::Constant { rows } => {
                     return Ok(Plan::Constant(rows.clone()));

--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -210,7 +210,7 @@ impl<'a> DataflowBuilder<'a> {
                 }
             }
         }
-        dataflow.insert_view(*view_id, view.clone());
+        dataflow.insert_plan(*view_id, view.clone());
 
         Ok(())
     }
@@ -226,8 +226,8 @@ impl<'a> DataflowBuilder<'a> {
         let on_type = on_entry.desc().unwrap().typ().clone();
         let mut dataflow = DataflowDesc::new(name, id);
         self.import_into_dataflow(&index_description.on_id, &mut dataflow)?;
-        for BuildDesc { view, .. } in &mut dataflow.objects_to_build {
-            self.prep_relation_expr(view, ExprPrepStyle::Index)?;
+        for BuildDesc { plan, .. } in &mut dataflow.objects_to_build {
+            self.prep_relation_expr(plan, ExprPrepStyle::Index)?;
         }
         for key in &mut index_description.key {
             self.prep_scalar_expr(key, ExprPrepStyle::Index)?;
@@ -266,8 +266,8 @@ impl<'a> DataflowBuilder<'a> {
     ) -> Result<(), CoordError> {
         dataflow.set_as_of(sink_description.as_of.frontier.clone());
         self.import_into_dataflow(&sink_description.from, dataflow)?;
-        for BuildDesc { view, .. } in &mut dataflow.objects_to_build {
-            self.prep_relation_expr(view, ExprPrepStyle::Index)?;
+        for BuildDesc { plan, .. } in &mut dataflow.objects_to_build {
+            self.prep_relation_expr(plan, ExprPrepStyle::Index)?;
         }
         dataflow.export_sink(id, sink_description);
 

--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -18,8 +18,8 @@ use mz_dataflow_types::client::{controller::ComputeController, Client};
 use mz_dataflow_types::sinks::SinkDesc;
 use mz_dataflow_types::{BuildDesc, DataflowDesc, IndexDesc};
 use mz_expr::{
-    GlobalId, MapFilterProject, MirRelationExpr, MirScalarExpr, OptimizedMirRelationExpr,
-    UnmaterializableFunc,
+    CollectionPlan, GlobalId, MapFilterProject, MirRelationExpr, MirScalarExpr,
+    OptimizedMirRelationExpr, UnmaterializableFunc,
 };
 use mz_ore::stack::maybe_grow;
 use mz_repr::adt::array::ArrayDimension;
@@ -188,7 +188,7 @@ impl<'a> DataflowBuilder<'a> {
         dataflow: &mut DataflowDesc,
     ) -> Result<(), CoordError> {
         // TODO: We only need to import Get arguments for which we cannot find arrangements.
-        for get_id in view.global_uses() {
+        for get_id in view.depends_on() {
             self.import_into_dataflow(&get_id, dataflow)?;
 
             // TODO: indexes should be imported after the optimization process, and only those

--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -125,7 +125,7 @@ impl<'a> DataflowBuilder<'a> {
                     .get_by_id(id)
                     .desc()
                     .expect("indexes can only be built on items with descs");
-                dataflow.import_index(*index_id, index_desc, desc.typ().clone(), *id);
+                dataflow.import_index(*index_id, index_desc, desc.typ().clone());
             } else {
                 let entry = self.catalog.get_by_id(id);
                 match entry.item() {
@@ -206,7 +206,7 @@ impl<'a> DataflowBuilder<'a> {
                         on_id: get_id,
                         key: keys.clone(),
                     };
-                    dataflow.import_index(*id, index_desc, on_type, *view_id);
+                    dataflow.import_index(*id, index_desc, on_type);
                 }
             }
         }

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -228,13 +228,13 @@ impl<T: timely::progress::Timestamp> Command<T> {
                         let mut builds_parts = vec![Vec::new(); parts];
                         // Partition each build description among `parts`.
                         for build_desc in dataflow.objects_to_build {
-                            let build_part = build_desc.view.partition_among(parts);
-                            for (view, objects_to_build) in
+                            let build_part = build_desc.plan.partition_among(parts);
+                            for (plan, objects_to_build) in
                                 build_part.into_iter().zip(builds_parts.iter_mut())
                             {
                                 objects_to_build.push(crate::BuildDesc {
                                     id: build_desc.id,
-                                    view,
+                                    plan,
                                 });
                             }
                         }

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -248,7 +248,6 @@ impl<T: timely::progress::Timestamp> Command<T> {
                                 objects_to_build,
                                 index_exports: dataflow.index_exports.clone(),
                                 sink_exports: dataflow.sink_exports.clone(),
-                                dependent_objects: dataflow.dependent_objects.clone(),
                                 as_of: dataflow.as_of.clone(),
                                 debug_name: dataflow.debug_name.clone(),
                                 id: dataflow.id,

--- a/src/dataflow-types/src/explain.rs
+++ b/src/dataflow-types/src/explain.rs
@@ -101,7 +101,7 @@ where
         let views = dataflow
             .objects_to_build
             .iter()
-            .map(|build_desc| (build_desc.id, &build_desc.view))
+            .map(|build_desc| (build_desc.id, &build_desc.plan))
             .collect::<Vec<_>>();
         Self {
             formatter,

--- a/src/dataflow-types/src/plan/mod.rs
+++ b/src/dataflow-types/src/plan/mod.rs
@@ -947,7 +947,6 @@ This is not expected to cause incorrect results, but could indicate a performanc
             objects_to_build,
             index_exports: desc.index_exports,
             sink_exports: desc.sink_exports,
-            dependent_objects: desc.dependent_objects,
             as_of: desc.as_of,
             debug_name: desc.debug_name,
             id: desc.id,

--- a/src/dataflow-types/src/plan/mod.rs
+++ b/src/dataflow-types/src/plan/mod.rs
@@ -933,12 +933,9 @@ This is not expected to cause incorrect results, but could indicate a performanc
         // Build each object in order, registering the arrangements it forms.
         let mut objects_to_build = Vec::with_capacity(desc.objects_to_build.len());
         for build in desc.objects_to_build.into_iter() {
-            let (plan, keys) = Self::from_mir(&build.view, &mut arrangements)?;
+            let (plan, keys) = Self::from_mir(&build.plan, &mut arrangements)?;
             arrangements.insert(Id::Global(build.id), keys);
-            objects_to_build.push(crate::BuildDesc {
-                id: build.id,
-                view: plan,
-            });
+            objects_to_build.push(crate::BuildDesc { id: build.id, plan });
         }
 
         Ok(DataflowDescription {

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -19,7 +19,7 @@ use std::num::NonZeroUsize;
 use serde::{Deserialize, Serialize};
 use timely::progress::frontier::Antichain;
 
-use mz_expr::{GlobalId, MirRelationExpr, MirScalarExpr, OptimizedMirRelationExpr};
+use mz_expr::{CollectionPlan, GlobalId, MirRelationExpr, MirScalarExpr, OptimizedMirRelationExpr};
 use mz_repr::{Diff, RelationType, Row};
 
 use crate::sources::persistence::SourcePersistDesc;
@@ -203,7 +203,7 @@ impl<T> DataflowDescription<OptimizedMirRelationExpr, T> {
 
     /// Binds to `id` the relation expression `view`.
     pub fn insert_view(&mut self, id: GlobalId, view: OptimizedMirRelationExpr) {
-        for get_id in view.global_uses() {
+        for get_id in view.depends_on() {
             self.record_depends_on(id, get_id);
         }
         self.objects_to_build.push(BuildDesc { id, view });

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -351,7 +351,7 @@ where
         object: BuildDesc<plan::Plan>,
     ) {
         // First, transform the relation expression into a render plan.
-        let bundle = self.render_plan(object.view, scope, scope.index());
+        let bundle = self.render_plan(object.plan, scope, scope.index());
         self.insert_id(Id::Global(object.id), bundle);
     }
 

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -100,7 +100,7 @@
 //! stream. This reduces the amount of recomputation that must be performed
 //! if/when the errors are retracted.
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 use std::rc::Rc;
 
 use differential_dataflow::AsCollection;
@@ -270,7 +270,7 @@ pub fn build_compute_dataflow<A: Allocate, B: ComputeReplay>(
                 .index_exports
                 .iter()
                 .cloned()
-                .map(|(idx_id, idx, _typ)| (idx_id, dataflow.get_imports(&idx.on_id), idx))
+                .map(|(idx_id, idx, _typ)| (idx_id, dataflow.depends_on(idx.on_id), idx))
                 .collect::<Vec<_>>();
 
             // Determine sinks to export
@@ -278,7 +278,7 @@ pub fn build_compute_dataflow<A: Allocate, B: ComputeReplay>(
                 .sink_exports
                 .iter()
                 .cloned()
-                .map(|(sink_id, sink)| (sink_id, dataflow.get_imports(&sink.from), sink))
+                .map(|(sink_id, sink)| (sink_id, dataflow.depends_on(sink.from), sink))
                 .collect::<Vec<_>>();
 
             // Build declared objects.
@@ -359,7 +359,7 @@ where
         &mut self,
         compute_state: &mut ComputeState,
         tokens: &mut BTreeMap<GlobalId, Rc<dyn std::any::Any>>,
-        import_ids: HashSet<GlobalId>,
+        import_ids: BTreeSet<GlobalId>,
         idx_id: GlobalId,
         idx: &IndexDesc,
     ) {

--- a/src/dataflow/src/render/sinks.rs
+++ b/src/dataflow/src/render/sinks.rs
@@ -11,7 +11,7 @@
 
 use std::any::Any;
 use std::cell::RefCell;
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use std::rc::Rc;
 
 use differential_dataflow::operators::arrange::arrangement::ArrangeByKey;
@@ -34,7 +34,7 @@ where
         &mut self,
         compute_state: &mut crate::server::ComputeState,
         tokens: &mut std::collections::BTreeMap<GlobalId, Rc<dyn std::any::Any>>,
-        import_ids: HashSet<GlobalId>,
+        import_ids: BTreeSet<GlobalId>,
         sink_id: GlobalId,
         sink: &SinkDesc,
     ) {

--- a/src/dataflow/src/server/compute_state.rs
+++ b/src/dataflow/src/server/compute_state.rs
@@ -103,7 +103,7 @@ impl<'a, A: Allocate, B: ComputeReplay> ActiveComputeState<'a, A, B> {
                         if let Some(logger) = self.compute_state.materialized_logger.as_mut() {
                             logger.log(MaterializedEvent::Dataflow(*idx_id, true));
                             logger.log(MaterializedEvent::Frontier(*idx_id, 0, 1));
-                            for import_id in dataflow.get_imports(&idx.on_id) {
+                            for import_id in dataflow.depends_on(idx.on_id) {
                                 logger.log(MaterializedEvent::DataflowDependency {
                                     dataflow: *idx_id,
                                     source: import_id,

--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -11,6 +11,7 @@
 
 #![warn(missing_debug_implementations)]
 
+use std::collections::BTreeSet;
 use std::fmt;
 use std::ops::Deref;
 
@@ -38,8 +39,8 @@ pub use relation::func::{AggregateFunc, TableFunc};
 pub use relation::func::{AnalyzedRegex, CaptureGroupDesc};
 pub use relation::join_input_mapper::JoinInputMapper;
 pub use relation::{
-    compare_columns, AggregateExpr, ColumnOrder, JoinImplementation, MirRelationExpr,
-    RowSetFinishing, RECURSION_LIMIT,
+    compare_columns, AggregateExpr, CollectionPlan, ColumnOrder, JoinImplementation,
+    MirRelationExpr, RowSetFinishing, RECURSION_LIMIT,
 };
 pub use scalar::func::{self, BinaryFunc, UnaryFunc, UnmaterializableFunc, VariadicFunc};
 pub use scalar::{like_pattern, EvalError, MirScalarExpr};
@@ -76,6 +77,12 @@ impl Deref for OptimizedMirRelationExpr {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl CollectionPlan for OptimizedMirRelationExpr {
+    fn depends_on_into(&self, out: &mut BTreeSet<GlobalId>) {
+        self.0.depends_on_into(out)
     }
 }
 

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -46,7 +46,7 @@ use mz_dataflow_types::{
         UnplannedSourceEnvelope, UpsertStyle,
     },
 };
-use mz_expr::GlobalId;
+use mz_expr::{CollectionPlan, GlobalId};
 use mz_interchange::avro::{self, AvroSchemaGenerator};
 use mz_interchange::envelopes;
 use mz_ore::collections::CollectionExt;
@@ -1352,7 +1352,7 @@ pub fn plan_create_view(
     let (name, view) = plan_view(scx, definition, params, *temporary)?;
     let replace = if *if_exists == IfExistsBehavior::Replace {
         if let Ok(item) = scx.catalog.resolve_item(&name.clone().into()) {
-            if view.expr.global_uses().contains(&item.id()) {
+            if view.expr.depends_on().contains(&item.id()) {
                 bail!(
                     "cannot replace view {0}: depended upon by new {0} definition",
                     item.name()

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -90,7 +90,7 @@ fn inline_views(dataflow: &mut DataflowDesc) -> Result<(), TransformError> {
         let mut occurrences_in_later_views = Vec::new();
         for other in (index + 1)..dataflow.objects_to_build.len() {
             if dataflow.objects_to_build[other]
-                .view
+                .plan
                 .depends_on()
                 .contains(&global_id)
             {
@@ -112,19 +112,19 @@ fn inline_views(dataflow: &mut DataflowDesc) -> Result<(), TransformError> {
             let new_local = LocalId::new(id_gen.allocate_id());
             // Use the same `id_gen` to assign new identifiers to `index`.
             update_let.action(
-                dataflow.objects_to_build[index].view.as_inner_mut(),
+                dataflow.objects_to_build[index].plan.as_inner_mut(),
                 &mut HashMap::new(),
                 &mut id_gen,
             )?;
             // Assign new identifiers to the other relation.
             update_let.action(
-                dataflow.objects_to_build[other].view.as_inner_mut(),
+                dataflow.objects_to_build[other].plan.as_inner_mut(),
                 &mut HashMap::new(),
                 &mut id_gen,
             )?;
             // Install the `new_local` name wherever `global_id` was used.
             dataflow.objects_to_build[other]
-                .view
+                .plan
                 .as_inner_mut()
                 .visit_mut_post(&mut |expr| {
                     if let MirRelationExpr::Get { id, .. } = expr {
@@ -138,14 +138,14 @@ fn inline_views(dataflow: &mut DataflowDesc) -> Result<(), TransformError> {
             // a `MirRelationExpr::Let` binding, whose value is `index` and
             // whose body is `other`.
             let body = dataflow.objects_to_build[other]
-                .view
+                .plan
                 .as_inner_mut()
                 .take_dangerous();
             let value = dataflow.objects_to_build[index]
-                .view
+                .plan
                 .as_inner_mut()
                 .take_dangerous();
-            *dataflow.objects_to_build[other].view.as_inner_mut() = MirRelationExpr::Let {
+            *dataflow.objects_to_build[other].plan.as_inner_mut() = MirRelationExpr::Let {
                 id: new_local,
                 value: Box::new(value),
                 body: Box::new(body),
@@ -172,7 +172,7 @@ fn optimize_dataflow_relations(
         // Re-name bindings to accommodate other analyses, specifically
         // `InlineLet` which probably wants a reworking in any case.
         // Re-run all optimizations on the composite views.
-        optimizer.transform(object.view.as_inner_mut(), &indexes)?;
+        optimizer.transform(object.plan.as_inner_mut(), &indexes)?;
     }
 
     Ok(())
@@ -212,7 +212,7 @@ fn optimize_dataflow_demand(dataflow: &mut DataflowDesc) -> Result<(), Transform
             .objects_to_build
             .iter_mut()
             .rev()
-            .map(|build_desc| (Id::Global(build_desc.id), build_desc.view.as_inner_mut())),
+            .map(|build_desc| (Id::Global(build_desc.id), build_desc.plan.as_inner_mut())),
         &mut demand,
     )?;
 
@@ -296,7 +296,7 @@ fn optimize_dataflow_filters(dataflow: &mut DataflowDesc) -> Result<(), Transfor
             .objects_to_build
             .iter_mut()
             .rev()
-            .map(|build_desc| (Id::Global(build_desc.id), build_desc.view.as_inner_mut())),
+            .map(|build_desc| (Id::Global(build_desc.id), build_desc.plan.as_inner_mut())),
         &mut predicates,
     )?;
 
@@ -362,7 +362,7 @@ pub fn optimize_dataflow_monotonic(dataflow: &mut DataflowDesc) -> Result<(), Tr
     // Propagate predicate information from outputs to inputs.
     for build_desc in dataflow.objects_to_build.iter_mut() {
         monotonic_flag.apply(
-            build_desc.view.as_inner_mut(),
+            build_desc.plan.as_inner_mut(),
             &monotonic,
             &mut HashSet::new(),
         )?;

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -15,7 +15,7 @@
 //! in which the views will be executed.
 
 use mz_dataflow_types::{DataflowDesc, LinearOperator};
-use mz_expr::{GlobalId, Id, LocalId, MirRelationExpr, MirScalarExpr};
+use mz_expr::{CollectionPlan, GlobalId, Id, LocalId, MirRelationExpr, MirScalarExpr};
 use mz_ore::id_gen::IdGen;
 use std::collections::{BTreeSet, HashMap, HashSet};
 
@@ -91,7 +91,7 @@ fn inline_views(dataflow: &mut DataflowDesc) -> Result<(), TransformError> {
         for other in (index + 1)..dataflow.objects_to_build.len() {
             if dataflow.objects_to_build[other]
                 .view
-                .global_uses()
+                .depends_on()
                 .contains(&global_id)
             {
                 occurrences_in_later_views.push(other);


### PR DESCRIPTION
Rather than requiring the caller to carefully provide dependency
information for the objects it adds to the `DataflowDescription`, derive
that information on the fly. It was all sitting in the
`DataflowDescription` already, and just needed to be tied together.

Fix https://github.com/MaterializeInc/materialize/issues/7267.

### Motivation

  * This PR accomplishes a known-desirable refactoring.

### Tips for reviewer

Go commit by commit.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
