### PR TITLE
dataflow-types: split out immutable controllers

### DIFF
--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -14,7 +14,8 @@
 //! and indicate which identifiers have arrangements available. This module
 //! isolates that logic from the rest of the somewhat complicated coordinator.
 
-use mz_dataflow_types::client::{controller::ComputeController, Client};
+use mz_dataflow_types::client::controller::ComputeController;
+use mz_dataflow_types::client::ComputeInstanceId;
 use mz_dataflow_types::sinks::SinkDesc;
 use mz_dataflow_types::{BuildDesc, DataflowDesc, IndexDesc};
 use mz_expr::{
@@ -39,8 +40,8 @@ pub struct DataflowBuilder<'a> {
     /// A handle to the compute abstraction, which describes indexes by identifier.
     ///
     /// This can also be used to grab a handle to the storage abstraction, through
-    /// its `storage()` method.
-    pub compute: ComputeController<'a, Box<dyn Client>, mz_repr::Timestamp>,
+    /// its `storage_mut()` method.
+    pub compute: ComputeController<'a, mz_repr::Timestamp>,
 }
 
 /// The styles in which an expression can be prepared for use in a dataflow.
@@ -58,10 +59,7 @@ pub enum ExprPrepStyle<'a> {
 
 impl Coordinator {
     /// Creates a new dataflow builder from the catalog and indexes in `self`.
-    pub fn dataflow_builder<'a>(
-        &'a mut self,
-        instance: mz_dataflow_types::client::ComputeInstanceId,
-    ) -> DataflowBuilder {
+    pub fn dataflow_builder(&self, instance: ComputeInstanceId) -> DataflowBuilder {
         let compute = self.dataflow_client.compute(instance).unwrap();
         DataflowBuilder {
             catalog: self.catalog.state(),


### PR DESCRIPTION
Split the `StorageController` and `ComputeController` types into mutable
and immutable variants. This is useful in several `Coordinator` code
paths where we want to call immutable methods on the controllers but it
is distasteful (or impossible) to get the required mutable references to
construct the controllers.

An immutable controller can be constructed out of a mutable controller
via the `as_ref()` method. (You might hope to use `Deref`, but that's
not possible due to the lifetimes in the trait.)

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
