### PR TITLE
expr: make array_to_string handle empty arrays

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -5126,7 +5126,10 @@ fn array_to_string<'a>(
             out.push_str(delimiter);
         }
     }
-    out.truncate(out.len() - delimiter.len()); // lop off last delimiter
+    if out.len() > 0 {
+        // Lop off last delimiter only if string is not empty
+        out.truncate(out.len() - delimiter.len());
+    }
     Ok(Datum::String(temp_storage.push_string(out)))
 }
 

--- a/test/sqllogictest/arrays.slt
+++ b/test/sqllogictest/arrays.slt
@@ -66,6 +66,12 @@ NULL  NULL
 query error Cannot call function array_to_string\(unknown, unknown\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
 SELECT array_to_string(NULL, ','), array_to_string(NULL, 'foo', 'zerp')
 
+# Handle empty arrays as an input
+query T
+SELECT array_to_string('{}'::text[], '')
+----
+(empty)
+
 # Test ANY/SOME/ALL.
 
 query B


### PR DESCRIPTION
Make `array_to_string` not panic when receiving empty arrays.
Fix #11073.

### Motivation
  * This PR fixes a recognized bug: #11073

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - `array_to_string` now supports empty arrays as input.
