### PR TITLE
sql: move unnest to pg_catalog

### DIFF
--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -2512,6 +2512,18 @@ lazy_static! {
                     })
                 }), 3931;
             },
+            "unnest" => Table {
+                vec![ArrayAny] => Operation::unary(move |ecx, e| {
+                    let el_typ = ecx.scalar_type(&e).unwrap_array_element_type().clone();
+                    Ok(TableFuncPlan {
+                        expr: HirRelationExpr::CallTable {
+                            func: TableFunc::UnnestArray { el_typ },
+                            exprs: vec![e],
+                        },
+                        column_names: vec!["unnest".into()],
+                    })
+                }) => ReturnType::set_of(ListElementAny), 2331;
+            },
             // Note that these implementations' input to `generate_series` is
             // contrived to match Flink's expected values. There are other,
             // equally valid windows we could generate.
@@ -2692,16 +2704,6 @@ lazy_static! {
                 }), oid::FUNC_REPEAT_OID;
             },
             "unnest" => Table {
-                vec![ArrayAny] => Operation::unary(move |ecx, e| {
-                    let el_typ = ecx.scalar_type(&e).unwrap_array_element_type().clone();
-                    Ok(TableFuncPlan {
-                        expr: HirRelationExpr::CallTable {
-                            func: TableFunc::UnnestArray { el_typ },
-                            exprs: vec![e],
-                        },
-                        column_names: vec!["unnest".into()],
-                    })
-                }) => ReturnType::set_of(ListElementAny), 2331;
                 vec![ListAny] => Operation::unary(move |ecx, e| {
                     let el_typ = ecx.scalar_type(&e).unwrap_list_element_type().clone();
                     Ok(TableFuncPlan {


### PR DESCRIPTION
The version of `unnest` that takes arrays as arguments rightly belongs in `pg_catalog`, not `mz_catalog`.

### Motivation

This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Move `unnest(arrayany)` to the `pg_catalog` schema. Previously, it had unintentionally been in the `mz_catalog` schema.
