### PR TITLE
coordd: Remove unused --workers

### DIFF
--- a/src/materialized/src/bin/coordd.rs
+++ b/src/materialized/src/bin/coordd.rs
@@ -46,16 +46,6 @@ struct Args {
     /// The address of the storage dataflowd servers to connect to.
     #[clap(long)]
     storaged_addr: Vec<String>,
-    /// Number of dataflow worker threads. This must match the number of
-    /// workers that the targeted dataflowd was started with.
-    #[clap(
-        short,
-        long,
-        env = "COORDD_DATAFLOWD_WORKERS",
-        value_name = "N",
-        default_value = "1"
-    )]
-    workers: usize,
     /// Where to store data.
     #[clap(
         short = 'D',
@@ -148,7 +138,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
 
     let metrics = Metrics::register_with(
         &mut metrics_registry,
-        args.workers,
+        usize::MAX,
         coord_handle.start_instant(),
     );
 

--- a/test/cluster/README.md
+++ b/test/cluster/README.md
@@ -41,7 +41,7 @@ docker run -p 2101:2101 -p 6876:6876 materialize/dataflowd:latest --workers 2 --
 On `coord`, run:
 
 ```
-docker run -v /share/mzdata -p 6875:6875 materialize/coordd:latest -D /share/mzdata --workers 4 dataflow1:6876 dataflow2:6876
+docker run -v /share/mzdata -p 6875:6875 materialize/coordd:latest -D /share/mzdata dataflow1:6876 dataflow2:6876
 ```
 
 Then connect to the coordinator via psql:
@@ -67,7 +67,6 @@ To launch the coordinator:
 
 ```
 docker run -p 6875:6875 materialize/coordd:latest \
-    --workers <W*N> \
     --dataflowd-addr dataflow1:2101 dataflow2:2101 ... dataflow<N>:2101
 ```
 

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -38,7 +38,7 @@ SERVICES = [
     ),
     Coordd(
         name="materialized",
-        options="--workers 4 dataflowd_1:6876 dataflowd_2:6876",
+        options="dataflowd_1:6876 dataflowd_2:6876",
     ),
     Dataflowd(
         name="dataflowd_compute_1",
@@ -62,7 +62,7 @@ SERVICES = [
     ),
     Coordd(
         name="materialized_compute_storage",
-        options="--workers 4 dataflowd_compute_1:6876 dataflowd_compute_2:6876 --storaged-addr dataflowd_storage:6876",
+        options="dataflowd_compute_1:6876 dataflowd_compute_2:6876 --storaged-addr dataflowd_storage:6876",
     ),
     Testdrive(
         volumes=[


### PR DESCRIPTION
This PR refactors existing code: Remove the `--workers` parameter to `coordd`. It was only used for metrics, which are irrelevant for coordd.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
