### PR TITLE
dataflow: Only send frontier uppers for non-empty lists

### DIFF
--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -746,13 +746,17 @@ pub mod partitioned {
                         }
                     }
 
-                    Box::new(
-                        Some(Response::Compute(
-                            ComputeResponse::FrontierUppers(list),
-                            instance,
-                        ))
-                        .into_iter(),
-                    )
+                    if list.is_empty() {
+                        Box::new(None.into_iter())
+                    } else {
+                        Box::new(
+                            Some(Response::Compute(
+                                ComputeResponse::FrontierUppers(list),
+                                instance,
+                            ))
+                            .into_iter(),
+                        )
+                    }
                 }
                 // Avoid multiple retractions of minimum time, to present as updates from one worker.
                 Response::Storage(StorageResponse::TimestampBindings(mut feedback)) => {


### PR DESCRIPTION
Currently, we as send many `ComputeResponse::FrontierUppers` to the
coordinator as there are Timely workers. This is not required as the
partitioned client absorbs updates from all its Timely workers anly only
releases combined frontier information.

With this change, we only pass the command to the coordinator if the list
of frontiers is non-empty.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A