### PR TITLE
persist: simplify compaction test

### DIFF
--- a/test/persistence/compaction/compaction.td
+++ b/test/persistence/compaction/compaction.td
@@ -10,6 +10,9 @@
 #
 # Smoke tests that verify compaction occurs as expected.
 #
+# Right now this test only verifies that user tables are hooked up together properly
+# and will compact stored data. There's more detailed tests that check exactly
+# how the persist codebase does compaction in src/persist.
 
 $ set-sql-timeout duration=30s
 
@@ -21,147 +24,28 @@ $ set-sql-timeout duration=30s
     WHERE metric = grp.metric
     ORDER BY time DESC LIMIT 1)
 
-# At the beginning there are no trace batches.
-> SELECT value FROM most_recent_mz_metrics where metric = 'mz_persist_trace_blob_count'
-value
+> CREATE TABLE compaction (f1 TEXT);
+
+# At the beginning there's fewer than 200 bytes in the stored arrangement.
+> SELECT value < 200 AS result FROM most_recent_mz_metrics where metric = 'mz_persist_trace_blob_bytes'
+result
 -----
-0
+true
 
-> CREATE TABLE compaction (f1 INTEGER);
+# Insert over 1 MiB of data.
+> INSERT INTO compaction VALUES (repeat('this is a compaction test. ', 50000));
 
-> INSERT INTO compaction VALUES (1);
-
-# The insert should make it into trace, and form 1 trace batch.
-> SELECT value FROM most_recent_mz_metrics where metric = 'mz_persist_trace_blob_count'
-value
+# There's at least 1 MiB in the stored arrangement.
+> SELECT value > 1 << 20 AS result FROM most_recent_mz_metrics where metric = 'mz_persist_trace_blob_bytes'
+result
 -----
-1
+true
 
-# Read after write to coerce different writes to happen at different timestamps.
-> SELECT * FROM compaction
-f1
-----
-1
+# Delete all the values from the table.
+> DELETE FROM compaction;
 
-> INSERT INTO compaction VALUES (2);
-
-> SELECT * FROM compaction
-f1
-----
-1
-2
-
-# The previous insert should get compacted into one batch with the one before it.
-> SELECT value FROM most_recent_mz_metrics where metric = 'mz_persist_trace_blob_count'
-value
+# After deletion and compaction there's fewer than 200 bytes in the stored arrangement.
+> SELECT value < 200 AS result FROM most_recent_mz_metrics where metric = 'mz_persist_trace_blob_bytes'
+result
 -----
-1
-
-> INSERT INTO compaction VALUES (3);
-
-> SELECT * FROM compaction
-f1
-----
-1
-2
-3
-
-# The most recent insert forms a new batch because it is at a lower compaction level.
-> SELECT value FROM most_recent_mz_metrics where metric = 'mz_persist_trace_blob_count'
-value
------
-2
-
-> INSERT INTO compaction VALUES (4);
-
-> SELECT * FROM compaction
-f1
-----
-1
-2
-3
-4
-
-# The previous insert should compact together with the previous batch, which then compacts recursively
-# up, leaving just one batch.
-> SELECT value FROM most_recent_mz_metrics where metric = 'mz_persist_trace_blob_count'
-value
------
-1
-
-> INSERT INTO compaction VALUES (5);
-
-> SELECT * FROM compaction
-f1
-----
-1
-2
-3
-4
-5
-
-# The previous insert forms a new batch.
-> SELECT value FROM most_recent_mz_metrics where metric = 'mz_persist_trace_blob_count'
-value
------
-2
-
-> INSERT INTO compaction VALUES (6);
-
-> SELECT * FROM compaction
-f1
-----
-1
-2
-3
-4
-5
-6
-
-# The previous insert gets merged together with the one just before it.
-> SELECT value FROM most_recent_mz_metrics where metric = 'mz_persist_trace_blob_count'
-value
------
-2
-
-> INSERT INTO compaction VALUES (7);
-
-> SELECT * FROM compaction
-f1
-----
-1
-2
-3
-4
-5
-6
-7
-
-# The previous insert forms a new batch.
-> SELECT value FROM most_recent_mz_metrics where metric = 'mz_persist_trace_blob_count'
-value
------
-3
-
-> INSERT INTO compaction VALUES (8);
-
-> SELECT * FROM compaction
-f1
-----
-1
-2
-3
-4
-5
-6
-7
-8
-
-# TODO: This suddenly started flaking fairly frequently with nothing related in
-# persist seemingly changing. Reenable when we figure out what's going on.
-#
-# # All of the previously inserted batches get compacted together into one batch.
-# > SELECT value FROM most_recent_mz_metrics where metric = 'mz_persist_trace_blob_count'
-# value
-# -----
-# 1
+true


### PR DESCRIPTION
The previous iteration of this test was too specifically coupled to the compaction
implementation in the persist crate, and made unreasonable assumptions about exactly
what happened and when.

This test is more simple, and has only two steps:

1. Write some data, and observe that the number of stored bytes increased.
2. Retract that data, and observe that the number of stored bytes decreased.

It's important to note that this happens to work because all of step 1 happened
in one batch and all of step 2 happened in one batch. If we instead, break step
1 into two insert statements, we won't observe the data reduction we expect
because now the two inserts are compacted together into one batch, which will
only be compacted together with the result of another two batches themselves
compacted together.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
