### PR TITLE
transform: introduce a trait for available indexes

### DIFF
--- a/src/transform/src/fusion/filter.rs
+++ b/src/transform/src/fusion/filter.rs
@@ -36,7 +36,7 @@
 //! use mz_transform::{Transform, TransformArgs};
 //! Filter.transform(&mut expr, TransformArgs {
 //!   id_gen: &mut Default::default(),
-//!   indexes: &std::collections::HashMap::new(),
+//!   indexes: &mz_transform::EmptyIndexOracle,
 //! });
 //!
 //! let correct = input.filter(vec![predicate0]);

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -21,9 +21,9 @@
 #![warn(missing_docs)]
 #![warn(missing_debug_implementations)]
 
-use std::collections::HashMap;
 use std::error::Error;
 use std::fmt;
+use std::iter;
 
 use mz_expr::GlobalId;
 use mz_expr::MirRelationExpr;
@@ -63,7 +63,7 @@ pub struct TransformArgs<'a> {
     /// A shared instance of IdGen to allow constructing new Let expressions.
     pub id_gen: &'a mut IdGen,
     /// The indexes accessible.
-    pub indexes: &'a HashMap<GlobalId, Vec<(GlobalId, Vec<MirScalarExpr>)>>,
+    pub indexes: &'a dyn IndexOracle,
 }
 
 /// Types capable of transforming relation expressions.
@@ -103,6 +103,32 @@ impl Error for TransformError {}
 impl From<RecursionLimitError> for TransformError {
     fn from(error: RecursionLimitError) -> Self {
         TransformError::Internal(error.to_string())
+    }
+}
+
+/// A trait for a type that can answer questions about what indexes exist.
+pub trait IndexOracle: fmt::Debug {
+    /// Returns an iterator over the indexes that exist on the identified
+    /// collection.
+    ///
+    /// Each index is described by the list of key expressions. If no indexes
+    /// exist for the identified collection, or if the identified collection
+    /// is unknown, the returned iterator will be empty.
+    ///
+    // NOTE(benesch): The allocation here is unfortunate, but on the other hand
+    // you need only allocate when you actually look for an index. Can we do
+    // better somehow? Making the entire optimizer generic over this iterator
+    // type doesn't presently seem worthwhile.
+    fn indexes_on(&self, id: GlobalId) -> Box<dyn Iterator<Item = &[MirScalarExpr]> + '_>;
+}
+
+/// An [`IndexOracle`] that knows about no indexes.
+#[derive(Debug)]
+pub struct EmptyIndexOracle;
+
+impl IndexOracle for EmptyIndexOracle {
+    fn indexes_on(&self, _: GlobalId) -> Box<dyn Iterator<Item = &[MirScalarExpr]> + '_> {
+        Box::new(iter::empty())
     }
 }
 
@@ -374,7 +400,7 @@ impl Optimizer {
         &mut self,
         mut relation: MirRelationExpr,
     ) -> Result<mz_expr::OptimizedMirRelationExpr, TransformError> {
-        self.transform(&mut relation, &HashMap::new())?;
+        self.transform(&mut relation, &EmptyIndexOracle)?;
         Ok(mz_expr::OptimizedMirRelationExpr(relation))
     }
 
@@ -385,7 +411,7 @@ impl Optimizer {
     fn transform(
         &self,
         relation: &mut MirRelationExpr,
-        indexes: &HashMap<GlobalId, Vec<(GlobalId, Vec<MirScalarExpr>)>>,
+        indexes: &dyn IndexOracle,
     ) -> Result<(), TransformError> {
         let mut id_gen = Default::default();
         for transform in self.transforms.iter() {

--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -60,7 +60,7 @@
 //! use mz_transform::{Transform, TransformArgs};
 //! PredicatePushdown::default().transform(&mut expr, TransformArgs {
 //!   id_gen: &mut Default::default(),
-//!   indexes: &std::collections::HashMap::new(),
+//!   indexes: &mz_transform::EmptyIndexOracle,
 //! });
 //!
 //! let predicate00 = MirScalarExpr::column(0).call_binary(MirScalarExpr::column(0), BinaryFunc::AddInt64);

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -28,7 +28,7 @@ mod tests {
     use mz_lowertest::{deserialize, tokenize};
     use mz_ore::str::separated;
     use mz_transform::dataflow::{optimize_dataflow_demand_inner, optimize_dataflow_filters_inner};
-    use mz_transform::{Optimizer, Transform, TransformArgs};
+    use mz_transform::{EmptyIndexOracle, Optimizer, Transform, TransformArgs};
     use proc_macro2::TokenTree;
 
     // Global options
@@ -123,13 +123,12 @@ mod tests {
     ) -> Result<String, Error> {
         let mut rel = parse_relation(s, cat, args)?;
         let mut id_gen = Default::default();
-        let indexes = HashMap::new();
         for t in args.get("apply").cloned().unwrap_or_else(Vec::new).iter() {
             get_transform(t)?.transform(
                 &mut rel,
                 TransformArgs {
                     id_gen: &mut id_gen,
-                    indexes: &indexes,
+                    indexes: &EmptyIndexOracle,
                 },
             )?;
         }
@@ -143,7 +142,7 @@ mod tests {
                         &mut rel,
                         TransformArgs {
                             id_gen: &mut id_gen,
-                            indexes: &indexes,
+                            indexes: &EmptyIndexOracle,
                         },
                     )?;
                 }
@@ -167,7 +166,7 @@ mod tests {
                             &mut rel,
                             TransformArgs {
                                 id_gen: &mut id_gen,
-                                indexes: &indexes,
+                                indexes: &EmptyIndexOracle,
                             },
                         )?;
 


### PR DESCRIPTION
The optimizer only needs to ask the question "for this collection, what
index keys exist?" Introduce an `IndexOracle` trait which answers this
specific question.

This decouples the `transform` crate from the physical representation of
index metadata tracking, freeing up the coordinator to derive this
information on the fly, rather than specifically storing it in a:

    HashMap<GlobalId, Vec<(GlobalId, Vec<MirScalarExpr)>>

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.


### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
