### PR TITLE
coord: extract index oracle type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3174,6 +3174,7 @@ dependencies = [
  "bytes",
  "chrono",
  "crossbeam-channel",
+ "derivative",
  "differential-dataflow",
  "enum-iterator",
  "enum-kinds",

--- a/src/coord/src/coord/indexes.rs
+++ b/src/coord/src/coord/indexes.rs
@@ -1,0 +1,105 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::BTreeSet;
+
+use mz_dataflow_types::client::controller::ComputeController;
+use mz_dataflow_types::client::ComputeInstanceId;
+use mz_expr::GlobalId;
+use mz_expr::MirScalarExpr;
+use mz_transform::IndexOracle;
+
+use crate::catalog::{CatalogItem, CatalogState, Index};
+use crate::coord::dataflow_builder::DataflowBuilder;
+use crate::coord::{CollectionIdBundle, Coordinator};
+
+/// Answers questions about the indexes available on a particular compute
+/// instance.
+#[derive(Debug)]
+pub struct ComputeInstanceIndexOracle<'a> {
+    catalog: &'a CatalogState,
+    compute: ComputeController<'a, mz_repr::Timestamp>,
+}
+
+impl Coordinator {
+    /// Creates a new index oracle for the specified compute instance.
+    pub fn index_oracle(&self, instance: ComputeInstanceId) -> ComputeInstanceIndexOracle {
+        ComputeInstanceIndexOracle {
+            catalog: self.catalog.state(),
+            compute: self.dataflow_client.compute(instance).unwrap(),
+        }
+    }
+}
+
+impl DataflowBuilder<'_> {
+    /// Creates a new index oracle for the same compute instance as the dataflow
+    /// builder.
+    pub fn index_oracle(&self) -> ComputeInstanceIndexOracle {
+        ComputeInstanceIndexOracle {
+            catalog: self.catalog,
+            compute: self.compute,
+        }
+    }
+}
+
+impl ComputeInstanceIndexOracle<'_> {
+    /// Identifies a bundle of storage and compute collection ids sufficient for
+    /// building a dataflow for the identifiers in `ids` out of the indexes
+    /// available in this compute instance.
+    pub fn sufficient_collections<'a, I>(&self, ids: I) -> CollectionIdBundle
+    where
+        I: IntoIterator<Item = &'a GlobalId>,
+    {
+        let mut id_bundle = CollectionIdBundle::default();
+        let mut todo: BTreeSet<GlobalId> = ids.into_iter().cloned().collect();
+
+        // Iteratively extract the largest element, potentially introducing lesser elements.
+        while let Some(id) = todo.iter().rev().next().cloned() {
+            // Extract available indexes as those that are enabled, and installed on the cluster.
+            let mut available_indexes = self.indexes_on(id).map(|(id, _)| id).peekable();
+
+            if available_indexes.peek().is_some() {
+                id_bundle.compute_ids.extend(available_indexes);
+            } else {
+                match self.catalog.get_by_id(&id).item() {
+                    // Unmaterialized view. Search its dependencies.
+                    view @ CatalogItem::View(_) => {
+                        todo.extend(view.uses());
+                    }
+                    CatalogItem::Source(_) | CatalogItem::Table(_) => {
+                        // Unmaterialized source or table. Record that we are
+                        // missing at least one index.
+                        id_bundle.storage_ids.insert(id);
+                    }
+                    _ => {
+                        // Non-indexable thing; no work to do.
+                    }
+                }
+            }
+            todo.remove(&id);
+        }
+
+        id_bundle
+    }
+
+    pub fn indexes_on(&self, id: GlobalId) -> impl Iterator<Item = (GlobalId, &Index)> {
+        self.catalog
+            .get_indexes_on(id)
+            .filter(|(idx_id, _idx)| self.compute.collection(*idx_id).is_ok())
+    }
+}
+
+impl IndexOracle for ComputeInstanceIndexOracle<'_> {
+    fn indexes_on(&self, id: GlobalId) -> Box<dyn Iterator<Item = &[MirScalarExpr]> + '_> {
+        Box::new(
+            ComputeInstanceIndexOracle::indexes_on(self, id)
+                .map(|(_idx_id, idx)| idx.keys.as_slice()),
+        )
+    }
+}

--- a/src/dataflow-types/Cargo.toml
+++ b/src/dataflow-types/Cargo.toml
@@ -15,6 +15,7 @@ aws-types = { version = "0.8.0", features = ["hardcoded-credentials"] }
 bytes = "1.1.0"
 chrono = { version = "0.4.0", default-features = false, features = ["std"] }
 crossbeam-channel = "0.5.2"
+derivative = "2.2.0"
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 enum-iterator = "0.7.0"
 enum-kinds = "0.5.1"

--- a/src/dataflow-types/src/client/controller.rs
+++ b/src/dataflow-types/src/client/controller.rs
@@ -23,6 +23,7 @@
 
 use std::collections::BTreeMap;
 
+use derivative::Derivative;
 use differential_dataflow::lattice::Lattice;
 use timely::progress::frontier::{Antichain, AntichainRef};
 use timely::progress::Timestamp;
@@ -160,7 +161,8 @@ impl<C> Controller<C> {
 use std::sync::Arc;
 
 /// Compaction policies for collections maintained by `Controller`.
-#[derive(Clone)]
+#[derive(Clone, Derivative)]
+#[derivative(Debug)]
 pub enum ReadPolicy<T> {
     /// Maintain the collection as valid from this frontier onward.
     ValidFrom(Antichain<T>),
@@ -171,7 +173,7 @@ pub enum ReadPolicy<T> {
     /// consider using the `ValidFrom` variant to manually pilot compaction.
     ///
     /// The `Arc` makes the function cloneable.
-    LagWriteFrontier(Arc<dyn Fn(AntichainRef<T>) -> Antichain<T>>),
+    LagWriteFrontier(#[derivative(Debug = "ignore")] Arc<dyn Fn(AntichainRef<T>) -> Antichain<T>>),
     /// Allows one to express multiple read policies, taking the least of
     /// the resulting frontiers.
     Multiple(Vec<ReadPolicy<T>>),

--- a/src/dataflow-types/src/client/controller/compute.rs
+++ b/src/dataflow-types/src/client/controller/compute.rs
@@ -39,12 +39,14 @@ use mz_repr::Row;
 use super::ReadPolicy;
 
 /// Controller state maintained for each compute instance.
+#[derive(Debug)]
 pub(super) struct ComputeControllerState<T> {
     /// Tracks expressed `since` and received `upper` frontiers for indexes and sinks.
     pub(super) collections: BTreeMap<GlobalId, CollectionState<T>>,
 }
 
 /// An immutable controller for a compute instance.
+#[derive(Debug, Copy, Clone)]
 pub struct ComputeController<'a, T> {
     pub(super) _instance: ComputeInstanceId, // likely to be needed soon
     pub(super) compute: &'a ComputeControllerState<T>,
@@ -52,6 +54,7 @@ pub struct ComputeController<'a, T> {
 }
 
 /// A mutable controller for a compute instance.
+#[derive(Debug)]
 pub struct ComputeControllerMut<'a, C, T> {
     pub(super) instance: ComputeInstanceId,
     pub(super) compute: &'a mut ComputeControllerState<T>,
@@ -519,6 +522,7 @@ impl<'a, C: Client<T>, T: Timestamp + Lattice> ComputeControllerMut<'a, C, T> {
 }
 
 /// State maintained about individual collections.
+#[derive(Debug)]
 pub struct CollectionState<T> {
     /// Accumulation of read capabilities for the collection.
     ///

--- a/src/dataflow-types/src/client/controller/storage.rs
+++ b/src/dataflow-types/src/client/controller/storage.rs
@@ -30,6 +30,7 @@ use crate::Update;
 use mz_expr::GlobalId;
 
 /// Controller state maintained for each storage instance.
+#[derive(Debug)]
 pub struct StorageControllerState<T> {
     /// Collections maintained by the storage controller.
     ///
@@ -346,6 +347,7 @@ impl<'a, C: Client<T>, T: Timestamp + Lattice> StorageControllerMut<'a, C, T> {
 }
 
 /// State maintained about individual collections.
+#[derive(Debug)]
 pub struct CollectionState<T> {
     /// Description with which the source was created, and its initial `since`.
     pub(super) description: (crate::sources::SourceDesc, Antichain<T>),


### PR DESCRIPTION
Extract a new `ComputeInstanceIndexOracle` type which is the
authoritative reference on which indexes are available for use on a
particular compute instance. It does this by mashing up information from
the catalog and the compute controller.

This type is used to determine what indexes are available during
timestamp determination *and* dataflow building, so it fixes #8318 at
long last.

By request, this PR also fixes #10955.

With this PR in place, #11029 is unblocked. It should now be
relatively straightforward to wire up `CREATE CLUSTER`.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
