### PR TITLE
coord,sql: rename "default database" to "active database"

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -2390,7 +2390,7 @@ impl ExprHumanizer for ConnCatalog<'_> {
 }
 
 impl SessionCatalog for ConnCatalog<'_> {
-    fn user(&self) -> &str {
+    fn active_user(&self) -> &str {
         &self.user
     }
 
@@ -2400,7 +2400,7 @@ impl SessionCatalog for ConnCatalog<'_> {
             .flatten()
     }
 
-    fn default_database(&self) -> &str {
+    fn active_database(&self) -> &str {
         &self.database
     }
 

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1030,12 +1030,9 @@ impl Coordinator {
 
                 let mut messages = vec![];
                 let catalog = self.catalog.for_session(&session);
-                if catalog
-                    .resolve_database(catalog.default_database())
-                    .is_err()
-                {
+                if catalog.resolve_database(catalog.active_database()).is_err() {
                     messages.push(StartupMessage::UnknownSessionDatabase(
-                        catalog.default_database().into(),
+                        catalog.active_database().into(),
                     ));
                 }
 

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -319,7 +319,7 @@ impl<'a> StatementContext<'a> {
         FullName {
             database: match name.database {
                 Some(name) => DatabaseSpecifier::Name(name),
-                None => DatabaseSpecifier::Name(self.catalog.default_database().into()),
+                None => DatabaseSpecifier::Name(self.catalog.active_database().into()),
             },
             schema: name.schema.unwrap_or_else(|| "public".into()),
             item: name.item,
@@ -334,12 +334,12 @@ impl<'a> StatementContext<'a> {
         }
     }
 
-    pub fn resolve_default_database(&self) -> Result<&dyn CatalogDatabase, PlanError> {
-        let name = self.catalog.default_database();
+    pub fn resolve_active_database(&self) -> Result<&dyn CatalogDatabase, PlanError> {
+        let name = self.catalog.active_database();
         Ok(self.catalog.resolve_database(name)?)
     }
 
-    pub fn resolve_default_schema(&self) -> Result<&dyn CatalogSchema, PlanError> {
+    pub fn resolve_active_schema(&self) -> Result<&dyn CatalogSchema, PlanError> {
         self.resolve_schema(UnresolvedObjectName::unqualified("public"))
     }
 

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -130,7 +130,7 @@ pub fn plan_create_schema(
             .expect("names always have at least one component"),
     );
     let database_name = match name.0.pop() {
-        None => DatabaseSpecifier::Name(scx.catalog.default_database().into()),
+        None => DatabaseSpecifier::Name(scx.catalog.active_database().into()),
         Some(n) => DatabaseSpecifier::Name(normalize::ident(n)),
     };
     Ok(Plan::CreateSchema(CreateSchemaPlan {
@@ -2413,7 +2413,7 @@ pub fn plan_drop_role(
         } else {
             bail!("invalid role name {}", name.to_string().quoted())
         };
-        if name == scx.catalog.user() {
+        if name == scx.catalog.active_user() {
             bail!("current user cannot be dropped");
         }
         match scx.catalog.resolve_role(&name) {

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -230,7 +230,7 @@ fn show_schemas<'a>(
     let database = if let Some(from) = from {
         scx.resolve_database(from)?
     } else {
-        scx.resolve_default_database()?
+        scx.resolve_active_database()?
     };
     let query = if !full & !extended {
         format!(
@@ -272,7 +272,7 @@ fn show_tables<'a>(
     let schema = if let Some(from) = from {
         scx.resolve_schema(from)?
     } else {
-        scx.resolve_default_schema()?
+        scx.resolve_active_schema()?
     };
 
     let mut query = format!(
@@ -302,7 +302,7 @@ fn show_sources<'a>(
     let schema = if let Some(from) = from {
         scx.resolve_schema(from)?
     } else {
-        scx.resolve_default_schema()?
+        scx.resolve_active_schema()?
     };
 
     let query = match (full, materialized) {
@@ -364,7 +364,7 @@ fn show_views<'a>(
     let schema = if let Some(from) = from {
         scx.resolve_schema(from)?
     } else {
-        scx.resolve_default_schema()?
+        scx.resolve_active_schema()?
     };
 
     let query = if !full & !materialized {
@@ -410,7 +410,7 @@ fn show_sinks<'a>(
     let schema = if let Some(from) = from {
         scx.resolve_schema(from)?
     } else {
-        scx.resolve_default_schema()?
+        scx.resolve_active_schema()?
     };
 
     let query = if full {
@@ -439,7 +439,7 @@ fn show_types<'a>(
     let schema = if let Some(from) = from {
         scx.resolve_schema(from)?
     } else {
-        scx.resolve_default_schema()?
+        scx.resolve_active_schema()?
     };
 
     let mut query = format!(
@@ -469,7 +469,7 @@ fn show_all_objects<'a>(
     let schema = if let Some(from) = from {
         scx.resolve_schema(from)?
     } else {
-        scx.resolve_default_schema()?
+        scx.resolve_active_schema()?
     };
 
     let mut query = format!(

--- a/src/sql/src/query_model/test/catalog.rs
+++ b/src/sql/src/query_model/test/catalog.rs
@@ -176,7 +176,7 @@ impl Default for TestCatalog {
 }
 
 impl SessionCatalog for TestCatalog {
-    fn user(&self) -> &str {
+    fn active_user(&self) -> &str {
         "dummy"
     }
 
@@ -184,7 +184,7 @@ impl SessionCatalog for TestCatalog {
         None
     }
 
-    fn default_database(&self) -> &str {
+    fn active_database(&self) -> &str {
         "dummy"
     }
 
@@ -300,9 +300,9 @@ impl TestCatalog {
                             TestCatalogItem::BaseTable {
                                 name: FullName {
                                     database: DatabaseSpecifier::from(Some(
-                                        self.default_database().to_string(),
+                                        self.active_database().to_string(),
                                     )),
-                                    schema: self.user().to_string(),
+                                    schema: self.active_user().to_string(),
                                     item: source_name,
                                 },
                                 id,


### PR DESCRIPTION
The latter better represents that the database is the actively-selected
database. (It is occasionally *used as a default* when none is
specified, but it is a meaningfully different concept from the default
database being the database named "materialize".)

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code to clarify terminology.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
