### PR TITLE
feature benchmark: Add index to the Update scenario

### DIFF
--- a/test/feature-benchmark/scenarios.py
+++ b/test/feature-benchmark/scenarios.py
@@ -157,6 +157,8 @@ class Update(DML):
                 f"""
 > CREATE TABLE t1 (f1 BIGINT);
 
+> CREATE DEFAULT INDEX ON t1;
+
 > INSERT INTO t1 SELECT {self.unique_values()} FROM {self.join()}
 """
             ),


### PR DESCRIPTION
Work around #11071 by adding a default index to the table
that is being used in the Update scenario.