### PR TITLE
pg-cdc: handle errors while reading from PG copy out stream

### DIFF
--- a/src/dataflow/src/source/postgres.rs
+++ b/src/dataflow/src/source/postgres.rs
@@ -253,7 +253,7 @@ impl PostgresSourceReader {
 
             pin_mut!(reader);
             let mut mz_row = Row::default();
-            while let Ok(b) = reader.next().await.transpose()? {
+            while let Some(b) = reader.next().await.transpose()? {
                 let mut packer = mz_row.packer();
                 packer.push(relation_id);
                 // Convert raw rows from COPY into repr:Row. Each Row is a relation_id

--- a/src/dataflow/src/source/postgres.rs
+++ b/src/dataflow/src/source/postgres.rs
@@ -253,34 +253,25 @@ impl PostgresSourceReader {
 
             pin_mut!(reader);
             let mut mz_row = Row::default();
-            while let Some(next) = reader.next().await {
-                match next {
-                    Ok(b) => {
-                        let mut packer = mz_row.packer();
-                        packer.push(relation_id);
-                        // Convert raw rows from COPY into repr:Row. Each Row is a relation_id
-                        // and list of string-encoded values, e.g. Row{ 16391 , ["1", "2"] }
-                        let parser = mz_pgcopy::CopyTextFormatParser::new(b.as_ref(), "\t", "\\N");
+            while let Ok(b) = reader.next().await.transpose()? {
+                let mut packer = mz_row.packer();
+                packer.push(relation_id);
+                // Convert raw rows from COPY into repr:Row. Each Row is a relation_id
+                // and list of string-encoded values, e.g. Row{ 16391 , ["1", "2"] }
+                let parser = mz_pgcopy::CopyTextFormatParser::new(b.as_ref(), "\t", "\\N");
 
-                        let mut raw_values = parser.iter_raw(info.columns.len() as i32);
-                        try_fatal!(packer.push_list_with(|rp| -> Result<(), anyhow::Error> {
-                            while let Some(raw_value) = raw_values.next() {
-                                match raw_value? {
-                                    Some(value) => {
-                                        rp.push(Datum::String(std::str::from_utf8(value)?))
-                                    }
-                                    None => rp.push(Datum::Null),
-                                }
-                            }
-                            Ok(())
-                        }));
-                        try_recoverable!(snapshot_tx.insert(mz_row.clone()).await);
-                        try_fatal!(buffer.write(&try_fatal!(bincode::serialize(&mz_row))).await);
+                let mut raw_values = parser.iter_raw(info.columns.len() as i32);
+                try_fatal!(packer.push_list_with(|rp| -> Result<(), anyhow::Error> {
+                    while let Some(raw_value) = raw_values.next() {
+                        match raw_value? {
+                            Some(value) => rp.push(Datum::String(std::str::from_utf8(value)?)),
+                            None => rp.push(Datum::Null),
+                        }
                     }
-                    Err(e) => {
-                        return Err(e.into());
-                    }
-                }
+                    Ok(())
+                }));
+                try_recoverable!(snapshot_tx.insert(mz_row.clone()).await);
+                try_fatal!(buffer.write(&try_fatal!(bincode::serialize(&mz_row))).await);
             }
 
             self.metrics.tables.inc();


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

As a first pass, we need to handle errors that can arise during the copy out stream. When I manually test the scenario, this now resumes from errors correctly for me, but the stripped down mzcompose test still hangs locally. I think regardless of local success, adding error handling here is a net win.

### Motivation

https://github.com/MaterializeInc/materialize/issues/10938

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Improve recovery of Postgres sources if errors occur during initial data loading
