### PR TITLE
qgm: introduce `RequiredAttributes` type

### DIFF
--- a/src/sql/src/query_model/attribute/core.rs
+++ b/src/sql/src/query_model/attribute/core.rs
@@ -116,23 +116,46 @@ impl<A: AttributeKey> TypeMapKey for AsKey<A> {
     type Value = A::Value;
 }
 
-/// derive attributes for the entire model before each transform
-pub(crate) fn derive_dft_attributes(
-    model: &mut Model,
-    attributes: &Vec<Box<dyn Attribute>>,
-    root: BoxId,
-) {
-    if !attributes.is_empty() {
-        let _ = model.try_visit_mut_pre_post_descendants(
-            &mut |_, _| -> Result<(), ()> { Ok(()) },
-            &mut |m, box_id| -> Result<(), ()> {
-                for attr in attributes.iter() {
-                    attr.derive(m, *box_id);
-                }
-                Ok(())
-            },
-            root,
-        );
+/// A struct that represents an [`Attribute`] set that needs
+/// to be present for some follow-up logic (most likely
+/// transformation, but can also be pretty-printing or something
+/// else).
+pub(crate) struct RequiredAttributes {
+    attributes: Vec<Box<dyn Attribute>>,
+}
+
+impl From<HashSet<Box<dyn Attribute>>> for RequiredAttributes {
+    /// Completes the set attributes with transitive dependencies
+    /// and wraps the result in a representation that is suitable
+    /// for attribute derivation in a minimum number of passes.
+    fn from(mut attributes: HashSet<Box<dyn Attribute>>) -> Self {
+        // add missing dependencies required to derive this set of attributes
+        transitive_closure(&mut attributes);
+        // order transitive closure topologically based on dependency order
+        let attributes = dependency_order(attributes);
+        // wrap resulting vector a new RequiredAttributes instance
+        RequiredAttributes { attributes }
+    }
+}
+
+impl RequiredAttributes {
+    /// Derive attributes for the entire model.
+    ///
+    /// The currently implementation assumes that all attributes
+    /// can be derived in a single bottom up pass.
+    pub(crate) fn derive(&self, model: &mut Model, root: BoxId) {
+        if !self.attributes.is_empty() {
+            let _ = model.try_visit_mut_pre_post_descendants(
+                &mut |_, _| -> Result<(), ()> { Ok(()) },
+                &mut |m, box_id| -> Result<(), ()> {
+                    for attr in self.attributes.iter() {
+                        attr.derive(m, *box_id);
+                    }
+                    Ok(())
+                },
+                root,
+            );
+        }
     }
 }
 
@@ -143,7 +166,7 @@ pub(crate) fn derive_dft_attributes(
 /// We use Kahn's algorithm[^1] to sort the input.
 ///
 /// [^1]: <https://en.wikipedia.org/wiki/Topological_sorting#Kahn's_algorithm>
-pub(crate) fn dependency_order(attributes: HashSet<Box<dyn Attribute>>) -> Vec<Box<dyn Attribute>> {
+fn dependency_order(attributes: HashSet<Box<dyn Attribute>>) -> Vec<Box<dyn Attribute>> {
     let mut rest = attributes.into_iter().collect::<Vec<_>>();
     let mut seen = HashSet::new() as HashSet<&'static str>;
     let mut sort = vec![] as Vec<Box<dyn Attribute>>;
@@ -165,7 +188,7 @@ pub(crate) fn dependency_order(attributes: HashSet<Box<dyn Attribute>>) -> Vec<B
 }
 
 /// Compute the transitive closure of the given set of attributes.
-pub(crate) fn transitive_closure(attributes: &mut HashSet<Box<dyn Attribute>>) {
+fn transitive_closure(attributes: &mut HashSet<Box<dyn Attribute>>) {
     let mut diff = requirements(&attributes);
 
     // iterate until no new attributes can be discovered

--- a/src/sql/src/query_model/dot.rs
+++ b/src/sql/src/query_model/dot.rs
@@ -21,9 +21,7 @@ use mz_ore::str::separated;
 use std::collections::{BTreeMap, HashSet};
 use std::fmt::{self, Write};
 
-use super::attribute::core::{
-    dependency_order, derive_dft_attributes, transitive_closure, Attribute,
-};
+use super::attribute::core::{Attribute, RequiredAttributes};
 use super::attribute::relation_type::RelationType;
 
 impl Model {
@@ -73,18 +71,13 @@ impl<'a> DotGenerator<'a> {
 
     /// Derive attributes required for rendering the given [`Model`].
     fn derive_required_attributes(&self, model: &mut Model, start_box: BoxId) {
-        // collect a set of attributes required by the given rules
+        // collect a set of required attributes for rendering
         let mut attributes = HashSet::new();
         if self.with_types {
             attributes.insert(Box::new(RelationType) as Box<dyn Attribute>);
         }
-        // add missing dependencies required to derive this set of attributes
-        transitive_closure(&mut attributes);
-        // order transitive closure topologically based on dependency order
-        let attributes = dependency_order(attributes);
-        // compute initial values of the required derived attributes
-
-        derive_dft_attributes(model, &attributes, start_box);
+        // derive the required derived attributes
+        RequiredAttributes::from(attributes).derive(model, start_box);
     }
 
     /// Generates a graphviz graph for the given model, labeled with `label`.

--- a/src/sql/src/query_model/model/graph.rs
+++ b/src/sql/src/query_model/model/graph.rs
@@ -139,7 +139,6 @@ pub(crate) struct QueryBox {
     /// rows from its input boxes. See [DistinctOperation].
     pub distinct: DistinctOperation,
     /// Derived attributes
-    #[allow(dead_code)]
     pub attributes: Attributes,
 }
 

--- a/src/sql/src/query_model/rewrite/mod.rs
+++ b/src/sql/src/query_model/rewrite/mod.rs
@@ -15,9 +15,7 @@ mod rule;
 
 use std::collections::HashSet;
 
-use super::attribute::core::{
-    dependency_order, derive_dft_attributes, transitive_closure, Attribute,
-};
+use super::attribute::core::{Attribute, RequiredAttributes};
 use super::model::{BoxId, Model};
 
 impl Model {
@@ -141,16 +139,13 @@ pub fn rewrite_model(model: &mut Model) {
 /// Transform the model by applying a list of rewrite rules.
 fn apply_rules_to_model(model: &mut Model, rules: Vec<Box<dyn ApplyRule>>) {
     // collect a set of attributes required by the given rules
-    let mut attributes = rules
+    let attributes = rules
         .iter()
         .flat_map(|r| r.required_attributes())
         .collect::<HashSet<_>>();
-    // add missing dependencies required to derive this set of attributes
-    transitive_closure(&mut attributes);
-    // order transitive closure topologically based on dependency order
-    let attributes = dependency_order(attributes);
-    // compute initial values of the required derived attributes
-    derive_dft_attributes(model, &attributes, model.top_box);
+    let attributes = RequiredAttributes::from(attributes);
+    // derived initial values of the required attributes
+    attributes.derive(model, model.top_box);
 
     let (top_box, other): (Vec<Box<dyn ApplyRule>>, Vec<Box<dyn ApplyRule>>) = rules
         .into_iter()
@@ -168,7 +163,7 @@ fn apply_rules_to_model(model: &mut Model, rules: Vec<Box<dyn ApplyRule>>) {
         for rule in &top_box {
             if rule.apply(model, model.top_box) {
                 rewritten_in_top |= true;
-                derive_dft_attributes(model, &attributes, model.top_box);
+                attributes.derive(model, model.top_box);
             }
         }
 
@@ -177,7 +172,7 @@ fn apply_rules_to_model(model: &mut Model, rules: Vec<Box<dyn ApplyRule>>) {
                 for rule in pre.iter() {
                     if rule.apply(model, *box_id) {
                         rewritten_in_pre |= true;
-                        derive_dft_attributes(model, &attributes, model.top_box);
+                        attributes.derive(model, model.top_box);
                     }
                 }
                 Ok(())
@@ -186,7 +181,7 @@ fn apply_rules_to_model(model: &mut Model, rules: Vec<Box<dyn ApplyRule>>) {
                 for rule in post.iter() {
                     if rule.apply(model, *box_id) {
                         rewritten_in_post |= true;
-                        derive_dft_attributes(model, &attributes, *box_id);
+                        attributes.derive(model, model.top_box);
                     }
                 }
                 Ok(())


### PR DESCRIPTION
Introduces a `RequiredAttributes` type, as suggested [in this comment](https://github.com/MaterializeInc/materialize/pull/10901#discussion_r821468962).

### Motivation

   * This PR refactors existing code.

Basically, some low-level logic, such as `transitive_closure` and `dependency_order` calls were leaking into client code that wants to derive attributes. See [this discussion thread](https://github.com/MaterializeInc/materialize/pull/10901#discussion_r817241139) for details.

### Tips for reviewer

This PR refactors the code as suggested [in this comment](https://github.com/MaterializeInc/materialize/pull/10901#discussion_r821468962):

- We introduce a dedicated `RequiredAttributes` type to model attributes that are required by some client code and need to be derived (ans possibly re-derived).
- The `RequiredAttributes` type has a sole smart constructor that takes a `HashSet<Box<dyn Attribute>>` and wraps the transitively closed version of that set in a dependency order in a `RequiredAttributes` struct. 
- The `derive_dft_attributes` function is refactored as a method called `derive` on `RequiredAttributes`.
- This ensures that we cannot pass an incomplete versions of required attributes in client code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

N/A