### PR TITLE
Render time redux

### DIFF
--- a/src/dataflow-types/src/client/controller/compute.rs
+++ b/src/dataflow-types/src/client/controller/compute.rs
@@ -338,7 +338,7 @@ impl<'a, C: Client<T>, T: Timestamp + Lattice> ComputeControllerMut<'a, C, T> {
     /// Downgrade the read capabilities of specific identifiers to specific frontiers.
     ///
     /// Downgrading any read capability to the empty frontier will drop the item and eventually reclaim its resources.
-    pub async fn allow_compaction(
+    async fn allow_compaction(
         &mut self,
         frontiers: Vec<(GlobalId, Antichain<T>)>,
     ) -> Result<(), ComputeError> {

--- a/src/dataflow-types/src/client/controller/storage.rs
+++ b/src/dataflow-types/src/client/controller/storage.rs
@@ -171,7 +171,7 @@ impl<'a, C: Client<T>, T: Timestamp + Lattice> StorageControllerMut<'a, C, T> {
     /// Downgrade the read capabilities of specific identifiers to specific frontiers.
     ///
     /// Downgrading any read capability to the empty frontier will drop the item and eventually reclaim its resources.
-    pub async fn allow_compaction(
+    async fn allow_compaction(
         &mut self,
         frontiers: Vec<(GlobalId, Antichain<T>)>,
     ) -> Result<(), StorageError> {

--- a/src/dataflow/src/render/context.rs
+++ b/src/dataflow/src/render/context.rs
@@ -73,15 +73,14 @@ where
     /// without affecting the results. We *should* apply it, to sources and
     /// imported traces, both because it improves performance, and because
     /// potentially incorrect results are visible in sinks.
-    pub as_of_frontier: Antichain<mz_repr::Timestamp>,
+    pub as_of_frontier: Antichain<T>,
     /// Bindings of identifiers to collections.
     pub bindings: BTreeMap<Id, CollectionBundle<S, V, T>>,
 }
 
-impl<S: Scope, V: Data, T> Context<S, V, T>
+impl<S: Scope, V: Data> Context<S, V, mz_repr::Timestamp>
 where
-    T: Timestamp + Lattice,
-    S::Timestamp: Lattice + Refines<T>,
+    S::Timestamp: Lattice + Refines<mz_repr::Timestamp>,
 {
     /// Creates a new empty Context.
     pub fn for_dataflow<Plan>(dataflow: &DataflowDescription<Plan>, dataflow_id: usize) -> Self {
@@ -97,7 +96,13 @@ where
             bindings: BTreeMap::new(),
         }
     }
+}
 
+impl<S: Scope, V: Data, T> Context<S, V, T>
+where
+    T: Timestamp + Lattice,
+    S::Timestamp: Lattice + Refines<T>,
+{
     /// Insert a collection bundle by an identifier.
     ///
     /// This is expected to be used to install external collections (sources, indexes, other views),
@@ -468,9 +473,12 @@ where
     }
 }
 
-impl<S> CollectionBundle<S, mz_repr::Row, mz_repr::Timestamp>
+impl<S, T> CollectionBundle<S, mz_repr::Row, T>
 where
-    S: Scope<Timestamp = mz_repr::Timestamp>,
+    T: timely::progress::Timestamp + Lattice,
+    S: Scope,
+    S::Timestamp:
+        Refines<T> + Lattice + timely::progress::Timestamp + crate::render::RenderTimestamp,
 {
     /// Presents `self` as a stream of updates, having been subjected to `mfp`.
     ///
@@ -511,15 +519,34 @@ where
             let mut datum_vec = DatumVec::new();
 
             move |row_parts, time, diff| {
+                use crate::render::RenderTimestamp;
+
                 let temp_storage = RowArena::new();
                 let mut datums_local = datum_vec.borrow_with_many(row_parts);
-                mfp_plan.evaluate(
-                    &mut datums_local,
-                    &temp_storage,
-                    time.clone(),
-                    diff.clone(),
-                    &mut row_builder,
-                )
+                let time = time.clone();
+                let event_time: mz_repr::Timestamp = *time.clone().event_time();
+                mfp_plan
+                    .evaluate(
+                        &mut datums_local,
+                        &temp_storage,
+                        event_time,
+                        diff.clone(),
+                        &mut row_builder,
+                    )
+                    .map(move |x| match x {
+                        Ok((row, event_time, diff)) => {
+                            // Copy the whole time, and re-populate event time.
+                            let mut time: S::Timestamp = time.clone();
+                            *time.event_time() = event_time;
+                            Ok((row, time, diff))
+                        }
+                        Err((e, event_time, diff)) => {
+                            // Copy the whole time, and re-populate event time.
+                            let mut time: S::Timestamp = time.clone();
+                            *time.event_time() = event_time;
+                            Err((e, time, diff))
+                        }
+                    })
             }
         });
 

--- a/src/dataflow/src/render/context.rs
+++ b/src/dataflow/src/render/context.rs
@@ -60,7 +60,7 @@ pub type ErrArrangementImport<S, T> = Arranged<
 /// former must refine the latter. The former is the timestamp used by the scope in question,
 /// and the latter is the timestamp of imported traces. The two may be different in the case
 /// of regions or iteration.
-pub struct Context<S: Scope, V: Data, T>
+pub struct Context<S: Scope, V: Data, T = mz_repr::Timestamp>
 where
     T: Timestamp + Lattice,
     S::Timestamp: Lattice + Refines<T>,
@@ -78,7 +78,7 @@ where
     pub bindings: BTreeMap<Id, CollectionBundle<S, V, T>>,
 }
 
-impl<S: Scope, V: Data> Context<S, V, mz_repr::Timestamp>
+impl<S: Scope, V: Data> Context<S, V>
 where
     S::Timestamp: Lattice + Refines<mz_repr::Timestamp>,
 {
@@ -145,7 +145,7 @@ where
 
 /// Describes flavor of arrangement: local or imported trace.
 #[derive(Clone)]
-pub enum ArrangementFlavor<S: Scope, V: Data, T: Lattice>
+pub enum ArrangementFlavor<S: Scope, V: Data, T = mz_repr::Timestamp>
 where
     T: Timestamp + Lattice,
     S::Timestamp: Lattice + Refines<T>,
@@ -257,7 +257,7 @@ where
 /// This type maintains the invariant that it does contain at least one valid
 /// source of data, either a collection or at least one arrangement.
 #[derive(Clone)]
-pub struct CollectionBundle<S: Scope, V: Data, T: Lattice>
+pub struct CollectionBundle<S: Scope, V: Data, T = mz_repr::Timestamp>
 where
     T: Timestamp + Lattice,
     S::Timestamp: Lattice + Refines<T>,

--- a/src/dataflow/src/render/flat_map.rs
+++ b/src/dataflow/src/render/flat_map.rs
@@ -19,23 +19,24 @@ use mz_repr::DatumVec;
 
 impl<G> Context<G, Row, mz_repr::Timestamp>
 where
-    G: Scope<Timestamp = mz_repr::Timestamp>,
+    G: Scope,
+    G::Timestamp: crate::render::RenderTimestamp,
 {
     /// Renders `relation_expr` followed by `map_filter_project` if provided.
     pub fn render_flat_map(
         &mut self,
-        input: CollectionBundle<G, Row, G::Timestamp>,
+        input: CollectionBundle<G, Row, mz_repr::Timestamp>,
         func: TableFunc,
         exprs: Vec<MirScalarExpr>,
         mfp: MapFilterProject,
         input_key: Option<Vec<MirScalarExpr>>,
-    ) -> CollectionBundle<G, Row, G::Timestamp> {
+    ) -> CollectionBundle<G, Row, mz_repr::Timestamp> {
         let mfp_plan = mfp.into_plan().expect("MapFilterProject planning failed");
         let (ok_collection, err_collection) = input.as_specific_collection(input_key.as_deref());
         let (oks, errs) = ok_collection.inner.flat_map_fallible("FlatMapStage", {
             let mut datums = DatumVec::new();
             let mut row_builder = Row::default();
-            move |(input_row, time, diff)| {
+            move |(input_row, mut time, diff)| {
                 let temp_storage = RowArena::new();
                 // Unpack datums and capture its length (to rewind MFP eval).
                 let mut datums_local = datums.borrow_with(&input_row);
@@ -52,6 +53,10 @@ where
                     Ok(exprs) => exprs,
                     Err(e) => return vec![(Err((e.into(), time, diff)))],
                 };
+
+                use crate::render::RenderTimestamp;
+                let event_time = time.event_time().clone();
+
                 // Declare borrows outside the closure so that appropriately lifetimed
                 // borrows are moved in and used by `mfp.evaluate`.
                 let temp_storage = &temp_storage;
@@ -69,11 +74,25 @@ where
                             .evaluate(
                                 &mut datums_local,
                                 temp_storage,
-                                time,
+                                event_time,
                                 diff * *r,
                                 row_builder,
                             )
                             .collect::<Vec<_>>()
+                    })
+                    .map(|x| match x {
+                        Ok((row, event_time, diff)) => {
+                            // Copy the whole time, and re-populate event time.
+                            let mut time = time.clone();
+                            *time.event_time() = event_time;
+                            Ok((row, time, diff))
+                        }
+                        Err((e, event_time, diff)) => {
+                            // Copy the whole time, and re-populate event time.
+                            let mut time = time.clone();
+                            *time.event_time() = event_time;
+                            Err((e, time, diff))
+                        }
                     })
                     .collect::<Vec<_>>()
             }

--- a/src/dataflow/src/render/flat_map.rs
+++ b/src/dataflow/src/render/flat_map.rs
@@ -17,7 +17,7 @@ use crate::render::context::CollectionBundle;
 use crate::render::context::Context;
 use mz_repr::DatumVec;
 
-impl<G> Context<G, Row, mz_repr::Timestamp>
+impl<G> Context<G, Row>
 where
     G: Scope,
     G::Timestamp: crate::render::RenderTimestamp,
@@ -25,12 +25,12 @@ where
     /// Renders `relation_expr` followed by `map_filter_project` if provided.
     pub fn render_flat_map(
         &mut self,
-        input: CollectionBundle<G, Row, mz_repr::Timestamp>,
+        input: CollectionBundle<G, Row>,
         func: TableFunc,
         exprs: Vec<MirScalarExpr>,
         mfp: MapFilterProject,
         input_key: Option<Vec<MirScalarExpr>>,
-    ) -> CollectionBundle<G, Row, mz_repr::Timestamp> {
+    ) -> CollectionBundle<G, Row> {
         let mfp_plan = mfp.into_plan().expect("MapFilterProject planning failed");
         let (ok_collection, err_collection) = input.as_specific_collection(input_key.as_deref());
         let (oks, errs) = ok_collection.inner.flat_map_fallible("FlatMapStage", {

--- a/src/dataflow/src/render/join/delta_join.rs
+++ b/src/dataflow/src/render/join/delta_join.rs
@@ -28,7 +28,7 @@ use crate::operator::CollectionExt;
 use crate::render::context::CollectionBundle;
 use mz_repr::DatumVec;
 
-impl<G> Context<G, Row, mz_repr::Timestamp>
+impl<G> Context<G, Row>
 where
     G: Scope,
     G::Timestamp: crate::render::RenderTimestamp,
@@ -39,10 +39,10 @@ where
     /// implementation will be pushed in to the join pipeline if at all possible.
     pub fn render_delta_join(
         &mut self,
-        inputs: Vec<CollectionBundle<G, Row, mz_repr::Timestamp>>,
+        inputs: Vec<CollectionBundle<G, Row>>,
         join_plan: DeltaJoinPlan,
         scope: &mut G,
-    ) -> CollectionBundle<G, Row, mz_repr::Timestamp> {
+    ) -> CollectionBundle<G, Row> {
         // Collects error streams for the ambient scope.
         let mut scope_errs = Vec::new();
 

--- a/src/dataflow/src/render/join/delta_join.rs
+++ b/src/dataflow/src/render/join/delta_join.rs
@@ -30,7 +30,8 @@ use mz_repr::DatumVec;
 
 impl<G> Context<G, Row, mz_repr::Timestamp>
 where
-    G: Scope<Timestamp = mz_repr::Timestamp>,
+    G: Scope,
+    G::Timestamp: crate::render::RenderTimestamp,
 {
     /// Renders `MirRelationExpr:Join` using dogs^3 delta query dataflows.
     ///
@@ -38,10 +39,10 @@ where
     /// implementation will be pushed in to the join pipeline if at all possible.
     pub fn render_delta_join(
         &mut self,
-        inputs: Vec<CollectionBundle<G, Row, G::Timestamp>>,
+        inputs: Vec<CollectionBundle<G, Row, mz_repr::Timestamp>>,
         join_plan: DeltaJoinPlan,
         scope: &mut G,
-    ) -> CollectionBundle<G, Row, G::Timestamp> {
+    ) -> CollectionBundle<G, Row, mz_repr::Timestamp> {
         // Collects error streams for the ambient scope.
         let mut scope_errs = Vec::new();
 
@@ -319,7 +320,8 @@ fn build_halfjoin<G, Tr, CF>(
     Collection<G, DataflowError, Diff>,
 )
 where
-    G: Scope<Timestamp = mz_repr::Timestamp>,
+    G: Scope,
+    G::Timestamp: crate::render::RenderTimestamp,
     Tr: TraceReader<Time = G::Timestamp, Key = Row, Val = Row, R = Diff> + Clone + 'static,
     Tr::Batch: BatchReader<Tr::Key, Tr::Val, Tr::Time, Tr::R>,
     Tr::Cursor: Cursor<Tr::Key, Tr::Val, Tr::Time, Tr::R>,
@@ -347,6 +349,7 @@ where
         }
     });
 
+    use crate::render::RenderTimestamp;
     use differential_dataflow::AsCollection;
     use timely::dataflow::operators::OkErr;
 
@@ -356,7 +359,7 @@ where
     let (oks, errs2) = dogsdogsdogs::operators::half_join::half_join_internal_unsafe(
         &updates,
         trace,
-        |time| time.saturating_sub(1),
+        |time| time.step_back(),
         comparison,
         // TODO(mcsherry): investigate/establish trade-offs here; time based had problems,
         // in that we seem to yield too much and do too little work when we do.
@@ -393,12 +396,13 @@ where
 /// updates happening at the same time on different relations.
 fn build_update_stream<G, Tr>(
     trace: Arranged<G, Tr>,
-    as_of: Antichain<G::Timestamp>,
+    as_of: Antichain<mz_repr::Timestamp>,
     source_relation: usize,
     initial_closure: JoinClosure,
 ) -> (Collection<G, Row, Diff>, Collection<G, DataflowError, Diff>)
 where
-    G: Scope<Timestamp = mz_repr::Timestamp>,
+    G: Scope,
+    G::Timestamp: crate::render::RenderTimestamp,
     Tr: TraceReader<Time = G::Timestamp, Key = Row, Val = Row, R = Diff> + Clone + 'static,
     Tr::Batch: BatchReader<Tr::Key, Tr::Val, Tr::Time, Tr::R>,
     Tr::Cursor: Cursor<Tr::Key, Tr::Val, Tr::Time, Tr::R>,
@@ -406,6 +410,12 @@ where
     use crate::operator::StreamExt;
     use differential_dataflow::AsCollection;
     use timely::dataflow::channels::pact::Pipeline;
+
+    use timely::progress::timestamp::Refines;
+    let mut inner_as_of = Antichain::new();
+    for event_time in as_of.elements().iter() {
+        inner_as_of.insert(<G::Timestamp>::to_inner(event_time.clone()));
+    }
 
     let mut row_buf = Row::default();
     let (ok_stream, err_stream) =
@@ -425,7 +435,8 @@ where
                                     cursor.map_times(batch, |time, diff| {
                                         // note: only the delta path for the first relation will see
                                         // updates at start-up time
-                                        if source_relation == 0 || !as_of.elements().contains(&time)
+                                        if source_relation == 0
+                                            || !inner_as_of.elements().contains(&time)
                                         {
                                             let temp_storage = RowArena::new();
                                             let mut datums_local =

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -88,7 +88,7 @@
 //! unsatisfactory long term. We suspect that we can continue to imbue the oks
 //! stream with semantics if we are very careful in describing what data should
 //! and should not be produced upon encountering an error. Roughly speaking, the
-//! oks stream could represent the correct result of the computation where all
+//! oks stream could mz_represent the correct result of the computation where all
 //! rows that caused an error have been pruned from the stream. There are
 //! strange and confusing questions here around foreign keys, though: what if
 //! the optimizer proves that a particular key must exist in a collection, but
@@ -108,13 +108,13 @@ use timely::communication::Allocate;
 use timely::dataflow::operators::to_stream::ToStream;
 use timely::dataflow::scopes::Child;
 use timely::dataflow::Scope;
-use timely::progress::Antichain;
+use timely::progress::{Antichain, Timestamp};
 use timely::worker::Worker as TimelyWorker;
 
 use mz_dataflow_types::*;
 use mz_expr::{GlobalId, Id};
 use mz_ore::collections::CollectionExt as IteratorExt;
-use mz_repr::{Row, Timestamp};
+use mz_repr::Row;
 
 use crate::arrangement::manager::TraceBundle;
 pub use crate::render::context::CollectionBundle;
@@ -195,7 +195,6 @@ pub fn build_storage_dataflow<A: Allocate, B: StorageCapture>(
                             let mut borrow = shared_frontier.borrow_mut();
                             for time1 in borrow.iter() {
                                 for time2 in &input.frontier.frontier() {
-                                    use differential_dataflow::lattice::Lattice;
                                     joined_frontier.insert(time1.join(time2));
                                 }
                             }
@@ -299,16 +298,17 @@ pub fn build_compute_dataflow<A: Allocate, B: ComputeReplay>(
     })
 }
 
-impl<'g, G> Context<Child<'g, G, G::Timestamp>, Row, Timestamp>
+impl<'g, G, T> Context<Child<'g, G, T>, Row, mz_repr::Timestamp>
 where
-    G: Scope<Timestamp = Timestamp>,
+    G: Scope<Timestamp = mz_repr::Timestamp>,
+    T: Refines<G::Timestamp> + RenderTimestamp,
 {
     pub(crate) fn import_index(
         &mut self,
         compute_state: &mut ComputeState,
         tokens: &mut BTreeMap<GlobalId, Rc<dyn std::any::Any>>,
         scope: &mut G,
-        region: &mut Child<'g, G, G::Timestamp>,
+        region: &mut Child<'g, G, T>,
         idx_id: GlobalId,
         idx: &IndexDesc,
     ) {
@@ -344,17 +344,28 @@ where
             );
         }
     }
+}
 
-    pub(crate) fn build_object(
-        &mut self,
-        scope: &mut Child<'g, G, G::Timestamp>,
-        object: BuildDesc<plan::Plan>,
-    ) {
+// This implementation block allows child timestamps to vary from parent timestamps.
+
+impl<G> Context<G, Row, mz_repr::Timestamp>
+where
+    G: Scope,
+    G::Timestamp: Refines<mz_repr::Timestamp> + Lattice + RenderTimestamp,
+{
+    pub(crate) fn build_object(&mut self, scope: &mut G, object: BuildDesc<plan::Plan>) {
         // First, transform the relation expression into a render plan.
         let bundle = self.render_plan(object.plan, scope, scope.index());
         self.insert_id(Id::Global(object.id), bundle);
     }
+}
 
+// This implementation block requires the scopes have the same timestamp as the trace manager.
+// That makes some sense, because we are hoping to deposit an arrangement in the trace manager.
+impl<'g, G> Context<Child<'g, G, G::Timestamp>, Row, G::Timestamp>
+where
+    G: Scope<Timestamp = mz_repr::Timestamp>,
+{
     pub(crate) fn export_index(
         &mut self,
         compute_state: &mut ComputeState,
@@ -405,41 +416,55 @@ where
     }
 }
 
-impl<G> Context<G, Row, Timestamp>
+impl<G> Context<G, Row, mz_repr::Timestamp>
 where
-    G: Scope<Timestamp = Timestamp>,
+    G: Scope,
+    G::Timestamp: Refines<mz_repr::Timestamp> + Lattice + RenderTimestamp,
 {
     /// Renders a plan to a differential dataflow, producing the collection of results.
     ///
-    /// The return type reflects the uncertainty about the data representation, perhaps
+    /// The return type reflects the uncertainty about the data mz_representation, perhaps
     /// as a stream of data, perhaps as an arrangement, perhaps as a stream of batches.
     pub fn render_plan(
         &mut self,
         plan: plan::Plan,
         scope: &mut G,
         worker_index: usize,
-    ) -> CollectionBundle<G, Row, G::Timestamp> {
+    ) -> CollectionBundle<G, Row, mz_repr::Timestamp> {
         match plan {
             Plan::Constant { rows } => {
                 // Produce both rows and errs to avoid conditional dataflow construction.
-                let (mut rows, errs) = match rows {
+                let (rows, errs) = match rows {
                     Ok(rows) => (rows, Vec::new()),
                     Err(e) => (Vec::new(), vec![e]),
                 };
 
                 // We should advance times in constant collections to start from `as_of`.
-                use differential_dataflow::lattice::Lattice;
-                for (_, time, _) in rows.iter_mut() {
-                    time.advance_by(self.as_of_frontier.borrow());
-                }
-                let mut error_time: G::Timestamp = timely::progress::Timestamp::minimum();
+                let as_of_frontier = self.as_of_frontier.clone();
+                let ok_collection = rows
+                    .into_iter()
+                    .map(move |(row, mut time, diff)| {
+                        time.advance_by(as_of_frontier.borrow());
+                        (
+                            row,
+                            <G::Timestamp as Refines<mz_repr::Timestamp>>::to_inner(time),
+                            diff,
+                        )
+                    })
+                    .to_stream(scope)
+                    .as_collection();
+
+                let mut error_time: mz_repr::Timestamp = Timestamp::minimum();
                 error_time.advance_by(self.as_of_frontier.borrow());
-
-                let ok_collection = rows.into_iter().to_stream(scope).as_collection();
-
                 let err_collection = errs
                     .into_iter()
-                    .map(move |e| (DataflowError::from(e), error_time, 1))
+                    .map(move |e| {
+                        (
+                            DataflowError::from(e),
+                            <G::Timestamp as Refines<mz_repr::Timestamp>>::to_inner(error_time),
+                            1,
+                        )
+                    })
                     .to_stream(scope)
                     .as_collection();
 
@@ -570,5 +595,44 @@ where
                 input.ensure_collections(keys, input_key, input_mfp)
             }
         }
+    }
+}
+
+use differential_dataflow::lattice::Lattice;
+use timely::progress::timestamp::Refines;
+
+/// A timestamp type that can be used for operations within MZ's dataflow layer.
+pub trait RenderTimestamp: Timestamp + Lattice + Refines<mz_repr::Timestamp> {
+    /// The system timestamp component of the timestamp.
+    ///
+    /// This is useful for manipulating the system time, as when delaying
+    /// updates for subsequent cancellation, as with monotonic reduction.
+    fn system_time(&mut self) -> &mut mz_repr::Timestamp;
+    /// Effects a system delay in terms of the timestamp summary.
+    fn system_delay(delay: mz_repr::Timestamp) -> <Self as Timestamp>::Summary;
+    /// The event timestamp component of the timestamp.
+    fn event_time(&mut self) -> &mut mz_repr::Timestamp;
+    /// Effects an event delay in terms of the timestamp summary.
+    fn event_delay(delay: mz_repr::Timestamp) -> <Self as Timestamp>::Summary;
+    /// Steps the timestamp back so that logical compaction to the output will
+    /// not conflate `self` with any historical times.
+    fn step_back(&self) -> Self;
+}
+
+impl RenderTimestamp for mz_repr::Timestamp {
+    fn system_time(&mut self) -> &mut mz_repr::Timestamp {
+        self
+    }
+    fn system_delay(delay: mz_repr::Timestamp) -> <Self as Timestamp>::Summary {
+        delay
+    }
+    fn event_time(&mut self) -> &mut mz_repr::Timestamp {
+        self
+    }
+    fn event_delay(delay: mz_repr::Timestamp) -> <Self as Timestamp>::Summary {
+        delay
+    }
+    fn step_back(&self) -> Self {
+        self.saturating_sub(1)
     }
 }

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -1094,7 +1094,7 @@ fn flatten_results_prepend_keys<G>(
     results: timely::dataflow::Stream<G, KV>,
 ) -> timely::dataflow::Stream<G, Result<Row, DecodeError>>
 where
-    G: Scope<Timestamp = Timestamp>,
+    G: Scope,
 {
     match key_envelope {
         KeyEnvelope::None => results.flat_map(|KV { val, .. }| val),

--- a/src/dataflow/src/render/top_k.rs
+++ b/src/dataflow/src/render/top_k.rs
@@ -30,16 +30,16 @@ use crate::render::context::CollectionBundle;
 use crate::render::context::Context;
 
 // The implementation requires integer timestamps to be able to delay feedback for monotonic inputs.
-impl<G> Context<G, Row, mz_repr::Timestamp>
+impl<G> Context<G, Row>
 where
     G: Scope,
     G::Timestamp: crate::render::RenderTimestamp,
 {
     pub fn render_topk(
         &mut self,
-        input: CollectionBundle<G, Row, mz_repr::Timestamp>,
+        input: CollectionBundle<G, Row>,
         top_k_plan: TopKPlan,
-    ) -> CollectionBundle<G, Row, mz_repr::Timestamp> {
+    ) -> CollectionBundle<G, Row> {
         let (ok_input, err_input) = input.as_specific_collection(None);
 
         // We create a new region to compartmentalize the topk logic.


### PR DESCRIPTION
This is an updated version of https://github.com/MaterializeInc/materialize/pull/9160 that just refreshes it for the current codebase, and cleans up a bit of noise by using default type parameters. It is not yet "useful" in that we still need some work work to allow e.g. iterative subscopes, but I think it is nonetheless helpful (for me, at least).

Future work includes allowing iterative scopes, and mapping out the actual dependencies that force us to use `mz_repr::Timestamp` here, rather than as a generic argument (for example, that `mz_logical_timestamp` requires "something that can be converted to a `numeric`, and that we need some handle on real time to allow cutesy compaction tricks for top_k).

cc: @mjibson for the "timestamp generalization" vibe.

### Motivation

Our rendering code made various assumptions that the timestamp types are everywhere `mz_repr::Timestamp`. This means they could not be used in either iterative contexts, or with more complex logical timestamps.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
